### PR TITLE
ci: label database changes in the path labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@
 #
 # Labels are not created on demand: every key here must already exist in the
 # repository or the run fails on it. `ci` and `build` were added alongside this
-# file; `app`, `engine` and `documentation` already existed.
+# file; `app`, `engine`, `database` and `documentation` already existed.
 #
 # Overlap is expected and fine. A change to `.github/release-notes/*.md` is both
 # `ci` and `documentation`, and a release bump touching both trees earns `app`,
@@ -16,6 +16,19 @@ app:
 engine:
   - changed-files:
       - any-glob-to-any-file: 'engine/**'
+
+# A subset of `engine`, so a database change earns both labels - which is the
+# point of a finer label, and consistent with the overlap noted above. The
+# store is one translation unit plus its header, test and schema doc, so this
+# is an explicit file list rather than a directory. Uses the existing
+# `database` label; there is no separate `db` label.
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'engine/src/db/**'
+          - 'engine/include/vayu/db/**'
+          - 'engine/tests/db_test.cpp'
+          - 'docs/engine/db-schema.md'
 
 ci:
   - changed-files:


### PR DESCRIPTION
## Description

Adds a `database` entry to `.github/labeler.yml` so pull requests touching the SQLite store get labelled. Covers the store's translation unit, header, test, and schema doc:

- `engine/src/db/**`
- `engine/include/vayu/db/**`
- `engine/tests/db_test.cpp`
- `docs/engine/db-schema.md`

## Type of Change
- [x] CI / automation

## Notes

- **Uses the existing `database` label**, not a new `db`. The repository already has `database`; a second near-duplicate name would only confuse. Flagging because the request was phrased as "db".
- The db paths are a **subset of `engine`**, so a database change is labelled both `engine` and `database`. That overlap is intended and matches the file's stated model that labels describe where a change lands, not what kind it is.
- `db_test.cpp` is listed explicitly because the store's test does not live under a `db/` directory the way the source does.

## Testing

The labeler runs via `pull_request_target` from the base branch, so this PR cannot label itself with the new rule - it touches only `.github/**` and will get `ci`. The `database` rule takes effect on the first PR touching db paths after merge. A natural first exercise would be any follow-up to the db-indexes work that just merged.

## Related Issues

None. Follows the labeler added in #72.