### PR TITLE
fix(app): stop the import mutation retrying a committed bulk apply

### DIFF
--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -138,7 +138,11 @@ export function ImportModal() {
 			});
 			handleClose();
 		} catch (e) {
-			// Import failed (orchestrator rolled back) - surface it instead of silently re-enabling.
+			// There is no rollback since #145: the engine write is atomic, so a validation
+			// failure persisted nothing - but a failure *after* it (the id-map check, the
+			// globals write) leaves the tree committed. Surface the error and leave the
+			// modal in its error phase; the mutation invalidates on every outcome, so
+			// whatever did land is already visible behind this dialog.
 			setError((e as Error).message || "Import failed");
 			setPhase("error");
 		}

--- a/app/src/queries/import.test.ts
+++ b/app/src/queries/import.test.ts
@@ -15,6 +15,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 import { apiService } from "@/services/api";
+import { QUERY_CACHE } from "@/config/cache";
 import { createImportApi, useImportMutation } from "./import";
 import { queryKeys } from "./keys";
 import type { ImportResult } from "@/services/importers/types";
@@ -43,8 +44,50 @@ describe("createImportApi", () => {
 	});
 });
 
+/**
+ * The hook's retry override is only meaningful against the *app's* defaults, so the
+ * wrapper reproduces them instead of using a bare `new QueryClient()` (which defaults
+ * mutations to no retry and would make the retry test vacuous).
+ */
+function appDefaultsClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: { mutations: { retry: QUERY_CACHE.DEFAULT_MUTATION_RETRY } },
+	});
+}
+
+const COLLECTION_ONLY: ImportResult = {
+	collections: [
+		{
+			name: "Imported",
+			description: "",
+			variables: {},
+			auth: { mode: "none" },
+			preRequestScript: "",
+			postRequestScript: "",
+			children: [],
+			requests: [],
+		},
+	],
+	environments: [],
+	globals: {},
+	meta: {
+		format: "Postman Collection v2.1",
+		requestCount: 0,
+		folderCount: 1,
+		environmentCount: 0,
+		globalCount: 0,
+		skipped: [],
+		nonExecutableAuth: 0,
+	},
+};
+
 describe("useImportMutation", () => {
-	beforeEach(() => vi.clearAllMocks());
+	// clearAllMocks wipes calls but keeps implementations, so the per-test
+	// reject/resolve overrides below would leak into whatever runs after them.
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(apiService.applyImport).mockResolvedValue({ idMap: { c1: "col_1" } });
+	});
 
 	/**
 	 * A globals import writes the singleton on the engine. Without an invalidation
@@ -82,5 +125,61 @@ describe("useImportMutation", () => {
 		expect(apiService.updateGlobals).toHaveBeenCalledWith({
 			token: { value: "t", enabled: true },
 		});
+	});
+
+	/**
+	 * `POST /import/apply` is create-only and has no idempotency key, so a retry after a
+	 * lost response (the tree committed, the 30s fetch timeout fired) is a second full
+	 * copy of it - reported to the user as one clean import.
+	 */
+	it("never re-POSTs the bulk import when the apply call rejects", async () => {
+		// Guard: with no retry in the defaults this test would pass while asserting nothing.
+		expect(QUERY_CACHE.DEFAULT_MUTATION_RETRY).toBeGreaterThan(0);
+		vi.mocked(apiService.applyImport).mockRejectedValue(new Error("Request timed out"));
+
+		const qc = appDefaultsClient();
+		const wrapper = ({ children }: { children: ReactNode }) =>
+			createElement(QueryClientProvider, { client: qc }, children);
+		const { result } = renderHook(() => useImportMutation(), { wrapper });
+
+		await expect(
+			result.current.mutateAsync({
+				result: COLLECTION_ONLY,
+				opts: { importEnvironments: true, importScripts: true },
+			})
+		).rejects.toThrow("Request timed out");
+
+		expect(apiService.applyImport).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * The id-map check throws *after* the atomic apply committed the tree. Invalidating
+	 * only in onSuccess left that tree invisible - `refetchOnWindowFocus` is off - until
+	 * the user reloaded the app.
+	 */
+	it("invalidates the caches when the orchestrator throws after a committed apply", async () => {
+		vi.mocked(apiService.applyImport).mockResolvedValue({ idMap: {} });
+
+		const qc = appDefaultsClient();
+		const spy = vi.spyOn(qc, "invalidateQueries");
+		const wrapper = ({ children }: { children: ReactNode }) =>
+			createElement(QueryClientProvider, { client: qc }, children);
+		const { result } = renderHook(() => useImportMutation(), { wrapper });
+
+		await expect(
+			result.current.mutateAsync({
+				result: COLLECTION_ONLY,
+				opts: { importEnvironments: true, importScripts: true },
+			})
+		).rejects.toThrow(/Import incomplete/);
+
+		for (const queryKey of [
+			queryKeys.collections.all,
+			queryKeys.requests.all,
+			queryKeys.environments.all,
+			queryKeys.globals.all,
+		]) {
+			expect(spy).toHaveBeenCalledWith({ queryKey });
+		}
 	});
 });

