### PR TITLE
fix(app): clamp response viewer to a tab that still renders (#59)

### DIFF
--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -89,6 +89,35 @@ export default function ResponseViewer() {
 		);
 	}
 
+	// Which of the four conditional tabs are present on *this* response. The
+	// engine emits `timing`/`rawRequest` on every live execute but omits them
+	// from some restored traces, and `consoleLogs`/`testResults` only when a
+	// script produced them - so the tab set shrinks as you switch responses.
+	const hasTiming = !!response.timing;
+	const hasConsole = !!response.consoleLogs && response.consoleLogs.length > 0;
+	const hasTests = !!response.testResults && response.testResults.length > 0;
+	const hasRaw = !!response.rawRequest;
+
+	// The tabs actually rendered below, in trigger order. Both the triggers and
+	// their panels key off the same `has*` flags, so this list is exactly the
+	// set Radix has to select from.
+	const availableTabs: ResponseTab[] = [
+		"body",
+		"headers",
+		"cookies",
+		...(hasTiming ? (["timing"] as const) : []),
+		...(hasConsole ? (["console"] as const) : []),
+		...(hasTests ? (["tests"] as const) : []),
+		...(hasRaw ? (["raw-request"] as const) : []),
+	];
+
+	// Clamp the selection to a tab that still renders. `activeTab` is local state
+	// that survives a response change, so a tab clicked on one response can name
+	// a trigger the next response no longer draws - leaving the controlled Tabs
+	// root with nothing to select and a blank pane (issue #59). Falling back to
+	// `body`, which is always present, keeps a tab selected and the body shown.
+	const effectiveTab = availableTabs.includes(activeTab) ? activeTab : "body";
+
 	// Client-side error state (status === 0 means no server response)
 	const isClientError = response.status === 0;
 
