### PR TITLE
fix(engine,app): let scripts read the collection ancestor chain

### DIFF
--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -25,12 +25,14 @@
  * resolves to `undefined`. `scriptVariableCompletionContext` decides which set
  * applies; this hook only renders it.
  *
- * **And collection scope is narrower here than in a body.** Decision D2: the
- * engine fills a script's single collection scope from the request's immediate
- * parent collection, while the resolver merges the whole ancestor chain (which
- * is right for `{{name}}`, resolved at compose time). So an ancestor's variable
- * is dropped from this list - offering it would be the same `undefined` the
- * rule above exists to prevent. See docs/app/variable-resolution.md.
+ * **Collection scope is the whole chain, the same as in a body.** The engine
+ * fills a script's collection scope from the request's collection *chain*
+ * (issue #234, leaf shadowing ancestor), so an ancestor's variable resolves
+ * inside `pm.collectionVariables.get()` exactly as it does inside `{{name}}` -
+ * and it belongs in this list for the same reason every other offered name
+ * does. This list narrowed to the immediate collection while the engine did;
+ * the two move together, or one of them offers names the other cannot read.
+ * See docs/app/variable-resolution.md.
  *
  * Call once (in App). A completion provider is global per language, so a single
  * registration covers every script editor instance. The same shape as
@@ -61,8 +63,8 @@ export function useScriptVariableCompletionProvider() {
 	/*
 	 * The active tab's collection, since a provider registered per language has
 	 * no request builder context to take one from and the resolver offers no
-	 * collection variables without it. It is also the *immediate* collection,
-	 * which is what the D2 narrowing below needs.
+	 * collection variables without it. The resolver walks up from here, which is
+	 * the same chain the engine hands the script.
 	 */
 	const collectionId = useActiveCollectionId();
 	const { getAllVariables } = useVariableResolver({ collectionId });
@@ -102,11 +104,6 @@ export function useScriptVariableCompletionProvider() {
 					// `pm.environment.get` reads one scope; only the merged
 					// `pm.variables` sees them all.
 					.filter(([, info]) => context.scope === "all" || info.scope === context.scope)
-					// D2: a script's collection scope is the immediate collection, not
-					// the merged chain the resolver returns.
-					.filter(
-						([, info]) => info.scope !== "collection" || info.sourceId === collectionId
-					)
 					.map(([name, info]) => ({
 						label: name,
 						kind: monaco.languages.CompletionItemKind.Variable,

--- a/app/src/hooks/variable-completion-scope.test.tsx
+++ b/app/src/hooks/variable-completion-scope.test.tsx
@@ -20,17 +20,20 @@
  * was fine, because `VariableInput` reads the request builder's context, which
  * does pass the id.
  *
- * Two things are asserted here, and they pull in opposite directions:
+ * Two things are asserted here:
  *
  * - **which collection each provider asks for**, since asking for none was the
  *   whole defect; and
- * - **that the script list narrows the answer back down** to the immediate
- *   collection, because of decision D2 - the engine fills a script's single
- *   collection scope from the request's immediate parent, while the resolver
- *   merges the whole ancestor chain for `{{name}}`. Offering an ancestor's
- *   variable inside `pm.collectionVariables.get()` would offer a name that
- *   returns `undefined`, which is the exact failure the "the accessor picks the
- *   scope" rule exists to prevent.
+ * - **that both lists carry the whole ancestor chain**. They did not always:
+ *   while the engine filled a script's collection scope from the request's
+ *   immediate parent alone (decision D2), the script list narrowed to match,
+ *   because offering an ancestor's variable inside
+ *   `pm.collectionVariables.get()` would have offered a name that returns
+ *   `undefined`. Issue #234 made the engine walk the chain for scripts too, so
+ *   the narrowing came off. The rule underneath is unchanged and is what these
+ *   cases pin: **the list offers exactly what the call can read** - so if the
+ *   engine's walk ever changes again, these fail rather than the user finding
+ *   out from an `undefined`.
  *
  * The lists themselves are covered by
  * `useVariableCompletionProvider.dynamic.test.tsx` and
@@ -133,7 +136,7 @@ describe("the body `{{` list offers the whole ancestor chain", () => {
 	});
 });
 
-describe("the script list narrows collection scope to the immediate collection (D2)", () => {
+describe("the script list offers the ancestor chain the engine now walks (#234)", () => {
 	beforeEach(() => {
 		activeCollectionId.current = "leaf";
 		variables.from_parent = { value: "1", scope: "collection", sourceId: "root" };
@@ -141,7 +144,7 @@ describe("the script list narrows collection scope to the immediate collection (
 		variables.from_env = { value: "3", scope: "environment", sourceId: "e1" };
 	});
 
-	it("drops an ancestor's variable from `pm.collectionVariables.get()`", () => {
+	it("offers an ancestor's variable inside `pm.collectionVariables.get()`", () => {
 		const labels = labelsFor(
 			() => useScriptVariableCompletionProvider(),
 			'pm.collectionVariables.get("'
@@ -149,22 +152,26 @@ describe("the script list narrows collection scope to the immediate collection (
 		expect(labels).toContain("from_leaf");
 		expect(
 			labels,
-			"the engine's script collection scope is the immediate parent only"
-		).not.toContain("from_parent");
+			"the engine walks the collection chain for scripts, so this call does read it"
+		).toContain("from_parent");
+		// The accessor still picks the scope: this one does not read environment.
+		expect(labels).not.toContain("from_env");
 	});
 
-	it("drops it from the merged `pm.variables.get()` too, keeping the other scopes", () => {
+	it("offers it from the merged `pm.variables.get()` too, alongside the other scopes", () => {
 		const labels = labelsFor(() => useScriptVariableCompletionProvider(), 'pm.variables.get("');
 		expect(labels).toContain("from_leaf");
 		expect(labels).toContain("from_env");
-		expect(labels).not.toContain("from_parent");
+		expect(labels).toContain("from_parent");
 	});
 
-	it("leaves the other scopes alone when no collection is in scope", () => {
+	// With the narrowing gone, the resolver is the only thing deciding which
+	// collection variables exist - so what this provider asks it for is the
+	// whole of the scoping, and a second local filter would be a copy that
+	// drifts.
+	it("asks the resolver for nothing when no collection is in scope", () => {
 		activeCollectionId.current = undefined;
-		const labels = labelsFor(() => useScriptVariableCompletionProvider(), 'pm.variables.get("');
-		expect(labels).toContain("from_env");
-		expect(labels).not.toContain("from_leaf");
-		expect(labels).not.toContain("from_parent");
+		labelsFor(() => useScriptVariableCompletionProvider(), 'pm.variables.get("');
+		expect(scopes).toEqual([undefined]);
 	});
 });

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -78,9 +78,10 @@ script explicitly asked to resolve.
 Two timing consequences worth knowing: the map is built **at call time**, so a
 variable the script set a line earlier resolves (unlike `{{}}` in the URL,
 which was composed before the script started); and the collection scope is the
-script context's - the request's immediate parent only, the same asymmetry
-`pm.collectionVariables` has. The argument must be a string; anything else is
-a `TypeError` rather than a silently coerced `"undefined"`.
+script context's - the request's whole collection chain, leaf shadowing
+ancestor, the same walk `pm.collectionVariables` does (#234). The argument must
+be a string; anything else is a `TypeError` rather than a silently coerced
+`"undefined"`.
 
 ### Hashing (`pm.crypto`) is Vayu's own name, and it is synchronous
 

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -302,18 +302,32 @@ A script reads a scope by name (`pm.environment.get`,
 at the first scope that has the name enabled - this page's priority order, read
 from the top down.
 
-One difference to know about, kept deliberately in #226 (decision D2): the
-script side has a single collection scope, and the engine fills it from the
-request's **immediate parent collection only** (`execution.cpp`, where
-`collectionVariables` is loaded). The chain merge described above applies to
-`{{name}}` (at compose time), so a variable defined on an ancestor collection
-is visible to `{{name}}` and *not* to `pm.collectionVariables.get` /
-`pm.variables.get`. Closing the gap was considered and rejected for now:
-scripts write `collectionVariables` back to the immediate parent
-(`persist_script_variables`), so merging the chain into that scope would copy
-ancestor variables down into the leaf collection on the next script write.
-Read such a value from the environment or globals, or define it on the
-request's own collection. See
+The collection scope a script reads is the **whole chain**, the same one
+`{{name}}` merges (issue #234; `load_script_variable_scopes` in
+`execution.cpp` builds it from `collection_chain`). A variable defined on an
+ancestor collection therefore reads the same in `pm.collectionVariables.get`,
+`pm.variables.get` and `pm.variables.replaceIn("{{name}}")` as it substitutes
+in the URL.
+
+**Reads walk the chain; writes stay on the leaf.** `set`, `unset` and `clear`
+only ever touch the request's own collection - the one
+`persist_script_variables` writes back. So the rule for an inherited name is
+CSS-like:
+
+- `pm.collectionVariables.set("token", x)` on a descendant **shadows** the
+  ancestor's `token`; the ancestor's stored value is untouched.
+- `pm.collectionVariables.unset("token")` removes the descendant's copy, and
+  `get("token")` then finds the ancestor's value again.
+- `pm.collectionVariables.clear()` empties the request's own collection only.
+
+Inheritance can be shadowed from below, never deleted from below. That
+asymmetry is the point rather than an oversight: #226 (decision D2) originally
+kept the whole chain out of scripts precisely because a single merged,
+writable map would have let one `set()` copy every ancestor's variables down
+into the leaf collection on the next persist. Read-only ancestors make that
+impossible while still answering the read. A disabled row is looked past
+wherever it sits, so unticking an inherited name in a descendant falls through
+to the ancestor's value rather than hiding it. See
 [pm API compatibility](./pm-api-compatibility.md) and
 [scripting.md](../engine/scripting.md#variables-pmvariables).
 
@@ -340,13 +354,12 @@ Three rules make the offered set match what the call can actually read:
   collection, or a collection tab itself - so the list is globals + the
   collection chain + the active environment, the same set every other surface
   offers.
-- **The script list narrows that chain back down.** Decision D2 applies here:
-  the engine fills a script's collection scope from the immediate parent
-  collection, so an ancestor's variable is dropped from
-  `pm.collectionVariables.get()` and from the merged `pm.variables.get()`.
-  Offering it would offer a name that returns `undefined`, which is the same
-  failure the rule above prevents. The `{{name}}` list keeps the whole chain,
-  because that is what compose-time resolution actually reads.
+- **The script list carries the same chain.** The engine walks the collection
+  chain for scripts too (#234), so an ancestor's variable is offered inside
+  `pm.collectionVariables.get()` and the merged `pm.variables.get()` - it is a
+  name the call can read. This list narrowed to the immediate collection while
+  the engine did; the rule underneath is unchanged, which is that the list
+  offers exactly what the call resolves.
 - **Generators belong to `replaceIn` alone.** `pm.variables.replaceIn` takes a
   template and interpolates it, so it gets brace-style completion including
   `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -360,11 +360,18 @@ pm.globals.set('run_id', '42');
 Each `set()` persists to the scope it names, with the same
 keep-the-flags behaviour described for `pm.environment` above.
 
-`pm.collectionVariables` is the request's **immediate parent collection**, not
-the whole collection chain. `{{name}}` resolution merges every ancestor
-root-first before the payload reaches the engine, so a variable defined on a
-parent collection resolves in a URL and is *not* readable from a script. Define
-it on the request's own collection, or in the environment, if a script needs it.
+`pm.collectionVariables` reads the request's **whole collection chain**, the
+same merge `{{name}}` resolution uses: `get`, `has` and `toObject` take the
+nearest enabled definition, walking from the request's own collection up to the
+root. A variable defined on a parent collection therefore reads the same in a
+script as it substitutes in a URL.
+
+**Writes stay on the request's own collection.** `set`, `unset` and `clear`
+never reach an ancestor, so `set` on a descendant *shadows* an inherited name
+and `unset` un-shadows it - the ancestor's value comes back rather than being
+deleted. A disabled row is looked past wherever it sits in the chain. The full
+rule, and why ancestors are read-only, is in
+[Variable Resolution](../app/variable-resolution.md).
 
 ## Variables (`pm.variables`)
 

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
@@ -414,6 +415,34 @@ const nlohmann::json& json,
 bool is_create);
 std::optional<std::pair<int, nlohmann::json>>
 apply_environment_fields (vayu::db::Environment& e, const nlohmann::json& json, bool is_create);
+
+/**
+ * The variable scopes a design run hands its pre/post-request scripts.
+ *
+ * `collection` is the request's immediate parent - the only collection scope a
+ * script may write, and the one `persist_script_variables` writes back.
+ * `collection_ancestors` is the rest of that collection's chain, root first,
+ * which scripts read through but cannot modify (issue #234).
+ */
+struct ScriptVariableScopes {
+    vayu::Environment environment;
+    vayu::Environment globals;
+    vayu::Environment collection;
+    std::vector<vayu::Environment> collection_ancestors;
+};
+
+/**
+ * Load those scopes for @p run. The collection chain is the same walk
+ * `{{variable}}` composition uses, so a script and a request field resolve an
+ * inherited name identically; a run with no environment, no request or a
+ * request outside any collection simply yields empty scopes.
+ *
+ * Extracted from the `POST /execute` handler (execution.cpp) so
+ * script_variables_test.cpp can drive it against a real database, matching the
+ * suite's other route-core tests.
+ */
+ScriptVariableScopes
+load_script_variable_scopes (vayu::db::Database& db, const vayu::db::Run& run);
 
 /**
  * @brief Callback type for graceful shutdown

--- a/engine/include/vayu/runtime/script_engine.hpp
+++ b/engine/include/vayu/runtime/script_engine.hpp
@@ -46,6 +46,24 @@ struct ScriptContext {
     Environment* collectionVariables = nullptr;
 
     /**
+     * @brief The collection scopes above `collectionVariables`, root first.
+     *
+     * The request's collection ancestors - `collection_chain` without its leaf
+     * - so a script reads a name an ancestor collection defines exactly as
+     * `{{name}}` in the URL does (issue #234). Collection reads walk leaf ->
+     * root and take the nearest enabled definition; `set`, `unset` and `clear`
+     * still touch `collectionVariables` alone, so the leaf shadows an ancestor
+     * but can never delete it.
+     *
+     * The `const` is the design rather than politeness:
+     * `persist_script_variables` writes a scope back by diffing it against the
+     * leaf collection's stored blob, so a writable ancestor would let one
+     * `set()` copy every inherited variable down into the leaf collection
+     * permanently. Ancestors that cannot be written cannot be copied down.
+     */
+    const std::vector<Environment>* collectionAncestors = nullptr;
+
+    /**
      * @brief Where the script's `pm.request` edits land, or null to discard them.
      *
      * Set only for pre-request scripts, and only through

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -25,6 +25,7 @@
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/request_builder.hpp"
+#include "vayu/http/request_composer.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/http/script_parts.hpp"
 #include "vayu/http/status.hpp"
@@ -169,6 +170,47 @@ const vayu::Response& response) {
     trace["downloadMs"]  = timing.download_ms;
 
     return trace;
+}
+
+// The variable scopes a design run's scripts read. The collection scope is the
+// request's own collection *chain* - the same walk `{{variable}}` composition
+// does (`collection_chain`) - so a name an ancestor collection defines answers
+// the same in a script as it does in the URL (issue #234). Only the leaf is
+// handed over writable; ancestors ride along read-only, which is what keeps a
+// script's `set()` from copying inherited variables down into the leaf on the
+// next persist.
+ScriptVariableScopes
+load_script_variable_scopes (vayu::db::Database& db, const vayu::db::Run& run) {
+    ScriptVariableScopes scopes;
+
+    if (run.environment_id.has_value ()) {
+        if (auto db_env = db.get_environment (*run.environment_id)) {
+            scopes.environment = vayu::json::parse_variables (db_env->variables);
+        }
+    }
+
+    if (auto db_globals = db.get_globals ()) {
+        scopes.globals = vayu::json::parse_variables (db_globals->variables);
+    }
+
+    if (run.request_id.has_value ()) {
+        if (auto db_request = db.get_request (*run.request_id)) {
+            if (!db_request->collection_id.empty ()) {
+                auto chain = vayu::http::collection_chain (db, db_request->collection_id);
+                if (!chain.empty ()) {
+                    scopes.collection =
+                    vayu::json::parse_variables (chain.back ().variables);
+                    scopes.collection_ancestors.reserve (chain.size () - 1);
+                    for (size_t i = 0; i + 1 < chain.size (); ++i) {
+                        scopes.collection_ancestors.push_back (
+                        vayu::json::parse_variables (chain[i].variables));
+                    }
+                }
+            }
+        }
+    }
+
+    return scopes;
 }
 
 // Persist script-set variables to DB (design mode only). Best-effort: logs errors, does not change response.
@@ -580,29 +622,10 @@ void register_execution_routes (RouteContext& ctx) {
         vayu::runtime::ScriptEngine script_engine (script_config);
 
         // Load variables
-        vayu::Environment env, globals, collectionVariables;
-
-        if (run.environment_id.has_value ()) {
-            if (auto db_env = ctx.db.get_environment (*run.environment_id)) {
-                env = vayu::json::parse_variables (db_env->variables);
-            }
-        }
-
-        if (auto db_globals = ctx.db.get_globals ()) {
-            globals = vayu::json::parse_variables (db_globals->variables);
-        }
-
-        if (run.request_id.has_value ()) {
-            if (auto db_request = ctx.db.get_request (*run.request_id)) {
-                if (!db_request->collection_id.empty ()) {
-                    if (auto db_collection =
-                        ctx.db.get_collection (db_request->collection_id)) {
-                        collectionVariables =
-                        vayu::json::parse_variables (db_collection->variables);
-                    }
-                }
-            }
-        }
+        auto scopes                = load_script_variable_scopes (ctx.db, run);
+        vayu::Environment& env     = scopes.environment;
+        vayu::Environment& globals = scopes.globals;
+        vayu::Environment& collectionVariables = scopes.collection;
 
         // Take the request built above. Auth is already resolved into its
         // headers/url, so pm.request reflects the real outgoing set - and
@@ -636,6 +659,7 @@ void register_execution_routes (RouteContext& ctx) {
         pre_ctx.environment         = &env;
         pre_ctx.globals             = &globals;
         pre_ctx.collectionVariables = &collectionVariables;
+        pre_ctx.collectionAncestors = &scopes.collection_ancestors;
         auto pre_script_result =
         execute_script (script_engine, pre_request_script, pre_ctx, "Pre-request");
 
@@ -655,6 +679,7 @@ void register_execution_routes (RouteContext& ctx) {
         post_ctx.environment         = &env;
         post_ctx.globals             = &globals;
         post_ctx.collectionVariables = &collectionVariables;
+        post_ctx.collectionAncestors = &scopes.collection_ancestors;
         auto post_script_result =
         execute_script (script_engine, post_request_script, post_ctx, "Post-request");
 

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -437,7 +437,9 @@ nlohmann::json get_script_completions () {
     { "insertTextRules", INSERT_AS_SNIPPET },
     { "detail", "pm.collectionVariables.get(name: string): string | undefined" },
     { "documentation",
-    "Get a collection variable value by name.\n\nExample:\nconst baseUrl = "
+    "Get a collection variable value by name. Reads the whole collection chain "
+    "- the nearest enabled definition wins, so a parent collection's variable "
+    "resolves here too.\n\nExample:\nconst baseUrl = "
     "pm.collectionVariables.get('base_url');" },
     { "sortText", "1_pm_collectionVariables_get" } });
 
@@ -445,7 +447,12 @@ nlohmann::json get_script_completions () {
     { "insertText", "pm.collectionVariables.set(\"${1:variable}\", ${2:value})" },
     { "insertTextRules", INSERT_AS_SNIPPET },
     { "detail", "pm.collectionVariables.set(name: string, value: any): void" },
-    { "documentation", "Set a collection variable. The value will be persisted.\n\nExample:\npm.collectionVariables.set('base_url', 'https://api.example.com');" },
+    { "documentation",
+    "Set a collection variable on the request's own collection - it shadows a "
+    "parent collection's variable of the same name rather than changing it. "
+    "The value will be "
+    "persisted.\n\nExample:\npm.collectionVariables.set('base_url', "
+    "'https://api.example.com');" },
     { "sortText", "1_pm_collectionVariables_set" } });
 
     // ========================================

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -73,7 +73,8 @@ struct ContextData {
     Environment* environment         = nullptr;
     Environment* globals             = nullptr;
     Environment* collectionVariables = nullptr;
-    bool has_error                   = false;
+    const std::vector<Environment>* collectionAncestors = nullptr;
+    bool has_error                                      = false;
     std::string error_message;
 };
 
@@ -3056,6 +3057,62 @@ Environment* scope_variables (JSContext* ctx, int magic) {
     }
 }
 
+// Every map a *read* of `magic` may see, weakest first. Only the collection
+// scope has more than one: its ancestor collections stack underneath it, root
+// weakest, so an inherited name resolves for a script the way `{{name}}`
+// already resolves it in the URL (issue #234). A write never consults this -
+// `scope_variables` alone is the write target, which is what keeps ancestors
+// read-only and the copy-down hazard impossible.
+//
+// One order for the whole file: the lookups below reverse it to stop at the
+// nearest definition and the snapshots fold along it so a nearer definition
+// overwrites a farther one. Deriving both from one list is what stops `get`
+// and `toObject` answering the same name two ways.
+std::vector<const Environment*> scope_maps (JSContext* ctx, int magic) {
+    std::vector<const Environment*> maps;
+    auto* data = get_context_data (ctx);
+    if (data && magic == SCOPE_COLLECTION_VARIABLES && data->collectionAncestors) {
+        maps.reserve (data->collectionAncestors->size () + 1);
+        for (const Environment& ancestor : *data->collectionAncestors) {
+            maps.push_back (&ancestor);
+        }
+    }
+    if (const Environment* own = scope_variables (ctx, magic)) {
+        maps.push_back (own);
+    }
+    return maps;
+}
+
+// The definition of `key` a read of `magic` finds, or null when the walk ends
+// without one. A disabled row is looked *past* rather than stopped at, so a
+// leaf collection that unticks an inherited name falls through to the
+// ancestor's value - the same rule that already makes a disabled variable
+// invisible within a single scope.
+const Variable* lookup_variable (JSContext* ctx, int magic, const std::string& key) {
+    const auto maps = scope_maps (ctx, magic);
+    for (auto it = maps.rbegin (); it != maps.rend (); ++it) {
+        auto found = (*it)->find (key);
+        if (found != (*it)->end () && found->second.enabled) {
+            return &found->second;
+        }
+    }
+    return nullptr;
+}
+
+// Hand every enabled variable a read of `magic` can see to `emit`, weakest
+// scope first, so a caller merging them lands on the same value
+// `lookup_variable` would have answered for that name.
+template <typename Emit>
+void merge_visible_variables (JSContext* ctx, int magic, Emit&& emit) {
+    for (const Environment* map : scope_maps (ctx, magic)) {
+        for (const auto& [key, variable] : *map) {
+            if (variable.enabled) {
+                emit (key, variable);
+            }
+        }
+    }
+}
+
 // A disabled variable is a row the user unticked in the variables editor, so
 // `get`, `has` and `toObject` all look straight past it - reading it would
 // resurrect a value that was switched off. `unset` and `clear` still remove it:
@@ -3067,14 +3124,9 @@ js_pm_scope_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* 
         return JS_UNDEFINED;
     }
 
-    Environment* variables = scope_variables (ctx, magic);
-    if (!variables) {
-        return JS_UNDEFINED;
-    }
-
-    auto it = variables->find (js_to_string (ctx, argv[0]));
-    if (it != variables->end () && it->second.enabled) {
-        return cast_variable_to_jsvalue (ctx, it->second);
+    if (const Variable* found =
+        lookup_variable (ctx, magic, js_to_string (ctx, argv[0]))) {
+        return cast_variable_to_jsvalue (ctx, *found);
     }
 
     return JS_UNDEFINED;
@@ -3130,13 +3182,8 @@ js_pm_scope_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* 
         return JS_NewBool (ctx, 0);
     }
 
-    Environment* variables = scope_variables (ctx, magic);
-    if (!variables) {
-        return JS_NewBool (ctx, 0);
-    }
-
-    auto it = variables->find (js_to_string (ctx, argv[0]));
-    return JS_NewBool (ctx, it != variables->end () && it->second.enabled ? 1 : 0);
+    return JS_NewBool (ctx,
+    lookup_variable (ctx, magic, js_to_string (ctx, argv[0])) != nullptr ? 1 : 0);
 }
 
 // The method with no workaround: setting a variable to "" leaves an enabled
@@ -3144,6 +3191,12 @@ js_pm_scope_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* 
 // resolution as the variable being gone. The removal reaches disk through
 // persist_script_variables, which rewrites a scope whenever the map it ends
 // with differs from the one on disk.
+//
+// Like `set` and `clear`, this erases from the scope's own map only. On the
+// collection scope that is the request's immediate parent: unsetting a name
+// the leaf shadowed makes an ancestor's definition visible again rather than
+// deleting it. Inheritance can be shadowed from below, never deleted from
+// below (issue #234).
 JSValue
 js_pm_scope_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic) {
     (void)this_val;
@@ -3185,14 +3238,10 @@ js_pm_scope_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
         return snapshot;
     }
 
-    if (Environment* variables = scope_variables (ctx, magic)) {
-        for (const auto& [key, variable] : *variables) {
-            if (variable.enabled) {
-                JS_SetPropertyStr (ctx, snapshot, key.c_str (),
-                cast_variable_to_jsvalue (ctx, variable));
-            }
-        }
-    }
+    merge_visible_variables (ctx, magic, [&] (const std::string& key, const Variable& variable) {
+        JS_SetPropertyStr (
+        ctx, snapshot, key.c_str (), cast_variable_to_jsvalue (ctx, variable));
+    });
 
     return snapshot;
 }
@@ -3230,13 +3279,8 @@ JSValue js_pm_variables_get (JSContext* ctx, JSValueConst this_val, int argc, JS
 
     const std::string key = js_to_string (ctx, argv[0]);
     for (const VariableScope scope : variables_precedence) {
-        Environment* variables = scope_variables (ctx, scope);
-        if (!variables) {
-            continue;
-        }
-        auto it = variables->find (key);
-        if (it != variables->end () && it->second.enabled) {
-            return cast_variable_to_jsvalue (ctx, it->second);
+        if (const Variable* found = lookup_variable (ctx, scope, key)) {
+            return cast_variable_to_jsvalue (ctx, *found);
         }
     }
 
@@ -3251,12 +3295,7 @@ JSValue js_pm_variables_has (JSContext* ctx, JSValueConst this_val, int argc, JS
 
     const std::string key = js_to_string (ctx, argv[0]);
     for (const VariableScope scope : variables_precedence) {
-        Environment* variables = scope_variables (ctx, scope);
-        if (!variables) {
-            continue;
-        }
-        auto it = variables->find (key);
-        if (it != variables->end () && it->second.enabled) {
+        if (lookup_variable (ctx, scope, key)) {
             return JS_NewBool (ctx, 1);
         }
     }
@@ -3278,16 +3317,11 @@ JSValue js_pm_variables_to_object (JSContext* ctx, JSValueConst this_val, int ar
     // agrees with what get() would have answered for every key in it.
     for (auto it = std::rbegin (variables_precedence);
          it != std::rend (variables_precedence); ++it) {
-        Environment* variables = scope_variables (ctx, *it);
-        if (!variables) {
-            continue;
-        }
-        for (const auto& [key, variable] : *variables) {
-            if (variable.enabled) {
-                JS_SetPropertyStr (ctx, snapshot, key.c_str (),
-                cast_variable_to_jsvalue (ctx, variable));
-            }
-        }
+        merge_visible_variables (
+        ctx, *it, [&] (const std::string& key, const Variable& variable) {
+            JS_SetPropertyStr (ctx, snapshot, key.c_str (),
+            cast_variable_to_jsvalue (ctx, variable));
+        });
     }
 
     return snapshot;
@@ -3309,10 +3343,11 @@ JSValue js_pm_variables_to_object (JSContext* ctx, JSValueConst this_val, int ar
 //  - The map is built at call time from the script's scopes, so a variable
 //    set earlier in the same script resolves - unlike `{{}}` in the URL,
 //    which was composed before the script started (D1).
-//  - The collection scope is the script context's: the request's immediate
-//    parent only (the D2 asymmetry), with pm.variables' own precedence
-//    (environment > collection > globals). The raw stored string substitutes,
-//    never the typed value - matching `{{}}`, not pm.variables.get.
+//  - The collection scope is the script context's - the request's collection
+//    chain, leaf shadowing ancestor (issue #234) - with pm.variables' own
+//    precedence (environment > collection > globals). The raw stored string
+//    substitutes, never the typed value - matching `{{}}`, not
+//    pm.variables.get.
 //
 // Strict about its argument: a non-string is a TypeError rather than a
 // coerced "undefined" - the caller almost certainly holds a bug.
@@ -3330,15 +3365,10 @@ JSValue js_pm_variables_replace_in (JSContext* ctx, JSValueConst this_val, int a
     // toObject() does, and the same answer get() would give per name.
     for (auto it = std::rbegin (variables_precedence);
          it != std::rend (variables_precedence); ++it) {
-        Environment* variables = scope_variables (ctx, *it);
-        if (!variables) {
-            continue;
-        }
-        for (const auto& [key, variable] : *variables) {
-            if (variable.enabled) {
-                values[key] = variable.value;
-            }
-        }
+        merge_visible_variables (
+        ctx, *it, [&] (const std::string& key, const Variable& variable) {
+            values[key] = variable.value;
+        });
     }
 
     return JS_NewString (ctx, vayu::http::resolve_template (input, values).c_str ());
@@ -3561,6 +3591,7 @@ class ScriptEngine::Impl {
         ctx_data.environment         = ctx.environment;
         ctx_data.globals             = ctx.globals;
         ctx_data.collectionVariables = ctx.collectionVariables;
+        ctx_data.collectionAncestors = ctx.collectionAncestors;
         JS_SetContextOpaque (js_ctx, &ctx_data);
 
         // Refresh pm.request and pm.response with new data

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -2273,6 +2273,230 @@ TEST_F (ScriptEngineTest, ReplaceInResolvesScopesLikeTheRequestFieldsDo) {
     EXPECT_EQ (globals["singlePass"].value, "{{everywhere}}");
 }
 
+// ============================================================================
+// The collection chain in a script (issue #234)
+//
+// `{{name}}` has always walked the whole collection ancestor chain, while the
+// script scopes saw the request's immediate parent alone - so the same name,
+// and after replaceIn the same *notation*, answered differently in a URL and
+// in a script. These pin the walk: reads see the chain, writes stay on the
+// leaf.
+// ============================================================================
+
+TEST_F (ScriptEngineTest, CollectionReadsWalkTheAncestorChain) {
+    // Collections API (root) -> Users (leaf); the request lives in Users.
+    std::vector<Environment> ancestors (1);
+    ancestors[0]["token"]     = Variable{ "from-root", false, true };
+    ancestors[0]["root_only"] = Variable{ "root-value", false, true };
+    Environment leaf;
+    leaf["leaf_only"] = Variable{ "leaf-value", false, true };
+    Environment globals;
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &leaf;
+    ctx.collectionAncestors = &ancestors;
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('inherited', String(pm.collectionVariables.get('token')));
+        pm.globals.set('hasInherited', String(pm.collectionVariables.has('token')));
+        pm.globals.set('ownKey', String(pm.collectionVariables.get('leaf_only')));
+        var snapshot = pm.collectionVariables.toObject();
+        pm.globals.set('snapshotInherited', String(snapshot['token']));
+        pm.globals.set('snapshotOwn', String(snapshot['leaf_only']));
+        // The merged accessor and {{}} resolution ride on the same walk.
+        pm.globals.set('merged', String(pm.variables.get('root_only')));
+        pm.globals.set('replaced', pm.variables.replaceIn('{{token}}'));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (globals["inherited"].value, "from-root");
+    EXPECT_EQ (globals["hasInherited"].value, "true");
+    EXPECT_EQ (globals["ownKey"].value, "leaf-value");
+    EXPECT_EQ (globals["snapshotInherited"].value, "from-root");
+    EXPECT_EQ (globals["snapshotOwn"].value, "leaf-value");
+    EXPECT_EQ (globals["merged"].value, "root-value");
+    // The whole point of the issue: {{token}} in the URL and replaceIn in the
+    // script must not answer one name two ways.
+    EXPECT_EQ (globals["replaced"].value, "from-root");
+}
+
+// Inheritance can be shadowed from below but not deleted from below. `set` on
+// the leaf hides the ancestor's value; `unset` removes the leaf's copy and the
+// ancestor's shows through again.
+TEST_F (ScriptEngineTest, TheLeafShadowsAnAncestorAndUnsetUnShadowsIt) {
+    std::vector<Environment> ancestors (1);
+    ancestors[0]["token"] = Variable{ "from-root", false, true };
+    Environment leaf;
+    Environment globals;
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &leaf;
+    ctx.collectionAncestors = &ancestors;
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('before', String(pm.collectionVariables.get('token')));
+        pm.collectionVariables.set('token', 'from-leaf');
+        pm.globals.set('shadowed', String(pm.collectionVariables.get('token')));
+        pm.collectionVariables.unset('token');
+        pm.globals.set('after', String(pm.collectionVariables.get('token')));
+        pm.globals.set('stillThere', String(pm.collectionVariables.has('token')));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (globals["before"].value, "from-root");
+    EXPECT_EQ (globals["shadowed"].value, "from-leaf");
+    EXPECT_EQ (globals["after"].value, "from-root");
+    EXPECT_EQ (globals["stillThere"].value, "true");
+    // The write landed on the leaf and the unset took it away again; the
+    // ancestor was never a write target.
+    EXPECT_EQ (leaf.count ("token"), 0U);
+    EXPECT_EQ (ancestors[0]["token"].value, "from-root");
+}
+
+// The copy-down hazard #226 kept D2 open for, at the map level: a script that
+// reads an inherited name and then writes must leave the leaf map holding its
+// own variables only. persist_script_variables diffs that map against the leaf
+// collection's stored blob, so anything the walk leaked into it would be
+// written into the leaf collection permanently.
+TEST_F (ScriptEngineTest, WritingTheCollectionScopeNeverCopiesAnAncestorIntoTheLeaf) {
+    std::vector<Environment> ancestors (1);
+    ancestors[0]["inherited"] = Variable{ "from-root", false, true };
+    Environment leaf;
+    leaf["own"] = Variable{ "leaf-value", false, true };
+    Environment globals;
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &leaf;
+    ctx.collectionAncestors = &ancestors;
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('read', String(pm.collectionVariables.get('inherited')));
+        pm.collectionVariables.set('fresh', 'written');
+        pm.collectionVariables.unset('missing');
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (globals["read"].value, "from-root");
+    EXPECT_EQ (leaf.count ("inherited"), 0U)
+    << "an ancestor's variable was copied down into the leaf collection";
+    EXPECT_EQ (leaf.size (), 2U); // own + fresh, nothing inherited
+    EXPECT_EQ (ancestors[0].size (), 1U);
+}
+
+// clear() is the destructive twin of the copy-down: emptying the leaf must not
+// reach up the chain, and the inherited names it was hiding come back.
+TEST_F (ScriptEngineTest, ClearEmptiesTheLeafAndLeavesAncestorsIntact) {
+    std::vector<Environment> ancestors (1);
+    ancestors[0]["token"] = Variable{ "from-root", false, true };
+    Environment leaf;
+    leaf["token"] = Variable{ "from-leaf", false, true };
+    Environment globals;
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &leaf;
+    ctx.collectionAncestors = &ancestors;
+
+    auto result = engine.execute (R"JS(
+        pm.collectionVariables.clear();
+        pm.globals.set('after', String(pm.collectionVariables.get('token')));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_TRUE (leaf.empty ());
+    EXPECT_EQ (ancestors[0].size (), 1U) << "clear() reached up the chain";
+    EXPECT_EQ (globals["after"].value, "from-root");
+}
+
+// Precedence across the whole stack: environment beats any collection, and
+// within the collections the nearest definition wins. A disabled row is looked
+// past wherever it sits, so unticking a name in the leaf falls through to the
+// ancestor rather than hiding it.
+TEST_F (ScriptEngineTest, PrecedenceRunsEnvironmentThenLeafThenAncestorThenGlobals) {
+    std::vector<Environment> ancestors (2);
+    ancestors[0]["depth"]     = Variable{ "root", false, true }; // root
+    ancestors[0]["only_root"] = Variable{ "root-only", false, true };
+    ancestors[0]["unticked"]  = Variable{ "root-value", false, true };
+    ancestors[1]["depth"]     = Variable{ "middle", false, true }; // middle
+    Environment leaf;
+    leaf["unticked"] = Variable{ "leaf-value", false, false }; // disabled
+    Environment globals;
+    globals["depth"] = Variable{ "globals", false, true };
+    Environment environment;
+    environment["everywhere"] = Variable{ "environment", false, true };
+    leaf["everywhere"]        = Variable{ "leaf", false, true };
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &environment;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &leaf;
+    ctx.collectionAncestors = &ancestors;
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('nearest', String(pm.collectionVariables.get('depth')));
+        pm.globals.set('farthest', String(pm.collectionVariables.get('only_root')));
+        pm.globals.set('acrossScopes', String(pm.variables.get('everywhere')));
+        // The leaf's row is unticked, so the read keeps walking.
+        pm.globals.set('unticked', String(pm.collectionVariables.get('unticked')));
+        var merged = pm.variables.toObject();
+        pm.globals.set('mergedNearest', String(merged['depth']));
+        pm.globals.set('mergedAcross', String(merged['everywhere']));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (globals["nearest"].value, "middle");
+    EXPECT_EQ (globals["farthest"].value, "root-only");
+    EXPECT_EQ (globals["acrossScopes"].value, "environment");
+    EXPECT_EQ (globals["unticked"].value, "root-value");
+    // The snapshot must agree with get() name for name, or it is a second
+    // answer to the same question.
+    EXPECT_EQ (globals["mergedNearest"].value, "middle");
+    EXPECT_EQ (globals["mergedAcross"].value, "environment");
+}
+
+// A run that carries no chain at all - every request outside a nested
+// collection - must behave exactly as it did before the walk existed.
+TEST_F (ScriptEngineTest, ANullAncestorListReadsAsNoChainRatherThanThrowing) {
+    Environment leaf;
+    leaf["token"] = Variable{ "from-leaf", false, true };
+    Environment globals;
+
+    ScriptContext ctx;
+    ctx.request             = &request;
+    ctx.environment         = &env;
+    ctx.globals             = &globals;
+    ctx.collectionVariables = &leaf; // collectionAncestors stays null
+
+    auto result = engine.execute (R"JS(
+        pm.globals.set('own', String(pm.collectionVariables.get('token')));
+        pm.globals.set('missing', String(pm.collectionVariables.get('nowhere')));
+        pm.globals.set('snapshotKeys', String(Object.keys(pm.collectionVariables.toObject()).length));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (globals["own"].value, "from-leaf");
+    EXPECT_EQ (globals["missing"].value, "undefined");
+    EXPECT_EQ (globals["snapshotKeys"].value, "1");
+}
+
 TEST_F (ScriptEngineTest, ReplaceInGeneratesDynamicVariablesPerOccurrence) {
     auto result = engine.execute_prerequest (R"JS(
         var pair = pm.variables.replaceIn('{{$guid}}|{{$guid}}').split('|');

--- a/engine/tests/script_variables_test.cpp
+++ b/engine/tests/script_variables_test.cpp
@@ -1,7 +1,8 @@
 /**
  * @file tests/script_variables_test.cpp
- * @brief Tests for the stored-variables round trip and the design-run persist
- *        of the three variable scopes (issue #135).
+ * @brief Tests for the stored-variables round trip, the design-run persist of
+ *        the three variable scopes (issue #135), and the collection chain
+ *        those scopes are loaded from (issue #234).
  *
  * A variables blob is written by the app and rewritten by the engine after
  * every design run, so the two halves of `parse_variables`/`serialize_variables`
@@ -28,6 +29,9 @@
 #include <nlohmann/json.hpp>
 
 #include "vayu/db/database.hpp"
+#include "vayu/http/request_composer.hpp"
+#include "vayu/http/routes.hpp"
+#include "vayu/runtime/script_engine.hpp"
 #include "vayu/types.hpp"
 #include "vayu/utils/json.hpp"
 
@@ -301,6 +305,209 @@ TEST_F (PersistScriptVariablesTest, AClearedScopeIsStoredAsEmptyAndTheOthersAreU
     EXPECT_EQ (stored_environment_variables (), "{}");
     EXPECT_EQ (stored_globals_variables (), APP_BLOB);
     EXPECT_EQ (stored_collection_variables (), APP_BLOB);
+}
+
+// ---------------------------------------------------------------------------
+// load_script_variable_scopes - the collection chain a script reads (issue #234)
+//
+// This is where the D2 asymmetry lived: composition walked the whole ancestor
+// chain for `{{name}}` while the route handed the scripts one `get_collection`
+// of the immediate parent, so an inherited name read as undefined in a script
+// and substituted fine in the URL. The two tests that carry the design are the
+// agreement one (both notations answer the same) and the hazard one (a script
+// write still reaches the leaf collection alone).
+// ---------------------------------------------------------------------------
+
+using vayu::http::routes::load_script_variable_scopes;
+
+class ScriptVariableScopesTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_script_scopes.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+
+        // API (root, defines `token`) -> Users (leaf, defines `page_size`).
+        add_collection ("col_root", "API", std::nullopt,
+        R"({"token":{"value":"root-token","enabled":true},)"
+        R"("shadowed":{"value":"root-wins","enabled":true}})");
+        add_collection ("col_leaf", "Users", "col_root",
+        R"({"page_size":{"value":"25","enabled":true}})");
+
+        vayu::db::Request request;
+        request.id            = "req_1";
+        request.collection_id = "col_leaf";
+        request.name          = "List users";
+        request.method        = vayu::HttpMethod::GET;
+        request.url           = "https://api.example.com/users?token={{token}}";
+        request.params        = "[]";
+        request.headers       = "[]";
+        request.body          = R"({"mode":"none"})";
+        request.body_type     = "none";
+        request.auth          = R"({"mode":"none"})";
+        request.order         = 0;
+        request.created_at    = 1;
+        request.updated_at    = 1;
+        db_->save_request (request);
+
+        run_.id              = "run_1";
+        run_.request_id      = "req_1";
+        run_.type            = vayu::RunType::Design;
+        run_.status          = vayu::RunStatus::Completed;
+        run_.config_snapshot = "{}";
+        run_.start_time      = 1;
+        run_.end_time        = 1;
+        db_->create_run (run_);
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+
+    static void cleanup () {
+        std::filesystem::remove (DB_PATH);
+        std::filesystem::remove (std::string (DB_PATH) + "-wal");
+        std::filesystem::remove (std::string (DB_PATH) + "-shm");
+    }
+
+    void add_collection (const std::string& id,
+    const std::string& name,
+    std::optional<std::string> parent,
+    const std::string& variables) {
+        vayu::db::Collection collection;
+        collection.id         = id;
+        collection.name       = name;
+        collection.parent_id  = std::move (parent);
+        collection.variables  = variables;
+        collection.auth       = "{}";
+        collection.order      = 0;
+        collection.created_at = 1;
+        collection.updated_at = 1;
+        db_->create_collection (collection);
+    }
+
+    std::string stored_variables (const std::string& collection_id) {
+        auto c = db_->get_collection (collection_id);
+        EXPECT_TRUE (c.has_value ());
+        return c ? c->variables : std::string ();
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+    vayu::db::Run run_;
+};
+
+// The leaf is the request's own collection and the only writable one; the rest
+// of the chain arrives root-first and separate. Revert the walk to the old
+// single get_collection and `collection_ancestors` is empty here.
+TEST_F (ScriptVariableScopesTest, TheChainArrivesRootFirstWithTheLeafHeldSeparately) {
+    auto scopes = load_script_variable_scopes (*db_, run_);
+
+    ASSERT_EQ (scopes.collection_ancestors.size (), 1U);
+    EXPECT_EQ (scopes.collection_ancestors[0].at ("token").value, "root-token");
+    EXPECT_EQ (scopes.collection.count ("token"), 0U)
+    << "the ancestor's variables were merged into the writable leaf scope";
+    EXPECT_EQ (scopes.collection.at ("page_size").value, "25");
+}
+
+TEST_F (ScriptVariableScopesTest, ARequestOutsideAnyCollectionGetsEmptyCollectionScopes) {
+    vayu::db::Request loose;
+    loose.id         = "req_loose";
+    loose.name       = "Loose";
+    loose.method     = vayu::HttpMethod::GET;
+    loose.url        = "https://api.example.com/ping";
+    loose.params     = "[]";
+    loose.headers    = "[]";
+    loose.body       = R"({"mode":"none"})";
+    loose.body_type  = "none";
+    loose.auth       = R"({"mode":"none"})";
+    loose.order      = 0;
+    loose.created_at = 1;
+    loose.updated_at = 1;
+    db_->save_request (loose);
+
+    vayu::db::Run run = run_;
+    run.id            = "run_loose";
+    run.request_id    = "req_loose";
+
+    auto scopes = load_script_variable_scopes (*db_, run);
+
+    EXPECT_TRUE (scopes.collection.empty ());
+    EXPECT_TRUE (scopes.collection_ancestors.empty ());
+}
+
+// The issue in one assertion: the same `{{token}}`, defined only on an
+// ancestor, must mean the same thing in a request field and in a script.
+TEST_F (ScriptVariableScopesTest, AnInheritedNameResolvesTheSameInAScriptAsInTheUrl) {
+    auto [status, composed] =
+    vayu::http::compose_request_core (*db_, json{ { "requestId", "req_1" } });
+    ASSERT_EQ (status, 200) << composed.dump ();
+    const std::string composed_url = composed["url"].get<std::string> ();
+    ASSERT_NE (composed_url.find ("root-token"), std::string::npos) << composed_url;
+
+    auto scopes = load_script_variable_scopes (*db_, run_);
+    vayu::runtime::ScriptContext ctx;
+    ctx.environment         = &scopes.environment;
+    ctx.globals             = &scopes.globals;
+    ctx.collectionVariables = &scopes.collection;
+    ctx.collectionAncestors = &scopes.collection_ancestors;
+
+    vayu::runtime::ScriptEngine engine;
+    auto result = engine.execute (R"JS(
+        pm.globals.set('replaced', pm.variables.replaceIn('{{token}}'));
+        pm.globals.set('scoped', String(pm.collectionVariables.get('token')));
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (scopes.globals.at ("replaced").value, "root-token");
+    EXPECT_EQ (scopes.globals.at ("scoped").value, "root-token");
+    EXPECT_NE (composed_url.find (scopes.globals.at ("replaced").value), std::string::npos);
+}
+
+// The hazard #226 declined to risk, end to end: a script reads an inherited
+// name and writes its own, and the persist that follows must touch the leaf
+// collection only. If the chain were merged into one writable map, the diff
+// against the leaf's stored blob would report the ancestor's variables as new
+// and write them into the leaf permanently.
+TEST_F (ScriptVariableScopesTest, AScriptThatReadsAnAncestorAndWritesPersistsOnlyTheLeaf) {
+    const std::string root_before = stored_variables ("col_root");
+
+    auto scopes = load_script_variable_scopes (*db_, run_);
+    vayu::runtime::ScriptContext ctx;
+    ctx.environment         = &scopes.environment;
+    ctx.globals             = &scopes.globals;
+    ctx.collectionVariables = &scopes.collection;
+    ctx.collectionAncestors = &scopes.collection_ancestors;
+
+    vayu::runtime::ScriptEngine engine;
+    auto result = engine.execute (R"JS(
+        pm.collectionVariables.get('token');
+        pm.collectionVariables.get('shadowed');
+        pm.collectionVariables.toObject();
+        pm.collectionVariables.set('cursor', 'abc');
+    )JS",
+    ctx);
+    ASSERT_TRUE (result.success) << result.error_message;
+
+    persist_script_variables (
+    *db_, run_, scopes.environment, scopes.globals, scopes.collection);
+
+    auto leaf = json::parse (stored_variables ("col_leaf"));
+    EXPECT_EQ (leaf["cursor"]["value"], "abc");
+    EXPECT_EQ (leaf["page_size"]["value"], "25");
+    EXPECT_FALSE (leaf.contains ("token"))
+    << "an ancestor's variable was copied down into the leaf collection: "
+    << leaf.dump ();
+    EXPECT_FALSE (leaf.contains ("shadowed")) << leaf.dump ();
+    // The ancestor is not a write target at all, so its row is untouched -
+    // blob and `updated_at` both.
+    EXPECT_EQ (stored_variables ("col_root"), root_before);
+    auto root = db_->get_collection ("col_root");
+    ASSERT_TRUE (root.has_value ());
+    EXPECT_EQ (root->updated_at, 1);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

**Plan.** Root cause: `execution.cpp` filled the script's collection scope from a single `get_collection(request.collection_id)`, while `{{name}}` composition walks the whole ancestor chain (`collection_chain`). So with `API` (defines `token`) → `Users` → request, `{{token}}` substituted in the URL and `pm.collectionVariables.get("token")` / `pm.variables.get("token")` / `pm.variables.replaceIn("{{token}}")` all answered `undefined` / `""` - after #231 that is one notation with two meanings, not just two APIs disagreeing. Approach: the issue's *read-walks, write-leaf* design. `ScriptContext` carries the chain as a list of per-collection scopes rather than one merged map - `collectionVariables` stays the single **writable** leaf, and a new `const std::vector<Environment>* collectionAncestors` (root first) rides along read-only. Collection reads walk leaf → root and take the nearest enabled definition; snapshots fold root → leaf so `toObject` agrees with `get` name for name. **The alternative I rejected is the naive merged map** (what compose builds for `{{}}`): `persist_script_variables` diffs the collection scope against the leaf collection's stored blob, so ancestors merged into that one map would be reported as new keys and written down into the leaf collection on the next script write - the silent data restructuring #226 kept D2 open for. Read-only ancestors make that unrepresentable rather than merely avoided.

Verified the problem still existed as described at master `6d4bbbc`; the code matched the issue line for line. **Blast radius traced:** the collection scope has readers in `js_pm_scope_get/has/to_object`, `js_pm_variables_get/has/to_object` and `js_pm_variables_replace_in` - all six now go through two shared helpers (`lookup_variable`, `merge_visible_variables`) built from one walk order, so `get` and `toObject` cannot answer a name two ways. Writers (`set`/`unset`/`clear`) still call `scope_variables`, the leaf alone. The load path (`run_manager.cpp`) carries no collection scope at all and is untouched.

**One consumer outside the issue's list, included because it is now wrong.** `useScriptVariableCompletionProvider` filtered ancestor variables out of the script editor's completion list *because* the engine could not read them (`info.sourceId === collectionId`). With the engine walking the chain, that narrowing would withhold names the call resolves - the mirror of the `undefined`-offering failure the rule was written to prevent. The filter is removed and its test inverted; `docs/app/variable-resolution.md` described the narrowing in two places and is updated with it.

**Behaviour change, stated plainly:** `pm.collectionVariables.get` / `pm.variables.get` / `replaceIn` start seeing ancestor-defined names that previously read as `undefined` / `""`. The shadowing rule is CSS-like and now documented: `set` on a descendant shadows an ancestor's name, `unset` un-shadows it (the ancestor's value returns), `clear` empties the leaf only. A disabled row is looked past wherever it sits in the chain, so unticking an inherited name falls through to the ancestor rather than hiding it. Worth a release-note line.

All five decisions folded into the issue are implemented as written (`has` answers what `get` finds; `toObject` is the walked merge with no per-collection introspection; precedence stays environment → collection → globals; null scopes stay null-tolerant; `unset`/`clear` touch the leaf only).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run on this branch, all green. No pre-existing failures observed on the base commit.

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **770 passed, 0 failed** (+33 over master's 737).
- `cd app && pnpm test` - **272 files / 2324 tests passed**.
- `cd app && pnpm type-check` - clean (all three tsconfigs).
- `npx eslint` and `npx prettier --check` on the two touched app files - clean. `git clang-format` on changed C++ lines only, per `CLAUDE.md` (no repo-wide run). `mkdocs build --strict` could not run here - mkdocs is not installed in this environment - so the docs edits add no page, no rename and no new anchor; the one added link target (`../app/variable-resolution.md`) is a path `scripting.md` already uses three times.

New engine coverage - `script_engine_test.cpp` (script-visible semantics) and `script_variables_test.cpp` (the DB wiring, where the bug actually lived):

- an ancestor's variable read through `get` / `has` / `toObject` / `pm.variables.get` / `replaceIn`;
- the leaf shadows an ancestor, `unset` un-shadows it, `clear` empties the leaf and leaves ancestors intact;
- precedence across the whole stack (environment > leaf > middle > root > globals), including a disabled leaf row falling through to the ancestor;
- a null ancestor list reading as no chain rather than throwing;
- `load_script_variable_scopes` returns the chain root-first with the leaf held separately, and empty scopes for a request outside any collection;
- **the `{{}}`-vs-script agreement case**: one name defined only on an ancestor, `compose_request_core`'s resolved URL and `replaceIn` compared against each other;
- **the copy-down hazard, end to end**: a script reads inherited names and writes its own, then `persist_script_variables` runs - the leaf's stored blob gains `cursor` and gains neither `token` nor `shadowed`, and the root collection's blob *and* `updated_at` are untouched.

**Mutation-checked** (applied, rebuilt, confirmed red, reverted):

| Mutation | Result |
|---|---|
| `scope_maps` ignores `collectionAncestors` (engine-side revert) | 5 red, incl. the agreement test |
| `load_script_variable_scopes` returns no ancestors (route-side revert) | 2 red |
| the `sourceId === collectionId` filter restored in the completion provider | 2 red |

Each half of the fix is independently pinned - reverting either one alone goes red.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit, per the issue's list: `docs/app/variable-resolution.md` (the D2 asymmetry paragraph becomes the shadowing rule, plus the completion-list rule below it), `docs/engine/scripting.md` (collection scope docs), `docs/app/pm-api-compatibility.md` (the D2 caveat in the `replaceIn` section). `docs/engine/architecture.md` does not name the single-collection scope, so it needed no edit. The engine's `/scripting/completions` strings for `pm.collectionVariables.get` / `.set` are updated too - they are the editor-side description of exactly this contract.

## Related Issues
Closes #234

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwLnoNUytA978SUYb2pxtL)_