### PR TITLE
fix(app): own the engine we adopt, and let only one Vayu drive it

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -35,6 +35,15 @@ export const ENGINE_HEALTH_POLL_INTERVAL_MS = 500;
 export const ENGINE_HEALTH_REQUEST_TIMEOUT_MS = 2000;
 export const ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS = 2000;
 export const ENGINE_GRACEFUL_EXIT_TIMEOUT_MS = 5000;
+/**
+ * Poll interval while waiting for an *adopted* engine to exit.
+ *
+ * A spawned engine reports its own exit through the child's `exit` event; an
+ * adopted one is not our child, so the only way to learn it is gone is to keep
+ * asking the OS. Kept well under the graceful ceiling so the verified kill that
+ * follows a stuck engine still happens inside the same quit.
+ */
+export const ENGINE_EXIT_POLL_INTERVAL_MS = 100;
 export const ENGINE_RESTART_MAX_RETRIES = 3;
 export const ENGINE_RESTART_BASE_DELAY_MS = 1000;
 /** Pause between stop and start during restart so the port is released. */

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -14,6 +14,7 @@ import { loadWindowState, trackWindowState } from "./window-state.js";
 import { initAutoUpdater, checkForUpdatesNow } from "./updater.js";
 import { installQuitOnSignal } from "./quit-signals.js";
 import { createSaveFlusher } from "./save-flush.js";
