### PR TITLE
fix(app): run lifecycle state - delete patch, zombie run tabs, stale report race

### DIFF
--- a/app/src/modules/history/main/HistoryDetail.states.test.tsx
+++ b/app/src/modules/history/main/HistoryDetail.states.test.tsx
@@ -46,10 +46,17 @@ const runQuery = {
 	refetch: refetchRun,
 };
 
-vi.mock("@/queries", () => ({
-	useRunQuery: () => runQuery,
-	useRunReportQuery: () => reportQuery,
-}));
+// `isRunNotFound` is the real one: the pane's whole job here is to discriminate
+// a deletion from a transport failure, and a stubbed predicate would assert
+// nothing about that.
+vi.mock("@/queries", async () => {
+	const runs = await vi.importActual<typeof import("@/queries/runs")>("@/queries/runs");
+	return {
+		useRunQuery: () => runQuery,
+		useRunReportQuery: () => reportQuery,
+		isRunNotFound: runs.isRunNotFound,
+	};
+});
 
 // The detail routers render heavy chart trees that are irrelevant here; the
 // question is only which of the three panes HistoryDetail chooses.
@@ -100,6 +107,25 @@ describe("HistoryDetail error", () => {
 		const retry = screen.getByRole("button", { name: /try again/i });
 		fireEvent.click(retry);
 		expect(refetchRun).toHaveBeenCalledTimes(1);
+	});
+
+	/*
+	 * A run tab outlives its run: tabs are persisted, so a run deleted in
+	 * another window - or before the last quit - rehydrates into this pane on
+	 * launch. Retrying a 404 can only 404 again, which is what the global
+	 * `retry: 2` had it doing; the way out is closing the tab.
+	 */
+	it("says the run is gone and offers the tab close, with no doomed retry", async () => {
+		const { RunNotFoundError } = await import("@/queries/runs");
+		runQuery.error = new RunNotFoundError("run-1");
+		runQuery.data = undefined;
+		render(<HistoryDetail />);
+
+		expect(screen.getByText(/this run no longer exists/i)).toBeTruthy();
+		expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+
+		fireEvent.click(screen.getByRole("button", { name: /close tab/i }));
+		expect(useTabsStore.getState().openTabs).toHaveLength(0);
 	});
 
 	it("treats a settled-but-empty report as an error, not as content", () => {

--- a/app/src/modules/history/main/HistoryDetail.tsx
+++ b/app/src/modules/history/main/HistoryDetail.tsx
@@ -26,15 +26,15 @@
  */
 
 import { History } from "lucide-react";
-import { useRunQuery, useRunReportQuery } from "@/queries";
+import { useRunQuery, useRunReportQuery, isRunNotFound } from "@/queries";
 import { useTabsStore } from "@/stores";
-import { Badge } from "@/components/ui";
+import { Badge, Button } from "@/components/ui";
 import { EmptyState, ErrorState, DetailSkeleton } from "@/components/shared";
 import LoadTestDetail from "./LoadTestDetail";
 import DesignRunView from "./DesignRunView";
 
 export default function HistoryDetail() {
-	const { openTabs, activeTabId } = useTabsStore();
+	const { openTabs, activeTabId, closeTab } = useTabsStore();
 
 	// Get selectedRunId from active tab
 	const activeTab = openTabs.find((t) => t.id === activeTabId);
@@ -79,7 +79,31 @@ export default function HistoryDetail() {
 	// History" - it walked the user away from the run instead of offering the
 	// one thing that might work, a retry. A transient engine hiccup left no way
 	// back in short of re-selecting the run.
+	//
+	// A deleted run is the other case entirely, and the tab strip is where it
+	// arrives from: tabs persist, so a run deleted in another window (or before
+	// the last quit) rehydrates into this pane on launch. Retrying a 404 can
+	// only fail again, so that one offers the move that works instead.
 	if (runError || !run) {
+		if (isRunNotFound(runError)) {
+			return (
+				<ErrorState
+					title="This run no longer exists"
+					detail="It was deleted from History. Nothing here can be recovered - closing the tab is safe."
+					action={
+						activeTab ? (
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => closeTab(activeTab.id)}
+							>
+								Close tab
+							</Button>
+						) : undefined
+					}
+				/>
+			);
+		}
 		const detail = runError instanceof Error ? runError.message : null;
 		return (
 			<ErrorState

--- a/app/src/modules/history/sidebar/HistoryList.delete.test.tsx
+++ b/app/src/modules/history/sidebar/HistoryList.delete.test.tsx
@@ -26,6 +26,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
 import { ApiError } from "@/services";
+import { useTabsStore } from "@/stores";
 import HistoryList from "./HistoryList";
 
 const showToast = vi.fn();
@@ -183,5 +184,33 @@ describe("HistoryList when the delete is refused", () => {
 
 		await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith("r1"));
 		expect(showToast).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * Tabs are persisted, so a run tab left open after its run is deleted is not
+ * merely stale - it rehydrates into a pane that can never load, on every
+ * restart, forever. Deleting a request already closes its tabs; a run did not.
+ */
+describe("HistoryList closing the deleted run's tab", () => {
+	beforeEach(() => {
+		useTabsStore.setState({ openTabs: [], activeTabId: null });
+		useTabsStore.getState().openTab({ type: "run", entityId: "r1" });
+	});
+
+	it("closes the run's tab once the engine has deleted it", async () => {
+		await openDeleteDialog();
+		await confirmDelete();
+
+		await waitFor(() => expect(useTabsStore.getState().openTabs).toHaveLength(0));
+	});
+
+	it("keeps the tab when the delete was refused - the run is still there", async () => {
+		mutateAsync.mockRejectedValue(new ApiError(409, "UNKNOWN_ERROR", "HTTP 409: Conflict", {}));
+		await openDeleteDialog();
+		await confirmDelete();
+
+		await waitFor(() => expect(showToast).toHaveBeenCalled());
+		expect(useTabsStore.getState().openTabs.map((t) => t.entityId)).toEqual(["r1"]);
 	});
 });

--- a/app/src/modules/history/sidebar/HistoryList.tsx
+++ b/app/src/modules/history/sidebar/HistoryList.tsx
@@ -49,7 +49,7 @@ function deleteRunErrorMessage(error: unknown): string {
 }
 
 export default function HistoryList() {
-	const { openTab, openTabs, activeTabId } = useTabsStore();
+	const { openTab, openTabs, activeTabId, closeTabsForEntities } = useTabsStore();
 	const { activateDrawerView } = useLayoutStore();
 	const {
 		searchQuery,
@@ -140,6 +140,9 @@ export default function HistoryList() {
 		setDeletingId(runIdToDelete);
 		try {
 			await deleteRunMutation.mutateAsync(runIdToDelete);
+			// The run is gone; its tabs are persisted, so leaving them open would
+			// rehydrate a pane for a run that cannot load on every restart.
+			closeTabsForEntities([runIdToDelete], "run");
 			if (selectedRunId === runIdToDelete) {
 				navigateToHistory();
 			}

--- a/app/src/modules/settings/main/panels/GeneralPanel.clear-history.test.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.clear-history.test.tsx
@@ -25,6 +25,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useTabsStore } from "@/stores";
 import GeneralPanel from "./GeneralPanel";
 
 const deleteRun = vi.fn((_id: string) => Promise.resolve());
@@ -78,6 +79,26 @@ describe("GeneralPanel - clear run history", () => {
 
 		await waitFor(() => expect(deleteRun).toHaveBeenCalledTimes(runs.length));
 		expect(confirmSpy).not.toHaveBeenCalled();
+	});
+
+	it("closes the run tabs it emptied, and only those the engine accepted", async () => {
+		// r2's delete is refused (a run still stopping answers 409), so its run
+		// is still there and its tab has to stay. Tabs persist, so a tab left
+		// open for a deleted run comes back as a dead pane on the next launch.
+		deleteRun.mockImplementation((id: string) =>
+			id === "r2" ? Promise.reject(new Error("still stopping")) : Promise.resolve()
+		);
+		useTabsStore.setState({ openTabs: [], activeTabId: null });
+		useTabsStore.getState().openTab({ type: "run", entityId: "r1" });
+		useTabsStore.getState().openTab({ type: "run", entityId: "r2" });
+
+		render(<GeneralPanel />);
+		fireEvent.click(screen.getByRole("button", { name: /clear run history/i }));
+		fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
+
+		await waitFor(() =>
+			expect(useTabsStore.getState().openTabs.map((t) => t.entityId)).toEqual(["r2"])
+		);
 	});
 
 	it("deletes nothing when the dialog is cancelled", async () => {

--- a/app/src/modules/settings/main/panels/GeneralPanel.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui";
 import { modKey } from "@/lib/platform";
 import { useClientSettingsStore } from "@/stores";
-import { useToastStore } from "@/stores";
+import { useToastStore, useTabsStore } from "@/stores";
 import { useAllRunsQuery, useInvalidateRuns } from "@/queries/runs";
 import { apiService } from "@/services";
 import { AUTO_SAVE_DELAY_OPTIONS } from "@/constants/client-settings";
@@ -53,6 +53,7 @@ export default function GeneralPanel() {
 	// not just a polled page.
 	const { data: runs = [] } = useAllRunsQuery();
 	const invalidateRuns = useInvalidateRuns();
+	const closeTabsForEntities = useTabsStore((s) => s.closeTabsForEntities);
 	const showToast = useToastStore((s) => s.showToast);
 	const [clearing, setClearing] = useState(false);
 	const [confirmClear, setConfirmClear] = useState(false);
@@ -81,6 +82,13 @@ export default function GeneralPanel() {
 		try {
 			const results = await Promise.allSettled(runs.map((r) => apiService.deleteRun(r.id)));
 			const failed = results.filter((r) => r.status === "rejected").length;
+			// Close the tab of every run that actually went away - by index, so a
+			// run the engine refused (a 409 while it is still stopping) keeps its
+			// tab. Without this the tabs persist and rehydrate as dead panes.
+			closeTabsForEntities(
+				runs.filter((_, i) => results[i].status === "fulfilled").map((r) => r.id),
+				"run"
+			);
 			invalidateRuns();
 			showToast(
 				failed === 0

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -44,9 +44,10 @@ export {
 	useRunReportQuery,
 	useLastDesignRunQuery,
 	useDeleteRunMutation,
-	useAddRunToCache,
 	useInvalidateRuns,
+	isRunNotFound,
 } from "./runs";
+export { RunNotFoundError } from "./runs";
 
 // Environments
 export {

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -41,6 +41,13 @@ export const queryKeys = {
 		// invalidate/patch every variant at once.
 		list: (filters: Record<string, unknown> = {}) =>
 			[...queryKeys.runs.lists(), filters] as const,
+		// The last completed design run for a request is one row cached as a
+		// plain `RunListResponse`, so it must NOT sit under `lists()`: the
+		// delete-run patch walks every cache under that prefix as `InfiniteData`
+		// and threw on this shape (`old.pages` undefined) for any open request
+		// tab. Its own family keeps the two apart at the root.
+		lastDesign: (requestId: string) =>
+			[...queryKeys.runs.all, "lastDesign", requestId] as const,
 		allRuns: () => [...queryKeys.runs.all, "allRuns"] as const,
 		details: () => [...queryKeys.runs.all, "detail"] as const,
 		detail: (id: string) => [...queryKeys.runs.details(), id] as const,

--- a/app/src/queries/runs.query.test.tsx
+++ b/app/src/queries/runs.query.test.tsx
@@ -23,16 +23,31 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useLastDesignRunQuery, useRunsQuery, flattenRunPages } from "./runs";
+import {
+	useLastDesignRunQuery,
+	useRunsQuery,
+	flattenRunPages,
+	runsPollInterval,
+	runDetailOptions,
+	useDeleteRunMutation,
+	RunNotFoundError,
+	isRunNotFound,
+} from "./runs";
+import { queryKeys } from "./keys";
+import { ApiError } from "@/services";
 import type { RunListResponse } from "@/types";
 
 const listRuns = vi.fn();
 const getRunReport = vi.fn();
+const getRun = vi.fn();
+const deleteRun = vi.fn();
 
 vi.mock("@/services/api", () => ({
 	apiService: {
 		listRuns: (...a: unknown[]) => listRuns(...a),
 		getRunReport: (...a: unknown[]) => getRunReport(...a),
+		getRun: (...a: unknown[]) => getRun(...a),
+		deleteRun: (...a: unknown[]) => deleteRun(...a),
 	},
 }));
 
@@ -63,7 +78,13 @@ function wrapper(client: QueryClient) {
 beforeEach(() => {
 	listRuns.mockReset();
 	getRunReport.mockReset();
+	getRun.mockReset();
+	deleteRun.mockReset();
 });
+
+function runRow(id: string) {
+	return { id, type: "load", status: "completed", startTime: 1, endTime: 2 } as const;
+}
 
 describe("useLastDesignRunQuery", () => {
 	it("issues one filtered single-run call, not a full-list scan", async () => {
@@ -178,5 +199,125 @@ describe("flattenRunPages", () => {
 
 	it("is empty for undefined", () => {
 		expect(flattenRunPages(undefined)).toEqual([]);
+	});
+});
+
+/**
+ * The delete-run patch walks *every* cache under the `runs.lists()` prefix and
+ * treats each as `InfiniteData`. `useLastDesignRunQuery` caches a plain
+ * `RunListResponse`, and `RequestBuilderProvider` mounts it for every open
+ * request tab - so with one request tab open, deleting a run threw a TypeError
+ * inside the mutation's own `onSuccess`: the engine had deleted the run, but the
+ * row lingered, the all-runs patch and the report eviction never ran, and the
+ * user saw "Couldn't delete run".
+ *
+ * Fixed at the root (its own key family) with a shape guard as the belt. The
+ * three tests below pin the two halves separately, so reverting either is red.
+ */
+describe("useDeleteRunMutation with a foreign cache shape under the runs prefix", () => {
+	function seededClient() {
+		const client = makeClient();
+		client.setQueryData(queryKeys.runs.list({ q: undefined }), {
+			pages: [page([runRow("r1"), runRow("r2")], { total: 2 })],
+			pageParams: [0],
+		});
+		client.setQueryData(queryKeys.runs.allRuns(), [runRow("r1"), runRow("r2")]);
+		return client;
+	}
+
+	it("keys the last-design-run lookup outside the infinite-list prefix", () => {
+		const lists = queryKeys.runs.lists() as readonly unknown[];
+		const lastDesign = queryKeys.runs.lastDesign("req_1") as readonly unknown[];
+		// Not a prefix match: `setQueriesData({queryKey: lists()})` must not reach it.
+		expect(lastDesign.slice(0, lists.length)).not.toEqual([...lists]);
+	});
+
+	it("deletes cleanly with a last-design-run cache present, and patches every cache", async () => {
+		const client = seededClient();
+		client.setQueryData(queryKeys.runs.report("r1"), { summary: {} });
+		deleteRun.mockResolvedValue(undefined);
+
+		// Populated by the hook itself, not by hand - what an open request tab
+		// leaves in the cache is only wrong if the *hook* keys it under
+		// `lists()`, so the hook is what has to write it.
+		listRuns.mockResolvedValue(page([runRow("r1")]));
+		getRunReport.mockResolvedValue({ summary: {} });
+		const design = renderHook(() => useLastDesignRunQuery("req_1"), {
+			wrapper: wrapper(client),
+		});
+		await waitFor(() => expect(design.result.current.run?.id).toBe("r1"));
+
+		const { result } = renderHook(() => useDeleteRunMutation(), {
+			wrapper: wrapper(client),
+		});
+
+		await result.current.mutateAsync("r1");
+
+		const list = client.getQueryData(queryKeys.runs.list({ q: undefined })) as {
+			pages: RunListResponse[];
+		};
+		expect(list.pages[0].data.map((r) => r.id)).toEqual(["r2"]);
+		expect(list.pages[0].pagination.total).toBe(1);
+		// The two patches that used to be skipped because the first one threw.
+		expect(client.getQueryData(queryKeys.runs.allRuns())).toEqual([runRow("r2")]);
+		expect(client.getQueryData(queryKeys.runs.report("r1"))).toBeUndefined();
+	});
+
+	it("leaves a non-paged cache under the list prefix alone instead of throwing on it", async () => {
+		const client = seededClient();
+		// The pre-fix key, written by hand: the guard is what stops any future
+		// plain-shaped cache under this prefix from breaking the delete again.
+		const strayKey = queryKeys.runs.list({ requestId: "req_1", limit: 1 });
+		client.setQueryData(strayKey, page([runRow("r1")]));
+		deleteRun.mockResolvedValue(undefined);
+
+		const { result } = renderHook(() => useDeleteRunMutation(), {
+			wrapper: wrapper(client),
+		});
+
+		await expect(result.current.mutateAsync("r1")).resolves.toBeUndefined();
+		// Untouched - the updater does not know this shape and says so by refusing it.
+		expect(client.getQueryData(strayKey)).toEqual(page([runRow("r1")]));
+	});
+});
+
+/**
+ * A deleted run and an unreachable engine are different answers, and a run tab
+ * outlives its run (tabs are persisted). Retrying a 404 forever is what the
+ * global `retry: 2` did to a zombie tab.
+ */
+describe("runDetailOptions", () => {
+	it("maps only a 404 to RunNotFoundError, rethrowing anything else untouched", async () => {
+		const { queryFn } = runDetailOptions("run_1");
+
+		getRun.mockRejectedValueOnce(new ApiError(404, "NOT_FOUND", "HTTP 404", {}));
+		await expect(queryFn()).rejects.toBeInstanceOf(RunNotFoundError);
+
+		const transport = new Error("Network error: engine unreachable");
+		getRun.mockRejectedValueOnce(transport);
+		await expect(queryFn()).rejects.toBe(transport);
+	});
+
+	it("never retries a deletion, but still retries a transport failure", () => {
+		const { retry } = runDetailOptions("run_1");
+
+		expect(retry(0, new RunNotFoundError("run_1"))).toBe(false);
+		expect(retry(0, new Error("Failed to fetch"))).toBe(true);
+	});
+
+	it("discriminates by type, not by message", () => {
+		expect(isRunNotFound(new RunNotFoundError("run_1"))).toBe(true);
+		expect(isRunNotFound(new Error("Run run_1 no longer exists"))).toBe(false);
+	});
+});
+
+describe("runsPollInterval", () => {
+	it("polls the unpaged list and stops once older pages are loaded", () => {
+		// Refetching an infinite query refetches every loaded page, so a user ten
+		// pages deep drove ~10 requests per tick.
+		expect(runsPollInterval(0)).toBe(5000);
+		expect(runsPollInterval(1)).toBe(5000);
+		expect(runsPollInterval(2)).toBe(false);
+		expect(runsPollInterval(10)).toBe(false);
 	});
 });

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -19,6 +19,7 @@ import {
 	type InfiniteData,
 } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
+import { ApiError } from "@/services";
 import { queryKeys } from "./keys";
 import { QUERY_CACHE } from "@/config/cache";
 import { STATS_PAGE_LIMIT, RUNS_PAGE_LIMIT } from "@/config/network";
@@ -26,6 +27,22 @@ import type { Run, RunListResponse } from "@/types";
 import type { TimeSeriesResponse } from "@/modules/history/types";
 
 // ============ Run Queries ============
+
+/** How often the unpaged run list re-asks the engine. */
+const RUNS_POLL_MS = 5000;
+
+/**
+ * Polling is gated to the unpaged state on purpose.
+ *
+ * Refetching an infinite query re-fetches *every* loaded page in sequence, so a
+ * user ten pages deep drove ~10 engine requests every 5s for as long as the
+ * drawer stayed open. Only page 1 can gain rows anyway (`start_time DESC`), and
+ * paging older runs in is an explicit act - once the user has done it the list
+ * refreshes on the next mutation or invalidation instead of on a timer.
+ */
+export function runsPollInterval(loadedPages: number): number | false {
+	return loadedPages > 1 ? false : RUNS_POLL_MS;
+}
 
 /**
  * Fetch run history as an infinite query over the `{data, pagination}`
@@ -48,7 +65,7 @@ export function useRunsQuery(q?: string) {
 			lastPage.pagination.hasMore
 				? lastPage.pagination.offset + lastPage.pagination.limit
 				: undefined,
-		refetchInterval: 5000, // 5 seconds
+		refetchInterval: (query) => runsPollInterval(query.state.data?.pages.length ?? 0),
 	});
 }
 
@@ -90,6 +107,29 @@ export function useAllRunsQuery() {
 }
 
 /**
+ * A run that the engine says is gone, as opposed to an engine that did not
+ * answer. Deleting a run is permanent and its tab can outlive it (a persisted
+ * tab rehydrates on the next launch), so the pane has to tell "this was
+ * deleted - close the tab" from "the engine is down - try again". Callers
+ * discriminate with `isRunNotFound`, never by matching the message.
+ *
+ * The same contract `RequestNotFoundError` carries for requests.
+ */
+export class RunNotFoundError extends Error {
+	readonly runId: string;
+	constructor(runId: string) {
+		super(`Run ${runId} no longer exists`);
+		this.name = "RunNotFoundError";
+		this.runId = runId;
+	}
+}
+
+/** True only for a genuine deletion, never for a transport failure. */
+export function isRunNotFound(error: unknown): error is RunNotFoundError {
+	return error instanceof RunNotFoundError;
+}
+
+/**
  * Fetch one run, including its configSnapshot and - for a design run - the
  * stored exchange. The report is a load-test aggregate and carries no
  * configuration for a design run, so this is the only source for it.
@@ -98,8 +138,23 @@ export function useAllRunsQuery() {
 export function runDetailOptions(runId: string | null) {
 	return {
 		queryKey: queryKeys.runs.detail(runId ?? ""),
-		queryFn: () => apiService.getRun(runId!),
+		queryFn: async () => {
+			try {
+				return await apiService.getRun(runId!);
+			} catch (error) {
+				// A definitive deletion, distinct from a transport failure.
+				if (error instanceof ApiError && error.statusCode === 404) {
+					throw new RunNotFoundError(runId!);
+				}
+				throw error;
+			}
+		},
 		enabled: !!runId,
+		// Never retry a real deletion - a 404 is final, and a zombie run tab
+		// retrying it forever is exactly what the global retry produced. A
+		// transport failure still gets the default budget.
+		retry: (count: number, error: unknown) =>
+			!isRunNotFound(error) && count < QUERY_CACHE.DEFAULT_QUERY_RETRY,
 		staleTime: QUERY_CACHE.RUNS_STALE_TIME_MS,
 	};
 }
@@ -153,12 +208,8 @@ export function useRunTimeSeriesQuery(runId: string | null) {
  */
 export function useLastDesignRunQuery(requestId: string | null | undefined) {
 	const { data, isLoading: runLoading } = useQuery({
-		queryKey: queryKeys.runs.list({
-			requestId: requestId ?? "",
-			type: "design",
-			status: "completed",
-			limit: 1,
-		}),
+		// Its own key family, not `runs.list(...)` - see `queryKeys.runs.lastDesign`.
+		queryKey: queryKeys.runs.lastDesign(requestId ?? ""),
 		queryFn: () =>
 			apiService.listRuns({
 				requestId: requestId!,
@@ -198,7 +249,10 @@ export function useDeleteRunMutation() {
 			queryClient.setQueriesData<InfiniteData<RunListResponse>>(
 				{ queryKey: queryKeys.runs.lists() },
 				(old) => {
-					if (!old) return old;
+					// Belt to `runs.lastDesign`'s braces: a prefix patch must never
+					// assume the shape of a cache it did not write. Anything that is
+					// not paged is left alone rather than thrown on.
+					if (!old || !Array.isArray(old.pages)) return old;
 					return {
 						...old,
 						pages: old.pages.map((page) => {
@@ -228,39 +282,6 @@ export function useDeleteRunMutation() {
 			});
 		},
 	});
-}
-
-/**
- * Add a new run to the front of the first list page (after starting a load
- * test), so it shows immediately without waiting for the next poll.
- */
-export function useAddRunToCache() {
-	const queryClient = useQueryClient();
-
-	return (newRun: Run) => {
-		queryClient.setQueriesData<InfiniteData<RunListResponse>>(
-			{ queryKey: queryKeys.runs.lists() },
-			(old) => {
-				if (!old || old.pages.length === 0) return old;
-				const [first, ...rest] = old.pages;
-				return {
-					...old,
-					pages: [
-						{
-							...first,
-							data: [newRun, ...first.data],
-							pagination: {
-								...first.pagination,
-								total: first.pagination.total + 1,
-								returned: first.data.length + 1,
-							},
-						},
-						...rest,
-					],
-				};
-			}
-		);
-	};
 }
 
 /**

--- a/app/src/services/load-test-service.test.ts
+++ b/app/src/services/load-test-service.test.ts
@@ -12,9 +12,13 @@ const mockSetError = vi.fn();
 const mockSetFinalReport = vi.fn();
 const mockReset = vi.fn();
 const mockAddMetricsBatch = vi.fn();
+// Which run the dashboard is showing *right now* - re-read after every await,
+// which is the whole point of the guard under test.
+const dashboard = { currentRunId: null as string | null };
 vi.mock("@/stores", () => ({
 	useDashboardStore: {
 		getState: () => ({
+			currentRunId: dashboard.currentRunId,
 			setStreaming: mockSetStreaming,
 			setError: mockSetError,
 			setFinalReport: mockSetFinalReport,
@@ -22,6 +26,7 @@ vi.mock("@/stores", () => ({
 			addMetricsBatch: mockAddMetricsBatch,
 		}),
 	},
+	useClientSettingsStore: { getState: () => ({ liveRefreshMs: 0 }) },
 }));
 vi.mock("./sse-client", () => ({ sseClient: { connect: vi.fn(), disconnect: vi.fn() } }));
 vi.mock("./api", () => ({
@@ -32,8 +37,16 @@ import { loadTestService } from "./load-test-service";
 import { sseClient } from "./sse-client";
 import { apiService } from "./api";
 
+/** `handleClose` is private; the SSE client is what calls it in production. */
+function closeStream(): Promise<void> {
+	return (loadTestService as unknown as { handleClose: () => Promise<void> }).handleClose();
+}
+
 describe("LoadTestService", () => {
-	beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => {
+		vi.clearAllMocks();
+		dashboard.currentRunId = null;
+	});
 	afterEach(() => loadTestService.stopMonitoring());
 
 	it("connects to SSE synchronously (no setTimeout delay)", () => {
@@ -48,10 +61,40 @@ describe("LoadTestService", () => {
 	});
 
 	it("fetches the stored report once when the run completes (terminal convergence)", async () => {
+		dashboard.currentRunId = "run_2";
 		loadTestService.startMonitoring("run_2");
-		await (loadTestService as unknown as { handleClose: () => Promise<void> }).handleClose();
+		await closeStream();
 		expect(apiService.getRunReport).toHaveBeenCalledWith("run_2");
 		expect(mockSetFinalReport).toHaveBeenCalled();
+	});
+
+	/*
+	 * Finish run A, start run B before A's report comes back. The fetch is one
+	 * local round trip, so the window is small and entirely reachable: A's
+	 * report landed on B's dashboard, flipping a running test to "completed"
+	 * with A's percentiles. The store is therefore re-read *after* the await,
+	 * not captured before it.
+	 */
+	it("drops a finished run's report when the dashboard has moved to another run", async () => {
+		dashboard.currentRunId = "run_A";
+		loadTestService.startMonitoring("run_A");
+
+		let release: () => void = () => {};
+		vi.mocked(apiService.getRunReport).mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					release = () => resolve({ summary: {}, latency: {} } as never);
+				})
+		);
+
+		const closed = closeStream();
+		// The user starts run B while A's report is still in flight.
+		dashboard.currentRunId = "run_B";
+		release();
+		await closed;
+
+		expect(apiService.getRunReport).toHaveBeenCalledWith("run_A");
+		expect(mockSetFinalReport).not.toHaveBeenCalled();
 	});
 
 	// Regression guard: the caller invokes store.startRun() first (which registers

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -15,6 +15,9 @@
 
 import { sseClient } from "./sse-client";
 import { apiService } from "./api";
+import { queryClient } from "@/lib/query-client";
+import { queryKeys } from "@/queries/keys";
+import { QUERY_CACHE } from "@/config/cache";
 import { useDashboardStore, useClientSettingsStore } from "@/stores";
 import type { LoadTestMetrics } from "@/types";
 // Engine emits at 10 Hz (100ms cadence - see engine/src/http/routes/metrics.cpp).
@@ -157,13 +160,32 @@ class LoadTestService {
 		// Fetch the canonical final report from the engine and store it so the
 		// dashboard shows definitive completed-view data (final percentiles, reconciled
 		// error rate, setup overhead) - one terminal truth, same as the 404-path.
+		//
+		// Through the query cache, not a bare fetch: opening the same run in
+		// History reads `runs.report(runId)` and would otherwise re-fetch a
+		// report that cannot change.
 		if (runId) {
 			try {
-				const report = await apiService.getRunReport(runId);
-				store.setFinalReport(report);
+				const report = await queryClient.fetchQuery({
+					queryKey: queryKeys.runs.report(runId),
+					queryFn: () => apiService.getRunReport(runId),
+					staleTime: QUERY_CACHE.RUNS_STALE_TIME_MS,
+				});
+				// Re-read the store *after* the await. Finishing run A and
+				// immediately starting run B leaves this continuation holding A's
+				// report while the dashboard shows B; applying it flipped B to
+				// "completed" with A's percentiles. The window is one local round
+				// trip, which is exactly long enough.
+				if (useDashboardStore.getState().currentRunId === runId) {
+					useDashboardStore.getState().setFinalReport(report);
+				}
 			} catch (e) {
 				console.warn("[LoadTestService] report fetch failed", e);
 			}
+			// The run has reached a terminal state, so the lists that carry its
+			// status are stale until the next 5s poll - and once the user has
+			// paged History, that poll is off.
+			void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
 			this.activeRunId = null;
 		}
 	}

--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -72,6 +72,28 @@ describe("closeTabsForEntities", () => {
 		expect(useTabsStore.getState().openTabs).toEqual(before.openTabs);
 		expect(useTabsStore.getState().activeTabId).toBe(before.activeTabId);
 	});
+
+	it("closes only the named kind of tab when a type is given", () => {
+		// Deleting a run must not reach a request tab that happens to carry the
+		// same id. Ids are engine-generated and do not collide, so this is about
+		// the call site stating what a deletion is allowed to close.
+		useTabsStore.getState().openTab({ type: "run", entityId: "x" });
+		openRequests(["x"]);
+
+		useTabsStore.getState().closeTabsForEntities(["x"], "run");
+
+		const { openTabs } = useTabsStore.getState();
+		expect(openTabs.map((t) => t.type)).toEqual(["request"]);
+	});
+
+	it("still closes every kind when no type is given", () => {
+		useTabsStore.getState().openTab({ type: "run", entityId: "x" });
+		openRequests(["x"]);
+
+		useTabsStore.getState().closeTabsForEntities(["x"]);
+
+		expect(useTabsStore.getState().openTabs).toHaveLength(0);
+	});
 });
 
 /**

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -39,8 +39,16 @@ interface TabsState {
 
 	openTab: (tab: Omit<Tab, "id">) => void;
 	closeTab: (tabId: string) => void;
-	/** Close every tab bound to one of the given entity ids (e.g. after deletion). */
-	closeTabsForEntities: (entityIds: Iterable<string>) => void;
+	/**
+	 * Close every tab bound to one of the given entity ids (e.g. after deletion).
+	 *
+	 * `type` narrows the sweep to one kind of tab. Ids are engine-generated and
+	 * do not collide across families, so it is not needed for correctness - it
+	 * states at the call site which tabs a deletion is allowed to close, which
+	 * is the difference between "close the run tabs for these deleted runs" and
+	 * "close whatever happens to carry these ids".
+	 */
+	closeTabsForEntities: (entityIds: Iterable<string>, type?: TabType) => void;
 	focusTab: (tabId: string) => void;
 	/** Replace the active tab in place (used when welcome tab spawns a request) */
 	replaceActiveTab: (tab: Omit<Tab, "id">) => void;
@@ -161,11 +169,14 @@ export const useTabsStore = create<TabsState>()(
 				set({ openTabs: remaining, activeTabId: nextActiveId });
 			},
 
-			closeTabsForEntities: (entityIds) => {
+			closeTabsForEntities: (entityIds, type) => {
 				const ids = new Set(entityIds);
 				if (ids.size === 0) return;
 				const { openTabs, activeTabId } = get();
-				const shouldClose = (t: Tab) => t.entityId !== null && ids.has(t.entityId);
+				const shouldClose = (t: Tab) =>
+					t.entityId !== null &&
+					ids.has(t.entityId) &&
+					(type === undefined || t.type === type);
 
 				const remaining = openTabs.filter((t) => !shouldClose(t));
 				if (remaining.length === openTabs.length) return; // nothing matched

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -477,10 +477,14 @@ Located in `app/src/services/queries/` (or `hooks/`), with types and cache inval
 - **`useRunsQuery(q?)`** - Run history as an **infinite query** over the
   paginated `GET /runs` `{data, pagination}` envelope, newest first. Mirrors
   `useRunTimeSeriesQuery`'s `getNextPageParam` on the same envelope shape;
-  `fetchNextPage` pages older runs in on demand. The 5s `refetchInterval` keeps
-  the loaded pages fresh - in the default (unpaged) state that is **only the
-  first page**, so new runs (which land on page 1 under `start_time DESC`)
-  appear without re-fetching older pages. `q` is the optional server-side search.
+  `fetchNextPage` pages older runs in on demand. `q` is the optional
+  server-side search.
+  - **Polling is gated to the unpaged state** (`runsPollInterval`): 5s while
+    only page 1 is loaded, **off** once the user has paged older runs in.
+    Refetching an infinite query re-fetches *every* loaded page in sequence, so
+    a user ten pages deep drove ~10 engine requests per tick. Only page 1 can
+    gain rows (`start_time DESC`) anyway; a paged list refreshes on the next
+    mutation or invalidation instead of on a timer.
   - **`flattenRunPages(data)`** - flatten the pages into a de-duped `Run[]`
     (dedupe by id guards the momentary double-row a head insertion can cause
     across two refetched pages). **`runsTotal(data)`** - the server's total from
@@ -492,15 +496,39 @@ Located in `app/src/services/queries/` (or `hooks/`), with types and cache inval
   for a request, in **one** filtered call
   (`?requestId=&type=design&status=completed&limit=1`) - the server sorts
   `start_time DESC`, so its single row is the answer. No client-side
-  download-and-filter.
-- **`useRunQuery(runId)`** - Fetch single run (full `configSnapshot`)
-- **`useRunReportQuery(runId)`** - Fetch final report for a run
+  download-and-filter. It caches a **plain `RunListResponse`**, so it has its
+  own key family (`queryKeys.runs.lastDesign(requestId)`) and deliberately does
+  **not** sit under `runs.lists()`: `RequestBuilderProvider` mounts it for every
+  open request tab, and the delete-run patch walks that prefix as
+  `InfiniteData`. Keeping the two shapes apart at the root is the rule - a
+  prefix patch must never meet a cache shape it did not write.
+- **`useRunQuery(runId)`** / **`runDetailOptions(runId)`** - Fetch a single run
+  (full `configSnapshot`). Same 404 contract as `requestDetailOptions`: only an
+  `ApiError` with `statusCode === 404` becomes **`RunNotFoundError`** (test it
+  with `isRunNotFound`, never by message), and that error is **never retried** -
+  a run tab is persisted and outlives its run, so a deleted run used to retry
+  forever behind a "Try again" that could not work. Everything else - a 5xx, an
+  unreachable engine - is rethrown untouched and keeps the default retry budget.
+  `HistoryDetail` renders the two cases differently: "this run no longer exists"
+  with **Close tab**, versus "couldn't load this run" with **Try again**.
+- **`useRunReportQuery(runId)`** - Fetch final report for a run. Also written by
+  `LoadTestService` at stream end via `queryClient.fetchQuery`, so opening the
+  run in History reads the cached copy rather than re-fetching a report that
+  cannot change.
 
 **Mutations:**
 - **`useStopRunMutation()`** - Stop a running load test
 - **`useDeleteRunMutation()`** - Delete a run. Patches every infinite-list cache
   variant in place (drops the row, decrements the mirrored `total`) plus the
-  all-runs cache.
+  all-runs cache, and evicts the run's report. The list updater shape-guards
+  (`!Array.isArray(old.pages)`) as a belt to `lastDesign`'s braces.
+
+**Deleting a run closes its tabs.** Both delete flows - `HistoryList`'s row
+delete and Settings' *Clear run history* - call
+`closeTabsForEntities(ids, "run")` for the runs the engine actually accepted (a
+409'd run keeps its tab, because the run is still there). Tabs are persisted, so
+a run tab left open after its run is gone is not merely stale: it rehydrates
+into a pane that can never load on every restart.
 
 #### Engine Health & Config
 
@@ -810,8 +838,8 @@ const { draft, setDraft, isDirty, reset } = useEntityDraft({
 6. As metrics stream in, `addMetricsBatch()` efficiently folds them into historical metrics (capped at 3,000) and updates running aggregates (peak concurrency, SLO breakpoint)
 7. Dashboard view shows live metrics, request/response (from the SSE stream's final response), and aggregates
 8. When the run completes, the engine sends a `complete` event
-9. `useRunReportQuery(runId)` fetches the final report and is stored in `dashboard-store.finalReport`
-10. Dashboard switches to "completed" mode showing the final report
+9. `LoadTestService.handleClose()` fetches the final report through the query cache (under `queryKeys.runs.report(runId)`, so History reuses it) and stores it in `dashboard-store.finalReport` - **only if the dashboard is still showing that run**. The store is re-read after the await: finishing run A and immediately starting run B otherwise landed A's report on B's dashboard, flipping a running test to "completed" with A's percentiles.
+10. Dashboard switches to "completed" mode showing the final report; the runs lists are invalidated so the terminal status lands without waiting for a poll
 
 ### Saving a Request with Auto-Save
 


### PR DESCRIPTION
## Description

All seven anchors from #238 were re-verified on current master (`469b90c`) before any edit - each still reproduces as described, at the stated lines.

**Plan.** The root cause of the headline defect is a prefix patch meeting a cache shape it did not write: `useDeleteRunMutation` walks every cache under `runs.lists()` as `InfiniteData`, and `useLastDesignRunQuery` cached a plain `RunListResponse` under that same prefix - mounted by `RequestBuilderProvider` for every open request tab. The fix is at the root (its own key family, `runs.lastDesign`) rather than only defensive, because a guard alone leaves the next plain-shaped cache under that prefix free to reappear; the guard is kept as the belt. The alternative I rejected was making the last-design lookup an infinite query so the shapes match - it would satisfy the patch, but it dresses a deliberate single-row lookup (`limit=1`, one round trip) up as a paginated one and invites `fetchNextPage` on something that has no next page. The remaining five are independent edge cases at the same lifecycle boundary, each fixed where it lives.

### 1+2. Delete-run cache patch (`queries/runs.ts`, `queries/keys.ts`)

`useLastDesignRunQuery` now keys on `queryKeys.runs.lastDesign(requestId)`. The list updater additionally shape-guards (`!old || !Array.isArray(old.pages)`). Effect: with a request tab open, deleting a run removes the row immediately, and the two patches that used to be skipped because the first one threw - the all-runs cache and the report eviction - now run.

`useAddRunToCache` is **deleted** rather than wired. It had zero consumers, its docblock described behaviour the start-load-test path never asked for (that path opens the dashboard tab; the run appears via the list poll), and it carried the same latent `old.pages.length` bug. Deleting the dead copy is the smaller diff and removes the trap.

### 3. Run tabs outliving their runs

`closeTabsForEntities` grows an optional `type` narrowing, and both delete flows use it: `HistoryList`'s row delete after the mutation resolves, and Settings' *Clear run history* for the runs whose `allSettled` entry was `fulfilled` - a run the engine refused with a 409 is still there, so its tab stays. Ids do not collide across families, so the type parameter is not needed for correctness; it states at the call site which tabs a deletion is allowed to close. Existing callers (`CollectionTree`) are unchanged.

### 4. 404 vs transport on a run lookup

`runDetailOptions` copies `requestDetailOptions` exactly: only `ApiError` with `statusCode === 404` becomes `RunNotFoundError`, discriminated by `isRunNotFound` and never by message; that error is not retried, everything else keeps the default budget. `HistoryDetail` renders the two apart - "This run no longer exists" with **Close tab** (no retry offered, since a 404 can only 404 again), versus the existing "Couldn't load this run" with **Try again**. No new retry constant: the transport path reuses `QUERY_CACHE.DEFAULT_QUERY_RETRY`, which is what it was already getting globally.

### 5+6. Stale report race, and the report fetched outside the cache

`LoadTestService.handleClose` re-reads `useDashboardStore.getState()` **after** the await and applies the report only if `currentRunId` still matches the run it fetched for. It fetches through `queryClient.fetchQuery` under `queryKeys.runs.report(runId)`, so opening that run in History reuses it, and invalidates `runs.lists()` at stream end so the terminal status lands without waiting on a poll. Importing the singleton query client into a service follows `services/api.ts`, which already does.

### 7. Deep-pagination refetch storm

Polling is gated to the unpaged state via a small exported `runsPollInterval(loadedPages)`: 5s at 0-1 pages, off beyond that. Extracted rather than left inline so it is testable without fake timers around an infinite query. A paged list refreshes on the next mutation/invalidation instead of on a timer - the trade the issue proposed, and only page 1 can gain rows under `start_time DESC` anyway.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **245 files, 2150 tests, all passing** (2136 on the base commit; 14 new). `pnpm type-check` clean. App-only change, so no engine build/ctest: no C++, CMake or engine test file is in the diff, and the issue's own Tests section lists `pnpm test` only.

New, all mutation-checked (fix reverted, test confirmed red, fix restored):

- `queries/runs.query.test.tsx` (+7) - the delete-run patch with a last-design cache **populated by the hook itself** rather than by hand, since keying it by hand would not notice the hook drifting back under `lists()`: the delete resolves, the row goes, and the all-runs + report patches both land. Reverting the key split *and* the shape guard fails it; a separate test pins the stray non-paged cache under the list prefix, and another pins that `lastDesign` is not a prefix match for `lists()`. Plus the `RunNotFoundError` mapping (404 → mapped, transport → rethrown by identity), the retry predicate, that discrimination is by type and not by message, and the poll gate.
- `services/load-test-service.test.ts` (+1) - run A's report is held open on a deferred promise, `currentRunId` is flipped to run B mid-flight, and `setFinalReport` must not be called. Fails when the guard is removed.
- `stores/tabs-store.test.ts` (+2) - the type narrowing closes the run tab and spares a request tab carrying the same id; without a type it still closes both.
- `modules/history/sidebar/HistoryList.delete.test.tsx` (+2) - a successful delete closes the run's tab; a 409 leaves it open.
- `modules/settings/main/panels/GeneralPanel.clear-history.test.tsx` (+1) - Clear history closes the tabs of the runs that were accepted and keeps the one whose delete was rejected.
- `modules/history/main/HistoryDetail.states.test.tsx` (+1) - a `RunNotFoundError` renders "this run no longer exists" with a working Close tab and **no** Try again. Uses the real `isRunNotFound` via `importActual`, since a stubbed predicate would assert nothing about the discrimination this pane exists to make.

One honest limit worth stating: the "deletes cleanly" test goes red only when **both** the key split and the shape guard are reverted, because either alone prevents the throw. The two halves are pinned individually by the two adjacent tests.

ESLint on the touched files reports the same 2 pre-existing errors in `HistoryList.tsx` (`no-explicit-any`, lines unchanged apart from the offset) as the base commit - part of #189, not touched here. Prettier was run only on `queries/keys.ts`, the one touched file that was clean beforehand.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/app/state-management.md` is updated in the same commit: the poll gate on `useRunsQuery`, why `useLastDesignRunQuery` has its own key family, the `RunNotFoundError` contract and the two error panes, the report's cache write, the delete mutation's shape guard and report eviction, the "deleting a run closes its tabs" rule, and steps 9-10 of the load-test flow example (which credited the report fetch to `useRunReportQuery`). Coordinated with #241 by staying inside this delta - no wholesale rewrite of that page here.

## Related Issues
Closes #238

---
_Generated by [Claude Code](https://claude.ai/code/session_017WEp1Ua6eZwXbSMV7XAMyc)_