### PR TITLE
fix(engine): join run workers on shutdown instead of detaching them

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -926,6 +926,13 @@ The sample rates are additionally clamped to &ge; 1 inside the metrics
 collector, so the modulo cannot divide by zero even for a caller that bypasses
 this route.
 
+**Shutdown refuses new runs.** Once the daemon has begun draining its run
+workers, `POST /runs` answers `503 {"error": "Engine is shutting down"}` rather
+than accepting a run nothing will ever execute. The window is small - the HTTP
+server stops before the drain begins - but it is not empty, and a request
+already in a handler when the drain starts must not be able to spawn a worker
+past it (see `RunManager::shutdown`).
+
 **Auth pre-flight.** When `auth.mode` is `oauth2`, the run route resolves the
 token **before** creating the run and warms the cache for the workers. An
 unauthorizable config is rejected up front with `409` (interactive sign-in
@@ -1483,6 +1490,7 @@ Get script engine API completions for UI autocomplete.
 | 409 | OAuth 2.0 interactive authorization required (`/run` pre-flight, `/oauth2/token`) |
 | 500 | Internal server error |
 | 502 | Upstream network error (OAuth 2.0 token endpoint, `/import/fetch` proxy) |
+| 503 | Engine is shutting down (`POST /runs` only - see below) |
 
 ## Notes
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -115,8 +115,17 @@ Manages the lifecycle of load test runs:
   counts still agree.
 - **The move to the retained map is the "worker is finished" signal**: it happens after the
   final metrics flush and status update, which is what `DELETE /runs/:id` waits on before
-  removing rows (see the API reference).
-- **Graceful shutdown**: Stops active runs on daemon shutdown
+  removing rows (see the API reference). It is *not* the "worker thread has exited" signal -
+  the move is the worker's last statement, and the thread is still unwinding after it.
+- **Graceful shutdown drains, then joins**: `RunManager::shutdown()` sets `should_stop` on
+  every active run, waits up to 5s (`RUN_SHUTDOWN_GRACE_MS`) for them to reach a terminal
+  status, and then **joins** every worker thread. The manager owns those thread handles -
+  a worker holds a `shared_ptr` to its own `RunContext`, so a context that owned its thread
+  could end up joining itself. The wait is bounded; the join is not, because abandoning a
+  worker leaves it writing through references to a `Database` that `main` is about to
+  destroy. A run started while the drain is in progress is refused with a `503`.
+- **Finished workers are reaped on the next `start_run`**: a thread cannot join itself, so
+  its handle outlives it until another thread collects it.
 
 ### Metrics Collector
 
@@ -364,6 +373,12 @@ prompt cancellation rather than waiting for in-flight requests to drain.
 - **Worker Threads**: One per active load test (executes load strategy)
 - **Metrics Thread**: One per active load test (aggregates and streams metrics)
 - **Event Loop Threads**: One per CPU core (handles curl_multi I/O)
+
+Shutdown unwinds that in a fixed order, because every one of these threads
+holds references to state `main` owns: HTTP server stopped → run workers
+signalled and joined (each joins its own metrics thread and stops its event
+loop first) → `curl_global_cleanup` → `Database` / `RunManager` destroyed at
+scope exit. Nothing is detached.
 
 ## Performance Characteristics
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -400,6 +400,7 @@ if(VAYU_BUILD_TESTS)
         tests/run_manager_test.cpp
         tests/run_route_test.cpp
         tests/run_stop_test.cpp
+        tests/run_shutdown_test.cpp
         tests/run_config_validation_test.cpp
         tests/script_compose_test.cpp
         tests/encoding_test.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -156,6 +156,12 @@ constexpr int DEFAULT_LIVE_REPLAY_WINDOW_MS = 300000;
 constexpr size_t DEFAULT_MAX_LIVE_TICKS = 50000;
 /// Size of the context pool for request handling
 constexpr size_t CONTEXT_POOL_SIZE = 64;
+/// How long `RunManager::shutdown` waits for signalled runs to reach a terminal
+/// status before it logs that they have not. The *wait* is bounded; the join
+/// that follows it is not, because abandoning a still-running worker is exactly
+/// the use-after-free the drain exists to prevent. Matches the 5s the daemon
+/// waited before the drain was ordered.
+constexpr int64_t RUN_SHUTDOWN_GRACE_MS = 5000;
 } // namespace server
 
 /**

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -8,6 +8,7 @@
  */
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -68,7 +69,11 @@ size_t max_ticks = constants::server::DEFAULT_MAX_LIVE_TICKS) {
 struct RunContext {
     std::string run_id;
     std::unique_ptr<vayu::http::EventLoop> event_loop;
-    std::thread worker_thread;
+    // The run's worker thread is NOT owned here: it holds a shared_ptr to this
+    // context, so a context whose last reference is dropped by its own worker
+    // (a retained run swept while the worker is still unwinding) would join
+    // itself and terminate. RunManager owns the handle instead - see
+    // `run_workers_` - and joins it from a thread that is never the worker.
     std::thread metrics_thread;
     std::atomic<bool> should_stop{ false };
     std::atomic<bool> is_running{ false };
@@ -248,6 +253,20 @@ class RunManager {
     // liveRetentionMs from the UI takes effect without a daemon restart.
     std::function<int64_t ()> sweeper_ttl_provider_;
 
+    // Joinable handles for the worker threads spawned by start_run, keyed by
+    // run id. A worker cannot join itself, so its handle outlives the thread
+    // until either a later start_run reaps it or shutdown joins it. Guarded by
+    // its own mutex: a worker takes `mutex_` (retain_run) as its last act, so
+    // reaping must never hold `mutex_` while it joins.
+    mutable std::mutex workers_mtx_;
+    std::map<std::string, std::thread> run_workers_;
+    bool shutting_down_{ false }; // workers_mtx_
+
+    // Move out the handles of workers whose runs are no longer active, for the
+    // caller to join once it has dropped every lock. Requires `workers_mtx_`;
+    // takes `mutex_` itself.
+    std::vector<std::thread> take_finished_workers ();
+
     public:
     ~RunManager ();
 
@@ -279,11 +298,39 @@ class RunManager {
     void start_sweeper (int64_t ttl_ms);
     void stop_sweeper ();
 
-    // Helper to start a run
-    void start_run (const std::string& run_id,
+    // Helper to start a run. Returns false - having registered nothing and
+    // spawned nothing - if shutdown() has already begun, so a request that
+    // races the drain is refused rather than starting a worker nobody will
+    // join. Any other failure still surfaces as an exception from the worker.
+    bool start_run (const std::string& run_id,
     const nlohmann::json& config,
     vayu::db::Database& db,
     bool verbose);
+
+    /**
+     * @brief Stop every active run and join its worker thread.
+     *
+     * The daemon's `Database`, `RunManager` and curl global state are torn down
+     * in `main`'s scope exit while a run worker may still be writing metrics
+     * through references to all three. This is the ordered drain that has to
+     * happen first: signal `should_stop` on every active run, wait for them to
+     * settle, then join.
+     *
+     * `grace` bounds the *wait*, not the join. A worker that has not settled by
+     * then is logged and still joined, because letting go of it is precisely
+     * the use-after-free being prevented - the bound exists to make a slow
+     * shutdown visible, not to permit an unsafe one.
+     *
+     * Idempotent, and safe to call with no runs active. After it returns,
+     * start_run refuses; the destructor calls it as a backstop.
+     */
+    void shutdown (std::chrono::milliseconds grace = std::chrono::milliseconds (
+                   constants::server::RUN_SHUTDOWN_GRACE_MS));
+
+    // Worker thread handles still held (running, or finished but not yet
+    // reaped). Test-only hook - a drain that returns with this non-zero has
+    // left threads running over freed state.
+    [[nodiscard]] size_t tracked_worker_count () const;
 };
 
 // Worker functions

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -219,9 +219,10 @@ RunContext::~RunContext () {
     // Wake the closed-loop controller so it observes should_stop without
     // waiting for its 50ms safety-net timeout before the join below.
     notify_refill ();
-    if (worker_thread.joinable ()) {
-        worker_thread.join ();
-    }
+    // The worker joins this itself before it returns; the join here only covers
+    // a context destroyed before its worker ever ran. The *worker* thread is
+    // owned by RunManager (run_workers_), never by the context - see the
+    // declaration for why.
     if (metrics_thread.joinable ()) {
         metrics_thread.join ();
     }
@@ -334,7 +335,84 @@ void RunManager::stop_sweeper () {
 }
 
 RunManager::~RunManager () {
+    // A destructor must not throw; shutdown() only logs and joins, but the
+    // logger and the joins are the parts a broken invariant would surface in.
+    try {
+        shutdown ();
+    } catch (...) {
+    }
     stop_sweeper ();
+}
+
+size_t RunManager::tracked_worker_count () const {
+    std::lock_guard<std::mutex> lock (workers_mtx_);
+    return run_workers_.size ();
+}
+
+std::vector<std::thread> RunManager::take_finished_workers () {
+    // `mutex_` answers "is this run still active"; `workers_mtx_` owns the
+    // handle. Whenever both are held the order is workers_mtx_ -> mutex_,
+    // which is what lets start_run hold the former across register_run.
+    std::vector<std::thread> finished;
+    std::lock_guard<std::mutex> runs_lock (mutex_);
+    for (auto it = run_workers_.begin (); it != run_workers_.end ();) {
+        if (active_runs_.find (it->first) == active_runs_.end ()) {
+            finished.push_back (std::move (it->second));
+            it = run_workers_.erase (it);
+        } else {
+            ++it;
+        }
+    }
+    return finished;
+}
+
+void RunManager::shutdown (std::chrono::milliseconds grace) {
+    {
+        std::lock_guard<std::mutex> lock (workers_mtx_);
+        shutting_down_ = true;
+    }
+
+    // Signal first, then wait: every worker gets its stop request before any
+    // of them is waited on, so the grace period is shared rather than serial.
+    auto active = get_all_active_runs ();
+    for (const auto& context : active) {
+        context->should_stop = true;
+        context->notify_refill ();
+    }
+
+    if (!active.empty ()) {
+        vayu::utils::log_info (
+        "Stopping " + std::to_string (active.size ()) + " active load test(s)...");
+        auto deadline = std::chrono::steady_clock::now () + grace;
+        while (active_count () > 0 && std::chrono::steady_clock::now () < deadline) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (10));
+        }
+        if (size_t remaining = active_count (); remaining > 0) {
+            vayu::utils::log_warning (std::to_string (remaining) +
+            " load test(s) had not settled after " + std::to_string (grace.count ()) +
+            "ms; waiting for them anyway - abandoning a worker would leave it "
+            "writing to a destroyed database");
+        }
+    }
+
+    std::vector<std::thread> workers;
+    {
+        std::lock_guard<std::mutex> lock (workers_mtx_);
+        for (auto& entry : run_workers_) {
+            workers.push_back (std::move (entry.second));
+        }
+        run_workers_.clear ();
+    }
+    // Joined outside every lock: a worker's last act is retain_run, which takes
+    // `mutex_`, so joining while holding it would deadlock the drain.
+    for (auto& thread : workers) {
+        if (thread.joinable ())
+            thread.join ();
+    }
+
+    if (!active.empty ()) {
+        vayu::utils::log_info ("All load tests stopped");
+    }
 }
 
 std::vector<std::shared_ptr<RunContext>> RunManager::get_all_active_runs () const {
@@ -346,35 +424,65 @@ std::vector<std::shared_ptr<RunContext>> RunManager::get_all_active_runs () cons
     return runs;
 }
 
-void RunManager::start_run (const std::string& run_id,
+bool RunManager::start_run (const std::string& run_id,
 const nlohmann::json& config,
 vayu::db::Database& db,
 bool verbose) {
-    auto context = std::make_shared<RunContext> (run_id, config,
-    static_cast<size_t> (db.get_config_int ("maxStoredErrors",
-    static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS))));
-    register_run (run_id, context);
+    // `workers_mtx_` is held from the shutting_down_ check through the moment
+    // the new worker's handle is recorded. Anything narrower loses the run:
+    // shutdown() could set the flag, snapshot run_workers_ and join it between
+    // the check and the insert, leaving this worker running over state the
+    // drain has already declared safe to destroy.
+    std::vector<std::thread> finished;
+    {
+        std::lock_guard<std::mutex> workers_lock (workers_mtx_);
+        if (shutting_down_) {
+            vayu::utils::log_warning (
+            "Refusing to start run " + run_id + ": engine is shutting down");
+            return false;
+        }
 
-    // Sweep stale retained runs on each new registration so that headless /
-    // API-only usage (which never hits /metrics/live) doesn't accumulate them.
-    int retention_ms = db.get_config_int ("liveRetentionMs", 60000);
-    sweep_retained (retention_ms);
+        // Reap the handles of runs that have already finished, so a long-lived
+        // daemon does not accumulate one per run. Done here rather than by the
+        // workers themselves because a thread cannot join itself.
+        finished = take_finished_workers ();
 
-    // IMPORTANT: Set is_running BEFORE spawning threads to avoid race condition
-    // where metrics_thread exits immediately because is_running is still false
-    context->is_running    = true;
-    context->start_time_ms = now_ms ();
+        auto context = std::make_shared<RunContext> (run_id, config,
+        static_cast<size_t> (db.get_config_int ("maxStoredErrors",
+        static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS))));
+        register_run (run_id, context);
 
-    // Spawn metrics collection thread first (will be joined by worker thread)
-    context->metrics_thread =
-    std::thread ([context, &db] () { collect_metrics (context, &db); });
-    // Note: metrics_thread is NOT detached - it will be joined by the worker thread
+        // Sweep stale retained runs on each new registration so that headless /
+        // API-only usage (which never hits /metrics/live) doesn't accumulate them.
+        int retention_ms = db.get_config_int ("liveRetentionMs", 60000);
+        sweep_retained (retention_ms);
 
-    // Spawn background thread for execution
-    context->worker_thread = std::thread ([context, &db, verbose, this] () {
-        execute_load_test (context, &db, verbose, *this);
-    });
-    context->worker_thread.detach ();
+        // IMPORTANT: Set is_running BEFORE spawning threads to avoid race condition
+        // where metrics_thread exits immediately because is_running is still false
+        context->is_running    = true;
+        context->start_time_ms = now_ms ();
+
+        // Spawn metrics collection thread first (will be joined by worker thread)
+        context->metrics_thread =
+        std::thread ([context, &db] () { collect_metrics (context, &db); });
+        // Note: metrics_thread is NOT detached - it will be joined by the worker thread
+
+        // Spawn background thread for execution. The handle is kept - not
+        // detached - so shutdown can join it before `db` and this manager go
+        // out of scope from under the references the lambda captures.
+        run_workers_[run_id] = std::thread ([context, &db, verbose, this] () {
+            execute_load_test (context, &db, verbose, *this);
+        });
+    }
+
+    // Outside the lock: these threads are past retain_run and only unwinding,
+    // so the join is a formality - but it is still a join, and the discipline
+    // is that no lock is held across one.
+    for (auto& thread : finished) {
+        if (thread.joinable ())
+            thread.join ();
+    }
+    return true;
 }
 
 void execute_load_test (std::shared_ptr<RunContext> context,

--- a/engine/src/daemon.cpp
+++ b/engine/src/daemon.cpp
@@ -204,35 +204,16 @@ int main (int argc, char* argv[]) {
     vayu::utils::log_debug (
     "Server stopped in " + std::to_string (server_stop_elapsed) + "ms");
 
-    // Signal all active runs to stop
-    size_t active = run_manager.active_count ();
-    if (active > 0) {
-        vayu::utils::log_info ("Stopping " + std::to_string (active) + " active load tests...");
-
-        auto active_runs = run_manager.get_all_active_runs ();
-        for (const auto& context : active_runs) {
-            context->should_stop = true;
-        }
-
-        // Wait for active runs to complete (max 5 seconds)
-        auto shutdown_start = std::chrono::steady_clock::now ();
-        while (run_manager.active_count () > 0) {
-            auto elapsed = std::chrono::duration_cast<std::chrono::seconds> (
-            std::chrono::steady_clock::now () - shutdown_start)
-                           .count ();
-
-            if (elapsed >= 5) {
-                vayu::utils::log_warning (
-                "Warning: " + std::to_string (run_manager.active_count ()) +
-                " tests still running after 5s, forcing shutdown");
-                break;
-            }
-
-            std::this_thread::sleep_for (std::chrono::milliseconds (100));
-        }
-
-        vayu::utils::log_info ("All load tests stopped");
-    }
+    // Stop every active run and JOIN its worker before anything it holds a
+    // reference to is torn down. The loop this replaced stopped waiting once
+    // `active_count()` hit zero - which a worker reaches at retain_run, its
+    // last statement, with the thread still unwinding - and gave up entirely
+    // after 5s, leaving detached workers writing to `db` and calling into curl
+    // while both were destroyed underneath them.
+    //
+    // The order below is load-bearing: workers joined, then curl's global
+    // teardown, then `server` / `run_manager` / `db` at scope exit.
+    run_manager.shutdown ();
 
     vayu::http::global_cleanup ();
 

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -714,8 +714,13 @@ void register_execution_routes (RouteContext& ctx) {
             return;
         }
 
-        // Start run via RunManager
-        ctx.run_manager.start_run (run_id, json, ctx.db, ctx.verbose);
+        // Start run via RunManager. A refusal means the daemon is draining its
+        // workers for shutdown; the row exists but nothing will ever run it, so
+        // say so rather than returning a 202 for a run that never starts.
+        if (!ctx.run_manager.start_run (run_id, json, ctx.db, ctx.verbose)) {
+            send_error (res, 503, "Engine is shutting down");
+            return;
+        }
 
         nlohmann::json response;
         response["runId"]   = run_id;

--- a/engine/tests/run_shutdown_test.cpp
+++ b/engine/tests/run_shutdown_test.cpp
@@ -1,0 +1,229 @@
+/**
+ * @file run_shutdown_test.cpp
+ * @brief Shutting down mid-run stops and JOINS the run workers (#125).
+ *
+ * The worker thread used to be detached, and the daemon's drain stopped waiting
+ * as soon as `active_count()` hit zero - which a worker reaches at `retain_run`,
+ * its final statement, with the thread still unwinding - and gave up entirely
+ * after 5s. Either way `main` went on to run curl's global teardown and destroy
+ * the `Database` and `RunManager` the still-running worker holds references to.
+ *
+ * The assertions here are about *ownership*, not timing: a handle is tracked
+ * while the worker runs, and shutdown returns only once every one of them has
+ * been joined. Timing bounds are upper bounds against an upstream that holds
+ * the connection open for 30s, so a regression does not shave milliseconds off
+ * - it reintroduces a wait of tens of seconds, or an abandoned thread.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+#include "mock_server.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
+
+namespace {
+
+using vayu::tests::SlowMockServer;
+using Clock = std::chrono::steady_clock;
+
+int64_t ms_since (Clock::time_point start) {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (Clock::now () - start)
+    .count ();
+}
+
+class RunShutdownTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_run_shutdown.db";
+
+    void SetUp () override {
+        vayu::http::global_init ();
+        server = std::make_unique<SlowMockServer> ();
+        cleanup ();
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+    void TearDown () override {
+        db.reset ();
+        cleanup ();
+        server.reset ();
+        vayu::http::global_cleanup ();
+    }
+
+    static void cleanup () {
+        for (const char* suffix : { "", "-wal", "-shm" }) {
+            std::filesystem::remove (std::string (DB_PATH) + suffix);
+        }
+    }
+
+    // A row for the run, so the worker's status writes have something to land
+    // on. Stamped now rather than at the epoch: a terminal run triggers
+    // prune_runs_configured, and an age-based retention window would sweep a
+    // 1970 row away before the assertions could read its status.
+    void create_run_row (const std::string& run_id) {
+        vayu::db::Run row;
+        row.id              = run_id;
+        row.type            = vayu::RunType::Load;
+        row.status          = vayu::RunStatus::Pending;
+        row.config_snapshot = "{}";
+        row.start_time = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                         .count ();
+        row.end_time = 0;
+        db->create_run (row);
+    }
+
+    // A run long enough that it cannot end on its own inside any of these
+    // tests, against an upstream that never answers.
+    nlohmann::json hang_config () const {
+        return { { "mode", "constant_rps" }, { "duration", "30s" },
+            { "targetRps", 50.0 }, { "url", server->hang_url () },
+            { "method", "GET" }, { "timeout", 120000 }, { "workers", 1 } };
+    }
+
+    // Wait until the run has actually put requests on the wire, so what follows
+    // interrupts a *working* worker rather than one still setting up.
+    static void wait_until_submitting (const std::shared_ptr<vayu::core::RunContext>& context) {
+        auto start = Clock::now ();
+        while (context->requests_sent.load () == 0 && ms_since (start) < 5000) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (10));
+        }
+        ASSERT_GT (context->requests_sent.load (), 0u)
+        << "the run never submitted anything";
+    }
+
+    std::unique_ptr<SlowMockServer> server;
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+// The acceptance criterion: shutdown stops the run AND joins its worker, so
+// nothing is still executing over `db` when it returns.
+TEST_F (RunShutdownTest, ShutdownStopsAndJoinsAWorkerMidRun) {
+    const std::string run_id = "run-shutdown-joins";
+    create_run_row (run_id);
+
+    vayu::core::RunManager manager;
+    ASSERT_TRUE (manager.start_run (run_id, hang_config (), *db, false));
+
+    auto context = manager.get_run (run_id);
+    ASSERT_NE (context, nullptr);
+    ASSERT_NO_FATAL_FAILURE (wait_until_submitting (context));
+
+    // The handle exists at all only because the worker is no longer detached.
+    EXPECT_EQ (manager.tracked_worker_count (), 1u)
+    << "the run's worker thread is not owned by anyone that could join it";
+
+    auto start = Clock::now ();
+    manager.shutdown (std::chrono::milliseconds (5000));
+    auto elapsed = ms_since (start);
+
+    EXPECT_LT (elapsed, 15000) << "the drain took " << elapsed << "ms against a hung upstream";
+    EXPECT_EQ (manager.active_count (), 0u);
+    EXPECT_EQ (manager.tracked_worker_count (), 0u)
+    << "shutdown returned with worker threads still unjoined";
+
+    // A joined worker has finished its writes; the status cannot still be
+    // in-flight once shutdown has returned.
+    auto stored = db->get_run (run_id);
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_NE (stored->status, vayu::RunStatus::Running);
+    EXPECT_NE (stored->status, vayu::RunStatus::Pending);
+    EXPECT_FALSE (context->is_running.load ());
+}
+
+// The destructor is the backstop for a caller that forgets to drain - and the
+// direct mutation check for the original defect. With the worker detached and
+// nothing joining it, `~RunManager` returns while the run is still going and
+// the status below is still `running`.
+TEST_F (RunShutdownTest, DestructorDrainsAnActiveRun) {
+    const std::string run_id = "run-shutdown-dtor";
+    create_run_row (run_id);
+
+    auto start = Clock::now ();
+    {
+        vayu::core::RunManager manager;
+        ASSERT_TRUE (manager.start_run (run_id, hang_config (), *db, false));
+        auto context = manager.get_run (run_id);
+        ASSERT_NE (context, nullptr);
+        ASSERT_NO_FATAL_FAILURE (wait_until_submitting (context));
+        EXPECT_EQ (manager.tracked_worker_count (), 1u)
+        << "nothing owns the worker, so the destructor has nothing to join";
+    }
+    auto elapsed = ms_since (start);
+    EXPECT_LT (elapsed, 20000) << "the destructor took " << elapsed << "ms to drain";
+
+    auto stored = db->get_run (run_id);
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_NE (stored->status, vayu::RunStatus::Running)
+    << "~RunManager returned while the run was still executing - its worker "
+       "outlives the manager and the database";
+}
+
+// Once the drain has begun, a request that races it is refused rather than
+// starting a worker that nothing will join.
+TEST_F (RunShutdownTest, StartRunAfterShutdownIsRefused) {
+    vayu::core::RunManager manager;
+    manager.shutdown ();
+
+    const std::string run_id = "run-shutdown-refused";
+    create_run_row (run_id);
+
+    EXPECT_FALSE (manager.start_run (run_id, hang_config (), *db, false));
+    EXPECT_EQ (manager.active_count (), 0u);
+    EXPECT_EQ (manager.tracked_worker_count (), 0u);
+    EXPECT_EQ (manager.get_run (run_id), nullptr);
+}
+
+// Draining an idle manager must not wait out the grace period, and calling it
+// twice must not double-join.
+TEST_F (RunShutdownTest, ShutdownWithNoActiveRunsIsPromptAndIdempotent) {
+    vayu::core::RunManager manager;
+
+    auto start = Clock::now ();
+    manager.shutdown (std::chrono::milliseconds (5000));
+    manager.shutdown (std::chrono::milliseconds (5000));
+    auto elapsed = ms_since (start);
+
+    EXPECT_LT (elapsed, 1000) << "an idle drain waited " << elapsed << "ms for nothing";
+    EXPECT_EQ (manager.tracked_worker_count (), 0u);
+}
+
+// A worker cannot join itself, so its handle outlives it. Without a reap, a
+// long-lived daemon accumulates one per run for the life of the process.
+TEST_F (RunShutdownTest, FinishedWorkersAreReapedByTheNextStartRun) {
+    vayu::core::RunManager manager;
+
+    const std::string first = "run-shutdown-reap-1";
+    create_run_row (first);
+    // Bounded by iterations rather than duration, against the mock's instant
+    // endpoint, so it finishes on its own within the wait below.
+    nlohmann::json quick = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 }, { "url", server->fast_url () },
+        { "method", "GET" }, { "timeout", 5000 }, { "workers", 1 } };
+    ASSERT_TRUE (manager.start_run (first, quick, *db, false));
+
+    auto start = Clock::now ();
+    while (manager.active_count () > 0 && ms_since (start) < 15000) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (10));
+    }
+    ASSERT_EQ (manager.active_count (), 0u) << "the bounded run never finished";
+
+    const std::string second = "run-shutdown-reap-2";
+    create_run_row (second);
+    ASSERT_TRUE (manager.start_run (second, hang_config (), *db, false));
+
+    EXPECT_EQ (manager.tracked_worker_count (), 1u)
+    << "the finished run's thread handle was never reaped";
+
+    manager.shutdown ();
+}
+
+} // namespace


### PR DESCRIPTION
## Description

**Plan.** The root cause is ownership: `start_run` detached the run worker, so nothing could join it, and the daemon's drain used `active_count() == 0` as its "worker is done" signal. That signal is wrong twice over - a worker reaches it at `retain_run`, its *final statement*, with the thread still unwinding, and the loop gave up outright after 5s - after which `main` ran `curl_global_cleanup` and destroyed the `Database` and `RunManager` the worker holds by reference. The fix makes `RunManager` own the worker handles and adds an ordered `shutdown()`: signal `should_stop` on every active run, wait up to `RUN_SHUTDOWN_GRACE_MS` for them to settle, then **join** every worker, before curl teardown and before `db` / `run_manager` leave scope.

The alternative I rejected was keeping the handle in `RunContext::worker_thread` (the field that already existed) and joining it there. It cannot work: the worker captures a `shared_ptr` to its own context, so a retained run swept by the TTL sweeper while its worker is still unwinding drops the last reference *on that worker*, and `~RunContext` would join the calling thread to itself - `std::terminate`. The manager joins from a thread that is never the worker. The now-dead `worker_thread` field is deleted rather than left as a field nothing writes.

I verified the anchors against current master first, as the issue asks: PR #138's stop/DELETE rework moved the surrounding lifecycle code but left the defect exactly as described - `run_manager.cpp` still spawned and detached, and `~RunManager` still only called `stop_sweeper()`.

**Two consequences worth naming, both deliberate:**

- **The grace period bounds the wait, not the join.** A worker that has not settled in 5s is logged and still joined. Letting go of it is precisely the use-after-free being fixed, so the bound exists to make a slow shutdown *visible*, not permissible.
- **`POST /runs` gains a `503`.** The HTTP server stops before the drain, but a request already inside the handler could otherwise spawn a worker past it. `start_run` now returns `false` once the drain has begun and the route answers `503 {"error": "Engine is shutting down"}` rather than a `202` for a run nothing will execute. `workers_mtx_` is held from that check through the handle insert, because anything narrower lets `shutdown()` snapshot and join in between.

A thread also cannot reap itself, so a finished worker's handle outlives it; the next `start_run` collects them, which keeps a long-lived daemon from accumulating one per run.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

New `engine/tests/run_shutdown_test.cpp` (5 tests), driving real runs through `RunManager` against the in-process mock's `/hang` endpoint:

- `ShutdownStopsAndJoinsAWorkerMidRun` - the handle is tracked while the worker runs, `shutdown()` returns with `active_count()` and `tracked_worker_count()` both zero, and the run's status is already terminal.
- `DestructorDrainsAnActiveRun` - the backstop, asserted from outside the manager's scope.
- `StartRunAfterShutdownIsRefused`, `ShutdownWithNoActiveRunsIsPromptAndIdempotent`, `FinishedWorkersAreReapedByTheNextStartRun`.

**Mutation-checked, both directions:**

- Restore `detach()` on the spawned worker → `ShutdownStopsAndJoinsAWorkerMidRun`, `DestructorDrainsAnActiveRun` and `FinishedWorkersAreReapedByTheNextStartRun` fail.
- Remove the `shutdown()` call from `~RunManager` → `DestructorDrainsAnActiveRun` aborts (a joinable `std::thread` destroyed unjoined is a `std::terminate`, which is the loud version of the same defect).

Full verification on this branch:

```
python build.py -e -t                                      # clean, no new warnings
cd engine && ctest --preset linux-dev --output-on-failure   # 510/510 passed (505 before, +5 new)
cd app && pnpm test                                         # 221 files, 1828 tests passed
cd app && pnpm type-check                                   # clean
bash scripts/pre-commit                                     # clang-tidy clean on all 6 touched files
mkdocs build --strict -f .github/mkdocs.yml                 # clean
```

No pre-existing failures observed. `run_manager.cpp`, `run_manager.hpp` and `execution.cpp` were not clang-format-clean at the base commit, so per CLAUDE.md only the added lines were formatted (`git clang-format`).

**App changes: none, verified.** The issue asks for this explicitly. `app/electron/sidecar.ts` is the only `POST /shutdown` caller; the route sets its content and *then* signals the daemon from a separate thread, so the client still gets its `200` before the drain begins - unchanged by this PR. Worth knowing for a future sitting: the app SIGKILLs the engine `ENGINE_GRACEFUL_EXIT_TIMEOUT_MS` (5s) after that response, so a drain that outruns the grace period can still be killed - safely now, since the process dies rather than the worker outliving its database.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/architecture.md` (Run Manager - the drain-then-join ordering and why the manager owns the handles; Thread Model - the full shutdown order) and `docs/engine/api-reference.md` (the new `503` on `POST /runs`, plus the status-code table).

## Related Issues
Closes #125

---
_Generated by [Claude Code](https://claude.ai/code/session_018d4HAMSBYD1CTP9udnNuQe)_