### PR TITLE
fix(engine): return specific /config validation reason in nested error shape

### DIFF
--- a/docs/plans/pending-backlog.md
+++ b/docs/plans/pending-backlog.md
@@ -2,7 +2,7 @@
 
 Living backlog of deferred / surfaced work. Each item notes **why** it's pending and **what** it needs so it can be picked up as a focused plan.
 
-_Last updated: 2026-06-05 (branch `claude/sweet-johnson-vUNGE`)._
+_Last updated: 2026-07-18 (branch `claude/session-tjt2op`; base master `05357cf`, engine `0.6.0`)._
 
 ---
 
@@ -31,8 +31,13 @@ Against `/fast` on loopback, tuned Vayu reaches ~45k req/s (vs `wrk` ~51k), but 
 
 **Needs:** lower the default `workers`; make the connection cap a **global budget** (or auto-derive from workers); bound the default `maxInFlight`. (Confirmed PR #10 is NOT the cause; ceiling is long-standing architecture. The branch-only 12-worker collapse was traced to added per-completion CPU and only bites at `workers=ncpu`.) Needs a spec.
 
-### P2. `/config` validation error message
-`POST /config` returns a generic `"Failed to update configuration. Check logs for details."` on a validation failure - the specific reason (which key / out-of-range / min-max) is logged server-side (`config.cpp:167`) but never returned. **Needs:** echo the specific validation error in the 400 body. Small UX fix.
+### P2. `/config` validation error message - _done on `claude/session-tjt2op` (commit `4a6ce5f`), pending build+merge_
+`POST /config` returned a generic `"Failed to update configuration. Check logs for details."` on a validation failure. Turned out to be **two** bugs: the reason wasn't returned, **and** the generic `send_error` helper emits the flat `{"error":"..."}` shape while the app's http-client reads the nested `error.message` shape - so even the generic string was dropped and surfaced as a bare "HTTP 400".
+
+**Fix (shipped on branch):** extracted the parse/validate/apply logic into a pure `apply_config_update(db, body) -> {status, json}` (mirrors `oauth2_token_post`, now unit-testable via `config_route_test.cpp`); returns the specific reason (unknown key / non-numeric / out-of-range with offending value + bound) in the **nested** shape the client surfaces. All-or-nothing preserved. _Not yet built/verified - the sandbox can't reach vcpkg dep hosts; needs a local `build.py -t && ctest` or CI green before merge._
+
+### P3. Remaining flat-error routes swallowed by the app client _(surfaced 2026-07-18 during P2)_
+The generic `send_error` helper (`routes.hpp:39`) emits flat `{"error":"<string>"}`, but `http-client.ts` only reads the nested `error.message`/`error.code`. Every route still using the flat helper (e.g. `config.cpp`'s "Invalid JSON", `execution.cpp:287/456`, `health`, 500 fallbacks) therefore shows a bare `HTTP <status>` in the UI, dropping the message. P2 fixed only the `/config` validation path. **Needs:** either migrate `send_error` to the nested shape (audit all call sites - some may rely on the flat body) or teach the client to accept both. Small, but cross-cutting. Low priority - most of these are developer-facing.
 
 ---
 
@@ -55,9 +60,9 @@ A `startConcurrency=0` ramp shows ~0.8% structural lag on a healthy run (integer
 
 ## Process
 
-- **Branch `claude/sweet-johnson-vUNGE` is well past reviewable** - ~40+ commits spanning many features, diverged from origin (ahead, 1 behind), **no PR**. Land PR(s); pull fresh master first; confirm target per qa→staging→master.
-- **cpp-httplib FD_SETSIZE fix is a master bug** - worth cherry-picking to master independently/first.
-- `docs/engine/api-reference.md` updated for `/metrics/live` replay + `liveRetentionMs` - currently uncommitted.
+- **`claude/sweet-johnson-vUNGE` concerns are resolved** - that work (OAuth 2.0 + N1 metrics + live retention) landed via PRs #45/#46 into **`0.6.0`**; the `/metrics/live` + `liveRetentionMs` api-reference doc is committed. The branch no longer exists on origin.
+- **cpp-httplib FD_SETSIZE fix - status unclear.** No `FD_SETSIZE`/`CPPHTTPLIB_` reference exists anywhere in `engine/` on current master, despite the "Shipped" note below claiming it landed. Re-verify whether the high-FD ceiling is actually addressed before relying on it.
+- Active branch `claude/session-tjt2op` carries the P2 fix (unmerged); rebased onto master `05357cf`.
 
 ---
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -382,6 +382,7 @@ if(VAYU_BUILD_TESTS)
         tests/metrics_helper_test.cpp
         tests/metrics_collector_test.cpp
         tests/import_route_test.cpp
+        tests/config_route_test.cpp
         tests/execution_timeout_test.cpp
         tests/load_strategy_test.cpp
         tests/refill_deficit_test.cpp
@@ -395,6 +396,7 @@ if(VAYU_BUILD_TESTS)
         tests/debug_redact_test.cpp
         tests/oauth_authorize_test.cpp
         src/http/routes/import.cpp
+        src/http/routes/config.cpp
         src/http/routes/oauth.cpp
         src/http/routes/oauth_authorize.cpp
         src/http/routes/execution.cpp

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -10,12 +10,200 @@
  * @brief Configuration management routes
  */
 
+#include <chrono>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/logger.hpp"
 
 namespace vayu::http::routes {
+
+namespace {
+
+// Serialize a config entry to the wire JSON shape shared by the GET and POST
+// responses (keeps the two paths from drifting).
+nlohmann::json config_entry_json (const vayu::db::ConfigEntry& entry) {
+    nlohmann::json entry_json;
+    entry_json["key"]         = entry.key;
+    entry_json["value"]       = entry.value;
+    entry_json["type"]        = entry.type;
+    entry_json["label"]       = entry.label;
+    entry_json["description"] = entry.description;
+    entry_json["category"]    = entry.category;
+    entry_json["default"]     = entry.default_value;
+    if (entry.min_value) {
+        entry_json["min"] = *entry.min_value;
+    }
+    if (entry.max_value) {
+        entry_json["max"] = *entry.max_value;
+    }
+    entry_json["updatedAt"] = entry.updated_at;
+    return entry_json;
+}
+
+// Build the nested error body the app's http-client reads
+// (`errorData.error.message`); the flat `{"error": "..."}` shape is dropped by
+// the client and surfaces only as a bare "HTTP 400".
+nlohmann::json config_error (const std::string& message) {
+    return nlohmann::json{ { "error",
+    { { "code", "invalid_config" }, { "message", message } } } };
+}
+
+} // namespace
+
+/**
+ * @brief Parse, validate, and apply a POST /config request body.
+ *
+ * Split out of the route handler so the validation path (and the specific
+ * failure reason it now returns) is unit-testable without a live server.
+ *
+ * @return {http_status, json_body}. On validation failure the body carries the
+ *         specific reason(s) - which key, and why (bad type / out of range) -
+ *         so the app can show it instead of a generic "check the logs".
+ */
+std::pair<int, nlohmann::json> apply_config_update (vayu::db::Database& db,
+const std::string& body) {
+    nlohmann::json json;
+    try {
+        json = nlohmann::json::parse (body);
+    } catch (const nlohmann::json::parse_error& e) {
+        vayu::utils::log_error (
+        "POST /config - JSON parse error: " + std::string (e.what ()));
+        return { 400, config_error ("Invalid JSON: " + std::string (e.what ())) };
+    }
+
+    std::unordered_map<std::string, std::string> updates;
+
+    // Bulk update format: { "entries": { "key": "value", ... } }
+    if (json.contains ("entries") && json["entries"].is_object ()) {
+        for (const auto& [key, value] : json["entries"].items ()) {
+            if (value.is_string ()) {
+                updates[key] = value.get<std::string> ();
+            } else if (value.is_number ()) {
+                updates[key] = std::to_string (value.get<double> ());
+            } else if (value.is_boolean ()) {
+                updates[key] = value.get<bool> () ? "true" : "false";
+            } else {
+                updates[key] = value.dump ();
+            }
+        }
+    }
+    // Single update format: { "key": "key1", "value": "value1" }
+    else if (json.contains ("key") && json.contains ("value")) {
+        std::string key = json["key"].get<std::string> ();
+        std::string value;
+        const auto& v = json["value"];
+        if (v.is_string ()) {
+            value = v.get<std::string> ();
+        } else if (v.is_number ()) {
+            value = std::to_string (v.get<double> ());
+        } else if (v.is_boolean ()) {
+            value = v.get<bool> () ? "true" : "false";
+        } else {
+            value = v.dump ();
+        }
+        updates[key] = value;
+    } else {
+        return { 400,
+        config_error ("Invalid request format. Expected { \"entries\": {...} } "
+                      "or { \"key\": \"...\", \"value\": \"...\" }") };
+    }
+
+    if (updates.empty ()) {
+        return { 400, config_error ("No updates provided") };
+    }
+
+    // Validate every key first; apply nothing unless all pass (all-or-nothing).
+    std::vector<vayu::db::ConfigEntry> to_update;
+    std::vector<std::string> errors;
+
+    for (const auto& [key, value] : updates) {
+        auto existing = db.get_config_entry (key);
+        if (!existing) {
+            errors.push_back ("Unknown config key '" + key + "'");
+            continue;
+        }
+
+        std::string reason;
+        if (existing->type == "integer") {
+            try {
+                int int_val = std::stoi (value);
+                if (existing->min_value && int_val < std::stoi (*existing->min_value)) {
+                    reason = "'" + key + "' must be at least " + *existing->min_value +
+                    " (got " + value + ")";
+                } else if (existing->max_value &&
+                int_val > std::stoi (*existing->max_value)) {
+                    reason = "'" + key + "' must be at most " + *existing->max_value +
+                    " (got " + value + ")";
+                }
+            } catch (...) {
+                reason = "'" + key + "' must be an integer (got '" + value + "')";
+            }
+        } else if (existing->type == "number") {
+            try {
+                double double_val = std::stod (value);
+                if (existing->min_value && double_val < std::stod (*existing->min_value)) {
+                    reason = "'" + key + "' must be at least " + *existing->min_value +
+                    " (got " + value + ")";
+                } else if (existing->max_value &&
+                double_val > std::stod (*existing->max_value)) {
+                    reason = "'" + key + "' must be at most " + *existing->max_value +
+                    " (got " + value + ")";
+                }
+            } catch (...) {
+                reason = "'" + key + "' must be a number (got '" + value + "')";
+            }
+        } else if (existing->type == "boolean") {
+            if (value != "true" && value != "false") {
+                reason = "'" + key + "' must be 'true' or 'false' (got '" + value + "')";
+            }
+        }
+
+        if (!reason.empty ()) {
+            errors.push_back (reason);
+            continue;
+        }
+
+        vayu::db::ConfigEntry updated = *existing;
+        updated.value                 = value;
+        updated.updated_at = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                             .count ();
+        to_update.push_back (updated);
+    }
+
+    if (!errors.empty ()) {
+        std::string joined;
+        for (size_t i = 0; i < errors.size (); ++i) {
+            if (i > 0) {
+                joined += "; ";
+            }
+            joined += errors[i];
+        }
+        vayu::utils::log_error ("POST /config - Validation failed: " + joined);
+        return { 400, config_error (joined) };
+    }
+
+    for (const auto& entry : to_update) {
+        db.save_config_entry (entry);
+    }
+
+    vayu::utils::log_info ("POST /config - Updated " +
+    std::to_string (to_update.size ()) + " config entries");
+
+    nlohmann::json entries_array = nlohmann::json::array ();
+    for (const auto& entry : db.get_all_config_entries ()) {
+        entries_array.push_back (config_entry_json (entry));
+    }
+
+    nlohmann::json response;
+    response["entries"] = entries_array;
+    response["success"] = true;
+    return { 200, response };
+}
 
 void register_config_routes (RouteContext& ctx) {
     /**
@@ -25,30 +213,12 @@ void register_config_routes (RouteContext& ctx) {
     ctx.server.Get ("/config", [&ctx] (const httplib::Request&, httplib::Response& res) {
         vayu::utils::log_info ("GET /config - Fetching configuration entries");
         try {
-            auto entries = ctx.db.get_all_config_entries ();
-
-            nlohmann::json response;
             nlohmann::json entries_array = nlohmann::json::array ();
-
-            for (const auto& entry : entries) {
-                nlohmann::json entry_json;
-                entry_json["key"]         = entry.key;
-                entry_json["value"]       = entry.value;
-                entry_json["type"]        = entry.type;
-                entry_json["label"]       = entry.label;
-                entry_json["description"] = entry.description;
-                entry_json["category"]    = entry.category;
-                entry_json["default"]     = entry.default_value;
-                if (entry.min_value) {
-                    entry_json["min"] = *entry.min_value;
-                }
-                if (entry.max_value) {
-                    entry_json["max"] = *entry.max_value;
-                }
-                entry_json["updatedAt"] = entry.updated_at;
-                entries_array.push_back (entry_json);
+            for (const auto& entry : ctx.db.get_all_config_entries ()) {
+                entries_array.push_back (config_entry_json (entry));
             }
 
+            nlohmann::json response;
             response["entries"] = entries_array;
             res.set_content (response.dump (2), "application/json");
         } catch (const std::exception& e) {
@@ -66,163 +236,9 @@ void register_config_routes (RouteContext& ctx) {
     ctx.server.Post ("/config", [&ctx] (const httplib::Request& req, httplib::Response& res) {
         vayu::utils::log_info ("POST /config - Updating configuration");
         try {
-            auto json = nlohmann::json::parse (req.body);
-
-            std::unordered_map<std::string, std::string> updates;
-
-            // Handle bulk update format: { "entries": { "key": "value", ... } }
-            if (json.contains ("entries") && json["entries"].is_object ()) {
-                for (const auto& [key, value] : json["entries"].items ()) {
-                    if (value.is_string ()) {
-                        updates[key] = value.get<std::string> ();
-                    } else if (value.is_number ()) {
-                        updates[key] = std::to_string (value.get<double> ());
-                    } else if (value.is_boolean ()) {
-                        updates[key] = value.get<bool> () ? "true" : "false";
-                    } else {
-                        updates[key] = value.dump ();
-                    }
-                }
-            }
-            // Handle single update format: { "key": "key1", "value": "value1" }
-            else if (json.contains ("key") && json.contains ("value")) {
-                std::string key = json["key"].get<std::string> ();
-                std::string value;
-                if (json["value"].is_string ()) {
-                    value = json["value"].get<std::string> ();
-                } else if (json["value"].is_number ()) {
-                    value = std::to_string (json["value"].get<double> ());
-                } else if (json["value"].is_boolean ()) {
-                    value = json["value"].get<bool> () ? "true" : "false";
-                } else {
-                    value = json["value"].dump ();
-                }
-                updates[key] = value;
-            } else {
-                send_error (res, 400,
-                "Invalid request format. Expected { \"entries\": {...} } or { "
-                "\"key\": \"...\", \"value\": \"...\" }");
-                return;
-            }
-
-            if (updates.empty ()) {
-                send_error (res, 400, "No updates provided");
-                return;
-            }
-
-            // Validate and update all config entries
-            bool all_valid = true;
-            std::vector<vayu::db::ConfigEntry> to_update;
-
-            for (const auto& [key, value] : updates) {
-                auto existing = ctx.db.get_config_entry (key);
-                if (!existing) {
-                    vayu::utils::log_warning (
-                    "POST /config - Unknown config key: " + key);
-                    all_valid = false;
-                    continue;
-                }
-
-                // Validate value based on type
-                bool valid = true;
-                if (existing->type == "integer") {
-                    try {
-                        int int_val = std::stoi (value);
-                        if (existing->min_value) {
-                            int min_val = std::stoi (*existing->min_value);
-                            if (int_val < min_val)
-                                valid = false;
-                        }
-                        if (existing->max_value) {
-                            int max_val = std::stoi (*existing->max_value);
-                            if (int_val > max_val)
-                                valid = false;
-                        }
-                    } catch (...) {
-                        valid = false;
-                    }
-                } else if (existing->type == "number") {
-                    try {
-                        double double_val = std::stod (value);
-                        if (existing->min_value) {
-                            double min_val = std::stod (*existing->min_value);
-                            if (double_val < min_val)
-                                valid = false;
-                        }
-                        if (existing->max_value) {
-                            double max_val = std::stod (*existing->max_value);
-                            if (double_val > max_val)
-                                valid = false;
-                        }
-                    } catch (...) {
-                        valid = false;
-                    }
-                } else if (existing->type == "boolean") {
-                    if (value != "true" && value != "false") {
-                        valid = false;
-                    }
-                }
-
-                if (!valid) {
-                    vayu::utils::log_error (
-                    "POST /config - Invalid value for key " + key + ": " + value);
-                    all_valid = false;
-                    continue;
-                }
-
-                // Create updated entry
-                vayu::db::ConfigEntry updated = *existing;
-                updated.value                 = value;
-                updated.updated_at = std::chrono::duration_cast<std::chrono::milliseconds> (
-                std::chrono::system_clock::now ().time_since_epoch ())
-                                     .count ();
-                to_update.push_back (updated);
-            }
-
-            if (!all_valid) {
-                send_error (res, 400, "Failed to update configuration. Check logs for details.");
-                return;
-            }
-
-            // Apply all updates to database
-            for (const auto& entry : to_update) {
-                ctx.db.save_config_entry (entry);
-            }
-
-            vayu::utils::log_info ("POST /config - Updated " +
-            std::to_string (to_update.size ()) + " config entries");
-
-            // Return updated entries
-            auto entries = ctx.db.get_all_config_entries ();
-            nlohmann::json response;
-            nlohmann::json entries_array = nlohmann::json::array ();
-
-            for (const auto& entry : entries) {
-                nlohmann::json entry_json;
-                entry_json["key"]         = entry.key;
-                entry_json["value"]       = entry.value;
-                entry_json["type"]        = entry.type;
-                entry_json["label"]       = entry.label;
-                entry_json["description"] = entry.description;
-                entry_json["category"]    = entry.category;
-                entry_json["default"]     = entry.default_value;
-                if (entry.min_value) {
-                    entry_json["min"] = *entry.min_value;
-                }
-                if (entry.max_value) {
-                    entry_json["max"] = *entry.max_value;
-                }
-                entry_json["updatedAt"] = entry.updated_at;
-                entries_array.push_back (entry_json);
-            }
-
-            response["entries"] = entries_array;
-            response["success"] = true;
-            res.set_content (response.dump (2), "application/json");
-        } catch (const nlohmann::json::parse_error& e) {
-            vayu::utils::log_error (
-            "POST /config - JSON parse error: " + std::string (e.what ()));
-            send_error (res, 400, "Invalid JSON: " + std::string (e.what ()));
+            auto [status, response_body] = apply_config_update (ctx.db, req.body);
+            res.status = status;
+            res.set_content (response_body.dump (2), "application/json");
         } catch (const std::exception& e) {
             vayu::utils::log_error ("POST /config - Error: " + std::string (e.what ()));
             send_error (res, 500, e.what ());

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -1,0 +1,128 @@
+/**
+ * @file tests/config_route_test.cpp
+ * @brief Tests for POST /config validation (apply_config_update).
+ *
+ * Focus: a validation failure must return the *specific* reason (which key,
+ * why) in the nested `error.message` shape the app reads - not a generic
+ * "check the logs" string that surfaces as a bare "HTTP 400".
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/db/database.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Declared in config.cpp; returns {http_status, json_body}.
+std::pair<int, nlohmann::json> apply_config_update (vayu::db::Database& db,
+const std::string& body);
+} // namespace vayu::http::routes
+
+namespace {
+
+class ConfigRouteTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_config_route.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + s);
+        }
+    }
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+TEST_F (ConfigRouteTest, InvalidJsonIs400WithReason) {
+    auto [status, body] = vayu::http::routes::apply_config_update (*db_, "not json");
+    EXPECT_EQ (status, 400);
+    EXPECT_EQ (body["error"]["code"], "invalid_config");
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Invalid JSON"),
+    std::string::npos);
+}
+
+TEST_F (ConfigRouteTest, InvalidRequestFormatIs400) {
+    auto [status, body] = vayu::http::routes::apply_config_update (*db_, R"({"foo":"bar"})");
+    EXPECT_EQ (status, 400);
+    EXPECT_EQ (body["error"]["code"], "invalid_config");
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Invalid request format"),
+    std::string::npos);
+}
+
+TEST_F (ConfigRouteTest, UnknownKeyNamesTheKey) {
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"totally_made_up_key":"1"}})");
+    EXPECT_EQ (status, 400);
+    const auto message = body["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("Unknown config key"), std::string::npos);
+    EXPECT_NE (message.find ("totally_made_up_key"), std::string::npos);
+}
+
+TEST_F (ConfigRouteTest, OutOfRangeReportsBoundAndValue) {
+    // "workers" is seeded as an integer with min 1 / max 128.
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"workers":"999"}})");
+    EXPECT_EQ (status, 400);
+    const auto message = body["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("workers"), std::string::npos);
+    EXPECT_NE (message.find ("128"), std::string::npos); // the exceeded bound
+    EXPECT_NE (message.find ("999"), std::string::npos); // the offending value
+}
+
+TEST_F (ConfigRouteTest, NonIntegerReportsType) {
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"workers":"abc"}})");
+    EXPECT_EQ (status, 400);
+    const auto message = body["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("workers"), std::string::npos);
+    EXPECT_NE (message.find ("integer"), std::string::npos);
+}
+
+TEST_F (ConfigRouteTest, InvalidValueDoesNotPersist) {
+    auto before = db_->get_config_entry ("workers");
+    ASSERT_TRUE (before.has_value ());
+
+    vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"999"}})");
+
+    auto after = db_->get_config_entry ("workers");
+    ASSERT_TRUE (after.has_value ());
+    EXPECT_EQ (after->value, before->value); // rejected update left the DB untouched
+}
+
+TEST_F (ConfigRouteTest, ValidUpdateSucceedsAndPersists) {
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"workers":"4"}})");
+    EXPECT_EQ (status, 200);
+    EXPECT_TRUE (body["success"].get<bool> ());
+
+    auto stored = db_->get_config_entry ("workers");
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_EQ (stored->value, "4");
+}
+
+TEST_F (ConfigRouteTest, SingleUpdateFormatSucceeds) {
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"key":"workers","value":"8"})");
+    EXPECT_EQ (status, 200);
+    EXPECT_TRUE (body["success"].get<bool> ());
+
+    auto stored = db_->get_config_entry ("workers");
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_EQ (stored->value, "8");
+}
+
+} // namespace


### PR DESCRIPTION
## Description
`POST /config` rejected invalid values with a generic `"Failed to update configuration. Check logs for details."`. Tracing it end-to-end surfaced **two** bugs:

1. The specific reason (which key, why) was logged server-side but never returned.
2. The generic `send_error` helper emits the **flat** `{"error":"..."}` shape, but the app's `http-client` reads the **nested** `error.message`/`error.code` shape (as the OAuth routes already emit). So even the generic string was dropped — the Settings save error showed only a bare **"HTTP 400"**.

Changes:
- Extracted the parse/validate/apply logic into a pure `apply_config_update(db, body) -> {status, json}` (mirrors `oauth2_token_post`), so validation is unit-testable without a live server.
- On failure it returns the specific reason(s) — unknown key / non-numeric / out-of-range *with the offending value and the bound* — in the nested `{"error":{"code","message"}}` shape the client surfaces. Example: `workers = 999` → `'workers' must be at most 128 (got 999)`.
- Preserved all-or-nothing semantics (a rejected batch persists nothing) and folded the duplicated entry serialization into one `config_entry_json` helper shared by GET/POST.
- Refreshed `docs/plans/pending-backlog.md`: marked P2 done, added P3 (the remaining flat-error routes are swallowed the same way — a follow-up), and resolved stale process notes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
Added `engine/tests/config_route_test.cpp` (wired into the `vayu_tests` target) covering: invalid JSON, invalid request format, unknown key (names the key), out-of-range (reports bound + offending value), non-integer (reports type), non-persistence on failure, and valid single + bulk updates.

⚠️ **Not built/run in this environment** — the sandbox proxy can't reach vcpkg's dependency-source hosts, so the C++ engine could not be compiled here. The change follows existing compiling, tested precedent (the nested-error idiom is byte-identical to `execution.cpp:522`; the `{status, json}` pure-function + test pattern matches the already-tested `import.cpp`/`oauth.cpp`), and every `ConfigEntry` field / DB signature used was verified against the headers. **Please confirm CI green (or `python build.py -t && ctest --preset linux-dev --output-on-failure`) before merge.**

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STpSxBqZM7dBemdMJLEt2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01STpSxBqZM7dBemdMJLEt2V)_