### PR TITLE
feat(scripting): add pm.crypto and base64 globals so scripts can sign requests

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -112,7 +112,10 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 				tab.
 			</>,
 			<>
-				No crypto, base64 or <code className={CODE_CLASS}>URL</code> in the sandbox, and
+				Sign what you send with <code className={CODE_CLASS}>pm.crypto.hmacSha256</code> or{" "}
+				<code className={CODE_CLASS}>pm.crypto.sha256</code> (synchronous, hex by default);{" "}
+				<code className={CODE_CLASS}>btoa</code> / <code className={CODE_CLASS}>atob</code>{" "}
+				are there too. No <code className={CODE_CLASS}>URL</code> parser in the sandbox, and
 				load tests do not run pre-request scripts at all.
 			</>,
 		],

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -26,6 +26,8 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Globals             | `pm.globals.get/set/has/unset/clear/toObject`                                    |
 | Collection vars     | `pm.collectionVariables.get/set/has/unset/clear/toObject`                        |
 | Merged variables    | `pm.variables.get(name)`, `.has(name)`, `.toObject()` - read-only, see below     |
+| Crypto              | `pm.crypto.sha256(data, encoding?)`, `.hmacSha256(key, data, encoding?)` - synchronous, see below |
+| Base64              | `btoa(binaryString)`, `atob(base64)` - globals, standard web semantics           |
 | Console             | `console.log/info/warn/error`                                                    |
 
 `pm.response.headers` is a plain object keyed by the **lower-cased** header name, not
