### PR TITLE
fix(engine): reject collection parent cycles; cycle-safe, atomic cascade delete

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -120,9 +120,24 @@ Create or update a collection. If `id` is provided and exists, performs an updat
 
 **Response:** The saved collection object.
 
+**Errors:** `parentId` is validated to keep the collection tree acyclic, since a
+cycle would make the cascade delete below loop forever. Both cases return `400`
+with the flat `{"error": message}` shape:
+
+- `parentId` equal to the collection's own `id` - `{"error": "A collection cannot be its own parent"}`.
+- `parentId` pointing at one of the collection's own descendants (a reparent that
+  would form a cycle) - `{"error": "Cannot move a collection into its own descendant"}`.
+
+Parent *existence* is intentionally not checked: the import orchestrator creates
+collections in bulk, so requiring the parent to exist first would couple to
+import ordering. Only self-parent and descendant cycles are rejected.
+
 ### DELETE /collections/:id
 
-Delete a collection and all its requests (cascading delete).
+Delete a collection and all its requests (cascading delete). The cascade removes
+every descendant collection and its requests in a single transaction, and
+terminates even if the stored `parent_id` tree contains a cycle (see
+[db-schema.md](db-schema.md) - collections).
 
 **Response:**
 ```json

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -36,7 +36,16 @@ Stores folder/group hierarchy for requests.
 Collections are always auth sources - they never store `{"mode":"inherit"}`.
 
 **Cascade delete**: deleting a collection performs BFS to collect all descendant IDs, then
-deletes all their requests before deleting the collections deepest-first. See `Database::delete_collection()`.
+deletes all their requests before deleting the collections deepest-first, wrapped in a single
+transaction so a crash mid-cascade cannot leave a half-deleted subtree. See
+`Database::delete_collection()`.
+
+`parent_id` forms a tree, but SQLite enforces no such constraint, so the BFS carries a visited
+set and is **cycle-safe**: a self-parent (`parent_id == id`) or an `A -> B -> A` loop terminates
+instead of growing the work list forever under the global DB mutex (which would hang every
+endpoint, including `/health`). `POST /collections` rejects the writes that would create such a
+cycle (see [api-reference.md](api-reference.md) - POST /collections), so cycles only arise from
+data written before that validation existed; the visited set is what lets deletion recover from it.
 
 ---
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -385,6 +385,7 @@ if(VAYU_BUILD_TESTS)
         tests/import_route_test.cpp
         tests/config_route_test.cpp
         tests/requests_route_test.cpp
+        tests/collections_route_test.cpp
         tests/stats_route_test.cpp
         tests/execution_timeout_test.cpp
         tests/load_strategy_test.cpp
@@ -403,6 +404,7 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/import.cpp
         src/http/routes/config.cpp
         src/http/routes/requests.cpp
+        src/http/routes/collections.cpp
         src/http/routes/metrics.cpp
         src/http/routes/oauth.cpp
         src/http/routes/oauth_authorize.cpp

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -39,6 +39,7 @@
 #include <sstream>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "vayu/core/constants.hpp"
 #include "vayu/utils/logger.hpp"
@@ -556,28 +557,46 @@ std::optional<Collection> Database::get_collection (const std::string& id) {
 }
 
 // Cascade delete: recursively removes all descendant collections and their requests.
-// BFS discovers all descendant IDs, then deletes deepest-first.
+// BFS discovers all descendant IDs, then deletes deepest-first inside a single
+// transaction.
 void Database::delete_collection (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     vayu::utils::log_debug ("Deleting collection (cascade): id=" + id);
 
-    // 1. Collect all descendant IDs via BFS (root first)
-    std::vector<std::string> to_delete = { id };
-    size_t idx                         = 0;
+    // 1. Collect all descendant IDs via BFS (root first). The visited set makes
+    //    the walk terminate even on cyclic parent_id data - a self-parent or an
+    //    A -> B -> A loop that may have been written before write-time
+    //    validation existed. Without it, `to_delete` grows forever while this
+    //    method holds the global DB mutex, hanging every endpoint including
+    //    /health until the daemon is restarted (issue #79).
+    std::vector<std::string> to_delete;
+    std::unordered_set<std::string> visited;
+    to_delete.push_back (id);
+    visited.insert (id);
+    size_t idx = 0;
     while (idx < to_delete.size ()) {
         auto children = impl_->storage.get_all<Collection> (
         where (c (&Collection::parent_id) == to_delete[idx]));
         for (const auto& child : children) {
-            to_delete.push_back (child.id);
+            if (visited.insert (child.id).second) {
+                to_delete.push_back (child.id);
+            }
         }
         ++idx;
     }
 
-    // 2. Delete deepest-first so foreign-key integrity holds at each step
-    for (auto it = to_delete.rbegin (); it != to_delete.rend (); ++it) {
-        impl_->storage.remove_all<Request> (where (c (&Request::collection_id) == *it));
-        impl_->storage.remove_all<Collection> (where (c (&Collection::id) == *it));
-    }
+    // 2. Delete deepest-first so foreign-key integrity holds at each step,
+    //    wrapped in a single transaction so a crash mid-cascade cannot leave a
+    //    half-deleted subtree. Safe under the recursive mutex already held -
+    //    the lambda only calls sqlite_orm on the same storage handle (same
+    //    pattern as add_metrics_batch).
+    impl_->storage.transaction ([&] {
+        for (auto it = to_delete.rbegin (); it != to_delete.rend (); ++it) {
+            impl_->storage.remove_all<Request> (where (c (&Request::collection_id) == *it));
+            impl_->storage.remove_all<Collection> (where (c (&Collection::id) == *it));
+        }
+        return true; // Commit
+    });
 }
 
 // ============================================================================

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -14,7 +14,66 @@
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
 namespace vayu::http::routes {
+
+/**
+ * Testable core of the parent-id validation for POST /collections, returning
+ * an error response {http_status, json_body} when the proposed parent would
+ * form a cycle in the collection tree, or std::nullopt when the assignment is
+ * legal.
+ *
+ * Two shapes are rejected, both with 400:
+ *   - Self-parent (`parentId == id`): a collection cannot be its own parent.
+ *   - Reparent into a descendant: walking the proposed parent's ancestor chain
+ *     reaches the collection being saved, so the move would make a node its own
+ *     ancestor. A cycle here is what let `delete_collection`'s BFS loop forever
+ *     under the global DB mutex, hanging every endpoint (see issue #79).
+ *
+ * The walk carries a visited set so pre-existing corrupt data (a cycle written
+ * before this validation existed) cannot hang the validator itself. A parent id
+ * that does not resolve to a stored collection ends the walk cleanly - parent
+ * *existence* is intentionally not required here, because the import
+ * orchestrator creates collections in bulk and an existence check would couple
+ * this fix to import ordering.
+ *
+ * Extracted so the wiring is covered without an in-process HTTP server - see
+ * collections_route_test.cpp. The error body matches send_error's flat
+ * `{"error": message}` shape.
+ */
+std::optional<std::pair<int, nlohmann::json>> validate_parent_assignment (
+vayu::db::Database& db, const std::string& id,
+const std::optional<std::string>& parent_id) {
+    if (!parent_id.has_value ()) {
+        return std::nullopt; // No parent -> no cycle possible.
+    }
+    if (*parent_id == id) {
+        return std::make_pair (400,
+        nlohmann::json{ { "error", "A collection cannot be its own parent" } });
+    }
+
+    std::unordered_set<std::string> visited;
+    std::optional<std::string> cursor = parent_id;
+    while (cursor.has_value ()) {
+        if (*cursor == id) {
+            return std::make_pair (400,
+            nlohmann::json{
+            { "error", "Cannot move a collection into its own descendant" } });
+        }
+        if (!visited.insert (*cursor).second) {
+            break; // Already seen -> pre-existing corrupt cycle; stop, bounded.
+        }
+        auto ancestor = db.get_collection (*cursor);
+        if (!ancestor.has_value ()) {
+            break; // Chain ends at a missing parent; existence is not required.
+        }
+        cursor = ancestor->parent_id;
+    }
+    return std::nullopt;
+}
 
 void register_collection_routes (RouteContext& ctx) {
     /**
@@ -134,6 +193,20 @@ void register_collection_routes (RouteContext& ctx) {
 
             if (is_update) {
                 c.updated_at = now_ms ();
+            }
+
+            // Reject writes that would put a cycle in the collection tree
+            // (self-parent, or reparent into a descendant) before they reach
+            // the DB - a cycle makes cascade delete loop forever under the
+            // global mutex. Cycle/self checks only; parent existence is not
+            // required (import creates collections in bulk).
+            if (auto err = validate_parent_assignment (ctx.db, c.id, c.parent_id)) {
+                vayu::utils::log_warning (
+                "POST /collections - Rejected cyclic parent for id=" + c.id + ": " +
+                (*err).second["error"].get<std::string> ());
+                res.status = (*err).first;
+                res.set_content ((*err).second.dump (), "application/json");
+                return;
             }
 
             std::string parent_id = c.parent_id.value_or ("root");

--- a/engine/tests/collections_route_test.cpp
+++ b/engine/tests/collections_route_test.cpp
@@ -1,0 +1,208 @@
+/**
+ * @file tests/collections_route_test.cpp
+ * @brief Tests for the collection-tree cycle guards (issue #79).
+ *
+ * Two layers are covered:
+ *
+ *  - Write-time validation (`validate_parent_assignment`, the extracted core of
+ *    POST /collections): a self-parent and a reparent-into-descendant are each
+ *    rejected with 400; a legal reparent and a null parent pass. Corrupt data
+ *    already in the tree must not hang the validator, so the ancestor walk is
+ *    bounded by a visited set.
+ *
+ *  - Cascade delete (`Database::delete_collection`): it must terminate and
+ *    remove every member even when the parent_id tree contains a cycle (data
+ *    that predates the validation above), and the normal nested cascade - parent
+ *    + child + their requests - must still delete cleanly. Without the visited
+ *    set the BFS loops forever under the global DB mutex, hanging every endpoint.
+ *
+ * Follows the suite's route-test convention (requests_route_test.cpp): the
+ * route's extracted core is exercised directly, no in-process HTTP server.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/db/database.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in collections.cpp; returns std::nullopt when the parent assignment
+// is legal, else {http_status, json_body} describing the 400 rejection.
+std::optional<std::pair<int, nlohmann::json>> validate_parent_assignment (
+vayu::db::Database& db, const std::string& id,
+const std::optional<std::string>& parent_id);
+} // namespace vayu::http::routes
+
+namespace {
+
+class CollectionsRouteTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_collections_route.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + s);
+        }
+    }
+
+    // Persist a collection with an optional parent. Bypasses the route so tests
+    // can build shapes (including corrupt cycles) the route would reject.
+    void seed_collection (const std::string& id, const std::string& name,
+    std::optional<std::string> parent = std::nullopt) {
+        vayu::db::Collection col;
+        col.id        = id;
+        col.name      = name;
+        col.parent_id = std::move (parent);
+        col.order     = 0;
+        db_->create_collection (col);
+    }
+
+    void seed_request (const std::string& id, const std::string& collection_id) {
+        vayu::db::Request r;
+        r.id            = id;
+        r.collection_id = collection_id;
+        r.name          = "req";
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test/";
+        r.order         = 0;
+        r.created_at    = 1;
+        r.updated_at    = 2;
+        db_->save_request (r);
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// -- Write-time validation -------------------------------------------------
+
+TEST_F (CollectionsRouteTest, NullParentIsAllowed) {
+    seed_collection ("col_a", "A");
+    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", std::nullopt);
+    EXPECT_FALSE (err.has_value ());
+}
+
+TEST_F (CollectionsRouteTest, SelfParentRejectedWith400) {
+    seed_collection ("col_a", "A");
+    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_a");
+    ASSERT_TRUE (err.has_value ());
+    EXPECT_EQ (err->first, 400);
+    EXPECT_EQ (err->second["error"], "A collection cannot be its own parent");
+}
+
+TEST_F (CollectionsRouteTest, ReparentIntoDescendantRejectedWith400) {
+    // A -> B -> C. Moving A under C would make A its own descendant's child.
+    seed_collection ("col_a", "A");
+    seed_collection ("col_b", "B", "col_a");
+    seed_collection ("col_c", "C", "col_b");
+
+    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_c");
+    ASSERT_TRUE (err.has_value ());
+    EXPECT_EQ (err->first, 400);
+    EXPECT_EQ (err->second["error"], "Cannot move a collection into its own descendant");
+}
+
+TEST_F (CollectionsRouteTest, LegalReparentSucceeds) {
+    // A -> B, and a sibling D. Moving D under B is legal (B is not a descendant
+    // of D). Validation returns nullopt.
+    seed_collection ("col_a", "A");
+    seed_collection ("col_b", "B", "col_a");
+    seed_collection ("col_d", "D");
+
+    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_d", "col_b");
+    EXPECT_FALSE (err.has_value ());
+}
+
+TEST_F (CollectionsRouteTest, MissingParentEndsWalkCleanly) {
+    // Parent existence is intentionally not required (import creates in bulk).
+    // A parent id that resolves to nothing must pass, not throw or reject.
+    seed_collection ("col_a", "A");
+    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_ghost");
+    EXPECT_FALSE (err.has_value ());
+}
+
+TEST_F (CollectionsRouteTest, PreExistingCycleDoesNotHangValidator) {
+    // Corrupt data: X -> Y -> X, written before validation existed. Validating
+    // an unrelated node whose parent chain enters the cycle must terminate
+    // (the visited set bounds the walk) rather than spin forever.
+    seed_collection ("col_x", "X", "col_y");
+    seed_collection ("col_y", "Y", "col_x");
+    seed_collection ("col_z", "Z");
+
+    auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_z", "col_x");
+    // col_z is not on the x/y cycle, so the walk simply terminates: legal.
+    EXPECT_FALSE (err.has_value ());
+}
+
+// -- Cascade delete --------------------------------------------------------
+
+TEST_F (CollectionsRouteTest, DeleteTerminatesAndClearsCycle) {
+    // Self-referential corrupt data: a collection that is its own parent. The
+    // old BFS (no visited set) would grow to_delete forever here. Deletion must
+    // terminate and remove the collection and its requests.
+    seed_collection ("col_loop", "Loop", "col_loop");
+    seed_request ("req_loop", "col_loop");
+
+    db_->delete_collection ("col_loop");
+
+    EXPECT_FALSE (db_->get_collection ("col_loop").has_value ());
+    EXPECT_FALSE (db_->get_request ("req_loop").has_value ());
+}
+
+TEST_F (CollectionsRouteTest, DeleteTerminatesOnTwoNodeCycle) {
+    // A -> B -> A cycle plus requests in each. Deleting either entry point must
+    // terminate and remove both collections and both requests.
+    seed_collection ("col_a", "A", "col_b");
+    seed_collection ("col_b", "B", "col_a");
+    seed_request ("req_a", "col_a");
+    seed_request ("req_b", "col_b");
+
+    db_->delete_collection ("col_a");
+
+    EXPECT_FALSE (db_->get_collection ("col_a").has_value ());
+    EXPECT_FALSE (db_->get_collection ("col_b").has_value ());
+    EXPECT_FALSE (db_->get_request ("req_a").has_value ());
+    EXPECT_FALSE (db_->get_request ("req_b").has_value ());
+}
+
+TEST_F (CollectionsRouteTest, NestedCascadeDeletesChildrenAndRequests) {
+    // Acyclic regression, made explicit so the transaction rewrite stays honest:
+    // parent -> child, requests in both, all gone after deleting the parent; an
+    // unrelated sibling tree is untouched.
+    seed_collection ("col_parent", "Parent");
+    seed_collection ("col_child", "Child", "col_parent");
+    seed_request ("req_parent", "col_parent");
+    seed_request ("req_child", "col_child");
+
+    seed_collection ("col_other", "Other");
+    seed_request ("req_other", "col_other");
+
+    db_->delete_collection ("col_parent");
+
+    EXPECT_FALSE (db_->get_collection ("col_parent").has_value ());
+    EXPECT_FALSE (db_->get_collection ("col_child").has_value ());
+    EXPECT_FALSE (db_->get_request ("req_parent").has_value ());
+    EXPECT_FALSE (db_->get_request ("req_child").has_value ());
+
+    // Sibling tree survives.
+    EXPECT_TRUE (db_->get_collection ("col_other").has_value ());
+    EXPECT_TRUE (db_->get_request ("req_other").has_value ());
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Fixes #79. `POST /collections` accepted any `parentId`, so a collection could be made its own parent or reparented under one of its own descendants, forming a cycle in the `collections.parent_id` tree. `Database::delete_collection` then ran a BFS with **no visited set**: on a cycle the work list grew forever while holding the global DB mutex, hanging **every** endpoint (including `/health`) until the daemon was restarted. The cascade was also **not transactional**, so a crash mid-delete could leave a half-deleted subtree.

Three layers, all engine-side (no app changes required - the app only sets `parentId` at creation and already surfaces the 400 via its mutation error toast):

1. **Validate on write.** `validate_parent_assignment` (extracted, testable core of `POST /collections`) rejects with `400`:
   - `parentId == id` - `{"error": "A collection cannot be its own parent"}`
   - reparent into a descendant (proposed parent's ancestor chain reaches the collection) - `{"error": "Cannot move a collection into its own descendant"}`

   The ancestor walk carries a visited set so pre-existing corrupt data cannot hang the validator. Parent **existence** is intentionally not checked, so bulk import ordering is unaffected.
2. **Harden the BFS.** `delete_collection` now tracks visited ids, so deletion terminates even on cyclic data written before the validation existed.
3. **Atomic cascade.** The delete loop runs inside a single `storage.transaction`, matching the `add_metrics_batch` pattern; safe under the recursive mutex already held.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -t && cd engine && ctest --preset linux-dev` - **300/300 pass**, clang-tidy clean on the touched sources.

New `engine/tests/collections_route_test.cpp` (9 tests):
- self-parent rejected `400`; reparent-into-descendant rejected `400`; legal reparent passes; null/missing parent passes; a bounded walk over a pre-existing cycle terminates.
- `delete_collection` terminates and removes members on a self-cycle and on a two-node `A -> B -> A` cycle (with requests in each).
- nested cascade regression: parent + child + their requests all deleted, an unrelated sibling tree untouched (guards the transaction rewrite).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #79

## Docs
- `docs/engine/api-reference.md`: the two new `400` responses on `POST /collections`.
- `docs/engine/db-schema.md`: cycle-safety and atomicity of the `collections` cascade delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017askMcZPDHhGs2g5sDG9An)_