### PR TITLE
fix(app): per-editor save wiring - stop the clobber, the silent failures and the promptless discards

### DIFF
--- a/app/src/components/layout/ContextBar.save-error.test.tsx
+++ b/app/src/components/layout/ContextBar.save-error.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Editing a variable in the context bar used to fail in complete silence.
+ *
+ * The three mutations were fired with no `onError`, nothing read `isError`, and
+ * there is no global `MutationCache.onError` in `lib/query-client.ts` - so an
+ * engine 400 or a refused connection left the typed value sitting in the input
+ * looking committed. The inputs are uncontrolled (`defaultValue`, with a `key`
+ * derived from the stored value), so a rejected save changes nothing that would
+ * put the old text back: the cache never moved, therefore neither did the key.
+ *
+ * Both halves are asserted - the toast, and the value on screen - because a
+ * toast beside an input still showing the new value tells the user their edit
+ * was saved and also that it failed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { ContextBar } from "./ContextBar";
+import { useToastStore } from "@/stores/toast-store";
+import { useSaveStore } from "@/stores/save-store";
+import type { ResolvedVariable } from "@/types";
+
+const globalsMutate = vi.fn();
+
+vi.mock("@/queries", () => ({
+	useRequestQuery: () => ({ data: { id: "req_1", collectionId: null } }),
+	useGlobalsQuery: () => ({
+		data: {
+			variables: {
+				host: { value: "example.com", enabled: true, secret: false, type: "string" },
+			},
+		},
+	}),
+	useCollectionsQuery: () => ({ data: [] }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateGlobalsMutation: () => ({ mutate: globalsMutate }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+}));
+
+const resolved: Record<string, ResolvedVariable> = {
+	host: { value: "example.com", scope: "global" },
+};
+
+vi.mock("@/hooks/useVariableResolver", () => ({
+	useVariableResolver: () => ({ getAllVariables: () => resolved }),
+}));
+
+const layoutStore = {
+	contextBarOpen: true,
+	setContextBarOpen: vi.fn(),
+	contextBarWidth: 280,
+	setContextBarWidth: vi.fn(),
+};
+const tabsStore = {
+	openTabs: [{ id: "t1", type: "request", entityId: "req_1" }],
+	activeTabId: "t1",
+};
+
+vi.mock("@/stores", async () => {
+	const saveStore =
+		await vi.importActual<typeof import("@/stores/save-store")>("@/stores/save-store");
+	return {
+		useLayoutStore: () => layoutStore,
+		useTabsStore: () => tabsStore,
+		useSessionStore: () => ({ activeEnvironmentId: null }),
+		useSaveStore: saveStore.useSaveStore,
+	};
+});
+
+function valueInput(): HTMLInputElement {
+	return screen.getByDisplayValue("example.com") as HTMLInputElement;
+}
+
+describe("ContextBar - a rejected variable edit", () => {
+	beforeEach(() => {
+		globalsMutate.mockReset();
+		useToastStore.setState({ toasts: [] });
+		useSaveStore.getState().reset();
+	});
+
+	it("toasts the engine's reason and puts the stored value back", () => {
+		globalsMutate.mockImplementation(
+			(_payload: unknown, opts: { onError: (e: Error) => void }) => {
+				opts.onError(new Error("value must not be empty"));
+			}
+		);
+
+		render(<ContextBar />);
+		const input = valueInput();
+
+		act(() => {
+			fireEvent.change(input, { target: { value: "example.org" } });
+			fireEvent.blur(input);
+		});
+
+		expect(globalsMutate).toHaveBeenCalledTimes(1);
+		const toasts = useToastStore.getState().toasts;
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0].message).toBe("value must not be empty");
+		expect(toasts[0].variant).toBe("error");
+		expect(input.value).toBe("example.com");
+	});
+
+	it("refuses out loud when the variable is gone from its scope", () => {
+		// The scope map no longer holds it - deleted elsewhere between render and
+		// blur. Writing it back would resurrect it, so the edit is dropped; the
+		// old code dropped it without a word.
+		delete resolved.host;
+		resolved.missing = { value: "example.com", scope: "global" };
+
+		render(<ContextBar />);
+		const input = valueInput();
+
+		act(() => {
+			fireEvent.change(input, { target: { value: "example.org" } });
+			fireEvent.blur(input);
+		});
+
+		expect(globalsMutate).not.toHaveBeenCalled();
+		expect(useToastStore.getState().toasts).toHaveLength(1);
+		expect(input.value).toBe("example.com");
+
+		delete resolved.missing;
+		resolved.host = { value: "example.com", scope: "global" };
+	});
+});

