### PR TITLE
fix(ci): title check rejected Dependabot's own pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,15 @@ updates:
         patterns:
           - '*'
     open-pull-requests-limit: 5
-    # Without this Dependabot titles its pull requests "Bump actions/checkout
-    # from 6 to 7", which `pr-title.yml` rejects: no conventional type, and a
-    # capitalised subject. The prefix makes it `ci: bump ...` instead, so
-    # Dependabot's own pull requests satisfy the check this branch adds.
+    # Gets a conventional type in front of the title: "ci: Bump the actions
+    # group ..." rather than a bare "Bump ...".
+    #
+    # It does not make the title pass `pr-title.yml`, which an earlier version
+    # of this comment claimed. Dependabot capitalises its subject and has no
+    # setting to stop it, so the `subjectPattern` rule rejects it regardless of
+    # the prefix. That workflow skips bots instead. The prefix is still worth
+    # setting: it is the half that lands in the commit on master after a squash
+    # merge, where the convention is the point.
     commit-message:
       prefix: ci
     # There is deliberately no `labels:` key. Dependabot applies (and creates)

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,7 +22,18 @@ jobs:
     name: Conventional title
     runs-on: ubuntu-latest
     steps:
+      # Skipped for bots, and the `if` is on the step rather than the job on
+      # purpose. Skipping the job means the check never reports, and a required
+      # check that never reports blocks the pull request permanently - the same
+      # deadlock `paths-ignore` caused in pr-tests.yml. On the step, the job
+      # still completes and reports green.
+      #
+      # Dependabot needs the exemption because it capitalises its subject
+      # ("ci: Bump the actions group...") and offers no setting to change that.
+      # `commit-message.prefix` in dependabot.yml gets the type in front, which
+      # is as far as configuration reaches; the capital B is not negotiable.
       - uses: amannn/action-semantic-pull-request@v6
+        if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Description

The two rules added in #72 contradict each other, and #73 is the proof.

`dependabot.yml` sets `commit-message.prefix: ci`, so Dependabot titles its pull requests `ci: Bump the actions group with 5 updates`. `pr-title.yml` sets `subjectPattern: ^(?![A-Z]).+$`, which requires a lowercase subject. Dependabot capitalises "Bump" and has no setting to change it, so **every** Dependabot pull request fails the check that shipped alongside the config generating them.

```
##[error]The subject "Bump the actions group with 5 updates" should start
with a lowercase letter
```

The action now skips any author whose login ends in `[bot]`.

## Type of Change
- [x] Bug fix

## Testing

This pull request cannot demonstrate the fix on itself, since the author is not a bot. The verification is #73: once this merges, re-running its `Conventional title` check should go green by skipping.

What this pull request *does* verify is that the exemption has not broken the check for humans. `fix(ci): title check rejected Dependabot's own pull requests` must still pass.

## Notes for review

**The `if` is on the step, not the job, and that is the whole point.** Putting it on the job would skip the job, the check would never report, and a required check that never reports blocks a pull request permanently. That is precisely the `paths-ignore` deadlock faf6c12 fixed, and it would have been reintroduced by the more obvious fix.

**The prefix stays.** It does not rescue the title check, but it is the half that survives a squash merge into the commit message on master, which is where the convention actually matters. The comment in `dependabot.yml` claimed the prefix made those pull requests pass the check; that claim is corrected here rather than left to mislead.

**`endsWith(..., '[bot]')` rather than naming Dependabot.** Any future bot has the same problem, and none of them read CONTRIBUTING.md.

## Related Issues

None. Follows #72.