### PR TITLE
chore: keep session setup from leaving pnpm manifests dirty

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,4 +8,48 @@ fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
-python3 "$PROJECT_DIR/build.py" --setup
+# `build.py --setup` ends in `pnpm install`, and pnpm reserializes the manifests
+# it reads whenever it decides they need normalizing - migrating the deprecated
+# pnpm settings out of `app/.npmrc`, folding `allowBuilds` into
+# `onlyBuiltDependencies` (or back), reindenting the YAML on the way out. Which
+# of those fire depends on the pnpm build the environment happens to ship, so it
+# cannot be pinned down from inside the repo: pnpm 10.34.5 leaves the tree clean
+# on a cold `--frozen-lockfile` install, yet a session came up with
+# `app/pnpm-workspace.yaml` already rewritten and its `allowBuilds` block gone.
+#
+# The cost is a session that opens with a tracked file modified by nobody, which
+# reads as the user's own uncommitted work and invites a commit that quietly
+# drops config. Snapshot the manifests, then restore only the ones whose bytes
+# setup itself changed - an edit already in the working tree is inside the
+# snapshot, so it survives untouched.
+MANIFESTS=(
+  app/pnpm-workspace.yaml
+  app/pnpm-lock.yaml
+  app/package.json
+  app/.npmrc
+)
+
+snapshot_dir="$(mktemp -d)"
+trap 'rm -rf "$snapshot_dir"' EXIT
+
+for manifest in "${MANIFESTS[@]}"; do
+  [ -f "$PROJECT_DIR/$manifest" ] || continue
+  mkdir -p "$snapshot_dir/$(dirname "$manifest")"
+  cp -p "$PROJECT_DIR/$manifest" "$snapshot_dir/$manifest"
+done
+
+# Restore before propagating a failure: a setup that died midway is exactly when
+# a half-rewritten manifest is most likely to be left behind.
+setup_status=0
+python3 "$PROJECT_DIR/build.py" --setup || setup_status=$?
+
+for manifest in "${MANIFESTS[@]}"; do
+  [ -f "$snapshot_dir/$manifest" ] || continue
+  [ -f "$PROJECT_DIR/$manifest" ] || continue
+  if ! cmp -s "$snapshot_dir/$manifest" "$PROJECT_DIR/$manifest"; then
+    cp -p "$snapshot_dir/$manifest" "$PROJECT_DIR/$manifest"
+    echo "session-start: restored $manifest (rewritten during setup)" >&2
+  fi
+done
+
+exit "$setup_status"


### PR DESCRIPTION
## Description

A remote session opened with `app/pnpm-workspace.yaml` already modified in the working tree, by nobody:

```diff
-allowBuilds:
-    electron: true
-    electron-winstaller: true
-    esbuild: true
 onlyBuiltDependencies:
-    - electron
-    - electron-winstaller
-    - esbuild
+  - electron
+  - electron-winstaller
+  - esbuild
```

That is pnpm reserializing a manifest it decided needed normalizing. The repo declares the same three build-script packages in three places - `app/.npmrc` (`only-built-dependencies=`), `allowBuilds:`, and `onlyBuiltDependencies:` - and pnpm 10 migrates the deprecated `.npmrc` settings into `pnpm-workspace.yaml` and folds `allowBuilds` into `onlyBuiltDependencies` (or back), reindenting on the way out.

`.claude/hooks/session-start.sh` runs `build.py --setup`, which ends in `pnpm install`, so it is the setup path that can surface this. Worth stating plainly: **the exact pnpm build that did the rewrite is not identified**. pnpm 10.34.5 - the version this environment ships - leaves the tree clean on a cold `--frozen-lockfile` install of the real manifest, so the rewrite came from a different pnpm somewhere in environment provisioning. This change therefore guards the outcome rather than the trigger.

The cost of the dirty file is not cosmetic: it reads as the user's own uncommitted work, so the natural next step is to commit it - quietly dropping the `allowBuilds` block from the repo.

**The fix:** snapshot the app's pnpm manifests around the setup run, then restore only the ones whose bytes setup itself changed. An edit that was already in the working tree is inside the snapshot, so it survives untouched. Restore runs before a non-zero setup status is propagated, since a setup that dies midway is exactly when a half-rewritten manifest is most likely to be left behind.

Scope is one file, `.claude/hooks/session-start.sh`, which runs only in remote Claude Code environments (`CLAUDE_CODE_REMOTE=true`). No app, engine, build, or CI behaviour changes. The redundant `only-built-dependencies=` line in `app/.npmrc` is a plausible root cause and is left alone here - removing it is a separate call, since it changes what pnpm reads.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`shellcheck` clean. Behaviour verified against a fake project tree with a stub `build.py`, including a mutation check:

| Case | Result |
|---|---|
| Setup rewrites the manifest | restored, message on stderr |
| Setup rewrites it *and* exits non-zero | restored, exit code propagates (3) |
| Setup touches nothing | file untouched, no message, silent |
| Working tree already carried a user edit, setup then clobbers it | user edit preserved, not the committed version |
| Guard removed (pre-change hook) | file left dirty - confirms the guard is what fixes it |

Also ran the real hook end-to-end in this environment: `build.py --setup` completes, exit 0, working tree clean.

No app or engine tests were run - nothing this change touches is reachable from either suite.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - the hook has no existing test harness; verification is documented above
- [x] I have updated documentation - no doc describes this hook

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_018k5Ai9ypUZV3rnMWdE6zGJ)_