### PR TITLE
refactor(engine,app): one trace declaration, one timing key convention

### DIFF
--- a/app/src/modules/history/main/components/SampleRequestCard.tsx
+++ b/app/src/modules/history/main/components/SampleRequestCard.tsx
@@ -130,9 +130,11 @@ export default function SampleRequestCard({
 						<UnifiedResponseViewer
 							response={{
 								body:
-									typeof sample.trace.response.body === "object"
-										? JSON.stringify(sample.trace.response.body, null, 2)
-										: sample.trace.response.body || "",
+									typeof sample.trace.response.body === "string"
+										? sample.trace.response.body
+										: sample.trace.response.body == null
+											? ""
+											: JSON.stringify(sample.trace.response.body, null, 2),
 								headers: sample.trace.response.headers || {},
 								status: sample.statusCode,
 							}}

--- a/app/src/modules/history/main/components/SamplesTab.tsx
+++ b/app/src/modules/history/main/components/SamplesTab.tsx
@@ -51,7 +51,7 @@ export default function SamplesTab({ report }: TabProps) {
 				{report.results.map((sample: SampleResult, idx: number) => (
 					<SampleRequestCard
 						key={idx}
-						sample={sample as SampleResult}
+						sample={sample}
 						index={idx}
 						isExpanded={expandedIndex === idx}
 						onToggle={() => setExpandedIndex(expandedIndex === idx ? null : idx)}

--- a/app/src/modules/history/types.ts
+++ b/app/src/modules/history/types.ts
@@ -39,7 +39,7 @@ export interface LoadTestDetailProps {
  * One sampled request/response outcome from a run report. Derived from the
  * domain type (`RunReport.results[]`) rather than restated, so a field added to
  * the engine's trace surfaces here without a hand-edit. The element type carries
- * the shared {@link RunResultTrace}, whose phase fields use the `*Ms` dialect.
+ * the shared {@link RunResultTrace} (`*Ms` phase fields, like all timing).
  */
 export type SampleResult = NonNullable<RunReport["results"]>[number];
 

--- a/app/src/modules/history/types.ts
+++ b/app/src/modules/history/types.ts
@@ -35,29 +35,13 @@ export interface LoadTestDetailProps {
 	runId: string;
 }
 
-export interface SampleResult {
-	timestamp: number;
-	statusCode: number;
-	latencyMs: number;
-	error?: string;
-	trace?: {
-		dnsMs?: number;
-		connectMs?: number;
-		tlsMs?: number;
-		firstByteMs?: number;
-		downloadMs?: number;
-		request?: {
-			method?: string;
-			url?: string;
-			headers?: Record<string, string>;
-			body?: string;
-		};
-		response?: {
-			headers?: Record<string, string>;
-			body?: any;
-		};
-	};
-}
+/**
+ * One sampled request/response outcome from a run report. Derived from the
+ * domain type (`RunReport.results[]`) rather than restated, so a field added to
+ * the engine's trace surfaces here without a hand-edit. The element type carries
+ * the shared {@link RunResultTrace}, whose phase fields use the `*Ms` dialect.
+ */
+export type SampleResult = NonNullable<RunReport["results"]>[number];
 
 /**
  * Time-series metrics response from GET /runs/:runId/metrics

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx
@@ -11,14 +11,14 @@ import ResponseTimingTab from "./ResponseTimingTab";
 import type { ResponseTiming } from "../../types";
 
 const sample: ResponseTiming = {
-	total: 1011,
-	wire: 1008,
-	queueWait: 0.2,
-	dns: 64,
-	connect: 214,
-	tls: 517,
-	firstByte: 213,
-	download: 0,
+	totalMs: 1011,
+	wireMs: 1008,
+	queueWaitMs: 0.2,
+	dnsMs: 64,
+	connectMs: 214,
+	tlsMs: 517,
+	firstByteMs: 213,
+	downloadMs: 0,
 };
 
 describe("ResponseTimingTab", () => {
@@ -59,12 +59,12 @@ describe("ResponseTimingTab", () => {
 
 	it("omits Wire and Queue when those fields are absent (restored responses)", () => {
 		const minimal: ResponseTiming = {
-			total: 42,
-			dns: 5,
-			connect: 10,
-			tls: 20,
-			firstByte: 7,
-			download: 0,
+			totalMs: 42,
+			dnsMs: 5,
+			connectMs: 10,
+			tlsMs: 20,
+			firstByteMs: 7,
+			downloadMs: 0,
 		};
 		render(<ResponseTimingTab timing={minimal} />);
 		expect(screen.queryByText("Wire")).not.toBeInTheDocument();
@@ -74,14 +74,14 @@ describe("ResponseTimingTab", () => {
 
 	it("handles all-zero phases without dividing by zero", () => {
 		const zero: ResponseTiming = {
-			total: 0,
-			wire: 0,
-			queueWait: 0,
-			dns: 0,
-			connect: 0,
-			tls: 0,
-			firstByte: 0,
-			download: 0,
+			totalMs: 0,
+			wireMs: 0,
+			queueWaitMs: 0,
+			dnsMs: 0,
+			connectMs: 0,
+			tlsMs: 0,
+			firstByteMs: 0,
+			downloadMs: 0,
 		};
 		render(<ResponseTimingTab timing={zero} />);
 		// Every phase share is 0% - at least the five legend rows render it.

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
@@ -63,35 +63,35 @@ export default function ResponseTimingTab({ timing }: ResponseTimingTabProps) {
 		{
 			key: "dns",
 			label: "DNS",
-			value: timing.dns,
+			value: timing.dnsMs,
 			color: "hsl(var(--chart-2))",
 			tip: "Hostname → IP resolution. Usually a few ms once cached; >50ms suggests slow DNS or a fresh lookup.",
 		},
 		{
 			key: "connect",
 			label: "Connect",
-			value: timing.connect,
+			value: timing.connectMs,
 			color: "hsl(var(--chart-4))",
 			tip: "TCP three-way handshake. Zero on connection reuse (HTTP keep-alive / HTTP/2).",
 		},
 		{
 			key: "tls",
 			label: "TLS",
-			value: timing.tls,
+			value: timing.tlsMs,
 			color: "hsl(var(--chart-5))",
 			tip: "SSL/TLS handshake (HTTPS only). Zero for plain HTTP and on resumed connections.",
 		},
 		{
 			key: "ttfb",
 			label: "TTFB",
-			value: timing.firstByte,
+			value: timing.firstByteMs,
 			color: "hsl(var(--primary))",
 			tip: "Time to first byte - server processing + propagation. If this dominates, the bottleneck is the server, not the network.",
 		},
 		{
 			key: "download",
 			label: "Download",
-			value: timing.download,
+			value: timing.downloadMs,
 			color: "hsl(var(--success))",
 			tip: "Response body transfer time. Large for big payloads or slow links; near-zero for small JSON.",
 		},
@@ -156,23 +156,23 @@ export default function ResponseTimingTab({ timing }: ResponseTimingTabProps) {
 
 			{/* Summary: wire vs generator-side overhead vs perceived total. */}
 			<div className="mt-3.5 pt-3 border-t border-dashed border-border flex flex-wrap items-center gap-x-5 gap-y-1.5 text-[11px]">
-				{timing.wire !== undefined && (
+				{timing.wireMs !== undefined && (
 					<TimingStat
 						label="Wire"
-						value={timing.wire}
+						value={timing.wireMs}
 						tip="libcurl transfer time - DNS + connect + TLS + send + receive."
 					/>
 				)}
-				{timing.queueWait !== undefined && (
+				{timing.queueWaitMs !== undefined && (
 					<TimingStat
 						label="Queue"
-						value={timing.queueWait}
+						value={timing.queueWaitMs}
 						tip="Generator-side overhead (perceived − wire). Near-zero for a single request; grows under load."
 					/>
 				)}
 				<TimingStat
 					label="Total"
-					value={timing.total}
+					value={timing.totalMs}
 					tip="Perceived latency: submit → completion. What the response header shows."
 					emphasized
 				/>

--- a/app/src/modules/request-builder/components/ResponseViewer/tab-strand.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/tab-strand.test.tsx
@@ -63,7 +63,7 @@ function fullResponse(): ResponseState {
 		bodyType: "json",
 		size: BODY.length,
 		time: 34,
-		timing: { total: 34, dns: 1, connect: 2, tls: 3, firstByte: 20, download: 8 },
+		timing: { totalMs: 34, dnsMs: 1, connectMs: 2, tlsMs: 3, firstByteMs: 20, downloadMs: 8 },
 		consoleLogs: ["hello from a script"],
 		testResults: [{ name: "status is 200", passed: true }],
 	};

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -19,6 +19,7 @@ import type {
 	KeyValueEntry,
 	OAuth2Config,
 	ResolvedVariable,
+	ResponseTiming,
 	ScriptPart,
 	VariableScope,
 } from "@/types";
@@ -150,26 +151,12 @@ export interface RequestState {
 // ============================================================================
 
 /**
- * Per-request timing breakdown (milliseconds). Phase fields (dns…download) are
- * sequential segments of the request; `wire` is libcurl's transfer time and
- * `queueWait` is generator-side overhead (total − wire).
- *
+ * Per-request timing breakdown. Declared once in the domain types (it is the
+ * `POST /execute` wire shape) and re-exported here for the builder's consumers.
  * Present on a live execute, and again when a response is restored from the
- * last stored design run - the engine writes the five phases into that run's
- * trace (`store_result`, engine/src/http/routes/execution.cpp). `wire` and
- * `queueWait` are the two the design-mode writer omits, so they are absent on a
- * restored response; every consumer must treat both as optional.
+ * last stored design run (`restore-response.ts`).
  */
-export interface ResponseTiming {
-	total: number;
-	wire?: number;
-	queueWait?: number;
-	dns: number;
-	connect: number;
-	tls: number;
-	firstByte: number;
-	download: number;
-}
+export type { ResponseTiming } from "@/types";
 
 /** Which stored run a response was rebuilt from, and when that run happened. */
 export interface RestoredFrom {

--- a/app/src/modules/request-builder/utils/execute-mapping.ts
+++ b/app/src/modules/request-builder/utils/execute-mapping.ts
@@ -124,7 +124,7 @@ export function responseFromExecuteResult(result: SanityResult): ResponseState {
 		body,
 		bodyRaw,
 		bodyType: bodyTypeFromContentType(result.headers),
-		time: result.timing?.total || 0,
+		time: result.timing?.totalMs || 0,
 		timing: result.timing,
 		size: result.bodySize || 0,
 		errorCode: result.errorCode,

--- a/app/src/modules/request-builder/utils/restore-response.test.ts
+++ b/app/src/modules/request-builder/utils/restore-response.test.ts
@@ -57,12 +57,12 @@ describe("responseFromRunResult", () => {
 		// The regression: this was undefined, which hides the whole Timing tab.
 		expect(restored?.timing).toBeDefined();
 		expect(restored?.timing).toEqual({
-			total: 254.5,
-			dns: 4.2,
-			connect: 21.7,
-			tls: 63.1,
-			firstByte: 160.4,
-			download: 5.1,
+			totalMs: 254.5,
+			dnsMs: 4.2,
+			connectMs: 21.7,
+			tlsMs: 63.1,
+			firstByteMs: 160.4,
+			downloadMs: 5.1,
 		});
 	});
 
@@ -161,7 +161,7 @@ describe("a run that failed before reaching the server", () => {
 		const restored = responseFromRunResult(failed);
 
 		expect(restored?.rawRequest).toContain("GET / HTTP/1.1");
-		expect(restored?.timing?.dns).toBe(12);
+		expect(restored?.timing?.dnsMs).toBe(12);
 	});
 
 	it("falls back to the result's own error text", () => {
@@ -183,20 +183,20 @@ describe("timingFromTrace", () => {
 		const timing = timingFromTrace({ dnsMs: 0.4, firstByteMs: 88.2, downloadMs: 1.1 }, 90.3);
 
 		expect(timing).toEqual({
-			total: 90.3,
-			dns: 0.4,
-			connect: 0,
-			tls: 0,
-			firstByte: 88.2,
-			download: 1.1,
+			totalMs: 90.3,
+			dnsMs: 0.4,
+			connectMs: 0,
+			tlsMs: 0,
+			firstByteMs: 88.2,
+			downloadMs: 1.1,
 		});
 	});
 
-	it("leaves wire and queueWait unset - the design-mode writer omits them", () => {
+	it("leaves wireMs and queueWaitMs unset - the design-mode writer omits them", () => {
 		const timing = timingFromTrace({ firstByteMs: 12 }, 14);
 
-		expect(timing).not.toHaveProperty("wire");
-		expect(timing).not.toHaveProperty("queueWait");
+		expect(timing).not.toHaveProperty("wireMs");
+		expect(timing).not.toHaveProperty("queueWaitMs");
 	});
 
 	it("is undefined when no phase was stored, so no empty Timing tab appears", () => {
@@ -205,6 +205,6 @@ describe("timingFromTrace", () => {
 	});
 
 	it("falls back to the trace total when the result carries no latency", () => {
-		expect(timingFromTrace({ totalMs: 77, firstByteMs: 70 }, undefined)?.total).toBe(77);
+		expect(timingFromTrace({ totalMs: 77, firstByteMs: 70 }, undefined)?.totalMs).toBe(77);
 	});
 });

--- a/app/src/modules/request-builder/utils/restore-response.test.ts
+++ b/app/src/modules/request-builder/utils/restore-response.test.ts
@@ -178,8 +178,8 @@ describe("a run that failed before reaching the server", () => {
 });
 
 describe("timingFromTrace", () => {
-	it("treats an omitted phase as zero - the engine only writes non-zero phases", () => {
-		// Reused connection: no TCP handshake, no TLS, so neither key is written.
+	it("treats an omitted phase as zero - older engines only wrote non-zero phases", () => {
+		// Reused connection: no TCP handshake, no TLS, so neither key was written.
 		const timing = timingFromTrace({ dnsMs: 0.4, firstByteMs: 88.2, downloadMs: 1.1 }, 90.3);
 
 		expect(timing).toEqual({
@@ -192,7 +192,28 @@ describe("timingFromTrace", () => {
 		});
 	});
 
-	it("leaves wireMs and queueWaitMs unset - the design-mode writer omits them", () => {
+	it("passes wireMs and queueWaitMs through when the trace stored them", () => {
+		// The current design-mode writer stores all eight keys (store_result,
+		// execution.cpp), so a restored Timing tab shows Wire and Queue too.
+		const timing = timingFromTrace(
+			{
+				totalMs: 90.3,
+				wireMs: 89.9,
+				queueWaitMs: 0.4,
+				dnsMs: 0.4,
+				connectMs: 0,
+				tlsMs: 0,
+				firstByteMs: 88.2,
+				downloadMs: 1.1,
+			},
+			90.3
+		);
+
+		expect(timing?.wireMs).toBe(89.9);
+		expect(timing?.queueWaitMs).toBe(0.4);
+	});
+
+	it("leaves wireMs and queueWaitMs unset on rows older engines wrote without them", () => {
 		const timing = timingFromTrace({ firstByteMs: 12 }, 14);
 
 		expect(timing).not.toHaveProperty("wireMs");

--- a/app/src/modules/request-builder/utils/restore-response.ts
+++ b/app/src/modules/request-builder/utils/restore-response.ts
@@ -28,11 +28,12 @@ export type RunResultSample = NonNullable<RunReport["results"]>[number];
 /**
  * Rebuild the timing breakdown from a stored trace. The stored trace and the
  * live `/execute` response share one key convention (`dnsMs`…`downloadMs`), so
- * no renaming happens here - only defaulting: the engine writes each phase
- * only when it is non-zero (a reused connection has no `connectMs`/`tlsMs`),
- * so a missing phase means zero, not unknown. `wireMs`/`queueWaitMs` are
- * deliberately absent: the design-mode writer records the five phases and
- * `latency_ms` only, and the Timing tab already treats both as optional.
+ * no renaming happens here - only defaulting for rows written by older
+ * engines, which omitted zero-valued phases (a reused connection stored no
+ * `connectMs`/`tlsMs`) and never stored `wireMs`/`queueWaitMs`. The current
+ * writer stores all eight keys, so on fresh rows the restored Timing tab shows
+ * exactly what the live one did, Wire and Queue included; on old rows a
+ * missing phase means zero and Wire/Queue stay absent.
  *
  * Returns `undefined` when the trace carries no phase at all, so the caller
  * does not surface a Timing tab that would render an all-zero timeline.
@@ -46,6 +47,8 @@ export function timingFromTrace(
 
 	return {
 		totalMs: latencyMs ?? trace.totalMs ?? 0,
+		...(typeof trace.wireMs === "number" && { wireMs: trace.wireMs }),
+		...(typeof trace.queueWaitMs === "number" && { queueWaitMs: trace.queueWaitMs }),
 		dnsMs: trace.dnsMs ?? 0,
 		connectMs: trace.connectMs ?? 0,
 		tlsMs: trace.tlsMs ?? 0,

--- a/app/src/modules/request-builder/utils/restore-response.ts
+++ b/app/src/modules/request-builder/utils/restore-response.ts
@@ -26,13 +26,13 @@ import { buildRawRequest } from "@/components/shared/response-viewer";
 export type RunResultSample = NonNullable<RunReport["results"]>[number];
 
 /**
- * Rebuild the timing breakdown from a stored trace.
- *
- * The engine writes each phase only when it is non-zero (a reused connection
- * has no `connectMs`/`tlsMs`), so a missing phase means zero, not unknown.
- * `wire`/`queueWait` are deliberately absent: the design-mode writer records
- * the five phases and `latency_ms` only, and the Timing tab already treats
- * both as optional.
+ * Rebuild the timing breakdown from a stored trace. The stored trace and the
+ * live `/execute` response share one key convention (`dnsMs`…`downloadMs`), so
+ * no renaming happens here - only defaulting: the engine writes each phase
+ * only when it is non-zero (a reused connection has no `connectMs`/`tlsMs`),
+ * so a missing phase means zero, not unknown. `wireMs`/`queueWaitMs` are
+ * deliberately absent: the design-mode writer records the five phases and
+ * `latency_ms` only, and the Timing tab already treats both as optional.
  *
  * Returns `undefined` when the trace carries no phase at all, so the caller
  * does not surface a Timing tab that would render an all-zero timeline.
@@ -45,12 +45,12 @@ export function timingFromTrace(
 	if (!phases.some((v) => typeof v === "number")) return undefined;
 
 	return {
-		total: latencyMs ?? trace.totalMs ?? 0,
-		dns: trace.dnsMs ?? 0,
-		connect: trace.connectMs ?? 0,
-		tls: trace.tlsMs ?? 0,
-		firstByte: trace.firstByteMs ?? 0,
-		download: trace.downloadMs ?? 0,
+		totalMs: latencyMs ?? trace.totalMs ?? 0,
+		dnsMs: trace.dnsMs ?? 0,
+		connectMs: trace.connectMs ?? 0,
+		tlsMs: trace.tlsMs ?? 0,
+		firstByteMs: trace.firstByteMs ?? 0,
+		downloadMs: trace.downloadMs ?? 0,
 	};
 }
 

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -252,6 +252,10 @@ export interface RunConfigSnapshot {
  */
 export interface RunResultTrace {
 	totalMs?: number;
+	/** libcurl's transfer time; `queueWaitMs` is generator-side overhead. Both
+	 * writers store them now, but rows persisted by older engines lack them. */
+	wireMs?: number;
+	queueWaitMs?: number;
 	dnsMs?: number;
 	connectMs?: number;
 	tlsMs?: number;
@@ -340,8 +344,8 @@ export interface LoadTestConfig {
  * The field names are the engine's wire keys - the same `*Ms` convention the
  * stored trace ({@link RunResultTrace}) uses, so a live response and one
  * restored from a stored design run agree without renaming. `wireMs` /
- * `queueWaitMs` are the two the design-mode writer omits, so they are absent
- * on a restored response; every consumer must treat both as optional.
+ * `queueWaitMs` stay optional because traces stored by older engines omitted
+ * them (current ones store all eight); consumers must treat both as optional.
  */
 export interface ResponseTiming {
 	totalMs: number;

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -331,6 +331,29 @@ export interface LoadTestConfig {
 	max_in_flight?: number;
 }
 
+/**
+ * Per-request timing breakdown (milliseconds), as `POST /execute` returns it
+ * (`serialize(Response)`, engine/src/utils/json.cpp). Phase fields
+ * (dns…download) are sequential segments of the request; `wireMs` is libcurl's
+ * transfer time and `queueWaitMs` is generator-side overhead (total − wire).
+ *
+ * The field names are the engine's wire keys - the same `*Ms` convention the
+ * stored trace ({@link RunResultTrace}) uses, so a live response and one
+ * restored from a stored design run agree without renaming. `wireMs` /
+ * `queueWaitMs` are the two the design-mode writer omits, so they are absent
+ * on a restored response; every consumer must treat both as optional.
+ */
+export interface ResponseTiming {
+	totalMs: number;
+	wireMs?: number;
+	queueWaitMs?: number;
+	dnsMs: number;
+	connectMs: number;
+	tlsMs: number;
+	firstByteMs: number;
+	downloadMs: number;
+}
+
 export interface HttpResponse {
 	status: number;
 	statusText: string;
@@ -340,16 +363,7 @@ export interface HttpResponse {
 	body: unknown;
 	bodyRaw: string;
 	bodySize: number;
-	timing: {
-		total: number;
-		wire?: number;
-		queueWait?: number;
-		dns: number;
-		connect: number;
-		tls: number;
-		firstByte: number;
-		download: number;
-	};
+	timing: ResponseTiming;
 	errorCode?: string;
 	errorMessage?: string;
 }

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -623,23 +623,25 @@ the request was configured with.
 **Response:**
 ```json
 {
-  "runId": "run_1234567890",
-  "statusCode": 200,
+  "status": 200,
   "statusText": "OK",
   "headers": {
     "content-type": "application/json"
   },
-  "body": "{\"id\":1,\"name\":\"John\"}",
+  "requestHeaders": { "accept": "*/*" },
+  "rawRequest": "GET /users HTTP/1.1\n...",
+  "body": { "id": 1, "name": "John" },
+  "bodyRaw": "{\"id\":1,\"name\":\"John\"}",
   "bodySize": 20,
   "timing": {
-    "total": 245.5,
-    "wire": 245.1,
-    "queueWait": 0.4,
-    "dns": 5.2,
-    "connect": 12.3,
-    "tls": 45.1,
-    "firstByte": 180.2,
-    "download": 2.7
+    "totalMs": 245.5,
+    "wireMs": 245.1,
+    "queueWaitMs": 0.4,
+    "dnsMs": 5.2,
+    "connectMs": 12.3,
+    "tlsMs": 45.1,
+    "firstByteMs": 180.2,
+    "downloadMs": 2.7
   },
   "testResults": [
     {
@@ -651,16 +653,15 @@ the request was configured with.
 }
 ```
 
-**Two timing dialects, on purpose.** The synchronous `/execute` response above
-names the phases **without** the `Ms` suffix (`firstByte`, `dns`, `download`,
-…; `serialize(Response)` in `engine/src/utils/json.cpp`). The **stored** trace
-for the same exchange - written to the run's `results` row by `store_result`
-(design mode) and `load_strategy` (load mode), and returned inside
-`GET /runs/:runId/report` `results[].trace` - names them **with** the suffix
-(`firstByteMs`, `dnsMs`, `downloadMs`, …). The renderer consumes the first
-directly (`ResponseTiming`) and adapts the second at one boundary when it
-restores a design run (`restore-response.ts`). The two dialects are the wire
-contract; do not "fix" one to match the other without updating that adapter.
+**One timing convention.** The `timing` keys above are the same `*Ms` names the
+stored trace uses (`store_result` / `load_strategy` → `results[].trace` in
+`GET /runs/:runId/report`), so a live response and a restored one need no
+renaming. The two shapes still differ in *coverage*, not naming: the live
+response always carries all eight fields, while the stored trace omits
+zero-valued phases and never records `wireMs`/`queueWaitMs` (see
+[db-schema.md](db-schema.md)). Earlier releases named the live response's keys
+without the suffix (`firstByte`, `dns`, …); consumers of the raw `/execute`
+body written against that dialect must switch to the `*Ms` names.
 
 ### POST /runs
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -632,14 +632,14 @@ the request was configured with.
   "body": "{\"id\":1,\"name\":\"John\"}",
   "bodySize": 20,
   "timing": {
-    "totalMs": 245.5,
-    "wireMs": 245.1,
-    "queueWaitMs": 0.4,
-    "dnsMs": 5.2,
-    "connectMs": 12.3,
-    "tlsMs": 45.1,
-    "firstByteMs": 180.2,
-    "downloadMs": 2.7
+    "total": 245.5,
+    "wire": 245.1,
+    "queueWait": 0.4,
+    "dns": 5.2,
+    "connect": 12.3,
+    "tls": 45.1,
+    "firstByte": 180.2,
+    "download": 2.7
   },
   "testResults": [
     {
@@ -650,6 +650,17 @@ the request was configured with.
   "consoleLogs": []
 }
 ```
+
+**Two timing dialects, on purpose.** The synchronous `/execute` response above
+names the phases **without** the `Ms` suffix (`firstByte`, `dns`, `download`,
+…; `serialize(Response)` in `engine/src/utils/json.cpp`). The **stored** trace
+for the same exchange - written to the run's `results` row by `store_result`
+(design mode) and `load_strategy` (load mode), and returned inside
+`GET /runs/:runId/report` `results[].trace` - names them **with** the suffix
+(`firstByteMs`, `dnsMs`, `downloadMs`, …). The renderer consumes the first
+directly (`ResponseTiming`) and adapts the second at one boundary when it
+restores a design run (`restore-response.ts`). The two dialects are the wire
+contract; do not "fix" one to match the other without updating that adapter.
 
 ### POST /runs
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -655,12 +655,13 @@ the request was configured with.
 
 **One timing convention.** The `timing` keys above are the same `*Ms` names the
 stored trace uses (`store_result` / `load_strategy` → `results[].trace` in
-`GET /runs/:runId/report`), so a live response and a restored one need no
-renaming. The two shapes still differ in *coverage*, not naming: the live
-response always carries all eight fields, while the stored trace omits
-zero-valued phases and never records `wireMs`/`queueWaitMs` (see
-[db-schema.md](db-schema.md)). Earlier releases named the live response's keys
-without the suffix (`firstByte`, `dns`, …); consumers of the raw `/execute`
+`GET /runs/:runId/report`), and the design-mode writer stores all eight keys
+unconditionally - so a live response and one restored from the stored trace
+carry the same fields with the same names, Wire/Queue included. Traces written
+by earlier releases differ two ways, and readers must tolerate both: stored
+rows omitted zero-valued phases and all of `totalMs`/`wireMs`/`queueWaitMs`
+(see [db-schema.md](db-schema.md)), and the live response named its keys
+without the suffix (`firstByte`, `dns`, …) - consumers of the raw `/execute`
 body written against that dialect must switch to the `*Ms` names.
 
 ### POST /runs

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -270,7 +270,7 @@ than assuming all eight are there and flat:
 |--------|----------------------------|
 | Load run, success sample (`load_strategy.cpp`) | timing only, flat, all eight keys - and only when `save_timing_breakdown` is on or the sample crossed `slow_threshold_ms` (which also adds `isSlow` / `thresholdMs`) |
 | Load run, error (`load_strategy.cpp`) | an error envelope (`error_type`, `message`, `request_number`) with the eight keys **nested under `timing`**, present whenever `totalMs > 0` |
-| Design mode (`store_result` in `execution.cpp`) | the five phase keys flat (`dnsMs`…`downloadMs`), **each only when non-zero** - a reused connection writes no `connectMs`/`tlsMs`. No `totalMs`/`wireMs`/`queueWaitMs`; perceived total lives in the `latency_ms` column. Written on **every** single request, alongside a nested `request` object plus either `response` (success) or `error_type` / `error_message` (failure). |
+| Design mode (`store_result` in `execution.cpp`) | all eight keys flat, unconditionally - the same set the live `/execute` response carries, so a restored response shows exactly what the live one did (a skipped phase is stored as `0`). Written on **every** single request, alongside a nested `request` object plus either `response` (success) or `error_type` / `error_message` (failure). Rows written by older engines omitted zero-valued phases and all of `totalMs`/`wireMs`/`queueWaitMs`, so readers must default missing keys (perceived total also lives in the `latency_ms` column). |
 
 That design-mode subset is what rebuilds the request builder's response pane (Timing tab included)
 after a restart - see `app/src/modules/request-builder/utils/restore-response.ts`.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -384,6 +384,7 @@ if(VAYU_BUILD_TESTS)
         tests/rate_limit_test.cpp
         tests/metrics_helper_test.cpp
         tests/metrics_collector_test.cpp
+        tests/execution_trace_test.cpp
         tests/import_route_test.cpp
         tests/config_route_test.cpp
         tests/requests_route_test.cpp

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -156,12 +156,12 @@ vayu::Response parse_daemon_response (const std::string& json_str) {
 
     if (json.contains ("timing")) {
         const auto& t                 = json["timing"];
-        response.timing.total_ms      = t.value ("total", 0.0);
-        response.timing.dns_ms        = t.value ("dns", 0.0);
-        response.timing.connect_ms    = t.value ("connect", 0.0);
-        response.timing.tls_ms        = t.value ("tls", 0.0);
-        response.timing.first_byte_ms = t.value ("firstByte", 0.0);
-        response.timing.download_ms   = t.value ("download", 0.0);
+        response.timing.total_ms      = t.value ("totalMs", 0.0);
+        response.timing.dns_ms        = t.value ("dnsMs", 0.0);
+        response.timing.connect_ms    = t.value ("connectMs", 0.0);
+        response.timing.tls_ms        = t.value ("tlsMs", 0.0);
+        response.timing.first_byte_ms = t.value ("firstByteMs", 0.0);
+        response.timing.download_ms   = t.value ("downloadMs", 0.0);
     }
 
     return response;

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -235,18 +235,21 @@ const vayu::Response& response) {
             trace["error_message"] = response.error_message;
         }
 
-        // Timing information
-        const auto& timing = response.timing;
-        if (timing.dns_ms > 0)
-            trace["dnsMs"] = timing.dns_ms;
-        if (timing.connect_ms > 0)
-            trace["connectMs"] = timing.connect_ms;
-        if (timing.tls_ms > 0)
-            trace["tlsMs"] = timing.tls_ms;
-        if (timing.first_byte_ms > 0)
-            trace["firstByteMs"] = timing.first_byte_ms;
-        if (timing.download_ms > 0)
-            trace["downloadMs"] = timing.download_ms;
+        // Timing information - all eight keys, unconditionally, so the stored
+        // trace matches the live /execute response and the load-mode success
+        // writer (load_strategy.cpp) key for key. A skipped phase (reused
+        // connection, plain HTTP) is stored as 0, exactly as the live response
+        // reports it. Rows written before this change omitted zero phases and
+        // the three totals, so readers must keep defaulting missing keys.
+        const auto& timing   = response.timing;
+        trace["totalMs"]     = timing.total_ms;
+        trace["wireMs"]      = timing.wire_ms;
+        trace["queueWaitMs"] = timing.queue_wait_ms;
+        trace["dnsMs"]       = timing.dns_ms;
+        trace["connectMs"]   = timing.connect_ms;
+        trace["tlsMs"]       = timing.tls_ms;
+        trace["firstByteMs"] = timing.first_byte_ms;
+        trace["downloadMs"]  = timing.download_ms;
 
         db_result.trace_data = trace.dump ();
         db.add_result (db_result);

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -42,6 +42,47 @@ int resolve_request_timeout_ms (const nlohmann::json& json, int configured_defau
     return configured_default;
 }
 
+// Build the trace_data JSON a design run persists for its single exchange.
+// Non-static (tested by execution_trace_test.cpp): the stored trace is a
+// contract - restore-response.ts rebuilds the response pane from it after a
+// restart, so what lands here decides what a restored tab can show.
+//
+// Timing carries all eight keys, unconditionally, the same `*Ms` set the live
+// /execute response serializes (json.cpp) and the load-mode success writer
+// stores (load_strategy.cpp). A skipped phase (reused connection, plain HTTP)
+// is stored as 0, exactly as the live response reports it. Rows written before
+// this change omitted zero phases and the three totals, so readers must keep
+// defaulting missing keys.
+nlohmann::json build_result_trace (const vayu::Request& request,
+const vayu::Response& response) {
+    nlohmann::json trace;
+    trace["request"] = { { "method", to_string (request.method) },
+        { "url", request.url }, { "headers", request.headers } };
+    if (!request.body.content.empty ()) {
+        trace["request"]["body"] = request.body.content;
+    }
+
+    if (!response.has_error ()) {
+        trace["response"] = { { "headers", response.headers },
+            { "body", response.body } };
+    } else {
+        trace["error_type"]    = to_string (response.error_code);
+        trace["error_message"] = response.error_message;
+    }
+
+    const auto& timing   = response.timing;
+    trace["totalMs"]     = timing.total_ms;
+    trace["wireMs"]      = timing.wire_ms;
+    trace["queueWaitMs"] = timing.queue_wait_ms;
+    trace["dnsMs"]       = timing.dns_ms;
+    trace["connectMs"]   = timing.connect_ms;
+    trace["tlsMs"]       = timing.tls_ms;
+    trace["firstByteMs"] = timing.first_byte_ms;
+    trace["downloadMs"]  = timing.download_ms;
+
+    return trace;
+}
+
 namespace {
 
 // Helper function to parse variables JSON string to Environment
@@ -219,39 +260,7 @@ const vayu::Response& response) {
         db_result.latency_ms  = response.timing.total_ms;
         db_result.error       = has_error ? response.error_message : "";
 
-        // Build trace data
-        nlohmann::json trace;
-        trace["request"] = { { "method", to_string (request.method) },
-            { "url", request.url }, { "headers", request.headers } };
-        if (!request.body.content.empty ()) {
-            trace["request"]["body"] = request.body.content;
-        }
-
-        if (!has_error) {
-            trace["response"] = { { "headers", response.headers },
-                { "body", response.body } };
-        } else {
-            trace["error_type"]    = to_string (response.error_code);
-            trace["error_message"] = response.error_message;
-        }
-
-        // Timing information - all eight keys, unconditionally, so the stored
-        // trace matches the live /execute response and the load-mode success
-        // writer (load_strategy.cpp) key for key. A skipped phase (reused
-        // connection, plain HTTP) is stored as 0, exactly as the live response
-        // reports it. Rows written before this change omitted zero phases and
-        // the three totals, so readers must keep defaulting missing keys.
-        const auto& timing   = response.timing;
-        trace["totalMs"]     = timing.total_ms;
-        trace["wireMs"]      = timing.wire_ms;
-        trace["queueWaitMs"] = timing.queue_wait_ms;
-        trace["dnsMs"]       = timing.dns_ms;
-        trace["connectMs"]   = timing.connect_ms;
-        trace["tlsMs"]       = timing.tls_ms;
-        trace["firstByteMs"] = timing.first_byte_ms;
-        trace["downloadMs"]  = timing.download_ms;
-
-        db_result.trace_data = trace.dump ();
+        db_result.trace_data = build_result_trace (request, response).dump ();
         db.add_result (db_result);
 
         auto status = has_error ? vayu::RunStatus::Failed : vayu::RunStatus::Completed;

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -414,17 +414,18 @@ Json serialize (const Response& response) {
         json["errorMessage"] = response.error_message;
     }
 
-    // Timing
+    // Timing. Same `*Ms` key convention as the stored trace (store_result /
+    // load_strategy), so the live response and a restored one need no renaming.
     Json timing;
-    timing["total"]      = response.timing.total_ms;
-    timing["wire"]       = response.timing.wire_ms;
-    timing["queueWait"]  = response.timing.queue_wait_ms;
-    timing["dns"]        = response.timing.dns_ms;
-    timing["connect"]    = response.timing.connect_ms;
-    timing["tls"]        = response.timing.tls_ms;
-    timing["firstByte"]  = response.timing.first_byte_ms;
-    timing["download"]   = response.timing.download_ms;
-    json["timing"]       = timing;
+    timing["totalMs"]     = response.timing.total_ms;
+    timing["wireMs"]      = response.timing.wire_ms;
+    timing["queueWaitMs"] = response.timing.queue_wait_ms;
+    timing["dnsMs"]       = response.timing.dns_ms;
+    timing["connectMs"]   = response.timing.connect_ms;
+    timing["tlsMs"]       = response.timing.tls_ms;
+    timing["firstByteMs"] = response.timing.first_byte_ms;
+    timing["downloadMs"]  = response.timing.download_ms;
+    json["timing"]        = timing;
 
     return json;
 }

--- a/engine/tests/execution_trace_test.cpp
+++ b/engine/tests/execution_trace_test.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Atharva Kusumbia
+// Licensed under AGPL-3.0; see LICENSE in the engine directory.
+//
+// The stored design-run trace is a contract: restore-response.ts rebuilds a
+// request tab's response pane from it after a restart, so whatever
+// build_result_trace omits, the restored Timing tab silently loses. That is
+// exactly what happened with wireMs/queueWaitMs (never stored) and zero-valued
+// phases (stored only when > 0) - the live Timing tab showed Wire and Queue,
+// the restored one didn't.
+//
+// These tests pin the fixed contract two ways: every timing key is stored,
+// including zeros, and - the invariant that keeps the two writers from
+// drifting again - the stored key set matches what serialize(Response) puts
+// on the live /execute wire, key for key.
+//
+// Covers vayu::http::routes::build_result_trace (the trace builder) in
+// isolation, not the POST /execute route handler - the suite has no
+// in-process HTTP route tests (see run_route_test.cpp).
+
+#include "vayu/types.hpp"
+#include "vayu/utils/json.hpp"
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace vayu::http::routes {
+// Declared in execution.cpp.
+nlohmann::json build_result_trace (const vayu::Request& request,
+const vayu::Response& response);
+} // namespace vayu::http::routes
+
+namespace {
+
+using vayu::http::routes::build_result_trace;
+
+vayu::Request make_request () {
+    vayu::Request request;
+    request.method            = vayu::HttpMethod::GET;
+    request.url               = "http://127.0.0.1/health";
+    request.headers["accept"] = "application/json";
+    return request;
+}
+
+// A keep-alive reuse over plain HTTP: dns/connect/tls all legitimately 0.
+vayu::Response make_response () {
+    vayu::Response response;
+    response.status_code          = 200;
+    response.status_text          = "OK";
+    response.body                 = R"({"ok":true})";
+    response.headers["server"]    = "mock";
+    response.timing.total_ms      = 12.5;
+    response.timing.wire_ms       = 12.1;
+    response.timing.queue_wait_ms = 0.4;
+    response.timing.dns_ms        = 0.0;
+    response.timing.connect_ms    = 0.0;
+    response.timing.tls_ms        = 0.0;
+    response.timing.first_byte_ms = 11.0;
+    response.timing.download_ms   = 1.1;
+    return response;
+}
+
+TEST (ExecutionTrace, StoresAllTimingKeysIncludingZeroPhases) {
+    auto trace = build_result_trace (make_request (), make_response ());
+
+    // Zero does not mean omitted: a reused plain-HTTP connection stores
+    // dns/connect/tls as 0, exactly as the live response reports them.
+    EXPECT_DOUBLE_EQ (trace["totalMs"], 12.5);
+    EXPECT_DOUBLE_EQ (trace["wireMs"], 12.1);
+    EXPECT_DOUBLE_EQ (trace["queueWaitMs"], 0.4);
+    EXPECT_DOUBLE_EQ (trace["dnsMs"], 0.0);
+    EXPECT_DOUBLE_EQ (trace["connectMs"], 0.0);
+    EXPECT_DOUBLE_EQ (trace["tlsMs"], 0.0);
+    EXPECT_DOUBLE_EQ (trace["firstByteMs"], 11.0);
+    EXPECT_DOUBLE_EQ (trace["downloadMs"], 1.1);
+}
+
+TEST (ExecutionTrace, StoredTimingKeysMatchTheLiveWireKeys) {
+    // The invariant behind "restored shows what live showed": every timing
+    // key the live /execute response carries is also persisted. Add a ninth
+    // field to serialize(Response) without storing it and this fails.
+    auto response = make_response ();
+    auto trace    = build_result_trace (make_request (), response);
+    auto live     = vayu::json::serialize (response)["timing"];
+
+    ASSERT_FALSE (live.empty ());
+    for (const auto& [key, value] : live.items ()) {
+        EXPECT_TRUE (trace.contains (key)) << "live timing key not stored: " << key;
+        EXPECT_DOUBLE_EQ (trace[key].get<double> (), value.get<double> ())
+        << "stored value diverges from live for: " << key;
+    }
+}
+
+TEST (ExecutionTrace, SuccessNestsTheExchange) {
+    auto trace = build_result_trace (make_request (), make_response ());
+
+    EXPECT_EQ (trace["request"]["method"], "GET");
+    EXPECT_EQ (trace["request"]["url"], "http://127.0.0.1/health");
+    EXPECT_EQ (trace["response"]["body"], R"({"ok":true})");
+    EXPECT_FALSE (trace.contains ("error_type"));
+}
+
+TEST (ExecutionTrace, FailureStoresErrorInsteadOfResponse) {
+    auto response          = make_response ();
+    response.status_code   = 0;
+    response.error_code    = vayu::ErrorCode::ConnectionFailed;
+    response.error_message = "connection refused";
+
+    auto trace = build_result_trace (make_request (), response);
+
+    EXPECT_FALSE (trace.contains ("response"));
+    EXPECT_EQ (trace["error_type"], to_string (vayu::ErrorCode::ConnectionFailed));
+    EXPECT_EQ (trace["error_message"], "connection refused");
+    // Timing still stored - a timeout's partial phases are diagnostics.
+    EXPECT_TRUE (trace.contains ("firstByteMs"));
+}
+
+} // namespace

--- a/engine/tests/json_test.cpp
+++ b/engine/tests/json_test.cpp
@@ -142,7 +142,7 @@ TEST (JsonTest, SerializesResponse) {
     EXPECT_EQ (json["statusText"], "OK");
     EXPECT_EQ (json["headers"]["content-type"], "application/json");
     EXPECT_EQ (json["body"]["success"], true); // Parsed as JSON
-    EXPECT_DOUBLE_EQ (json["timing"]["total"], 123.45);
+    EXPECT_DOUBLE_EQ (json["timing"]["totalMs"], 123.45);
 }
 
 TEST (JsonTest, SerializesError) {


### PR DESCRIPTION
## Description

Resolves both halves of #62 - the trace shape declared three times, and the two naming conventions for the same five phases - then goes one step further and makes the stored trace carry exactly what the live response shows. (The `TraceData` declaration and the dead `trace` prop were already removed by #65, per the issue's follow-up comment.)

**One trace declaration.** `history/types.ts` hand-wrote the trace shape; `SampleResult` now derives from the domain type:

```ts
export type SampleResult = NonNullable<RunReport["results"]>[number];
```

so the shared `RunResultTrace` is the single source of truth and a field added to the engine's trace surfaces without a hand-edit. Drops the redundant `as SampleResult` cast in `SamplesTab` and adjusts `SampleRequestCard`'s body normalization for the derived `unknown` body type (previously `any`).

**One timing key convention.** The engine spoke two dialects for the same eight timing numbers (`firstByte` on the live `/execute` wire, `firstByteMs` in the stored trace). Unified on `*Ms` - the direction that needs **no data migration**, since the suffixed keys are the ones persisted in SQLite `results.trace_data` (renaming those would have needed a read-both shim like the existing `error_type`/`errorType` one in `metrics_helper.cpp`). `serialize(Response)` and the CLI parser now use the `*Ms` keys; `ResponseTiming` is declared **once** in `domain.ts` with the wire's field names (also removing a fourth restatement, the inline `HttpResponse.timing` shape) and re-exported by `request-builder/types.ts`; the `restore-response.ts` rename adapter is gone. Scripts unaffected (`pm.response` exposes its own `responseTime*` names).

**Consistent values stored and shown.** The design-mode writer (`store_result`) used to store only non-zero phases and never `totalMs`/`wireMs`/`queueWaitMs` - so a restored response's Timing tab silently lost Wire and Queue after a restart. It now stores all eight keys unconditionally, matching the live response and the load-mode writer key for key. No migration: readers keep defaulting missing keys, so rows from older engines still restore. `RunResultTrace` now declares `wireMs`/`queueWaitMs` (the load-mode writer already persisted them with no declared type) and `timingFromTrace` passes both through.

**The contract is test-pinned.** The trace builder is extracted into a named `build_result_trace` (the `resolve_request_timeout_ms` precedent) and covered by `execution_trace_test.cpp`, whose central test iterates the live serializer's timing keys and asserts each is stored with the same value - the live and persisted writers cannot drift apart again without a failure. Mutation-checked: suppressing `wireMs` in the builder fails both timing tests.

**Docs** (`api-reference.md`, `db-schema.md`) corrected against a running engine - the old `/execute` example also showed a `runId` field the endpoint never returns and `statusCode` where the wire says `status`.

## Type of Change
- [x] Refactor / wire-contract cleanup (renderer + CLI updated in the same commits)
- [x] Bug fix (stored trace lost Wire/Queue and zero phases on restore)
- [x] Documentation update

## Testing
- Engine: `ctest --preset linux-dev` - **313/313 passed** (4 new contract tests, mutation-checked)
- App: `pnpm type-check` clean; `pnpm test` - **1122 passed (156 files)**; ESLint clean on all touched files
- Live wire: ran the built daemon - `POST /execute` and the stored trace in `GET /runs/:id/report` now return the identical key set (`totalMs, wireMs, queueWaitMs, dnsMs, connectMs, tlsMs, firstByteMs, downloadMs`)
- **Real-app end-to-end:** launched the Electron app headless against the rebuilt engine, sent a request, verified the live Timing tab (five phases + Wire/Queue/Total), then reloaded the window and verified the **restored** Timing tab shows the identical values, Wire and Queue included - the exact regression this fixes

## Checklist
- [x] My code follows the style guidelines (edited C++ blocks are clang-format clean)
- [x] I have performed a self-review
- [x] I have added tests - `execution_trace_test.cpp` (engine) + restore pass-through tests (app), mutation-checked
- [x] I have updated documentation - `docs/engine/api-reference.md`, `docs/engine/db-schema.md`

## Related Issues
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFPwqWYWRkJBbL4R9kdvX2