### PR TITLE
feat(engine,db): cap stored trace bodies and add run retention

### DIFF
--- a/app/src/modules/history/main/design-run-seed.test.ts
+++ b/app/src/modules/history/main/design-run-seed.test.ts
@@ -242,4 +242,44 @@ describe("seedFromRun", () => {
 			expect(seed.request.preRequestScript).toBe("");
 		});
 	});
+
+	describe("a truncated request body", () => {
+		// The engine sets bodyTruncated on the trace when a stored body exceeded
+		// maxTraceBodyBytes. The seed must carry the flag so Save can refuse to
+		// write an incomplete body back.
+		function truncatedRun(): Run {
+			return run({
+				result: {
+					timestamp: 1_750_000_000_000,
+					statusCode: 200,
+					statusText: "OK",
+					latencyMs: 12,
+					trace: {
+						request: {
+							method: "POST",
+							url: "https://api.example.test/users?page=2",
+							headers: { "X-Plain": "visible" },
+							body: "SLICE",
+							bodyTruncated: true,
+							bodyBytes: 5_242_880,
+						},
+						response: { headers: {}, body: "{}" },
+					},
+				},
+			});
+		}
+
+		it("sets requestBodyTruncated from the trace", () => {
+			expect(seedFromRun(truncatedRun(), liveRequest).requestBodyTruncated).toBe(true);
+		});
+
+		it("carries the flag whether or not the request still exists", () => {
+			// Read the same way in both the live-request and request-gone branches.
+			expect(seedFromRun(truncatedRun(), null).requestBodyTruncated).toBe(true);
+		});
+
+		it("leaves it undefined for an untruncated run", () => {
+			expect(seedFromRun(run(), liveRequest).requestBodyTruncated).toBeUndefined();
+		});
+	});
 });

--- a/app/src/modules/history/main/design-run-seed.ts
+++ b/app/src/modules/history/main/design-run-seed.ts
@@ -68,6 +68,14 @@ export interface DesignRunSeed {
 	 * mode. `undefined` when the run recorded no auth (mode "none" or absent).
 	 */
 	recordedAuthMode?: string;
+	/**
+	 * True when the engine truncated this run's stored request body
+	 * (`maxTraceBodyBytes`). The editable copy still shows the full body from the
+	 * config snapshot (which is not capped), but "Save this run to the request"
+	 * must not write a possibly-incomplete body back - see
+	 * {@link applyRunToRequest}. Read from `trace.request.bodyTruncated`.
+	 */
+	requestBodyTruncated?: boolean;
 }
 
 function toHeaderItems(headers: Record<string, string> | undefined) {
@@ -140,5 +148,7 @@ export function seedFromRun(run: Run, liveRequest?: Request | null): DesignRunSe
 		// "none" carries no information the absence would not, so normalise it away.
 		recordedAuthMode:
 			snapshot.auth?.mode && snapshot.auth.mode !== "none" ? snapshot.auth.mode : undefined,
+		// Only surfaces `true`; an untruncated run leaves it undefined.
+		requestBodyTruncated: trace?.request?.bodyTruncated ? true : undefined,
 	};
 }

--- a/app/src/modules/history/main/save-run-to-request.test.ts
+++ b/app/src/modules/history/main/save-run-to-request.test.ts
@@ -59,6 +59,29 @@ function run(overrides: Partial<Run> = {}): Run {
 	} as Run;
 }
 
