### PR TITLE
fix(ci): repair Linux + Windows release packaging after electron-builder 26.15.2 bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,17 @@ jobs:
             file app/build/icon.png
             sips -g pixelWidth -g pixelHeight app/build/icon.png
           else
-            # Linux: Use icons directory with all sizes
+            # Linux: electron-builder's icon-set resolver only recognizes files
+            # named "<size>x<size>.png" (e.g. 512x512.png); the shared icons are
+            # prefixed (vayu_icon_512x512.png), so strip the prefix when copying.
+            rm -rf app/build/icons
             mkdir -p app/build/icons
-            cp -r shared/icon_png/* app/build/icons/
+            for f in shared/icon_png/vayu_icon_*.png; do
+              size=$(basename "$f" | sed -E 's/^vayu_icon_([0-9]+x[0-9]+)\.png$/\1/')
+              cp "$f" "app/build/icons/${size}.png"
+            done
+            echo "Icon setup for Linux - contents of app/build/icons:"
+            ls -1 app/build/icons
           fi
 
       - name: Copy engine binary to resources (Windows)

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
 		"electron:dev": "node scripts/electron-dev.mjs",
 		"electron:start": "cross-env NODE_ENV=development electron .",
 		"electron:build": "pnpm electron:compile && pnpm build && electron-builder --config electron-builder.json",
-		"electron:pack": "electron-builder --config electron-builder.json",
+		"electron:pack": "electron-builder --config electron-builder.json --publish never",
 		"clean": "rimraf dist dist-electron release build/resources/bin build/icon.png build/icon.ico build/icon.icns.png build/icons tsconfig.node.tsbuildinfo && rimraf ../engine/build ../engine/build-release",
 		"clean:all": "pnpm clean && rimraf node_modules",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
All three jobs (Ubuntu, Windows, macOS) in the latest release build (run [`27222698299`](https://github.com/athrvk/vayu/actions/runs/27222698299), v0.4.0) failed at the **Package application** step — regressions from the `electron-builder` bump (26.4.0 → 26.15.2).

## 1. Linux — crash in icon resolution

```
⨯ Cannot read properties of undefined (reading 'file')
    at LinuxTargetHelper.computeDesktopIcons (...LinuxTargetHelper.ts:207:50)
```

**Root cause:** the new version rewrote its icon resolver in JS. Its icon-set directory scanner (`collectIconsFromDir` in `iconConverter.js`) only recognizes files whose names **start with the size**:

```js
const match = name.match(/^(\d+)(?:x\d+)?\.png$/i);
```

The CI step copied `shared/icon_png/*` verbatim, producing `vayu_icon_512x512.png` — none of which match. With no icons found, the resolver fell back to the default icon, and for the `"set"` format returned an empty array, crashing at `result[result.length - 1].file`.

**Fix:** strip the `vayu_icon_` prefix when populating `app/build/icons` so files are named `512x512.png`, `256x256.png`, etc.

## 2. Windows & macOS — auto-publish without a token

Both built their installers fine (Windows signed `Vayu-x64.exe`; macOS produced the universal DMG/zip, code-signing skipped as expected without an Apple cert), then failed during publishing:

```
• Implicit publishing triggered by git tag. This behavior will be disabled in electron-builder v27. Please use --publish explicitly.  tag=v0.4.0
...
⨯ Cannot cleanup:
Error: GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
    at PublishManager.artifactCreatedWithoutExplicitPublishConfig
```

**Root cause:** on a tag build, electron-builder saw the `github` `publish` config in `electron-builder.json` and implicitly tried to auto-upload artifacts, but `GH_TOKEN` isn't passed to the package step. The workflow uploads artifacts in a later step, so publishing should be off.

**Fix:** pass `--publish never` to the `electron:pack` script. Update-feed metadata (`latest*.yml`) is still generated locally, just not uploaded — so the workflow's `latest-*.yml` copy steps keep working.

> Note: the v0.4.0 run was triggered from the tag and won't pick up these fixes automatically; they apply to the next tagged release (or a re-run from a ref containing these commits).

https://claude.ai/code/session_0135Qa3m2JSE4ZqsdXQut8f8