### PR TITLE
fix(app): take the GraphQL Content-Type header back when the body mode changes

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.test.tsx
@@ -54,6 +54,9 @@ function renderPanel(overrides: Partial<RequestState> = {}) {
 		// BodyPanel stashes through these on a mode change.
 		getBodyDrafts: () => emptyDrafts(request.id),
 		setBodyDrafts: () => {},
+		// And remembers the Content-Type row it wrote through these.
+		getAutoContentType: () => null,
+		setAutoContentType: () => {},
 		resolveString: (s: string) => s.replace(/\{\{(\w+)\}\}/g, (_m, n) => `resolved-${n}`),
 		// The form-data / urlencoded modes render the key/value table, which
 		// reaches VariableInput for every cell.

--- a/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
@@ -16,12 +16,15 @@
  * mode with an editor pair, an introspection lifecycle and a header side effect
  * of its own. It is its own component now.
  *
- * **Choosing GraphQL still adds a Content-Type header, but says so.** It used
- * to write `Content-Type: application/json` into `request.headers` in silence,
- * on a tab you are not looking at, and never take it back - so picking GraphQL
- * once and returning to None left the header behind for good. The header is
- * genuinely required, so it is still added; what changed is that the panel
- * announces it and offers the way back.
+ * **Choosing GraphQL still adds a Content-Type header, but says so - and
+ * leaving GraphQL removes it again.** It used to write `Content-Type:
+ * application/json` into `request.headers` in silence, on a tab you are not
+ * looking at, and never take it back - so picking GraphQL once and returning to
+ * None left the header behind for good, on a request that sends no body at all.
+ * The header is genuinely required, so it is still added; what changed is that
+ * the panel announces it, and that the next mode change takes back the row it
+ * wrote (`body/content-type.ts`, by row id - a Content-Type the user typed is
+ * indistinguishable by value and must survive).
  *
  * **The resolved preview swaps rather than splits.** It used to put the editor
  * and a read-only echo side by side at `grid-cols-2`, so the code you are
@@ -48,7 +51,7 @@ import { createEmptyKeyValue, toFlatHeaders } from "../../../utils/key-value";
 import { useResizable } from "@/hooks/useResizable";
 import { cn } from "@/lib/utils";
 import GraphQLBody from "./body/GraphQLBody";
-import { contentTypeToAdd, contentTypeRow, withoutContentType } from "./body/content-type";
+import { switchContentType, withoutContentType } from "./body/content-type";
 import { ContentTypeNotice } from "./body/ContentTypeNotice";
 import { switchBody } from "../../../utils/body-drafts";
 
@@ -144,8 +147,15 @@ function ResizeHandle({
 }
 
 export default function BodyPanel() {
-	const { request, updateField, resolveString, getBodyDrafts, setBodyDrafts } =
-		useRequestBuilderContext();
+	const {
+		request,
+		updateField,
+		resolveString,
+		getBodyDrafts,
+		setBodyDrafts,
+		getAutoContentType,
+		setAutoContentType,
+	} = useRequestBuilderContext();
 	const [showResolved, setShowResolved] = useState(false);
 
 	// Drag-to-resize editor height, shared across body modes that host an editor.
@@ -172,10 +182,13 @@ export default function BodyPanel() {
 	}, [editorHeight]);
 
 	/*
-	 * The Content-Type this mode change added, so it can be taken back.
+	 * The Content-Type this mode change added, for the notice.
 	 *
 	 * Null once dismissed, undone, or the mode changes again - the notice is
-	 * about the edit that just happened, not a standing state.
+	 * about the edit that just happened, not a standing state. *Which row* was
+	 * added is remembered separately and durably (`getAutoContentType`), because
+	 * removing it again must survive dismissing the notice and unmounting the
+	 * panel.
 	 */
 	const [addedContentType, setAddedContentType] = useState<string | null>(null);
 
@@ -213,7 +226,6 @@ export default function BodyPanel() {
 		if (body !== (request.body ?? "")) updateField("body", body);
 
 		updateField("bodyMode", mode);
-		setAddedContentType(null);
 
 		// Initialize appropriate data for mode
 		if (mode === "form-data" && request.formData.length === 0) {
@@ -224,21 +236,30 @@ export default function BodyPanel() {
 		}
 
 		/*
-		 * The mode may require a Content-Type. Adding it automatically is right -
-		 * GraphQL genuinely needs one - but doing so *silently*, to a tab the user
-		 * is not looking at, was not, and nothing ever removed it, so one visit to
-		 * this mode left the header on the request permanently.
+		 * The mode may require a Content-Type, and the mode being left may have
+		 * required one this panel added. Adding it automatically is right - GraphQL
+		 * genuinely needs one - but doing so *silently*, to a tab the user is not
+		 * looking at, was not, and nothing ever removed it: one visit to GraphQL
+		 * left the header on the request permanently, including after switching
+		 * back to None, which sends no body at all. Both halves happen in one call
+		 * because they read and write the same array.
 		 */
-		const required = contentTypeToAdd(mode, request.headers);
-		if (required) {
-			updateField("headers", [...request.headers, contentTypeRow(required)]);
-			setAddedContentType(required);
-		}
+		const contentType = switchContentType(
+			mode,
+			request.headers,
+			request.id,
+			getAutoContentType()
+		);
+		if (contentType.headers !== request.headers) updateField("headers", contentType.headers);
+		setAutoContentType(contentType.auto);
+		setAddedContentType(contentType.added);
 	};
 
 	const undoContentType = () => {
-		if (!addedContentType) return;
-		updateField("headers", withoutContentType(request.headers, addedContentType));
+		const auto = getAutoContentType();
+		if (!auto) return;
+		updateField("headers", withoutContentType(request.headers, auto));
+		setAutoContentType(null);
 		setAddedContentType(null);
 	};
 

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/ContentTypeNotice.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/ContentTypeNotice.tsx
@@ -6,7 +6,12 @@
  */
 
 /**
- * "Choosing this mode edited your Headers tab."
+ * "Choosing this mode edited your Headers tab, and will put it back."
+ *
+ * Undo is the impatient version of what a mode change does anyway - the row is
+ * removed when the body type next changes to one that does not need it. The
+ * notice says so, because an edit to a tab you are not looking at reads as
+ * permanent unless something tells you otherwise.
  *
  * Its own component so it can be rendered and tested directly. Inside the panel
  * it only appears after a Radix Select commits a value, and a Select does not
@@ -33,7 +38,7 @@ export function ContentTypeNotice({ value, onUndo, onDismiss }: ContentTypeNotic
 				<code className="font-mono">
 					{CONTENT_TYPE}: {value}
 				</code>{" "}
-				to Headers.
+				to Headers - removed again when you change body type.
 			</span>
 			<div className="flex shrink-0 items-center gap-1">
 				<Button size="sm" variant="ghost" onClick={onUndo} className="h-6 px-2 text-xs">

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.test.tsx
@@ -10,13 +10,14 @@
 
 /**
  * Choosing GraphQL edits the Headers tab. This is the rule that decides when,
- * and the notice that admits it.
+ * when it puts the edit back, and the notice that admits both.
  *
  * The old version did it inside `handleModeChange`: appended
  * `Content-Type: application/json` with no feedback of any kind - the Headers
  * tab's count badge simply went up - and **nothing ever removed it**, so one
  * visit to GraphQL left the header on the request permanently, including after
- * switching back to None.
+ * switching back to None. The notice fixed the first half; `switchContentType`
+ * fixes the second.
  *
  * The rule is tested here rather than through the panel because the panel only
  * runs it when a Radix Select commits a value, and a Select does not commit in
@@ -27,9 +28,16 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { contentTypeToAdd, withoutContentType, contentTypeRow, CONTENT_TYPE } from "./content-type";
+import {
+	contentTypeToAdd,
+	requiredContentType,
+	switchContentType,
+	withoutContentType,
+	contentTypeRow,
+	CONTENT_TYPE,
+} from "./content-type";
 import { ContentTypeNotice } from "./ContentTypeNotice";
-import type { KeyValueItem } from "../../../../types";
+import type { AutoContentType, KeyValueItem } from "../../../../types";
 
 const header = (key: string, value: string, enabled = true): KeyValueItem => ({
 	id: `${key}-${value}`,
@@ -37,6 +45,8 @@ const header = (key: string, value: string, enabled = true): KeyValueItem => ({
 	value,
 	enabled,
 });
+
+const REQUEST = "req_a";
 
 describe("when a mode needs a Content-Type", () => {
 	it("asks for one on GraphQL, which is sent as a JSON envelope", () => {
@@ -80,15 +90,42 @@ describe("when a mode needs a Content-Type", () => {
 });
 
 describe("taking it back", () => {
+	const ours = (row: KeyValueItem): AutoContentType => ({
+		requestId: REQUEST,
+		rowId: row.id,
+		value: row.value,
+	});
+
 	it("removes the row that was added", () => {
-		const headers = [header("Accept", "*/*"), header(CONTENT_TYPE, "application/json")];
-		expect(withoutContentType(headers, "application/json")).toEqual([header("Accept", "*/*")]);
+		const added = header(CONTENT_TYPE, "application/json");
+		const headers = [header("Accept", "*/*"), added];
+		expect(withoutContentType(headers, ours(added))).toEqual([header("Accept", "*/*")]);
 	});
 
 	it("leaves a Content-Type it did not add", () => {
-		// Undo means "undo what I just did", not "delete any Content-Type".
-		const headers = [header(CONTENT_TYPE, "application/graphql")];
-		expect(withoutContentType(headers, "application/json")).toEqual(headers);
+		// Undo means "undo what I just did", not "delete any Content-Type" - and
+		// the user's own row is identical apart from its id.
+		const headers = [header(CONTENT_TYPE, "application/json")];
+		const someoneElses: AutoContentType = {
+			requestId: REQUEST,
+			rowId: "a-row-we-never-wrote",
+			value: "application/json",
+		};
+		expect(withoutContentType(headers, someoneElses)).toEqual(headers);
+	});
+
+	it("leaves the row alone once the user has retyped its value", () => {
+		// Same row, their content now: they changed application/json to
+		// application/graphql, which is a decision, not our leftover.
+		const added = header(CONTENT_TYPE, "application/json");
+		const retyped = { ...added, value: "application/graphql" };
+		expect(withoutContentType([retyped], ours(added))).toEqual([retyped]);
+	});
+
+	it("removes a row the user only switched off", () => {
+		// Disabling our row is not adopting it.
+		const added = header(CONTENT_TYPE, "application/json");
+		expect(withoutContentType([{ ...added, enabled: false }], ours(added))).toEqual([]);
 	});
 
 	it("builds an enabled row, or adding it would do nothing", () => {
@@ -97,6 +134,99 @@ describe("taking it back", () => {
 			value: "application/json",
 			enabled: true,
 		});
+	});
+});
+
+describe("what a mode change does to the header", () => {
+	const base = [header("Accept", "*/*")];
+
+	/** Into GraphQL, which is where every case below starts. */
+	const intoGraphql = (headers = base, requestId: string | null = REQUEST) =>
+		switchContentType("graphql", headers, requestId, null);
+
+	it("adds the header GraphQL needs, and remembers the row", () => {
+		const on = intoGraphql();
+		expect(on.added).toBe("application/json");
+		expect(on.headers).toHaveLength(2);
+		expect(on.auto).toMatchObject({ requestId: REQUEST, value: "application/json" });
+		expect(on.auto?.rowId).toBe(on.headers[1].id);
+	});
+
+	it("removes it again on the way out", () => {
+		// The reported bug: picking GraphQL and going back to None left
+		// `Content-Type: application/json` on a request that sends no body.
+		const on = intoGraphql();
+		const off = switchContentType("none", on.headers, REQUEST, on.auto);
+		expect(off.headers).toEqual(base);
+		expect(off.auto).toBeNull();
+		expect(off.added).toBeNull();
+	});
+
+	it.each(["json", "text", "form-data", "x-www-form-urlencoded"] as const)(
+		"removes it on the way to %s too",
+		(mode) => {
+			// JSON declares the same content type, but the engine sets it from the
+			// mode - the row we wrote is still ours to clear.
+			const on = intoGraphql();
+			expect(switchContentType(mode, on.headers, REQUEST, on.auto).headers).toEqual(base);
+		}
+	);
+
+	it("keeps the user's own Content-Type through the whole trip", () => {
+		// Nothing was added on the way in, so there is nothing to take away - and
+		// their row must not be mistaken for ours on the way out.
+		const theirs = [...base, header(CONTENT_TYPE, "application/json")];
+		const on = intoGraphql(theirs);
+		expect(on.added).toBeNull();
+		expect(on.headers).toEqual(theirs);
+		expect(switchContentType("none", on.headers, REQUEST, on.auto).headers).toEqual(theirs);
+	});
+
+	it("leaves the row behind once the user has retyped it", () => {
+		const on = intoGraphql();
+		const edited = on.headers.map((h) =>
+			h.id === on.auto?.rowId ? { ...h, value: "application/graphql" } : h
+		);
+		const off = switchContentType("none", edited, REQUEST, on.auto);
+		expect(off.headers).toEqual(edited);
+		// And it is no longer ours, so a later switch cannot come back for it.
+		expect(off.auto).toBeNull();
+	});
+
+	it("does not apply a record belonging to another request", () => {
+		// One provider serves every request tab and the record outlives the request
+		// that filled it. Row ids are not unique across a duplicated request, so an
+		// id match alone would delete a header from a request we never edited.
+		const on = intoGraphql(base, "req_a");
+		const off = switchContentType("none", on.headers, "req_b", on.auto);
+		expect(off.headers).toEqual(on.headers);
+	});
+
+	it("returns the same array when there is nothing to do", () => {
+		// The panel skips `updateField` on identity, so an unrelated mode change
+		// must not mark the request dirty.
+		const result = switchContentType("json", base, REQUEST, null);
+		expect(result.headers).toBe(base);
+	});
+
+	it("keeps the row when the next mode needs the same header", () => {
+		// No mode pair does this today; the rule is here so adding one does not
+		// silently churn the Headers tab by removing and re-adding the row.
+		const on = intoGraphql();
+		const again = switchContentType("graphql", on.headers, REQUEST, on.auto);
+		expect(again.headers).toBe(on.headers);
+		expect(again.auto).toBe(on.auto);
+		expect(again.added).toBeNull();
+	});
+});
+
+describe("what a mode requires", () => {
+	it("separates the requirement from whether it needs adding", () => {
+		// `contentTypeToAdd` answers "add one?" and goes null once a header is
+		// there; the switch needs "does this mode still want that value?", which
+		// must stay true for a request that already carries it.
+		expect(requiredContentType("graphql")).toBe("application/json");
+		expect(requiredContentType("json")).toBeNull();
 	});
 });
 

