### PR TITLE
fix(app): give tooltips one delay, set once at the app root

### DIFF
--- a/app/src/components/layout/Dock.tsx
+++ b/app/src/components/layout/Dock.tsx
@@ -9,7 +9,7 @@ import { FolderOpen, Clock, Braces, PanelRight, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatChord } from "@/lib/platform";
 import { useLayoutStore, useEngineStore, useSaveStore, type DrawerView } from "@/stores";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 
 interface DrawerButton {
 	view: DrawerView;
@@ -124,8 +124,10 @@ export function Dock() {
 	const { isEngineConnected } = useEngineStore();
 	const saveStatus = useSaveStore((s) => s.status);
 
+	// No TooltipProvider of its own. A bare nested one would reset this strip to
+	// Radix's 700ms default, ignoring the app-wide delay set in main.tsx.
 	return (
-		<TooltipProvider>
+		<>
 			{/*
 			 * Height comes from --dock-height, not a bare `h-8`, because the toast
 			 * viewport is `fixed` and has to offset itself above this strip - see
@@ -216,6 +218,6 @@ export function Dock() {
 					</DockButton>
 				</div>
 			</div>
-		</TooltipProvider>
+		</>
 	);
 }

--- a/app/src/components/layout/variables-icon.test.tsx
+++ b/app/src/components/layout/variables-icon.test.tsx
@@ -31,6 +31,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Dock } from "./Dock";
 import { TabStrip } from "./TabStrip";
@@ -73,9 +74,21 @@ function iconNames(root: Element): string[] {
 
 beforeEach(cleanup);
 
+/**
+ * `Dock` no longer mounts its own `TooltipProvider` - the delay is set once at
+ * the app root (`main.tsx`), and a bare nested provider would have reset this
+ * strip to Radix's 700ms. So the harness supplies one, as the app does.
+ */
+const renderDock = () =>
+	render(
+		<TooltipProvider>
+			<Dock />
+		</TooltipProvider>
+	);
+
 describe("the variables icon", () => {
 	it("is Braces in the Dock, not the load-test bolt", () => {
-		render(<Dock />);
+		renderDock();
 		const button = screen.getByRole("button", { name: "Variables" });
 
 		const names = iconNames(button);
@@ -87,7 +100,7 @@ describe("the variables icon", () => {
 	});
 
 	it("does not reuse an icon another Dock button already owns", () => {
-		render(<Dock />);
+		renderDock();
 		const nav = screen.getByRole("navigation", { name: "Sidebar views" });
 		const buttons = Array.from(nav.querySelectorAll("button"));
 
@@ -99,7 +112,7 @@ describe("the variables icon", () => {
 	it("keeps the bolt out of the drawer switchers entirely", () => {
 		// `Zap` means "load test" in this app. Any of the four wearing it would
 		// re-introduce the same misreading in a different slot.
-		render(<Dock />);
+		renderDock();
 		const nav = screen.getByRole("navigation", { name: "Sidebar views" });
 		expect(iconNames(nav)).not.toContain("zap");
 	});

--- a/app/src/components/ui/tooltip-delay.test.tsx
+++ b/app/src/components/ui/tooltip-delay.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One tooltip delay, and only the root sets it.
+ *
+ * `TIMING.TOOLTIP_DELAY_MS` documented itself as "used across the app" and
+ * reached almost none of it: `main.tsx` mounted a bare `<TooltipProvider>`, so
+ * Radix's 700ms default governed nearly every tooltip, while two components set
+ * 150ms locally.
+ *
+ * The quiet part is that a *bare* nested provider is not a no-op. Radix's
+ * `delayDuration` defaults to `DEFAULT_DELAY_DURATION = 700` on every provider,
+ * so a nested one with no prop **re-establishes 700ms for its subtree** rather
+ * than inheriting. `Dock` and `CollectionTree` each had one, which is why
+ * setting the root alone would not have reached them.
+ *
+ * Two things are guarded, because fixing one without the other does nothing:
+ *
+ *   1. The root passes the constant.
+ *   2. No component mounts a nested provider that would shadow it.
+ *
+ * The second is a source scan, so it asserts it scanned something first - a
+ * scan that reads nothing passes every assertion after it, which has happened
+ * in this repo before.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { TIMING } from "@/config/timing";
+
+const SRC = resolve(__dirname, "..", "..");
+
+function walk(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name === "dist") continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walk(full));
+		else if (/\.tsx$/.test(entry.name)) out.push(full);
+	}
+	return out;
+}
+
+/** Components, not test harnesses - a test may mount its own provider freely. */
+const componentFiles = walk(SRC).filter((f) => !/\.test\.tsx$/.test(f));
+
+const MAIN = join(SRC, "main.tsx");
+
+describe("the scan itself", () => {
+	it("found component files to search", () => {
+		expect(componentFiles.length).toBeGreaterThan(100);
+		expect(componentFiles).toContain(MAIN);
+	});
+});
+
+describe("the root provider", () => {
+	const main = readFileSync(MAIN, "utf8");
+
+	it("passes the shared delay rather than taking Radix's default", () => {
+		expect(main).toMatch(/<TooltipProvider\s+delayDuration=\{TIMING\.TOOLTIP_DELAY_MS\}>/);
+	});
+
+	it("uses a delay that is actually faster than the default it replaced", () => {
+		// A constant that drifted up to 700 would make the whole exercise a no-op
+		// while every assertion above still passed.
+		expect(TIMING.TOOLTIP_DELAY_MS).toBeGreaterThan(0);
+		expect(TIMING.TOOLTIP_DELAY_MS).toBeLessThan(700);
+	});
+});
+
+describe("nested providers", () => {
+	it("exist nowhere but the root, since a bare one re-establishes 700ms", () => {
+		const offenders = componentFiles.filter(
+			(f) => f !== MAIN && readFileSync(f, "utf8").includes("<TooltipProvider")
+		);
+		expect(offenders.map((f) => f.slice(SRC.length + 1))).toEqual([]);
+	});
+});

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -27,7 +27,17 @@ export const TIMING = {
 	/** Transient status feedback (copied / saved / error chips) reset delay. */
 	STATUS_RESET_MS: 2000,
 
-	/** Radix tooltip open delay used across the app. */
+	/**
+	 * Radix tooltip open delay, set once on the root `TooltipProvider` in
+	 * `main.tsx` and inherited everywhere.
+	 *
+	 * This comment used to claim "used across the app" while the root provider
+	 * set nothing, so Radix's 700ms default governed almost everything and two
+	 * components opted into 150ms locally. Worse, two more mounted *bare* nested
+	 * providers, which do not inherit - a provider with no `delayDuration` prop
+	 * re-establishes 700ms for its subtree. Those are gone; a nested provider is
+	 * now the exception that has to say why.
+	 */
 	TOOLTIP_DELAY_MS: 150,
 
 	/** Engine health poll interval while the app is open. */

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -13,6 +13,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "./lib/query-client";
 import { TooltipProvider } from "./components/ui";
+import { TIMING } from "./config/timing";
 import { ErrorBoundary } from "./errors";
 import App from "./App";
 import "./index.css";
@@ -21,7 +22,18 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 	<React.StrictMode>
 		<ErrorBoundary>
 			<QueryClientProvider client={queryClient}>
-				<TooltipProvider>
+				{/*
+				 * One tooltip delay for the whole app.
+				 *
+				 * This was a bare provider, so Radix's 700ms default governed almost
+				 * everything while two components set 150ms locally - and two more
+				 * mounted bare nested providers, which *re-establish* 700ms for their
+				 * subtree rather than inheriting. `TIMING.TOOLTIP_DELAY_MS` described
+				 * itself as "used across the app" and reached none of it.
+				 *
+				 * A nested provider is now the exception that has to justify itself.
+				 */}
+				<TooltipProvider delayDuration={TIMING.TOOLTIP_DELAY_MS}>
 					<App />
 				</TooltipProvider>
 				<ReactQueryDevtools initialIsOpen={false} />

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -25,7 +25,6 @@ import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
-	TooltipProvider,
 	DeleteConfirmDialog,
 } from "@/components/ui";
 import CollectionItem from "./CollectionItem";
@@ -529,64 +528,64 @@ export default function CollectionTree() {
 			title="Collections"
 			actions={
 				<>
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									variant="ghost"
-									size="icon"
-									onClick={handleOpenNewCollectionForm}
-									disabled={createCollectionMutation.isPending}
-									className="h-8 w-8"
-									aria-label="Add collection"
-								>
-									{createCollectionMutation.isPending ? (
-										<Loader2 className="w-4 h-4 animate-spin" />
-									) : (
-										<FolderPlus className="w-4 h-4" />
-									)}
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Add collection</TooltipContent>
-						</Tooltip>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									variant="ghost"
-									size="icon"
-									onClick={handleNewRequestClick}
-									disabled={createRequestMutation.isPending}
-									className="h-8 w-8"
-									aria-label="Add request"
-								>
-									{createRequestMutation.isPending ? (
-										<Loader2 className="w-4 h-4 animate-spin" />
-									) : (
-										<Plus className="w-4 h-4" />
-									)}
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>
-								{selectedCollectionId
-									? `Add request in ${collections.find((c) => c.id === selectedCollectionId)?.name ?? "selected collection"}`
-									: "Add request"}
-							</TooltipContent>
-						</Tooltip>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									variant="ghost"
-									size="icon"
-									onClick={openImport}
-									className="h-8 w-8"
-									aria-label="Import collection"
-								>
-									<Download className="w-4 h-4" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Import collection</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+					{/* No TooltipProvider - a bare nested one would reset this
+					    subtree to Radix's 700ms, ignoring main.tsx. */}
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={handleOpenNewCollectionForm}
+								disabled={createCollectionMutation.isPending}
+								className="h-8 w-8"
+								aria-label="Add collection"
+							>
+								{createCollectionMutation.isPending ? (
+									<Loader2 className="w-4 h-4 animate-spin" />
+								) : (
+									<FolderPlus className="w-4 h-4" />
+								)}
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Add collection</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={handleNewRequestClick}
+								disabled={createRequestMutation.isPending}
+								className="h-8 w-8"
+								aria-label="Add request"
+							>
+								{createRequestMutation.isPending ? (
+									<Loader2 className="w-4 h-4 animate-spin" />
+								) : (
+									<Plus className="w-4 h-4" />
+								)}
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							{selectedCollectionId
+								? `Add request in ${collections.find((c) => c.id === selectedCollectionId)?.name ?? "selected collection"}`
+								: "Add request"}
+						</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={openImport}
+								className="h-8 w-8"
+								aria-label="Import collection"
+							>
+								<Download className="w-4 h-4" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Import collection</TooltipContent>
+					</Tooltip>
 				</>
 			}
 		>

--- a/app/src/modules/dashboard/components/RequestResponseView.primitives.test.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.primitives.test.tsx
@@ -22,6 +22,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
 import RequestResponseView from "./RequestResponseView";
 import type { RunReport } from "@/types";
 
@@ -62,16 +63,25 @@ function makeReport(): RunReport {
 	};
 }
 
+// Components here use `InfoChip`, which no longer brings its own
+// `TooltipProvider` - the delay is set once at the app root (main.tsx).
+const renderView = () =>
+	render(
+		<TooltipProvider>
+			<RequestResponseView report={makeReport()} />
+		</TooltipProvider>
+	);
+
 describe("RequestResponseView shared-primitive adoption (#60)", () => {
 	it("renders the sample status through StatusCodeBadge", () => {
-		render(<RequestResponseView report={makeReport()} />);
+		renderView();
 		const chip = screen.getByText("200 OK");
 		// The chip variant, not the old semantic-variant Badge.
 		expect(chip.className).toContain("text-primary-foreground");
 	});
 
 	it("formats per-sample phase durations with formatPhaseDuration, not raw toFixed(1)", () => {
-		render(<RequestResponseView report={makeReport()} />);
+		renderView();
 		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
 
 		// 0.04ms keeps its significant digits through formatPhaseDuration; the
@@ -81,7 +91,7 @@ describe("RequestResponseView shared-primitive adoption (#60)", () => {
 	});
 
 	it("renders response headers through the shared CompactHeadersViewer", () => {
-		render(<RequestResponseView report={makeReport()} />);
+		renderView();
 		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
 
 		// CompactHeadersViewer renders each name as `key:`; the reverted

--- a/app/src/modules/dashboard/components/hero/hero.characterization.test.tsx
+++ b/app/src/modules/dashboard/components/hero/hero.characterization.test.tsx
@@ -9,6 +9,7 @@
 
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
 import { RateFidelityCard } from "./RateFidelityCard";
 import { ThroughputTwinCard } from "./ThroughputTwinCard";
 import { ErrorRateCard } from "./ErrorRateCard";
@@ -30,7 +31,9 @@ const notCrossed: Breakpoint = {
 };
 
 const snap = (ui: React.ReactElement) => {
-	const { container } = render(ui);
+	// Components here use `InfoChip`, which no longer brings its own
+	// `TooltipProvider` - the delay is set once at the app root (main.tsx).
+	const { container } = render(<TooltipProvider>{ui}</TooltipProvider>);
 	expect(container.innerHTML).toMatchSnapshot();
 };
 

--- a/app/src/modules/dashboard/components/shared.tsx
+++ b/app/src/modules/dashboard/components/shared.tsx
@@ -7,31 +7,30 @@
 
 import { type ReactNode } from "react";
 import { Info } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { TIMING } from "@/config/timing";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export const EYEBROW_CLASS =
 	"text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground";
 
 /** Tiny "i" affordance with a Radix tooltip. */
 export function InfoChip({ tip }: { tip: ReactNode }) {
+	// No TooltipProvider of its own: the delay is set once at the app root
+	// (main.tsx). A nested one here would only re-declare what it inherits.
 	return (
-		<TooltipProvider delayDuration={TIMING.TOOLTIP_DELAY_MS}>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						className="ml-1.5 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-border bg-accent text-muted-foreground hover:border-primary/40 hover:bg-primary/10 hover:text-primary transition-colors cursor-help align-middle"
-						aria-label="More information"
-					>
-						<Info className="h-2.5 w-2.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent className="max-w-[260px] text-[11px] leading-relaxed">
-					{tip}
-				</TooltipContent>
-			</Tooltip>
-		</TooltipProvider>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					className="ml-1.5 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-border bg-accent text-muted-foreground hover:border-primary/40 hover:bg-primary/10 hover:text-primary transition-colors cursor-help align-middle"
+					aria-label="More information"
+				>
+					<Info className="h-2.5 w-2.5" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-[260px] text-[11px] leading-relaxed">
+				{tip}
+			</TooltipContent>
+		</Tooltip>
 	);
 }
 

--- a/app/src/modules/history/main/components/historyDetail.characterization.test.tsx
+++ b/app/src/modules/history/main/components/historyDetail.characterization.test.tsx
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 import LoadTestDetail from "../LoadTestDetail";
@@ -22,7 +23,13 @@ import type { RunReport } from "@/types";
  */
 function renderWithClient(ui: ReactElement) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+	// Components here use `InfoChip`, which no longer brings its own
+	// `TooltipProvider` - the delay is set once at the app root (main.tsx).
+	return render(
+		<QueryClientProvider client={qc}>
+			<TooltipProvider>{ui}</TooltipProvider>
+		</QueryClientProvider>
+	);
 }
 
 function report(mode: string, cfg: Record<string, unknown>): RunReport {

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.test.tsx
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
 import ResponseTimingTab from "./ResponseTimingTab";
 import type { ResponseTiming } from "../../types";
 
@@ -21,9 +22,20 @@ const sample: ResponseTiming = {
 	downloadMs: 0,
 };
 
+/**
+ * The tab no longer mounts its own `TooltipProvider` - the delay is set once at
+ * the app root (`main.tsx`). So the harness supplies one, as the app does.
+ */
+const renderTab = (props: React.ComponentProps<typeof ResponseTimingTab>) =>
+	render(
+		<TooltipProvider>
+			<ResponseTimingTab {...props} />
+		</TooltipProvider>
+	);
+
 describe("ResponseTimingTab", () => {
 	it("renders all five phases with their millisecond values", () => {
-		render(<ResponseTimingTab timing={sample} />);
+		renderTab({ timing: sample });
 		for (const label of ["DNS", "Connect", "TLS", "TTFB", "Download"]) {
 			expect(screen.getByText(label)).toBeInTheDocument();
 		}
@@ -34,7 +46,7 @@ describe("ResponseTimingTab", () => {
 	});
 
 	it("computes each phase as a percentage of the summed network phases", () => {
-		render(<ResponseTimingTab timing={sample} />);
+		renderTab({ timing: sample });
 		// phaseSum = 64+214+517+213+0 = 1008. TLS = 517/1008 ≈ 51%.
 		expect(screen.getByText("51%")).toBeInTheDocument();
 		// Download = 0 → 0%.
@@ -42,7 +54,7 @@ describe("ResponseTimingTab", () => {
 	});
 
 	it("shows Wire, Queue and Total in the summary", () => {
-		render(<ResponseTimingTab timing={sample} />);
+		renderTab({ timing: sample });
 		expect(screen.getByText("Wire")).toBeInTheDocument();
 		expect(screen.getByText("Queue")).toBeInTheDocument();
 		expect(screen.getByText("Total")).toBeInTheDocument();
@@ -66,7 +78,7 @@ describe("ResponseTimingTab", () => {
 			firstByteMs: 7,
 			downloadMs: 0,
 		};
-		render(<ResponseTimingTab timing={minimal} />);
+		renderTab({ timing: minimal });
 		expect(screen.queryByText("Wire")).not.toBeInTheDocument();
 		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
 		expect(screen.getByText("Total")).toBeInTheDocument();
@@ -83,7 +95,7 @@ describe("ResponseTimingTab", () => {
 			firstByteMs: 0,
 			downloadMs: 0,
 		};
-		render(<ResponseTimingTab timing={zero} />);
+		renderTab({ timing: zero });
 		// Every phase share is 0% - at least the five legend rows render it.
 		expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(5);
 	});

--- a/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/ResponseTimingTab.tsx
@@ -21,9 +21,8 @@ import { type ReactNode } from "react";
 import { formatDuration, formatPhaseDuration } from "@/components/shared/response-viewer/utils";
 import { PHASE_TIPS } from "@/components/shared/response-viewer/phase-tips";
 import { Info } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ResponseTiming } from "../../types";
-import { TIMING } from "@/config/timing";
 
 interface Phase {
 	key: string;
@@ -33,25 +32,30 @@ interface Phase {
 	tip: ReactNode;
 }
 
-/** Tiny "i" affordance with a Radix tooltip (local to keep this tab self-contained). */
+/**
+ * Tiny "i" affordance with a Radix tooltip.
+ *
+ * No `TooltipProvider` of its own. It had one *inside* this component, so a
+ * five-phase timing tab mounted five of them; and now that the delay is set
+ * once at the app root (main.tsx), even one here would only re-declare what it
+ * inherits.
+ */
 function InfoTip({ tip }: { tip: ReactNode }) {
 	return (
-		<TooltipProvider delayDuration={TIMING.TOOLTIP_DELAY_MS}>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						className="ml-1 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-border bg-accent text-muted-foreground hover:border-primary/40 hover:bg-primary/10 hover:text-primary transition-colors cursor-help align-middle"
-						aria-label="More information"
-					>
-						<Info className="h-2.5 w-2.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent className="max-w-[260px] text-[11px] leading-relaxed">
-					{tip}
-				</TooltipContent>
-			</Tooltip>
-		</TooltipProvider>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					className="ml-1 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-border bg-accent text-muted-foreground hover:border-primary/40 hover:bg-primary/10 hover:text-primary transition-colors cursor-help align-middle"
+					aria-label="More information"
+				>
+					<Info className="h-2.5 w-2.5" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-[260px] text-[11px] leading-relaxed">
+				{tip}
+			</TooltipContent>
+		</Tooltip>
 	);
 }
 


### PR DESCRIPTION
`TIMING.TOOLTIP_DELAY_MS` documented itself as "Radix tooltip open delay used
across the app" and reached almost none of it.

## What was actually happening

| Provider | Delay |
|---|---|
| `main.tsx` (root) | **700ms** - bare, so Radix's default |
| `Dock` | **700ms** - bare *nested* |
| `CollectionTree` | **700ms** - bare *nested* |
| dashboard `InfoChip` | 150ms |
| response `InfoTip` | 150ms, mounted **once per tip** |

## The part that makes this more than a one-line change

A bare nested provider is **not** a no-op. Radix defaults `delayDuration` to
`DEFAULT_DELAY_DURATION = 700` on *every* provider, so a nested one with no prop
**re-establishes 700ms for its subtree** rather than inheriting from above.

`Dock` and `CollectionTree` were not neutral wrappers - they were actively
pinning those two surfaces at the default. Setting the root alone would have left
the dock and the collections tree exactly as they were, and looked like it worked
everywhere else.

## The change

The root passes the constant. All four nested providers are gone, including the
timing tab's, which mounted one *per tip* - five for a five-phase tab. A nested
provider is now the exception that has to say why.

Those components consequently require an ancestor provider, as every other
tooltip user already did. **Five test harnesses** that rendered them standalone
supply one now, matching the rest of the suite. A Radix provider renders no DOM,
so the characterization tests' output is unchanged.

## Guard

`components/ui/tooltip-delay.test.tsx` pins **both halves**, because fixing
either alone does nothing:

1. The root passes the constant.
2. No component mounts a nested provider that would shadow it.

The second is a source scan, so it asserts it scanned something first.

| Mutation | Fails |
|---|---|
| Root back to a bare provider | 1 |
| `Dock` given back a bare nested provider | 1 |
| Constant drifts up to 700 (a silent no-op) | 1 |

That third one matters: without it, someone could "keep" this change and undo its
entire effect while every other assertion stayed green.

## User-visible effect

**Tooltips across the app now open in 150ms rather than 700ms.** That is the
point, and it is a real change of feel. The two surfaces already at 150ms - the
dashboard info chips and the response timing tab - are what everything else now
matches.

## Note on #160

[#160](https://github.com/athrvk/vayu/pull/160) hoists the timing tab's provider
to the tab root rather than removing it, because at that point the root set no
delay. This PR removes it outright, so the two branches touch
`ResponseTimingTab.tsx` differently and will conflict. Whichever lands second
should keep **this** shape - no local provider, and the tab's test supplying one.

## Verification

`pnpm type-check`, `pnpm build`, full suite - **199 files, 1545 tests**. Lint
clean on the touched files (the 2 remaining warnings there are pre-existing,
confirmed against a stashed baseline).

**Not visually verified** - and since this changes tooltip feel app-wide, it is
worth opening the app and sweeping a few icon rows before merging.
