### PR TITLE
fix(app): make the whole drawer row clickable, not just the label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,21 @@ line naming a model, delete it before committing.
   full-bleed editors) - only the component knows which it is, so render it and
   read `element.className`. Seven boxes in the request builder were stuck square
   this way. → `boxed-surfaces.test.tsx`, `KeyValueRow.test.tsx`
+- **A drawer row's hit area needs two things, not one.** A row that carries a `⋯`
+  menu cannot be one button, so it is an `h-8 items-center` container that paints
+  the hover fill plus a narrower activator button holding the handler. That leaks
+  clicks twice over: `items-center` leaves the button *content*-height (18px in a
+  collection or environment row, so 7px above and below are dead), and the row's
+  own box - the `paddingLeft` indent, the flex gaps, the right padding - belongs
+  to no child at all. Measured in the running app, a collection row responded
+  over **41%** of the area that looked clickable, a request row 51%, an
+  environment row 36%. The fix is `self-stretch` on the activator **plus** the row
+  delegating clicks that land on itself (`e.target === e.currentTarget`, which
+  keeps the chevron and `⋯` out and stops a double-fire on bubble). The indent
+  cannot simply move onto the activator - on a collection row the chevron sits
+  between them. → `drawer-row-hit-area.test.tsx`. Assert the height as a
+  `className`, not `offsetHeight`: jsdom has no layout and reports 0 for
+  everything, so an `offsetHeight` guard passes while measuring nothing.
 - **Adding an accent scheme:** `constants/color-schemes.ts` + `index.css`, both
   themes, nothing else. → `color-schemes.test.ts`
 - **A `Badge` that paints its own `bg-` must be `variant="chip"`.** Every other

