### PR TITLE
fix(engine): de-flake rate_limit_test + surface queue_wait clock skew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,18 +104,18 @@ jobs:
           testPreset: macos-prod-arm64
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
 
-      - name: Build engine (x64, no tests)
-        # Tests are run on arm64 only. x64 is built solely as input to the
-        # `lipo` universal-binary step; running ctest under Rosetta on
-        # M-series CI runners causes timing-sensitive tests (e.g.
-        # RateLimiterTest.EnforcesTargetRPS) to flake without representing a
-        # real engine bug. See follow-up issue.
+      - name: Build and run engine tests (x64)
+        # Both architectures run ctest now that RateLimiterTest hits an
+        # in-process mock instead of httpbin.org (issue #30). x64 still goes
+        # through Rosetta on M-series runners, but the remaining tests don't
+        # assert on tight wall-clock windows tied to a remote endpoint.
         if: runner.os == 'macOS'
         uses: lukka/run-cmake@v10
         with:
           cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
           configurePreset: macos-prod-x64
           buildPreset: macos-prod-x64
+          testPreset: macos-prod-x64
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
 
       - name: Create universal binary (macOS)

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -19,6 +19,7 @@
 #include "vayu/http/event_loop/event_loop_worker.hpp"
 #include "vayu/http/event_loop/transfer_context.hpp"
 #include "vayu/http/status.hpp"