--- a/app/src/queries/import.ts
+++ b/app/src/queries/import.ts
@@ -24,11 +24,24 @@ export function createImportApi(): ImportApi {
 export function useImportMutation() {
 	const queryClient = useQueryClient();
 	return useMutation({
+		// `POST /import/apply` is create-only, atomic and carries no idempotency key -
+		// the engine mints fresh ids per temp id on every call - so a second attempt
+		// is a second full copy of the tree, not a resumed write. The shared
+		// QueryClient defaults mutations to `retry: 1`, and TanStack re-invokes
+		// `mutationFn` whole, so a *lost response* (commit succeeded, the 30s fetch
+		// timeout fired) would duplicate everything and then report one clean import.
+		// Retrying safely needs an engine-side idempotency key; until then, never.
+		retry: false,
 		mutationFn: async ({ result, opts }: { result: ImportResult; opts: ImportOptions }) => {
 			const withTempIds = assignTempIds(result);
 			await new ImportOrchestrator(createImportApi()).run(withTempIds, opts);
 		},
-		onSuccess: () => {
+		// Settled, not success: `run()` can throw *after* the tree is committed (the
+		// id-map completeness check, or the globals write behind it), and with
+		// `refetchOnWindowFocus: false` an uninvalidated sidebar hides a persisted
+		// import until a manual reload. Invalidating after a failure that committed
+		// nothing only costs a refetch.
+		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.collections.all });
 			queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
 			queryClient.invalidateQueries({ queryKey: queryKeys.requests.all });

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -74,12 +74,18 @@ items one POST at a time and had to wire the tree itself - which is the only rea
 - The engine generates every real id and returns an `idMap` keyed by temp id. The
   orchestrator checks that map covers every item it sent and throws
   `Import incomplete: …` otherwise - a silently skipped item would otherwise read as a
-  clean import. Nothing else consumes the real ids: `useImportMutation` invalidates the
-  collection / request / environment queries, which refetch.
-- **No rollback.** The engine write is atomic (validation over the whole payload, then one
-  transaction), so a failure means nothing was persisted and the error the modal shows is
-  the engine's, naming the item that broke. The old per-item loop needed best-effort
-  deletion of already-created roots; that code is gone.
+  clean import. Note this throw happens *after* the tree is committed. Nothing else
+  consumes the real ids: `useImportMutation` invalidates the collection / request /
+  environment / globals queries, which refetch.
+- **No rollback, and no retry.** The engine write is atomic (validation over the whole
+  payload, then one transaction), so a *rejected* payload persisted nothing and the error
+  the modal shows is the engine's, naming the item that broke. The old per-item loop needed
+  best-effort deletion of already-created roots; that code is gone. What atomicity does
+  **not** cover is a lost response: `/import/apply` has no idempotency key and mints fresh
+  ids per temp id on every call, so a second attempt after a committed-but-unanswered write
+  is a second copy of the whole tree. `useImportMutation` therefore sets `retry: false`,
+  overriding the QueryClient's `retry: 1` mutation default, and invalidates in `onSettled`
+  rather than `onSuccess` so a tree that landed behind a later failure is still visible.
 - **Globals are the one write outside that payload.** They are an engine singleton behind
   `POST /globals`, not a tree item with a temp id, so `applyGlobals` runs as a second
   request *after* the apply and its id-map check - nothing may fail behind it, since it is
@@ -122,6 +128,7 @@ Parsers emit drafts, not engine rows. A draft's `tempId` is absent until
 |---|---|---|
 | `collections` | `CollectionDraft[]` | Root collections (`parentId = null`) |
 | `environments` | `EnvironmentDraft[]` | Persisted only if `importEnvironments` |
+| `globals` | `Record<string, VariableValue>` | Variables for the globals scope, keyed by name. Not a draft list - globals are an engine singleton, so there is no name and no temp id to assign. Required, so every parser states its answer: `{}` for all but the Postman globals export |
 | `meta` | `ImportMeta` | Counts + lossy-import signals for the Preview UI |
 
 **`CollectionDraft`** - `name`, `description`, `variables: Record<string, VariableValue>`,
@@ -137,7 +144,7 @@ execution time), `preRequestScript`, `postRequestScript`.
 **`EnvironmentDraft`** - `name`, `description`, `variables: Record<string, VariableValue>`.
 
 **`ImportMeta`** - `format`, `fileName?`, `requestCount`, `folderCount`,
-`environmentCount`, `skipped: SkippedItem[]`, `nonExecutableAuth: number`.
+`environmentCount`, `globalCount`, `skipped: SkippedItem[]`, `nonExecutableAuth: number`.
 
 **`SkippedItem`** - `{ kind: "websocket" | "grpc" | "api_spec" | "unit_test" | "file_body", count }`.
 Surfaces work Vayu can't represent so the Preview can warn instead of silently dropping.
@@ -168,6 +175,7 @@ the environment drafts). Honoring is **per-parser**:
 | Parser | `importScripts` | `importEnvironments` |
 |---|---|---|
 | Postman v2.1 / v2.0 | Honored - scripts emitted as `""` when false | Moot - collection files embed no environments |
+| Postman Environment / Globals | Moot - this shape carries no scripts | Honored - gates both `environments` and `globals` at parse time, so the Preview counts report 0 |
 | Insomnia v4 | Honored | Honored - `environment` resources become `EnvironmentDraft`s |
 | OpenAPI 3.0 | Ignored - never generates scripts | Ignored - never generates environments |
 | OpenAPI 2.0 (Swagger) | Ignored | Ignored |


### PR DESCRIPTION
## Description

Part of #192. All four findings in #194 were re-verified against current master (`9fc4b9d`) before editing - line anchors had shifted slightly but every defect is still present as described.

**Plan (root cause, approach, rejected alternative).** The root cause is a non-idempotent write sitting under generic retry infrastructure: `useImportMutation` declared no `retry`, so it inherited the shared QueryClient's `mutations: { retry: 1 }` (`app/src/lib/query-client.ts:29`, `app/src/config/cache.ts:24`), and TanStack re-invokes `mutationFn` *whole* on rejection. `POST /import/apply` is create-only, atomic, and carries no idempotency key - `claim_all` mints a fresh real id per temp id on every call - so the retry is not a resumed write but a second full copy of the tree. The trigger is ordinary: a commit that outlives the flat 30s request timeout, or a response lost after commit. Atomicity does not protect against that, only against a *rejected* payload. The approach is the narrow one the issue prescribes: `retry: false` on the mutation, and invalidation moved from `onSuccess` to `onSettled` so a tree committed behind a later throw is still visible. I rejected the alternative of invalidating from a `finally` inside `ImportOrchestrator.run`: the orchestrator takes an injected `ImportApi` precisely so it knows nothing about TanStack, and giving it a `QueryClient` would couple the parser/persistence layer to renderer cache plumbing for no gain. The deeper fix - an engine-side idempotency key - is an explicit non-goal of #194 and is left untouched.

**Changes**

- **`app/src/queries/import.ts`** - `retry: false`, and the four `invalidateQueries` calls move to `onSettled`. Both carry a comment naming the constraint (non-idempotent endpoint; a post-commit throw with `refetchOnWindowFocus: false`) rather than restating the code.
- **`app/src/modules/collections/ImportModal.tsx`** - the error-path comment claimed "orchestrator rolled back", which has been false since #145 removed the rollback. It now states the actual semantics: a rejected payload persisted nothing, but a failure *after* the apply (the id-map check, the globals write) leaves the tree committed, and invalidation has already made it visible.
- **`docs/app/import-collections/README.md`** - the drift behind #155: a `globals` row in the `ImportResult` table, `globalCount` in the `ImportMeta` bullet, and a Postman Environment/Globals row in the `ImportOptions` honoring table (`importScripts` moot - the shape carries no scripts; `importEnvironments` honored, gating both `environments` and `globals` at parse time per `postman-environment.ts:56-73`). The "No rollback" bullet is also corrected in the same commit, since it asserted "a failure means nothing was persisted" - the exact misconception being fixed in the code comment two files over.

**Blast radius traced.** `useImportMutation` has one consumer (`ImportModal.handleImport`); it is the only caller of `ImportOrchestrator`, which is the only caller of `applyImport`. `retry: false` is scoped to this mutation, so no other mutation's retry policy changes. `onSettled` fires on both outcomes, so the success path's invalidation is unchanged - the globals invalidation the existing test pins still runs. Nothing reads the mutation's `onSuccess` context, so there was no ordering to preserve.

**Deliberate deviation:** none from the issue's fix pathway. The one addition beyond its literal list is the README "No rollback" bullet above, on the docs-in-the-same-commit rule.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

Run on this branch at `41636a6`, on Linux. App-only change (no C++ touched), so the engine build and `ctest` were not run - no engine test could go from green to red here.

- `cd app && pnpm test` - **1928 passed, 230 files** (1926 before; 2 tests added to `app/src/queries/import.test.ts`).
- `cd app && pnpm type-check` - clean.
- `npx eslint` on the three touched app files - no diagnostics.
- `npx prettier --check` on the three touched app files - clean. `docs/app/import-collections/README.md` is **not** prettier-clean, and was not clean on the base commit either, so it was deliberately left unformatted per CLAUDE.md.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.

Both new tests are mutation-checked, run and confirmed rather than reasoned about:

| Test | Fix reverted | Result |
|---|---|---|
| `never re-POSTs the bulk import when the apply call rejects` | drop `retry: false` | fails - `expected "vi.fn()" to be called 1 times, but got 2 times` |
| `invalidates the caches when the orchestrator throws after a committed apply` | `onSettled` back to `onSuccess` | fails - `expected "invalidateQueries" to be called with [{ queryKey: ['collections'] }]`, number of calls: 0 |

The retry test builds its `QueryClient` with `retry: QUERY_CACHE.DEFAULT_MUTATION_RETRY` rather than a bare `new QueryClient()` - a bare client defaults mutations to no retry, which would have made the test assert nothing - and asserts `DEFAULT_MUTATION_RETRY > 0` up front so it cannot silently become vacuous if that default is ever lowered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #194

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqQG4juNSBA6YzwoepoDkV)_