### PR TITLE
perf(engine): index the hot run_id / collection_id / parent_id lookups

### DIFF
--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -283,6 +283,31 @@ written by `POST /config`. Struct is `db::ConfigEntry`.
 
 ---
 
+## Indexes
+
+Declared alongside the tables in `make_storage()` (`engine/src/db/database.cpp`). `sqlite_orm`
+requires index arguments to precede the table arguments. `sync_schema()` creates them on startup
+for fresh **and** pre-existing databases, so adding an index is additive and needs no migration.
+
+| Index                        | Column                  | Query paths that rely on it                                                                                                                       |
+|------------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `idx_metrics_run_id`         | `metrics.run_id`        | `get_metrics`, `get_metrics_since` (polled every 500ms by the legacy SSE loop in `http/routes/metrics.cpp`), `get_metrics_paginated`, `count_metrics`, and the `remove_all` in `delete_run` |
+| `idx_results_run_id`         | `results.run_id`        | `get_results` and the `remove_all` in `delete_run`                                                                                                |
+| `idx_requests_collection_id` | `requests.collection_id`| `get_requests_in_collection` (every sidebar load) and cascade delete                                                                              |
+| `idx_collections_parent_id`  | `collections.parent_id` | The cascade-delete BFS in `Database::delete_collection`, which does one lookup per node in the subtree                                            |
+| `idx_runs_start_time`        | `runs.start_time`       | `get_all_runs`, which sorts on every `GET /runs`                                                                                                  |
+
+`metrics` and `results` are the unbounded-growth tables - a load run writes roughly 20 metric
+rows per second - so without `run_id` indexes a lookup slows down with every run ever recorded,
+not just the current one. `collections.parent_id` is a nullable column; `sqlite_orm` indexes it
+without special handling.
+
+Guarded by `DatabaseTest.CreatesIndexesOnFreshDatabase` and
+`DatabaseTest.RecreatesIndexesOnExistingDatabase` in `engine/tests/db_test.cpp`, which read
+`sqlite_master` directly rather than trusting what `sqlite_orm` reports about itself.
+
+---
+
 ## VariableValue shape
 
 Used in `collections.variables`, `environments.variables`, and `globals.variables`:

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -179,6 +179,24 @@ namespace vayu::db {
 inline auto make_storage (const std::string& path) {
     return sqlite_orm::make_storage (path,
 
+    // ─────────────── INDEXES ───────────────
+    // sqlite_orm requires indexes to precede the tables in the argument list.
+    // sync_schema() creates them on fresh and pre-existing databases alike, so
+    // this is additive and needs no migration.
+    //
+    // metrics/results are the unbounded-growth tables (a load run writes ~20
+    // metric rows/sec), so a run_id scan slows down with every run ever
+    // recorded, not just the current one. get_metrics_since is polled every
+    // 500ms by the legacy SSE loop.
+    make_index ("idx_metrics_run_id", &Metric::run_id),
+    make_index ("idx_results_run_id", &Result::run_id),
+    // Sidebar load (get_requests_in_collection) and cascade delete.
+    make_index ("idx_requests_collection_id", &Request::collection_id),
+    // The cascade-delete BFS in delete_collection walks one lookup per node.
+    make_index ("idx_collections_parent_id", &Collection::parent_id),
+    // get_all_runs sorts the whole table on every GET /runs.
+    make_index ("idx_runs_start_time", &Run::start_time),
+
     // ─────────────── PROJECT MANAGEMENT TABLES ───────────────
 
     // Collections: Folder hierarchy for organizing requests

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -4,8 +4,12 @@
  */
 
 #include <gtest/gtest.h>
+#include <sqlite3.h>
 
 #include <filesystem>
+#include <set>
+#include <string>
+#include <vector>
 
 #include "vayu/db/database.hpp"
 
@@ -234,6 +238,111 @@ TEST_F (DatabaseTest, DeletesEnvironment) {
 
     auto deleted = db.get_environment ("env_1");
     EXPECT_FALSE (deleted.has_value ());
+}
+
+// ==================== Index Tests ====================
+
+// Every index declared in make_storage(), each backing a hot query path:
+// metrics/results by run_id, requests by collection_id, collections by
+// parent_id, runs by start_time. See the comments there for which queries
+// rely on which. Named explicitly rather than counted, because sqlite also
+// creates sqlite_autoindex_* entries of its own.
+const std::vector<std::string> EXPECTED_INDEXES = { "idx_metrics_run_id",
+    "idx_results_run_id", "idx_requests_collection_id",
+    "idx_collections_parent_id", "idx_runs_start_time" };
+
+// Reads index names straight out of sqlite_master on a separate connection,
+// so the assertion does not rest on anything sqlite_orm reports about itself.
+// Callers open this only after the Database has been destroyed, which keeps
+// WAL visibility out of the picture.
+std::set<std::string> read_index_names (const std::string& path) {
+    std::set<std::string> names;
+
+    sqlite3* handle = nullptr;
+    if (sqlite3_open (path.c_str (), &handle) != SQLITE_OK) {
+        ADD_FAILURE () << "could not open " << path << ": " << sqlite3_errmsg (handle);
+        sqlite3_close (handle);
+        return names;
+    }
+
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2 (handle, "SELECT name FROM sqlite_master WHERE type='index'",
+        -1, &stmt, nullptr) != SQLITE_OK) {
+        ADD_FAILURE () << "could not query sqlite_master: " << sqlite3_errmsg (handle);
+        sqlite3_close (handle);
+        return names;
+    }
+
+    while (sqlite3_step (stmt) == SQLITE_ROW) {
+        const auto* name = sqlite3_column_text (stmt, 0);
+        if (name != nullptr) {
+            names.emplace (reinterpret_cast<const char*> (name));
+        }
+    }
+
+    sqlite3_finalize (stmt);
+    sqlite3_close (handle);
+    return names;
+}
+
+void drop_index (const std::string& path, const std::string& index_name) {
+    sqlite3* handle = nullptr;
+    ASSERT_EQ (sqlite3_open (path.c_str (), &handle), SQLITE_OK);
+
+    const std::string sql = "DROP INDEX IF EXISTS " + index_name;
+    char* err             = nullptr;
+    if (sqlite3_exec (handle, sql.c_str (), nullptr, nullptr, &err) != SQLITE_OK) {
+        ADD_FAILURE () << "could not drop " << index_name << ": "
+                       << (err != nullptr ? err : "(no message)");
+        sqlite3_free (err);
+    }
+
+    sqlite3_close (handle);
+}
+
+TEST_F (DatabaseTest, CreatesIndexesOnFreshDatabase) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+    }
+
+    const auto names = read_index_names (TEST_DB_PATH);
+    for (const auto& expected : EXPECTED_INDEXES) {
+        EXPECT_TRUE (names.contains (expected)) << "missing index: " << expected;
+    }
+}
+
+// Adding indexes is meant to be additive - an existing database picks them up
+// on the next startup, with no migration. Dropping them and re-opening
+// reproduces exactly that, without needing a pre-index schema on disk to test
+// against.
+TEST_F (DatabaseTest, RecreatesIndexesOnExistingDatabase) {
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+    }
+
+    for (const auto& name : EXPECTED_INDEXES) {
+        drop_index (TEST_DB_PATH, name);
+    }
+
+    // Guard the guard: if the drop silently did nothing, the re-open assertion
+    // below would pass without proving anything.
+    const auto after_drop = read_index_names (TEST_DB_PATH);
+    for (const auto& name : EXPECTED_INDEXES) {
+        ASSERT_FALSE (after_drop.contains (name)) << "drop did not remove: " << name;
+    }
+
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+    }
+
+    const auto recreated = read_index_names (TEST_DB_PATH);
+    for (const auto& expected : EXPECTED_INDEXES) {
+        EXPECT_TRUE (recreated.contains (expected))
+        << "sync_schema did not recreate: " << expected;
+    }
 }
 
 } // namespace