@@ -122,7 +151,7 @@ export default function ResponseViewer() {
 
 			{/* Response Tabs */}
 			<Tabs
-				value={activeTab}
+				value={effectiveTab}
 				onValueChange={(v) => setActiveTab(v as ResponseTab)}
 				className="flex-1 flex flex-col overflow-hidden"
 			>
@@ -153,7 +182,7 @@ export default function ResponseViewer() {
 						>
 							Cookies
 						</TabsTrigger>
-						{response.timing && (
+						{hasTiming && (
 							<TabsTrigger
 								value="timing"
 								className={cn("shrink-0", RESPONSE_TAB_TRIGGER)}
@@ -161,7 +190,7 @@ export default function ResponseViewer() {
 								Timing
 							</TabsTrigger>
 						)}
-						{response.consoleLogs && response.consoleLogs.length > 0 && (
+						{hasConsole && (
 							<TabsTrigger
 								value="console"
 								className={cn("shrink-0", RESPONSE_TAB_TRIGGER)}
@@ -169,11 +198,11 @@ export default function ResponseViewer() {
 								<Terminal className="w-4 h-4 mr-1.5" />
 								Console
 								<Badge variant="secondary" className="ml-1.5 text-xs">
-									{response.consoleLogs.length}
+									{response.consoleLogs!.length}
 								</Badge>
 							</TabsTrigger>
 						)}
-						{response.testResults && response.testResults.length > 0 && (
+						{hasTests && (
 							<TabsTrigger
 								value="tests"
 								className={cn("shrink-0", RESPONSE_TAB_TRIGGER)}
@@ -181,18 +210,18 @@ export default function ResponseViewer() {
 								Tests
 								<Badge
 									variant={
-										response.testResults.every((t) => t.passed)
+										response.testResults!.every((t) => t.passed)
 											? "default"
 											: "destructive"
 									}
 									className="ml-1.5 text-xs"
 								>
-									{response.testResults.filter((t) => t.passed).length}/
-									{response.testResults.length}
+									{response.testResults!.filter((t) => t.passed).length}/
+									{response.testResults!.length}
 								</Badge>
 							</TabsTrigger>
 						)}
-						{response.rawRequest && (
+						{hasRaw && (
 							<TabsTrigger
 								value="raw-request"
 								className={cn("shrink-0", RESPONSE_TAB_TRIGGER)}
@@ -232,12 +261,12 @@ export default function ResponseViewer() {
 				<TabsContent value="cookies" className="mt-0 flex-1 overflow-hidden">
 					<ResponseCookies headers={response.headers} />
 				</TabsContent>
-				{response.timing && (
+				{hasTiming && (
 					<TabsContent value="timing" className="mt-0 flex-1 overflow-hidden">
-						<ResponseTimingTab timing={response.timing} />
+						<ResponseTimingTab timing={response.timing!} />
 					</TabsContent>
 				)}
-				{response.consoleLogs && response.consoleLogs.length > 0 && (
+				{hasConsole && (
 					<TabsContent value="console" className="mt-0 flex-1 overflow-hidden">
 						<ConsoleOutput
 							logs={response.consoleLogs || []}
@@ -248,12 +277,12 @@ export default function ResponseViewer() {
 						/>
 					</TabsContent>
 				)}
-				{response.testResults && response.testResults.length > 0 && (
+				{hasTests && (
 					<TabsContent value="tests" className="mt-0 flex-1 overflow-hidden">
 						<TestResults results={response.testResults || []} />
 					</TabsContent>
 				)}
-				{response.rawRequest && (
+				{hasRaw && (
 					<TabsContent value="raw-request" className="mt-0 flex-1 overflow-hidden">
 						<RawRequestResponse
 							rawRequest={response.rawRequest || ""}

--- a/app/src/modules/request-builder/components/ResponseViewer/tab-strand.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/tab-strand.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The response pane must not go blank when the tab you are standing on stops
+ * existing in the next response (issue #59).
+ *
+ * `ResponseViewer` keeps the active tab in local state that survives a response
+ * change. Four of the seven tabs are conditional - `timing`, `console`, `tests`
+ * and `raw-request` - and each trigger unmounts with its panel. The `Tabs` root
+ * is controlled, so once `value` names a tab that no longer renders, Radix has
+ * nothing to select and nothing to show: no tab highlighted, empty body.
+ *
+ * A source scan cannot see this - the defect lives in state that outlives a prop
+ * change - so these render the component, shrink the tab set between renders and
+ * assert a tab is still selected and the body still renders. Revert the
+ * `effectiveTab` clamp in index.tsx and both cases fail: zero tabs active, no
+ * body panel in the tree.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
+import type { ResponseState } from "../../types";
+import ResponseViewer from "./index";
+
+// Monaco does not run under jsdom. Render the body text plainly so "is the body
+// panel on screen" is a real assertion, not a check for an empty editor shell.
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: ({ value }: { value?: string }) => <div data-testid="body-content">{value}</div>,
+}));
+
+// The context is mutated between renders to model a second response arriving.
+const state: { response: ResponseState | null; isExecuting: boolean } = {
+	response: null,
+	isExecuting: false,
+};
+vi.mock("../../context", () => ({
+	useRequestBuilderContext: () => state,
+}));
+
+const BODY = "the-response-body";
+
+/** A response carrying every conditional tab. */
+function fullResponse(): ResponseState {
+	return {
+		status: 200,
+		statusText: "OK",
+		headers: { "content-type": "application/json" },
+		requestHeaders: { host: "example.com" },
+		rawRequest: "GET / HTTP/1.1",
+		body: BODY,
+		bodyRaw: BODY,
+		bodyType: "json",
+		size: BODY.length,
+		time: 34,
+		timing: { total: 34, dns: 1, connect: 2, tls: 3, firstByte: 20, download: 8 },
+		consoleLogs: ["hello from a script"],
+		testResults: [{ name: "status is 200", passed: true }],
+	};
+}
+
+// `ResponseActions` uses a Tooltip and relies on the app-level provider (main.tsx).
+function renderViewer() {
+	const result = render(
+		<TooltipProvider>
+			<ResponseViewer />
+		</TooltipProvider>
+	);
+	return {
+		...result,
+		rerender: () =>
+			result.rerender(
+				<TooltipProvider>
+					<ResponseViewer />
+				</TooltipProvider>
+			),
+	};
+}
+
+// Radix selects a trigger on `mousedown`/focus, not on a bare `click` - and
+// `user-event` is not a dependency here, so drive it the way Radix listens.
+function selectTab(name: RegExp) {
+	const trigger = screen.getByRole("tab", { name });
+	trigger.focus();
+	fireEvent.mouseDown(trigger);
+}
+
+/** The active trigger, or null if the strip has nothing selected. */
+function activeTabName(): string | null {
+	const active = screen
+		.getAllByRole("tab")
+		.filter((t) => t.getAttribute("data-state") === "active");
+	expect(active.length, "exactly one tab must be selected").toBe(1);
+	return active[0]?.textContent?.trim() ?? null;
+}
+
+function bodyIsVisible(): boolean {
+	const panel = screen.queryByTestId("body-content");
+	return !!panel && within(panel).queryByText(BODY) !== null;
+}
+
+describe("ResponseViewer active-tab clamping", () => {
+	it("renders the conditional tab this test relies on (guards the fixture)", () => {
+		state.response = fullResponse();
+		const { unmount } = renderViewer();
+
+		// If the fixture stopped producing a Tests tab, the strand test below
+		// would pass vacuously - so prove the tab is really there first.
+		expect(screen.getByRole("tab", { name: /tests/i })).toBeTruthy();
+		unmount();
+	});
+
+	it("falls back to Body when the selected tab disappears from the next response", () => {
+		state.response = fullResponse();
+		const { rerender } = renderViewer();
+
+		// Stand on Tests, the way the app's repro does.
+		selectTab(/tests/i);
+		expect(activeTabName()).toMatch(/tests/i);
+
+		// A scriptless re-send: same response, no test results. The Tests tab and
+		// its panel unmount together.
+		state.response = { ...fullResponse(), testResults: undefined };
+		rerender();
+
+		expect(screen.queryByRole("tab", { name: /tests/i })).toBeNull();
+		expect(activeTabName()).toMatch(/body/i);
+		expect(bodyIsVisible()).toBe(true);
+	});
+
+	it("survives switching between restored responses with differing tab sets", () => {
+		// One restored trace has timing, the next has none - the sequence #65
+		// makes routine by routing design-run history through this viewer.
+		state.response = fullResponse();
+		const { rerender } = renderViewer();
+
+		selectTab(/timing/i);
+		expect(activeTabName()).toMatch(/timing/i);
+
+		state.response = { ...fullResponse(), timing: undefined };
+		rerender();
+
+		expect(screen.queryByRole("tab", { name: /timing/i })).toBeNull();
+		expect(activeTabName()).toMatch(/body/i);
+		expect(bodyIsVisible()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Description

The response pane went blank whenever the tab you were standing on stopped existing in the next response - no tab highlighted, no body. `ResponseViewer` held the active tab in local state that was never reconciled against the tabs actually rendered. Four of the seven tabs are conditional (`timing`, `console`, `tests`, `raw-request`), and each trigger unmounts together with its `TabsContent`. The `Tabs` root is controlled, so once `value` named a tab that no longer rendered, Radix had nothing to select and nothing to show.

The fix follows the issue's guidance - clamp the selection rather than removing the conditionals (the engine deliberately omits those fields on scriptless and some restored responses):

- Derive the available tab set once from the same `has*` flags that gate both the triggers and the panels, so they cannot drift.
- Feed the `Tabs` root an `effectiveTab` that is the current selection when it is still present, and falls back to `body` (always rendered) when it drops out of the set.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- New behavioural test `tab-strand.test.tsx`: renders the viewer, shrinks the tab set between renders, and asserts a tab is still selected and the body still renders - through both the **Tests** path (scriptless re-send) and the restored-**Timing** path (issue #65's sequence). Reverting the `effectiveTab` clamp fails it (verified: 0 tabs active, no body panel).
- `pnpm test` - 995 passed (138 files).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [ ] I have updated documentation (no doc describes this behaviour; no API change)

## Related Issues
Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAhymvGcJKgAEn2PHKdLdN)_