### PR TITLE
fix(engine,runtime): enforce script execution timeout via QuickJS interrupt handler

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -213,7 +213,10 @@ QuickJS supports ES2020 features with some limitations:
 - **No Node.js APIs**: No `require()`, `fs`, `http`, etc.
 - **Sandboxed**: No filesystem or network access
 - **Memory limit**: 64MB per script execution
-- **Timeout**: 5 seconds per script
+- **Timeout**: 5 seconds per script (default), enforced by a wall-clock deadline - an
+  infinite-loop script is aborted and reported as an error rather than hanging the
+  engine. Configurable via the `scriptTimeout` setting (milliseconds); `0` disables
+  the limit.
 
 ## Script Execution Context
 

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -60,8 +60,20 @@ void validate_scripts (std::shared_ptr<RunContext> context, vayu::db::Database& 
     db.add_metric ({ 0, context->run_id, now_ms (),
     vayu::MetricName::TestsSampled, static_cast<double> (samples.size ()), "" });
 
-    // Create script engine for validation
-    vayu::runtime::ScriptEngine engine;
+    // Create script engine for validation, bounded by the same timeout/limits
+    // the execute path reads so an infinite-loop test script cannot spin the
+    // run's worker thread forever.
+    vayu::runtime::ScriptConfig script_config;
+    script_config.timeout_ms     = static_cast<uint64_t> (db.get_config_int (
+    "scriptTimeout", vayu::core::constants::script_engine::TIMEOUT_MS));
+    script_config.memory_limit   = static_cast<size_t> (db.get_config_int (
+    "scriptMemoryLimit", vayu::core::constants::script_engine::MEMORY_LIMIT));
+    script_config.stack_size     = static_cast<size_t> (db.get_config_int (
+    "scriptStackSize", vayu::core::constants::script_engine::STACK_SIZE));
+    script_config.enable_console = db.get_config_bool (
+    "scriptEnableConsole", vayu::core::constants::script_engine::ENABLE_CONSOLE);
+
+    vayu::runtime::ScriptEngine engine (script_config);
     vayu::Environment env;
 
     // Build a dummy request for script context (HTTP request fields are at root level)

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1186,10 +1186,12 @@ void Database::seed_default_config () {
 
     upsert_config (ConfigEntry{ "scriptTimeout",
     std::to_string (vayu::core::constants::script_engine::TIMEOUT_MS), "integer", "Script Execution Timeout",
-    "Max runtime for pre/post-request scripts. Prevents infinite loops. "
-    "Value is in milliseconds (5000 = 5 seconds).",
+    "Max runtime in milliseconds for pre/post-request scripts "
+    "(5000 = 5 seconds). A script that exceeds this is aborted and "
+    "reported as an error, so an infinite loop cannot hang the "
+    "engine. Set to 0 to disable the limit (not recommended).",
     "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::TIMEOUT_MS),
-    "100", "60000", now });
+    "0", "60000", now });
 
     upsert_config (ConfigEntry{ "scriptEnableConsole",
     vayu::core::constants::script_engine::ENABLE_CONSOLE ? "true" : "false",

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <limits>
 #include <mutex>
 #include <sstream>
@@ -1097,6 +1098,25 @@ void setup_pm_object (JSContext* ctx) {
 // ScriptEngine Implementation
 // ============================================================================
 
+// Per-runtime deadline state for the interrupt handler. One instance is owned by
+// each pooled JSRuntime (stored as its runtime opaque) and refreshed before every
+// execution. QuickJS runtimes are single-threaded, and each pooled context pair is
+// used by one thread at a time, so no synchronization is needed here.
+struct RuntimeState {
+    bool enabled = false; // false => no wall-clock limit (timeout_ms == 0)
+    std::chrono::steady_clock::time_point deadline{};
+};
+
+// QuickJS calls this periodically during evaluation. Returning non-zero aborts
+// the current JS_Eval with an InternalError, which the execute() exception path
+// turns into result.error_message.
+extern "C" int script_interrupt_handler (JSRuntime* /*rt*/, void* opaque) {
+    auto* state = static_cast<RuntimeState*> (opaque);
+    if (!state || !state->enabled)
+        return 0;
+    return std::chrono::steady_clock::now () > state->deadline ? 1 : 0;
+}
+
 class ScriptEngine::Impl {
     public:
     ScriptConfig config;
@@ -1112,8 +1132,10 @@ class ScriptEngine::Impl {
     ~Impl () {
         std::lock_guard<std::mutex> lock (pool_mutex);
         for (auto& pair : context_pool) {
+            auto* rt_state = static_cast<RuntimeState*> (JS_GetRuntimeOpaque (pair.first));
             JS_FreeContext (pair.second);
             JS_FreeRuntime (pair.first);
+            delete rt_state;
         }
         context_pool.clear ();
     }
@@ -1133,6 +1155,13 @@ class ScriptEngine::Impl {
 
         JS_SetMemoryLimit (rt, config.memory_limit);
         JS_SetMaxStackSize (rt, config.stack_size);
+
+        // Install a wall-clock deadline interrupt so infinite-loop scripts
+        // cannot hang the thread. The RuntimeState is owned by this runtime
+        // (freed in ~Impl) and refreshed before each execute().
+        auto* rt_state = new RuntimeState ();
+        JS_SetRuntimeOpaque (rt, rt_state);
+        JS_SetInterruptHandler (rt, &script_interrupt_handler, rt_state);
 
         // Register Expectation class
         if (expect_class_id == 0) {
@@ -1180,6 +1209,16 @@ class ScriptEngine::Impl {
             return result;
         }
 
+        // Refresh the per-execution deadline. A pooled context reused for the next
+        // script gets a fresh budget; timeout_ms == 0 disables the wall-clock limit.
+        if (auto* rt_state = static_cast<RuntimeState*> (JS_GetRuntimeOpaque (rt))) {
+            rt_state->enabled = config.timeout_ms != 0;
+            if (rt_state->enabled) {
+                rt_state->deadline = std::chrono::steady_clock::now () +
+                std::chrono::milliseconds (config.timeout_ms);
+            }
+        }
+
         // Set up context data
         ContextData ctx_data;
         ctx_data.request             = ctx.request;
@@ -1207,9 +1246,18 @@ class ScriptEngine::Impl {
         wrapped_script.size (), "<script>", JS_EVAL_TYPE_GLOBAL);
 
         if (JS_IsException (eval_result)) {
-            JSValue exc          = JS_GetException (js_ctx);
-            result.success       = false;
-            result.error_message = js_to_string (js_ctx, exc);
+            JSValue exc    = JS_GetException (js_ctx);
+            result.success = false;
+            // If the deadline interrupt fired, report a clear timeout message
+            // rather than QuickJS's raw "interrupted" InternalError.
+            auto* rt_state = static_cast<RuntimeState*> (JS_GetRuntimeOpaque (rt));
+            if (rt_state && rt_state->enabled &&
+            std::chrono::steady_clock::now () > rt_state->deadline) {
+                result.error_message = "Script execution timed out after " +
+                std::to_string (config.timeout_ms) + "ms";
+            } else {
+                result.error_message = js_to_string (js_ctx, exc);
+            }
             JS_FreeValue (js_ctx, exc);
         } else {
             result.success = true;

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <chrono>
+
 #include "vayu/http/script_parts.hpp"
 #include "vayu/types.hpp"
 
@@ -552,4 +554,79 @@ TEST_F (ScriptEngineTest, ContextPooling) {
         ASSERT_EQ (result.tests.size (), 1);
         EXPECT_TRUE (result.tests[0].passed);
     }
+}
+
+// ============================================================================
+// Script Execution Timeout Tests (#107)
+// ============================================================================
+
+// A non-allocating infinite loop must be interrupted by the wall-clock deadline
+// rather than hanging the calling thread. Mutation-check: revert the
+// JS_SetInterruptHandler wiring in acquire_context/execute and this test hangs.
+TEST_F (ScriptEngineTest, InfiniteLoopTimesOut) {
+#ifdef VAYU_HAS_QUICKJS
+    ScriptConfig cfg;
+    cfg.timeout_ms = 200;
+    ScriptEngine timeout_engine (cfg);
+
+    ScriptContext ctx;
+    ctx.response = &response;
+
+    const auto start   = std::chrono::steady_clock::now ();
+    auto result        = timeout_engine.execute ("while (true) {}", ctx);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - start)
+                         .count ();
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("timed out"), std::string::npos)
+    << "error was: " << result.error_message;
+    // Should abort near the deadline, not run indefinitely. Generous upper bound to
+    // stay robust on slow CI while still proving the loop does not run forever.
+    EXPECT_LT (elapsed, 5000) << "took " << elapsed << "ms";
+#else
+    GTEST_SKIP () << "QuickJS not compiled in";
+#endif
+}
+
+// A fast script under the limit must not be falsely aborted by the deadline.
+TEST_F (ScriptEngineTest, FastScriptUnderTimeoutStillPasses) {
+#ifdef VAYU_HAS_QUICKJS
+    ScriptConfig cfg;
+    cfg.timeout_ms = 200;
+    ScriptEngine timeout_engine (cfg);
+
+    auto result = timeout_engine.execute_test (R"(
+        pm.test("Fast test", function() {
+            pm.expect(1).to.equal(1);
+        });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+    EXPECT_TRUE (result.error_message.empty ());
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_TRUE (result.tests[0].passed);
+#else
+    GTEST_SKIP () << "QuickJS not compiled in";
+#endif
+}
+
+// timeout_ms == 0 disables the wall-clock limit (escape hatch); a bounded loop
+// still completes normally with no false timeout.
+TEST_F (ScriptEngineTest, ZeroTimeoutDisablesLimit) {
+#ifdef VAYU_HAS_QUICKJS
+    ScriptConfig cfg;
+    cfg.timeout_ms = 0;
+    ScriptEngine no_timeout_engine (cfg);
+
+    ScriptContext ctx;
+    auto result = no_timeout_engine.execute (
+    "var n = 0; for (var i = 0; i < 100000; i++) { n += i; } n", ctx);
+
+    EXPECT_TRUE (result.success);
+    EXPECT_TRUE (result.error_message.empty ());
+#else
+    GTEST_SKIP () << "QuickJS not compiled in";
+#endif
 }


### PR DESCRIPTION
## Description

`ScriptConfig::timeout_ms` was populated from the `scriptTimeout` DB setting but read by **nothing**. `acquire_context()` installed only `JS_SetMemoryLimit` / `JS_SetMaxStackSize` and never an interrupt handler, so `JS_Eval` ran with no wall-clock budget. A non-allocating infinite-loop script (`while (true) {}`) ran forever and hung the invoking thread - on `POST /execute` this permanently consumes a cpp-httplib worker (enough of them starve the pool so `/health` never runs), and in a load run `validate_scripts` runs the test script on the run's detached worker thread with no `should_stop` check, spinning a core indefinitely. The setting actively lied: the DB row was described as "Prevents infinite loops" and `scripting.md` promised "Timeout: 5 seconds per script".

This wires the timeout that was always intended:

**Engine**
- A per-runtime `RuntimeState` (deadline + `enabled` flag) is owned by each pooled `JSRuntime` (stored as its runtime opaque via `JS_SetRuntimeOpaque`, freed in `~Impl`) and refreshed at the top of every `execute()`, so a pooled context reused for the next script gets a fresh budget.
- `script_interrupt_handler` (installed once per runtime via `JS_SetInterruptHandler`) returns non-zero once `steady_clock::now()` passes the deadline. QuickJS aborts `JS_Eval` with an `InternalError`, which the existing exception path already turns into `result.error_message`; that message is replaced with a clear `Script execution timed out after Nms`.
- `timeout_ms == 0` disables the wall-clock limit (escape hatch).
- `validate_scripts` (`run_manager.cpp`) now constructs its `ScriptEngine` with a `ScriptConfig` read from the **same** DB settings the execute path reads (`scriptTimeout`/`scriptMemoryLimit`/`scriptStackSize`/`scriptEnableConsole`) - previously it default-constructed the engine, so load-run test scripts are now bounded by the same mechanism.

**Config / UI (`database.cpp` seed)**
The `scriptTimeout` row is already surfaced in the app's generic engine-settings form (Settings -> Engine Settings -> "Scripting Environment"), rendered from the `/config` endpoint metadata - so with this PR the existing UI control finally *does* something (before it, editing it changed a value the engine ignored). Two metadata corrections make that setting honest:
- The seed description now states that a script exceeding the limit is aborted and reported as an error, and documents that `0` disables the limit (replacing the aspirational "Prevents infinite loops").
- `min_value` lowered `100` -> `0` so the `0`-disables sentinel is actually reachable from the settings form and the server-side `POST /config` validator (both enforce the row's min/max). `upsert_config` refreshes metadata while preserving each user's existing value, so existing installs pick up the corrected description/min without losing their configured timeout.

Because `/execute` and `validate_scripts` read `scriptTimeout` from the DB when they build `ScriptConfig`, a UI change takes effect on the next execute / load run with no engine restart (the seed row carries no "Requires Restart" marker, which is now correct).

**App code changes: none - verified, not assumed.** The settings form is generic and metadata-driven, so the corrected `scriptTimeout` row renders with no app-side code change. I specifically checked the `min = "0"` change is safe through the render/validate path in `app/src/modules/settings/main/SettingsMain.tsx`:
- `validateValue` gates the min with `entry.min !== undefined` (not a falsy check), so a value of `0` and a min of `"0"` both pass (`SettingsMain.tsx:302-307`).
- The number `<Input min={entry.min} .../>` receives `"0"` directly, and the constraint-helper text uses `entry.min && entry.max` where `"0"` is a truthy string, so it renders `0 - 60000` correctly (`SettingsMain.tsx:649,659-670`) - no zero-trap.
- `scriptTimeout` is a plain `integer` (not a size config), so it renders as a number field.

Verification run: `pnpm type-check` clean; the settings module tests pass (6 files / 23 tests); no app test pins the old `scriptTimeout` metadata (`min 100` / old description).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```bash
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
cd app && pnpm type-check && pnpm test --run src/modules/settings
```

- **Engine gtest** (`engine/tests/script_engine_test.cpp`), mutation-checked:
  - `InfiniteLoopTimesOut` - `while(true){}` with a 200ms `timeout_ms` returns `success == false` with a "timed out" message, aborting in ~0.21s (not indefinitely). Reverting the interrupt wiring hangs this test.
  - `FastScriptUnderTimeoutStillPasses` - a quick passing `pm.test` under the limit is not falsely aborted.
  - `ZeroTimeoutDisablesLimit` - the `timeout_ms == 0` escape hatch lets a bounded loop complete with no false timeout.
- Full engine suite green: **312/312 passed** (both before and after the `database.cpp` metadata change).
- App: `pnpm type-check` clean; settings module tests **23/23 passed**. No app source changed.

## Checklist
- [x] My code follows the style guidelines (added C++ lines are clang-format clean; pre-existing non-clean regions of `run_manager.cpp` were left untouched per repo convention)
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (`docs/engine/scripting.md`; `scriptTimeout` config seed description)

## Related Issues
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)