### PR TITLE
docs(engine): pm.request is a read-only snapshot, not a mutable request

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -93,6 +93,14 @@ pm.request.headers           // Request headers (object)
 pm.request.body              // Request body (string, if any)
 ```
 
+`pm.request` is a **read-only snapshot** of the request the engine is about to send
+(auth already resolved into headers/URL). It is a plain JavaScript object built for
+the script and never read back afterwards, so assigning to it - `pm.request.url = …`,
+`pm.request.headers['X-Sig'] = …` - changes only that throwaway object and is silently
+discarded. There are no `headers.add/upsert/remove` mutators either. See
+[Request mutation & URL variables](../app/pm-api-compatibility.md#request-mutation--url-variables)
+for the full compatibility notes and what it would take to support this.
+
 ## Environment Variables (`pm.environment`)
 
 Access and modify environment variables:
@@ -165,17 +173,23 @@ pm.environment.set('token', json.token);
 
 ### Pre-request Script
 
-Modify request before sending:
+Inspect the outgoing request and stage variables for later runs:
 
 ```javascript
-// Add timestamp header
-pm.request.headers['X-Timestamp'] = Date.now().toString();
+// Inspect what is about to be sent (read-only)
+console.log(pm.request.method, pm.request.url);
 
-// Add signature header
-const secret = pm.environment.get('secret');
-const data = pm.request.body + secret;
-pm.request.headers['X-Signature'] = computeHash(data);
+// Stage a value for subsequent runs - it does NOT affect this request
+pm.environment.set('lastRunAt', Date.now().toString());
 ```
+
+> **Not supported:** a pre-request script cannot change the outgoing request.
+> Writing to `pm.request` (headers, body, URL, method) is discarded, and setting a
+> variable that a `{{placeholder}}` in the URL references does not re-resolve it -
+> placeholders are substituted app-side before the payload reaches the engine, so the
+> new value only applies to later runs. Signing or stamping a request from a script is
+> therefore not possible today; see
+> [Request mutation & URL variables](../app/pm-api-compatibility.md#request-mutation--url-variables).
 
 ### Response Time Assertion
 
@@ -223,7 +237,8 @@ QuickJS supports ES2020 features with some limitations:
 ### Pre-request Scripts
 
 - Execute before sending the HTTP request
-- Can modify `pm.request` (headers, body)
+- Can **read** `pm.request` (method, url, headers, body) - it is a snapshot; writes to it
+  are discarded and the request is sent unchanged
 - Can access `pm.environment` and `pm.variables`
 - Cannot access `pm.response` (request hasn't been sent yet)
 

--- a/engine/include/vayu/runtime/script_engine.hpp
+++ b/engine/include/vayu/runtime/script_engine.hpp
@@ -93,8 +93,14 @@ class ScriptEngine {
 
     /**
      * @brief Execute a pre-request script
+     *
+     * The request is exposed to the script as `pm.request`, a read-only
+     * snapshot. Nothing is read back out of the JS object, so the script
+     * cannot change what is sent - see docs/engine/scripting.md and
+     * docs/app/pm-api-compatibility.md.
+     *
      * @param script JavaScript code
-     * @param request Request to potentially modify
+     * @param request Read by the script via `pm.request`; never written back
      * @param env Environment variables
      * @return Script result
      */

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -417,8 +417,9 @@ void register_execution_routes (RouteContext& ctx) {
         }
 
         // Take the request built above (auth already resolved into headers/url,
-        // so pm.request reflects the real outgoing set). It may be further
-        // modified by the pre-request script.
+        // so pm.request reflects the real outgoing set). This is what gets
+        // sent: the pre-request script only reads it, and writes to
+        // `pm.request` are discarded (see docs/app/pm-api-compatibility.md).
         auto request = std::move (built.request);
 
         // Auth failure: record a failed result against the run and return the

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -538,6 +538,40 @@ TEST_F (ScriptEngineTest, RequestHeaders) {
     EXPECT_TRUE (result.success);
 }
 
+// `pm.request` is a read-only snapshot: built as a plain JS object for the
+// script and never read back, so a pre-request script cannot change what is
+// sent. Both docs say so (docs/engine/scripting.md,
+// docs/app/pm-api-compatibility.md); this pins the contract so implementing
+// write-back becomes a deliberate change that also updates them.
+TEST_F (ScriptEngineTest, PreRequestWritesToPmRequestAreDiscarded) {
+    Request req;
+    req.method       = HttpMethod::GET;
+    req.url          = "https://api.example.com/users";
+    req.headers      = { { "Content-Type", "application/json" } };
+    req.body.mode    = BodyMode::Text;
+    req.body.content = "original";
+
+    auto result = engine.execute_prerequest (R"(
+        pm.request.url = "https://evil.example.com/";
+        pm.request.method = "DELETE";
+        pm.request.headers["X-Signature"] = "injected";
+        pm.request.headers["Content-Type"] = "text/plain";
+        pm.request.body = "tampered";
+        // The writes land on the JS object - proving the assignments ran and the
+        // assertions below are about the C++ Request, not a script that no-opped.
+        pm.environment.set("jsSideUrl", pm.request.url);
+    )",
+    req, env);
+
+    EXPECT_TRUE (result.success);
+    EXPECT_EQ (env.at ("jsSideUrl").value, "https://evil.example.com/");
+    EXPECT_EQ (req.url, "https://api.example.com/users");
+    EXPECT_EQ (req.method, HttpMethod::GET);
+    EXPECT_EQ (req.headers.count ("X-Signature"), 0U);
+    EXPECT_EQ (req.headers.at ("Content-Type"), "application/json");
+    EXPECT_EQ (req.body.content, "original");
+}
+
 // ============================================================================
 // pm.environment Tests
 // ============================================================================


### PR DESCRIPTION
## Description

`docs/engine/scripting.md` taught pre-request scripts as a way to sign or stamp the outgoing request, but the runtime discards every such write. A user who followed the documented pattern shipped an unsigned request and got no error. `docs/app/pm-api-compatibility.md` already documented the truth, so the two docs contradicted each other and the aspirational one is the one users reach for first.

**Plan (root cause, approach, rejected alternative).** The root cause is that `setup_pm_request` (`script_engine.cpp`) copies `url`/`method`/`headers`/`body` out of the C++ `Request` into a plain JS object and nothing ever reads that object back; `execution.cpp` sends the request built *before* the script ran. This is the codebase's signature "written but never read" pattern at the script boundary. The approach is Option A from the issue - make the docs and the code comments tell the truth, and pin the contract with a test so a future write-back implementation is a deliberate change. The rejected alternative is Option B, implementing request mutation: it needs a non-const request path, read-back plumbing in `execute()`, and a defined precedence rule against engine-applied auth (a script-set `Authorization` would otherwise be clobbered by the engine's own auth resolution). That is a genuine feature, and the owner chose Option A in [a comment on the issue](https://github.com/athrvk/vayu/issues/109#issuecomment-5073671779).

Verified the problem still exists at `6dd7901` exactly as the issue describes: `ScriptContext::request` is still `const Request*`, `setup_pm_request` still has no write-back, `execution.cpp` still sends `request` unchanged after `execute_script(..., "Pre-request")`, and both misleading comments are still present.

Changes:

- **`docs/engine/scripting.md`** - state the read-only-snapshot contract under **Request Object (`pm.request`)**; replace the "Modify request before sending" example (which showed `X-Timestamp` / `X-Signature` header writes) with an honest inspect-and-stage-a-variable example plus a **Not supported** callout; correct the "Can modify `pm.request` (headers, body)" bullet in **Script Execution Context**. Both new mentions link to `pm-api-compatibility.md#request-mutation--url-variables`, so the two docs now agree and point at each other.
- **`engine/include/vayu/runtime/script_engine.hpp`** - `execute_prerequest`'s `@param request Request to potentially modify` corrected; the doc block now says the request is exposed as a read-only snapshot and is never written back.
- **`engine/src/http/routes/execution.cpp`** - "It may be further modified by the pre-request script" corrected to state that this is what gets sent and writes to `pm.request` are discarded.
- **`engine/tests/script_engine_test.cpp`** - new `PreRequestWritesToPmRequestAreDiscarded`.