--- a/app/src/components/layout/ContextBar.tsx
+++ b/app/src/components/layout/ContextBar.tsx
@@ -8,7 +8,7 @@
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PanelResizeHandle } from "./PanelResizeHandle";
-import { useLayoutStore, useTabsStore, useSessionStore } from "@/stores";
+import { useLayoutStore, useTabsStore, useSessionStore, useSaveStore } from "@/stores";
 import { DEFAULT_CONTEXT_BAR_WIDTH } from "@/constants/layout";
 import { useVariableResolver } from "@/hooks/useVariableResolver";
 import {
@@ -62,32 +62,65 @@ export function ContextBar({ mode = "push" }: ContextBarProps) {
 	const updateGlobalsMutation = useUpdateGlobalsMutation();
 	const updateEnvironmentMutation = useUpdateEnvironmentMutation();
 	const updateCollectionMutation = useUpdateCollectionMutation();
+	const failSave = useSaveStore((s) => s.failSave);
 
 	if (!contextBarOpen || activeTab?.type !== "request") return null;
 
-	// Write the edited value back to the scope the resolved variable came from
-	const commitValue = (name: string, resolved: ResolvedVariable, newValue: string) => {
+	/**
+	 * Write the edited value back to the scope the resolved variable came from.
+	 *
+	 * Takes the input element, not the string, because every failure below has to
+	 * put the old value back on screen. These inputs are uncontrolled -
+	 * `defaultValue` with a `key` derived from the stored value - so a rejected
+	 * save changes nothing: the cache is untouched, therefore the key is
+	 * untouched, therefore React keeps the DOM node and the typed text sits there
+	 * looking committed. Failures used to end here entirely (no `onError`, no
+	 * `isError` reader, and there is no global `MutationCache.onError` either),
+	 * which is the same defect `CollectionDetail/shared.tsx` documents for the
+	 * collection tabs.
+	 */
+	const commitValue = (name: string, resolved: ResolvedVariable, input: HTMLInputElement) => {
+		const newValue = input.value;
 		if (newValue === resolved.value) return;
+
+		const rollBack = (message: string) => {
+			input.value = resolved.value;
+			failSave(message);
+		};
+		// `failSave` is the app's one save-failure surface (it toasts and sets the
+		// Dock's status) - see the note on it in save-store.
+		const onError = (error: unknown) =>
+			rollBack(error instanceof Error ? error.message : `Couldn't save {{${name}}}`);
+		// The definition this bar resolved against is gone - deleted from its
+		// scope, or the active environment changed, between render and blur.
+		// Writing it back would resurrect it, so the edit is refused; saying so
+		// is the difference between "refused" and "silently swallowed".
+		const gone = () =>
+			rollBack(`{{${name}}} is no longer defined in its ${resolved.scope} scope`);
 
 		if (resolved.scope === "global") {
 			const vars = globalsData?.variables;
-			if (!vars?.[name]) return;
-			updateGlobalsMutation.mutate({
-				variables: { ...vars, [name]: { ...vars[name], value: newValue } },
-			});
+			if (!vars?.[name]) return gone();
+			updateGlobalsMutation.mutate(
+				{ variables: { ...vars, [name]: { ...vars[name], value: newValue } } },
+				{ onError }
+			);
 			return;
 		}
 
 		if (resolved.scope === "environment") {
 			const env = environments.find((e) => e.id === activeEnvironmentId);
-			if (!env?.variables?.[name]) return;
-			updateEnvironmentMutation.mutate({
-				id: env.id,
-				variables: {
-					...env.variables,
-					[name]: { ...env.variables[name], value: newValue },
+			if (!env?.variables?.[name]) return gone();
+			updateEnvironmentMutation.mutate(
+				{
+					id: env.id,
+					variables: {
+						...env.variables,
+						[name]: { ...env.variables[name], value: newValue },
+					},
 				},
-			});
+				{ onError }
+			);
 			return;
 		}
 
@@ -95,14 +128,17 @@ export function ContextBar({ mode = "push" }: ContextBarProps) {
 		if (request?.collectionId) {
 			const chain = buildLeafFirstChain(request.collectionId, collections);
 			const source = chain.find((col) => col.variables?.[name]?.enabled);
-			if (!source?.variables) return;
-			updateCollectionMutation.mutate({
-				id: source.id,
-				variables: {
-					...source.variables,
-					[name]: { ...source.variables[name], value: newValue },
+			if (!source?.variables) return gone();
+			updateCollectionMutation.mutate(
+				{
+					id: source.id,
+					variables: {
+						...source.variables,
+						[name]: { ...source.variables[name], value: newValue },
+					},
 				},
-			});
+				{ onError }
+			);
 		}
 	};
 
@@ -168,7 +204,7 @@ export function ContextBar({ mode = "push" }: ContextBarProps) {
 										key={`${name}:${resolved.value}`}
 										defaultValue={resolved.value}
 										className="h-7 text-xs font-mono"
-										onBlur={(e) => commitValue(name, resolved, e.target.value)}
+										onBlur={(e) => commitValue(name, resolved, e.target)}
 										onKeyDown={(e) => {
 											if (e.key === "Enter") {
 												e.currentTarget.blur();

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -9,6 +9,7 @@
 export { useEngine } from "./useEngine";
 export { useSaveManager } from "./useSaveManager";
 export { useEntityDraft } from "./useEntityDraft";
+export { useDraftSaveContext } from "./useDraftSaveContext";
 export { useVariableResolver } from "./useVariableResolver";
 export { useVariableCompletionProvider } from "./useVariableCompletionProvider";
 export { useElectronTheme } from "./useElectronTheme";

--- a/app/src/hooks/useDraftSaveContext.ts
+++ b/app/src/hooks/useDraftSaveContext.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * useDraftSaveContext - registration for the manual save-button model.
+ *
+ * `useSaveManager` registers the autosave editors with the save store. The
+ * `useEntityDraft` editors had no counterpart: they never called
+ * `registerContext`, so `triggerSave` (Ctrl/Cmd+S) and `flushAll` (the quit
+ * flush, tab eviction) could not see them at all. A collection's auth, its
+ * description, its scripts - all dirty, all invisible, all gone on quit.
+ *
+ * This is registration only. It does not schedule anything, and the Save button
+ * stays the primary affordance: the manual model is a deliberate choice for
+ * these editors (see `useEntityDraft`), and the defect was that the *other*
+ * ways to save could not reach them.
+ *
+ * A failure on this path toasts through `failSave` rather than resolving
+ * quietly. The editors render their own inline `SaveFailed` callout for a
+ * button press, but a Cmd+S from another pane - or a quit flush with nothing on
+ * screen at all - has no callout to read, and `runSave` in the save store treats
+ * a resolved promise as a success. Swallowing here would report "Saved" for a
+ * write that failed.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { useSaveStore } from "@/stores/save-store";
+
+interface DraftSaveContextOptions {
+	/** Unique id for this editor, e.g. `collection-<id>-auth`. */
+	id: string;
+	/** Human-readable name, shown wherever a save context is named. */
+	name: string;
+	/** Whether the draft differs from the persisted value. */
+	isDirty: boolean;
+	/**
+	 * Whether this editor is the one the user is looking at. Only the active
+	 * editor claims the store's active context, so Ctrl/Cmd+S saves the panel on
+	 * screen rather than whichever sibling mounted last - these editors are kept
+	 * mounted while hidden precisely so their drafts survive a tab switch.
+	 */
+	isActive: boolean;
+	/** Persist the draft. Rejecting is how a failure is reported. */
+	save: () => Promise<void>;
+}
+
+export function useDraftSaveContext({
+	id,
+	name,
+	isDirty,
+	isActive,
+	save,
+}: DraftSaveContextOptions): void {
+	const registerContext = useSaveStore((s) => s.registerContext);
+	const unregisterContext = useSaveStore((s) => s.unregisterContext);
+	const updateContext = useSaveStore((s) => s.updateContext);
+	const setActiveContext = useSaveStore((s) => s.setActiveContext);
+	const failSave = useSaveStore((s) => s.failSave);
+
+	// The registered save is bound once and reads the latest `save` when it runs,
+	// so a keystroke does not have to re-register the context.
+	const saveRef = useRef(save);
+	useEffect(() => {
+		saveRef.current = save;
+	}, [save]);
+
+	const runSave = useCallback(async () => {
+		try {
+			await saveRef.current();
+		} catch (error) {
+			failSave(error instanceof Error ? error.message : `Couldn't save ${name}`);
+		}
+	}, [failSave, name]);
+
+	// Registration is deliberately independent of the dirty flag - it is pushed
+	// by the effect below, which runs later in the same commit. Taking `isDirty`
+	// as a dependency here would tear the context down and rebuild it on the
+	// first keystroke.
+	useEffect(() => {
+		registerContext({ id, name, save: runSave, hasPendingChanges: false });
+		return () => unregisterContext(id);
+	}, [id, name, runSave, registerContext, unregisterContext]);
+
+	useEffect(() => {
+		updateContext(id, { hasPendingChanges: isDirty });
+	}, [id, isDirty, updateContext]);
+
+	useEffect(() => {
+		if (isActive) setActiveContext(id);
+	}, [id, isActive, setActiveContext]);
+}

--- a/app/src/modules/collections/CollectionDetail/AuthTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/AuthTab.test.tsx
@@ -31,6 +31,9 @@ import { TooltipProvider } from "@/components/ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mutation = {
+	// `mutateAsync`, not `mutate`: the tab's save has to be awaitable so the
+	// quit flush and Ctrl/Cmd+S can report a real outcome (useDraftSaveContext).
+	mutateAsync: vi.fn(() => Promise.resolve()),
 	mutate: vi.fn(),
 	reset: vi.fn(),
 	isPending: false,
@@ -87,6 +90,7 @@ function wrap(collection: Collection) {
 
 beforeEach(() => {
 	mutation.mutate.mockReset();
+	mutation.mutateAsync.mockClear();
 	mutation.reset.mockReset();
 	mutation.isPending = false;
 	mutation.isError = false;
@@ -155,7 +159,7 @@ describe("AuthTab with an editable auth mode", () => {
 		fireEvent.click(screen.getByRole("option", { name: /No Auth \(blocks inheriting\)/i }));
 		fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
 
-		expect(mutation.mutate).toHaveBeenCalledWith({ id: "c1", auth: { mode: "noauth" } });
+		expect(mutation.mutateAsync).toHaveBeenCalledWith({ id: "c1", auth: { mode: "noauth" } });
 	});
 
 	it("says no auth when there genuinely is none", () => {

--- a/app/src/modules/collections/CollectionDetail/AuthTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/AuthTab.tsx
@@ -16,6 +16,8 @@
  * resolve to.
  */
 
+import { useCallback } from "react";
+
 import {
 	Button,
 	Select,
@@ -32,7 +34,7 @@ import {
 	uneditableAuthLabel,
 	type CollectionAuthMode,
 } from "@/constants/auth-modes";
-import { useEntityDraft } from "@/hooks";
+import { useDraftSaveContext, useEntityDraft } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import type { Collection } from "@/types";
 import { InfoBanner, SaveFailed, SectionLabel } from "./shared";
@@ -93,9 +95,11 @@ function defaultsFor(mode: CollectionAuthMode): CollectionAuth {
 
 interface AuthTabProps {
 	collection: Collection;
+	/** Whether this is the tab on screen - see `useDraftSaveContext`. */
+	active?: boolean;
 }
 
-export default function AuthTab({ collection }: AuthTabProps) {
+export default function AuthTab({ collection, active = false }: AuthTabProps) {
 	const updateCollection = useUpdateCollectionMutation();
 
 	// Draft/resync/isDirty/mutation-reset all live in the shared hook - the
@@ -116,10 +120,22 @@ export default function AuthTab({ collection }: AuthTabProps) {
 	const uneditableLabel = uneditableAuthLabel(auth.mode);
 	const hint = mode ? AUTH_MODE_HINTS[mode] : undefined;
 
-	const handleSave = () => {
+	const persist = useCallback(async () => {
 		if (!isDirty) return;
-		updateCollection.mutate({ id: collection.id, auth });
-	};
+		await updateCollection.mutateAsync({ id: collection.id, auth });
+	}, [isDirty, updateCollection, collection.id, auth]);
+
+	useDraftSaveContext({
+		id: `collection-${collection.id}-auth`,
+		name: `Collection auth: ${collection.name}`,
+		isDirty,
+		isActive: active,
+		save: persist,
+	});
+
+	// A rejection here is rendered by <SaveFailed> below; the store-driven paths
+	// toast instead, since this callout may not be on screen at all.
+	const handleSave = () => void persist().catch(() => {});
 
 	const handleModeChange = (next: CollectionAuthMode) => {
 		setAuth(defaultsFor(next));

--- a/app/src/modules/collections/CollectionDetail/InfoTab.markdown.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/InfoTab.markdown.test.tsx
@@ -36,6 +36,7 @@ import { TooltipProvider } from "@/components/ui";
 import type { Collection } from "@/types";
 
 const mutation = {
+	mutateAsync: vi.fn(() => Promise.resolve()),
 	mutate: vi.fn(),
 	reset: vi.fn(),
 	isPending: false,

--- a/app/src/modules/collections/CollectionDetail/InfoTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/InfoTab.tsx
@@ -5,8 +5,10 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
+import { useCallback } from "react";
+
 import { Button, Input, MarkdownEditor } from "@/components/ui";
-import { useEntityDraft } from "@/hooks";
+import { useDraftSaveContext, useEntityDraft } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import type { Collection } from "@/types";
 import { Field, SaveFailed, Stat, formatRelative } from "./shared";
@@ -14,6 +16,8 @@ import { Field, SaveFailed, Stat, formatRelative } from "./shared";
 interface InfoTabProps {
 	collection: Collection;
 	requestCount: number;
+	/** Whether this is the tab on screen - see `useDraftSaveContext`. */
+	active?: boolean;
 }
 
 interface InfoDraft {
@@ -21,7 +25,7 @@ interface InfoDraft {
 	description: string;
 }
 
-export default function InfoTab({ collection, requestCount }: InfoTabProps) {
+export default function InfoTab({ collection, requestCount, active = false }: InfoTabProps) {
 	const updateCollection = useUpdateCollectionMutation();
 
 	// Draft/resync/isDirty/mutation-reset all live in the shared hook - the
@@ -45,14 +49,31 @@ export default function InfoTab({ collection, requestCount }: InfoTabProps) {
 	});
 	const { name, description } = draft;
 
-	const handleSave = () => {
-		if (!isDirty || !name.trim()) return;
-		updateCollection.mutate({
+	// A collection must keep a name, so a blank one is not saveable - and the
+	// store-driven paths (Ctrl/Cmd+S, the quit flush) have no disabled button to
+	// stop them, so the guard lives here rather than only on the button.
+	const canSave = isDirty && name.trim().length > 0;
+
+	const persist = useCallback(async () => {
+		if (!canSave) return;
+		await updateCollection.mutateAsync({
 			id: collection.id,
 			name: name.trim(),
 			description,
 		});
-	};
+	}, [canSave, updateCollection, collection.id, name, description]);
+
+	useDraftSaveContext({
+		id: `collection-${collection.id}-info`,
+		name: `Collection: ${collection.name}`,
+		isDirty: canSave,
+		isActive: active,
+		save: persist,
+	});
+
+	// A rejection here is rendered by <SaveFailed> below; the store-driven paths
+	// toast instead, since this callout may not be on screen at all.
+	const handleSave = () => void persist().catch(() => {});
 
 	return (
 		<div className="max-w-[540px] flex flex-col gap-5">
@@ -105,7 +126,7 @@ export default function InfoTab({ collection, requestCount }: InfoTabProps) {
 			<div className="flex gap-2">
 				<Button
 					onClick={handleSave}
-					disabled={!isDirty || !name.trim() || updateCollection.isPending}
+					disabled={!canSave || updateCollection.isPending}
 					className="font-semibold"
 				>
 					{updateCollection.isPending ? "Saving…" : "Save Changes"}

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
@@ -22,10 +22,10 @@
  * Used by both the Pre-request and Post-request tabs in CollectionDetail.
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { Badge, Button, CodeEditor } from "@/components/ui";
-import { useEntityDraft } from "@/hooks";
+import { useDraftSaveContext, useEntityDraft } from "@/hooks";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import type { Collection } from "@/types";
 import { InfoBanner, SaveFailed } from "./shared";
@@ -35,6 +35,8 @@ type ScriptKind = "pre" | "post";
 interface ScriptTabProps {
 	collection: Collection;
 	kind: ScriptKind;
+	/** Whether this is the tab on screen - see `useDraftSaveContext`. */
+	active?: boolean;
 }
 
 const QUICK_REF: Array<[string, string]> = [
@@ -44,7 +46,7 @@ const QUICK_REF: Array<[string, string]> = [
 	["Response (post only)", "pm.response.json()\npm.response.code\npm.response.responseTime"],
 ];
 
-export default function ScriptTab({ collection, kind }: ScriptTabProps) {
+export default function ScriptTab({ collection, kind, active = false }: ScriptTabProps) {
 	const isPre = kind === "pre";
 	const fieldKey = isPre ? "preRequestScript" : "postRequestScript";
 
@@ -76,10 +78,22 @@ export default function ScriptTab({ collection, kind }: ScriptTabProps) {
 		return [...new Set([...fromGet, ...fromTpl])];
 	}, [script]);
 
-	const handleSave = () => {
+	const persist = useCallback(async () => {
 		if (!isDirty) return;
-		updateCollection.mutate({ id: collection.id, [fieldKey]: script });
-	};
+		await updateCollection.mutateAsync({ id: collection.id, [fieldKey]: script });
+	}, [isDirty, updateCollection, collection.id, fieldKey, script]);
+
+	useDraftSaveContext({
+		id: `collection-${collection.id}-${fieldKey}`,
+		name: `Collection ${isPre ? "pre-request" : "post-request"} script: ${collection.name}`,
+		isDirty,
+		isActive: active,
+		save: persist,
+	});
+
+	// A rejection here is rendered by <SaveFailed> below; the store-driven paths
+	// toast instead, since this callout may not be on screen at all.
+	const handleSave = () => void persist().catch(() => {});
 
 	const handleClear = () => {
 		setScript("");

--- a/app/src/modules/collections/CollectionDetail/draft-survival.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/draft-survival.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The collection tabs hold their drafts in component state, and two things used
+ * to take those drafts away without a word.
+ *
+ * **A tab switch.** Radix unmounts an inactive `TabsContent`, so renaming the
+ * collection, glancing at Auth and coming back showed the old name again - the
+ * same defect the request builder's body drafts hit, and fixed the same way, by
+ * keeping the panel alive rather than by moving where the draft is stored.
+ *
+ * **Quit, or Ctrl/Cmd+S from anywhere.** None of the three tabs called
+ * `registerContext`, so `flushAll` and `triggerSave` could not see them at all:
+ * the save store's registry was the only list of dirty editors, and these were
+ * absent from it.
+ *
+ * Both are asserted against the real save store, since a mocked registry would
+ * pass whatever it was told.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import CollectionDetail from "./index";
+import { useSaveStore } from "@/stores/save-store";
+import { TooltipProvider } from "@/components/ui";
+import type { Collection } from "@/types";
+
+const collection: Collection = {
+	id: "c1",
+	name: "Acme API",
+	description: "",
+	order: 0,
+	variables: {},
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const mutateAsync = vi.fn((_patch: { id: string; name?: string }) => Promise.resolve(collection));
+const mutation = {
+	mutate: vi.fn(),
+	mutateAsync,
+	reset: vi.fn(),
+	isPending: false,
+	isError: false,
+	error: null as Error | null,
+};
+
+vi.mock("@/queries/collections", () => ({
+	useCollectionsQuery: () => ({ data: [collection], isLoading: false, isError: false }),
+	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	useUpdateCollectionMutation: () => mutation,
+	useCollectionAncestors: () => [],
+}));
+
+vi.mock("@/stores", () => ({
+	useTabsStore: () => ({
+		openTabs: [{ id: "t1", type: "collection", entityId: "c1" }],
+		activeTabId: "t1",
+	}),
+	useSessionStore: (selector: (s: unknown) => unknown) =>
+		selector({ setLastCollectionId: vi.fn() }),
+}));
+
+// Monaco and the variables editor are not what these tests are about, and both
+// drag in a great deal of setup.
+vi.mock("./ScriptTab", () => ({ default: () => null }));
+vi.mock("./VariablesTab", () => ({ default: () => null }));
+
+function Screen() {
+	return (
+		<QueryClientProvider client={new QueryClient()}>
+			<TooltipProvider>
+				<CollectionDetail />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+function nameInput(): HTMLInputElement {
+	return screen.getByDisplayValue("Acme API") as HTMLInputElement;
+}
+
+/**
+ * Radix activates a trigger on `mousedown`, not on `click` - `fireEvent.click`
+ * fires neither the mousedown nor the focus it listens for, so a click-driven
+ * version of the test below never left the Info tab and passed against the
+ * unfixed component.
+ */
+function selectTab(label: RegExp) {
+	fireEvent.mouseDown(screen.getByRole("tab", { name: label }), { button: 0 });
+	expect(screen.getByRole("tab", { name: label })).toHaveAttribute("data-state", "active");
+}
+
+describe("CollectionDetail - an unsaved draft", () => {
+	beforeEach(() => {
+		mutateAsync.mockClear();
+		useSaveStore.setState({ contexts: new Map(), activeContextId: null, status: "idle" });
+	});
+
+	it("survives a switch to another tab and back", () => {
+		render(<Screen />);
+		fireEvent.change(nameInput(), { target: { value: "Renamed" } });
+
+		selectTab(/auth/i);
+		selectTab(/info/i);
+
+		expect((screen.getByDisplayValue("Renamed") as HTMLInputElement).value).toBe("Renamed");
+	});
+
+	it("is visible to the quit flush, which writes it", async () => {
+		render(<Screen />);
+		fireEvent.change(nameInput(), { target: { value: "Renamed" } });
+
+		await act(async () => {
+			await useSaveStore.getState().flushAll();
+		});
+
+		expect(mutateAsync).toHaveBeenCalledTimes(1);
+		expect(mutateAsync.mock.calls[0][0]).toMatchObject({ id: "c1", name: "Renamed" });
+	});
+
+	it("is what Ctrl/Cmd+S saves while its tab is the one on screen", async () => {
+		render(<Screen />);
+		fireEvent.change(nameInput(), { target: { value: "Renamed" } });
+
+		// `triggerSave` prefers the active context, so the wrong tab claiming it
+		// would save the wrong thing - hence the `active` prop.
+		expect(useSaveStore.getState().activeContextId).toBe("collection-c1-info");
+
+		await act(async () => {
+			await useSaveStore.getState().triggerSave();
+		});
+
+		expect(mutateAsync).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers nothing pending while it is clean", () => {
+		render(<Screen />);
+
+		const dirty = [...useSaveStore.getState().contexts.values()].filter(
+			(c) => c.hasPendingChanges
+		);
+		expect(dirty).toHaveLength(0);
+	});
+
+	it("does not offer a blank collection name to the flush", async () => {
+		// The Save button is disabled on an empty name; the store-driven paths
+		// have no button to disable, so the guard has to be in the save itself.
+		render(<Screen />);
+		fireEvent.change(nameInput(), { target: { value: "" } });
+
+		await act(async () => {
+			await useSaveStore.getState().flushAll();
+		});
+
+		expect(mutateAsync).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/index.tsx
+++ b/app/src/modules/collections/CollectionDetail/index.tsx
@@ -33,6 +33,28 @@ const TABS: { id: CollectionTab; label: string }[] = [
 	{ id: "variables", label: "Variables" },
 ];
 
+/**
+ * Tabs that hold an unsaved draft, and therefore must not be torn down when the
+ * user looks at a sibling.
+ *
+ * These four use the manual save-button model (`useEntityDraft`), which keeps
+ * the draft in component state. Radix unmounts an inactive `TabsContent`, so
+ * writing a script, glancing at Auth and coming back used to lose the script -
+ * no save, no prompt, no trace. Keeping them mounted is the same fix, for the
+ * same reason, as the request builder's body drafts living in its provider
+ * rather than in `BodyPanel` (see `request-builder/utils/body-drafts.ts`).
+ *
+ * `variables` is absent deliberately: it autosaves and registers its own save
+ * context on mount, so keeping it alive behind another tab would leave the
+ * variables editor claiming Ctrl/Cmd+S while something else is on screen.
+ */
+const TABS_HOLDING_DRAFTS: ReadonlySet<CollectionTab> = new Set([
+	"info",
+	"auth",
+	"pre-script",
+	"post-script",
+]);
+
 export default function CollectionDetail() {
 	const { openTabs, activeTabId } = useTabsStore();
 
@@ -61,6 +83,10 @@ export default function CollectionDetail() {
 	);
 
 	const [tab, setTab] = useState<CollectionTab>("info");
+	// Panels are force-mounted from their first visit onwards, not from mount:
+	// a draft can only exist in a tab the user has opened, and two of these
+	// carry a Monaco editor that costs nothing while nobody has asked for it.
+	const [visited, setVisited] = useState<ReadonlySet<CollectionTab>>(() => new Set(["info"]));
 
 	// Loading and missing are different answers. `collections` defaults to `[]`,
 	// so a collection tab restored from a previous session resolves to nothing
@@ -107,7 +133,11 @@ export default function CollectionDetail() {
 			{/* Tab bar */}
 			<Tabs
 				value={tab}
-				onValueChange={(v) => setTab(v as CollectionTab)}
+				onValueChange={(v) => {
+					const next = v as CollectionTab;
+					setTab(next);
+					setVisited((prev) => (prev.has(next) ? prev : new Set(prev).add(next)));
+				}}
 				className="flex-1 flex flex-col overflow-hidden"
 			>
 				{/* The active trigger's weight change used to shift its neighbours
@@ -137,15 +167,36 @@ export default function CollectionDetail() {
 					<TabsContent
 						key={t.id}
 						value={t.id}
+						// Radix hides a force-mounted panel with `hidden` rather than
+						// unmounting it, which is what lets the draft survive.
+						forceMount={
+							TABS_HOLDING_DRAFTS.has(t.id) && visited.has(t.id) ? true : undefined
+						}
 						className="mt-0 flex-1 overflow-auto p-6 bg-background"
 					>
 						{t.id === "info" && (
-							<InfoTab collection={collection} requestCount={requests.length} />
+							<InfoTab
+								collection={collection}
+								requestCount={requests.length}
+								active={tab === "info"}
+							/>
 						)}
-						{t.id === "auth" && <AuthTab collection={collection} />}
-						{t.id === "pre-script" && <ScriptTab collection={collection} kind="pre" />}
+						{t.id === "auth" && (
+							<AuthTab collection={collection} active={tab === "auth"} />
+						)}
+						{t.id === "pre-script" && (
+							<ScriptTab
+								collection={collection}
+								kind="pre"
+								active={tab === "pre-script"}
+							/>
+						)}
 						{t.id === "post-script" && (
-							<ScriptTab collection={collection} kind="post" />
+							<ScriptTab
+								collection={collection}
+								kind="post"
+								active={tab === "post-script"}
+							/>
 						)}
 						{t.id === "variables" && <VariablesTab collection={collection} />}
 					</TabsContent>

--- a/app/src/modules/settings/main/SettingsMain.category-switch.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.category-switch.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Picking another settings category used to throw away whatever was typed.
+ *
+ * The reset was a bare `setEditedValues({})` keyed on `selectedCategory`: no
+ * save, no prompt, and nothing on screen afterwards to say an edit had ever
+ * existed. Unmounting the panel - navigating away from Settings - ran the same
+ * path. Engine settings are merge-patches, so leaving a category now writes its
+ * edits rather than dropping them.
+ *
+ * The second test covers the status stomp that lived in the same file: a
+ * `setStatus("idle")` fired on mount and on every clean render, so opening
+ * Settings cleared an `error` some other context had just published to the Dock.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SettingsMain from "./SettingsMain";
+
+const entries = [
+	{
+		key: "max_connections",
+		label: "Max connections",
+		description: "Upper bound on concurrent connections",
+		type: "integer" as const,
+		value: "10",
+		default: "10",
+		category: "network_performance",
+		min: "1",
+		max: "100",
+		updatedAt: 0,
+	},
+	{
+		key: "worker_threads",
+		label: "Worker threads",
+		description: "Engine worker pool size",
+		type: "integer" as const,
+		value: "4",
+		default: "4",
+		category: "general_engine",
+		min: "1",
+		max: "64",
+		updatedAt: 0,
+	},
+];
+
+const mutateAsync = vi.fn((_payload: { entries: Record<string, string> }) => Promise.resolve({}));
+
+vi.mock("@/queries", () => ({
+	useConfigQuery: () => ({ data: { entries }, isLoading: false, error: null }),
+	useUpdateConfigMutation: () => ({ mutateAsync, isPending: false }),
+}));
+
+/** Driven by the test - the store the sidebar would write on a click. */
+let selectedCategory = "network_performance";
+
+vi.mock("@/modules/settings/settings-store", () => ({
+	useSettingsStore: () => ({ selectedCategory, restartRequiredKeys: [] }),
+}));
+
+vi.mock("@/stores", () => ({
+	useEngineStore: () => ({
+		isEngineConnected: true,
+		pendingRestart: false,
+		restartRequiredKeys: [],
+		addRestartRequiredKey: vi.fn(),
+		clearRestartRequired: vi.fn(),
+	}),
+}));
+
+const setStatus = vi.fn();
+vi.mock("@/stores/save-store", () => ({
+	useSaveStore: () => ({
+		startSaving: vi.fn(),
+		completeSave: vi.fn(),
+		failSave: vi.fn(),
+		setStatus: (...args: unknown[]) => setStatus(...args),
+		markPendingSave: vi.fn(),
+		registerContext: vi.fn(),
+		unregisterContext: vi.fn(),
+		setActiveContext: vi.fn(),
+		updateContext: vi.fn(),
+	}),
+}));
+
+/** Only the engine-restart button reaches the real client; the rest is mocked. */
+function Panel() {
+	return (
+		<QueryClientProvider client={new QueryClient()}>
+			<SettingsMain />
+		</QueryClientProvider>
+	);
+}
+
+describe("SettingsMain - leaving a category", () => {
+	beforeEach(() => {
+		mutateAsync.mockClear();
+		setStatus.mockClear();
+		selectedCategory = "network_performance";
+	});
+
+	it("saves the edits instead of dropping them", async () => {
+		const { rerender } = render(<Panel />);
+
+		fireEvent.change(screen.getByLabelText("Max connections"), { target: { value: "42" } });
+
+		selectedCategory = "general_engine";
+		await act(async () => {
+			rerender(<Panel />);
+		});
+
+		expect(mutateAsync).toHaveBeenCalledTimes(1);
+		expect(mutateAsync.mock.calls[0][0]).toEqual({ entries: { max_connections: "42" } });
+	});
+
+	it("saves them on unmount too - navigating away is the same loss", async () => {
+		const { unmount } = render(<Panel />);
+
+		fireEvent.change(screen.getByLabelText("Max connections"), { target: { value: "7" } });
+
+		await act(async () => {
+			unmount();
+		});
+
+		expect(mutateAsync).toHaveBeenCalledTimes(1);
+		expect(mutateAsync.mock.calls[0][0]).toEqual({ entries: { max_connections: "7" } });
+	});
+
+	it("does not write an out-of-range value", async () => {
+		// `handleSave` refuses an invalid batch and the Save button is disabled
+		// while one exists; the flush must not be the way around that.
+		const { unmount } = render(<Panel />);
+
+		fireEvent.change(screen.getByLabelText("Max connections"), { target: { value: "9999" } });
+
+		await act(async () => {
+			unmount();
+		});
+
+		expect(mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("leaves the save status alone while it has nothing pending", async () => {
+		// Mounting a clean Settings panel used to publish `idle`, wiping whatever
+		// another context had put there - most damagingly an `error`.
+		const { unmount } = render(<Panel />);
+		await act(async () => {
+			unmount();
+		});
+
+		expect(setStatus).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -117,8 +117,18 @@ export default function SettingsMain() {
 	const [editedValues, setEditedValues] = useState<Record<string, EditedValue>>({});
 	const [isRestarting, setIsRestarting] = useState(false);
 
-	// Ref for save function to avoid stale closures
+	// Refs for the save function and the live edits, so the category-switch
+	// cleanup below can flush without either becoming one of its dependencies.
 	const handleSaveRef = useRef<(() => Promise<void>) | undefined>(undefined);
+	const saveEntriesRef = useRef<
+		((entries: Record<string, EditedValue>) => Promise<void>) | undefined
+	>(undefined);
+	const editedValuesRef = useRef(editedValues);
+	// Whether the `pending` status on the Dock is one this panel put there. The
+	// unconditional `setStatus("idle")` this replaces ran on mount and on every
+	// clean render, so merely opening Settings wiped an `error` another context
+	// had just published.
+	const markedPendingRef = useRef(false);
 
 	// Filter entries by selected category (calculate before early returns)
 	const categoryEntries =
@@ -136,67 +146,129 @@ export default function SettingsMain() {
 	const hasChanges = Object.keys(editedValues).length > 0;
 	const hasInvalidValues = Object.values(editedValues).some((v) => !v.isValid);
 
-	// Reset edited values when category changes
 	useEffect(() => {
-		setEditedValues({});
-	}, [selectedCategory]);
+		editedValuesRef.current = editedValues;
+	});
 
 	// Mark as pending when there are unsaved changes
 	// This hook must be called before any early returns to follow Rules of Hooks
 	useEffect(() => {
 		if (hasChanges && !hasInvalidValues) {
+			markedPendingRef.current = true;
 			markPendingSave();
-		} else {
+			return;
+		}
+		// Only clear a status this panel set. Anything else on screen - another
+		// context's `error`, or the `saved` a successful save here just
+		// published - is not ours to overwrite.
+		if (markedPendingRef.current) {
+			markedPendingRef.current = false;
 			setStatus("idle");
 		}
 	}, [hasChanges, hasInvalidValues, markPendingSave, setStatus]);
 
+	/**
+	 * Persist an explicit set of edits.
+	 *
+	 * Split out from `handleSave` because the category-switch flush below saves
+	 * the edits captured at the moment of the switch, not whatever is in state by
+	 * the time the write lands. Invalid entries are dropped here rather than
+	 * refused: `handleSave` still refuses the whole batch (the Save button is
+	 * disabled while any value is invalid and the inline error says why), but a
+	 * flush has no screen left to show that error on, so it saves what it can.
+	 */
+	const saveEntries = useCallback(
+		async (entries: Record<string, EditedValue>) => {
+			const updates: Record<string, string> = {};
+			const restartKeys: string[] = [];
+
+			for (const [key, edited] of Object.entries(entries)) {
+				if (!edited.isValid) continue;
+				updates[key] = edited.value;
+
+				// Check if this config requires restart
+				const entry = configResponse?.entries.find((e) => e.key === key);
+				if (entry && isRestartRequired(entry)) {
+					restartKeys.push(key);
+				}
+			}
+			if (Object.keys(updates).length === 0) return;
+
+			// From here the status sequence (saving -> saved -> idle) is this
+			// function's; the pending effect above must keep its hands off it, or
+			// a category switch would idle away the "saving" it just started.
+			markedPendingRef.current = false;
+			startSaving();
+			try {
+				await updateConfigMutation.mutateAsync({ entries: updates });
+				// Clear only what this write actually persisted, and only where the
+				// value is still the one that was written. A category switch flushes
+				// asynchronously, so the user can be typing in the *next* category
+				// by the time this resolves - clearing wholesale took those edits
+				// with it.
+				setEditedValues((prev) => {
+					const next = { ...prev };
+					for (const key of Object.keys(updates)) {
+						if (next[key]?.value === updates[key]) delete next[key];
+					}
+					return next;
+				});
+				completeSave();
+
+				// Track restart-required configs
+				for (const key of restartKeys) {
+					addRestartRequiredKey(key);
+				}
+
+				// Reset to idle after showing "saved" status
+				setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+			} catch (err) {
+				console.error("Failed to save settings:", err);
+				failSave(err instanceof Error ? err.message : "Failed to save settings");
+			}
+		},
+		[
+			configResponse,
+			updateConfigMutation,
+			startSaving,
+			completeSave,
+			failSave,
+			setStatus,
+			addRestartRequiredKey,
+		]
+	);
+
 	// Save changes - MUST be defined before early returns (Rules of Hooks)
 	const handleSave = useCallback(async () => {
 		if (hasInvalidValues || !hasChanges) return;
+		await saveEntries(editedValues);
+	}, [hasInvalidValues, hasChanges, editedValues, saveEntries]);
 
-		const updates: Record<string, string> = {};
-		const restartKeys: string[] = [];
+	useEffect(() => {
+		saveEntriesRef.current = saveEntries;
+	}, [saveEntries]);
 
-		for (const [key, edited] of Object.entries(editedValues)) {
-			updates[key] = edited.value;
-
-			// Check if this config requires restart
-			const entry = configResponse?.entries.find((e) => e.key === key);
-			if (entry && isRestartRequired(entry)) {
-				restartKeys.push(key);
-			}
-		}
-
-		startSaving();
-		try {
-			await updateConfigMutation.mutateAsync({ entries: updates });
-			setEditedValues({});
-			completeSave();
-
-			// Track restart-required configs
-			for (const key of restartKeys) {
-				addRestartRequiredKey(key);
-			}
-
-			// Reset to idle after showing "saved" status
-			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
-		} catch (err) {
-			console.error("Failed to save settings:", err);
-			failSave(err instanceof Error ? err.message : "Failed to save settings");
-		}
-	}, [
-		hasInvalidValues,
-		hasChanges,
-		editedValues,
-		configResponse,
-		updateConfigMutation,
-		startSaving,
-		completeSave,
-		failSave,
-		setStatus,
-		addRestartRequiredKey,
-	]);
+	/**
+	 * Leaving a category saves its edits instead of dropping them.
+	 *
+	 * This effect used to be a bare `setEditedValues({})`: picking another
+	 * category in the sidebar - or navigating away from Settings entirely, which
+	 * runs the same cleanup - discarded whatever had been typed, with no save, no
+	 * prompt, and nothing on screen to say it had happened. Engine settings are
+	 * cheap merge-patches, so they are saved rather than confirmed; the switch is
+	 * not itself a destructive act.
+	 *
+	 * The cleanup reads the edits through a ref because it runs before this
+	 * commit's effect bodies, so the ref still holds the *outgoing* category's
+	 * values - which is exactly what needs writing.
+	 */
+	useEffect(() => {
+		setEditedValues({});
+		return () => {
+			const pending = editedValuesRef.current;
+			if (Object.keys(pending).length > 0) void saveEntriesRef.current?.(pending);
+		};
+	}, [selectedCategory]);
 
 	// Keep handleSave ref updated
 	useEffect(() => {

--- a/app/src/modules/variables/main/VariableTableEditor.tsx
+++ b/app/src/modules/variables/main/VariableTableEditor.tsx
@@ -77,6 +77,32 @@ interface VariableRow {
 
 type VariableEditorType = "globals" | "environment" | "collection";
 
+/**
+ * Row-wise equality over every field a row carries.
+ *
+ * Used to tell "the cache echo of the save I just made" from "someone typed
+ * while it was in flight", which is the difference between clearing the dirty
+ * flag and silently losing an edit. Compared by value rather than by array
+ * identity on purpose: a reseed that happens to produce identical rows must
+ * count as unchanged, and identity would call it a change and leave the editor
+ * dirty forever.
+ */
+function sameRows(a: VariableRow[], b: VariableRow[]): boolean {
+	if (a.length !== b.length) return false;
+	return a.every((row, i) => {
+		const other = b[i];
+		return (
+			row.key === other.key &&
+			row.value === other.value &&
+			row.enabled === other.enabled &&
+			(row.secret ?? false) === (other.secret ?? false) &&
+			(row.type ?? "string") === (other.type ?? "string") &&
+			row.createdAt === other.createdAt &&
+			(row.isNew ?? false) === (other.isNew ?? false)
+		);
+	});
+}
+
 interface VariableEditorConfig {
 	type: VariableEditorType;
 	// For globals
@@ -172,9 +198,13 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 	const [hasPendingChanges, setHasPendingChanges] = useState(false);
 	const [revealedSecrets, setRevealedSecrets] = useState<Set<number>>(new Set());
-	const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const variablesRef = useRef<VariableRow[]>([]);
 	const performSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
+	// The dirty flag, readable from an effect without being one of its
+	// dependencies - the row-init effect has to know whether the user has
+	// uncommitted edits *at the moment the cache changes under it*, and taking
+	// the state as a dep would re-run the effect on every flip of the flag.
+	const hasPendingChangesRef = useRef(false);
 
 	// Determine context ID and name
 	const contextId =
@@ -227,6 +257,35 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 		[]
 	);
 
+	// Every edit goes through here so the ref and the state can never disagree.
+	const markDirty = useCallback(() => {
+		hasPendingChangesRef.current = true;
+		setHasPendingChanges(true);
+		markPendingSave();
+	}, [markPendingSave]);
+
+	/**
+	 * Compare-and-clear: only drop the dirty flag if the rows are still the ones
+	 * this save wrote.
+	 *
+	 * A save snapshots `variablesRef` when it starts, so anything typed before it
+	 * lands is not in the payload. Clearing unconditionally marked those edits
+	 * saved - the debounce and the blur handler both skip a clean editor - and
+	 * they never reached the engine. Staying dirty leaves the normal paths (blur,
+	 * Cmd+S, the quit flush) to write them.
+	 */
+	const finishSave = useCallback(
+		(snapshot: VariableRow[]) => {
+			if (sameRows(variablesRef.current, snapshot)) {
+				hasPendingChangesRef.current = false;
+				setHasPendingChanges(false);
+			}
+			completeSave();
+			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+		},
+		[completeSave, setStatus]
+	);
+
 	// Auto-save function (payload order by createdAt so round-trip preserves order)
 	const performSave = useCallback(async () => {
 		const varsToSave = variablesRef.current;
@@ -267,9 +326,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 					{ variables: variablesObj },
 					{
 						onSuccess: () => {
-							setHasPendingChanges(false);
-							completeSave();
-							setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+							finishSave(varsToSave);
 							resolve();
 						},
 						onError: (error) => {
@@ -288,9 +345,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 					},
 					{
 						onSuccess: () => {
-							setHasPendingChanges(false);
-							completeSave();
-							setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+							finishSave(varsToSave);
 							resolve();
 						},
 						onError: (error) => {
@@ -308,9 +363,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 					},
 					{
 						onSuccess: () => {
-							setHasPendingChanges(false);
-							completeSave();
-							setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+							finishSave(varsToSave);
 							resolve();
 						},
 						onError: (error) => {
@@ -330,9 +383,8 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 		updateEnvironmentMutation,
 		updateCollectionMutation,
 		startSaving,
-		completeSave,
+		finishSave,
 		failSave,
-		setStatus,
 	]);
 
 	// Keep performSaveRef updated
@@ -350,15 +402,8 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 		});
 		setActiveContext(contextId);
 
-		// Alias the ref object (not .current) so cleanup still reads the live
-		// .current - the timeout handle is scheduled after mount during debounced
-		// save, so cleanup must clear whatever is actually pending, not a stale copy.
-		const timeoutRef = saveTimeoutRef;
 		return () => {
 			unregisterContext(contextId);
-			if (timeoutRef.current) {
-				clearTimeout(timeoutRef.current);
-			}
 		};
 	}, [contextId, contextName, registerContext, unregisterContext, setActiveContext]);
 
@@ -367,33 +412,34 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 		updateContext(contextId, { hasPendingChanges });
 	}, [contextId, hasPendingChanges, updateContext]);
 
-	// Handle blur - save when user leaves the field
+	// Handle blur - save when user leaves the field.
+	//
+	// There is no debounce here and never was: `saveTimeoutRef` was cleared in
+	// three places and assigned in none, so the three `clearTimeout` calls it
+	// guarded were always no-ops. Saves fire on blur and on the toggles.
 	const handleBlur = useCallback(() => {
 		if (hasPendingChanges) {
-			if (saveTimeoutRef.current) {
-				clearTimeout(saveTimeoutRef.current);
-			}
 			performSaveRef.current();
 		}
 	}, [hasPendingChanges]);
 
-	// Handle focus - cancel any pending save
-	const handleFocus = useCallback(() => {
-		if (saveTimeoutRef.current) {
-			clearTimeout(saveTimeoutRef.current);
-		}
-	}, []);
-
-	// Initialize variables from data (sorted by createdAt: oldest first, newest at bottom)
-	// Key the init effect on the identity of the active data source so it re-runs
-	// when the user switches between globals / a specific environment / collection.
-	const dataSourceKey =
-		type === "globals"
-			? globalsData
-			: type === "environment"
-				? environment?.id
-				: collection?.id;
+	// Initialize variables from data (sorted by createdAt: oldest first, newest at bottom).
+	// `contextId` is the identity of the active data source, so the effect
+	// reseeds when the user switches between globals / a specific environment /
+	// collection.
+	const lastSeededSourceRef = useRef<string | null>(null);
 	useEffect(() => {
+		const isNewDataSource = lastSeededSourceRef.current !== contextId;
+		lastSeededSourceRef.current = contextId;
+
+		// A save's `onSuccess` writes the query cache, which arrives back here as
+		// a new `dataVariables`. Rebuilding rows from it would revert anything
+		// typed while that save was in flight - the payload was snapshotted
+		// before those keystrokes, so the cache is genuinely one edit behind.
+		// Only a *different* entity is allowed to overwrite uncommitted edits;
+		// a refetch or an echo of our own write waits for the editor to be clean.
+		if (!isNewDataSource && hasPendingChangesRef.current) return;
+
 		if (dataVariables && Object.keys(dataVariables).length > 0) {
 			const entries = sortByCreatedAt(Object.entries(dataVariables));
 			const rows: VariableRow[] = entries.map(([key, val]) => ({
@@ -418,7 +464,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 				{ key: "", value: "", enabled: true, secret: false, type: "string", isNew: true },
 			]);
 		}
-	}, [dataSourceKey, dataVariables, sortByCreatedAt]);
+	}, [contextId, dataVariables, sortByCreatedAt]);
 
 	const updateVariable = (index: number, field: keyof VariableRow, value: string | boolean) => {
 		const newVariables = [...variables];
@@ -438,8 +484,7 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 		// would persist the pre-edit value and the backend re-sync would then
 		// revert the change. Mirrors removeVariable.
 		variablesRef.current = newVariables;
-		setHasPendingChanges(true);
-		markPendingSave();
+		markDirty();
 	};
 
 	const removeVariable = (index: number) => {
@@ -448,8 +493,8 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 			newVariables.push({ key: "", value: "", enabled: true, type: "string", isNew: true });
 		}
 		setVariables(newVariables);
-		setHasPendingChanges(true);
 		variablesRef.current = newVariables;
+		markDirty();
 		performSaveRef.current();
 	};
 
@@ -652,7 +697,6 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 											onChange={(e) =>
 												updateVariable(index, "key", e.target.value)
 											}
-											onFocus={handleFocus}
 											onBlur={handleBlur}
 											placeholder="variable_name"
 											className={cn(
@@ -671,7 +715,6 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 												onChange={(e) =>
 													updateVariable(index, "value", e.target.value)
 												}
-												onFocus={handleFocus}
 												onBlur={handleBlur}
 												placeholder="value"
 												className={cn(

--- a/app/src/modules/variables/main/concurrent-edit-clobber.test.tsx
+++ b/app/src/modules/variables/main/concurrent-edit-clobber.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Typing while a save is in flight used to lose the keystrokes twice over.
+ *
+ * The sequence is one mutation round trip wide, and wider on a slow engine:
+ * blur row A, so its save snapshots the rows and leaves; type in row B; the
+ * save lands. Its `onSuccess` writes the query cache, the new `variables` prop
+ * comes back into the editor, and the row-init effect rebuilt every row from
+ * it - server state that predates B, so **B was reverted on screen**. The same
+ * `onSuccess` also cleared the dirty flag, so B was marked saved as well and
+ * nothing would ever write it: blur skips a clean editor, and so do Ctrl/Cmd+S
+ * and the quit flush.
+ *
+ * Both halves are asserted here, because either one alone still loses data:
+ * surviving on screen but reported clean is a row that dies at quit, and
+ * reported dirty but reverted on screen is the user's edit gone regardless.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen, act } from "@testing-library/react";
+import VariableTableEditor from "./VariableTableEditor";
+import { TooltipProvider } from "@/components/ui";
+import type { Collection, VariableValue } from "@/types";
+
+interface MutateOptions {
+	onSuccess: () => void;
+	onError: (error: Error) => void;
+}
+
+/** The save that is "in flight" - resolved by hand, so the window stays open. */
+let pendingSave: { payload: { variables: Record<string, VariableValue> }; opts: MutateOptions };
+const updateCollection = vi.fn(
+	(payload: { variables: Record<string, VariableValue> }, opts: MutateOptions) => {
+		pendingSave = { payload, opts };
+	}
+);
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: undefined, isLoading: false, error: null }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+	useDeleteEnvironmentMutation: () => ({
+		mutate: vi.fn(),
+		mutateAsync: vi.fn(),
+		isPending: false,
+	}),
+	useUpdateCollectionMutation: () => ({
+		mutate: (...args: unknown[]) =>
+			updateCollection(...(args as Parameters<typeof updateCollection>)),
+		mutateAsync: vi.fn(),
+	}),
+}));
+
+const sessionStore = { activeEnvironmentId: null, setActiveEnvironmentId: vi.fn() };
+
+/** Every `hasPendingChanges` the editor has published to the save store. */
+const pendingChangesReported: boolean[] = [];
+const saveStore = {
+	registerContext: vi.fn(),
+	unregisterContext: vi.fn(),
+	updateContext: vi.fn((_id: string, updates: { hasPendingChanges?: boolean }) => {
+		if (updates.hasPendingChanges !== undefined) {
+			pendingChangesReported.push(updates.hasPendingChanges);
+		}
+	}),
+	setActiveContext: vi.fn(),
+	markPendingSave: vi.fn(),
+	startSaving: vi.fn(),
+	completeSave: vi.fn(),
+	failSave: vi.fn(),
+	setStatus: vi.fn(),
+};
+
+vi.mock("@/stores", () => ({
+	useSaveStore: () => saveStore,
+	useSessionStore: Object.assign(() => sessionStore, { getState: () => sessionStore }),
+}));
+
+vi.mock("@/modules/variables/variables-store", () => ({
+	useVariablesStore: () => ({ selectedCategory: null, setSelectedCategory: vi.fn() }),
+}));
+
+function makeCollection(variables: Record<string, VariableValue>): Collection {
+	return {
+		id: "col_1",
+		name: "demo",
+		description: "",
+		order: 0,
+		variables,
+		auth: { mode: "none" },
+		preRequestScript: "",
+		postRequestScript: "",
+		createdAt: new Date(0).toISOString(),
+		updatedAt: new Date(0).toISOString(),
+	};
+}
+
+const initial = makeCollection({
+	host: { value: "example.com", enabled: true, secret: false, type: "string", createdAt: 1000 },
+	token: { value: "abc", enabled: true, secret: false, type: "string", createdAt: 2000 },
+});
+
+/** The most recent `hasPendingChanges` the editor published. */
+function lastReported(): boolean | undefined {
+	return pendingChangesReported[pendingChangesReported.length - 1];
+}
+
+/** Rows render in `createdAt` order, then the trailing blank row. */
+function valueInputs(): HTMLInputElement[] {
+	return screen.getAllByPlaceholderText("value") as HTMLInputElement[];
+}
+
+describe("variables editor - an edit made while a save is in flight", () => {
+	beforeEach(() => {
+		updateCollection.mockClear();
+		pendingChangesReported.length = 0;
+	});
+
+	it("survives the cache echo of the earlier save, and stays dirty", () => {
+		const { rerender } = render(
+			<TooltipProvider>
+				<VariableTableEditor config={{ type: "collection", collection: initial }} />
+			</TooltipProvider>
+		);
+
+		// Row A: edit and blur, which starts a save carrying only this change.
+		const [hostValue] = valueInputs();
+		fireEvent.change(hostValue, { target: { value: "example.org" } });
+		fireEvent.blur(hostValue);
+		expect(updateCollection).toHaveBeenCalledTimes(1);
+		expect(pendingSave.payload.variables.host.value).toBe("example.org");
+		expect(pendingSave.payload.variables.token.value).toBe("abc");
+
+		// Row B: typed before the save lands, so it is not in the flying payload.
+		fireEvent.change(valueInputs()[1], { target: { value: "xyz" } });
+
+		// The save lands: `onSuccess` fires and the query cache is written with
+		// the server's copy, which arrives back as a new `collection` prop.
+		act(() => pendingSave.opts.onSuccess());
+		rerender(
+			<TooltipProvider>
+				<VariableTableEditor
+					config={{
+						type: "collection",
+						collection: makeCollection({
+							host: {
+								value: "example.org",
+								enabled: true,
+								secret: false,
+								type: "string",
+								createdAt: 1000,
+							},
+							token: {
+								value: "abc",
+								enabled: true,
+								secret: false,
+								type: "string",
+								createdAt: 2000,
+							},
+						}),
+					}}
+				/>
+			</TooltipProvider>
+		);
+
+		expect(valueInputs()[1].value).toBe("xyz");
+		expect(lastReported()).toBe(true);
+	});
+
+	it("does clear the dirty flag when nothing was typed during the save", () => {
+		// The other side of the compare-and-clear: an editor that stays dirty
+		// forever would re-save on every blur and never settle.
+		render(
+			<TooltipProvider>
+				<VariableTableEditor config={{ type: "collection", collection: initial }} />
+			</TooltipProvider>
+		);
+
+		const [hostValue] = valueInputs();
+		fireEvent.change(hostValue, { target: { value: "example.org" } });
+		fireEvent.blur(hostValue);
+		act(() => pendingSave.opts.onSuccess());
+
+		expect(lastReported()).toBe(false);
+	});
+
+	it("still adopts a different scope's variables over an uncommitted edit", () => {
+		// The guard is "ignore echoes of my own scope", not "ignore the props".
+		// Switching to another collection must reseed even while dirty, or the
+		// editor would show the previous collection's rows.
+		const { rerender } = render(
+			<TooltipProvider>
+				<VariableTableEditor config={{ type: "collection", collection: initial }} />
+			</TooltipProvider>
+		);
+
+		fireEvent.change(valueInputs()[0], { target: { value: "typed-but-unsaved" } });
+
+		const other = makeCollection({
+			region: {
+				value: "eu-west-1",
+				enabled: true,
+				secret: false,
+				type: "string",
+				createdAt: 1000,
+			},
+		});
+		other.id = "col_2";
+		rerender(
+			<TooltipProvider>
+				<VariableTableEditor config={{ type: "collection", collection: other }} />
+			</TooltipProvider>
+		);
+
+		expect(screen.getByDisplayValue("eu-west-1")).toBeTruthy();
+		expect(screen.queryByDisplayValue("typed-but-unsaved")).toBeNull();
+	});
+});

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -164,10 +164,20 @@ Orchestrates auto-save across the app with a registry of saveable contexts (e.g.
 ```
 
 **`failSave` is the app's single failure seam.** It sets `status: "error"` *and*
-raises an error toast carrying the reason. Eight call sites reach it - the
-collection tree's create / delete / duplicate / rename, `useSaveManager`,
-`SettingsMain`, `VariableTableEditor` - and doing the reporting here rather than
-at each of them means a new caller cannot forget to report.
+raises an error toast carrying the reason. Its call sites are the collection
+tree's create / delete / duplicate / rename, `useSaveManager`, `SettingsMain`,
+`VariableTableEditor`, `useDraftSaveContext` and `ContextBar` - and doing the
+reporting here rather than at each of them means a new caller cannot forget to
+report. The last two were added because both could fail in complete silence:
+`ContextBar` fired three mutations with no `onError` at all, and the
+manual-draft editors rendered an inline callout that a quit flush has no screen
+to show.
+
+**Only the context that set a status clears it.** `SettingsMain` used to run an
+unconditional `setStatus("idle")` whenever it had nothing pending - which
+included mount - so merely opening Settings wiped an `error` another context had
+just published to the Dock. It now tracks whether the `pending` on screen is its
+own and leaves anything else alone.
 
 There is no `errorMessage` field. The reason travels in the toast; the store
 holds only the status the Dock renders. The field used to exist and its sole
@@ -208,7 +218,11 @@ const {
 } = useSaveStore();
 ```
 
-**Non-persisted**. See `useSaveManager` hook for registration details.
+**Non-persisted**. See `useSaveManager` (autosave editors) and
+`useDraftSaveContext` (manual save-button editors) for registration details.
+Between them every dirty editor in the app is in this registry, which is what
+`flushAll` walks on quit - a surface that is not registered is not merely
+unsaved on quit, it is invisible.
 
 #### `response-store.ts` - Response Cache
 
@@ -788,6 +802,51 @@ const { draft, setDraft, isDirty, reset } = useEntityDraft({
 });
 ```
 
+**The draft lives in component state, so its panel must not unmount.** Radix
+unmounts an inactive `TabsContent`; `CollectionDetail` therefore force-mounts the
+four draft-holding tabs (Info, Auth, Pre-request, Post-request) from their first
+visit onwards, so an intra-collection tab switch stops discarding the draft.
+This is the same call, for the same reason, as the request builder's body drafts
+living in `RequestBuilderProvider` rather than in `BodyPanel` (see
+`request-builder/utils/body-drafts.ts`). The Variables tab is deliberately not
+force-mounted: it autosaves and claims the store's active context on mount, so
+keeping it alive behind another tab would point Ctrl/Cmd+S at the wrong editor.
+
+A *collection* switch still reseeds and discards, deliberately - it is the
+hook's documented behaviour above, and pinned by `useEntityDraft.test.ts`.
+
+### `useDraftSaveContext()` - Registering a Manual Draft
+
+The counterpart to `useSaveManager`'s registration half, for editors using the
+`useEntityDraft` model. Located in `app/src/hooks/useDraftSaveContext.ts`. Used
+by `InfoTab`, `AuthTab` and `ScriptTab`.
+
+```typescript
+useDraftSaveContext({
+  id: `collection-${collection.id}-auth`,  // Unique per editor
+  name: `Collection auth: ${collection.name}`,
+  isDirty,                                 // From useEntityDraft
+  isActive: active,                        // Is this the tab on screen?
+  save: persist,                           // Rejecting is how failure is reported
+});
+```
+
+**Behaviour:**
+- **Registration only.** It schedules nothing; the Save button stays the primary
+  affordance. The defect it fixes is that the *other* ways to save - Ctrl/Cmd+S,
+  the quit flush, tab eviction - could not reach these editors at all, because
+  none of the three tabs ever called `registerContext`.
+- **`isActive` decides who owns Ctrl/Cmd+S.** `triggerSave` prefers the active
+  context, and these editors stay mounted while hidden, so without it the last
+  sibling to mount would answer for the panel on screen.
+- **A failure toasts rather than resolving quietly.** The editors render an
+  inline `SaveFailed` callout for a button press, but a quit flush has no callout
+  on screen, and `runSave` reads a resolved promise as success - swallowing here
+  would report "Saved" for a write that failed.
+- **The save must carry its own validity guard.** A disabled button does not stop
+  the store-driven paths, which is why `InfoTab` refuses a blank collection name
+  inside `persist` and not only on the button.
+
 ## State Flow Examples
 
 ### Executing a Single Request
@@ -857,16 +916,20 @@ starts the engine at import time.
 
 3. **TanStack Query for server state:** Use TanStack Query for collections, requests, environments, globals, runs, and reports. It is the single source of truth and ensures consistency across the app.
 
-4. **Save manager integration:** Use `useSaveManager()` in any component that edits a persistable entity (request, environment, etc.) that autosaves. It handles debouncing, context registration, and centralized save state. Do not manually call `useSaveStore()` for auto-save. For an editor that saves on an explicit button instead, use `useEntityDraft()` - do not hand-roll the draft/resync/`isDirty`/mutation-reset parts again.
+4. **Save manager integration:** Use `useSaveManager()` in any component that edits a persistable entity (request, environment, etc.) that autosaves. It handles debouncing, context registration, and centralized save state. Do not manually call `useSaveStore()` for auto-save. For an editor that saves on an explicit button instead, use `useEntityDraft()` **plus `useDraftSaveContext()`** - the first owns the draft, the second puts it in the registry - and do not hand-roll the draft/resync/`isDirty`/mutation-reset parts again.
 
-5. **Centralized save on app quit:** On Electron's `before-quit` event, call `useSaveStore().flushAll()` to persist any pending changes before the app closes.
+5. **Centralized save on app quit:** On Electron's `before-quit` event, call `useSaveStore().flushAll()` to persist any pending changes before the app closes. An editor that is not registered is not merely unsaved here, it is invisible - which is how the collection tabs lost drafts silently for as long as they existed.
 
-6. **Tab LRU and dirty state:** The tab store coordinates with save-store to avoid evicting dirty tabs. When a tab is evicted due to LRU, any pending saves are flushed first.
+    Corollary: **an editing surface must never fail without saying so.** There is no global `MutationCache.onError` in `lib/query-client.ts`, so a bare `mutation.mutate(...)` reports nothing at all. Route the failure through `failSave` (toast + status) or render the mutation's `isError`, and roll an uncontrolled input back to the stored value while you are at it - `ContextBar` did neither, so a rejected edit sat on screen looking committed.
 
-7. **Response persistence:** Responses are stored in memory (not localStorage) so they survive tab switches but are cleared on page reload. This balances UX (quick switch back) with memory (responses can be large).
+6. **Leaving an editor saves or asks; it does not drop.** A settings category switch, an unmount, a tab switch - each used to discard dirty state silently in at least one place. Settings flushes its valid edits on the way out (engine config writes are cheap merge-patches); the collection tabs keep their panels mounted so there is nothing to discard.
 
-8. **Metrics cap for performance:** Historical metrics are capped at **3,000 points** per run (defined in `app/src/config/metrics.ts` as `HISTORICAL_METRICS_CAP = 3000`). This provides ~5 minutes of full-fidelity data at the engine's 10 Hz tick rate, long enough for typical load test sessions but short enough to keep chart slicing efficient.
+7. **Tab LRU and dirty state:** The tab store coordinates with save-store to avoid evicting dirty tabs. When a tab is evicted due to LRU, any pending saves are flushed first.
 
-9. **Variable resolution priority:** Always resolve variables in priority order: environment > collection > global. Use `useVariableResolver({ collectionId, environmentId })` to ensure correct scoping.
+8. **Response persistence:** Responses are stored in memory (not localStorage) so they survive tab switches but are cleared on page reload. This balances UX (quick switch back) with memory (responses can be large).
 
-10. **Lazy loading and prefetch:** Use `usePrefetchCollectionsAndRequests()` on app init to warm up caches. Lazily fetch environments, globals, and run reports only when needed to reduce initial bundle size and API load.
+9. **Metrics cap for performance:** Historical metrics are capped at **3,000 points** per run (defined in `app/src/config/metrics.ts` as `HISTORICAL_METRICS_CAP = 3000`). This provides ~5 minutes of full-fidelity data at the engine's 10 Hz tick rate, long enough for typical load test sessions but short enough to keep chart slicing efficient.
+
+10. **Variable resolution priority:** Always resolve variables in priority order: environment > collection > global. Use `useVariableResolver({ collectionId, environmentId })` to ensure correct scoping.
+
+11. **Lazy loading and prefetch:** Use `usePrefetchCollectionsAndRequests()` on app init to warm up caches. Lazily fetch environments, globals, and run reports only when needed to reduce initial bundle size and API load.


### PR DESCRIPTION
## Description

Four editing surfaces lose or hide data at their edges. All four anchors from #237 were re-verified on current master (`469b90c`) before touching anything - each still reproduces as described.

**Plan.** The root cause is the same shape four times: an editor knows something the rest of the save machinery does not. (1) `VariableTableEditor`'s save snapshots its rows when it *starts*, but its `onSuccess` treats the cache write that follows as authoritative for the rows as they are *now* - so it reverts a concurrent edit on screen and marks it clean. The fix makes both halves ask "are these still the rows I saved?": the row-init effect reseeds only for a different scope or a clean editor, and the dirty flag is compare-and-clear. (2)/(4) `ContextBar` and the collection tabs fail without a reader - no `onError`, no registration - so failures and dirty state go nowhere; both are routed into `failSave` and the save-context registry, which already exist. (3) Settings drops edits on a category switch; it now flushes them.

The alternative I rejected for (4) was lifting the drafts into `CollectionDetail` and passing them down as props. It works, but it forces one shared `useUpdateCollectionMutation` (or four hoisted ones) and rewrites the prop API of three tabs plus their tests, to buy the same thing force-mounting buys. Keeping the panel alive is also the precedent this repo already set for exactly this Radix behaviour - see the note in `request-builder/utils/body-drafts.ts`, which moved the body drafts into the provider for the same reason.

### 1. `VariableTableEditor` clobbers and false-cleans a concurrent edit

Blur row A → the save snapshots `variablesRef` → type in row B → the save lands → `onSuccess` writes the query cache → new `dataVariables` → rows rebuilt from pre-B server state, **reverting B on screen** - and the same `onSuccess` cleared `hasPendingChanges`, so B was marked saved and nothing would ever write it (blur, Ctrl/Cmd+S and the quit flush all skip a clean editor).

- The row-init effect reseeds only when the **data source** changed (a different environment/collection/globals) or the editor is clean. An echo of its own write, or a background refetch, no longer overwrites uncommitted edits.
- `setHasPendingChanges(false)` became compare-and-clear against the exact rows the save carried.
- `saveTimeoutRef` is deleted - it was cleared in three places and assigned in none, so the three `clearTimeout` calls it guarded were always no-ops. `handleFocus` went with it.

### 2. `ContextBar` variable edits failed with zero feedback

Three mutations with no `onError`, nothing reading `isError`, and no global `MutationCache.onError`. The inputs are uncontrolled (`defaultValue` + a `key` derived from the stored value), so a rejected save changes nothing that would put the old text back - the typed value sat there looking committed. Failures now roll the input back and report through `failSave` (toast + Dock status), the same seam every other editor uses. The three "variable is no longer in its scope" guards, which silently swallowed the edit, say so too.

### 3. Settings discarded dirty edits on a category switch

`setEditedValues({})` keyed on `selectedCategory`, with no save and no prompt; unmount ran the same path. Engine config writes are cheap merge-patches, so leaving a category now **saves** its edits (the issue's first option). Out-of-range values are still refused, as the disabled Save button already implies. The mount-time `setStatus("idle")` is scoped to statuses this panel set, instead of wiping an `error` another context had just published.

Clearing after a save is now targeted at the keys that were actually written - a flush resolving after the user has started typing in the next category used to take those edits with it.

### 4. Collection-detail drafts were invisible to Ctrl/Cmd+S and quit, and died on a tab switch

New `useDraftSaveContext` hook - the registration half of the manual-save model, the counterpart to what `useSaveManager` does for autosave editors. `InfoTab`, `AuthTab` and `ScriptTab` register through it, so `flushAll` and `triggerSave` can finally see them; `isActive` decides which one owns Ctrl/Cmd+S. A failure on the store-driven path toasts rather than resolving quietly, because `runSave` reads a resolved promise as success and a quit flush has no inline callout on screen. `InfoTab`'s blank-name guard moved into the save itself, since a disabled button does not stop the store.

`CollectionDetail` force-mounts the four draft-holding tabs from their first visit, so a tab switch no longer discards. Gated on *visited* rather than always, so two Monaco editors are not created for a user who only opens Info. The Variables tab is deliberately excluded: it autosaves and claims the active context on mount, so keeping it alive behind another tab would point Ctrl/Cmd+S at the wrong editor.

### Deliberate deviation from the issue spec

Acceptance criterion 3 says "No category/tab/collection switch discards dirty state without saving or asking". The **collection** switch is left as-is: the issue's own Problem section calls that reseed deliberate and it is pinned by `useEntityDraft.test.ts` ("reseeds the draft, discarding an unsaved edit"), and the fix pathway for (4) asks only for registration plus the intra-collection tab switch. Auto-saving a half-typed script because the user clicked another collection also fights the manual-save model these editors chose. Category switch and tab switch are both fixed. Happy to add the collection-switch flush if you'd rather have it - it is a few lines in `useDraftSaveContext`, but it would need that pinned test changed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **249 files, 2150 tests, all passing** (2136 on the base commit; 14 new). `pnpm type-check` clean.

Engine untouched, so `python build.py -t` / `ctest` were not run - no C++, CMake or engine test file is in the diff, and the issue's own Tests section lists `pnpm test` only.

New, all mutation-checked (fix reverted, test confirmed red, fix restored):

- `variables/main/concurrent-edit-clobber.test.tsx` (3) - the exact blur-A/type-B/resolve sequence: B survives on screen **and** still reports dirty. Reverting either half (the effect guard, or the compare-and-clear) fails it. Plus the converse - a save with nothing typed during it does clear the flag - and that a genuine scope switch still reseeds over an uncommitted edit.
- `layout/ContextBar.save-error.test.tsx` (2) - a mocked 400 raises an error toast carrying the engine's text and restores the stored value; a variable missing from its scope refuses out loud. Both fail when the `onError`/`gone()` handling is removed.
- `settings/main/SettingsMain.category-switch.test.tsx` (4) - a category switch and an unmount each write the pending edits; an out-of-range value is not written; a clean panel touches no save status.
- `collections/CollectionDetail/draft-survival.test.tsx` (5) - against the **real** save store: the draft survives a tab switch (fails without `forceMount`), `flushAll` writes it and `triggerSave` targets the right context (both fail without registration), a clean tab registers nothing pending, and a blank name is not offered to the flush.

One note on that last file: the first version used `fireEvent.click` on the tab trigger and **passed against the unfixed component** - Radix activates on `mousedown`, so the test never left the Info tab. It now asserts the switch actually happened before asserting the draft survived.

Updated: `AuthTab.test.tsx` and `InfoTab.markdown.test.tsx` - the tabs persist through `mutateAsync` now (the save has to be awaitable for the store to report a real outcome), so the mock and one assertion follow.

ESLint on the touched files reports the same 3 errors + 1 warning as the base commit - all pre-existing, none in the new code (see #189).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/app/state-management.md` is updated in the same commit: the `failSave` call-site list, the "only the context that set a status clears it" rule, the force-mount note on `useEntityDraft`, a new `useDraftSaveContext()` section, and two best-practice entries (an editor must never fail silently; leaving an editor saves or asks). Prettier was run only on the files I touched that were clean beforehand.

## Related Issues
Closes #237

---
_Generated by [Claude Code](https://claude.ai/code/session_018AAzUgn2dY1F2MwcmTfBoY)_