### PR TITLE
perf(db): never sleep holding the DB mutex; drop dead txn helpers; unify busy-retry

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -379,6 +379,7 @@ if(VAYU_BUILD_TESTS)
         tests/event_loop_test.cpp
         tests/sse_test.cpp
         tests/db_test.cpp
+        tests/db_concurrency_test.cpp
         tests/rate_limit_test.cpp
         tests/metrics_helper_test.cpp
         tests/metrics_collector_test.cpp

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -72,11 +74,6 @@ class Database {
     void add_results_batch (const std::vector<Result>& results); // Transactional batch insert
     std::vector<Result> get_results (const std::string& run_id);
 
-    // Transaction helpers
-    void begin_transaction ();
-    void commit_transaction ();
-    void rollback_transaction ();
-
     // Config Entries - Structured configuration with metadata
     void save_config_entry (const ConfigEntry& entry);
     std::optional<ConfigEntry> get_config_entry (const std::string& key);
@@ -93,6 +90,20 @@ class Database {
     private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
+
+    /**
+     * @brief Run @p fn under the DB mutex, retrying on a SQLite busy/locked error.
+     *
+     * On a busy error the mutex is released *before* sleeping (exponential
+     * backoff, @p base * (attempt+1)), then the call is retried - so a retry
+     * never stalls other endpoints that need the same mutex. Non-busy
+     * exceptions rethrow immediately; busy exhaustion after @p attempts logs
+     * and rethrows. @p what names the operation for log messages.
+     */
+    void retry_on_busy (const char* what,
+    int attempts,
+    std::chrono::milliseconds base,
+    const std::function<void ()>& fn);
 };
 
 } // namespace vayu::db

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -34,6 +34,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <functional>
 #include <iostream>
 #include <mutex>
 #include <sstream>