+/** A run whose stored request body the engine truncated (over maxTraceBodyBytes). */
+function truncatedRun(): Run {
+	return run({
+		result: {
+			timestamp: 1_750_000_000_000,
+			statusCode: 200,
+			statusText: "OK",
+			latencyMs: 12,
+			trace: {
+				request: {
+					method: "POST",
+					url: "https://api.example.test/users?page=2",
+					headers: { "X-Plain": "visible" },
+					body: "SLICE",
+					bodyTruncated: true,
+					bodyBytes: 5_242_880,
+				},
+				response: { headers: {}, body: "{}" },
+			},
+		},
+	});
+}
+
 /** The saved request as it reads today - deliberately different from the run. */
 function liveRequest(overrides: Partial<Request> = {}): Request {
 	return {
@@ -118,6 +141,30 @@ describe("applyRunToRequest", () => {
 		// live request holds, which is the one thing that cannot be recovered.
 		expect(patch).not.toHaveProperty("auth");
 		expect(Object.keys(patch)).not.toContain("auth");
+	});
+
+	it("never writes a truncated request body back to the saved request", () => {
+		// The lock: the engine caps a stored trace body at maxTraceBodyBytes, so a
+		// truncated run holds only a slice. Writing that slice onto the saved
+		// request would silently corrupt it, so the body must be left off the
+		// patch entirely - the same treatment auth gets. Reverting the guard in
+		// applyRunToRequest makes this fail.
+		const live = liveRequest();
+		const patch = applyRunToRequest(seedFromRun(truncatedRun(), live), live);
+
+		expect(patch).not.toHaveProperty("body");
+		expect(patch).not.toHaveProperty("bodyType");
+		// The rest of the request still saves.
+		expect(patch.method).toBe("POST");
+		expect(patch.url).toBe("https://api.example.test/users?page=2");
+	});
+
+	it("writes the body normally when the run was not truncated", () => {
+		const live = liveRequest();
+		const patch = applyRunToRequest(seedFromRun(run(), live), live);
+
+		expect(patch.body).toEqual({ mode: "json", content: '{"a":1}' });
+		expect(patch.bodyType).toBe("json");
 	});
 
 	it("omits scripts entirely for a run that has only the old glued string", () => {
@@ -283,6 +330,17 @@ describe("buildChangeset", () => {
 		const written = (patch.headers ?? []).map((h) => h.key.toLowerCase());
 		expect(written).not.toContain("x-vayu-version");
 		expect(written).not.toContain("x-request-id");
+	});
+
+	it("shows Body as a kept row with a reason when the run was truncated", () => {
+		const live = liveRequest();
+		const body = buildChangeset(seedFromRun(truncatedRun(), live), live).find(
+			(i) => i.field === "Body"
+		);
+
+		expect(body).toBeDefined();
+		expect(body!.state).toBe("kept");
+		expect(body!.note).toMatch(/truncat|too large|incomplete/i);
 	});
 
 	it("shows only the kept rows when the request already matches the run", () => {

--- a/app/src/modules/history/main/save-run-to-request.ts
+++ b/app/src/modules/history/main/save-run-to-request.ts
@@ -28,7 +28,12 @@
  * script inside the request permanently - the next send would glue it on again
  * and run it twice.
  *
- * Neither is silent: {@link buildChangeset} emits both as `kept` rows, in the
+ * **Body, for a run whose stored request body was truncated.** The engine caps
+ * a stored trace body at `maxTraceBodyBytes`, so such a run holds only a slice
+ * of what was sent; writing that slice back would corrupt the saved body. When
+ * `seed.requestBodyTruncated` is set the body is left off the patch.
+ *
+ * None is silent: {@link buildChangeset} emits each as a `kept` row, in the
  * same list as every change, with the reason inline. That is what makes "an
  * older run saves fewer fields" visible rather than surprising.
  */
@@ -311,7 +316,20 @@ export function buildChangeset(seed: DesignRunSeed, live: Request): ChangesetIte
 	scalar("URL", live.url, patch.url ?? live.url);
 	keyValues("Params", live.params ?? [], patch.params ?? []);
 	keyValues("Headers", live.headers ?? [], patch.headers ?? []);
-	scalar("Body", describeBody(live.body), describeBody(patch.body ?? live.body));
+	// A truncated run stores only a slice of its request body, so the body is not
+	// written (applyRunToRequest omits it). Shown as a kept row with the reason,
+	// the same way Auth is - never silently dropped.
+	if (seed.requestBodyTruncated) {
+		items.push({
+			field: "Body",
+			state: "kept",
+			detail: "kept",
+			value: describeBody(live.body),
+			note: "This run's request body was too large to store in full, so only a slice was kept. It is not written back, to avoid overwriting the saved body with an incomplete copy.",
+		});
+	} else {
+		scalar("Body", describeBody(live.body), describeBody(patch.body ?? live.body));
+	}
 
 	if (isLegacyRun(seed)) {
 		items.push({
@@ -363,11 +381,19 @@ export function applyRunToRequest(seed: DesignRunSeed, live: Request): UpdateReq
 		// with current values on load, so writing a run's stale X-Vayu-Version /
 		// X-Request-ID would pin an old version onto the request.
 		headers: userEntries(items(request.headers)),
-		body,
-		bodyType: body.mode,
 		followRedirects: request.followRedirects ?? live.followRedirects,
 		maxRedirects: request.maxRedirects ?? live.maxRedirects,
 	};
+
+	// The body is only written when the run's stored request body was not
+	// truncated. A truncated run holds only a slice of what was sent, and writing
+	// that slice back would silently corrupt the saved request - so the body (and
+	// bodyType) are left off the patch entirely, the same way auth never is. Note
+	// there is no `body: undefined`, which some serialisers would still send.
+	if (!seed.requestBodyTruncated) {
+		patch.body = body;
+		patch.bodyType = body.mode;
+	}
 
 	if (!isLegacyRun(seed)) {
 		patch.preRequestScript = request.preRequestScript ?? "";

--- a/app/src/modules/request-builder/components/ResponseViewer/index.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/index.tsx
@@ -31,7 +31,9 @@ import {
 	ResponseActions,
 	ResponseHeadersPanel,
 	RESPONSE_TAB_TRIGGER,
+	formatSize,
 } from "@/components/shared/response-viewer";
+import { Callout } from "@/components/shared";
 import ResponseCookies from "./ResponseCookies";
 import ResponseTimingTab from "./ResponseTimingTab";
 import ConsoleOutput from "./ConsoleOutput";
@@ -247,12 +249,31 @@ export default function ResponseViewer() {
 				 * always rendered together.
 				 */}
 				<TabsContent value="body" className="mt-0 flex-1 overflow-hidden">
-					<SharedResponseBody
-						body={response.body}
-						bodyRaw={response.bodyRaw}
-						headers={response.headers}
-						showModeToggle
-					/>
+					<div className="flex flex-col h-full">
+						{/*
+						 * The engine caps a stored trace body at `maxTraceBodyBytes`,
+						 * so a response restored from a run (cold start, or a design
+						 * run opened from History) may hold only the stored slice.
+						 * Say so, and how to get the whole thing back.
+						 */}
+						{response.bodyTruncated && (
+							<div className="px-4 pt-3 shrink-0">
+								<Callout severity="warning" title="Body truncated for storage">
+									Only the first {formatSize(response.body.length)} of{" "}
+									{formatSize(response.bodyBytes ?? response.body.length)} was
+									kept. Re-send the request to view the full response.
+								</Callout>
+							</div>
+						)}
+						<div className="flex-1 min-h-0">
+							<SharedResponseBody
+								body={response.body}
+								bodyRaw={response.bodyRaw}
+								headers={response.headers}
+								showModeToggle
+							/>
+						</div>
+					</div>
 				</TabsContent>
 				<TabsContent value="headers" className="mt-0 flex-1 overflow-hidden">
 					<ResponseHeadersPanel

--- a/app/src/modules/request-builder/components/ResponseViewer/truncation-notice.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/truncation-notice.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The truncation notice in the response body pane.
+ *
+ * The engine caps a stored trace body at `maxTraceBodyBytes`, so a response
+ * restored from a run (a cold-start tab, or a design run opened from History)
+ * can hold only the stored slice. `restore-response.ts` carries the
+ * `bodyTruncated` / `bodyBytes` flags into `ResponseState`; this pane is where
+ * the user is told, and how to get the whole body back.
+ *
+ * Both restored responses and design-run views render through this same viewer,
+ * so one notice here covers both readers.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ResponseState } from "../../types";
+
+// Monaco does not run in jsdom - the body editor is not what this test is about.
+vi.mock("@/components/ui/code-editor", () => ({
+	CodeEditor: () => <div data-testid="code-editor" />,
+}));
+
+// The viewer reads its response from context; feed it a fixed one per render.
+let response: ResponseState | null = null;
+vi.mock("../../context", () => ({
+	useRequestBuilderContext: () => ({ response, isExecuting: false }),
+}));
+
+// Imported after the mocks above are registered.
+const { default: ResponseViewer } = await import("./index");
+
+function baseResponse(overrides: Partial<ResponseState> = {}): ResponseState {
+	return {
+		status: 200,
+		statusText: "OK",
+		headers: { "content-type": "application/json" },
+		body: '{"ok":true}',
+		bodyType: "json",
+		size: 11,
+		time: 12,
+		...overrides,
+	};
+}
+
+describe("response body truncation notice", () => {
+	it("shows the notice when the restored response body was truncated", () => {
+		response = baseResponse({
+			body: "STORED_SLICE",
+			bodyTruncated: true,
+			bodyBytes: 5_242_880,
+			restoredFrom: { at: new Date(1_750_000_000_000).toISOString() },
+		});
+
+		render(
+			<TooltipProvider>
+				<ResponseViewer />
+			</TooltipProvider>
+		);
+
+		expect(screen.getByText(/Body truncated for storage/i)).toBeInTheDocument();
+		// The "how to recover" instruction is the actionable half of the notice.
+		expect(screen.getByText(/Re-send the request to view the full response/i)).toBeInTheDocument();
+	});
+
+	it("shows no notice for an untruncated response", () => {
+		response = baseResponse();
+
+		render(
+			<TooltipProvider>
+				<ResponseViewer />
+			</TooltipProvider>
+		);
+
+		expect(screen.queryByText(/Body truncated for storage/i)).toBeNull();
+	});
+});

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -188,6 +188,15 @@ export interface ResponseState {
 	bodyRaw?: string;
 	bodyType: "json" | "html" | "xml" | "text" | "binary";
 	size: number;
+	/**
+	 * Set when this response was restored from a stored run whose body the engine
+	 * truncated for storage (`maxTraceBodyBytes`). `body` then holds only the
+	 * stored slice, and `bodyBytes` is the original length. Drives the truncation
+	 * notice in the response viewer; re-sending fetches the full body.
+	 */
+	bodyTruncated?: boolean;
+	/** The response body's original byte length, present only when truncated. */
+	bodyBytes?: number;
 	time: number;
 	timing?: ResponseTiming;
 	/**

--- a/app/src/modules/request-builder/utils/restore-response.test.ts
+++ b/app/src/modules/request-builder/utils/restore-response.test.ts
@@ -121,6 +121,44 @@ describe("responseFromRunResult", () => {
 		expect(restored?.body).toBe("");
 		expect(restored?.bodyType).toBe("text");
 	});
+
+	/**
+	 * The engine caps a stored trace body at `maxTraceBodyBytes`. When it does,
+	 * the trace carries `bodyTruncated` / `bodyBytes`, and the restore must pass
+	 * them through so ResponseViewer can show the truncation notice - and report
+	 * the *original* size, not the stored slice's length. Reverting the mapping
+	 * in `responseFromRunResult` fails this test.
+	 */
+	it("surfaces a truncated response body's flag and original size", () => {
+		const restored = responseFromRunResult(
+			sample({
+				trace: {
+					request: { method: "GET", url: "https://api.example.test/big", headers: {} },
+					response: {
+						headers: { "content-type": "application/json" },
+						body: "STORED_SLICE",
+						bodyTruncated: true,
+						bodyBytes: 5_242_880,
+					},
+				},
+			})
+		);
+
+		expect(restored?.bodyTruncated).toBe(true);
+		expect(restored?.bodyBytes).toBe(5_242_880);
+		// `size` shows the original length, not the 12-char stored slice.
+		expect(restored?.size).toBe(5_242_880);
+		expect(restored?.body).toBe("STORED_SLICE");
+	});
+
+	it("leaves the truncation fields unset for an untruncated body", () => {
+		const restored = responseFromRunResult(sample());
+
+		expect(restored?.bodyTruncated).toBeUndefined();
+		expect(restored?.bodyBytes).toBeUndefined();
+		// Falls back to the stored body's own length.
+		expect(restored?.size).toBe('{"ok":true}'.length);
+	});
 });
 
 /**

--- a/app/src/modules/request-builder/utils/restore-response.ts
+++ b/app/src/modules/request-builder/utils/restore-response.ts
@@ -140,7 +140,12 @@ export function responseFromRunResult(
 		...sentSide(trace),
 		body,
 		bodyType: detectBodyType(body),
-		size: body.length,
+		// `size` is what the pane's byte count shows. When the body was truncated
+		// for storage the stored slice is not the real size, so prefer the
+		// original `bodyBytes` the engine recorded and fall back to the slice.
+		size: trace.response.bodyBytes ?? body.length,
+		bodyTruncated: trace.response.bodyTruncated,
+		bodyBytes: trace.response.bodyBytes,
 		time: result.latencyMs || 0,
 		timing: timingFromTrace(trace, result.latencyMs),
 		restoredFrom,

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -276,10 +276,18 @@ export interface RunResultTrace {
 		url?: string;
 		headers?: Record<string, string>;
 		body?: string;
+		/** Set by `store_result` when the request body exceeded `maxTraceBodyBytes`. */
+		bodyTruncated?: boolean;
+		/** The request body's original byte length, present only when truncated. */
+		bodyBytes?: number;
 	};
 	response?: {
 		headers?: Record<string, string>;
 		body?: unknown;
+		/** Set by `store_result` when the response body exceeded `maxTraceBodyBytes`. */
+		bodyTruncated?: boolean;
+		/** The response body's original byte length, present only when truncated. */
+		bodyBytes?: number;
 	};
 }
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -116,7 +116,7 @@ changes. Three `observability` keys govern how much run history the engine keeps
 
 | Key                 | Default   | Range        | Effect |
 |---------------------|-----------|--------------|--------|
-| `maxTraceBodyBytes` | `1048576` | 1024–104857600 | Largest request/response body stored in a design run's `trace_data`. Bigger bodies are truncated with `bodyTruncated`/`bodyBytes` (see `GET /runs/:id`). |
+| `maxTraceBodyBytes` | `5242880` | 1024–104857600 | Largest request/response body stored in a design run's `trace_data`. Bigger bodies are truncated with `bodyTruncated`/`bodyBytes` (see `GET /runs/:id`). |
 | `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results) are pruned at startup and after each run finishes. `0` = unlimited. |
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -111,6 +111,17 @@ min/max):
 `default` are always strings; `type` is one of `integer`, `number`, `boolean`,
 or `string`.
 
+The Settings panel renders entries dynamically, so new keys appear without app
+changes. Three `observability` keys govern how much run history the engine keeps:
+
+| Key                 | Default   | Range        | Effect |
+|---------------------|-----------|--------------|--------|
+| `maxTraceBodyBytes` | `1048576` | 1024–104857600 | Largest request/response body stored in a design run's `trace_data`. Bigger bodies are truncated with `bodyTruncated`/`bodyBytes` (see `GET /runs/:id`). |
+| `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results) are pruned at startup and after each run finishes. `0` = unlimited. |
+| `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
+
+In-progress (`running`/`pending`) runs are never pruned.
+
 ### POST /config
 
 Update one or more configuration entries. Two body shapes are accepted:
@@ -930,6 +941,13 @@ run.
   }
 }
 ```
+
+If the engine truncated a body for storage (over `maxTraceBodyBytes`), the
+affected `trace.request` and/or `trace.response` object carries
+`"bodyTruncated": true` and `"bodyBytes": <original length>`; its `body` then
+holds only the first `maxTraceBodyBytes` of the original. Absent when the body
+fit. Clients surface this as a "body truncated for storage" notice and re-send
+to fetch the whole body.
 
 ### POST /runs/:runId/stop
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -169,6 +169,18 @@ reduced to just `{"mode": "..."}` (via `sanitize_config_snapshot` in
 `utils/json.cpp`) - an allowlist, so no current or future auth field
 (`clientSecret`, `password`, tokens) leaks into a stored run.
 
+**Retention** - runs are append-only in normal use (every design-mode click adds a `runs` row,
+every load run its `metrics`/`results`), so `Database::prune_runs(max_runs, max_age_days)` trims
+the history. A run is a victim when it falls **beyond the `maxRunsRetained` most-recent runs**
+(ordered by `start_time`) **or** its `start_time` is older than **`runRetentionDays`** days;
+either knob is disabled by `0`. Runs still `running`/`pending` are never pruned and never count
+toward the cap. Deletion goes through the `delete_run` cascade (runs + their `metrics` + their
+`results`), batched inside transactions that release the DB mutex between batches so a large
+backlog cannot stall `/health`, SSE, or the runs poll. `prune_runs_configured()` reads the two
+knobs (config, `observability`, defaults 200 / 30) and runs at **startup** (`Database::init`) and
+after a run reaches a **terminal** status (design mode's `store_result`, and the load-run
+completion/failure paths in `run_manager.cpp`).
+
 ---
 
 ### `oauth_tokens`
@@ -263,8 +275,24 @@ than assuming all eight are there and flat:
 | Load run, error (`load_strategy.cpp`) | an error envelope (`error_type`, `message`, `request_number`) with the eight keys **nested under `timing`**, present whenever `totalMs > 0` |
 | Design mode (`store_result` in `execution.cpp`) | the five phase keys flat (`dnsMs`…`downloadMs`), **each only when non-zero** - a reused connection writes no `connectMs`/`tlsMs`. No `totalMs`/`wireMs`/`queueWaitMs`; perceived total lives in the `latency_ms` column. Written on **every** single request, alongside a nested `request` object plus either `response` (success) or `error_type` / `error_message` (failure). |
 
+The design-mode `request.body` and `response.body` are **capped at `maxTraceBodyBytes`**
+(config, `observability`, default 1 MiB) before storage, so downloading one 50 MB response does
+not live in SQLite forever. When a body is cut, its node gains two keys:
+
+| Key on `request` / `response` | Type | Meaning |
+|-------------------------------|------|---------|
+| `bodyTruncated`               | bool | Present and `true` only when the stored `body` is a prefix, not the whole body |
+| `bodyBytes`                   | int  | The **original** body length in bytes (the stored `body` is the first `maxTraceBodyBytes` of it) |
+
+The cut is on a raw byte boundary (the body is an opaque string), so a split UTF-8 sequence is
+possible; `store_result` dumps the trace with `error_handler_t::replace`, turning a stray
+continuation byte into U+FFFD rather than throwing. The cap is built by
+`vayu::json::build_design_trace` (`utils/json.cpp`). It applies **only** to the design-mode
+writer - the load-run writers store timing/error envelopes, not bodies.
+
 That design-mode subset is what rebuilds the request builder's response pane (Timing tab included)
-after a restart - see `app/src/modules/request-builder/utils/restore-response.ts`.
+after a restart - see `app/src/modules/request-builder/utils/restore-response.ts`, which surfaces
+`bodyTruncated`/`bodyBytes` as a "body truncated for storage" notice.
 
 A design run has exactly one `results` row. `GET /runs/:runId` serves it (as `result`)
 alongside the run itself, in addition to `GET /runs/:runId/report`'s `results` array - the

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -276,7 +276,7 @@ than assuming all eight are there and flat:
 | Design mode (`store_result` in `execution.cpp`) | the five phase keys flat (`dnsMs`…`downloadMs`), **each only when non-zero** - a reused connection writes no `connectMs`/`tlsMs`. No `totalMs`/`wireMs`/`queueWaitMs`; perceived total lives in the `latency_ms` column. Written on **every** single request, alongside a nested `request` object plus either `response` (success) or `error_type` / `error_message` (failure). |
 
 The design-mode `request.body` and `response.body` are **capped at `maxTraceBodyBytes`**
-(config, `observability`, default 1 MiB) before storage, so downloading one 50 MB response does
+(config, `observability`, default 5 MiB) before storage, so downloading one 50 MB response does
 not live in SQLite forever. When a body is cut, its node gains two keys:
 
 | Key on `request` / `response` | Type | Meaning |

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -127,6 +127,9 @@ namespace json {
 constexpr int DEFAULT_INDENT = 2;
 /// Maximum size for JSON field parsing to prevent OOM (10MB)
 constexpr size_t MAX_FIELD_SIZE = 10 * 1024 * 1024;
+/// Maximum request/response body bytes stored per design-run trace (1MB).
+/// Larger bodies are truncated in results.trace_data with bodyTruncated set.
+constexpr size_t MAX_TRACE_BODY_BYTES = 1024 * 1024;
 } // namespace json
 
 /**
@@ -187,6 +190,10 @@ constexpr int WAL_AUTOCHECKPOINT = 1000;
 constexpr int BUSY_TIMEOUT_MS = 10000;
 /// SQLite synchronous mode (0=OFF, 1=NORMAL, 2=FULL) - 0 is safe with WAL
 constexpr int SYNCHRONOUS = 0;
+/// Run retention: keep at most N most-recent runs (0 = unlimited).
+constexpr int MAX_RUNS_RETAINED = 200;
+/// Run retention: delete runs older than N days (0 = unlimited).
+constexpr int RUN_RETENTION_DAYS = 30;
 } // namespace database
 } // namespace vayu::core::constants
 

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -127,9 +127,9 @@ namespace json {
 constexpr int DEFAULT_INDENT = 2;
 /// Maximum size for JSON field parsing to prevent OOM (10MB)
 constexpr size_t MAX_FIELD_SIZE = 10 * 1024 * 1024;
-/// Maximum request/response body bytes stored per design-run trace (1MB).
+/// Maximum request/response body bytes stored per design-run trace (5MB).
 /// Larger bodies are truncated in results.trace_data with bodyTruncated set.
-constexpr size_t MAX_TRACE_BODY_BYTES = 1024 * 1024;
+constexpr size_t MAX_TRACE_BODY_BYTES = 5 * 1024 * 1024;
 } // namespace json
 
 /**

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -61,6 +61,25 @@ class Database {
     std::vector<Run> get_all_runs ();
     void delete_run (const std::string& id);
 
+    /**
+     * @brief Prune old runs (and their cascaded metrics/results) by two limits.
+     *
+     * A run is a victim when it falls beyond @p max_runs most-recent runs
+     * (ordered by start_time) OR its start_time is older than @p max_age_days.
+     * Either limit is disabled by passing 0. Runs still `running`/`pending` are
+     * never pruned and never count toward @p max_runs. Deletion goes through the
+     * `delete_run` cascade in start_time-batched transactions, releasing the DB
+     * mutex between batches so a large backlog cannot stall other endpoints.
+     */
+    void prune_runs (int max_runs, int max_age_days);
+
+    /**
+     * @brief Prune runs using the configured `maxRunsRetained` /
+     * `runRetentionDays` knobs. Called at startup and after a run reaches a
+     * terminal status.
+     */
+    void prune_runs_configured ();
+
     // Metrics
     void add_metric (const Metric& metric);
     void add_metrics_batch (const std::vector<Metric>& metrics); // Transactional batch insert

--- a/engine/include/vayu/utils/json.hpp
+++ b/engine/include/vayu/utils/json.hpp
@@ -76,6 +76,24 @@ const vayu::db::Run& run,
 const std::vector<vayu::db::Result>& results);
 
 /**
+ * Build the trace JSON stored in `results.trace_data` for a design-mode run.
+ *
+ * Mirrors what `store_result` (engine/src/http/routes/execution.cpp) persists:
+ * the outgoing request, the response headers/body (or the error envelope), and
+ * the per-phase timing breakdown.
+ *
+ * The request and response bodies are capped at @p max_body_bytes. When either
+ * is cut, its node gains `bodyTruncated: true` and `bodyBytes` (the original
+ * byte length) so a reader can tell a stored slice from the whole body. The cut
+ * is on a raw byte boundary - the body is an opaque string - so the caller must
+ * dump with `error_handler_t::replace` in case the slice splits a UTF-8
+ * sequence. See docs/engine/db-schema.md (results.trace_data).
+ */
+[[nodiscard]] nlohmann::json build_design_trace (const vayu::Request& request,
+const vayu::Response& response,
+size_t max_body_bytes);
+
+/**
  * @brief Deserialize a Request from JSON
  */
 [[nodiscard]] Result<Request> deserialize_request (const Json& json);

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -590,6 +590,14 @@ RunManager& manager) {
         context->should_stop ? vayu::RunStatus::Stopped : vayu::RunStatus::Completed;
         db.update_run_status_with_retry (context->run_id, final_status);
 
+        // Terminal status reached - trim old runs per the retention knobs.
+        // Best-effort: a prune failure must not fail the completed run.
+        try {
+            db.prune_runs_configured ();
+        } catch (const std::exception& e) {
+            vayu::utils::log_warning ("Run pruning failed: " + std::string (e.what ()));
+        }
+
         if (verbose) {
             vayu::utils::log_info (
             "Load test " + context->run_id + " " + vayu::to_string (final_status));
@@ -621,6 +629,13 @@ RunManager& manager) {
             db.add_metric (
             { 0, context->run_id, now_ms (), vayu::MetricName::Completed, 1.0, "" });
         } catch (...) {
+        }
+
+        // Failed is terminal too - prune per the retention knobs, best-effort.
+        try {
+            db.prune_runs_configured ();
+        } catch (const std::exception& ex) {
+            vayu::utils::log_warning ("Run pruning failed: " + std::string (ex.what ()));
         }
     }
 

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1367,7 +1367,7 @@ void Database::seed_default_config () {
     "Largest request/response body kept in a design run's stored trace. "
     "Bodies over this size are truncated in the database (the response viewer "
     "shows a notice and re-sending fetches the full body), so downloading one "
-    "huge response does not bloat storage forever. Default 1MB.",
+    "huge response does not bloat storage forever. Default 5MB.",
     "observability", std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES),
     "1024",       // 1KB
     "104857600",  // 100MB

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -32,6 +32,7 @@
 #include <sqlite3.h>
 #include <sqlite_orm/sqlite_orm.h>
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <functional>
@@ -532,6 +533,16 @@ void Database::init () {
     "wal_checkpoint=" + std::to_string (wal_checkpoint) + " pages, " +
     "busy_timeout=" + std::to_string (busy_timeout) + "ms, " +
     "synchronous=" + std::to_string (synchronous) + ")");
+
+    // Trim accumulated run history on startup (design-mode clicks and load runs
+    // are otherwise append-only). Best-effort: a prune failure must not block a
+    // successful startup.
+    try {
+        prune_runs_configured ();
+    } catch (const std::exception& e) {
+        vayu::utils::log_warning (
+        "Startup run pruning failed: " + std::string (e.what ()));
+    }
 }
 
 // ============================================================================
@@ -765,6 +776,80 @@ void Database::delete_run (const std::string& id) {
     impl_->storage.remove_all<Metric> (where (c (&Metric::run_id) == id));
     impl_->storage.remove_all<Result> (where (c (&Result::run_id) == id));
     impl_->storage.remove<Run> (id);
+}
+
+// Retention: drop runs beyond the count cap and/or older than the age cap.
+void Database::prune_runs (int max_runs, int max_age_days) {
+    // Both limits off - nothing to do (0 = unlimited for each).
+    if (max_runs <= 0 && max_age_days <= 0) {
+        return;
+    }
+
+    // 1. Select victim ids under the lock, then release it before deleting so
+    //    the (potentially large) delete loop batches its own locking below.
+    std::vector<std::string> victims;
+    {
+        std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+        // Newest first, matching get_all_runs / the count cap's "most-recent N".
+        auto runs = impl_->storage.get_all<Run> (order_by (&Run::start_time).desc ());
+
+        const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                            .count ();
+        // 0 disables the age cap; guard the multiply against overflow.
+        const int64_t age_cutoff =
+        max_age_days > 0 ? now - static_cast<int64_t> (max_age_days) * 86'400'000LL : 0;
+
+        int kept = 0;
+        for (const auto& run : runs) {
+            // In-flight runs are never pruned and do not count toward the cap.
+            if (run.status == RunStatus::Running || run.status == RunStatus::Pending) {
+                continue;
+            }
+            const bool over_count = (max_runs > 0) && (kept >= max_runs);
+            const bool too_old = (max_age_days > 0) && (run.start_time < age_cutoff);
+            if (over_count || too_old) {
+                victims.push_back (run.id);
+            } else {
+                ++kept;
+            }
+        }
+    }
+
+    if (victims.empty ()) {
+        return;
+    }
+
+    // 2. Delete via the delete_run cascade, batched so a huge backlog does not
+    //    hold the DB mutex for seconds. The lock is re-taken per batch and
+    //    released between them, letting /health, SSE and the runs poll interleave.
+    constexpr size_t BATCH_SIZE = 100;
+    for (size_t start = 0; start < victims.size (); start += BATCH_SIZE) {
+        const size_t end = std::min (start + BATCH_SIZE, victims.size ());
+        std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+        impl_->storage.transaction ([&] {
+            for (size_t i = start; i < end; ++i) {
+                const auto& id = victims[i];
+                impl_->storage.remove_all<Metric> (where (c (&Metric::run_id) == id));
+                impl_->storage.remove_all<Result> (where (c (&Result::run_id) == id));
+                impl_->storage.remove<Run> (id);
+            }
+            return true; // Commit
+        });
+    }
+
+    vayu::utils::log_info ("Pruned " + std::to_string (victims.size ()) +
+    " old run(s) (max_runs=" + std::to_string (max_runs) +
+    ", max_age_days=" + std::to_string (max_age_days) + ")");
+}
+
+void Database::prune_runs_configured () {
+    const int max_runs =
+    get_config_int ("maxRunsRetained", vayu::core::constants::database::MAX_RUNS_RETAINED);
+    const int max_age_days =
+    get_config_int ("runRetentionDays", vayu::core::constants::database::RUN_RETENTION_DAYS);
+    prune_runs (max_runs, max_age_days);
 }
 
 // ============================================================================
@@ -1275,6 +1360,36 @@ void Database::seed_default_config () {
     "1024",      // 1KB
     "104857600", // 100MB
     now });
