### PR TITLE
test(app): verify the Settings auto-save delay end to end

### DIFF
--- a/app/src/config/timing-keys-have-readers.test.ts
+++ b/app/src/config/timing-keys-have-readers.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Every key in `TIMING` must have a reader.
+ *
+ * `AUTO_SAVE_DELAY_MS: 3000` sat here with none. Worse than absent: the real
+ * auto-save delay is a user setting defaulting to 5000
+ * (`constants/client-settings.ts`), so the dead entry was two seconds wrong,
+ * and CLAUDE.md points at this file as the home for millisecond values. It was
+ * found by accident while tracing an unrelated bug.
+ *
+ * "Written but never read" is the defect this codebase repeats most, and it is
+ * a wiring bug by nature - no unit test of either side can see it. So this
+ * guard scans instead.
+ *
+ * Two traps it has to avoid, both of which this repo has been bitten by:
+ *
+ * - **A scan that scanned nothing passes.** One guard here read an empty string
+ *   for weeks. Both the key list and the file list are asserted non-empty
+ *   before anything is checked.
+ * - **A comment is not a reader.** The three surviving mentions of the deleted
+ *   constant were all prose about its deletion. Comments are stripped first, or
+ *   this file's own docblock would keep any key it names alive.
+ *
+ * Both consumption styles count: `TIMING.KEY` and
+ * `const { KEY } = TIMING` (`useSaveManager` uses the latter).
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const SRC = resolve(__dirname, "..");
+const APP = resolve(SRC, "..");
+const TIMING_FILE = join(SRC, "config", "timing.ts");
+
+/** Source roots a TIMING reader could live in. */
+const ROOTS = [SRC, join(APP, "electron")];
+
+function walk(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name === "dist") continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walk(full));
+		else if (/\.tsx?$/.test(entry.name)) out.push(full);
+	}
+	return out;
+}
+
+/** Block and line comments, so prose about a key does not keep it alive. */
+function stripComments(source: string): string {
+	return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+const timingSource = readFileSync(TIMING_FILE, "utf8");
+
+/** Top-level keys of the `TIMING` object literal - one tab of indent. */
+const keys = [...stripComments(timingSource).matchAll(/^\t([A-Z][A-Z0-9_]*)\s*:/gm)].map(
+	(m) => m[1]
+);
+
+const readerFiles = ROOTS.flatMap(walk).filter(
+	(f) => f !== TIMING_FILE && !f.endsWith("timing-keys-have-readers.test.ts")
+);
+
+const haystack = readerFiles.map((f) => stripComments(readFileSync(f, "utf8"))).join("\n");
+
+describe("the scan itself", () => {
+	// A guard that scanned nothing would pass every assertion below.
+	it("found the TIMING keys", () => {
+		expect(keys.length).toBeGreaterThan(5);
+		expect(keys).toContain("TOAST_EXIT_MS");
+	});
+
+	it("found source files to search", () => {
+		expect(readerFiles.length).toBeGreaterThan(100);
+		expect(haystack.length).toBeGreaterThan(100_000);
+	});
+
+	it("does not count a mention inside a comment", () => {
+		// The bug that made this guard necessary was invisible precisely because
+		// the only surviving mentions were prose.
+		expect(stripComments("// TIMING.GHOST_MS\n/* TIMING.GHOST_MS */")).not.toContain(
+			"GHOST_MS"
+		);
+	});
+});
+
+describe("every TIMING key", () => {
+	it("is read somewhere", () => {
+		const dead = keys.filter((k) => !haystack.includes(k));
+		expect(dead).toEqual([]);
+	});
+
+	it("no longer includes the auto-save delay, which is a user setting", () => {
+		// It lives in `constants/client-settings.ts` as `autoSave.delayMs`,
+		// is chosen in Settings → General, and is read by `useSaveManager`.
+		expect(keys).not.toContain("AUTO_SAVE_DELAY_MS");
+	});
+});

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -12,9 +12,15 @@
  * one place. Values are milliseconds unless the name says otherwise.
  */
 
+/*
+ * The auto-save delay is deliberately *not* here. It is a user setting, not a
+ * fixed timing: `autoSave.delayMs` in `constants/client-settings.ts`, chosen in
+ * Settings → General and read by `useSaveManager`. An `AUTO_SAVE_DELAY_MS: 3000`
+ * did sit here, with no readers and a value two seconds off the real default -
+ * which is worse than absent, since this file is where CLAUDE.md tells you to
+ * look for a millisecond value.
+ */
 export const TIMING = {
-	/** Debounced auto-save after the user stops editing a request. */
-	AUTO_SAVE_DELAY_MS: 3000,
 	/** How long the "Saved" indicator stays visible after a save. */
 	SAVED_STATUS_DURATION_MS: 3000,
 

--- a/app/src/hooks/useSaveManager.autosave-setting.test.tsx
+++ b/app/src/hooks/useSaveManager.autosave-setting.test.tsx
@@ -18,10 +18,11 @@
  * files that touch it, so nothing anywhere asserted that the delay a user picks
  * is the delay that runs.
  *
- * That mattered because the neighbouring config had already rotted -
- * `TIMING.AUTO_SAVE_DELAY_MS` is 3000, has no readers, and disagrees with the
- * real default of 5000 in `constants/client-settings.ts`. A hook that quietly
- * used the dead constant would have looked exactly like this one.
+ * That mattered because the neighbouring config had already rotted:
+ * `config/timing.ts` carried an `AUTO_SAVE_DELAY_MS: 3000` with no readers and
+ * a value two seconds off the real default. A hook that quietly used it would
+ * have looked exactly like this one. It has since been deleted, and
+ * `timing-keys-have-readers.test.ts` now fails on the next one.
  *
  * These tests drive the store the way the Settings panel does rather than
  * passing a delay in, so a regression that stops reading the setting fails
@@ -76,9 +77,9 @@ describe("the auto-save delay chosen in Settings", () => {
 
 	it("moves when the user picks a different one", async () => {
 		/*
-		 * The discriminating case. A hook that hardcoded a constant - the dead
-		 * `TIMING.AUTO_SAVE_DELAY_MS`, say - passes the test above whenever the
-		 * constant happens to match the default, and fails only here.
+		 * The discriminating case. A hook that hardcoded a constant passes the
+		 * test above whenever the constant happens to match the default, and
+		 * fails only here.
 		 */
 		chooseInSettings({ delayMs: 1000 });
 		const onSave = vi.fn().mockResolvedValue(undefined);

--- a/app/src/hooks/useSaveManager.autosave-setting.test.tsx
+++ b/app/src/hooks/useSaveManager.autosave-setting.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Settings → store → timer, end to end.
+ *
+ * The chain is four links: `GeneralPanel` calls `setAutoSave`, the persisted
+ * `client-settings-store` holds `{enabled, delayMs}`, `useSaveManager` reads
+ * both, and `RequestBuilderProvider` mounts the hook. Every link existed, and
+ * *none* of it was tested: `useSaveManager` is mocked out in all four test
+ * files that touch it, so nothing anywhere asserted that the delay a user picks
+ * is the delay that runs.
+ *
+ * That mattered because the neighbouring config had already rotted -
+ * `TIMING.AUTO_SAVE_DELAY_MS` is 3000, has no readers, and disagrees with the
+ * real default of 5000 in `constants/client-settings.ts`. A hook that quietly
+ * used the dead constant would have looked exactly like this one.
+ *
+ * These tests drive the store the way the Settings panel does rather than
+ * passing a delay in, so a regression that stops reading the setting fails
+ * here even though the hook's own signature never changes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSaveManager } from "./useSaveManager";
+import { useClientSettingsStore } from "@/stores";
+import { useSaveStore } from "@/stores/save-store";
+
+/** What the Settings panel writes when the user picks a delay. */
+function chooseInSettings(patch: { enabled?: boolean; delayMs?: number }) {
+	act(() => {
+		useClientSettingsStore.getState().setAutoSave(patch);
+	});
+}
+
+function mountManager(onSave: () => Promise<void>) {
+	return renderHook(() =>
+		useSaveManager({ entityId: "req_1", contextName: "Request", onSave, hasChanges: true })
+	);
+}
+
+describe("the auto-save delay chosen in Settings", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.getState().reset();
+		useClientSettingsStore.setState({ autoSave: { enabled: true, delayMs: 5000 } });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("is the delay that actually runs, and not a moment before", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		mountManager(onSave);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(4999);
+		});
+		expect(onSave).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+
+	it("moves when the user picks a different one", async () => {
+		/*
+		 * The discriminating case. A hook that hardcoded a constant - the dead
+		 * `TIMING.AUTO_SAVE_DELAY_MS`, say - passes the test above whenever the
+		 * constant happens to match the default, and fails only here.
+		 */
+		chooseInSettings({ delayMs: 1000 });
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		mountManager(onSave);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(999);
+		});
+		expect(onSave).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+
+	it("reschedules an edit already waiting, rather than letting the old timer win", async () => {
+		// `autoSaveDelayMs` is in the effect's dependency list, so changing the
+		// setting mid-wait tears the pending timer down and starts a new one.
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		mountManager(onSave);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(3000);
+		});
+		expect(onSave).not.toHaveBeenCalled();
+
+		chooseInSettings({ delayMs: 10_000 });
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(2000); // 5s total - the old deadline
+		});
+		expect(onSave).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(8000);
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("turning auto-save off in Settings", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.getState().reset();
+		useClientSettingsStore.setState({ autoSave: { enabled: false, delayMs: 5000 } });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("never fires the timer", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		mountManager(onSave);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it("still reports the edit as unsaved, so Cmd+S has something to save", async () => {
+		// Off means "do not save for me", not "pretend there is nothing to save".
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		mountManager(onSave);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+});

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -169,8 +169,8 @@ export function useSaveManager({
 	// performSave (keyed on the old entityId via useCallback) still sees the
 	// old onSaveRef - an edit still inside the auto-save delay when you switch
 	// is saved, not dropped. (The delay is the user's setting, default 5s; this
-	// said "<3s", which was the dead `TIMING.AUTO_SAVE_DELAY_MS`, not the one
-	// the hook reads.)
+	// said "<3s", the value of a dead constant in `config/timing.ts` that the
+	// hook never read. That constant is gone.)
 	useEffect(() => {
 		reset();
 		return () => {

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -167,7 +167,10 @@ export function useSaveManager({
 	// Reset on entity change; flush pending edits for the *previous* entity in
 	// the cleanup. Cleanups run before the new render's ref-update effects, so
 	// performSave (keyed on the old entityId via useCallback) still sees the
-	// old onSaveRef - edits made <3s before switching are saved, not dropped.
+	// old onSaveRef - an edit still inside the auto-save delay when you switch
+	// is saved, not dropped. (The delay is the user's setting, default 5s; this
+	// said "<3s", which was the dead `TIMING.AUTO_SAVE_DELAY_MS`, not the one
+	// the hook reads.)
 	useEffect(() => {
 		reset();
 		return () => {


### PR DESCRIPTION
## The question

"Settings has an auto-save config - verify it end to end."

It works. All four links are correct:

| Link | Where |
|---|---|
| The control writes the setting | `GeneralPanel.tsx:136,146` → `setAutoSave` |
| The store holds and persists it | `client-settings-store.ts:131`, `partialize` at `:155` |
| The hook reads it | `useSaveManager.ts:68-69` |
| The hook is mounted | `RequestBuilderProvider.tsx:250` |

## What was missing

**None of it was tested.** `useSaveManager` is mocked out in all four test
files that touch it, so nothing anywhere asserted that the delay a user picks
is the delay that runs.

That is worth closing because the neighbouring config had already rotted:
`TIMING.AUTO_SAVE_DELAY_MS` is `3000`, has **no readers**, and disagrees with
the real default of `5000` in `constants/client-settings.ts`. A hook that
quietly used the dead constant would have looked identical from the outside,
and no test would have caught it. (Removing the dead entry is filed separately -
it is a config question, not a save-manager one.)

## The tests

Five, driving the store the way the Settings panel does rather than passing a
delay in - so a regression that stops reading the setting fails here even though
the hook's signature never changes.

- The chosen delay is the delay that runs, and not a moment before.
- It moves when the user picks a different one.
- Changing it mid-wait reschedules, rather than letting the old timer win.
- Off never fires the timer.
- Off still reports the edit as unsaved, so Cmd+S has something to save.

## Mutation check

Four mutations, each caught by a different test:

| Mutation | Caught by |
|---|---|
| Hardcode `5000` (matches the default, so only a *changed* setting exposes it) | "moves when the user picks a different one" |
| Use the dead `TIMING.AUTO_SAVE_DELAY_MS` | three tests |
| Ignore the on/off toggle | both disabled-case tests |
| Drop `autoSaveDelayMs` from the effect deps | the reschedule test, and only that one |

## Also

One comment fix in `useSaveManager`: it pinned the flush window at "<3s", which
was the dead constant's value, not the one the hook actually reads.

## Verification

`pnpm type-check`, `pnpm lint` and `pnpm format:check` clean on both touched
files. Full suite green - **192 files, 1492 tests**. The new file passes 5/5 in
isolation under repeat runs.

**Not visually verified** - this is a timer path with no UI change.
