### PR TITLE
ci: add pull request automation and keep actions current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# GitHub Actions only, on purpose.
+#
+# The repository pulls in ten third-party actions and none are pinned to a
+# commit SHA, so keeping the tags current is the cheapest supply-chain work
+# available. Actions change rarely, so monthly is quiet.
+#
+# npm and vcpkg are deliberately absent. An Electron dependency tree produces a
+# steady stream of pull requests, and with a single code owner every one of them
+# lands on the same reviewer. Worth revisiting when there is more review
+# capacity, not before.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    # One pull request for all of them rather than one per action.
+    groups:
+      actions:
+        patterns:
+          - '*'
+    open-pull-requests-limit: 5
+    # Without this Dependabot titles its pull requests "Bump actions/checkout
+    # from 6 to 7", which `pr-title.yml` rejects: no conventional type, and a
+    # capitalised subject. The prefix makes it `ci: bump ...` instead, so
+    # Dependabot's own pull requests satisfy the check this branch adds.
+    commit-message:
+      prefix: ci
+    # There is deliberately no `labels:` key. Dependabot applies (and creates)
+    # `dependencies` on its own, whereas naming a label that does not exist yet
+    # is a config error, and this repository has no `dependencies` label.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,42 @@
+# Path-based labels for pull requests, applied by .github/workflows/labeler.yml.
+#
+# Labels are not created on demand: every key here must already exist in the
+# repository or the run fails on it. `ci` and `build` were added alongside this
+# file; `app`, `engine` and `documentation` already existed.
+#
+# Overlap is expected and fine. A change to `.github/release-notes/*.md` is both
+# `ci` and `documentation`, and a release bump touching both trees earns `app`,
+# `engine` and `build` at once. These describe where a change lands, not what
+# kind of change it is, so `bug` and `enhancement` stay manual.
+
+app:
+  - changed-files:
+      - any-glob-to-any-file: 'app/**'
+
+engine:
+  - changed-files:
+      - any-glob-to-any-file: 'engine/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+# The build system spans both trees and the repo root, so this one is a list of
+# specific files rather than a directory: the version manifests, the CMake
+# configuration, the dependency manifests and the build script itself.
+build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'build.py'
+          - 'VERSION'
+          - 'engine/CMakeLists.txt'
+          - 'engine/CMakePresets.json'
+          - 'engine/vcpkg.json'
+          - 'app/package.json'
+          - 'app/pnpm-lock.yaml'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,33 @@
+name: Labeler
+
+# `pull_request_target`, unlike `pr-title.yml` next door, and the difference is
+# deliberate. Applying a label needs `pull-requests: write`, and a fork pull
+# request on the plain `pull_request` trigger gets a read-only token no matter
+# what this file requests, so the labeller would silently do nothing for exactly
+# the contributors it is most useful for.
+#
+# `pull_request_target` runs with a real token, which is only safe because this
+# job never checks out the pull request's code. It reads the changed-file list
+# from the API and applies labels. Do not add `actions/checkout` here: checking
+# out the head of an untrusted fork under this trigger is the well-known way to
+# hand a write-scoped token to someone else's code.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v7
+        with:
+          # Re-evaluate on every push rather than only adding. A pull request
+          # that stops touching the engine should stop being labelled `engine`.
+          # Only labels named in .github/labeler.yml are affected, so `bug`,
+          # `enhancement` and the rest stay under human control.
+          sync-labels: true

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -33,12 +33,22 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          # Same list the trigger used to carry. Leading `**` then exclusions:
-          # `code` is false only when every changed file matches an exclusion.
+          # `every`, not the default `some`. The default means "include the file
+          # if it matches at least one pattern" - and `**` matches everything,
+          # so every file short-circuits on the first line and the `!` patterns
+          # below never subtract anything. The filter could not return false,
+          # which the first run showed plainly: it listed CONTRIBUTING.md as a
+          # matching file. `every` requires all patterns to hold, so `**` admits
+          # the file and each exclusion can then reject it.
+          predicate-quantifier: every
+          # Same list the trigger used to carry. Both `*.md` and `**/*.md` are
+          # present because the first covers root-level files like README.md and
+          # the second covers nested ones.
           filters: |
             code:
               - '**'
               - '!docs/**'
