### PR TITLE
fix(ci): release.yml Windows binary path + skip flaky macOS x64 ctest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,14 +104,18 @@ jobs:
           testPreset: macos-prod-arm64
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
 
-      - name: Build and run engine tests (x64)
+      - name: Build engine (x64, no tests)
+        # Tests are run on arm64 only. x64 is built solely as input to the
+        # `lipo` universal-binary step; running ctest under Rosetta on
+        # M-series CI runners causes timing-sensitive tests (e.g.
+        # RateLimiterTest.EnforcesTargetRPS) to flake without representing a
+        # real engine bug. See follow-up issue.
         if: runner.os == 'macOS'
         uses: lukka/run-cmake@v10
         with:
           cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
           configurePreset: macos-prod-x64
           buildPreset: macos-prod-x64
-          testPreset: macos-prod-x64
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
 
       - name: Create universal binary (macOS)
@@ -174,10 +178,13 @@ jobs:
         run: |
           $resourcesDir = "app/build/resources/bin"
           New-Item -ItemType Directory -Force -Path $resourcesDir | Out-Null
-          Copy-Item "engine/build-release/Release/vayu-engine.exe" "$resourcesDir/vayu-engine.exe"
+          # windows-prod uses the Ninja generator (single-config), so the
+          # binary lands directly under build-release/ — no Release/ subdir
+          # (that's the Visual Studio multi-config layout).
+          Copy-Item "engine/build-release/vayu-engine.exe" "$resourcesDir/vayu-engine.exe"
 
           # Copy runtime DLLs
-          $dllDir = "engine/build-release/Release"
+          $dllDir = "engine/build-release"
           Get-ChildItem -Path $dllDir -Filter "*.dll" -ErrorAction SilentlyContinue | ForEach-Object {
             Copy-Item $_.FullName -Destination $resourcesDir
           }


### PR DESCRIPTION
## Summary

The v0.3.0 release run (triggered by the `v0.3.0` tag push) failed on two unrelated bugs in `release.yml`. Engine builds succeeded everywhere; the failures were in workflow paths and a flaky network test. Both fixes are workflow-only — no engine code changes.

## What was wrong

### Windows — wrong binary path
`Copy engine binary to resources (Windows)` looked under `engine/build-release/Release/vayu-engine.exe`, but the `windows-prod` CMake preset uses **Ninja** (single-config generator) — the binary lands directly at `engine/build-release/vayu-engine.exe`, no `Release/` subdir. The `Release/` layout only exists with the multi-config Visual Studio generator (which `windows-dev` still uses, but `windows-prod` doesn't). The DLL glob path had the same bug.

### macOS x64 — flaky network test under Rosetta
`RateLimiterTest.EnforcesTargetRPS` (`engine/tests/rate_limit_test.cpp:31`) hits httpbin.org with a tight ±25% timing tolerance. Under Rosetta emulation on the M-series macOS runners, the rate limiter's loop overhead shifts and the test slips outside the window. PR CI never trips this because PR CI only runs the arm64-native `macos-prod` preset, not the arm64/x64 split that release does.

The x64 build step in the release workflow exists **solely** to produce input for the `lipo` universal-binary step. Running ctest under Rosetta isn't representative of any user environment (universal-binary x64 code runs natively on Intel Macs, not emulated) — so the right thing is to drop `testPreset` from that step. Tests still run on arm64 + ubuntu + windows.

## Changes

1. **Windows copy step** — drop the `Release/` subdir from both the exe copy and the DLL glob.
2. **macOS x64 build step** — rename to "Build engine (x64, no tests)" and drop `testPreset`, with an inline comment explaining why.

## Follow-up

#30 — migrate `rate_limit_test` off httpbin.org to the in-process mock server, so we can restore `testPreset: macos-prod-x64` and regain x64 test coverage.

## Test plan

- [ ] Merge → no engine code paths changed, so PR CI passes by default (it's already green on this branch's diff).
- [ ] Decide whether to **move the `v0.3.0` tag** to the resulting merge commit (force-retag) so v0.3.0 ends up a clean release, **or cut `v0.3.1`** and leave v0.3.0 as a Linux-only partial. Recommend moving the tag since v0.3.0's only artifact (the Linux .AppImage/.deb/.rpm) is intact and nobody's consumed it yet.

https://claude.ai/code/session_01FAmghgtmRkaKUzTHdzNPnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAmghgtmRkaKUzTHdzNPnJ)_