### PR TITLE
fix: move pnpm build allowlist to pnpm-workspace.yaml

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -86,8 +86,5 @@
 		"vite": "^7.3.1",
 		"wait-on": "^9.0.3"
 	},
-	"license": "MIT",
-	"pnpm": {
-		"onlyBuiltDependencies": ["electron", "esbuild", "electron-winstaller"]
-	}
+	"license": "MIT"
 }

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - electron
+  - electron-winstaller
+  - esbuild


### PR DESCRIPTION
pnpm 10 no longer reads onlyBuiltDependencies from package.json; it must live in pnpm-workspace.yaml. This allows electron, esbuild, and electron-winstaller to run their install scripts.

## Description
Brief description of changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
How was this tested?

## Checklist
- [ ] My code follows the style guidelines
- [ ] I have performed a self-review
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation

## Related Issues
Closes #
