### PR TITLE
docs(engine,app): stop teaching `pm.variables` and `pm.response.headers.get`

### DIFF
--- a/app/src/hooks/useVariableCompletionProvider.ts
+++ b/app/src/hooks/useVariableCompletionProvider.ts
@@ -18,7 +18,8 @@
  * **Registered for the body languages only.** `json`, `plaintext` and `graphql`
  * are what `CodeEditor` mounts for a request body. Deliberately *not*
  * `javascript`: the script editors are the one place `{{name}}` is not the
- * syntax - a script reaches variables through `pm.variables.get()`, and
+ * syntax - a script reaches variables through `pm.environment.get()` and its
+ * sibling scope accessors (there is no `pm.variables`), and
  * offering brace completion there would teach the wrong thing.
  *
  * Called once, in App - a completion provider is global per language, so one

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script-panels.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script-panels.test.tsx
@@ -228,6 +228,26 @@ describe.each(PANELS)("%s panel", (_name, variant, ownMarker, ownChain, ownLegac
 		}
 	});
 
+	/*
+	 * The quick reference is copy-paste bait: it sits next to the editor and a
+	 * script author types what it shows. It showed
+	 * `pm.response.headers.get("Content-Type")` for as long as the panel has
+	 * existed, and that throws `TypeError: not a function` - the runtime builds
+	 * `headers` as a plain object (`script_engine.cpp`, `setup_pm_response`),
+	 * with keys the HTTP client has already lower-cased.
+	 */
+	it("suggests only header reads that the runtime supports", () => {
+		const { container } = render(<Panel />);
+		const text = container.textContent ?? "";
+
+		expect(text).not.toContain("headers.get(");
+		if (variant === "post") {
+			expect(text).toContain('pm.response.headers["content-type"]');
+			// The rule the snippet cannot show: why the key is lower-cased.
+			expect(text).toMatch(/lower-cases every key/i);
+		}
+	});
+
 	describe("the sunken slabs", () => {
 		it("declares the surface its rule reads from", () => {
 			const { container } = render(<Panel />);

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -128,9 +128,15 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 			"});",
 			"pm.response.json()",
 			"pm.response.text()",
-			'pm.response.headers.get("Content-Type")',
+			'pm.response.headers["content-type"]',
 		],
 		notes: [
+			<>
+				<code className={CODE_CLASS}>pm.response.headers</code> is a plain object, not
+				Postman&apos;s <code className={CODE_CLASS}>HeaderList</code>: there is no{" "}
+				<code className={CODE_CLASS}>.get()</code>, and the engine lower-cases every key as
+				it parses the response, so index it with the lower-cased name.
+			</>,
 			<>
 				<code className={CODE_CLASS}>pm.request</code> is readable here as a record of what
 				was sent, but writing to it does nothing - the request has already gone out. Change

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -25,6 +25,9 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Collection vars     | `pm.collectionVariables.get(name)`, `pm.collectionVariables.set(name, value)`    |
 | Console             | `console.log/info/warn/error`                                                    |
 
+`pm.response.headers` is a plain object keyed by the **lower-cased** header name -
+`pm.response.headers['content-type']`, not Postman's `HeaderList` (see below).
+
 Variable writes persist to the scope they target (environment / collection / globals) and
 participate in [variable resolution](./variable-resolution.md). Calling `set(name, value)`
 on a variable that already exists updates only its value - the existing `secret` flag,
@@ -55,6 +58,11 @@ These Postman APIs are **not** implemented - scripts that rely on them will fail
 - `pm.sendRequest(...)` - sending auxiliary requests from a script
 - `pm.variables.*` - the merged/resolved variable accessor (use the scoped
   `pm.environment` / `pm.collectionVariables` / `pm.globals` instead)
+- `pm.response.headers.get/has(...)` - Postman's `headers` is a `HeaderList`;
+  Vayu's is a plain object keyed by the **lower-cased** header name, so read it
+  as `pm.response.headers['content-type']`. The engine's HTTP client lower-cases
+  every response header name as it parses it (`client.cpp`), so a mixed-case key
+  reads back `undefined`.
 - `pm.iterationData.*` - data-file driven runs
 - `pm.cookies.*`
 - Postman's header *methods* - `pm.request.headers.add/upsert/remove(...)`. Vayu's

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -68,7 +68,9 @@ pm.response.responseTimeWire  // CURLINFO_TOTAL_TIME in ms - DNS + TCP + TLS +
 pm.response.responseTimeQueueWait // Generator-side queue overhead in ms,
                               // i.e. responseTime − responseTimeWire (clamped
                               // to >= 0). For single-shot sends this is ~0.
-pm.response.headers           // Headers object (lowercase keys)
+pm.response.headers           // Plain object, lower-cased keys. Read it with
+                              // pm.response.headers['content-type'] - it is not
+                              // Postman's HeaderList, so there is no .get()/.has().
 pm.response.body              // Raw body string
 pm.response.text()            // Body as string
 pm.response.json()            // Parse JSON (throws if invalid)
@@ -146,22 +148,36 @@ created with the defaults and stamped with its creation time, so it appears at
 the bottom of that scope in the variables editor rather than above the rows
 that were already there. A scope no script wrote is not persisted at all.
 
-## Variables (`pm.variables`)
+## Collection and Global Variables
 
-Access collection and global variables:
+The other two scopes are reached the same way as the environment, each through
+its own accessor:
 
 ```javascript
-// Get variable (searches: environment → collection → global)
-const value = pm.variables.get('baseUrl');
+const value = pm.collectionVariables.get('baseUrl');
+pm.collectionVariables.set('baseUrl', 'https://api.example.com');
 
-// Set variable
-pm.variables.set('baseUrl', 'https://api.example.com');
+const runId = pm.globals.get('run_id');
+pm.globals.set('run_id', '42');
 ```
 
-**Variable Resolution Order:**
-1. Environment variables
-2. Collection variables
-3. Global variables
+Each `set()` persists to the scope it names, with the same
+keep-the-flags behaviour described for `pm.environment` above.
+
+### `pm.variables` is not supported
+
+Postman's merged accessor - `pm.variables.get(name)`, which searches every scope
+in precedence order - **does not exist in the runtime**. `pm.variables` is
+`undefined`, so `pm.variables.get('baseUrl')` throws
+`TypeError: cannot read property 'get' of undefined`. Use the three scoped
+accessors above.
+
+Scope precedence (environment, then collection, then global) is applied when
+`{{baseUrl}}` is resolved before the request is sent - see
+[Variable Resolution](../app/variable-resolution.md) - not by anything a script
+can call. Implementing `pm.variables` on top of that order is tracked in
+[#184](https://github.com/athrvk/vayu/issues/184); when it lands, this section is
+what it replaces.
 
 ## Console Output
 
@@ -435,7 +451,7 @@ QuickJS supports ES2020 features with some limitations:
 - Can modify `pm.request` - method, url, headers and body - and the edits are
   applied to the request that is sent
   ([rules](#mutating-the-request-pre-request-scripts))
-- Can access `pm.environment` and `pm.variables`
+- Can access `pm.environment`, `pm.collectionVariables` and `pm.globals`
 - Cannot access `pm.response` (request hasn't been sent yet)
 - Run in Design Mode / Send only, not in load tests
 
@@ -443,7 +459,7 @@ QuickJS supports ES2020 features with some limitations:
 
 - Execute after receiving the HTTP response
 - Can access `pm.request` (read-only here - it has already been sent) and `pm.response`
-- Can access `pm.environment` and `pm.variables`
+- Can access `pm.environment`, `pm.collectionVariables` and `pm.globals`
 - Test results are included in the response
 
 ### Load Test Scripts

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1165,6 +1165,70 @@ TEST_F (ScriptEngineTest, NoCryptoBase64OrUrlParserIsExposed) {
 }
 
 // ============================================================================
+// The `pm` surface the docs and the app teach
+// ============================================================================
+//
+// Same reason as the two above: a name that is written down but not installed
+// throws in the user's face, and nothing else notices. `scripting.md` taught
+// `pm.variables` and the Tests panel's quick reference taught
+// `pm.response.headers.get()`; neither has ever existed. These pin the runtime
+// so the docs can be trusted, and so implementing either one flips a test red
+// and forces the doc to be rewritten with it.
+
+TEST_F (ScriptEngineTest, PmVariablesIsAbsentAndTheScopedAccessorsAreNot) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('mergedAccessor', typeof pm.variables);
+        var missing = [];
+        var scopes = ['environment', 'globals', 'collectionVariables'];
+        for (var i = 0; i < scopes.length; i++) {
+            var scope = pm[scopes[i]];
+            if (!scope || typeof scope.get !== 'function'
+                || typeof scope.set !== 'function') {
+                missing.push(scopes[i]);
+            }
+        }
+        pm.environment.set('missingScopes', missing.join(','));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["missingScopes"].value, "")
+    << "a scoped accessor the docs point at instead of pm.variables is gone";
+    // Implementing the merged accessor is #184. When it lands, this expectation
+    // is the one that says "now rewrite the 'not supported' section in
+    // scripting.md and the unsupported list in pm-api-compatibility.md".
+    EXPECT_EQ (env["mergedAccessor"].value, "undefined")
+    << "pm.variables now exists; both docs say it does not";
+}
+
+TEST_F (ScriptEngineTest, ResponseHeadersIsAPlainObjectReadByLowerCasedKey) {
+    // The header names a real response arrives with: `client.cpp` lower-cases
+    // every key as it parses, so this - not the fixture's mixed-case default -
+    // is the shape a script actually sees.
+    response.headers = { { "content-type", "application/json" },
+        { "x-request-id", "abc123" } };
+
+    auto result = engine.execute_test (R"JS(
+        pm.test("the form the Tests panel suggests reads the header", function() {
+            pm.expect(pm.response.headers['content-type']).to.equal('application/json');
+        });
+        pm.environment.set('getType', typeof pm.response.headers.get);
+        pm.environment.set('hasType', typeof pm.response.headers.has);
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed);
+    // Postman's `headers` is a HeaderList with these; ours is a bag. The Tests
+    // panel taught `.get("Content-Type")`, which threw "not a function".
+    EXPECT_EQ (env["getType"].value, "undefined")
+    << "pm.response.headers.get exists now - say so in pm-api-compatibility.md "
+       "and put it back in the Tests panel quick reference";
+    EXPECT_EQ (env["hasType"].value, "undefined");
+}
+
+// ============================================================================
 // The worked examples in scripting.md actually run
 // ============================================================================
 //


### PR DESCRIPTION
## Description

**Plan.** Root cause is that two names are written down and never installed: `setup_pm_object` binds seven members and `variables` is not one of them, and `setup_pm_response` builds `headers` with a plain `JS_NewObject` loop, so it has no `.get`. Both verified still absent at `0cf1fed` before touching anything. The approach is the cheap half the issue asks for - make the surfaces honest, implement nothing - because the merged accessor needs a defined precedence rule across three scopes (properly #184's job) and `headers.get` belongs with the rest of the request/response surface (#185); folding either in would leave the misleading text standing until a feature lands. The alternative I rejected was deleting the `## Variables (pm.variables)` section outright: the two accessors it half-documented (`pm.collectionVariables`, `pm.globals`) had no section of their own anywhere else in `scripting.md`, so deleting it would have removed the only place they were shown. The section is replaced rather than dropped, and the `pm.variables` note under it says explicitly that #184 is what reverses it.

Blast radius traced: `pm.variables` appears in `scripting.md` (one section, two execution-context bullets), in `pm-api-compatibility.md` (already correct, under "Not (yet) supported"), and in one code comment in `useVariableCompletionProvider.ts` that told the next contributor scripts reach variables through `pm.variables.get()` - fixed, since that comment is the rationale for *not* registering brace completion on `javascript`. `pm.response.headers.get` appears only in the Tests panel quick reference. The engine's completion list (`routes/scripting.cpp`) offers neither, so it needed no change.

Verified against the code rather than the issue text: the engine's HTTP client lower-cases every response header name as it parses (`engine/src/http/client.cpp`), which is why `pm.response.headers["content-type"]` is the form that works and the mixed-case one reads back `undefined`. That is now stated in all three surfaces instead of implied.

### Changes

- **`docs/engine/scripting.md`** - `## Variables (pm.variables)` becomes `## Collection and Global Variables` (the two accessors that exist, with the same keep-the-flags `set()` behaviour, confirmed to be the shared `set_variable_preserving` helper) followed by `### pm.variables is not supported`, which names the `TypeError` it throws, points at the scoped accessors, explains that scope precedence is applied during `{{var}}` resolution and not by anything a script can call, and links #184. The two "Can access `pm.environment` and `pm.variables`" bullets now name the three real accessors. The `pm.response.headers` line in the response section says plain object / lower-cased keys / no `.get()`/`.has()`.
- **`app/.../script/script-variants.tsx`** - the Tests quick reference shows `pm.response.headers["content-type"]`, plus a note stating the object-vs-`HeaderList` difference and why the key is lower-cased.
- **`docs/app/pm-api-compatibility.md`** - `pm.response.headers.get/has(...)` added to the unsupported list with the `client.cpp` reason, and a one-line note under the supported table.
- **`app/src/hooks/useVariableCompletionProvider.ts`** - the doc comment no longer cites a nonexistent API as the reason for its own design.

### Adjacent, deliberately not in this diff

The engine's completion list has the same *casing* defect one surface over: `pm.response.headers`'s documentation string and the "Test: Content-Type JSON" snippet both use `pm.response.headers['Content-Type']`, which reads `undefined` against a real response. That is neither of the two APIs this issue is about, and the snippet is inserted into the user's editor, so it deserves its own change - reported on #180 rather than folded in here.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev`: **626/626 pass**, including the two new gtests (`ctest -N` lists them as #111 and #112). `cd app && pnpm test`: **1926 passed, 230 files** (up from 1924 - the new panel case runs once per variant). `pnpm type-check` clean; prettier and ESLint clean on the three touched app files; `clang-format --dry-run -Werror` clean on `script_engine_test.cpp`, which was clean before. `mkdocs build --strict -f .github/mkdocs.yml` succeeds, so the new `../app/variable-resolution.md` link resolves and the removed heading had no inbound anchors.

**Mutation-checked, all three:**

- Restoring `'pm.response.headers.get("Content-Type")'` in the panel turns the new `suggests only header reads that the runtime supports` case red (the `pre` variant's copy stays green, which is correct - it never carried the line).
- Flipping the two expectations to the implemented-API values (`typeof pm.variables === "object"`, `typeof headers.get === "function"`) and rebuilding fails both gtests, so they read the live runtime rather than passing vacuously.
- Changing the gtest's header read to `['Content-Type']` fails `ResponseHeadersIsAPlainObjectReadByLowerCasedKey`, pinning the lower-cased form specifically and not just "some key works".

New tests:
- `ScriptEngineTest.PmVariablesIsAbsentAndTheScopedAccessorsAreNot` - `pm.variables` is `undefined` and all three scoped accessors expose `get`/`set`, mirroring `NoCryptoBase64OrUrlParserIsExposed`.
- `ScriptEngineTest.ResponseHeadersIsAPlainObjectReadByLowerCasedKey` - headers set the way `client.cpp` stores them; the bracket read the panel now suggests passes, and `.get`/`.has` are absent. The existing `ResponseHeaders` test uses the fixture's mixed-case defaults, which no real response has - left alone, since rewriting it is not this issue's scope.
- `script-panels.test.tsx` - the quick reference contains no `headers.get(` call in either variant, and the post variant carries the working form and the lower-casing note.

No pre-existing failures reproduced on this branch.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #182

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvwFtQ7sdEdMnou1wo3Y72)_