### PR TITLE
fix(request-builder): stop silently destroying imported digest/aws/ntlm auth

### DIFF
--- a/app/src/constants/auth-modes.ts
+++ b/app/src/constants/auth-modes.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Auth modes a request or collection can *store* but neither editor can edit -
+ * the single source of truth for their display names.
+ *
+ * The engine has no resolution for digest/aws/ntlm, so offering them in a
+ * picker would let someone configure something that silently does nothing. But
+ * they still arrive: the Insomnia importer produces `digest`/`aws`/`ntlm` on
+ * requests and the Postman importer preserves them, so both editors have to
+ * *surface* them (name the stored mode, warn that it is still what runs) rather
+ * than narrow them to "none" and quietly rewrite them on save.
+ *
+ * Both hosts named these independently before this existed - the collection
+ * `AuthTab` and the request `AuthPanel`. One list, one set of words.
+ */
+
+import type { AuthMode } from "@/types";
+
+/** The modes stored-but-not-editable in either auth editor. */
+export type UneditableAuthMode = "digest" | "aws" | "ntlm";
+
+/** Display names for the stored-but-not-editable modes. */
+export const UNEDITABLE_AUTH_LABELS: Record<UneditableAuthMode, string> = {
+	digest: "Digest",
+	aws: "AWS Signature",
+	ntlm: "NTLM",
+};
+
+/** Narrowing guard: is this mode one an editor stores but cannot edit? */
+export function isUneditableAuthMode(mode: AuthMode | string): mode is UneditableAuthMode {
+	return mode === "digest" || mode === "aws" || mode === "ntlm";
+}

--- a/app/src/modules/collections/CollectionDetail/AuthTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/AuthTab.tsx
@@ -26,6 +26,7 @@ import {
 	SelectValue,
 } from "@/components/ui";
 import { Callout } from "@/components/shared";
+import { UNEDITABLE_AUTH_LABELS, isUneditableAuthMode } from "@/constants/auth-modes";
 import { cn } from "@/lib/utils";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import type { Collection } from "@/types";
@@ -37,8 +38,10 @@ import { defaultOAuth2Config } from "@/services/oauth/defaults";
 type CollectionAuthMode = "none" | "bearer" | "basic" | "apikey" | "oauth2";
 type CollectionAuth = Collection["auth"];
 
-/**
- * Display names for the modes this tab stores but cannot edit.
+/*
+ * Display names for the modes this tab stores but cannot edit live in
+ * `@/constants/auth-modes` (`UNEDITABLE_AUTH_LABELS`) - the request `AuthPanel`
+ * surfaces the same modes and shares that list.
  *
  * OAuth 2.0 used to be here. It is editable now: the engine resolves it, an
  * import can produce it, requests inherit it, and `OAuth2Form` was written to be
@@ -48,12 +51,6 @@ type CollectionAuth = Collection["auth"];
  * digest/aws/ntlm stay: the engine has no resolution for them, so offering them
  * here would let you configure something that silently does nothing.
  */
-const UNEDITABLE_LABELS: Record<string, string> = {
-	digest: "Digest",
-	aws: "AWS Signature",
-	ntlm: "NTLM",
-};
-
 const AUTH_OPTIONS: { value: CollectionAuthMode; label: string; hint: string }[] = [
 	{
 		value: "none",
@@ -149,7 +146,11 @@ export default function AuthTab({ collection }: AuthTabProps) {
 	}, [collection.id, resetSave]);
 
 	const mode = asEditable(auth);
-	const uneditableLabel = mode === null ? (UNEDITABLE_LABELS[auth.mode] ?? auth.mode) : null;
+	// `mode === null` is exactly the digest/aws/ntlm set, but the guard also
+	// narrows the index type for `UNEDITABLE_AUTH_LABELS`.
+	const uneditableLabel = isUneditableAuthMode(auth.mode)
+		? UNEDITABLE_AUTH_LABELS[auth.mode]
+		: null;
 	const hint = useMemo(() => AUTH_OPTIONS.find((o) => o.value === mode)?.hint, [mode]);
 
 	const isDirty = useMemo(

--- a/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The request builder's mirror of the collection AuthTab bug (issue #61).
+ *
+ * A request imported with digest/aws/ntlm auth read as "No Auth" and, because
+ * the builder autosaves, the next edit silently wrote `{ mode: "none" }` back -
+ * destroying config the user was never shown. The panel must now name the
+ * stored mode and warn, exactly as the collection AuthTab does; `auth-mapping`
+ * keeps the config so the round-trip no longer loses it.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RequestBuilderContext } from "../../../context";
+import type { RequestBuilderContextValue, RequestState } from "../../../types";
+import { authToEditor } from "../../../utils/auth-mapping";
+import type { RequestAuth } from "@/types";
+import AuthPanel from "./AuthPanel";
+
+function renderPanel(auth: RequestAuth) {
+	const { authType, authConfig } = authToEditor(auth);
+	const request = { authType, authConfig, collectionId: null } as unknown as RequestState;
+	const ctx = {
+		request,
+		updateField: vi.fn(),
+		setRequest: vi.fn(),
+		resolveString: (s: string) => s,
+		// The editable branches render VariableInput, which reads these.
+		getAllVariables: () => ({}),
+		getVariable: () => null,
+		resolveVariables: (s: string) => s,
+		updateVariable: vi.fn(),
+	} as unknown as RequestBuilderContextValue;
+	return render(
+		<RequestBuilderContext.Provider value={ctx}>
+			<AuthPanel />
+		</RequestBuilderContext.Provider>
+	);
+}
+
+describe("AuthPanel with an auth mode it cannot edit", () => {
+	it("names the stored mode instead of reading No Auth", () => {
+		renderPanel({ mode: "digest", config: { username: "u" } });
+
+		expect(screen.getByText(/Digest auth is set/i)).toBeInTheDocument();
+		expect(screen.getByText(/Picking a type above replaces it/i)).toBeInTheDocument();
+		// The "No Auth" empty state is what the picker falls back to - it must not
+		// claim the request has no auth when it has digest.
+		expect(
+			screen.queryByText(/No authentication will be sent with this request/i)
+		).not.toBeInTheDocument();
+	});
+
+	it("labels aws and ntlm too", () => {
+		renderPanel({ mode: "aws", config: {} });
+		expect(screen.getByText(/AWS Signature auth is set/i)).toBeInTheDocument();
+
+		renderPanel({ mode: "ntlm", config: {} });
+		expect(screen.getByText(/NTLM auth is set/i)).toBeInTheDocument();
+	});
+});
+
+describe("AuthPanel with an editable mode", () => {
+	it("does not warn when the mode is one it understands", () => {
+		renderPanel({ mode: "bearer", token: "abc" });
+		expect(screen.queryByText(/not editable here/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/auth is set/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the No Auth empty state when there genuinely is none", () => {
+		renderPanel({ mode: "none" });
+		expect(
+			screen.getByText(/No authentication will be sent with this request/i)
+		).toBeInTheDocument();
+	});
+});

--- a/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx
@@ -27,7 +27,9 @@ import {
 	SecretInput,
 } from "@/components/ui";
 import { OAuth2Form, type OAuth2TextInput } from "@/components/shared/OAuth2Form";
+import { Callout } from "@/components/shared";
 import { defaultOAuth2Config } from "@/services/oauth/defaults";
+import { UNEDITABLE_AUTH_LABELS, isUneditableAuthMode } from "@/constants/auth-modes";
 import { useRequestBuilderContext } from "../../../context";
 import VariableInput from "../../../shared/VariableInput";
 import type { AuthType, AuthConfigState } from "../../../types";
@@ -86,14 +88,28 @@ export default function AuthPanel() {
 		updateField("authConfig", { ...authConfig, ...updates });
 	};
 
+	// digest/aws/ntlm are stored but not editable here (the engine can't resolve
+	// them). Name the real mode and warn instead of showing the "No Auth" empty
+	// state, which is what the picker would fall back to - the same treatment the
+	// collection AuthTab gives them. Selecting any type below replaces it.
+	const uneditableLabel = isUneditableAuthMode(authType)
+		? UNEDITABLE_AUTH_LABELS[authType]
+		: null;
+
 	return (
 		<div className="space-y-6">
 			{/* Auth Type Selector */}
 			<div className="space-y-2">
 				<Label>Authentication Type</Label>
-				<Select value={authType} onValueChange={handleTypeChange}>
+				<Select value={uneditableLabel ? "" : authType} onValueChange={handleTypeChange}>
 					<SelectTrigger className="w-auto">
-						<SelectValue />
+						<SelectValue
+							placeholder={
+								uneditableLabel
+									? `${uneditableLabel} (not editable here)`
+									: undefined
+							}
+						/>
 					</SelectTrigger>
 					<SelectContent>
 						{AUTH_TYPES.map((type) => {
@@ -113,6 +129,14 @@ export default function AuthPanel() {
 
 			{/* Inherit resolution */}
 			{authType === "inherit" && <AuthInheritBanner collectionId={request.collectionId} />}
+
+			{/* Stored-but-not-editable mode (imported digest/aws/ntlm) */}
+			{uneditableLabel && (
+				<Callout severity="warning" title={`${uneditableLabel} auth is set`}>
+					It was imported and can't be edited here yet - it is still sent with this
+					request. Picking a type above replaces it.
+				</Callout>
+			)}
 
 			{/* Auth Configuration */}
 			{authType === "none" && (

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -18,6 +18,7 @@ import type {
 	HttpMethod,
 	KeyValueEntry,
 	OAuth2Config,
+	RequestAuth,
 	ResolvedVariable,
 	ScriptPart,
 	VariableScope,
@@ -60,7 +61,23 @@ export interface TabInfo {
 // Auth Types
 // ============================================================================
 
-export type AuthType = "none" | "inherit" | "bearer" | "basic" | "api-key" | "oauth2";
+/**
+ * The editor's auth discriminant. `api-key` renames the domain's `apikey`; the
+ * rest match. `digest` / `aws` / `ntlm` are *not* offered in the picker - the
+ * engine cannot resolve them - but a request can be stored with one (imports
+ * produce them), so the editor carries the mode to surface it rather than
+ * collapsing it to "none" and rewriting it away on the next autosave.
+ */
+export type AuthType =
+	| "none"
+	| "inherit"
+	| "bearer"
+	| "basic"
+	| "api-key"
+	| "oauth2"
+	| "digest"
+	| "aws"
+	| "ntlm";
 
 /**
  * Flat auth fields backing the request builder's Auth tab. Which fields are
@@ -76,6 +93,13 @@ export interface AuthConfigState {
 	value?: string;
 	addTo?: "header" | "query";
 	oauth2?: OAuth2Config;
+	/**
+	 * Verbatim domain config for a stored-but-not-editable mode
+	 * (digest/aws/ntlm). No field of it is editable here, so it is kept whole
+	 * and round-tripped by {@link authToEditor}/{@link editorToAuth} rather than
+	 * flattened - autosave must return exactly what it loaded.
+	 */
+	nonEditable?: Extract<RequestAuth, { mode: "digest" | "aws" | "ntlm" }>;
 }
 
 export interface AuthConfig {

--- a/app/src/modules/request-builder/utils/auth-mapping.test.ts
+++ b/app/src/modules/request-builder/utils/auth-mapping.test.ts
@@ -44,7 +44,22 @@ describe("auth-mapping", () => {
 		expect(auth).toEqual({ mode: "oauth2", config: defaultOAuth2Config() });
 	});
 
-	it("maps unknown/non-editable modes to none", () => {
-		expect(authToEditor({ mode: "ntlm", config: {} }).authType).toBe("none");
+	// Regression: the editor cannot edit digest/aws/ntlm, but it used to collapse
+	// them to "none" on load. The next autosave then wrote `{ mode: "none" }`
+	// back, destroying imported config the user was never shown. They must now
+	// carry the real mode and round-trip byte-for-byte.
+	it("preserves stored-but-not-editable modes instead of collapsing to none", () => {
+		const cases: RequestAuth[] = [
+			{ mode: "digest", config: { username: "u", realm: "r", nonce: "n" } },
+			{ mode: "aws", config: { accessKey: "AK", secretKey: "SK", region: "us-east-1" } },
+			{ mode: "ntlm", config: { domain: "CORP", username: "u", password: "p" } },
+		];
+		for (const auth of cases) {
+			const { authType, authConfig } = authToEditor(auth);
+			// The picker never offers these, but the mode is carried so the panel
+			// can name it rather than reading "No Auth".
+			expect(authType).toBe(auth.mode);
+			expect(editorToAuth(authType, authConfig)).toEqual(auth);
+		}
 	});
 });

--- a/app/src/modules/request-builder/utils/auth-mapping.ts
+++ b/app/src/modules/request-builder/utils/auth-mapping.ts
@@ -12,6 +12,13 @@
  * paths share one implementation and it can be unit-tested in isolation.
  *
  * Note the field rename: domain apikey uses `in`, the editor uses `addTo`.
+ *
+ * Modes the editor cannot edit (digest/aws/ntlm) are *not* collapsed to "none".
+ * That collapse is the data-loss bug this file used to have: an imported digest
+ * request read as "No Auth", and the very next autosave wrote `{ mode: "none" }`
+ * back, destroying config the user was never shown. The mode is now carried
+ * through verbatim (see {@link AuthConfigState.nonEditable}) and round-trips
+ * unchanged - the AuthPanel surfaces it, mirroring the collection AuthTab.
  */
 
 import type { Collection, RequestAuth } from "@/types";
@@ -40,8 +47,13 @@ export function authToEditor(auth: RequestAuth): {
 			return { authType: "oauth2", authConfig: { oauth2: auth.config } };
 		case "inherit":
 			return { authType: "inherit", authConfig: {} };
+		case "digest":
+		case "aws":
+		case "ntlm":
+			// Stored but not editable: keep the whole config so the round-trip
+			// through the editor returns it unchanged instead of dropping it.
+			return { authType: auth.mode, authConfig: { nonEditable: auth } };
 		default:
-			// none, plus the stored-but-not-editable modes (digest/aws/ntlm)
 			return { authType: "none", authConfig: {} };
 	}
 }
@@ -68,6 +80,12 @@ export function editorToAuth(authType: AuthType, authConfig: AuthConfigState): R
 			return { mode: "oauth2", config: authConfig.oauth2 ?? defaultOAuth2Config() };
 		case "inherit":
 			return { mode: "inherit" };
+		case "digest":
+		case "aws":
+		case "ntlm":
+			// Hand back exactly what was loaded. The fallback only fires if the
+			// mode was set without its config, which the mappers never do.
+			return authConfig.nonEditable ?? { mode: authType, config: {} };
 		default:
 			return { mode: "none" };
 	}


### PR DESCRIPTION
## Description

The request builder's Auth panel had the same data-loss bug the collection `AuthTab` already fixed with its `asEditable` treatment.

`authToEditor` collapsed every stored-but-not-editable mode (`digest` / `aws` / `ntlm`) to `"none"`. So for a request imported with digest auth (the Insomnia importer produces `digest`/`ntlm`/`aws`; the Postman importer counts them as `nonExecutableAuth`):

1. The Auth tab read **"No Auth"** and stated "No authentication will be sent with this request" - about a request that *does* have auth.
2. Because the builder autosaves, editing anything (the URL, a header) ran `editorToAuth("none", {})` = `{ mode: "none" }`.
3. The digest config was gone - config the user was never shown and never touched.

This PR gives the request panel the same treatment the collection editor already has:

- **`auth-mapping.ts`** carries the whole domain config through a new `AuthConfigState.nonEditable` field instead of dropping it. `authToEditor` preserves the real `mode`, `editorToAuth` returns the stored config verbatim, and the round-trip is byte-for-byte - so autosave writes back exactly what it loaded.
- **`AuthPanel.tsx`** surfaces the mode: the picker shows `Digest (not editable here)` and a warning Callout ("Digest auth is set ... Picking a type above replaces it") instead of falling back to the "No Auth" empty state. Selecting a real type still replaces it, deliberately.
- **`constants/auth-modes.ts`** is a new single source of truth for these modes' display names, which the two editors had duplicated. The collection `AuthTab` now consumes it too.

This is the **correctness half** of #61, which its own text says "is a correctness fix and should not wait for the consolidation." The larger `AuthFields` component consolidation (unifying the four editable field groups and the request/collection vocabularies) is tracked separately in **#105**.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- New `AuthPanel.test.tsx`: an imported `digest`/`aws`/`ntlm` request names the stored mode and warns rather than reading "No Auth"; editable modes (`bearer`) and genuine `none` are unaffected.
- Updated `auth-mapping.test.ts`: replaced the old "maps non-editable modes to none" assertion with a round-trip test proving `digest`/`aws`/`ntlm` (with config) survive `authToEditor` → `editorToAuth` unchanged.
- Existing `AuthTab.test.tsx` still green after switching it to the shared label constant.
- `pnpm type-check`, `pnpm lint` (touched files clean), and Prettier all pass; full suite green (1120 tests).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (no reference doc described the fixed behavior; import docs already state these modes are stored)

## Related Issues
Closes #61 (correctness fix). Consolidation follow-up tracked in #105.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)