### PR TITLE
docs: serve install.sh from the docs site, shortening the macOS install command

### DIFF
--- a/.github/hooks/install_script.py
+++ b/.github/hooks/install_script.py
@@ -1,0 +1,59 @@
+"""Serve the macOS installer from the docs site, off the repo's real script.
+
+The command a Mac user copies used to point at raw.githubusercontent.com, which
+spends most of its 92 characters on `owner/repo/branch`. Served from this site
+it is a third shorter and reads as the product's own URL:
+
+    bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)"
+
+`install.sh` stays at the repo root, because that is where the things that test
+it look: `shellcheck install.sh` in .github/workflows/pr-tests.yml, and
+scripts/test/install_test.sh. MkDocs can only read files under `docs_dir`, so
+the obvious alternative - a copy at docs/install.sh - would be a *second copy of
+an executable script*, free to drift from the tested one with nothing failing.
+This hook registers the root script as a generated file instead, the same trick
+hooks/brand_assets.py uses for the icon, so there is exactly one install.sh and
+the published one is it.
+
+That buys one obligation: `install.sh` must stay in the `paths:` filters of
+.github/workflows/docs.yml (push *and* pull_request). Miss it and editing the
+installer no longer redeploys the site, so the published copy silently falls
+behind master - a failure mode the raw.githubusercontent URL did not have,
+since it served the branch directly. The old URL still works, and anything
+already pointing at it keeps working.
+
+Wired up via `hooks:` in mkdocs.yml. If a future MkDocs drops hook support, the
+fallback is a copy at docs/install.sh plus a CI check that it matches the root
+one - delete this file, no other config changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mkdocs.structure.files import File, Files
+
+# Resolved from this file rather than the working directory, so it holds however
+# mkdocs was invoked.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SCRIPT_SOURCE = REPO_ROOT / "install.sh"
+
+# Site root, so the published URL is <site_url>install.sh and nothing longer.
+# The install commands in README.md and docs/index.md hardcode it.
+SCRIPT_DEST = "install.sh"
+
+
+def on_files(files: Files, config) -> Files:
+    if not SCRIPT_SOURCE.is_file():
+        # Loud on purpose. A missing script would otherwise publish as a 404 on
+        # the one URL the install instructions tell people to pipe into bash.
+        raise FileNotFoundError(
+            f"docs site installer missing: {SCRIPT_SOURCE}. "
+            "It is the script README.md and docs/index.md tell macOS users to run."
+        )
+
+    files.append(
+        File.generated(config, SCRIPT_DEST, abs_src_path=str(SCRIPT_SOURCE))
+    )
+    return files

--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -158,6 +158,10 @@ plugins:
 
 hooks:
   - hooks/brand_assets.py
+  # Publishes the repo-root install.sh at <site_url>install.sh, which is the URL
+  # the macOS install command curls. Keep `install.sh` in the `paths:` filters of
+  # workflows/docs.yml or the published copy goes stale - see the hook.
+  - hooks/install_script.py
   # Turns the analytics + consent blocks below off when GOOGLE_ANALYTICS_KEY is
   # unset, which an empty `!ENV` value does not do on its own.
   - hooks/analytics.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,11 @@ on:
       - '.github/mkdocs.yml'
       - '.github/hooks/**'
       - 'shared/icon_png/**'
+      # Published at the site root by hooks/install_script.py, and the URL the
+      # macOS install command curls. It is not under docs/, so without this line
+      # a change to the installer would not redeploy the site and the published
+      # script would silently fall behind master.
+      - 'install.sh'
       - 'requirements-docs.txt'
       - '.github/workflows/docs.yml'
   pull_request:
@@ -37,6 +42,7 @@ on:
       - '.github/mkdocs.yml'
       - '.github/hooks/**'
       - 'shared/icon_png/**'
+      - 'install.sh'
       - 'requirements-docs.txt'
       - '.github/workflows/docs.yml'
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,21 @@ remaining variable/auth resolution into the engine) is deferred and documented i
 
 macOS also ships a one-command installer: `install.sh` (repo root) downloads the release zip, ad-hoc signs the app + sidecar on-device, and strips quarantine (no Apple Developer cert). Unit-tested via `scripts/test/install_test.sh` (set `VAYU_DRYRUN=1`), shellchecked in CI on Linux + macOS.
 
+**The installer is served from the docs site**, at
+<https://athrvk.github.io/vayu/install.sh> - a third shorter than the
+raw.githubusercontent URL it replaced, which spent most of its 92 characters on
+`owner/repo/branch`. The file stays at the repo root (that is where shellcheck
+and `install_test.sh` look); `.github/hooks/install_script.py` registers it as a
+generated file at the site root, so there is no second copy to drift. That makes
+`install.sh` a **docs-site input**, so it is listed in the `paths:` filters of
+`.github/workflows/docs.yml` - without that line, editing the installer would not
+redeploy the site and the published copy would silently fall behind master. The
+old raw URL is unaffected and keeps working. Documented as `bash -c "$(curl -fsSL
+...)"` rather than `curl ... | bash`: the wrapper buffers the whole script before
+running any of it and leaves stdin on the terminal, so the installer can still
+grow an interactive prompt (`sudo -v` already reads `/dev/tty`, so both forms
+work today).
+
 **Windows also publishes to winget, automatically.** The `publish-winget` job in
 `release.yml` submits `Vayu-x64.exe` to `microsoft/winget-pkgs` after the
 release is built, so `winget install athrvk.Vayu` follows each tag with no

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Or download the installer directly:
 ### macOS
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/athrvk/vayu/master/install.sh)"
+bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)"
 ```
 
 Installs the latest release to `/Applications`. You will be prompted for your password once. Vayu is distributed unsigned - the installer ad-hoc signs it and clears the quarantine flag so it opens without the "damaged app" warning.
@@ -128,13 +128,13 @@ Installs the latest release to `/Applications`. You will be prompted for your pa
 To pin a specific version:
 
 ```sh
-VAYU_VERSION=0.2.1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/athrvk/vayu/master/install.sh)"
+VAYU_VERSION=0.2.1 bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)"
 ```
 
 To uninstall:
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/athrvk/vayu/master/install.sh)" -- --uninstall
+bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)" -- --uninstall
 ```
 
 Add `--purge` to also remove settings and data. Or drag `Vayu.app` from `/Applications` to the Trash.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,12 +25,17 @@ of it on your machine: no account, no cloud sync, no telemetry.
 Windows (x64), macOS (universal), and Linux (AppImage). No account, no sign-in.
 
 <!-- Keep these in step with the Download section of README.md, which is the
-     canonical copy - both point at the same release assets and install.sh. -->
+     canonical copy - both point at the same release assets and install.sh.
+
+     The macOS URL is this site serving the repo's own install.sh, published at
+     the site root by .github/hooks/install_script.py. It is a real file, not a
+     redirect, so it only refreshes when this site deploys - which is why
+     workflows/docs.yml watches install.sh too. -->
 
 === "macOS"
 
     ```sh
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/athrvk/vayu/master/install.sh)"
+    bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)"
     ```
 
     Installs the latest release to `/Applications`, and asks for your password

--- a/install.sh
+++ b/install.sh
@@ -153,11 +153,15 @@ main() {
 }
 
 usage() {
+	# The docs site serves this very script at that URL (published from the repo
+	# root by .github/hooks/install_script.py), so the lines below are the exact
+	# commands README.md and docs/index.md give.
+	local url="https://athrvk.github.io/vayu/install.sh"
 	cat <<EOF
 Vayu installer
-  install:        bash -c "\$(curl -fsSL <url>)"
-  pin version:    VAYU_VERSION=x.y.z bash -c "\$(curl -fsSL <url>)"
-  uninstall:      bash -c "\$(curl -fsSL <url>)" -- --uninstall [--purge]
+  install:        bash -c "\$(curl -fsSL $url)"
+  pin version:    VAYU_VERSION=x.y.z bash -c "\$(curl -fsSL $url)"
+  uninstall:      bash -c "\$(curl -fsSL $url)" -- --uninstall [--purge]
 EOF
 }
 


### PR DESCRIPTION
## Description

The macOS one-liner spent most of its 92 characters on `raw.githubusercontent.com` plus `owner/repo/branch`. Now that the docs site is published, it serves the installer too:

```sh
bash -c "$(curl -fsSL https://athrvk.github.io/vayu/install.sh)"   # 92 -> 64 chars
```

`install.sh` **stays at the repo root**, which is where `shellcheck install.sh` and `scripts/test/install_test.sh` look for it. A copy under `docs/` would be a second copy of an executable script, free to drift from the tested one with nothing failing - so `.github/hooks/install_script.py` registers the root script as a generated file at the site root instead, the same trick `hooks/brand_assets.py` already uses for the app icon.

That makes `install.sh` a docs-site input, so it joins the `paths:` filters of `workflows/docs.yml` on both `push` and `pull_request`. That line is load-bearing: without it, editing the installer would not redeploy the site and the published copy would silently fall behind master - a failure mode the raw URL did not have, since it served the branch directly.

The old `raw.githubusercontent.com` URL is untouched and keeps working, so existing links and bookmarks are fine.

Kept the `bash -c "$(curl ...)"` wrapper rather than moving to `curl ... | bash` (which would have been 6 characters shorter): the wrapper buffers the whole script before running any of it, and leaves stdin on the terminal so the installer can grow an interactive prompt later. `sudo -v` reads `/dev/tty`, so both forms work today - this just keeps the door open.

Files:

- **`.github/hooks/install_script.py`** (new) - publishes the root script at the site root.
- **`.github/mkdocs.yml`** - hook wired in.
- **`.github/workflows/docs.yml`** - `install.sh` added to both `paths:` filters.
- **`README.md`** (3 commands), **`docs/index.md`** - URL swapped; the `/bin/bash` prefix dropped, since plain `bash` was already on `PATH` for the old command to have worked at all.
- **`install.sh`** - `--help` now prints the real URL instead of the `<url>` placeholder.
- **`CLAUDE.md`** - records the arrangement and the workflow-`paths:` coupling.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `mkdocs build --strict -f .github/mkdocs.yml` passes; `site/install.sh` is byte-identical to the repo-root file (`diff -q`), and the rendered home page emits the new command exactly.
- **Mutation-checked the hook's guard**: temporarily moving `install.sh` aside fails the build with `FileNotFoundError: docs site installer missing: ...` rather than publishing a 404 at the URL the instructions tell people to pipe into bash.
- `shellcheck install.sh` clean; `bash scripts/test/install_test.sh` 4/4 pass; `bash install.sh --help` renders the three commands correctly.

Note the URL goes live only after this merges and the docs workflow deploys - worth curling it once before pointing anything external at it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - no new test file; the hook is covered by `mkdocs build --strict` in CI, and the installer's existing shellcheck + dry-run tests still gate the script itself
- [x] I have updated documentation

## Related Issues

None - follow-up to the docs site now being published.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DX1HN7nN4GYpUfgDXCTDde)_