### PR TITLE
refactor(app): rebuild the key/value editor behind Params and Headers

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/EmptyTableHint.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/EmptyTableHint.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The instruction line, and the fact that it goes away.
+ *
+ * Params and Headers each opened with a permanent sentence - "Add headers to
+ * include with your request. Use `{{variable}}` for dynamic values." - in a
+ * dense developer tool, repeated on the sibling tab, restating what the field
+ * placeholder and the coloured token already say the moment you have a row.
+ * Useful once, furniture thereafter. Same shape as "Auto-saves when you click
+ * away", which came out of the variable popover last round.
+ *
+ * The condition is the whole point, and it is not `items.length`: the editor
+ * always keeps one blank row at the end, so a genuinely empty table still has a
+ * row in it. Counting rows would hide the hint exactly when it is wanted.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EmptyTableHint } from "./EmptyTableHint";
+import type { KeyValueItem } from "../../../types";
+
+const blank: KeyValueItem = { id: "1", key: "", value: "", enabled: true };
+const filled: KeyValueItem = { id: "2", key: "Accept", value: "application/json", enabled: true };
+
+const hint = (items: KeyValueItem[]) =>
+	render(
+		<EmptyTableHint items={items} noun="headers">
+			Add headers to send with this request.
+		</EmptyTableHint>
+	);
+
+describe("when the hint shows", () => {
+	it("shows on a table with nothing in it", () => {
+		hint([]);
+		expect(screen.getByText(/Add headers to send/)).toBeInTheDocument();
+	});
+
+	it("still shows when the only row is the editor's trailing blank", () => {
+		// The case `items.length` would get wrong.
+		hint([blank]);
+		expect(screen.getByText(/Add headers to send/)).toBeInTheDocument();
+	});
+
+	it("goes away once a row has a key", () => {
+		hint([filled, blank]);
+		expect(screen.queryByText(/Add headers to send/)).not.toBeInTheDocument();
+	});
+
+	it("goes away for a row with only a value", () => {
+		hint([{ id: "3", key: "", value: "something", enabled: true }]);
+		expect(screen.queryByText(/Add headers to send/)).not.toBeInTheDocument();
+	});
+
+	it("treats whitespace as empty", () => {
+		hint([{ id: "4", key: "   ", value: "  ", enabled: true }]);
+		expect(screen.getByText(/Add headers to send/)).toBeInTheDocument();
+	});
+
+	it("counts a disabled row as content, because it is still there", () => {
+		hint([{ ...filled, enabled: false }]);
+		expect(screen.queryByText(/Add headers to send/)).not.toBeInTheDocument();
+	});
+});
+
+describe("what it says", () => {
+	it("names the variable syntax once, where it is new", () => {
+		hint([]);
+		expect(screen.getByText("{{variable}}")).toBeInTheDocument();
+	});
+
+	it("uses the caller's noun in the singular", () => {
+		hint([]);
+		expect(
+			screen.getByText(/in a header for a value resolved at send time/)
+		).toBeInTheDocument();
+	});
+});

--- a/app/src/modules/request-builder/components/RequestTabs/panels/EmptyTableHint.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/EmptyTableHint.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The one-line explanation above a key/value table, shown only while it is
+ * empty.
+ *
+ * Both Params and Headers opened with a permanent sentence - "Add headers to
+ * include with your request. Use `{{variable}}` for dynamic values." - in a
+ * dense developer tool, repeated on the sibling tab, saying what the field
+ * placeholder and the coloured token already say once you have a row. It is
+ * genuinely useful on an empty tab and furniture every time after, which is the
+ * same shape as "Auto-saves when you click away" in the variable popover.
+ *
+ * A table is "empty" when it has nothing but the trailing blank row the editor
+ * always keeps - so this counts rows with content rather than rows.
+ */
+
+import type { KeyValueItem } from "../../../types";
+
+export interface EmptyTableHintProps {
+	items: KeyValueItem[];
+	/** "headers" / "query parameters" - used in the variable sentence. */
+	noun: string;
+	children: React.ReactNode;
+}
+
+export function EmptyTableHint({ items, noun, children }: EmptyTableHintProps) {
+	const hasContent = items.some((i) => i.key.trim() || i.value.trim());
+	if (hasContent) return null;
+
+	return (
+		<p className="text-xs text-muted-foreground">
+			{children} Use{" "}
+			<code className="bg-muted px-1 rounded-md font-mono">{"{{variable}}"}</code> in a{" "}
+			{noun.replace(/s$/, "")} for a value resolved at send time.
+		</p>
+	);
+}
+
+export default EmptyTableHint;

--- a/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
@@ -8,26 +8,24 @@
 /**
  * HeadersPanel Component
  *
- * Request headers editor with inline bulk edit support
- * Uses useHeadersManager hook for centralized header management
+ * The headers table, plus the text form of the same thing.
+ *
+ * The bulk-edit machinery - the mode flag, the draft text, the toggle handler,
+ * the toolbar and the textarea - used to live here *and* in `ParamsPanel`, in
+ * duplicate. It is `BulkEditor` now; only the format differs between the two,
+ * and that is what this file passes.
  */
 
-import { useState } from "react";
-import { Edit3, Table2 } from "lucide-react";
 import { useRequestBuilderContext } from "../../../context";
-import KeyValueEditor from "../../../shared/KeyValueEditor";
+import KeyValueEditor, { BulkEditor } from "../../../shared/KeyValueEditor";
 import type { KeyValueItem } from "../../../types";
 import { useHeadersManager } from "../../../hooks/useHeadersManager";
-import { Button, Label } from "@/components/ui";
-import { Textarea } from "@/components/ui/textarea";
 import { STANDARD_HEADERS } from "@/constants/http";
+import { EmptyTableHint } from "./EmptyTableHint";
 
 export default function HeadersPanel() {
 	const { request, updateField } = useRequestBuilderContext();
-	const [isBulkEditMode, setIsBulkEditMode] = useState(false);
-	const [bulkEditText, setBulkEditText] = useState("");
 
-	// Use centralized headers manager hook
 	const {
 		displayHeaders,
 		handleHeadersChange,
@@ -41,88 +39,41 @@ export default function HeadersPanel() {
 		onUpdate: (newHeaders: KeyValueItem[]) => updateField("headers", newHeaders),
 	});
 
-	// Toggle between table and bulk edit mode
-	const handleToggleMode = () => {
-		if (isBulkEditMode) {
-			// Switching to table mode - save bulk edit
-			handleBulkEdit(bulkEditText);
-			setIsBulkEditMode(false);
-		} else {
-			// Switching to bulk edit mode - load current headers
-			setBulkEditText(formatForBulkEdit());
-			setIsBulkEditMode(true);
-		}
-	};
-
-	// Handle bulk edit text change
-	const handleBulkEditTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-		setBulkEditText(e.target.value);
-	};
-
 	return (
-		<div className="space-y-4">
-			<div className="flex items-center justify-between">
-				<p className="text-sm text-muted-foreground">
-					Add headers to include with your request. Use{" "}
-					<code className="bg-muted px-1 rounded-md">{"{{variable}}"}</code> for dynamic
-					values.
-				</p>
-				<Button variant="outline" size="sm" onClick={handleToggleMode} className="shrink-0">
-					{isBulkEditMode ? (
-						<>
-							<Table2 className="w-4 h-4 mr-1" />
-							Table View
-						</>
-					) : (
-						<>
-							<Edit3 className="w-4 h-4 mr-1" />
-							Bulk Edit
-						</>
-					)}
-				</Button>
-			</div>
-
-			{isBulkEditMode ? (
-				<div className="space-y-2">
-					<Label htmlFor="bulk-edit">Headers</Label>
-					<Textarea
-						id="bulk-edit"
-						value={bulkEditText}
-						onChange={handleBulkEditTextChange}
-						placeholder="User-Agent: MyApp/1.0&#10;Authorization: Bearer token&#10;Content-Type: application/json"
-						className="font-mono text-sm min-h-[400px]"
-					/>
-					{/*
-					 * The format shown here now matches the placeholder above it and
-					 * the parser below it - all three disagreed. It advertised
-					 * `Header-Name=value` while the placeholder demonstrated
-					 * `Authorization: Bearer token`, and the parser accepted only the
-					 * first, discarding every line written in the second.
-					 *
-					 * "Duplicate keys will override previous values" was also untrue:
-					 * nothing dedupes, so both rows survive and both are sent - which
-					 * is what HTTP allows and what a user pasting a real header block
-					 * would want.
-					 */}
-					<p className="text-xs text-muted-foreground">
-						Format: <code className="bg-muted px-1 rounded-md">Header-Name: value</code>{" "}
-						(one per line). Repeated names are kept as separate headers.
-					</p>
-				</div>
-			) : (
-				<KeyValueEditor
-					items={displayHeaders}
-					onChange={handleHeadersChange}
-					keyPlaceholder="Header"
-					valuePlaceholder="Value"
-					showResolved={true}
-					allowDisable={true}
-					keySuggestions={STANDARD_HEADERS}
-					canEdit={canEdit}
-					canRemove={canRemove}
-					canDisable={canDisable}
-				/>
-			)}
-		</div>
+		<BulkEditor
+			label="Headers"
+			format={formatForBulkEdit}
+			// `handleBulkEdit` parses *and* re-imposes the managed system headers,
+			// which is a headers rule rather than a bulk-edit one - so it stays
+			// here and BulkEditor only ever handles text.
+			onCommit={handleBulkEdit}
+			placeholder={
+				"User-Agent: MyApp/1.0\nAuthorization: Bearer token\nContent-Type: application/json"
+			}
+			hint={
+				<>
+					Format: <code className="bg-muted px-1 rounded-md">Header-Name: value</code>{" "}
+					(one per line). Repeated names are kept as separate headers.
+				</>
+			}
+			tableHeader={
+				<EmptyTableHint items={displayHeaders} noun="headers">
+					Add headers to send with this request.
+				</EmptyTableHint>
+			}
+		>
+			<KeyValueEditor
+				items={displayHeaders}
+				onChange={handleHeadersChange}
+				keyPlaceholder="Header"
+				valuePlaceholder="Value"
+				showResolved={true}
+				allowDisable={true}
+				keySuggestions={STANDARD_HEADERS}
+				canEdit={canEdit}
+				canRemove={canRemove}
+				canDisable={canDisable}
+			/>
+		</BulkEditor>
 	);
 }

