### PR TITLE
docs(site): design pass, product-page Home, and SEO

### DIFF
--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -17,6 +17,14 @@ copyright: Engine AGPL-3.0 &middot; App Apache-2.0
 theme:
   name: material
   language: en
+  # Inter, plus the app's mono (--font-mono in app/src/index.css). Both are
+  # already in the app's own font list (app/index.html), so the site and the UI
+  # draw from one family set. Material fetches them from Google Fonts, which it
+  # already did for its default Roboto - this changes which fonts are requested,
+  # not whether any are.
+  font:
+    text: Inter
+    code: JetBrains Mono
   # Both are the app's own icon. There is no such file under docs/ - the path is
   # populated at build time by .github/hooks/brand_assets.py, which reads
   # shared/icon_png/vayu_icon_256x256.png (the same source setup_icons in
@@ -34,7 +42,10 @@ theme:
     - navigation.footer
     - navigation.indexes
     - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.path
     - navigation.sections
+    - navigation.tabs
     - navigation.top
     - navigation.tracking
     - search.highlight
@@ -62,9 +73,9 @@ theme:
 
 nav:
   - Home: index.md
-  - Architecture: architecture.md
-  - Building from Source: building.md
-  - Design System: design-system.md
+  - Get Started:
+      - System Architecture: architecture.md
+      - Building from Source: building.md
   - Engine:
       - Architecture: engine/architecture.md
       - HTTP API Reference: engine/api-reference.md
@@ -77,6 +88,7 @@ nav:
   - App:
       - Architecture: app/architecture.md
       - Components: app/COMPONENTS.md
+      - Design System: design-system.md
       - State Management: app/state-management.md
       - API Integration: app/api-integration.md
       - Variable Resolution: app/variable-resolution.md

--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -1,7 +1,9 @@
-site_name: Vayu Docs
+site_name: Vayu
+# Kept under 160 characters: search results truncate past roughly that, and this
+# string is both the fallback <meta name="description"> for every page and the
+# product description in the home page's structured data.
 site_description: >-
-  Documentation for Vayu - an open source desktop app for REST and GraphQL API
-  testing and native load testing, built on a C++20 engine and an Electron UI.
+  Free, open source desktop API client for REST and GraphQL with a native load tester built in. Import Postman collections. Runs offline, no account.
 site_url: https://athrvk.github.io/vayu/
 site_author: athrvk
 
@@ -17,6 +19,9 @@ copyright: Engine AGPL-3.0 &middot; App Apache-2.0
 theme:
   name: material
   language: en
+  # Adds Open Graph / Twitter card tags and the product's structured data, which
+  # Material does not emit by itself. Path is relative to this config file.
+  custom_dir: overrides
   # Inter, plus the app's mono (--font-mono in app/src/index.css). Both are
   # already in the app's own font list (app/index.html), so the site and the UI
   # draw from one family set. Material fetches them from Google Fonts, which it
@@ -72,39 +77,44 @@ theme:
         name: Switch to system preference
 
 nav:
+  # "Get Started" used to hold the architecture doc and the C++ build guide -
+  # a visitor clicking it expecting "how do I install this" got a CMake page.
+  # Installing now lives on Home, and the build guides are grouped as what they
+  # are. "App" became "Desktop App" because the site talks about the engine and
+  # the app in the same breath and only one of them is a thing you download.
   - Home: index.md
-  - Get Started:
-      - System Architecture: architecture.md
-      - Building from Source: building.md
+  - How It Works: architecture.md
   - Engine:
-      - Architecture: engine/architecture.md
-      - HTTP API Reference: engine/api-reference.md
-      - Scripting Runtime: engine/scripting.md
-      - Database Schema: engine/db-schema.md
-      - CLI: engine/cli.md
+      - Overview: engine/architecture.md
+      - HTTP API: engine/api-reference.md
+      - Test Scripting: engine/scripting.md
+      - Local Database: engine/db-schema.md
+      - Command Line: engine/cli.md
       - MCP Server: engine/mcp.md
       - Benchmarks: engine/benchmarks.md
-      - Building the Engine: engine/building.md
-  - App:
-      - Architecture: app/architecture.md
-      - Components: app/COMPONENTS.md
+  - Desktop App:
+      - Overview: app/architecture.md
+      - UI Components: app/COMPONENTS.md
       - Design System: design-system.md
       - State Management: app/state-management.md
