### PR TITLE
fix(engine): reject wrong-shape object fields on resource writes

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -99,6 +99,26 @@ verb rather than a silently discarded write. Those fields are a collection's
 `name`, an environment's `name`, and a request's `collectionId`, `name`,
 `method` and `url`. Each is also required on create.
 
+### Accepted field shapes
+
+A field that is present and not `null` must have the shape below, on both verbs.
+Anything else is a `400` naming the field, e.g.
+`{"error": "Invalid 'auth': must be a JSON object"}`.
+
+| Field | Shape |
+|---|---|
+| `variables` (collection / environment / globals) | object |
+| `auth` (collection / request) | object |
+| `body` (request) | object |
+| `params` / `headers` (request) | array of `{key: string, value: string, enabled: bool}` |
+
+Object-shaped fields are stored as JSON blobs, and every reader of one degrades
+quietly when it is not an object - `variables` reads back empty, a request `body`
+is dropped, and `auth` resolves to none, so a request the caller believes carries
+credentials goes out bare. The write is therefore rejected rather than stored:
+`{"variables": 42}` and `{"auth": "bearer"}` are `400`s, and the previously
+stored value is left untouched.
+
 ### Behavior change (pre-1.0)
 
 `POST /<resource>` used to be a silent upsert on all three resources, so a
@@ -624,7 +644,9 @@ absent and `variables: null` both mean the default, `{}`.
 `variables: null` used to store the literal four-character text `null`, which
 parses as JSON but is not an object. `GET /globals` returns `{}` for anything it
 cannot read as an object, so the failure showed up as globals silently