**Blast radius traced.** `rg "pm\.request"` over `app/src` and `app/electron` is empty - the app never references it (no editor autocomplete entry, no script template), so **App changes: none, verified**. The only other doc mentions (`api-reference.md:732`, `architecture.md:200`) say auth is resolved *before* the script so `pm.request` is accurate - both already correct, left alone. `execute_prerequest` has no production callers (only tests); noted below rather than touched.

**Deliberate scope limits.** `scripting.md` also documents `pm.variables` (unsupported) on an adjacent line and has other drift - that is #112's explicit remit, which is sequenced to land last and sweep the residue, so it is left untouched here to avoid taking its diff. Only the mutation claims this issue names are corrected.

## Type of Change
- [x] Bug fix (a documented behavior that does not exist; no runtime behavior change)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **388/388 passed** (387 before, +1 new).
- `cd app && pnpm test` - **1215 passed across 168 files**; `pnpm type-check` clean. No app files changed; run to confirm nothing regressed.
- `mkdocs build -f .github/mkdocs.yml --strict` - clean, which validates the new relative cross-link and its heading anchor.
- No pre-existing failures observed on the base commit.

The new test is mutation-checked: flipping `EXPECT_EQ(req.url, "https://api.example.com/users")` to the value the script assigns makes it fail, then restoring makes it pass - so the assertions really do read the C++ `Request`. It also asserts the script *did* write successfully on the JS side (`pm.environment.set("jsSideUrl", pm.request.url)` comes back as the assigned URL), so the test cannot pass by the script silently no-opping. Implementing write-back now breaks this test, which is the point: it forces the docs to be updated with it.

## Checklist
- [x] My code follows the style guidelines (no em-dashes; `prettier` deliberately **not** run on `docs/engine/scripting.md`, which was not prettier-clean before this change, per CLAUDE.md)
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (this change *is* the documentation fix; done in the same commit)

## Related Issues
Closes #109

Adjacent, not fixed here (flagging for #112, the dead-code sweep): `ScriptEngine::execute_prerequest` has no callers outside `script_engine.cpp` and the test suite, and its `Request&` (non-const) parameter is itself a leftover claim that pre-request scripts mutate. Its doc comment is corrected here; whether to delete the method or make it `const Request&` belongs in that cleanup, not this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jnm3Bp7TjhJjitSibzeS7n)_