+import { createQuitShutdown } from "./quit-shutdown.js";
 import { stampInstalledVersion } from "./appimage-stamp.js";
 import {
 	VayuMcpService,
@@ -422,7 +423,10 @@ async function stopMcp() {
 async function stopEngine() {
 	if (engineSidecar) {
 		try {
-			await engineSidecar.stop();
+			// `shutdown()`, not `stop()`: the app is going away, so a restart in
+			// flight has to be waited out and no further one allowed - otherwise
+			// the engine it spawns outlives the process that would kill it.
+			await engineSidecar.shutdown();
 			console.log("[Main] Engine stopped successfully");
 		} catch (error) {
 			console.error("[Main] Error stopping engine:", error);
@@ -678,7 +682,38 @@ function setupIpcHandlers() {
 	});
 }
 
+/**
+ * Vayu is a single-instance app, and the engine is why.
+ *
+ * The engine binds one fixed port and owns one SQLite database, so a second
+ * launch does not get a second backend - it adopts the first one's. Both UIs
+ * then share one engine with nothing to say so, and the first to quit POSTs
+ * `/shutdown`, which the engine obeys unconditionally: the survivor's backend
+ * dies under it mid-session, its pending saves go into a dead port, and its
+ * only surface is the dock dot turning grey.
+ *
+ * Losing the lock means another instance is already up, so hand the user over
+ * to it and leave. `second-instance` fires in the instance that holds the lock.
+ */
+const isPrimaryInstance = app.requestSingleInstanceLock();
+
+if (!isPrimaryInstance) {
+	console.log("[Main] Another Vayu instance is already running; focusing it and exiting.");
+	app.quit();
+} else {
+	app.on("second-instance", () => {
+		if (!mainWindow) return;
+		if (mainWindow.isMinimized()) mainWindow.restore();
+		mainWindow.show();
+		mainWindow.focus();
+	});
+}
+
 app.whenReady().then(async () => {
+	// A losing second instance is on its way out; do not start an engine, a
+	// server or a window on top of the instance that owns them.
+	if (!isPrimaryInstance) return;
+
 	// Setup IPC handlers first
 	setupIpcHandlers();
 
@@ -748,6 +783,22 @@ app.on("window-all-closed", () => {
 // second pass once rather than starting two engine shutdowns.
 const resumeQuit = () => app.quit();
 
+// Second pass of the quit: stop the children exactly once. See quit-shutdown.ts
+// for why "has a shutdown started" is the guard rather than "is the engine
+// still running" - the latter only clears after the awaits, so a quit landing
+// mid-shutdown started a second one on top of it.
+const quitShutdown = createQuitShutdown({
+	hasWork: () => Boolean((engineSidecar && engineSidecar.isRunning()) || mcpService),
+	stop: async () => {
+		await stopMcp();
+		await stopEngine();
+	},
+	quit: () => app.quit(),
+	defer: (run) => {
+		setImmediate(run);
+	},
+});
+
 // Ensure saves are flushed and engine is stopped when the app quits
 app.on("before-quit", (event) => {
 	// First pass: ask the renderer to flush pending saves. Quit resumes as
@@ -761,16 +812,7 @@ app.on("before-quit", (event) => {
 		return;
 	}
 
-	// Second pass: stop the MCP server and engine before actually quitting
-	if ((engineSidecar && engineSidecar.isRunning()) || mcpService) {
-		event.preventDefault();
-		(async () => {
-			await stopMcp();
-			await stopEngine();
-			// Continue with quit process
-			setImmediate(() => app.quit());
-		})();
-	}
+	quitShutdown.handleQuit(event);
 });
 
 // A signal is how anything outside the UI asks Vayu to stop, and Node's default

--- a/app/electron/quit-shutdown.test.ts
+++ b/app/electron/quit-shutdown.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The engine and the MCP server must be stopped once, and the app must still
+ * exit.
+ *
+ * Both halves are load-bearing and they pull against each other. The guard used
+ * to be "is the engine still running", state that clears only after the awaits,
+ * so a `before-quit` landing mid-shutdown ran a second `stopMcp()`/`stopEngine()`
+ * on top of the first - reachable with no second gesture, because an X click
+ * closes the window and `window-all-closed` fires a quit into the shutdown a
+ * prior quit already began. Make the guard latch instead and the opposite
+ * failure appears: the shutdown's own resumed quit gets deferred by the latch
+ * and the app never exits.
+ *
+ * Driven through a fake transport rather than Electron, which is the whole
+ * reason this lives outside main.ts.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createQuitShutdown, type QuitShutdownTransport } from "./quit-shutdown";
+
+/** A quit event, plus the children and the deferred quit main would have had. */
+function fakeTransport(options: { hasWork?: boolean } = {}) {
+	const { hasWork = true } = options;
+	let releaseStop: (() => void) | null = null;
+	const stop = vi.fn(
+		() =>
+			new Promise<void>((resolve) => {
+				releaseStop = resolve;
+			})
+	);
+	const quit = vi.fn();
+	const deferred: Array<() => void> = [];
+
+	const transport: QuitShutdownTransport = {
+		hasWork: () => hasWork,
+		stop,
+		quit,
+		defer: (run) => {
+			deferred.push(run);
+		},
+	};
+
+	return {
+		transport,
+		stop,
+		quit,
+		/** The children finished stopping. */
+		finishStop: async () => {
+			releaseStop?.();
+			// Let the `finally` that marks the shutdown done run.
+			await Promise.resolve();
+			await Promise.resolve();
+		},
+		/** `setImmediate` fired. */
+		runDeferred: () => deferred.splice(0).forEach((run) => run()),
+	};
+}
+
+function quitEvent() {
+	return { preventDefault: vi.fn() };
+}
+
+describe("createQuitShutdown", () => {
+	it("defers the first quit and stops the children", () => {
+		const fake = fakeTransport();
+		const shutdown = createQuitShutdown(fake.transport);
+
+		const event = quitEvent();
+		shutdown.handleQuit(event);
+
+		expect(event.preventDefault).toHaveBeenCalledOnce();
+		expect(fake.stop).toHaveBeenCalledOnce();
+		expect(shutdown.hasStopped()).toBe(false);
+	});
+
+	it("does not start a second shutdown for a quit that lands mid-shutdown", async () => {
+		const fake = fakeTransport();
+		const shutdown = createQuitShutdown(fake.transport);
+
+		shutdown.handleQuit(quitEvent());
+
+		// The X-click path: window-all-closed fires app.quit() while the first
+		// shutdown is still awaiting its children.
+		const second = quitEvent();
+		shutdown.handleQuit(second);
+
+		expect(fake.stop).toHaveBeenCalledOnce();
+		// Held, not let through - exiting here would leave an adopted engine up.
+		expect(second.preventDefault).toHaveBeenCalledOnce();
+		expect(fake.quit).not.toHaveBeenCalled();
+
+		await fake.finishStop();
+		fake.runDeferred();
+		expect(fake.quit).toHaveBeenCalledOnce();
+	});
+
+	it("lets the quit it resumes through, so the app actually exits", async () => {
+		const fake = fakeTransport();
+		const shutdown = createQuitShutdown(fake.transport);
+
+		shutdown.handleQuit(quitEvent());
+		await fake.finishStop();
+		expect(shutdown.hasStopped()).toBe(true);
+
+		const resumed = quitEvent();
+		shutdown.handleQuit(resumed);
+		expect(resumed.preventDefault).not.toHaveBeenCalled();
+		expect(fake.stop).toHaveBeenCalledOnce();
+	});
+
+	it("falls through, without latching, when there is nothing to stop yet", () => {
+		let hasWork = false;
+		const stop = vi.fn().mockResolvedValue(undefined);
+		const shutdown = createQuitShutdown({
+			hasWork: () => hasWork,
+			stop,
+			quit: vi.fn(),
+			defer: () => {},
+		});
+
+		const early = quitEvent();
+		shutdown.handleQuit(early);
+
+		expect(early.preventDefault).not.toHaveBeenCalled();
+		expect(stop).not.toHaveBeenCalled();
+
+		// The engine finished coming up after that quit was let through. A later
+		// quit must still stop it rather than read a latch set while it was down.
+		hasWork = true;
+		const later = quitEvent();
+		shutdown.handleQuit(later);
+
+		expect(later.preventDefault).toHaveBeenCalledOnce();
+		expect(stop).toHaveBeenCalledOnce();
+	});
+
+	it("still quits when stopping the children throws", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const stop = vi.fn().mockRejectedValue(new Error("engine wedged"));
+		const quit = vi.fn();
+		const deferred: Array<() => void> = [];
+		const shutdown = createQuitShutdown({
+			hasWork: () => true,
+			stop,
+			quit,
+			defer: (run) => {
+				deferred.push(run);
+			},
+		});
+
+		shutdown.handleQuit(quitEvent());
+		await Promise.resolve();
+		await Promise.resolve();
+		deferred.splice(0).forEach((run) => run());
+
+		expect(quit).toHaveBeenCalledOnce();
+		expect(shutdown.hasStopped()).toBe(true);
+	});
+});
+
+describe("main.ts wiring", () => {
+	// main.ts creates windows and starts the engine at import time, so the wiring
+	// itself can only be read. Everything above this line would still pass with
+	// main.ts calling the old inline shutdown, which is the bug being fixed.
+	const main = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.ts"), "utf8");
+
+	it("reads a non-empty main.ts", () => {
+		expect(main.length).toBeGreaterThan(1000);
+	});
+
+	it("routes before-quit's second pass through the coordinator", () => {
+		expect(main).toContain("createQuitShutdown(");
+		expect(main).toContain("quitShutdown.handleQuit(event)");
+		// The old guard, which re-entered its own in-flight shutdown.
+		expect(main).not.toContain(
+			"if ((engineSidecar && engineSidecar.isRunning()) || mcpService)"
+		);
+	});
+
+	it("takes the single-instance lock and focuses the window a second launch wanted", () => {
+		expect(main).toContain("app.requestSingleInstanceLock()");
+		expect(main).toContain('app.on("second-instance"');
+		expect(main).toMatch(/second-instance[\s\S]{0,400}mainWindow\.focus\(\)/);
+	});
+
+	it("shuts the engine down for good on quit rather than merely stopping it", () => {
+		expect(main).toContain("engineSidecar.shutdown()");
+	});
+});

--- a/app/electron/quit-shutdown.ts
+++ b/app/electron/quit-shutdown.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Stopping the engine and the MCP server exactly once on the way out.
+ *
+ * `before-quit`'s second pass defers the quit, stops both children, and quits
+ * again when they are down. Its guard used to be "is the engine still running",
+ * which is state that only clears *after* those awaits - so a second
+ * `before-quit` arriving mid-shutdown started a second `stopMcp()`/`stopEngine()`
+ * on top of the first. No extra user gesture is needed to get there: an X click
+ * flushes and closes the window, `window-all-closed` fires `app.quit()`, and
+ * that quit can land inside a shutdown a prior quit already began.
+ *
+ * So the guard has to be "has a shutdown started", which is three states rather
+ * than two - a quit arriving *during* the shutdown must be deferred (letting it
+ * through exits the app with the engine half-stopped, and an adopted engine
+ * would survive as an orphan), while the quit the shutdown itself resumes must
+ * fall straight through, or the app never exits at all.
+ *
+ * Kept out of main.ts so it can be tested - main.ts creates windows and starts
+ * the engine at import time, which no unit test can do.
+ */
+
+/** The slice of main.ts this needs, so a test can pass a fake. */
+export interface QuitShutdownTransport {
+	/** Whether anything still needs stopping (engine, MCP server). */
+	hasWork: () => boolean;
+	/** Stop everything. Rejections are absorbed - a quit still has to finish. */
+	stop: () => Promise<void>;
+	/** Resume the quit once the children are down. */
+	quit: () => void;
+	/**
+	 * Defer the resumed quit past the current turn (`setImmediate` in main), so
+	 * `quit()` is not re-entered from inside the handler that stopped for it.
+	 */
+	defer: (run: () => void) => void;
+}
+
+export interface QuitShutdown {
+	/**
+	 * Handle a `before-quit` whose save flush has already settled. Prevents the
+	 * default while there is still something to stop.
+	 */
+	handleQuit: (event: { preventDefault: () => void }) => void;
+	/** Whether a shutdown has run to completion. Read by tests, not by main. */
+	hasStopped: () => boolean;
+}
+
+export function createQuitShutdown(transport: QuitShutdownTransport): QuitShutdown {
+	let state: "idle" | "stopping" | "stopped" = "idle";
+
+	return {
+		hasStopped: () => state === "stopped",
+
+		handleQuit: (event) => {
+			// The shutdown is over: this is either the quit it resumed, or a later
+			// one. Either way there is nothing left to stop.
+			if (state === "stopped") return;
+
+			// A shutdown is in flight. Hold this quit - the one in flight resumes
+			// it - rather than exiting on top of a half-stopped engine.
+			if (state === "stopping") {
+				event.preventDefault();
+				return;
+			}
+
+			// Nothing to stop *yet* - the engine may still be coming up. Let this
+			// quit through without latching, so a later one still finds work.
+			if (!transport.hasWork()) return;
+
+			state = "stopping";
+			event.preventDefault();
+			void (async () => {
+				try {
+					await transport.stop();
+				} catch (error) {
+					// A child that will not stop cannot hold the app open - and an
+					// unhandled rejection here would take down the quit as well.
+					console.error("[Main] Error during shutdown, quitting anyway:", error);
+				} finally {
+					// Marked before the resumed quit, so the `before-quit` it fires
+					// falls through instead of deferring itself forever.
+					state = "stopped";
+					transport.defer(transport.quit);
+				}
+			})();
+		},
+	};
+}

--- a/app/electron/sidecar.test.ts
+++ b/app/electron/sidecar.test.ts
@@ -55,11 +55,29 @@ class FakeChild extends EventEmitter {
 	readonly stderr = null;
 	readonly signals: string[] = [];
 
+	/** A wedged engine: only SIGKILL gets it, which is what the grace period is for. */
+	ignoresSigterm = false;
+
 	kill(signal?: string) {
-		this.signals.push(signal ?? "SIGTERM");
-		queueMicrotask(() => this.emit("exit", null, signal ?? "SIGTERM"));
+		const sent = signal ?? "SIGTERM";
+		this.signals.push(sent);
+		if (sent !== "SIGKILL" && this.ignoresSigterm) return true;
+		this.exit();
 		return true;
 	}
+
+	exit() {
+		queueMicrotask(() => this.emit("exit", null, null));
+	}
+}
+
+/**
+ * The stop path forks on the host platform - Windows has no SIGTERM to send, so
+ * the HTTP shutdown is its only graceful route there. Both branches are driven
+ * by stubbing the input rather than by trusting whichever CI runner shows up.
+ */
+function stubPlatform(platform: NodeJS.Platform) {
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
 }
 
 /**
@@ -226,8 +244,11 @@ describe("EngineSidecar - adoption", () => {
 });
 
 describe("EngineSidecar - spawned engine", () => {
-	it("spawns when nothing is on the port, and stops what it spawned", async () => {
-		const { system, state } = fakeSystem();
+	const realPlatform = process.platform;
+	afterEach(() => stubPlatform(realPlatform));
+
+	it("spawns when nothing is on the port", async () => {
+		const { system } = fakeSystem();
 		const sidecar = new EngineSidecar(TEST_PORT, system);
 
 		await sidecar.start();
@@ -235,10 +256,51 @@ describe("EngineSidecar - spawned engine", () => {
 		expect(system.spawnEngine).toHaveBeenCalledOnce();
 		expect(vi.mocked(system.spawnEngine).mock.calls[0][1]).toContain(String(TEST_PORT));
 		expect(sidecar.isRunning()).toBe(true);
+	});
+
+	it("stops what it spawned with SIGTERM off Windows", async () => {
+		stubPlatform("linux");
+		const { system, state } = fakeSystem();
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
 
 		await sidecar.stop();
 
-		expect(state.spawned[0].signals.length).toBeGreaterThan(0);
+		expect(state.spawned[0].signals).toContain("SIGTERM");
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("stops what it spawned on Windows, where the HTTP shutdown is the only graceful path", async () => {
+		stubPlatform("win32");
+		const { system, state } = fakeSystem();
+		// A real engine exits once it has accepted POST /shutdown.
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.spawned[0]?.exit();
+			state.healthy = false;
+			return true;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		await sidecar.stop();
+
+		// SIGTERM is not a request on Windows, it is an immediate kill - so the
+		// stop path must not reach for one, and must not sit out the grace period
+		// waiting for an engine that already left.
+		expect(state.spawned[0].signals).toEqual([]);
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("force-kills a spawned engine that ignores the graceful shutdown", async () => {
+		stubPlatform("linux");
+		const { system, state } = fakeSystem();
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+		state.spawned[0].ignoresSigterm = true;
+
+		await sidecar.stop();
+
+		expect(state.spawned[0].signals).toEqual(["SIGTERM", "SIGKILL"]);
 		expect(sidecar.isRunning()).toBe(false);
 	});
 });

--- a/app/electron/sidecar.test.ts
+++ b/app/electron/sidecar.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * An engine the app did not spawn is still the app's engine.
+ *
+ * `start()` has two paths that attach to an engine already on the port - the
+ * lock file and the health probe - and both used to return with `this.process`
+ * still null, while every other method keyed off exactly that. So a healthy
+ * adopted engine reported `isRunning() === false`, `stop()` returned early and
+ * left it running past quit (re-adopted, and orphaned again, on every launch),
+ * and `restart()` "restarted" it by stopping nothing, waiting 500ms and
+ * re-adopting the same process - reporting success, so Settings cleared its
+ * restart-required banner while the config change never took effect.
+ *
+ * The lifecycle is driven through a fake `SidecarSystem` rather than real
+ * processes and ports: adoption, shutdown and the restart/quit race are
+ * ownership logic, and the alternative is a spawned binary and a 45-second
+ * health ceiling per assertion. The lock file, the data directory and the
+ * binary lookup are real, against a temp directory - those are the parts a mock
+ * would have "passed" against.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChildProcess } from "node:child_process";
+
+/** Mutable because the mock is hoisted above the temp directory each test makes. */
+const fake = vi.hoisted(() => ({ userData: "" }));
+
+vi.mock("electron", () => ({
+	app: {
+		getPath: () => fake.userData,
+		getAppPath: () => fake.userData,
+		getVersion: () => "0.0.0-test",
+	},
+}));
+
+import { EngineSidecar, type SidecarSystem } from "./sidecar";
+import { ENGINE_LOCK_FILE, ENGINE_PORT_RELEASE_DELAY_MS } from "./constants";
+
+const TEST_PORT = 39876;
+const ADOPTED_PID = 4242;
+
+/** A spawned engine: enough of a ChildProcess for the sidecar to drive. */
+class FakeChild extends EventEmitter {
+	readonly stdout = null;
+	readonly stderr = null;
+	readonly signals: string[] = [];
+
+	kill(signal?: string) {
+		this.signals.push(signal ?? "SIGTERM");
+		queueMicrotask(() => this.emit("exit", null, signal ?? "SIGTERM"));
+		return true;
+	}
+}
+
+/**
+ * A fake OS: which PIDs are alive, whether anything answers on the port, and
+ * what got spawned. `sleep` resolves immediately - the waits under test are
+ * ordering, not duration.
+ */
+function fakeSystem(overrides: Partial<SidecarSystem> = {}) {
+	const state = {
+		alivePids: new Set<number>(),
+		healthy: false,
+		spawned: [] as FakeChild[],
+	};
+
+	const system: SidecarSystem = {
+		spawnEngine: vi.fn(() => {
+			const child = new FakeChild();
+			state.spawned.push(child);
+			state.healthy = true;
+			return child as unknown as ChildProcess;
+		}),
+		isEngineProcessAlive: vi.fn((pid: number) => state.alivePids.has(pid)),
+		killEngineProcess: vi.fn((pid: number) => {
+			const killed = state.alivePids.delete(pid);
+			if (killed) state.healthy = false;
+			return killed;
+		}),
+		probeHealth: vi.fn(async () => state.healthy),
+		requestShutdown: vi.fn(async () => true),
+		isPortFree: vi.fn(async () => !state.healthy),
+		sleep: vi.fn(async () => {}),
+		...overrides,
+	};
+
+	return { system, state };
+}
+
+/** An engine already up on the port, with the lock file the engine writes. */
+function engineAlreadyRunning(state: { alivePids: Set<number>; healthy: boolean }) {
+	state.alivePids.add(ADOPTED_PID);
+	state.healthy = true;
+	writeFileSync(join(fake.userData, ENGINE_LOCK_FILE), `${ADOPTED_PID}\n`);
+}
+
+beforeEach(() => {
+	fake.userData = mkdtempSync(join(tmpdir(), "vayu-sidecar-"));
+	// Production resolves the binary under process.resourcesPath, which exists
+	// only inside a packaged Electron app - that is the path that ships, so it is
+	// the path these drive.
+	Object.defineProperty(process, "resourcesPath", {
+		value: fake.userData,
+		configurable: true,
+	});
+	mkdirSync(join(fake.userData, "bin"), { recursive: true });
+	writeFileSync(join(fake.userData, "bin", "vayu-engine"), "");
+	writeFileSync(join(fake.userData, "bin", "vayu-engine.exe"), "");
+	vi.spyOn(console, "log").mockImplementation(() => {});
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	rmSync(fake.userData, { recursive: true, force: true });
+	vi.restoreAllMocks();
+});
+
+describe("EngineSidecar - adoption", () => {
+	it("adopts the engine the lock file points at, and knows it is running", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await sidecar.start();
+
+		expect(system.spawnEngine).not.toHaveBeenCalled();
+		expect(sidecar.isRunning()).toBe(true);
+	});
+
+	it("adopts an engine answering on the port with no readable lock PID", async () => {
+		const { system, state } = fakeSystem();
+		state.healthy = true;
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await sidecar.start();
+
+		expect(system.spawnEngine).not.toHaveBeenCalled();
+		expect(sidecar.isRunning()).toBe(true);
+	});
+
+	it("stops an adopted engine on quit, force-killing one that ignores the request", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		await sidecar.stop();
+
+		expect(system.requestShutdown).toHaveBeenCalledWith(TEST_PORT);
+		// The HTTP request was accepted but the process stayed up - the PID kill
+		// is what makes "zero engines left behind" true rather than hopeful.
+		expect(system.killEngineProcess).toHaveBeenCalledWith(ADOPTED_PID);
+		expect(state.alivePids.has(ADOPTED_PID)).toBe(false);
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("does not kill an adopted engine that shuts down when asked", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.alivePids.delete(ADOPTED_PID);
+			state.healthy = false;
+			return true;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		await sidecar.stop();
+
+		expect(system.killEngineProcess).not.toHaveBeenCalled();
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("really restarts an adopted engine instead of re-adopting it", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.alivePids.delete(ADOPTED_PID);
+			state.healthy = false;
+			return true;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		await sidecar.restart(0);
+
+		// A spawn, not a 500ms pause and the same process again: this is what makes
+		// the Settings restart-required banner tell the truth.
+		expect(system.spawnEngine).toHaveBeenCalledOnce();
+		expect(state.spawned).toHaveLength(1);
+		expect(sidecar.isRunning()).toBe(true);
+		// The stale lock of the engine we stopped must not survive into the new one.
+		expect(existsSync(join(fake.userData, ENGINE_LOCK_FILE))).toBe(false);
+	});
+
+	it("reports failure when the restarted engine never becomes healthy", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.alivePids.delete(ADOPTED_PID);
+			state.healthy = false;
+			return true;
+		});
+		// Spawns, but never answers /health.
+		(system.spawnEngine as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			const child = new FakeChild();
+			state.spawned.push(child);
+			return child as unknown as ChildProcess;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		await expect(sidecar.restart(0)).rejects.toThrow(/close the Application/i);
+	});
+});
+
+describe("EngineSidecar - spawned engine", () => {
+	it("spawns when nothing is on the port, and stops what it spawned", async () => {
+		const { system, state } = fakeSystem();
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await sidecar.start();
+
+		expect(system.spawnEngine).toHaveBeenCalledOnce();
+		expect(vi.mocked(system.spawnEngine).mock.calls[0][1]).toContain(String(TEST_PORT));
+		expect(sidecar.isRunning()).toBe(true);
+
+		await sidecar.stop();
+
+		expect(state.spawned[0].signals.length).toBeGreaterThan(0);
+		expect(sidecar.isRunning()).toBe(false);
+	});
+});
+
+describe("EngineSidecar - restart racing quit", () => {
+	it("does not spawn an engine when quit lands in the stop-to-spawn gap", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		(system.requestShutdown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			state.alivePids.delete(ADOPTED_PID);
+			state.healthy = false;
+			return true;
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		// The port-release pause is the gap: the old engine is down and the new one
+		// is not spawned yet. A quit arriving here used to leave a fresh engine
+		// nothing would ever kill.
+		let quitting: Promise<void> | null = null;
+		(system.sleep as ReturnType<typeof vi.fn>).mockImplementation(async (ms: number) => {
+			if (ms === ENGINE_PORT_RELEASE_DELAY_MS && !quitting) {
+				quitting = sidecar.shutdown();
+			}
+		});
+
+		await expect(sidecar.restart(0)).rejects.toThrow(/shutting down/i);
+		await quitting;
+
+		expect(system.spawnEngine).not.toHaveBeenCalled();
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("refuses to restart once the app is shutting down", async () => {
+		const { system, state } = fakeSystem();
+		engineAlreadyRunning(state);
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+		await sidecar.start();
+
+		await sidecar.shutdown();
+
+		await expect(sidecar.restart(0)).rejects.toThrow(/shutting down/i);
+		expect(system.spawnEngine).not.toHaveBeenCalled();
+	});
+});

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -596,37 +596,40 @@ export class EngineSidecar {
 	}
 
 	/** Wait out (and if necessary kill) the child this instance spawned. */
-	private stopSpawned(): Promise<void> {
-		return new Promise((resolve) => {
-			const child = this.process;
-			if (!child) {
-				this.ownership = { kind: "none" };
-				resolve();
-				return;
-			}
+	private async stopSpawned(): Promise<void> {
+		const child = this.process;
+		if (!child) {
+			this.ownership = { kind: "none" };
+			return;
+		}
 
-			// Give the process a grace period to exit before force-killing
-			const timeout = setTimeout(() => {
-				if (this.process) {
-					console.log("[Sidecar] Engine did not exit gracefully, killing...");
-					this.process.kill("SIGKILL");
-				}
-			}, ENGINE_GRACEFUL_EXIT_TIMEOUT_MS);
-
-			child.on("exit", () => {
-				clearTimeout(timeout);
-				this.process = null;
-				this.ownership = { kind: "none" };
-				console.log("[Sidecar] Engine stopped");
-				resolve();
-			});
-
-			// Send SIGTERM as fallback (works on Unix, immediate termination on Windows)
-			// On Windows, the HTTP shutdown should have already initiated graceful shutdown
-			if (process.platform !== "win32") {
-				child.kill("SIGTERM");
-			}
+		const exited = new Promise<void>((resolve) => {
+			child.once("exit", () => resolve());
 		});
+
+		// Send SIGTERM as fallback (works on Unix, immediate termination on Windows)
+		// On Windows, the HTTP shutdown should have already initiated graceful shutdown
+		if (process.platform !== "win32") {
+			child.kill("SIGTERM");
+		}
+
+		// Give the process a grace period to exit before force-killing. Through
+		// the system seam, so this is one wait a test can make instant rather than
+		// a real five seconds - on Windows there is no SIGTERM to shortcut it.
+		const exitedInTime = await Promise.race([
+			exited.then(() => true),
+			this.system.sleep(ENGINE_GRACEFUL_EXIT_TIMEOUT_MS).then(() => false),
+		]);
+
+		if (!exitedInTime) {
+			console.log("[Sidecar] Engine did not exit gracefully, killing...");
+			child.kill("SIGKILL");
+			await exited;
+		}
+
+		if (this.process === child) this.process = null;
+		this.ownership = { kind: "none" };
+		console.log("[Sidecar] Engine stopped");
 	}
 
 	/**

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -23,6 +23,7 @@ import {
 	ENGINE_HEALTH_REQUEST_TIMEOUT_MS,
 	ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS,
 	ENGINE_GRACEFUL_EXIT_TIMEOUT_MS,
+	ENGINE_EXIT_POLL_INTERVAL_MS,
 	ENGINE_RESTART_MAX_RETRIES,
 	ENGINE_RESTART_BASE_DELAY_MS,
 	ENGINE_PORT_RELEASE_DELAY_MS,
@@ -51,10 +52,29 @@ function isPortAvailable(port: number): Promise<boolean> {
 async function isEngineRunning(port: number): Promise<boolean> {
 	try {
 		const response = await fetch(`http://127.0.0.1:${port}/health`, {
-			signal: AbortSignal.timeout(1000),
+			signal: AbortSignal.timeout(ENGINE_HEALTH_REQUEST_TIMEOUT_MS),
 		});
 		const data = await response.json();
 		return data?.status === "ok";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Ask the engine to shut itself down over HTTP.
+ *
+ * The engine answers the POST before it stops, so a `true` here means the
+ * request was accepted, never that the process is gone - the caller still has
+ * to watch for the exit.
+ */
+async function requestEngineShutdown(port: number): Promise<boolean> {
+	try {
+		const response = await fetch(`http://127.0.0.1:${port}/shutdown`, {
+			method: "POST",
+			signal: AbortSignal.timeout(ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS),
+		});
+		return response.ok;
 	} catch {
 		return false;
 	}
@@ -122,6 +142,32 @@ function isVayuEngineRunning(pid: number): boolean {
 }
 
 /**
+ * Force-kill a vayu-engine process by PID.
+ *
+ * Name-verified first, for the same reason `isVayuEngineRunning` verifies: the
+ * PID comes from a lock file written by a process that may be long gone, and
+ * killing whatever inherited that PID would be far worse than leaving an engine
+ * running. Returns whether a kill was actually issued.
+ */
+function killVayuEngineProcess(pid: number): boolean {
+	if (!isVayuEngineRunning(pid)) {
+		return false;
+	}
+
+	try {
+		if (process.platform === "win32") {
+			execSync(`taskkill /PID ${pid} /F /T`, { stdio: "ignore" });
+		} else {
+			process.kill(pid, "SIGKILL");
+		}
+		return true;
+	} catch (err) {
+		console.warn(`[Sidecar] Failed to kill engine process ${pid}: ${err}`);
+		return false;
+	}
+}
+
+/**
  * Read PID from lock file
  */
 function readPidFromLock(lockPath: string): number | null {
@@ -148,7 +194,10 @@ function readPidFromLock(lockPath: string): number | null {
  * This verifies both that the PID exists AND that it belongs to vayu-engine,
  * preventing false positives from PID reuse.
  */
-function checkLockFile(lockPath: string): {
+function checkLockFile(
+	lockPath: string,
+	isAlive: (pid: number) => boolean
+): {
 	locked: boolean;
 	pid: number | null;
 	running: boolean;
@@ -158,18 +207,85 @@ function checkLockFile(lockPath: string): {
 		return { locked: false, pid: null, running: false };
 	}
 
-	const running = isVayuEngineRunning(pid);
-	return { locked: true, pid, running };
+	return { locked: true, pid, running: isAlive(pid) };
 }
+
+/**
+ * The OS- and network-facing half of the sidecar.
+ *
+ * Everything here talks to a real process, a real port or a real clock, which
+ * is exactly what a test cannot have: adoption, shutdown and the restart/quit
+ * race are all *ownership* logic, and driving them through real engines would
+ * mean 45-second health waits and a spawned binary per assertion. Production
+ * passes `defaultSidecarSystem`, which is the code that used to be inline.
+ */
+export interface SidecarSystem {
+	/** Spawn the engine binary. Stdio is piped; the caller drains it. */
+	spawnEngine(binaryPath: string, args: string[]): ChildProcess;
+	/** Is this PID alive *and* still vayu-engine? (PID reuse is real.) */
+	isEngineProcessAlive(pid: number): boolean;
+	/** Force-kill a name-verified engine PID. Returns whether a kill was issued. */
+	killEngineProcess(pid: number): boolean;
+	/** Does an engine answer `/health` with `status: ok` on this port? */
+	probeHealth(port: number): Promise<boolean>;
+	/** `POST /shutdown`. True means accepted, not that the process has gone. */
+	requestShutdown(port: number): Promise<boolean>;
+	/** Can we bind this port, i.e. is nothing at all listening? */
+	isPortFree(port: number): Promise<boolean>;
+	sleep(ms: number): Promise<void>;
+}
+
+export const defaultSidecarSystem: SidecarSystem = {
+	spawnEngine: (binaryPath, args) =>
+		spawn(binaryPath, args, {
+			stdio: ["ignore", "pipe", "pipe"],
+			detached: false,
+		}),
+	isEngineProcessAlive: isVayuEngineRunning,
+	killEngineProcess: killVayuEngineProcess,
+	probeHealth: isEngineRunning,
+	requestShutdown: requestEngineShutdown,
+	isPortFree: isPortAvailable,
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+/**
+ * How this instance came to be attached to the engine it is talking to.
+ *
+ * `spawned` is the ordinary case. `adopted` is an engine that was already up on
+ * the port when we started - after the single-instance lock in main.ts, that
+ * can only be an orphan of a crashed session (or, in development, an engine
+ * started by hand), never a second Vayu. Either way this instance owns it: it
+ * is stopped on quit and really restarted on request, which is what the three
+ * defects in issue #270 were about. Every method that used to key off
+ * `this.process` alone reported "no engine" for an adopted one and quietly did
+ * nothing.
+ */
+type Ownership =
+	| { kind: "none" }
+	| { kind: "spawned" }
+	/** `pid` is null when the engine answered health but wrote no readable lock. */
+	| { kind: "adopted"; pid: number | null };
 
 export class EngineSidecar {
 	private process: ChildProcess | null = null;
+	private ownership: Ownership = { kind: "none" };
 	private port: number;
 	private dataDir: string;
 	private binaryPath: string;
+	private system: SidecarSystem;
+	/**
+	 * Set once the app is on its way out. Read at every point in `start()` and
+	 * `restart()` that could otherwise spawn - a spawn that lands after the quit
+	 * path has taken its last look at the sidecar is a process nothing kills.
+	 */
+	private stopping = false;
+	/** A restart in progress, so the quit path can wait it out rather than race it. */
+	private restartInFlight: Promise<void> | null = null;
 
-	constructor(port: number = ENGINE_PORT) {
+	constructor(port: number = ENGINE_PORT, system: SidecarSystem = defaultSidecarSystem) {
 		this.port = port;
+		this.system = system;
 		this.dataDir = this.getDataDirectory();
 		this.binaryPath = this.getEngineBinaryPath();
 	}
@@ -249,7 +365,7 @@ export class EngineSidecar {
 	 * Start the engine process
 	 */
 	async start(): Promise<void> {
-		if (this.process) {
+		if (this.ownership.kind !== "none") {
 			console.log("[Sidecar] Engine already running (managed by this instance)");
 			return;
 		}
@@ -259,7 +375,7 @@ export class EngineSidecar {
 
 		// Check lock file to see if engine is already running
 		const lockPath = this.getLockFilePath();
-		const lockStatus = checkLockFile(lockPath);
+		const lockStatus = checkLockFile(lockPath, this.system.isEngineProcessAlive);
 
 		if (lockStatus.locked) {
 			if (lockStatus.running && lockStatus.pid !== null) {
@@ -267,10 +383,11 @@ export class EngineSidecar {
 					`[Sidecar] Lock file found with PID ${lockStatus.pid}, process is running`
 				);
 				// Verify engine is actually responding on the port
-				if (await isEngineRunning(this.port)) {
+				if (await this.system.probeHealth(this.port)) {
 					console.log(
-						`[Sidecar] Engine already running on port ${this.port}, reusing existing instance`
+						`[Sidecar] Adopting the engine already running on port ${this.port} (PID ${lockStatus.pid})`
 					);
+					this.ownership = { kind: "adopted", pid: lockStatus.pid };
 					return;
 				} else {
 					console.warn(
@@ -295,16 +412,19 @@ export class EngineSidecar {
 			}
 		}
 
-		// Check if engine is already running on this port (from previous session or crash)
-		if (await isEngineRunning(this.port)) {
+		// Check if engine is already running on this port (from previous session or
+		// crash). No lock file to read a PID from, so ownership is by port only -
+		// stop() falls back to watching health for the exit.
+		if (await this.system.probeHealth(this.port)) {
 			console.log(
-				`[Sidecar] Engine already running on port ${this.port}, reusing existing instance`
+				`[Sidecar] Adopting the engine already running on port ${this.port} (no lock PID)`
 			);
+			this.ownership = { kind: "adopted", pid: readPidFromLock(lockPath) };
 			return;
 		}
 
 		// Check if port is in use by something else
-		if (!(await isPortAvailable(this.port))) {
+		if (!(await this.system.isPortFree(this.port))) {
 			throw new Error(
 				`[Sidecar] Port ${this.port} is already in use by another application.`
 			);
@@ -333,22 +453,22 @@ export class EngineSidecar {
 		console.log(`[Sidecar]   Data Dir: ${this.dataDir}`);
 		console.log(`[Sidecar]   Port: ${this.port}`);
 
+		// Last look before the spawn, with no `await` between the two: from here
+		// on the child is tracked, so the quit path can kill it. Every check
+		// earlier than this one has an await after it, which is a window a quit
+		// can land in - and a child spawned into that window is an orphan.
+		this.assertNotStopping();
+
 		// Spawn the engine process
-		this.process = spawn(
-			this.binaryPath,
-			[
-				"--port",
-				this.port.toString(),
-				"--data-dir",
-				this.dataDir,
-				"--verbose",
-				`${isDev ? "2" : "1"}`,
-			],
-			{
-				stdio: ["ignore", "pipe", "pipe"],
-				detached: false,
-			}
-		);
+		this.process = this.system.spawnEngine(this.binaryPath, [
+			"--port",
+			this.port.toString(),
+			"--data-dir",
+			this.dataDir,
+			"--verbose",
+			`${isDev ? "2" : "1"}`,
+		]);
+		this.ownership = { kind: "spawned" };
 
 		// Handle stdout - set up listeners immediately to prevent buffering issues
 		// On Linux, if pipes aren't read, the process can block waiting for buffer space
@@ -383,16 +503,28 @@ export class EngineSidecar {
 			this.process.stderr.resume();
 		}
 
-		// Handle process exit
-		this.process.on("exit", (code, signal) => {
-			console.log(`[Sidecar] Engine exited with code ${code} signal ${signal}`);
+		// Forget the child only while it is still the current one: a restart's
+		// replacement is already spawned by the time a slow `exit` can land, and
+		// clearing then would drop the handle to a live engine.
+		const child = this.process;
+		const forget = () => {
+			if (this.process !== child) return;
 			this.process = null;
+			if (this.ownership.kind === "spawned") {
+				this.ownership = { kind: "none" };
+			}
+		};
+
+		// Handle process exit
+		child.on("exit", (code, signal) => {
+			console.log(`[Sidecar] Engine exited with code ${code} signal ${signal}`);
+			forget();
 		});
 
 		// Handle errors
-		this.process.on("error", (err) => {
+		child.on("error", (err) => {
 			console.error(`[Sidecar] Engine error:`, err);
-			this.process = null;
+			forget();
 		});
 
 		// Wait for the engine to be ready
@@ -406,41 +538,41 @@ export class EngineSidecar {
 		maxAttempts: number = ENGINE_HEALTH_MAX_ATTEMPTS,
 		delay: number = ENGINE_HEALTH_POLL_INTERVAL_MS
 	): Promise<void> {
-		const healthUrl = `http://127.0.0.1:${this.port}/health`;
-
 		for (let i = 0; i < maxAttempts; i++) {
-			try {
-				const controller = new AbortController();
-				const timeout = setTimeout(
-					() => controller.abort(),
-					ENGINE_HEALTH_REQUEST_TIMEOUT_MS
-				);
+			// A quit arriving mid-startup must not be held for the rest of the
+			// ceiling: the child is already tracked, so the quit path kills it and
+			// this loop's only remaining job is to stop waiting.
+			this.assertNotStopping();
 
-				const response = await fetch(healthUrl, {
-					signal: controller.signal,
-				});
-
-				clearTimeout(timeout);
-
-				if (response.ok) {
-					console.log(`[Sidecar] Engine is ready`);
-					return;
-				}
-			} catch {
-				// Engine not ready yet, continue waiting
+			if (await this.system.probeHealth(this.port)) {
+				console.log(`[Sidecar] Engine is ready`);
+				return;
 			}
 
-			await new Promise((resolve) => setTimeout(resolve, delay));
+			await this.system.sleep(delay);
 		}
 
 		throw new Error(`Engine failed to start within ${(maxAttempts * delay) / 1000} seconds`);
 	}
 
+	/** Throw if the app is shutting down, so no caller spawns into a quit. */
+	private assertNotStopping(): void {
+		if (this.stopping) {
+			throw new Error("Engine start aborted: the app is shutting down");
+		}
+	}
+
 	/**
-	 * Stop the engine process
+	 * Stop the engine this instance is attached to - spawned or adopted.
+	 *
+	 * An adopted engine is not our child, so there is no `exit` event to wait on
+	 * and `kill()` on a handle we do not have is not available either: it is
+	 * asked over HTTP, watched by PID (or by health, when no lock PID was
+	 * readable), and force-killed by PID if it outlives the grace period.
 	 */
 	async stop(): Promise<void> {
-		if (!this.process) {
+		const owned = this.ownership;
+		if (owned.kind === "none") {
 			console.log("[Sidecar] Engine not running");
 			return;
 		}
@@ -448,21 +580,27 @@ export class EngineSidecar {
 		console.log("[Sidecar] Stopping engine...");
 
 		// Try graceful HTTP shutdown first (works reliably on all platforms)
-		try {
-			console.log("[Sidecar] Requesting graceful shutdown via HTTP...");
-			const response = await fetch(`http://127.0.0.1:${this.port}/shutdown`, {
-				method: "POST",
-				signal: AbortSignal.timeout(ENGINE_SHUTDOWN_REQUEST_TIMEOUT_MS),
-			});
-			if (response.ok) {
-				console.log("[Sidecar] Shutdown request accepted");
-			}
-		} catch {
+		console.log("[Sidecar] Requesting graceful shutdown via HTTP...");
+		if (await this.system.requestShutdown(this.port)) {
+			console.log("[Sidecar] Shutdown request accepted");
+		} else {
 			console.log("[Sidecar] HTTP shutdown request failed, will use signal");
 		}
 
+		if (owned.kind === "adopted") {
+			await this.stopAdopted(owned.pid);
+			return;
+		}
+
+		await this.stopSpawned();
+	}
+
+	/** Wait out (and if necessary kill) the child this instance spawned. */
+	private stopSpawned(): Promise<void> {
 		return new Promise((resolve) => {
-			if (!this.process) {
+			const child = this.process;
+			if (!child) {
+				this.ownership = { kind: "none" };
 				resolve();
 				return;
 			}
@@ -475,9 +613,10 @@ export class EngineSidecar {
 				}
 			}, ENGINE_GRACEFUL_EXIT_TIMEOUT_MS);
 
-			this.process.on("exit", () => {
+			child.on("exit", () => {
 				clearTimeout(timeout);
 				this.process = null;
+				this.ownership = { kind: "none" };
 				console.log("[Sidecar] Engine stopped");
 				resolve();
 			});
@@ -485,9 +624,60 @@ export class EngineSidecar {
 			// Send SIGTERM as fallback (works on Unix, immediate termination on Windows)
 			// On Windows, the HTTP shutdown should have already initiated graceful shutdown
 			if (process.platform !== "win32") {
-				this.process.kill("SIGTERM");
+				child.kill("SIGTERM");
 			}
 		});
+	}
+
+	/**
+	 * Wait out (and if necessary kill) an engine this instance adopted.
+	 *
+	 * The lock file is re-read when adoption produced no PID: the engine writes
+	 * it at startup, so a health-only adoption early in its life can still learn
+	 * the PID by the time we come to stop it.
+	 */
+	private async stopAdopted(adoptedPid: number | null): Promise<void> {
+		const lockPath = this.getLockFilePath();
+		const pid = adoptedPid ?? readPidFromLock(lockPath);
+
+		const gone = await this.waitForAdoptedExit(pid);
+
+		if (!gone && pid !== null) {
+			console.log(
+				`[Sidecar] Adopted engine (PID ${pid}) did not exit gracefully, killing...`
+			);
+			if (this.system.killEngineProcess(pid)) {
+				await this.waitForAdoptedExit(pid);
+			}
+		}
+
+		// Ownership is released either way: a survivor we could not kill is not
+		// ours to keep claiming, and saying otherwise would make `isRunning()`
+		// lie in the other direction.
+		this.ownership = { kind: "none" };
+		console.log(
+			gone ? "[Sidecar] Adopted engine stopped" : "[Sidecar] Adopted engine released"
+		);
+	}
+
+	/**
+	 * Poll until the adopted engine is gone or the grace period expires.
+	 *
+	 * By PID when we have one - a healthy `/health` answer would keep reporting
+	 * "alive" for a *replacement* engine on the same port, and a dead one for an
+	 * engine still writing its final flush. Health is only the fallback.
+	 */
+	private async waitForAdoptedExit(pid: number | null): Promise<boolean> {
+		const deadline = ENGINE_GRACEFUL_EXIT_TIMEOUT_MS;
+		for (let waited = 0; waited < deadline; waited += ENGINE_EXIT_POLL_INTERVAL_MS) {
+			await this.system.sleep(ENGINE_EXIT_POLL_INTERVAL_MS);
+			const alive =
+				pid !== null
+					? this.system.isEngineProcessAlive(pid)
+					: await this.system.probeHealth(this.port);
+			if (!alive) return true;
+		}
+		return false;
 	}
 
 	/**
@@ -498,16 +688,42 @@ export class EngineSidecar {
 	}
 
 	/**
-	 * Check if the engine is running
+	 * Whether the engine this app is using is alive - however we came by it.
+	 *
+	 * This used to read `this.process !== null`, which is false for every
+	 * adopted engine, so a perfectly healthy backend reported "not running" and
+	 * the quit path skipped shutting it down.
 	 */
 	isRunning(): boolean {
-		return this.process !== null;
+		return this.ownership.kind !== "none";
 	}
 
 	/**
-	 * Restart the engine process with retry logic and exponential backoff
+	 * Restart the engine process with retry logic and exponential backoff.
+	 *
+	 * The promise is kept on the instance so `shutdown()` can wait it out: a
+	 * restart's stop-then-spawn has a gap, and a quit landing inside it used to
+	 * leave a fresh engine nothing would ever kill.
 	 */
 	async restart(maxRetries: number = ENGINE_RESTART_MAX_RETRIES): Promise<void> {
+		const run = this.runRestart(maxRetries);
+		// Swallowed separately from the caller's copy: the quit path only needs to
+		// know the restart is over, not whether it worked.
+		const inFlight = run.then(
+			() => undefined,
+			() => undefined
+		);
+		this.restartInFlight = inFlight;
+		try {
+			await run;
+		} finally {
+			// Only clear our own: an overlapping restart owns the field now, and
+			// dropping its promise would let a quit stop waiting for a live one.
+			if (this.restartInFlight === inFlight) this.restartInFlight = null;
+		}
+	}
+
+	private async runRestart(maxRetries: number): Promise<void> {
 		console.log("[Sidecar] Restarting engine...");
 
 		let lastError: Error | null = null;
@@ -515,18 +731,22 @@ export class EngineSidecar {
 
 		for (let attempt = 0; attempt <= maxRetries; attempt++) {
 			try {
+				// Checked per attempt, not once up front: a quit can arrive between
+				// two retries just as easily as before the first.
+				this.assertNotStopping();
+
 				if (attempt > 0) {
 					// Calculate exponential delay: baseDelay * 2^(attempt-1)
 					const delay = baseDelay * Math.pow(2, attempt - 1);
 					console.log(
 						`[Sidecar] Retry attempt ${attempt}/${maxRetries} after ${delay}ms delay...`
 					);
-					await new Promise((resolve) => setTimeout(resolve, delay));
+					await this.system.sleep(delay);
 				}
 
 				await this.stop();
 				// Small delay to ensure port is released
-				await new Promise((resolve) => setTimeout(resolve, ENGINE_PORT_RELEASE_DELAY_MS));
+				await this.system.sleep(ENGINE_PORT_RELEASE_DELAY_MS);
 				await this.start();
 				console.log("[Sidecar] Engine restarted successfully");
 				return;
@@ -537,11 +757,34 @@ export class EngineSidecar {
 					lastError.message
 				);
 
+				// A shutdown is not a failed restart to retry - the engine is meant
+				// to be down, and retrying would spawn the orphan we just avoided.
+				if (this.stopping) {
+					throw lastError;
+				}
+
 				// If this was the last attempt, throw the error
 				if (attempt === maxRetries) {
 					throw new Error(`Please close the Application and reopen it.`);
 				}
 			}
 		}
+	}
+
+	/**
+	 * Stop the engine for good, on the way out of the app.
+	 *
+	 * Distinct from `stop()` because quit is one-way: further restarts are
+	 * refused from here on, and a restart already in flight is waited out rather
+	 * than raced, so the engine cannot be spawned again behind the shutdown.
+	 */
+	async shutdown(): Promise<void> {
+		this.stopping = true;
+		const inFlight = this.restartInFlight;
+		if (inFlight) {
+			console.log("[Sidecar] Waiting for the in-flight restart before shutting down...");
+			await inFlight;
+		}
+		await this.stop();
 	}
 }

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -86,6 +86,14 @@ The `EngineSidecar` class manages the C++ engine process:
 - **Process Management**: Spawns, monitors, and terminates the engine process
 - **Health Checking**: Polls `/health` endpoint to verify engine readiness
 - **Port Management**: Checks if port 9876 is available or if engine is already running
+- **Ownership**: Tracks whether the engine was *spawned* or *adopted* (already
+  running at startup). An adopted engine is owned just as fully - `isRunning()`
+  reports it, `restart()` really replaces it, and quit shuts it down by PID.
+  See [Ownership model](../architecture.md#ownership-model)
+- **System seam**: The process/port/clock calls sit behind a `SidecarSystem`
+  interface (`defaultSidecarSystem` in production), so `sidecar.test.ts` can
+  drive adoption, shutdown and the restart-versus-quit race without real
+  engines or 45-second health waits
 
 **Development vs Production:**
 - **Development**: Binary at `../engine/build/vayu-engine` (or `Debug/vayu-engine.exe` on Windows)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,6 +153,29 @@ The Engine runs as a separate process managed by the Electron main process:
 2. **Health Monitoring**: Manager polls `/health` endpoint to verify connectivity
 3. **Graceful Shutdown**: Engine is stopped when Electron app quits
 
+### Ownership model
+
+The engine binds one fixed port (9876) and owns one SQLite database, so exactly
+one app instance may drive it:
+
+- **One instance.** The app takes `app.requestSingleInstanceLock()` before it
+  starts anything. A second launch focuses the running window and exits - it
+  never gets its own engine, and never attaches to the first instance's.
+- **Spawned or adopted, the running instance owns the engine.** Normally the app
+  spawns it. If an engine is already answering on the port at startup - an
+  orphan left by a crashed session, or in development one started by hand - the
+  app *adopts* it: it is tracked by the PID in the lock file (`vayu.lock` in the
+  data directory), reported as running, restarted for real when Settings asks,
+  and shut down on quit like any engine the app spawned itself.
+- **Quit leaves nothing behind.** Shutdown is `POST /shutdown` first, then a
+  wait for the process to go, then a name-verified kill by PID if it outstays
+  the grace period. The name check is what keeps a recycled PID from being
+  killed in the engine's place.
+- **A quit during a restart wins.** Once the app is quitting, the sidecar
+  refuses to start an engine, and a restart already in flight is waited out
+  rather than raced - otherwise a freshly spawned engine outlives the process
+  that was supposed to kill it.
+
 **Development vs Production:**
 - **Development**: Engine binary at `engine/build/vayu-engine`
 - **Production**: Engine binary packaged in `Vayu.app/Contents/Resources/bin/vayu-engine`


### PR DESCRIPTION
## Description

**Root cause.** `EngineSidecar.start()` has two paths that attach to an engine already on the port - the lock file (`sidecar.ts:264-281`) and the health probe (`sidecar.ts:298-304`) - and both returned with `this.process` still `null`, while every other method keyed off exactly that field. So an adopted engine was invisible: `isRunning()` false for a healthy backend, `stop()` an early return (the orphan survives quit, is re-adopted next launch, forever), and `restart()` a no-op `stop()` plus a 500ms pause plus a re-adoption of the same process, reported as success - which is why "Restart Engine" cleared the Settings banner while the config change never took effect.

**Approach.** Ownership becomes explicit state (`none` / `spawned` / `adopted{pid}`) that every method reads, and adoption is fully owned rather than merely tolerated: an adopted engine is asked over HTTP, watched by PID (health as the fallback when the lock gave no PID), and force-killed by a **name-verified** PID if it outstays the grace period - the name check is what keeps a recycled PID from being killed in the engine's place. `app.requestSingleInstanceLock()` makes the multi-attach path unreachable in the first place: a second launch focuses the running window and exits, instead of sharing one engine and one database with the first instance and killing its backend on quit. Quit now beats a restart: the sidecar refuses to start once `shutdown()` has been entered, the check sits with **no `await` between it and `spawn()`**, and `shutdown()` waits out a restart in flight rather than racing it.

**Alternative rejected.** The issue's option (a) - never adopt, kill any engine found at startup and spawn fresh. It is simpler on paper, but it makes every startup that finds an engine pay a kill-and-respawn, it kills a hand-started engine in development (debugger attached and all), and the acceptance criteria themselves say quit must leave zero engines "spawned **or adopted**" - i.e. adoption stays a state the app can be in. Option (b), with adoption tracked and every method truthful about it, is the model that survives contact with a shared fixed-port daemon. Documented in `docs/architecture.md`.

Also here, from your follow-up comment on the issue: `before-quit`'s second pass was re-entrant against its own in-flight shutdown, because its guard read engine state that only clears *after* the awaits. An X click needs no second gesture to reach it - `window-all-closed` fires `app.quit()` into the shutdown a prior quit already began, and both passes saw `mcpService` non-null and called `stop()` twice. It moves to `quit-shutdown.ts` as a three-state coordinator (idle / stopping / stopped): a quit landing mid-shutdown is *held* rather than let through (exiting there would strand an adopted engine), and the quit the shutdown itself resumes falls straight through, or the app would never exit. A quit arriving before the engine is up does not latch, so a later quit still finds work.

The process/port/clock calls move behind a `SidecarSystem` interface (`defaultSidecarSystem` in production is the code that used to be inline), which is what makes `sidecar.ts` testable at all - `app/electron/` had no `sidecar.test.ts` before this.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **283 files, 2444 tests, all passing** (17 electron files / 257 tests, of which 15 are new: `sidecar.test.ts` 9, `quit-shutdown.test.ts` 6 + 4 wiring scans).
- `cd app && pnpm type-check` - clean (renderer, `tsconfig.node.json`, electron tests).
- `cd app && pnpm lint` - clean, zero warnings. `prettier --check` clean on every file touched; `docs/architecture.md` and `docs/app/architecture.md` were already not prettier-clean before this change, so they are left alone per CLAUDE.md.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (new `#ownership-model` anchor is linked from `docs/app/architecture.md`).
- Engine C++ untouched, so no engine build or ctest run - nothing there could change colour.

Mutation-checked, each reverted and re-run:

| Reverted fix | Failing tests |
|---|---|
| `isRunning()` back to `this.process !== null` | 2 |
| `stop()` back to ignoring anything not spawned | 5 |
| pre-spawn quit guard removed | 1 (the restart/quit race) |

The four `main.ts` assertions are source scans - `main.ts` starts an engine and creates windows at import time, so its wiring can only be read - and they assert against a non-empty read, per CLAUDE.md.

Not unit-tested, stated as the issue asks: the single-instance lock itself (Electron-level, covered by a source scan only) and the cross-platform kill paths (`taskkill` on Windows, `SIGKILL` on Unix) - both need manual verification on a real machine.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Notes on the issue's other checks

- **Renderer restart flow** (`SettingsMain.tsx:509-529`): unchanged, as expected. With the fix, `restart()` returning success now implies a restart actually happened, which is precisely what that banner assumed all along; a refused restart (app shutting down) surfaces as `{success: false, error}` and the banner stays.
- **MCP consumers**: `rg EngineSidecar app/electron/mcp/` - no hits. The MCP service holds a base URL, not the sidecar. No behaviour change.
- Left alone deliberately, as #274's scope: the inline `9876` in `startEngine()` and the dead `engine:status` IPC chain (which this makes truthful in passing, but does not delete).

## Related Issues
Closes #270

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWLKGjpgyfruqXFGkW129Y)_