### PR TITLE
fix(engine,app): one error-body shape, so validation messages reach the user

### DIFF
--- a/app/src/modules/collections/ImportModal.import-error.test.tsx
+++ b/app/src/modules/collections/ImportModal.import-error.test.tsx
@@ -7,16 +7,29 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-// Force the import mutation to reject so we can assert the modal surfaces the failure.
+// Force the import mutation to reject so we can assert the modal surfaces the
+// failure. `rejection` is per-test so one case can fail with a plain Error and
+// another with the engine's per-item ApiError.
+const state = vi.hoisted(() => ({ rejection: new Error("import boom") as unknown }));
+
 vi.mock("@/queries/import", () => ({
 	useImportMutation: () => ({
-		mutateAsync: vi.fn().mockRejectedValue(new Error("import boom")),
+		mutateAsync: vi.fn().mockImplementation(async ({ result }) => {
+			// The real mutation stamps temp ids onto this same object before it
+			// sends it, and the modal's failure message resolves the engine's temp
+			// id back through it - so a fake that skips that step would test a
+			// lookup that can never hit.
+			assignTempIds(result);
+			throw state.rejection;
+		}),
 		isPending: false,
 	}),
 }));
 
 import { ImportModal } from "./ImportModal";
 import { useImportModalStore } from "@/stores";
