### PR TITLE
feat(app): import Postman environment and globals exports

### DIFF
--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Importing Collections:
           - How Import Works: app/import-collections/README.md
           - Postman: app/import-collections/postman.md
+          - Postman Environment: app/import-collections/postman-environment.md
           - Insomnia v4: app/import-collections/insomnia-v4.md
           - OpenAPI 3.0: app/import-collections/openapi-v3.md
           - Swagger 2.0: app/import-collections/openapi-v2.md

--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -104,7 +104,7 @@ nav:
       - Importing Collections:
           - How Import Works: app/import-collections/README.md
           - Postman: app/import-collections/postman.md
-          - Postman Environment: app/import-collections/postman-environment.md
+          - Postman Environment and Globals: app/import-collections/postman-environment.md
           - Insomnia v4: app/import-collections/insomnia-v4.md
           - OpenAPI 3.0: app/import-collections/openapi-v3.md
           - Swagger 2.0: app/import-collections/openapi-v2.md

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ A broader comparison against k6, JMeter, and the Postman collection runner is in
 
 ## Coming from Postman, Insomnia, or an OpenAPI spec?
 
-Migrating takes seconds. Drop an existing export onto Vayu and the workspace is rebuilt as a native collection - folders, variables, auth, and pre/post-request scripts all carry across, plus environments from an Insomnia workspace. (Postman keeps environments in a separate export, which is not read.)
+Migrating takes seconds. Drop an existing export onto Vayu and the workspace is rebuilt as a native collection - folders, variables, auth, and pre/post-request scripts all carry across, plus environments - from an Insomnia workspace, or from the separate file Postman exports them as.
 
-- **Postman** - Collection v2.0 and v2.1 JSON exports
+- **Postman** - Collection v2.0 and v2.1 JSON exports, plus environment exports
 - **Insomnia** - v4 exports
 - **OpenAPI / Swagger** - 3.0 and 2.0 specs (JSON or YAML); generates a ready-to-use collection from the spec
 
@@ -87,7 +87,7 @@ Migrating takes seconds. Drop an existing export onto Vayu and the workspace is 
 - **Native load testing** - multi-worker C++ event loop sustains tens of thousands of req/s with metrics streamed over SSE in real time; no second tool needed
 - **REST + GraphQL request builder** - GET, POST, PUT, PATCH, DELETE and more; JSON, form-data, URL-encoded, raw text, and GraphQL bodies
 - **Collections & folder hierarchy** - nested collections with per-collection variables, auth, and pre/post scripts
-- **One-drop import** - Postman v2.0/v2.1, Insomnia v4, OpenAPI 3.0, Swagger 2.0
+- **One-drop import** - Postman v2.0/v2.1 and Postman environments, Insomnia v4, OpenAPI 3.0, Swagger 2.0
 - **Layered environments** - variable resolution flows from globals → collection chain → active environment, with overrides at any level
 - **Auth, the way you expect it** - Bearer token, Basic auth, API key (header or query), and OAuth 2.0 (client credentials, password, and interactive authorization code with PKCE); resolved engine-side and inherits down the collection tree
 - **Postman-compatible test scripts** - QuickJS engine implementing `pm.test()`, `pm.expect()`, `pm.environment.set()`, `pm.response.*` - most Postman scripts run unmodified
@@ -219,7 +219,7 @@ Yes. All execution happens locally. Vayu never contacts external servers during 
 No. Download, install, and use it immediately with no sign-up.
 
 **Can I import my Postman collections?**
-Yes - Postman Collection v2.0 and v2.1 JSON exports, including folders, collection variables, auth settings, and pre/post-request scripts. Postman environments live in a separate export file and are not read; Insomnia workspace environments do import.
+Yes - Postman Collection v2.0 and v2.1 JSON exports, including folders, collection variables, auth settings, and pre/post-request scripts. Postman environments live in a separate export file; drop that in too and it imports as a Vayu environment. Insomnia workspace environments import as well.
 
 **Can I import OpenAPI / Swagger specs?**
 Yes. Drop in an OpenAPI 3.0 or Swagger 2.0 file (JSON or YAML) and Vayu generates a ready-to-use collection from the spec.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A broader comparison against k6, JMeter, and the Postman collection runner is in
 
 Migrating takes seconds. Drop an existing export onto Vayu and the workspace is rebuilt as a native collection - folders, variables, auth, and pre/post-request scripts all carry across, plus environments - from an Insomnia workspace, or from the separate file Postman exports them as.
 
-- **Postman** - Collection v2.0 and v2.1 JSON exports, plus environment exports
+- **Postman** - Collection v2.0 and v2.1 JSON exports, plus environment and globals exports
 - **Insomnia** - v4 exports
 - **OpenAPI / Swagger** - 3.0 and 2.0 specs (JSON or YAML); generates a ready-to-use collection from the spec
 
@@ -87,7 +87,7 @@ Migrating takes seconds. Drop an existing export onto Vayu and the workspace is 
 - **Native load testing** - multi-worker C++ event loop sustains tens of thousands of req/s with metrics streamed over SSE in real time; no second tool needed
 - **REST + GraphQL request builder** - GET, POST, PUT, PATCH, DELETE and more; JSON, form-data, URL-encoded, raw text, and GraphQL bodies
 - **Collections & folder hierarchy** - nested collections with per-collection variables, auth, and pre/post scripts
-- **One-drop import** - Postman v2.0/v2.1 and Postman environments, Insomnia v4, OpenAPI 3.0, Swagger 2.0
+- **One-drop import** - Postman v2.0/v2.1, Postman environments and globals, Insomnia v4, OpenAPI 3.0, Swagger 2.0
 - **Layered environments** - variable resolution flows from globals → collection chain → active environment, with overrides at any level
 - **Auth, the way you expect it** - Bearer token, Basic auth, API key (header or query), and OAuth 2.0 (client credentials, password, and interactive authorization code with PKCE); resolved engine-side and inherits down the collection tree
 - **Postman-compatible test scripts** - QuickJS engine implementing `pm.test()`, `pm.expect()`, `pm.environment.set()`, `pm.response.*` - most Postman scripts run unmodified
@@ -219,7 +219,7 @@ Yes. All execution happens locally. Vayu never contacts external servers during 
 No. Download, install, and use it immediately with no sign-up.
 
 **Can I import my Postman collections?**
-Yes - Postman Collection v2.0 and v2.1 JSON exports, including folders, collection variables, auth settings, and pre/post-request scripts. Postman environments live in a separate export file; drop that in too and it imports as a Vayu environment. Insomnia workspace environments import as well.
+Yes - Postman Collection v2.0 and v2.1 JSON exports, including folders, collection variables, auth settings, and pre/post-request scripts. Postman environments live in a separate export file; drop that in too and it imports as a Vayu environment. A Postman globals export imports the same way, merging into Vayu's globals scope. Insomnia workspace environments import as well.
 
 **Can I import OpenAPI / Swagger specs?**
 Yes. Drop in an OpenAPI 3.0 or Swagger 2.0 file (JSON or YAML) and Vayu generates a ready-to-use collection from the spec.

--- a/app/src/modules/collections/ImportModal.environments.test.tsx
+++ b/app/src/modules/collections/ImportModal.environments.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A Postman environment export is the only import whose result has no
+ * collections, which puts two previously unreachable states on screen:
+ *
+ * 1. The preview tree renders environments. It only ever rendered collections,
+ *    so an environment-only import previewed as an empty box.
+ * 2. With "Import environments & variables" off, the parse yields nothing at
+ *    all. Import would have created nothing and closed the modal - a silent
+ *    no-op. It is blocked, and the toggle that recovers it is in the same footer.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+vi.mock("@/services/api", () => ({ apiService: { importFetch: vi.fn() } }));
+
+import { ImportModal } from "./ImportModal";
+import { useImportModalStore } from "@/stores";
+
+const environmentFile = readFileSync(
+	join(__dirname, "../../services/importers/__fixtures__/postman-environment.json"),
+	"utf8"
+);
+
+function renderModal() {
+	const qc = new QueryClient();
+	return render(
+		<QueryClientProvider client={qc}>
+			<ImportModal />
+		</QueryClientProvider>
+	);
+}
+
+/** Radix TabsTrigger activates on mousedown, not on a bare synthetic click. */
+function selectTab(name: RegExp) {
+	const tab = screen.getByRole("tab", { name });
+	fireEvent.mouseDown(tab);
+	fireEvent.click(tab);
+}
+
+async function pasteAndPreview(raw: string) {
+	selectTab(/Paste JSON/i);
+	fireEvent.change(screen.getByPlaceholderText(/Paste/i), { target: { value: raw } });
+	fireEvent.click(screen.getByRole("button", { name: /Detect & Preview/i }));
+	await waitFor(() => expect(screen.getByRole("button", { name: /^Import/i })).toBeVisible());
+}
+
+beforeEach(() => {
+	useImportModalStore.setState({ isOpen: true });
+});
+
+describe("ImportModal with a Postman environment export", () => {
+	it("previews the environment and its variable count", async () => {
+		renderModal();
+		await pasteAndPreview(environmentFile);
+
+		expect(screen.getByText("Postman Environment")).toBeVisible();
+		expect(screen.getByText("Sample Staging")).toBeVisible();
+		expect(screen.getByText("5 variables")).toBeVisible();
+		expect(screen.getByText(/0 requests · 0 folders · 1 environments/)).toBeVisible();
+	});
+
+	it("keeps Import enabled - an environment-only import is a real import", async () => {
+		renderModal();
+		await pasteAndPreview(environmentFile);
+
+		expect(screen.getByRole("button", { name: /^Import/i })).toBeEnabled();
+	});
+
+	it("blocks Import and says why once environments are excluded", async () => {
+		renderModal();
+		await pasteAndPreview(environmentFile);
+
+		fireEvent.click(screen.getByLabelText(/Import environments/i));
+
+		expect(screen.getByRole("button", { name: /^Import/i })).toBeDisabled();
+		expect(screen.getByText(/No collections in this file/i)).toBeVisible();
+		expect(screen.queryByText("Sample Staging")).toBeNull();
+	});
+
+	it("recovers when the option is turned back on", async () => {
+		renderModal();
+		await pasteAndPreview(environmentFile);
+
+		const envs = screen.getByLabelText(/Import environments/i);
+		fireEvent.click(envs);
+		fireEvent.click(envs);
+
+		expect(screen.getByRole("button", { name: /^Import/i })).toBeEnabled();
+		expect(screen.getByText("Sample Staging")).toBeVisible();
+		expect(screen.queryByText(/No collections in this file/i)).toBeNull();
+	});
+});

--- a/app/src/modules/collections/ImportModal.environments.test.tsx
+++ b/app/src/modules/collections/ImportModal.environments.test.tsx
@@ -35,6 +35,11 @@ const environmentFile = readFileSync(
 	"utf8"
 );
 
