### PR TITLE
feat(mcp): expose the script sandbox surface as a resource

### DIFF
--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -157,6 +157,19 @@ export class EngineClient {
 		return this.request("GET", "/config", undefined, signal);
 	}
 
+	// --- Script sandbox surface ----------------------------------------------
+
+	/**
+	 * The script sandbox's API surface: every `pm.*` name, global and assertion
+	 * chain the QuickJS runtime installs. Generated engine-side from one table
+	 * and cross-checked against the runtime by `script_completions_test.cpp`,
+	 * which is why both the editor and MCP read it rather than describing the
+	 * sandbox themselves (issue #233).
+	 */
+	getScriptCompletions(signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", "/scripting/completions", undefined, signal);
+	}
+
 	updateConfig(payload: unknown, signal?: AbortSignal): Promise<unknown> {
 		return this.request("POST", "/config", payload, signal);
 	}

--- a/app/electron/mcp/protocol.integration.test.ts
+++ b/app/electron/mcp/protocol.integration.test.ts
@@ -45,6 +45,23 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		}),
 		listCollections: async () => [{ id: "col_1", name: "API" }],
 		listEnvironments: async () => [],
+		// The engine's completions shape, Monaco fields included - the resource is
+		// expected to hand the agent the names and drop the editor scaffolding.
+		getScriptCompletions: async () => ({
+			version: "1.0.0",
+			engine: "quickjs",
+			completions: [
+				{
+					label: "pm.crypto.hmacSha256",
+					kind: 1,
+					insertText: "pm.crypto.hmacSha256(${1:key}, ${2:data})",
+					insertTextRules: 4,
+					sortText: "1_pm_crypto_hmacSha256",
+					detail: "pm.crypto.hmacSha256(key, data, encoding?): string | Uint8Array",
+					documentation: "HMAC-SHA256, hex by default. Synchronous.",
+				},
+			],
+		}),
 		// Identity composition: the request echoed back, as the engine's
 		// POST /compose returns for an inline request with nothing to resolve.
 		composeRequest: async (body: { request?: object; environmentId?: string }) => ({
@@ -211,6 +228,20 @@ describe("resources", () => {
 		expect(uris).toContain("vayu://collections");
 		expect(uris).toContain("vayu://environments");
 		expect(uris).toContain("vayu://config");
+		expect(uris).toContain("vayu://scripting/completions");
+		await server.close();
+	});
+
+	// Issue #233: an agent's only view of the sandbox used to be two sentences in
+	// tool descriptions, so anything not named there was undiscoverable.
+	it("serves the script sandbox surface from the engine, without Monaco's fields", async () => {
+		const { client, server } = await connectClient();
+		const res = await client.readResource({ uri: "vayu://scripting/completions" });
+		const text = String((res.contents[0] as { text?: string }).text);
+		expect(text).toContain("pm.crypto.hmacSha256");
+		expect(text).toContain("Synchronous");
+		expect(text).not.toContain("insertText");
+		expect(text).not.toContain("sortText");
 		await server.close();
 	});
 

--- a/app/electron/mcp/resources.test.ts
+++ b/app/electron/mcp/resources.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @file resources.test.ts
+ * @brief Covers the script-sandbox resource added for issue #233. The load-
+ *        bearing assertion is the anti-drift one: the resource's contents must
+ *        come from what the engine served, so a hand-maintained list of pm.*
+ *        names in the app would fail these tests rather than quietly going
+ *        stale the way the app's own quick-reference panel did.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { STATIC_RESOURCES, projectScriptingSurface } from "./resources.js";
+import type { ToolContext } from "./tools.js";
+import type { EngineClient } from "./engine-client.js";
+
+/** One completion in the engine's shape - Monaco fields and all. */
+function engineEntry(label: string, extra: Record<string, unknown> = {}) {
+	return {
+		label,
+		kind: 1,
+		insertText: `${label}(\${1:arg})`,
+		insertTextRules: 4,
+		sortText: `1_${label}`,
+		filterText: `.${label}`,
+		detail: `${label}(arg: string): string`,
+		documentation: `What ${label} does.`,
+		...extra,
+	};
+}
+
+function scriptingResource() {
+	const r = STATIC_RESOURCES.find((s) => s.uri === "vayu://scripting/completions");
+	if (!r) throw new Error("scripting resource is not registered");
+	return r;
+}
+
+function contextWith(completionsPayload: unknown, getScriptCompletions = vi.fn()) {
+	getScriptCompletions.mockResolvedValue(completionsPayload);
+	return {
+		ctx: { client: { getScriptCompletions } as unknown as EngineClient } as ToolContext,
+		getScriptCompletions,
+	};
+}
+
+describe("projectScriptingSurface", () => {
+	test("keeps the fields that mean something outside an editor", () => {
+		const surface = projectScriptingSurface({
+			version: "1.0.0",
+			engine: "quickjs",
+			completions: [engineEntry("pm.crypto.sha256")],
+		});
+
+		expect(surface.version).toBe("1.0.0");
+		expect(surface.engine).toBe("quickjs");
+		expect(surface.completions).toEqual([
+			{
+				label: "pm.crypto.sha256",
+				detail: "pm.crypto.sha256(arg: string): string",
+				documentation: "What pm.crypto.sha256 does.",
+			},
+		]);
+	});
+
+	test("drops Monaco's own fields - snippet placeholders and the kind enum", () => {
+		const surface = projectScriptingSurface({
+			completions: [engineEntry("pm.test")],
+		});
+
+		const [entry] = surface.completions;
+		for (const monacoOnly of [
+			"kind",
+			"insertText",
+			"insertTextRules",
+			"sortText",
+			"filterText",
+		]) {
+			expect(entry).not.toHaveProperty(monacoOnly);
+		}
+	});
+
+	test("keeps snippet entries - their label and documentation still name a capability", () => {
+		const surface = projectScriptingSurface({
+			completions: [
+				engineEntry("Sign the outgoing request", {
+					kind: 28,
+					detail: "Script template",
+					documentation: "HMAC-sign the request from a pre-request script.",
+				}),
+			],
+		});
+
+		expect(surface.completions).toHaveLength(1);
+		expect(surface.completions[0].documentation).toContain("HMAC-sign");
+	});
+
+	test("omits detail / documentation when the engine sent none, rather than emitting undefined", () => {
+		const surface = projectScriptingSurface({ completions: [{ label: "pm" }] });
+
+		expect(surface.completions[0]).toEqual({ label: "pm" });
+	});
+
+	test("skips entries with no usable label instead of offering a nameless API", () => {
+		const surface = projectScriptingSurface({
+			completions: [{ label: "" }, { kind: 1 }, null, "pm.test", engineEntry("pm.expect")],
+		});
+
+		expect(surface.completions.map((c) => c.label)).toEqual(["pm.expect"]);
+	});
+
+	// A partial surface is worse than an error: an agent reads a short list as
+	// "the sandbox cannot do that" and never attempts what is missing.
+	test.each([
+		["a payload that is not an object", "not json"],
+		["a payload with no completions key", { version: "1.0.0" }],
+		["a completions value that is not an array", { completions: { label: "pm" } }],
+		["null", null],
+	])("throws loudly on %s", (_label, payload) => {
+		expect(() => projectScriptingSurface(payload)).toThrow(/scripting\/completions/);
+	});
+});
+
+describe("vayu://scripting/completions resource", () => {
+	test("serves whatever the engine's completions endpoint returned", async () => {
+		// A name the app has never heard of: only a resource that actually reads
+		// the engine can produce it, so a hardcoded list here fails.
+		const { ctx, getScriptCompletions } = contextWith({
+			version: "1.0.0",
+			engine: "quickjs",
+			completions: [engineEntry("pm.somethingTheAppHasNeverHeardOf")],
+		});
+
+		const surface = (await scriptingResource().read(ctx)) as {
+			completions: Array<{ label: string }>;
+		};
+
+		expect(getScriptCompletions).toHaveBeenCalledTimes(1);
+		expect(surface.completions.map((c) => c.label)).toEqual([
+			"pm.somethingTheAppHasNeverHeardOf",
+		]);
+	});
+
+	test("a name the engine stops serving disappears from the resource", async () => {
+		const { ctx } = contextWith({ completions: [engineEntry("pm.test")] });
+
+		const surface = (await scriptingResource().read(ctx)) as {
+			completions: Array<{ label: string }>;
+		};
+
+		expect(surface.completions.map((c) => c.label)).not.toContain("pm.crypto.sha256");
+	});
+
+	test("forwards the cancellation signal to the engine client", async () => {
+		const { ctx, getScriptCompletions } = contextWith({ completions: [] });
+		const controller = new AbortController();
+
+		await scriptingResource().read(ctx, controller.signal);
+
+		expect(getScriptCompletions).toHaveBeenCalledWith(controller.signal);
+	});
+
+	test("propagates an engine failure rather than serving an empty surface", async () => {
+		const ctx = {
+			client: {
+				getScriptCompletions: vi.fn().mockRejectedValue(new Error("engine is down")),
+			} as unknown as EngineClient,
+		} as ToolContext;
+
+		await expect(scriptingResource().read(ctx)).rejects.toThrow("engine is down");
+	});
+});

--- a/app/electron/mcp/resources.ts
+++ b/app/electron/mcp/resources.ts
@@ -12,7 +12,10 @@
  *        environments, engine config); a templated resource
  *        `vayu://run/{runId}/report` exposes any run's full report, with a list
  *        callback (enumerate recent runs) and a completion callback (autocomplete
- *        run IDs). All read-only; no allowlist/caps apply. See docs/engine/mcp.md.
+ *        run IDs). `vayu://scripting/completions` re-serves the engine's own
+ *        script-sandbox surface so an agent discovers it the way the editor does,
+ *        instead of from a prose copy that drifts (issue #233).
+ *        All read-only; no allowlist/caps apply. See docs/engine/mcp.md.
  */
 
 import type { ToolContext } from "./tools.js";
@@ -56,7 +59,67 @@ export const STATIC_RESOURCES: StaticResourceDef[] = [
 			"The engine's tunable configuration entries with values, defaults, and ranges.",
 		read: (ctx, signal) => ctx.client.getConfig(signal),
 	},
+	{
+		name: "scripting",
+		uri: "vayu://scripting/completions",
+		title: "Script sandbox API",
+		description:
+			"Every name the pre-request / test script sandbox provides: pm.request and pm.response, " +
+			"the pm.expect assertion chains, the variable scopes, pm.crypto (synchronous SHA-256 / " +
+			"HMAC-SHA256) and the btoa / atob globals. Read this before writing a preRequestScript " +
+			"or postRequestScript.",
+		read: async (ctx, signal) =>
+			projectScriptingSurface(await ctx.client.getScriptCompletions(signal)),
+	},
 ];
