### PR TITLE
docs: describe the pm scripting API in Vayu's own terms

### DIFF
--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -103,7 +103,7 @@ nav:
       - State Management: app/state-management.md
       - Talking to the Engine: app/api-integration.md
       - Variables: app/variable-resolution.md
-      - Postman Script Support: app/pm-api-compatibility.md
+      - pm Scripting API: app/pm-api-compatibility.md
       - File Naming: app/file-name-conventions.md
       - Importing Collections:
           - How Import Works: app/import-collections/README.md

--- a/.github/overrides/main.html
+++ b/.github/overrides/main.html
@@ -92,7 +92,7 @@
         "Native C++ load testing with live metrics over SSE",
         "Built-in MCP server for Claude Code, Cursor, VS Code, Codex and Zed",
         "Import Postman, Insomnia, OpenAPI 3.0 and Swagger 2.0 collections",
-        "Postman-compatible pm.* test scripts",
+        "pm.* scripting API for test scripts",
         "OAuth 2.0, Bearer, Basic and API key auth",
         "Fully offline - no account, no telemetry, no cloud sync"
       ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,7 +465,7 @@ ways before anyone checked.
 | `docs/app/api-integration.md` | Renderer ↔ engine calls | Request/response shapes the renderer sends |
 | `docs/app/variable-resolution.md` | `{{var}}` resolution + scope precedence | Resolution order, scopes, the resolver hook |
 | `docs/app/import-collections/` | Import pipeline + per-format mapping | Detectors, drafts, any format mapping |
-| `docs/app/pm-api-compatibility.md` | Postman `pm.*` surface | Which `pm.*` APIs the runtime supports |
+| `docs/app/pm-api-compatibility.md` | `pm.*` scripting API surface | Which `pm.*` APIs the runtime supports |
 | `docs/app/file-name-conventions.md` | Naming rules | The conventions themselves |
 | `docs/app/building.md` | App build | App build steps or tooling |
 | `docs/engine/architecture.md` | Engine internals, engine-side auth | Core engine structure, auth resolution |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Vayu is a free, open source desktop app for Windows, macOS, and Linux that merge
 *The load-test dashboard. Throughput, latency percentiles, and error counters stream live from the C++ engine while the UI stays responsive.*
 
 ![GraphQL request builder](docs/images/vayu-graphql.png)
-*REST and GraphQL request builder with collections, layered environments, and Postman-compatible scripting.*
+*REST and GraphQL request builder with collections, layered environments, and a `pm` scripting API.*
 
 ---
 
@@ -90,7 +90,7 @@ Migrating takes seconds. Drop an existing export onto Vayu and the workspace is 
 - **One-drop import** - Postman v2.0/v2.1, Postman environments and globals, Insomnia v4, OpenAPI 3.0, Swagger 2.0
 - **Layered environments** - variable resolution flows from globals → collection chain → active environment, with overrides at any level
 - **Auth, the way you expect it** - Bearer token, Basic auth, API key (header or query), and OAuth 2.0 (client credentials, password, and interactive authorization code with PKCE); resolved engine-side and inherits down the collection tree
-- **Postman-compatible test scripts** - QuickJS engine implementing `pm.test()`, `pm.expect()`, `pm.environment.set()`, `pm.response.*` - most Postman scripts run unmodified
+- **Test scripts with the `pm` API** - QuickJS engine implementing `pm.test()`, `pm.expect()`, `pm.environment.set()`, `pm.response.*` - most existing test scripts run unmodified
 - **Composable scripting** - pre/post-request scripts compose down the hierarchy (root → folder → request)
 - **Private by default** - 100% offline execution; no telemetry, no account, no cloud sync
 - **Cross-platform** - native installers for Windows (x64), macOS (universal), and Linux (AppImage)

