### PR TITLE
fix(ci): repair Collect-artifacts step + clear packaging warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p app/build
+          # electron-builder's EULA license must be plain text (.txt/.rtf/.html
+          # for NSIS, plain text for AppImage). The repo-root AGPL-3.0 LICENSE
+          # has no extension, so stage a .txt copy referenced by the config.
+          cp LICENSE app/build/license.txt
           if [ "${{ runner.os }}" = "Windows" ]; then
             # Windows: Use .ico file
             cp shared/icon_ico/vayu_icon_256x256.ico app/build/icon.ico

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,10 @@ jobs:
           # sees new releases.
           cp app/release/latest-linux.yml artifacts/ 2>/dev/null || true
           # Count installers only (the .yml metadata doesn't count as a build).
-          artifact_count=$(ls artifacts/*.AppImage artifacts/*.deb artifacts/*.rpm 2>/dev/null | wc -l | tr -d ' ')
+          # Use find, not `ls <glob>`: under `set -eo pipefail` a non-matching
+          # glob (e.g. no .rpm — Linux only builds AppImage+deb) makes ls exit
+          # non-zero and aborts the step before the count is ever checked.
+          artifact_count=$(find artifacts -maxdepth 1 -type f \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) | wc -l | tr -d ' ')
           if [ "$artifact_count" -eq 0 ]; then
             echo "::error::No Linux artifacts built — AppImage/deb/rpm all missing." >&2
             exit 1
@@ -259,7 +262,8 @@ jobs:
         run: |
           mkdir -p artifacts
           cp app/release/*.dmg artifacts/ 2>/dev/null || true
-          zip_count=$(ls app/release/*.zip 2>/dev/null | wc -l | tr -d ' ')
+          # find avoids `ls <glob>` aborting the step under `set -eo pipefail`.
+          zip_count=$(find app/release -maxdepth 1 -type f -name '*.zip' | wc -l | tr -d ' ')
           if [ "$zip_count" -eq 0 ]; then
             echo "::error::No macOS .zip artifact built - the curl installer would 404. Failing the release." >&2
             exit 1

--- a/app/electron-builder.json
+++ b/app/electron-builder.json
@@ -81,6 +81,7 @@
 		"target": ["AppImage", "deb"],
 		"category": "Development",
 		"icon": "build/icons",
+		"syncDesktopName": true,
 		"maintainer": "Atharva Kusumbia <atharvakusumbia@gmail.com>"
 	},
 	"appImage": {

--- a/app/electron-builder.json
+++ b/app/electron-builder.json
@@ -38,7 +38,7 @@
 		"createDesktopShortcut": "always",
 		"createStartMenuShortcut": true,
 		"shortcutName": "Vayu",
-		"license": "../LICENSE"
+		"license": "build/license.txt"
 	},
 	"mac": {
 		"category": "public.app-category.developer-tools",
@@ -88,7 +88,7 @@
 		"artifactName": "${productName}-${version}-${arch}.${ext}",
 		"category": "Development",
 		"description": "Vayu - High-Performance API Testing Platform",
-		"license": "../LICENSE"
+		"license": "build/license.txt"
 	},
 	"deb": {
 		"afterInstall": "installer/linux-postinst.sh",

--- a/app/package.json
+++ b/app/package.json
@@ -2,6 +2,7 @@
 	"name": "vayu-client",
 	"version": "0.4.0",
 	"description": "Vayu - High-Performance API Testing Platform",
+	"desktopName": "vayu.desktop",
 	"author": {
 		"name": "Atharva Kusumbia",
 		"email": "atharvakusumbia@gmail.com"


### PR DESCRIPTION
Follow-up to #38. After those icon + auto-publish fixes landed, the v0.4.0 release run got further but the Ubuntu job still failed — at the **Collect artifacts** step this time (packaging itself succeeded). This PR fixes that, plus two packaging warnings surfaced in the same logs.

## 1. Collect-artifacts step aborts (the remaining hard failure)

The Linux collect step runs under `bash -eo pipefail` and counted installers with:

```bash
artifact_count=$(ls artifacts/*.AppImage artifacts/*.deb artifacts/*.rpm 2>/dev/null | wc -l | tr -d ' ')
```

Linux only builds AppImage + deb, so the non-matching `*.rpm` glob makes `ls` exit non-zero; `pipefail` propagates it and `set -e` aborts the step (**exit 2**) before the count check ever runs — failing the job even though packaging succeeded. The explicit "No Linux artifacts built" error never printed, which is the tell.

**Fix:** count with `find` (which doesn't error on a non-matching pattern) in both the Linux and macOS collect steps.

## 2. `desktopName is not set in package.json` (warning)

electron-builder 26.15.2 warns the generated `.desktop` entry's `StartupWMClass` can't be matched to Electron's runtime WM_CLASS/`app_id`, so desktop environments may not associate the running window with its launcher.

**Fix:** set `desktopName: "vayu.desktop"` in `package.json` (a real `Metadata` field, read by both Electron and electron-builder) and `linux.syncDesktopName: true`. Verified against the installed schema/source: this makes `StartupWMClass` resolve to `vayu` and names the installed file `vayu.desktop`.

## 3. `license file has unexpected extension` (warning)

`nsis`/`appImage` pointed at the extension-less repo-root `LICENSE`; NSIS needs `.txt`/`.rtf`/`.html` and AppImage needs plain text.

**Fix:** stage `build/license.txt` (a copy of the AGPL-3.0 `LICENSE`, kept as-is per maintainer decision since the distribution bundles the AGPL engine) during the build — next to the icon setup, since `app/build` is gitignored — and reference it from both license fields.

### Not changed (verified harmless)
- `duplicate dependency references` — pnpm hoisting of transitive deps, informational.
- macOS `skipped … code signing` — expected; no Apple cert, `install.sh` ad-hoc signs on-device.

https://claude.ai/code/session_0135Qa3m2JSE4ZqsdXQut8f8

---
_Generated by [Claude Code](https://claude.ai/code/session_0135Qa3m2JSE4ZqsdXQut8f8)_