--- a/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.ts
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/body/content-type.ts
@@ -7,15 +7,26 @@
 
 /**
  * Choosing GraphQL adds a header to the request, which is a side effect on a
- * tab you are not looking at.
+ * tab you are not looking at - and **leaving GraphQL takes it back**.
  *
- * The rule is small but it is a *rule* - "does this mode require a Content-Type,
- * and does the request already carry one" - so it lives here rather than inside
- * a click handler, where the only way to exercise it is to drive a Radix Select
- * through jsdom.
+ * Adding it was only ever half the rule. Nothing removed it, so one visit to
+ * GraphQL left `Content-Type: application/json` on the request for good: switch
+ * back to None, which sends no body at all, and the header was still there,
+ * still going out on every send. The notice below the mode picker offered an
+ * Undo, but only while the panel was mounted and only until it was dismissed.
+ *
+ * So the panel remembers the row it wrote - which row, by id, and with what
+ * value - and a mode change that no longer needs that header removes it. Row id
+ * rather than "a Content-Type whose value is application/json", because those
+ * are not the same header: a Content-Type the *user* typed must survive a mode
+ * change, and it is indistinguishable by value.
+ *
+ * The rule is small but it is a *rule*, so it lives here rather than inside a
+ * click handler, where the only way to exercise it is to drive a Radix Select
+ * through jsdom - which does not commit a value there.
  */
 
