### PR TITLE
fix(app): surface engineError, evict stale responses, harden store persistence

### DIFF
--- a/app/src/components/layout/Dock.engine-status.test.tsx
+++ b/app/src/components/layout/Dock.engine-status.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A disconnected engine has to say why.
+ *
+ * `queries/health.ts` writes `engineError` on every failed poll - ECONNREFUSED,
+ * a timeout, a TLS failure - and nothing in the app read the field. The two
+ * connection surfaces render `isEngineConnected` alone, so all three causes
+ * printed the same word and the difference was only visible in devtools. That
+ * is the write-only defect class CLAUDE.md calls this codebase's most repeated.
+ *
+ * Rendered, not source-scanned: the reason arrives through a store binding, and
+ * a scan cannot see a value that is not a literal in the file (the badge-hover
+ * guard missed both real instances for exactly that reason).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
+import { Dock } from "./Dock";
+import { useEngineStore } from "@/stores";
+
+// The Dock prints the app version, which Vite `define`s at build time; vitest
+// does not, so without this the component throws before it renders anything.
+vi.stubGlobal("__VAYU_VERSION__", "0.0.0-test");
+
+const renderDock = () =>
+	render(
+		<TooltipProvider>
+			<Dock />
+		</TooltipProvider>
+	);
+
+beforeEach(() => {
+	cleanup();
+	useEngineStore.setState({ isEngineConnected: false, engineError: null });
+});
+
+describe("the engine status indicator", () => {
+	it("says Disconnected with no affordance when no reason was recorded", () => {
+		renderDock();
+		expect(screen.getByText("Disconnected")).toBeTruthy();
+		// Nothing to hover for, so nothing pretends there is.
+		expect(document.querySelector("[tabindex='0'] .lucide-info")).toBeNull();
+	});
+
+	it("carries the health-poll error, reachable by keyboard", async () => {
+		useEngineStore.setState({
+			isEngineConnected: false,
+			engineError: "fetch failed: ECONNREFUSED 127.0.0.1:9876",
+		});
+		renderDock();
+
+		const trigger = screen.getByText("Disconnected").closest("[tabindex='0']");
+		expect(trigger).toBeTruthy();
+
+		fireEvent.focus(trigger!);
+		// Radix renders the content twice - the visible bubble and a
+		// visually-hidden copy carrying `role="tooltip"` for screen readers - so
+		// this counts "at least one", not "exactly one".
+		await waitFor(() => {
+			expect(
+				screen.getAllByText("fetch failed: ECONNREFUSED 127.0.0.1:9876").length
+			).toBeGreaterThan(0);
+		});
+	});
+
+	it("does not truncate the reason the transport produced", async () => {
+		// The full text is what identifies the failure - a port, a path, a TLS
+		// error. The tooltip wraps; nothing here clips it to a fixed length.
+		const long =
+			"request to http://127.0.0.1:9876/health failed, reason: connect ETIMEDOUT after 5000ms";
+		useEngineStore.setState({ isEngineConnected: false, engineError: long });
+		renderDock();
+
+		fireEvent.focus(screen.getByText("Disconnected").closest("[tabindex='0']")!);
+		await waitFor(() => expect(screen.getAllByText(long).length).toBeGreaterThan(0));
+	});
+
+	it("keeps the connected state a plain label", () => {
+		// A stale error must not follow the engine back up: `health.ts` clears it
+		// on success, and the indicator only offers the tooltip while down.
+		useEngineStore.setState({ isEngineConnected: true, engineError: null });
+		renderDock();
+		expect(screen.getByText("Connected")).toBeTruthy();
+		expect(screen.getByText("Connected").closest("[tabindex='0']")).toBeNull();
+	});
+});

--- a/app/src/components/layout/Dock.tsx
+++ b/app/src/components/layout/Dock.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { FolderOpen, Clock, Braces, PanelRight, Settings } from "lucide-react";
+import { FolderOpen, Clock, Braces, Info, PanelRight, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatChord } from "@/lib/platform";
 import { useLayoutStore, useEngineStore, useSaveStore, type DrawerView } from "@/stores";
@@ -118,10 +118,72 @@ function DockButton({ active, onClick, label, shortcut, children }: DockButtonPr
 	);
 }
 
