### PR TITLE
docs(site): brand-first title, plus MCP and import showcased

### DIFF
--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Vayu
 # string is both the fallback <meta name="description"> for every page and the
 # product description in the home page's structured data.
 site_description: >-
-  Free, open source desktop API client for REST and GraphQL with a native load tester built in. Import Postman collections. Runs offline, no account.
+  Free, open source desktop API client for REST and GraphQL with a native load tester and a built-in MCP server for coding agents. Offline, no account.
 site_url: https://athrvk.github.io/vayu/
 site_author: athrvk
 

--- a/.github/overrides/main.html
+++ b/.github/overrides/main.html
@@ -14,20 +14,34 @@
   screenshot works as a static preview image and needs nothing. Revisit if
   per-page previews become worth the build dependency.
 #}
+{#
+  One definition of the page title, used by <title> and by the social cards, so
+  the tab and a pasted link can never disagree.
+
+  Material's own rule is "{{ page title }} - {{ site name }}", which is right for
+  a doc page and wrong for the front page: it can only ever put the brand last,
+  and a root URL should lead with the product. `home_title` is therefore written
+  out in full, and every other page keeps Material's shape.
+
+  Kept to ~50 characters: Google truncates a title around 60, and this one has to
+  survive being suffixed in some surfaces.
+#}
+{% set home_title = "Vayu - REST & GraphQL API Client with Load Testing" %}
+
+{% if page.is_homepage %}
+  {% set page_title = home_title %}
+{% elif page.meta and page.meta.title %}
+  {% set page_title = page.meta.title ~ " - " ~ config.site_name %}
+{% else %}
+  {% set page_title = page.title ~ " - " ~ config.site_name %}
+{% endif %}
+
+{% block htmltitle %}
+  <title>{{ page_title }}</title>
+{% endblock %}
+
 {% block extrahead %}
-  {#
-    Mirrors Material's own <title> logic (a front-matter title wins, and the site
-    name is appended to it), so the social card and the tab never disagree. The
-    home page would otherwise share a card titled just "Vayu", which says nothing
-    to someone seeing the link cold.
-  #}
-  {% if page.meta and page.meta.title %}
-    {% set title = page.meta.title ~ " - " ~ config.site_name %}
-  {% elif page.is_homepage %}
-    {% set title = config.site_name %}
-  {% else %}
-    {% set title = page.title ~ " - " ~ config.site_name %}
-  {% endif %}
+  {% set title = page_title %}
   {% set description = page.meta.description if page.meta and page.meta.description else config.site_description %}
   {% set image = config.site_url ~ "images/vayu-loadtest.png" %}
 
@@ -76,6 +90,7 @@
       "featureList": [
         "REST and GraphQL request builder",
         "Native C++ load testing with live metrics over SSE",
+        "Built-in MCP server for Claude Code, Cursor, VS Code, Codex and Zed",
         "Import Postman, Insomnia, OpenAPI 3.0 and Swagger 2.0 collections",
         "Postman-compatible pm.* test scripts",
         "OAuth 2.0, Bearer, Basic and API key auth",

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A broader comparison against k6, JMeter, and the Postman collection runner is in
 
 ## Coming from Postman, Insomnia, or an OpenAPI spec?
 
-Migrating takes seconds. Drop an existing export onto Vayu and the workspace is rebuilt as a native collection - folders, environments, variables, auth, and pre/post-request scripts all carry across.
+Migrating takes seconds. Drop an existing export onto Vayu and the workspace is rebuilt as a native collection - folders, variables, auth, and pre/post-request scripts all carry across, plus environments from an Insomnia workspace. (Postman keeps environments in a separate export, which is not read.)
 
 - **Postman** - Collection v2.0 and v2.1 JSON exports
 - **Insomnia** - v4 exports
@@ -219,7 +219,7 @@ Yes. All execution happens locally. Vayu never contacts external servers during 
 No. Download, install, and use it immediately with no sign-up.
 
 **Can I import my Postman collections?**
-Yes - Postman Collection v2.0 and v2.1 JSON exports, including folders, environments, variables, auth settings, and pre/post-request scripts.
+Yes - Postman Collection v2.0 and v2.1 JSON exports, including folders, collection variables, auth settings, and pre/post-request scripts. Postman environments live in a separate export file and are not read; Insomnia workspace environments do import.
 
 **Can I import OpenAPI / Swagger specs?**
 Yes. Drop in an OpenAPI 3.0 or Swagger 2.0 file (JSON or YAML) and Vayu generates a ready-to-use collection from the spec.

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,8 +76,8 @@ Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
 
 - :material-import: **Bring what you already have**
 
-    Import Postman v2.0/v2.1, Insomnia v4, OpenAPI 3.0, and Swagger 2.0 -
-    [what maps to what](app/import-collections/README.md).
+    Drop in a Postman, Insomnia, OpenAPI or Swagger export and keep your folders,
+    variables, auth and scripts. [What carries over](#bring-your-existing-collections).
 
 - :material-code-braces: **Keep your Postman tests**
 
@@ -101,6 +101,43 @@ Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
     requests and secrets never leave the machine.
 
 </div>
+
+## Bring your existing collections
+
+Switching tools is only cheap if your work comes with you. Drop in an export -
+the format is detected for you, no "which importer?" dialog - and Vayu rebuilds
+the tree, variables, auth and scripts.
+
+=== "Postman"
+
+    **v2.1 and v2.0 exports.** The folder tree, collection and folder variables,
+    auth (Bearer, Basic, API key, OAuth 2.0), pre-request and test scripts, query
+    parameters including disabled ones and their descriptions, and raw, JSON,
+    URL-encoded, form-data and GraphQL bodies.
+
+    Not carried: **environments** - Postman exports those as separate files, which
+    this importer does not read. Binary and file bodies are dropped and reported
+    with a count rather than silently, and Digest / AWS / NTLM auth imports as
+    data but will not execute.
+
+=== "Insomnia"
+
+    **Export v4.** Vayu rebuilds the workspace, folder and request tree from
+    Insomnia's flat resource list, and workspace **environments do come across**.
+
+    `{{var}}` templates are converted to Vayu's own. Nunjucks tags (`{% ... %}`)
+    and filtered expressions (`{{ x | filter }}`) are left verbatim as text, since
+    Vayu has no equivalent - they stay visible instead of silently breaking.
+
+=== "OpenAPI & Swagger"
+
+    **OpenAPI 3.0 and Swagger 2.0**, JSON or YAML. A spec describes endpoints
+    rather than recording requests, so Vayu generates **stubs**: one collection
+    per tag, a `{{baseUrl}}` variable from the server definition, parameters with
+    empty values, and a request body sampled from the schema. Auth schemes map
+    across, seeded with `{{variables}}` for you to fill in.
+
+[How import works, format by format](app/import-collections/README.md){ .md-button }
 
 ## How it fits together
 
@@ -219,10 +256,10 @@ persists.
 
 ??? question "Can I import my Postman collections?"
 
-    Yes. Postman Collection v2.0 and v2.1 exports, including folders,
-    environments, variables, auth settings, and pre/post-request scripts. Also
-    Insomnia v4, OpenAPI 3.0, and Swagger 2.0 - see
-    [how import works](app/import-collections/README.md).
+    Yes - v2.0 and v2.1 exports, including folders, collection variables, auth,
+    and pre/post-request scripts. Postman environments are a separate export and
+    are not read. Insomnia v4, OpenAPI 3.0 and Swagger 2.0 import too; see
+    [what carries over](#bring-your-existing-collections).
 
 ??? question "Will my Postman test scripts still run?"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,22 @@
 ---
-title: Free API Client with Native Load Testing
+title: Vayu
 description: >-
-  Vayu is a free API client for REST and GraphQL with native load testing built in - import Postman collections, keep pm.* scripts, run fully offline.
+  Free, open source API client for REST and GraphQL with a native load tester and an MCP server your coding agent can drive. Runs offline, no account.
 hide:
   - navigation
   - toc
 ---
 
-# The API client that load tests, too
+# Build the request. Load test it. Let your agent drive.
 
 **Vayu** is a free, open source **API client for REST and GraphQL** with a
-**native load tester** built in. Build a request the way you would in Postman,
-then hammer the same endpoint at tens of thousands of requests per second with a
-C++ engine - no second tool, no account, no cloud sync. Your requests and secrets
-never leave the machine.
+**native C++ load tester** built in - and an **MCP server** that hands the whole
+engine to Claude Code, Cursor, VS Code, or Codex. One app instead of three, all
+of it on your machine: no account, no cloud sync, no telemetry.
 
 [Download Vayu](#install){ .md-button .md-button--primary }
+[Use it from your agent](#drive-vayu-from-your-coding-agent){ .md-button }
 [See what it does](#what-you-can-do){ .md-button }
-[Engine HTTP API](engine/api-reference.md){ .md-button }
 
 ![The load-test dashboard: throughput, latency percentiles and error counters streaming live from the C++ engine while the UI stays responsive.](images/vayu-loadtest.png){ .shot }
 
@@ -90,6 +89,12 @@ Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
     Bearer, Basic, API key, and OAuth 2.0 (client credentials, password,
     authorization code + PKCE) - resolved engine-side, inherited down the tree.
 
+- :material-robot-outline: **Hand it to your coding agent**
+
+    A built-in MCP server exposes the engine to Claude Code, Cursor, VS Code,
+    Codex and Zed - behind a host allowlist and load caps you set.
+    [Drive Vayu from your agent](#drive-vayu-from-your-coding-agent).
+
 - :material-shield-lock-outline: **Private by default**
 
     100% offline execution. No telemetry, no account, no cloud sync - your
@@ -106,6 +111,65 @@ engine saturates a target - and why the engine can be driven on its own, from th
 [MCP](engine/mcp.md).
 
 [How it works in full](architecture.md){ .md-button }
+
+## Drive Vayu from your coding agent
+
+Vayu ships an **MCP server**, so an agent can use the same engine the UI does -
+send a request, start a load run, read the report, compare two runs. It runs
+inside the app on `127.0.0.1:9877`, proxying the engine's REST API; there is no
+second process to manage, and nothing leaves the machine.
+
+=== "Claude Code"
+
+    ```bash
+    claude mcp add --transport http vayu http://127.0.0.1:9877/mcp
+    ```
+
+    Or click **Connect** in **Settings → MCP**, which shells out to the CLI for
+    you.
+
+=== "Cursor"
+
+    ```json
+    // .cursor/mcp.json
+    {
+      "mcpServers": {
+        "vayu": { "type": "http", "url": "http://127.0.0.1:9877/mcp" }
+      }
+    }
+    ```
+
+=== "VS Code"
+
+    ```json
+    // .vscode/mcp.json - note the "servers" key, not "mcpServers"
+    {
+      "servers": { "vayu": { "type": "http", "url": "http://127.0.0.1:9877/mcp" } }
+    }
+    ```
+
+=== "Codex"
+
+    ```toml
+    # ~/.codex/config.toml
+    [mcp_servers.vayu]
+    url = "http://127.0.0.1:9877/mcp"
+    ```
+
+**16 tools, 5 resources, 4 prompts.** Inspection (`list_collections`,
+`get_run_report`, `compare_runs`), execution (`run_request`,
+`run_collection_smoke`), load (`start_load_run`, `stop_run`), and writes
+(`create_request`, `update_environment`) - each with a typed schema, so the agent
+gets validation rather than guesswork.
+
+**An agent pointed at your engine is a real capability, so it is gated.** Tools
+that touch the network refuse any host outside an **allowlist that starts empty**
+(deny all). Load runs are additionally capped on RPS, concurrency and duration,
+and require confirmation. The tools that mutate saved data sit behind a **write
+toggle that is off by default**. All of it lives in **Settings → MCP** and
+persists.
+
+[MCP reference](engine/mcp.md){ .md-button }
 
 ## Reference
 
@@ -166,6 +230,14 @@ engine saturates a target - and why the engine can be driven on its own, from th
     `pm.test()`, `pm.expect()`, `pm.environment.get/set()`, `pm.response.*` -
     and [Postman Script Support](app/pm-api-compatibility.md) lists exactly
     what is covered.
+
+??? question "Can my coding agent use it?"
+
+    Yes - Vayu hosts an MCP server on `127.0.0.1:9877` and one command registers
+    it with Claude Code, Cursor, VS Code, Codex or Zed. The agent gets 16 tools
+    across inspection, execution, load runs and writes, behind a host allowlist,
+    load caps, and a write toggle that ships off. See the
+    [MCP reference](engine/mcp.md).
 
 ??? question "Does it work offline, and does it need an account?"
 


### PR DESCRIPTION
## Description

Three changes to the product page, on a fresh branch off `master`.

### 1. The title led with the price (`72b6a41`)

The tab read **"Free API Client with Native Load Testing - Vayu"** - opening on *free* rather than the product, with the brand buried at the end of the one URL where it should lead. Material can only ever append `site_name`, so the front page now writes its own title through an `htmltitle` override:

> **Vayu - REST & GraphQL API Client with Load Testing**

50 characters, inside the ~60 Google displays. Every other page keeps `Page - Vayu`. One definition feeds both the `<title>` and the social cards, so they cannot drift apart. "Free" moves to the description, where it still earns the query without being the first thing read.

The h1 follows: **"Build the request. Load test it. Let your agent drive."**

### 2. MCP was a footnote (`72b6a41`)

One mid-paragraph mention and one table row, for a capability few API clients have. Now: a hero mention, a card, its own section with connect snippets tabbed per client (Claude Code, Cursor, VS Code, Codex), an FAQ entry, and a line in `featureList`.

The section leads with capability and closes with the gates, because an agent pointed at a load generator deserves both halves stated: 16 tools across inspection / execution / load / write, then the **allowlist that starts empty**, the RPS / concurrency / duration caps, and the **write toggle that ships off**.

### 3. Importing was undersold - and one claim was wrong (`ddc8fdf`)

Import had a card and an FAQ line, which undersells the thing people weigh first when leaving another tool: *does my work come with me?* It now has its own section, placed between "What you can do" and the architecture, with a tab per format.

**Writing it surfaced a real error, repeated in three places.** Postman **environments do not carry across** - `postman.ts` always returns `environments: []`, because Postman exports environments as separate files the importer never reads (`docs/app/import-collections/postman.md`, *Variables & environments*). Insomnia workspace environments are the case that *does* import. Two README claims and the site's FAQ said otherwise; all three are corrected here.

The section also states limits next to capabilities rather than burying them: binary and file bodies are dropped (reported with a count, not silently), Digest / AWS / NTLM auth imports as data but will not execute, and a spec import yields stubs with empty values because a spec describes endpoints rather than recording requests.

Every claim on the page - MCP tool names and counts, per-format import behaviour - is taken from the reference docs rather than written fresh, so the landing page cannot drift from what it summarises.

## Type of Change

- [x] Bug fix - the Postman environments claim, in README (x2) and the site
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `mkdocs build --strict` clean on each step.
- **5,093 internal links crawled, 0 broken**, including the two new anchors reached from the hero card, the buttons, and the FAQ.
- **Home emits exactly one `<title>`** - checked explicitly, since an `htmltitle` override that fails to replace the parent block silently produces two. Inner pages verified to keep `Page - Vayu`.
- JSON-LD parses, carries MCP in `featureList`, and still contains no fabricated rating or review fields.
- Both meta descriptions measured under 160 chars (149 site, 148 page).
- Page order verified from the rendered DOM: Install → What you can do → Bring your existing collections → How it fits together → Drive Vayu from your coding agent → Reference → FAQ → Contribute.
- Rendered in Chromium at 2x, light and dark, on the hero and both new sections.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - none; site content, guarded by the existing strict build
- [x] I have updated documentation - `README.md` corrected in two places; the parser reference itself was already right and remains the source

## Related Issues

Follow-up to #141, #143 and #144.