+#include "vayu/utils/logger.hpp"
 
 namespace vayu::http::detail {
 
@@ -275,11 +276,23 @@ Result<Response> extract_response (CURL* curl, TransferData* data, CURLcode resu
 
     double wire_ms = wire_seconds * 1000.0;
     // Clamp queue_wait to >= 0 to absorb sub-microsecond clock jitter where
-    // perceived_ms can appear marginally smaller than wire_ms. In debug builds,
-    // assert that the discrepancy is sub-millisecond (a larger negative would
-    // indicate a real bug — wrong clock, stamp-after-submit, etc.).
-    assert (perceived_ms - wire_ms > -1.0 && "perceived_ms - wire_ms below -1ms — clock issue?");
-    double queue_wait_ms = std::max (0.0, perceived_ms - wire_ms);
+    // perceived_ms can appear marginally smaller than wire_ms. A discrepancy
+    // larger than 1ms indicates a real problem (wrong stamp point, clock
+    // skew between steady_clock and curl's TOTAL_TIME, etc.) — debug builds
+    // trip an assert; release builds log a warning so the signal isn't lost
+    // silently in the clamp. Without this, a future regression that moves
+    // `submitted_at` later in the pipeline would zero out queue_wait_ms in
+    // production while CI stays green.
+    double delta = perceived_ms - wire_ms;
+    assert (delta > -1.0 && "perceived_ms - wire_ms below -1ms — clock issue?");
+    if (delta < -1.0) {
+        vayu::utils::log_warning (
+        "queue_wait clock skew: perceived_ms=" + std::to_string (perceived_ms) +
+        " wire_ms=" + std::to_string (wire_ms) +
+        " delta_ms=" + std::to_string (delta) +
+        " — submitted_at stamp may be set after curl wire start");
+    }
+    double queue_wait_ms = std::max (0.0, delta);
 
     response.timing.total_ms      = perceived_ms;        // redefined as perceived
     response.timing.wire_ms       = wire_ms;             // new

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -14,13 +14,13 @@
 #include "vayu/core/load_strategy.hpp"
 
 #include <gtest/gtest.h>
-#include <httplib.h>
 
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
 
+#include "mock_server.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
@@ -28,54 +28,7 @@
 
 namespace {
 
-// Mock server whose only endpoint sleeps ~500ms before responding, so
-// requests stay in-flight long enough for the cap to bite.
-class SlowMockServer {
-    public:
-    SlowMockServer () {
-        // Generous server-side thread pool: the closed-loop tests hold tens of
-        // concurrent /slow requests, and the worker drains active transfers on
-        // stop(). A thread-starved mock would serialize them and make teardown
-        // take tens of seconds (a harness artifact, not engine behavior).
-        svr.new_task_queue = [] { return new httplib::ThreadPool (128); };
-
-        svr.Get ("/slow", [] (const httplib::Request&, httplib::Response& res) {
-            std::this_thread::sleep_for (std::chrono::milliseconds (500));
-            res.set_content ("{}", "application/json");
-        });
-        svr.Get ("/fast", [] (const httplib::Request&, httplib::Response& res) {
-            res.set_content ("{}", "application/json");
-        });
-
-        port   = svr.bind_to_any_port ("127.0.0.1");
-        thread = std::thread ([this] () { svr.listen_after_bind (); });
-
-        // Block until the listener thread has entered accept(); otherwise a
-        // test that tears the fixture down before issuing any request can race
-        // svr.stop() against listen_after_bind() startup. On Windows the stop
-        // signal can be missed in that race, leaving thread.join() to block
-        // forever. wait_until_ready() makes the start synchronous.
-        svr.wait_until_ready ();
-    }
-
-    ~SlowMockServer () {
-        svr.stop ();
-        if (thread.joinable ())
-            thread.join ();
-    }
-
-    std::string slow_url () const {
-        return "http://127.0.0.1:" + std::to_string (port) + "/slow";
-    }
-
-    std::string fast_url () const {
-        return "http://127.0.0.1:" + std::to_string (port) + "/fast";
-    }
-
-    httplib::Server svr;
-    std::thread thread;
-    int port = 0;
-};
+using vayu::tests::SlowMockServer;
 
 const std::string TEST_DB_PATH = "test_load_strategy.db";
 

--- a/engine/tests/mock_server.hpp
+++ b/engine/tests/mock_server.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/**
+ * @file mock_server.hpp
+ * @brief In-process HTTP mock used by tests that need a deterministic endpoint.
+ *
+ * Tests must not depend on external endpoints (e.g. httpbin.org): real network
+ * latency is incompatible with the tight timing windows these tests assert on,
+ * and a runner without outbound network access fails them spuriously.
+ */
+
+#include <httplib.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace vayu::tests {
+
+class SlowMockServer {
+    public:
+    SlowMockServer () {
+        // Generous server-side thread pool: the closed-loop tests hold tens of
+        // concurrent /slow requests, and the worker drains active transfers on
+        // stop(). A thread-starved mock would serialize them and make teardown
+        // take tens of seconds (a harness artifact, not engine behavior).
+        svr.new_task_queue = [] { return new httplib::ThreadPool (128); };
+
+        svr.Get ("/slow", [] (const httplib::Request&, httplib::Response& res) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (500));
+            res.set_content ("{}", "application/json");
+        });
+        svr.Get ("/fast", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content ("{}", "application/json");
+        });
+
+        port   = svr.bind_to_any_port ("127.0.0.1");
+        thread = std::thread ([this] () { svr.listen_after_bind (); });
+
+        // Block until the listener thread has entered accept(); otherwise a
+        // test that tears the fixture down before issuing any request can race
+        // svr.stop() against listen_after_bind() startup. On Windows the stop
+        // signal can be missed in that race, leaving thread.join() to block
+        // forever. wait_until_ready() makes the start synchronous.
+        svr.wait_until_ready ();
+    }
+
+    ~SlowMockServer () {
+        svr.stop ();
+        if (thread.joinable ())
+            thread.join ();
+    }
+
+    std::string slow_url () const {
+        return "http://127.0.0.1:" + std::to_string (port) + "/slow";
+    }
+
+    std::string fast_url () const {
+        return "http://127.0.0.1:" + std::to_string (port) + "/fast";
+    }
+
+    httplib::Server svr;
+    std::thread thread;
+    int port = 0;
+};
+
+} // namespace vayu::tests

--- a/engine/tests/rate_limit_test.cpp
+++ b/engine/tests/rate_limit_test.cpp
@@ -5,16 +5,40 @@
 
 #include <gtest/gtest.h>
 
-#include <atomic>
 #include <chrono>
+#include <thread>
+#include <vector>
 
