### PR TITLE
perf(engine): lock-free per-request status path + single tick snapshot

### DIFF
--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -22,7 +22,9 @@
  * - All errors preserved, success results sampled if memory constrained
  */
 
+#include <array>
 #include <atomic>
+#include <map>
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -296,11 +298,18 @@ class MetricsCollector {
      * @param requests_sent Total requests submitted to event loop (for send rate)
      * @param requests_expected Total expected requests for the run (0 for open-ended
      *        modes like constant_rps; feeds the dashboard ETA stat)
+     * @param status_snapshot Optional precomputed status-code distribution. When
+     *        non-null it is used verbatim for the `statusCodes` field and the
+     *        derived class breakdown, avoiding a redundant scan when the caller
+     *        already snapshotted the distribution this tick. When null the
+     *        distribution is computed internally.
      * @return JSON object with current metrics
      */
-    [[nodiscard]] nlohmann::json
-    get_current_stats (size_t current_active, double elapsed_seconds, size_t requests_sent,
-    size_t requests_expected = 0) const;
+    [[nodiscard]] nlohmann::json get_current_stats (size_t current_active,
+    double elapsed_seconds,
+    size_t requests_sent,
+    size_t requests_expected                     = 0,
+    const std::map<int, size_t>* status_snapshot = nullptr) const;
 
     private:
     std::string run_id_;
@@ -315,11 +324,15 @@ class MetricsCollector {
     std::atomic<size_t> total_bytes_sent_{ 0 };
     std::atomic<size_t> total_bytes_recv_{ 0 };
 
-    // Status code counts (lock-free for common codes)
-    std::atomic<size_t> status_2xx_{ 0 };
-    std::atomic<size_t> status_3xx_{ 0 };
-    std::atomic<size_t> status_4xx_{ 0 };
-    std::atomic<size_t> status_5xx_{ 0 };
+    // Per-code counts, lock-free on the hot path. HTTP status codes (and the
+    // synthetic code 0 used for transport errors) live in [0, STATUS_CODE_SLOTS).
+    // record_success/record_error do a single relaxed atomic increment here —
+    // no mutex — so the recorder path scales to the 60k+ RPS target. Class
+    // breakdowns (2xx..5xx) are derived at read time, not maintained on the hot
+    // path. Out-of-range codes (>= STATUS_CODE_SLOTS or < 0) fall back to the
+    // rarely-hit overflow map below; real HTTP traffic never takes that lock.
+    static constexpr int STATUS_CODE_SLOTS = 600;
+    std::array<std::atomic<size_t>, STATUS_CODE_SLOTS> status_code_counts_{};
 
     // Lock-free HdrHistogram for latency recording (thread-safe)
     struct hdr_histogram* latency_histogram_{ nullptr };
@@ -336,12 +349,18 @@ class MetricsCollector {
     std::vector<ResponseSample> response_samples_;
     std::atomic<size_t> response_sample_counter_{ 0 };
 
-    // Detailed status code tracking
-    mutable std::mutex status_codes_mutex_;
-    std::map<int, size_t> status_code_counts_;
+    // Overflow for non-standard / out-of-range codes (e.g. 999 from misbehaving
+    // proxies). Dead path for real traffic; guarded by a mutex it almost never
+    // takes, so it adds no contention to the hot path.
+    mutable std::mutex status_overflow_mutex_;
+    std::map<int, size_t> status_overflow_;
 
     // Helper for atomic double addition
     void atomic_add_double (std::atomic<double>& target, double value);
+
+    // Increment the count for a status code. Lock-free for codes in
+    // [0, STATUS_CODE_SLOTS); falls back to the overflow map otherwise.
+    void record_status_code (int status_code);
 };
 
 } // namespace vayu::core

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -122,7 +122,9 @@ struct RunContext {
  * collect_metrics so it can be unit-tested deterministically.
  */
 [[nodiscard]] std::vector<vayu::db::Metric> build_tick_enrichment_metrics (
-const std::shared_ptr<RunContext>& context, int64_t timestamp);
+const std::shared_ptr<RunContext>& context,
+int64_t timestamp,
+const std::map<int, size_t>* status_snapshot = nullptr);
 
 /**
  * @brief Wrap a per-tick stats object as a wire-ready SSE "metrics" event,

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -85,28 +85,14 @@ const std::string& trace_data) {
     atomic_add_double (total_latency_sum_, latency_ms);
     atomic_add_double (total_queue_wait_sum_, queue_wait_ms);
 
-    // Update status code category counters (lock-free)
-    if (status_code >= 200 && status_code < 300) {
-        status_2xx_.fetch_add (1, std::memory_order_relaxed);
-    } else if (status_code >= 300 && status_code < 400) {
-        status_3xx_.fetch_add (1, std::memory_order_relaxed);
-    } else if (status_code >= 400 && status_code < 500) {
-        status_4xx_.fetch_add (1, std::memory_order_relaxed);
-    } else if (status_code >= 500 && status_code < 600) {
-        status_5xx_.fetch_add (1, std::memory_order_relaxed);
-    }
+    // Track the per-code count (lock-free for in-range codes).
+    record_status_code (status_code);
 
     // Record latency in histogram (lock-free, thread-safe)
     // Convert milliseconds to microseconds for histogram precision
     int64_t latency_us = static_cast<int64_t> (latency_ms * 1000.0);
     if (latency_us < 1) latency_us = 1;  // Minimum 1 microsecond
     hdr_record_value (latency_histogram_, latency_us);
-
-    // Track detailed status codes
-    {
-        std::lock_guard<std::mutex> lock (status_codes_mutex_);
-        status_code_counts_[status_code]++;
-    }
 
     // Store success result if configured (sampled)
     if (config_.store_success_traces && !trace_data.empty ()) {
@@ -148,10 +134,7 @@ const std::string& trace_data) {
     // to total_requests — the dashboard breakdown reconciles with the headline
     // count, and the report's failed/errorRate tallies (recomputed from the
     // distribution) account for them instead of silently dropping to zero.
-    {
-        std::lock_guard<std::mutex> lock (status_codes_mutex_);
-        status_code_counts_[0]++;
-    }
+    record_status_code (0);
 
     // Store error record (always store all errors)
     {
@@ -202,9 +185,32 @@ MetricsCollector::Percentiles MetricsCollector::calculate_percentiles () {
     return result;
 }
 
+void MetricsCollector::record_status_code (int status_code) {
+    if (status_code >= 0 && status_code < STATUS_CODE_SLOTS) {
+        // Hot path: single relaxed atomic increment, no lock.
+        status_code_counts_[status_code].fetch_add (1, std::memory_order_relaxed);
+        return;
+    }
+    // Out-of-range (non-standard) code: dead path for real HTTP traffic.
+    std::lock_guard<std::mutex> lock (status_overflow_mutex_);
+    status_overflow_[status_code]++;
+}
+
 std::map<int, size_t> MetricsCollector::status_code_distribution () const {
-    std::lock_guard<std::mutex> lock (status_codes_mutex_);
-    return status_code_counts_;
+    std::map<int, size_t> result;
+    for (int code = 0; code < STATUS_CODE_SLOTS; ++code) {
+        size_t count = status_code_counts_[code].load (std::memory_order_relaxed);
+        if (count > 0) {
+            result[code] = count;
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock (status_overflow_mutex_);
+        for (const auto& [code, count] : status_overflow_) {
+            result[code] += count;
+        }
+    }
+    return result;
 }
 
 size_t MetricsCollector::flush_to_database (db::Database& db) {
@@ -293,7 +299,8 @@ size_t MetricsCollector::memory_usage_bytes () const {
 nlohmann::json MetricsCollector::get_current_stats (size_t current_active,
 double elapsed_seconds,
 size_t requests_sent,
-size_t requests_expected) const {
+size_t requests_expected,
+const std::map<int, size_t>* status_snapshot) const {
     // Lock-free reads from atomic counters
     size_t total    = total_requests ();
     size_t errors   = total_errors ();
@@ -326,11 +333,34 @@ size_t requests_expected) const {
     stats["requestsSent"]     = requests_sent;
     stats["requestsExpected"] = requests_expected;
 
-    // Status code distribution (lock-free)
-    stats["status2xx"] = status_2xx_.load (std::memory_order_relaxed);
-    stats["status3xx"] = status_3xx_.load (std::memory_order_relaxed);
-    stats["status4xx"] = status_4xx_.load (std::memory_order_relaxed);
-    stats["status5xx"] = status_5xx_.load (std::memory_order_relaxed);
+    // Snapshot the status-code distribution once: reuse the caller's snapshot
+    // when provided (the metrics tick takes one snapshot and feeds it to both
+    // the SSE builder and the persisted-rows builder), otherwise compute it.
+    // Both the class breakdown and the full map below derive from this single
+    // copy — no second scan.
+    std::map<int, size_t> local_dist;
+    const std::map<int, size_t>& dist = status_snapshot != nullptr ?
+    *status_snapshot :
+    (local_dist = status_code_distribution ());
+
+    // Status code class breakdown. The dedicated class atomics were removed to
+    // keep the hot path a single increment; classes are derived here. Code 0
+    // (transport errors) and out-of-range codes belong to no class bucket.
+    size_t s2xx = 0, s3xx = 0, s4xx = 0, s5xx = 0;
+    for (const auto& [code, count] : dist) {
+        if (code >= 200 && code < 300)
+            s2xx += count;
+        else if (code >= 300 && code < 400)
+            s3xx += count;
+        else if (code >= 400 && code < 500)
+            s4xx += count;
+        else if (code >= 500 && code < 600)
+            s5xx += count;
+    }
+    stats["status2xx"]       = s2xx;
+    stats["status3xx"]       = s3xx;
+    stats["status4xx"]       = s4xx;
+    stats["status5xx"]       = s5xx;
     stats["droppedRequests"] = dropped_requests_.load (std::memory_order_relaxed);
     stats["avgQueueWaitMs"] = average_queue_wait ();
 
@@ -355,9 +385,10 @@ size_t requests_expected) const {
     stats["bytesReceived"] = total_bytes_received ();
 
     // Full status-code map (same shape the stored time-series carries), so the
-    // app maps one shape for both live and history.
+    // app maps one shape for both live and history. Derived from the same
+    // single snapshot as the class breakdown above.
     nlohmann::json codes = nlohmann::json::object ();
-    for (const auto& [code, count] : status_code_distribution ()) {
+    for (const auto& [code, count] : dist) {
         codes[std::to_string (code)] = count;
     }
     stats["statusCodes"] = codes;

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -567,7 +567,9 @@ std::string build_tick_payload (const nlohmann::json& stats, size_t offset) {
 }
 
 std::vector<vayu::db::Metric> build_tick_enrichment_metrics (
-const std::shared_ptr<RunContext>& context, int64_t timestamp) {
+const std::shared_ptr<RunContext>& context,
+int64_t timestamp,
+const std::map<int, size_t>* status_snapshot) {
     auto& mc = *context->metrics_collector;
     std::vector<vayu::db::Metric> rows;
     rows.reserve (4);
@@ -577,8 +579,14 @@ const std::shared_ptr<RunContext>& context, int64_t timestamp) {
     static_cast<double> (mc.total_bytes_sent ()), "" });
     rows.push_back ({ 0, context->run_id, timestamp, vayu::MetricName::BytesReceived,
     static_cast<double> (mc.total_bytes_received ()), "" });
+    // Reuse the tick's snapshot when provided to avoid a second scan/copy of the
+    // distribution; otherwise compute it (e.g. unit tests calling directly).
+    std::map<int, size_t> local_dist;
+    const std::map<int, size_t>& dist = status_snapshot != nullptr ?
+    *status_snapshot :
+    (local_dist = mc.status_code_distribution ());
     nlohmann::json codes = nlohmann::json::object ();
-    for (const auto& [code, count] : mc.status_code_distribution ()) {
+    for (const auto& [code, count] : dist) {
         codes[std::to_string (code)] = count;
     }
     rows.push_back (
@@ -603,7 +611,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 
     // Build and append one SSE "metrics" event to the in-memory tick topic.
     // Fields match the SSE handler (metrics.cpp) field-for-field.
-    auto emit_live_tick = [&] () {
+    auto emit_live_tick = [&] (const std::map<int, size_t>* status_snapshot) {
         size_t active_count =
         context->event_loop ? context->event_loop->active_count () : 0;
         size_t requests_sent     = context->requests_sent.load ();
@@ -612,8 +620,8 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         double elapsed_seconds =
         context->start_time_ms > 0 ?
         static_cast<double> (now_wall_ms - context->start_time_ms) / 1000.0 : 0.0;
-        auto stats = context->metrics_collector->get_current_stats (
-        active_count, elapsed_seconds, requests_sent, requests_expected);
+        auto stats = context->metrics_collector->get_current_stats (active_count,
+        elapsed_seconds, requests_sent, requests_expected, status_snapshot);
 
         // Instantaneous RPS: delta-based, updated every ≥100 ms.
         auto now_steady     = std::chrono::steady_clock::now ();
@@ -655,13 +663,18 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         "liveTickIntervalMs", vayu::core::constants::server::STATS_INTERVAL_MS);
 
         // Tick 0: emit immediately so consumers see data before the first sleep.
-        emit_live_tick ();
+        emit_live_tick (nullptr);
 
         while (context->is_running && !context->should_stop) {
             std::this_thread::sleep_for (std::chrono::milliseconds (tick_interval_ms));
 
+            // Snapshot the status-code distribution once per tick and share it
+            // with both the SSE builder and (on DB-gated ticks) the persisted
+            // enrichment builder — avoids scanning/copying the map twice.
+            auto status_snapshot = context->metrics_collector->status_code_distribution ();
+
             // Emit a live tick every iteration regardless of the 1 Hz DB gate.
-            emit_live_tick ();
+            emit_live_tick (&status_snapshot);
 
             auto now = std::chrono::steady_clock::now ();
             auto elapsed = std::chrono::duration<double> (now - last_update).count ();
@@ -736,7 +749,9 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
                     vayu::MetricName::Backpressure, static_cast<double> (backpressure), "" });
 
                     // Per-tick enrichment: dropped / bytes / status-code map.
-                    auto enrichment = build_tick_enrichment_metrics (context, timestamp);
+                    // Reuse the snapshot already taken for the live tick above.
+                    auto enrichment = build_tick_enrichment_metrics (
+                    context, timestamp, &status_snapshot);
                     metrics.insert (metrics.end (), enrichment.begin (), enrichment.end ());
 
                     // Avg latency and queue-wait enrichment for the DB batch.
@@ -760,7 +775,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 
         // Final settled tick before signalling closed — consumers use this ordering
         // as the termination contract (last data before closed==true).
-        emit_live_tick ();
+        emit_live_tick (nullptr);
     } catch (const std::exception& e) {
         vayu::utils::log_error ("collect_metrics: " + std::string (e.what ()));
     } catch (...) {

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -176,9 +176,71 @@ TEST_F (MetricsCollectorTest, StatusDistributionSumsToTotalRequests) {
     EXPECT_EQ (distribution[0], 2);
 }
 
+// Out-of-range / non-standard codes (nginx 499 is in-range; 999 from misbehaving
+// proxies, or any code >= 600) must still be preserved exactly, not dropped. The
+// lock-free array covers [0,600); everything else falls back to an overflow map.
+TEST_F (MetricsCollectorTest, PreservesOutOfRangeStatusCodes) {
+    collector->record_success (200, 10.0, 0.0);
+    collector->record_success (999, 10.0, 0.0); // out of array range
+    collector->record_success (999, 10.0, 0.0);
+    collector->record_success (1000, 10.0, 0.0); // out of array range
+
+    auto distribution = collector->status_code_distribution ();
+
+    EXPECT_EQ (distribution[200], 1);
+    EXPECT_EQ (distribution[999], 2);
+    EXPECT_EQ (distribution[1000], 1);
+
+    // Sum invariant must hold even with out-of-range codes.
+    size_t sum = 0;
+    for (const auto& [code, count] : distribution)
+        sum += count;
+    EXPECT_EQ (sum, collector->total_requests ());
+}
+
 // ============================================================================
 // Thread Safety Tests
 // ============================================================================
+
+// Per-code counts must be exact under concurrency: the lock-free hot path
+// (#20) replaced the mutex-guarded map, so verify N threads hammering a spread
+// of distinct codes — including an out-of-range code on the overflow path —
+// produce exact per-code totals with no lost increments.
+TEST_F (MetricsCollectorTest, ThreadSafePerCodeCounts) {
+    const int num_threads         = 8;
+    const int requests_per_thread = 5000;
+    // Codes spanning every class plus one out-of-range overflow code.
+    const std::vector<int> codes = { 200, 201, 301, 404, 500, 503, 999 };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back ([this, &codes] () {
+            for (int i = 0; i < requests_per_thread; ++i) {
+                collector->record_success (codes[i % codes.size ()], 5.0, 0.0);
+            }
+        });
+    }
+    for (auto& t : threads)
+        t.join ();
+
+    auto distribution = collector->status_code_distribution ();
+
+    // Each code is hit floor/ceil of (total / codes.size()) times. With
+    // requests_per_thread a multiple of codes.size()? 5000 % 7 != 0, so compute
+    // exact expected per code from the deterministic round-robin.
+    std::map<int, size_t> expected;
+    for (int t = 0; t < num_threads; ++t)
+        for (int i = 0; i < requests_per_thread; ++i)
+            expected[codes[i % codes.size ()]]++;
+
+    for (const auto& [code, count] : expected) {
+        EXPECT_EQ (distribution[code], count) << "code " << code;
+    }
+    size_t sum = 0;
+    for (const auto& [code, count] : distribution)
+        sum += count;
+    EXPECT_EQ (sum, collector->total_requests ());
+}
 
 TEST_F (MetricsCollectorTest, ThreadSafeRecording) {
     const int num_threads         = 8;
@@ -396,4 +458,25 @@ TEST_F (MetricsCollectorTest, CurrentStatsIncludesBytesAndStatusMap) {
     ASSERT_TRUE (stats.contains ("statusCodes"));
     EXPECT_EQ (stats["statusCodes"]["200"].get<size_t> (), 1u);
     EXPECT_EQ (stats["statusCodes"]["404"].get<size_t> (), 1u);
+}
+
+// The status2xx..5xx SSE fields are now derived at read time from the per-code
+// array (the dedicated class atomics were removed in #20). Verify the derived
+// class breakdown still matches the recorded codes, and that an out-of-range
+// code contributes to no class bucket (same as the old class-counter behavior).
+TEST_F (MetricsCollectorTest, GetCurrentStatsDerivesStatusClasses) {
+    collector->record_success (200, 1.0, 0.0);
+    collector->record_success (204, 1.0, 0.0);
+    collector->record_success (301, 1.0, 0.0);
+    collector->record_success (404, 1.0, 0.0);
+    collector->record_success (404, 1.0, 0.0);
+    collector->record_success (500, 1.0, 0.0);
+    collector->record_success (999, 1.0, 0.0); // out of range: no class bucket
+    collector->record_error (vayu::ErrorCode::Timeout, "t"); // code 0: no class bucket
+
+    auto stats = collector->get_current_stats (0, 1.0, 0, 0);
+    EXPECT_EQ (stats["status2xx"].get<size_t> (), 2u);
+    EXPECT_EQ (stats["status3xx"].get<size_t> (), 1u);
+    EXPECT_EQ (stats["status4xx"].get<size_t> (), 2u);
+    EXPECT_EQ (stats["status5xx"].get<size_t> (), 1u);
 }


### PR DESCRIPTION
## Summary

Two perf fixes on the engine metrics path, both Tier-1 issues raised in post-#19 code review.

**#20 — lock-free per-request status path.** Replace the mutex-guarded `status_code_counts_` map with a fixed `std::array<atomic, 600>` indexed by code. `record_success` and `record_error` now do a single relaxed atomic increment on the hot path — no lock — so the detailed status-code map no longer caps RPS at the mutex contention ceiling at the 60k+ RPS target. Out-of-range / non-standard codes (e.g. 999) fall back to a rarely-hit overflow map so nothing is dropped. The dedicated `status_2xx_..5xx_` atomics are removed; class breakdowns are derived at read time from the per-code array.

**#29 — single tick snapshot.** The metrics tick takes one `status_code_distribution()` snapshot and threads it into both `get_current_stats` (SSE payload) and `build_tick_enrichment_metrics` (persisted rows) via optional pointer params, eliminating the redundant second scan + JSON serialize on DB-gated ticks.

Wire contract unchanged: `statusCodes` map shape and `status2xx..5xx` fields are identical, so no app changes required.

## Testing

Added engine tests:
- `PreservesOutOfRangeStatusCodes`
- `ThreadSafePerCodeCounts` (8x5000 concurrent, exact per-code totals)
- `GetCurrentStatsDerivesStatusClasses`

177 engine tests pass; clang-format + clang-tidy clean.

## Related Issues

Closes #20
Closes #29
