### PR TITLE
docs(labels): record the release label's new navy colour

### DIFF
--- a/.github/LABELING.md
+++ b/.github/LABELING.md
@@ -26,7 +26,7 @@ Special                                        priority:critical  🔴  Blocks o
   help wanted        🟪  Needs expertise
   severity:blocking  🔴  Breaking change
   dependencies       ⚪  Dependency updates
-  release            🟡  Version-bump PR (auto)
+  release            🔵  Version-bump PR (auto)
 ```
 
 ## Label Categories
@@ -120,7 +120,7 @@ These labels indicate **urgency**. Apply manually based on impact and timeline.
 | `build` | Gray (#95A5A6) | Build-related | Used manually; path-based label is `component:build` |
 | `ci` | Gray (#95A5A6) | CI/CD related | Used manually; path-based label is `component:ci` |
 | `correctness` | Red (#E74C3C) | Correctness issue | Logic error or incorrect behavior |
-| `release` | Yellow (#F1C40F) | Version-bump / release PR | Auto-applied whenever `VERSION` changes |
+| `release` | Navy (#062477) | Version-bump / release PR | Auto-applied whenever `VERSION` changes |
 
 ## Labeling Guidelines
 


### PR DESCRIPTION
## Description
The `release` label was recoloured in the repository from yellow (`#F1C40F`) to navy (`#062477`), but `.github/LABELING.md` still documented the old value in two places. This brings the doc back in step with the live label.

- `.github/LABELING.md:29` - quick-reference swatch, 🟡 → 🔵
- `.github/LABELING.md:123` - Special Labels table, `Yellow (#F1C40F)` → `Navy (#062477)`

Two notes on scope:

- The doc's Description column stays `Version-bump / release PR` rather than syncing to GitHub's `A new release`. The column reads as prose throughout the table, and the longer wording says more about when the label applies.
- The 🔵 swatch is shared with `component:app` (`#3498DB`); there is no dark-blue circle emoji, so the hex in the table is what tells them apart.

Nothing else needed touching. The `release` rule in `.github/labeler.yml` keys on `VERSION` and is about paths, not colour, so it is unchanged. Every other label I spot-checked against the live repo (`component:build` `#7F8C8D`, `dependencies` `#95A5A6`) already matches the doc, and no script, workflow, or other doc hardcodes a label colour - `grep` for `F1C40F` repo-wide now returns nothing.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
Documentation only - no code paths touched, so no tests were added or run. Verified by fetching the live label via the GitHub API (`#062477`, description `A new release`) and confirming the repo-wide `grep` for the old hex comes back empty.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
None - this is a follow-up to a label colour change made directly in the repository settings.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uiMtwKhjNMu7QD1AYmyQq)_