### PR TITLE
fix(build): use vcpkg manifest mode for engine dep pre-warm

### DIFF
--- a/build.py
+++ b/build.py
@@ -834,9 +834,11 @@ def setup_environment(project_root: Path):
     vcpkg_bin = Path(vcpkg_root) / "vcpkg"
     engine_dir = project_root / "engine"
     triplet = "x64-osx" if system_name == "macOS" else "x64-linux"
-    vcpkg_packages = ["curl", "nlohmann-json", "cpp-httplib", "gtest", "sqlite3", "sqlite-orm"]
+    # engine/ has a vcpkg.json manifest, so vcpkg runs in manifest mode and
+    # installs the declared dependencies. Manifest mode rejects individual
+    # package arguments, so pass only the triplet and let vcpkg.json drive it.
     result = subprocess.run(
-        [str(vcpkg_bin), "install"] + vcpkg_packages + ["--triplet", triplet],
+        [str(vcpkg_bin), "install", "--triplet", triplet],
         cwd=engine_dir,
     )
     if result.returncode == 0:


### PR DESCRIPTION
## Description
The `python build.py --setup` step (run by the `.claude/hooks/session-start.sh` SessionStart hook) invoked `vcpkg install curl nlohmann-json cpp-httplib gtest sqlite3 sqlite-orm --triplet x64-linux` from inside `engine/`. Because `engine/` contains a `vcpkg.json` manifest, vcpkg runs in **manifest mode**, which rejects individual package arguments:

```
error: In manifest mode, `vcpkg install` does not support individual package arguments.
```

The pre-warm therefore always failed (non-fatally, so the build still recovered via CMake's own manifest-mode install). This drops the explicit package list and passes only the triplet, letting `vcpkg.json` drive the install — which is the correct manifest-mode invocation and matches how the environment's setup script pre-warms via `cmake --preset`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Ran `python build.py --setup` in the remote environment. The `Pre-installing vcpkg engine dependencies...` step now completes without the manifest-mode error and reports `vcpkg packages ready` instead of the warning.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [ ] I have updated documentation

## Related Issues
Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuseouNaVay42z9xBPZogf

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuseouNaVay42z9xBPZogf)_