### PR TITLE
docs: restructure CLAUDE.md for on-demand context loading

### DIFF
--- a/.claude/skills/docs-site/SKILL.md
+++ b/.claude/skills/docs-site/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: docs-site
+description: Rules for the published MkDocs site under docs/ - nav entries, relative links, heading anchors, analytics gating, and local preview. Use when adding, renaming, moving or linking a page under docs/, or when touching .github/mkdocs.yml, the docs workflow or its hooks.
+---
+
+# `docs/` is published, so a broken link is a build failure
+
+`docs/` ships to <https://athrvk.github.io/vayu/> via MkDocs Material
+(`.github/mkdocs.yml`, `.github/workflows/docs.yml`, deps pinned in
+`requirements-docs.txt`). `mkdocs build --strict` runs on every docs-touching
+pull request and fails on an unresolvable relative `.md` link or a missing
+heading anchor, so:
+
+- **Add a new page to the `nav:` in `.github/mkdocs.yml`** in the same commit.
+  Off-nav pages build and are reachable by URL, but never appear in the sidebar.
+- **Do not rename or move a doc file** without checking for readers. Tests read
+  doc paths (`app/src/design-system-doc.test.ts` reads `docs/design-system.md`;
+  `app/src/state-management-doc.test.ts` reads `docs/app/state-management.md`,
+  `architecture.md` and `api-integration.md`, and fails on a `useXxx` or
+  `SCREAMING_CASE` name they quote that no longer exists in the app source),
+  and every relative cross-link is validated by the build.
+- **Anchors follow GitHub's slug rules** (`pymdownx.slugs.slugify` is configured
+  for exactly this), so one anchor form works both in GitHub's markdown view and
+  on the site. Heading punctuation counts: `## Shared Auth Fields
+  (components/shared/AuthFields/)` is `#shared-auth-fields-componentssharedauthfields`.
+- **Links out of `docs/`** (`SECURITY.md`, `LICENSE`, `CONTRIBUTING.md`) must be
+  absolute `https://github.com/athrvk/vayu/blob/master/...` URLs - those files
+  are outside the published tree.
+- **Analytics is on the published site only, and only when it has an ID.** The
+  GA4 measurement ID comes from the `GOOGLE_ANALYTICS_KEY` Actions *repository
+  variable* (Settings -> Secrets and variables -> Actions -> Variables), read by
+  `extra.analytics.property` via `!ENV`. With it unset - every fork, every
+  pull-request preview, every local `mkdocs serve` - `.github/hooks/analytics.py`
+  strips `extra.analytics`, `extra.consent` and the footer's "Cookie settings"
+  link, so those builds ship no tracker and no banner. `!ENV` alone does **not**
+  do this: Material emits its gtag snippet even for an empty property, which is
+  the whole reason that hook exists. On the published site GA is consent-gated -
+  the snippet is defined but only runs once the visitor accepts. **This is the
+  docs website, not the app**; `no telemetry` in `docs/index.md` and `README.md`
+  is a claim about the app and stays true, so keep the two apart when editing
+  either.
+- **Jekyll is not an option here** and the workflow says why: Pages' default
+  Jekyll build runs Liquid over page content, and these docs contain 40+
+  `{{variable}}` examples (rendered as empty strings) plus `{% ... %}` (an
+  unknown tag, which fails the build). MkDocs never templates page content.
+
+Preview locally with `pip install -r requirements-docs.txt && mkdocs serve -f
+.github/mkdocs.yml`. The `-f` is required - the config is not at the repo root -
+and the site serves under `/vayu/`. The favicon/logo are not files under `docs/`:
+`.github/hooks/brand_assets.py` pulls `shared/icon_png/vayu_icon_256x256.png`
+into the build, so do not add a copy.
+
+`install.sh` at the repo root is also published at the site root by
+`.github/hooks/install_script.py`, which is why it appears in the `paths:`
+filters of `docs.yml`.

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: releasing
+description: Cut a Vayu release - version bump, curated release notes, tagging, and what CI publishes (installers, install.sh, winget). Use when preparing or tagging a release, writing release notes, or changing install.sh or the release/winget workflows.
+---
+
+# Releasing Vayu
+
+1. `python build.py --bump-version patch` - updates VERSION, CMakeLists.txt,
+   vcpkg.json, package.json. (`patch` | `minor` | `major` | `x.y.z`; add
+   `--dry-run` to preview.)
+2. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a
+   Changelog format, see below).
+3. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes
+   file together).
+4. Tag: `git tag v$(cat VERSION) && git push origin --tags`
+5. CI builds installers and publishes the GitHub Release, using
+   `.github/release-notes/<tag>.md` as the release body automatically (no manual
+   paste).
+
+A release commit needs no test run - every edit is a version string or Markdown.
+The version stamp is worth one cheap check (`./build/vayu-engine --help` prints
+it) and nothing else.
+
+**Tag *after* the release commit lands on the default branch.** When the version
+bump goes through a pull request (the usual path), run steps 1-2 on the feature
+branch so the bump merges with the PR, but do **not** tag the PR-branch commit.
+A squash/rebase merge rewrites the commit hash, so a tag on the pre-merge commit
+would point at a commit that never reaches the default branch. Wait for the PR to
+merge, then tag the merged commit on the default branch
+(`git checkout <default-branch> && git pull && git tag v$(cat VERSION) && git
+push origin --tags`). The tag triggers the release build, so it must sit on the
+canonical merged history.
+
+## Release changelog
+
+Release notes live on the [GitHub Releases](https://github.com/athrvk/vayu/releases)
+page (there is no `CHANGELOG.md` in the repo). Write them in
+[Keep a Changelog](https://keepachangelog.com) style so entries stay consistent
+across versions:
+
+- **Heading:** `## [X.Y.Z] - YYYY-MM-DD` (ISO date).
+- **Lead paragraph:** 2-4 sentences naming the release theme and where the change
+  concentrates (engine vs app), e.g. "The OAuth 2.0 release ... the bulk of the
+  change is new C++ in the engine and new React/Electron surface in the app."
+- **Grouped sections, in this order, omitting any that are empty:** `### Added`,
+  `### Changed`, `### Fixed`. Use `### Security` / `### Removed` /
+  `### Deprecated` only when they apply.
+- **Bullets:** lead with a bold headline, then the detail, e.g. `- **OAuth 2.0
+  auth mode.** A new \`oauth2\` mode in the request Auth panel and Collection
+  Detail ...`. Prefer user-facing wording; reference files/endpoints only when
+  they aid a contributor.
+- **Fold internal churn** (doc hygiene, refactors with no user-visible effect)
+  into a single summary bullet rather than listing each commit.
+- **Compare link footer:** `[X.Y.Z]: https://github.com/athrvk/vayu/compare/vPREV...vX.Y.Z`.
+- **Version choice:** patch = fixes only; minor = new user-facing feature; major
+  = breaking change (still `0.x`, so reserve major for a stable milestone).
+
+**Release notes are published from a file - no manual paste.** On tag push,
+`.github/workflows/release.yml` reads `.github/release-notes/<tag>.md` and sets
+it as the GitHub Release body via `softprops/action-gh-release`'s `body_path`.
+If that file is missing for the tag, the workflow falls back to GitHub's
+automatically generated PR-based notes (`generate_release_notes`) so a release is
+never published empty.
+
+**Authoring the notes (Claude's job before tagging).** Derive them from
+`git log vPREV..vX.Y.Z`; read a recent entry to match voice. Because the workflow
+resolves the file from the tagged commit's tree, the notes file must be committed
+**before** the tag is pushed (i.e. it rides along in the release PR). To correct
+a published release's notes after the fact, edit the file, then either re-run the
+release workflow or update the release body by hand.
+
+## `install.sh` (repo root) installs *and updates*, on macOS and Linux
+
+macOS: downloads the release zip, ad-hoc signs app + sidecar, strips quarantine,
+`sudo`-installs to `/Applications`. Linux: AppImage + `.desktop` entry + icon +
+a `vayu` symlink when `~/.local/bin` is on `PATH`, all under
+`~/.local/share/vayu`, **no sudo**. Both share every decision and dispatch only
+the actions, on `platform()` - a function wrapping `uname -s`, so tests can force
+either branch on either host. Tested by `scripts/test/install_test.sh`
+(`VAYU_DRYRUN=1`), shellchecked in CI on both. Published by the docs site:
+`.github/hooks/install_script.py` registers the repo-root file at the site root,
+which is why `install.sh` is in the `paths:` filters of `docs.yml` - without that
+the published copy silently falls behind master. Documented as
+`bash -c "$(curl …)"`, not `curl … | bash`, so the script is buffered before it
+runs and stdin stays on the terminal.
+
+Things about it that the code cannot tell you:
+
+- **It is the macOS *update* path** - `resolveUpdateStrategy` returns `notify`
+  there, since an ad-hoc signature gives Squirrel.Mac nothing to verify. So the
+  app is usually *running* when the script starts, and `macInstallCommand()`
+  (`app/electron/updater.ts`) must match the command README publishes;
+  `updater.test.ts` asserts that by reading the README, because a template
+  literal is invisible to a URL grep.
+- **Never detect the running app by matching command lines.**
+  `bash -c "$(curl …)"` puts the whole script - comments included - into its own
+  argv, so a `pgrep -f` pattern appearing anywhere in the file matches the
+  installer itself. That aborted every Linux install while the suite stayed
+  green, because sourcing the file never populates argv. Linux reads
+  `/proc/<pid>/exe`, both platforms filter by process group, and
+  `install_test.sh` exercises the real `bash -c "$(cat install.sh)"` form.
+- **A flag appended to the documented command lands in `$0`, not `$1`.**
+  `bash -c "$(curl …)" --force` gives bash's `-c` its *name* argument, so `$#` is
+  0 and the flag silently vanished - the run reported "already installed -
+  nothing to do" while ignoring the `--force` it was handed. `parse_args` now
+  recovers a `-`-prefixed `$0` back into `"$@"`, skipping a bare `--` (with the
+  separator present bash puts *that* in `$0`, so a naive `-*` match turns a
+  correct invocation into "Unknown option: --"). Sourcing can never reproduce
+  this, so the coverage runs the real `bash -c "$(cat install.sh)"` form. Same
+  family: a flag that parses but does nothing - `--purge` without `--uninstall`
+  is now a usage error, and any hint the script prints must be a command that
+  actually runs (`--uninstall --purge`, not `--purge`).
+- **`electron/quit-signals.ts` is load-bearing.** Linux has no Apple Event, so
+  the installer quits with `SIGTERM`, and Node's default would kill the process
+  without running `before-quit` - losing pending saves and orphaning the engine.
+  The app can also quit itself (`update:quitForUpdate`, the **Quit to update**
+  button), the only quit needing no Automation consent.
+- **The install target follows the existing copy.** `/Applications` is only the
+  *fresh install* default; two copies are reported rather than silently picked
+  between, and uninstall removes every copy. Resolution
+  (`resolved_install_path`) prints and the single assignment lives in
+  `adopt_install_target`, so nothing here is unsafe to call from a subshell.
+- **The Linux version stamp (`~/.local/share/vayu/version`) has two writers**:
+  the installer, and `electron/appimage-stamp.ts` at startup - the AppImage
+  self-updates in place and would otherwise leave the stamp stale. That module
+  duplicates `install.sh`'s path constants; move one, move both.
+- **Every `sudo` goes through `privileged()`, which refuses to run before
+  `authorize()`.** The ordering used to be a convention and the convention
+  broke: `sweep_staging` deleted a bundle in `/Applications` *without* sudo two
+  lines above one that used it, both before the password was ever asked for.
+  `VAYU_SUDO` lets `install_e2e.sh` substitute a stub, which is the only way CI
+  can see the privileged path at all - the runners have passwordless sudo and no
+  terminal, which is where three bugs in a row hid.
+- **Every release artifact publishes a `.sha256`** (checksum steps in
+  `release.yml`), so the installer's verification is real on all three platforms
+  rather than dead code outside macOS.
+- **Errors go through `die()`, never `step || exit 1` at a call site.** Bash
+  disables `errexit` for the whole body of a function invoked in an `||`
+  context, so an unchecked command inside it falls through - that is how a failed
+  download was once reported as success. A step that cannot continue says so
+  itself. The cost: a dying function cannot be called in-process by a test, so
+  `install_test.sh` wraps those calls in a subshell.
+- **Two suites, two jobs.** `install_test.sh` is dry-run and owns the
+  *decisions* (which version, which platform branch, which order, sudo or not -
+  including the other platform's branch, which is why it stubs `platform()`).
+  `scripts/test/install_e2e.sh` runs the installer for real against a local
+  release in a temp root and owns the *effects*. Put a new assertion in whichever
+  answers it; do not duplicate.
+- **Release assets carry versions** (`Vayu-<v>-universal.zip`,
+  `Vayu-<v>-x86_64.AppImage`) while `Vayu-x64.exe` and `Vayu-amd64.deb` do not,
+  so `/releases/latest/download/<name>` **404s for macOS and Linux**. Link the
+  installer or `/releases/latest`; never invent an unversioned asset URL.
+
+## Windows also publishes to winget, automatically
+
+The `publish-winget` job in `release.yml` submits `Vayu-x64.exe` to
+`microsoft/winget-pkgs` after the release is built, so
+`winget install athrvk.Vayu` follows each tag with no manual step. It runs only
+on a tag push and only if the whole build matrix succeeded, and it skips silently
+when the `WINGET_TOKEN` secret is absent - so a release can never fail because of
+it.
+
+It keeps the **five newest versions** on winget (`max-versions-to-keep`) and
+drops older ones as each release is submitted. Unbounded, every version ever
+released stays installable at an explicit `--version`, including 0.10.0, whose
+engine cannot start without the Visual C++ redistributable. The manual workflow
+below deliberately does *not* prune, because it exists partly to publish an
+older tag and pruning keeps the *newest* N - it could delete the very version
+being submitted. The next tagged release restores the cap on its own. Pruning
+affects the winget index only; the GitHub Releases page keeps everything.
+
+For anything the tag-triggered path does not cover - a release that predates the
+automation, a re-submission after a winget-pkgs pull request was closed,
+publishing an older tag - run the **Publish to winget (manual)** workflow
+(`.github/workflows/winget-publish.yml`) from the Actions tab. It takes an
+optional tag (defaulting to the latest release), validates that the release and
+its `Vayu-x64.exe` asset exist, and submits only that - it builds nothing.
+Unlike the automatic job it **fails** rather than skips when `WINGET_TOKEN` is
+missing, because a manual run that published nothing while reporting success
+would be worse than an error. `WINGET_TOKEN` must be a **classic** PAT with
+`public_repo` scope; fine-grained PATs are not supported by the action.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,176 +1,23 @@
 # Vayu - Claude Code Guide
 
-Vayu is a high-performance API testing and load-testing platform. It uses a **sidecar architecture**: a C++20 engine (daemon) runs alongside an Electron + React UI, communicating over HTTP on port 9876.
+Vayu is a high-performance API testing and load-testing platform. It uses a
+**sidecar architecture**: a C++20 engine (daemon) runs alongside an Electron +
+React UI, communicating over HTTP on port 9876.
 
-- **Engine** (`/engine`): C++20, CMake + vcpkg, licensed AGPL-3.0
-- **App** (`/app`): Electron + React + TypeScript, licensed Apache-2.0
-- **Build script**: `build.py` is the single entry point for all build operations
+- **Engine** (`engine/`): C++20, CMake + vcpkg, AGPL-3.0
+- **App** (`app/`): Electron + React + TypeScript, Apache-2.0
+- **`build.py`**: the single entry point for every build operation
+- **`VERSION`**: single source of truth for the version
+- **`scripts/`**: `pre-commit` (clang-tidy on staged C++), `install-git-hooks.sh`,
+  and `test/` (load-test fixtures + mock server, installer suites)
 
-## Core Principle
+This file holds only what applies to *every* session. Deeper material loads on
+demand - see [Where the rest lives](#where-the-rest-lives) at the bottom.
 
-Make architectural decisions for the long term. Do not accept a stopgap that
-only works for now and is meant to be replaced later.
+## Core principle
 
-## Project Structure
-
-```
-vayu/
-├── engine/
-│   ├── src/
-│   │   ├── core/          # load_strategy, metrics_collector, run_manager
-│   │   ├── http/          # HTTP server, SSE, routes, thread_pool, rate_limiter
-│   │   ├── db/            # SQLite persistence
-│   │   ├── runtime/       # QuickJS scripting engine
-│   │   └── utils/
-│   ├── include/vayu/      # Public headers
-│   ├── tests/             # Google Test suite
-│   ├── vendor/            # Vendored deps: quickjs-ng, picosha2 (PKCE/SHA-256), hdrhistogram
-│   ├── CMakeLists.txt
-│   ├── CMakePresets.json
-│   └── vcpkg.json         # curl, nlohmann-json, cpp-httplib, gtest, sqlite3, sqlite-orm
-├── app/
-│   ├── src/               # React + TS UI (modules, components, services, queries, stores, hooks)
-│   ├── electron/          # Electron main process
-│   └── package.json
-├── scripts/
-│   ├── pre-commit         # clang-tidy on staged C++ files
-│   ├── install-git-hooks.sh
-│   └── test/              # Load test fixtures + mock server
-├── build.py               # Unified build script (all platforms)
-└── VERSION                # Single source of truth for version
-```
-
-## Prerequisites
-
-- CMake ≥ 3.25, Ninja, C++20 compiler (g++ or clang++)
-- vcpkg with `$VCPKG_ROOT` set (Linux/macOS; on Windows it is auto-detected - see below)
-- Node.js ≥ 20.19 (22 LTS recommended - see `app/.nvmrc`), pnpm ≥ 10
-
-Run `python build.py --setup` to install all prerequisites automatically (Linux/macOS only).
-
-**On Windows, do not hand-configure cmake or set `VCPKG_ROOT` - just run
-`build.py`.** It imports the MSVC environment via `vcvars` and finds cmake,
-ninja and vcpkg inside the Visual Studio Build Tools install
-(`...\BuildTools\VC\vcpkg`) on its own, so an unset `VCPKG_ROOT` is fine. Poking
-at the build tree directly (empty `build/`, no `VCPKG_ROOT`) looks like "can't
-build locally" when `python build.py -e -t` builds the engine and runs the C++
-tests in ~2 min. If you keep vcpkg elsewhere, set `VCPKG_ROOT` and it is honored.
-
-## Build Commands
-
-```bash
-# First-time setup (Linux/macOS)
-python build.py --setup
-
-# Development build (engine + app)
-python build.py --dev
-
-# Production build
-python build.py
-
-# Engine only
-python build.py -e
-
-# App only (requires engine already built)
-python build.py -a
-
-# Build with tests enabled
-python build.py -t
-
-# Bump version (patch | minor | major | x.y.z)
-python build.py --bump-version patch --dry-run   # preview
-python build.py --bump-version patch             # apply
-```
-
-## Running the App
-
-```bash
-cd app && pnpm run electron:dev
-```
-
-## Testing
-
-### Engine (C++ / Google Test)
-
-```bash
-# Build with tests, then run via ctest
-python build.py -t
-cd engine && ctest --preset linux-dev --output-on-failure
-```
-
-CMake presets: `linux-dev`, `linux-prod`, `macos-dev`, `macos-prod`, `windows-dev`, `windows-prod`.
-
-### Frontend
-
-```bash
-cd app && pnpm test
-```
-
-**A test must never assert the host platform.** Vayu is built on Linux, macOS
-and Windows and CI runs all three. `platform.test.ts` asserted `isMac === false`
-and called that "the test environment"; it was true only because jsdom reports
-a Linux-ish user-agent, so the macOS branch was never exercised anywhere. Moving
-to `node` removed the accident - Node has a real global `navigator` - and only
-the macOS runner failed. Stub the input (`vi.stubGlobal`, or `process.platform`
-as `updater.test.ts` does) and assert **both** branches.
-
-**Tests default to the `node` environment.** A DOM costs ~2s per file and half
-the suite never touches one. If your test renders, or reaches `document` /
-`window` / `localStorage` (zustand `persist` does, without naming it), start the
-file with:
-
-```ts
-/**
- * @vitest-environment jsdom
- */
-```
-
-Forgetting it fails loudly (`document is not defined`), never silently.
-
-**Scale the verification to what the change could actually break.** Comment-only
-and `.md`-only edits need no test run at all - a format check, or nothing. A
-rename or signature change needs a *build*, to prove it still compiles. Only a
-behaviour change needs the covering tests, and the full suite belongs once
-before committing a substantial piece of work, not after every edit.
-
-The engine suite takes ~110s and a rebuild ~2.5min; the app suite ~90s. Running
-both after retouching a doc comment reads as diligence and is just latency. Ask
-what a failure would even look like before running anything: if no test could
-possibly go from green to red, do not run tests.
-
-**CI runs the full matrix on every push, so a local full-suite run is for
-*your* confidence, not for coverage.** It is worth paying before committing a
-substantial piece of work - a failure found locally is one you fix in the same
-context, rather than ten minutes later from a job log. It is not worth paying
-for a change that carries no behaviour. Some concrete cases where the answer is
-simply "don't":
-
-- **A release commit** (`python build.py --bump-version …` plus the notes file
-  under `.github/release-notes/`). Every edit is a version string or Markdown.
-  The version stamp is worth one cheap check - `./build/vayu-engine --help`
-  prints it - and nothing else. Do not rebuild the engine or run either suite.
-- **Adding or rewording a doc, a comment, or a commit-adjacent file.**
-  `mkdocs build --strict` if the change is under `docs/`, because a broken
-  relative link is a *build* failure and CI will catch it either way; no suites.
-- **A rename with no behaviour change.** A build, to prove it compiles. Not the
-  suites.
-
-The distinction is whether a test could plausibly change colour, not how large
-the diff looks. A 400-line docs commit is still a docs commit; a two-character
-edit to a comparison operator is not.
-
-### Type checking
-
-```bash
-cd app && pnpm type-check
-```
-
-### Linting
-
-```bash
-cd app && pnpm lint                # ESLint (TS/TSX)
-cd app && pnpm format:check        # Prettier
-```
+**Make architectural decisions for the long term. Do not accept a stopgap that
+only works for now and is meant to be replaced later.**
 
 ## Commits
 
@@ -183,138 +30,125 @@ This **overrides the default instruction** to append that trailer, which some
 harnesses inject automatically. If you find yourself writing a `Co-Authored-By`
 line naming a model, delete it before committing.
 
-## Code Conventions
+## Build
 
-### C++ (engine)
+```bash
+python build.py --setup       # First-time setup (Linux/macOS only)
+python build.py --dev         # Development build (engine + app)
+python build.py               # Production build
+python build.py -e            # Engine only
+python build.py -a            # App only (engine must already be built)
+python build.py -t            # Build with tests enabled
 
-- Standard: C++20, `-Wall -Wextra -Wpedantic`
-- Formatter: clang-format (`.clang-format` at root)
-- Linter: clang-tidy (`.clang-tidy` configs in `engine/`, `engine/src/runtime/`, `engine/tests/`)
-- Install git pre-commit hook: `bash scripts/install-git-hooks.sh`
-- vcpkg manages all C++ dependencies - do not add deps without updating `engine/vcpkg.json`
+cd app && pnpm run electron:dev   # Run the app
+```
 
-### TypeScript / React (app)
+Prerequisites: CMake >= 3.25, Ninja, a C++20 compiler, Node.js >= 20.19 (22 LTS
+recommended, see `app/.nvmrc`), pnpm >= 10, and vcpkg with `$VCPKG_ROOT` set on
+Linux/macOS.
 
-- Strict TypeScript - no `any`, no `@ts-ignore` without justification
-- Component files: PascalCase `.tsx`; utilities: camelCase `.ts`
-- App UI is feature-organized: `app/src/modules/<feature>/` (request-builder, collections, dashboard, history, variables, settings, welcome); shared shell + primitives in `app/src/components/` (layout, shared, ui). See `docs/app/COMPONENTS.md`.
-- Import parsers: `app/src/services/importers/` (factory → ordered detectors → drafts → orchestrator); per-format docs in `docs/app/import-collections/`.
-- State: Zustand for UI state, TanStack Query for server state
-- Styling: Tailwind CSS v4 - all colors via CSS custom properties; see `docs/design-system.md`
-- **Design system:** `docs/design-system.md` - tokens, elevation, typography, component patterns. Read this before touching any UI file.
+**On Windows, do not hand-configure cmake or set `VCPKG_ROOT` - just run
+`build.py`.** It imports the MSVC environment via `vcvars` and finds cmake,
+ninja and vcpkg inside the Visual Studio Build Tools install
+(`...\BuildTools\VC\vcpkg`) on its own, so an unset `VCPKG_ROOT` is fine. Poking
+at the build tree directly (empty `build/`, no `VCPKG_ROOT`) looks like "can't
+build locally" when `python build.py -e -t` builds the engine and runs the C++
+tests in ~2 min. If you keep vcpkg elsewhere, set `VCPKG_ROOT` and it is honored.
 
-## UI rules (enforced by tests - breaking one fails CI)
+## Testing
 
-- **Status colours have three tokens:** `--status-*` (dot/icon/tint),
-  `--status-*-text` (when the colour *is* the text), `--status-*-fill` (solid
-  chip under a white label). Using the bare fill as a foreground is the most
-  common colour bug here. → `status-color-tokens.test.ts`
-- **`--primary` vs `--primary-fill`:** `--primary` is text/ring/chart and
-  brightens in dark; `--primary-fill` is the solid button background and is one
-  value in both themes. Do not unify them - pinning `--primary` drops accent text
-  from APCA Lc 44–69 to 22–37.
-- **No raw Tailwind palette** (`text-green-500`) in the request/response tree
-  → `palette-tokens.test.ts`. Elsewhere only with an explicit `dark:` pair.
-- **No chart series on `--primary`/`--chart-1`** - both track the user's accent
-  and can collide with a semantic series. Use `categorical`.
-  → `status-code-series.test.ts`
-- **No bare `rounded`** - it ignores the Roundedness setting. → `radius-token.test.tsx`.
-  **No radius class at all** is the same escape hatch pointing the other way: it
-  pins the box at 0 for a user who chose Rounded. No source scan can flag it,
-  because plenty of surfaces are square on purpose (header bars, tab strips,
-  full-bleed editors) - only the component knows which it is, so render it and
-  read `element.className`. Seven boxes in the request builder were stuck square
-  this way. → `boxed-surfaces.test.tsx`, `KeyValueRow.test.tsx`
-- **A drawer row's hit area needs two things, not one.** A row that carries a `⋯`
-  menu cannot be one button, so it is an `h-8 items-center` container that paints
-  the hover fill plus a narrower activator button holding the handler. That leaks
-  clicks twice over: `items-center` leaves the button *content*-height (18px in a
-  collection or environment row, so 7px above and below are dead), and the row's
-  own box - the `paddingLeft` indent, the flex gaps, the right padding - belongs
-  to no child at all. Measured in the running app, a collection row responded
-  over **41%** of the area that looked clickable, a request row 51%, an
-  environment row 36%. The fix is `self-stretch` on the activator **plus** the row
-  delegating clicks that land on itself (`e.target === e.currentTarget`, which
-  keeps the chevron and `⋯` out and stops a double-fire on bubble). The indent
-  cannot simply move onto the activator - on a collection row the chevron sits
-  between them. → `drawer-row-hit-area.test.tsx`. Assert the height as a
-  `className`, not `offsetHeight`: jsdom has no layout and reports 0 for
-  everything, so an `offsetHeight` guard passes while measuring nothing.
-- **Adding an accent scheme:** `constants/color-schemes.ts` + `index.css`, both
-  themes, nothing else. → `color-schemes.test.ts`
-- **A `Badge` that paints its own `bg-` must be `variant="chip"`.** Every other
-  variant pairs `bg-x` with `hover:bg-x/80`, and `cn()` (tailwind-merge) replaces
-  `bg-*` but *not* `hover:bg-*` - so the caller's fill won at rest and the
-  variant's hover won on hover. Status chips turned the accent colour under the
-  pointer. → `badge-hover.test.tsx`
+```bash
+python build.py -t && cd engine && ctest --preset linux-dev --output-on-failure
+cd app && pnpm test          # vitest
+cd app && pnpm type-check
+cd app && pnpm lint          # ESLint (TS/TSX)
+cd app && pnpm format:check  # Prettier
+```
+
+CMake presets: `linux-dev`, `linux-prod`, `macos-dev`, `macos-prod`,
+`windows-dev`, `windows-prod`.
+
+**Scale the verification to what the change could actually break.** Comment-only
+and `.md`-only edits need no test run at all - a format check, or nothing. A
+rename or signature change needs a *build*, to prove it still compiles. Only a
+behaviour change needs the covering tests, and the full suite belongs once
+before committing a substantial piece of work, not after every edit.
+
+The engine suite takes ~110s and a rebuild ~2.5min; the app suite ~90s. Running
+both after retouching a doc comment reads as diligence and is just latency. Ask
+what a failure would even look like before running anything: **if no test could
+possibly go from green to red, do not run tests.** CI runs the full matrix on
+every push, so a local full-suite run is for *your* confidence, not for coverage.
+
+Concrete cases where the answer is simply "don't":
+
+- **A release commit** (version bump plus the notes file under
+  `.github/release-notes/`). Every edit is a version string or Markdown. The
+  version stamp is worth one cheap check - `./build/vayu-engine --help` prints
+  it - and nothing else. Do not rebuild the engine or run either suite.
+- **Adding or rewording a doc, a comment, or a commit-adjacent file.**
+  `mkdocs build --strict` if the change is under `docs/`, because a broken
+  relative link is a *build* failure; no suites.
+- **A rename with no behaviour change.** A build, to prove it compiles. Not the
+  suites.
+
+The distinction is whether a test could plausibly change colour, not how large
+the diff looks. A 400-line docs commit is still a docs commit; a two-character
+edit to a comparison operator is not.
+
+**A test must never assert the host platform.** Vayu is built on Linux, macOS
+and Windows and CI runs all three. `platform.test.ts` asserted `isMac === false`
+and called that "the test environment"; it was true only because jsdom reports
+a Linux-ish user-agent, so the macOS branch was never exercised anywhere. Stub
+the input (`vi.stubGlobal`, or `process.platform` as `updater.test.ts` does) and
+assert **both** branches.
+
+## Repo-wide conventions
+
 - **No em-dashes anywhere in the repo.** Use ` - `.
-- **`docs/design-system.md` values are checked against `index.css`**
-  → `design-system-doc.test.ts`. Prose is not - if you change a value, read the
-  sentence around it.
+- **Never run prettier or `eslint --fix` repo-wide**, and never format
+  `docs/design-system.md` - most of the tree isn't prettier-clean and formatting
+  that file reflows ~480 lines. Format only files you touched that were clean
+  before.
+- **"Written but never read" is this codebase's most repeated defect** - found
+  nine times: state one layer records and no layer displays (SSE errors,
+  save-failure reasons, an import phase, parsed cookie attributes), and config
+  one branch defines and another re-derives inline (`SCOPE_CONFIG.global`).
+  Store-level tests never catch these; they are wiring bugs. When you add a
+  field, grep for a reader before assuming there is one.
+- **A hand-rolled copy of a primitive does not receive the primitive's fixes.**
+  Before styling or reimplementing something that already exists as a primitive,
+  `rg` for the primitive.
+- **Mutation-check behavioural tests** (revert the fix, confirm failure,
+  restore). Source-scanning guards must assert they scanned something non-empty
+  - one passed for weeks reading an empty string, since vitest stubs CSS imports
+  to `""`.
+- Labels separate WHERE a change lands (`component:*`) from WHAT kind it is
+  (`type:*`). See `.github/LABELING.md`; auto-labeling is `.github/labeler.yml`.
 
-**A border is invisible or not depending on what it sits *on*, never on what it
-is.** `--border` is tuned for the canvas (1.14) and is the *same colour* as
-`--card` in dark (1.00), so a rule inside a card is simply absent. A card's own
-outline on `border-border` is correct, though, because that edge faces the
-canvas - and both read as `border border-border bg-card` in the source, so only
-the ancestry tells them apart. This was found and fixed one component at a time
-about ten times before it was centralised.
+## Docs - keep them in step with the code
 
-**Write `border-rule`, not a border token.** A surface class (`surface-card`,
-`surface-sunken`) sets its background *and* declares the `--rule` that reads on
-it; `border-rule` inherits the right value, per theme, including through
-nesting. Card resolves to 1.304 light / 1.278 dark, sunken to 1.356 / 1.343 -
-parity a single token cannot give, since `--border` is invisible in dark and
-`--border-strong` overshoots light. On `--muted` / `--accent` no border token
-works at all: `--border-strong` is *weaker* there than `--border` in dark
-(1.11 vs 1.16) and the pair inverts in light, which is why sunken uses an alpha
-of `--foreground`. Definitions in `index.css`, rationale in
-`docs/design-system.md`.
+**If you change something a doc describes, update that doc in the same commit.**
+These are reference material future sessions are told to trust, so a stale line
+is worse than a missing one - the design-system doc had drifted five separate
+ways before anyone checked.
 
-The mistake is now **enumerable, not impossible**: a `border-rule` under no
-declared surface silently falls back to the invisible default. So guard the
-*declarations* (`surface-rule.test.tsx`, `ImportModal.surface-rule.test.tsx`) -
-asserting `border-rule` is present proves nothing. Adopted by the
-response-viewer family and the import dialog; elsewhere still uses explicit
-tokens, migrate as you touch. On an element whose primitive already sets a
-background utility (`DialogContent`'s `bg-background`), `surface-card` alone
-loses the cascade - write the pair `bg-card surface-card`
-(see `docs/design-system.md`).
+`app/CLAUDE.md` and `engine/CLAUDE.md` each carry the doc map for their side.
+Repo-level docs:
 
-**"Written but never read" is this codebase's most repeated defect** - found
-nine times: state one layer records and no layer displays (SSE errors,
-save-failure reasons, an import phase, parsed cookie attributes), and config one
-branch defines and another re-derives inline (`SCOPE_CONFIG.global`). Store-level
-tests never catch these; they are wiring bugs. When you add a field, grep for a
-reader before assuming there is one.
+| Doc | Update it when you change… |
+|-----|----------------------------|
+| `docs/architecture.md` | How app and engine talk, lifecycle, ports |
+| `docs/building.md` | `build.py`, prerequisites, platform quirks |
+| `docs/lock-file-handling.md` | Lock / concurrency behaviour |
+| `docs/request-storage-design.md` | How requests are stored |
+| `docs/plans/pending-backlog.md` | Deferring something, or picking it up |
+| `CONTRIBUTING.md` | PR process or style rules |
 
-**A hand-rolled copy of a primitive does not receive the primitive's fixes.**
-The script panels printed `scope[0].toUpperCase()` in a plain `Badge` instead of
-using `VariableScopeBadge`, so the scope-colour fix that landed in the primitive
-never reached them and all three scopes stayed grey. Before styling something
-that already exists as a primitive, `rg` for the primitive.
-
-**Before measuring or changing a class, `rg` for it in the components.** Twice a
-conclusion was drawn about a combination the app never renders (`bg-border-strong`
-only existed behind a `data-[state=]` variant; white-on-`--primary` never occurs
-because fills use `--primary-fill`).
-
-**Never run prettier/`eslint --fix` repo-wide, and never format
-`docs/design-system.md`** - most of the tree isn't prettier-clean and formatting
-that file reflows ~480 lines. Format only files you touched that were clean before.
-
-**Mutation-check behavioural tests** (revert the fix, confirm failure, restore).
-Source-scanning guards must assert they scanned something non-empty - one passed
-for weeks reading an empty string, since vitest stubs CSS imports to `""`.
-
-**A source scan cannot see a class that arrives in a variable.** The badge-hover
-guard scanned for `<Badge className="bg-…">` and missed both real instances,
-because each got its background from a `statusColor` / `config.tint` binding;
-reverting the fix left the scan green. For class-list defects, render the
-component and assert on `element.className`. Derive a guard's rule from the
-component (e.g. which variants actually carry a `hover:bg-*`) rather than
-hardcoding it - a hardcoded version flagged `variant="outline"`, which owns no
-background and cannot collide.
+**`docs/` is published** to <https://athrvk.github.io/vayu/> via MkDocs, and
+`mkdocs build --strict` gates every docs-touching PR - a broken relative link or
+a missing heading anchor is a build failure. Before adding, moving or renaming a
+page, load the **`docs-site`** skill.
 
 ## Subagents in worktrees - check the base first
 
@@ -324,7 +158,9 @@ behind and one was current. An agent that does not check will produce findings
 against code that no longer exists; a previous round lost five agents' work this
 way, ~190 commits behind.
 
-Every subagent prompt must open with a base check naming the expected commit:
+Every subagent prompt must open with a base check naming the expected commit,
+pinned **as a literal SHA** ("the current branch" means nothing inside a
+worktree cut from somewhere else):
 
 ```bash
 git log --oneline -1
@@ -336,282 +172,14 @@ A strict ancestor with a clean tree can be repaired losslessly
 (`git reset --hard <expected>`); anything else should stop and report. Have the
 agent state which case applied, so a silent misfire still shows up.
 
-Also pin the base **in the prompt as a literal SHA**. "The current branch" means
-nothing inside a worktree that was cut from somewhere else.
+## Where the rest lives
 
-## Engine HTTP API
+Nested guides load automatically when you read a file in that tree; skills load
+when the task comes up, or on request by name.
 
-The engine daemon listens on `http://127.0.0.1:9876`. Key endpoints:
-
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/compose` | Resolve `{{vars}}` + `inherit` auth; returns an execute-ready payload (sends nothing) |
-| POST | `/execute` | Send a single request (auth resolved engine-side) |
-| POST | `/runs` | Start a load test run |
-| GET | `/runs/:runId/live` | SSE stream of live metrics |
-| GET | `/runs/:runId/metrics` | Historical time-series (JSON) for a run |
-| POST | `/oauth2/token` | Acquire/return a cached OAuth 2.0 token (auth resolved engine-side) |
-| GET | `/health` | Health check |
-| POST | `/import/apply` | Persist a whole parsed import atomically; returns a temp-id -> real-id map |
-| POST | `/collections`, `/requests`, `/environments` | **Create only** - 409 on an existing id |
-| PUT | `/collections/:id`, `/requests/:id`, `/environments/:id` | **Update only** (merge-patch) - 404 on a missing id |
-
-The pre-consolidation paths (`POST /request`, `POST /run`, `GET /run/:id[/report|/stop]`,
-`DELETE /run/:id`, `GET /metrics/live/:runId`, `GET /stats/:runId?format=json`) still
-work as **deprecated aliases** and will be removed in a future minor release; `GET
-/stats/:runId` in its SSE mode is retained wholesale. See `docs/engine/api-reference.md`
-(Deprecated aliases) for full reference.
-
-Three things worth knowing before you design around them:
-
-- **POST creates, PUT updates - they are not interchangeable.** `POST
-  /<resource>` never updates and `PUT /<resource>/:id` on an id that does not
-  exist is a `404`; POST-as-upsert is gone (issue #95). One null-vs-absent rule
-  covers all three resources: on create
-  absent and `null` both mean "use the default", on update absent means "keep"
-  and `null` means "reset to the default", and a field with no default (a
-  collection's / environment's `name`, a request's `collectionId` / `name` /
-  `method` / `url`) rejects `null` with a `400` instead of ignoring the write.
-  The rule lives in one place per side - `apply_*_field` in
-  `engine/include/vayu/http/routes.hpp`, and `apiService.updateX` in
-  `app/src/services/api.ts` - so add fields there rather than re-deriving the
-  rule per handler. **The engine owns every id** (#97): a create carrying an `id`
-  is a `400` (presence alone, `null` included - `id` is outside the null rule),
-  and a `PUT` whose body `id` disagrees with the path is a `400` too, so the 409
-  on an existing id now only guards a `generate_id` collision.
-  `reject_client_supplied_id` / `reject_mismatched_body_id` in `routes.hpp` are
-  the one copy of that; `apiService.createX` strips `id` on the renderer side
-  because TypeScript only excess-property-checks object literals. Bulk import
-  goes through **`POST /import/apply`** (#96), which takes opaque `tempId`s,
-  generates every real id engine-side, returns the `idMap`, and writes the whole
-  tree in one transaction (a rejected payload persists nothing, so the old
-  client-side rollback is gone). The same per-resource field appliers back both
-  paths - `apply_collection_fields` / `apply_request_fields` /
-  `apply_environment_fields`, declared in `routes.hpp` - so add a field there and
-  bulk import gets it too.
-- **`GET /requests/:id` is a single-request lookup.** `useRequestQuery` uses it
-  to load a restored request tab or a design-run copy on cold start - one round
-  trip, not the old scan of every collection's list. A `404` means the request
-  was genuinely deleted; anything else (a `5xx`, an unreachable engine) is a
-  transport failure, and callers (`DesignRunView`) must keep those apart - only
-  a real 404 becomes `RequestNotFoundError`. `GET /requests?collectionId=` still
-  lists a collection's requests.
-- **`followRedirects` / `maxRedirects` are per-request and stored** (request
-  builder → **Settings** tab, `requests.follow_redirects` / `max_redirects`).
-  Both clients send them on *every* execute and load test rather than eliding
-  the defaults, because the engine's `follow_redirects` defaults to **true** -
-  an omitted `false` would silently follow the 3xx the user asked to see.
-  **`verifySSL` is still engine-only**; it was deliberately not exposed.
-
-## Request composition (engine-owned - POST /compose)
-
-The **engine owns** request composition (issue #226, backlog A1 shipped):
-`POST /compose` (`engine/src/http/request_composer.cpp`) resolves
-`{{variables}}` and `inherit` auth (collection-chain walk, `noauth`
-terminates, `none` steps over) and returns the execute-ready payload that
-`POST /execute` / `POST /runs` accept unchanged. Compose is **pure** (sends
-nothing, no run row) and the execution endpoints **never interpolate**, so a
-payload is resolved exactly once - that split is load-bearing, do not "merge"
-compose into execute. Two entry shapes: `requestId` (stored request; MCP uses
-this, and gates its allowlist on the *composed* URL) and an inline `request`
-(+ `collectionId` scope; the renderer uses this because Send/replay execute
-*editor state*, which may be unsaved or detached). Inline over stored = the
-overlay MCP's `start_load_run` overrides ride on.
-
-**The renderer's resolver is preview-only.** `useVariableResolver` /
-`app/src/lib/variable-resolution.ts` back tab titles, previews, the
-unresolved-token painting and the OAuth-guard preview - never a payload. The
-preview must show what the engine will substitute, so its rules are pinned to
-the engine's by the **cross-language conformance fixture**
-(`engine/tests/fixtures/variable-resolution-conformance.json`), read by both
-`request_composer_test.cpp` (gtest) and
-`variable-resolution.conformance.test.ts` (vitest). Change resolution
-semantics → change engine + renderer lib + fixture together; a case added to
-the fixture fails whichever side forgot. The dynamic-variable name set
-(`$guid`, `$timestamp`, …) is part of that fixture-pinned contract (C++ table
-in `request_composer.cpp`, renderer table in `lib/dynamic-variables.ts`).
-The D17 malformed-data rules (absent/non-boolean `enabled` = enabled;
-non-string `value` = "") live engine-side in `parse_variables` and
-renderer-side in `lib/variable-resolution.ts`. Interpolation happens strictly
-**before** the pre-request script (D1 - deliberate Postman divergence), and
-script text is never interpolated (D16). **MCP has no composition copy
-anymore** (`resolve.ts` deleted) - a new engine client should call
-`POST /compose`, never re-implement resolution client-side.
-
-Script parts: clients on the inline path still build the ordered `ScriptPart`
-list themselves (`scriptParts` in
-`app/src/modules/request-builder/utils/script-parts.ts` - now the only
-client-side copy); the by-id path builds it engine-side
-(`compose_script_parts`). The **engine** joins parts with `"\n\n"` and runs
-the result. **Both names reach the same script**: `read_post_request_script`
-(`engine/src/http/script_parts.cpp`) owns every spelling the post-request
-script answers to - stored as `postRequestScript`, `postRequestScript(s)` on
-`/execute`, `tests` on `/runs` - and both routes read through it, so a payload
-composed for one endpoint can start the other kind of run unchanged. Add a
-spelling to that table, never to a route.
-
-The endpoint names above are the canonical ones (`POST /compose`,
-`POST /execute`, `POST /runs`); the old `POST /request` / `POST /run` still
-work as deprecated aliases. An unresolved `{"mode":"inherit"}` reaching an
-execution endpoint is treated as no auth and logged as a **warning** - it
-means a client skipped composition.
-
-## Releasing
-
-1. `python build.py --bump-version patch` - updates VERSION, CMakeLists.txt, vcpkg.json, package.json
-2. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a Changelog format, see below).
-3. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes file together).
-4. Tag: `git tag v$(cat VERSION) && git push origin --tags`
-5. CI builds installers and publishes the GitHub Release, using `.github/release-notes/<tag>.md` as the release body automatically (no manual paste).
-
-**Tag *after* the release commit lands on the default branch.** When the version bump goes through a pull request (the usual path), run steps 1-2 on the feature branch so the bump merges with the PR, but do **not** tag the PR-branch commit. A squash/rebase merge rewrites the commit hash, so a tag on the pre-merge commit would point at a commit that never reaches the default branch. Wait for the PR to merge, then run step 3 against the merged commit on the default branch (`git checkout <default-branch> && git pull && git tag v$(cat VERSION) && git push origin --tags`). The tag triggers the release build, so it must sit on the canonical merged history.
-
-**`install.sh` (repo root) installs *and updates*, on macOS and Linux.** macOS: downloads the release zip, ad-hoc signs app + sidecar, strips quarantine, `sudo`-installs to `/Applications`. Linux: AppImage + `.desktop` entry + icon + a `vayu` symlink when `~/.local/bin` is on `PATH`, all under `~/.local/share/vayu`, **no sudo**. Both share every decision and dispatch only the actions, on `platform()` - a function wrapping `uname -s`, so tests can force either branch on either host. Tested by `scripts/test/install_test.sh` (`VAYU_DRYRUN=1`), shellchecked in CI on both. Published by the docs site: `.github/hooks/install_script.py` registers the repo-root file at the site root, which is why `install.sh` is in the `paths:` filters of `docs.yml` - without that the published copy silently falls behind master. Documented as `bash -c "$(curl …)"`, not `curl … | bash`, so the script is buffered before it runs and stdin stays on the terminal.
-
-Six things about it that the code cannot tell you:
-
-- **It is the macOS *update* path** - `resolveUpdateStrategy` returns `notify` there, since an ad-hoc signature gives Squirrel.Mac nothing to verify. So the app is usually *running* when the script starts, and `macInstallCommand()` (`app/electron/updater.ts`) must match the command README publishes; `updater.test.ts` asserts that by reading the README, because a template literal is invisible to a URL grep.
-- **Never detect the running app by matching command lines.** `bash -c "$(curl …)"` puts the whole script - comments included - into its own argv, so a `pgrep -f` pattern appearing anywhere in the file matches the installer itself. That aborted every Linux install while the suite stayed green, because sourcing the file never populates argv. Linux reads `/proc/<pid>/exe`, both platforms filter by process group, and `install_test.sh` exercises the real `bash -c "$(cat install.sh)"` form.
-- **A flag appended to the documented command lands in `$0`, not `$1`.** `bash -c "$(curl …)" --force` gives bash's `-c` its *name* argument, so `$#` is 0 and the flag silently vanished - the run reported "already installed - nothing to do" while ignoring the `--force` it was handed. `parse_args` now recovers a `-`-prefixed `$0` back into `"$@"`, skipping a bare `--` (with the separator present bash puts *that* in `$0`, so a naive `-*` match turns a correct invocation into "Unknown option: --"). Sourcing can never reproduce this, so the coverage runs the real `bash -c "$(cat install.sh)"` form. Same family: a flag that parses but does nothing - `--purge` without `--uninstall` is now a usage error, and any hint the script prints must be a command that actually runs (`--uninstall --purge`, not `--purge`).
-- **`electron/quit-signals.ts` is load-bearing.** Linux has no Apple Event, so the installer quits with `SIGTERM`, and Node's default would kill the process without running `before-quit` - losing pending saves and orphaning the engine. The app can also quit itself (`update:quitForUpdate`, the **Quit to update** button), the only quit needing no Automation consent.
-- **The install target follows the existing copy.** `/Applications` is only the *fresh install* default; two copies are reported rather than silently picked between, and uninstall removes every copy. Resolution (`resolved_install_path`) prints and the single assignment lives in `adopt_install_target`, so nothing here is unsafe to call from a subshell.
-- **The Linux version stamp (`~/.local/share/vayu/version`) has two writers**: the installer, and `electron/appimage-stamp.ts` at startup - the AppImage self-updates in place and would otherwise leave the stamp stale. That module duplicates `install.sh`'s path constants; move one, move both.
-- **Every `sudo` goes through `privileged()`, which refuses to run before `authorize()`.** The ordering used to be a convention and the convention broke: `sweep_staging` deleted a bundle in `/Applications` *without* sudo two lines above one that used it, both before the password was ever asked for. `VAYU_SUDO` lets `install_e2e.sh` substitute a stub, which is the only way CI can see the privileged path at all - the runners have passwordless sudo and no terminal, which is where three bugs in a row hid.
-- **Every release artifact publishes a `.sha256`** (checksum steps in `release.yml`), so the installer's verification is real on all three platforms rather than dead code outside macOS.
-- **Errors go through `die()`, never `step || exit 1` at a call site.** Bash disables `errexit` for the whole body of a function invoked in an `||` context, so an unchecked command inside it falls through - that is how a failed download was once reported as success. A step that cannot continue says so itself. The cost: a dying function cannot be called in-process by a test, so `install_test.sh` wraps those calls in a subshell.
-- **Two suites, two jobs.** `install_test.sh` is dry-run and owns the *decisions* (which version, which platform branch, which order, sudo or not - including the other platform's branch, which is why it stubs `platform()`). `scripts/test/install_e2e.sh` runs the installer for real against a local release in a temp root and owns the *effects*. Put a new assertion in whichever answers it; do not duplicate.
-- **Release assets carry versions** (`Vayu-<v>-universal.zip`, `Vayu-<v>-x86_64.AppImage`) while `Vayu-x64.exe` and `Vayu-amd64.deb` do not, so `/releases/latest/download/<name>` **404s for macOS and Linux**. Link the installer or `/releases/latest`; never invent an unversioned asset URL.
-
-**Windows also publishes to winget, automatically.** The `publish-winget` job in
-`release.yml` submits `Vayu-x64.exe` to `microsoft/winget-pkgs` after the
-release is built, so `winget install athrvk.Vayu` follows each tag with no
-manual step. It runs only on a tag push and only if the whole build matrix
-succeeded, and it skips silently when the `WINGET_TOKEN` secret is absent - so
-a release can never fail because of it.
-
-It keeps the **five newest versions** on winget (`max-versions-to-keep`) and
-drops older ones as each release is submitted. Unbounded, every version ever
-released stays installable at an explicit `--version`, including 0.10.0, whose
-engine cannot start without the Visual C++ redistributable. The manual workflow
-below deliberately does *not* prune, because it exists partly to publish an
-older tag and pruning keeps the *newest* N - it could delete the very version
-being submitted. The next tagged release restores the cap on its own. Pruning
-affects the winget index only; the GitHub Releases page keeps everything.
-
-For anything the tag-triggered path does not cover - a release that predates
-the automation, a re-submission after a winget-pkgs pull request was closed,
-publishing an older tag - run the **Publish to winget (manual)** workflow
-(`.github/workflows/winget-publish.yml`) from the Actions tab. It takes an
-optional tag (defaulting to the latest release), validates that the release and
-its `Vayu-x64.exe` asset exist, and submits only that - it builds nothing.
-Unlike the automatic job it **fails** rather than skips when `WINGET_TOKEN` is
-missing, because a manual run that published nothing while reporting success
-would be worse than an error. `WINGET_TOKEN` must be a **classic** PAT with
-`public_repo` scope; fine-grained PATs are not supported by the action.
-
-### Release changelog
-
-Release notes live on the [GitHub Releases](https://github.com/athrvk/vayu/releases) page (there is no `CHANGELOG.md` in the repo). Write them in [Keep a Changelog](https://keepachangelog.com) style so entries stay consistent across versions:
-
-- **Heading:** `## [X.Y.Z] - YYYY-MM-DD` (ISO date).
-- **Lead paragraph:** 2-4 sentences naming the release theme and where the change concentrates (engine vs app), e.g. "The OAuth 2.0 release ... the bulk of the change is new C++ in the engine and new React/Electron surface in the app."
-- **Grouped sections, in this order, omitting any that are empty:** `### Added`, `### Changed`, `### Fixed`. Use `### Security` / `### Removed` / `### Deprecated` only when they apply.
-- **Bullets:** lead with a bold headline, then the detail, e.g. `- **OAuth 2.0 auth mode.** A new \`oauth2\` mode in the request Auth panel and Collection Detail ...`. Prefer user-facing wording; reference files/endpoints only when they aid a contributor.
-- **Fold internal churn** (doc hygiene, refactors with no user-visible effect) into a single summary bullet rather than listing each commit.
-- **Compare link footer:** `[X.Y.Z]: https://github.com/athrvk/vayu/compare/vPREV...vX.Y.Z`.
-- **Version choice:** patch = fixes only; minor = new user-facing feature; major = breaking change (still `0.x`, so reserve major for a stable milestone). See the [prior releases](https://github.com/athrvk/vayu/releases) for worked examples.
-
-**Release notes are published from a file - no manual paste.** Curated notes for each version live in the repo at `.github/release-notes/vX.Y.Z.md`, committed alongside the version bump (Releasing step 2). On tag push, `.github/workflows/release.yml` reads `.github/release-notes/<tag>.md` and sets it as the GitHub Release body via `softprops/action-gh-release`'s `body_path`. If that file is missing for the tag, the workflow falls back to GitHub's automatically generated PR-based notes (`generate_release_notes`) so a release is never published empty.
-
-**Authoring the notes (Claude's job before tagging).** When preparing a release, write `.github/release-notes/vX.Y.Z.md` in the format above, derived from `git log vPREV..vX.Y.Z`; read a recent entry to match voice. The file *is* the release body, so it needs no tooling to publish - CI handles it. Because the workflow resolves the file from the tagged commit's tree, the notes file must be committed **before** the tag is pushed (i.e., it rides along in the release PR). To correct a published release's notes after the fact, edit the file, then either re-run the release workflow or update the release body by hand.
-
-## Labels and Issue Organization
-
-Repository labels are organized by semantic purpose with a color strategy that separates WHERE changes land (`component:*`, cool/neutral colors) from WHAT kind of change they are (`type:*`, semantic colors) - e.g. `component:engine` (teal) and `type:bug` (red) no longer look alike. **See `.github/LABELING.md` for the full category breakdown, color table, and auto-labeling rules** (driven by `.github/labeler.yml`).
-
-## Docs - keep them in step with the code
-
-**If you change something a doc describes, update that doc in the same commit.**
-These are reference material future sessions are told to trust, so a stale line
-is worse than a missing one - the design-system doc had drifted five separate
-ways before anyone checked.
-
-| Doc | Covers | Update it when you change… |
-|-----|--------|----------------------------|
-| `docs/architecture.md` | Sidecar pattern, process model | How app and engine talk, lifecycle, ports |
-| `docs/building.md` | Cross-platform build notes | `build.py`, prerequisites, platform quirks |
-| `docs/design-system.md` | UI tokens, elevation, type, component patterns | Any token value, colour rule, radius, or shared UI primitive |
-| `docs/app/COMPONENTS.md` | React structure (`modules/` + `components/`) | Adding or moving a module / shared component |
-| `docs/app/architecture.md` | Renderer architecture | Renderer-side structural decisions |
-| `docs/app/state-management.md` | Zustand stores + TanStack Query | Adding a store, changing query keys or cache policy |
-| `docs/app/api-integration.md` | Renderer ↔ engine calls | Request/response shapes the renderer sends |
-| `docs/app/variable-resolution.md` | `{{var}}` resolution + scope precedence | Resolution order, scopes, the resolver hook |
-| `docs/app/import-collections/` | Import pipeline + per-format mapping | Detectors, drafts, any format mapping |
-| `docs/app/pm-api-compatibility.md` | Postman `pm.*` surface | Which `pm.*` APIs the runtime supports |
-| `docs/app/file-name-conventions.md` | Naming rules | The conventions themselves |
-| `docs/app/building.md` | App build | App build steps or tooling |
-| `docs/engine/architecture.md` | Engine internals, engine-side auth | Core engine structure, auth resolution |
-| `docs/engine/api-reference.md` | Engine HTTP API | **Any** endpoint, payload, or status code |
-| `docs/engine/db-schema.md` | SQLite tables + JSON shapes | Schema, migrations, stored JSON |
-| `docs/engine/scripting.md` | QuickJS runtime + script API | Script globals, hooks, sandbox limits |
-| `docs/engine/mcp.md` | MCP server surface | MCP tools or their schemas |
-| `docs/engine/cli.md` | Engine CLI | Flags or subcommands |
-| `docs/engine/benchmarks.md` | Perf numbers + method | Load generation or measurement |
-| `docs/engine/building.md` | Engine build | CMake presets, vcpkg deps |
-| `docs/lock-file-handling.md` | Lock-file strategy | Lock / concurrency behaviour |
-| `docs/request-storage-design.md` | Request persistence design | How requests are stored |
-| `docs/plans/pending-backlog.md` | Deferred work (e.g. A1) | Deferring something, or picking it up |
-| `CONTRIBUTING.md` | PR process, code style | Process or style rules |
-
-Module READMEs carry the *why* for their feature and are easy to miss:
-`app/src/modules/README.md`, plus one each for `welcome/`, `request-builder/`
-and `dashboard/`.
-
-Release notes live in `.github/release-notes/vX.Y.Z.md` - see **Releasing**.
-
-### `docs/` is published, so a broken link is a build failure
-
-`docs/` ships to <https://athrvk.github.io/vayu/> via MkDocs Material
-(`.github/mkdocs.yml`, `.github/workflows/docs.yml`, deps pinned in
-`requirements-docs.txt`). `mkdocs build --strict` runs on every docs-touching
-pull request and fails on an unresolvable relative `.md` link or a missing
-heading anchor, so:
-
-- **Add a new page to the `nav:` in `.github/mkdocs.yml`** in the same commit. Off-nav
-  pages build and are reachable by URL, but never appear in the sidebar.
-- **Do not rename or move a doc file** without checking for readers. Tests read
-  doc paths (`app/src/design-system-doc.test.ts` reads `docs/design-system.md`;
-  `app/src/state-management-doc.test.ts` reads `docs/app/state-management.md`,
-  `architecture.md` and `api-integration.md`, and fails on a `useXxx` or
-  `SCREAMING_CASE` name they quote that no longer exists in the app source),
-  and every relative cross-link is validated by the build.
-- **Anchors follow GitHub's slug rules** (`pymdownx.slugs.slugify` is configured
-  for exactly this), so one anchor form works both in GitHub's markdown view and
-  on the site. Heading punctuation counts: `## Shared Auth Fields
-  (components/shared/AuthFields/)` is `#shared-auth-fields-componentssharedauthfields`.
-- **Links out of `docs/`** (`SECURITY.md`, `LICENSE`, `CONTRIBUTING.md`) must be
-  absolute `https://github.com/athrvk/vayu/blob/master/...` URLs - those files
-  are outside the published tree.
-- **Analytics is on the published site only, and only when it has an ID.** The
-  GA4 measurement ID comes from the `GOOGLE_ANALYTICS_KEY` Actions *repository
-  variable* (Settings -> Secrets and variables -> Actions -> Variables), read by
-  `extra.analytics.property` via `!ENV`. With it unset - every fork, every
-  pull-request preview, every local `mkdocs serve` - `.github/hooks/analytics.py`
-  strips `extra.analytics`, `extra.consent` and the footer's "Cookie settings"
-  link, so those builds ship no tracker and no banner. `!ENV` alone does **not**
-  do this: Material emits its gtag snippet even for an empty property, which is
-  the whole reason that hook exists. On the published site GA is consent-gated -
-  the snippet is defined but only runs once the visitor accepts. **This is the
-  docs website, not the app**; `no telemetry` in `docs/index.md` and `README.md`
-  is a claim about the app and stays true, so keep the two apart when editing
-  either.
-- **Jekyll is not an option here** and the workflow says why: Pages' default
-  Jekyll build runs Liquid over page content, and these docs contain 40+
-  `{{variable}}` examples (rendered as empty strings) plus `{% ... %}` (an
-  unknown tag, which fails the build). MkDocs never templates page content.
-
-Preview locally with `pip install -r requirements-docs.txt && mkdocs serve -f
-.github/mkdocs.yml`. The `-f` is required - the config is not at the repo root -
-and the site serves under `/vayu/`. The favicon/logo are not files under `docs/`:
-`.github/hooks/brand_assets.py` pulls `shared/icon_png/vayu_icon_256x256.png`
-into the build, so do not add a copy.
+| Load | Covers |
+|------|--------|
+| `app/CLAUDE.md` | TypeScript/React conventions, the UI rules enforced by tests, design-system and border/surface rules, renderer doc map |
+| `engine/CLAUDE.md` | C++ conventions, the engine HTTP API contract, request composition (`POST /compose`), engine doc map |
+| `releasing` skill | Version bump, release notes, tagging, `install.sh`, winget publishing |
+| `docs-site` skill | MkDocs publishing rules, nav, anchors, analytics, local preview |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,11 @@ Vayu is a high-performance API testing and load-testing platform. It uses a **si
 - **App** (`/app`): Electron + React + TypeScript, licensed Apache-2.0
 - **Build script**: `build.py` is the single entry point for all build operations
 
+## Core Principle
+
+Make architectural decisions for the long term. Do not accept a stopgap that
+only works for now and is meant to be replaced later.
+
 ## Project Structure
 
 ```

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,150 @@
+# App (Electron + React + TypeScript)
+
+Renderer and Electron main process for Vayu. Apache-2.0. See the repo root
+`CLAUDE.md` for build commands, commit rules and repo-wide conventions.
+
+## Conventions
+
+- Strict TypeScript - no `any`, no `@ts-ignore` without justification
+- Component files: PascalCase `.tsx`; utilities: camelCase `.ts`
+- Feature-organized: `app/src/modules/<feature>/` (request-builder, collections,
+  dashboard, history, variables, settings, welcome); shared shell + primitives in
+  `app/src/components/` (layout, shared, ui). See `docs/app/COMPONENTS.md`.
+- Import parsers: `app/src/services/importers/` (factory → ordered detectors →
+  drafts → orchestrator); per-format docs in `docs/app/import-collections/`.
+- State: Zustand for UI state, TanStack Query for server state
+- Styling: Tailwind CSS v4 - all colors via CSS custom properties
+- **Design system: `docs/design-system.md`** - tokens, elevation, typography,
+  component patterns. **Read this before touching any UI file.**
+
+## Tests default to the `node` environment
+
+A DOM costs ~2s per file and half the suite never touches one. If your test
+renders, or reaches `document` / `window` / `localStorage` (zustand `persist`
+does, without naming it), start the file with:
+
+```ts
+/**
+ * @vitest-environment jsdom
+ */
+```
+
+Forgetting it fails loudly (`document is not defined`), never silently.
+
+**A source scan cannot see a class that arrives in a variable.** The badge-hover
+guard scanned for `<Badge className="bg-…">` and missed both real instances,
+because each got its background from a `statusColor` / `config.tint` binding;
+reverting the fix left the scan green. For class-list defects, render the
+component and assert on `element.className`. Derive a guard's rule from the
+component (e.g. which variants actually carry a `hover:bg-*`) rather than
+hardcoding it - a hardcoded version flagged `variant="outline"`, which owns no
+background and cannot collide.
+
+**A hand-rolled copy of a primitive does not receive the primitive's fixes.**
+The script panels printed `scope[0].toUpperCase()` in a plain `Badge` instead of
+using `VariableScopeBadge`, so the scope-colour fix that landed in the primitive
+never reached them and all three scopes stayed grey. Before styling something
+that already exists as a primitive, `rg` for the primitive.
+
+**Before measuring or changing a class, `rg` for it in the components.** Twice a
+conclusion was drawn about a combination the app never renders
+(`bg-border-strong` only existed behind a `data-[state=]` variant;
+white-on-`--primary` never occurs because fills use `--primary-fill`).
+
+## UI rules (enforced by tests - breaking one fails CI)
+
+- **Status colours have three tokens:** `--status-*` (dot/icon/tint),
+  `--status-*-text` (when the colour _is_ the text), `--status-*-fill` (solid
+  chip under a white label). Using the bare fill as a foreground is the most
+  common colour bug here. → `status-color-tokens.test.ts`
+- **`--primary` vs `--primary-fill`:** `--primary` is text/ring/chart and
+  brightens in dark; `--primary-fill` is the solid button background and is one
+  value in both themes. Do not unify them - pinning `--primary` drops accent text
+  from APCA Lc 44–69 to 22–37.
+- **No raw Tailwind palette** (`text-green-500`) in the request/response tree
+  → `palette-tokens.test.ts`. Elsewhere only with an explicit `dark:` pair.
+- **No chart series on `--primary`/`--chart-1`** - both track the user's accent
+  and can collide with a semantic series. Use `categorical`.
+  → `status-code-series.test.ts`
+- **No bare `rounded`** - it ignores the Roundedness setting. → `radius-token.test.tsx`.
+  **No radius class at all** is the same escape hatch pointing the other way: it
+  pins the box at 0 for a user who chose Rounded. No source scan can flag it,
+  because plenty of surfaces are square on purpose (header bars, tab strips,
+  full-bleed editors) - only the component knows which it is, so render it and
+  read `element.className`. Seven boxes in the request builder were stuck square
+  this way. → `boxed-surfaces.test.tsx`, `KeyValueRow.test.tsx`
+- **A drawer row's hit area needs two things, not one.** A row that carries a `⋯`
+  menu cannot be one button, so it is an `h-8 items-center` container that paints
+  the hover fill plus a narrower activator button holding the handler. That leaks
+  clicks twice over: `items-center` leaves the button _content_-height (18px in a
+  collection or environment row, so 7px above and below are dead), and the row's
+  own box - the `paddingLeft` indent, the flex gaps, the right padding - belongs
+  to no child at all. Measured in the running app, a collection row responded
+  over **41%** of the area that looked clickable, a request row 51%, an
+  environment row 36%. The fix is `self-stretch` on the activator **plus** the row
+  delegating clicks that land on itself (`e.target === e.currentTarget`, which
+  keeps the chevron and `⋯` out and stops a double-fire on bubble). The indent
+  cannot simply move onto the activator - on a collection row the chevron sits
+  between them. → `drawer-row-hit-area.test.tsx`. Assert the height as a
+  `className`, not `offsetHeight`: jsdom has no layout and reports 0 for
+  everything, so an `offsetHeight` guard passes while measuring nothing.
+- **Adding an accent scheme:** `constants/color-schemes.ts` + `index.css`, both
+  themes, nothing else. → `color-schemes.test.ts`
+- **A `Badge` that paints its own `bg-` must be `variant="chip"`.** Every other
+  variant pairs `bg-x` with `hover:bg-x/80`, and `cn()` (tailwind-merge) replaces
+  `bg-*` but _not_ `hover:bg-*` - so the caller's fill won at rest and the
+  variant's hover won on hover. Status chips turned the accent colour under the
+  pointer. → `badge-hover.test.tsx`
+- **`docs/design-system.md` values are checked against `index.css`**
+  → `design-system-doc.test.ts`. Prose is not - if you change a value, read the
+  sentence around it.
+
+## Borders: what a rule sits _on_, never what it is
+
+**A border is invisible or not depending on what it sits _on_, never on what it
+is.** `--border` is tuned for the canvas (1.14) and is the _same colour_ as
+`--card` in dark (1.00), so a rule inside a card is simply absent. A card's own
+outline on `border-border` is correct, though, because that edge faces the
+canvas - and both read as `border border-border bg-card` in the source, so only
+the ancestry tells them apart. This was found and fixed one component at a time
+about ten times before it was centralised.
+
+**Write `border-rule`, not a border token.** A surface class (`surface-card`,
+`surface-sunken`) sets its background _and_ declares the `--rule` that reads on
+it; `border-rule` inherits the right value, per theme, including through
+nesting. Card resolves to 1.304 light / 1.278 dark, sunken to 1.356 / 1.343 -
+parity a single token cannot give, since `--border` is invisible in dark and
+`--border-strong` overshoots light. On `--muted` / `--accent` no border token
+works at all: `--border-strong` is _weaker_ there than `--border` in dark
+(1.11 vs 1.16) and the pair inverts in light, which is why sunken uses an alpha
+of `--foreground`. Definitions in `index.css`, rationale in
+`docs/design-system.md`.
+
+The mistake is now **enumerable, not impossible**: a `border-rule` under no
+declared surface silently falls back to the invisible default. So guard the
+_declarations_ (`surface-rule.test.tsx`, `ImportModal.surface-rule.test.tsx`) -
+asserting `border-rule` is present proves nothing. Adopted by the
+response-viewer family and the import dialog; elsewhere still uses explicit
+tokens, migrate as you touch. On an element whose primitive already sets a
+background utility (`DialogContent`'s `bg-background`), `surface-card` alone
+loses the cascade - write the pair `bg-card surface-card`
+(see `docs/design-system.md`).
+
+## Docs to keep in step
+
+| Doc                                 | Update it when you change…                                   |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `docs/design-system.md`             | Any token value, colour rule, radius, or shared UI primitive |
+| `docs/app/COMPONENTS.md`            | Adding or moving a module / shared component                 |
+| `docs/app/architecture.md`          | Renderer-side structural decisions                           |
+| `docs/app/state-management.md`      | Adding a store, changing query keys or cache policy          |
+| `docs/app/api-integration.md`       | Request/response shapes the renderer sends                   |
+| `docs/app/variable-resolution.md`   | Resolution order, scopes, the resolver hook                  |
+| `docs/app/import-collections/`      | Detectors, drafts, any format mapping                        |
+| `docs/app/pm-api-compatibility.md`  | Which `pm.*` APIs the runtime supports                       |
+| `docs/app/file-name-conventions.md` | The naming conventions themselves                            |
+| `docs/app/building.md`              | App build steps or tooling                                   |
+
+Module READMEs carry the _why_ for their feature and are easy to miss:
+`app/src/modules/README.md`, plus one each for `welcome/`, `request-builder/`
+and `dashboard/`.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -1,0 +1,155 @@
+# Engine (C++20 daemon)
+
+The load-testing and request-execution engine. AGPL-3.0. See the repo root
+`CLAUDE.md` for build commands, commit rules and repo-wide conventions.
+
+```
+engine/
+├── src/core/      # load_strategy, metrics_collector, run_manager
+├── src/http/      # HTTP server, SSE, routes, thread_pool, rate_limiter
+├── src/db/        # SQLite persistence
+├── src/runtime/   # QuickJS scripting engine
+├── include/vayu/  # Public headers
+├── tests/         # Google Test suite
+└── vendor/        # quickjs-ng, picosha2 (PKCE/SHA-256), hdrhistogram
+```
+
+## Conventions
+
+- Standard: C++20, `-Wall -Wextra -Wpedantic`
+- Formatter: clang-format (`.clang-format` at repo root)
+- Linter: clang-tidy (`.clang-tidy` configs in `engine/`, `engine/src/runtime/`,
+  `engine/tests/`)
+- Install the git pre-commit hook: `bash scripts/install-git-hooks.sh`
+- vcpkg manages all C++ dependencies - do not add one without updating
+  `engine/vcpkg.json`
+
+## HTTP API
+
+The daemon listens on `http://127.0.0.1:9876`. Key endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/compose` | Resolve `{{vars}}` + `inherit` auth; returns an execute-ready payload (sends nothing) |
+| POST | `/execute` | Send a single request (auth resolved engine-side) |
+| POST | `/runs` | Start a load test run |
+| GET | `/runs/:runId/live` | SSE stream of live metrics |
+| GET | `/runs/:runId/metrics` | Historical time-series (JSON) for a run |
+| POST | `/oauth2/token` | Acquire/return a cached OAuth 2.0 token (auth resolved engine-side) |
+| GET | `/health` | Health check |
+| POST | `/import/apply` | Persist a whole parsed import atomically; returns a temp-id -> real-id map |
+| POST | `/collections`, `/requests`, `/environments` | **Create only** - 409 on an existing id |
+| PUT | `/collections/:id`, `/requests/:id`, `/environments/:id` | **Update only** (merge-patch) - 404 on a missing id |
+
+The pre-consolidation paths (`POST /request`, `POST /run`, `GET /run/:id[/report|/stop]`,
+`DELETE /run/:id`, `GET /metrics/live/:runId`, `GET /stats/:runId?format=json`) still
+work as **deprecated aliases** and will be removed in a future minor release; `GET
+/stats/:runId` in its SSE mode is retained wholesale. See `docs/engine/api-reference.md`
+(Deprecated aliases) for full reference.
+
+Three things worth knowing before you design around them:
+
+- **POST creates, PUT updates - they are not interchangeable.** `POST
+  /<resource>` never updates and `PUT /<resource>/:id` on an id that does not
+  exist is a `404`; POST-as-upsert is gone (issue #95). One null-vs-absent rule
+  covers all three resources: on create
+  absent and `null` both mean "use the default", on update absent means "keep"
+  and `null` means "reset to the default", and a field with no default (a
+  collection's / environment's `name`, a request's `collectionId` / `name` /
+  `method` / `url`) rejects `null` with a `400` instead of ignoring the write.
+  The rule lives in one place per side - `apply_*_field` in
+  `engine/include/vayu/http/routes.hpp`, and `apiService.updateX` in
+  `app/src/services/api.ts` - so add fields there rather than re-deriving the
+  rule per handler. **The engine owns every id** (#97): a create carrying an `id`
+  is a `400` (presence alone, `null` included - `id` is outside the null rule),
+  and a `PUT` whose body `id` disagrees with the path is a `400` too, so the 409
+  on an existing id now only guards a `generate_id` collision.
+  `reject_client_supplied_id` / `reject_mismatched_body_id` in `routes.hpp` are
+  the one copy of that; `apiService.createX` strips `id` on the renderer side
+  because TypeScript only excess-property-checks object literals. Bulk import
+  goes through **`POST /import/apply`** (#96), which takes opaque `tempId`s,
+  generates every real id engine-side, returns the `idMap`, and writes the whole
+  tree in one transaction (a rejected payload persists nothing, so the old
+  client-side rollback is gone). The same per-resource field appliers back both
+  paths - `apply_collection_fields` / `apply_request_fields` /
+  `apply_environment_fields`, declared in `routes.hpp` - so add a field there and
+  bulk import gets it too.
+- **`GET /requests/:id` is a single-request lookup.** `useRequestQuery` uses it
+  to load a restored request tab or a design-run copy on cold start - one round
+  trip, not the old scan of every collection's list. A `404` means the request
+  was genuinely deleted; anything else (a `5xx`, an unreachable engine) is a
+  transport failure, and callers (`DesignRunView`) must keep those apart - only
+  a real 404 becomes `RequestNotFoundError`. `GET /requests?collectionId=` still
+  lists a collection's requests.
+- **`followRedirects` / `maxRedirects` are per-request and stored** (request
+  builder → **Settings** tab, `requests.follow_redirects` / `max_redirects`).
+  Both clients send them on *every* execute and load test rather than eliding
+  the defaults, because the engine's `follow_redirects` defaults to **true** -
+  an omitted `false` would silently follow the 3xx the user asked to see.
+  **`verifySSL` is still engine-only**; it was deliberately not exposed.
+
+## Request composition (engine-owned - POST /compose)
+
+The **engine owns** request composition (issue #226, backlog A1 shipped):
+`POST /compose` (`engine/src/http/request_composer.cpp`) resolves
+`{{variables}}` and `inherit` auth (collection-chain walk, `noauth`
+terminates, `none` steps over) and returns the execute-ready payload that
+`POST /execute` / `POST /runs` accept unchanged. Compose is **pure** (sends
+nothing, no run row) and the execution endpoints **never interpolate**, so a
+payload is resolved exactly once - that split is load-bearing, do not "merge"
+compose into execute. Two entry shapes: `requestId` (stored request; MCP uses
+this, and gates its allowlist on the *composed* URL) and an inline `request`
+(+ `collectionId` scope; the renderer uses this because Send/replay execute
+*editor state*, which may be unsaved or detached). Inline over stored = the
+overlay MCP's `start_load_run` overrides ride on.
+
+**The renderer's resolver is preview-only.** `useVariableResolver` /
+`app/src/lib/variable-resolution.ts` back tab titles, previews, the
+unresolved-token painting and the OAuth-guard preview - never a payload. The
+preview must show what the engine will substitute, so its rules are pinned to
+the engine's by the **cross-language conformance fixture**
+(`engine/tests/fixtures/variable-resolution-conformance.json`), read by both
+`request_composer_test.cpp` (gtest) and
+`variable-resolution.conformance.test.ts` (vitest). Change resolution
+semantics → change engine + renderer lib + fixture together; a case added to
+the fixture fails whichever side forgot. The dynamic-variable name set
+(`$guid`, `$timestamp`, …) is part of that fixture-pinned contract (C++ table
+in `request_composer.cpp`, renderer table in `lib/dynamic-variables.ts`).
+The D17 malformed-data rules (absent/non-boolean `enabled` = enabled;
+non-string `value` = "") live engine-side in `parse_variables` and
+renderer-side in `lib/variable-resolution.ts`. Interpolation happens strictly
+**before** the pre-request script (D1 - deliberate Postman divergence), and
+script text is never interpolated (D16). **MCP has no composition copy
+anymore** (`resolve.ts` deleted) - a new engine client should call
+`POST /compose`, never re-implement resolution client-side.
+
+Script parts: clients on the inline path still build the ordered `ScriptPart`
+list themselves (`scriptParts` in
+`app/src/modules/request-builder/utils/script-parts.ts` - now the only
+client-side copy); the by-id path builds it engine-side
+(`compose_script_parts`). The **engine** joins parts with `"\n\n"` and runs
+the result. **Both names reach the same script**: `read_post_request_script`
+(`engine/src/http/script_parts.cpp`) owns every spelling the post-request
+script answers to - stored as `postRequestScript`, `postRequestScript(s)` on
+`/execute`, `tests` on `/runs` - and both routes read through it, so a payload
+composed for one endpoint can start the other kind of run unchanged. Add a
+spelling to that table, never to a route.
+
+The endpoint names above are the canonical ones (`POST /compose`,
+`POST /execute`, `POST /runs`); the old `POST /request` / `POST /run` still
+work as deprecated aliases. An unresolved `{"mode":"inherit"}` reaching an
+execution endpoint is treated as no auth and logged as a **warning** - it
+means a client skipped composition.
+
+## Docs to keep in step
+
+| Doc | Update it when you change… |
+|-----|----------------------------|
+| `docs/engine/api-reference.md` | **Any** endpoint, payload, or status code |
+| `docs/engine/architecture.md` | Core engine structure, auth resolution |
+| `docs/engine/db-schema.md` | Schema, migrations, stored JSON |
+| `docs/engine/scripting.md` | Script globals, hooks, sandbox limits |
+| `docs/engine/mcp.md` | MCP tools or their schemas |
+| `docs/engine/cli.md` | Flags or subcommands |
+| `docs/engine/benchmarks.md` | Load generation or measurement |
+| `docs/engine/building.md` | CMake presets, vcpkg deps |


### PR DESCRIPTION
## Description

Two changes to the Claude Code guidance, restructured per https://code.claude.com/docs/en/best-practices.

**1. New core principle.** Added to the root `CLAUDE.md`:

> Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.

**2. Split the guide along "when is this knowledge needed".** The root file had grown to 617 lines / 42KB, loaded in full at the start of every session. That is the failure mode the best-practices guide names directly ("The over-specified CLAUDE.md ... Claude ignores half of it because important rules get lost in the noise"). The content was good; the delivery was wrong.

| File | Loads | Carries |
|------|-------|---------|
| `CLAUDE.md` (42KB → 9KB) | always | Core principle, commit-attribution override, build/test commands, how to scale verification to a change, repo-wide conventions, subagent worktree base check |
| `app/CLAUDE.md` | on reading an `app/` file | TS/React conventions, the UI rules enforced by tests, border/surface rules, frontend test environment |
| `engine/CLAUDE.md` | on reading an `engine/` file | C++ conventions, engine HTTP API contract, request composition (`POST /compose`) |
| `releasing` skill | when releasing | Version bump, release notes format, tagging, `install.sh`, winget publishing |
| `docs-site` skill | when touching `docs/` | MkDocs nav, links, anchors, analytics gating, local preview |

Nested `CLAUDE.md` files and skills are the two mechanisms the guide gives for on-demand loading, so this cuts always-loaded context by **78%** while keeping every hard-won note. Total bytes across the five files are within 1% of the original.

The doc-freshness table is split so each side lists its own docs. The root file ends with a table pointing at everything relocated, so nothing is discoverable only by accident.

### Content preservation

Diffed every line of the original against the union of the new files. The only deliberate cuts are the ASCII project tree (compressed to four lines; the guide lists "file-by-file descriptions of the codebase" under exclude, and it is discoverable with `ls`) and duplicated headings. Both over-compressed passages found during review were restored.

## Type of Change
- [x] Documentation update

## Testing
Doc-only change, so no suite run per `CLAUDE.md`'s own verification guidance. Verified instead:

- No test or workflow reads `CLAUDE.md` (grepped; the four CI hits are comments).
- All 24 rows of the doc-freshness table are accounted for across the three files.
- No em-dashes introduced, per the repo rule.
- `app/CLAUDE.md` falls under `app/`'s `pnpm format:check` glob, so it is prettier-clean. `npx prettier --check "**/*.md"` in `app/` passes.
- Files added are outside `docs/`, so the MkDocs build is unaffected.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
N/A
