### PR TITLE
fix(app): stop electron:compile from type-checking test files it cannot resolve

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,scss,md,html,yml,yaml,cjs,mjs}\"",
 		"format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,scss,md,html,yml,yaml,cjs,mjs}\"",
-		"type-check": "tsc --noEmit",
+		"type-check": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.electron-test.json",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},

--- a/app/tsconfig.electron-test.json
+++ b/app/tsconfig.electron-test.json
@@ -1,0 +1,38 @@
+/*
+ * Type-checks the tests under `electron/`, which `tsconfig.node.json`
+ * deliberately excludes.
+ *
+ * Two configs because the electron tests need something the electron *build*
+ * must not have: `resolve.test.ts` imports `@/lib/dynamic-variables` to compare
+ * the renderer's dynamic-variable table against the main-process copy, and that
+ * comparison is the only thing keeping the deliberate duplication honest. Giving
+ * `tsconfig.node.json` the `@/*` mapping would let production code in
+ * `electron/` reach into `app/src/` too, and would drag renderer sources under
+ * an `outDir`/`rootDir` that exist to emit the main process. So the alias lives
+ * here, where nothing is emitted: `noEmit`, and a `rootDir` widened to `app/`
+ * so a renderer source pulled in by a test is not "outside rootDir".
+ *
+ * Wired into `pnpm type-check`, because nothing else checks these files - the
+ * root config includes `src` only, and `electron:compile` skips them. The
+ * missing `@/lib/dynamic-variables` module went unnoticed through CI and broke
+ * `python build.py --dev` for exactly that reason.
+ */
+{
+	"extends": "./tsconfig.node.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": true,
+		"rootDir": ".",
+		/* Renderer sources reached from a test are DOM code; `electron/` is not. */
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"types": ["node", "vitest/globals"],
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"],
+			"@shared/*": ["../shared/*"]
+		}
+	},
+	"include": ["electron/**/*.test.ts"],
+	/* Undo the inherited exclusion - these files are the whole point here. */
+	"exclude": []
+}

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -11,5 +11,11 @@
 		"rootDir": "electron",
 		"noEmit": false
 	},
-	"include": ["electron"]
+	"include": ["electron"],
+	/*
+	 * Tests are not part of the main process - emitting them shipped vitest
+	 * imports into `dist-electron`, and `resolve.test.ts` reaches across to
+	 * `app/src/` (see tsconfig.electron-test.json, which checks them instead).
+	 */
+	"exclude": ["electron/**/*.test.ts"]
 }

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -62,7 +62,8 @@ app/
 ├── package.json        # Dependencies and scripts
 ├── vite.config.ts      # Vite configuration
 ├── tsconfig.json       # TypeScript config (React)
-└── tsconfig.node.json  # TypeScript config (Electron)
+├── tsconfig.node.json  # TypeScript config (Electron main process)
+└── tsconfig.electron-test.json  # Type-check config (Electron tests)
 ```
 
 ## Build Scripts
@@ -77,7 +78,7 @@ app/
 | `pnpm electron:watch` | Watch Electron code for changes |
 | `pnpm electron:build` | Full production build (compile + build + package) |
 | `pnpm electron:pack` | Package Electron app (requires build first) |
-| `pnpm type-check` | TypeScript type checking |
+| `pnpm type-check` | TypeScript type checking (renderer, main process, and the Electron tests) |
 | `pnpm lint` | Run ESLint |
 
 ## Development Workflow
@@ -169,11 +170,23 @@ Configuration is in `electron-builder.json`:
 - JSX: React
 - Path aliases: `@/*` → `src/*`
 
-### Electron (`tsconfig.node.json`)
+### Electron main process (`tsconfig.node.json`)
 
 - Target: ES2020
-- Module: CommonJS (for Electron compatibility)
-- Includes `electron/` directory
+- Module: ESNext (the app is `"type": "module"`)
+- Includes `electron/`, emitting to `dist-electron/`
+- Excludes `electron/**/*.test.ts` - tests are not part of the main process, and
+  emitting them put vitest imports in the shipped bundle
+
+### Electron tests (`tsconfig.electron-test.json`)
+
+- `noEmit` - it exists to type-check what `tsconfig.node.json` excludes
+- Adds the `@/*` → `src/*` alias, which the main-process config deliberately
+  lacks: only a test may cross into `app/src/` (`resolve.test.ts` compares the
+  renderer's dynamic-variable table against the main-process copy)
+- Run by `pnpm type-check`; without it nothing checked these files, and a
+  missing module in `resolve.test.ts` passed CI while breaking
+  `python build.py --dev`
 
 ## Vite Configuration
 


### PR DESCRIPTION
## Description

`pnpm electron:compile` (`tsc -p tsconfig.node.json`) fails, which breaks `python build.py --dev` and `pnpm electron:build`:

```
electron/mcp/resolve.test.ts(30,8): error TS2307: Cannot find module '@/lib/dynamic-variables' or its corresponding type declarations.
```

It was reported on macOS but is not platform-specific - it reproduces on Linux from a clean `dist-electron`. A stale `tsconfig.node.tsbuildinfo` is what hides it until the next clean build.

**Cause.** `tsconfig.node.json` includes the whole `electron/` directory, tests included. `electron/mcp/resolve.test.ts` imports `@/lib/dynamic-variables` on purpose - it compares the renderer's dynamic-variable table against the main-process copy, which is the only thing keeping that deliberate duplication honest - and the config carries no `@/*` mapping. Introduced in 96cba59.

CI stayed green because nothing type-checks `electron/` at all: `pnpm type-check` is `tsc --noEmit` against the root config, whose `include` is `src` only.

**Changes** (all in `app/`):

- **`tsconfig.node.json` excludes `electron/**/*.test.ts`.** They never belonged in the emitting config - they were also being emitted into `dist-electron/`, which electron-builder's `files` ships whole, so compiled tests and their vitest imports were going into the packaged app.
- **New `tsconfig.electron-test.json`** type-checks them instead: `noEmit`, plus the `@/*` → `src/*` alias. Keeping the alias out of the build config is deliberate - only a test may cross into `app/src/`.
- **`pnpm type-check` now runs all three configs**, so this class of error fails the PR job instead of the release build.
- **`docs/app/building.md`** documents the new config; also corrects the stale "Module: CommonJS" line in the section being edited (it is ESNext).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- Reproduced the failure on Linux from a wiped `dist-electron` + `tsconfig.node.tsbuildinfo`.
- `pnpm electron:compile` clean after the fix: no test files emitted, all main-process modules (`main.js`, `preload.js`, `sidecar.js`, `mcp/*`) present.
- `pnpm type-check` clean across all three configs; `--listFiles` confirms `resolve.test.ts`, `src/lib/dynamic-variables.ts` and `src/constants/variables.ts` are actually in the new program, so the cross-boundary import is genuinely checked rather than skipped.
- Mutation-checked the new config: pointing the import at a nonexistent module reproduces TS2307, restoring it goes green.
- `pnpm test` - 237 files / 2072 tests passing.
- `pnpm lint` reports 108 pre-existing problems, an identical count with these changes stashed - untouched by this diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - build-config change; covered by `pnpm type-check` now running the electron configs
- [x] I have updated documentation

## Related Issues

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K21EYSf2Agt1fRCa7vw5qH)_