### PR TITLE
docs: use the overview screenshot as the load-test hero shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Vayu is a free, open source desktop app for Windows, macOS, and Linux that merge
 
 ## See it in action
 
-![Load test dashboard](docs/images/vayu-loadtest4.png)
-*The load-test dashboard, mid-run at 51,922 req/s. Throughput, latency percentiles, and error counters stream live from the C++ engine while the UI stays responsive.*
+![Load test dashboard](docs/images/vayu-loadtest2.png)
+*The load-test dashboard: 52,738 req/s at concurrency 64, 738,406 requests, 100% success. Throughput, latency percentiles, and error counters stream live from the C++ engine while the UI stays responsive, with every run kept in the history sidebar.*
 
 ![GraphQL request builder](docs/images/vayu-graphql.png)
 *REST and GraphQL request builder with collections, layered environments, and Postman-compatible scripting.*
@@ -50,7 +50,9 @@ The HTTP core is a multi-worker libcurl event loop in C++20, isolated from the E
 
 Vayu **matches `wrk` and edges past `vegeta`** - all three converge on the same ~57k system throughput ceiling, and at that ceiling the machine is still 79% idle, so it is the target saturating, not the client. Full methodology, the concurrency sweep, the `workers` A/B, tuning notes, and a one-command reproduction script are in **[Engine Benchmarks](docs/engine/benchmarks.md)**.
 
-**And from the UI, not just the CLI.** The dashboard [above](#see-it-in-action) is a 60-second run started from the app's own Load Test panel: **51,922 req/s - 3,115,391 requests, zero errors, zero dropped**, p50 1.20 ms / p99 1.52 ms, with the charts streaming live throughout.
+**And from the UI, not just the CLI.** A 60-second run started from the app's own Load Test panel sustained **51,922 req/s - 3,115,391 requests, zero errors, zero dropped**, p50 1.20 ms / p99 1.52 ms, with the charts streaming live throughout:
+
+![In-app load test sustaining 51,922 req/s over 60 seconds with 3,115,391 requests and a 0.0% error rate](docs/images/vayu-loadtest4.png)
 
 A broader comparison against k6, JMeter, and the Postman collection runner is in progress - follow [the issues board](https://github.com/athrvk/vayu/issues) to track it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ of it on your machine: no account, no cloud sync, no telemetry.
 [Use it from your agent](#drive-vayu-from-your-coding-agent){ .md-button }
 [See what it does](#what-you-can-do){ .md-button }
 
-![The load-test dashboard mid-run at 51,922 req/s: throughput, latency percentiles and error counters streaming live from the C++ engine while the UI stays responsive.](images/vayu-loadtest4.png){ .shot }
+![The load-test dashboard at 52,738 req/s and 738,406 requests with a 100% success rate: throughput, latency percentiles and error counters streaming live from the C++ engine while the UI stays responsive.](images/vayu-loadtest2.png){ .shot }
 
 ## Install
 


### PR DESCRIPTION
## Description

Follow-up to #202. Swaps the load-test hero on `README.md` and the docs landing page from `vayu-loadtest4.png` (the charts view) to `vayu-loadtest2.png` (the run overview).

The overview shot shows the app **in context** rather than charts alone - the history sidebar with the whole sweep, the request tabs, the stat cards, and the status-code distribution - which reads better as a "see it in action" image. Its run: **52,738 req/s at concurrency 64, 738,406 requests, 100% success, 0 errors**.

Two things had to move with the image, because the surrounding prose was written against the old one:

- **Captions now state the numbers the screenshot actually shows.** The previous caption said "mid-run at 51,922 req/s", which belongs to the 60-second run, not this one.
- **The Performance section stops cross-referencing the hero.** It read *"The dashboard above is a 60-second run … 51,922 req/s - 3,115,391 requests"*, which would now point at a 14-second run showing 52,738 and 738,406. The 60 s run is re-embedded there instead, directly beneath the claim it evidences.

Net effect: each screenshot sits next to the numbers it proves, and no figure in the README describes a picture other than the one beside it. `docs/engine/benchmarks.md` is unchanged - it uses the 60 s run as the proof for its own section and that pairing was already correct.

## Type of Change

- [x] Documentation update

## Testing

- `mkdocs build --strict -f .github/mkdocs.yml` - passes, which validates the changed image path on the landing page.
- Verified every `vayu-loadtest*` reference across `README.md`, `docs/index.md` and `docs/engine/benchmarks.md` resolves to a file that exists, and that each caption matches the run in its image.
- Docs-only diff, so no engine or app suite was run - per CLAUDE.md, no test could go from green to red here.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - n/a, docs only
- [x] I have updated documentation - this PR *is* the documentation update

## Related Issues

No `Closes`. Worth knowing before this becomes the hero image: the history sidebar visible in it renders each run's concurrency as "N workers" ("256 workers", "64 workers"), which is #201 - the label collides with the engine's `workers` setting, and those runs actually executed with `workers = 8`. The screenshot is an accurate picture of the shipped UI; it just puts a known mislabel on the front page until #201 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WYwLmdqWjrzGje8isjtnG

---
_Generated by [Claude Code](https://claude.ai/code/session_014WYwLmdqWjrzGje8isjtnG)_