### PR TITLE
feat(engine): variable scopes gain has/unset/clear/toObject, add merged pm.variables

### DIFF
--- a/app/src/hooks/useVariableCompletionProvider.ts
+++ b/app/src/hooks/useVariableCompletionProvider.ts
@@ -18,9 +18,9 @@
  * **Registered for the body languages only.** `json`, `plaintext` and `graphql`
  * are what `CodeEditor` mounts for a request body. Deliberately *not*
  * `javascript`: the script editors are the one place `{{name}}` is not the
- * syntax - a script reaches variables through `pm.environment.get()` and its
- * sibling scope accessors (there is no `pm.variables`), and
- * offering brace completion there would teach the wrong thing.
+ * syntax - a script reaches variables through `pm.environment.get()`, its
+ * sibling scope accessors, or the merged `pm.variables.get()`, and offering
+ * brace completion there would teach the wrong thing.
  *
  * Called once, in App - a completion provider is global per language, so one
  * registration covers every editor instance. The same shape as

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -20,9 +20,10 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()` |
 | Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url`, `.method`, `.headers`, `.body`                                 |
-| Environment         | `pm.environment.get(name)`, `pm.environment.set(name, value)`                    |
-| Globals             | `pm.globals.get(name)`, `pm.globals.set(name, value)`                            |
-| Collection vars     | `pm.collectionVariables.get(name)`, `pm.collectionVariables.set(name, value)`    |
+| Environment         | `pm.environment.get/set/has/unset/clear/toObject`                                |
+| Globals             | `pm.globals.get/set/has/unset/clear/toObject`                                    |
+| Collection vars     | `pm.collectionVariables.get/set/has/unset/clear/toObject`                        |
+| Merged variables    | `pm.variables.get(name)`, `.has(name)`, `.toObject()` - read-only, see below     |
 | Console             | `console.log/info/warn/error`                                                    |
 
 `pm.response.headers` is a plain object keyed by the **lower-cased** header name -
