### PR TITLE
refactor(app): centralize constants + honor configured request timeout end-to-end

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Electron main-process constants.
+ *
+ * The main process is built separately from the renderer (tsconfig.node.json)
+ * and cannot import renderer modules, so values shared with the UI — most
+ * notably the engine port — are duplicated in src/config/network.ts. Keep
+ * them in sync.
+ */
+
+// Engine sidecar (must match src/config/network.ts)
+export const ENGINE_HOST = "127.0.0.1";
+export const ENGINE_PORT = 9876;
+/** Lock file written by the engine inside its data dir. */
+export const ENGINE_LOCK_FILE = "vayu.lock";
+
+// Engine lifecycle
+export const ENGINE_HEALTH_MAX_ATTEMPTS = 90;
+export const ENGINE_HEALTH_POLL_INTERVAL_MS = 500;
+export const ENGINE_HEALTH_REQUEST_TIMEOUT_MS = 2000;
+export const ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS = 2000;
+export const ENGINE_GRACEFUL_EXIT_TIMEOUT_MS = 5000;
+export const ENGINE_RESTART_MAX_RETRIES = 3;
+export const ENGINE_RESTART_BASE_DELAY_MS = 1000;
+/** Pause between stop and start during restart so the port is released. */
+export const ENGINE_PORT_RELEASE_DELAY_MS = 500;
+
+// Window
+export const WINDOW_DEFAULT_WIDTH = 1400;
+export const WINDOW_DEFAULT_HEIGHT = 900;
+export const WINDOW_MIN_WIDTH = 1024;
+export const WINDOW_MIN_HEIGHT = 768;
+/** Custom titlebar overlay height (Windows/Linux). */
+export const TITLEBAR_HEIGHT = 40;
+/** Debounce for persisting window bounds to disk. */
+export const WINDOW_STATE_SAVE_DEBOUNCE_MS = 500;
+
+// Dev server (must match vite.config.ts)
+export const DEV_SERVER_URL = "http://localhost:5173";
+
+// Project links
+export const REPO = "athrvk/vayu";
+export const DOCS_URL = `https://github.com/${REPO}#readme`;
+export const SCRIPTING_DOCS_URL = `https://github.com/${REPO}/blob/master/docs/engine/scripting.md`;
+export const ISSUES_URL = `https://github.com/${REPO}/issues`;
+
+// Auto-updater
+/** Re-check for updates every 6 hours while the app stays open. */
+export const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -11,17 +11,23 @@ import { fileURLToPath } from "url";
 import { EngineSidecar } from "./sidecar.js";
 import { loadWindowState, trackWindowState } from "./window-state.js";
 import { initAutoUpdater, checkForUpdatesNow } from "./updater.js";
+import {
+	DOCS_URL,
+	SCRIPTING_DOCS_URL,
+	ISSUES_URL,
+	DEV_SERVER_URL,
+	WINDOW_DEFAULT_WIDTH,
+	WINDOW_DEFAULT_HEIGHT,
+	WINDOW_MIN_WIDTH,
+	WINDOW_MIN_HEIGHT,
+	TITLEBAR_HEIGHT,
+} from "./constants.js";
 
 const isDev = process.env.NODE_ENV === "development";
 
 // __dirname is not defined in ES modules. Derive it from import.meta.url
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Documentation links opened from the Help menu.
-const DOCS_URL = "https://github.com/athrvk/vayu#readme";
-const SCRIPTING_DOCS_URL = "https://github.com/athrvk/vayu/blob/master/docs/engine/scripting.md";
-const ISSUES_URL = "https://github.com/athrvk/vayu/issues";
 
 // Global sidecar instance
 let engineSidecar: EngineSidecar | null = null;
