### PR TITLE
fix(app): a corrupt window-state.json must not brick startup

### DIFF
--- a/app/electron/window-state.test.ts
+++ b/app/electron/window-state.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Window geometry must never be able to stop the app from starting.
+ *
+ * The Store is built at module scope and conf parses the file inside its
+ * constructor, so a corrupt window-state.json used to throw during main-process
+ * module evaluation - before `app.whenReady`, before any of this module's own
+ * error handling - and Electron met the user with "A JavaScript error occurred
+ * in the main process" on every launch.
+ *
+ * These drive the real electron-store against a temp userData directory rather
+ * than a mock of it, because the defect was in what the library does with a file
+ * we hand it: a mocked store would have "passed" against the bug. `electron`
+ * itself is faked, since that is the part vitest cannot provide.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BrowserWindow, Rectangle } from "electron";
+
+/** Mutable because the mock is hoisted above every test that retargets it. */
+const fake = vi.hoisted(() => ({
+	userData: "",
+	displays: [{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }],
+}));
+
+vi.mock("electron", () => {
+	const api = {
+		app: {
+			getPath: () => fake.userData,
+			getVersion: () => "0.0.0-test",
+		},
+		ipcMain: { on: () => {} },
+		shell: { openPath: async () => "" },
+		screen: { getAllDisplays: () => fake.displays },
+	};
+	// electron-store reaches for the default export; window-state.ts for the named ones.
+	return { ...api, default: api };
+});
+
+const DEFAULTS = { defaultWidth: 1400, defaultHeight: 900 };
+
+/** Seed the userData directory the next import will read, with raw file bytes. */
+function seedStore(contents?: string): void {
+	fake.userData = mkdtempSync(join(tmpdir(), "vayu-window-state-"));
+	mkdirSync(fake.userData, { recursive: true });
+	if (contents !== undefined) {
+		writeFileSync(join(fake.userData, "window-state.json"), contents);
+	}
+}
+
+function storeFile(): string {
+	return readFileSync(join(fake.userData, "window-state.json"), "utf8");
+}
+
+/**
+ * A fresh module instance, so the module-scope `new Store(...)` runs against the
+ * directory just seeded. That constructor is where the crash lived, so the
+ * import itself is under test.
+ */
+async function importWindowState() {
+	vi.resetModules();
+	return import("./window-state");
+}
+
+/** Just enough BrowserWindow for the save path: bounds, maximized, listeners. */
+function fakeWindow(options: { bounds: Rectangle; isMaximized?: boolean }) {
+	const handlers = new Map<string, () => void>();
+	const window = {
+		isMaximized: () => options.isMaximized ?? false,
+		getBounds: () => options.bounds,
+		on: (event: string, handler: () => void) => {
+			handlers.set(event, handler);
+		},
+	} as unknown as BrowserWindow;
+
+	return { window, emit: (event: string) => handlers.get(event)?.() };
+}
+
+beforeEach(() => {
+	fake.displays = [{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }];
+});
+
+afterEach(() => {
+	if (fake.userData) rmSync(fake.userData, { recursive: true, force: true });
+	fake.userData = "";
+});
+
+describe("a corrupt window-state.json", () => {
+	it("does not throw at import time", async () => {
+		seedStore('{"windowState": {"width": 12');
+
+		await expect(importWindowState()).resolves.toBeDefined();
+	});
+
+	it("loads default geometry instead of crashing the launch", async () => {
+		seedStore("this is not json at all");
+
+		const { loadWindowState } = await importWindowState();
+
+		expect(loadWindowState(DEFAULTS)).toEqual({
+			width: 1400,
+			height: 900,
+			isMaximized: false,
+		});
+	});
+
+	it("is replaced by a valid file on the next save", async () => {
+		seedStore('{"windowState": {"width": 12');
+
+		const { trackWindowState } = await importWindowState();
+		const { window, emit } = fakeWindow({ bounds: { x: 10, y: 20, width: 800, height: 600 } });
+		trackWindowState(window);
+		emit("close");
+
+		expect(JSON.parse(storeFile())).toEqual({
+			windowState: { x: 10, y: 20, width: 800, height: 600, isMaximized: false },
+		});
+	});
+});
+
+describe("malformed but syntactically valid state", () => {
+	it.each([
+		["a non-numeric width", { width: "abc", height: 900 }],
+		["a negative width", { width: -800, height: 900 }],
+		["a zero height", { width: 1200, height: 0 }],
+		["an infinite height", { width: 1200, height: Number.POSITIVE_INFINITY }],
+		["a null width", { width: null, height: 900 }],
+		["a missing pair", {}],
+	])("falls back to the defaults for %s", async (_label, saved) => {
+		seedStore(JSON.stringify({ windowState: saved }));
+
+		const { loadWindowState } = await importWindowState();
+		const state = loadWindowState(DEFAULTS);
+
+		// Whatever survived must be a usable number - this is what reaches the
+		// BrowserWindow constructor.
+		expect(Number.isFinite(state.width) && state.width > 0).toBe(true);
+		expect(Number.isFinite(state.height) && state.height > 0).toBe(true);
+		expect(state.width === 1400 || state.height === 900).toBe(true);
+	});
+
+	it("keeps the good half of the pair", async () => {
+		seedStore(JSON.stringify({ windowState: { width: "abc", height: 1000 } }));
+
+		const { loadWindowState } = await importWindowState();
+
+		expect(loadWindowState(DEFAULTS)).toEqual({
+			width: 1400,
+			height: 1000,
+			isMaximized: false,
+		});
+	});
+
+	/*
+	 * `null` rather than a string on purpose. The on-a-display check compares with
+	 * `>=` / `<`, and `null` coerces to 0 - so it lands inside every display and
+	 * sails through, while `"nope"` fails both comparisons and would be dropped
+	 * even with no validation at all. Only the null case can tell the two apart.
+	 */
+	it.each([
+		["a null axis", { x: 100, y: null }],
+		["a string axis", { x: 100, y: "nope" }],
+		["an undefined axis", { x: 100 }],
+	])("drops both axes when %s makes one unusable", async (_label, position) => {
+		seedStore(JSON.stringify({ windowState: { ...position, width: 800, height: 600 } }));
+
+		const { loadWindowState } = await importWindowState();
+		const state = loadWindowState(DEFAULTS);
+
+		expect(state.x).toBeUndefined();
+		expect(state.y).toBeUndefined();
+	});
+
+	it("coerces a non-boolean isMaximized to false", async () => {
+		seedStore(JSON.stringify({ windowState: { width: 800, height: 600, isMaximized: 1 } }));
+
+		const { loadWindowState } = await importWindowState();
+
+		expect(loadWindowState(DEFAULTS).isMaximized).toBe(false);
+	});
+
+	it.each([
+		["a string", '{"windowState": "abc"}'],
+		["an array", '{"windowState": [1, 2, 3]}'],
+		["a number", '{"windowState": 42}'],
+	])("falls back to the defaults when the state is %s", async (_label, contents) => {
+		seedStore(contents);
+
+		const { loadWindowState } = await importWindowState();
+
+		expect(loadWindowState(DEFAULTS)).toEqual({
+			width: 1400,
+			height: 900,
+			isMaximized: false,
+		});
+	});
+
+	it("does not re-persist garbage when a maximized window saves", async () => {
+		seedStore(JSON.stringify({ windowState: { width: "abc", height: -5, x: 10, y: 20 } }));
+
+		const { trackWindowState } = await importWindowState();
+		const { window, emit } = fakeWindow({
+			bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+			isMaximized: true,
+		});
+		trackWindowState(window);
+		emit("close");
+
+		expect(JSON.parse(storeFile())).toEqual({
+			windowState: { x: 10, y: 20, width: 1920, height: 1080, isMaximized: true },
+		});
+	});
+});
+
+describe("valid state", () => {
+	it("round-trips through a save and a load", async () => {
+		seedStore();
+
+		const saver = await importWindowState();
+		const { window, emit } = fakeWindow({
+			bounds: { x: 120, y: 80, width: 1024, height: 768 },
+		});
+		saver.trackWindowState(window);
+		emit("close");
+
+		const { loadWindowState } = await importWindowState();
+
+		expect(loadWindowState(DEFAULTS)).toEqual({
+			x: 120,
+			y: 80,
+			width: 1024,
+			height: 768,
+			isMaximized: false,
+		});
+	});
+
+	it("still drops a position that no longer lands on a display", async () => {
+		seedStore(JSON.stringify({ windowState: { x: 9000, y: 9000, width: 800, height: 600 } }));
+
+		const { loadWindowState } = await importWindowState();
+		const state = loadWindowState(DEFAULTS);
+
+		expect(state.x).toBeUndefined();
+		expect(state.y).toBeUndefined();
+		expect(state.width).toBe(800);
+	});
+
+	it("keeps a position that is on a secondary display", async () => {
+		fake.displays = [
+			{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } },
+			{ bounds: { x: 1920, y: 0, width: 1920, height: 1080 } },
+		];
+		seedStore(JSON.stringify({ windowState: { x: 2000, y: 40, width: 800, height: 600 } }));
+
+		const { loadWindowState } = await importWindowState();
+
+		expect(loadWindowState(DEFAULTS).x).toBe(2000);
+	});
+});
+
+describe("the module surface", () => {
+	/*
+	 * `saveWindowState` was exported with no importer anywhere - not even a test.
+	 * "Written but never read" is this codebase's most repeated defect, so the
+	 * surface is asserted rather than left to drift back open.
+	 */
+	it("exports only what main.ts calls", async () => {
+		seedStore();
+
+		const module = await importWindowState();
+
+		expect(Object.keys(module).sort()).toEqual(["loadWindowState", "trackWindowState"]);
+	});
+});

