### PR TITLE
docs(engine): document /import/fetch and /shutdown, fix GET /config shape, correct dbSynchronous durability claim

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -62,24 +62,81 @@ Check engine status and version.
 }
 ```
 
-### GET /config
+### POST /shutdown
 
-Get global configuration settings. Backed by the `config_entries` table; each entry carries UI
-metadata (label, description, category, default, min/max). Keys include:
+Gracefully shut down the engine. This is the shutdown path the Electron app uses
+on quit (it is more reliable than a signal on Windows, where `SIGTERM` does not
+behave as expected).
 
+The response is sent **before** shutdown begins, so the client always receives
+the `200`. About 100ms later, on a detached thread, the engine invokes its
+shutdown callback: the daemon's main loop exits, active runs are stopped, the
+lock file is released, logs are flushed, and the process exits.
+
+**Response:** `200`
 ```json
 {
-  "workers": 8,
-  "maxConnections": 10000,
-  "defaultTimeout": 30000,
-  "statsInterval": 100,
-  "contextPoolSize": 64,
-  "liveTickIntervalMs": 100,
-  "liveRetentionMs": 60000
+  "status": "ok",
+  "message": "Shutdown initiated"
 }
 ```
 
-`POST /config` validates each key against its registered type and min/max range.
+### GET /config
+
+Get global configuration settings. Backed by the `config_entries` table. The
+response is an `entries` array; each entry carries its value plus the UI metadata
+the Settings panel renders (label, description, category, default, and optional
+min/max):
+
+```json
+{
+  "entries": [
+    {
+      "key": "workers",
+      "value": "8",
+      "type": "integer",
+      "label": "Worker Threads",
+      "description": "Number of worker threads for load generation.",
+      "category": "performance",
+      "default": "8",
+      "min": "1",
+      "max": "256",
+      "updatedAt": 1234567890
+    }
+  ]
+}
+```
+
+`min` and `max` are present only for entries that declare them. `value` and
+`default` are always strings; `type` is one of `integer`, `number`, `boolean`,
+or `string`.
+
+### POST /config
+
+Update one or more configuration entries. Two body shapes are accepted:
+
+**Batch** - update several keys at once:
+```json
+{ "entries": { "workers": "16", "defaultTimeout": "30000" } }
+```
+
+**Single** - update one key:
+```json
+{ "key": "workers", "value": "16" }
+```
+
+In both shapes, non-string values (numbers, booleans) are coerced to strings.
+Each key is validated against its registered `type` and, for `integer` / `number`
+entries, its `min`/`max` range; `boolean` entries must be `"true"` or `"false"`.
+Validation is all-or-nothing: if any key is unknown or out of range, nothing is
+applied and the response is `400` with the specific reason(s):
+
+```json
+{ "error": { "code": "invalid_config", "message": "'workers' must be at most 256 (got 9999)" } }
+```
+
+**Success response:** `200` - the full updated entries array (same shape as
+`GET /config`) plus `"success": true`.
 
 ## Collections
 
@@ -247,6 +304,41 @@ Delete a request.
   "id": "req_1234567890"
 }
 ```
+
+## Import
+
+### POST /import/fetch
+
+Fetch a remote collection or spec by URL, server-side, so the app can import a
+resource that browser CORS would otherwise block. The engine proxies the `GET`
+via libcurl and returns the raw body and content type.
+
+**Request:**
+```json
+{ "url": "https://example.com/collection.json" }
+```
+
+The `url` must be a string starting with `http://` or `https://`.
+
+**Response:** `200`
+```json
+{
+  "content": "...raw response body...",
+  "contentType": "application/json"
+}
+```
+
+`contentType` echoes the fetched response's `Content-Type` header, defaulting to
+`application/octet-stream` when absent. The response JSON is serialized with
+invalid UTF-8 replaced rather than throwing, so binary or malformed content can
+never turn into a `500`.
+
+**Errors:**
+- `400` `{ "error": "Invalid JSON body" }` - the request body did not parse.
+- `400` `{ "error": "Invalid URL" }` - `url` is missing, not a string, or does
+  not start with `http://` / `https://`.
+- `502` `{ "error": "Failed to fetch: <detail>" }` - the upstream request failed
+  (connection error, transport failure).
 
 ## Environments
 