+
+    upsert_config (ConfigEntry{ "maxTraceBodyBytes",
+    std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES), "integer",
+    "Maximum Stored Trace Body Size",
+    "Largest request/response body kept in a design run's stored trace. "
+    "Bodies over this size are truncated in the database (the response viewer "
+    "shows a notice and re-sending fetches the full body), so downloading one "
+    "huge response does not bloat storage forever. Default 1MB.",
+    "observability", std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES),
+    "1024",       // 1KB
+    "104857600",  // 100MB
+    now });
+
+    upsert_config (ConfigEntry{ "maxRunsRetained",
+    std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED), "integer",
+    "Maximum Runs Retained",
+    "Keep at most this many most-recent runs; older runs (and their metrics and "
+    "results) are pruned automatically at startup and after each run finishes. "
+    "In-progress runs are never pruned. Set to 0 to keep all runs. Default 200.",
+    "observability", std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED),
+    "0", "100000", now });
+
+    upsert_config (ConfigEntry{ "runRetentionDays",
+    std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS), "integer",
+    "Run Retention (Days)",
+    "Delete runs older than this many days (with their metrics and results) "
+    "automatically at startup and after each run finishes. In-progress runs are "
+    "never pruned. Set to 0 to keep runs regardless of age. Default 30.",
+    "observability", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
+    "0", "3650", now });
 
     upsert_config (ConfigEntry{ "sseConnectTimeout",
     std::to_string (vayu::core::constants::sse::CONNECT_TIMEOUT_MS), "integer", "SSE Connection Timeout",

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1378,7 +1378,9 @@ void Database::seed_default_config () {
     "Maximum Runs Retained",
     "Keep at most this many most-recent runs; older runs (and their metrics and "
     "results) are pruned automatically at startup and after each run finishes. "
-    "In-progress runs are never pruned. Set to 0 to keep all runs. Default 200.",
+    "Higher values - or 0 for unlimited - keep more history but grow the database "
+    "file on disk and slow down loading the run history. In-progress runs are "
+    "never pruned. Default 200.",
     "observability", std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED),
     "0", "100000", now });
 
