### PR TITLE
docs(app): `useVariableResolver` has one option, and a guard that says so

### DIFF
--- a/app/src/state-management-doc.test.ts
+++ b/app/src/state-management-doc.test.ts
@@ -157,4 +157,56 @@ describe("renderer state docs name real identifiers", () => {
 			expect(ids.has(name), `${name} is back in app/src - drop it from the list`).toBe(false);
 		}
 	});
+
+	/**
+	 * The identifier scan above cannot see this one.
+	 *
+	 * These docs documented an `environmentId` option on `useVariableResolver`
+	 * that nothing has ever accepted - the hook reads the active environment
+	 * from the session store itself. `environmentId` is a real identifier
+	 * elsewhere in the app, and the drifted call sits inside a fenced block, so
+	 * both of the scan's rules pass it. A wrong *option* is worse than a wrong
+	 * name too: it reads as a knob, so a caller writes one and silently gets
+	 * the session store's environment instead of the one they asked for.
+	 *
+	 * So this reads the option keys out of the interface and holds every
+	 * documented call to them - fenced blocks included, since a code sample is
+	 * exactly where someone copies a call from.
+	 */
+	it("documents only options the resolver hook accepts", () => {
+		const source = readFileSync(join(here, "hooks", "useVariableResolver.ts"), "utf8");
+		const body = source.match(/interface UseVariableResolverOptions \{([^}]*)\}/)?.[1];
+		expect(body, "UseVariableResolverOptions was renamed - update this guard").toBeTruthy();
+
+		const accepted = new Set([...body!.matchAll(/(\w+)\??\s*:/g)].map((m) => m[1]));
+		expect(accepted.size).toBeGreaterThan(0);
+
+		const offences: string[] = [];
+		let calls = 0;
+		for (const path of DOCS) {
+			readFileSync(join(repoRoot, path), "utf8")
+				.split(/\r?\n/)
+				.forEach((line, i) => {
+					for (const call of line.matchAll(/useVariableResolver\(\{([^}]*)\}/g)) {
+						calls++;
+						// One key per comma-separated entry, and only what comes
+						// before `?` or `:` - so `collectionId`,
+						// `collectionId?: string` and `collectionId: id` all
+						// reduce to the key, and a type name is never read as one.
+						for (const entry of call[1].split(",")) {
+							const key = entry.trim().split(/[?:]/)[0].trim();
+							if (!key || accepted.has(key)) continue;
+							offences.push(
+								`${path}:${i + 1}  \`${key}\` is not an option (accepted: ${[...accepted].join(", ")})`
+							);
+						}
+					}
+				});
+		}
+
+		// A guard that matched no call would pass on a doc that had stopped
+		// mentioning the hook at all, which is not the same as being correct.
+		expect(calls, "no documented useVariableResolver call was found").toBeGreaterThan(0);
+		expect(offences).toEqual([]);
+	});
 });

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -884,7 +884,7 @@ const {
   getVariable: (name: string) => ResolvedVariable | null
   getAllVariables: () => Record<string, ResolvedVariable>
   getVariableOrigins: (name: string) => VariableOrigin[]
-} = useVariableResolver({ collectionId?: string, environmentId?: string });
+} = useVariableResolver({ collectionId?: string });
 ```
 
 **Resolution Priority (highest to lowest):**
@@ -896,6 +896,14 @@ Collection scope comes from the `collectionId` option and nowhere else - a
 caller that passes none resolves against globals + environment. See
 `docs/app/variable-resolution.md` for why the session-store fallback was
 removed.
+
+**`collectionId` is the only option.** The environment is *not* passed in: the
+hook reads `useSessionStore().activeEnvironmentId` itself, so every caller
+resolves against the environment the user has actually selected and no caller
+can scope a preview to a different one. This page documented an
+`environmentId` option for a while; nothing has ever accepted one. The two
+scopes are asymmetric on purpose - the active environment is app-wide state,
+while the collection is a property of whatever the caller is rendering.
 
 `ResolvedVariable` carries `sourceId` / `sourceName` - the specific environment
 or collection the winning value came from (absent for `global`).
@@ -1183,7 +1191,7 @@ starts the engine at import time.
 ### Variable Resolution Priority
 
 1. User activates a request in a tab. The environment comes from `useSessionStore().activeEnvironmentId`; the collection comes from the request's own `collectionId` - **not** from the session store, which has held no collection scope since the `vayu.session` v2 migration
-2. Component calls `useVariableResolver({ collectionId, environmentId })`
+2. Component calls `useVariableResolver({ collectionId })` - the environment is not passed, the hook reads it from the session store
 3. Hook fetches globals, collection variables, and environment variables via TanStack Query
 4. When `resolveString("https://{{baseUrl}}/{{path}}")` is called:
    - First, check environment variables for `baseUrl` and `path`
@@ -1213,6 +1221,6 @@ starts the engine at import time.
 
 9. **Live metric retention is a time window, not a point count.** `addMetricsBatch` trims ticks older than `liveWindowSeconds` (the engine's `liveReplayWindowMs`, 5m by default, `null` = full run), with `maxRetainedTicks` (`DEFAULT_MAX_RETAINED_TICKS`, 50,000) as a memory backstop. Both are engine config so the replayed span and the displayed span cannot disagree. The only knob in `config/metrics.ts` is `METRICS_UI_THROTTLE_MS`, the SSE commit throttle; chart cost is bounded by bucketing (`chartBucketSeconds`), not by dropping ticks.
 
-10. **Variable resolution priority:** Always resolve variables in priority order: environment > collection > global. Use `useVariableResolver({ collectionId, environmentId })` to ensure correct scoping.
+10. **Variable resolution priority:** Always resolve variables in priority order: environment > collection > global. Use `useVariableResolver({ collectionId })` to scope a preview to a collection; the active environment comes from the session store and is not a parameter.
 
 11. **Lazy loading and prefetch:** Use `usePrefetchCollectionsAndRequests()` on app init to warm up caches. Lazily fetch environments, globals, and run reports only when needed to reduce initial bundle size and API load.


### PR DESCRIPTION
## Description

Follow-up to #254, from fresh `master` (`6939690`).

`docs/app/state-management.md` documents an `environmentId` option on `useVariableResolver` in three places - the API block (L887), the resolution-priority walkthrough (L1186) and the best-practice list (L1216). Nothing has ever accepted one. `UseVariableResolverOptions` is `{ collectionId?: string }`, and the hook reads `useSessionStore().activeEnvironmentId` itself - which the walkthrough's own **first** step already said, before the next line contradicted it. Re-verified against master at pickup: all three still there, and all six real call sites pass `collectionId` or nothing.

**A fabricated option is worse than a fabricated name.** A missing hook fails loudly the moment someone imports it. An option that does not exist fails silently: the extra key is ignored, so the caller believes the preview is scoped to the environment they named while it quietly follows the user's selected one. That is the same shape as the bug #227 fixed one layer down.

The prose gains a short paragraph on *why* the two scopes are asymmetric - the active environment is app-wide state, the collection is a property of what the caller is rendering - so the next reader has a reason not to add the parameter back.

**Guard.** #253's identifier scan cannot catch this class: `environmentId` is a real identifier elsewhere in the app, so the existence check passes, and two of the three sites sit inside fenced blocks, which that scan deliberately blanks. So `state-management-doc.test.ts` gains one case that reads the option keys out of `UseVariableResolverOptions` and holds every documented `useVariableResolver({ ... })` call to them - **including** code samples, since a sample is exactly where a call gets copied from. It asserts it matched at least one call, so a doc that stopped mentioning the hook cannot pass as correct, and it fails with a clear message if the interface is ever renamed rather than silently matching nothing.

The alternative I rejected was editing the three lines and stopping. That is what left the earlier drift in place through two doc passes; the guard is three dozen lines and closes the class.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **271 files, 2320 tests passing** (2319 on master + the new case).
- **Mutation-checked**: restoring `environmentId` to the API block fails the new case with ``docs/app/state-management.md:887  `environmentId` is not an option (accepted: collectionId)``; removing it returns green. An earlier draft of the extractor read the *type* out of `collectionId?: string` and reported `` `string` `` - it now takes only what precedes `?` or `:` in each comma-separated entry, so `collectionId`, `collectionId?: string` and `collectionId: id` all reduce to the key.
- `cd app && pnpm type-check` clean; `eslint` and `prettier --check` clean on the one touched source file.
- `mkdocs build -f .github/mkdocs.yml --strict` builds clean.
- No engine change, so the engine suite was not run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

No issue - this is the item I flagged at the end of #254 rather than folding into that diff.

## Notes

- While in the same block I checked the neighbouring `useEngine().executeRequest(params, environmentId?)` signature, since it names the same parameter. That one is accurate and is left alone.
- `docs/app/variable-resolution.md` describes the memo as "keyed by `(collectionId, environmentId)`", which is true of the cache key and is not the same claim; untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpDmhVCWQjoh8MUaggZTyF)_