### PR TITLE
fix(app): stop waiting on an engine that has already died

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -44,6 +44,15 @@ export const ENGINE_GRACEFUL_EXIT_TIMEOUT_MS = 5000;
  * follows a stuck engine still happens inside the same quit.
  */
 export const ENGINE_EXIT_POLL_INTERVAL_MS = 100;
+/**
+ * How many stderr lines to keep from a spawned engine, so the message shown
+ * when it dies before answering `/health` can quote its last words.
+ *
+ * Bounded because the drain runs for the engine's whole life, not just for
+ * startup - and the reason an engine died at spawn (a missing shared library, a
+ * lock it could not acquire) is always in the final few lines.
+ */
+export const ENGINE_STDERR_TAIL_LINES = 10;
 export const ENGINE_RESTART_MAX_RETRIES = 3;
 export const ENGINE_RESTART_BASE_DELAY_MS = 1000;
 /** Pause between stop and start during restart so the port is released. */

--- a/app/electron/sidecar.test.ts
+++ b/app/electron/sidecar.test.ts
@@ -23,13 +23,27 @@
  * health ceiling per assertion. The lock file, the data directory and the
  * binary lookup are real, against a temp directory - those are the parts a mock
  * would have "passed" against.
+ *
+ * The same harness covers the other end of `start()`: an engine that dies at
+ * spawn. That path used to poll a dead port for the full 45-second ceiling with
+ * no window on screen, so the assertions there are about *when* the failure
+ * arrives and what it says, not only that it arrives.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+	existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ChildProcess } from "node:child_process";
 
 /** Mutable because the mock is hoisted above the temp directory each test makes. */
@@ -49,10 +63,16 @@ import { ENGINE_LOCK_FILE, ENGINE_PORT_RELEASE_DELAY_MS } from "./constants";
 const TEST_PORT = 39876;
 const ADOPTED_PID = 4242;
 
