### PR TITLE
fix(app): zombie ids and invalidation gaps - dangling environment id, orphaned collection scope, under-invalidated cascade

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,6 +18,7 @@ import {
 	useRunsQuery,
 } from "./queries";
 import { useElectronTheme } from "./hooks/useElectronTheme";
+import { useActiveEnvironmentGuard } from "./hooks/useActiveEnvironmentGuard";
 import { useAppearance } from "./hooks/useAppearance";
 import { useScriptCompletionProvider } from "./hooks/useScriptCompletionProvider";
 import { useVariableCompletionProvider } from "./hooks/useVariableCompletionProvider";
@@ -35,6 +36,10 @@ function App() {
 
 	// Initialize health check with automatic polling
 	useHealthQuery();
+
+	// Drop a persisted environment id whose environment the engine no longer has
+	// - it would otherwise keep riding on every composed payload.
+	useActiveEnvironmentGuard();
 
 	// Prefetch collections and all their requests (TanStack handles caching automatically)
 	usePrefetchCollectionsAndRequests();

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -10,6 +10,7 @@ export { useEngine } from "./useEngine";
 export { useSaveManager } from "./useSaveManager";
 export { useEntityDraft } from "./useEntityDraft";
 export { useVariableResolver } from "./useVariableResolver";
+export { useActiveEnvironmentGuard } from "./useActiveEnvironmentGuard";
 export { useVariableCompletionProvider } from "./useVariableCompletionProvider";
 export { useElectronTheme } from "./useElectronTheme";
 export { useResizable } from "./useResizable";

--- a/app/src/hooks/useActiveEnvironmentGuard.ts
+++ b/app/src/hooks/useActiveEnvironmentGuard.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Active-environment rehydrate validation.
+ *
+ * `activeEnvironmentId` is persisted, so it outlives the environment it names:
+ * a delete performed by another window, a reset database, or a stored id from
+ * before the delete-time cleanup existed all leave a dangling id in
+ * localStorage. The switcher hides that (a defensive `find()` renders "No
+ * Environment"), but every send still forwards the id to `/compose`, so the UI
+ * says none while the wire says a deleted one.
+ *
+ * This clears it once - and only once - the engine has actually answered.
+ */
+
+import { useEffect } from "react";
+import { useEnvironmentsQuery } from "@/queries";
+import { useSessionStore } from "@/stores/session-store";
+
+export function useActiveEnvironmentGuard(): void {
+	const { data: environments, isSuccess } = useEnvironmentsQuery();
+	const activeEnvironmentId = useSessionStore((s) => s.activeEnvironmentId);
+	const setActiveEnvironmentId = useSessionStore((s) => s.setActiveEnvironmentId);
+
+	useEffect(() => {
+		/*
+		 * `isSuccess` is the load-bearing condition, not `environments.length`:
+		 * an unreachable engine or a failed fetch leaves the list empty too, and
+		 * clearing on that would throw away a perfectly good selection every time
+		 * the app started before the engine did.
+		 */
+		if (!isSuccess || !activeEnvironmentId) return;
+		if (!environments.some((e) => e.id === activeEnvironmentId)) {
+			setActiveEnvironmentId(null);
+		}
+	}, [isSuccess, environments, activeEnvironmentId, setActiveEnvironmentId]);
+}

--- a/app/src/hooks/useVariableResolver.dynamic.test.tsx
+++ b/app/src/hooks/useVariableResolver.dynamic.test.tsx
@@ -26,7 +26,6 @@ const collections: Array<Record<string, unknown>> = [];
 const environments: Array<Record<string, unknown>> = [];
 const session = {
 	activeEnvironmentId: null as string | null,
-	activeCollectionId: null as string | null,
 };
 
 vi.mock("@/queries", () => ({
@@ -51,7 +50,6 @@ beforeEach(() => {
 	globals.variables = {};
 	collections.length = 0;
 	environments.length = 0;
-	session.activeCollectionId = null;
 	session.activeEnvironmentId = null;
 });
 

--- a/app/src/hooks/useVariableResolver.origins.test.tsx
+++ b/app/src/hooks/useVariableResolver.origins.test.tsx
@@ -39,7 +39,6 @@ const collections: Array<Record<string, unknown>> = [];
 const environments: Array<Record<string, unknown>> = [];
 const session = {
 	activeEnvironmentId: null as string | null,
-	activeCollectionId: null as string | null,
 };
 
 vi.mock("@/queries", () => ({
@@ -77,16 +76,21 @@ function setup(opts: {
 	collections.push(...(opts.cols ?? []));
 	environments.length = 0;
 	environments.push(...(opts.envs ?? []));
-	session.activeCollectionId = opts.activeCollectionId ?? null;
 	session.activeEnvironmentId = opts.activeEnvironmentId ?? null;
-	return renderHook(() => useVariableResolver()).result.current;
+	/*
+	 * Collection scope is an explicit option, never a store field: the store
+	 * fallback was removed with `activeCollectionId` (#239), which had a reader
+	 * here and no writer anywhere.
+	 */
+	return renderHook(() =>
+		useVariableResolver({ collectionId: opts.activeCollectionId ?? undefined })
+	).result.current;
 }
 
 beforeEach(() => {
 	globals.variables = {};
 	collections.length = 0;
 	environments.length = 0;
-	session.activeCollectionId = null;
 	session.activeEnvironmentId = null;
 });
 

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -81,8 +81,16 @@ export function useVariableResolver(
 	const { data: collections = [] } = useCollectionsQuery();
 	const { data: environments = [] } = useEnvironmentsQuery();
 
-	const { activeEnvironmentId, activeCollectionId: storeCollectionId } = useSessionStore();
-	const activeCollectionId = options?.collectionId || storeCollectionId;
+	const { activeEnvironmentId } = useSessionStore();
+	/*
+	 * Collection scope is explicit only. There used to be a session-store
+	 * fallback (`activeCollectionId`) for option-less callers, but nothing ever
+	 * wrote it - so it could only ever hold a value rehydrated from an old
+	 * build, silently scoping resolution to a collection the user had left. An
+	 * option-less caller now resolves against globals + environment, which is
+	 * what it was already getting on every fresh install.
+	 */
+	const activeCollectionId = options?.collectionId ?? null;
 
 	/**
 	 * Every definition of every name, in precedence order (lowest first):

--- a/app/src/lib/query-client.ts
+++ b/app/src/lib/query-client.ts
@@ -13,13 +13,29 @@
 
 import { QueryClient } from "@tanstack/react-query";
 import { QUERY_CACHE } from "@/config/cache";
+import { ApiError } from "@/services/http-client";
+
+/**
+ * A 4xx from the engine is a verdict, not a hiccup: a 404 for a deleted row
+ * answers the same way three times in a row, and retrying it only delays the
+ * error the caller is waiting for. Anything else - a 5xx, a timeout, an
+ * unreachable engine - keeps the default budget, because those do recover.
+ *
+ * Exported so a query with its own retry rule can be checked against this one.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+	if (error instanceof ApiError && error.statusCode >= 400 && error.statusCode < 500) {
+		return false;
+	}
+	return failureCount < QUERY_CACHE.DEFAULT_QUERY_RETRY;
+}
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			staleTime: QUERY_CACHE.DEFAULT_STALE_TIME_MS,
 			gcTime: QUERY_CACHE.DEFAULT_GC_TIME_MS,
-			retry: QUERY_CACHE.DEFAULT_QUERY_RETRY,
+			retry: shouldRetryQuery,
 			// Don't refetch on window focus for desktop app
 			refetchOnWindowFocus: false,
 			// Refetch on reconnect

--- a/app/src/lib/query-retry.test.ts
+++ b/app/src/lib/query-retry.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The shared retry policy.
+ *
+ * `retry: 2` meant a deterministic 4xx was asked three times before the caller
+ * saw the error: a lookup for a deleted row fired three identical GETs and the
+ * pane sat on a spinner through all of them. Only `requestDetailOptions` had
+ * opted out, with its own predicate.
+ *
+ * The range check is deliberate rather than `statusCode < 500`: `ApiError` is
+ * only thrown with a real HTTP status (`http-client.ts` turns a timeout or a
+ * dead socket into a plain `Error`), so anything outside 4xx is either a server
+ * fault or something unclassified, and both are worth retrying.
+ */
+
+import { describe, it, expect } from "vitest";
+import { shouldRetryQuery } from "./query-client";
+import { QUERY_CACHE } from "@/config/cache";
+import { ApiError } from "@/services/http-client";
+
+const apiError = (status: number) => new ApiError(status, "CODE", `HTTP ${status}`);
+
+describe("shouldRetryQuery", () => {
+	it("does not retry a 404 - a deleted row answers the same way every time", () => {
+		expect(shouldRetryQuery(0, apiError(404))).toBe(false);
+	});
+
+	it("does not retry any other 4xx", () => {
+		for (const status of [400, 401, 403, 409, 422, 499]) {
+			expect(shouldRetryQuery(0, apiError(status))).toBe(false);
+		}
+	});
+
+	it("retries a 5xx up to the default budget", () => {
+		expect(shouldRetryQuery(0, apiError(500))).toBe(true);
+		expect(shouldRetryQuery(QUERY_CACHE.DEFAULT_QUERY_RETRY - 1, apiError(503))).toBe(true);
+		expect(shouldRetryQuery(QUERY_CACHE.DEFAULT_QUERY_RETRY, apiError(500))).toBe(false);
+	});
+
+	it("retries a transport failure, which is not an ApiError at all", () => {
+		// `http-client.ts` throws these for a timeout or an unreachable engine -
+		// exactly the failures that do recover on their own.
+		expect(shouldRetryQuery(0, new Error("Network error: fetch failed"))).toBe(true);
+		expect(shouldRetryQuery(0, new Error("Request timeout"))).toBe(true);
+	});
+
+	it("keeps the budget it always had for retryable errors", () => {
+		expect(QUERY_CACHE.DEFAULT_QUERY_RETRY).toBe(2);
+	});
+});

--- a/app/src/modules/history/main/DesignRunView.tsx
+++ b/app/src/modules/history/main/DesignRunView.tsx
@@ -50,6 +50,7 @@ import { toFlatHeaders } from "@/modules/request-builder/utils/key-value";
 import {
 	buildExecBody,
 	responseFromExecuteResult,
+	scriptsMayWriteVariables,
 } from "@/modules/request-builder/utils/execute-mapping";
 import { generateUUID } from "@/modules/request-builder/utils/id";
 import { responseFromRunResult } from "@/modules/request-builder/utils/restore-response";
@@ -242,7 +243,8 @@ export default function DesignRunView({ run }: DesignRunViewProps) {
 				// A resend is a new run, so History has to hear about it.
 				queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
 				queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
-				if (preScriptParts) {
+				// Same gate as the builder's send path, from the same helper.
+				if (scriptsMayWriteVariables(preScriptParts, postScriptParts)) {
 					queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.globals.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.collections.all });

--- a/app/src/modules/request-builder/RequestBuilder.states.test.tsx
+++ b/app/src/modules/request-builder/RequestBuilder.states.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A failed request lookup has two meanings, and the pane has to tell them
+ * apart.
+ *
+ * `useRequestQuery` hits `GET /requests/:id`, which throws the
+ * `RequestNotFoundError` sentinel for a genuine deletion and something else for
+ * every transport failure. Both used to render "This request no longer exists"
+ * with a Try again - so an engine that had not come up yet told the user their
+ * request was deleted, and invited them to close a tab they would want back.
+ *
+ * The discrimination is by type, never by message, so the real `isRequestNotFound`
+ * is used here rather than a stubbed predicate: a stub would assert nothing
+ * about the distinction this pane exists to make.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useTabsStore } from "@/stores";
+
+const requestQuery = {
+	data: undefined as unknown,
+	isLoading: false,
+	isError: false,
+	error: null as unknown,
+	refetch: vi.fn(),
+};
+
+vi.mock("@/queries", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/queries")>();
+	return {
+		...actual,
+		useRequestQuery: () => requestQuery,
+		useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), mutate: vi.fn() }),
+		useCollectionAncestors: () => [],
+	};
+});
+
+// The builder itself renders Monaco and the whole response tree; the question
+// here is only which pane it chooses when the lookup failed.
+vi.mock("./components/RequestBuilderLayout", () => ({
+	default: () => <div data-testid="builder-layout" />,
+}));
+
+const { RequestNotFoundError } = await import("@/queries");
+const { default: RequestBuilder } = await import("./index");
+
+/** The pane calls `useQueryClient()` before it ever reaches an error branch. */
+function renderPane() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+	return render(<RequestBuilder />, { wrapper });
+}
+
+beforeEach(() => {
+	requestQuery.data = undefined;
+	requestQuery.isLoading = false;
+	requestQuery.isError = true;
+	requestQuery.refetch = vi.fn();
+	useTabsStore.setState({
+		openTabs: [{ id: "t1", type: "request", entityId: "r1", title: "Req" } as never],
+		activeTabId: "t1",
+	});
+});
+
+describe("the request lookup failed", () => {
+	it("says the request is gone - and offers no retry - for a real 404", () => {
+		requestQuery.error = new RequestNotFoundError("r1");
+
+		renderPane();
+
+		expect(screen.getByText(/no longer exists/i)).toBeTruthy();
+		// A 404 can only 404 again, so a Try again here is a dead end dressed up
+		// as a way out.
+		expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+		expect(screen.getByRole("button", { name: /close tab/i })).toBeTruthy();
+	});
+
+	it("says the load failed - and offers a retry - for a transport failure", () => {
+		requestQuery.error = new Error("Network error: fetch failed");
+
+		renderPane();
+
+		// The request is probably fine; only the lookup failed. Claiming it was
+		// deleted here is the lie this branch exists to stop.
+		expect(screen.getByText(/couldn't load this request/i)).toBeTruthy();
+		expect(screen.queryByText(/no longer exists/i)).toBeNull();
+
+		const retry = screen.getByRole("button", { name: /try again/i });
+		retry.click();
+		expect(requestQuery.refetch).toHaveBeenCalled();
+	});
+
+	it("treats a settled-but-empty lookup as gone, not as a failure", () => {
+		// `isError` false with no data: nothing errored, the row simply is not
+		// there. Same conclusion as the sentinel, and it must not fall through to
+		// the transport pane.
+		requestQuery.isError = false;
+		requestQuery.error = null;
+
+		renderPane();
+
+		expect(screen.getByText(/no longer exists/i)).toBeTruthy();
+	});
+});

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.variables.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.variables.test.tsx
@@ -35,7 +35,6 @@ const collections: Array<Record<string, unknown>> = [];
 const environments: Array<Record<string, unknown>> = [];
 const session = {
 	activeEnvironmentId: null as string | null,
-	activeCollectionId: null as string | null,
 };
 
 const mutateGlobals = vi.fn();
@@ -76,7 +75,6 @@ function setup(opts: {
 	environments.length = 0;
 	environments.push(...(opts.envs ?? []));
 	session.activeEnvironmentId = opts.activeEnvironmentId ?? null;
-	session.activeCollectionId = null;
 
 	return renderHook(() => useRequestBuilderContext(), {
 		wrapper: ({ children }) => (
@@ -93,7 +91,6 @@ beforeEach(() => {
 	collections.length = 0;
 	environments.length = 0;
 	session.activeEnvironmentId = null;
-	session.activeCollectionId = null;
 });
 
 describe("which scopes a variable can be created in", () => {

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -28,6 +28,7 @@ import LoadTestConfigDialog from "./components/LoadTestConfigDialog";
 import { useTabsStore, useSessionStore, useDashboardStore, useToastStore } from "@/stores";
 import {
 	useRequestQuery,
+	isRequestNotFound,
 	useUpdateRequestMutation,
 	useCollectionAncestors,
 	queryKeys,
@@ -43,7 +44,11 @@ import { toKeyValueItems, toKeyValueEntries, toFlatHeaders } from "./utils/key-v
 import { generateUUID } from "./utils/id";
 import { scriptParts } from "./utils/script-parts";
 import { requestUsesDynamicVariables } from "./utils/dynamic-variable-scan";
-import { buildExecBody, responseFromExecuteResult } from "./utils/execute-mapping";
+import {
+	buildExecBody,
+	responseFromExecuteResult,
+	scriptsMayWriteVariables,
+} from "./utils/execute-mapping";
 import type {
 	HttpMethod,
 	LoadTestConfig,
@@ -82,6 +87,7 @@ export default function RequestBuilder() {
 		data: fetchedRequest,
 		isLoading,
 		isError,
+		error: requestLookupError,
 		refetch,
 	} = useRequestQuery(selectedRequestId);
 
@@ -254,8 +260,10 @@ export default function RequestBuilder() {
 					);
 				}
 
-				// Refresh variables so script-set values (e.g. pm.environment.set) appear in the UI
-				if (preScriptParts) {
+				// Refresh variables so script-set values (e.g. pm.environment.set)
+				// appear in the UI - post-request scripts write them too, see the
+				// helper's note.
+				if (scriptsMayWriteVariables(preScriptParts, postScriptParts)) {
 					queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.globals.all });
 					queryClient.invalidateQueries({ queryKey: queryKeys.collections.all });
@@ -516,29 +524,41 @@ export default function RequestBuilder() {
 	}
 
 	/*
-	 * Reaching here means the lookup errored. `useRequestQuery` hits
-	 * `GET /requests/:id`, so a genuine deletion (404) is authoritative rather
-	 * than the cold-start race it used to be; a transport failure lands here too,
-	 * but the retry below recovers it once the engine is back. The message reads
-	 * for the common case (deleted), and a centred "Request not found" with no
-	 * way out used to leave the user to work out that closing the tab was the
-	 * only move. Deleting a request already closes its tabs
-	 * (`closeTabsForEntities`), so the usual cause is a delete from another
-	 * window or a database restored underneath the app.
+	 * Reaching here means the lookup errored, and the two reasons need different
+	 * panes. `useRequestQuery` hits `GET /requests/:id`, so a genuine deletion
+	 * throws the `RequestNotFoundError` sentinel and is authoritative - telling
+	 * the user their request is gone is correct, and offering a retry is not,
+	 * since a 404 can only 404 again. Every other failure (a 5xx, an engine that
+	 * is not up yet) means the request is very probably still there and only the
+	 * lookup failed; saying "no longer exists" there is a lie that invites the
+	 * user to close a tab they will want back. Discriminated by type, never by
+	 * message - same rule as `DesignRunView`.
+	 *
+	 * Deleting a request already closes its tabs (`closeTabsForEntities`), so the
+	 * usual cause of the deleted branch is a delete from another window or a
+	 * database restored underneath the app.
 	 */
+	const requestWasDeleted =
+		isRequestNotFound(requestLookupError) || (!isError && !fetchedRequest);
 	if (isError || !fetchedRequest) {
-		return (
+		const closeTabAction = activeTab ? (
+			<Button variant="outline" size="sm" onClick={() => closeTab(activeTab.id)}>
+				Close tab
+			</Button>
+		) : undefined;
+
+		return requestWasDeleted ? (
 			<ErrorState
 				title="This request no longer exists"
 				detail="It was deleted, or the collection it lived in was. Nothing here can be recovered - closing the tab is safe."
+				action={closeTabAction}
+			/>
+		) : (
+			<ErrorState
+				title="Couldn't load this request"
+				detail="The engine could not be reached, or it failed to answer. The request itself is probably fine."
 				onRetry={() => refetch()}
-				action={
-					activeTab ? (
-						<Button variant="outline" size="sm" onClick={() => closeTab(activeTab.id)}>
-							Close tab
-						</Button>
-					) : undefined
-				}
+				action={closeTabAction}
 			/>
 		);
 	}

--- a/app/src/modules/request-builder/utils/execute-mapping.ts
+++ b/app/src/modules/request-builder/utils/execute-mapping.ts
@@ -23,7 +23,7 @@
  * are in scope.
  */
 
-import type { SanityResult } from "@/types";
+import type { SanityResult, ScriptPart } from "@/types";
 import type { RequestState, ResponseState } from "../types";
 import { toKeyValueEntries } from "./key-value";
 
@@ -151,4 +151,28 @@ export function responseFromExecuteResult(result: SanityResult): ResponseState {
 		preScriptError: result.preScriptError,
 		postScriptError: result.postScriptError,
 	};
+}
+
+/**
+ * Whether an execute that ran these script parts could have written a variable
+ * the UI is showing, and so needs the environment/globals/collection caches
+ * invalidated.
+ *
+ * Both kinds count. The gate used to read `if (preScriptParts)` at both call
+ * sites, which is the same "copy that never receives the fix" trap this module
+ * exists to close: `pm.environment.set` / `pm.globals.set` /
+ * `pm.collectionVariables.set` persist engine-side from a post-request (Tests
+ * tab) script exactly as they do from a pre-request one, so a request whose
+ * only script was in the Tests tab stored the value while the variables editor
+ * and the resolver kept showing the old one - `refetchOnWindowFocus` is off, so
+ * nothing else was coming to correct it.
+ *
+ * Empty part lists are treated as no script, matching what the call sites'
+ * truthiness checks already did with `undefined`.
+ */
+export function scriptsMayWriteVariables(
+	preScriptParts?: ScriptPart[],
+	postScriptParts?: ScriptPart[]
+): boolean {
+	return Boolean(preScriptParts?.length) || Boolean(postScriptParts?.length);
 }

--- a/app/src/modules/request-builder/utils/script-variable-invalidation.test.ts
+++ b/app/src/modules/request-builder/utils/script-variable-invalidation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A script that writes a variable has to leave the UI showing the new value.
+ *
+ * Both send paths gated variable invalidation on `if (preScriptParts)`, so a
+ * request whose only script sat in the Tests tab stored `auth_token`
+ * engine-side while the variables editor and the resolver kept showing the old
+ * one - indefinitely, since `refetchOnWindowFocus` is off. The predicate is
+ * shared rather than written twice for the reason `execute-mapping.ts` exists:
+ * the two copies of this gate had already drifted from one another once.
+ *
+ * The scan half is not decoration. A correct predicate that no send path calls
+ * is precisely the repo's "written but never read" defect, and a unit test of
+ * the helper alone cannot see it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { scriptsMayWriteVariables } from "./execute-mapping";
+import type { ScriptPart } from "@/types";
+
+const part = (script: string): ScriptPart => ({ origin: "request", script });
+
+describe("scriptsMayWriteVariables", () => {
+	it("is true for a post-request script alone - the case that was broken", () => {
+		expect(scriptsMayWriteVariables(undefined, [part("pm.environment.set('t', 1)")])).toBe(
+			true
+		);
+	});
+
+	it("is true for a pre-request script alone", () => {
+		expect(scriptsMayWriteVariables([part("pm.globals.set('t', 1)")], undefined)).toBe(true);
+	});
+
+	it("is true when both kinds ran", () => {
+		expect(scriptsMayWriteVariables([part("a")], [part("b")])).toBe(true);
+	});
+
+	it("is false when neither ran - nothing could have been written", () => {
+		expect(scriptsMayWriteVariables(undefined, undefined)).toBe(false);
+	});
+
+	it("treats an empty part list as no script", () => {
+		// `scriptParts()` returns undefined rather than [], but a replay builds
+		// its list by hand; an empty one means nothing executed either way.
+		expect(scriptsMayWriteVariables([], [])).toBe(false);
+	});
+});
+
+const sources = import.meta.glob(
+	["/src/modules/request-builder/index.tsx", "/src/modules/history/main/DesignRunView.tsx"],
+	{ query: "?raw", import: "default", eager: true }
+);
+
+describe("both send paths gate on the shared predicate", () => {
+	it.each([
+		["/src/modules/request-builder/index.tsx"],
+		["/src/modules/history/main/DesignRunView.tsx"],
+	])("%s calls scriptsMayWriteVariables and no longer gates on preScriptParts alone", (path) => {
+		const src = sources[path] as string | undefined;
+		// Guards the scan itself: vitest stubs some imports to "", and a moved
+		// file would make every assertion below pass vacuously.
+		expect(typeof src).toBe("string");
+		expect((src ?? "").length).toBeGreaterThan(1000);
+
+		const source = src ?? "";
+		expect(source).toContain("scriptsMayWriteVariables(preScriptParts, postScriptParts)");
+		// The reverted form. Matches `if (preScriptParts)` with any spacing, and
+		// nothing else in either file is written that way.
+		expect(source).not.toMatch(/if\s*\(\s*preScriptParts\s*\)/);
+	});
+
+	it("invalidates all three variable families behind that gate", () => {
+		for (const src of Object.values(sources)) {
+			const source = src as string;
+			const gate = source.indexOf("scriptsMayWriteVariables(");
+			expect(gate).toBeGreaterThan(-1);
+			// The three families the engine can write from a script. Sliced to the
+			// gate's own block so an unrelated invalidation elsewhere in the file
+			// cannot stand in for one of them.
+			const block = source.slice(gate, gate + 500);
+			expect(block).toContain("queryKeys.environments.all");
+			expect(block).toContain("queryKeys.globals.all");
+			expect(block).toContain("queryKeys.collections.all");
+		}
+	});
+});

--- a/app/src/queries/active-environment-lifecycle.test.tsx
+++ b/app/src/queries/active-environment-lifecycle.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `activeEnvironmentId` must never outlive its environment.
+ *
+ * The switcher hides a dangling id behind a defensive `find()` - it renders
+ * "No Environment" and looks correct - while every composed payload keeps
+ * carrying the deleted id, and localStorage keeps it across restarts. So the
+ * assertions here are about the *store*, not the label: what the UI shows was
+ * never the broken half.
+ *
+ * Two closing points, because an id can go stale two ways:
+ *   - the delete this app performed (the mutation), and
+ *   - an id that was already stale when the app started (the guard).
+ *
+ * The guard's `isSuccess` condition carries the weight: an unreachable engine
+ * also produces an empty list, and clearing on that would throw away a good
+ * selection every time the app won the startup race against the engine.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useDeleteEnvironmentMutation } from "./environments";
+import { useActiveEnvironmentGuard } from "@/hooks/useActiveEnvironmentGuard";
+import { useSessionStore } from "@/stores/session-store";
+import { queryKeys } from "./keys";
+import type { Environment } from "@/types";
+
+const deleteEnvironment = vi.fn();
+const listEnvironments = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		deleteEnvironment: (...a: unknown[]) => deleteEnvironment(...a),
+		listEnvironments: (...a: unknown[]) => listEnvironments(...a),
+	},
+}));
+
+const env = (id: string): Environment =>
+	({ id, name: id, variables: {} }) as unknown as Environment;
+
+function makeClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useSessionStore.setState({ activeEnvironmentId: null });
+});
+
+describe("deleting an environment clears it from the session", () => {
+	it("nulls the active id when the deleted environment was the active one", async () => {
+		useSessionStore.setState({ activeEnvironmentId: "e1" });
+		deleteEnvironment.mockResolvedValue(undefined);
+		const client = makeClient();
+		client.setQueryData(queryKeys.environments.list(), [env("e1"), env("e2")]);
+
+		const { result } = renderHook(() => useDeleteEnvironmentMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync("e1");
+
+		// The point of the fix: without it the id survives here, and every
+		// subsequent /compose carries an environment the engine has deleted.
+		expect(useSessionStore.getState().activeEnvironmentId).toBeNull();
+		expect(client.getQueryData(queryKeys.environments.list())).toEqual([env("e2")]);
+	});
+
+	it("leaves the active id alone when a different environment is deleted", async () => {
+		useSessionStore.setState({ activeEnvironmentId: "e1" });
+		deleteEnvironment.mockResolvedValue(undefined);
+		const client = makeClient();
+		client.setQueryData(queryKeys.environments.list(), [env("e1"), env("e2")]);
+
+		const { result } = renderHook(() => useDeleteEnvironmentMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync("e2");
+
+		expect(useSessionStore.getState().activeEnvironmentId).toBe("e1");
+	});
+
+	it("keeps the id when the delete fails - the environment is still there", async () => {
+		useSessionStore.setState({ activeEnvironmentId: "e1" });
+		deleteEnvironment.mockRejectedValue(new Error("engine said no"));
+		const client = makeClient();
+
+		const { result } = renderHook(() => useDeleteEnvironmentMutation(), {
+			wrapper: wrapper(client),
+		});
+		await expect(result.current.mutateAsync("e1")).rejects.toThrow("engine said no");
+
+		expect(useSessionStore.getState().activeEnvironmentId).toBe("e1");
+	});
+});
+
+describe("rehydrate validation", () => {
+	it("clears a stored id the engine's environment list does not contain", async () => {
+		useSessionStore.setState({ activeEnvironmentId: "gone" });
+		listEnvironments.mockResolvedValue([env("e1")]);
+		const client = makeClient();
+
+		renderHook(() => useActiveEnvironmentGuard(), { wrapper: wrapper(client) });
+
+		await waitFor(() => expect(useSessionStore.getState().activeEnvironmentId).toBeNull());
+	});
+
+	it("keeps an id the list does contain", async () => {
+		useSessionStore.setState({ activeEnvironmentId: "e1" });
+		listEnvironments.mockResolvedValue([env("e1")]);
+		const client = makeClient();
+
+		const { result } = renderHook(
+			() => {
+				useActiveEnvironmentGuard();
+				return useSessionStore.getState().activeEnvironmentId;
+			},
+			{ wrapper: wrapper(client) }
+		);
+
+		await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+		await waitFor(() => expect(result.current).toBe("e1"));
+		expect(useSessionStore.getState().activeEnvironmentId).toBe("e1");
+	});
+
+	it("keeps the id when the environments query failed - an empty list is not proof", async () => {
+		useSessionStore.setState({ activeEnvironmentId: "e1" });
+		listEnvironments.mockRejectedValue(new Error("engine unreachable"));
+		const client = makeClient();
+
+		renderHook(() => useActiveEnvironmentGuard(), { wrapper: wrapper(client) });
+
+		// The engine never answered, so nothing here is evidence that e1 is gone.
+		// Guarding on `environments.length` instead of `isSuccess` fails this.
+		await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+		expect(useSessionStore.getState().activeEnvironmentId).toBe("e1");
+	});
+});

--- a/app/src/queries/collection-cascade-delete.test.tsx
+++ b/app/src/queries/collection-cascade-delete.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Deleting a collection deletes a subtree, and the client cannot know its
+ * shape.
+ *
+ * The engine cascade-deletes descendant collections and every request under
+ * them. The mutation used to filter one id out of the collections list and
+ * invalidate one collection's request list, which leaves descendants in the
+ * cache feeding `useCollectionAncestors` and the resolver, and leaves
+ * `requests.detail` entries fresh forever (`staleTime: Infinity`).
+ *
+ * "Fresh" is the assertion that matters here, not "absent": invalidation is
+ * what makes the next read go back to the engine, so `getQueryState().isInvalidated`
+ * is the thing a revert flips, while `getQueryData` looks identical either way.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useDeleteCollectionMutation, useCreateCollectionMutation } from "./collections";
+import { queryKeys } from "./keys";
+import type { Collection } from "@/types";
+
+const deleteCollection = vi.fn();
+const createCollection = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		deleteCollection: (...a: unknown[]) => deleteCollection(...a),
+		createCollection: (...a: unknown[]) => createCollection(...a),
+	},
+}));
+
+const col = (id: string, parentId?: string): Collection =>
+	({ id, name: id, parentId, variables: {} }) as unknown as Collection;
+
+function makeClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("deleting a collection invalidates the whole cascade", () => {
+	it("leaves no descendant collection or request cache entry fresh", async () => {
+		deleteCollection.mockResolvedValue(undefined);
+		const client = makeClient();
+		// A two-level tree: deleting `root` takes `child` and both request lists
+		// with it, engine-side.
+		client.setQueryData(queryKeys.collections.list(), [col("root"), col("child", "root")]);
+		client.setQueryData(queryKeys.requests.listByCollection("root"), [{ id: "r1" }]);
+		client.setQueryData(queryKeys.requests.listByCollection("child"), [{ id: "r2" }]);
+		client.setQueryData(queryKeys.requests.detail("r2"), { id: "r2" });
+
+		const { result } = renderHook(() => useDeleteCollectionMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync("root");
+
+		// The descendant's caches: stale, so the next read asks the engine
+		// instead of serving a row the engine deleted. Reverting to
+		// `invalidateQueries(listByCollection(deletedId))` leaves all three valid.
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("child"))?.isInvalidated
+		).toBe(true);
+		expect(client.getQueryState(queryKeys.requests.detail("r2"))?.isInvalidated).toBe(true);
+		expect(client.getQueryState(queryKeys.collections.list())?.isInvalidated).toBe(true);
+
+		// The deleted collection itself still goes from the list immediately, so
+		// the tree does not wait for a refetch to stop showing it.
+		expect(client.getQueryData(queryKeys.collections.list())).toEqual([col("child", "root")]);
+	});
+
+	it("does not invalidate anything when the delete fails", async () => {
+		deleteCollection.mockRejectedValue(new Error("engine said no"));
+		const client = makeClient();
+		client.setQueryData(queryKeys.requests.detail("r2"), { id: "r2" });
+
+		const { result } = renderHook(() => useDeleteCollectionMutation(), {
+			wrapper: wrapper(client),
+		});
+		await expect(result.current.mutateAsync("root")).rejects.toThrow("engine said no");
+
+		expect(client.getQueryState(queryKeys.requests.detail("r2"))?.isInvalidated).toBe(false);
+	});
+});
+
+describe("the warm-cache prefetch re-runs for a collection created mid-session", () => {
+	it("invalidates the prefetch pass on create", async () => {
+		createCollection.mockResolvedValue(col("new"));
+		const client = makeClient();
+		client.setQueryData(queryKeys.collections.list(), []);
+		// The pass succeeded at startup; with `staleTime` it would never re-run,
+		// so a collection created now would miss its warm cache entirely.
+		client.setQueryData(queryKeys.prefetch.allRequests(), true);
+
+		const { result } = renderHook(() => useCreateCollectionMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync({ name: "new" });
+
+		expect(client.getQueryState(queryKeys.prefetch.allRequests())?.isInvalidated).toBe(true);
+	});
+});

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -51,7 +51,7 @@ export function usePrefetchCollectionsAndRequests() {
 
 	// Prefetch requests for all collections when collections are loaded
 	useQuery({
-		queryKey: ["prefetch", "all-requests"],
+		queryKey: queryKeys.prefetch.allRequests(),
 		queryFn: async () => {
 			// Prefetch requests for each collection in parallel
 			await Promise.all(
@@ -240,6 +240,10 @@ export function useCreateCollectionMutation() {
 				const next = old ? [...old, newCollection] : [newCollection];
 				return next.sort(compareCollectionOrder);
 			});
+			// The warm-cache pass is a query like any other: it succeeded once at
+			// startup and would stay fresh forever, so a collection created
+			// mid-session never got one. Invalidating re-runs it over the new set.
+			queryClient.invalidateQueries({ queryKey: queryKeys.prefetch.allRequests() });
 		},
 	});
 }
@@ -276,10 +280,22 @@ export function useDeleteCollectionMutation() {
 				queryKeys.collections.list(),
 				(old) => old?.filter((c) => c.id !== deletedId) ?? []
 			);
-			// Invalidate requests for this collection
-			queryClient.invalidateQueries({
-				queryKey: queryKeys.requests.listByCollection(deletedId),
-			});
+			/*
+			 * The engine cascade-deletes every descendant collection and their
+			 * requests, and which rows those are is engine-side knowledge - the
+			 * client must not re-derive the tree to patch caches surgically, or
+			 * the two definitions of "descendant" drift.
+			 *
+			 * So both families are invalidated wholesale. `requests.all` rather
+			 * than this collection's list: descendants had their own list caches,
+			 * and `requests.detail` entries carry `staleTime: Infinity`, so
+			 * without this a deleted request stays fresh forever and keeps feeding
+			 * restored tabs. `collections.all` covers the descendants left behind
+			 * by the single-id filter above, which the ancestor walk and the
+			 * resolver would otherwise still see.
+			 */
+			queryClient.invalidateQueries({ queryKey: queryKeys.collections.all });
+			queryClient.invalidateQueries({ queryKey: queryKeys.requests.all });
 		},
 	});
 }

--- a/app/src/queries/environments.ts
+++ b/app/src/queries/environments.ts
@@ -13,6 +13,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
+import { useSessionStore } from "@/stores/session-store";
 import { queryKeys } from "./keys";
 import type { Environment, CreateEnvironmentRequest, UpdateEnvironmentRequest } from "@/types";
 
@@ -100,6 +101,18 @@ export function useDeleteEnvironmentMutation() {
 			queryClient.removeQueries({
 				queryKey: queryKeys.environments.detail(deletedId),
 			});
+			/*
+			 * Deleting the active environment has to clear the session id, and it
+			 * belongs here rather than in either delete flow: the switcher only
+			 * *displays* "No Environment" through a defensive `find()`, while the
+			 * id itself keeps riding on every /compose and /runs payload and
+			 * persists to localStorage across restarts. Both delete call sites
+			 * (the editor's danger zone and the sidebar tree) go through this
+			 * mutation, so one cleanup covers both.
+			 */
+			if (useSessionStore.getState().activeEnvironmentId === deletedId) {
+				useSessionStore.getState().setActiveEnvironmentId(null);
+			}
 		},
 	});
 }

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -48,6 +48,15 @@ export const queryKeys = {
 		timeSeries: (id: string) => [...queryKeys.runs.all, "timeSeries", id] as const,
 	},
 