### PR DESCRIPTION
Closes #77. First of the four-issue `database.cpp` series (#77 -> #80 -> #79 -> #78);
based on `master`, so the ordering holds.

The schema declared zero indexes, so every hot query was a full table scan.

### Changes

**`engine/src/db/database.cpp`** - five `make_index` arguments in `make_storage()`,
placed **before** the tables as sqlite_orm requires:

| Index | Column | Why |
|---|---|---|
| `idx_metrics_run_id` | `metrics.run_id` | `get_metrics`, `get_metrics_since`, `get_metrics_paginated`, `count_metrics`, `delete_run`'s `remove_all` |
| `idx_results_run_id` | `results.run_id` | `get_results`, `delete_run`'s `remove_all` |
| `idx_requests_collection_id` | `requests.collection_id` | `get_requests_in_collection` (every sidebar load), cascade delete |
| `idx_collections_parent_id` | `collections.parent_id` | the cascade-delete BFS in `delete_collection`, one lookup per subtree node |
| `idx_runs_start_time` | `runs.start_time` | `get_all_runs` sorts on every `GET /runs` |

`metrics` and `results` are the unbounded-growth tables, so those scans were
slowing down with every run ever recorded, not just the current one - and
`get_metrics_since` sits behind a 500ms poll (`routes/metrics.cpp:330`).

Additive: `sync_schema()` creates indexes on fresh and pre-existing databases
alike, so there is no migration. No API shape changes, no app changes.

**`engine/tests/db_test.cpp`** - two tests, added to the existing file (already in
the `add_executable` list, so no CMake edit). Both read `sqlite_master` on their
own connection after the `Database` has been destroyed, rather than trusting what
sqlite_orm reports about itself, and assert the five **names** rather than a count
(sqlite creates `sqlite_autoindex_*` entries of its own).

- `CreatesIndexesOnFreshDatabase`
- `RecreatesIndexesOnExistingDatabase` - drops all five, then re-opens. This is
  what covers the "pre-existing database" half of the acceptance criteria without
  needing an old schema on disk. It asserts the drop actually removed them first,
  so it cannot pass vacuously.

**`docs/engine/db-schema.md`** - new Indexes section mapping each index to the
query paths that rely on it, per CLAUDE.md's same-commit doc rule. Every function
name cited there was grepped against the source.

### Verification

| Check | Result |
|---|---|
| Full engine suite (`ctest --preset windows-dev`) | **287/287 passed** |
| `DatabaseTest.*` | 11/11 passed |
| **Mutation check** | reverted just the `make_storage` change, rebuilt: both new tests **FAIL** with the five missing index names, then restored and re-verified green |
| clang-format on added lines | clean - `database.cpp` gains 0 new violations (the 20 the file reports are pre-existing on `master`, verified by stashing); the added test lines were formatted with `--lines` so untouched regions stay out of the diff |
| Em-dashes in added lines | none |

Built on Windows via `build.py`'s toolchain. One honest gap: **clang-tidy could not
run locally** - the clang-tidy bundled with VS Build Tools segfaults (0xC0000005) on
this tree, and it does so on untouched files too (verified against `json_test.cpp`),
so it is the tool, not this change. CI does not run clang-tidy either, so this is
worth a look from a Linux checkout if you want that gate closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016soB1ZwVYKdJPxF4WJpjmh
