### PR TITLE
feat(metrics): windowed (rolling) latency percentiles (W1)

### DIFF
--- a/app/src/modules/history/main/LoadTestDetail.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.tsx
@@ -11,19 +11,60 @@
  * Displays details for a load test run with tabs for overview, performance, and samples.
  */
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { CheckCircle, Activity, TrendingUp, BarChart3, Settings2 } from "lucide-react";
 import { Badge, Tabs, TabsContent, TabsList, TabsTrigger, ScrollArea } from "@/components/ui";
 import { formatNumber, loadTestTypeToLabel } from "@/utils";
 import type { LoadTestConfig } from "@/types";
 import { reportToDerived } from "@/modules/dashboard/utils/reportToDerived";
+import { computeBreakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
+import { useRunTimeSeriesQuery } from "@/queries/runs";
 import { OverviewTab, PerformanceTab, SamplesTab } from "./components";
-import type { LoadTestDetailProps } from "../types";
+import type { LoadTestDetailProps, TimeSeriesResponse } from "../types";
 
 export default function LoadTestDetail({ report, onBack: _onBack, runId }: LoadTestDetailProps) {
 	const [activeTab, setActiveTab] = useState("overview");
 	const config = report.metadata?.configuration;
-	const derived = useMemo(() => reportToDerived(report), [report]);
+
+	// Fetch the persisted per-tick time-series once, here, so both the Overview
+	// stat cards (breakpoint / saturation, derived below) and the Performance tab
+	// charts read the same data — one query, shared cache.
+	const {
+		data: timeSeriesData,
+		isLoading: isLoadingSeries,
+		isFetchingNextPage,
+		hasNextPage,
+		fetchNextPage,
+	} = useRunTimeSeriesQuery(runId ?? null);
+
+	// Auto-page through the full series so breakpoint detection and the charts see
+	// every tick, not just the first page.
+	useEffect(() => {
+		if (hasNextPage && !isFetchingNextPage) {
+			fetchNextPage();
+		}
+	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+	const timeSeries = useMemo(
+		() => timeSeriesData?.pages?.flatMap((page: TimeSeriesResponse) => page.data) ?? [],
+		[timeSeriesData]
+	);
+
+	const seriesProgress = useMemo(() => {
+		if (!timeSeriesData?.pages?.length) return undefined;
+		const lastPage = timeSeriesData.pages[timeSeriesData.pages.length - 1];
+		return { loaded: timeSeries.length, total: lastPage.pagination.total };
+	}, [timeSeriesData, timeSeries]);
+
+	// The report alone can't supply the capacity breakpoint (it needs the per-tick
+	// p99 series, now persisted per W1). Derive it from the time-series and fold it
+	// into the dashboard bundle so the Saturation card / Breakpoint stat light up
+	// for completed ramp_up runs instead of showing the "healthy"/"—" defaults.
+	const derived = useMemo(() => {
+		const base = reportToDerived(report);
+		if (timeSeries.length < 2) return base;
+		return { ...base, breakpoint: computeBreakpoint(timeSeries) };
+	}, [report, timeSeries]);
 
 	const successRate =
 		report.summary.totalRequests > 0
@@ -162,7 +203,15 @@ export default function LoadTestDetail({ report, onBack: _onBack, runId }: LoadT
 						</TabsContent>
 
 						<TabsContent value="performance" className="mt-0 space-y-4">
-							<PerformanceTab report={report} runId={runId} derived={derived} />
+							<PerformanceTab
+								report={report}
+								runId={runId}
+								derived={derived}
+								timeSeries={timeSeries}
+								isLoadingSeries={isLoadingSeries}
+								isFetchingMore={isFetchingNextPage}
+								progress={seriesProgress}
+							/>
 						</TabsContent>
 
 						<TabsContent value="samples" className="mt-0 space-y-4">

--- a/app/src/modules/history/main/components/PerformanceTab.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.tsx
@@ -11,60 +11,74 @@
  * Displays latency distribution, rate control metrics, and time-series charts.
  */
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/utils";
-import { useRunTimeSeriesQuery } from "@/queries/runs";
-import { isRateLimitedRun } from "@/modules/dashboard/utils/metricsTransforms";
+import {
+	isRateLimitedRun,
+	buildPercentileChartData,
+} from "@/modules/dashboard/utils/metricsTransforms";
+import { PercentilesOverTimeChart } from "@/modules/dashboard/components/charts/PercentilesOverTimeChart";
+import { ResponseTimeVsConcurrencyScatter } from "@/modules/dashboard/components/charts/ResponseTimeVsConcurrencyScatter";
 import LatencyMetric from "./LatencyMetric";
 import HistoricalChartsSection from "./HistoricalChartsSection";
-import type { TabProps, TimeSeriesResponse } from "../../types";
+import type { PerformanceTabProps } from "../../types";
 
-export default function PerformanceTab({ report, runId, derived }: TabProps) {
-	// Fetch time-series data for charts
-	const {
-		data: timeSeriesData,
-		isLoading,
-		isFetchingNextPage,
-		hasNextPage,
-		fetchNextPage,
-	} = useRunTimeSeriesQuery(runId ?? null);
-
-	// Auto-fetch all pages when component mounts or when more pages are available
-	useEffect(() => {
-		if (hasNextPage && !isFetchingNextPage) {
-			fetchNextPage();
-		}
-	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-	// Flatten paginated data into a single array
-	const flattenedData = useMemo(() => {
-		if (!timeSeriesData?.pages) return [];
-		return timeSeriesData.pages.flatMap((page: TimeSeriesResponse) => page.data);
-	}, [timeSeriesData]);
-
-	// Calculate progress for loading indicator
-	const progress = useMemo(() => {
-		if (!timeSeriesData?.pages?.length) return undefined;
-		const lastPage = timeSeriesData.pages[timeSeriesData.pages.length - 1];
-		return {
-			loaded: flattenedData.length,
-			total: lastPage.pagination.total,
-		};
-	}, [timeSeriesData, flattenedData]);
+export default function PerformanceTab({
+	report,
+	runId,
+	derived,
+	timeSeries,
+	isLoadingSeries,
+	isFetchingMore,
+	progress,
+}: PerformanceTabProps) {
+	// Windowed per-tick percentiles now persist for completed runs (W1), so the
+	// history percentile chart / scatter can render the same views as the live
+	// dashboard. Mirror MetricsView's split: ramp_up → response-time-vs-concurrency
+	// scatter (capacity elbow), other modes → percentiles-over-time.
+	const percentileChartData = useMemo(() => buildPercentileChartData(timeSeries), [timeSeries]);
+	const hasPercentileData = percentileChartData.some((d) => d.p99 > 0);
+	const isRampUp = derived.mode === "ramp_up";
 
 	return (
 		<div className="space-y-6">
 			{/* Time-Series Charts */}
 			{runId && (
 				<HistoricalChartsSection
-					data={flattenedData}
-					isLoading={isLoading}
-					isFetchingMore={isFetchingNextPage}
+					data={timeSeries}
+					isLoading={isLoadingSeries}
+					isFetchingMore={isFetchingMore}
 					progress={progress}
 				/>
 			)}
+
+			{/* Latency percentiles over time / response-time-vs-concurrency (W1) */}
+			{hasPercentileData &&
+				(isRampUp ? (
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-base">
+								Response Time vs Concurrency
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<ResponseTimeVsConcurrencyScatter data={timeSeries} isCompleted />
+						</CardContent>
+					</Card>
+				) : (
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-base">
+								Response Time Percentiles Over Time
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<PercentilesOverTimeChart data={percentileChartData} isCompleted />
+						</CardContent>
+					</Card>
+				))}
 
 			{/* Latency Statistics */}
 			<Card>

--- a/app/src/modules/history/main/components/historyDetail.characterization.test.tsx
+++ b/app/src/modules/history/main/components/historyDetail.characterization.test.tsx
@@ -6,8 +6,21 @@
  */
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
 import LoadTestDetail from "../LoadTestDetail";
 import type { RunReport } from "@/types";
+
+/**
+ * LoadTestDetail now fetches the per-tick time-series (for the breakpoint /
+ * percentile surfaces), so it needs a QueryClient. The default (Overview) tab
+ * snapshotted here doesn't depend on that data — the query stays in its loading
+ * state during the synchronous render — so the locked DOM is unaffected.
+ */
+function renderWithClient(ui: ReactElement) {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
 
 function report(mode: string, cfg: Record<string, unknown>): RunReport {
 	return {
@@ -61,7 +74,7 @@ const noop = () => {};
 
 describe("LoadTestDetail (mode-adaptive)", () => {
 	it("constant_rps", () => {
-		const { container } = render(
+		const { container } = renderWithClient(
 			<LoadTestDetail
 				report={report("constant_rps", { targetRps: 200 })}
 				onBack={noop}
@@ -71,7 +84,7 @@ describe("LoadTestDetail (mode-adaptive)", () => {
 		expect(container.innerHTML).toMatchSnapshot();
 	});
 	it("constant_concurrency", () => {
-		const { container } = render(
+		const { container } = renderWithClient(
 			<LoadTestDetail
 				report={report("constant_concurrency", { concurrency: 50 })}
 				onBack={noop}
@@ -81,7 +94,7 @@ describe("LoadTestDetail (mode-adaptive)", () => {
 		expect(container.innerHTML).toMatchSnapshot();
 	});
 	it("iterations", () => {
-		const { container } = render(
+		const { container } = renderWithClient(
 			<LoadTestDetail
 				report={report("iterations", { concurrency: 20 })}
 				onBack={noop}
@@ -91,9 +104,13 @@ describe("LoadTestDetail (mode-adaptive)", () => {
 		expect(container.innerHTML).toMatchSnapshot();
 	});
 	it("ramp_up", () => {
-		const { container } = render(
+		const { container } = renderWithClient(
 			<LoadTestDetail
-				report={report("ramp_up", { concurrency: 50, startConcurrency: 1, rampUpDuration: "2s" })}
+				report={report("ramp_up", {
+					concurrency: 50,
+					startConcurrency: 1,
+					rampUpDuration: "2s",
+				})}
 				onBack={noop}
 				runId="r"
 			/>

--- a/app/src/modules/history/types.ts
+++ b/app/src/modules/history/types.ts
@@ -18,6 +18,18 @@ export interface TabProps {
 	derived: DashboardDerived;
 }
 
+/**
+ * PerformanceTab additionally receives the persisted per-tick time-series
+ * (fetched once by LoadTestDetail) so it can render the latency percentile
+ * chart / response-time-vs-concurrency scatter without a second query.
+ */
+export interface PerformanceTabProps extends TabProps {
+	timeSeries: LoadTestMetrics[];
+	isLoadingSeries?: boolean;
+	isFetchingMore?: boolean;
+	progress?: { loaded: number; total: number };
+}
+
 export interface DesignRunDetailProps {
 	report: RunReport;
 	onBack: () => void;

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -491,6 +491,12 @@ target *is* the in-flight bound, so `maxInFlight` is ignored there.
 > in-memory tick topic with no attach race. `/stats/:runId` is the legacy DB-polling path; it
 > remains useful for **historical** retrieval via `?format=json&limit=&offset=` (paginated
 > time-series read), which the app uses to hydrate the history view.
+>
+> The `?format=json` per-tick rows carry the **windowed** latency percentiles
+> (`latency_p50_ms` / `latency_p95_ms` / `latency_p99_ms`, snake_case) alongside
+> rps/throughput/concurrency/status codes, so the history view can rebuild the
+> percentiles-over-time chart, the response-time-vs-concurrency scatter, and the
+> capacity-breakpoint / saturation stats from stored data.
 
 Stream real-time metrics for a load test using Server-Sent Events (SSE).
 
@@ -558,7 +564,7 @@ data: {"event":"complete","runId":"run_1234567890"}
 | `droppedRequests` | Requests discarded at the `maxInFlight` cap (never sent) |
 | `avgLatencyMs` | Mean **perceived** latency |
 | `avgQueueWaitMs` | Mean time queued inside the generator before the wire |
-| `latencyP50Ms` / `latencyP95Ms` / `latencyP99Ms` | Live percentiles (cumulative HdrHistogram) |
+| `latencyP50Ms` / `latencyP95Ms` / `latencyP99Ms` | Live **windowed** percentiles - a rolling per-tick window sampled from a phaser-based `hdr_interval_recorder`, so the chart tracks recent load instead of flattening toward the all-time distribution (the final report still uses the cumulative histogram) |
 | `bytesSent` / `bytesReceived` | Cumulative wire bytes |
 | `requestsSent` / `requestsExpected` | Progress for bounded modes (drives ETA) |
 | `status2xx`–`status5xx` | Per-class counts |

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -196,6 +196,19 @@ metrics producer thread writes a batch each tick. Struct is `db::Metric`.
 `peak_concurrency`, `status_codes`, `test_duration`, `setup_overhead`, and the
 `tests_validating/passed/failed/sampled` script-validation metrics.
 
+**Latency percentile rows come in two flavors, disambiguated by `labels`:**
+
+- **Per-tick windowed rows** (`latency_p50/p95/p99`, empty `labels`): written ~1/s during
+  the run. Each is a **rolling window** sampled from a phaser-based `hdr_interval_recorder`
+  (sample-and-reset per tick), so the value reflects the *recent* interval, not the
+  all-time distribution. These power the live/history "percentiles over time" chart, the
+  response-time-vs-concurrency scatter, and the capacity-breakpoint / saturation
+  derivations. `latency_p75/p90/p999/min/max` are **not** persisted per tick.
+- **Final-summary rows** (`latency_p50/p75/p90/p95/p99/p999/min/max`, `labels` =
+  `{"percentile":"p50"}` etc.): written once at completion from the cumulative-from-start
+  HdrHistogram — the whole-run numbers the report surfaces. The `/run/:id/report` reader
+  keys on the non-empty label so the per-tick windowed rows never overwrite these.
+
 ---
 
 ### `results`

--- a/docs/plans/pending-backlog.md
+++ b/docs/plans/pending-backlog.md
@@ -52,8 +52,8 @@ The generic `send_error` helper (`routes.hpp:39`) emits flat `{"error":"<string>
 
 ## Parked (revisit only if the trigger becomes real)
 
-### D8. HdrHistogram concurrent read/write
-`get_current_stats()` reads the histogram lock-free while workers record. Benign on x86_64 / Apple Silicon / Linux arm64 (atomic 64-bit reads). **W1's interval recorder resolves this properly** (phaser-based). Otherwise only a concern on an arch without atomic 64-bit reads → switch to `hdr_record_value_atomic`.
+### D8. HdrHistogram concurrent read/write - _mitigated by W1; cumulative-path atomic cure intentionally deferred_
+`get_current_stats()` read the histogram lock-free while workers record. **W1 mitigated this:** the live percentile path now reads the phaser-based `hdr_interval_recorder` (race-free by construction), and the cumulative histogram is no longer read concurrently on the live path — `calculate_percentiles()` runs post-run after workers stop. The literal cure (switch cumulative recording to `hdr_record_value_atomic`) is **intentionally not applied**: it adds a CAS per sample on the 60k+ RPS hot path (works against P1) for a race that is benign on every arch Vayu ships (x86_64 / Apple Silicon / Linux arm64 all have atomic 64-bit reads). Revisit only if a 32-bit / non-atomic-64-bit-read arch becomes a target — and pair it with a hot-path benchmark.
 
 ### D9. RampUp `ramp_lag` baseline for `start=0`
 A `startConcurrency=0` ramp shows ~0.8% structural lag on a healthy run (integer truncation vs real-valued integral). Far below the >5% real-stall threshold; signal intact. Optional cure: floor `startConcurrency` to 1 at the UI/validation layer (not the engine).

--- a/docs/plans/pending-backlog.md
+++ b/docs/plans/pending-backlog.md
@@ -2,22 +2,24 @@
 
 Living backlog of deferred / surfaced work. Each item notes **why** it's pending and **what** it needs so it can be picked up as a focused plan.
 
-_Last updated: 2026-07-18 (branch `claude/session-tjt2op`; base master `05357cf`, engine `0.6.0`)._
+_Last updated: 2026-07-18 (branch `claude/backlog-prioritization-sku0xx`; base master `367902f`, engine `0.7.0`)._
 
 ---
 
 ## Open features
 
-### W1. Windowed (rolling) percentiles
-The latency percentiles are computed from a single **cumulative-from-start** HdrHistogram, so the live "Response time percentiles over time" chart **flattens** as a run progresses (each point is the all-time percentile, not the recent window). This also leaves several history surfaces empty/inert.
+_(none currently open — W1 implemented, see below)_
 
-**Needs:**
-- Engine: a **windowed** percentile source alongside the cumulative one - use the vendored `hdr_interval_recorder` (writer/reader phaser, designed for sample-and-reset per interval; also properly resolves D8). `record_success` records into both; the per-tick producer (`collect_metrics`) samples the interval recorder each tick → windowed p50/p95/p99.
-- Producer: emit windowed percentiles in the live tick blob, and **persist per-tick `LatencyP50/P95/P99`** to the DB (explicitly deferred out of N1 - N1 only persists `LatencyAvg`/`QueueWaitAvg`).
-- App: live percentile chart consumes windowed values; **unblocks the history ramp stats** that currently render empty - `computeBreakpoint` (first concurrency where p99 crosses the SLO), p99-at-peak, saturation, and the response-time-vs-concurrency scatter all depend on a meaningful per-tick p99 series.
-- Tests: windowed-vs-cumulative behaviour; interval-recorder sampling.
+### W1. Windowed (rolling) percentiles - _implemented on `claude/backlog-prioritization-sku0xx`, pending merge_
+The latency percentiles were computed from a single **cumulative-from-start** HdrHistogram, so the live "Response time percentiles over time" chart **flattened** as a run progressed (each point was the all-time percentile, not the recent window). This also left several history surfaces empty/inert.
 
-_Size: medium - engine interval-recorder integration (TDD-able) + per-tick persistence; app is small if the percentile mapping already exists, medium if the ramp-stat derivations (breakpoint/saturation) need building. Verify before committing scope._
+**Shipped on branch:**
+- Engine: a **windowed** percentile source (`MetricsCollector::sample_window_percentiles`) backed by the vendored `hdr_interval_recorder` (writer/reader phaser, sample-and-reset per tick; also properly resolves D8). `record_success`/`record_latency` record into both the cumulative histogram and the interval recorder; `get_current_stats` now takes an optional `window_percentiles` and prefers it for `latencyP50/95/99Ms`.
+- Producer (`collect_metrics`): samples the window once per tick, emits windowed percentiles in the live tick blob, and **persists per-tick `LatencyP50/P95/P99`** (unlabeled rows) to the DB. `/run/:id/report` keys on the summary label so per-tick rows don't clobber the cumulative report; `/stats?format=json` maps the per-tick rows into `latency_p50/95/99_ms`.
+- App: history view now fetches the per-tick series in `LoadTestDetail`, derives the capacity breakpoint from it (Saturation card / Breakpoint stat / p99-at-peak light up for completed ramp_up runs), and renders the percentiles-over-time chart / response-time-vs-concurrency scatter in the Performance tab. Live chart consumes the windowed values with no client change.
+- Tests: 6 new `MetricsCollector` tests (windowed-vs-cumulative, reset-between-intervals, concurrent-writer safety, `get_current_stats` preference); history-detail characterization tests wrapped in a `QueryClientProvider`.
+
+_Verified: engine `build.py -t` + `ctest` green; app `type-check` + `test` (293) green; changed files lint-clean._
 
 ---
 
@@ -31,7 +33,7 @@ Against `/fast` on loopback, tuned Vayu reaches ~45k req/s (vs `wrk` ~51k), but 
 
 **Needs:** lower the default `workers`; make the connection cap a **global budget** (or auto-derive from workers); bound the default `maxInFlight`. (Confirmed PR #10 is NOT the cause; ceiling is long-standing architecture. The branch-only 12-worker collapse was traced to added per-completion CPU and only bites at `workers=ncpu`.) Needs a spec.
 
-### P2. `/config` validation error message - _done on `claude/session-tjt2op` (commit `4a6ce5f`), pending build+merge_
+### P2. `/config` validation error message - _✅ merged (PR #50, commit `4a6ce5f`); test-seed follow-up in `83a5397`_
 `POST /config` returned a generic `"Failed to update configuration. Check logs for details."` on a validation failure. Turned out to be **two** bugs: the reason wasn't returned, **and** the generic `send_error` helper emits the flat `{"error":"..."}` shape while the app's http-client reads the nested `error.message` shape - so even the generic string was dropped and surfaced as a bare "HTTP 400".
 
 **Fix (shipped on branch):** extracted the parse/validate/apply logic into a pure `apply_config_update(db, body) -> {status, json}` (mirrors `oauth2_token_post`, now unit-testable via `config_route_test.cpp`); returns the specific reason (unknown key / non-numeric / out-of-range with offending value + bound) in the **nested** shape the client surfaces. All-or-nothing preserved. _Not yet built/verified - the sandbox can't reach vcpkg dep hosts; needs a local `build.py -t && ctest` or CI green before merge._
@@ -62,7 +64,8 @@ A `startConcurrency=0` ramp shows ~0.8% structural lag on a healthy run (integer
 
 - **`claude/sweet-johnson-vUNGE` concerns are resolved** - that work (OAuth 2.0 + N1 metrics + live retention) landed via PRs #45/#46 into **`0.6.0`**; the `/metrics/live` + `liveRetentionMs` api-reference doc is committed. The branch no longer exists on origin.
 - **cpp-httplib FD_SETSIZE fix - status unclear.** No `FD_SETSIZE`/`CPPHTTPLIB_` reference exists anywhere in `engine/` on current master, despite the "Shipped" note below claiming it landed. Re-verify whether the high-FD ceiling is actually addressed before relying on it.
-- Active branch `claude/session-tjt2op` carries the P2 fix (unmerged); rebased onto master `05357cf`.
+- P2 landed via PR #50; its `ConfigRouteTest` seeding was fixed in `83a5397` (seed config via `init()`), so the suite is green on master `367902f` (engine `0.7.0`).
+- Active branch `claude/backlog-prioritization-sku0xx` carries the W1 implementation (unmerged); rebased onto master `367902f`.
 
 ---
 

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include <hdr/hdr_histogram.h>
+#include <hdr/hdr_interval_recorder.h>
 
 #include "vayu/core/constants.hpp"
 #include "vayu/db/database.hpp"
@@ -243,6 +244,24 @@ class MetricsCollector {
     [[nodiscard]] Percentiles calculate_percentiles ();
 
     /**
+     * @brief Sample the rolling (windowed) latency percentiles for the interval
+     *        that has elapsed since the previous call, then reset the window.
+     *
+     * Backed by a phaser-based hdr_interval_recorder: record_success/record_latency
+     * feed the recorder concurrently from worker threads while this single-reader
+     * sample-and-recycle runs safely alongside them (this is what properly resolves
+     * the cumulative-histogram concurrent read/write concern, D8). Unlike
+     * calculate_percentiles() — which reads the cumulative-from-start histogram and
+     * therefore flattens as a run progresses — each call here reflects only the most
+     * recent window, so the live percentile chart tracks the current load instead of
+     * the all-time distribution.
+     *
+     * @note Mutating (samples and resets the window). Call once per metrics tick
+     *       from the producer thread only. Returns zeros when the window is empty.
+     */
+    [[nodiscard]] Percentiles sample_window_percentiles ();
+
+    /**
      * @brief Get status code distribution
      */
     [[nodiscard]] std::map<int, size_t> status_code_distribution () const;
@@ -303,13 +322,20 @@ class MetricsCollector {
      *        derived class breakdown, avoiding a redundant scan when the caller
      *        already snapshotted the distribution this tick. When null the
      *        distribution is computed internally.
+     * @param window_percentiles Optional windowed (rolling) percentiles for the
+     *        `latencyP50Ms`/`latencyP95Ms`/`latencyP99Ms` fields. When non-null the
+     *        live tick carries these recent-window values (see
+     *        sample_window_percentiles). When null the fields fall back to the
+     *        cumulative-from-start histogram — kept for callers/tests that don't
+     *        drive the interval recorder.
      * @return JSON object with current metrics
      */
     [[nodiscard]] nlohmann::json get_current_stats (size_t current_active,
     double elapsed_seconds,
     size_t requests_sent,
     size_t requests_expected                     = 0,
-    const std::map<int, size_t>* status_snapshot = nullptr) const;
+    const std::map<int, size_t>* status_snapshot = nullptr,
+    const Percentiles* window_percentiles        = nullptr) const;
 
     private:
     std::string run_id_;
@@ -334,8 +360,16 @@ class MetricsCollector {
     static constexpr int STATUS_CODE_SLOTS = 600;
     std::array<std::atomic<size_t>, STATUS_CODE_SLOTS> status_code_counts_{};
 
-    // Lock-free HdrHistogram for latency recording (thread-safe)
+    // Lock-free HdrHistogram for latency recording (thread-safe). Cumulative from
+    // start of run — feeds calculate_percentiles() for the final report.
     struct hdr_histogram* latency_histogram_{ nullptr };
+
+    // Phaser-based interval recorder for the windowed (rolling) percentiles that
+    // the live/history per-tick series consume. Writers (record_success/
+    // record_latency) record here in parallel with the cumulative histogram; the
+    // producer thread sample-and-recycles it once per tick (sample_window_percentiles).
+    struct hdr_interval_recorder interval_recorder_{};
+    bool interval_recorder_ready_{ false };
 
     mutable std::mutex errors_mutex_;
     std::vector<ResultRecord> errors_;

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -40,6 +40,21 @@ MetricsCollector::MetricsCollector (const std::string& run_id, MetricsCollectorC
         throw std::runtime_error ("Failed to initialize HdrHistogram");
     }
 
+    // Windowed (rolling) percentile source. Same value range / precision as the
+    // cumulative histogram, but sampled-and-reset per tick so live percentiles
+    // reflect the recent window instead of the all-time distribution.
+    int interval_result = hdr_interval_recorder_init_all (
+        &interval_recorder_,
+        1,  // Minimum value (1 microsecond)
+        constants::metrics_collector::HISTOGRAM_MAX_LATENCY_US,
+        constants::metrics_collector::HISTOGRAM_SIGNIFICANT_FIGURES);
+    if (interval_result != 0) {
+        hdr_close (latency_histogram_);
+        latency_histogram_ = nullptr;
+        throw std::runtime_error ("Failed to initialize hdr_interval_recorder");
+    }
+    interval_recorder_ready_ = true;
+
     // Pre-allocate vectors to avoid reallocation during test
     size_t expected = config_.expected_requests;
 
@@ -65,6 +80,10 @@ MetricsCollector::~MetricsCollector () {
     if (latency_histogram_ != nullptr) {
         hdr_close (latency_histogram_);
         latency_histogram_ = nullptr;
+    }
+    if (interval_recorder_ready_) {
+        hdr_interval_recorder_destroy (&interval_recorder_);
+        interval_recorder_ready_ = false;
     }
 }
 
@@ -93,6 +112,8 @@ const std::string& trace_data) {
     int64_t latency_us = static_cast<int64_t> (latency_ms * 1000.0);
     if (latency_us < 1) latency_us = 1;  // Minimum 1 microsecond
     hdr_record_value (latency_histogram_, latency_us);
+    // Also feed the rolling-window recorder for the live per-tick percentiles.
+    hdr_interval_recorder_record_value (&interval_recorder_, latency_us);
 
     // Store success result if configured (sampled)
     if (config_.store_success_traces && !trace_data.empty ()) {
@@ -159,6 +180,7 @@ void MetricsCollector::record_latency (double latency_ms) {
     int64_t latency_us = static_cast<int64_t> (latency_ms * 1000.0);
     if (latency_us < 1) latency_us = 1;  // Minimum 1 microsecond
     hdr_record_value (latency_histogram_, latency_us);
+    hdr_interval_recorder_record_value (&interval_recorder_, latency_us);
 }
 
 MetricsCollector::Percentiles MetricsCollector::calculate_percentiles () {
@@ -181,6 +203,39 @@ MetricsCollector::Percentiles MetricsCollector::calculate_percentiles () {
     result.p95  = us_to_ms (hdr_value_at_percentile (latency_histogram_, 95.0));
     result.p99  = us_to_ms (hdr_value_at_percentile (latency_histogram_, 99.0));
     result.p999 = us_to_ms (hdr_value_at_percentile (latency_histogram_, 99.9));
+
+    return result;
+}
+
+MetricsCollector::Percentiles MetricsCollector::sample_window_percentiles () {
+    Percentiles result;
+
+    if (!interval_recorder_ready_) {
+        return result;
+    }
+
+    // Sample-and-recycle: hand back the histogram that has been accumulating since
+    // the previous call and swap in a fresh (reset) one for the next window. Safe
+    // to call concurrently with the recording writers via the phaser; must be
+    // driven by a single reader thread only (the metrics producer). The returned
+    // pointer is owned by the recorder and valid until the next sample.
+    struct hdr_histogram* interval = hdr_interval_recorder_sample (&interval_recorder_);
+    if (interval == nullptr || interval->total_count == 0) {
+        return result;  // empty window → zeros
+    }
+
+    auto us_to_ms = [] (int64_t us) -> double {
+        return static_cast<double> (us) / 1000.0;
+    };
+
+    result.min  = us_to_ms (hdr_min (interval));
+    result.max  = us_to_ms (hdr_max (interval));
+    result.p50  = us_to_ms (hdr_value_at_percentile (interval, 50.0));
+    result.p75  = us_to_ms (hdr_value_at_percentile (interval, 75.0));
+    result.p90  = us_to_ms (hdr_value_at_percentile (interval, 90.0));
+    result.p95  = us_to_ms (hdr_value_at_percentile (interval, 95.0));
+    result.p99  = us_to_ms (hdr_value_at_percentile (interval, 99.0));
+    result.p999 = us_to_ms (hdr_value_at_percentile (interval, 99.9));
 
     return result;
 }
@@ -300,7 +355,8 @@ nlohmann::json MetricsCollector::get_current_stats (size_t current_active,
 double elapsed_seconds,
 size_t requests_sent,
 size_t requests_expected,
-const std::map<int, size_t>* status_snapshot) const {
+const std::map<int, size_t>* status_snapshot,
+const Percentiles* window_percentiles) const {
     // Lock-free reads from atomic counters
     size_t total    = total_requests ();
     size_t errors   = total_errors ();
@@ -364,10 +420,16 @@ const std::map<int, size_t>* status_snapshot) const {
     stats["droppedRequests"] = dropped_requests_.load (std::memory_order_relaxed);
     stats["avgQueueWaitMs"] = average_queue_wait ();
 
-    // Per-tick latency percentiles — live snapshot from the lock-free
-    // histogram (same source as the post-run final report). Microsecond
-    // storage converted back to ms. Zero when no samples recorded yet.
-    if (latency_histogram_ != nullptr && latency_histogram_->total_count > 0) {
+    // Per-tick latency percentiles. When the caller supplies windowed (rolling)
+    // percentiles — the live producer samples the interval recorder each tick —
+    // emit those so the "percentiles over time" chart tracks the recent window
+    // instead of flattening. When absent (callers/tests that don't drive the
+    // interval recorder), fall back to the cumulative-from-start histogram.
+    if (window_percentiles != nullptr) {
+        stats["latencyP50Ms"] = window_percentiles->p50;
+        stats["latencyP95Ms"] = window_percentiles->p95;
+        stats["latencyP99Ms"] = window_percentiles->p99;
+    } else if (latency_histogram_ != nullptr && latency_histogram_->total_count > 0) {
         stats["latencyP50Ms"] =
         static_cast<double> (hdr_value_at_percentile (latency_histogram_, 50.0)) / 1000.0;
         stats["latencyP95Ms"] =

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -671,6 +671,12 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
     // Declared here so it is in scope inside the try block below.
     int tick_interval_ms = 0;
 
+    // Windowed (rolling) percentiles sampled by emit_live_tick each tick. Captured
+    // here so the 1 Hz DB-gated block below can persist the same window it just
+    // published — sample_window_percentiles() resets the window, so it must only be
+    // called once per tick (inside emit_live_tick) and reused, not re-sampled.
+    double win_p50 = 0.0, win_p95 = 0.0, win_p99 = 0.0;
+
     // Build and append one SSE "metrics" event to the in-memory tick topic.
     // Fields match the SSE handler (metrics.cpp) field-for-field. The wall-clock
     // timestamp is passed in by the caller so that the SSE tick and any
@@ -686,8 +692,16 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         double elapsed_seconds =
         context->start_time_ms > 0 ?
         static_cast<double> (now_wall_ms - context->start_time_ms) / 1000.0 : 0.0;
+
+        // Sample the rolling window exactly once per tick (it resets on read) and
+        // carry the values out for the 1 Hz persistence below.
+        auto window = context->metrics_collector->sample_window_percentiles ();
+        win_p50 = window.p50;
+        win_p95 = window.p95;
+        win_p99 = window.p99;
+
         auto stats = context->metrics_collector->get_current_stats (active_count,
-        elapsed_seconds, requests_sent, requests_expected, status_snapshot);
+        elapsed_seconds, requests_sent, requests_expected, status_snapshot, &window);
 
         // Instantaneous RPS: delta-based, updated every ≥100 ms.
         auto now_steady     = std::chrono::steady_clock::now ();
@@ -800,7 +814,7 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
                 try {
                     auto timestamp = tick_wall_ms;
                     std::vector<vayu::db::Metric> metrics;
-                    metrics.reserve (14);
+                    metrics.reserve (18);
 
                     metrics.push_back ({ 0, context->run_id, timestamp,
                     vayu::MetricName::Rps, current_rps, "" });
@@ -832,6 +846,20 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
                     metrics.push_back ({ 0, context->run_id, timestamp,
                     vayu::MetricName::QueueWaitAvg,
                     context->metrics_collector->average_queue_wait (), "" });
+
+                    // Windowed per-tick percentiles (rolling, from the interval
+                    // recorder) — unlabeled to distinguish them from the cumulative
+                    // final-summary percentile rows (which carry a {"percentile":..}
+                    // label). These power the history percentile chart, the
+                    // response-time-vs-concurrency scatter, and the capacity
+                    // breakpoint / saturation derivations. Reuses the window already
+                    // sampled by emit_live_tick this tick (do not re-sample).
+                    metrics.push_back ({ 0, context->run_id, timestamp,
+                    vayu::MetricName::LatencyP50, win_p50, "" });
+                    metrics.push_back ({ 0, context->run_id, timestamp,
+                    vayu::MetricName::LatencyP95, win_p95, "" });
+                    metrics.push_back ({ 0, context->run_id, timestamp,
+                    vayu::MetricName::LatencyP99, win_p99, "" });
 
                     // Single transaction instead of 5 separate lock acquisitions
                     db.add_metrics_batch (metrics);

--- a/engine/src/http/routes/metrics.cpp
+++ b/engine/src/http/routes/metrics.cpp
@@ -100,10 +100,18 @@ void register_metrics_routes (RouteContext& ctx) {
                         bucket["bytes_sent"] = 0;
                         bucket["bytes_received"] = 0;
                         bucket["status_codes"] = nlohmann::json::object ();
+                        // Windowed per-tick latency percentiles (0 until a tick
+                        // carries them). Snake_case keys match the app's
+                        // LoadTestMetrics shape (consumed without a transformer).
+                        bucket["latency_p50_ms"] = 0.0;
+                        bucket["latency_p95_ms"] = 0.0;
+                        bucket["latency_p99_ms"] = 0.0;
                     }
 
-                    // Map metric values to LoadTestMetrics fields
-                    // Note: LatencyAvg/P50/P95/P99 are only stored as final summary, not periodically
+                    // Map metric values to LoadTestMetrics fields. Latency percentiles
+                    // are now persisted per-tick as windowed (rolling) values —
+                    // unlabeled rows; the labeled cumulative final-summary rows are
+                    // skipped here so the series stays purely windowed.
                     if (metric.name == vayu::MetricName::Rps) {
                         bucket["current_rps"] = metric.value;
                     } else if (metric.name == vayu::MetricName::ErrorRate) {
@@ -127,6 +135,15 @@ void register_metrics_routes (RouteContext& ctx) {
                         bucket["bytes_sent"] = static_cast<size_t> (metric.value);
                     } else if (metric.name == vayu::MetricName::BytesReceived) {
                         bucket["bytes_received"] = static_cast<size_t> (metric.value);
+                    } else if (metric.name == vayu::MetricName::LatencyP50 &&
+                    metric.labels.empty ()) {
+                        bucket["latency_p50_ms"] = metric.value;
+                    } else if (metric.name == vayu::MetricName::LatencyP95 &&
+                    metric.labels.empty ()) {
+                        bucket["latency_p95_ms"] = metric.value;
+                    } else if (metric.name == vayu::MetricName::LatencyP99 &&
+                    metric.labels.empty ()) {
+                        bucket["latency_p99_ms"] = metric.value;
                     } else if (metric.name == vayu::MetricName::StatusCodes &&
                     !metric.labels.empty ()) {
                         // Last-write-wins per timestamp (the final StatusCodes row

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -213,15 +213,18 @@ void register_run_routes (RouteContext& ctx) {
                     bytes_sent = m.value;
                 } else if (m.name == vayu::MetricName::BytesReceived) {
                     bytes_received = m.value;
-                } else if (m.name == vayu::MetricName::LatencyP50) {
+                } else if (m.name == vayu::MetricName::LatencyP50 && !m.labels.empty ()) {
+                    // Only the labeled cumulative final-summary row counts here; the
+                    // unlabeled per-tick windowed rows (persisted during the run)
+                    // must not overwrite the whole-run percentile in the report.
                     report.latency_p50 = m.value;
                 } else if (m.name == vayu::MetricName::LatencyP75) {
                     report.latency_p75 = m.value;
                 } else if (m.name == vayu::MetricName::LatencyP90) {
                     report.latency_p90 = m.value;
-                } else if (m.name == vayu::MetricName::LatencyP95) {
+                } else if (m.name == vayu::MetricName::LatencyP95 && !m.labels.empty ()) {
                     report.latency_p95 = m.value;
-                } else if (m.name == vayu::MetricName::LatencyP99) {
+                } else if (m.name == vayu::MetricName::LatencyP99 && !m.labels.empty ()) {
                     report.latency_p99 = m.value;
                 } else if (m.name == vayu::MetricName::LatencyP999) {
                     report.latency_p999 = m.value;

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <thread>
 #include <vector>
 
@@ -121,6 +122,131 @@ TEST_F (MetricsCollectorTest, PercentilesHandleSingleValue) {
     EXPECT_NEAR (percentiles.max, 42.0, tolerance);
     EXPECT_NEAR (percentiles.p50, 42.0, tolerance);
     EXPECT_NEAR (percentiles.p99, 42.0, tolerance);
+}
+
+// ============================================================================
+// Windowed (rolling) Percentile Tests
+// ============================================================================
+
+TEST_F (MetricsCollectorTest, SampleWindowEmptyReturnsZeros) {
+    auto window = collector->sample_window_percentiles ();
+    EXPECT_DOUBLE_EQ (window.p50, 0.0);
+    EXPECT_DOUBLE_EQ (window.p95, 0.0);
+    EXPECT_DOUBLE_EQ (window.p99, 0.0);
+    EXPECT_DOUBLE_EQ (window.min, 0.0);
+    EXPECT_DOUBLE_EQ (window.max, 0.0);
+}
+
+TEST_F (MetricsCollectorTest, SampleWindowReflectsRecordedInterval) {
+    for (int i = 1; i <= 100; ++i) {
+        collector->record_success (200, static_cast<double> (i), 0.0);
+    }
+
+    auto window = collector->sample_window_percentiles ();
+
+    constexpr double tolerance = 1.0;  // 1ms — HdrHistogram bucketing
+    EXPECT_NEAR (window.min, 1.0, tolerance);
+    EXPECT_NEAR (window.max, 100.0, tolerance);
+    EXPECT_NEAR (window.p50, 50.0, tolerance);
+    EXPECT_NEAR (window.p95, 95.0, tolerance);
+    EXPECT_NEAR (window.p99, 99.0, tolerance);
+}
+
+TEST_F (MetricsCollectorTest, SampleWindowResetsBetweenIntervals) {
+    // First interval: all low-latency samples.
+    for (int i = 0; i < 500; ++i) {
+        collector->record_success (200, 10.0, 0.0);
+    }
+    auto first = collector->sample_window_percentiles ();
+    EXPECT_NEAR (first.p99, 10.0, 1.0);
+
+    // Second interval: all high-latency samples. The window must NOT carry the
+    // low-latency samples forward — sampling reset it.
+    for (int i = 0; i < 500; ++i) {
+        collector->record_success (200, 500.0, 0.0);
+    }
+    auto second = collector->sample_window_percentiles ();
+    EXPECT_NEAR (second.p99, 500.0, 5.0);
+
+    // Third interval with no new samples: empty window → zeros (not the last value).
+    auto third = collector->sample_window_percentiles ();
+    EXPECT_DOUBLE_EQ (third.p99, 0.0);
+}
+
+TEST_F (MetricsCollectorTest, WindowedTracksRecentWhileCumulativeFlattens) {
+    // Drain a first interval of fast responses.
+    for (int i = 0; i < 1000; ++i) {
+        collector->record_success (200, 10.0, 0.0);
+    }
+    (void) collector->sample_window_percentiles ();
+
+    // Now the server degrades: a second interval of slow responses.
+    for (int i = 0; i < 1000; ++i) {
+        collector->record_success (200, 500.0, 0.0);
+    }
+    auto window = collector->sample_window_percentiles ();
+
+    // Cumulative (from start) blends both halves; the rolling window sees only the
+    // recent (slow) interval. This divergence is the whole point of W1: the live
+    // percentile chart tracks current load instead of the all-time distribution.
+    auto cumulative = collector->calculate_percentiles ();
+    EXPECT_NEAR (window.p50, 500.0, 5.0);
+    EXPECT_LT (cumulative.p50, window.p50);  // cumulative median dragged down by fast half
+}
+
+TEST_F (MetricsCollectorTest, GetCurrentStatsPrefersWindowedPercentiles) {
+    // Record cumulative data that would yield ~100ms percentiles.
+    for (int i = 0; i < 100; ++i) {
+        collector->record_success (200, 100.0, 0.0);
+    }
+
+    // Explicit windowed values (as the producer would pass each tick).
+    MetricsCollector::Percentiles window;
+    window.p50 = 11.0;
+    window.p95 = 12.0;
+    window.p99 = 13.0;
+
+    auto stats = collector->get_current_stats (0, 1.0, 0, 0, nullptr, &window);
+    EXPECT_DOUBLE_EQ (stats["latencyP50Ms"].get<double> (), 11.0);
+    EXPECT_DOUBLE_EQ (stats["latencyP95Ms"].get<double> (), 12.0);
+    EXPECT_DOUBLE_EQ (stats["latencyP99Ms"].get<double> (), 13.0);
+
+    // Without windowed values the fields fall back to the cumulative histogram.
+    auto cumulative_stats = collector->get_current_stats (0, 1.0, 0);
+    EXPECT_NEAR (cumulative_stats["latencyP99Ms"].get<double> (), 100.0, 1.0);
+}
+
+TEST_F (MetricsCollectorTest, SampleWindowSafeUnderConcurrentWriters) {
+    // Writers record while the producer samples the window — the phaser must keep
+    // this race-free (resolves D8 for the windowed source). Assert correctness of
+    // the cumulative count and that sampling never crashes.
+    constexpr int kThreads = 4;
+    constexpr int kPerThread = 5000;
+    std::atomic<bool> stop{ false };
+
+    std::vector<std::thread> writers;
+    writers.reserve (kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        writers.emplace_back ([this] () {
+            for (int i = 0; i < kPerThread; ++i) {
+                collector->record_success (200, 25.0, 0.0);
+            }
+        });
+    }
+
+    // Sample repeatedly from this (single reader) thread while writers run.
+    while (!stop.load ()) {
+        (void) collector->sample_window_percentiles ();
+        bool all_done = collector->total_requests () >=
+        static_cast<size_t> (kThreads * kPerThread);
+        if (all_done) stop.store (true);
+    }
+
+    for (auto& w : writers) w.join ();
+    (void) collector->sample_window_percentiles ();
+
+    EXPECT_EQ (collector->total_requests (),
+    static_cast<size_t> (kThreads * kPerThread));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

Implements **W1** from `docs/plans/pending-backlog.md`: windowed (rolling) latency percentiles.

Live and per-tick latency percentiles were read from a single **cumulative-from-start** HdrHistogram, so the "Response time percentiles over time" chart **flattened** as a run progressed (each point was the all-time percentile, not the recent window), and the history ramp stats (breakpoint, saturation, p99-at-peak, response-time-vs-concurrency scatter) had **no per-tick p99 series** to consume and rendered inert.

**Engine**
- New **windowed** percentile source in `MetricsCollector`, backed by the vendored phaser-based `hdr_interval_recorder` (already compiled by the engine build). `record_success`/`record_latency` feed both the cumulative histogram and the interval recorder; `sample_window_percentiles()` sample-and-resets the interval each tick. It is single-reader safe against concurrent recording writers — which also **properly resolves D8** (the cumulative concurrent read/write concern).
- `get_current_stats()` takes an optional `window_percentiles` and prefers it for `latencyP50/95/99Ms`, falling back to the cumulative histogram when absent (existing callers/tests unchanged).
- `collect_metrics` samples the window once per tick, emits it in the live tick blob, and **persists per-tick `LatencyP50/P95/P99`** as unlabeled rows. `/run/:id/report` keys on the summary `{"percentile":...}` label so per-tick rows never overwrite the cumulative report; `/stats?format=json` maps the per-tick rows into `latency_p50/95/99_ms`.

**App**
- `LoadTestDetail` fetches the per-tick series once and derives the capacity breakpoint from it, so the **Saturation card / Breakpoint stat / p99-at-peak** light up for completed `ramp_up` runs instead of showing the healthy/"—" defaults.
- `PerformanceTab` renders the **percentiles-over-time chart** (non-ramp) and the **response-time-vs-concurrency scatter** (`ramp_up`) from the stored series. The live chart consumes windowed values with no client change.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing
- Engine: `python build.py -t` + `ctest --preset linux-dev` → **269/269 pass**, including 6 new `MetricsCollector` tests (windowed vs cumulative, reset-between-intervals, concurrent-writer safety, `get_current_stats` preference).
- App: `pnpm type-check` clean; `pnpm test` → **293/293 pass** (history-detail characterization tests wrapped in a `QueryClientProvider` now that the detail view fetches the time-series); changed files lint-clean.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (`db-schema.md`, `api-reference.md`, backlog)

## Related Issues
Closes # <!-- no tracking issue; tracked as W1 in docs/plans/pending-backlog.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9MuHbABPKKyusnUUtgTAk)_