+              - '!*.md'
               - '!**/*.md'
               - '!LICENSE'
               - '!.gitignore'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+# A squash merge writes the pull request title onto master:
+# `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, so a title that ignores
+# the convention in CONTRIBUTING.md becomes a commit message that ignores it
+# too. Nothing checked that until this workflow.
+name: PR title
+
+# `edited` matters more than it looks. Without it the check never re-runs when a
+# contributor fixes their title, so it stays red with no way to clear it.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+# `pull_request`, not `pull_request_target`. The action's README suggests the
+# latter so it can comment on fork pull requests, but that trigger runs with a
+# privileged token against the base repository. Reading a title does not need
+# one: the check simply fails and the reason is in the job log.
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Kept in step with the table in CONTRIBUTING.md. `ci` and `build` are
+          # in the history 24 times between them and were missing from that
+          # table, so a list copied from the doc would have rejected the
+          # repository's own convention.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+            build
+          # Both forms are in use: `fix(app):` and a bare `ci:`.
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: >
+            The subject "{subject}" should start with a lowercase letter, as in
+            `fix(app): resolve memory leak in response viewer`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,12 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 | `perf` | Performance improvement |
 | `test` | Adding tests |
 | `chore` | Maintenance tasks |
+| `ci` | CI workflows and automation |
+| `build` | Build scripts, tooling, dependencies |
+
+These are the types `.github/workflows/pr-title.yml` accepts. A pull request
+title outside the list fails that check, so add a row here first if you need a
+new one.
 
 ### Examples
 


### PR DESCRIPTION
## Description

Adds two automations, plus the CONTRIBUTING fix that writing the first one exposed.

**`.github/workflows/pr-title.yml`** validates that a pull request title follows Conventional Commits. This is not generic hygiene: `squash_merge_commit_title` on this repo is `COMMIT_OR_PR_TITLE`, so a squash merge writes the title onto master verbatim. `CONTRIBUTING.md` has required the convention since forever and nothing enforced it, which means a contributor's malformed title becomes a malformed commit in the permanent history.

**`.github/dependabot.yml`** covers GitHub Actions only, monthly, grouped into one pull request. Ten third-party actions are in use and none are pinned to a SHA.

**`CONTRIBUTING.md`** gains `ci` and `build` to the types table.

## Type of Change
- [x] Documentation update
- [x] CI / automation

## Testing

This pull request tests the title checker on itself. `ci: lint pull request titles and keep actions current` is the exact shape the workflow accepts, so the `Conventional title` check appearing green here is the verification.

The `changes` job from faf6c12 also gets its first real exercise: this branch touches `.github/**` and `CONTRIBUTING.md`, so `code` should resolve **true** and the full matrix should run. (A docs-only pull request would skip the matrix and still report `CI gate`, which is the deadlock that commit fixed.)

## Notes for review

Three decisions worth a look rather than a skim:

- **`pull_request`, not `pull_request_target`.** The action's own README suggests the latter so it can comment on fork pull requests. That trigger runs with a privileged token against the base repository, and reading a title does not need one. The tradeoff is no explanatory comment on failure; the reason is in the job log instead.
- **`edited` in the trigger types.** Without it, a contributor who fixes their title never re-runs the check and it stays red permanently.
- **`commit-message.prefix: ci` in the Dependabot config.** Without it Dependabot titles its pull requests "Bump actions/checkout from 6 to 7", which the new checker would reject on two counts. The prefix makes Dependabot's output satisfy the rule this same pull request introduces.

npm and vcpkg are deliberately excluded from Dependabot. An Electron dependency tree generates continuous pull requests, and with one code owner they all land on the same reviewer. Worth revisiting when there is more review capacity.

## Related Issues

None. Follow-up to the CI discussion around faf6c12.