@@ -30,8 +36,8 @@ let mainWindow: BrowserWindow | null = null;
 function createWindow() {
 	// Load persisted window state
 	const windowState = loadWindowState({
-		defaultWidth: 1400,
-		defaultHeight: 900,
+		defaultWidth: WINDOW_DEFAULT_WIDTH,
+		defaultHeight: WINDOW_DEFAULT_HEIGHT,
 	});
 
 	mainWindow = new BrowserWindow({
@@ -39,8 +45,8 @@ function createWindow() {
 		height: windowState.height,
 		x: windowState.x,
 		y: windowState.y,
-		minWidth: 1024,
-		minHeight: 768,
+		minWidth: WINDOW_MIN_WIDTH,
+		minHeight: WINDOW_MIN_HEIGHT,
 		// Custom titlebar settings
 		frame: false,
 		titleBarStyle: "hidden",
@@ -52,7 +58,7 @@ function createWindow() {
 				: {
 						color: nativeTheme.shouldUseDarkColors ? "#1a1a1a" : "#ffffff",
 						symbolColor: nativeTheme.shouldUseDarkColors ? "#ffffff" : "#1a1a1a",
-						height: 40,
+						height: TITLEBAR_HEIGHT,
 					},
 		webPreferences: {
 			nodeIntegration: false,
@@ -78,7 +84,7 @@ function createWindow() {
 	});
 
 	if (isDev) {
-		mainWindow.loadURL("http://localhost:5173");
+		mainWindow.loadURL(DEV_SERVER_URL);
 		// mainWindow.webContents.openDevTools();
 	} else {
 		mainWindow.loadFile(path.join(__dirname, "../dist/index.html"));

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -15,6 +15,18 @@ import { app } from "electron";
 import path from "path";
 import fs from "fs";
 import net from "net";
+import {
+	ENGINE_PORT,
+	ENGINE_LOCK_FILE,
+	ENGINE_HEALTH_MAX_ATTEMPTS,
+	ENGINE_HEALTH_POLL_INTERVAL_MS,
+	ENGINE_HEALTH_REQUEST_TIMEOUT_MS,
+	ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS,
+	ENGINE_GRACEFUL_EXIT_TIMEOUT_MS,
+	ENGINE_RESTART_MAX_RETRIES,
+	ENGINE_RESTART_BASE_DELAY_MS,
+	ENGINE_PORT_RELEASE_DELAY_MS,
+} from "./constants.js";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -156,7 +168,7 @@ export class EngineSidecar {
 	private dataDir: string;
 	private binaryPath: string;
 
-	constructor(port: number = 9876) {
+	constructor(port: number = ENGINE_PORT) {
 		this.port = port;
 		this.dataDir = this.getDataDirectory();
 		this.binaryPath = this.getEngineBinaryPath();
@@ -187,7 +199,7 @@ export class EngineSidecar {
 	 * This should match the path used by the engine: {dataDir}/vayu.lock
 	 */
 	private getLockFilePath(): string {
-		return path.join(this.dataDir, "vayu.lock");
+		return path.join(this.dataDir, ENGINE_LOCK_FILE);
 	}
 
 	/**
@@ -403,13 +415,19 @@ export class EngineSidecar {
 	/**
 	 * Wait for the engine to be ready by polling the health endpoint
 	 */
-	private async waitForEngine(maxAttempts: number = 90, delay: number = 500): Promise<void> {
+	private async waitForEngine(
+		maxAttempts: number = ENGINE_HEALTH_MAX_ATTEMPTS,
+		delay: number = ENGINE_HEALTH_POLL_INTERVAL_MS
+	): Promise<void> {
 		const healthUrl = `http://127.0.0.1:${this.port}/health`;
 
 		for (let i = 0; i < maxAttempts; i++) {
 			try {
 				const controller = new AbortController();
-				const timeout = setTimeout(() => controller.abort(), 2000);
+				const timeout = setTimeout(
+					() => controller.abort(),
+					ENGINE_HEALTH_REQUEST_TIMEOUT_MS
+				);
 
 				const response = await fetch(healthUrl, {
 					signal: controller.signal,
@@ -447,7 +465,7 @@ export class EngineSidecar {
 			console.log("[Sidecar] Requesting graceful shutdown via HTTP...");
 			const response = await fetch(`http://127.0.0.1:${this.port}/shutdown`, {
 				method: "POST",
-				signal: AbortSignal.timeout(2000),
+				signal: AbortSignal.timeout(ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS),
 			});
 			if (response.ok) {
 				console.log("[Sidecar] Shutdown request accepted");
@@ -462,13 +480,13 @@ export class EngineSidecar {
 				return;
 			}
 
-			// Give the process 5 seconds to exit gracefully
+			// Give the process a grace period to exit before force-killing
 			const timeout = setTimeout(() => {
 				if (this.process) {
 					console.log("[Sidecar] Engine did not exit gracefully, killing...");
 					this.process.kill("SIGKILL");
 				}
-			}, 5000);
+			}, ENGINE_GRACEFUL_EXIT_TIMEOUT_MS);
 
 			this.process.on("exit", () => {
 				clearTimeout(timeout);
@@ -502,11 +520,11 @@ export class EngineSidecar {
 	/**
 	 * Restart the engine process with retry logic and exponential backoff
 	 */
-	async restart(maxRetries: number = 3): Promise<void> {
+	async restart(maxRetries: number = ENGINE_RESTART_MAX_RETRIES): Promise<void> {
 		console.log("[Sidecar] Restarting engine...");
 
 		let lastError: Error | null = null;
-		const baseDelay = 1000; // Initial delay in milliseconds
+		const baseDelay = ENGINE_RESTART_BASE_DELAY_MS;
 
 		for (let attempt = 0; attempt <= maxRetries; attempt++) {
 			try {
@@ -521,7 +539,7 @@ export class EngineSidecar {
 
 				await this.stop();
 				// Small delay to ensure port is released
-				await new Promise((resolve) => setTimeout(resolve, 500));
+				await new Promise((resolve) => setTimeout(resolve, ENGINE_PORT_RELEASE_DELAY_MS));
 				await this.start();
 				console.log("[Sidecar] Engine restarted successfully");
 				return;

--- a/app/electron/updater.ts
+++ b/app/electron/updater.ts
@@ -11,12 +11,9 @@ import { app, dialog, ipcMain, shell } from "electron";
 // be pulled off the default import.
 import electronUpdater from "electron-updater";
 import { resolveUpdateStrategy, type UpdateStrategy } from "./updater-strategy.js";
+import { REPO, UPDATE_CHECK_INTERVAL_MS as CHECK_INTERVAL_MS } from "./constants.js";
 
 const { autoUpdater } = electronUpdater;
-
-const REPO = "athrvk/vayu";
-/** Re-check for updates every 6 hours while the app stays open. */
-const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 function releaseUrl(version: string): string {
 	return `https://github.com/${REPO}/releases/tag/v${version}`;

--- a/app/electron/window-state.ts
+++ b/app/electron/window-state.ts
@@ -12,6 +12,7 @@
 
 import Store from "electron-store";
 import { BrowserWindow, screen } from "electron";
+import { WINDOW_STATE_SAVE_DEBOUNCE_MS } from "./constants.js";
 
 interface WindowState {
 	x?: number;
@@ -103,7 +104,7 @@ export function trackWindowState(window: BrowserWindow): void {
 	let saveTimeout: NodeJS.Timeout | null = null;
 	const debouncedSave = () => {
 		if (saveTimeout) clearTimeout(saveTimeout);
-		saveTimeout = setTimeout(() => saveWindowState(window), 500);
+		saveTimeout = setTimeout(() => saveWindowState(window), WINDOW_STATE_SAVE_DEBOUNCE_MS);
 	};
 
 	window.on("resize", debouncedSave);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,7 +9,12 @@ import Shell from "./components/layout/Shell";
 import TitleBar from "./components/layout/TitleBar";
 import UpdateBanner from "./components/shared/UpdateBanner";
 import { useEngineConnectionStore } from "./stores";
-import { useHealthQuery, usePrefetchCollectionsAndRequests, useRunsQuery } from "./queries";
+import {
+	useConfigQuery,
+	useHealthQuery,
+	usePrefetchCollectionsAndRequests,
+	useRunsQuery,
+} from "./queries";
 import { useElectronTheme } from "./hooks/useElectronTheme";
 import { useScriptCompletionProvider } from "./hooks/useScriptCompletionProvider";
 import { useMenuActions } from "./hooks/useMenuActions";
@@ -26,6 +31,10 @@ function App() {
 	// Prefetch collections and all their requests (TanStack handles caching automatically)
 	usePrefetchCollectionsAndRequests();
 	useRunsQuery();
+
+	// Keep engine config warm — proxied call timeouts derive from its
+	// defaultTimeout setting (see services/api.ts proxiedRequestTimeoutMs)
+	useConfigQuery();
 
 	// Fetch pm.* completions and register them with Monaco's JavaScript language
 	useScriptCompletionProvider();

--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -12,8 +12,9 @@
  * Change these if the backend API routes change.
  */
 
-// Local development
-const BASE_URL = "http://127.0.0.1:9876";
+import { ENGINE_BASE_URL, STATS_PAGE_LIMIT } from "./network";
+
+const BASE_URL = ENGINE_BASE_URL;
 
 export const API_ENDPOINTS = {
 	// Base
@@ -55,7 +56,7 @@ export const API_ENDPOINTS = {
 	METRICS_LIVE: (runId: string) => `/metrics/live/${runId}`, // New endpoint (memory-based, faster)
 
 	// Time-series metrics (JSON, paginated)
-	STATS_TIME_SERIES: (runId: string, limit = 5000, offset = 0) =>
+	STATS_TIME_SERIES: (runId: string, limit = STATS_PAGE_LIMIT, offset = 0) =>
 		`/stats/${runId}?format=json&limit=${limit}&offset=${offset}`,
 
 	// Import

--- a/app/src/config/cache.ts
+++ b/app/src/config/cache.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * TanStack Query Cache Configuration
+ *
+ * Centralized staleTime / gcTime / retry policies. Per-query overrides should
+ * pull from here instead of hardcoding durations.
+ */
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+export const QUERY_CACHE = {
+	/** Defaults applied via the shared QueryClient. */
+	DEFAULT_STALE_TIME_MS: 30 * SECOND,
+	DEFAULT_GC_TIME_MS: 5 * MINUTE,
+	DEFAULT_QUERY_RETRY: 2,
+	DEFAULT_MUTATION_RETRY: 1,
+
+	/** Engine /config rarely changes while the app is open. */
+	CONFIG_STALE_TIME_MS: 1 * MINUTE,
+
+	/** Completed runs are immutable; cache them aggressively. */
+	RUNS_STALE_TIME_MS: 5 * MINUTE,
+	RUNS_GC_TIME_MS: 30 * MINUTE,
+
+	/** Script completion metadata is static per engine version. */
+	SCRIPT_COMPLETIONS_STALE_TIME_MS: 1 * HOUR,
+	SCRIPT_COMPLETIONS_GC_TIME_MS: 1 * HOUR,
+	SCRIPT_COMPLETIONS_RETRY: 1,
+
+	/** Looking a request up in the cache retries quickly while it populates. */
+	REQUEST_LOOKUP_RETRY: 3,
+	REQUEST_LOOKUP_RETRY_DELAY_MS: 100,
+} as const;

--- a/app/src/config/metrics.ts
+++ b/app/src/config/metrics.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Metrics Volume Configuration
+ *
+ * Knobs controlling how much live/historical metric data the UI keeps and
+ * how often it re-renders. These trade chart fidelity for memory and CPU.
+ */
+
+/** Max historical data points retained in the dashboard store per run. */
+export const HISTORICAL_METRICS_CAP = 3000;
+
+/** Max points per historical chart before downsampling kicks in. */
+export const CHART_DOWNSAMPLE_MAX_POINTS = 2000;
+
+/** Throttle for committing live SSE metrics into the UI store. */
+export const METRICS_UI_THROTTLE_MS = 500;

--- a/app/src/config/network.ts
+++ b/app/src/config/network.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * UI-to-Engine Network Configuration
+ *
+ * The engine sidecar listens on a fixed local port (see engine docs and
+ * app/electron/constants.ts — the electron main process duplicates the port
+ * because it cannot import renderer modules).
+ */
+
+export const ENGINE_HOST = "127.0.0.1";
+export const ENGINE_PORT = 9876;
+export const ENGINE_BASE_URL = `http://${ENGINE_HOST}:${ENGINE_PORT}`;
+
+/** Default timeout for UI-to-engine requests. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Page size when fetching time-series stats for a run. */
+export const STATS_PAGE_LIMIT = 5000;

--- a/app/src/config/network.ts
+++ b/app/src/config/network.ts
@@ -17,8 +17,24 @@ export const ENGINE_HOST = "127.0.0.1";
 export const ENGINE_PORT = 9876;
 export const ENGINE_BASE_URL = `http://${ENGINE_HOST}:${ENGINE_PORT}`;
 
-/** Default timeout for UI-to-engine requests. */
+/** Default timeout for UI-to-engine requests (local operations). */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Calls that proxy a remote server (/request, /import/fetch) are bounded by
+ * the engine's user-configurable `defaultTimeout` setting, not this client.
+ * The UI timeout for those calls is derived as engine timeout + grace so the
+ * engine's own TIMEOUT error (with proper error code) always arrives before
+ * the UI aborts.
+ */
+export const PROXIED_TIMEOUT_GRACE_MS = 10_000;
+
+/**
+ * Upper bound of the engine's `defaultTimeout` setting (see
+ * engine/src/db/database.cpp seed_default_config). Used as a safe fallback
+ * when the config cache is cold.
+ */
+export const ENGINE_MAX_DEFAULT_TIMEOUT_MS = 300_000;
 
 /** Page size when fetching time-series stats for a run. */
 export const STATS_PAGE_LIMIT = 5000;

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * UI Timing Configuration
+ *
+ * All UI-facing delays, debounces, polling intervals and retry policies in
+ * one place. Values are milliseconds unless the name says otherwise.
+ */
+
+export const TIMING = {
+	/** Debounced auto-save after the user stops editing a request. */
+	AUTO_SAVE_DELAY_MS: 3000,
+	/** How long the "Saved" indicator stays visible after a save. */
+	SAVED_STATUS_DURATION_MS: 3000,
+
+	/** Transient status feedback (copied / saved / error chips) reset delay. */
+	STATUS_RESET_MS: 2000,
+
+	/** Radix tooltip open delay used across the app. */
+	TOOLTIP_DELAY_MS: 150,
+
+	/** Delay to disambiguate single click from double click in tree items. */
+	TREE_CLICK_DELAY_MS: 80,
+
+	/** Engine health poll interval while the app is open. */
+	HEALTH_CHECK_INTERVAL_MS: 30_000,
+
+	/** Wait after asking electron to restart the engine before refetching. */
+	ENGINE_RESTART_WAIT_MS: 1500,
+
+	/** GraphQL editor diagnostics debounce. */
+	GRAPHQL_DIAGNOSTICS_DEBOUNCE_MS: 250,
+	/** GraphQL schema introspection debounce after URL/headers change. */
+	GRAPHQL_INTROSPECTION_DEBOUNCE_MS: 400,
+
+	/** Run report polling: first attempt delay, retry delay, and max attempts. */
+	REPORT_INITIAL_DELAY_MS: 3000,
+	REPORT_RETRY_DELAY_MS: 1000,
+	REPORT_MAX_ATTEMPTS: 5,
+} as const;

--- a/app/src/constants/http.ts
+++ b/app/src/constants/http.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import type { HttpMethod } from "@/types";
+
+/** HTTP methods supported by the request builder, in display order. */
+export const HTTP_METHODS: HttpMethod[] = [
+	"GET",
+	"POST",
+	"PUT",
+	"PATCH",
+	"DELETE",
+	"HEAD",
+	"OPTIONS",
+];
+
+/** Standard HTTP headers offered for autocomplete in the headers editor. */
+export const STANDARD_HEADERS = [
+	"Accept",
+	"Accept-Charset",
+	"Accept-Encoding",
+	"Accept-Language",
+	"Authorization",
+	"Cache-Control",
+	"Content-Disposition",
+	"Content-Encoding",
+	"Content-Language",
+	"Content-Length",
+	"Content-Type",
+	"Cookie",
+	"Date",
+	"ETag",
+	"Expires",
+	"Host",
+	"If-Match",
+	"If-Modified-Since",
+	"If-None-Match",
+	"If-Unmodified-Since",
+	"Origin",
+	"Pragma",
+	"Range",
+	"Referer",
+	"User-Agent",
+	"X-Api-Key",
+	"X-Correlation-Id",
+	"X-Forwarded-For",
+	"X-Forwarded-Host",
+	"X-Forwarded-Proto",
+	"X-Request-Id",
+	"X-Requested-With",
+];

--- a/app/src/constants/load-test.ts
+++ b/app/src/constants/load-test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Load test configuration defaults and input limits.
+ *
+ * Limits mirror what the engine accepts on /run — keep them in sync with the
+ * engine's validation when it changes.
+ */
+
+export const LOAD_TEST_DEFAULTS = {
+	MODE: "constant_rps",
+	DURATION_S: 60,
+	RPS: 100,
+	CONCURRENCY: 10,
+	ITERATIONS: 1000,
+	RAMP_DURATION_S: 30,
+	/** % of successful responses persisted for inspection. */
+	SAMPLE_RATE_PCT: 10,
+	/** Responses slower than this are flagged and saved. */
+	SLOW_THRESHOLD_MS: 1000,
+	SAVE_TIMING_BREAKDOWN: true,
+} as const;
+
+export const LOAD_TEST_LIMITS = {
+	DURATION_S: { MIN: 1, MAX: 3600 },
+	RPS: { MIN: 1, MAX: 50_000 },
+	MAX_IN_FLIGHT: { MIN: 1, MAX: 1_000_000 },
+	CONCURRENCY: { MIN: 1, MAX: 1000 },
+	ITERATIONS: { MIN: 1, MAX: 1_000_000 },
+	RAMP_DURATION_S: { MIN: 1, MAX: 3600 },
+	SAMPLE_RATE_PCT: { MIN: 0, MAX: 100 },
+	SLOW_THRESHOLD_MS: { MIN: 0, MAX: 60_000 },
+} as const;

--- a/app/src/constants/storage-keys.ts
+++ b/app/src/constants/storage-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Local persistence keys (localStorage + zustand persist names).
+ *
+ * Renaming a key orphans previously persisted data — treat these as part of
+ * the app's storage schema.
+ */
+
+export const STORAGE_KEYS = {
+	/** "system" | "light" | "dark" theme preference. */
+	THEME_SOURCE: "vayu-theme-source",
+	/** Resolved color scheme cached for instant paint before electron answers. */
+	COLOR_SCHEME: "vayu-color-scheme",
+	/** Last-used load test configuration (LoadTestConfigDialog). */
+	LAST_LOAD_TEST_CONFIG: "vayu:lastLoadTestConfig",
+	/** Zustand persist name for variables UI state. */
+	VARIABLES_UI_STORE: "variables-ui-store",
+} as const;

--- a/app/src/constants/variables.ts
+++ b/app/src/constants/variables.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Variable interpolation syntax: `{{variableName}}`.
+ *
+ * Shared regexes are global; only use them with APIs that reset lastIndex
+ * (String.replace / split / matchAll). For boolean checks use
+ * `isVariableToken` — `.test()` on a shared global regex is stateful.
+ */
+
+/** Matches `{{name}}`, capturing the variable name (without braces). */
+export const VARIABLE_PATTERN = /\{\{([^{}]+)\}\}/g;
+
+/** For String.split: capturing group keeps the `{{name}}` tokens in output. */
+export const VARIABLE_SPLIT_PATTERN = /(\{\{[^{}]+\}\})/g;
+
+/** True when the whole string is a single `{{name}}` token. */
+export function isVariableToken(text: string): boolean {
+	return /^\{\{[^{}]+\}\}$/.test(text);
+}

--- a/app/src/hooks/useElectronTheme.ts
+++ b/app/src/hooks/useElectronTheme.ts
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useCallback, useState } from "react";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
 
 export type ThemeSource = "system" | "light" | "dark";
 export type ColorScheme = "sky" | "ocean" | "forest" | "sunset" | "aurora" | "coral";
@@ -54,8 +55,12 @@ export function useElectronTheme(options: UseElectronThemeOptions = {}) {
 			let scheme: ColorScheme = "sunset";
 
 			// Load from localStorage
-			const savedSource = localStorage.getItem("vayu-theme-source") as ThemeSource | null;
-			const savedScheme = localStorage.getItem("vayu-color-scheme") as ColorScheme | null;
+			const savedSource = localStorage.getItem(
+				STORAGE_KEYS.THEME_SOURCE
+			) as ThemeSource | null;
+			const savedScheme = localStorage.getItem(
+				STORAGE_KEYS.COLOR_SCHEME
+			) as ColorScheme | null;
 
 			if (window.electronAPI) {
 				// Get theme from Electron
@@ -130,7 +135,7 @@ export function useElectronTheme(options: UseElectronThemeOptions = {}) {
 				}
 			}
 			// Persist preference
-			localStorage.setItem("vayu-theme-source", source);
+			localStorage.setItem(STORAGE_KEYS.THEME_SOURCE, source);
 		},
 		[applyTheme, colorScheme]
 	);
@@ -141,7 +146,7 @@ export function useElectronTheme(options: UseElectronThemeOptions = {}) {
 			setColorScheme(scheme);
 			const isDark = document.documentElement.classList.contains("dark");
 			applyTheme(isDark, scheme);
-			localStorage.setItem("vayu-color-scheme", scheme);
+			localStorage.setItem(STORAGE_KEYS.COLOR_SCHEME, scheme);
 		},
 		[applyTheme]
 	);

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -17,9 +17,9 @@
 
 import { useEffect, useRef, useCallback } from "react";
 import { useSaveStore } from "@/stores/save-store";
+import { TIMING } from "@/config/timing";
 
-const AUTO_SAVE_DELAY_MS = 3000; // 3000ms debounce
-const SAVED_STATUS_DURATION_MS = 3000; // Show "saved" for 3 seconds
+const { AUTO_SAVE_DELAY_MS, SAVED_STATUS_DURATION_MS } = TIMING;
 
 interface UseSaveManagerOptions {
 	/** Unique identifier for this save context (e.g., request ID) */

--- a/app/src/lib/graphql/language-providers.ts
+++ b/app/src/lib/graphql/language-providers.ts
@@ -20,9 +20,10 @@ import {
 } from "graphql-language-service";
 import { computeGraphqlDiagnostics } from "./diagnostics";
 import { useSchemaCache } from "./schema-cache";
+import { TIMING } from "@/config/timing";
 
 const MARKER_OWNER = "graphql";
-const DEBOUNCE_MS = 250;
+const DEBOUNCE_MS = TIMING.GRAPHQL_DIAGNOSTICS_DEBOUNCE_MS;
 
 export function registerGraphqlProviders(monaco: typeof Monaco): void {
 	const toSeverity = (s: "error" | "warning") =>

--- a/app/src/lib/query-client.ts
+++ b/app/src/lib/query-client.ts
@@ -12,24 +12,21 @@
  */
 
 import { QueryClient } from "@tanstack/react-query";
+import { QUERY_CACHE } from "@/config/cache";
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
-			// Data considered fresh for 30 seconds
-			staleTime: 30 * 1000,
-			// Keep unused data in cache for 5 minutes
-			gcTime: 5 * 60 * 1000,
-			// Retry failed requests 2 times
-			retry: 2,
+			staleTime: QUERY_CACHE.DEFAULT_STALE_TIME_MS,
+			gcTime: QUERY_CACHE.DEFAULT_GC_TIME_MS,
+			retry: QUERY_CACHE.DEFAULT_QUERY_RETRY,
 			// Don't refetch on window focus for desktop app
 			refetchOnWindowFocus: false,
 			// Refetch on reconnect
 			refetchOnReconnect: true,
 		},
 		mutations: {
-			// Retry mutations once on failure
-			retry: 1,
+			retry: QUERY_CACHE.DEFAULT_MUTATION_RETRY,
 		},
 	},
 });

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -12,6 +12,7 @@ import type { Collection, Request } from "@/types";
 import { compareCollectionOrder } from "@/types";
 import { Button, Input } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { TIMING } from "@/config/timing";
 
 export interface CollectionItemProps {
 	collection: Collection;
@@ -94,7 +95,7 @@ export default function CollectionItem({
 		.sort(compareCollectionOrder);
 
 	const expandTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const CLICK_DELAY_MS = 80;
+	const CLICK_DELAY_MS = TIMING.TREE_CLICK_DELAY_MS;
 
 	useEffect(
 		() => () => {

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -34,6 +34,7 @@ import {
 import CollectionItem from "./CollectionItem";
 import type { Collection, Request } from "@/types";
 import { compareCollectionOrder } from "@/types";
+import { TIMING } from "@/config/timing";
 
 export default function CollectionTree() {
 	const openImport = useImportModalStore((s) => s.open);
@@ -223,7 +224,7 @@ export default function CollectionTree() {
 			});
 			completeSave();
 			// Reset to idle after showing "saved" status
-			setTimeout(() => setStatus("idle"), 2000);
+			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 		} catch (error) {
 			failSave(error instanceof Error ? error.message : "Failed to rename collection");
 		}
@@ -343,7 +344,7 @@ export default function CollectionTree() {
 			});
 			completeSave();
 			// Reset to idle after showing "saved" status
-			setTimeout(() => setStatus("idle"), 2000);
+			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 		} catch (error) {
 			failSave(error instanceof Error ? error.message : "Failed to rename request");
 		}

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -11,6 +11,7 @@ import { getMethodColor } from "@/utils";
 import type { Request } from "@/types";
 import { Button, Badge, Input } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { TIMING } from "@/config/timing";
 
 export interface RequestItemProps {
 	request: Request;
@@ -45,7 +46,7 @@ export default function RequestItem({
 }: RequestItemProps) {
 	const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-	const CLICK_DELAY_MS = 80;
+	const CLICK_DELAY_MS = TIMING.TREE_CLICK_DELAY_MS;
 
 	const handleClick = () => {
 		if (isDeleting || isRenaming) return;

--- a/app/src/modules/dashboard/components/shared.tsx
+++ b/app/src/modules/dashboard/components/shared.tsx
@@ -8,6 +8,7 @@
 import { type ReactNode } from "react";
 import { Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { TIMING } from "@/config/timing";
 
 export const EYEBROW_CLASS =
 	"text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground";
@@ -15,7 +16,7 @@ export const EYEBROW_CLASS =
 /** Tiny "i" affordance with a Radix tooltip. */
 export function InfoChip({ tip }: { tip: ReactNode }) {
 	return (
-		<TooltipProvider delayDuration={150}>
+		<TooltipProvider delayDuration={TIMING.TOOLTIP_DELAY_MS}>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button

--- a/app/src/modules/dashboard/index.tsx
+++ b/app/src/modules/dashboard/index.tsx
@@ -24,6 +24,7 @@ import { useDashboardStore } from "@/stores";
 import { apiService, loadTestService } from "@/services";
 import { cn } from "@/lib/utils";
 import { DashboardHeader, MetricsView, RequestResponseView } from "./components";
+import { TIMING } from "@/config/timing";
 import type { DashboardView, DisplayMetrics } from "./types";
 
 export default function LoadTestDashboard() {
@@ -123,7 +124,10 @@ export default function LoadTestDashboard() {
 		) {
 			// Longer initial delay to allow database writes to complete
 			// This helps avoid "database is locked" issues
-			const delay = loadAttemptRef.current === 0 ? 3000 : 1000;
+			const delay =
+				loadAttemptRef.current === 0
+					? TIMING.REPORT_INITIAL_DELAY_MS
+					: TIMING.REPORT_RETRY_DELAY_MS;
 
 			const timeoutId = setTimeout(async () => {
 				setIsLoadingReport(true);
@@ -136,7 +140,7 @@ export default function LoadTestDashboard() {
 						if (isValidReport) {
 							setFinalReport(report);
 							loadAttemptRef.current = 0;
-						} else if (loadAttemptRef.current < 5) {
+						} else if (loadAttemptRef.current < TIMING.REPORT_MAX_ATTEMPTS) {
 							console.log(
 								`Report has zero data, retrying... (attempt ${loadAttemptRef.current + 1})`
 							);

--- a/app/src/modules/history/main/components/HistoricalChartsSection.tsx
+++ b/app/src/modules/history/main/components/HistoricalChartsSection.tsx
@@ -27,6 +27,7 @@ import { Loader2 } from "lucide-react";
 import type { LoadTestMetrics } from "@/types";
 import { buildStatusOverTime } from "@/modules/dashboard/utils/metricsTransforms";
 import { StatusCodesOverTimeChart } from "@/modules/dashboard/components/charts/StatusCodesOverTimeChart";
+import { CHART_DOWNSAMPLE_MAX_POINTS } from "@/config/metrics";
 
 interface HistoricalChartsSectionProps {
 	data: LoadTestMetrics[];
@@ -39,7 +40,7 @@ interface HistoricalChartsSectionProps {
  * Downsample data for chart rendering performance.
  * Keeps every Nth point to cap at maxPoints while preserving first and last points.
  */
-function downsample<T>(data: T[], maxPoints: number = 2000): T[] {
+function downsample<T>(data: T[], maxPoints: number = CHART_DOWNSAMPLE_MAX_POINTS): T[] {
 	if (data.length <= maxPoints) return data;
 
 	const step = Math.ceil(data.length / maxPoints);
@@ -91,7 +92,7 @@ function prepareChartData(metrics: LoadTestMetrics[]) {
 
 	// Convert to sorted array and downsample
 	const sorted = Array.from(dataBySecond.values()).sort((a, b) => a.time - b.time);
-	return downsample(sorted, 2000);
+	return downsample(sorted);
 }
 
 export default function HistoricalChartsSection({

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog.tsx
@@ -9,6 +9,8 @@ import { useState } from "react";
 import { Loader2, AlertTriangle } from "lucide-react";
 import type { LoadTestConfig } from "@/types";
 import { validateRampDuration } from "../utils/loadTestValidation";
+import { LOAD_TEST_DEFAULTS, LOAD_TEST_LIMITS } from "@/constants/load-test";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
 import {
 	Button,
 	Input,
@@ -26,8 +28,6 @@ import {
 	DialogFooter,
 } from "@/components/ui";
 
-const LOAD_TEST_CONFIG_KEY = "vayu:lastLoadTestConfig";
-
 interface SavedLoadTestConfig {
 	mode: LoadTestConfig["mode"];
 	duration: number;
@@ -43,7 +43,7 @@ interface SavedLoadTestConfig {
 
 function loadSavedConfig(): Partial<SavedLoadTestConfig> {
 	try {
-		const saved = localStorage.getItem(LOAD_TEST_CONFIG_KEY);
+		const saved = localStorage.getItem(STORAGE_KEYS.LAST_LOAD_TEST_CONFIG);
 		if (saved) {
 			return JSON.parse(saved);
 		}
@@ -55,7 +55,7 @@ function loadSavedConfig(): Partial<SavedLoadTestConfig> {
 
 function saveConfig(config: SavedLoadTestConfig): void {
 	try {
-		localStorage.setItem(LOAD_TEST_CONFIG_KEY, JSON.stringify(config));
+		localStorage.setItem(STORAGE_KEYS.LAST_LOAD_TEST_CONFIG, JSON.stringify(config));
 	} catch (e) {
 		console.warn("Failed to save load test config:", e);
 	}
@@ -80,22 +80,30 @@ export default function LoadTestConfigDialog({
 	// Load saved config or use defaults
 	const saved = loadSavedConfig();
 
-	const [mode, setMode] = useState<LoadTestConfig["mode"]>(saved.mode ?? "constant_rps");
-	const [duration, setDuration] = useState(saved.duration ?? 60);
-	const [rps, setRps] = useState(saved.rps ?? 100);
-	const [concurrency, setConcurrency] = useState(saved.concurrency ?? 10);
-	const [iterations, setIterations] = useState(saved.iterations ?? 1000);
-	const [rampDuration, setRampDuration] = useState(saved.rampDuration ?? 30);
+	const [mode, setMode] = useState<LoadTestConfig["mode"]>(saved.mode ?? LOAD_TEST_DEFAULTS.MODE);
+	const [duration, setDuration] = useState(saved.duration ?? LOAD_TEST_DEFAULTS.DURATION_S);
+	const [rps, setRps] = useState(saved.rps ?? LOAD_TEST_DEFAULTS.RPS);
+	const [concurrency, setConcurrency] = useState(
+		saved.concurrency ?? LOAD_TEST_DEFAULTS.CONCURRENCY
+	);
+	const [iterations, setIterations] = useState(saved.iterations ?? LOAD_TEST_DEFAULTS.ITERATIONS);
+	const [rampDuration, setRampDuration] = useState(
+		saved.rampDuration ?? LOAD_TEST_DEFAULTS.RAMP_DURATION_S
+	);
 	// Max in-flight cap (constant_rps only). Empty string = auto (engine derives
 	// a per-strategy default). Kept as a string so the field can be left blank.
 	const [maxInFlight, setMaxInFlight] = useState<string>(
 		saved.maxInFlight != null ? String(saved.maxInFlight) : ""
 	);
 	// Data capture options
-	const [sampleRate, setSampleRate] = useState(saved.sampleRate ?? 10);
-	const [slowThreshold, setSlowThreshold] = useState(saved.slowThreshold ?? 1000);
+	const [sampleRate, setSampleRate] = useState(
+		saved.sampleRate ?? LOAD_TEST_DEFAULTS.SAMPLE_RATE_PCT
+	);
+	const [slowThreshold, setSlowThreshold] = useState(
+		saved.slowThreshold ?? LOAD_TEST_DEFAULTS.SLOW_THRESHOLD_MS
+	);
 	const [saveTimingBreakdown, setSaveTimingBreakdown] = useState(
-		saved.saveTimingBreakdown ?? true
+		saved.saveTimingBreakdown ?? LOAD_TEST_DEFAULTS.SAVE_TIMING_BREAKDOWN
 	);
 	const [comment, setComment] = useState(""); // Don't persist comment
 
@@ -207,8 +215,8 @@ export default function LoadTestConfigDialog({
 							type="number"
 							value={duration}
 							onChange={(e) => setDuration(Number(e.target.value))}
-							min={1}
-							max={3600}
+							min={LOAD_TEST_LIMITS.DURATION_S.MIN}
+							max={LOAD_TEST_LIMITS.DURATION_S.MAX}
 						/>
 					</div>
 
@@ -221,8 +229,8 @@ export default function LoadTestConfigDialog({
 									type="number"
 									value={rps}
 									onChange={(e) => setRps(Number(e.target.value))}
-									min={1}
-									max={50000}
+									min={LOAD_TEST_LIMITS.RPS.MIN}
+									max={LOAD_TEST_LIMITS.RPS.MAX}
 								/>
 							</div>
 							<div className="space-y-2">
@@ -236,8 +244,8 @@ export default function LoadTestConfigDialog({
 									type="number"
 									value={maxInFlight}
 									onChange={(e) => setMaxInFlight(e.target.value)}
-									min={1}
-									max={1000000}
+									min={LOAD_TEST_LIMITS.MAX_IN_FLIGHT.MIN}
+									max={LOAD_TEST_LIMITS.MAX_IN_FLIGHT.MAX}
 									placeholder="Auto (derived from target RPS)"
 								/>
 								<p className="text-[11.5px] text-muted-foreground leading-relaxed">
@@ -258,8 +266,8 @@ export default function LoadTestConfigDialog({
 								type="number"
 								value={concurrency}
 								onChange={(e) => setConcurrency(Number(e.target.value))}
-								min={1}
-								max={1000}
+								min={LOAD_TEST_LIMITS.CONCURRENCY.MIN}
+								max={LOAD_TEST_LIMITS.CONCURRENCY.MAX}
 							/>
 						</div>
 					)}
@@ -271,8 +279,8 @@ export default function LoadTestConfigDialog({
 								type="number"
 								value={iterations}
 								onChange={(e) => setIterations(Number(e.target.value))}
-								min={1}
-								max={1000000}
+								min={LOAD_TEST_LIMITS.ITERATIONS.MIN}
+								max={LOAD_TEST_LIMITS.ITERATIONS.MAX}
 							/>
 						</div>
 					)}
@@ -284,8 +292,8 @@ export default function LoadTestConfigDialog({
 								type="number"
 								value={rampDuration}
 								onChange={(e) => setRampDuration(Number(e.target.value))}
-								min={1}
-								max={3600}
+								min={LOAD_TEST_LIMITS.RAMP_DURATION_S.MIN}
+								max={LOAD_TEST_LIMITS.RAMP_DURATION_S.MAX}
 							/>
 						</div>
 					)}
@@ -306,8 +314,8 @@ export default function LoadTestConfigDialog({
 									type="range"
 									value={sampleRate}
 									onChange={(e) => setSampleRate(Number(e.target.value))}
-									min="0"
-									max="100"
+									min={LOAD_TEST_LIMITS.SAMPLE_RATE_PCT.MIN}
+									max={LOAD_TEST_LIMITS.SAMPLE_RATE_PCT.MAX}
 									className="w-full accent-primary"
 								/>
 								<div className="flex justify-between text-xs text-muted-foreground">
@@ -323,8 +331,8 @@ export default function LoadTestConfigDialog({
 									type="number"
 									value={slowThreshold}
 									onChange={(e) => setSlowThreshold(Number(e.target.value))}
-									min={0}
-									max={60000}
+									min={LOAD_TEST_LIMITS.SLOW_THRESHOLD_MS.MIN}
+									max={LOAD_TEST_LIMITS.SLOW_THRESHOLD_MS.MAX}
 									placeholder="e.g., 1000 (1 second)"
 								/>
 								<p className="text-xs text-muted-foreground">

--- a/app/src/modules/request-builder/components/RequestTabs/panels/AuthInheritBanner.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/AuthInheritBanner.tsx
@@ -22,12 +22,11 @@ import { Folder, Info, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCollectionAncestors } from "@/queries/collections";
 import type { Collection } from "@/types";
+import { VARIABLE_SPLIT_PATTERN, isVariableToken } from "@/constants/variables";
 
 interface AuthInheritBannerProps {
 	collectionId: string | null | undefined;
 }
-
-const VARIABLE_PATTERN = /(\{\{[^{}]+\}\})/g;
 
 function describeAuth(c: Collection): { label: string; secret: string | null } {
 	const auth = c.auth;
@@ -51,8 +50,8 @@ function describeAuth(c: Collection): { label: string; secret: string | null } {
 }
 
 function renderWithVariables(text: string) {
-	return text.split(VARIABLE_PATTERN).map((part, i) =>
-		VARIABLE_PATTERN.test(part) ? (
+	return text.split(VARIABLE_SPLIT_PATTERN).map((part, i) =>
+		isVariableToken(part) ? (
 			<span key={i} className="text-variable font-mono">
 				{part}
 			</span>

--- a/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
@@ -41,6 +41,7 @@ import { useSchemaCache } from "@/lib/graphql/schema-cache";
 import { applyVariablesSchema } from "@/lib/graphql/variables-schema";
 import { useResizable } from "@/hooks/useResizable";
 import { cn } from "@/lib/utils";
+import { TIMING } from "@/config/timing";
 
 const BODY_MODES: { value: BodyMode; label: string; description: string }[] = [
 	{ value: "none", label: "None", description: "No request body" },
@@ -190,7 +191,7 @@ export default function BodyPanel() {
 		const headers = buildResolvedHeaders();
 		const id = setTimeout(() => {
 			void useSchemaCache.getState().ensureSchema(resolvedGqlUrl, headers);
-		}, 400);
+		}, TIMING.GRAPHQL_INTROSPECTION_DEBOUNCE_MS);
 		return () => clearTimeout(id);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [request.bodyMode, request.url, request.headers, resolveString]);

--- a/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
@@ -20,42 +20,7 @@ import type { KeyValueItem } from "../../../types";
 import { useHeadersManager } from "../../../hooks/useHeadersManager";
 import { Button, Label } from "@/components/ui";
 import { Textarea } from "@/components/ui/textarea";
-
-// Standard HTTP headers for autocomplete
-const STANDARD_HEADERS = [
-	"Accept",
-	"Accept-Charset",
-	"Accept-Encoding",
-	"Accept-Language",
-	"Authorization",
-	"Cache-Control",
-	"Content-Disposition",
-	"Content-Encoding",
-	"Content-Language",
-	"Content-Length",
-	"Content-Type",
-	"Cookie",
-	"Date",
-	"ETag",
-	"Expires",
-	"Host",
-	"If-Match",
-	"If-Modified-Since",
-	"If-None-Match",
-	"If-Unmodified-Since",
-	"Origin",
-	"Pragma",
-	"Range",
-	"Referer",
-	"User-Agent",
-	"X-Api-Key",
-	"X-Correlation-Id",
-	"X-Forwarded-For",
-	"X-Forwarded-Host",
-	"X-Forwarded-Proto",
-	"X-Request-Id",
-	"X-Requested-With",
-];
+import { STANDARD_HEADERS } from "@/constants/http";
 
 export default function HeadersPanel() {
 	const { request, updateField } = useRequestBuilderContext();

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
@@ -21,6 +21,7 @@ import { type ReactNode } from "react";
 import { Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ResponseTiming } from "../../types";
+import { TIMING } from "@/config/timing";
 
 interface Phase {
 	key: string;
@@ -33,7 +34,7 @@ interface Phase {
 /** Tiny "i" affordance with a Radix tooltip (local to keep this tab self-contained). */
 function InfoTip({ tip }: { tip: ReactNode }) {
 	return (
-		<TooltipProvider delayDuration={150}>
+		<TooltipProvider delayDuration={TIMING.TOOLTIP_DELAY_MS}>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button

--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -35,6 +35,7 @@ import {
 import { useRequestBuilderContext } from "../../context";
 import { useNavigationStore, useDashboardStore } from "@/stores";
 import { ResponseBody as SharedResponseBody } from "@/components/shared/response-viewer";
+import { TIMING } from "@/config/timing";
 import ResponseHeader from "./ResponseHeader";
 import ResponseHeadersTab from "./ResponseHeadersTab";
 import ResponseCookies from "./ResponseCookies";
@@ -129,7 +130,7 @@ export default function ResponseViewer() {
 	const handleCopy = async () => {
 		await navigator.clipboard.writeText(response.body);
 		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+		setTimeout(() => setCopied(false), TIMING.STATUS_RESET_MS);
 	};
 
 	const handleDownload = () => {

--- a/app/src/modules/request-builder/components/UrlBar/MethodSelector.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/MethodSelector.tsx
@@ -14,9 +14,8 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { useRequestBuilderContext } from "../../context";
+import { HTTP_METHODS } from "@/constants/http";
 import type { HttpMethod } from "@/types";
-
-const HTTP_METHODS: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
 
 const METHOD_COLORS: Record<HttpMethod, string> = {
 	GET: "method-get",

--- a/app/src/modules/request-builder/shared/VariableInput/index.tsx
+++ b/app/src/modules/request-builder/shared/VariableInput/index.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils";
 import { useRequestBuilderContext } from "../../context/RequestBuilderContext";
 import type { VariableScope } from "../../types";
 import EditableVariable from "./EditableVariable";
+import { VARIABLE_PATTERN } from "@/constants/variables";
 
 interface VariableInputProps {
 	value: string;
@@ -39,8 +40,6 @@ interface VariableInputProps {
 	suggestions?: string[]; // Optional list of plain text suggestions (e.g., standard headers)
 	onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void; // Raw paste passthrough
 }
-
-const VARIABLE_PATTERN = /\{\{([^{}]+)\}\}/g;
 
 // Parse text into segments (text and variables)
 function parseSegments(

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -43,6 +43,7 @@ import {
 import { cn } from "@/lib/utils";
 import UISettingsPanel from "./UISettingsPanel";
 import { isSizeConfig, formatBytes, formatSizeRange } from "../utils/format-size";
+import { TIMING } from "@/config/timing";
 
 /**
  * Check if a config entry requires a restart when changed
@@ -174,7 +175,7 @@ export default function SettingsMain() {
 			}
 
 			// Reset to idle after showing "saved" status
-			setTimeout(() => setStatus("idle"), 2000);
+			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 		} catch (err) {
 			console.error("Failed to save settings:", err);
 			failSave(err instanceof Error ? err.message : "Failed to save settings");
@@ -427,7 +428,10 @@ export default function SettingsMain() {
 											if (result.success) {
 												// Wait a moment for engine to fully initialize
 												await new Promise((resolve) =>
-													setTimeout(resolve, 1500)
+													setTimeout(
+														resolve,
+														TIMING.ENGINE_RESTART_WAIT_MS
+													)
 												);
 												// Invalidate all queries to refresh data from the new engine instance
 												await queryClient.invalidateQueries();

--- a/app/src/modules/variables/main/VariableTableEditor.tsx
+++ b/app/src/modules/variables/main/VariableTableEditor.tsx
@@ -53,6 +53,7 @@ import {
 	SelectValue,
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { TIMING } from "@/config/timing";
 
 type VariableType = NonNullable<VariableValue["type"]>;
 
@@ -254,7 +255,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 						onSuccess: () => {
 							setHasPendingChanges(false);
 							completeSave();
-							setTimeout(() => setStatus("idle"), 2000);
+							setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 							resolve();
 						},
 						onError: (error) => {
@@ -275,7 +276,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 						onSuccess: () => {
 							setHasPendingChanges(false);
 							completeSave();
-							setTimeout(() => setStatus("idle"), 2000);
+							setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 							resolve();
 						},
 						onError: (error) => {
@@ -295,7 +296,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 						onSuccess: () => {
 							setHasPendingChanges(false);
 							completeSave();
-							setTimeout(() => setStatus("idle"), 2000);
+							setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 							resolve();
 						},
 						onError: (error) => {

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -15,6 +15,7 @@ import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/rea
 import { useMemo } from "react";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
+import { QUERY_CACHE } from "@/config/cache";
 import type {
 	Collection,
 	Request,
@@ -57,14 +58,14 @@ export function usePrefetchCollectionsAndRequests() {
 					queryClient.prefetchQuery({
 						queryKey: queryKeys.requests.listByCollection(collection.id),
 						queryFn: () => apiService.listRequests({ collectionId: collection.id }),
-						staleTime: 30 * 1000, // Consider fresh for 30 seconds
+						staleTime: QUERY_CACHE.DEFAULT_STALE_TIME_MS,
 					})
 				)
 			);
 			return true;
 		},
 		enabled: collections.length > 0,
-		staleTime: 30 * 1000, // Re-prefetch after 30 seconds
+		staleTime: QUERY_CACHE.DEFAULT_STALE_TIME_MS, // Re-prefetch once stale
 		refetchOnWindowFocus: false,
 	});
 
@@ -153,8 +154,8 @@ export function useRequestQuery(requestId: string | null) {
 		},
 		enabled: !!requestId,
 		// Retry a few times with short delay - the cache might be updating
-		retry: 3,
-		retryDelay: 100,
+		retry: QUERY_CACHE.REQUEST_LOOKUP_RETRY,
+		retryDelay: QUERY_CACHE.REQUEST_LOOKUP_RETRY_DELAY_MS,
 		// Use stale data since we're reading from cache
 		staleTime: Infinity,
 	});

--- a/app/src/queries/config.ts
+++ b/app/src/queries/config.ts
@@ -14,6 +14,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
+import { QUERY_CACHE } from "@/config/cache";
 import type { GetConfigResponse, UpdateConfigRequest } from "@/types";
 
 /**
@@ -23,7 +24,7 @@ export function useConfigQuery() {
 	return useQuery({
 		queryKey: queryKeys.config.all,
 		queryFn: () => apiService.getConfig(),
-		staleTime: 60 * 1000, // Config rarely changes
+		staleTime: QUERY_CACHE.CONFIG_STALE_TIME_MS, // Config rarely changes
 	});
 }
 

--- a/app/src/queries/health.ts
+++ b/app/src/queries/health.ts
@@ -16,8 +16,7 @@ import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
 import { useEngineConnectionStore } from "@/stores";
 import { useEffect } from "react";
-
-const HEALTH_CHECK_INTERVAL_MS = 30000; // 30 seconds
+import { TIMING } from "@/config/timing";
 
 /**
  * Engine health check with automatic polling
@@ -29,7 +28,7 @@ export function useHealthQuery() {
 	const query = useQuery({
 		queryKey: queryKeys.health.status(),
 		queryFn: () => apiService.getHealth(),
-		refetchInterval: HEALTH_CHECK_INTERVAL_MS,
+		refetchInterval: TIMING.HEALTH_CHECK_INTERVAL_MS,
 		retry: 1,
 		// Don't show stale data for health checks
 		staleTime: 0,

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -14,6 +14,8 @@
 import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
+import { QUERY_CACHE } from "@/config/cache";
+import { STATS_PAGE_LIMIT } from "@/config/network";
 import type { Run } from "@/types";
 import type { TimeSeriesResponse } from "@/modules/history/types";
 
@@ -39,7 +41,7 @@ export function useRunReportQuery(runId: string | null) {
 		queryFn: () => apiService.getRunReport(runId!),
 		enabled: !!runId,
 		// Reports don't change, cache longer
-		staleTime: 5 * 60 * 1000,
+		staleTime: QUERY_CACHE.RUNS_STALE_TIME_MS,
 	});
 }
 
@@ -51,11 +53,14 @@ export function useRunTimeSeriesQuery(runId: string | null) {
 	return useInfiniteQuery<TimeSeriesResponse, Error>({
 		queryKey: queryKeys.runs.timeSeries(runId ?? ""),
 		queryFn: ({ pageParam = 0 }) =>
-			apiService.getRunTimeSeries(runId!, { limit: 5000, offset: pageParam as number }),
+			apiService.getRunTimeSeries(runId!, {
+				limit: STATS_PAGE_LIMIT,
+				offset: pageParam as number,
+			}),
 		enabled: !!runId,
 		// Historical data never changes
 		staleTime: Infinity,
-		gcTime: 30 * 60 * 1000, // Keep in cache for 30 minutes
+		gcTime: QUERY_CACHE.RUNS_GC_TIME_MS,
 		initialPageParam: 0,
 		getNextPageParam: (lastPage) =>
 			lastPage.pagination.hasMore

--- a/app/src/queries/script-completions.ts
+++ b/app/src/queries/script-completions.ts
@@ -14,6 +14,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
+import { QUERY_CACHE } from "@/config/cache";
 
 /**
  * Fetch script completions for Monaco editor
@@ -23,10 +24,10 @@ export function useScriptCompletionsQuery() {
 	return useQuery({
 		queryKey: queryKeys.scriptCompletions.all,
 		queryFn: () => apiService.getScriptCompletions(),
-		// Script completions don't change, cache for 1 hour
-		staleTime: 60 * 60 * 1000,
-		gcTime: 60 * 60 * 1000,
-		// Don't retry if it fails - not critical
-		retry: 1,
+		// Script completions don't change, cache for a long time
+		staleTime: QUERY_CACHE.SCRIPT_COMPLETIONS_STALE_TIME_MS,
+		gcTime: QUERY_CACHE.SCRIPT_COMPLETIONS_GC_TIME_MS,
+		// Don't retry hard if it fails - not critical
+		retry: QUERY_CACHE.SCRIPT_COMPLETIONS_RETRY,
 	});
 }

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -45,6 +45,32 @@ import type {
 	ImportFetchResponse,
 } from "@/types";
 import type { TimeSeriesResponse } from "@/modules/history/types";
+import { queryClient } from "@/lib/query-client";
+import { queryKeys } from "@/queries/keys";
+import {
+	PROXIED_TIMEOUT_GRACE_MS,
+	ENGINE_MAX_DEFAULT_TIMEOUT_MS,
+	STATS_PAGE_LIMIT,
+} from "@/config/network";
+
+/**
+ * Timeout for engine calls that proxy a remote server (/request,
+ * /import/fetch). These block for as long as the target takes, bounded by the
+ * engine's user-configurable `defaultTimeout` setting — so derive the UI
+ * timeout from it instead of the flat default, with enough grace that the
+ * engine's own TIMEOUT error (proper error code) arrives before the UI aborts.
+ * Falls back to the engine's max when the config cache is cold. If per-request
+ * timeout overrides are ever added, this must become max(default, override).
+ */
+function proxiedRequestTimeoutMs(): number {
+	const config = queryClient.getQueryData<GetConfigResponse>(queryKeys.config.all);
+	const engineTimeout = Number(config?.entries.find((e) => e.key === "defaultTimeout")?.value);
+	const base =
+		Number.isFinite(engineTimeout) && engineTimeout > 0
+			? engineTimeout
+			: ENGINE_MAX_DEFAULT_TIMEOUT_MS;
+	return base + PROXIED_TIMEOUT_GRACE_MS;
+}
 
 export const apiService = {
 	// Health & Configuration
@@ -155,7 +181,9 @@ export const apiService = {
 
 	// Execution
 	async executeRequest(data: ExecuteRequestRequest): Promise<SanityResult> {
-		return await httpClient.post<SanityResult>(API_ENDPOINTS.EXECUTE_REQUEST, data);
+		return await httpClient.post<SanityResult>(API_ENDPOINTS.EXECUTE_REQUEST, data, {
+			timeout: proxiedRequestTimeoutMs(),
+		});
 	},
 
 	async startLoadTest(data: StartLoadTestRequest): Promise<StartLoadTestResponse> {
@@ -194,7 +222,7 @@ export const apiService = {
 		id: string,
 		options: { limit?: number; offset?: number } = {}
 	): Promise<TimeSeriesResponse> {
-		const { limit = 5000, offset = 0 } = options;
+		const { limit = STATS_PAGE_LIMIT, offset = 0 } = options;
 		return await httpClient.get<TimeSeriesResponse>(
 			API_ENDPOINTS.STATS_TIME_SERIES(id, limit, offset)
 		);
@@ -207,6 +235,10 @@ export const apiService = {
 
 	// Import
 	async importFetch(url: string): Promise<ImportFetchResponse> {
-		return await httpClient.post<ImportFetchResponse>(API_ENDPOINTS.IMPORT_FETCH, { url });
+		return await httpClient.post<ImportFetchResponse>(
+			API_ENDPOINTS.IMPORT_FETCH,
+			{ url },
+			{ timeout: proxiedRequestTimeoutMs() }
+		);
 	},
 };

--- a/app/src/services/http-client.ts
+++ b/app/src/services/http-client.ts
@@ -8,6 +8,7 @@
 // HTTP Client - Fetch wrapper for UI-to-Engine communication
 
 import { API_ENDPOINTS } from "@/config/api-endpoints";
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "@/config/network";
 
 /**
  * ApiError represents failures in UI-to-Engine communication.
@@ -48,7 +49,7 @@ class HttpClient {
 		}
 	): Promise<T> {
 		const controller = new AbortController();
-		const timeout = options?.timeout || 30000;
+		const timeout = options?.timeout || DEFAULT_REQUEST_TIMEOUT_MS;
 
 		const timeoutId = setTimeout(() => controller.abort(), timeout);
 

--- a/app/src/services/http-client.ts
+++ b/app/src/services/http-client.ts
@@ -113,8 +113,8 @@ class HttpClient {
 		return this.request<T>("GET", path, undefined, { params });
 	}
 
-	async post<T>(path: string, body?: unknown): Promise<T> {
-		return this.request<T>("POST", path, body);
+	async post<T>(path: string, body?: unknown, options?: { timeout?: number }): Promise<T> {
+		return this.request<T>("POST", path, body, options);
 	}
 
 	async put<T>(path: string, body?: unknown): Promise<T> {

--- a/app/src/services/importers/api-fetch.test.ts
+++ b/app/src/services/importers/api-fetch.test.ts
@@ -15,9 +15,13 @@ describe("apiService.importFetch", () => {
 			contentType: "application/json",
 		});
 		const res = await apiService.importFetch("https://x/spec.json");
-		expect(httpClient.post).toHaveBeenCalledWith("/import/fetch", {
-			url: "https://x/spec.json",
-		});
+		expect(httpClient.post).toHaveBeenCalledWith(
+			"/import/fetch",
+			{ url: "https://x/spec.json" },
+			// Proxied call: timeout derives from the engine's defaultTimeout
+			// setting (engine max + grace when the config cache is cold)
+			{ timeout: expect.any(Number) }
+		);
 		expect(res).toEqual({ content: "{}", contentType: "application/json" });
 	});
 });

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -17,13 +17,10 @@ import { sseClient } from "./sse-client";
 import { apiService } from "./api";
 import { useDashboardStore } from "@/stores";
 import type { LoadTestMetrics } from "@/types";
-
-/**
- * Engine emits at 10 Hz (100ms cadence — see engine/src/http/routes/metrics.cpp).
- * We throttle UI commits to 2 Hz to keep render cost bounded, but BUFFER every
- * tick the engine sends so historicalMetrics keeps the full 10 Hz signal.
- */
-const METRICS_UI_THROTTLE_MS = 500;
+// Engine emits at 10 Hz (100ms cadence — see engine/src/http/routes/metrics.cpp).
+// We throttle UI commits to keep render cost bounded, but BUFFER every tick the
+// engine sends so historicalMetrics keeps the full 10 Hz signal.
+import { METRICS_UI_THROTTLE_MS } from "@/config/metrics";
 
 class LoadTestService {
 	private activeRunId: string | null = null;

--- a/app/src/stores/dashboard-store.ts
+++ b/app/src/stores/dashboard-store.ts
@@ -10,6 +10,11 @@
 import { create } from "zustand";
 import type { LoadTestMetrics, RunReport } from "@/types";
 import { DEFAULT_SLO_MS, type Breakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
+// With the engine at 10 Hz and the UI commit throttle buffering every tick
+// (load-test-service.ts), the cap is ~5 minutes of full-fidelity history
+// before the oldest points roll off — long enough for a typical load-test
+// session, short enough to keep chart slicing cheap.
+import { HISTORICAL_METRICS_CAP } from "@/config/metrics";
 
 type DashboardMode = "running" | "completed" | "stopped";
 type DashboardView = "metrics" | "request-response";
@@ -31,15 +36,6 @@ export interface LoadTestRequestInfo {
 	method: string;
 	url: string;
 }
-
-/**
- * Cap historical metrics at ~3000 points. With the engine at 10 Hz and the UI
- * commit throttle at 2 Hz buffering every tick (load-test-service.ts), this is
- * ~5 minutes of full-fidelity history before the oldest points roll off — long
- * enough for a typical load-test session, short enough to keep chart slicing
- * cheap.
- */
-const HISTORICAL_METRICS_CAP = 3000;
 
 const INITIAL_BREAKPOINT: Breakpoint = {
 	crossed: false,

--- a/app/src/stores/variables-store.ts
+++ b/app/src/stores/variables-store.ts
@@ -16,6 +16,7 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
 
 export type VariableCategory =
 	| { type: "globals" }
@@ -74,7 +75,7 @@ export const useVariablesStore = create<VariablesUIState>()(
 				}),
 		}),
 		{
-			name: "variables-ui-store",
+			name: STORAGE_KEYS.VARIABLES_UI_STORE,
 			partialize: (state) => ({
 				// Persist active selections
 				activeEnvironmentId: state.activeEnvironmentId,

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -371,10 +371,12 @@ if(VAYU_BUILD_TESTS)
         tests/metrics_helper_test.cpp
         tests/metrics_collector_test.cpp
         tests/import_route_test.cpp
+        tests/execution_timeout_test.cpp
         tests/load_strategy_test.cpp
         tests/refill_deficit_test.cpp
         tests/run_manager_test.cpp
         src/http/routes/import.cpp
+        src/http/routes/execution.cpp
     )
     
     target_link_libraries(vayu_tests PRIVATE

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -25,6 +25,18 @@
 
 namespace vayu::http::routes {
 
+// Resolve the effective HTTP request timeout for design-mode POST /request.
+// An explicit per-request "timeout" wins; otherwise fall back to the engine's
+// user-configurable `defaultTimeout` setting (passed in by the caller) rather
+// than the compile-time DEFAULT_TIMEOUT_MS, so raising the setting actually
+// extends how long a slow request is allowed to run.
+int resolve_request_timeout_ms (const nlohmann::json& json, int configured_default) {
+    if (json.contains ("timeout") && json["timeout"].is_number ()) {
+        return json["timeout"].get<int> ();
+    }
+    return configured_default;
+}
+
 namespace {
 
 // Helper function to parse variables JSON string to Environment
@@ -358,6 +370,13 @@ void register_execution_routes (RouteContext& ctx) {
 
         // Get the request (may be modified by pre-request script)
         auto request = request_result.value ();
+
+        // deserialize_request defaults an omitted timeout to the compile-time
+        // constant; override with the engine's configured defaultTimeout so the
+        // user-facing setting governs how long a slow design-mode request runs.
+        request.timeout_ms = resolve_request_timeout_ms (json,
+        ctx.db.get_config_int (
+        "defaultTimeout", vayu::core::constants::server::DEFAULT_TIMEOUT_MS));
 
         // Execute pre-request script
         vayu::runtime::ScriptContext pre_ctx;

--- a/engine/tests/execution_timeout_test.cpp
+++ b/engine/tests/execution_timeout_test.cpp
@@ -1,0 +1,39 @@
+/**
+ * @file tests/execution_timeout_test.cpp
+ * @brief Tests timeout resolution for design-mode POST /request.
+ *
+ * Regression: the handler used the compile-time DEFAULT_TIMEOUT_MS (30s)
+ * whenever the request body omitted a "timeout" field, ignoring the
+ * user-configurable engine `defaultTimeout` setting.
+ */
+
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+namespace vayu::http::routes {
+// Declared in execution.cpp.
+int resolve_request_timeout_ms (const nlohmann::json& json, int configured_default);
+} // namespace vayu::http::routes
+
+namespace {
+
+using vayu::http::routes::resolve_request_timeout_ms;
+
+TEST (ResolveRequestTimeout, ExplicitTimeoutWins) {
+    auto json = nlohmann::json::parse (R"({"timeout":5000})");
+    EXPECT_EQ (resolve_request_timeout_ms (json, 120000), 5000);
+}
+
+TEST (ResolveRequestTimeout, FallsBackToConfiguredDefaultWhenOmitted) {
+    auto json = nlohmann::json::parse (R"({"url":"http://x"})");
+    // Must use the configured engine defaultTimeout, NOT the 30s constant.
+    EXPECT_EQ (resolve_request_timeout_ms (json, 120000), 120000);
+}
+
+TEST (ResolveRequestTimeout, IgnoresNonNumericTimeout) {
+    auto json = nlohmann::json::parse (R"({"timeout":"oops"})");
+    EXPECT_EQ (resolve_request_timeout_ms (json, 120000), 120000);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Two related changes: a sweep that centralizes every scattered constant in the app's JS/TS code, and a fix (spanning UI + engine) that makes the user-configurable **Default Request Timeout** setting actually govern slow design-mode requests end-to-end.

### 1. Constants centralization (`608a580`)

All hardcoded constants across `app/src` and `app/electron` now live in dedicated modules, following the existing `config/` vs `constants/` split:

| Module | Contents |
|---|---|
| `src/config/network.ts` | engine host/port/base URL, request timeouts, stats page size |
| `src/config/timing.ts` | UI delays/debounces/polling/retry policy (incl. the 2000ms status-reset duplicated in 6+ files, 150ms tooltip delay, 80ms tree click delay) |
| `src/config/cache.ts` | all TanStack Query staleTime/gcTime/retry policies |
| `src/config/metrics.ts` | metrics history cap, chart downsample limit, SSE throttle |
| `src/constants/http.ts` | HTTP method list, standard-headers autocomplete list |
| `src/constants/load-test.ts` | load test defaults + input min/max limits |
| `src/constants/storage-keys.ts` | localStorage / zustand persist keys |
| `src/constants/variables.ts` | shared `{{variable}}` regexes |
| `electron/constants.ts` | engine port/lock file, sidecar lifecycle policy, window dims, dev server URL, updater interval (separate file — the main-process build can't import from `src/`) |

Deliberately left in place: single-consumer presentational constants (chart geometry, settings category titles, etc.) where moving them would hurt cohesion.

Also fixes a latent bug: `AuthInheritBanner` called `.test()` on a shared global regex (stateful `lastIndex`), which could intermittently mis-highlight variables. Replaced with a stateless `isVariableToken()` helper.

### 2. Request timeout honored end-to-end (`5f3ee06`, `2075f4f`)

Previously the timeout story was broken in two places:

- **UI:** the UI→sidecar HTTP client aborted *every* call at a flat 30s — so raising the engine's `defaultTimeout` setting past 30s made the UI bail with a generic "Request timeout" while the engine was still waiting on the target.
- **Engine:** design-mode `POST /request` used the compile-time `DEFAULT_TIMEOUT_MS` for the outbound request, so the setting didn't extend slow requests anyway.

Now:

- **Engine** (`execution.cpp`): the effective timeout for `/request` is the per-request `timeout` field if present, else the configured `defaultTimeout` setting (covered by `execution_timeout_test.cpp`).
- **UI** (`api.ts`): the two proxied calls (`/request`, `/import/fetch`) derive their abort timeout as *engine `defaultTimeout` + 10s grace*, read from the TanStack config cache (fallback: engine max 300s + grace when cold). The grace ensures the engine's structured `TIMEOUT` error always surfaces instead of a generic UI abort. `App.tsx` keeps the config cache warm at startup.
- **Local CRUD calls** keep the flat 30s as a fast wedged-sidecar detector.

No new user setting was added on purpose: Postman/Insomnia expose exactly one request-timeout knob, and Vayu already has it (engine `defaultTimeout`); a second UI-side timeout setting would just let users recreate the race.

## Verification

- `pnpm type-check` clean (renderer + `tsconfig.node.json` electron build)
- `pnpm lint` at pre-existing baseline; new/touched files clean
- `pnpm test`: 254/254 passing
- Engine: new `execution_timeout_test.cpp` gtest

Manual check: set Settings → General Engine → Default Request Timeout to 120000, hit an endpoint that takes ~45s — the request now completes instead of aborting at 30s; with the setting at 5000, the engine's `TIMEOUT` error code surfaces at ~5s.

https://claude.ai/code/session_01L33HA15R3Z5TsZnadndYNG