+/**
+ * The connection light - and, when it is out, why.
+ *
+ * `engineError` is written on every failed health poll (`queries/health.ts`)
+ * and was read by nothing: the strip said "Disconnected" whether the engine had
+ * refused the connection, timed out, or died mid-request, and the only place
+ * the difference existed was devtools. It rides a tooltip rather than the strip
+ * because the text is whatever the transport produced and can run long, and the
+ * strip is a 2rem ambient row - the same reason `save-store`'s failure reason
+ * became a toast rather than a line here.
+ *
+ * The trigger is focusable, so the reason is reachable by keyboard and not only
+ * by hover, and the icon exists to say there is something to hover at all.
+ */
+function EngineStatus() {
+	const isEngineConnected = useEngineStore((s) => s.isEngineConnected);
+	const engineError = useEngineStore((s) => s.engineError);
+
+	/*
+	 * success-text, not status-success. The status tokens are tuned as fills and
+	 * indicators; as 12px text `status-success` measures 2.21:1 on the light
+	 * panel, well under the 4.5 AA needs. The `-text` variant is the accessible
+	 * pair (4.57 light / 9.58 dark) and the dot inherits it via bg-current,
+	 * clearing the 3:1 that non-text indicators need too.
+	 */
+	const className = cn(
+		"flex items-center gap-1 text-xs",
+		isEngineConnected ? "text-success-text" : "text-muted-foreground"
+	);
+	const label = (
+		<>
+			<span className="w-1.5 h-1.5 rounded-full bg-current" />
+			{isEngineConnected ? "Connected" : "Disconnected"}
+		</>
+	);
+
+	if (isEngineConnected || !engineError) {
+		return <span className={className}>{label}</span>;
+	}
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span
+					tabIndex={0}
+					className={cn(
+						className,
+						"cursor-help rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					)}
+				>
+					{label}
+					<Info className="w-3 h-3" aria-hidden="true" />
+				</span>
+			</TooltipTrigger>
+			{/* Wraps rather than truncates: an engine message names a port, a path
+			    or a TLS failure, and the tail is the part that identifies it. */}
+			<TooltipContent side="top">
+				<p className="max-w-64 whitespace-normal break-words">{engineError}</p>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 export function Dock() {
 	const { drawerOpen, drawerView, activateDrawerView, contextBarOpen, toggleContextBar } =
 		useLayoutStore();
-	const { isEngineConnected } = useEngineStore();
 	const saveStatus = useSaveStore((s) => s.status);
 
 	// No TooltipProvider of its own. A bare nested one would reset this strip to
@@ -156,23 +218,7 @@ export function Dock() {
 
 				{/* Middle - ambient status */}
 				<div className="flex-1 flex items-center justify-center gap-4">
-					{/*
-					 * success-text, not status-success. The status tokens are tuned as
-					 * fills and indicators; as 12px text `status-success` measures
-					 * 2.21:1 on the light panel, well under the 4.5 AA needs. The
-					 * `-text` variant is the accessible pair (4.57 light / 9.58 dark)
-					 * and the dot inherits it via bg-current, clearing the 3:1 that
-					 * non-text indicators need too.
-					 */}
-					<span
-						className={cn(
-							"flex items-center gap-1 text-xs",
-							isEngineConnected ? "text-success-text" : "text-muted-foreground"
-						)}
-					>
-						<span className="w-1.5 h-1.5 rounded-full bg-current" />
-						{isEngineConnected ? "Connected" : "Disconnected"}
-					</span>
+					<EngineStatus />
 
 					{/*
 					 * "Unsaved changes" is the only place in the app that says so.

--- a/app/src/queries/collections.delete-response.test.tsx
+++ b/app/src/queries/collections.delete-response.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Deleting a request has to take its response with it.
+ *
+ * `response-store` is keyed by request id and nothing evicted from it: both of
+ * its clearing actions had zero callers, so a session accumulated every
+ * response it had ever rendered - body plus raw copy - including for requests
+ * that had since been deleted.
+ *
+ * The tab seam (`closeTabsForEntities`) covers the tree's delete flows, and
+ * this covers the delete itself: it is the mutation, not the tab, that makes
+ * the response unreachable, and a caller that deletes without touching tabs
+ * would otherwise leak the entry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useDeleteRequestMutation } from "./collections";
+import { useResponseStore } from "@/stores/response-store";
+
+const deleteRequest = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		deleteRequest: (...a: unknown[]) => deleteRequest(...a),
+	},
+}));
+
+const wrapper = (client: QueryClient) =>
+	function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+	};
+
+const storeResponse = (requestId: string) =>
+	useResponseStore.getState().setResponse(requestId, {
+		status: 200,
+		statusText: "OK",
+		headers: {},
+		body: "{}",
+		bodyType: "json",
+		size: 2,
+		time: 1,
+	});
+
+beforeEach(() => {
+	deleteRequest.mockReset();
+	useResponseStore.getState().clearAll();
+});
+
+describe("useDeleteRequestMutation", () => {
+	it("drops the deleted request's stored response", async () => {
+		deleteRequest.mockResolvedValue(undefined);
+		storeResponse("req_1");
+		storeResponse("req_2");
+
+		const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const { result } = renderHook(() => useDeleteRequestMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync("req_1");
+
+		await waitFor(() => {
+			expect(useResponseStore.getState().getResponse("req_1")).toBeNull();
+		});
+		expect(useResponseStore.getState().getResponse("req_2")).not.toBeNull();
+	});
+
+	it("keeps the response when the delete fails", async () => {
+		// onSuccess only. A failed delete leaves the request alive, and its
+		// response is still the one the user is looking at.
+		deleteRequest.mockRejectedValue(new Error("database is locked"));
+		storeResponse("req_1");
+
+		const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const { result } = renderHook(() => useDeleteRequestMutation(), {
+			wrapper: wrapper(client),
+		});
+		await expect(result.current.mutateAsync("req_1")).rejects.toThrow("database is locked");
+
+		expect(useResponseStore.getState().getResponse("req_1")).not.toBeNull();
+	});
+});

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -17,6 +17,7 @@ import { apiService } from "@/services/api";
 import { ApiError } from "@/services";
 import { queryKeys } from "./keys";
 import { QUERY_CACHE } from "@/config/cache";
+import { useResponseStore } from "@/stores/response-store";
 import type {
 	Collection,
 	Request,
@@ -343,6 +344,12 @@ export function useDeleteRequestMutation() {
 			queryClient.removeQueries({
 				queryKey: queryKeys.requests.detail(deletedId),
 			});
+			// The response map is keyed by request id and nothing else evicts from
+			// it, so a deleted request would otherwise hold its body (plus the raw
+			// copy) for the rest of the session. Here rather than only at the tab
+			// seam: the delete is what makes the response unreachable, whether or
+			// not a tab was open on it.
+			useResponseStore.getState().clearResponse(deletedId);
 		},
 	});
 }

--- a/app/src/queries/environments.ts
+++ b/app/src/queries/environments.ts
@@ -28,17 +28,6 @@ export function useEnvironmentsQuery() {
 	});
 }
 
-/**
- * Fetch a single environment by ID
- */
-export function useEnvironmentQuery(environmentId: string | null) {
-	return useQuery({
-		queryKey: queryKeys.environments.detail(environmentId ?? ""),
-		queryFn: () => apiService.getEnvironment(environmentId!),
-		enabled: !!environmentId,
-	});
-}
-
 // ============ Environment Mutations ============
 
 /**

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -51,7 +51,6 @@ export {
 // Environments
 export {
 	useEnvironmentsQuery,
-	useEnvironmentQuery,
 	useCreateEnvironmentMutation,
 	useUpdateEnvironmentMutation,
 	useDeleteEnvironmentMutation,

--- a/app/src/services/load-test-service.test.ts
+++ b/app/src/services/load-test-service.test.ts
@@ -10,7 +10,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockSetStreaming = vi.fn();
 const mockSetError = vi.fn();
 const mockSetFinalReport = vi.fn();
-const mockReset = vi.fn();
 const mockAddMetricsBatch = vi.fn();
 vi.mock("@/stores", () => ({
 	useDashboardStore: {
@@ -18,7 +17,6 @@ vi.mock("@/stores", () => ({
 			setStreaming: mockSetStreaming,
 			setError: mockSetError,
 			setFinalReport: mockSetFinalReport,
-			reset: mockReset,
 			addMetricsBatch: mockAddMetricsBatch,
 		}),
 	},
@@ -54,11 +52,16 @@ describe("LoadTestService", () => {
 		expect(mockSetFinalReport).toHaveBeenCalled();
 	});
 
-	// Regression guard: the caller invokes store.startRun() first (which registers
-	// currentRunId + clears the series). startMonitoring must NOT call store.reset()
-	// - doing so nulls currentRunId and the dashboard shows "no active tests".
-	it("does not reset the store on start (would wipe the active run registered by startRun)", () => {
+	// The guard this replaces asserted `store.reset()` was not called on start -
+	// doing so nulls the currentRunId that startRun just registered and the
+	// dashboard shows "no active tests". The store no longer has a `reset`, so
+	// that mistake is now a compile error rather than a mock assertion. What is
+	// still worth pinning is the positive form: start only opens the stream.
+	it("only opens the stream on start, touching no run state the caller registered", () => {
 		loadTestService.startMonitoring("run_3");
-		expect(mockReset).not.toHaveBeenCalled();
+		expect(mockSetStreaming).toHaveBeenCalledWith(true);
+		expect(mockSetError).toHaveBeenCalledWith(null);
+		expect(mockSetFinalReport).not.toHaveBeenCalled();
+		expect(mockAddMetricsBatch).not.toHaveBeenCalled();
 	});
 });

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -51,11 +51,12 @@ class LoadTestService {
 		this.isConnected = true;
 
 		const store = useDashboardStore.getState();
-		// NOTE: do NOT call store.reset() here - the caller invokes store.startRun()
-		// first to register the run (currentRunId, config, "running" mode) and that
-		// already clears the historical series / currentMetrics / finalReport.
-		// reset() would null out currentRunId and the dashboard would show no active
-		// test (replay-from-0 renders clean off startRun's wipe already).
+		// Nothing here may clear the run: the caller invokes store.startRun() first
+		// to register it (currentRunId, config, "running" mode) and that already
+		// wipes the historical series / currentMetrics / finalReport. Nulling
+		// currentRunId would leave the dashboard showing no active test while one
+		// streams (replay-from-0 renders clean off startRun's wipe already). The
+		// store-wide `reset` this used to warn against no longer exists.
 		store.setStreaming(true);
 		store.setError(null);
 

--- a/app/src/stores/client-settings-store.test.ts
+++ b/app/src/stores/client-settings-store.test.ts
@@ -8,7 +8,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { useClientSettingsStore, SETTINGS_STORAGE_KEYS } from "./client-settings-store";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
 import {
@@ -16,6 +16,7 @@ import {
 	DEFAULT_SLO_THRESHOLD_MS,
 	SLO_THRESHOLD_MAX_MS,
 } from "@/constants/client-settings";
+import { DEFAULT_NOTIFICATION_PREFS } from "@/constants/toast";
 import { DEFAULT_MONO_FONT } from "@/constants/appearance";
 
 describe("client-settings store", () => {
@@ -83,5 +84,94 @@ describe("client-settings store", () => {
 		expect(SETTINGS_STORAGE_KEYS).not.toContain(STORAGE_KEYS.TABS_STORE);
 		expect(SETTINGS_STORAGE_KEYS).not.toContain(STORAGE_KEYS.SESSION_STORE);
 		expect(SETTINGS_STORAGE_KEYS).not.toContain(STORAGE_KEYS.LAYOUT_STORE);
+	});
+});
+
+/**
+ * What survives a reload.
+ *
+ * Two failure modes, both of which hand a component `undefined` where it reads
+ * a number. Zustand discards a persisted payload whose stamped version does not
+ * match unless a `migrate` is supplied, and its default merge is a top-level spread -
+ * so a stored nested object replaces its defaults wholesale, and the next key
+ * added to `NotificationPrefs` or `EditorPrefs` would arrive undefined for
+ * every existing user. `notifications.maxVisible` is the live example:
+ * `toast-store` caps the queue with `slice(-maxVisible)`, and `slice(-undefined)`
+ * is `slice(NaN)` - no cap at all, silently.
+ */
+describe("client-settings rehydration", () => {
+	const seed = (payload: unknown) =>
+		localStorage.setItem(STORAGE_KEYS.CLIENT_SETTINGS, JSON.stringify(payload));
+
+	// Explicit, not inherited: the suite above leaves the store wherever its last
+	// case put it, and a rehydration test that starts from the value it is about
+	// to assert proves nothing.
+	beforeEach(() => {
+		useClientSettingsStore.setState({
+			sloThresholdMs: DEFAULT_SLO_THRESHOLD_MS,
+			notifications: { ...DEFAULT_NOTIFICATION_PREFS },
+		});
+	});
+
+	afterEach(() => localStorage.removeItem(STORAGE_KEYS.CLIENT_SETTINGS));
+
+	it("keeps preferences written before the store carried a version", async () => {
+		// zustand only compares versions when the payload stamped one (`typeof
+		// version === "number"`), so declaring `version: 1` does not strand the
+		// unversioned payloads already in everyone's localStorage. Pinned because
+		// the bump would be a bad trade if it did.
+		expect(DEFAULT_SLO_THRESHOLD_MS).not.toBe(350); // the assertion below must bite
+		seed({ state: { sloThresholdMs: 350 } });
+
+		await useClientSettingsStore.persist.rehydrate();
+
+		expect(useClientSettingsStore.getState().sloThresholdMs).toBe(350);
+	});
+
+	it("translates a stamped older version instead of discarding it", async () => {
+		// What `migrate` is actually for. A stamped version that does not match
+		// is discarded outright when no migrate is supplied - zustand logs and
+		// hands the store its defaults - so the next bump would silently reset
+		// every preference. This is that bump, rehearsed one version early.
+		seed({ version: 0, state: { sloThresholdMs: 350 } });
+
+		await useClientSettingsStore.persist.rehydrate();
+
+		expect(useClientSettingsStore.getState().sloThresholdMs).toBe(350);
+	});
+
+	it("completes a nested object stored before a key was added to it", async () => {
+		seed({ version: 1, state: { notifications: { position: "top-right" } } });
+
+		await useClientSettingsStore.persist.rehydrate();
+
+		const n = useClientSettingsStore.getState().notifications;
+		expect(n.position).toBe("top-right"); // the stored key still wins
+		expect(n.maxVisible).toBe(DEFAULT_NOTIFICATION_PREFS.maxVisible);
+		expect(n.minSeverity).toBe(DEFAULT_NOTIFICATION_PREFS.minSeverity);
+	});
+
+	it("completes every object-valued preference, not only the ones named today", async () => {
+		// Enumerated rather than listed: a fifth nested preference that nobody
+		// wired into the merge fails here instead of shipping `undefined` keys.
+		const nested = (): Record<string, Record<string, unknown>> =>
+			Object.fromEntries(
+				Object.entries(useClientSettingsStore.getState()).filter(
+					([, v]) => v !== null && typeof v === "object"
+				)
+			) as Record<string, Record<string, unknown>>;
+
+		const expected = nested();
+		const keys = Object.keys(expected);
+		expect(keys.length).toBeGreaterThan(3); // guards the enumeration itself
+
+		for (const key of keys) {
+			seed({ version: 1, state: { [key]: {} } });
+			await useClientSettingsStore.persist.rehydrate();
+
+			expect({ [key]: Object.keys(nested()[key]).sort() }).toEqual({
+				[key]: Object.keys(expected[key]).sort(),
+			});
+		}
 	});
 });

--- a/app/src/stores/client-settings-store.ts
+++ b/app/src/stores/client-settings-store.ts
@@ -107,6 +107,60 @@ function applyMonoStack(stack: string): void {
 	document.documentElement.style.setProperty("--font-mono", stack);
 }
 
+/** A stored nested preference object, completed against the current defaults. */
+function completeNested<T extends object>(defaults: T, stored: unknown): T {
+	return stored && typeof stored === "object" && !Array.isArray(stored)
+		? { ...defaults, ...(stored as Partial<T>) }
+		: { ...defaults };
+}
+
+/**
+ * Zustand's shallow merge, plus one level of defaults under each nested object.
+ *
+ * The default merge is a top-level spread, so a payload written before a key
+ * was added to one of these objects replaces the whole object and ships
+ * `undefined` for the new key: `notifications.maxVisible` feeds
+ * `slice(-maxVisible)` in `toast-store`, and `slice(-undefined)` is
+ * `slice(NaN)` - the toast cap silently stops capping. `loadTestCeilings`
+ * already carried that defense written out by hand.
+ *
+ * Every object-valued preference needs a line here, and the store's own test
+ * enumerates them rather than trusting this list - a fifth nested pref that is
+ * not completed fails there.
+ */
+function mergeWithNestedDefaults(
+	persisted: unknown,
+	current: ClientSettingsState
+): ClientSettingsState {
+	if (!persisted || typeof persisted !== "object") return current;
+	const stored = persisted as Partial<ClientSettingsState>;
+	return {
+		...current,
+		...stored,
+		editor: completeNested(DEFAULT_EDITOR_PREFS, stored.editor),
+		autoSave: completeNested(DEFAULT_AUTO_SAVE_PREFS, stored.autoSave),
+		notifications: completeNested(DEFAULT_NOTIFICATION_PREFS, stored.notifications),
+		loadTestCeilings: completeNested(DEFAULT_LOAD_TEST_CEILINGS, stored.loadTestCeilings),
+	};
+}
+
+/**
+ * Version translation for the stored preferences.
+ *
+ * There is one shape so far, so this only has to hand the payload back -
+ * `mergeWithNestedDefaults` fills in anything missing. It exists for the next
+ * bump: zustand *discards* a payload whose stamped version does not match when
+ * no `migrate` is given (it logs and hands the store its defaults), so a bump
+ * without one resets every preference. Add a branch here instead.
+ *
+ * The payloads already in users' localStorage carry no version at all, and
+ * zustand only compares when one was stamped - which is why declaring
+ * `version: 1` here does not reset anyone.
+ */
+function migrateClientSettings(persisted: unknown) {
+	return (persisted ?? {}) as Partial<ClientSettingsState>;
+}
+
 /** Flag the document so the global CSS can collapse transitions/animations. */
 function applyReducedMotion(on: boolean): void {
 	if (typeof document === "undefined") return;
@@ -164,6 +218,9 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 		{
 			name: STORAGE_KEYS.CLIENT_SETTINGS,
 			storage: createJSONStorage(() => localStorage),
+			version: 1,
+			migrate: migrateClientSettings,
+			merge: mergeWithNestedDefaults,
 			partialize: (s) => ({
 				editor: s.editor,
 				monoFont: s.monoFont,
@@ -194,12 +251,10 @@ export const useClientSettingsStore = create<ClientSettingsState>()(
 					// Re-clamp on the way out of storage. The bounds are the
 					// engine's crash guards, and a build that tightens one
 					// would otherwise keep offering the stored ceiling above
-					// it. The spread also fills in a key added after the
-					// stored payload was written.
-					state.loadTestCeilings = clampCeilings({
-						...DEFAULT_LOAD_TEST_CEILINGS,
-						...state.loadTestCeilings,
-					});
+					// it. Filling in a key added after the payload was written
+					// is `mergeWithNestedDefaults`'s job now, for every nested
+					// object rather than this one.
+					state.loadTestCeilings = clampCeilings(state.loadTestCeilings);
 				}
 			},
 		}

--- a/app/src/stores/dashboard-store.ts
+++ b/app/src/stores/dashboard-store.ts
@@ -109,14 +109,9 @@ interface DashboardState {
 	setError: (error: string | null) => void;
 	setActiveView: (view: DashboardView) => void;
 	setStopping: (stopping: boolean) => void;
-	reset: () => void;
-
-	// Helpers
-	getLatestMetrics: () => LoadTestMetrics | null;
-	getMetricsWindow: (seconds: number) => LoadTestMetrics[];
 }
 
-export const useDashboardStore = create<DashboardState>((set, get) => ({
+export const useDashboardStore = create<DashboardState>((set) => ({
 	currentRunId: null,
 	mode: "running",
 	isStreaming: false,
@@ -235,40 +230,4 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
 	setError: (error) => set({ error }),
 	setActiveView: (view) => set({ activeView: view }),
 	setStopping: (stopping) => set({ isStopping: stopping }),
-
-	reset: () =>
-		set({
-			currentRunId: null,
-			mode: "running",
-			isStreaming: false,
-			currentMetrics: null,
-			historicalMetrics: [],
-			finalReport: null,
-			error: null,
-			activeView: "metrics",
-			isStopping: false,
-			loadTestConfig: null,
-			requestInfo: null,
-			sourceRequestId: null,
-			peakConcurrency: 0,
-			breakpoint: INITIAL_BREAKPOINT,
-		}),
-
-	// Helpers
-	getLatestMetrics: () => {
-		const { historicalMetrics } = get();
-		return historicalMetrics.length > 0
-			? historicalMetrics[historicalMetrics.length - 1]
-			: null;
-	},
-
-	getMetricsWindow: (seconds) => {
-		const { historicalMetrics } = get();
-		if (historicalMetrics.length === 0) return [];
-
-		const latest = historicalMetrics[historicalMetrics.length - 1];
-		const cutoffTime = latest.timestamp - seconds * 1000;
-
-		return historicalMetrics.filter((m) => m.timestamp >= cutoffTime);
-	},
 }));

--- a/app/src/stores/engine-store.ts
+++ b/app/src/stores/engine-store.ts
@@ -29,12 +29,8 @@ interface EngineState {
 	setEngineError: (error: string | null) => void;
 
 	// Restart actions
-	setPendingRestart: (pending: boolean, keys?: string[]) => void;
 	addRestartRequiredKey: (key: string) => void;
 	clearRestartRequired: () => void;
-
-	// Reset
-	reset: () => void;
 }
 
 export const useEngineStore = create<EngineState>()((set) => ({
@@ -49,9 +45,6 @@ export const useEngineStore = create<EngineState>()((set) => ({
 	setEngineError: (error) => set({ engineError: error }),
 
 	// Restart actions
-	setPendingRestart: (pending, keys = []) =>
-		set({ pendingRestart: pending, restartRequiredKeys: keys }),
-
 	addRestartRequiredKey: (key) =>
 		set((state) => ({
 			pendingRestart: true,
@@ -61,13 +54,4 @@ export const useEngineStore = create<EngineState>()((set) => ({
 		})),
 
 	clearRestartRequired: () => set({ pendingRestart: false, restartRequiredKeys: [] }),
-
-	// Reset all
-	reset: () =>
-		set({
-			isEngineConnected: false,
-			engineError: null,
-			pendingRestart: false,
-			restartRequiredKeys: [],
-		}),
 }));

--- a/app/src/stores/persist-migrations.test.ts
+++ b/app/src/stores/persist-migrations.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A version bump must not be how a user loses their workspace.
+ *
+ * zustand compares a persisted payload's stamped version against the store's
+ * and, when they differ and no `migrate` is supplied, throws the payload away -
+ * it logs to the console and hands the store its defaults. `tabs-store` and
+ * `session-store` were `version: 1` with no migrate, so the next bump would
+ * have closed everyone's tabs and forgotten their active environment, quietly,
+ * as a side effect of an unrelated change.
+ *
+ * The stubs are pass-throughs because there is one shape so far. What is worth
+ * pinning is that the *seam* exists: these cases rehearse the next bump by
+ * feeding each store a payload stamped with an older version.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useTabsStore } from "./tabs-store";
+import { useSessionStore } from "./session-store";
+import { STORAGE_KEYS } from "@/constants/storage-keys";
+
+const seed = (key: string, payload: unknown) => localStorage.setItem(key, JSON.stringify(payload));
+
+beforeEach(() => {
+	localStorage.clear();
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+	useSessionStore.setState({
+		activeEnvironmentId: null,
+		activeCollectionId: null,
+		lastCollectionId: null,
+	});
+});
+
+describe("tabs-store rehydration", () => {
+	it("carries tabs across a version bump instead of dropping them", async () => {
+		seed(STORAGE_KEYS.TABS_STORE, {
+			version: 0,
+			state: {
+				openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+				activeTabId: "t1",
+			},
+		});
+
+		await useTabsStore.persist.rehydrate();
+
+		const { openTabs, activeTabId } = useTabsStore.getState();
+		expect(openTabs.map((t) => t.entityId)).toEqual(["r1"]);
+		expect(activeTabId).toBe("t1");
+	});
+
+	it("falls back to an empty workspace on a payload of the wrong shape", async () => {
+		// A hand-edited or half-written localStorage entry must not put a
+		// non-array where every reader iterates.
+		seed(STORAGE_KEYS.TABS_STORE, { version: 0, state: { openTabs: "nope", activeTabId: 7 } });
+
+		await useTabsStore.persist.rehydrate();
+
+		expect(useTabsStore.getState().openTabs).toEqual([]);
+		expect(useTabsStore.getState().activeTabId).toBeNull();
+	});
+});
+
+describe("session-store rehydration", () => {
+	it("carries the active ids across a version bump", async () => {
+		seed(STORAGE_KEYS.SESSION_STORE, {
+			version: 0,
+			state: {
+				activeEnvironmentId: "env_1",
+				activeCollectionId: "col_1",
+				lastCollectionId: "col_2",
+			},
+		});
+
+		await useSessionStore.persist.rehydrate();
+
+		const s = useSessionStore.getState();
+		expect(s.activeEnvironmentId).toBe("env_1");
+		expect(s.activeCollectionId).toBe("col_1");
+		expect(s.lastCollectionId).toBe("col_2");
+	});
+
+	it("refuses a non-string id rather than handing one to the resolver", async () => {
+		seed(STORAGE_KEYS.SESSION_STORE, {
+			version: 0,
+			state: { activeEnvironmentId: 42, activeCollectionId: {}, lastCollectionId: null },
+		});
+
+		await useSessionStore.persist.rehydrate();
+
+		const s = useSessionStore.getState();
+		expect(s.activeEnvironmentId).toBeNull();
+		expect(s.activeCollectionId).toBeNull();
+	});
+});

--- a/app/src/stores/session-store.ts
+++ b/app/src/stores/session-store.ts
@@ -35,6 +35,34 @@ interface SessionState {
 	setLastCollectionId: (id: string | null) => void;
 }
 
+/** The slice of the store that reaches localStorage - see `partialize` below. */
+interface PersistedSession {
+	activeEnvironmentId: string | null;
+	activeCollectionId: string | null;
+	lastCollectionId: string | null;
+}
+
+const asId = (value: unknown): string | null => (typeof value === "string" ? value : null);
+
+/**
+ * Version translation for the persisted session ids.
+ *
+ * zustand *discards* a payload whose stamped version does not match `version`
+ * unless a `migrate` is supplied - it logs to the console and hands the store
+ * its defaults - so a future bump without this would silently drop the user's
+ * active environment and collection. This is where that bump goes: add a branch
+ * per old version. Until then there is one shape, and the only work is refusing
+ * a payload that is not it.
+ */
+function migrateSession(persisted: unknown): PersistedSession {
+	const stored = (persisted ?? {}) as Partial<PersistedSession>;
+	return {
+		activeEnvironmentId: asId(stored.activeEnvironmentId),
+		activeCollectionId: asId(stored.activeCollectionId),
+		lastCollectionId: asId(stored.lastCollectionId),
+	};
+}
+
 export const useSessionStore = create<SessionState>()(
 	persist(
 		(set) => ({
@@ -53,6 +81,7 @@ export const useSessionStore = create<SessionState>()(
 				activeCollectionId: state.activeCollectionId,
 				lastCollectionId: state.lastCollectionId,
 			}),
+			migrate: migrateSession,
 		}
 	)
 );

--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -8,6 +8,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useTabsStore } from "./tabs-store";
 import { useSaveStore, type SaveContext } from "./save-store";
+import { useResponseStore } from "./response-store";
 
 beforeEach(() => {
 	useTabsStore.setState({ openTabs: [], activeTabId: null });
@@ -194,5 +195,68 @@ describe("LRU eviction never takes a dirty tab", () => {
 		// which carries no edits yet. Every tab holding work survives.
 		const ids = useTabsStore.getState().openTabs.map((t) => t.entityId);
 		for (let i = 0; i < 12; i++) expect(ids).toContain(`req_${i}`);
+	});
+});
+
+/**
+ * Nothing else evicts from the response map.
+ *
+ * `response-store` is keyed by request id, holds a body plus its raw copy per
+ * entry, and had no caller for either of its clearing actions - so a session
+ * that opened many requests kept every response it had ever seen, including for
+ * requests that no longer exist. Both callers of `closeTabsForEntities` reach it
+ * after a delete (one request, or a collection and everything under it), which
+ * makes it the seam where the ids are known to be gone for good.
+ */
+describe("closeTabsForEntities evicts stored responses", () => {
+	const storeResponse = (requestId: string) =>
+		useResponseStore.getState().setResponse(requestId, {
+			status: 200,
+			statusText: "OK",
+			headers: {},
+			body: "{}",
+			bodyType: "json",
+			size: 2,
+			time: 1,
+		});
+
+	beforeEach(() => useResponseStore.getState().clearAll());
+
+	it("drops the response of a deleted request", () => {
+		useTabsStore.getState().openTab({ type: "request", entityId: "r1" });
+		storeResponse("r1");
+
+		useTabsStore.getState().closeTabsForEntities(["r1"]);
+
+		expect(useResponseStore.getState().getResponse("r1")).toBeNull();
+	});
+
+	it("drops every response in a collection cascade", () => {
+		storeResponse("r1");
+		storeResponse("r2");
+		storeResponse("survivor");
+
+		// The tree hands over the collection plus every descendant it gathered.
+		useTabsStore.getState().closeTabsForEntities(["col_1", "r1", "r2"]);
+
+		expect(useResponseStore.getState().getResponse("r1")).toBeNull();
+		expect(useResponseStore.getState().getResponse("r2")).toBeNull();
+		expect(useResponseStore.getState().getResponse("survivor")).not.toBeNull();
+	});
+
+	it("drops the response even when no tab was open on the request", () => {
+		// The early return for "nothing matched" sits after the eviction on
+		// purpose: a deleted request with no tab still had a response cached.
+		storeResponse("r_no_tab");
+
+		useTabsStore.getState().closeTabsForEntities(["r_no_tab"]);
+
+		expect(useResponseStore.getState().getResponse("r_no_tab")).toBeNull();
+	});
+
+	it("leaves responses alone when handed nothing", () => {
+		storeResponse("r1");
+		useTabsStore.getState().closeTabsForEntities([]);
+		expect(useResponseStore.getState().getResponse("r1")).not.toBeNull();
 	});
 });

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -9,6 +9,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
 import { useSaveStore, type SaveContext } from "./save-store";
+import { useResponseStore } from "./response-store";
 
 export type TabType =
 	| "welcome"
@@ -42,10 +43,6 @@ interface TabsState {
 	/** Close every tab bound to one of the given entity ids (e.g. after deletion). */
 	closeTabsForEntities: (entityIds: Iterable<string>) => void;
 	focusTab: (tabId: string) => void;
-	/** Replace the active tab in place (used when welcome tab spawns a request) */
-	replaceActiveTab: (tab: Omit<Tab, "id">) => void;
-	/** Close all tabs */
-	closeAll: () => void;
 }
 
 /**
@@ -91,6 +88,29 @@ function isTabDirty(tab: Tab, contexts: Map<string, SaveContext>): boolean {
 		default:
 			return false;
 	}
+}
+
+/** The slice of the store that reaches localStorage - see `partialize` below. */
+interface PersistedTabs {
+	openTabs: Tab[];
+	activeTabId: string | null;
+}
+
+/**
+ * Version translation for the persisted tab list.
+ *
+ * zustand *discards* a payload whose stamped version does not match `version`
+ * unless a `migrate` is supplied - it logs to the console and hands the store
+ * its defaults - so a future bump without this would silently close everyone's
+ * tabs. This is where that bump goes: add a branch per old version. Until then
+ * there is one shape, and the only work is refusing a payload that is not it.
+ */
+function migrateTabs(persisted: unknown): PersistedTabs {
+	const stored = (persisted ?? {}) as Partial<PersistedTabs>;
+	return {
+		openTabs: Array.isArray(stored.openTabs) ? stored.openTabs : [],
+		activeTabId: typeof stored.activeTabId === "string" ? stored.activeTabId : null,
+	};
 }
 
 function makeId() {
@@ -164,6 +184,16 @@ export const useTabsStore = create<TabsState>()(
 			closeTabsForEntities: (entityIds) => {
 				const ids = new Set(entityIds);
 				if (ids.size === 0) return;
+
+				// Both callers reach this after a delete (a request, or a collection
+				// with everything under it), so the responses keyed by those ids can
+				// never be displayed again - nothing else evicts from that map and
+				// each entry holds a body plus its raw copy. Done before the early
+				// return below: a deleted request with no open tab still leaves a
+				// response behind. `clearResponse` on an id with none is a no-op.
+				const { clearResponse } = useResponseStore.getState();
+				for (const id of ids) clearResponse(id);
+
 				const { openTabs, activeTabId } = get();
 				const shouldClose = (t: Tab) => t.entityId !== null && ids.has(t.entityId);
 
@@ -193,31 +223,6 @@ export const useTabsStore = create<TabsState>()(
 					set({ activeTabId: tabId });
 				}
 			},
-
-			replaceActiveTab: (tabDef) => {
-				const { openTabs, activeTabId } = get();
-				if (!activeTabId) {
-					get().openTab(tabDef);
-					return;
-				}
-				// If a tab for this entity already exists elsewhere, focus it instead
-				const isSingleton = SINGLETON_TYPES.includes(tabDef.type);
-				const existing = openTabs.find(
-					(t) =>
-						t.id !== activeTabId &&
-						(isSingleton
-							? t.type === tabDef.type
-							: t.type === tabDef.type && t.entityId === tabDef.entityId)
-				);
-				if (existing) {
-					set({ activeTabId: existing.id });
-					return;
-				}
-				const newTab: Tab = { ...tabDef, id: activeTabId };
-				set({ openTabs: openTabs.map((t) => (t.id === activeTabId ? newTab : t)) });
-			},
-
-			closeAll: () => set({ openTabs: [], activeTabId: null }),
 		}),
 		{
 			name: STORAGE_KEYS.TABS_STORE,
@@ -226,6 +231,7 @@ export const useTabsStore = create<TabsState>()(
 				openTabs: state.openTabs,
 				activeTabId: state.activeTabId,
 			}),
+			migrate: migrateTabs,
 		}
 	)
 );

--- a/app/src/stores/toast-store.ts
+++ b/app/src/stores/toast-store.ts
@@ -81,7 +81,6 @@ interface ToastState {
 	showToast: (input: string | ToastOptions, variant?: ToastVariant) => string;
 	/** Closes the toast; it leaves the queue TIMING.TOAST_EXIT_MS later. */
 	dismissToast: (id: string) => void;
-	dismissAll: () => void;
 }
 
 export const useToastStore = create<ToastState>((set, get) => ({
@@ -155,9 +154,5 @@ export const useToastStore = create<ToastState>((set, get) => ({
 		setTimeout(() => {
 			set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
 		}, TIMING.TOAST_EXIT_MS);
-	},
-
-	dismissAll: () => {
-		for (const t of get().toasts) get().dismissToast(t.id);
 	},
 }));

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -106,7 +106,7 @@ Resize handle on the right edge (double-click resets to defaults). Visibility to
 Footer bar (h-8, shrink-0). Horizontal layout:
 
 - **Left - drawer switchers:** buttons for Collections (⇧⌘E), History (⇧⌘H), Variables (⇧⌘U), Settings (⌘,). Each activates its Drawer view; active state highlights when the drawer is open on that view. Settings sits here too because it is now a Drawer view like the rest.
-- **Middle - ambient status:** engine connection status (green dot + text if connected), save status (Saving… / Saved), app version. A save *failure* is not shown here - it is reported as a toast, like every other failure in the app.
+- **Middle - ambient status:** engine connection status (green dot + text if connected), save status (Saving… / Saved), app version. When the engine is *down* the indicator becomes a focusable tooltip carrying `engineError` - the health poll's reason, which was previously recorded and rendered nowhere, so a refused connection, a timeout and a TLS failure all read as one word. A save *failure* is not shown here - it is reported as a toast, like every other failure in the app.
 - **Right - toggles:** Context bar toggle (⌘I).
 
 ## Request Builder (`modules/request-builder/`)

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -65,13 +65,19 @@ Manages all open tabs (welcome, request, collection, dashboard, run, variables, 
   a `Tab` does not record which editor the sidebar has selected - over-matching
   keeps a tab that could have closed, under-matching loses work. Nothing is
   flushed *during* eviction; the predicate already refused the tab
-- Persistence: `vayu.tabs` (v1)
+- Response eviction: `closeTabsForEntities` clears each id's entry in
+  `response-store`. Both callers reach it after a delete, and nothing else
+  evicts from that map
+- Persistence: `vayu.tabs` (v1), with a pass-through `migrate`. zustand discards
+  a payload whose *stamped* version differs from the store's when no `migrate`
+  is supplied, so the stub is where the next bump goes; it also refuses a
+  payload of the wrong shape rather than handing a non-array to every reader
 
 **Key Methods:**
 ```typescript
-const { openTab, closeTab, focusTab, replaceActiveTab, closeAll } = useTabsStore();
+const { openTab, closeTab, focusTab, closeTabsForEntities } = useTabsStore();
 openTab({ type: "request", entityId: "req-123" });
-replaceActiveTab({ type: "request", entityId: "req-456" }); // Replace active in place
+closeTabsForEntities(["req-123"]); // after a delete: closes tabs, drops responses
 ```
 
 #### `layout-store.ts` - Drawer, Context Bar, & Split Ratio
@@ -122,7 +128,9 @@ const { activeEnvironmentId, setActiveEnvironmentId } = useSessionStore();
 setActiveCollectionId(collectionId);
 ```
 
-**Persistence:** `vayu.session` (v1)
+**Persistence:** `vayu.session` (v1), with the same pass-through `migrate` as
+`tabs-store` - and the same shape check, so a corrupt id never reaches the
+variable resolver.
 
 #### `engine-store.ts` - Engine Connection & Restart State
 
@@ -143,12 +151,16 @@ Merged store managing engine connection status and restart-required notification
 const {
   isEngineConnected, setEngineConnected,
   engineError, setEngineError,
-  pendingRestart, setPendingRestart, addRestartRequiredKey, clearRestartRequired,
-  reset
+  pendingRestart, addRestartRequiredKey, clearRestartRequired,
 } = useEngineStore();
 ```
 
-**Non-persisted** (reset on app restart).
+`engineError` is what the failed health poll recorded (`queries/health.ts`), and
+the Dock's connection indicator renders it in a tooltip when the engine is down -
+"Disconnected" alone read the same for a refused connection, a timeout and a TLS
+failure.
+
+**Non-persisted** (cleared on app restart).
 
 #### `save-store.ts` - Centralized Auto-Save
 
@@ -228,6 +240,12 @@ In-memory storage of responses per request ID, persisted across view/tab switche
 const { setResponse, getResponse, clearResponse, clearAll } = useResponseStore();
 ```
 
+**Eviction:** `clearResponse` runs from `useDeleteRequestMutation` (the delete is
+what makes the response unreachable) and from `tabs-store`'s
+`closeTabsForEntities` (the collection cascade, which knows every descendant id).
+Nothing else drops an entry, so a map with no eviction at all grew for the whole
+session - each entry holds a body plus its raw copy.
+
 **Non-persisted** (responses are reloadable from backend).
 
 #### `client-settings-store.ts` - Renderer Preferences
@@ -242,7 +260,18 @@ import { SETTINGS_STORAGE_KEYS } from "@/stores";  // localStorage keys reset by
 
 `loadTestCeilings` is the one slice with a bound outside the app: each value is clamped to `LOAD_TEST_CEILING_BOUNDS` (`constants/load-test.ts`) on write **and** on rehydrate, because the bounds are the engine's crash guards and a build that tightens one must not keep offering a stored ceiling above it. The load dialog turns them into its field ranges via `resolveLoadTestLimits`; nothing else reads them.
 
-**Persisted** to localStorage (via `zustand/persist`); workspace/session state (open tabs, layout, active collection) is deliberately excluded from the reset.
+**Persisted** to localStorage (via `zustand/persist`), `version: 1` with a
+pass-through `migrate`; workspace/session state (open tabs, layout, active
+collection) is deliberately excluded from the reset.
+
+**Nested preferences are completed against their defaults on rehydrate**
+(`mergeWithNestedDefaults`). zustand's merge is a shallow top-level spread, so a
+stored `editor` / `autoSave` / `notifications` / `loadTestCeilings` object
+replaces its defaults whole and a key added after that payload was written
+arrives `undefined` - `notifications.maxVisible` feeds `slice(-maxVisible)` in
+`toast-store`, and `slice(-undefined)` caps nothing. Adding an object-valued
+preference means adding a line to that merge; the store's test enumerates them
+rather than trusting the list.
 
 #### `dashboard-store.ts` - Load Test Metrics & State
 
@@ -281,10 +310,13 @@ const {
   addMetricsBatch,  // Efficiently fold batch into history and update aggregates
   setFinalReport, setError, setActiveView, setStopping,
   setLiveWindowSeconds,  // Update the live retention window (from useLiveChartWindow)
-  reset,
-  getLatestMetrics, getMetricsWindow
+  setMaxRetainedTicks
 } = useDashboardStore();
 ```
+
+There is deliberately no store-wide `reset`: `startRun` already wipes the series,
+the report and the aggregates, and a reset on top of it nulls `currentRunId` -
+the dashboard then shows no active test while one streams.
 
 **Non-persisted** (fresh per session).
 
@@ -320,7 +352,7 @@ off. There is no `setTimeout` in the store.
 
 **Key Methods:**
 ```typescript
-const { showToast, dismissToast, dismissAll } = useToastStore();
+const { showToast, dismissToast } = useToastStore();
 
 showToast("Run history cleared", "success");   // string form, still supported
 showToast({                                     // returns the toast id
@@ -463,7 +495,6 @@ Located in `app/src/services/queries/` (or `hooks/`), with types and cache inval
 #### Environments & Variables
 
 - **`useEnvironmentsQuery()`** - Fetch all environments
-- **`useEnvironmentQuery(id)`** - Fetch single environment
 - **`useGlobalsQuery()`** - Fetch global variables
 
 **Mutations:**


### PR DESCRIPTION
## Description

The hygiene tail of the state-layer sweep (#235). Four items, all renderer-side.

**Plan.** The root cause across items 1-3 is the repo's documented written-but-never-read class: a field, an action or a map entry with no consumer on the other side. So the approach is to give each one a reader or delete it, rather than add surface. `engineError` gets a reader (the Dock's connection indicator, in a tooltip); the eight dead actions and `useEnvironmentQuery` are deleted, which makes the type-check the proof that nothing called them; the response map gets its eviction wired at the two seams that know an id is gone for good. Item 4 is a forward hazard rather than a live bug, and is fixed at the persist layer: nested preference objects are completed against their defaults on rehydrate, and every persisted store now carries the `migrate` a version bump needs. **Alternative rejected:** surfacing `engineError` as a toast rather than a tooltip. The health poll fires on an interval, so a down engine would re-raise it on every tick; dedup in `toast-store` collapses the copies but a boot-time engine that is merely slow would still throw a toast the user did not ask for. The Dock is where connection state already lives.

Two anchors had drifted from the issue's snapshot and are noted here:

- The dashboard `reset` comment the issue placed at `dashboard-store.ts:239` actually lives in `services/load-test-service.ts` - a `NOTE: do NOT call store.reset()`. Deleting the action turns that invariant into a compile error, so the comment is rewritten to state it positively and the mock-level regression test is replaced with the positive form (start only opens the stream).
- The issue expected `version: 1` on `client-settings-store` to need a `migrate` so existing users are not reset. Verified against zustand 5.0.14: it only compares versions when the payload *stamped* one (`typeof version === "number"`), and the payloads in users' localStorage carry none, so they pass through either way. The `migrate` is still added, for the same reason as the tabs/session stubs - a *stamped* mismatch is discarded outright - and the tests pin both facts separately.

### 1. `engineError` has a reader

Written on every failed health poll (`queries/health.ts`), read by nothing: "Disconnected" said the same thing for ECONNREFUSED, a timeout and a TLS failure, and the difference only existed in devtools. The Dock's indicator becomes `EngineStatus`; when the engine is down and a reason was recorded, the label is a focusable tooltip trigger carrying that text, with an `Info` glyph so there is something to say it can be hovered. The text wraps rather than truncating - the tail is what identifies the failure.

### 2. Eight dead actions deleted (plus `useEnvironmentQuery`)

engine-store `setPendingRestart` / `reset`; dashboard-store `reset` / `getLatestMetrics` / `getMetricsWindow`; tabs-store `replaceActiveTab` / `closeAll`; toast-store `dismissAll`; and `useEnvironmentQuery`, folded in per the issue. `pnpm type-check` passing is the proof that none had a caller.

### 3. The response map is evicted

`clearResponse(requestId)` now runs from `useDeleteRequestMutation.onSuccess` (the delete is what makes a response unreachable, tab or no tab) and from `tabs-store`'s `closeTabsForEntities` (where the collection cascade already knows every descendant id). Eviction sits *before* that function's "nothing matched" early return, so a deleted request with no open tab is still cleared.

### 4. Persistence versioning

`client-settings-store` gains `version: 1`, a `migrate`, and a `merge` that completes each stored nested object against its defaults - the general form of the `loadTestCeilings` defense that was written out by hand. The live hazard: `notifications.maxVisible` feeds `slice(-maxVisible)` in `toast-store`, and `slice(-undefined)` is `slice(NaN)`, so a payload predating a new key would silently stop capping the toast queue. `tabs-store` and `session-store` gain the pass-through `migrate` a future bump needs (both also refuse a payload of the wrong shape rather than handing a non-array to every reader).

### Deliberate deviation

`response-store.clearAll` is kept rather than wired to Clear-history, which the issue offered as optional. Clearing run history deletes *runs*; the response map is keyed by *request* id, so evicting there would take away responses the user can still see and whose requests still exist. It remains the reset seam three test files use. Flagged rather than silently skipped.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **248 files, 2154 tests passed** on this branch. 3 test files and 18 cases are new here, and one existing case was rewritten in place rather than added. (I ran the suite on the branch only, not on the base commit, so those are the measured numbers and the baseline is inferred from them.)
- `cd app && pnpm type-check` - clean. This is what proves item 2: the deletions compile.
- `npx prettier --check` and `npx eslint` on every touched source file - clean. Docs were already not prettier-clean on master and are left unformatted per CLAUDE.md.
- Engine untouched, so no engine build or ctest run: the issue is app-only ("No engine or API change").

New/changed tests, each mutation-checked (fix reverted, failure confirmed, restored):

| Test | Guards | Reverting the fix |
|---|---|---|
| `Dock.engine-status.test.tsx` (4, new) | the reason renders, is keyboard-reachable, is not truncated, and does not follow the engine back up | 2 fail - no trigger to focus |
| `client-settings-store.test.ts` (+4) | unversioned payloads survive the bump; a *stamped* older version is translated; a nested object is completed; **every** object-valued pref is completed (enumerated, so a fifth one that nobody wired fails here) | dropping `migrate` fails 1; dropping `merge` fails 2 |
| `persist-migrations.test.ts` (4, new) | tabs and session survive a stamped version bump; a wrong-shaped payload degrades to defaults | dropping either `migrate` fails 1 each |
| `tabs-store.test.ts` (+4) | single delete, collection cascade, delete with no open tab, and the empty-input no-op | all but the last fail |
| `collections.delete-response.test.tsx` (2, new) | the mutation drops the response; a *failed* delete keeps it | 1 fails |
| `load-test-service.test.ts` | replaces the `reset` mock assertion with the positive form | n/a - the mistake is now a compile error |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #240

Docs updated in the same commit per CLAUDE.md: `docs/app/state-management.md` (tabs / session / engine / response / dashboard / toast / client-settings inventories, eviction and persistence notes) and `docs/app/COMPONENTS.md` (the Dock's ambient status row).