--- a/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
@@ -52,8 +52,9 @@ export default function HeadersPanel() {
 			}
 			hint={
 				<>
-					Format: <code className="bg-muted px-1 rounded-md">Header-Name: value</code>{" "}
-					(one per line). Repeated names are kept as separate headers.
+					<code className="bg-muted px-1 rounded-md">Name: value</code>, one per line -{" "}
+					<code className="bg-muted px-1 rounded-md">=</code> works too. Repeated names
+					are kept as separate headers.
 				</>
 			}
 			tableHeader={

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
@@ -8,17 +8,18 @@
 /**
  * ParamsPanel Component
  *
- * Query parameters editor with URL sync and bulk edit support
+ * Query parameters, kept in step with the URL in the bar above.
+ *
+ * The bulk-edit machinery that used to be duplicated here and in `HeadersPanel`
+ * is now `BulkEditor`; only the format differs, and that is what this passes.
  */
 
-import { useState, useCallback } from "react";
-import { Edit3, Table2 } from "lucide-react";
+import { useCallback } from "react";
 import { useRequestBuilderContext } from "../../../context";
-import KeyValueEditor from "../../../shared/KeyValueEditor";
+import KeyValueEditor, { BulkEditor } from "../../../shared/KeyValueEditor";
 import type { KeyValueItem } from "../../../types";
 import { formatParamsToText, parseParamsFromText } from "../../../utils/params-format";
-import { Button, Label } from "@/components/ui";
-import { Textarea } from "@/components/ui/textarea";
+import { EmptyTableHint } from "./EmptyTableHint";
 
 // Build URL from base and params
 // Note: We don't URL-encode values containing {{variables}} - they get resolved and encoded at request time
@@ -45,8 +46,6 @@ function buildUrlWithParams(baseUrl: string, params: KeyValueItem[]): string {
 
 export default function ParamsPanel() {
 	const { request, updateField, resolveString } = useRequestBuilderContext();
-	const [isBulkEditMode, setIsBulkEditMode] = useState(false);
-	const [bulkEditText, setBulkEditText] = useState("");
 
 	// Handle params change and sync to URL
 	const handleParamsChange = useCallback(
@@ -63,115 +62,62 @@ export default function ParamsPanel() {
 		[request.url, updateField]
 	);
 
-	// Handle bulk edit text
-	const handleBulkEdit = useCallback(
-		(text: string) => {
-			const parsedParams = parseParamsFromText(text);
-			handleParamsChange(parsedParams);
-		},
-		[handleParamsChange]
-	);
-
-	// Format params for bulk edit display
-	const formatForBulkEdit = useCallback(() => {
-		return formatParamsToText(request.params);
-	}, [request.params]);
-
-	// Toggle between table and bulk edit mode
-	const handleToggleMode = () => {
-		if (isBulkEditMode) {
-			// Switching to table mode - save bulk edit
-			handleBulkEdit(bulkEditText);
-			setIsBulkEditMode(false);
-		} else {
-			// Switching to bulk edit mode - load current params
-			setBulkEditText(formatForBulkEdit());
-			setIsBulkEditMode(true);
-		}
-	};
-
-	// Handle bulk edit text change
-	const handleBulkEditTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-		setBulkEditText(e.target.value);
-	};
-
 	const resolvedUrl = resolveString(request.url);
 	const displayParams = request.params.filter((param) => !param.system);
 
 	return (
-		<div className="space-y-4">
-			<div className="flex items-center justify-between">
-				<p className="text-sm text-muted-foreground">
-					Add query parameters to include with your request. Use{" "}
-					<code className="bg-muted px-1 rounded-md">{"{{variable}}"}</code> for dynamic
-					values.
-				</p>
-				<Button variant="outline" size="sm" onClick={handleToggleMode} className="shrink-0">
-					{isBulkEditMode ? (
-						<>
-							<Table2 className="w-4 h-4 mr-1" />
-							Table View
-						</>
-					) : (
-						<>
-							<Edit3 className="w-4 h-4 mr-1" />
-							Bulk Edit
-						</>
-					)}
-				</Button>
-			</div>
-
-			{isBulkEditMode ? (
-				<div className="space-y-2">
-					<Label htmlFor="bulk-edit">Query Parameters</Label>
-					<Textarea
-						id="bulk-edit"
-						value={bulkEditText}
-						onChange={handleBulkEditTextChange}
-						placeholder="page=1&#10;limit=10&#10;sort=name"
-						className="font-mono text-sm min-h-[400px]"
-					/>
-					{/* Params keep `=` alone - a query string is written `k=v`, and a
-					    value routinely contains a colon (`redirect=https://…`). Only
-					    the Headers editor accepts both separators. The override claim
-					    was wrong here too: repeated keys are all sent, joined with
-					    `&`, which is how an array parameter is expressed. */}
-					<p className="text-xs text-muted-foreground">
-						Format: <code className="bg-muted px-1 rounded-md">key=value</code> (one per
-						line). Repeated keys are kept and all sent.
-					</p>
-				</div>
-			) : (
+		<BulkEditor
+			label="Query Parameters"
+			format={() => formatParamsToText(request.params)}
+			// Parsed here rather than in BulkEditor, because applying params also
+			// means rewriting the URL - a params rule, not a bulk-edit one.
+			onCommit={(text) => handleParamsChange(parseParamsFromText(text))}
+			placeholder={"page=1\nlimit=10\nsort=name"}
+			hint={
+				/* Params keep `=` alone - a query string is written `k=v`, and a
+				   value routinely contains a colon (`redirect=https://…`). Only the
+				   Headers editor accepts both separators. Repeated keys are all
+				   sent, joined with `&`, which is how an array parameter is
+				   expressed. */
 				<>
-					{/* Query Parameters Editor */}
-					<div className="space-y-2">
-						<KeyValueEditor
-							items={displayParams}
-							onChange={handleParamsChange}
-							keyPlaceholder="Parameter"
-							valuePlaceholder="Value"
-							showResolved={true}
-							allowDisable={true}
-						/>
-					</div>
-
-					{/* Full Resolved URL */}
-					<div className="space-y-2">
-						<label className="text-sm font-medium text-muted-foreground">
-							Full Resolved URL
-						</label>
-						{/* `rounded-md` to match the Quick Reference blocks in the
-						    script panels, which are the same `bg-muted` code slab.
-						    Without a radius class this one stayed square at every
-						    Roundedness setting. */}
-						<div className="p-3 rounded-md bg-muted font-mono text-sm break-all">
-							{resolvedUrl || (
-								<span className="text-muted-foreground italic">No URL</span>
-							)}
-						</div>
-					</div>
+					Format: <code className="bg-muted px-1 rounded-md">key=value</code> (one per
+					line). Repeated keys are kept and all sent.
 				</>
-			)}
-		</div>
+			}
+			tableHeader={
+				<EmptyTableHint items={displayParams} noun="parameters">
+					Add query parameters to send with this request.
+				</EmptyTableHint>
+			}
+		>
+			<div className="space-y-3">
+				<KeyValueEditor
+					items={displayParams}
+					onChange={handleParamsChange}
+					keyPlaceholder="Parameter"
+					valuePlaceholder="Value"
+					showResolved={true}
+					allowDisable={true}
+				/>
+
+				{/*
+				 * The resolved URL, on one line.
+				 *
+				 * Not redundant with the bar above, which is the thing worth being
+				 * careful about: the bar shows the URL *with* its `{{variables}}`,
+				 * this shows what will actually be sent. It was a `p-3` slab under a
+				 * 13px label - two rows of chrome for one line of text - in a tab
+				 * whose table is now 36px per row. It is a labelled line now.
+				 */}
+				<div className="flex items-baseline gap-2 text-xs">
+					<span className="shrink-0 uppercase tracking-wide text-subtle-foreground">
+						Sends
+					</span>
+					<span className="min-w-0 flex-1 break-all font-mono text-muted-foreground">
+						{resolvedUrl || <span className="italic">No URL</span>}
+					</span>
+				</div>
+			</div>
+		</BulkEditor>
 	);
 }

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
@@ -80,8 +80,10 @@ export default function ParamsPanel() {
 				   sent, joined with `&`, which is how an array parameter is
 				   expressed. */
 				<>
-					Format: <code className="bg-muted px-1 rounded-md">key=value</code> (one per
-					line). Repeated keys are kept and all sent.
+					<code className="bg-muted px-1 rounded-md">key=value</code>, one per line. A
+					line with no <code className="bg-muted px-1 rounded-md">=</code> splits at{" "}
+					<code className="bg-muted px-1 rounded-md">:</code>, and a bare key sends a
+					valueless parameter. Repeated keys are kept and all sent.
 				</>
 			}
 			tableHeader={

--- a/app/src/modules/request-builder/shared/KeyValueEditor/BulkEditor.test.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/BulkEditor.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The table/text toggle, which used to exist twice.
+ *
+ * `ParamsPanel` and `HeadersPanel` each carried the same `isBulkEditMode` and
+ * `bulkEditText` state, the same toggle handler with the same "save on the way
+ * out, load on the way in" comment, the same toolbar row and the same textarea -
+ * both labelled `id="bulk-edit"`, which is only harmless because one panel is
+ * mounted at a time.
+ *
+ * The behaviour worth pinning is the *staging* one. Bulk edit is a scratch pad:
+ * the draft is local, and it commits when you switch back to the table. Parsing
+ * on every keystroke would rewrite the request underneath a half-finished
+ * paste - which is why `onCommit` fires on the toggle and nowhere else.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BulkEditor } from "./BulkEditor";
+
+function setup(format = () => "a: 1\nb: 2") {
+	const onCommit = vi.fn();
+	render(
+		<BulkEditor
+			label="Headers"
+			format={format}
+			onCommit={onCommit}
+			placeholder="Name: value"
+			hint={<>Format: Name: value</>}
+			tableHeader={<span>empty hint</span>}
+		>
+			<div data-testid="table">the table</div>
+		</BulkEditor>
+	);
+	return { onCommit };
+}
+
+const textarea = () => screen.queryByRole("textbox");
+const toggle = () => screen.getByRole("button");
+
+describe("switching between the table and the text", () => {
+	it("starts on the table", () => {
+		setup();
+		expect(screen.getByTestId("table")).toBeInTheDocument();
+		expect(textarea()).not.toBeInTheDocument();
+	});
+
+	it("loads the current rows as text when switching in", () => {
+		setup();
+		fireEvent.click(toggle());
+		expect((textarea() as HTMLTextAreaElement).value).toBe("a: 1\nb: 2");
+		expect(screen.queryByTestId("table")).not.toBeInTheDocument();
+	});
+
+	it("commits the draft only when switching back", () => {
+		// The staging property. Typing must not rewrite the request.
+		const { onCommit } = setup();
+		fireEvent.click(toggle());
+		fireEvent.change(textarea()!, { target: { value: "c: 3" } });
+		expect(onCommit).not.toHaveBeenCalled();
+
+		fireEvent.click(toggle());
+		expect(onCommit).toHaveBeenCalledExactlyOnceWith("c: 3");
+		expect(screen.getByTestId("table")).toBeInTheDocument();
+	});
+
+	it("re-reads the rows every time it opens, not once", () => {
+		// A stale draft would silently revert whatever the table did in between.
+		let rows = "a: 1";
+		setup(() => rows);
+		fireEvent.click(toggle());
+		expect((textarea() as HTMLTextAreaElement).value).toBe("a: 1");
+		fireEvent.click(toggle());
+
+		rows = "a: 1\nb: 2";
+		fireEvent.click(toggle());
+		expect((textarea() as HTMLTextAreaElement).value).toBe("a: 1\nb: 2");
+	});
+});
+
+describe("the label and the field agree", () => {
+	it("gives the textarea an id derived from the label", () => {
+		// Both old copies hardcoded `id="bulk-edit"`, so two of these on one
+		// screen would have pointed one label at the other's field.
+		setup();
+		fireEvent.click(toggle());
+		expect(textarea()).toHaveAttribute("id", "bulk-edit-headers");
+		expect(screen.getByText("Headers")).toHaveAttribute("for", "bulk-edit-headers");
+	});
+});
+
+describe("the header slot", () => {
+	it("shows the caller's hint beside the table", () => {
+		setup();
+		expect(screen.getByText("empty hint")).toBeInTheDocument();
+	});
+
+	it("hides it in text mode, where it does not apply", () => {
+		setup();
+		fireEvent.click(toggle());
+		expect(screen.queryByText("empty hint")).not.toBeInTheDocument();
+	});
+});

--- a/app/src/modules/request-builder/shared/KeyValueEditor/BulkEditor.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/BulkEditor.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The table/text toggle that sits above a `KeyValueEditor`, and the textarea it
+ * swaps in.
+ *
+ * **This existed twice**, in `ParamsPanel` and `HeadersPanel`: the same
+ * `isBulkEditMode` and `bulkEditText` state, the same `handleToggleMode` with
+ * the same "save on the way out, load on the way in" comment, the same toolbar
+ * row, and the same `<Textarea>` - both of them labelled `id="bulk-edit"`, so
+ * the two would have collided had either ever rendered beside the other.
+ *
+ * Only the *format* differed, which is the part that genuinely differs: headers
+ * are `Name: value`, params are `key=value`. So that is what the caller passes -
+ * a parse, a format, and the sentence describing the syntax. Everything else is
+ * here.
+ *
+ * The draft text is local state on purpose. Bulk edit is a staging area: you
+ * paste a block, fix it up, and it commits when you switch back to the table.
+ * Parsing on every keystroke would rewrite the request underneath a
+ * half-finished paste.
+ */
+
+import { useState } from "react";
+import { Edit3, Table2 } from "lucide-react";
+import { Button, Label, Textarea } from "@/components/ui";
+
+export interface BulkEditorProps {
+	/** The rows as text, for when the user switches *into* text mode. */
+	format: () => string;
+	/**
+	 * The edited text, when the user switches back to the table.
+	 *
+	 * Text rather than parsed rows: both callers already own a parser that knows
+	 * their syntax *and* what to do with the result - headers have to re-impose
+	 * the managed system rows, params have to rewrite the URL. Parsing here would
+	 * mean handing the rows straight back for a second pass.
+	 */
+	onCommit: (text: string) => void;
+	/** "Headers" / "Query Parameters" - names the textarea. */
+	label: string;
+	placeholder: string;
+	/** The syntax note under the field. Headers and params differ here. */
+	hint: React.ReactNode;
+	/** The table, rendered when not in text mode. */
+	children: React.ReactNode;
+	/** Sits between the toggle and the table - the empty-state hint. */
+	tableHeader?: React.ReactNode;
+}
+
+export function BulkEditor({
+	format,
+	onCommit,
+	label,
+	placeholder,
+	hint,
+	children,
+	tableHeader,
+}: BulkEditorProps) {
+	const [isText, setIsText] = useState(false);
+	const [draft, setDraft] = useState("");
+
+	const toggle = () => {
+		if (isText) {
+			onCommit(draft);
+			setIsText(false);
+		} else {
+			setDraft(format());
+			setIsText(true);
+		}
+	};
+
+	/*
+	 * Derived from the label, so Headers and Query Parameters get different ids.
+	 * Both old copies hardcoded `id="bulk-edit"` with a `<Label htmlFor>` to
+	 * match - harmless only because one panel is mounted at a time, and exactly
+	 * the copy-paste tell this component exists to remove.
+	 */
+	const fieldId = `bulk-edit-${label.replace(/\s+/g, "-").toLowerCase()}`;
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between gap-3">
+				{/*
+				 * Empty when the table has rows: the instruction that used to live
+				 * here permanently now belongs to the empty state, where it is read
+				 * once rather than every time.
+				 */}
+				<div className="min-w-0">{!isText && tableHeader}</div>
+				<Button variant="outline" size="sm" onClick={toggle} className="shrink-0">
+					{isText ? (
+						<>
+							<Table2 className="w-3.5 h-3.5 mr-1" />
+							Table
+						</>
+					) : (
+						<>
+							<Edit3 className="w-3.5 h-3.5 mr-1" />
+							Bulk edit
+						</>
+					)}
+				</Button>
+			</div>
+
+			{isText ? (
+				<div className="space-y-2">
+					<Label htmlFor={fieldId}>{label}</Label>
+					<Textarea
+						id={fieldId}
+						value={draft}
+						onChange={(e) => setDraft(e.target.value)}
+						placeholder={placeholder}
+						className="font-mono text-xs min-h-[320px]"
+					/>
+					<p className="text-xs text-muted-foreground">{hint}</p>
+				</div>
+			) : (
+				children
+			)}
+		</div>
+	);
+}
+
+export default BulkEditor;

--- a/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.test.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.test.tsx
@@ -25,6 +25,11 @@
  *   - The resolved-value preview had no radius class at all, pinning it square
  *     at every Roundedness setting, and paired `truncate` with `overflow-x-auto`,
  *     which contradict: `truncate` sets `overflow: hidden`.
+ *
+ * That preview has since been replaced - it was a column taking an equal third
+ * of the table to echo the two cells beside it - so those two guards are gone
+ * with the element. What replaced them is below: *when* the resolved marker
+ * appears, and the row's height.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -83,31 +88,76 @@ describe("the enable checkbox", () => {
 	});
 });
 