+
+/** One sandbox name as an agent sees it - the engine's own keys, minus Monaco's. */
+export interface ScriptingApiEntry {
+	label: string;
+	detail?: string;
+	documentation?: string;
+}
+
+export interface ScriptingSurface {
+	version?: unknown;
+	engine?: unknown;
+	completions: ScriptingApiEntry[];
+}
+
+/**
+ * Reduce `GET /scripting/completions` to the three fields that mean something
+ * outside an editor. `insertText`, `insertTextRules`, `sortText`, `filterText`
+ * and `kind` are Monaco's - snippet placeholders (`${1:secret}`) and a
+ * `CompletionItemKind` enum an agent has no use for.
+ *
+ * Every entry survives, snippets included: dropping them would mean testing
+ * `kind === 28`, which is exactly the copied-constant drift this resource exists
+ * to avoid, and a snippet's label plus documentation still names a capability.
+ *
+ * Throws rather than returning a partial surface - an agent that reads a
+ * silently-truncated API list concludes the sandbox cannot do what it can.
+ */
+export function projectScriptingSurface(payload: unknown): ScriptingSurface {
+	const root =
+		payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
+	if (!root || !Array.isArray(root.completions)) {
+		throw new Error(
+			"GET /scripting/completions returned no `completions` array - cannot describe the script sandbox"
+		);
+	}
+	const completions: ScriptingApiEntry[] = [];
+	for (const item of root.completions) {
+		if (!item || typeof item !== "object") continue;
+		const rec = item as Record<string, unknown>;
+		if (typeof rec.label !== "string" || !rec.label) continue;
+		completions.push({
+			label: rec.label,
+			...(typeof rec.detail === "string" ? { detail: rec.detail } : {}),
+			...(typeof rec.documentation === "string" ? { documentation: rec.documentation } : {}),
+		});
+	}
+	return { version: root.version, engine: root.engine, completions };
+}
 
 /** Templated per-run report resource. */
 export const RUN_REPORT_RESOURCE = {

--- a/app/electron/mcp/server.ts
+++ b/app/electron/mcp/server.ts
@@ -57,7 +57,10 @@ const INSTRUCTIONS =
 	"Vayu data is also available as resources (vayu://runs, vayu://collections, " +
 	"vayu://environments, vayu://config, and vayu://run/{runId}/report) to attach as " +
 	"context, and prompts (summarize_run, compare_runs, diagnose_errors, " +
-	"suggest_load_profile) provide ready-made starting points.";
+	"suggest_load_profile) provide ready-made starting points. Before writing a " +
+	"preRequestScript or postRequestScript, read vayu://scripting/completions - it is " +
+	"the engine's own list of every pm.* name the script sandbox provides, including " +
+	"synchronous pm.crypto hashing and btoa/atob for signing a request.";
 
 /**
  * Create an MCP server exposing the Vayu tools. `contextProvider` is invoked

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -381,7 +381,7 @@ const validationScriptInput = z
 	.string()
 	.optional()
 	.describe(
-		"JavaScript run after a response arrives; use pm.test(...) for assertions, returned as test results. This is the same script the app's Tests tab holds - under load it runs against sampled responses, not every one."
+		"JavaScript run after a response arrives; use pm.test(...) for assertions, returned as test results. This is the same script the app's Tests tab holds - under load it runs against sampled responses, not every one. Read the `vayu://scripting/completions` resource for the sandbox's full surface (pm.expect chains, pm.response.to.*, the variable scopes) rather than assuming what exists."
 	);
 
 const validationScriptAliasInput = z
@@ -644,7 +644,7 @@ export const TOOLS: McpTool[] = [
 				.string()
 				.optional()
 				.describe(
-					"JavaScript run before the request is sent. It may edit pm.request.url / .method / .headers / .body, and those edits are what gets sent - a script-set header overrides the engine-applied auth."
+					"JavaScript run before the request is sent. It may edit pm.request.url / .method / .headers / .body, and those edits are what gets sent - a script-set header overrides the engine-applied auth. The sandbox is synchronous and has no network: to sign a request use pm.crypto.sha256 / pm.crypto.hmacSha256 and the btoa / atob globals. Read the `vayu://scripting/completions` resource for the full surface."
 				),
 			postRequestScript: validationScriptInput,
 			tests: validationScriptAliasInput,

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -356,6 +356,22 @@ entry - it caught `queueMicrotask`, which quickjs-ng does provide, on its first 
 Narrow that suppression list rather than widening it: each code on it is a real mistake
 going unreported in exchange for not crying wolf on correct code.
 
+### The second consumer: MCP agents
+
+The completion set is no longer only an editor concern. An MCP agent writes scripts too -
+`run_request` takes a `preRequestScript` and both it and `start_load_run` take a
+`postRequestScript` - and it reaches the same sandbox, since the sandbox belongs to the
+engine and has no per-client gate.
+
+So the MCP server re-serves this endpoint as the `vayu://scripting/completions` resource
+(`app/electron/mcp/resources.ts`), trimmed to `label` / `detail` / `documentation` - see
+[`docs/engine/mcp.md`](../engine/mcp.md#the-script-sandbox-surface). The reason it reads
+the endpoint rather than describing the surface in its own prose is the one this page
+already demonstrates: a hand-written copy drifts, and the app's own pre-request quick
+reference had drifted into claiming "No crypto, base64 or `URL` in the sandbox" before
+`pm.crypto` landed. Adding a name to the completion table therefore reaches Monaco, the
+`.d.ts` and every agent at once - do not add a fourth place that lists `pm.*` names.
+
 ---
 
 ## Where it lives

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -286,11 +286,39 @@ Read-only Vayu data an agent can attach as context (`resources.ts`):
 | `vayu://collections`        | All request collections.         |
 | `vayu://environments`       | All environments.                |
 | `vayu://config`             | Engine configuration entries.    |
+| `vayu://scripting/completions` | The script sandbox's full API surface (see below). |
 | `vayu://run/{runId}/report` | A run's full report (templated). |
 
 The templated report resource has a **list** callback (enumerates recent runs so
 each shows in `resources/list`) and a **completion** callback (autocompletes run
 IDs).
+
+### The script sandbox surface
+
+`preRequestScript` and `postRequestScript` run in the engine's QuickJS sandbox,
+which is the same sandbox the app's editors target - there is no per-client
+capability gate, so an agent can do anything a script in the app can. What an
+agent lacked was any way to *know* that: until issue #233 the entire script
+surface it could see was the two sentences in those fields' descriptions, so
+`pm.expect` chains, `pm.response.to.*`, the variable scopes and `pm.crypto` were
+invisible and simply never attempted.
+
+`vayu://scripting/completions` closes that. It re-serves the engine's own
+`GET /scripting/completions` - the single source of truth that also feeds Monaco,
+generated from one table in `engine/src/http/routes/scripting.cpp` and
+cross-checked against the runtime by `script_completions_test.cpp`. Notably it
+carries `pm.crypto.sha256` / `.hmacSha256` and the `btoa` / `atob` globals, and
+their documentation states they are **synchronous** (the sandbox has no event
+loop, so nothing Promise-based would ever settle).
+
+Each entry is trimmed to `label`, `detail` and `documentation`; Monaco's own
+`insertText`, `insertTextRules`, `sortText`, `filterText` and `kind` are dropped,
+since snippet placeholders and a `CompletionItemKind` enum mean nothing outside
+an editor. The trim is the only transformation - **no list of `pm.*` names is
+maintained app-side**, which is the point: a name the engine adds reaches agents
+with no second edit, and `resources.test.ts` fails if the resource ever answers
+from a local literal instead of the engine. The tool descriptions carry one
+sentence pointing here, for an agent that never lists resources.
 
 ## Prompts
 


### PR DESCRIPTION
## Description

**Plan.** The root cause is not a capability gap but a discovery gap: the script sandbox belongs to the engine and has no per-client gate, so scripts an MCP agent sends on `preRequestScript` / `postRequestScript` already reach the same QuickJS context the app's editors target - including the `pm.crypto` / `btoa` / `atob` surface #230 added. What was missing is any way for an agent to *know* that. Its entire view of the sandbox was two sentences in those fields' `describe()` strings, so `pm.expect` chains, `pm.response.to.*`, the variable scopes and `pm.crypto` were invisible, and an agent does not attempt what it has not been told exists. The approach is the issue's **Option B with a short Option A alongside**: a new `vayu://scripting/completions` resource that re-serves the engine's own `GET /scripting/completions` - the single source of truth that already feeds Monaco, generated from one table in `scripting.cpp` and cross-checked against the runtime by `script_completions_test.cpp` - plus one sentence in each tool description pointing at it, for an agent that never lists resources. **The alternative I rejected is Option A alone** (prose in the two `describe()` strings): it would create a third hand-maintained copy of the sandbox surface, which is exactly the drift the completions endpoint was built to stop, and the app's own quick-reference panel had already drifted into claiming "No crypto, base64 or `URL` in the sandbox" before #230 corrected it. A Zod `describe()` string is even easier to leave stale, since nothing renders it where a human would notice.

I verified the problem still exists as described on current master before starting: `resources.ts` exposed only runs / collections / environments / config / run-report with no scripting resource, `prompts.ts` says nothing about scripting, and the two `describe()` strings were the whole surface. The line references in the issue still hold.

**What landed:**

- `EngineClient.getScriptCompletions()` - `GET /scripting/completions`.
- `vayu://scripting/completions`, a static resource whose contents come from that endpoint.
- `projectScriptingSurface()` trims each entry to `label` / `detail` / `documentation` and drops Monaco's `insertText`, `insertTextRules`, `sortText`, `filterText` and `kind`. Measured against the real engine (built at this branch): **127 entries, 41.1 KiB raw -> 31.1 KiB served**, a 37% cut, and what goes is snippet placeholders (`${1:secret}`) and a `CompletionItemKind` enum that mean nothing outside an editor.
- One sentence added to each of the two `describe()` strings and to the server `instructions`.

**Two design points worth a reviewer's eye:**

1. **Snippet entries are kept, not filtered.** Dropping them would mean testing `kind === 28`, which puts a copy of a Monaco enum value in the app - the copied-constant drift this resource exists to avoid. A snippet's `label` plus `documentation` ("HMAC-sign the request from a pre-request script") still names a capability, and the eight of them are a small share of the payload.
2. **A malformed payload throws instead of degrading.** An agent that reads a silently-truncated API list concludes the sandbox *cannot* do what it can - the same failure this issue is about. `projectScriptingSurface` throws naming the endpoint; individual unusable entries (no `label`) are skipped rather than emitted nameless.

**Blast radius traced.** `GET /scripting/completions` had two readers before this: the renderer's cached query (`app/src/queries/script-completions.ts` -> `useScriptCompletionProvider`) and `GET /scripting/types`, generated from the same table. Neither is touched - the projection is MCP-side and read-only, so the editor path is unchanged. The new `read` is the only consumer of the new client method. **No engine change**, consistent with `mcp.md`'s "the C++ engine is not modified".

**Adjacent things I left alone:** the pre-existing ESLint errors in `resources.ts` (the `extractRunIds` formatting) and `tools.ts:989` (`no-useless-escape`) reproduce identically on the base commit and belong to #189; I did not reformat around them, per CLAUDE.md's "format only files you touched that were clean before". A `prompts.ts` entry for script authoring is not in this issue's scope.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All run on this branch, all green:

- `cd app && pnpm test` - **2338 passed, 273 files** (+14: 13 in the new `resources.test.ts`, 1 in `protocol.integration.test.ts`).
- `cd app && pnpm type-check` - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (both docs pages touched).
- Prettier clean on every file I touched; ESLint adds no new error (the 7 reported are byte-identical on the base commit - verified by linting master's versions in place).
- Engine untouched, so no engine build or ctest run: no C++ test could change colour. I did build the engine once to *measure* the real payload against `GET /scripting/completions` rather than estimate it, which is where the 127 / 41.1 KiB / 31.1 KiB figures come from. That same probe confirms the acceptance criteria by name: `pm.crypto.sha256`, `pm.crypto.hmacSha256`, `btoa`, `atob`, `pm.variables.get`, `pm.response.to.be.ok` and `to.have.nested.property` all survive the projection, and `pm.crypto`'s documentation states it is synchronous.

New coverage, with the anti-drift assertion as the point rather than a string match:

- The resource serves a name **the app has never heard of** (`pm.somethingTheAppHasNeverHeardOf`), so only a resource that genuinely reads the engine can produce it; and a name the engine stops serving disappears.
- Monaco-only fields are absent from the output, end to end through a real MCP SDK client over the protocol.
- Failure paths asserted, not assumed: four malformed payload shapes throw; an unreachable engine propagates rather than yielding an empty surface; unusable entries are skipped; `detail` / `documentation` are omitted rather than set to `undefined` when absent; the cancellation signal reaches the client.

**Mutation-checked** (applied the mutation, ran, confirmed red, reverted):

| Mutation | Result |
|---|---|
| `read` answers from a hardcoded `[{label: "pm.test"}, {label: "pm.request"}]` instead of the engine | **4 red** - the two anti-drift cases, the signal-forwarding case, and the protocol-level case |
| Projection passes the engine entry through untrimmed | **3 red** - both Monaco-field cases and the protocol-level one |

The first is the one that matters: it is precisely the "third hand-maintained copy" this design exists to prevent, and the suite refuses it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #233

Follows #230 (which added the `pm.crypto` surface this makes discoverable); independent of #232.

---
_Generated by [Claude Code](https://claude.ai/code/session_01848rD9T3iEFKtgqtF7iMmQ)_