### PR TITLE
refactor(app): adopt shared response-viewer primitives in load-test sample paths

### DIFF
--- a/app/src/components/shared/response-viewer/index.ts
+++ b/app/src/components/shared/response-viewer/index.ts
@@ -15,6 +15,8 @@
 export { default as UnifiedResponseViewer } from "./UnifiedResponseViewer";
 export { default as ResponseBody } from "./ResponseBody";
 export { default as HeadersViewer, CompactHeadersViewer } from "./HeadersViewer";
+export { StatusCodeBadge } from "./StatusCodeBadge";
+export type { StatusCodeBadgeProps } from "./StatusCodeBadge";
 
 // Pieces shared by the two response viewers. They are two different shells -
 // seven tabs from live context, three from a stored run - so these are the
@@ -26,6 +28,9 @@ export { RESPONSE_TAB_TRIGGER } from "./tab-trigger";
 export type { ResponseStatusBarProps } from "./ResponseStatusBar";
 export type { ResponseActionsProps } from "./ResponseActions";
 export type { ResponseHeadersPanelProps } from "./ResponseHeadersPanel";
+
+// Per-phase timing tooltips, shared by every renderer of the five network phases.
+export { PHASE_TIPS } from "./phase-tips";
 
 // Utilities
 export {

--- a/app/src/components/shared/response-viewer/phase-tips.ts
+++ b/app/src/components/shared/response-viewer/phase-tips.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Per-phase explanations for the network timing breakdown (DNS -> Connect ->
+ * TLS -> TTFB -> Download).
+ *
+ * These five sentences were copied byte-for-byte between the dashboard's
+ * `RequestResponseView` and the request-builder's `ResponseTimingTab`, with a
+ * comment admitting the manual "keep in sync" obligation that nothing enforced.
+ * They live here now so every renderer of the same five numbers reads from one
+ * string, the way `formatPhaseDuration` already unified the numbers themselves.
+ */
+export const PHASE_TIPS = {
+	dns: "Hostname → IP resolution. Usually a few ms once cached; >50ms suggests slow DNS or a fresh lookup.",
+	connect: "TCP three-way handshake. Zero on connection reuse (HTTP keep-alive / HTTP/2).",
+	tls: "SSL/TLS handshake (HTTPS only). Zero for plain HTTP and on resumed connections.",
+	ttfb: "Time to first byte - server processing + propagation. If this dominates, the bottleneck is the server, not the network.",
+	download:
+		"Response body transfer time. Large for big payloads or slow links; near-zero for small JSON.",
+} as const;

--- a/app/src/modules/dashboard/components/RequestResponseView.primitives.test.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.primitives.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Issue #60 guard: `RequestResponseView` - the load test's fourth response
+ * inspector - must consume the shared response-viewer primitives.
+ *
+ * The load-bearing mutation check is the per-sample timing card. The file
+ * imported `formatPhaseDuration` for the run-level averages and then fell back
+ * to raw `.toFixed(1)` for the per-sample phase cards, so a 0.04ms cached DNS
+ * lookup rendered as `0.0ms` - the only signal there is, rounded away. Revert
+ * the cards to `.toFixed(1)` and the `0.04ms` assertion below fails.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RequestResponseView from "./RequestResponseView";
+import type { RunReport } from "@/types";
+
+// ResponseBody mounts Monaco via CodeEditor; stub it so the expanded sample
+// renders in jsdom.
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: () => <div data-testid="code-editor" />,
+}));
+
+function makeReport(): RunReport {
+	return {
+		summary: {
+			totalRequests: 1,
+			successfulRequests: 1,
+			failedRequests: 0,
+			errorRate: 0,
+			totalDurationSeconds: 1,
+			avgRps: 1,
+		},
+		latency: { min: 5, max: 5, avg: 5, p50: 5, p90: 5, p95: 5, p99: 5 },
+		statusCodes: {},
+		errors: { total: 0, withDetails: 0, types: {} },
+		results: [
+			{
+				timestamp: 1_700_000_000_000,
+				statusCode: 200,
+				statusText: "OK",
+				latencyMs: 5,
+				trace: {
+					dnsMs: 0.04,
+					connectMs: 12.5,
+					headers: { "content-type": "application/json" },
+					body: '{"ok":true}',
+				},
+			},
+		],
+	};
+}
+
+describe("RequestResponseView shared-primitive adoption (#60)", () => {
+	it("renders the sample status through StatusCodeBadge", () => {
+		render(<RequestResponseView report={makeReport()} />);
+		const chip = screen.getByText("200 OK");
+		// The chip variant, not the old semantic-variant Badge.
+		expect(chip.className).toContain("text-primary-foreground");
+	});
+
+	it("formats per-sample phase durations with formatPhaseDuration, not raw toFixed(1)", () => {
+		render(<RequestResponseView report={makeReport()} />);
+		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
+
+		// 0.04ms keeps its significant digits through formatPhaseDuration; the
+		// reverted `.toFixed(1)` collapses it to "0.0ms".
+		expect(screen.getByText(/0\.04ms/)).toBeTruthy();
+		expect(screen.queryByText(/0\.0ms/)).toBeNull();
+	});
+
+	it("renders response headers through the shared CompactHeadersViewer", () => {
+		render(<RequestResponseView report={makeReport()} />);
+		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
+
+		// CompactHeadersViewer renders each name as `key:`; the reverted
+		// hand-rolled div map did too, so pin the shared surface it declares.
+		const header = screen.getByText("content-type:");
+		expect(header.closest(".surface-sunken")).not.toBeNull();
+	});
+});