@@ -1386,8 +1388,9 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS), "integer",
     "Run Retention (Days)",
     "Delete runs older than this many days (with their metrics and results) "
-    "automatically at startup and after each run finishes. In-progress runs are "
-    "never pruned. Set to 0 to keep runs regardless of age. Default 30.",
+    "automatically at startup and after each run finishes. Higher values - or 0 "
+    "to keep runs forever - retain more history at the cost of a larger database "
+    "file on disk. In-progress runs are never pruned. Default 30.",
     "observability", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
     "0", "3650", now });
 

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -218,40 +218,34 @@ const vayu::Response& response) {
         db_result.latency_ms  = response.timing.total_ms;
         db_result.error       = has_error ? response.error_message : "";
 
-        // Build trace data
-        nlohmann::json trace;
-        trace["request"] = { { "method", to_string (request.method) },
-            { "url", request.url }, { "headers", request.headers } };
-        if (!request.body.content.empty ()) {
-            trace["request"]["body"] = request.body.content;
-        }
+        // Build trace data, capping request/response bodies at the configured
+        // limit so a single large exchange cannot bloat the DB forever. When a
+        // body is cut, build_design_trace records bodyTruncated/bodyBytes.
+        const auto max_trace_body_bytes = static_cast<size_t> (db.get_config_int (
+        "maxTraceBodyBytes",
+        static_cast<int> (vayu::core::constants::json::MAX_TRACE_BODY_BYTES)));
+        nlohmann::json trace =
+        vayu::json::build_design_trace (request, response, max_trace_body_bytes);
 
-        if (!has_error) {
-            trace["response"] = { { "headers", response.headers },
-                { "body", response.body } };
-        } else {
-            trace["error_type"]    = to_string (response.error_code);
-            trace["error_message"] = response.error_message;
-        }
-
-        // Timing information
-        const auto& timing = response.timing;
-        if (timing.dns_ms > 0)
-            trace["dnsMs"] = timing.dns_ms;
-        if (timing.connect_ms > 0)
-            trace["connectMs"] = timing.connect_ms;
-        if (timing.tls_ms > 0)
-            trace["tlsMs"] = timing.tls_ms;
-        if (timing.first_byte_ms > 0)
-            trace["firstByteMs"] = timing.first_byte_ms;
-        if (timing.download_ms > 0)
-            trace["downloadMs"] = timing.download_ms;
-
-        db_result.trace_data = trace.dump ();
+        // A truncated body may split a UTF-8 sequence, and the raw response body
+        // can be arbitrary bytes - dump with error_handler_t::replace so a lone
+        // continuation byte becomes U+FFFD instead of throwing (import.cpp uses
+        // the same guard).
+        db_result.trace_data =
+        trace.dump (-1, ' ', false, nlohmann::json::error_handler_t::replace);
         db.add_result (db_result);
 
         auto status = has_error ? vayu::RunStatus::Failed : vayu::RunStatus::Completed;
         db.update_run_status_with_retry (run_id, status);
+
+        // A design run reached a terminal status - trim the run history so
+        // per-request clicks do not accumulate forever (retention knobs, or 0
+        // to disable). Best-effort: a prune failure must not fail the request.
+        try {
+            db.prune_runs_configured ();
+        } catch (const std::exception& e) {
+            vayu::utils::log_warning ("Run pruning failed: " + std::string (e.what ()));
+        }
 
     } catch (const std::exception& e) {
         vayu::utils::log_error ("Failed to save result: " + std::string (e.what ()));

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -153,6 +153,62 @@ const std::vector<vayu::db::Result>& results) {
     json["result"] = out;
 }
 