+const globalsFile = readFileSync(
+	join(__dirname, "../../services/importers/__fixtures__/postman-globals.json"),
+	"utf8"
+);
+
 function renderModal() {
 	const qc = new QueryClient();
 	return render(
@@ -102,5 +107,53 @@ describe("ImportModal with a Postman environment export", () => {
 		expect(screen.getByRole("button", { name: /^Import/i })).toBeEnabled();
 		expect(screen.getByText("Sample Staging")).toBeVisible();
 		expect(screen.queryByText(/No collections in this file/i)).toBeNull();
+	});
+});
+
+/**
+ * A globals export produces neither collections nor environments - only the
+ * `globals` record - so every count-driven surface has to read that field too or
+ * the preview reports an empty import for a file that will write four variables.
+ */
+describe("ImportModal with a Postman globals export", () => {
+	it("previews the globals destination and its variable count", async () => {
+		renderModal();
+		await pasteAndPreview(globalsFile);
+
+		expect(screen.getByText("Postman Globals")).toBeVisible();
+		// Named for the destination scope, not the workspace the file came from.
+		expect(screen.getByText("Globals")).toBeVisible();
+		expect(screen.queryByText("Sample Workspace Globals")).toBeNull();
+		expect(screen.getByText("4 variables")).toBeVisible();
+		expect(screen.getByText(/0 environments · 4 globals/)).toBeVisible();
+	});
+
+	it("keeps Import enabled - a globals-only import is a real import", async () => {
+		renderModal();
+		await pasteAndPreview(globalsFile);
+
+		expect(screen.getByRole("button", { name: /^Import/i })).toBeEnabled();
+		expect(screen.queryByText(/Nothing to import/i)).toBeNull();
+	});
+
+	it("states that existing globals survive the merge", async () => {
+		renderModal();
+		await pasteAndPreview(globalsFile);
+
+		expect(screen.getByText(/Existing globals are kept/i)).toBeVisible();
+	});
+
+	it("blocks Import once variables are excluded, and recovers", async () => {
+		renderModal();
+		await pasteAndPreview(globalsFile);
+
+		const envs = screen.getByLabelText(/Import environments/i);
+		fireEvent.click(envs);
+		expect(screen.getByRole("button", { name: /^Import/i })).toBeDisabled();
+		expect(screen.queryByText("4 variables")).toBeNull();
+
+		fireEvent.click(envs);
+		expect(screen.getByRole("button", { name: /^Import/i })).toBeEnabled();
+		expect(screen.getByText("4 variables")).toBeVisible();
 	});
 });

