### PR TITLE
docs: publish docs/ to GitHub Pages with MkDocs Material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -94,9 +94,17 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # This trio is version-coupled through the Pages artifact format, so the
+      # pairing is taken verbatim from GitHub's own starter workflow
+      # (actions/starter-workflows, pages/static.yml) rather than each action
+      # being bumped to its newest major independently. `upload-pages-artifact`
+      # has a v5 and `configure-pages` a v6, but GitHub still ships v3 and v5
+      # alongside `deploy-pages@v5`. Nothing on a pull request exercises this
+      # job (it is skipped), so a bad pin here would only surface as a failed
+      # deploy on master.
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,17 @@ on:
 permissions:
   contents: read
 
+env:
+  # Silences the "Warning from the Material for MkDocs team" banner about MkDocs
+  # 2.0 (https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/).
+  # It is an unconditional advisory from the theme, not a finding about this
+  # config: the build still succeeds, and it printed 14 red lines above every
+  # run. Our exposure is small anyway - the only plugin here is MkDocs' built-in
+  # `search` and there are no theme overrides - and the version is pinned in
+  # requirements-docs.txt, so nothing upstream can change this site without a
+  # commit. Unset this to see the banner again.
+  NO_MKDOCS_2_WARNING: '1'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Superseded pull-request builds are throwaway; a superseded deploy is not -

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,102 @@
+name: Docs site
+
+# Publishes `docs/` to GitHub Pages (https://athrvk.github.io/vayu/) with
+# MkDocs Material. Source of truth stays on master - the built site is uploaded
+# as a Pages artifact, so there is no `gh-pages` branch to keep in sync.
+#
+# Requires one manual repository setting: Settings -> Pages -> Build and
+# deployment -> Source = "GitHub Actions". With the default "Deploy from a
+# branch" the deploy step fails with "Get Pages site failed".
+#
+# Jekyll is deliberately not used. GitHub Pages' default Jekyll build runs
+# Liquid over every page, and these docs are full of `{{variable}}` and
+# `{% ... %}` examples: the former would render as empty strings, the latter
+# fails the build as an unknown Liquid tag. MkDocs never templates page content.
+#
+# This workflow only triggers on docs paths, so it must NOT be added as a
+# required status check - it never starts on a code-only pull request, and a
+# check that never starts blocks the merge forever (see the note at the top of
+# pr-tests.yml for the same trap).
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Superseded pull-request builds are throwaway; a superseded deploy is not -
+  # cancelling one mid-upload can leave Pages serving a half-published site.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Cache pip wheels
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pip
+          key: pip-docs-${{ runner.os }}-${{ hashFiles('requirements-docs.txt') }}
+          restore-keys: |
+            pip-docs-${{ runner.os }}-
+
+      - name: Install MkDocs Material
+        run: python3 -m pip install --disable-pip-version-check -r requirements-docs.txt
+
+      # `--strict` promotes MkDocs warnings to failures, which is what makes the
+      # pull-request run worth having: these docs cross-link heavily by relative
+      # `.md` path and by heading anchor, and both are validated here (see the
+      # `validation:` block in mkdocs.yml).
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ Thumbs.db
 __pycache__/
 *.py[cod]
 
+# MkDocs output (`mkdocs build`). CI builds and uploads this; it is never
+# committed - the Pages deploy reads the artifact, not a branch.
+/site/
+
 # Engine data dir when the daemon is run from the repo root (it defaults to
 # ./data relative to the working directory). Anchored so it only matches here -
 # the in-tree location, engine/data/, is ignored by engine/.gitignore.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,3 +448,30 @@ Module READMEs carry the *why* for their feature and are easy to miss:
 and `dashboard/`.
 
 Release notes live in `.github/release-notes/vX.Y.Z.md` - see **Releasing**.
