### PR TITLE
feat(engine): paginate and filter GET /runs, replace per-row configSnapshot with a summary

### DIFF
--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -128,8 +128,13 @@ export class EngineClient {
 		return arr.find((e) => e && typeof e === "object" && e.id === id) ?? null;
 	}
 
+	/**
+	 * First page of run history (newest first), bounded so an agent never pulls
+	 * unbounded history. Returns the `{data, pagination}` envelope; `data` rows
+	 * carry the compact `summary`, not the full config_snapshot.
+	 */
 	listRuns(signal?: AbortSignal): Promise<unknown> {
-		return this.request("GET", "/runs", undefined, signal);
+		return this.request("GET", "/runs?limit=100&offset=0", undefined, signal);
 	}
 
 	getRunReport(runId: string, signal?: AbortSignal): Promise<unknown> {

--- a/app/electron/mcp/protocol.integration.test.ts
+++ b/app/electron/mcp/protocol.integration.test.ts
@@ -38,7 +38,11 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		health: async () => ({ status: "ok", version: "9.9.9" }),
 		getConfig: async () => ({ entries: [{ key: "workers", value: "8" }] }),
 		getRunReport: async () => REPORT,
-		listRuns: async () => [{ id: "run_1" }, { id: "run_2" }],
+		// The paginated envelope the engine now returns (rows carry a summary).
+		listRuns: async () => ({
+			data: [{ id: "run_1" }, { id: "run_2" }],
+			pagination: { total: 2, limit: 100, offset: 0, hasMore: false, returned: 2 },
+		}),
 		listCollections: async () => [{ id: "col_1", name: "API" }],
 		listEnvironments: async () => [],
 		startRun: vi.fn().mockResolvedValue({ runId: "run_1", status: "running" }),

--- a/app/electron/mcp/resources.ts
+++ b/app/electron/mcp/resources.ts
@@ -70,11 +70,21 @@ export const RUN_REPORT_RESOURCE = {
 	listRuns: (ctx: ToolContext, signal?: AbortSignal) => ctx.client.listRuns(signal),
 };
 
-/** Best-effort extraction of run IDs from the loosely-typed `/runs` payload. */
+/**
+ * Best-effort extraction of run IDs from the loosely-typed `/runs` payload.
+ * Accepts both the paginated `{data: [...]}` envelope (current) and a bare
+ * array (the legacy no-param shape), so it survives either.
+ */
 export function extractRunIds(runs: unknown): string[] {
-	if (!Array.isArray(runs)) return [];
+	const rows =
+		Array.isArray(runs)
+			? runs
+			: runs && typeof runs === "object" && Array.isArray((runs as { data?: unknown }).data)
+				? (runs as { data: unknown[] }).data
+				: null;
+	if (!rows) return [];
 	const ids: string[] = [];
-	for (const r of runs) {
+	for (const r of rows) {
 		if (r && typeof r === "object") {
 			const rec = r as Record<string, unknown>;
 			const id = rec.id ?? rec.runId ?? rec._id;

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -427,7 +427,10 @@ export const TOOLS: McpTool[] = [
 		name: "list_runs",
 		category: "read",
 		description:
-			"List past runs (both single Design-mode requests and load tests), newest first.",
+			"List recent past runs (both single Design-mode requests and load tests), " +
+			"newest first. Returns a {data, pagination} envelope bounded to the first " +
+			"100 runs; each row carries a compact summary (url/method/mode/duration/" +
+			"concurrency/comment), not the full config snapshot.",
 		readOnly: true,
 		annotations: {
 			title: "List runs",

--- a/app/src/config/api-endpoints.test.ts
+++ b/app/src/config/api-endpoints.test.ts
@@ -29,6 +29,21 @@ describe("API_ENDPOINTS canonical routes", () => {
 		expect(API_ENDPOINTS.RUN_STOP("r1")).toBe("/runs/r1/stop");
 	});
 
+	it("builds the paginated /runs list URL with only the given params", () => {
+		expect(API_ENDPOINTS.RUNS_LIST({ limit: 50, offset: 0 })).toBe("/runs?limit=50&offset=0");
+		expect(
+			API_ENDPOINTS.RUNS_LIST({
+				requestId: "req_1",
+				type: "design",
+				status: "completed",
+				limit: 1,
+			})
+		).toBe("/runs?limit=1&type=design&status=completed&requestId=req_1");
+		expect(API_ENDPOINTS.RUNS_LIST({ q: "users api" })).toBe("/runs?q=users+api");
+		// No params -> bare /runs, which the engine treats as the legacy array.
+		expect(API_ENDPOINTS.RUNS_LIST({})).toBe("/runs");
+	});
+
 	it("uses /runs/:id/live for live SSE metrics", () => {
 		expect(API_ENDPOINTS.METRICS_LIVE("r1")).toBe("/runs/r1/live");
 		expect(API_ENDPOINTS.METRICS_LIVE("r1")).not.toContain("/metrics/live/");

--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -48,6 +48,27 @@ export const API_ENDPOINTS = {
 
 	// Runs
 	RUNS: `/runs`,
+	// Paginated, filtered list. Passing any param opts into the `{data,
+	// pagination}` envelope; a bare `/runs` (no params) still returns the
+	// legacy bare array (removed next minor).
+	RUNS_LIST: (params: {
+		limit?: number;
+		offset?: number;
+		type?: string;
+		status?: string;
+		requestId?: string;
+		q?: string;
+	}) => {
+		const qs = new URLSearchParams();
+		if (params.limit !== undefined) qs.set("limit", String(params.limit));
+		if (params.offset !== undefined) qs.set("offset", String(params.offset));
+		if (params.type) qs.set("type", params.type);
+		if (params.status) qs.set("status", params.status);
+		if (params.requestId) qs.set("requestId", params.requestId);
+		if (params.q) qs.set("q", params.q);
+		const s = qs.toString();
+		return s ? `/runs?${s}` : `/runs`;
+	},
 	RUN_BY_ID: (id: string) => `/runs/${id}`,
 	RUN_REPORT: (id: string) => `/runs/${id}/report`,
 	RUN_STOP: (id: string) => `/runs/${id}/stop`,

--- a/app/src/config/network.ts
+++ b/app/src/config/network.ts
@@ -38,3 +38,16 @@ export const ENGINE_MAX_DEFAULT_TIMEOUT_MS = 300_000;
 
 /** Page size when fetching time-series stats for a run. */
 export const STATS_PAGE_LIMIT = 5000;
+
+/**
+ * Page size for the paginated `GET /runs` history list. The engine caps a page
+ * at 500; the history sidebar polls only the first page (newest runs land on
+ * page 1 under start_time DESC) and pages older runs in on demand.
+ */
+export const RUNS_PAGE_LIMIT = 50;
+
+/**
+ * Page size the MCP `list_runs` tool requests - a single bounded first page,
+ * so an agent gets recent runs without downloading unbounded history.
+ */
+export const MCP_RUNS_PAGE_LIMIT = 100;

--- a/app/src/modules/history/history-store.ts
+++ b/app/src/modules/history/history-store.ts
@@ -50,27 +50,19 @@ export const useHistoryStore = create<HistoryUIState>((set) => ({
 }));
 
 /**
- * Helper function to filter and sort runs
- * Use with TanStack Query data: filterRuns(runsQuery.data ?? [], store)
+ * Filter (by type/status) and sort a run list. Search is *not* handled here:
+ * it moved server-side to the `q` param so it covers all runs, not just the
+ * pages loaded into the sidebar (see `useRunsQuery`). Type/status/sort stay
+ * client-side, applied over the currently loaded pages.
+ * Use with the flattened infinite-query data.
  */
 export function filterRuns(
 	runs: Run[],
-	filters: Pick<HistoryUIState, "searchQuery" | "filterType" | "filterStatus" | "sortBy">
+	filters: Pick<HistoryUIState, "filterType" | "filterStatus" | "sortBy">
 ): Run[] {
-	const { searchQuery, filterType, filterStatus, sortBy } = filters;
+	const { filterType, filterStatus, sortBy } = filters;
 
 	let filtered = runs;
-
-	// Apply search filter
-	if (searchQuery.trim()) {
-		const query = searchQuery.toLowerCase();
-		filtered = filtered.filter(
-			(run) =>
-				run.id.toLowerCase().includes(query) ||
-				(run.requestId && run.requestId.toLowerCase().includes(query)) ||
-				run.configSnapshot?.url?.toLowerCase().includes(query)
-		);
-	}
 
 	// Apply type filter
 	if (filterType !== "all") {

--- a/app/src/modules/history/main/DesignRunView.tsx
+++ b/app/src/modules/history/main/DesignRunView.tsx
@@ -244,7 +244,8 @@ export default function DesignRunView({ run }: DesignRunViewProps) {
 				}
 
 				// A resend is a new run, so History has to hear about it.
-				queryClient.invalidateQueries({ queryKey: queryKeys.runs.list() });
+				queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
+				queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
 				if (preScriptParts) {
 					queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.globals.all });

--- a/app/src/modules/history/sidebar/HistoryList.error.test.tsx
+++ b/app/src/modules/history/sidebar/HistoryList.error.test.tsx
@@ -33,19 +33,45 @@ import { TooltipProvider } from "@/components/ui";
 import HistoryList from "./HistoryList";
 
 const refetch = vi.fn();
-const queryState = {
-	runs: {
-		data: [] as unknown[],
+
+// Wrap rows in the infinite-query envelope shape HistoryList flattens.
+function infinite(rows: unknown[], total = rows.length) {
+	return {
+		pages: [
+			{
+				data: rows,
+				pagination: { total, limit: 50, offset: 0, hasMore: false, returned: rows.length },
+			},
+		],
+		pageParams: [0],
+	};
+}
+
+function state(over: Record<string, unknown> = {}) {
+	return {
+		data: infinite([]),
 		isLoading: false,
 		isError: false,
 		error: null as Error | null,
 		refetch,
-	},
+		fetchNextPage: vi.fn(),
+		hasNextPage: false,
+		isFetchingNextPage: false,
+		...over,
+	};
+}
+
+const queryState = {
+	runs: state() as ReturnType<typeof state>,
 };
 
 vi.mock("@/queries", () => ({
 	useRunsQuery: () => queryState.runs,
 	useDeleteRunMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	flattenRunPages: (d: { pages?: Array<{ data: unknown[] }> } | undefined) =>
+		d?.pages?.flatMap((p) => p.data) ?? [],
+	runsTotal: (d: { pages?: Array<{ pagination: { total: number } }> } | undefined) =>
+		d?.pages?.[0]?.pagination.total ?? 0,
 }));
 
 // Stubbed so a fixture run only needs the fields `filterRuns` reads. RunItem's
@@ -54,13 +80,7 @@ vi.mock("./RunItem", () => ({
 	default: ({ run }: { run: { id: string } }) => <div>run-{run.id}</div>,
 }));
 
-const failed = {
-	data: [] as unknown[],
-	isLoading: false,
-	isError: true,
-	error: new Error("Failed to fetch"),
-	refetch,
-};
+const failed = state({ isError: true, error: new Error("Failed to fetch") });
 
 function renderList() {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -75,7 +95,7 @@ function renderList() {
 
 beforeEach(() => {
 	refetch.mockReset();
-	queryState.runs = { data: [], isLoading: false, isError: false, error: null, refetch };
+	queryState.runs = state();
 });
 
 describe("HistoryList when the runs query fails", () => {
@@ -102,13 +122,11 @@ describe("HistoryList when the runs query fails", () => {
 	it("keeps a working list when a background refetch fails", () => {
 		// TanStack keeps the last good data through a failed refetch. Replacing
 		// a populated list with an error pane takes away more than it says.
-		queryState.runs = {
-			data: [{ id: "r1", type: "load", status: "completed", startTime: 1 }],
-			isLoading: false,
+		queryState.runs = state({
+			data: infinite([{ id: "r1", type: "load", status: "completed", startTime: 1 }]),
 			isError: true,
 			error: new Error("Failed to fetch"),
-			refetch,
-		};
+		});
 		renderList();
 
 		expect(screen.getByText("run-r1")).toBeInTheDocument();

--- a/app/src/modules/history/sidebar/HistoryList.tsx
+++ b/app/src/modules/history/sidebar/HistoryList.tsx
@@ -5,11 +5,11 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Search, Clock } from "lucide-react";
 import { useTabsStore, useLayoutStore } from "@/stores";
 import { useHistoryStore, filterRuns } from "@/modules/history/history-store";
-import { useRunsQuery, useDeleteRunMutation } from "@/queries";
+import { useRunsQuery, useDeleteRunMutation, flattenRunPages, runsTotal } from "@/queries";
 import {
 	DrawerPanel,
 	EmptyState,
@@ -50,15 +50,36 @@ export default function HistoryList() {
 	const navigateToRunDetail = (runId: string) => openTab({ type: "run", entityId: runId });
 	const navigateToHistory = () => activateDrawerView("history");
 
-	// Use TanStack Query for runs data
-	const { data: allRuns = [], isLoading, isError, error, refetch } = useRunsQuery();
+	// Debounce the search box into the server-side `q` param so a search covers
+	// all runs (not just loaded pages) without a request per keystroke.
+	const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
+	useEffect(() => {
+		const t = setTimeout(() => setDebouncedSearch(searchQuery), 300);
+		return () => clearTimeout(t);
+	}, [searchQuery]);
+
+	// Infinite runs query over the paginated envelope; polls the first page.
+	const {
+		data,
+		isLoading,
+		isError,
+		error,
+		refetch,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = useRunsQuery(debouncedSearch);
 	const deleteRunMutation = useDeleteRunMutation();
 
 	const [deletingId, setDeletingId] = useState<string | null>(null);
 	const [deleteConfirmRunId, setDeleteConfirmRunId] = useState<string | null>(null);
 
-	// Filter and sort runs using the helper function
-	const runs = filterRuns(allRuns, { searchQuery, filterType, filterStatus, sortBy });
+	// Flatten (de-duped) the loaded pages, then apply the client-side type/
+	// status/sort filters over them. `total` is the server's count for the
+	// current search.
+	const allRuns = flattenRunPages(data);
+	const total = runsTotal(data);
+	const runs = filterRuns(allRuns, { filterType, filterStatus, sortBy });
 
 	/*
 	 * The drawer has three sibling views. The collections tree already tells the
@@ -79,7 +100,7 @@ export default function HistoryList() {
 		? allRuns.find((r) => r.id === deleteConfirmRunId)
 		: null;
 	const deleteConfirmLabel =
-		runToDelete?.configSnapshot?.url ??
+		runToDelete?.summary?.url ??
 		(deleteConfirmRunId ? `${deleteConfirmRunId.slice(0, 8)}…` : "");
 
 	const handleDeleteClick = (runId: string, event: React.MouseEvent) => {
@@ -106,9 +127,9 @@ export default function HistoryList() {
 		<DrawerPanel
 			title="History"
 			actions={
-				allRuns.length > 0 ? (
+				total > 0 ? (
 					<span className="text-xs text-muted-foreground shrink-0">
-						{allRuns.length} {allRuns.length === 1 ? "run" : "runs"}
+						{total} {total === 1 ? "run" : "runs"}
 					</span>
 				) : undefined
 			}
@@ -242,6 +263,20 @@ export default function HistoryList() {
 									isSelected={selectedRunId === run.id}
 								/>
 							))}
+
+						{/* Older runs page in on demand - the poll only refreshes
+						    the first page. */}
+						{!isLoading && !showError && hasNextPage && (
+							<Button
+								variant="ghost"
+								size="sm"
+								className="w-full"
+								onClick={() => void fetchNextPage()}
+								disabled={isFetchingNextPage}
+							>
+								{isFetchingNextPage ? "Loading…" : "Load older runs"}
+							</Button>
+						)}
 					</div>
 				</div>
 

--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -43,12 +43,13 @@ export default function RunItem({
 		return formatRelativeTime(new Date(timestamp).toISOString());
 	};
 
-	// Get URL and method from configSnapshot (unified flat structure)
+	// Read from the compact list-row summary (paginated GET /runs). The full
+	// configSnapshot lives only on GET /runs/:id, which the list does not fetch.
 	const getRequestInfo = () => {
-		if (!run.configSnapshot) return { url: null, method: null };
-		const url = run.configSnapshot.url || null;
-		const method = run.configSnapshot.method || "GET";
-		const type = run.configSnapshot.mode;
+		if (!run.summary) return { url: null, method: null };
+		const url = run.summary.url || null;
+		const method = run.summary.method || "GET";
+		const type = run.summary.mode;
 		return { url, method, type };
 	};
 
@@ -170,18 +171,18 @@ export default function RunItem({
 				)}
 
 				{/* Config Info (if load test) */}
-				{run.type === "load" && run.configSnapshot && (
+				{run.type === "load" && run.summary && (
 					<div className="flex items-center gap-3 text-[10px] text-muted-foreground mt-1.5 flex-wrap">
-						{run.configSnapshot.duration && (
+						{run.summary.duration && (
 							<span className="flex items-center gap-1 shrink-0">
 								<Clock className="w-3 h-3" />
-								{run.configSnapshot.duration}
+								{run.summary.duration}
 							</span>
 						)}
-						{run.configSnapshot.concurrency && (
+						{run.summary.concurrency && (
 							<span className="flex items-center gap-1 shrink-0">
 								<Activity className="w-3 h-3" />
-								{run.configSnapshot.concurrency} workers
+								{run.summary.concurrency} workers
 							</span>
 						)}
 						{loadTestType && (
@@ -194,9 +195,9 @@ export default function RunItem({
 				)}
 
 				{/* Comment if exists */}
-				{run.configSnapshot?.comment && (
+				{run.summary?.comment && (
 					<p className="text-xs text-muted-foreground italic mt-1.5 break-words">
-						"{run.configSnapshot.comment}"
+						"{run.summary.comment}"
 					</p>
 				)}
 			</div>

--- a/app/src/modules/settings/main/panels/GeneralPanel.clear-history.test.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.clear-history.test.tsx
@@ -36,7 +36,7 @@ const runs = [
 ];
 
 vi.mock("@/queries/runs", () => ({
-	useRunsQuery: () => ({ data: runs }),
+	useAllRunsQuery: () => ({ data: runs }),
 	useInvalidateRuns: () => invalidateRuns,
 }));
 

--- a/app/src/modules/settings/main/panels/GeneralPanel.reset.test.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.reset.test.tsx
@@ -27,7 +27,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import GeneralPanel from "./GeneralPanel";
 
 vi.mock("@/queries/runs", () => ({
-	useRunsQuery: () => ({ data: [] }),
+	useAllRunsQuery: () => ({ data: [] }),
 	useInvalidateRuns: () => vi.fn(),
 }));
 

--- a/app/src/modules/settings/main/panels/GeneralPanel.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.tsx
@@ -29,7 +29,7 @@ import {
 import { modKey } from "@/lib/platform";
 import { useClientSettingsStore } from "@/stores";
 import { useToastStore } from "@/stores";
-import { useRunsQuery, useInvalidateRuns } from "@/queries/runs";
+import { useAllRunsQuery, useInvalidateRuns } from "@/queries/runs";
 import { apiService } from "@/services";
 import { AUTO_SAVE_DELAY_OPTIONS } from "@/constants/client-settings";
 import { OptionButtons, ToggleRow } from "./SettingControls";
@@ -48,7 +48,9 @@ export default function GeneralPanel() {
 	const setAutoSave = useClientSettingsStore((s) => s.setAutoSave);
 	const resetAll = useClientSettingsStore((s) => s.resetAll);
 
-	const { data: runs = [] } = useRunsQuery();
+	// The whole history (all pages) - this panel counts and clears every run,
+	// not just a polled page.
+	const { data: runs = [] } = useAllRunsQuery();
 	const invalidateRuns = useInvalidateRuns();
 	const showToast = useToastStore((s) => s.showToast);
 	const [clearing, setClearing] = useState(false);

--- a/app/src/modules/welcome/WelcomeScreen.error.test.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.error.test.tsx
@@ -56,6 +56,7 @@ const queryState = {
 vi.mock("@/queries", () => ({
 	useCollectionsQuery: () => queryState.collections,
 	useRunsQuery: () => queryState.runs,
+	flattenRunPages: (d: Run[] | undefined) => d ?? [],
 	useCreateRequestMutation: () => ({ mutateAsync: vi.fn() }),
 	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn() }),
 	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map() }),

--- a/app/src/modules/welcome/WelcomeScreen.test.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.test.tsx
@@ -18,6 +18,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/queries", () => ({
 	useCollectionsQuery: () => mocks.collections,
 	useRunsQuery: () => mocks.runs,
+	// The mock feeds a flat array as `data`; WelcomeScreen pipes it through
+	// flattenRunPages, so identity here keeps the flat fixtures unchanged.
+	flattenRunPages: (d: Run[] | undefined) => d ?? [],
 	useCreateRequestMutation: () => ({ mutateAsync: mocks.createRequest }),
 	useCreateCollectionMutation: () => ({ mutateAsync: mocks.createCollection }),
 	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map() }),

--- a/app/src/modules/welcome/WelcomeScreen.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.tsx
@@ -28,6 +28,7 @@ import {
 import {
 	useCollectionsQuery,
 	useRunsQuery,
+	flattenRunPages,
 	useCreateRequestMutation,
 	useCreateCollectionMutation,
 } from "@/queries";
@@ -56,12 +57,14 @@ export default function WelcomeScreen() {
 		refetch: refetchCollections,
 	} = useCollectionsQuery();
 	const {
-		data: runs = [],
+		data: runsData,
 		isLoading: runsLoading,
 		isError: runsFailed,
 		error: runsError,
 		refetch: refetchRuns,
 	} = useRunsQuery();
+	// Flatten the loaded pages; the Launcher only shows the most recent handful.
+	const runs = flattenRunPages(runsData);
 	const createRequestMutation = useCreateRequestMutation();
 	const createCollectionMutation = useCreateCollectionMutation();
 

--- a/app/src/modules/welcome/components/RecentRuns.test.tsx
+++ b/app/src/modules/welcome/components/RecentRuns.test.tsx
@@ -15,9 +15,9 @@
  * with nothing distinguishing one row from the next - the only way to find out
  * which run was which was to open it.
  *
- * The identifier is the method and URL from `configSnapshot`, not the request's
- * name: runs store no name, and `requestId` is set only for design runs, so
- * every load test would have nothing to look up.
+ * The identifier is the method and URL from the run `summary` (the compact list
+ * row), not the request's name: runs store no name, and `requestId` is set only
+ * for design runs, so every load test would have nothing to look up.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -33,7 +33,7 @@ function run(over: Partial<Run> = {}): Run {
 		status: "completed",
 		startTime: Date.now() - 60_000,
 		endTime: Date.now(),
-		configSnapshot: { url: "http://localhost:8080/fast", method: "GET" },
+		summary: { url: "http://localhost:8080/fast", method: "GET" },
 		...over,
 	} as Run;
 }
@@ -56,12 +56,12 @@ describe("RecentRuns", () => {
 				runs={[
 					run({
 						id: "a",
-						configSnapshot: { url: "https://api.test/one", method: "GET" },
+						summary: { url: "https://api.test/one", method: "GET" },
 					}),
 					run({
 						id: "b",
 						startTime: Date.now() - 120_000,
-						configSnapshot: { url: "https://api.test/two", method: "POST" },
+						summary: { url: "https://api.test/two", method: "POST" },
 					}),
 				]}
 			/>
@@ -80,9 +80,9 @@ describe("RecentRuns", () => {
 	});
 
 	it("says so rather than rendering a blank row when no URL was recorded", () => {
-		// `configSnapshot` is optional on the type and absent on older runs; a
-		// bare row would read as a rendering failure.
-		render(<RecentRuns runs={[run({ configSnapshot: undefined })]} />);
+		// `summary` is optional on the type and absent on older runs; a bare row
+		// would read as a rendering failure.
+		render(<RecentRuns runs={[run({ summary: undefined })]} />);
 		expect(screen.getByText(/No URL recorded/i)).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /Open load test run/i })).toBeInTheDocument();
 	});

--- a/app/src/modules/welcome/components/RecentRuns.tsx
+++ b/app/src/modules/welcome/components/RecentRuns.tsx
@@ -17,8 +17,8 @@
  * Completed · 2 hours ago" five times over, with nothing to tell one row from
  * the next - you had to open a run to find out which one it was.
  *
- * The identifier is the method and URL from `configSnapshot`, which is what the
- * history sidebar shows for the same records. Not the request's *name*: a run
+ * The identifier is the method and URL from the run `summary`, which is what
+ * the history sidebar shows for the same records. Not the request's *name*: a run
  * stores no name, and `requestId` is only set for design runs, so most rows -
  * every load test - would have nothing to look up. The snapshot's URL is
  * always there, and it is the truth about what was actually sent, even if the
@@ -65,8 +65,8 @@ export function RecentRuns({ runs }: { runs: Run[] }) {
 			<div className="flex flex-col">
 				{recent.map((run) => {
 					const status = statusLabel(run.status);
-					const url = run.configSnapshot?.url;
-					const method = run.configSnapshot?.method;
+					const url = run.summary?.url;
+					const method = run.summary?.method;
 					return (
 						<button
 							key={run.id}

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -35,6 +35,9 @@ export { RequestNotFoundError } from "./collections";
 // Runs (History)
 export {
 	useRunsQuery,
+	useAllRunsQuery,
+	flattenRunPages,
+	runsTotal,
 	useRunQuery,
 	useRunReportQuery,
 	useLastDesignRunQuery,

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -36,7 +36,12 @@ export const queryKeys = {
 	runs: {
 		all: ["runs"] as const,
 		lists: () => [...queryKeys.runs.all, "list"] as const,
-		list: () => [...queryKeys.runs.lists()] as const,
+		// Paginated list cache is keyed by its server-side filters (q), so
+		// different searches cache separately. `lists()` is the prefix used to
+		// invalidate/patch every variant at once.
+		list: (filters: Record<string, unknown> = {}) =>
+			[...queryKeys.runs.lists(), filters] as const,
+		allRuns: () => [...queryKeys.runs.all, "allRuns"] as const,
 		details: () => [...queryKeys.runs.all, "detail"] as const,
 		detail: (id: string) => [...queryKeys.runs.details(), id] as const,
 		report: (id: string) => [...queryKeys.runs.all, "report", id] as const,

--- a/app/src/queries/runs.query.test.tsx
+++ b/app/src/queries/runs.query.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The runs list is a paginated, filtered server query, not a client-side scan.
+ *
+ * - `useLastDesignRunQuery` must ask the server for exactly one row
+ *   (`requestId` + `type=design` + `status=completed` + `limit=1`) and trust
+ *   its start_time DESC order - no download-the-whole-list-and-filter.
+ * - `useRunsQuery` is an infinite query over the `{data, pagination}` envelope:
+ *   `fetchNextPage` advances the offset, and `flattenRunPages` de-dupes rows
+ *   that a head insertion can momentarily place in two refetched pages.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useLastDesignRunQuery, useRunsQuery, flattenRunPages } from "./runs";
+import type { RunListResponse } from "@/types";
+
+const listRuns = vi.fn();
+const getRunReport = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		listRuns: (...a: unknown[]) => listRuns(...a),
+		getRunReport: (...a: unknown[]) => getRunReport(...a),
+	},
+}));
+
+function page(rows: RunListResponse["data"], over: Partial<RunListResponse["pagination"]> = {}) {
+	return {
+		data: rows,
+		pagination: {
+			total: rows.length,
+			limit: 50,
+			offset: 0,
+			hasMore: false,
+			returned: rows.length,
+			...over,
+		},
+	} satisfies RunListResponse;
+}
+
+function makeClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	listRuns.mockReset();
+	getRunReport.mockReset();
+});
+
+describe("useLastDesignRunQuery", () => {
+	it("issues one filtered single-run call, not a full-list scan", async () => {
+		listRuns.mockResolvedValue(
+			page([{ id: "run_9", type: "design", status: "completed", startTime: 5, endTime: 6 }])
+		);
+		getRunReport.mockResolvedValue({ summary: {}, latency: {} });
+
+		const { result } = renderHook(() => useLastDesignRunQuery("req_1"), {
+			wrapper: wrapper(makeClient()),
+		});
+
+		await waitFor(() => expect(result.current.run?.id).toBe("run_9"));
+		expect(listRuns).toHaveBeenCalledTimes(1);
+		expect(listRuns).toHaveBeenCalledWith({
+			requestId: "req_1",
+			type: "design",
+			status: "completed",
+			limit: 1,
+		});
+	});
+
+	it("does not fetch when there is no request id", () => {
+		renderHook(() => useLastDesignRunQuery(null), { wrapper: wrapper(makeClient()) });
+		expect(listRuns).not.toHaveBeenCalled();
+	});
+});
+
+describe("useRunsQuery", () => {
+	it("paginates: fetchNextPage advances the offset off the envelope", async () => {
+		listRuns.mockImplementation(({ offset }: { offset: number }) =>
+			offset === 0
+				? Promise.resolve(
+						page(
+							[
+								{
+									id: "a",
+									type: "load",
+									status: "completed",
+									startTime: 2,
+									endTime: 3,
+								},
+							],
+							{
+								total: 2,
+								hasMore: true,
+								offset: 0,
+							}
+						)
+					)
+				: Promise.resolve(
+						page(
+							[
+								{
+									id: "b",
+									type: "load",
+									status: "completed",
+									startTime: 1,
+									endTime: 2,
+								},
+							],
+							{
+								total: 2,
+								hasMore: false,
+								offset: 50,
+							}
+						)
+					)
+		);
+
+		const { result } = renderHook(() => useRunsQuery(), { wrapper: wrapper(makeClient()) });
+
+		await waitFor(() => expect(result.current.data?.pages.length).toBe(1));
+		expect(result.current.hasNextPage).toBe(true);
+
+		await result.current.fetchNextPage();
+		await waitFor(() => expect(result.current.data?.pages.length).toBe(2));
+		expect(result.current.hasNextPage).toBe(false);
+		// Second call requested offset = first offset + limit.
+		expect(listRuns).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 50 }));
+		expect(flattenRunPages(result.current.data).map((r) => r.id)).toEqual(["a", "b"]);
+	});
+
+	it("passes a trimmed search as the q param, omitting a blank one", async () => {
+		listRuns.mockResolvedValue(page([]));
+
+		renderHook(() => useRunsQuery("  users  "), { wrapper: wrapper(makeClient()) });
+		await waitFor(() => expect(listRuns).toHaveBeenCalled());
+		expect(listRuns).toHaveBeenCalledWith(expect.objectContaining({ q: "users" }));
+
+		listRuns.mockClear();
+		renderHook(() => useRunsQuery("   "), { wrapper: wrapper(makeClient()) });
+		await waitFor(() => expect(listRuns).toHaveBeenCalled());
+		expect(listRuns).toHaveBeenCalledWith(expect.objectContaining({ q: undefined }));
+	});
+});
+
+describe("flattenRunPages", () => {
+	it("de-dupes by id across pages, keeping the first occurrence", () => {
+		const data = {
+			pages: [
+				page([{ id: "x", type: "load", status: "completed", startTime: 3, endTime: 4 }]),
+				page([
+					{ id: "x", type: "load", status: "completed", startTime: 3, endTime: 4 },
+					{ id: "y", type: "load", status: "completed", startTime: 2, endTime: 3 },
+				]),
+			],
+			pageParams: [0, 50],
+		};
+		expect(flattenRunPages(data).map((r) => r.id)).toEqual(["x", "y"]);
+	});
+
+	it("is empty for undefined", () => {
+		expect(flattenRunPages(undefined)).toEqual([]);
+	});
+});

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -11,24 +11,81 @@
  * TanStack Query hooks for run history operations.
  */
 
-import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
+import {
+	useQuery,
+	useMutation,
+	useQueryClient,
+	useInfiniteQuery,
+	type InfiniteData,
+} from "@tanstack/react-query";
 import { apiService } from "@/services/api";
 import { queryKeys } from "./keys";
 import { QUERY_CACHE } from "@/config/cache";
-import { STATS_PAGE_LIMIT } from "@/config/network";
-import type { Run } from "@/types";
+import { STATS_PAGE_LIMIT, RUNS_PAGE_LIMIT } from "@/config/network";
+import type { Run, RunListResponse } from "@/types";
 import type { TimeSeriesResponse } from "@/modules/history/types";
 
 // ============ Run Queries ============
 
 /**
- * Fetch all runs (history)
+ * Fetch run history as an infinite query over the `{data, pagination}`
+ * envelope, newest first. The 5s `refetchInterval` keeps the loaded pages
+ * fresh - in the default state that is just the first page, so new runs (which
+ * land on page 1 under start_time DESC) appear without re-fetching older pages.
+ * Older pages are fetched on demand via `fetchNextPage`.
+ *
+ * @param q Optional server-side substring search over the stored snapshot.
+ *          Type/status/sort stay client-side (see history-store `filterRuns`).
  */
-export function useRunsQuery() {
-	return useQuery({
-		queryKey: queryKeys.runs.list(),
-		queryFn: () => apiService.listRuns(),
+export function useRunsQuery(q?: string) {
+	const search = q?.trim() || undefined;
+	return useInfiniteQuery<RunListResponse, Error>({
+		queryKey: queryKeys.runs.list({ q: search }),
+		queryFn: ({ pageParam = 0 }) =>
+			apiService.listRuns({ q: search, limit: RUNS_PAGE_LIMIT, offset: pageParam as number }),
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) =>
+			lastPage.pagination.hasMore
+				? lastPage.pagination.offset + lastPage.pagination.limit
+				: undefined,
 		refetchInterval: 5000, // 5 seconds
+	});
+}
+
+/**
+ * Flatten an infinite runs query's pages into a de-duplicated list. Dedup by id
+ * matters because offset pagination + head insertions (a new run prepends to
+ * page 1) can momentarily place one run in two refetched pages; keeping the
+ * first occurrence avoids a doubled row.
+ */
+export function flattenRunPages(data: InfiniteData<RunListResponse> | undefined): Run[] {
+	if (!data) return [];
+	const seen = new Set<string>();
+	const runs: Run[] = [];
+	for (const page of data.pages) {
+		for (const run of page.data) {
+			if (seen.has(run.id)) continue;
+			seen.add(run.id);
+			runs.push(run);
+		}
+	}
+	return runs;
+}
+
+/** Total run count matching the query, from the first loaded page's envelope. */
+export function runsTotal(data: InfiniteData<RunListResponse> | undefined): number {
+	return data?.pages[0]?.pagination.total ?? 0;
+}
+
+/**
+ * Fetch every run (all pages) as a flat list. For callers that need the whole
+ * set rather than a polled page - counting and clearing history in Settings.
+ * Not polled; rows carry the compact summary so it stays cheap.
+ */
+export function useAllRunsQuery() {
+	return useQuery({
+		queryKey: queryKeys.runs.allRuns(),
+		queryFn: () => apiService.listAllRuns(),
 	});
 }
 
@@ -84,29 +141,38 @@ export function useRunTimeSeriesQuery(runId: string | null) {
 }
 
 /**
- * Find the last design run for a specific request
- * Returns the most recent completed design run and its report
+ * Find the last completed design run for a specific request. One filtered
+ * server call (`requestId`, `type=design`, `status=completed`, `limit=1`) -
+ * the server already sorts start_time DESC, so the single row it returns is
+ * the most recent. No client-side download-and-filter.
  */
 export function useLastDesignRunQuery(requestId: string | null | undefined) {
-	const { data: runs = [] } = useRunsQuery();
+	const { data, isLoading: runLoading } = useQuery({
+		queryKey: queryKeys.runs.list({
+			requestId: requestId ?? "",
+			type: "design",
+			status: "completed",
+			limit: 1,
+		}),
+		queryFn: () =>
+			apiService.listRuns({
+				requestId: requestId!,
+				type: "design",
+				status: "completed",
+				limit: 1,
+			}),
+		enabled: !!requestId,
+	});
 
-	// Find the most recent completed design run for this request
-	const lastDesignRun = requestId
-		? runs
-				.filter(
-					(r) =>
-						r.type === "design" && r.requestId === requestId && r.status === "completed"
-				)
-				.sort((a, b) => b.startTime - a.startTime)[0] || null
-		: null;
+	const lastDesignRun = data?.data[0] ?? null;
 
 	// Fetch the report for that run
-	const { data: report, isLoading } = useRunReportQuery(lastDesignRun?.id || null);
+	const { data: report, isLoading: reportLoading } = useRunReportQuery(lastDesignRun?.id || null);
 
 	return {
 		run: lastDesignRun,
 		report,
-		isLoading,
+		isLoading: runLoading || reportLoading,
 	};
 }
 
@@ -121,10 +187,35 @@ export function useDeleteRunMutation() {
 	return useMutation({
 		mutationFn: (runId: string) => apiService.deleteRun(runId),
 		onSuccess: (_, deletedId) => {
-			// Remove from cache
+			// Remove from every infinite-list cache variant (each search caches
+			// separately). Patch the InfiniteData page shape in place: drop the
+			// row and decrement the mirrored total so the count stays right.
+			queryClient.setQueriesData<InfiniteData<RunListResponse>>(
+				{ queryKey: queryKeys.runs.lists() },
+				(old) => {
+					if (!old) return old;
+					return {
+						...old,
+						pages: old.pages.map((page) => {
+							const data = page.data.filter((r) => r.id !== deletedId);
+							if (data.length === page.data.length) return page;
+							return {
+								...page,
+								data,
+								pagination: {
+									...page.pagination,
+									total: Math.max(0, page.pagination.total - 1),
+									returned: data.length,
+								},
+							};
+						}),
+					};
+				}
+			);
+			// Keep the all-runs (Settings) cache in step.
 			queryClient.setQueryData<Run[]>(
-				queryKeys.runs.list(),
-				(old) => old?.filter((r) => r.id !== deletedId) ?? []
+				queryKeys.runs.allRuns(),
+				(old) => old?.filter((r) => r.id !== deletedId) ?? old
 			);
 			// Remove report from cache
 			queryClient.removeQueries({
@@ -135,27 +226,47 @@ export function useDeleteRunMutation() {
 }
 
 /**
- * Add a new run to the cache (used after starting a load test)
+ * Add a new run to the front of the first list page (after starting a load
+ * test), so it shows immediately without waiting for the next poll.
  */
 export function useAddRunToCache() {
 	const queryClient = useQueryClient();
 
 	return (newRun: Run) => {
-		queryClient.setQueryData<Run[]>(queryKeys.runs.list(), (old) =>
-			old ? [newRun, ...old] : [newRun]
+		queryClient.setQueriesData<InfiniteData<RunListResponse>>(
+			{ queryKey: queryKeys.runs.lists() },
+			(old) => {
+				if (!old || old.pages.length === 0) return old;
+				const [first, ...rest] = old.pages;
+				return {
+					...old,
+					pages: [
+						{
+							...first,
+							data: [newRun, ...first.data],
+							pagination: {
+								...first.pagination,
+								total: first.pagination.total + 1,
+								returned: first.data.length + 1,
+							},
+						},
+						...rest,
+					],
+				};
+			}
 		);
 	};
 }
 
 /**
- * Invalidate runs list (trigger refetch)
+ * Invalidate every runs list (trigger refetch) - both the polled infinite list
+ * and the all-runs Settings query.
  */
 export function useInvalidateRuns() {
 	const queryClient = useQueryClient();
 
 	return () => {
-		queryClient.invalidateQueries({
-			queryKey: queryKeys.runs.list(),
-		});
+		queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
+		queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
 	};
 }

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -22,6 +22,8 @@ import type {
 	GlobalVariables,
 	VariableValue,
 	Run,
+	RunListResponse,
+	RunListParams,
 	RunReport,
 	EngineHealth,
 	SanityResult,
@@ -57,6 +59,7 @@ import {
 	PROXIED_TIMEOUT_GRACE_MS,
 	ENGINE_MAX_DEFAULT_TIMEOUT_MS,
 	STATS_PAGE_LIMIT,
+	RUNS_PAGE_LIMIT,
 } from "@/config/network";
 
 /**
@@ -197,9 +200,36 @@ export const apiService = {
 	},
 
 	// Run Management
-	async listRuns(): Promise<Run[]> {
-		// Backend returns flat array directly
-		return await httpClient.get<Run[]>(API_ENDPOINTS.RUNS);
+	/**
+	 * List runs, newest first, as a `{data, pagination}` envelope. Passing
+	 * pagination/filter params opts into the envelope; the history sidebar polls
+	 * the first page and pages older runs in on demand.
+	 */
+	async listRuns(params: RunListParams = {}): Promise<RunListResponse> {
+		const { limit = RUNS_PAGE_LIMIT, offset = 0, type, status, requestId, q } = params;
+		return await httpClient.get<RunListResponse>(
+			API_ENDPOINTS.RUNS_LIST({ limit, offset, type, status, requestId, q })
+		);
+	},
+
+	/**
+	 * Fetch every run matching @p params by paging to exhaustion. For callers
+	 * that genuinely need the whole set (clearing all history, counting) rather
+	 * than a polled page. Rows still carry the compact `summary`, so this stays
+	 * cheap even over a large history.
+	 */
+	async listAllRuns(params: Omit<RunListParams, "limit" | "offset"> = {}): Promise<Run[]> {
+		const limit = 500; // Engine's max page size.
+		const all: Run[] = [];
+		let offset = 0;
+		// Bounded by pagination.hasMore; the engine caps limit at 500.
+		for (;;) {
+			const page = await this.listRuns({ ...params, limit, offset });
+			all.push(...page.data);
+			if (!page.pagination.hasMore) break;
+			offset += page.pagination.limit;
+		}
+		return all;
 	},
 
 	async getRun(id: string): Promise<Run> {

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -298,17 +298,60 @@ export interface RunResult {
 	trace?: RunResultTrace;
 }
 
+/**
+ * The compact per-row summary the paginated `GET /runs` list carries in place
+ * of the full {@link RunConfigSnapshot}. Exactly the six keys the history and
+ * dashboard list UIs read; each is omitted by the engine when absent from the
+ * stored snapshot. The full snapshot is still available on `GET /runs/:id`.
+ */
+export interface RunSummary {
+	url?: string;
+	method?: string;
+	mode?: string;
+	duration?: string;
+	concurrency?: number;
+	comment?: string;
+}
+
 export interface Run {
 	id: string;
 	type: "load" | "design";
 	status: "pending" | "running" | "completed" | "stopped" | "failed";
 	startTime: number; // Unix timestamp in ms
 	endTime: number;
+	/**
+	 * Present on list rows from the paginated `GET /runs`. The single-run
+	 * `GET /runs/:id` returns {@link configSnapshot} instead.
+	 */
+	summary?: RunSummary;
+	/** Full snapshot - present on `GET /runs/:id`, not on paginated list rows. */
 	configSnapshot?: RunConfigSnapshot;
 	requestId?: string | null;
 	environmentId?: string | null;
 	/** The exchange, present only for a design run once it has completed or failed. */
 	result?: RunResult;
+}
+
+/** The `{data, pagination}` envelope the paginated `GET /runs` returns. */
+export interface RunListResponse {
+	data: Run[];
+	pagination: {
+		total: number;
+		limit: number;
+		offset: number;
+		hasMore: boolean;
+		returned: number;
+	};
+}
+
+/** Server-side filters for the paginated `GET /runs` list. */
+export interface RunListParams {
+	limit?: number;
+	offset?: number;
+	type?: "load" | "design";
+	status?: Run["status"];
+	requestId?: string;
+	q?: string;
 }
 
 /** Load-test execution strategy. Single source of truth for the mode union. */

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -149,8 +149,12 @@ apiService.startLoadTest(data): Promise<StartLoadTestResponse>
 #### Run Management
 
 ```typescript
-apiService.listRuns(): Promise<Run[]>
-apiService.getRun(id): Promise<Run>
+// Paginated, filtered history (newest first). Rows carry a compact `summary`
+// (url/method/mode/duration/concurrency/comment), not the full configSnapshot.
+apiService.listRuns(params?: RunListParams): Promise<RunListResponse>
+// Every page as a flat list (Settings' count + clear).
+apiService.listAllRuns(params?): Promise<Run[]>
+apiService.getRun(id): Promise<Run>            // full configSnapshot
 apiService.getRunReport(id): Promise<RunReport>
 apiService.stopRun(id): Promise<StopRunResponse>
 apiService.deleteRun(id): Promise<void>

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -304,7 +304,10 @@ UI-only: Search, filter (type/status), and sort (newest/oldest) for the history 
 }
 ```
 
-**Helper:** `filterRuns(runs, filters)` applies filters and sorting to server data.
+**Helper:** `filterRuns(runs, filters)` applies **type/status filtering and
+sorting** to the loaded pages. Search is **not** handled here: `searchQuery` is
+debounced into the server-side `q` param (see `useRunsQuery`) so it covers all
+runs, not just the pages loaded into the sidebar.
 
 **Key Methods:**
 ```typescript
@@ -388,13 +391,33 @@ Located in `app/src/services/queries/` (or `hooks/`), with types and cache inval
 
 #### Runs & History
 
-- **`useRunsQuery()`** - Fetch all runs
-- **`useRunQuery(runId)`** - Fetch single run
+- **`useRunsQuery(q?)`** - Run history as an **infinite query** over the
+  paginated `GET /runs` `{data, pagination}` envelope, newest first. Mirrors
+  `useRunTimeSeriesQuery`'s `getNextPageParam` on the same envelope shape;
+  `fetchNextPage` pages older runs in on demand. The 5s `refetchInterval` keeps
+  the loaded pages fresh - in the default (unpaged) state that is **only the
+  first page**, so new runs (which land on page 1 under `start_time DESC`)
+  appear without re-fetching older pages. `q` is the optional server-side search.
+  - **`flattenRunPages(data)`** - flatten the pages into a de-duped `Run[]`
+    (dedupe by id guards the momentary double-row a head insertion can cause
+    across two refetched pages). **`runsTotal(data)`** - the server's total from
+    the first page.
+- **`useAllRunsQuery()`** - Every run (all pages) as a flat list, for callers
+  that need the whole set rather than a polled page (Settings' count + clear).
+  Not polled.
+- **`useLastDesignRunQuery(requestId)`** - The most recent completed design run
+  for a request, in **one** filtered call
+  (`?requestId=&type=design&status=completed&limit=1`) - the server sorts
+  `start_time DESC`, so its single row is the answer. No client-side
+  download-and-filter.
+- **`useRunQuery(runId)`** - Fetch single run (full `configSnapshot`)
 - **`useRunReportQuery(runId)`** - Fetch final report for a run
 
 **Mutations:**
 - **`useStopRunMutation()`** - Stop a running load test
-- **`useDeleteRunMutation()`** - Delete a run
+- **`useDeleteRunMutation()`** - Delete a run. Patches every infinite-list cache
+  variant in place (drops the row, decrements the mirrored `total`) plus the
+  all-runs cache.
 
 #### Engine Health & Config
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -47,6 +47,12 @@ canonical paths.
 `GET /stats/:id` in its **SSE** mode is legacy DB-polling and is retained
 wholesale (no canonical rename); prefer `GET /runs/:id/live` for live metrics.
 
+`GET /runs` with **no query params** is likewise a deprecated shape: it returns
+the pre-pagination bare array of full-`configSnapshot` rows. Passing any
+pagination/filter param returns the `{data, pagination}` envelope with compact
+`summary` rows (see [GET /runs](#get-runs)). The no-param array is removed at the
+next minor release.
+
 ## Health & Configuration
 
 ### GET /health
@@ -877,9 +883,55 @@ are configurable via `POST /config`.
 
 ### GET /runs
 
-List all test runs (both design mode and load tests).
+List test runs (both design mode and load tests), newest first
+(`start_time DESC` - the only order the UI uses). Rows carry a compact
+`summary` rather than the full `configSnapshot`, so the polled history sidebar
+stays cheap as history grows.
 
-**Response:**
+**Query parameters** (passing **any** of them opts into the paginated envelope):
+- `limit` - page size (default 50, invalid/&le;0 falls back to 50, capped at 500).
+- `offset` - rows to skip (default 0, negative floored to 0).
+- `type` - `design` | `load` (an unrecognised value is ignored, not an error).
+- `status` - a `RunStatus` string (`pending` | `running` | `completed` | `failed` | `stopped`; unrecognised ignored).
+- `requestId` - exact match on the run's linked request.
+- `q` - case-insensitive substring **over the stored `config_snapshot` text**
+  (SQL `LIKE`). It searches the raw snapshot, so it may over-match JSON keys or
+  structure - acceptable for a search box.
+
+**`summary`** carries exactly these six keys, each **omitted** when absent from
+the snapshot (a malformed snapshot yields an empty `summary`, never a `500`):
+`url`, `method`, `mode`, `duration`, `concurrency`, `comment`. The full snapshot
+stays available on `GET /runs/:runId`.
+
+**Response (envelope):**
+```json
+{
+  "data": [
+    {
+      "id": "run_1234567890",
+      "requestId": "req_1234567890",
+      "environmentId": null,
+      "type": "load",
+      "status": "completed",
+      "startTime": 1234567890,
+      "endTime": 1234567891,
+      "summary": {
+        "url": "https://api.example.com/users",
+        "method": "GET",
+        "mode": "constant_rps",
+        "duration": "60s",
+        "concurrency": 100,
+        "comment": "nightly"
+      }
+    }
+  ],
+  "pagination": { "total": 812, "limit": 50, "offset": 0, "hasMore": true, "returned": 50 }
+}
+```
+
+**Legacy no-param behavior (deprecated, removed next minor).** A request with
+**no query params at all** returns today's bare array of full-`configSnapshot`
+rows unchanged, so external scripts keep working:
 ```json
 [
   {
@@ -894,6 +946,10 @@ List all test runs (both design mode and load tests).
   }
 ]
 ```
+This legacy branch is a temporary alias (like those in
+[Deprecated aliases](#deprecated-aliases)) and is removed at the next minor
+release; new callers should always pass pagination params and read the
+`{data, pagination}` envelope.
 
 ### GET /runs/:runId
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -304,7 +304,8 @@ for fresh **and** pre-existing databases, so adding an index is additive and nee
 | `idx_results_run_id`         | `results.run_id`        | `get_results` and the `remove_all` in `delete_run`                                                                                                |
 | `idx_requests_collection_id` | `requests.collection_id`| `get_requests_in_collection` (every sidebar load) and cascade delete                                                                              |
 | `idx_collections_parent_id`  | `collections.parent_id` | The cascade-delete BFS in `Database::delete_collection`, which does one lookup per node in the subtree                                            |
-| `idx_runs_start_time`        | `runs.start_time`       | `get_all_runs`, which sorts on every `GET /runs`                                                                                                  |
+| `idx_runs_start_time`        | `runs.start_time`       | `get_all_runs` and `get_runs_paginated`, which sort `start_time DESC` on every `GET /runs`                                                        |
+| `idx_runs_request_id`        | `runs.request_id`       | `GET /runs?requestId=` and `useLastDesignRunQuery`'s single-run lookup (`get_runs_paginated` with a `request_id` filter)                          |
 
 `metrics` and `results` are the unbounded-growth tables - a load run writes roughly 20 metric
 rows per second - so without `run_id` indexes a lookup slows down with every run ever recorded,

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -125,7 +125,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `list_collections`     | read     | `GET /collections`                           | -                          |
 | `list_requests`        | read     | `GET /requests?collectionId=`                | -                          |
 | `list_environments`    | read     | `GET /environments`                          | -                          |
-| `list_runs`            | read     | `GET /runs`                                  | -                          |
+| `list_runs`            | read     | `GET /runs?limit=100`                        | First page (100) of the `{data, pagination}` envelope; rows carry a compact summary |
 | `get_run_report`       | read     | `GET /runs/:id/report`                       | -                          |
 | `get_engine_config`    | read     | `GET /config`                                | -                          |
 | `get_live_metrics`     | read     | SSE snapshot of last N ticks                 | -                          |
@@ -220,7 +220,7 @@ Read-only Vayu data an agent can attach as context (`resources.ts`):
 
 | URI                         | Contents                         |
 | --------------------------- | -------------------------------- |
-| `vayu://runs`               | All runs, newest first.          |
+| `vayu://runs`               | Recent runs (first page, 100), newest first. |
 | `vayu://collections`        | All request collections.         |
 | `vayu://environments`       | All environments.                |
 | `vayu://config`             | Engine configuration entries.    |

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -386,6 +386,7 @@ if(VAYU_BUILD_TESTS)
         tests/import_route_test.cpp
         tests/config_route_test.cpp
         tests/requests_route_test.cpp
+        tests/runs_route_test.cpp
         tests/collections_route_test.cpp
         tests/stats_route_test.cpp
         tests/execution_timeout_test.cpp
@@ -405,6 +406,7 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/import.cpp
         src/http/routes/config.cpp
         src/http/routes/requests.cpp
+        src/http/routes/runs.cpp
         src/http/routes/collections.cpp
         src/http/routes/metrics.cpp
         src/http/routes/oauth.cpp

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -19,6 +19,20 @@
 #include "vayu/types.hpp"
 
 namespace vayu::db {
+
+/**
+ * Optional filters for the paginated GET /runs list. An unset field is a
+ * wildcard - it does not constrain the query. `q` is a case-insensitive
+ * substring matched against the stored `config_snapshot` text (via SQL LIKE);
+ * it may over-match JSON keys/structure, which is acceptable for a search box.
+ */
+struct RunFilter {
+    std::optional<RunType> type;
+    std::optional<RunStatus> status;
+    std::optional<std::string> request_id;
+    std::optional<std::string> q;
+};
+
 class Database {
     public:
     explicit Database (const std::string& db_path);
@@ -59,6 +73,11 @@ class Database {
     void update_run_status_with_retry (const std::string& id, RunStatus status, int max_retries = 3);
     void update_run_end_time (const std::string& id); // Update end_time without changing status
     std::vector<Run> get_all_runs ();
+    // Paginated, filtered run list ordered start_time DESC (newest first) - the
+    // only order the UI uses. count_runs returns the total matching @p filter
+    // (ignoring limit/offset) for the pagination envelope.
+    std::vector<Run> get_runs_paginated (const RunFilter& filter, int64_t limit, int64_t offset);
+    int64_t count_runs (const RunFilter& filter);
     void delete_run (const std::string& id);
 
     // Metrics

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -196,8 +196,11 @@ inline auto make_storage (const std::string& path) {
     make_index ("idx_requests_collection_id", &Request::collection_id),
     // The cascade-delete BFS in delete_collection walks one lookup per node.
     make_index ("idx_collections_parent_id", &Collection::parent_id),
-    // get_all_runs sorts the whole table on every GET /runs.
+    // get_all_runs / get_runs_paginated sort the whole table on every GET /runs.
     make_index ("idx_runs_start_time", &Run::start_time),
+    // GET /runs?requestId= (and useLastDesignRunQuery's single-run lookup)
+    // filter on request_id; the design-run seed hits this per opened request.
+    make_index ("idx_runs_request_id", &Run::request_id),
 
     // ─────────────── PROJECT MANAGEMENT TABLES ───────────────
 
@@ -757,6 +760,41 @@ void Database::update_run_status_with_retry (const std::string& id, RunStatus st
 std::vector<Run> Database::get_all_runs () {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     return impl_->storage.get_all<Run> (order_by (&Run::start_time).desc ());
+}
+
+namespace {
+// Compose the sqlite_orm WHERE for a RunFilter. Each optional filter becomes
+// `(column == value) OR <inactive>`, where <inactive> is a bound `true` when
+// the filter is unset - so an unset field is a wildcard and the same compiled
+// expression serves every filter combination (no per-combination branching).
+// `q` is a substring LIKE over config_snapshot (see RunFilter's contract).
+auto run_filter_where (const RunFilter& filter) {
+    const bool no_type   = !filter.type.has_value ();
+    const bool no_status = !filter.status.has_value ();
+    const bool no_req    = !filter.request_id.has_value ();
+    const bool no_q      = !filter.q.has_value () || filter.q->empty ();
+
+    const RunType type_val     = filter.type.value_or (RunType::Design);
+    const RunStatus status_val = filter.status.value_or (RunStatus::Pending);
+    const std::string req_val  = filter.request_id.value_or ("");
+    const std::string q_pat    = "%" + (filter.q ? *filter.q : std::string{}) + "%";
+
+    return where ((c (&Run::type) == type_val || no_type) &&
+    (c (&Run::status) == status_val || no_status) &&
+    (c (&Run::request_id) == req_val || no_req) &&
+    (like (&Run::config_snapshot, q_pat) || no_q));
+}
+} // namespace
+
+std::vector<Run> Database::get_runs_paginated (const RunFilter& filter, int64_t limit, int64_t offset) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.get_all<Run> (run_filter_where (filter),
+    order_by (&Run::start_time).desc (), sqlite_orm::limit (offset, limit));
+}
+
+int64_t Database::count_runs (const RunFilter& filter) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.count<Run> (run_filter_where (filter));
 }
 
 // Cascade delete: removes metrics and results first

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -15,25 +15,179 @@
 #include "vayu/utils/logger.hpp"
 #include "vayu/utils/metrics_helper.hpp"
 
+#include <algorithm>
+#include <utility>
+
 namespace vayu::http::routes {
+
+namespace {
+
+// Copy src[key] to dst[key] when present and not null. Shared by the list-row
+// `summary` builder and the report route's `config_obj` (which adds a few
+// renamed keys on top) so the two extract config fields the same way.
+void add_if_present (nlohmann::json& dst, const nlohmann::json& src, const char* key) {
+    if (src.contains (key) && !src[key].is_null ())
+        dst[key] = src[key];
+}
+
+// The compact list-row summary: exactly the six keys the history/dashboard
+// list UIs read, each omitted when absent from the snapshot. A malformed
+// config_snapshot yields an empty object, never an error - the full snapshot
+// stays available on GET /runs/:id.
+nlohmann::json build_run_summary (const std::string& config_snapshot) {
+    nlohmann::json summary = nlohmann::json::object ();
+    try {
+        auto config = nlohmann::json::parse (config_snapshot);
+        if (config.is_object ()) {
+            for (const char* key :
+            { "url", "method", "mode", "duration", "concurrency", "comment" }) {
+                add_if_present (summary, config, key);
+            }
+        }
+    } catch (...) {
+        // Malformed snapshot -> empty summary (never a 500).
+    }
+    return summary;
+}
+
+// Serialize one run into a list row: identity + status + the compact summary,
+// deliberately *without* the full config_snapshot (that is what makes the list
+// cheap). Mirrors the camelCase keys vayu::json::serialize(Run) emits.
+nlohmann::json serialize_run_row (const vayu::db::Run& run) {
+    nlohmann::json row;
+    row["id"]        = run.id;
+    row["type"]      = vayu::to_string (run.type);
+    row["status"]    = vayu::to_string (run.status);
+    row["startTime"] = run.start_time;
+    row["endTime"]   = run.end_time;
+    row["requestId"] =
+    run.request_id.has_value () ? nlohmann::json (*run.request_id) : nlohmann::json (nullptr);
+    row["environmentId"] = run.environment_id.has_value () ?
+    nlohmann::json (*run.environment_id) :
+    nlohmann::json (nullptr);
+    row["summary"] = build_run_summary (run.config_snapshot);
+    return row;
+}
+
+} // namespace
+
+/**
+ * Testable core of the paginated GET /runs list, returning {http_status,
+ * json_body}. Always 200 - a list of zero rows is a valid list, not a 404.
+ *
+ * `limit`/`offset` arrive already parsed and clamped by the caller (limit
+ * default 50, capped at 500; offset floored at 0); `filter` holds the already
+ * validated type/status/requestId/q constraints. Rows carry the compact
+ * `summary` (six keys) instead of the full `config_snapshot`, wrapped in the
+ * same `{data, pagination}` envelope GET /runs/:id/metrics uses (post-#86).
+ *
+ * Extracted so the envelope shape, clamping and filtering are covered without
+ * an in-process HTTP server - see runs_route_test.cpp. Exceptions propagate to
+ * the route's try/catch (500).
+ */
+std::pair<int, nlohmann::json> get_runs_response (vayu::db::Database& db,
+const vayu::db::RunFilter& filter, int64_t limit, int64_t offset) {
+    const int64_t total = db.count_runs (filter);
+    auto runs           = db.get_runs_paginated (filter, limit, offset);
+
+    nlohmann::json data = nlohmann::json::array ();
+    for (const auto& run : runs) {
+        data.push_back (serialize_run_row (run));
+    }
+
+    nlohmann::json response;
+    response["data"]                   = std::move (data);
+    response["pagination"]["total"]    = total;
+    response["pagination"]["limit"]    = limit;
+    response["pagination"]["offset"]   = offset;
+    response["pagination"]["hasMore"]  = (offset + static_cast<int64_t> (runs.size ())) < total;
+    response["pagination"]["returned"] = runs.size ();
+    return { 200, response };
+}
 
 void register_run_routes (RouteContext& ctx) {
     /**
-     * GET /runs
-     * Retrieves all test runs from the database.
-     * Returns both "design" mode single requests and "load" mode test runs.
+     * GET /runs?limit=&offset=&type=&status=&requestId=&q=
+     * Lists test runs (both "design" single requests and "load" tests), newest
+     * first. Rows carry a compact `summary` (url/method/mode/duration/
+     * concurrency/comment) instead of the full config_snapshot, wrapped in the
+     * `{data, pagination}` envelope.
+     *
+     * Query params:
+     * - limit: page size, default 50, capped at 500
+     * - offset: rows to skip, floored at 0
+     * - type: "design" | "load" (invalid -> ignored)
+     * - status: RunStatus string (invalid -> ignored)
+     * - requestId: exact match
+     * - q: case-insensitive substring over the stored config_snapshot text
+     *
+     * Back-compat (removed next minor): a request with *no* query params at all
+     * returns the legacy bare array of full-configSnapshot rows unchanged, so
+     * external scripts keep working. Any recognised param opts into the envelope.
      */
-    ctx.server.Get ("/runs", [&ctx] (const httplib::Request&, httplib::Response& res) {
-        vayu::utils::log_info ("GET /runs - Fetching all runs");
-        try {
-            auto runs                = ctx.db.get_all_runs ();
-            nlohmann::json json_runs = nlohmann::json::array ();
-            for (const auto& run : runs) {
-                json_runs.push_back (vayu::json::serialize (run));
+    ctx.server.Get ("/runs", [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const bool wants_envelope = req.has_param ("limit") || req.has_param ("offset") ||
+        req.has_param ("type") || req.has_param ("status") ||
+        req.has_param ("requestId") || req.has_param ("q");
+
+        if (!wants_envelope) {
+            // Legacy no-param path: today's bare array, byte-shape-identical.
+            vayu::utils::log_info ("GET /runs - Fetching all runs (legacy)");
+            try {
+                auto runs                = ctx.db.get_all_runs ();
+                nlohmann::json json_runs = nlohmann::json::array ();
+                for (const auto& run : runs) {
+                    json_runs.push_back (vayu::json::serialize (run));
+                }
+                vayu::utils::log_debug (
+                "GET /runs - Returning " + std::to_string (runs.size ()) + " runs");
+                res.set_content (json_runs.dump (), "application/json");
+            } catch (const std::exception& e) {
+                vayu::utils::log_error ("GET /runs - Error: " + std::string (e.what ()));
+                send_error (res, 500, e.what ());
             }
-            vayu::utils::log_debug (
-            "GET /runs - Returning " + std::to_string (runs.size ()) + " runs");
-            res.set_content (json_runs.dump (), "application/json");
+            return;
+        }
+
+        // Parse + clamp pagination; validate filters (invalid enum -> ignored).
+        int64_t limit = 50;
+        if (req.has_param ("limit")) {
+            try {
+                limit = std::stoll (req.get_param_value ("limit"));
+            } catch (...) {
+                limit = 50;
+            }
+            if (limit <= 0)
+                limit = 50;
+            limit = std::min<int64_t> (limit, 500); // Cap page size.
+        }
+        int64_t offset = 0;
+        if (req.has_param ("offset")) {
+            try {
+                offset = std::stoll (req.get_param_value ("offset"));
+            } catch (...) {
+                offset = 0;
+            }
+            if (offset < 0)
+                offset = 0;
+        }
+
+        vayu::db::RunFilter filter;
+        if (req.has_param ("type"))
+            filter.type = vayu::parse_run_type (req.get_param_value ("type"));
+        if (req.has_param ("status"))
+            filter.status = vayu::parse_run_status (req.get_param_value ("status"));
+        if (req.has_param ("requestId"))
+            filter.request_id = req.get_param_value ("requestId");
+        if (req.has_param ("q"))
+            filter.q = req.get_param_value ("q");
+
+        vayu::utils::log_info ("GET /runs - Listing runs (limit=" +
+        std::to_string (limit) + ", offset=" + std::to_string (offset) + ")");
+        try {
+            auto [status, body] = get_runs_response (ctx.db, filter, limit, offset);
+            res.status          = status;
+            res.set_content (body.dump (), "application/json");
         } catch (const std::exception& e) {
             vayu::utils::log_error ("GET /runs - Error: " + std::string (e.what ()));
             send_error (res, 500, e.what ());
@@ -351,24 +505,16 @@ void register_run_routes (RouteContext& ctx) {
                 }
 
                 nlohmann::json config_obj;
-                if (config.contains ("mode"))
-                    config_obj["mode"] = config["mode"];
-                if (config.contains ("duration"))
-                    config_obj["duration"] = config["duration"];
+                // Straight copies share the list-row summary's helper; `rps`
+                // is the one rename (-> targetRps), so it stays inline.
+                for (const char* key : { "mode", "duration", "concurrency",
+                     "startConcurrency", "rampUpDuration", "timeout", "comment" }) {
+                    add_if_present (config_obj, config, key);
+                }
                 if (config.contains ("rps"))
                     config_obj["targetRps"] = config["rps"];
                 if (config.contains ("targetRps"))
                     config_obj["targetRps"] = config["targetRps"];
-                if (config.contains ("concurrency"))
-                    config_obj["concurrency"] = config["concurrency"];
-                if (config.contains ("startConcurrency"))
-                    config_obj["startConcurrency"] = config["startConcurrency"];
-                if (config.contains ("rampUpDuration"))
-                    config_obj["rampUpDuration"] = config["rampUpDuration"];
-                if (config.contains ("timeout"))
-                    config_obj["timeout"] = config["timeout"];
-                if (config.contains ("comment") && !config["comment"].is_null ())
-                    config_obj["comment"] = config["comment"];
 
                 if (!config_obj.empty ()) {
                     metadata["configuration"] = config_obj;

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -1,0 +1,259 @@
+/**
+ * @file tests/runs_route_test.cpp
+ * @brief Tests for the paginated GET /runs list (get_runs_response) and the
+ * DB-level filtering/pagination it rests on (get_runs_paginated / count_runs).
+ *
+ * Focus: the list must return the `{data, pagination}` envelope with compact
+ * per-row `summary` objects (not the full config_snapshot), honour each filter
+ * (type / status / requestId / q), clamp limit/offset, and never 500 on a
+ * malformed snapshot. The legacy no-param path (a bare array of full
+ * configSnapshot rows) is preserved by vayu::json::serialize(Run), asserted
+ * here too so a change to the row shape cannot silently break external scripts.
+ *
+ * Covers the route's extracted core in isolation, matching the suite's other
+ * route tests (no in-process HTTP server).
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/db/database.hpp"
+#include "vayu/utils/json.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in runs.cpp; returns {http_status, json_body}.
+std::pair<int, nlohmann::json> get_runs_response (vayu::db::Database& db,
+const vayu::db::RunFilter& filter, int64_t limit, int64_t offset);
+} // namespace vayu::http::routes
+
+namespace {
+
+class RunsRouteTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_runs_route.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + s);
+        }
+    }
+
+    struct RunSpec {
+        std::string id;
+        vayu::RunType type            = vayu::RunType::Load;
+        vayu::RunStatus status        = vayu::RunStatus::Completed;
+        int64_t start_time            = 0;
+        std::optional<std::string> request_id = std::nullopt;
+        std::string config_snapshot   = R"({"url":"https://x.test/","method":"GET"})";
+    };
+
+    void seed (const RunSpec& s) {
+        vayu::db::Run run;
+        run.id              = s.id;
+        run.type            = s.type;
+        run.status          = s.status;
+        run.request_id      = s.request_id;
+        run.environment_id  = std::nullopt;
+        run.config_snapshot = s.config_snapshot;
+        run.start_time      = s.start_time;
+        run.end_time        = s.start_time + 1;
+        db_->create_run (run);
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// The happy path: envelope keys, DESC ordering by start_time, and the compact
+// summary in place of the full config_snapshot.
+TEST_F (RunsRouteTest, EnvelopeShapeAndNewestFirst) {
+    seed ({ .id = "run_a", .start_time = 100 });
+    seed ({ .id = "run_b", .start_time = 300 });
+    seed ({ .id = "run_c", .start_time = 200 });
+
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    EXPECT_EQ (status, 200);
+
+    ASSERT_TRUE (body.contains ("data"));
+    ASSERT_TRUE (body["data"].is_array ());
+    ASSERT_EQ (body["data"].size (), 3u);
+    // Newest first.
+    EXPECT_EQ (body["data"][0]["id"], "run_b");
+    EXPECT_EQ (body["data"][1]["id"], "run_c");
+    EXPECT_EQ (body["data"][2]["id"], "run_a");
+
+    // Rows carry summary, never the full config_snapshot.
+    const auto& row = body["data"][0];
+    EXPECT_TRUE (row.contains ("summary"));
+    EXPECT_FALSE (row.contains ("configSnapshot"));
+    EXPECT_TRUE (row.contains ("requestId"));
+    EXPECT_TRUE (row.contains ("environmentId"));
+
+    const auto& pag = body["pagination"];
+    EXPECT_EQ (pag["total"], 3);
+    EXPECT_EQ (pag["limit"], 50);
+    EXPECT_EQ (pag["offset"], 0);
+    EXPECT_EQ (pag["returned"], 3);
+    EXPECT_EQ (pag["hasMore"], false);
+}
+
+TEST_F (RunsRouteTest, PaginationHasMoreAndOffset) {
+    for (int i = 0; i < 5; ++i)
+        seed ({ .id = "run_" + std::to_string (i), .start_time = i });
+
+    auto [_, page1] = vayu::http::routes::get_runs_response (*db_, {}, 2, 0);
+    EXPECT_EQ (page1["data"].size (), 2u);
+    EXPECT_EQ (page1["pagination"]["total"], 5);
+    EXPECT_EQ (page1["pagination"]["hasMore"], true);
+    EXPECT_EQ (page1["pagination"]["returned"], 2);
+
+    auto [__, page3] = vayu::http::routes::get_runs_response (*db_, {}, 2, 4);
+    EXPECT_EQ (page3["data"].size (), 1u);
+    EXPECT_EQ (page3["pagination"]["hasMore"], false);
+}
+
+TEST_F (RunsRouteTest, SummaryHasExactlySixKeysAndOmitsAbsent) {
+    seed ({ .id = "run_full",
+    .config_snapshot = R"({"url":"https://a/","method":"POST","mode":"constant_rps",
+    "duration":"60s","concurrency":100,"comment":"nightly","headers":{"X":"1"}})" });
+    seed ({ .id = "run_sparse", .start_time = 1,
+    .config_snapshot = R"({"url":"https://b/"})" });
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    // Sparse row is newest (start_time 1 > 0).
+    const auto& sparse = body["data"][0]["summary"];
+    EXPECT_EQ (body["data"][0]["id"], "run_sparse");
+    EXPECT_EQ (sparse.size (), 1u); // only url present
+    EXPECT_EQ (sparse["url"], "https://b/");
+    EXPECT_FALSE (sparse.contains ("comment"));
+
+    const auto& full = body["data"][1]["summary"];
+    // Exactly the six documented keys, no more (headers must not leak in).
+    EXPECT_EQ (full.size (), 6u);
+    for (const char* k : { "url", "method", "mode", "duration", "concurrency", "comment" })
+        EXPECT_TRUE (full.contains (k)) << k;
+    EXPECT_FALSE (full.contains ("headers"));
+    EXPECT_EQ (full["concurrency"], 100);
+}
+
+TEST_F (RunsRouteTest, MalformedSnapshotYieldsEmptySummaryNot500) {
+    seed ({ .id = "run_bad", .config_snapshot = "not valid json {{{" });
+
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    EXPECT_EQ (status, 200);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_TRUE (body["data"][0]["summary"].is_object ());
+    EXPECT_TRUE (body["data"][0]["summary"].empty ());
+}
+
+TEST_F (RunsRouteTest, FilterByType) {
+    seed ({ .id = "run_load", .type = vayu::RunType::Load });
+    seed ({ .id = "run_design", .type = vayu::RunType::Design, .start_time = 1 });
+
+    vayu::db::RunFilter f;
+    f.type = vayu::RunType::Design;
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_EQ (body["data"][0]["id"], "run_design");
+    EXPECT_EQ (body["pagination"]["total"], 1);
+}
+
+TEST_F (RunsRouteTest, FilterByStatus) {
+    seed ({ .id = "run_done", .status = vayu::RunStatus::Completed });
+    seed ({ .id = "run_fail", .status = vayu::RunStatus::Failed, .start_time = 1 });
+
+    vayu::db::RunFilter f;
+    f.status = vayu::RunStatus::Failed;
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_EQ (body["data"][0]["id"], "run_fail");
+}
+
+TEST_F (RunsRouteTest, FilterByRequestId) {
+    seed ({ .id = "run_1", .request_id = "req_A" });
+    seed ({ .id = "run_2", .start_time = 1, .request_id = "req_B" });
+    seed ({ .id = "run_3", .start_time = 2, .request_id = std::nullopt });
+
+    vayu::db::RunFilter f;
+    f.request_id = "req_A";
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_EQ (body["data"][0]["id"], "run_1");
+    EXPECT_EQ (body["data"][0]["requestId"], "req_A");
+}
+
+TEST_F (RunsRouteTest, FilterByQSubstringOverSnapshot) {
+    seed ({ .id = "run_users", .config_snapshot = R"({"url":"https://api/users"})" });
+    seed ({ .id = "run_orders", .start_time = 1,
+    .config_snapshot = R"({"url":"https://api/orders"})" });
+
+    vayu::db::RunFilter f;
+    f.q = "orders";
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 50, 0);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_EQ (body["data"][0]["id"], "run_orders");
+}
+
+TEST_F (RunsRouteTest, FiltersCombine) {
+    seed ({ .id = "keep", .type = vayu::RunType::Design,
+    .status = vayu::RunStatus::Completed, .request_id = "req_X" });
+    seed ({ .id = "wrong_status", .type = vayu::RunType::Design,
+    .status = vayu::RunStatus::Failed, .start_time = 1, .request_id = "req_X" });
+    seed ({ .id = "wrong_type", .type = vayu::RunType::Load,
+    .status = vayu::RunStatus::Completed, .start_time = 2, .request_id = "req_X" });
+
+    vayu::db::RunFilter f;
+    f.type       = vayu::RunType::Design;
+    f.status     = vayu::RunStatus::Completed;
+    f.request_id = "req_X";
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, f, 1, 0);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_EQ (body["data"][0]["id"], "keep");
+    EXPECT_EQ (body["pagination"]["total"], 1);
+}
+
+// count_runs / get_runs_paginated agree on the filtered total.
+TEST_F (RunsRouteTest, DbCountMatchesFilter) {
+    seed ({ .id = "a", .status = vayu::RunStatus::Completed });
+    seed ({ .id = "b", .status = vayu::RunStatus::Completed, .start_time = 1 });
+    seed ({ .id = "c", .status = vayu::RunStatus::Failed, .start_time = 2 });
+
+    vayu::db::RunFilter f;
+    f.status = vayu::RunStatus::Completed;
+    EXPECT_EQ (db_->count_runs (f), 2);
+    EXPECT_EQ (db_->get_runs_paginated (f, 50, 0).size (), 2u);
+    EXPECT_EQ (db_->count_runs ({}), 3); // no filter -> everything
+}
+
+// The legacy no-param path serializes runs with the full configSnapshot (and
+// no `summary`). This is what the route returns when called with zero query
+// params; asserting the serializer keeps that shape guards external scripts.
+TEST_F (RunsRouteTest, LegacySerializationKeepsConfigSnapshot) {
+    seed ({ .id = "run_legacy",
+    .config_snapshot = R"({"url":"https://a/","method":"GET","headers":{"X":"1"}})" });
+
+    auto runs = db_->get_all_runs ();
+    ASSERT_EQ (runs.size (), 1u);
+    auto legacy = vayu::json::serialize (runs.front ());
+    EXPECT_TRUE (legacy.contains ("configSnapshot"));
+    EXPECT_FALSE (legacy.contains ("summary"));
+    // Full snapshot, including keys the summary would drop.
+    EXPECT_TRUE (legacy["configSnapshot"].contains ("headers"));
+}
+
+} // namespace


### PR DESCRIPTION
## Description

`GET /runs` returned **every run ever recorded**, each with its full `config_snapshot` JSON, and the app polled it every 5s (`useRunsQuery`) for as long as the history sidebar was mounted, so the call's cost grew monotonically for the life of the install.

This makes the list paginated, filtered, and cheap:

**Engine**
- `GET /runs?limit=&offset=&type=&status=&requestId=&q=` returns the `{data, pagination}` envelope (post-#86 shape), newest first (`start_time DESC`). `limit` defaults 50, capped 500; `offset` floored 0; invalid `type`/`status` ignored; `q` is a case-insensitive `LIKE` over the stored snapshot text.
- Rows carry a compact **`summary`** (`url`, `method`, `mode`, `duration`, `concurrency`, `comment`, each omitted when absent) instead of the full snapshot. A malformed snapshot yields an empty `summary`, never a 500. The full snapshot stays on `GET /runs/:id`.
- **Back-compat:** a request with *no* params at all still returns today's legacy bare array (deprecated, removed next minor).
- `Database::get_runs_paginated` / `count_runs` take a `RunFilter` (dynamic `WHERE` via an OR-with-bound-flag so one compiled query serves every filter combination); added `idx_runs_request_id`. Testable core `get_runs_response` extracted following the `get_request_response` pattern; the report route's `config_obj` now shares the summary extraction helper (factored, not copied).

**App**
- `useRunsQuery` is now an infinite query over the envelope; the 5s poll refreshes the loaded pages (only page 1 in the default state - new runs land there under `start_time DESC`), older runs page in via a Load-more control. `flattenRunPages` de-dupes across pages.
- Search moved to the debounced server-side `q` param so it covers all runs; type/status/sort stay client-side over loaded pages (`filterRuns`).
- `useLastDesignRunQuery` is one filtered call (`requestId&type=design&status=completed&limit=1`) - no client-side download-and-filter.
- `useDeleteRunMutation` patches the infinite-query cache shape; `useAllRunsQuery` backs Settings' count + clear. List rows read `run.summary`; single-run consumers (`useRunQuery`, `DesignRunView`, `TabStrip`) keep the full `configSnapshot`.
- MCP `list_runs` bounded to the first 100; `extractRunIds` unwraps the envelope.

## Type of Change
- [x] New feature
- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change

(Not breaking: the no-param `GET /runs` array is preserved for one release.)

## Testing
- **Engine:** new `engine/tests/runs_route_test.cpp` (envelope shape, clamping, each filter, exactly-six-key summary + omission, malformed snapshot, legacy shape) - full suite green (316 tests).
- **App:** new `src/queries/runs.query.test.tsx` (single-call `useLastDesignRunQuery`, infinite pagination, `q` handling, dedupe) + endpoint builder test; existing runs/history/welcome/settings/MCP tests updated to the new shapes - `pnpm test` green (1123 tests), `pnpm type-check` clean.

```bash
python build.py -t && cd engine && ctest --preset linux-dev --output-on-failure
cd app && pnpm test && pnpm type-check
```

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018eu54BzYV69kSahUD2rHpF)_