### PR TITLE
fix(engine,runtime): pm.*.set() preserves secret flag and type of existing vars

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -26,7 +26,10 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Console             | `console.log/info/warn/error`                                                    |
 
 Variable writes persist to the scope they target (environment / collection / globals) and
-participate in [variable resolution](./variable-resolution.md).
+participate in [variable resolution](./variable-resolution.md). Calling `set(name, value)`
+on a variable that already exists updates only its value - the existing `secret` flag,
+`enabled` flag and `type` are preserved. A `set` on a new name creates it with the defaults
+(not secret, enabled, `type: "string"`).
 
 ### Assertion chains (`pm.expect` / `pm.response.to`)
 

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -937,6 +937,20 @@ JSValue js_pm_environment_get (JSContext* ctx, JSValueConst this_val, int argc, 
     return JS_UNDEFINED;
 }
 
+// Update a variable's value while preserving an existing key's secret, enabled
+// and type fields; a brand-new key gets the current defaults. Shared by the
+// environment/globals/collectionVariables pm.*.set() bindings so a script that
+// re-sets an existing (e.g. secret) variable does not silently strip its flag
+// or reset its type.
+void set_variable_preserving (Environment& map, const std::string& key, std::string value) {
+    auto it = map.find (key);
+    if (it != map.end ()) {
+        it->second.value = std::move (value); // preserve secret, enabled, type
+    } else {
+        map[key] = Variable{ std::move (value), false, true }; // new var: current defaults
+    }
+}
+
 JSValue js_pm_environment_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     if (argc < 2) {
         return JS_UNDEFINED;
@@ -950,7 +964,7 @@ JSValue js_pm_environment_set (JSContext* ctx, JSValueConst this_val, int argc, 
     std::string key   = js_to_string (ctx, argv[0]);
     std::string value = js_to_string (ctx, argv[1]);
 
-    (*data->environment)[key] = Variable{ value, false, true };
+    set_variable_preserving (*data->environment, key, std::move (value));
 
     return JS_UNDEFINED;
 }
@@ -998,7 +1012,7 @@ JSValue js_pm_globals_set (JSContext* ctx, JSValueConst this_val, int argc, JSVa
     std::string key   = js_to_string (ctx, argv[0]);
     std::string value = js_to_string (ctx, argv[1]);
 
-    (*data->globals)[key] = Variable{ value, false, true };
+    set_variable_preserving (*data->globals, key, std::move (value));
 
     return JS_UNDEFINED;
 }
@@ -1046,7 +1060,7 @@ JSValue js_pm_collectionVariables_set (JSContext* ctx, JSValueConst this_val, in
     std::string key   = js_to_string (ctx, argv[0]);
     std::string value = js_to_string (ctx, argv[1]);
 
-    (*data->collectionVariables)[key] = Variable{ value, false, true };
+    set_variable_preserving (*data->collectionVariables, key, std::move (value));
 
     return JS_UNDEFINED;
 }

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -383,6 +383,65 @@ TEST_F (ScriptEngineTest, EnvironmentSet) {
     EXPECT_EQ (env["new_var"].value, "new_value");
 }
 
+// Regression for #110: pm.*.set() on an existing key must preserve the
+// variable's secret flag, enabled flag and type - only the value changes. The
+// pre-fix whole-record replace silently un-masked a secret variable in the UI
+// and reset its type. Mutation-check: restore the Variable{value,false,true}
+// assignment in set_variable_preserving and the secret/type asserts here fail.
+TEST_F (ScriptEngineTest, SetPreservesSecretFlagAndType) {
+    env["token"] = Variable{ "old", true, true, "json" };
+
+    auto result = engine.execute_test (R"(
+        pm.environment.set("token", "rotated");
+        pm.test("dummy", function() {});
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+    EXPECT_EQ (env["token"].value, "rotated"); // value updated
+    EXPECT_TRUE (env["token"].secret);         // secret preserved
+    EXPECT_TRUE (env["token"].enabled);        // enabled preserved
+    EXPECT_EQ (env["token"].type, "json");     // type preserved
+}
+
+// A brand-new key still gets the current defaults (not secret, enabled, string).
+TEST_F (ScriptEngineTest, SetNewKeyGetsDefaults) {
+    auto result = engine.execute_test (R"(
+        pm.environment.set("fresh", "value");
+        pm.test("dummy", function() {});
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+    ASSERT_TRUE (env.count ("fresh"));
+    EXPECT_EQ (env["fresh"].value, "value");
+    EXPECT_FALSE (env["fresh"].secret);
+    EXPECT_TRUE (env["fresh"].enabled);
+    EXPECT_EQ (env["fresh"].type, "string");
+}
+
+// Guards that the collectionVariables setter is wired to the shared helper too
+// (all three setters must preserve, not just pm.environment).
+TEST_F (ScriptEngineTest, CollectionVariableSetPreservesSecretFlagAndType) {
+    Environment collVars;
+    collVars["cv_token"] = Variable{ "old", true, true, "json" };
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.response            = &response;
+    ctx.collectionVariables = &collVars;
+
+    auto result = engine.execute (R"(
+        pm.collectionVariables.set("cv_token", "rotated");
+    )",
+    ctx);
+
+    EXPECT_TRUE (result.success);
+    EXPECT_EQ (collVars["cv_token"].value, "rotated");
+    EXPECT_TRUE (collVars["cv_token"].secret);
+    EXPECT_EQ (collVars["cv_token"].type, "json");
+}
+
 // ============================================================================
 // Console Output Tests
 // ============================================================================


### PR DESCRIPTION
## Description

`pm.environment.set()` (and the `globals` / `collectionVariables` equivalents) replaced the **entire** `Variable` record for a key with `Variable{ value, false, true }`, silently stripping an existing key's `secret` flag and resetting its `type` to the `"string"` default. In design mode this is persisted (`persist_script_variables` serializes the whole in-memory map), so a script that merely re-sets a secret variable permanently un-masks it in the UI (and changes its declared type). The `secret` flag is UI-load-bearing: it drives value masking in `VariableTableEditor` and the reveal/hide affordance in the variable popover and context bar.

The fix factors the three identical `js_pm_*_set` bodies into one helper and routes all three bindings through it:

```cpp
void set_variable_preserving (Environment& map, const std::string& key, std::string value) {
    auto it = map.find (key);
    if (it != map.end ()) {
        it->second.value = std::move (value); // preserve secret, enabled, type
    } else {
        map[key] = Variable{ std::move (value), false, true }; // new var: current defaults
    }
}
```

An existing key gets a field-preserving value update; a brand-new key still gets the current defaults. One helper, so a fourth divergence cannot reappear. `serialize_variables_json` already reads `secret`/`type` off the `Variable`, so the preserved fields round-trip unchanged.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```bash
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
```

- **Engine gtest** (`engine/tests/script_engine_test.cpp`), mutation-checked:
  - `SetPreservesSecretFlagAndType` - `pm.environment.set` on a seeded `secret=true`, `type="json"` var keeps `secret`/`enabled`/`type` and changes only `value`.
  - `SetNewKeyGetsDefaults` - a brand-new key still gets `secret=false`, `enabled=true`, `type="string"`.
  - `CollectionVariableSetPreservesSecretFlagAndType` - guards that the `collectionVariables` setter is wired to the shared helper too (via a manual `ScriptContext`, since `execute_test` only wires environment).
  - **Mutation-check:** reverting the helper to the whole-record replace fails both preservation tests; the new-key defaults test correctly still passes.
- Full engine suite green: **312/312 passed** (+3 new). No pre-existing failures.
- Added C++ lines are clang-format clean; no pre-existing non-clean regions were reformatted.

## App changes

None (verified in the issue: "none, verified"). The renderer already reads the `secret` flag; the fix restores the flag the UI expects, and the app sends nothing that influences this path. No app files changed, so the app suite is unaffected.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Docs

- `docs/app/pm-api-compatibility.md` - notes that `set(name, value)` on an existing variable updates only its value and preserves `secret`/`enabled`/`type`, and that a new name gets the defaults. `docs/engine/scripting.md`'s broader `set`-semantics drift is deliberately left to #112 (docs cleanup, lands last) to avoid a merge conflict with the rest of the scripting series.

## Related Issues
Closes #110

---
_Generated by [Claude Code](https://claude.ai/code/session_011wxzJPUE3hWT1FccYPpRCh)_