### PR TITLE
fix(engine): pm.response.to.be asserted nothing, so a 500 passed

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -18,7 +18,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | ------------------- | -------------------------------------------------------------------------------- |
 | Core                | `pm`, `pm.test(name, fn)`, `pm.expect(value)`                                    |
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()` |
-| Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`               |
+| Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url`, `.method`, `.headers`, `.body`                                 |
 | Environment         | `pm.environment.get(name)`, `pm.environment.set(name, value)`                    |
 | Globals             | `pm.globals.get(name)`, `pm.globals.set(name, value)`                            |
@@ -45,6 +45,28 @@ Chai-style chains, implemented in the QuickJS runtime:
 .to.be.a(type)    .to.be.an(type)   .to.match(/regex/)
 .to.not …         (negates the chain)
 ```
+
+### Response status classes (`pm.response.to.be`)
+
+Getters, so the paren-less form is the assertion:
+
+```
+.to.be.ok          .to.be.success       (2xx)
+.to.be.info        (1xx)                .to.be.redirection   (3xx)
+.to.be.clientError (4xx)                .to.be.serverError   (5xx)
+.to.be.error       (4xx or 5xx)
+.to.be.accepted    (202)                .to.be.badRequest    (400)
+.to.be.unauthorized(401)                .to.be.forbidden     (403)
+.to.be.notFound    (404)                .to.be.rateLimited   (429)
+.to.be.json        (body parses as JSON)
+.to.be.withBody    (body is not empty)
+```
+
+**Every other name under `pm.response.to` throws a `TypeError`** naming the
+chain - a misspelling, or an idiom Vayu does not implement such as the negated
+`pm.response.to.not.be.ok`. This is deliberate: a paren-less assertion is an
+expression statement, so a name that merely evaluated to `undefined` would
+report PASS against a broken API.
 
 ---
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -82,6 +82,34 @@ pm.response.to.have.header('Content-Type');
 pm.response.to.have.jsonBody();
 ```
 
+Status-class assertions hang off `pm.response.to.be`. They are **getters** - the
+paren-less form is the assertion:
+
+```javascript
+pm.response.to.be.ok;            // 2xx
+pm.response.to.be.success;       // 2xx
+pm.response.to.be.info;          // 1xx
+pm.response.to.be.redirection;   // 3xx
+pm.response.to.be.clientError;   // 4xx
+pm.response.to.be.serverError;   // 5xx
+pm.response.to.be.error;         // 4xx or 5xx
+pm.response.to.be.accepted;      // 202
+pm.response.to.be.badRequest;    // 400
+pm.response.to.be.unauthorized;  // 401
+pm.response.to.be.forbidden;     // 403
+pm.response.to.be.notFound;      // 404
+pm.response.to.be.rateLimited;   // 429
+pm.response.to.be.json;          // body parses as JSON
+pm.response.to.be.withBody;      // body is not empty
+```
+
+**Anything else under `pm.response.to` throws.** A misspelled or unimplemented
+name - `pm.response.to.be.definitelyNotAMatcher`, or the negated
+`pm.response.to.not.be.ok`, which Vayu does not have - raises a `TypeError`
+naming the chain rather than evaluating to `undefined`. A paren-less assertion
+is an expression statement, so a silent `undefined` would report PASS against a
+broken API; failing loudly is the point.
+
 ## Request Object (`pm.request`)
 
 Access request data:

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -10,6 +10,8 @@
  * @brief Scripting API routes - provides script engine capabilities for UI autocomplete
  */
 
+#include <string>
+
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/logger.hpp"
 
@@ -158,6 +160,46 @@ nlohmann::json get_script_completions () {
     { "detail", "pm.response.to.have.jsonBody()" },
     { "documentation", "Assert that the response has a valid JSON body." },
     { "sortText", "1_pm_response_to_have_jsonBody" } });
+
+    // ========================================
+    // pm.response.to.be - Status-class assertions
+    // ========================================
+    // Getters, so the offered text is paren-less: writing the parentheses would
+    // call the assertion's result rather than assert. Every name the runtime
+    // implements belongs here - one it does not offer is one an author never
+    // finds, and one that is offered but missing throws at run time.
+    struct StatusClassCompletion {
+        const char* name;
+        const char* condition;
+    };
+    constexpr StatusClassCompletion status_classes[] = {
+        { "ok", "a 2xx status code" },
+        { "success", "a 2xx status code" },
+        { "info", "a 1xx status code" },
+        { "redirection", "a 3xx status code" },
+        { "clientError", "a 4xx status code" },
+        { "serverError", "a 5xx status code" },
+        { "error", "a 4xx or 5xx status code" },
+        { "accepted", "status 202" },
+        { "badRequest", "status 400" },
+        { "unauthorized", "status 401" },
+        { "forbidden", "status 403" },
+        { "notFound", "status 404" },
+        { "rateLimited", "status 429" },
+        { "json", "a body that parses as JSON" },
+        { "withBody", "a non-empty body" },
+    };
+
+    for (const auto& status_class : status_classes) {
+        const std::string label = std::string ("pm.response.to.be.") + status_class.name;
+        completions.push_back ({ { "label", label }, { "kind", KIND_FIELD },
+        { "insertText", label }, { "detail", label },
+        { "documentation",
+        std::string ("Assert that the response has ") + status_class.condition +
+        ".\n\nWritten without parentheses - the property access is the "
+        "assertion.\n\nExample:\n" + label + ";" },
+        { "sortText", std::string ("1_pm_response_to_be_") + status_class.name } });
+    }
 
     // ========================================
     // pm.request - Request object

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -1125,9 +1125,190 @@ JSValue js_response_have_jsonBody (JSContext* ctx, JSValueConst this_val, int ar
     return JS_UNDEFINED;
 }
 
+// ============================================================================
+// pm.response.to.be Status-Class Assertions
+// ============================================================================
+
+// Each matcher asserts the status code falls in [lo, hi]. Single-code matchers
+// set lo == hi. `expectation` completes "Expected response to have ...".
+struct StatusClassMatcher {
+    const char* name;
+    int lo;
+    int hi;
+    const char* expectation;
+};
+
+// Status ranges only. The body-shape assertions (`json`, `withBody`) are not
+// ranges, so they get their own getters below.
+constexpr StatusClassMatcher status_class_matchers[] = {
+    { "info", 100, 199, "a 1xx status code" },
+    { "ok", 200, 299, "a 2xx status code" },
+    { "success", 200, 299, "a 2xx status code" },
+    { "accepted", 202, 202, "status 202" },
+    { "redirection", 300, 399, "a 3xx status code" },
+    { "clientError", 400, 499, "a 4xx status code" },
+    { "badRequest", 400, 400, "status 400" },
+    { "unauthorized", 401, 401, "status 401" },
+    { "forbidden", 403, 403, "status 403" },
+    { "notFound", 404, 404, "status 404" },
+    { "rateLimited", 429, 429, "status 429" },
+    { "serverError", 500, 599, "a 5xx status code" },
+    { "error", 400, 599, "a 4xx or 5xx status code" },
+};
+
+// `magic` indexes status_class_matchers. Registered as a getter, never a plain
+// property: `pm.response.to.be.ok` is written without parentheses, so a
+// function-valued property would be a discarded reference that asserts nothing
+// (the defect ExpectTrueFalseAssertsOnAccess pins for pm.expect).
+JSValue js_response_be_status_class (
+JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto* data = get_context_data (ctx);
+    if (!data || !data->response) {
+        return JS_ThrowInternalError (ctx, "No response available");
+    }
+
+    const StatusClassMatcher& matcher = status_class_matchers[magic];
+    const int code                    = data->response->status_code;
+    if (code < matcher.lo || code > matcher.hi) {
+        std::string msg = std::string ("Expected response to have ") +
+        matcher.expectation + " but got " + std::to_string (code);
+        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    }
+
+    return JS_UNDEFINED;
+}
+
+JSValue js_response_be_json (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto* data = get_context_data (ctx);
+    if (!data || !data->response) {
+        return JS_ThrowInternalError (ctx, "No response available");
+    }
+
+    JSValue json = JS_ParseJSON (ctx, data->response->body.c_str (),
+    data->response->body.size (), "<response>");
+    if (JS_IsException (json)) {
+        return JS_ThrowTypeError (ctx, "Expected response body to be valid JSON");
+    }
+    JS_FreeValue (ctx, json);
+
+    return JS_UNDEFINED;
+}
+
+JSValue js_response_be_with_body (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto* data = get_context_data (ctx);
+    if (!data || !data->response) {
+        return JS_ThrowInternalError (ctx, "No response available");
+    }
+
+    if (data->response->body.empty ()) {
+        return JS_ThrowTypeError (ctx, "Expected response to have a body");
+    }
+
+    return JS_UNDEFINED;
+}
+
+// ============================================================================
+// pm.response.to chain objects
+// ============================================================================
+
+// Every link in the chain carries this class. Its exotic hook turns an
+// unrecognised member into a throw: `pm.response.to.be.ok` is an expression
+// statement, so a member that does not exist evaluates to undefined and
+// asserts nothing - a green test against a broken API, which is strictly worse
+// than a missing matcher that fails loudly. Own properties are resolved before
+// the hook runs, so it only ever sees names nothing implements.
+JSClassID response_chain_class_id = 0;
+
+// Names the engine itself probes on an arbitrary value. Answering "no own
+// property" for them keeps JSON.stringify and promise resolution working;
+// reporting them as misspelled assertions would make console.log(pm.response)
+// throw. They are not on Object.prototype, so the prototype check below does
+// not cover them.
+constexpr const char* response_chain_passthrough[] = { "toJSON", "then" };
+
+int response_chain_unknown_member (
+JSContext* ctx, JSPropertyDescriptor* desc, JSValueConst obj, JSAtom prop) {
+    (void)desc;
+
+    // The opaque path doubles as the armed flag. Defining a property looks up
+    // the existing own property first, so a hook that threw from the moment the
+    // object existed would reject the chain's own members as they are installed
+    // - arm_response_chain_object runs last, once every member is in place.
+    const auto* path =
+    static_cast<const char*> (JS_GetOpaque (obj, response_chain_class_id));
+    if (!path) {
+        return 0;
+    }
+
+    // Symbol keys (Symbol.toPrimitive, Symbol.toStringTag) are plumbing too.
+    JSValue key              = JS_AtomToValue (ctx, prop);
+    const bool is_string_key = JS_IsString (key);
+    JS_FreeValue (ctx, key);
+    if (!is_string_key) {
+        return 0;
+    }
+
+    const char* name_cstr = JS_AtomToCString (ctx, prop);
+    const std::string name (name_cstr ? name_cstr : "<unknown>");
+    JS_FreeCString (ctx, name_cstr);
+
+    for (const char* passthrough : response_chain_passthrough) {
+        if (name == passthrough) {
+            return 0;
+        }
+    }
+
+    // Anything the prototype answers (toString, hasOwnProperty) is not an
+    // assertion either; let the normal lookup continue to it.
+    JSValue proto      = JS_GetPrototype (ctx, obj);
+    const int on_proto = JS_IsObject (proto) ? JS_HasProperty (ctx, proto, prop) : 0;
+    JS_FreeValue (ctx, proto);
+    if (on_proto != 0) {
+        return on_proto < 0 ? -1 : 0;
+    }
+
+    const std::string msg = std::string (path) + "." + name + " is not a supported assertion";
+    JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+    return -1;
+}
+
+JSClassExoticMethods response_chain_exotic = {
+    .get_own_property = response_chain_unknown_member,
+};
+
+JSClassDef response_chain_class = { .class_name = "ResponseAssertionChain",
+    .finalizer                                  = nullptr,
+    .gc_mark                                    = nullptr,
+    .call                                       = nullptr,
+    .exotic                                     = &response_chain_exotic };
+
+JSValue create_response_chain_object (JSContext* ctx) {
+    return JS_NewObjectClass (ctx, static_cast<int> (response_chain_class_id));
+}
+
+// Arms the unknown-member hook. Call once the object holds every member it is
+// meant to have; `path` names the chain in the error and must outlive the
+// object, so every caller passes a string literal and the class needs no
+// finalizer.
+void arm_response_chain_object (JSValue obj, const char* path) {
+    (void)JS_SetOpaque (obj, const_cast<char*> (path));
+}
+
 // Create the pm.response.to.have chain object
 JSValue create_response_have_object (JSContext* ctx) {
-    JSValue have = JS_NewObject (ctx);
+    JSValue have = create_response_chain_object (ctx);
+    if (JS_IsException (have)) {
+        return have;
+    }
     JS_SetPropertyStr (ctx, have, "status",
     JS_NewCFunction (ctx, js_response_have_status, "status", 1));
     JS_SetPropertyStr (ctx, have, "header",
@@ -1136,14 +1317,51 @@ JSValue create_response_have_object (JSContext* ctx) {
     ctx, have, "body", JS_NewCFunction (ctx, js_response_have_body, "body", 1));
     JS_SetPropertyStr (ctx, have, "jsonBody",
     JS_NewCFunction (ctx, js_response_have_jsonBody, "jsonBody", 1));
+    arm_response_chain_object (have, "pm.response.to.have");
     return have;
+}
+
+// Create the pm.response.to.be chain object
+JSValue create_response_be_object (JSContext* ctx) {
+    JSValue be = create_response_chain_object (ctx);
+    if (JS_IsException (be)) {
+        return be;
+    }
+
+    int magic = 0;
+    for (const auto& matcher : status_class_matchers) {
+        JSAtom atom = JS_NewAtom (ctx, matcher.name);
+        JS_DefinePropertyGetSet (ctx, be, atom,
+        JS_NewCFunctionMagic (ctx, js_response_be_status_class, matcher.name, 0,
+        JS_CFUNC_generic_magic, magic),
+        JS_UNDEFINED, 0);
+        JS_FreeAtom (ctx, atom);
+        magic++;
+    }
+
+    JSAtom json_atom = JS_NewAtom (ctx, "json");
+    JS_DefinePropertyGetSet (ctx, be, json_atom,
+    JS_NewCFunction (ctx, js_response_be_json, "json", 0), JS_UNDEFINED, 0);
+    JS_FreeAtom (ctx, json_atom);
+
+    JSAtom with_body_atom = JS_NewAtom (ctx, "withBody");
+    JS_DefinePropertyGetSet (ctx, be, with_body_atom,
+    JS_NewCFunction (ctx, js_response_be_with_body, "withBody", 0), JS_UNDEFINED, 0);
+    JS_FreeAtom (ctx, with_body_atom);
+
+    arm_response_chain_object (be, "pm.response.to.be");
+    return be;
 }
 
 // Create the pm.response.to chain object
 JSValue create_response_to_object (JSContext* ctx) {
-    JSValue to = JS_NewObject (ctx);
+    JSValue to = create_response_chain_object (ctx);
+    if (JS_IsException (to)) {
+        return to;
+    }
     JS_SetPropertyStr (ctx, to, "have", create_response_have_object (ctx));
-    JS_SetPropertyStr (ctx, to, "be", JS_NewObject (ctx)); // placeholder for future assertions
+    JS_SetPropertyStr (ctx, to, "be", create_response_be_object (ctx));
+    arm_response_chain_object (to, "pm.response.to");
     return to;
 }
 
@@ -1617,6 +1835,15 @@ void setup_pm_object (JSContext* ctx) {
     JSValue global = JS_GetGlobalObject (ctx);
     JSValue pm     = JS_NewObject (ctx);
 
+    // A class registered with JS_NewClass has no prototype until one is set, so
+    // without this the pm.response.to.* objects would answer nothing but their
+    // own members - toString, hasOwnProperty and friends would reach the
+    // unknown-member hook and throw.
+    JSValue plain        = JS_NewObject (ctx);
+    JSValue object_proto = JS_GetPrototype (ctx, plain);
+    JS_FreeValue (ctx, plain);
+    JS_SetClassProto (ctx, response_chain_class_id, object_proto);
+
     // pm.test()
     JS_SetPropertyStr (ctx, pm, "test", JS_NewCFunction (ctx, js_pm_test, "test", 2));
 
@@ -1718,6 +1945,13 @@ class ScriptEngine::Impl {
             QJS_NewClassID (rt, &expect_class_id);
         }
         JS_NewClass (rt, expect_class_id, &expect_class);
+
+        // Register the pm.response.to.* chain class, whose exotic hook makes an
+        // unknown assertion throw instead of silently evaluating to undefined.
+        if (response_chain_class_id == 0) {
+            QJS_NewClassID (rt, &response_chain_class_id);
+        }
+        JS_NewClass (rt, response_chain_class_id, &response_chain_class);
 
         JSContext* ctx = JS_NewContext (rt);
         if (ctx) {

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -17,6 +17,9 @@
 
 #include <string>
 
+#include "vayu/runtime/script_engine.hpp"
+#include "vayu/types.hpp"
+
 namespace vayu::http::routes {
 // Defined in scripting.cpp.
 nlohmann::json get_script_completions ();
@@ -121,6 +124,48 @@ TEST (ScriptCompletions, TheMutationSnippetsAreOfferedAndReachable) {
     EXPECT_TRUE (has_set_header) << "no snippet for setting a header";
     EXPECT_TRUE (has_delete_header) << "no snippet for removing a header";
     EXPECT_TRUE (has_body_rewrite) << "no snippet for rewriting the body";
+}
+
+// The list and the runtime are in different translation units, so nothing but
+// this stops them drifting: an offered `to.be` matcher the runtime does not
+// implement now throws "not a supported assertion" the moment it is used, which
+// makes the editor's suggestion the source of a failing test.
+TEST (ScriptCompletions, EveryOfferedResponseStatusClassExistsInTheRuntime) {
+    const auto completions = get_script_completions ();
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request;
+    vayu::Response response;
+    vayu::Environment env;
+    request.method       = vayu::HttpMethod::GET;
+    request.url          = "https://api.example.com/users";
+    response.status_code = 200;
+    response.body        = R"({"ok": true})";
+
+    int offered = 0;
+    for (const auto& item : completions) {
+        const std::string label = item.value ("label", std::string{});
+        if (label.rfind ("pm.response.to.be.", 0) != 0) {
+            continue;
+        }
+        offered++;
+
+        const std::string insert = item.value ("insertText", std::string{});
+        EXPECT_EQ (insert.find ('('), std::string::npos)
+        << label << " is a getter - offering parentheses would call its result";
+
+        // Whether the assertion passes against this response is beside the
+        // point; only "the runtime has no such member" is a list defect.
+        const std::string script = "pm.test(\"t\", function() { " + insert + "; });";
+        auto result              = engine.execute_test (script, request, response, env);
+        ASSERT_EQ (result.tests.size (), 1u) << script;
+        EXPECT_EQ (result.tests[0].error_message.find ("not a supported assertion"),
+        std::string::npos)
+        << label << " is offered but the runtime does not implement it";
+    }
+
+    EXPECT_GE (offered, 10)
+    << "the pm.response.to.be matchers are missing from the completion list";
 }
 
 } // namespace

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -464,6 +464,159 @@ TEST_F (ScriptEngineTest, ResponseJsonBodyNoArgFailsOnNonJson) {
     EXPECT_FALSE (result.tests[0].passed);
 }
 
+// ============================================================================
+// pm.response.to.be Tests
+// ============================================================================
+//
+// `to.be` was an empty object, so every assertion hanging off it evaluated to
+// undefined and, as an expression statement, asserted nothing: a test whose
+// only line was `pm.response.to.be.ok` reported PASS against a 500. The first
+// two tests below are the mutation check - restore the empty placeholder and
+// ResponseToBeOkFailsOnServerError goes green while the API stays broken.
+
+TEST_F (ScriptEngineTest, ResponseToBeOkFailsOnServerError) {
+    response.status_code = 500;
+    response.status_text = "Internal Server Error";
+
+    auto result = engine.execute_test (R"(
+        pm.test("api is healthy", function() {
+            pm.response.to.be.ok;
+        });
+    )",
+    request, response, env);
+
+    EXPECT_FALSE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_FALSE (result.tests[0].passed);
+    EXPECT_NE (result.tests[0].error_message.find ("500"), std::string::npos)
+    << "the failure must name the status it got: " << result.tests[0].error_message;
+}
+
+TEST_F (ScriptEngineTest, ResponseToBeOkPassesOnSuccess) {
+    auto result = engine.execute_test (R"(
+        pm.test("api is healthy", function() {
+            pm.response.to.be.ok;
+            pm.response.to.be.success;
+        });
+    )",
+    request, response, env);
+
+    EXPECT_TRUE (result.success);
+    ASSERT_EQ (result.tests.size (), 1);
+    EXPECT_TRUE (result.tests[0].passed);
+}
+
+// Each matcher, on both sides of its boundary. A matcher that passed
+// unconditionally would satisfy the first half of every pair and fail here.
+TEST_F (ScriptEngineTest, ResponseToBeStatusClassMatchersAssertOnBothSides) {
+    struct Case {
+        int status;
+        const char* matches;
+        const char* does_not_match;
+    };
+    const Case cases[] = {
+        { 100, "info", "ok" },
+        { 202, "accepted", "notFound" },
+        { 301, "redirection", "success" },
+        { 400, "badRequest", "serverError" },
+        { 401, "unauthorized", "forbidden" },
+        { 403, "forbidden", "unauthorized" },
+        { 404, "notFound", "badRequest" },
+        { 429, "rateLimited", "serverError" },
+        { 404, "clientError", "serverError" },
+        { 503, "serverError", "clientError" },
+        { 503, "error", "redirection" },
+        { 404, "error", "info" },
+    };
+
+    for (const auto& c : cases) {
+        response.status_code = c.status;
+
+        const std::string passing = std::string ("pm.test(\"t\", function() { "
+                                                 "pm.response.to.be.") +
+        c.matches + "; });";
+        auto pass_result = engine.execute_test (passing, request, response, env);
+        ASSERT_EQ (pass_result.tests.size (), 1u) << passing;
+        EXPECT_TRUE (pass_result.tests[0].passed)
+        << c.matches << " should match status " << c.status << ": "
+        << pass_result.tests[0].error_message;
+
+        const std::string failing = std::string ("pm.test(\"t\", function() { "
+                                                 "pm.response.to.be.") +
+        c.does_not_match + "; });";
+        auto fail_result = engine.execute_test (failing, request, response, env);
+        ASSERT_EQ (fail_result.tests.size (), 1u) << failing;
+        EXPECT_FALSE (fail_result.tests[0].passed)
+        << c.does_not_match << " must not match status " << c.status;
+    }
+}
+
+TEST_F (ScriptEngineTest, ResponseToBeJsonAndWithBody) {
+    auto json_result = engine.execute_test (R"(
+        pm.test("json body", function() {
+            pm.response.to.be.json;
+            pm.response.to.be.withBody;
+        });
+    )",
+    request, response, env);
+    EXPECT_TRUE (json_result.success) << json_result.tests[0].error_message;
+
+    response.body   = "not json at all";
+    auto not_json   = engine.execute_test (R"(
+        pm.test("json body", function() { pm.response.to.be.json; });
+    )",
+      request, response, env);
+    ASSERT_EQ (not_json.tests.size (), 1u);
+    EXPECT_FALSE (not_json.tests[0].passed);
+
+    response.body   = "";
+    auto empty_body = engine.execute_test (R"(
+        pm.test("has a body", function() { pm.response.to.be.withBody; });
+    )",
+    request, response, env);
+    ASSERT_EQ (empty_body.tests.size (), 1u);
+    EXPECT_FALSE (empty_body.tests[0].passed);
+}
+
+// A name nothing implements must fail loudly. Silently returning undefined is
+// the whole defect - a misspelled matcher would otherwise report PASS.
+TEST_F (ScriptEngineTest, ResponseToChainRejectsUnknownAssertions) {
+    const char* scripts[] = {
+        R"(pm.test("t", function() { pm.response.to.be.definitelyNotAMatcher; });)",
+        R"(pm.test("t", function() { pm.response.to.have.definitelyNotAMatcher; });)",
+        R"(pm.test("t", function() { pm.response.to.definitelyNotAMatcher; });)",
+        // The negated form is not implemented; it must throw, not pass.
+        R"(pm.test("t", function() { pm.response.to.not.be.ok; });)",
+    };
+
+    for (const char* script : scripts) {
+        auto result = engine.execute_test (script, request, response, env);
+        ASSERT_EQ (result.tests.size (), 1u) << script;
+        EXPECT_FALSE (result.tests[0].passed) << script;
+        EXPECT_NE (result.tests[0].error_message.find ("not a supported assertion"), std::string::npos)
+        << script << " -> " << result.tests[0].error_message;
+    }
+}
+
+// The exotic hook only rejects assertion names: the object still has to behave
+// like an object for the plumbing that touches it (printing, serialising).
+TEST_F (ScriptEngineTest, ResponseToChainStillBehavesLikeAnObject) {
+    auto result = engine.execute_test (R"(
+        pm.test("printable", function() {
+            var label = String(pm.response.to.be);
+            pm.expect(label).to.include("object");
+            pm.expect(typeof pm.response.to.have.status).to.equal("function");
+            // console.log(pm.response) serialises the whole response; a chain
+            // link that rejected `toJSON` would turn that into a throw.
+            pm.expect(JSON.stringify(pm.response)).to.include("to");
+        });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
 TEST_F (ScriptEngineTest, ResponseHeaders) {
     auto result = engine.execute_test (R"(
         pm.test("Content-Type header", function() {


### PR DESCRIPTION
## Description

**Plan.** Root cause is one line: `create_response_to_object` stubbed `to.be` with a bare `JS_NewObject`, so every assertion hanging off it evaluated to `undefined`. A paren-less assertion is an expression statement, so `pm.response.to.be.ok` on a 500 discarded that `undefined` and the test reported PASS. Verified still present at `ffafcd0` before touching anything. The approach has two parts, and the first matters more: make an unrecognised member **throw** rather than no-op, then implement the status-class matchers as getters. For the throw I rejected the "install every documented name, unimplemented ones throwing" option the issue offered as sufficient - it closes the documented set but leaves a *misspelling* (`to.be.definitelyNotAMatcher`) silently passing, which is the same defect one step over. Instead all three chain links carry a class whose exotic `get_own_property` hook raises a `TypeError` naming the chain; own members resolve before the hook runs, so it only ever sees names nothing implements. A JS `Proxy` would have been fewer lines but needs a `JS_Eval` per response (`setup_pm_response` runs on every execution), which is not a cost a load run should pay.

Two details a future reader will otherwise rediscover the hard way, both commented at the call site:

- **The hook is armed last.** Defining a property looks up the existing own property first, so a hook that threw from the moment the object existed rejected the chain's own members as they were installed. The opaque path pointer doubles as the armed flag; `arm_response_chain_object` runs once every member is in place.
- **The class needs an explicit prototype.** `JS_NewClass` leaves the class proto null, so `toString` / `hasOwnProperty` reached the hook and threw. `setup_pm_object` now points the class at `Object.prototype`, and `toJSON` / `then` / symbol keys pass through explicitly (they are not on the prototype), so `console.log(pm.response)` still serialises instead of throwing.

Implemented matchers: `ok`, `success`, `info`, `redirection`, `clientError`, `serverError`, `error`, `accepted`, `badRequest`, `unauthorized`, `forbidden`, `notFound`, `rateLimited`, `json`, `withBody`. All getters, for the reason `ExpectTrueFalseAssertsOnAccess` pins.

**Deliberate deviation:** the issue's implement-list omits `rateLimited`. It is one row of the same status-range table, and the alternative under part 1 was to make it throw "not supported" - so it is implemented rather than stubbed. `to.have` was audited as the issue asks: its four members are real, and it is now covered by the same unknown-member hook.

Blast radius checked: the only `pm.response.to.*` uses outside the engine are `to.have.status(200)` in `script-variants.tsx` and two MCP tests, all still valid. App changes are none, as the issue states; the engine-side completion list is the one addition, and a test now runs every offered `to.be` name through the runtime so the list cannot drift from it.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **631/631 pass** (up from 626; 5 new tests). CI green on ubuntu, macos and windows.

**Mutation-checked.** Restoring the original `JS_SetPropertyStr (ctx, to, "be", JS_NewObject (ctx))` placeholder and rebuilding turns 4 of the 5 new tests red, including `ResponseToBeOkFailsOnServerError` - the false pass this fixes. `ResponseToBeOkPassesOnSuccess` stays green under the mutation, which is exactly the point: the broken version only ever passed.

New tests:
- `ResponseToBeOkFailsOnServerError` / `ResponseToBeOkPassesOnSuccess` - the 500-fails / 200-passes pair, asserting the failure names the status it got.
- `ResponseToBeStatusClassMatchersAssertOnBothSides` - 12 status/matcher pairs, each matcher checked on both sides of its boundary.
- `ResponseToBeJsonAndWithBody` - valid JSON, non-JSON, empty body.
- `ResponseToChainRejectsUnknownAssertions` - unknown names under `to`, `to.have`, `to.be`, plus the negated `to.not.be.ok`.
- `ResponseToChainStillBehavesLikeAnObject` - `String(...)`, `typeof`, and `JSON.stringify(pm.response)` keep working.
- `EveryOfferedResponseStatusClassExistsInTheRuntime` (completions) - executes every offered matcher against the engine.

Pre-existing flakes seen while iterating, both unrelated and green on the final run: `MetricsCollectorTest.SuccessCountNeverExceedsTotalRequests` (the race tracked by #179) and one `HttpClientTest` timeout.

App suite not run: no file under `app/` is touched, so no app test could go from green to red (CLAUDE.md, "scale the verification to what the change could actually break").

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #181