### PR TITLE
feat(app): request-builder execution fixes and collections/history UX enhancements

### DIFF
--- a/app/src/components/layout/icon-button-labels.test.tsx
+++ b/app/src/components/layout/icon-button-labels.test.tsx
@@ -80,8 +80,10 @@ describe("icon-only buttons have accessible names", () => {
 
 	it("finds icon buttons to check (guards the scan itself)", () => {
 		// A renamed primitive or a broken glob would match nothing, and every
-		// assertion below would then vacuously pass.
-		expect(iconTags.length).toBeGreaterThan(10);
+		// assertion below would then vacuously pass. The floor only has to be
+		// clear of zero - kept well below the real count so removing a button
+		// (e.g. the run header's back button) does not trip the guard.
+		expect(iconTags.length).toBeGreaterThan(5);
 	});
 
 	it("names every icon-only Button", () => {

--- a/app/src/components/ui/input.tsx
+++ b/app/src/components/ui/input.tsx
@@ -15,7 +15,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				"flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"flex h-9 w-full rounded-md border border-input bg-transparent px-2 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
 				className
 			)}
 			{...props}

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -24,9 +24,6 @@ export const TIMING = {
 	/** Radix tooltip open delay used across the app. */
 	TOOLTIP_DELAY_MS: 150,
 
-	/** Delay to disambiguate single click from double click in tree items. */
-	TREE_CLICK_DELAY_MS: 80,
-
 	/** Engine health poll interval while the app is open. */
 	HEALTH_CHECK_INTERVAL_MS: 30_000,
 

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { ChevronRight, ChevronDown, Folder, Loader2 } from "lucide-react";
+import { ChevronRight, ChevronDown, Folder, FolderOpen, Loader2 } from "lucide-react";
 import RequestItem from "./RequestItem";
 import type { Collection, Request } from "@/types";
 import { compareCollectionOrder } from "@/types";
@@ -89,6 +89,8 @@ export default function CollectionItem({
 	onStartRequestRename,
 }: CollectionItemProps) {
 	const isExpanded = expandedCollectionIds.has(collection.id);
+	// Open-folder glyph while expanded, so the folder itself echoes the chevron.
+	const FolderIcon = isExpanded ? FolderOpen : Folder;
 	const isSelected = selectedCollectionId === collection.id;
 	const requests = getRequestsByCollection(collection.id);
 	const isRenaming = renamingId === collection.id;
@@ -192,7 +194,7 @@ export default function CollectionItem({
 					className="flex min-w-0 items-center gap-2 flex-1 text-left cursor-pointer"
 					disabled={isDeleting || isRenaming}
 				>
-					<Folder
+					<FolderIcon
 						className={cn(
 							"w-4 h-4 shrink-0",
 							depth === 0 ? "text-primary" : "text-primary/70"
@@ -250,6 +252,16 @@ export default function CollectionItem({
 						actions={getCollectionActions(collection)}
 					/>
 				)}
+				{/* Keyboard-only rename target: F2 clicks it (see useRovingTreeFocus).
+				    Never shown; the same action lives in the row's menu. */}
+				<button
+					type="button"
+					className="hidden"
+					aria-hidden="true"
+					tabIndex={-1}
+					data-tree-rename
+					onClick={() => onStartRename(collection)}
+				/>
 			</div>
 
 			{/* Children (Subfolders + Requests) - indented by depth */}

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { useRef, useEffect } from "react";
 import { ChevronRight, ChevronDown, Folder, Loader2 } from "lucide-react";
 import RequestItem from "./RequestItem";
 import type { Collection, Request } from "@/types";
@@ -13,7 +12,6 @@ import { compareCollectionOrder } from "@/types";
 import { Button, Input } from "@/components/ui";
 import { RowActionsMenu, TruncatedText, type RowAction } from "@/components/shared";
 import { cn } from "@/lib/utils";
-import { TIMING } from "@/config/timing";
 import { INDENT_STEP } from "@/constants/layout";
 
 export interface CollectionItemProps {
@@ -99,41 +97,19 @@ export default function CollectionItem({
 		.filter((c) => c.parentId === collection.id)
 		.sort(compareCollectionOrder);
 
-	const expandTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const CLICK_DELAY_MS = TIMING.TREE_CLICK_DELAY_MS;
-
-	useEffect(
-		() => () => {
-			if (expandTimeoutRef.current) clearTimeout(expandTimeoutRef.current);
-		},
-		[]
-	);
-
 	const handleClick = (e: React.MouseEvent) => {
 		if (isDeleting || isRenaming) return;
-		// Second click of a double-click: ignore (double-click handler will run rename only)
-		if (e.detail === 2) return;
-
-		if (expandTimeoutRef.current) {
-			clearTimeout(expandTimeoutRef.current);
-			expandTimeoutRef.current = null;
-		}
-
-		expandTimeoutRef.current = setTimeout(() => {
-			expandTimeoutRef.current = null;
-			onCollectionClick(collection);
-		}, CLICK_DELAY_MS);
+		// The second click of a double-click also fires `click`; ignore it so the
+		// double-click starts a rename. The first click already opened the
+		// collection (opening is idempotent), so there is nothing to defer - and
+		// none of the 80ms delay that made a single click to open feel laggy.
+		if (e.detail > 1) return;
+		onCollectionClick(collection);
 	};
 
 	const handleDoubleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
 		if (isDeleting || isRenaming) return;
-
-		if (expandTimeoutRef.current) {
-			clearTimeout(expandTimeoutRef.current);
-			expandTimeoutRef.current = null;
-		}
-
 		onStartRename(collection);
 	};
 

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -568,8 +568,16 @@ export default function CollectionTree() {
 		>
 			<div ref={treeRef} className="flex h-full flex-col">
 				{/* New Collection Form */}
+				{/*
+				 * px-3 pt-2 is not decorative. The DrawerPanel body scrolls
+				 * (overflow-y-auto overflow-x-hidden) and is flush so rows run edge
+				 * to edge, so it clips at its own edge - and this field's focus ring
+				 * is drawn *outside* its border box. Flush against the top-left, the
+				 * ring was clipped; the padding gives it room. Same fix the History
+				 * search field uses (see HistoryList).
+				 */}
 				{creatingCollection && (
-					<div className="flex gap-2 mb-2">
+					<div className="flex gap-2 mb-2 px-3 pt-2">
 						<Input
 							type="text"
 							value={newCollectionName}

--- a/app/src/modules/collections/RequestItem.test.tsx
+++ b/app/src/modules/collections/RequestItem.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Opening a request from the tree must be instant.
+ *
+ * The row used to defer `onSelect` behind an 80ms `setTimeout` so it could tell
+ * a single click (open) from a double click (rename). That delay was felt on
+ * every open. Opening is idempotent, so the row now opens on the first click and
+ * lets the double click rename on top of it - no timer. These lock that in: the
+ * open fires synchronously (reintroducing the debounce makes the first test
+ * fail, since no timers are advanced), the second click of a double click is
+ * ignored, and a double click still renames.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import RequestItem from "./RequestItem";
+import type { Request } from "@/types";
+
+const REQUEST: Request = {
+	id: "req_1",
+	collectionId: "col_1",
+	name: "Get user",
+	description: "",
+	method: "GET",
+	url: "https://api.test/user",
+	params: [],
+	headers: [],
+	body: { mode: "none" },
+	bodyType: "none",
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	followRedirects: true,
+	maxRedirects: 10,
+	order: 0,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function renderItem() {
+	const onSelect = vi.fn();
+	const onStartRename = vi.fn();
+	const { container } = render(
+		<RequestItem
+			request={REQUEST}
+			collectionId="col_1"
+			onSelect={onSelect}
+			onDelete={vi.fn()}
+			onStartRename={onStartRename}
+		/>
+	);
+	const target = container.querySelector("[data-tree-activate]") as HTMLElement;
+	return { onSelect, onStartRename, target };
+}
+
+describe("RequestItem opens without a click delay", () => {
+	it("opens on a single click, synchronously", () => {
+		const { onSelect, target } = renderItem();
+		fireEvent.click(target, { detail: 1 });
+		// No fake timers, nothing advanced: the open must already have fired.
+		// Reintroducing the setTimeout debounce trips this.
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect).toHaveBeenCalledWith("col_1", "req_1");
+	});
+
+	it("ignores the second click of a double click", () => {
+		const { onSelect, target } = renderItem();
+		fireEvent.click(target, { detail: 2 });
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it("starts a rename on double click", () => {
+		const { onStartRename, target } = renderItem();
+		fireEvent.doubleClick(target);
+		expect(onStartRename).toHaveBeenCalledWith(REQUEST);
+	});
+});

--- a/app/src/modules/collections/RequestItem.test.tsx
+++ b/app/src/modules/collections/RequestItem.test.tsx
@@ -59,7 +59,7 @@ function renderItem() {
 		/>
 	);
 	const target = container.querySelector("[data-tree-activate]") as HTMLElement;
-	return { onSelect, onStartRename, target };
+	return { onSelect, onStartRename, target, container };
 }
 
 describe("RequestItem opens without a click delay", () => {
@@ -81,6 +81,15 @@ describe("RequestItem opens without a click delay", () => {
 	it("starts a rename on double click", () => {
 		const { onStartRename, target } = renderItem();
 		fireEvent.doubleClick(target);
+		expect(onStartRename).toHaveBeenCalledWith(REQUEST);
+	});
+
+	// The keyboard path: useRovingTreeFocus clicks this hidden control on F2.
+	it("exposes a data-tree-rename control wired to onStartRename", () => {
+		const { onStartRename, container } = renderItem();
+		const control = container.querySelector("[data-tree-rename]") as HTMLElement;
+		expect(control).toBeTruthy();
+		fireEvent.click(control);
 		expect(onStartRename).toHaveBeenCalledWith(REQUEST);
 	});
 });

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -131,10 +131,18 @@ export default function RequestItem({
 			)}
 
 			{/*
-			 * Delete moved into the ⋯ menu, but the Delete key still targets a
-			 * data-tree-delete element (see useRovingTreeFocus). This is that
-			 * target: never shown, never announced - a keyboard path only.
+			 * Keyboard-only targets for the roving tree (see useRovingTreeFocus):
+			 * F2 clicks data-tree-rename, Delete clicks data-tree-delete. Never
+			 * shown, never announced - the same actions live in the ⋯ menu.
 			 */}
+			<button
+				type="button"
+				className="hidden"
+				aria-hidden="true"
+				tabIndex={-1}
+				data-tree-rename
+				onClick={() => onStartRename?.(request)}
+			/>
 			<button
 				type="button"
 				className="hidden"

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -5,13 +5,11 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { useRef } from "react";
 import { Loader2, Trash2, Edit2, Copy } from "lucide-react";
 import type { Request } from "@/types";
 import { Input } from "@/components/ui";
 import { RowActionsMenu, MethodBadge, TruncatedText } from "@/components/shared";
 import { cn } from "@/lib/utils";
-import { TIMING } from "@/config/timing";
 import { INDENT_STEP } from "@/constants/layout";
 
 export interface RequestItemProps {
@@ -50,38 +48,19 @@ export default function RequestItem({
 	onStartRename,
 	onDuplicate,
 }: RequestItemProps) {
-	const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-	const CLICK_DELAY_MS = TIMING.TREE_CLICK_DELAY_MS;
-
-	const handleClick = () => {
+	const handleClick = (e: React.MouseEvent) => {
 		if (isDeleting || isRenaming) return;
-
-		// Clear any existing timeout
-		if (clickTimeoutRef.current) {
-			clearTimeout(clickTimeoutRef.current);
-			clickTimeoutRef.current = null;
-			// This was a double-click, don't trigger single click
-			return;
-		}
-
-		// Set timeout for single click
-		clickTimeoutRef.current = setTimeout(() => {
-			onSelect(collectionId, request.id);
-			clickTimeoutRef.current = null;
-		}, CLICK_DELAY_MS); // 80ms delay to detect double-click
+		// The second click of a double-click also fires `click`; ignore it so the
+		// double-click starts a rename. The first click already opened the request
+		// (opening is idempotent), so there is nothing to defer - and none of the
+		// 80ms delay that made a single click to open feel laggy.
+		if (e.detail > 1) return;
+		onSelect(collectionId, request.id);
 	};
 
 	const handleDoubleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
 		if (isDeleting || isRenaming) return;
-
-		// Clear single click timeout
-		if (clickTimeoutRef.current) {
-			clearTimeout(clickTimeoutRef.current);
-			clickTimeoutRef.current = null;
-		}
-
 		onStartRename?.(request);
 	};
 

--- a/app/src/modules/collections/useRovingTreeFocus.test.tsx
+++ b/app/src/modules/collections/useRovingTreeFocus.test.tsx
@@ -10,6 +10,7 @@ const activate = vi.fn();
 const toggle = vi.fn();
 const del = vi.fn();
 const menu = vi.fn();
+const rename = vi.fn();
 
 /**
  * Mirrors the real shape: collections are treeitems with aria-expanded whose
@@ -33,6 +34,9 @@ function Tree({ expanded }: { expanded: boolean }) {
 						<button tabIndex={-1} data-tree-menu onClick={menu}>
 							menu
 						</button>
+						<button tabIndex={-1} data-tree-rename onClick={rename}>
+							rename
+						</button>
 					</div>
 					{expanded && (
 						<div>
@@ -42,6 +46,9 @@ function Tree({ expanded }: { expanded: boolean }) {
 								</button>
 								<button tabIndex={-1} data-tree-delete onClick={del}>
 									del
+								</button>
+								<button tabIndex={-1} data-tree-rename onClick={rename}>
+									rename
 								</button>
 							</div>
 							<div role="treeitem" tabIndex={-1} data-name="req-2" />
@@ -65,6 +72,7 @@ describe("useRovingTreeFocus", () => {
 		toggle.mockClear();
 		del.mockClear();
 		menu.mockClear();
+		rename.mockClear();
 	});
 
 	it("makes the tree a single tab stop", () => {
@@ -167,6 +175,19 @@ describe("useRovingTreeFocus", () => {
 		expect(menu).toHaveBeenCalledTimes(1);
 		key("ContextMenu");
 		expect(menu).toHaveBeenCalledTimes(2);
+	});
+
+	// F2 is the keyboard path to the rename control the ⋯ menu also offers.
+	it("renames the focused row with F2", () => {
+		render(<Tree expanded />);
+		byName("demo").focus();
+		key("F2");
+		expect(rename).toHaveBeenCalledTimes(1);
+
+		// Works on a leaf request row too, not only collections.
+		byName("req-1").focus();
+		key("F2");
+		expect(rename).toHaveBeenCalledTimes(2);
 	});
 
 	it("ignores arrow keys while renaming in a text field", () => {

--- a/app/src/modules/collections/useRovingTreeFocus.ts
+++ b/app/src/modules/collections/useRovingTreeFocus.ts
@@ -22,6 +22,7 @@
  *   data-tree-activate  the primary control (open the collection/request)
  *   data-tree-toggle    expand/collapse control (collections only)
  *   data-tree-menu      row actions            (Shift+F10 / Menu key)
+ *   data-tree-rename    rename control         (F2 key)
  *   data-tree-delete    delete control         (Delete key)
  *
  * Focus is deliberately separate from selection: arrows move focus without
@@ -130,6 +131,10 @@ export function useRovingTreeFocus(treeRef: RefObject<HTMLElement | null>) {
 				case " ":
 					take();
 					click("[data-tree-activate]");
+					break;
+				case "F2":
+					take();
+					click("[data-tree-rename]");
 					break;
 				case "Delete":
 					take();

--- a/app/src/modules/history/main/HistoryDetail.tsx
+++ b/app/src/modules/history/main/HistoryDetail.tsx
@@ -25,23 +25,20 @@
  * status - the things the pane below does not repeat.
  */
 
-import { History, ArrowLeft } from "lucide-react";
+import { History } from "lucide-react";
 import { useRunQuery, useRunReportQuery } from "@/queries";
-import { useTabsStore, useLayoutStore } from "@/stores";
-import { Button, Badge } from "@/components/ui";
+import { useTabsStore } from "@/stores";
+import { Badge } from "@/components/ui";
 import { EmptyState, ErrorState, DetailSkeleton } from "@/components/shared";
 import LoadTestDetail from "./LoadTestDetail";
 import DesignRunView from "./DesignRunView";
 
 export default function HistoryDetail() {
 	const { openTabs, activeTabId } = useTabsStore();
-	const { activateDrawerView } = useLayoutStore();
 
 	// Get selectedRunId from active tab
 	const activeTab = openTabs.find((t) => t.id === activeTabId);
 	const selectedRunId = activeTab?.type === "run" ? activeTab.entityId : null;
-
-	const navigateToHistory = () => activateDrawerView("history");
 
 	const {
 		data: run,
@@ -106,18 +103,14 @@ export default function HistoryDetail() {
 
 	return (
 		<div className="flex flex-col h-full bg-background">
-			{/* Header with Back Button */}
+			{/*
+			 * Run identity header. No back button: this is a tab, closed from the
+			 * tab strip, and History lives in the left nav. The old "Back to
+			 * history" only called activateDrawerView("history"), which toggled the
+			 * drawer open/closed rather than navigating anywhere.
+			 */}
 			<div className="border-b border-border bg-card px-6 py-3 shrink-0">
 				<div className="flex items-center gap-3">
-					<Button
-						variant="ghost"
-						size="icon"
-						onClick={navigateToHistory}
-						className="shrink-0"
-						aria-label="Back to history"
-					>
-						<ArrowLeft className="w-5 h-5" />
-					</Button>
 					<div className="flex-1 min-w-0 flex items-center gap-2">
 						<h1 className="text-sm font-semibold text-foreground shrink-0">
 							{isDesignRun ? "Design run" : "Load test"}
@@ -153,11 +146,7 @@ export default function HistoryDetail() {
 				{isDesignRun ? (
 					<DesignRunView run={run} />
 				) : (
-					<LoadTestDetail
-						report={report!}
-						onBack={navigateToHistory}
-						runId={selectedRunId}
-					/>
+					<LoadTestDetail report={report!} runId={selectedRunId} />
 				)}
 			</div>
 		</div>

--- a/app/src/modules/history/main/LoadTestDetail.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.tsx
@@ -24,7 +24,7 @@ import { useClientSettingsStore } from "@/stores";
 import { OverviewTab, PerformanceTab, SamplesTab } from "./components";
 import type { LoadTestDetailProps, TimeSeriesResponse } from "../types";
 
-export default function LoadTestDetail({ report, onBack: _onBack, runId }: LoadTestDetailProps) {
+export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 	const [activeTab, setActiveTab] = useState("overview");
 	const config = report.metadata?.configuration;
 

--- a/app/src/modules/history/main/components/historyDetail.characterization.test.tsx
+++ b/app/src/modules/history/main/components/historyDetail.characterization.test.tsx
@@ -73,16 +73,10 @@ function report(mode: string, cfg: Record<string, unknown>): RunReport {
 	};
 }
 
-const noop = () => {};
-
 describe("LoadTestDetail (mode-adaptive)", () => {
 	it("constant_rps", () => {
 		const { container } = renderWithClient(
-			<LoadTestDetail
-				report={report("constant_rps", { targetRps: 200 })}
-				onBack={noop}
-				runId="r"
-			/>
+			<LoadTestDetail report={report("constant_rps", { targetRps: 200 })} runId="r" />
 		);
 		expect(container.innerHTML).toMatchSnapshot();
 	});
@@ -90,7 +84,6 @@ describe("LoadTestDetail (mode-adaptive)", () => {
 		const { container } = renderWithClient(
 			<LoadTestDetail
 				report={report("constant_concurrency", { concurrency: 50 })}
-				onBack={noop}
 				runId="r"
 			/>
 		);
@@ -98,11 +91,7 @@ describe("LoadTestDetail (mode-adaptive)", () => {
 	});
 	it("iterations", () => {
 		const { container } = renderWithClient(
-			<LoadTestDetail
-				report={report("iterations", { concurrency: 20 })}
-				onBack={noop}
-				runId="r"
-			/>
+			<LoadTestDetail report={report("iterations", { concurrency: 20 })} runId="r" />
 		);
 		expect(container.innerHTML).toMatchSnapshot();
 	});
@@ -114,7 +103,6 @@ describe("LoadTestDetail (mode-adaptive)", () => {
 					startConcurrency: 1,
 					rampUpDuration: "2s",
 				})}
-				onBack={noop}
 				runId="r"
 			/>
 		);

--- a/app/src/modules/history/types.ts
+++ b/app/src/modules/history/types.ts
@@ -32,7 +32,6 @@ export interface PerformanceTabProps extends TabProps {
 
 export interface LoadTestDetailProps {
 	report: RunReport;
-	onBack: () => void;
 	runId: string;
 }
 

--- a/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Load Test button is hidden when the builder cannot start one.
+ *
+ * A detached copy of a past design run (History run view) is mounted without an
+ * `onStartLoadTest` handler, so `canStartLoadTest` is false. The button used to
+ * render anyway and do nothing on click. Dropping the `canStartLoadTest` gate in
+ * the bar makes the second case below render the button again.
+ *
+ * The method selector and URL input are stubbed - they pull in the
+ * variable-highlighting input and are not what this guards.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RequestBuilderContext } from "../../context";
+import type { RequestBuilderContextValue } from "../../types";
+import { createDefaultRequestState } from "../../utils/request-state";
+import UrlBar from "./index";
+
+vi.mock("./MethodSelector", () => ({ default: () => null }));
+vi.mock("./UrlInput", () => ({ default: () => null }));
+
+function ctx(canStartLoadTest: boolean): RequestBuilderContextValue {
+	return {
+		request: { ...createDefaultRequestState(), url: "https://example.test/x" },
+		setRequest: vi.fn(),
+		updateField: vi.fn(),
+		response: null,
+		setResponse: vi.fn(),
+		activeTab: "params",
+		setActiveTab: vi.fn(),
+		isExecuting: false,
+		isSaving: false,
+		hasUnsavedChanges: false,
+		saveStatus: "idle",
+		resolveString: (s: string) => s,
+		resolveVariables: (s: string) => s,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+		updateVariable: vi.fn(),
+		executeRequest: vi.fn(async () => {}),
+		saveRequest: vi.fn(async () => {}),
+		startLoadTest: vi.fn(),
+		canStartLoadTest,
+	};
+}
+
+function renderBar(canStartLoadTest: boolean) {
+	return render(
+		<RequestBuilderContext.Provider value={ctx(canStartLoadTest)}>
+			<UrlBar />
+		</RequestBuilderContext.Provider>
+	);
+}
+
+describe("UrlBar Load Test button visibility", () => {
+	it("shows Load Test when the builder can start one", () => {
+		renderBar(true);
+		expect(screen.getByRole("button", { name: /load test/i })).toBeTruthy();
+	});
+
+	it("hides Load Test on a detached copy that cannot start one", () => {
+		renderBar(false);
+		expect(screen.queryByRole("button", { name: /load test/i })).toBeNull();
+		// Send is still there - only the load-test affordance is gated.
+		expect(screen.getByRole("button", { name: /send/i })).toBeTruthy();
+	});
+});

--- a/app/src/modules/request-builder/components/UrlBar/index.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/index.tsx
@@ -21,7 +21,8 @@ import MethodSelector from "./MethodSelector";
 import UrlInput from "./UrlInput";
 
 export default function UrlBar() {
-	const { request, isExecuting, executeRequest, startLoadTest } = useRequestBuilderContext();
+	const { request, isExecuting, executeRequest, startLoadTest, canStartLoadTest } =
+		useRequestBuilderContext();
 	const isLoadTestRunning = useDashboardStore((s) => s.isStreaming);
 	const openTab = useTabsStore((s) => s.openTab);
 
@@ -75,24 +76,28 @@ export default function UrlBar() {
 			    not be fixed without breaking dark (which was fine at 7.40). It now
 			    mirrors the idle variant's `text-primary border-primary bg-primary/10`
 			    shape with status tokens, and measures 4.98 light / 8.36 dark. */}
-			{isLoadTestRunning ? (
-				<button
-					onClick={viewRunningTest}
-					className="h-[34px] px-3.5 rounded-md text-xs font-semibold flex items-center gap-1.5 transition-opacity shrink-0 font-[inherit] text-status-success-text border border-status-success/40 bg-status-success/10"
-				>
-					<Activity className="w-3.5 h-3.5" />
-					View running test
-				</button>
-			) : (
-				<button
-					onClick={startLoadTest}
-					disabled={!canExecute}
-					className="h-[34px] px-3.5 rounded-md text-xs font-semibold flex items-center gap-1.5 disabled:opacity-50 transition-opacity shrink-0 font-[inherit] text-primary border border-primary bg-primary/10"
-				>
-					<Zap className="w-3.5 h-3.5" />
-					Load Test
-				</button>
-			)}
+			{/* Hidden entirely when the builder cannot load test - a detached copy
+			    of a past design run has no load-test handler, so showing the button
+			    (or a disabled one) would only mislead. */}
+			{canStartLoadTest &&
+				(isLoadTestRunning ? (
+					<button
+						onClick={viewRunningTest}
+						className="h-[34px] px-3.5 rounded-md text-xs font-semibold flex items-center gap-1.5 transition-opacity shrink-0 font-[inherit] text-status-success-text border border-status-success/40 bg-status-success/10"
+					>
+						<Activity className="w-3.5 h-3.5" />
+						View running test
+					</button>
+				) : (
+					<button
+						onClick={startLoadTest}
+						disabled={!canExecute}
+						className="h-[34px] px-3.5 rounded-md text-xs font-semibold flex items-center gap-1.5 disabled:opacity-50 transition-opacity shrink-0 font-[inherit] text-primary border border-primary bg-primary/10"
+					>
+						<Zap className="w-3.5 h-3.5" />
+						Load Test
+					</button>
+				))}
 		</div>
 	);
 }

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -93,6 +93,14 @@ export default function RequestBuilderProvider({
 		collectionId: collectionId || null,
 	}));
 
+	// The id of the request currently on screen. This single provider is reused
+	// across request tabs (no per-tab key), so an execute that is still in flight
+	// when the user switches requests must be able to tell whether its result
+	// still belongs on screen. A ref, not the closure's `request`, because the
+	// running executeRequest closed over the request that was active at Send.
+	const currentRequestIdRef = useRef<string | null>(request.id ?? null);
+	currentRequestIdRef.current = request.id ?? null;
+
 	// Response state - use store for persistence across view switches
 	const { getResponse, setResponse: storeSetResponse } = useResponseStore();
 	const [response, setLocalResponse] = useState<ResponseState | null>(() => {
@@ -192,6 +200,10 @@ export default function RequestBuilderProvider({
 				collectionId: collectionId || null,
 			});
 			setHasUnsavedChanges(false);
+			// Clear any executing state carried over from the request we just left.
+			// It belongs to that request's in-flight run, not this one; without this
+			// the switched-to request shows a "Sending" spinner it never triggered.
+			setIsExecuting(false);
 
 			// Restore response from store for this request
 			const requestId = initialRequest.id;
@@ -340,20 +352,39 @@ export default function RequestBuilderProvider({
 	const executeRequest = useCallback(async () => {
 		if (!onExecute) return;
 
+		// Snapshot the request as it is at Send. If the user switches to another
+		// request before this resolves, the result must land on the request that
+		// actually ran - not on whatever is on screen when it finishes.
+		const executingRequest = request;
+		const executingId = executingRequest.id;
+
 		setIsExecuting(true);
-		setResponse(null);
+		setLocalResponse(null);
 
 		try {
-			const result = await onExecute(request);
+			const result = await onExecute(executingRequest);
 			if (result) {
-				setResponse(result);
+				// Persist under the request that ran, so returning to it shows its
+				// own response. `storeSetResponse` is keyed by id and is safe even
+				// if this provider has since moved on to another request.
+				if (executingId) storeSetResponse(executingId, result);
+				// Only touch the shared live view if that request is still on
+				// screen. The ref reflects the current request, unlike this
+				// closure's frozen `executingId`.
+				if (currentRequestIdRef.current === executingId) {
+					setLocalResponse(result);
+				}
 			}
 		} catch (error) {
 			console.error("Request execution failed:", error);
 		} finally {
-			setIsExecuting(false);
+			// Same guard: a stale finish must not clear the spinner of a different
+			// request the user has since started.
+			if (currentRequestIdRef.current === executingId) {
+				setIsExecuting(false);
+			}
 		}
-	}, [request, onExecute, setResponse]);
+	}, [request, onExecute, storeSetResponse]);
 
 	// Start load test
 	const startLoadTest = useCallback(() => {

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -99,7 +99,9 @@ export default function RequestBuilderProvider({
 	// still belongs on screen. A ref, not the closure's `request`, because the
 	// running executeRequest closed over the request that was active at Send.
 	const currentRequestIdRef = useRef<string | null>(request.id ?? null);
-	currentRequestIdRef.current = request.id ?? null;
+	useEffect(() => {
+		currentRequestIdRef.current = request.id ?? null;
+	}, [request.id]);
 
 	// Response state - use store for persistence across view switches
 	const { getResponse, setResponse: storeSetResponse } = useResponseStore();
@@ -419,6 +421,7 @@ export default function RequestBuilderProvider({
 			executeRequest,
 			saveRequest,
 			startLoadTest,
+			canStartLoadTest: !!onStartLoadTest,
 		}),
 		[
 			request,
@@ -442,6 +445,7 @@ export default function RequestBuilderProvider({
 			executeRequest,
 			saveRequest,
 			startLoadTest,
+			onStartLoadTest,
 		]
 	);
 

--- a/app/src/modules/request-builder/context/execute-request-switch.test.tsx
+++ b/app/src/modules/request-builder/context/execute-request-switch.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One `RequestBuilderProvider` is reused across request tabs (Shell renders a
+ * single `<RequestBuilder />` with no per-entity key), so an execute that is
+ * still in flight when the user switches requests must land on the request that
+ * actually ran - not on whatever is on screen when it resolves.
+ *
+ * Before the fix the shared `isExecuting` / `response` state leaked: switching
+ * mid-flight left the new request showing a "Sending" spinner it never
+ * triggered, and the slow request's body then appeared under the new request.
+ * These lock the two halves of the fix - the reset effect clears `isExecuting`
+ * on a request change, and `executeRequest` guards the shared view with the id
+ * that is on screen *now* while still persisting the result under the id that
+ * ran. Revert either half and one of these fails.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect } from "react";
+import { render, act, waitFor } from "@testing-library/react";
+import RequestBuilderProvider from "./RequestBuilderProvider";
+import { useRequestBuilderContext } from "./RequestBuilderContext";
+import { useResponseStore } from "@/stores";
+import type { RequestBuilderContextValue, RequestState, ResponseState } from "../types";
+
+// The provider is wired to variable resolution, the save manager and several
+// TanStack Query hooks. None of those are under test here, so stub them to inert
+// values - the response store stays real, because the leak we are guarding is a
+// write to it under the wrong id.
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+	}),
+	useSaveManager: () => ({ forceSave: vi.fn(), status: "idle", isSaving: false }),
+}));
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+}));
+
+function makeResponse(tag: string): ResponseState {
+	return {
+		status: 200,
+		statusText: "OK",
+		headers: {},
+		body: tag,
+		bodyType: "text",
+		size: tag.length,
+		time: 1,
+	};
+}
+
+// The latest context value, republished after each commit. Updated in an effect
+// (not during render) so it does not reassign an outer binding while rendering.
+const captured: { ctx: RequestBuilderContextValue | null } = { ctx: null };
+const ctx = () => {
+	if (!captured.ctx) throw new Error("context not captured yet");
+	return captured.ctx;
+};
+function Capture() {
+	const value = useRequestBuilderContext();
+	useEffect(() => {
+		captured.ctx = value;
+	});
+	return null;
+}
+
+function renderFor(id: string, onExecute: (r: RequestState) => Promise<ResponseState | null>) {
+	return (
+		<RequestBuilderProvider
+			initialRequest={{ id, name: id } as Partial<RequestState>}
+			onExecute={onExecute}
+		>
+			<Capture />
+		</RequestBuilderProvider>
+	);
+}
+
+/** An onExecute whose promise the test resolves by hand. */
+function deferredExecute() {
+	let resolve!: (r: ResponseState | null) => void;
+	const fn = vi.fn(() => new Promise<ResponseState | null>((r) => (resolve = r)));
+	return { fn, resolve: (r: ResponseState | null) => resolve(r) };
+}
+
+describe("execute survives a request switch without leaking", () => {
+	beforeEach(() => {
+		useResponseStore.getState().clearAll();
+	});
+
+	it("harness: a normal execute shows its own response (guards the wiring)", async () => {
+		const exec = deferredExecute();
+		render(renderFor("A", exec.fn));
+
+		await act(async () => {
+			void ctx().executeRequest();
+		});
+		expect(ctx().isExecuting).toBe(true);
+
+		const result = makeResponse("A-RESULT");
+		await act(async () => {
+			exec.resolve(result);
+		});
+		await waitFor(() => expect(ctx().response?.body).toBe("A-RESULT"));
+		expect(ctx().isExecuting).toBe(false);
+		expect(useResponseStore.getState().getResponse("A")?.body).toBe("A-RESULT");
+	});
+
+	it("finishing after switching to another request does not leak into it", async () => {
+		const exec = deferredExecute();
+		const { rerender } = render(renderFor("A", exec.fn));
+
+		// Send request A, then switch to B before it resolves.
+		await act(async () => {
+			void ctx().executeRequest();
+		});
+		expect(ctx().isExecuting).toBe(true);
+
+		rerender(renderFor("B", exec.fn));
+		// The switched-to request must not inherit A's spinner.
+		expect(ctx().isExecuting).toBe(false);
+		expect(ctx().response).toBeNull();
+
+		// A finishes now, while B is on screen.
+		const resultA = makeResponse("A-RESULT");
+		await act(async () => {
+			exec.resolve(resultA);
+		});
+		// Its result is stored under A (returning to A would show it)...
+		await waitFor(() =>
+			expect(useResponseStore.getState().getResponse("A")?.body).toBe("A-RESULT")
+		);
+		// ...but never touches B's live view or B's stored response.
+		expect(ctx().response).toBeNull();
+		expect(ctx().isExecuting).toBe(false);
+		expect(useResponseStore.getState().getResponse("B")).toBeNull();
+	});
+
+	it("finishing after switching away and back lands the response in view", async () => {
+		const exec = deferredExecute();
+		const { rerender } = render(renderFor("A", exec.fn));
+
+		await act(async () => {
+			void ctx().executeRequest();
+		});
+
+		// Leave A, then come back before it finishes.
+		rerender(renderFor("B", exec.fn));
+		rerender(renderFor("A", exec.fn));
+
+		const resultA = makeResponse("A-RESULT");
+		await act(async () => {
+			exec.resolve(resultA);
+		});
+
+		// Same instance is still in flight for A, so the result appears.
+		await waitFor(() => expect(ctx().response?.body).toBe("A-RESULT"));
+		expect(ctx().isExecuting).toBe(false);
+		expect(useResponseStore.getState().getResponse("A")?.body).toBe("A-RESULT");
+	});
+});

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -325,7 +325,14 @@ export default function RequestBuilder() {
 
 			await updateRequestMutation.mutateAsync({
 				id: fetchedRequest.id,
-				name: request.name,
+				// `name` is deliberately omitted: the builder never edits it (it is
+				// renamed from the collection sidebar), so `request.name` is only a
+				// snapshot taken when the tab opened and the reset effect keeps it
+				// keyed by id - a rename does not change the id, so the snapshot goes
+				// stale. Sending it here made this debounced auto-save clobber a
+				// sidebar rename with the old name a few seconds later. The engine
+				// does a partial update on an existing id, so omitting `name` leaves
+				// the current (renamed) value untouched.
 				description: request.description,
 				method: request.method as HttpMethod,
 				url: request.url,

--- a/app/src/modules/request-builder/save-omits-request-name.test.ts
+++ b/app/src/modules/request-builder/save-omits-request-name.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The request builder's debounced auto-save must not carry `name`.
+ *
+ * The builder never edits the name - it is renamed from the collection sidebar -
+ * so `request.name` is only a snapshot taken when the tab opened, and the reset
+ * effect keeps the builder state keyed by request id. A rename does not change
+ * the id, so that snapshot goes stale. When the save payload still included
+ * `name`, the auto-save fired a few seconds after any edit and overwrote a fresh
+ * sidebar rename with the old name. The engine does a partial update on an
+ * existing id, so omitting `name` leaves the current (renamed) value untouched.
+ *
+ * A scan, not a render, for the reason `redirect-policy-plumbing.test.ts` gives:
+ * the save lives inside a `useCallback` wired to TanStack Query, several zustand
+ * stores and the engine service, and standing that up would test the mocks. The
+ * name must still be *loaded* into the editor (it seeds `initialRequest`), so
+ * this locks both directions: read yes, write no.
+ */
+
+import { describe, it, expect } from "vitest";
+
+const sources = import.meta.glob("/src/modules/request-builder/index.tsx", {
+	query: "?raw",
+	import: "default",
+	eager: true,
+});
+
+const source = (Object.values(sources)[0] as string | undefined) ?? "";
+
+/** The object literal passed to `updateRequestMutation.mutateAsync(...)`. */
+function savePayload(src: string): string | null {
+	const start = src.indexOf("updateRequestMutation.mutateAsync(");
+	if (start === -1) return null;
+	const open = src.indexOf("{", start);
+	if (open === -1) return null;
+	let depth = 0;
+	for (let i = open; i < src.length; i++) {
+		if (src[i] === "{") depth++;
+		else if (src[i] === "}" && --depth === 0) return src.slice(open, i + 1);
+	}
+	return null;
+}
+
+describe("the request builder save omits name", () => {
+	it("found the request builder source (guards the scan itself)", () => {
+		// vitest stubs some imports to "", and a moved file would make every
+		// assertion below pass vacuously.
+		expect(source.length).toBeGreaterThan(1000);
+		expect(source).toContain("updateRequestMutation.mutateAsync");
+	});
+
+	it("still loads the name into the editor state", () => {
+		// initialRequest seeds the builder from the fetched request; the name has
+		// to round-trip in, it just must not round-trip back out on save.
+		const loads = source.match(/\bname:\s*fetchedRequest\.name\b/g) ?? [];
+		expect(loads).toHaveLength(1);
+	});
+
+	it("does not send name in the save payload", () => {
+		const payload = savePayload(source);
+		expect(payload).not.toBeNull();
+		// Right block, non-empty: these builder-owned fields are still saved.
+		expect(payload).toContain("description: request.description");
+		expect(payload).toContain("url: request.url");
+		// The regression: a `name:` key anywhere in the payload reintroduces the
+		// clobber. Reverting the fix puts `name: request.name` back and trips this.
+		expect(payload).not.toMatch(/\bname\s*:/);
+	});
+});

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -257,6 +257,13 @@ export interface RequestBuilderContextValue {
 	executeRequest: () => Promise<void>;
 	saveRequest: () => Promise<void>;
 	startLoadTest: () => void;
+	/**
+	 * Whether this builder can start a load test at all. False for a detached
+	 * copy (a past design run replayed in the builder), which is given no
+	 * `onStartLoadTest` - so the UrlBar hides the Load Test button rather than
+	 * showing one that does nothing.
+	 */
+	canStartLoadTest: boolean;
 }
 
 // Re-export from centralized types for backward compatibility


### PR DESCRIPTION
## Summary

A batch of UI fixes and enhancements found while testing, spanning the request builder (execution correctness), the collections tree (speed, focus ring, keyboard rename, icons), and the history run views (navigation, load-test affordance). The request-builder execution bugs share two root causes - a single `RequestBuilderProvider` reused across tabs with no per-tab key, and an auto-save carrying a field it does not own - and are longstanding, not regressions from the recent PRs.

## Fixes

**1. Switching tabs while a request is executing shows the previously-running request.** `isExecuting` and the in-flight request were provider-local and not tied to the request that was sent, so a mid-flight switch left the new request with a "Sending" spinner and the finished response painted onto whatever was on screen.

**2. Renaming a request in the sidebar reverts after a few seconds.** The debounced auto-save POSTed the full request including `name`, but the builder never edits the name and its reset keys on `id`, so a stale `name` snapshot clobbered a fresh rename.

**3. Slow request, then switch to another and execute it, swaps/duplicates the responses.** Same root cause as #1 - a late finish wrote its response under whichever request was on screen.

**4. Opening a request/collection from the tree felt laggy.** Every open was deferred behind an 80ms `setTimeout` used only to tell single-click (open) from double-click (rename). Opening is idempotent, so it now opens on the first click; the second click of a double-click is ignored via `e.detail`.

**5. The run header's "Back to history" button just toggled the left sidebar.** It only called `activateDrawerView("history")`, flipping the drawer rather than navigating. Removed it (a run is a tab, closed from the tab strip; History is in the left nav).

**6. The Load Test button did nothing on a historical design run.** That view is a detached copy with no `onStartLoadTest` handler. The provider now exposes `canStartLoadTest` and the UrlBar hides the button when it cannot start one - matching this view's own "hide, don't disable" rule.

**7. The New Collection input's focus ring was clipped.** The `DrawerPanel` body scrolls (`overflow-y-auto/overflow-x-hidden`) and is flush, so a ring drawn outside the input's border box was cut off at the panel edge. Padded the form wrapper (`px-3 pt-2`), the same fix the History search field uses.

## Enhancements

**8. F2 renames the focused request or collection.** The roving-focus hook clicks a hidden `data-tree-rename` control (mirroring `data-tree-delete` for Delete); each item wires it to `onStartRename`.

**9. A collection shows an open-folder icon while expanded**, echoing the chevron.

(Also includes a small Input-primitive padding tweak for alignment.)

## Tests (mutation-checked - each fails when its fix is reverted)

- `context/execute-request-switch.test.tsx` - execute against a deferred promise, switch, resolve; no leak into the new request, `isExecuting` cleared, result stored under the request that ran. (#1, #3)
- `save-omits-request-name.test.ts` - the save payload carries no `name` key while `name` still loads into the editor. (#2)
- `collections/RequestItem.test.tsx` - open fires synchronously; the second click of a double-click is ignored; double-click renames; a `data-tree-rename` control is wired to `onStartRename`. (#4, #8)
- `UrlBar/UrlBar.test.tsx` - Load Test is hidden without a handler, shown with one. (#6)
- `collections/useRovingTreeFocus.test.tsx` - F2 clicks `data-tree-rename` for both a collection and a leaf. (#8)

Full suite (1116 tests) green; `type-check` clean; lint clean on new/changed files.

## Verification

Reproduced #1-#3 and #5-#7 live before the fix and confirmed fixed after (running dev app + fetch/DOM instrumentation). #8 and #9 verified live (F2 renames a request and a collection; the open-folder icon shows on the expanded collection). #4 is covered by its mutation-checked test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