--- a/app/src/modules/dashboard/components/RequestResponseView.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.tsx
@@ -26,19 +26,13 @@ import { ChevronDown, ChevronRight, AlertCircle, CheckCircle2, Clock } from "luc
 import type { RequestResponseViewProps } from "../types";
 import { InfoChip } from "./shared";
 import { formatPhaseDuration } from "@/components/shared/response-viewer/utils";
+import {
+	StatusCodeBadge,
+	CompactHeadersViewer,
+	ResponseBody,
+	PHASE_TIPS,
+} from "@/components/shared/response-viewer";
 import { httpStatusClass, statusCodeLabel, STATUS_CLASS_STYLE } from "@/constants/http-status";
-
-// Per-phase explanations for the network timing breakdown. Kept in sync with
-// the wording in ResponseTimingTab (request-builder), which explains the same
-// DNS → Connect → TLS → TTFB → Download sequence.
-const PHASE_TIPS = {
-	dns: "Hostname → IP resolution. Usually a few ms once cached; >50ms suggests slow DNS or a fresh lookup.",
-	connect: "TCP three-way handshake. Zero on connection reuse (HTTP keep-alive / HTTP/2).",
-	tls: "SSL/TLS handshake (HTTPS only). Zero for plain HTTP and on resumed connections.",
-	ttfb: "Time to first byte - server processing + propagation. If this dominates, the bottleneck is the server, not the network.",
-	download:
-		"Response body transfer time. Large for big payloads or slow links; near-zero for small JSON.",
-} as const;
 
 // Helper to format timestamp
 function formatTime(timestamp: number): string {
@@ -52,14 +46,6 @@ function formatTime(timestamp: number): string {
 	// Add milliseconds manually
 	const ms = String(date.getMilliseconds()).padStart(3, "0");
 	return `${timeStr}.${ms}`;
-}
-
-// Helper to get status badge variant
-function getStatusBadgeVariant(code: number): "default" | "secondary" | "destructive" | "outline" {
-	if (code === 0) return "destructive";
-	if (code >= 200 && code < 300) return "default";
-	if (code >= 400) return "destructive";
-	return "secondary";
 }
 
 export default function RequestResponseView({ report }: RequestResponseViewProps) {
@@ -308,6 +294,52 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 									const isError = !!result.error || result.statusCode === 0;
 									const isSlow = result.trace?.isSlow;
 
+									// One data-driven list, not five hand-rolled cards each
+									// with its own `.toFixed(1)`. `formatPhaseDuration` (imported
+									// above and already used for the run-level averages) keeps
+									// the significant-digit ladder a raw fixed precision drops -
+									// a 0.04ms cached DNS lookup no longer rounds to `0.0ms`.
+									const timingPhases: {
+										label: string;
+										value: number;
+										tip: string;
+									}[] = (
+										[
+											{
+												label: "DNS",
+												value: result.trace?.dnsMs,
+												tip: PHASE_TIPS.dns,
+											},
+											{
+												label: "Connect",
+												value: result.trace?.connectMs,
+												tip: PHASE_TIPS.connect,
+											},
+											{
+												label: "TLS",
+												value: result.trace?.tlsMs,
+												tip: PHASE_TIPS.tls,
+											},
+											{
+												label: "TTFB",
+												value: result.trace?.firstByteMs,
+												tip: PHASE_TIPS.ttfb,
+											},
+											{
+												label: "Download",
+												value: result.trace?.downloadMs,
+												tip: PHASE_TIPS.download,
+											},
+										] as {
+											label: string;
+											value: number | undefined;
+											tip: string;
+										}[]
+									).filter(
+										(p): p is { label: string; value: number; tip: string } =>
+											p.value !== undefined
+									);
+
 									return (
 										<div key={index} className="border-b last:border-b-0">
 											{/* Result Header - Clickable */}
@@ -338,16 +370,11 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 													</span>
 
 													{/* Status Code */}
-													<Badge
-														variant={getStatusBadgeVariant(
-															result.statusCode
-														)}
-														className="font-mono shrink-0"
-													>
-														{result.statusCode === 0
-															? "ERR"
-															: result.statusCode}
-													</Badge>
+													<StatusCodeBadge
+														status={result.statusCode}
+														statusText={result.statusText}
+														className="shrink-0"
+													/>
 
 													{/* Latency */}
 													<span
@@ -402,115 +429,47 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																</div>
 															)}
 
-															{/* Timing Breakdown - using camelCase field names from backend */}
-															{(result.trace.dnsMs !== undefined ||
-																result.trace.connectMs !==
-																	undefined ||
-																result.trace.tlsMs !== undefined ||
-																result.trace.firstByteMs !==
-																	undefined ||
-																result.trace.downloadMs !==
-																	undefined) && (
+															{/* Timing Breakdown - camelCase phase fields from the
+															    load-test trace, formatted through the shared
+															    `formatPhaseDuration`. */}
+															{timingPhases.length > 0 && (
 																<div className="space-y-1">
 																	<p className="text-xs font-medium text-muted-foreground">
 																		Timing Breakdown
 																	</p>
 																	<div className="grid grid-cols-[repeat(auto-fit,minmax(90px,1fr))] gap-2 text-xs">
-																		{result.trace.dnsMs !==
-																			undefined && (
-																			<div className="bg-card border border-border rounded-md p-2 text-center">
-																				<p className="text-muted-foreground">
-																					DNS{" "}
-																					<InfoChip
-																						tip={
-																							PHASE_TIPS.dns
+																		{timingPhases.map(
+																			(phase) => {
+																				const d =
+																					formatPhaseDuration(
+																						phase.value
+																					);
+																				return (
+																					<div
+																						key={
+																							phase.label
 																						}
-																					/>
-																				</p>
-																				<p className="font-mono font-medium">
-																					{result.trace.dnsMs.toFixed(
-																						1
-																					)}
-																					ms
-																				</p>
-																			</div>
-																		)}
-																		{result.trace.connectMs !==
-																			undefined && (
-																			<div className="bg-card border border-border rounded-md p-2 text-center">
-																				<p className="text-muted-foreground">
-																					Connect{" "}
-																					<InfoChip
-																						tip={
-																							PHASE_TIPS.connect
-																						}
-																					/>
-																				</p>
-																				<p className="font-mono font-medium">
-																					{result.trace.connectMs.toFixed(
-																						1
-																					)}
-																					ms
-																				</p>
-																			</div>
-																		)}
-																		{result.trace.tlsMs !==
-																			undefined && (
-																			<div className="bg-card border border-border rounded-md p-2 text-center">
-																				<p className="text-muted-foreground">
-																					TLS{" "}
-																					<InfoChip
-																						tip={
-																							PHASE_TIPS.tls
-																						}
-																					/>
-																				</p>
-																				<p className="font-mono font-medium">
-																					{result.trace.tlsMs.toFixed(
-																						1
-																					)}
-																					ms
-																				</p>
-																			</div>
-																		)}
-																		{result.trace
-																			.firstByteMs !==
-																			undefined && (
-																			<div className="bg-card border border-border rounded-md p-2 text-center">
-																				<p className="text-muted-foreground">
-																					TTFB{" "}
-																					<InfoChip
-																						tip={
-																							PHASE_TIPS.ttfb
-																						}
-																					/>
-																				</p>
-																				<p className="font-mono font-medium">
-																					{result.trace.firstByteMs.toFixed(
-																						1
-																					)}
-																					ms
-																				</p>
-																			</div>
-																		)}
-																		{result.trace.downloadMs !==
-																			undefined && (
-																			<div className="bg-card border border-border rounded-md p-2 text-center">
-																				<p className="text-muted-foreground">
-																					Download{" "}
-																					<InfoChip
-																						tip={
-																							PHASE_TIPS.download
-																						}
-																					/>
-																				</p>
-																				<p className="font-mono font-medium">
-																					{result.trace.downloadMs.toFixed(
-																						1
-																					)}
-																					ms
-																				</p>
-																			</div>
+																						className="bg-card border border-border rounded-md p-2 text-center"
+																					>
+																						<p className="text-muted-foreground">
+																							{
+																								phase.label
+																							}{" "}
+																							<InfoChip
+																								tip={
+																									phase.tip
+																								}
+																							/>
+																						</p>
+																						<p className="font-mono font-medium">
+																							{
+																								d.value
+																							}
+																							{d.unit}
+																						</p>
+																					</div>
+																				);
+																			}
 																		)}
 																	</div>
 																</div>
@@ -541,45 +500,36 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 																</div>
 															)}
 
-															{/* Response Headers */}
-															{result.trace.headers &&
-																Object.keys(result.trace.headers)
-																	.length > 0 && (
-																	<div className="space-y-1">
-																		<p className="text-xs font-medium text-muted-foreground">
-																			Response Headers
-																		</p>
-																		<div className="bg-muted p-2 rounded-md text-xs font-mono max-h-32 overflow-auto">
-																			{Object.entries(
-																				result.trace.headers
-																			).map(
-																				([key, value]) => (
-																					<div
-																						key={key}
-																						className="flex gap-2"
-																					>
-																						<span className="text-muted-foreground">
-																							{key}:
-																						</span>
-																						<span className="break-all">
-																							{value}
-																						</span>
-																					</div>
-																				)
-																			)}
-																		</div>
-																	</div>
-																)}
+															{/* Response Headers - the shared compact viewer. It
+															    declares its own `surface-sunken`, so its row rules
+															    resolve correctly on this `bg-muted/30` panel where a
+															    bare `border-rule` would fall back to invisible. */}
+															{result.trace.headers && (
+																<CompactHeadersViewer
+																	headers={result.trace.headers}
+																	title="Response Headers"
+																	className="max-h-40 overflow-auto"
+																/>
+															)}
 
-															{/* Response Body */}
+															{/* Response Body - the shared viewer (pretty/raw/preview
+															    with body-type detection), not a raw `<pre>`. */}
 															{result.trace.body && (
 																<div className="space-y-1">
 																	<p className="text-xs font-medium text-muted-foreground">
 																		Response Body
 																	</p>
-																	<pre className="bg-muted p-2 rounded-md text-xs font-mono max-h-48 overflow-auto whitespace-pre-wrap break-all">
-																		{result.trace.body}
-																	</pre>
+																	<div className="h-48 overflow-hidden rounded-md border border-border">
+																		<ResponseBody
+																			body={result.trace.body}
+																			headers={
+																				result.trace
+																					.headers || {}
+																			}
+																			height="100%"
+																			compact
+																		/>
+																	</div>
 																</div>
 															)}
 														</>

--- a/app/src/modules/history/main/components/SampleRequestCard.primitives.test.tsx
+++ b/app/src/modules/history/main/components/SampleRequestCard.primitives.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Issue #60 guard: the load-test sample paths must *consume* the shared
+ * response-viewer primitives, not hand-roll them - a hand-rolled copy does not
+ * receive the primitive's fixes.
+ *
+ * These are mutation-check tests. Revert the status chip to the local `? "ERR"`
+ * Badge and the class assertion fails; revert the request headers to the
+ * `<pre>{JSON.stringify(...)}</pre>` dump and the "renders a <table>, not a
+ * <pre>" assertion fails.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SampleRequestCard from "./SampleRequestCard";
+import type { SampleResult } from "../../types";
+
+// The response body path mounts Monaco via CodeEditor; stub it so these tests
+// stay in jsdom. None of the samples below carry a response, so it never
+// actually renders - the mock is belt-and-braces.
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: () => <div data-testid="code-editor" />,
+}));
+
+function makeSample(overrides: Partial<SampleResult> = {}): SampleResult {
+	return {
+		timestamp: 1_700_000_000_000,
+		statusCode: 200,
+		latencyMs: 5,
+		...overrides,
+	};
+}
+
+describe("SampleRequestCard shared-primitive adoption (#60)", () => {
+	it("renders the status through StatusCodeBadge (ERR chip on a connection failure)", () => {
+		render(
+			<SampleRequestCard
+				sample={makeSample({ statusCode: 0 })}
+				index={0}
+				isExpanded={false}
+				onToggle={() => {}}
+			/>
+		);
+		const chip = screen.getByText("ERR");
+		// StatusCodeBadge is variant="chip": a white label on a solid semantic
+		// fill. The old hand-rolled Badge used destructive/default variants and
+		// carried neither of these classes.
+		expect(chip.className).toContain("text-primary-foreground");
+		expect(chip.className).toContain("bg-status-no-response-fill");
+	});
+
+	it("renders request headers through HeadersViewer (a table), not a raw JSON <pre>", () => {
+		const { container } = render(
+			<SampleRequestCard
+				sample={makeSample({
+					trace: { request: { headers: { "x-trace-id": "abc123" } } },
+				})}
+				index={0}
+				isExpanded
+				onToggle={() => {}}
+			/>
+		);
+		const table = container.querySelector("table");
+		expect(table).not.toBeNull();
+		expect(table?.textContent).toContain("x-trace-id");
+		expect(table?.textContent).toContain("abc123");
+		// The reverted implementation dumped the headers as pretty-printed JSON in
+		// a <pre>. There is none now.
+		expect(container.querySelector("pre")).toBeNull();
+	});
+});

--- a/app/src/modules/history/main/components/SampleRequestCard.tsx
+++ b/app/src/modules/history/main/components/SampleRequestCard.tsx
@@ -12,10 +12,13 @@
  */
 
 import { CheckCircle, XCircle } from "lucide-react";
-import { Badge } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import TimingBreakdown from "./TimingBreakdown";
-import { UnifiedResponseViewer } from "@/components/shared/response-viewer";
+import {
+	UnifiedResponseViewer,
+	HeadersViewer,
+	StatusCodeBadge,
+} from "@/components/shared/response-viewer";
 import type { SampleResult } from "../../types";
 
 interface SampleRequestCardProps {
@@ -61,12 +64,7 @@ export default function SampleRequestCard({
 					<CheckCircle className="w-4 h-4 text-status-success-text shrink-0" />
 				)}
 
-				<Badge
-					variant={isError ? "destructive" : isSuccess ? "default" : "outline"}
-					className="font-mono text-xs"
-				>
-					{sample.statusCode === 0 ? "ERR" : sample.statusCode}
-				</Badge>
+				<StatusCodeBadge status={sample.statusCode} className="text-xs" />
 
 				<span className="text-sm font-medium font-mono">
 					{sample.latencyMs.toFixed(1)}ms
@@ -111,18 +109,11 @@ export default function SampleRequestCard({
 						</div>
 					)}
 
-					{/* Request Headers */}
+					{/* Request Headers - the shared collapsible table, not a raw JSON
+					    dump. It sat directly above a UnifiedResponseViewer that already
+					    renders headers properly; the two treatments no longer differ. */}
 					{sample.trace?.request?.headers && (
-						<div>
-							<h4 className="text-xs font-semibold text-muted-foreground mb-2 uppercase">
-								Request Headers
-							</h4>
-							<pre className="bg-muted p-3 text-xs overflow-x-auto max-h-40">
-								{typeof sample.trace.request.headers === "object"
-									? JSON.stringify(sample.trace.request.headers, null, 2)
-									: sample.trace.request.headers}
-							</pre>
-						</div>
+						<HeadersViewer headers={sample.trace.request.headers} variant="request" />
 					)}
 
 					{/* Response using UnifiedResponseViewer */}

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
@@ -19,6 +19,7 @@
 
 import { type ReactNode } from "react";
 import { formatDuration, formatPhaseDuration } from "@/components/shared/response-viewer/utils";
+import { PHASE_TIPS } from "@/components/shared/response-viewer/phase-tips";
 import { Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ResponseTiming } from "../../types";
@@ -65,35 +66,35 @@ export default function ResponseTimingTab({ timing }: ResponseTimingTabProps) {
 			label: "DNS",
 			value: timing.dns,
 			color: "hsl(var(--chart-2))",
-			tip: "Hostname → IP resolution. Usually a few ms once cached; >50ms suggests slow DNS or a fresh lookup.",
+			tip: PHASE_TIPS.dns,
 		},
 		{
 			key: "connect",
 			label: "Connect",
 			value: timing.connect,
 			color: "hsl(var(--chart-4))",
-			tip: "TCP three-way handshake. Zero on connection reuse (HTTP keep-alive / HTTP/2).",
+			tip: PHASE_TIPS.connect,
 		},
 		{
 			key: "tls",
 			label: "TLS",
 			value: timing.tls,
 			color: "hsl(var(--chart-5))",
-			tip: "SSL/TLS handshake (HTTPS only). Zero for plain HTTP and on resumed connections.",
+			tip: PHASE_TIPS.tls,
 		},
 		{
 			key: "ttfb",
 			label: "TTFB",
 			value: timing.firstByte,
 			color: "hsl(var(--primary))",
-			tip: "Time to first byte - server processing + propagation. If this dominates, the bottleneck is the server, not the network.",
+			tip: PHASE_TIPS.ttfb,
 		},
 		{
 			key: "download",
 			label: "Download",
 			value: timing.download,
 			color: "hsl(var(--success))",
-			tip: "Response body transfer time. Large for big payloads or slow links; near-zero for small JSON.",
+			tip: PHASE_TIPS.download,
 		},
 	];
 

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -270,6 +270,7 @@ Response-rendering primitives reused outside the request builder (e.g. history d
 - `ResponseActions.tsx` - the copy/download pair
 - `ResponseHeadersPanel.tsx` - the Headers tab body
 - `tab-trigger.ts` - `RESPONSE_TAB_TRIGGER`, the underline-on-active class
+- `phase-tips.ts` - `PHASE_TIPS`, the five per-phase timing tooltips (DNS -> Connect -> TLS -> TTFB -> Download), shared so every renderer of those numbers reads one string
 
 > **Two shells, shared parts.** The request builder has its own richer
 > `components/ResponseViewer/` (console output, test results, cookies, timing,


### PR DESCRIPTION
## Description

The load-test sample views hand-rolled the response UI instead of consuming `components/shared/response-viewer/`, so none of the primitives' fixes reached them - the exact defect CLAUDE.md warns about ("a hand-rolled copy of a primitive does not receive the primitive's fixes"). This makes the two sample paths (`dashboard/RequestResponseView.tsx`, `history/.../SampleRequestCard.tsx`) consume the shared primitives, the way `SampleRequestCard` already did for the response body.

- **`SampleRequestCard`** - status chip -> `StatusCodeBadge`; request-header `<pre>{JSON.stringify(...)}</pre>` dump -> `HeadersViewer` (it sat directly above a `UnifiedResponseViewer` already rendering headers properly).
- **`RequestResponseView`** - status chip -> `StatusCodeBadge` (drops the local `getStatusBadgeVariant` helper); response headers -> `CompactHeadersViewer`; response body `<pre>` -> `ResponseBody`; the five hand-rolled per-sample phase cards collapse into one data-driven list formatted through `formatPhaseDuration`. The file already imported `formatPhaseDuration` for the run-level averages but fell back to raw `.toFixed(1)` for the per-sample cards, so a 0.04ms cached DNS lookup rendered as `0.0ms` - the only signal there is, rounded away.
- **`PHASE_TIPS`** - extracted to `components/shared/response-viewer/phase-tips.ts` and consumed from both `RequestResponseView` and `ResponseTimingTab`, replacing the byte-for-byte copy that only a `// keep in sync` comment held together.

Net -52 lines. Scope kept to the two sample files + the shared extraction; the `rawRequest`/dead-`UnifiedResponseViewer` items (moved to #65) and dead-`MetricCard` deletion (spun out to #66) are intentionally out of scope.

## Type of Change
- [x] Bug fix (per-sample DNS phase rounding)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (`docs/app/COMPONENTS.md`)

Also a refactor/consolidation.

## Testing

- `pnpm type-check`, `pnpm lint` (touched files), `pnpm format:check` (touched files) - all clean.
- Full `pnpm test` suite green (156 files / 1121 tests).
- Added mutation-check guard tests for both sample paths:
  - `SampleRequestCard.primitives.test.tsx` - asserts the status renders as a `StatusCodeBadge` chip and request headers render as a `<table>` (not a raw `<pre>`).
  - `RequestResponseView.primitives.test.tsx` - asserts `StatusCodeBadge`, `CompactHeadersViewer`'s declared surface, and that a 0.04ms phase renders as `0.04ms` (not `0.0ms`).
  - Verified the timing guard bites: reverting the per-sample card to `.toFixed(1)` fails the test; restored to green.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEob6zugMsYd6UJchdsKhE)_