### PR TITLE
fix(app): read the updater's window at send time, and reset readyToInstall on any new version

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "url";
 import { EngineSidecar } from "./sidecar.js";
 import { setupOAuthIpcHandlers } from "./oauth.js";
 import { loadWindowState, trackWindowState } from "./window-state.js";
-import { initAutoUpdater, checkForUpdatesNow } from "./updater.js";
+import { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } from "./updater.js";
 import { installQuitOnSignal } from "./quit-signals.js";
 import { createSaveFlusher } from "./save-flush.js";
 import { createQuitShutdown } from "./quit-shutdown.js";
@@ -760,10 +760,11 @@ app.whenReady().then(async () => {
 	// Then create the window
 	createWindow();
 
-	// Start checking for updates once the window exists to receive events
-	if (mainWindow) {
-		initAutoUpdater(mainWindow);
-	}
+	// Start checking for updates once a window exists to receive events. The
+	// updater reads `mainWindow` at send time rather than being handed the window
+	// now: on macOS the app outlives its window, and a dock-activate builds a
+	// replacement that a captured reference would never reach.
+	initAutoUpdater(() => mainWindow);
 
 	app.on("activate", () => {
 		if (BrowserWindow.getAllWindows().length === 0) {
@@ -813,6 +814,12 @@ app.on("before-quit", (event) => {
 	}
 
 	quitShutdown.handleQuit(event);
+});
+
+// The quit is settled by now, so stop the periodic update check and answer a
+// check the user is still waiting on - its events will never arrive.
+app.on("will-quit", () => {
+	disposeAutoUpdater();
 });
 
 // A signal is how anything outside the UI asks Vayu to stop, and Node's default

--- a/app/electron/updater.test.ts
+++ b/app/electron/updater.test.ts
@@ -62,10 +62,30 @@ vi.mock("electron-updater", () => ({
 	},
 }));
 
-const win = {
-	isDestroyed: () => false,
-	webContents: { send: vi.fn() },
-} as unknown as Parameters<typeof import("./updater.js").initAutoUpdater>[0];
+interface FakeWindow {
+	destroyed: boolean;
+	isDestroyed: () => boolean;
+	webContents: { send: ReturnType<typeof vi.fn> };
+}
+
+function makeWindow(): FakeWindow {
+	const win: FakeWindow = {
+		destroyed: false,
+		isDestroyed: () => win.destroyed,
+		webContents: { send: vi.fn() },
+	};
+	return win;
+}
+
+/**
+ * The window as main.ts owns it: one variable the updater reads through, not a
+ * reference it is handed once. Tests move it the way the app does - closed on
+ * the X, rebuilt on a macOS dock-activate.
+ */
+let currentWindow: FakeWindow | null = null;
+const getWindow = (() => currentWindow) as unknown as Parameters<
+	typeof import("./updater.js").initAutoUpdater
+>[0];
 
 /** Re-import with fresh module state - the updater keeps module-level state. */
 async function loadUpdater(platform: NodeJS.Platform = "win32") {
@@ -81,6 +101,7 @@ const realPlatform = process.platform;
 beforeEach(() => {
 	showMessageBox.mockClear();
 	checkForUpdates.mockClear().mockResolvedValue(null);
+	currentWindow = makeWindow();
 	vi.stubEnv("NODE_ENV", "production");
 });
 
@@ -93,7 +114,7 @@ afterEach(() => {
 describe("checkForUpdatesNow", () => {
 	it("resolves up-to-date without claiming a version it does not have", async () => {
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		listeners.get("update-not-available")?.({});
 		await expect(pending).resolves.toEqual({ status: "up-to-date", version: "0.9.0" });
@@ -101,7 +122,7 @@ describe("checkForUpdatesNow", () => {
 
 	it("resolves with the available release and its notes URL", async () => {
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		listeners.get("update-available")?.({ version: "1.0.0" });
 		await expect(pending).resolves.toMatchObject({
@@ -113,7 +134,7 @@ describe("checkForUpdatesNow", () => {
 
 	it("resolves with the error rather than hanging", async () => {
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		listeners.get("error")?.(new Error("ENOTFOUND"));
 		await expect(pending).resolves.toEqual({ status: "error", message: "ENOTFOUND" });
@@ -123,7 +144,7 @@ describe("checkForUpdatesNow", () => {
 		// Two clicks - the menu item and the settings button, or an impatient
 		// double-click - must not race two checks whose events interleave.
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		checkForUpdates.mockClear();
 
 		const first = checkForUpdatesNow("renderer");
@@ -137,7 +158,7 @@ describe("checkForUpdatesNow", () => {
 	it("gives up rather than waiting forever for an event that never comes", async () => {
 		vi.useFakeTimers();
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		await vi.advanceTimersByTimeAsync(30_000);
 		await expect(pending).resolves.toEqual({
@@ -148,7 +169,7 @@ describe("checkForUpdatesNow", () => {
 
 	it("settles a check left waiting at teardown", async () => {
 		const { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		disposeAutoUpdater();
 		await expect(pending).resolves.toMatchObject({ status: "error" });
@@ -159,7 +180,7 @@ describe("checkForUpdatesNow", () => {
 		// would read as something being broken.
 		vi.stubEnv("NODE_ENV", "development");
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		await expect(checkForUpdatesNow("renderer")).resolves.toMatchObject({
 			status: "unavailable",
 		});
@@ -171,7 +192,7 @@ describe("checkForUpdatesNow", () => {
 		// like a bug rather than "this is a dev build".
 		vi.stubEnv("NODE_ENV", "development");
 		const { initAutoUpdater } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		expect([...ipcHandlers.keys()]).toEqual(
 			expect.arrayContaining([
 				"update:check",
@@ -210,14 +231,14 @@ describe("the macOS update instruction", () => {
 		// and stops the engine first.
 		quit.mockClear();
 		const { initAutoUpdater } = await loadUpdater("darwin");
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		await ipcHandlers.get("update:quitForUpdate")?.(null);
 		expect(quit).toHaveBeenCalled();
 	});
 
 	it("hands macOS users exactly the command the README publishes", async () => {
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		listeners.get("update-available")?.({ version: "1.0.0" });
 		await expect(pending).resolves.toMatchObject({
@@ -230,7 +251,7 @@ describe("the macOS update instruction", () => {
 describe("where the result is delivered", () => {
 	it("shows a native dialog for the menu, which has no UI of its own", async () => {
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("menu");
 		listeners.get("update-not-available")?.({});
 		await pending;
@@ -239,20 +260,106 @@ describe("where the result is delivered", () => {
 
 	it("shows no dialog for the settings panel, which renders the result itself", async () => {
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
 		listeners.get("update-not-available")?.({});
 		await pending;
 		expect(showMessageBox).not.toHaveBeenCalled();
 	});
 
+	it("parents the dialog to the window that is open now", async () => {
+		// The first window is gone and a dock-activate built a replacement. A
+		// dialog parented to the dead one is unowned; parented to the live one it
+		// is the sheet the user expects.
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		const firstWindow = currentWindow;
+
+		firstWindow!.destroyed = true;
+		const reopened = makeWindow();
+		currentWindow = reopened;
+
+		const pending = checkForUpdatesNow("menu");
+		listeners.get("update-not-available")?.({});
+		await pending;
+
+		expect(showMessageBox).toHaveBeenCalledWith(reopened, expect.anything());
+	});
+
+	it("still answers the menu when no window is open at all", async () => {
+		// macOS keeps the app running with every window closed, and the menu's
+		// "Check for Updates…" is still there to click. Dropping the answer
+		// because there is nothing to parent to would leave that click silent.
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		currentWindow = null;
+
+		const pending = checkForUpdatesNow("menu");
+		listeners.get("update-not-available")?.({});
+		await pending;
+
+		expect(showMessageBox).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "You're up to date" })
+		);
+	});
+
 	it("stays silent for the periodic check, which nobody is waiting on", async () => {
 		const { initAutoUpdater } = await loadUpdater();
-		initAutoUpdater(win);
+		initAutoUpdater(getWindow);
 		// No manual check in flight - the interval's events must not pop a
 		// dialog over whatever the user is doing.
 		listeners.get("update-not-available")?.({});
 		listeners.get("error")?.(new Error("offline"));
 		expect(showMessageBox).not.toHaveBeenCalled();
+	});
+
+	it("cancels a menu check at teardown without raising a dialog", async () => {
+		// `will-quit` settles the waiting check so nothing hangs, but the app is
+		// already going: a modal raised here either flashes past unread or holds
+		// up the quit.
+		const { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		const pending = checkForUpdatesNow("menu");
+
+		disposeAutoUpdater();
+
+		await expect(pending).resolves.toMatchObject({ status: "error" });
+		expect(showMessageBox).not.toHaveBeenCalled();
+	});
+});
+
+describe("which window the update events reach", () => {
+	it("sends to the window that exists now, not the one open at startup", async () => {
+		// macOS keeps the app alive when its window closes, and a dock-activate
+		// builds a new one. Holding the startup window would drop every periodic
+		// event from then on - and on the notify path that pushed banner is the
+		// entire passive update path, so update discovery would stop for the rest
+		// of the session.
+		const { initAutoUpdater } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		const firstWindow = currentWindow!;
+
+		firstWindow.destroyed = true;
+		const reopened = makeWindow();
+		currentWindow = reopened;
+
+		listeners.get("update-available")?.({ version: "1.0.0" });
+
+		expect(reopened.webContents.send).toHaveBeenCalledWith(
+			"update:available",
+			expect.objectContaining({ version: "1.0.0" })
+		);
+		expect(firstWindow.webContents.send).not.toHaveBeenCalled();
+	});
+
+	it("drops the event rather than sending into a destroyed window", async () => {
+		const { initAutoUpdater } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		const win = currentWindow!;
+		win.destroyed = true;
+
+		listeners.get("update-downloaded")?.({ version: "1.0.0" });
+
+		expect(win.webContents.send).not.toHaveBeenCalled();
 	});
 });

--- a/app/electron/updater.ts
+++ b/app/electron/updater.ts
@@ -81,7 +81,24 @@ let intervalTimer: NodeJS.Timeout | null = null;
 /** True once initAutoUpdater has configured the updater (not in dev). */
 let updaterReady = false;
 let pendingCheck: PendingCheck | null = null;
-let mainWindowRef: BrowserWindow | null = null;
+let resolveWindow: WindowAccessor | null = null;
+
+/**
+ * How the updater finds the window to talk to, asked fresh every time.
+ *
+ * Not a captured `BrowserWindow`: on macOS the app outlives its window, and a
+ * dock-activate builds a new one. A reference taken at startup would point at
+ * the closed window for the rest of the session, so every periodic update event
+ * would hit the `isDestroyed()` guard and be dropped - and on macOS that banner
+ * is the whole passive update path.
+ */
+export type WindowAccessor = () => BrowserWindow | null;
+
+/** The window as it is right now, or null if there isn't a usable one. */
+function liveWindow(): BrowserWindow | null {
+	const win = resolveWindow?.() ?? null;
+	return win && !win.isDestroyed() ? win : null;
+}
 
 /**
  * Wire up auto-update for the current platform.
@@ -92,7 +109,7 @@ let mainWindowRef: BrowserWindow | null = null;
  *     newer release in the UI; the user updates out-of-band.
  *   - disabled (development): no-op.
  */
-export function initAutoUpdater(win: BrowserWindow): void {
+export function initAutoUpdater(getWindow: WindowAccessor): void {
 	const isDev = process.env.NODE_ENV === "development";
 	const isAppImage = Boolean(process.env.APPIMAGE);
 	const strategy = resolveUpdateStrategy({
@@ -101,7 +118,7 @@ export function initAutoUpdater(win: BrowserWindow): void {
 		isAppImage,
 	});
 
-	mainWindowRef = win;
+	resolveWindow = getWindow;
 
 	// Registered before the `disabled` bail-out. The renderer calls these
 	// unconditionally, and an unregistered channel rejects with "No handler
@@ -142,9 +159,7 @@ export function initAutoUpdater(win: BrowserWindow): void {
 	autoUpdater.allowPrerelease = false;
 
 	const send = (channel: string, payload: unknown) => {
-		if (!win.isDestroyed()) {
-			win.webContents.send(channel, payload);
-		}
+		liveWindow()?.webContents.send(channel, payload);
 	};
 
 	autoUpdater.on("update-available", (info) => {
@@ -185,30 +200,50 @@ export function initAutoUpdater(win: BrowserWindow): void {
 }
 
 /**
- * Deliver the outcome of the check the user is waiting on, if any.
+ * Show a dialog parented to the window the user is actually looking at.
  *
- * Events fire for the periodic check too, so a result with nothing waiting is
- * dropped - that is the silent path doing its job, not a missed answer.
+ * Parenting matters (a sheet on macOS, a modal owned by the window elsewhere),
+ * but a missing window must not swallow the message: with no live window the
+ * dialog is shown unparented rather than not at all, which is the macOS
+ * all-windows-closed case for the menu's "Check for Updates…".
  */
-function settleCheck(result: UpdateCheckResult): void {
+function showUpdateDialog(options: Electron.MessageBoxOptions): void {
+	const win = liveWindow();
+	void (win ? dialog.showMessageBox(win, options) : dialog.showMessageBox(options));
+}
+
+/**
+ * Claim the check the user is waiting on, if any, so it can be answered exactly
+ * once. Events fire for the periodic check too, so nothing waiting means there
+ * is nothing to answer - that is the silent path doing its job, not a missed
+ * result.
+ */
+function takePendingCheck(): PendingCheck | null {
 	const pending = pendingCheck;
-	if (!pending) return;
+	if (!pending) return null;
 	pendingCheck = null;
 	clearTimeout(pending.timer);
+	return pending;
+}
+
+/** Deliver the outcome of the check the user is waiting on, if any. */
+function settleCheck(result: UpdateCheckResult): void {
+	const pending = takePendingCheck();
+	if (!pending) return;
 
 	// The menu item has no UI of its own, so it reports through a native
 	// dialog. The settings panel renders the same result in place, and a modal
 	// on top of it would be redundant.
-	if (pending.source === "menu" && mainWindowRef) {
+	if (pending.source === "menu") {
 		if (result.status === "up-to-date") {
-			void dialog.showMessageBox(mainWindowRef, {
+			showUpdateDialog({
 				type: "info",
 				message: "You're up to date",
 				detail: `Vayu ${result.version} is the latest version.`,
 				buttons: ["OK"],
 			});
 		} else if (result.status === "error") {
-			void dialog.showMessageBox(mainWindowRef, {
+			showUpdateDialog({
 				type: "error",
 				message: "Couldn't check for updates",
 				detail: result.message,
@@ -232,8 +267,8 @@ export function checkForUpdatesNow(source: CheckSource = "menu"): Promise<Update
 			status: "unavailable",
 			detail: "Update checks only run in packaged builds of Vayu.",
 		};
-		if (source === "menu" && mainWindowRef) {
-			void dialog.showMessageBox(mainWindowRef, {
+		if (source === "menu") {
+			showUpdateDialog({
 				type: "info",
 				message: "Updates unavailable",
 				detail: result.detail,
@@ -269,13 +304,18 @@ export function checkForUpdatesNow(source: CheckSource = "menu"): Promise<Update
 	return promise;
 }
 
-/** Stop the periodic check (used on app teardown / tests). */
+/**
+ * Stop the periodic check. Called from `will-quit` in main.ts, and by tests.
+ *
+ * The waiting check is settled without a dialog: the app is on its way out, and
+ * a modal raised during teardown either flashes past unread or holds up the
+ * quit. The caller still gets its answer, so no promise is left hanging.
+ */
 export function disposeAutoUpdater(): void {
 	if (intervalTimer) {
 		clearInterval(intervalTimer);
 		intervalTimer = null;
 	}
-	// A check waiting on an event that will never arrive now the app is going
-	// away: settle it so nothing is left hanging on the promise.
-	settleCheck({ status: "error", message: "The update check was cancelled." });
+	takePendingCheck()?.settle({ status: "error", message: "The update check was cancelled." });
+	resolveWindow = null;
 }

--- a/app/src/hooks/useAppUpdate.test.ts
+++ b/app/src/hooks/useAppUpdate.test.ts
@@ -72,6 +72,36 @@ describe("useAppUpdate", () => {
 		expect(result.current.readyToInstall).toBe(true);
 	});
 
+	test("a newly announced version is not installable until it has downloaded", () => {
+		// The silent path's nastiest edge: v1 is downloaded and the banner offers
+		// "restart to install", then the 6h check announces v2. The banner's
+		// version updates, so leaving readyToInstall true offers to install a
+		// version that is still downloading - and what quitAndInstall then finds
+		// staged is v1 on Windows, or on AppImage a file electron-updater has
+		// already deleted, taking the running AppImage with it.
+		const { result } = renderHook(() => useAppUpdate());
+		act(() => {
+			availableCb?.({ version: "1.2.3", strategy: "silent", releaseUrl: "u" });
+		});
+		act(() => {
+			downloadedCb?.({ version: "1.2.3" });
+		});
+		expect(result.current.readyToInstall).toBe(true);
+
+		act(() => {
+			availableCb?.({ version: "1.3.0", strategy: "silent", releaseUrl: "u" });
+		});
+		expect(result.current.readyToInstall).toBe(false);
+		// Nothing actionable to show while it downloads, either.
+		expect(result.current.update).toBeNull();
+
+		act(() => {
+			downloadedCb?.({ version: "1.3.0" });
+		});
+		expect(result.current.readyToInstall).toBe(true);
+		expect(result.current.update?.version).toBe("1.3.0");
+	});
+
 	test("dismiss hides the banner", () => {
 		const { result } = renderHook(() => useAppUpdate());
 		act(() => {

--- a/app/src/hooks/useAppUpdate.ts
+++ b/app/src/hooks/useAppUpdate.ts
@@ -41,11 +41,13 @@ export function useAppUpdate(): AppUpdateState {
 
 		const offAvailable = api.onUpdateAvailable((info) => {
 			setUpdate(info);
-			// Silent path downloads in the background; wait for update-downloaded.
-			// Notify path surfaces immediately.
-			if (info.strategy === "notify") {
-				setReadyToInstall(false);
-			}
+			// A newly announced version is by definition not the downloaded one, on
+			// either path. Leaving this true across an announcement let the silent
+			// path offer "restart to install" for a version still downloading, and
+			// the restart then installs whatever is staged - the previous version on
+			// Windows, or a file electron-updater has already deleted on AppImage.
+			// `update-downloaded` sets it again for the version the banner names.
+			setReadyToInstall(false);
 		});
 
 		const offDownloaded = api.onUpdateDownloaded((info) => {


### PR DESCRIPTION
## Description

First of the E3 cluster from the 2026-08-02 Electron main-process sweep (#278). Verified against current master `ed8fe1a`: every anchor in the issue still holds as described, so no adaptation was needed.

**Plan.** The root cause of (1) is that `initAutoUpdater` runs exactly once and stores a `BrowserWindow` - in `mainWindowRef` and in the `send` closure - while on macOS the app outlives its window and a dock-activate builds a new one, so from the first close/reopen on, every periodic update event hits a destroyed window's guard and is dropped. The fix inverts the direction: the updater is handed a `() => BrowserWindow | null` accessor backed by main.ts's own `mainWindow` variable and resolves it on every send and every dialog. The alternative I rejected was re-binding the updater from `createWindow()`, which works but adds a lifecycle hook that a future window path can forget; an accessor cannot go stale. Root cause of (2) is that `useAppUpdate` treated "not downloaded yet" as a notify-path-only condition, when a newly announced version is by definition not the downloaded one on either path - so the reset became unconditional rather than growing a second strategy branch.

Three changes:

1. **`initAutoUpdater(getWindow)`** (`app/electron/updater.ts`, `app/electron/main.ts`). `send` and both dialog paths go through `liveWindow()`, which asks the accessor and drops a destroyed window. With no live window at all the menu's dialog is now shown *unparented* rather than not at all - on macOS the menu's "Check for Updates…" is clickable with every window closed, and dropping the answer would leave that click silent.
2. **`readyToInstall` resets on any `update-available`** (`app/src/hooks/useAppUpdate.ts`). On the silent path a v2 announced while v1 sat downloaded left the banner offering "restart to install" for a version still downloading; `update-downloaded` restores the flag for the version the banner actually names. This makes the two installer edges in the issue (Windows installing the staged v1, AppImage unlinking the running file after the v2 sha mismatch deleted the staged one) unreachable, which is why they are not tested directly - they are electron-updater internals.
3. **`disposeAutoUpdater` wired to `will-quit`** (`app/electron/main.ts`). It had only test callers, leaving `intervalTimer` production-write-only. Wiring it meant it must not raise a dialog during teardown, so the pending-check bookkeeping is factored into `takePendingCheck()` and dispose settles the waiting promise without the announcement `settleCheck` would have made.

Deviation from the issue spec: none in substance. The issue offered "wire `disposeAutoUpdater` **or** trim its comment" - I wired it, which required the dialog-free cancel above (a small addition the issue did not name, justified by not popping a modal mid-quit).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **283 files, 2459 tests, all passing** (was 2454 before; 5 new). `pnpm type-check`, `pnpm lint` and `prettier --check` on the touched files are green. No pre-existing failures observed.

Engine untouched, so no engine build or ctest run: no C++ source, CMake input or engine behaviour is in the diff, and no engine test could change colour.

New tests, each mutation-checked (fix reverted, test confirmed failing, fix restored):

`app/electron/updater.test.ts` - the fake window became a mutable `currentWindow` the tests move the way the app does (closed on the X, rebuilt on dock-activate):
- *sends to the window that exists now, not the one open at startup* - fails when the window is captured at init.
- *drops the event rather than sending into a destroyed window* - keeps the old guard honest.
- *parents the dialog to the window that is open now* - fails against a frozen ref.
- *still answers the menu when no window is open at all* - fails if a missing window suppresses the dialog.
- *cancels a menu check at teardown without raising a dialog* - fails if dispose routes through `settleCheck`.

`app/src/hooks/useAppUpdate.test.ts`:
- *a newly announced version is not installable until it has downloaded* - the silent-path sequence available(1.2.3) → downloaded(1.2.3) → available(1.3.0) → downloaded(1.3.0); fails with the `strategy === "notify"` guard restored.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Documentation: none needed, as the issue predicted and I verified - no repo doc describes the updater event flow (`docs/architecture.md` covers app/engine lifecycle, not updater internals; a grep across `docs/` for `initAutoUpdater`, `autoUpdater`, `update:available` and `readyToInstall` returns nothing). The README's `macInstallCommand` contract is untouched and still guarded by `updater.test.ts`.

Consumer check per CLAUDE.md's written-never-read rule: `update:available` / `update:downloaded` are bridged in `preload.ts` and read only by `useAppUpdate`, whose only consumer is `UpdateBanner.tsx`. `initAutoUpdater` has no callers outside `main.ts` and its test.

## Related Issues
Closes #272

---
_Generated by [Claude Code](https://claude.ai/code/session_011hcQeicyoTZABPTTRx3mzz)_