+import { ApiError } from "@/services/http-client";
+import { assignTempIds } from "@/services/importers/assign-ids";
 
 const postman = readFileSync(
 	join(__dirname, "../../services/importers/__fixtures__/postman-v21.json"),
@@ -44,9 +57,13 @@ function selectTab(name: RegExp) {
 }
 
 describe("ImportModal - failed import", () => {
-	beforeEach(() => useImportModalStore.setState({ isOpen: true }));
+	beforeEach(() => {
+		useImportModalStore.setState({ isOpen: true });
+		state.rejection = new Error("import boom");
+	});
 
-	it("surfaces the error when the import rejects (modal stays open)", async () => {
+	/** Drive the modal to the point where Import has been clicked and has failed. */
+	async function failAnImport() {
 		renderModal();
 		selectTab(/Paste JSON/i);
 		fireEvent.change(screen.getByPlaceholderText(/Paste/i), { target: { value: postman } });
@@ -54,8 +71,28 @@ describe("ImportModal - failed import", () => {
 		await waitFor(() =>
 			expect(screen.getByRole("button", { name: /^Import/i })).toBeInTheDocument()
 		);
-
 		fireEvent.click(screen.getByRole("button", { name: /^Import/i }));
+	}
+
+	it("surfaces the error when the import rejects (modal stays open)", async () => {
+		await failAnImport();
 		await waitFor(() => expect(screen.getByText(/import boom/i)).toBeInTheDocument());
+	});
+
+	/**
+	 * The documented contract of `POST /import/apply` is that a failure "names the
+	 * item that broke" - and until issue #173 that name died at this hop: the
+	 * engine's message was dropped by the http-client and the temp id was never
+	 * read at all, so a 500-item import failed with "HTTP 400: Bad Request".
+	 */
+	it("names the item the engine rejected, by the name shown in the preview", async () => {
+		state.rejection = new ApiError(400, "bad_request", "Missing required field: method", {
+			error: { code: "bad_request", message: "Missing required field: method", item: "c1" },
+		});
+
+		await failAnImport();
+		await waitFor(() =>
+			expect(screen.getByText(/Missing required field: method \(item: "/)).toBeInTheDocument()
+		);
 	});
 });

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -26,6 +26,7 @@ import { useImportMutation } from "@/queries/import";
 import { apiService } from "@/services/api";
 import { parseImport } from "@/services/importers/factory";
 import { UnrecognisedFormatError, type ImportResult } from "@/services/importers/types";
+import { importFailureMessage } from "@/services/importers/failure-message";
 import { MethodBadge } from "@/components/shared";
 
 type Tab = "file" | "url" | "paste";
@@ -143,7 +144,10 @@ export function ImportModal() {
 			// globals write) leaves the tree committed. Surface the error and leave the
 			// modal in its error phase; the mutation invalidates on every outcome, so
 			// whatever did land is already visible behind this dialog.
-			setError((e as Error).message || "Import failed");
+			//
+			// The engine names the item that broke by its temp id; `importFailureMessage`
+			// resolves that back to the name shown in the preview (issue #173).
+			setError(importFailureMessage(e, result));
 			setPhase("error");
 		}
 	};

--- a/app/src/services/http-client.error-shape.test.ts
+++ b/app/src/services/http-client.error-shape.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the user is shown when an engine call fails (issue #173).
+ *
+ * The regression this closes is not a wrong status code - those always worked -
+ * it is a *dropped message*. The engine writes "Missing required field: name";
+ * the client used to read `errorData.error.message` only, which on the flat
+ * `{"error": "..."}` body the CRUD routes emitted is `undefined`, so the save
+ * dialog said "HTTP 400: Bad Request" and the reason never reached anyone.
+ *
+ * Every case here therefore asserts the **text** on the thrown ApiError.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { httpClient, ApiError } from "./http-client";
+
+/** A fetch that answers once with the given status and body. */
+function respondWith(status: number, body: unknown, ok = false) {
+	const text = typeof body === "string" ? body : JSON.stringify(body);
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({
+			ok,
+			status,
+			statusText: status === 400 ? "Bad Request" : "Not Found",
+			json: async () => JSON.parse(text),
+		})
+	);
+}
+
+async function failedGet(): Promise<ApiError> {
+	try {
+		await httpClient.get("/collections");
+	} catch (e) {
+		return e as ApiError;
+	}
+	throw new Error("expected the request to reject");
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("httpClient error bodies", () => {
+	it("surfaces the engine's message and code from the nested shape", async () => {
+		respondWith(400, {
+			error: { code: "bad_request", message: "Missing required field: name" },
+		});
+
+		const error = await failedGet();
+		expect(error).toBeInstanceOf(ApiError);
+		expect(error.message).toBe("Missing required field: name");
+		expect(error.errorCode).toBe("bad_request");
+		expect(error.statusCode).toBe(400);
+	});
+
+	it("keeps a route's own code rather than flattening it to the status default", async () => {
+		respondWith(400, {
+			error: { code: "invalid_config", message: "'workers' must be at most 256 (got 9999)" },
+		});
+
+		const error = await failedGet();
+		expect(error.errorCode).toBe("invalid_config");
+		expect(error.message).toContain("9999");
+	});
+
+	// The sidecar and the app are not updated atomically, so a new app can meet
+	// an engine that predates the migration. Its message must still be read.
+	it("still reads the legacy flat body a pre-#173 engine sends", async () => {
+		respondWith(404, { error: "Collection not found" });
+
+		const error = await failedGet();
+		expect(error.message).toBe("Collection not found");
+		expect(error.errorCode).toBe("UNKNOWN_ERROR");
+	});
+
+	it("falls back to the status line when the body carries no message", async () => {
+		respondWith(400, {});
+
+		const error = await failedGet();
+		expect(error.message).toBe("HTTP 400: Bad Request");
+	});
+
+	it("falls back to the status line when the body is not JSON at all", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: false,
+				status: 400,
+				statusText: "Bad Request",
+				json: async () => {
+					throw new SyntaxError("Unexpected token <");
+				},
+			})
+		);
+
+		const error = await failedGet();
+		expect(error.message).toBe("HTTP 400: Bad Request");
+	});
+
+	it("keeps the raw body on the error so a caller can read extra detail", async () => {
+		respondWith(400, {
+			error: { code: "bad_request", message: "Duplicate tempId 'c1'", item: "c1" },
+		});
+
+		const error = await failedGet();
+		expect((error.response as { error: { item: string } }).error.item).toBe("c1");
+	});
+});

--- a/app/src/services/http-client.ts
+++ b/app/src/services/http-client.ts
@@ -85,20 +85,20 @@ class HttpClient {
 
 			if (!response.ok) {
 				const errorData = await response.json().catch(() => ({}));
-				// The engine emits two error shapes and always has. Most routes
-				// use `send_error` in routes.hpp, which writes a flat
-				// `{"error": "some message"}`; a handful (POST /config, the
-				// POST /runs config check, the auth pre-flight) write a nested
-				// `{"error": {"code", "message"}}`. Reading only the nested one
-				// meant every flat error - which is the large majority, and
-				// includes every validation message the requests, collections
-				// and environments routes produce - surfaced as a bare
-				// "HTTP 400" with the reason silently dropped.
+				// The engine emits one shape since issue #173:
+				// `{"error": {"code", "message"}}`, built by `error_body` in
+				// routes.hpp. It used to emit two - most routes wrote a flat
+				// `{"error": "some message"}` and a handful wrote the nested
+				// object - and reading only the nested one dropped every
+				// validation message the requests, collections and environments
+				// routes produce, surfacing them as a bare "HTTP 400".
 				//
-				// Accept both here rather than converting 38 call sites across
-				// nine route files: the fix belongs wherever the payload is
-				// read, it makes every existing flat error legible at once, and
-				// a route that later moves to the nested shape keeps working.
+				// The flat branch stays as a fallback, not as an alternative
+				// contract: the app and the engine sidecar are not updated
+				// atomically, so a new app can be talking to an older engine,
+				// and reading its message is better than showing the status
+				// line. Anything else - a body that is not JSON, an `error`
+				// that is neither - still falls back to the status text.
 				const rawError: unknown = errorData?.error;
 				const nested = typeof rawError === "object" && rawError !== null;
 				const errorCode = nested

--- a/app/src/services/importers/failure-message.test.ts
+++ b/app/src/services/importers/failure-message.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `POST /import/apply` names the item that broke, and this is the last hop of
+ * that contract (issue #173): the name the user recognises, not the temp id the
+ * engine speaks in.
+ */
+
+import { describe, it, expect } from "vitest";
+import { ApiError } from "@/services/http-client";
+import { importFailureMessage } from "./failure-message";
+import type { ImportResult } from "./types";
+
+function result(): ImportResult {
+	return {
+		collections: [
+			{
+				tempId: "c1",
+				name: "Payments API",
+				description: "",
+				variables: {},
+				auth: { mode: "none" },
+				preRequestScript: "",
+				postRequestScript: "",
+				children: [
+					{
+						tempId: "c2",
+						name: "Refunds",
+						description: "",
+						variables: {},
+						auth: { mode: "none" },
+						preRequestScript: "",
+						postRequestScript: "",
+						children: [],
+						requests: [
+							{
+								tempId: "r9",
+								name: "Create refund",
+								description: "",
+								method: "POST",
+								url: "https://x/refunds",
+								params: [],
+								headers: [],
+								body: { mode: "none" },
+								auth: { mode: "inherit" },
+								preRequestScript: "",
+								postRequestScript: "",
+							},
+						],
+					},
+				],
+				requests: [],
+			},
+		],
+		environments: [{ tempId: "e1", name: "Staging", description: "", variables: {} }],
+		globals: {},
+		meta: {
+			format: "postman-v21",
+			requestCount: 1,
+			folderCount: 2,
+			environmentCount: 1,
+			globalCount: 0,
+			skipped: [],
+			nonExecutableAuth: 0,
+		},
+	};
+}
+
+function importError(body: unknown): ApiError {
+	return new ApiError(400, "bad_request", "Missing required field: method", body);
+}
+
+describe("importFailureMessage", () => {
+	it("names the failing item by the name shown in the preview", () => {
+		const error = importError({
+			error: { code: "bad_request", message: "Missing required field: method", item: "r9" },
+		});
+
+		expect(importFailureMessage(error, result())).toBe(
+			'Missing required field: method (item: "Create refund")'
+		);
+	});
+
+	it("finds an item nested inside a child collection, and an environment", () => {
+		const nested = importError({ error: { item: "c2" } });
+		const environment = importError({ error: { item: "e1" } });
+
+		expect(importFailureMessage(nested, result())).toContain('"Refunds"');
+		expect(importFailureMessage(environment, result())).toContain('"Staging"');
+	});
+
+	// A pre-#173 engine put the temp id at the top level; the app and the sidecar
+	// are not updated together, so that reading has to keep working.
+	it("reads the legacy top-level item field", () => {
+		const error = importError({ error: "Duplicate tempId 'c1'", item: "c1" });
+
+		expect(importFailureMessage(error, result())).toContain('"Payments API"');
+	});
+
+	it("falls back to the temp id when the parsed result no longer has that item", () => {
+		const error = importError({ error: { item: "r404" } });
+
+		expect(importFailureMessage(error, result())).toBe(
+			"Missing required field: method (item: r404)"
+		);
+	});
+
+	it("leaves a whole-payload failure (no item) as the engine's message", () => {
+		const error = new ApiError(400, "bad_request", "Body must be a JSON object", {
+			error: { code: "bad_request", message: "Body must be a JSON object" },
+		});
+
+		expect(importFailureMessage(error, result())).toBe("Body must be a JSON object");
+	});
+
+	it("handles a plain Error and an empty message without inventing detail", () => {
+		expect(importFailureMessage(new Error("Network error: failed"), result())).toBe(
+			"Network error: failed"
+		);
+		expect(importFailureMessage(new Error(""), result())).toBe("Import failed");
+		expect(importFailureMessage(undefined, null)).toBe("Import failed");
+	});
+});

--- a/app/src/services/importers/failure-message.ts
+++ b/app/src/services/importers/failure-message.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { ApiError } from "@/services/http-client";
+import type { ImportResult } from "./types";
+
+/**
+ * The temp id the engine named as the item that broke, whichever error shape the
+ * body arrived in.
+ *
+ * Since issue #173 every engine error is `{"error": {"code", "message", ...}}`
+ * and `/import/apply` puts the temp id inside that object. The top-level reading
+ * is the shape the engine emitted before that, kept because the app and the
+ * engine sidecar are not always updated together - a new app talking to an older
+ * engine still names the item rather than silently dropping it.
+ */
+function failedTempId(error: unknown): string | null {
+	if (!(error instanceof ApiError)) return null;
+	const body = error.response as { error?: { item?: unknown }; item?: unknown } | undefined;
+	const item = body?.error?.item ?? body?.item;
+	return typeof item === "string" && item.length > 0 ? item : null;
+}
+
+/**
+ * The name the user gave the item carrying `tempId`, if it is still in the
+ * parsed result.
+ *
+ * The dialog's `ImportResult` carries temp ids at this point because
+ * `assignTempIds` stamps them onto that same object in place, on the way into
+ * the mutation. If that ever stops being true the lookup simply misses and the
+ * caller falls back to the temp id - a worse message, not a broken one.
+ */
+function nameOfTempId(result: ImportResult, tempId: string): string | null {
+	const inCollection = (collections: ImportResult["collections"]): { name: string } | null => {
+		for (const c of collections) {
+			if (c.tempId === tempId) return c;
+			const request = c.requests.find((r) => r.tempId === tempId);
+			if (request) return request;
+			const child = inCollection(c.children);
+			if (child) return child;
+		}
+		return null;
+	};
+
+	const found =
+		inCollection(result.collections) ?? result.environments.find((e) => e.tempId === tempId);
+	return found ? found.name : null;
+}
+
+/**
+ * The text the import dialog shows when an import fails.
+ *
+ * `/import/apply` is atomic, so a failure names one item and persists nothing -
+ * but a temp id (`c1`, `r47`) means nothing to the person who chose the file.
+ * Resolving it back to the name they see in the preview is what makes a
+ * 500-item import diagnosable; the temp id is the fallback for an item the
+ * engine named but the parsed result no longer contains.
+ */
+export function importFailureMessage(error: unknown, result: ImportResult | null): string {
+	const message = (error instanceof Error ? error.message : "") || "Import failed";
+	const tempId = failedTempId(error);
+	if (!tempId) return message;
+
+	const name = result ? nameOfTempId(result, tempId) : null;
+	return `${message} (item: ${name ? `"${name}"` : tempId})`;
+}

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -62,6 +62,17 @@ class ApiError extends Error {
 }
 ```
 
+Every engine error body is `{"error": {"code", "message"}}`, so `message` is the
+engine's own text (a validation reason, a not-found) and `errorCode` is its
+`code` - per-status (`bad_request`, `not_found`, ...) unless the route names a
+more specific one. Two fallbacks sit behind that, and both matter: a body in the
+**legacy flat** shape (`{"error": "..."}`, which a pre-#173 engine sends and the
+sidecar's version can lag the app's) still yields its string as the message, and
+a body carrying neither falls back to `HTTP <status>: <statusText>`. `response`
+keeps the raw body, which is where per-error detail lives - `error.item` on a
+failed bulk import, the provider fields on `/oauth2`. See
+[the engine's error contract](../engine/api-reference.md).
+
 **Error Types:**
 - `isTimeout`: Request timeout
 - `isNetworkError`: Connection/DNS errors
@@ -208,9 +219,10 @@ takes as long as the stop does, and it **rejects with a 409** if the run's worke
 has not finished writing in time - nothing is deleted in that case. Callers must
 handle that rejection: `HistoryList` turns it into a toast telling the user to
 retry, and Settings' *Clear run history* already counts per-run failures through
-`Promise.allSettled`. The engine's error body is a bare `{"error": "..."}`
-string, which `httpClient` cannot read into `ApiError.message` (it looks for
-`error.message`), so the wording is the caller's, keyed off `statusCode`.
+`Promise.allSettled`. The wording of that toast is the caller's, keyed off
+`statusCode`, rather than the engine's message - which is a caller's choice now
+that `httpClient` reads the message on every error shape (issue #173), not a
+constraint.
 
 #### Scripting
 

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -81,7 +81,12 @@ create carrying an `id` is a `400`, on the single-resource routes and per item i
   environment / globals queries, which refetch.
 - **No rollback, and no retry.** The engine write is atomic (validation over the whole
   payload, then one transaction), so a *rejected* payload persisted nothing and the error
-  the modal shows is the engine's, naming the item that broke. The old per-item loop needed
+  the modal shows is the engine's, naming the item that broke. The engine names it by
+  `tempId` (inside the error object - see
+  [api-reference](../../engine/api-reference.md));
+  `importFailureMessage` (`services/importers/failure-message.ts`) resolves that back to
+  the name shown in the preview, since `c37` means nothing to whoever chose the file.
+  The old per-item loop needed
   best-effort deletion of already-created roots; that code is gone. What atomicity does
   **not** cover is a lost response: `/import/apply` has no idempotency key and mints fresh
   ids per temp id on every call, so a second attempt after a committed-but-unanswered write

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2,16 +2,27 @@
 
 **Base URL:** `http://127.0.0.1:9876` (default, configurable via `--port`)
 
-All endpoints return JSON. Most error responses follow this format:
+All endpoints return JSON. **Every** error response has one shape - an `error`
+object carrying a machine-readable `code` and a human-readable `message`:
 
 ```json
 {
-  "error": "Error message"
+  "error": {
+    "code": "bad_request",
+    "message": "Missing required field: name"
+  }
 }
 ```
 
-The OAuth 2.0 endpoints (`/oauth2/*`) use a **nested** error shape that also
-carries a machine-readable code (and any provider detail):
+`code` is per-status unless the route names a more specific one: `bad_request`
+(400), `unauthorized` (401), `forbidden` (403), `not_found` (404), `conflict`
+(409), `bad_gateway` (502), `unavailable` (503), `internal_error` (5xx). Routes
+with their own vocabulary pass it instead - `invalid_config` (`POST /config`),
+`invalid_run_config` (`POST /runs`), and the `oauth2_*` family.
+
+Any per-error detail sits **inside** the same object, so a client reads one
+place for the whole failure - `item` on `POST /import/apply`, the provider's
+reply on `/oauth2/*`:
 
 ```json
 {
@@ -23,6 +34,11 @@ carries a machine-readable code (and any provider detail):
   }
 }
 ```
+
+Most routes used to emit a flat `{"error": "message"}` instead, which the app's
+http-client could not read - every validation message surfaced as a bare
+`HTTP 400` (issue #173). The client still accepts the flat shape so a newer app
+can read an older engine, but the engine no longer produces it.
 
 ## Deprecated aliases
 
@@ -77,7 +93,7 @@ A create must **not** carry an `id`. The engine generates one via `generate_id`,
 giving the `<prefix>_<uuidv4>` form, and a body containing the field is a `400`:
 
 ```json
-{"error": "id is assigned by the engine; omit it (bulk import: POST /import/apply)"}
+{"error": {"code": "bad_request", "message": "id is assigned by the engine; omit it (bulk import: POST /import/apply)"}}
 ```
 
 Presence alone is rejected, `null` included - `id` is not a settable field with a
@@ -91,14 +107,14 @@ anything was persisted; import sends one
 
 On `PUT`, the path is the identity. A body `id` matching it is accepted and
 ignored; one that disagrees - including `null` - is a `400`
-(`{"error": "Body 'id' must match the id in the path ('col_1') or be omitted"}`),
+(message `Body 'id' must match the id in the path ('col_1') or be omitted`),
 because the payload otherwise names two different records and guessing between
 them is how a `PUT` to one id rewrites another. This is checked before the record
 is looked up, so a malformed body answers `400` whether or not the target exists.
 
 Since no create can select an id, the pre-existing "id already exists" `409` -
 whose body names the update path, e.g.
-`{"error": "Collection 'col_1' already exists; use PUT /collections/:id to update"}` -
+message `Collection 'col_1' already exists; use PUT /collections/:id to update` -
 is now reachable only on a `generate_id` collision, which 122 bits of entropy put
 out of reach. It stays as a guard: on that draw the alternative is overwriting a
 live record.
@@ -135,7 +151,7 @@ verb rather than a silently discarded write. Those fields are a collection's
 
 A field that is present and not `null` must have the shape below, on both verbs.
 Anything else is a `400` naming the field, e.g.
-`{"error": "Invalid 'auth': must be a JSON object"}`.
+message `Invalid 'auth': must be a JSON object`.
 
 | Field | Shape |
 |---|---|
@@ -366,12 +382,11 @@ on a cycle (below).
 
 **Cycle validation (both verbs):** `parentId` is validated to keep the
 collection tree acyclic, since a
-cycle would make the cascade delete below loop forever. Both cases return `400`
-with the flat `{"error": message}` shape:
+cycle would make the cascade delete below loop forever. Both cases return `400`:
 
-- `parentId` equal to the collection's own `id` - `{"error": "A collection cannot be its own parent"}`.
+- `parentId` equal to the collection's own `id` - message `A collection cannot be its own parent`.
 - `parentId` pointing at one of the collection's own descendants (a reparent that
-  would form a cycle) - `{"error": "Cannot move a collection into its own descendant"}`.
+  would form a cycle) - message `Cannot move a collection into its own descendant`.
 
 Parent *existence* is intentionally not checked: the import orchestrator creates
 collections in bulk, so requiring the parent to exist first would couple to
@@ -584,10 +599,10 @@ invalid UTF-8 replaced rather than throwing, so binary or malformed content can
 never turn into a `500`.
 
 **Errors:**
-- `400` `{ "error": "Invalid JSON body" }` - the request body did not parse.
-- `400` `{ "error": "Invalid URL" }` - `url` is missing, not a string, or does
+- `400` `Invalid JSON body` - the request body did not parse.
+- `400` `Invalid URL` - `url` is missing, not a string, or does
   not start with `http://` / `https://`.
-- `502` `{ "error": "Failed to fetch: <detail>" }` - the upstream request failed
+- `502` `Failed to fetch: <detail>` - the upstream request failed
   (connection error, transport failure).
 
 ### POST /import/apply
@@ -655,28 +670,35 @@ Every `tempId` sent appears in `idMap`.
 and the write itself is a single SQLite transaction. A `400` therefore means
 **nothing was persisted** - there is no partial tree to clean up.
 
-**Errors:** every `400` carries `error`, and the per-item ones also carry `item`
-(the offending `tempId`) so a large import can name what broke.
-- `400` `{ "error": "Invalid JSON body" }` - the body did not parse.
-- `400` `{ "error": "Body must be a JSON object" }`.
-- `400` `{ "error": "Invalid 'collections': must be an array" }` - a section was
+**Errors:** every `400` uses the standard error object, and the per-item ones add
+an `item` key **inside** it (the offending `tempId`) so a large import can name
+what broke:
+
+```json
+{ "error": { "code": "bad_request", "message": "Duplicate tempId 'c1'", "item": "c1" } }
+```
+
+Messages, by case:
+- `400` `Invalid JSON body` - the body did not parse.
+- `400` `Body must be a JSON object`.
+- `400` `Invalid 'collections': must be an array` - a section was
   present but not an array (same for `requests` / `environments`).
-- `400` `{ "error": "Invalid collection at index 2: 'tempId' must be a non-empty string" }`.
-- `400` `{ "error": "Invalid collection at index 0: 'id' is not accepted - the engine assigns ids; reference items by 'tempId'" }`.
-- `400` `{ "error": "Duplicate tempId 'c1'", "item": "c1" }`.
-- `400` `{ "error": "Unknown parentTempId 'c9'", "item": "c2" }`, and the same for
+- `400` `Invalid collection at index 2: 'tempId' must be a non-empty string`.
+- `400` `Invalid collection at index 0: 'id' is not accepted - the engine assigns ids; reference items by 'tempId'`.
+- `400` `Duplicate tempId 'c1'`, with `item: "c1"`.
+- `400` `Unknown parentTempId 'c9'`, with `item: "c2"`, and the same for
   `collectionTempId` - including a `collectionTempId` that names an environment
   rather than a collection.
-- `400` `{ "error": "Cycle in parentTempId references at 'c1'", "item": "c2" }` -
+- `400` `Cycle in parentTempId references at 'c1'`, with `item: "c2"` -
   a cycle (including a self-parent) in the payload's own parent graph. The
   stored-tree walk that guards `POST /collections` cannot see this one, because
   none of these rows exist yet, and a cycle makes cascade delete loop forever
   (issue #79).
-- `400` `{ "error": "Missing required field: name", "item": "c1" }` and the other
+- `400` `Missing required field: name`, with `item: "c1"`, and the other
   per-field errors of the matching `POST /<resource>`, including a wrong-typed
   field (`"name": 42`), which is a `400` rather than a `500`.
-- `400` `{ "error": "Import too large: 10001 items exceeds the limit of 10000 per call" }`.
-- `500` `{ "error": "<detail>" }` - the transaction itself failed; nothing was
+- `400` `Import too large: 10001 items exceeds the limit of 10000 per call`.
+- `500` `<detail>` - the transaction itself failed; nothing was
   written.
 
 ## Environments
@@ -878,8 +900,8 @@ else re-acquires). `interactive` is only used for the `authorization_code` grant
 ```
 
 `expiresAt` is `null` for a non-expiring token; `scope` is omitted when empty.
-Errors use the nested shape: `400` invalid config, `401` provider rejected the
-request, `409` interactive authorization required, `502` network error.
+Errors carry an `oauth2_*` code: `400` invalid config, `401` provider rejected
+the request, `409` interactive authorization required, `502` network error.
 
 #### GET /oauth2/token?key=&lt;cacheKey&gt;
 
@@ -1151,9 +1173,8 @@ load.
 
 **Accepted ranges.** The numeric config is range-checked **before the run row is
 created**, so a rejected request leaves no `pending` row behind. A violation is
-a `400` carrying the nested error shape (`{"error": {"code":
-"invalid_run_config", "message": "..."}}`), whose message names the offending
-field and why the bound exists:
+a `400` whose `error.code` is `invalid_run_config` rather than the per-status
+default, and whose message names the offending field and why the bound exists:
 
 | Field | Accepted | Rejected because |
 |-------|----------|------------------|
@@ -1174,7 +1195,7 @@ collector, so the modulo cannot divide by zero even for a caller that bypasses
 this route.
 
 **Shutdown refuses new runs.** Once the daemon has begun draining its run
-workers, `POST /runs` answers `503 {"error": "Engine is shutting down"}` rather
+workers, `POST /runs` answers `503` with the message `Engine is shutting down` rather
 than accepting a run nothing will ever execute. The window is small - the HTTP
 server stops before the drain begins - but it is not empty, and a request
 already in a handler when the drain starts must not be able to spawn a worker
@@ -1183,7 +1204,7 @@ past it (see `RunManager::shutdown`).
 **Auth pre-flight.** When `auth.mode` is `oauth2`, the run route resolves the
 token **before** creating the run and warms the cache for the workers. An
 unauthorizable config is rejected up front with `409` (interactive sign-in
-required) or `400`, using the nested `/oauth2` error shape, so a bad token never
+required) or `400`, carrying the `/oauth2` error codes, so a bad token never
 surfaces as a silently-failed run.
 
 **Concurrency model.** `constant_concurrency`, `ramp_up`, and `iterations` are
@@ -1303,7 +1324,7 @@ the `requests_sent` row having already been seen for the same timestamp, and the
 producer writes `error_rate` first, so it read a completed count of 0 and every
 bucket of every run reported 0 failed requests.
 
-A missing run returns `404` with `{"error":"Run not found"}`.
+A missing run returns `404` with the message `Run not found`.
 
 **Storage (response shape unchanged).** Each `data[]` entry is one stored row of
 `metric_ticks` - the engine writes the tick object once, at write time, instead
@@ -1751,7 +1772,10 @@ daemon restarted under it) has nobody to race and is deleted immediately.
 **409 Conflict** (still stopping - nothing was deleted):
 ```json
 {
-  "error": "Run is still stopping; it was not deleted. Retry once it reports a terminal status."
+  "error": {
+    "code": "conflict",
+    "message": "Run is still stopping; it was not deleted. Retry once it reports a terminal status."
+  }
 }
 ```
 

--- a/docs/plans/pending-backlog.md
+++ b/docs/plans/pending-backlog.md
@@ -18,10 +18,6 @@ Against `/fast` on loopback, tuned Vayu reaches ~45k req/s (vs `wrk` ~51k), but 
 
 **Needs:** lower the default `workers`; make the connection cap a **global budget** (or auto-derive from workers); bound the default `maxInFlight`. (Confirmed PR #10 is NOT the cause; ceiling is long-standing architecture. The branch-only 12-worker collapse was traced to added per-completion CPU and only bites at `workers=ncpu`.) Needs a spec.
 
-### P3. Remaining flat-error routes swallowed by the app client _(surfaced 2026-07-18 during P2)_
-
-The generic `send_error` helper (`routes.hpp:39`) emits flat `{"error":"<string>"}`, but `http-client.ts` only reads the nested `error.message`/`error.code`. Every route still using the flat helper (e.g. `config.cpp`'s "Invalid JSON", `execution.cpp:287/456`, `health`, 500 fallbacks) therefore shows a bare `HTTP <status>` in the UI, dropping the message. P2 fixed only the `/config` validation path. **Needs:** either migrate `send_error` to the nested shape (audit all call sites - some may rely on the flat body) or teach the client to accept both. Small, but cross-cutting. Low priority - most of these are developer-facing.
-
 ---
 
 ## Janitorial

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -402,6 +402,7 @@ if(VAYU_BUILD_TESTS)
         tests/runs_route_test.cpp
         tests/collections_route_test.cpp
         tests/resource_write_route_test.cpp
+        tests/error_shape_route_test.cpp
         tests/globals_route_test.cpp
         tests/script_variables_test.cpp
         tests/stats_route_test.cpp

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -13,6 +13,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "vayu/core/run_manager.hpp"
@@ -38,11 +39,79 @@ inline int64_t now_ms () {
 }
 
 /**
+ * @brief The error code an error body carries when its call site does not name one.
+ *
+ * Codes are per-status rather than per-message so a caller can branch on the
+ * class of failure without string-matching the message, and so the ~50 existing
+ * call sites needed no per-site invention. A route that has a more specific code
+ * (`invalid_config`, the `oauth2_*` family) passes it explicitly.
+ */
+inline const char* default_error_code (int status) {
+    switch (status) {
+    case 400: return "bad_request";
+    case 401: return "unauthorized";
+    case 403: return "forbidden";
+    case 404: return "not_found";
+    case 409: return "conflict";
+    case 502: return "bad_gateway";
+    case 503: return "unavailable";
+    default: return status >= 500 ? "internal_error" : "error";
+    }
+}
+
+/**
+ * @brief The one error body shape the engine emits: `{"error": {"code", "message"}}`.
+ *
+ * The engine used to emit two shapes - this nested one from `/config` and
+ * `/oauth2`, and a flat `{"error": "<message>"}` from `send_error` and the
+ * testable-core route helpers. The app's shared http-client reads
+ * `errorData.error.message`, and on a flat body that is `undefined` (a string
+ * carries no `.message`), so every validation message the CRUD routes built was
+ * dropped and surfaced as a bare "HTTP 400" (issue #173). Build error bodies
+ * here rather than inline, so a new route cannot reintroduce the split.
+ *
+ * Extra per-error detail belongs *inside* the nested object (see `item_error`
+ * in import.cpp), which keeps `error` the single place a client has to look.
+ */
+inline nlohmann::json
+error_body (int status, const std::string& message, std::string_view code = {}) {
+    const std::string error_code =
+    code.empty () ? default_error_code (status) : std::string (code);
+    return nlohmann::json{ { "error",
+    { { "code", error_code }, { "message", message } } } };
+}
+
+/**
+ * @brief Read the human-readable message out of an error body.
+ *
+ * Route handlers log the message of the response their testable core returned,
+ * and a raw `body["error"].get<std::string>()` throws once that value is an
+ * object - turning a 404 log line into a 500. Tolerates the legacy flat shape
+ * so this is also safe against a body built elsewhere.
+ */
+inline std::string error_message_of (const nlohmann::json& body) {
+    const auto error = body.find ("error");
+    if (error == body.end ()) {
+        return {};
+    }
+    if (error->is_string ()) {
+        return error->get<std::string> ();
+    }
+    if (error->is_object () && error->contains ("message") && (*error)["message"].is_string ()) {
+        return (*error)["message"].get<std::string> ();
+    }
+    return error->dump ();
+}
+
+/**
  * @brief Send a JSON error response
  */
-inline void send_error (httplib::Response& res, int status, const std::string& message) {
+inline void send_error (httplib::Response& res,
+int status,
+const std::string& message,
+std::string_view code = {}) {
     res.status = status;
-    res.set_content (nlohmann::json{ { "error", message } }.dump (), "application/json");
+    res.set_content (error_body (status, message, code).dump (), "application/json");
 }
 
 /**
@@ -144,8 +213,7 @@ bool is_create) {
     }
     if (!value.is_object ()) {
         return std::make_pair (400,
-        nlohmann::json{
-        { "error", std::string ("Invalid '") + key + "': must be a JSON object" } });
+        error_body (400, std::string ("Invalid '") + key + "': must be a JSON object"));
     }
     out = value.dump ();
     return std::nullopt;
@@ -244,15 +312,13 @@ bool is_create) {
             return std::nullopt;
         }
         return std::make_pair (400,
-        nlohmann::json{ { "error",
-        std::string ("Invalid '") + key + "': '" + candidate +
-        "' is not a valid HTTP version. Valid values: " + http_version_valid_list () } });
+        error_body (400, std::string ("Invalid '") + key + "': '" + candidate +
+        "' is not a valid HTTP version. Valid values: " + http_version_valid_list ()));
     }
 
     return std::make_pair (400,
-    nlohmann::json{ { "error",
-    std::string ("Invalid '") + key +
-    "': must be a string. Valid values: " + http_version_valid_list () } });
+    error_body (400, std::string ("Invalid '") + key +
+    "': must be a string. Valid values: " + http_version_valid_list ()));
 }
 
 /**
@@ -266,14 +332,14 @@ apply_required_string_field (const nlohmann::json& json, const char* key, std::s
     if (!json.contains (key)) {
         if (is_create) {
             return std::make_pair (400,
-            nlohmann::json{ { "error", std::string ("Missing required field: ") + key } });
+            error_body (400, std::string ("Missing required field: ") + key));
         }
         return std::nullopt; // Absent on update -> keep.
     }
     if (json[key].is_null ()) {
         return std::make_pair (400,
-        nlohmann::json{ { "error",
-        std::string ("Invalid '") + key + "': null is not allowed (this field has no default)" } });
+        error_body (400, std::string ("Invalid '") + key +
+        "': null is not allowed (this field has no default)"));
     }
     out = json[key].get<std::string> ();
     return std::nullopt;
@@ -298,9 +364,8 @@ const nlohmann::json& json) {
         return std::nullopt;
     }
     return std::make_pair (400,
-    nlohmann::json{ { "error",
-    "id is assigned by the engine; omit it "
-    "(bulk import: POST /import/apply)" } });
+    error_body (400, "id is assigned by the engine; omit it "
+    "(bulk import: POST /import/apply)"));
 }
 
 /**
@@ -322,8 +387,7 @@ reject_mismatched_body_id (const nlohmann::json& json, const std::string& path_i
         return std::nullopt;
     }
     return std::make_pair (400,
-    nlohmann::json{ { "error",
-    "Body 'id' must match the id in the path ('" + path_id + "') or be omitted" } });
+    error_body (400, "Body 'id' must match the id in the path ('" + path_id + "') or be omitted"));
 }
 
 /**

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -42,8 +42,8 @@ namespace vayu::http::routes {
  * this fix to import ordering.
  *
  * Extracted so the wiring is covered without an in-process HTTP server - see
- * collections_route_test.cpp. The error body matches send_error's flat
- * `{"error": message}` shape.
+ * collections_route_test.cpp. The error body is built by `error_body`, like
+ * every other error the engine emits.
  */
 std::optional<std::pair<int, nlohmann::json>> validate_parent_assignment (
 vayu::db::Database& db, const std::string& id,
@@ -52,17 +52,15 @@ const std::optional<std::string>& parent_id) {
         return std::nullopt; // No parent -> no cycle possible.
     }
     if (*parent_id == id) {
-        return std::make_pair (400,
-        nlohmann::json{ { "error", "A collection cannot be its own parent" } });
+        return std::make_pair (400, error_body (400, "A collection cannot be its own parent"));
     }
 
     std::unordered_set<std::string> visited;
     std::optional<std::string> cursor = parent_id;
     while (cursor.has_value ()) {
         if (*cursor == id) {
-            return std::make_pair (400,
-            nlohmann::json{
-            { "error", "Cannot move a collection into its own descendant" } });
+            return std::make_pair (
+            400, error_body (400, "Cannot move a collection into its own descendant"));
         }
         if (!visited.insert (*cursor).second) {
             break; // Already seen -> pre-existing corrupt cycle; stop, bounded.
@@ -168,8 +166,8 @@ create_collection_response (vayu::db::Database& db, const nlohmann::json& json) 
 
     if (db.get_collection (id).has_value ()) {
         return { 409,
-            nlohmann::json{ { "error",
-            "Collection '" + id + "' already exists; use PUT /collections/:id to update" } } };
+            error_body (409, "Collection '" + id +
+            "' already exists; use PUT /collections/:id to update") };
     }
 
     vayu::db::Collection c;
@@ -203,7 +201,7 @@ const nlohmann::json& json) {
     }
     auto existing = db.get_collection (id);
     if (!existing) {
-        return { 404, nlohmann::json{ { "error", "Collection not found" } } };
+        return { 404, error_body (404, "Collection not found") };
     }
 
     vayu::db::Collection c = *existing;
@@ -252,7 +250,7 @@ void register_collection_routes (RouteContext& ctx) {
             auto [status, body] = create_collection_response (ctx.db, json);
             if (status != 200) {
                 vayu::utils::log_warning ("POST /collections - " +
-                std::to_string (status) + ": " + body["error"].get<std::string> ());
+                std::to_string (status) + ": " + error_message_of (body));
             } else {
                 vayu::utils::log_info (
                 "POST /collections - Created collection: id=" + body["id"].get<std::string> () +
@@ -284,7 +282,7 @@ void register_collection_routes (RouteContext& ctx) {
             if (status != 200) {
                 vayu::utils::log_warning ("PUT /collections/:id - " +
                 std::to_string (status) + " for id=" + collection_id + ": " +
-                body["error"].get<std::string> ());
+                error_message_of (body));
             } else {
                 vayu::utils::log_info (
                 "PUT /collections/:id - Updated collection: id=" + collection_id +

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -67,12 +67,11 @@ nlohmann::json config_entry_json (const vayu::db::ConfigEntry& entry) {
     return entry_json;
 }
 
-// Build the nested error body the app's http-client reads
-// (`errorData.error.message`); the flat `{"error": "..."}` shape is dropped by
-// the client and surfaces only as a bare "HTTP 400".
+// A /config validation failure, which names its own code rather than taking the
+// per-status default. Thin wrapper over the shared builder so the shape stays in
+// one place (routes.hpp).
 nlohmann::json config_error (const std::string& message) {
-    return nlohmann::json{ { "error",
-    { { "code", "invalid_config" }, { "message", message } } } };
+    return error_body (400, message, "invalid_config");
 }
 
 } // namespace

--- a/engine/src/http/routes/environments.cpp
+++ b/engine/src/http/routes/environments.cpp
@@ -66,8 +66,8 @@ create_environment_response (vayu::db::Database& db, const nlohmann::json& json)
 
     if (db.get_environment (id).has_value ()) {
         return { 409,
-            nlohmann::json{ { "error",
-            "Environment '" + id + "' already exists; use PUT /environments/:id to update" } } };
+            error_body (409, "Environment '" + id +
+            "' already exists; use PUT /environments/:id to update") };
     }
 
     vayu::db::Environment e;
@@ -97,7 +97,7 @@ const nlohmann::json& json) {
     }
     auto existing = db.get_environment (id);
     if (!existing) {
-        return { 404, nlohmann::json{ { "error", "Environment not found" } } };
+        return { 404, error_body (404, "Environment not found") };
     }
 
     vayu::db::Environment e = *existing;
@@ -146,7 +146,7 @@ void register_environment_routes (RouteContext& ctx) {
             auto [status, body] = create_environment_response (ctx.db, json);
             if (status != 200) {
                 vayu::utils::log_warning ("POST /environments - " +
-                std::to_string (status) + ": " + body["error"].get<std::string> ());
+                std::to_string (status) + ": " + error_message_of (body));
             } else {
                 vayu::utils::log_info (
                 "POST /environments - Created environment: id=" + body["id"].get<std::string> () +
@@ -179,7 +179,7 @@ void register_environment_routes (RouteContext& ctx) {
             if (status != 200) {
                 vayu::utils::log_warning ("PUT /environments/:id - " +
                 std::to_string (status) + " for id=" + environment_id + ": " +
-                body["error"].get<std::string> ());
+                error_message_of (body));
             } else {
                 vayu::utils::log_info (
                 "PUT /environments/:id - Updated environment: id=" + environment_id +

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -684,19 +684,11 @@ void register_execution_routes (RouteContext& ctx) {
         }
 
         // Range-check the numeric config *before* the run row exists, so a
-        // rejected request leaves nothing behind. The nested error shape is
-        // deliberate: the app's http-client reads `errorData.error.message`
-        // and drops the flat `{"error": "..."}` body, which would surface this
-        // as a bare "HTTP 400" with no reason (same shape as the auth
-        // pre-flight below and POST /config).
+        // rejected request leaves nothing behind. `invalid_run_config` is the
+        // specific code this failure carries in place of the per-status default.
         if (auto invalid = validate_run_config (json)) {
             vayu::utils::log_warning ("POST /runs - Invalid run config: " + *invalid);
-            res.status = 400;
-            res.set_content (
-            nlohmann::json{
-            { "error", { { "code", "invalid_run_config" }, { "message", *invalid } } } }
-            .dump (),
-            "application/json");
+            send_error (res, 400, *invalid, "invalid_run_config");
             return;
         }
 
@@ -759,10 +751,8 @@ void register_execution_routes (RouteContext& ctx) {
             preflight.message);
             res.status =
             (preflight.code == vayu::ErrorCode::AuthRequired) ? 409 : 400;
-            res.set_content (nlohmann::json{ { "error",
-                                 { { "code", preflight.detail_code },
-                                 { "message", preflight.message } } } }
-            .dump (),
+            res.set_content (
+            error_body (res.status, preflight.message, preflight.detail_code).dump (),
             "application/json");
             return;
         }

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -37,28 +37,28 @@ std::pair<int, nlohmann::json> import_fetch (const std::string& request_body) {
     try {
         req = nlohmann::json::parse (request_body);
     } catch (const std::exception&) {
-        return { 400, nlohmann::json{ { "error", "Invalid JSON body" } } };
+        return { 400, error_body (400, "Invalid JSON body") };
     }
 
     if (!req.contains ("url") || !req["url"].is_string ()) {
-        return { 400, nlohmann::json{ { "error", "Invalid URL" } } };
+        return { 400, error_body (400, "Invalid URL") };
     }
     const std::string url = req["url"].get<std::string> ();
     if (url.rfind ("http://", 0) != 0 && url.rfind ("https://", 0) != 0) {
-        return { 400, nlohmann::json{ { "error", "Invalid URL" } } };
+        return { 400, error_body (400, "Invalid URL") };
     }
 
     vayu::http::Client client;
     auto result = client.get (url);
     if (!result.is_ok ()) {
-        return { 502, nlohmann::json{ { "error", "Failed to fetch: " + client.last_error () } } };
+        return { 502, error_body (502, "Failed to fetch: " + client.last_error ()) };
     }
 
     const auto& resp = result.value ();
     if (resp.has_error ()) {
         const std::string detail =
         resp.error_message.empty () ? "connection error" : resp.error_message;
-        return { 502, nlohmann::json{ { "error", "Failed to fetch: " + detail } } };
+        return { 502, error_body (502, "Failed to fetch: " + detail) };
     }
     std::string content_type = "application/octet-stream";
     for (const auto& [key, value] : resp.headers) {
@@ -89,16 +89,19 @@ const nlohmann::json EMPTY_ITEMS = nlohmann::json::array ();
 
 /** A 400 about the payload as a whole. */
 std::pair<int, nlohmann::json> body_error (const std::string& message) {
-    return { 400, nlohmann::json{ { "error", message } } };
+    return { 400, error_body (400, message) };
 }
 
 /**
  * A 400 that names the offending item by its temp id, so a client importing
  * hundreds of items can point at the one that failed. `item` is part of the
- * endpoint's documented error shape.
+ * endpoint's documented error shape and sits *inside* the error object, next to
+ * the code and message, so a client reads one place for the whole failure.
  */
 std::pair<int, nlohmann::json> item_error (const std::string& message, const std::string& temp_id) {
-    return { 400, nlohmann::json{ { "error", message }, { "item", temp_id } } };
+    auto body                 = error_body (400, message);
+    body["error"]["item"]     = temp_id;
+    return { 400, body };
 }
 
 /**
@@ -279,7 +282,9 @@ apply_item_fields (Apply apply, const char* kind, const std::string& temp_id) {
         return item_error (std::string ("Invalid ") + kind + ": " + e.what (), temp_id);
     }
     if (err) {
-        err->second["item"] = temp_id;
+        // Inside the error object, next to the code and message the shared
+        // applier already built - the same place `item_error` puts it.
+        err->second["error"]["item"] = temp_id;
         return err;
     }
     return std::nullopt;
@@ -493,7 +498,7 @@ void register_import_routes (RouteContext& ctx) {
      * means none). Each item carries a `tempId`; a collection may carry
      * `parentTempId`, a request must carry `collectionTempId`. All other fields
      * are the ones the matching POST /<resource> accepts, minus `id`.
-     * Returns: 200 `{"idMap": {...}}`, or 400 with `{"error", "item"}` naming the
+     * Returns: 200 `{"idMap": {...}}`, or 400 with `error.item` naming the
      * item that failed - in which case nothing at all was written.
      */
     ctx.server.Post ("/import/apply",
@@ -513,7 +518,7 @@ void register_import_routes (RouteContext& ctx) {
             auto [status, response] = import_apply_response (ctx.db, body);
             if (status != 200) {
                 vayu::utils::log_warning ("POST /import/apply - " + std::to_string (status) +
-                ": " + response["error"].get<std::string> ());
+                ": " + error_message_of (response));
             } else {
                 vayu::utils::log_info ("POST /import/apply - applied " +
                 std::to_string (response["idMap"].size ()) + " items");

--- a/engine/src/http/routes/metrics.cpp
+++ b/engine/src/http/routes/metrics.cpp
@@ -78,8 +78,8 @@ int64_t offset) {
  * json_body}. Serves both `GET /runs/:id/metrics` (canonical) and the legacy
  * `GET /stats/:id?format=json`, so the two paths cannot drift.
  *
- * A missing run is a definitive 404 with the flat `{"error": message}` shape
- * `send_error` uses. Otherwise it returns the run's per-tick objects (the app's
+ * A missing run is a definitive 404 with the `{"error": {"code", "message"}}`
+ * shape `send_error` uses. Otherwise it returns the run's per-tick objects (the app's
  * snake_case `LoadTestMetrics` shape, consumed without a transformer) in the
  * `{data, pagination}` envelope - read straight from `metric_ticks`, or, for a
  * run recorded before that table existed, regrouped from its legacy EAV rows.
@@ -94,7 +94,7 @@ std::pair<int, nlohmann::json> run_time_series_response (vayu::db::Database& db,
 const std::string& run_id, int64_t limit, int64_t offset) {
     auto run = db.get_run (run_id);
     if (!run) {
-        return { 404, nlohmann::json{ { "error", "Run not found" } } };
+        return { 404, error_body (404, "Run not found") };
     }
 
     // Ticks decide the path: a run has them or it predates the table. Counting

--- a/engine/src/http/routes/oauth.cpp
+++ b/engine/src/http/routes/oauth.cpp
@@ -30,10 +30,15 @@ namespace vayu::http::routes {
 
 namespace {
 
-nlohmann::json error_body (const oauth::TokenError& err) {
-    nlohmann::json e;
-    e["code"]    = err.code;
-    e["message"] = err.message;
+/**
+ * A token failure in the shared error shape, with the provider's own reply
+ * carried as extra keys *inside* the error object - the same place
+ * `/import/apply` puts its `item`, so a client reads one object for the whole
+ * failure regardless of which route produced it.
+ */
+nlohmann::json token_error_body (const oauth::TokenError& err) {
+    auto body  = routes::error_body (err.http_status, err.message, err.code);
+    auto& e    = body["error"];
     if (err.provider_status != 0) {
         e["providerStatus"] = err.provider_status;
     }
@@ -43,7 +48,7 @@ nlohmann::json error_body (const oauth::TokenError& err) {
     if (!err.provider_error_description.empty ()) {
         e["providerErrorDescription"] = err.provider_error_description;
     }
-    return nlohmann::json{ { "error", e } };
+    return body;
 }
 
 int64_t now_ms_epoch () {
@@ -64,9 +69,8 @@ oauth2_token_post (vayu::db::Database& db, const std::string& request_body) {
     try {
         req = nlohmann::json::parse (request_body);
     } catch (const nlohmann::json::exception& e) {
-        return { 400, nlohmann::json{ { "error",
-                     { { "code", "oauth2_invalid_config" },
-                     { "message", "Invalid JSON: " + std::string (e.what ()) } } } } };
+        return { 400, error_body (400, "Invalid JSON: " + std::string (e.what ()),
+                     "oauth2_invalid_config") };
     }
 
     const auto config = req.value ("config", nlohmann::json ());
@@ -83,7 +87,7 @@ oauth2_token_post (vayu::db::Database& db, const std::string& request_body) {
 
     auto result = oauth::acquire_token (db, config, force, interactive);
     if (auto* err = std::get_if<oauth::TokenError> (&result)) {
-        return { err->http_status, error_body (*err) };
+        return { err->http_status, token_error_body (*err) };
     }
     return { 200, oauth::serialize_token (std::get<vayu::db::OAuthToken> (result)) };
 }
@@ -152,11 +156,8 @@ void register_oauth_routes (RouteContext& ctx) {
             body = nlohmann::json::parse (req.body);
         } catch (const nlohmann::json::exception& e) {
             res.status = 400;
-            res.set_content (nlohmann::json{ { "error",
-                                 { { "code", "oauth2_invalid_config" },
-                                 { "message", std::string ("Invalid JSON: ") + e.what () } } } }
-            .dump (),
-            "application/json");
+            send_error (res, 400, std::string ("Invalid JSON: ") + e.what (),
+            "oauth2_invalid_config");
             return;
         }
         const auto config = body.value ("config", nlohmann::json ());
@@ -164,10 +165,8 @@ void register_oauth_routes (RouteContext& ctx) {
         auto result       = ctx.authorize_manager.start (ctx.db, config, mode);
         if (!result.ok) {
             res.status = result.http_status;
-            res.set_content (nlohmann::json{ { "error",
-                                 { { "code", result.error_code },
-                                 { "message", result.error_message } } } }
-            .dump (),
+            res.set_content (
+            error_body (res.status, result.error_message, result.error_code).dump (),
             "application/json");
             return;
         }

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -35,14 +35,14 @@ namespace vayu::http::routes {
  * (`serialize(const db::Request&)`), so the client transforms it identically.
  *
  * Extracted so the wiring (404 vs 200 + body) is covered without an in-process
- * HTTP server - see requests_route_test.cpp. The error body matches
- * `send_error`'s flat `{"error": message}` shape.
+ * HTTP server - see requests_route_test.cpp. The error body is built by
+ * `error_body`, like every other error the engine emits.
  */
 std::pair<int, nlohmann::json> get_request_response (vayu::db::Database& db,
 const std::string& id) {
     auto request = db.get_request (id);
     if (!request) {
-        return { 404, nlohmann::json{ { "error", "Request not found" } } };
+        return { 404, error_body (404, "Request not found") };
     }
     return { 200, vayu::json::serialize (*request) };
 }
@@ -105,8 +105,8 @@ apply_key_value_field (const nlohmann::json& json, const char* key, std::string&
     }
     if (!value.is_array ()) {
         return std::make_pair (400,
-        nlohmann::json{ { "error",
-        std::string ("Invalid '") + key + "': must be an array of {key, value, enabled}" } });
+        error_body (400, std::string ("Invalid '") + key +
+        "': must be an array of {key, value, enabled}"));
     }
     for (size_t i = 0; i < value.size (); ++i) {
         const auto& entry = value[i];
@@ -114,9 +114,8 @@ apply_key_value_field (const nlohmann::json& json, const char* key, std::string&
         !entry.contains ("value") || !entry["value"].is_string () ||
         !entry.contains ("enabled") || !entry["enabled"].is_boolean ()) {
             return std::make_pair (400,
-            nlohmann::json{ { "error",
-            std::string ("Invalid ") + key + " entry at index " + std::to_string (i) +
-            ": missing required field (key, value, or enabled)" } });
+            error_body (400, std::string ("Invalid ") + key + " entry at index " +
+            std::to_string (i) + ": missing required field (key, value, or enabled)"));
         }
     }
     out = value.dump ();
@@ -174,7 +173,7 @@ bool is_create) {
     }
     auto method = vayu::parse_method (method_str);
     if (!method) {
-        return std::make_pair (400, nlohmann::json{ { "error", "Invalid HTTP method" } });
+        return std::make_pair (400, error_body (400, "Invalid HTTP method"));
     }
     r.method = *method;
 
@@ -238,8 +237,8 @@ create_request_response (vayu::db::Database& db, const nlohmann::json& json) {
 
     if (db.get_request (id).has_value ()) {
         return { 409,
-            nlohmann::json{ { "error",
-            "Request '" + id + "' already exists; use PUT /requests/:id to update" } } };
+            error_body (409,
+            "Request '" + id + "' already exists; use PUT /requests/:id to update") };
     }
 
     vayu::db::Request r;
@@ -269,7 +268,7 @@ const nlohmann::json& json) {
     }
     auto existing = db.get_request (id);
     if (!existing) {
-        return { 404, nlohmann::json{ { "error", "Request not found" } } };
+        return { 404, error_body (404, "Request not found") };
     }
 
     vayu::db::Request r = *existing;
@@ -357,7 +356,7 @@ void register_request_routes (RouteContext& ctx) {
             auto [status, body] = create_request_response (ctx.db, json);
             if (status != 200) {
                 vayu::utils::log_warning ("POST /requests - " +
-                std::to_string (status) + ": " + body["error"].get<std::string> ());
+                std::to_string (status) + ": " + error_message_of (body));
             } else {
                 vayu::utils::log_info (
                 "POST /requests - Created request: id=" + body["id"].get<std::string> () +
@@ -390,7 +389,7 @@ void register_request_routes (RouteContext& ctx) {
             auto [status, body] = update_request_response (ctx.db, request_id, json);
             if (status != 200) {
                 vayu::utils::log_warning ("PUT /requests/:id - " + std::to_string (status) +
-                " for id=" + request_id + ": " + body["error"].get<std::string> ());
+                " for id=" + request_id + ": " + error_message_of (body));
             } else {
                 vayu::utils::log_info (
                 "PUT /requests/:id - Updated request: id=" + request_id +

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -378,7 +378,7 @@ const std::string& run_id,
 int64_t stop_wait_ms) {
     auto run = db.get_run (run_id);
     if (!run) {
-        return { 404, nlohmann::json{ { "error", "Run not found" } } };
+        return { 404, error_body (404, "Run not found") };
     }
 
     if (auto context = run_manager.get_run (run_id)) {
@@ -400,9 +400,8 @@ int64_t stop_wait_ms) {
                 "DELETE /runs/:id - Run did not settle within " +
                 std::to_string (stop_wait_ms) + "ms, refusing to delete: " + run_id);
                 return { 409,
-                    nlohmann::json{ { "error",
-                    "Run is still stopping; it was not deleted. Retry once it "
-                    "reports a terminal status." } } };
+                    error_body (409, "Run is still stopping; it was not deleted. Retry once it "
+                    "reports a terminal status.") };
             }
             std::this_thread::sleep_for (std::chrono::milliseconds (20));
         }
@@ -415,7 +414,8 @@ int64_t stop_wait_ms) {
 
 /**
  * Testable core of GET /runs/:id/report, returning {http_status, json_body}. A
- * missing run is a definitive 404 with the flat `{"error": message}` shape.
+ * missing run is a definitive 404 in the shared `{"error": {"code", "message"}}`
+ * shape.
  *
  * Two sources feed the whole-run aggregates, in order:
  *   1. `runs.summary` - the values the run itself computed at completion. Used
@@ -435,7 +435,7 @@ std::pair<int, nlohmann::json> run_report_response (vayu::db::Database& db,
 const std::string& run_id) {
     auto run = db.get_run (run_id);
     if (!run) {
-        return { 404, nlohmann::json{ { "error", "Run not found" } } };
+        return { 404, error_body (404, "Run not found") };
     }
 
     auto results = db.get_results (run_id);

--- a/engine/tests/collections_route_test.cpp
+++ b/engine/tests/collections_route_test.cpp
@@ -103,7 +103,7 @@ TEST_F (CollectionsRouteTest, SelfParentRejectedWith400) {
     auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_a");
     ASSERT_TRUE (err.has_value ());
     EXPECT_EQ (err->first, 400);
-    EXPECT_EQ (err->second["error"], "A collection cannot be its own parent");
+    EXPECT_EQ (err->second["error"]["message"], "A collection cannot be its own parent");
 }
 
 TEST_F (CollectionsRouteTest, ReparentIntoDescendantRejectedWith400) {
@@ -115,7 +115,7 @@ TEST_F (CollectionsRouteTest, ReparentIntoDescendantRejectedWith400) {
     auto err = vayu::http::routes::validate_parent_assignment (*db_, "col_a", "col_c");
     ASSERT_TRUE (err.has_value ());
     EXPECT_EQ (err->first, 400);
-    EXPECT_EQ (err->second["error"], "Cannot move a collection into its own descendant");
+    EXPECT_EQ (err->second["error"]["message"], "Cannot move a collection into its own descendant");
 }
 
 TEST_F (CollectionsRouteTest, LegalReparentSucceeds) {

--- a/engine/tests/error_shape_route_test.cpp
+++ b/engine/tests/error_shape_route_test.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file tests/error_shape_route_test.cpp
+ * @brief Every engine error body is one shape: {"error": {"code", "message"}}
+ *        (issue #173).
+ *
+ * The engine used to emit two. `send_error` and the extracted route cores wrote
+ * a flat `{"error": "<message>"}`; `/config` and `/oauth2` wrote the nested
+ * object. The app's shared http-client reads `errorData.error.message`, which
+ * on a flat body is `undefined` (a JSON string carries no `.message`) - so
+ * every validation and not-found message the CRUD routes so carefully worded
+ * was dropped and the user saw a bare "HTTP 400: Bad Request".
+ *
+ * The per-route suites assert the *message text* of their own failures. This
+ * file asserts the **envelope** those messages arrive in, across routes,
+ * because the defect was never in one route: it was a convention that half the
+ * engine followed. A route that goes back to a flat body fails here even if its
+ * own message assertions still pass, since those read `error.message` and a
+ * flat body has none.
+ *
+ * Follows the suite's route-test convention (requests_route_test.cpp): the
+ * routes' extracted cores are exercised directly, no in-process HTTP server.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/db/database.hpp"
+#include "vayu/http/routes.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in their route .cpp files; each returns {http_status, json_body} -
+// the same pair the HTTP handler writes out.
+std::pair<int, nlohmann::json>
+create_collection_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+get_request_response (vayu::db::Database& db, const std::string& id);
+std::pair<int, nlohmann::json>
+create_request_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+run_report_response (vayu::db::Database& db, const std::string& run_id);
+std::pair<int, nlohmann::json>
+import_apply_response (vayu::db::Database& db, const nlohmann::json& body);
+} // namespace vayu::http::routes
+
+namespace {
+
+using vayu::http::routes::error_body;
+using vayu::http::routes::error_message_of;
+
+class ErrorShapeRouteTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_error_shape_route.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* suffix : { "", "-wal", "-shm" }) {
+            std::filesystem::remove (std::string (DB_PATH) + suffix);
+        }
+    }
+
+    /**
+     * The contract in one place: an object under `error` carrying a non-empty
+     * string `code` and a non-empty string `message`. Asserting `is_object` is
+     * what a reverted `send_error` fails on; asserting the message is non-empty
+     * is what an over-eager "just add a code" fix fails on.
+     */
+    static void expect_error_shape (const json& body, const std::string& expected_code) {
+        ASSERT_TRUE (body.contains ("error")) << body.dump ();
+        const auto& error = body["error"];
+        ASSERT_TRUE (error.is_object ()) << "flat error body: " << body.dump ();
+        ASSERT_TRUE (error.contains ("code"));
+        ASSERT_TRUE (error["code"].is_string ());
+        EXPECT_EQ (error["code"], expected_code);
+        ASSERT_TRUE (error.contains ("message"));
+        ASSERT_TRUE (error["message"].is_string ());
+        EXPECT_FALSE (error["message"].get<std::string> ().empty ());
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// One case per status the CRUD verbs produce, spread across all three
+// resources, so a resource that reverts to the flat shape is caught wherever it
+// lives rather than only where the fix happened to be tested.
+
+TEST_F (ErrorShapeRouteTest, ValidationFailureIsNestedBadRequest) {
+    auto [status, body] = vayu::http::routes::create_collection_response (
+    *db_, json{ { "description", "no name" } });
+    EXPECT_EQ (status, 400);
+    expect_error_shape (body, "bad_request");
+    // The reason survives the envelope - this is the text the user sees.
+    EXPECT_NE (error_message_of (body).find ("name"), std::string::npos);
+}
+
+TEST_F (ErrorShapeRouteTest, MissingRequestIsNestedNotFound) {
+    auto [status, body] = vayu::http::routes::get_request_response (*db_, "req_nope");
+    EXPECT_EQ (status, 404);
+    expect_error_shape (body, "not_found");
+}
+
+TEST_F (ErrorShapeRouteTest, MissingCollectionOnUpdateIsNestedNotFound) {
+    auto [status, body] = vayu::http::routes::update_collection_response (
+    *db_, "col_nope", json{ { "name", "x" } });
+    EXPECT_EQ (status, 404);
+    expect_error_shape (body, "not_found");
+}
+
+TEST_F (ErrorShapeRouteTest, MissingEnvironmentOnUpdateIsNestedNotFound) {
+    auto [status, body] = vayu::http::routes::update_environment_response (
+    *db_, "env_nope", json{ { "name", "x" } });
+    EXPECT_EQ (status, 404);
+    expect_error_shape (body, "not_found");
+}
+
+TEST_F (ErrorShapeRouteTest, ClientSuppliedIdIsNestedBadRequest) {
+    auto [status, body] = vayu::http::routes::create_request_response (*db_,
+    json{ { "id", "req_mine" }, { "collectionId", "col_1" }, { "name", "n" },
+    { "method", "GET" }, { "url", "http://x" } });
+    EXPECT_EQ (status, 400);
+    expect_error_shape (body, "bad_request");
+}
+
+TEST_F (ErrorShapeRouteTest, MissingRunReportIsNestedNotFound) {
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_nope");
+    EXPECT_EQ (status, 404);
+    expect_error_shape (body, "not_found");
+}
+
+/**
+ * The import failure is the one the user is most likely to hit at scale, and
+ * the `item` detail is the whole reason a 500-item import is diagnosable. It
+ * moved *inside* the error object with the migration, so a client reads one
+ * object for the whole failure - assert both halves together.
+ */
+TEST_F (ErrorShapeRouteTest, ImportItemErrorNamesTheItemInsideTheErrorObject) {
+    const json payload{ { "collections",
+    json::array ({ json{ { "tempId", "c1" }, { "name", "A" } },
+    json{ { "tempId", "c1" }, { "name", "B" } } }) } };
+
+    auto [status, body] = vayu::http::routes::import_apply_response (*db_, payload);
+    EXPECT_EQ (status, 400);
+    expect_error_shape (body, "bad_request");
+    ASSERT_TRUE (body["error"].contains ("item"));
+    EXPECT_EQ (body["error"]["item"], "c1");
+    // The temp id must not also sit at the top level - one place to look.
+    EXPECT_FALSE (body.contains ("item"));
+}
+
+// The builder itself: the per-status code table, and the reader route handlers
+// log through.
+
+TEST_F (ErrorShapeRouteTest, DefaultCodeFollowsTheStatus) {
+    EXPECT_EQ (error_body (400, "m")["error"]["code"], "bad_request");
+    EXPECT_EQ (error_body (404, "m")["error"]["code"], "not_found");
+    EXPECT_EQ (error_body (409, "m")["error"]["code"], "conflict");
+    EXPECT_EQ (error_body (502, "m")["error"]["code"], "bad_gateway");
+    EXPECT_EQ (error_body (503, "m")["error"]["code"], "unavailable");
+    EXPECT_EQ (error_body (500, "m")["error"]["code"], "internal_error");
+}
+
+TEST_F (ErrorShapeRouteTest, ExplicitCodeWinsOverTheStatusDefault) {
+    EXPECT_EQ (error_body (400, "m", "invalid_config")["error"]["code"], "invalid_config");
+    EXPECT_EQ (error_body (400, "m",
+               std::string ("oauth2_invalid_config"))["error"]["code"],
+    "oauth2_invalid_config");
+}
+
+/**
+ * `error_message_of` tolerates the flat shape on purpose: it also reads bodies
+ * that did not come from `error_body`. Route handlers log through it, and a raw
+ * `body["error"].get<std::string>()` throws on an object - which would turn a
+ * logged 404 into a 500.
+ */
+TEST_F (ErrorShapeRouteTest, ErrorMessageOfReadsBothShapesAndNeitherThrows) {
+    EXPECT_EQ (error_message_of (error_body (404, "Run not found")), "Run not found");
+    EXPECT_EQ (error_message_of (json{ { "error", "legacy flat" } }), "legacy flat");
+    EXPECT_EQ (error_message_of (json{ { "ok", true } }), "");
+    EXPECT_NO_THROW (error_message_of (json{ { "error", json::array ({ 1, 2 }) } }));
+}
+
+} // namespace

--- a/engine/tests/execution_http_version_test.cpp
+++ b/engine/tests/execution_http_version_test.cpp
@@ -62,7 +62,7 @@ TEST (NormalizeRunHttpVersion, RejectsUnrecognizedString) {
     auto err  = normalize_run_http_version (json);
     ASSERT_TRUE (err.has_value ());
     EXPECT_EQ (err->first, 400);
-    const std::string message = err->second["error"].get<std::string> ();
+    const std::string message = err->second["error"]["message"].get<std::string> ();
     EXPECT_NE (message.find ("httpVersion"), std::string::npos);
     // Every wire value must be named in the rejection, the same guarantee
     // resource_write_route_test.cpp holds the CRUD route to.
@@ -77,7 +77,8 @@ TEST (NormalizeRunHttpVersion, RejectsNonStringValue) {
     auto err  = normalize_run_http_version (json);
     ASSERT_TRUE (err.has_value ());
     EXPECT_EQ (err->first, 400);
-    EXPECT_NE (err->second["error"].get<std::string> ().find ("httpVersion"),
+    EXPECT_NE (
+    err->second["error"]["message"].get<std::string> ().find ("httpVersion"),
     std::string::npos);
 }
 

--- a/engine/tests/globals_route_test.cpp
+++ b/engine/tests/globals_route_test.cpp
@@ -130,7 +130,8 @@ TEST_F (GlobalsRouteTest, WrongShapeVariablesIsRejected) {
     { json (42), json ("token"), json::array ({ 1, 2 }), json (true) }) {
         auto [status, body] = save_globals_response (*db_, json{ { "variables", bad } });
         EXPECT_EQ (status, 400) << "variables = " << bad.dump ();
-        EXPECT_NE (body["error"].get<std::string> ().find ("variables"), std::string::npos);
+        EXPECT_NE (
+        body["error"]["message"].get<std::string> ().find ("variables"), std::string::npos);
     }
 
     EXPECT_EQ (stored_variables (), before)

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -220,8 +220,8 @@ TEST_F (ImportApplyRouteTest, WritesNothingWhenOneItemIsInvalid) {
         { "environments", json::array ({ json{ { "tempId", "e1" }, { "name", "Prod" } } }) } });
 
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "r2");
-    EXPECT_NE (response["error"].get<std::string> ().find ("method"), std::string::npos);
+    EXPECT_EQ (response["error"]["item"], "r2");
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("method"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u); // the valid items must not have landed either
 }
 
@@ -232,7 +232,7 @@ TEST_F (ImportApplyRouteTest, RejectsANullNameThatHasNoDefault) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ collection }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "c1");
+    EXPECT_EQ (response["error"]["item"], "c1");
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -247,7 +247,7 @@ TEST_F (ImportApplyRouteTest, RejectsAWrongTypedFieldWithA400NotA500) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ collection }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "c1");
+    EXPECT_EQ (response["error"]["item"], "c1");
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -258,8 +258,8 @@ TEST_F (ImportApplyRouteTest, RejectsAnUnknownParentTempId) {
     auto [status, response] = import_apply_response (*db_,
     json{ { "collections", json::array ({ collection_item ("c1", "root"), child }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "c2");
-    EXPECT_NE (response["error"].get<std::string> ().find ("parentTempId"), std::string::npos);
+    EXPECT_EQ (response["error"]["item"], "c2");
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("parentTempId"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -267,7 +267,7 @@ TEST_F (ImportApplyRouteTest, RejectsAnUnknownCollectionTempId) {
     auto [status, response] = import_apply_response (*db_,
     json{ { "requests", json::array ({ request_item ("r1", "c9", "orphan") }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "r1");
+    EXPECT_EQ (response["error"]["item"], "r1");
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -277,7 +277,7 @@ TEST_F (ImportApplyRouteTest, RejectsARequestWhoseOwnerIsNotACollection) {
     json{ { "environments", json::array ({ json{ { "tempId", "e1" }, { "name", "Prod" } } }) },
         { "requests", json::array ({ request_item ("r1", "e1", "wrong owner") }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "r1");
+    EXPECT_EQ (response["error"]["item"], "r1");
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -290,7 +290,7 @@ TEST_F (ImportApplyRouteTest, RejectsACycleInParentTempIds) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ a, b }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (response["error"].get<std::string> ().find ("Cycle"), std::string::npos);
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("Cycle"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -301,7 +301,7 @@ TEST_F (ImportApplyRouteTest, RejectsASelfParent) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ self }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "c1");
+    EXPECT_EQ (response["error"]["item"], "c1");
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -310,8 +310,8 @@ TEST_F (ImportApplyRouteTest, RejectsADuplicateTempId) {
     json{ { "collections", json::array ({ collection_item ("c1", "a") }) },
         { "environments", json::array ({ json{ { "tempId", "c1" }, { "name", "clash" } } }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (response["item"], "c1");
-    EXPECT_NE (response["error"].get<std::string> ().find ("Duplicate"), std::string::npos);
+    EXPECT_EQ (response["error"]["item"], "c1");
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("Duplicate"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -319,7 +319,7 @@ TEST_F (ImportApplyRouteTest, RejectsAMissingTempId) {
     auto [status, response] = import_apply_response (*db_,
     json{ { "collections", json::array ({ json{ { "name", "no temp id" } } }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (response["error"].get<std::string> ().find ("tempId"), std::string::npos);
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("tempId"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -330,7 +330,7 @@ TEST_F (ImportApplyRouteTest, RejectsAClientSuppliedId) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", json::array ({ collection }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (response["error"].get<std::string> ().find ("'id' is not accepted"), std::string::npos);
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("'id' is not accepted"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -338,7 +338,7 @@ TEST_F (ImportApplyRouteTest, RejectsANonArraySection) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", "not an array" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (response["error"].get<std::string> ().find ("collections"), std::string::npos);
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("collections"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -350,7 +350,7 @@ TEST_F (ImportApplyRouteTest, EnforcesTheItemCap) {
     auto [status, response] =
     import_apply_response (*db_, json{ { "collections", collections } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (response["error"].get<std::string> ().find ("too large"), std::string::npos);
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find ("too large"), std::string::npos);
     EXPECT_EQ (stored_rows (), 0u);
 }
 
@@ -409,7 +409,7 @@ TEST_F (ImportApplyRouteTest, RejectsAnObjectFieldGivenANonObject) {
 
             auto [status, response] = import_apply_response (*db_, body);
             EXPECT_EQ (status, 400) << c.field << " = " << bad_shape.dump ();
-            EXPECT_NE (response["error"].get<std::string> ().find (c.field), std::string::npos)
+            EXPECT_NE (response["error"]["message"].get<std::string> ().find (c.field), std::string::npos)
             << "the 400 must name the offending field, got " << response.dump ();
             EXPECT_EQ (stored_rows (), 0u) << c.field << " = " << bad_shape.dump ();
         }

--- a/engine/tests/requests_route_test.cpp
+++ b/engine/tests/requests_route_test.cpp
@@ -82,10 +82,12 @@ class RequestsRouteTest : public ::testing::Test {
 TEST_F (RequestsRouteTest, MissingRequestIs404) {
     auto [status, body] = vayu::http::routes::get_request_response (*db_, "req_nope");
     EXPECT_EQ (status, 404);
-    // Flat {"error": message} shape, matching send_error. The app maps on the
-    // status code, so the body only has to be well-formed, not richly typed.
+    // The one error shape (issue #173): a nested object carrying a per-status
+    // code and the message. The app's http-client reads `error.message`, so a
+    // flat string here would surface as a bare "HTTP 404".
     ASSERT_TRUE (body.contains ("error"));
-    EXPECT_TRUE (body["error"].is_string ());
+    EXPECT_EQ (body["error"]["code"], "not_found");
+    EXPECT_EQ (body["error"]["message"], "Request not found");
 }
 
 // GET /requests must contain every row of the collection and preserve the

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -164,7 +164,7 @@ TEST_F (ResourceWriteRouteTest, CollectionCreateRejectsClientId) {
     auto [status, body] = create_collection_response (
     *db_, json{ { "id", "col_fixed" }, { "name", "New" } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (body["error"], ENGINE_OWNS_ID);
+    EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
     EXPECT_FALSE (db_->get_collection ("col_fixed").has_value ())
     << "a rejected create must not persist anything";
 
@@ -178,7 +178,7 @@ TEST_F (ResourceWriteRouteTest, CollectionCreateRejectsNullClientId) {
     auto [status, body] =
     create_collection_response (*db_, json{ { "id", nullptr }, { "name", "New" } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (body["error"], ENGINE_OWNS_ID);
+    EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
     EXPECT_TRUE (db_->get_collections ().empty ());
 }
 
@@ -191,7 +191,7 @@ TEST_F (ResourceWriteRouteTest, CollectionCreateOnExistingIdIsRejected) {
     auto [status, body] =
     create_collection_response (*db_, json{ { "id", id }, { "name", "Impostor" } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (body["error"], ENGINE_OWNS_ID);
+    EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
 
     auto stored = db_->get_collection (id);
     ASSERT_TRUE (stored.has_value ());
@@ -204,7 +204,8 @@ TEST_F (ResourceWriteRouteTest, CollectionUpdateRejectsMismatchedBodyId) {
     auto [status, body] = update_collection_response (
     *db_, id, json{ { "id", "col_somewhere_else" }, { "name", "Renamed" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("Body 'id'"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
+    std::string::npos);
     EXPECT_EQ (db_->get_collection (id)->name, "Original")
     << "a body id naming another record must not write through the path id";
 }
@@ -227,7 +228,8 @@ TEST_F (ResourceWriteRouteTest, CollectionUpdateRejectsNullBodyId) {
     auto [status, body] = update_collection_response (
     *db_, id, json{ { "id", nullptr }, { "name", "Renamed" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("Body 'id'"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
+    std::string::npos);
     EXPECT_EQ (db_->get_collection (id)->name, "Original");
 }
 
@@ -237,20 +239,21 @@ TEST_F (ResourceWriteRouteTest, UpdateRejectsBodyIdBeforeLookingTheRecordUp) {
     auto [status, body] = update_collection_response (
     *db_, "col_does_not_exist", json{ { "id", "col_other" }, { "name", "X" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("Body 'id'"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
+    std::string::npos);
 }
 
 TEST_F (ResourceWriteRouteTest, CollectionCreateRequiresName) {
     auto [status, body] = create_collection_response (*db_, json::object ());
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("name"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("name"), std::string::npos);
 }
 
 TEST_F (ResourceWriteRouteTest, CollectionUpdateMissingIsNotFound) {
     auto [status, body] =
     update_collection_response (*db_, "col_does_not_exist", json{ { "name", "X" } });
     EXPECT_EQ (status, 404);
-    EXPECT_EQ (body["error"], "Collection not found");
+    EXPECT_EQ (body["error"]["message"], "Collection not found");
     EXPECT_FALSE (db_->get_collection ("col_does_not_exist").has_value ())
     << "a 404 must not leave a record behind";
 }
@@ -296,7 +299,7 @@ TEST_F (ResourceWriteRouteTest, CollectionNullNameIsRejected) {
     auto [status, body] =
     update_collection_response (*db_, id, json{ { "name", nullptr } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("name"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("name"), std::string::npos);
     EXPECT_EQ (db_->get_collection (id)->name, "Keep me");
 }
 
@@ -325,7 +328,8 @@ TEST_F (ResourceWriteRouteTest, CollectionWrongShapeObjectFieldIsRejected) {
             auto [status, body] =
             update_collection_response (*db_, id, json{ { field, bad } });
             EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
-            EXPECT_NE (body["error"].get<std::string> ().find (field), std::string::npos)
+            EXPECT_NE (body["error"]["message"].get<std::string> ().find (field),
+            std::string::npos)
             << "the 400 must name the field";
         }
     }
@@ -343,7 +347,8 @@ TEST_F (ResourceWriteRouteTest, CollectionCreateWrongShapeObjectFieldIsRejected)
             auto [status, body] = create_collection_response (
             *db_, json{ { "name", "N" }, { field, bad } });
             EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
-            EXPECT_NE (body["error"].get<std::string> ().find (field), std::string::npos);
+            EXPECT_NE (body["error"]["message"].get<std::string> ().find (field),
+            std::string::npos);
         }
     }
     EXPECT_TRUE (db_->get_collections ().empty ())
@@ -379,7 +384,7 @@ TEST_F (ResourceWriteRouteTest, RequestCreateRejectsClientId) {
     json{ { "id", id }, { "collectionId", collection }, { "name", "Impostor" },
     { "method", "POST" }, { "url", "https://evil.example" } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (body["error"], ENGINE_OWNS_ID);
+    EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
     EXPECT_EQ (db_->get_request (id)->name, "R");
     EXPECT_EQ (db_->get_requests_in_collection (collection).size (), 1U)
     << "a rejected create must not persist a second row under a generated id";
@@ -392,7 +397,8 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateRejectsMismatchedBodyId) {
     auto [status, body] = update_request_response (
     *db_, id, json{ { "id", "req_somewhere_else" }, { "name", "Renamed" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("Body 'id'"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
+    std::string::npos);
     EXPECT_EQ (db_->get_request (id)->name, "R");
 }
 
@@ -404,7 +410,8 @@ TEST_F (ResourceWriteRouteTest, RequestCreateRequiresItsNoDefaultFields) {
         body.erase (missing);
         auto [status, error] = create_request_response (*db_, body);
         EXPECT_EQ (status, 400) << "missing " << missing;
-        EXPECT_NE (error["error"].get<std::string> ().find (missing), std::string::npos);
+        EXPECT_NE (error["error"]["message"].get<std::string> ().find (missing),
+        std::string::npos);
     }
 }
 
@@ -412,7 +419,7 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateMissingIsNotFound) {
     auto [status, body] =
     update_request_response (*db_, "req_does_not_exist", json{ { "name", "X" } });
     EXPECT_EQ (status, 404);
-    EXPECT_EQ (body["error"], "Request not found");
+    EXPECT_EQ (body["error"]["message"], "Request not found");
     EXPECT_FALSE (db_->get_request ("req_does_not_exist").has_value ());
 }
 
@@ -456,7 +463,8 @@ TEST_F (ResourceWriteRouteTest, RequestNullNoDefaultFieldIsRejected) {
         auto [status, body] =
         update_request_response (*db_, id, json{ { field, nullptr } });
         EXPECT_EQ (status, 400) << field << ": null on a no-default field";
-        EXPECT_NE (body["error"].get<std::string> ().find (field), std::string::npos);
+        EXPECT_NE (body["error"]["message"].get<std::string> ().find (field),
+        std::string::npos);
     }
     EXPECT_EQ (db_->get_request (id)->url, "https://example.com");
 }
@@ -467,7 +475,8 @@ TEST_F (ResourceWriteRouteTest, RequestInvalidMethodIsRejected) {
              json{ { "collectionId", collection }, { "name", "R" },
              { "method", "TELEPORT" }, { "url", "https://example.com" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("method"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("method"),
+    std::string::npos);
 }
 
 TEST_F (ResourceWriteRouteTest, RequestMalformedKeyValueEntryIsRejected) {
@@ -477,7 +486,8 @@ TEST_F (ResourceWriteRouteTest, RequestMalformedKeyValueEntryIsRejected) {
              { "url", "https://example.com" },
              { "headers", json::array ({ json{ { "key", "X" } } }) } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("index 0"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("index 0"),
+    std::string::npos);
 }
 
 TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
@@ -495,7 +505,8 @@ TEST_F (ResourceWriteRouteTest, RequestWrongShapeObjectFieldIsRejected) {
             auto [status, error] =
             update_request_response (*db_, id, json{ { field, bad } });
             EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
-            EXPECT_NE (error["error"].get<std::string> ().find (field), std::string::npos);
+            EXPECT_NE (error["error"]["message"].get<std::string> ().find (field),
+            std::string::npos);
         }
     }
 
@@ -515,7 +526,8 @@ TEST_F (ResourceWriteRouteTest, RequestCreateWrongShapeObjectFieldIsRejected) {
             payload[field]       = bad;
             auto [status, error] = create_request_response (*db_, payload);
             EXPECT_EQ (status, 400) << field << " = " << bad.dump ();
-            EXPECT_NE (error["error"].get<std::string> ().find (field), std::string::npos);
+            EXPECT_NE (error["error"]["message"].get<std::string> ().find (field),
+            std::string::npos);
         }
     }
     EXPECT_TRUE (db_->get_requests_in_collection (collection).empty ())
@@ -598,7 +610,7 @@ TEST_F (ResourceWriteRouteTest, RequestCreateInvalidHttpVersionIsRejectedAndNotS
              json{ { "collectionId", collection }, { "name", "R" }, { "method", "GET" },
              { "url", "https://example.com" }, { "httpVersion", "http3" } });
     EXPECT_EQ (status, 400);
-    const auto message = body["error"].get<std::string> ();
+    const auto message = body["error"]["message"].get<std::string> ();
     EXPECT_NE (message.find ("httpVersion"), std::string::npos)
     << "the 400 must name the offending field";
     EXPECT_NE (message.find ("http3"), std::string::npos)
@@ -620,7 +632,8 @@ TEST_F (ResourceWriteRouteTest, RequestCreateNonStringHttpVersionIsRejected) {
              json{ { "collectionId", collection }, { "name", "R" }, { "method", "GET" },
              { "url", "https://example.com" }, { "httpVersion", 2 } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("httpVersion"), std::string::npos);
+    EXPECT_NE (
+    body["error"]["message"].get<std::string> ().find ("httpVersion"), std::string::npos);
 }
 
 TEST_F (ResourceWriteRouteTest, RequestUpdateAbsentHttpVersionKeepsExisting) {
@@ -680,7 +693,7 @@ TEST_F (ResourceWriteRouteTest, RequestUpdateInvalidHttpVersionIsRejectedAndUnch
     auto [status, body] =
     update_request_response (*db_, id, json{ { "httpVersion", "spdy" } });
     EXPECT_EQ (status, 400);
-    const auto message = body["error"].get<std::string> ();
+    const auto message = body["error"]["message"].get<std::string> ();
     EXPECT_NE (message.find ("httpVersion"), std::string::npos);
     EXPECT_NE (message.find ("spdy"), std::string::npos);
     EXPECT_EQ (db_->get_request (id)->http_version, "http2")
@@ -716,7 +729,7 @@ TEST_F (ResourceWriteRouteTest, EnvironmentCreateRejectsClientId) {
     auto [status, body] =
     create_environment_response (*db_, json{ { "id", id }, { "name", "Impostor" } });
     EXPECT_EQ (status, 400);
-    EXPECT_EQ (body["error"], ENGINE_OWNS_ID);
+    EXPECT_EQ (body["error"]["message"], ENGINE_OWNS_ID);
     EXPECT_EQ (db_->get_environment (id)->name, "Original");
     EXPECT_EQ (db_->get_environments ().size (), 1U)
     << "a rejected create must not persist a second row under a generated id";
@@ -731,7 +744,8 @@ TEST_F (ResourceWriteRouteTest, EnvironmentUpdateRejectsMismatchedBodyId) {
     auto [status, body] = update_environment_response (
     *db_, id, json{ { "id", "env_somewhere_else" }, { "name", "Renamed" } });
     EXPECT_EQ (status, 400);
-    EXPECT_NE (body["error"].get<std::string> ().find ("Body 'id'"), std::string::npos);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("Body 'id'"),
+    std::string::npos);
     EXPECT_EQ (db_->get_environment (id)->name, "Original");
 }
 
@@ -739,7 +753,7 @@ TEST_F (ResourceWriteRouteTest, EnvironmentUpdateMissingIsNotFound) {
     auto [status, body] =
     update_environment_response (*db_, "env_does_not_exist", json{ { "name", "X" } });
     EXPECT_EQ (status, 404);
-    EXPECT_EQ (body["error"], "Environment not found");
+    EXPECT_EQ (body["error"]["message"], "Environment not found");
 }
 
 TEST_F (ResourceWriteRouteTest, EnvironmentNullVariablesResetsToEmptyObject) {
@@ -811,7 +825,8 @@ TEST_F (ResourceWriteRouteTest, EnvironmentWrongShapeVariablesIsRejected) {
         auto [status, body] =
         update_environment_response (*db_, id, json{ { "variables", bad } });
         EXPECT_EQ (status, 400) << "variables = " << bad.dump ();
-        EXPECT_NE (body["error"].get<std::string> ().find ("variables"), std::string::npos);
+        EXPECT_NE (
+        body["error"]["message"].get<std::string> ().find ("variables"), std::string::npos);
     }
     EXPECT_EQ (db_->get_environment (id)->variables, before)
     << "a rejected write must not reach the column";

--- a/engine/tests/run_stop_test.cpp
+++ b/engine/tests/run_stop_test.cpp
@@ -371,7 +371,7 @@ TEST_F (DeleteRunTest, UnknownRunIs404) {
     vayu::http::routes::delete_run_response (*db, manager, "nope", 100);
 
     EXPECT_EQ (status, 404);
-    EXPECT_EQ (body["error"], "Run not found");
+    EXPECT_EQ (body["error"]["message"], "Run not found");
 }
 
 TEST_F (DeleteRunTest, FinishedRunIsDeletedOutright) {

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -377,7 +377,8 @@ TEST_F (RunsRouteTest, ReportMissingRunIs404) {
     auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_nope");
     EXPECT_EQ (status, 404);
     ASSERT_TRUE (body.contains ("error"));
-    EXPECT_TRUE (body["error"].is_string ());
+    EXPECT_EQ (body["error"]["code"], "not_found");
+    EXPECT_EQ (body["error"]["message"], "Run not found");
 }
 
 // A completed run reports from its stored summary - no metric rows involved.

--- a/engine/tests/stats_route_test.cpp
+++ b/engine/tests/stats_route_test.cpp
@@ -4,7 +4,7 @@
  *
  * This core backs both the canonical GET /runs/:id/metrics and the legacy
  * GET /stats/:id?format=json, so the two paths cannot drift. It must:
- *   - return a definitive 404 {"error": ...} for a missing run,
+ *   - return a definitive 404 {"error": {"code", "message"}} for a missing run,
  *   - return 200 with an empty `data` array and a well-formed pagination
  *     envelope for a run that has no metrics yet,
  *   - group Metric rows into per-timestamp tick buckets carrying the app's
@@ -157,7 +157,8 @@ TEST_F (StatsRouteTest, MissingRunIs404) {
     vayu::http::routes::run_time_series_response (*db_, "run_nope", 5000, 0);
     EXPECT_EQ (status, 404);
     ASSERT_TRUE (body.contains ("error"));
-    EXPECT_TRUE (body["error"].is_string ());
+    EXPECT_EQ (body["error"]["code"], "not_found");
+    EXPECT_EQ (body["error"]["message"], "Run not found");
 }
 
 TEST_F (StatsRouteTest, ExistingRunWithNoMetricsIs200WithEmptyEnvelope) {


### PR DESCRIPTION
## Description

**Root cause.** The engine emitted two error shapes: `send_error` and the extracted route cores wrote a flat `{"error": "<message>"}`, while `/config` and `/oauth2` wrote `{"error": {"code", "message"}}`. The app's shared http-client reads `errorData.error.message`, which on a flat body is `undefined` (a JSON string carries no `.message`), so every validation and not-found message the CRUD routes built was discarded and the user saw a bare `HTTP 400: Bad Request`.

**Approach.** Migrate the producer, not just the reader: one `error_body (status, message, code?)` helper in `routes.hpp` builds every error body, defaulting `code` from the status (`bad_request` / `not_found` / `conflict` / `bad_gateway` / `unavailable` / `internal_error`) so ~50 call sites needed no per-site invention, while routes with their own vocabulary (`invalid_config`, `invalid_run_config`, the `oauth2_*` family) pass one explicitly. Per-error detail moves *inside* that object - `/import/apply`'s `item`, `/oauth2`'s provider fields - so a client reads one place for the whole failure.

**Alternative rejected.** Teaching only the client to accept both shapes (the issue's option (b)) was already done on master, which is why this is no longer a user-visible outage. It was rejected as the whole fix because it leaves two contracts alive - `ApiError.errorCode` stays `UNKNOWN_ERROR` for every CRUD failure, and `/import/apply`'s `item` still has no defined home. The client's flat branch is **kept** as a version-skew fallback (the app and the engine sidecar are not updated atomically), now documented as a fallback rather than an alternative contract.

### Deviations from the issue spec, and why

- **The issue's step 2 (client flat fallback) already exists on master** - added after the issue was written. Kept, comment rewritten to describe the fix instead of the defect, and pinned by a new test.
- **`item` moved inside the error object** rather than staying a top-level key. The issue allowed either; nesting it keeps `error` the single place a client looks, and the client's legacy top-level reading is retained and tested.
- Also migrated: two log sites per resource that did `body["error"].get<std::string>()`. That read **throws** on an object, which would have turned a logged 404 into a 500 - they now go through `error_message_of`, which reads both shapes.

### App changes (required by the issue)

- `services/http-client.ts` - comment rewritten; dual-shape reading kept and now covered by tests.
- `services/importers/failure-message.ts` (new) - resolves the engine's temp id back to the name shown in the import preview, since `c37` means nothing to whoever chose the file. Falls back to the temp id when the item is not in the parsed result.
- `ImportModal.tsx` - shows that message, so the documented "names the item that broke" contract finally reaches the UI.
- Verified `app/electron/mcp/engine-client.ts` needs no change: it keeps the raw body text and never parses the error shape. `services/oauth/authorize.ts` reads its own `/oauth2` payloads, which were already nested.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **692/692 passed**, including the new `error_shape_route_test.cpp` (10 cases). One earlier run had `HttpClientTest.UnreachableHostsRawRequestNamesWhatWasAskedFor` time out; it is a DNS-dependent test unrelated to this diff and passes in the clean full run.
- `cd app && pnpm test` - **2111 passed, 242 files**, including the new `http-client.error-shape.test.ts` (6 cases) and `failure-message.test.ts` (6 cases).
- `cd app && pnpm type-check` - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (new relative doc links resolve).
- **Mutation-checked.** Reverting `ImportModal` to `(e as Error).message` was run for real and turns the new modal test red. On the engine side, `expect_error_shape` asserts `error.is_object()`, so a `send_error` reverted to the flat shape fails there even though the per-route message assertions would fail too (they read `error.message`).
- Pre-existing and untouched: `pnpm lint` reports `no-explicit-any` on `ApiError.response` (part of the ESLint debt tracked in #189); the local clang-tidy is too old to parse `.clang-tidy`'s `ExcludeHeaderFilterRegex`.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the unified contract, the code table, every flat example), `docs/app/api-integration.md`, `docs/app/import-collections/README.md`, and `docs/plans/pending-backlog.md` (entry **P3** removed - this supersedes it). The `config.cpp` / `oauth.cpp` / route-core comments describing the split now describe the convention instead.

## Related Issues
Closes #173

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGFWCAyDbxBWsNU47k4QsL)_