### PR TITLE
fix(app): send the sample rate in the engine's unit, and make the load-test ceilings a setting

### DIFF
--- a/app/src/constants/load-test.test.ts
+++ b/app/src/constants/load-test.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Two units and two audiences meet in this file, and both were previously
+ * wrong in ways nothing failed on:
+ *
+ *   - The sample-rate control is a percentage; the engine's field is a period.
+ *     They were the same number, so the slider meant its own inverse.
+ *   - The dialog's ceilings are the app's policy, sitting inside the engine's
+ *     crash guards. A user-set ceiling that escaped those guards would turn a
+ *     settings screen into a way to make the daemon reject - or before the
+ *     engine's own validation landed, crash on - a run.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+	DEFAULT_LOAD_TEST_CEILINGS,
+	LOAD_TEST_CEILING_BOUNDS,
+	LOAD_TEST_DEFAULTS,
+	LOAD_TEST_LIMITS,
+	clampCeiling,
+	clampToRange,
+	resolveLoadTestLimits,
+	successSamplePeriod,
+	type LoadTestCeilingKey,
+} from "./load-test";
+
+const CEILING_KEYS = Object.keys(LOAD_TEST_CEILING_BOUNDS) as LoadTestCeilingKey[];
+
+describe("successSamplePeriod", () => {
+	it("maps the ends of the slider to the ends they are labelled with", () => {
+		// 100% keeps everything, which is a period of 1. This is the pair that
+		// was inverted: 100 went out as 100 and kept one response in a hundred.
+		expect(successSamplePeriod(100)).toBe(1);
+		expect(successSamplePeriod(1)).toBe(100);
+	});
+
+	it("leaves the default unchanged, the one value that was accidentally right", () => {
+		expect(successSamplePeriod(LOAD_TEST_DEFAULTS.SAMPLE_RATE_PCT)).toBe(
+			LOAD_TEST_DEFAULTS.SAMPLE_RATE_PCT
+		);
+	});
+
+	it("rounds a percentage that does not divide 100 to the nearest whole period", () => {
+		expect(successSamplePeriod(50)).toBe(2);
+		expect(successSamplePeriod(33)).toBe(3);
+		expect(successSamplePeriod(40)).toBe(3); // 100/40 = 2.5
+	});
+
+	it("never returns 0, whatever it is handed", () => {
+		// 0 on the wire is `counter % 0` engine-side - a SIGFPE that takes the
+		// daemon down mid-run, along with every other run and SSE stream.
+		for (const input of [0, -1, -100, 1000, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(successSamplePeriod(input)).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("is monotonic: a higher percentage never keeps less", () => {
+		let previous = Number.POSITIVE_INFINITY;
+		for (let pct = 1; pct <= 100; pct++) {
+			const period = successSamplePeriod(pct);
+			expect(period).toBeLessThanOrEqual(previous);
+			previous = period;
+		}
+	});
+});
+
+describe("ceiling clamping", () => {
+	it.each(CEILING_KEYS)("holds %s inside the engine's guard", (key) => {
+		const { MIN, MAX } = LOAD_TEST_CEILING_BOUNDS[key];
+		expect(clampCeiling(key, MAX * 10)).toBe(MAX);
+		expect(clampCeiling(key, MIN - 1)).toBe(MIN);
+		expect(clampCeiling(key, Number.NaN)).toBe(MIN);
+	});
+
+	it("keeps a value already inside the range", () => {
+		expect(clampCeiling("concurrency", 2500)).toBe(2500);
+	});
+
+	it("rounds, since a ceiling on a whole-number field cannot be fractional", () => {
+		expect(clampCeiling("concurrency", 12.6)).toBe(13);
+	});
+
+	it.each(CEILING_KEYS)("ships %s at a default inside its own bounds", (key) => {
+		const { MIN, MAX } = LOAD_TEST_CEILING_BOUNDS[key];
+		expect(DEFAULT_LOAD_TEST_CEILINGS[key]).toBeGreaterThanOrEqual(MIN);
+		expect(DEFAULT_LOAD_TEST_CEILINGS[key]).toBeLessThanOrEqual(MAX);
+	});
+});
+
+describe("clampToRange", () => {
+	it("repairs a NaN to the floor rather than propagating it", () => {
+		// An emptied number input parses to NaN, and a NaN `max` on a field
+		// disables the browser's own range check silently.
+		expect(clampToRange(Number.NaN, { MIN: 5, MAX: 10 })).toBe(5);
+	});
+});
+
+describe("resolveLoadTestLimits", () => {
+	it("returns the shipped ranges for the shipped ceilings", () => {
+		expect(resolveLoadTestLimits(DEFAULT_LOAD_TEST_CEILINGS)).toEqual(LOAD_TEST_LIMITS);
+	});
+
+	it("applies a connection ceiling to the ramp's start as well as its target", () => {
+		const limits = resolveLoadTestLimits({ ...DEFAULT_LOAD_TEST_CEILINGS, concurrency: 4000 });
+		expect(limits.CONCURRENCY.MAX).toBe(4000);
+		expect(limits.START_CONCURRENCY.MAX).toBe(4000);
+	});
+
+	it("applies a duration ceiling to the ramp duration as well as the run", () => {
+		const limits = resolveLoadTestLimits({
+			...DEFAULT_LOAD_TEST_CEILINGS,
+			durationSeconds: 7200,
+		});
+		expect(limits.DURATION_S.MAX).toBe(7200);
+		expect(limits.RAMP_DURATION_S.MAX).toBe(7200);
+	});
+
+	it("clamps ceilings it is handed, so a stale stored value cannot widen a range", () => {
+		const limits = resolveLoadTestLimits({
+			...DEFAULT_LOAD_TEST_CEILINGS,
+			concurrency: 10_000_000,
+		});
+		expect(limits.CONCURRENCY.MAX).toBe(LOAD_TEST_CEILING_BOUNDS.concurrency.MAX);
+	});
+
+	it("leaves the floors alone - those are not the user's to move", () => {
+		const limits = resolveLoadTestLimits({
+			rps: 1,
+			concurrency: 1,
+			durationSeconds: 1,
+			iterations: 1,
+		});
+		for (const key of ["RPS", "CONCURRENCY", "DURATION_S", "ITERATIONS"] as const) {
+			expect(limits[key].MIN).toBe(1);
+		}
+		// And the ranges the user cannot move stay put.
+		expect(limits.SAMPLE_RATE_PCT).toEqual(LOAD_TEST_LIMITS.SAMPLE_RATE_PCT);
+		expect(limits.MAX_IN_FLIGHT).toEqual(LOAD_TEST_LIMITS.MAX_IN_FLIGHT);
+	});
+
+	it("never lets the sample-rate floor return to the divisor-of-zero value", () => {
+		expect(LOAD_TEST_LIMITS.SAMPLE_RATE_PCT.MIN).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/app/src/constants/load-test.ts
+++ b/app/src/constants/load-test.ts
@@ -8,8 +8,17 @@
 /**
  * Load test configuration defaults and input limits.
  *
- * Limits mirror what the engine accepts on /run - keep them in sync with the
- * engine's validation when it changes.
+ * Two different things live here and they are easy to confuse:
+ *
+ *   - **`LOAD_TEST_LIMITS`** - the range each control in the load dialog
+ *     offers. The ceilings are *this app's* policy, not the engine's, and four
+ *     of them are user-adjustable (Settings -> Load testing). They sit well
+ *     inside what the engine accepts, which is deliberate: the engine's own
+ *     bounds are crash guards, so hitting one should be impossible from the UI
+ *     rather than merely unlikely.
+ *   - **`LOAD_TEST_CEILING_BOUNDS`** - how far the user may move those
+ *     ceilings. The upper end of each is the engine's guard, so no Settings
+ *     value can produce a request the engine rejects.
  */
 
 export const LOAD_TEST_DEFAULTS = {
@@ -28,7 +37,30 @@ export const LOAD_TEST_DEFAULTS = {
 	SAVE_TIMING_BREAKDOWN: true,
 } as const;
 
-export const LOAD_TEST_LIMITS = {
+export interface LimitRange {
+	MIN: number;
+	MAX: number;
+}
+
+export type LoadTestLimitKey =
+	| "DURATION_S"
+	| "RPS"
+	| "MAX_IN_FLIGHT"
+	| "CONCURRENCY"
+	| "ITERATIONS"
+	| "RAMP_DURATION_S"
+	| "START_CONCURRENCY"
+	| "SAMPLE_RATE_PCT"
+	| "SLOW_THRESHOLD_MS";
+
+export type LoadTestLimits = Record<LoadTestLimitKey, LimitRange>;
+
+/**
+ * The dialog's ranges with no user overrides applied. Read through
+ * `resolveLoadTestLimits` rather than directly, unless you specifically want
+ * the shipped defaults.
+ */
+export const LOAD_TEST_LIMITS: LoadTestLimits = {
 	DURATION_S: { MIN: 1, MAX: 3600 },
 	RPS: { MIN: 1, MAX: 50_000 },
 	MAX_IN_FLIGHT: { MIN: 1, MAX: 1_000_000 },
@@ -36,6 +68,111 @@ export const LOAD_TEST_LIMITS = {
 	ITERATIONS: { MIN: 1, MAX: 1_000_000 },
 	RAMP_DURATION_S: { MIN: 1, MAX: 3600 },
 	START_CONCURRENCY: { MIN: 1, MAX: 1000 },
-	SAMPLE_RATE_PCT: { MIN: 0, MAX: 100 },
+	/**
+	 * MIN is 1, not 0. The value is a *percentage of successful responses to
+	 * keep*, converted to the engine's sampling period by
+	 * `successSamplePeriod`. 0% has no period that expresses it (the period
+	 * would be infinite, and a literal 0 on the wire is a division by zero
+	 * engine-side), so "keep no success traces" is the Save timing breakdown
+	 * toggle instead - that gates storage entirely.
+	 */
+	SAMPLE_RATE_PCT: { MIN: 1, MAX: 100 },
 	SLOW_THRESHOLD_MS: { MIN: 0, MAX: 60_000 },
-} as const;
+};
+
+/**
+ * Convert the dialog's percentage into the engine's `success_sample_rate`.
+ *
+ * The engine treats that field as a sampling **period** - it keeps a trace when
+ * `counter % success_sample_rate == 0`, i.e. one in every N - while the slider
+ * has always been labelled, and stored, as a percentage. Nothing converted
+ * between the two, so the two ends of the slider meant the opposite of what
+ * they said: "100% - everything" sent a period of 100 and kept 1%, and the
+ * left stop sent a period of 1 and kept *every* response. Only the default of
+ * 10 was accidentally right, 1-in-10 being 10%, which is why it went unnoticed.
+ *
+ * Percentages that do not divide 100 land on the nearest whole period (33% ->
+ * 1 in 3), because a period is by definition an integer.
+ */
+export function successSamplePeriod(percent: number): number {
+	const { MIN, MAX } = LOAD_TEST_LIMITS.SAMPLE_RATE_PCT;
+	const usable = Number.isFinite(percent) ? percent : LOAD_TEST_DEFAULTS.SAMPLE_RATE_PCT;
+	const clamped = Math.min(Math.max(Math.round(usable), MIN), MAX);
+	return Math.max(1, Math.round(100 / clamped));
+}
+
+/**
+ * The four dialog ceilings a user can move, and the range each may move
+ * within. `MAX` is the engine's own guard in every case, so a user who raises
+ * a ceiling to its top still cannot compose a run the engine will reject:
+ *
+ * - `concurrency` - the engine caps a run at 10x `event_loop::MAX_CONCURRENT`,
+ *   because that number becomes an *eager* per-worker curl-handle
+ *   pre-allocation. It is also the ceiling on the `eventLoopMaxConcurrent`
+ *   engine setting, which is the per-worker value a run actually gets.
+ * - `durationSeconds` - a day, matching the engine's per-transfer timeout
+ *   guard. A run longer than that wants a scheduler, not a dialog.
+ * - `rps` / `iterations` - no engine guard applies; these are throughput
+ *   figures, and the bound is the point past which a single desktop engine is
+ *   not the right tool.
+ */
+export const LOAD_TEST_CEILING_BOUNDS = {
+	rps: { MIN: 1, MAX: 1_000_000 },
+	concurrency: { MIN: 1, MAX: 10_000 },
+	durationSeconds: { MIN: 1, MAX: 86_400 },
+	iterations: { MIN: 1, MAX: 100_000_000 },
+} as const satisfies Record<string, LimitRange>;
+
+export type LoadTestCeilingKey = keyof typeof LOAD_TEST_CEILING_BOUNDS;
+
+export type LoadTestCeilings = Record<LoadTestCeilingKey, number>;
+
+/** The shipped ceilings, identical to `LOAD_TEST_LIMITS` above. */
+export const DEFAULT_LOAD_TEST_CEILINGS: LoadTestCeilings = {
+	rps: LOAD_TEST_LIMITS.RPS.MAX,
+	concurrency: LOAD_TEST_LIMITS.CONCURRENCY.MAX,
+	durationSeconds: LOAD_TEST_LIMITS.DURATION_S.MAX,
+	iterations: LOAD_TEST_LIMITS.ITERATIONS.MAX,
+};
+
+/** Hold a value inside a range. Also repairs a NaN from an emptied input. */
+export function clampToRange(value: number, range: LimitRange): number {
+	if (!Number.isFinite(value)) return range.MIN;
+	return Math.min(Math.max(value, range.MIN), range.MAX);
+}
+
+/** One ceiling, forced inside what the engine will accept. */
+export function clampCeiling(key: LoadTestCeilingKey, value: number): number {
+	return Math.round(clampToRange(value, LOAD_TEST_CEILING_BOUNDS[key]));
+}
+
+/** Every ceiling clamped, for a stored object of unknown provenance. */
+export function clampCeilings(ceilings: LoadTestCeilings): LoadTestCeilings {
+	return {
+		rps: clampCeiling("rps", ceilings.rps),
+		concurrency: clampCeiling("concurrency", ceilings.concurrency),
+		durationSeconds: clampCeiling("durationSeconds", ceilings.durationSeconds),
+		iterations: clampCeiling("iterations", ceilings.iterations),
+	};
+}
+
+/**
+ * The dialog's effective ranges under a set of user ceilings.
+ *
+ * Ramp duration follows the duration ceiling and ramp start follows the
+ * connection ceiling, because each pair measures the same physical quantity -
+ * a separate knob for them would let a user set a target of 5000 connections
+ * that the ramp could only start climbing towards from a capped 1000.
+ */
+export function resolveLoadTestLimits(ceilings: LoadTestCeilings): LoadTestLimits {
+	const { rps, concurrency, durationSeconds, iterations } = clampCeilings(ceilings);
+	return {
+		...LOAD_TEST_LIMITS,
+		RPS: { MIN: LOAD_TEST_LIMITS.RPS.MIN, MAX: rps },
+		CONCURRENCY: { MIN: LOAD_TEST_LIMITS.CONCURRENCY.MIN, MAX: concurrency },
+		START_CONCURRENCY: { MIN: LOAD_TEST_LIMITS.START_CONCURRENCY.MIN, MAX: concurrency },
+		DURATION_S: { MIN: LOAD_TEST_LIMITS.DURATION_S.MIN, MAX: durationSeconds },
+		RAMP_DURATION_S: { MIN: LOAD_TEST_LIMITS.RAMP_DURATION_S.MIN, MAX: durationSeconds },
+		ITERATIONS: { MIN: LOAD_TEST_LIMITS.ITERATIONS.MIN, MAX: iterations },
+	};
+}

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -19,6 +19,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, within, cleanup } from "@testing-library/react";
 import LoadTestConfigDialog from "./index";
 import type { LoadTestConfig } from "@/types";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
+import { useClientSettingsStore } from "@/stores";
+import { DEFAULT_LOAD_TEST_CEILINGS, LOAD_TEST_CEILING_BOUNDS } from "@/constants/load-test";
 
 vi.mock("../OAuth2LoadTestGuard", () => ({
 	default: () => null,
@@ -50,6 +53,9 @@ const started = (onStart: ReturnType<typeof vi.fn>): LoadTestConfig => {
 beforeEach(() => {
 	cleanup();
 	localStorage.clear();
+	// The ceilings store is module-level and persists across tests in this
+	// file; clearing localStorage does not roll it back.
+	useClientSettingsStore.getState().setLoadTestCeilings(DEFAULT_LOAD_TEST_CEILINGS);
 });
 
 describe("load profile → fields", () => {
@@ -113,7 +119,7 @@ describe("payload", () => {
 	it("keeps the recording options even though they are folded away", () => {
 		const { onStart } = open();
 		const config = started(onStart);
-		expect(config.data_sample_rate).toBeTypeOf("number");
+		expect(config.success_sample_period).toBeTypeOf("number");
 		expect(config.slow_threshold_ms).toBeTypeOf("number");
 		expect(config.save_timing_breakdown).toBeTypeOf("boolean");
 	});
@@ -283,5 +289,96 @@ describe("ramp start concurrency", () => {
 		pickProfile("Ramp-Up");
 		fireEvent.change(screen.getByLabelText(/start from/i), { target: { value: "3" } });
 		expect(screen.getByText(/Climbs from 3 to 10 connections/i)).toBeInTheDocument();
+	});
+});
+
+/**
+ * The slider is a percentage and the engine's field is a sampling period (keep
+ * 1 in N, `counter % N`). Nothing converted between them, so the two ends of
+ * the control meant the opposite of what they said: "100% - everything" sent a
+ * period of 100 and kept 1%, while the left stop kept every single response.
+ * Only the default of 10 was right, 1-in-10 being 10%.
+ *
+ * Asserted through the payload rather than on `successSamplePeriod` alone,
+ * because the unit conversion existing is not the point - it being applied on
+ * the way out of this dialog is.
+ */
+describe("success sample rate reaches the engine in the engine's unit", () => {
+	const rateSlider = () => screen.getByLabelText(/success sample rate/i) as HTMLInputElement;
+	const openRecording = () => fireEvent.click(screen.getByRole("button", { name: /recording/i }));
+
+	it("sends a period of 1 - every response - at the 100% stop", () => {
+		const { onStart } = open();
+		openRecording();
+		fireEvent.change(rateSlider(), { target: { value: "100" } });
+		expect(started(onStart).success_sample_period).toBe(1);
+	});
+
+	it("sends a period of 100 - one in a hundred - at the 1% stop", () => {
+		const { onStart } = open();
+		openRecording();
+		fireEvent.change(rateSlider(), { target: { value: "1" } });
+		expect(started(onStart).success_sample_period).toBe(100);
+	});
+
+	it("leaves the default alone, which is the one value that was already right", () => {
+		const { onStart } = open();
+		expect(started(onStart).success_sample_period).toBe(10);
+	});
+
+	it("never offers, or sends, the divide-by-zero value", () => {
+		// The floor used to be 0, and `saved.sampleRate ?? DEFAULT` keeps a
+		// stored 0 because 0 is present. A 0 on the wire is `% 0` engine-side.
+		localStorage.setItem(STORAGE_KEYS.LAST_LOAD_TEST_CONFIG, JSON.stringify({ sampleRate: 0 }));
+		const { onStart } = open();
+		openRecording();
+		expect(Number(rateSlider().min)).toBeGreaterThanOrEqual(1);
+		expect(started(onStart).success_sample_period).toBeGreaterThanOrEqual(1);
+	});
+});
+
+/**
+ * The dialog's ceilings are a user setting, not a constant. Nothing else in the
+ * app reads `loadTestCeilings`, so if this dialog stopped resolving them the
+ * setting would be written and never read - which is the defect class this
+ * codebase repeats most.
+ */
+describe("ceilings from Settings", () => {
+	const connections = () => screen.getByLabelText(/^connections/i) as HTMLInputElement;
+
+	it("offers the raised ceiling on the field it governs", () => {
+		useClientSettingsStore.getState().setLoadTestCeilings({ concurrency: 5000 });
+		open();
+		pickProfile("Constant Concurrency");
+		expect(Number(connections().max)).toBe(5000);
+	});
+
+	it("applies a connection ceiling to the ramp's start too, not just its target", () => {
+		// Same physical quantity. A ramp that may only start below 1000 cannot
+		// climb to a target of 5000 from anywhere sensible.
+		useClientSettingsStore.getState().setLoadTestCeilings({ concurrency: 5000 });
+		open();
+		pickProfile("Ramp-Up");
+		expect(Number((screen.getByLabelText(/start from/i) as HTMLInputElement).max)).toBe(5000);
+	});
+
+	it("pulls a restored value back under a ceiling lowered since it was saved", () => {
+		localStorage.setItem(
+			STORAGE_KEYS.LAST_LOAD_TEST_CONFIG,
+			JSON.stringify({ mode: "constant_concurrency", concurrency: 800 })
+		);
+		useClientSettingsStore.getState().setLoadTestCeilings({ concurrency: 100 });
+		const { onStart } = open();
+		expect(connections().value).toBe("100");
+		expect(started(onStart).concurrency).toBe(100);
+	});
+
+	it("cannot be set past what the engine accepts", () => {
+		// The bound is the engine's crash guard, so this clamp is what makes
+		// "no setting on that screen can compose a rejected run" true.
+		useClientSettingsStore.getState().setLoadTestCeilings({ concurrency: 999_999 });
+		open();
+		pickProfile("Constant Concurrency");
+		expect(Number(connections().max)).toBe(LOAD_TEST_CEILING_BOUNDS.concurrency.MAX);
 	});
 });

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -30,8 +30,14 @@ import { Loader2 } from "lucide-react";
 import type { LoadTestConfig, OAuth2Config } from "@/types";
 import OAuth2LoadTestGuard from "../OAuth2LoadTestGuard";
 import { validateRampDuration, validateStartConcurrency } from "../../utils/loadTestValidation";
-import { LOAD_TEST_DEFAULTS, LOAD_TEST_LIMITS } from "@/constants/load-test";
+import {
+	LOAD_TEST_DEFAULTS,
+	clampToRange,
+	resolveLoadTestLimits,
+	successSamplePeriod,
+} from "@/constants/load-test";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
+import { useClientSettingsStore } from "@/stores";
 import {
 	Button,
 	Input,
@@ -174,24 +180,43 @@ export default function LoadTestConfigDialog({
 }: LoadTestConfigDialogProps) {
 	const saved = loadSavedConfig();
 
+	/**
+	 * The ceilings are a user setting (Settings -> Load testing), so every
+	 * range below is resolved rather than read off the constant. Restored
+	 * values are clamped into it: the memo is written by a past run, and a
+	 * ceiling lowered since then would otherwise seed a field above its own
+	 * `max` - which a number input shows without complaint.
+	 */
+	const ceilings = useClientSettingsStore((s) => s.loadTestCeilings);
+	const limits = useMemo(() => resolveLoadTestLimits(ceilings), [ceilings]);
+	const restore = (value: number | undefined, fallback: number, key: keyof typeof limits) =>
+		clampToRange(value ?? fallback, limits[key]);
+
 	const [mode, setMode] = useState<LoadTestConfig["mode"]>(saved.mode ?? LOAD_TEST_DEFAULTS.MODE);
-	const [duration, setDuration] = useState(saved.duration ?? LOAD_TEST_DEFAULTS.DURATION_S);
-	const [rps, setRps] = useState(saved.rps ?? LOAD_TEST_DEFAULTS.RPS);
-	const [concurrency, setConcurrency] = useState(
-		saved.concurrency ?? LOAD_TEST_DEFAULTS.CONCURRENCY
+	const [duration, setDuration] = useState(() =>
+		restore(saved.duration, LOAD_TEST_DEFAULTS.DURATION_S, "DURATION_S")
 	);
-	const [iterations, setIterations] = useState(saved.iterations ?? LOAD_TEST_DEFAULTS.ITERATIONS);
-	const [rampDuration, setRampDuration] = useState(
-		saved.rampDuration ?? LOAD_TEST_DEFAULTS.RAMP_DURATION_S
+	const [rps, setRps] = useState(() => restore(saved.rps, LOAD_TEST_DEFAULTS.RPS, "RPS"));
+	const [concurrency, setConcurrency] = useState(() =>
+		restore(saved.concurrency, LOAD_TEST_DEFAULTS.CONCURRENCY, "CONCURRENCY")
 	);
-	const [startConcurrency, setStartConcurrency] = useState(
-		saved.startConcurrency ?? LOAD_TEST_DEFAULTS.START_CONCURRENCY
+	const [iterations, setIterations] = useState(() =>
+		restore(saved.iterations, LOAD_TEST_DEFAULTS.ITERATIONS, "ITERATIONS")
+	);
+	const [rampDuration, setRampDuration] = useState(() =>
+		restore(saved.rampDuration, LOAD_TEST_DEFAULTS.RAMP_DURATION_S, "RAMP_DURATION_S")
+	);
+	const [startConcurrency, setStartConcurrency] = useState(() =>
+		restore(saved.startConcurrency, LOAD_TEST_DEFAULTS.START_CONCURRENCY, "START_CONCURRENCY")
 	);
 	const [maxInFlight, setMaxInFlight] = useState<string>(
 		saved.maxInFlight != null ? String(saved.maxInFlight) : ""
 	);
-	const [sampleRate, setSampleRate] = useState(
-		saved.sampleRate ?? LOAD_TEST_DEFAULTS.SAMPLE_RATE_PCT
+	// Clamped like the rest, and load-bearing for a second reason: a config
+	// saved when the slider's floor was 0 restores that 0, because
+	// `saved.sampleRate ?? DEFAULT` keeps a present 0.
+	const [sampleRate, setSampleRate] = useState(() =>
+		restore(saved.sampleRate, LOAD_TEST_DEFAULTS.SAMPLE_RATE_PCT, "SAMPLE_RATE_PCT")
 	);
 	const [slowThreshold, setSlowThreshold] = useState(
 		saved.slowThreshold ?? LOAD_TEST_DEFAULTS.SLOW_THRESHOLD_MS
@@ -284,7 +309,10 @@ export default function LoadTestConfigDialog({
 
 		const config: LoadTestConfig = {
 			mode,
-			data_sample_rate: sampleRate,
+			// The slider is a percentage; the engine's field is a period. The
+			// memo above keeps the percentage, so the control restores to what
+			// the user set rather than to a converted number.
+			success_sample_period: successSamplePeriod(sampleRate),
 			slow_threshold_ms: slowThreshold,
 			save_timing_breakdown: saveTimingBreakdown,
 			comment: comment || undefined,
@@ -344,8 +372,8 @@ export default function LoadTestConfigDialog({
 								unit="req/s"
 								value={rps}
 								onChange={num(setRps)}
-								min={LOAD_TEST_LIMITS.RPS.MIN}
-								max={LOAD_TEST_LIMITS.RPS.MAX}
+								min={limits.RPS.MIN}
+								max={limits.RPS.MAX}
 							/>
 						)}
 
@@ -355,8 +383,8 @@ export default function LoadTestConfigDialog({
 								label={mode === "ramp_up" ? "Target connections" : "Connections"}
 								value={concurrency}
 								onChange={num(setConcurrency)}
-								min={LOAD_TEST_LIMITS.CONCURRENCY.MIN}
-								max={LOAD_TEST_LIMITS.CONCURRENCY.MAX}
+								min={limits.CONCURRENCY.MIN}
+								max={limits.CONCURRENCY.MAX}
 							/>
 						)}
 
@@ -366,8 +394,8 @@ export default function LoadTestConfigDialog({
 								label="Requests"
 								value={iterations}
 								onChange={num(setIterations)}
-								min={LOAD_TEST_LIMITS.ITERATIONS.MIN}
-								max={LOAD_TEST_LIMITS.ITERATIONS.MAX}
+								min={limits.ITERATIONS.MIN}
+								max={limits.ITERATIONS.MAX}
 							/>
 						)}
 
@@ -378,8 +406,8 @@ export default function LoadTestConfigDialog({
 								unit="sec"
 								value={duration}
 								onChange={num(setDuration)}
-								min={LOAD_TEST_LIMITS.DURATION_S.MIN}
-								max={LOAD_TEST_LIMITS.DURATION_S.MAX}
+								min={limits.DURATION_S.MIN}
+								max={limits.DURATION_S.MAX}
 							/>
 						)}
 
@@ -389,8 +417,8 @@ export default function LoadTestConfigDialog({
 								label="Start from"
 								value={startConcurrency}
 								onChange={num(setStartConcurrency)}
-								min={LOAD_TEST_LIMITS.START_CONCURRENCY.MIN}
-								max={LOAD_TEST_LIMITS.START_CONCURRENCY.MAX}
+								min={limits.START_CONCURRENCY.MIN}
+								max={limits.START_CONCURRENCY.MAX}
 								hint="Connections at the start of the ramp. The engine climbs from here to the target."
 							/>
 						)}
@@ -402,8 +430,8 @@ export default function LoadTestConfigDialog({
 								unit="sec"
 								value={rampDuration}
 								onChange={num(setRampDuration)}
-								min={LOAD_TEST_LIMITS.RAMP_DURATION_S.MIN}
-								max={LOAD_TEST_LIMITS.RAMP_DURATION_S.MAX}
+								min={limits.RAMP_DURATION_S.MIN}
+								max={limits.RAMP_DURATION_S.MAX}
 							/>
 						)}
 					</div>
@@ -470,12 +498,20 @@ export default function LoadTestConfigDialog({
 									type="range"
 									value={sampleRate}
 									onChange={(e) => setSampleRate(Number(e.target.value))}
-									min={LOAD_TEST_LIMITS.SAMPLE_RATE_PCT.MIN}
-									max={LOAD_TEST_LIMITS.SAMPLE_RATE_PCT.MAX}
+									min={limits.SAMPLE_RATE_PCT.MIN}
+									max={limits.SAMPLE_RATE_PCT.MAX}
 									className="w-full accent-primary"
 								/>
+								{/*
+								    The left stop is 1%, not 0%. The value is
+								    converted to the engine's sampling period, and
+								    no period expresses "none" - that is the Save
+								    timing breakdown toggle below, which gates
+								    storage outright. Errors are never sampled
+								    either way; they are always kept.
+								 */}
 								<div className="flex justify-between text-[11px] text-muted-foreground">
-									<span>0% - errors only</span>
+									<span>1% - a trickle</span>
 									<span>100% - everything</span>
 								</div>
 							</div>
@@ -486,8 +522,8 @@ export default function LoadTestConfigDialog({
 								unit="ms"
 								value={slowThreshold}
 								onChange={num(setSlowThreshold)}
-								min={LOAD_TEST_LIMITS.SLOW_THRESHOLD_MS.MIN}
-								max={LOAD_TEST_LIMITS.SLOW_THRESHOLD_MS.MAX}
+								min={limits.SLOW_THRESHOLD_MS.MIN}
+								max={limits.SLOW_THRESHOLD_MS.MAX}
 								hint="Requests slower than this are flagged and always saved, whatever the sample rate."
 							/>
 
@@ -498,8 +534,8 @@ export default function LoadTestConfigDialog({
 									optional
 									value={maxInFlight}
 									onChange={setMaxInFlight}
-									min={LOAD_TEST_LIMITS.MAX_IN_FLIGHT.MIN}
-									max={LOAD_TEST_LIMITS.MAX_IN_FLIGHT.MAX}
+									min={limits.MAX_IN_FLIGHT.MIN}
+									max={limits.MAX_IN_FLIGHT.MAX}
 									placeholder="Auto"
 									hint="Hard cap on concurrent in-flight requests. Blank derives it from the target rate. Lowering it drops requests sooner under backpressure; raising it queues instead."
 								/>

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -451,7 +451,7 @@ export default function RequestBuilder() {
 					requestId: fetchedRequest.id,
 					environmentId: activeEnvironmentId || undefined,
 					comment: config.comment,
-					success_sample_rate: config.data_sample_rate,
+					success_sample_rate: config.success_sample_period,
 					slow_threshold_ms: config.slow_threshold_ms,
 					save_timing_breakdown: config.save_timing_breakdown,
 					// The collection chain's test scripts too. Load runs only ever

--- a/app/src/modules/settings/main/app-panels.ts
+++ b/app/src/modules/settings/main/app-panels.ts
@@ -17,11 +17,12 @@
 
 import type { ComponentType } from "react";
 import type { LucideIcon } from "lucide-react";
-import { Palette, Code2, LayoutDashboard, Bell, Plug, Info } from "lucide-react";
+import { Palette, Code2, LayoutDashboard, Gauge, Bell, Plug, Info } from "lucide-react";
 import type { ClientSettingsCategory, SettingsCategory } from "@/types";
 import AppearancePanel from "./panels/AppearancePanel";
 import EditorPanel from "./panels/EditorPanel";
 import DashboardPanel from "./panels/DashboardPanel";
+import LoadTestingPanel from "./panels/LoadTestingPanel";
 import McpSettingsPanel from "./panels/McpSettingsPanel";
 import NotificationsPanel from "./panels/NotificationsPanel";
 import GeneralPanel from "./panels/GeneralPanel";
@@ -56,6 +57,13 @@ export const APP_SETTINGS_PANELS: readonly AppSettingsPanel[] = [
 		description: "How live test dashboards and charts behave",
 		icon: LayoutDashboard,
 		Component: DashboardPanel,
+	},
+	{
+		id: "load-testing",
+		label: "Load testing",
+		description: "How far the load-test dialog lets you push a run",
+		icon: Gauge,
+		Component: LoadTestingPanel,
 	},
 	{
 		id: "notifications",

--- a/app/src/modules/settings/main/panels/LoadTestingPanel.test.tsx
+++ b/app/src/modules/settings/main/panels/LoadTestingPanel.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The panel's whole job is to move a ceiling without ever letting it out of
+ * the range the engine will accept - a settings screen that could produce a
+ * rejected (and, before the engine's own validation, a crashing) run would be
+ * worse than no screen. So the assertions are about what reaches the store,
+ * not about the markup.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import LoadTestingPanel from "./LoadTestingPanel";
+import { useClientSettingsStore } from "@/stores";
+import { DEFAULT_LOAD_TEST_CEILINGS, LOAD_TEST_CEILING_BOUNDS } from "@/constants/load-test";
+
+const ceilings = () => useClientSettingsStore.getState().loadTestCeilings;
+const connectionsField = () => screen.getByLabelText(/max connections/i) as HTMLInputElement;
+
+beforeEach(() => {
+	cleanup();
+	useClientSettingsStore.getState().setLoadTestCeilings(DEFAULT_LOAD_TEST_CEILINGS);
+});
+
+describe("LoadTestingPanel", () => {
+	it("shows the shipped ceilings", () => {
+		render(<LoadTestingPanel />);
+		expect(connectionsField().value).toBe(String(DEFAULT_LOAD_TEST_CEILINGS.concurrency));
+	});
+
+	it("raises a ceiling the user types", () => {
+		render(<LoadTestingPanel />);
+		fireEvent.change(connectionsField(), { target: { value: "5000" } });
+		expect(ceilings().concurrency).toBe(5000);
+	});
+
+	it("clamps a value above the engine's guard instead of storing it", () => {
+		render(<LoadTestingPanel />);
+		fireEvent.change(connectionsField(), { target: { value: "999999" } });
+		expect(ceilings().concurrency).toBe(LOAD_TEST_CEILING_BOUNDS.concurrency.MAX);
+	});
+
+	it("clamps an emptied field to the floor rather than storing a NaN", () => {
+		// `parseInt("")` is NaN, and a NaN ceiling makes every range in the load
+		// dialog nonsense - the field would show `max=""` and stop bounding.
+		render(<LoadTestingPanel />);
+		fireEvent.change(connectionsField(), { target: { value: "" } });
+		expect(ceilings().concurrency).toBe(LOAD_TEST_CEILING_BOUNDS.concurrency.MIN);
+	});
+
+	it("never lets a ceiling drop below one - the engine rejects a zero", () => {
+		render(<LoadTestingPanel />);
+		fireEvent.change(connectionsField(), { target: { value: "0" } });
+		expect(ceilings().concurrency).toBeGreaterThanOrEqual(1);
+	});
+
+	it("offers a reset only once something is off the default, and it restores every field", () => {
+		const { rerender } = render(<LoadTestingPanel />);
+		expect(screen.queryByRole("button", { name: /reset/i })).not.toBeInTheDocument();
+
+		fireEvent.change(connectionsField(), { target: { value: "5000" } });
+		fireEvent.change(screen.getByLabelText(/max duration/i), { target: { value: "120" } });
+		rerender(<LoadTestingPanel />);
+
+		fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+		expect(ceilings()).toEqual(DEFAULT_LOAD_TEST_CEILINGS);
+	});
+
+	it("names every ceiling it renders, so each input is reachable by its label", () => {
+		// The labels are what the load dialog's fields are called; a rename on
+		// one side without the other is the thing that makes this screen unclear.
+		render(<LoadTestingPanel />);
+		for (const label of [
+			/max connections/i,
+			/max target rate/i,
+			/max duration/i,
+			/max requests/i,
+		]) {
+			expect(screen.getByLabelText(label)).toBeInTheDocument();
+		}
+	});
+});

--- a/app/src/modules/settings/main/panels/LoadTestingPanel.tsx
+++ b/app/src/modules/settings/main/panels/LoadTestingPanel.tsx
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * LoadTestingPanel
+ *
+ * The ceilings the load-test dialog offers. These are *this app's* policy, not
+ * the engine's: the engine range-checks a run config too, but those bounds are
+ * crash guards (a negative `concurrency` is an eager pre-allocation of ~1.8e19
+ * curl handles), so they sit far above anything a dialog should offer and are
+ * not settings. What was left was a shipped default of 1000 connections that a
+ * user on real hardware had no way to raise.
+ *
+ * Each field here is clamped to the engine's guard on the way into the store,
+ * so no value set on this screen can compose a run the engine will reject.
+ * Client-side only (localStorage-backed); read by the load dialog through
+ * `resolveLoadTestLimits`.
+ */
+
+import { Gauge, RotateCcw } from "lucide-react";
+import {
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Input,
+	Label,
+} from "@/components/ui";
+import { useClientSettingsStore } from "@/stores";
+import {
+	DEFAULT_LOAD_TEST_CEILINGS,
+	LOAD_TEST_CEILING_BOUNDS,
+	type LoadTestCeilingKey,
+} from "@/constants/load-test";
+
+interface CeilingField {
+	key: LoadTestCeilingKey;
+	label: string;
+	unit?: string;
+	description: string;
+}
+
+/**
+ * Four ceilings, not six: ramp duration follows the duration ceiling and ramp
+ * start follows the connection ceiling, because each pair is the same physical
+ * quantity (see `resolveLoadTestLimits`).
+ */
+const FIELDS: readonly CeilingField[] = [
+	{
+		key: "concurrency",
+		label: "Max connections",
+		description:
+			"Upper bound on the Connections field, and on where a ramp may start or finish. The engine pre-allocates connections per worker before any traffic flows, so this is the setting that costs memory up front.",
+	},
+	{
+		key: "rps",
+		label: "Max target rate",
+		unit: "req/s",
+		description:
+			"Upper bound on the Target rate field for Constant RPS runs. What a single desktop engine can actually reach depends on the target and your network long before this does.",
+	},
+	{
+		key: "durationSeconds",
+		label: "Max duration",
+		unit: "sec",
+		description:
+			"Upper bound on both Duration and Ramp duration. The default of one hour is a session; the ceiling of one day is the engine's own per-transfer limit.",
+	},
+	{
+		key: "iterations",
+		label: "Max requests",
+		description: "Upper bound on the Requests field for Fixed Iterations runs.",
+	},
+];
+
+export default function LoadTestingPanel() {
+	const ceilings = useClientSettingsStore((s) => s.loadTestCeilings);
+	const setCeilings = useClientSettingsStore((s) => s.setLoadTestCeilings);
+
+	const isDefault = FIELDS.every((f) => ceilings[f.key] === DEFAULT_LOAD_TEST_CEILINGS[f.key]);
+
+	return (
+		<Card>
+			<CardHeader className="pb-3">
+				<div className="flex items-start justify-between gap-4">
+					<div>
+						<div className="flex items-center gap-2">
+							<Gauge className="w-5 h-5 text-muted-foreground" />
+							<CardTitle className="text-base">Load test ceilings</CardTitle>
+						</div>
+						<CardDescription className="mt-1">
+							The largest value each field in the Run a load test dialog will offer.
+							Raising one does not change any run you have already configured - it
+							only widens what you can ask for. The engine enforces its own limits
+							regardless, and no value here can exceed them.
+						</CardDescription>
+					</div>
+					{!isDefault && (
+						<Button
+							variant="ghost"
+							size="sm"
+							className="shrink-0 text-xs h-7 px-2"
+							onClick={() => setCeilings(DEFAULT_LOAD_TEST_CEILINGS)}
+						>
+							<RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+							Reset
+						</Button>
+					)}
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-5">
+				{FIELDS.map((field) => {
+					const bounds = LOAD_TEST_CEILING_BOUNDS[field.key];
+					const id = `load-ceiling-${field.key}`;
+					return (
+						<div key={field.key} className="space-y-1.5">
+							<Label htmlFor={id} className="text-sm font-medium">
+								{field.label}
+							</Label>
+							<div className="flex items-center gap-2">
+								<div className="relative">
+									<Input
+										id={id}
+										type="number"
+										inputMode="numeric"
+										className={
+											field.unit ? "max-w-[10rem] pr-12" : "max-w-[10rem]"
+										}
+										value={ceilings[field.key]}
+										min={bounds.MIN}
+										max={bounds.MAX}
+										onChange={(e) => {
+											const n = parseInt(e.target.value, 10);
+											// An emptied field parses to NaN. The store
+											// clamps it to the floor rather than storing a
+											// NaN that would make every dialog range
+											// nonsense.
+											setCeilings({ [field.key]: n });
+										}}
+									/>
+									{field.unit && (
+										<span
+											className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground"
+											aria-hidden="true"
+										>
+											{field.unit}
+										</span>
+									)}
+								</div>
+								<span className="text-xs text-muted-foreground whitespace-nowrap">
+									{bounds.MIN.toLocaleString()} - {bounds.MAX.toLocaleString()}
+								</span>
+							</div>
+							<p className="text-xs text-muted-foreground">{field.description}</p>
+							{ceilings[field.key] !== DEFAULT_LOAD_TEST_CEILINGS[field.key] && (
+								<p className="text-xs text-muted-foreground">
+									Default:{" "}
+									{DEFAULT_LOAD_TEST_CEILINGS[field.key].toLocaleString()}
+								</p>
+							)}
+						</div>
+					);
+				})}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/src/stores/client-settings-store.ts
+++ b/app/src/stores/client-settings-store.ts
@@ -38,6 +38,11 @@ import {
 	type AutoSavePrefs,
 	nearestAutoSaveDelay,
 } from "@/constants/client-settings";
+import {
+	DEFAULT_LOAD_TEST_CEILINGS,
+	clampCeilings,
+	type LoadTestCeilings,
+} from "@/constants/load-test";
 
 /** localStorage keys reset by "Reset app settings" - all renderer preferences,
  *  but NOT workspace/session state (open tabs, layout, active collection). */
@@ -65,6 +70,8 @@ interface ClientSettingsState {
 	reducedMotion: boolean;
 	/** Toast position, duration scale, stack cap and severity floor. */
 	notifications: NotificationPrefs;
+	/** Upper bounds the load-test dialog offers. Read via `resolveLoadTestLimits`. */
+	loadTestCeilings: LoadTestCeilings;
 
 	setEditor: (patch: Partial<EditorPrefs>) => void;
 	setMonoFont: (font: MonoFontChoice) => void;
@@ -75,6 +82,8 @@ interface ClientSettingsState {
 	setAutoSave: (patch: Partial<AutoSavePrefs>) => void;
 	setNotifications: (patch: Partial<NotificationPrefs>) => void;
 	setReducedMotion: (on: boolean) => void;
+	/** Patch one or more ceilings; each is clamped to what the engine accepts. */
+	setLoadTestCeilings: (patch: Partial<LoadTestCeilings>) => void;
 	/** Clear every renderer preference and reload so defaults re-apply cleanly. */
 	resetAll: () => void;
 }
@@ -115,6 +124,7 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 			autoSave: { ...DEFAULT_AUTO_SAVE_PREFS },
 			reducedMotion: false,
 			notifications: { ...DEFAULT_NOTIFICATION_PREFS },
+			loadTestCeilings: { ...DEFAULT_LOAD_TEST_CEILINGS },
 
 			setEditor: (patch) => set((s) => ({ editor: { ...s.editor, ...patch } })),
 			setMonoFont: (font) => {
@@ -135,6 +145,13 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 				applyReducedMotion(on);
 				set({ reducedMotion: on });
 			},
+			// Clamped on the way in, not only on the way out: the dialog reads
+			// this to build its own ranges, so an out-of-range ceiling stored
+			// here would present the user a value the engine rejects.
+			setLoadTestCeilings: (patch) =>
+				set((s) => ({
+					loadTestCeilings: clampCeilings({ ...s.loadTestCeilings, ...patch }),
+				})),
 
 			resetAll: () => {
 				for (const key of SETTINGS_STORAGE_KEYS) localStorage.removeItem(key);
@@ -155,6 +172,7 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 				autoSave: s.autoSave,
 				reducedMotion: s.reducedMotion,
 				notifications: s.notifications,
+				loadTestCeilings: s.loadTestCeilings,
 			}),
 			onRehydrateStorage: () => (state) => {
 				// Re-assert persisted DOM-affecting prefs after rehydrate.
@@ -170,6 +188,16 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 					if (snapped !== state.autoSave.delayMs) {
 						state.autoSave = { ...state.autoSave, delayMs: snapped };
 					}
+
+					// Re-clamp on the way out of storage. The bounds are the
+					// engine's crash guards, and a build that tightens one
+					// would otherwise keep offering the stored ceiling above
+					// it. The spread also fills in a key added after the
+					// stored payload was written.
+					state.loadTestCeilings = clampCeilings({
+						...DEFAULT_LOAD_TEST_CEILINGS,
+						...state.loadTestCeilings,
+					});
 				}
 			},
 		}

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -251,7 +251,11 @@ export interface StartLoadTestRequest {
 	maxInFlight?: number; // Max concurrent in-flight requests before drops/queue. Default per-strategy.
 
 	// Data capture options
-	success_sample_rate?: number; // 0-100
+	// Sampling period, not a percentage: the engine keeps a trace when
+	// `counter % success_sample_rate == 0`, so 1 keeps every response and 100
+	// keeps 1%. A 0 is a division by zero engine-side. Build it with
+	// `successSamplePeriod`, which converts from the percentage the UI shows.
+	success_sample_rate?: number;
 	slow_threshold_ms?: number;
 	save_timing_breakdown?: boolean;
 	tests?: ScriptPart[];

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -431,7 +431,13 @@ export interface LoadTestConfig {
 	ramp_duration_seconds?: number;
 	/** Ramp-Up only: connections at t=0, climbing to `concurrency`. */
 	start_concurrency?: number;
-	data_sample_rate?: number;
+	/**
+	 * Sampling **period** for stored success traces - keep 1 in N, engine-side
+	 * `counter % N`. Named for the unit on purpose: the dialog's control is a
+	 * percentage, and the two used to be the same number, so the slider meant
+	 * the inverse of its own label. `successSamplePeriod` does the conversion.
+	 */
+	success_sample_period?: number;
 	slow_threshold_ms?: number;
 	save_timing_breakdown?: boolean;
 	comment?: string;
@@ -641,6 +647,7 @@ export type ClientSettingsCategory =
 	| "appearance"
 	| "editor"
 	| "dashboard"
+	| "load-testing"
 	| "notifications"
 	| "general"
 	| "mcp";

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -244,7 +244,11 @@ Past runs (single executions and load tests), split into a sidebar list and a ma
 Same nav/content split as Variables: the category tree renders in the **Drawer** (`settings` view), not inside the settings tab. Selecting a category sets `useSettingsStore.selectedCategory` **and** opens the settings tab, so `SettingsMain` shows that panel. There is no `SettingsLayout` two-pane wrapper anymore - the Drawer is the left pane.
 
 - **Sidebar (`sidebar/SettingsCategoryTree.tsx`)** - settings category navigation; rendered by the Drawer.
-- **Main (`main/`)** - `SettingsMain.tsx` (screen `"settings"`) hosts the app-settings category panels under `main/panels/`: `AppearancePanel.tsx`, `DashboardPanel.tsx`, `GeneralPanel.tsx`, and `EditorPanel.tsx`, plus the shared `ClientSettingsPanel.tsx` wrapper, `FontPicker.tsx`, and `SettingControls.tsx` primitives. `app-panels.ts` is the panel registry/metadata. (The former monolithic `UISettingsPanel.tsx` was split into these panels in PR #55.)
+- **Main (`main/`)** - `SettingsMain.tsx` (screen `"settings"`) hosts the app-settings category panels under `main/panels/`: `AppearancePanel.tsx`, `DashboardPanel.tsx`, `LoadTestingPanel.tsx`, `GeneralPanel.tsx`, and `EditorPanel.tsx`, plus the shared `ClientSettingsPanel.tsx` wrapper, `FontPicker.tsx`, and `SettingControls.tsx` primitives. `app-panels.ts` is the panel registry/metadata. (The former monolithic `UISettingsPanel.tsx` was split into these panels in PR #55.)
+
+Adding an app panel is three edits and no branching: a member on `ClientSettingsCategory` (`types/domain.ts`), one entry in `APP_SETTINGS_PANELS`, and the panel file. The sidebar tree and `SettingsMain` both read the registry.
+
+`LoadTestingPanel.tsx` is the ceilings the load-test dialog offers - the app's own policy, clamped to the engine's crash guards on the way into `client-settings-store`. The engine's bounds themselves are deliberately **not** settings; see `docs/app/api-integration.md` (Dialog ceilings are a user setting).
 
 ## Welcome (`modules/welcome/`)
 

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -402,6 +402,34 @@ await apiService.startLoadTest({
 });
 ```
 
+#### `success_sample_rate` is a period, not a percentage
+
+The engine keeps a success trace when `counter % success_sample_rate == 0` - one
+in every N. The dialog's control is a percentage, and the renderer converts
+between them with `successSamplePeriod` (`constants/load-test.ts`): 100% becomes
+a period of `1`, 1% becomes `100`, and the default 10% is the fixed point where
+the two units coincide. Sending the percentage straight through, as the renderer
+did before, inverts the slider - "100% - everything" kept 1%.
+
+A `0` is a division by zero engine-side, so the control's floor is 1%. "Keep no
+success traces" is the **Save timing breakdown** toggle, which gates storage
+outright.
+
+#### Dialog ceilings are a user setting
+
+`LOAD_TEST_LIMITS` (`constants/load-test.ts`) holds the ranges the load dialog
+offers, and four of its ceilings are user-adjustable in **Settings → Load
+testing** (`loadTestCeilings` on `client-settings-store`). The dialog reads them
+through `resolveLoadTestLimits`, never off the constant.
+
+These are the app's policy and sit inside the engine's own bounds, which are
+crash guards rather than throttles: a run's `concurrency` becomes an *eager*
+per-worker curl-handle pre-allocation, so the engine caps it at 10x
+`event_loop::MAX_CONCURRENT`. `LOAD_TEST_CEILING_BOUNDS` pins each settable
+ceiling at that guard, so no value on the settings screen can compose a run the
+engine rejects. The floors are not settable at all - below them the values are
+not "small", they are unusable (a `concurrency` of 0, a sample period of 0).
+
 ## Error Handling
 
 ### HTTP Errors

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -211,13 +211,15 @@ const { setResponse, getResponse, clearResponse, clearAll } = useResponseStore()
 
 #### `client-settings-store.ts` - Renderer Preferences
 
-Central home for renderer-only preferences that aren't part of the pre-paint appearance set (theme/color/UI-font/scale/radius live in their own localStorage keys so `index.html` can apply them before React mounts). Holds editor behavior, the monospace/code font, chart granularity, the capacity SLO threshold, the live refresh rate, and auto-save preferences. Backs the Settings **panels** (`modules/settings/main/panels/`). Non-React consumers (services, the dashboard store) read via `getState()`.
+Central home for renderer-only preferences that aren't part of the pre-paint appearance set (theme/color/UI-font/scale/radius live in their own localStorage keys so `index.html` can apply them before React mounts). Holds editor behavior, the monospace/code font, chart granularity, the capacity SLO threshold, the live refresh rate, auto-save preferences, and the load-test dialog's ceilings. Backs the Settings **panels** (`modules/settings/main/panels/`). Non-React consumers (services, the dashboard store) read via `getState()`.
 
 **Key exports:**
 ```typescript
-const store = useClientSettingsStore();   // editorPrefs, autoSavePrefs, monoFont, chartBucketSeconds, sloThresholdMs, liveRefreshMs, ...
+const store = useClientSettingsStore();   // editorPrefs, autoSavePrefs, monoFont, chartBucketSeconds, sloThresholdMs, liveRefreshMs, loadTestCeilings, ...
 import { SETTINGS_STORAGE_KEYS } from "@/stores";  // localStorage keys reset by "Reset app settings"
 ```
+
+`loadTestCeilings` is the one slice with a bound outside the app: each value is clamped to `LOAD_TEST_CEILING_BOUNDS` (`constants/load-test.ts`) on write **and** on rehydrate, because the bounds are the engine's crash guards and a build that tightens one must not keep offering a stored ceiling above it. The load dialog turns them into its field ranges via `resolveLoadTestLimits`; nothing else reads them.
 
 **Persisted** to localStorage (via `zustand/persist`); workspace/session state (open tabs, layout, active collection) is deliberately excluded from the reset.
 


### PR DESCRIPTION
## Description

Two changes to the load-test dialog, both about a number meaning something different at each end of the wire.

### 1. The success sample rate was inverted

The slider is a percentage and says so - *"keeping 10% of successful responses"*, *"100% - everything"*. The engine reads `success_sample_rate` as a sampling **period**: it keeps a trace when `counter % rate == 0`, one in every N (`metrics_collector.cpp:121`, and `expected / success_sample_rate` in the constructor's reserve at `:71`).

Nothing converted between the two. `LoadTestConfigDialog` sent `data_sample_rate: sampleRate` and `request-builder/index.tsx:454` passed it straight through as `success_sample_rate`, so the control meant its own inverse:

| Slider | Label says | Engine actually kept |
|---|---|---|
| 100 | 100% - everything | 1% |
| 10 | 10% | 10% ✅ |
| 1 | (left stop) | 100% - every response |

Only the default of 10 was right, 1-in-10 being 10%, which is why it went unnoticed. This is pre-existing on `master`, not introduced by #132 - but #132 relabels the left stop as *"1% - errors and a trickle"*, i.e. it names the **heaviest** setting as the lightest. With this conversion in place that label becomes correct.

`successSamplePeriod` now does the conversion, and `LoadTestConfig` carries `success_sample_period` rather than `data_sample_rate` so the unit is named at every hop - the rename is what makes a future mis-wiring a type error instead of a silent inversion. The stored memo stays a percentage, so the control restores to what the user set rather than to a converted number.

The floor moves `0` -> `1`: 0% has no period that expresses it, and a literal `0` on the wire is `% 0` engine-side. "Keep no success traces" is the **Save timing breakdown** toggle, which gates storage outright.

No memory-cliff change: a period of 1 (keep everything, `reserve(expected)`) was already reachable before this - at the slider's *left* stop, labelled "0% - errors only". It now sits at the right stop, where the label says "everything".

### 2. Load-test ceilings are now user-adjustable

New **Settings → Load testing** panel: max connections, target rate, duration, requests.

These are the app's own policy and sat an order of magnitude below what the engine accepts (dialog `concurrency` ≤ 1000 against an engine guard of 10000), so a user on real hardware had no way past 1000 connections. Backed by `loadTestCeilings` on `client-settings-store`, clamped to `LOAD_TEST_CEILING_BOUNDS` on write **and** on rehydrate - a build that tightens a bound must not keep offering a stored ceiling above it.

The upper end of each bound is the engine's crash guard, so no value set on that screen can compose a run the engine rejects. **The floors are not settable**, deliberately: below them the values are not small, they are unusable (`concurrency: 0`, a sample period of `0`). The engine's own bounds stay fixed constants for the same reason - they are crash guards, not throttles, and a settings control is a promise that everything in its range works.

Ramp duration follows the duration ceiling and ramp start follows the connection ceiling - each pair is one physical quantity, and separate knobs would allow a target of 5000 the ramp could only climb to from a capped 1000. Restored dialog values are clamped into the effective range, so a ceiling lowered since the last run cannot seed a field above its own `max`.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

Not breaking: the sample-rate change alters what a *moved* slider sends, but only in the direction the label always claimed. The default is unchanged.

## Testing

```bash
cd app && pnpm test && pnpm type-check && pnpm lint
```

- **1758/1758 pass (216 files)**, up from 1738 - **+20** across `constants/load-test.test.ts` (new), `LoadTestingPanel.test.tsx` (new), and `LoadTestConfigDialog.test.tsx`.
- `pnpm type-check` clean. ESLint clean on every touched file; the two warnings in `request-builder/index.tsx` are pre-existing and on lines this PR does not touch.
- **Mutation-checked** per CLAUDE.md, both halves, reverted and restored:
  - Make `successSamplePeriod` an identity: **5 fail**, including both payload assertions in the dialog.
  - Point the dialog back at the `LOAD_TEST_LIMITS` constant, and drop the store's clamp: **7 fail**.
  - Restored, all green.
- Assertions go through the rendered dialog's payload rather than the helper alone - the conversion existing is not the point, it being applied on the way out is.
- Prettier run on **only** the three files it flagged; `LoadTestConfigDialog.test.tsx` verified prettier-clean on `origin/master` first, so no unrelated reflow.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Docs

- **`docs/app/api-integration.md`** - two new subsections under Load Test Execution: `success_sample_rate` is a period not a percentage (with the conversion and the 1% floor), and why the dialog ceilings are a setting while the engine's bounds are not.
- **`docs/app/state-management.md`** - `loadTestCeilings` on `client-settings-store`, and why it is the one slice clamped against a bound that lives outside the app.
- **`docs/app/COMPONENTS.md`** - `LoadTestingPanel.tsx` in the panel list, plus the three edits an app panel needs (union member, registry entry, panel file).

## Notes for #132

Filed here rather than as review comments so they are not lost:

1. `run_config::MAX_CONCURRENCY` derives from the compile-time `event_loop::MAX_CONCURRENT` (1000 -> guard 10000), while the value a run actually gets comes from the **user-settable** `eventLoopMaxConcurrent` config row, whose own max is also 10000. They coincide exactly by luck. Raise that row's max later and an explicit `concurrency` above the guard 400s while the default path silently accepts it. Deriving the guard from the config row's max, or a comment locking the two, would close it.
2. #132's new left-stop label is backwards without the conversion in this PR (see above).

File overlap with #132 is `app/src/constants/load-test.ts` and the load dialog - both change `SAMPLE_RATE_PCT.MIN` to `1` and the slider label, and they agree semantically, so whichever lands second is a text merge rather than a rethink.

## Related Issues

Follows up on #132 / #122.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QknboWDuX8Lncw2StGhKg6)_