### PR TITLE
fix(engine): make SuccessCountNeverExceedsTotalRequests deterministic

### DIFF
--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -445,10 +445,34 @@ TEST_F (MetricsCollectorTest, SuccessCountNeverExceedsTotalRequests) {
         writer_done.store (true);
     });
 
+    // Sample success_count() *before* total_requests(), and into locals: the
+    // two reads must be ordered, and this is the only order the invariant is
+    // stated over. success_count() loads total_requests_ first internally, so a
+    // total read afterwards is never stale relative to it. Passing both calls
+    // straight to ASSERT_LE left their evaluation order unspecified - compilers
+    // commonly take the right operand first, which reads a total from before
+    // the writer's increment and compares it against a success count from
+    // after, reporting a violation the collector does not have.
+    //
+    // The check is non-fatal so a real violation joins the writer before
+    // reporting. A fatal assertion returns from the test body with `writer`
+    // still joinable, and ~std::thread then calls std::terminate - killing the
+    // process before gtest prints why.
+    size_t observed_success = 0;
+    size_t observed_total   = 0;
+    bool inverted           = false;
     while (!writer_done.load ()) {
-        ASSERT_LE (collector->success_count (), collector->total_requests ());
+        observed_success = collector->success_count ();
+        observed_total   = collector->total_requests ();
+        if (observed_success > observed_total) {
+            inverted = true;
+            break;
+        }
     }
     writer.join ();
+
+    EXPECT_FALSE (inverted) << "success_count() " << observed_success
+                            << " exceeded total_requests() " << observed_total;
 
     EXPECT_EQ (collector->success_count (), 0u);
     EXPECT_EQ (collector->total_errors (), static_cast<size_t> (kIterations));


### PR DESCRIPTION
## Description

Both defects in #179 were re-verified against current master (`e5eaf0b`) before editing - the line anchors had shifted (the assertion is at `metrics_collector_test.cpp:449` now, not 436), but both are present exactly as described, and `record_error` still bumps `total_requests_` before `total_errors_` (`metrics_collector.cpp:172-174`).

**Plan (root cause, approach, rejected alternative).** The root cause is that the assertion compared two counters sampled at two different instants and called the gap an invariant break. `ASSERT_LE` forwards both calls as arguments, so their evaluation order is unspecified; compilers commonly take the right operand first, which reads `total_requests()` as `0`, lets the writer complete its first `record_error`, and only then computes `success_count()` as `1` from `total=1, errors=0` - the reported `1 vs 0`. The approach is to sample into locals in the one order the invariant is actually stated over: **`success_count()` first, `total_requests()` second**. That order is sound rather than merely conventional - `success_count()` loads `total_requests_` internally before it returns, and both counters are monotonic, so a total read afterwards is never stale relative to the success count derived from it. The reverse order compares a total from *before* the writer's increment against a success count from *after*, which is the failing interleaving.

I rejected the obvious-looking alternative of relaxing the assertion (widening it by a tolerance, or dropping the in-loop check for a post-join one): both would stop the test detecting the defect it exists for. The unguarded subtraction this test guards wraps to a huge `size_t`, which still trips `observed_success > observed_total` under the new sampling - so the fix removes the false failure without removing the true one. I also kept `success_count()`'s ordering as an implementation fact the comment states explicitly, rather than reaching into `MetricsCollector` to add a snapshot accessor: this is a test-only defect and the issue rules a production change out.

The second defect is separate and needed its own fix: the fatal `ASSERT_` returned from the test body while `writer` was still joinable, so `~std::thread` called `std::terminate` and the process died before gtest printed anything. The check is now non-fatal and `break`s, recording the observed pair, so a genuine violation joins the writer and reports through gtest.

**Blast radius traced.** Test-only, one function - `git diff --stat` is a single file. No production header or source is touched, so no caller of `success_count()` / `total_requests()` changes behaviour (`average_latency()`, `average_queue_wait()` and `error_rate()` in `metrics_collector.hpp:213-238` are the readers, all untouched). The issue's "check the sibling concurrency tests in the same file" was done: `SampleWindowSafeUnderConcurrentWriters`, `ThreadSafePerCodeCounts`, `ThreadSafeRecording` and `HistogramLosesNoSamplesUnderConcurrentWriters` all `join()` first and then use `EXPECT_` only, so line 449 was the file's only `ASSERT_`-with-a-live-thread. A wider sweep of the other engine test files was **not** done - it is outside this issue's scope; say the word and I will file it separately.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

All run on this branch at `4490d87`, on Linux (`python build.py -e -t`, then the `linux-dev` preset binary).

- `cd engine && ctest --preset linux-dev --output-on-failure` - **640 passed, 0 failed**.
- **500 consecutive runs of the target test: 500/500 pass** (the issue's acceptance criterion).

Both defects were mutation-checked by restoring the original assertion in place, rebuilding, and re-running - then restoring the fix:

| State | 500 runs | Aborted (`terminate called`) |
|---|---|---|
| `ASSERT_LE (success_count (), total_requests ())` (reverted) | **483 pass / 17 fail** | 17 of 17 |
| this branch | **500 pass / 0 fail** | - |

So the revert reproduces the flake at ~1 in 29 here (the issue measured ~1 in 200), and every one of those failures killed the process - which is the second defect reproducing at the same time.

For the second acceptance criterion - *a deliberate failure reports through gtest rather than aborting* - I tripped the check deterministically (`>` widened to `>=`, so the first `0 > 0` iteration fires) and got a clean gtest report with the observed pair and a normal summary, no `terminate called`:

```
metrics_collector_test.cpp:474: Failure
Value of: inverted
  Actual: true
Expected: false
success_count() 0 exceeded total_requests() 0
[  FAILED  ] MetricsCollectorTest.SuccessCountNeverExceedsTotalRequests
```

Lint and format:

- `clang-tidy -p build tests/metrics_collector_test.cpp` - the only two diagnostics are pre-existing sign-conversion warnings at lines 345 and 360, inside `ThreadSafePerCodeCounts`, which this PR does not touch (the compiler flags line 360 on master too). The added lines produce none. Note the tool also errors on `engine/.clang-tidy`'s `ExcludeHeaderFilterRegex` key, which clang-tidy 18 (the Ubuntu 24.04 default) does not know - pre-existing environment drift, unrelated to this change and not touched here.
- `clang-format --dry-run --Werror` on the file reports the **same 19 violations as master**, merely shifted by the added lines (723/724 → 747/748). The file was not clang-format-clean before, so per CLAUDE.md it was deliberately left unformatted rather than reformatted in this diff.
- **App suite and type-check were not run**: no TypeScript changed, so no app test could go from green to red.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - the test *is* the fix; mutation-checked both directions above
- [x] I have updated documentation - none needed, the issue's Docs section is "None - test-only"

## Related Issues
Closes #179

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMn8bd4XSiBwjfGSSyQBrA)_