### PR TITLE
Configure pnpm to only build native dependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -86,5 +86,8 @@
 		"vite": "^7.3.1",
 		"wait-on": "^9.0.3"
 	},
-	"license": "MIT"
+	"license": "MIT",
+	"pnpm": {
+		"onlyBuiltDependencies": ["electron", "esbuild", "electron-winstaller"]
+	}
 }


### PR DESCRIPTION
## Description
Add pnpm configuration to specify that only `electron`, `esbuild`, and `electron-winstaller` should be built from source. This optimizes the dependency installation process by allowing pnpm to use prebuilt binaries for other dependencies where available.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
No testing needed. This is a pnpm configuration change that affects dependency installation behavior. The configuration will be validated during the next `pnpm install` run in CI/CD and local development workflows.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation

## Related Issues
Closes #

https://claude.ai/code/session_01UkNm1CUkfyuUKdCghcSq11