### PR TITLE
feat(labeler): add area:mcp for the MCP server in the app tree

### DIFF
--- a/.github/LABELING.md
+++ b/.github/LABELING.md
@@ -12,10 +12,12 @@ Component (Auto-Applied) - WHERE            Type (Manual, pick one) - WHAT
   component:ci        ⚪  CI config            type:perf          🟧  Speed/resource
   component:build     ⚫  Build system         type:test          🟦  Tests/benchmarks
 
-Area (engine sub-areas, auto-applied)        Status (PRs, manual)
+Area (feature sub-areas, auto-applied)       Status (PRs, manual)
   area:http       HTTP server, SSE             status:needs-review  🟧  Awaiting review
-  area:auth       OAuth2, authentication        status:blocked       🔴  Waiting on something
-  area:metrics    Metrics, statistics           status:ready-merge   🟢  Approved
+  area:auth       OAuth2, authentication       status:blocked       🔴  Waiting on something
+  area:metrics    Metrics, statistics          status:ready-merge   🟢  Approved
+  area:scripting  QuickJS, pm.* API
+  area:mcp        MCP server (in the app)
 
                                               Priority (issues, manual)
 Special                                        priority:critical  🔴  Blocks other work
@@ -45,7 +47,7 @@ These labels indicate **where** in the codebase a change lands. **Applied automa
 
 ### Area Labels (`area:*`)
 
-These labels narrow down sub-areas **within the engine**. Useful for routing engine changes to appropriate reviewers. These are path-based and not manually applied.
+These labels narrow a change to a **feature sub-area**, one level finer than `component:*`. Useful for routing to the right reviewer. These are path-based and not manually applied. All but `area:mcp` are engine sub-areas.
 
 | Label | Description | Applies to |
 |-------|-------------|-----------|
@@ -53,8 +55,11 @@ These labels narrow down sub-areas **within the engine**. Useful for routing eng
 | `area:auth` | Authentication, OAuth2, authorization | Any file under `engine/**` with `auth` or `oauth` in its name - also matches `area:http`, since auth lives under `engine/src/http/` today |
 | `area:metrics` | Metrics collection, statistics, measurement | Any file under `engine/**` with `metrics` in its name |
 | `area:scripting` | QuickJS runtime, script execution, pm.* API | `engine/src/runtime/**` |
+| `area:mcp` | MCP server, tools, resources, prompts | `app/electron/mcp/**`, plus any file under `app/**` with `mcp` or `Mcp` in its name |
 
-`area:auth`/`area:metrics` match by filename convention (see "zero-maintenance" below); a file that doesn't follow it won't be caught - use a manual label as a fallback.
+`area:auth`/`area:metrics`/`area:mcp` match by filename convention (see "zero-maintenance" below); a file that doesn't follow it won't be caught - use a manual label as a fallback.
+
+**`area:mcp` is the one `area:*` outside the engine.** The MCP server is TypeScript in the app tree, proxying the engine's HTTP API, so it earns `component:app` - `area:mcp` is what distinguishes it from any other app change. The name wildcard is spelled twice (`*mcp*` and `*Mcp*`) because globs are case-sensitive and the settings panel is PascalCase.
 
 ### Type Labels (`type:*`)
 
@@ -124,14 +129,14 @@ These labels indicate **urgency**. Apply manually based on impact and timeline.
 1. **Component:** Add one `component:*` label to indicate where the issue lives. This may be auto-applied if the issue references a specific file.
 2. **Type:** Add one `type:*` label to indicate what kind of work it is.
 3. **Priority:** Add one `priority:*` label if it's urgent.
-4. **Area (engine only):** Add an `area:*` label if it's an engine issue that fits a sub-area.
+4. **Area:** Add an `area:*` label if the issue fits a sub-area (engine sub-areas, or `area:mcp`).
 5. **Special:** Add special labels as needed (`good first issue`, `help wanted`, `documentation`, etc.).
 
 ### For Pull Requests
 
 1. **Component:** Auto-applied based on changed files. Override if the labeler got it wrong.
 2. **Type:** Applied manually to describe the kind of change.
-3. **Area (engine only):** Auto-applied for engine files in a sub-area.
+3. **Area:** Auto-applied for files in a sub-area (engine sub-areas, or the MCP server in the app).
 4. **Status:** Apply `status:needs-review` when ready, update to `status:ready-merge` when approved.
 5. **Special:** Add as needed.
 
@@ -143,19 +148,20 @@ The `.github/labeler.yml` file defines path-based rules that automatically apply
 
 Exact paths/patterns for each rule are in the category tables above (`Auto-applied when` / `Applies to` columns); `release` triggers on `VERSION` alone, which also matches `component:build`.
 
-`component:database` and `area:*` rules are kept strictly inside `engine/**` -
-a `docs/engine/*.md` change earns `documentation`, not a component/area label
-for code it never touched.
+`component:database` and every `area:*` rule are kept strictly inside a *code*
+tree - `engine/**` for all of them except `area:mcp`, which is scoped to
+`app/**`. The point is that a `docs/engine/*.md` change earns `documentation`,
+not a component/area label for code it never touched.
 
 If a PR changes files in multiple categories, it gets all matching labels. A release PR touching `app/`, `engine/`, and build files will earn `component:app`, `component:engine`, and `component:build`.
 
 ### Most rules are zero-maintenance; `component:build` is not
 
 `component:app`, `component:engine`, `component:ci`, `component:database`,