@@ -728,37 +729,10 @@ void Database::update_run_end_time (const std::string& id) {
 }
 
 void Database::update_run_status_with_retry (const std::string& id, RunStatus status, int max_retries) {
-    for (int attempt = 0; attempt < max_retries; attempt++) {
-        try {
-            update_run_status (id, status);
-            return; // Success
-        } catch (const std::system_error& e) {
-            std::string error_msg = e.what ();
-            // Check if it's a database lock error
-            if (error_msg.find ("database is locked") != std::string::npos ||
-            error_msg.find ("SQLITE_BUSY") != std::string::npos) {
-                if (attempt == max_retries - 1) {
-                    // Last attempt failed, rethrow
-                    vayu::utils::log_error (
-                    "Failed to update run status after " +
-                    std::to_string (max_retries) + " attempts: " + error_msg);
-                    throw;
-                }
-                // Wait before retry with exponential backoff
-                vayu::utils::log_debug ("Database locked, retrying in " +
-                std::to_string (100 * (attempt + 1)) + "ms (attempt " +
-                std::to_string (attempt + 1) + "/" + std::to_string (max_retries) + ")");
-                std::this_thread::sleep_for (
-                std::chrono::milliseconds (100 * (attempt + 1)));
-            } else {
-                // Different error, rethrow immediately
-                throw;
-            }
-        } catch (...) {
-            // Non-system_error exceptions, rethrow immediately
-            throw;
-        }
-    }
+    // Public signature is unchanged (real callers in runs.cpp, execution.cpp,
+    // load_strategy.cpp); delegate to the shared busy-retry helper.
+    retry_on_busy ("update run status", max_retries,
+    std::chrono::milliseconds (100), [&] { update_run_status (id, status); });
 }
 
 std::vector<Run> Database::get_all_runs () {
@@ -779,82 +753,24 @@ void Database::delete_run (const std::string& id) {
 // ============================================================================
 
 void Database::add_metric (const Metric& metric) {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    const int max_retries = 3;
-    for (int attempt = 0; attempt < max_retries; attempt++) {
-        try {
-            impl_->storage.insert (metric);
-            return; // Success
-        } catch (const std::system_error& e) {
-            std::string error_msg = e.what ();
-            // Check if it's a database lock error
-            if (error_msg.find ("database is locked") != std::string::npos ||
-            error_msg.find ("SQLITE_BUSY") != std::string::npos) {
-                if (attempt == max_retries - 1) {
-                    // Last attempt failed, rethrow
-                    vayu::utils::log_error ("Failed to add metric after " +
-                    std::to_string (max_retries) + " attempts: " + error_msg);
-                    throw;
-                }
-                // Wait before retry with exponential backoff
-                std::this_thread::sleep_for (
-                std::chrono::milliseconds (50 * (attempt + 1)));
-            } else {
-                // Different error, rethrow immediately
-                throw;
-            }
-        } catch (...) {
-            // Non-system_error exceptions, rethrow immediately
-            throw;
-        }
-    }
+    retry_on_busy ("add metric", 5, std::chrono::milliseconds (100),
+    [&] { impl_->storage.insert (metric); });
 }
 
 // Batch insert with transaction for better performance and reduced lock
 // contention Includes retry logic to handle database lock contention
 void Database::add_metrics_batch (const std::vector<Metric>& metrics) {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     if (metrics.empty ())
         return;
 
-    const int max_retries = 5;
-    for (int attempt = 0; attempt < max_retries; attempt++) {
-        try {
-            impl_->storage.transaction ([&] {
-                for (const auto& metric : metrics) {
-                    impl_->storage.insert (metric);
-                }
-                return true; // Commit
-            });
-            return; // Success
-        } catch (const std::system_error& e) {
-            std::string error_msg = e.what ();
-            // Check if it's a database lock error
-            if (error_msg.find ("database is locked") != std::string::npos ||
-            error_msg.find ("SQLITE_BUSY") != std::string::npos) {
-                if (attempt == max_retries - 1) {
-                    // Last attempt failed, rethrow
-                    vayu::utils::log_error (
-                    "Failed to store metrics batch after " +
-                    std::to_string (max_retries) + " attempts: " + error_msg);
-                    throw;
-                }
-                // Wait before retry with exponential backoff
-                vayu::utils::log_debug (
-                "Database locked during metrics batch, retrying in " +
-                std::to_string (100 * (attempt + 1)) + "ms (attempt " +
-                std::to_string (attempt + 1) + "/" + std::to_string (max_retries) + ")");
-                std::this_thread::sleep_for (
-                std::chrono::milliseconds (100 * (attempt + 1)));
-            } else {
-                // Different error, rethrow immediately
-                throw;
+    retry_on_busy ("store metrics batch", 5, std::chrono::milliseconds (100), [&] {
+        impl_->storage.transaction ([&] {
+            for (const auto& metric : metrics) {
+                impl_->storage.insert (metric);
             }
-        } catch (...) {
-            // Non-system_error exceptions, rethrow immediately
-            throw;
-        }
-    }
+            return true; // Commit
+        });
+    });
 }
 
 std::vector<Metric> Database::get_metrics (const std::string& run_id) {
@@ -897,48 +813,17 @@ void Database::add_result (const Result& result) {
 // Batch insert with transaction for better performance
 // Includes retry logic to handle database lock contention
 void Database::add_results_batch (const std::vector<Result>& results) {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     if (results.empty ())
         return;
 
-    const int max_retries = 5;
-    for (int attempt = 0; attempt < max_retries; attempt++) {
-        try {
-            impl_->storage.transaction ([&] {
-                for (const auto& result : results) {
-                    impl_->storage.insert (result);
-                }
-                return true; // Commit
-            });
-            return; // Success
-        } catch (const std::system_error& e) {
-            std::string error_msg = e.what ();
-            // Check if it's a database lock error
-            if (error_msg.find ("database is locked") != std::string::npos ||
-            error_msg.find ("SQLITE_BUSY") != std::string::npos) {
-                if (attempt == max_retries - 1) {
-                    // Last attempt failed, rethrow
-                    vayu::utils::log_error (
-                    "Failed to flush results batch after " +
-                    std::to_string (max_retries) + " attempts: " + error_msg);
-                    throw;
-                }
-                // Wait before retry with exponential backoff
-                vayu::utils::log_debug (
-                "Database locked during results batch, retrying in " +
-                std::to_string (100 * (attempt + 1)) + "ms (attempt " +
-                std::to_string (attempt + 1) + "/" + std::to_string (max_retries) + ")");
-                std::this_thread::sleep_for (
-                std::chrono::milliseconds (100 * (attempt + 1)));
-            } else {
-                // Different error, rethrow immediately
-                throw;
+    retry_on_busy ("flush results batch", 5, std::chrono::milliseconds (100), [&] {
+        impl_->storage.transaction ([&] {
+            for (const auto& result : results) {
+                impl_->storage.insert (result);
             }
-        } catch (...) {
-            // Non-system_error exceptions, rethrow immediately
-            throw;
-        }
-    }
+            return true; // Commit
+        });
+    });
 }
 
 std::vector<Result> Database::get_results (const std::string& run_id) {
@@ -947,22 +832,42 @@ std::vector<Result> Database::get_results (const std::string& run_id) {
 }
 
 // ============================================================================
-// Transaction Helpers
+// Busy-retry helper - shared by the four write paths above
 // ============================================================================
 
-void Database::begin_transaction () {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    impl_->storage.begin_transaction ();
-}
-
-void Database::commit_transaction () {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    impl_->storage.commit ();
-}
-
-void Database::rollback_transaction () {
-    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    impl_->storage.rollback ();
+void Database::retry_on_busy (const char* what,
+int attempts,
+std::chrono::milliseconds base,
+const std::function<void ()>& fn) {
+    for (int attempt = 0; attempt < attempts; attempt++) {
+        try {
+            std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+            fn ();
+            return; // Success
+        } catch (const std::system_error& e) {
+            std::string error_msg = e.what ();
+            // Only SQLite busy/locked errors are retried; sqlite_orm surfaces
+            // them as std::system_error with these substrings in what().
+            const bool busy = error_msg.find ("database is locked") != std::string::npos ||
+            error_msg.find ("SQLITE_BUSY") != std::string::npos;
+            if (!busy) {
+                throw; // Different error, rethrow immediately
+            }
+            if (attempt == attempts - 1) {
+                // Busy persisted through every attempt - log and rethrow.
+                vayu::utils::log_error (std::string ("Failed to ") + what +
+                " after " + std::to_string (attempts) + " attempts: " + error_msg);
+                throw;
+            }
+            vayu::utils::log_debug (std::string ("Database locked during ") + what +
+            ", retrying in " + std::to_string (base.count () * (attempt + 1)) + "ms (attempt " +
+            std::to_string (attempt + 1) + "/" + std::to_string (attempts) + ")");
+        }
+        // The lock_guard scope above has ended: we sleep *without* holding the
+        // mutex so a busy retry never stalls other endpoints (/health, SSE,
+        // the runs poll) that serialize on the same lock.
+        std::this_thread::sleep_for (base * (attempt + 1));
+    }
 }
 
 // ============================================================================

--- a/engine/tests/db_concurrency_test.cpp
+++ b/engine/tests/db_concurrency_test.cpp
@@ -1,0 +1,127 @@
+/**
+ * @file tests/db_concurrency_test.cpp
+ * @brief Concurrency smoke test for the Database busy-retry restructuring.
+ *
+ * Guards the lock-scope change in issue #88: the shared retry_on_busy helper
+ * serializes writes on the DB mutex but must release it before sleeping, and
+ * the four write paths (add_metrics_batch here) must interleave safely with
+ * concurrent readers (get_metrics / get_run) on the *same* Database instance.
+ *
+ * This is a smoke test, not a busy-path test: injecting SQLITE_BUSY reliably
+ * needs fault injection we deliberately do not build (see the issue). The value
+ * here is proving the restructured locking neither deadlocks nor loses rows
+ * under contention - the concurrency the recursive_mutex is there to tame.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "vayu/db/database.hpp"
+
+namespace vayu::db {
+namespace {
+
+class DatabaseConcurrencyTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_db_concurrency.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<Database> (DB_PATH);
+        db_->init ();
+
+        vayu::db::Run run;
+        run.id              = "run_1";
+        run.type            = vayu::RunType::Load;
+        run.status          = vayu::RunStatus::Running;
+        run.start_time      = 1000;
+        run.config_snapshot = "{}";
+        db_->create_run (run);
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + s);
+        }
+    }
+
+    std::unique_ptr<Database> db_;
+};
+
+// N writers batch-insert metrics while M readers poll get_metrics / get_run on
+// the same Database. Passing means: no deadlock (the per-test ctest TIMEOUT is
+// the deadlock backstop), no lost writes, and readers never crash mid-write.
+TEST_F (DatabaseConcurrencyTest, ConcurrentBatchWritesAndReadsReconcile) {
+    constexpr int kWriters          = 4;
+    constexpr int kBatchesPerWriter = 25;
+    constexpr int kMetricsPerBatch  = 10;
+    constexpr int kReaders          = 3;
+
+    std::atomic<bool> writers_done{ false };
+    std::atomic<int> reads_ok{ 0 };
+
+    std::vector<std::thread> threads;
+    threads.reserve (kWriters + kReaders);
+
+    for (int w = 0; w < kWriters; ++w) {
+        threads.emplace_back ([this, w] {
+            for (int b = 0; b < kBatchesPerWriter; ++b) {
+                std::vector<Metric> batch;
+                batch.reserve (kMetricsPerBatch);
+                for (int i = 0; i < kMetricsPerBatch; ++i) {
+                    vayu::db::Metric m;
+                    m.run_id = "run_1";
+                    m.timestamp =
+                    1000 + (w * kBatchesPerWriter + b) * kMetricsPerBatch + i;
+                    m.name  = vayu::MetricName::TotalRequests;
+                    m.value = static_cast<double> (i);
+                    batch.push_back (m);
+                }
+                db_->add_metrics_batch (batch);
+            }
+        });
+    }
+
+    for (int r = 0; r < kReaders; ++r) {
+        threads.emplace_back ([this, &writers_done, &reads_ok] {
+            while (!writers_done.load (std::memory_order_relaxed)) {
+                // Both reader paths share the same mutex the writers hold; a
+                // retry that slept under the lock would stall these.
+                auto metrics = db_->get_metrics ("run_1");
+                auto run     = db_->get_run ("run_1");
+                if (run.has_value () &&
+                metrics.size () <=
+                static_cast<size_t> (kWriters * kBatchesPerWriter * kMetricsPerBatch)) {
+                    reads_ok.fetch_add (1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    for (int w = 0; w < kWriters; ++w) {
+        threads[static_cast<size_t> (w)].join ();
+    }
+    writers_done.store (true, std::memory_order_relaxed);
+    for (int r = kWriters; r < kWriters + kReaders; ++r) {
+        threads[static_cast<size_t> (r)].join ();
+    }
+
+    // Every batched row landed exactly once - no write lost to the interleaving.
+    const auto expected =
+    static_cast<size_t> (kWriters * kBatchesPerWriter * kMetricsPerBatch);
+    EXPECT_EQ (db_->get_metrics ("run_1").size (), expected);
+    EXPECT_EQ (db_->count_metrics ("run_1"), static_cast<int64_t> (expected));
+    // Readers ran throughout and observed only consistent snapshots.
+    EXPECT_GT (reads_ok.load (), 0);
+}
+
+} // namespace
+} // namespace vayu::db


### PR DESCRIPTION
## Description
Fixes three related concurrency defects in the `Database` layer (`engine/src/db/database.cpp` / `engine/include/vayu/db/database.hpp`), per issue #88.

1. **Never sleep while holding the global mutex.** The four hand-rolled `SQLITE_BUSY` retry loops (`update_run_status_with_retry`, `add_metric`, `add_metrics_batch`, `add_results_batch`) took the `recursive_mutex` and then slept *inside* it on backoff - up to ~1s under lock - stalling every other endpoint (`/health`, live SSE ticks, the UI's 5s runs poll) that serializes on the same mutex. They now delegate to a shared helper whose `lock_guard` scope ends **before** the sleep, so a busy retry never blocks unrelated callers.

2. **Delete the dead public transaction helpers.** `begin_transaction` / `commit_transaction` / `rollback_transaction` each took the mutex only for their own call, so any transaction spanning them was interleaved by other threads' writes - the API could not be used safely. Zero callers anywhere in `engine/src`, `engine/include`, or `engine/tests` (verified); the build itself proves the removal safe. The safe internal pattern (`storage.transaction([&]{...})` under the lock) is untouched.

3. **One retry implementation, four call sites.** New private `retry_on_busy(what, attempts, base, fn)` replaces ~130 near-identical lines. It keeps the existing busy detection (substring match on `e.what()`, which is what sqlite_orm surfaces) and the log-and-rethrow behavior. Structure: `for attempt { lock_guard; try fn(); catch(busy){...} } sleep;` - the lock scope closes before the sleep by construction.

**Policy unified to 5 attempts / 100ms base** for the three metric/result paths; `add_metric` was previously 3 attempts / 50ms for no documented reason. `update_run_status_with_retry` keeps its **public signature unchanged** (`max_retries` default 3; real callers in `runs.cpp`, `execution.cpp`, `load_strategy.cpp`) and delegates internally.

No behavior change on the success path. No API shape changes - engine-internal only, so no app changes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Unit / suite
- New `engine/tests/db_concurrency_test.cpp`: a concurrency smoke test - 4 batch-writers (`add_metrics_batch`) racing 3 readers (`get_metrics` / `get_run`) on one `Database`, asserting the final row counts reconcile exactly and the test completes without deadlock (the per-test ctest `TIMEOUT` is the deadlock backstop). Guards the lock-scope restructuring.
- Full engine suite green after rebasing onto latest `master`: `python build.py -t && cd engine && ctest --preset linux-dev` - **296/296 tests pass** (295 pre-existing + the new one).
- clang-format applied to touched regions; clang-tidy clean on touched files.
- No docs reference the removed helpers or the retry behavior (`rg` over `docs/engine/`), so no doc update is needed - engine-internal change.

### Load test - the scenario the retry was originally added for
Ran the release daemon (`build-release`, `-O2`, `-v 2` debug logging, fresh data-dir) against the Go mock server (`scripts/test/mock-server.go` on `:8080`), driving load via `vayu-cli run` with a `targetRps: 60000`, 15s constant config. **Two runs:**

| | Run 1 | Run 2 |
|---|---|---|
| Requests served | 900,000 | 900,000 |
| Status codes | all 200 | all 200 |
| Errors / failed / dropped | 0 / 0 / 0 | 0 / 0 / 0 |
| Actual RPS | 30,587 | 27,019 |
| **DB lock / retry / `SQLITE_BUSY` events** | **0** | **0** |
| **`[ERROR]` log lines** | **0** | **0** |

During a run, worst-case endpoint latency under the concurrent load was **`/health` = 10 ms**, **`/runs` = 13.7 ms** (probed continuously) - no 100 ms-1 s spikes, which is exactly what an under-lock sleep would have produced.

Notes on interpretation:
- The **60k target was not physically reachable** in this environment (4 CPU cores shared by client + engine + mock server), so actual throughput capped at ~27-31k rps. Each run still pushed 900k requests with zero DB contention.
- **DB write volume is independent of RPS**: metric writes are tick-driven at 100 ms (`liveTickIntervalMs`), so each run wrote only ~514 metric rows regardless of request rate, and per-request results are not persisted in load mode (`results` table = 0). A true 60k run would hit the DB with the *same* light, infrequent batch writes.
- This confirms issue #88's own analysis empirically: with a single engine process + WAL + a 10s `busy_timeout`, **in-process `SQLITE_BUSY` is effectively unreachable**; the retry stays as a safety net for an *external* writer on `vayu.db`, and this change ensures that if it ever fires it no longer stalls every endpoint.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (n/a - engine-internal, no docs reference this)

## Related Issues
Closes #88