### PR TITLE
docs: add consent-gated Google Analytics to the docs site

### DIFF
--- a/.github/hooks/analytics.py
+++ b/.github/hooks/analytics.py
@@ -1,0 +1,61 @@
+"""Drop analytics and the cookie banner from builds that have no measurement ID.
+
+`extra.analytics.property` in mkdocs.yml is `!ENV GOOGLE_ANALYTICS_KEY`, which
+resolves to `None` on a fork, a pull-request preview or a local `mkdocs serve`.
+That is *not* enough on its own to switch analytics off: Material's
+`partials/integrations/analytics/google.html` has no guard on an empty property,
+so it still emits the `__md_analytics()` snippet and would still request
+`gtag/js?id=` with an empty id once a visitor accepted cookies. Nothing is
+collected - Google has no property to attribute an empty id to - but the page
+carries dead tracking code and, worse, shows a cookie-consent banner asking
+permission for a tracker that does not exist.
+
+So the switch lives here instead: no key, no `extra.analytics` and no
+`extra.consent`, and the two are removed together on purpose. A consent banner
+whose only cookie is one the build cannot set is a dialog that lies to the
+visitor, and it would be the *only* thing most contributors ever saw of this
+feature, on every local preview.
+
+The same switch owns the footer's "Cookie settings" link, for the same reason: it
+is the only route back into the dialog once the banner has been dismissed, and
+`#__consent` resolves to nothing on a build that has no dialog.
+
+Wired up via `hooks:` in mkdocs.yml, after brand_assets. Deleting this file
+leaves a working site - just one that ships the inert snippet and the banner
+everywhere, and no way to reopen the banner.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("mkdocs.hooks.analytics")
+
+# Material re-opens the consent dialog for this anchor specifically; it is not a
+# link to a page. Appended to `copyright` in mkdocs.yml.
+CONSENT_LINK = ' &middot; <a href="#__consent">Cookie settings</a>'
+
+
+def on_config(config):
+    analytics = config.extra.get("analytics") or {}
+
+    # `.strip()` so a repository variable that exists but was blanked out counts
+    # as "off" - emptying the variable is the documented way to disable
+    # analytics without a commit, and GitHub hands an empty variable through as
+    # an empty string rather than leaving it unset.
+    if (analytics.get("property") or "").strip():
+        if config.copyright and CONSENT_LINK not in config.copyright:
+            config.copyright += CONSENT_LINK
+        return config
+
+    config.extra.pop("analytics", None)
+    config.extra.pop("consent", None)
+
+    # INFO, not a warning: this is the correct and expected state for every
+    # build that is not the deploy from master, and `mkdocs build --strict`
+    # turns warnings into failures.
+    log.info(
+        "GOOGLE_ANALYTICS_KEY is unset - building without analytics or the "
+        "cookie consent banner."
+    )
+    return config

--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -14,6 +14,10 @@ edit_uri: edit/master/docs/
 docs_dir: ../docs
 site_dir: ../site
 
+# A "Cookie settings" link is appended to this by .github/hooks/analytics.py, but
+# only on a build that actually has analytics - see the note there. It is not
+# written in here because a `#__consent` anchor with no consent dialog behind it
+# is a dead link, which is what every local preview would show.
 copyright: Engine AGPL-3.0 &middot; App Apache-2.0
 
 theme:
@@ -154,6 +158,9 @@ plugins:
 
 hooks:
   - hooks/brand_assets.py
+  # Turns the analytics + consent blocks below off when GOOGLE_ANALYTICS_KEY is
+  # unset, which an empty `!ENV` value does not do on its own.
+  - hooks/analytics.py
 
 # Broken cross-references are a build failure in CI (`mkdocs build --strict`),
 # which is the point: these docs cross-link heavily by relative `.md` path.
@@ -168,3 +175,50 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/athrvk/vayu
       name: Vayu on GitHub
+
+  # Google Analytics 4 for this documentation site only. The measurement ID is
+  # deliberately *not* checked in: `.github/workflows/docs.yml` passes it from
+  # the `GOOGLE_ANALYTICS_KEY` Actions repository variable (Settings -> Secrets
+  # and variables -> Actions -> Variables), so a fork, a pull-request preview or
+  # a local `mkdocs serve` builds with the variable unset and gets no analytics
+  # and no cookie banner. `!ENV` with no default yields None when unset, which is
+  # a supported state rather than a build failure - but note that Material still
+  # emits its (inert) gtag snippet for an empty property, so the actual removal
+  # is done by hooks/analytics.py. Empty the variable to switch analytics off
+  # site-wide without a commit.
+  #
+  # An ID is not a secret (it ships in the page source of every built page), but
+  # a repository variable keeps forks from polluting the property, which is the
+  # thing that actually matters.
+  analytics:
+    provider: google
+    property: !ENV GOOGLE_ANALYTICS_KEY
+
+  # Nothing is loaded until the visitor acts: Material defers the gtag snippet
+  # behind `__md_analytics()` and only calls it once `analytics` is in the stored
+  # consent. Removing this block would make GA load on first paint for everyone,
+  # so the two settings belong together.
+  #
+  # The `analytics` key is not arbitrary - Material matches that exact name to
+  # decide whether the analytics provider above may run. Renaming it silently
+  # leaves GA permanently off.
+  consent:
+    title: Cookies on this site
+    # Says which site, because the product's own claim is the opposite and both
+    # are true: the Vayu app ships no telemetry, this docs website measures page
+    # views. Conflating them would make one of the two statements a lie.
+    description: >-
+      This documentation site uses Google Analytics to count page views, so we
+      can see which docs people actually read. The Vayu app itself sends
+      nothing - it runs fully offline, with no account and no telemetry.
+    cookies:
+      # Checked by default so the primary "Accept" button means what it looks
+      # like it means. This is not pre-consent: nothing is stored, and no script
+      # runs, until one of the buttons below is pressed.
+      analytics:
+        name: Google Analytics
+        checked: true
+    actions:
+      - accept
+      - reject
+      - manage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,9 +50,9 @@ env:
   # It is an unconditional advisory from the theme, not a finding about this
   # config: the build still succeeds, and it printed 14 red lines above every
   # run. Our exposure is small anyway - the only plugin here is MkDocs' built-in
-  # `search` and there are no theme overrides - and the version is pinned in
-  # requirements-docs.txt, so nothing upstream can change this site without a
-  # commit. Unset this to see the banner again.
+  # `search`, and the overrides and hooks are a handful of files under .github/ -
+  # and the version is pinned in requirements-docs.txt, so nothing upstream can
+  # change this site without a commit. Unset this to see the banner again.
   NO_MKDOCS_2_WARNING: '1'
 
 concurrency:
@@ -91,7 +91,18 @@ jobs:
       # `-f` is required: the config lives in .github/, not the repo root, so
       # bare `mkdocs build` cannot find it. site_dir is ../site, so the output
       # still lands at the repo root and the upload path below is unchanged.
+      #
+      # GOOGLE_ANALYTICS_KEY is read by `extra.analytics.property` in
+      # .github/mkdocs.yml via `!ENV`. It comes from an Actions *variable*, not a
+      # secret: a GA4 measurement ID is public by construction (it ships in the
+      # page source of every page it is on), and a variable stays readable and
+      # editable in the repository settings. Unset is a valid state - the site
+      # then builds with no analytics and no cookie banner (see
+      # .github/hooks/analytics.py) - which is what a fork of this repo gets,
+      # since forks inherit neither variables nor secrets.
       - name: Build site
+        env:
+          GOOGLE_ANALYTICS_KEY: ${{ vars.GOOGLE_ANALYTICS_KEY }}
         run: mkdocs build --strict -f .github/mkdocs.yml
 
       - name: Upload Pages artifact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,19 @@ heading anchor, so:
 - **Links out of `docs/`** (`SECURITY.md`, `LICENSE`, `CONTRIBUTING.md`) must be
   absolute `https://github.com/athrvk/vayu/blob/master/...` URLs - those files
   are outside the published tree.
+- **Analytics is on the published site only, and only when it has an ID.** The
+  GA4 measurement ID comes from the `GOOGLE_ANALYTICS_KEY` Actions *repository
+  variable* (Settings -> Secrets and variables -> Actions -> Variables), read by
+  `extra.analytics.property` via `!ENV`. With it unset - every fork, every
+  pull-request preview, every local `mkdocs serve` - `.github/hooks/analytics.py`
+  strips `extra.analytics`, `extra.consent` and the footer's "Cookie settings"
+  link, so those builds ship no tracker and no banner. `!ENV` alone does **not**
+  do this: Material emits its gtag snippet even for an empty property, which is
+  the whole reason that hook exists. On the published site GA is consent-gated -
+  the snippet is defined but only runs once the visitor accepts. **This is the
+  docs website, not the app**; `no telemetry` in `docs/index.md` and `README.md`
+  is a claim about the app and stays true, so keep the two apart when editing
+  either.
 - **Jekyll is not an option here** and the workflow says why: Pages' default
   Jekyll build runs Liquid over page content, and these docs contain 40+
   `{{variable}}` examples (rendered as empty strings) plus `{% ... %}` (an


### PR DESCRIPTION
## Description

The published docs site (athrvk.github.io/vayu) had no measurement at all, so there was no way to tell which pages people actually read. This adds GA4, consent-gated, to the published site only.

**The measurement ID is not checked in.** `extra.analytics.property` reads it from a `GOOGLE_ANALYTICS_KEY` Actions **repository variable** via `!ENV`, which `docs.yml` passes to the build step. A variable rather than a secret: the ID ships in the page source of every page anyway, and a variable stays readable and editable in the repository settings. Forks inherit neither variables nor secrets, so a fork cannot report into the property.

**`!ENV` alone does not switch analytics off.** Material 9.7.7's `partials/integrations/analytics/google.html` has no guard on an empty property - it still emits the `__md_analytics()` snippet, and would still request `gtag/js?id=` with an empty id once a visitor accepted cookies. Nothing would be collected, but every fork, every PR preview and every local `mkdocs serve` would carry dead tracking code and, worse, a cookie banner asking permission for a tracker that does not exist. So the actual switch lives in a new hook, `.github/hooks/analytics.py`, which drops `extra.analytics`, `extra.consent` and the footer's "Cookie settings" link **together** when the key is unset or blank.

On the published site GA is consent-gated - the emitted call site is `consent&&consent.analytics&&__md_analytics()`, so no request goes out before the visitor accepts - and the footer link reopens the dialog for anyone who changes their mind.

The banner copy names the site explicitly, because the product's own claim is the opposite and both are true: the Vayu app ships no telemetry, this website counts page views. `no telemetry` in `docs/index.md` and `README.md` is a claim about the app and stays accurate.

**Files**
- `.github/mkdocs.yml` - `extra.analytics` (GA4) + `extra.consent` (Accept / Reject / Manage); `hooks:` gains the new hook.
- `.github/workflows/docs.yml` - passes `vars.GOOGLE_ANALYTICS_KEY` into the build step; also corrects a stale comment that claimed the site has no theme overrides.
- `.github/hooks/analytics.py` - new; the on/off switch described above.
- `CLAUDE.md` - documents the variable, the hook's reason for existing, and the app-vs-website telemetry distinction.

**Requires one repository setting before it does anything:** Settings → Secrets and variables → Actions → **Variables** → `GOOGLE_ANALYTICS_KEY` = the GA4 measurement ID. Until that exists, the site builds exactly as it does today.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`mkdocs build --strict -f .github/mkdocs.yml` in all three states of the variable:

| State | gtag snippet | consent dialog | footer link |
|---|---|---|---|
| unset | 0 pages | 0 pages | 0 pages |
| set but blank | 0 pages | 0 pages | 0 pages |
| `G-TEST12345` | 30 pages | 30 pages | 30 pages |

Strict build passes in every state. With the key set, the built HTML carries the real measurement ID in the gtag URL and the invocation is gated on `consent.analytics` - confirmed by reading the emitted markup, not just the page count. `.github/workflows/docs.yml` validated as YAML and the hook byte-compiled.

No app or engine code is touched, so no unit tests apply; the docs workflow triggers on this PR's paths and is the covering check.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjggAEkmynE9ZEvukgWvCS)_