@@ -51,6 +53,37 @@ because Postman writes it to a per-request *local* scope that Vayu does not have
 alternatives (persisting to the environment, or dropping the write) would misrepresent
 what happened. The error names the three scoped setters. See
 [scripting.md](../engine/scripting.md#variables-pmvariables).
+
+### Hashing (`pm.crypto`) is Vayu's own name, and it is synchronous
+
+Postman exposes **Web Crypto** globally (`crypto.subtle`), whose every method
+returns a Promise. Vayu's sandbox has no event loop and no `setTimeout`, so
+nothing drains the job queue: an `await crypto.subtle.digest(...)` would never
+resume and the script would report a timeout rather than a result. Rather than
+wear a familiar name with unfamiliar behaviour, the surface is `pm.crypto` and
+it returns its result directly.
+
+```javascript
+pm.crypto.sha256('abc');                        // hex, 64 chars
+pm.crypto.sha256('abc', 'base64');              // 'hex' | 'base64' | 'base64url' | 'bytes'
+pm.crypto.hmacSha256(secret, canonicalString);  // hex by default
+```
+
+Strings are hashed as their **UTF-8** bytes. Pass a `Uint8Array` to hash bytes
+directly, and ask for `'bytes'` to get one back - that is what multi-round key
+derivation (AWS SigV4) needs, since each round is keyed by the raw digest of the
+previous one. Anything that is neither a string nor a byte-sized typed array
+throws: stringifying an object would hash the text `[object Object]` and return
+a digest that looks perfectly valid.
+
+`btoa` / `atob` keep their web semantics deliberately - they operate on **binary
+strings**, one byte per code unit, so `btoa` throws on a code point above U+00FF
+instead of silently UTF-8 encoding it. A signature over quietly-substituted
+bytes verifies nowhere.
+
+Not provided: `crypto`/`crypto.subtle` under those names, `TextEncoder`, MD5,
+SHA-1, and any asymmetric algorithm. The engine-side detail is in
+[scripting.md](../engine/scripting.md#what-a-script-can-compute).
 
 ### Assertion chains (`pm.expect`)
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -169,6 +169,11 @@ JavaScript execution engine for pre-request and test scripts:
 - **Postman-compatible API**: `pm.test()`, `pm.expect()`, `pm.response`, etc.
 - **Mutable request**: a pre-request script's `pm.request` writes are applied to the
   request before it is sent (see `docs/engine/scripting.md`)
+- **Signing**: `pm.crypto.sha256` / `.hmacSha256` plus the `btoa` / `atob` globals, so
+  a pre-request script can sign the request it just rewrote. Backed by the already
+  vendored picosha2 (`utils/sha256.hpp`, shared with PKCE) and `utils/encoding.hpp` -
+  **no new dependency, and OpenSSL is still not linked**. Synchronous, because the
+  sandbox has no event loop to settle a Promise on
 - **Memory limit**: 64MB per script execution
 - **Timeout**: 5 seconds per script
 - **Sandboxed**: No filesystem or network access

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -590,25 +590,12 @@ properties but one HTTP header, so the write-back rejects it rather than
 picking a winner, and the request is sent unchanged with the reason in
 `preScriptError`.
 
-### Sign a request with a checksum you can actually compute
+### Sign a request
 
-**There is no crypto in the sandbox** - no `crypto`, no `TextEncoder`, no
-`btoa`. A real HMAC is therefore not possible in-script today, and any example
-claiming otherwise is wrong. What *is* possible is a pure-JS digest over a
-canonical string, which is enough for a checksum, a cache key, or a test double
-of a signing scheme:
+`pm.crypto` gives a pre-request script a real HMAC, so the request it rewrites
+can be signed for what it actually became:
 
 ```javascript
-// FNV-1a, 32-bit. Not a cryptographic hash - do not use it as one.
-function fnv1a(text) {
-  var hash = 0x811c9dc5;
-  for (var i = 0; i < text.length; i++) {
-    hash ^= text.charCodeAt(i);
-    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
-  }
-  return ('00000000' + hash.toString(16)).slice(-8);
-}
-
 var timestamp = Date.now().toString();
 var canonical = [
   pm.request.method,
@@ -618,12 +605,53 @@ var canonical = [
 ].join('\n');
 
 pm.request.headers['X-Timestamp'] = timestamp;
-pm.request.headers['X-Checksum'] = fnv1a(canonical + pm.environment.get('secret'));
+pm.request.headers['X-Signature'] =
+  pm.crypto.hmacSha256(pm.environment.get('secret'), canonical);
 ```
 
 Note the ordering: the canonical string is built from `pm.request` *after* the
 other edits, so it covers what is actually sent. If you sign first and rewrite
 the body second, the signature describes a request that never existed.
+
+**Signatures compared as base64** - Shopify's, for instance - only need a
+different last argument:
+
+```javascript
+pm.request.headers['X-Signature'] =
+  pm.crypto.hmacSha256(pm.environment.get('secret'), canonical, 'base64');
+```
+
+#### Derived signing keys (AWS SigV4)
+
+A scheme that chains HMACs cannot be expressed with text output alone: each
+round is keyed by the **raw digest** of the previous one, and hex or base64 is a
+different byte string. That is what the `'bytes'` encoding is for - it returns a
+`Uint8Array`, which is also accepted as a key or as data:
+
+```javascript
+var secret  = pm.environment.get('aws_secret_key');
+var date    = '20150830';
+
+var kDate    = pm.crypto.hmacSha256('AWS4' + secret, date, 'bytes');
+var kRegion  = pm.crypto.hmacSha256(kDate, 'us-east-1', 'bytes');
+var kService = pm.crypto.hmacSha256(kRegion, 'iam', 'bytes');
+var kSigning = pm.crypto.hmacSha256(kService, 'aws4_request', 'bytes');
+
+// stringToSign is built per the SigV4 spec, hashing the canonical request with
+// pm.crypto.sha256(canonicalRequest) - hex, which is what the spec asks for.
+pm.request.headers['Authorization'] =
+  'AWS4-HMAC-SHA256 Credential=…, Signature=' +
+  pm.crypto.hmacSha256(kSigning, stringToSign);
+```
+
+#### What is hashed
+
+A string contributes its **UTF-8** bytes - the same bytes the engine puts on the
+wire, so a digest computed here matches one computed by `sha256sum` over the
+same text. A `Uint8Array` contributes its bytes unchanged; that is the only way
+to key an HMAC with bytes that are not valid UTF-8. Passing anything else (an
+object, a number, `null`) throws rather than being stringified: hashing the text
+`[object Object]` would return a digest that looks perfectly valid.
 
 ### Hand a value to the test script
 
@@ -646,20 +674,43 @@ pm.test('server echoed our nonce', function () {
 
 ### What a script can compute
 
-The sandbox is QuickJS plus exactly two globals, `pm` and `console`. Available:
-`JSON`, `Date`, `Math`, `RegExp`, `String`, `Array`, `Object`, `Number`,
-`Promise`, `BigInt`, `encodeURIComponent`, `parseInt` and the rest of the ES2020
-built-ins. **Not** available: `crypto`, `btoa` / `atob`, `TextEncoder`, `URL`,
-`URLSearchParams`, `setTimeout`, `require`, `fetch`.
+The sandbox is QuickJS plus `pm`, `console`, and the two base64 globals.
+Available: `JSON`, `Date`, `Math`, `RegExp`, `String`, `Array`, `Object`,
+`Number`, `Uint8Array`, `Promise`, `BigInt`, `encodeURIComponent`, `parseInt`
+and the rest of the ES2020 built-ins, plus:
 
-The practical consequences: no HMAC or SHA signing, no base64 (so no
-hand-rolled Basic auth header - use the request's Auth tab, which the engine
-applies), no URL parsing helper - which is why `pm.request.url` has no `.query`
-/ `.path` accessors either, see
-[URL parts are not exposed](#url-parts-are-not-exposed-deferred) - and nothing
-asynchronous. Both halves of this list are pinned by tests in
-`engine/tests/script_engine_test.cpp`, so if a global is ever added this section
-is what needs rewriting.
+| Name | Shape |
+| ---- | ----- |
+| `pm.crypto.sha256(data, encoding?)` | SHA-256; `data` is a string (UTF-8) or `Uint8Array` |
+| `pm.crypto.hmacSha256(key, data, encoding?)` | HMAC-SHA256; key and data take the same types |
+| `btoa(binaryString)` | base64-encode one byte per code unit |
+| `atob(base64)` | decode to a binary string; throws on invalid base64 |
+
+`encoding` is `'hex'` (the default), `'base64'`, `'base64url'` or `'bytes'`;
+`'bytes'` returns a `Uint8Array`, and any other value throws rather than
+silently falling back to hex.
+
+**Not** available: `crypto` / `crypto.subtle`, `TextEncoder`, `URL`,
+`URLSearchParams`, `setTimeout`, `require`, `fetch`. The practical
+consequences: no URL parsing helper - which is why `pm.request.url` has no
+`.query` / `.path` accessors either, see
+[URL parts are not exposed](#url-parts-are-not-exposed-deferred) - no hash
+other than SHA-256 (no MD5, no SHA-1, nothing asymmetric), and nothing
+asynchronous.
+
+**Why the hashing surface is not called `crypto`.** Web Crypto's `crypto.subtle`
+is Promise-based. `Promise` exists here, but nothing drains the job queue - there
+is no event loop and no `setTimeout` - so an `await crypto.subtle.digest(...)`
+would never resume and the script would report a timeout rather than a result.
+Vayu therefore takes a name of its own and is honestly synchronous. `btoa` and
+`atob` keep their standard names because they are synchronous on the web too,
+and they keep the rest of their semantics with them: they operate on **binary
+strings**, one byte per code unit, so `btoa` throws on a code point above U+00FF
+rather than silently UTF-8 encoding it.
+
+Both halves of this list are pinned by tests in
+`engine/tests/script_engine_test.cpp`, so if a global is ever added or removed
+this section is what needs rewriting.
 
 ## Limitations
 

--- a/engine/include/vayu/utils/encoding.hpp
+++ b/engine/include/vayu/utils/encoding.hpp
@@ -8,6 +8,7 @@
  */
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -57,6 +58,96 @@ inline std::string base64_encode (std::string_view in) {
         out.push_back ('=');
     }
 
+    return out;
+}
+
+/**
+ * @brief Decode standard base64 (RFC 4648 §4), rejecting anything malformed.
+ *
+ * Returns std::nullopt rather than a best-effort decode: the script sandbox's
+ * `atob` has to throw on bad input, and a caller that silently accepted a
+ * truncated group would hand back bytes the author never encoded. ASCII
+ * whitespace is skipped first (WHATWG `atob` forgives it, and wrapped base64
+ * from a config file or a PEM-ish blob is common), so only non-whitespace
+ * characters outside the alphabet, a '=' in a non-terminal position, or a
+ * length that is not a multiple of 4 after padding are errors.
+ */
+inline std::optional<std::string> base64_decode (std::string_view in) {
+    const auto sextet = [] (char c) -> int {
+        if (c >= 'A' && c <= 'Z')
+            return c - 'A';
+        if (c >= 'a' && c <= 'z')
+            return c - 'a' + 26;
+        if (c >= '0' && c <= '9')
+            return c - '0' + 52;
+        if (c == '+')
+            return 62;
+        if (c == '/')
+            return 63;
+        return -1;
+    };
+
+    std::string packed;
+    packed.reserve (in.size ());
+    for (const char c : in) {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f')
+            continue;
+        packed.push_back (c);
+    }
+
+    // Padding is only legal as the last one or two characters of the whole
+    // string; '=' anywhere else is a malformed group, not a short one.
+    size_t pad = 0;
+    while (pad < 2 && !packed.empty () && packed.back () == '=') {
+        packed.pop_back ();
+        ++pad;
+    }
+    if (packed.size () % 4 == 1)
+        return std::nullopt;
+    if (pad != 0 && (packed.size () + pad) % 4 != 0)
+        return std::nullopt;
+
+    std::string out;
+    out.reserve (packed.size () / 4 * 3 + 2);
+
+    uint32_t accum = 0;
+    int bits       = 0;
+    for (const char c : packed) {
+        const int value = sextet (c);
+        if (value < 0)
+            return std::nullopt;
+        accum = (accum << 6) | static_cast<uint32_t> (value);
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back (static_cast<char> ((accum >> bits) & 0xFF));
+        }
+    }
+
+    // Leftover bits belong to a sextet that encodes no whole byte; they must be
+    // zero, or the input carried data that decoding would drop.
+    if (bits != 0 && (accum & ((1U << bits) - 1)) != 0)
+        return std::nullopt;
+
+    return out;
+}
+
+/**
+ * @brief Lowercase hex of arbitrary bytes.
+ *
+ * The default digest encoding for the script sandbox's hashing surface, and the
+ * one every webhook-signature scheme (Stripe, GitHub, Slack) compares against.
+ */
+inline std::string hex_encode (std::string_view in) {
+    static constexpr char hex[] = "0123456789abcdef";
+
+    std::string out;
+    out.reserve (in.size () * 2);
+    for (const char ch : in) {
+        const auto c = static_cast<uint8_t> (ch);
+        out.push_back (hex[c >> 4]);
+        out.push_back (hex[c & 0x0F]);
+    }
     return out;
 }
 

--- a/engine/include/vayu/utils/sha256.hpp
+++ b/engine/include/vayu/utils/sha256.hpp
@@ -7,16 +7,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// SHA-256 for PKCE code challenges (RFC 7636 S256). Thin wrapper over the
-// vendored, MIT-licensed picosha2 single-header (engine/vendor/picosha2) so the
-// engine neither hand-maintains a hash implementation nor links OpenSSL. Not
-// required to be constant-time: PKCE hashes a client-generated, non-secret
-// verifier whose resulting challenge is transmitted in the clear.
+// SHA-256 and HMAC-SHA256. Thin wrappers over the vendored, MIT-licensed
+// picosha2 single-header (engine/vendor/picosha2) so the engine neither
+// hand-maintains a hash implementation nor links OpenSSL.
+//
+// Two callers with different threat models share these: PKCE code challenges
+// (RFC 7636 S256), which hash a client-generated, non-secret verifier whose
+// challenge is then transmitted in the clear; and the script sandbox's
+// pm.crypto surface, where a user signs an outgoing request with their own
+// secret. Neither is constant-time - these compute a signature to send, they do
+// not compare an attacker-supplied one - so do not reach for them to verify a
+// MAC without adding a constant-time comparison of your own.
 
 #include <picosha2.h>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 namespace vayu::utils {
@@ -31,6 +39,45 @@ inline std::array<uint8_t, 32> sha256 (std::string_view data) {
     std::array<uint8_t, 32> out{};
     picosha2::hash256 (data.begin (), data.end (), out.begin (), out.end ());
     return out;
+}
+
+/**
+ * @brief HMAC-SHA256 (RFC 2104) of `data` under `key`.
+ *
+ * Keys longer than the 64-byte SHA-256 block are hashed down first and keys
+ * shorter are zero-padded, both per RFC 2104 - so a key is never rejected for
+ * its length, and a 64-byte key and its 32-byte digest are deliberately *not*
+ * interchangeable.
+ */
+inline std::array<uint8_t, 32> hmac_sha256 (std::string_view key, std::string_view data) {
+    constexpr size_t block_size = 64;
+
+    std::array<uint8_t, block_size> padded_key{};
+    if (key.size () > block_size) {
+        const auto digest = sha256 (key);
+        std::copy (digest.begin (), digest.end (), padded_key.begin ());
+    } else {
+        for (size_t i = 0; i < key.size (); ++i) {
+            padded_key[i] = static_cast<uint8_t> (key[i]);
+        }
+    }
+
+    std::string inner;
+    inner.reserve (block_size + data.size ());
+    std::string outer;
+    outer.reserve (block_size + 32);
+
+    for (const uint8_t byte : padded_key) {
+        inner.push_back (static_cast<char> (byte ^ 0x36));
+        outer.push_back (static_cast<char> (byte ^ 0x5c));
+    }
+    inner.append (data);
+
+    const auto inner_digest = sha256 (inner);
+    outer.append (
+    reinterpret_cast<const char*> (inner_digest.data ()), inner_digest.size ());
+
+    return sha256 (outer);
 }
 
 } // namespace vayu::utils

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -541,6 +541,75 @@ nlohmann::json get_script_completions () {
     { "sortText", "1_pm_variables_toObject" } });
 
     // ========================================
+    // pm.crypto - Hashing, and the base64 globals that go with it
+    // ========================================
+    completions.push_back ({ { "label", "pm.crypto" }, { "kind", KIND_VARIABLE },
+    { "insertText", "pm.crypto" }, { "detail", "Synchronous hashing" },
+    { "documentation",
+    "SHA-256 and HMAC-SHA256 for signing an outgoing request from a "
+    "pre-request script.\n\nSynchronous, unlike Web Crypto's crypto.subtle: "
+    "the sandbox has no event loop, so a Promise-based API would never "
+    "settle. That is why this is pm.crypto rather than a global named "
+    "crypto." },
+    { "sortText", "0_pm_crypto" } });
+
+    completions.push_back ({ { "label", "pm.crypto.sha256" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.crypto.sha256(${1:data})" }, { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail",
+    "pm.crypto.sha256(data: string | Uint8Array, encoding?: 'hex' | 'base64' "
+    "| 'base64url' | 'bytes'): string | Uint8Array" },
+    { "documentation",
+    "SHA-256 digest, hex by default. A string is hashed as its UTF-8 bytes; "
+    "pass a Uint8Array to hash bytes directly.\n\nExample:\nconst digest = "
+    "pm.crypto.sha256(pm.request.body || '');" },
+    { "sortText", "1_pm_crypto_sha256" } });
+
+    completions.push_back ({ { "label", "pm.crypto.hmacSha256" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.crypto.hmacSha256(${1:key}, ${2:data})" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail",
+    "pm.crypto.hmacSha256(key: string | Uint8Array, data: string | "
+    "Uint8Array, encoding?: 'hex' | 'base64' | 'base64url' | 'bytes'): string "
+    "| Uint8Array" },
+    { "documentation",
+    "HMAC-SHA256, hex by default. Use encoding 'bytes' to get a Uint8Array "
+    "you can pass back as the key, which is what multi-round key derivation "
+    "(AWS SigV4) needs.\n\nExample:\npm.request.headers['X-Signature'] =\n  "
+    "pm.crypto.hmacSha256(pm.environment.get('secret'), canonical);" },
+    { "sortText", "1_pm_crypto_hmacSha256" } });
+
+    completions.push_back ({ { "label", "btoa" }, { "kind", KIND_FUNCTION },
+    { "insertText", "btoa(${1:text})" }, { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "btoa(data: string): string" },
+    { "documentation",
+    "Base64-encode a binary string, with the standard web semantics: one byte "
+    "per character, so a code point above U+00FF throws rather than being "
+    "silently UTF-8 encoded." },
+    { "sortText", "2_btoa" } });
+
+    completions.push_back ({ { "label", "atob" }, { "kind", KIND_FUNCTION },
+    { "insertText", "atob(${1:encoded})" }, { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "atob(encoded: string): string" },
+    { "documentation",
+    "Decode base64 to a binary string - one character per byte. Throws on "
+    "input that is not valid base64." },
+    { "sortText", "2_atob" } });
+
+    completions.push_back ({ { "label", "Sign the outgoing request" }, { "kind", KIND_SNIPPET },
+    { "insertText",
+    "// Pre-request: sign what is actually about to be sent.\nconst timestamp "
+    "= Date.now().toString();\nconst canonical = [pm.request.method, "
+    "pm.request.url, timestamp, pm.request.body || "
+    "''].join('\\n');\npm.request.headers['X-Timestamp'] = "
+    "timestamp;\npm.request.headers['X-Signature'] = "
+    "pm.crypto.hmacSha256(pm.environment.get(\"${1:secret}\"), canonical);" },
+    { "insertTextRules", INSERT_AS_SNIPPET }, { "detail", "Script template" },
+    { "documentation",
+    "HMAC-sign the request from a pre-request script. Build the canonical "
+    "string after any other edits, so the signature covers what is sent." },
+    { "sortText", "3_snippet_sign" } });
+
+    // ========================================
     // console - Console output
     // ========================================
     completions.push_back ({ { "label", "console.log" }, { "kind", KIND_FUNCTION },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -17,6 +17,7 @@
 #include "vayu/runtime/script_engine.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <chrono>
 #include <cmath>
@@ -29,7 +30,9 @@
 #include <vector>
 
 #include "vayu/http/status.hpp"
+#include "vayu/utils/encoding.hpp"
 #include "vayu/utils/json.hpp"
+#include "vayu/utils/sha256.hpp"
 
 #ifdef VAYU_HAS_QUICKJS
 // Disable warnings for QuickJS C header in C++ code
@@ -1615,6 +1618,290 @@ JSValue create_expectation (JSContext* ctx, JSValue actual) {
 }
 
 // ============================================================================
+// Base64 globals and pm.crypto
+// ============================================================================
+//
+// Why this is synchronous, and why it is not called `crypto.subtle`.
+//
+// Web Crypto's SubtleCrypto returns Promises. `Promise` exists in this sandbox
+// but nothing drains the job queue - there is no event loop and no setTimeout
+// (see the timeout note on ScriptConfig) - so `await crypto.subtle.digest(...)`
+// would never resume and the script would report a timeout rather than a
+// result. Wearing the Web Crypto name while behaving differently is the exact
+// trap the sandbox-surface tests exist to catch, so the hashing surface takes a
+// name of its own, `pm.crypto`, and is honestly synchronous. `btoa` / `atob`
+// keep their standard names because they are synchronous on the web too, and
+// they keep their standard Latin-1 semantics with them.
+
+// A JS string reaches C++ as UTF-8. `btoa` is defined over code units, not code
+// points, so anything above U+00FF is a range error there; every other caller
+// wants the UTF-8 bytes as they stand. Returning the byte string keeps one
+// conversion rule in one place.
+enum class ByteSource { Utf8, Latin1 };
+
+// Decodes UTF-8 to Latin-1 bytes, failing on any code point above U+00FF.
+// Returns false when the string cannot be represented, leaving `out` unusable.
+bool utf8_to_latin1 (std::string_view in, std::string& out) {
+    out.clear ();
+    out.reserve (in.size ());
+    for (size_t i = 0; i < in.size ();) {
+        const auto lead = static_cast<uint8_t> (in[i]);
+        if (lead < 0x80) {
+            out.push_back (static_cast<char> (lead));
+            i += 1;
+        } else if ((lead & 0xE0) == 0xC0 && i + 1 < in.size ()) {
+            const auto cont = static_cast<uint8_t> (in[i + 1]);
+            if ((cont & 0xC0) != 0x80)
+                return false;
+            const unsigned cp = ((lead & 0x1FU) << 6) | (cont & 0x3FU);
+            if (cp > 0xFF)
+                return false;
+            out.push_back (static_cast<char> (cp));
+            i += 2;
+        } else {
+            // Three- and four-byte sequences are all above U+00FF by
+            // definition, and a malformed lead byte is not representable
+            // either.
+            return false;
+        }
+    }
+    return true;
+}
+
+// Latin-1 bytes back to a JS string: each byte becomes the code point of the
+// same value, which is UTF-8 encoded so QuickJS decodes it to that code unit.
+std::string latin1_to_utf8 (std::string_view in) {
+    std::string out;
+    out.reserve (in.size ());
+    for (const char ch : in) {
+        const auto byte = static_cast<uint8_t> (ch);
+        if (byte < 0x80) {
+            out.push_back (static_cast<char> (byte));
+        } else {
+            out.push_back (static_cast<char> (0xC0 | (byte >> 6)));
+            out.push_back (static_cast<char> (0x80 | (byte & 0x3F)));
+        }
+    }
+    return out;
+}
+
+JSValue js_btoa (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "btoa requires a string");
+    }
+    if (!JS_IsString (argv[0])) {
+        return JS_ThrowTypeError (ctx, "btoa expects a string");
+    }
+
+    std::string bytes;
+    if (!utf8_to_latin1 (js_to_string (ctx, argv[0]), bytes)) {
+        return JS_ThrowTypeError (ctx,
+        "btoa: the string contains characters outside the Latin-1 range. "
+        "Base64 encodes bytes, so encode the text yourself first (for example "
+        "with pm.crypto's digest output) or restrict it to code points <= "
+        "U+00FF");
+    }
+
+    const std::string encoded = vayu::utils::base64_encode (bytes);
+    return JS_NewStringLen (ctx, encoded.data (), encoded.size ());
+}
+
+JSValue js_atob (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "atob requires a string");
+    }
+    if (!JS_IsString (argv[0])) {
+        return JS_ThrowTypeError (ctx, "atob expects a string");
+    }
+
+    const auto decoded = vayu::utils::base64_decode (js_to_string (ctx, argv[0]));
+    if (!decoded) {
+        return JS_ThrowTypeError (ctx, "atob: the string is not valid base64");
+    }
+
+    const std::string text = latin1_to_utf8 (*decoded);
+    return JS_NewStringLen (ctx, text.data (), text.size ());
+}
+
+// Reads a hash input: a string contributes its UTF-8 bytes, a Uint8Array its
+// bytes as they are. Anything else throws rather than being stringified -
+// hashing the text "[object Object]" would be a silent wrong answer, and the
+// digest gives the author no clue that it happened.
+// Deliberately built from JS_GetTypedArrayBuffer + JS_GetArrayBuffer rather
+// than JS_GetUint8Array: the engine vendors Bellard's QuickJS on Linux and
+// macOS and quickjs-ng on Windows, and only the latter has the Uint8Array
+// shortcuts. These two calls exist in both.
+bool read_crypto_bytes (JSContext* ctx, JSValueConst value, const char* what, std::string& out) {
+    if (JS_IsString (value)) {
+        out = js_to_string (ctx, value);
+        return true;
+    }
+
+    size_t byte_offset  = 0;
+    size_t byte_length  = 0;
+    size_t element_size = 0;
+    JSValue buffer =
+    JS_GetTypedArrayBuffer (ctx, value, &byte_offset, &byte_length, &element_size);
+
+    if (!JS_IsException (buffer)) {
+        // A wider element type would make the digest depend on this machine's
+        // byte order, so only byte-sized views are accepted.
+        if (element_size != 1) {
+            JS_FreeValue (ctx, buffer);
+            JS_ThrowTypeError (ctx,
+            "%s must be a byte-sized typed array (Uint8Array); a %zu-byte "
+            "element type would hash in this machine's byte order",
+            what, element_size);
+            return false;
+        }
+
+        size_t buffer_size = 0;
+        uint8_t* base      = JS_GetArrayBuffer (ctx, &buffer_size, buffer);
+        JS_FreeValue (ctx, buffer);
+
+        // A detached buffer reads as zero length with a null base; hashing
+        // nothing and calling it a digest of the caller's data is the silent
+        // wrong answer this whole path exists to avoid.
+        if (!base || byte_offset + byte_length > buffer_size) {
+            JS_FreeValue (ctx, JS_GetException (ctx));
+            JS_ThrowTypeError (ctx, "%s is backed by a detached buffer", what);
+            return false;
+        }
+
+        out.assign (reinterpret_cast<const char*> (base + byte_offset), byte_length);
+        return true;
+    }
+
+    // JS_GetTypedArrayBuffer threw its own TypeError for the not-a-typed-array
+    // case; replace it with one that names the argument and what is accepted.
+    JS_FreeValue (ctx, JS_GetException (ctx));
+    JS_ThrowTypeError (ctx, "%s must be a string or a Uint8Array", what);
+    return false;
+}
+
+// Turns a digest into whatever the caller asked for. 'bytes' exists so a digest
+// can be fed back in as a key: multi-round key derivation (AWS SigV4 signs with
+// the raw digest of the previous round) is impossible when the only outputs are
+// text.
+JSValue encode_digest (JSContext* ctx,
+const std::array<uint8_t, 32>& digest,
+const std::string& encoding) {
+    const std::string_view raw (
+    reinterpret_cast<const char*> (digest.data ()), digest.size ());
+
+    if (encoding == "bytes") {
+        // Constructed through the global Uint8Array rather than a helper, for
+        // the same cross-vendor reason as read_crypto_bytes.
+        JSValue global = JS_GetGlobalObject (ctx);
+        JSValue ctor   = JS_GetPropertyStr (ctx, global, "Uint8Array");
+        JS_FreeValue (ctx, global);
+        if (!JS_IsFunction (ctx, ctor)) {
+            JS_FreeValue (ctx, ctor);
+            return JS_ThrowTypeError (ctx, "Uint8Array is not available in this context");
+        }
+
+        JSValue buffer = JS_NewArrayBufferCopy (ctx, digest.data (), digest.size ());
+        JSValue array = JS_CallConstructor (ctx, ctor, 1, &buffer);
+        JS_FreeValue (ctx, buffer);
+        JS_FreeValue (ctx, ctor);
+        return array;
+    }
+
+    std::string out;
+    if (encoding == "hex") {
+        out = vayu::utils::hex_encode (raw);
+    } else if (encoding == "base64") {
+        out = vayu::utils::base64_encode (raw);
+    } else if (encoding == "base64url") {
+        out = vayu::utils::base64url_encode (raw);
+    } else {
+        return JS_ThrowTypeError (ctx,
+        "unknown digest encoding '%s' - expected 'hex', 'base64', "
+        "'base64url' or 'bytes'",
+        encoding.c_str ());
+    }
+
+    return JS_NewStringLen (ctx, out.data (), out.size ());
+}
+
+// The encoding argument, which is optional and defaults to hex. An explicit
+// undefined is the same as omitting it; anything else non-string is a typo
+// worth failing on rather than coercing to a name that then fails anyway.
+bool read_digest_encoding (JSContext* ctx, int argc, JSValueConst* argv, int index, std::string& out) {
+    out = "hex";
+    if (argc <= index || JS_IsUndefined (argv[index])) {
+        return true;
+    }
+    if (!JS_IsString (argv[index])) {
+        JS_ThrowTypeError (ctx, "the encoding must be a string");
+        return false;
+    }
+    out = js_to_string (ctx, argv[index]);
+    return true;
+}
+
+JSValue js_crypto_sha256 (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 1) {
+        return JS_ThrowTypeError (ctx, "pm.crypto.sha256 requires data");
+    }
+
+    std::string data;
+    if (!read_crypto_bytes (ctx, argv[0], "pm.crypto.sha256 data", data)) {
+        return JS_EXCEPTION;
+    }
+
+    std::string encoding;
+    if (!read_digest_encoding (ctx, argc, argv, 1, encoding)) {
+        return JS_EXCEPTION;
+    }
+
+    return encode_digest (ctx, vayu::utils::sha256 (data), encoding);
+}
+
+JSValue js_crypto_hmac_sha256 (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    if (argc < 2) {
+        return JS_ThrowTypeError (ctx, "pm.crypto.hmacSha256 requires a key and data");
+    }
+
+    std::string key;
+    if (!read_crypto_bytes (ctx, argv[0], "pm.crypto.hmacSha256 key", key)) {
+        return JS_EXCEPTION;
+    }
+
+    std::string data;
+    if (!read_crypto_bytes (ctx, argv[1], "pm.crypto.hmacSha256 data", data)) {
+        return JS_EXCEPTION;
+    }
+
+    std::string encoding;
+    if (!read_digest_encoding (ctx, argc, argv, 2, encoding)) {
+        return JS_EXCEPTION;
+    }
+
+    return encode_digest (ctx, vayu::utils::hmac_sha256 (key, data), encoding);
+}
+
+void setup_base64_globals (JSContext* ctx) {
+    JSValue global = JS_GetGlobalObject (ctx);
+    JS_SetPropertyStr (ctx, global, "btoa", JS_NewCFunction (ctx, js_btoa, "btoa", 1));
+    JS_SetPropertyStr (ctx, global, "atob", JS_NewCFunction (ctx, js_atob, "atob", 1));
+    JS_FreeValue (ctx, global);
+}
+
+void setup_pm_crypto (JSContext* ctx, JSValue pm) {
+    JSValue crypto = JS_NewObject (ctx);
+    JS_SetPropertyStr (
+    ctx, crypto, "sha256", JS_NewCFunction (ctx, js_crypto_sha256, "sha256", 2));
+    JS_SetPropertyStr (ctx, crypto, "hmacSha256",
+    JS_NewCFunction (ctx, js_crypto_hmac_sha256, "hmacSha256", 3));
+    JS_SetPropertyStr (ctx, pm, "crypto", crypto);
+}
+
+// ============================================================================
 // pm Object Implementation
 // ============================================================================
 
