### PR TITLE
ci(release): publish curated release notes from a repo file

### DIFF
--- a/.github/release-notes/v0.7.0.md
+++ b/.github/release-notes/v0.7.0.md
@@ -1,0 +1,29 @@
+## [0.7.0] - 2026-07-18
+
+An app-focused polish release. What began as a fix for tab titles grew into a full theming system, user-facing personalization controls, and a modernization of the UI primitives — the bulk of the change is new React/TypeScript in the app (`/app`), with a handful of engine and build fixes alongside. Existing settings and workspaces carry over unchanged.
+
+### Added
+- **Meaningful tab titles.** Request tabs now show the request's **name** when you've set one (falling back to the path); collection tabs show the collection name.
+- **Interface personalization.** A new Interface panel in Settings lets you choose the **font** (Inter, Space Grotesk, System, or JetBrains Mono), **scale** (Compact / Default / Comfortable), and **corner roundedness** (Square / Default / Rounded). All three persist and apply before first paint, and roundedness drives a single `--radius` token across every component.
+- **Paper White light theme.** The light theme was retuned from warm-stone to a cool, near-neutral Paper White.
+- **Timing tooltips.** Per-phase timing tooltips now appear on both the request **Trace Info** panel and the load-test **aggregate Timing Breakdown**.
+
+### Changed
+- **Accent system split.** `--primary` (accent text, mode-adaptive) is now separate from `--primary-fill` (button fills), so contrast clears 3:1 on buttons and 6.6:1+ on text in both light and dark modes; the chart palette was harmonized to match.
+- **Colors tokenized.** ~430 hardcoded colors moved onto semantic tokens — variable scope, run/connection/test status, HTTP-severity, latency, and console — and low-contrast `subtle-foreground`, warning, and success text gained accessible `-text` variants.
+- **shadcn primitives modernized.** All 16 UI primitives were moved to the current React 19 pattern (`data-slot`, function components, no `forwardRef`), and `tailwindcss-animate` was replaced with the Tailwind v4-native `tw-animate-css`.
+- **Default-name literals centralized.** Request, collection, folder, and environment default names now come from shared constants instead of being duplicated across the codebase; the default color scheme (Ocean) and UI font (Inter) are single-sourced too.
+- **Resizable settings sidebar.** The settings category list is now drag-resizable instead of a fixed width that truncated longer labels.
+- **Clearer engine config errors.** A rejected `POST /config` update now returns the specific reason (which key, why) in the nested `error.message` shape the app reads, rather than a generic "HTTP 400".
+
+### Fixed
+- **Stale tabs on delete.** Deleting a request or collection now closes its open tab(s) instead of leaving an orphaned tab pointing at a deleted entity.
+- **Variable "secret" toggle.** Marking a variable secret now persists instead of snapping back to its previous state on the next backend sync.
+- **Setting icons.** The Color Scheme and Theme Mode settings now use meaningful, distinct icons.
+- **No theme flash.** The persisted theme, accent, font, and radius are applied before the first paint, eliminating the light-to-dark flash on launch.
+- **Windows titlebar.** The native window-controls overlay width is now reserved in the custom titlebar so controls no longer overlap content.
+- **Build & CI hygiene.** `build.py` works with Visual Studio Build Tools, `windows-dev` uses the Ninja generator, the engine dependency pre-warm uses vcpkg manifest mode, and a config-route test now seeds its database via `init()` (matching daemon startup) so it exercises real config keys.
+
+> Note: this release swaps in `tw-animate-css`, so run `pnpm install` in `app/` after pulling.
+
+[0.7.0]: https://github.com/athrvk/vayu/compare/v0.6.0...v0.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,24 @@ jobs:
           done
           ls -lh artifacts/
 
+      # Prefer the curated, hand-written notes committed at .github/release-notes/<tag>.md
+      # (Keep a Changelog format, see CLAUDE.md). If that file is absent for this tag,
+      # fall back to GitHub's automatically generated PR-based notes so the release is
+      # never published with an empty body.
+      - name: Resolve release notes
+        if: github.event_name == 'push'
+        id: relnotes
+        shell: bash
+        run: |
+          notes=".github/release-notes/${GITHUB_REF_NAME}.md"
+          if [ -f "$notes" ]; then
+            echo "Using curated release notes: $notes"
+            echo "path=$notes" >> "$GITHUB_OUTPUT"
+          else
+            echo "No curated notes at $notes - falling back to auto-generated notes."
+            echo "path=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload artifacts to release
         if: github.event_name == 'push'
         uses: softprops/action-gh-release@v2
