### PR TITLE
test(app): scan LINUX_DATA_HOME in the appimage-stamp layout guard

### DIFF
--- a/app/electron/appimage-stamp.layout.test.ts
+++ b/app/electron/appimage-stamp.layout.test.ts
@@ -15,7 +15,11 @@
  * nobody connects to the rename that caused it.
  *
  * So the duplication is guarded rather than trusted. This reads the shell
- * definitions and asserts the TypeScript computes the same paths from them.
+ * definitions - including `LINUX_DATA_HOME`, the root the rest hang off - and
+ * asserts the TypeScript computes the same paths from them. Nothing here may
+ * hardcode a path segment the shell also spells: a constant the test invents is
+ * a hole in the guard, since both sides of the assertion would keep using it
+ * after `install.sh` moved on.
  */
 
 import { describe, expect, it } from "vitest";
@@ -34,40 +38,131 @@ function shellValue(name: string): string {
 	return match[1];
 }
 
-/** Expand the handful of shell variables these definitions actually use. */
+/**
+ * Expand the shell syntax these definitions actually use: `$NAME`, `${NAME}`
+ * and `${NAME:-default}`, the last nestable because `LINUX_DATA_HOME` nests it
+ * (`${XDG_DATA_HOME:-${HOME:-}/.local/share}`). An unset name expands empty, as
+ * the shell does - a definition that leans on a variable this test does not
+ * supply collapses to a path `resolveStampPath` cannot match, which fails.
+ */
 function expand(value: string, vars: Record<string, string>): string {
-	return value.replace(/\$\{?(\w+)\}?/g, (whole, name: string) =>
-		name in vars ? vars[name] : whole
-	);
+	let out = "";
+	let i = 0;
+	while (i < value.length) {
+		const dollar = value.indexOf("$", i);
+		if (dollar === -1) return out + value.slice(i);
+		out += value.slice(i, dollar);
+
+		if (value[dollar + 1] === "{") {
+			const close = closingBrace(value, dollar + 1);
+			out += expandBraced(value.slice(dollar + 2, close), vars);
+			i = close + 1;
+			continue;
+		}
+
+		const bare = /^\w+/.exec(value.slice(dollar + 1));
+		if (!bare) throw new Error(`install.sh uses shell syntax this test cannot read: ${value}`);
+		out += vars[bare[0]] ?? "";
+		i = dollar + 1 + bare[0].length;
+	}
+	return out;
 }
 