@@ -943,7 +1035,7 @@ Get script engine API completions for UI autocomplete.
 | 404 | Resource not found |
 | 409 | OAuth 2.0 interactive authorization required (`/run` pre-flight, `/oauth2/token`) |
 | 500 | Internal server error |
-| 502 | OAuth 2.0 token-endpoint network error |
+| 502 | Upstream network error (OAuth 2.0 token endpoint, `/import/fetch` proxy) |
 
 ## Notes
 

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1201,10 +1201,12 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::database::SYNCHRONOUS), "integer",
     "Data Safety Mode (Requires Restart)",
     "How aggressively SQLite ensures test results are written to disk. "
-    "Options: 0 = Off (fastest, safe with WAL mode), 1 = Normal "
-    "(balanced), 2 = Full (safest, slowest). "
-    "For load testing, Off (0) is recommended - WAL mode provides "
-    "durability while maximizing write throughput for storing results. "
+    "Options: 0 = Off (fastest; the database stays consistent after a crash, "
+    "but the most recent results may be lost on power failure or OS crash - "
+    "acceptable for test telemetry), 1 = Normal (balanced), 2 = Full (safest, "
+    "slowest). "
+    "For load testing, Off (0) is recommended - it maximizes write throughput "
+    "for storing results while keeping the database uncorrupted. "
     "This setting directly impacts how fast results can be saved during "
     "high-RPS tests. Default: Off.",
     "database_performance",


### PR DESCRIPTION
## Summary

Fixes four verified documentation drifts in the engine API surface (issue #87). Docs-only plus a one-string wording change in `database.cpp`; no behavior changes.

### 1. `POST /import/fetch` documented
Added to `api-reference.md` under a new **Import** section, verified against `engine/src/http/routes/import.cpp`: request `{ "url": "http(s)://..." }`, `200 { "content", "contentType" }` (contentType defaults to `application/octet-stream`, UTF-8 replaced on dump so bad content can't 500), `400 Invalid JSON body` / `400 Invalid URL`, `502 Failed to fetch: ...`.

### 2. `POST /shutdown` documented
Added to the Health & Configuration section, verified against `engine/src/http/routes/health.cpp`: `200 { "status": "ok", "message": "Shutdown initiated" }` sent **before** shutdown, callback runs ~100ms later on a detached thread (stops runs, releases lock, flushes logs, exits). Noted as the app's graceful-quit path.

### 3. `GET /config` / `POST /config` corrected
Replaced the wrong flat-map example with the real `{ "entries": [ ... ] }` envelope, mirroring the exact field names from `config_entry_json` in `config.cpp` (`key`, `value`, `type`, `label`, `description`, `category`, `default`, `min`, `max`, `updatedAt` - note `default`/`min`/`max`, not the `defaultValue`/`minValue`/`maxValue` from the issue text). Documented `POST /config`'s batch and single body shapes, string coercion, per-key type/min/max validation, all-or-nothing behavior, and the nested `{ "error": { "code", "message" } }` failure body.

### 4. `dbSynchronous` durability claim corrected
Reworded the config entry description in `Database::seed_default_config()` so it no longer claims WAL provides durability at `synchronous=OFF`. It now states the database stays consistent after a crash but recent results may be lost on power failure - acceptable for test telemetry. `seed_default_config`'s upsert refreshes metadata on startup, so existing installs pick up the new text with no migration. The only durability prose in the repo was this one line (`rg -i durab`).

Also broadened the `502` row in the status-code table to cover the `/import/fetch` proxy.

## Verification
- Engine builds clean: `python build.py -e` (exit 0).
- No em-dashes; `docs/design-system.md` untouched; no repo-wide prettier.
- Out-of-scope items (#80's params/headers shapes, db-schema UUID wording) left alone per the issue.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ61REPECszWZ6ZKihaLoS)_