-`area:http`, `area:auth`, `area:metrics`, and `area:scripting` are all either
-a directory glob or a filename-convention wildcard - a new file placed in the
-right directory, or named the way every existing file in that area is named,
-gets labeled automatically with no `labeler.yml` change.
+`area:http`, `area:auth`, `area:metrics`, `area:scripting`, and `area:mcp` are
+all either a directory glob or a filename-convention wildcard - a new file
+placed in the right directory, or named the way every existing file in that
+area is named, gets labeled automatically with no `labeler.yml` change.
 
 `component:build` is the one rule left as an enumerated file list, because
 build/version manifests don't share a naming convention (`build.py`,
@@ -186,6 +192,7 @@ exception: kept and restyled as manual-only companions to `component:ci` /
 | Database schema migration | `component:engine`, `component:database` | `type:enhancement`, `documentation` (if adding schema docs) |
 | Perf improvement to the request scheduler | `component:engine`, `area:http` | `type:perf`, `priority:high` |
 | Test for the QuickJS sandbox | `component:engine`, `area:scripting` | `type:test` |
+| New tool added to the MCP server | `component:app`, `area:mcp` | `type:feature`, `documentation` (if updating `docs/engine/mcp.md`) |
 
 ## Applying Labels to the Repository
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,9 +69,11 @@ documentation:
           - 'docs/**'
           - '**/*.md'
 
-# Area labels - sub-areas within engine. Kept strictly inside `engine/**`,
-# same reasoning as `component:database`: a doc-only change earns
-# `documentation`, not an `area:*` label whose code it didn't touch.
+# Area labels - a feature slice within a tree, one level finer than
+# `component:*`. Every rule is kept strictly inside a *code* tree (`engine/**`
+# or `app/**`), same reasoning as `component:database`: a doc-only change earns
+# `documentation`, not an `area:*` label whose code it didn't touch. All of
+# these are engine sub-areas except `area:mcp`, whose server lives in the app.
 #
 # area:auth and area:metrics match by naming convention (`*auth*`/`*oauth*`,
 # `*metrics*`) instead of an enumerated file list. Auth and metrics code
@@ -110,3 +112,25 @@ area:scripting:
       - any-glob-to-any-file:
           - 'engine/src/runtime/**'
           - 'engine/include/vayu/runtime/**'
+
+# The MCP server is TypeScript under `app/electron/mcp/` proxying the engine's
+# HTTP API, so it earns `component:app` and never `component:engine`. This is
+# the label that tells an MCP change apart from any other app change.
+#
+# Three globs, and none of them is redundant. A path is matched whole, so
+# `app/**/*mcp*` does *not* match `app/electron/mcp/tools.ts` - the final
+# segment (`tools.ts`) has to match, and it doesn't. The directory glob is what
+# covers the 21 files under the server; the name wildcards are what reach MCP
+# files living elsewhere in `app/`. Today `*Mcp*` earns exactly one
+# (`McpSettingsPanel.tsx`) and `*mcp*` earns none - it is spelled out anyway
+# because globs are case-sensitive, and a lowercase `mcp-*.ts` under `app/src/`
+# is the obvious next file this rule should catch without a change here.
+#
+# Scoped to `app/**` so `docs/engine/mcp.md` stays `documentation` only, like
+# every other rule here.
+area:mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/electron/mcp/**'
+          - 'app/**/*mcp*'
+          - 'app/**/*Mcp*'


### PR DESCRIPTION
## What

Adds an `area:mcp` path label. The MCP server is 21 TypeScript files under `app/electron/mcp/` plus `McpSettingsPanel.tsx`, so an MCP-only change previously earned `component:app` and nothing that distinguished it from any other app change.

```yaml
area:mcp:
  - changed-files:
      - any-glob-to-any-file:
          - 'app/electron/mcp/**'
          - 'app/**/*mcp*'
          - 'app/**/*Mcp*'
```

## ⚠️ The label must exist before this merges

`.github/labeler.yml` fails on a key that isn't a real repository label, so the Labeler check on this PR will fail until someone with write access runs:

```
gh label create "area:mcp" --color A9CCE3 --description "MCP server, tools, resources, prompts"
```

`A9CCE3` is the colour all four existing `area:*` labels already share.

## Why `area:` and not `component:`

`area:*` is the finer "where" axis - a feature slice one level below `component:*` - and that shape fits MCP. `component:mcp` would have had to stretch `component:*` from *tree* to *feature*; `area:` only has to relax "engine sub-area" to "sub-area".

The cost is that `area:mcp` is the first `area:*` outside `engine/**`, which the docs asserted in six places. Those are reworded, not dropped: every `area:*` rule is still scoped strictly to a **code** tree, which is the invariant that actually mattered - it's what keeps a docs-only change earning `documentation` rather than a label for code it never touched. `docs/engine/mcp.md` still gets `documentation` alone.

## Three globs, none redundant

A path is matched whole, so `app/**/*mcp*` does **not** match `app/electron/mcp/tools.ts` - the final segment (`tools.ts`) has to match, and it doesn't. So the directory glob is what covers the server, and the name wildcards are what reach MCP files living elsewhere in `app/`. `*Mcp*` is spelled out separately because globs are case-sensitive and the panel is PascalCase.

Today that's 21 / 0 / 1 per glob. `*mcp*` earns nothing yet and is deliberate - a lowercase `mcp-*.ts` under `app/src/` is the obvious next file this should catch with no config change.

## Verification

Globs were run against the real file tree using minimatch path semantics:

- 22 files matched - all 21 under `app/electron/mcp/` plus `McpSettingsPanel.tsx`
- nothing matched outside `app/`
- `docs/engine/mcp.md` not matched
- YAML re-parses, 12 rules

## Incidental

Two unrelated fixes inside the LABELING.md quick-reference block this PR was already editing: `area:auth` and `area:metrics` were each one space off the `status:` column, and `area:scripting` was absent from the block entirely.

## Not done here

The Area table has no Colour column (unlike Component and Type), so the shared `A9CCE3` is recorded nowhere in the repo. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