-      - API Integration: app/api-integration.md
-      - Variable Resolution: app/variable-resolution.md
-      - Postman API Compatibility: app/pm-api-compatibility.md
-      - File Name Conventions: app/file-name-conventions.md
-      - Building the App: app/building.md
-      - Import Collections:
-          - Pipeline Overview: app/import-collections/README.md
+      - Talking to the Engine: app/api-integration.md
+      - Variables: app/variable-resolution.md
+      - Postman Script Support: app/pm-api-compatibility.md
+      - File Naming: app/file-name-conventions.md
+      - Importing Collections:
+          - How Import Works: app/import-collections/README.md
           - Postman: app/import-collections/postman.md
           - Insomnia v4: app/import-collections/insomnia-v4.md
           - OpenAPI 3.0: app/import-collections/openapi-v3.md
           - Swagger 2.0: app/import-collections/openapi-v2.md
+  - Build from Source:
+      - Overview: building.md
+      - Engine: engine/building.md
+      - Desktop App: app/building.md
   - Design Notes:
       - Request Storage: request-storage-design.md
-      - Lock File Handling: lock-file-handling.md
-      - Pending Backlog: plans/pending-backlog.md
+      - Lock Files: lock-file-handling.md
+      - Deferred Work: plans/pending-backlog.md
 
 markdown_extensions:
   - admonition

