### PR TITLE
docs(readme): add GitHub release downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Vayu is a free, open source desktop app for Windows, macOS, and Linux that merges two tools API teams normally split: a full REST + GraphQL request builder with collections, environments, and scripting, and a high-throughput load tester powered by a C++20 engine. The request UI will feel familiar coming from Postman or Insomnia — but underneath, a native event loop pushes load-test throughput that Electron + Node.js clients cannot reach, with every byte staying on your machine.
 
 [![Latest Release](https://img.shields.io/github/v/release/athrvk/vayu)](https://github.com/athrvk/vayu/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/athrvk/vayu/total)](https://github.com/athrvk/vayu/releases)
 [![License](https://img.shields.io/badge/license-AGPL--3.0%20%26%20Apache--2.0-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)](https://github.com/athrvk/vayu/releases)
 [![GitHub stars](https://img.shields.io/github/stars/athrvk/vayu?style=social&label=Star)](https://github.com/athrvk/vayu)


### PR DESCRIPTION
## Description
Adds a shields.io downloads badge to the README badge row, next to the "Latest Release" badge. It shows the total download count across all GitHub release assets (`img.shields.io/github/downloads/athrvk/vayu/total`) and links to the releases page.

## Type of Change
- [x] Documentation update

## Testing
Rendered the badge URL manually to confirm it resolves; no code paths affected.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
None


---
_Generated by [Claude Code](https://claude.ai/code/session_01HdD4vJajov9bTNUsdaSvL1)_