### PR TITLE
chore(engine): drop the dead script config and the stale documented APIs

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -134,7 +134,6 @@ pm.response.responseTimeQueueWait // Generator-side queue overhead in ms,
                               // to >= 0). For single-shot sends this is ~0.
 pm.response.headers           // Plain object, lower-cased keys, with
                               // case-insensitive get()/has() over it - see below
-pm.response.body              // Raw body string
 pm.response.text()            // Body as string
 pm.response.json()            // Parse JSON (throws if invalid)
 pm.response.reason()          // Status reason phrase ('OK', 'Not Found')

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -156,8 +156,6 @@ constexpr int DEFAULT_LIVE_REPLAY_WINDOW_MS = 300000;
 /// app/src/constants/live-window.ts) and reads this key too, so neither side
 /// promises a window the other cannot hold.
 constexpr size_t DEFAULT_MAX_LIVE_TICKS = 50000;
-/// Size of the context pool for request handling
-constexpr size_t CONTEXT_POOL_SIZE = 64;
 /// How long `RunManager::shutdown` waits for signalled runs to reach a terminal
 /// status before it logs that they have not. The *wait* is bounded; the join
 /// that follows it is not, because abandoning a still-running worker is exactly

--- a/engine/src/cli.cpp
+++ b/engine/src/cli.cpp
@@ -23,9 +23,6 @@
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 #include "vayu/version.hpp"
-#ifdef VAYU_HAS_QUICKJS
-#include "vayu/runtime/script_engine.hpp"
-#endif
 
 #include <chrono>
 #include <fstream>

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1289,12 +1289,19 @@ std::string http_version_options_json () {
 void Database::seed_default_config () {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
 
-    // Retired settings: "requestBatchSize" drove the removed batched request
-    // iteration and is no longer read anywhere. Delete any row left behind by
-    // an older version so the Settings UI (which renders engine entries
+    // Retired settings: keys nothing reads any more. Delete any row left behind
+    // by an older version so the Settings UI (which renders engine entries
     // dynamically from GET /config) stops offering a dead knob.
-    impl_->storage.remove_all<ConfigEntry> (
-    where (c (&ConfigEntry::key) == "requestBatchSize"));
+    //
+    //   requestBatchSize - drove the removed batched request iteration.
+    //   contextPoolSize  - promised "pre-initialized JS contexts", but the
+    //                      script context pool is grown lazily and never read a
+    //                      bound (issue #112). A user could set it 1..256 and
+    //                      change nothing.
+    for (const char* retired : { "requestBatchSize", "contextPoolSize" }) {
+        impl_->storage.remove_all<ConfigEntry> (
+        where (c (&ConfigEntry::key) == std::string (retired)));
+    }
 
     // Get existing config entries (if any) to preserve user-modified values
     auto existing = impl_->storage.get_all<ConfigEntry> ();
@@ -1534,14 +1541,6 @@ void Database::seed_default_config () {
     "debugging.",
     "scripting_sandbox", vayu::core::constants::script_engine::ENABLE_CONSOLE ? "true" : "false",
     std::nullopt, std::nullopt, std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "contextPoolSize",
-    std::to_string (vayu::core::constants::server::CONTEXT_POOL_SIZE), "integer", "Script Context Pool Size",
-    "Number of pre-initialized JS contexts. Increase for high-concurrency "
-    "script workloads. "
-    "Each context uses ~2-5MB of memory.",
-    "scripting_sandbox", std::to_string (vayu::core::constants::server::CONTEXT_POOL_SIZE),
-    "1", "256", std::nullopt, now });
 
     upsert_config (ConfigEntry{ "scriptMemoryLimit",
     std::to_string (vayu::core::constants::script_engine::MEMORY_LIMIT), "integer", "Script Memory Limit",

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -3669,7 +3669,10 @@ bool ScriptEngine::is_available () {
 }
 
 std::string ScriptEngine::version () {
-    return "QuickJS 2024-01-13";
+    // Derived from the vendored runtime, never written down here: a literal
+    // goes stale at the next vendor bump with nothing to catch it. This one
+    // reported "QuickJS 2024-01-13" while the tree carried quickjs-ng 0.16.0.
+    return std::string ("QuickJS-ng ") + JS_GetVersion ();
 }
 
 #else // !VAYU_HAS_QUICKJS

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -327,6 +327,35 @@ TEST_F (DatabaseTest, SeedRemovesRetiredRequestBatchSizeEntry) {
     EXPECT_FALSE (db.get_config_entry ("requestBatchSize").has_value ());
 }
 
+// "contextPoolSize" described "pre-initialized JS contexts" and accepted 1..256,
+// but the script context pool is grown lazily and never read the value (issue
+// #112) - a knob a user could turn with no effect anywhere. Same two guarantees
+// as the entry above: a fresh seed does not create it, and an upgraded database
+// sheds the row it was already carrying.
+TEST_F (DatabaseTest, SeedRemovesRetiredContextPoolSizeEntry) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    EXPECT_FALSE (db.get_config_entry ("contextPoolSize").has_value ())
+    << "a fresh seed must not create the retired key";
+
+    ConfigEntry stale;
+    stale.key           = "contextPoolSize";
+    stale.value         = "128";
+    stale.type          = "integer";
+    stale.label         = "Script Context Pool Size";
+    stale.description   = "left behind by an older version";
+    stale.category      = "scripting_sandbox";
+    stale.default_value = "64";
+    stale.updated_at    = 1;
+    db.save_config_entry (stale);
+    ASSERT_TRUE (db.get_config_entry ("contextPoolSize").has_value ());
+
+    db.seed_default_config ();
+
+    EXPECT_FALSE (db.get_config_entry ("contextPoolSize").has_value ());
+}
+
 // The "options" column is new (Task 4); an existing on-disk database predates
 // it, so sync_schema must add the nullable column without a migration, and
 // re-seeding on an already-upgraded row must both preserve the user's chosen

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -60,6 +60,24 @@ TEST_F (ScriptEngineTest, IsAvailable) {
 #endif
 }
 
+#ifdef VAYU_HAS_QUICKJS
+// version() reported a hardcoded "QuickJS 2024-01-13" while the tree carried
+// quickjs-ng 0.16.0 (issue #112), and the assertion above - non-empty - could
+// not tell the difference. Pin it to what the vendored runtime reports instead,
+// so the string tracks a vendor bump rather than needing to be remembered.
+TEST_F (ScriptEngineTest, VersionReportsTheVendoredRuntime) {
+    const std::string reported = ScriptEngine::version ();
+
+    // A version, not a release date. Deliberately not pinned to the current
+    // 0.16.0: the point is that the string comes from the vendored runtime, so
+    // a vendor bump should keep this green while a hardcoded literal cannot.
+    EXPECT_TRUE (std::regex_search (reported, std::regex (R"(QuickJS-ng \d+\.\d+\.\d+)")))
+    << "version() must report the vendored quickjs-ng version, got: " << reported;
+    EXPECT_EQ (reported.find ("2024-01-13"), std::string::npos)
+    << "version() is carrying a hardcoded date again: " << reported;
+}
+#endif
+
 TEST_F (ScriptEngineTest, ExecuteEmptyScript) {
     ScriptContext ctx;
     ctx.response = &response;
@@ -2362,6 +2380,29 @@ TEST_F (ScriptEngineTest, AScopeTheRunDoesNotCarryBehavesAsEmptyRatherThanThrowi
     EXPECT_EQ (env["absentHas"].value, "false");
     EXPECT_EQ (env["absentKeys"].value, "");
     EXPECT_EQ (env["mergedStillReads"].value, "https://api.example.com");
+}
+
+// `pm.response.body` never existed - `setup_pm_response` binds json(), text(),
+// reason(), size() and headers, and no `body` property - but scripting.md
+// documented it as "Raw body string" for long enough that someone would write
+// it and read `undefined` (issue #112). The doc line is gone; this pins the
+// contract so a future `body` binding has to be a deliberate change that
+// updates the docs with it, rather than quietly making the old line true again.
+TEST_F (ScriptEngineTest, ResponseExposesTextNotABodyProperty) {
+    response.body = R"({"n":1})";
+
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('bodyType', typeof pm.response.body);
+        pm.test("text() is how a script reads the body", function() {
+            pm.expect(pm.response.text()).to.equal('{"n":1}');
+        });
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_EQ (env["bodyType"].value, "undefined");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

**Plan.** The root cause is that this issue is a *residue* list, and residue moves: #112 batched eight small hygiene items and told the implementer to "re-scope the residue list against current master at pickup". So the first work was verification rather than editing - I checked all eight against `6d4bbbc` before touching anything, and **three were already fixed and one is already owned by an open PR**. The approach is to fix only what is still broken, and to pin each fix with a test that fails if it regresses, since every one of these is a "written but never read" defect that no existing test could catch. **The alternative I rejected was implementing the missing APIs rather than removing their claims** - binding `pm.response.body` and wiring `contextPoolSize` to the context pool. The issue rules the first out of scope, and the second would invent a bound the pool does not need: contexts are created lazily and returned to a vector, so a cap would be a new mechanism justified only by making an old label true. Deleting the claim is the honest fix; adding a knob to match stale copy is not.

### What I verified as already resolved (no change in this PR)

| Item | State on current master |
|---|---|
| 2 - `pm.variables` documented but absent | **Resolved.** `pm.variables` is implemented (`get`/`has`/`toObject`/`replaceIn`, #184). `scripting.md` now documents a real API. |
| 3 - `?.` / `??` listed as unsupported "ES2021+" | **Resolved.** `scripting.md:747` now states they are ES2020 and supported, and calls out that the section used to say the opposite. |
| 4 - "lower-cased keys" claimed to be false | **Resolved, and the doc is right - the issue's premise has since inverted.** The issue read `setup_pm_response` and concluded casing is preserved. It is, *in the script engine* - but the HTTP layer lower-cases every response header key as it parses (`client.cpp:138`, `curl_callbacks.cpp:116`), so a real response reaches a script lower-cased. The mixed-case test at `script_engine_test.cpp:920` passes only because it injects a fixture directly, bypassing the parser. Correcting this to "keyed as received" would have made the doc **wrong**. Left as-is. |
| 7 - `TestsValidating` dead metric | **Owned by PR #266**, which deletes the whole `MetricName` enum, its `to_string`/`parse_metric_name` and the `tests_validating` line in `db-schema.md`. Editing it here would be a guaranteed `types.hpp` conflict for no gain. Its emitter at `run_manager.cpp:56` is already gone, so nothing emits it today either way. |

### What this PR changes (items 1, 5, 6, 8)

- **Item 1 - `pm.response.body`.** `scripting.md:137` documented it as "Raw body string". `setup_pm_response` binds `json()`, `text()`, `reason()`, `size()` and `headers` and never a `body` property, so the documented line pointed at `undefined`. Removed - `text()` is the line directly beneath it, so the reader lands on the right accessor.
- **Item 5 - `ScriptEngine::version()`.** Returned a hardcoded `"QuickJS 2024-01-13"`. The tree vendors **quickjs-ng 0.16.0**, so the string was wrong by both engine name and version, and its only assertion (`EXPECT_FALSE(...empty())`) could not tell. Now `"QuickJS-ng " + JS_GetVersion()`, so it tracks a vendor bump instead of needing to be remembered.
- **Item 6 - `contextPoolSize`.** Seeded as a Settings row describing "Number of pre-initialized JS contexts" over a `1..256` range, with **no reader**: `get_config_int("contextPoolSize")` appears nowhere, and the pool is a `std::vector<ContextPair>` grown lazily on miss (`script_engine.cpp:3452-3474`) that never reads a bound. Contexts are not pre-initialized either, so the description was doubly false. Removed the seed, and added the key to the delete-on-seed list so an upgraded database sheds the row - copying the `requestBatchSize` pattern already in `seed_default_config()` rather than inventing a second one. `constants::server::CONTEXT_POOL_SIZE` went with it; the seed was its only user.
- **Item 8 - dead include.** `cli.cpp` included `script_engine.hpp` and never named `ScriptEngine`. Removed, along with the now-empty `#ifdef VAYU_HAS_QUICKJS` guard around it.

**Blast radius traced.** `ScriptEngine::version()` has no production reader - only the two assertions in `script_engine_test.cpp`, so no HTTP payload or UI string changes shape. `CONTEXT_POOL_SIZE` and `contextPoolSize` have no reference anywhere in `engine/src`, `engine/include`, `app/src` or `app/electron`. Removing the seed row is invisible to the Settings UI beyond the row disappearing, because that UI renders engine entries dynamically from `GET /config` - which is exactly why the stale row had to be deleted rather than merely un-seeded.

**Two items from the issue comments are deliberately not here.** `maxConnections` and `statsInterval` (same defect class, surfaced in a later comment) are left untouched: they are `general_engine` / `observability` rather than script config, `maxConnections` overlaps #197's connection-budget work, and the comment thread explicitly ends by asking which shape you want rather than settling it. Wiring them up on my own reading would be the scope creep that comment was flagging.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` - clean, no new warnings.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **763 passed, 0 failed** (760 on the base commit, plus the 3 added below). No pre-existing failures on `6d4bbbc`.
- No app suite run and no app change: `rg "contextPoolSize|testsValidating|tests_validating" app/src app/electron` is **empty (verified)**, so no TypeScript test could change colour.
- `mkdocs build --strict` not run - mkdocs is not installed in this environment; the docs change is a one-line deletion inside a fenced code block, adding/moving/renaming no page and changing no link or anchor. The docs CI job gates it.
- Formatting: `database.cpp`, `script_engine.cpp` and `db_test.cpp` are **not** clang-format-clean on `origin/master` either - verified against the base blobs - so per CLAUDE.md they were left unformatted rather than reflowed. `cli.cpp` and `constants.hpp` are clean and stayed clean.

**Mutation-checked** (applied the mutation, rebuilt, confirmed red, reverted, re-ran full suite green):

| Mutation | Result |
|---|---|
| Restore `return "QuickJS 2024-01-13";` | `ScriptEngineTest.VersionReportsTheVendoredRuntime` fails |
| Bind `pm.response.body` in `setup_pm_response` | `ScriptEngineTest.ResponseExposesTextNotABodyProperty` fails (`bodyType` is `"string"`, not `"undefined"`) |
| Drop `contextPoolSize` from the retired list and restore its seed row | `DatabaseTest.SeedRemovesRetiredContextPoolSizeEntry` fails |

The version test deliberately asserts the *shape* (`QuickJS-ng <major>.<minor>.<patch>`) and the absence of the old date, not `0.16.0` - pinning the current version would turn every vendor bump into a test edit, which is the same maintenance trap the hardcoded string was.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (3 added, all mutation-checked)
- [x] I have updated documentation

## Related Issues

Closes #112

Coordinates with **#266** (owns item 7, `TestsValidating`) and **#197** (owns `maxConnections`, per the scope split in this issue's comments). Independent of the #180 series, which has drained to #188 - a scoping record that writes no code and is explicitly non-blocking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Np1omSciY9xW3DAdftZGvy)_