### PR TITLE
feat(app): complete variable names inside pm.* accessors in script editors

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -22,6 +22,7 @@ import { useActiveEnvironmentGuard } from "./hooks/useActiveEnvironmentGuard";
 import { useAppearance } from "./hooks/useAppearance";
 import { useScriptCompletionProvider } from "./hooks/useScriptCompletionProvider";
 import { useVariableCompletionProvider } from "./hooks/useVariableCompletionProvider";
+import { useScriptVariableCompletionProvider } from "./hooks/useScriptVariableCompletionProvider";
 import { useMenuActions } from "./hooks/useMenuActions";
 import { useSaveStore } from "./stores/save-store";
 
@@ -54,6 +55,10 @@ function App() {
 	// `{{variable}}` completion in the body editors. Global per language, so one
 	// registration covers every editor instance - same as the line above.
 	useVariableCompletionProvider();
+	// Variable names inside `pm.environment.get("…")` and its siblings - the
+	// script editors' equivalent of the line above, since a script names
+	// variables through the accessors rather than through braces.
+	useScriptVariableCompletionProvider();
 
 	// Bridge native menu items (Preferences…/Settings) to in-app navigation
 	useMenuActions();

--- a/app/src/hooks/script-completion-split.test.tsx
+++ b/app/src/hooks/script-completion-split.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The two script-editor completion lists, and the line they divide.
+ *
+ * `useScriptCompletionProvider` owns the dotted `pm.*` surface; this hook's
+ * sibling owns variable names. Both register against `javascript`, so Monaco
+ * merges whatever they return - which makes "who yields where" a property of
+ * the pair, not of either file, and the reason they are tested together.
+ *
+ * Driven the way Monaco drives them (build the provider, call
+ * `provideCompletionItems` with a model stub) rather than by scanning source:
+ * the scope filter and the string-literal guard are both invisible to a grep.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+interface Suggestion {
+	label: string;
+	insertText: string;
+	detail?: string;
+	range: { startColumn: number; endColumn: number };
+}
+
+interface ProviderLike {
+	provideCompletionItems: (
+		model: { getLineContent: () => string },
+		position: { lineNumber: number; column: number }
+	) => { suggestions: Suggestion[] };
+}
+
+const registered: ProviderLike[] = [];
+
+const monacoStub = {
+	languages: {
+		CompletionItemKind: { Variable: 4, Function: 1 },
+		registerCompletionItemProvider: (_language: string, provider: ProviderLike) => {
+			registered.push(provider);
+			return { dispose: () => {} };
+		},
+	},
+};
+
+vi.mock("@monaco-editor/react", () => ({ useMonaco: () => monacoStub }));
+
+const variables: Record<string, { value: string; scope: string }> = {};
+
+/**
+ * Which collection each name is defined on, for the D2 rule below. Defaults to
+ * the active one, so only a test that cares has to say anything.
+ */
+const ACTIVE_COLLECTION = "leaf";
+const definedOn: Record<string, string> = {};
+
+vi.mock("./useVariableResolver", () => ({
+	useVariableResolver: () => ({
+		getAllVariables: () => variables,
+		getVariableOrigins: (name: string) =>
+			variables[name]?.scope === "collection"
+				? [
+						{
+							scope: "collection",
+							sourceId: definedOn[name] ?? ACTIVE_COLLECTION,
+							enabled: true,
+						},
+					]
+				: [],
+	}),
+}));
+
+vi.mock("@/stores", () => ({
+	useSessionStore: (select: (s: { activeCollectionId: string }) => unknown) =>
+		select({ activeCollectionId: ACTIVE_COLLECTION }),
+}));
+
+/** One `pm.*` entry is enough to tell "the list appeared" from "it yielded". */
+vi.mock("@/queries", () => ({
+	useScriptCompletionsQuery: () => ({
+		data: { completions: [{ label: "pm.response.body", insertText: "pm.response.body" }] },
+	}),
+}));
+
+import { useScriptVariableCompletionProvider } from "./useScriptVariableCompletionProvider";
+import { useScriptCompletionProvider } from "./useScriptCompletionProvider";
+
+/** Runs one hook's provider against a line with the caret at its end. */
+function suggestionsFrom(hook: () => void, line: string) {
+	registered.length = 0;
+	renderHook(hook);
+	expect(registered.length).toBeGreaterThan(0);
+	return registered[0].provideCompletionItems(
+		{ getLineContent: () => line },
+		{ lineNumber: 1, column: line.length + 1 }
+	).suggestions;
+}
+
+const variableNames = (line: string) =>
+	suggestionsFrom(useScriptVariableCompletionProvider, line).map((s) => s.label);
+
+const pmLabels = (line: string) =>
+	suggestionsFrom(useScriptCompletionProvider, line).map((s) => s.label);
+
+beforeEach(() => {
+	for (const key of Object.keys(variables)) delete variables[key];
+	for (const key of Object.keys(definedOn)) delete definedOn[key];
+	variables.apiHost = { value: "https://api.test", scope: "environment" };
+	variables.retries = { value: "3", scope: "collection" };
+	variables.traceId = { value: "abc", scope: "global" };
+});
+
+describe("variable names in the script editors", () => {
+	it("offers the accessor's own scope, and not the other two", () => {
+		expect(variableNames('pm.environment.get("')).toEqual(["apiHost"]);
+		expect(variableNames('pm.collectionVariables.get("')).toEqual(["retries"]);
+		expect(variableNames('pm.globals.get("')).toEqual(["traceId"]);
+	});
+
+	it("offers every scope for the merged read", () => {
+		expect(variableNames('pm.variables.get("').sort()).toEqual([
+			"apiHost",
+			"retries",
+			"traceId",
+		]);
+	});
+
+	it("inserts a bare name inside the quotes, and shows the resolved value", () => {
+		const [item] = suggestionsFrom(useScriptVariableCompletionProvider, 'pm.environment.get("');
+		expect(item.insertText).toBe("apiHost");
+		expect(item.detail).toBe("https://api.test");
+	});
+
+	it("replaces the half-typed name rather than appending to it", () => {
+		const [item] = suggestionsFrom(
+			useScriptVariableCompletionProvider,
+			'pm.environment.get("api'
+		);
+		// The opening quote is at index 19, so the name starts at column 21.
+		expect(item.range.startColumn).toBe(21);
+		expect(item.range.endColumn).toBe(24);
+	});
+
+	it("hides a secret's value while still offering the name", () => {
+		variables.apiKey = { value: "s3cret", scope: "environment", secret: true } as never;
+		const item = suggestionsFrom(
+			useScriptVariableCompletionProvider,
+			'pm.environment.get("'
+		).find((s) => s.label === "apiKey");
+		expect(item?.detail).toBe("secret");
+	});
+
+	/**
+	 * D2 (#226): the engine fills the script's collection scope from the
+	 * request's immediate parent only, so an ancestor's variable resolves for
+	 * `{{name}}` and reads back `undefined` in a script. The `{{` list offers it
+	 * and this one must not - the single place the two lists legitimately differ.
+	 */
+	it("drops a variable defined on an ancestor collection, which a script cannot read", () => {
+		variables.inherited = { value: "from-parent", scope: "collection" };
+		definedOn.inherited = "ancestor";
+		expect(variableNames('pm.collectionVariables.get("')).toEqual(["retries"]);
+		expect(variableNames('pm.variables.get("')).not.toContain("inherited");
+	});
+
+	it("offers nothing outside a name argument", () => {
+		expect(variableNames("pm.response.")).toHaveLength(0);
+		expect(variableNames('console.log("')).toHaveLength(0);
+	});
+});
+
+describe("replaceIn, which interpolates rather than looks up", () => {
+	it("writes the braces and offers generators alongside real variables", () => {
+		const labels = variableNames('pm.variables.replaceIn("{{');
+		expect(labels).toContain("apiHost");
+		expect(labels).toContain("$guid");
+	});
+
+	it("does not offer a generator to a lookup that would return undefined", () => {
+		expect(variableNames('pm.variables.get("')).not.toContain("$guid");
+	});
+
+	it("closes the braces it opened, but not when they are already there", () => {
+		const opened = suggestionsFrom(
+			useScriptVariableCompletionProvider,
+			'pm.variables.replaceIn("{{'
+		)[0];
+		expect(opened.insertText).toBe("{{apiHost}}");
+	});
+});
+
+describe("the pm.* list yields inside a string", () => {
+	it("still offers the dotted surface in code", () => {
+		expect(pmLabels("pm.")).toContain("pm.response.body");
+	});
+
+	it("offers nothing inside a name argument, where a variable belongs instead", () => {
+		expect(pmLabels('pm.environment.get("')).toHaveLength(0);
+		expect(pmLabels('pm.environment.get("api')).toHaveLength(0);
+	});
+
+	it("comes back once the string is closed", () => {
+		expect(pmLabels('pm.environment.get("api"); pm.')).toContain("pm.response.body");
+	});
+});

--- a/app/src/hooks/script-completion-split.test.tsx
+++ b/app/src/hooks/script-completion-split.test.tsx
@@ -54,32 +54,8 @@ vi.mock("@monaco-editor/react", () => ({ useMonaco: () => monacoStub }));
 
 const variables: Record<string, { value: string; scope: string }> = {};
 
-/**
- * Which collection each name is defined on, for the D2 rule below. Defaults to
- * the active one, so only a test that cares has to say anything.
- */
-const ACTIVE_COLLECTION = "leaf";
-const definedOn: Record<string, string> = {};
-
 vi.mock("./useVariableResolver", () => ({
-	useVariableResolver: () => ({
-		getAllVariables: () => variables,
-		getVariableOrigins: (name: string) =>
-			variables[name]?.scope === "collection"
-				? [
-						{
-							scope: "collection",
-							sourceId: definedOn[name] ?? ACTIVE_COLLECTION,
-							enabled: true,
-						},
-					]
-				: [],
-	}),
-}));
-
-vi.mock("@/stores", () => ({
-	useSessionStore: (select: (s: { activeCollectionId: string }) => unknown) =>
-		select({ activeCollectionId: ACTIVE_COLLECTION }),
+	useVariableResolver: () => ({ getAllVariables: () => variables }),
 }));
 
 /** One `pm.*` entry is enough to tell "the list appeared" from "it yielded". */
@@ -111,13 +87,20 @@ const pmLabels = (line: string) =>
 
 beforeEach(() => {
 	for (const key of Object.keys(variables)) delete variables[key];
-	for (const key of Object.keys(definedOn)) delete definedOn[key];
 	variables.apiHost = { value: "https://api.test", scope: "environment" };
 	variables.retries = { value: "3", scope: "collection" };
 	variables.traceId = { value: "abc", scope: "global" };
 });
 
 describe("variable names in the script editors", () => {
+	/*
+	 * `collection` is exercised here because the filter handles it, not because
+	 * the app reaches it today: collection scope is explicit-only on the
+	 * resolver and this provider registers once per language, with no request to
+	 * take a `collectionId` from. So the live list is environment + global. The
+	 * case is kept so the filter stays correct for whatever gives the provider a
+	 * request context - see the note in the hook.
+	 */
 	it("offers the accessor's own scope, and not the other two", () => {
 		expect(variableNames('pm.environment.get("')).toEqual(["apiHost"]);
 		expect(variableNames('pm.collectionVariables.get("')).toEqual(["retries"]);
@@ -155,19 +138,6 @@ describe("variable names in the script editors", () => {
 			'pm.environment.get("'
 		).find((s) => s.label === "apiKey");
 		expect(item?.detail).toBe("secret");
-	});
-
-	/**
-	 * D2 (#226): the engine fills the script's collection scope from the
-	 * request's immediate parent only, so an ancestor's variable resolves for
-	 * `{{name}}` and reads back `undefined` in a script. The `{{` list offers it
-	 * and this one must not - the single place the two lists legitimately differ.
-	 */
-	it("drops a variable defined on an ancestor collection, which a script cannot read", () => {
-		variables.inherited = { value: "from-parent", scope: "collection" };
-		definedOn.inherited = "ancestor";
-		expect(variableNames('pm.collectionVariables.get("')).toEqual(["retries"]);
-		expect(variableNames('pm.variables.get("')).not.toContain("inherited");
 	});
 
 	it("offers nothing outside a name argument", () => {

--- a/app/src/hooks/useScriptCompletionProvider.ts
+++ b/app/src/hooks/useScriptCompletionProvider.ts
@@ -22,6 +22,7 @@ import { useMonaco } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import { useScriptCompletionsQuery } from "@/queries";
 import { completionReplaceStartColumn } from "@/lib/script-completion-range";
+import { openStringLiteral } from "@/lib/script-variable-completion";
 
 /** Script editors mount with language="javascript". */
 const SCRIPT_LANGUAGE = "javascript";
@@ -44,6 +45,18 @@ export function useScriptCompletionProvider() {
 				const linePrefix = model
 					.getLineContent(position.lineNumber)
 					.slice(0, position.column - 1);
+
+				/*
+				 * Nothing in this list belongs inside a string literal. The chain
+				 * regex is happy to match the word under the caret wherever it sits,
+				 * so `pm.environment.get("ba` offered the whole dotted `pm.*` surface
+				 * and accepting one replaced the half-typed variable name with
+				 * `pm.response.body`. A string argument is exactly where the
+				 * *variable* list belongs (`useScriptVariableCompletionProvider`), so
+				 * yielding here is what leaves the right list showing alone.
+				 */
+				if (openStringLiteral(linePrefix)) return { suggestions: [] };
+
 				const range: Monaco.IRange = {
 					startLineNumber: position.lineNumber,
 					endLineNumber: position.lineNumber,

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Variable-name autocomplete inside the script editors.
+ *
+ * The `{{name}}` list is registered for the body languages and deliberately not
+ * for `javascript`, because a script reaches variables through
+ * `pm.environment.get()` rather than braces. That reasoning is right and this
+ * hook keeps it: it offers the same names in the place a script actually names
+ * them - the string argument of a `pm.*` accessor - so nothing here teaches
+ * brace syntax where it does not apply.
+ *
+ * Until now the names were visible only in the panel *above* the editor, which
+ * you had to read off and retype into the call. A misremembered name is silent:
+ * `pm.environment.get()` returns `undefined` for a name that does not exist, so
+ * the script carries on and fails somewhere else entirely.
+ *
+ * **The scope comes from the accessor.** `pm.environment.get` only reads the
+ * environment, so a collection variable offered there would be a name that
+ * resolves to `undefined`. `scriptVariableCompletionContext` decides which set
+ * applies; this hook only renders it.
+ *
+ * Call once (in App). A completion provider is global per language, so a single
+ * registration covers every script editor instance. The same shape as
+ * `useScriptCompletionProvider` and `useVariableCompletionProvider` beside it.
+ */
+
+import { useCallback, useEffect } from "react";
+import { useMonaco } from "@monaco-editor/react";
+import type * as Monaco from "monaco-editor";
+import { useVariableResolver } from "./useVariableResolver";
+import { useSessionStore } from "@/stores";
+import { scriptVariableCompletionContext } from "@/lib/script-variable-completion";
+import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
+
+/** Script editors mount with language="javascript". */
+const SCRIPT_LANGUAGE = "javascript";
+
+const CLOSE_BRACES = "}}";
+
+/** The resolver's own precedence, so the winning definition sorts first. */
+const SCOPE_ORDER: Record<string, number> = { environment: 0, collection: 1, global: 2 };
+
+/** Sorts after every scope above, so a generator never outranks a real variable. */
+const DYNAMIC_SORT_GROUP = 8;
+
+export function useScriptVariableCompletionProvider() {
+	const monaco = useMonaco();
+	const { getAllVariables, getVariableOrigins } = useVariableResolver();
+	const activeCollectionId = useSessionStore((s) => s.activeCollectionId);
+
+	/**
+	 * The one place this list must be narrower than the `{{name}}` one.
+	 *
+	 * The engine fills the script's single collection scope from the request's
+	 * **immediate parent collection only** (#226, decision D2), while this
+	 * resolver merges the whole chain root→leaf. So a variable defined on an
+	 * *ancestor* collection resolves for `{{name}}` and is `undefined` to
+	 * `pm.collectionVariables.get` and `pm.variables.get` alike - precisely the
+	 * name this list exists to stop you guessing at.
+	 */
+	const readableByScript = useCallback(
+		(name: string, scope: string) => {
+			if (scope !== "collection") return true;
+			return getVariableOrigins(name).some(
+				(origin) =>
+					origin.scope === "collection" &&
+					origin.sourceId === activeCollectionId &&
+					origin.enabled
+			);
+		},
+		[getVariableOrigins, activeCollectionId]
+	);
+
+	useEffect(() => {
+		if (!monaco) return;
+
+		const disposable = monaco.languages.registerCompletionItemProvider(SCRIPT_LANGUAGE, {
+			/*
+			 * The quotes open the argument, `{` covers `replaceIn`'s braces, and `$`
+			 * re-triggers on a generator name. Monaco re-queries as you keep typing,
+			 * which is what filters the list.
+			 */
+			triggerCharacters: ['"', "'", "`", "{", "$"],
+			provideCompletionItems(model, position) {
+				const line = model.getLineContent(position.lineNumber);
+				const context = scriptVariableCompletionContext(line.slice(0, position.column - 1));
+				if (!context) return { suggestions: [] };
+
+				const range: Monaco.IRange = {
+					startLineNumber: position.lineNumber,
+					endLineNumber: position.lineNumber,
+					startColumn: context.startIndex + 1,
+					endColumn: position.column,
+				};
+
+				const template = context.mode === "template";
+
+				// Whatever already follows the caret decides if we owe a `}}`, so
+				// completing inside a pre-typed `{{}}` does not produce `{{name}}}}`.
+				const rest = line.slice(position.column - 1);
+				const closing = !template || rest.startsWith(CLOSE_BRACES) ? "" : CLOSE_BRACES;
+				const wrap = (name: string) => (template ? `{{${name}${closing}` : name);
+
+				const variables = getAllVariables();
+				const suggestions: Monaco.languages.CompletionItem[] = Object.entries(variables)
+					// `pm.environment.get` reads one scope; only the merged
+					// `pm.variables` sees them all - and neither sees an ancestor
+					// collection's variables.
+					.filter(
+						([name, info]) =>
+							(context.scope === "all" || info.scope === context.scope) &&
+							readableByScript(name, info.scope)
+					)
+					.map(([name, info]) => ({
+						label: name,
+						kind: monaco.languages.CompletionItemKind.Variable,
+						insertText: wrap(name),
+						// The resolved value, which is the thing you are actually
+						// checking when you reach for the list.
+						detail: info.secret ? "secret" : info.value || "(empty)",
+						documentation: info.sourceName
+							? `${info.scope} - ${info.sourceName}`
+							: info.scope,
+						sortText: `${SCOPE_ORDER[info.scope] ?? 9}${name}`,
+						filterText: wrap(name),
+						range,
+					}));
+
+				/*
+				 * Generators only exist during interpolation, so they belong to
+				 * `replaceIn` and nowhere else here: `pm.variables.get("$guid")` is
+				 * not a lookup that resolves, it returns `undefined`.
+				 */
+				if (template) {
+					for (const dynamic of DYNAMIC_VARIABLES) {
+						if (dynamic.name in variables) continue; // a real variable shadows it
+						suggestions.push({
+							label: dynamic.name,
+							kind: monaco.languages.CompletionItemKind.Function,
+							insertText: wrap(dynamic.name),
+							detail: dynamic.description,
+							documentation: "Generated per use",
+							sortText: `${DYNAMIC_SORT_GROUP}${dynamic.name}`,
+							filterText: wrap(dynamic.name),
+							range,
+						});
+					}
+				}
+
+				return { suggestions };
+			},
+		});
+
+		return () => disposable.dispose();
+	}, [monaco, getAllVariables, readableByScript]);
+}

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -30,11 +30,10 @@
  * `useScriptCompletionProvider` and `useVariableCompletionProvider` beside it.
  */
 
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import { useMonaco } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import { useVariableResolver } from "./useVariableResolver";
-import { useSessionStore } from "@/stores";
 import { scriptVariableCompletionContext } from "@/lib/script-variable-completion";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 
@@ -51,31 +50,20 @@ const DYNAMIC_SORT_GROUP = 8;
 
 export function useScriptVariableCompletionProvider() {
 	const monaco = useMonaco();
-	const { getAllVariables, getVariableOrigins } = useVariableResolver();
-	const activeCollectionId = useSessionStore((s) => s.activeCollectionId);
-
-	/**
-	 * The one place this list must be narrower than the `{{name}}` one.
+	/*
+	 * No `collectionId`, so no collection variables - collection scope is
+	 * explicit only, and a Monaco completion provider is registered once per
+	 * language rather than per editor, so it has no request to take one from.
+	 * The `{{name}}` provider beside it is scoped the same way for the same
+	 * reason; whatever gives one of them a request context gives both.
 	 *
-	 * The engine fills the script's single collection scope from the request's
-	 * **immediate parent collection only** (#226, decision D2), while this
-	 * resolver merges the whole chain root→leaf. So a variable defined on an
-	 * *ancestor* collection resolves for `{{name}}` and is `undefined` to
-	 * `pm.collectionVariables.get` and `pm.variables.get` alike - precisely the
-	 * name this list exists to stop you guessing at.
+	 * That also makes the engine's D2 divergence unreachable from here (the
+	 * script's collection scope is the immediate parent only, while this
+	 * resolver would merge the chain): with no collection variables to offer,
+	 * there is nothing for that rule to narrow. Re-derive it here if this
+	 * provider ever learns which request it is completing for.
 	 */
-	const readableByScript = useCallback(
-		(name: string, scope: string) => {
-			if (scope !== "collection") return true;
-			return getVariableOrigins(name).some(
-				(origin) =>
-					origin.scope === "collection" &&
-					origin.sourceId === activeCollectionId &&
-					origin.enabled
-			);
-		},
-		[getVariableOrigins, activeCollectionId]
-	);
+	const { getAllVariables } = useVariableResolver();
 
 	useEffect(() => {
 		if (!monaco) return;
@@ -110,13 +98,8 @@ export function useScriptVariableCompletionProvider() {
 				const variables = getAllVariables();
 				const suggestions: Monaco.languages.CompletionItem[] = Object.entries(variables)
 					// `pm.environment.get` reads one scope; only the merged
-					// `pm.variables` sees them all - and neither sees an ancestor
-					// collection's variables.
-					.filter(
-						([name, info]) =>
-							(context.scope === "all" || info.scope === context.scope) &&
-							readableByScript(name, info.scope)
-					)
+					// `pm.variables` sees them all.
+					.filter(([, info]) => context.scope === "all" || info.scope === context.scope)
 					.map(([name, info]) => ({
 						label: name,
 						kind: monaco.languages.CompletionItemKind.Variable,
@@ -158,5 +141,5 @@ export function useScriptVariableCompletionProvider() {
 		});
 
 		return () => disposable.dispose();
-	}, [monaco, getAllVariables, readableByScript]);
+	}, [monaco, getAllVariables]);
 }

--- a/app/src/lib/script-variable-completion.test.ts
+++ b/app/src/lib/script-variable-completion.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The rule behind variable-name completion in the script editors.
+ *
+ * Two halves are worth pinning here rather than only through Monaco: which
+ * scope an accessor implies (offering the wrong one hands you a name that
+ * resolves to `undefined` at run time), and where a string literal starts
+ * (which is also what keeps the `pm.*` list out of a name argument).
+ */
+
+import { describe, it, expect } from "vitest";
+import { openStringLiteral, scriptVariableCompletionContext } from "./script-variable-completion";
+
+describe("openStringLiteral", () => {
+	it("finds the quote a caret sits inside, of each flavour", () => {
+		expect(openStringLiteral('f("')).toEqual({ quote: '"', index: 2 });
+		expect(openStringLiteral("f('")).toEqual({ quote: "'", index: 2 });
+		expect(openStringLiteral("f(`")).toEqual({ quote: "`", index: 2 });
+	});
+
+	it("returns null once the string is closed again", () => {
+		expect(openStringLiteral('f("done")')).toBeNull();
+		expect(openStringLiteral("pm.response.code")).toBeNull();
+	});
+
+	it("does not let an escaped quote close the string", () => {
+		expect(openStringLiteral('f("a\\"b')).toEqual({ quote: '"', index: 2 });
+	});
+
+	it("reopens on a second literal after the first one closed", () => {
+		expect(openStringLiteral('f("a"); g("b')).toEqual({ quote: '"', index: 10 });
+	});
+
+	it("treats a different quote inside a string as content, not a delimiter", () => {
+		expect(openStringLiteral("f(\"it's")).toEqual({ quote: '"', index: 2 });
+	});
+});
+
+describe("scriptVariableCompletionContext", () => {
+	it("takes the scope from the accessor, since that is what the call reads", () => {
+		const cases: Array<[string, string]> = [
+			['pm.environment.get("', "environment"],
+			["pm.globals.get('", "global"],
+			['pm.collectionVariables.get("', "collection"],
+			['pm.variables.get("', "all"],
+		];
+		for (const [line, scope] of cases) {
+			expect(scriptVariableCompletionContext(line)?.scope).toBe(scope);
+		}
+	});
+
+	it("reports what has been typed, and where replacing it starts", () => {
+		const context = scriptVariableCompletionContext('pm.environment.get("ba');
+		expect(context).toMatchObject({ scope: "environment", mode: "name", query: "ba" });
+		// The opening quote is at index 19, so the name starts at 20.
+		expect(context?.startIndex).toBe(20);
+	});
+
+	it("covers the writing accessors too, not just get", () => {
+		for (const method of ["get", "set", "has", "unset"]) {
+			expect(scriptVariableCompletionContext(`pm.environment.${method}("`)).not.toBeNull();
+		}
+	});
+
+	it("offers nothing for the second argument, which is a value and not a name", () => {
+		expect(scriptVariableCompletionContext('pm.environment.set("token", "')).toBeNull();
+	});
+
+	it("skips pm.variables.set and unset, which the merged view does not support", () => {
+		expect(scriptVariableCompletionContext('pm.variables.set("')).toBeNull();
+		expect(scriptVariableCompletionContext('pm.variables.unset("')).toBeNull();
+	});
+
+	it("switches to brace syntax for replaceIn, which interpolates its argument", () => {
+		const context = scriptVariableCompletionContext('pm.variables.replaceIn("{{ba');
+		expect(context).toMatchObject({ scope: "all", mode: "template", query: "ba" });
+	});
+
+	it("offers nothing in replaceIn until the braces are open", () => {
+		expect(scriptVariableCompletionContext('pm.variables.replaceIn("')).toBeNull();
+	});
+
+	it("ignores calls that are not variable accessors", () => {
+		expect(scriptVariableCompletionContext('console.log("')).toBeNull();
+		expect(scriptVariableCompletionContext('pm.response.headers.get("')).toBeNull();
+		expect(scriptVariableCompletionContext('pm.test("')).toBeNull();
+	});
+
+	it("needs the caret inside the argument, not merely after the paren", () => {
+		expect(scriptVariableCompletionContext("pm.environment.get(")).toBeNull();
+		expect(scriptVariableCompletionContext('pm.environment.get("done")')).toBeNull();
+	});
+
+	it("tolerates the whitespace a formatter can leave in the call", () => {
+		expect(scriptVariableCompletionContext('pm . environment . get ( "')?.scope).toBe(
+			"environment"
+		);
+	});
+
+	it("reads the accessor nearest the caret when a line holds two calls", () => {
+		expect(
+			scriptVariableCompletionContext('pm.environment.get("a"); pm.globals.get("')?.scope
+		).toBe("global");
+	});
+});

--- a/app/src/lib/script-variable-completion.ts
+++ b/app/src/lib/script-variable-completion.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * "Is the caret inside the name argument of a `pm.*` variable accessor?"
+ *
+ * A script does not reach variables through `{{name}}` - it calls
+ * `pm.environment.get("name")` and its siblings - so the body editors'
+ * brace completion is deliberately not registered for `javascript`
+ * (see `useVariableCompletionProvider`). That left the script editors with no
+ * way to see what is in scope at all: the names live in the panel above the
+ * editor, and you had to read them off it and spell them yourself.
+ *
+ * This is the rule that fills that gap without teaching brace syntax where it
+ * does not apply. It is pure and single-line, which is all a variable name
+ * needs - the caret is inside one string literal on one line.
+ *
+ * **The accessor decides the scope, not a merged list.** `pm.environment.get`
+ * only ever reads the environment, so offering a collection variable there
+ * would offer a name that resolves to `undefined` at run time. Only
+ * `pm.variables` (the merged read) gets everything.
+ */
+
+import { variableCompletionContext } from "./variable-completion";
+
+/** Which names belong in the list. `all` is the merged read - `pm.variables`. */
+export type ScriptVariableScope = "environment" | "collection" | "global" | "all";
+
+export interface ScriptVariableCompletionContext {
+	scope: ScriptVariableScope;
+	/**
+	 * `name` - a bare variable name, the argument to `get`/`set`/`has`/`unset`.
+	 * `template` - `{{name}}` inside `pm.variables.replaceIn`, which interpolates
+	 * its argument exactly as a URL or body is interpolated, so the braces *are*
+	 * the syntax there and generators (`{{$guid}}`) resolve too.
+	 */
+	mode: "name" | "template";
+	/** 0-based index in the line where the replacement starts. */
+	startIndex: number;
+	/** What has been typed so far, for filtering. */
+	query: string;
+}
+
+/** The open quote the caret sits inside, or null when it sits in code. */
+export interface OpenString {
+	quote: string;
+	/** 0-based index of the opening quote character. */
+	index: number;
+}
+
+/**
+ * Scans a single line for a string literal left open at the caret.
+ *
+ * Exported because the `pm.*` completion provider needs the same answer for the
+ * opposite reason: a dotted member list has no business appearing *inside* a
+ * string, where the only useful suggestion is a variable name.
+ */
+export function openStringLiteral(textBeforeCaret: string): OpenString | null {
+	let quote: string | null = null;
+	let index = -1;
+
+	for (let i = 0; i < textBeforeCaret.length; i++) {
+		const ch = textBeforeCaret[i];
+		if (quote) {
+			// A backslash escapes the next character, including the closing quote,
+			// so `"a\""` is still one open-then-closed string.
+			if (ch === "\\") {
+				i++;
+				continue;
+			}
+			if (ch === quote) {
+				quote = null;
+				index = -1;
+			}
+		} else if (ch === '"' || ch === "'" || ch === "`") {
+			quote = ch;
+			index = i;
+		}
+	}
+
+	return quote ? { quote, index } : null;
+}
+
+/** Accessor object -> the scope its reads and writes actually touch. */
+const SCOPE_BY_ACCESSOR: Record<string, ScriptVariableScope> = {
+	environment: "environment",
+	globals: "global",
+	collectionVariables: "collection",
+	variables: "all",
+};
+
+/**
+ * Methods whose *first* argument is a variable name.
+ *
+ * `pm.variables` is the odd one: it is the merged read, so it has no `unset`,
+ * and its `set` throws by design (the merged view has no scope to write to).
+ * Offering a name inside a call that always throws would teach the wrong thing,
+ * so those spellings are simply absent here.
+ */
+const NAME_METHODS: Record<string, readonly string[]> = {
+	environment: ["get", "set", "has", "unset"],
+	globals: ["get", "set", "has", "unset"],
+	collectionVariables: ["get", "set", "has", "unset"],
+	variables: ["get", "has"],
+};
+
+/**
+ * `pm.<accessor>.<method>(` immediately before the caret's string, allowing the
+ * whitespace a formatter might leave. Anchored to the end so only the *first*
+ * argument matches - `set`'s second argument is a value, not a name.
+ */
+const ACCESSOR_CALL = /pm\s*\.\s*(\w+)\s*\.\s*(\w+)\s*\(\s*$/;
+
+/**
+ * Returns null when the caret is not inside a `pm.*` variable name argument.
+ *
+ * @param textBeforeCaret line content from column 1 up to (not including) the caret
+ */
+export function scriptVariableCompletionContext(
+	textBeforeCaret: string
+): ScriptVariableCompletionContext | null {
+	const open = openStringLiteral(textBeforeCaret);
+	if (!open) return null;
+
+	const call = textBeforeCaret.slice(0, open.index).match(ACCESSOR_CALL);
+	if (!call) return null;
+
+	const [, accessor, method] = call;
+	const scope = SCOPE_BY_ACCESSOR[accessor];
+	if (!scope) return null;
+
+	const contents = textBeforeCaret.slice(open.index + 1);
+
+	/*
+	 * `replaceIn` takes a template, not a name, so its list is the brace one -
+	 * and the same rule the body editors use decides whether the caret is inside
+	 * an open `{{`. Reusing it keeps one definition of "inside a marker".
+	 */
+	if (accessor === "variables" && method === "replaceIn") {
+		const braces = variableCompletionContext(contents);
+		if (!braces) return null;
+		return {
+			scope: "all",
+			mode: "template",
+			startIndex: open.index + 1 + braces.openIndex,
+			query: braces.query,
+		};
+	}
+
+	if (!NAME_METHODS[accessor]?.includes(method)) return null;
+
+	// A name is a plain identifier-ish token; a `{{` typed here is a mistake the
+	// list should not encourage, and a quote cannot appear unescaped anyway.
+	return {
+		scope,
+		mode: "name",
+		startIndex: open.index + 1,
+		query: contents,
+	};
+}

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -320,9 +320,14 @@ Three rules make the offered set match what the call can actually read:
   variables only, because that is the one scope it reads - a collection
   variable offered there would be a name that returns `undefined`. Only the
   merged `pm.variables.get` lists all three.
-- **Ancestor collection variables are excluded**, per decision D2 above. They
-  resolve for `{{name}}` and are invisible to a script, which makes this the
-  one place the two completion lists legitimately disagree.
+- **Collection variables are not offered yet.** Collection scope is
+  explicit-only (see *Collection scope is explicit only* above) and a Monaco
+  completion provider is registered once per *language*, not per editor, so it
+  has no request to take a `collectionId` from. The live list is therefore
+  environment + global. The `{{name}}` provider is scoped the same way for the
+  same reason, so whatever gives one of them a request context gives both - and
+  that is also when decision D2 starts to matter here, since the script's
+  collection scope is the immediate parent while the resolver merges the chain.
 - **Generators belong to `replaceIn` alone.** `pm.variables.replaceIn` takes a
   template and interpolates it, so it gets brace-style completion including
   `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -305,6 +305,33 @@ request's own collection. See
 [pm API compatibility](./pm-api-compatibility.md) and
 [scripting.md](../engine/scripting.md#variables-pmvariables).
 
+#### Autocomplete inside the accessors
+
+The script editors complete variable **names** inside the string argument of a
+`pm.*` accessor - `pm.environment.get("…")`, and the `set` / `has` / `unset`
+spellings beside it (`useScriptVariableCompletionProvider`). The `{{name}}`
+list is deliberately *not* registered for `javascript`: braces are not the
+syntax in a script, so offering them there would teach the wrong thing. The
+names are the same names; only the place you type them differs.
+
+Three rules make the offered set match what the call can actually read:
+
+- **The accessor picks the scope.** `pm.environment.get` lists environment
+  variables only, because that is the one scope it reads - a collection
+  variable offered there would be a name that returns `undefined`. Only the
+  merged `pm.variables.get` lists all three.
+- **Ancestor collection variables are excluded**, per decision D2 above. They
+  resolve for `{{name}}` and are invisible to a script, which makes this the
+  one place the two completion lists legitimately disagree.
+- **Generators belong to `replaceIn` alone.** `pm.variables.replaceIn` takes a
+  template and interpolates it, so it gets brace-style completion including
+  `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no
+  generator is offered there.
+
+The dotted `pm.*` completions (served by the engine, see
+[the scripting docs](../engine/scripting.md)) yield inside a string literal so
+the two lists never appear together.
+
 ---
 
 ## Scope labels

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -728,9 +728,17 @@ this section is what needs rewriting.
 
 ## Limitations
 
-QuickJS supports ES2020 features with some limitations:
+The **language** is current; what is missing is the **host environment**:
 
-- **No ES2021+ features**: No optional chaining (`?.`), nullish coalescing (`??`), etc.
+- **Modern syntax works.** Optional chaining (`?.`) and nullish coalescing
+  (`??`) are ES2020 and supported, as are later additions like
+  `Array.prototype.at`, `Object.hasOwn` and `String.prototype.replaceAll`. This
+  section used to say the opposite, listing `?.` and `??` as "ES2021+" and
+  unavailable - wrong on both counts, so any workaround written around that
+  claim can go. What limits a script is the global list above, not the syntax.
+- **No host globals**: no `setTimeout`, `fetch`, `URL`, `TextEncoder`,
+  `structuredClone` or `crypto.subtle` - see the table above for what replaces
+  the ones that have a replacement.
 - **No Node.js APIs**: No `require()`, `fs`, `http`, etc.
 - **Sandboxed**: No filesystem or network access
 - **Memory limit**: 64MB per script execution


### PR DESCRIPTION
## Description

The script editors could already complete the dotted `pm.*` surface (engine-served, `useScriptCompletionProvider`), but never the one thing only the workspace knows: **the variable names**. Those were visible in the panel *above* the editor, which you had to read off and retype into `pm.environment.get("...")` by hand. A misremembered name is silent - the accessor returns `undefined` and the script fails somewhere else entirely.

The `{{name}}` list stays deliberately unregistered for `javascript` (braces are not the syntax in a script). Instead the names are offered where a script actually writes them: the **string argument of an accessor** - `pm.environment.get` / `pm.globals.get` / `pm.collectionVariables.get` / `pm.variables.get`, plus the `set` / `has` / `unset` spellings.

Two rules keep the offered set equal to what the call can really read:

- **The accessor picks the scope.** `pm.environment.get` lists environment variables only; a global offered there would be a name that resolves to `undefined`. Only the merged `pm.variables.get` lists across scopes.
- **Generators belong to `replaceIn` alone**, which interpolates its argument. `pm.variables.replaceIn` gets brace-style completion including `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no generator is offered there.

The `pm.*` list now **yields inside a string literal**. Its chain regex matched the word under the caret wherever it sat, so `pm.environment.get("ba` offered the whole dotted surface, and accepting an item replaced the half-typed variable name with `pm.response.body`. Both providers register against `javascript`, so who yields where is a property of the pair.

### Known scope: environment + global, not collection

Collection scope on the resolver is **explicit-only**, and a Monaco completion provider is registered once per *language* rather than per editor - so it has no request to take a `collectionId` from. The live list is therefore environment + global. The `{{name}}` provider beside it is scoped the same way for the same reason, so whatever gives one of them a request context gives both. That is also the point at which decision D2 starts to matter here (the script's collection scope is the immediate parent, while the resolver merges the chain); the hook and `docs/app/variable-resolution.md` both record that as the thing to re-derive.

An earlier revision of this PR carried a D2 ancestor filter keyed on `useSessionStore().activeCollectionId`. That field was deleted on master in the `vayu.session` v2 migration - it had a reader and never a writer - and with no collection variables in the map there was nothing for the rule to narrow, so it came out rather than being repointed.

### Docs correction

`docs/engine/scripting.md` listed optional chaining and nullish coalescing as unavailable "ES2021+" features. Both are **ES2020 and both work**, as do `Array.prototype.at`, `Object.hasOwn` and `String.prototype.replaceAll` - verified by linking a probe against the vendored quickjs-ng build in this repo:

```
OK    ({a:1})?.a                       -> 1
OK    null ?? 'dflt'                   -> dflt
OK    [1,2,3].at(-1)                   -> 3
OK    Object.hasOwn({a:1},'a')         -> true
OK    'abc'.replaceAll('b','X')        -> aXc
FAIL  structuredClone === undefined    -> ReferenceError
OK    String(globalThis.setTimeout)    -> undefined
```

What a script lacks is **host globals**, not modern syntax. The section is rewritten to say that, so workarounds written around the old claim can go.

## Type of Change
- [x] New feature
- [x] Bug fix (the `pm.*` list appearing inside string arguments)
- [x] Documentation update

## Testing

- `app/src/lib/script-variable-completion.test.ts` - the pure rule (scope per accessor, string-literal scanning incl. escapes, first-argument-only, `replaceIn` brace mode).
- `app/src/hooks/script-completion-split.test.tsx` - the wiring, driving both providers the way Monaco does (build the provider, call `provideCompletionItems` with a model stub) rather than scanning source: the scope filter and the string guard are both invisible to a grep.
- **Mutation-checked** (revert the guard, confirm red, restore) on all three surviving guards - the scope filter, the string-literal suppression, and generators-only-in-`replaceIn`. Each produces failures; restoring returns green.
- Full app suite after rebase: **261 files, 2255 tests passing**. `pnpm type-check` clean. `eslint` reports zero problems in the touched files. `mkdocs build --strict` passes.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues

Relates to #226 (decision D2 is referenced but not yet reachable, per the scope note above).

## Follow-up worth considering, deliberately not in this PR

Full "LSP" in the script editors - Monaco's in-browser TypeScript service via `addExtraLib` + diagnostics - would add hover docs, signature help, and squiggles for typos like `pm.response.staus`. It is feasible (the TS worker is already wired in `monaco-setup.ts` and unused for this). The reason to hold: the `pm.*` surface is **already owned by the engine** as a single source of truth (`engine/src/http/routes/scripting.cpp`, ~1000 lines of hand-maintained completions). A hand-written `pm.d.ts` in the app would be a second copy that drifts from it - the exact defect class `CLAUDE.md` warns about. The right shape is to *generate* the `.d.ts` from that table (or have the engine serve it), which is its own piece of work. Note also that the compiler `target` must be ES2022-ish, not ES2020: targeting ES2020 on the old docs' advice would have flagged `Object.hasOwn` and `.at()` as errors when they actually run fine.