### PR TITLE
fix(engine): cap the metrics collector's pre-allocation so a long high-rate run cannot wedge

### DIFF
--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -150,6 +150,20 @@ constexpr bool DEFAULT_STORE_SUCCESS_TRACES = false;
 constexpr size_t DEFAULT_MAX_RESPONSE_SAMPLES = 1000;
 /// Sample rate for response storage (1 = all, 100 = 1%, etc.)
 constexpr size_t DEFAULT_RESPONSE_SAMPLE_RATE = 100;
+/// Upper bound on the collector's *pre-allocation* - not on what a run may go
+/// on to store, since both vectors still grow past it.
+///
+/// Both derived reserves scale with `expected_requests`, which RunContext
+/// computes as duration x RPS x 1.2 with no ceiling of its own. At 1M RPS for
+/// a day that is ~1.04e11, and the errors reserve (expected / 20, taken
+/// whenever `max_errors` is 0 - the default, and nothing overrides it) asks
+/// for ~5.2e9 ResultRecords, on the order of 450 GB. That allocation throws
+/// out of the collector's constructor, which runs inside RunContext's, which
+/// the route calls *after* writing the run row - so the caller gets an opaque
+/// 500 and the row is stranded `pending` forever. A reserve is only an
+/// optimisation, so capping it costs a few reallocations on a run that large
+/// and nothing at all otherwise. 1M records is ~90 MB, still generous.
+constexpr size_t MAX_RESERVE_RECORDS = 1000000;
 /// HdrHistogram significant figures (3 = ~0.1% precision)
 constexpr int HISTOGRAM_SIGNIFICANT_FIGURES = 3;
 /// HdrHistogram max trackable latency in microseconds (1 hour)

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -58,18 +58,27 @@ MetricsCollector::MetricsCollector (const std::string& run_id, MetricsCollectorC
     // Pre-allocate vectors to avoid reallocation during test
     size_t expected = config_.expected_requests;
 
+    // Both reserves below are capped. They derive from `expected_requests`,
+    // which is duration x RPS and has no ceiling of its own, so a long run at a
+    // high rate asks for an allocation that simply cannot be served - and it
+    // throws from here, inside RunContext's constructor, which the route calls
+    // *after* it has written the run row. The caller sees an opaque 500 and the
+    // row sits `pending` forever. Capping only costs a reallocation on a run
+    // that big; the vectors still grow to whatever the run actually produces.
+    const size_t max_reserve = constants::metrics_collector::MAX_RESERVE_RECORDS;
+
     // Reserve errors vector (assume ~5% error rate max)
     size_t error_reserve = config_.max_errors > 0 ?
     config_.max_errors :
     std::max (expected / 20U, size_t (10000));
-    errors_.reserve (error_reserve);
+    errors_.reserve (std::min (error_reserve, max_reserve));
 
     // Reserve success results if storing traces
     if (config_.store_success_traces) {
         size_t success_reserve = config_.max_success_results > 0 ?
         config_.max_success_results :
         expected / config_.success_sample_rate;
-        success_results_.reserve (success_reserve);
+        success_results_.reserve (std::min (success_reserve, max_reserve));
     }
 
     // Reserve response samples for script validation

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -606,3 +606,57 @@ TEST_F (MetricsCollectorTest, GetCurrentStatsDerivesStatusClasses) {
     EXPECT_EQ (stats["status4xx"].get<size_t> (), 2u);
     EXPECT_EQ (stats["status5xx"].get<size_t> (), 1u);
 }
+
+// ============================================================================
+// Pre-allocation guard
+// ============================================================================
+
+// `expected_requests` is duration x RPS x 1.2 and has no ceiling of its own,
+// while the errors reserve is `expected / 20` whenever `max_errors` is 0 - the
+// default, and nothing overrides it. A day at a high rate therefore asked for
+// billions of ResultRecords, which throws from this constructor - inside
+// RunContext's, which the run route calls *after* writing the run row, so the
+// caller got an opaque 500 and the row was stranded `pending`. Constructing at
+// all is most of the assertion here.
+TEST (MetricsCollectorReserveGuard, HugeExpectedRequestsDoesNotThrow) {
+    MetricsCollectorConfig config;
+    // 24h at 1M RPS with the 20% buffer - the top of what the load dialog's
+    // ceilings can now be raised to.
+    config.expected_requests    = 103'680'000'000ULL;
+    config.store_success_traces = true;
+    config.max_success_results  = 0; // take the derived branch, not the default cap
+    config.success_sample_rate  = 1; // 100% sampling: the largest derived reserve
+
+    std::unique_ptr<MetricsCollector> collector;
+    ASSERT_NO_THROW (
+    collector = std::make_unique<MetricsCollector> ("run_huge_expected", config));
+
+    EXPECT_LE (collector->errors ().capacity (),
+    vayu::core::constants::metrics_collector::MAX_RESERVE_RECORDS);
+}
+
+// The cap must not become a floor: an ordinary run still gets the exact
+// pre-allocation it asked for, which is the point of reserving at all.
+TEST (MetricsCollectorReserveGuard, OrdinaryRunKeepsItsFullReserve) {
+    MetricsCollectorConfig config;
+    config.expected_requests = 200000; // 60s at ~2.8k RPS
+    MetricsCollector collector ("run_ordinary", config);
+
+    // expected / 20, uncapped because it is far below the ceiling.
+    EXPECT_GE (collector.errors ().capacity (), 10000u);
+    EXPECT_LT (collector.errors ().capacity (),
+    vayu::core::constants::metrics_collector::MAX_RESERVE_RECORDS);
+}
+
+// Capping the *reserve* must not cap what a run records - the vector grows.
+TEST (MetricsCollectorReserveGuard, RecordingIsUnaffectedByTheCap) {
+    MetricsCollectorConfig config;
+    config.expected_requests = 103'680'000'000ULL;
+    MetricsCollector collector ("run_capped_recording", config);
+
+    for (int i = 0; i < 50; ++i) {
+        collector.record_error (vayu::ErrorCode::Timeout, "t");
+    }
+    EXPECT_EQ (collector.total_errors (), 50u);
+    EXPECT_EQ (collector.errors ().size (), 50u);
+}


### PR DESCRIPTION
## Description

`MetricsCollector`'s constructor sizes two vectors from `expected_requests`, which `RunContext` computes as `duration x RPS x 1.2` (`run_manager.cpp:189`) with no ceiling of its own. The errors reserve is `expected / 20` whenever `max_errors` is `0` - which is `DEFAULT_MAX_ERRORS`, and nothing overrides it - so the pre-allocation grows without bound with the run's size:

```cpp
// metrics_collector.cpp, constructor
size_t error_reserve = config_.max_errors > 0 ?
config_.max_errors :
std::max (expected / 20U, size_t (10000));
errors_.reserve (error_reserve);
```

At the top of what the load dialog now offers - 24h at 1M RPS, after #170 made those ceilings user-adjustable - that is ~1.04e11 expected requests and a reserve of **~5.2e9 `ResultRecord`s, on the order of 450 GB**.

The failure mode is the interesting part. That allocation throws from this constructor, which runs inside `RunContext`'s constructor, which `POST /runs` calls **after** `create_run` has already written the run row (`execution.cpp`). So the caller gets an opaque `500` and the row is stranded `pending` forever - the same shape as defect 4 in #122, reached through a different field.

**Pre-existing rather than introduced by #170.** At the shipped ceilings (3600s at 50k RPS) the same expression already reserved ~10.8M records, near 1 GB, on a max-config run. But the settable ceilings widen the top of that range by roughly 480x, so the guard belongs alongside them.

### The fix

Both *derived* reserves are capped at `MAX_RESERVE_RECORDS` (1M records, ~90 MB). A reserve is only an optimisation - the vectors still grow to whatever the run actually produces - so the cap costs a few reallocations on a run that large and nothing at all otherwise.

The explicit `max_errors` / `max_success_results` branches are deliberately **untouched**: a caller-supplied cap is stated intent, not a derived guess, and clamping it would silently under-allocate for someone who asked for exactly that size.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Not breaking: nothing that previously succeeded changes behaviour. The capped path is one that previously threw, and below the cap the reserve is byte-for-byte what it was.

## Testing

```bash
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure
```

- **Engine: 390/390 pass**, up from 387 - the 3 new tests are `MetricsCollectorReserveGuard` in `engine/tests/metrics_collector_test.cpp`.
- **Mutation-checked** per CLAUDE.md, reverted and restored: dropping both `std::min`s fails `HugeExpectedRequestsDoesNotThrow` (the allocation genuinely throws - this is not a threshold assertion) and `RecordingIsUnaffectedByTheCap`. Restored, 390/390 re-run green.
- The three tests cover both directions and the thing a cap could break:
  - `HugeExpectedRequestsDoesNotThrow` - constructs at the new ceiling's worst case and asserts the capacity is bounded. Constructing at all is most of the assertion.
  - `OrdinaryRunKeepsItsFullReserve` - a 200k-request run still gets its exact `expected / 20`, so the cap cannot quietly become a floor and turn every run into a reallocation storm.
  - `RecordingIsUnaffectedByTheCap` - capping the *reserve* must not cap what a run records; the vector grows.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Docs

**None needed, checked rather than assumed.** No doc describes the collector's pre-allocation - `docs/engine/architecture.md`, `api-reference.md` and `db-schema.md` were grepped for `reserve` / `expected_requests` / `pre-alloc` and none mentions it. Nothing observable over HTTP changes either: no status code, payload or stored shape moves, so `api-reference.md` has nothing to say about this.

## Checked and deliberately not changed

- **The success reserve is not reachable from the app.** `DEFAULT_MAX_SUCCESS_RESULTS` is `1000` and `run_manager` never overrides it, so the `expected / success_sample_rate` branch is dead in practice and the reserve is 1000. It is capped here anyway, because it is the same expression and the next caller to set `max_success_results = 0` should not rediscover this. (Side effect of that cap being 1000, unchanged by this PR and worth knowing: at 100% sampling you get the *first* 1000 traces rather than 1000 spread across the run.)
- **`max_errors == 0` still means `errors_` grows unboundedly during a run.** The constant's comment says `0 = unlimited (prevents OOM at high error rates)`, which is the opposite of what `0` does. Capping the reserve does not touch the growth. That is a real defect, but it is a retention-policy change rather than a crash guard, so it belongs with #121's hardening rather than here.
- **`response_samples_.reserve (config_.max_response_samples)`** is left to #132, which range-checks that field at the route.

## Related Issues

Follow-up to #170. Adjacent to #122 / #121 (load-generation core hardening) - same stuck-`pending` failure shape, different field.

Touches `metrics_collector.cpp`'s constructor, which #132 also edits (it adds a sample-rate clamp at the top). Different hunks about 30 lines apart, so the two merge cleanly in either order.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QknboWDuX8Lncw2StGhKg6)_