+	// Warm-cache pass over every collection's requests (see
+	// usePrefetchCollectionsAndRequests). Keyed here rather than inline so it
+	// can be invalidated when the set of collections changes - it succeeds once
+	// and would otherwise never re-run for a collection created mid-session.
+	prefetch: {
+		all: ["prefetch"] as const,
+		allRequests: () => [...queryKeys.prefetch.all, "all-requests"] as const,
+	},
+
 	// Environments
 	environments: {
 		all: ["environments"] as const,

--- a/app/src/stores/session-store.test.ts
+++ b/app/src/stores/session-store.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `activeCollectionId` is gone, and a persisted one must not come back.
+ *
+ * The field had a reader - the resolver's fallback scope for option-less
+ * callers - and no writer anywhere, so on a fresh install it was permanently
+ * null, and on an install old enough to have stored one it rehydrated every
+ * launch and scoped `{{var}}` previews to a collection the user had left or
+ * deleted. Removing the reader is not enough on its own: the stored key
+ * survives in localStorage, so the migration has to drop it, or a future field
+ * reusing the name would inherit a value from an unrelated build.
+ *
+ * `lastCollectionId` is the field that looks similar and is not: it has a real
+ * writer and feeds the welcome screen, never the resolver.
+ */
+
+import { describe, it, expect } from "vitest";
+import { useSessionStore } from "./session-store";
+
+/** The persist option the store was built with, reached the way zustand does. */
+const persistOptions = useSessionStore.persist.getOptions();
+
+describe("session-store persistence", () => {
+	it("drops a v1 activeCollectionId on migration", () => {
+		const migrated = persistOptions.migrate?.(
+			{ activeEnvironmentId: "e1", activeCollectionId: "c1", lastCollectionId: "c9" },
+			1
+		) as Record<string, unknown>;
+
+		expect(migrated).not.toHaveProperty("activeCollectionId");
+		// The two fields that survive it, so the migration is a drop and not a wipe.
+		expect(migrated.activeEnvironmentId).toBe("e1");
+		expect(migrated.lastCollectionId).toBe("c9");
+	});
+
+	it("tolerates a v1 payload that never had the key", () => {
+		const migrated = persistOptions.migrate?.({ activeEnvironmentId: null }, 1) as Record<
+			string,
+			unknown
+		>;
+		expect(migrated).not.toHaveProperty("activeCollectionId");
+	});
+
+	it("is at version 2, so the migration actually runs for stored v1 state", () => {
+		// zustand only calls `migrate` when the stored version is below this one.
+		expect(persistOptions.version).toBe(2);
+	});
+
+	it("persists only the environment id and the new-request target", () => {
+		const persisted = persistOptions.partialize?.({
+			activeEnvironmentId: "e1",
+			lastCollectionId: "c9",
+			setActiveEnvironmentId: () => {},
+			setLastCollectionId: () => {},
+		} as Parameters<NonNullable<typeof persistOptions.partialize>>[0]);
+
+		expect(Object.keys(persisted as object).sort()).toEqual([
+			"activeEnvironmentId",
+			"lastCollectionId",
+		]);
+	});
+});

--- a/app/src/stores/session-store.ts
+++ b/app/src/stores/session-store.ts
@@ -10,7 +10,7 @@
  *
  * Manages persistent application session state:
  * - Active environment (for variable resolution)
- * - Active collection context (for collection variables)
+ * - Last collection worked in (new-request target)
  */
 
 import { create } from "zustand";
@@ -18,20 +18,25 @@ import { persist } from "zustand/middleware";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
 
 interface SessionState {
+	/**
+	 * The environment every send resolves against. Cleared when that
+	 * environment is deleted and when a rehydrated id names an environment the
+	 * engine no longer has (`useActiveEnvironmentGuard`) - a stale id here does
+	 * not just mislead the switcher, it rides on every `/compose` payload.
+	 */
 	activeEnvironmentId: string | null;
-	activeCollectionId: string | null;
 	/**
 	 * The collection the user most recently worked in - updated when a request
 	 * or collection tab becomes the source of truth (RequestBuilder /
 	 * CollectionDetail). Used by the welcome screen to land a new request where
-	 * the user was working. Deliberately distinct from `activeCollectionId`,
-	 * which scopes variable resolution; this is only a new-request target and
-	 * must not feed the resolver.
+	 * the user was working. This is only a new-request target and must never
+	 * feed the resolver: the resolver takes its scope from an explicit
+	 * `collectionId`, so a collection the user has left cannot silently scope a
+	 * `{{var}}` preview.
 	 */
 	lastCollectionId: string | null;
 
 	setActiveEnvironmentId: (id: string | null) => void;
-	setActiveCollectionId: (id: string | null) => void;
 	setLastCollectionId: (id: string | null) => void;
 }
 
@@ -39,20 +44,34 @@ export const useSessionStore = create<SessionState>()(
 	persist(
 		(set) => ({
 			activeEnvironmentId: null,
-			activeCollectionId: null,
 			lastCollectionId: null,
 			setActiveEnvironmentId: (id) => set({ activeEnvironmentId: id }),
-			setActiveCollectionId: (id) => set({ activeCollectionId: id }),
 			setLastCollectionId: (id) => set({ lastCollectionId: id }),
 		}),
 		{
 			name: STORAGE_KEYS.SESSION_STORE,
-			version: 1,
+			version: 2,
 			partialize: (state) => ({
 				activeEnvironmentId: state.activeEnvironmentId,
-				activeCollectionId: state.activeCollectionId,
 				lastCollectionId: state.lastCollectionId,
 			}),
+			/**
+			 * v1 -> v2 drops `activeCollectionId`. It had a reader (the resolver's
+			 * fallback scope) and never had a writer, so an id stored by a much
+			 * older build would rehydrate forever and scope preview resolution to a
+			 * collection the user left - or deleted - versions ago. Dropping the key
+			 * here rather than ignoring it keeps it from coming back if the field
+			 * name is ever reused.
+			 */
+			migrate: (persisted, version) => {
+				const state = (persisted ?? {}) as Partial<SessionState> & {
+					activeCollectionId?: string | null;
+				};
+				if (version < 2) {
+					delete state.activeCollectionId;
+				}
+				return state as SessionState;
+			},
 		}
 	)
 );

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -104,25 +104,46 @@ setDrawerWidth("collections", 300); // Clamp to [220, 480]
 
 **Persistence:** `vayu.layout` (v1)
 
-#### `session-store.ts` - Active Environment & Collection
+#### `session-store.ts` - Active Environment
 
-Tracks the active environment (for variable resolution) and active collection context, persisted across sessions.
+Tracks the active environment (for variable resolution) and the collection the
+user last worked in (a new-request target only), persisted across sessions.
 
 **State:**
 ```typescript
 {
   activeEnvironmentId: string | null
-  activeCollectionId: string | null
+  lastCollectionId: string | null
 }
 ```
 
 **Key Methods:**
 ```typescript
 const { activeEnvironmentId, setActiveEnvironmentId } = useSessionStore();
-setActiveCollectionId(collectionId);
+setLastCollectionId(collectionId);
 ```
 
-**Persistence:** `vayu.session` (v1)
+**Persistence:** `vayu.session` (v2)
+
+**A persisted id must not outlive what it names.** `activeEnvironmentId` rides
+on every composed payload, so a dangling one is not cosmetic - the switcher
+renders "No Environment" through a defensive `find()` while the wire still
+carries a deleted id. It is cleared at both ends:
+`useDeleteEnvironmentMutation` clears it when the active environment is the one
+deleted (in the mutation, so both delete flows are covered), and
+`useActiveEnvironmentGuard()` - mounted once in `App.tsx` - clears an id the
+engine's environment list does not contain. That guard keys on the query's
+`isSuccess`, never on the list being empty: an unreachable engine produces an
+empty list too, and clearing on that would discard a good selection whenever
+the app started before the engine did.
+
+`activeCollectionId` was **removed** in v2. It had a reader (the resolver's
+fallback scope) and no writer, so it was permanently null on a fresh install
+and, on an older one, rehydrated a collection the user had long left and
+silently scoped `{{var}}` previews to it. The persist `migrate` drops the
+stored key. `lastCollectionId` is the field that looks similar and is not: it
+has a real writer and feeds only the welcome screen's new-request target - it
+must never feed the resolver.
 
 #### `engine-store.ts` - Engine Connection & Restart State
 
@@ -531,6 +552,25 @@ export const queryKeys = {
 **Automatic Invalidation:**
 - Mutations automatically invalidate related queries (e.g., creating a request invalidates the collection's request list)
 - Some mutations use optimistic updates and cache updates for instant UI feedback
+- **A cascade delete invalidates coarsely, on purpose.** Deleting a collection
+  deletes its descendant collections and all their requests *engine-side*, and
+  which rows those are is engine-side knowledge - a client that re-derives the
+  subtree to patch caches surgically will drift from the engine's definition of
+  "descendant". So `useDeleteCollectionMutation` invalidates
+  `collections.all` + `requests.all` wholesale. `requests.detail` entries carry
+  `staleTime: Infinity`, so without this a deleted request stays fresh forever
+  and keeps feeding restored tabs.
+- **The warm-cache prefetch is a query too.** `usePrefetchCollectionsAndRequests`
+  is keyed as `queryKeys.prefetch.allRequests()` rather than an inline key, so
+  creating a collection can invalidate it - it succeeds once at startup and
+  would otherwise never re-run for a collection created mid-session.
+
+**Retry policy:** the shared default is `shouldRetryQuery` (`lib/query-client.ts`),
+not a bare count. A 4xx from the engine is a verdict, not a hiccup - a 404 for a
+deleted row answers identically every time, so retrying it only delays the error
+the caller is waiting on. 4xx is never retried; everything else (5xx, timeout,
+unreachable engine - which `http-client.ts` throws as a plain `Error`, not an
+`ApiError`) keeps the `DEFAULT_QUERY_RETRY` budget.
 
 **Stale Time:**
 - Collections/Requests: 30 seconds
@@ -600,6 +640,11 @@ const {
 1. Environment variables
 2. Collection variables
 3. Global variables
+
+Collection scope comes from the `collectionId` option and nowhere else - a
+caller that passes none resolves against globals + environment. See
+`docs/app/variable-resolution.md` for why the session-store fallback was
+removed.
 
 `ResolvedVariable` carries `sourceId` / `sourceName` - the specific environment
 or collection the winning value came from (absent for `global`).
@@ -799,6 +844,7 @@ const { draft, setDraft, isDirty, reset } = useEntityDraft({
 5. Response is stored in `useResponseStore()` keyed by request ID
 6. Response viewer component reads the response and displays it
 7. On **request tab switch**, the response persists in `response-store` and is displayed if the user returns
+8. If any script ran, the environment / globals / collection query families are invalidated so values the script wrote are visible in the variables editor and the resolver. The gate is `scriptsMayWriteVariables(pre, post)` (`request-builder/utils/execute-mapping.ts`), shared by the builder's send path and the History run view's resend. **Both** script kinds count: `pm.environment.set` and friends persist engine-side from a Tests-tab script exactly as from a pre-request one, and with `refetchOnWindowFocus: false` nothing else is coming to correct a stale value
 
 ### Starting a Load Test Run
 

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -89,6 +89,14 @@ for ([key, val] of env.variables)
 `buildCollectionChain(startId, collections)` walks `parentId` links upward and
 returns the chain with the root at index 0.
 
+**Collection scope is explicit only.** It comes from the `collectionId` option
+and nothing else; a caller that passes none resolves against globals +
+environment. There used to be a session-store fallback (`activeCollectionId`),
+but nothing ever wrote that field, so it could only ever hold a value
+rehydrated from an old build - scoping a preview to a collection the user had
+left, or deleted, versions ago. It was removed in the `vayu.session` v2
+migration.
+
 The resolved `Record<string, ResolvedVariable>` is **derived** from that list
 (the origin carrying `winner: true`) rather than built beside it, so the two
 cannot disagree about which definition won. A name whose every definition is


### PR DESCRIPTION
## Description

All anchors from #239 were re-verified on current master (`469b90c`) before any edit - each still reproduces at the stated lines. `setActiveCollectionId` still has zero callers, both environment delete flows still go through `useDeleteEnvironmentMutation`, both execute sites still gate on `if (preScriptParts)`.

**Plan.** The root cause of the headline defect is an id that outlives what it names: `activeEnvironmentId` is persisted and read on every send, but nothing clears it when its environment is deleted - and the switcher's defensive `find()` hides that, rendering "No Environment" while `/compose` keeps receiving the dead id. The fix closes both ends an id can go stale from: the delete this app performed (in the **mutation**, not either delete flow, so one cleanup covers the editor's danger zone and the sidebar tree alike) and an id that was already stale at startup (`useActiveEnvironmentGuard`). The alternative I rejected was validating inside `EnvSwitcher`, which already reads both the store and the list: it is the wrong owner - the switcher is the one consumer that *already* degrades gracefully, while the payload builders that actually break are elsewhere, and a component that can be unmounted is a poor place for a correctness invariant.

`activeCollectionId` is **deleted** rather than wired to collection navigation. The issue offers both; deleting is the honest one, since the explicit `collectionId` option already covers every live consumer, and the field's only observable effect today is on installs old enough to have stored one - where it silently scopes previews to a collection the user has left. The persist `migrate` drops the stored key, because removing the reader alone leaves the value in localStorage for whatever reuses the name next.

The remaining items are independent gaps at the same surface, each fixed where it lives.

### 1. A deleted environment's id no longer reaches the wire

`useDeleteEnvironmentMutation.onSuccess` clears `activeEnvironmentId` when the deleted environment was the active one. `useActiveEnvironmentGuard()` (new, mounted once in `App.tsx`) clears an id the engine's environment list does not contain. That guard keys on `isSuccess`, never on the list being empty - an unreachable engine also produces an empty list, and clearing on that would discard a good selection every time the app won the startup race against the engine.

### 2. `activeCollectionId` removed, `vayu.session` v1 → v2

Field, setter, persistence entry and the resolver's fallback all go; `migrate` drops the stored key. `useVariableResolver` takes collection scope from `options.collectionId` and nothing else. `lastCollectionId` is untouched - it looks similar and is not: real writer, feeds only the welcome screen's new-request target.

### 3. Collection delete invalidates the whole cascade

`collections.all` + `requests.all`, coarse on purpose: which rows the engine cascade-deleted is engine-side knowledge, and a client that re-derives the subtree to patch surgically will drift from the engine's definition of "descendant". `requests.detail` carries `staleTime: Infinity`, so without this a deleted request stayed fresh forever and kept feeding restored tabs.

### 4. Post-request scripts count for variable invalidation

Both sites now call `scriptsMayWriteVariables(pre, post)`, a shared predicate in `execute-mapping.ts` - the module that exists because these two send paths had already drifted as copies once. This replaces the second copy of the gate rather than adding a third. A request whose only script sat in the Tests tab stored `auth_token` engine-side while the editor and resolver showed the old value indefinitely (`refetchOnWindowFocus` is off, so nothing was coming to correct it).

### 5. Query-layer items

Default retry is `shouldRetryQuery`: a 4xx is a verdict, not a hiccup, so it is not retried; 5xx and transport failures keep the `DEFAULT_QUERY_RETRY` budget. The range check is `>= 400 && < 500` rather than the issue's `< 500` because `ApiError` only ever carries a real HTTP status - `http-client.ts` turns a timeout or a dead socket into a plain `Error` - so anything outside 4xx is unclassified and worth retrying. The prefetch key moves into `keys.ts` as `queryKeys.prefetch.allRequests()` and is invalidated on collection create, so a collection created mid-session gets its warm-cache pass.

### 6. The "include it here if convenient" item, included

`request-builder/index.tsx` told the user their request no longer exists whenever the lookup failed - including when the engine was simply not up - and offered a retry on the 404 where retrying is doomed. It now discriminates on the `RequestNotFoundError` sentinel (by type, never by message), same pattern as `DesignRunView` and #238's run pane: deleted gets **Close tab** and no retry, a transport failure gets "Couldn't load this request" with **Try again**.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **251 files, 2165 tests, all passing** (2136 on the base commit; 29 new). `pnpm type-check` clean.

App-only change, so no engine build or `ctest`: no C++, CMake or engine test file is in the diff, and the issue's own Tests section lists `pnpm test` only.

New, all mutation-checked (fix reverted, test confirmed red, fix restored):

- `queries/active-environment-lifecycle.test.tsx` (6) - deleting the active environment nulls the session id; deleting a different one does not; a failed delete keeps it. Then the guard: a dangling id is cleared once the list loads, a live one is kept, and **an id survives a failed environments query** - that last one is what fails if the guard keys on `environments.length` instead of `isSuccess`.
- `queries/collection-cascade-delete.test.tsx` (3) - asserts `getQueryState().isInvalidated`, not `getQueryData`: invalidation is what sends the next read back to the engine, and it is the only thing a revert flips. A failed delete invalidates nothing. Plus the prefetch re-run on create.
- `lib/query-retry.test.ts` (5) - 404 and the other 4xx are not retried; 5xx keeps the budget; a transport failure (a plain `Error`, not an `ApiError`) still retries.
- `stores/session-store.test.ts` (4) - the migration drops `activeCollectionId` and keeps the other two fields, tolerates a payload that never had the key, and the store is at v2 so the migration actually runs.
- `modules/request-builder/utils/script-variable-invalidation.test.ts` (8) - the predicate, plus a scan proving both send paths call it and neither still reads `if (preScriptParts)`. The scan half is not decoration: a correct predicate no send path calls is exactly the repo's written-but-never-read defect, and a unit test cannot see it. Guarded against scanning an empty string.
- `modules/request-builder/RequestBuilder.states.test.tsx` (3) - the two error panes, using the **real** `RequestNotFoundError` rather than a stubbed predicate, since a stub would assert nothing about the distinction the branch exists to make.

Updated: `useVariableResolver.origins.test.tsx`, `useVariableResolver.dynamic.test.tsx`, `RequestBuilderProvider.variables.test.tsx` - they fed collection scope through the removed store field; they now pass the explicit option, which is what every real caller does.

ESLint on the touched files reports the same 2 pre-existing warnings in `request-builder/index.tsx` (lines shifted only) as the base commit and **0 errors** - part of #189, not touched here. Prettier was run only on the files I touched that were clean beforehand.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/app/state-management.md` and `docs/app/variable-resolution.md` are updated in the same commit: the session-store fields and the v2 persistence, both closing points for a dangling environment id and why the guard keys on `isSuccess`, why the cascade invalidates coarsely, the prefetch key, the retry policy, that collection scope is explicit-only, and the invalidation step in the execute flow example. Coordinated with #241 by staying strictly inside this delta - the pre-existing drift on those pages (e.g. step 3 of the execute flow, which predates #226 moving resolution engine-side) is left for that issue rather than half-rewritten here.

## Related Issues
Closes #239

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdQr9niUQopycboMGcEjTm)_