### PR TITLE
fix(engine,runtime): pm.expect terminals assert on access, add missing matchers

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -191,7 +191,7 @@ pm.test('Response time is acceptable', function() {
 pm.test('Returns array of users', function() {
   const users = pm.response.json();
   pm.expect(users).to.be.an('array');
-  pm.expect(users).to.have.length.above(0);
+  pm.expect(users.length).to.be.above(0);
   pm.expect(users[0]).to.have.property('id');
 });
 ```

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -536,6 +536,296 @@ JSValue expect_have_property (JSContext* ctx, JSValueConst this_val, int argc, J
     return JS_UNDEFINED;
 }
 
+// Terminal getters: assert on property access (Chai/Postman paren-less idiom).
+// Each honors the tracked `negated` flag, throws on failure, and returns the
+// expectation object so a chain can continue.
+
+JSValue expect_null_getter (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    bool is_null = JS_IsNull (state->actual);
+    bool pass    = state->negated ? !is_null : is_null;
+
+    if (!pass) {
+        const char* msg = state->negated ? "Expected value to not be null" :
+                                           "Expected value to be null";
+        return JS_ThrowTypeError (ctx, "%s", msg);
+    }
+
+    return JS_DupValue (ctx, this_val);
+}
+
+JSValue expect_undefined_getter (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    bool is_undef = JS_IsUndefined (state->actual);
+    bool pass     = state->negated ? !is_undef : is_undef;
+
+    if (!pass) {
+        const char* msg = state->negated ?
+        "Expected value to not be undefined" :
+        "Expected value to be undefined";
+        return JS_ThrowTypeError (ctx, "%s", msg);
+    }
+
+    return JS_DupValue (ctx, this_val);
+}
+
+JSValue expect_ok_getter (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    bool is_ok = JS_ToBool (ctx, state->actual) == 1;
+    bool pass  = state->negated ? !is_ok : is_ok;
+
+    if (!pass) {
+        const char* msg = state->negated ? "Expected value to not be truthy" :
+                                           "Expected value to be truthy";
+        return JS_ThrowTypeError (ctx, "%s", msg);
+    }
+
+    return JS_DupValue (ctx, this_val);
+}
+
+JSValue expect_empty_getter (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    bool is_empty = false;
+    if (JS_IsString (state->actual)) {
+        is_empty = js_to_string (ctx, state->actual).empty ();
+    } else if (QJS_IsArray (ctx, state->actual)) {
+        JSValue length = JS_GetPropertyStr (ctx, state->actual, "length");
+        uint32_t len   = 0;
+        JS_ToUint32 (ctx, &len, length);
+        JS_FreeValue (ctx, length);
+        is_empty = (len == 0);
+    } else if (JS_IsObject (state->actual)) {
+        JSPropertyEnum* tab = nullptr;
+        uint32_t count      = 0;
+        if (JS_GetOwnPropertyNames (ctx, &tab, &count, state->actual,
+            JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) == 0) {
+            is_empty = (count == 0);
+            for (uint32_t i = 0; i < count; i++) {
+                JS_FreeAtom (ctx, tab[i].atom);
+            }
+            js_free (ctx, tab);
+        }
+    }
+
+    bool pass = state->negated ? !is_empty : is_empty;
+
+    if (!pass) {
+        const char* msg = state->negated ? "Expected value to not be empty" :
+                                           "Expected value to be empty";
+        return JS_ThrowTypeError (ctx, "%s", msg);
+    }
+
+    return JS_DupValue (ctx, this_val);
+}
+
+// Callable matchers documented in pm-api-compatibility.md but previously absent.
+
+JSValue expect_least (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "least() requires an argument");
+    }
+
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    double actual, expected;
+    if (JS_ToFloat64 (ctx, &actual, state->actual) < 0 ||
+    JS_ToFloat64 (ctx, &expected, argv[0]) < 0) {
+        return JS_ThrowTypeError (ctx, "least() requires numeric values");
+    }
+
+    bool at_least = actual >= expected;
+    bool pass     = state->negated ? !at_least : at_least;
+
+    if (!pass) {
+        std::string msg = "Expected " + std::to_string (actual) +
+        (state->negated ? " to not be at least " : " to be at least ") +
+        std::to_string (expected);
+        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    }
+
+    return JS_UNDEFINED;
+}
+
+JSValue expect_most (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "most() requires an argument");
+    }
+
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    double actual, expected;
+    if (JS_ToFloat64 (ctx, &actual, state->actual) < 0 ||
+    JS_ToFloat64 (ctx, &expected, argv[0]) < 0) {
+        return JS_ThrowTypeError (ctx, "most() requires numeric values");
+    }
+
+    bool at_most = actual <= expected;
+    bool pass    = state->negated ? !at_most : at_most;
+
+    if (!pass) {
+        std::string msg = "Expected " + std::to_string (actual) +
+        (state->negated ? " to not be at most " : " to be at most ") +
+        std::to_string (expected);
+        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    }
+
+    return JS_UNDEFINED;
+}
+
+JSValue expect_length (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "length() requires an argument");
+    }
+
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    JSValue length_val = JS_GetPropertyStr (ctx, state->actual, "length");
+    if (JS_IsUndefined (length_val)) {
+        JS_FreeValue (ctx, length_val);
+        return JS_ThrowTypeError (ctx, "length() requires a value with a length");
+    }
+
+    double actual_len, expected;
+    JS_ToFloat64 (ctx, &actual_len, length_val);
+    JS_FreeValue (ctx, length_val);
+    if (JS_ToFloat64 (ctx, &expected, argv[0]) < 0) {
+        return JS_ThrowTypeError (ctx, "length() requires a numeric argument");
+    }
+
+    bool matches = (actual_len == expected);
+    bool pass    = state->negated ? !matches : matches;
+
+    if (!pass) {
+        std::string msg = "Expected length " + std::to_string (actual_len) +
+        (state->negated ? " to not equal " : " to equal ") + std::to_string (expected);
+        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    }
+
+    return JS_UNDEFINED;
+}
+
+JSValue expect_a (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "a() requires a type name");
+    }
+
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    std::string type_name;
+    if (JS_IsNull (state->actual)) {
+        type_name = "null";
+    } else if (JS_IsUndefined (state->actual)) {
+        type_name = "undefined";
+    } else if (QJS_IsArray (ctx, state->actual)) {
+        type_name = "array";
+    } else if (JS_IsString (state->actual)) {
+        type_name = "string";
+    } else if (JS_IsNumber (state->actual)) {
+        type_name = "number";
+    } else if (JS_IsBool (state->actual)) {
+        type_name = "boolean";
+    } else if (JS_IsFunction (ctx, state->actual)) {
+        type_name = "function";
+    } else if (JS_IsObject (state->actual)) {
+        type_name = "object";
+    } else {
+        type_name = "undefined";
+    }
+
+    std::string expected = js_to_string (ctx, argv[0]);
+    for (auto& c : expected) {
+        c = static_cast<char> (std::tolower (static_cast<unsigned char> (c)));
+    }
+
+    bool matches = (type_name == expected);
+    bool pass    = state->negated ? !matches : matches;
+
+    if (!pass) {
+        std::string msg = "Expected type " + type_name +
+        (state->negated ? " to not be " : " to be ") + expected;
+        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    }
+
+    return JS_UNDEFINED;
+}
+
+JSValue expect_match (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "match() requires a regular expression");
+    }
+
+    auto* state = static_cast<ExpectState*> (JS_GetOpaque (this_val, expect_class_id));
+    if (!state) {
+        return JS_ThrowInternalError (ctx, "Invalid expectation state");
+    }
+
+    JSValue test_fn = JS_GetPropertyStr (ctx, argv[0], "test");
+    if (!JS_IsFunction (ctx, test_fn)) {
+        JS_FreeValue (ctx, test_fn);
+        return JS_ThrowTypeError (ctx, "match() requires a regular expression");
+    }
+
+    std::string subject = js_to_string (ctx, state->actual);
+    JSValue arg         = JS_NewString (ctx, subject.c_str ());
+    JSValue result      = JS_Call (ctx, test_fn, argv[0], 1, &arg);
+    JS_FreeValue (ctx, arg);
+    JS_FreeValue (ctx, test_fn);
+
+    if (JS_IsException (result)) {
+        JS_FreeValue (ctx, result);
+        return JS_EXCEPTION;
+    }
+
+    bool matched = JS_ToBool (ctx, result) == 1;
+    JS_FreeValue (ctx, result);
+    bool pass = state->negated ? !matched : matched;
+
+    if (!pass) {
+        std::string msg = state->negated ?
+        "Expected '" + subject + "' to not match the pattern" :
+        "Expected '" + subject + "' to match the pattern";
+        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    }
+
+    return JS_UNDEFINED;
+}
+
 JSValue create_expectation (JSContext* ctx, JSValue actual) {
     JSValue obj = JS_NewObjectClass (ctx, static_cast<int> (expect_class_id));
     if (JS_IsException (obj)) {
@@ -569,16 +859,48 @@ JSValue create_expectation (JSContext* ctx, JSValue actual) {
     JS_NewCFunction (ctx, expect_to_getter, "have", 0), JS_UNDEFINED, 0);
     JS_FreeAtom (ctx, have_atom);
 
-    // Add assertion methods
+    // Add "at" getter for chaining (for `.at.least(n)` / `.at.most(n)`)
+    JSAtom at_atom = JS_NewAtom (ctx, "at");
+    JS_DefinePropertyGetSet (ctx, obj, at_atom,
+    JS_NewCFunction (ctx, expect_to_getter, "at", 0), JS_UNDEFINED, 0);
+    JS_FreeAtom (ctx, at_atom);
+
+    // Terminal matchers assert on access (Chai/Postman paren-less idiom), so
+    // register them as getters rather than function-valued properties - a bare
+    // `.to.be.true` must run the check, not silently return an uncalled function.
+    struct TerminalGetter {
+        const char* name;
+        JSCFunction* fn;
+    };
+    const TerminalGetter terminals[] = { { "exist", expect_exist },
+        { "true", expect_true }, { "false", expect_false },
+        { "null", expect_null_getter }, { "undefined", expect_undefined_getter },
+        { "ok", expect_ok_getter }, { "empty", expect_empty_getter } };
+    for (const auto& t : terminals) {
+        JSAtom atom = JS_NewAtom (ctx, t.name);
+        JS_DefinePropertyGetSet (
+        ctx, obj, atom, JS_NewCFunction (ctx, t.fn, t.name, 0), JS_UNDEFINED, 0);
+        JS_FreeAtom (ctx, atom);
+    }
+
+    // Add callable assertion methods
     JS_SetPropertyStr (ctx, obj, "equal", JS_NewCFunction (ctx, expect_equal, "equal", 1));
     JS_SetPropertyStr (ctx, obj, "eql", JS_NewCFunction (ctx, expect_equal, "eql", 1));
-    JS_SetPropertyStr (ctx, obj, "exist", JS_NewCFunction (ctx, expect_exist, "exist", 0));
-    JS_SetPropertyStr (ctx, obj, "true", JS_NewCFunction (ctx, expect_true, "true", 0));
-    JS_SetPropertyStr (ctx, obj, "false", JS_NewCFunction (ctx, expect_false, "false", 0));
     JS_SetPropertyStr (ctx, obj, "above", JS_NewCFunction (ctx, expect_above, "above", 1));
     JS_SetPropertyStr (ctx, obj, "below", JS_NewCFunction (ctx, expect_below, "below", 1));
+    JS_SetPropertyStr (ctx, obj, "least", JS_NewCFunction (ctx, expect_least, "least", 1));
+    JS_SetPropertyStr (ctx, obj, "most", JS_NewCFunction (ctx, expect_most, "most", 1));
     JS_SetPropertyStr (
     ctx, obj, "include", JS_NewCFunction (ctx, expect_include, "include", 1));
+    JS_SetPropertyStr (
+    ctx, obj, "contain", JS_NewCFunction (ctx, expect_include, "contain", 1));
+    JS_SetPropertyStr (
+    ctx, obj, "length", JS_NewCFunction (ctx, expect_length, "length", 1));
+    JS_SetPropertyStr (
+    ctx, obj, "lengthOf", JS_NewCFunction (ctx, expect_length, "lengthOf", 1));
+    JS_SetPropertyStr (ctx, obj, "a", JS_NewCFunction (ctx, expect_a, "a", 1));
+    JS_SetPropertyStr (ctx, obj, "an", JS_NewCFunction (ctx, expect_a, "an", 1));
+    JS_SetPropertyStr (ctx, obj, "match", JS_NewCFunction (ctx, expect_match, "match", 1));
     JS_SetPropertyStr (ctx, obj, "property",
     JS_NewCFunction (ctx, expect_have_property, "property", 2));
 
@@ -745,23 +1067,27 @@ JSValue js_response_have_body (JSContext* ctx, JSValueConst this_val, int argc, 
 }
 
 JSValue js_response_have_jsonBody (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
-    if (argc < 1) {
-        return JS_ThrowTypeError (ctx, "jsonBody() requires a property path");
-    }
-
     auto* data = get_context_data (ctx);
     if (!data->response) {
         return JS_ThrowInternalError (ctx, "No response available");
     }
 
-    std::string prop_path = js_to_string (ctx, argv[0]);
-
     // Parse body as JSON
     JSValue json = JS_ParseJSON (ctx, data->response->body.c_str (),
     data->response->body.size (), "<response>");
     if (JS_IsException (json)) {
+        // Swallow the parse exception so we report a clean assertion failure.
+        JS_FreeValue (ctx, JS_GetException (ctx));
         return JS_ThrowTypeError (ctx, "Response body is not valid JSON");
     }
+
+    // No-arg form asserts only that the body is valid JSON (Postman semantics).
+    if (argc < 1) {
+        JS_FreeValue (ctx, json);
+        return JS_UNDEFINED;
+    }
+
+    std::string prop_path = js_to_string (ctx, argv[0]);
 
     // Navigate to the property
     JSValue current              = JS_DupValue (ctx, json);

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -243,6 +243,163 @@ TEST_F (ScriptEngineTest, ExpectTrueFalse) {
     EXPECT_TRUE (result.success);
 }
 
+// Mutation-checked: the paren-less terminal must actually run the assertion.
+// Before the getter fix `.to.be.true` was a discarded function reference, so a
+// deliberately-wrong assertion still passed. This asserts the failing case fails.
+TEST_F (ScriptEngineTest, ExpectTrueFalseAssertsOnAccess) {
+    auto result = engine.execute_test (R"(
+        pm.test("false is not true", function() {
+            pm.expect(false).to.be.true;
+        });
+
+        pm.test("true is not false", function() {
+            pm.expect(true).to.be.false;
+        });
+
+        pm.test("negation works", function() {
+            pm.expect(false).to.not.be.true;
+        });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 3);
+    EXPECT_FALSE (result.tests[0].passed);
+    EXPECT_FALSE (result.tests[0].error_message.empty ());
+    EXPECT_FALSE (result.tests[1].passed);
+    EXPECT_TRUE (result.tests[2].passed);
+}
+
+TEST_F (ScriptEngineTest, ExpectNullUndefinedOkEmpty) {
+    auto result = engine.execute_test (R"(
+        pm.test("null", function() { pm.expect(null).to.be.null; });
+        pm.test("undefined", function() { pm.expect(undefined).to.be.undefined; });
+        pm.test("ok", function() { pm.expect(1).to.be.ok; });
+        pm.test("not ok", function() { pm.expect(0).to.not.be.ok; });
+        pm.test("empty string", function() { pm.expect("").to.be.empty; });
+        pm.test("empty array", function() { pm.expect([]).to.be.empty; });
+        pm.test("empty object", function() { pm.expect({}).to.be.empty; });
+        pm.test("non-empty array", function() { pm.expect([1]).to.not.be.empty; });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ExpectNullFailsForNonNull) {
+    auto result = engine.execute_test (R"(
+        pm.test("1 is not null", function() { pm.expect(1).to.be.null; });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
+}
+
+TEST_F (ScriptEngineTest, ExpectLength) {
+    auto result = engine.execute_test (R"(
+        pm.test("array length", function() { pm.expect([1,2,3]).to.have.length(3); });
+        pm.test("string lengthOf", function() { pm.expect("abcd").to.have.lengthOf(4); });
+        pm.test("wrong length not", function() { pm.expect([1,2]).to.not.have.length(3); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ExpectLengthFailsNotThrows) {
+    auto result = engine.execute_test (R"(
+        pm.test("wrong length", function() { pm.expect([1,2,3]).to.have.length(2); });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
+    // A mismatch must fail, not throw "not a function".
+    EXPECT_EQ (result.tests[0].error_message.find ("not a function"), std::string::npos);
+}
+
+TEST_F (ScriptEngineTest, ExpectTypeMatcher) {
+    auto result = engine.execute_test (R"(
+        pm.test("string", function() { pm.expect("hi").to.be.a("string"); });
+        pm.test("number", function() { pm.expect(5).to.be.a("number"); });
+        pm.test("array", function() { pm.expect([1]).to.be.an("array"); });
+        pm.test("object", function() { pm.expect({}).to.be.an("object"); });
+        pm.test("wrong type", function() { pm.expect("hi").to.not.be.a("number"); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ExpectTypeMatcherFails) {
+    auto result = engine.execute_test (R"(
+        pm.test("string is not number", function() { pm.expect("hi").to.be.a("number"); });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
+    EXPECT_EQ (result.tests[0].error_message.find ("not a function"), std::string::npos);
+}
+
+TEST_F (ScriptEngineTest, ExpectMatchRegex) {
+    auto result = engine.execute_test (R"(
+        pm.test("matches", function() { pm.expect("hello123").to.match(/[0-9]+/); });
+        pm.test("does not match", function() { pm.expect("hello").to.not.match(/[0-9]+/); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ExpectMatchFails) {
+    auto result = engine.execute_test (R"(
+        pm.test("no digits", function() { pm.expect("hello").to.match(/[0-9]+/); });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
+}
+
+TEST_F (ScriptEngineTest, ExpectAtLeastAtMost) {
+    auto result = engine.execute_test (R"(
+        pm.test("at least equal boundary", function() { pm.expect(5).to.be.at.least(5); });
+        pm.test("at least above", function() { pm.expect(10).to.be.at.least(5); });
+        pm.test("at most equal boundary", function() { pm.expect(5).to.be.at.most(5); });
+        pm.test("at most below", function() { pm.expect(3).to.be.at.most(5); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ExpectAtLeastFails) {
+    auto result = engine.execute_test (R"(
+        pm.test("4 is not at least 5", function() { pm.expect(4).to.be.at.least(5); });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
+}
+
+TEST_F (ScriptEngineTest, ExpectContain) {
+    auto result = engine.execute_test (R"(
+        pm.test("string contain", function() { pm.expect("hello world").to.contain("world"); });
+        pm.test("array contain", function() { pm.expect([1,2,3]).to.contain(2); });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
 // ============================================================================
 // pm.response Tests
 // ============================================================================
@@ -277,6 +434,31 @@ TEST_F (ScriptEngineTest, ResponseJson) {
     request, response, env);
 
     EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ResponseHasJsonBodyNoArg) {
+    auto result = engine.execute_test (R"(
+        pm.test("body is valid JSON", function() {
+            pm.response.to.have.jsonBody();
+        });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+}
+
+TEST_F (ScriptEngineTest, ResponseJsonBodyNoArgFailsOnNonJson) {
+    response.body = "this is not json";
+    auto result   = engine.execute_test (R"(
+        pm.test("invalid json fails", function() {
+            pm.response.to.have.jsonBody();
+        });
+    )",
+      request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
 }
 
 TEST_F (ScriptEngineTest, ResponseHeaders) {
@@ -419,8 +601,7 @@ TEST_F (ScriptEngineTest, ComposedPartsShareOneScope) {
         {"origin":"request","script":"console.log(\"got \" + shared);"}
       ]
     })");
-    auto script =
-    vayu::http::read_script (json, "preRequestScripts", "preRequestScript");
+    auto script = vayu::http::read_script (json, "preRequestScripts", "preRequestScript");
 
     ScriptContext ctx;
     ctx.request = &request;


### PR DESCRIPTION
## Description

This is the worst class of defect for a testing tool: `pm.expect` assertions that render **green whether or not they hold**. Fixes both failure modes from #108, verified in `create_expectation` (`engine/src/runtime/script_engine.cpp`).

**Mode 1 - terminal matchers were silent no-ops.** `to`/`not`/`be`/`have` were real getters, but `exist`/`true`/`false` were plain **function-valued properties** and `null`/`undefined`/`ok`/`empty` were undefined. So the paren-less Chai/Postman idiom `pm.expect(x).to.be.true` was a property *access* that returned an uncalled function (or `undefined`) and asserted nothing - the expression statement discarded it, nothing threw. `pm.expect(false).to.be.true` "passed" identically to `pm.expect(true).to.be.true`. Every doc and every test uses this paren-less form.

- **Fix:** `exist`/`true`/`false`/`null`/`undefined`/`ok`/`empty` are now registered as **getters** (via `JS_DefinePropertyGetSet`, like `to`/`be`) whose C function performs the assertion the moment the property is read and honors the tracked `negated` flag. `.to.be.true` now evaluates the check on access, matching Chai/Postman.

**Mode 2 - matchers the compat doc lists as implemented threw `TypeError`.** `docs/app/pm-api-compatibility.md` advertises `.to.have.length(n)`/`.lengthOf(n)`, `.to.contain(v)`, `.to.be.a(type)`/`.an(type)`, `.to.match(/re/)`, `.at.least(n)`/`.at.most(n)` as "implemented in the QuickJS runtime", but none were registered - calling any threw "not a function".

- **Fix:** added `length`/`lengthOf`, `contain` (alias of `include`), `a`/`an` (type check), `match` (RegExp `test`), `least`/`most` as callable methods next to `equal`/`above`, plus an `at` chaining getter for `.at.least`/`.at.most`. Each reads the actual value and honors `not`; a mismatch **fails** (throws an assertion error caught by `pm.test`) rather than throwing "not a function".

**`jsonBody()` no-arg.** `pm.response.to.have.jsonBody()` with no argument required a path and threw; Postman's no-arg form asserts "body is valid JSON". It now parses the body and returns success on valid JSON, an assertion failure on non-JSON.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```bash
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
```

- **Engine gtest** (`engine/tests/script_engine_test.cpp`), **mutation-checked** per CLAUDE.md - the failing-case tests assert `tests[0].passed == false`, so they go red against the old no-op behavior (where the assertion silently passed):
  - `ExpectTrueFalseAssertsOnAccess` - `pm.expect(false).to.be.true` **fails** its `pm.test`; `.to.not.be.true` on `false` passes.
  - `ExpectNullUndefinedOkEmpty` / `ExpectNullFailsForNonNull` - the new terminals assert on access; the non-matching case fails.
  - `ExpectLength`/`ExpectLengthFailsNotThrows`, `ExpectTypeMatcher`/`ExpectTypeMatcherFails`, `ExpectMatchRegex`/`ExpectMatchFails`, `ExpectAtLeastAtMost`/`ExpectAtLeastFails`, `ExpectContain` - each passes on a match and **fails (not throws)** on a mismatch (asserted: error message contains no "not a function").
  - `ResponseHasJsonBodyNoArg` / `ResponseJsonBodyNoArgFailsOnNonJson` - no-arg `jsonBody()` passes on JSON, fails on a non-JSON body.
  - The existing `ExpectTrueFalse` was left as the passing baseline; the new `...AssertsOnAccess` companion is the mutation guard the old suite lacked.
- **Full engine suite green: 323/323 passed** (14 new tests). No pre-existing failures.
- Added C++ lines are clang-format clean; the one pre-existing non-clean region (`js_console_log`) was left untouched per repo convention.

## App changes

None - verified in the issue ("none, verified"). Assertion results already surface through `pm.test` pass/fail counts and `testResults`, which the renderer reads; no client depended on the broken behavior.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Docs

- `docs/app/pm-api-compatibility.md`'s "assertion chains" table is now accurate against the implementation - every listed matcher exists (previously the table was aspirational), so it needed no edit, only verification.
- `docs/engine/scripting.md`'s examples (`.to.be.a('string')`, `.to.be.null`, `jsonBody()` no-arg, etc.) are now true. The one example using the unsupported chained-getter form `.to.have.length.above(0)` was changed to the supported `pm.expect(users.length).to.be.above(0)`.

## Related Issues
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012HZpD5oEdL76tzjz9ZKEXy)_