### PR TITLE
fix(engine)+feat(app): consistent Timing across endpoints + Response Timing tab

### DIFF
--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for ResponseTimingTab — the per-request timing breakdown.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ResponseTimingTab from "./ResponseTimingTab";
+import type { ResponseTiming } from "../../types";
+
+const sample: ResponseTiming = {
+	total: 1011,
+	wire: 1008,
+	queueWait: 0.2,
+	dns: 64,
+	connect: 214,
+	tls: 517,
+	firstByte: 213,
+	download: 0,
+};
+
+describe("ResponseTimingTab", () => {
+	it("renders all five phases with their millisecond values", () => {
+		render(<ResponseTimingTab timing={sample} />);
+		for (const label of ["DNS", "Connect", "TLS", "TTFB", "Download"]) {
+			expect(screen.getByText(label)).toBeInTheDocument();
+		}
+		// Phase values (>=100 render with no decimals).
+		expect(screen.getByText("64.0")).toBeInTheDocument(); // dns (10..100 → 1 dp)
+		expect(screen.getByText("214")).toBeInTheDocument(); // connect
+		expect(screen.getByText("517")).toBeInTheDocument(); // tls
+	});
+
+	it("computes each phase as a percentage of the summed network phases", () => {
+		render(<ResponseTimingTab timing={sample} />);
+		// phaseSum = 64+214+517+213+0 = 1008. TLS = 517/1008 ≈ 51%.
+		expect(screen.getByText("51%")).toBeInTheDocument();
+		// Download = 0 → 0%.
+		expect(screen.getByText("0%")).toBeInTheDocument();
+	});
+
+	it("shows Wire, Queue and Total in the summary", () => {
+		render(<ResponseTimingTab timing={sample} />);
+		expect(screen.getByText("Wire")).toBeInTheDocument();
+		expect(screen.getByText("Queue")).toBeInTheDocument();
+		expect(screen.getByText("Total")).toBeInTheDocument();
+		expect(screen.getByText("1008")).toBeInTheDocument(); // wire
+		expect(screen.getByText("1011")).toBeInTheDocument(); // total
+		expect(screen.getByText("0.20")).toBeInTheDocument(); // queueWait (<10 → 2 dp)
+	});
+
+	it("omits Wire and Queue when those fields are absent (restored responses)", () => {
+		const minimal: ResponseTiming = {
+			total: 42,
+			dns: 5,
+			connect: 10,
+			tls: 20,
+			firstByte: 7,
+			download: 0,
+		};
+		render(<ResponseTimingTab timing={minimal} />);
+		expect(screen.queryByText("Wire")).not.toBeInTheDocument();
+		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+		expect(screen.getByText("Total")).toBeInTheDocument();
+	});
+
+	it("handles all-zero phases without dividing by zero", () => {
+		const zero: ResponseTiming = {
+			total: 0,
+			wire: 0,
+			queueWait: 0,
+			dns: 0,
+			connect: 0,
+			tls: 0,
+			firstByte: 0,
+			download: 0,
+		};
+		render(<ResponseTimingTab timing={zero} />);
+		// Every phase share is 0% — at least the five legend rows render it.
+		expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(5);
+	});
+});

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * ResponseTimingTab Component
+ *
+ * Per-request timing breakdown for a single (design-mode) response. The five
+ * network phases (DNS → Connect → TLS → TTFB → Download) are sequential, so
+ * they render as one continuous timeline track with proportional segments,
+ * followed by a precise legend and a Wire · Queue · Total summary.
+ *
+ * Mirrors the dashboard TimingWaterfall's visual idiom (same --chart-* tokens),
+ * but is driven by a single response's timing object rather than run averages.
+ */
+
+import { type ReactNode } from "react";
+import { Info } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { ResponseTiming } from "../../types";
+
+interface Phase {
+	key: string;
+	label: string;
+	value: number;
+	color: string;
+	tip: ReactNode;
+}
+
+/** Tiny "i" affordance with a Radix tooltip (local to keep this tab self-contained). */
+function InfoTip({ tip }: { tip: ReactNode }) {
+	return (
+		<TooltipProvider delayDuration={150}>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						className="ml-1 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-border bg-accent text-muted-foreground hover:border-primary/40 hover:bg-primary/10 hover:text-primary transition-colors cursor-help align-middle"
+						aria-label="More information"
+					>
+						<Info className="h-2.5 w-2.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-[260px] text-[11.5px] leading-relaxed">
+					{tip}
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
+const fmtMs = (v: number): string =>
+	v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
+
+export interface ResponseTimingTabProps {
+	timing: ResponseTiming;
+}
+
+export default function ResponseTimingTab({ timing }: ResponseTimingTabProps) {
+	const phases: Phase[] = [
+		{
+			key: "dns",
+			label: "DNS",
+			value: timing.dns,
+			color: "hsl(var(--chart-2))",
+			tip: "Hostname → IP resolution. Usually a few ms once cached; >50ms suggests slow DNS or a fresh lookup.",
+		},
+		{
+			key: "connect",
+			label: "Connect",
+			value: timing.connect,
+			color: "hsl(var(--chart-4))",
+			tip: "TCP three-way handshake. Zero on connection reuse (HTTP keep-alive / HTTP/2).",
+		},
+		{
+			key: "tls",
+			label: "TLS",
+			value: timing.tls,
+			color: "hsl(var(--chart-5))",
+			tip: "SSL/TLS handshake (HTTPS only). Zero for plain HTTP and on resumed connections.",
+		},
+		{
+			key: "ttfb",
+			label: "TTFB",
+			value: timing.firstByte,
+			color: "hsl(var(--primary))",
+			tip: "Time to first byte — server processing + propagation. If this dominates, the bottleneck is the server, not the network.",
+		},
+		{
+			key: "download",
+			label: "Download",
+			value: timing.download,
+			color: "hsl(var(--success))",
+			tip: "Response body transfer time. Large for big payloads or slow links; near-zero for small JSON.",
+		},
+	];
+
+	// Bar segments are proportional to the network phases (which sum to ≈ wire).
+	const phaseSum = phases.reduce((s, p) => s + Math.max(0, p.value), 0);
+	const pct = (v: number) => (phaseSum > 0 ? (Math.max(0, v) / phaseSum) * 100 : 0);
+
+	return (
+		<div className="p-4 overflow-auto h-full">
+			<p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground mb-3">
+				Request timing
+			</p>
+
+			{/* Continuous timeline: each phase is a sequential segment of the request. */}
+			<div className="flex h-2.5 w-full overflow-hidden rounded-sm bg-accent">
+				{phases.map((p) => (
+					<span
+						key={p.key}
+						className="block h-full transition-[width] duration-300"
+						style={{
+							width: `${pct(p.value)}%`,
+							background: p.color,
+							boxShadow: "inset -1px 0 0 hsl(var(--card))",
+						}}
+						aria-hidden
+					/>
+				))}
+			</div>
+
+			{/* Legend: color swatch · phase · value · share of network time. */}
+			<div className="mt-3.5 space-y-1.5">
+				{phases.map((p) => (
+					<div
+						key={p.key}
+						className="grid grid-cols-[10px_1fr_auto_46px] items-center gap-2.5"
+					>
+						<span
+							className="h-2.5 w-2.5 rounded-[3px]"
+							style={{ background: p.color }}
+							aria-hidden
+						/>
+						<span className="text-[12px] text-muted-foreground inline-flex items-center">
+							{p.label}
+							<InfoTip tip={p.tip} />
+						</span>
+						<span className="text-right font-mono tabular-nums text-[12px]">
+							<span className="text-foreground">{fmtMs(p.value)}</span>
+							<span className="text-subtle-foreground ml-0.5">ms</span>
+						</span>
+						<span className="text-right font-mono tabular-nums text-[11px] text-subtle-foreground">
+							{pct(p.value).toFixed(0)}%
+						</span>
+					</div>
+				))}
+			</div>
+
+			{/* Summary: wire vs generator-side overhead vs perceived total. */}
+			<div className="mt-3.5 pt-3 border-t border-dashed border-border flex flex-wrap items-center gap-x-5 gap-y-1.5 text-[11px]">
+				{timing.wire !== undefined && (
+					<TimingStat
+						label="Wire"
+						value={timing.wire}
+						tip="libcurl transfer time — DNS + connect + TLS + send + receive."
+					/>
+				)}
+				{timing.queueWait !== undefined && (
+					<TimingStat
+						label="Queue"
+						value={timing.queueWait}
+						tip="Generator-side overhead (perceived − wire). Near-zero for a single request; grows under load."
+					/>
+				)}
+				<TimingStat
+					label="Total"
+					value={timing.total}
+					tip="Perceived latency: submit → completion. What the response header shows."
+					emphasized
+				/>
+			</div>
+		</div>
+	);
+}
+
+function TimingStat({
+	label,
+	value,
+	tip,
+	emphasized = false,
+}: {
+	label: string;
+	value: number;
+	tip: ReactNode;
+	emphasized?: boolean;
+}) {
+	return (
+		<span className="inline-flex items-center gap-1.5">
+			<span className="text-muted-foreground inline-flex items-center">
+				{label}
+				<InfoTip tip={tip} />
+			</span>
+			<span
+				className={
+					emphasized
+						? "font-mono tabular-nums font-semibold text-foreground"
+						: "font-mono tabular-nums text-foreground"
+				}
+			>
+				{fmtMs(value)}
+				<span className="text-subtle-foreground ml-0.5">ms</span>
+			</span>
+		</span>
+	);
+}

--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -38,12 +38,13 @@ import { ResponseBody as SharedResponseBody } from "@/components/shared/response
 import ResponseHeader from "./ResponseHeader";
 import ResponseHeadersTab from "./ResponseHeadersTab";
 import ResponseCookies from "./ResponseCookies";
+import ResponseTimingTab from "./ResponseTimingTab";
 import ConsoleOutput from "./ConsoleOutput";
 import TestResults from "./TestResults";
 import RawRequestResponse from "./RawRequestResponse";
 import ClientErrorView from "./ClientErrorView";
 
-type ResponseTab = "body" | "headers" | "cookies" | "console" | "tests" | "raw-request";
+type ResponseTab = "body" | "headers" | "cookies" | "timing" | "console" | "tests" | "raw-request";
 
 export default function ResponseViewer() {
 	const { response, isExecuting } = useRequestBuilderContext();
@@ -188,6 +189,14 @@ export default function ResponseViewer() {
 						>
 							Cookies
 						</TabsTrigger>
+						{response.timing && (
+							<TabsTrigger
+								value="timing"
+								className="shrink-0 border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent"
+							>
+								Timing
+							</TabsTrigger>
+						)}
 						{response.consoleLogs && response.consoleLogs.length > 0 && (
 							<TabsTrigger
 								value="console"
@@ -286,6 +295,9 @@ export default function ResponseViewer() {
 					)}
 					{activeTab === "headers" && <ResponseHeadersTab response={response} />}
 					{activeTab === "cookies" && <ResponseCookies headers={response.headers} />}
+					{activeTab === "timing" && response.timing && (
+						<ResponseTimingTab timing={response.timing} />
+					)}
 					{activeTab === "console" && (
 						<ConsoleOutput
 							logs={response.consoleLogs || []}

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -301,6 +301,7 @@ export default function RequestBuilder() {
 					bodyRaw, // Always include raw body for raw view mode
 					bodyType,
 					time: result.timing?.total || 0,
+					timing: result.timing,
 					size: result.bodySize || 0,
 					// Client-side error info (from engine/curl)
 					errorCode: result.errorCode,

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -112,6 +112,23 @@ export interface RequestState {
 // Response Types
 // ============================================================================
 
+/**
+ * Per-request timing breakdown (milliseconds). Phase fields (dns…download) are
+ * sequential segments of the request; `wire` is libcurl's transfer time and
+ * `queueWait` is generator-side overhead (total − wire). Populated for live
+ * executes; absent for responses restored from history (latency only).
+ */
+export interface ResponseTiming {
+	total: number;
+	wire?: number;
+	queueWait?: number;
+	dns: number;
+	connect: number;
+	tls: number;
+	firstByte: number;
+	download: number;
+}
+
 export interface ResponseState {
 	status: number;
 	statusText: string;
@@ -123,6 +140,7 @@ export interface ResponseState {
 	bodyType: "json" | "html" | "xml" | "text" | "binary";
 	size: number;
 	time: number;
+	timing?: ResponseTiming;
 	timestamp?: string;
 	errorCode?: string;
 	errorMessage?: string;

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -202,6 +202,8 @@ export interface HttpResponse {
 	bodySize: number;
 	timing: {
 		total: number;
+		wire?: number;
+		queueWait?: number;
 		dns: number;
 		connect: number;
 		tls: number;

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -24,6 +24,9 @@
 
 #include <curl/curl.h>
 
+#include <algorithm>
+#include <cassert>
+#include <chrono>
 #include <cstring>
 #include <stdexcept>
 
@@ -353,6 +356,12 @@ Result<Response> Client::send (const Request& request) {
         curl_easy_setopt (curl, CURLOPT_PROXY, impl_->config.proxy_url.c_str ());
     }
 
+    // Stamp submit time before handing off to curl so we can compute perceived
+    // latency the same way the event-loop path does (see curl_utils.cpp). For
+    // single-shot calls queue_wait will be near zero — that's correct and
+    // keeps Timing's contract consistent across endpoints.
+    auto submitted_at = std::chrono::steady_clock::now ();
+
     // Perform the request
     CURLcode res = curl_easy_perform (curl);
 
@@ -362,21 +371,32 @@ Result<Response> Client::send (const Request& request) {
     }
 
     // Get timing info (try to get even on errors, as curl may have partial timing)
-    double total_time = 0, namelookup_time = 0, connect_time = 0;
+    double wire_seconds = 0, namelookup_time = 0, connect_time = 0;
     double appconnect_time = 0, starttransfer_time = 0;
 
-    curl_easy_getinfo (curl, CURLINFO_TOTAL_TIME, &total_time);
+    curl_easy_getinfo (curl, CURLINFO_TOTAL_TIME, &wire_seconds);
     curl_easy_getinfo (curl, CURLINFO_NAMELOOKUP_TIME, &namelookup_time);
     curl_easy_getinfo (curl, CURLINFO_CONNECT_TIME, &connect_time);
     curl_easy_getinfo (curl, CURLINFO_APPCONNECT_TIME, &appconnect_time);
     curl_easy_getinfo (curl, CURLINFO_STARTTRANSFER_TIME, &starttransfer_time);
 
-    response.timing.total_ms   = total_time * 1000.0;
-    response.timing.dns_ms     = namelookup_time * 1000.0;
-    response.timing.connect_ms = (connect_time - namelookup_time) * 1000.0;
-    response.timing.tls_ms     = (appconnect_time - connect_time) * 1000.0;
+    // Match the event-loop semantics: total_ms is perceived (submit→completion),
+    // wire_ms is libcurl's view, queue_wait_ms is the delta. See curl_utils.cpp.
+    auto completion = std::chrono::steady_clock::now ();
+    double perceived_ms = std::chrono::duration<double, std::milli> (
+        completion - submitted_at).count ();
+    double wire_ms = wire_seconds * 1000.0;
+    assert (perceived_ms - wire_ms > -1.0 && "perceived_ms - wire_ms below -1ms — clock issue?");
+    double queue_wait_ms = std::max (0.0, perceived_ms - wire_ms);
+
+    response.timing.total_ms      = perceived_ms;
+    response.timing.wire_ms       = wire_ms;
+    response.timing.queue_wait_ms = queue_wait_ms;
+    response.timing.dns_ms        = namelookup_time * 1000.0;
+    response.timing.connect_ms    = (connect_time - namelookup_time) * 1000.0;
+    response.timing.tls_ms        = (appconnect_time - connect_time) * 1000.0;
     response.timing.first_byte_ms = (starttransfer_time - appconnect_time) * 1000.0;
-    response.timing.download_ms = (total_time - starttransfer_time) * 1000.0;
+    response.timing.download_ms   = (wire_seconds - starttransfer_time) * 1000.0;
 
     // Check for errors
     if (res != CURLE_OK) {


### PR DESCRIPTION
## Summary

Two related changes that finish the work started in #19:

### 1. Engine — align single-shot client Timing with event-loop semantics

PR #19 redefined `Timing::total_ms` as **perceived latency** (`completion − submitted_at`) at the event-loop completion site (`curl_utils.cpp`), with `wire_ms` and `queue_wait_ms` as the breakdown. But the single-shot HTTP client path (`engine/src/http/client.cpp`, used by `POST /request` / design-mode send) still set `response.timing.total_ms` directly from `CURLINFO_TOTAL_TIME` (wire seconds) and left `wire_ms` and `queue_wait_ms` at `0.0`.

So the same `Timing` struct meant two different things depending on which endpoint produced it:

| Endpoint | `total_ms` | `wire_ms` | `queue_wait_ms` |
| --- | --- | --- | --- |
| Load test (event loop) | perceived | curl wire | delta |
| Single-shot `/request` (pre-fix) | wire (mislabeled) | 0 | 0 |

`client.cpp` now stamps `submitted_at` before `curl_easy_perform` and computes the three fields the same way `curl_utils.cpp:264-291` does. For single-shot calls `queue_wait_ms` will be near zero (no event-loop queue) — that's correct and keeps the contract consistent across endpoints.

### 2. App — new Response Timing tab in the request builder

Now that single-shot responses carry a real timing breakdown, surface it. A new `ResponseTimingTab` renders a continuous DNS → Connect → TLS → TTFB → Download timeline (same `--chart-*` tokens as the dashboard waterfall) with a Wire · Queue · Total summary underneath. The tab only appears when `response.timing` is present, so history-restored responses (latency only) keep their existing UI.

- `app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx` — new component
- `app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx` — vitest coverage for phases, percentages, summary, restored-response fallback, all-zero edge case
- `ResponseViewer/index.tsx` — wires the tab (conditional on `response.timing`)
- `request-builder/types.ts` + `types/domain.ts` — `ResponseTiming` with `wire?` / `queueWait?`
- `request-builder/index.tsx` — passes `result.timing` through to the response state

## Test plan

- [ ] Engine builds locally (CI gate)
- [ ] `POST /request` against any URL — response payload now includes non-zero `wire_ms` and `queue_wait_ms ≈ 0`
- [ ] Request-builder shows a new **Timing** tab on a live send with the five phases + Wire/Queue/Total summary
- [ ] Restoring a response from history (no `timing` field) does not show the Timing tab
- [ ] `pnpm test` — new `ResponseTimingTab.test.tsx` passes

Closes #23

https://claude.ai/code/session_01AqFhva6uLpbJJtpXKA7tM8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqFhva6uLpbJJtpXKA7tM8)_