### PR TITLE
fix(app): the embedded OAuth window must always answer

### DIFF
--- a/app/electron/oauth-window.test.ts
+++ b/app/electron/oauth-window.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The embedded OAuth window must always answer.
+ *
+ * The hole this closes was specific: the window is created hidden and shown on
+ * `ready-to-show`, so an authorize URL that failed before first paint produced
+ * an invisible window, and the only exit the flow had left was the user closing
+ * a window they could not see. The `loadURL` rejection naming the failure was
+ * swallowed by a catch written for the *successful* path, where the callback
+ * host is deliberately never reached.
+ *
+ * So the assertions worth holding are all about which failures settle the flow
+ * and which are noise: a dead authorize host settles with an error, the
+ * capture's own aborted navigation does not, and a load failure arriving after
+ * a capture cannot overwrite the answer already given.
+ *
+ * These drive the flow through a fake window rather than Electron, which is the
+ * whole reason it lives outside oauth.ts.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+	createAuthWindowFlow,
+	AUTH_WINDOW_TIMEOUT_MS,
+	ERR_ABORTED,
+	type AuthWindowFlow,
+	type AuthWindowResult,
+	type AuthWindowTransport,
+} from "./oauth-window";
+
+// oauth.ts registers IPC handlers at import time, so the wiring itself can only
+// be read. Everything above this line would still pass with `did-fail-load`
+// never subscribed, which is half of the bug being fixed.
+const oauthSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "oauth.ts"), "utf8");
+
+const PARAMS = {
+	authorizeUrl: "https://idp.example.com/authorize?client_id=abc",
+	redirectUri: "https://app.example.com/callback",
+};
+
+const CALLBACK = "https://app.example.com/callback?code=xyz&state=s";
+
+/** A BrowserWindow that never existed, plus the timer the adapter would arm. */
+function fakeWindow() {
+	let rejectLoad!: (err: unknown) => void;
+	const load = new Promise<void>((_resolve, reject) => {
+		rejectLoad = reject;
+	});
+	let timer: { fire: () => void; ms: number } | null = null;
+	let deadlineCancelled = false;
+
+	const transport: AuthWindowTransport = {
+		loadUrl: vi.fn(() => load),
+		destroy: vi.fn(),
+		schedule: (listener, ms) => {
+			timer = { fire: listener, ms };
+			return () => {
+				deadlineCancelled = true;
+			};
+		},
+	};
+
+	return {
+		transport,
+		destroy: transport.destroy as ReturnType<typeof vi.fn>,
+		/** The authorize page failed to load. */
+		failLoad: async (err: unknown) => {
+			rejectLoad(err);
+			await load.catch(() => undefined);
+		},
+		/** The deadline expired. */
+		expire: () => timer?.fire(),
+		timeoutMs: () => timer?.ms,
+		deadlineCancelled: () => deadlineCancelled,
+	};
+}
+
+/** Chromium hands the code back on the rejection, not in the message. */
+function loadError(code: number, message: string): Error {
+	return Object.assign(new Error(message), { errno: code });
+}
+
+/**
+ * The flow's answer, or `"pending"` when it has not settled. Racing an
+ * already-resolved marker is what turns "never settles" - the defect - into a
+ * failing assertion instead of a hanging test.
+ */
+async function answer(flow: AuthWindowFlow): Promise<AuthWindowResult | "pending"> {
+	await Promise.resolve();
+	await Promise.resolve();
+	return Promise.race([flow.result, Promise.resolve<"pending">("pending")]);
+}
+
+describe("a failed authorize load settles the flow", () => {
+	it("reports the load failure instead of hanging on a window nobody can see", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		await w.failLoad(loadError(-105, "ERR_NAME_NOT_RESOLVED (-105) loading 'https://…'"));
+
+		expect(await answer(flow)).toEqual({
+			error: "Could not load authorization page: ERR_NAME_NOT_RESOLVED (-105) loading 'https://…'",
+		});
+		expect(w.destroy).toHaveBeenCalledTimes(1); // no hidden window survives
+	});
+
+	it("reports a main-frame did-fail-load with no rejection to go with it", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		flow.onLoadFailure(-102, "ERR_CONNECTION_REFUSED");
+
+		expect(await answer(flow)).toEqual({
+			error: "Could not load authorization page: ERR_CONNECTION_REFUSED",
+		});
+		expect(w.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it("survives a rejection that is not an Error at all", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		await w.failLoad(undefined);
+
+		expect(await answer(flow)).toEqual({
+			error: "Could not load authorization page: unknown error",
+		});
+	});
+});
+
+describe("ERR_ABORTED is a superseded navigation, never a failure", () => {
+	it("ignores an aborted load - an IdP that redirects itself mid-load is fine", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		await w.failLoad(loadError(ERR_ABORTED, "ERR_ABORTED (-3) loading 'https://…'"));
+
+		expect(await answer(flow)).toBe("pending");
+		expect(w.destroy).not.toHaveBeenCalled();
+	});
+
+	it("ignores an aborted did-fail-load, which the capture itself produces", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		flow.onLoadFailure(ERR_ABORTED, "ERR_ABORTED");
+
+		expect(await answer(flow)).toBe("pending");
+	});
+});
+
+describe("the capture path is unaffected", () => {
+	it("settles with the callback URL and tells the caller to cancel the navigation", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		expect(flow.onNavigate(CALLBACK)).toBe(true);
+
+		expect(await answer(flow)).toEqual({ callbackUrl: CALLBACK });
+		expect(w.deadlineCancelled()).toBe(true);
+	});
+
+	it("does not fire on an intermediate IdP page sharing the callback prefix", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		expect(flow.onNavigate("https://app.example.com/callback/consent")).toBe(false);
+		expect(await answer(flow)).toBe("pending");
+	});
+
+	it("keeps the captured URL when the callback host then fails to load", async () => {
+		// This is the failure the old catch existed for: the fake callback host
+		// is unresolvable on purpose, and its rejection must not become an error.
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		flow.onNavigate(CALLBACK);
+		await w.failLoad(loadError(-105, "ERR_NAME_NOT_RESOLVED"));
+		flow.onLoadFailure(-105, "ERR_NAME_NOT_RESOLVED");
+
+		expect(await answer(flow)).toEqual({ callbackUrl: CALLBACK });
+		expect(w.destroy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("the deadline is the backstop for a load that neither ends nor fails", () => {
+	it("gives up after the ceiling and takes the window with it", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		expect(w.timeoutMs()).toBe(AUTH_WINDOW_TIMEOUT_MS);
+		expect(await answer(flow)).toBe("pending");
+
+		w.expire();
+
+		expect(await answer(flow)).toEqual({ error: "Authorization timed out" });
+		expect(w.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it("cannot overwrite an answer already given", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		flow.onNavigate(CALLBACK);
+		w.expire();
+
+		expect(await answer(flow)).toEqual({ callbackUrl: CALLBACK });
+		expect(w.destroy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("the window going away settles the flow", () => {
+	it("reports the close, once, however many times it is reported", async () => {
+		const w = fakeWindow();
+		const flow = createAuthWindowFlow(PARAMS, w.transport);
+		flow.start();
+
+		flow.onClosed();
+		flow.onClosed();
+
+		expect(await answer(flow)).toEqual({ error: "Authorization window was closed" });
+		expect(w.destroy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("oauth.ts wiring", () => {
+	it("read the real oauth.ts", () => {
+		// A guard that scanned an empty string would pass every assertion below.
+		expect(oauthSource.length).toBeGreaterThan(1000);
+		expect(oauthSource).toContain("createAuthWindowFlow");
+	});
+
+	it("subscribes did-fail-load, gated to the main frame", () => {
+		expect(oauthSource).toContain('win.webContents.on("did-fail-load"');
+		const handler = oauthSource.slice(oauthSource.indexOf('"did-fail-load"'));
+		expect(handler).toContain(
+			"if (isMainFrame) flow.onLoadFailure(errorCode, errorDescription)"
+		);
+	});
+
+	it("keeps no second copy of the settle bookkeeping", () => {
+		// The `settled` flag lived here and was the discriminator the catch
+		// failed to use; a copy left behind would drift from the flow's own.
+		expect(oauthSource).not.toContain("let settled");
+	});
+
+	it("starts the flow and returns its promise, rather than resolving its own", () => {
+		expect(oauthSource).toContain("flow.start()");
+		expect(oauthSource).toContain("return flow.result");
+	});
+});

--- a/app/electron/oauth-window.ts
+++ b/app/electron/oauth-window.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The settle protocol for the embedded OAuth window.
+ *
+ * The window must answer exactly once, and until this existed it could answer
+ * never. It is created hidden and shown on `ready-to-show`, so an authorize URL
+ * that failed before first paint left an invisible window behind: the flow's
+ * only other exit was the user closing that window, and there was no window to
+ * close. The `loadURL` rejection that would have named the failure was swallowed
+ * by a catch written for a different failure entirely - the deliberate abort of
+ * the callback navigation, which is how a *successful* capture ends.
+ *
+ * `settled` is the discriminator between those two. A load failure before the
+ * flow has settled is the authorize page failing and must be reported; the same
+ * failure after is the (usually unresolvable) callback host, which is expected
+ * and already answered. ERR_ABORTED is never a failure in either direction - it
+ * is what a superseded navigation reports, including the capture's own
+ * `preventDefault` and an IdP page that redirects itself mid-load.
+ *
+ * The deadline is the backstop for the case neither covers: a load that neither
+ * completes nor fails (a host that accepts the connection and never responds).
+ *
+ * Kept out of oauth.ts so a fake window can drive it - oauth.ts registers
+ * Electron IPC handlers at import time, which no unit test can do.
+ */
+
+export type AuthWindowResult = { callbackUrl: string } | { error: string };
+
+export interface AuthWindowFlowParams {
+	authorizeUrl: string;
+	/** The registered callback URL, matched by prefix to capture the redirect. */
+	redirectUri: string;
+}
+
+/** The slice of the BrowserWindow this needs, so a test can pass a fake. */
+export interface AuthWindowTransport {
+	/** Navigate to the authorize URL. Rejects when the load fails. */
+	loadUrl: (url: string) => Promise<void>;
+	/** Tear the window down. Called once, and safe on an already-gone window. */
+	destroy: () => void;
+	/** Arm the deadline timer. Returns a cancel function. */
+	schedule: (listener: () => void, ms: number) => () => void;
+}
+
+export interface AuthWindowFlow {
+	/** Settles exactly once, whichever way the flow ends. */
+	readonly result: Promise<AuthWindowResult>;
+	/** Arm the deadline and load the authorize URL. */
+	start: () => void;
+	/**
+	 * Report a navigation the window is attempting. Returns `true` when it was
+	 * the callback, which the caller must then cancel - the callback host is
+	 * usually unresolvable and contacting it buys nothing.
+	 */
+	onNavigate: (url: string) => boolean;
+	/** Report a main-frame load failure. */
+	onLoadFailure: (errorCode: number, description: string) => void;
+	/** Report that the window went away. */
+	onClosed: () => void;
+}
+
+/**
+ * How long the window may stay open before the flow gives up. Matches the
+ * loopback branch's patience (`POLL_TIMEOUT_MS` in the renderer) - the user is
+ * doing the same thing, in a different window.
+ */
+export const AUTH_WINDOW_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Chromium's `ERR_ABORTED`: a navigation that was superseded or cancelled, not
+ * one that failed. The capture path produces it on purpose.
+ */
+export const ERR_ABORTED = -3;
+
+function describeLoadError(err: unknown): string {
+	if (err instanceof Error && err.message) return err.message;
+	if (typeof err === "string" && err) return err;
+	return "unknown error";
+}
+
+/** `loadURL` rejects with a plain Error carrying Chromium's code in `errno`. */
+function loadErrorCode(err: unknown): number | undefined {
+	return typeof err === "object" && err !== null ? (err as { errno?: number }).errno : undefined;
+}
+
+export function createAuthWindowFlow(
+	params: AuthWindowFlowParams,
+	transport: AuthWindowTransport
+): AuthWindowFlow {
+	let settled = false;
+	let cancelDeadline: (() => void) | null = null;
+	let resolve!: (result: AuthWindowResult) => void;
+	const result = new Promise<AuthWindowResult>((r) => {
+		resolve = r;
+	});
+
+	const finish = (value: AuthWindowResult) => {
+		if (settled) return;
+		settled = true;
+		cancelDeadline?.();
+		transport.destroy();
+		resolve(value);
+	};
+
+	const callbackPrefix = params.redirectUri.split("?")[0];
+
+	// Match the registered callback URL AND require an OAuth indicator, so we
+	// don't fire on intermediate IdP pages sharing the prefix (Bruno's rule).
+	const matches = (url: string) =>
+		url.startsWith(callbackPrefix) &&
+		(url.includes("code=") || url.includes("error=") || url.includes("#"));
+
+	return {
+		result,
+
+		start: () => {
+			cancelDeadline = transport.schedule(
+				() => finish({ error: "Authorization timed out" }),
+				AUTH_WINDOW_TIMEOUT_MS
+			);
+			void transport.loadUrl(params.authorizeUrl).catch((err: unknown) => {
+				if (loadErrorCode(err) === ERR_ABORTED) return;
+				finish({
+					error: `Could not load authorization page: ${describeLoadError(err)}`,
+				});
+			});
+		},
+
+		onNavigate: (url) => {
+			if (!matches(url)) return false;
+			finish({ callbackUrl: url });
+			return true;
+		},
+
+		onLoadFailure: (errorCode, description) => {
+			if (errorCode === ERR_ABORTED) return;
+			finish({ error: `Could not load authorization page: ${description}` });
+		},
+
+		onClosed: () => finish({ error: "Authorization window was closed" }),
+	};
+}

--- a/app/electron/oauth.ts
+++ b/app/electron/oauth.ts
@@ -18,6 +18,7 @@
  */
 
 import { ipcMain, shell, BrowserWindow } from "electron";
+import { createAuthWindowFlow, type AuthWindowResult } from "./oauth-window";
 
 export interface OpenAuthWindowParams {
 	authorizeUrl: string;
@@ -26,72 +27,63 @@ export interface OpenAuthWindowParams {
 	partition?: string;
 }
 
-export type OpenAuthWindowResult = { callbackUrl: string } | { error: string };
+export type OpenAuthWindowResult = AuthWindowResult;
 
 /**
  * Open a hardened window at the authorize URL and resolve with the redirect URL
  * the moment the IdP navigates to it - before the (often unresolvable) callback
  * host is ever contacted.
+ *
+ * Everything about *when* this settles lives in `oauth-window.ts`; this function
+ * is only the Electron window it settles for.
  */
 function openAuthWindow(params: OpenAuthWindowParams): Promise<OpenAuthWindowResult> {
-	return new Promise((resolve) => {
-		const win = new BrowserWindow({
-			width: 520,
-			height: 680,
-			show: false,
-			autoHideMenuBar: true,
-			webPreferences: {
-				nodeIntegration: false,
-				contextIsolation: true,
-				sandbox: true,
-				partition: params.partition ?? "oauth:default",
-			},
-		});
-
-		// The IdP page is untrusted: never let it spawn child windows that could
-		// escape the redirect matcher below.
-		win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-
-		let settled = false;
-		const callbackPrefix = params.redirectUri.split("?")[0];
-
-		const finish = (result: OpenAuthWindowResult) => {
-			if (settled) return;
-			settled = true;
-			if (!win.isDestroyed()) {
-				win.webContents.removeAllListeners();
-				win.removeAllListeners("closed");
-				win.destroy();
-			}
-			resolve(result);
-		};
-
-		// Match the registered callback URL AND require an OAuth indicator, so we
-		// don't fire on intermediate IdP pages sharing the prefix (Bruno's rule).
-		const matches = (url: string) =>
-			url.startsWith(callbackPrefix) &&
-			(url.includes("code=") || url.includes("error=") || url.includes("#"));
-
-		const onNav = (url: string) => {
-			if (matches(url)) {
-				finish({ callbackUrl: url });
-				return true;
-			}
-			return false;
-		};
-
-		win.webContents.on("will-redirect", (e, url) => {
-			if (onNav(url)) e.preventDefault();
-		});
-		win.webContents.on("did-start-navigation", (_e, url) => onNav(url));
-		win.webContents.on("did-navigate", (_e, url) => onNav(url));
-		win.once("ready-to-show", () => win.show());
-		win.on("closed", () => finish({ error: "Authorization window was closed" }));
-
-		void win.loadURL(params.authorizeUrl).catch(() => {
-			/* navigation to the fake callback host is expected to fail; ignore */
-		});
+	const win = new BrowserWindow({
+		width: 520,
+		height: 680,
+		show: false,
+		autoHideMenuBar: true,
+		webPreferences: {
+			nodeIntegration: false,
+			contextIsolation: true,
+			sandbox: true,
+			partition: params.partition ?? "oauth:default",
+		},
 	});
+
+	// The IdP page is untrusted: never let it spawn child windows that could
+	// escape the redirect matcher in the flow.
+	win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+	const flow = createAuthWindowFlow(params, {
+		loadUrl: (url) => win.loadURL(url),
+		destroy: () => {
+			if (win.isDestroyed()) return;
+			win.webContents.removeAllListeners();
+			win.removeAllListeners("closed");
+			win.destroy();
+		},
+		schedule: (listener, ms) => {
+			const timer = setTimeout(listener, ms);
+			return () => clearTimeout(timer);
+		},
+	});
+
+	win.webContents.on("will-redirect", (e, url) => {
+		if (flow.onNavigate(url)) e.preventDefault();
+	});
+	win.webContents.on("did-start-navigation", (_e, url) => flow.onNavigate(url));
+	win.webContents.on("did-navigate", (_e, url) => flow.onNavigate(url));
+	// Only the main frame decides the flow; a subframe on the IdP page failing
+	// to load is the IdP's problem, not an authorization failure.
+	win.webContents.on("did-fail-load", (_e, errorCode, errorDescription, _url, isMainFrame) => {
+		if (isMainFrame) flow.onLoadFailure(errorCode, errorDescription);
+	});
+	win.once("ready-to-show", () => win.show());
+	win.on("closed", () => flow.onClosed());
+
+	flow.start();
+	return flow.result;
 }
 
 export function setupOAuthIpcHandlers(): void {

--- a/app/src/services/oauth/authorize.test.ts
+++ b/app/src/services/oauth/authorize.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The interactive flow must not be able to wait forever.
+ *
+ * The loopback branch has always had a deadline; the embedded branch awaited
+ * `oauthOpenWindow` with none at all, so a main process that never answered -
+ * an authorize URL that failed before the hidden window ever painted - spun the
+ * UI with no error and no way back short of a restart. The main process now
+ * owns the real deadline and closes that window itself; this ceiling is the
+ * backstop for the answer never arriving, and is deliberately the longer of the
+ * two so the specific error wins whenever there is one.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { runInteractiveAuthorization, InteractiveAuthError } from "./authorize";
+import type { OAuth2Config } from "@/types";
+
+const startOAuth2Authorize = vi.fn();
+const completeOAuth2Authorize = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		startOAuth2Authorize: (...a: unknown[]) => startOAuth2Authorize(...a),
+		completeOAuth2Authorize: (...a: unknown[]) => completeOAuth2Authorize(...a),
+	},
+}));
+
+const CONFIG: OAuth2Config = {
+	grantType: "authorization_code",
+	accessTokenUrl: "https://idp.example.com/token",
+	clientId: "abc",
+	useEmbeddedBrowser: true,
+};
+
+const STARTED = {
+	attemptId: "attempt_1",
+	authorizeUrl: "https://idp.example.com/authorize?client_id=abc",
+	redirectUri: "https://app.example.com/callback",
+};
+
+/** Install a desktop bridge whose embedded window answers however we say. */
+function bridge(oauthOpenWindow: () => Promise<unknown>) {
+	vi.stubGlobal("electronAPI", { oauthOpenWindow, openExternalUrl: vi.fn() });
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	startOAuth2Authorize.mockResolvedValue(STARTED);
+	completeOAuth2Authorize.mockResolvedValue({ state: "completed", cacheKey: "key" });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.clearAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("the embedded branch cannot await forever", () => {
+	it("gives up once the ceiling passes, rather than spinning with no error", async () => {
+		bridge(() => new Promise(() => undefined)); // the main process never answers
+
+		const flow = runInteractiveAuthorization(CONFIG);
+		const settled = expect(flow).rejects.toThrow(InteractiveAuthError);
+
+		// Let the start call resolve so the await on the window is actually armed.
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+
+		await settled;
+	});
+
+	it("names the timeout, so the UI has something to show", async () => {
+		bridge(() => new Promise(() => undefined));
+
+		const flow = runInteractiveAuthorization(CONFIG);
+		const settled = expect(flow).rejects.toThrow("Authorization timed out");
+
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+
+		await settled;
+	});
+
+	it("waits longer than the window's own deadline, so its error wins the race", async () => {
+		// The main process settles at 5 minutes with a specific message; if this
+		// ceiling were not the later of the two, that message would be lost.
+		bridge(
+			() =>
+				new Promise((resolve) =>
+					setTimeout(
+						() => resolve({ error: "Could not load authorization page: nope" }),
+						5 * 60 * 1000
+					)
+				)
+		);
+
+		const flow = runInteractiveAuthorization(CONFIG);
+		const settled = expect(flow).rejects.toThrow("Could not load authorization page: nope");
+
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+
+		await settled;
+	});
+});
+
+describe("a window that answers is untouched by the ceiling", () => {
+	it("completes the flow on a captured callback URL", async () => {
+		bridge(() => Promise.resolve({ callbackUrl: "https://app.example.com/callback?code=xyz" }));
+
+		const flow = runInteractiveAuthorization(CONFIG);
+		await vi.advanceTimersByTimeAsync(0);
+
+		await expect(flow).resolves.toBe("key");
+		expect(completeOAuth2Authorize).toHaveBeenCalledWith(
+			"attempt_1",
+			"https://app.example.com/callback?code=xyz"
+		);
+	});
+
+	it("surfaces the window's own error without waiting out the ceiling", async () => {
+		bridge(() => Promise.resolve({ error: "Authorization window was closed" }));
+
+		const flow = runInteractiveAuthorization(CONFIG);
+		const settled = expect(flow).rejects.toThrow("Authorization window was closed");
+
+		await vi.advanceTimersByTimeAsync(0);
+
+		await settled;
+		expect(completeOAuth2Authorize).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/services/oauth/authorize.ts
+++ b/app/src/services/oauth/authorize.ts
@@ -22,8 +22,33 @@ export class InteractiveAuthError extends Error {}
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
+/**
+ * The embedded branch's ceiling. The main process owns the real deadline for
+ * that window and closes it with a specific error, so this only covers an IPC
+ * call that never answers at all - hence deliberately longer, so the specific
+ * error wins whenever the main process is alive to send one.
+ */
+const EMBEDDED_TIMEOUT_MS = POLL_TIMEOUT_MS + 10 * 1000;
+
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Reject with `message` if `promise` has not settled within `ms`. */
+function withDeadline<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new InteractiveAuthError(message)), ms);
+		void promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timer);
+				reject(error instanceof Error ? error : new InteractiveAuthError(String(error)));
+			}
+		);
+	});
 }
 
 /**
@@ -46,11 +71,15 @@ export async function runInteractiveAuthorization(config: OAuth2Config): Promise
 	});
 
 	if (useEmbedded) {
-		const result = await api.oauthOpenWindow({
-			authorizeUrl: started.authorizeUrl,
-			redirectUri: started.redirectUri,
-			partition: `oauth:${computeOAuth2CacheKey(config)}`,
-		});
+		const result = await withDeadline(
+			api.oauthOpenWindow({
+				authorizeUrl: started.authorizeUrl,
+				redirectUri: started.redirectUri,
+				partition: `oauth:${computeOAuth2CacheKey(config)}`,
+			}),
+			EMBEDDED_TIMEOUT_MS,
+			"Authorization timed out"
+		);
 		if ("error" in result) {
 			throw new InteractiveAuthError(result.error);
 		}


### PR DESCRIPTION
## Description

Closes #275.

**Plan.** The root cause is that `openAuthWindow` had exactly two exits - a matched callback navigation, or the user closing the window - and the window is created `show: false`, shown only on `ready-to-show`. An authorize URL that fails before first paint therefore reaches neither exit: no paint, so no visible window to close. The `loadURL` rejection that names the failure was swallowed by a catch written for the *opposite* case, where the deliberately-unreachable callback host rejects after a successful capture. `settled` was already the discriminator between those two and simply went unused. The approach: extract the settle protocol into `app/electron/oauth-window.ts` behind a transport interface (the repo's extracted-testable-core pattern, as in `save-flush.ts`), teach it the discriminator, subscribe `did-fail-load` for main-frame failures, and add a deadline for the case neither covers - a load that neither completes nor fails. The alternative I rejected was showing the window unconditionally instead of on `ready-to-show`, which makes the failure *visible* but still requires the user to close a blank window to get an error, and gives up the flicker-free show the current code buys; it treats the symptom, not the swallowed rejection.

Verified against master `a72b380`: the anchors in the issue all still hold (`oauth.ts:88` `ready-to-show`, `:91-93` the swallowing catch, `:36-37` the `settled` pair, zero `did-fail-load` hits in `app/electron/`), so no adaptation to drift was needed.

What changed:

- **`app/electron/oauth-window.ts`** (new) - the settle protocol. A load failure *before* the flow settles is the authorize page failing and is reported; the same failure after is the callback host, expected and already answered. `ERR_ABORTED` (-3) is never a failure in either direction, so it is filtered in both the `loadURL` rejection and `did-fail-load`. `AUTH_WINDOW_TIMEOUT_MS` (5 min, matching the loopback branch's patience) settles with `Authorization timed out` and destroys the window.
- **`app/electron/oauth.ts`** - now only the Electron window the flow settles for: it adapts `loadURL` / destroy / `setTimeout` into the transport and forwards navigation, `did-fail-load` (gated to `isMainFrame`), and `closed`. The redirect matcher, the `setWindowOpenHandler` deny, and the window options are unchanged.
- **`app/src/services/oauth/authorize.ts`** - the embedded branch gets the ceiling the loopback branch always had, via a small `withDeadline` helper.

**One deliberate refinement over the issue's step 1.** The issue specifies `if (!settled) finish(...)` in the `loadURL` catch. Taken literally that also fires on `ERR_ABORTED`, which Chromium reports for any superseded navigation - including an IdP page that redirects itself mid-load - so a perfectly healthy flow would die with `Could not load authorization page: ERR_ABORTED`. The same ERR_ABORTED exemption the issue asks for on `did-fail-load` (step 2) is applied to the rejection too; the deadline (step 3) is what keeps an aborted-and-never-resumed load from hanging.

**One deviation on step 3's placement.** The issue puts the deadline in `authorize.ts`, but a renderer timeout cannot close a main-process window, and the acceptance criterion requires the window to be closed. So the real deadline lives in the main process, where it destroys the window and returns a specific error; `authorize.ts` gets a backstop at `POLL_TIMEOUT_MS + 10s` for an IPC call that never answers at all, deliberately the longer of the two so the main process's specific message wins whenever it is alive to send one. A test locks that ordering.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app`:

- `pnpm test` - **280 files, 2392 tests, all passing** (was 278/2372; +2 files, +20 tests)
  - `electron/oauth-window.test.ts` - 15 tests
  - `src/services/oauth/authorize.test.ts` - 5 tests
- `pnpm type-check` - clean (all three tsconfigs, including `tsconfig.electron-test.json`)
- `pnpm lint` - clean, 0 warnings
- `prettier --check` on the five touched files - clean. No repo-wide formatting was run.

No pre-existing failures. The engine is untouched, so per CLAUDE.md's verification-scaling rule no engine build or ctest run was done - no C++ test could change colour from a TypeScript-only diff.

Every fix was mutation-checked by actually reverting it and confirming the failure, not by inspection:

| Mutation | Tests that go red |
|---|---|
| `loadURL` catch back to swallow-everything | 2 |
| `ERR_ABORTED` guards removed (both sites) | 2 |
| deadline never armed | 2 |
| `finish()` loses its `settled` guard | 3 |
| `did-fail-load` unsubscribed in `oauth.ts` | 1 (source guard) |
| `withDeadline` removed from the embedded branch | 2 |

The source-scanning guard over `oauth.ts` asserts it read something non-empty (`length > 1000`) before asserting on content, per CLAUDE.md - the empty-string-scan failure mode. No test asserts the host platform.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

On documentation: the issue predicted none was needed, and I verified it rather than assuming - `rg -ni "embedded browser|oauth.*window|openAuthWindow|useEmbeddedBrowser"` across `docs/`, `CLAUDE.md` and `app/CLAUDE.md` returns nothing, so no repo doc describes this flow at a level this change contradicts. `docs/architecture.md` is untouched.

On blast radius: `oauthOpenWindow` has exactly one renderer caller (`authorize.ts`), and its result shape (`{ callbackUrl } | { error }`) is unchanged, so `preload.ts` and `src/types/electron.d.ts` need no edit - the new failure modes arrive as `{ error }`, which that caller already handles by throwing `InteractiveAuthError`. The engine-side loopback path is untouched. `OpenAuthWindowResult` is now an alias of the flow's `AuthWindowResult` rather than a second copy of the same shape.

## Related Issues
Closes #275

Part of the 2026-08-02 Electron main-process sweep (#278), wave E1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXUUSPUV6rSJAPjbAtXeNN)_