--- a/app/electron/window-state.ts
+++ b/app/electron/window-state.ts
@@ -29,7 +29,53 @@ interface WindowStateOptions {
 
 const store = new Store<{ windowState: WindowState }>({
 	name: "window-state",
+	/*
+	 * conf reads and parses the file inside its constructor, and this Store is
+	 * constructed at module scope - which main.ts imports before `app.whenReady`.
+	 * Without this flag a corrupt window-state.json throws a SyntaxError during
+	 * module evaluation, so Electron shows "A JavaScript error occurred in the
+	 * main process" and the app never starts, on every launch until the user
+	 * finds and deletes a hidden file. Starting over from an empty store is the
+	 * right failure mode for a file whose only job is window geometry.
+	 */
+	clearInvalidConfig: true,
 });
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * What `store.get` returns is JSON off disk, not a `WindowState` - the type
+ * parameter describes what we wrote, not what is there now. A hand edit or a
+ * half-finished write can leave any shape at all, and every field here is passed
+ * straight to the `BrowserWindow` constructor, so `width: "abc"` reaches Electron.
+ *
+ * Each field falls back on its own: a default is a perfectly good value for any
+ * one of them, and nothing about the geometry couples them. The exception is the
+ * position, which BrowserWindow honours as a pair or not at all - so one bad axis
+ * drops both and the window is centred.
+ */
+function sanitizeWindowState(saved: unknown, defaults: WindowState): WindowState {
+	if (typeof saved !== "object" || saved === null || Array.isArray(saved)) {
+		return { ...defaults };
+	}
+
+	const { x, y, width, height, isMaximized } = saved as Record<string, unknown>;
+
+	const state: WindowState = {
+		width: isFiniteNumber(width) && width > 0 ? width : defaults.width,
+		height: isFiniteNumber(height) && height > 0 ? height : defaults.height,
+		isMaximized: typeof isMaximized === "boolean" ? isMaximized : defaults.isMaximized,
+	};
+
+	if (isFiniteNumber(x) && isFiniteNumber(y)) {
+		state.x = x;
+		state.y = y;
+	}
+
+	return state;
+}
 
 export function loadWindowState(options: WindowStateOptions): WindowState {
 	const defaultState: WindowState = {
@@ -43,44 +89,47 @@ export function loadWindowState(options: WindowStateOptions): WindowState {
 		return defaultState;
 	}
 
+	const state = sanitizeWindowState(savedState, defaultState);
+
 	// Validate that the saved position is still on a visible display
-	if (savedState.x !== undefined && savedState.y !== undefined) {
+	if (state.x !== undefined && state.y !== undefined) {
 		const displays = screen.getAllDisplays();
 		const isOnDisplay = displays.some((display) => {
 			const { x, y, width, height } = display.bounds;
-			return (
-				savedState.x! >= x &&
-				savedState.x! < x + width &&
-				savedState.y! >= y &&
-				savedState.y! < y + height
-			);
+			return state.x! >= x && state.x! < x + width && state.y! >= y && state.y! < y + height;
 		});
 
 		if (!isOnDisplay) {
 			// Position is off-screen, reset to center
-			delete savedState.x;
-			delete savedState.y;
+			delete state.x;
+			delete state.y;
 		}
 	}
 
-	return { ...defaultState, ...savedState };
+	return state;
 }
 
-export function saveWindowState(window: BrowserWindow): void {
+function saveWindowState(window: BrowserWindow): void {
 	const isMaximized = window.isMaximized();
 	const bounds = window.getBounds();
 
 	let state: WindowState;
 
 	if (isMaximized) {
-		// When maximized, preserve the previous non-maximized bounds
-		const existingState = store.get("windowState");
+		// When maximized, preserve the previous non-maximized bounds. They come off
+		// disk, so they get the same scrubbing a load does - otherwise a maximize
+		// re-persists whatever garbage was already in the file.
+		const existingState = sanitizeWindowState(store.get("windowState"), {
+			width: bounds.width,
+			height: bounds.height,
+			isMaximized: true,
+		});
 		state = {
 			isMaximized: true,
-			x: existingState?.x,
-			y: existingState?.y,
-			width: existingState?.width ?? bounds.width,
-			height: existingState?.height ?? bounds.height,
+			x: existingState.x,
+			y: existingState.y,
+			width: existingState.width,
+			height: existingState.height,
 		};
 	} else {
 		// Save current bounds when not maximized

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -19,7 +19,15 @@ export default defineConfig({
 		include: ["src/**/*.test.{ts,tsx}", "electron/**/*.test.ts"],
 		server: {
 			deps: {
-				inline: ["graphql-language-service"],
+				/*
+				 * `electron-store` is inlined so that `vi.mock("electron")` reaches it.
+				 * An externalised dependency imports `electron` through Node directly,
+				 * missing the mock registry entirely - and the real package throws
+				 * "Electron failed to install correctly" outside an Electron runtime.
+				 * window-state.test.ts drives the real store against a temp directory,
+				 * which is the only way to test what the library does with a corrupt file.
+				 */
+				inline: ["graphql-language-service", "electron-store"],
 			},
 		},
 	},


### PR DESCRIPTION
## Description

Closes #276.

**Plan.** The root cause is a construction-order fact, not a missing try/catch: the `electron-store` `Store` is built at module scope (`window-state.ts:30`), `main.ts:13` imports it before `app.whenReady`, and conf 15.1.0 reads *and parses* the file inside its constructor - `#initializeStore` opens with `const fileStore = this.store`. With conf's default `clearInvalidConfig: false` a corrupt `window-state.json` throws a `SyntaxError` during main-process module evaluation, so Electron shows "A JavaScript error occurred in the main process" and the app never starts, recurring every launch until the user finds and deletes a hidden file. `loadWindowState`'s own error handling is downstream of the throw and never runs. The approach is the issue's: pass `clearInvalidConfig: true`, the primitive conf provides for exactly this (verified in `conf/dist/source/index.js:226-231` - a `SyntaxError` becomes an empty store), plus shape validation on read, plus dropping the dead `export`. The alternative I rejected is the issue's own stated fallback, lazy construction inside `loadWindowState` under try/catch: it hand-rolls what the library already does, leaves the module-scope-throw shape available to the next edit, and per CLAUDE.md a hand-rolled copy of a primitive never receives the primitive's fixes.

Verified against master `a72b380`: every anchor in the issue still holds (`window-state.ts:30-32` module-scope `Store` with no `clearInvalidConfig`, `main.ts:13` import, `:102`/`:151` the two real callers, `saveWindowState` exported at `:69` with zero importers), so no adaptation to drift was needed.

What changed, all in `app/electron/window-state.ts`:

- **`clearInvalidConfig: true`** on the `Store`. A corrupt file yields an empty store; the file itself is left alone until the next save rewrites it, which is conf's behaviour and what the acceptance criterion describes.
- **`sanitizeWindowState`** - the type parameter on `Store` describes what we *wrote*, not what is on disk, and every field is passed to the `BrowserWindow` constructor, so `width: "abc"` reached Electron. Each field falls back independently (a default is a good value for any one of them, and nothing couples them); the position is the exception, honoured by `BrowserWindow` as a pair or not at all, so one bad axis drops both and the window centres. The existing on-a-visible-display check is unchanged and still runs after.
- **`saveWindowState` is no longer exported.** `pnpm type-check` green proves no external caller existed.

**One addition beyond the issue's three steps.** The maximized branch of `saveWindowState` reads the previous bounds back off disk and writes them out again, so it could re-persist the same garbage `loadWindowState` now scrubs. It runs through the same `sanitizeWindowState` with the live bounds as its fallback - this replaces the old `??` chain rather than adding to it, and it is what makes "malformed state cannot reach the constructor" hold across a maximize/restart cycle instead of only on the first read. Behaviour for valid data is identical.

**One change outside `window-state.ts`.** `vitest.config.ts` gains `electron-store` in `server.deps.inline`. Externalised dependencies import `electron` through Node directly and miss `vi.mock("electron")` entirely - the real package then throws "Electron failed to install correctly" outside an Electron runtime. Inlining it is what lets the test drive the **real** electron-store against a temp `userData` directory, which matters here: the defect is in what the library does with a file we hand it, so a mocked store would have passed against the bug. The reason is recorded in a comment at the config.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app`:

- `pnpm test` - **279 files, 2394 tests, all passing** (was 278/2372 on `a72b380`; +1 file, +22 tests)
  - `electron/window-state.test.ts` - 22 tests, the first coverage this module has ever had
- `pnpm type-check` - clean (all three tsconfigs, including `tsconfig.electron-test.json`)
- `pnpm lint` - clean, 0 warnings
- `prettier --check` on the three touched files - clean. No repo-wide formatting was run.

No pre-existing failures. The engine is untouched, so per CLAUDE.md's verification-scaling rule no engine build or ctest run was done - no C++ test could change colour from a TypeScript-only diff.

Every fix was mutation-checked by reverting it and running the suite, not by inspection:

| Mutation | Tests that go red |
|---|---|
| `clearInvalidConfig` removed | 3 |
| `sanitizeWindowState` replaced by the old `{ ...defaults, ...saved }` spread | 11 |
| `saveWindowState` exported again | 1 |
| maximized-save reads the store unsanitized | 1 |

One test needed strengthening *because* of that check. The dropped-axis case originally used `y: "nope"`, which the pre-existing on-a-display check already rejected (`"nope"` fails both comparisons), so it stayed green under the mutation and was testing nothing. It is now `y: null`, which coerces to `0`, lands inside every display and sails through unvalidated - the only variant that can tell the fix from its absence. The reason is in a comment above the test so it does not get "simplified" back.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

On documentation: the issue predicted none was needed and I verified rather than assumed - `grep -rni "window-state|window state|windowState|window geometry"` across `docs/`, `CLAUDE.md` and `app/CLAUDE.md` returns nothing. No doc describes window-state persistence, so none is contradicted by this change.

On blast radius: `loadWindowState` and `trackWindowState` have exactly one caller each (`main.ts:102`, `:151`) and their signatures and return shape are unchanged - a valid saved state loads to the same object it did before, so `createWindow` needs no edit. There is no renderer reader of window state (verified across `app/src`). The only other reference to this module anywhere is a comment in `electron/mcp/store.ts:28` pointing at it as precedent for `userData` resolution, which still describes it accurately.

## Related Issues
Closes #276

Part of the 2026-08-02 Electron main-process sweep (#278), wave E1. Independent of the in-flight #275 / PR #279 - no file overlap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhNu89mgwBoS4kgWoeJc1g)_