+#include "mock_server.hpp"
+#include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
 #include "vayu/types.hpp"
 
 using namespace vayu::http;
 using namespace vayu;
+using vayu::tests::SlowMockServer;
 
-TEST (RateLimiterTest, EnforcesTargetRPS) {
+class RateLimiterTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        global_init ();
+        mock = std::make_unique<SlowMockServer> ();
+    }
+    void TearDown () override {
+        mock.reset ();
+        global_cleanup ();
+    }
+    std::unique_ptr<SlowMockServer> mock;
+};
+
+// Pacing assertion is made against an in-process mock (`/fast`) instead of an
+// external endpoint. The previous version pointed at httpbin.org, which made
+// the test depend on real network latency: on macOS x64 (Rosetta-emulated on
+// Apple-silicon runners) the curl_multi loop overhead shifted the measured
+// RPS outside the ±25% window even though the rate limiter itself was fine.
+// Hitting localhost removes that variance — we're checking engine behavior,
+// not someone else's web service.
+TEST_F (RateLimiterTest, EnforcesTargetRPS) {
     // Configure for 100 RPS
     EventLoopConfig config;
     config.target_rps     = 100.0;
@@ -25,10 +49,9 @@ TEST (RateLimiterTest, EnforcesTargetRPS) {
     EventLoop loop (config);
     loop.start ();
 
-    // Prepare request - use a faster endpoint
     Request req;
     req.method = HttpMethod::GET;
-    req.url    = "https://httpbin.org/get";
+    req.url    = mock->fast_url ();
 
     // Track submission timing
     auto submission_start = std::chrono::steady_clock::now ();
@@ -60,7 +83,7 @@ TEST (RateLimiterTest, EnforcesTargetRPS) {
     loop.stop ();
 
     // Check if submission rate is close to target
-    // Allow wider tolerance (±20%) due to curl_multi loop overhead:
+    // Allow wider tolerance (±25%) due to curl_multi loop overhead:
     // - Each iteration includes curl_multi_perform, curl_multi_info_read
     // - Poll timeout adds ~1ms per check when rate-limited
     // - Effective RPS is typically 80-90% of target


### PR DESCRIPTION
## Summary

Fixes two engine hygiene issues filed on 2026-06-05.

### Closes #30 — `rate_limit_test` no longer depends on httpbin.org

`RateLimiterTest.EnforcesTargetRPS` used to hit `https://httpbin.org/get` and assert a tight ±25% window around 100 RPS. Under Rosetta on Apple-silicon runners the `curl_multi` loop overhead shifted measured RPS outside that window and broke the v0.3.0 release. The previous workaround dropped `testPreset` from the macOS x64 lane — losing all rate-limit coverage on x64.

- Extracted `SlowMockServer` from `load_strategy_test.cpp` into `engine/tests/mock_server.hpp`.
- `rate_limit_test.cpp` now points at the in-process `/fast` endpoint.
- Restored `testPreset: macos-prod-x64` in `.github/workflows/release.yml` so both architectures run ctest again.

### Closes #28 — `queue_wait_ms` clock-skew now surfaces in release builds

`queue_wait_ms = std::max(0, perceived_ms - wire_ms)` silently zeroed negative deltas in release builds (only the debug `assert` fired). A future regression moving `submitted_at` later in the pipeline would flatten the metric in production with no signal, even though the PR that added `queue_wait_ms` was specifically intended to surface backpressure.

- Keep the clamp for sub-microsecond jitter.
- When the delta is below -1ms, emit `vayu::utils::log_warning` with `perceived_ms`, `wire_ms`, and `delta_ms` so operators have a signal.
- Debug `assert` retained.

## Test plan

- [x] `python build.py -t` succeeds locally.
- [x] `ctest --preset linux-dev -R RateLimiterTest` passes (1.93s, no network).
- [x] `ctest --preset linux-dev -R LoadStrategy` all 11 tests pass (15.31s).
- [ ] CI: confirm `macos-prod-x64` lane runs ctest green.

---
_Generated by [Claude Code](https://claude.ai/code/session_012mxX9z5T38Mf5XGj74QNGF)_