### PR TITLE
fix(engine): align single-shot Timing semantics + expose wire/queue_wait to pm.response

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -57,7 +57,17 @@ Access HTTP response data:
 ```javascript
 pm.response.code              // Status code (number, e.g., 200)
 pm.response.status            // Alias for code
-pm.response.responseTime      // Response time in milliseconds
+pm.response.responseTime      // Perceived latency in ms (submit → completion).
+                              // In load tests this includes generator-side
+                              // queue wait. For pure server wire time, use
+                              // responseTimeWire.
+pm.response.responseTimeWire  // CURLINFO_TOTAL_TIME in ms — DNS + TCP + TLS +
+                              // send + recv. Matches the pre-v0.3 meaning of
+                              // responseTime; use this to assert on server SLAs
+                              // independent of generator load.
+pm.response.responseTimeQueueWait // Generator-side queue overhead in ms,
+                              // i.e. responseTime − responseTimeWire (clamped
+                              // to >= 0). For single-shot sends this is ~0.
 pm.response.headers           // Headers object (lowercase keys)
 pm.response.body              // Raw body string
 pm.response.text()            // Body as string

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -24,6 +24,8 @@
 
 #include <curl/curl.h>
 
+#include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <stdexcept>
 
@@ -353,8 +355,13 @@ Result<Response> Client::send (const Request& request) {
         curl_easy_setopt (curl, CURLOPT_PROXY, impl_->config.proxy_url.c_str ());
     }
 
-    // Perform the request
+    // Perform the request. Stamp submission just before perform so that
+    // perceived latency excludes our own setup cost above but covers everything
+    // libcurl does on this thread. For single-shot sends there is no generator
+    // queue, so queue_wait_ms will be near zero — that's the correct contract.
+    auto submitted_at = std::chrono::steady_clock::now ();
     CURLcode res = curl_easy_perform (curl);
+    auto completion = std::chrono::steady_clock::now ();
 
     // Cleanup headers
     if (headers_list) {
@@ -362,21 +369,27 @@ Result<Response> Client::send (const Request& request) {
     }
 
     // Get timing info (try to get even on errors, as curl may have partial timing)
-    double total_time = 0, namelookup_time = 0, connect_time = 0;
+    double wire_seconds = 0, namelookup_time = 0, connect_time = 0;
     double appconnect_time = 0, starttransfer_time = 0;
 
-    curl_easy_getinfo (curl, CURLINFO_TOTAL_TIME, &total_time);
+    curl_easy_getinfo (curl, CURLINFO_TOTAL_TIME, &wire_seconds);
     curl_easy_getinfo (curl, CURLINFO_NAMELOOKUP_TIME, &namelookup_time);
     curl_easy_getinfo (curl, CURLINFO_CONNECT_TIME, &connect_time);
     curl_easy_getinfo (curl, CURLINFO_APPCONNECT_TIME, &appconnect_time);
     curl_easy_getinfo (curl, CURLINFO_STARTTRANSFER_TIME, &starttransfer_time);
 
-    response.timing.total_ms   = total_time * 1000.0;
-    response.timing.dns_ms     = namelookup_time * 1000.0;
-    response.timing.connect_ms = (connect_time - namelookup_time) * 1000.0;
-    response.timing.tls_ms     = (appconnect_time - connect_time) * 1000.0;
+    double perceived_ms = std::chrono::duration<double, std::milli> (
+        completion - submitted_at).count ();
+    double wire_ms = wire_seconds * 1000.0;
+
+    response.timing.total_ms      = perceived_ms;
+    response.timing.wire_ms       = wire_ms;
+    response.timing.queue_wait_ms = std::max (0.0, perceived_ms - wire_ms);
+    response.timing.dns_ms        = namelookup_time * 1000.0;
+    response.timing.connect_ms    = (connect_time - namelookup_time) * 1000.0;
+    response.timing.tls_ms        = (appconnect_time - connect_time) * 1000.0;
     response.timing.first_byte_ms = (starttransfer_time - appconnect_time) * 1000.0;
-    response.timing.download_ms = (total_time - starttransfer_time) * 1000.0;
+    response.timing.download_ms   = (wire_seconds - starttransfer_time) * 1000.0;
 
     // Check for errors
     if (res != CURLE_OK) {

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -91,8 +91,27 @@ nlohmann::json get_script_completions () {
 
     completions.push_back ({ { "label", "pm.response.responseTime" },
     { "kind", KIND_FIELD }, { "insertText", "pm.response.responseTime" },
-    { "detail", "number" }, { "documentation", "The total response time in milliseconds." },
+    { "detail", "number" },
+    { "documentation",
+    "Perceived response time in milliseconds (submit → completion). Use "
+    "responseTimeWire for server-only timing." },
     { "sortText", "1_pm_response_time" } });
+
+    completions.push_back ({ { "label", "pm.response.responseTimeWire" },
+    { "kind", KIND_FIELD }, { "insertText", "pm.response.responseTimeWire" },
+    { "detail", "number" },
+    { "documentation",
+    "Wire-only response time in milliseconds (CURLINFO_TOTAL_TIME). Pre-#19 "
+    "semantics — use for server-only SLA assertions." },
+    { "sortText", "1_pm_response_time_wire" } });
+
+    completions.push_back ({ { "label", "pm.response.responseTimeQueueWait" },
+    { "kind", KIND_FIELD }, { "insertText", "pm.response.responseTimeQueueWait" },
+    { "detail", "number" },
+    { "documentation",
+    "Generator-side overhead in milliseconds (responseTime − responseTimeWire). "
+    "Near-zero for single-shot sends." },
+    { "sortText", "1_pm_response_time_queue" } });
 
     completions.push_back ({ { "label", "pm.response.headers" }, { "kind", KIND_FIELD },
     { "insertText", "pm.response.headers" }, { "detail", "object" },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -839,9 +839,15 @@ void setup_pm_response (JSContext* ctx, JSValue pm) {
         JS_SetPropertyStr (
         ctx, response, "status", JS_NewInt32 (ctx, data->response->status_code));
 
-        // pm.response.responseTime
+        // pm.response.responseTime — perceived latency (submit → completion),
+        // includes generator-side queue wait. For pure server time, use
+        // responseTimeWire. queue_wait_ms is exposed as responseTimeQueueWait.
         JS_SetPropertyStr (ctx, response, "responseTime",
         JS_NewFloat64 (ctx, data->response->timing.total_ms));
+        JS_SetPropertyStr (ctx, response, "responseTimeWire",
+        JS_NewFloat64 (ctx, data->response->timing.wire_ms));
+        JS_SetPropertyStr (ctx, response, "responseTimeQueueWait",
+        JS_NewFloat64 (ctx, data->response->timing.queue_wait_ms));
 
         // Error information (for client-side failures)
         if (data->response->error_code != vayu::ErrorCode::None) {


### PR DESCRIPTION
## Summary

Closes #23, closes #24.

After PR #19 redefined `Timing::total_ms` as perceived latency (submit → completion) at the event-loop site (`curl_utils.cpp`), the single-shot HTTP path in `engine/src/http/client.cpp` kept emitting `CURLINFO_TOTAL_TIME` (wire seconds) into `total_ms` with `wire_ms`/`queue_wait_ms` left at `0.0`. Same `Timing` struct, two different meanings depending on the endpoint that produced it — and `pm.response.responseTime` (which reads `total_ms`) silently changed semantics for user scripts.

This PR aligns the two sites and gives script authors a way to recover the pre-PR value:

- **`engine/src/http/client.cpp`** — stamp `submitted_at` just before `curl_easy_perform` and `completion` just after, then compute `perceived_ms`, `wire_ms`, and `queue_wait_ms` the same way `curl_utils.cpp` does. For single-shot sends `queue_wait_ms` is ~0, which is the correct contract (no generator queue).
- **`engine/src/runtime/script_engine.cpp`** — add sibling fields to `pm.response`:
  - `responseTime` — perceived latency (existing accessor, unchanged meaning post-#19)
  - `responseTimeWire` — pure `CURLINFO_TOTAL_TIME` in ms (pre-#19 semantics, use for server-only SLA assertions)
  - `responseTimeQueueWait` — `responseTime − responseTimeWire`, clamped ≥ 0
- **`docs/engine/scripting.md`** — document the new semantics and point users at `responseTimeWire` when they want server-only timing.

## Test plan

- [x] `python build.py -e -t` clean
- [x] `ctest --preset linux-dev` — 177/177 pass
- [ ] Smoke: single `POST /request` in design mode shows non-zero `wire_ms`, near-zero `queue_wait_ms`, and a `total_ms` ≈ `wire_ms`
- [ ] Smoke: existing user script using `pm.response.responseTime` still gets a number; new `pm.response.responseTimeWire` matches pre-#19 behavior

https://claude.ai/code/session_01DS49vetHf3HU1aVHK8amyM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DS49vetHf3HU1aVHK8amyM)_