--- a/app/electron/mcp/server.ts
+++ b/app/electron/mcp/server.ts
@@ -31,14 +31,14 @@ export interface McpServerInfo {
 /** Vayu's identity, surfaced to clients via the server's Implementation info. */
 const VAYU_TITLE = "Vayu";
 const VAYU_DESCRIPTION =
-	"Vayu is a local API testing and load-testing platform: Postman-style requests " +
+	"Vayu is a local API testing and load-testing platform: manual API requests " +
 	"plus k6-level load tests in one app, driven by a native C++ engine. This MCP " +
 	"server exposes that engine so an agent can send requests, run and analyze load " +
 	"tests, and read or tune engine configuration on the user's machine.";
 const VAYU_WEBSITE = "https://github.com/athrvk/vayu";
 
 const INSTRUCTIONS =
-	"Vayu is a local API testing and load-testing platform (Postman-style requests " +
+	"Vayu is a local API testing and load-testing platform (manual API requests " +
 	"plus k6-level load tests in one app, backed by a native C++ engine); these " +
 	"tools drive that engine. Call get_engine_health first. Tools are grouped by " +
 	"capability: read (inspect collections, requests, environments, runs, config, " +

--- a/app/src/components/shared/response-viewer/ResponseBody.tsx
+++ b/app/src/components/shared/response-viewer/ResponseBody.tsx
@@ -12,8 +12,6 @@
  * - Pretty: Formatted/syntax highlighted view (default)
  * - Raw: Unformatted text view
  * - Preview: HTML/image rendering (when applicable)
- *
- * Similar to Postman's response body viewer.
  */
 
 import { useState, useMemo, type ReactNode } from "react";

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -1,6 +1,6 @@
 # `pm` Scripting API Compatibility
 
-Vayu exposes a **Postman-compatible** `pm` scripting API for pre-request and test
+Vayu exposes a `pm` scripting API for pre-request and test
 scripts. Scripts run in the engine's QuickJS runtime
 (`engine/src/runtime/script_engine.cpp`); the global `pm` object is bound there. The
 intent is that the most common Postman scripts paste in and run unchanged.

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -35,7 +35,7 @@ The Vayu Engine is a high-performance C++ daemon that executes HTTP requests and
 │           ▼                │   Script Engine (QuickJS)   │  │
 │  ┌──────────────────┐      │  • Pre-request scripts      │  │
 │  │  Run Manager     │      │  • Test scripts             │  │
-│  │  • Active runs   │      │  • Postman-compatible API   │  │
+│  │  • Active runs   │      │  • pm scripting API         │  │
 │  │  • Lifecycle     │      └─────────────────────────────┘  │
 │  └────────┬─────────┘                                        │
 │           │                                                  │
@@ -166,7 +166,7 @@ High-performance in-memory metrics collection optimized for 60k+ RPS:
 
 JavaScript execution engine for pre-request and test scripts:
 
-- **Postman-compatible API**: `pm.test()`, `pm.expect()`, `pm.response`, etc.
+- **`pm` scripting API**: `pm.test()`, `pm.expect()`, `pm.response`, etc.
 - **Mutable request**: a pre-request script's `pm.request` writes are applied to the
   request before it is sent (see `docs/engine/scripting.md`)
 - **Memory limit**: 64MB per script execution

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1,6 +1,6 @@
 # Vayu Scripting Guide
 
-Vayu uses QuickJS for JavaScript execution in pre-request and test scripts. The scripting API is compatible with Postman's `pm` object, making it easy to migrate tests from Postman.
+Vayu uses QuickJS for JavaScript execution in pre-request and test scripts. The scripting API exposes a `pm` object for tests and assertions, making it easy to migrate tests from Postman.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -236,7 +236,7 @@ persists.
 | [State Management](app/state-management.md) | Zustand stores, TanStack Query keys, cache policy |
 | [Talking to the Engine](app/api-integration.md) | What the renderer sends the engine, and when |
 | [Variables](app/variable-resolution.md) | How `{{variables}}` resolve, and scope precedence |
-| [Postman Script Support](app/pm-api-compatibility.md) | Which `pm.*` APIs the runtime supports |
+| [`pm` Scripting API Compatibility](app/pm-api-compatibility.md) | Which `pm.*` APIs the runtime supports |
 | [File Naming](app/file-name-conventions.md) | Naming rules across the renderer |
 | [Importing Collections](app/import-collections/README.md) | The import pipeline, plus per-format mapping |
 
@@ -271,8 +271,8 @@ persists.
 
     Most run unmodified. A QuickJS runtime implements the `pm.*` API -
     `pm.test()`, `pm.expect()`, `pm.environment.get/set()`, `pm.response.*` -
-    and [Postman Script Support](app/pm-api-compatibility.md) lists exactly
-    what is covered.
+    and [`pm` Scripting API Compatibility](app/pm-api-compatibility.md) lists
+    exactly what is covered.
 
 ??? question "Can my coding agent use it?"
 

--- a/engine/include/vayu/runtime/script_engine.hpp
+++ b/engine/include/vayu/runtime/script_engine.hpp
@@ -11,7 +11,7 @@
  * @file script_engine.hpp
  * @brief JavaScript scripting engine using QuickJS
  *
- * Provides Postman-compatible scripting with pm.test(), pm.expect(),
+ * Provides the `pm` scripting API - pm.test(), pm.expect(),
  * and access to request/response data.
  */
 
@@ -72,7 +72,7 @@ struct ScriptContext {
  * @brief JavaScript scripting engine
  *
  * Executes pre-request and test scripts with access to request/response
- * data through Postman-compatible `pm` object.
+ * data through the `pm` object.
  *
  * Example script:
  * @code

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -422,7 +422,8 @@ Result<Response> Client::send (const Request& request) {
         // Convert curl error to ErrorCode and message
         Error error = curl_to_error (res, impl_->error_buffer);
 
-        // Return Response object with error details (Postman-compatible approach)
+        // Return a Response object with error details rather than throwing, so
+        // the caller always gets a uniform result
         response.status_code = 0; // 0 indicates client-side error (no server response)
         response.status_text = vayu::http::status_text (0);
         response.error_code    = error.code;

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -40,10 +40,10 @@ nlohmann::json get_script_completions () {
     // pm object
     // ========================================
     completions.push_back ({ { "label", "pm" }, { "kind", KIND_VARIABLE },
-    { "insertText", "pm" }, { "detail", "pm object (Postman-compatible)" },
+    { "insertText", "pm" }, { "detail", "pm object" },
     { "documentation",
     "The pm object provides access to request, response, environment, and "
-    "testing utilities. Vayu implements a Postman-compatible scripting API." },
+    "testing utilities for pre-request and test scripts." },
     { "sortText", "0_pm" } });
 
     // ========================================

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -538,7 +538,7 @@ JSValue expect_have_property (JSContext* ctx, JSValueConst this_val, int argc, J
     return JS_UNDEFINED;
 }
 
-// Terminal getters: assert on property access (Chai/Postman paren-less idiom).
+// Terminal getters: assert on property access (Chai paren-less idiom).
 // Each honors the tracked `negated` flag, throws on failure, and returns the
 // expectation object so a chain can continue.
 
@@ -867,7 +867,7 @@ JSValue create_expectation (JSContext* ctx, JSValue actual) {
     JS_NewCFunction (ctx, expect_to_getter, "at", 0), JS_UNDEFINED, 0);
     JS_FreeAtom (ctx, at_atom);
 
-    // Terminal matchers assert on access (Chai/Postman paren-less idiom), so
+    // Terminal matchers assert on access (Chai paren-less idiom), so
     // register them as getters rather than function-valued properties - a bare
     // `.to.be.true` must run the check, not silently return an uncalled function.
     struct TerminalGetter {
@@ -975,7 +975,7 @@ JSValue js_response_text (JSContext* ctx, JSValueConst this_val, int argc, JSVal
 }
 
 // ============================================================================
-// pm.response.to.have Assertions (Postman-compatible)
+// pm.response.to.have Assertions
 // ============================================================================
 
 JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
@@ -1083,7 +1083,7 @@ JSValue js_response_have_jsonBody (JSContext* ctx, JSValueConst this_val, int ar
         return JS_ThrowTypeError (ctx, "Response body is not valid JSON");
     }
 
-    // No-arg form asserts only that the body is valid JSON (Postman semantics).
+    // No-arg form asserts only that the body is valid JSON.
     if (argc < 1) {
         JS_FreeValue (ctx, json);
         return JS_UNDEFINED;
@@ -1419,7 +1419,7 @@ void setup_pm_response (JSContext* ctx, JSValue pm) {
         }
         JS_SetPropertyStr (ctx, response, "headers", headers);
 
-        // pm.response.to.have chain for Postman-compatible assertions
+        // pm.response.to.have chain for response assertions
         JS_SetPropertyStr (ctx, response, "to", create_response_to_object (ctx));
     }
 

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@ Vayu is a free Postman alternative that runs entirely on your machine. It combin
 - **License**: Engine - AGPL-3.0 / UI - Apache-2.0
 - **No account, no telemetry, 100% offline**
 - **Import formats**: Postman v2.0/v2.1, Insomnia v4, OpenAPI 3.0, Swagger 2.0
-- **Scripting**: QuickJS with `pm.*` API - compatible with Postman test scripts
+- **Scripting**: QuickJS with `pm.*` API for pre-request and test scripts
 - **Auth**: Bearer, Basic, API key, and OAuth 2.0 (client credentials, password, authorization code + PKCE); resolved engine-side
 - **Load testing**: built-in, real-time metrics streaming via SSE
 - **Variable resolution**: layered - globals → collection chain → active environment


### PR DESCRIPTION
## Description

A trademark-hygiene sweep. Phrasing that presented **Vayu's own scripting API as another product's** - "Postman-compatible `pm` object", "Postman semantics", "the Postman paren-less idiom" - now states the behaviour directly. No code path changes: the diff is comments, doc prose, and three descriptive strings.

**What was deliberately left alone, and why.** A blanket removal would have broken working features, so the sweep draws one line: a reference that *names a third-party format Vayu interoperates with* is load-bearing and stays; a reference that *describes our own API by attribution* goes. Kept unchanged:

- the importers and everything they depend on - `services/importers/**`, format labels (`Postman v2.1`, `Postman Env`, `Postman Globals`), fixtures, and the tests asserting on those strings. Deleting these breaks format detection and the import UI's detection badge.
- `docs/app/import-collections/**` and its mkdocs nav entries
- the nominative-use and trademark note at the top of `docs/app/pm-api-compatibility.md`, verbatim - that paragraph is the existing protection, and removing it while keeping interop claims would be backwards
- factual statements about how *other* tools behave (what "Raw" means in each viewer; the OAuth token cache keying note)
- published release notes under `.github/release-notes/` - shipped history, never rewritten
- statements of interop that remain accurate and useful to a user ("most existing test scripts run unmodified", "easy to migrate tests")

Naming a format you import is the standard nominative case; it is the "our API *is* theirs" framing that this PR removes.

**Changed strings that reach a user** (worth a look, since they are copy, not comments):

- the `pm` autocomplete entry served to the Monaco editor - `detail` "pm object (Postman-compatible)" becomes "pm object", and its documentation now describes the object instead of claiming compatibility
- the MCP server's title and instructions text ("Postman-style requests" becomes "manual API requests")
- the docs-site structured data in `.github/overrides/main.html`, the README feature bullet and screenshot caption, and `llms.txt`

The mkdocs nav entry and the `docs/index.md` link text for `pm-api-compatibility.md` are retitled **together** so the sidebar and the in-page link agree. The file name and every link target are unchanged, so no relative link or anchor moves.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Text only - no behaviour changes.

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev`: **631/631 pass**. Run because `routes/scripting.cpp` holds string literals that `script_completions_test.cpp` reads.
- `pnpm test`: **1924 tests in 230 files pass**. Run because `app/electron/mcp/server.ts` and `ResponseBody.tsx` are touched.
- `pnpm type-check`: clean.
- No em-dashes in any changed file.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - text-only change, nothing to lock
- [x] I have updated documentation

## Related Issues

Not tied to an issue - requested directly.

**Stacked on #199**, whose branch is the base here, because both edit `docs/engine/scripting.md` and `docs/app/pm-api-compatibility.md`. Merge #199 first and this retargets cleanly to `master`; alternatively I can rebase it onto `master` now and resolve the overlap by hand. Say which you prefer.