@@ -3038,6 +3325,9 @@ void setup_pm_object (JSContext* ctx) {
     // pm.variables
     setup_pm_variables (ctx, pm);
 
+    // pm.crypto
+    setup_pm_crypto (ctx, pm);
+
     JS_SetPropertyStr (ctx, global, "pm", pm);
     JS_FreeValue (ctx, global);
 }
@@ -3131,6 +3421,7 @@ class ScriptEngine::Impl {
             if (config.enable_console) {
                 setup_console (ctx);
             }
+            setup_base64_globals (ctx);
             setup_pm_object (ctx);
         } else {
             JS_FreeRuntime (rt);

--- a/engine/tests/encoding_test.cpp
+++ b/engine/tests/encoding_test.cpp
@@ -7,8 +7,10 @@
 
 #include "vayu/utils/encoding.hpp"
 
+using vayu::utils::base64_decode;
 using vayu::utils::base64_encode;
 using vayu::utils::form_encode;
+using vayu::utils::hex_encode;
 using vayu::utils::url_decode;
 using vayu::utils::url_encode;
 
@@ -82,4 +84,63 @@ TEST (Encoding, FormEncodeOrdersAndEscapes) {
     form_encode ({ { "grant_type", "client_credentials" }, { "scope", "a b" } }),
     "grant_type=client_credentials&scope=a%20b");
     EXPECT_EQ (form_encode ({}), "");
+}
+
+// ============================================================================
+// base64_decode
+// ============================================================================
+//
+// The inverse of the vectors above, plus the malformed cases - this helper
+// backs the sandbox's `atob`, which must throw rather than hand a script bytes
+// its author never encoded.
+
+TEST (Encoding, Base64DecodeRfc4648Vectors) {
+    EXPECT_EQ (base64_decode ("").value (), "");
+    EXPECT_EQ (base64_decode ("Zg==").value (), "f");
+    EXPECT_EQ (base64_decode ("Zm8=").value (), "fo");
+    EXPECT_EQ (base64_decode ("Zm9v").value (), "foo");
+    EXPECT_EQ (base64_decode ("Zm9vYg==").value (), "foob");
+    EXPECT_EQ (base64_decode ("Zm9vYmE=").value (), "fooba");
+    EXPECT_EQ (base64_decode ("Zm9vYmFy").value (), "foobar");
+}
+
+TEST (Encoding, Base64DecodeAcceptsUnpaddedAndWrappedInput) {
+    // Padding is optional as long as the trailing bits are zero, and wrapped
+    // base64 (a PEM-ish blob, a value pasted out of a config file) is common
+    // enough that rejecting the newline would be its own bug.
+    EXPECT_EQ (base64_decode ("Zg").value (), "f");
+    EXPECT_EQ (base64_decode ("Zm8").value (), "fo");
+    EXPECT_EQ (base64_decode ("Zm9v\nYmFy").value (), "foobar");
+    EXPECT_EQ (base64_decode ("Zm9v YmFy").value (), "foobar");
+}
+
+TEST (Encoding, Base64DecodeRejectsMalformedInput) {
+    EXPECT_FALSE (base64_decode ("Z").has_value ()); // a lone sextet is no byte
+    EXPECT_FALSE (base64_decode ("Zm9$").has_value ()); // outside the alphabet
+    EXPECT_FALSE (base64_decode ("Zg=v").has_value ()); // padding mid-string
+    EXPECT_FALSE (base64_decode ("Zm9vYmF").has_value ()); // truncated: trailing bits set
+    EXPECT_FALSE (base64_decode ("Zm9v=").has_value ()); // padding on a whole group
+    EXPECT_FALSE (base64_decode ("-_").has_value ()); // base64url is a different alphabet
+}
+
+TEST (Encoding, Base64DecodeCarriesHighBytesAndNul) {
+    const std::string decoded = base64_decode ("AP8Q").value ();
+    ASSERT_EQ (decoded.size (), 3U);
+    EXPECT_EQ (static_cast<unsigned char> (decoded[0]), 0x00);
+    EXPECT_EQ (static_cast<unsigned char> (decoded[1]), 0xFF);
+    EXPECT_EQ (static_cast<unsigned char> (decoded[2]), 0x10);
+}
+
+TEST (Encoding, Base64RoundTripsEveryByteValue) {
+    std::string all;
+    for (int i = 0; i < 256; ++i) {
+        all.push_back (static_cast<char> (i));
+    }
+    EXPECT_EQ (base64_decode (base64_encode (all)).value (), all);
+}
+
+TEST (Encoding, HexEncodeIsLowercaseAndZeroPadded) {
+    EXPECT_EQ (hex_encode (""), "");
+    EXPECT_EQ (hex_encode (std::string ("\x00\x0f\xff\xa5", 4)), "000fffa5");
+    EXPECT_EQ (hex_encode ("foobar"), "666f6f626172");
 }

--- a/engine/tests/pkce_test.cpp
+++ b/engine/tests/pkce_test.cpp
@@ -13,14 +13,11 @@
 
 namespace {
 
+// Delegates rather than repeating the table: vayu::utils::hex_encode is the one
+// hex encoder, and a second copy here would not receive its fixes.
 std::string hex (const std::array<uint8_t, 32>& d) {
-    static constexpr char h[] = "0123456789abcdef";
-    std::string out;
-    for (uint8_t b : d) {
-        out.push_back (h[b >> 4]);
-        out.push_back (h[b & 0xf]);
-    }
-    return out;
+    return vayu::utils::hex_encode (
+    std::string_view (reinterpret_cast<const char*> (d.data ()), d.size ()));
 }
 
 TEST (Sha256, Fips180Vectors) {

--- a/engine/tests/pkce_test.cpp
+++ b/engine/tests/pkce_test.cpp
@@ -42,6 +42,53 @@ TEST (Sha256, HandlesMultiBlockAndPaddingBoundary) {
     "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a");
 }
 
+// RFC 4231 §4. Cases 1-3 cover a short key, an ASCII key and a full-block-ish
+// key; case 6 is the one that matters most here, because its 131-byte key
+// exercises the "hash the key down first" branch of RFC 2104 that a short key
+// never reaches. Backs pm.crypto.hmacSha256 in the script sandbox.
+TEST (HmacSha256, Rfc4231Vectors) {
+    EXPECT_EQ (hex (vayu::utils::hmac_sha256 (std::string (20, '\x0b'), "Hi There")),
+    "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")
+    << "case 1";
+
+    EXPECT_EQ (hex (vayu::utils::hmac_sha256 ("Jefe", "what do ya want for nothing?")),
+    "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843")
+    << "case 2";
+
+    EXPECT_EQ (
+    hex (vayu::utils::hmac_sha256 (std::string (20, '\xaa'), std::string (50, '\xdd'))),
+    "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe")
+    << "case 3";
+
+    EXPECT_EQ (hex (vayu::utils::hmac_sha256 (std::string (131, '\xaa'),
+               "Test Using Larger Than Block-Size Key - Hash Key First")),
+    "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54")
+    << "case 6 - key longer than the 64-byte block";
+}
+
+TEST (HmacSha256, KeyLengthsAroundTheBlockBoundary) {
+    // 64 bytes is used as-is; 65 is hashed to 32 first. Pinned to known answers
+    // rather than just to each other, because an off-by-one in the length test
+    // (>= where > belongs) still produces two different MACs - "these differ"
+    // would pass while a 64-byte key was quietly being hashed down.
+    EXPECT_EQ (hex (vayu::utils::hmac_sha256 (std::string (63, 'k'), "payload")),
+    "053491462ff9bc089fc983b345332712f18867b013011373dac80d58326beba5");
+    EXPECT_EQ (hex (vayu::utils::hmac_sha256 (std::string (64, 'k'), "payload")),
+    "825fe496b2f55f2c6a78d8e3f21cff15b59fc2bcd437be6f7bda2fb2c4d8a9f4")
+    << "a key of exactly one block is used as-is, not hashed";
+    const auto over = vayu::utils::hmac_sha256 (std::string (65, 'k'), "payload");
+    EXPECT_EQ (hex (over), "bd24b45a850e5df5a7f21642c7f47ace8444900a95d1eb8284553e273b262d22");
+
+    // A 65-byte key is hashed to 32 bytes, but that is not the same as being
+    // *given* those 32 bytes zero-padded... it is exactly that, by
+    // construction. So the equality below is the specification, not an
+    // accident: pass the digest of an over-long key and you get the same MAC.
+    const auto digest = vayu::utils::sha256 (std::string (65, 'k'));
+    const std::string_view digest_bytes (
+    reinterpret_cast<const char*> (digest.data ()), digest.size ());
+    EXPECT_EQ (hex (over), hex (vayu::utils::hmac_sha256 (digest_bytes, "payload")));
+}
+
 TEST (Base64Url, NoPaddingUrlSafeAlphabet) {
     // bytes that base64 to values containing + and / → become - and _
     EXPECT_EQ (vayu::utils::base64url_encode (std::string ("\xfb\xff\xbf", 3)), "-_-_");

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -415,4 +415,57 @@ TEST (ScriptCompletions, EveryExpectMemberTheRuntimeBindsIsOffered) {
     << result.tests[0].error_message;
 }
 
+// The signing surface (#187). Same drift risk as the matchers above, with a
+// sharper edge: an author who is offered `pm.crypto.hmacSha256` and finds it
+// undefined has no fallback - there is no other way to compute an HMAC in the
+// sandbox. This calls every offered pm.crypto member for real rather than
+// checking a name exists, because the failure mode being guarded is the list
+// promising something the runtime never bound.
+TEST (ScriptCompletions, EveryOfferedCryptoMemberIsCallableInTheRuntime) {
+    const auto completions = get_script_completions ();
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request;
+    vayu::Response response;
+    vayu::Environment env;
+    request.method       = vayu::HttpMethod::GET;
+    request.url          = "https://api.example.com/users";
+    response.status_code = 200;
+    response.body        = R"({"ok": true})";
+
+    int offered = 0;
+    for (const auto& item : completions) {
+        const std::string label = item.value ("label", std::string{});
+        if (label.rfind ("pm.crypto.", 0) != 0 && label != "btoa" && label != "atob") {
+            continue;
+        }
+        offered++;
+
+        // Call it with arguments of the documented types rather than the
+        // snippet's placeholders, which are not valid JS on their own.
+        std::string call;
+        if (label == "btoa")
+            call = "btoa('abc')";
+        else if (label == "atob")
+            call = "atob('YWJj')";
+        else if (label == "pm.crypto.sha256")
+            call = "pm.crypto.sha256('abc')";
+        else if (label == "pm.crypto.hmacSha256")
+            call = "pm.crypto.hmacSha256('k', 'abc')";
+        else
+            FAIL () << label << " is offered but this test does not know how to call it";
+
+        const std::string script = "pm.test(\"t\", function() { var out = " +
+        call + "; if (typeof out !== 'string' || !out.length) throw new Error('no result'); });";
+        auto result = engine.execute_test (script, request, response, env);
+        ASSERT_EQ (result.tests.size (), 1u) << script;
+        EXPECT_TRUE (result.tests[0].passed)
+        << label << " is offered but the runtime does not provide it: "
+        << result.tests[0].error_message;
+    }
+
+    EXPECT_EQ (offered, 4)
+    << "the signing surface changed - update this test and the docs it backs";
+}
+
 } // namespace

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -1685,10 +1685,9 @@ TEST_F (ScriptEngineTest, ZeroTimeoutDisablesLimit) {
 // ============================================================================
 //
 // `scripting.md` now teaches request rewriting, so what a script can *compute*
-// is part of the contract. Only `console` and `pm` are installed on top of
-// QuickJS's built-ins - there is no crypto, no base64, no URL parser - which is
-// why the docs' worked examples do string surgery and a pure-JS checksum rather
-// than an HMAC. This pins both halves so a doc example cannot come to rely on
+// is part of the contract. Installed on top of QuickJS's built-ins: `console`,
+// `pm`, and `btoa` / `atob` (#187). Still absent: a URL parser and anything
+// asynchronous. This pins both halves so a doc example cannot come to rely on
 // something that was never there (`scripting.md` used to show a `computeHash`
 // that does not exist).
 
@@ -1709,11 +1708,11 @@ TEST_F (ScriptEngineTest, StandardBuiltinsAreAvailableToScripts) {
     << "a built-in the docs rely on disappeared";
 }
 
-TEST_F (ScriptEngineTest, NoCryptoBase64OrUrlParserIsExposed) {
+TEST_F (ScriptEngineTest, NoUrlParserOrAsyncSurfaceIsExposed) {
     auto result = engine.execute_prerequest (R"JS(
         var present = [];
-        var absent = ['crypto', 'btoa', 'atob', 'TextEncoder', 'URL',
-                      'URLSearchParams', 'require', 'fetch'];
+        var absent = ['crypto', 'TextEncoder', 'URL', 'URLSearchParams',
+                      'require', 'fetch', 'setTimeout'];
         for (var i = 0; i < absent.length; i++) {
             if (typeof globalThis[absent[i]] !== 'undefined') present.push(absent[i]);
         }
@@ -1722,11 +1721,284 @@ TEST_F (ScriptEngineTest, NoCryptoBase64OrUrlParserIsExposed) {
     request, env);
 
     ASSERT_TRUE (result.success) << result.error_message;
-    // If one of these ever lands, the "you cannot HMAC-sign in a script" note in
+    // If one of these ever lands, the "what a script can compute" section in
     // scripting.md stops being true and should be rewritten, not left standing.
+    // `crypto` in particular: a global of that name is a promise of Web Crypto,
+    // which is async, and nothing drains this sandbox's job queue - which is
+    // why the hashing surface is pm.crypto and synchronous.
     EXPECT_EQ (env["present"].value, "")
-    << "a new global is available - update the request-signing note in "
-       "scripting.md";
+    << "a new global is available - update the 'What a script can compute' "
+       "section in scripting.md";
+}
+
+TEST_F (ScriptEngineTest, Base64AndHashingGlobalsAreInstalled) {
+    auto result = engine.execute_prerequest (R"JS(
+        var missing = [];
+        if (typeof btoa !== 'function') missing.push('btoa');
+        if (typeof atob !== 'function') missing.push('atob');
+        if (typeof pm.crypto !== 'object') missing.push('pm.crypto');
+        if (typeof pm.crypto.sha256 !== 'function') missing.push('pm.crypto.sha256');
+        if (typeof pm.crypto.hmacSha256 !== 'function') missing.push('pm.crypto.hmacSha256');
+        pm.environment.set('missing', missing.join(','));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["missing"].value, "")
+    << "the signing surface #187 added is incomplete - scripting.md and "
+       "pm-api-compatibility.md teach these names";
+}
+
+// ============================================================================
+// btoa / atob (#187)
+// ============================================================================
+//
+// Known answers, not round-trips: a round-trip passes just as happily over two
+// mirrored bugs. The vectors are RFC 4648 §10, which is also what
+// encoding_test.cpp checks the C++ helpers against - the point here is that the
+// JS boundary hands over the same bytes.
+
+TEST_F (ScriptEngineTest, BtoaMatchesRfc4648Vectors) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('out', [btoa(''), btoa('f'), btoa('fo'), btoa('foo'),
+                                   btoa('foob'), btoa('fooba'), btoa('foobar')].join('|'));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["out"].value, "|Zg==|Zm8=|Zm9v|Zm9vYg==|Zm9vYmE=|Zm9vYmFy");
+}
+
+TEST_F (ScriptEngineTest, AtobDecodesRfc4648VectorsIncludingPadding) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('out', [atob(''), atob('Zg=='), atob('Zm8='), atob('Zm9v'),
+                                   atob('Zm9vYg=='), atob('Zm9vYmE='), atob('Zm9vYmFy')].join('|'));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["out"].value, "|f|fo|foo|foob|fooba|foobar");
+}
+
+TEST_F (ScriptEngineTest, Base64CarriesHighBytesThroughTheJsBoundary) {
+    // atob returns a binary string: one code unit per byte, 0x80-0xFF included.
+    // This is where a naive "just hand QuickJS the bytes" implementation breaks,
+    // because a JS string is not a byte array - 0x80 alone is not valid UTF-8.
+    auto result = engine.execute_prerequest (R"JS(
+        var s = atob('gP/+AQ==');           // 0x80 0xFF 0xFE 0x01
+        var codes = [];
+        for (var i = 0; i < s.length; i++) codes.push(s.charCodeAt(i));
+        pm.environment.set('codes', codes.join(','));
+        pm.environment.set('again', btoa(s));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["codes"].value, "128,255,254,1");
+    EXPECT_EQ (env["again"].value, "gP/+AQ==");
+}
+
+TEST_F (ScriptEngineTest, BtoaRejectsCharactersAboveLatin1) {
+    // Web `btoa` semantics: it encodes code units, so anything above U+00FF is a
+    // range error rather than a silent UTF-8 encode. Failing loudly matters here
+    // - a signature over quietly-substituted bytes verifies nowhere and gives
+    // the author nothing to go on.
+    auto result = engine.execute_prerequest (R"JS(
+        try {
+            btoa('naïve €');
+            pm.environment.set('outcome', 'no throw');
+        } catch (e) {
+            pm.environment.set('outcome', String(e));
+        }
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_NE (env["outcome"].value.find ("Latin-1"), std::string::npos)
+    << "expected a range error naming Latin-1, got: " << env["outcome"].value;
+    // U+00E9 is inside the range and must still encode.
+    EXPECT_TRUE (env["outcome"].value.find ("no throw") == std::string::npos);
+}
+
+TEST_F (ScriptEngineTest, BtoaEncodesLatin1SupplementCharacters) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('out', btoa('héllo'));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    // Latin-1 bytes 68 e9 6c 6c 6f, not the UTF-8 encoding of the same text.
+    EXPECT_EQ (env["out"].value, "aOlsbG8=");
+}
+
+TEST_F (ScriptEngineTest, AtobThrowsOnMalformedBase64) {
+    auto result = engine.execute_prerequest (R"JS(
+        var outcomes = [];
+        ['Zm9vYmF', 'Zm9$', 'Zg=v', 'Z==='].forEach(function (bad) {
+            try { atob(bad); outcomes.push('accepted:' + bad); }
+            catch (e) { outcomes.push('threw'); }
+        });
+        pm.environment.set('outcomes', outcomes.join(','));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["outcomes"].value, "threw,threw,threw,threw");
+}
+
+// ============================================================================
+// pm.crypto (#187)
+// ============================================================================
+
+TEST_F (ScriptEngineTest, Sha256MatchesPublishedVectors) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('abc', pm.crypto.sha256('abc'));
+        pm.environment.set('empty', pm.crypto.sha256(''));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["abc"].value,
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    EXPECT_EQ (env["empty"].value,
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+TEST_F (ScriptEngineTest, Sha256HashesTheUtf8BytesOfNonAsciiText) {
+    // The one place a hashing API silently disagrees with every other tool: what
+    // "the bytes of this string" means. UTF-8, matching what the engine puts on
+    // the wire, so a digest computed here equals `printf 'h\xc3\xa9llo' | sha256sum`.
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('out', pm.crypto.sha256('héllo'));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["out"].value,
+    "3c48591d8d098a4538f5e013dfcf406e948eac4d3277b10bf614e295d6068179");
+}
+
+TEST_F (ScriptEngineTest, HmacSha256MatchesRfc4231Vectors) {
+    // RFC 4231 cases 2 and 6. Case 6 uses a 131-byte key, which exercises the
+    // "hash the key down first" branch of RFC 2104 - the branch a hand-written
+    // HMAC most often skips, and the one that stays invisible under short keys.
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('case2',
+            pm.crypto.hmacSha256('Jefe', 'what do ya want for nothing?'));
+
+        var longKey = new Uint8Array(131);
+        for (var i = 0; i < longKey.length; i++) longKey[i] = 0xaa;
+        pm.environment.set('case6', pm.crypto.hmacSha256(
+            longKey, 'Test Using Larger Than Block-Size Key - Hash Key First'));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["case2"].value, "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843")
+    << "RFC 4231 test case 2";
+    // The RFC's key is 131 raw 0xaa bytes, which no string can carry: a JS
+    // string of U+00AA characters is UTF-8 encoded to 0xc2 0xaa pairs and would
+    // hash something else entirely. That is what the Uint8Array input is for.
+    EXPECT_EQ (env["case6"].value, "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54")
+    << "RFC 4231 test case 6 (key longer than the SHA-256 block)";
+}
+
+TEST_F (ScriptEngineTest, DigestEncodingsAgreeOnTheSameDigest) {
+    auto result = engine.execute_prerequest (R"JS(
+        pm.environment.set('hex', pm.crypto.sha256('abc', 'hex'));
+        pm.environment.set('b64', pm.crypto.sha256('abc', 'base64'));
+        pm.environment.set('b64url', pm.crypto.sha256('abc', 'base64url'));
+        var bytes = pm.crypto.sha256('abc', 'bytes');
+        pm.environment.set('len', String(bytes.length));
+        pm.environment.set('first', String(bytes[0]));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["hex"].value,
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    EXPECT_EQ (env["b64"].value, "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=");
+    // base64url differs from base64 in exactly the two substituted characters
+    // and the dropped padding.
+    EXPECT_EQ (env["b64url"].value, "ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0");
+    EXPECT_EQ (env["len"].value, "32");
+    EXPECT_EQ (env["first"].value, "186"); // 0xba
+}
+
+TEST_F (ScriptEngineTest, DigestBytesCanBeFedBackAsAKey) {
+    // The reason 'bytes' exists. AWS SigV4 derives its signing key in four HMAC
+    // rounds, each keyed by the *raw* digest of the previous one; with only text
+    // outputs the chain cannot be expressed at all. Compare against the
+    // published SigV4 example key for 20150830/us-east-1/iam.
+    auto result = engine.execute_prerequest (R"JS(
+        var kDate    = pm.crypto.hmacSha256('AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY', '20150830', 'bytes');
+        var kRegion  = pm.crypto.hmacSha256(kDate, 'us-east-1', 'bytes');
+        var kService = pm.crypto.hmacSha256(kRegion, 'iam', 'bytes');
+        var kSigning = pm.crypto.hmacSha256(kService, 'aws4_request', 'hex');
+        pm.environment.set('kSigning', kSigning);
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["kSigning"].value,
+    "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9");
+}
+
+TEST_F (ScriptEngineTest, CryptoRejectsInputItCannotHashHonestly) {
+    // Stringifying an object would hash the text "[object Object]" and return a
+    // digest that looks perfectly valid. Every one of these must throw.
+    auto result = engine.execute_prerequest (R"JS(
+        var outcomes = [];
+        function attempt(label, fn) {
+            try { fn(); outcomes.push('accepted:' + label); }
+            catch (e) { outcomes.push('threw:' + label); }
+        }
+        attempt('object', function () { pm.crypto.sha256({ a: 1 }); });
+        attempt('number', function () { pm.crypto.sha256(42); });
+        attempt('null', function () { pm.crypto.sha256(null); });
+        attempt('missing', function () { pm.crypto.sha256(); });
+        attempt('badEncoding', function () { pm.crypto.sha256('abc', 'utf16'); });
+        attempt('keyOnly', function () { pm.crypto.hmacSha256('key'); });
+        pm.environment.set('outcomes', outcomes.join(','));
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["outcomes"].value, "threw:object,threw:number,threw:null,threw:missing,threw:badEncoding,threw:keyOnly");
+}
+
+TEST_F (ScriptEngineTest, UnknownDigestEncodingNamesTheValidOnes) {
+    auto result = engine.execute_prerequest (R"JS(
+        try { pm.crypto.sha256('abc', 'utf16'); }
+        catch (e) { pm.environment.set('message', String(e)); }
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    const auto& message = env["message"].value;
+    EXPECT_NE (message.find ("utf16"), std::string::npos) << message;
+    EXPECT_NE (message.find ("base64url"), std::string::npos) << message;
+}
+
+TEST_F (ScriptEngineTest, PreRequestScriptSignsTheOutgoingRequest) {
+    // #109's write-back and #187's crypto meeting: the headline use case the
+    // issue named. The signature is over the canonical string built from
+    // pm.request *after* the other edits, which is what scripting.md teaches.
+    auto result = engine.execute_prerequest (R"JS(
+        var timestamp = '1700000000';
+        var canonical = [pm.request.method, pm.request.url, timestamp].join('\n');
+        pm.request.headers['X-Timestamp'] = timestamp;
+        pm.request.headers['X-Signature'] =
+            pm.crypto.hmacSha256(pm.environment.get('api_key'), canonical);
+    )JS",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_TRUE (request.headers.contains ("X-Signature"));
+    // HMAC-SHA256("secret123", "GET\nhttps://api.example.com/users\n1700000000").
+    EXPECT_EQ (request.headers.at ("X-Signature"),
+    "25cba17ca82852d836fc8d44d8efed36cadb53f858a2c81fe88aece44c415ab3");
+    EXPECT_EQ (request.headers.at ("X-Timestamp"), "1700000000");
 }
 
 // ============================================================================
@@ -2224,37 +2496,32 @@ TEST_F (ScriptEngineTest, DocExampleSetsAQueryParamAcrossItsThreeCases) {
     }
 }
 
-TEST_F (ScriptEngineTest, DocExampleChecksumIsComputableAndStable) {
+// scripting.md's "Sign a request" example, with the timestamp pinned so the
+// signature is reproducible. Until #187 this section taught an FNV-1a checksum
+// and said in as many words that a real HMAC was impossible.
+TEST_F (ScriptEngineTest, DocExampleSignsWithHmac) {
     env["secret"] = Variable{ "s3cr3t", true, true };
 
     auto result = engine.execute_prerequest (R"JS(
-        function fnv1a(text) {
-          var hash = 0x811c9dc5;
-          for (var i = 0; i < text.length; i++) {
-            hash ^= text.charCodeAt(i);
-            hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
-          }
-          return ('00000000' + hash.toString(16)).slice(-8);
-        }
-
+        var timestamp = '1700000000000';
         var canonical = [
           pm.request.method,
           pm.request.url,
-          '1700000000000',
+          timestamp,
           pm.request.body || ''
         ].join('\n');
 
-        pm.request.headers['X-Timestamp'] = '1700000000000';
-        pm.request.headers['X-Checksum'] = fnv1a(canonical + pm.environment.get('secret'));
+        pm.request.headers['X-Timestamp'] = timestamp;
+        pm.request.headers['X-Signature'] =
+          pm.crypto.hmacSha256(pm.environment.get('secret'), canonical);
     )JS",
     request, env);
 
     ASSERT_TRUE (result.success) << result.error_message;
     EXPECT_EQ (request.headers.at ("X-Timestamp"), "1700000000000");
-    // Eight lower-case hex digits, deterministic for a fixed canonical string.
-    const std::string checksum = request.headers.at ("X-Checksum");
-    EXPECT_EQ (checksum.size (), 8u) << checksum;
-    EXPECT_EQ (checksum.find_first_not_of ("0123456789abcdef"), std::string::npos) << checksum;
+    // HMAC-SHA256("s3cr3t", "GET\nhttps://api.example.com/users\n1700000000000\n").
+    EXPECT_EQ (request.headers.at ("X-Signature"),
+    "01366dd94b411a4bf53f7785b38f5f1ce16bf2b47dfe8c26de150f475dc61509");
 }
 
 TEST_F (ScriptEngineTest, DocExampleSwapsAuthScheme) {


### PR DESCRIPTION
## Description

**Plan.** The root cause is that #109 gave pre-request scripts the ability to rewrite the outgoing request while the sandbox had no way to compute a signature over the result: QuickJS plus `pm` and `console`, no hash, no base64. `scripting.md` papered over it with an FNV-1a checksum explicitly labelled "not a cryptographic hash - do not use it as one". The approach is the issue's items 1 and 2 only, built on dependencies the engine already carries: `btoa` / `atob` as globals, and a `pm.crypto` object with `sha256` and `hmacSha256` backed by the vendored picosha2 that PKCE already uses. **The alternative I rejected is a real `crypto.subtle`**: Web Crypto is Promise-based, and this sandbox has no event loop and no `setTimeout`, so nothing drains the job queue - an `await crypto.subtle.digest(...)` would never resume and the script would report a timeout rather than a result. Naming a synchronous API `crypto.subtle` is exactly the lie of a familiar name that `NoCryptoBase64OrUrlParserIsExposed` was written to catch, so the surface takes a name of its own and the sync decision is documented with its reason in three places. I also rejected implementing a job-queue pump, which is a much larger change than "let me sign this request".

I verified the problem still exists as described on current master before starting: the two globals, the `NoCryptoBase64OrUrlParserIsExposed` test, and the FNV-1a doc section were all where the issue said.

**What landed:**

- `pm.crypto.sha256(data, encoding?)` and `pm.crypto.hmacSha256(key, data, encoding?)`. `encoding` is `'hex'` (default), `'base64'`, `'base64url'` or `'bytes'`.
- `btoa` / `atob` globals with standard web semantics - binary strings, one byte per code unit, so `btoa` throws above U+00FF rather than silently UTF-8 encoding.
- `utils/hmac_sha256` (RFC 2104 over the existing `utils/sha256`), `utils/base64_decode` and `utils/hex_encode`. **No new dependency; OpenSSL is still not linked.**

**Two design points worth a reviewer's eye:**

1. **What a string means as bytes.** `pm.crypto` hashes a string's **UTF-8** bytes - the bytes the engine puts on the wire, so a digest here matches `sha256sum` over the same text. `btoa` keeps **Latin-1** code-unit semantics, because that is what the web name promises. The two conventions differ, deliberately, and each is pinned by a test.
2. **`'bytes'` output.** AWS SigV4 derives its signing key in four HMAC rounds, each keyed by the *raw* digest of the previous one; with only text outputs that chain cannot be expressed. `'bytes'` returns a `Uint8Array`, which is also accepted as key or data. Pinned against the published SigV4 example key.

**Blast radius traced:** the sandbox surface has one reader in the runtime and three documented readers - the completion list (engine-side, served to Monaco), `docs/engine/scripting.md`, and the app's pre-request quick reference in `script-variants.tsx`, which asserted "No crypto, base64 or `URL` in the sandbox" and is now two-thirds false. All three are updated. Per CLAUDE.md's "written but never read", the completion entries have a test that *calls* each offered name in the runtime rather than checking a string is present.

**Deliberate deviations from the issue spec**, both toward a smaller surface:

- **`TextEncoder` skipped** (the issue's item 4 makes it conditional). Accepting `Uint8Array` directly covers byte input without a second global.
- **No `URL` / `URLSearchParams`** - the issue scopes them out as their own issue.
- `base64_decode` is slightly **stricter than WHATWG `atob`**: it rejects trailing bits that decoding would drop, e.g. `atob('Zm9vYmF')`. Truncated base64 failing loudly beats returning bytes the author never encoded. Whitespace is still forgiven.

**Cross-platform note:** the implementation reads and builds typed arrays through `JS_GetTypedArrayBuffer` / `JS_NewArrayBufferCopy` rather than `JS_GetUint8Array` / `JS_NewUint8ArrayCopy`. The engine vendors Bellard's QuickJS on Linux/macOS and quickjs-ng on Windows, and only the latter has the Uint8Array shortcuts - the first build failed on exactly this.

**Adjacent things I left alone:** `docs/engine/scripting.md`'s Limitations section, and the `crypto`-adjacent items in #188 (`pm.sendRequest`, `pm.cookies`). #187 is the last code item in the #180 series, so #112's "land after the series drains" gate is now down to #188, which is a scoping record rather than code.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run on this branch, all green:

- `python build.py -e -t` - clean, 0 errors.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **706 passed, 0 failed** (+24 net new; 26 added, 2 renamed).
- `cd app && pnpm test` - **2098 passed, 240 files**.
- `cd app && pnpm type-check` - clean.
- Prettier + ESLint on the one touched `.tsx`; `git clang-format` on changed lines only, leaving the pre-existing (non-clean) formatting of those files untouched per CLAUDE.md.

No pre-existing failures observed on the base commit.

New coverage, chosen as known-answer vectors rather than round-trips (a round-trip passes over two mirrored bugs):

- SHA-256 against FIPS 180-4; **HMAC-SHA256 against RFC 4231 cases 1, 2, 3 and 6** - case 6's 131-byte key exercises the "hash the key down first" branch of RFC 2104 that short keys never reach.
- Base64 against RFC 4648 §10 including every padding case and the empty string, both directions, plus a full 0-255 byte round trip.
- Non-ASCII in three shapes: `sha256('héllo')` equals `printf 'h\xc3\xa9llo' | sha256sum`; `btoa('héllo')` gives the **Latin-1** encoding, not the UTF-8 one; `btoa('naïve €')` throws.
- Failure paths asserted, not assumed: malformed base64, an object / number / null / missing argument to `sha256`, an unknown encoding name (and that the message names the valid ones), a missing HMAC argument.
- End to end: a pre-request script signs a canonical string and the sent `Request` carries the header - #109's write-back and this feature meeting.

**Mutation-checked** (applied the mutation, rebuilt, confirmed red, reverted):

| Mutation | Result |
|---|---|
| `key.size() > block_size` → `>=` in `hmac_sha256` | `HmacSha256.KeyLengthsAroundTheBlockBoundary` fails |
| `btoa` passes UTF-8 through instead of Latin-1 | 3 tests fail (`BtoaRejectsCharactersAboveLatin1`, `BtoaEncodesLatin1SupplementCharacters`, `Base64CarriesHighBytesThroughTheJsBoundary`) |

The first is the reason the boundary test pins *known answers* rather than "the two differ" - an off-by-one there still yields two different MACs, so the weaker assertion would have passed while a 64-byte key was quietly being hashed down.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #187

Part of #180 - this is the last of that series' code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Xq11zNfSUizKCNxF3FxTF)_