@@ -32,7 +33,19 @@ Variable writes persist to the scope they target (environment / collection / glo
 participate in [variable resolution](./variable-resolution.md). Calling `set(name, value)`
 on a variable that already exists updates only its value - the existing `secret` flag,
 `enabled` flag and `type` are preserved. A `set` on a new name creates it with the defaults
-(not secret, enabled, `type: "string"`).
+(not secret, enabled, `type: "string"`). `unset(name)` removes it outright, which is not
+the same as setting it to `""`: an emptied variable is still an enabled row that
+`{{name}}` resolves to.
+
+`get`, `has` and `toObject` read only **enabled** variables, so a row unticked in the
+variables editor is invisible to a script; `unset` and `clear` remove it regardless.
+
+`pm.variables` resolves a name across the scopes - environment, then collection, then
+global - the same order `{{name}}` uses. It is read-only: **`pm.variables.set()` throws**,
+because Postman writes it to a per-request *local* scope that Vayu does not have, and both
+alternatives (persisting to the environment, or dropping the write) would misrepresent
+what happened. The error names the three scoped setters. See
+[scripting.md](../engine/scripting.md#variables-pmvariables).
 
 ### Assertion chains (`pm.expect` / `pm.response.to`)
 
@@ -78,8 +91,13 @@ report PASS against a broken API.
 These Postman APIs are **not** implemented - scripts that rely on them will fail:
 
 - `pm.sendRequest(...)` - sending auxiliary requests from a script
-- `pm.variables.*` - the merged/resolved variable accessor (use the scoped
-  `pm.environment` / `pm.collectionVariables` / `pm.globals` instead)
+- `pm.variables.set(...)` - throws; Vayu has no local scope to write to, so name
+  one of the three scoped setters instead. The read half (`get`/`has`/`toObject`)
+  is supported - see above
+- `replaceIn(...)` on any scope - `{{name}}` interpolation of an arbitrary string.
+  The engine does no `{{var}}` interpolation at all (it is resolved app-side
+  before the payload arrives), so there is nothing to expose
+- `pm.environment.name` - the active environment's name
 - `pm.response.headers.get/has(...)` - Postman's `headers` is a `HeaderList`;
   Vayu's is a plain object keyed by the **lower-cased** header name, so read it
   as `pm.response.headers['content-type']`. The engine's HTTP client lower-cases

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -152,6 +152,25 @@ scripts are dropped); the **engine** joins the surviving parts with a blank
 line and runs the result. See `docs/engine/architecture.md` → *Request
 composition boundary* for the wire shape.
 
+### Reading a variable from a script
+
+A script does not see `{{name}}` - those are already resolved by the time the
+payload reaches the engine. It reads a scope by name (`pm.environment.get`,
+`pm.collectionVariables.get`, `pm.globals.get`) or reads across all three with
+`pm.variables.get`, which walks **environment → collection → global** and stops
+at the first scope that has the name enabled - this page's priority order, read
+from the top down.
+
+One difference to know about: the script side has a single collection scope, and
+the engine fills it from the request's **immediate parent collection only**
+(`execution.cpp`, where `collectionVariables` is loaded). The chain merge
+described above is done app-side for `{{name}}`, so a variable defined on an
+ancestor collection is visible to `{{name}}` and *not* to
+`pm.collectionVariables.get` / `pm.variables.get`. Read such a value from the
+environment or globals, or define it on the request's own collection. See
+[pm API compatibility](./pm-api-compatibility.md) and
+[scripting.md](../engine/scripting.md#variables-pmvariables).
+
 ---
 
 ## Scope labels

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -176,10 +176,40 @@ created with the defaults and stamped with its creation time, so it appears at
 the bottom of that scope in the variables editor rather than above the rows
 that were already there. A scope no script wrote is not persisted at all.
 
+### The six methods every scope has
+
+| Method | Returns | Notes |
+|---|---|---|
+| `get(name)` | the value, cast by its declared type, or `undefined` | a disabled variable reads as `undefined` |
+| `set(name, value)` | `undefined` | keeps `secret` / `enabled` / `type` / creation time |
+| `has(name)` | `boolean` | true only for the rows `get()` can read, so a disabled variable is `false` |
+| `unset(name)` | `undefined` | removes the name; removing one that is not there is not an error |
+| `clear()` | `undefined` | empties **this** scope only, disabled rows included |
+| `toObject()` | plain object | every enabled variable, values cast by type; a snapshot, not a live view |
+
+```javascript
+if (pm.environment.has('auth_token')) {
+	pm.environment.unset('auth_token');
+}
+
+console.log(pm.environment.toObject());
+```
+
+`unset()` is not the same as `set(name, '')`. An emptied variable is still an
+enabled row, so `{{auth_token}}` resolves to the empty string; an unset one is
+gone, and the template resolves as it does for a name nobody defined. The
+removal reaches disk the same way any other write does - the scope is rewritten
+after the run because the map the script left differs from the stored one.
+
+A scope the run was not given (a design run with no active environment, say)
+behaves as an empty one: `get` is `undefined`, `has` is `false`, `toObject` is
+`{}`, and writes go nowhere. A script cannot see which scopes a run carries, so
+this is deliberately not an error.
+
 ## Collection and Global Variables
 
 The other two scopes are reached the same way as the environment, each through
-its own accessor:
+its own accessor, and answer the same six methods:
 
 ```javascript
 const value = pm.collectionVariables.get('baseUrl');
@@ -192,20 +222,46 @@ pm.globals.set('run_id', '42');
 Each `set()` persists to the scope it names, with the same
 keep-the-flags behaviour described for `pm.environment` above.
 
-### `pm.variables` is not supported
+`pm.collectionVariables` is the request's **immediate parent collection**, not
+the whole collection chain. `{{name}}` resolution merges every ancestor
+root-first before the payload reaches the engine, so a variable defined on a
+parent collection resolves in a URL and is *not* readable from a script. Define
+it on the request's own collection, or in the environment, if a script needs it.
 
-Postman's merged accessor - `pm.variables.get(name)`, which searches every scope
-in precedence order - **does not exist in the runtime**. `pm.variables` is
-`undefined`, so `pm.variables.get('baseUrl')` throws
-`TypeError: cannot read property 'get' of undefined`. Use the three scoped
-accessors above.
+## Variables (`pm.variables`)
 
-Scope precedence (environment, then collection, then global) is applied when
-`{{baseUrl}}` is resolved before the request is sent - see
-[Variable Resolution](../app/variable-resolution.md) - not by anything a script
-can call. Implementing `pm.variables` on top of that order is tracked in
-[#184](https://github.com/athrvk/vayu/issues/184); when it lands, this section is
-what it replaces.
+`pm.variables` reads a name without naming its scope, resolving
+**environment, then collection, then global** and stopping at the first scope
+that has it enabled. That is the same order `{{baseUrl}}` is resolved in before
+the request is sent (see
+[Variable Resolution](../app/variable-resolution.md)), so a script and a URL in
+the same request cannot read one name two different ways.
+
+```javascript
+const baseUrl = pm.variables.get('baseUrl'); // wherever it is defined
+if (pm.variables.has('debug')) { /* ... */ }
+console.log(pm.variables.toObject()); // all three scopes, merged
+```
+
+It has `get`, `has` and `toObject` - and no `unset` or `clear`, because it owns
+no scope to remove a name from.
+
+**`pm.variables.set()` throws.** In Postman it writes to a *local* scope that
+lives for one request and is never stored; Vayu has no such scope. Writing to
+the environment instead would persist a value the script author expects to
+vanish, and quietly dropping the call would lose a write they believe happened,
+so it fails loudly and names the three scopes that do exist:
+
+```
+TypeError: pm.variables.set is not supported: Vayu has no local variable scope.
+Use pm.environment.set(), pm.collectionVariables.set() or pm.globals.set() to
+choose where the value is stored.
+```
+
+`replaceIn()` - Postman's `{{name}}` interpolation of an arbitrary string - is
+still absent from every scope. The engine deliberately does no `{{var}}`
+interpolation at all (it is resolved app-side before the payload arrives), so
+there is nothing for it to call.
 
 ## Console Output
 

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -362,6 +362,100 @@ nlohmann::json get_script_completions () {
     { "sortText", "1_pm_collectionVariables_set" } });
 
     // ========================================
+    // has / unset / clear / toObject - identical on all three scopes, so
+    // emitted from one table rather than nine more hand-written entries that
+    // would then have to be kept in step with each other.
+    // ========================================
+    struct VariableScopeCompletion {
+        const char* accessor; // pm.<accessor>
+        const char* noun;     // what its variables are called in prose
+        const char* example;  // a variable name that reads naturally for it
+    };
+    constexpr VariableScopeCompletion variable_scopes[] = {
+        { "environment", "environment variable", "auth_token" },
+        { "globals", "global variable", "api_key" },
+        { "collectionVariables", "collection variable", "base_url" },
+    };
+
+    for (const auto& scope : variable_scopes) {
+        const std::string accessor = std::string ("pm.") + scope.accessor;
+        const std::string sort = std::string ("1_pm_") + scope.accessor + "_";
+        const std::string noun = scope.noun;
+
+        completions.push_back ({ { "label", accessor + ".has" },
+        { "kind", KIND_FUNCTION }, { "insertText", accessor + ".has(\"${1:variable}\")" },
+        { "insertTextRules", INSERT_AS_SNIPPET },
+        { "detail", accessor + ".has(name: string): boolean" },
+        { "documentation",
+        "True when the " + noun + " exists and is enabled - the same rows " +
+        accessor + ".get() can read.\n\nExample:\nif (" + accessor + ".has('" +
+        scope.example + "')) { /* ... */ }" },
+        { "sortText", sort + "has" } });
+
+        completions.push_back ({ { "label", accessor + ".unset" },
+        { "kind", KIND_FUNCTION }, { "insertText", accessor + ".unset(\"${1:variable}\")" },
+        { "insertTextRules", INSERT_AS_SNIPPET },
+        { "detail", accessor + ".unset(name: string): void" },
+        { "documentation",
+        "Remove the " + noun +
+        " entirely. Not the same as setting it to \"\", which leaves an "
+        "enabled empty variable behind for {{template}} resolution to "
+        "find.\n\nExample:\n" +
+        accessor + ".unset('" + scope.example + "');" },
+        { "sortText", sort + "unset" } });
+
+        completions.push_back ({ { "label", accessor + ".clear" },
+        { "kind", KIND_FUNCTION }, { "insertText", accessor + ".clear()" },
+        { "detail", accessor + ".clear(): void" },
+        { "documentation", "Remove every " + noun + ", disabled ones included. Only this scope is affected." },
+        { "sortText", sort + "clear" } });
+
+        completions.push_back ({ { "label", accessor + ".toObject" },
+        { "kind", KIND_FUNCTION }, { "insertText", accessor + ".toObject()" },
+        { "detail", accessor + ".toObject(): Record<string, any>" },
+        { "documentation",
+        "A plain object of every enabled " + noun + ", each value cast by its declared type.\n\nExample:\nconsole.log(" +
+        accessor + ".toObject());" },
+        { "sortText", sort + "toObject" } });
+    }
+
+    // ========================================
+    // pm.variables - merged read across the scopes
+    // ========================================
+    completions.push_back ({ { "label", "pm.variables" }, { "kind", KIND_VARIABLE },
+    { "insertText", "pm.variables" }, { "detail", "Merged variables object (read-only)" },
+    { "documentation",
+    "Read a variable without naming its scope. Resolves environment, then "
+    "collection, then global - the same order {{name}} uses. Writes must name "
+    "a scope: pm.variables.set() throws." },
+    { "sortText", "0_pm_variables" } });
+
+    completions.push_back ({ { "label", "pm.variables.get" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.variables.get(\"${1:variable}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.variables.get(name: string): any | undefined" },
+    { "documentation",
+    "Get a variable from the highest-precedence scope that has it enabled: "
+    "environment, then collection, then global.\n\nExample:\nconst baseUrl = "
+    "pm.variables.get('base_url');" },
+    { "sortText", "1_pm_variables_get" } });
+
+    completions.push_back ({ { "label", "pm.variables.has" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.variables.has(\"${1:variable}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.variables.has(name: string): boolean" },
+    { "documentation", "True when any scope has the variable enabled." },
+    { "sortText", "1_pm_variables_has" } });
+
+    completions.push_back ({ { "label", "pm.variables.toObject" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.variables.toObject()" },
+    { "detail", "pm.variables.toObject(): Record<string, any>" },
+    { "documentation",
+    "Every enabled variable from all three scopes, merged in precedence "
+    "order - each name resolves to what pm.variables.get() would answer." },
+    { "sortText", "1_pm_variables_toObject" } });
+
+    // ========================================
     // console - Console output
     // ========================================
     completions.push_back ({ { "label", "console.log" }, { "kind", KIND_FUNCTION },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -1663,19 +1664,76 @@ std::optional<std::string> apply_pm_request_writeback (JSContext* ctx, Request& 
     return std::nullopt;
 }
 
-JSValue js_pm_environment_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+// ============================================================================
+// Variable scopes: pm.environment / pm.globals / pm.collectionVariables
+// ============================================================================
+
+// Which of the run's three variable maps a binding reads and writes. The value
+// is the `magic` argument QuickJS hands back, so one implementation serves all
+// three scopes. They were three hand-written copies of get/set; six methods
+// each would have tripled that, and a copy is exactly what stops a fix landing
+// everywhere it belongs.
+enum VariableScope : int {
+    SCOPE_ENVIRONMENT,
+    SCOPE_GLOBALS,
+    SCOPE_COLLECTION_VARIABLES
+};
+
+struct VariableScopeBinding {
+    const char* property; // the name this scope answers to on `pm`
+    VariableScope scope;
+};
+
+constexpr VariableScopeBinding variable_scope_bindings[] = {
+    { "environment", SCOPE_ENVIRONMENT },
+    { "globals", SCOPE_GLOBALS },
+    { "collectionVariables", SCOPE_COLLECTION_VARIABLES },
+};
+
+// Postman resolves an unqualified name local -> data -> environment ->
+// collection -> global. Vayu has neither a local nor a data scope, so the chain
+// starts at the environment - the same order `{{name}}` resolution already uses
+// app-side (docs/app/variable-resolution.md), which is what keeps a script's
+// reading of a name identical to the URL's.
+constexpr VariableScope variables_precedence[] = { SCOPE_ENVIRONMENT,
+    SCOPE_COLLECTION_VARIABLES, SCOPE_GLOBALS };
+
+// The map behind a scope, or nullptr when the run carries no such scope (a
+// design run with no active environment, say). Every binding below reads that
+// as an empty scope rather than an error: a script cannot see which scopes a
+// run was given, so throwing would fail it for a reason its author has no way
+// to inspect.
+Environment* scope_variables (JSContext* ctx, int magic) {
+    auto* data = get_context_data (ctx);
+    if (!data) {
+        return nullptr;
+    }
+    switch (magic) {
+    case SCOPE_ENVIRONMENT: return data->environment;
+    case SCOPE_GLOBALS: return data->globals;
+    case SCOPE_COLLECTION_VARIABLES: return data->collectionVariables;
+    default: return nullptr;
+    }
+}
+
+// A disabled variable is a row the user unticked in the variables editor, so
+// `get`, `has` and `toObject` all look straight past it - reading it would
+// resurrect a value that was switched off. `unset` and `clear` still remove it:
+// those are asked to delete a key, not to read one.
+JSValue
+js_pm_scope_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
     if (argc < 1) {
         return JS_UNDEFINED;
     }
 
-    auto* data = get_context_data (ctx);
-    if (!data->environment) {
+    Environment* variables = scope_variables (ctx, magic);
+    if (!variables) {
         return JS_UNDEFINED;
     }
 
-    std::string key = js_to_string (ctx, argv[0]);
-    auto it         = data->environment->find (key);
-    if (it != data->environment->end () && it->second.enabled) {
+    auto it = variables->find (js_to_string (ctx, argv[0]));
+    if (it != variables->end () && it->second.enabled) {
         return cast_variable_to_jsvalue (ctx, it->second);
     }
 
@@ -1683,10 +1741,9 @@ JSValue js_pm_environment_get (JSContext* ctx, JSValueConst this_val, int argc, 
 }
 
 // Update a variable's value while preserving an existing key's secret, enabled
-// and type fields; a brand-new key gets the current defaults. Shared by the
-// environment/globals/collectionVariables pm.*.set() bindings so a script that
-// re-sets an existing (e.g. secret) variable does not silently strip its flag
-// or reset its type.
+// and type fields; a brand-new key gets the current defaults. Shared by every
+// scope's set() so a script that re-sets an existing (e.g. secret) variable
+// does not silently strip its flag or reset its type.
 //
 // A brand-new key is also stamped with its creation time, the app's ordering
 // key for the variables editor (issue #135). This is the one place the engine
@@ -1706,129 +1763,226 @@ void set_variable_preserving (Environment& map, const std::string& key, std::str
     }
 }
 
-JSValue js_pm_environment_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+JSValue
+js_pm_scope_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
     if (argc < 2) {
         return JS_UNDEFINED;
     }
 
-    auto* data = get_context_data (ctx);
-    if (!data->environment) {
+    Environment* variables = scope_variables (ctx, magic);
+    if (!variables) {
         return JS_UNDEFINED;
     }
 
     std::string key   = js_to_string (ctx, argv[0]);
     std::string value = js_to_string (ctx, argv[1]);
 
-    set_variable_preserving (*data->environment, key, std::move (value));
+    set_variable_preserving (*variables, key, std::move (value));
 
     return JS_UNDEFINED;
 }
 
-void setup_pm_environment (JSContext* ctx, JSValue pm) {
-    JSValue env = JS_NewObject (ctx);
+JSValue
+js_pm_scope_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
+    if (argc < 1) {
+        return JS_NewBool (ctx, 0);
+    }
 
-    JS_SetPropertyStr (
-    ctx, env, "get", JS_NewCFunction (ctx, js_pm_environment_get, "get", 1));
-    JS_SetPropertyStr (
-    ctx, env, "set", JS_NewCFunction (ctx, js_pm_environment_set, "set", 2));
+    Environment* variables = scope_variables (ctx, magic);
+    if (!variables) {
+        return JS_NewBool (ctx, 0);
+    }
 
-    JS_SetPropertyStr (ctx, pm, "environment", env);
+    auto it = variables->find (js_to_string (ctx, argv[0]));
+    return JS_NewBool (ctx, it != variables->end () && it->second.enabled ? 1 : 0);
 }
 
-JSValue js_pm_globals_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+// The method with no workaround: setting a variable to "" leaves an enabled
+// empty variable behind, which is not the same thing to `{{template}}`
+// resolution as the variable being gone. The removal reaches disk through
+// persist_script_variables, which rewrites a scope whenever the map it ends
+// with differs from the one on disk.
+JSValue
+js_pm_scope_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
     if (argc < 1) {
         return JS_UNDEFINED;
     }
 
-    auto* data = get_context_data (ctx);
-    if (!data->globals) {
+    Environment* variables = scope_variables (ctx, magic);
+    if (!variables) {
         return JS_UNDEFINED;
     }
 
-    std::string key = js_to_string (ctx, argv[0]);
-    auto it         = data->globals->find (key);
-    if (it != data->globals->end () && it->second.enabled) {
-        return cast_variable_to_jsvalue (ctx, it->second);
+    variables->erase (js_to_string (ctx, argv[0]));
+
+    return JS_UNDEFINED;
+}
+
+JSValue
+js_pm_scope_clear (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+
+    if (Environment* variables = scope_variables (ctx, magic)) {
+        variables->clear ();
     }
 
     return JS_UNDEFINED;
 }
 
-JSValue js_pm_globals_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
-    if (argc < 2) {
-        return JS_UNDEFINED;
+JSValue
+js_pm_scope_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+
+    JSValue snapshot = JS_NewObject (ctx);
+    if (JS_IsException (snapshot)) {
+        return snapshot;
     }
 
-    auto* data = get_context_data (ctx);
-    if (!data->globals) {
-        return JS_UNDEFINED;
+    if (Environment* variables = scope_variables (ctx, magic)) {
+        for (const auto& [key, variable] : *variables) {
+            if (variable.enabled) {
+                JS_SetPropertyStr (ctx, snapshot, key.c_str (),
+                cast_variable_to_jsvalue (ctx, variable));
+            }
+        }
     }
 
-    std::string key   = js_to_string (ctx, argv[0]);
-    std::string value = js_to_string (ctx, argv[1]);
-
-    set_variable_preserving (*data->globals, key, std::move (value));
-
-    return JS_UNDEFINED;
+    return snapshot;
 }
 
-void setup_pm_globals (JSContext* ctx, JSValue pm) {
-    JSValue globals = JS_NewObject (ctx);
+void setup_pm_variable_scope (JSContext* ctx, JSValue pm, const VariableScopeBinding& binding) {
+    JSValue scope   = JS_NewObject (ctx);
+    const int magic = binding.scope;
 
-    JS_SetPropertyStr (
-    ctx, globals, "get", JS_NewCFunction (ctx, js_pm_globals_get, "get", 1));
-    JS_SetPropertyStr (
-    ctx, globals, "set", JS_NewCFunction (ctx, js_pm_globals_set, "set", 2));
+    JS_SetPropertyStr (ctx, scope, "get",
+    JS_NewCFunctionMagic (ctx, js_pm_scope_get, "get", 1, JS_CFUNC_generic_magic, magic));
+    JS_SetPropertyStr (ctx, scope, "set",
+    JS_NewCFunctionMagic (ctx, js_pm_scope_set, "set", 2, JS_CFUNC_generic_magic, magic));
+    JS_SetPropertyStr (ctx, scope, "has",
+    JS_NewCFunctionMagic (ctx, js_pm_scope_has, "has", 1, JS_CFUNC_generic_magic, magic));
+    JS_SetPropertyStr (ctx, scope, "unset",
+    JS_NewCFunctionMagic (ctx, js_pm_scope_unset, "unset", 1, JS_CFUNC_generic_magic, magic));
+    JS_SetPropertyStr (ctx, scope, "clear",
+    JS_NewCFunctionMagic (ctx, js_pm_scope_clear, "clear", 0, JS_CFUNC_generic_magic, magic));
+    JS_SetPropertyStr (ctx, scope, "toObject",
+    JS_NewCFunctionMagic (
+    ctx, js_pm_scope_to_object, "toObject", 0, JS_CFUNC_generic_magic, magic));
 
-    JS_SetPropertyStr (ctx, pm, "globals", globals);
+    JS_SetPropertyStr (ctx, pm, binding.property, scope);
 }
 
-JSValue js_pm_collectionVariables_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+// ============================================================================
+// pm.variables - the merged, read-only accessor
+// ============================================================================
+
+JSValue js_pm_variables_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
     if (argc < 1) {
         return JS_UNDEFINED;
     }
 
-    auto* data = get_context_data (ctx);
-    if (!data->collectionVariables) {
-        return JS_UNDEFINED;
-    }
-
-    std::string key = js_to_string (ctx, argv[0]);
-    auto it         = data->collectionVariables->find (key);
-    if (it != data->collectionVariables->end () && it->second.enabled) {
-        return cast_variable_to_jsvalue (ctx, it->second);
+    const std::string key = js_to_string (ctx, argv[0]);
+    for (const VariableScope scope : variables_precedence) {
+        Environment* variables = scope_variables (ctx, scope);
+        if (!variables) {
+            continue;
+        }
+        auto it = variables->find (key);
+        if (it != variables->end () && it->second.enabled) {
+            return cast_variable_to_jsvalue (ctx, it->second);
+        }
     }
 
     return JS_UNDEFINED;
 }
 
-JSValue js_pm_collectionVariables_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
-    if (argc < 2) {
-        return JS_UNDEFINED;
+JSValue js_pm_variables_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 1) {
+        return JS_NewBool (ctx, 0);
     }
 
-    auto* data = get_context_data (ctx);
-    if (!data->collectionVariables) {
-        return JS_UNDEFINED;
+    const std::string key = js_to_string (ctx, argv[0]);
+    for (const VariableScope scope : variables_precedence) {
+        Environment* variables = scope_variables (ctx, scope);
+        if (!variables) {
+            continue;
+        }
+        auto it = variables->find (key);
+        if (it != variables->end () && it->second.enabled) {
+            return JS_NewBool (ctx, 1);
+        }
     }
 
-    std::string key   = js_to_string (ctx, argv[0]);
-    std::string value = js_to_string (ctx, argv[1]);
-
-    set_variable_preserving (*data->collectionVariables, key, std::move (value));
-
-    return JS_UNDEFINED;
+    return JS_NewBool (ctx, 0);
 }
 
-void setup_pm_collectionVariables (JSContext* ctx, JSValue pm) {
-    JSValue collectionVariables = JS_NewObject (ctx);
+JSValue js_pm_variables_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
 
-    JS_SetPropertyStr (ctx, collectionVariables, "get",
-    JS_NewCFunction (ctx, js_pm_collectionVariables_get, "get", 1));
-    JS_SetPropertyStr (ctx, collectionVariables, "set",
-    JS_NewCFunction (ctx, js_pm_collectionVariables_set, "set", 2));
+    JSValue snapshot = JS_NewObject (ctx);
+    if (JS_IsException (snapshot)) {
+        return snapshot;
+    }
 
-    JS_SetPropertyStr (ctx, pm, "collectionVariables", collectionVariables);
+    // Weakest scope first, so a stronger one overwrites it and the snapshot
+    // agrees with what get() would have answered for every key in it.
+    for (auto it = std::rbegin (variables_precedence);
+         it != std::rend (variables_precedence); ++it) {
+        Environment* variables = scope_variables (ctx, *it);
+        if (!variables) {
+            continue;
+        }
+        for (const auto& [key, variable] : *variables) {
+            if (variable.enabled) {
+                JS_SetPropertyStr (ctx, snapshot, key.c_str (),
+                cast_variable_to_jsvalue (ctx, variable));
+            }
+        }
+    }
+
+    return snapshot;
+}
+
+// Postman's pm.variables.set writes to the *local* scope: alive for one
+// request, never stored. Vayu has no such scope, and neither substitute is
+// honest - writing to the environment persists a value the author expects to
+// vanish, and dropping the call loses a write they believe happened. So it
+// throws, naming the three scopes that do exist. Documented in
+// docs/engine/scripting.md; changing this changes a documented contract.
+JSValue js_pm_variables_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    return JS_ThrowTypeError (ctx,
+    "pm.variables.set is not supported: Vayu has no local variable scope. "
+    "Use pm.environment.set(), pm.collectionVariables.set() or "
+    "pm.globals.set() "
+    "to choose where the value is stored.");
+}
+
+void setup_pm_variables (JSContext* ctx, JSValue pm) {
+    JSValue variables = JS_NewObject (ctx);
+
+    JS_SetPropertyStr (
+    ctx, variables, "get", JS_NewCFunction (ctx, js_pm_variables_get, "get", 1));
+    JS_SetPropertyStr (
+    ctx, variables, "has", JS_NewCFunction (ctx, js_pm_variables_has, "has", 1));
+    JS_SetPropertyStr (ctx, variables, "toObject",
+    JS_NewCFunction (ctx, js_pm_variables_to_object, "toObject", 0));
+    JS_SetPropertyStr (
+    ctx, variables, "set", JS_NewCFunction (ctx, js_pm_variables_set, "set", 2));
+
+    JS_SetPropertyStr (ctx, pm, "variables", variables);
 }
 
 void setup_pm_object (JSContext* ctx) {
@@ -1856,14 +2010,13 @@ void setup_pm_object (JSContext* ctx) {
     // pm.request
     setup_pm_request (ctx, pm);
 
-    // pm.environment
-    setup_pm_environment (ctx, pm);
+    // pm.environment, pm.globals, pm.collectionVariables
+    for (const auto& binding : variable_scope_bindings) {
+        setup_pm_variable_scope (ctx, pm, binding);
+    }
 
-    // pm.globals
-    setup_pm_globals (ctx, pm);
-
-    // pm.collectionVariables
-    setup_pm_collectionVariables (ctx, pm);
+    // pm.variables
+    setup_pm_variables (ctx, pm);
 
     JS_SetPropertyStr (ctx, global, "pm", pm);
     JS_FreeValue (ctx, global);

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -168,4 +168,88 @@ TEST (ScriptCompletions, EveryOfferedResponseStatusClassExistsInTheRuntime) {
     << "the pm.response.to.be matchers are missing from the completion list";
 }
 
+// The same drift, on the variable scopes: `pm.variables` was offered by
+// `scripting.md` for months while the runtime had no such object, and every
+// scope method added in #184 is invisible in the editor until it is listed
+// here. Both directions are defects, so both are checked - an offered method
+// the runtime lacks throws "is not a function" the moment it is accepted, and a
+// runtime method nobody lists is a feature no user can find.
+TEST (ScriptCompletions, TheOfferedVariableScopeMethodsAreExactlyWhatTheRuntimeHas) {
+    const auto completions = get_script_completions ();
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request;
+    vayu::Environment env;
+    vayu::Environment globals;
+    vayu::Environment collection_variables;
+    request.method = vayu::HttpMethod::GET;
+    request.url    = "https://api.example.com/users";
+
+    vayu::runtime::ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &collection_variables;
+
+    // Every offered `pm.<scope>.<method>` exists as a function.
+    int offered = 0;
+    std::string probe;
+    for (const auto& item : completions) {
+        const std::string label = item.value ("label", std::string{});
+        for (const char* accessor : { "pm.environment.", "pm.globals.",
+             "pm.collectionVariables.", "pm.variables." }) {
+            if (label.rfind (accessor, 0) != 0) {
+                continue;
+            }
+            offered++;
+            probe += "if (typeof " + label + " !== 'function') missing.push('" + label + "');\n";
+        }
+    }
+    ASSERT_GT (offered, 0)
+    << "no variable-scope completions at all - the loop below proves nothing";
+
+    auto result = engine.execute (
+    "var missing = [];\n" + probe + "pm.environment.set('missing', missing.join(','));", ctx);
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["missing"].value, "")
+    << "offered by the completion list, absent from the runtime";
+
+    // And nothing the runtime has is missing from the list. Read off the
+    // runtime rather than hardcoded, so a method added to
+    // setup_pm_variable_scope has to be listed rather than merely renamed here.
+    env.clear ();
+    auto installed = engine.execute (R"JS(
+        var names = [];
+        var scopes = ['environment', 'globals', 'collectionVariables', 'variables'];
+        for (var i = 0; i < scopes.length; i++) {
+            var scope = pm[scopes[i]];
+            for (var key in scope) {
+                if (typeof scope[key] === 'function') names.push('pm.' + scopes[i] + '.' + key);
+            }
+        }
+        pm.environment.set('names', names.join(','));
+    )JS",
+    ctx);
+    ASSERT_TRUE (installed.success) << installed.error_message;
+
+    const std::string names = env["names"].value;
+    ASSERT_FALSE (names.empty ())
+    << "the runtime enumeration found nothing to check";
+    for (size_t start = 0; start <= names.size ();) {
+        const size_t comma     = names.find (',', start);
+        const std::string name = names.substr (
+        start, comma == std::string::npos ? std::string::npos : comma - start);
+        // pm.variables.set exists only to throw and name the three real scopes;
+        // offering it in the editor would be suggesting a call that cannot work.
+        if (!name.empty () && name != "pm.variables.set") {
+            EXPECT_NE (find_by_label (completions, name), nullptr)
+            << name << " is in the runtime but not in the completion list";
+        }
+        if (comma == std::string::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+}
+
 } // namespace

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1324,34 +1324,238 @@ TEST_F (ScriptEngineTest, NoCryptoBase64OrUrlParserIsExposed) {
 // Same reason as the two above: a name that is written down but not installed
 // throws in the user's face, and nothing else notices. `scripting.md` taught
 // `pm.variables` and the Tests panel's quick reference taught
-// `pm.response.headers.get()`; neither has ever existed. These pin the runtime
-// so the docs can be trusted, and so implementing either one flips a test red
-// and forces the doc to be rewritten with it.
+// `pm.response.headers.get()`; neither had ever existed. `pm.variables` has
+// since been built (#184), so the tests below now pin it as *present* and its
+// documented precedence; `pm.response.headers.get()` is still absent and stays
+// pinned that way, so implementing it flips a test red and forces the doc to be
+// rewritten with it.
 
-TEST_F (ScriptEngineTest, PmVariablesIsAbsentAndTheScopedAccessorsAreNot) {
+// Every scope answers the same six names, and the merged accessor exists (#184).
+// This is the list both script docs promise, checked against the runtime rather
+// than against itself - a method dropped from setup_pm_variable_scope shows up
+// here as a name, not as a mysteriously undefined call somewhere downstream.
+TEST_F (ScriptEngineTest, EveryVariableScopeExposesTheSameSurfaceAndPmVariablesExists) {
     auto result = engine.execute_prerequest (R"JS(
-        pm.environment.set('mergedAccessor', typeof pm.variables);
         var missing = [];
         var scopes = ['environment', 'globals', 'collectionVariables'];
+        var methods = ['get', 'set', 'has', 'unset', 'clear', 'toObject'];
         for (var i = 0; i < scopes.length; i++) {
             var scope = pm[scopes[i]];
-            if (!scope || typeof scope.get !== 'function'
-                || typeof scope.set !== 'function') {
-                missing.push(scopes[i]);
+            if (!scope) { missing.push(scopes[i]); continue; }
+            for (var j = 0; j < methods.length; j++) {
+                if (typeof scope[methods[j]] !== 'function') {
+                    missing.push(scopes[i] + '.' + methods[j]);
+                }
             }
         }
-        pm.environment.set('missingScopes', missing.join(','));
+        // The merged accessor reads across scopes; it deliberately has no
+        // unset/clear, since it owns no scope to remove a name from.
+        var merged = ['get', 'has', 'toObject', 'set'];
+        for (var k = 0; k < merged.length; k++) {
+            if (!pm.variables || typeof pm.variables[merged[k]] !== 'function') {
+                missing.push('variables.' + merged[k]);
+            }
+        }
+        pm.environment.set('missing', missing.join(','));
     )JS",
     request, env);
 
     ASSERT_TRUE (result.success) << result.error_message;
-    EXPECT_EQ (env["missingScopes"].value, "")
-    << "a scoped accessor the docs point at instead of pm.variables is gone";
-    // Implementing the merged accessor is #184. When it lands, this expectation
-    // is the one that says "now rewrite the 'not supported' section in
-    // scripting.md and the unsupported list in pm-api-compatibility.md".
-    EXPECT_EQ (env["mergedAccessor"].value, "undefined")
-    << "pm.variables now exists; both docs say it does not";
+    EXPECT_EQ (env["missing"].value, "")
+    << "a variable-scope method both script docs teach is not installed";
+}
+
+TEST_F (ScriptEngineTest, HasIsTrueOnlyForAVariableGetCanRead) {
+    env["disabled"] = Variable{ "value", false, false };
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('present', String(pm.environment.has('base_url')));
+        pm.environment.set('absent', String(pm.environment.has('nope')));
+        // A row the user unticked reads as absent, the same way get() skips it.
+        pm.environment.set('disabledIsHidden', String(pm.environment.has('disabled')));
+        pm.environment.set('noArgument', String(pm.environment.has()));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["present"].value, "true");
+    EXPECT_EQ (env["absent"].value, "false");
+    EXPECT_EQ (env["disabledIsHidden"].value, "false");
+    EXPECT_EQ (env["noArgument"].value, "false");
+}
+
+// The method with no workaround before #184: setting a variable to "" leaves an
+// enabled empty variable behind, which {{template}} resolution still finds.
+TEST_F (ScriptEngineTest, UnsetRemovesTheVariableRatherThanEmptyingIt) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.unset('api_key');
+        pm.environment.set('readBack', String(pm.environment.get('api_key')));
+        pm.environment.unset('never_existed');
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env.count ("api_key"), 0U) << "the key is still in the map";
+    EXPECT_EQ (env["readBack"].value, "undefined");
+}
+
+// A disabled variable is invisible to get/has but is still a key, so unset and
+// clear remove it - they were asked to delete a name, not to read one.
+TEST_F (ScriptEngineTest, UnsetAndClearRemoveDisabledVariablesToo) {
+    env["disabled"] = Variable{ "value", false, false };
+
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.unset('disabled');
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env.count ("disabled"), 0U);
+}
+
+TEST_F (ScriptEngineTest, ClearEmptiesOnlyItsOwnScope) {
+    Environment globals;
+    globals["g"] = Variable{ "kept", false, true };
+    Environment collVars;
+    collVars["c"] = Variable{ "kept", false, true };
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &collVars;
+
+    auto result = engine.execute (R"JS(
+        pm.environment.clear();
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_TRUE (env.empty ());
+    EXPECT_EQ (globals.size (), 1U)
+    << "clear() reached a scope it was not called on";
+    EXPECT_EQ (collVars.size (), 1U);
+}
+
+TEST_F (ScriptEngineTest, ToObjectSnapshotsEnabledVariablesWithTheirDeclaredTypes) {
+    env["count"]    = Variable{ "42", false, true, "number" };
+    env["disabled"] = Variable{ "value", false, false };
+
+    auto result = engine.execute_prerequest (R"JS(
+        var snapshot = pm.environment.toObject();
+        pm.environment.set('baseUrl', snapshot['base_url']);
+        // Cast by declared type, exactly as get() would answer it.
+        pm.environment.set('countType', typeof snapshot['count']);
+        pm.environment.set('hasDisabled', String('disabled' in snapshot));
+        // A snapshot, not a view: writing to it must not reach the scope.
+        snapshot['base_url'] = 'mutated';
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["baseUrl"].value, "https://api.example.com");
+    EXPECT_EQ (env["countType"].value, "number");
+    EXPECT_EQ (env["hasDisabled"].value, "false");
+    EXPECT_EQ (env["base_url"].value, "https://api.example.com")
+    << "toObject() handed out a live view of the scope";
+}
+
+// The precedence pm.variables resolves in - environment, then collection, then
+// global - is the order {{name}} already uses app-side, so a script and a URL
+// in the same request cannot read one name two ways.
+TEST_F (ScriptEngineTest, PmVariablesResolvesEnvironmentThenCollectionThenGlobal) {
+    Environment globals;
+    globals["everywhere"]  = Variable{ "from-globals", false, true };
+    globals["only_global"] = Variable{ "global-only", false, true };
+    Environment collVars;
+    collVars["everywhere"] = Variable{ "from-collection", false, true };
+    collVars["in_two"]     = Variable{ "from-collection", false, true };
+    Environment environment;
+    environment["everywhere"] = Variable{ "from-environment", false, true };
+    environment["disabled"]   = Variable{ "hidden", false, false };
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &environment;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &collVars;
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('winner', String(pm.variables.get('everywhere')));
+        pm.globals.set('lowestOnly', String(pm.variables.get('only_global')));
+        pm.globals.set('middle', String(pm.variables.get('in_two')));
+        pm.globals.set('nowhere', String(pm.variables.get('missing')));
+        pm.globals.set('hasLowest', String(pm.variables.has('only_global')));
+        pm.globals.set('hasNowhere', String(pm.variables.has('missing')));
+        // A disabled variable is not a hit, so resolution keeps looking.
+        pm.globals.set('hasDisabled', String(pm.variables.has('disabled')));
+        var merged = pm.variables.toObject();
+        pm.globals.set('mergedWinner', String(merged['everywhere']));
+        pm.globals.set('mergedKeeps', String(merged['only_global']));
+        pm.globals.set('mergedHasDisabled', String('disabled' in merged));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (globals["winner"].value, "from-environment");
+    EXPECT_EQ (globals["middle"].value, "from-collection");
+    EXPECT_EQ (globals["lowestOnly"].value, "global-only");
+    EXPECT_EQ (globals["nowhere"].value, "undefined");
+    EXPECT_EQ (globals["hasLowest"].value, "true");
+    EXPECT_EQ (globals["hasNowhere"].value, "false");
+    EXPECT_EQ (globals["hasDisabled"].value, "false");
+    // The merged snapshot agrees with get() name for name, or it is a second
+    // answer to the same question.
+    EXPECT_EQ (globals["mergedWinner"].value, "from-environment");
+    EXPECT_EQ (globals["mergedKeeps"].value, "global-only");
+    EXPECT_EQ (globals["mergedHasDisabled"].value, "false");
+}
+
+// Postman's pm.variables.set writes to a local scope that lives for one request.
+// Vayu has none, and both substitutes lie: writing to the environment persists
+// a value the author expects to vanish, dropping it loses a write they believe
+// happened. So it throws, and the message names the three scopes that exist.
+TEST_F (ScriptEngineTest, PmVariablesSetThrowsRatherThanGuessingAScope) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.variables.set('token', 'value');
+    )JS",
+    request, env);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("pm.variables.set is not supported"),
+    std::string::npos)
+    << result.error_message;
+    EXPECT_NE (result.error_message.find ("pm.environment.set()"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (env.count ("token"), 0U)
+    << "the throwing write still landed somewhere";
+}
+
+// A run can be given fewer than three scopes - a design run with no active
+// environment, for instance. Every method has to read that as an empty scope: a
+// script cannot see which scopes it was handed, so a throw here would fail it
+// for a reason its author cannot inspect.
+TEST_F (ScriptEngineTest, AScopeTheRunDoesNotCarryBehavesAsEmptyRatherThanThrowing) {
+    ScriptContext ctx;
+    ctx.request     = &request;
+    ctx.environment = &env; // globals and collectionVariables stay null
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('ignored', 'value');
+        pm.globals.unset('ignored');
+        pm.globals.clear();
+        pm.environment.set('absentGet', String(pm.globals.get('anything')));
+        pm.environment.set('absentHas', String(pm.globals.has('anything')));
+        pm.environment.set('absentKeys', Object.keys(pm.globals.toObject()).join(','));
+        pm.environment.set('mergedStillReads', String(pm.variables.get('base_url')));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["absentGet"].value, "undefined");
+    EXPECT_EQ (env["absentHas"].value, "false");
+    EXPECT_EQ (env["absentKeys"].value, "");
+    EXPECT_EQ (env["mergedStillReads"].value, "https://api.example.com");
 }
 
 TEST_F (ScriptEngineTest, ResponseHeadersIsAPlainObjectReadByLowerCasedKey) {

--- a/engine/tests/script_variables_test.cpp
+++ b/engine/tests/script_variables_test.cpp
@@ -265,4 +265,42 @@ TEST_F (PersistScriptVariablesTest, ARunWithoutAnEnvironmentOrRequestWritesOnlyG
     EXPECT_EQ (stored_collection_variables (), APP_BLOB);
 }
 
+// `pm.environment.unset()` (#184) is the first thing that can make a scope
+// *smaller*, and a removal is the write most easily lost: every other one shows
+// up as a changed value, while this one shows up only as a key that is no
+// longer there. The scope is rewritten because the two maps differ, and the
+// serializer writes the map it is given rather than merging into what is on
+// disk - so an absent key stays absent.
+TEST_F (PersistScriptVariablesTest, AnUnsetVariableIsRemovedFromTheStoredBlob) {
+    auto env       = parse_variables (stored_environment_variables ());
+    auto globals   = parse_variables (stored_globals_variables ());
+    auto coll_vars = parse_variables (stored_collection_variables ());
+
+    ASSERT_EQ (env.count ("token"), 1U);
+    env.erase ("token"); // what pm.environment.unset("token") leaves behind
+    env["kept"] = vayu::Variable{ "still here", false, true };
+
+    persist_script_variables (*db_, run_, env, globals, coll_vars);
+
+    auto stored = json::parse (stored_environment_variables ());
+    EXPECT_FALSE (stored.contains ("token")) << stored.dump ();
+    EXPECT_EQ (stored["kept"]["value"], "still here");
+}
+
+// `clear()` empties one scope and no other. An empty blob is `{}`, not a
+// scope left untouched because "nothing to write" was mistaken for "no change".
+TEST_F (PersistScriptVariablesTest, AClearedScopeIsStoredAsEmptyAndTheOthersAreUntouched) {
+    auto env       = parse_variables (stored_environment_variables ());
+    auto globals   = parse_variables (stored_globals_variables ());
+    auto coll_vars = parse_variables (stored_collection_variables ());
+
+    env.clear (); // what pm.environment.clear() leaves behind
+
+    persist_script_variables (*db_, run_, env, globals, coll_vars);
+
+    EXPECT_EQ (stored_environment_variables (), "{}");
+    EXPECT_EQ (stored_globals_variables (), APP_BLOB);
+    EXPECT_EQ (stored_collection_variables (), APP_BLOB);
+}
+
 } // namespace


### PR DESCRIPTION
## Description

All three variable scopes exposed exactly `get`/`set`, as three near-identical hand-written copies. Re-verified against `e5eaf0b` before editing: the shape the issue describes is still there, only the line numbers drifted (`setup_pm_environment` is at `script_engine.cpp:1727`, not `:1509`). The method whose absence has no workaround is `unset` - setting a variable to `""` leaves an **enabled empty** row behind, which is not the same thing to `{{template}}` resolution as the variable being gone.

**Plan (root cause, approach, rejected alternative).** The root cause is three copies of a scope binding, which is why adding four methods each was never worth doing. The three copies are now one implementation parameterised by QuickJS's `magic` argument (the pattern already used in this file for the `pm.response.to.be.*` status classes), and each scope gets `get`/`set`/`has`/`unset`/`clear`/`toObject`. `pm.variables` is added as a **read-only** merged accessor resolving environment → collection → global.

The one real design decision is what `pm.variables.set()` does. In Postman it writes to a *local* scope that lives for one request and is never stored; Vayu has no such scope. I rejected the quieter option - writing to the environment - because it persists to disk a value the script author expects to vanish, which is precisely the "silently pick environment and let a user believe it is ephemeral" outcome the issue warns against. It throws instead, naming the three scoped setters, and the message is asserted by a test. I also rejected giving `pm.variables` `unset`/`clear`: it owns no scope to remove a name from, so `pm.variables.unset(...)` is a plain "is not a function" rather than a method that has to invent a target.

**Blast radius traced.** The scopes reach disk through `persist_script_variables` (`routes/execution.cpp`), which rewrites a scope when the map the script left differs from the stored one - so a *removal* is the first write that shows up only as a key that is no longer there, and it is covered by two new persistence tests. The other reader is `GET /scripting/completions` (`routes/scripting.cpp`), which feeds Monaco: a runtime method nobody lists is a feature no user can find, so the four new methods are listed for all three scopes plus `pm.variables`, and a new test checks the offered set against the *installed* set **in both directions** (an offered method the runtime lacks, and a runtime method the list omits). `pm.variables.set` is deliberately not offered - suggesting a call that can only throw is worse than not suggesting it.

### Deliberate deviations from the issue spec

- **`replaceIn()` and `pm.environment.name` are not implemented.** Both are named in the issue's Problem section but not in its Fix or Acceptance criteria. `replaceIn` is `{{name}}` interpolation of an arbitrary string, and the engine deliberately does **no** `{{var}}` interpolation at all (it is resolved app-side before the payload arrives), so there is nothing for it to call. Both are recorded in `pm-api-compatibility.md`'s not-supported list rather than left unmentioned.
- **`toObject()` skips disabled variables.** Not stated either way in the issue. Chosen for consistency with `get`/`has`, which already skip them, so the snapshot cannot disagree with a `get` of the same name. Locked by a test.

### Adjacent, not fixed here

While tracing the persistence path I found that `pm.collectionVariables` is loaded from the request's **immediate parent collection only** (`execution.cpp`), while `{{name}}` resolution merges the whole root→leaf chain app-side. So an ancestor collection's variable resolves in a URL and is invisible to a script. That is out of this issue's scope, so it is **documented** in `scripting.md` and `variable-resolution.md` rather than changed, and raised as a comment on #184 for its own issue.

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Testing

`python build.py -e -t` then the commands the issue names, on this branch:

- **Engine: 651/651 passed** (`ctest --preset linux-dev --output-on-failure`), up from 640 on the base commit - 11 new tests.
- **App: 1931/1931 passed** across 230 files (`pnpm test`); `pnpm type-check` clean.
- **`mkdocs build --strict -f .github/mkdocs.yml`** clean, including the new `#variables-pmvariables` anchor the two cross-links resolve to.
- **clang-format**: only the added line ranges were formatted (`--lines=`), since these files each carried pre-existing violations and CLAUDE.md forbids reformatting a file that was not clean before.
- **clang-tidy**: `script_engine.cpp` is under `engine/src/runtime/`, whose `.clang-tidy` disables all checks for the QuickJS integration. `scripting.cpp` reports one warning, `lambda capture 'ctx' is not used` at the route registration - **pre-existing**, reproduces on the base commit, untouched by this diff and not fixed here.

Mutation-checked, rebuilding and re-running each time:

| Mutation | Test that went red |
|---|---|
| `unset` made a no-op | `UnsetRemovesTheVariableRatherThanEmptyingIt`, `UnsetAndClearRemoveDisabledVariablesToo` |
| precedence inverted to global-first | `PmVariablesResolvesEnvironmentThenCollectionThenGlobal` |
| `toObject` includes disabled rows | `ToObjectSnapshotsEnabledVariablesWithTheirDeclaredTypes` |
| `has` ignores the enabled flag | `HasIsTrueOnlyForAVariableGetCanRead` |
| `pm.variables.has` dropped from the completion list | `TheOfferedVariableScopeMethodsAreExactlyWhatTheRuntimeHas` ("pm.variables.has is in the runtime but not in the completion list") |

The failure paths are tested, not assumed: a scope the run does not carry, a `pm.variables.set` that must throw *without* leaving a write behind, `unset` of a name that was never there, and `clear` reaching only its own scope.

`ScriptEngineTest.PmVariablesIsAbsentAndTheScopedAccessorsAreNot` was the guard #182 left behind saying "when #184 lands, this is the test that says rewrite both docs". It is replaced by `EveryVariableScopeExposesTheSameSurfaceAndPmVariablesExists`, and the docs are rewritten in this commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `docs/engine/scripting.md`, `docs/app/pm-api-compatibility.md`, `docs/app/variable-resolution.md`, in the same commit

## Related Issues
Closes #184

---
_Generated by [Claude Code](https://claude.ai/code/session_013wP2rxScGWY8zKofgne4GL)_