--- a/app/src/modules/collections/ImportModal.surface-rule.test.tsx
+++ b/app/src/modules/collections/ImportModal.surface-rule.test.tsx
@@ -151,7 +151,7 @@ describe("the import dialog declares its surfaces", () => {
 		await openPreview();
 		// The detected-collections slab is the same surface as the drop zone and
 		// gets the same declaration.
-		const slab = screen.getByText(/Acme API/).closest(".surface-sunken");
+		const slab = screen.getByText(/Sample API/).closest(".surface-sunken");
 		expect(slab, "the preview tree should sit on a declared sunken surface").toBeTruthy();
 		// The footer divider only mounts in the preview phase - re-run the
 		// invisible-token scan with it on screen.

--- a/app/src/modules/collections/ImportModal.test.tsx
+++ b/app/src/modules/collections/ImportModal.test.tsx
@@ -50,7 +50,7 @@ describe("ImportModal", () => {
 		await waitFor(() =>
 			expect(screen.getByText(/Postman Collection v2.1/i)).toBeInTheDocument()
 		);
-		expect(screen.getByText(/Acme API/)).toBeInTheDocument();
+		expect(screen.getByText(/Sample API/)).toBeInTheDocument();
 		expect(screen.getByText(/2 requests/)).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /^Import/i })).toBeInTheDocument();
 	});

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useRef, useState } from "react";
-import { Upload, CheckCircle2, X, Folder, AlertTriangle } from "lucide-react";
+import { Upload, CheckCircle2, X, Folder, Layers, AlertTriangle } from "lucide-react";
 import {
 	Button,
 	Dialog,
@@ -31,7 +31,14 @@ import { MethodBadge } from "@/components/shared";
 type Tab = "file" | "url" | "paste";
 type Phase = "idle" | "detecting" | "preview" | "error";
 
-const FORMAT_BADGES = ["Postman v2.1", "Postman v2.0", "Insomnia v4", "OpenAPI 3.0", "OpenAPI 2.0"];
+const FORMAT_BADGES = [
+	"Postman v2.1",
+	"Postman v2.0",
+	"Postman Env",
+	"Insomnia v4",
+	"OpenAPI 3.0",
+	"OpenAPI 2.0",
+];
 
 export function ImportModal() {
 	const { isOpen, close } = useImportModalStore();
@@ -136,6 +143,13 @@ export function ImportModal() {
 		}
 	};
 
+	// A Postman *environment* export parses to a result with no collections, and the
+	// options are applied at parse time - so with "Import environments & variables"
+	// off the whole result is empty and Import would create nothing and close the
+	// modal. Block it instead; the toggle that recovers it sits in the same footer.
+	const nothingToImport =
+		!!result && result.collections.length === 0 && result.environments.length === 0;
+
 	const toggleEnvironments = (v: boolean) => {
 		setImportEnvironments(v);
 		redetect({ importEnvironments: v, importScripts });
@@ -150,7 +164,11 @@ export function ImportModal() {
 	const panelBody = (
 		<>
 			{phase === "preview" && result ? (
-				<PreviewView result={result} onDismiss={reset} />
+				<PreviewView
+					result={result}
+					importEnvironments={importEnvironments}
+					onDismiss={reset}
+				/>
 			) : (
 				<>
 					{tab === "file" && (
@@ -386,7 +404,10 @@ export function ImportModal() {
 							>
 								Cancel
 							</Button>
-							<Button onClick={handleImport} disabled={importMutation.isPending}>
+							<Button
+								onClick={handleImport}
+								disabled={importMutation.isPending || nothingToImport}
+							>
 								{importMutation.isPending ? "Importing…" : "Import →"}
 							</Button>
 						</div>
@@ -397,8 +418,16 @@ export function ImportModal() {
 	);
 }
 
-function PreviewView({ result, onDismiss }: { result: ImportResult; onDismiss: () => void }) {
-	const { meta, collections } = result;
+function PreviewView({
+	result,
+	importEnvironments,
+	onDismiss,
+}: {
+	result: ImportResult;
+	importEnvironments: boolean;
+	onDismiss: () => void;
+}) {
+	const { meta, collections, environments } = result;
 	return (
 		<div className="space-y-3">
 			<div className="flex items-center gap-2 rounded-md border border-status-success/20 bg-status-success/10 px-3 py-2">
@@ -421,11 +450,35 @@ function PreviewView({ result, onDismiss }: { result: ImportResult; onDismiss: (
 				{collections.map((c, i) => (
 					<TreeNode key={i} name={c.name} requests={c.requests} children={c.children} />
 				))}
+				{/*
+				 * Environments were parsed but never shown. For a Postman environment
+				 * export they are the entire import, so the box rendered empty.
+				 */}
+				{environments.map((e, i) => (
+					<div
+						key={i}
+						className="flex items-center gap-1.5 py-0.5 pl-1 text-xs font-medium"
+					>
+						<Layers className="h-3.5 w-3.5 text-primary" />
+						{e.name}
+						<span className="text-[11px] font-normal text-muted-foreground">
+							{varCountLabel(Object.keys(e.variables).length)}
+						</span>
+					</div>
+				))}
 			</div>
 			<p className="text-[11px] text-muted-foreground">
 				{meta.requestCount} requests · {meta.folderCount} folders · {meta.environmentCount}{" "}
 				environments
 			</p>
+			{collections.length === 0 && environments.length === 0 && (
+				<p className="flex items-center gap-1.5 text-[11px] text-destructive-text">
+					<AlertTriangle className="h-3.5 w-3.5" />
+					{importEnvironments
+						? "Nothing to import from this file."
+						: "No collections in this file. Enable Import environments & variables below to import its environments."}
+				</p>
+			)}
 			{(meta.skipped.length > 0 || meta.nonExecutableAuth > 0) && (
 				<p className="flex items-center gap-1.5 text-[11px] text-destructive-text">
 					<AlertTriangle className="h-3.5 w-3.5" />
@@ -439,6 +492,10 @@ function PreviewView({ result, onDismiss }: { result: ImportResult; onDismiss: (
 			)}
 		</div>
 	);
+}
+
+function varCountLabel(n: number): string {
+	return `${n} ${n === 1 ? "variable" : "variables"}`;
 }
 
 function TreeNode({

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useRef, useState } from "react";
-import { Upload, CheckCircle2, X, Folder, Layers, AlertTriangle } from "lucide-react";
+import { Upload, CheckCircle2, X, Folder, Layers, Globe, AlertTriangle } from "lucide-react";
 import {
 	Button,
 	Dialog,
@@ -35,6 +35,7 @@ const FORMAT_BADGES = [
 	"Postman v2.1",
 	"Postman v2.0",
 	"Postman Env",
+	"Postman Globals",
 	"Insomnia v4",
 	"OpenAPI 3.0",
 	"OpenAPI 2.0",
@@ -143,12 +144,16 @@ export function ImportModal() {
 		}
 	};
 
-	// A Postman *environment* export parses to a result with no collections, and the
-	// options are applied at parse time - so with "Import environments & variables"
-	// off the whole result is empty and Import would create nothing and close the
-	// modal. Block it instead; the toggle that recovers it sits in the same footer.
+	// A Postman *environment* or *globals* export parses to a result with no
+	// collections, and the options are applied at parse time - so with "Import
+	// environments & variables" off the whole result is empty and Import would create
+	// nothing and close the modal. Block it instead; the toggle that recovers it sits
+	// in the same footer.
 	const nothingToImport =
-		!!result && result.collections.length === 0 && result.environments.length === 0;
+		!!result &&
+		result.collections.length === 0 &&
+		result.environments.length === 0 &&
+		Object.keys(result.globals).length === 0;
 
 	const toggleEnvironments = (v: boolean) => {
 		setImportEnvironments(v);
@@ -427,7 +432,8 @@ function PreviewView({
 	importEnvironments: boolean;
 	onDismiss: () => void;
 }) {
-	const { meta, collections, environments } = result;
+	const { meta, collections, environments, globals } = result;
+	const globalCount = Object.keys(globals).length;
 	return (
 		<div className="space-y-3">
 			<div className="flex items-center gap-2 rounded-md border border-status-success/20 bg-status-success/10 px-3 py-2">
@@ -466,17 +472,35 @@ function PreviewView({
 						</span>
 					</div>
 				))}
+				{/*
+				 * Globals have no name of their own - they are a singleton scope, not a
+				 * named environment - so the row names the destination rather than the file.
+				 */}
+				{globalCount > 0 && (
+					<div className="flex items-center gap-1.5 py-0.5 pl-1 text-xs font-medium">
+						<Globe className="h-3.5 w-3.5 text-primary" />
+						Globals
+						<span className="text-[11px] font-normal text-muted-foreground">
+							{varCountLabel(globalCount)}
+						</span>
+					</div>
+				)}
 			</div>
 			<p className="text-[11px] text-muted-foreground">
 				{meta.requestCount} requests · {meta.folderCount} folders · {meta.environmentCount}{" "}
-				environments
+				environments · {meta.globalCount} globals
 			</p>
-			{collections.length === 0 && environments.length === 0 && (
+			{collections.length === 0 && environments.length === 0 && globalCount === 0 && (
 				<p className="flex items-center gap-1.5 text-[11px] text-destructive-text">
 					<AlertTriangle className="h-3.5 w-3.5" />
 					{importEnvironments
 						? "Nothing to import from this file."
 						: "No collections in this file. Enable Import environments & variables below to import its environments."}
+				</p>
+			)}
+			{globalCount > 0 && (
+				<p className="text-[11px] text-muted-foreground">
+					Existing globals are kept; a variable of the same name is overwritten.
 				</p>
 			)}
 			{(meta.skipped.length > 0 || meta.nonExecutableAuth > 0) && (

--- a/app/src/queries/import.test.ts
+++ b/app/src/queries/import.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/services/api", () => ({
@@ -7,11 +10,18 @@ vi.mock("@/services/api", () => ({
 		createEnvironment: vi.fn(async (d) => ({ id: d.id })),
 		deleteCollection: vi.fn(async () => {}),
 		deleteEnvironment: vi.fn(async () => {}),
+		getGlobals: vi.fn(async () => ({ id: "globals", variables: {}, updatedAt: "0" })),
+		updateGlobals: vi.fn(async (variables) => ({ id: "globals", variables, updatedAt: "1" })),
 	},
 }));
 
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
 import { apiService } from "@/services/api";
-import { createImportApi } from "./import";
+import { createImportApi, useImportMutation } from "./import";
+import { queryKeys } from "./keys";
+import type { ImportResult } from "@/services/importers/types";
 
 describe("createImportApi", () => {
 	beforeEach(() => vi.clearAllMocks());
@@ -28,10 +38,56 @@ describe("createImportApi", () => {
 		await api.createEnvironment({ id: "env_1", name: "e", variables: {} } as any);
 		await api.deleteCollection("col_1");
 		await api.deleteEnvironment("env_1");
+		await api.getGlobals();
+		await api.updateGlobals({ a: { value: "1", enabled: true } });
 		expect(apiService.createCollection).toHaveBeenCalled();
 		expect(apiService.createRequest).toHaveBeenCalled();
 		expect(apiService.createEnvironment).toHaveBeenCalled();
 		expect(apiService.deleteCollection).toHaveBeenCalledWith("col_1");
 		expect(apiService.deleteEnvironment).toHaveBeenCalledWith("env_1");
+		expect(apiService.getGlobals).toHaveBeenCalled();
+		expect(apiService.updateGlobals).toHaveBeenCalledWith({ a: { value: "1", enabled: true } });
+	});
+});
+
+describe("useImportMutation", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	/**
+	 * A globals import writes the singleton on the engine. Without an invalidation
+	 * the imported variables sit there unread until the next reload - the
+	 * "written but never read" shape CLAUDE.md warns about.
+	 */
+	it("invalidates the globals cache after an import", async () => {
+		const qc = new QueryClient();
+		const spy = vi.spyOn(qc, "invalidateQueries");
+		const wrapper = ({ children }: { children: ReactNode }) =>
+			createElement(QueryClientProvider, { client: qc }, children);
+
+		const { result } = renderHook(() => useImportMutation(), { wrapper });
+
+		const importResult: ImportResult = {
+			collections: [],
+			environments: [],
+			globals: { token: { value: "t", enabled: true } },
+			meta: {
+				format: "Postman Globals",
+				requestCount: 0,
+				folderCount: 0,
+				environmentCount: 0,
+				globalCount: 1,
+				skipped: [],
+				nonExecutableAuth: 0,
+			},
+		};
+		await result.current.mutateAsync({
+			result: importResult,
+			opts: { importEnvironments: true, importScripts: true },
+		});
+
+		await waitFor(() => expect(spy).toHaveBeenCalledWith({ queryKey: queryKeys.globals.all }));
+		expect(apiService.updateGlobals).toHaveBeenCalledWith({
+			token: { value: "t", enabled: true },
+		});
 	});
 });

--- a/app/src/queries/import.ts
+++ b/app/src/queries/import.ts
@@ -20,6 +20,8 @@ export function createImportApi(): ImportApi {
 		createEnvironment: (d) => apiService.createEnvironment(d),
 		deleteCollection: (id) => apiService.deleteCollection(id),
 		deleteEnvironment: (id) => apiService.deleteEnvironment(id),
+		getGlobals: () => apiService.getGlobals(),
+		updateGlobals: (variables) => apiService.updateGlobals(variables),
 	};
 }
 
@@ -34,6 +36,9 @@ export function useImportMutation() {
 			queryClient.invalidateQueries({ queryKey: queryKeys.collections.all });
 			queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
 			queryClient.invalidateQueries({ queryKey: queryKeys.requests.all });
+			// A Postman globals export writes the globals singleton; without this the
+			// imported variables sit on the engine unread until the next reload.
+			queryClient.invalidateQueries({ queryKey: queryKeys.globals.all });
 		},
 	});
 }

--- a/app/src/services/importers/__fixtures__/postman-environment.json
+++ b/app/src/services/importers/__fixtures__/postman-environment.json
@@ -1,0 +1,45 @@
+{
+	"id": "8f1c2a44-9c3e-4b0d-9f2a-1d7e5b6c0a11",
+	"name": "Sample Staging",
+	"values": [
+		{
+			"key": "baseUrl",
+			"value": "https://staging.api.example.com",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "apiKey",
+			"value": "test-api-key-1",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "emptySecret",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "legacyHost",
+			"value": "old.example.com",
+			"type": "default",
+			"enabled": false
+		},
+		{
+			"key": "greeting",
+			"value": "hello {{ user.name }}",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "",
+			"value": "dropped - no key",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2026-07-27T06:00:00.000Z",
+	"_postman_exported_using": "Postman/11.62.3"
+}

--- a/app/src/services/importers/__fixtures__/postman-globals.json
+++ b/app/src/services/importers/__fixtures__/postman-globals.json
@@ -1,0 +1,33 @@
+{
+	"id": "3c9d7e21-5a48-4f16-b8c2-6e0f9a4d2b73",
+	"name": "Sample Workspace Globals",
+	"values": [
+		{
+			"key": "apiHost",
+			"value": "https://api.example.com",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "sharedToken",
+			"value": "test-shared-token-1",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "retiredFlag",
+			"value": "off",
+			"type": "default",
+			"enabled": false
+		},
+		{
+			"key": "banner",
+			"value": "welcome {{ tenant }}",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "globals",
+	"_postman_exported_at": "2026-07-28T09:00:00.000Z",
+	"_postman_exported_using": "Postman/11.62.3"
+}

--- a/app/src/services/importers/__fixtures__/postman-v20.json
+++ b/app/src/services/importers/__fixtures__/postman-v20.json
@@ -8,7 +8,7 @@
 			"name": "Get thing",
 			"request": {
 				"method": "GET",
-				"url": "https://api.legacy.com/things?id=5",
+				"url": "https://legacy.example.com/things?id=5",
 				"auth": { "type": "bearer", "bearer": { "token": "LEGACY" } }
 			}
 		}

--- a/app/src/services/importers/__fixtures__/postman-v21.json
+++ b/app/src/services/importers/__fixtures__/postman-v21.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"name": "Acme API",
+		"name": "Sample API",
 		"description": "Demo",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
-	"variable": [{ "key": "baseUrl", "value": "https://api.acme.com" }],
+	"variable": [{ "key": "baseUrl", "value": "https://api.example.com" }],
 	"auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{token}}" }] },
 	"event": [{ "listen": "prerequest", "script": { "exec": ["console.log('pre')"] } }],
 	"item": [

--- a/app/src/services/importers/assign-ids.test.ts
+++ b/app/src/services/importers/assign-ids.test.ts
@@ -41,11 +41,13 @@ function fixture(): ImportResult {
 			},
 		],
 		environments: [{ name: "e", description: "", variables: {} }],
+		globals: {},
 		meta: {
 			format: "x",
 			requestCount: 1,
 			folderCount: 1,
 			environmentCount: 1,
+			globalCount: 0,
 			skipped: [],
 			nonExecutableAuth: 0,
 		},

--- a/app/src/services/importers/factory.test.ts
+++ b/app/src/services/importers/factory.test.ts
@@ -31,10 +31,13 @@ describe("parseImport", () => {
 			"Postman Collection v2.1"
 		);
 	});
-	it("leaves a Postman globals export unrecognised", () => {
-		expect(() =>
-			parseImport('{"_postman_variable_scope":"globals","values":[]}', opts)
-		).toThrow(UnrecognisedFormatError);
+	it("routes a Postman globals export, reporting it as its own format", () => {
+		const r = parseImport(fx("postman-globals.json"), opts);
+		expect(r.meta.format).toBe("Postman Globals");
+		// Same parser as the environment export, but the variables land in the
+		// globals scope rather than becoming a named environment.
+		expect(r.environments).toHaveLength(0);
+		expect(Object.keys(r.globals)).toContain("apiHost");
 	});
 	it("routes Insomnia v4", () => {
 		expect(parseImport(fx("insomnia-v4.json"), opts).meta.format).toBe("Insomnia Export v4");

--- a/app/src/services/importers/factory.test.ts
+++ b/app/src/services/importers/factory.test.ts
@@ -18,6 +18,24 @@ describe("parseImport", () => {
 			"Postman Collection v2.0"
 		);
 	});
+	it("routes a Postman environment export", () => {
+		const r = parseImport(fx("postman-environment.json"), opts);
+		expect(r.meta.format).toBe("Postman Environment");
+		expect(r.collections).toEqual([]);
+		expect(r.environments).toHaveLength(1);
+	});
+	it("still routes a Postman collection to the collection parser", () => {
+		// The environment detector sits between v2.0 and Insomnia; a collection
+		// export must not fall through to it.
+		expect(parseImport(fx("postman-v21.json"), opts).meta.format).toBe(
+			"Postman Collection v2.1"
+		);
+	});
+	it("leaves a Postman globals export unrecognised", () => {
+		expect(() =>
+			parseImport('{"_postman_variable_scope":"globals","values":[]}', opts)
+		).toThrow(UnrecognisedFormatError);
+	});
 	it("routes Insomnia v4", () => {
 		expect(parseImport(fx("insomnia-v4.json"), opts).meta.format).toBe("Insomnia Export v4");
 	});

--- a/app/src/services/importers/factory.ts
+++ b/app/src/services/importers/factory.ts
@@ -9,6 +9,7 @@ import yaml from "js-yaml";
 import type { ImportOptions, ImportParser, ImportResult } from "./types";
 import { UnrecognisedFormatError } from "./types";
 import { PostmanV21Parser, PostmanV20Parser } from "./postman";
+import { PostmanEnvironmentParser } from "./postman-environment";
 import { InsomniaV4Parser } from "./insomnia-v4";
 import { OpenApiV3Parser } from "./openapi-v3";
 import { OpenApiV2Parser } from "./openapi-v2";
@@ -17,6 +18,9 @@ import { OpenApiV2Parser } from "./openapi-v2";
 const PARSERS: ImportParser[] = [
 	new PostmanV21Parser(),
 	new PostmanV20Parser(),
+	// An environment export carries neither `info` nor `item[]`, so v2.0's
+	// permissive fallback branch cannot claim it and this position is not load-bearing.
+	new PostmanEnvironmentParser(),
 	new InsomniaV4Parser(),
 	new OpenApiV3Parser(),
 	new OpenApiV2Parser(),

--- a/app/src/services/importers/insomnia-v4.ts
+++ b/app/src/services/importers/insomnia-v4.ts
@@ -243,11 +243,13 @@ export class InsomniaV4Parser implements ImportParser {
 		return {
 			collections,
 			environments,
+			globals: {}, // Insomnia has no globals scope; workspace envs map to environments
 			meta: {
 				format: this.formatName,
 				requestCount,
 				folderCount,
 				environmentCount: environments.length,
+				globalCount: 0,
 				skipped,
 				nonExecutableAuth: authCtx.nonExec,
 			},

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -109,11 +109,13 @@ export class OpenApiV2Parser implements ImportParser {
 		return {
 			collections: [root],
 			environments: [],
+			globals: {}, // a spec has no environment or globals concept
 			meta: {
 				format: this.formatName,
 				requestCount,
 				folderCount: tagCollections.size,
 				environmentCount: 0,
+				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
 			},

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -97,11 +97,13 @@ export class OpenApiV3Parser implements ImportParser {
 		return {
 			collections: [root],
 			environments: [],
+			globals: {}, // a spec has no environment or globals concept
 			meta: {
 				format: this.formatName,
 				requestCount,
 				folderCount: tagCollections.size,
 				environmentCount: 0,
+				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
 			},

--- a/app/src/services/importers/orchestrator.test.ts
+++ b/app/src/services/importers/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { ImportOrchestrator, type ImportApi } from "./orchestrator";
 import { assignIds } from "./assign-ids";
+import type { Collection, Environment, VariableValue } from "@/types";
 import type { ImportResult } from "./types";
 
 function fakeApi(overrides: Partial<ImportApi> = {}): { api: ImportApi; calls: any } {
@@ -10,6 +11,8 @@ function fakeApi(overrides: Partial<ImportApi> = {}): { api: ImportApi; calls: a
 		environments: [] as any[],
 		deletedCols: [] as string[],
 		deletedEnvs: [] as string[],
+		globalsRead: 0,
+		globalsWritten: [] as Record<string, unknown>[],
 	};
 	const api: ImportApi = {
 		createCollection: vi.fn(async (d) => {
@@ -29,6 +32,14 @@ function fakeApi(overrides: Partial<ImportApi> = {}): { api: ImportApi; calls: a
 		}),
 		deleteEnvironment: vi.fn(async (id) => {
 			calls.deletedEnvs.push(id);
+		}),
+		getGlobals: vi.fn(async () => {
+			calls.globalsRead++;
+			return { id: "globals", variables: {}, updatedAt: "0" };
+		}),
+		updateGlobals: vi.fn(async (variables) => {
+			calls.globalsWritten.push(variables);
+			return { id: "globals", variables, updatedAt: "1" };
 		}),
 		...overrides,
 	};
@@ -89,11 +100,13 @@ function fixture(): ImportResult {
 		environments: [
 			{ name: "Prod", description: "d", variables: { a: { value: "1", enabled: true } } },
 		],
+		globals: {},
 		meta: {
 			format: "x",
 			requestCount: 2,
 			folderCount: 1,
 			environmentCount: 1,
+			globalCount: 0,
 			skipped: [],
 			nonExecutableAuth: 0,
 		},
@@ -157,11 +170,13 @@ describe("ImportOrchestrator", () => {
 				},
 			],
 			environments: [{ name: "e", description: "", variables: {} }],
+			globals: {},
 			meta: {
 				format: "x",
 				requestCount: 0,
 				folderCount: 1,
 				environmentCount: 1,
+				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
 			},
@@ -228,11 +243,13 @@ describe("ImportOrchestrator", () => {
 				},
 			],
 			environments: [],
+			globals: {},
 			meta: {
 				format: "x",
 				requestCount: 2,
 				folderCount: 2,
 				environmentCount: 0,
+				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
 			},
@@ -241,5 +258,121 @@ describe("ImportOrchestrator", () => {
 		expect(calls.deletedCols).toContain(result.collections[0].id);
 		expect(calls.deletedCols).toContain(result.collections[1].id);
 		expect(calls.deletedCols).toHaveLength(2);
+	});
+
+	describe("globals", () => {
+		/** A globals-only result, the shape a Postman globals export parses to. */
+		function globalsFixture(globals: Record<string, VariableValue>): ImportResult {
+			return assignIds({
+				collections: [],
+				environments: [],
+				globals,
+				meta: {
+					format: "Postman Globals",
+					requestCount: 0,
+					folderCount: 0,
+					environmentCount: 0,
+					globalCount: Object.keys(globals).length,
+					skipped: [],
+					nonExecutableAuth: 0,
+				},
+			});
+		}
+
+		it("merges into the existing set rather than replacing it", async () => {
+			// POST /globals replaces everything, so a write that is not a merge would
+			// delete `keep` - the whole reason applyGlobals reads first.
+			const { api, calls } = fakeApi({
+				getGlobals: vi.fn(async () => ({
+					id: "globals",
+					variables: { keep: { value: "old", enabled: true } },
+					updatedAt: "0",
+				})),
+			});
+			await new ImportOrchestrator(api).run(
+				globalsFixture({ fresh: { value: "new", enabled: true } }),
+				opts
+			);
+			expect(calls.globalsWritten).toHaveLength(1);
+			expect(calls.globalsWritten[0]).toEqual({
+				keep: { value: "old", enabled: true },
+				fresh: { value: "new", enabled: true },
+			});
+		});
+
+		it("lets the imported value win a name collision", async () => {
+			const { api, calls } = fakeApi({
+				getGlobals: vi.fn(async () => ({
+					id: "globals",
+					variables: { token: { value: "old", enabled: true } },
+					updatedAt: "0",
+				})),
+			});
+			await new ImportOrchestrator(api).run(
+				globalsFixture({ token: { value: "imported", enabled: true } }),
+				opts
+			);
+			expect(calls.globalsWritten[0].token).toEqual({ value: "imported", enabled: true });
+		});
+
+		it("neither reads nor writes globals when the result has none", async () => {
+			// Every other format lands here; an import must not touch the globals scope.
+			const { api, calls } = fakeApi();
+			await new ImportOrchestrator(api).run(fixture(), opts);
+			expect(calls.globalsRead).toBe(0);
+			expect(calls.globalsWritten).toHaveLength(0);
+		});
+
+		it("skips globals when importEnvironments=false", async () => {
+			const { api, calls } = fakeApi();
+			await new ImportOrchestrator(api).run(
+				globalsFixture({ a: { value: "1", enabled: true } }),
+				{ ...opts, importEnvironments: false }
+			);
+			expect(calls.globalsRead).toBe(0);
+			expect(calls.globalsWritten).toHaveLength(0);
+		});
+
+		it("rolls back created collections when the globals write fails", async () => {
+			const { api, calls } = fakeApi({
+				updateGlobals: vi.fn(async () => {
+					throw new Error("globals boom");
+				}),
+			});
+			const result = fixture();
+			result.globals = { g: { value: "1", enabled: true } };
+			result.meta.globalCount = 1;
+			await expect(new ImportOrchestrator(api).run(result, opts)).rejects.toThrow(
+				"globals boom"
+			);
+			expect(calls.deletedCols).toContain(result.collections[0].id);
+			expect(calls.deletedEnvs).toHaveLength(1);
+		});
+
+		it("writes globals only after collections and environments exist", async () => {
+			// Ordering is load-bearing: globals is the one write that can destroy data the
+			// import did not create, so nothing may fail behind it.
+			const order: string[] = [];
+			const { api } = fakeApi({
+				createCollection: vi.fn(async (d) => {
+					order.push("collection");
+					return { id: d.id } as Collection;
+				}),
+				createEnvironment: vi.fn(async (d) => {
+					order.push("environment");
+					return { id: d.id } as Environment;
+				}),
+				updateGlobals: vi.fn(async (variables) => {
+					order.push("globals");
+					return { id: "globals", variables, updatedAt: "1" };
+				}),
+			});
+			const result = fixture();
+			result.globals = { g: { value: "1", enabled: true } };
+			await new ImportOrchestrator(api).run(result, opts);
+			expect(order[order.length - 1]).toBe("globals");
+			expect(order.indexOf("collection")).toBeLessThan(order.indexOf("globals"));
+			expect(order.indexOf("environment")).toBeLessThan(order.indexOf("globals"));
+		});
 	});
 });

--- a/app/src/services/importers/orchestrator.ts
+++ b/app/src/services/importers/orchestrator.ts
@@ -8,7 +8,9 @@
 import type {
 	Collection,
 	Environment,
+	GlobalVariables,
 	Request,
+	VariableValue,
 	CreateCollectionRequest,
 	CreateRequestRequest,
 	CreateEnvironmentRequest,
@@ -22,6 +24,8 @@ export interface ImportApi {
 	createEnvironment(data: CreateEnvironmentRequest & { id: string }): Promise<Environment>;
 	deleteCollection(id: string): Promise<void>;
 	deleteEnvironment(id: string): Promise<void>;
+	getGlobals(): Promise<GlobalVariables>;
+	updateGlobals(variables: Record<string, VariableValue>): Promise<GlobalVariables>;
 }
 
 export class ImportOrchestrator {
@@ -54,10 +58,34 @@ export class ImportOrchestrator {
 					this.createdEnvIds.push(env.id!);
 				}
 			}
+			// Globals last, and deliberately so: `POST /globals` **replaces** the whole
+			// set, so it is the one write here that can destroy data the import did not
+			// create. Running it after everything else means nothing can fail behind it,
+			// so a failed import never leaves the user's globals half-rewritten and
+			// rollback has no globals case to restore. Do not reorder without adding one.
+			await this.applyGlobals(result, opts);
 		} catch (err) {
 			await this.rollback();
 			throw err;
 		}
+	}
+
+	/**
+	 * Merge imported globals into the existing set. The engine has no merge verb -
+	 * a POST replaces everything - so the union is computed here from a fresh read.
+	 * Writing `result.globals` alone would silently delete every global the user
+	 * already had.
+	 *
+	 * On a key collision the imported value wins: the user explicitly asked for this
+	 * file's variables, and skipping them would be the silent no-op the issue calls
+	 * the worst outcome. Documented in `docs/app/import-collections/postman-environment.md`.
+	 */
+	private async applyGlobals(result: ImportResult, opts: ImportOptions): Promise<void> {
+		if (!opts.importEnvironments) return;
+		// No read, no write - every other format lands here and must not touch the scope.
+		if (Object.keys(result.globals).length === 0) return;
+		const existing = await this.api.getGlobals();
+		await this.api.updateGlobals({ ...existing.variables, ...result.globals });
 	}
 
 	/** Create this collection, then its requests, then recurse into children. */

--- a/app/src/services/importers/postman-environment.test.ts
+++ b/app/src/services/importers/postman-environment.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PostmanEnvironmentParser } from "./postman-environment";
+
+const raw = readFileSync(join(__dirname, "__fixtures__/postman-environment.json"), "utf8");
+const parsed = JSON.parse(raw);
+const opts = { importEnvironments: true, importScripts: true };
+
+describe("PostmanEnvironmentParser", () => {
+	const p = new PostmanEnvironmentParser();
+
+	describe("detect", () => {
+		it("claims an environment export", () => {
+			expect(p.detect(parsed, raw)).toBe(true);
+		});
+
+		it("ignores a globals export - Vayu's globals scope is a separate decision", () => {
+			expect(p.detect({ _postman_variable_scope: "globals", values: [] }, "")).toBe(false);
+		});
+
+		it("needs a values array, not just the scope marker", () => {
+			expect(p.detect({ _postman_variable_scope: "environment" }, "")).toBe(false);
+			expect(p.detect({ _postman_variable_scope: "environment", values: {} }, "")).toBe(
+				false
+			);
+		});
+
+		it("does not claim a collection export", () => {
+			expect(p.detect({ info: { schema: "v2.1.0" }, item: [] }, "")).toBe(false);
+		});
+
+		it("survives a non-object document", () => {
+			expect(p.detect(null, "")).toBe(false);
+			expect(p.detect(42, "")).toBe(false);
+		});
+	});
+
+	describe("parse", () => {
+		it("produces one environment named after the file, and no collections", () => {
+			const r = p.parse(parsed, raw, opts);
+			expect(r.collections).toEqual([]);
+			expect(r.environments).toHaveLength(1);
+			expect(r.environments[0].name).toBe("Sample Staging");
+			expect(r.environments[0].description).toBe("");
+		});
+
+		it("carries value, enabled state and the secret flag", () => {
+			const vars = p.parse(parsed, raw, opts).environments[0].variables;
+			expect(vars.baseUrl).toEqual({
+				value: "https://staging.api.example.com",
+				enabled: true,
+			});
+			expect(vars.apiKey).toEqual({ value: "test-api-key-1", enabled: true, secret: true });
+			expect(vars.legacyHost).toEqual({ value: "old.example.com", enabled: false });
+		});
+
+		it("keeps a secret whose value Postman omitted, so the key is not lost", () => {
+			const vars = p.parse(parsed, raw, opts).environments[0].variables;
+			expect(vars.emptySecret).toEqual({ value: "", enabled: true, secret: true });
+		});
+
+		it("normalizes {{ spaced }} templates like every other parser", () => {
+			const vars = p.parse(parsed, raw, opts).environments[0].variables;
+			expect(vars.greeting.value).toBe("hello {{user.name}}");
+		});
+
+		it("drops a keyless entry", () => {
+			const vars = p.parse(parsed, raw, opts).environments[0].variables;
+			expect(Object.keys(vars)).toEqual([
+				"baseUrl",
+				"apiKey",
+				"emptySecret",
+				"legacyHost",
+				"greeting",
+			]);
+		});
+
+		it("reports counts that describe an environment-only import", () => {
+			expect(p.parse(parsed, raw, opts).meta).toEqual({
+				format: "Postman Environment",
+				requestCount: 0,
+				folderCount: 0,
+				environmentCount: 1,
+				skipped: [],
+				nonExecutableAuth: 0,
+			});
+		});
+
+		it("emits nothing at all when importEnvironments is off", () => {
+			const r = p.parse(parsed, raw, { importEnvironments: false, importScripts: true });
+			expect(r.environments).toEqual([]);
+			expect(r.collections).toEqual([]);
+			expect(r.meta.environmentCount).toBe(0);
+		});
+
+		it("falls back to a name when the export has none", () => {
+			const r = p.parse({ _postman_variable_scope: "environment", values: [] }, "", opts);
+			expect(r.environments[0].name).toBe("Imported Environment");
+			expect(r.environments[0].variables).toEqual({});
+		});
+	});
+});

--- a/app/src/services/importers/postman-environment.test.ts
+++ b/app/src/services/importers/postman-environment.test.ts
@@ -15,8 +15,12 @@ describe("PostmanEnvironmentParser", () => {
 			expect(p.detect(parsed, raw)).toBe(true);
 		});
 
-		it("ignores a globals export - Vayu's globals scope is a separate decision", () => {
-			expect(p.detect({ _postman_variable_scope: "globals", values: [] }, "")).toBe(false);
+		it("claims a globals export - same shape, different destination", () => {
+			expect(p.detect({ _postman_variable_scope: "globals", values: [] }, "")).toBe(true);
+		});
+
+		it("claims neither scope without a values array", () => {
+			expect(p.detect({ _postman_variable_scope: "globals" }, "")).toBe(false);
 		});
 
 		it("needs a values array, not just the scope marker", () => {
@@ -82,6 +86,7 @@ describe("PostmanEnvironmentParser", () => {
 				requestCount: 0,
 				folderCount: 0,
 				environmentCount: 1,
+				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
 			});
@@ -91,6 +96,7 @@ describe("PostmanEnvironmentParser", () => {
 			const r = p.parse(parsed, raw, { importEnvironments: false, importScripts: true });
 			expect(r.environments).toEqual([]);
 			expect(r.collections).toEqual([]);
+			expect(r.globals).toEqual({});
 			expect(r.meta.environmentCount).toBe(0);
 		});
 
@@ -98,6 +104,59 @@ describe("PostmanEnvironmentParser", () => {
 			const r = p.parse({ _postman_variable_scope: "environment", values: [] }, "", opts);
 			expect(r.environments[0].name).toBe("Imported Environment");
 			expect(r.environments[0].variables).toEqual({});
+		});
+
+		it("leaves globals empty for an environment export", () => {
+			expect(p.parse(parsed, raw, opts).globals).toEqual({});
+		});
+	});
+
+	describe("parse - globals scope", () => {
+		const gRaw = readFileSync(join(__dirname, "__fixtures__/postman-globals.json"), "utf8");
+		const gParsed = JSON.parse(gRaw);
+
+		it("routes the variables to globals, creating no environment", () => {
+			const r = p.parse(gParsed, gRaw, opts);
+			expect(r.environments).toEqual([]);
+			expect(r.collections).toEqual([]);
+			expect(r.globals.apiHost).toEqual({ value: "https://api.example.com", enabled: true });
+		});
+
+		it("applies the same mapping rules as an environment export", () => {
+			const { globals } = p.parse(gParsed, gRaw, opts);
+			// secret flag from `type`, disabled entries kept as enabled:false,
+			// and {{ spaced }} normalised - all inherited from toVarRecord.
+			expect(globals.sharedToken).toEqual({
+				value: "test-shared-token-1",
+				enabled: true,
+				secret: true,
+			});
+			expect(globals.retiredFlag.enabled).toBe(false);
+			expect(globals.banner.value).toBe("welcome {{tenant}}");
+		});
+
+		it("reports the globals count and its own format name", () => {
+			expect(p.parse(gParsed, gRaw, opts).meta).toEqual({
+				format: "Postman Globals",
+				requestCount: 0,
+				folderCount: 0,
+				environmentCount: 0,
+				globalCount: 4,
+				skipped: [],
+				nonExecutableAuth: 0,
+			});
+		});
+
+		it("drops the workspace name - the globals scope is a singleton with nowhere to put it", () => {
+			const r = p.parse(gParsed, gRaw, opts);
+			expect(r.environments).toHaveLength(0);
+			expect(JSON.stringify(r)).not.toContain("Sample Workspace Globals");
+		});
+
+		it("emits no globals when importEnvironments is off", () => {
+			const r = p.parse(gParsed, gRaw, { importEnvironments: false, importScripts: true });
+			expect(r.globals).toEqual({});
+			expect(r.meta.globalCount).toBe(0);
 		});
 	});
 });

--- a/app/src/services/importers/postman-environment.ts
+++ b/app/src/services/importers/postman-environment.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
+import type { VariableValue } from "@/types";
 import type { EnvironmentDraft, ImportOptions, ImportParser, ImportResult } from "./types";
 import { asString, toVarRecord } from "./shared";
 
@@ -13,50 +14,74 @@ import { asString, toVarRecord } from "./shared";
  * export - which is why `postman.ts` correctly returns `environments: []`. This
  * parser reads that separate file.
  *
- * The result has no collections at all, the only parser that produces that.
- * `ImportOrchestrator.run` already handles it (its collection loop simply does
- * not execute), and `ImportModal` blocks the import when nothing would be
- * created rather than closing on a no-op.
+ * It claims both variable scopes Postman writes in this shape:
  *
- * Only `_postman_variable_scope: "environment"` is claimed. Postman uses the
- * same file shape for `"globals"`; whether an import may write Vayu's globals
- * scope is a separate decision (issue #153), so a globals file stays
- * unrecognised rather than being silently routed somewhere.
+ * - `"environment"` → one `EnvironmentDraft`, created like any other environment.
+ * - `"globals"`     → `ImportResult.globals`, merged into Vayu's globals scope.
+ *
+ * They share a document shape and therefore a parser, so the mapping rules
+ * (secret flag, enabled precedence, `{{ var }}` normalisation) cannot drift
+ * between them. Only the destination differs.
+ *
+ * Either way the result has no collections at all, the only parser that produces
+ * that. `ImportOrchestrator.run` already handles it (its collection loop simply
+ * does not execute), and `ImportModal` blocks the import when nothing would be
+ * created rather than closing on a no-op.
  */
+
+/** Postman's marker for a globals export; an environment export says `"environment"`. */
+const GLOBALS_SCOPE = "globals";
+const ENVIRONMENT_SCOPE = "environment";
+
 export class PostmanEnvironmentParser implements ImportParser {
+	// Registry label. The *user-facing* format is per-document (`meta.format`
+	// below), since one parser now covers two exports that read differently.
 	readonly formatName = "Postman Environment";
 	readonly formatKey = "postman-environment";
 
 	detect(parsed: unknown, _raw: string): boolean {
 		const p = parsed as { _postman_variable_scope?: unknown; values?: unknown } | null;
-		return p?._postman_variable_scope === "environment" && Array.isArray(p?.values);
+		const scope = p?._postman_variable_scope;
+		return (scope === ENVIRONMENT_SCOPE || scope === GLOBALS_SCOPE) && Array.isArray(p?.values);
 	}
 
 	parse(parsed: unknown, _raw: string, opts: ImportOptions): ImportResult {
-		const p = parsed as { name?: unknown; values?: unknown };
+		const p = parsed as { name?: unknown; values?: unknown; _postman_variable_scope?: unknown };
+		const isGlobals = p._postman_variable_scope === GLOBALS_SCOPE;
+
 		// Gated at parse time, matching InsomniaV4Parser: with the option off the
-		// draft carries no environments and `environmentCount` reports 0, so the
-		// preview shows what will actually be created.
-		const environments: EnvironmentDraft[] = opts.importEnvironments
-			? [
-					{
-						name: asString(p.name) || "Imported Environment",
-						description: "",
-						variables: toVarRecord(
-							(p.values ?? []) as Parameters<typeof toVarRecord>[0]
-						),
-					},
-				]
-			: [];
+		// draft carries nothing and the counts report 0, so the preview shows what
+		// will actually be created. The one toggle covers both scopes - it reads
+		// "Import environments & variables", and globals are variables.
+		const variables: Record<string, VariableValue> = opts.importEnvironments
+			? toVarRecord((p.values ?? []) as Parameters<typeof toVarRecord>[0])
+			: {};
+
+		const environments: EnvironmentDraft[] =
+			isGlobals || !opts.importEnvironments
+				? []
+				: [
+						{
+							name: asString(p.name) || "Imported Environment",
+							description: "",
+							variables,
+						},
+					];
+		// A globals export carries a `name` too (the workspace's), but Vayu's globals
+		// scope is a singleton with nowhere to put it, so it is dropped rather than
+		// invented into an environment name.
+		const globals = isGlobals ? variables : {};
 
 		return {
 			collections: [],
 			environments,
+			globals,
 			meta: {
-				format: this.formatName,
+				format: isGlobals ? "Postman Globals" : this.formatName,
 				requestCount: 0,
 				folderCount: 0,
 				environmentCount: environments.length,
+				globalCount: Object.keys(globals).length,
 				skipped: [],
 				nonExecutableAuth: 0,
 			},

--- a/app/src/services/importers/postman-environment.ts
+++ b/app/src/services/importers/postman-environment.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import type { EnvironmentDraft, ImportOptions, ImportParser, ImportResult } from "./types";
+import { asString, toVarRecord } from "./shared";
+
+/**
+ * Postman exports an environment as its own file, separate from the collection
+ * export - which is why `postman.ts` correctly returns `environments: []`. This
+ * parser reads that separate file.
+ *
+ * The result has no collections at all, the only parser that produces that.
+ * `ImportOrchestrator.run` already handles it (its collection loop simply does
+ * not execute), and `ImportModal` blocks the import when nothing would be
+ * created rather than closing on a no-op.
+ *
+ * Only `_postman_variable_scope: "environment"` is claimed. Postman uses the
+ * same file shape for `"globals"`; whether an import may write Vayu's globals
+ * scope is a separate decision (issue #153), so a globals file stays
+ * unrecognised rather than being silently routed somewhere.
+ */
+export class PostmanEnvironmentParser implements ImportParser {
+	readonly formatName = "Postman Environment";
+	readonly formatKey = "postman-environment";
+
+	detect(parsed: unknown, _raw: string): boolean {
+		const p = parsed as { _postman_variable_scope?: unknown; values?: unknown } | null;
+		return p?._postman_variable_scope === "environment" && Array.isArray(p?.values);
+	}
+
+	parse(parsed: unknown, _raw: string, opts: ImportOptions): ImportResult {
+		const p = parsed as { name?: unknown; values?: unknown };
+		// Gated at parse time, matching InsomniaV4Parser: with the option off the
+		// draft carries no environments and `environmentCount` reports 0, so the
+		// preview shows what will actually be created.
+		const environments: EnvironmentDraft[] = opts.importEnvironments
+			? [
+					{
+						name: asString(p.name) || "Imported Environment",
+						description: "",
+						variables: toVarRecord(
+							(p.values ?? []) as Parameters<typeof toVarRecord>[0]
+						),
+					},
+				]
+			: [];
+
+		return {
+			collections: [],
+			environments,
+			meta: {
+				format: this.formatName,
+				requestCount: 0,
+				folderCount: 0,
+				environmentCount: environments.length,
+				skipped: [],
+				nonExecutableAuth: 0,
+			},
+		};
+	}
+}

--- a/app/src/services/importers/postman.test.ts
+++ b/app/src/services/importers/postman.test.ts
@@ -19,8 +19,8 @@ describe("PostmanV21Parser", () => {
 		const r = p.parse(parsed, raw, opts);
 		expect(r.collections).toHaveLength(1);
 		const root = r.collections[0];
-		expect(root.name).toBe("Acme API");
-		expect(root.variables.baseUrl.value).toBe("https://api.acme.com");
+		expect(root.name).toBe("Sample API");
+		expect(root.variables.baseUrl.value).toBe("https://api.example.com");
 		expect(root.auth).toEqual({ mode: "bearer", token: "{{token}}" });
 		expect(root.preRequestScript).toBe("console.log('pre')");
 	});
@@ -67,7 +67,7 @@ describe("PostmanV21Parser", () => {
 					name: "Callback",
 					request: {
 						method: "GET",
-						url: "https://api.acme.com/cb?code=dGVzdA==&state=1",
+						url: "https://api.example.com/cb?code=dGVzdA==&state=1",
 					},
 				},
 			],
@@ -101,7 +101,7 @@ describe("PostmanV20Parser", () => {
 
 	it("parses string URL with query and v2.0 object-shape bearer auth", () => {
 		const req = p.parse(parsed20, raw20, opts).collections[0].requests[0];
-		expect(req.url).toBe("https://api.legacy.com/things");
+		expect(req.url).toBe("https://legacy.example.com/things");
 		expect(req.params).toEqual([{ key: "id", value: "5", enabled: true }]);
 		expect(req.auth).toEqual({ mode: "bearer", token: "LEGACY" });
 	});

--- a/app/src/services/importers/postman.ts
+++ b/app/src/services/importers/postman.ts
@@ -154,11 +154,13 @@ function parsePostman(parsed: any, opts: ImportOptions, formatName: string): Imp
 	return {
 		collections: [root],
 		environments: [], // collection files don't embed environments
+		globals: {}, // nor globals - both are separate exports, see postman-environment.ts
 		meta: {
 			format: formatName,
 			requestCount: ctx.requestCount,
 			folderCount: ctx.folderCount,
 			environmentCount: 0,
+			globalCount: 0,
 			skipped,
 			nonExecutableAuth: ctx.nonExecutableAuth,
 		},

--- a/app/src/services/importers/shared.test.ts
+++ b/app/src/services/importers/shared.test.ts
@@ -13,6 +13,19 @@ describe("toVarRecord", () => {
 			b: { value: "x", enabled: false },
 		});
 	});
+
+	it("marks a Postman secret-typed variable, and omits the flag otherwise", () => {
+		const out = toVarRecord([
+			{ key: "token", value: "s3cr3t", type: "secret" },
+			{ key: "host", value: "example.com", type: "default" },
+		]);
+		expect(out).toEqual({
+			token: { value: "s3cr3t", enabled: true, secret: true },
+			host: { value: "example.com", enabled: true },
+		});
+		// Not `secret: false` - a non-secret variable must serialise as it did before.
+		expect("secret" in out.host).toBe(false);
+	});
 });
 
 describe("mapPostmanAuth", () => {

--- a/app/src/services/importers/shared.ts
+++ b/app/src/services/importers/shared.ts
@@ -17,15 +17,34 @@ export function asString(v: unknown): string {
 	return String(v);
 }
 
-/** Postman/Insomnia variable arrays → Vayu VariableValue record. */
+/**
+ * Postman/Insomnia variable arrays → Vayu VariableValue record.
+ *
+ * `type` is Postman's per-variable kind. Only `"secret"` is meaningful to Vayu
+ * (it maps to `VariableValue.secret`); the rest describe a value type Vayu does
+ * not store, since every value is a string. The flag is omitted rather than set
+ * to `false` so a non-secret variable serialises the same as before.
+ */
 export function toVarRecord(
-	vars: Array<{ key: string; value?: unknown; enabled?: boolean; disabled?: boolean }> | undefined
+	vars:
+		| Array<{
+				key: string;
+				value?: unknown;
+				enabled?: boolean;
+				disabled?: boolean;
+				type?: unknown;
+		  }>
+		| undefined
 ): Record<string, VariableValue> {
 	const out: Record<string, VariableValue> = {};
 	for (const v of vars ?? []) {
 		if (!v || !v.key) continue;
 		const enabled = v.disabled != null ? !v.disabled : v.enabled != null ? v.enabled : true;
-		out[v.key] = { value: normalizeVars(asString(v.value)), enabled };
+		out[v.key] = {
+			value: normalizeVars(asString(v.value)),
+			enabled,
+			...(v.type === "secret" ? { secret: true } : {}),
+		};
 	}
 	return out;
 }

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -24,6 +24,8 @@ export interface ImportMeta {
 	requestCount: number;
 	folderCount: number;
 	environmentCount: number;
+	/** Variables destined for Vayu's globals scope. Only a Postman globals export produces any. */
+	globalCount: number;
 	// TODO: populated by parsers so the Preview can warn the user about lossy imports.
 	// Vayu is HTTP-only and has no OAuth execution path; WebSocket/gRPC are dropped and
 	// oauth2/digest/aws/ntlm auth is stored-but-not-executed. Surface both rather than
@@ -68,6 +70,14 @@ export interface EnvironmentDraft {
 export interface ImportResult {
 	collections: CollectionDraft[]; // roots (parentId = null)
 	environments: EnvironmentDraft[];
+	/**
+	 * Variables for Vayu's globals scope, keyed by name. Not a draft list like the
+	 * two above: globals are a singleton on the engine (`POST /globals` replaces the
+	 * whole set), so there is nothing to name and no id to assign. Required rather
+	 * than optional so every parser states its answer - `{}` for all but the Postman
+	 * globals export.
+	 */
+	globals: Record<string, VariableValue>;
 	meta: ImportMeta;
 }
 

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -13,7 +13,7 @@ are detected, parsed into Vayu's internal draft model, and persisted.
 | Format | Module | Detection (summary) | Doc |
 |---|---|---|---|
 | Postman Collection v2.1 / v2.0 | `postman.ts` | `info.schema` contains `v2.1.0` / `v2.0.0` (or `info`+`item` with no schema) | [postman.md](./postman.md) |
-| Postman Environment | `postman-environment.ts` | `_postman_variable_scope === "environment"` && `values` is an array | [postman-environment.md](./postman-environment.md) |
+| Postman Environment / Globals | `postman-environment.ts` | `_postman_variable_scope` is `"environment"` or `"globals"` && `values` is an array | [postman-environment.md](./postman-environment.md) |
 | Insomnia Export v4 | `insomnia-v4.ts` | `_type === "export"` && `__export_format === 4` | [insomnia-v4.md](./insomnia-v4.md) |
 | OpenAPI 3.0 | `openapi-v3.ts` | `openapi` starts with `3.` | [openapi-v3.md](./openapi-v3.md) |
 | OpenAPI 2.0 (Swagger) | `openapi-v2.ts` | `swagger === "2.0"` | [openapi-v2.md](./openapi-v2.md) |

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -13,6 +13,7 @@ are detected, parsed into Vayu's internal draft model, and persisted.
 | Format | Module | Detection (summary) | Doc |
 |---|---|---|---|
 | Postman Collection v2.1 / v2.0 | `postman.ts` | `info.schema` contains `v2.1.0` / `v2.0.0` (or `info`+`item` with no schema) | [postman.md](./postman.md) |
+| Postman Environment | `postman-environment.ts` | `_postman_variable_scope === "environment"` && `values` is an array | [postman-environment.md](./postman-environment.md) |
 | Insomnia Export v4 | `insomnia-v4.ts` | `_type === "export"` && `__export_format === 4` | [insomnia-v4.md](./insomnia-v4.md) |
 | OpenAPI 3.0 | `openapi-v3.ts` | `openapi` starts with `3.` | [openapi-v3.md](./openapi-v3.md) |
 | OpenAPI 2.0 (Swagger) | `openapi-v2.ts` | `swagger === "2.0"` | [openapi-v2.md](./openapi-v2.md) |
@@ -38,7 +39,7 @@ raw string ──▶ parseImport() ──▶ assignIds() ──▶ ImportOrchest
 1. **`parseRaw`** - `JSON.parse(raw)`, falling back to `yaml.load(raw)` on JSON failure.
    Malformed YAML throws and propagates as a parse error.
 2. Runs each parser's `detect()` in a fixed **most-specific-first** order:
-   `PostmanV21 → PostmanV20 → InsomniaV4 → OpenApiV3 → OpenApiV2`.
+   `PostmanV21 → PostmanV20 → PostmanEnvironment → InsomniaV4 → OpenApiV3 → OpenApiV2`.
    The first parser whose `detect()` returns `true` gets to `parse()`.
 3. No match → throws `UnrecognisedFormatError`.
 

--- a/docs/app/import-collections/postman-environment.md
+++ b/docs/app/import-collections/postman-environment.md
@@ -1,0 +1,93 @@
+# Postman Environment
+
+Parses a Postman **environment** export - the separate `*.postman_environment.json` file Postman produces from _Environments → Export_ - into a Vayu environment. It is not the collection export; see [postman.md](./postman.md) for that.
+
+- **Source:** `app/src/services/importers/postman-environment.ts`
+- **Exports:**
+
+  | Class | `formatName` | `formatKey` |
+  |-------|--------------|-------------|
+  | `PostmanEnvironmentParser` | `Postman Environment` | `postman-environment` |
+
+Implements `ImportParser` (`detect` + `parse`) from `./types`.
+
+## Detection
+
+```ts
+parsed._postman_variable_scope === "environment" && Array.isArray(parsed.values)
+```
+
+Both halves are required. The scope marker alone is not enough - Postman uses the same document shape for globals - and `values` must be an array, since it is walked directly.
+
+`PostmanEnvironmentParser` is registered **third** in the factory's `PARSERS`, after the two collection parsers and before Insomnia:
+
+```
+PostmanV21 → PostmanV20 → PostmanEnvironment → InsomniaV4 → OpenApiV3 → OpenApiV2
+```
+
+That position is not load-bearing. An environment export carries neither `info` nor `item[]`, so `PostmanV20Parser`'s permissive fallback branch (`info` present + `item[]` array + no schema) cannot claim it, and no other detector looks at `_postman_variable_scope`. The grouping is for readability.
+
+### Globals are deliberately not claimed
+
+A `_postman_variable_scope: "globals"` file has the identical shape and would be trivial to route into Vayu's globals scope. It is left **unrecognised** on purpose: whether an import may write the globals scope at all is a product decision that has not been made ([#153](https://github.com/athrvk/vayu/issues/153)). A globals file therefore fails with `UnrecognisedFormatError` ("Unrecognised format") rather than landing somewhere the user did not ask for.
+
+## Field mapping
+
+| Postman | Vayu `EnvironmentDraft` | Notes |
+|---------|-------------------------|-------|
+| `name` | `name` | Falls back to `"Imported Environment"` when absent or empty. |
+| - | `description` | Always `""`; the export has no description field. |
+| `values[]` | `variables` | Via the shared `toVarRecord` helper. |
+
+### `values[]` → `variables`
+
+`toVarRecord` (`shared.ts`) is the same helper Postman **collection** variables go through, so the rules are shared rather than re-derived:
+
+| Postman entry field | Effect |
+|---|---|
+| `key` | The record key. An entry with a falsy `key` is **dropped**. |
+| `value` | `asString` then `normalizeVars`, so `{{ user.name }}` tightens to `{{user.name}}` like every other parser. |
+| `enabled` / `disabled` | `disabled` wins if present, else `enabled`, else `true`. |
+| `type === "secret"` | Sets `secret: true`. Any other `type` omits the flag entirely (not `secret: false`). |
+
+Postman's other `type` values describe a value kind Vayu does not store - every variable value is a string - so only `"secret"` is read.
+
+**Empty secret values are imported, not skipped.** Some Postman export paths blank out secret-typed values. The variable is still created (empty, enabled, `secret: true`) so the key stays visible for the user to fill in; dropping it would lose the name too, with nothing on screen to say so.
+
+## Result shape
+
+```ts
+{
+  collections: [],            // the only parser that produces none
+  environments: [ /* 0 or 1 */ ],
+  meta: {
+    format: "Postman Environment",
+    requestCount: 0, folderCount: 0,
+    environmentCount: environments.length,
+    skipped: [], nonExecutableAuth: 0,
+  },
+}
+```
+
+### `importEnvironments`
+
+Honored **at parse time**, matching `InsomniaV4Parser`: when the option is false the parser emits `environments: []` and `environmentCount: 0`, so the preview shows what will actually be created rather than what the file contains.
+
+For this format that is the whole result, which puts two states on screen no other format reaches:
+
+- **The preview renders environments.** `ImportModal`'s preview tree listed collections only, so an environment-only import previewed as an empty box. It now renders one row per environment (name + variable count) beneath the collection tree - for every format, not just this one.
+- **Import is blocked when nothing would be created.** With `importEnvironments` off there is no collection and no environment, so importing would create nothing and close the modal - a silent no-op. The Import button is disabled and the preview says why. The toggle that recovers it is in the same footer, so the state is never a dead end.
+
+`ImportOrchestrator.run` needed no change: its collection loop simply does not execute, and its environment creation was already gated on `opts.importEnvironments`.
+
+## Not covered
+
+- **Globals exports** - see above.
+- **Workspace dumps.** Postman's _Export Data_ produces a directory of collection *and* environment files. Import takes one file at a time; each file in such a dump imports individually.
+
+## Tests
+
+- `app/src/services/importers/postman-environment.test.ts` - detection (including the globals and collection negatives), mapping, the secret flag, the empty-secret case, and the `importEnvironments: false` path.
+- `app/src/services/importers/factory.test.ts` - routing, plus the guard that a collection export still reaches the collection parser.
+- `app/src/modules/collections/ImportModal.environments.test.tsx` - the preview row, the blocked Import, and recovery via the toggle.
+- Fixture: `app/src/services/importers/__fixtures__/postman-environment.json`.

--- a/docs/app/import-collections/postman-environment.md
+++ b/docs/app/import-collections/postman-environment.md
@@ -1,6 +1,13 @@
-# Postman Environment
+# Postman Environment and Globals
 
-Parses a Postman **environment** export - the separate `*.postman_environment.json` file Postman produces from _Environments → Export_ - into a Vayu environment. It is not the collection export; see [postman.md](./postman.md) for that.
+Parses the two variable exports Postman writes as standalone files, both from _Environments → Export_:
+
+| Export | `_postman_variable_scope` | Lands in |
+|---|---|---|
+| Environment (`*.postman_environment.json`) | `"environment"` | A new Vayu environment |
+| Globals (`*.postman_globals.json`) | `"globals"` | Vayu's globals scope, merged |
+
+Neither is the collection export; see [postman.md](./postman.md) for that. The two share a document shape and therefore a parser, so the mapping rules cannot drift between them - only the destination differs.
 
 - **Source:** `app/src/services/importers/postman-environment.ts`
 - **Exports:**
@@ -14,10 +21,11 @@ Implements `ImportParser` (`detect` + `parse`) from `./types`.
 ## Detection
 
 ```ts
-parsed._postman_variable_scope === "environment" && Array.isArray(parsed.values)
+(parsed._postman_variable_scope === "environment" ||
+	parsed._postman_variable_scope === "globals") && Array.isArray(parsed.values)
 ```
 
-Both halves are required. The scope marker alone is not enough - Postman uses the same document shape for globals - and `values` must be an array, since it is walked directly.
+Both halves are required: `values` must be an array, since it is walked directly.
 
 `PostmanEnvironmentParser` is registered **third** in the factory's `PARSERS`, after the two collection parsers and before Insomnia:
 
@@ -27,17 +35,23 @@ PostmanV21 → PostmanV20 → PostmanEnvironment → InsomniaV4 → OpenApiV3 �
 
 That position is not load-bearing. An environment export carries neither `info` nor `item[]`, so `PostmanV20Parser`'s permissive fallback branch (`info` present + `item[]` array + no schema) cannot claim it, and no other detector looks at `_postman_variable_scope`. The grouping is for readability.
 
-### Globals are deliberately not claimed
+### Globals merge, they do not replace
 
-A `_postman_variable_scope: "globals"` file has the identical shape and would be trivial to route into Vayu's globals scope. It is left **unrecognised** on purpose: whether an import may write the globals scope at all is a product decision that has not been made ([#153](https://github.com/athrvk/vayu/issues/153)). A globals file therefore fails with `UnrecognisedFormatError` ("Unrecognised format") rather than landing somewhere the user did not ask for.
+`POST /globals` **replaces** the whole set - the engine has no merge verb (see [api-reference.md](../../engine/api-reference.md#post-globals)). Writing the imported record straight to it would delete every global the user already had, so `ImportOrchestrator.applyGlobals` reads the current set first and writes the union.
+
+On a name collision **the imported value wins**. The user explicitly asked for this file's variables, and silently keeping the old value would be the no-op outcome this import path exists to avoid. The preview states it: *"Existing globals are kept; a variable of the same name is overwritten."*
+
+Globals are written **last**, after every collection and environment. That ordering is load-bearing: it is the one write here that can destroy data the import did not create, so nothing may fail behind it. A failed import therefore never leaves globals half-rewritten, and rollback has no globals case to restore. Do not reorder without adding one.
+
+A globals export carries a `name` (the workspace's). Vayu's globals scope is a singleton with nowhere to put it, so it is dropped rather than invented into an environment name.
 
 ## Field mapping
 
-| Postman | Vayu `EnvironmentDraft` | Notes |
-|---------|-------------------------|-------|
-| `name` | `name` | Falls back to `"Imported Environment"` when absent or empty. |
-| - | `description` | Always `""`; the export has no description field. |
-| `values[]` | `variables` | Via the shared `toVarRecord` helper. |
+| Postman | Vayu | Notes |
+|---------|------|-------|
+| `name` | `EnvironmentDraft.name` | Environment scope only. Falls back to `"Imported Environment"` when absent or empty; **dropped** for a globals export. |
+| - | `EnvironmentDraft.description` | Always `""`; the export has no description field. |
+| `values[]` | `variables` / `ImportResult.globals` | Via the shared `toVarRecord` helper, identically for both scopes. |
 
 ### `values[]` → `variables`
 
@@ -59,35 +73,44 @@ Postman's other `type` values describe a value kind Vayu does not store - every 
 ```ts
 {
   collections: [],            // the only parser that produces none
-  environments: [ /* 0 or 1 */ ],
+  environments: [ /* 0 or 1; always 0 for a globals export */ ],
+  globals: { /* {} unless a globals export */ },
   meta: {
-    format: "Postman Environment",
+    format: "Postman Environment" | "Postman Globals",
     requestCount: 0, folderCount: 0,
     environmentCount: environments.length,
+    globalCount: Object.keys(globals).length,
     skipped: [], nonExecutableAuth: 0,
   },
 }
 ```
 
+`ImportResult.globals` is a plain `Record<string, VariableValue>`, not a draft list: globals are a singleton on the engine, so there is nothing to name and no id for `assignIds` to stamp. It is a **required** field on `ImportResult`, so every parser states its answer (`{}` for all but this one) rather than leaving the destination implicit.
+
+`meta.format` is per-document rather than the parser's `formatName`, since one parser now covers two exports the user sees differently.
+
 ### `importEnvironments`
 
-Honored **at parse time**, matching `InsomniaV4Parser`: when the option is false the parser emits `environments: []` and `environmentCount: 0`, so the preview shows what will actually be created rather than what the file contains.
+The one toggle governs **both** scopes - it reads "Import environments & variables", and globals are variables. No separate control was added.
+
+Honored **at parse time**, matching `InsomniaV4Parser`: when the option is false the parser emits `environments: []`, `globals: {}` and zeroed counts, so the preview shows what will actually be created rather than what the file contains.
 
 For this format that is the whole result, which puts two states on screen no other format reaches:
 
-- **The preview renders environments.** `ImportModal`'s preview tree listed collections only, so an environment-only import previewed as an empty box. It now renders one row per environment (name + variable count) beneath the collection tree - for every format, not just this one.
-- **Import is blocked when nothing would be created.** With `importEnvironments` off there is no collection and no environment, so importing would create nothing and close the modal - a silent no-op. The Import button is disabled and the preview says why. The toggle that recovers it is in the same footer, so the state is never a dead end.
+- **The preview renders environments and globals.** `ImportModal`'s preview tree listed collections only, so an environment-only import previewed as an empty box. It now renders one row per environment (name + variable count) beneath the collection tree, plus a single **Globals** row when the import carries any - named for the destination scope, since a globals export has no name of its own worth showing. This is for every format, not just this one.
+- **Import is blocked when nothing would be created.** With `importEnvironments` off there is no collection, no environment and no globals, so importing would create nothing and close the modal - a silent no-op. The Import button is disabled and the preview says why. The toggle that recovers it is in the same footer, so the state is never a dead end.
 
-`ImportOrchestrator.run` needed no change: its collection loop simply does not execute, and its environment creation was already gated on `opts.importEnvironments`.
+`ImportOrchestrator.run` gained `applyGlobals` (above); its collection loop simply does not execute, and environment creation was already gated on `opts.importEnvironments`. `useImportMutation` also invalidates `queryKeys.globals.all`, without which the imported variables would sit on the engine unread until the next reload.
 
 ## Not covered
 
-- **Globals exports** - see above.
 - **Workspace dumps.** Postman's _Export Data_ produces a directory of collection *and* environment files. Import takes one file at a time; each file in such a dump imports individually.
 
 ## Tests
 
-- `app/src/services/importers/postman-environment.test.ts` - detection (including the globals and collection negatives), mapping, the secret flag, the empty-secret case, and the `importEnvironments: false` path.
-- `app/src/services/importers/factory.test.ts` - routing, plus the guard that a collection export still reaches the collection parser.
-- `app/src/modules/collections/ImportModal.environments.test.tsx` - the preview row, the blocked Import, and recovery via the toggle.
-- Fixture: `app/src/services/importers/__fixtures__/postman-environment.json`.
+- `app/src/services/importers/postman-environment.test.ts` - detection for both scopes (and the collection negative), mapping, the secret flag, the empty-secret case, the dropped workspace name, and the `importEnvironments: false` path for each scope.
+- `app/src/services/importers/factory.test.ts` - routing for both exports, plus the guard that a collection export still reaches the collection parser.
+- `app/src/services/importers/orchestrator.test.ts` - the merge, the collision rule, that a result with no globals neither reads nor writes the scope, the `importEnvironments: false` skip, rollback when the globals write fails, and the globals-last ordering.
+- `app/src/queries/import.test.ts` - `getGlobals` / `updateGlobals` delegation and the globals cache invalidation.
+- `app/src/modules/collections/ImportModal.environments.test.tsx` - the preview rows for both scopes, the merge notice, the blocked Import, and recovery via the toggle.
+- Fixtures: `app/src/services/importers/__fixtures__/postman-environment.json`, `postman-globals.json`.

--- a/docs/app/import-collections/postman.md
+++ b/docs/app/import-collections/postman.md
@@ -149,7 +149,7 @@ Collection- and folder-level `variable[]` arrays map to `CollectionDraft.variabl
 - enabled state is `!disabled` if `disabled` is set, else `enabled` if set, else `true`;
 - the value is coerced to a string (`asString`) and run through `normalizeVars`.
 
-Postman **collection** files do not embed environments, so this parser always returns `environments: []` and `meta.environmentCount: 0`. (Postman environments are exported as separate files and are not handled here.)
+Postman **collection** files do not embed environments, so this parser always returns `environments: []` and `meta.environmentCount: 0`. Postman exports environments as separate files, which [`postman-environment.ts`](./postman-environment.md) reads.
 
 ## Options & lossy behavior
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,10 +115,12 @@ the tree, variables, auth and scripts.
     parameters including disabled ones and their descriptions, and raw, JSON,
     URL-encoded, form-data and GraphQL bodies.
 
-    Not carried: **environments** - Postman exports those as separate files, which
-    this importer does not read. Binary and file bodies are dropped and reported
-    with a count rather than silently, and Digest / AWS / NTLM auth imports as
-    data but will not execute.
+    **Environments** come across too. Postman exports those as separate files -
+    drop one in and it imports as a Vayu environment, keys, values, enabled state
+    and secret flag intact.
+
+    Binary and file bodies are dropped and reported with a count rather than
+    silently, and Digest / AWS / NTLM auth imports as data but will not execute.
 
 === "Insomnia"
 
@@ -257,8 +259,9 @@ persists.
 ??? question "Can I import my Postman collections?"
 
     Yes - v2.0 and v2.1 exports, including folders, collection variables, auth,
-    and pre/post-request scripts. Postman environments are a separate export and
-    are not read. Insomnia v4, OpenAPI 3.0 and Swagger 2.0 import too; see
+    and pre/post-request scripts. Postman environments are a separate export;
+    import that file too and it becomes a Vayu environment. Insomnia v4,
+    OpenAPI 3.0 and Swagger 2.0 import too; see
     [what carries over](#bring-your-existing-collections).
 
 ??? question "Will my Postman test scripts still run?"

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,9 @@ the tree, variables, auth and scripts.
 
     **Environments** come across too. Postman exports those as separate files -
     drop one in and it imports as a Vayu environment, keys, values, enabled state
-    and secret flag intact.
+    and secret flag intact. A **globals** export imports the same way, merging
+    into Vayu's globals scope rather than creating an environment; variables you
+    already had are kept, and a name that clashes is overwritten.
 
     Binary and file bodies are dropped and reported with a count rather than
     silently, and Digest / AWS / NTLM auth imports as data but will not execute.
@@ -260,7 +262,8 @@ persists.
 
     Yes - v2.0 and v2.1 exports, including folders, collection variables, auth,
     and pre/post-request scripts. Postman environments are a separate export;
-    import that file too and it becomes a Vayu environment. Insomnia v4,
+    import that file too and it becomes a Vayu environment, and a globals export
+    merges into Vayu's globals scope. Insomnia v4,
     OpenAPI 3.0 and Swagger 2.0 import too; see
     [what carries over](#bring-your-existing-collections).
 


### PR DESCRIPTION
## Description

A Postman environment export dropped into **Import** was rejected as *"Unrecognised format"*, and the **Import environments &amp; variables** checkbox - on by default - changed nothing for any Postman import. Nothing misbehaved; the capability was never built and the surface implied it existed.

**Plan.** The root cause is a missing detector, not a missing subsystem: `parseImport` runs five collection/spec detectors and a `*.postman_environment.json` file matches none, so the factory throws. Everything downstream already exists (`EnvironmentDraft`, `assignIds`'s `env_` stamping, the orchestrator's `importEnvironments`-gated create + rollback), and Insomnia is a working precedent for the whole path. So the fix is one new `ImportParser` registered in the factory, mapping `values[]` through the **existing** `toVarRecord` helper rather than a private copy - the helper gains one rule (`type: "secret"` → `VariableValue.secret`) so collection and environment variables cannot drift. The alternative I rejected was gating `importEnvironments` by **throwing** from the parser: it reads as the loudest failure, but the option checkboxes only render in the preview phase, so an error would hide the very control needed to recover and re-dropping the file would fail again. Blocking the Import button with a stated reason, next to the toggle, is loud without the dead end.

**Verified against the tree first:** the problem is exactly as #153 describes - `factory.ts:17-23` lists five detectors, `postman.ts:156` hardcodes `environments: []`, and `ImportModal.tsx` binds the checkbox to `opts.importEnvironments`, which `postman.ts` never reads.

### Parser

`PostmanEnvironmentParser` (`app/src/services/importers/postman-environment.ts`) detects `_postman_variable_scope` of `"environment"` **or** `"globals"` together with an array `values`, and is registered third: `PostmanV21 → PostmanV20 → PostmanEnvironment → InsomniaV4 → OpenApiV3 → OpenApiV2`. The position is not load-bearing - neither export has `info` or `item[]`, so v2.0's permissive fallback branch cannot claim them - and there is a test pinning that a collection export still routes to the collection parser.

`toVarRecord` now reads Postman's per-variable `type`: `"secret"` sets `secret: true`, anything else **omits** the flag (not `secret: false`), so a non-secret variable serialises exactly as it did before. Value, enabled/disabled precedence, keyless-entry dropping and `{{ var }}` normalisation are inherited unchanged.

### Globals (follow-up, per the issue comment)

The original revision of this PR left `_postman_variable_scope: "globals"` **unclaimed**, treating "may an import write Vayu's globals scope" as an open product decision. [The issue comment](https://github.com/athrvk/vayu/issues/153#issuecomment-5102747238) settles it - *"Postman's Globals also need to be imported"* - so that decision is now made and this branch implements it.

**One parser, two destinations.** The globals export has an identical document shape, so it is claimed by the same parser rather than a copy - a hand-rolled second parser would not receive the first one's fixes. An environment export still becomes an `EnvironmentDraft`; a globals export fills the new `ImportResult.globals` record. `meta.format` is per-document (`Postman Environment` / `Postman Globals`) since one parser now covers two exports the user sees differently.

**The merge is the load-bearing part.** `POST /globals` **replaces** the whole set - the engine has no merge verb. Writing `result.globals` straight to it would silently delete every global the user already had, so `ImportOrchestrator.applyGlobals` reads the current set first and writes the union. On a name collision the imported value wins (the user explicitly asked for this file's variables; keeping the old one silently would be the no-op outcome the issue calls the worst of the three), and the preview says so inline: *"Existing globals are kept; a variable of the same name is overwritten."*

**Ordering is deliberate.** Globals are written **last**, after every collection and environment. It is the one write here that can destroy data the import did not create, so nothing may fail behind it - which means a failed import never leaves globals half-rewritten, and `rollback()` needs no globals case at all rather than carrying a snapshot/restore path that could never fire. A test pins the ordering so a future reorder fails rather than silently creating that gap.

**`ImportResult.globals` is required, not optional.** Every parser states its answer (`{}` for the other four) rather than leaving the destination implicit - the compiler flagged all five sites plus the test fixtures when the field was added, which is the intended loudness.

Rejected alternative: importing globals as an ordinary environment named "Globals". It reuses the existing path with no orchestrator change, but Postman globals apply unconditionally while a Vayu environment applies only when selected, so it would quietly change what the variables mean.

### Decisions on the issue's open questions

- **Globals.** Implemented, see above.
- **`importEnvironments: false` on an environment-only file.** Honored at **parse time**, matching `InsomniaV4Parser`, so the preview reports what will be created rather than what the file contains. That makes the whole result empty, so the modal disables Import and states the reason instead of creating nothing and closing (the "silently importing nothing" outcome the issue called the worst of the three). The same single toggle governs globals - it reads "Import environments &amp; variables", and globals are variables, so no second control was added.
- **Empty secret values.** Imported as an empty enabled variable with `secret: true`, not skipped. Skipping would lose the key name too, with nothing on screen to say so.

### App changes

The result is the first with `collections: []`, which put two previously unreachable states on screen:

- **Preview renders environments and globals.** The tree listed collections only, so an environment-only import previewed as an empty box. It now renders one row per environment (name + variable count) beneath the collection tree, plus a single **Globals** row when the import carries any - named for the destination scope, since a globals export's own `name` is the workspace's and has nowhere to live in a singleton scope. This is for every format, not just this one. This is the "written but never read" shape: `environments` was parsed and never displayed.
- **Import is blocked when nothing would be created**, with the reason inline. The toggle that recovers it sits in the same footer, so the state is never a dead end.
- `Postman Env` and `Postman Globals` added to the format badges on the drop zone (the row is `flex-wrap`).
- `useImportMutation` invalidates `queryKeys.globals.all`; without it the imported variables sit on the engine unread until the next reload.

`ImportOrchestrator` gained `applyGlobals` and two `ImportApi` methods (`getGlobals` / `updateGlobals`); its collection loop still simply does not execute, and environment creation was already gated on `opts.importEnvironments`.

### Deviations from the issue spec

None. Multi-file workspace dumps were listed as out of scope in the issue and remain so.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run on this branch; no pre-existing failures observed.

| Command | Result |
|---|---|
| `cd app &amp;&amp; pnpm test` | **189 files, 1467 tests passed** |
| `cd app &amp;&amp; pnpm type-check` | clean |
| `cd app &amp;&amp; pnpm lint` | 122 problems - **identical to the `master` baseline**, measured by stashing this branch's changes and re-running; no new file contributes any |
| `pnpm exec prettier --check` (touched files only) | clean |
| `python build.py -e -t` + `ctest --preset linux-dev` | **387/387 passed** (no engine files touched; run as a regression check) |
| `mkdocs build --strict -f .github/mkdocs.yml` | clean |

New tests for the globals path (18 added on top of the environment work, 1449 → 1467):

- `postman-environment.test.ts` - detection for both scopes, the globals mapping (secret flag, disabled entry, `{{ spaced }}` normalisation), the exact `meta` shape incl. `globalCount`, the dropped workspace name, and `importEnvironments: false` per scope.
- `factory.test.ts` - the globals export routes and reports `Postman Globals`; the previous "stays unrecognised" assertion is inverted rather than deleted.
- `orchestrator.test.ts` - the merge preserves existing globals, the collision rule, a result with no globals neither reads nor writes the scope, the `importEnvironments: false` skip, rollback when the globals write fails, and the globals-last ordering.
- `queries/import.test.ts` - `getGlobals` / `updateGlobals` delegation and the globals cache invalidation.
- `ImportModal.environments.test.tsx` - the Globals preview row and count, the merge notice, Import staying enabled, and blocked-then-recovered via the toggle.

**Mutation-checked**, not assumed - each fix reverted, the failure observed, then restored:

| Mutation | Result |
|---|---|
| `applyGlobals` writes without merging | 1 failure |
| globals written first instead of last | 2 failures |
| `nothingToImport` ignores globals | 2 failures |
| preview drops the globals row | 2 failures |
| parser stops claiming the globals scope | 2 failures |
| globals cache invalidation removed | 1 failure |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/import-collections/postman-environment.md` now covers both scopes (detection, the merge and collision rules, the ordering rationale, the result shape) and its `nav:` entry is retitled; the import README's format table; and the import claims in `README.md` and `docs/index.md` name globals. The caveats added by #152 remain removed.

## Related Issues
Closes #153