### PR TITLE
perf(app)+fix(engine): O(1) dashboard aggregates, single per-tick now_ms, non-negative timing phases

### DIFF
--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -24,6 +24,7 @@
 import { memo, useMemo } from "react";
 import { Activity } from "lucide-react";
 import { formatNumber } from "@/utils";
+import { useDashboardStore } from "@/stores";
 import type { MetricsViewProps, DashboardDerived } from "../types";
 import { InfoChip, fmt } from "./shared";
 import { TOOLTIPS } from "./tooltips";
@@ -36,7 +37,6 @@ import {
 	buildStatusOverTime,
 	latestThroughputMbps,
 } from "../utils/metricsTransforms";
-import { computeBreakpoint } from "../utils/computeBreakpoint";
 import { HeroRow } from "./hero/HeroRow";
 import { ModeStatsRow } from "./stats/ModeStatsRow";
 import { ThroughputOverTimeChart, type ThroughputPoint } from "./charts/ThroughputOverTimeChart";
@@ -94,15 +94,19 @@ function MetricsView({
 		[loadMode, chartWindow, rampConfig]
 	);
 
-	const peakConcurrency = useMemo(() => {
-		let max = 0;
-		for (const m of historicalMetrics) {
-			if (m.current_concurrency > max) max = m.current_concurrency;
-		}
-		return max;
-	}, [historicalMetrics]);
+	// Read the monotonic aggregates from the store — they are folded into running
+	// values on each tick in addMetricsBatch, so this is O(1) per render instead
+	// of an O(n) scan over the full historicalMetrics buffer.
+	const peakConcurrency = useDashboardStore((s) => s.peakConcurrency);
+	const breakpoint = useDashboardStore((s) => s.breakpoint);
 
-	const breakpoint = useMemo(() => computeBreakpoint(historicalMetrics), [historicalMetrics]);
+	// Only the latest tick's elapsed_seconds is consumed below — depending on the
+	// whole historicalMetrics array would rebuild `derived` every tick (10 Hz) and
+	// defeat the React.memo on HeroRow / ModeStatsRow.
+	const lastElapsedSeconds =
+		historicalMetrics.length > 0
+			? historicalMetrics[historicalMetrics.length - 1].elapsed_seconds
+			: 0;
 
 	// Derived bundle — computed once, consumed by HeroRow + ModeStatsRow.
 	const derived = useMemo<DashboardDerived | null>(() => {
@@ -117,7 +121,6 @@ function MetricsView({
 			metrics.throughput ??
 			metrics.current_rps;
 		const droppedRequests = metrics.dropped_requests ?? 0;
-		const lastTick = historicalMetrics[historicalMetrics.length - 1];
 
 		return {
 			mode: loadMode,
@@ -144,7 +147,7 @@ function MetricsView({
 			medianLatency: finalReport?.latency?.p50 ?? metrics.latency_p50_ms ?? 0,
 			p95Latency: finalReport?.latency?.p95 ?? metrics.latency_p95_ms ?? 0,
 			testDuration: finalReport?.summary?.testDuration,
-			elapsedSeconds: lastTick?.elapsed_seconds ?? 0,
+			elapsedSeconds: lastElapsedSeconds,
 			setupOverhead: finalReport?.summary?.setupOverhead,
 			droppedRequests,
 			showDropped: isRateLimitedRun(mode, targetRps) && droppedRequests > 0,
@@ -157,7 +160,7 @@ function MetricsView({
 	}, [
 		metrics,
 		finalReport,
-		historicalMetrics,
+		lastElapsedSeconds,
 		loadMode,
 		isCompleted,
 		targetRps,

--- a/app/src/stores/dashboard-store.ts
+++ b/app/src/stores/dashboard-store.ts
@@ -9,6 +9,7 @@
 
 import { create } from "zustand";
 import type { LoadTestMetrics, RunReport } from "@/types";
+import { DEFAULT_SLO_MS, type Breakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
 
 type DashboardMode = "running" | "completed" | "stopped";
 type DashboardView = "metrics" | "request-response";
@@ -40,6 +41,13 @@ export interface LoadTestRequestInfo {
  */
 const HISTORICAL_METRICS_CAP = 3000;
 
+const INITIAL_BREAKPOINT: Breakpoint = {
+	crossed: false,
+	concurrency: null,
+	timeSeconds: null,
+	p99Ms: null,
+};
+
 interface DashboardState {
 	currentRunId: string | null;
 	mode: DashboardMode;
@@ -53,6 +61,14 @@ interface DashboardState {
 	// Config and request info (available during live streaming)
 	loadTestConfig: LoadTestRunConfig | null;
 	requestInfo: LoadTestRequestInfo | null;
+	/**
+	 * Running monotonic aggregates updated on each tick in {@link addMetricsBatch}.
+	 * Stored here instead of recomputed in MetricsView so that consumers see O(1)
+	 * updates per tick rather than a full scan of {@link historicalMetrics} (which
+	 * holds up to {@link HISTORICAL_METRICS_CAP} entries). See PR #26 / #25.
+	 */
+	peakConcurrency: number;
+	breakpoint: Breakpoint;
 
 	// Actions
 	startRun: (
@@ -86,6 +102,8 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 	isStopping: false,
 	loadTestConfig: null,
 	requestInfo: null,
+	peakConcurrency: 0,
+	breakpoint: INITIAL_BREAKPOINT,
 
 	startRun: (runId, config, requestInfo) =>
 		set({
@@ -100,6 +118,8 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 			isStopping: false,
 			loadTestConfig: config ?? null,
 			requestInfo: requestInfo ?? null,
+			peakConcurrency: 0,
+			breakpoint: INITIAL_BREAKPOINT,
 		}),
 
 	stopRun: () =>
@@ -116,9 +136,32 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 			const newHistory = [...state.historicalMetrics, ...batch].slice(
 				-HISTORICAL_METRICS_CAP
 			);
+
+			// Fold the new ticks into the running aggregates. Both are monotone:
+			// peak only grows, breakpoint is latched on the first SLO crossing —
+			// so we walk each batch entry exactly once, never the full history.
+			let peak = state.peakConcurrency;
+			let bp = state.breakpoint;
+			for (const m of batch) {
+				if (m.current_concurrency > peak) peak = m.current_concurrency;
+				if (!bp.crossed) {
+					const p99 = m.latency_p99_ms ?? 0;
+					if (p99 > DEFAULT_SLO_MS) {
+						bp = {
+							crossed: true,
+							concurrency: m.current_concurrency,
+							timeSeconds: m.elapsed_seconds,
+							p99Ms: p99,
+						};
+					}
+				}
+			}
+
 			return {
 				currentMetrics: batch[batch.length - 1],
 				historicalMetrics: newHistory,
+				peakConcurrency: peak,
+				breakpoint: bp,
 			};
 		}),
 
@@ -152,6 +195,8 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 			isStopping: false,
 			loadTestConfig: null,
 			requestInfo: null,
+			peakConcurrency: 0,
+			breakpoint: INITIAL_BREAKPOINT,
 		}),
 
 	// Helpers

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -610,13 +610,17 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
     int tick_interval_ms = 0;
 
     // Build and append one SSE "metrics" event to the in-memory tick topic.
-    // Fields match the SSE handler (metrics.cpp) field-for-field.
-    auto emit_live_tick = [&] (const std::map<int, size_t>* status_snapshot) {
+    // Fields match the SSE handler (metrics.cpp) field-for-field. The wall-clock
+    // timestamp is passed in by the caller so that the SSE tick and any
+    // persisted enrichment for the same logical tick share one timestamp —
+    // re-sampling now_ms() inside drifts them into adjacent ms buckets and the
+    // dashboard sees status-codes shift left vs throughput on the same x-axis.
+    auto emit_live_tick = [&] (const std::map<int, size_t>* status_snapshot,
+        int64_t now_wall_ms) {
         size_t active_count =
         context->event_loop ? context->event_loop->active_count () : 0;
         size_t requests_sent     = context->requests_sent.load ();
         size_t requests_expected = context->requests_expected.load ();
-        int64_t now_wall_ms      = now_ms ();
         double elapsed_seconds =
         context->start_time_ms > 0 ?
         static_cast<double> (now_wall_ms - context->start_time_ms) / 1000.0 : 0.0;
@@ -663,10 +667,15 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         "liveTickIntervalMs", vayu::core::constants::server::STATS_INTERVAL_MS);
 
         // Tick 0: emit immediately so consumers see data before the first sleep.
-        emit_live_tick (nullptr);
+        emit_live_tick (nullptr, now_ms ());
 
         while (context->is_running && !context->should_stop) {
             std::this_thread::sleep_for (std::chrono::milliseconds (tick_interval_ms));
+
+            // Single wall-clock sample per tick — shared by the SSE payload
+            // timestamp, the run-elapsed calc, and (on DB-gated ticks) every
+            // persisted metric row below. See #27.
+            int64_t tick_wall_ms = now_ms ();
 
             // Snapshot the status-code distribution once per tick and share it
             // with both the SSE builder and (on DB-gated ticks) the persisted
@@ -674,7 +683,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
             auto status_snapshot = context->metrics_collector->status_code_distribution ();
 
             // Emit a live tick every iteration regardless of the 1 Hz DB gate.
-            emit_live_tick (&status_snapshot);
+            emit_live_tick (&status_snapshot, tick_wall_ms);
 
             auto now = std::chrono::steady_clock::now ();
             auto elapsed = std::chrono::duration<double> (now - last_update).count ();
@@ -693,7 +702,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
                 // Calculate send rate (requests dispatched per second) and throughput (responses per second)
                 size_t requests_sent = context->requests_sent.load ();
                 double run_elapsed_s =
-                (static_cast<double> (now_ms () - context->start_time_ms)) / 1000.0;
+                (static_cast<double> (tick_wall_ms - context->start_time_ms)) / 1000.0;
                 double send_rate  = run_elapsed_s > 0 ?
                 static_cast<double> (requests_sent) / run_elapsed_s :
                 0.0;
@@ -727,7 +736,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 
                 // Store metrics (batched to reduce lock contention)
                 try {
-                    auto timestamp = now_ms ();
+                    auto timestamp = tick_wall_ms;
                     std::vector<vayu::db::Metric> metrics;
                     metrics.reserve (14);
 
@@ -775,7 +784,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 
         // Final settled tick before signalling closed — consumers use this ordering
         // as the termination contract (last data before closed==true).
-        emit_live_tick (nullptr);
+        emit_live_tick (nullptr, now_ms ());
     } catch (const std::exception& e) {
         vayu::utils::log_error ("collect_metrics: " + std::string (e.what ()));
     } catch (...) {

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -387,11 +387,20 @@ Result<Response> Client::send (const Request& request) {
     response.timing.total_ms      = perceived_ms;
     response.timing.wire_ms       = wire_ms;
     response.timing.queue_wait_ms = std::max (0.0, perceived_ms - wire_ms);
-    response.timing.dns_ms        = namelookup_time * 1000.0;
-    response.timing.connect_ms    = (connect_time - namelookup_time) * 1000.0;
-    response.timing.tls_ms        = (appconnect_time - connect_time) * 1000.0;
-    response.timing.first_byte_ms = (starttransfer_time - appconnect_time) * 1000.0;
-    response.timing.download_ms   = (wire_seconds - starttransfer_time) * 1000.0;
+    // curl phase timers are cumulative from request start; a skipped phase
+    // reports 0. APPCONNECT_TIME is 0 for plain HTTP and for reused keep-alive
+    // connections, which made the naive successive differences render TLS as a
+    // negative "-0ms" and over-count TTFB (it absorbed the connect time). Treat
+    // a zero appconnect as "no TLS phase" by collapsing it onto connect_time,
+    // and clamp every delta at 0 (mirrors the queue_wait_ms guard above).
+    double appconnect = appconnect_time > 0.0 ? appconnect_time : connect_time;
+    response.timing.dns_ms = std::max (0.0, namelookup_time * 1000.0);
+    response.timing.connect_ms = std::max (0.0, (connect_time - namelookup_time) * 1000.0);
+    response.timing.tls_ms = std::max (0.0, (appconnect - connect_time) * 1000.0);
+    response.timing.first_byte_ms =
+    std::max (0.0, (starttransfer_time - appconnect) * 1000.0);
+    response.timing.download_ms =
+    std::max (0.0, (wire_seconds - starttransfer_time) * 1000.0);
 
     // Check for errors
     if (res != CURLE_OK) {

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -132,6 +132,22 @@ TEST_F (HttpClientTest, SendsGetRequest) {
     EXPECT_GT (response.timing.total_ms, 0);
 }
 
+// The mock is plain HTTP (no TLS), so APPCONNECT_TIME is 0 — the case that used
+// to render the TLS phase as a negative "-0ms". Every phase delta must be
+// non-negative, and TLS specifically must be 0 when no handshake occurred.
+TEST_F (HttpClientTest, TimingPhasesAreNonNegative) {
+    auto result = client_->get (mock_->url ("/get"));
+    ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
+
+    const auto& t = result.value ().timing;
+    EXPECT_GE (t.dns_ms, 0.0);
+    EXPECT_GE (t.connect_ms, 0.0);
+    EXPECT_GE (t.tls_ms, 0.0);
+    EXPECT_GE (t.first_byte_ms, 0.0);
+    EXPECT_GE (t.download_ms, 0.0);
+    EXPECT_DOUBLE_EQ (t.tls_ms, 0.0); // plain HTTP — no TLS phase
+}
+
 TEST_F (HttpClientTest, SendsPostRequest) {
     Headers headers = { { "Content-Type", "application/json" } };
 


### PR DESCRIPTION
## Summary

Four small fixes on the metrics-tick / per-request timing path. The first three close issues; the last is a UI follow-up surfaced while testing the per-request timing waterfall on plain HTTP.

### #25 + #26 — Dashboard tick cost

Two issues from the post-#19 review:

- `MetricsView` recomputed `peakConcurrency` and `computeBreakpoint` by scanning the full 3000-entry `historicalMetrics` buffer on every tick (10 Hz). Both are monotone — peak only grows, breakpoint latches on the first SLO crossing.
- The `derived: DashboardDerived` `useMemo` depended on the whole `historicalMetrics` array, so it allocated a new 22-field bundle every tick and reference-broke `HeroRow` / `ModeStatsRow`'s `React.memo`.

**Fix** — move the running aggregates into `dashboard-store.ts`:

```ts
// addMetricsBatch
for (const m of batch) {
  if (m.current_concurrency > peak) peak = m.current_concurrency;
  if (!bp.crossed && (m.latency_p99_ms ?? 0) > DEFAULT_SLO_MS) {
    bp = { crossed: true, concurrency: m.current_concurrency, ... };
  }
}
```

`MetricsView` reads `peakConcurrency` and `breakpoint` from the store, and the `derived` `useMemo` depends on `lastElapsedSeconds` (the only field it actually consumes from history) instead of the whole array — so `HeroRow` and `ModeStatsRow` can now skip renders on ticks where their inputs are unchanged.

### #27 — One `now_ms()` per `collect_metrics` tick

`emit_live_tick` was sampling `now_ms()` for `stats["timestamp"]`, and the DB-write branch called `now_ms()` twice more (for `run_elapsed_s` and the persisted row timestamp). Sub-ms drift between the three samples landed the SSE payload and the persisted enrichment metrics in adjacent ms buckets — visible in the dashboard as a left-shift of the status-codes stacked area vs the throughput chart on the same x-axis.

**Fix** — capture `tick_wall_ms = now_ms()` once per loop iteration, pass it into `emit_live_tick`, and reuse it for the elapsed calc and the persisted timestamp.

### `engine/http/client.cpp` — non-negative timing phases for plain HTTP / keep-alive

Surfaced while exercising the new Response Timing tab (PR #33) against plain-HTTP and keep-alive reused connections: curl's `APPCONNECT_TIME` is `0` when no TLS handshake occurred, so the naive successive differences sent TLS negative (`-0ms` rendered) and TTFB absorbed the connect time.

**Fix** — collapse a zero `appconnect` onto `connect_time` (no TLS phase → `tls_ms = 0`, TTFB measured from connect), and `std::max(0.0, …)` every phase delta — same guard pattern the `queue_wait_ms` line already uses. HTTPS timing is unchanged (`appconnect > connect` there).

New test `TimingPhasesAreNonNegative` against the plain-HTTP `MockHttpBin` asserts every phase ≥ 0 and `tls_ms == 0` when no handshake occurred.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test --run` — 31 files / 190 tests pass
- [x] `python build.py -e -t` — engine builds clean
- [x] `ctest --preset linux-dev` — passes (incl. new `TimingPhasesAreNonNegative`)
- [ ] Smoke: long run (5+ min) — the status-codes stacked area aligns horizontally with the throughput chart (no off-by-one bucket on the same x-axis)
- [ ] Smoke: a ramp_up run shows the saturation card / breakpoint stat update once at the SLO crossing and not on every subsequent tick
- [ ] Smoke: send a single plain-HTTP request — Response Timing tab shows TLS = 0ms (no "-0ms"), TTFB no longer absorbs connect

Closes #25, closes #26, closes #27.

https://claude.ai/code/session_01JpS1JwZWz9NHmzopRUtmo1

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpS1JwZWz9NHmzopRUtmo1)_