--- a/.github/overrides/main.html
+++ b/.github/overrides/main.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+
+{#
+  Social preview tags and structured data.
+
+  Material emits <title>, <meta name="description"> and the canonical link on its
+  own, but no Open Graph or Twitter tags - so a link to this site pasted into
+  Slack, X or LinkedIn rendered as a bare URL. These fill that in for every page,
+  using the page's own title/description and falling back to the site's.
+
+  The alternative was Material's `social` plugin, which renders a per-page OG
+  image at build time. It needs cairo/pango/libffi system packages in CI, which is
+  a real cost for a docs job that currently installs one wheel; the product
+  screenshot works as a static preview image and needs nothing. Revisit if
+  per-page previews become worth the build dependency.
+#}
+{% block extrahead %}
+  {#
+    Mirrors Material's own <title> logic (a front-matter title wins, and the site
+    name is appended to it), so the social card and the tab never disagree. The
+    home page would otherwise share a card titled just "Vayu", which says nothing
+    to someone seeing the link cold.
+  #}
+  {% if page.meta and page.meta.title %}
+    {% set title = page.meta.title ~ " - " ~ config.site_name %}
+  {% elif page.is_homepage %}
+    {% set title = config.site_name %}
+  {% else %}
+    {% set title = page.title ~ " - " ~ config.site_name %}
+  {% endif %}
+  {% set description = page.meta.description if page.meta and page.meta.description else config.site_description %}
+  {% set image = config.site_url ~ "images/vayu-loadtest.png" %}
+
+  <meta property="og:type" content="{{ 'website' if page.is_homepage else 'article' }}">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta property="og:image" content="{{ image }}">
+  <meta property="og:image:alt" content="Vayu's load-test dashboard showing live throughput, latency percentiles and error counters.">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ description }}">
+  <meta name="twitter:image" content="{{ image }}">
+
+  {#
+    SoftwareApplication on the home page only - it describes the product, not each
+    document. Deliberately carries no aggregateRating or review: Vayu has no
+    collected ratings, and inventing them to chase a rich result would be
+    fabricating data. Version is not pinned here either, since it would go stale
+    on every release with nothing to catch it.
+  #}
+  {% if page.is_homepage %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Vayu",
+      "applicationCategory": "DeveloperApplication",
+      "applicationSubCategory": "API client and load testing tool",
+      "operatingSystem": "Windows 10, Windows 11, macOS, Linux",
+      "description": {{ config.site_description | tojson }},
+      "url": {{ config.site_url | tojson }},
+      "downloadUrl": "https://github.com/athrvk/vayu/releases/latest",
+      "installUrl": "https://github.com/athrvk/vayu/releases/latest",
+      "codeRepository": "https://github.com/athrvk/vayu",
+      "license": "https://github.com/athrvk/vayu/blob/master/LICENSE",
+      "isAccessibleForFree": true,
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "screenshot": {{ image | tojson }},
+      "featureList": [
+        "REST and GraphQL request builder",
+        "Native C++ load testing with live metrics over SSE",
+        "Import Postman, Insomnia, OpenAPI 3.0 and Swagger 2.0 collections",
+        "Postman-compatible pm.* test scripts",
+        "OAuth 2.0, Bearer, Basic and API key auth",
+        "Fully offline - no account, no telemetry, no cloud sync"
+      ],
+      "author": {
+        "@type": "Person",
+        "name": "athrvk",
+        "url": "https://github.com/athrvk"
+      }
+    }
+  </script>
+  {% endif %}
+{% endblock %}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,6 +270,11 @@ exits with "Config file 'mkdocs.yml' does not exist." The preview URL is
 `http://127.0.0.1:8000/vayu/` - the `/vayu/` prefix is there because the site is
 a project page served from a subdirectory, and `/` redirects to it.
 
+Site-only styling lives in `docs/stylesheets/extra.css` (accent, header, headings,
+landing page). It styles the documentation site, **not** the product - the token
+rules in [Design System](docs/design-system.md) do not apply to it, and it must
+never be used as a reference for app CSS.
+
 The site's favicon and header logo are **not** files under `docs/`.
 `.github/hooks/brand_assets.py` pulls `shared/icon_png/vayu_icon_256x256.png` into the
 build, so the docs share one icon with the installers and cannot drift from

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 # Vayu Documentation
 
 Vayu is an open source desktop app that merges a REST/GraphQL request builder
@@ -8,6 +14,12 @@ It is built as a **sidecar**: an Electron + React UI (the manager) talks to a
 C++20 daemon (the engine) over HTTP on `127.0.0.1:9876`. The split is what lets
 the UI stay responsive while the engine saturates a target at tens of thousands
 of requests per second.
+
+[Read the architecture](architecture.md){ .md-button .md-button--primary }
+[Engine HTTP API](engine/api-reference.md){ .md-button }
+[Download](https://github.com/athrvk/vayu/releases/latest){ .md-button }
+
+![The load-test dashboard: throughput, latency percentiles and error counters streaming live from the C++ engine.](images/vayu-loadtest.png){ .shot }
 
 <div class="grid cards" markdown>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,93 +1,199 @@
 ---
+title: Free API Client with Native Load Testing
+description: >-
+  Vayu is a free API client for REST and GraphQL with native load testing built in - import Postman collections, keep pm.* scripts, run fully offline.
 hide:
   - navigation
   - toc
 ---
 
-# Vayu Documentation
+# The API client that load tests, too
 
-Vayu is an open source desktop app that merges a REST/GraphQL request builder
-with a native load tester. Everything runs on your machine: no account, no cloud
-sync, no quotas.
+**Vayu** is a free, open source **API client for REST and GraphQL** with a
+**native load tester** built in. Build a request the way you would in Postman,
+then hammer the same endpoint at tens of thousands of requests per second with a
+C++ engine - no second tool, no account, no cloud sync. Your requests and secrets
+never leave the machine.
 
-It is built as a **sidecar**: an Electron + React UI (the manager) talks to a
-C++20 daemon (the engine) over HTTP on `127.0.0.1:9876`. The split is what lets
-the UI stay responsive while the engine saturates a target at tens of thousands
-of requests per second.
-
-[Read the architecture](architecture.md){ .md-button .md-button--primary }
+[Download Vayu](#install){ .md-button .md-button--primary }
+[See what it does](#what-you-can-do){ .md-button }
 [Engine HTTP API](engine/api-reference.md){ .md-button }
-[Download](https://github.com/athrvk/vayu/releases/latest){ .md-button }
 
-![The load-test dashboard: throughput, latency percentiles and error counters streaming live from the C++ engine.](images/vayu-loadtest.png){ .shot }
+![The load-test dashboard: throughput, latency percentiles and error counters streaming live from the C++ engine while the UI stays responsive.](images/vayu-loadtest.png){ .shot }
+
+## Install
+
+Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
+
+<!-- Keep these in step with the Download section of README.md, which is the
+     canonical copy - both point at the same release assets and install.sh. -->
+
+=== "macOS"
+
+    ```sh
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/athrvk/vayu/master/install.sh)"
+    ```
+
+    Installs the latest release to `/Applications`, and asks for your password
+    once. Vayu ships unsigned, so the script ad-hoc signs the app and clears the
+    quarantine flag - without that, macOS reports it as damaged.
+
+    Pin a version with `VAYU_VERSION=0.2.1` in front of the command, or
+    uninstall by re-running it with `-- --uninstall`.
+
+=== "Windows"
+
+    1. Download [**Vayu-x64.exe**](https://github.com/athrvk/vayu/releases/latest/download/Vayu-x64.exe).
+    2. Run the installer and follow the wizard.
+    3. Launch **Vayu** from the Start menu.
+
+=== "Linux"
+
+    ```sh
+    chmod +x Vayu-x86_64.AppImage
+    ./Vayu-x86_64.AppImage
+    ```
+
+    Download [**Vayu-x86_64.AppImage**](https://github.com/athrvk/vayu/releases/latest/download/Vayu-x86_64.AppImage)
+    first. It is self-contained: no wizard, no root.
+
+[All releases](https://github.com/athrvk/vayu/releases){ .md-button }
+[Build from source instead](building.md){ .md-button }
+
+## What you can do
 
 <div class="grid cards" markdown>
 
-- :material-sitemap: **[Architecture](architecture.md)**
+- :material-swap-horizontal: **Send REST and GraphQL requests**
 
-    The sidecar pattern, process model, lifecycle, and IPC. Start here.
+    Every method, and JSON, form-data, URL-encoded, raw, or GraphQL bodies.
+    Collections nest, with their own variables, auth, and scripts.
 
-- :material-hammer-wrench: **[Building from Source](building.md)**
+- :material-speedometer: **Load test without a second tool**
 
-    Prerequisites, `build.py`, CMake presets, and platform quirks.
+    A multi-worker C++ event loop drives the load and streams throughput,
+    latency percentiles, and error counts live. See the
+    [benchmarks](engine/benchmarks.md) against wrk and vegeta.
 
-- :material-api: **[Engine HTTP API](engine/api-reference.md)**
+- :material-import: **Bring what you already have**
 
-    Every endpoint, payload, and status code the engine serves.
+    Import Postman v2.0/v2.1, Insomnia v4, OpenAPI 3.0, and Swagger 2.0 -
+    [what maps to what](app/import-collections/README.md).
 
-- :material-palette: **[Design System](design-system.md)**
+- :material-code-braces: **Keep your Postman tests**
 
-    Tokens, elevation, typography, and the component patterns the UI is built on.
+    A QuickJS runtime implements `pm.test()`, `pm.expect()`,
+    `pm.environment.set()` and `pm.response.*`, so most scripts run unmodified.
+
+- :material-key-variant: **Auth that inherits**
+
+    Bearer, Basic, API key, and OAuth 2.0 (client credentials, password,
+    authorization code + PKCE) - resolved engine-side, inherited down the tree.
+
+- :material-shield-lock-outline: **Private by default**
+
+    100% offline execution. No telemetry, no account, no cloud sync - your
+    requests and secrets never leave the machine.
 
 </div>
 
-## Engine
+## How it fits together
 
-The C++20 daemon: request execution, load generation, persistence, and scripting.
+Vayu is a **sidecar**: the Electron + React UI talks to a C++20 daemon over HTTP
+on `127.0.0.1:9876`. That split is why the interface stays responsive while the
+engine saturates a target - and why the engine can be driven on its own, from the
+[command line](engine/cli.md) or by a coding agent over
+[MCP](engine/mcp.md).
+
+[How it works in full](architecture.md){ .md-button }
+
+## Reference
+
+**Engine** - the C++20 daemon: execution, load generation, persistence, scripting.
 
 | Document | Covers |
 |---|---|
-| [Architecture](engine/architecture.md) | Core structure, thread pool, engine-side auth resolution |
-| [HTTP API Reference](engine/api-reference.md) | All endpoints, payload shapes, status codes, deprecated aliases |
-| [Scripting Runtime](engine/scripting.md) | The QuickJS sandbox, script globals, hooks, limits |
-| [Database Schema](engine/db-schema.md) | SQLite tables and the JSON shapes stored in them |
-| [CLI](engine/cli.md) | Flags and subcommands for running the engine standalone |
-| [MCP Server](engine/mcp.md) | The MCP tool surface exposed to coding agents |
+| [Overview](engine/architecture.md) | Core structure, thread pool, engine-side auth resolution |
+| [HTTP API](engine/api-reference.md) | Every endpoint, payload shape, and status code |
+| [Test Scripting](engine/scripting.md) | The QuickJS sandbox, script globals, hooks, limits |
+| [Local Database](engine/db-schema.md) | SQLite tables and the JSON shapes stored in them |
+| [Command Line](engine/cli.md) | Flags and subcommands for running the engine standalone |
+| [MCP Server](engine/mcp.md) | The tool surface exposed to coding agents |
 | [Benchmarks](engine/benchmarks.md) | RPS head-to-head against wrk and vegeta, with methodology |
-| [Building the Engine](engine/building.md) | CMake presets and vcpkg dependencies |
 
-## App
-
-The Electron + React renderer: request builder, collections, dashboard, and the
-client half of request composition.
+**Desktop app** - the Electron + React renderer.
 
 | Document | Covers |
 |---|---|
-| [Architecture](app/architecture.md) | Renderer-side structural decisions |
-| [Components](app/COMPONENTS.md) | The `modules/` + `components/` layout |
+| [Overview](app/architecture.md) | Renderer-side structural decisions |
+| [UI Components](app/COMPONENTS.md) | The `modules/` + `components/` layout |
+| [Design System](design-system.md) | Tokens, elevation, typography, component patterns |
 | [State Management](app/state-management.md) | Zustand stores, TanStack Query keys, cache policy |
-| [API Integration](app/api-integration.md) | What the renderer sends the engine, and when |
-| [Variable Resolution](app/variable-resolution.md) | How `{{variables}}` resolve, and scope precedence |
-| [Postman API Compatibility](app/pm-api-compatibility.md) | Which `pm.*` APIs the runtime supports |
-| [File Name Conventions](app/file-name-conventions.md) | Naming rules across the renderer |
-| [Building the App](app/building.md) | App build steps and tooling |
-| [Import Collections](app/import-collections/README.md) | The import pipeline, plus per-format mapping for Postman, Insomnia v4, OpenAPI 3.0, and Swagger 2.0 |
+| [Talking to the Engine](app/api-integration.md) | What the renderer sends the engine, and when |
+| [Variables](app/variable-resolution.md) | How `{{variables}}` resolve, and scope precedence |
+| [Postman Script Support](app/pm-api-compatibility.md) | Which `pm.*` APIs the runtime supports |
+| [File Naming](app/file-name-conventions.md) | Naming rules across the renderer |
+| [Importing Collections](app/import-collections/README.md) | The import pipeline, plus per-format mapping |
 
-## Design notes
+**Design notes** - rationale that is easy to misread from the code alone:
+[Request Storage](request-storage-design.md),
+[Lock Files](lock-file-handling.md),
+[Deferred Work](plans/pending-backlog.md).
 
-Longer-form rationale for decisions that are easy to misread from the code alone.
+## Questions people ask
 
-- [Request Storage](request-storage-design.md) - how requests are persisted.
-- [Lock File Handling](lock-file-handling.md) - lock and concurrency behaviour.
-- [Pending Backlog](plans/pending-backlog.md) - deferred work, and why it is deferred.
+??? question "Is Vayu free?"
 
-## Elsewhere
+    Yes - fully free and open source, with no paid tier, no subscription, and no
+    feature gating. The engine is AGPL-3.0 and the app is Apache-2.0.
 
-- [Contributing Guide](https://github.com/athrvk/vayu/blob/master/CONTRIBUTING.md) - dev setup, code style, PR process, releases.
-- [Security Policy](https://github.com/athrvk/vayu/blob/master/SECURITY.md) - threat model and reporting.
-- [Releases](https://github.com/athrvk/vayu/releases/latest) - installers for Windows, macOS, and Linux.
+??? question "How is it different from Postman, Bruno, or Insomnia?"
+
+    Those are good API clients, but none of them load test - for that you reach
+    for k6 or JMeter as a second tool. Vayu does both in one app: build the
+    request, then load test that same endpoint with a native C++ engine.
+
+??? question "Can I import my Postman collections?"
+
+    Yes. Postman Collection v2.0 and v2.1 exports, including folders,
+    environments, variables, auth settings, and pre/post-request scripts. Also
+    Insomnia v4, OpenAPI 3.0, and Swagger 2.0 - see
+    [how import works](app/import-collections/README.md).
+
+??? question "Will my Postman test scripts still run?"
+
+    Most run unmodified. A QuickJS runtime implements the `pm.*` API -
+    `pm.test()`, `pm.expect()`, `pm.environment.get/set()`, `pm.response.*` -
+    and [Postman Script Support](app/pm-api-compatibility.md) lists exactly
+    what is covered.
+
+??? question "Does it work offline, and does it need an account?"
+
+    Offline, and no account. All execution is local; Vayu contacts no external
+    server during normal use - no telemetry, no license check, no cloud sync.
+
+??? question "How fast is the load testing, really?"
+
+    The engine reaches roughly 93% of [wrk](https://github.com/wg/wrk) and holds
+    par with [vegeta](https://github.com/tsenart/vegeta), converging on the same
+    system throughput ceiling. Full method, concurrency sweep, and a
+    one-command reproduction are in the [benchmarks](engine/benchmarks.md).
+
+??? question "Which platforms are supported?"
+
+    Windows (x64), macOS (Apple Silicon and Intel, universal), and Linux
+    (x86_64 AppImage).
+
+## Contribute
+
+Bug reports, feature ideas, docs, and code are all welcome. The
+[Contributing Guide](https://github.com/athrvk/vayu/blob/master/CONTRIBUTING.md)
+covers dev setup, code style, testing, and the release process;
+[Build from Source](building.md) gets the engine and app compiling locally.
 
 !!! note "Licensing"
 
     The engine is AGPL-3.0 and the app is Apache-2.0. See
-    [LICENSE](https://github.com/athrvk/vayu/blob/master/LICENSE) for both texts.
+    [LICENSE](https://github.com/athrvk/vayu/blob/master/LICENSE) for both texts,
+    and the [Security Policy](https://github.com/athrvk/vayu/blob/master/SECURITY.md)
+    for the threat model and how to report an issue.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,6 @@
+# Vayu documentation and product site - https://athrvk.github.io/vayu/
+# Everything here is public and meant to be indexed.
+User-agent: *
+Allow: /
+
+Sitemap: https://athrvk.github.io/vayu/sitemap.xml

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -141,3 +141,31 @@
 	border-color: hsl(217 90% 66%);
 	color: hsl(225 14% 12%);
 }
+
+/* FAQ accordions. Material's `question` admonition is teal-green, which put seven
+ * bright green bars down a product page that is otherwise blue and neutral. Only
+ * the colour is changed: the chevron, the collapse behaviour and the icon are
+ * Material's. The icon keeps the accent so the rows still read as interactive
+ * rather than as inert boxes. */
+.md-typeset details.question {
+	border-color: var(--md-default-fg-color--lighter);
+}
+
+.md-typeset details.question > summary {
+	background-color: var(--md-default-fg-color--lightest);
+}
+
+.md-typeset details.question > summary::before {
+	background-color: var(--md-primary-fg-color);
+}
+
+/* The chevron is tinted from the same admonition colour as the icon, so it stayed
+ * green after the row went neutral. Muted foreground: it is an affordance, not a
+ * second accent competing with the icon. */
+.md-typeset details.question > summary::after {
+	background-color: var(--md-default-fg-color--light);
+}
+
+[data-md-color-scheme="slate"] .md-typeset details.question > summary::before {
+	background-color: hsl(217 90% 66%);
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -46,3 +46,98 @@
 	height: 1.4rem;
 	width: 1.4rem;
 }
+
+/* ---------------------------------------------------------------------------
+ * Dark mode: a calm header.
+ *
+ * Material paints the header and the tab bar with --md-primary-fg-color, so the
+ * brand blue that reads well on a white canvas became a heavy saturated slab
+ * against near-black. The chrome goes quiet; the accent stays on links, active
+ * nav items and buttons.
+ *
+ * The background is set on the elements, NOT by redefining
+ * --md-primary-fg-color, because that variable does double duty: `.md-button`
+ * takes both its border and its text colour from it, and `--md-button--primary`
+ * its fill. Darkening the token drained every button on the page to dark-on-dark
+ * - the landing page's two outline buttons were effectively invisible. Two
+ * consumers, one token: style the surface, not the token.
+ *
+ * The hairline is needed once the header is no longer a colour break from the
+ * canvas: without it the bar and the page merge into one dark field.
+ * ------------------------------------------------------------------------- */
+[data-md-color-scheme="slate"] .md-header,
+[data-md-color-scheme="slate"] .md-tabs {
+	background-color: hsl(225 14% 15%);
+}
+
+[data-md-color-scheme="slate"] .md-header {
+	border-bottom: 1px solid hsl(225 10% 24%);
+}
+
+/* The tab bar sits directly under the header, so it needs the divider only when
+ * the header's own border is hidden behind it (Material hides .md-tabs on scroll
+ * for a page with no tabs). Keeping both edges quiet avoids a double rule. */
+[data-md-color-scheme="slate"] .md-tabs {
+	border-bottom: 1px solid hsl(225 10% 24%);
+}
+
+/* Material sets h1/h2 in --md-default-fg-color--light at weight 300. Inter at 300
+ * reads as disabled text rather than a heading, and it was the weakest part of
+ * the page in dark mode. Full-strength foreground, and enough weight to hold the
+ * hierarchy against body copy. The negative tracking is Inter-specific: it is
+ * drawn a little wide for display sizes. */
+.md-typeset h1 {
+	color: var(--md-default-fg-color);
+	font-weight: 600;
+	letter-spacing: -0.02em;
+}
+
+.md-typeset h2 {
+	color: var(--md-default-fg-color);
+	font-weight: 600;
+	letter-spacing: -0.01em;
+}
+
+.md-typeset h3,
+.md-typeset h4 {
+	color: var(--md-default-fg-color);
+	font-weight: 500;
+}
+
+/* Landing page: the button row needs its own rhythm, since consecutive
+ * .md-button elements are inline and would otherwise sit flush. */
+.md-typeset .md-button {
+	margin: 0 0.4rem 0.6rem 0;
+}
+
+/* Product screenshots. Not decoration: the border keeps a light-UI screenshot
+ * from bleeding into the page background in light mode, where both are near
+ * white and the frame edge would otherwise disappear. */
+.md-typeset img.shot {
+	border: 1px solid var(--md-default-fg-color--lightest);
+	border-radius: 0.3rem;
+	display: block;
+	width: 100%;
+}
+
+/* Buttons in dark mode take the brightened accent, for the same reason links do:
+ * the light-mode blue (hsl(217 80% 48%)) sits at ~2:1 against the slate canvas,
+ * which is unreadable. Measured, not guessed - see the contrast check in the
+ * commit message. The primary button keeps the deeper fill, since its label is
+ * white and it needs the weight. */
+[data-md-color-scheme="slate"] .md-typeset .md-button {
+	color: hsl(217 90% 66%);
+	border-color: hsl(217 90% 66%);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--primary {
+	background-color: hsl(217 80% 48%);
+	border-color: hsl(217 80% 48%);
+	color: hsl(0 0% 100%);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button:is(:hover, :focus) {
+	background-color: hsl(217 90% 66%);
+	border-color: hsl(217 90% 66%);
+	color: hsl(225 14% 12%);
+}


### PR DESCRIPTION
## Description

Two commits. The first is a design pass on the published site; the second turns Home into a product page and adds the SEO layer that was missing entirely.

### 1. Design pass (`b035352`)

Reviewed the built site at 390 / 900 / 1440 px in both themes.

- **Navigation** - all 26 pages were listed in the sidebar at once, on every page. `navigation.tabs` puts the groups in a top bar so the sidebar shows only the current section; `navigation.path` adds breadcrumbs.
- **Typography** - Inter + JetBrains Mono, both already in the app's own font list, replacing Material's Roboto. Material also sets `h1`/`h2` at weight 300 in muted grey, which reads as *disabled* text; headings now take full-strength foreground.
- **Dark mode** - the brand-blue header is right on white and a heavy saturated slab against near-black, so the chrome goes quiet and the accent stays on links, nav and buttons.

**Bug found mid-pass:** darkening the header via `--md-primary-fg-color` drained every button on the page - `.md-button` takes its text and border from the same token, so both outline buttons went dark-on-dark at ~2:1. Two consumers, one token; the fix styles the header surface instead. Same shape as the `--primary` vs `--primary-fill` rule in `CLAUDE.md`.

### 2. Product-page Home + SEO (`fd2183f`)

**Header reads "Vayu"**, not "Vayu Docs" - the site fronts the product, and the docs are part of it rather than the whole of it.

**Terminology.** "Get Started" held the architecture doc and the C++ build guide, so a visitor clicking it for install instructions got CMake presets. Installing now lives on Home, and the three build guides group as **Build from Source**. "App" became **Desktop App** (the site discusses the engine and the app together, and only one is a thing you download). Internal labels that assumed context are now plain: HTTP API, Test Scripting, Local Database, Command Line, Talking to the Engine, Variables, Postman Script Support, Importing Collections, Deferred Work. **Labels only - every path, URL and anchor is unchanged.**

**Home drives use.** Hero states what it is, Download is the primary action, and per-platform install instructions sit on the page in tabs (macOS one-liner, Windows installer, Linux AppImage) rather than only linking out. Then what you can do, how it fits together, the reference tables, and an FAQ built from README's so the two cannot disagree.

**SEO.** No marketing/SEO skill exists in this environment, so this is hand-rolled:

| Added | Why |
|---|---|
| Title + description written for the SERP, both under 160 chars | They were ~265, which truncates |
| Open Graph + Twitter card tags (theme override) | Material emits none - a link pasted into Slack or X rendered as a bare URL |
| `SoftwareApplication` structured data, Home only | Product-level markup; describes the app, not each doc |
| `robots.txt` referencing the sitemap | MkDocs already generates `sitemap.xml` (28 URLs); nothing pointed at it |

Three deliberate omissions, each recorded in a comment next to the code:

- **No `aggregateRating` or `review`** - there are no collected ratings, and inventing them to chase a rich result would be fabricating data.
- **No `softwareVersion`** - it would go stale on every release with nothing to catch it.
- **No `FAQPage` markup** - Google restricted those rich results to authoritative health/government sites, so it would be cargo cult.
- **Static OG image over Material's `social` plugin** - that plugin renders per-page cards but needs cairo/pango/libffi in CI, a real cost for a job that currently installs one wheel.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- **`mkdocs build --strict`** clean on every iteration.
- **Link crawl: 5,063 internal links, 0 broken** - run specifically after the nav regrouping and relabelling to prove no path or anchor moved.
- **Contrast measured, not eyeballed.** Body, `h1`, `h2`, links, both button variants, header title, tabs and inline code, in both themes, each against its WCAG threshold. All pass, worst case **5.39:1**. Dark-mode buttons needed the brightened accent to clear it.
- **SEO output verified in the built HTML**, not assumed: JSON-LD parses and carries no fabricated fields, `<title>` / description / canonical / OG / Twitter present on Home and inherited correctly on inner pages, JSON-LD absent from inner pages, meta descriptions measured at 147-148 chars, `og:image` confirmed 1600x1000 (clears the 1200x628 large-card floor), `sitemap.xml` and `robots.txt` served.
- **Rendered in Chromium at 2x** across 390 / 900 / 1440 in both schemes at each step.

Two defects in my own work were caught this way and fixed: the front-matter title double-stamped the brand (`Vayu - ... - Vayu`, because Material already appends `site_name`), and Material's `question` admonition painted seven bright green bars down the page (restyled neutral, accent kept on the icon only).

One apparent defect was investigated and **dismissed**: a large gap under the mobile `h1` measured as Material's standard 40px heading margin, identical at 390 and 1440, with no element between - the apparent size was the 2x capture scale.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - none; site chrome, guarded by the existing strict build
- [x] I have updated documentation - `CONTRIBUTING.md` notes that `docs/stylesheets/extra.css` styles the site and is not a reference for app CSS

## Related Issues

Follow-up to #141 and #143.