-describe("the Linux layout, as install.sh defines it", () => {
-	const home = "/home/tester";
-	const vars: Record<string, string> = { APP_NAME: "Vayu" };
-	vars.LINUX_DATA_HOME = `${home}/.local/share`;
-	vars.LINUX_APP_DIR = expand(shellValue("LINUX_APP_DIR"), vars);
-	vars.LINUX_APP_BIN = expand(shellValue("LINUX_APP_BIN"), vars);
+/** The index of the `}` closing the `{` at `open`, counting nested braces. */
+function closingBrace(value: string, open: number): number {
+	let depth = 0;
+	for (let i = open; i < value.length; i++) {
+		if (value[i] === "{") depth++;
+		else if (value[i] === "}" && --depth === 0) return i;
+	}
+	throw new Error(`unbalanced \${...} in install.sh: ${value}`);
+}
 
-	it("scans a definition rather than nothing", () => {
-		// Without this the regexes above could quietly match an empty string and
+/** The inside of a `${...}`, which is either a name or `name:-default`. */
+function expandBraced(body: string, vars: Record<string, string>): string {
+	let depth = 0;
+	for (let i = 0; i < body.length; i++) {
+		if (body[i] === "{") depth++;
+		else if (body[i] === "}") depth--;
+		else if (depth === 0 && body[i] === ":" && body[i + 1] === "-") {
+			const set = vars[body.slice(0, i)];
+			// `:-` takes the default when unset *or* empty, which is why
+			// `${HOME:-}` in install.sh yields "" rather than an unexpanded name.
+			return set ? set : expand(body.slice(i + 2), vars);
+		}
+	}
+	return vars[body] ?? "";
+}
+
+/** Every path in the Linux layout, as install.sh computes it for one shell env. */
+function layoutFor(shellEnv: Record<string, string>) {
+	const vars: Record<string, string> = { ...shellEnv };
+	for (const name of [
+		"LINUX_DATA_HOME",
+		"LINUX_APP_DIR",
+		"LINUX_APP_BIN",
+		"LINUX_VERSION_FILE",
+	]) {
+		vars[name] = expand(shellValue(name), vars);
+	}
+	return vars;
+}
+
+const home = "/home/tester";
+const xdg = "/home/tester/xdg-data";
+
+/**
+ * Both halves of `LINUX_DATA_HOME`'s `${XDG_DATA_HOME:-...}`. Each case names
+ * the shell environment and the `resolveStampPath` environment together, so a
+ * scenario cannot describe one side of the duplication and not the other.
+ */
+const cases = [
+	{
+		what: "with XDG_DATA_HOME unset, so the layout falls back to $HOME",
+		shell: { APP_NAME: "Vayu", HOME: home },
+		app: { platform: "linux", home },
+		expectedDataHome: `${home}/.local/share`,
+	},
+	{
+		what: "with XDG_DATA_HOME set, which the installer honours",
+		shell: { APP_NAME: "Vayu", HOME: home, XDG_DATA_HOME: xdg },
+		app: { platform: "linux", home, xdgDataHome: xdg },
+		expectedDataHome: xdg,
+	},
+] as const;
+
+describe("the Linux layout, as install.sh defines it", () => {
+	it("scans definitions rather than nothing", () => {
+		// Without this the regexes above could quietly match empty strings and
 		// every assertion below would compare "" to "" and pass.
 		expect(installer.length).toBeGreaterThan(1000);
-		expect(vars.LINUX_APP_DIR).toContain("/vayu");
-		expect(vars.LINUX_APP_BIN).toContain("Vayu.AppImage");
+		expect(shellValue("LINUX_DATA_HOME")).toContain("XDG_DATA_HOME");
+		const linux = layoutFor(cases[0].shell);
+		expect(linux.LINUX_DATA_HOME).toBe(`${home}/.local/share`);
+		expect(linux.LINUX_APP_DIR).toContain("/vayu");
+		expect(linux.LINUX_APP_BIN).toContain("Vayu.AppImage");
+		expect(linux.LINUX_VERSION_FILE).toContain("/vayu/");
 	});
 
-	it("puts the AppImage where the app expects to find itself", () => {
-		// resolveStampPath only answers for the managed install, so agreeing on
-		// this path is what makes the stamp get written at all.
-		expect(
-			resolveStampPath({ platform: "linux", appImagePath: vars.LINUX_APP_BIN, home })
-		).not.toBeNull();
-	});
+	describe.each(cases)("$what", ({ shell, app, expectedDataHome }) => {
+		const linux = layoutFor(shell);
 
-	it("puts the version stamp where the app writes it", () => {
-		const stamp = expand(shellValue("LINUX_VERSION_FILE"), vars);
-		expect(
-			resolveStampPath({ platform: "linux", appImagePath: vars.LINUX_APP_BIN, home })
-		).toBe(stamp);
+		it("roots the layout where the app roots it", () => {
+			// The one path the test used to invent. Scanning it is what makes the
+			// two assertions below able to fail when install.sh moves alone.
+			expect(linux.LINUX_DATA_HOME).toBe(expectedDataHome);
+		});
+
+		it("puts the AppImage where the app expects to find itself", () => {
+			// resolveStampPath only answers for the managed install, so agreeing on
+			// this path is what makes the stamp get written at all.
+			expect(resolveStampPath({ ...app, appImagePath: linux.LINUX_APP_BIN })).not.toBeNull();
+		});
+
+		it("puts the version stamp where the app writes it", () => {
+			expect(resolveStampPath({ ...app, appImagePath: linux.LINUX_APP_BIN })).toBe(
+				linux.LINUX_VERSION_FILE
+			);
+		});
 	});
 });


### PR DESCRIPTION
## Description

`appimage-stamp.layout.test.ts` guards the "move one, move both" duplication between `install.sh` and `appimage-stamp.ts`, but it hardcoded the root of the very layout it guards: `vars.LINUX_DATA_HOME = ${home}/.local/share`, invented by the test, instead of scanned from `install.sh:34` (`LINUX_DATA_HOME="${XDG_DATA_HOME:-${HOME:-}/.local/share}"`). Every assertion then derived both of its sides from that constant, so a change to the installer's fallback left the file green while the app stamped a path the installer no longer reads - the un-attributable redundant ~160MB download this file exists to prevent.

**Plan.** Root cause: the guard scanned the three leaf definitions but not the root they hang off, because the test's `expand()` could not read `${NAME:-default}` and `LINUX_DATA_HOME` is written that way (nested, twice). Approach: scan it with the existing `shellValue()` helper, teach `expand()` the `${NAME:-default}` form with brace-depth-aware nesting, and drive `resolveStampPath`'s `home` / `xdgDataHome` inputs from the scanned value - so the assertion fails when either side moves alone. Both halves of the fallback run as separate cases (`describe.each`), pairing the shell environment and the `resolveStampPath` environment in one object so a case cannot describe one side of the duplication and not the other; that also makes a change to *XDG handling* (not just the path) fail. Rejected alternative: the issue's option of asserting the raw string equals the exact known pattern. It fails on any edit to that line including a semantically identical one, and it still never couples the scanned value to what `resolveStampPath` is handed - a brittle tripwire where the expansion gives real coupling.

Verified against master `a72b380` before writing: the problem exists exactly as described, and `install.sh:34-47` and `appimage-stamp.ts:62` still agree, so no production change was needed. Blast radius: `resolveStampPath` has two callers - `stampInstalledVersion` (same file) and `main.ts:686`, which passes both `process.env.HOME` and `process.env.XDG_DATA_HOME`, so both scanned cases are paths the app really takes. Test-only diff; `appimage-stamp.ts` and `install.sh` are untouched.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Test (closes a hole in an existing source-scanning guard)

## Testing

Mutation-checked in three directions, each restored afterwards:

| Mutation | New guard | Old guard |
|---|---|---|
| `install.sh` fallback `.local/share` -> `.local/share2` | 4 failed / 3 passed | **3 passed (missed it)** |
| `install.sh` drops `${XDG_DATA_HOME:-...}` | 4 failed / 3 passed | - |
| `appimage-stamp.ts:62` `.local/share` -> `.local/state` | 2 failed / 5 passed | - |

The first row is the hole this closes: the previous version of the file stayed green.

Acceptance commands, all green on the final tree:

- `cd app && pnpm test` - **278 files, 2376 tests passed** (112s)
- `cd app && pnpm type-check` - clean
- `cd app && pnpm lint` - clean (0 errors, 0 warnings)
- `npx prettier --check electron/appimage-stamp.layout.test.ts` - clean (only the touched file was formatted; it was prettier-clean before)

`appimage-stamp.test.ts`'s behavioural suite is unchanged and green. No engine change, so no engine build or ctest run - no C++ test could change colour. Docs: none, per the issue.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation (none required - test-only change)

## Related Issues
Closes #277

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZzJgcDPzunSyLgHRY8M9g)_