+namespace {
+
+// Store a body string onto @p node, capping it at @p max_body_bytes. Records
+// bodyTruncated + bodyBytes (the original length) when the body is cut so a
+// reader can tell a stored slice from the whole body.
+void store_capped_body (nlohmann::json& node, const std::string& body, size_t max_body_bytes) {
+    if (body.size () > max_body_bytes) {
+        node["body"]          = body.substr (0, max_body_bytes);
+        node["bodyTruncated"] = true;
+        node["bodyBytes"]     = body.size ();
+    } else {
+        node["body"] = body;
+    }
+}
+
+} // namespace
+
+nlohmann::json build_design_trace (const vayu::Request& request,
+const vayu::Response& response,
+size_t max_body_bytes) {
+    const bool has_error = response.has_error ();
+
+    nlohmann::json trace;
+    trace["request"] = { { "method", to_string (request.method) },
+        { "url", request.url }, { "headers", request.headers } };
+    if (!request.body.content.empty ()) {
+        store_capped_body (trace["request"], request.body.content, max_body_bytes);
+    }
+
+    if (!has_error) {
+        nlohmann::json resp;
+        resp["headers"] = response.headers;
+        store_capped_body (resp, response.body, max_body_bytes);
+        trace["response"] = std::move (resp);
+    } else {
+        trace["error_type"]    = to_string (response.error_code);
+        trace["error_message"] = response.error_message;
+    }
+
+    // Timing information: each phase is written only when non-zero (a reused
+    // connection has no connect/tls phase).
+    const auto& timing = response.timing;
+    if (timing.dns_ms > 0)
+        trace["dnsMs"] = timing.dns_ms;
+    if (timing.connect_ms > 0)
+        trace["connectMs"] = timing.connect_ms;
+    if (timing.tls_ms > 0)
+        trace["tlsMs"] = timing.tls_ms;
+    if (timing.first_byte_ms > 0)
+        trace["firstByteMs"] = timing.first_byte_ms;
+    if (timing.download_ms > 0)
+        trace["downloadMs"] = timing.download_ms;
+
+    return trace;
+}
+
 Json serialize (const vayu::db::Collection& c) {
     Json json;
     json["id"] = c.id;

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <sqlite3.h>
 
+#include <chrono>
 #include <filesystem>
 #include <set>
 #include <string>
@@ -410,6 +411,134 @@ TEST_F (DatabaseTest, RecreatesIndexesOnExistingDatabase) {
         EXPECT_TRUE (recreated.contains (expected))
         << "sync_schema did not recreate: " << expected;
     }
+}
+
+// ============================================================================
+// Run retention (prune_runs)
+// ============================================================================
+
+namespace {
+
+// A terminal run with an explicit id/start_time, plus one metric and one result
+// so prune's cascade delete is observable.
+void seed_run_with_children (Database& db,
+const std::string& id,
+int64_t start_time,
+vayu::RunStatus status = vayu::RunStatus::Completed) {
+    vayu::db::Run run;
+    run.id              = id;
+    run.type            = vayu::RunType::Design;
+    run.status          = status;
+    run.start_time      = start_time;
+    run.config_snapshot = "{}";
+    db.create_run (run);
+
+    vayu::db::Metric m;
+    m.run_id    = id;
+    m.timestamp = start_time;
+    m.name      = vayu::MetricName::TotalRequests;
+    m.value     = 1.0;
+    db.add_metric (m);
+
+    vayu::db::Result r;
+    r.run_id      = id;
+    r.timestamp   = start_time;
+    r.status_code = 200;
+    r.status_text = "OK";
+    r.latency_ms  = 1.0;
+    r.trace_data  = "{}";
+    db.add_result (r);
+}
+
+std::set<std::string> run_ids (Database& db) {
+    std::set<std::string> ids;
+    for (const auto& r : db.get_all_runs ()) {
+        ids.insert (r.id);
+    }
+    return ids;
+}
+
+} // namespace
+
+TEST_F (DatabaseTest, PruneRunsByCountKeepsMostRecentAndCascades) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    // Five terminal runs, oldest first by start_time.
+    for (int i = 1; i <= 5; ++i) {
+        seed_run_with_children (db, "run_" + std::to_string (i), i * 1000);
+    }
+
+    // Keep the 2 most-recent; age cap disabled.
+    db.prune_runs (2, 0);
+
+    auto ids = run_ids (db);
+    EXPECT_EQ (ids.size (), 2u);
+    EXPECT_TRUE (ids.count ("run_5"));
+    EXPECT_TRUE (ids.count ("run_4"));
+
+    // The pruned runs took their metrics and results with them.
+    EXPECT_TRUE (db.get_metrics ("run_1").empty ());
+    EXPECT_TRUE (db.get_results ("run_1").empty ());
+    // The survivors kept theirs.
+    EXPECT_EQ (db.get_metrics ("run_5").size (), 1u);
+    EXPECT_EQ (db.get_results ("run_5").size (), 1u);
+}
+
+TEST_F (DatabaseTest, PruneRunsByAgeDeletesOldOnly) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                        .count ();
+    const int64_t day = 86'400'000LL;
+
+    seed_run_with_children (db, "fresh", now - 1 * day);
+    seed_run_with_children (db, "stale", now - 40 * day);
+
+    // Count cap disabled; drop anything older than 30 days.
+    db.prune_runs (0, 30);
+
+    auto ids = run_ids (db);
+    EXPECT_TRUE (ids.count ("fresh"));
+    EXPECT_FALSE (ids.count ("stale"));
+    EXPECT_TRUE (db.get_metrics ("stale").empty ());
+    EXPECT_TRUE (db.get_results ("stale").empty ());
+}
+
+TEST_F (DatabaseTest, PruneRunsNeverDeletesInFlightRuns) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    // A running and a pending run sit "beyond" the cap by start_time, but must
+    // survive; they also must not count toward the cap, so the one terminal run
+    // is kept even with max_runs = 1.
+    seed_run_with_children (db, "running", 1000, vayu::RunStatus::Running);
+    seed_run_with_children (db, "pending", 2000, vayu::RunStatus::Pending);
+    seed_run_with_children (db, "done", 3000, vayu::RunStatus::Completed);
+
+    db.prune_runs (1, 0);
+
+    auto ids = run_ids (db);
+    EXPECT_TRUE (ids.count ("running"));
+    EXPECT_TRUE (ids.count ("pending"));
+    EXPECT_TRUE (ids.count ("done"));
+    EXPECT_EQ (ids.size (), 3u);
+}
+
+TEST_F (DatabaseTest, PruneRunsZeroLimitsDisableEachCap) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    const int64_t old_time = 1000; // ancient by wall-clock, so an age cap would bite
+    for (int i = 1; i <= 4; ++i) {
+        seed_run_with_children (db, "run_" + std::to_string (i), old_time + i);
+    }
+
+    // Both caps disabled: nothing is pruned even though every run is ancient.
+    db.prune_runs (0, 0);
+    EXPECT_EQ (run_ids (db).size (), 4u);
 }
 
 } // namespace

