### PR TITLE
fix(engine): sweep retained runs in background (live TTL) + document SSE reconnect contract

### DIFF
--- a/app/src/services/sse-client.ts
+++ b/app/src/services/sse-client.ts
@@ -148,6 +148,16 @@ export class SSEClient {
 				// If the connection is definitively closed, treat as terminal.
 				// The engine now sends an explicit `complete` event for normal run end,
 				// so a CLOSED error state means a genuine connection failure.
+				//
+				// NOTE: we intentionally do NOT reconnect here. Standard `EventSource`
+				// has no API to set the `Last-Event-ID` header on a fresh connection,
+				// so a manual reconnect would request `from=0` and the engine would
+				// replay the entire retained topic — duplicating every tick already
+				// shown and clobbering live RPS / throughput visuals. The browser's
+				// own intra-connection retry (while in CONNECTING) does carry
+				// Last-Event-ID and is fine; once the browser gives up (CLOSED), the
+				// canonical recovery is to converge on `GET /run/:id/report`, which
+				// the load-test service does in its onClose handler.
 				if (this.eventSource?.readyState === EventSource.CLOSED) {
 					console.log("SSE connection closed unexpectedly — treating as terminal");
 					this.disconnect();

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -444,9 +444,18 @@ data: {"event":"complete","runId":"run_1234567890"}
 | `status2xx`–`status5xx` | Per-class counts |
 | `statusCodes` | Full per-code distribution map |
 
-Each `metrics` event carries an `id:` equal to its zero-based offset. On
-reconnect the client may send a `Last-Event-ID` header; the stream resumes from
-`Last-Event-ID + 1` (omit it to replay from the beginning).
+Each `metrics` event carries an `id:` equal to its zero-based offset. The
+browser's built-in `EventSource` retry automatically replays this id as
+`Last-Event-ID` on its **own** intra-connection retries (no application code
+needed), and the stream resumes from `Last-Event-ID + 1`.
+
+**Application-level reconnect**: clients that close the EventSource themselves
+(e.g. after observing `readyState === CLOSED`) should NOT open a new connection
+and rely on `Last-Event-ID` — `EventSource` does not expose a header-setting
+API, so a fresh connect would request `from=0` and replay the entire retained
+topic, duplicating ticks already shown. The canonical recovery is to converge
+on the stored report via `GET /run/:runId/report` (the same path used at normal
+run end). This is the pattern the bundled app uses.
 
 **Responses:**
 - `200` — SSE stream (active run, or finished run still within the retention window).

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -146,7 +147,9 @@ class RunManager {
     std::mutex sweeper_mtx_;
     std::condition_variable sweeper_cv_;
     bool sweeper_stop_{ false };
-    int64_t sweeper_ttl_ms_{ 0 };
+    // Re-read each tick (not captured once) so a runtime change to
+    // liveRetentionMs from the UI takes effect without a daemon restart.
+    std::function<int64_t ()> sweeper_ttl_provider_;
 
     public:
     ~RunManager ();
@@ -169,9 +172,13 @@ class RunManager {
     // Number of retained (completed but not yet swept) runs. Test-only hook.
     size_t retained_count () const;
 
-    // Start a background thread that calls sweep_retained(ttl_ms) every
-    // ttl_ms/2. Idempotent — second calls are no-ops. Stopped in the
+    // Start a background thread that periodically calls sweep_retained. The
+    // provider is invoked each tick to obtain the current TTL (ms), so a config
+    // change to liveRetentionMs is honored live; sweep cadence is TTL/2
+    // (floored at 500ms). Idempotent — second calls are no-ops. Stopped in the
     // destructor (or via stop_sweeper) so daemon shutdown is clean.
+    void start_sweeper (std::function<int64_t ()> ttl_provider);
+    // Convenience overload for a fixed TTL (used by tests).
     void start_sweeper (int64_t ttl_ms);
     void stop_sweeper ();
 

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -138,7 +138,19 @@ class RunManager {
     std::map<std::string, std::shared_ptr<RunContext>> active_runs_;
     std::map<std::string, std::shared_ptr<RunContext>> retained_runs_;
 
+    // Background TTL sweeper. Without this, retained runs only get evicted when
+    // /metrics/live or start_run fires — headless API users (POST /run +
+    // GET /run/:id/report) never trigger either, and retained RunContexts
+    // (full tick_buffer, HdrHistogram, counters) accumulate indefinitely.
+    std::thread sweeper_thread_;
+    std::mutex sweeper_mtx_;
+    std::condition_variable sweeper_cv_;
+    bool sweeper_stop_{ false };
+    int64_t sweeper_ttl_ms_{ 0 };
+
     public:
+    ~RunManager ();
+
     void register_run (const std::string& run_id, std::shared_ptr<RunContext> context);
     std::shared_ptr<RunContext> get_run (const std::string& run_id);
     void unregister_run (const std::string& run_id);
@@ -154,6 +166,14 @@ class RunManager {
     std::shared_ptr<RunContext> get_run_or_retained (const std::string& run_id);
     // Evict retained runs whose completed_at_ms is older than ttl_ms.
     void sweep_retained (int64_t ttl_ms);
+    // Number of retained (completed but not yet swept) runs. Test-only hook.
+    size_t retained_count () const;
+
+    // Start a background thread that calls sweep_retained(ttl_ms) every
+    // ttl_ms/2. Idempotent — second calls are no-ops. Stopped in the
+    // destructor (or via stop_sweeper) so daemon shutdown is clean.
+    void start_sweeper (int64_t ttl_ms);
+    void stop_sweeper ();
 
     // Helper to start a run
     void start_run (const std::string& run_id,

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -262,6 +262,54 @@ size_t RunManager::active_count () const {
     return active_runs_.size ();
 }
 
+size_t RunManager::retained_count () const {
+    std::lock_guard<std::mutex> lock (mutex_);
+    return retained_runs_.size ();
+}
+
+void RunManager::start_sweeper (int64_t ttl_ms) {
+    {
+        std::lock_guard<std::mutex> lock (sweeper_mtx_);
+        if (sweeper_thread_.joinable ()) return; // already running
+        sweeper_stop_   = false;
+        sweeper_ttl_ms_ = std::max<int64_t> (ttl_ms, 1000);
+    }
+    sweeper_thread_ = std::thread ([this] () {
+        int64_t ttl = sweeper_ttl_ms_;
+        // Sweep at half the TTL so a retained run is evicted within ttl..1.5*ttl
+        // of completion. Use a cv with timed_wait so daemon shutdown wakes us.
+        auto interval = std::chrono::milliseconds (std::max<int64_t> (ttl / 2, 500));
+        std::unique_lock<std::mutex> lock (sweeper_mtx_);
+        while (!sweeper_stop_) {
+            if (sweeper_cv_.wait_for (lock, interval, [this] { return sweeper_stop_; })) {
+                break;
+            }
+            lock.unlock ();
+            try {
+                sweep_retained (ttl);
+            } catch (...) {
+                // Defensive: never let an exception escape the sweeper thread.
+            }
+            lock.lock ();
+        }
+    });
+}
+
+void RunManager::stop_sweeper () {
+    {
+        std::lock_guard<std::mutex> lock (sweeper_mtx_);
+        sweeper_stop_ = true;
+    }
+    sweeper_cv_.notify_all ();
+    if (sweeper_thread_.joinable ()) {
+        sweeper_thread_.join ();
+    }
+}
+
+RunManager::~RunManager () {
+    stop_sweeper ();
+}
+
 std::vector<std::shared_ptr<RunContext>> RunManager::get_all_active_runs () const {
     std::lock_guard<std::mutex> lock (mutex_);
     std::vector<std::shared_ptr<RunContext>> runs;

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -267,20 +267,24 @@ size_t RunManager::retained_count () const {
     return retained_runs_.size ();
 }
 
-void RunManager::start_sweeper (int64_t ttl_ms) {
+void RunManager::start_sweeper (std::function<int64_t ()> ttl_provider) {
     {
         std::lock_guard<std::mutex> lock (sweeper_mtx_);
         if (sweeper_thread_.joinable ()) return; // already running
-        sweeper_stop_   = false;
-        sweeper_ttl_ms_ = std::max<int64_t> (ttl_ms, 1000);
+        sweeper_stop_         = false;
+        sweeper_ttl_provider_ = std::move (ttl_provider);
     }
     sweeper_thread_ = std::thread ([this] () {
-        int64_t ttl = sweeper_ttl_ms_;
-        // Sweep at half the TTL so a retained run is evicted within ttl..1.5*ttl
-        // of completion. Use a cv with timed_wait so daemon shutdown wakes us.
-        auto interval = std::chrono::milliseconds (std::max<int64_t> (ttl / 2, 500));
         std::unique_lock<std::mutex> lock (sweeper_mtx_);
         while (!sweeper_stop_) {
+            // Re-read the TTL each tick so a runtime change to liveRetentionMs
+            // (Settings → Observability) takes effect without a daemon restart.
+            // Sweep at half the TTL so a retained run is evicted within
+            // ttl..1.5*ttl of completion; the 500ms cadence floor keeps a tiny
+            // or zero TTL (retention disabled) from busy-looping. ttl==0 means
+            // "evict immediately", which sweep_retained already handles.
+            int64_t ttl = std::max<int64_t> (sweeper_ttl_provider_ (), 0);
+            auto interval = std::chrono::milliseconds (std::max<int64_t> (ttl / 2, 500));
             if (sweeper_cv_.wait_for (lock, interval, [this] { return sweeper_stop_; })) {
                 break;
             }
@@ -293,6 +297,10 @@ void RunManager::start_sweeper (int64_t ttl_ms) {
             lock.lock ();
         }
     });
+}
+
+void RunManager::start_sweeper (int64_t ttl_ms) {
+    start_sweeper ([ttl_ms] () { return ttl_ms; });
 }
 
 void RunManager::stop_sweeper () {

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -164,14 +164,12 @@ int main (int argc, char* argv[]) {
 
     // Create RunManager and start its background TTL sweeper so retained
     // runs (completed but kept for /metrics/live replay) get evicted even in
-    // headless flows that never hit /metrics/live or /run.
+    // headless flows that never hit /metrics/live or /run. The provider is
+    // re-read each sweep tick, so changing liveRetentionMs from the UI takes
+    // effect without restarting the daemon (0 = evict immediately).
     vayu::core::RunManager run_manager;
-    {
-        int retention_ms = db.get_config_int ("liveRetentionMs", 60000);
-        if (retention_ms > 0) {
-            run_manager.start_sweeper (retention_ms);
-        }
-    }
+    run_manager.start_sweeper (
+    [&db] () -> int64_t { return db.get_config_int ("liveRetentionMs", 60000); });
 
     // Create and start HTTP server
     // verbose parameter is kept for backward compatibility with server internals

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -162,8 +162,16 @@ int main (int argc, char* argv[]) {
     // Initialize curl
     vayu::http::global_init ();
 
-    // Create RunManager
+    // Create RunManager and start its background TTL sweeper so retained
+    // runs (completed but kept for /metrics/live replay) get evicted even in
+    // headless flows that never hit /metrics/live or /run.
     vayu::core::RunManager run_manager;
+    {
+        int retention_ms = db.get_config_int ("liveRetentionMs", 60000);
+        if (retention_ms > 0) {
+            run_manager.start_sweeper (retention_ms);
+        }
+    }
 
     // Create and start HTTP server
     // verbose parameter is kept for backward compatibility with server internals

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -78,13 +78,28 @@ TEST (RunManagerRetention, BackgroundSweeperEvictsWithoutExternalTriggers) {
 
     EXPECT_EQ (mgr.retained_count (), 1u);
 
-    // ttl is clamped to >= 1s; sweep cadence is ttl/2 (clamped >= 500ms).
-    // After ~750ms the sweeper has had at least one tick.
+    // Sweep cadence is ttl/2, floored at 500ms. With ttl=1000 → 500ms cadence,
+    // so after ~750ms the sweeper has had at least one tick.
     mgr.start_sweeper (1000);
     std::this_thread::sleep_for (std::chrono::milliseconds (750));
     EXPECT_EQ (mgr.retained_count (), 0u);
 
     mgr.stop_sweeper (); // also exercised by destructor
+}
+
+// The TTL provider must be invoked every tick (not captured once at start), so
+// a runtime change to liveRetentionMs is honored without a daemon restart.
+TEST (RunManagerRetention, BackgroundSweeperRereadsTtlProviderEachTick) {
+    RunManager mgr;
+    std::atomic<int> calls{ 0 };
+    // ttl=1000 → 500ms cadence; over ~1300ms expect at least two invocations.
+    mgr.start_sweeper ([&calls] () -> int64_t {
+        calls.fetch_add (1);
+        return 1000;
+    });
+    std::this_thread::sleep_for (std::chrono::milliseconds (1300));
+    mgr.stop_sweeper ();
+    EXPECT_GE (calls.load (), 2);
 }
 
 TEST (RunManagerRetention, SweepEvictsExpiredOnly) {

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -68,6 +68,25 @@ TEST (BuildTickPayload, WrapsStatsAsSseEventWithOffsetId) {
     EXPECT_EQ (p.substr (p.size () - 2), "\n\n");
 }
 
+TEST (RunManagerRetention, BackgroundSweeperEvictsWithoutExternalTriggers) {
+    RunManager mgr;
+    nlohmann::json cfg;
+    auto a = std::make_shared<RunContext> ("a", cfg);
+    mgr.register_run ("a", a);
+    mgr.retain_run ("a");
+    a->completed_at_ms.store (1); // backdate "a" so it's immediately expired
+
+    EXPECT_EQ (mgr.retained_count (), 1u);
+
+    // ttl is clamped to >= 1s; sweep cadence is ttl/2 (clamped >= 500ms).
+    // After ~750ms the sweeper has had at least one tick.
+    mgr.start_sweeper (1000);
+    std::this_thread::sleep_for (std::chrono::milliseconds (750));
+    EXPECT_EQ (mgr.retained_count (), 0u);
+
+    mgr.stop_sweeper (); // also exercised by destructor
+}
+
 TEST (RunManagerRetention, SweepEvictsExpiredOnly) {
     RunManager mgr;
     nlohmann::json cfg;


### PR DESCRIPTION
Tier-1 fixes from PR #19's live-metrics retention work, plus a follow-up so the new sweeper picks up runtime config changes.

## Summary

**Closes #22 — RunManager retained-run memory leak**
Retained finished runs only got swept when `/metrics/live` or `start_run` was called. Headless API users (`POST /run` + `GET /run/:id/report`) never triggered either, so retained `RunContext`s (tick_buffer + HdrHistogram + counters, ~6-10MB per 10-min run) accumulated indefinitely. Added a background sweeper thread started from `daemon.cpp`; sweep cadence is `ttl/2` (≥500ms floor), cv-driven shutdown joins cleanly in the destructor.

**Closes #21 — SSE Last-Event-ID reconnect contract**
The `/metrics/live` docs encouraged clients to manually send `Last-Event-ID` on reconnect, but standard `EventSource` has no header-setting API, so an app-level reconnect would request `from=0` and replay the entire retained topic (duplicating ticks, clobbering live visuals). The bundled app already converges on `GET /run/:id/report` after a CLOSED EventSource; updated the API reference to formalize this as the canonical recovery and noted that `Last-Event-ID` only applies to the browser's intra-connection retry. Pinned the contract in `sse-client.ts` so the no-reconnect choice is explicit.

**Follow-up: sweeper honors live `liveRetentionMs` changes**
`start_sweeper` originally captured the TTL once at boot, so changing `liveRetentionMs` from Settings → Observability didn't affect the background sweeper until daemon restart (on-demand sweeps from `/metrics/live` and `start_run` already re-read live). `start_sweeper` now takes a `std::function<int64_t()>` provider; `daemon.cpp` passes a lambda reading `db.get_config_int("liveRetentionMs")`. Cadence (`ttl/2`, 500ms floor) is recomputed each tick. The 1000ms TTL floor is dropped so `retention=0` (= evict immediately) is honored. The daemon now always starts the sweeper so raising retention from 0 at runtime works. A fixed-TTL overload is kept for tests, and a new test asserts the provider is invoked on every tick. Change is honored within one sweep cycle (≤ ttl/2), not instantly.

## Test plan
- [x] `ctest --preset linux-dev` — all engine tests pass, including new sweeper coverage (`BackgroundSweeperEvictsWithoutExternalTriggers` + provider-invocation test)
- [x] `pnpm type-check` clean
- [ ] Manual: run engine, start a run, observe retained run gets evicted ~`liveRetentionMs` after completion without any `/metrics/live` traffic
- [ ] Manual: change `liveRetentionMs` from Settings while the daemon is running and confirm the sweeper picks up the new TTL within one cycle