+
+### `docs/` is published, so a broken link is a build failure
+
+`docs/` ships to <https://athrvk.github.io/vayu/> via MkDocs Material
+(`mkdocs.yml` at the root, `.github/workflows/docs.yml`, deps pinned in
+`requirements-docs.txt`). `mkdocs build --strict` runs on every docs-touching
+pull request and fails on an unresolvable relative `.md` link or a missing
+heading anchor, so:
+
+- **Add a new page to the `nav:` in `mkdocs.yml`** in the same commit. Off-nav
+  pages build and are reachable by URL, but never appear in the sidebar.
+- **Do not rename or move a doc file** without checking for readers. Tests read
+  doc paths (`app/src/design-system-doc.test.ts` reads `docs/design-system.md`),
+  and every relative cross-link is validated by the build.
+- **Anchors follow GitHub's slug rules** (`pymdownx.slugs.slugify` is configured
+  for exactly this), so one anchor form works both in GitHub's markdown view and
+  on the site. Heading punctuation counts: `## Shared Auth Fields
+  (components/shared/AuthFields/)` is `#shared-auth-fields-componentssharedauthfields`.
+- **Links out of `docs/`** (`SECURITY.md`, `LICENSE`, `CONTRIBUTING.md`) must be
+  absolute `https://github.com/athrvk/vayu/blob/master/...` URLs - those files
+  are outside the published tree.
+- **Jekyll is not an option here** and the workflow says why: Pages' default
+  Jekyll build runs Liquid over page content, and these docs contain 40+
+  `{{variable}}` examples (rendered as empty strings) plus `{% ... %}` (an
+  unknown tag, which fails the build). MkDocs never templates page content.
+
+Preview locally with `pip install -r requirements-docs.txt && mkdocs serve`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,37 @@ Currently, the app does not have automated tests. If you add tests:
 - Use Vitest for unit tests
 - Use Playwright for E2E tests (if needed)
 