--- a/app/src/drawer-row-hit-area.test.tsx
+++ b/app/src/drawer-row-hit-area.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A drawer row's hit area must be the whole row the user sees.
+ *
+ * Three rows - a collection, a request, an environment - are a container `div`
+ * that paints the 32px (`h-8`) hover fill, the selection tint and
+ * `cursor-pointer`, with the action on a narrower activator button inside it.
+ * That split is deliberate and cannot be collapsed: the row carries a ⋯ menu, so
+ * it cannot itself be one button, and a plain `<div onClick>` is not keyboard
+ * operable (see the comment above the environment row).
+ *
+ * Two independent gaps opened up between the row and its activator, and each
+ * needs its own guard:
+ *
+ * 1. **Height.** The container is `items-center`, which makes every child
+ *    content-height, so the activator was as tall as its label - ~22px in a
+ *    request row where the MethodBadge props it open, 18px in a collection or
+ *    environment row - inside a 32px row. `self-stretch` overrides the centring.
+ * 2. **The row's own box.** The indent is `paddingLeft` *on the row* (so the fill
+ *    reaches the panel edge), and the flex gaps and right padding belong to no
+ *    child either. `self-stretch` cannot reach any of it, and on a collection row
+ *    the indent cannot move onto the button even in principle, because the
+ *    chevron sits between them. So the row delegates clicks that land on itself.
+ *
+ * Measured in the running app at the 260px default drawer width, the share of
+ * each row that actually responded before either fix: 41% collection, 51%
+ * request, 36% environment.
+ *
+ * jsdom has no layout, so `offsetHeight` is 0 for every element here and an
+ * `offsetHeight` assertion would pass while measuring nothing. The height half is
+ * therefore asserted as a class; the delegation half is asserted behaviourally,
+ * which is stronger - `fireEvent.click(row)` targets the row itself, exactly the
+ * pointer that used to land on dead padding.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import RequestItem from "@/modules/collections/RequestItem";
+import CollectionItem from "@/modules/collections/CollectionItem";
+import VariablesCategoryTree from "@/modules/variables/sidebar/VariablesCategoryTree";
+import type { Collection, Environment, Request } from "@/types";
+
+const REQUEST: Request = {
+	id: "req_1",
+	collectionId: "col_1",
+	name: "Get user",
+	description: "",
+	method: "GET",
+	url: "https://api.test/user",
+	params: [],
+	headers: [],
+	body: { mode: "none" },
+	bodyType: "none",
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	followRedirects: true,
+	maxRedirects: 10,
+	order: 0,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const COLLECTION: Collection = {
+	id: "col_1",
+	name: "Acme API",
+	description: "",
+	order: 0,
+	variables: {},
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const ENVIRONMENT: Environment = {
+	id: "env_1",
+	name: "Staging",
+	description: "",
+	variables: {},
+	isActive: false,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const idle = { data: [], isLoading: false, isError: false, refetch: vi.fn() };
+const noopMutation = { mutateAsync: vi.fn(), isPending: false };
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => idle,
+	useEnvironmentsQuery: () => ({ ...idle, data: [ENVIRONMENT] }),
+	useCreateEnvironmentMutation: () => noopMutation,
+	useDeleteEnvironmentMutation: () => noopMutation,
+	useUpdateEnvironmentMutation: () => noopMutation,
+}));
+
+// The environment row's action goes through the store rather than a prop, so
+// stub the two stores it touches to get the same kind of spy the other rows
+// take as a prop. `VariableCategory` is a type-only import and is erased.
+const setSelectedCategory = vi.fn();
+vi.mock("@/stores", () => ({ useTabsStore: () => ({ openTab: vi.fn() }) }));
+vi.mock("@/modules/variables/variables-store", () => ({
+	useVariablesStore: () => ({ selectedCategory: null, setSelectedCategory }),
+}));
+
+interface Row {
+	/** The element that paints the height, the fill and the indent. */
+	row: HTMLElement;
+	/** The control that owns the action. */
+	activator: HTMLElement;
+	/** Called when the row's primary action runs. */
+	activated: ReturnType<typeof vi.fn>;
+	/**
+	 * Called when the row starts a rename. Only the two collection-tree rows
+	 * rename on double click; the environment row renames from its ⋯ menu only.
+	 */
+	renamed?: ReturnType<typeof vi.fn>;
+}
+
+function requestRow(): Row {
+	const onSelect = vi.fn();
+	const onStartRename = vi.fn();
+	const { container } = render(
+		<RequestItem
+			request={REQUEST}
+			collectionId="col_1"
+			onSelect={onSelect}
+			onDelete={vi.fn()}
+			onStartRename={onStartRename}
+		/>
+	);
+	return {
+		row: container.querySelector('[role="treeitem"]') as HTMLElement,
+		activator: container.querySelector("[data-tree-activate]") as HTMLElement,
+		activated: onSelect,
+		renamed: onStartRename,
+	};
+}
+
+function collectionRow(): Row {
+	const onCollectionClick = vi.fn();
+	const onStartRename = vi.fn();
+	const { container } = render(
+		<CollectionItem
+			collection={COLLECTION}
+			allCollections={[COLLECTION]}
+			depth={0}
+			expandedCollectionIds={new Set()}
+			selectedCollectionId={null}
+			selectedRequestId={null}
+			renamingId={null}
+			renameValue=""
+			deletingCollectionId={null}
+			deletingRequestId={null}
+			creatingSubfolder={null}
+			newSubCollectionName=""
+			isCreatingSubfolder={false}
+			renamingRequestId={null}
+			renameRequestValue=""
+			getRequestsByCollection={() => []}
+			onCollectionClick={onCollectionClick}
+			onRequestClick={vi.fn()}
+			onCollectionToggle={vi.fn()}
+			getCollectionActions={() => []}
+			onRenameChange={vi.fn()}
+			onRenameSubmit={vi.fn()}
+			onRenameCancel={vi.fn()}
+			onStartRename={onStartRename}
+			onDeleteRequest={vi.fn()}
+			onSubCollectionNameChange={vi.fn()}
+			onCreateSubfolder={vi.fn()}
+			onCancelSubfolder={vi.fn()}
+			onRequestRenameChange={vi.fn()}
+			onRequestRenameSubmit={vi.fn()}
+			onRequestRenameCancel={vi.fn()}
+			onStartRequestRename={vi.fn()}
+		/>
+	);
+	return {
+		row: container.querySelector('[role="treeitem"]') as HTMLElement,
+		activator: container.querySelector("[data-tree-activate]") as HTMLElement,
+		activated: onCollectionClick,
+		renamed: onStartRename,
+	};
+}
+
+function environmentRow(): Row {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	render(
+		<QueryClientProvider client={qc}>
+			<TooltipProvider>
+				<VariablesCategoryTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+	// This row has no `data-tree-activate` - it is not part of the collection
+	// tree's roving-focus group. Reach it through its label.
+	const activator = screen.getByText(ENVIRONMENT.name).closest("button") as HTMLElement;
+	return {
+		row: activator.parentElement as HTMLElement,
+		activator,
+		activated: setSelectedCategory,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe.each([
+	["request row", requestRow],
+	["collection row", collectionRow],
+	["environment row", environmentRow],
+])("%s", (_label, renderRow) => {
+	it("stretches its activator to the full height of the row that paints the fill", () => {
+		const { row, activator } = renderRow();
+
+		expect(row).toBeTruthy();
+		expect(activator).toBeTruthy();
+		// Both halves of the rule together: the row pins its height and centres
+		// its children, so the activator has to opt out of that centring.
+		expect(row.className).toContain("h-8");
+		expect(row.className).toContain("items-center");
+		expect(activator.className).toContain("self-stretch");
+	});
+
+	it("acts on a click that lands on the row's own box, not on any child", () => {
+		const { row, activated } = renderRow();
+
+		// Dispatching on the row *is* the dead-padding pointer: `target` is the
+		// row, which is what the browser reports for a click on the indent, a
+		// flex gap, or the right padding.
+		fireEvent.click(row);
+
+		expect(activated).toHaveBeenCalledTimes(1);
+	});
+
+	it("acts exactly once when the click lands on the activator", () => {
+		const { activator, activated } = renderRow();
+
+		// The activator's click bubbles through the row, so the row's delegation
+		// must recognise it as already handled. Without that check this is 2.
+		fireEvent.click(activator);
+
+		expect(activated).toHaveBeenCalledTimes(1);
+	});
+
+	it("acts exactly once on the keyboard path", () => {
+		const { activator, activated } = renderRow();
+
+		// Not `fireEvent`: the Enter key path is useRovingTreeFocus doing
+		// `click("[data-tree-activate]")`, i.e. a native `HTMLElement.click()`.
+		// It bubbles too, so it meets the row's delegation the same way - assert
+		// that rather than assume the two dispatches behave alike.
+		activator.click();
+
+		expect(activated).toHaveBeenCalledTimes(1);
+	});
+});
+
+/**
+ * Delegating `onDoubleClick` as well as `onClick` is what makes a double click on
+ * the indent rename, matching a double click on the label. Nothing else covers
+ * it, and the environment row is deliberately excluded - it renames from its ⋯
+ * menu only, so it has no double-click handler to delegate.
+ */
+describe.each([
+	["request row", requestRow],
+	["collection row", collectionRow],
+])("%s double click", (_label, renderRow) => {
+	it("renames from a double click on the row's own box", () => {
+		const { row, renamed } = renderRow();
+
+		fireEvent.doubleClick(row);
+
+		expect(renamed).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -123,6 +123,15 @@ export default function CollectionItem({
 	};
 
 	/**
+	 * The row's own box delegates to the label button - see RequestItem for the
+	 * rule and why the check is what it is. This is the row where the indent
+	 * *cannot* move onto that button even in principle: the chevron sits between
+	 * them, so padding on the button would push the label away from the chevron
+	 * rather than indent the row.
+	 */
+	const isRowSurface = (e: React.MouseEvent) => e.target === e.currentTarget;
+
+	/**
 	 * Indentation is padding *inside* the row, never margin around it. A margin
 	 * would push the row's background in too, so a nested row's hover and
 	 * selection fill would stop short of the panel edge while a top-level row's
@@ -145,6 +154,8 @@ export default function CollectionItem({
 				data-collection-id={collection.id}
 				aria-expanded={isExpanded}
 				aria-selected={isSelected}
+				onClick={(e) => isRowSurface(e) && handleClick(e)}
+				onDoubleClick={(e) => isRowSurface(e) && handleDoubleClick(e)}
 				className={cn(
 					// focus-row: this row is the perceived target, not the narrower
 					// label button inside it - it paints the keyboard focus ring.
@@ -194,7 +205,12 @@ export default function CollectionItem({
 					onDoubleClick={handleDoubleClick}
 					tabIndex={-1}
 					data-tree-activate
-					className="flex min-w-0 items-center gap-2 flex-1 text-left cursor-pointer"
+					// self-stretch: see RequestItem. The row is `items-center`, so
+					// this button - the only thing wired to onCollectionClick - was
+					// as tall as its 18px label inside a 32px row, leaving ~7px of
+					// dead space above and below that still showed the hover fill
+					// and the pointer cursor.
+					className="flex min-w-0 self-stretch items-center gap-2 flex-1 text-left cursor-pointer"
 					disabled={isDeleting || isRenaming}
 				>
 					<FolderIcon

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -64,6 +64,20 @@ export default function RequestItem({
 		onStartRename?.(request);
 	};
 
+	/**
+	 * The row's own box - the indent, the flex gap, `pr-3` - belongs to no child,
+	 * so a click there has nowhere to go. `self-stretch` on the label button
+	 * recovered the height; it cannot recover the indent, because the indent is
+	 * padding on the row (deliberately, so the fill reaches the panel edge) and on
+	 * a collection row the chevron sits between it and the button.
+	 *
+	 * So the row delegates. `target === currentTarget` is exactly "the pointer
+	 * landed on the row itself, not on anything inside it", which excludes the
+	 * label button, the ⋯ menu and the chevron without naming any of them - and
+	 * without double-firing when a click on the button bubbles through here.
+	 */
+	const isRowSurface = (e: React.MouseEvent) => e.target === e.currentTarget;
+
 	// Prefer the confirmation flow when the tree supplies one.
 	const handleDelete = () => {
 		if (isDeleting) return;
@@ -77,6 +91,8 @@ export default function RequestItem({
 			role="treeitem"
 			tabIndex={-1}
 			aria-selected={isSelected}
+			onClick={(e) => isRowSurface(e) && handleClick(e)}
+			onDoubleClick={(e) => isRowSurface(e) && handleDoubleClick(e)}
 			// Indent inside the row (see CollectionItem) so the fill still
 			// reaches both panel edges.
 			style={{ paddingLeft: 8 + depth * INDENT_STEP }}
@@ -98,7 +114,14 @@ export default function RequestItem({
 				onDoubleClick={handleDoubleClick}
 				tabIndex={-1}
 				data-tree-activate
-				className="flex min-w-0 items-center gap-2 flex-1 text-left cursor-pointer"
+				// self-stretch: the row is `items-center`, which makes every child
+				// content-height - so this button, the only thing wired to onSelect,
+				// was ~22px tall inside a 32px row that paints a full-height hover
+				// fill and `cursor-pointer`. The top and bottom ~5px of the row
+				// looked clickable and were not. Stretching to the row's height
+				// costs nothing (the button's own `items-center` still centres the
+				// badge and label) and `focus-row` keeps painting the ring.
+				className="flex min-w-0 self-stretch items-center gap-2 flex-1 text-left cursor-pointer"
 				disabled={isDeleting || isRenaming}
 			>
 				<MethodBadge method={request.method} size="md" />

--- a/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
+++ b/app/src/modules/variables/sidebar/VariablesCategoryTree.tsx
@@ -303,19 +303,36 @@ export default function VariablesCategoryTree() {
 										const isDeleting = deletingEnvId === environment.id;
 										return (
 											/*
-											 * Container + inner activator, not a
-											 * <div onClick>. The row carries a
+											 * Container + inner activator, never a
+											 * bare <div onClick>. The row carries a
 											 * RowActionsMenu, so it cannot be one
 											 * button (the collection rows below can,
 											 * and are). As a plain div it was not
 											 * focusable and not operable by keyboard
 											 * at all - the ⋯ menu was reachable but
 											 * selecting the environment was not.
+											 *
+											 * The button therefore stays and owns the
+											 * action. The row *additionally* delegates
+											 * clicks landing on its own box - the 50px
+											 * `pl-12.5` indent, the gap, `px-3` - which
+											 * belong to no child and so had nowhere to
+											 * go. RequestItem carries the rule and why
+											 * the target check is what it is.
 											 */
 											<div
 												key={environment.id}
+												onClick={(e) => {
+													if (e.target !== e.currentTarget) return;
+													if (isDeleting) return;
+													if (renamingEnvId === environment.id) return;
+													selectCategory({
+														type: "environment",
+														environmentId: environment.id,
+													});
+												}}
 												className={cn(
-													"focus-row group flex h-8 items-center gap-2 px-3 pl-12.5 text-sm hover:bg-accent transition-colors",
+													"focus-row group flex h-8 cursor-pointer items-center gap-2 px-3 pl-12.5 text-sm hover:bg-accent transition-colors",
 													isSelected({
 														type: "environment",
 														environmentId: environment.id,
@@ -355,7 +372,15 @@ export default function VariablesCategoryTree() {
 																environmentId: environment.id,
 															})
 														}
-														className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
+														// self-stretch: the row above is
+														// `items-center`, which leaves this
+														// button - the only thing wired to
+														// selectCategory - as tall as its 18px
+														// label inside a 32px row. The band above
+														// and below it took the hover fill but
+														// not the click. Same fix as the
+														// collection and request rows.
+														className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 self-stretch text-left"
 													>
 														<TruncatedText className="flex-1">
 															{environment.name}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1152,7 +1152,57 @@ Section *headers* (e.g. "Environments") stay shorter on purpose - they are group
 labels, not list items, and the difference carries hierarchy.
 
 The disclosure chevron is `w-6 h-6` (24px) so it fits a 32px row. That is still
-an adequate pointer target, and the whole row remains clickable for opening.
+an adequate pointer target, and the row around it opens the collection.
+
+**`h-8 items-center` on the row means the activator needs `self-stretch`.** The
+two rules above interact, and the interaction is a bug the eye cannot see. A
+composite row (see `.focus-row`) paints the height, the hover fill, the selection
+tint and `cursor-pointer`, while the click handler sits on a narrower activator
+button inside it - the row carries a `⋯` menu, so it cannot itself be one button,
+and a plain `<div onClick>` is not keyboard operable. `items-center` then makes
+that button *content*-height: ~22px in a request row, where the `MethodBadge`
+props it open, and ~18px in a collection or environment row. The remaining 5-7px
+above and below took the fill and the pointer and did nothing on click. Measured
+in the running app at the 260px default drawer width, the share of the row that
+actually responded was **41%** for a collection, **51%** for a request and
+**36%** for an environment - and hit-testing 3px inside the top or bottom edge
+landed on the container, which has no handler.
+
+`self-stretch` on the activator overrides the row's centring; the activator's own
+`items-center` still centres its contents, and `.focus-row` is unaffected because
+the row paints the ring either way.
+
+**`self-stretch` fixes the height; the row's own box needs delegation.** The
+indent is `paddingLeft` *on the row* - deliberately, so the fill reaches the panel
+edge - and the flex gaps and right padding belong to no child either. No amount of
+stretching reaches any of it, and on a collection row the indent cannot move onto
+the activator even in principle, because the chevron sits between them. So the row
+takes the click itself and forwards it:
+
+```tsx
+const isRowSurface = (e: React.MouseEvent) => e.target === e.currentTarget;
+// on the row:
+onClick={(e) => isRowSurface(e) && handleClick(e)}
+```
+
+`target === currentTarget` is exactly "the pointer landed on the row's own box".
+It excludes the chevron and the `⋯` menu without naming them - they are children,
+and they own their own actions - and it stops a click on the activator from firing
+twice as it bubbles through. Drop the check and every label click activates twice.
+
+This is *not* the `<div onClick>` the environment row's comment warns against: the
+activator button stays and remains the keyboard path (`useRovingTreeFocus` clicks
+`[data-tree-activate]` on Enter). The row is a second, pointer-only entrance to
+the same handler.
+
+Together the two changes take all three rows to **100% of their own pixels** -
+measured by sweeping `elementFromPoint` across the row box in the running app. The
+only pixels a row does not own are the chevron, the `⋯` menu and the drawer's 8px
+`cursor-col-resize` handle at the panel edge. Both halves are guarded by
+`drawer-row-hit-area.test.tsx`: the height as a `className` assertion (jsdom has
+no layout, so an `offsetHeight` assertion would pass while measuring nothing), the
+delegation behaviourally, because `fireEvent.click(row)` targets the row itself -
+exactly the pointer that used to land on dead padding.
 
 ---
 


### PR DESCRIPTION
A collection, request or environment row in the drawer is a container `div` that
paints the 32px hover fill, the selection tint and `cursor-pointer`, with the
click handler on a narrower activator button inside it. Clicking what looked
like the row often did nothing.

That split cannot be collapsed: the row carries a ⋯ menu, so it cannot itself be
one button, and a bare `<div onClick>` left the environment row
keyboard-inoperable once before (the comment above that row records it).

## What was wrong

The row leaked clicks in two independent ways.

**Height.** The container is `items-center`, which makes every child
content-height, so the activator was only as tall as its label - 18px in a
collection or environment row, 22px in a request row where the `MethodBadge`
props it open - inside a 32px row.

**The row's own box.** The `paddingLeft` indent, the flex gaps and the right
padding belong to no child at all.

Measured in the running app at the 260px default drawer width:

| Row | Row box | Activator | Reachable |
| --- | --- | --- | --- |
| Collection (depth 0) | 260 x 32 | 188 x 18 | **41%** |
| Request (depth 1) | 260 x 32 | 196 x 21.8 | **51%** |
| Environment | 260 x 32 | 166 x 18 | **36%** |

Hit-testing 3px inside the top or bottom edge landed on the container, which has
no handler:

```
before:  top+3 -> dead row  |  middle -> activator  |  bottom-3 -> dead row
after:   top+3 -> activator |  middle -> activator  |  bottom-3 -> activator
```

`docs/design-system.md` claimed "the whole row remains clickable for opening".
That line was false, and is corrected here.

## The fix

Two changes, because the two gaps have different causes.

**`self-stretch` on the activator** overrides the row's centring, so the button
fills the row's height. Its own `items-center` still centres the badge and
label, and `.focus-row` is unaffected because the row paints the ring either
way.

**The row delegates clicks that land on its own box.** The indent cannot be
fixed by stretching, or by moving it onto the activator: it is padding on the
row *so that* the fill reaches the panel edge, and on a collection row the
chevron sits between the indent and the button, so padding on the button would
push the label away from the chevron rather than indent the row.

```tsx
const isRowSurface = (e: React.MouseEvent) => e.target === e.currentTarget;
// on the row:
onClick={(e) => isRowSurface(e) && handleClick(e)}
```

`e.target === e.currentTarget` is exactly "the pointer hit the row, not anything
inside it". It excludes the chevron and the ⋯ menu without naming them - they
own their own actions - and stops a click on the label firing twice as it
bubbles through. Drop that check and every label click activates twice.

The activator stays and remains the keyboard path: `useRovingTreeFocus` calls
`querySelector("[data-tree-activate]")?.click()` on Enter and `take()` calls
`preventDefault()`, so there is exactly one activation.

## Result

Sweeping `elementFromPoint` across each row box in the running app now reaches
the open action on **100% of the pixels the row owns**, for all three rows. The
only exclusions are the chevron, the ⋯ menu, and the drawer's 8px
`cursor-col-resize` handle at the panel edge - that last one showed up as a dead
strip in the first sweep and is correct, it is the panel resizer.

A click at x=4, y=top+2 (the indent *and* the former dead band at once) opens
the request. The chevron still toggles rather than opening, and the ⋯ menu still
opens with Rename / Duplicate / Delete.

## Behaviour change

Double-clicking the indent now starts a rename, matching a double click on the
label, where before it did nothing. The environment row is deliberately
excluded: it renames from its ⋯ menu only, so it has no double-click handler to
delegate.

## Tests

`app/src/drawer-row-hit-area.test.tsx` guards both halves for all three rows -
14 cases. The height is asserted as a `className`, because jsdom has no layout
and reports `offsetHeight` 0 for everything, so an `offsetHeight` guard would
pass while measuring nothing. The delegation is asserted behaviourally, and
separately for the native `HTMLElement.click()` the keyboard path actually uses
rather than `fireEvent`, which is a different dispatch.

Three mutations, each caught by the intended test:

| Mutation | Test that reddens |
| --- | --- |
| remove the delegation | acts on a click that lands on the row's own box |
| remove the `isRowSurface` check | acts exactly once when the click lands on the activator |
| remove `onDoubleClick` | renames from a double click on the row's own box |

## Verification

- `pnpm test` -> 209 files, 1677 tests. Two failures, both in
  `app-icon-system-menu.test.tsx`, and **both pre-existing**: the same two test
  names fail on a clean stashed baseline of this branch's base, and the file is
  flaky under load (1, 4, then 2 failures across runs, 8-25s, passing in
  isolation). Worth a separate look; untouched here.
- `pnpm type-check`, `eslint` and `prettier --check` clean on all touched files.
- Verified in the running dev app (`python build.py --dev`, `pnpm electron:dev`)
  against the live engine. No browser console errors.

## Docs

`docs/design-system.md` (Drawer Row Metric) and `CLAUDE.md` (UI rules) both
updated in this commit, since the rule they state is what changed.
