### PR TITLE
fix(app): stop Windows native controls overlay from hiding the env switcher

### DIFF
--- a/app/src/components/layout/TitleBar.tsx
+++ b/app/src/components/layout/TitleBar.tsx
@@ -157,7 +157,17 @@ export default function TitleBar() {
 			{/* Right controls */}
 			<div
 				className="flex items-center gap-2 px-3 shrink-0"
-				style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+				style={
+					{
+						WebkitAppRegion: "no-drag",
+						// Windows paints native min/max/close as an overlay on top of the
+						// web content in the top-right corner. Reserve its width (exposed by
+						// the Window Controls Overlay API) so the env switcher isn't covered.
+						...(isWindows && {
+							paddingRight: "calc(100vw - env(titlebar-area-width, 100vw) + 0.5rem)",
+						}),
+					} as React.CSSProperties
+				}
 			>
 				<EnvSwitcher />
 				{/* Linux only — Windows uses native overlay, macOS uses traffic lights */}


### PR DESCRIPTION
## Description
On Windows the min/max/close buttons are painted by Electron's **native controls overlay** (`titleBarOverlay`, `app/electron/main.ts:77-84`) on top of the web content in the top-right corner (~138px wide at 100% DPI). The custom titlebar layout reserved no space for it, so the env switcher pill sat flush against the window edge and was drawn *underneath* the native buttons:

- **No active environment** → the pill reads "No Environment" (wide), so only its left edge — the `Cloud` icon — peeked out to the left of the minimize button; the rest was covered.
- **Active environment** → the pill is short (`bg-accent`, just the name), so it fit entirely inside the overlay region and disappeared completely.

macOS (traffic lights on the left) and Linux (in-flow HTML controls) are unaffected.

**Fix:** reserve the overlay width on Windows via the Window Controls Overlay CSS env variable `titlebar-area-width`, which Chromium/Electron exposes when `titleBarOverlay` is enabled, so the switcher renders to the left of the native buttons.

```tsx
...(isWindows && {
  paddingRight: "calc(100vw - env(titlebar-area-width, 100vw) + 0.5rem)",
})
```

`100vw − titlebar-area-width` equals the native controls' width; the `100vw` fallback makes it a no-op if the API is unavailable, and it reacts automatically to resize/DPI changes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- `pnpm type-check` — passes
- `pnpm exec eslint` + `pnpm exec prettier --check` on the changed file — clean

Note: this was developed on Linux, so the pixel result on an actual Windows build hasn't been visually confirmed. The mechanism is the standard documented WCO approach; a quick eyeball on a Windows build is recommended, particularly the 0.5rem gap, which can be tuned to taste.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation

## Related Issues
Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhmRTJkZfKWyAhT6Zmm83S

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhmRTJkZfKWyAhT6Zmm83S)_