@@ -288,5 +306,9 @@ jobs:
           files: |
             artifacts/*
           fail_on_unmatched_files: false
+          # body_path is ignored by the action when empty; generate_release_notes then
+          # supplies GitHub's auto notes as the fallback.
+          body_path: ${{ steps.relnotes.outputs.path }}
+          generate_release_notes: ${{ steps.relnotes.outputs.path == '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,10 @@ See `docs/engine/api-reference.md` for full reference.
 ## Releasing
 
 1. `python build.py --bump-version patch` - updates VERSION, CMakeLists.txt, vcpkg.json, package.json
-2. Commit: `git commit -m "chore(release): x.y.z"`
-3. Tag: `git tag v$(cat VERSION) && git push origin --tags`
-4. CI builds and uploads installers automatically.
+2. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a Changelog format, see below).
+3. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes file together).
+4. Tag: `git tag v$(cat VERSION) && git push origin --tags`
+5. CI builds installers and publishes the GitHub Release, using `.github/release-notes/<tag>.md` as the release body automatically (no manual paste).
 
 **Tag *after* the release commit lands on the default branch.** When the version bump goes through a pull request (the usual path), run steps 1-2 on the feature branch so the bump merges with the PR, but do **not** tag the PR-branch commit. A squash/rebase merge rewrites the commit hash, so a tag on the pre-merge commit would point at a commit that never reaches the default branch. Wait for the PR to merge, then run step 3 against the merged commit on the default branch (`git checkout <default-branch> && git pull && git tag v$(cat VERSION) && git push origin --tags`). The tag triggers the release build, so it must sit on the canonical merged history.
 
@@ -164,7 +165,9 @@ Release notes live on the [GitHub Releases](https://github.com/athrvk/vayu/relea
 - **Compare link footer:** `[X.Y.Z]: https://github.com/athrvk/vayu/compare/vPREV...vX.Y.Z`.
 - **Version choice:** patch = fixes only; minor = new user-facing feature; major = breaking change (still `0.x`, so reserve major for a stable milestone). See the [prior releases](https://github.com/athrvk/vayu/releases) for worked examples.
 
-**Keep the GitHub Release current.** Whenever a new `vX.Y.Z` tag is created (Releasing step 3), Claude should write/refresh that version's GitHub Release notes to a changelog entry in the format above, derived from `git log vPREV..vX.Y.Z`. Discover the right tooling at runtime rather than assuming a fixed command — look for a release-publishing capability among the session's tools (search available MCP tools for release create/edit, or fall back to a CLI like `gh` if present), read a recent release to match voice, then publish. If only read-only release tools are available, draft the notes and hand them off rather than skipping the step.
+**Release notes are published from a file — no manual paste.** Curated notes for each version live in the repo at `.github/release-notes/vX.Y.Z.md`, committed alongside the version bump (Releasing step 2). On tag push, `.github/workflows/release.yml` reads `.github/release-notes/<tag>.md` and sets it as the GitHub Release body via `softprops/action-gh-release`'s `body_path`. If that file is missing for the tag, the workflow falls back to GitHub's automatically generated PR-based notes (`generate_release_notes`) so a release is never published empty.
+
+**Authoring the notes (Claude's job before tagging).** When preparing a release, write `.github/release-notes/vX.Y.Z.md` in the format above, derived from `git log vPREV..vX.Y.Z`; read a recent entry to match voice. The file *is* the release body, so it needs no tooling to publish — CI handles it. Because the workflow resolves the file from the tagged commit's tree, the notes file must be committed **before** the tag is pushed (i.e., it rides along in the release PR). To correct a published release's notes after the fact, edit the file, then either re-run the release workflow or update the release body by hand.
 
 ## Key Docs
 


### PR DESCRIPTION
## Description

Automates the "plumbing" for release notes while keeping the curated [Keep a Changelog](https://keepachangelog.com) format we already write by hand. The GitHub Release body now comes from a version-controlled file instead of a manual copy-paste after each tag.

- **`.github/release-notes/<tag>.md`** holds the curated body for a version, committed alongside the version bump.
- **`.github/workflows/release.yml`** gains a `Resolve release notes` step that locates `.github/release-notes/<tag>.md` from the tagged commit and passes it to `softprops/action-gh-release` via `body_path`. If the file is absent for the tag, it falls back to GitHub's automatically generated PR-based notes (`generate_release_notes`) so a release is never published empty.
- **`.github/release-notes/v0.7.0.md`** seeds the current release's notes.
- **`CLAUDE.md`** documents the new flow in the Releasing section.

Net effect: write the notes file, push the tag, and CI publishes the exact curated prose — no manual paste. The tag push itself remains a human step (the `v*` protected-tag rule is unchanged).

> Note: because the workflow resolves the notes file from the tagged commit's tree, the file must be committed **before** the tag is pushed (it rides along in the release PR).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

_(Not a code breaking change — "breaking" only in that it changes the release process: notes now come from a repo file.)_

## Testing
- `release.yml` validated as well-formed YAML.
- `body_path` is ignored by `action-gh-release` when empty, so the `generate_release_notes` fallback engages when no curated file exists for a tag; when the file exists it is used verbatim as the body.
- No engine or app code touched, so the standard test suites are unaffected.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGtPc6EDksbjaepkqA2VcF)_