### PR TITLE
docs(app): sync app docs with PR #55 (uPlot charts, settings panels, client-settings store)

### DIFF
--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -191,7 +191,7 @@ The dashboard is **mode-adaptive**: a `useMode()` discriminator maps the run con
 
 **`hero/` - mode-adaptive hero cards** (`HeroRow.tsx` selects per mode, all built on `HeroCardShell.tsx`): `RateFidelityCard`, `DroppedRequestsCard`, `AchievedThroughputCard`, `ThroughputCard`, `ThroughputTwinCard`, `CurrentConcurrencyCard`, `ConcurrencyUtilCard`, `SaturationCard`, `ProgressCard`, `ErrorRateCard`.
 
-**`charts/`** (all built on the shared `TimeSeriesChart.tsx` + `utils/chartGeometry.ts`): `ThroughputOverTimeChart` (configured-vs-achieved for ramp_up), `LatencyOverTimeChart` (wire/queue-wait split), `PercentilesOverTimeChart` (p50/p95/p99), `StatusCodesOverTimeChart` (stacked), `ResponseTimeVsConcurrencyScatter` (ramp_up capacity discovery w/ breakpoint marker), `HdrPercentilePlot`, `TimingWaterfall`.
+**`charts/`** - all time-series, scatter, and distribution plots are centralized in **`charts/uplot/`** and built on a single Canvas primitive, `UPlotChart.tsx` (uPlot). Import them from `charts/uplot/index.ts` so live and history render identical components: `LatencyPercentilesChart` (p50/p95/p99), `LatencyBreakdownChart` (wire/queue-wait split), `RequestRateChart` (configured-vs-achieved throughput), `ConnectionsChart`, `ErrorRateChart` (from `TimeSeriesCharts.tsx`); `ResponseTimeVsConcurrencyChart` (ramp_up capacity discovery w/ breakpoint marker) and `HdrPercentileChart` (from `ScatterAndDistribution.tsx`); and `StatusCodesOverTimeChart` (stacked). Supporting modules in the same folder: `buildData.ts` (series → uPlot data), `chartFocus.ts` + `syncKeys.ts` (scatter↔time cross-highlight/cursor sync), `plugins.ts`, `formatters.ts`, and `uplotTheme.ts` (CSS-token-driven theming). Outside `uplot/`, `HdrPercentilePlot.tsx` is now just the loading skeleton (`SkeletonHdrPlot`), and `TimingWaterfall.tsx` remains an SVG chart.
 
 **`stats/`** - `ModeStatsRow.tsx` routes to the per-mode Row 4 stat set; `ModeStatCards.tsx`, `StatCard.tsx`.
 
@@ -225,7 +225,7 @@ Past runs (single executions and load tests), split into a sidebar list and a ma
 ## Settings (`modules/settings/`)
 
 - **Sidebar (`sidebar/SettingsCategoryTree.tsx`)** - settings category navigation.