--- a/engine/tests/json_test.cpp
+++ b/engine/tests/json_test.cpp
@@ -248,5 +248,95 @@ TEST (JsonTest, SerializesMetric) {
     EXPECT_EQ (json["labels"]["region"], "us-east-1");
 }
 
+// ============================================================================
+// build_design_trace - body caps + truncation metadata
+// ============================================================================
+
+namespace {
+
+vayu::Request make_trace_request (const std::string& body) {
+    vayu::Request req;
+    req.method            = vayu::HttpMethod::POST;
+    req.url               = "http://example.test/";
+    req.headers["Accept"] = "application/json";
+    req.body.mode         = vayu::BodyMode::Text;
+    req.body.content      = body;
+    return req;
+}
+
+vayu::Response make_trace_response (const std::string& body) {
+    vayu::Response resp;
+    resp.status_code = 200;
+    resp.status_text = "OK";
+    resp.body        = body;
+    return resp;
+}
+
+} // namespace
+
+TEST (BuildDesignTrace, TruncatesOversizedBodiesAndRecordsMetadata) {
+    const size_t cap = 8;
+    // Both bodies exceed the cap.
+    auto req  = make_trace_request ("REQUESTBODY");   // 11 bytes
+    auto resp = make_trace_response ("RESPONSEBODY"); // 12 bytes
+
+    auto trace = build_design_trace (req, resp, cap);
+
+    // Response body: stored slice is exactly the cap, metadata reflects the original.
+    ASSERT_TRUE (trace["response"].contains ("body"));
+    EXPECT_EQ (trace["response"]["body"].get<std::string> ().size (), cap);
+    EXPECT_EQ (trace["response"]["body"], "RESPONSE");
+    EXPECT_TRUE (trace["response"]["bodyTruncated"].get<bool> ());
+    EXPECT_EQ (trace["response"]["bodyBytes"].get<size_t> (), 12u);
+
+    // Request body is capped the same way.
+    EXPECT_EQ (trace["request"]["body"].get<std::string> ().size (), cap);
+    EXPECT_EQ (trace["request"]["body"], "REQUESTB");
+    EXPECT_TRUE (trace["request"]["bodyTruncated"].get<bool> ());
+    EXPECT_EQ (trace["request"]["bodyBytes"].get<size_t> (), 11u);
+}
+
+TEST (BuildDesignTrace, StoresUnderCapBodyVerbatimWithoutMetadata) {
+    const size_t cap = 1024;
+    auto req  = make_trace_request ("small-request");
+    auto resp = make_trace_response ("small-response");
+
+    auto trace = build_design_trace (req, resp, cap);
+
+    EXPECT_EQ (trace["response"]["body"], "small-response");
+    EXPECT_FALSE (trace["response"].contains ("bodyTruncated"));
+    EXPECT_FALSE (trace["response"].contains ("bodyBytes"));
+
+    EXPECT_EQ (trace["request"]["body"], "small-request");
+    EXPECT_FALSE (trace["request"].contains ("bodyTruncated"));
+    EXPECT_FALSE (trace["request"].contains ("bodyBytes"));
+}
+
+TEST (BuildDesignTrace, InvalidUtf8SliceDumpsWithReplacement) {
+    // A cap that splits a multi-byte UTF-8 sequence must not make dump() throw.
+    const size_t cap = 4;
+    // "abc" + a 2-byte sequence (0xC3 0xA9 = e-acute); cap 4 keeps the lead byte only.
+    auto resp  = make_trace_response (std::string ("abc\xC3\xA9"));
+    auto req   = make_trace_request ("x");
+    auto trace = build_design_trace (req, resp, cap);
+
+    EXPECT_TRUE (trace["response"]["bodyTruncated"].get<bool> ());
+    EXPECT_NO_THROW (
+    (void)trace.dump (-1, ' ', false, nlohmann::json::error_handler_t::replace));
+}
+
+TEST (BuildDesignTrace, ErrorResponseWritesEnvelopeNotBody) {
+    auto req         = make_trace_request ("x");
+    vayu::Response resp;
+    resp.status_code    = 0;
+    resp.error_code     = vayu::ErrorCode::ConnectionFailed;
+    resp.error_message  = "could not connect";
+    auto trace = build_design_trace (req, resp, 1024);
+
+    EXPECT_FALSE (trace.contains ("response"));
+    EXPECT_EQ (trace["error_type"], "CONNECTION_FAILED");
+    EXPECT_EQ (trace["error_message"], "could not connect");
+}
+
 } // namespace
 } // namespace vayu::json