-describe("the resolved-value preview", () => {
-	/** The preview box: the only `bg-muted/50` element in the row. */
-	const preview = (container: HTMLElement) =>
-		Array.from(container.querySelectorAll<HTMLElement>("*")).find((el) =>
-			/\bbg-muted\/50\b/.test(el.className)
-		)!;
+describe("the resolved value", () => {
+	/*
+	 * It used to be a column holding an equal third of the table, printing
+	 * `key=value` on every row whether or not anything resolved. Most rows have
+	 * no variable, so most of that third echoed the two cells beside it.
+	 *
+	 * It is a marker now, on the rows that have something to show. The two
+	 * guards that block replaced - a missing radius class and `truncate` paired
+	 * with a contradicting `overflow-x-auto` - died with the element they were
+	 * about; what matters here is *when* the marker appears, because a marker
+	 * that shows on every row is the old column with extra steps, and one that
+	 * never shows is the feature silently gone.
+	 */
+	const peek = (container: HTMLElement) =>
+		container.querySelector<HTMLElement>('[aria-label^="Resolved value of"]');
 
-	it("follows the roundedness setting", () => {
-		expect(preview(row()).className).toMatch(/\brounded-md\b/);
+	it("appears on a row that contains a variable", () => {
+		expect(peek(row())).not.toBeNull();
 	});
 
-	it("does not pair truncate with an overflow rule that contradicts it", () => {
-		const cls = preview(row()).className;
-		expect(cls).toMatch(/\btruncate\b/);
-		expect(cls).not.toMatch(/\boverflow-x-auto\b/);
+	it("stays away from a row with nothing to resolve", () => {
+		const container = row({
+			item: { id: "r1", key: "Accept", value: "application/json", enabled: true },
+		});
+		expect(peek(container)).toBeNull();
 	});
 
-	it("still shows the resolved value", () => {
-		expect(preview(row()).textContent).toContain("resolved-format");
+	it("is a real control, so the resolved value is reachable without a mouse", () => {
+		// Row-hover was the alternative and would have had nothing on screen to
+		// say it existed - and would have fired underneath the variable token's
+		// own tooltip.
+		expect(peek(row())!.tagName).toBe("BUTTON");
 	});
 
-	it("shows a dash rather than a stale value once the row is disabled", () => {
+	it("names the row it belongs to", () => {
+		expect(peek(row())!.getAttribute("aria-label")).toBe("Resolved value of Accept");
+	});
+
+	it("says nothing once the row is disabled", () => {
+		// A disabled row is not sent, so there is no resolved value to report.
 		const container = row({
 			item: { id: "r1", key: "Accept", value: "{{format}}", enabled: false },
 		});
-		expect(preview(container).textContent).toBe("-");
+		expect(peek(container)).toBeNull();
+	});
+
+	it("is withheld entirely when the caller turns resolution off", () => {
+		const container = row({ showResolved: false });
+		expect(peek(container)).toBeNull();
+	});
+});
+
+describe("row density", () => {
+	/*
+	 * 48px per row in the densest table in the app: `h-9` fields, `p-1` on the
+	 * row, `space-y-1` between. Eight headers cost 384px beside a 24px tab band.
+	 */
+	it("sizes both fields on the app's own step", () => {
+		const fields = row().querySelectorAll<HTMLElement>('[class*="h-8"]');
+		expect(fields.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("does not put the old h-9 back", () => {
+		/*
+		 * `String.raw`, deliberately - the same trap `no-dead-handlers.test.ts`
+		 * records. Written as a plain regex literal through a generating
+		 * script, the word-boundary escape collapsed to a backspace character
+		 * and the pattern matched nothing - so the guard passed against its own
+		 * mutation, which is the one failure a guard cannot have.
+		 */
+		expect(row().innerHTML).not.toMatch(new RegExp(String.raw`\bh-9\b`));
 	});
 });

--- a/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.tsx
@@ -6,14 +6,19 @@
  */
 
 /**
- * KeyValueRow Component
+ * One row of the key/value table.
  *
- * Single row in the KeyValueEditor with variable support
+ * `h-8` fields at a 36px pitch, down from `h-9` in a `p-1` row at 48px. This is
+ * the densest table in the app and it was the loosest thing in the panel.
+ *
+ * The resolved value moved out of a column and into `ResolvedPeek` - see the
+ * note there for why, and for how it stays out of the way of the variable
+ * token's own popover.
  */
 
 import { memo } from "react";
-import { Trash2 } from "lucide-react";
-import { Button } from "@/components/ui";
+import { Trash2, Sigma } from "lucide-react";
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { KeyValueItem } from "../../types";
 import { useRequestBuilderContext } from "../../context/RequestBuilderContext";
@@ -30,8 +35,47 @@ interface KeyValueRowProps {
 	onUpdate: (id: string, field: keyof KeyValueItem, value: string | boolean) => void;
 	onRemove: (id: string) => void;
 	canRemove?: boolean;
-	canEdit?: boolean;
+	/** Per field - see the note at the call site in KeyValueEditor. */
+	canEditKey?: boolean;
+	canEditValue?: boolean;
 	canDisable?: boolean;
+}
+
+/**
+ * The resolved form of a row that contains `{{variables}}`, on demand.
+ *
+ * It used to be a column holding an equal third of the table, printing
+ * `key=value` - the two cells to its left, joined - on every row whether or not
+ * anything in it resolved. Most rows have no variable, so most of that third
+ * was an echo.
+ *
+ * **A marker rather than bare row-hover.** Hovering the row itself would fire
+ * underneath the variable token's own tooltip, which already answers "what does
+ * *this* variable resolve to" - two hover surfaces in one space, one of them
+ * invisible. This is a separate target with its own column, so the two never
+ * overlap: the token answers for itself, the marker answers for the whole line.
+ *
+ * It renders only where there is something to resolve, so the column is empty
+ * on an ordinary row and the marker is its own affordance - the alternative was
+ * a hover with nothing on screen to say it existed.
+ */
+function ResolvedPeek({ label, resolved }: { label: string; resolved: string }) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					aria-label={`Resolved value of ${label}`}
+					className="flex h-8 w-5 items-center justify-center rounded-md text-subtle-foreground transition-colors hover:text-primary-text focus-visible:text-primary-text focus-visible:outline-none"
+				>
+					<Sigma className="h-3 w-3" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="left" className="max-w-md">
+				<span className="font-mono break-all">{resolved}</span>
+			</TooltipContent>
+		</Tooltip>
+	);
 }
 
 function KeyValueRow({
@@ -45,37 +89,40 @@ function KeyValueRow({
 	onUpdate,
 	onRemove,
 	canRemove = true,
-	canEdit = true,
+	canEditKey = true,
+	canEditValue = true,
 	canDisable = true,
 }: KeyValueRowProps) {
 	const { resolveString } = useRequestBuilderContext();
 
 	const resolvedKey = resolveString(item.key);
 	const resolvedValue = resolveString(item.value);
-	const hasVariableInKey = item.key !== resolvedKey;
-	const hasVariableInValue = item.value !== resolvedValue;
+	/*
+	 * "Contains a variable" is exactly "resolving changed something". A row whose
+	 * text is already literal has nothing to peek at, which is the condition the
+	 * marker keys off.
+	 */
+	const hasVariables = item.key !== resolvedKey || item.value !== resolvedValue;
 
-	const isProtected = !canEdit || !canRemove || !canDisable;
-	const isReadOnly = readOnly || !canEdit;
+	const keyReadOnly = readOnly || !canEditKey;
+	const valueReadOnly = readOnly || !canEditValue;
+	const isProtected = !canEditKey || !canEditValue || !canRemove || !canDisable;
 
 	return (
 		<div
 			className={cn(
-				"grid gap-2 items-center group p-1",
-				showResolved
-					? "grid-cols-[24px_1fr_1fr_1fr_32px]"
-					: "grid-cols-[24px_1fr_1fr_32px]",
+				"grid gap-2 items-center group px-1 py-0.5 rounded-md",
+				"grid-cols-[24px_1fr_1fr_20px_28px]",
 				!item.enabled && "opacity-50",
 				isProtected && "bg-muted/30"
 			)}
 		>
-			{/* Enable/Disable Checkbox */}
 			{allowDisable ? (
 				<input
 					type="checkbox"
 					checked={item.enabled}
 					onChange={(e) => onUpdate(item.id, "enabled", e.target.checked)}
-					disabled={isReadOnly || !canDisable}
+					disabled={keyReadOnly || !canDisable}
 					// Named after the row it governs. Without this it announced as
 					// a bare "checkbox", giving no clue which row it enables - and
 					// there is one per row.
@@ -94,61 +141,38 @@ function KeyValueRow({
 				<div className="w-4" />
 			)}
 
-			{/* Key Input */}
 			<VariableInput
 				value={item.key}
 				onChange={(v) => onUpdate(item.id, "key", v)}
 				placeholder={keyPlaceholder}
-				disabled={isReadOnly || !item.enabled}
+				disabled={keyReadOnly || !item.enabled}
 				suggestions={keySuggestions}
+				className="h-8"
 			/>
 
-			{/* Value Input */}
 			<VariableInput
 				value={item.value}
 				onChange={(v) => onUpdate(item.id, "value", v)}
 				placeholder={valuePlaceholder}
-				disabled={isReadOnly || !item.enabled}
+				disabled={valueReadOnly || !item.enabled}
+				className="h-8"
 			/>
 
-			{/* Resolved Preview */}
-			{showResolved && (
-				<div className="flex items-center min-w-0">
-					{/*
-					 * `rounded-md`, so the preview follows Settings → Appearance →
-					 * Roundedness like every other box. With no radius class at all it
-					 * was pinned square at every setting - the same escape hatch as a
-					 * bare `rounded`, in the other direction.
-					 *
-					 * `truncate` alone: it sets `overflow: hidden`, which the old
-					 * `overflow-x-auto` beside it contradicted outright. Nothing
-					 * scrolled; the ellipsis just fought a scrollbar that could not
-					 * appear.
-					 */}
-					<div className="truncate rounded-md text-sm font-mono text-muted-foreground bg-muted/50 px-2 py-1.5 w-full h-9 flex items-center">
-						{item.enabled && (resolvedKey || resolvedValue) ? (
-							<>
-								<span className={hasVariableInKey ? "text-primary" : ""}>
-									{resolvedKey}
-								</span>
-								{resolvedKey && resolvedValue && <span>=</span>}
-								<span className={hasVariableInValue ? "text-primary" : ""}>
-									{resolvedValue}
-								</span>
-							</>
-						) : (
-							<span className="italic text-muted-foreground">-</span>
-						)}
-					</div>
-				</div>
-			)}
+			{/* Empty on an ordinary row; the column keeps the grid aligned. */}
+			<div className="flex items-center justify-center">
+				{showResolved && item.enabled && hasVariables && (
+					<ResolvedPeek
+						label={item.key || "this row"}
+						resolved={resolvedValue ? `${resolvedKey}: ${resolvedValue}` : resolvedKey}
+					/>
+				)}
+			</div>
 
-			{/* Remove Button */}
 			<Button
 				size="icon"
 				variant="rowActionDestructive"
 				onClick={() => onRemove(item.id)}
-				disabled={isReadOnly || !canRemove}
+				disabled={keyReadOnly || !canRemove}
 				aria-label="Remove row"
 				className={cn(
 					// `focus-visible:opacity-100` is not decoration. The button was
@@ -156,13 +180,13 @@ function KeyValueRow({
 					// headers table landed on a fully transparent control - including
 					// its focus ring - once per row, and Enter there silently deleted
 					// the row they could not see they were on.
-					"h-8 w-8 transition-opacity focus-visible:opacity-100",
+					"h-7 w-7 transition-opacity focus-visible:opacity-100",
 					!canRemove
 						? "opacity-0 cursor-not-allowed"
 						: "opacity-0 group-hover:opacity-100"
 				)}
 			>
-				<Trash2 className="w-4 h-4" />
+				<Trash2 className="w-3.5 h-3.5" />
 			</Button>
 		</div>
 	);

--- a/app/src/modules/request-builder/shared/KeyValueEditor/index.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/index.tsx
@@ -8,22 +8,35 @@
 /**
  * KeyValueEditor Component
  *
- * Reusable editor for key-value pairs with variable support.
- * Used for: Query Params, Headers, Form Data, URL Encoded
+ * The table behind four surfaces: Query Params, Headers, form-data and
+ * urlencoded. It is the densest data surface in the app, which is what most of
+ * the decisions below are about.
  *
- * Features:
- * - Add/remove rows
- * - Enable/disable individual rows
- * - Variable syntax highlighting and autocomplete
- * - Optional resolved value preview
- * - Optional description field
+ * **Rows were 48px.** `VariableInput` is `h-9` (36px), the row added `p-1` and
+ * the stack added `space-y-1` - so eight headers cost 384px, in a panel whose
+ * tab band is 24px and whose URL bar is 40px. They are `h-8` now, the height 43
+ * other places in the app already use, at a 36px pitch. Same eight headers,
+ * 288px.
+ *
+ * **The Resolved column is gone.** It held an equal third of the table -
+ * `grid-cols-[24px_1fr_1fr_1fr_32px]` - and on a row with no variable in it,
+ * which is most rows, it printed the two cells to its left joined by `=`. Key
+ * and Value now have the whole width, and a row that *does* contain a variable
+ * carries a marker that reveals the resolved line on hover or focus. See
+ * `ResolvedPeek`.
+ *
+ * **The trailing blank row** comes from one `withTrailingBlank` rather than two
+ * copies that had drifted.
  */
 
 import { useCallback } from "react";
-import { cn } from "@/lib/utils";
 import type { KeyValueItem, KeyValueEditorProps } from "../../types";
-import { createEmptyKeyValue } from "../../utils/key-value";
+import { withTrailingBlank } from "../../utils/key-value";
 import KeyValueRow from "./KeyValueRow";
+
+// Re-exported here so a panel takes the table and its text form from one place.
+export { BulkEditor } from "./BulkEditor";
+export type { BulkEditorProps } from "./BulkEditor";
 
 export default function KeyValueEditor({
 	items,
@@ -38,89 +51,48 @@ export default function KeyValueEditor({
 	canRemove = () => true, // Default: allow removing all items
 	canDisable = () => true, // Default: allow disabling all items
 }: KeyValueEditorProps) {
-	// Remove row
 	const handleRemove = useCallback(
 		(id: string) => {
 			const itemToRemove = items.find((item) => item.id === id);
-
-			// Check if parent allows removal
-			if (itemToRemove && !canRemove(itemToRemove)) {
-				return;
-			}
-
-			const newItems = items.filter((item) => item.id !== id);
-			// Always ensure there's at least one empty row at the end
-			if (newItems.length === 0) {
-				newItems.push(createEmptyKeyValue());
-			} else {
-				const lastItem = newItems[newItems.length - 1];
-				// If the last item has a value, add an empty row
-				if (lastItem.key.trim() || lastItem.value.trim()) {
-					newItems.push(createEmptyKeyValue());
-				}
-			}
-			onChange(newItems);
+			if (itemToRemove && !canRemove(itemToRemove)) return;
+			onChange(withTrailingBlank(items.filter((item) => item.id !== id)));
 		},
 		[items, onChange, canRemove]
 	);
 
-	// Update row
 	const handleUpdate = useCallback(
 		(id: string, field: keyof KeyValueItem, value: string | boolean) => {
 			const itemToUpdate = items.find((item) => item.id === id);
 			if (!itemToUpdate) return;
-
-			// Check if parent allows editing this field
-			if (!canEdit(itemToUpdate, field)) {
-				return;
-			}
-
-			// Check if parent allows disabling
-			if (field === "enabled" && value === false && !canDisable(itemToUpdate)) {
-				return;
-			}
+			if (!canEdit(itemToUpdate, field)) return;
+			if (field === "enabled" && value === false && !canDisable(itemToUpdate)) return;
 
 			const newItems = items.map((item) =>
 				item.id === id ? { ...item, [field]: value } : item
 			);
-
-			// Check if we're updating the last row
-			const lastItem = newItems[newItems.length - 1];
-			const isLastRow = lastItem && lastItem.id === id;
-
-			// If editing the last row and it now has a value, add a new empty row
-			if (isLastRow) {
-				const hasValue = lastItem.key.trim() || lastItem.value.trim();
-				if (hasValue) {
-					newItems.push(createEmptyKeyValue());
-				}
-			}
-
-			onChange(newItems);
+			onChange(withTrailingBlank(newItems));
 		},
 		[items, onChange, canEdit, canDisable]
 	);
 
 	return (
-		<div className="space-y-2">
-			{/* Column Headers */}
-			<div
-				className={cn(
-					"grid gap-2 text-xs font-medium text-muted-foreground px-1",
-					showResolved
-						? "grid-cols-[24px_1fr_1fr_1fr_32px]"
-						: "grid-cols-[24px_1fr_1fr_32px]"
-				)}
-			>
-				<div></div>
-				<div>{keyPlaceholder}</div>
-				<div>{valuePlaceholder}</div>
-				{showResolved && <div>Resolved</div>}
-				<div></div>
+		<div className="space-y-1.5">
+			{/*
+			 * The column headers no longer repeat the placeholders. They used to
+			 * render `keyPlaceholder` verbatim, so an empty Headers table said
+			 * "Header" as a column title and "Header" again inside every field
+			 * below it. The placeholder is the one that has to name the thing,
+			 * because it is the one still visible once you start typing.
+			 */}
+			<div className="grid gap-2 grid-cols-[24px_1fr_1fr_20px_28px] px-1 text-[11px] font-medium uppercase tracking-wide text-subtle-foreground">
+				<div />
+				<div>Key</div>
+				<div>Value</div>
+				<div />
+				<div />
 			</div>
 
-			{/* Rows */}
-			<div className="space-y-1">
+			<div className="space-y-0.5">
 				{items.map((item) => (
 					<KeyValueRow
 						key={item.id}
@@ -129,12 +101,23 @@ export default function KeyValueEditor({
 						valuePlaceholder={valuePlaceholder}
 						showResolved={showResolved}
 						allowDisable={allowDisable}
-						readOnly={readOnly || !canEdit(item, "key")}
+						readOnly={readOnly}
 						keySuggestions={keySuggestions}
 						onUpdate={handleUpdate}
 						onRemove={handleRemove}
 						canRemove={canRemove(item)}
-						canEdit={canEdit(item, "key") || canEdit(item, "value")}
+						/*
+						 * Per field, not one boolean for both. `canEdit(item, field)`
+						 * has always taken a field, and `handleUpdate` above honours
+						 * it - but the row derived its disabled state from the *key*
+						 * alone and applied it to both inputs. Nothing exercised the
+						 * difference today (every rule that says no says no to both),
+						 * so this was a promise the UI could not keep rather than a
+						 * live bug: a value-editable, key-locked row would have given
+						 * you a field you could type into that discarded the write.
+						 */
+						canEditKey={canEdit(item, "key")}
+						canEditValue={canEdit(item, "value")}
 						canDisable={canDisable(item)}
 					/>
 				))}

--- a/app/src/modules/request-builder/utils/headers-format.ts
+++ b/app/src/modules/request-builder/utils/headers-format.ts
@@ -30,6 +30,7 @@
 
 import type { KeyValueItem } from "../types";
 import { generateId } from "./id";
+import { splitKeyValueLine, HEADER_SEPARATORS } from "./kv-line";
 import { VERSION_HEADER_KEY } from "./system-headers";
 
 /**
@@ -52,27 +53,16 @@ export const formatHeadersToText = (headers: KeyValueItem[]): string => {
 /**
  * Split one line at whichever of `:` or `=` comes first.
  *
+ * A header name may contain neither, so the earliest of the two is always the
+ * separator - which is why this cannot simply be shared with the params parser,
+ * whose keys *may* contain a colon. See `kv-line.ts` for the rule both follow.
+ *
  * Returns null when the line carries neither, or when the separator is the first
  * character - `: value` names no header, and writing an empty key into the table
  * would produce a row the user cannot identify.
  */
-const splitHeaderLine = (line: string): { key: string; value: string } | null => {
-	const colon = line.indexOf(":");
-	const equals = line.indexOf("=");
-
-	// -1 means absent; pick the smaller of the two positions that exist.
-	let at: number;
-	if (colon === -1) at = equals;
-	else if (equals === -1) at = colon;
-	else at = Math.min(colon, equals);
-
-	if (at <= 0) return null;
-
-	const key = line.slice(0, at).trim();
-	if (!key) return null;
-
-	return { key, value: line.slice(at + 1).trim() };
-};
+const splitHeaderLine = (line: string): { key: string; value: string } | null =>
+	splitKeyValueLine(line, HEADER_SEPARATORS);
 
 /**
  * Parse text format to headers array

--- a/app/src/modules/request-builder/utils/key-value.ts
+++ b/app/src/modules/request-builder/utils/key-value.ts
@@ -31,6 +31,25 @@ export const createEmptyKeyValue = (): KeyValueItem => ({
 });
 
 /**
+ * Ensure the list ends with exactly one blank row, so there is always somewhere
+ * to type without pressing "add".
+ *
+ * The rule was written twice inside `KeyValueEditor` - once in `handleRemove`
+ * and once in `handleUpdate` - with conditions that had already drifted apart:
+ * the remove path appended a blank when the list emptied *or* when the last row
+ * had content, while the update path only appended when the row being edited
+ * was the last one. Delete the second-to-last row while the last is blank and
+ * neither branch tidied up.
+ *
+ * One definition, applied to whatever the caller produces.
+ */
+export const withTrailingBlank = (items: KeyValueItem[]): KeyValueItem[] => {
+	const last = items[items.length - 1];
+	const lastIsBlank = last && !last.key.trim() && !last.value.trim();
+	return lastIsBlank ? items : [...items, createEmptyKeyValue()];
+};
+
+/**
  * Convert domain KeyValueEntry[] to UI KeyValueItem[].
  * Adds ephemeral `id` for React keys.
  * When `withSystemHeaders` is true, injects managed system headers at the top.

--- a/app/src/modules/request-builder/utils/kv-line.ts
+++ b/app/src/modules/request-builder/utils/kv-line.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Splitting one `key<sep>value` line, for the bulk editors.
+ *
+ * Headers and params looked like they had two arbitrary formats - `Name: value`
+ * against `key=value` - and the obvious tidy-up is to pick one. They cannot
+ * share one, and a single line shows why:
+ *
+ *     filter:status=open
+ *
+ * That is a legal query parameter: a param *name* may contain a colon (JIRA,
+ * Elasticsearch and OData all do it), so `:` cannot be the separator or the line
+ * splits as `filter` / `status=open`. Meanwhile a header line frequently has no
+ * `=` at all - `Authorization: Bearer abc` - so `=` cannot be the only
+ * separator either.
+ *
+ * The rule they *do* share is one level up:
+ *
+ *   **the separator is the earliest character the key is not allowed to contain**
+ *
+ * which resolves differently only because the two key alphabets differ:
+ *
+ *   - a header name may contain neither `:` nor `=`, so whichever comes first
+ *     is the separator;
+ *   - a param name may contain `:` but never `=`, so `=` wins wherever it
+ *     appears, and `:` is consulted only when the line has no `=` - which is
+ *     what makes a header block pasted into the Params tab parse instead of
+ *     vanishing.
+ *
+ * Tiers express exactly that: try each tier in order, take the earliest match
+ * within a tier.
+ */
+
+/** One tier of candidate separators. The earliest occurrence in a tier wins. */
+export type SeparatorTiers = readonly (readonly string[])[];
+
+/** A header name may contain neither, so the first of either is the split. */
+export const HEADER_SEPARATORS: SeparatorTiers = [[":", "="]];
+
+/**
+ * A param name may contain `:` but not `=`, so `=` outranks it. The second tier
+ * is what lets a pasted `Name: value` line survive.
+ */
+export const PARAM_SEPARATORS: SeparatorTiers = [["="], [":"]];
+
+export interface SplitOptions {
+	/**
+	 * Treat a line with no separator as a key with an empty value.
+	 *
+	 * True for params, where `?page` is a legal valueless parameter and
+	 * `buildUrlWithParams` already emits one. False for headers, where a bare
+	 * word names no header - `justsometext` is not a header line, and inventing
+	 * an empty one from it would put a row in the table the user did not write.
+	 */
+	allowBareKey?: boolean;
+}
+
+/**
+ * Split one line into a key and a value, or return null if it names nothing.
+ *
+ * A line that opens with its separator - `: orphaned`, `=orphaned` - names no
+ * key, and a row with an empty key is one the user can neither identify nor
+ * fix. That is handled by the empty-key check rather than a separate guard on
+ * the separator's position: an earlier draft had both, and a mutation run
+ * showed the position check could be deleted with every test still green,
+ * because `slice(0, 0)` is empty and the key check already rejects it.
+ *
+ * Once a tier matches, the result stands - it does not fall through to a later
+ * tier. A line whose `=` is at position 0 is malformed, not a line that meant
+ * to be split at its colon instead.
+ */
+export function splitKeyValueLine(
+	line: string,
+	tiers: SeparatorTiers,
+	{ allowBareKey = false }: SplitOptions = {}
+): { key: string; value: string } | null {
+	for (const tier of tiers) {
+		const positions = tier.map((sep) => line.indexOf(sep)).filter((i) => i !== -1);
+		if (positions.length === 0) continue;
+
+		const at = Math.min(...positions);
+		const key = line.slice(0, at).trim();
+		if (!key) return null;
+		return { key, value: line.slice(at + 1).trim() };
+	}
+
+	if (!allowBareKey) return null;
+	const key = line.trim();
+	return key ? { key, value: "" } : null;
+}

--- a/app/src/modules/request-builder/utils/params-format.test.ts
+++ b/app/src/modules/request-builder/utils/params-format.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The params bulk editor dropped two kinds of line in silence, and the panel
+ * wrote the result over the user's params either way.
+ *
+ * The old parser was `/^([^=]+)=\s*(.*)$/` - `=` or nothing:
+ *
+ *   - `Authorization: Bearer abc` has no `=`, so pasting a header block by
+ *     mistake returned `[]`, and every param the user had was replaced by
+ *     nothing. No error, no warning, same failure the Headers tab already had
+ *     fixed for itself.
+ *   - `page` matched nothing either, although `?page` is a legal valueless
+ *     parameter and `buildUrlWithParams` already emits exactly that.
+ *
+ * **Why params and headers cannot share one separator**, which is the question
+ * that turned these up: a param *name* may legally contain a colon
+ * (`filter:status=open` - JIRA, Elasticsearch, OData), a header name may not.
+ * So headers split at whichever of `:` or `=` comes first, while params must
+ * let `=` win wherever it is and consult `:` only when there is no `=` at all.
+ * The shared rule is one level up - see `kv-line.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatParamsToText, parseParamsFromText } from "./params-format";
+import type { KeyValueItem } from "../types";
+
+const pairs = (text: string) => parseParamsFromText(text).map(({ key, value }) => ({ key, value }));
+
+const items = (...kv: Array<[string, string]>): KeyValueItem[] =>
+	kv.map(([key, value], i) => ({ id: `id-${i}`, key, value, enabled: true }));
+
+describe("the format the panel tells the user to write", () => {
+	it("parses the placeholder's own example", () => {
+		// Verbatim from the ParamsPanel textarea placeholder.
+		expect(pairs("page=1\nlimit=10\nsort=name")).toEqual([
+			{ key: "page", value: "1" },
+			{ key: "limit", value: "10" },
+			{ key: "sort", value: "name" },
+		]);
+	});
+
+	it("round-trips without drift", () => {
+		const original = items(["page", "1"], ["q", "hello world"]);
+		expect(pairs(formatParamsToText(original))).toEqual([
+			{ key: "page", value: "1" },
+			{ key: "q", value: "hello world" },
+		]);
+	});
+});
+
+describe("a param name may contain a colon", () => {
+	it("splits at the equals, not the colon", () => {
+		// The line that proves params and headers cannot share a rule. Under the
+		// headers rule (first of either) this becomes `filter` / `status=open`.
+		expect(pairs("filter:status=open")).toEqual([{ key: "filter:status", value: "open" }]);
+	});
+
+	it("keeps a colon inside a value attached to it", () => {
+		expect(pairs("redirect=https://example.com/cb")).toEqual([
+			{ key: "redirect", value: "https://example.com/cb" },
+		]);
+	});
+
+	it("keeps a time value intact", () => {
+		expect(pairs("from=12:30")).toEqual([{ key: "from", value: "12:30" }]);
+	});
+});
+
+describe("a header block pasted here", () => {
+	it("parses instead of vanishing", () => {
+		// The whole failure: no `=` anywhere, so the old parser returned [] and
+		// the panel wrote that over the user's params.
+		expect(pairs("Authorization: Bearer abc\nAccept: application/json")).toEqual([
+			{ key: "Authorization", value: "Bearer abc" },
+			{ key: "Accept", value: "application/json" },
+		]);
+	});
+
+	it("still prefers the equals when a line has both", () => {
+		expect(pairs("X-Origin=https://example.com:8443")).toEqual([
+			{ key: "X-Origin", value: "https://example.com:8443" },
+		]);
+	});
+});
+
+describe("a valueless parameter", () => {
+	it("survives a round trip", () => {
+		// `?page` is legal, and `buildUrlWithParams` already emits it - so losing
+		// it here was the editor disagreeing with the thing that sends it.
+		expect(pairs("page")).toEqual([{ key: "page", value: "" }]);
+	});
+
+	it("writes back as a bare key, not `page=`", () => {
+		expect(formatParamsToText(items(["page", ""]))).toBe("page");
+	});
+
+	it("does not turn a valued param into a bare one", () => {
+		expect(formatParamsToText(items(["page", "2"]))).toBe("page=2");
+	});
+});
+
+describe("lines that name nothing", () => {
+	it.each([
+		["a leading equals", "=orphaned"],
+		["a leading colon", ": orphaned"],
+		["whitespace before the separator", "   = orphaned"],
+	])("drops %s", (_label, line) => {
+		// An empty key is a row the user can neither identify nor fix.
+		expect(pairs(line)).toEqual([]);
+	});
+
+	it("drops blank lines without dropping the rest", () => {
+		expect(pairs("page=1\n\n   \nlimit=10")).toEqual([
+			{ key: "page", value: "1" },
+			{ key: "limit", value: "10" },
+		]);
+	});
+});
+
+describe("system params", () => {
+	it("are never offered for editing", () => {
+		const withSystem: KeyValueItem[] = [
+			{ id: "1", key: "page", value: "1", enabled: true },
+			{ id: "2", key: "internal", value: "x", enabled: true, system: true },
+		];
+		expect(formatParamsToText(withSystem)).toBe("page=1");
+	});
+});

--- a/app/src/modules/request-builder/utils/params-format.ts
+++ b/app/src/modules/request-builder/utils/params-format.ts
@@ -13,25 +13,38 @@
 
 import type { KeyValueItem } from "../types";
 import { generateId } from "./id";
+import { splitKeyValueLine, PARAM_SEPARATORS } from "./kv-line";
 
 /**
  * Format params array to text format for bulk edit
  * Format: "key=value" (one per line)
  */
 export const formatParamsToText = (params: KeyValueItem[]): string => {
-	return params
-		.filter((p) => {
-			// Filter out empty params and system params
-			const hasContent = p.key.trim() || p.value.trim();
-			return hasContent && !p.system;
-		})
-		.map((p) => `${p.key}=${p.value}`)
-		.join("\n");
+	return (
+		params
+			.filter((p) => {
+				// Filter out empty params and system params
+				const hasContent = p.key.trim() || p.value.trim();
+				return hasContent && !p.system;
+			})
+			// A valueless param writes as a bare key, matching how it is sent:
+			// `buildUrlWithParams` emits `?page`, not `?page=`. Writing `page=` here
+			// round-tripped, but told the user something the request does not do.
+			.map((p) => (p.value ? `${p.key}=${p.value}` : p.key))
+			.join("\n")
+	);
 };
 
 /**
  * Parse text format to params array
- * Format: "key=value" (one per line)
+ * Format: "key=value" (one per line); "key: value" is accepted when the line
+ * carries no `=`, so a header block pasted here parses instead of vanishing.
+ *
+ * Two kinds of line used to be dropped in silence. `Authorization: Bearer abc`
+ * has no `=`, so pasting a header block returned an empty array - which the
+ * panel then wrote over the user's params. And `page`, a legal valueless
+ * parameter that `buildUrlWithParams` already emits as `?page`, matched nothing
+ * either, so bulk-editing lost it.
  *
  * @param text - Params in text format
  * @returns Array of KeyValueItem
@@ -41,18 +54,15 @@ export const parseParamsFromText = (text: string): KeyValueItem[] => {
 	const params: KeyValueItem[] = [];
 
 	lines.forEach((line) => {
-		const match = line.match(/^([^=]+)=\s*(.*)$/);
-		if (match) {
-			const key = match[1].trim();
-			const value = match[2].trim();
+		const parsed = splitKeyValueLine(line, PARAM_SEPARATORS, { allowBareKey: true });
+		if (!parsed) return;
 
-			params.push({
-				id: generateId(),
-				key,
-				value,
-				enabled: true,
-			});
-		}
+		params.push({
+			id: generateId(),
+			key: parsed.key,
+			value: parsed.value,
+			enabled: true,
+		});
 	});
 
 	return params;


### PR DESCRIPTION
First of the request-builder components, taken one at a time. This one is
`KeyValueEditor` - not a tab, but the component behind four of them: Query
Params, Headers, and Body's form-data and urlencoded modes.

Every number below is derived from the classes in the source. **Nothing here is
visually verified by me.**

## The row was 48px, in the densest table in the app

`VariableInput` is `h-9` (36px), the row added `p-1`, the stack added
`space-y-1`. Eight headers cost **384px** - beside a 24px tab band and a 40px
URL bar.

`h-8` now, the height 43 other places in the app already use, at a 36px pitch.
Same eight headers, **288px**.

## The Resolved column held a third of the table to echo its neighbours

`grid-cols-[24px_1fr_1fr_1fr_32px]` gave Key, Value and Resolved an equal
share. On a row with no variable in it - which is most rows - Resolved printed
the two cells to its left joined by `=`.

Key and Value take the whole width now. A row that *does* contain a variable
carries a marker that reveals the resolved line.

**A marker rather than bare row-hover**, for two reasons. Hovering the row would
fire underneath the variable token's own tooltip, which already answers "what
does *this* variable resolve to" - two hover surfaces in one space, one of them
invisible. And a hover with nothing on screen to announce it is not an
affordance. It sits in its own 20px column, so the grid stays aligned and rows
keep a fixed height, which is what makes a dense table scannable.

## Bulk edit was written twice

`ParamsPanel` and `HeadersPanel` each carried the same `isBulkEditMode` and
`bulkEditText` state, the same toggle handler with the same "save on the way
out, load on the way in" comment, the same toolbar row and the same textarea -
both labelled `id="bulk-edit"`, harmless only because one panel mounts at a
time.

One `BulkEditor` now. Only the format genuinely differs, so that is what the
panels pass. **Parsing stays with them**: applying the result is a headers rule
(re-impose the managed system rows) or a params rule (rewrite the URL), not a
bulk-edit one - so `BulkEditor` only ever handles text.

The draft staying local is the property worth knowing: bulk edit is a scratch
pad, and parsing on every keystroke would rewrite the request underneath a
half-finished paste.

## The instruction sentence moved into the empty state

*"Add headers to include with your request. Use `{{variable}}` for dynamic
values."* was permanent on both tabs, restating what the placeholder and the
coloured token say the moment you have a row. Useful once, furniture after -
the same shape as "Auto-saves when you click away", which came out of the
variable popover last round.

It keys off row **content**, not row count: the editor always keeps a trailing
blank, so counting rows would hide the hint exactly when it is wanted.

## The trailing-blank rule was written twice, and had drifted

`handleRemove` appended a blank when the list emptied *or* when the last row had
content; `handleUpdate` only appended when the row being edited was the last
one. Delete the second-to-last row while the last is blank and neither branch
tidied up. One `withTrailingBlank`.

## `canEdit(item, field)` is now a promise the UI keeps

The editor blocked a disallowed write inside `handleUpdate`, but the row derived
its disabled state from the **key** field alone and applied it to both inputs.
A rule permitting a value edit but not a key edit would have given you a field
you could type into that silently discarded.

**Latent, not live** - every rule today (`canEditHeaderField`) says no to both
fields together - so this is a shape fix with a test, not a behaviour change.

## Params' "Full Resolved URL" is a line, not a slab

Worth being careful about, because my first read had it wrong: it is **not**
redundant with the URL bar. The bar shows the URL *with* its `{{variables}}`;
this shows what will actually be sent. It was `p-3` under a 13px label - two
rows of chrome for one line of text - in a tab whose table is now 36px per row.

## Smaller

The column headers no longer render `keyPlaceholder`, so an empty Headers table
stops saying "Header" as a column title and "Header" again inside every field
below it.

## One guard was born broken

`/\bh-9\b/`, written through a generating script, had its word boundaries
collapse into literal backspace characters - so it matched nothing and passed
against its own mutation. Caught by mutation-checking it. It is `String.raw`
now, the same trap `no-dead-handlers.test.ts` already records.

## A correction to my own issue list

I listed "resolved text uses `--primary`, not `--primary-text`" as a
straightforward swap. It is not, and measuring proved it.

`--primary` as small text on `--card`, light mode:

| scheme | light | dark |
|---|---|---|
| sunset | **3.61** | 6.72 |
| sky | **3.71** | 9.78 |
| forest | **4.07** | 8.91 |
| ocean | 5.41 | 5.88 |
| aurora | 5.80 | 6.47 |
| coral | 4.54 | 5.79 |
| magenta | 4.91 | 6.91 |
| graphite | 4.94 | 8.31 |

Three of eight fail the 4.5 a 13px label needs. But **`--primary-text` is
declared as `var(--primary)` and only graphite overrides it**, so swapping the
class fixes nothing in the three failing schemes. The real fix is to give
sunset, sky and forest their own `--primary-text` - a design-system change
touching every accent-text surface in the app, which does not belong buried in
this PR. Filed separately.

This editor no longer paints any bare `text-primary`, so the instance I listed
is resolved incidentally by removing the column. The remaining eight live in
`AuthInheritBanner` and `InheritedScriptsNotice`, which are the Auth and Scripts
panels - later in this series.

## Verification

`pnpm type-check` (both tsconfigs), `pnpm build`, `pnpm test` - **189 files,
1447 tests**. Every new guard mutation-checked: reverted the fix, confirmed
failure, restored.

The four tests that guarded the removed Resolved column were replaced rather
than deleted - what they protected (a missing radius class, `truncate` paired
with a contradicting `overflow-x-auto`) died with the element, and what
replaced them is *when* the marker appears. A marker on every row is the old
column with extra steps; a marker on none is the feature silently gone.

**Not visually verified, on any platform.**


---

# Bulk-edit separators (added after review)

Asked whether Params and Headers should share one bulk-edit format - `key=value`
against `Name: value`. **They cannot**, and one line is the proof:

```
filter:status=open
```

A query parameter *name* may legally contain a colon (JIRA, Elasticsearch,
OData), so `:` cannot be the separator there or that splits as `filter` /
`status=open`. A header name may contain neither `:` nor `=`, so whichever comes
first is always its separator. Unify on `=` and every `Authorization: Bearer abc`
is lost; unify on first-of-either and legal param names break.

The rule they **do** share is one level up:

> the separator is the earliest character the key is not allowed to contain

which resolves differently only because the key alphabets differ. That now lives
in one `splitKeyValueLine`, with the two alphabets expressed as tiers. Headers
keep their exact behaviour - all 16 existing header tests pass untouched.

## Two silent defects the question turned up

Both on the params side, both losing user data with no feedback.

**A pasted header block vanished.** `Authorization: Bearer abc` carries no `=`,
so the old `/^([^=]+)=\s*(.*)$/` returned `[]` for the whole block - and the
panel wrote that empty array over the user's params. No error, no warning. The
Headers tab had already fixed this failure for itself; Params never got it.
Params now fall back to `:` when a line has no `=`.

**A valueless parameter was lost.** `?page` is legal and `buildUrlWithParams`
already emits exactly that, but `page` matched nothing on the way in and
`formatParamsToText` wrote `page=` on the way out - so the editor disagreed with
the code that sends the request.

| line | before | after |
|---|---|---|
| `filter:status=open` | `filter:status` \| `open` | unchanged |
| `Authorization: Bearer abc` | **dropped** | `Authorization` \| `Bearer abc` |
| `page` | **dropped** | `page` \| *(empty)* |
| `redirect=https://example.com/cb` | correct | unchanged |

Both panels' hints now describe what the parser does rather than a subset of it.

## A guard of mine was dead code

The splitter had a check rejecting a separator at position 0, with a confident
comment explaining that it stopped a later tier splitting the line somewhere
arbitrary. Deleting it left every test green - `slice(0, 0)` is empty and the
empty-key check already rejected it. Removed. The empty-key check is verified as
the load-bearing one: taking *it* out fails six tests.

## Verification

**190 files, 1462 tests.** `pnpm type-check` (both tsconfigs) and lint clean on
the touched files. Every new guard mutation-checked.