-- **Main (`main/`)** - `SettingsMain.tsx` (screen `"settings"`) hosting category panels such as `UISettingsPanel.tsx`.
+- **Main (`main/`)** - `SettingsMain.tsx` (screen `"settings"`) hosts the app-settings category panels under `main/panels/`: `AppearancePanel.tsx`, `DashboardPanel.tsx`, `GeneralPanel.tsx`, and `EditorPanel.tsx`, plus the shared `ClientSettingsPanel.tsx` wrapper, `FontPicker.tsx`, and `SettingControls.tsx` primitives. `app-panels.ts` is the panel registry/metadata. (The former monolithic `UISettingsPanel.tsx` was split into these panels in PR #55.)
 
 ## Welcome (`modules/welcome/`)
 

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -230,7 +230,7 @@ Variables are resolved with priority: **Environment > Collection > Global**
 - **Radix UI**: Accessible component primitives
 - **Tailwind CSS**: Utility-first styling
 - **Monaco Editor**: Code editing - scripts, JSON body, and GraphQL (with syntax diagnostics, autocomplete, hover, and formatting via `graphql-language-service`)
-- **Recharts**: Charts for metrics visualization
+- **uPlot**: Charts for metrics visualization (all dashboard/history charts centralize on one Canvas primitive; see `modules/dashboard/components/charts/uplot/`)
 - **Vite**: Build tool and dev server
 
 ## Electron Preload Bridge

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -195,7 +195,7 @@ Key settings in `vite.config.ts`:
 - **Radix UI**: Component primitives
 - **Tailwind CSS**: Styling
 - **Monaco Editor**: Code editing
-- **Recharts**: Charts
+- **uPlot**: Charts
 
 ### Development Dependencies
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -200,9 +200,21 @@ const { setResponse, getResponse, clearResponse, clearAll } = useResponseStore()
 
 **Non-persisted** (responses are reloadable from backend).
 
+#### `client-settings-store.ts` - Renderer Preferences
+
+Central home for renderer-only preferences that aren't part of the pre-paint appearance set (theme/color/UI-font/scale/radius live in their own localStorage keys so `index.html` can apply them before React mounts). Holds editor behavior, the monospace/code font, chart granularity, the capacity SLO threshold, the live refresh rate, and auto-save preferences. Backs the Settings **panels** (`modules/settings/main/panels/`). Non-React consumers (services, the dashboard store) read via `getState()`.
+
+**Key exports:**
+```typescript
+const store = useClientSettingsStore();   // editorPrefs, autoSavePrefs, monoFont, chartBucketSeconds, sloThresholdMs, liveRefreshMs, ...
+import { SETTINGS_STORAGE_KEYS } from "@/stores";  // localStorage keys reset by "Reset app settings"
+```
+
+**Persisted** to localStorage (via `zustand/persist`); workspace/session state (open tabs, layout, active collection) is deliberately excluded from the reset.
+
 #### `dashboard-store.ts` - Load Test Metrics & State
 
-Manages live load test run state: streaming metrics, final reports, and running aggregates (peak concurrency, SLO breakpoint). Caps historical metrics at **3,000 points** (defined in `app/src/config/metrics.ts` as `HISTORICAL_METRICS_CAP = 3000`). This provides ~5 minutes of full-fidelity data at the engine's 10 Hz tick rate, long enough for typical load test sessions but short enough to keep chart slicing efficient.
+Manages live load test run state: streaming metrics, final reports, and running aggregates (peak concurrency, SLO breakpoint). Retention is **time-based, not a fixed point count**: `addMetricsBatch` trims ticks older than the user-configurable live window (`liveWindowSeconds`, sourced from `constants/live-window.ts`, default 5m, `null` = full run), backstopped by a hard `MAX_RETAINED_TICKS` safety cap (20,000). The window is kept in sync by the `useLiveChartWindow` hook and drives what the live charts plot. (`app/src/config/metrics.ts` now only holds the SSE commit throttle, `METRICS_UI_THROTTLE_MS`.)
 
 **State:**
 ```typescript
@@ -211,7 +223,8 @@ Manages live load test run state: streaming metrics, final reports, and running 
   mode: "running" | "completed" | "stopped"
   isStreaming: boolean
   currentMetrics: LoadTestMetrics | null
-  historicalMetrics: LoadTestMetrics[]  // Capped at 3,000
+  historicalMetrics: LoadTestMetrics[]  // Trimmed to liveWindowSeconds (cap: MAX_RETAINED_TICKS)
+  liveWindowSeconds: number | null             // Live retention window; null = full run
   finalReport: RunReport | null
   error: string | null
   activeView: "metrics" | "request-response"
@@ -229,6 +242,7 @@ const {
   startRun, stopRun, setStreaming,
   addMetricsBatch,  // Efficiently fold batch into history and update aggregates
   setFinalReport, setError, setActiveView, setStopping,
+  setLiveWindowSeconds,  // Update the live retention window (from useLiveChartWindow)
   reset,
   getLatestMetrics, getMetricsWindow
 } = useDashboardStore();


### PR DESCRIPTION
## Description
PR #55 (`charts-uplot-unify`, shipped as v0.8.0) unified all dashboard/history charts onto a single uPlot Canvas primitive, split the monolithic settings panel into per-category panels, and moved live-metric retention to a time-based window. Several `docs/app/` files still described the pre-#55 world. This PR brings them back in sync — docs only, no code changes.

- **`docs/app/COMPONENTS.md`** — replaced the removed Recharts/hand-rolled-SVG chart components (`TimeSeriesChart`, `ThroughputOverTimeChart`, `LatencyOverTimeChart`, `PercentilesOverTimeChart`, `StatusCodesOverTimeChart`, `ResponseTimeVsConcurrencyScatter`) with the centralized `charts/uplot/` module built on `UPlotChart.tsx`; documented the new `settings/main/panels/` split (Appearance/Dashboard/General/Editor + shared primitives) that replaced `UISettingsPanel.tsx`.
- **`docs/app/architecture.md`, `docs/app/building.md`** — tech-stack lists: **Recharts → uPlot** (`recharts` was removed from `package.json`, `uplot` added).
- **`docs/app/state-management.md`** — added the new `client-settings-store.ts` entry; corrected the `dashboard-store` retention description from the removed fixed `HISTORICAL_METRICS_CAP = 3000` to the time-based `liveWindowSeconds` window bounded by `MAX_RETAINED_TICKS`, and added `liveWindowSeconds` / `setLiveWindowSeconds`.

Verified as already accurate (no change needed): `docs/plans/pending-backlog.md` (already records N3/PR #55 as shipped) and the engine docs (PR #55 touched only the engine version bump).

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Docs-only change. Each updated reference was cross-checked against the current source tree on `master` after PR #55 (chart modules under `app/src/modules/dashboard/components/charts/uplot/`, settings panels under `app/src/modules/settings/main/panels/`, `app/src/stores/client-settings-store.ts`, and the `liveWindowSeconds` / `MAX_RETAINED_TICKS` retention in `dashboard-store.ts` + `constants/live-window.ts`).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) — N/A, documentation only
- [x] I have updated documentation

## Related Issues
N/A — follow-up documentation sync for the changes merged in #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q13oDJuD7xZQaD3fjgYffX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q13oDJuD7xZQaD3fjgYffX)_