--- a/engine/tests/run_route_test.cpp
+++ b/engine/tests/run_route_test.cpp
@@ -72,3 +72,25 @@ TEST (RunRoute, DesignRunWithNoResultsStaysQuiet) {
 
     EXPECT_FALSE (json.contains ("result"));
 }
+
+// A truncated design-run trace round-trips: the bodyTruncated / bodyBytes keys
+// store_result writes survive parsing and reach GET /runs/:id's result.trace, so
+// the app readers can surface the notice.
+TEST (RunRoute, DesignRunPassesTruncationFieldsThrough) {
+    auto run    = make_run ("run_trunc", vayu::RunType::Design);
+    auto result = make_result ("run_trunc");
+    result.trace_data =
+    R"({"request":{"method":"POST","url":"http://x/","body":"REQ",)"
+    R"("bodyTruncated":true,"bodyBytes":2048},)"
+    R"("response":{"headers":{},"body":"RES","bodyTruncated":true,"bodyBytes":4096}})";
+
+    auto json = vayu::json::serialize (run);
+    vayu::json::attach_design_result (json, run, { result });
+
+    ASSERT_TRUE (json.contains ("result"));
+    const auto& trace = json["result"]["trace"];
+    EXPECT_TRUE (trace["response"]["bodyTruncated"].get<bool> ());
+    EXPECT_EQ (trace["response"]["bodyBytes"].get<int> (), 4096);
+    EXPECT_TRUE (trace["request"]["bodyTruncated"].get<bool> ());
+    EXPECT_EQ (trace["request"]["bodyBytes"].get<int> (), 2048);
+}