+/** Just enough of a piped stdio stream for the sidecar's drain to attach to. */
+class FakeStream extends EventEmitter {
+	setEncoding() {}
+	resume() {}
+}
+
 /** A spawned engine: enough of a ChildProcess for the sidecar to drive. */
 class FakeChild extends EventEmitter {
-	readonly stdout = null;
-	readonly stderr = null;
+	readonly stdout = new FakeStream();
+	readonly stderr = new FakeStream();
 	readonly signals: string[] = [];
 
 	/** A wedged engine: only SIGKILL gets it, which is what the grace period is for. */
@@ -66,8 +86,17 @@ class FakeChild extends EventEmitter {
 		return true;
 	}
 
-	exit() {
-		queueMicrotask(() => this.emit("exit", null, null));
+	/**
+	 * Deferred, because the sidecar attaches its handlers only after `spawnEngine`
+	 * has returned - anything emitted synchronously inside the mock is emitted at
+	 * nobody. A microtask lands after that and still before the first `await`.
+	 */
+	say(line: string) {
+		queueMicrotask(() => this.stderr.emit("data", `${line}\n`));
+	}
+
+	exit(code: number | null = null, signal: string | null = null) {
+		queueMicrotask(() => this.emit("exit", code, signal));
 	}
 }
 
@@ -302,6 +331,114 @@ describe("EngineSidecar - spawned engine", () => {
 
 		expect(state.spawned[0].signals).toEqual(["SIGTERM", "SIGKILL"]);
 		expect(sidecar.isRunning()).toBe(false);
+	});
+});
+
+describe("EngineSidecar - an engine that dies at spawn", () => {
+	/** Spawns a child that leaves the way `die` says, instead of coming up. */
+	function spawnsAndDies(
+		state: { spawned: FakeChild[] },
+		system: SidecarSystem,
+		die: (child: FakeChild) => void
+	) {
+		(system.spawnEngine as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			const child = new FakeChild();
+			state.spawned.push(child);
+			die(child);
+			return child as unknown as ChildProcess;
+		});
+	}
+
+	it("fails at the exit instead of polling out the 45-second ceiling", async () => {
+		const { system, state } = fakeSystem();
+		// The outcome sidecar.ts calls expected: the engine could not take its own
+		// lock, so it is gone milliseconds after the spawn.
+		spawnsAndDies(state, system, (child) => child.exit(3, null));
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await expect(sidecar.start()).rejects.toThrow(/exit code 3/);
+
+		// The point of the fix, and what a revert breaks: without consulting the
+		// child, the loop runs all 90 attempts before saying anything - 45 real
+		// seconds with no window on screen. Two probes are the pre-spawn adoption
+		// check and the loop's first pass.
+		expect(vi.mocked(system.probeHealth).mock.calls.length).toBeLessThanOrEqual(3);
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("names the signal and the engine's last words", async () => {
+		const { system, state } = fakeSystem();
+		spawnsAndDies(state, system, (child) => {
+			child.say("error while loading shared libraries: libssl.so.3");
+			child.exit(null, "SIGABRT");
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		// The stderr line is the whole diagnosis; an exit status alone sends the
+		// user to the logs for it.
+		await expect(sidecar.start()).rejects.toThrow(/libssl\.so\.3/);
+		await expect(sidecar.start()).rejects.toThrow(/signal SIGABRT/);
+	});
+
+	it("reports a spawn that never produced a process at all", async () => {
+		const { system, state } = fakeSystem();
+		spawnsAndDies(state, system, (child) => {
+			queueMicrotask(() => child.emit("error", new Error("spawn EACCES")));
+		});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await expect(sidecar.start()).rejects.toThrow(/EACCES/);
+		expect(sidecar.isRunning()).toBe(false);
+	});
+
+	it("still waits out the ceiling for an engine that is merely slow", async () => {
+		const { system, state } = fakeSystem();
+		// Spawns, stays alive, never answers: the loop has nothing to shortcut on
+		// and must not mistake "not ready yet" for "dead".
+		spawnsAndDies(state, system, () => {});
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		await expect(sidecar.start()).rejects.toThrow(/failed to start within 45 seconds/);
+		// The early exit must not have shortened the wait for a live engine.
+		expect(vi.mocked(system.probeHealth).mock.calls.length).toBeGreaterThan(50);
+	});
+});
+
+describe("EngineSidecar - the missing-binary message", () => {
+	function removeBinaries() {
+		for (const name of ["vayu-engine", "vayu-engine.exe"]) {
+			rmSync(join(fake.userData, "bin", name), { force: true });
+		}
+	}
+
+	it("points at the build entry point that exists", async () => {
+		const { system } = fakeSystem();
+		removeBinaries();
+		const sidecar = new EngineSidecar(TEST_PORT, system);
+
+		// Read exactly once by a user, at the moment nothing works, so every line
+		// of it has to lead somewhere real.
+		await expect(sidecar.start()).rejects.toThrow(/python build\.py -e/);
+		await expect(sidecar.start()).rejects.toThrow(/docs\/building\.md/);
+		expect(system.spawnEngine).not.toHaveBeenCalled();
+	});
+
+	it("leaves no reference to the build-script directory the repo does not have", () => {
+		const here = dirname(fileURLToPath(import.meta.url));
+		const sources = readdirSync(here, { recursive: true, withFileTypes: true })
+			.filter((entry) => entry.isFile() && /\.tsx?$/.test(entry.name))
+			// This file spells the dead path in the assertion below, so scanning it
+			// would flag the guard itself.
+			.filter((entry) => entry.name !== "sidecar.test.ts")
+			.map((entry) => readFileSync(join(entry.parentPath, entry.name), "utf8"));
+
+		// Without this the scan below passes on an empty list - the failure mode
+		// CLAUDE.md records a source guard sitting in for weeks.
+		expect(sources.length).toBeGreaterThan(10);
+		expect(sources.join("").length).toBeGreaterThan(10_000);
+
+		const deadPath = ["scripts", "build", ""].join("/");
+		expect(sources.filter((source) => source.includes(deadPath))).toEqual([]);
 	});
 });
 

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -27,6 +27,7 @@ import {
 	ENGINE_RESTART_MAX_RETRIES,
 	ENGINE_RESTART_BASE_DELAY_MS,
 	ENGINE_PORT_RELEASE_DELAY_MS,
+	ENGINE_STDERR_TAIL_LINES,
 } from "./constants.js";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -267,6 +268,39 @@ type Ownership =
 	/** `pid` is null when the engine answered health but wrote no readable lock. */
 	| { kind: "adopted"; pid: number | null };
 
+/**
+ * Why a spawned engine is never going to answer.
+ *
+ * Recorded by the child's `exit` and `error` handlers so `waitForEngine` can
+ * stop polling a port nothing is listening on. The loop used to consult only
+ * the health probe, so an engine that died at spawn - a missing shared library,
+ * a corrupt binary, a lock it could not take - still cost the full 45-second
+ * ceiling, and with no window on screen yet the user watched nothing happen for
+ * all of it.
+ */
+type SpawnFailure =
+	| { kind: "exit"; code: number | null; signal: NodeJS.Signals | null; stderr: string[] }
+	| { kind: "error"; message: string };
+
+/** The user-facing half of a `SpawnFailure`; ends up in a `showErrorBox`. */
+function describeSpawnFailure(failure: SpawnFailure): string {
+	if (failure.kind === "error") {
+		return `The engine process could not be started: ${failure.message}`;
+	}
+
+	// A signal means something killed it; a code means it decided to leave. Only
+	// one of the two is ever set, and naming the wrong one reads as a crash that
+	// did not happen.
+	const cause =
+		failure.signal !== null
+			? `killed by signal ${failure.signal}`
+			: `exit code ${failure.code}`;
+	const tail =
+		failure.stderr.length > 0 ? `\n\nLast engine output:\n${failure.stderr.join("\n")}` : "";
+
+	return `The engine exited before it was ready (${cause}).${tail}`;
+}
+
 export class EngineSidecar {
 	private process: ChildProcess | null = null;
 	private ownership: Ownership = { kind: "none" };
@@ -430,21 +464,17 @@ export class EngineSidecar {
 			);
 		}
 
-		// Check if binary exists
+		// Check if binary exists. The remediation names `build.py` because that is
+		// the repo's single build entry point - the per-platform shell scripts this
+		// message used to name have never existed, and the raw cmake line it
+		// offered skips the vcpkg toolchain wiring build.py does for you.
 		if (!fs.existsSync(this.binaryPath)) {
-			const platform = process.platform;
-			let buildScript = "./scripts/build/build-macos.sh";
-			if (platform === "win32") {
-				buildScript = "./scripts/build/build-windows.ps1";
-			} else if (platform === "linux") {
-				buildScript = "./scripts/build/build-linux.sh";
-			}
-
 			throw new Error(
-				`Engine binary not found at: ${this.binaryPath}\n` +
-					`Please build the engine first:\n` +
-					`  Development: cd engine && cmake -B build && cmake --build build\n` +
-					`  Production: ${buildScript}`
+				`Engine binary not found at: ${this.binaryPath}\n\n` +
+					`From a source checkout, build it with:\n` +
+					`  python build.py -e\n\n` +
+					`If this is an installed copy of Vayu, the installation is incomplete - ` +
+					`reinstall it. Prerequisites and platform notes are in docs/building.md.`
 			);
 		}
 
@@ -487,6 +517,11 @@ export class EngineSidecar {
 			this.process.stdout.resume();
 		}
 
+		// Kept for the failure message: an engine that dies at spawn has usually
+		// said why on stderr, and that line is the difference between "exit code 127"
+		// and "cannot open shared object file".
+		const stderrTail: string[] = [];
+
 		// Handle stderr - set up listeners immediately to prevent buffering issues
 		if (this.process.stderr) {
 			this.process.stderr.setEncoding("utf8");
@@ -497,6 +532,8 @@ export class EngineSidecar {
 					.filter((line: string) => line.trim());
 				for (const line of lines) {
 					console.error(`[Engine] ${line}`);
+					stderrTail.push(line);
+					if (stderrTail.length > ENGINE_STDERR_TAIL_LINES) stderrTail.shift();
 				}
 			});
 			// Resume reading to prevent backpressure
@@ -515,44 +552,61 @@ export class EngineSidecar {
 			}
 		};
 
+		// Scoped to this spawn rather than to the instance: a restart's replacement
+		// is a different child, and its wait must not inherit the reason the
+		// previous one died.
+		let failure: SpawnFailure | null = null;
+
 		// Handle process exit
 		child.on("exit", (code, signal) => {
 			console.log(`[Sidecar] Engine exited with code ${code} signal ${signal}`);
+			failure = { kind: "exit", code, signal, stderr: [...stderrTail] };
 			forget();
 		});
 
 		// Handle errors
 		child.on("error", (err) => {
 			console.error(`[Sidecar] Engine error:`, err);
+			failure = { kind: "error", message: err.message };
 			forget();
 		});
 
 		// Wait for the engine to be ready
-		await this.waitForEngine();
+		await this.waitForEngine(() => failure);
 	}
 
 	/**
-	 * Wait for the engine to be ready by polling the health endpoint
+	 * Wait for the engine to be ready by polling the health endpoint.
+	 *
+	 * `spawnFailure` reports what the child we just spawned did instead of coming
+	 * up, and is the loop's early exit: polling out the remaining attempts against
+	 * a process that has already gone only delays the error the user needs.
 	 */
-	private async waitForEngine(
-		maxAttempts: number = ENGINE_HEALTH_MAX_ATTEMPTS,
-		delay: number = ENGINE_HEALTH_POLL_INTERVAL_MS
-	): Promise<void> {
-		for (let i = 0; i < maxAttempts; i++) {
+	private async waitForEngine(spawnFailure: () => SpawnFailure | null): Promise<void> {
+		for (let i = 0; i < ENGINE_HEALTH_MAX_ATTEMPTS; i++) {
 			// A quit arriving mid-startup must not be held for the rest of the
 			// ceiling: the child is already tracked, so the quit path kills it and
 			// this loop's only remaining job is to stop waiting.
 			this.assertNotStopping();
+
+			// Before the probe, not after: by the time control is back here the
+			// child's exit handler has already run, and one more health request to a
+			// closed port would answer no faster than the record already has.
+			const died = spawnFailure();
+			if (died) {
+				throw new Error(describeSpawnFailure(died));
+			}
 
 			if (await this.system.probeHealth(this.port)) {
 				console.log(`[Sidecar] Engine is ready`);
 				return;
 			}
 
-			await this.system.sleep(delay);
+			await this.system.sleep(ENGINE_HEALTH_POLL_INTERVAL_MS);
 		}
 
-		throw new Error(`Engine failed to start within ${(maxAttempts * delay) / 1000} seconds`);
+		const ceilingSeconds = (ENGINE_HEALTH_MAX_ATTEMPTS * ENGINE_HEALTH_POLL_INTERVAL_MS) / 1000;
+		throw new Error(`Engine failed to start within ${ceilingSeconds} seconds`);
 	}
 
 	/** Throw if the app is shutting down, so no caller spawns into a quit. */

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -84,7 +84,12 @@ The `EngineSidecar` class manages the C++ engine process:
 
 - **Binary Resolution**: Locates the engine binary (dev vs production paths)
 - **Process Management**: Spawns, monitors, and terminates the engine process
-- **Health Checking**: Polls `/health` endpoint to verify engine readiness
+- **Health Checking**: Polls `/health` endpoint to verify engine readiness, and
+  gives up the moment the spawned child exits rather than polling out the
+  45-second ceiling against a dead port. The failure carries the exit
+  code/signal and the engine's last stderr lines
+- **Build guidance**: A missing binary names `python build.py -e` and
+  `docs/building.md` - the single build entry point, not per-platform scripts
 - **Port Management**: Checks if port 9876 is available or if engine is already running
 - **Ownership**: Tracks whether the engine was *spawned* or *adopted* (already
   running at startup). An adopted engine is owned just as fully - `isRunning()`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,6 +175,12 @@ one app instance may drive it:
   refuses to start an engine, and a restart already in flight is waited out
   rather than raced - otherwise a freshly spawned engine outlives the process
   that was supposed to kill it.
+- **A startup that cannot succeed fails immediately.** The readiness poll allows
+  45 seconds, but it watches the spawned child as well as the port: an engine
+  that exits first - a missing shared library, a lock it could not acquire -
+  fails the launch at once, naming the exit code or signal and the engine's last
+  stderr lines. The window is created after startup, so the ceiling would
+  otherwise be 45 seconds of an empty screen.
 
 **Development vs Production:**
 - **Development**: Engine binary at `engine/build/vayu-engine`


### PR DESCRIPTION
## Description

Third and last of the E2 chain in #278, on top of the `sidecar.ts` restructuring #270 landed.

**Plan.** Root cause of the blind wait: `waitForEngine` polled only the health endpoint, and the spawned child's `exit` handler logged the death without telling the loop about it - so a first-run failure (missing shared library, corrupt binary, a lock the engine could not take) burned all 90 attempts at 500ms before saying anything, and since `createWindow()` runs after `startEngine()`, that is 45 seconds of an empty screen. The approach is to record *why* the child went, in the handlers that already fire, and check that record at the top of each poll pass - the failure arrives within one poll interval of the exit, carrying the exit code or signal plus the last stderr lines, which is usually the whole diagnosis. The alternative considered and rejected was racing the poll against an `exit` promise: it reads shorter but loses the reason (a resolved race says only "it exited"), and it would need its own listener on a child whose `exit` is already handled - two handlers on one event, one of which must not fire for a *restart's* replacement child. The per-spawn closure is what keeps a previous child's death from failing the next one's wait.

Both defects still reproduced as described; the line anchors moved by ~30 lines under #270, nothing else drifted.

Deliberate deviation from the issue spec: the issue proposed forking the missing-binary remediation into a dev case and a production case. It is one message instead. `isDev` is a module-level `NODE_ENV` read, so testing both branches means `vi.resetModules()` + re-import, and the dev branch's data directory resolves to `<appPath>/../engine/data` - outside the test's temp dir. A single message names both routes, is the one string the acceptance criteria ask for, and tells a packaged user that building from source is even an option. The stderr tail is bounded by a new `ENGINE_STDERR_TAIL_LINES` constant because that drain runs for the engine's whole life, not just startup.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **283 files, 2453 tests, all passing** (18 in `electron/sidecar.test.ts`, 6 of them new). `pnpm type-check` and `pnpm lint` clean; `mkdocs build --strict` clean for the docs edits. No pre-existing failures. Engine suite not run - this change is TypeScript and Markdown only, so no C++ test could change colour (CLAUDE.md's verification-scaling rule).

Mutation-checked: removing the early-exit check from `waitForEngine` turns 3 of the new tests red (the ceiling shortcut, the signal/stderr message, and the spawn-`error` path), not just one. New coverage:

- an engine that exits at spawn fails with `exit code 3` and at most 3 health probes - reverted, that is 91 probes and a "failed to start within 45 seconds" message
- a `SIGABRT` death quotes the engine's `libssl.so.3` stderr line
- a spawn that emits `error` (EACCES) instead of ever running is reported as such
- an engine that is merely *slow* still gets its full ceiling - the shortcut must not mistake "not ready yet" for "dead"
- the missing-binary message names `python build.py -e` and `docs/building.md`
- a source scan over `app/electron/**/*.ts` finds no `scripts/build/` reference left, asserting first that it scanned >10 files and >10k characters

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/architecture.md` (ownership model gains the fail-fast bullet) and `docs/app/architecture.md` (the sidecar's health-checking and build-guidance lines).

## Related Issues
Closes #271

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPuELDRKDviM17pAxwhyoV)_