-import type { BodyMode, KeyValueItem } from "../../../../types";
+import type { AutoContentType, BodyMode, KeyValueItem } from "../../../../types";
 import { generateId } from "../../../../utils/id";
 
 export const CONTENT_TYPE = "Content-Type";
@@ -27,6 +38,11 @@ const REQUIRED_CONTENT_TYPE: Partial<Record<BodyMode, string>> = {
 
 const isContentType = (item: KeyValueItem) =>
 	item.key.trim().toLowerCase() === CONTENT_TYPE.toLowerCase();
+
+/** The Content-Type a mode must be sent with, or null if it needs none. */
+export function requiredContentType(mode: BodyMode): string | null {
+	return REQUIRED_CONTENT_TYPE[mode] ?? null;
+}
 
 /**
  * The Content-Type this mode change should add, or null if none is needed.
@@ -40,17 +56,77 @@ const isContentType = (item: KeyValueItem) =>
  * so the request would go out without the header.
  */
 export function contentTypeToAdd(mode: BodyMode, headers: KeyValueItem[]): string | null {
-	const required = REQUIRED_CONTENT_TYPE[mode];
+	const required = requiredContentType(mode);
 	if (!required) return null;
 	return headers.some((h) => isContentType(h) && h.enabled) ? null : required;
 }
 
+/**
+ * Is this the row we wrote, unchanged?
+ *
+ * A row the user has since retyped - a different value, or a different header
+ * name - is theirs now, and stays. Being switched off does not hand it over:
+ * disabling our row is not the same as adopting it.
+ */
+const isOurs = (item: KeyValueItem, auto: AutoContentType) =>
+	item.id === auto.rowId && isContentType(item) && item.value === auto.value;
+
 /** The header list with the row this panel added taken back out. */
-export function withoutContentType(headers: KeyValueItem[], value: string): KeyValueItem[] {
-	return headers.filter((h) => !(isContentType(h) && h.value === value));
+export function withoutContentType(headers: KeyValueItem[], auto: AutoContentType): KeyValueItem[] {
+	return headers.filter((h) => !isOurs(h, auto));
 }
 
 /** The header row to append, ready for `updateField("headers", …)`. */
 export function contentTypeRow(value: string): KeyValueItem {
 	return { id: generateId(), key: CONTENT_TYPE, value, enabled: true };
+}
+
+export interface ContentTypeSwitch {
+	/** Headers for the new mode. The same array when nothing changed. */
+	headers: KeyValueItem[];
+	/** The row this panel now owns, or null if it owns none. */
+	auto: AutoContentType | null;
+	/** The value just added, for the notice, or null if nothing was added. */
+	added: string | null;
+}
+
+/**
+ * Remove the header the old mode needed, add the one the new mode does.
+ *
+ * Both halves in one place: they read and write the same array, and a panel
+ * that did them as two `updateField("headers", …)` calls would compute the
+ * second against the headers it had before the first.
+ *
+ * `requestId` is the request being edited *now*. A record belonging to another
+ * request is dropped rather than applied - the provider's ref outlives the
+ * request that filled it, and row ids are not unique across a duplicated
+ * request.
+ *
+ * Switching between two modes that need the *same* header keeps the row (and
+ * the record with it) rather than removing and re-adding it, which would churn
+ * the Headers tab and lose the row's position.
+ */
+export function switchContentType(
+	mode: BodyMode,
+	headers: KeyValueItem[],
+	requestId: string | null,
+	auto: AutoContentType | null
+): ContentTypeSwitch {
+	let next = headers;
+	let ours = auto?.requestId === requestId ? auto : null;
+
+	if (ours && requiredContentType(mode) !== ours.value) {
+		next = withoutContentType(next, ours);
+		ours = null;
+	}
+
+	const required = contentTypeToAdd(mode, next);
+	if (!required) return { headers: next, auto: ours, added: null };
+
+	const row = contentTypeRow(required);
+	return {
+		headers: [...next, row],
+		auto: { requestId, rowId: row.id, value: required },
+		added: required,
+	};
 }

--- a/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
@@ -44,6 +44,9 @@ function ctx(canStartLoadTest: boolean): RequestBuilderContextValue {
 		// complete.
 		getBodyDrafts: () => emptyDrafts(null),
 		setBodyDrafts: vi.fn(),
+		// Likewise the Content-Type row a body mode added: the Body panel's record.
+		getAutoContentType: () => null,
+		setAutoContentType: vi.fn(),
 		response: null,
 		setResponse: vi.fn(),
 		activeTab: "params",

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -32,6 +32,7 @@ import {
 import { useSessionStore, useResponseStore } from "@/stores";
 import type { ScriptPart, VariableValue } from "@/types";
 import type {
+	AutoContentType,
 	RequestState,
 	ResponseState,
 	RequestTab,
@@ -194,6 +195,24 @@ export default function RequestBuilderProvider({
 	const getBodyDrafts = useCallback(() => bodyDraftsRef.current, []);
 	const setBodyDrafts = useCallback((drafts: BodyDrafts) => {
 		bodyDraftsRef.current = drafts;
+	}, []);
+
+	/*
+	 * The Content-Type row a body mode added on its way in, so leaving the mode
+	 * can remove it again. Here rather than in `BodyPanel` for the drafts' reason
+	 * and one of its own: the panel is unmounted whenever another tab is on
+	 * screen, so a panel-local record is gone by the next mode change - and then
+	 * the header outlives the mode that needed it, which is the bug the record
+	 * exists to fix.
+	 *
+	 * Not reset by the request-change effect below, for the same reason as the
+	 * drafts: the record names its own request and `switchContentType` drops one
+	 * belonging to another.
+	 */
+	const autoContentTypeRef = useRef<AutoContentType | null>(null);
+	const getAutoContentType = useCallback(() => autoContentTypeRef.current, []);
+	const setAutoContentType = useCallback((auto: AutoContentType | null) => {
+		autoContentTypeRef.current = auto;
 	}, []);
 
 	// Variable resolution
@@ -462,6 +481,8 @@ export default function RequestBuilderProvider({
 			updateField,
 			getBodyDrafts,
 			setBodyDrafts,
+			getAutoContentType,
+			setAutoContentType,
 			response,
 			setResponse,
 			inheritedPreScripts,
@@ -492,6 +513,8 @@ export default function RequestBuilderProvider({
 			updateField,
 			getBodyDrafts,
 			setBodyDrafts,
+			getAutoContentType,
+			setAutoContentType,
 			response,
 			setResponse,
 			inheritedPreScripts,

--- a/app/src/modules/request-builder/context/body-drafts-lifetime.test.tsx
+++ b/app/src/modules/request-builder/context/body-drafts-lifetime.test.tsx
@@ -29,6 +29,10 @@
  *
  * The rule the drafts follow - two buckets, and ownership by request id - is
  * tested as logic in `utils/body-drafts.test.ts`.
+ *
+ * The second half of the file guards the same lifetime for the second thing
+ * kept up here for the same reason: which Content-Type row a body mode added,
+ * so that leaving the mode can remove it (`panels/body/content-type.ts`).
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -37,7 +41,7 @@ import { render, act } from "@testing-library/react";
 import RequestBuilderProvider from "./RequestBuilderProvider";
 import { useRequestBuilderContext } from "./RequestBuilderContext";
 import { switchBody } from "../utils/body-drafts";
-import type { RequestState } from "../types";
+import type { AutoContentType, RequestState } from "../types";
 
 // The provider is wired to variable resolution, the save manager and several
 // TanStack Query hooks. None of them matter to a ref's lifetime.
@@ -145,5 +149,68 @@ describe("drafts across a tab switch", () => {
 		);
 		await act(async () => {});
 		expect(seen.restored).toBe("");
+	});
+});
+
+/**
+ * The record of the Content-Type row a body mode added lives here for the same
+ * reason and one of its own: the panel is unmounted while any other tab is on
+ * screen, so a panel-local record is gone by the next mode change - and then
+ * nothing removes the header, which is the bug the record exists to fix.
+ */
+const ADDED: AutoContentType = { requestId: "req_a", rowId: "row_1", value: "application/json" };
+
+const contentType: { read: AutoContentType | null } = { read: null };
+
+function ContentTypeStandIn({ write }: { write?: boolean }) {
+	const { getAutoContentType, setAutoContentType } = useRequestBuilderContext();
+	useEffect(() => {
+		if (write) {
+			setAutoContentType(ADDED);
+			contentType.read = null;
+			return;
+		}
+		contentType.read = getAutoContentType();
+	}, [getAutoContentType, setAutoContentType, write]);
+	return null;
+}
+
+function ContentTypeHarness() {
+	const [step, setStep] = useState<"write" | "away" | "back">("write");
+	useEffect(() => {
+		contentTypeStep = setStep;
+	}, []);
+	if (step === "write") return <ContentTypeStandIn write />;
+	if (step === "away") return null; // the Headers tab: BodyPanel is unmounted
+	return <ContentTypeStandIn />;
+}
+
+let contentTypeStep: (s: "write" | "away" | "back") => void = () => {};
+
+describe("the added Content-Type row across a tab switch", () => {
+	it("is still known after BodyPanel unmounts and comes back", async () => {
+		contentType.read = null;
+		render(
+			<RequestBuilderProvider initialRequest={{ id: "req_a" } as Partial<RequestState>}>
+				<ContentTypeHarness />
+			</RequestBuilderProvider>
+		);
+
+		await act(async () => contentTypeStep("away"));
+		await act(async () => contentTypeStep("back"));
+
+		expect(contentType.read).toEqual(ADDED);
+	});
+
+	it("is null for a provider that has added nothing", async () => {
+		// Guards the assertion above from passing on a stale module-level value.
+		contentType.read = ADDED;
+		render(
+			<RequestBuilderProvider initialRequest={{ id: "req_z" } as Partial<RequestState>}>
+				<ContentTypeStandIn />
+			</RequestBuilderProvider>
+		);
+		await act(async () => {});
+		expect(contentType.read).toBeNull();
 	});
 });

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -91,6 +91,25 @@ export interface BodyConfig {
 	urlEncoded?: KeyValueItem[];
 }
 
+/**
+ * The Content-Type row a body mode added on its way in, so leaving that mode can
+ * take it back. Written by `BodyPanel` through the context accessors; the rule
+ * that reads it is in `components/RequestTabs/panels/body/content-type.ts`.
+ *
+ * By **row id**, not by value: `Content-Type: application/json` typed by the
+ * user and the identical row this panel wrote look the same and must not be
+ * treated the same. `value` is kept beside it so a row the user has since
+ * retyped is recognised as no longer ours.
+ *
+ * Ephemeral, like the body drafts - `requestId` says whose row it is, and a
+ * record belonging to another request is dropped rather than applied.
+ */
+export interface AutoContentType {
+	requestId: string | null;
+	rowId: string;
+	value: string;
+}
+
 // ============================================================================
 // Request State
 // ============================================================================
@@ -221,6 +240,16 @@ export interface RequestBuilderContextValue {
 	 */
 	getBodyDrafts: () => BodyDrafts;
 	setBodyDrafts: (drafts: BodyDrafts) => void;
+
+	/**
+	 * The Content-Type row `BodyPanel` wrote when a mode required one, so that
+	 * leaving the mode can take it back. Behind accessors and living in the
+	 * provider for the same reasons as the drafts above - and for one more: the
+	 * record has to outlive the panel, or the header outlives the mode that
+	 * needed it, which is the bug it exists to fix.
+	 */
+	getAutoContentType: () => AutoContentType | null;
+	setAutoContentType: (auto: AutoContentType | null) => void;
 
 	// Response State
 	response: ResponseState | null;

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -140,6 +140,8 @@ The request editor. Entry: `modules/request-builder/index.tsx`.
 
 > **Body tabs** support `none` / `json` / `text` / `graphql` / `form-data` / `x-www-form-urlencoded`. The `graphql` mode renders a split resizable editor: a **Query** pane (Monaco `graphql` language with diagnostics, autocomplete, hover, and formatting) and a **Variables** pane (Monaco `json` with schema-derived validation). **Scripts** are two separate panels - pre-request and test - not a single tab.
 
+> **Choosing GraphQL writes a header, and leaving GraphQL removes it.** GraphQL is sent as a JSON envelope, so picking it appends `Content-Type: application/json` to the Headers tab (unless an enabled `Content-Type` is already there) and says so in a notice with an Undo. The next mode change that no longer needs that header takes the row back out. The row is tracked **by id** - a `Content-Type` the user typed is indistinguishable by value and always survives, as does one whose value has since been edited. The rule is `panels/body/content-type.ts`; the record lives in `RequestBuilderProvider` (see [state-management](state-management.md#requestbuildercontext---the-added-content-type-row)) because the panel is unmounted whenever another tab is on screen.
+
 ## GraphQL Library (`lib/graphql/`)
 
 Shared, Monaco-independent modules that power the GraphQL body mode.

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -637,6 +637,41 @@ Two things about it are deliberate and easy to undo by accident:
 Deliberately **not** persisted: a request has one body, and storing payloads it
 will never send would put them in exports and in the engine's schema.
 
+### `RequestBuilderContext` - the added Content-Type row
+
+```typescript
+getAutoContentType: () => AutoContentType | null
+setAutoContentType: (auto: AutoContentType | null) => void
+```
+
+Which `Content-Type` row a body mode added on its way in, so that leaving the
+mode can take it back. GraphQL is sent as a JSON envelope and genuinely needs
+`Content-Type: application/json`, so `BodyPanel` appends one - but nothing
+removed it, so a single visit to GraphQL left the header on the request for
+good, including after switching back to `none`, which sends no body at all.
+
+The record is `{ requestId, rowId, value }` and the rule that reads it is
+`switchContentType` in
+`modules/request-builder/components/RequestTabs/panels/body/content-type.ts`,
+called once per mode change: it removes the remembered row when the new mode
+does not need that same header, then adds whatever the new mode does need.
+
+Three things it is deliberate about:
+
+- **By row id, not by value.** A `Content-Type` the user typed and the row the
+  panel wrote are identical apart from their id, and only ours may be removed.
+- **A row whose value has been edited is no longer ours** - retyping it is a
+  decision, so it stays and the record is dropped. Merely disabling it is not.
+- **A record naming another request is dropped, not applied.** One provider
+  serves every request tab, and row ids are not unique across a duplicated
+  request.
+
+In the provider rather than in `BodyPanel` for the drafts' reason and one of its
+own: Radix unmounts an inactive `TabsContent`, so a panel-local record is gone
+by the next mode change - and then nothing removes the header, which is the bug
+the record exists to fix. Ephemeral, like the drafts: what is persisted is the
+header row itself, in `request.headers`.
+
 ### `useSaveManager()` - Auto-Save Manager
 
 Orchestrates auto-save for a saveable entity (request, environment, etc.) with debouncing, context registration, and centralized save state tracking. Located in `app/src/hooks/useSaveManager.ts`.


### PR DESCRIPTION
## Description

Choosing GraphQL in the request builder's Body panel appends `Content-Type: application/json` to the Headers tab. That is correct - GraphQL is sent as a JSON envelope - but nothing ever removed it. One visit to GraphQL left the header on the request for good, including after switching back to **None**, which sends no body at all. The notice under the mode picker offered an Undo, but only while the panel was mounted and only until it was dismissed.

`BodyPanel` now remembers the row it wrote - which row, by id, and with what value - and `switchContentType` (`panels/body/content-type.ts`) runs both halves of the rule on every mode change: remove the remembered row when the new mode no longer needs that header, then add whatever the new mode does need. One `updateField("headers", …)`, since both halves read and write the same array.

Three things it is deliberate about:

- **By row id, not by value.** A `Content-Type` the user typed is identical apart from its id and must survive a mode change.
- **A row whose value has since been retyped is theirs** and stays (the record is dropped with it); one they only switched off is still ours and goes.
- **A record naming another request is dropped, not applied** - one provider serves every request tab, and row ids are not unique across a duplicated request.

The record lives in `RequestBuilderProvider` beside the body drafts, for the drafts' reason and one of its own: Radix unmounts an inactive `TabsContent`, so a panel-local record is gone by the next mode change - and then nothing removes the header, which is the bug it exists to fix.

`ContentTypeNotice` now says the header is removed again when the body type changes, so Undo reads as the impatient version of what happens anyway.

**One case this deliberately does not cover:** a header already saved to a request before this change, or one whose row id was regenerated by a reload/refetch, is not recognised as ours and stays put. Removing it would mean deleting a `Content-Type` on nothing but a value match - the user's-header-deleted bug in the other direction.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `pnpm test` - 208 files, 1679 tests passing.
- `pnpm type-check` clean; eslint + prettier clean on every touched file (the two `set-state-in-effect` errors in `RequestBuilderProvider.tsx` pre-date this change - verified against `master`).
- `mkdocs build --strict -f .github/mkdocs.yml` clean.
- New unit tests for `switchContentType` in `content-type.test.tsx`: the round trip out of GraphQL for every other mode, the user's own `Content-Type` surviving the whole trip, a retyped row being left behind, a foreign request's record being ignored, and array identity when there is nothing to do. `body-drafts-lifetime.test.tsx` gains a guard that the record survives `BodyPanel` unmounting and coming back.
- Mutation-checked: disabling the removal branch fails 6 of the new tests; restoring it turns them green.

The rule is tested as logic rather than through the panel because `handleModeChange` only runs when a Radix `Select` commits a value, and a `Select` does not commit in jsdom.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

None filed - reported directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgJ93CQMynAbpJ9LTixfv4)_