-disappearing rather than as an error.
+disappearing rather than as an error. A non-object `variables` (`42`, a string,
+an array) had the same effect and is now a `400` - see
+[Accepted field shapes](#accepted-field-shapes).
 
 ## Authentication
 

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -110,17 +110,45 @@ bool is_create) {
  * Same rule for a field stored as a dumped JSON blob (variables, auth, body).
  * `null` resets to `default_value`, which is the blob's canonical default text
  * (e.g. `{}` for variables, `{"mode":"none"}` for a collection's auth).
+ *
+ * Every field routed through here is **object-shaped**, and the helper rejects
+ * anything else with a 400 naming the field. It used to dump whatever it was
+ * handed, so `{"variables": 42}` stored `42` and `{"auth": "bearer"}` stored
+ * `"bearer"` - blobs that parse as JSON but are not the object each reader
+ * expects, and every reader degrades quietly (`parse_variables_json` yields no
+ * variables, `parse_auth` yields no auth, so the request goes out bare). The
+ * write returned 200 and the user found out from the wire. That is the same
+ * defect the `"null"`-string fix closed, one level up: it removed a bad
+ * *value*, this removes a bad *shape*. Array-shaped fields have their own
+ * validating helper (`apply_key_value_field` for `params` / `headers`).
+ *
+ * `[[nodiscard]]` because dropping the returned error is exactly the silent
+ * acceptance this helper exists to prevent.
  */
-inline void apply_json_field (const nlohmann::json& json,
+[[nodiscard]] inline std::optional<std::pair<int, nlohmann::json>>
+apply_json_field (const nlohmann::json& json,
 const char* key,
 std::string& out,
 const char* default_value,
 bool is_create) {
-    if (json.contains (key)) {
-        out = json[key].is_null () ? default_value : json[key].dump ();
-    } else if (is_create) {
-        out = default_value;
+    if (!json.contains (key)) {
+        if (is_create) {
+            out = default_value;
+        }
+        return std::nullopt;
     }
+    const auto& value = json[key];
+    if (value.is_null ()) {
+        out = default_value;
+        return std::nullopt;
+    }
+    if (!value.is_object ()) {
+        return std::make_pair (400,
+        nlohmann::json{
+        { "error", std::string ("Invalid '") + key + "': must be a JSON object" } });
+    }
+    out = value.dump ();
+    return std::nullopt;
 }
 
 /** Same rule for a boolean field. A non-boolean, non-null value is ignored. */

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -121,9 +121,13 @@ bool is_create) {
         c.order = 0; // Explicit null on update -> reset to the column default.
     }
 
-    apply_json_field (json, "variables", c.variables, "{}", is_create);
+    if (auto err = apply_json_field (json, "variables", c.variables, "{}", is_create)) {
+        return err;
+    }
     // Collection auth is never 'inherit' - a collection is the root of a chain.
-    apply_json_field (json, "auth", c.auth, R"({"mode":"none"})", is_create);
+    if (auto err = apply_json_field (json, "auth", c.auth, R"({"mode":"none"})", is_create)) {
+        return err;
+    }
     apply_string_field (json, "preRequestScript", c.pre_request_script, "", is_create);
     apply_string_field (json, "postRequestScript", c.post_request_script, "", is_create);
 

--- a/engine/src/http/routes/environments.cpp
+++ b/engine/src/http/routes/environments.cpp
@@ -40,7 +40,9 @@ apply_environment_fields (vayu::db::Environment& e, const nlohmann::json& json, 
         return err;
     }
     apply_string_field (json, "description", e.description, "", is_create);
-    apply_json_field (json, "variables", e.variables, "{}", is_create);
+    if (auto err = apply_json_field (json, "variables", e.variables, "{}", is_create)) {
+        return err;
+    }
     apply_bool_field (json, "isActive", e.is_active, false, is_create);
     return std::nullopt;
 }

--- a/engine/src/http/routes/globals.cpp
+++ b/engine/src/http/routes/globals.cpp
@@ -41,7 +41,9 @@ save_globals_response (vayu::db::Database& db, const nlohmann::json& json) {
     vayu::db::Globals g;
     g.id = "globals"; // Singleton ID
 
-    apply_json_field (json, "variables", g.variables, "{}", /*is_create=*/true);
+    if (auto err = apply_json_field (json, "variables", g.variables, "{}", /*is_create=*/true)) {
+        return *err;
+    }
 
     g.updated_at = now_ms ();
 

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -164,11 +164,15 @@ apply_request_fields (vayu::db::Request& r, const nlohmann::json& json, bool is_
         return err;
     }
 
-    apply_json_field (json, "body", r.body, R"({"mode":"none"})", is_create);
+    if (auto err = apply_json_field (json, "body", r.body, R"({"mode":"none"})", is_create)) {
+        return err;
+    }
     apply_string_field (json, "bodyType", r.body_type, "none", is_create);
     // A request's auth may be 'inherit' - that is its default, and the app
     // resolves the collection chain before the request is executed.
-    apply_json_field (json, "auth", r.auth, R"({"mode":"inherit"})", is_create);
+    if (auto err = apply_json_field (json, "auth", r.auth, R"({"mode":"inherit"})", is_create)) {
+        return err;
+    }
     apply_string_field (json, "preRequestScript", r.pre_request_script, "", is_create);
     apply_string_field (json, "postRequestScript", r.post_request_script, "", is_create);
     apply_int_field (json, "order", r.order, 0, is_create);

--- a/engine/tests/globals_route_test.cpp
+++ b/engine/tests/globals_route_test.cpp
@@ -118,4 +118,23 @@ TEST_F (GlobalsRouteTest, SaveReplacesTheWholeSet) {
     EXPECT_EQ (stored["b"], "2");
 }
 
+// Issue #133: the null guard removed one bad *value*; this removes the bad
+// *shape*. `{"variables": 42}` used to store `42` - JSON that parses but is not
+// an object, so `GET /globals` fell back to `{}` and the globals vanished
+// exactly as they did for the `null` case.
+TEST_F (GlobalsRouteTest, WrongShapeVariablesIsRejected) {
+    save_globals_response (*db_, json{ { "variables", { { "token", "abc" } } } });
+    const std::string before = stored_variables ();
+
+    for (const json& bad :
+    { json (42), json ("token"), json::array ({ 1, 2 }), json (true) }) {
+        auto [status, body] = save_globals_response (*db_, json{ { "variables", bad } });
+        EXPECT_EQ (status, 400) << "variables = " << bad.dump ();
+        EXPECT_NE (body["error"].get<std::string> ().find ("variables"), std::string::npos);
+    }
+
+    EXPECT_EQ (stored_variables (), before)
+    << "a rejected write must not reach the column";
+}
+
 } // namespace

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -20,6 +20,14 @@
  *    ignoring the write. The environments `variables: null` case is a
  *    regression test: it used to store the literal text `null`.
  *
+ *  - **Object-shaped fields reject a wrong shape** (issue #133).
+ *    `variables`, `auth` and a request's `body` are dumped JSON blobs.
+ *    A non-object used to be dumped verbatim, stored, and then
+ *    silently discarded by every reader - `auth` most severely, since
+ *    a request the user believed carried credentials went out bare.
+ *    Those tests assert the **stored blob**, because a response-only
+ *    assertion passes against the old code too.
+ *
  * Follows the suite's route-test convention (requests_route_test.cpp): the
  * routes' extracted cores are exercised directly, no in-process HTTP server.
  */
@@ -30,6 +38,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -100,6 +109,17 @@ class ResourceWriteRouteTest : public ::testing::Test {
         { "method", "GET" }, { "url", "https://example.com" } });
         EXPECT_EQ (status, 200);
         return body["id"].get<std::string> ();
+    }
+
+    /**
+     * Values that are valid JSON but not an object - each one used to be dumped
+     * into the blob column verbatim. `"bearer"` is the realistic one: an `auth`
+     * written as a bare mode string rather than `{"mode":"bearer",...}`.
+     */
+    static const std::vector<json>& wrong_shapes () {
+        static const std::vector<json> values{ json (42), json ("bearer"),
+            json::array ({ 1, 2 }), json (true) };
+        return values;
     }
 
     std::unique_ptr<vayu::db::Database> db_;
@@ -210,6 +230,46 @@ TEST_F (ResourceWriteRouteTest, CollectionCreateNullMeansDefault) {
     EXPECT_TRUE (body["variables"].empty ());
     EXPECT_EQ (body["auth"]["mode"], "none");
     EXPECT_EQ (body["description"], "");
+}
+
+TEST_F (ResourceWriteRouteTest, CollectionWrongShapeObjectFieldIsRejected) {
+    const std::string id = make_collection ();
+    ASSERT_EQ (
+    update_collection_response (*db_, id,
+    json{ { "variables", { { "token", { { "value", "abc" }, { "enabled", true } } } } },
+    { "auth", { { "mode", "bearer" }, { "token", "t" } } } })
+    .first,
+    200);
+    const auto before = *db_->get_collection (id);
+
+    for (const char* field : { "variables", "auth" }) {
+        for (const json& bad : wrong_shapes ()) {
+            auto [status, body] =
+            update_collection_response (*db_, id, json{ { field, bad } });
+            EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
+            EXPECT_NE (body["error"].get<std::string> ().find (field), std::string::npos)
+            << "the 400 must name the field";
+        }
+    }
+
+    // The stored blobs are what matters: the old helper returned 200 and wrote
+    // the junk, so asserting only the response would pass either way.
+    const auto after = *db_->get_collection (id);
+    EXPECT_EQ (after.variables, before.variables);
+    EXPECT_EQ (after.auth, before.auth);
+}
+
+TEST_F (ResourceWriteRouteTest, CollectionCreateWrongShapeObjectFieldIsRejected) {
+    for (const char* field : { "variables", "auth" }) {
+        for (const json& bad : wrong_shapes ()) {
+            auto [status, body] = create_collection_response (
+            *db_, json{ { "name", "N" }, { field, bad } });
+            EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
+            EXPECT_NE (body["error"].get<std::string> ().find (field), std::string::npos);
+        }
+    }
+    EXPECT_TRUE (db_->get_collections ().empty ())
+    << "a rejected create must not leave a record behind";
 }
 
 TEST_F (ResourceWriteRouteTest, CollectionUpdateKeepsCycleGuard) {
@@ -330,6 +390,48 @@ TEST_F (ResourceWriteRouteTest, RequestMalformedKeyValueEntryIsRejected) {
     EXPECT_NE (body["error"].get<std::string> ().find ("index 0"), std::string::npos);
 }
 
+TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
+    const std::string collection = make_collection ();
+    const std::string id         = make_request (collection);
+    ASSERT_EQ (update_request_response (*db_, id,
+               json{ { "body", { { "mode", "raw" }, { "raw", "{}" } } },
+               { "auth", { { "mode", "bearer" }, { "token", "t" } } } })
+               .first,
+    200);
+    const auto before = *db_->get_request (id);
+
+    for (const char* field : { "body", "auth" }) {
+        for (const json& bad : wrong_shapes ()) {
+            auto [status, error] =
+            update_request_response (*db_, id, json{ { field, bad } });
+            EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
+            EXPECT_NE (error["error"].get<std::string> ().find (field), std::string::npos);
+        }
+    }
+
+    const auto after = *db_->get_request (id);
+    EXPECT_EQ (after.body, before.body);
+    EXPECT_EQ (after.auth, before.auth)
+    << "a stored non-object auth reads back as no auth, and the request goes "
+       "out bare";
+}
+
+TEST_F (ResourceWriteRouteTest, RequestCreateWrongShapeObjectFieldIsRejected) {
+    const std::string collection = make_collection ();
+    for (const char* field : { "body", "auth" }) {
+        for (const json& bad : wrong_shapes ()) {
+            json payload{ { "collectionId", collection }, { "name", "R" },
+                { "method", "GET" }, { "url", "https://example.com" } };
+            payload[field]       = bad;
+            auto [status, error] = create_request_response (*db_, payload);
+            EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
+            EXPECT_NE (error["error"].get<std::string> ().find (field), std::string::npos);
+        }
+    }
+    EXPECT_TRUE (db_->get_requests_in_collection (collection).empty ())
+    << "a rejected create must not leave a record behind";
+}
+
 TEST_F (ResourceWriteRouteTest, RequestMaxRedirectsIsClamped) {
     const std::string collection = make_collection ();
     const std::string id         = make_request (collection);
@@ -419,6 +521,34 @@ TEST_F (ResourceWriteRouteTest, EnvironmentUpdateAbsentKeepsVariables) {
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["name"], "Renamed");
     EXPECT_TRUE (body["variables"].contains ("token")) << "absent means keep";
+}
+
+TEST_F (ResourceWriteRouteTest, EnvironmentWrongShapeVariablesIsRejected) {
+    auto [created_status, created] = create_environment_response (*db_,
+    json{ { "name", "Env" },
+    { "variables", { { "token", { { "value", "abc" }, { "enabled", true } } } } } });
+    ASSERT_EQ (created_status, 200);
+    const std::string id     = created["id"].get<std::string> ();
+    const std::string before = db_->get_environment (id)->variables;
+
+    for (const json& bad : wrong_shapes ()) {
+        auto [status, body] =
+        update_environment_response (*db_, id, json{ { "variables", bad } });
+        EXPECT_EQ (status, 400) << "variables = " << bad.dump ();
+        EXPECT_NE (body["error"].get<std::string> ().find ("variables"), std::string::npos);
+    }
+    EXPECT_EQ (db_->get_environment (id)->variables, before)
+    << "a rejected write must not reach the column";
+}
+
+TEST_F (ResourceWriteRouteTest, EnvironmentCreateWrongShapeVariablesIsRejected) {
+    for (const json& bad : wrong_shapes ()) {
+        auto [status, body] = create_environment_response (
+        *db_, json{ { "name", "Env" }, { "variables", bad } });
+        EXPECT_EQ (status, 400) << "variables = " << bad.dump ();
+    }
+    EXPECT_TRUE (db_->get_environments ().empty ())
+    << "a rejected create must not leave a record behind";
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentNullNameIsRejected) {


### PR DESCRIPTION
## Description

`apply_json_field` (`engine/include/vayu/http/routes.hpp`) stored whatever it was handed, so `{"variables": 42}` stored `42`, `{"auth": "bearer"}` stored `"bearer"`, and `{"body": [1,2]}` stored `[1,2]`. I verified the problem still exists exactly as the issue describes: the helper was still `out = json[key].is_null() ? default_value : json[key].dump()` and all six call sites were unguarded.

**Plan.** Root cause: the `null` guard added by #95 removed one bad *value* but never constrained the *shape*, and every reader of those blobs degrades quietly (`parse_variables_json` and `execution.cpp:96` gate on `is_object()`, `json.cpp:354` drops a non-object body, `auth_resolver.cpp:116` resolves a non-object `auth` to none) - so the write returned `200` and the corruption only surfaced on the wire, `auth` most severely, with a request the user believed carried credentials going out bare. Approach: give `apply_json_field` the shape it expects and return a `400` naming the field, mirroring its sibling `apply_key_value_field`, so one helper change covers all six sites and the rule stays in the single place #95 established. The alternative I rejected is full per-blob schema validation (auth `mode` against the known modes, each variable entry's `value`/`enabled`/`secret`): it catches structurally valid nonsense too, but it is a much larger change, duplicates knowledge the app already encodes, and belongs in its own issue - this PR is about shape, not semantics.

Two details worth review:

- The helper is `[[nodiscard]]`. It is the only helper in the header that carries the attribute, deliberately: dropping the returned error at a call site silently restores the exact bug being fixed. `apply_key_value_field` was left as-is rather than widened in the same diff.
- **Blast radius traced.** All six sites go through the extracted `apply_*_fields` cores, which already thread an error back (`return err`); `save_globals_response` has no such wrapper so it returns `*err` directly. The only writers of these blob columns are those cores - `import.cpp` fetches a URL and does not touch them - and the callers are the two engine clients: the renderer is typed, and MCP is the one that generates LLM-authored payloads.
- **On the follow-up check in the issue** ("should the client-side guard in `app/electron/mcp/tools.ts` stay?"): kept. Its `typeof vars !== "object"` check guards the local `Object.entries(vars)` merge that runs *before* the engine is called, not just the engine write, so removing it would turn a clear message into a `TypeError` on a path the engine never sees. No app change was required for this issue and none is included.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

A write that used to return `200` now returns `400`, which is a wire-visible change - but the only writes affected are ones whose stored value was discarded by every reader, so no working client behavior changes.

## Testing

`python build.py -t` then `ctest --preset linux-dev`: **394/394 passed** (387 before; 7 new). `cd app && pnpm test`: **1215 passed across 168 files**, and `pnpm type-check` clean - both unchanged, since no app code was touched.

New tests (all assert the **stored blob**, because a response-only assertion passes against the old code):

| Test | Covers |
|---|---|
| `CollectionWrongShapeObjectFieldIsRejected` | PUT `variables` / `auth`, stored blobs untouched |
| `CollectionCreateWrongShapeObjectFieldIsRejected` | POST, no record left behind |
| `RequestWrongShapeObjectFieldIsRejected` | PUT `body` / `auth`, stored blobs untouched |
| `RequestCreateWrongShapeObjectFieldIsRejected` | POST, no record left behind |
| `EnvironmentWrongShapeVariablesIsRejected` | PUT `variables` |
| `EnvironmentCreateWrongShapeVariablesIsRejected` | POST |
| `GlobalsRouteTest.WrongShapeVariablesIsRejected` | the singleton POST path |

Each iterates four wrong shapes (`42`, `"bearer"`, `[1,2]`, `true`). **Mutation-checked**: with the `!value.is_object()` branch disabled, all 7 fail; restored, all 7 pass.

No pre-existing failures were observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`clang-format` was applied only to the two test files, which were clean before; `routes.hpp`, `collections.cpp` and `requests.cpp` carry pre-existing violations and were formatted over the new lines only, leaving their counts unchanged (14 / 2 / 2). `scripts/pre-commit` (clang-tidy) passes on all seven changed C++ files.

`docs/engine/api-reference.md` gains an **Accepted field shapes** subsection under the null-vs-absent rule, listing the shape per field and the `400` body, plus a pointer from the `POST /globals` section - same commit, per the docs-in-step rule.

## Related Issues
Closes #133

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT5QkvcwUinYhguLbfnaM3)_