### PR TITLE
fix(app): match a collection tab's draft-context suffixes in isTabDirty

### DIFF
--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -189,13 +189,48 @@ describe("LRU eviction never takes a dirty tab", () => {
 		expect(openTypes()).toContain("variables");
 	});
 
-	it("spares a dirty collection tab", () => {
-		useTabsStore.getState().openTab({ type: "collection", entityId: "col_1" });
+	it("spares a dirty Variables tab editing a collection", () => {
+		useTabsStore.getState().openTab({ type: "variables", entityId: null });
 		markDirty("collection-col_1");
+		openRequestTabs(12);
+
+		expect(openTypes()).toContain("variables");
+	});
+
+	/**
+	 * One case per key family a collection tab's editors can register.
+	 *
+	 * `VariableTableEditor` keys on the bare id; the Info, Auth and the two
+	 * Script panels suffix it (`useDraftSaveContext`). The case used to match
+	 * only the bare key, so every suffixed sibling read as clean - the
+	 * "under-matching discards someone's work" direction the guard's own header
+	 * names. Reverting the prefix match fails all four suffix cases.
+	 */
+	it.each([
+		["the Variables sub-tab", "collection-col_1"],
+		["the Info tab", "collection-col_1-info"],
+		["the Auth tab", "collection-col_1-auth"],
+		["the pre-request Script tab", "collection-col_1-preRequestScript"],
+		["the post-request Script tab", "collection-col_1-postRequestScript"],
+	])("spares a collection tab dirty in %s", (_label, contextId) => {
+		useTabsStore.getState().openTab({ type: "collection", entityId: "col_1" });
+		markDirty(contextId);
 		openRequestTabs(12);
 
 		const ids = useTabsStore.getState().openTabs.map((t) => t.entityId);
 		expect(ids).toContain("col_1");
+	});
+
+	it("evicts a collection tab when it is a different collection that is dirty", () => {
+		// The discriminating case for the prefix match: matching a bare
+		// `collection-` would spare every collection tab whenever any one of
+		// them held edits.
+		useTabsStore.getState().openTab({ type: "collection", entityId: "col_1" });
+		markDirty("collection-col_2-auth");
+		openRequestTabs(12);
+
+		const ids = useTabsStore.getState().openTabs.map((t) => t.entityId);
+		expect(ids).not.toContain("col_1");
 	});
 
 	it("evicts a clean Settings tab, so the guard is not just refusing everything", () => {

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -69,6 +69,14 @@ interface TabsState {
  * from a collection tab's Variables sub-tab, so this over-matches - which is
  * the safe direction. Over-matching keeps a tab that could have closed;
  * under-matching discards someone's work.
+ *
+ * A collection tab hosts more than that one editor, and its siblings key
+ * themselves off the same id with a suffix: `collection-<id>-info`, `-auth`,
+ * `-preRequestScript`, `-postRequestScript` (`useDraftSaveContext`). Matching
+ * only the exact key read every one of those as clean, so the case scans for
+ * its own id plus that suffix family. It stays scoped to `tab.entityId` - a
+ * blanket `collection-` prefix would make every collection tab dirty whenever
+ * any one of them was.
  */
 function isTabDirty(tab: Tab, contexts: Map<string, SaveContext>): boolean {
 	const isDirty = (key: string) => contexts.get(key)?.hasPendingChanges === true;
@@ -76,8 +84,15 @@ function isTabDirty(tab: Tab, contexts: Map<string, SaveContext>): boolean {
 	switch (tab.type) {
 		case "request":
 			return tab.entityId !== null && isDirty(`request-${tab.entityId}`);
-		case "collection":
-			return tab.entityId !== null && isDirty(`collection-${tab.entityId}`);
+		case "collection": {
+			if (tab.entityId === null) return false;
+			const own = `collection-${tab.entityId}`;
+			for (const [key, ctx] of contexts) {
+				if (!ctx.hasPendingChanges) continue;
+				if (key === own || key.startsWith(`${own}-`)) return true;
+			}
+			return false;
+		}
 		case "settings":
 			return isDirty("settings");
 		case "variables":


### PR DESCRIPTION
## Description

**Plan.** Root cause: `isTabDirty`'s `collection` case (`app/src/stores/tabs-store.ts`) looked up exactly one context key, `collection-<id>` - the `VariableTableEditor` key from the tab's Variables sub-tab. The collection-detail panels register through `useDraftSaveContext` under a suffixed key instead (`collection-<id>-info`, `-auth`, `-preRequestScript`, `-postRequestScript`), so a collection tab with a dirty Info/Auth/Script draft read as clean to the LRU eviction guard. That is the "under-matching discards someone's work" direction the function's own header names as its failure mode, and the direction its `variables` case already guards against by deliberately over-matching. Approach: scan the context map for the tab's own id plus that suffix family, mirroring the `variables` loop. The alternative I rejected is a blanket `collection-` prefix match (what the `variables` case does): it is correct there because that tab does not record which editor it hosts, but on a collection tab it would report every collection tab dirty whenever any one of them held edits, so the match stays scoped to `tab.entityId`.

Verified the problem still exists as described at master `6d4bbbc`; the code matches the issue's account line for line. Blast radius: `isTabDirty` has one caller, the LRU eviction predicate in `openTab`, and reads only the save store's context map. I enumerated every `registerContext` call site to get the full key list - `useSaveManager` (`request-<id>`), `SettingsMain` (`settings`), `VariableTableEditor` (`globals-editor` / `environment-<id>` / `collection-<id>`), and the three `useDraftSaveContext` callers under `CollectionDetail/`. The `-preRequestScript` / `-postRequestScript` spellings come from `ScriptTab`'s `fieldKey`, not the `-script` sketched in the issue.

Calibration, unchanged from the issue: **no reachable data-loss path exists today.** Eviction runs inside `openTab`, excludes the outgoing tab, and only the active tab is mounted, so a non-active collection tab has already unregistered its contexts. This keeps a defense-in-depth guard honest under future changes (background tabs staying mounted, eviction triggered from elsewhere).

## Type of Change
- [x] Bug fix

## Testing

Verification scaled to an app-only, single-function behaviour change; the engine is untouched, so no engine build or `ctest` run.

- `cd app && pnpm test` - **272 files / 2330 tests passed**, no pre-existing failures.
- `cd app && pnpm type-check` - clean.
- `npx prettier --check` and `npx eslint` on the two touched files - clean. (No repo-wide format run, per `CLAUDE.md`.)
- **Mutation check:** reverting the prefix match to the old exact lookup turns the four suffix cases red (`Tests 4 failed | 23 passed`), and restoring it returns 27/27.

New cases in `tabs-store.test.ts`, one per context-key family a collection tab's editors can produce (the acceptance criterion): the Variables sub-tab's bare key plus `-info`, `-auth`, `-preRequestScript`, `-postRequestScript`; a Variables tab holding a `collection-<id>` context, which completes that tab type's families too; and the discriminating negative - a collection tab **is** evicted when it is a *different* collection that is dirty, which is what fails if the match is widened to a blanket `collection-` prefix.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: none, per the issue - no behaviour is visible outside the guard, and no doc in the freshness table describes it.

## Related Issues
Closes #256

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdRT8K6D83jUFVDRKP5iJk)_