### PR TITLE
ci(winget): keep the five newest versions, document the anchored installer regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,6 +418,22 @@ jobs:
           # passing github.ref_name explicitly would NOT strip the `v` and would
           # publish a malformed PackageVersion. `fork-user` is likewise omitted
           # and defaults to the repository owner (athrvk), where the fork lives.
+          # The trailing `$` is load-bearing, not decoration. Every installer is
+          # published alongside a `<name>.sha256`, so an unanchored pattern also
+          # matches `Vayu-x64.exe.sha256` and the action would try to publish a
+          # 65-byte text file as the installer. Anchored, this matches exactly
+          # one of the release's assets.
           installers-regex: 'Vayu-x64\.exe$'
           release-tag: ${{ github.ref_name }}
           token: ${{ env.WINGET_TOKEN }}
+          # Keep the five newest versions in winget-pkgs and drop older ones as
+          # part of each submission. Unbounded, every version Vayu has ever
+          # released stays installable forever at an explicit `--version`, which
+          # matters here because the two oldest are not merely stale: 0.10.0
+          # ships an engine that cannot start without the Visual C++
+          # redistributable. Five keeps a real rollback window - well past the
+          # release cadence that put three versions on winget in three days -
+          # without leaving known-broken builds on offer indefinitely. The
+          # GitHub Releases page is unaffected; this prunes the winget index
+          # only.
+          max-versions-to-keep: 5

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -108,12 +108,23 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Submitting athrvk.Vayu $version from tag $tag"
 
+      # `max-versions-to-keep` is deliberately NOT set here, unlike the
+      # automatic job in release.yml which prunes to the five newest. This
+      # workflow exists partly to publish an older tag on purpose, and pruning
+      # keeps the newest N - so it could delete the very version being
+      # submitted, in the same run, and report success. Leaving it unbounded
+      # means a manual submission always does what was asked. The cap is not
+      # lost: the next tagged release prunes back to five, so the invariant is
+      # restored automatically rather than fought here.
       - name: Submit manifest to winget-pkgs
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: athrvk.Vayu
           version: ${{ steps.resolve.outputs.version }}
           release-tag: ${{ steps.resolve.outputs.tag }}
+          # Anchored for the same reason as release.yml: each installer ships
+          # with a `<name>.sha256` beside it, and an unanchored pattern would
+          # also match `Vayu-x64.exe.sha256`.
           installers-regex: 'Vayu-x64\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,15 @@ manual step. It runs only on a tag push and only if the whole build matrix
 succeeded, and it skips silently when the `WINGET_TOKEN` secret is absent - so
 a release can never fail because of it.
 
+It keeps the **five newest versions** on winget (`max-versions-to-keep`) and
+drops older ones as each release is submitted. Unbounded, every version ever
+released stays installable at an explicit `--version`, including 0.10.0, whose
+engine cannot start without the Visual C++ redistributable. The manual workflow
+below deliberately does *not* prune, because it exists partly to publish an
+older tag and pruning keeps the *newest* N - it could delete the very version
+being submitted. The next tagged release restores the cap on its own. Pruning
+affects the winget index only; the GitHub Releases page keeps everything.
+
 For anything the tag-triggered path does not cover - a release that predates
 the automation, a re-submission after a winget-pkgs pull request was closed,
 publishing an older tag - run the **Publish to winget (manual)** workflow


### PR DESCRIPTION
## Description

Two small changes to the winget publishing path, plus the reasoning behind both.

**1. `max-versions-to-keep: 5` on the automatic job.** Unbounded, every version Vayu has ever released stays installable from winget at an explicit `--version`. That matters more than tidiness here: **0.10.0 is still on offer and its engine cannot start without the Visual C++ redistributable** - the bug fixed in #210. Five keeps a real rollback window, comfortably past a cadence that put three versions on winget in three days, and retires the broken manifests automatically as new releases land. This prunes the winget index only; the GitHub Releases page keeps everything.

**2. The manual workflow deliberately does *not* prune.** It exists partly to publish an older tag on purpose, and pruning keeps the *newest* N - so it could delete the very version being submitted, in the same run, and still report success. Leaving it unbounded means a manual submission always does what was asked. The cap is not lost: the next tagged release restores it, so the invariant self-heals rather than being fought in the one place it would misfire.

**3. Documented why `installers-regex` is anchored.** Every installer now ships with a `<name>.sha256` beside it, so an unanchored `Vayu-x64\.exe` would *also* match `Vayu-x64.exe.sha256` and the action would try to publish a 65-byte text file as the installer. The trailing `$` is load-bearing, and now says so in both workflows.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

Audited against the live published state rather than reasoned about:

- **Pipeline record is 3/3.** Every release since the automation landed is on winget - 0.12.0, 0.13.0, 0.14.0 - with 0.11.0 correctly absent (it predates the job and carried the CRT bug).
- **The regex was checked against v0.14.0's real asset list**: 13 assets, 5 of them `.sha256`. The anchored pattern matches exactly one, `Vayu-x64.exe`.
- **Checksums agree three ways.** The published `Vayu-x64.exe.sha256`, the actual downloaded installer, and the winget manifest's `InstallerSha256` are all `1F313CFB…D5B3`.
- **The #210 fix is confirmed live in the shipped binary.** Extracting the 0.14.0 installer that winget serves, `resources/bin` contains only `vayu-engine.exe` - no DLLs at all - and the dependency guard passes it clean:

```
Imports of vayu-engine.exe (9 DLLs):
  ADVAPI32  CRYPT32  IPHLPAPI  KERNEL32  Secur32  WINMM  WS2_32
  api-ms-win-core-synch  bcrypt
OK: every import ships with Windows - no redistributable needed.
```

Both workflows validated as YAML. No behaviour to unit-test here; the change is two action inputs and comments, and per `CLAUDE.md` the suites could not change colour.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - n/a, workflow config
- [x] I have updated documentation - `CLAUDE.md`

## Related Issues
Follows #210.

---

**Note on effect:** the pruning takes hold on the *next* tagged release. Once two more versions ship, 0.10.0 drops out of the winget index on its own - no manual cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lz4BfTYAQ24JtMfJzvZGP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lz4BfTYAQ24JtMfJzvZGP6)_