### PR DESCRIPTION
## Description

Fixes the two compounding unbounded-growth issues in the `runs` / `results` tables from #78.

**Part A - body cap in design-mode `store_result` (engine).** Every design-mode request persisted the full request and response body into `results.trace_data`, uncapped. New config `maxTraceBodyBytes` (`observability`, default 1 MiB, 1 KB–100 MB) caps both bodies before storage. When a body is cut, its `trace.request` / `trace.response` node gains `bodyTruncated: true` and `bodyBytes` (the original length). The cap logic is extracted into `vayu::json::build_design_trace` (unit-testable), and the trace is dumped with `error_handler_t::replace` since a byte-boundary cut can split a UTF-8 sequence. Scope is design mode only - the load-run writers store timing/error envelopes, not bodies.

**Part B - run retention (engine).** There was no retention policy; every design click and load run was permanent. New config `maxRunsRetained` (default 200) and `runRetentionDays` (default 30), each disabled by `0`. `Database::prune_runs` selects victims beyond the count cap or older than the age cap, never touching `running`/`pending` runs, and deletes through the existing `delete_run` cascade in transactions that release the DB mutex between batches. `prune_runs_configured()` runs at startup and after a run reaches a terminal status (design `store_result`; load completion/failure in `run_manager.cpp`).

**App changes (a written field must have a reader).** The trace type and `ResponseState` carry `bodyTruncated`/`bodyBytes`; `restore-response.ts` surfaces them and reports the original size; `ResponseViewer` renders a "body truncated for storage" `Callout` - covering both the request-builder cold-start restore and the History design-run view, since both render through the same viewer. `design-run-seed.ts` carries `requestBodyTruncated`, and `save-run-to-request.ts` excludes a truncated body from the write-back (shown as a kept row with the reason), so a truncated slice can never overwrite the saved request.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- **Engine gtests:** oversized body stores exactly the cap and sets the truncation fields; under-cap body stored verbatim with no metadata; a UTF-8-splitting cut still dumps without throwing; error responses write the envelope not a body; `prune_runs` deletes the right victims (with cascaded metrics/results), never deletes `running`/`pending`, and disables each cap at `0`; truncation fields pass through `attach_design_result` on `GET /runs/:id`. Full engine suite green (314/314).
- **App vitest:** `restore-response` maps the truncation fields and original size; `design-run-seed` carries `requestBodyTruncated` in both the live-request and request-gone branches; `save-run-to-request` never puts a truncated body on the patch and shows it as a kept row; the viewer renders/hides the notice. Full app suite green (1126/1126), `pnpm type-check` clean.

```bash
python build.py -t && cd engine && ctest --preset linux-dev --output-on-failure
cd app && pnpm test && pnpm type-check
```

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011qB2hPyiKEhC6GMQbTum8y)_