+## Documentation
+
+Everything in `docs/` is published to **[athrvk.github.io/vayu](https://athrvk.github.io/vayu/)**
+by `.github/workflows/docs.yml` on every push to `master` that touches the docs.
+The site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
+from `mkdocs.yml` at the repo root.
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve            # live preview on http://127.0.0.1:8000
+mkdocs build --strict   # exactly what CI runs
+```
+
+Two rules when you add or change a doc:
+
+- **Add the page to the `nav:` in `mkdocs.yml`.** A file that is not in the nav
+  still builds and is still reachable by URL, but it never appears in the
+  sidebar, so in practice nobody finds it.
+- **Keep cross-links relative and anchors real.** `mkdocs build --strict` fails
+  on a relative `.md` link that does not resolve and on a `#heading-anchor` that
+  does not exist, and the pull-request run does the same. Anchors follow GitHub's
+  slug rules (configured in `mkdocs.yml`), so a link that works in GitHub's
+  markdown view works on the site, and vice versa. Note that a heading such as
+  `## Shared Auth Fields (components/shared/AuthFields/)` slugifies to
+  `#shared-auth-fields-componentssharedauthfields` - the parenthetical is part of
+  the anchor.
+
+Links out of `docs/` (to `SECURITY.md`, `LICENSE`, `CONTRIBUTING.md`) must be
+absolute `https://github.com/athrvk/vayu/blob/master/...` URLs: those files are
+outside the published tree, so a relative path 404s on the site.
+
 ## Commit Messages
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ See [Architecture Documentation](docs/architecture.md) for the full process mode
 
 ## Documentation
 
+**Full docs: [athrvk.github.io/vayu](https://athrvk.github.io/vayu/)** - searchable, and built from `docs/` on every push to `master`.
+
 | Document | Description |
 |---|---|
 | [Architecture](docs/architecture.md) | Sidecar pattern, process model, IPC |

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -128,7 +128,7 @@ The request editor. Entry: `modules/request-builder/index.tsx`.
 | `context/RequestBuilderProvider.tsx`, `context/RequestBuilderContext.tsx` | Local request-editing state + the execute/save/load-test callbacks |
 | `components/RequestBuilderLayout.tsx` | Resizable vertical layout composing UrlBar / RequestTabs / ResponseViewer |
 | `components/UrlBar/` | `index`, `MethodSelector`, `UrlInput` - method dropdown, URL input (variable highlighting), Send + Load Test buttons. Pasting a curl/wget command into `UrlInput` auto-imports it (see note below) |
-| `components/RequestTabs/` | `index` + `panels/`: `ParamsPanel`, `HeadersPanel`, `BodyPanel`, `AuthPanel`, `AuthInheritBanner`, `PreScriptPanel`, `TestScriptPanel`, `InheritedScriptsNotice`, `SettingsPanel`. `AuthPanel` owns the mode picker (it is the only host that offers `inherit`) and delegates every field group to the shared [`AuthFields`](#shared-auth-fields), injecting a variable-aware `VariableInput`; OAuth 2.0 reaches [`OAuth2Form`](#shared-oauth-20-form) through it. `PreScriptPanel` and `TestScriptPanel` each render `InheritedScriptsNotice` (the script equivalent of `AuthInheritBanner`) to name which ancestor collections contribute a pre-request or test script; it accepts an optional `entries` prop so a stored-run view can supply parts directly instead of reading the live chain. `SettingsPanel` holds the per-request redirect policy (**Follow redirects** + **Maximum redirects**); the tab strip badges it via `isRedirectPolicyNonDefault` (in `utils/request-state`) only when the request departs from the engine defaults |
+| `components/RequestTabs/` | `index` + `panels/`: `ParamsPanel`, `HeadersPanel`, `BodyPanel`, `AuthPanel`, `AuthInheritBanner`, `PreScriptPanel`, `TestScriptPanel`, `InheritedScriptsNotice`, `SettingsPanel`. `AuthPanel` owns the mode picker (it is the only host that offers `inherit`) and delegates every field group to the shared [`AuthFields`](#shared-auth-fields-componentssharedauthfields), injecting a variable-aware `VariableInput`; OAuth 2.0 reaches [`OAuth2Form`](#shared-oauth-20-form-componentssharedoauth2form) through it. `PreScriptPanel` and `TestScriptPanel` each render `InheritedScriptsNotice` (the script equivalent of `AuthInheritBanner`) to name which ancestor collections contribute a pre-request or test script; it accepts an optional `entries` prop so a stored-run view can supply parts directly instead of reading the live chain. `SettingsPanel` holds the per-request redirect policy (**Follow redirects** + **Maximum redirects**); the tab strip badges it via `isRedirectPolicyNonDefault` (in `utils/request-state`) only when the request departs from the engine defaults |
 | `components/ResponseViewer/` | `index`, `ResponseCookies`, `ResponseTimingTab`, `TestResults`, `ConsoleOutput`, `RawRequestResponse`, `ClientErrorView` (status bar, actions and the Headers tab now come from `shared/response-viewer/`). The Console tab renders whenever the response carries console logs **or** a `preScriptError`/`postScriptError`, so a script that throws before logging still shows its error rather than a silent 200 |
 | `components/RequestDescription.tsx` | Editable request description |
 | `components/LoadTestConfigDialog.tsx` | Load-test configuration dialog (mode, duration, RPS, concurrency, …). Renders `OAuth2LoadTestGuard` when the request's effective auth is OAuth 2.0 |
@@ -172,7 +172,7 @@ Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows n
 | Tab | Component | Notes |
 |---|---|---|
 | Info | `InfoTab.tsx` | Name, description, request count |
-| Auth | `AuthTab.tsx` | Collection-level auth (concrete; never `inherit`). Mode picker + hints only - the fields are the shared [`AuthFields`](#shared-auth-fields) |
+| Auth | `AuthTab.tsx` | Collection-level auth (concrete; never `inherit`). Mode picker + hints only - the fields are the shared [`AuthFields`](#shared-auth-fields-componentssharedauthfields) |
 | Pre-request | `ScriptTab.tsx` (`kind="pre"`) | Collection pre-request script |
 | Post-request | `ScriptTab.tsx` (`kind="post"`) | Collection post-request script |
 | Variables | `VariablesTab.tsx` | Collection-scoped variables (count badge) |
@@ -311,7 +311,7 @@ domain `RequestAuth` shape, so the component reads `mode` and `in` directly -
 there is no editor-local vocabulary and nothing to translate at the boundary.
 
 - `AuthFields.tsx` - the None / Bearer / Basic / API Key field groups, and
-  oauth2 delegated to [`OAuth2Form`](#shared-oauth-20-form). Takes an **injected
+  oauth2 delegated to [`OAuth2Form`](#shared-oauth-20-form-componentssharedoauth2form). Takes an **injected
   `TextInput`** (the same contract `OAuth2Form` defines) so the builder supplies
   a variable-aware token editor while the collection editor takes the default
   plain input, which accents `{{var}}`. `noAuthDescription` is host-supplied: a

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -10,7 +10,7 @@ and proxies the engine's REST API on `:9876`. The **C++ engine is not modified**
 the MCP layer is Apache-2.0 like the rest of the app.
 
 Once Vayu is running, any agent opts in with one command; if Vayu is down, the
-agent gets a clean "start Vayu" error. Threat model and posture: [`SECURITY.md`](../../SECURITY.md).
+agent gets a clean "start Vayu" error. Threat model and posture: [`SECURITY.md`](https://github.com/athrvk/vayu/blob/master/SECURITY.md).
 
 ## Overview
 
@@ -392,4 +392,4 @@ builds on the mechanism the spec is deprecating and the payoff is client-depende
   [Codex](https://developers.openai.com/codex/mcp) ·
   [Cursor](https://cursor.com/docs/mcp)
 - Engine API surface: [`api-reference.md`](./api-reference.md) · Threat model:
-  [`SECURITY.md`](../../SECURITY.md)
+  [`SECURITY.md`](https://github.com/athrvk/vayu/blob/master/SECURITY.md)

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -301,4 +301,4 @@ Test failures don't stop script execution - all tests run and results are collec
 
 ## API Reference
 
-For complete API documentation, see the [Scripting Completions API](../api-reference.md#scripting) which lists all available `pm.*` functions and properties.
+For complete API documentation, see the [Scripting Completions API](api-reference.md#scripting) which lists all available `pm.*` functions and properties.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# Vayu Documentation
+
+Vayu is an open source desktop app that merges a REST/GraphQL request builder
+with a native load tester. Everything runs on your machine: no account, no cloud
+sync, no quotas.
+
+It is built as a **sidecar**: an Electron + React UI (the manager) talks to a
+C++20 daemon (the engine) over HTTP on `127.0.0.1:9876`. The split is what lets
+the UI stay responsive while the engine saturates a target at tens of thousands
+of requests per second.
+
+<div class="grid cards" markdown>
+
+- :material-sitemap: **[Architecture](architecture.md)**
+
+    The sidecar pattern, process model, lifecycle, and IPC. Start here.
+
+- :material-hammer-wrench: **[Building from Source](building.md)**
+
+    Prerequisites, `build.py`, CMake presets, and platform quirks.
+
+- :material-api: **[Engine HTTP API](engine/api-reference.md)**
+
+    Every endpoint, payload, and status code the engine serves.
+
+- :material-palette: **[Design System](design-system.md)**
+
+    Tokens, elevation, typography, and the component patterns the UI is built on.
+
+</div>
+
+## Engine
+
+The C++20 daemon: request execution, load generation, persistence, and scripting.
+
+| Document | Covers |
+|---|---|
+| [Architecture](engine/architecture.md) | Core structure, thread pool, engine-side auth resolution |
+| [HTTP API Reference](engine/api-reference.md) | All endpoints, payload shapes, status codes, deprecated aliases |
+| [Scripting Runtime](engine/scripting.md) | The QuickJS sandbox, script globals, hooks, limits |
+| [Database Schema](engine/db-schema.md) | SQLite tables and the JSON shapes stored in them |
+| [CLI](engine/cli.md) | Flags and subcommands for running the engine standalone |
+| [MCP Server](engine/mcp.md) | The MCP tool surface exposed to coding agents |
+| [Benchmarks](engine/benchmarks.md) | RPS head-to-head against wrk and vegeta, with methodology |
+| [Building the Engine](engine/building.md) | CMake presets and vcpkg dependencies |
+
+## App
+
+The Electron + React renderer: request builder, collections, dashboard, and the
+client half of request composition.
+
+| Document | Covers |
+|---|---|
+| [Architecture](app/architecture.md) | Renderer-side structural decisions |
+| [Components](app/COMPONENTS.md) | The `modules/` + `components/` layout |
+| [State Management](app/state-management.md) | Zustand stores, TanStack Query keys, cache policy |
+| [API Integration](app/api-integration.md) | What the renderer sends the engine, and when |
+| [Variable Resolution](app/variable-resolution.md) | How `{{variables}}` resolve, and scope precedence |
+| [Postman API Compatibility](app/pm-api-compatibility.md) | Which `pm.*` APIs the runtime supports |
+| [File Name Conventions](app/file-name-conventions.md) | Naming rules across the renderer |
+| [Building the App](app/building.md) | App build steps and tooling |
+| [Import Collections](app/import-collections/README.md) | The import pipeline, plus per-format mapping for Postman, Insomnia v4, OpenAPI 3.0, and Swagger 2.0 |
+
+## Design notes
+
+Longer-form rationale for decisions that are easy to misread from the code alone.
+
+- [Request Storage](request-storage-design.md) - how requests are persisted.
+- [Lock File Handling](lock-file-handling.md) - lock and concurrency behaviour.
+- [Pending Backlog](plans/pending-backlog.md) - deferred work, and why it is deferred.
+
+## Elsewhere
+
+- [Contributing Guide](https://github.com/athrvk/vayu/blob/master/CONTRIBUTING.md) - dev setup, code style, PR process, releases.
+- [Security Policy](https://github.com/athrvk/vayu/blob/master/SECURITY.md) - threat model and reporting.
+- [Releases](https://github.com/athrvk/vayu/releases/latest) - installers for Windows, macOS, and Linux.
+
+!!! note "Licensing"
+
+    The engine is AGPL-3.0 and the app is Apache-2.0. See
+    [LICENSE](https://github.com/athrvk/vayu/blob/master/LICENSE) for both texts.

--- a/llms.txt
+++ b/llms.txt
@@ -21,12 +21,16 @@ Sidecar pattern: Electron UI (Manager) communicates with a C++20 daemon (Engine)
 
 ## Documentation
 
+Documentation site: https://athrvk.github.io/vayu/
+
 - [README](https://github.com/athrvk/vayu/blob/master/README.md)
-- [Architecture](https://github.com/athrvk/vayu/blob/master/docs/architecture.md)
-- [Engine API Reference](https://github.com/athrvk/vayu/blob/master/docs/engine/api-reference.md)
-- [Variable Resolution](https://github.com/athrvk/vayu/blob/master/docs/app/variable-resolution.md)
-- [DB Schema](https://github.com/athrvk/vayu/blob/master/docs/engine/db-schema.md)
-- [Building](https://github.com/athrvk/vayu/blob/master/docs/building.md)
+- [Architecture](https://athrvk.github.io/vayu/architecture/)
+- [Engine API Reference](https://athrvk.github.io/vayu/engine/api-reference/)
+- [Engine Scripting](https://athrvk.github.io/vayu/engine/scripting/)
+- [MCP Server](https://athrvk.github.io/vayu/engine/mcp/)
+- [Variable Resolution](https://athrvk.github.io/vayu/app/variable-resolution/)
+- [DB Schema](https://athrvk.github.io/vayu/engine/db-schema/)
+- [Building](https://athrvk.github.io/vayu/building/)
 
 ## Download
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,133 @@
+site_name: Vayu Docs
+site_description: >-
+  Documentation for Vayu - an open source desktop app for REST and GraphQL API
+  testing and native load testing, built on a C++20 engine and an Electron UI.
+site_url: https://athrvk.github.io/vayu/
+site_author: athrvk
+
+repo_url: https://github.com/athrvk/vayu
+repo_name: athrvk/vayu
+edit_uri: edit/master/docs/
+
+docs_dir: docs
+site_dir: site
+
+copyright: Engine AGPL-3.0 &middot; App Apache-2.0
+
+theme:
+  name: material
+  language: en
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - content.action.edit
+    - content.code.annotate
+    - content.code.copy
+    - navigation.footer
+    - navigation.indexes
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+
+nav:
+  - Home: index.md
+  - Architecture: architecture.md
+  - Building from Source: building.md
+  - Design System: design-system.md
+  - Engine:
+      - Architecture: engine/architecture.md
+      - HTTP API Reference: engine/api-reference.md
+      - Scripting Runtime: engine/scripting.md
+      - Database Schema: engine/db-schema.md
+      - CLI: engine/cli.md
+      - MCP Server: engine/mcp.md
+      - Benchmarks: engine/benchmarks.md
+      - Building the Engine: engine/building.md
+  - App:
+      - Architecture: app/architecture.md
+      - Components: app/COMPONENTS.md
+      - State Management: app/state-management.md
+      - API Integration: app/api-integration.md
+      - Variable Resolution: app/variable-resolution.md
+      - Postman API Compatibility: app/pm-api-compatibility.md
+      - File Name Conventions: app/file-name-conventions.md
+      - Building the App: app/building.md
+      - Import Collections:
+          - Pipeline Overview: app/import-collections/README.md
+          - Postman: app/import-collections/postman.md
+          - Insomnia v4: app/import-collections/insomnia-v4.md
+          - OpenAPI 3.0: app/import-collections/openapi-v3.md
+          - Swagger 2.0: app/import-collections/openapi-v2.md
+  - Design Notes:
+      - Request Storage: request-storage-design.md
+      - Lock File Handling: lock-file-handling.md
+      - Pending Backlog: plans/pending-backlog.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  # GitHub-compatible heading slugs. Both renderings share one anchor scheme, so
+  # links like `#url--path-parameters` (double dash from "URL / Path") resolve on
+  # the site and in GitHub's markdown view. Do not swap this for the default
+  # Python-Markdown slugify, which collapses the dashes and 404s those anchors.
+  - toc:
+      permalink: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+# Broken cross-references are a build failure in CI (`mkdocs build --strict`),
+# which is the point: these docs cross-link heavily by relative `.md` path.
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/athrvk/vayu
+      name: Vayu on GitHub

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,8 @@
+# Documentation site (docs/ -> https://athrvk.github.io/vayu/).
+# Built by .github/workflows/docs.yml; pinned so a theme release cannot change
+# the published site without a commit here.
+#
+#   pip install -r requirements-docs.txt
+#   mkdocs serve          # local preview on http://127.0.0.1:8000
+#   mkdocs build --strict # what CI runs
+mkdocs-material==9.7.7


### PR DESCRIPTION
## Description

Serves `docs/` at **https://athrvk.github.io/vayu/**, built by a new workflow on every push to `master` that touches the docs. Source of truth stays on `master`: the site is uploaded as a Pages artifact, so there is no `gh-pages` branch to keep in sync.

| File | Purpose |
|---|---|
| `mkdocs.yml` | Material theme, full nav for all 26 pages, GitHub-compatible heading slugs, strict link/anchor validation |
| `docs/index.md` | Landing page - `docs/` had no index, so the site root would have 404'd |
| `.github/workflows/docs.yml` | `mkdocs build --strict` on docs-touching PRs; build + Pages deploy on push to `master` |
| `requirements-docs.txt` | Pins `mkdocs-material==9.7.7` |
| 4 docs + `.gitignore`, `README.md`, `llms.txt`, `CONTRIBUTING.md`, `CLAUDE.md` | Link fixes, `/site/` ignore, site pointers, contributor + agent rules |

### Why MkDocs and not Jekyll

GitHub Pages' default Jekyll build runs Liquid over page content, and these docs are *about* `{{variable}}` syntax: 41 occurrences across 19 files would render as empty strings, and the two `{% ... %}` examples in the import docs are unknown Liquid tags that fail the build outright. MkDocs never templates page content. The reasoning is recorded in a comment at the top of the workflow so it does not have to be rediscovered.

### GitHub-compatible anchors

Heading slugs use `pymdownx.slugs.slugify(case="lower")`, which reproduces GitHub's algorithm including consecutive dashes - so `#url--path-parameters` and `#auth--security` resolve unchanged. One anchor form serves both GitHub's markdown view and the site, and no existing cross-link had to be bent to suit the generator.

### Five links fixed that were already broken

`mkdocs build --strict` fails on a dead relative link or a missing anchor, which is what makes the PR run worth having. It found these on the first run; four are broken on GitHub today:

- `engine/scripting.md:304` pointed at `../api-reference.md#scripting`, one directory too high.
- `app/COMPONENTS.md` linked `#shared-auth-fields` and `#shared-oauth-20-form` (4 links), but both headings carry a parenthetical that is part of the slug.
- `engine/mcp.md` reached `../../SECURITY.md` twice - resolves on GitHub, but sits outside the published tree; now an absolute URL.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`mkdocs build --strict` passes clean locally (`Documentation built in 1.97 seconds`, zero warnings). Verified in the generated HTML that:

- `{{variableName}}` and `{{baseUrl}}` survive verbatim (the Jekyll failure mode this setup exists to avoid).
- `app/import-collections/README.md` becomes that directory's index, so the 20+ `./README.md#anchor` links resolve - e.g. `href="../#shared-helpers"`.
- Every internal link on the new landing page resolves to a real page, and both `docs/images/*.png` copied through.
- The `llms.txt` URLs match real built paths.

The workflow itself runs on this PR (it touches `docs/**`, `mkdocs.yml`, and the workflow file), so the strict build is exercised here before merge.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - no test code; the strict build is the guard, and it runs on every docs-touching PR
- [x] I have updated documentation - `CONTRIBUTING.md` gains a Documentation section (preview commands, nav requirement, anchor rules) and `CLAUDE.md` records the same for future sessions

## Required before this works

**Settings → Pages → Build and deployment → Source must be set to "GitHub Actions."** With the default "Deploy from a branch" the deploy job fails with `Get Pages site failed`. This is a repository setting, not something the PR can carry.

One caveat worth flagging: **`Docs site` must not be added as a required status check.** It only triggers on docs paths, so it never starts on a code-only PR, and a check that never starts blocks the merge permanently - the same deadlock documented at the top of `pr-tests.yml`.

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwXnv6LDtSqMU2Tkdfip45)_