### PR TITLE
feat(data-model): preserve KeyValueEntry arrays and add hierarchical auth/scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,8 @@ cd app && pnpm format:check        # Prettier
 - Strict TypeScript — no `any`, no `@ts-ignore` without justification
 - Component files: PascalCase `.tsx`; utilities: camelCase `.ts`
 - State: Zustand for UI state, TanStack Query for server state
-- Styling: Tailwind CSS
+- Styling: Tailwind CSS v4 — all colors via CSS custom properties; see `docs/design-system.md`
+- **Design system:** `docs/design-system.md` — tokens, elevation, typography, component patterns. Read this before touching any UI file.
 
 ## Engine HTTP API
 
@@ -147,5 +148,6 @@ See `docs/engine/api-reference.md` for full reference.
 
 - `docs/architecture.md` — sidecar pattern details
 - `docs/building.md` — platform-specific build notes
+- `docs/design-system.md` — UI tokens, elevation, component patterns, typography
 - `docs/engine/api-reference.md` — engine HTTP API
 - `CONTRIBUTING.md` — PR process and code style

--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,9 @@
 		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Vayu</title>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" />
 	</head>
 	<body>
 		<div id="root"></div>

--- a/app/src/components/layout/Shell.tsx
+++ b/app/src/components/layout/Shell.tsx
@@ -6,29 +6,21 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigationStore } from "@/stores";
 import { useSaveStore } from "@/stores/save-store";
 import Sidebar from "./Sidebar";
-// Main content modules (displayed in main content area)
 import RequestBuilder from "@/modules/request-builder";
 import LoadTestDashboard from "@/modules/dashboard";
 import { HistoryDetail } from "@/modules/history/main";
 import WelcomeScreen from "@/modules/welcome/WelcomeScreen";
 import { SettingsMain } from "@/modules/settings";
 import VariablesMain from "@/modules/variables/main/VariablesMain";
-import { cn } from "@/lib/utils";
-
-const MIN_SIDEBAR_WIDTH = 280;
-const MAX_SIDEBAR_WIDTH = 600;
 
 export default function Shell() {
 	const { resolveActiveScreen } = useNavigationStore();
 	const activeScreen = resolveActiveScreen();
 	const { triggerSave } = useSaveStore();
-	const [sidebarWidth, setSidebarWidth] = useState(320);
-	const [isResizing, setIsResizing] = useState(false);
-	const sidebarRef = useRef<HTMLDivElement>(null);
 
 	// App-wide Ctrl/Cmd+S keyboard handler
 	useEffect(() => {
@@ -42,40 +34,6 @@ export default function Shell() {
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [triggerSave]);
-
-	// Global mouse event handlers for resizing
-	useEffect(() => {
-		const handleMouseMove = (e: MouseEvent) => {
-			if (!isResizing) return;
-
-			const newWidth = e.clientX;
-			if (newWidth >= MIN_SIDEBAR_WIDTH && newWidth <= MAX_SIDEBAR_WIDTH) {
-				setSidebarWidth(newWidth);
-			}
-		};
-
-		const handleMouseUp = () => {
-			setIsResizing(false);
-		};
-
-		if (isResizing) {
-			document.addEventListener("mousemove", handleMouseMove);
-			document.addEventListener("mouseup", handleMouseUp);
-			document.body.style.cursor = "col-resize";
-			document.body.style.userSelect = "none";
-		}
-
-		return () => {
-			document.removeEventListener("mousemove", handleMouseMove);
-			document.removeEventListener("mouseup", handleMouseUp);
-			document.body.style.cursor = "";
-			document.body.style.userSelect = "";
-		};
-	}, [isResizing]);
-
-	const handleMouseDown = () => {
-		setIsResizing(true);
-	};
 
 	const renderMainContent = () => {
 		switch (activeScreen) {
@@ -97,30 +55,7 @@ export default function Shell() {
 
 	return (
 		<div className="flex h-full bg-background overflow-hidden">
-			{/* Sidebar Container - Handles width constraints */}
-			<div
-				ref={sidebarRef}
-				style={{
-					width: `${sidebarWidth}px`,
-					minWidth: `${MIN_SIDEBAR_WIDTH}px`,
-					maxWidth: `${MAX_SIDEBAR_WIDTH}px`,
-				}}
-				className="flex-shrink-0 flex flex-col overflow-hidden"
-			>
-				<Sidebar />
-			</div>
-
-			{/* Resize Handle */}
-			<div
-				onMouseDown={handleMouseDown}
-				className={cn(
-					"w-1 bg-border hover:bg-primary cursor-col-resize transition-colors shrink-0",
-					isResizing && "bg-primary"
-				)}
-				title="Drag to resize sidebar"
-			/>
-
-			{/* Main Content Container - Handles overflow */}
+			<Sidebar />
 			<main className="flex-1 flex flex-col overflow-hidden min-w-0">
 				{renderMainContent()}
 			</main>

--- a/app/src/components/layout/Shell.tsx
+++ b/app/src/components/layout/Shell.tsx
@@ -9,6 +9,8 @@
 import { useEffect } from "react";
 import { useNavigationStore } from "@/stores";
 import { useSaveStore } from "@/stores/save-store";
+import { useResizable } from "@/hooks";
+import { cn } from "@/lib/utils";
 import Sidebar from "./Sidebar";
 import RequestBuilder from "@/modules/request-builder";
 import LoadTestDashboard from "@/modules/dashboard";
@@ -17,10 +19,19 @@ import WelcomeScreen from "@/modules/welcome/WelcomeScreen";
 import { SettingsMain } from "@/modules/settings";
 import VariablesMain from "@/modules/variables/main/VariablesMain";
 
+const MIN_SIDEBAR_WIDTH = 280;
+const MAX_SIDEBAR_WIDTH = 600;
+
 export default function Shell() {
 	const { resolveActiveScreen } = useNavigationStore();
 	const activeScreen = resolveActiveScreen();
 	const { triggerSave } = useSaveStore();
+
+	const { size: sidebarWidth, isResizing, startResizing } = useResizable({
+		defaultSize: 320,
+		min: MIN_SIDEBAR_WIDTH,
+		max: MAX_SIDEBAR_WIDTH,
+	});
 
 	// App-wide Ctrl/Cmd+S keyboard handler
 	useEffect(() => {
@@ -55,7 +66,28 @@ export default function Shell() {
 
 	return (
 		<div className="flex h-full bg-background overflow-hidden">
-			<Sidebar />
+			{/* Sidebar container — controlled width */}
+			<div
+				style={{
+					width: `${sidebarWidth}px`,
+					minWidth: `${MIN_SIDEBAR_WIDTH}px`,
+					maxWidth: `${MAX_SIDEBAR_WIDTH}px`,
+				}}
+				className="flex-shrink-0 flex flex-col overflow-hidden"
+			>
+				<Sidebar />
+			</div>
+
+			{/* Resize handle */}
+			<div
+				onMouseDown={startResizing}
+				className={cn(
+					"w-1 bg-border hover:bg-primary cursor-col-resize transition-colors shrink-0",
+					isResizing && "bg-primary"
+				)}
+			/>
+
+			{/* Main content */}
 			<main className="flex-1 flex flex-col overflow-hidden min-w-0">
 				{renderMainContent()}
 			</main>

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -6,11 +6,11 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { Folder, History, Settings, Variable } from "lucide-react";
+import { useState } from "react";
+import { Folder, Clock, Code2, Settings2 } from "lucide-react";
 import { useNavigationStore } from "@/stores";
 import type { SidebarTab } from "@/types";
 import {
-	Button,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
@@ -18,7 +18,6 @@ import {
 	ScrollArea,
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
-// Sidebar modules (displayed in left sidebar)
 import CollectionTree from "@/modules/collections/CollectionTree";
 import { HistoryList } from "@/modules/history/sidebar";
 import { VariablesCategoryTree } from "@/modules/variables/sidebar";
@@ -26,29 +25,93 @@ import { SettingsCategoryTree } from "@/modules/settings";
 import { useCollectionsQuery, useEnvironmentsQuery } from "@/queries";
 import ConnectionStatus from "../status/ConnectionStatus";
 
-export default function Sidebar() {
-	const { activeSidebarTab, setActiveSidebarTab, navigateToVariables, navigateToSettings } =
-		useNavigationStore();
-	const { data: collections = [] } = useCollectionsQuery();
-	const { data: environments = [] } = useEnvironmentsQuery();
+const TOP_TABS: Array<{ id: SidebarTab; label: string; icon: typeof Folder }> = [
+	{ id: "collections", label: "Collections", icon: Folder },
+	{ id: "history",     label: "History",     icon: Clock },
+	{ id: "variables",   label: "Variables",   icon: Code2 },
+];
 
-	const tabs: Array<{ id: SidebarTab; label: string; icon: typeof Folder }> = [
-		{ id: "collections", label: "Collections", icon: Folder },
-		{ id: "history", label: "History", icon: History },
-		{ id: "variables", label: "Variables", icon: Variable },
-		{ id: "settings", label: "Settings", icon: Settings },
-	];
+const BOTTOM_TAB = { id: "settings" as SidebarTab, label: "Settings", icon: Settings2 };
 
-	const handleTabClick = (tabId: SidebarTab) => {
-		if (tabId === "variables") {
-			navigateToVariables();
-		} else if (tabId === "settings") {
-			navigateToSettings();
-		} else {
-			setActiveSidebarTab(tabId);
-		}
-	};
+function ActivityTabButton({
+	tab,
+	isActive,
+	onClick,
+}: {
+	tab: { id: SidebarTab; label: string; icon: typeof Folder };
+	isActive: boolean;
+	onClick: (id: SidebarTab) => void;
+}) {
+	const Icon = tab.icon;
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<div className="relative w-full flex justify-center">
+					{/* Active indicator — 2px left accent bar */}
+					{isActive && (
+						<span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r-sm" />
+					)}
+					<button
+						onClick={() => onClick(tab.id)}
+						className={cn(
+							"w-10 h-10 flex items-center justify-center rounded-md transition-colors duration-100",
+							isActive
+								? "bg-primary/10 text-primary"
+								: "text-muted-foreground hover:bg-accent hover:text-foreground"
+						)}
+						aria-label={tab.label}
+					>
+						<Icon className="w-4 h-4" />
+					</button>
+				</div>
+			</TooltipTrigger>
+			<TooltipContent side="right">{tab.label}</TooltipContent>
+		</Tooltip>
+	);
+}
 
+function ActivityBar({
+	activeSidebarTab,
+	panelOpen,
+	onTabClick,
+}: {
+	activeSidebarTab: SidebarTab;
+	panelOpen: boolean;
+	onTabClick: (id: SidebarTab) => void;
+}) {
+	return (
+		<div className="w-11 h-full bg-panel border-r border-border flex flex-col items-center py-1.5 shrink-0">
+			<div className="flex flex-col items-center gap-0.5 w-full">
+				{TOP_TABS.map((tab) => (
+					<ActivityTabButton
+						key={tab.id}
+						tab={tab}
+						isActive={activeSidebarTab === tab.id && panelOpen}
+						onClick={onTabClick}
+					/>
+				))}
+			</div>
+
+			<div className="flex-1" />
+
+			<ActivityTabButton
+				tab={BOTTOM_TAB}
+				isActive={activeSidebarTab === "settings" && panelOpen}
+				onClick={onTabClick}
+			/>
+		</div>
+	);
+}
+
+function SidebarPanel({
+	activeSidebarTab,
+	collections,
+	environments,
+}: {
+	activeSidebarTab: SidebarTab;
+	collections: ReturnType<typeof useCollectionsQuery>["data"];
+	environments: ReturnType<typeof useEnvironmentsQuery>["data"];
+}) {
 	const renderContent = () => {
 		switch (activeSidebarTab) {
 			case "collections":
@@ -57,7 +120,10 @@ export default function Sidebar() {
 				return <HistoryList />;
 			case "variables":
 				return (
-					<VariablesCategoryTree collections={collections} environments={environments} />
+					<VariablesCategoryTree
+						collections={collections ?? []}
+						environments={environments ?? []}
+					/>
 				);
 			case "settings":
 				return <SettingsCategoryTree />;
@@ -67,50 +133,60 @@ export default function Sidebar() {
 	};
 
 	return (
+		<div className="w-60 h-full bg-panel border-r border-border flex flex-col overflow-hidden shrink-0">
+			<div className="flex-1 min-h-0 overflow-hidden">
+				<ScrollArea className="h-full w-full">
+					<div className="w-full min-w-0">{renderContent()}</div>
+				</ScrollArea>
+			</div>
+
+			<div className="shrink-0 border-t border-border z-10">
+				<ConnectionStatus />
+			</div>
+		</div>
+	);
+}
+
+export default function Sidebar() {
+	const { activeSidebarTab, setActiveSidebarTab, navigateToVariables, navigateToSettings } =
+		useNavigationStore();
+	const { data: collections } = useCollectionsQuery();
+	const { data: environments } = useEnvironmentsQuery();
+	const [panelOpen, setPanelOpen] = useState(true);
+
+	const handleTabClick = (tabId: SidebarTab) => {
+		// Clicking the active tab while panel is open → collapse
+		if (tabId === activeSidebarTab && panelOpen) {
+			setPanelOpen(false);
+			return;
+		}
+
+		setPanelOpen(true);
+
+		if (tabId === "variables") {
+			navigateToVariables();
+		} else if (tabId === "settings") {
+			navigateToSettings();
+		} else {
+			setActiveSidebarTab(tabId);
+		}
+	};
+
+	return (
 		<TooltipProvider>
-			{/* Sidebar Container - Handles all width and overflow constraints */}
-			<div className="w-full h-full bg-card border-r border-border flex flex-col overflow-hidden">
-				{/* Tab Headers - Fixed height, handles text truncation */}
-				<div className="flex border-b border-border shrink-0 min-w-0">
-					{tabs.map((tab) => {
-						const Icon = tab.icon;
-						const isActive = activeSidebarTab === tab.id;
-						return (
-							<Tooltip key={tab.id}>
-								<TooltipTrigger asChild>
-									<Button
-										variant="ghost"
-										onClick={() => handleTabClick(tab.id)}
-										className={cn(
-											"flex-1 flex flex-col items-center justify-center gap-1 px-2 py-3 h-auto min-w-0 ",
-											isActive
-												? "text-primary bg-primary/10 border-b-2 border-primary"
-												: "text-muted-foreground hover:text-foreground hover:bg-accent"
-										)}
-									>
-										<Icon className="w-5 h-5 shrink-0" />
-										<span className="text-xs font-medium truncate text-center w-full">
-											{tab.label}
-										</span>
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="bottom">{tab.label}</TooltipContent>
-							</Tooltip>
-						);
-					})}
-				</div>
-
-				{/* Tab Content - Handles overflow, children just fill space */}
-				<div className="flex-1 min-h-0 min-w-0 overflow-hidden">
-					<ScrollArea className="h-full w-full">
-						<div className="w-full min-w-0">{renderContent()}</div>
-					</ScrollArea>
-				</div>
-
-				{/* Footer - Fixed height, always visible at bottom */}
-				<div className="shrink-0 border-t border-border z-10">
-					<ConnectionStatus />
-				</div>
+			<div className="flex h-full shrink-0">
+				<ActivityBar
+					activeSidebarTab={activeSidebarTab}
+					panelOpen={panelOpen}
+					onTabClick={handleTabClick}
+				/>
+				{panelOpen && (
+					<SidebarPanel
+						activeSidebarTab={activeSidebarTab}
+						collections={collections}
+						environments={environments}
+					/>
+				)}
 			</div>
 		</TooltipProvider>
 	);

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -11,6 +11,7 @@ export { useEngine } from "./useEngine";
 export { useSaveManager } from "./useSaveManager";
 export { useVariableResolver } from "./useVariableResolver";
 export { useElectronTheme } from "./useElectronTheme";
+export { useResizable } from "./useResizable";
 
 // Note: useCollections, useRuns, useHealthCheck have been replaced by TanStack Query hooks
 // Import from @/queries instead

--- a/app/src/hooks/useEngine.ts
+++ b/app/src/hooks/useEngine.ts
@@ -12,6 +12,7 @@ import { useState, useCallback } from "react";
 import { ApiError, apiService } from "@/services";
 import type {
 	SanityResult,
+	ExecuteRequestRequest,
 	StartLoadTestRequest,
 	StartLoadTestResponse,
 	LoadTestConfig,
@@ -19,7 +20,14 @@ import type {
 } from "@/types";
 
 interface UseEngineReturn {
-	executeRequest: (request: Request, environmentId?: string) => Promise<SanityResult | null>;
+	/**
+	 * Execute a request against the engine.
+	 * Accepts a pre-resolved ExecuteRequestRequest (flat headers, resolved auth/body).
+	 */
+	executeRequest: (
+		params: ExecuteRequestRequest,
+		environmentId?: string
+	) => Promise<SanityResult | null>;
 	startLoadTest: (
 		request: Request,
 		config: LoadTestConfig,
@@ -35,39 +43,24 @@ export function useEngine(): UseEngineReturn {
 	const [error, setError] = useState<string | null>(null);
 
 	const executeRequest = useCallback(
-		async (request: Request, environmentId?: string): Promise<SanityResult | null> => {
+		async (
+			params: ExecuteRequestRequest,
+			environmentId?: string
+		): Promise<SanityResult | null> => {
 			setIsExecuting(true);
 			setError(null);
 
 			try {
-				// Build the request body according to API documentation
-				// Backend expects body as { mode: string, content: string }
-				const bodyPayload = request.body
-					? {
-							mode: request.bodyType || "text",
-							content: request.body,
-						}
-					: undefined;
-
 				const result = await apiService.executeRequest({
-					method: request.method,
-					url: request.url,
-					headers: request.headers,
-					body: bodyPayload,
-					auth: request.auth,
-					preRequestScript: request.preRequestScript,
-					postRequestScript: request.postRequestScript,
-					requestId: request.id,
-					environmentId: environmentId,
+					...params,
+					environmentId: params.environmentId ?? environmentId,
 				});
 				return result;
 			} catch (err) {
-				// Handle engine API failures (engine down, network error to engine, etc.)
-				// All valid request executions return HTTP 200 with response in body
 				const errorMessage =
 					err instanceof Error ? err.message : "Failed to connect to engine";
 				const errorCode = err instanceof ApiError ? err.errorCode : "ENGINE_ERROR";
-				
+
 				setError(errorMessage);
 				return {
 					status: 0,
@@ -93,40 +86,24 @@ export function useEngine(): UseEngineReturn {
 			setError(null);
 
 			try {
-				// Build payload matching backend POST /run expectations
-				// Backend expects body as { mode: string, content: string }
-				const bodyPayload = request.body
-					? {
-							mode: request.bodyType || "text",
-							content: request.body,
-						}
-					: undefined;
-
 				const payload: StartLoadTestRequest = {
-					// HTTP request fields at root level (flat structure)
 					method: request.method,
 					url: request.url,
-					headers: request.headers,
-					body: bodyPayload,
-					// Load test strategy
+					// Flat headers passed in from caller (already resolved)
+					headers: {},
 					mode: config.mode,
-					// Duration (convert seconds to string format)
 					duration: config.duration_seconds ? `${config.duration_seconds}s` : undefined,
 					targetRps: config.rps,
 					iterations: config.iterations,
 					concurrency: config.concurrency,
-					// Ramp-up settings
 					rampUpDuration: config.ramp_duration_seconds
 						? `${config.ramp_duration_seconds}s`
 						: undefined,
-					// Linking
 					requestId: request.id,
 					environmentId: environmentId,
-					// Data capture options
 					success_sample_rate: config.data_sample_rate,
 					slow_threshold_ms: config.slow_threshold_ms,
 					save_timing_breakdown: config.save_timing_breakdown,
-					// Metadata
 					comment: config.comment,
 				};
 

--- a/app/src/hooks/useEngine.ts
+++ b/app/src/hooks/useEngine.ts
@@ -13,10 +13,6 @@ import { ApiError, apiService } from "@/services";
 import type {
 	SanityResult,
 	ExecuteRequestRequest,
-	StartLoadTestRequest,
-	StartLoadTestResponse,
-	LoadTestConfig,
-	Request,
 } from "@/types";
 
 interface UseEngineReturn {
@@ -28,11 +24,6 @@ interface UseEngineReturn {
 		params: ExecuteRequestRequest,
 		environmentId?: string
 	) => Promise<SanityResult | null>;
-	startLoadTest: (
-		request: Request,
-		config: LoadTestConfig,
-		environmentId?: string
-	) => Promise<StartLoadTestResponse | null>;
 	stopLoadTest: (runId: string) => Promise<boolean>;
 	isExecuting: boolean;
 	error: string | null;
@@ -76,51 +67,6 @@ export function useEngine(): UseEngineReturn {
 		[]
 	);
 
-	const startLoadTest = useCallback(
-		async (
-			request: Request,
-			config: LoadTestConfig,
-			environmentId?: string
-		): Promise<StartLoadTestResponse | null> => {
-			setIsExecuting(true);
-			setError(null);
-
-			try {
-				const payload: StartLoadTestRequest = {
-					method: request.method,
-					url: request.url,
-					// Flat headers passed in from caller (already resolved)
-					headers: {},
-					mode: config.mode,
-					duration: config.duration_seconds ? `${config.duration_seconds}s` : undefined,
-					targetRps: config.rps,
-					iterations: config.iterations,
-					concurrency: config.concurrency,
-					rampUpDuration: config.ramp_duration_seconds
-						? `${config.ramp_duration_seconds}s`
-						: undefined,
-					requestId: request.id,
-					environmentId: environmentId,
-					success_sample_rate: config.data_sample_rate,
-					slow_threshold_ms: config.slow_threshold_ms,
-					save_timing_breakdown: config.save_timing_breakdown,
-					comment: config.comment,
-				};
-
-				const response = await apiService.startLoadTest(payload);
-				return response;
-			} catch (err) {
-				const errorMessage =
-					err instanceof Error ? err.message : "Failed to start load test";
-				setError(errorMessage);
-				return null;
-			} finally {
-				setIsExecuting(false);
-			}
-		},
-		[]
-	);
-
 	const stopLoadTest = useCallback(async (runId: string): Promise<boolean> => {
 		setError(null);
 
@@ -136,7 +82,6 @@ export function useEngine(): UseEngineReturn {
 
 	return {
 		executeRequest,
-		startLoadTest,
 		stopLoadTest,
 		isExecuting,
 		error,

--- a/app/src/hooks/useResizable.ts
+++ b/app/src/hooks/useResizable.ts
@@ -1,0 +1,68 @@
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+interface UseResizableOptions {
+	defaultSize: number;
+	min: number;
+	max: number;
+	/** "horizontal" (default) resizes width; "vertical" resizes height */
+	direction?: "horizontal" | "vertical";
+}
+
+interface UseResizableReturn {
+	size: number;
+	isResizing: boolean;
+	startResizing: () => void;
+}
+
+/**
+ * Manages drag-to-resize behavior for a panel along one axis.
+ *
+ * Returns `size` (px), `isResizing` flag, and `startResizing` to wire up
+ * to the drag handle's onMouseDown. Cleans up global listeners automatically.
+ */
+export function useResizable({
+	defaultSize,
+	min,
+	max,
+	direction = "horizontal",
+}: UseResizableOptions): UseResizableReturn {
+	const [size, setSize] = useState(defaultSize);
+	const [isResizing, setIsResizing] = useState(false);
+
+	const startResizing = useCallback(() => {
+		setIsResizing(true);
+	}, []);
+
+	useEffect(() => {
+		if (!isResizing) return;
+
+		const handleMouseMove = (e: MouseEvent) => {
+			const next = direction === "horizontal" ? e.clientX : e.clientY;
+			if (next >= min && next <= max) setSize(next);
+		};
+
+		const handleMouseUp = () => setIsResizing(false);
+
+		document.addEventListener("mousemove", handleMouseMove);
+		document.addEventListener("mouseup", handleMouseUp);
+		document.body.style.cursor = direction === "horizontal" ? "col-resize" : "row-resize";
+		document.body.style.userSelect = "none";
+
+		return () => {
+			document.removeEventListener("mousemove", handleMouseMove);
+			document.removeEventListener("mouseup", handleMouseUp);
+			document.body.style.cursor = "";
+			document.body.style.userSelect = "";
+		};
+	}, [isResizing, min, max, direction]);
+
+	return { size, isResizing, startResizing };
+}

--- a/app/src/hooks/useResizable.ts
+++ b/app/src/hooks/useResizable.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 
 interface UseResizableOptions {
 	defaultSize: number;
@@ -19,14 +19,17 @@ interface UseResizableOptions {
 interface UseResizableReturn {
 	size: number;
 	isResizing: boolean;
-	startResizing: () => void;
+	/** Wire to the drag handle's onMouseDown. Captures the drag origin so size
+	 *  is computed as a delta — works for panels that don't start at x=0. */
+	startResizing: (e: React.MouseEvent) => void;
 }
 
 /**
  * Manages drag-to-resize behavior for a panel along one axis.
  *
- * Returns `size` (px), `isResizing` flag, and `startResizing` to wire up
- * to the drag handle's onMouseDown. Cleans up global listeners automatically.
+ * Uses delta-based calculation: new size = size at drag start + mouse delta.
+ * This means the hook is correct regardless of where the panel sits in the
+ * layout, unlike an approach that sets size = raw clientX.
  */
 export function useResizable({
 	defaultSize,
@@ -36,20 +39,36 @@ export function useResizable({
 }: UseResizableOptions): UseResizableReturn {
 	const [size, setSize] = useState(defaultSize);
 	const [isResizing, setIsResizing] = useState(false);
+	const dragStart = useRef<{ mousePos: number; size: number } | null>(null);
 
-	const startResizing = useCallback(() => {
-		setIsResizing(true);
-	}, []);
+	const startResizing = useCallback(
+		(e: React.MouseEvent) => {
+			dragStart.current = {
+				mousePos: direction === "horizontal" ? e.clientX : e.clientY,
+				size,
+			};
+			setIsResizing(true);
+		},
+		[direction, size],
+	);
 
 	useEffect(() => {
 		if (!isResizing) return;
 
 		const handleMouseMove = (e: MouseEvent) => {
-			const next = direction === "horizontal" ? e.clientX : e.clientY;
-			if (next >= min && next <= max) setSize(next);
+			if (!dragStart.current) return;
+			const current = direction === "horizontal" ? e.clientX : e.clientY;
+			const next = Math.min(
+				max,
+				Math.max(min, dragStart.current.size + (current - dragStart.current.mousePos)),
+			);
+			setSize(next);
 		};
 
-		const handleMouseUp = () => setIsResizing(false);
+		const handleMouseUp = () => {
+			dragStart.current = null;
+			setIsResizing(false);
+		};
 
 		document.addEventListener("mousemove", handleMouseMove);
 		document.addEventListener("mouseup", handleMouseUp);

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -10,59 +10,61 @@
  * useVariableResolver Hook
  *
  * Provides functions to resolve {{variables}} in strings using the current
- * variable context (globals, active collection, active environment).
+ * variable context (globals, collection chain, active environment).
  *
- * Resolution priority: Environment > Collection > Global
+ * Resolution priority (highest wins): Environment > Collection chain (leaf → root) > Global
+ * Within the collection chain, variables closer to the leaf override those closer to the root.
+ * Cached per (collectionId, environmentId) via useMemo.
  */
 
 import { useMemo, useCallback } from "react";
 import { useGlobalsQuery, useCollectionsQuery, useEnvironmentsQuery } from "@/queries";
 import { useVariablesStore } from "@/stores";
-import type { VariableValue, ResolvedVariable } from "@/types";
+import type { VariableValue, ResolvedVariable, Collection } from "@/types";
 
 interface UseVariableResolverOptions {
-	/** Override collection ID (e.g., from current request) */
 	collectionId?: string;
 }
 
 interface UseVariableResolverReturn {
-	/** Resolve all {{variables}} in a string */
 	resolveString: (input: string) => string;
-
-	/** Resolve variables in an object (deep, including nested strings) */
 	resolveObject: <T>(obj: T) => T;
-
-	/** Get resolved value for a specific variable name */
 	getVariable: (name: string) => ResolvedVariable | null;
-
-	/** Get all available variables with their sources */
 	getAllVariables: () => Record<string, ResolvedVariable>;
-
-	/** Check if a string contains any unresolved variables */
 	hasUnresolvedVariables: (input: string) => boolean;
 }
 
 const VARIABLE_PATTERN = /\{\{([^{}]+)\}\}/g;
 
+/** Build root-first ancestor chain for a collection (inclusive of the collection itself). */
+function buildCollectionChain(startId: string, collections: Collection[]): Collection[] {
+	const chain: Collection[] = [];
+	let currentId: string | undefined = startId;
+	while (currentId) {
+		const col = collections.find((c) => c.id === currentId);
+		if (!col) break;
+		chain.unshift(col); // root first
+		currentId = col.parentId;
+	}
+	return chain;
+}
+
 export function useVariableResolver(
 	options?: UseVariableResolverOptions
 ): UseVariableResolverReturn {
-	// Fetch all variable sources
 	const { data: globalsData } = useGlobalsQuery();
 	const { data: collections = [] } = useCollectionsQuery();
 	const { data: environments = [] } = useEnvironmentsQuery();
 
-	// Get active environment from variables store (set by VariableEditor when editing environments)
 	const { activeEnvironmentId, activeCollectionId: storeCollectionId } = useVariablesStore();
-
-	// Use option collectionId if provided, otherwise fall back to store
 	const activeCollectionId = options?.collectionId || storeCollectionId;
 
-	// Build flat variable map with sources
+	// Build variable map with hierarchical resolution:
+	// globals < collection chain (root → leaf) < environment
 	const variableMap = useMemo(() => {
 		const result: Record<string, ResolvedVariable> = {};
 
-		// Add globals first (lowest priority)
+		// 1. Globals (lowest priority)
 		if (globalsData?.variables) {
 			for (const [key, val] of Object.entries(globalsData.variables)) {
 				const v = val as VariableValue;
@@ -72,20 +74,22 @@ export function useVariableResolver(
 			}
 		}
 
-		// Add collection variables (medium priority, overwrites globals)
+		// 2. Collection chain — root-first so leaf variables override parent variables
 		if (activeCollectionId) {
-			const col = collections.find((c) => c.id === activeCollectionId);
-			if (col?.variables) {
-				for (const [key, val] of Object.entries(col.variables)) {
-					const v = val as VariableValue;
-					if (v.enabled) {
-						result[key] = { value: v.value, scope: "collection", secret: v.secret };
+			const chain = buildCollectionChain(activeCollectionId, collections);
+			for (const col of chain) {
+				if (col.variables) {
+					for (const [key, val] of Object.entries(col.variables)) {
+						const v = val as VariableValue;
+						if (v.enabled) {
+							result[key] = { value: v.value, scope: "collection", secret: v.secret };
+						}
 					}
 				}
 			}
 		}
 
-		// Add environment variables (highest priority, overwrites all)
+		// 3. Environment (highest priority)
 		if (activeEnvironmentId) {
 			const env = environments.find((e) => e.id === activeEnvironmentId);
 			if (env?.variables) {
@@ -102,24 +106,21 @@ export function useVariableResolver(
 	}, [globalsData, collections, environments, activeCollectionId, activeEnvironmentId]);
 
 	const getVariable = useCallback(
-		(name: string): ResolvedVariable | null => {
-			return variableMap[name] || null;
-		},
+		(name: string): ResolvedVariable | null => variableMap[name] || null,
 		[variableMap]
 	);
 
-	const getAllVariables = useCallback((): Record<string, ResolvedVariable> => {
-		return { ...variableMap };
-	}, [variableMap]);
+	const getAllVariables = useCallback(
+		(): Record<string, ResolvedVariable> => ({ ...variableMap }),
+		[variableMap]
+	);
 
 	const resolveString = useCallback(
 		(input: string): string => {
 			if (!input || typeof input !== "string") return input;
-
 			return input.replace(VARIABLE_PATTERN, (match, varName) => {
-				const trimmedName = varName.trim();
-				const source = variableMap[trimmedName];
-				return source ? source.value : match; // Keep original if not found
+				const source = variableMap[varName.trim()];
+				return source ? source.value : match;
 			});
 		},
 		[variableMap]
@@ -128,15 +129,8 @@ export function useVariableResolver(
 	const resolveObject = useCallback(
 		<T>(obj: T): T => {
 			if (obj === null || obj === undefined) return obj;
-
-			if (typeof obj === "string") {
-				return resolveString(obj) as unknown as T;
-			}
-
-			if (Array.isArray(obj)) {
-				return obj.map((item) => resolveObject(item)) as unknown as T;
-			}
-
+			if (typeof obj === "string") return resolveString(obj) as unknown as T;
+			if (Array.isArray(obj)) return obj.map((item) => resolveObject(item)) as unknown as T;
 			if (typeof obj === "object") {
 				const result: Record<string, unknown> = {};
 				for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
@@ -144,7 +138,6 @@ export function useVariableResolver(
 				}
 				return result as T;
 			}
-
 			return obj;
 		},
 		[resolveString]
@@ -153,23 +146,12 @@ export function useVariableResolver(
 	const hasUnresolvedVariables = useCallback(
 		(input: string): boolean => {
 			if (!input || typeof input !== "string") return false;
-
 			const matches = input.match(VARIABLE_PATTERN);
 			if (!matches) return false;
-
-			return matches.some((match) => {
-				const varName = match.slice(2, -2).trim();
-				return !variableMap[varName];
-			});
+			return matches.some((match) => !variableMap[match.slice(2, -2).trim()]);
 		},
 		[variableMap]
 	);
 
-	return {
-		resolveString,
-		resolveObject,
-		getVariable,
-		getAllVariables,
-		hasUnresolvedVariables,
-	};
+	return { resolveString, resolveObject, getVariable, getAllVariables, hasUnresolvedVariables };
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -2,8 +2,6 @@
 @config "../tailwind.config.js";
 
 /* Tailwind 4 theme configuration for custom colors */
-/* Define custom semantic colors that reference CSS variables */
-/* Using 'inline' preserves default Tailwind colors (green, red, etc.) */
 @theme inline {
 	--color-background: hsl(var(--background));
 	--color-foreground: hsl(var(--foreground));
@@ -19,11 +17,15 @@
 	--color-muted-foreground: hsl(var(--muted-foreground));
 	--color-accent: hsl(var(--accent));
 	--color-accent-foreground: hsl(var(--accent-foreground));
+	--color-accent-active: hsl(var(--accent-active));
 	--color-destructive: hsl(var(--destructive));
 	--color-destructive-foreground: hsl(var(--destructive-foreground));
 	--color-border: hsl(var(--border));
+	--color-border-strong: hsl(var(--border-strong));
 	--color-input: hsl(var(--input));
 	--color-ring: hsl(var(--ring));
+	--color-panel: hsl(var(--panel));
+	--color-subtle-foreground: hsl(var(--subtle-foreground));
 	--color-success: hsl(var(--success));
 	--color-success-foreground: hsl(var(--success-foreground));
 	--color-warning: hsl(var(--warning));
@@ -43,259 +45,245 @@
 
 /*
  * Vayu Design System
- * 
- * Color Philosophy: Clean gray palette with orange accent
- * - Primary: Warm orange for actions, variables, highlights
- * - Neutral: Zinc-based grays for backgrounds, text, borders
- * 
- * Usage:
- * - bg-background, text-foreground (main app)
- * - bg-card, text-card-foreground (cards, panels)
- * - bg-primary, text-primary-foreground (buttons, badges)
- * - bg-muted, text-muted-foreground (subtle backgrounds, secondary text)
- * - bg-accent, text-accent-foreground (hover states)
- * - bg-destructive (errors, delete actions)
- * - border-border, border-input (borders)
- * - ring-ring (focus rings)
+ *
+ * Color Philosophy: 3-level elevation system
+ * Dark:  canvas (#09090b) → panel (#111113) → card (#1a1a1f)
+ * Light: warm stone canvas (#e6e3dc) → warm panel (#f2f0eb) → white card (#ffffff)
+ *
+ * Primary accent: Sunset orange (default), Electric cyan, Royal violet
  */
 
 @layer base {
 	:root {
-		/* Base colors - Light mode */
-		--background: 0 0% 100%; /* white */
-		--foreground: 240 10% 3.9%; /* near black */
+		/* ── Light mode — Warm Stone ── */
 
-		/* Card/Panel surfaces */
-		--card: 0 0% 100%; /* white */
-		--card-foreground: 240 10% 3.9%;
+		/* 3-level elevation */
+		--background: 42 17% 88%;     /* #e6e3dc — warm stone canvas */
+		--card:        0 0% 100%;     /* #ffffff — white card (floats on bg) */
+		--panel:      42 21% 94%;     /* #f2f0eb — sidebar/panel (between canvas and card) */
 
-		/* Popover/Dropdown surfaces */
-		--popover: 0 0% 100%;
-		--popover-foreground: 240 10% 3.9%;
+		--card-foreground:    240 6% 10%;
+		--popover:             0 0% 100%;
+		--popover-foreground: 240 6% 10%;
 
-		/* Primary - Sunset (default, warm and energetic) */
-		--primary: 24.6 95% 53.1%; /* orange-500 */
-		--primary-foreground: 0 0% 100%; /* white text on orange */
+		/* Primary — Sunset orange (default) */
+		--primary:            24.6 95% 53.1%;  /* #f97316 orange-500 */
+		--primary-foreground:  0 0% 100%;
 
-		/* Secondary - Subtle gray */
-		--secondary: 240 4.8% 95.9%; /* zinc-100 */
-		--secondary-foreground: 240 5.9% 10%;
+		/* Secondary */
+		--secondary:          42 21% 94%;
+		--secondary-foreground: 240 6% 10%;
 
-		/* Muted - For subtle backgrounds and disabled states */
-		--muted: 240 4.8% 95.9%; /* zinc-100 */
-		--muted-foreground: 240 3.8% 46.1%; /* zinc-500 */
+		/* Hover / active states */
+		--muted:              38 20% 89%;      /* #e9e5de — accent-hover */
+		--muted-foreground:  240 4% 46%;       /* #71717a — zinc-500 */
+		--accent:             38 20% 89%;      /* #e9e5de — accent-hover */
+		--accent-foreground: 240 6% 10%;
+		--accent-active:     40 16% 85%;       /* #dedad2 — accent-active / selected */
 
-		/* Accent - For hover states */
-		--accent: 240 4.8% 95.9%;
-		--accent-foreground: 240 5.9% 10%;
-
-		/* Destructive - For errors and delete actions */
-		--destructive: 0 84.2% 60.2%; /* red-500 */
-		--destructive-foreground: 0 0% 98%;
+		/* Foreground scale */
+		--foreground:         240 6% 10%;      /* #18181b — zinc-900 */
+		--subtle-foreground: 240 7% 78%;       /* #c4c4cc — muted placeholder */
 
 		/* Borders */
-		--border: 240 5.9% 90%; /* zinc-200 */
-		--input: 240 5.9% 90%; /* zinc-200 */
-		--ring: 24.6 95% 53.1%; /* orange for focus rings */
+		--border:        40 9% 80%;            /* ≈ rgba(0,0,0,0.09) on warm stone */
+		--border-strong: 40 6% 72%;            /* ≈ rgba(0,0,0,0.18) on warm stone */
+		--input:         40 9% 80%;
+		--ring:          24.6 95% 53.1%;
 
-		/* Chart colors */
-		--chart-1: 24.6 95% 53.1%; /* orange */
-		--chart-2: 173 58% 39%; /* teal */
-		--chart-3: 197 37% 24%; /* dark cyan */
-		--chart-4: 43 74% 66%; /* yellow */
-		--chart-5: 27 87% 67%; /* light orange */
+		/* Destructive */
+		--destructive:            0 84.2% 60.2%;
+		--destructive-foreground: 0 0% 98%;
 
-		/* Semantic colors for HTTP methods */
-		--method-get: 142 76% 36%; /* green */
-		--method-post: 217 91% 60%; /* blue */
-		--method-put: 38 92% 50%; /* amber */
-		--method-patch: 262 83% 58%; /* purple */
-		--method-delete: 0 84% 60%; /* red */
-		--method-head: 199 89% 48%; /* cyan */
-		--method-options: 240 5% 64%; /* gray */
+		/* Charts */
+		--chart-1: 24.6 95% 53.1%;
+		--chart-2: 173 58% 39%;
+		--chart-3: 197 37% 24%;
+		--chart-4:  43 74% 66%;
+		--chart-5:  27 87% 67%;
 
-		/* Variables highlight */
-		--variable: 24.6 95% 53.1%; /* sunset orange for {{variables}} */
+		/* HTTP method colors */
+		--method-get:     142 76% 36%;
+		--method-post:    217 91% 60%;
+		--method-put:      38 92% 50%;
+		--method-patch:   262 83% 58%;
+		--method-delete:    0 84% 60%;
+		--method-head:    199 89% 48%;
+		--method-options: 240  5% 64%;
+
+		/* Variable highlight */
+		--variable: 24.6 95% 53.1%;
+
+		/* Semantic */
+		--success:            142 76% 36%;
+		--success-foreground:   0  0% 100%;
+		--warning:             38 92% 50%;
+		--warning-foreground:   0  0% 100%;
+		--info:               199 89% 48%;
+		--info-foreground:      0  0% 100%;
+
+		/* Geometry */
+		--radius: 0.375rem;
 	}
 
-	/* Color Schemes - Modern Themes */
+	/* ── Accent color schemes (light mode) ── */
+
+	[data-color-scheme="sunset"] {
+		--primary:            24.6 95% 53.1%;
+		--primary-foreground:  0 0% 100%;
+		--ring:               24.6 95% 53.1%;
+		--variable:           24.6 95% 53.1%;
+		--chart-1:            24.6 95% 53.1%;
+	}
+
 	[data-color-scheme="sky"] {
-		/* Sky - Light sky blue, calm and airy like clouds */
-		--primary: 199 89% 48%; /* sky-500 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 199 89% 48%;
-		--variable: 199 89% 48%;
-		--chart-1: 199 89% 48%;
+		--primary:           188 94% 43%;      /* #22d3ee cyan-400 */
+		--primary-foreground:  0  0% 100%;
+		--ring:              188 94% 43%;
+		--variable:          188 94% 43%;
+		--chart-1:           188 94% 43%;
 	}
 
 	[data-color-scheme="ocean"] {
-		/* Ocean - Deep blue, calm and professional */
-		--primary: 217 91% 60%; /* blue-500 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 217 91% 60%;
-		--variable: 217 91% 60%;
-		--chart-1: 217 91% 60%;
+		--primary:           217 91% 60%;
+		--primary-foreground:  0  0% 100%;
+		--ring:              217 91% 60%;
+		--variable:          217 91% 60%;
+		--chart-1:           217 91% 60%;
 	}
 
 	[data-color-scheme="forest"] {
-		/* Forest - Fresh green, nature-inspired and calm */
-		--primary: 142 76% 36%; /* green-600 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 142 76% 36%;
-		--variable: 142 76% 36%;
-		--chart-1: 142 76% 36%;
-	}
-
-	[data-color-scheme="sunset"] {
-		/* Sunset - Warm orange, energetic and vibrant */
-		--primary: 24.6 95% 53.1%; /* orange-500 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 24.6 95% 53.1%;
-		--variable: 24.6 95% 53.1%;
-		--chart-1: 24.6 95% 53.1%;
+		--primary:           142 76% 36%;
+		--primary-foreground:  0  0% 100%;
+		--ring:              142 76% 36%;
+		--variable:          142 76% 36%;
+		--chart-1:           142 76% 36%;
 	}
 
 	[data-color-scheme="aurora"] {
-		/* Aurora - Purple/blue, magical and modern */
-		--primary: 262 83% 58%; /* purple-500 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 262 83% 58%;
-		--variable: 262 83% 58%;
-		--chart-1: 262 83% 58%;
+		--primary:           258 87% 74%;      /* #a78bfa violet-400 */
+		--primary-foreground:  0  0% 100%;
+		--ring:              258 87% 74%;
+		--variable:          258 87% 74%;
+		--chart-1:           258 87% 74%;
 	}
 
 	[data-color-scheme="coral"] {
-		/* Coral - Warm pink/coral, vibrant and energetic */
-		--primary: 0 72% 65%; /* rose-400 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 0 72% 65%;
-		--variable: 0 72% 65%;
-		--chart-1: 0 72% 65%;
+		--primary:             0 72% 65%;
+		--primary-foreground:  0  0% 100%;
+		--ring:                0 72% 65%;
+		--variable:            0 72% 65%;
+		--chart-1:             0 72% 65%;
 	}
 
-	/* Success/Warning/Info */
-	:root {
-		--success: 142 76% 36%; /* green-600 */
-		--success-foreground: 0 0% 100%;
-		--warning: 38 92% 50%; /* amber-500 */
-		--warning-foreground: 0 0% 100%;
-		--info: 199 89% 48%; /* sky-500 */
-		--info-foreground: 0 0% 100%;
-
-		/* Radius */
-		--radius: 0.2rem;
-	}
+	/* ── Dark mode ── */
 
 	.dark {
-		/* Base colors - Dark mode */
-		--background: 240 10% 3.9%; /* near black */
-		--foreground: 0 0% 98%; /* near white */
+		/* 3-level elevation */
+		--background: 240 10%  4%;    /* #09090b — outermost canvas */
+		--card:       240  6% 11%;    /* #1a1a1f — elevated surface */
+		--panel:      240  6%  7%;    /* #111113 — sidebar/panel bg */
 
-		/* Card/Panel surfaces */
-		--card: 240 10% 3.9%;
-		--card-foreground: 0 0% 98%;
+		--card-foreground:    240  5% 96%;
+		--popover:            240  6% 11%;
+		--popover-foreground: 240  5% 96%;
 
-		/* Popover/Dropdown surfaces */
-		--popover: 240 10% 3.9%;
-		--popover-foreground: 0 0% 98%;
-
-		/* Primary - Sunset (slightly adjusted for dark, default) */
-		--primary: 20.5 90.2% 48.2%; /* orange-600 */
-		--primary-foreground: 0 0% 100%;
+		/* Primary — Sunset orange (default) */
+		--primary:            24.6 95% 53.1%;
+		--primary-foreground:  0   0% 100%;
 
 		/* Secondary */
-		--secondary: 240 3.7% 15.9%; /* zinc-800 */
-		--secondary-foreground: 0 0% 98%;
+		--secondary:          240  7% 16%;
+		--secondary-foreground: 240 5% 96%;
 
-		/* Muted */
-		--muted: 240 3.7% 15.9%;
-		--muted-foreground: 240 5% 64.9%;
+		/* Hover / active states */
+		--muted:              240  7% 16%;     /* #26262c — accent-hover */
+		--muted-foreground:   240  5% 65%;     /* #a1a1aa — zinc-400 */
+		--accent:             240  7% 16%;     /* #26262c — accent-hover */
+		--accent-foreground:  240  5% 96%;
+		--accent-active:      240  6% 21%;     /* #323238 — accent-active / selected */
 
-		/* Accent */
-		--accent: 240 3.7% 15.9%;
-		--accent-foreground: 0 0% 98%;
-
-		/* Destructive */
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 0% 98%;
+		/* Foreground scale */
+		--foreground:         240  5% 96%;     /* #f4f4f5 — zinc-100 */
+		--subtle-foreground:  240  5% 34%;     /* #52525b — zinc-600 */
 
 		/* Borders */
-		--border: 240 3.7% 15.9%;
-		--input: 240 3.7% 15.9%;
-		--ring: 20.5 90.2% 48.2%;
+		--border:              0   0% 10%;     /* ≈ rgba(255,255,255,0.07) on dark canvas */
+		--border-strong:       0   0% 18%;     /* ≈ rgba(255,255,255,0.15) on dark canvas */
+		--input:              240  6% 11%;
+		--ring:               24.6 95% 53.1%;
 
-		/* Chart colors (adjusted for dark mode) */
-		--chart-1: 20.5 90.2% 48.2%;
-		--chart-2: 160 60% 45%;
-		--chart-3: 30 80% 55%;
-		--chart-4: 280 65% 60%;
-		--chart-5: 340 75% 55%;
+		/* Destructive */
+		--destructive:             0 62.8% 30.6%;
+		--destructive-foreground:  0  0% 98%;
 
-		/* Variables highlight (dark mode) */
-		--variable: 20.5 90.2% 48.2%; /* sunset orange */
+		/* Charts */
+		--chart-1: 24.6 95% 53.1%;
+		--chart-2: 160  60% 45%;
+		--chart-3:  30  80% 55%;
+		--chart-4: 280  65% 60%;
+		--chart-5: 340  75% 55%;
 
-		/* Success/Warning/Info (dark mode) */
-		--success: 142 70% 45%;
-		--success-foreground: 0 0% 100%;
-		--warning: 38 92% 50%;
-		--warning-foreground: 0 0% 100%;
-		--info: 199 89% 48%;
-		--info-foreground: 0 0% 100%;
+		/* Variable highlight */
+		--variable: 24.6 95% 53.1%;
+
+		/* Semantic */
+		--success:            142 70% 45%;
+		--success-foreground:   0  0% 100%;
+		--warning:             38 92% 50%;
+		--warning-foreground:   0  0% 100%;
+		--info:               199 89% 48%;
+		--info-foreground:      0  0% 100%;
 	}
 
-	/* Color Schemes - Dark Mode */
+	/* ── Accent color schemes (dark mode) ── */
+
+	.dark[data-color-scheme="sunset"] {
+		--primary:            24.6 95% 53.1%;
+		--primary-foreground:  0   0% 100%;
+		--ring:               24.6 95% 53.1%;
+		--variable:           24.6 95% 53.1%;
+		--chart-1:            24.6 95% 53.1%;
+	}
+
 	.dark[data-color-scheme="sky"] {
-		/* Sky - Adjusted for dark mode */
-		--primary: 199 89% 48%; /* sky-500 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 199 89% 48%;
-		--variable: 199 89% 48%;
-		--chart-1: 199 89% 48%;
+		--primary:           188 94% 43%;
+		--primary-foreground:  0  0% 100%;
+		--ring:              188 94% 43%;
+		--variable:          188 94% 43%;
+		--chart-1:           188 94% 43%;
 	}
 
 	.dark[data-color-scheme="ocean"] {
-		/* Ocean - Deep blue for dark mode */
-		--primary: 217 78% 51%; /* blue-600 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 217 78% 51%;
-		--variable: 217 78% 51%;
-		--chart-1: 217 78% 51%;
+		--primary:           217 78% 51%;
+		--primary-foreground:  0  0% 100%;
+		--ring:              217 78% 51%;
+		--variable:          217 78% 51%;
+		--chart-1:           217 78% 51%;
 	}
 
 	.dark[data-color-scheme="forest"] {
-		/* Forest - Fresh green for dark mode */
-		--primary: 142 70% 45%; /* green-600 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 142 70% 45%;
-		--variable: 142 70% 45%;
-		--chart-1: 142 70% 45%;
-	}
-
-	.dark[data-color-scheme="sunset"] {
-		/* Sunset - Warm orange for dark mode */
-		--primary: 20.5 90.2% 48.2%; /* orange-600 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 20.5 90.2% 48.2%;
-		--variable: 20.5 90.2% 48.2%;
-		--chart-1: 20.5 90.2% 48.2%;
+		--primary:           142 70% 45%;
+		--primary-foreground:  0  0% 100%;
+		--ring:              142 70% 45%;
+		--variable:          142 70% 45%;
+		--chart-1:           142 70% 45%;
 	}
 
 	.dark[data-color-scheme="aurora"] {
-		/* Aurora - Purple/blue for dark mode */
-		--primary: 262 80% 50%; /* purple-600 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 262 80% 50%;
-		--variable: 262 80% 50%;
-		--chart-1: 262 80% 50%;
+		--primary:           258 87% 74%;
+		--primary-foreground:  0  0% 100%;
+		--ring:              258 87% 74%;
+		--variable:          258 87% 74%;
+		--chart-1:           258 87% 74%;
 	}
 
 	.dark[data-color-scheme="coral"] {
-		/* Coral - Warm pink for dark mode */
-		--primary: 0 72% 55%; /* rose-500 */
-		--primary-foreground: 0 0% 100%;
-		--ring: 0 72% 55%;
-		--variable: 0 72% 55%;
-		--chart-1: 0 72% 55%;
+		--primary:             0 72% 55%;
+		--primary-foreground:  0  0% 100%;
+		--ring:                0 72% 55%;
+		--variable:            0 72% 55%;
+		--chart-1:             0 72% 55%;
 	}
 }
 
@@ -312,7 +300,7 @@
 
 	body {
 		@apply bg-background text-foreground;
-		font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+		font-family: "Space Grotesk", system-ui, sans-serif;
 		height: 100%;
 		margin: 0;
 		padding: 0;
@@ -324,7 +312,22 @@
 	}
 }
 
-/* Custom scrollbar using theme colors */
+/* Animations */
+@keyframes vayu-spin {
+	to { transform: rotate(360deg); }
+}
+
+@keyframes vayu-pulse {
+	0%, 100% { opacity: 1; }
+	50%       { opacity: 0.35; }
+}
+
+@keyframes vayu-fadepulse {
+	0%, 100% { opacity: 0.9; }
+	50%       { opacity: 0.5; }
+}
+
+/* Custom scrollbar */
 @layer components {
 	.scrollbar-thin {
 		scrollbar-width: thin;
@@ -348,10 +351,9 @@
 	}
 }
 
-/* Code/Mono styling */
 @layer utilities {
 	.font-code {
-		font-family: "Consolas", "Monaco", "Courier New", monospace;
+		font-family: "JetBrains Mono", "Consolas", "Monaco", monospace;
 	}
 
 	.truncate-2-lines {
@@ -361,55 +363,26 @@
 		overflow: hidden;
 	}
 
-	/* Variable highlight in text */
 	.variable-highlight {
 		@apply text-[hsl(var(--variable))] font-medium;
 	}
 }
 
-/* HTTP Method colors - utility classes */
+/* HTTP Method color utilities */
 @layer utilities {
-	.method-get {
-		@apply text-[hsl(var(--method-get))];
-	}
-	.method-post {
-		@apply text-[hsl(var(--method-post))];
-	}
-	.method-put {
-		@apply text-[hsl(var(--method-put))];
-	}
-	.method-patch {
-		@apply text-[hsl(var(--method-patch))];
-	}
-	.method-delete {
-		@apply text-[hsl(var(--method-delete))];
-	}
-	.method-head {
-		@apply text-[hsl(var(--method-head))];
-	}
-	.method-options {
-		@apply text-[hsl(var(--method-options))];
-	}
+	.method-get     { @apply text-[hsl(var(--method-get))]; }
+	.method-post    { @apply text-[hsl(var(--method-post))]; }
+	.method-put     { @apply text-[hsl(var(--method-put))]; }
+	.method-patch   { @apply text-[hsl(var(--method-patch))]; }
+	.method-delete  { @apply text-[hsl(var(--method-delete))]; }
+	.method-head    { @apply text-[hsl(var(--method-head))]; }
+	.method-options { @apply text-[hsl(var(--method-options))]; }
 
-	.bg-method-get {
-		@apply bg-[hsl(var(--method-get))];
-	}
-	.bg-method-post {
-		@apply bg-[hsl(var(--method-post))];
-	}
-	.bg-method-put {
-		@apply bg-[hsl(var(--method-put))];
-	}
-	.bg-method-patch {
-		@apply bg-[hsl(var(--method-patch))];
-	}
-	.bg-method-delete {
-		@apply bg-[hsl(var(--method-delete))];
-	}
-	.bg-method-head {
-		@apply bg-[hsl(var(--method-head))];
-	}
-	.bg-method-options {
-		@apply bg-[hsl(var(--method-options))];
-	}
+	.bg-method-get     { @apply bg-[hsl(var(--method-get))]; }
+	.bg-method-post    { @apply bg-[hsl(var(--method-post))]; }
+	.bg-method-put     { @apply bg-[hsl(var(--method-put))]; }
+	.bg-method-patch   { @apply bg-[hsl(var(--method-patch))]; }
+	.bg-method-delete  { @apply bg-[hsl(var(--method-delete))]; }
+	.bg-method-head    { @apply bg-[hsl(var(--method-head))]; }
+	.bg-method-options { @apply bg-[hsl(var(--method-options))]; }
 }

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -95,10 +95,12 @@ export default function RequestItem({
 			>
 				<Badge
 					variant="outline"
-					className={cn(
-						"text-xs font-mono font-semibold px-1.5 py-0.5",
-						getMethodColor(request.method)
-					)}
+					className="text-xs font-mono font-semibold px-1.5 py-0.5"
+					style={{
+						color: getMethodColor(request.method),
+						borderColor: `${getMethodColor(request.method)}50`,
+						background: `${getMethodColor(request.method)}12`,
+					}}
 				>
 					{request.method}
 				</Badge>

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -97,9 +97,9 @@ export default function RequestItem({
 					variant="outline"
 					className="text-xs font-mono font-semibold px-1.5 py-0.5"
 					style={{
-						color: getMethodColor(request.method),
-						borderColor: `${getMethodColor(request.method)}50`,
-						background: `${getMethodColor(request.method)}12`,
+						color:       `hsl(${getMethodColor(request.method)})`,
+						borderColor: `hsl(${getMethodColor(request.method)} / 0.3)`,
+						background:  `hsl(${getMethodColor(request.method)} / 0.1)`,
 					}}
 				>
 					{request.method}

--- a/app/src/modules/dashboard/components/DashboardHeader.tsx
+++ b/app/src/modules/dashboard/components/DashboardHeader.tsx
@@ -9,73 +9,140 @@
 /**
  * DashboardHeader Component
  *
- * Header with title, status badge, back button, and stop button
+ * Compact 52px single-row header with status, method, URL, config info, and stop button
  */
 
-import { Activity, StopCircle, Loader2, ArrowLeft } from "lucide-react";
-import { Button, Badge } from "@/components/ui";
-import { useNavigationStore } from "@/stores";
+import { useEffect, useState } from "react";
+import { StopCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui";
 import type { DashboardHeaderProps } from "../types";
+
+function getMethodColor(method: string): string {
+	switch (method.toUpperCase()) {
+		case "GET": return "#22c55e";
+		case "POST": return "#3b82f6";
+		case "PUT": return "#f59e0b";
+		case "PATCH": return "#a855f7";
+		case "DELETE": return "#ef4444";
+		default: return "#6b7280";
+	}
+}
+
+function formatElapsed(ms: number): string {
+	const totalSeconds = Math.floor(ms / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
 
 export default function DashboardHeader({
 	mode,
 	isStreaming,
 	isStopping,
 	onStop,
+	requestUrl,
+	requestMethod,
+	elapsedDuration = 0,
+	configuration,
 }: DashboardHeaderProps) {
-	const { navigateBack, canNavigateBack } = useNavigationStore();
-	const showBackButton = canNavigateBack();
+	// Live counter for running tests
+	const [liveTick, setLiveTick] = useState(0);
+
+	useEffect(() => {
+		if (mode === "running" && isStreaming) {
+			const interval = setInterval(() => setLiveTick((t) => t + 1), 1000);
+			return () => clearInterval(interval);
+		}
+	}, [mode, isStreaming]);
+
+	const displayMs =
+		mode === "running" && isStreaming
+			? elapsedDuration + liveTick * 1000
+			: elapsedDuration;
+
+	// Config summary line
+	const configParts: string[] = [];
+	if (configuration?.concurrency) configParts.push(`${configuration.concurrency} VUs`);
+	if (configuration?.mode) {
+		const modeLabel =
+			configuration.mode === "rps" ? "RPS Mode" :
+			configuration.mode === "concurrency" ? "Concurrency Mode" :
+			configuration.mode;
+		configParts.push(modeLabel);
+	}
+	if (displayMs > 0) configParts.push(`${formatElapsed(displayMs)} elapsed`);
+	const configSummary = configParts.join(" · ");
 
 	return (
-		<div className="flex items-center justify-between">
-			<div className="flex items-center gap-3">
-				{showBackButton && (
-					<Button
-						variant="ghost"
-						size="icon"
-						onClick={navigateBack}
-						className="h-8 w-8"
-						title="Back to Request Builder"
-					>
-						<ArrowLeft className="w-4 h-4" />
-					</Button>
-				)}
-				<Activity className="w-6 h-6 text-primary" />
-				<h2 className="text-xl font-semibold text-foreground">Load Test Dashboard</h2>
-				{isStreaming && (
-					<Badge
-						variant="outline"
-						className="bg-success/10 text-success border-success/20"
-					>
-						<span className="w-2 h-2 bg-success animate-pulse mr-2" />
-						Live
-					</Badge>
-				)}
-				{mode === "completed" && <Badge variant="secondary">Completed</Badge>}
-				{mode === "stopped" && (
-					<Badge variant="outline" className="border-warning text-warning">
-						Stopped
-					</Badge>
-				)}
-			</div>
+		<div className="h-[52px] flex items-center gap-3 px-5 bg-panel border-b border-border shrink-0">
+			{/* Status pill */}
+			{isStreaming ? (
+				<span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-semibold tracking-wide bg-green-500/15 text-green-500 border border-green-500/25 shrink-0">
+					<span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+					LIVE
+				</span>
+			) : mode === "completed" ? (
+				<span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-semibold tracking-wide bg-muted text-muted-foreground border border-border shrink-0">
+					COMPLETED
+				</span>
+			) : mode === "stopped" ? (
+				<span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-semibold tracking-wide bg-muted text-muted-foreground border border-border shrink-0">
+					STOPPED
+				</span>
+			) : null}
 
-			<div className="flex items-center gap-2">
-				{mode === "running" && (
-					<Button variant="destructive" onClick={onStop} disabled={isStopping}>
-						{isStopping ? (
-							<>
-								<Loader2 className="w-4 h-4 animate-spin mr-2" />
-								Stopping...
-							</>
-						) : (
-							<>
-								<StopCircle className="w-4 h-4 mr-2" />
-								Stop Test
-							</>
-						)}
-					</Button>
-				)}
-			</div>
+			{/* Method badge */}
+			{requestMethod && (
+				<span
+					className="text-[11px] font-bold font-mono px-1.5 py-0.5 rounded shrink-0"
+					style={{
+						color: getMethodColor(requestMethod),
+						background: `${getMethodColor(requestMethod)}18`,
+						border: `1px solid ${getMethodColor(requestMethod)}30`,
+					}}
+				>
+					{requestMethod.toUpperCase()}
+				</span>
+			)}
+
+			{/* URL */}
+			{requestUrl ? (
+				<span className="text-[12px] font-mono text-foreground flex-1 truncate min-w-0">
+					{requestUrl}
+				</span>
+			) : (
+				<span className="flex-1" />
+			)}
+
+			{/* Config summary */}
+			{configSummary && (
+				<span className="text-[12px] text-muted-foreground shrink-0 hidden sm:block">
+					{configSummary}
+				</span>
+			)}
+
+			{/* Stop button */}
+			{mode === "running" && (
+				<Button
+					size="sm"
+					variant="ghost"
+					onClick={onStop}
+					disabled={isStopping}
+					className="h-7 px-2.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive border border-destructive/30 shrink-0"
+				>
+					{isStopping ? (
+						<>
+							<Loader2 className="w-3 h-3 animate-spin mr-1.5" />
+							Stopping…
+						</>
+					) : (
+						<>
+							<StopCircle className="w-3 h-3 mr-1.5" />
+							Stop
+						</>
+					)}
+				</Button>
+			)}
 		</div>
 	);
 }

--- a/app/src/modules/dashboard/components/DashboardHeader.tsx
+++ b/app/src/modules/dashboard/components/DashboardHeader.tsx
@@ -87,9 +87,9 @@ export default function DashboardHeader({
 				<span
 					className="text-[11px] font-bold font-mono px-1.5 py-0.5 rounded shrink-0"
 					style={{
-						color: getMethodColor(requestMethod),
-						background: `${getMethodColor(requestMethod)}18`,
-						border: `1px solid ${getMethodColor(requestMethod)}30`,
+						color:       `hsl(${getMethodColor(requestMethod)})`,
+						background:  `hsl(${getMethodColor(requestMethod)} / 0.094)`,
+						border:      `1px solid hsl(${getMethodColor(requestMethod)} / 0.188)`,
 					}}
 				>
 					{requestMethod.toUpperCase()}

--- a/app/src/modules/dashboard/components/DashboardHeader.tsx
+++ b/app/src/modules/dashboard/components/DashboardHeader.tsx
@@ -15,18 +15,8 @@
 import { useEffect, useState } from "react";
 import { StopCircle, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui";
+import { getMethodColor } from "@/utils";
 import type { DashboardHeaderProps } from "../types";
-
-function getMethodColor(method: string): string {
-	switch (method.toUpperCase()) {
-		case "GET": return "#22c55e";
-		case "POST": return "#3b82f6";
-		case "PUT": return "#f59e0b";
-		case "PATCH": return "#a855f7";
-		case "DELETE": return "#ef4444";
-		default: return "#6b7280";
-	}
-}
 
 function formatElapsed(ms: number): string {
 	const totalSeconds = Math.floor(ms / 1000);
@@ -45,11 +35,12 @@ export default function DashboardHeader({
 	elapsedDuration = 0,
 	configuration,
 }: DashboardHeaderProps) {
-	// Live counter for running tests
+	// Live counter for running tests — reset to 0 each time a new run starts
 	const [liveTick, setLiveTick] = useState(0);
 
 	useEffect(() => {
 		if (mode === "running" && isStreaming) {
+			setLiveTick(0);
 			const interval = setInterval(() => setLiveTick((t) => t + 1), 1000);
 			return () => clearInterval(interval);
 		}
@@ -62,7 +53,7 @@ export default function DashboardHeader({
 
 	// Config summary line
 	const configParts: string[] = [];
-	if (configuration?.concurrency) configParts.push(`${configuration.concurrency} VUs`);
+	if (configuration?.concurrency != null) configParts.push(`${configuration.concurrency} VUs`);
 	if (configuration?.mode) {
 		const modeLabel =
 			configuration.mode === "rps" ? "RPS Mode" :

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -275,16 +275,16 @@ function MetricsView({ metrics, historicalMetrics, isCompleted }: MetricsViewPro
 					sub={`${totalReqs} total · ${formatNumber(metrics.requests_failed ?? 0)} failed`}
 				/>
 				<HeroCard
-					label="P99 Latency"
+					label={isCompleted ? "P99 Latency" : "Avg Latency"}
 					value={
-						isCompleted && metrics.latency_p99_ms
-							? `${metrics.latency_p99_ms.toFixed(0)}ms`
-							: "—"
+						isCompleted
+							? (metrics.latency_p99_ms != null ? `${metrics.latency_p99_ms.toFixed(0)}ms` : "—")
+							: (metrics.avg_latency_ms != null && metrics.avg_latency_ms > 0 ? `${metrics.avg_latency_ms.toFixed(0)}ms` : "—")
 					}
 					sub={
 						isCompleted
 							? `p50: ${metrics.latency_p50_ms?.toFixed(0) ?? "—"}ms · p95: ${metrics.latency_p95_ms?.toFixed(0) ?? "—"}ms`
-							: "Available after test completes"
+							: "Live average — p50/p95/p99 after test"
 					}
 					sparkColor="#ef4444"
 				/>
@@ -292,9 +292,9 @@ function MetricsView({ metrics, historicalMetrics, isCompleted }: MetricsViewPro
 
 			{/* Row 2 — Latency distribution bar (completed only) */}
 			{isCompleted &&
-				metrics.latency_p50_ms &&
-				metrics.latency_p95_ms &&
-				metrics.latency_p99_ms && (
+				metrics.latency_p50_ms != null &&
+				metrics.latency_p95_ms != null &&
+				metrics.latency_p99_ms != null && (
 					<LatencyBar
 						p50={metrics.latency_p50_ms}
 						p95={metrics.latency_p95_ms}

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -9,73 +9,210 @@
 /**
  * MetricsView Component
  *
- * Displays key metrics, latency breakdown, and charts
+ * Displays key metrics, latency breakdown, and charts (pure SVG — no Recharts)
  */
 
 import { useMemo, memo } from "react";
-import { Activity, Info } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
-import {
-	Tooltip as UITooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { Activity } from "lucide-react";
 import { formatNumber } from "@/utils";
-import {
-	LineChart,
-	Line,
-	XAxis,
-	YAxis,
-	CartesianGrid,
-	Tooltip,
-	ResponsiveContainer,
-} from "recharts";
 import type { MetricsViewProps } from "../types";
 
-// Color classes for metric cards
-const colorClasses = {
-	blue: "bg-blue-50 border-blue-200 text-blue-900 dark:bg-blue-950 dark:border-blue-800 dark:text-blue-100",
-	red: "bg-red-50 border-red-200 text-red-900 dark:bg-red-950 dark:border-red-800 dark:text-red-100",
-	green: "bg-green-50 border-green-200 text-green-900 dark:bg-green-950 dark:border-green-800 dark:text-green-100",
-	purple: "bg-purple-50 border-purple-200 text-purple-900 dark:bg-purple-950 dark:border-purple-800 dark:text-purple-100",
-	orange: "bg-orange-50 border-orange-200 text-orange-900 dark:bg-orange-950 dark:border-orange-800 dark:text-orange-100",
-	cyan: "bg-cyan-50 border-cyan-200 text-cyan-900 dark:bg-cyan-950 dark:border-cyan-800 dark:text-cyan-100",
-};
+// ============================================================================
+// Mini SVG Sparkline
+// ============================================================================
 
-function KeyMetricCard({
-	label,
-	value,
-	color,
-	tooltip,
-}: {
-	label: string;
-	value: string;
-	color: keyof typeof colorClasses;
-	tooltip?: string;
-}) {
+function Sparkline({ data, color }: { data: number[]; color: string }) {
+	if (!data || data.length < 2) return null;
+	const max = Math.max(...data), min = Math.min(...data), rng = max - min || 1;
+	const w = 108, h = 26;
+	const pts = data.map((v, i) =>
+		`${(1 + (i / (data.length - 1)) * w).toFixed(1)},${(1 + h * (1 - (v - min) / rng)).toFixed(1)}`
+	);
+	const area = `M1,${h + 1} L${pts.join(" L")} L${w + 1},${h + 1}Z`;
 	return (
-		<div className={cn("p-4 border", colorClasses[color])}>
-			<div className="flex items-center gap-1 mb-1">
-				<p className="text-sm font-medium opacity-75">{label}</p>
-				{tooltip && (
-					<TooltipProvider>
-						<UITooltip>
-							<TooltipTrigger asChild>
-								<Info className="h-3 w-3 opacity-50 cursor-help" />
-							</TooltipTrigger>
-							<TooltipContent>
-								<p className="max-w-xs text-xs">{tooltip}</p>
-							</TooltipContent>
-						</UITooltip>
-					</TooltipProvider>
-				)}
+		<svg width={110} height={28} className="block overflow-visible">
+			<path d={area} fill={color} fillOpacity="0.15" />
+			<polyline points={pts.join(" ")} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+		</svg>
+	);
+}
+
+// ============================================================================
+// SVG Area Chart (replaces Recharts)
+// ============================================================================
+
+function SvgAreaChart({
+	data,
+	dataKey,
+	color,
+	height = 170,
+}: {
+	data: Array<Record<string, number>>;
+	dataKey: string;
+	color: string;
+	height?: number;
+}) {
+	if (!data || data.length < 2) return null;
+	const VW = 600, VH = 150;
+	const PL = 42, PR = 8, PT = 6, PB = 20;
+	const IW = VW - PL - PR, IH = VH - PT - PB;
+	const vals = data.map((d) => d[dataKey]);
+	const maxV = Math.max(...vals) * 1.08 || 1;
+	const toX = (i: number) => PL + (i / (data.length - 1)) * IW;
+	const toY = (v: number) => PT + (1 - v / maxV) * IH;
+	const pts = data.map((d, i) => `${toX(i).toFixed(1)},${toY(d[dataKey]).toFixed(1)}`);
+	const bottomY = (PT + IH).toFixed(1);
+	const areaD = `M${PL},${bottomY} L${pts.join(" L")} L${toX(data.length - 1).toFixed(1)},${bottomY}Z`;
+	const yTicks = [0.25, 0.5, 0.75, 1.0].map((f) => ({
+		y: toY(maxV * f),
+		label: maxV * f >= 1000 ? `${((maxV * f) / 1000).toFixed(0)}k` : Math.round(maxV * f),
+	}));
+	const xStep = Math.max(1, Math.floor(data.length / 6));
+	const xTicks = data
+		.filter((_, i) => i % xStep === 0)
+		.map((d, idx) => ({
+			x: toX(idx * xStep),
+			label: d.time !== undefined ? `${d.time}s` : `${idx * xStep}`,
+		}));
+	return (
+		<svg viewBox={`0 0 ${VW} ${VH}`} style={{ width: "100%", height, display: "block" }}>
+			{yTicks.map((t, i) => (
+				<g key={i}>
+					<line x1={PL} y1={t.y} x2={VW - PR} y2={t.y} stroke="hsl(var(--border))" strokeDasharray="2 2" />
+					<text x={PL - 4} y={t.y + 3.5} textAnchor="end" fontSize="9" fill="hsl(var(--muted-foreground))" fontFamily="'JetBrains Mono', monospace">{t.label}</text>
+				</g>
+			))}
+			{xTicks.map((t, i) => (
+				<text key={i} x={t.x} y={VH - 3} textAnchor="middle" fontSize="9" fill="hsl(var(--muted-foreground))" fontFamily="'JetBrains Mono', monospace">{t.label}</text>
+			))}
+			<path d={areaD} fill={color} fillOpacity="0.12" />
+			<polyline points={pts.join(" ")} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+		</svg>
+	);
+}
+
+// ============================================================================
+// Latency Distribution Bar
+// ============================================================================
+
+function LatencyBar({ p50, p95, p99 }: { p50: number; p95: number; p99: number }) {
+	const mx = Math.max(p99 * 1.2, 120);
+	const pct = (v: number) => `${((v / mx) * 100).toFixed(1)}%`;
+	const markers = [
+		{ lbl: "p50", v: p50, col: "#22c55e" },
+		{ lbl: "p95", v: p95, col: "#f59e0b" },
+		{ lbl: "p99", v: p99, col: "#ef4444" },
+	];
+	return (
+		<div className="bg-card border border-border rounded-md p-4 pb-8">
+			<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground mb-6">
+				Latency Distribution
+			</p>
+			<div className="relative h-14">
+				{/* gradient track */}
+				<div
+					className="absolute top-2.5 inset-x-0 h-1 rounded-sm border border-border"
+					style={{
+						background:
+							"linear-gradient(to right, rgba(34,197,94,.18), rgba(245,158,11,.18), rgba(239,68,68,.18))",
+					}}
+				/>
+				{markers.map(({ lbl, v, col }) => (
+					<div
+						key={lbl}
+						className="absolute top-0"
+						style={{ left: pct(v), transform: "translateX(-50%)" }}
+					>
+						<div className="w-px h-4 mx-auto opacity-85" style={{ background: col }} />
+						<div
+							className="w-2 h-2 rounded-full mx-auto -mt-1"
+							style={{ background: col, boxShadow: "0 0 0 2px hsl(var(--card))" }}
+						/>
+						<div className="text-center mt-2 whitespace-nowrap">
+							<div className="text-[13px] font-bold font-mono" style={{ color: col }}>
+								{v.toFixed(1)}ms
+							</div>
+							<div className="text-[10px] text-muted-foreground">{lbl}</div>
+						</div>
+					</div>
+				))}
+				<div className="absolute text-[10px] text-muted-foreground" style={{ top: 18, left: 0 }}>
+					0
+				</div>
+				<div className="absolute text-[10px] text-muted-foreground" style={{ top: 18, right: 0 }}>
+					{mx.toFixed(0)}ms
+				</div>
 			</div>
-			<p className="text-2xl font-bold">{value}</p>
 		</div>
 	);
 }
+
+// ============================================================================
+// Hero Card
+// ============================================================================
+
+function HeroCard({
+	label,
+	value,
+	unit,
+	sub,
+	sparkData,
+	sparkColor,
+	valueColor,
+}: {
+	label: string;
+	value: string;
+	unit?: string;
+	sub?: string;
+	sparkData?: number[];
+	sparkColor?: string;
+	valueColor?: string;
+}) {
+	return (
+		<div className="bg-card border border-border rounded-md p-4 flex flex-col gap-1">
+			<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+				{label}
+			</p>
+			<div className="flex items-baseline gap-1.5 mt-0.5">
+				<span
+					className="text-[34px] font-bold leading-none font-mono tabular-nums"
+					style={{ color: valueColor || "hsl(var(--foreground))" }}
+				>
+					{value}
+				</span>
+				{unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+			</div>
+			{sub && <p className="text-[11px] text-muted-foreground mt-0.5">{sub}</p>}
+			{sparkData && sparkData.length > 1 && (
+				<div className="mt-2">
+					<Sparkline data={sparkData} color={sparkColor || "hsl(var(--primary))"} />
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ============================================================================
+// Secondary Stat Card
+// ============================================================================
+
+function StatCard({ label, value, unit }: { label: string; value: string; unit?: string }) {
+	return (
+		<div className="bg-card border border-border rounded-md p-3">
+			<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground mb-1.5">
+				{label}
+			</p>
+			<div className="flex items-baseline gap-1">
+				<span className="text-[22px] font-bold font-mono text-foreground">{value}</span>
+				{unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+			</div>
+		</div>
+	);
+}
+
+// ============================================================================
+// Main MetricsView
+// ============================================================================
 
 function MetricsView({ metrics, historicalMetrics, isCompleted }: MetricsViewProps) {
 	if (!metrics || typeof metrics.requests_completed === "undefined") {
@@ -86,13 +223,6 @@ function MetricsView({ metrics, historicalMetrics, isCompleted }: MetricsViewPro
 			</div>
 		);
 	}
-
-	const successRate =
-		metrics.requests_completed > 0
-			? ((metrics.requests_completed - (metrics.requests_failed || 0)) /
-				metrics.requests_completed) *
-			100
-			: 0;
 
 	// Prepare chart data - last 300 points, deduplicated by 0.5s, to keep charts fast
 	const chartData = useMemo(() => {
@@ -109,202 +239,115 @@ function MetricsView({ metrics, historicalMetrics, isCompleted }: MetricsViewPro
 		return Array.from(dataByHalfSec.values()).sort((a, b) => a.time - b.time);
 	}, [historicalMetrics]);
 
+	// Sparkline data from last 40 historical points
+	const rpsSparkData = useMemo(
+		() => historicalMetrics.slice(-40).map((m) => m.current_rps),
+		[historicalMetrics]
+	);
+
+	// Error rate
+	const errorRate =
+		metrics.requests_completed > 0
+			? ((metrics.requests_failed || 0) / metrics.requests_completed) * 100
+			: 0;
+	const errorRateStr = `${errorRate.toFixed(1)}%`;
+	const errorColor = errorRate === 0 ? "#22c55e" : "#ef4444";
+
+	const totalReqs = formatNumber(metrics.requests_completed);
+	const liveRps = formatNumber(Math.round(metrics.current_rps ?? 0));
+
 	return (
-		<div className="space-y-6">
-			{/* Key Metrics */}
-			<div className="grid grid-cols-3 gap-4">
-				<KeyMetricCard
-					label="Total Requests"
-					value={formatNumber(metrics.requests_completed)}
-					color="blue"
+		<div className="p-5 flex flex-col gap-3.5 max-w-[1080px]">
+			{/* Row 1 — Hero cards */}
+			<div className="grid grid-cols-3 gap-3">
+				<HeroCard
+					label="Throughput"
+					value={liveRps}
+					unit="req/s"
+					sub={isCompleted ? "Avg RPS" : "Live — instantaneous"}
+					sparkData={rpsSparkData}
+					sparkColor="hsl(var(--primary))"
 				/>
-				<KeyMetricCard
-					label="Failed"
-					value={formatNumber(metrics.requests_failed ?? 0)}
-					color="red"
+				<HeroCard
+					label="Error Rate"
+					value={errorRateStr}
+					valueColor={errorColor}
+					sub={`${totalReqs} total · ${formatNumber(metrics.requests_failed ?? 0)} failed`}
 				/>
-				<KeyMetricCard
-					label="Success Rate"
-					value={`${successRate.toFixed(1)}%`}
-					color="green"
-				/>
-			</div>
-
-			{/* Rate Metrics */}
-			<div className="grid grid-cols-3 gap-4">
-				<KeyMetricCard
-					label={isCompleted ? "Avg RPS" : "Live RPS"}
-					value={formatNumber(Math.round(metrics.current_rps ?? 0))}
-					color="purple"
-					tooltip={isCompleted
-						? "Average requests per second over the entire test duration"
-						: "Instantaneous requests per second in the last measurement interval. Shows real-time fluctuations."
+				<HeroCard
+					label="P99 Latency"
+					value={
+						isCompleted && metrics.latency_p99_ms
+							? `${metrics.latency_p99_ms.toFixed(0)}ms`
+							: "—"
 					}
-				/>
-				<KeyMetricCard
-					label="Avg Send Rate"
-					value={formatNumber(Math.round(metrics.send_rate ?? 0))}
-					color="orange"
-					tooltip="Average rate at which Vayu dispatches requests to the server (req/s) since test start. If this is much higher than throughput, your server is the bottleneck."
-				/>
-				<KeyMetricCard
-					label="Avg Throughput"
-					value={formatNumber(Math.round(metrics.throughput ?? 0))}
-					color="cyan"
-					tooltip="Average rate at which responses are received from the server (req/s) since test start. This represents your server's actual processing capacity."
+					sub={
+						isCompleted
+							? `p50: ${metrics.latency_p50_ms?.toFixed(0) ?? "—"}ms · p95: ${metrics.latency_p95_ms?.toFixed(0) ?? "—"}ms`
+							: "Available after test completes"
+					}
+					sparkColor="#ef4444"
 				/>
 			</div>
 
-			{/* Queue & Connection Metrics */}
-			<div className="grid grid-cols-2 gap-4">
-				<KeyMetricCard
-					label="Backpressure"
-					value={formatNumber(metrics.backpressure ?? 0)}
-					color="red"
-					tooltip="Queue depth: requests that have been sent but not yet received a response. High values indicate the server is struggling to keep up with the request rate."
-				/>
-				<KeyMetricCard
+			{/* Row 2 — Latency distribution bar (completed only) */}
+			{isCompleted &&
+				metrics.latency_p50_ms &&
+				metrics.latency_p95_ms &&
+				metrics.latency_p99_ms && (
+					<LatencyBar
+						p50={metrics.latency_p50_ms}
+						p95={metrics.latency_p95_ms}
+						p99={metrics.latency_p99_ms}
+					/>
+				)}
+
+			{/* Row 3 — RPS chart */}
+			{chartData.length > 1 && (
+				<div className="bg-card border border-border rounded-md p-3.5">
+					<div className="flex items-center gap-2 mb-3">
+						<span className="text-[12px] font-semibold text-foreground">
+							Requests per Second
+						</span>
+						{!isCompleted && (
+							<span
+								className="text-[10px] font-bold text-[#22c55e] tracking-[0.05em]"
+								style={{ animation: "vayu-fadepulse 2s ease-in-out infinite" }}
+							>
+								● LIVE
+							</span>
+						)}
+					</div>
+					<SvgAreaChart data={chartData} dataKey="rps" color="hsl(var(--primary))" height={170} />
+				</div>
+			)}
+
+			{/* Row 4 — Connections chart */}
+			{chartData.length > 1 && (
+				<div className="bg-card border border-border rounded-md p-3.5">
+					<p className="text-[12px] font-semibold text-foreground mb-3">Active Connections</p>
+					<SvgAreaChart data={chartData} dataKey="concurrency" color="#6366f1" height={120} />
+				</div>
+			)}
+
+			{/* Row 5 — Secondary stats */}
+			<div className="grid grid-cols-4 gap-3">
+				<StatCard label="Total Requests" value={totalReqs} />
+				<StatCard
 					label="Active Connections"
 					value={formatNumber(metrics.current_concurrency ?? 0)}
-					color="blue"
-					tooltip="Number of concurrent HTTP connections currently open to the server."
+				/>
+				<StatCard
+					label="Backpressure"
+					value={formatNumber(metrics.backpressure ?? 0)}
+					unit="queued"
+				/>
+				<StatCard
+					label="Send Rate"
+					value={formatNumber(Math.round(metrics.send_rate ?? 0))}
+					unit="req/s"
 				/>
 			</div>
-
-			{/* Latency Metrics */}
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-lg">Latency</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<div className="grid grid-cols-4 gap-4">
-						<div>
-							<p className="text-sm text-muted-foreground">Average</p>
-							<p className="text-2xl font-bold text-foreground">
-								{(metrics.avg_latency_ms ?? 0).toFixed(2)}ms
-							</p>
-						</div>
-						<div>
-							<p className="text-sm text-muted-foreground">P50</p>
-							{isCompleted ? (
-								<p className="text-2xl font-bold text-foreground">
-									{(metrics.latency_p50_ms ?? 0).toFixed(2)}ms
-								</p>
-							) : (
-								<p className="text-sm text-muted-foreground italic">
-									Calculating...
-								</p>
-							)}
-						</div>
-						<div>
-							<p className="text-sm text-muted-foreground">P95</p>
-							{isCompleted ? (
-								<p className="text-2xl font-bold text-foreground">
-									{(metrics.latency_p95_ms ?? 0).toFixed(2)}ms
-								</p>
-							) : (
-								<p className="text-sm text-muted-foreground italic">
-									Calculating...
-								</p>
-							)}
-						</div>
-						<div>
-							<p className="text-sm text-muted-foreground">P99</p>
-							{isCompleted ? (
-								<p className="text-2xl font-bold text-foreground">
-									{(metrics.latency_p99_ms ?? 0).toFixed(2)}ms
-								</p>
-							) : (
-								<p className="text-sm text-muted-foreground italic">
-									Calculating...
-								</p>
-							)}
-						</div>
-					</div>
-				</CardContent>
-			</Card>
-
-			{/* Charts */}
-			{chartData.length > 1 && (
-				<>
-					<Card>
-						<CardHeader>
-							<CardTitle className="text-lg">Requests per Second</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<ResponsiveContainer width="100%" height={300} debounce={800}>
-								<LineChart data={chartData}>
-									<CartesianGrid
-										strokeDasharray="3 3"
-										className="stroke-border"
-									/>
-									<XAxis
-										dataKey="time"
-										label={{
-											value: "Time (s)",
-											position: "insideBottom",
-											offset: -5,
-										}}
-									/>
-									<YAxis
-										label={{ value: "RPS", angle: -90, position: "insideLeft" }}
-									/>
-									<Tooltip />
-									<Line
-										type="monotone"
-										dataKey="rps"
-										stroke="hsl(var(--primary))"
-										strokeWidth={2}
-										dot={false}
-										isAnimationActive={false}
-									/>
-								</LineChart>
-							</ResponsiveContainer>
-						</CardContent>
-					</Card>
-
-					<Card>
-						<CardHeader>
-							<CardTitle className="text-lg">Active Connections</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<ResponsiveContainer width="100%" height={300} debounce={800}>
-								<LineChart data={chartData}>
-									<CartesianGrid
-										strokeDasharray="3 3"
-										className="stroke-border"
-									/>
-									<XAxis
-										dataKey="time"
-										label={{
-											value: "Time (s)",
-											position: "insideBottom",
-											offset: -5,
-										}}
-									/>
-									<YAxis
-										label={{
-											value: "Connections",
-											angle: -90,
-											position: "insideLeft",
-											offset: 5,
-										}}
-									/>
-									<Tooltip />
-									<Line
-										type="monotone"
-										dataKey="concurrency"
-										stroke="hsl(var(--chart-2))"
-										strokeWidth={2}
-										dot={false}
-										isAnimationActive={false}
-									/>
-								</LineChart>
-							</ResponsiveContainer>
-						</CardContent>
-					</Card>
-				</>
-			)}
 		</div>
 	);
 }

--- a/app/src/modules/dashboard/components/RequestResponseView.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.tsx
@@ -53,7 +53,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 
 	if (!report) {
 		return (
-			<div className="text-center py-12 text-gray-500">
+			<div className="p-5 text-center py-12 text-muted-foreground">
 				<p>Request/Response view available after test completion</p>
 			</div>
 		);
@@ -73,7 +73,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 	const hasStatusCodes = Object.keys(statusCodes).length > 0;
 
 	return (
-		<div className="space-y-6">
+		<div className="p-5 space-y-4 max-w-[1080px]">
 			{/* Status Code Distribution */}
 			<Card>
 				<CardHeader>
@@ -83,7 +83,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 					{hasStatusCodes ? (
 						<div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
 							{Object.entries(statusCodes).map(([code, count]) => (
-								<div key={code} className="p-3 bg-muted rounded">
+								<div key={code} className="p-3 bg-card border border-border rounded-md">
 									<span
 										className={cn(
 											"font-mono font-bold text-lg",
@@ -343,7 +343,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 															<p className="text-xs font-medium text-muted-foreground">
 																Error
 															</p>
-															<p className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/30 p-2 rounded font-mono text-xs break-all">
+															<p className="text-sm bg-destructive/10 text-destructive p-2 rounded font-mono text-xs break-all">
 																{result.error}
 															</p>
 														</div>
@@ -379,7 +379,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																	<div className="grid grid-cols-5 gap-2 text-xs">
 																		{result.trace.dnsMs !==
 																			undefined && (
-																			<div className="bg-muted p-2 rounded text-center">
+																			<div className="bg-card border border-border rounded-md p-2 text-center">
 																				<p className="text-muted-foreground">
 																					DNS
 																				</p>
@@ -393,7 +393,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																		)}
 																		{result.trace.connectMs !==
 																			undefined && (
-																			<div className="bg-muted p-2 rounded text-center">
+																			<div className="bg-card border border-border rounded-md p-2 text-center">
 																				<p className="text-muted-foreground">
 																					Connect
 																				</p>
@@ -407,7 +407,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																		)}
 																		{result.trace.tlsMs !==
 																			undefined && (
-																			<div className="bg-muted p-2 rounded text-center">
+																			<div className="bg-card border border-border rounded-md p-2 text-center">
 																				<p className="text-muted-foreground">
 																					TLS
 																				</p>
@@ -422,7 +422,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																		{result.trace
 																			.firstByteMs !==
 																			undefined && (
-																			<div className="bg-muted p-2 rounded text-center">
+																			<div className="bg-card border border-border rounded-md p-2 text-center">
 																				<p className="text-muted-foreground">
 																					TTFB
 																				</p>
@@ -436,7 +436,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																		)}
 																		{result.trace.downloadMs !==
 																			undefined && (
-																			<div className="bg-muted p-2 rounded text-center">
+																			<div className="bg-card border border-border rounded-md p-2 text-center">
 																				<p className="text-muted-foreground">
 																					Download
 																				</p>
@@ -454,7 +454,7 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 
 															{/* Slow Request Warning */}
 															{result.trace.isSlow && (
-																<div className="flex items-center gap-2 text-xs bg-orange-50 dark:bg-orange-950/30 text-orange-700 dark:text-orange-400 p-2 rounded">
+																<div className="flex items-center gap-2 text-xs bg-destructive/10 text-destructive p-2 rounded">
 																	<Clock className="w-3 h-3" />
 																	<span>
 																		Slow request:{" "}

--- a/app/src/modules/dashboard/index.tsx
+++ b/app/src/modules/dashboard/index.tsx
@@ -21,11 +21,10 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { BarChart3, Eye } from "lucide-react";
 import { useDashboardStore } from "@/stores";
 import { apiService, loadTestService } from "@/services";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui";
-import { DashboardHeader, RunMetadata, MetricsView, RequestResponseView } from "./components";
+import { cn } from "@/lib/utils";
+import { DashboardHeader, MetricsView, RequestResponseView } from "./components";
 import type { DashboardView, DisplayMetrics } from "./types";
 
 export default function LoadTestDashboard() {
@@ -280,45 +279,42 @@ export default function LoadTestDashboard() {
 
 	return (
 		<div className="flex-1 flex flex-col overflow-hidden">
-			{/* Header */}
-			<div className="p-4 border-b bg-card">
-				<DashboardHeader
-					runId={currentRunId}
-					mode={mode}
-					isStreaming={isStreaming}
-					isStopping={isStopping}
-					onStop={handleStop}
-				/>
+			{/* Compact single-row header */}
+			<DashboardHeader
+				runId={currentRunId}
+				mode={mode}
+				isStreaming={isStreaming}
+				isStopping={isStopping}
+				onStop={handleStop}
+				requestUrl={displayRequestUrl}
+				requestMethod={displayRequestMethod}
+				elapsedDuration={elapsedDuration}
+				configuration={displayConfiguration}
+			/>
 
-				{/* Run Metadata */}
-				<RunMetadata
-					requestUrl={displayRequestUrl}
-					requestMethod={displayRequestMethod}
-					startTime={startTime ?? undefined}
-					endTime={endTime ?? undefined}
-					mode={mode}
-					elapsedDuration={elapsedDuration}
-					setupOverhead={finalReport?.summary?.setupOverhead}
-					configuration={displayConfiguration}
-				/>
-
-				{/* View Toggle */}
-				<Tabs value={activeView} onValueChange={(v) => setActiveView(v as DashboardView)}>
-					<TabsList>
-						<TabsTrigger value="metrics" className="gap-2">
-							<BarChart3 className="w-4 h-4" />
-							Metrics Dashboard
-						</TabsTrigger>
-						<TabsTrigger value="request-response" className="gap-2">
-							<Eye className="w-4 h-4" />
-							Request/Response
-						</TabsTrigger>
-					</TabsList>
-				</Tabs>
+			{/* Tab bar */}
+			<div className="flex border-b border-border bg-panel px-5 shrink-0">
+				{[
+					{ id: "metrics" as DashboardView, label: "Metrics" },
+					{ id: "request-response" as DashboardView, label: "Request / Response" },
+				].map((tab) => (
+					<button
+						key={tab.id}
+						onClick={() => setActiveView(tab.id)}
+						className={cn(
+							"px-3.5 py-2.5 text-[13px] border-b-2 -mb-px transition-colors font-[inherit]",
+							activeView === tab.id
+								? "border-primary text-foreground font-semibold"
+								: "border-transparent text-muted-foreground hover:text-foreground"
+						)}
+					>
+						{tab.label}
+					</button>
+				))}
 			</div>
 
 			{/* Content */}
-			<div className="flex-1 overflow-auto p-6 bg-muted/30">
+			<div className="flex-1 overflow-auto bg-background">
 				{activeView === "metrics" ? (
 					<MetricsView
 						metrics={displayMetrics}

--- a/app/src/modules/dashboard/types.ts
+++ b/app/src/modules/dashboard/types.ts
@@ -31,6 +31,16 @@ export interface DashboardHeaderProps {
 	isStreaming: boolean;
 	isStopping: boolean;
 	onStop: () => Promise<void>;
+	requestUrl?: string;
+	requestMethod?: string;
+	elapsedDuration?: number;
+	configuration?: {
+		mode?: string;
+		duration?: number | string | undefined;
+		targetRps?: number;
+		concurrency?: number;
+		comment?: string;
+	};
 }
 
 export interface RunMetadataProps {

--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -6,6 +6,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
+import type React from "react";
 import { formatRelativeTime, loadTestTypeToLabel } from "@/utils";
 import type { Run } from "@/types";
 import { Button } from "@/components/ui";
@@ -29,13 +30,14 @@ interface RunItemProps {
 	isSelected?: boolean;
 }
 
-const METHOD_BADGE_CLASSES: Record<string, string> = {
-	GET:    "text-[#22c55e] bg-green-500/10 border border-green-500/30",
-	POST:   "text-[#3b82f6] bg-blue-500/10 border border-blue-500/30",
-	PUT:    "text-[#f59e0b] bg-amber-500/10 border border-amber-500/30",
-	PATCH:  "text-[#a855f7] bg-purple-500/10 border border-purple-500/30",
-	DELETE: "text-[#ef4444] bg-red-500/10 border border-red-500/30",
-};
+function methodBadgeStyle(method: string): React.CSSProperties {
+	const c = `var(--method-${method.toLowerCase()})`;
+	return {
+		color:      `hsl(${c})`,
+		background: `hsl(${c} / 0.1)`,
+		border:     `1px solid hsl(${c} / 0.3)`,
+	};
+}
 
 export default function RunItem({ run, onSelect, onDelete, isDeleting, isSelected = false }: RunItemProps) {
 	// Format timestamp to relative time
@@ -144,7 +146,10 @@ export default function RunItem({ run, onSelect, onDelete, isDeleting, isSelecte
 				{requestUrl && (
 					<div className="flex items-start gap-2 mb-1.5 min-w-0 flex-wrap">
 						{method && (
-							<span className={cn("text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded", METHOD_BADGE_CLASSES[method] ?? "")}>
+							<span
+								className="text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded"
+								style={methodBadgeStyle(method)}
+							>
 								{method}
 							</span>
 						)}

--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -8,7 +8,7 @@
 
 import { formatRelativeTime, loadTestTypeToLabel } from "@/utils";
 import type { Run } from "@/types";
-import { Button, Badge } from "@/components/ui";
+import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import {
 	CheckCircle2,
@@ -28,6 +28,14 @@ interface RunItemProps {
 	isDeleting: boolean;
 	isSelected?: boolean;
 }
+
+const METHOD_BADGE_CLASSES: Record<string, string> = {
+	GET:    "text-[#22c55e] bg-green-500/10 border border-green-500/30",
+	POST:   "text-[#3b82f6] bg-blue-500/10 border border-blue-500/30",
+	PUT:    "text-[#f59e0b] bg-amber-500/10 border border-amber-500/30",
+	PATCH:  "text-[#a855f7] bg-purple-500/10 border border-purple-500/30",
+	DELETE: "text-[#ef4444] bg-red-500/10 border border-red-500/30",
+};
 
 export default function RunItem({ run, onSelect, onDelete, isDeleting, isSelected = false }: RunItemProps) {
 	// Format timestamp to relative time
@@ -67,7 +75,7 @@ export default function RunItem({ run, onSelect, onDelete, isDeleting, isSelecte
 		<div
 			onClick={() => onSelect(run.id)}
 			className={cn(
-				"group relative bg-card border cursor-pointer transition-all overflow-hidden w-full",
+				"group relative bg-card border cursor-pointer transition-all transition-colors overflow-hidden w-full",
 				isSelected
 					? "bg-primary/10 hover:bg-primary/15 border-primary/50 ring-1 ring-inset ring-primary/20 shadow-sm"
 					: "hover:border-primary/50 hover:shadow-sm"
@@ -136,22 +144,9 @@ export default function RunItem({ run, onSelect, onDelete, isDeleting, isSelecte
 				{requestUrl && (
 					<div className="flex items-start gap-2 mb-1.5 min-w-0 flex-wrap">
 						{method && (
-							<Badge
-								variant="outline"
-								className={cn(
-									"text-[10px] h-5 px-1.5 font-mono shrink-0",
-									method === "GET" &&
-									"bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/30 dark:text-blue-400 dark:border-blue-900",
-									method === "POST" &&
-									"bg-green-50 text-green-700 border-green-200 dark:bg-green-950/30 dark:text-green-400 dark:border-green-900",
-									method === "PUT" &&
-									"bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950/30 dark:text-orange-400 dark:border-orange-900",
-									method === "DELETE" &&
-									"bg-red-50 text-red-700 border-red-200 dark:bg-red-950/30 dark:text-red-400 dark:border-red-900"
-								)}
-							>
+							<span className={cn("text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded", METHOD_BADGE_CLASSES[method] ?? "")}>
 								{method}
-							</Badge>
+							</span>
 						)}
 						<p
 							className="text-xs text-foreground font-medium break-words flex-1 min-w-0 leading-5"

--- a/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx
@@ -32,6 +32,7 @@ import VariableInput from "../../../shared/VariableInput";
 import type { AuthType } from "../../../types";
 
 const AUTH_TYPES: { value: AuthType; label: string; icon: typeof Key }[] = [
+	{ value: "inherit", label: "Inherit from Collection", icon: Lock },
 	{ value: "none", label: "No Auth", icon: Lock },
 	{ value: "bearer", label: "Bearer Token", icon: Key },
 	{ value: "basic", label: "Basic Auth", icon: User },

--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -21,7 +21,7 @@
  */
 
 import { useState } from "react";
-import { FileText, Copy, Check, Download, Terminal, BarChart3 } from "lucide-react";
+import { Copy, Check, Download, Terminal, BarChart3 } from "lucide-react";
 import {
 	Tabs,
 	TabsList,
@@ -62,10 +62,10 @@ export default function ResponseViewer() {
 	// Loading state
 	if (isExecuting) {
 		return (
-			<div className="flex-1 flex items-center justify-center bg-card">
+			<div className="flex-1 flex items-center justify-center bg-panel">
 				<div className="text-center space-y-4">
-					<div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
-					<p className="text-muted-foreground">Sending request...</p>
+					<div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-[vayu-spin_0.7s_linear_infinite] mx-auto" />
+					<p className="text-[12px] text-muted-foreground">Sending request…</p>
 				</div>
 			</div>
 		);
@@ -74,30 +74,30 @@ export default function ResponseViewer() {
 	// Empty state
 	if (!response) {
 		return (
-			<div className="flex-1 flex items-center justify-center bg-card">
-				<div className="text-center space-y-4">
-					<FileText className="w-12 h-12 mx-auto text-muted-foreground/50" />
-					<div className="space-y-2">
-						<p className="text-muted-foreground">Response will appear here</p>
-						<p className="text-xs text-muted-foreground/70">
-							Send a request to see the response
+			<div className="flex-1 flex items-center justify-center bg-panel">
+				<div className="flex flex-col items-center gap-3">
+					{/* 48px send icon circle */}
+					<div className="w-12 h-12 rounded-full bg-accent border border-border flex items-center justify-center text-muted-foreground">
+						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+							<line x1="22" y1="2" x2="11" y2="13"/>
+							<polygon points="22 2 15 22 11 13 2 9 22 2"/>
+						</svg>
+					</div>
+					<div className="text-center">
+						<p className="text-[13px] font-medium text-foreground mb-1">No response yet</p>
+						<p className="text-[11px] text-muted-foreground">
+							Press{" "}
+							<kbd className="font-mono bg-card border border-border rounded px-1.5 py-px text-[10px] text-foreground">⌘↵</kbd>
+							{" "}or click Send
 						</p>
 					</div>
-
-					{/* Show button to view load test dashboard if available */}
+					{/* Keep the existing load test dashboard button if it was there */}
 					{hasLoadTestDashboard && (
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleViewLoadTest}
-							className="mt-4"
-						>
+						<Button variant="outline" size="sm" onClick={handleViewLoadTest} className="mt-2">
 							<BarChart3 className="w-4 h-4 mr-2" />
 							View Load Test Dashboard
 							{dashboardMode === "running" && (
-								<Badge variant="default" className="ml-2 text-xs">
-									Live
-								</Badge>
+								<Badge variant="default" className="ml-2 text-xs">Live</Badge>
 							)}
 						</Button>
 					)}

--- a/app/src/modules/request-builder/components/UrlBar/MethodSelector.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/MethodSelector.tsx
@@ -20,13 +20,13 @@ import type { HttpMethod } from "@/types";
 const HTTP_METHODS: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
 const METHOD_COLORS: Record<HttpMethod, string> = {
-	GET: "text-[#22c55e]",
-	POST: "text-[#3b82f6]",
-	PUT: "text-[#f59e0b]",
-	PATCH: "text-[#a855f7]",
-	DELETE: "text-[#ef4444]",
-	HEAD: "text-[#06b6d4]",
-	OPTIONS: "text-[#6b7280]",
+	GET:     "method-get",
+	POST:    "method-post",
+	PUT:     "method-put",
+	PATCH:   "method-patch",
+	DELETE:  "method-delete",
+	HEAD:    "method-head",
+	OPTIONS: "method-options",
 };
 
 export default function MethodSelector() {

--- a/app/src/modules/request-builder/components/UrlBar/MethodSelector.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/MethodSelector.tsx
@@ -20,13 +20,13 @@ import type { HttpMethod } from "@/types";
 const HTTP_METHODS: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
 const METHOD_COLORS: Record<HttpMethod, string> = {
-	GET: "text-green-600",
-	POST: "text-yellow-600",
-	PUT: "text-blue-600",
-	PATCH: "text-purple-600",
-	DELETE: "text-red-600",
-	HEAD: "text-gray-600",
-	OPTIONS: "text-gray-600",
+	GET: "text-[#22c55e]",
+	POST: "text-[#3b82f6]",
+	PUT: "text-[#f59e0b]",
+	PATCH: "text-[#a855f7]",
+	DELETE: "text-[#ef4444]",
+	HEAD: "text-[#06b6d4]",
+	OPTIONS: "text-[#6b7280]",
 };
 
 export default function MethodSelector() {
@@ -38,10 +38,7 @@ export default function MethodSelector() {
 			onValueChange={(value) => updateField("method", value as HttpMethod)}
 		>
 			<SelectTrigger
-				className={cn(
-					"w-28 font-mono font-semibold text-sm",
-					METHOD_COLORS[request.method]
-				)}
+				className={cn("w-[76px] h-[34px] font-mono font-bold text-[11px] bg-accent border-border", METHOD_COLORS[request.method])}
 			>
 				<SelectValue />
 			</SelectTrigger>

--- a/app/src/modules/request-builder/components/UrlBar/UrlInput.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/UrlInput.tsx
@@ -44,7 +44,11 @@ function parseQueryParams(url: string): KeyValueItem[] {
 	}
 }
 
-export default function UrlInput() {
+interface UrlInputProps {
+	className?: string;
+}
+
+export default function UrlInput({ className }: UrlInputProps) {
 	const { request, updateField } = useRequestBuilderContext();
 
 	// Sync params from URL when URL changes directly
@@ -64,13 +68,11 @@ export default function UrlInput() {
 	);
 
 	return (
-		<div className="flex-1">
-			<VariableInput
-				value={request.url}
-				onChange={handleUrlChange}
-				placeholder="https://api.example.com/endpoint?key={{variable}}"
-				className="w-full"
-			/>
-		</div>
+		<VariableInput
+			value={request.url}
+			onChange={handleUrlChange}
+			placeholder="https://api.example.com/endpoint?key={{variable}}"
+			className={className ?? "w-full"}
+		/>
 	);
 }

--- a/app/src/modules/request-builder/components/UrlBar/index.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/index.tsx
@@ -15,8 +15,7 @@
  * - Action buttons (Send, Load Test)
  */
 
-import { Play, Zap, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui";
+import { Zap } from "lucide-react";
 import { useRequestBuilderContext } from "../../context";
 import MethodSelector from "./MethodSelector";
 import UrlInput from "./UrlInput";
@@ -27,38 +26,33 @@ export default function UrlBar() {
 	const canExecute = !isExecuting && request.url.trim().length > 0;
 
 	return (
-		<div className="flex items-center gap-2 p-4 border-b border-border bg-card">
-			{/* Method Selector */}
+		<div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-panel shrink-0">
 			<MethodSelector />
-
-			{/* URL Input */}
-			<UrlInput />
-
-			{/* Send Button */}
-			<Button onClick={executeRequest} disabled={!canExecute} className="min-w-[100px]">
+			<UrlInput className="flex-1 h-[34px] bg-card border border-border rounded-md px-3 text-[13px] font-mono focus:border-primary focus:outline-none transition-colors" />
+			{/* Send button with loading state */}
+			<button
+				onClick={executeRequest}
+				disabled={!canExecute}
+				className="h-[34px] px-4 rounded-md bg-primary text-white text-[13px] font-semibold flex items-center gap-1.5 disabled:opacity-50 transition-opacity shrink-0 font-[inherit]"
+			>
 				{isExecuting ? (
 					<>
-						<Loader2 className="w-4 h-4 animate-spin mr-2" />
+						<span className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-[vayu-spin_0.7s_linear_infinite] inline-block" />
 						Sending
 					</>
 				) : (
-					<>
-						<Play className="w-4 h-4 mr-2" />
-						Send
-					</>
+					<>▶ Send</>
 				)}
-			</Button>
-
-			{/* Load Test Button */}
-			<Button
-				variant="secondary"
+			</button>
+			{/* Load Test button — token-based, not hardcoded purple */}
+			<button
 				onClick={startLoadTest}
 				disabled={!canExecute}
-				className="bg-purple-600 text-white hover:bg-purple-700"
+				className="h-[34px] px-3.5 rounded-md text-[12px] font-semibold flex items-center gap-1.5 disabled:opacity-50 transition-opacity shrink-0 font-[inherit] text-primary border border-primary bg-primary/10"
 			>
-				<Zap className="w-4 h-4 mr-2" />
+				<Zap className="w-3.5 h-3.5" />
 				Load Test
-			</Button>
+			</button>
 		</div>
 	);
 }

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -143,11 +143,29 @@ export default function RequestBuilder() {
 				);
 				const resolvedBody = request.body ? resolveString(request.body) : request.body;
 
-				// Build body payload for engine: {mode, content}
-				const execBody =
-					request.bodyMode !== "none" && resolvedBody
-						? { mode: request.bodyMode || "text", content: resolvedBody }
-						: undefined;
+				// Build body payload for engine matching the discriminated union
+				let execBody: { mode: string; content?: string; fields?: Array<{ key: string; value: string; enabled: boolean }> } | undefined;
+				if (request.bodyMode === "form-data") {
+					execBody = {
+						mode: "form-data",
+						fields: toKeyValueEntries(request.formData).map((e) => ({
+							key: resolveString(e.key),
+							value: resolveString(e.value),
+							enabled: e.enabled,
+						})),
+					};
+				} else if (request.bodyMode === "x-www-form-urlencoded") {
+					execBody = {
+						mode: "x-www-form-urlencoded",
+						fields: toKeyValueEntries(request.urlEncoded).map((e) => ({
+							key: resolveString(e.key),
+							value: resolveString(e.value),
+							enabled: e.enabled,
+						})),
+					};
+				} else if (request.bodyMode !== "none" && resolvedBody) {
+					execBody = { mode: request.bodyMode || "text", content: resolvedBody };
+				}
 
 				// Build resolved auth for engine (exclude inherit — engine needs concrete auth)
 				const execAuth =
@@ -316,13 +334,32 @@ export default function RequestBuilder() {
 					? resolveString(pendingLoadTestRequest.body)
 					: pendingLoadTestRequest.body;
 
-				// Build body in the format backend expects: { mode, content }
-				const bodyPayload = resolvedBody
-					? {
+				// Build body payload matching the discriminated union
+				let bodyPayload: { mode: string; content?: string; fields?: Array<{ key: string; value: string; enabled: boolean }> } | undefined;
+				if (pendingLoadTestRequest.bodyMode === "form-data") {
+					bodyPayload = {
+						mode: "form-data",
+						fields: toKeyValueEntries(pendingLoadTestRequest.formData).map((e) => ({
+							key: resolveString(e.key),
+							value: resolveString(e.value),
+							enabled: e.enabled,
+						})),
+					};
+				} else if (pendingLoadTestRequest.bodyMode === "x-www-form-urlencoded") {
+					bodyPayload = {
+						mode: "x-www-form-urlencoded",
+						fields: toKeyValueEntries(pendingLoadTestRequest.urlEncoded).map((e) => ({
+							key: resolveString(e.key),
+							value: resolveString(e.value),
+							enabled: e.enabled,
+						})),
+					};
+				} else if (resolvedBody) {
+					bodyPayload = {
 						mode: pendingLoadTestRequest.bodyMode || "text",
 						content: resolvedBody,
-					}
-					: undefined;
+					};
+				}
 
 				// Convert LoadTestConfig to StartLoadTestRequest (flat structure)
 				const apiRequest: StartLoadTestRequest = {

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -31,9 +31,9 @@ import { useRequestQuery, useUpdateRequestMutation, queryKeys } from "@/queries"
 import { useEngine, useVariableResolver } from "@/hooks";
 import { apiService, loadTestService } from "@/services";
 import type { RequestState, ResponseState } from "./types";
-import { recordToKeyValue, keyValueToRecord } from "./utils/key-value";
+import { toKeyValueItems, toKeyValueEntries, toFlatHeaders } from "./utils/key-value";
 import { generateUUID } from "./utils/id";
-import type { Request, HttpMethod, LoadTestConfig, StartLoadTestRequest } from "@/types";
+import type { HttpMethod, LoadTestConfig, StartLoadTestRequest, RequestBody, RequestAuth } from "@/types";
 
 /**
  * RequestBuilder - Main entry point
@@ -66,37 +66,55 @@ export default function RequestBuilder() {
 	const initialRequest = useMemo((): Partial<RequestState> | undefined => {
 		if (!fetchedRequest) return undefined;
 
+		const body = fetchedRequest.body;
+		const bodyMode =
+			body.mode === "json"
+				? "json"
+				: body.mode === "form-data"
+					? "form-data"
+					: body.mode === "x-www-form-urlencoded"
+						? "x-www-form-urlencoded"
+						: body.mode === "text"
+							? "text"
+							: body.mode === "graphql"
+								? "text"
+								: "none";
+
+		const rawBody = "content" in body ? body.content : "";
+		const formFields = "fields" in body && body.mode === "form-data" ? body.fields : [];
+		const urlEncodedFields =
+			"fields" in body && body.mode === "x-www-form-urlencoded" ? body.fields : [];
+
+		const auth = fetchedRequest.auth;
+		const authType =
+			auth.mode === "bearer"
+				? "bearer"
+				: auth.mode === "basic"
+					? "basic"
+					: auth.mode === "apikey"
+						? "api-key"
+						: auth.mode === "inherit"
+							? "inherit"
+							: "none";
+		const authConfig: Record<string, any> =
+			auth.mode !== "none" && auth.mode !== "inherit" ? (auth as any) : {};
+
 		return {
 			id: fetchedRequest.id,
 			name: fetchedRequest.name,
+			description: fetchedRequest.description,
 			method: fetchedRequest.method,
 			url: fetchedRequest.url,
-			params: recordToKeyValue(fetchedRequest.params || {}, false), // No system headers for params
-			headers: recordToKeyValue(fetchedRequest.headers || {}, true), // System headers only for headers
-			bodyMode:
-				fetchedRequest.bodyType === "json"
-					? "json"
-					: fetchedRequest.bodyType === "form-data"
-						? "form-data"
-						: fetchedRequest.bodyType === "x-www-form-urlencoded"
-							? "x-www-form-urlencoded"
-							: fetchedRequest.bodyType === "text"
-								? "text"
-								: "none",
-			body: fetchedRequest.body || "",
-			formData: [],
-			urlEncoded: [],
-			authType:
-				fetchedRequest.auth?.type === "bearer"
-					? "bearer"
-					: fetchedRequest.auth?.type === "basic"
-						? "basic"
-						: fetchedRequest.auth?.type === "api_key"
-							? "api-key"
-							: "none",
-			authConfig: fetchedRequest.auth || {},
-			preRequestScript: fetchedRequest.preRequestScript || "",
-			testScript: fetchedRequest.postRequestScript || "",
+			params: toKeyValueItems(fetchedRequest.params),
+			headers: toKeyValueItems(fetchedRequest.headers, true), // inject system headers
+			bodyMode,
+			body: rawBody,
+			formData: toKeyValueItems(formFields),
+			urlEncoded: toKeyValueItems(urlEncodedFields),
+			authType,
+			authConfig,
+			preRequestScript: fetchedRequest.preRequestScript,
+			testScript: fetchedRequest.postRequestScript,
 			collectionId: fetchedRequest.collectionId,
 		};
 	}, [fetchedRequest]);
@@ -110,9 +128,8 @@ export default function RequestBuilder() {
 				// Resolve variables in URL, headers, and body before sending
 				const resolvedUrl = resolveString(request.url);
 
-				// Regenerate UUID for X-Request-ID header on each execution
-				// Also ensure version header is always from package.json (protected)
-				const headersRecord = keyValueToRecord(request.headers);
+				// Flatten enabled headers for execution; inject per-request system headers
+				const headersRecord = toFlatHeaders(request.headers);
 				headersRecord["X-Request-ID"] = generateUUID();
 				const version =
 					typeof __VAYU_VERSION__ !== "undefined" ? __VAYU_VERSION__ : "0.1.1";
@@ -126,49 +143,29 @@ export default function RequestBuilder() {
 				);
 				const resolvedBody = request.body ? resolveString(request.body) : request.body;
 
-				// Resolve auth config if present
-				const resolvedAuthConfig =
-					request.authType !== "none" && request.authConfig
-						? resolveObject(request.authConfig)
-						: request.authConfig;
+				// Build body payload for engine: {mode, content}
+				const execBody =
+					request.bodyMode !== "none" && resolvedBody
+						? { mode: request.bodyMode || "text", content: resolvedBody }
+						: undefined;
 
-				// Convert RequestState back to Request format for the engine
-				const engineRequest: Request = {
-					...fetchedRequest,
-					method: request.method as HttpMethod,
-					url: resolvedUrl,
-					headers: resolvedHeaders,
-					body: resolvedBody,
-					bodyType:
-						request.bodyMode === "json"
-							? "json"
-							: request.bodyMode === "form-data"
-								? "form-data"
-								: request.bodyMode === "x-www-form-urlencoded"
-									? "x-www-form-urlencoded"
-									: request.bodyMode === "text"
-										? "text"
-										: undefined,
-					auth:
-						request.authType !== "none"
-							? {
-								type:
-									request.authType === "bearer"
-										? "bearer"
-										: request.authType === "basic"
-											? "basic"
-											: request.authType === "api-key"
-												? "api-key"
-												: "bearer",
-								...resolvedAuthConfig,
-							}
-							: undefined,
-					preRequestScript: request.preRequestScript || undefined,
-					postRequestScript: request.testScript || undefined,
-				};
+				// Build resolved auth for engine (exclude inherit — engine needs concrete auth)
+				const execAuth =
+					request.authType !== "none" && request.authType !== "inherit"
+						? resolveObject(request.authConfig)
+						: undefined;
 
 				const result = await engineExecuteRequest(
-					engineRequest,
+					{
+						method: request.method,
+						url: resolvedUrl,
+						headers: resolvedHeaders,
+						body: execBody,
+						auth: execAuth as Record<string, unknown> | undefined,
+						preRequestScript: request.preRequestScript || undefined,
+						postRequestScript: request.testScript || undefined,
+						requestId: fetchedRequest.id,
+					},
 					activeEnvironmentId || undefined
 				);
 
@@ -251,29 +248,43 @@ export default function RequestBuilder() {
 		async (request: RequestState) => {
 			if (!fetchedRequest) return;
 
-			await updateRequestMutation.mutateAsync({
+			// Build RequestBody discriminated union from flat UI state
+		let bodyPayload: RequestBody;
+		if (request.bodyMode === "form-data") {
+			bodyPayload = { mode: "form-data", fields: toKeyValueEntries(request.formData) };
+		} else if (request.bodyMode === "x-www-form-urlencoded") {
+			bodyPayload = { mode: "x-www-form-urlencoded", fields: toKeyValueEntries(request.urlEncoded) };
+		} else if (request.bodyMode !== "none" && request.body) {
+			bodyPayload = { mode: request.bodyMode as "json" | "text" | "graphql", content: request.body };
+		} else {
+			bodyPayload = { mode: "none" };
+		}
+
+		// Build RequestAuth from UI state
+		let authPayload: RequestAuth;
+		if (request.authType === "bearer") {
+			authPayload = { mode: "bearer", token: request.authConfig.token ?? "" };
+		} else if (request.authType === "basic") {
+			authPayload = { mode: "basic", username: request.authConfig.username ?? "", password: request.authConfig.password ?? "" };
+		} else if (request.authType === "api-key") {
+			authPayload = { mode: "apikey", key: request.authConfig.key ?? "", value: request.authConfig.value ?? "", in: request.authConfig.addTo ?? "header" };
+		} else if (request.authType === "inherit") {
+			authPayload = { mode: "inherit" };
+		} else {
+			authPayload = { mode: "none" };
+		}
+
+		await updateRequestMutation.mutateAsync({
 				id: fetchedRequest.id,
 				name: request.name,
+				description: request.description,
 				method: request.method as HttpMethod,
 				url: request.url,
-				headers: keyValueToRecord(request.headers),
-				params: keyValueToRecord(request.params),
-				body: request.body || undefined,
-				bodyType: request.bodyMode || undefined,
-				auth:
-					request.authType !== "none"
-						? {
-							type:
-								request.authType === "bearer"
-									? "bearer"
-									: request.authType === "basic"
-										? "basic"
-										: request.authType === "api-key"
-											? "api-key"
-											: "bearer",
-							...request.authConfig,
-						}
-						: undefined,
+				params: toKeyValueEntries(request.params),
+				headers: toKeyValueEntries(request.headers),
+				body: bodyPayload,
+				bodyType: bodyPayload.mode,
+				auth: authPayload,
 				preRequestScript: request.preRequestScript || undefined,
 				postRequestScript: request.testScript || undefined,
 			});
@@ -297,7 +308,7 @@ export default function RequestBuilder() {
 				// Resolve variables in URL, headers, and body before sending
 				const resolvedUrl = resolveString(pendingLoadTestRequest.url);
 				const resolvedHeaders = Object.fromEntries(
-					Object.entries(keyValueToRecord(pendingLoadTestRequest.headers)).map(
+					Object.entries(toFlatHeaders(pendingLoadTestRequest.headers)).map(
 						([key, value]) => [resolveString(key), resolveString(value)]
 					)
 				);
@@ -315,7 +326,6 @@ export default function RequestBuilder() {
 
 				// Convert LoadTestConfig to StartLoadTestRequest (flat structure)
 				const apiRequest: StartLoadTestRequest = {
-					// HTTP request fields at root level
 					method: pendingLoadTestRequest.method,
 					url: resolvedUrl,
 					headers: resolvedHeaders,

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -27,13 +27,35 @@ import { RequestBuilderProvider } from "./context";
 import RequestBuilderLayout from "./components/RequestBuilderLayout";
 import LoadTestConfigDialog from "./components/LoadTestConfigDialog";
 import { useNavigationStore, useVariablesStore, useDashboardStore } from "@/stores";
-import { useRequestQuery, useUpdateRequestMutation, queryKeys } from "@/queries";
+import { useRequestQuery, useUpdateRequestMutation, useCollectionAncestors, queryKeys } from "@/queries";
 import { useEngine, useVariableResolver } from "@/hooks";
 import { apiService, loadTestService } from "@/services";
 import type { RequestState, ResponseState } from "./types";
 import { toKeyValueItems, toKeyValueEntries, toFlatHeaders } from "./utils/key-value";
 import { generateUUID } from "./utils/id";
-import type { HttpMethod, LoadTestConfig, StartLoadTestRequest, RequestBody, RequestAuth } from "@/types";
+import type { HttpMethod, LoadTestConfig, StartLoadTestRequest, RequestBody, RequestAuth, Collection } from "@/types";
+
+/**
+ * Walk the ancestor chain leaf-first and return the first non-none auth.
+ * Collections are always concrete auth sources (never inherit), so the first
+ * non-none one found is the effective inherited auth for the request.
+ */
+function resolveInheritedAuth(ancestors: Collection[]): Record<string, unknown> | undefined {
+	for (let i = ancestors.length - 1; i >= 0; i--) {
+		const auth = ancestors[i].auth;
+		if (auth.mode !== "none") {
+			// Spread the discriminated union into a plain record for the engine
+			return { ...auth } as Record<string, unknown>;
+		}
+	}
+	return undefined;
+}
+
+/** Convert a concrete RequestAuth (non-inherit) to the flat record the engine expects. */
+function authToRecord(auth: Exclude<RequestAuth, { mode: "inherit" }>): Record<string, unknown> | undefined {
+	if (auth.mode === "none") return undefined;
+	return { ...auth } as Record<string, unknown>;
+}
 
 /**
  * RequestBuilder - Main entry point
@@ -56,6 +78,9 @@ export default function RequestBuilder() {
 
 	// Fetch request data
 	const { data: fetchedRequest, isLoading } = useRequestQuery(selectedRequestId);
+
+	// Ancestor chain for the current request's collection (root-first)
+	const collectionAncestors = useCollectionAncestors(fetchedRequest?.collectionId);
 
 	// Variable resolver for the current request's collection
 	const { resolveString, resolveObject } = useVariableResolver({
@@ -167,11 +192,26 @@ export default function RequestBuilder() {
 					execBody = { mode: request.bodyMode || "text", content: resolvedBody };
 				}
 
-				// Build resolved auth for engine (exclude inherit — engine needs concrete auth)
-				const execAuth =
-					request.authType !== "none" && request.authType !== "inherit"
-						? resolveObject(request.authConfig)
-						: undefined;
+				// Resolve auth — walk collection chain for inherit, resolve variables for concrete
+				let execAuth: Record<string, unknown> | undefined;
+				if (request.authType === "inherit") {
+					execAuth = resolveInheritedAuth(collectionAncestors);
+					if (execAuth) execAuth = resolveObject(execAuth) as Record<string, unknown>;
+				} else if (request.authType !== "none") {
+					const concreteAuth = { mode: request.authType, ...request.authConfig } as Exclude<RequestAuth, { mode: "inherit" }>;
+					const raw = authToRecord(concreteAuth);
+					execAuth = raw ? (resolveObject(raw) as Record<string, unknown>) : undefined;
+				}
+
+				// Compose pre/post scripts: collection chain root→leaf, then the request's own script
+				const composedPreScript = [
+					...collectionAncestors.map((c) => c.preRequestScript).filter(Boolean),
+					request.preRequestScript,
+				].filter(Boolean).join("\n\n");
+				const composedPostScript = [
+					...collectionAncestors.map((c) => c.postRequestScript).filter(Boolean),
+					request.testScript,
+				].filter(Boolean).join("\n\n");
 
 				const result = await engineExecuteRequest(
 					{
@@ -179,9 +219,9 @@ export default function RequestBuilder() {
 						url: resolvedUrl,
 						headers: resolvedHeaders,
 						body: execBody,
-						auth: execAuth as Record<string, unknown> | undefined,
-						preRequestScript: request.preRequestScript || undefined,
-						postRequestScript: request.testScript || undefined,
+						auth: execAuth,
+						preRequestScript: composedPreScript || undefined,
+						postRequestScript: composedPostScript || undefined,
 						requestId: fetchedRequest.id,
 					},
 					activeEnvironmentId || undefined
@@ -190,7 +230,7 @@ export default function RequestBuilder() {
 				if (!result) return null;
 
 				// Refresh variables so script-set values (e.g. pm.environment.set) appear in the UI
-				if (request.preRequestScript.trim()) {
+				if (composedPreScript) {
 					queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.globals.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.collections.all });
@@ -258,7 +298,7 @@ export default function RequestBuilder() {
 				};
 			}
 		},
-		[fetchedRequest, engineExecuteRequest, activeEnvironmentId, resolveString, resolveObject, queryClient]
+		[fetchedRequest, engineExecuteRequest, activeEnvironmentId, resolveString, resolveObject, queryClient, collectionAncestors]
 	);
 
 	// Save request callback
@@ -361,12 +401,24 @@ export default function RequestBuilder() {
 					};
 				}
 
+				// Resolve auth for load test (same inherit logic as regular execute)
+				let loadTestAuth: Record<string, unknown> | undefined;
+				if (pendingLoadTestRequest.authType === "inherit") {
+					loadTestAuth = resolveInheritedAuth(collectionAncestors);
+					if (loadTestAuth) loadTestAuth = resolveObject(loadTestAuth) as Record<string, unknown>;
+				} else if (pendingLoadTestRequest.authType !== "none") {
+					const concreteAuth = { mode: pendingLoadTestRequest.authType, ...pendingLoadTestRequest.authConfig } as Exclude<RequestAuth, { mode: "inherit" }>;
+					const raw = authToRecord(concreteAuth);
+					loadTestAuth = raw ? (resolveObject(raw) as Record<string, unknown>) : undefined;
+				}
+
 				// Convert LoadTestConfig to StartLoadTestRequest (flat structure)
 				const apiRequest: StartLoadTestRequest = {
 					method: pendingLoadTestRequest.method,
 					url: resolvedUrl,
 					headers: resolvedHeaders,
 					body: bodyPayload,
+					auth: loadTestAuth,
 					// Load test config
 					mode: config.mode,
 					duration: config.duration_seconds ? `${config.duration_seconds}s` : undefined,
@@ -424,6 +476,8 @@ export default function RequestBuilder() {
 			startRun,
 			navigateToDashboard,
 			resolveString,
+			resolveObject,
+			collectionAncestors,
 		]
 	);
 

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -9,22 +9,25 @@
 /**
  * RequestBuilder Types
  *
- * Centralized type definitions for the request builder module
+ * Centralized type definitions for the request builder module.
+ * KeyValueItem is the UI-layer extension of the domain KeyValueEntry,
+ * adding an ephemeral `id` for stable React keys and a `system` flag.
  */
 
-import type { HttpMethod, ResolvedVariable, VariableScope } from "@/types";
+import type { HttpMethod, KeyValueEntry, ResolvedVariable, VariableScope } from "@/types";
 
 // ============================================================================
 // Key-Value Types (shared across params, headers, form-data)
 // ============================================================================
 
-export interface KeyValueItem {
+/**
+ * UI-layer extension of KeyValueEntry with a stable React key (`id`).
+ * The `id` is ephemeral — it is NOT persisted to the backend.
+ * Strip it with `toKeyValueEntries()` before sending to the API.
+ */
+export interface KeyValueItem extends KeyValueEntry {
 	id: string;
-	key: string;
-	value: string;
-	enabled: boolean;
-	description?: string;
-	system?: boolean;
+	system?: boolean; // true = row is managed by the system (e.g. X-Request-ID)
 }
 
 // ============================================================================
@@ -43,7 +46,7 @@ export interface TabInfo {
 // Auth Types
 // ============================================================================
 
-export type AuthType = "none" | "bearer" | "basic" | "api-key";
+export type AuthType = "none" | "inherit" | "bearer" | "basic" | "api-key";
 
 export interface AuthConfig {
 	type: AuthType;
@@ -91,11 +94,11 @@ export interface RequestState {
 	params: KeyValueItem[];
 	headers: KeyValueItem[];
 
-	// Body (flattened for easier access)
+	// Body (flattened for editor access)
 	bodyMode: BodyMode;
-	body: string; // Raw body content (JSON, text)
-	formData: KeyValueItem[];
-	urlEncoded: KeyValueItem[];
+	body: string; // Raw body content for json/text/graphql modes
+	formData: KeyValueItem[]; // Fields for form-data mode
+	urlEncoded: KeyValueItem[]; // Fields for x-www-form-urlencoded mode
 
 	// Auth
 	authType: AuthType;
@@ -117,15 +120,13 @@ export interface ResponseState {
 	requestHeaders?: Record<string, string>;
 	rawRequest?: string;
 	body: string;
-	bodyRaw?: string;  // Raw response body from server (always available, even for non-JSON)
+	bodyRaw?: string;
 	bodyType: "json" | "html" | "xml" | "text" | "binary";
 	size: number;
 	time: number;
 	timestamp?: string;
-	// Client-side error information (when status === 0)
-	errorCode?: string;    // "TIMEOUT", "CONNECTION_FAILED", "SSL_ERROR", etc.
-	errorMessage?: string; // Human-readable error from engine
-	// Script execution results
+	errorCode?: string;
+	errorMessage?: string;
 	consoleLogs?: string[];
 	testResults?: Array<{ name: string; passed: boolean; error?: string }>;
 	preScriptError?: string;
@@ -182,8 +183,7 @@ export interface KeyValueEditorProps {
 	showResolved?: boolean;
 	allowDisable?: boolean;
 	readOnly?: boolean;
-	keySuggestions?: string[]; // Optional autocomplete suggestions for the key field
-	// Callbacks for controlling editability - allows parent to control behavior (loose coupling)
+	keySuggestions?: string[];
 	canEdit?: (item: KeyValueItem, field: keyof KeyValueItem) => boolean;
 	canRemove?: (item: KeyValueItem) => boolean;
 	canDisable?: (item: KeyValueItem) => boolean;

--- a/app/src/modules/request-builder/utils/key-value.ts
+++ b/app/src/modules/request-builder/utils/key-value.ts
@@ -9,15 +9,20 @@
 /**
  * Key-Value Utilities
  *
- * Utilities for working with KeyValueItem arrays
+ * Helpers for converting between the domain KeyValueEntry[] (storage) and
+ * the UI-layer KeyValueItem[] (adds ephemeral `id` for React keys).
+ *
+ * There is no conversion to/from Record<string,string> for storage — that was
+ * the source of silent data loss. Flat headers are only built for HTTP execution.
  */
 
+import type { KeyValueEntry } from "@/types";
 import type { KeyValueItem } from "../types";
 import { generateId } from "./id";
 import { createDefaultSystemHeaders } from "./system-headers";
 
 /**
- * Create an empty KeyValueItem
+ * Create an empty KeyValueItem for a new editor row.
  */
 export const createEmptyKeyValue = (): KeyValueItem => ({
 	id: generateId(),
@@ -27,67 +32,58 @@ export const createEmptyKeyValue = (): KeyValueItem => ({
 });
 
 /**
- * Convert KeyValueItem[] to Record<string, string>
- * When duplicate keys exist, the last one wins (allows user overrides of system headers)
+ * Convert domain KeyValueEntry[] to UI KeyValueItem[].
+ * Adds ephemeral `id` for React keys.
+ * When `withSystemHeaders` is true, injects managed system headers at the top.
  */
-export const keyValueToRecord = (items: KeyValueItem[]): Record<string, string> => {
+export const toKeyValueItems = (
+	entries: KeyValueEntry[] | undefined,
+	withSystemHeaders = false
+): KeyValueItem[] => {
+	const items: KeyValueItem[] = [];
+
+	if (withSystemHeaders) {
+		items.push(...createDefaultSystemHeaders());
+		const systemKeys = new Set(items.map((h) => h.key.toLowerCase()));
+		(entries ?? []).forEach((entry) => {
+			if (!systemKeys.has(entry.key.toLowerCase())) {
+				items.push({ ...entry, id: generateId() });
+			}
+		});
+	} else {
+		(entries ?? []).forEach((entry) => {
+			items.push({ ...entry, id: generateId() });
+		});
+	}
+
+	// Always keep an empty trailing row for new entries
+	items.push(createEmptyKeyValue());
+	return items;
+};
+
+/**
+ * Convert UI KeyValueItem[] back to domain KeyValueEntry[].
+ * Strips the ephemeral `id` and `system` fields.
+ * Empty trailing rows (no key AND no value) are omitted.
+ */
+export const toKeyValueEntries = (items: KeyValueItem[]): KeyValueEntry[] => {
+	return items
+		.filter((item) => item.key.trim() || item.value.trim())
+		.map(({ id: _id, system: _sys, ...entry }) => entry);
+};
+
+/**
+ * Build a flat Record<string,string> from KeyValueItems for HTTP execution.
+ * Only enabled rows with non-empty keys are included.
+ * Last value wins when duplicate keys exist (allows user headers to override system headers).
+ * This is ONLY used for the engine execution endpoint — never for storage.
+ */
+export const toFlatHeaders = (items: KeyValueItem[]): Record<string, string> => {
 	const result: Record<string, string> = {};
 	items.forEach((item) => {
 		if (item.enabled && item.key.trim()) {
-			// Last one wins - allows user headers to override system headers
 			result[item.key] = item.value;
 		}
 	});
 	return result;
-};
-
-/**
- * Convert Record<string, string> to KeyValueItem[]
- * Only adds system headers when preserveSystemHeaders is true (for headers only, not params)
- */
-export const recordToKeyValue = (
-	record: Record<string, string> | undefined,
-	preserveSystemHeaders: boolean = false
-): KeyValueItem[] => {
-	const items: KeyValueItem[] = [];
-
-	// Only add system headers for headers, not for params or other key-value pairs
-	if (preserveSystemHeaders) {
-		const systemHeaders = createDefaultSystemHeaders();
-		const systemHeaderKeys = new Set(systemHeaders.map((h) => h.key.toLowerCase()));
-
-		// Add system headers first
-		items.push(...systemHeaders);
-
-		// Add loaded items (excluding system headers that are already added)
-		if (record) {
-			Object.entries(record).forEach(([key, value]) => {
-				// Skip if it's a system header (already added)
-				if (!systemHeaderKeys.has(key.toLowerCase())) {
-					items.push({
-						id: generateId(),
-						key,
-						value,
-						enabled: true,
-					});
-				}
-			});
-		}
-	} else {
-		// For params and other non-header key-value pairs, just convert the record
-		if (record) {
-			Object.entries(record).forEach(([key, value]) => {
-				items.push({
-					id: generateId(),
-					key,
-					value,
-					enabled: true,
-				});
-			});
-		}
-	}
-
-	// Always add an empty row at the end for new entries
-	items.push(createEmptyKeyValue());
-	return items;
 };

--- a/app/src/modules/variables/main/VariableTableEditor.tsx
+++ b/app/src/modules/variables/main/VariableTableEditor.tsx
@@ -552,7 +552,7 @@ export default function VariableEditor({ config }: VariableEditorProps) {
 											onBlur={handleBlur}
 											placeholder="variable_name"
 											className={cn(
-												"h-8",
+												"h-8 text-primary",
 												!variable.enabled &&
 												!variable.isNew &&
 												"text-muted-foreground bg-muted"

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -13,6 +13,7 @@
  */
 
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
 import type {
@@ -95,13 +96,14 @@ export function useMultipleCollectionRequests(collectionIds: string[]) {
 		})),
 	});
 
-	// Build a map of collectionId -> requests (sorted by createdAt for stable order)
+	// Build a map of collectionId -> requests, sorted by order then createdAt
 	const requestsByCollection = new Map<string, Request[]>();
 	queries.forEach((query, index) => {
 		const collectionId = collectionIds[index];
 		const requests = query.data ?? [];
-		// Sort by createdAt to maintain stable order after renames
 		const sortedRequests = [...requests].sort((a, b) => {
+			const orderDiff = (a.order ?? 0) - (b.order ?? 0);
+			if (orderDiff !== 0) return orderDiff;
 			const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
 			const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
 			return aTime - bTime;
@@ -157,6 +159,27 @@ export function useRequestQuery(requestId: string | null) {
 		// Use stale data since we're reading from cache
 		staleTime: Infinity,
 	});
+}
+
+/**
+ * Return the ancestor chain for a collection, root-first (inclusive of the collection itself).
+ * Used for hierarchical auth/script composition before execution.
+ */
+export function useCollectionAncestors(collectionId: string | null | undefined): Collection[] {
+	const { data: collections = [] } = useCollectionsQuery();
+
+	return useMemo(() => {
+		if (!collectionId) return [];
+		const chain: Collection[] = [];
+		let currentId: string | undefined = collectionId;
+		while (currentId) {
+			const col = collections.find((c) => c.id === currentId);
+			if (!col) break;
+			chain.unshift(col); // root first
+			currentId = col.parentId;
+		}
+		return chain;
+	}, [collections, collectionId]);
 }
 
 // ============ Collection Mutations ============

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -22,6 +22,7 @@ export {
 	useRequestsQuery,
 	useMultipleCollectionRequests,
 	useRequestQuery,
+	useCollectionAncestors,
 	useCreateCollectionMutation,
 	useUpdateCollectionMutation,
 	useDeleteCollectionMutation,

--- a/app/src/services/transformers/collection-transformer.ts
+++ b/app/src/services/transformers/collection-transformer.ts
@@ -9,40 +9,34 @@
 /**
  * Collection Transformer
  *
- * Transforms backend collection format to frontend format.
- * Handles date conversion (number to ISO string) for createdAt/updatedAt fields.
+ * Transforms backend collection format to frontend domain Collection type.
+ * Handles timestamp conversion and provides safe defaults for new fields.
  */
 
-import type { Collection } from "@/types";
+import type { Collection, RequestAuth } from "@/types";
 
-/**
- * Backend collection format (camelCase with number timestamps)
- */
-export type BackendCollection = Omit<Collection, "createdAt" | "updatedAt"> & {
-	createdAt: number | string;
-	updatedAt: number | string;
-};
-
-/**
- * Collection Transformer
- *
- * Converts backend collection (with number timestamps) to frontend format (with ISO string timestamps).
- */
 export class CollectionTransformer {
-	/**
-	 * Transform backend collection to frontend collection
-	 * Converts createdAt/updatedAt from number (Unix timestamp ms) to ISO string
-	 */
-	static toFrontend(backendCollection: BackendCollection): Collection {
-		if (!backendCollection.id) {
-			throw new Error("Collection must have an id");
+	static toFrontend(raw: Record<string, any>): Collection {
+		if (!raw.id) throw new Error("Collection must have an id");
+
+		// Auth: defaults to {mode: "none"} if missing or malformed
+		let auth: Exclude<RequestAuth, { mode: "inherit" }> = { mode: "none" };
+		if (raw.auth && typeof raw.auth === "object" && raw.auth.mode && raw.auth.mode !== "inherit") {
+			auth = raw.auth as Exclude<RequestAuth, { mode: "inherit" }>;
 		}
 
-		// Handle createdAt/updatedAt conversion from number to string if needed
 		return {
-			...backendCollection,
-			createdAt: new Date(backendCollection.createdAt).toISOString(),
-			updatedAt: new Date(backendCollection.updatedAt).toISOString(),
+			id: raw.id,
+			name: raw.name ?? "",
+			description: raw.description ?? "",
+			parentId: raw.parentId ?? undefined,
+			order: raw.order ?? 0,
+			variables: raw.variables ?? {},
+			auth,
+			preRequestScript: raw.preRequestScript ?? "",
+			postRequestScript: raw.postRequestScript ?? "",
+			createdAt: new Date(raw.createdAt).toISOString(),
+			updatedAt: new Date(raw.updatedAt).toISOString(),
 		};
 	}
 }

--- a/app/src/services/transformers/index.ts
+++ b/app/src/services/transformers/index.ts
@@ -16,6 +16,6 @@
  */
 
 export { RequestTransformer, type BackendRequest } from "./request-transformer";
-export { CollectionTransformer, type BackendCollection } from "./collection-transformer";
+export { CollectionTransformer } from "./collection-transformer";
 export { RunReportTransformer } from "./run-report-transformer";
 export { GlobalsTransformer, type BackendGlobals } from "./globals-transformer";

--- a/app/src/services/transformers/request-transformer.ts
+++ b/app/src/services/transformers/request-transformer.ts
@@ -9,40 +9,56 @@
 /**
  * Request Transformer
  *
- * Transforms backend request format to frontend format.
- * Handles date conversion (number to ISO string) for createdAt/updatedAt fields.
+ * Transforms backend request format to frontend domain Request type.
+ * Handles timestamp conversion and provides safe defaults for new fields.
  */
 
-import type { Request } from "@/types";
+import type { Request, KeyValueEntry, RequestBody, RequestAuth } from "@/types";
 
-/**
- * Backend request format (camelCase with number timestamps)
- */
 export type BackendRequest = Omit<Request, "createdAt" | "updatedAt"> & {
 	createdAt: number | string;
 	updatedAt: number | string;
 };
 
-/**
- * Request Transformer
- *
- * Converts backend request (with number timestamps) to frontend format (with ISO string timestamps).
- */
 export class RequestTransformer {
-	/**
-	 * Transform backend request to frontend request
-	 * Converts createdAt/updatedAt from number (Unix timestamp ms) to ISO string
-	 */
-	static toFrontend(backendRequest: BackendRequest): Request {
-		if (!backendRequest.id) {
-			throw new Error("Request must have an id");
+	static toFrontend(raw: Record<string, any>): Request {
+		if (!raw.id) throw new Error("Request must have an id");
+
+		// Params: array of KeyValueEntry (new) or legacy empty object {}
+		const params: KeyValueEntry[] = Array.isArray(raw.params) ? raw.params : [];
+
+		// Headers: array of KeyValueEntry (new) or legacy empty object {}
+		const headers: KeyValueEntry[] = Array.isArray(raw.headers) ? raw.headers : [];
+
+		// Body: discriminated union (new) or legacy string
+		let body: RequestBody = { mode: "none" };
+		if (raw.body && typeof raw.body === "object" && raw.body.mode) {
+			body = raw.body as RequestBody;
 		}
 
-		// Handle createdAt/updatedAt conversion from number to string if needed
+		// Auth: RequestAuth (new) or legacy object
+		let auth: RequestAuth = { mode: "inherit" };
+		if (raw.auth && typeof raw.auth === "object" && raw.auth.mode) {
+			auth = raw.auth as RequestAuth;
+		}
+
 		return {
-			...backendRequest,
-			createdAt: new Date(backendRequest.createdAt).toISOString(),
-			updatedAt: new Date(backendRequest.updatedAt).toISOString(),
+			id: raw.id,
+			collectionId: raw.collectionId ?? "",
+			name: raw.name ?? "",
+			description: raw.description ?? "",
+			method: raw.method ?? "GET",
+			url: raw.url ?? "",
+			params,
+			headers,
+			body,
+			bodyType: raw.bodyType ?? body.mode ?? "none",
+			auth,
+			preRequestScript: raw.preRequestScript ?? "",
+			postRequestScript: raw.postRequestScript ?? "",
+			order: raw.order ?? 0,
+			createdAt: new Date(raw.createdAt).toISOString(),
+			updatedAt: new Date(raw.updatedAt).toISOString(),
 		};
 	}
 }

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -17,6 +17,9 @@ import type {
 	RunReport,
 	EngineHealth,
 	VariableValue,
+	KeyValueEntry,
+	RequestBody,
+	RequestAuth,
 } from "./domain";
 
 // API Response wrapper
@@ -37,6 +40,9 @@ export interface CreateCollectionRequest {
 	parentId?: string;
 	order?: number;
 	variables?: Record<string, VariableValue>;
+	auth?: Exclude<RequestAuth, { mode: "inherit" }>;
+	preRequestScript?: string;
+	postRequestScript?: string;
 }
 
 export interface UpdateCollectionRequest {
@@ -46,6 +52,9 @@ export interface UpdateCollectionRequest {
 	parentId?: string;
 	order?: number;
 	variables?: Record<string, VariableValue>;
+	auth?: Exclude<RequestAuth, { mode: "inherit" }>;
+	preRequestScript?: string;
+	postRequestScript?: string;
 }
 
 // Requests API
@@ -63,13 +72,14 @@ export interface CreateRequestRequest {
 	description?: string;
 	method: string;
 	url: string;
-	params?: Record<string, string>;
-	headers?: Record<string, string>;
-	body?: string;
+	params?: KeyValueEntry[];
+	headers?: KeyValueEntry[];
+	body?: RequestBody;
 	bodyType?: string;
-	auth?: Record<string, any>;
+	auth?: RequestAuth;
 	preRequestScript?: string;
 	postRequestScript?: string;
+	order?: number;
 }
 
 export interface UpdateRequestRequest {
@@ -78,13 +88,14 @@ export interface UpdateRequestRequest {
 	description?: string;
 	method?: string;
 	url?: string;
-	params?: Record<string, string>;
-	headers?: Record<string, string>;
-	body?: string;
+	params?: KeyValueEntry[];
+	headers?: KeyValueEntry[];
+	body?: RequestBody;
 	bodyType?: string;
-	auth?: Record<string, any>;
+	auth?: RequestAuth;
 	preRequestScript?: string;
 	postRequestScript?: string;
+	order?: number;
 }
 
 // Environments API
@@ -119,20 +130,14 @@ export interface UpdateGlobalsRequest {
 // Execution API
 // Execute Request API - matches /request endpoint
 export interface ExecuteRequestRequest {
-	// Required HTTP request fields
 	method: string;
 	url: string;
-
-	// Optional HTTP request fields
+	// Engine execution endpoint expects flat headers (resolved, enabled-only)
 	headers?: Record<string, string>;
 	body?: any;
-	auth?: Record<string, any>;
-
-	// Scripts
+	auth?: Record<string, unknown>;
 	preRequestScript?: string;
 	postRequestScript?: string;
-
-	// Optional linking fields (camelCase as per API docs)
 	requestId?: string;
 	environmentId?: string;
 }
@@ -147,9 +152,9 @@ export interface ExecuteRequestResponse extends SanityResult {}
  * - Mode-specific params (duration, targetRps, iterations, concurrency, etc.)
  */
 export interface StartLoadTestRequest {
-	// HTTP request fields (same structure as ExecuteRequestRequest)
 	method: string;
 	url: string;
+	// Engine load-test endpoint expects flat headers (resolved, enabled-only)
 	headers?: Record<string, string>;
 	body?: any;
 

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -157,6 +157,7 @@ export interface StartLoadTestRequest {
 	// Engine load-test endpoint expects flat headers (resolved, enabled-only)
 	headers?: Record<string, string>;
 	body?: any;
+	auth?: Record<string, unknown>;
 
 	// Load test strategy
 	mode: "constant_rps" | "constant_concurrency" | "iterations" | "ramp_up";

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -10,24 +10,75 @@
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 
+export type BodyMode = "none" | "json" | "text" | "graphql" | "form-data" | "x-www-form-urlencoded";
+
+export type AuthMode =
+	| "none"
+	| "inherit"
+	| "bearer"
+	| "basic"
+	| "apikey"
+	| "oauth2"
+	| "digest"
+	| "aws"
+	| "ntlm";
+
 /**
- * Variable value with enabled flag (Postman-style)
- * Note: The `secret` field is a UI hint for masking display - values are NOT encrypted at rest.
+ * A single key-value entry (headers, params, form fields).
+ * `enabled: false` rows are preserved in storage and excluded only at HTTP-execution time.
+ * Duplicates are allowed (useful for multiple `Accept` headers etc.).
+ */
+export interface KeyValueEntry {
+	key: string;
+	value: string;
+	enabled: boolean;
+	description?: string;
+}
+
+/**
+ * Variable value with enabled flag and optional type hint.
+ * Note: `secret` is a UI masking hint — values are NOT encrypted at rest.
+ * Note: `type` affects UI rendering and validation only; values are always stored as strings.
  */
 export interface VariableValue {
 	value: string;
 	enabled: boolean;
 	secret?: boolean;
+	type?: "string" | "number" | "boolean" | "json";
 	createdAt?: number;
 }
+
+/**
+ * Request body as a discriminated union.
+ * `body_type` on the domain `Request` is a denormalized mirror of `body.mode`.
+ */
+export type RequestBody =
+	| { mode: "none" }
+	| { mode: "json" | "text" | "graphql"; content: string }
+	| { mode: "form-data" | "x-www-form-urlencoded"; fields: KeyValueEntry[] };
+
+/**
+ * Auth configuration for requests.
+ * `inherit` resolves by walking the parent collection chain at execution time.
+ * Collections never use `inherit` — they are always the auth source.
+ */
+export type RequestAuth =
+	| { mode: "none" | "inherit" }
+	| { mode: "bearer"; token: string }
+	| { mode: "basic"; username: string; password: string }
+	| { mode: "apikey"; key: string; value: string; in: "header" | "query" }
+	| { mode: "oauth2" | "digest" | "aws" | "ntlm"; config: Record<string, unknown> };
 
 export interface Collection {
 	id: string;
 	name: string;
-	description?: string;
+	description: string;
 	parentId?: string;
-	order?: number; // Position in the collection list
-	variables?: Record<string, VariableValue>; // Collection-scoped variables
+	order: number;
+	variables: Record<string, VariableValue>;
+	auth: Exclude<RequestAuth, { mode: "inherit" }>; // Collections are auth sources, never inherit
+	preRequestScript: string;
+	postRequestScript: string;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -43,23 +94,32 @@ export interface Request {
 	id: string;
 	collectionId: string;
 	name: string;
-	description?: string;
+	description: string;
 	method: HttpMethod;
 	url: string;
-	params?: Record<string, string>; // Query parameters
-	headers?: Record<string, string>;
-	body?: string;
-	bodyType?: "json" | "text" | "form-data" | "x-www-form-urlencoded";
-	auth?: Record<string, any>;
-	preRequestScript?: string;
-	postRequestScript?: string;
+	params: KeyValueEntry[];
+	headers: KeyValueEntry[];
+	body: RequestBody;
+	bodyType: BodyMode; // Denormalized mirror of body.mode — kept for queryability
+	auth: RequestAuth;
+	preRequestScript: string;
+	postRequestScript: string;
+	order: number;
 	createdAt: string;
 	updatedAt: string;
+}
+
+/** Stable comparator for sorting requests within a collection. */
+export function compareRequestOrder(a: Request, b: Request): number {
+	const orderDiff = (a.order ?? 0) - (b.order ?? 0);
+	if (orderDiff !== 0) return orderDiff;
+	return (a.id ?? "").localeCompare(b.id ?? "");
 }
 
 export interface Environment {
 	id: string;
 	name: string;
+	description: string;
 	variables: Record<string, VariableValue>;
 	isActive: boolean;
 	createdAt: string;
@@ -77,14 +137,13 @@ export interface GlobalVariables {
 
 /**
  * Variable scope for UI display and resolution priority.
- * Resolution priority: Environment > Collection > Global
+ * Resolution priority: Environment > Collection (leaf-to-root) > Global
  */
 export type VariableScope = "global" | "collection" | "environment";
 
 /**
  * Resolved variable with its value, scope, and secret flag.
- * This is the base interface used throughout the app for variable resolution and display.
- * Note: The `secret` field is a UI hint for masking - values are NOT encrypted at rest.
+ * Note: The `secret` field is a UI hint for masking — values are NOT encrypted at rest.
  */
 export interface ResolvedVariable {
 	value: string;
@@ -94,7 +153,6 @@ export interface ResolvedVariable {
 
 /**
  * Extended variable info for autocomplete and quick view.
- * Includes additional context about the variable's source.
  */
 export interface VariableInfo extends ResolvedVariable {
 	name: string;
@@ -104,11 +162,11 @@ export interface VariableInfo extends ResolvedVariable {
 
 export interface Run {
 	id: string;
-	type: "load" | "design"; // Backend uses "design" not "sanity"
+	type: "load" | "design";
 	status: "pending" | "running" | "completed" | "stopped" | "failed";
 	startTime: number; // Unix timestamp in ms
 	endTime: number;
-	configSnapshot?: any; // The request config used for this run
+	configSnapshot?: any;
 	requestId?: string | null;
 	environmentId?: string | null;
 }
@@ -120,11 +178,9 @@ export interface LoadTestConfig {
 	iterations?: number;
 	mode: "constant_rps" | "constant_concurrency" | "iterations" | "ramp_up";
 	ramp_duration_seconds?: number;
-	// Data capture options
 	data_sample_rate?: number;
 	slow_threshold_ms?: number;
 	save_timing_breakdown?: boolean;
-	// Metadata
 	comment?: string;
 	latency_percentiles?: number[];
 }
@@ -146,10 +202,8 @@ export interface HttpResponse {
 		firstByte: number;
 		download: number;
 	};
-	// Client-side error information (from curl/libcurl)
-	// Present when status === 0 (no server response received)
-	errorCode?: string;    // "TIMEOUT", "CONNECTION_FAILED", "SSL_ERROR", etc.
-	errorMessage?: string; // Human-readable error description
+	errorCode?: string;
+	errorMessage?: string;
 }
 
 export interface TestResult {
@@ -158,14 +212,10 @@ export interface TestResult {
 	error?: string;
 }
 
-// SanityResult is the response from /request endpoint
-// It directly contains the HTTP response fields
 export interface SanityResult extends HttpResponse {
 	requestId?: string;
-	// Script execution results (camelCase from backend)
 	testResults?: TestResult[];
 	consoleLogs?: string[];
-	// Script errors
 	preScriptError?: string;
 	postScriptError?: string;
 	error?: string;
@@ -184,14 +234,12 @@ export interface LoadTestMetrics {
 	avg_latency_ms: number;
 	bytes_sent: number;
 	bytes_received: number;
-	// Rate metrics (Open Model)
-	send_rate?: number; // Rate at which requests are dispatched to the server
-	throughput?: number; // Rate at which responses are received from the server
-	backpressure?: number; // Queue depth: requests sent but not yet responded
+	send_rate?: number;
+	throughput?: number;
+	backpressure?: number;
 }
 
 export interface RunReport {
-	// Phase 1: Metadata section
 	metadata?: {
 		runId: string;
 		runType: string;
@@ -209,7 +257,6 @@ export interface RunReport {
 			comment?: string;
 		};
 	};
-	// Summary section
 	summary: {
 		totalRequests: number;
 		successfulRequests: number;
@@ -217,43 +264,36 @@ export interface RunReport {
 		errorRate: number;
 		totalDurationSeconds: number;
 		avgRps: number;
-		// Rate metrics (Open Model)
-		sendRate?: number; // Rate at which requests are dispatched to the server
-		throughput?: number; // Rate at which responses are received from the server
-		backpressure?: number; // Queue depth: requests sent but not yet responded
-		// Phase 2: Accurate timing metrics
-		testDuration?: number; // Actual test duration in seconds
-		setupOverhead?: number; // Context overhead before test started (seconds)
+		sendRate?: number;
+		throughput?: number;
+		backpressure?: number;
+		testDuration?: number;
+		setupOverhead?: number;
 	};
-	// Latency section
 	latency: {
 		min: number;
 		max: number;
 		avg: number;
-		median?: number; // Phase 1: Renamed from p50
+		median?: number;
 		p50: number;
-		p75?: number; // Phase 1
+		p75?: number;
 		p90: number;
 		p95: number;
 		p99: number;
-		p999?: number; // Phase 1
+		p999?: number;
 	};
-	// Status code distribution
 	statusCodes: Record<string, number>;
-	// Error details
 	errors: {
 		total: number;
 		withDetails: number;
 		types: Record<string, number>;
-		byStatusCode?: Record<string, number>; // Phase 1
+		byStatusCode?: Record<string, number>;
 	};
-	// Phase 1: Rate control metrics
 	rateControl?: {
 		targetRps: number;
 		actualRps: number;
 		achievement: number;
 	};
-	// Optional timing breakdown
 	timingBreakdown?: {
 		avgDnsMs: number;
 		avgConnectMs: number;
@@ -261,28 +301,23 @@ export interface RunReport {
 		avgFirstByteMs: number;
 		avgDownloadMs: number;
 	};
-	// Optional slow requests info
 	slowRequests?: {
 		count: number;
 		thresholdMs: number;
 		percentage: number;
 	};
-	// Optional test validation results
 	testValidation?: {
 		samplesTested: number;
 		testsPassed: number;
 		testsFailed: number;
 		successRate: number;
 	};
-	// Request/Response results (errors + sampled successes)
-	// Backend returns this as a direct array
 	results?: Array<{
 		timestamp: number;
 		statusCode: number;
 		latencyMs: number;
 		error?: string;
 		trace?: {
-			// Success trace fields (camelCase from backend)
 			totalMs?: number;
 			dnsMs?: number;
 			connectMs?: number;
@@ -291,12 +326,10 @@ export interface RunReport {
 			downloadMs?: number;
 			isSlow?: boolean;
 			thresholdMs?: number;
-			// Error trace fields
 			request_number?: number;
 			error_code?: number;
 			error_type?: string;
 			message?: string;
-			// Legacy/optional fields
 			headers?: Record<string, string>;
 			body?: string;
 		};
@@ -316,9 +349,6 @@ export interface EngineConfig {
 	verify_ssl: boolean;
 }
 
-/**
- * Configuration entry with metadata for UI display
- */
 export interface ConfigEntry {
 	key: string;
 	value: string;
@@ -330,21 +360,14 @@ export interface ConfigEntry {
 	min?: string;
 	max?: string;
 	updatedAt: number;
-	/** Whether changing this config requires an engine restart */
 	requiresRestart?: boolean;
 }
 
-/**
- * Configuration response from backend
- */
 export interface ConfigResponse {
 	entries: ConfigEntry[];
 	success?: boolean;
 }
 
-/**
- * Settings category for UI grouping
- */
 export type SettingsCategory =
 	| "general_engine"
 	| "database_performance"
@@ -353,7 +376,6 @@ export type SettingsCategory =
 	| "observability"
 	| "ui";
 
-// Script Editor Completions (from backend)
 export interface ScriptCompletion {
 	label: string;
 	kind: number;

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -52,15 +52,15 @@ export function formatPercent(value: number, total: number): string {
  */
 export function getMethodColor(method: string): string {
 	const colors: Record<string, string> = {
-		GET: "text-blue-600 bg-blue-50",
-		POST: "text-green-600 bg-green-50",
-		PUT: "text-yellow-600 bg-yellow-50",
-		PATCH: "text-purple-600 bg-purple-50",
-		DELETE: "text-red-600 bg-red-50",
-		HEAD: "text-gray-600 bg-gray-50",
-		OPTIONS: "text-gray-600 bg-gray-50",
+		GET:     "#22c55e",
+		POST:    "#3b82f6",
+		PUT:     "#f59e0b",
+		PATCH:   "#a855f7",
+		DELETE:  "#ef4444",
+		HEAD:    "#06b6d4",
+		OPTIONS: "#6b7280",
 	};
-	return colors[method.toUpperCase()] || "text-gray-600 bg-gray-50";
+	return colors[method.toUpperCase()] ?? "#6b7280";
 }
 
 export function loadTestTypeToLabel(type: LoadTestConfig["mode"] | string): string {

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -50,17 +50,15 @@ export function formatPercent(value: number, total: number): string {
 /**
  * Get HTTP method color class
  */
+/**
+ * Returns the CSS variable reference for an HTTP method's color token.
+ * Use as: `hsl(${getMethodColor(method)})` for a solid color,
+ *      or `hsl(${getMethodColor(method)} / 0.1)` for a tinted background.
+ */
 export function getMethodColor(method: string): string {
-	const colors: Record<string, string> = {
-		GET:     "#22c55e",
-		POST:    "#3b82f6",
-		PUT:     "#f59e0b",
-		PATCH:   "#a855f7",
-		DELETE:  "#ef4444",
-		HEAD:    "#06b6d4",
-		OPTIONS: "#6b7280",
-	};
-	return colors[method.toUpperCase()] ?? "#6b7280";
+	const m = method.toLowerCase();
+	const known = ["get", "post", "put", "patch", "delete", "head", "options"];
+	return known.includes(m) ? `var(--method-${m})` : "var(--method-options)";
 }
 
 export function loadTestTypeToLabel(type: LoadTestConfig["mode"] | string): string {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -31,14 +31,22 @@ export default {
 				accent: {
 					DEFAULT: "hsl(var(--accent))",
 					foreground: "hsl(var(--accent-foreground))",
+					active: "hsl(var(--accent-active))",
 				},
 				destructive: {
 					DEFAULT: "hsl(var(--destructive))",
 					foreground: "hsl(var(--destructive-foreground))",
 				},
 				border: "hsl(var(--border))",
+				"border-strong": "hsl(var(--border-strong))",
 				input: "hsl(var(--input))",
 				ring: "hsl(var(--ring))",
+
+				// Panel — sidebar / panel bg (between background and card)
+				panel: "hsl(var(--panel))",
+
+				// Subtle foreground for truly de-emphasized text
+				"subtle-foreground": "hsl(var(--subtle-foreground))",
 
 				// Status colors
 				success: {
@@ -67,8 +75,8 @@ export default {
 				variable: "hsl(var(--variable))",
 			},
 			fontFamily: {
-				sans: ["Inter", "system-ui", "Avenir", "Helvetica", "Arial", "sans-serif"],
-				mono: ["Consolas", "Monaco", "Courier New", "monospace"],
+				sans: ["Space Grotesk", "system-ui", "sans-serif"],
+				mono: ["JetBrains Mono", "Consolas", "Monaco", "monospace"],
 			},
 			borderRadius: {
 				lg: "var(--radius)",
@@ -92,12 +100,26 @@ export default {
 					from: { transform: "translateY(-10px)", opacity: "0" },
 					to: { transform: "translateY(0)", opacity: "1" },
 				},
+				"vayu-spin": {
+					to: { transform: "rotate(360deg)" },
+				},
+				"vayu-pulse": {
+					"0%, 100%": { opacity: "1" },
+					"50%": { opacity: "0.35" },
+				},
+				"vayu-fadepulse": {
+					"0%, 100%": { opacity: "0.9" },
+					"50%": { opacity: "0.5" },
+				},
 			},
 			animation: {
 				"accordion-down": "accordion-down 0.2s ease-out",
 				"accordion-up": "accordion-up 0.2s ease-out",
 				"fade-in": "fade-in 0.2s ease-out",
 				"slide-in": "slide-in 0.2s ease-out",
+				"vayu-spin": "vayu-spin 0.7s linear infinite",
+				"vayu-pulse": "vayu-pulse 1.6s ease-in-out infinite",
+				"vayu-fadepulse": "vayu-fadepulse 2s ease-in-out infinite",
 			},
 		},
 	},

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -1,0 +1,123 @@
+# Variable Resolution
+
+Vayu resolves `{{variableName}}` placeholders at request-execution time using a layered
+priority system. Higher-priority layers override lower ones; within each layer the last
+write wins.
+
+## Priority order (lowest → highest)
+
+```
+Globals  <  Collection chain (root → leaf)  <  Active environment
+```
+
+A variable set in the active environment always wins over a collection variable, which
+always wins over a global.
+
+---
+
+## Layers
+
+### 1. Globals
+
+App-wide variables stored in the singleton `globals` table. Edited via the Globals panel.
+These form the base layer — any layer above can override them.
+
+### 2. Collection chain
+
+Each collection can define its own variables. When a request belongs to a nested
+collection (e.g. `Root → API → Users`), variables are merged walking **root-first**:
+
+```
+Root.variables   →  applied first
+API.variables    →  overrides Root
+Users.variables  →  overrides API  ←  request's direct parent
+```
+
+This means a child collection's variable always takes precedence over an ancestor's
+variable of the same name.
+
+### 3. Active environment
+
+The environment selected in the variables store (top of the sidebar). Environment
+variables override everything else. This is the intended override point for
+per-environment values like base URLs and API keys.
+
+---
+
+## Implementation
+
+`useVariableResolver` (`app/src/hooks/useVariableResolver.ts`) builds a flat
+`Record<string, ResolvedVariable>` on every render via `useMemo`, keyed by
+`(collectionId, environmentId)`:
+
+```typescript
+// 1. Globals
+for ([key, val] of globalsData.variables) result[key] = { value, scope: "global" };
+
+// 2. Collection chain — root first so leaf overrides parent
+const chain = buildCollectionChain(activeCollectionId, collections); // root-first array
+for (const col of chain)
+  for ([key, val] of col.variables)
+    result[key] = { value, scope: "collection" };
+
+// 3. Environment — highest priority
+for ([key, val] of env.variables)
+  result[key] = { value, scope: "environment" };
+```
+
+`buildCollectionChain(startId, collections)` walks `parentId` links upward and
+returns the chain with the root at index 0.
+
+The resolved map is then used by `resolveString(input)` which replaces all
+`{{name}}` occurrences. Unresolved variables are left as-is (e.g. `{{unknown}}`
+stays in the output rather than becoming an empty string).
+
+---
+
+## Auth inheritance
+
+When a request's auth mode is `"inherit"`, Vayu walks the collection ancestor chain
+**leaf-first** (most specific wins) and uses the first collection whose auth mode is
+not `"none"`. This is resolved in `RequestBuilder` before sending to the engine:
+
+```
+Users auth  →  checked first  (leaf, most specific)
+API auth    →  checked second
+Root auth   →  checked last   (root, least specific)
+```
+
+If no ancestor has non-none auth the request executes without auth.
+
+Auth variable placeholders (e.g. `{{bearer_token}}`) are resolved through the same
+variable map before the value is sent to the engine.
+
+---
+
+## Script composition
+
+Pre-request and post-request scripts are composed from the collection chain plus the
+request's own script before execution. Scripts run **root → leaf → request**:
+
+```
+Root.preRequestScript
+API.preRequestScript
+Users.preRequestScript
+request.preRequestScript    ←  runs last
+```
+
+This lets a parent collection set up shared variables or auth tokens that child
+requests and their own scripts can rely on.
+
+Empty scripts are omitted; non-empty scripts are joined with a blank line between them.
+
+---
+
+## Scope labels
+
+`ResolvedVariable.scope` is a display hint used by the variable inspector:
+
+| Value         | Meaning                        |
+|---------------|--------------------------------|
+| `"global"`    | Came from globals              |
+| `"collection"`| Came from any collection layer |
+| `"environment"`| Came from the active environment |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,497 @@
+# Vayu Design System
+
+> Reference for all UI tokens, component patterns, and visual conventions.
+> Future sessions must use this doc to stay consistent with the established design language.
+
+---
+
+## Philosophy
+
+**3-level elevation** — every surface sits on one of three layers. Nothing floats outside this hierarchy.
+
+| Level | Token | Dark | Light |
+|-------|-------|------|-------|
+| Canvas (outermost) | `bg-background` | `#09090b` | `#e6e3dc` |
+| Panel (sidebar/header/toolbar) | `bg-panel` | `#111113` | `#f2f0eb` |
+| Card (content surface) | `bg-card` | `#1a1a1f` | `#ffffff` |
+
+**Warm Stone light mode** — light surfaces use warm gray-stone tones, never cold white/gray.  
+**Dark canvas** — dark mode uses near-black with subtle violet undertones (zinc-950 family).
+
+---
+
+## CSS Custom Properties
+
+All tokens live in `app/src/index.css` as CSS custom properties in HSL channel format (no `hsl()` wrapper — the `@theme inline` block and Tailwind config add that).
+
+### Elevation
+
+```css
+/* Dark mode */
+--background: 240 10%  4%;   /* #09090b — outermost canvas */
+--panel:      240  6%  7%;   /* #111113 — sidebar / panel bg */
+--card:       240  6% 11%;   /* #1a1a1f — elevated surface */
+
+/* Light mode */
+--background: 42 17% 88%;   /* #e6e3dc — warm stone canvas */
+--panel:      42 21% 94%;   /* #f2f0eb — warm panel */
+--card:        0  0% 100%;  /* #ffffff — white card */
+```
+
+### Foreground Scale
+
+```css
+/* Dark */
+--foreground:         240  5% 96%;   /* #f4f4f5 — primary text */
+--muted-foreground:   240  5% 65%;   /* #a1a1aa — secondary / labels */
+--subtle-foreground:  240  5% 34%;   /* #52525b — de-emphasized, placeholders */
+
+/* Light */
+--foreground:         240  6% 10%;   /* #18181b — primary text */
+--muted-foreground:   240  4% 46%;   /* #71717a — secondary / labels */
+--subtle-foreground:  240  7% 78%;   /* #c4c4cc — de-emphasized, placeholders */
+```
+
+### Interactive States
+
+```css
+/* Dark */
+--accent:        240  7% 16%;   /* #26262c — hover background */
+--accent-active: 240  6% 21%;   /* #323238 — selected / active background */
+
+/* Light */
+--accent:        38 20% 89%;   /* #e9e5de — hover background */
+--accent-active: 40 16% 85%;   /* #dedad2 — selected / active background */
+```
+
+### Borders
+
+```css
+/* Dark */
+--border:        0  0% 10%;   /* ≈ rgba(255,255,255,0.07) — default dividers */
+--border-strong: 0  0% 18%;   /* ≈ rgba(255,255,255,0.15) — prominent borders */
+
+/* Light */
+--border:       40  9% 80%;   /* ≈ rgba(0,0,0,0.09) — default dividers */
+--border-strong: 40  6% 72%;  /* ≈ rgba(0,0,0,0.18) — prominent borders */
+```
+
+### Primary (Accent Color)
+
+Default is Sunset orange. Overridden by `[data-color-scheme]` attribute.
+
+```css
+--primary:            24.6 95% 53.1%;   /* #f97316 — orange-500 */
+--primary-foreground:  0   0% 100%;     /* white text on primary */
+--ring:               24.6 95% 53.1%;   /* focus rings */
+--variable:           24.6 95% 53.1%;   /* variable highlights in URL/body */
+```
+
+### Semantic Status Colors
+
+```css
+--success:   142 76% 36%;   /* green — completed, passing */
+--warning:    38 92% 50%;   /* amber — warnings, slow requests */
+--info:      199 89% 48%;   /* cyan — informational */
+--destructive: 0 84% 60%;   /* red — errors, stop, delete */
+```
+
+### Charts
+
+```css
+/* Dark */
+--chart-1: 24.6 95% 53.1%;   /* primary (orange by default) */
+--chart-2: 160  60% 45%;     /* teal */
+--chart-3:  30  80% 55%;     /* amber */
+--chart-4: 280  65% 60%;     /* violet */
+--chart-5: 340  75% 55%;     /* rose */
+
+/* Light — same chart-1; others differ slightly */
+--chart-2: 173 58% 39%;
+--chart-3: 197 37% 24%;
+--chart-4:  43 74% 66%;
+--chart-5:  27 87% 67%;
+```
+
+---
+
+## Color Schemes (Accent Themes)
+
+Applied via `data-color-scheme` attribute on `<html>`. Only `--primary`, `--primary-foreground`, `--ring`, `--variable`, and `--chart-1` change.
+
+| Scheme | Token value (light) | Token value (dark) | Hex approx |
+|--------|--------------------|--------------------|------------|
+| `sunset` (default) | `24.6 95% 53.1%` | same | `#f97316` |
+| `sky` | `188 94% 43%` | same | `#22d3ee` |
+| `ocean` | `217 91% 60%` | `217 78% 51%` | `#3b82f6` |
+| `forest` | `142 76% 36%` | `142 70% 45%` | `#22c55e` |
+| `aurora` | `258 87% 74%` | same | `#a78bfa` |
+| `coral` | `0 72% 65%` | `0 72% 55%` | `#ef4444`-family |
+
+---
+
+## HTTP Method Colors
+
+These are **fixed semantic colors**, never substituted with theme tokens. Used in method badges, badges in RunItem, MethodSelector, DashboardHeader, etc.
+
+| Method | Hex | Tailwind approx | Usage |
+|--------|-----|-----------------|-------|
+| GET | `#22c55e` | green-500 | Text + `bg-green-500/10 border-green-500/30` |
+| POST | `#3b82f6` | blue-500 | Text + `bg-blue-500/10 border-blue-500/30` |
+| PUT | `#f59e0b` | amber-500 | Text + `bg-amber-500/10 border-amber-500/30` |
+| PATCH | `#a855f7` | purple-500 | Text + `bg-purple-500/10 border-purple-500/30` |
+| DELETE | `#ef4444` | red-500 | Text + `bg-red-500/10 border-red-500/30` |
+| HEAD | `#06b6d4` | cyan-500 | Text only (badge uncommon) |
+| OPTIONS | `#6b7280` | gray-500 | Text only |
+
+**Method badge pattern** (inline `<span>`, not a `<Badge>` component):
+```tsx
+<span
+  className="text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded"
+  style={{
+    color: methodColor,
+    background: `${methodColor}18`,   // ~10% opacity
+    border: `1px solid ${methodColor}30`,  // ~19% opacity
+  }}
+>
+  {method}
+</span>
+```
+
+Or via CSS variable tokens (`--method-get`, `--method-post`, etc.) with utility classes `.method-get`, `.bg-method-get`.
+
+---
+
+## Typography
+
+### Fonts
+
+| Role | Family | Import |
+|------|--------|--------|
+| UI / body | Space Grotesk | Google Fonts |
+| Code / mono | JetBrains Mono | Google Fonts |
+
+```html
+<!-- app/index.html -->
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" />
+```
+
+```css
+body { font-family: "Space Grotesk", system-ui, sans-serif; }
+/* mono via font-mono Tailwind class, or .font-code utility */
+```
+
+### Type Scale Conventions
+
+| Use | Size | Weight | Class |
+|-----|------|--------|-------|
+| Section label / eyebrow | 11px | semibold, uppercase, +tracking | `text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground` |
+| Hero metric value | 34px | bold | `text-[34px] font-bold font-mono` |
+| Secondary metric value | 22px | semibold | `text-[22px] font-semibold font-mono` |
+| Body / default | 13px | regular | `text-[13px]` |
+| Small label | 12px | medium | `text-[12px] font-medium` |
+| Micro / badge | 10–11px | mono bold | `text-[10px] font-mono font-bold` |
+| URL / path | 12–13px | mono | `text-[12px] font-mono` |
+
+---
+
+## Geometry
+
+```css
+--radius: 0.375rem;   /* 6px — base border radius */
+```
+
+| Class | Value |
+|-------|-------|
+| `rounded` (default) | 4px |
+| `rounded-md` | `calc(0.375rem - 2px)` = 4px |
+| `rounded-lg` | `0.375rem` = 6px |
+| `rounded-full` | pill / circle |
+
+Cards and panels use `rounded-md`. Badges/chips use `rounded` or `rounded-sm`. Status pills use `rounded-full`.
+
+---
+
+## Animations
+
+Defined in both `index.css` and `tailwind.config.js`.
+
+| Name | Duration | Curve | Use |
+|------|----------|-------|-----|
+| `vayu-spin` | 0.7s | linear | Loading spinners |
+| `vayu-pulse` | 1.6s | ease-in-out | Live indicators (0→35% opacity) |
+| `vayu-fadepulse` | 2s | ease-in-out | Subtle breathe (90→50% opacity) |
+| `accordion-down/up` | 0.2s | ease-out | Radix accordion |
+| `fade-in` | 0.2s | ease-out | General reveal |
+| `slide-in` | 0.2s | ease-out | Dropdown/panel entry |
+
+**Spinner pattern:**
+```tsx
+<span className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-[vayu-spin_0.7s_linear_infinite] inline-block" />
+```
+
+**Live dot pattern:**
+```tsx
+<span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+```
+
+---
+
+## Layout Structure
+
+```
+Shell
+├── Sidebar (shrink-0)
+│   ├── ActivityBar        44px wide   bg-panel border-r border-border
+│   └── SidebarPanel       240px wide  bg-panel border-r border-border  (collapsible)
+└── main (flex-1)          routes render here
+```
+
+### ActivityBar
+
+- **Width:** `w-11` (44px), full height, `bg-panel border-r border-border`
+- **Tab buttons:** `w-10 h-10 flex items-center justify-center rounded-md`
+- **Active state:** `bg-primary/10 text-primary` + 2px left accent bar
+  ```tsx
+  <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-r-sm" />
+  ```
+- **Inactive hover:** `hover:bg-accent hover:text-foreground`
+- **Icon size:** `w-4 h-4`
+- **Tabs (top):** Collections (Folder), History (Clock), Variables (Code2)
+- **Tab (bottom, pinned):** Settings (Settings2) — pushed down with `flex-1` spacer
+- **Collapse:** clicking active tab while panel open → `setPanelOpen(false)`
+- **Tooltips:** `side="right"` via `TooltipContent`
+
+### SidebarPanel
+
+- **Width:** `w-60` (240px), `bg-panel border-r border-border`, `overflow-hidden`
+- **Content:** `ScrollArea` fills available space
+- **Footer:** `ConnectionStatus` pinned to bottom with `border-t border-border`
+
+---
+
+## Component Patterns
+
+### Cards
+
+```tsx
+<div className="bg-card border border-border rounded-md p-4">
+  ...
+</div>
+```
+
+Never use hardcoded background colors like `bg-gray-50`, `bg-blue-50`, `bg-zinc-900` for card surfaces. Always `bg-card`.
+
+### Section Eyebrow Label
+
+```tsx
+<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground mb-4">
+  Section Title
+</p>
+```
+
+### Status Badges / Pills
+
+**Live (running):**
+```tsx
+<span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-semibold tracking-wide bg-green-500/15 text-green-500 border border-green-500/25">
+  <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+  LIVE
+</span>
+```
+
+**Completed / Stopped:**
+```tsx
+<span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-semibold tracking-wide bg-muted text-muted-foreground border border-border">
+  COMPLETED
+</span>
+```
+
+**Run status left-bar (RunItem):**
+```tsx
+<div className={cn(
+  "absolute left-0 top-0 bottom-0 w-1",
+  status === "completed" && "bg-green-500",
+  status === "failed"    && "bg-red-500",
+  status === "running"   && "bg-blue-500",
+  status === "stopped"   && "bg-orange-500",
+  status === "pending"   && "bg-muted-foreground"
+)} />
+```
+
+### Destructive Actions
+
+```tsx
+/* Error/warning banner */
+<div className="bg-destructive/10 text-destructive rounded-md p-3">...</div>
+
+/* Stop button */
+<Button
+  variant="ghost"
+  className="text-destructive hover:bg-destructive/10 hover:text-destructive border border-destructive/30"
+>
+  Stop
+</Button>
+
+/* Delete icon button */
+<Button
+  variant="ghost"
+  size="icon"
+  className="h-6 w-6 hover:bg-destructive/10 hover:text-destructive opacity-0 group-hover:opacity-100"
+>
+  <Trash2 className="w-3 h-3" />
+</Button>
+```
+
+### URL Bar (Flat Style)
+
+```tsx
+<div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-panel shrink-0">
+  <MethodSelector />   {/* w-[76px] h-[34px] bg-accent font-mono font-bold text-[11px] */}
+  <UrlInput className="flex-1 h-[34px] bg-card border border-border rounded-md px-3 text-[13px] font-mono focus:border-primary focus:outline-none transition-colors" />
+
+  {/* Primary action */}
+  <button className="h-[34px] px-4 rounded-md bg-primary text-white text-[13px] font-semibold ...">
+    {isExecuting
+      ? <><Spinner /> Sending</>
+      : <>▶ Send</>
+    }
+  </button>
+
+  {/* Secondary action — token-based, never hardcoded purple */}
+  <button className="h-[34px] px-3.5 rounded-md text-[12px] font-semibold text-primary border border-primary bg-primary/10 ...">
+    <Zap className="w-3.5 h-3.5" /> Load Test
+  </button>
+</div>
+```
+
+### Dashboard Header (Compact 52px)
+
+```tsx
+<div className="h-[52px] flex items-center gap-3 px-5 bg-panel border-b border-border shrink-0">
+  {/* Status pill */}
+  {/* Method badge (inline span with style prop, not Tailwind) */}
+  {/* URL — font-mono text-[12px] flex-1 truncate */}
+  {/* Config summary — text-[12px] text-muted-foreground hidden sm:block */}
+  {/* Stop button — ghost variant, destructive color */}
+</div>
+```
+
+### SVG Sparkline (pure SVG, no Recharts)
+
+```tsx
+function Sparkline({ data, color }: { data: number[]; color: string }) {
+  const max = Math.max(...data), min = Math.min(...data), rng = max - min || 1;
+  const w = 108, h = 26;
+  const pts = data.map((v, i) =>
+    `${(1 + (i / (data.length - 1)) * w).toFixed(1)},${(1 + h * (1 - (v - min) / rng)).toFixed(1)}`
+  );
+  const area = `M1,${h + 1} L${pts.join(" L")} L${w + 1},${h + 1}Z`;
+  return (
+    <svg width={110} height={28}>
+      <path d={area} fill={color} fillOpacity="0.15" />
+      <polyline points={pts.join(" ")} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+```
+
+### SVG Area Chart (replaces Recharts entirely)
+
+Key settings: `viewBox="0 0 600 150"`, padding `PL=42 PR=8 PT=6 PB=20`, grid lines use `hsl(var(--border))` with `strokeDasharray="2 2"`, axis labels use `hsl(var(--muted-foreground))` in JetBrains Mono at `fontSize="9"`.
+
+### Hero Metric Card
+
+```
+┌─────────────────────────────────────────┐
+│ LABEL (11px, uppercase, muted)          │
+│ 34px bold mono value    [sparkline 110w]│
+│ sub-label (11px, muted)                 │
+└─────────────────────────────────────────┘
+```
+
+```tsx
+<div className="bg-card border border-border rounded-md p-4 flex flex-col gap-1">
+  <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">{label}</p>
+  <div className="flex items-end justify-between gap-2">
+    <span className="text-[34px] font-bold font-mono leading-none text-foreground">{value}</span>
+    {sparklineData && <Sparkline data={sparklineData} color={sparklineColor} />}
+  </div>
+  {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+</div>
+```
+
+### Latency Distribution Bar
+
+Gradient track (green→amber→red, 18% opacity), with needle markers at p50/p95/p99. Each marker: absolute-positioned, `w-0.5 h-6 rounded-sm` pin + `w-4 h-4 rounded-full border-2 ring-4` dot + label below.
+
+---
+
+## Tailwind Utility Reference
+
+| Token | Tailwind class |
+|-------|---------------|
+| Canvas background | `bg-background` |
+| Panel background | `bg-panel` |
+| Card background | `bg-card` |
+| Primary text | `text-foreground` |
+| Secondary text | `text-muted-foreground` |
+| De-emphasized text | `text-subtle-foreground` |
+| Primary accent | `text-primary`, `bg-primary`, `border-primary` |
+| Default border | `border-border` |
+| Strong border | `border-border-strong` |
+| Hover state | `hover:bg-accent` |
+| Selected state | `bg-accent-active` |
+| Success | `text-success`, `bg-success/10` |
+| Warning | `text-warning`, `bg-warning/10` |
+| Info | `text-info`, `bg-info/10` |
+| Error | `text-destructive`, `bg-destructive/10` |
+| Mono font | `font-mono` |
+| Code font (utility) | `font-code` |
+| Thin scrollbar | `scrollbar-thin` |
+| Variable color | `text-variable` or `.variable-highlight` |
+
+### Never use
+
+- `bg-gray-*`, `bg-zinc-*`, `bg-slate-*` — use `bg-card`, `bg-panel`, `bg-background`
+- `bg-blue-50`, `bg-red-950`, etc. — use `bg-destructive/10`, `bg-info/10`, etc.
+- `dark:bg-*` hardcoded overrides — tokens handle both modes automatically
+- Hardcoded `purple` for Load Test / secondary actions — use `text-primary/border-primary/bg-primary/10`
+- `text-gray-500` — use `text-muted-foreground`
+- `text-gray-400` in dark — use `text-muted-foreground`
+
+---
+
+## Response Body Syntax Highlighting
+
+For JSON pretty-printer and code viewer (planned / pending implementation):
+
+| Token | Color |
+|-------|-------|
+| Object keys | `#7dd3fc` (sky-300) |
+| String values | `#86efac` (green-300) |
+| Number values | `#fbbf24` (amber-400) |
+| Boolean values | `#a78bfa` (violet-400) |
+| Null | `#94a3b8` (slate-400) |
+
+---
+
+## Scrollbar
+
+All scrollable panes use `.scrollbar-thin` utility:
+```css
+scrollbar-width: thin;
+scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+```
+
+---
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `app/src/index.css` | All CSS custom properties, keyframes, utility classes |
+| `app/tailwind.config.js` | Color mapping, font families, keyframes, animation aliases |
+| `app/index.html` | Google Fonts preconnect + link tags |
+| `app/src/components/layout/Sidebar.tsx` | ActivityBar + SidebarPanel layout |
+| `app/src/components/layout/Shell.tsx` | Root layout (Sidebar + main) |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,7 +1,7 @@
 # Vayu Design System
 
 > Reference for all UI tokens, component patterns, and visual conventions.
-> Future sessions must use this doc to stay consistent with the established design language.
+> Future sessions must read this before touching any UI file.
 
 ---
 
@@ -22,17 +22,17 @@
 
 ## CSS Custom Properties
 
-All tokens live in `app/src/index.css` as CSS custom properties in HSL channel format (no `hsl()` wrapper — the `@theme inline` block and Tailwind config add that).
+All tokens live in `app/src/index.css` as HSL channel values (no `hsl()` wrapper — `@theme inline` and Tailwind config add that). Separate light and dark values are listed where they differ.
 
 ### Elevation
 
 ```css
-/* Dark mode */
+/* Dark */
 --background: 240 10%  4%;   /* #09090b — outermost canvas */
 --panel:      240  6%  7%;   /* #111113 — sidebar / panel bg */
 --card:       240  6% 11%;   /* #1a1a1f — elevated surface */
 
-/* Light mode */
+/* Light */
 --background: 42 17% 88%;   /* #e6e3dc — warm stone canvas */
 --panel:      42 21% 94%;   /* #f2f0eb — warm panel */
 --card:        0  0% 100%;  /* #ffffff — white card */
@@ -89,11 +89,79 @@ Default is Sunset orange. Overridden by `[data-color-scheme]` attribute.
 
 ### Semantic Status Colors
 
+These differ between light and dark mode.
+
 ```css
---success:   142 76% 36%;   /* green — completed, passing */
---warning:    38 92% 50%;   /* amber — warnings, slow requests */
---info:      199 89% 48%;   /* cyan — informational */
---destructive: 0 84% 60%;   /* red — errors, stop, delete */
+/* Light */
+--success:            142 76% 36%;   /* green */
+--warning:             38 92% 50%;   /* amber */
+--info:               199 89% 48%;   /* cyan */
+--destructive:          0 84% 60%;   /* red */
+
+/* Dark */
+--success:            142 70% 45%;   /* lighter green */
+--warning:             38 92% 50%;   /* same */
+--info:               199 89% 48%;   /* same */
+--destructive:          0 62.8% 30.6%;  /* darker red */
+```
+
+### HTTP Method Color Tokens
+
+Method colors are design tokens defined in `:root`, not hardcoded hex values. They are consistent between light and dark mode.
+
+```css
+--method-get:     142 76% 36%;   /* green */
+--method-post:    217 91% 60%;   /* blue */
+--method-put:      38 92% 50%;   /* amber */
+--method-patch:   262 83% 58%;   /* purple */
+--method-delete:    0 84% 60%;   /* red */
+--method-head:    199 89% 48%;   /* cyan */
+--method-options: 240  5% 64%;   /* gray */
+```
+
+**Utility classes** (defined in `index.css`, available as Tailwind class names):
+- Text color: `.method-get`, `.method-post`, `.method-put`, `.method-patch`, `.method-delete`, `.method-head`, `.method-options`
+- Background: `.bg-method-get`, `.bg-method-post`, etc.
+
+**`getMethodColor(method)`** in `app/src/utils/helpers.ts` returns `var(--method-xxx)` — the raw CSS variable reference. Callers construct full color values:
+
+```tsx
+const c = getMethodColor(method); // e.g. "var(--method-get)"
+
+// Solid color (text, stroke):
+color: `hsl(${c})`
+
+// Tinted background (~10% opacity):
+background: `hsl(${c} / 0.1)`
+
+// Tinted border (~30% opacity):
+borderColor: `hsl(${c} / 0.3)`
+```
+
+**Method badge pattern** (inline `<span>`, not a `<Badge>` component — used in RunItem, DashboardHeader):
+
+```tsx
+const c = `var(--method-${method.toLowerCase()})`;
+<span
+  className="text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded"
+  style={{
+    color:      `hsl(${c})`,
+    background: `hsl(${c} / 0.1)`,
+    border:     `1px solid hsl(${c} / 0.3)`,
+  }}
+>
+  {method}
+</span>
+```
+
+**MethodSelector** uses the `.method-get` etc. utility classes as Tailwind classNames:
+
+```tsx
+const METHOD_COLORS: Record<HttpMethod, string> = {
+  GET: "method-get", POST: "method-post", PUT: "method-put",
+  PATCH: "method-patch", DELETE: "method-delete", HEAD: "method-head", OPTIONS: "method-options",
+};
+// Usage: className={cn("font-mono font-semibold", METHOD_COLORS[method])}
 ```
 
 ### Charts
@@ -101,12 +169,13 @@ Default is Sunset orange. Overridden by `[data-color-scheme]` attribute.
 ```css
 /* Dark */
 --chart-1: 24.6 95% 53.1%;   /* primary (orange by default) */
---chart-2: 160  60% 45%;     /* teal */
---chart-3:  30  80% 55%;     /* amber */
---chart-4: 280  65% 60%;     /* violet */
---chart-5: 340  75% 55%;     /* rose */
+--chart-2: 160  60% 45%;
+--chart-3:  30  80% 55%;
+--chart-4: 280  65% 60%;
+--chart-5: 340  75% 55%;
 
-/* Light — same chart-1; others differ slightly */
+/* Light */
+--chart-1: 24.6 95% 53.1%;   /* same */
 --chart-2: 173 58% 39%;
 --chart-3: 197 37% 24%;
 --chart-4:  43 74% 66%;
@@ -119,46 +188,14 @@ Default is Sunset orange. Overridden by `[data-color-scheme]` attribute.
 
 Applied via `data-color-scheme` attribute on `<html>`. Only `--primary`, `--primary-foreground`, `--ring`, `--variable`, and `--chart-1` change.
 
-| Scheme | Token value (light) | Token value (dark) | Hex approx |
-|--------|--------------------|--------------------|------------|
-| `sunset` (default) | `24.6 95% 53.1%` | same | `#f97316` |
-| `sky` | `188 94% 43%` | same | `#22d3ee` |
-| `ocean` | `217 91% 60%` | `217 78% 51%` | `#3b82f6` |
-| `forest` | `142 76% 36%` | `142 70% 45%` | `#22c55e` |
-| `aurora` | `258 87% 74%` | same | `#a78bfa` |
-| `coral` | `0 72% 65%` | `0 72% 55%` | `#ef4444`-family |
-
----
-
-## HTTP Method Colors
-
-These are **fixed semantic colors**, never substituted with theme tokens. Used in method badges, badges in RunItem, MethodSelector, DashboardHeader, etc.
-
-| Method | Hex | Tailwind approx | Usage |
-|--------|-----|-----------------|-------|
-| GET | `#22c55e` | green-500 | Text + `bg-green-500/10 border-green-500/30` |
-| POST | `#3b82f6` | blue-500 | Text + `bg-blue-500/10 border-blue-500/30` |
-| PUT | `#f59e0b` | amber-500 | Text + `bg-amber-500/10 border-amber-500/30` |
-| PATCH | `#a855f7` | purple-500 | Text + `bg-purple-500/10 border-purple-500/30` |
-| DELETE | `#ef4444` | red-500 | Text + `bg-red-500/10 border-red-500/30` |
-| HEAD | `#06b6d4` | cyan-500 | Text only (badge uncommon) |
-| OPTIONS | `#6b7280` | gray-500 | Text only |
-
-**Method badge pattern** (inline `<span>`, not a `<Badge>` component):
-```tsx
-<span
-  className="text-[10px] h-5 px-1.5 font-mono font-bold shrink-0 inline-flex items-center rounded"
-  style={{
-    color: methodColor,
-    background: `${methodColor}18`,   // ~10% opacity
-    border: `1px solid ${methodColor}30`,  // ~19% opacity
-  }}
->
-  {method}
-</span>
-```
-
-Or via CSS variable tokens (`--method-get`, `--method-post`, etc.) with utility classes `.method-get`, `.bg-method-get`.
+| Scheme | Light HSL | Dark HSL |
+|--------|-----------|----------|
+| `sunset` (default) | `24.6 95% 53.1%` | same |
+| `sky` | `188 94% 43%` | same |
+| `ocean` | `217 91% 60%` | `217 78% 51%` |
+| `forest` | `142 76% 36%` | `142 70% 45%` |
+| `aurora` | `258 87% 74%` | same |
+| `coral` | `0 72% 65%` | `0 72% 55%` |
 
 ---
 
@@ -186,8 +223,8 @@ body { font-family: "Space Grotesk", system-ui, sans-serif; }
 | Use | Size | Weight | Class |
 |-----|------|--------|-------|
 | Section label / eyebrow | 11px | semibold, uppercase, +tracking | `text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground` |
-| Hero metric value | 34px | bold | `text-[34px] font-bold font-mono` |
-| Secondary metric value | 22px | semibold | `text-[22px] font-semibold font-mono` |
+| Hero metric value | 34px | bold, tabular | `text-[34px] font-bold leading-none font-mono tabular-nums` |
+| Secondary metric value | 22px | bold | `text-[22px] font-bold font-mono` |
 | Body / default | 13px | regular | `text-[13px]` |
 | Small label | 12px | medium | `text-[12px] font-medium` |
 | Micro / badge | 10–11px | mono bold | `text-[10px] font-mono font-bold` |
@@ -203,10 +240,12 @@ body { font-family: "Space Grotesk", system-ui, sans-serif; }
 
 | Class | Value |
 |-------|-------|
-| `rounded` (default) | 4px |
+| `rounded-sm` | `calc(0.375rem - 4px)` = 2px |
 | `rounded-md` | `calc(0.375rem - 2px)` = 4px |
 | `rounded-lg` | `0.375rem` = 6px |
 | `rounded-full` | pill / circle |
+
+Note: Tailwind's unsuffixed `rounded` is its own default scale (4px) and is not in the custom config. Prefer explicit `rounded-md` or `rounded-lg`.
 
 Cards and panels use `rounded-md`. Badges/chips use `rounded` or `rounded-sm`. Status pills use `rounded-full`.
 
@@ -214,20 +253,20 @@ Cards and panels use `rounded-md`. Badges/chips use `rounded` or `rounded-sm`. S
 
 ## Animations
 
-Defined in both `index.css` and `tailwind.config.js`.
+Defined in both `index.css` and `tailwind.config.js`. All three `vayu-*` animations have Tailwind shorthand aliases (`animate-vayu-spin`, `animate-vayu-pulse`, `animate-vayu-fadepulse`) in addition to the verbose arbitrary form.
 
-| Name | Duration | Curve | Use |
-|------|----------|-------|-----|
-| `vayu-spin` | 0.7s | linear | Loading spinners |
-| `vayu-pulse` | 1.6s | ease-in-out | Live indicators (0→35% opacity) |
-| `vayu-fadepulse` | 2s | ease-in-out | Subtle breathe (90→50% opacity) |
-| `accordion-down/up` | 0.2s | ease-out | Radix accordion |
-| `fade-in` | 0.2s | ease-out | General reveal |
-| `slide-in` | 0.2s | ease-out | Dropdown/panel entry |
+| Name | Duration | Curve | Tailwind class | Use |
+|------|----------|-------|----------------|-----|
+| `vayu-spin` | 0.7s | linear | `animate-vayu-spin` | Loading spinners |
+| `vayu-pulse` | 1.6s | ease-in-out | `animate-vayu-pulse` | Live indicators (100→35% opacity) |
+| `vayu-fadepulse` | 2s | ease-in-out | `animate-vayu-fadepulse` | Subtle breathe (90→50% opacity) |
+| `accordion-down/up` | 0.2s | ease-out | `animate-accordion-down/up` | Radix accordion |
+| `fade-in` | 0.2s | ease-out | `animate-fade-in` | General reveal |
+| `slide-in` | 0.2s | ease-out | `animate-slide-in` | Dropdown/panel entry |
 
 **Spinner pattern:**
 ```tsx
-<span className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-[vayu-spin_0.7s_linear_infinite] inline-block" />
+<span className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-vayu-spin inline-block" />
 ```
 
 **Live dot pattern:**
@@ -241,11 +280,45 @@ Defined in both `index.css` and `tailwind.config.js`.
 
 ```
 Shell
-├── Sidebar (shrink-0)
-│   ├── ActivityBar        44px wide   bg-panel border-r border-border
-│   └── SidebarPanel       240px wide  bg-panel border-r border-border  (collapsible)
-└── main (flex-1)          routes render here
+├── Resizable sidebar container  (280–600px, default 320px — useResizable hook)
+│   └── Sidebar
+│       ├── ActivityBar     w-11 (44px)  bg-panel border-r border-border
+│       └── SidebarPanel    w-60 (240px) bg-panel border-r border-border  (collapsible)
+├── Resize handle            w-1  bg-border hover:bg-primary cursor-col-resize
+└── main (flex-1)            routes render here
 ```
+
+### Resizable Sidebar
+
+Shell uses `useResizable` from `app/src/hooks/useResizable.ts`:
+
+```tsx
+const { size: sidebarWidth, isResizing, startResizing } = useResizable({
+  defaultSize: 320,
+  min: 280,
+  max: 600,
+});
+
+// Sidebar container:
+<div style={{ width: `${sidebarWidth}px`, minWidth: "280px", maxWidth: "600px" }} className="flex-shrink-0 ...">
+  <Sidebar />
+</div>
+
+// Drag handle:
+<div
+  onMouseDown={startResizing}
+  className={cn("w-1 bg-border hover:bg-primary cursor-col-resize transition-colors shrink-0", isResizing && "bg-primary")}
+/>
+```
+
+**`useResizable` API:**
+
+```ts
+useResizable({ defaultSize, min, max, direction?: "horizontal" | "vertical" })
+// → { size: number, isResizing: boolean, startResizing: (e: React.MouseEvent) => void }
+```
+
+`startResizing` takes a `React.MouseEvent` (wire directly to `onMouseDown`). Uses delta-based calculation — captures drag origin on mousedown, computes `newSize = startSize + delta` — so it works for panels that don't start at the viewport origin.
 
 ### ActivityBar
 
@@ -264,7 +337,8 @@ Shell
 
 ### SidebarPanel
 
-- **Width:** `w-60` (240px), `bg-panel border-r border-border`, `overflow-hidden`
+- **Width:** `w-60` (240px) internal — the outer resizable container starts at 320px
+- `bg-panel border-r border-border overflow-hidden`
 - **Content:** `ScrollArea` fills available space
 - **Footer:** `ConnectionStatus` pinned to bottom with `border-t border-border`
 
@@ -353,12 +427,12 @@ Never use hardcoded background colors like `bg-gray-50`, `bg-blue-50`, `bg-zinc-
   {/* Primary action */}
   <button className="h-[34px] px-4 rounded-md bg-primary text-white text-[13px] font-semibold ...">
     {isExecuting
-      ? <><Spinner /> Sending</>
+      ? <><span className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-vayu-spin inline-block" /> Sending</>
       : <>▶ Send</>
     }
   </button>
 
-  {/* Secondary action — token-based, never hardcoded purple */}
+  {/* Secondary action — always token-based (text-primary/border-primary/bg-primary/10), never hardcoded purple */}
   <button className="h-[34px] px-3.5 rounded-md text-[12px] font-semibold text-primary border border-primary bg-primary/10 ...">
     <Zap className="w-3.5 h-3.5" /> Load Test
   </button>
@@ -369,18 +443,21 @@ Never use hardcoded background colors like `bg-gray-50`, `bg-blue-50`, `bg-zinc-
 
 ```tsx
 <div className="h-[52px] flex items-center gap-3 px-5 bg-panel border-b border-border shrink-0">
-  {/* Status pill */}
-  {/* Method badge (inline span with style prop, not Tailwind) */}
+  {/* Status pill — LIVE (green animated dot) or COMPLETED/STOPPED (muted) */}
+  {/* Method badge — inline <span> with hsl(var(--method-xxx)) inline style */}
   {/* URL — font-mono text-[12px] flex-1 truncate */}
   {/* Config summary — text-[12px] text-muted-foreground hidden sm:block */}
-  {/* Stop button — ghost variant, destructive color */}
+  {/* Stop button — ghost variant, destructive color, Loader2 spinner while stopping */}
 </div>
 ```
 
-### SVG Sparkline (pure SVG, no Recharts)
+The header has a live elapsed timer (`liveTick` state) that resets to 0 at the start of each run.
+
+### SVG Sparkline
 
 ```tsx
 function Sparkline({ data, color }: { data: number[]; color: string }) {
+  if (!data || data.length < 2) return null;
   const max = Math.max(...data), min = Math.min(...data), rng = max - min || 1;
   const w = 108, h = 26;
   const pts = data.map((v, i) =>
@@ -388,7 +465,7 @@ function Sparkline({ data, color }: { data: number[]; color: string }) {
   );
   const area = `M1,${h + 1} L${pts.join(" L")} L${w + 1},${h + 1}Z`;
   return (
-    <svg width={110} height={28}>
+    <svg width={110} height={28} className="block overflow-visible">
       <path d={area} fill={color} fillOpacity="0.15" />
       <polyline points={pts.join(" ")} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
     </svg>
@@ -396,34 +473,62 @@ function Sparkline({ data, color }: { data: number[]; color: string }) {
 }
 ```
 
-### SVG Area Chart (replaces Recharts entirely)
+### SVG Area Chart
 
-Key settings: `viewBox="0 0 600 150"`, padding `PL=42 PR=8 PT=6 PB=20`, grid lines use `hsl(var(--border))` with `strokeDasharray="2 2"`, axis labels use `hsl(var(--muted-foreground))` in JetBrains Mono at `fontSize="9"`.
+`viewBox="0 0 600 150"`, padding `PL=42 PR=8 PT=6 PB=20`. Area fill uses `fillOpacity="0.12"` (slightly less than the sparkline's `0.15`). Grid lines use `hsl(var(--border))` with `strokeDasharray="2 2"`. Axis labels use `hsl(var(--muted-foreground))` in JetBrains Mono at `fontSize="9"`. Requires `data.length >= 2` (returns null otherwise).
 
 ### Hero Metric Card
 
 ```
 ┌─────────────────────────────────────────┐
 │ LABEL (11px, uppercase, muted)          │
-│ 34px bold mono value    [sparkline 110w]│
+│ 34px bold mono value   unit (xs, muted) │
 │ sub-label (11px, muted)                 │
+│ [sparkline 110w] (optional, below)      │
 └─────────────────────────────────────────┘
 ```
 
 ```tsx
 <div className="bg-card border border-border rounded-md p-4 flex flex-col gap-1">
   <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">{label}</p>
-  <div className="flex items-end justify-between gap-2">
-    <span className="text-[34px] font-bold font-mono leading-none text-foreground">{value}</span>
-    {sparklineData && <Sparkline data={sparklineData} color={sparklineColor} />}
+  <div className="flex items-baseline gap-1.5 mt-0.5">
+    <span
+      className="text-[34px] font-bold leading-none font-mono tabular-nums"
+      style={{ color: valueColor || "hsl(var(--foreground))" }}
+    >
+      {value}
+    </span>
+    {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
   </div>
-  {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+  {sub && <p className="text-[11px] text-muted-foreground mt-0.5">{sub}</p>}
+  {sparkData && sparkData.length > 1 && (
+    <div className="mt-2">
+      <Sparkline data={sparkData} color={sparkColor || "hsl(var(--primary))"} />
+    </div>
+  )}
+</div>
+```
+
+Note: sparkline renders **below** the value row, not beside it.
+
+### Secondary Stat Card
+
+```tsx
+<div className="bg-card border border-border rounded-md p-3">
+  <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground mb-1.5">{label}</p>
+  <div className="flex items-baseline gap-1">
+    <span className="text-[22px] font-bold font-mono text-foreground">{value}</span>
+    {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+  </div>
 </div>
 ```
 
 ### Latency Distribution Bar
 
-Gradient track (green→amber→red, 18% opacity), with needle markers at p50/p95/p99. Each marker: absolute-positioned, `w-0.5 h-6 rounded-sm` pin + `w-4 h-4 rounded-full border-2 ring-4` dot + label below.
+Gradient track (green→amber→red at 18% opacity), with absolute-positioned needle markers at p50/p95/p99. Each marker consists of:
+- A 1px-wide, 16px-tall vertical pin: `w-px h-4 mx-auto opacity-85`
+- A dot below it: `w-2 h-2 rounded-full mx-auto -mt-1` with `boxShadow: "0 0 0 2px hsl(var(--card))"` (creates the ring effect without Tailwind ring classes)
+- Value label + percentile label below
 
 ---
 
@@ -446,6 +551,8 @@ Gradient track (green→amber→red, 18% opacity), with needle markers at p50/p9
 | Warning | `text-warning`, `bg-warning/10` |
 | Info | `text-info`, `bg-info/10` |
 | Error | `text-destructive`, `bg-destructive/10` |
+| Method text (GET) | `method-get` (and `method-post`, `method-put`, etc.) |
+| Method bg (GET) | `bg-method-get` (and `bg-method-post`, etc.) |
 | Mono font | `font-mono` |
 | Code font (utility) | `font-code` |
 | Thin scrollbar | `scrollbar-thin` |
@@ -456,15 +563,16 @@ Gradient track (green→amber→red, 18% opacity), with needle markers at p50/p9
 - `bg-gray-*`, `bg-zinc-*`, `bg-slate-*` — use `bg-card`, `bg-panel`, `bg-background`
 - `bg-blue-50`, `bg-red-950`, etc. — use `bg-destructive/10`, `bg-info/10`, etc.
 - `dark:bg-*` hardcoded overrides — tokens handle both modes automatically
-- Hardcoded `purple` for Load Test / secondary actions — use `text-primary/border-primary/bg-primary/10`
-- `text-gray-500` — use `text-muted-foreground`
-- `text-gray-400` in dark — use `text-muted-foreground`
+- `text-gray-500`, `text-gray-400` — use `text-muted-foreground`
+- Hardcoded hex method colors like `text-[#22c55e]` — use `method-get` or `hsl(var(--method-get))`
+- `${hexColor}18` hex-alpha concatenation — use `hsl(var(--method-xxx) / 0.1)`
+- Hardcoded purple for Load Test / secondary actions — use `text-primary/border-primary/bg-primary/10`
 
 ---
 
 ## Response Body Syntax Highlighting
 
-For JSON pretty-printer and code viewer (planned / pending implementation):
+Planned / pending implementation. Intended colors for the JSON pretty-printer:
 
 | Token | Color |
 |-------|-------|
@@ -493,5 +601,8 @@ scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
 | `app/src/index.css` | All CSS custom properties, keyframes, utility classes |
 | `app/tailwind.config.js` | Color mapping, font families, keyframes, animation aliases |
 | `app/index.html` | Google Fonts preconnect + link tags |
-| `app/src/components/layout/Sidebar.tsx` | ActivityBar + SidebarPanel layout |
-| `app/src/components/layout/Shell.tsx` | Root layout (Sidebar + main) |
+| `app/src/components/layout/Shell.tsx` | Root layout — resizable sidebar + drag handle + main |
+| `app/src/components/layout/Sidebar.tsx` | ActivityBar + SidebarPanel |
+| `app/src/hooks/useResizable.ts` | Drag-to-resize hook (delta-based, horizontal/vertical) |
+| `app/src/utils/helpers.ts` | `getMethodColor(method)` → `var(--method-xxx)` |
+| `app/src/modules/dashboard/components/MetricsView.tsx` | Sparkline, SvgAreaChart, LatencyBar, HeroCard, StatCard |

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -1,0 +1,149 @@
+# Engine Database Schema
+
+Vayu uses SQLite via `sqlite_orm`. The schema is defined in `engine/src/db/database.cpp` and the
+struct definitions live in `engine/include/vayu/types.hpp`. `sync_schema()` adds new columns
+automatically on startup — no migration scripts are needed for additive changes.
+
+> **Breaking changes**: because Vayu is pre-release, destructive schema changes (column removal,
+> type changes) wipe the database rather than migrating it. The `PRAGMA user_version` is
+> not currently managed; wipe is done by deleting the `.db` file.
+
+---
+
+## Tables
+
+### `collections`
+
+Stores folder/group hierarchy for requests.
+
+| Column               | Type    | Notes                                        |
+|----------------------|---------|----------------------------------------------|
+| `id`                 | TEXT PK | UUID                                         |
+| `parent_id`          | TEXT    | NULL for root collections                    |
+| `name`               | TEXT    |                                              |
+| `description`        | TEXT    | Default `""`                                 |
+| `variables`          | TEXT    | JSON: `Record<string, VariableValue>`        |
+| `auth`               | TEXT    | JSON: `RequestAuth` (never `inherit`)        |
+| `pre_request_script` | TEXT    | Default `""`                                 |
+| `post_request_script`| TEXT    | Default `""`                                 |
+| `order`              | INTEGER | Sort order within parent; default 0          |
+| `created_at`         | INTEGER | Unix ms                                      |
+| `updated_at`         | INTEGER | Unix ms                                      |
+
+**auth** is a JSON discriminated union: `{"mode":"none"}` | `{"mode":"bearer","token":"..."}` |
+`{"mode":"basic","username":"...","password":"..."}` | `{"mode":"apikey","key":"...","value":"...","in":"header"|"query"}`.
+Collections are always auth sources — they never store `{"mode":"inherit"}`.
+
+**Cascade delete**: deleting a collection performs BFS to collect all descendant IDs, then
+deletes all their requests before deleting the collections deepest-first. See `Database::delete_collection()`.
+
+---
+
+### `requests`
+
+Stores individual HTTP request definitions.
+
+| Column                | Type    | Notes                                                |
+|-----------------------|---------|------------------------------------------------------|
+| `id`                  | TEXT PK | UUID                                                 |
+| `collection_id`       | TEXT    | FK → `collections.id` (not enforced by SQLite FK)   |
+| `name`                | TEXT    |                                                      |
+| `description`         | TEXT    | Default `""`                                         |
+| `method`              | TEXT    | `GET` / `POST` / `PUT` / `PATCH` / `DELETE` / etc.  |
+| `url`                 | TEXT    |                                                      |
+| `params`              | TEXT    | JSON array of `KeyValueEntry[]`                      |
+| `headers`             | TEXT    | JSON array of `KeyValueEntry[]`                      |
+| `body`                | TEXT    | JSON discriminated union (see below)                 |
+| `body_type`           | TEXT    | Denormalized mirror of `body.mode`; kept for queries |
+| `auth`                | TEXT    | JSON discriminated union (see below)                 |
+| `pre_request_script`  | TEXT    | Default `""`                                         |
+| `post_request_script` | TEXT    | Default `""`                                         |
+| `order`               | INTEGER | Sort order within collection; default 0              |
+| `created_at`          | INTEGER | Unix ms                                              |
+| `updated_at`          | INTEGER | Unix ms                                              |
+
+**params / headers** — stored as a JSON array of objects:
+```json
+[{"key":"Content-Type","value":"application/json","enabled":true,"description":""}]
+```
+Disabled rows (`"enabled":false`) are preserved in storage and filtered at HTTP-execution time only.
+Duplicate keys are allowed.
+
+**body** — discriminated union:
+```json
+{"mode":"none"}
+{"mode":"json"|"text"|"graphql","content":"..."}
+{"mode":"form-data"|"x-www-form-urlencoded","fields":[{"key":"...","value":"...","enabled":true}]}
+```
+
+**auth** — discriminated union (same shape as collection auth, plus `inherit`):
+```json
+{"mode":"none"}
+{"mode":"inherit"}                                        // resolved at execution time
+{"mode":"bearer","token":"..."}
+{"mode":"basic","username":"...","password":"..."}
+{"mode":"apikey","key":"...","value":"...","in":"header"|"query"}
+```
+
+---
+
+### `environments`
+
+Stores named variable sets.
+
+| Column       | Type    | Notes                                 |
+|--------------|---------|---------------------------------------|
+| `id`         | TEXT PK | UUID                                  |
+| `name`       | TEXT    |                                       |
+| `description`| TEXT    | Default `""`                          |
+| `variables`  | TEXT    | JSON: `Record<string, VariableValue>` |
+| `is_active`  | INTEGER | Boolean; 0 or 1                       |
+| `created_at` | INTEGER | Unix ms                               |
+| `updated_at` | INTEGER | Unix ms                               |
+
+---
+
+### `globals`
+
+Singleton table; always has exactly one row with `id = "globals"`.
+
+| Column       | Type    | Notes                                 |
+|--------------|---------|---------------------------------------|
+| `id`         | TEXT PK | Always `"globals"`                    |
+| `variables`  | TEXT    | JSON: `Record<string, VariableValue>` |
+| `updated_at` | INTEGER | Unix ms                               |
+
+---
+
+### `runs`
+
+Stores load-test and sanity-check run records.
+
+See `engine/include/vayu/types.hpp` (`db::Run`) for the full column list. Key fields:
+
+| Column       | Type    | Notes                                    |
+|--------------|---------|------------------------------------------|
+| `id`         | TEXT PK | UUID                                     |
+| `request_id` | TEXT    | FK → `requests.id` (optional)            |
+| `type`       | TEXT    | `"load"` or `"sanity"`                   |
+| `status`     | TEXT    | `"running"` / `"completed"` / `"failed"` |
+| `config`     | TEXT    | JSON snapshot of the run config          |
+| `summary`    | TEXT    | JSON aggregate metrics                   |
+| `created_at` | INTEGER | Unix ms                                  |
+| `updated_at` | INTEGER | Unix ms                                  |
+
+---
+
+## VariableValue shape
+
+Used in `collections.variables`, `environments.variables`, and `globals.variables`:
+
+```json
+{
+  "value": "https://api.example.com",
+  "enabled": true,
+  "secret": false
+}
+```
+
+`secret` is a UI masking hint only — values are not encrypted at rest.

--- a/docs/features/data-model-refactor-prd.md
+++ b/docs/features/data-model-refactor-prd.md
@@ -1,0 +1,585 @@
+# PRD: Data Model Refactor
+
+**Status:** Design  
+**Scope:** Tier 0+1+2 (storage fixes + inheritance), no workspaces  
+**Migration policy:** Breaking change, no backward compatibility (pre-release product, no users)
+
+## 1. Motivation
+
+Vayu's storage layer is silently losing user-entered data and forcing every import format to flatten richer source models into a poorer destination model. The frontend already models headers, params, and form-data fields as `KeyValueItem[]` with per-row `enabled` and `description` — but the storage layer collapses these into `Record<string, string>`, dropping disabled rows, duplicate keys, and descriptions. Reload the app and the user discovers their work is gone.
+
+This refactor aligns the storage layer with what the UI already models, and adds three composition concepts (auth inheritance, folder-level scripts, hierarchical variables) that are standard in Postman and Insomnia and that several entries in the [Import Format Mappings](./import-format-mappings.md) document are forced to flatten because Vayu can't represent them.
+
+## 2. Goals
+
+1. **No silent data loss** for any field the UI already exposes. Toggle a header off → it stays off across reloads. Add duplicate `Accept` headers → both persist.
+2. **Hierarchical composition** — auth, scripts, and variables defined at a parent collection apply to descendants without manual propagation.
+3. **Eliminate ~70% of documented import compromises** by raising the floor of the data model rather than weakening parsers.
+4. **No new engine execution logic.** All composition happens client-side as a pre-send step. The engine receives flat resolved values, same as today.
+5. **Schema clarity over backward compatibility.** This is a pre-release product; users have no data to preserve. The DB file is wiped on upgrade.
+
+## 3. Non-Goals
+
+- Workspaces (deferred — see "Future Work")
+- Saved response examples / Postman Examples-tab equivalent
+- Tags or labels on requests
+- Per-collection default environment binding
+- Drag-and-drop reordering UI (the `order` column is added to unblock it, but the UI is a separate effort)
+- URL stored as a structured object (host/path/query as separate columns)
+- Request-level config overrides (timeout, follow_redirects per request)
+- Migration infrastructure (`schema_migrations` table, numbered migration scripts). Not needed under nuke policy. Will be added before first public release.
+
+## 4. Current State (Concise)
+
+| Field | Engine DB | Engine wire (API) | Frontend state | Wire→state conversion |
+|---|---|---|---|---|
+| headers | JSON `Record<string,string>` | `Record<string,string>` | `KeyValueItem[]` with `enabled`, `description` | **Lossy:** disabled rows + descriptions dropped via `keyValueToRecord()` |
+| params | JSON `Record<string,string>` | Baked into URL by frontend | `KeyValueItem[]` | Same loss; also no engine-side parse |
+| body | JSON string | `{mode, content}` object | `bodyMode` + `body` string + `formData[]` + `urlEncoded[]` | `formData`/`urlEncoded` arrays serialized into flat string on save |
+| auth | JSON opaque blob | JSON object | `authType: AuthType` + `authConfig: Record<string,any>` | Lossless |
+| description | **No column** | Not in wire format | Used in UI for editing | Permanent loss on save |
+| collection.parent_id | optional string | `parentId` | Used for tree rendering | Lossless |
+| collection.variables | JSON `Record<string, VariableValue>` | same | `Record<string, VariableValue>` | Lossless; **no inheritance from parent collection** |
+| collection auth/scripts | **No columns** | Not in API | No UI | N/A |
+| request.order | **No column** | N/A | N/A | Requests are unordered |
+| environment.variables | JSON `Record<string, VariableValue>` | same | same | Lossless; no `type` field |
+
+**Variable resolution:** frontend-only for the HTTP request payload. Engine scripts have separate access to raw variable objects via `pm.environment` / `pm.globals` / `pm.collectionVariables`.
+
+**Cascade delete:** `delete_collection` removes a collection's direct requests but **does not** remove child collections — they become orphans pointing at a non-existent `parent_id`.
+
+## 5. New Data Model
+
+### 5.1 Engine — DB Schema
+
+#### `collections` table
+
+```
+id              TEXT PRIMARY KEY
+parent_id       TEXT NULL                  -- unchanged
+name            TEXT NOT NULL              -- unchanged
+description     TEXT NOT NULL DEFAULT ''   -- NEW
+variables       TEXT NOT NULL DEFAULT '{}' -- unchanged shape; values get `type` field
+auth            TEXT NOT NULL DEFAULT '{}' -- NEW; see Auth section
+pre_request_script  TEXT NOT NULL DEFAULT ''  -- NEW
+post_request_script TEXT NOT NULL DEFAULT ''  -- NEW
+"order"         INTEGER NOT NULL DEFAULT 0 -- unchanged
+created_at      INTEGER NOT NULL
+updated_at      INTEGER NOT NULL
+```
+
+#### `requests` table
+
+```
+id              TEXT PRIMARY KEY
+collection_id   TEXT NOT NULL              -- unchanged
+name            TEXT NOT NULL              -- unchanged
+description     TEXT NOT NULL DEFAULT ''   -- NEW
+method          TEXT NOT NULL              -- unchanged
+url             TEXT NOT NULL              -- unchanged
+params          TEXT NOT NULL DEFAULT '[]' -- CHANGED: array, not Record
+headers         TEXT NOT NULL DEFAULT '[]' -- CHANGED: array, not Record
+body            TEXT NOT NULL DEFAULT '{}' -- CHANGED: structured object, see Body section
+body_type       TEXT NOT NULL DEFAULT 'none' -- unchanged
+auth            TEXT NOT NULL DEFAULT '{}' -- unchanged shape (already structured)
+pre_request_script  TEXT NOT NULL DEFAULT ''  -- unchanged
+post_request_script TEXT NOT NULL DEFAULT ''  -- unchanged
+"order"         INTEGER NOT NULL DEFAULT 0 -- NEW
+created_at      INTEGER NOT NULL
+updated_at      INTEGER NOT NULL
+```
+
+#### `environments` table
+
+```
+id              TEXT PRIMARY KEY
+name            TEXT NOT NULL              -- unchanged
+description     TEXT NOT NULL DEFAULT ''   -- NEW
+variables       TEXT NOT NULL DEFAULT '{}' -- unchanged shape; values get `type` field
+is_active       INTEGER NOT NULL DEFAULT 0 -- unchanged
+created_at      INTEGER NOT NULL
+updated_at      INTEGER NOT NULL
+```
+
+#### `globals` table
+
+```
+id              TEXT PRIMARY KEY  -- always 'globals'
+variables       TEXT NOT NULL     -- unchanged shape; values get `type` field
+updated_at      INTEGER NOT NULL
+```
+
+### 5.2 Field-Level Schemas (JSON contents)
+
+#### Headers / Params — array of entries
+
+```typescript
+type KeyValueEntry = {
+  key: string;
+  value: string;
+  enabled: boolean;            // false = preserved but excluded at execution
+  description?: string;        // optional per-row note
+};
+
+// Stored as JSON in headers/params columns:
+// [{"key":"Accept","value":"application/json","enabled":true},
+//  {"key":"Accept","value":"text/html","enabled":false,"description":"alt format"}]
+```
+
+Order in the array is the user-facing order. Duplicates are allowed at any key. Disabled entries are dropped only at HTTP-execution time, not at storage time.
+
+#### Body — discriminated by mode
+
+```typescript
+type RequestBody =
+  | { mode: 'none' }
+  | { mode: 'json'; content: string }
+  | { mode: 'text'; content: string }
+  | { mode: 'graphql'; content: string }            // JSON-stringified {query, variables}
+  | { mode: 'form-data'; fields: KeyValueEntry[] }
+  | { mode: 'x-www-form-urlencoded'; fields: KeyValueEntry[] };
+```
+
+`body_type` column remains as a denormalized convenience (matches `body.mode`); enables querying without JSON parsing.
+
+#### Auth — uniform across requests and collections
+
+```typescript
+type RequestAuth =
+  | { mode: 'none' }
+  | { mode: 'inherit' }                              // only valid on requests, never on collections
+  | { mode: 'bearer'; token: string }
+  | { mode: 'basic'; username: string; password: string }
+  | { mode: 'apikey'; key: string; value: string; in: 'header' | 'query' }
+  | { mode: 'oauth2'; config: Record<string, unknown> }  // opaque, stored not executed
+  | { mode: 'digest' | 'aws' | 'ntlm'; config: Record<string, unknown> };  // same
+```
+
+- A request's `auth.mode === 'inherit'` triggers a parent-chain walk at execution time.
+- A collection's `auth.mode` can be any value **except** `'inherit'` (collections have no parent auth to inherit from in the request sense — they're the source).
+- A collection with `auth.mode === 'none'` is explicit: descendants that inherit will resolve to no auth.
+
+#### Variables (typed)
+
+```typescript
+type VariableValue = {
+  value: string;
+  enabled: boolean;
+  secret?: boolean;
+  type?: 'string' | 'number' | 'boolean' | 'json';  // default 'string'
+};
+```
+
+The `value` is always stored as a string regardless of `type`. The `type` field hints UI rendering (number input vs. text), validation, and how scripts cast the value when reading via `pm.environment.get(...)`.
+
+### 5.3 Wire Format (HTTP API)
+
+The HTTP API mirrors storage. The engine no longer transforms headers/params shape on read or write — it stores and returns the same JSON.
+
+**`POST /requests`** (create or update):
+
+```json
+{
+  "id": "req_optional",
+  "collectionId": "col_xxx",
+  "name": "List Users",
+  "description": "Returns paginated user list",
+  "method": "GET",
+  "url": "{{baseUrl}}/users",
+  "params": [
+    { "key": "page", "value": "1", "enabled": true },
+    { "key": "limit", "value": "20", "enabled": true, "description": "max 100" }
+  ],
+  "headers": [
+    { "key": "Accept", "value": "application/json", "enabled": true }
+  ],
+  "body": { "mode": "none" },
+  "bodyType": "none",
+  "auth": { "mode": "inherit" },
+  "preRequestScript": "",
+  "postRequestScript": "pm.test('status 200', () => pm.response.to.have.status(200));",
+  "order": 0
+}
+```
+
+**`POST /collections`** (create or update):
+
+```json
+{
+  "id": "col_optional",
+  "name": "Users API",
+  "description": "User management endpoints",
+  "parentId": null,
+  "order": 0,
+  "variables": {
+    "baseUrl": { "value": "https://api.example.com", "enabled": true, "type": "string" }
+  },
+  "auth": { "mode": "bearer", "token": "{{authToken}}" },
+  "preRequestScript": "// runs before every request in this collection",
+  "postRequestScript": ""
+}
+```
+
+**Cascade delete:** `DELETE /collections/:id` now removes the collection's direct requests AND recursively removes child collections and their requests, depth-first.
+
+### 5.4 Frontend Types
+
+`/home/user/vayu/app/src/types/domain.ts`:
+
+```typescript
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+
+export type BodyMode = 'none' | 'json' | 'text' | 'graphql' | 'form-data' | 'x-www-form-urlencoded';
+
+export type AuthMode = 'none' | 'inherit' | 'bearer' | 'basic' | 'apikey' | 'oauth2' | 'digest' | 'aws' | 'ntlm';
+
+export interface KeyValueEntry {
+  key: string;
+  value: string;
+  enabled: boolean;
+  description?: string;
+}
+
+export interface VariableValue {
+  value: string;
+  enabled: boolean;
+  secret?: boolean;
+  type?: 'string' | 'number' | 'boolean' | 'json';
+  createdAt?: number;
+}
+
+export type RequestBody =
+  | { mode: 'none' }
+  | { mode: 'json' | 'text' | 'graphql'; content: string }
+  | { mode: 'form-data' | 'x-www-form-urlencoded'; fields: KeyValueEntry[] };
+
+export type RequestAuth =
+  | { mode: 'none' | 'inherit' }
+  | { mode: 'bearer'; token: string }
+  | { mode: 'basic'; username: string; password: string }
+  | { mode: 'apikey'; key: string; value: string; in: 'header' | 'query' }
+  | { mode: 'oauth2' | 'digest' | 'aws' | 'ntlm'; config: Record<string, unknown> };
+
+export interface Collection {
+  id: string;
+  parentId?: string;
+  name: string;
+  description?: string;
+  order: number;
+  variables: Record<string, VariableValue>;
+  auth: Exclude<RequestAuth, { mode: 'inherit' }>;
+  preRequestScript: string;
+  postRequestScript: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Request {
+  id: string;
+  collectionId: string;
+  name: string;
+  description?: string;
+  method: HttpMethod;
+  url: string;
+  params: KeyValueEntry[];
+  headers: KeyValueEntry[];
+  body: RequestBody;
+  bodyType: BodyMode;          // denormalized, equals body.mode
+  auth: RequestAuth;
+  preRequestScript: string;
+  postRequestScript: string;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Environment {
+  id: string;
+  name: string;
+  description?: string;
+  variables: Record<string, VariableValue>;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+**The `KeyValueItem` UI-state type in `app/src/modules/request-builder/types.ts` becomes redundant.** It collapses into `KeyValueEntry` (the storage type already has `enabled` and `description`; the `id` field in UI-state was only needed for React `key` props and can be added as an ephemeral `_id` symbol or derived from array index in editor components).
+
+### 5.5 Variable Resolution — Hierarchical Walk
+
+`/home/user/vayu/app/src/hooks/useVariableResolver.ts`:
+
+Replace the current flat merge with a parent-chain walk for collection variables:
+
+```typescript
+// pseudocode
+function buildVariableMap(requestId, environmentId): Map<string, ResolvedVariable> {
+  const map = new Map();
+
+  // 1. Globals (lowest priority)
+  for (const [k, v] of globals.entries()) {
+    if (v.enabled) map.set(k, { value: castByType(v), scope: 'global', secret: v.secret });
+  }
+
+  // 2. Collection chain — walk from root to leaf, child overrides parent
+  const collectionChain = walkUpToRoot(request.collectionId);  // [root, ..., direct parent]
+  for (const collection of collectionChain) {
+    for (const [k, v] of Object.entries(collection.variables)) {
+      if (v.enabled) map.set(k, { value: castByType(v), scope: 'collection', secret: v.secret });
+    }
+  }
+
+  // 3. Environment (highest priority)
+  if (environmentId) {
+    for (const [k, v] of Object.entries(env.variables)) {
+      if (v.enabled) map.set(k, { value: castByType(v), scope: 'environment', secret: v.secret });
+    }
+  }
+
+  return map;
+}
+```
+
+`walkUpToRoot` traverses `parentId` from the request's direct collection up to the root, returning the array in **root-first** order. Variables defined closer to the leaf override variables defined closer to the root.
+
+### 5.6 Auth Composition
+
+A request with `auth.mode === 'inherit'`:
+
+1. Frontend walks `parentId` chain from the request's direct collection upward.
+2. First collection whose `auth.mode !== 'none'` wins. Its auth is applied.
+3. If the entire chain has `auth.mode === 'none'`, no auth is applied.
+
+A request with any other `auth.mode` value uses its own auth and ignores the chain.
+
+This resolution happens in `useEngine.ts` immediately before constructing the execution payload. The engine receives a fully resolved auth blob, never `'inherit'`.
+
+### 5.7 Script Composition
+
+For each execution, the frontend composes the final `preRequestScript` and `postRequestScript` strings:
+
+```
+preRequestScript = [
+  rootCollection.preRequestScript,
+  ...intermediateCollections.map(c => c.preRequestScript),
+  directParent.preRequestScript,
+  request.preRequestScript,
+].filter(nonEmpty).join('\n\n// ─── scope boundary ─── \n\n');
+
+postRequestScript = [
+  request.postRequestScript,
+  directParent.postRequestScript,
+  ...intermediateCollections.reverse().map(c => c.postRequestScript),
+  rootCollection.postRequestScript,
+].filter(nonEmpty).join('\n\n// ─── scope boundary ─── \n\n');
+```
+
+Pre-request scripts run **outer-first** (root → leaf → request) so child scripts see state set by parents. Post-request scripts run **inner-first** (request → leaf → root) so they tear down in reverse order. This matches Postman's behavior.
+
+Concatenation is done client-side; the engine receives a single combined script for each phase.
+
+### 5.8 Cascade Delete
+
+`/home/user/vayu/engine/src/db/database.cpp` — `delete_collection`:
+
+```cpp
+void Database::delete_collection(const std::string& id) {
+    std::lock_guard<std::recursive_mutex> lock(impl_->mutex);
+
+    // 1. Find all descendant collection IDs recursively
+    std::vector<std::string> to_delete = {id};
+    size_t idx = 0;
+    while (idx < to_delete.size()) {
+        auto children = impl_->storage.get_all<Collection>(
+            where(c(&Collection::parent_id) == to_delete[idx])
+        );
+        for (const auto& child : children) to_delete.push_back(child.id);
+        idx++;
+    }
+
+    // 2. Delete in reverse-discovery order (deepest first)
+    for (auto it = to_delete.rbegin(); it != to_delete.rend(); ++it) {
+        impl_->storage.remove_all<Request>(where(c(&Request::collection_id) == *it));
+        impl_->storage.remove_all<Collection>(where(c(&Collection::id) == *it));
+    }
+}
+```
+
+## 6. Implementation Phases
+
+### Phase 1 — Engine schema + API (no UI changes)
+
+1. **DB struct changes** in `engine/include/vayu/types.hpp`:
+   - Add `description`, `auth`, `pre_request_script`, `post_request_script` to `db::Collection`
+   - Add `description`, `order` to `db::Request`
+   - Add `description` to `db::Environment`
+2. **Schema definition** in `engine/src/db/database.cpp` — update `make_table()` calls.
+3. **JSON (de)serialization** in `engine/src/utils/json.cpp` — update `serialize`/`deserialize` for new fields.
+4. **Cascade delete** in `database.cpp::delete_collection`.
+5. **Routes** in `engine/src/http/routes/collections.cpp` and `requests.cpp` — accept and persist new fields. The engine **does not** validate `params`/`headers` array shape — it stores the JSON verbatim (same way it currently stores opaque `auth` JSON).
+6. **Drop the DB file** on engine startup if it exists (single-shot nuke). Optionally guarded by a build flag so dev environments can be rebuilt fresh.
+
+### Phase 2 — Frontend types + storage layer
+
+1. **`types/domain.ts`** — replace types per section 5.4.
+2. **`types/api.ts`** — update `CreateRequestRequest`, `UpdateRequestRequest`, `CreateCollectionRequest` shapes.
+3. **`services/transformers/`** — remove `keyValueToRecord` calls; transformers now pass through `params`/`headers` as arrays.
+4. **`services/api.ts`** — type updates only; HTTP shape mirrors storage.
+5. **Default values** — `Request.body` defaults to `{ mode: 'none' }`, `Request.auth` defaults to `{ mode: 'inherit' }`, collection auth defaults to `{ mode: 'none' }`.
+
+### Phase 3 — Frontend composition layer
+
+1. **`hooks/useVariableResolver.ts`** — implement parent-chain walk per section 5.5.
+2. **`hooks/useEngine.ts`** — before executing, compose auth (resolve `inherit`) and scripts (concatenate chain). Pass composed values to the engine.
+3. **`queries/collections.ts`** — add a helper `useCollectionAncestors(collectionId)` that returns the chain (root → leaf) so resolution can use the TanStack Query cache.
+
+### Phase 4 — UI updates
+
+1. **Request builder** — header/param editor reads/writes `KeyValueEntry[]` directly; remove the dual-type dance (`KeyValueItem` UI state vs `Record<string,string>` storage). The editor already supports the richer shape; the conversion functions just go away.
+2. **Collection editor** — new sections for description, auth, pre/post scripts. New routes (e.g., `/collections/:id/settings`).
+3. **Auth picker** — add `'inherit'` as an option on request-level auth selector. Display resolved auth inline ("Inheriting Bearer from 'Users API' collection").
+4. **Variables editor** — add `type` selector dropdown next to each variable. Inputs become typed (number input for `type: 'number'`).
+5. **Order field on requests** — no UI yet; just respect it for sorting in the collection tree.
+
+### Phase 5 — Update import PRD
+
+1. Revise `import-format-mappings.md` — remove eliminated compromises from the tables.
+2. Update parser implementations (when we build them) to use the new types directly. Postman folder-level auth/scripts now map cleanly; Insomnia disabled entries preserved; descriptions round-trip.
+
+## 7. Detailed File Impact Map
+
+### Engine
+
+| File | Change |
+|---|---|
+| `engine/include/vayu/types.hpp` | Add fields to `db::Collection`, `db::Request`, `db::Environment` |
+| `engine/src/db/database.cpp` | Update schema in `make_storage()`; rewrite `delete_collection` for cascade |
+| `engine/src/utils/json.cpp` | Add (de)serialization for new fields |
+| `engine/src/http/routes/collections.cpp` | Accept/return new fields in POST `/collections` |
+| `engine/src/http/routes/requests.cpp` | Accept/return new fields in POST `/requests`; new `order` handling |
+| `engine/src/http/routes/environments.cpp` | Accept/return `description` |
+| `engine/src/daemon.cpp` (or wherever DB init lives) | One-shot nuke: delete DB file on startup if old schema detected |
+| `engine/tests/` | New unit tests for cascade delete, new field round-trips |
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `app/src/types/domain.ts` | Replace all types per section 5.4 |
+| `app/src/types/api.ts` | Update request/response shapes |
+| `app/src/services/transformers/collection-transformer.ts` | Pass through new fields; no `keyValueToRecord` |
+| `app/src/services/transformers/request-transformer.ts` | Same |
+| `app/src/services/api.ts` | Type updates only |
+| `app/src/hooks/useVariableResolver.ts` | Parent-chain walk; type-aware casting |
+| `app/src/hooks/useEngine.ts` | Compose auth + scripts before sending |
+| `app/src/queries/collections.ts` | Add ancestor helper |
+| `app/src/modules/request-builder/types.ts` | Delete `KeyValueItem`; use `KeyValueEntry` from domain |
+| `app/src/modules/request-builder/utils/key-value.ts` | **Delete** `keyValueToRecord` and `recordToKeyValue` |
+| `app/src/modules/request-builder/shared/KeyValueEditor/` | Bind directly to `KeyValueEntry[]` |
+| `app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx` | Add `'inherit'` mode; show resolved-from indicator |
+| `app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx` | Remove `buildUrlWithParams`; engine no longer needs URL-baked params (or keep as resolver step) |
+| `app/src/modules/variables/` | Add `type` dropdown per variable; typed inputs |
+| `app/src/modules/collections/` (new files) | Collection settings view: description, auth, scripts editors |
+
+## 8. Open Questions
+
+1. **`params` execution path.** Currently, the frontend bakes query params into the URL string before sending. Should we keep doing that, or send `params` separately and let the engine append them? Sending separately would enable engine-side scripts to mutate `pm.request.params` and have it affect the final URL. Recommendation: **send separately**, append in engine. This is a small engine change but architecturally cleaner.
+
+2. **Script scope boundary comments.** Inserting `// ─── scope boundary ───` between concatenated scripts is helpful for stack traces but is just a string. Should we use sourcemap-style metadata so errors can be attributed to the correct collection? Recommendation: defer — concat with comments is fine for V1.
+
+3. **`auth.mode === 'inherit'` for collections?** I propose collections cannot inherit (they're the source). Alternative: collections can also inherit from their parent collection. Recommendation: keep collections non-inheriting in V1; revisit if real workflows demand it.
+
+4. **`variables` `type: 'json'` semantics.** Should JSON-typed variables be auto-parsed when interpolated into a JSON request body (so `{{user}}` → `{"id":1}` not `"{\"id\":1}"`)? Recommendation: yes, but only when the surrounding context is JSON. Track as a follow-up; initial implementation treats it as string.
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Wire format change breaks any external scripts/integrations | None exist; pre-release |
+| Cascade delete becomes accidentally destructive | Add UI confirmation dialog ("Delete 'Users API' and 18 child items?") |
+| Script concatenation produces hard-to-debug errors | Scope-boundary comments + future sourcemap work |
+| Hierarchical variable walk is slow for deep trees | Cache the merged var map per request; invalidate on parent collection edit |
+| Engine accepts arbitrary JSON in `params`/`headers` without validation | Add lightweight schema check; reject if not array of `{key, value, enabled}` |
+| Frontend `KeyValueEntry` array order matters for execution but is fragile | Use stable array indices; preserve order on save |
+
+## 10. Future Work (Explicitly Deferred)
+
+- **Workspaces** — top-level grouping above collections
+- **Saved examples** — `examples` table linked to requests
+- **Tags on requests** — `tags TEXT` column with comma-separated values
+- **Per-collection default environment** — `default_environment_id` on collections
+- **Drag-and-drop reordering** — UI for the `order` columns we're adding now
+- **Engine-side variable resolution** — pass the var map to the engine; let it resolve templates. Enables server-side scripts to see unresolved templates.
+- **Migration infrastructure** — `schema_migrations` table + numbered migration scripts. Required before first public release.
+
+## 11. Integration Review Findings
+
+A codebase audit against this design surfaced six concrete integration points that needed explicit handling beyond the original plan.
+
+### 11.1 Engine internal type stays flat
+
+`vayu::Headers` is `std::map<string,string>` in `engine/include/vayu/types.hpp:110`. The HTTP client (`engine/src/http/client.cpp:247-250`) converts this to a `curl_slist`. **This internal model does not change.** What changes is the wire-format deserialization step: `engine/src/utils/json.cpp:276-280` must now parse the incoming array, drop entries where `enabled === false`, drop the `description` field, and flatten into the existing `Headers` map. Same pattern for params if we choose to send them separately (see 11.6).
+
+Scripts continue to see headers as a flat JS object via `pm.request.headers`. **No script API break.**
+
+### 11.2 Form-data and urlencoded body serialization moves to the engine
+
+Today the frontend serializes form fields into a flat string (`key=value&key2=value2`) before sending. With the new wire format `body: { mode: 'form-data', fields: [...] }`, the engine must:
+
+- For `mode: 'form-data'`: build a multipart body with proper `Content-Type: multipart/form-data; boundary=...` header
+- For `mode: 'x-www-form-urlencoded'`: URL-encode each enabled field and join with `&`
+
+This was implicit in section 5.2 but is a non-trivial addition to `engine/src/utils/json.cpp:283-312` and `engine/src/http/client.cpp`. Add a unit test that round-trips each body mode.
+
+### 11.3 `runs.config_snapshot` becomes a one-shot loss
+
+Run records snapshot the request config as JSON into `runs.config_snapshot`. Pre-refactor snapshots have headers as `Record<string,string>`, post-refactor as `KeyValueEntry[]`. Two options:
+
+- **Versioned snapshot** with a `schemaVersion` field and a transform-on-read in the history viewer
+- **Accept the loss** consistent with nuke policy — old runs become unviewable, treat history as ephemeral
+
+**Decision:** Accept the loss. The runs table is wiped along with the DB. Document in release notes when we eventually ship: "Run history does not survive the V1 schema change."
+
+### 11.4 Five call sites that depend on the old Record shape
+
+The audit found these locations that will break and must be updated as part of Phase 4:
+
+| File | Line | Issue |
+|---|---|---|
+| `app/src/modules/request-builder/index.tsx` | 261 | `Object.entries(headersRecord).map(...)` — passes flat Record to a child component |
+| `app/src/modules/request-builder/index.tsx` | 312 | `Object.entries(keyValueToRecord(...))` — double conversion, will be removed |
+| `app/src/hooks/useEngine.ts` | ~55 | Already passes `request.headers` as a Record at execution; type mismatch with `RequestState.headers: KeyValueItem[]` exists today and is masked by the conversion |
+| `app/src/types/api.ts` | 149–154 | `StartLoadTestRequest.headers?: Record<string, string>` — must become `KeyValueEntry[]` |
+| `engine/tests/json_test.cpp` | 46 | Test fixture has headers as JSON object — rewrite to array form |
+
+### 11.5 Request ordering UI must be wired
+
+The design doc adds `Request.order` but the audit confirmed `CollectionTree.tsx` does not currently sort requests within a collection — they render in arbitrary DB order. Add a `compareRequestOrder()` companion to the existing `compareCollectionOrder()` in `domain.ts` and apply it in the tree render. The DnD UI is still out of scope for this refactor, but the sort must work or the new `order` column has no effect.
+
+### 11.6 Params handling — decision moved out of "open questions"
+
+The audit confirmed:
+- Engine has no `params` field in `vayu::Request` (`types.hpp:104-108`)
+- Frontend bakes params into the URL via `buildUrlWithParams()` in `ParamsPanel.tsx:26-45`
+- Scripts cannot read `pm.request.params` (not exposed)
+
+**Decision for this refactor:** Keep params as `KeyValueEntry[]` on the request object in storage and wire format (for UI fidelity — disabled rows, descriptions, duplicates), but **continue baking them into the URL on the frontend** before sending to the engine. The engine receives a URL with the query string already attached, exactly as today.
+
+Rationale: separating params at the engine level is a meaningful additional refactor (script `pm.request.params` exposure, URL builder in C++, encoding edge cases). It's clean future work but doesn't pay for itself in this PRD. Track as deferred work in section 10.
+
+This means `params` round-trips faithfully through storage but at execution time still gets flattened to `Record<string,string>` (enabled only) and concatenated into the URL — the same lossy step that exists today, but only for the wire-to-execute hop, not for storage.
+
+## 12. Acceptance Criteria
+
+- [ ] User can disable a header, save, reload — disabled state persists
+- [ ] User can add two headers with the same key — both persist and both are sent
+- [ ] User can attach a description to a header — visible on reload
+- [ ] User can set a description on a collection and a request — visible on reload
+- [ ] User can set Bearer auth on a collection — every descendant request with `auth.mode: 'inherit'` sends that Bearer
+- [ ] User can set a pre-request script on a collection — runs before every descendant request
+- [ ] Variable defined on root collection is visible to a request in a deeply nested sub-collection
+- [ ] Deleting a parent collection deletes all descendants and their requests
+- [ ] Variable can be marked as `type: 'number'` — UI renders a number input
+- [ ] Request reorder via API (`POST /requests` with new `order`) persists and is reflected in collection tree
+- [ ] No `keyValueToRecord` / `recordToKeyValue` calls remain in the frontend codebase

--- a/docs/features/data-model-refactor-prd.md
+++ b/docs/features/data-model-refactor-prd.md
@@ -482,26 +482,30 @@ void Database::delete_collection(const std::string& id) {
 | `app/src/modules/variables/` | Add `type` dropdown per variable; typed inputs |
 | `app/src/modules/collections/` (new files) | Collection settings view: description, auth, scripts editors |
 
-## 8. Open Questions
+## 8. Resolved Decisions
 
-1. **`params` execution path.** Currently, the frontend bakes query params into the URL string before sending. Should we keep doing that, or send `params` separately and let the engine append them? Sending separately would enable engine-side scripts to mutate `pm.request.params` and have it affect the final URL. Recommendation: **send separately**, append in engine. This is a small engine change but architecturally cleaner.
+The following questions were raised during design and resolved with the noted decisions. They are committed scope, not open items.
 
-2. **Script scope boundary comments.** Inserting `// ─── scope boundary ───` between concatenated scripts is helpful for stack traces but is just a string. Should we use sourcemap-style metadata so errors can be attributed to the correct collection? Recommendation: defer — concat with comments is fine for V1.
+1. **`params` execution path.** Decided in §11.6 — `params` stored and round-tripped as `KeyValueEntry[]`, but the frontend continues to bake the enabled subset into the URL string before sending to the engine. Engine-side `params` parsing and `pm.request.params` script exposure are tracked in §10 as future work.
 
-3. **`auth.mode === 'inherit'` for collections?** I propose collections cannot inherit (they're the source). Alternative: collections can also inherit from their parent collection. Recommendation: keep collections non-inheriting in V1; revisit if real workflows demand it.
+2. **Script scope boundary comments.** Concatenated scripts are joined with `// ─── scope boundary ─── ` plain-string comments. No sourcemap metadata in V1. Errors attributed by string-search if needed; sourcemap support tracked in §10.
 
-4. **`variables` `type: 'json'` semantics.** Should JSON-typed variables be auto-parsed when interpolated into a JSON request body (so `{{user}}` → `{"id":1}` not `"{\"id\":1}"`)? Recommendation: yes, but only when the surrounding context is JSON. Track as a follow-up; initial implementation treats it as string.
+3. **`auth.mode === 'inherit'` for collections?** Collections cannot inherit. They are always the auth source. A collection's `auth.mode` may be `'none'` or any concrete type, never `'inherit'`. The type system enforces this — collection auth is typed as `Exclude<RequestAuth, { mode: 'inherit' }>`.
 
-## 9. Risks
+4. **`variables` `type: 'json'` semantics.** Initial implementation treats all variable values as strings during interpolation, regardless of `type`. The `type` field only affects UI rendering (number input vs text) and validation. Context-aware interpolation (auto-parsing JSON-typed variables when substituted into a JSON body) is tracked in §10 as future work.
 
-| Risk | Mitigation |
+## 9. Risks and Mitigations
+
+All mitigations below are committed decisions, not proposals.
+
+| Risk | Mitigation (committed) |
 |---|---|
-| Wire format change breaks any external scripts/integrations | None exist; pre-release |
-| Cascade delete becomes accidentally destructive | Add UI confirmation dialog ("Delete 'Users API' and 18 child items?") |
-| Script concatenation produces hard-to-debug errors | Scope-boundary comments + future sourcemap work |
-| Hierarchical variable walk is slow for deep trees | Cache the merged var map per request; invalidate on parent collection edit |
-| Engine accepts arbitrary JSON in `params`/`headers` without validation | Add lightweight schema check; reject if not array of `{key, value, enabled}` |
-| Frontend `KeyValueEntry` array order matters for execution but is fragile | Use stable array indices; preserve order on save |
+| Wire format change breaks any external scripts/integrations | None exist; pre-release product. No mitigation needed. |
+| Cascade delete becomes accidentally destructive | Add a UI confirmation dialog before any collection delete that has descendants. Format: `"Delete 'Users API' and 18 child items?"` — count must include all descendant collections + all requests across them. Dialog only shown when descendants exist (leaf collections delete without confirmation). |
+| Script concatenation produces hard-to-debug errors | Scope-boundary comments between concatenated script blocks. Sourcemap-style metadata deferred to §10. |
+| Hierarchical variable walk is slow for deep trees | Cache the merged variable map per `(requestId, environmentId)` pair in a `useMemo`. Invalidate when any of the following change: the request's `collectionId`, any ancestor collection's `variables`, the active environment's `variables`, or globals. Use TanStack Query cache keys for ancestor invalidation. |
+| Engine accepts arbitrary JSON in `params`/`headers` without validation | Add a lightweight schema check in `engine/src/http/routes/requests.cpp` on `POST /requests`. Reject (HTTP 400) if `params` or `headers` is not an array, or if any entry lacks `key` (string), `value` (string), or `enabled` (boolean). `description` is optional. Return error: `"Invalid headers entry at index N: missing required field 'enabled'"`. |
+| Frontend `KeyValueEntry` array order matters for execution but is fragile | Storage and wire format preserve array order as authored. The `KeyValueEditor` component uses stable array indices for React keys (or an ephemeral `_id` symbol attached client-side). On save, the array is sent verbatim — no reordering, no deduplication, no sorting. |
 
 ## 10. Future Work (Explicitly Deferred)
 
@@ -570,7 +574,65 @@ Rationale: separating params at the engine level is a meaningful additional refa
 
 This means `params` round-trips faithfully through storage but at execution time still gets flattened to `Record<string,string>` (enabled only) and concatenated into the URL — the same lossy step that exists today, but only for the wire-to-execute hop, not for storage.
 
-## 12. Acceptance Criteria
+## 12. Documentation Updates Required
+
+The refactor invalidates field shapes, wire formats, and behavior described in several existing docs. Each must be updated as part of the implementation work, not after. Group them into the same PR as the corresponding code phase so the docs never lag behind the code.
+
+### Update with Phase 1 (engine schema + API)
+
+| File | Section / change |
+|---|---|
+| `docs/engine/api-reference.md` | Lines 65–82: `POST /collections` body schema — add `description`, `auth`, `preRequestScript`, `postRequestScript`. Lines 112–148: `POST /requests` body schema — change `params` and `headers` from `{}` (object) to `[]` (array of `KeyValueEntry`), change `body` from string to `{mode, content?, fields?}` discriminated object, add `description` and `order`. Lines 172–205: `POST /environments` — add `description`. Lines 240–250: globals — add `type` to variable value shape. Update `DELETE /collections/:id` to document the new cascade semantics. |
+| `docs/engine/architecture.md` | Update the DB schema diagram or list to reflect the new columns on `collections`, `requests`, `environments`. Note the cascade-delete behavior. |
+| `docs/request-storage-design.md` | Lines 26, 58, 64, 93: example JSON blobs show `headers` as an object — rewrite to `KeyValueEntry[]` array form. Update the "execution flow" section if it describes header flattening (now happens engine-side, not frontend-side). |
+
+### Update with Phase 2 (frontend types)
+
+| File | Section / change |
+|---|---|
+| `docs/app/api-integration.md` | Any example request/response payload showing headers/params/body as flat shapes. Mirror the engine API reference changes. |
+| `docs/app/state-management.md` | Remove references to `KeyValueItem` UI-only type and the `keyValueToRecord` / `recordToKeyValue` helpers. The `RequestState` shape now matches the domain `Request` shape directly. |
+| `docs/app/COMPONENTS.md` | If it documents `KeyValueEditor` props as accepting `KeyValueItem[]`, retype to `KeyValueEntry[]`. |
+
+### Update with Phase 3 (composition layer)
+
+| File | Section / change |
+|---|---|
+| `docs/request-storage-design.md` | "Variable Resolution" section — replace the flat 3-tier merge description with the new hierarchical walk (globals → parent-chain collections root-to-leaf → environment). Add a note that resolution caches per `(requestId, environmentId)`. |
+| `docs/engine/scripting.md` | If it documents script execution order, add a section explaining that pre-request scripts now run outer-to-inner (root collection → leaf collection → request) and post-request scripts run inner-to-outer. Note that scripts are concatenated client-side with scope-boundary comments. |
+
+### Update with Phase 4 (UI)
+
+| File | Section / change |
+|---|---|
+| `docs/design-system.md` | If it has component patterns for KeyValueEditor or auth selectors, update for the new `enabled`/`description` per-row fields and the `'inherit'` auth option. |
+| `docs/app/architecture.md` | Note the new collection settings view (description, auth, scripts editors) in the module map. |
+
+### Update with Phase 5 (import PRD revisions)
+
+| File | Section / change |
+|---|---|
+| `docs/features/import-collections-prd.md` | "Out of Scope" section — review whether any deferred items are now achievable. Update "What this means for the Import PRD" cross-reference. |
+| `docs/features/import-format-mappings.md` | **Compromise Summary** tables (all four: Universal, Postman, Insomnia, OpenAPI) — strike through compromises eliminated by the refactor. Specifically: drop "disabled silently skipped", "duplicate keys collapse", "description fields dropped", "form-data flattened", "folder-level scripts dropped", "auth inheritance baked in at parse time", "variable type metadata dropped", "Postman `secret` flag". Add a header note: "Updated after data-model refactor v1." |
+
+### New docs to create (during this refactor)
+
+| File | Why |
+|---|---|
+| `docs/engine/db-schema.md` | The engine has no canonical schema reference today — schema is buried in `database.cpp`. Create a single source-of-truth doc describing every table, column, and JSON-field shape. Cross-link from `engine/architecture.md` and `request-storage-design.md`. |
+| `docs/app/variable-resolution.md` | Hierarchical variable walk + caching strategy deserves a dedicated doc rather than burying in `request-storage-design.md`. Include the resolution diagram and the cache invalidation rules from §9. |
+
+### Verification
+
+Before merging the final phase, grep the docs tree for stale terms that should no longer appear:
+
+```
+grep -rn "KeyValueItem\|keyValueToRecord\|recordToKeyValue\|headers.*Record<string\|params.*Record<string" docs/
+```
+
+This should return zero results outside `data-model-refactor-prd.md` (which describes the old state as context) and `import-format-mappings.md` (which describes the per-format mappings).
+
+## 13. Acceptance Criteria
 
 - [ ] User can disable a header, save, reload — disabled state persists
 - [ ] User can add two headers with the same key — both persist and both are sent

--- a/docs/features/import-collections-prd.md
+++ b/docs/features/import-collections-prd.md
@@ -84,7 +84,17 @@ app/src/modules/collections/
 
 ### Core Interfaces
 
+These mirror the post-refactor domain types in `app/src/types/domain.ts`. Drafts use the same shapes as the persisted entities so the orchestrator can pass them straight to the create endpoints (minus server-assigned fields like `id`, `createdAt`, `updatedAt`).
+
 ```typescript
+import type {
+  HttpMethod,
+  KeyValueEntry,
+  RequestBody,
+  RequestAuth,
+  VariableValue,
+} from "@/types";
+
 interface ImportParser {
   readonly formatName: string;       // "Postman Collection v2.1"
   readonly formatKey: string;        // "postman-v21"
@@ -100,26 +110,35 @@ interface ImportResult {
 
 interface CollectionDraft {
   name: string;
+  description: string;
   variables: Record<string, VariableValue>;
+  // Collections are always concrete auth sources (never "inherit")
+  auth: Exclude<RequestAuth, { mode: "inherit" }>;
+  preRequestScript: string;
+  postRequestScript: string;
   children: CollectionDraft[];       // Sub-folders (recursive)
   requests: RequestDraft[];          // Requests directly in this collection
 }
 
 interface RequestDraft {
   name: string;
+  description: string;
   method: HttpMethod;
   url: string;
-  params: Record<string, string>;
-  headers: Record<string, string>;
-  body: string;
-  bodyType: "json" | "text" | "form-data" | "x-www-form-urlencoded" | "none";
-  auth: Record<string, unknown>;
+  // Arrays — preserves disabled rows and duplicate keys
+  params: KeyValueEntry[];
+  headers: KeyValueEntry[];
+  // Discriminated union — engine reads body.mode to know how to interpret it
+  body: RequestBody;
+  // Discriminated union — "inherit" is allowed and resolved at execution time
+  auth: RequestAuth;
   preRequestScript: string;
   postRequestScript: string;
 }
 
 interface EnvironmentDraft {
   name: string;
+  description: string;
   variables: Record<string, VariableValue>;
 }
 
@@ -133,7 +152,7 @@ interface ImportMeta {
 
 interface ImportOptions {
   importEnvironments: boolean;       // Checkbox: "Import environments & variables"
-  importScripts: boolean;            // Checkbox: "Import pre-request & test scripts"
+  importScripts: boolean;            // Checkbox: "Import pre-request & test scripts" (applies to both collection and request scripts)
 }
 ```
 
@@ -209,5 +228,5 @@ If no parser matches: show error state "Unrecognised format".
 - Bruno `.bru` format
 - Postman standalone environment JSON import
 - Postman workspace-level data export (ZIP)
-- GraphQL-specific body type
-- OAuth2 token execution (stored as JSON, not executed)
+- OAuth2 / Digest / AWS / NTLM token execution (auth stored as JSON, not executed)
+- File / binary request bodies (no file attachment support in Vayu)

--- a/docs/features/import-collections-prd.md
+++ b/docs/features/import-collections-prd.md
@@ -1,0 +1,213 @@
+# PRD: Collection Import
+
+## Problem Statement
+
+Vayu has no import capability. Users migrating from Postman or Insomnia must recreate every request manually — a hard adoption blocker. API teams that standardise on OpenAPI specs also have no path to generate a working request collection in Vayu.
+
+## Goal
+
+Allow users to import request collections from external tools with a single file drop. The result should be immediately usable in Vayu with minimal post-import editing.
+
+## Scope (V1)
+
+| Format | Version | Source |
+|---|---|---|
+| Postman Collection | v2.1 | JSON export from Postman app |
+| Postman Collection | v2.0 | JSON export from older Postman versions |
+| Insomnia Export | v4 | JSON export from Insomnia app |
+| OpenAPI / Swagger | 3.0.x | JSON or YAML spec file |
+| OpenAPI / Swagger | 2.0 | JSON or YAML Swagger spec file |
+
+**Deferred:** Bruno (non-JSON `.bru` DSL), Postman Environment files as standalone import, workspace-level Postman data exports.
+
+## Entry Points
+
+Two places trigger the import modal:
+
+1. **Collections sidebar header** — download icon button (always accessible)
+2. **Welcome screen** — "Import Collection" quick action button
+
+## User Flow
+
+```
+User opens modal
+  └─ Tab: File (default) | URL | Paste JSON
+
+  [File tab]
+    Drop zone → user drops or clicks to browse
+    → Detecting… (spinner, ~900ms parse time)
+    → Preview state
+
+  [URL tab]
+    Input URL → click Fetch
+    → Engine proxies GET request (POST /import/fetch)
+    → Detecting… → Preview state
+
+  [Paste tab]
+    Textarea → click "Detect & Preview"
+    → Detecting… → Preview state
+
+  [Preview state]
+    Green badge: "✓ Postman Collection v2.1 · production-api.json"
+    Tree preview: folders + request list (max-height scroll)
+    Stats: "12 requests · 3 folders · 2 environments"
+    Options:
+      ☑ Import environments & variables
+      ☑ Import pre-request & test scripts
+    Buttons: [Cancel] [Import →]
+
+  [Importing state]
+    Button shows spinner + "Importing…"
+    Sequential API calls to engine
+    On complete: modal closes, collections sidebar refreshes
+```
+
+## Architecture
+
+### Frontend — Factory Pattern
+
+All parsing is done in the frontend (TypeScript). No new engine parsing logic needed for file/paste/URL-body content.
+
+```
+app/src/services/importers/
+  types.ts          — ImportParser interface, ImportResult, ImportOptions
+  factory.ts        — ImportParserFactory.detect(rawString) → ImportParser
+  postman.ts        — PostmanV21Parser + PostmanV20Parser
+  insomnia-v4.ts    — InsomniaV4Parser
+  openapi-v3.ts     — OpenApiV3Parser
+  openapi-v2.ts     — OpenApiV2Parser (Swagger)
+  orchestrator.ts   — ImportOrchestrator: calls apiService sequentially
+
+app/src/modules/collections/
+  ImportModal.tsx   — Modal UI: tabs, drop zone, preview tree, options
+```
+
+### Core Interfaces
+
+```typescript
+interface ImportParser {
+  readonly formatName: string;       // "Postman Collection v2.1"
+  readonly formatKey: string;        // "postman-v21"
+  detect(raw: string): boolean;      // Returns true if this parser owns this input
+  parse(raw: string, opts: ImportOptions): ImportResult;
+}
+
+interface ImportResult {
+  collections: CollectionDraft[];    // Root collections (parentId = null)
+  environments: EnvironmentDraft[];
+  meta: ImportMeta;
+}
+
+interface CollectionDraft {
+  name: string;
+  variables: Record<string, VariableValue>;
+  children: CollectionDraft[];       // Sub-folders (recursive)
+  requests: RequestDraft[];          // Requests directly in this collection
+}
+
+interface RequestDraft {
+  name: string;
+  method: HttpMethod;
+  url: string;
+  params: Record<string, string>;
+  headers: Record<string, string>;
+  body: string;
+  bodyType: "json" | "text" | "form-data" | "x-www-form-urlencoded" | "none";
+  auth: Record<string, unknown>;
+  preRequestScript: string;
+  postRequestScript: string;
+}
+
+interface EnvironmentDraft {
+  name: string;
+  variables: Record<string, VariableValue>;
+}
+
+interface ImportMeta {
+  format: string;
+  fileName?: string;
+  requestCount: number;
+  folderCount: number;
+  environmentCount: number;
+}
+
+interface ImportOptions {
+  importEnvironments: boolean;       // Checkbox: "Import environments & variables"
+  importScripts: boolean;            // Checkbox: "Import pre-request & test scripts"
+}
+```
+
+### Engine — URL Proxy Endpoint
+
+The URL import tab cannot fetch arbitrary URLs from the browser (CORS). The engine proxies it using its existing libcurl infrastructure.
+
+```
+POST /import/fetch
+Body:  { "url": "https://petstore.swagger.io/v2/swagger.json" }
+Response:
+  200: { "content": "<raw body string>", "contentType": "application/json" }
+  400: { "error": "Invalid URL" }
+  502: { "error": "Failed to fetch: <curl error>" }
+```
+
+New file: `engine/src/http/routes/import.cpp`
+Register in: `engine/src/http/server.cpp` + `engine/include/vayu/http/routes.hpp`
+
+### Vayu Data Model Mapping
+
+Vayu has no workspace concept. The mapping is:
+
+| External concept | Vayu entity |
+|---|---|
+| Postman Collection / Insomnia Workspace / OpenAPI spec | Root `Collection` (parentId = null) |
+| Postman Folder / Insomnia request_group / OpenAPI tag | Child `Collection` (parentId = parent id) |
+| Request at any level | `Request` (collectionId = its immediate parent Collection) |
+| Postman/Insomnia environment | `Environment` |
+
+Root-level requests (directly in a Postman Collection outside any folder) get `collectionId = rootCollectionId`.
+
+### Orchestrator Sequencing
+
+Order matters because children reference parent IDs.
+
+```
+1. Create root Collection(s)
+2. For each depth level (BFS): create child Collections with parentId
+3. Create all Requests (parallelisable per-collection after its Collection exists)
+4. If importEnvironments=true: create all Environments
+5. Invalidate TanStack Query: queryKeys.collections, queryKeys.environments
+```
+
+## UI Reference
+
+See `/design_handoff/vayu-app.jsx` → `ImportModal` component for pixel-precise design.
+
+Key design tokens:
+- Modal: 500px wide, `background: --card`, `border: 1px solid --border-strong`, `border-radius: 10px`
+- Drop zone: `border: 2px dashed --border-strong`, drag-over → `border-color: --primary`
+- Format badges: 10px, `background: --card`, `border: 1px solid --border`
+- Preview tree: `background: --accent-hover`, max-height 190px scroll
+- Detection badge (green): `background: rgba(34,197,94,0.08)`, `border: rgba(34,197,94,0.22)`
+
+## Format Detection Order
+
+The factory tries parsers in this order (most specific first):
+
+1. Postman v2.1 — `info.schema` contains `"v2.1.0"`
+2. Postman v2.0 — `info.schema` contains `"v2.0.0"` or has `info` + `item` but no schema
+3. Insomnia v4 — `_type === "export"` AND `__export_format === 4`
+4. OpenAPI 3.0 — `openapi` field starts with `"3."`
+5. OpenAPI 2.0 — `swagger === "2.0"`
+
+If no parser matches: show error state "Unrecognised format".
+
+## Out of Scope (V1)
+
+- Exporting collections from Vayu to Postman/Insomnia format
+- Merging an import into an existing collection (always creates new)
+- Incremental re-import / sync
+- Bruno `.bru` format
+- Postman standalone environment JSON import
+- Postman workspace-level data export (ZIP)
+- GraphQL-specific body type
+- OAuth2 token execution (stored as JSON, not executed)

--- a/docs/features/import-format-mappings.md
+++ b/docs/features/import-format-mappings.md
@@ -3,40 +3,55 @@
 Reference for how each external format maps to Vayu's internal data model.
 Read alongside `import-collections-prd.md`.
 
+> **2026-05 refresh:** This doc was updated after the data-model refactor (PR #11).
+> Many compromises listed in older revisions — folder scripts dropped, descriptions
+> dropped, duplicate header collapse, etc. — are no longer needed.
+
 ## Vayu Data Model Constraints
 
 Understanding these constraints is essential before reading the format tables.
+See `docs/engine/db-schema.md` for the full column-by-column reference.
 
 **Collection** (engine `db::Collection`):
 - `id: string`
 - `parent_id: optional<string>` — nesting supported at any depth
 - `name: string`
+- `description: string` — preserved end-to-end
 - `variables: string` — JSON `Record<string, {value, enabled, secret?}>`
+- `auth: string` — JSON discriminated union (`none` / `bearer` / `basic` / `apikey` / …); collections are always concrete auth sources, **never** `inherit`
+- `pre_request_script: string` — JS, runs in `pm.*` runtime before the request
+- `post_request_script: string` — JS, runs after the response
 - `order: int`
-- **No `description` column** — frontend type has it, engine DB does not
 
 **Request** (engine `db::Request`):
 - `id: string`
-- `collection_id: string` — belongs to exactly **one** Collection node
+- `collection_id: string`
 - `name: string`
+- `description: string`
 - `method: HttpMethod` — GET | POST | PUT | PATCH | DELETE | HEAD | OPTIONS
 - `url: string`
-- `params: string` — JSON `Record<string, string>` — **flat, no duplicate keys**
-- `headers: string` — JSON `Record<string, string>` — **flat, no duplicate keys**
-- `body: string` — raw string content
-- `body_type: string` — `"json" | "text" | "form-data" | "x-www-form-urlencoded" | "none"`
-- `auth: string` — opaque JSON; engine stores but only executes bearer/basic/apikey
-- `pre_request_script: string` — JS; Vayu runtime supports `pm.*` API
-- `post_request_script: string` — JS
-- **No `description` column**
+- `params: string` — JSON **array** of `KeyValueEntry[]`; duplicates allowed; `enabled:false` preserved
+- `headers: string` — JSON **array** of `KeyValueEntry[]`; same semantics
+- `body: string` — JSON **discriminated union**:
+  - `{"mode":"none"}`
+  - `{"mode":"json"|"text"|"graphql","content":"..."}`
+  - `{"mode":"form-data"|"x-www-form-urlencoded","fields":KeyValueEntry[]}`
+- `body_type: string` — denormalized mirror of `body.mode`, kept for queryability
+- `auth: string` — JSON discriminated union; requests can be `{"mode":"inherit"}` and are resolved against the collection chain at execution time
+- `pre_request_script: string`
+- `post_request_script: string`
+- `order: int`
 
 **Environment** (engine `db::Environment`):
 - `id: string`
 - `name: string`
+- `description: string`
 - `variables: string` — JSON `Record<string, {value, enabled, secret?}>`
 - `is_active: bool`
 
-**Delete cascade note:** `delete_collection` removes Requests with that `collection_id` but does NOT cascade to child Collections. Deleting a parent orphans children — pre-existing limitation, not introduced by import.
+`KeyValueEntry`: `{ key: string, value: string, enabled: boolean, description?: string }`.
+
+**Cascade delete:** `delete_collection` recursively deletes all descendant collections and their requests (BFS, deepest-first).
 
 ---
 
@@ -58,30 +73,35 @@ Walk is recursive. Depth is unbounded — Vayu supports arbitrary nesting via `p
 | Postman field | Vayu field | Notes |
 |---|---|---|
 | `info.name` | `collection.name` | |
-| `variable[].key/value/enabled` | `collection.variables` | `secret` preserved if present |
+| `info.description` | `collection.description` | Postman supports string or object form; flatten to string |
+| `variable[].{key,value,enabled,description?}` | `collection.variables` | Stringify non-string values; `enabled` defaults to `true` |
 | `variable[].type` | dropped | Vayu stores all values as strings |
+| `auth` (non-inherit) | `collection.auth` | See Auth section |
+| `event[prerequest].script.exec[]` | `collection.preRequestScript` | Lines joined with `\n` |
+| `event[test].script.exec[]` | `collection.postRequestScript` | Lines joined with `\n` |
 
 **Collection (from Postman Folder):**
 | Postman field | Vayu field | Notes |
 |---|---|---|
 | `name` | `collection.name` | |
-| Folder-level `variable[]` | `collection.variables` | Same mapping |
-| Folder-level `auth` | resolved into child requests | See Auth section |
-| Folder-level `event[]` scripts | **dropped** | No folder-level scripts in Vayu |
+| `description` | `collection.description` | |
+| Folder-level `variable[]` | `collection.variables` | Same shape |
+| Folder-level `auth` (non-inherit) | `collection.auth` | Collections cannot inherit — folders that say `inherit` are imported as `{"mode":"none"}` (parent already supplied auth via the chain) |
+| Folder-level `event[]` scripts | `collection.preRequestScript` / `collection.postRequestScript` | Now supported — Vayu composes parent→child→request at execution time |
 
 **Request:**
 | Postman field | Vayu field | Notes |
 |---|---|---|
 | `name` | `request.name` | |
+| `description` | `request.description` | |
 | `request.method` | `request.method` | Uppercased |
 | `request.url.raw` (object) or `request.url` (string) | `request.url` | See URL section |
-| `request.url.query[]` (filtered) | `request.params` | Filter `disabled: true`; last value wins on duplicate keys |
-| `request.header[]` (filtered) | `request.headers` | Filter `disabled: true`; last value wins |
-| `request.body` | `request.body` + `request.bodyType` | See Body section |
-| `request.auth` (resolved) | `request.auth` | See Auth section |
+| `request.url.query[]` | `request.params` | Mapped to `KeyValueEntry[]`; preserves `disabled:true` rows as `enabled:false`; duplicates preserved |
+| `request.header[]` | `request.headers` | Same — `KeyValueEntry[]` with `enabled` flag |
+| `request.body` | `request.body` (discriminated union) | See Body section |
+| `request.auth` | `request.auth` | `inherit` → `{"mode":"inherit"}`; resolved at execution time |
 | `event[prerequest].script.exec[]` | `request.preRequestScript` | Lines joined with `\n` |
 | `event[test].script.exec[]` | `request.postRequestScript` | Lines joined with `\n` |
-| `description` | **dropped** | Engine DB has no description column |
 
 ### URL Handling
 
@@ -99,39 +119,39 @@ Postman v2.1 URL can be a **string** or an **object**:
 ```
 
 Strategy:
-- If object: use `url.raw` as `request.url`. Extract `url.query[]` (non-disabled) into `params`. Strip query string from `url.raw` to avoid duplication.
-- If string: use as-is for `request.url`. Parse and strip the `?query` portion into `params`.
+- If object: use `url.raw` as `request.url` (strip query string to avoid duplication). Map `url.query[]` directly to `KeyValueEntry[]`, preserving all rows including `disabled`.
+- If string: use as-is. Parse the `?query` portion into `KeyValueEntry[]` with `enabled:true`.
 
 ### Body Mapping
 
-| Postman `body.mode` | Postman detail | Vayu `bodyType` | Vayu `body` |
-|---|---|---|---|
-| `raw` | `options.raw.language = "json"` | `"json"` | `body.raw` |
-| `raw` | `options.raw.language = "text"` | `"text"` | `body.raw` |
-| `raw` | no language set | `"json"` if `JSON.parse` succeeds, else `"text"` | `body.raw` |
-| `urlencoded` | `body.urlencoded[]` | `"x-www-form-urlencoded"` | `key=value&key2=value2` (non-disabled entries) |
-| `formdata` | `body.formdata[]` | `"form-data"` | `key=value&key2=value2` (text fields only, non-disabled) |
-| `none` / absent | — | `"none"` | `""` |
-| `graphql` | `body.graphql` | `"text"` | `JSON.stringify(body.graphql)` |
-| `file` / `binary` | — | **dropped** | Vayu has no binary body support |
+| Postman `body.mode` | Postman detail | Vayu `body` |
+|---|---|---|
+| `raw` | `options.raw.language = "json"` | `{"mode":"json","content":body.raw}` |
+| `raw` | `options.raw.language = "text"` | `{"mode":"text","content":body.raw}` |
+| `raw` | no language set | `{"mode":"json","content":body.raw}` if `JSON.parse` succeeds, else `{"mode":"text",...}` |
+| `urlencoded` | `body.urlencoded[]` | `{"mode":"x-www-form-urlencoded","fields":KeyValueEntry[]}` — `disabled:true` preserved as `enabled:false` |
+| `formdata` | `body.formdata[]` text fields | `{"mode":"form-data","fields":KeyValueEntry[]}` — file fields dropped (no binary support) |
+| `none` / absent | — | `{"mode":"none"}` |
+| `graphql` | `body.graphql = {query, variables}` | `{"mode":"graphql","content":JSON.stringify({...})}` |
+| `file` / `binary` | — | **dropped** — Vayu has no binary body support |
 
-### Auth Resolution
+### Auth Mapping
 
 Postman auth exists at three levels: collection, folder, request. Each can be `"noauth"`, a specific type, or `"inherit"`.
 
-Resolution at parse time (bottom-up):
-1. Start at the request's own `auth`
-2. If `type === "inherit"` (or auth absent): walk up to parent folder, then collection
-3. Apply the first non-inherit auth found
+**New strategy (post-refactor):** preserve the hierarchy. Don't flatten at import time.
+- Collection / folder `auth` is stored on the matching Vayu Collection (`{"mode":"none"}` if Postman says `noauth` or `inherit`, since collections cannot themselves inherit).
+- Request `auth` set to `"inherit"` → store `{"mode":"inherit"}` on the Request; Vayu resolves it at execution time by walking the collection chain leaf-first.
 
 | Postman auth type | Vayu `auth` JSON |
 |---|---|
-| `bearer` | `{ "type": "bearer", "token": "<value>" }` |
-| `basic` | `{ "type": "basic", "username": "<u>", "password": "<p>" }` |
-| `apikey` | `{ "type": "apikey", "key": "<k>", "value": "<v>", "in": "header"\|"query" }` |
-| `oauth2` | stored as-is (not executed by engine) |
-| `digest` / `aws` / `ntlm` | stored as-is (not executed by engine) |
-| `noauth` / resolved to nothing | `{}` (empty) |
+| `bearer` | `{"mode":"bearer","token":"<value>"}` |
+| `basic` | `{"mode":"basic","username":"<u>","password":"<p>"}` |
+| `apikey` | `{"mode":"apikey","key":"<k>","value":"<v>","in":"header"\|"query"}` |
+| `oauth2` | `{"mode":"oauth2","config":{...}}` (stored as-is; not executed) |
+| `digest` / `aws` / `ntlm` | `{"mode":"digest"\|"aws"\|"ntlm","config":{...}}` (stored as-is; not executed) |
+| `noauth` | `{"mode":"none"}` |
+| `inherit` (request-level only) | `{"mode":"inherit"}` |
 
 ### Environments
 
@@ -188,7 +208,7 @@ Insomnia uses Nunjucks-style templates. Normalize to Vayu's `{{variable}}` synta
 | `{% now %}` / `{% uuid %}` / `{% randomInt %}` | kept as-is | **No Vayu equivalent** — will render as literal text |
 | `{{ variable \| lower }}` | kept as-is | Nunjucks filter — will render as literal text |
 
-Apply normalization to: URL, all header values, all param values, body text.
+Apply normalization to: URL, all header values, all param values, body text/fields.
 
 ### Field Mapping
 
@@ -196,43 +216,46 @@ Apply normalization to: URL, all header values, all param values, body text.
 | Insomnia field | Vayu field | Notes |
 |---|---|---|
 | `name` | `collection.name` | |
-| `description` | **dropped** | |
+| `description` | `collection.description` | |
 | `environment` (workspace-level base vars) | `collection.variables` | Only for workspace resources; normalize values |
+| `authentication` (group-level) | `collection.auth` | If present and not `disabled` |
 
 **Request:**
 | Insomnia field | Vayu field | Notes |
 |---|---|---|
 | `name` | `request.name` | |
+| `description` | `request.description` | |
 | `method` | `request.method` | Uppercased |
 | `url` (normalized) | `request.url` | Apply template normalization |
-| `parameters[]` (non-disabled) | `request.params` | `{name, value}` → `Record<string,string>` |
-| `headers[]` (non-disabled) | `request.headers` | `{name, value}` → `Record<string,string>` |
-| `body` | `request.body` + `request.bodyType` | See Body section |
+| `parameters[]` | `request.params` | `{name,value,disabled}` → `KeyValueEntry[]` with `enabled = !disabled` |
+| `headers[]` | `request.headers` | Same shape; preserves duplicates and disabled rows |
+| `body` | `request.body` (discriminated union) | See Body section |
 | `authentication` | `request.auth` | See Auth section |
 | `preRequestScript` | `request.preRequestScript` | Non-standard; present only in Insomnia versions with scripting |
 | `afterResponseScript` | `request.postRequestScript` | Same note |
-| `description` | **dropped** | |
 
 ### Body Mapping
 
-| Insomnia `body.mimeType` | Vayu `bodyType` | Vayu `body` |
-|---|---|---|
-| `application/json` | `"json"` | `body.text` |
-| `text/plain` | `"text"` | `body.text` |
-| `application/x-www-form-urlencoded` | `"x-www-form-urlencoded"` | rebuild from `body.params[]` |
-| `multipart/form-data` | `"form-data"` | text fields from `body.params[]`; file fields dropped |
-| `application/graphql` | `"text"` | `body.text` |
-| absent / empty | `"none"` | `""` |
+| Insomnia `body.mimeType` | Vayu `body` |
+|---|---|
+| `application/json` | `{"mode":"json","content":body.text}` |
+| `text/plain` | `{"mode":"text","content":body.text}` |
+| `application/x-www-form-urlencoded` | `{"mode":"x-www-form-urlencoded","fields":KeyValueEntry[]}` from `body.params[]` |
+| `multipart/form-data` | `{"mode":"form-data","fields":KeyValueEntry[]}` from `body.params[]` text fields; file fields dropped |
+| `application/graphql` | `{"mode":"graphql","content":body.text}` |
+| absent / empty | `{"mode":"none"}` |
 
 ### Auth Mapping
 
 | Insomnia `authentication.type` | Vayu `auth` JSON |
 |---|---|
-| `bearer` | `{ "type": "bearer", "token": auth.token }` |
-| `basic` | `{ "type": "basic", "username": auth.username, "password": auth.password }` |
-| `apikey` | `{ "type": "apikey", "key": auth.key, "value": auth.value, "in": auth.addTo }` |
-| `oauth2` | stored as-is (not executed) |
-| `disabled: true` (any type) | `{}` (empty auth) |
+| `bearer` | `{"mode":"bearer","token":auth.token}` |
+| `basic` | `{"mode":"basic","username":auth.username,"password":auth.password}` |
+| `apikey` | `{"mode":"apikey","key":auth.key,"value":auth.value,"in":auth.addTo}` |
+| `oauth2` | `{"mode":"oauth2","config":{...}}` (stored as-is; not executed) |
+| `disabled: true` (any type) | `{"mode":"none"}` |
+
+Insomnia has no first-class `"inherit"` concept; if a request has no `authentication`, it imports as `{"mode":"inherit"}` so the parent collection's auth (if any) applies at execution time.
 
 ### Environments
 
@@ -282,23 +305,31 @@ OpenAPI is an **API specification**, not a test collection. We generate syntheti
 | OpenAPI field | Vayu field | Notes |
 |---|---|---|
 | `info.title` | `collection.name` | |
+| `info.description` | `collection.description` | |
 | `servers[0].url` | `collection.variables.baseUrl` | `{ value: url, enabled: true }` |
-| Additional servers | **dropped** | Only first server used |
-| `info.description` | **dropped** | |
+| Additional servers | dropped | Only first server used |
+
+**Collection (per tag):**
+| OpenAPI field | Vayu field | Notes |
+|---|---|---|
+| `tags[].name` | `collection.name` | |
+| `tags[].description` | `collection.description` | |
 
 **Request (per operation):**
 | OpenAPI field | Vayu field | Notes |
 |---|---|---|
 | `summary` → `operationId` → `METHOD /path` | `request.name` | Prefers summary, falls back in order |
+| `description` | `request.description` | |
 | HTTP method (lowercased key) | `request.method` | Uppercased |
 | `{{baseUrl}}` + path | `request.url` | Path params `{x}` → `{{x}}` |
-| `parameters[in=query]` | `request.params` | Example/default value used; else `""` |
-| `parameters[in=header]` | `request.headers` | Skip standard headers (Authorization, Content-Type) |
-| `requestBody.content[application/json]` | `body` + `bodyType="json"` | See Body generation section |
-| `requestBody.content[text/plain]` | `body=""` + `bodyType="text"` | |
-| `security[]` / `securitySchemes` | **dropped** | No auth set; user fills in post-import |
+| `parameters[in=query]` | `request.params` | Mapped to `KeyValueEntry[]`; one entry per parameter; description from spec preserved on the entry |
+| `parameters[in=header]` | `request.headers` | Same; skip Authorization and Content-Type (added by Vayu) |
+| `requestBody.content[application/json]` | `{"mode":"json","content":<generated>}` | See Body generation section |
+| `requestBody.content[text/plain]` | `{"mode":"text","content":""}` | |
+| `requestBody.content[application/x-www-form-urlencoded]` | `{"mode":"x-www-form-urlencoded","fields":KeyValueEntry[]}` | Generated stub per property |
+| `requestBody.content[multipart/form-data]` | `{"mode":"form-data","fields":KeyValueEntry[]}` | Same |
+| `security[]` / `securitySchemes` | `request.auth = {"mode":"inherit"}` | Lets the user set auth at the collection level once and have it apply to all child requests |
 | `tags[0]` | determines parent Collection | |
-| `description` / `externalDocs` | **dropped** | |
 
 ### Body Generation from Schema
 
@@ -306,7 +337,7 @@ One level deep only — no recursion into nested objects or `$ref` chains.
 
 | Schema type | Generated value |
 |---|---|
-| `string` | `""` |
+| `string` | `""` (or `enum[0]` if present) |
 | `integer` / `number` | `0` |
 | `boolean` | `false` |
 | `array` | `[]` |
@@ -315,7 +346,7 @@ One level deep only — no recursion into nested objects or `$ref` chains.
 | `oneOf` / `anyOf` / `allOf` | `{}` — too ambiguous to resolve |
 | `$ref` | resolved one level; if that resolves to another `$ref`, stops and returns `{}` |
 
-Resulting JSON is pretty-printed and stored as `body` string with `bodyType = "json"`.
+Resulting JSON is pretty-printed and stored as `content` in `{"mode":"json","content":"..."}`.
 
 ### Path Parameters
 
@@ -343,20 +374,20 @@ baseUrl = (schemes[0] || "https") + "://" + host + (basePath !== "/" ? basePath 
 Stored as `collection.variables.baseUrl`. Multiple schemes → only the first used.
 
 **Body content type:** Swagger doesn't define `requestBody` per-operation. Uses `consumes[]` at spec level or operation level. Strategy:
-- If operation has `consumes: ["application/json"]` → generate JSON body from `parameters[in=body]` schema
+- If operation has `consumes: ["application/json"]` → generate JSON body from `parameters[in=body]` schema → `{"mode":"json","content":...}`
 - If spec-level `consumes` has `application/json` → same
-- If `in=body` parameter exists but no JSON consume → store body as `bodyType: "text"`
+- If `in=body` parameter exists but no JSON consume → `{"mode":"text","content":...}`
 
 **Parameter location:** Swagger `parameters[in=body]` is equivalent to OpenAPI `requestBody`. All other `in` values (`query`, `header`, `path`, `formData`) map the same way.
 
-**`formData` parameters:** Swagger uses `in=formData` instead of `requestBody`. Map to `bodyType: "form-data"` with values joined as `key=value&...`.
+**`formData` parameters:** Swagger uses `in=formData` instead of `requestBody`. Map to `{"mode":"form-data","fields":KeyValueEntry[]}`, one entry per `formData` parameter.
 
 **`$ref` resolution:** Swagger uses `#/definitions/ModelName`. Resolved one level deep (same constraint as OpenAPI 3.0).
 
-**`collectionFormat` for array query params:**
-- `csv` → join values with `,` into a single string
-- `multi` → **collapses to last value** (Vayu params is a flat Record)
-- `ssv` / `tsv` / `pipes` → join with respective separator into single string
+**`collectionFormat` for array query params:** Now that `request.params` is `KeyValueEntry[]`, we can preserve repeated values rather than collapsing.
+- `csv` → join values with `,` into a single entry value
+- `multi` → **one `KeyValueEntry` per value, same key, all enabled** (no more loss)
+- `ssv` / `tsv` / `pipes` → join with respective separator into single entry value
 
 ---
 
@@ -366,10 +397,12 @@ Stored as `collection.variables.baseUrl`. Multiple schemes → only the first us
 
 | Loss | Root cause |
 |---|---|
-| `description` fields dropped | Engine DB has no description column |
-| Duplicate query param keys → last value wins | `params` is `Record<string,string>` |
-| Duplicate header keys → last value wins | `headers` is `Record<string,string>` |
 | File/binary upload body dropped | Vayu has no file attachment in requests |
+| Variable type metadata (`type: "secret"`, etc.) reduced to `secret: boolean` | Vayu has no rich type system |
+
+> Removed from this list after the data model refactor: `description` drops,
+> duplicate-key collapse on params/headers, disabled-row loss, folder-script drops,
+> auth-inheritance flattening, body-type opacity. All of these now round-trip.
 
 ### Postman v2.1 / v2.0
 
@@ -377,12 +410,8 @@ Stored as `collection.variables.baseUrl`. Multiple schemes → only the first us
 |---|---|
 | Environments not in collection file | High — separate import needed |
 | Disabled requests/folders silently skipped | Medium |
-| Folder-level scripts (pre/post) dropped | Medium |
 | `postman.*` deprecated API in scripts → runtime errors | Medium |
-| Auth inheritance resolved at import time (not dynamic) | Low |
 | OAuth2 / Digest / AWS / NTLM stored but not executed | Low |
-| `urlencoded`/`formdata` body rebuilt as flat string | Low |
-| GraphQL body stored as text | Low |
 | Variable type metadata dropped | Low |
 
 ### Insomnia v4
@@ -401,10 +430,9 @@ Stored as `collection.variables.baseUrl`. Multiple schemes → only the first us
 | Loss | Severity |
 |---|---|
 | No real values — all params/body are stubs | High — expected for spec import |
-| Security schemes / auth dropped | High — user fills in post-import |
+| Security schemes / auth set to inherit (user fills at collection level) | Medium — better than dropping |
 | `oneOf`/`anyOf`/`allOf` body → empty `{}` | Medium |
 | Multi-tag operations → first tag only (no duplication) | Medium |
 | Additional servers beyond first dropped | Low |
 | Deep `$ref` chains → one level resolved | Low |
 | Response schemas dropped | Low |
-| `collectionFormat: multi` collapses to last value | Low |

--- a/docs/features/import-format-mappings.md
+++ b/docs/features/import-format-mappings.md
@@ -1,0 +1,410 @@
+# Import Format Mappings
+
+Reference for how each external format maps to Vayu's internal data model.
+Read alongside `import-collections-prd.md`.
+
+## Vayu Data Model Constraints
+
+Understanding these constraints is essential before reading the format tables.
+
+**Collection** (engine `db::Collection`):
+- `id: string`
+- `parent_id: optional<string>` — nesting supported at any depth
+- `name: string`
+- `variables: string` — JSON `Record<string, {value, enabled, secret?}>`
+- `order: int`
+- **No `description` column** — frontend type has it, engine DB does not
+
+**Request** (engine `db::Request`):
+- `id: string`
+- `collection_id: string` — belongs to exactly **one** Collection node
+- `name: string`
+- `method: HttpMethod` — GET | POST | PUT | PATCH | DELETE | HEAD | OPTIONS
+- `url: string`
+- `params: string` — JSON `Record<string, string>` — **flat, no duplicate keys**
+- `headers: string` — JSON `Record<string, string>` — **flat, no duplicate keys**
+- `body: string` — raw string content
+- `body_type: string` — `"json" | "text" | "form-data" | "x-www-form-urlencoded" | "none"`
+- `auth: string` — opaque JSON; engine stores but only executes bearer/basic/apikey
+- `pre_request_script: string` — JS; Vayu runtime supports `pm.*` API
+- `post_request_script: string` — JS
+- **No `description` column**
+
+**Environment** (engine `db::Environment`):
+- `id: string`
+- `name: string`
+- `variables: string` — JSON `Record<string, {value, enabled, secret?}>`
+- `is_active: bool`
+
+**Delete cascade note:** `delete_collection` removes Requests with that `collection_id` but does NOT cascade to child Collections. Deleting a parent orphans children — pre-existing limitation, not introduced by import.
+
+---
+
+## Postman Collection v2.1
+
+### Detection
+`info.schema` string contains `"v2.1.0"`
+
+### Tree Walk
+`item[]` entries are discriminated by presence of a nested `item[]` array:
+- Has nested `item[]` → folder → create child Collection
+- Has `request` object → create Request in current Collection
+
+Walk is recursive. Depth is unbounded — Vayu supports arbitrary nesting via `parentId`.
+
+### Field Mapping
+
+**Collection (from Postman Collection root):**
+| Postman field | Vayu field | Notes |
+|---|---|---|
+| `info.name` | `collection.name` | |
+| `variable[].key/value/enabled` | `collection.variables` | `secret` preserved if present |
+| `variable[].type` | dropped | Vayu stores all values as strings |
+
+**Collection (from Postman Folder):**
+| Postman field | Vayu field | Notes |
+|---|---|---|
+| `name` | `collection.name` | |
+| Folder-level `variable[]` | `collection.variables` | Same mapping |
+| Folder-level `auth` | resolved into child requests | See Auth section |
+| Folder-level `event[]` scripts | **dropped** | No folder-level scripts in Vayu |
+
+**Request:**
+| Postman field | Vayu field | Notes |
+|---|---|---|
+| `name` | `request.name` | |
+| `request.method` | `request.method` | Uppercased |
+| `request.url.raw` (object) or `request.url` (string) | `request.url` | See URL section |
+| `request.url.query[]` (filtered) | `request.params` | Filter `disabled: true`; last value wins on duplicate keys |
+| `request.header[]` (filtered) | `request.headers` | Filter `disabled: true`; last value wins |
+| `request.body` | `request.body` + `request.bodyType` | See Body section |
+| `request.auth` (resolved) | `request.auth` | See Auth section |
+| `event[prerequest].script.exec[]` | `request.preRequestScript` | Lines joined with `\n` |
+| `event[test].script.exec[]` | `request.postRequestScript` | Lines joined with `\n` |
+| `description` | **dropped** | Engine DB has no description column |
+
+### URL Handling
+
+Postman v2.1 URL can be a **string** or an **object**:
+
+```json
+// Object form (v2.1 standard)
+"url": {
+  "raw": "https://api.example.com/users/{{userId}}?page=1",
+  "query": [{ "key": "page", "value": "1", "disabled": false }]
+}
+
+// String form (common in older collections and pre-request-generated URLs)
+"url": "https://api.example.com/users/{{userId}}?page=1"
+```
+
+Strategy:
+- If object: use `url.raw` as `request.url`. Extract `url.query[]` (non-disabled) into `params`. Strip query string from `url.raw` to avoid duplication.
+- If string: use as-is for `request.url`. Parse and strip the `?query` portion into `params`.
+
+### Body Mapping
+
+| Postman `body.mode` | Postman detail | Vayu `bodyType` | Vayu `body` |
+|---|---|---|---|
+| `raw` | `options.raw.language = "json"` | `"json"` | `body.raw` |
+| `raw` | `options.raw.language = "text"` | `"text"` | `body.raw` |
+| `raw` | no language set | `"json"` if `JSON.parse` succeeds, else `"text"` | `body.raw` |
+| `urlencoded` | `body.urlencoded[]` | `"x-www-form-urlencoded"` | `key=value&key2=value2` (non-disabled entries) |
+| `formdata` | `body.formdata[]` | `"form-data"` | `key=value&key2=value2` (text fields only, non-disabled) |
+| `none` / absent | — | `"none"` | `""` |
+| `graphql` | `body.graphql` | `"text"` | `JSON.stringify(body.graphql)` |
+| `file` / `binary` | — | **dropped** | Vayu has no binary body support |
+
+### Auth Resolution
+
+Postman auth exists at three levels: collection, folder, request. Each can be `"noauth"`, a specific type, or `"inherit"`.
+
+Resolution at parse time (bottom-up):
+1. Start at the request's own `auth`
+2. If `type === "inherit"` (or auth absent): walk up to parent folder, then collection
+3. Apply the first non-inherit auth found
+
+| Postman auth type | Vayu `auth` JSON |
+|---|---|
+| `bearer` | `{ "type": "bearer", "token": "<value>" }` |
+| `basic` | `{ "type": "basic", "username": "<u>", "password": "<p>" }` |
+| `apikey` | `{ "type": "apikey", "key": "<k>", "value": "<v>", "in": "header"\|"query" }` |
+| `oauth2` | stored as-is (not executed by engine) |
+| `digest` / `aws` / `ntlm` | stored as-is (not executed by engine) |
+| `noauth` / resolved to nothing | `{}` (empty) |
+
+### Environments
+
+Postman v2.1 **collection files do not embed environments**. Collection-level `variable[]` is imported as `collection.variables`. Postman environment JSON files are a separate import (out of scope V1).
+
+### Scripts Compatibility Note
+
+Vayu's QuickJS runtime supports the modern `pm.*` API. Scripts using the deprecated `postman.*` namespace (e.g., `postman.setEnvironmentVariable()`) are imported as-is — they will throw runtime errors if executed.
+
+---
+
+## Postman Collection v2.0
+
+Identical to v2.1 with these differences:
+
+**Detection:** `info.schema` contains `"v2.0.0"`, or file has `info` + `item` but no `schema` field.
+
+**URL:** Always treat as string — v2.0 predates the URL object format. Parse query string out manually. More error-prone on encoded characters.
+
+**Auth structure:** v2.0 auth uses a slightly different key format in some types (e.g., `bearer.token` vs v2.1's array `bearer[{key:"token", value:"..."}]`). Parser must handle both shapes.
+
+---
+
+## Insomnia v4
+
+### Detection
+`_type === "export"` AND `__export_format === 4`
+
+### Structure
+
+Insomnia v4 exports are **flat arrays** of typed resources. The tree is reconstructed from `_id` / `parentId` references.
+
+Resource types and their Vayu mapping:
+
+| Insomnia `_type` | Vayu entity | Notes |
+|---|---|---|
+| `workspace` | Root Collection (parentId = null) | Multiple workspaces → multiple root Collections |
+| `request_group` | Child Collection | parentId references workspace or another request_group |
+| `request` | Request | parentId references request_group or workspace |
+| `environment` | Environment (if opt-in) | See Environments section |
+| `api_spec` | **dropped** | OpenAPI text stored alongside requests |
+| `grpc_request` | **dropped** | gRPC not supported by Vayu |
+| `websocket_request` | **dropped** | WebSocket not supported by Vayu |
+| `unit_test_suite` / `unit_test` | **dropped** | No Vayu equivalent |
+
+### Template Variable Normalization
+
+Insomnia uses Nunjucks-style templates. Normalize to Vayu's `{{variable}}` syntax:
+
+| Insomnia syntax | Vayu syntax | Notes |
+|---|---|---|
+| `{{ variable }}` | `{{variable}}` | Strip surrounding spaces |
+| `{{ _.variable }}` | `{{variable}}` | Strip `_.` prefix — Insomnia env-scoped lookup |
+| `{% now %}` / `{% uuid %}` / `{% randomInt %}` | kept as-is | **No Vayu equivalent** — will render as literal text |
+| `{{ variable \| lower }}` | kept as-is | Nunjucks filter — will render as literal text |
+
+Apply normalization to: URL, all header values, all param values, body text.
+
+### Field Mapping
+
+**Collection (from workspace/request_group):**
+| Insomnia field | Vayu field | Notes |
+|---|---|---|
+| `name` | `collection.name` | |
+| `description` | **dropped** | |
+| `environment` (workspace-level base vars) | `collection.variables` | Only for workspace resources; normalize values |
+
+**Request:**
+| Insomnia field | Vayu field | Notes |
+|---|---|---|
+| `name` | `request.name` | |
+| `method` | `request.method` | Uppercased |
+| `url` (normalized) | `request.url` | Apply template normalization |
+| `parameters[]` (non-disabled) | `request.params` | `{name, value}` → `Record<string,string>` |
+| `headers[]` (non-disabled) | `request.headers` | `{name, value}` → `Record<string,string>` |
+| `body` | `request.body` + `request.bodyType` | See Body section |
+| `authentication` | `request.auth` | See Auth section |
+| `preRequestScript` | `request.preRequestScript` | Non-standard; present only in Insomnia versions with scripting |
+| `afterResponseScript` | `request.postRequestScript` | Same note |
+| `description` | **dropped** | |
+
+### Body Mapping
+
+| Insomnia `body.mimeType` | Vayu `bodyType` | Vayu `body` |
+|---|---|---|
+| `application/json` | `"json"` | `body.text` |
+| `text/plain` | `"text"` | `body.text` |
+| `application/x-www-form-urlencoded` | `"x-www-form-urlencoded"` | rebuild from `body.params[]` |
+| `multipart/form-data` | `"form-data"` | text fields from `body.params[]`; file fields dropped |
+| `application/graphql` | `"text"` | `body.text` |
+| absent / empty | `"none"` | `""` |
+
+### Auth Mapping
+
+| Insomnia `authentication.type` | Vayu `auth` JSON |
+|---|---|
+| `bearer` | `{ "type": "bearer", "token": auth.token }` |
+| `basic` | `{ "type": "basic", "username": auth.username, "password": auth.password }` |
+| `apikey` | `{ "type": "apikey", "key": auth.key, "value": auth.value, "in": auth.addTo }` |
+| `oauth2` | stored as-is (not executed) |
+| `disabled: true` (any type) | `{}` (empty auth) |
+
+### Environments
+
+Insomnia environment resources have:
+- `_type: "environment"`
+- `data: Record<string, unknown>` — variable values (may be non-string)
+- `parentId` — references a workspace (base env) or another environment (sub-env)
+
+**Sub-environment flattening:** Insomnia's base env + sub-env inheritance is flattened at import time. Each sub-environment becomes a fully independent Vayu `Environment` with base env variables merged in (sub-env values override base).
+
+```
+Insomnia:
+  Base Env: { baseUrl: "https://api.example.com", timeout: 30 }
+  Sub-env "Production": { baseUrl: "https://prod.api.example.com" }
+  Sub-env "Staging": { baseUrl: "https://staging.api.example.com" }
+
+Vayu result:
+  Environment "Production": { baseUrl: "https://prod.api.example.com", timeout: "30" }
+  Environment "Staging":    { baseUrl: "https://staging.api.example.com", timeout: "30" }
+```
+
+All values stringified (Vayu `VariableValue.value` is always `string`).
+
+---
+
+## OpenAPI 3.0
+
+### Detection
+Root-level `openapi` field exists and `openapi.startsWith("3.")`
+
+### Fundamental Difference
+
+OpenAPI is an **API specification**, not a test collection. We generate synthetic request stubs from path/operation definitions. No real values exist — the user must fill in actual values after import.
+
+### Tree Structure
+
+| OpenAPI concept | Vayu entity |
+|---|---|
+| Spec (`info.title`) | Root Collection (parentId = null) |
+| `tags[].name` | Child Collection per tag (parentId = root) |
+| Untagged operations | Requests directly in root Collection |
+| Operations with multiple tags | Assigned to first tag only; not duplicated |
+
+### Field Mapping
+
+**Collection (root):**
+| OpenAPI field | Vayu field | Notes |
+|---|---|---|
+| `info.title` | `collection.name` | |
+| `servers[0].url` | `collection.variables.baseUrl` | `{ value: url, enabled: true }` |
+| Additional servers | **dropped** | Only first server used |
+| `info.description` | **dropped** | |
+
+**Request (per operation):**
+| OpenAPI field | Vayu field | Notes |
+|---|---|---|
+| `summary` → `operationId` → `METHOD /path` | `request.name` | Prefers summary, falls back in order |
+| HTTP method (lowercased key) | `request.method` | Uppercased |
+| `{{baseUrl}}` + path | `request.url` | Path params `{x}` → `{{x}}` |
+| `parameters[in=query]` | `request.params` | Example/default value used; else `""` |
+| `parameters[in=header]` | `request.headers` | Skip standard headers (Authorization, Content-Type) |
+| `requestBody.content[application/json]` | `body` + `bodyType="json"` | See Body generation section |
+| `requestBody.content[text/plain]` | `body=""` + `bodyType="text"` | |
+| `security[]` / `securitySchemes` | **dropped** | No auth set; user fills in post-import |
+| `tags[0]` | determines parent Collection | |
+| `description` / `externalDocs` | **dropped** | |
+
+### Body Generation from Schema
+
+One level deep only — no recursion into nested objects or `$ref` chains.
+
+| Schema type | Generated value |
+|---|---|
+| `string` | `""` |
+| `integer` / `number` | `0` |
+| `boolean` | `false` |
+| `array` | `[]` |
+| `object` with `properties` | `{ "key": <typed-default> }` for each property (one level) |
+| `object` without `properties` | `{}` |
+| `oneOf` / `anyOf` / `allOf` | `{}` — too ambiguous to resolve |
+| `$ref` | resolved one level; if that resolves to another `$ref`, stops and returns `{}` |
+
+Resulting JSON is pretty-printed and stored as `body` string with `bodyType = "json"`.
+
+### Path Parameters
+
+OpenAPI path parameters use `{param}` syntax. Converted to Vayu `{{param}}`:
+
+```
+/users/{userId}/posts/{postId}  →  {{baseUrl}}/users/{{userId}}/posts/{{postId}}
+```
+
+These `{{userId}}` etc. appear in the URL but have no value set. The user sets them via collection variables or environment variables.
+
+---
+
+## OpenAPI 2.0 (Swagger)
+
+### Detection
+Root-level `swagger === "2.0"`
+
+### Differences from OpenAPI 3.0
+
+**Base URL construction:**
+```
+baseUrl = (schemes[0] || "https") + "://" + host + (basePath !== "/" ? basePath : "")
+```
+Stored as `collection.variables.baseUrl`. Multiple schemes → only the first used.
+
+**Body content type:** Swagger doesn't define `requestBody` per-operation. Uses `consumes[]` at spec level or operation level. Strategy:
+- If operation has `consumes: ["application/json"]` → generate JSON body from `parameters[in=body]` schema
+- If spec-level `consumes` has `application/json` → same
+- If `in=body` parameter exists but no JSON consume → store body as `bodyType: "text"`
+
+**Parameter location:** Swagger `parameters[in=body]` is equivalent to OpenAPI `requestBody`. All other `in` values (`query`, `header`, `path`, `formData`) map the same way.
+
+**`formData` parameters:** Swagger uses `in=formData` instead of `requestBody`. Map to `bodyType: "form-data"` with values joined as `key=value&...`.
+
+**`$ref` resolution:** Swagger uses `#/definitions/ModelName`. Resolved one level deep (same constraint as OpenAPI 3.0).
+
+**`collectionFormat` for array query params:**
+- `csv` → join values with `,` into a single string
+- `multi` → **collapses to last value** (Vayu params is a flat Record)
+- `ssv` / `tsv` / `pipes` → join with respective separator into single string
+
+---
+
+## Compromise Summary
+
+### Universal (all formats)
+
+| Loss | Root cause |
+|---|---|
+| `description` fields dropped | Engine DB has no description column |
+| Duplicate query param keys → last value wins | `params` is `Record<string,string>` |
+| Duplicate header keys → last value wins | `headers` is `Record<string,string>` |
+| File/binary upload body dropped | Vayu has no file attachment in requests |
+
+### Postman v2.1 / v2.0
+
+| Loss | Severity |
+|---|---|
+| Environments not in collection file | High — separate import needed |
+| Disabled requests/folders silently skipped | Medium |
+| Folder-level scripts (pre/post) dropped | Medium |
+| `postman.*` deprecated API in scripts → runtime errors | Medium |
+| Auth inheritance resolved at import time (not dynamic) | Low |
+| OAuth2 / Digest / AWS / NTLM stored but not executed | Low |
+| `urlencoded`/`formdata` body rebuilt as flat string | Low |
+| GraphQL body stored as text | Low |
+| Variable type metadata dropped | Low |
+
+### Insomnia v4
+
+| Loss | Severity |
+|---|---|
+| gRPC / WebSocket / API spec resources dropped | High (if user has these) |
+| Nunjucks template tags (`{% now %}` etc.) rendered as literals | Medium |
+| Nunjucks filters (`\| lower`) rendered as literals | Low |
+| Sub-environment inheritance flattened | Low |
+| Folder-scoped environments dropped | Low |
+| Unit test suites dropped | Low |
+
+### OpenAPI 3.0 / 2.0
+
+| Loss | Severity |
+|---|---|
+| No real values — all params/body are stubs | High — expected for spec import |
+| Security schemes / auth dropped | High — user fills in post-import |
+| `oneOf`/`anyOf`/`allOf` body → empty `{}` | Medium |
+| Multi-tag operations → first tag only (no duplication) | Medium |
+| Additional servers beyond first dropped | Low |
+| Deep `$ref` chains → one level resolved | Low |
+| Response schemas dropped | Low |
+| `collectionFormat: multi` collapses to last value | Low |

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -634,7 +634,11 @@ struct Collection {
     std::string id;
     std::optional<std::string> parent_id;
     std::string name;
-    std::string variables; // JSON - Collection-scoped variables
+    std::string description;  // TEXT NOT NULL DEFAULT ''
+    std::string variables;    // JSON - Collection-scoped variables
+    std::string auth;         // JSON - Auth config (mode + fields), never 'inherit'
+    std::string pre_request_script;  // JS - runs before every request in this collection
+    std::string post_request_script; // JS - runs after every request in this collection
     int order;
     int64_t created_at;
     int64_t updated_at;
@@ -644,15 +648,17 @@ struct Request {
     std::string id;
     std::string collection_id;
     std::string name;
+    std::string description; // TEXT NOT NULL DEFAULT ''
     HttpMethod method;
     std::string url;
-    std::string params;  // JSON - Query parameters
-    std::string headers; // JSON
-    std::string body;    // JSON/Text
-    std::string body_type; // "json", "text", "form-data", "x-www-form-urlencoded", "none"
-    std::string auth;                // JSON
+    std::string params;    // JSON array of KeyValueEntry: [{key,value,enabled,description?}]
+    std::string headers;   // JSON array of KeyValueEntry
+    std::string body;      // JSON discriminated union: {mode,content?} | {mode,fields?}
+    std::string body_type; // Denormalized: equals body.mode for queryability
+    std::string auth;      // JSON - RequestAuth (mode + fields, may be 'inherit')
     std::string pre_request_script;  // JS Code
     std::string post_request_script; // JS Code (Tests)
+    int order;             // INTEGER NOT NULL DEFAULT 0 — position within collection
     int64_t created_at;
     int64_t updated_at;
 };
@@ -660,7 +666,8 @@ struct Request {
 struct Environment {
     std::string id;
     std::string name;
-    std::string variables; // JSON
+    std::string description; // TEXT NOT NULL DEFAULT ''
+    std::string variables;   // JSON
     bool is_active = false;
     int64_t created_at;
     int64_t updated_at;

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -184,7 +184,11 @@ inline auto make_storage (const std::string& path) {
     // Collections: Folder hierarchy for organizing requests
     make_table ("collections", make_column ("id", &Collection::id, primary_key ()),
     make_column ("parent_id", &Collection::parent_id), make_column ("name", &Collection::name),
-    make_column ("variables", &Collection::variables), // JSON: collection-scoped vars
+    make_column ("description", &Collection::description), // NEW: collection description
+    make_column ("variables", &Collection::variables),     // JSON: collection-scoped vars
+    make_column ("auth", &Collection::auth),               // NEW: JSON auth config
+    make_column ("pre_request_script", &Collection::pre_request_script),   // NEW: JS
+    make_column ("post_request_script", &Collection::post_request_script), // NEW: JS
     make_column ("order", &Collection::order),
     make_column ("created_at", &Collection::created_at),
     make_column ("updated_at", &Collection::updated_at)),
@@ -192,20 +196,26 @@ inline auto make_storage (const std::string& path) {
     // Requests: HTTP request definitions with pre/post scripts
     make_table ("requests", make_column ("id", &Request::id, primary_key ()),
     make_column ("collection_id", &Request::collection_id),
-    make_column ("name", &Request::name), make_column ("method", &Request::method),
-    make_column ("url", &Request::url), make_column ("params", &Request::params), // JSON
-    make_column ("headers", &Request::headers), // JSON
-    make_column ("body", &Request::body), make_column ("body_type", &Request::body_type), // Content type
+    make_column ("name", &Request::name),
+    make_column ("description", &Request::description), // NEW: request description
+    make_column ("method", &Request::method),
+    make_column ("url", &Request::url),
+    make_column ("params", &Request::params),   // JSON array of KeyValueEntry
+    make_column ("headers", &Request::headers), // JSON array of KeyValueEntry
+    make_column ("body", &Request::body),       // JSON discriminated union
+    make_column ("body_type", &Request::body_type),
     make_column ("auth", &Request::auth),                               // JSON
     make_column ("pre_request_script", &Request::pre_request_script),   // JS
     make_column ("post_request_script", &Request::post_request_script), // JS
+    make_column ("order", &Request::order),     // NEW: position within collection
     make_column ("created_at", &Request::created_at),
     make_column ("updated_at", &Request::updated_at)),
 
     // Environments: Named variable sets (dev, staging, prod)
     make_table ("environments", make_column ("id", &Environment::id, primary_key ()),
     make_column ("name", &Environment::name),
-    make_column ("variables", &Environment::variables), // JSON: {key: {value, enabled}}
+    make_column ("description", &Environment::description), // NEW: environment description
+    make_column ("variables", &Environment::variables),     // JSON: {key: {value, enabled}}
     make_column ("is_active", &Environment::is_active),
     make_column ("created_at", &Environment::created_at),
     make_column ("updated_at", &Environment::updated_at)),
@@ -510,12 +520,29 @@ std::optional<Collection> Database::get_collection (const std::string& id) {
     return cols.front ();
 }
 
-// Cascade delete: removes all requests in collection first
+// Cascade delete: recursively removes all descendant collections and their requests.
+// BFS discovers all descendant IDs, then deletes deepest-first.
 void Database::delete_collection (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    vayu::utils::log_debug ("Deleting collection: id=" + id);
-    impl_->storage.remove_all<Request> (where (c (&Request::collection_id) == id));
-    impl_->storage.remove_all<Collection> (where (c (&Collection::id) == id));
+    vayu::utils::log_debug ("Deleting collection (cascade): id=" + id);
+
+    // 1. Collect all descendant IDs via BFS (root first)
+    std::vector<std::string> to_delete = { id };
+    size_t idx                         = 0;
+    while (idx < to_delete.size ()) {
+        auto children = impl_->storage.get_all<Collection> (
+        where (c (&Collection::parent_id) == to_delete[idx]));
+        for (const auto& child : children) {
+            to_delete.push_back (child.id);
+        }
+        ++idx;
+    }
+
+    // 2. Delete deepest-first so foreign-key integrity holds at each step
+    for (auto it = to_delete.rbegin (); it != to_delete.rend (); ++it) {
+        impl_->storage.remove_all<Request> (where (c (&Request::collection_id) == *it));
+        impl_->storage.remove_all<Collection> (where (c (&Collection::id) == *it));
+    }
 }
 
 // ============================================================================

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -78,6 +78,12 @@ void register_collection_routes (RouteContext& ctx) {
                 c.name = json["name"].get<std::string> ();
             }
 
+            if (json.contains ("description")) {
+                c.description = json["description"].is_null ()
+                ? ""
+                : json["description"].get<std::string> ();
+            }
+
             if (json.contains ("parentId")) {
                 if (json["parentId"].is_null ()) {
                     c.parent_id = std::nullopt;
@@ -90,7 +96,7 @@ void register_collection_routes (RouteContext& ctx) {
                 c.order = json["order"].get<int> ();
             } else if (!is_update) {
                 // New collection: assign next order among siblings for stable ordering
-                auto all     = ctx.db.get_collections ();
+                auto all      = ctx.db.get_collections ();
                 int max_order = -1;
                 for (const auto& col : all) {
                     if (col.parent_id == c.parent_id && col.order > max_order) {
@@ -100,16 +106,30 @@ void register_collection_routes (RouteContext& ctx) {
                 c.order = max_order + 1;
             }
 
-            // Handle collection variables
+            // Collection variables
             if (json.contains ("variables")) {
-                if (json["variables"].is_null ()) {
-                    c.variables = "{}";
-                } else {
-                    c.variables = json["variables"].dump ();
-                }
+                c.variables = json["variables"].is_null () ? "{}" : json["variables"].dump ();
             } else if (!is_update) {
-                // New collection - initialize with empty variables
                 c.variables = "{}";
+            }
+
+            // Collection auth — never 'inherit'; defaults to {mode: "none"}
+            if (json.contains ("auth")) {
+                c.auth = json["auth"].is_null () ? "{\"mode\":\"none\"}" : json["auth"].dump ();
+            } else if (!is_update) {
+                c.auth = "{\"mode\":\"none\"}";
+            }
+
+            if (json.contains ("preRequestScript")) {
+                c.pre_request_script = json["preRequestScript"].is_null ()
+                ? ""
+                : json["preRequestScript"].get<std::string> ();
+            }
+
+            if (json.contains ("postRequestScript")) {
+                c.post_request_script = json["postRequestScript"].is_null ()
+                ? ""
+                : json["postRequestScript"].get<std::string> ();
             }
 
             if (is_update) {

--- a/engine/src/http/routes/environments.cpp
+++ b/engine/src/http/routes/environments.cpp
@@ -77,6 +77,11 @@ void register_environment_routes (RouteContext& ctx) {
             if (json.contains ("name") && !json["name"].is_null ()) {
                 e.name = json["name"].get<std::string> ();
             }
+            if (json.contains ("description")) {
+                e.description = json["description"].is_null ()
+                ? ""
+                : json["description"].get<std::string> ();
+            }
             if (json.contains ("variables")) {
                 e.variables = json["variables"].dump ();
             }

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -144,6 +144,11 @@ void register_request_routes (RouteContext& ctx) {
             if (json.contains ("name") && !json["name"].is_null ()) {
                 r.name = json["name"].get<std::string> ();
             }
+            if (json.contains ("description")) {
+                r.description = json["description"].is_null ()
+                ? ""
+                : json["description"].get<std::string> ();
+            }
             if (json.contains ("method") && !json["method"].is_null ()) {
                 auto method = vayu::parse_method (json["method"].get<std::string> ());
                 if (!method)
@@ -153,21 +158,73 @@ void register_request_routes (RouteContext& ctx) {
             if (json.contains ("url") && !json["url"].is_null ()) {
                 r.url = json["url"].get<std::string> ();
             }
-            if (json.contains ("params"))
-                r.params = json["params"].dump ();
-            if (json.contains ("headers"))
-                r.headers = json["headers"].dump ();
+
+            // Validate and store params — must be an array of KeyValueEntry
+            if (json.contains ("params")) {
+                const auto& p = json["params"];
+                if (!p.is_array () && !p.is_null ()) {
+                    send_error (res, 400,
+                    "Invalid 'params': must be an array of {key, value, enabled}");
+                    return;
+                }
+                if (p.is_array ()) {
+                    for (size_t i = 0; i < p.size (); ++i) {
+                        const auto& entry = p[i];
+                        if (!entry.contains ("key") || !entry["key"].is_string () ||
+                        !entry.contains ("value") || !entry["value"].is_string () ||
+                        !entry.contains ("enabled") || !entry["enabled"].is_boolean ()) {
+                            send_error (res, 400,
+                            "Invalid params entry at index " + std::to_string (i) +
+                            ": missing required field (key, value, or enabled)");
+                            return;
+                        }
+                    }
+                }
+                r.params = p.is_null () ? "[]" : p.dump ();
+            }
+
+            // Validate and store headers — must be an array of KeyValueEntry
+            if (json.contains ("headers")) {
+                const auto& h = json["headers"];
+                if (!h.is_array () && !h.is_null ()) {
+                    send_error (res, 400,
+                    "Invalid 'headers': must be an array of {key, value, enabled}");
+                    return;
+                }
+                if (h.is_array ()) {
+                    for (size_t i = 0; i < h.size (); ++i) {
+                        const auto& entry = h[i];
+                        if (!entry.contains ("key") || !entry["key"].is_string () ||
+                        !entry.contains ("value") || !entry["value"].is_string () ||
+                        !entry.contains ("enabled") || !entry["enabled"].is_boolean ()) {
+                            send_error (res, 400,
+                            "Invalid headers entry at index " + std::to_string (i) +
+                            ": missing required field (key, value, or enabled)");
+                            return;
+                        }
+                    }
+                }
+                r.headers = h.is_null () ? "[]" : h.dump ();
+            }
+
             if (json.contains ("body"))
-                r.body = json["body"].dump ();
+                r.body = json["body"].is_null () ? "{\"mode\":\"none\"}" : json["body"].dump ();
             if (json.contains ("bodyType") && !json["bodyType"].is_null ()) {
                 r.body_type = json["bodyType"].get<std::string> ();
             }
             if (json.contains ("auth"))
-                r.auth = json["auth"].dump ();
+                r.auth = json["auth"].is_null () ? "{\"mode\":\"inherit\"}" : json["auth"].dump ();
             if (json.contains ("preRequestScript"))
-                r.pre_request_script = json["preRequestScript"].get<std::string> ();
+                r.pre_request_script = json["preRequestScript"].is_null ()
+                ? ""
+                : json["preRequestScript"].get<std::string> ();
             if (json.contains ("postRequestScript"))
-                r.post_request_script = json["postRequestScript"].get<std::string> ();
+                r.post_request_script = json["postRequestScript"].is_null ()
+                ? ""
+                : json["postRequestScript"].get<std::string> ();
+            if (json.contains ("order") && !json["order"].is_null ()) {
+                r.order = json["order"].get<int> ();
+            }
 
             if (is_update) {
                 r.updated_at = now_ms ();

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -134,10 +134,11 @@ Json serialize (const vayu::db::Collection& c) {
     json["id"] = c.id;
     json["parentId"] =
     c.parent_id.has_value () ? Json (c.parent_id.value ()) : Json (nullptr);
-    json["name"]      = c.name;
-    json["order"]     = c.order;
-    json["createdAt"] = c.created_at;
-    json["updatedAt"] = c.updated_at;
+    json["name"]        = c.name;
+    json["description"] = c.description;
+    json["order"]       = c.order;
+    json["createdAt"]   = c.created_at;
+    json["updatedAt"]   = c.updated_at;
 
     // Parse collection variables JSON
     if (c.variables.empty ()) {
@@ -150,6 +151,20 @@ Json serialize (const vayu::db::Collection& c) {
         }
     }
 
+    // Parse auth JSON
+    if (c.auth.empty ()) {
+        json["auth"] = Json::object ({ { "mode", "none" } });
+    } else {
+        try {
+            json["auth"] = Json::parse (c.auth);
+        } catch (const std::exception&) {
+            json["auth"] = Json::object ({ { "mode", "none" } });
+        }
+    }
+
+    json["preRequestScript"]  = c.pre_request_script;
+    json["postRequestScript"] = c.post_request_script;
+
     return json;
 }
 
@@ -158,53 +173,53 @@ Json serialize (const vayu::db::Request& r) {
     json["id"]           = r.id;
     json["collectionId"] = r.collection_id;
     json["name"]         = r.name;
+    json["description"]  = r.description;
     json["method"]       = to_string (r.method);
     json["url"]          = r.url;
+    json["order"]        = r.order;
 
-    // Query params
+    // Query params — stored as JSON array of KeyValueEntry
     if (r.params.empty ()) {
-        json["params"] = Json::object ();
+        json["params"] = Json::array ();
     } else {
         try {
             json["params"] = Json::parse (r.params);
         } catch (const std::exception&) {
-            json["params"] = Json::object ();
+            json["params"] = Json::array ();
         }
     }
 
-    // Safely parse JSON fields with exception handling to prevent "out of
-    // memory" errors from invalid JSON strings stored in the database
+    // Headers — stored as JSON array of KeyValueEntry
     if (r.headers.empty ()) {
-        json["headers"] = Json::object ();
+        json["headers"] = Json::array ();
     } else {
         try {
             json["headers"] = Json::parse (r.headers);
         } catch (const std::exception&) {
-            json["headers"] = Json::object ();
+            json["headers"] = Json::array ();
         }
     }
 
+    // Body — stored as JSON discriminated union {mode, content?} | {mode, fields?}
     if (r.body.empty ()) {
-        json["body"] = Json ();
+        json["body"] = Json::object ({ { "mode", "none" } });
     } else {
         try {
             json["body"] = Json::parse (r.body);
         } catch (const std::exception&) {
-            // If body is not valid JSON, store it as a string
-            json["body"] = r.body;
+            json["body"] = Json::object ({ { "mode", "none" } });
         }
     }
 
-    // Body type
     json["bodyType"] = r.body_type.empty () ? "none" : r.body_type;
 
     if (r.auth.empty ()) {
-        json["auth"] = Json::object ();
+        json["auth"] = Json::object ({ { "mode", "inherit" } });
     } else {
         try {
             json["auth"] = Json::parse (r.auth);
         } catch (const std::exception&) {
-            json["auth"] = Json::object ();
+            json["auth"] = Json::object ({ { "mode", "inherit" } });
         }
     }
 
@@ -217,8 +232,9 @@ Json serialize (const vayu::db::Request& r) {
 
 Json serialize (const vayu::db::Environment& e) {
     Json json;
-    json["id"]   = e.id;
-    json["name"] = e.name;
+    json["id"]          = e.id;
+    json["name"]        = e.name;
+    json["description"] = e.description;
 
     // Safely parse variables JSON with exception handling
     if (e.variables.empty ()) {
@@ -231,6 +247,7 @@ Json serialize (const vayu::db::Environment& e) {
         }
     }
 
+    json["isActive"]  = e.is_active;
     json["updatedAt"] = e.updated_at;
     return json;
 }
@@ -506,93 +523,88 @@ std::string pretty_print (const Json& json, bool color) {
 // ============================================================================
 
 void serialize_to_stream (const vayu::db::Request& r, std::ostream& out) {
-    // Use constant for max field size
-    // This is a reasonable default for most use cases
     const size_t max_field_size = vayu::core::constants::json::MAX_FIELD_SIZE;
 
-    // Manually write JSON to stream to avoid building full object in memory
     out << "{";
     out << "\"id\":" << Json (r.id).dump () << ",";
     out << "\"collectionId\":" << Json (r.collection_id).dump () << ",";
     out << "\"name\":" << Json (r.name).dump () << ",";
+    out << "\"description\":" << Json (r.description).dump () << ",";
     out << "\"method\":" << Json (to_string (r.method)).dump () << ",";
     out << "\"url\":" << Json (r.url).dump () << ",";
+    out << "\"order\":" << r.order << ",";
 
-    // Query params
+    // Query params — JSON array of KeyValueEntry
     out << "\"params\":";
     if (r.params.empty ()) {
-        out << "{}";
+        out << "[]";
     } else {
         try {
-            // Validate size before parsing to prevent OOM
             if (r.params.size () > max_field_size) {
-                out << "{}";
+                out << "[]";
             } else {
                 auto parsed = Json::parse (r.params);
                 out << parsed.dump ();
             }
         } catch (const std::exception&) {
-            out << "{}";
+            out << "[]";
         }
     }
     out << ",";
 
-    // Headers
+    // Headers — JSON array of KeyValueEntry
     out << "\"headers\":";
     if (r.headers.empty ()) {
-        out << "{}";
+        out << "[]";
     } else {
         try {
             if (r.headers.size () > max_field_size) {
-                out << "{}";
+                out << "[]";
             } else {
                 auto parsed = Json::parse (r.headers);
                 out << parsed.dump ();
             }
         } catch (const std::exception&) {
-            out << "{}";
+            out << "[]";
         }
     }
     out << ",";
 
-    // Body
+    // Body — JSON discriminated union
     out << "\"body\":";
     if (r.body.empty ()) {
-        out << "null";
+        out << "{\"mode\":\"none\"}";
     } else {
         try {
             if (r.body.size () > max_field_size) {
-                // For very large bodies, just return as string
-                out << Json (r.body).dump ();
+                out << "{\"mode\":\"none\"}";
             } else {
                 auto parsed = Json::parse (r.body);
                 out << parsed.dump ();
             }
         } catch (const std::exception&) {
-            // If body is not valid JSON, store it as a string
-            out << Json (r.body).dump ();
+            out << "{\"mode\":\"none\"}";
         }
     }
     out << ",";
 
-    // Body type
     out << "\"bodyType\":" << Json (r.body_type.empty () ? "none" : r.body_type).dump ()
         << ",";
 
-    // Auth
+    // Auth — JSON RequestAuth object
     out << "\"auth\":";
     if (r.auth.empty ()) {
-        out << "{}";
+        out << "{\"mode\":\"inherit\"}";
     } else {
         try {
             if (r.auth.size () > max_field_size) {
-                out << "{}";
+                out << "{\"mode\":\"inherit\"}";
             } else {
                 auto parsed = Json::parse (r.auth);
                 out << parsed.dump ();
             }
         } catch (const std::exception&) {
-            out << "{}";
+            out << "{\"mode\":\"inherit\"}";
         }
     }
     out << ",";

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -1,26 +1,128 @@
 /**
  * @file tests/http_client_test.cpp
  * @brief Tests for HTTP client
+ *
+ * Uses a local httplib mock server instead of external services so tests are
+ * deterministic and work in network-isolated CI environments.
  */
 
 #include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
 
 #include "vayu/http/client.hpp"
 
 namespace vayu::http {
 namespace {
 
+// ---------------------------------------------------------------------------
+// Local mock server that mimics the httpbin endpoints used by the tests.
+// Bound to a random port on 127.0.0.1 so tests never touch the network.
+// ---------------------------------------------------------------------------
+class MockHttpBin {
+    public:
+    MockHttpBin () {
+        // GET /get — echo back a JSON object
+        svr_.Get ("/get", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (R"({"origin":"127.0.0.1","url":"/get"})", "application/json");
+        });
+
+        // POST /post — echo body back inside a JSON wrapper
+        svr_.Post ("/post", [] (const httplib::Request& req, httplib::Response& res) {
+            std::string body = R"({"data":")" + req.body + R"(","origin":"127.0.0.1"})";
+            res.set_content (body, "application/json");
+        });
+
+        // GET /delay/:n — sleep n seconds then respond (used for timeout test)
+        svr_.Get ("/delay/10", [] (const httplib::Request&, httplib::Response& res) {
+            std::this_thread::sleep_for (std::chrono::seconds (10));
+            res.set_content (R"({"delayed":true})", "application/json");
+        });
+
+        // GET /redirect/1 — one redirect to /get
+        svr_.Get ("/redirect/1", [this] (const httplib::Request&, httplib::Response& res) {
+            res.set_redirect ("/get", 302);
+        });
+
+        // GET /headers — echo request headers back in the body
+        svr_.Get ("/headers", [] (const httplib::Request& req, httplib::Response& res) {
+            std::string body = "{";
+            bool first       = true;
+            for (const auto& [k, v] : req.headers) {
+                if (!first)
+                    body += ",";
+                body += "\"" + k + "\":\"" + v + "\"";
+                first = false;
+            }
+            body += "}";
+            res.set_content (body, "application/json");
+        });
+
+        // PUT /put — echo back 200
+        svr_.Put ("/put", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (R"({"ok":true})", "application/json");
+        });
+
+        // DELETE /delete — echo back 200
+        svr_.Delete ("/delete", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (R"({"ok":true})", "application/json");
+        });
+
+        // PATCH /patch — echo back 200
+        svr_.Patch ("/patch", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (R"({"ok":true})", "application/json");
+        });
+
+        // GET /response-headers — return a custom header
+        svr_.Get ("/response-headers", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_header ("X-Custom", "test");
+            res.set_content (R"({"X-Custom":"test"})", "application/json");
+        });
+
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+    }
+
+    ~MockHttpBin () {
+        svr_.stop ();
+        if (thread_.joinable ())
+            thread_.join ();
+    }
+
+    std::string url (const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string (port_) + path;
+    }
+
+    private:
+    httplib::Server svr_;
+    std::thread thread_;
+    int port_ = 0;
+};
+
+} // namespace
+
 class HttpClientTest : public ::testing::Test {
     protected:
     void SetUp () override {
+        global_init ();
+        mock_ = std::make_unique<MockHttpBin> ();
         client_ = std::make_unique<Client> ();
     }
 
+    void TearDown () override {
+        mock_.reset ();
+        global_cleanup ();
+    }
+
+    std::unique_ptr<MockHttpBin> mock_;
     std::unique_ptr<Client> client_;
 };
 
 TEST_F (HttpClientTest, SendsGetRequest) {
-    auto result = client_->get ("https://httpbin.org/get");
+    auto result = client_->get (mock_->url ("/get"));
 
     ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
 
@@ -33,8 +135,7 @@ TEST_F (HttpClientTest, SendsGetRequest) {
 TEST_F (HttpClientTest, SendsPostRequest) {
     Headers headers = { { "Content-Type", "application/json" } };
 
-    auto result =
-    client_->post ("https://httpbin.org/post", R"({"name": "test"})", headers);
+    auto result = client_->post (mock_->url ("/post"), R"({"name": "test"})", headers);
 
     ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
 
@@ -46,12 +147,11 @@ TEST_F (HttpClientTest, SendsPostRequest) {
 TEST_F (HttpClientTest, HandlesTimeout) {
     Request request;
     request.method     = HttpMethod::GET;
-    request.url        = "https://httpbin.org/delay/10"; // 10 second delay
-    request.timeout_ms = 1000;                           // 1 second timeout
+    request.url        = mock_->url ("/delay/10");
+    request.timeout_ms = 500; // 500 ms — server sleeps 10 s
 
     auto result = client_->send (request);
 
-    // Client returns Response with status_code=0 and error info for client-side errors
     ASSERT_TRUE (result.is_ok ());
     const auto& response = result.value ();
     EXPECT_EQ (response.status_code, 0);
@@ -61,17 +161,14 @@ TEST_F (HttpClientTest, HandlesTimeout) {
 TEST_F (HttpClientTest, HandlesInvalidUrl) {
     auto result = client_->get ("not-a-valid-url");
 
-    // Client returns Response with status_code=0 and error info for client-side errors
     ASSERT_TRUE (result.is_ok ());
     const auto& response = result.value ();
     EXPECT_EQ (response.status_code, 0);
-    // Could be InvalidUrl or ConnectionFailed depending on curl behavior
     EXPECT_NE (response.error_code, ErrorCode::None);
 }
 
 TEST_F (HttpClientTest, ParsesResponseHeaders) {
-    auto result =
-    client_->get ("https://httpbin.org/response-headers?X-Custom=test");
+    auto result = client_->get (mock_->url ("/response-headers"));
 
     ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
 
@@ -82,7 +179,7 @@ TEST_F (HttpClientTest, ParsesResponseHeaders) {
 TEST_F (HttpClientTest, FollowsRedirects) {
     Request request;
     request.method           = HttpMethod::GET;
-    request.url              = "https://httpbin.org/redirect/1";
+    request.url              = mock_->url ("/redirect/1");
     request.follow_redirects = true;
 
     auto result = client_->send (request);
@@ -94,7 +191,7 @@ TEST_F (HttpClientTest, FollowsRedirects) {
 TEST_F (HttpClientTest, DoesNotFollowRedirectsWhenDisabled) {
     Request request;
     request.method           = HttpMethod::GET;
-    request.url              = "https://httpbin.org/redirect/1";
+    request.url              = mock_->url ("/redirect/1");
     request.follow_redirects = false;
 
     auto result = client_->send (request);
@@ -106,7 +203,7 @@ TEST_F (HttpClientTest, DoesNotFollowRedirectsWhenDisabled) {
 TEST_F (HttpClientTest, SendsCustomHeaders) {
     Request request;
     request.method                     = HttpMethod::GET;
-    request.url                        = "https://httpbin.org/headers";
+    request.url                        = mock_->url ("/headers");
     request.headers["X-Custom-Header"] = "custom-value";
 
     auto result = client_->send (request);
@@ -120,7 +217,7 @@ TEST_F (HttpClientTest, HandlesHttpMethods) {
     {
         Request request;
         request.method                  = HttpMethod::PUT;
-        request.url                     = "https://httpbin.org/put";
+        request.url                     = mock_->url ("/put");
         request.body.mode               = BodyMode::Json;
         request.body.content            = R"({"updated": true})";
         request.headers["Content-Type"] = "application/json";
@@ -134,7 +231,7 @@ TEST_F (HttpClientTest, HandlesHttpMethods) {
     {
         Request request;
         request.method = HttpMethod::DELETE;
-        request.url    = "https://httpbin.org/delete";
+        request.url    = mock_->url ("/delete");
 
         auto result = client_->send (request);
         ASSERT_TRUE (result.is_ok ()) << "DELETE Error: " << result.error ().message;
@@ -145,7 +242,7 @@ TEST_F (HttpClientTest, HandlesHttpMethods) {
     {
         Request request;
         request.method                  = HttpMethod::PATCH;
-        request.url                     = "https://httpbin.org/patch";
+        request.url                     = mock_->url ("/patch");
         request.body.mode               = BodyMode::Json;
         request.body.content            = R"({"patched": true})";
         request.headers["Content-Type"] = "application/json";
@@ -156,5 +253,4 @@ TEST_F (HttpClientTest, HandlesHttpMethods) {
     }
 }
 
-} // namespace
 } // namespace vayu::http


### PR DESCRIPTION
## Summary

- **Fixes silent data loss**: headers/params with `enabled` flags were previously collapsed to `Record<string,string>` at save time, losing disabled rows, duplicate keys, and descriptions. They are now stored as `KeyValueEntry[]` arrays.
- **Hierarchical auth/scripts**: Collections now carry `auth`, `preRequestScript`, `postRequestScript` fields; requests can set `auth.mode = "inherit"` to delegate to their collection chain.
- **Cascade delete**: `delete_collection()` rewritten with BFS to recursively delete all descendant collections and their requests (deepest-first).
- **Hierarchical variable resolution**: `useVariableResolver` now walks the full ancestor chain root-first (globals < root→leaf collections < environment).

## Engine changes (C++/SQLite)

- New columns on `Collection`: `description`, `auth`, `pre_request_script`, `post_request_script`
- New columns on `Request`: `description`, `order`; `params`/`headers` changed from JSON object → JSON array; `body` is now a discriminated union `{mode, content|fields}`; `auth` defaults to `{mode:"inherit"}`
- New column on `Environment`: `description`
- All JSON serializers updated with safe defaults

## Frontend changes (TypeScript/React)

- New domain types: `KeyValueEntry`, `RequestBody` (discriminated union), `RequestAuth` (discriminated union with `inherit` mode)
- Removed lossy `keyValueToRecord`/`recordToKeyValue`; replaced with:
  - `toKeyValueItems()` — domain → UI (adds ephemeral `id`)
  - `toKeyValueEntries()` — UI → domain (strips `id`/`system`)
  - `toFlatHeaders()` — UI → `Record<string,string>` for HTTP execution only
- `useVariableResolver`: hierarchical resolution across full ancestor chain
- `useEngine`: accepts `ExecuteRequestRequest` directly (flat resolved values)
- `AuthPanel`: adds "Inherit from Collection" option
- New `useCollectionAncestors()` hook returning root-first ancestor chain

## Test plan

- [ ] Create a request with disabled headers — verify they survive save/reload
- [ ] Create a request with duplicate header keys — verify both survive
- [ ] Set collection-level Bearer auth, set request auth to "Inherit" — verify request uses collection token
- [ ] Delete a parent collection with nested sub-collections — verify all descendants removed
- [ ] Set a variable in a root collection, override in child collection — verify child value wins in resolution
- [ ] Verify `pnpm type-check` passes (clean)

https://claude.ai/code/session_013M6Ny2agPLr1hNMpaZGfTm

---
_Generated by [Claude Code](https://claude.ai/code/session_013M6Ny2agPLr1hNMpaZGfTm)_