### PR TITLE
feat(engine,app): store response headers and body for sampled load-run requests

### DIFF
--- a/app/src/components/shared/CapturedDataWarning.test.tsx
+++ b/app/src/components/shared/CapturedDataWarning.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Issue #174: capture stores response headers and bodies verbatim - the
+ * decision was explicitly *not* to redact, on the grounds that design-mode
+ * traces already store request headers as sent and a redaction guess is wrong
+ * in both directions. The mitigation for that decision is this notice, so a
+ * silent version of it is the same as not having made the decision.
+ *
+ * Mutation check: drop the `captured > 0` guard and the "says nothing" cases
+ * fail; drop the component from SamplesTab and its own test fails.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CapturedDataWarning } from "./CapturedDataWarning";
+import type { RunReport } from "@/types/domain";
+
+function sampling(over: Partial<NonNullable<RunReport["sampling"]>> = {}) {
+	return {
+		errorsDropped: 0,
+		successTracesDropped: 0,
+		slowTracesDropped: 0,
+		responseSamplesDropped: 0,
+		...over,
+	};
+}
+
+describe("CapturedDataWarning", () => {
+	it("warns when the run stored captured responses", () => {
+		render(<CapturedDataWarning sampling={sampling({ responseBodiesCaptured: 12 })} />);
+		expect(screen.getByText("Captured response data")).toBeTruthy();
+		expect(screen.getByText(/12 responses/)).toBeTruthy();
+		// The expiry is the actionable half - without it the notice is a worry
+		// with no answer.
+		expect(screen.getByText("maxRunsRetained")).toBeTruthy();
+	});
+
+	it("says nothing when the run captured nothing", () => {
+		const { container } = render(
+			<CapturedDataWarning sampling={sampling({ responseBodiesCaptured: 0 })} />
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("says nothing on a run recorded before capture existed", () => {
+		// The field is absent, not zero - "we cannot tell" is worse as prose
+		// than as absence, the same rule SampleRetentionNote follows.
+		const { container } = render(<CapturedDataWarning sampling={sampling()} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("says nothing when the report has no sampling section at all", () => {
+		const { container } = render(<CapturedDataWarning sampling={undefined} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("mentions bodies the run's budget could not keep", () => {
+		render(
+			<CapturedDataWarning
+				sampling={sampling({ responseBodiesCaptured: 3, sampleBodiesDropped: 40 })}
+			/>
+		);
+		expect(screen.getByText(/40 further bodies were not captured/)).toBeTruthy();
+	});
+});

--- a/app/src/components/shared/CapturedDataWarning.tsx
+++ b/app/src/components/shared/CapturedDataWarning.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * "The responses below were stored verbatim" - wherever a run's captured
+ * exchanges are on screen.
+ *
+ * Capture does not redact, deliberately and consistently with design-mode
+ * traces, which already store request headers as sent. The mitigation for that
+ * decision is this notice plus the run's own persisted marker
+ * (`sampling.responseBodiesCaptured`), rather than the UI trying to guess which
+ * header or body field is a credential - a guess that is wrong in both
+ * directions and gives false confidence when it is wrong the reassuring way.
+ *
+ * Silent when the run captured nothing, and silent on runs recorded before
+ * capture existed (the field is absent, not zero). Both surfaces that show
+ * captured samples render it, so the wording lives here once.
+ */
+
+import { Callout } from "./Callout";
+import type { RunReport } from "@/types/domain";
+
+export interface CapturedDataWarningProps {
+	sampling: RunReport["sampling"];
+	className?: string;
+}
+
+export function CapturedDataWarning({ sampling, className }: CapturedDataWarningProps) {
+	const captured = sampling?.responseBodiesCaptured ?? 0;
+	if (captured <= 0) return null;
+
+	const droppedForBudget = sampling?.sampleBodiesDropped ?? 0;
+
+	return (
+		<Callout severity="warning" title="Captured response data" className={className}>
+			This run stored {captured.toLocaleString()} response
+			{captured === 1 ? "" : "s"} exactly as received, headers included, so anything
+			credential-shaped the server sent - a <code>Set-Cookie</code>, a token in a body - is
+			stored with them. It is deleted when the run is, so the <code>maxRunsRetained</code>{" "}
+			setting is its expiry.
+			{droppedForBudget > 0 && (
+				<>
+					{" "}
+					{droppedForBudget.toLocaleString()} further{" "}
+					{droppedForBudget === 1 ? "body was" : "bodies were"} not captured once the
+					run&apos;s budget was spent.
+				</>
+			)}
+		</Callout>
+	);
+}

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -27,6 +27,9 @@ export * from "./callout-severity";
 // "These 100 samples are 100 of 30,000" - wherever a sampled set is displayed
 export * from "./SampleRetentionNote";
 
+// "These responses were stored verbatim" - wherever captured samples are shown
+export * from "./CapturedDataWarning";
+
 // Row "⋯" actions menu (requests, environments)
 export * from "./RowActionsMenu";
 

--- a/app/src/components/shared/response-viewer/CapturedResponseNotice.tsx
+++ b/app/src/components/shared/response-viewer/CapturedResponseNotice.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What a captured load-run response is *not*, said out loud.
+ *
+ * A load run captures its failures, its slow outliers and a few exemplars of
+ * each status code, within a per-body cap and a whole-run budget. All three
+ * limits can leave a reader looking at something that is not the response the
+ * server sent, and the difference is invisible in the bytes:
+ *
+ * - a truncated body ends mid-JSON and looks like a malformed response;
+ * - a body dropped for budget looks like an empty response;
+ * - a binary body has no text at all, and rendering the bytes as text would
+ *   produce a mojibake that reads like a real one.
+ *
+ * Both surfaces that show captured samples (the dashboard's Sampled Requests
+ * and the history Samples tab) render this, so the wording exists once instead
+ * of twice and drifting.
+ */
+
+import { Callout } from "../Callout";
+import type { RunSample } from "@/types/domain";
+
+export interface CapturedResponseNoticeProps {
+	response: RunSample["response"];
+	className?: string;
+}
+
+/** Human-readable byte count - "1.2 KB", "34 B". */
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function CapturedResponseNotice({ response, className }: CapturedResponseNoticeProps) {
+	if (response.binary) {
+		return (
+			<Callout severity="info" title="Binary response" className={className}>
+				{formatBytes(response.bodyBytes)}
+				{response.contentType ? ` of ${response.contentType}` : ""} was received. Binary
+				bodies are recorded by size and type rather than stored as text, which would show
+				you a corrupted version of them.
+			</Callout>
+		);
+	}
+
+	if (response.bodyDropped) {
+		return (
+			<Callout severity="warning" title="Body not captured" className={className}>
+				This response was {formatBytes(response.bodyBytes)}, but the run had already spent
+				its capture budget. Its headers were kept; the body was not. Raise{" "}
+				<code>maxSampleBytes</code> in Settings to capture more.
+			</Callout>
+		);
+	}
+
+	if (response.bodyTruncated) {
+		return (
+			<Callout severity="info" title="Body truncated" className={className}>
+				Showing the first part of a {formatBytes(response.bodyBytes)} response. Raise{" "}
+				<code>maxSampleBodyBytes</code> in Settings to keep more of each captured body.
+			</Callout>
+		);
+	}
+
+	return null;
+}

--- a/app/src/components/shared/response-viewer/UnifiedResponseViewer.tsx
+++ b/app/src/components/shared/response-viewer/UnifiedResponseViewer.tsx
@@ -39,8 +39,12 @@ export default function UnifiedResponseViewer({
 }: UnifiedResponseViewerProps) {
 	const [activeTab, setActiveTab] = useState<ResponseTab>("body");
 
-	// Empty state
-	if (!response?.body && !request) {
+	// Empty state. Headers count as content, not just a body: a load-run sample
+	// whose body was binary or dropped for the run's capture budget (#174) has
+	// real headers and no body, and calling that "no response captured" would
+	// hide the only thing the run did keep.
+	const hasHeaders = !!response?.headers && Object.keys(response.headers).length > 0;
+	if (!response?.body && !hasHeaders && !request) {
 		return (
 			<div className={cn("flex-1 flex surface-card", className)}>
 				<EmptyState

--- a/app/src/components/shared/response-viewer/index.ts
+++ b/app/src/components/shared/response-viewer/index.ts
@@ -22,6 +22,10 @@ export {
 	ResponseHeadersPanel,
 } from "./HeadersViewer";
 export type { ResponseHeadersPanelProps } from "./HeadersViewer";
+// Says what a captured load-run response is *not* - truncated, dropped for
+// budget, or binary. Rendered by both surfaces that show captured samples.
+export { CapturedResponseNotice } from "./CapturedResponseNotice";
+export type { CapturedResponseNoticeProps } from "./CapturedResponseNotice";
 export { StatusCodeBadge } from "./StatusCodeBadge";
 export type { StatusCodeBadgeProps } from "./StatusCodeBadge";
 

--- a/app/src/components/shared/response-viewer/sampled-exchange-adoption.test.tsx
+++ b/app/src/components/shared/response-viewer/sampled-exchange-adoption.test.tsx
@@ -30,6 +30,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import type { RunReport } from "@/types";
+import { withQueryClient } from "@/test/query-wrapper";
 
 vi.mock("@/components/shared/response-viewer/SampledExchange", () => ({
 	SampledExchange: (props: Record<string, unknown>) => (
@@ -80,7 +81,7 @@ describe("both sampled views render through SampledExchange (#76)", () => {
 			],
 		} as unknown as RunReport;
 
-		render(<RequestResponseView report={report} />);
+		render(withQueryClient(<RequestResponseView report={report} />));
 
 		const row = screen.getByTestId("sampled-exchange");
 		expect(row).toHaveAttribute("data-status", "503");

--- a/app/src/components/shared/response-viewer/timing-phases.test.tsx
+++ b/app/src/components/shared/response-viewer/timing-phases.test.tsx
@@ -38,6 +38,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { TooltipProvider } from "@/components/ui";
 import type { RunReport } from "@/types";
+import { withQueryClient } from "@/test/query-wrapper";
 
 /** The synthetic sixth phase. Nothing in the app declares it. */
 const PROBE = {
@@ -156,7 +157,7 @@ describe("every timing renderer reads TIMING_PHASES (#76)", () => {
 			await import("@/modules/dashboard/components/RequestResponseView")
 		).default;
 
-		withTooltips(<RequestResponseView report={reportWithSample()} />);
+		withTooltips(withQueryClient(<RequestResponseView report={reportWithSample()} />));
 
 		expect(screen.getByText(PROBE.longLabel)).toBeInTheDocument();
 	});
@@ -166,7 +167,7 @@ describe("every timing renderer reads TIMING_PHASES (#76)", () => {
 			await import("@/modules/dashboard/components/RequestResponseView")
 		).default;
 
-		withTooltips(<RequestResponseView report={reportWithSample()} />);
+		withTooltips(withQueryClient(<RequestResponseView report={reportWithSample()} />));
 		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
 
 		// The averages card prints `longLabel`, the tiles print `label` - so a

--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -82,6 +82,12 @@ export const API_ENDPOINTS = {
 	RUN_BY_ID: (id: string) => `/runs/${id}`,
 	RUN_REPORT: (id: string) => `/runs/${id}/report`,
 	RUN_STOP: (id: string) => `/runs/${id}/stop`,
+	// The response headers and body captured for a run's retained samples.
+	// Separate from the report on purpose: the report path loads and parses
+	// every result row for a run on each fetch and the dashboard polls it, so
+	// bodies are fetched here instead, only when a sample is expanded.
+	RUN_SAMPLES: (id: string, limit: number, offset: number) =>
+		`/runs/${id}/samples?limit=${limit}&offset=${offset}`,
 
 	// Real-time stats (SSE, memory-based, faster)
 	METRICS_LIVE: (runId: string) => `/runs/${runId}/live`,

--- a/app/src/config/network.ts
+++ b/app/src/config/network.ts
@@ -40,6 +40,13 @@ export const ENGINE_MAX_DEFAULT_TIMEOUT_MS = 300_000;
 export const STATS_PAGE_LIMIT = 5000;
 
 /**
+ * Page size for `GET /runs/:id/samples`. The report itself serialises at most
+ * 100 result rows, so one page covers every sample a surface can show; the
+ * engine caps a page at 500 either way.
+ */
+export const RUN_SAMPLES_PAGE_LIMIT = 100;
+
+/**
  * Page size for the paginated `GET /runs` history list. The engine caps a page
  * at 500; the history sidebar polls only the first page (newest runs land on
  * page 1 under start_time DESC) and pages older runs in on demand.

--- a/app/src/modules/dashboard/components/RequestResponseView.failures.test.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.failures.test.tsx
@@ -23,6 +23,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import RequestResponseView from "./RequestResponseView";
+import { withQueryClient } from "@/test/query-wrapper";
 import type { RunReport } from "@/types";
 
 // ResponseBody mounts Monaco via CodeEditor; stub it so an expanded sample
@@ -66,7 +67,7 @@ function makeReportWithFailures(): RunReport {
 
 describe("RequestResponseView renders per-test validation failures (#111)", () => {
 	it("lists each failing test's message when a validation-failure row is expanded", () => {
-		render(<RequestResponseView report={makeReportWithFailures()} />);
+		render(withQueryClient(<RequestResponseView report={makeReportWithFailures()} />));
 
 		// The row's error preview carries the summary text; expand it.
 		fireEvent.click(screen.getByRole("button", { name: /Script validation failures/ }));
@@ -81,7 +82,7 @@ describe("RequestResponseView renders per-test validation failures (#111)", () =
 		const report = makeReportWithFailures();
 		report.results![0].trace = { error_type: "ConnectionError" };
 		report.results![0].error = "connection refused";
-		render(<RequestResponseView report={report} />);
+		render(withQueryClient(<RequestResponseView report={report} />));
 
 		fireEvent.click(screen.getByRole("button", { name: /connection refused/ }));
 

--- a/app/src/modules/dashboard/components/RequestResponseView.primitives.test.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.primitives.test.tsx
@@ -18,13 +18,20 @@
  * to raw `.toFixed(1)` for the per-sample phase cards, so a 0.04ms cached DNS
  * lookup rendered as `0.0ms` - the only signal there is, rounded away. Revert
  * the cards to `.toFixed(1)` and the `0.04ms` assertion below fails.
+ *
+ * The fixture used to hand-author `trace.headers` / `trace.body` - a flat shape
+ * no engine writer emits, so this file exercised a dead branch in CI for as
+ * long as it existed (issue #174). Headers and bodies now arrive from
+ * `GET /runs/:id/samples`, which is what the mocked `getRunSamples` below
+ * stands in for.
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui";
+import { withQueryClient } from "@/test/query-wrapper";
 import RequestResponseView from "./RequestResponseView";
-import type { RunReport } from "@/types";
+import type { RunReport, RunSamplesResponse } from "@/types";
 
 // ResponseBody mounts Monaco via CodeEditor; stub it so the expanded sample
 // renders in jsdom.
@@ -33,8 +40,22 @@ vi.mock("@/components/ui", async (importOriginal) => ({
 	CodeEditor: () => <div data-testid="code-editor" />,
 }));
 
+const getRunSamples = vi.fn();
+vi.mock("@/services/api", () => ({
+	apiService: {
+		getRunSamples: (...a: unknown[]) => getRunSamples(...a),
+	},
+}));
+
 function makeReport(): RunReport {
 	return {
+		metadata: {
+			runId: "run_1",
+			runType: "load",
+			status: "completed",
+			startTime: 0,
+			endTime: 1,
+		},
 		summary: {
 			totalRequests: 1,
 			successfulRequests: 1,
@@ -48,29 +69,48 @@ function makeReport(): RunReport {
 		errors: { total: 0, withDetails: 0, types: {} },
 		results: [
 			{
+				id: 7,
 				timestamp: 1_700_000_000_000,
 				statusCode: 200,
 				statusText: "OK",
 				latencyMs: 5,
-				trace: {
-					dnsMs: 0.04,
-					connectMs: 12.5,
-					headers: { "content-type": "application/json" },
-					body: '{"ok":true}',
-				},
+				trace: { dnsMs: 0.04, connectMs: 12.5 },
 			},
 		],
 	};
 }
 
-// Components here use `InfoChip`, which no longer brings its own
-// `TooltipProvider` - the delay is set once at the app root (main.tsx).
+function samplesPage(): RunSamplesResponse {
+	return {
+		data: [
+			{
+				resultId: 7,
+				response: {
+					headers: { "content-type": "application/json" },
+					body: '{"ok":true}',
+					bodyBytes: 11,
+				},
+			},
+		],
+		pagination: { total: 1, limit: 100, offset: 0, hasMore: false, returned: 1 },
+	};
+}
+
 const renderView = () =>
 	render(
-		<TooltipProvider>
-			<RequestResponseView report={makeReport()} />
-		</TooltipProvider>
+		// InfoChip no longer brings its own TooltipProvider - the delay is set
+		// once at the app root (main.tsx).
+		withQueryClient(
+			<TooltipProvider>
+				<RequestResponseView report={makeReport()} />
+			</TooltipProvider>
+		)
 	);
+
+beforeEach(() => {
+	getRunSamples.mockReset();
+	getRunSamples.mockResolvedValue(samplesPage());
+});
 
 describe("RequestResponseView shared-primitive adoption (#60)", () => {
 	it("renders the sample status through StatusCodeBadge", () => {
@@ -90,13 +130,46 @@ describe("RequestResponseView shared-primitive adoption (#60)", () => {
 		expect(screen.queryByText(/0\.0ms/)).toBeNull();
 	});
 
-	it("renders response headers through the shared CompactHeadersViewer", () => {
+	it("renders captured response headers through the shared CompactHeadersViewer", async () => {
 		renderView();
 		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
 
 		// CompactHeadersViewer renders each name as `key:`; the reverted
 		// hand-rolled div map did too, so pin the shared surface it declares.
-		const header = screen.getByText("content-type:");
+		const header = await screen.findByText("content-type:");
 		expect(header.closest(".surface-sunken")).not.toBeNull();
+	});
+});
+
+describe("RequestResponseView captured samples (#174)", () => {
+	it("does not fetch captured bodies until a sample is expanded", async () => {
+		renderView();
+		expect(getRunSamples).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
+		await waitFor(() => expect(getRunSamples).toHaveBeenCalledWith("run_1"));
+	});
+
+	it("renders the captured body, joined to the row by result id", async () => {
+		renderView();
+		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
+		expect(await screen.findByText("Response Body")).toBeTruthy();
+	});
+
+	it("shows nothing when the run captured no exchange for this row", async () => {
+		// A sample whose result id is absent from the captured page - the normal
+		// case for a uniformly sampled success, which is deliberately body-less.
+		getRunSamples.mockResolvedValue({
+			data: [],
+			pagination: { total: 0, limit: 100, offset: 0, hasMore: false, returned: 0 },
+		});
+		renderView();
+		fireEvent.click(screen.getByRole("button", { name: /200 OK/ }));
+
+		await waitFor(() => expect(getRunSamples).toHaveBeenCalled());
+		// Not an empty "Response Body" heading: a heading over nothing reads as
+		// a bug in the engine rather than as "this sample has no body".
+		expect(screen.queryByText("Response Body")).toBeNull();
+		expect(screen.queryByText("Response Headers")).toBeNull();
 	});
 });

--- a/app/src/modules/dashboard/components/RequestResponseView.retention.test.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.retention.test.tsx
@@ -25,6 +25,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui";
 import RequestResponseView from "./RequestResponseView";
+import { withQueryClient } from "@/test/query-wrapper";
 import type { RunReport } from "@/types";
 
 vi.mock("@/components/ui", async (importOriginal) => ({
@@ -60,9 +61,11 @@ function makeReport(sampling?: RunReport["sampling"]): RunReport {
 
 const renderReport = (sampling?: RunReport["sampling"]) =>
 	render(
-		<TooltipProvider>
-			<RequestResponseView report={makeReport(sampling)} />
-		</TooltipProvider>
+		withQueryClient(
+			<TooltipProvider>
+				<RequestResponseView report={makeReport(sampling)} />
+			</TooltipProvider>
+		)
 	);
 
 describe("RequestResponseView retention", () => {

--- a/app/src/modules/dashboard/components/RequestResponseView.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.tsx
@@ -20,12 +20,14 @@ import { InfoChip } from "./shared";
 import { formatPhaseDuration } from "@/components/shared/response-viewer/utils";
 import {
 	CompactHeadersViewer,
+	CapturedResponseNotice,
 	ResponseBody,
 	SampledExchange,
 	phasesFromAverages,
 	phasesFromTrace,
 } from "@/components/shared/response-viewer";
-import { SampleRetentionNote } from "@/components/shared";
+import { SampleRetentionNote, CapturedDataWarning } from "@/components/shared";
+import { useRunSamplesQuery } from "@/queries/runs";
 import { httpStatusClass, statusCodeLabel, STATUS_CLASS_STYLE } from "@/constants/http-status";
 
 // Helper to format timestamp
@@ -44,6 +46,14 @@ function formatTime(timestamp: number): string {
 
 export default function RequestResponseView({ report }: RequestResponseViewProps) {
 	const [expandedResults, setExpandedResults] = useState<Set<number>>(new Set());
+
+	// Fetched only once a row is open. The captured bodies are deliberately not
+	// part of the report payload - that response is polled, and this one is not.
+	// The hook runs before the early return below, as hooks must.
+	const { data: capturedSamples } = useRunSamplesQuery(
+		report?.metadata?.runId ?? null,
+		expandedResults.size > 0
+	);
 
 	if (!report) {
 		return (
@@ -266,10 +276,15 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 							budget="traces"
 							className="mx-5 mb-3"
 						/>
+						<CapturedDataWarning sampling={report.sampling} className="mx-5 mb-3" />
 						<ScrollArea className="h-[400px]">
 							<div className="divide-y">
 								{report.results.map((result, index) => {
 									const trace = result.trace;
+									const captured =
+										result.id === undefined
+											? undefined
+											: capturedSamples?.get(result.id);
 
 									// The phases this sample actually reported, in wire order, from the
 									// shared descriptor. Absent ones are dropped: a trace with no TLS is
@@ -359,34 +374,43 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 												</div>
 											)}
 
-											{/* Response Headers - the shared compact viewer. It declares its
-											    own `surface-sunken`, so its row rules resolve correctly on the
-											    shell's `bg-muted/30` panel where a bare `border-rule` would
-											    fall back to invisible. */}
-											{trace?.headers && (
-												<CompactHeadersViewer
-													headers={trace.headers}
-													title="Response Headers"
-													className="max-h-40 overflow-auto"
-												/>
-											)}
-
-											{/* Response Body - the shared viewer (pretty/raw/preview with
-											    body-type detection), not a raw `<pre>`. */}
-											{trace?.body && (
-												<div className="space-y-1">
-													<p className="text-xs font-medium text-muted-foreground">
-														Response Body
-													</p>
-													<div className="h-48 overflow-hidden rounded-md border border-rule">
-														<ResponseBody
-															body={trace.body}
-															headers={trace.headers || {}}
-															height="100%"
-															compact
+											{/* The captured exchange (issue #174). These two blocks used
+											    to read flat `trace.headers` / `trace.body`, a shape no
+											    engine writer emits at that nesting, so both were dead and
+											    this panel showed timing and nothing else. The bodies now
+											    come from GET /runs/:id/samples, fetched only once a row is
+											    expanded. */}
+											{captured && (
+												<>
+													<CapturedResponseNotice
+														response={captured.response}
+													/>
+													{Object.keys(captured.response.headers).length >
+														0 && (
+														<CompactHeadersViewer
+															headers={captured.response.headers}
+															title="Response Headers"
+															className="max-h-40 overflow-auto"
 														/>
-													</div>
-												</div>
+													)}
+													{captured.response.body && (
+														<div className="space-y-1">
+															<p className="text-xs font-medium text-muted-foreground">
+																Response Body
+															</p>
+															<div className="h-48 overflow-hidden rounded-md border border-rule">
+																<ResponseBody
+																	body={captured.response.body}
+																	headers={
+																		captured.response.headers
+																	}
+																	height="100%"
+																	compact
+																/>
+															</div>
+														</div>
+													)}
+												</>
 											)}
 										</SampledExchange>
 									);

--- a/app/src/modules/history/main/components/SampleRequestCard.primitives.test.tsx
+++ b/app/src/modules/history/main/components/SampleRequestCard.primitives.test.tsx
@@ -15,15 +15,22 @@
  * receive the primitive's fixes.
  *
  * These are mutation-check tests. Revert the status chip to the local `? "ERR"`
- * Badge and the class assertion fails; revert the request headers to the
- * `<pre>{JSON.stringify(...)}</pre>` dump and the "renders a <table>, not a
- * <pre>" assertion fails.
+ * Badge and the class assertion fails; render the captured response with a
+ * hand-rolled header list instead of `UnifiedResponseViewer` and the
+ * `surface-sunken` assertion fails.
+ *
+ * The headers assertion used to be fed `trace.request.headers` - the
+ * design-mode nesting, on a load-run-only surface, which no writer produces.
+ * It exercised a dead branch. Since issue #174 the exchange arrives from
+ * `GET /runs/:id/samples` as the `captured` prop, so the same guard now runs
+ * over data a real run actually stores.
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import SampleRequestCard from "./SampleRequestCard";
 import type { SampleResult } from "../../types";
+import type { RunSample } from "@/types/domain";
 
 // The response body path mounts Monaco via CodeEditor; stub it so these tests
 // stay in jsdom. None of the samples below carry a response, so it never
@@ -39,6 +46,13 @@ function makeSample(overrides: Partial<SampleResult> = {}): SampleResult {
 		statusCode: 200,
 		latencyMs: 5,
 		...overrides,
+	};
+}
+
+function makeCaptured(response: Partial<RunSample["response"]> = {}): RunSample {
+	return {
+		resultId: 1,
+		response: { headers: {}, bodyBytes: 0, ...response },
 	};
 }
 
@@ -60,23 +74,99 @@ describe("SampleRequestCard shared-primitive adoption (#60)", () => {
 		expect(chip.className).toContain("bg-status-no-response-fill");
 	});
 
-	it("renders request headers through HeadersViewer (a table), not a raw JSON <pre>", () => {
+	it("renders captured response headers through the shared viewer, not a hand-rolled list", () => {
 		const { container } = render(
 			<SampleRequestCard
-				sample={makeSample({
-					trace: { request: { headers: { "x-trace-id": "abc123" } } },
-				})}
+				sample={makeSample()}
 				index={0}
 				isExpanded
 				onToggle={() => {}}
+				captured={makeCaptured({
+					headers: { "x-trace-id": "abc123" },
+					body: "",
+					bodyBytes: 0,
+				})}
 			/>
 		);
-		const table = container.querySelector("table");
-		expect(table).not.toBeNull();
-		expect(table?.textContent).toContain("x-trace-id");
-		expect(table?.textContent).toContain("abc123");
+		// Headers live behind UnifiedResponseViewer's Headers tab - which is the
+		// point of routing them through the shared viewer rather than printing
+		// a second, differently-styled table beside it.
+		// Radix Tabs activate on pointer-down, not click.
+		fireEvent.mouseDown(screen.getByRole("tab", { name: /Headers/ }));
+		// CompactHeadersViewer renders each name as `key:` on a sunken slab;
+		// pin that surface, since a hand-rolled div map would render the same
+		// text without it.
+		const name = screen.getByText("x-trace-id:");
+		expect(name.closest(".surface-sunken")).not.toBeNull();
+		expect(screen.getByText("abc123")).toBeTruthy();
 		// The reverted implementation dumped the headers as pretty-printed JSON in
 		// a <pre>. There is none now.
 		expect(container.querySelector("pre")).toBeNull();
+	});
+});
+
+describe("SampleRequestCard captured exchange (#174)", () => {
+	it("renders nothing about the response when the run captured none", () => {
+		const { container } = render(
+			<SampleRequestCard sample={makeSample()} index={0} isExpanded onToggle={() => {}} />
+		);
+		// No empty "Response" heading, no headers table: most samples in a
+		// healthy run carry no body, and a heading over nothing reads as a bug
+		// in the engine rather than as "this sample has none".
+		expect(container.querySelector("table")).toBeNull();
+	});
+
+	it("says a body was truncated rather than showing a slice as the whole response", () => {
+		render(
+			<SampleRequestCard
+				sample={makeSample()}
+				index={0}
+				isExpanded
+				onToggle={() => {}}
+				captured={makeCaptured({
+					headers: {},
+					body: "{".repeat(8),
+					bodyBytes: 500_000,
+					bodyTruncated: true,
+				})}
+			/>
+		);
+		expect(screen.getByText("Body truncated")).toBeTruthy();
+	});
+
+	it("reports a binary body by size and type instead of rendering its bytes", () => {
+		render(
+			<SampleRequestCard
+				sample={makeSample()}
+				index={0}
+				isExpanded
+				onToggle={() => {}}
+				captured={makeCaptured({
+					headers: {},
+					bodyBytes: 2048,
+					binary: true,
+					contentType: "image/png",
+				})}
+			/>
+		);
+		expect(screen.getByText("Binary response")).toBeTruthy();
+		expect(screen.getByText(/image\/png/)).toBeTruthy();
+	});
+
+	it("distinguishes a body dropped for budget from an empty response", () => {
+		render(
+			<SampleRequestCard
+				sample={makeSample()}
+				index={0}
+				isExpanded
+				onToggle={() => {}}
+				captured={makeCaptured({
+					headers: { "content-type": "application/json" },
+					bodyBytes: 4096,
+					bodyDropped: true,
+				})}
+			/>
+		);
+		expect(screen.getByText("Body not captured")).toBeTruthy();
 	});
 });

--- a/app/src/modules/history/main/components/SampleRequestCard.tsx
+++ b/app/src/modules/history/main/components/SampleRequestCard.tsx
@@ -12,24 +12,34 @@
  * the error block and the timing tiles are the shared `SampledExchange` - the
  * dashboard's live sample list renders the same shell (#76). What is left here
  * is what is genuinely history's: the outcome-tinted card border, a stored
- * run's date formatting, and the two sections this side shows (request headers,
- * then the response through `UnifiedResponseViewer`).
+ * run's date formatting, and the response section.
+ *
+ * The response comes from `GET /runs/:id/samples` (issue #174), not from the
+ * trace. This card used to read `sample.trace.request.headers` and
+ * `sample.trace.response.body` - the design-mode nesting - on a surface that
+ * only ever shows load-run rows, which no writer produces. Both branches were
+ * dead, so the card rendered nothing but its timing tiles. There is also no
+ * per-sample request to show any more: a load run's request is constant across
+ * iterations and lives once in `runs.config_snapshot`.
  */
 
 import { cn } from "@/lib/utils";
 import {
 	UnifiedResponseViewer,
-	HeadersViewer,
 	SampledExchange,
+	CapturedResponseNotice,
 	phasesFromTrace,
 } from "@/components/shared/response-viewer";
 import type { SampleResult } from "../../types";
+import type { RunSample } from "@/types/domain";
 
 interface SampleRequestCardProps {
 	sample: SampleResult;
 	index: number;
 	isExpanded: boolean;
 	onToggle: () => void;
+	/** The captured exchange for this row, once the samples query has it. */
+	captured?: RunSample;
 }
 
 export default function SampleRequestCard({
@@ -37,6 +47,7 @@ export default function SampleRequestCard({
 	index,
 	isExpanded,
 	onToggle,
+	captured,
 }: SampleRequestCardProps) {
 	const isError = !!sample.error || sample.statusCode === 0;
 	const isSuccess = sample.statusCode >= 200 && sample.statusCode < 300;
@@ -70,28 +81,22 @@ export default function SampleRequestCard({
 				isSuccess && "border-status-success/20"
 			)}
 		>
-			{/* Request Headers - the shared collapsible table, not a raw JSON
-			    dump. It sat directly above a UnifiedResponseViewer that already
-			    renders headers properly; the two treatments no longer differ. */}
-			{sample.trace?.request?.headers && (
-				<HeadersViewer headers={sample.trace.request.headers} variant="request" />
-			)}
-
-			{/* Response using UnifiedResponseViewer */}
-			{(sample.trace?.response?.body || sample.trace?.response?.headers) && (
-				<UnifiedResponseViewer
-					response={{
-						body:
-							typeof sample.trace.response.body === "string"
-								? sample.trace.response.body
-								: sample.trace.response.body == null
-									? ""
-									: JSON.stringify(sample.trace.response.body, null, 2),
-						headers: sample.trace.response.headers || {},
-						status: sample.statusCode,
-					}}
-					className="max-h-[400px]"
-				/>
+			{/* The captured exchange, when this run stored one for this row.
+			    Rendering nothing (not an empty heading) when it did not is
+			    deliberate: most samples in a healthy run carry no body, and a
+			    "Response" heading over nothing reads as a bug in the engine. */}
+			{captured && (
+				<div className="space-y-2">
+					<CapturedResponseNotice response={captured.response} />
+					<UnifiedResponseViewer
+						response={{
+							body: captured.response.body ?? "",
+							headers: captured.response.headers,
+							status: sample.statusCode,
+						}}
+						className="max-h-[400px]"
+					/>
+				</div>
 			)}
 		</SampledExchange>
 	);

--- a/app/src/modules/history/main/components/SamplesTab.retention.test.tsx
+++ b/app/src/modules/history/main/components/SamplesTab.retention.test.tsx
@@ -17,9 +17,10 @@
  * CLAUDE.md warns about.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import SamplesTab from "./SamplesTab";
+import { withQueryClient } from "@/test/query-wrapper";
 import { reportToDerived } from "@/modules/dashboard/utils/reportToDerived";
 import type { RunReport } from "@/types";
 
@@ -51,9 +52,17 @@ function makeReport(sampling?: RunReport["sampling"]): RunReport {
 	};
 }
 
+// The tab fetches captured exchanges lazily; nothing here expands a row, so
+// the mock only exists to keep the query from reaching a real client.
+vi.mock("@/services/api", () => ({
+	apiService: { getRunSamples: vi.fn() },
+}));
+
 const renderTab = (sampling?: RunReport["sampling"]) => {
 	const report = makeReport(sampling);
-	return render(<SamplesTab report={report} derived={reportToDerived(report)} />);
+	return render(
+		withQueryClient(<SamplesTab report={report} derived={reportToDerived(report)} />)
+	);
 };
 
 describe("SamplesTab retention", () => {
@@ -82,5 +91,31 @@ describe("SamplesTab retention", () => {
 	it("counts what it shows rather than claiming a capture total", () => {
 		renderTab();
 		expect(screen.getByText("1 samples shown")).toBeInTheDocument();
+	});
+
+	// Issue #174: capture stores responses verbatim, so the tab that displays
+	// them is where the reader has to be told.
+	it("warns that a run's captured responses are stored verbatim", () => {
+		renderTab({
+			errorsDropped: 0,
+			successTracesDropped: 0,
+			slowTracesDropped: 0,
+			responseSamplesDropped: 0,
+			responseBodiesCaptured: 7,
+		});
+
+		expect(screen.getByText("Captured response data")).toBeInTheDocument();
+	});
+
+	it("stays quiet about capture on a run that captured nothing", () => {
+		renderTab({
+			errorsDropped: 0,
+			successTracesDropped: 0,
+			slowTracesDropped: 0,
+			responseSamplesDropped: 0,
+			responseBodiesCaptured: 0,
+		});
+
+		expect(screen.queryByText("Captured response data")).not.toBeInTheDocument();
 	});
 });

--- a/app/src/modules/history/main/components/SamplesTab.tsx
+++ b/app/src/modules/history/main/components/SamplesTab.tsx
@@ -14,12 +14,20 @@
 import { useState } from "react";
 import { Activity } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, Badge } from "@/components/ui";
-import { EmptyState, SampleRetentionNote } from "@/components/shared";
+import { EmptyState, SampleRetentionNote, CapturedDataWarning } from "@/components/shared";
+import { useRunSamplesQuery } from "@/queries/runs";
 import SampleRequestCard from "./SampleRequestCard";
 import type { TabProps, SampleResult } from "../../types";
 
 export default function SamplesTab({ report }: TabProps) {
 	const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+	// Fetched only once a row is open, which is the whole reason the captured
+	// bodies are not part of the report payload.
+	const { data: captured } = useRunSamplesQuery(
+		report.metadata?.runId ?? null,
+		expandedIndex !== null
+	);
 
 	if (!report.results || report.results.length === 0) {
 		return (
@@ -53,6 +61,7 @@ export default function SamplesTab({ report }: TabProps) {
 					shown={report.results.length}
 					budget="traces"
 				/>
+				<CapturedDataWarning sampling={report.sampling} />
 				{report.results.map((sample: SampleResult, idx: number) => (
 					<SampleRequestCard
 						key={idx}
@@ -60,6 +69,7 @@ export default function SamplesTab({ report }: TabProps) {
 						index={idx}
 						isExpanded={expandedIndex === idx}
 						onToggle={() => setExpandedIndex(expandedIndex === idx ? null : idx)}
+						captured={sample.id === undefined ? undefined : captured?.get(sample.id)}
 					/>
 				))}
 			</CardContent>

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -53,6 +53,10 @@ export const queryKeys = {
 		detail: (id: string) => [...queryKeys.runs.details(), id] as const,
 		report: (id: string) => [...queryKeys.runs.all, "report", id] as const,
 		timeSeries: (id: string) => [...queryKeys.runs.all, "timeSeries", id] as const,
+		// Captured response headers/bodies for a run's samples. Its own family,
+		// not part of `report`, because it is fetched lazily - only once a
+		// reader expands a sample - and must not ride on the report's cache.
+		samples: (id: string) => [...queryKeys.runs.all, "samples", id] as const,
 	},
 
 	// Warm-cache pass over every collection's requests (see

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -177,6 +177,30 @@ export function useRunReportQuery(runId: string | null) {
 }
 
 /**
+ * Fetch a run's captured response exchanges, indexed by result id.
+ *
+ * `enabled` is the point of this hook: the bodies are not part of the report
+ * and must not be fetched with it - a surface passes `true` only once a reader
+ * has expanded a sample. Returns a Map so a card can look its own exchange up
+ * in constant time instead of scanning the page.
+ *
+ * Captured data never changes after a run finishes, so it is cached like the
+ * time series rather than the polled report.
+ */
+export function useRunSamplesQuery(runId: string | null, enabled: boolean) {
+	return useQuery({
+		queryKey: queryKeys.runs.samples(runId ?? ""),
+		queryFn: async () => {
+			const page = await apiService.getRunSamples(runId!);
+			return new Map(page.data.map((sample) => [sample.resultId, sample]));
+		},
+		enabled: !!runId && enabled,
+		staleTime: Infinity,
+		gcTime: QUERY_CACHE.RUNS_GC_TIME_MS,
+	});
+}
+
+/**
  * Fetch time-series metrics for a run (paginated, auto-fetches all pages)
  * Used for rendering historical charts in load test detail view.
  */

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -27,6 +27,7 @@ import type {
 	RunListResponse,
 	RunListParams,
 	RunReport,
+	RunSamplesResponse,
 	EngineHealth,
 	SanityResult,
 	ScriptCompletionsResponse,
@@ -66,6 +67,7 @@ import {
 	PROXIED_TIMEOUT_GRACE_MS,
 	ENGINE_MAX_DEFAULT_TIMEOUT_MS,
 	STATS_PAGE_LIMIT,
+	RUN_SAMPLES_PAGE_LIMIT,
 	RUNS_PAGE_LIMIT,
 } from "@/config/network";
 
@@ -289,6 +291,24 @@ export const apiService = {
 	async getRunReport(id: string): Promise<RunReport> {
 		const response = await httpClient.get<GetRunReportResponse>(API_ENDPOINTS.RUN_REPORT(id));
 		return RunReportTransformer.toFrontend(response);
+	},
+
+	/**
+	 * The response headers and body captured for a run's retained samples -
+	 * every error, the slow outliers, and the first few of each status code.
+	 *
+	 * Its own request rather than fields on the report: the report path loads
+	 * and parses every result row for a run on each fetch, and the dashboard
+	 * polls it. Join a page's `resultId` against `report.results[].id`.
+	 */
+	async getRunSamples(
+		id: string,
+		options: { limit?: number; offset?: number } = {}
+	): Promise<RunSamplesResponse> {
+		const { limit = RUN_SAMPLES_PAGE_LIMIT, offset = 0 } = options;
+		return await httpClient.get<RunSamplesResponse>(
+			API_ENDPOINTS.RUN_SAMPLES(id, limit, offset)
+		);
 	},
 
 	async stopRun(id: string): Promise<StopRunResponse> {

--- a/app/src/test/query-wrapper.tsx
+++ b/app/src/test/query-wrapper.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A TanStack Query provider for tests that render a component which fetches.
+ *
+ * Every such test needs the same three lines - a fresh client, retries off so a
+ * failure surfaces immediately instead of after three backoffs, and the
+ * provider around the tree. Written once here rather than six times across the
+ * files that render `RequestResponseView` and `SamplesTab`, both of which pull
+ * their captured response bodies from `GET /runs/:id/samples`.
+ *
+ * A fresh client per call is deliberate: a shared one would carry one test's
+ * cached page into the next.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+export function withQueryClient(children: ReactNode) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -779,8 +779,34 @@ export interface RunReport {
 		slowTracesDropped: number;
 		/** Responses displaced or dropped before test validation ran. */
 		responseSamplesDropped: number;
+		/**
+		 * Per-status exemplars refused because the exemplar store was full
+		 * (`max_exemplar_results`). Only a target answering with more distinct
+		 * status codes than that limit can produce a non-zero figure.
+		 */
+		exemplarsDropped?: number;
+		/**
+		 * Samples whose response body was dropped once the run's capture budget
+		 * (`maxSampleBytes`) was spent. Their headers and metadata were still
+		 * captured, so the sample exists and only its body is missing.
+		 */
+		sampleBodiesDropped?: number;
+		/**
+		 * Captured exchanges this run stored. Non-zero is the run's own record
+		 * that it holds response headers and bodies **verbatim** - capture does
+		 * not redact, by design - which is what the Samples tab warns on rather
+		 * than leaving the reader to infer it. Absent on runs recorded before
+		 * capture existed.
+		 */
+		responseBodiesCaptured?: number;
 	};
 	results?: Array<{
+		/**
+		 * The `results` row id, and the join key against
+		 * {@link RunSample.resultId} from `GET /runs/:id/samples`. Absent on
+		 * reports from engines older than 0.15.0.
+		 */
+		id?: number;
 		timestamp: number;
 		statusCode: number;
 		statusText?: string;
@@ -788,6 +814,49 @@ export interface RunReport {
 		error?: string;
 		trace?: RunResultTrace;
 	}>;
+}
+
+/**
+ * One sampled load-run result's captured response, from
+ * `GET /runs/:id/samples`.
+ *
+ * Deliberately not part of {@link RunReport}: the report path loads and parses
+ * every result row for a run on each fetch and the dashboard polls it, so
+ * bodies travel on their own endpoint and are fetched only when a reader
+ * expands a sample. Join to a report row by `resultId`.
+ */
+export interface RunSample {
+	resultId: number;
+	response: {
+		headers: Record<string, string>;
+		/**
+		 * The stored body. Absent when {@link RunSample.response.binary} is set -
+		 * a body that is not text is reported as its shape, never as a string
+		 * that reads like a response and is not one.
+		 */
+		body?: string;
+		/** Size of the body as received, before any truncation. */
+		bodyBytes: number;
+		/** `body` is a prefix; the response was larger than `maxSampleBodyBytes`. */
+		bodyTruncated?: boolean;
+		/** The run's capture budget was spent before this sample, so only its
+		 * headers were kept. Distinct from an empty response body. */
+		bodyDropped?: boolean;
+		/** Stored as a descriptor: size and content type, no bytes. */
+		binary?: boolean;
+		contentType?: string;
+	};
+}
+
+export interface RunSamplesResponse {
+	data: RunSample[];
+	pagination: {
+		total: number;
+		limit: number;
+		offset: number;
+		hasMore: boolean;
+		returned: number;
+	};
 }
 
 export interface EngineHealth {

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -291,12 +291,32 @@ reported no counts at all (an older summary): "nothing was dropped" and "we
 cannot tell" are both worse as prose than as absence. Built on `Callout`
 (`severity="info"`) rather than a hand-rolled muted row.
 
+## Captured Data Warning (`components/shared/CapturedDataWarning.tsx`)
+
+Wherever a run's captured response exchanges are on screen: the run stored those
+responses **verbatim**, headers included, so anything credential-shaped the
+server sent is stored with them, and it is deleted when the run is
+(`maxRunsRetained` is its expiry).
+
+Capture deliberately does not redact - consistently with design-mode traces,
+which already store request headers as sent, and because a redaction guess is
+wrong in both directions and gives false confidence when it is wrong the
+reassuring way. This notice plus the run's own persisted marker
+(`sampling.responseBodiesCaptured`) is the mitigation for that decision, which
+makes a silent version of it the same as not having made the decision.
+
+Renders nothing when the run captured nothing, and nothing on a run recorded
+before capture existed (the field is absent, not zero) - the same rule
+`SampleRetentionNote` follows. Both surfaces that list captured samples render
+it: the dashboard's Sampled Requests and the history Samples tab.
+
 ## Shared Response Viewer (`components/shared/response-viewer/`)
 
 Response-rendering primitives reused outside the request builder (e.g. history detail):
 
 - `UnifiedResponseViewer.tsx` - top-level response view for stored runs
 - `ResponseBody.tsx` - body rendering (JSON/text/HTML/XML)
+- `CapturedResponseNotice.tsx` - what a captured load-run response is *not*: truncated at `maxSampleBodyBytes`, dropped once the run's `maxSampleBytes` budget was spent, or binary and therefore stored by size and type. All three are invisible in the bytes - a truncated body looks malformed, a dropped one looks empty - so the difference is stated rather than left to be inferred
 - `HeadersViewer.tsx` - the headers family, three variants in one file: the collapsible table, `CompactHeadersViewer` (same content on a sunken slab, for panes with no room for a table), and `ResponseHeadersPanel` (the Headers *tab* - request collapsed above response open, with the empty state `HeadersViewer` alone cannot give)
 - `StatusCodeBadge.tsx` - the status chip
 - `ResponseStatusBar.tsx` - status chip + elapsed time + payload size

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -221,6 +221,9 @@ apiService.listRuns(params?: RunListParams): Promise<RunListResponse>
 apiService.listAllRuns(params?): Promise<Run[]>
 apiService.getRun(id): Promise<Run>            // full configSnapshot
 apiService.getRunReport(id): Promise<RunReport>
+// Response headers/bodies captured for a run's samples. Its own request, not
+// fields on the report - see below.
+apiService.getRunSamples(id, { limit?, offset? }): Promise<RunSamplesResponse>
 apiService.stopRun(id): Promise<StopRunResponse>
 apiService.deleteRun(id): Promise<void>
 ```
@@ -234,6 +237,23 @@ retry, and Settings' *Clear run history* already counts per-run failures through
 `statusCode`, rather than the engine's message - which is a caller's choice now
 that `httpClient` reads the message on every error shape (issue #173), not a
 constraint.
+
+**Captured response bodies are fetched separately, and lazily.** A load run
+stores the response headers and body for its failures, its slow outliers and a
+few exemplars of each status code; `GET /runs/:id/report` deliberately does not
+carry them, because that endpoint loads and JSON-parses every result row for the
+run on each fetch and the dashboard polls it. `useRunSamplesQuery(runId, enabled)`
+(`queries/runs.ts`) wraps `getRunSamples` and is enabled **only once a reader
+expands a sample** - passing `true` unconditionally would reintroduce exactly the
+cost the split exists to avoid. It returns a `Map` keyed by `resultId`, joined
+against `report.results[].id`.
+
+Two surfaces consume it - the dashboard's Sampled Requests
+(`RequestResponseView`) and the history Samples tab - and both render
+`CapturedResponseNotice` (truncated / dropped for budget / binary) and
+`CapturedDataWarning` (the run stored responses verbatim, including anything
+credential-shaped). Both notices live in `components/shared`, so the wording
+exists once rather than twice.
 
 #### Scripting
 
@@ -338,6 +358,9 @@ export const API_ENDPOINTS = {
   RUN_BY_ID: (id: string) => `/runs/${id}`,
   RUN_REPORT: (id: string) => `/runs/${id}/report`,
   RUN_STOP: (id: string) => `/runs/${id}/stop`,
+  // Captured response headers/bodies, fetched only when a sample is expanded
+  RUN_SAMPLES: (id: string, limit: number, offset: number) =>
+    `/runs/${id}/samples?limit=${limit}&offset=${offset}`,
   
   // Real-time stats (SSE)
   METRICS_LIVE: (runId: string) => `/runs/${runId}/live`,

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -758,6 +758,7 @@ runs: {
   detail: (id) => ["runs", "detail", id],
   report: (id) => ["runs", "report", id],
   timeSeries: (id) => ["runs", "timeSeries", id],
+  samples: (id) => ["runs", "samples", id],               // captured response bodies, fetched lazily
 },
 // environments mirrors collections; globals / health / config /
 // scriptCompletions / scriptTypes / oauth / prefetch each own a root.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -276,14 +276,16 @@ It is a write-time seed only - changing it never alters a request that already
 exists, and it is never consulted at execution time.
 
 The Settings panel renders entries dynamically, so new keys appear without app
-changes. These `observability` keys govern how much a run keeps - three of them
+changes. These `observability` keys govern how much a run keeps - most of them
 on disk, one in memory:
 
 | Key                 | Default   | Range        | Effect |
 |---------------------|-----------|--------------|--------|
 | `maxTraceBodyBytes` | `5242880` | 1024–104857600 | Largest request/response body stored in a design run's `trace_data`. Bigger bodies are truncated with `bodyTruncated`/`bodyBytes` (see `GET /runs/:id`). |
 | `maxResponseBodyBytes` | `33554432` | 1024–1073741824 | Largest response body a **load-test** transfer reads into memory. A bigger response fails that request (see `POST /runs`). Not a storage cap and unrelated to `maxTraceBodyBytes`, which truncates what a *completed* design request writes to the database. |
-| `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results) are pruned at startup and after each run finishes. `0` = unlimited. |
+| `maxSampleBodyBytes` | `32768`  | 0–104857600  | Largest response body kept for a single captured **load-run** sample. Bigger bodies are stored truncated and marked. Deliberately far below `maxTraceBodyBytes`: a design run stores one exchange the user asked for, a load run stores tens nobody asked for individually. `0` keeps headers and metadata and no body. |
+| `maxSampleBytes`    | `2097152` | 0–1073741824 | Total captured body bytes one load run may store. Once spent, samples keep their headers and metadata and only their bodies are dropped; the report counts them as `sampling.sampleBodiesDropped`. |
+| `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results, **including captured response bodies**) are pruned at startup and after each run finishes. `0` = unlimited. Captured data is stored verbatim, so this doubles as its expiry. |
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
 
 In-progress (`running`/`pending`) runs are never pruned.
@@ -1299,6 +1301,9 @@ default, and whose message names the offending field and why the bound exists:
 | `max_success_results` | `0`-`1000000` | Each retained record holds a serialised timing breakdown, and the store is reserved up front. `0` means unlimited. |
 | `max_slow_results` | `0`-`1000000` | Same store, same reserve, separate budget. `0` means unlimited. |
 | `slow_threshold_ms` | `0`-`86400000` ms | `0` disables outlier capture; a negative threshold would mark **every** completion an outlier and fill the slow store with the whole run. |
+| `max_sample_body_bytes` | `0`-`104857600` | A captured body is copied on the completion callback, so the cap bounds hot-path work. `0` keeps headers and metadata and no body. Defaults to the `maxSampleBodyBytes` setting. |
+| `max_sample_bytes` | `0`-`1073741824` | The whole-run capture budget; every byte under it is held in memory until the run flushes. Defaults to the `maxSampleBytes` setting. |
+| `max_exemplar_results` | `0`-`100000` | Each retained exemplar holds a captured exchange. `0` means unlimited. |
 | `concurrency` | `1`-`10000` | Connections are eagerly pre-allocated per worker before any traffic flows, so `-1` (a natural "unlimited" guess) allocated until malloc failed. |
 | `timeout` | `1`-`86400000` ms | A transfer that never times out never completes, leaving the run stuck `running` and unstoppable. |
 | `duration` | string, positive, optional unit (`ms`\|`s`\|`m`\|`h`) | A JSON *number* threw out of the run-context constructor *after* the row was written, stranding it `pending` forever behind an opaque `500`. |
@@ -1321,6 +1326,7 @@ independent budgets:
 | Sampled timing traces | 1 in `success_sample_rate` completions, only while `save_timing_breakdown` is on | `max_success_results` |
 | Slow-request traces | any completion at or past `slow_threshold_ms`, **regardless** of `save_timing_breakdown` | `max_slow_results` |
 | Response samples (post-run test scripts) | 1 in `response_sample_rate` completions | `max_response_samples` |
+| Per-status exemplars (captured responses) | the first three completions of each distinct status code | `max_exemplar_results` |
 
 Two properties are worth relying on. An outlier **never consumes a sampling
 slot**: a run whose target degrades does not silently stop sampling ordinary
@@ -1329,6 +1335,21 @@ its bound a later record displaces a uniformly chosen incumbent instead of being
 refused - so what a long run retains describes the whole run rather than its
 first few seconds, and `sampling` in
 [the report](#get-runsrunidreport) says how many records that thinning cost.
+
+The exemplar budget is the one exception to the reservoir rule, and deliberately
+so: an exemplar that gets displaced is not an exemplar, so past its bound a
+later candidate is refused and counted rather than evicting an incumbent.
+
+**Response capture.** `capture_response_bodies` (boolean, default `true`) decides
+whether the retained samples carry their response headers and body. On by default
+is only defensible because capture is failure-and-outlier-shaped rather than
+uniform - errors, slow outliers and the per-status exemplars, never the 1-in-N
+slice - so a healthy run captures a handful of exchanges. Set it to `false` and
+the collector is byte-for-byte what it was before capture existed: no gate is
+consulted, no exemplar is claimed, nothing is copied, and no rows are written.
+What is captured is read back with
+[GET /runs/:runId/samples](#get-runsrunidsamples) and described in
+[`result_bodies`](db-schema.md#result_bodies).
 
 **Shutdown refuses new runs.** Once the daemon has begun draining its run
 workers, `POST /runs` answers `503` with the message `Engine is shutting down` rather
@@ -1857,10 +1878,12 @@ alone rather than erroring. **The response shape is the same either way.**
   "slowRequests": { "count": 12, "thresholdMs": 1000, "percentage": 0.2 },
   "sampling": {
     "errorsDropped": 0, "successTracesDropped": 29000,
-    "slowTracesDropped": 0, "responseSamplesDropped": 998000
+    "slowTracesDropped": 0, "responseSamplesDropped": 998000,
+    "exemplarsDropped": 0, "sampleBodiesDropped": 12,
+    "responseBodiesCaptured": 23
   },
   "testValidation": { "samplesTested": 500, "testsPassed": 498, "testsFailed": 2, "successRate": 99.6 },
-  "results": [ { "...": "sampled request/response outcomes" } ]
+  "results": [ { "id": 41, "...": "sampled request/response outcomes" } ]
 }
 ```
 
@@ -1889,12 +1912,108 @@ count means they are a **uniform sample of the whole run** (reservoir retention)
 rather than a truncated prefix of it. The section is absent on a run recorded
 before it was reported, which is not the same claim as "nothing was dropped".
 
+Three of its keys are about captured responses rather than retention:
+`responseBodiesCaptured` is how many exchanges the run stored (see
+[GET /runs/:runId/samples](#get-runsrunidsamples)), and is also the run's own
+marker that it holds response data **stored verbatim** - non-zero is what the
+Samples tab warns on. `sampleBodiesDropped` counts samples whose headers were
+kept but whose body was dropped once the run's `maxSampleBytes` budget was
+spent. `exemplarsDropped` counts per-status exemplars refused because
+`max_exemplar_results` was full, which only a target answering with more
+distinct status codes than that limit can reach. All three are absent on runs
+recorded before 0.15.0.
+
+`results[].id` is the `results` row id, and the join key against
+`GET /runs/:runId/samples`. It is absent on reports served by an engine older
+than 0.15.0.
+
 `metadata.configuration` carries the load-test tuning knobs present in the
 snapshot (`mode`, `duration`, `concurrency`, `startConcurrency`,
 `rampUpDuration`, `timeout`, `comment`, `followRedirects`, `maxRedirects` -
 each omitted when absent) plus `httpVersion`, which is always present with the
 same `"auto"`-when-unknown normalization `GET /runs`'s `summary` uses (see
 above). `rps` in the raw snapshot is renamed to `targetRps` here.
+
+### GET /runs/:runId/samples
+
+Get the response headers and body a load run captured for its retained samples.
+Paginated; **no deprecated alias** - the endpoint is new in 0.15.0, so there is
+no pre-consolidation spelling for it to keep working.
+
+Deliberately **not** part of `GET /runs/:runId/report`. That path loads every
+`results` row for the run and JSON-parses each `trace_data` to accumulate
+aggregates that never look at a body, and the dashboard polls it; at 1000
+samples carrying 32 KiB bodies, folding them in would turn every poll into ~32 MB
+read from SQLite and parsed. So the bodies live in their own tables and are
+fetched here, per page, only when a reader actually expands a sample.
+
+**Query params:**
+
+| Param    | Default | Notes                                     |
+|----------|---------|-------------------------------------------|
+| `limit`  | `50`    | Capped at 500; a non-numeric value falls back to the default |
+| `offset` | `0`     | Floored at 0                              |
+
+**What a run captures** - and does not - is described under
+[`result_bodies`](db-schema.md#result_bodies): every error, the slow outliers,
+and the first three of each distinct status code, within `maxSampleBodyBytes`
+per body and `maxSampleBytes` for the run. A uniformly sampled success carries
+no body by design.
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "resultId": 41,
+      "response": {
+        "headers": { "content-type": "application/json", "server": "nginx" },
+        "body": "{\"error\":\"upstream timeout\"}",
+        "bodyBytes": 28,
+        "contentType": "application/json"
+      }
+    },
+    {
+      "resultId": 42,
+      "response": {
+        "headers": { "content-type": "image/png" },
+        "bodyBytes": 20480,
+        "contentType": "image/png",
+        "binary": true
+      }
+    }
+  ],
+  "pagination": { "total": 23, "limit": 50, "offset": 0, "hasMore": false, "returned": 23 }
+}
+```
+
+`resultId` is the `results` row this exchange belongs to - join it against
+`results[].id` on the report rather than re-deriving an order.
+
+The `response` node always carries `headers` and `bodyBytes` (the size **as
+received**, before any truncation). The rest is conditional, and each key means
+something the bytes alone cannot say:
+
+| Key             | When present | Meaning                                                                 |
+|-----------------|--------------|-------------------------------------------------------------------------|
+| `body`          | Not binary   | The stored bytes. `""` when the response had none, or when the body was dropped |
+| `bodyTruncated` | `true` only  | `body` is a prefix; the response was larger than `maxSampleBodyBytes`. Same convention design-mode traces use |
+| `bodyDropped`   | `true` only  | The run's `maxSampleBytes` budget was spent before this sample: headers kept, body not. **Distinct from an empty response body** |
+| `binary`        | `true` only  | Stored as a descriptor - `bodyBytes` and `contentType`, no bytes. See [`result_bodies`](db-schema.md#result_bodies) for why a binary body is never stored as text |
+| `contentType`   | Non-empty    | The response's `Content-Type`                                           |
+
+**Captured data is stored verbatim** - no redaction, consistently with
+design-mode traces, which already store request headers as sent. A response
+`Set-Cookie` is captured along with everything else. It is deleted with the run,
+so `maxRunsRetained` is its expiry.
+
+A run that captured nothing is an empty page, not an error; an unknown run id is
+a **404** in the shared error shape.
+
+**Response (404):**
+```json
+{ "error": { "code": 404, "message": "Run not found" } }
+```
 
 ### DELETE /runs/:runId
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1326,7 +1326,7 @@ independent budgets:
 | Sampled timing traces | 1 in `success_sample_rate` completions, only while `save_timing_breakdown` is on | `max_success_results` |
 | Slow-request traces | any completion at or past `slow_threshold_ms`, **regardless** of `save_timing_breakdown` | `max_slow_results` |
 | Response samples (post-run test scripts) | 1 in `response_sample_rate` completions | `max_response_samples` |
-| Per-status exemplars (captured responses) | the first three completions of each distinct status code | `max_exemplar_results` |
+| Per-status exemplars (captured responses) | the first three completions of each distinct status code **that no other budget already stored** | `max_exemplar_results` |
 
 Two properties are worth relying on. An outlier **never consumes a sampling
 slot**: a run whose target degrades does not silently stop sampling ordinary
@@ -1339,6 +1339,15 @@ first few seconds, and `sampling` in
 The exemplar budget is the one exception to the reservoir rule, and deliberately
 so: an exemplar that gets displaced is not an exemplar, so past its bound a
 later candidate is refused and counted rather than evicting an incumbent.
+
+It is also the **last** budget consulted, not the first. A completion that is
+already an outlier stays charged to the slow budget and a sampled one stays
+charged to the sampling budget - claiming an exemplar never moves a record out
+of the store that wanted it, because the first few completions of a status code
+are often exactly where a run's outliers are. What the exemplar claim decides is
+whether the response **body** is captured, which is independent of which budget
+pays: a completion that is both sampled and a claimed exemplar is stored in the
+sampling budget *and* keeps its body.
 
 **Response capture.** `capture_response_bodies` (boolean, default `true`) decides
 whether the retained samples carry their response headers and body. On by default

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -448,6 +448,14 @@ a thousand identical 200s. Three buckets, all decided before anything is copied:
 | Slow outliers | `max_slow_results`, the existing slow-request reservoir |
 | The first `EXEMPLARS_PER_STATUS` (3) of each distinct status code | `max_exemplar_results` (64), and unlike its neighbours **not** a reservoir - an exemplar that gets displaced is not an exemplar |
 
+The buckets overlap, and the overlap resolves toward the *other* store: an
+outlier that is also one of its status code's first three stays charged to the
+slow budget, and a sampled completion stays charged to the sampling budget. The
+exemplar store holds only what no other budget wanted. Claiming an exemplar is
+what decides that a **body** is captured, separately from which budget pays - so
+a completion that is both sampled and an exemplar is stored as a sample and
+still keeps its body.
+
 A uniformly sampled success (`success_sample_rate`) is deliberately body-less.
 
 **Budgets.** `maxSampleBodyBytes` (config, `observability`, default 32 KiB) caps a single body;

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -375,6 +375,13 @@ Individual request outcomes - all errors plus sampled successes (sampling is con
 | `error`       | TEXT       | Error message for failures; empty on success                 |
 | `trace_data`  | TEXT       | JSON (headers/body/timing breakdown) - design mode + errors + slow samples |
 
+A load run's captured response headers and bodies are **not** here - they live in
+[`result_bodies`](#result_bodies) / [`body_blobs`](#body_blobs). That split is load-bearing:
+`Database::get_results` loads every row for a run with no limit and
+`calculate_detailed_report` JSON-parses each `trace_data` on every report fetch, which the
+dashboard polls. At ~200 bytes per trace that is free; with bodies inline it would be megabytes
+read and parsed per poll, to compute aggregates that never look at a body.
+
 `trace_data` timing keys are all in ms and carry the `Ms` suffix: `totalMs`, `wireMs`,
 `queueWaitMs`, `dnsMs`, `connectMs`, `tlsMs`, `firstByteMs`, `downloadMs`. `totalMs` is perceived
 latency; `wireMs` is libcurl's `CURLINFO_TOTAL_TIME`; `queueWaitMs = totalMs − wireMs` is time
@@ -412,6 +419,89 @@ after a restart - see `app/src/modules/request-builder/utils/restore-response.ts
 A design run has exactly one `results` row. `GET /runs/:runId` serves it (as `result`)
 alongside the run itself, in addition to `GET /runs/:runId/report`'s `results` array - the
 same row, read by two routes for two different callers.
+
+---
+
+### `result_bodies`
+
+The response captured for one sampled **load-run** result, one-to-one with a `results` row.
+Struct is `db::ResultBody`. Read only by [`GET /runs/:runId/samples`](api-reference.md#get-runsrunidsamples);
+nothing on the report path touches it.
+
+| Column         | Type       | Notes                                                              |
+|----------------|------------|--------------------------------------------------------------------|
+| `result_id`    | INTEGER PK | The `results.id` this exchange belongs to (not autoincrement)      |
+| `run_id`       | TEXT       | FK → `runs.id`; what the run cascade and the endpoint filter on    |
+| `headers`      | TEXT       | JSON object of the response headers, as received                   |
+| `blob_id`      | INTEGER    | FK → `body_blobs.id`, or **0** when no body was stored             |
+| `body_bytes`   | INTEGER    | Size of the body **as received**, before any truncation            |
+| `truncated`    | INTEGER    | 1 when the stored bytes are a prefix (`maxSampleBodyBytes`)        |
+| `binary`       | INTEGER    | 1 when the body was stored as a descriptor rather than as text     |
+| `content_type` | TEXT       | The response's `Content-Type`, `""` when it sent none              |
+
+**Which completions get a row.** Not a uniform sample - a uniform slice of a 30M-request run is
+a thousand identical 200s. Three buckets, all decided before anything is copied:
+
+| Bucket | Bound |
+|--------|-------|
+| Every error | `maxStoredErrors` (the error store's own cap) |
+| Slow outliers | `max_slow_results`, the existing slow-request reservoir |
+| The first `EXEMPLARS_PER_STATUS` (3) of each distinct status code | `max_exemplar_results` (64), and unlike its neighbours **not** a reservoir - an exemplar that gets displaced is not an exemplar |
+
+A uniformly sampled success (`success_sample_rate`) is deliberately body-less.
+
+**Budgets.** `maxSampleBodyBytes` (config, `observability`, default 32 KiB) caps a single body;
+`maxSampleBytes` (default 2 MiB) is the whole-run budget. Once the run budget is spent, samples
+keep their headers and metadata and lose only their bodies - the row then has `blob_id = 0` with
+`body_bytes > 0`, and `runs.summary`'s `sampling.sample_bodies_dropped` counts them, so the UI
+can say the set is incomplete rather than presenting a biased subset as the whole story. Both
+defaults are far below design mode's `maxTraceBodyBytes` (5 MiB): a design run stores one
+exchange the user asked for, a load run stores tens nobody asked for individually.
+
+**Binary bodies.** The engine never sets `CURLOPT_ACCEPT_ENCODING`, so a request that asks for
+`gzip` gets the compressed bytes in the response body; images and protobuf arrive the same way.
+Those are stored as a descriptor (`binary = 1`, `blob_id = 0`, with `body_bytes` and
+`content_type`), never as text - `error_handler_t::replace` would keep `dump()` from throwing and
+hand the reader a mojibake that reads like a real response. The rule is
+`vayu::core::looks_binary` (`core/sample_capture.cpp`): a content type that is not text-shaped,
+or a bounded prefix that is not valid UTF-8 / contains a NUL.
+
+**No redaction.** Captured data is stored verbatim, consistently with design-mode traces, which
+already store request headers as sent. A response `Set-Cookie` is captured along with everything
+else. The mitigation is the run's own marker - `sampling.response_bodies_captured` in
+`runs.summary` - which the Samples tab reads to warn, plus the run cascade below, which makes
+`maxRunsRetained` the expiry for anything credential-shaped a capture picked up.
+
+**Per-run request.** There is deliberately no per-sample request copy: a load run's request is
+constant across iterations and already lives in `runs.config_snapshot`, and the event-loop path
+never populates `Response::request_headers` at all (only the synchronous `client.cpp` does).
+
+---
+
+### `body_blobs`
+
+One row per **distinct** captured body within a run - the dedup table. Struct is `db::BodyBlob`.
+
+| Column    | Type       | Notes                                                            |
+|-----------|------------|------------------------------------------------------------------|
+| `id`      | INTEGER PK | Autoincrement; `result_bodies.blob_id` points here               |
+| `run_id`  | TEXT       | FK → `runs.id`; scopes dedup to one run                          |
+| `hash`    | TEXT       | Lowercase hex SHA-256 of `content` (`vayu::core::body_digest`)   |
+| `content` | TEXT       | The stored bytes, already truncated to `maxSampleBodyBytes`      |
+
+Load-test responses are overwhelmingly identical, so 1000 samples of one 2 KiB body store 2 KiB,
+not 2 MB. The digest is taken over the **stored** (already truncated) bytes: two bodies that
+differ only past the truncation point are byte-identical as stored, and storing them twice would
+be storing the same row twice.
+
+Dedup is scoped per run rather than globally so that deleting a run deletes its blobs with no
+cross-run refcount to maintain. Both tables are removed by `remove_run_cascade_locked` - bodies
+before the results they hang off, so a delete interrupted between the two leaves results without
+bodies rather than body rows pointing at nothing.
+
+Both tables are new in 0.15.0. `sync_schema()` creates new tables outright, so there is no
+migration: an existing database picks them up on the next startup and older runs simply have no
+rows in them.
 
 ---
 
@@ -470,6 +560,8 @@ for fresh **and** pre-existing databases, so adding an index is additive and nee
 |------------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | `idx_metric_ticks_run_id`    | `metric_ticks.run_id`   | `get_metric_ticks_paginated` / `count_metric_ticks` (every `GET /runs/:id/metrics`), `get_metric_ticks_since` (the legacy SSE poll), and the `remove_all` in the run cascade |
 | `idx_results_run_id`         | `results.run_id`        | `get_results` and the `remove_all` in `delete_run`                                                                                                |
+| `idx_result_bodies_run_id`   | `result_bodies.run_id`  | `get_result_bodies_paginated` / `count_result_bodies` (every `GET /runs/:id/samples`) and the `remove_all` in the run cascade                     |
+| `idx_body_blobs_run_id`      | `body_blobs.run_id`     | The `remove_all` in the run cascade                                                                                                               |
 | `idx_requests_collection_id` | `requests.collection_id`| `get_requests_in_collection` (every sidebar load) and cascade delete                                                                              |
 | `idx_collections_parent_id`  | `collections.parent_id` | The cascade-delete BFS in `Database::delete_collection`, which does one lookup per node in the subtree                                            |
 | `idx_runs_start_time`        | `runs.start_time`       | `get_all_runs` and `get_runs_paginated`, which sort `start_time DESC` on every `GET /runs`                                                        |

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -274,6 +274,7 @@ add_library(vayu_core STATIC
     src/core/load_strategy.cpp
     src/core/run_manager.cpp
     src/core/metrics_collector.cpp
+    src/core/sample_capture.cpp
     ${PLATFORM_SOURCES}
 )
 
@@ -426,6 +427,7 @@ if(VAYU_BUILD_TESTS)
         tests/load_strategy_test.cpp
         tests/refill_deficit_test.cpp
         tests/reservoir_test.cpp
+        tests/sample_capture_test.cpp
         tests/load_pacing_test.cpp
         tests/run_manager_test.cpp
         tests/run_route_test.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -122,6 +122,16 @@ constexpr int64_t MAX_RETAINED_RESULTS = 1000000;
 /// Upper bound on `slow_threshold_ms` (a day - past that no completion is an
 /// outlier because no completion survives).
 constexpr int64_t MAX_SLOW_THRESHOLD_MS = 86400000;
+/// Upper bound on `max_sample_body_bytes`. A captured body is copied on the
+/// completion callback, so an unbounded per-body cap turns one huge response
+/// into a hot-path memcpy the whole worker waits on.
+constexpr int64_t MAX_SAMPLE_BODY_BYTES = 104857600; // 100MB
+/// Upper bound on `max_sample_bytes` (the whole-run capture budget). Every
+/// byte under it is held in memory until the run flushes.
+constexpr int64_t MAX_SAMPLE_BYTES = 1073741824; // 1GB
+/// Upper bound on `max_exemplar_results`. Each retained exemplar holds a
+/// captured exchange, bounded in turn by the two budgets above.
+constexpr int64_t MAX_EXEMPLAR_RESULTS = 100000;
 } // namespace run_config
 
 /**
@@ -263,6 +273,35 @@ constexpr size_t DEFAULT_RESPONSE_SAMPLE_RATE = 100;
 /// optimisation, so capping it costs a few reallocations on a run that large
 /// and nothing at all otherwise. 1M records is ~90 MB, still generous.
 constexpr size_t MAX_RESERVE_RECORDS = 1000000;
+/// Whether a load run captures response headers/bodies for its retained
+/// samples by default (config key `capture_response_bodies`). On by default is
+/// only defensible because capture is failure-and-outlier-shaped rather than
+/// uniform: a healthy run captures roughly `EXEMPLARS_PER_STATUS` bodies per
+/// distinct status code and nothing else, so the common case costs kilobytes.
+constexpr bool DEFAULT_CAPTURE_RESPONSE_BODIES = true;
+/// Largest single captured response body kept, in bytes (config key
+/// `maxSampleBodyBytes`). Deliberately far below design mode's
+/// `maxTraceBodyBytes` (5 MiB): a design run stores one exchange the user asked
+/// for, a load run stores tens of them nobody asked for individually.
+constexpr size_t DEFAULT_MAX_SAMPLE_BODY_BYTES = 32768;
+/// Whole-run budget for captured body bytes (config key `maxSampleBytes`).
+/// Once spent, samples keep being recorded with their headers and metadata and
+/// only the bodies are dropped - counted by
+/// MetricsCollector::sample_bodies_dropped so the UI can say the set is
+/// incomplete rather than showing a silently biased subset.
+constexpr size_t DEFAULT_MAX_SAMPLE_BYTES = 2 * 1024 * 1024;
+/// How many exemplars of each distinct status code a run guarantees to retain.
+/// Small on purpose: exemplars answer "what does a 503 from this target look
+/// like", which the first few answer as well as the first few hundred.
+constexpr size_t EXEMPLARS_PER_STATUS = 3;
+/// Ceiling on the exemplar store (config key `max_exemplar_results`; 0 =
+/// unlimited). The per-status gate already bounds a normal run to
+/// `EXEMPLARS_PER_STATUS x distinct status codes`, which is single digits;
+/// this is the guard for a target that answers with hundreds of distinct
+/// codes. Exemplars past it are dropped and counted, never displaced - an
+/// exemplar's whole value is that it was retained, so a reservoir would defeat
+/// the bucket.
+constexpr size_t DEFAULT_MAX_EXEMPLAR_RESULTS = 64;
 /// HdrHistogram significant figures (3 = ~0.1% precision)
 constexpr int HISTOGRAM_SIGNIFICANT_FIGURES = 3;
 /// HdrHistogram max trackable latency in microseconds (1 hour)

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -27,6 +27,7 @@
 #include <map>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -59,6 +60,27 @@ struct ResponseSample {
 };
 
 /**
+ * @brief A retained sample's response headers and body, copied on the hot path.
+ *
+ * Only the copy happens inline in the completion drain; everything expensive -
+ * binary detection, hashing, dedup, JSON - waits for the flush (see
+ * MetricsCollector::flush_to_database). The bytes here are already truncated
+ * to `max_sample_body_bytes`, because copying a 30 MB body to throw 29.97 MB
+ * of it away at flush would be paying the hot-path cost for nothing;
+ * `body_bytes` remembers the size as received so a reader can tell a slice
+ * from the whole.
+ */
+struct CapturedExchange {
+    Headers headers;
+    std::string body;
+    std::string content_type;
+    int64_t body_bytes = 0; ///< size as received, before truncation
+    bool truncated     = false;
+    /// The run's byte budget was already spent, so only headers were kept.
+    bool body_dropped = false;
+};
+
+/**
  * @brief Record for a single request result (lighter than db::Result)
  */
 struct ResultRecord {
@@ -68,6 +90,10 @@ struct ResultRecord {
     ErrorCode error_code;
     std::string error_message;
     std::string trace_data;
+    /// Present only for the three captured buckets (errors, slow outliers,
+    /// per-status exemplars). A uniformly sampled success carries none: a
+    /// thousand identical 200s are not worth a thousand bodies.
+    std::optional<CapturedExchange> capture;
 
     ResultRecord () = default;
     ResultRecord (int64_t ts, int status, double latency)
@@ -119,6 +145,21 @@ struct MetricsCollectorConfig {
 
     /// Sample rate for response storage (1 = all, 100 = 1%, etc.)
     size_t response_sample_rate = constants::metrics_collector::DEFAULT_RESPONSE_SAMPLE_RATE;
+
+    /// Whether retained samples carry the response headers and body. Off makes
+    /// the collector byte-for-byte what it was before capture existed: no gate
+    /// is consulted, no exemplar is claimed, nothing is copied.
+    bool capture_response_bodies = constants::metrics_collector::DEFAULT_CAPTURE_RESPONSE_BODIES;
+
+    /// Largest captured body per sample; the copy is truncated to it.
+    size_t max_sample_body_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES;
+
+    /// Whole-run budget for captured body bytes. Past it, samples keep their
+    /// headers and metadata and lose only their bodies (sample_bodies_dropped).
+    size_t max_sample_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES;
+
+    /// Ceiling on the per-status exemplar store, 0 = unlimited.
+    size_t max_exemplar_results = constants::metrics_collector::DEFAULT_MAX_EXEMPLAR_RESULTS;
 };
 
 /**
@@ -127,11 +168,18 @@ struct MetricsCollectorConfig {
  * A completion that is both sampled and slow is stored as Slow: the trace is
  * identical either way (it carries `isSlow`), and charging it to the slow
  * budget leaves the 1-in-N budget for ordinary traffic.
+ *
+ * Exemplar outranks both. The other two stores are reservoirs, so a record in
+ * them can be displaced later; an exemplar's entire value is that the run
+ * *kept* one response per status code, which a reservoir cannot promise. The
+ * trace is the same object in every case, so the only thing precedence decides
+ * is which budget pays.
  */
 enum class SuccessTraceReason {
-    None,    ///< no trace was built for this completion
-    Sampled, ///< the 1-in-N sampler selected it
-    Slow     ///< it crossed slow_threshold_ms
+    None,     ///< no trace was built for this completion
+    Sampled,  ///< the 1-in-N sampler selected it
+    Slow,     ///< it crossed slow_threshold_ms
+    Exemplar  ///< it is one of the first EXEMPLARS_PER_STATUS of its status code
 };
 
 /**
@@ -169,6 +217,22 @@ class MetricsCollector {
     [[nodiscard]] bool should_sample_success ();
 
     /**
+     * @brief Claim one of this status code's exemplar slots, if any are left.
+     *
+     * Phase 1 of capture, and the whole of what capture costs a completion
+     * that is not retained: a single relaxed fetch_add on a fixed array,
+     * decided before anything is built or copied. Returns true at most
+     * `EXEMPLARS_PER_STATUS` times per distinct status code per run.
+     *
+     * "First K of each status code" rather than a uniform slice, because a
+     * uniform slice of 30M requests is a thousand identical 200s, while three
+     * of each code answers what the user is actually asking - what does this
+     * target's 503 look like. Returns false when capture is off, so the caller
+     * needs no second toggle check.
+     */
+    [[nodiscard]] bool claim_status_exemplar (int status_code);
+
+    /**
      * @brief Record a successful request
      * Thread-safe, optimized for high-throughput
      *
@@ -176,12 +240,19 @@ class MetricsCollector {
      * @param trace_reason which budget retains @p trace_data. `None` with a
      *                   non-empty trace stores nothing - the two are decided
      *                   together by the caller (see should_sample_success).
+     * @param capture_source the live response, or nullptr to capture nothing.
+     *                   Passed as a pointer rather than copied by the caller
+     *                   so the headers and body are copied *after* the store
+     *                   has accepted the record - a reservoir refusal costs no
+     *                   body-sized copy. Ignored for `Sampled` records, which
+     *                   are a uniform slice and deliberately body-less.
      */
     void record_success (int status_code,
     double latency_ms,
     double queue_wait_ms,
-    const std::string& trace_data   = "",
-    SuccessTraceReason trace_reason = SuccessTraceReason::None);
+    const std::string& trace_data     = "",
+    SuccessTraceReason trace_reason   = SuccessTraceReason::None,
+    const Response* capture_source    = nullptr);
 
     /**
      * @brief Record a response sample for deferred script validation
@@ -197,7 +268,8 @@ class MetricsCollector {
      */
     void record_error (ErrorCode code,
     const std::string& message,
-    const std::string& trace_data = "");
+    const std::string& trace_data  = "",
+    const Response* capture_source = nullptr);
 
     /**
      * @brief Number of error records discarded because the store was full.
@@ -226,6 +298,46 @@ class MetricsCollector {
     /** @brief Response samples dropped or displaced by the reservoir. */
     [[nodiscard]] size_t response_samples_dropped () const {
         return response_dropped_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Exemplar records dropped because the exemplar store was full.
+     * Only a target answering with more distinct status codes than
+     * max_exemplar_results can reach this.
+     */
+    [[nodiscard]] size_t exemplar_results_dropped () const {
+        return exemplar_dropped_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Samples whose body was dropped because the run's capture budget
+     *        was spent. Their headers and metadata were still captured.
+     *
+     * Surfaced so the Samples tab can say the captured set is incomplete
+     * rather than presenting a silently biased subset as the whole story.
+     */
+    [[nodiscard]] size_t sample_bodies_dropped () const {
+        return sample_bodies_dropped_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Captured body bytes held for this run, after truncation.
+     * The figure the budget is spent against.
+     */
+    [[nodiscard]] size_t captured_body_bytes () const {
+        return captured_bytes_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Captured exchanges written by the last flush_to_database.
+     *
+     * Zero until the run flushes. Non-zero is the run's marker that it holds
+     * response headers and bodies stored verbatim - capture does not redact,
+     * by decision, so this is what lets a reader be warned rather than left to
+     * infer it.
+     */
+    [[nodiscard]] size_t response_bodies_captured () const {
+        return response_bodies_captured_.load (std::memory_order_relaxed);
     }
 
     /**
@@ -391,6 +503,14 @@ class MetricsCollector {
     }
 
     /**
+     * @brief Get the retained per-status exemplar records - the first
+     *        EXEMPLARS_PER_STATUS completions of each distinct status code.
+     */
+    [[nodiscard]] const std::vector<ResultRecord>& exemplar_results () const {
+        return exemplar_results_;
+    }
+
+    /**
      * @brief Get latency count from histogram
      * @note Raw latencies are no longer stored; use calculate_percentiles() for analysis
      */
@@ -516,6 +636,19 @@ class MetricsCollector {
     std::vector<ResultRecord> slow_results_;
     std::atomic<size_t> slow_seen_{ 0 };
     std::atomic<size_t> slow_dropped_{ 0 };
+    // Per-status exemplars. Shares success_mutex_ with the two stores above:
+    // the gate that fills it fires at most EXEMPLARS_PER_STATUS times per
+    // status code for the whole run, so it contends with nothing.
+    //
+    // Not a reservoir, unlike its neighbours - a displaced exemplar is not an
+    // exemplar. Past max_exemplar_results a later candidate is refused and
+    // counted rather than evicting an incumbent.
+    std::vector<ResultRecord> exemplar_results_;
+    std::atomic<size_t> exemplar_dropped_{ 0 };
+    // How many exemplar slots each status code has spent. Indexed the same way
+    // as status_code_counts_, with the overflow codes sharing the last slot -
+    // a target answering 999 gets exemplars, just not per-code ones.
+    std::array<std::atomic<size_t>, STATUS_CODE_SLOTS> exemplar_claims_{};
 
     // Response samples for deferred script validation
     mutable std::mutex response_samples_mutex_;
@@ -529,6 +662,25 @@ class MetricsCollector {
     // takes, so it adds no contention to the hot path.
     mutable std::mutex status_overflow_mutex_;
     std::map<int, size_t> status_overflow_;
+
+    // Whole-run capture budget, spent in `max_sample_body_bytes`-bounded
+    // chunks by the copies below.
+    std::atomic<size_t> captured_bytes_{ 0 };
+    std::atomic<size_t> sample_bodies_dropped_{ 0 };
+    std::atomic<size_t> response_bodies_captured_{ 0 };
+
+    /**
+     * @brief Phase 2 of capture: copy the exchange into a record the store has
+     *        already accepted.
+     *
+     * Never called before a slot is claimed, so a refused candidate costs no
+     * body-sized copy. Charges the run budget atomically; when it is spent the
+     * headers and metadata are still captured and only the body is dropped
+     * (counted by sample_bodies_dropped) - metadata is what tells the reader
+     * the set is incomplete, so dropping that too would hide the truncation
+     * being reported.
+     */
+    [[nodiscard]] CapturedExchange capture_exchange (const Response& response);
 
     // Helper for atomic double addition
     void atomic_add_double (std::atomic<double>& target, double value);

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -169,11 +169,16 @@ struct MetricsCollectorConfig {
  * identical either way (it carries `isSlow`), and charging it to the slow
  * budget leaves the 1-in-N budget for ordinary traffic.
  *
- * Exemplar outranks both. The other two stores are reservoirs, so a record in
- * them can be displaced later; an exemplar's entire value is that the run
- * *kept* one response per status code, which a reservoir cannot promise. The
- * trace is the same object in every case, so the only thing precedence decides
- * is which budget pays.
+ * `Exemplar` ranks **last** - it names the store for a completion no other
+ * budget wanted. Ranking it first was tried and was wrong: the first few
+ * completions of a status code are often exactly where a run's outliers are,
+ * so it quietly emptied the slow store, which exists to hold what the user
+ * asked for.
+ *
+ * This enum therefore says only *which budget pays*. Whether the record also
+ * carries a captured body is a separate decision, made by the caller and
+ * passed to record_success - a record can sit in the sampled budget and still
+ * deserve a body, which no ordering of these three could express.
  */
 enum class SuccessTraceReason {
     None,     ///< no trace was built for this completion
@@ -244,8 +249,10 @@ class MetricsCollector {
      *                   Passed as a pointer rather than copied by the caller
      *                   so the headers and body are copied *after* the store
      *                   has accepted the record - a reservoir refusal costs no
-     *                   body-sized copy. Ignored for `Sampled` records, which
-     *                   are a uniform slice and deliberately body-less.
+     *                   body-sized copy. Honoured whatever @p trace_reason is:
+     *                   the caller decides what deserves a body (see
+     *                   handle_result), because the store a record lands in is
+     *                   not what makes its body worth keeping.
      */
     void record_success (int status_code,
     double latency_ms,

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -67,6 +67,19 @@ size_t max_ticks = constants::server::DEFAULT_MAX_LIVE_TICKS) {
     return ticks > max_ticks ? max_ticks : ticks;
 }
 
+/**
+ * @brief Engine-config-backed defaults a run needs at construction time.
+ *
+ * RunContext is built from the run's JSON alone - it holds no Database - so
+ * anything whose default lives in `config_entries` is resolved by the caller
+ * and handed in, the way `maxStoredErrors` always has been. A run's own config
+ * still overrides these; they are only what it falls back to.
+ */
+struct CaptureDefaults {
+    size_t max_sample_body_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES;
+    size_t max_sample_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES;
+};
+
 struct RunContext {
     std::string run_id;
     std::unique_ptr<vayu::http::EventLoop> event_loop;
@@ -97,6 +110,15 @@ struct RunContext {
     // MetricsCollectorConfig::store_success_traces, which is where the sampling
     // gate reads it; a second copy here would have no reader.
     int slow_threshold_ms{ constants::metrics_collector::DEFAULT_SLOW_THRESHOLD_MS };
+
+    // Whether retained samples carry their response headers and body, resolved
+    // once here for the same reason as `slow_threshold_ms` above: handle_result
+    // reads it per completion inside the curl completion drain, where a
+    // string-keyed `config.value(...)` is on the critical path of that worker's
+    // socket processing. The collector holds its own copy (it decides what to
+    // copy); this one exists so a capture-off run never even reaches the
+    // exemplar gate.
+    bool capture_response_bodies{ constants::metrics_collector::DEFAULT_CAPTURE_RESPONSE_BODIES };
 
     // High-performance in-memory metrics collector
     // Replaces direct DB writes for individual results during load tests
@@ -230,7 +252,8 @@ struct RunContext {
     // caller without a database to hand) on the stock cap.
     RunContext (const std::string& id,
     nlohmann::json cfg,
-    size_t max_errors = constants::metrics_collector::DEFAULT_MAX_ERRORS);
+    size_t max_errors                = constants::metrics_collector::DEFAULT_MAX_ERRORS,
+    CaptureDefaults capture_defaults = {});
     ~RunContext ();
 };
 
@@ -295,6 +318,15 @@ struct SamplingRetention {
     size_t success_traces_dropped   = 0;
     size_t slow_traces_dropped      = 0;
     size_t response_samples_dropped = 0;
+    size_t exemplars_dropped        = 0;
+    /// Samples whose body was dropped once the run's capture budget was spent.
+    size_t sample_bodies_dropped = 0;
+    /// Captured exchanges persisted for this run. Doubles as the run's marker
+    /// that it holds response data stored verbatim - headers and bodies are
+    /// captured without redaction, so a non-zero count is what lets the Samples
+    /// tab warn that the stored set may contain credentials. Deleted with the
+    /// run, which makes `maxRunsRetained` the expiry for that data too.
+    size_t response_bodies_captured = 0;
 };
 
 /**

--- a/engine/include/vayu/core/sample_capture.hpp
+++ b/engine/include/vayu/core/sample_capture.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file core/sample_capture.hpp
+ * @brief Pure decisions about a captured load-run response body.
+ *
+ * Everything here runs at flush time, never on the completion callback: the
+ * hot path only gates and copies bytes it already owns (see
+ * MetricsCollector::record_success). Binary detection, hashing and dedup are
+ * deferred precisely because they are the expensive half.
+ *
+ * Extracted rather than left inline in the collector so each rule is testable
+ * on its own - see engine/tests/sample_capture_test.cpp.
+ */
+
+#include <string>
+#include <string_view>
+
+namespace vayu::core {
+
+/**
+ * @brief Whether a captured body should be stored as a binary descriptor
+ *        instead of text.
+ *
+ * The engine never sets `CURLOPT_ACCEPT_ENCODING`, so a request that asks for
+ * `gzip` gets the compressed bytes in `Response::body`; images and protobuf
+ * arrive the same way. Storing those as a string means `dump()` either throws
+ * or - with `error_handler_t::replace` - silently rewrites them into a
+ * mojibake that reads like a real body. Neither is honest, so a binary body is
+ * recorded as its size and content type and nothing else.
+ *
+ * Two independent signals, either sufficient:
+ * - a content type that is not text-shaped (not a `text/` type, and not one of
+ *   the structured-text markers `json` / `xml` / `javascript` /
+ *   `x-www-form-urlencoded` / `csv`);
+ * - bytes that are not valid UTF-8, or that contain a NUL.
+ *
+ * The byte scan is bounded (`SNIFF_BYTES`) so a 32 KiB body costs a fixed
+ * prefix walk. A body whose first `SNIFF_BYTES` are clean text is treated as
+ * text even if it turns binary later; the alternative is walking every
+ * captured byte for a case that does not occur in practice.
+ */
+[[nodiscard]] bool looks_binary (std::string_view body, std::string_view content_type);
+
+/// How many leading bytes `looks_binary` inspects.
+inline constexpr size_t SNIFF_BYTES = 1024;
+
+/**
+ * @brief Lowercased media type of a `Content-Type` header value, parameters
+ *        stripped (`"application/JSON; charset=utf-8"` -> `"application/json"`).
+ *
+ * Returns `""` for an absent or blank header, which `looks_binary` treats as
+ * "no opinion from the header" and falls through to the byte scan.
+ */
+[[nodiscard]] std::string media_type (std::string_view content_type);
+
+/**
+ * @brief Lowercase hex SHA-256 of the stored bytes - the dedup key.
+ *
+ * Load-test responses are overwhelmingly identical, so the run's bodies are
+ * deduplicated by this digest before insert: 1000 samples of one 2 KiB body
+ * store 2 KiB. Hashing the *stored* (already truncated) bytes rather than the
+ * original is deliberate - two bodies that differ only past the truncation
+ * point are byte-identical as stored, and storing them twice would be storing
+ * the same row twice.
+ */
+[[nodiscard]] std::string body_digest (std::string_view stored_body);
+
+} // namespace vayu::core

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -149,8 +149,32 @@ class Database {
 
     // Results
     void add_result (const Result& result);
-    void add_results_batch (const std::vector<Result>& results); // Transactional batch insert
+    /**
+     * @brief Transactional batch insert of a run's sampled results, optionally
+     *        with the response bodies captured alongside them.
+     *
+     * `bodies` refer to results by index (`PendingResultBody::result_index`),
+     * because the row ids only exist once the insert has run. Results, the
+     * deduplicated blobs and the per-result body rows all land in one
+     * transaction, so a crash mid-flush cannot leave a body row pointing at a
+     * result that was rolled back.
+     *
+     * Bodies are deduplicated by `body_hash` within this call: identical
+     * responses - the norm for a load test - share one `body_blobs` row.
+     */
+    void add_results_batch (const std::vector<Result>& results,
+    const std::vector<PendingResultBody>& bodies = {});
     std::vector<Result> get_results (const std::string& run_id);
+
+    // Captured response bodies for a run's sampled results. Deliberately not
+    // reachable from get_results: the report path loads and parses every
+    // result row for a run, and this is exactly the data it must not pay for.
+    std::vector<ResultBody> get_result_bodies_paginated (const std::string& run_id,
+    int64_t limit,
+    int64_t offset);
+    int64_t count_result_bodies (const std::string& run_id);
+    /// The stored bytes of a blob, or `""` when the id is 0 or unknown.
+    std::string get_body_blob_content (int blob_id);
 
     // Config Entries - Structured configuration with metadata
     void save_config_entry (const ConfigEntry& entry);

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -742,7 +742,66 @@ struct Result {
     std::string status_text; // Wire reason phrase, or canonical IANA text
     double latency_ms;
     std::string error;
-    std::string trace_data; // JSON (Headers/Body - only for Design Mode or Errors)
+    // JSON. Design mode stores the whole exchange here (request + response,
+    // nested). A load run stores only the timing breakdown - never a body -
+    // because `calculate_detailed_report` parses every row of this column on
+    // every report fetch, and the dashboard polls that. Load-run bodies live in
+    // `result_bodies`/`body_blobs` instead, read only by GET /runs/:id/samples.
+    std::string trace_data;
+};
+
+/**
+ * @brief One captured response body, content-addressed and shared within a run.
+ *
+ * Load-test responses are overwhelmingly identical, so the sample rows below
+ * point at these rather than each carrying its own copy: 1000 samples of one
+ * 2 KiB body store 2 KiB. Scoped per run (`run_id` + `hash` is unique) so
+ * deleting a run deletes its blobs without any cross-run refcount to maintain.
+ */
+struct BodyBlob {
+    int id;
+    std::string run_id;
+    std::string hash;    // lowercase hex SHA-256 of `content` (vayu::core::body_digest)
+    std::string content; // the stored bytes, already truncated to the per-body cap
+};
+
+/**
+ * @brief The captured exchange for one sampled load-run result.
+ *
+ * Keyed by the `results` row it belongs to, one-to-one. Its own table so the
+ * report path - which loads every `results` row for a run and JSON-parses each
+ * `trace_data` - never reads a body it does not use.
+ */
+struct ResultBody {
+    int result_id; // PK, and the `results.id` this exchange belongs to
+    std::string run_id;
+    std::string headers;   // JSON object of response headers
+    // 0 when no body was stored: the response had none, it was binary, or the
+    // run's capture budget was spent. `body_bytes` and the flags say which.
+    int blob_id;
+    int64_t body_bytes;    // size of the body as received, before truncation
+    bool truncated;        // stored bytes are a prefix of `body_bytes`
+    bool is_binary;        // stored as a descriptor; `blob_id` is 0
+    std::string content_type;
+};
+
+/**
+ * @brief A captured exchange on its way to `result_bodies`, still unattached.
+ *
+ * `results.id` is assigned by the insert, so the pairing between a result and
+ * its exchange has to travel as the result's index within the batch. Both are
+ * written in one transaction (Database::add_results_batch), so a run never
+ * persists a body row pointing at a result that did not land.
+ */
+struct PendingResultBody {
+    size_t result_index = 0;
+    std::string headers;   // JSON object
+    std::string body;      // stored bytes; "" when binary, absent or dropped
+    std::string body_hash; // digest of `body`; "" when nothing is stored
+    int64_t body_bytes = 0;
+    bool truncated     = false;
+    bool binary        = false;
+    std::string content_type;
 };
 
 /**

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -133,13 +133,21 @@ vayu::Result<vayu::Response> result) {
         auto trace_reason = SuccessTraceReason::None;
 
         if (sampled || is_slow || exemplar) {
-            // Exemplar outranks both: the other two stores are reservoirs and
-            // can displace what they hold, and an exemplar that gets displaced
-            // is not an exemplar. Between the remaining two, slow wins - the
-            // trace is identical, and charging it to the slow budget leaves the
-            // 1-in-N budget for ordinary traffic.
-            trace_reason = exemplar ? SuccessTraceReason::Exemplar :
-            (is_slow ? SuccessTraceReason::Slow : SuccessTraceReason::Sampled);
+            // Slow still wins, then sampled: the trace is identical either way,
+            // and charging an outlier to the slow budget leaves the 1-in-N
+            // budget for ordinary traffic.
+            //
+            // Exemplar is *last*, and only decides the store for a completion
+            // no other budget wanted. Ranking it first stole outliers from the
+            // slow store - the first few completions of a status code are
+            // usually where a run's outliers are - which is a behaviour change
+            // nobody asked for, on the store whose whole purpose is to hold
+            // what the user asked for. Being retained is still guaranteed:
+            // whichever budget claims it, the record is stored, and the
+            // exemplar's real job (capturing a body for it) is decided
+            // separately below.
+            trace_reason = is_slow ? SuccessTraceReason::Slow :
+            (sampled ? SuccessTraceReason::Sampled : SuccessTraceReason::Exemplar);
 
             nlohmann::json timing_json = { { "totalMs", response.timing.total_ms },
                 { "wireMs", response.timing.wire_ms },
@@ -158,13 +166,17 @@ vayu::Result<vayu::Response> result) {
             trace_data = timing_json.dump ();
         }
 
-        // Record to in-memory collector (high-performance, no DB writes). The
-        // collector ignores the capture source for a plain `Sampled` record -
-        // that budget is a uniform slice, and capture is deliberately
-        // failure-and-outlier-shaped.
+        // Whether a body is captured is decided here, not by which store won
+        // above. Capture is failure-and-outlier-shaped: an outlier or a claimed
+        // exemplar gets one, a plain 1-in-N sample does not - a thousand
+        // identical 200s are not worth a thousand bodies. A completion that is
+        // both sampled and an exemplar is stored in the sampled budget *and*
+        // keeps its body, which is the case the old precedence-based version
+        // could only express by moving the record.
+        const bool capture_body = context->capture_response_bodies && (is_slow || exemplar);
         context->metrics_collector->record_success (response.status_code, latency,
         response.timing.queue_wait_ms, trace_data, trace_reason,
-        context->capture_response_bodies ? &response : nullptr);
+        capture_body ? &response : nullptr);
         context->metrics_collector->record_bytes (
         response.timing.bytes_up, response.timing.bytes_down);
 

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -96,8 +96,14 @@ vayu::Result<vayu::Response> result) {
                 { "downloadMs", response.timing.download_ms } };
         }
 
-        context->metrics_collector->record_error (
-        response.error_code, response.error_message, error_json.dump ());
+        // Every error is a capture candidate: a failure is exactly the sample a
+        // user opens the Samples tab for, and errors are already bounded by
+        // `maxStoredErrors`. Passing the response rather than a copy keeps the
+        // body-sized work inside the collector, after it has decided to keep
+        // the record (see MetricsCollector::record_error).
+        context->metrics_collector->record_error (response.error_code,
+        response.error_message, error_json.dump (),
+        context->capture_response_bodies ? &response : nullptr);
         context->metrics_collector->record_bytes (
         response.timing.bytes_up, response.timing.bytes_down);
     } else {
@@ -115,15 +121,25 @@ vayu::Result<vayu::Response> result) {
         const bool is_slow = context->slow_threshold_ms > 0 &&
         latency >= static_cast<double> (context->slow_threshold_ms);
         const bool sampled = context->metrics_collector->should_sample_success ();
+        // Third reason, and the cheapest: one relaxed fetch_add deciding
+        // whether this completion is among the first few of its status code. A
+        // uniform slice of a 30M-request run is a thousand identical 200s;
+        // three of each code is what answers "what does this target's 503
+        // look like".
+        const bool exemplar =
+        context->metrics_collector->claim_status_exemplar (response.status_code);
 
         std::string trace_data;
         auto trace_reason = SuccessTraceReason::None;
 
-        if (sampled || is_slow) {
-            // Slow wins when a completion is both: the trace is identical, and
-            // charging it to the slow budget leaves the 1-in-N budget for
-            // ordinary traffic.
-            trace_reason = is_slow ? SuccessTraceReason::Slow : SuccessTraceReason::Sampled;
+        if (sampled || is_slow || exemplar) {
+            // Exemplar outranks both: the other two stores are reservoirs and
+            // can displace what they hold, and an exemplar that gets displaced
+            // is not an exemplar. Between the remaining two, slow wins - the
+            // trace is identical, and charging it to the slow budget leaves the
+            // 1-in-N budget for ordinary traffic.
+            trace_reason = exemplar ? SuccessTraceReason::Exemplar :
+            (is_slow ? SuccessTraceReason::Slow : SuccessTraceReason::Sampled);
 
             nlohmann::json timing_json = { { "totalMs", response.timing.total_ms },
                 { "wireMs", response.timing.wire_ms },
@@ -142,9 +158,13 @@ vayu::Result<vayu::Response> result) {
             trace_data = timing_json.dump ();
         }
 
-        // Record to in-memory collector (high-performance, no DB writes)
-        context->metrics_collector->record_success (response.status_code,
-        latency, response.timing.queue_wait_ms, trace_data, trace_reason);
+        // Record to in-memory collector (high-performance, no DB writes). The
+        // collector ignores the capture source for a plain `Sampled` record -
+        // that budget is a uniform slice, and capture is deliberately
+        // failure-and-outlier-shaped.
+        context->metrics_collector->record_success (response.status_code, latency,
+        response.timing.queue_wait_ms, trace_data, trace_reason,
+        context->capture_response_bodies ? &response : nullptr);
         context->metrics_collector->record_bytes (
         response.timing.bytes_up, response.timing.bytes_down);
 

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -291,10 +291,12 @@ const Response* capture_source) {
     auto& seen_counter = slow ? slow_seen_ : success_seen_;
     auto& dropped      = slow ? slow_dropped_ : success_dropped_;
 
-    // Only the slow store captures bodies here. A `Sampled` record is a uniform
-    // slice of ordinary traffic, and a thousand identical 200s are not worth a
-    // thousand bodies - that is the decision the three-bucket policy rests on.
-    const Response* capture = slow ? capture_source : nullptr;
+    // Whether to capture is the caller's call, not this store's: handle_result
+    // knows whether the completion was an outlier or a claimed exemplar, and a
+    // record can land in the sampled budget while still deserving a body.
+    // Deciding it from `trace_reason` here would make the two inseparable, and
+    // the store a record lands in is not what makes its body worth keeping.
+    const Response* capture = capture_source;
 
     if (capacity == 0) { // unlimited
         if (capture != nullptr) {

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -12,6 +12,7 @@
 
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/reservoir.hpp"
+#include "vayu/core/sample_capture.hpp"
 #include "vayu/http/status.hpp"
 #include "vayu/utils/logger.hpp"
 
@@ -138,6 +139,13 @@ MetricsCollector::MetricsCollector (const std::string& run_id, MetricsCollectorC
         slow_results_.reserve (std::min (config_.max_slow_results, max_reserve));
     }
 
+    // Exemplars are bounded by EXEMPLARS_PER_STATUS x distinct status codes,
+    // which is single digits on any real target, so the reserve is the store's
+    // own ceiling rather than anything derived from the request count.
+    if (config_.capture_response_bodies && config_.max_exemplar_results > 0) {
+        exemplar_results_.reserve (std::min (config_.max_exemplar_results, max_reserve));
+    }
+
     // Reserve response samples for script validation
     response_samples_.reserve (config_.max_response_samples);
 }
@@ -161,11 +169,67 @@ void MetricsCollector::atomic_add_double (std::atomic<double>& target, double va
     }
 }
 
+bool MetricsCollector::claim_status_exemplar (int status_code) {
+    if (!config_.capture_response_bodies) {
+        return false;
+    }
+    // Out-of-range codes share the last slot rather than taking a lock: a
+    // misbehaving proxy answering 999 still gets exemplars, they are just not
+    // per-code. Keeping this branch lock-free is the point - it runs on every
+    // completion, retained or not.
+    const int slot = (status_code >= 0 && status_code < STATUS_CODE_SLOTS - 1) ?
+    status_code :
+    STATUS_CODE_SLOTS - 1;
+    const size_t claimed = exemplar_claims_[slot].fetch_add (1, std::memory_order_relaxed);
+    return claimed < constants::metrics_collector::EXEMPLARS_PER_STATUS;
+}
+
+CapturedExchange MetricsCollector::capture_exchange (const Response& response) {
+    CapturedExchange captured;
+    captured.headers    = response.headers;
+    captured.body_bytes = static_cast<int64_t> (response.body.size ());
+
+    // Headers compares case-insensitively, so one lookup covers every spelling
+    // an origin might send.
+    const auto content_type = response.headers.find ("content-type");
+    if (content_type != response.headers.end ()) {
+        captured.content_type = content_type->second;
+    }
+
+    if (response.body.empty ()) {
+        return captured;
+    }
+
+    const size_t want = std::min (response.body.size (), config_.max_sample_body_bytes);
+    if (want == 0) {
+        // max_sample_body_bytes of 0 keeps headers and metadata and no body.
+        captured.body_dropped = true;
+        sample_bodies_dropped_.fetch_add (1, std::memory_order_relaxed);
+        return captured;
+    }
+
+    // Charge the run budget before copying. fetch_add-then-refund rather than a
+    // CAS loop: the overshoot is bounded by one body per concurrent writer, and
+    // the budget is a memory guard, not an accounting figure.
+    const size_t before = captured_bytes_.fetch_add (want, std::memory_order_relaxed);
+    if (before + want > config_.max_sample_bytes) {
+        captured_bytes_.fetch_sub (want, std::memory_order_relaxed);
+        captured.body_dropped = true;
+        sample_bodies_dropped_.fetch_add (1, std::memory_order_relaxed);
+        return captured;
+    }
+
+    captured.body      = response.body.substr (0, want);
+    captured.truncated = want < response.body.size ();
+    return captured;
+}
+
 void MetricsCollector::record_success (int status_code,
 double latency_ms,
 double queue_wait_ms,
 const std::string& trace_data,
-SuccessTraceReason trace_reason) {
+SuccessTraceReason trace_reason,
+const Response* capture_source) {
     // Update atomic counters (lock-free)
     total_requests_.fetch_add (1, std::memory_order_relaxed);
     atomic_add_double (total_latency_sum_, latency_ms);
@@ -196,13 +260,46 @@ SuccessTraceReason trace_reason) {
     ResultRecord record (now_ms (), status_code, latency_ms);
     record.trace_data = trace_data;
 
+    // Exemplars take the straight path: a fixed number per status code, kept
+    // until the store is full and then refused. No reservoir, because being
+    // retained is the only thing an exemplar is for.
+    //
+    // A refusal here leaves its captured bytes charged to the run budget with
+    // no record to show for them. Left unrefunded deliberately: the budget is a
+    // memory ceiling rather than an accounting figure, over-counting it only
+    // makes capture stop sooner, and the alternative is holding the store's
+    // mutex across a body-sized copy. The gate above already bounds this to
+    // EXEMPLARS_PER_STATUS per status code, so it needs a target answering with
+    // more distinct codes than `max_exemplar_results` to happen at all.
+    if (trace_reason == SuccessTraceReason::Exemplar) {
+        if (capture_source != nullptr) {
+            record.capture = capture_exchange (*capture_source);
+        }
+        std::lock_guard<std::mutex> lock (success_mutex_);
+        if (config_.max_exemplar_results > 0 &&
+        exemplar_results_.size () >= config_.max_exemplar_results) {
+            exemplar_dropped_.fetch_add (1, std::memory_order_relaxed);
+            return;
+        }
+        exemplar_results_.push_back (std::move (record));
+        return;
+    }
+
     const bool slow = trace_reason == SuccessTraceReason::Slow;
     const size_t capacity = slow ? config_.max_slow_results : config_.max_success_results;
     auto& store        = slow ? slow_results_ : success_results_;
     auto& seen_counter = slow ? slow_seen_ : success_seen_;
     auto& dropped      = slow ? slow_dropped_ : success_dropped_;
 
+    // Only the slow store captures bodies here. A `Sampled` record is a uniform
+    // slice of ordinary traffic, and a thousand identical 200s are not worth a
+    // thousand bodies - that is the decision the three-bucket policy rests on.
+    const Response* capture = slow ? capture_source : nullptr;
+
     if (capacity == 0) { // unlimited
+        if (capture != nullptr) {
+            record.capture = capture_exchange (*capture);
+        }
         std::lock_guard<std::mutex> lock (success_mutex_);
         store.push_back (std::move (record));
         return;
@@ -213,6 +310,12 @@ SuccessTraceReason trace_reason) {
     if (!slot.accepted) {
         dropped.fetch_add (1, std::memory_order_relaxed);
         return;
+    }
+
+    // The slot is claimed, so this record is being kept: copying the body now
+    // is the point of deferring it past the reservoir refusal above.
+    if (capture != nullptr) {
+        record.capture = capture_exchange (*capture);
     }
 
     bool displaced = false;
@@ -271,10 +374,11 @@ void MetricsCollector::record_response_sample (const Response& response) {
 
 void MetricsCollector::record_error (ErrorCode code,
 const std::string& message,
-const std::string& trace_data) {
+const std::string& trace_data,
+const Response* capture_source) {
     // Update atomic counters (lock-free)
     total_requests_.fetch_add (1, std::memory_order_relaxed);
-    total_errors_.fetch_add (1, std::memory_order_relaxed);
+    const size_t error_index = total_errors_.fetch_add (1, std::memory_order_relaxed);
 
     // Transport errors (timeout, connection, DNS, …) carry no HTTP status, so
     // bucket them under code 0. This keeps the status-code distribution summing
@@ -288,12 +392,24 @@ const std::string& trace_data) {
     // above stay exact, so only the per-error detail is lost. Without the cap a
     // fully-failing target grows this vector for the life of the run and then
     // flushes it as one enormous transaction.
+    // Copy the exchange before taking the store's mutex, so a body-sized copy
+    // never lengthens a critical section every failing completion queues on.
+    // `error_index` is this call's position in the error sequence, and the
+    // store admits the first `max_errors` of exactly that sequence, so this
+    // predicate and the one under the lock agree without a second counter.
+    std::optional<CapturedExchange> captured;
+    if (capture_source != nullptr &&
+    (config_.max_errors == 0 || error_index < config_.max_errors)) {
+        captured = capture_exchange (*capture_source);
+    }
+
     bool first_drop = false;
     {
         std::lock_guard<std::mutex> lock (errors_mutex_);
         if (config_.max_errors == 0 || errors_.size () < config_.max_errors) {
             ResultRecord record (now_ms (), code, message);
             record.trace_data = trace_data;
+            record.capture    = std::move (captured);
             errors_.push_back (std::move (record));
         } else {
             first_drop =
@@ -402,6 +518,38 @@ std::map<int, size_t> MetricsCollector::status_code_distribution () const {
 
 size_t MetricsCollector::flush_to_database (db::Database& db) {
     std::vector<db::Result> batch;
+    std::vector<db::PendingResultBody> bodies;
+
+    // Turn a record's captured exchange into a row for `result_bodies`. This is
+    // where the expensive half of capture lives - JSON, binary detection and
+    // hashing - deliberately after load generation has stopped rather than
+    // inline in the completion drain (see CapturedExchange).
+    auto collect_capture = [&] (const ResultRecord& record) {
+        if (!record.capture.has_value ()) {
+            return;
+        }
+        const CapturedExchange& exchange = *record.capture;
+
+        db::PendingResultBody pending;
+        pending.result_index = batch.size () - 1;
+        pending.headers = nlohmann::json (exchange.headers)
+                          .dump (-1, ' ', false, nlohmann::json::error_handler_t::replace);
+        pending.body_bytes   = exchange.body_bytes;
+        pending.truncated    = exchange.truncated;
+        pending.content_type = exchange.content_type;
+
+        if (!exchange.body_dropped && !exchange.body.empty ()) {
+            // A binary body is stored as its size and content type, never as
+            // text: `error_handler_t::replace` would keep dump() from throwing
+            // and hand the reader a mojibake that looks like a real response.
+            pending.binary = looks_binary (exchange.body, exchange.content_type);
+            if (!pending.binary) {
+                pending.body      = exchange.body;
+                pending.body_hash = body_digest (pending.body);
+            }
+        }
+        bodies.push_back (std::move (pending));
+    };
 
     // Collect all error records
     {
@@ -418,15 +566,17 @@ size_t MetricsCollector::flush_to_database (db::Database& db) {
             db_result.error       = error.error_message;
             db_result.trace_data  = error.trace_data;
             batch.push_back (std::move (db_result));
+            collect_capture (error);
         }
     }
 
-    // Collect sampled success records and the slow-request outliers. Two
-    // budgets in memory, one table on disk: a stored row is a stored row, and
-    // the report tells them apart by the trace's `isSlow` marker.
+    // Collect sampled success records, the slow-request outliers and the
+    // per-status exemplars. Three budgets in memory, one table on disk: a
+    // stored row is a stored row, and the report tells them apart by the
+    // trace's `isSlow` marker.
     {
         std::lock_guard<std::mutex> lock (success_mutex_);
-        for (const auto* store : { &success_results_, &slow_results_ }) {
+        for (const auto* store : { &success_results_, &slow_results_, &exemplar_results_ }) {
             for (const auto& success : *store) {
                 db::Result db_result;
                 db_result.run_id      = run_id_;
@@ -439,14 +589,17 @@ size_t MetricsCollector::flush_to_database (db::Database& db) {
                 db_result.latency_ms = success.latency_ms;
                 db_result.trace_data = success.trace_data;
                 batch.push_back (std::move (db_result));
+                collect_capture (success);
             }
         }
     }
 
-    // Batch insert with transaction (prevents WAL growth and OOM)
+    // Batch insert with transaction (prevents WAL growth and OOM). Results and
+    // their captured bodies land together, so a failure leaves neither.
     if (!batch.empty ()) {
-        db.add_results_batch (batch);
+        db.add_results_batch (batch, bodies);
     }
+    response_bodies_captured_.store (bodies.size (), std::memory_order_relaxed);
 
     return batch.size ();
 }
@@ -466,22 +619,37 @@ size_t MetricsCollector::memory_usage_bytes () const {
         bytes += hdr_get_memory_size (latency_histogram_);
     }
 
+    // A record's captured exchange, when it has one. Counted here rather than
+    // assumed small: bodies are what make a retained record expensive, and the
+    // whole-run budget is only a ceiling, not a measurement.
+    auto capture_bytes = [] (const ResultRecord& record) -> size_t {
+        if (!record.capture.has_value ()) {
+            return 0;
+        }
+        size_t bytes = record.capture->body.capacity () +
+        record.capture->content_type.capacity ();
+        for (const auto& [name, value] : record.capture->headers) {
+            bytes += name.capacity () + value.capacity ();
+        }
+        return bytes;
+    };
+
     // Errors vector
     {
         std::lock_guard<std::mutex> lock (errors_mutex_);
         bytes += errors_.capacity () * sizeof (ResultRecord);
         for (const auto& e : errors_) {
-            bytes += e.error_message.capacity () + e.trace_data.capacity ();
+            bytes += e.error_message.capacity () + e.trace_data.capacity () + capture_bytes (e);
         }
     }
 
-    // Success and slow-request result vectors
+    // Success, slow-request and exemplar result vectors
     {
         std::lock_guard<std::mutex> lock (success_mutex_);
-        for (const auto* store : { &success_results_, &slow_results_ }) {
+        for (const auto* store : { &success_results_, &slow_results_, &exemplar_results_ }) {
             bytes += store->capacity () * sizeof (ResultRecord);
             for (const auto& s : *store) {
-                bytes += s.trace_data.capacity ();
+                bytes += s.trace_data.capacity () + capture_bytes (s);
             }
         }
     }

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -37,6 +37,9 @@ SamplingRetention read_retention (const MetricsCollector& mc) {
     retention.success_traces_dropped   = mc.success_results_dropped ();
     retention.slow_traces_dropped      = mc.slow_results_dropped ();
     retention.response_samples_dropped = mc.response_samples_dropped ();
+    retention.exemplars_dropped        = mc.exemplar_results_dropped ();
+    retention.sample_bodies_dropped    = mc.sample_bodies_dropped ();
+    retention.response_bodies_captured = mc.response_bodies_captured ();
     return retention;
 }
 
@@ -169,7 +172,10 @@ validate_scripts (std::shared_ptr<RunContext> context, vayu::db::Database& db, b
 }
 } // namespace
 
-RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_errors)
+RunContext::RunContext (const std::string& id,
+nlohmann::json cfg,
+size_t max_errors,
+CaptureDefaults capture_defaults)
 : run_id (id), config (cfg.is_object () ? std::move (cfg) : nlohmann::json::object ()), start_time_ms (0) {
     // Initialize MetricsCollector with configuration from test config
     MetricsCollectorConfig mc_config;
@@ -209,6 +215,22 @@ RunContext::RunContext (const std::string& id, nlohmann::json cfg, size_t max_er
     // Outlier capture threshold, read once here rather than per completion.
     slow_threshold_ms = config.value ("slow_threshold_ms",
     constants::metrics_collector::DEFAULT_SLOW_THRESHOLD_MS);
+
+    // Response capture for the retained samples. On by default because the
+    // policy is failure-and-outlier-shaped rather than uniform - a healthy run
+    // captures a handful of exemplars and nothing else. The per-body cap and
+    // the whole-run budget default from engine config (both `observability`
+    // keys) and can be overridden per run, the same way the retention caps are.
+    mc_config.capture_response_bodies = config.value ("capture_response_bodies",
+    constants::metrics_collector::DEFAULT_CAPTURE_RESPONSE_BODIES);
+    mc_config.max_sample_body_bytes = static_cast<size_t> (config.value (
+    "max_sample_body_bytes", static_cast<int64_t> (capture_defaults.max_sample_body_bytes)));
+    mc_config.max_sample_bytes = static_cast<size_t> (
+    config.value ("max_sample_bytes", static_cast<int64_t> (capture_defaults.max_sample_bytes)));
+    mc_config.max_exemplar_results =
+    static_cast<size_t> (config.value ("max_exemplar_results",
+    static_cast<int64_t> (constants::metrics_collector::DEFAULT_MAX_EXEMPLAR_RESULTS)));
+    capture_response_bodies = mc_config.capture_response_bodies;
 
     // Configure response sampling for script validation
     mc_config.max_response_samples =
@@ -476,9 +498,20 @@ bool verbose) {
         // workers themselves because a thread cannot join itself.
         finished = take_finished_workers ();
 
+        // The config-backed defaults RunContext cannot read for itself - it
+        // holds no Database - resolved here, the way `maxStoredErrors` always
+        // has been. A run's own config still overrides each of them.
+        CaptureDefaults capture_defaults;
+        capture_defaults.max_sample_body_bytes =
+        static_cast<size_t> (db.get_config_int ("maxSampleBodyBytes",
+        static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES)));
+        capture_defaults.max_sample_bytes = static_cast<size_t> (db.get_config_int ("maxSampleBytes",
+        static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES)));
+
         auto context = std::make_shared<RunContext> (run_id, config,
         static_cast<size_t> (db.get_config_int ("maxStoredErrors",
-        static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS))));
+        static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS))),
+        capture_defaults);
         register_run (run_id, context);
 
         // Sweep stale retained runs on each new registration so that headless /
@@ -872,7 +905,14 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     summary["sampling"] = { { "errors_dropped", inputs.retention.errors_dropped },
         { "success_traces_dropped", inputs.retention.success_traces_dropped },
         { "slow_traces_dropped", inputs.retention.slow_traces_dropped },
-        { "response_samples_dropped", inputs.retention.response_samples_dropped } };
+        { "response_samples_dropped", inputs.retention.response_samples_dropped },
+        { "exemplars_dropped", inputs.retention.exemplars_dropped },
+        { "sample_bodies_dropped", inputs.retention.sample_bodies_dropped },
+        // The run's own record that it captured response data verbatim. Read
+        // by the Samples tab to warn about credentials, so it has to be
+        // persisted rather than re-derived - the tab renders from the report
+        // long after the collector is gone.
+        { "response_bodies_captured", inputs.retention.response_bodies_captured } };
     // Omitted entirely when validation did not run, so the report keeps
     // distinguishing "no test script" from "a script that passed nothing".
     if (inputs.tests.has_value ()) {

--- a/engine/src/core/sample_capture.cpp
+++ b/engine/src/core/sample_capture.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/core/sample_capture.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+
+#include "vayu/utils/encoding.hpp"
+#include "vayu/utils/sha256.hpp"
+
+namespace vayu::core {
+
+namespace {
+
+/// Media types (or suffixes of them) whose payload is text by definition.
+/// Anything else with a declared type is treated as binary without reading a
+/// byte, which is what makes `image/png` cheap to classify.
+bool text_shaped (std::string_view type) {
+    if (type.rfind ("text/", 0) == 0) {
+        return true;
+    }
+    static constexpr std::array<std::string_view, 6> kTextish = { "json", "xml",
+        "javascript", "ecmascript", "x-www-form-urlencoded", "csv" };
+    return std::any_of (kTextish.begin (), kTextish.end (), [type] (std::string_view needle) {
+        return type.find (needle) != std::string_view::npos;
+    });
+}
+
+/**
+ * @brief Validate a bounded prefix as UTF-8, rejecting NUL.
+ *
+ * A truncated capture can cut a multi-byte sequence in half, so a sequence
+ * that runs off the end of the inspected window is *not* a failure - the
+ * bytes we did see were well-formed, and the split is an artefact of our own
+ * cap rather than anything about the body.
+ */
+bool prefix_is_utf8_text (std::string_view bytes) {
+    const auto* p         = reinterpret_cast<const unsigned char*> (bytes.data ());
+    const size_t inspect  = std::min (bytes.size (), SNIFF_BYTES);
+
+    size_t i = 0;
+    while (i < inspect) {
+        const unsigned char c = p[i];
+        if (c == 0x00) {
+            return false; // NUL never appears in text; it is the strongest signal.
+        }
+        size_t extra = 0;
+        if (c < 0x80) {
+            extra = 0;
+        } else if ((c & 0xE0) == 0xC0 && c >= 0xC2) {
+            extra = 1;
+        } else if ((c & 0xF0) == 0xE0) {
+            extra = 2;
+        } else if ((c & 0xF8) == 0xF0 && c <= 0xF4) {
+            extra = 3;
+        } else {
+            return false; // continuation byte in leading position, or 0xC0/0xC1/0xF5+
+        }
+
+        if (i + extra >= inspect) {
+            // The sequence runs past the window. Whatever we have seen so far
+            // was valid, so stop here rather than blaming our own cap.
+            return true;
+        }
+        for (size_t k = 1; k <= extra; k++) {
+            if ((p[i + k] & 0xC0) != 0x80) {
+                return false;
+            }
+        }
+        i += extra + 1;
+    }
+    return true;
+}
+
+} // namespace
+
+std::string media_type (std::string_view content_type) {
+    const size_t semi = content_type.find (';');
+    std::string_view head =
+    semi == std::string_view::npos ? content_type : content_type.substr (0, semi);
+
+    // Trim ASCII whitespace both ends.
+    while (!head.empty () && (std::isspace (static_cast<unsigned char> (head.front ())) != 0)) {
+        head.remove_prefix (1);
+    }
+    while (!head.empty () && (std::isspace (static_cast<unsigned char> (head.back ())) != 0)) {
+        head.remove_suffix (1);
+    }
+
+    std::string out (head);
+    std::transform (out.begin (), out.end (), out.begin (), [] (unsigned char ch) {
+        return static_cast<char> (std::tolower (ch));
+    });
+    return out;
+}
+
+bool looks_binary (std::string_view body, std::string_view content_type) {
+    if (body.empty ()) {
+        return false; // Nothing to misread; an empty body is stored as text.
+    }
+
+    const std::string type = media_type (content_type);
+    if (!type.empty () && !text_shaped (type)) {
+        return true;
+    }
+
+    // Either no usable header, or one that claims text. The bytes get the last
+    // word, because a mislabelled `text/html` gzip stream is exactly the case
+    // that corrupts silently.
+    return !prefix_is_utf8_text (body);
+}
+
+std::string body_digest (std::string_view stored_body) {
+    const auto digest = vayu::utils::sha256 (stored_body);
+    return vayu::utils::hex_encode (
+    std::string_view (reinterpret_cast<const char*> (digest.data ()), digest.size ()));
+}
+
+} // namespace vayu::core

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -39,6 +39,7 @@
 #include <filesystem>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <mutex>
 #include <sstream>
 #include <thread>
@@ -167,6 +168,10 @@ inline auto make_storage (const std::string& path) {
     // get_metric_ticks_since is polled every 500ms by the legacy SSE loop.
     make_index ("idx_metric_ticks_run_id", &MetricTick::run_id),
     make_index ("idx_results_run_id", &Result::run_id),
+    // GET /runs/:id/samples pages result_bodies by run, and the run cascade
+    // deletes both new tables by run_id.
+    make_index ("idx_result_bodies_run_id", &ResultBody::run_id),
+    make_index ("idx_body_blobs_run_id", &BodyBlob::run_id),
     // Sidebar load (get_requests_in_collection) and cascade delete.
     make_index ("idx_requests_collection_id", &Request::collection_id),
     // The cascade-delete BFS in delete_collection walks one lookup per node.
@@ -257,7 +262,29 @@ inline auto make_storage (const std::string& path) {
     make_column ("status_code", &Result::status_code),
     make_column ("status_text", &Result::status_text), // Wire reason phrase
     make_column ("latency_ms", &Result::latency_ms), make_column ("error", &Result::error),
-    make_column ("trace_data", &Result::trace_data)), // JSON: headers/body for errors
+    make_column ("trace_data", &Result::trace_data)), // JSON: timing, or a design-mode exchange
+
+    // Body blobs: one row per *distinct* captured response body in a run.
+    // Content-addressed within the run so N identical load-test responses cost
+    // one copy. sync_schema() creates new tables outright, so this and the
+    // table below need no migration.
+    make_table ("body_blobs", make_column ("id", &BodyBlob::id, primary_key ().autoincrement ()),
+    make_column ("run_id", &BodyBlob::run_id), make_column ("hash", &BodyBlob::hash),
+    make_column ("content", &BodyBlob::content)),
+
+    // Result bodies: the captured exchange for one sampled result, one-to-one
+    // with a `results` row. Separate from `results` on purpose - the report
+    // path loads every result row for a run and JSON-parses each trace_data, so
+    // a body stored there would be read (and parsed) on every dashboard poll.
+    make_table ("result_bodies",
+    make_column ("result_id", &ResultBody::result_id, primary_key ()),
+    make_column ("run_id", &ResultBody::run_id),
+    make_column ("headers", &ResultBody::headers), // JSON object
+    make_column ("blob_id", &ResultBody::blob_id), // 0 = no stored body
+    make_column ("body_bytes", &ResultBody::body_bytes),
+    make_column ("truncated", &ResultBody::truncated),
+    make_column ("is_binary", &ResultBody::is_binary),
+    make_column ("content_type", &ResultBody::content_type)),
 
     // ─────────────── CONFIGURATION TABLES ───────────────
 
@@ -881,6 +908,13 @@ int64_t Database::count_runs (const RunFilter& filter) {
 // was added to both by editing only this function). Caller holds the mutex.
 void Database::remove_run_cascade_locked (const std::string& id) {
     impl_->storage.remove_all<MetricTick> (where (c (&MetricTick::run_id) == id));
+    // Captured bodies before the results they hang off, so a delete interrupted
+    // between the two leaves results without bodies rather than body rows
+    // pointing at nothing. `maxRunsRetained` doubles as the expiry for anything
+    // credential-shaped a capture picked up, which is what makes this cascade
+    // load-bearing rather than housekeeping.
+    impl_->storage.remove_all<ResultBody> (where (c (&ResultBody::run_id) == id));
+    impl_->storage.remove_all<BodyBlob> (where (c (&BodyBlob::run_id) == id));
     impl_->storage.remove_all<Result> (where (c (&Result::run_id) == id));
     impl_->storage.remove<Run> (id);
 }
@@ -1055,14 +1089,56 @@ void Database::add_result (const Result& result) {
 
 // Batch insert with transaction for better performance
 // Includes retry logic to handle database lock contention
-void Database::add_results_batch (const std::vector<Result>& results) {
+void Database::add_results_batch (const std::vector<Result>& results,
+const std::vector<PendingResultBody>& bodies) {
     if (results.empty ())
         return;
 
     retry_on_busy ("flush results batch", 5, std::chrono::milliseconds (100), [&] {
         impl_->storage.transaction ([&] {
+            // Row ids only exist after the insert, so keep them alongside the
+            // batch positions the pending bodies refer to.
+            std::vector<int> result_ids;
+            result_ids.reserve (results.size ());
             for (const auto& result : results) {
-                impl_->storage.insert (result);
+                result_ids.push_back (
+                static_cast<int> (impl_->storage.insert (result)));
+            }
+
+            // Dedup within the run: identical bodies (the norm for a load test)
+            // share one blob row. The map is rebuilt per attempt on purpose -
+            // a retried transaction re-inserts the blobs it rolled back.
+            std::map<std::string, int> blob_ids;
+            for (const auto& pending : bodies) {
+                if (pending.result_index >= result_ids.size ()) {
+                    continue; // Defensive: an index with no result cannot be attached.
+                }
+
+                int blob_id = 0;
+                if (!pending.body_hash.empty ()) {
+                    auto it = blob_ids.find (pending.body_hash);
+                    if (it != blob_ids.end ()) {
+                        blob_id = it->second;
+                    } else {
+                        BodyBlob blob;
+                        blob.run_id  = results[pending.result_index].run_id;
+                        blob.hash    = pending.body_hash;
+                        blob.content = pending.body;
+                        blob_id = static_cast<int> (impl_->storage.insert (blob));
+                        blob_ids.emplace (pending.body_hash, blob_id);
+                    }
+                }
+
+                ResultBody row;
+                row.result_id    = result_ids[pending.result_index];
+                row.run_id       = results[pending.result_index].run_id;
+                row.headers      = pending.headers;
+                row.blob_id      = blob_id;
+                row.body_bytes   = pending.body_bytes;
+                row.truncated    = pending.truncated;
+                row.is_binary    = pending.binary;
+                row.content_type = pending.content_type;
+                impl_->storage.replace (row);
             }
             return true; // Commit
         });
@@ -1072,6 +1148,31 @@ void Database::add_results_batch (const std::vector<Result>& results) {
 std::vector<Result> Database::get_results (const std::string& run_id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     return impl_->storage.get_all<Result> (where (c (&Result::run_id) == run_id));
+}
+
+// ============================================================================
+// Captured response bodies - read only by GET /runs/:id/samples
+// ============================================================================
+
+std::vector<ResultBody>
+Database::get_result_bodies_paginated (const std::string& run_id, int64_t limit, int64_t offset) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.get_all<ResultBody> (where (c (&ResultBody::run_id) == run_id),
+    order_by (&ResultBody::result_id), sqlite_orm::limit (offset, limit));
+}
+
+int64_t Database::count_result_bodies (const std::string& run_id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.count<ResultBody> (where (c (&ResultBody::run_id) == run_id));
+}
+
+std::string Database::get_body_blob_content (int blob_id) {
+    if (blob_id == 0) {
+        return {}; // No stored body: binary, absent, or dropped for budget.
+    }
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    auto blob = impl_->storage.get_pointer<BodyBlob> (blob_id);
+    return blob ? blob->content : std::string{};
 }
 
 // ============================================================================
@@ -1579,6 +1680,33 @@ void Database::seed_default_config () {
     "observability", std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES),
     "1024",       // 1KB
     "104857600",  // 100MB
+    std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "maxSampleBodyBytes",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES),
+    "integer", "Maximum Captured Sample Body",
+    "Largest response body kept for a single captured load-run sample. "
+    "Deliberately far smaller than the design-run trace limit, because a load "
+    "run captures tens of exchanges nobody asked for individually. Bodies over "
+    "this size are stored truncated and marked as such. Default 32KB.",
+    "observability",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES),
+    "0",         // 0 disables body capture while keeping headers and metadata
+    "104857600", // 100MB
+    std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "maxSampleBytes",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES),
+    "integer", "Load-Run Capture Budget",
+    "Total captured response-body bytes one load run may store. Once spent, "
+    "samples keep their headers and metadata and only their bodies are "
+    "dropped, and the report reports how many. Captured data is stored "
+    "verbatim and can contain credentials; it is deleted with the run. "
+    "Default 2MB.",
+    "observability",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES),
+    "0",          // 0 disables body capture while keeping headers and metadata
+    "1073741824", // 1GB
     std::nullopt, now });
 
     upsert_config (ConfigEntry{ "maxResponseBodyBytes",

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1171,8 +1171,11 @@ std::string Database::get_body_blob_content (int blob_id) {
         return {}; // No stored body: binary, absent, or dropped for budget.
     }
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    auto blob = impl_->storage.get_pointer<BodyBlob> (blob_id);
-    return blob ? blob->content : std::string{};
+    // get_all + where rather than a by-primary-key lookup, matching every other
+    // single-row read in this file (get_run, get_request, ...) - one idiom, and
+    // a missing row is an empty vector rather than a throw or a null to handle.
+    auto blobs = impl_->storage.get_all<BodyBlob> (where (c (&BodyBlob::id) == blob_id));
+    return blobs.empty () ? std::string{} : blobs.front ().content;
 }
 
 // ============================================================================

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -528,6 +528,14 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         { "slow_threshold_ms", 0, limits::MAX_SLOW_THRESHOLD_MS,
         "0 disables outlier capture; a negative threshold would mark every "
         "completion an outlier." },
+        { "max_sample_body_bytes", 0, limits::MAX_SAMPLE_BODY_BYTES,
+        "A captured body is copied on the completion callback, so the cap "
+        "bounds hot-path work; 0 keeps headers and metadata and no body." },
+        { "max_sample_bytes", 0, limits::MAX_SAMPLE_BYTES,
+        "It is the whole-run capture budget, and every byte under it is held "
+        "in memory until the run flushes." },
+        { "max_exemplar_results", 0, limits::MAX_EXEMPLAR_RESULTS,
+        "Each retained exemplar holds a captured exchange." },
         { "concurrency", 1, limits::MAX_CONCURRENCY,
         "Connections are pre-allocated per worker before any traffic flows." },
         { "timeout", 1, 86400000,

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <map>
 #include <thread>
 #include <utility>
 
@@ -110,6 +111,12 @@ struct ReportExtras {
     size_t success_traces_dropped   = 0;
     size_t slow_traces_dropped      = 0;
     size_t response_samples_dropped = 0;
+    size_t exemplars_dropped        = 0;
+    size_t sample_bodies_dropped    = 0;
+    // Non-zero means this run stored response headers and bodies verbatim.
+    // Capture does not redact, by decision, so the Samples tab reads this to
+    // warn rather than leaving the reader to infer it.
+    size_t response_bodies_captured = 0;
     // How many of this run's transfers asked for HTTP/2 and negotiated
     // something older. Not a performance number - it is what tells the reader
     // whether the protocol the report is labelled with is the one the numbers
@@ -208,6 +215,9 @@ ReportExtras& extras) {
         read_number (sampling, "success_traces_dropped", extras.success_traces_dropped);
         read_number (sampling, "slow_traces_dropped", extras.slow_traces_dropped);
         read_number (sampling, "response_samples_dropped", extras.response_samples_dropped);
+        read_number (sampling, "exemplars_dropped", extras.exemplars_dropped);
+        read_number (sampling, "sample_bodies_dropped", extras.sample_bodies_dropped);
+        read_number (sampling, "response_bodies_captured", extras.response_bodies_captured);
     }
 
     if (summary.contains ("tests") && summary["tests"].is_object ()) {
@@ -271,6 +281,92 @@ const vayu::db::RunFilter& filter, int64_t limit, int64_t offset) {
     response["pagination"]["hasMore"]  = (offset + static_cast<int64_t> (runs.size ())) < total;
     response["pagination"]["returned"] = runs.size ();
     return { 200, response };
+}
+
+/**
+ * Testable core of GET /runs/:id/samples, returning {http_status, json_body}.
+ * A missing run is a 404 in the shared error shape; a run that captured
+ * nothing is an empty page, not an error.
+ *
+ * Deliberately **not** an extension of the report's `results[]` array. That
+ * path loads every result row for a run and JSON-parses each `trace_data` to
+ * accumulate aggregates that never look at a body, and the dashboard polls it;
+ * bodies travelling on it would turn a ~200-byte-per-row read into a megabytes
+ * one on every poll. So the exchanges live in their own tables and are fetched
+ * here, per page, only when a reader actually expands a sample.
+ *
+ * `limit`/`offset` arrive already parsed and clamped by the caller. The
+ * envelope is the `{data, pagination}` shape GET /runs and GET /runs/:id/metrics
+ * already use.
+ */
+std::pair<int, nlohmann::json>
+run_samples_response (vayu::db::Database& db, const std::string& run_id, int64_t limit, int64_t offset) {
+    auto run = db.get_run (run_id);
+    if (!run) {
+        return { 404, error_body (404, "Run not found") };
+    }
+
+    const int64_t total = db.count_result_bodies (run_id);
+    auto rows           = db.get_result_bodies_paginated (run_id, limit, offset);
+
+    // Bodies are deduplicated in storage, so a page of 50 samples of the same
+    // response points at one blob. Read it once rather than 50 times.
+    std::map<int, std::string> blob_cache;
+
+    nlohmann::json data = nlohmann::json::array ();
+    for (const auto& row : rows) {
+        nlohmann::json sample;
+        // The `results.id` this exchange belongs to. Clients join it against
+        // the report's `results[].id` rather than re-deriving an order.
+        sample["resultId"] = row.result_id;
+
+        nlohmann::json response = nlohmann::json::object ();
+        try {
+            response["headers"] = nlohmann::json::parse (row.headers);
+        } catch (...) {
+            response["headers"] = nlohmann::json::object ();
+        }
+        response["bodyBytes"] = row.body_bytes;
+        if (!row.content_type.empty ()) {
+            response["contentType"] = row.content_type;
+        }
+
+        if (row.is_binary) {
+            // A binary body is reported as its shape, never as text: the
+            // alternative is a mojibake that reads like a real response.
+            response["binary"] = true;
+        } else {
+            auto cached = blob_cache.find (row.blob_id);
+            if (cached == blob_cache.end ()) {
+                cached =
+                blob_cache.emplace (row.blob_id, db.get_body_blob_content (row.blob_id)).first;
+            }
+            response["body"] = cached->second;
+            if (row.truncated) {
+                // Same convention design-mode traces use (cap_trace_bodies), so
+                // a reader has one rule for "this is a slice".
+                response["bodyTruncated"] = true;
+            }
+            // No blob and not binary means the run's capture budget was spent
+            // before this sample: headers were kept, the body was not. Said
+            // explicitly so the UI does not render "empty response body".
+            if (row.blob_id == 0 && row.body_bytes > 0) {
+                response["bodyDropped"] = true;
+            }
+        }
+
+        sample["response"] = std::move (response);
+        data.push_back (std::move (sample));
+    }
+
+    nlohmann::json body;
+    body["data"]                   = std::move (data);
+    body["pagination"]["total"]    = total;
+    body["pagination"]["limit"]    = limit;
+    body["pagination"]["offset"]   = offset;
+    body["pagination"]["hasMore"]  = (offset + static_cast<int64_t> (rows.size ())) < total;
+    body["pagination"]["returned"] = rows.size ();
+    return { 200, body };
 }
 
 /**
@@ -550,7 +646,10 @@ const std::string& run_id) {
         json_report["sampling"] = { { "errorsDropped", extras.errors_dropped },
             { "successTracesDropped", extras.success_traces_dropped },
             { "slowTracesDropped", extras.slow_traces_dropped },
-            { "responseSamplesDropped", extras.response_samples_dropped } };
+            { "responseSamplesDropped", extras.response_samples_dropped },
+            { "exemplarsDropped", extras.exemplars_dropped },
+            { "sampleBodiesDropped", extras.sample_bodies_dropped },
+            { "responseBodiesCaptured", extras.response_bodies_captured } };
     }
 
     if (extras.has_tests) {
@@ -572,6 +671,10 @@ const std::string& run_id) {
         if (count >= max_results)
             break;
         nlohmann::json result_obj;
+        // The row id, and the only way a client can ask GET /runs/:id/samples
+        // for this sample's captured exchange - the bodies deliberately do not
+        // travel on this payload (see run_samples_response).
+        result_obj["id"]         = result.id;
         result_obj["timestamp"]  = result.timestamp;
         result_obj["statusCode"] = result.status_code;
         result_obj["statusText"] = result.status_text;
@@ -845,6 +948,60 @@ void register_run_routes (RouteContext& ctx) {
     };
     ctx.server.Get (R"(/runs/([^/]+)/report)", get_run_report);
     ctx.server.Get (R"(/run/([^/]+)/report)", deprecated_alias (get_run_report));
+
+    /**
+     * GET /runs/:runId/samples?limit=&offset=
+     * The response headers and body captured for this run's retained samples -
+     * every error, the slow outliers, and the first few of each status code.
+     *
+     * Its own endpoint rather than more fields on the report: the report loads
+     * and parses every result row for a run on each fetch, and the dashboard
+     * polls it. This is fetched only when a reader expands a sample.
+     *
+     * No deprecated `/run/...` alias - the endpoint is new, so there is no
+     * pre-consolidation spelling for it to keep working.
+     */
+    ctx.server.Get (R"(/runs/([^/]+)/samples)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        std::string run_id = req.matches[1];
+        vayu::utils::log_info ("GET /runs/:id/samples - Fetching captured samples for run: " + run_id);
+
+        int64_t limit = 50;
+        if (req.has_param ("limit")) {
+            try {
+                limit = std::stoll (req.get_param_value ("limit"));
+            } catch (...) {
+                limit = 50;
+            }
+            if (limit <= 0)
+                limit = 50;
+            limit = std::min<int64_t> (limit, 500); // Cap page size, as GET /runs does.
+        }
+        int64_t offset = 0;
+        if (req.has_param ("offset")) {
+            try {
+                offset = std::stoll (req.get_param_value ("offset"));
+            } catch (...) {
+                offset = 0;
+            }
+            if (offset < 0)
+                offset = 0;
+        }
+
+        try {
+            auto [status, body] = run_samples_response (ctx.db, run_id, limit, offset);
+            if (status == 404) {
+                vayu::utils::log_warning (
+                "GET /runs/:id/samples - Run not found: " + run_id);
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "GET /runs/:id/samples - Error for run " + run_id + ": " + e.what ());
+            send_error (res, 500, e.what ());
+        }
+    });
 }
 
 } // namespace vayu::http::routes

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -429,7 +429,8 @@ TEST_F (DatabaseTest, ImportedActiveEnvironmentAlsoDeactivatesTheStoredOne) {
 // creates sqlite_autoindex_* entries of its own.
 const std::vector<std::string> EXPECTED_INDEXES = { "idx_metric_ticks_run_id",
     "idx_results_run_id", "idx_requests_collection_id",
-    "idx_collections_parent_id", "idx_runs_start_time" };
+    "idx_collections_parent_id", "idx_runs_start_time",
+    "idx_result_bodies_run_id", "idx_body_blobs_run_id" };
 
 // Reads index names straight out of sqlite_master on a separate connection,
 // so the assertion does not rest on anything sqlite_orm reports about itself.

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -787,3 +787,80 @@ TEST_F (LoadStrategyTest, RunContextResolvesTheSamplingConfigOnce) {
     EXPECT_EQ (stock->slow_threshold_ms,
     vayu::core::constants::metrics_collector::DEFAULT_SLOW_THRESHOLD_MS);
 }
+
+// Issue #174: which completions get their response body captured is decided
+// here, in the completion path, not by whichever retention budget the record
+// lands in. The three buckets are errors, outliers and per-status exemplars; a
+// plain 1-in-N sample is deliberately body-less, because a uniform slice of a
+// long run is a thousand identical 200s.
+//
+// Mutation check: rank `Exemplar` above `Slow` again (the shape this replaced)
+// and the outlier below stops reaching the slow store at all.
+TEST_F (LoadStrategyTest, OutliersAndExemplarsCaptureBodiesButPlainSamplesDoNot) {
+    nlohmann::json config = {
+        { "mode", "constant_rps" },
+        { "slow_threshold_ms", 100 },
+        { "save_timing_breakdown", true },
+        { "success_sample_rate", 1 }, // every completion is sampled
+    };
+    auto context = std::make_shared<vayu::core::RunContext> ("test-capture", config);
+    vayu::db::Database db (TEST_DB_PATH);
+
+    const size_t quota = vayu::core::constants::metrics_collector::EXEMPLARS_PER_STATUS;
+
+    // Spend this status code's exemplar quota on fast completions, then send
+    // one more fast completion and one outlier.
+    for (size_t i = 0; i < quota; ++i) {
+        vayu::core::handle_result (context, db, completion (5.0));
+    }
+    vayu::core::handle_result (context, db, completion (5.0));   // past the quota
+    vayu::core::handle_result (context, db, completion (500.0)); // outlier
+
+    // The outlier is charged to the slow budget, exactly as it was before
+    // capture existed - being an early completion of its status code must not
+    // move it out of the store that exists to hold outliers.
+    const auto& slow = context->metrics_collector->slow_results ();
+    ASSERT_EQ (slow.size (), 1u)
+    << "the outlier was rerouted out of the slow store by the exemplar bucket";
+    ASSERT_TRUE (slow[0].capture.has_value ()) << "an outlier must carry its body";
+
+    // Every sampled fast completion is stored; the first `quota` of them
+    // claimed an exemplar and kept a body, the one past the quota did not.
+    const auto& sampled = context->metrics_collector->success_results ();
+    ASSERT_EQ (sampled.size (), quota + 1);
+    size_t with_body = 0;
+    for (const auto& record : sampled) {
+        if (record.capture.has_value ())
+            with_body++;
+    }
+    EXPECT_EQ (with_body, quota)
+    << "a plain 1-in-N sample must not carry a body, and an exemplar must";
+}
+
+// Capture off restores the completion path exactly: no exemplar is claimed, so
+// nothing is rerouted, and no record carries a body.
+TEST_F (LoadStrategyTest, CaptureOffLeavesTheCompletionPathUnchanged) {
+    nlohmann::json config = {
+        { "mode", "constant_rps" },
+        { "slow_threshold_ms", 100 },
+        { "save_timing_breakdown", true },
+        { "success_sample_rate", 1 },
+        { "capture_response_bodies", false },
+    };
+    auto context = std::make_shared<vayu::core::RunContext> ("test-capture-off", config);
+    vayu::db::Database db (TEST_DB_PATH);
+
+    for (int i = 0; i < 5; ++i) {
+        vayu::core::handle_result (context, db, completion (5.0));
+    }
+    vayu::core::handle_result (context, db, completion (500.0));
+
+    EXPECT_TRUE (context->metrics_collector->exemplar_results ().empty ());
+    EXPECT_EQ (context->metrics_collector->success_results ().size (), 5u);
+    EXPECT_EQ (context->metrics_collector->slow_results ().size (), 1u);
+    for (const auto& record : context->metrics_collector->success_results ()) {
+        EXPECT_FALSE (record.capture.has_value ());
+    }
+    EXPECT_FALSE (context->metrics_collector->slow_results ()[0].capture.has_value ());
+    EXPECT_EQ (context->metrics_collector->captured_body_bytes (), 0u);
+}

--- a/engine/tests/response_capture_test.cpp
+++ b/engine/tests/response_capture_test.cpp
@@ -1,0 +1,474 @@
+/**
+ * @file tests/response_capture_test.cpp
+ * @brief Tests for load-run response capture - policy, budgets, storage and
+ *        the GET /runs/:id/samples endpoint that reads it back.
+ *
+ * The feature exists because two UI surfaces were written to display a load
+ * run's response headers and body, and no writer ever produced them. So the
+ * bar here is not "a body reaches the database" but the four things that make
+ * capture affordable and honest:
+ *
+ * - the captured set is failures + outliers + per-status exemplars, never a
+ *   uniform slice (a uniform slice of 30M requests is a thousand identical
+ *   200s);
+ * - the bodies live outside `results.trace_data`, so the report path - which
+ *   loads and parses every result row on every poll - reads none of them;
+ * - identical bodies are stored once, because load-test responses are
+ *   overwhelmingly identical;
+ * - a body that cannot be text is stored as a descriptor, never as a string
+ *   that reads like a real response but is not.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/core/metrics_collector.hpp"
+#include "vayu/db/database.hpp"
+
+namespace vayu::http::routes {
+// Defined in runs.cpp; returns {http_status, json_body}.
+std::pair<int, nlohmann::json>
+run_samples_response (vayu::db::Database& db, const std::string& run_id, int64_t limit, int64_t offset);
+std::pair<int, nlohmann::json> run_report_response (vayu::db::Database& db,
+const std::string& run_id);
+} // namespace vayu::http::routes
+
+using namespace vayu::core;
+
+namespace {
+
+vayu::Response make_response (int status, std::string body, std::string content_type = "application/json") {
+    vayu::Response response;
+    response.status_code     = status;
+    response.body            = std::move (body);
+    response.timing.total_ms = 1.0;
+    if (!content_type.empty ()) {
+        response.headers["Content-Type"] = std::move (content_type);
+    }
+    response.headers["X-Trace"] = "abc";
+    return response;
+}
+
+/// A collector configured the way a run with capture on is, with the sampling
+/// knobs pinned so a test decides what is retained rather than a 1-in-100 die.
+MetricsCollectorConfig capture_config () {
+    MetricsCollectorConfig config;
+    config.expected_requests      = 1000;
+    config.capture_response_bodies = true;
+    config.store_success_traces   = false;
+    config.success_sample_rate    = 1;
+    return config;
+}
+
+class ResponseCaptureTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_response_capture.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + suffix);
+        }
+    }
+
+    void seed_run (const std::string& id) {
+        vayu::db::Run run;
+        run.id              = id;
+        run.type            = vayu::RunType::Load;
+        run.status          = vayu::RunStatus::Completed;
+        run.request_id      = std::nullopt;
+        run.environment_id  = std::nullopt;
+        run.config_snapshot = R"({"url":"https://x.test/","method":"GET"})";
+        run.start_time      = 100;
+        run.end_time        = 200;
+        db_->create_run (run);
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+// Capture policy: which completions get a body at all
+// ---------------------------------------------------------------------------
+
+// Every error is a candidate, within the bound `maxStoredErrors` already sets.
+// A failure is precisely the sample someone opens the Samples tab for.
+TEST_F (ResponseCaptureTest, EveryStoredErrorCarriesItsExchange) {
+    MetricsCollectorConfig config = capture_config ();
+    config.max_errors             = 5;
+    MetricsCollector collector ("run_errors", config);
+
+    for (int i = 0; i < 20; ++i) {
+        auto response = make_response (0, R"({"err":true})");
+        collector.record_error (vayu::ErrorCode::Timeout, "timed out", "{}", &response);
+    }
+
+    ASSERT_EQ (collector.errors ().size (), 5u);
+    for (const auto& record : collector.errors ()) {
+        ASSERT_TRUE (record.capture.has_value ());
+        EXPECT_EQ (record.capture->body, R"({"err":true})");
+    }
+    // Past the cap the record is dropped, so no body was copied for it either.
+    EXPECT_EQ (collector.errors_dropped (), 15u);
+}
+
+// The exemplar bucket: the first K of each distinct status code and no more.
+// Mutation check - drop the `claimed < EXEMPLARS_PER_STATUS` bound in
+// claim_status_exemplar and every completion becomes an exemplar, failing the
+// per-status count below.
+TEST_F (ResponseCaptureTest, ExemplarsAreBoundedPerStatusCode) {
+    MetricsCollector collector ("run_exemplars", capture_config ());
+
+    for (int status : { 200, 404, 503 }) {
+        for (int i = 0; i < 50; ++i) {
+            EXPECT_EQ (collector.claim_status_exemplar (status),
+            i < static_cast<int> (constants::metrics_collector::EXEMPLARS_PER_STATUS));
+        }
+    }
+}
+
+TEST_F (ResponseCaptureTest, ExemplarStoreKeepsOnePerStatusUpToTheLimit) {
+    MetricsCollector collector ("run_exemplar_store", capture_config ());
+
+    for (int status : { 200, 500 }) {
+        for (int i = 0; i < 10; ++i) {
+            auto response      = make_response (status, "body-" + std::to_string (status));
+            const bool exemplar = collector.claim_status_exemplar (status);
+            collector.record_success (status, 1.0, 0.0, exemplar ? "{}" : "",
+            exemplar ? SuccessTraceReason::Exemplar : SuccessTraceReason::None,
+            &response);
+        }
+    }
+
+    ASSERT_EQ (collector.exemplar_results ().size (),
+    2 * constants::metrics_collector::EXEMPLARS_PER_STATUS);
+    std::set<int> statuses;
+    for (const auto& record : collector.exemplar_results ()) {
+        ASSERT_TRUE (record.capture.has_value ());
+        statuses.insert (record.status_code);
+    }
+    EXPECT_EQ (statuses, (std::set<int>{ 200, 500 }));
+}
+
+// A uniformly sampled success is deliberately body-less: that budget is a
+// slice of ordinary traffic, and a thousand identical 200s are not worth a
+// thousand bodies. Slow outliers, on the same store family, are.
+TEST_F (ResponseCaptureTest, SampledSuccessesCarryNoBodyButSlowOnesDo) {
+    MetricsCollectorConfig config = capture_config ();
+    config.store_success_traces   = true;
+    MetricsCollector collector ("run_sampled", config);
+
+    auto response = make_response (200, "hello");
+    collector.record_success (200, 1.0, 0.0, "{}", SuccessTraceReason::Sampled, &response);
+    collector.record_success (200, 9000.0, 0.0, "{}", SuccessTraceReason::Slow, &response);
+
+    ASSERT_EQ (collector.success_results ().size (), 1u);
+    EXPECT_FALSE (collector.success_results ()[0].capture.has_value ());
+    ASSERT_EQ (collector.slow_results ().size (), 1u);
+    ASSERT_TRUE (collector.slow_results ()[0].capture.has_value ());
+    EXPECT_EQ (collector.slow_results ()[0].capture->body, "hello");
+}
+
+// A refused reservoir slot must not have cost a body-sized copy. Observable
+// through the run budget: only the retained records may have spent it.
+TEST_F (ResponseCaptureTest, RefusedSlotsSpendNoBudget) {
+    MetricsCollectorConfig config = capture_config ();
+    config.max_slow_results       = 2;
+    MetricsCollector collector ("run_refused", config);
+
+    const std::string body (1000, 'x');
+    for (int i = 0; i < 500; ++i) {
+        auto response = make_response (200, body);
+        collector.record_success (200, 9000.0, 0.0, "{}", SuccessTraceReason::Slow, &response);
+    }
+
+    ASSERT_EQ (collector.slow_results ().size (), 2u);
+    // Every accepted candidate charges 1000 bytes. A reservoir accepts more
+    // than it finally holds (it displaces), so the bound is generous - but it
+    // must be far below the 500,000 bytes "copy everything" would spend.
+    EXPECT_LT (collector.captured_body_bytes (), 100u * 1000u)
+    << "bodies were copied for candidates the reservoir refused";
+}
+
+// ---------------------------------------------------------------------------
+// Budgets
+// ---------------------------------------------------------------------------
+
+TEST_F (ResponseCaptureTest, BodyOverThePerBodyCapIsTruncatedAndSaysSo) {
+    MetricsCollectorConfig config  = capture_config ();
+    config.max_sample_body_bytes   = 16;
+    MetricsCollector collector ("run_truncate", config);
+
+    auto response = make_response (500, std::string (100, 'y'));
+    collector.record_error (vayu::ErrorCode::ConnectionFailed, "server error", "{}", &response);
+
+    ASSERT_EQ (collector.errors ().size (), 1u);
+    const auto& captured = collector.errors ()[0].capture;
+    ASSERT_TRUE (captured.has_value ());
+    EXPECT_EQ (captured->body.size (), 16u);
+    EXPECT_TRUE (captured->truncated);
+    EXPECT_EQ (captured->body_bytes, 100);
+}
+
+// Once the run budget is spent, metadata keeps being captured and only the
+// bodies stop - and the count says so, so the UI can report an incomplete set
+// rather than presenting a biased one as the whole story.
+TEST_F (ResponseCaptureTest, SpentBudgetKeepsMetadataAndCountsDroppedBodies) {
+    MetricsCollectorConfig config = capture_config ();
+    config.max_sample_bytes       = 250;
+    config.max_errors             = 0; // unlimited, so the store is not the limit
+    MetricsCollector collector ("run_budget", config);
+
+    for (int i = 0; i < 10; ++i) {
+        auto response = make_response (500, std::string (100, 'z'));
+        collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    }
+
+    ASSERT_EQ (collector.errors ().size (), 10u);
+    size_t with_body = 0;
+    for (const auto& record : collector.errors ()) {
+        ASSERT_TRUE (record.capture.has_value ()) << "metadata must survive a spent budget";
+        EXPECT_EQ (record.capture->headers.size (), 2u);
+        EXPECT_EQ (record.capture->body_bytes, 100);
+        if (!record.capture->body.empty ()) {
+            with_body++;
+        } else {
+            EXPECT_TRUE (record.capture->body_dropped);
+        }
+    }
+    EXPECT_EQ (with_body, 2u); // 250 / 100, floored
+    EXPECT_EQ (collector.sample_bodies_dropped (), 8u);
+}
+
+// ---------------------------------------------------------------------------
+// Storage: dedup, binary bodies, and isolation from the report path
+// ---------------------------------------------------------------------------
+
+TEST_F (ResponseCaptureTest, IdenticalBodiesAreStoredOnce) {
+    seed_run ("run_dedup");
+    MetricsCollectorConfig config = capture_config ();
+    config.max_errors             = 0;
+    MetricsCollector collector ("run_dedup", config);
+
+    for (int i = 0; i < 20; ++i) {
+        auto response = make_response (500, R"({"error":"upstream"})");
+        collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    }
+    collector.flush_to_database (*db_);
+
+    auto rows = db_->get_result_bodies_paginated ("run_dedup", 100, 0);
+    ASSERT_EQ (rows.size (), 20u);
+    std::set<int> blob_ids;
+    for (const auto& row : rows) {
+        blob_ids.insert (row.blob_id);
+    }
+    EXPECT_EQ (blob_ids.size (), 1u)
+    << "20 identical responses should share one stored body, not store 20 copies";
+
+    // And the shared blob still reads back as the body every row claims.
+    for (const auto& row : rows) {
+        EXPECT_EQ (db_->get_body_blob_content (row.blob_id), R"({"error":"upstream"})");
+    }
+}
+
+TEST_F (ResponseCaptureTest, BinaryBodyIsStoredAsADescriptor) {
+    seed_run ("run_binary");
+    MetricsCollector collector ("run_binary", capture_config ());
+
+    // Raw deflate bytes under an origin's own text/html - the realistic case,
+    // since the engine never sets CURLOPT_ACCEPT_ENCODING.
+    auto response = make_response (200, std::string ("\x1f\x8b\x08\x00\xff\xfe\x00\x01", 8), "text/html");
+    collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    collector.flush_to_database (*db_);
+
+    auto rows = db_->get_result_bodies_paginated ("run_binary", 100, 0);
+    ASSERT_EQ (rows.size (), 1u);
+    EXPECT_TRUE (rows[0].is_binary);
+    EXPECT_EQ (rows[0].blob_id, 0) << "a binary body must not be stored as text";
+    EXPECT_EQ (rows[0].body_bytes, 8);
+
+    auto [status, body] = vayu::http::routes::run_samples_response (*db_, "run_binary", 50, 0);
+    ASSERT_EQ (status, 200);
+    const auto& sample = body["data"][0]["response"];
+    EXPECT_TRUE (sample["binary"].get<bool> ());
+    EXPECT_FALSE (sample.contains ("body"));
+    EXPECT_EQ (sample["bodyBytes"].get<int64_t> (), 8);
+}
+
+// The point of the separate table: the report loads every result row for a run
+// and JSON-parses each trace_data on every fetch. Capture must not make that
+// read one byte larger. Asserted on the stored rows, not on the rendered
+// output - a report that merely omits a body it still read would pass an
+// output-only check.
+TEST_F (ResponseCaptureTest, CaptureAddsNothingToTheReportPathsRows) {
+    auto flush_trace_bytes = [this] (const std::string& run_id, bool capture) {
+        seed_run (run_id);
+        MetricsCollectorConfig config   = capture_config ();
+        config.capture_response_bodies = capture;
+        MetricsCollector collector (run_id, config);
+        for (int i = 0; i < 5; ++i) {
+            auto response = make_response (500, std::string (4096, 'q'));
+            collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", R"({"totalMs":1})",
+            capture ? &response : nullptr);
+        }
+        collector.flush_to_database (*db_);
+
+        size_t bytes = 0;
+        for (const auto& row : db_->get_results (run_id)) {
+            bytes += row.trace_data.size () + row.error.size ();
+        }
+        return bytes;
+    };
+
+    const size_t without = flush_trace_bytes ("run_off", false);
+    const size_t with    = flush_trace_bytes ("run_on", true);
+    EXPECT_EQ (with, without)
+    << "captured bodies leaked into the rows the report path reads";
+
+    // ...while the bodies really were captured on the second run.
+    EXPECT_EQ (db_->count_result_bodies ("run_on"), 5);
+    EXPECT_EQ (db_->count_result_bodies ("run_off"), 0);
+}
+
+// Capture off must leave the collector exactly as it was before the feature:
+// no exemplar is claimed, no body is copied, no row is written.
+TEST_F (ResponseCaptureTest, CaptureDisabledStoresNothingExtra) {
+    seed_run ("run_disabled");
+    MetricsCollectorConfig config  = capture_config ();
+    config.capture_response_bodies = false;
+    MetricsCollector collector ("run_disabled", config);
+
+    EXPECT_FALSE (collector.claim_status_exemplar (200));
+    auto response = make_response (200, "hello");
+    collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", nullptr);
+    collector.flush_to_database (*db_);
+
+    EXPECT_EQ (collector.captured_body_bytes (), 0u);
+    EXPECT_EQ (collector.response_bodies_captured (), 0u);
+    EXPECT_EQ (db_->count_result_bodies ("run_disabled"), 0);
+    EXPECT_EQ (db_->get_results ("run_disabled").size (), 1u);
+}
+
+TEST_F (ResponseCaptureTest, DeletingARunDeletesItsCapturedBodies) {
+    seed_run ("run_delete");
+    MetricsCollector collector ("run_delete", capture_config ());
+    auto response = make_response (500, "secret-token-in-here");
+    collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    collector.flush_to_database (*db_);
+    ASSERT_EQ (db_->count_result_bodies ("run_delete"), 1);
+
+    db_->delete_run ("run_delete");
+    EXPECT_EQ (db_->count_result_bodies ("run_delete"), 0)
+    << "captured data outlived the run it belongs to; maxRunsRetained is its expiry";
+}
+
+// ---------------------------------------------------------------------------
+// GET /runs/:id/samples
+// ---------------------------------------------------------------------------
+
+TEST_F (ResponseCaptureTest, SamplesEndpointReturnsTheCapturedExchange) {
+    seed_run ("run_endpoint");
+    MetricsCollector collector ("run_endpoint", capture_config ());
+    auto response = make_response (500, R"({"error":"nope"})");
+    collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    collector.flush_to_database (*db_);
+
+    auto [status, body] =
+    vayu::http::routes::run_samples_response (*db_, "run_endpoint", 50, 0);
+    ASSERT_EQ (status, 200);
+    ASSERT_EQ (body["data"].size (), 1u);
+
+    const auto& sample = body["data"][0];
+    EXPECT_GT (sample["resultId"].get<int> (), 0);
+    EXPECT_EQ (sample["response"]["body"].get<std::string> (), R"({"error":"nope"})");
+    EXPECT_EQ (sample["response"]["headers"]["Content-Type"].get<std::string> (),
+    "application/json");
+    EXPECT_EQ (sample["response"]["contentType"].get<std::string> (), "application/json");
+    EXPECT_FALSE (sample["response"].contains ("bodyTruncated"));
+
+    EXPECT_EQ (body["pagination"]["total"].get<int64_t> (), 1);
+    EXPECT_FALSE (body["pagination"]["hasMore"].get<bool> ());
+}
+
+// The result id is the join key between the report's `results[]` and this
+// endpoint. Without it a client would have to re-derive an order, which is
+// exactly the kind of implicit contract that drifts.
+TEST_F (ResponseCaptureTest, ReportResultIdsMatchTheSamplesEndpoint) {
+    seed_run ("run_join");
+    MetricsCollector collector ("run_join", capture_config ());
+    for (int i = 0; i < 3; ++i) {
+        auto response = make_response (500, "body-" + std::to_string (i));
+        collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    }
+    collector.flush_to_database (*db_);
+
+    auto [report_status, report] = vayu::http::routes::run_report_response (*db_, "run_join");
+    ASSERT_EQ (report_status, 200);
+    std::set<int> report_ids;
+    for (const auto& result : report["results"]) {
+        report_ids.insert (result["id"].get<int> ());
+    }
+
+    auto [samples_status, samples] =
+    vayu::http::routes::run_samples_response (*db_, "run_join", 50, 0);
+    ASSERT_EQ (samples_status, 200);
+    ASSERT_EQ (samples["data"].size (), 3u);
+    for (const auto& sample : samples["data"]) {
+        EXPECT_EQ (report_ids.count (sample["resultId"].get<int> ()), 1u);
+    }
+}
+
+TEST_F (ResponseCaptureTest, SamplesEndpointPaginatesAndFourOhFours) {
+    seed_run ("run_pages");
+    MetricsCollectorConfig config = capture_config ();
+    config.max_errors             = 0;
+    MetricsCollector collector ("run_pages", config);
+    for (int i = 0; i < 5; ++i) {
+        auto response = make_response (500, "body-" + std::to_string (i));
+        collector.record_error (vayu::ErrorCode::ConnectionFailed, "boom", "{}", &response);
+    }
+    collector.flush_to_database (*db_);
+
+    auto [status, page] = vayu::http::routes::run_samples_response (*db_, "run_pages", 2, 0);
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (page["data"].size (), 2u);
+    EXPECT_EQ (page["pagination"]["total"].get<int64_t> (), 5);
+    EXPECT_TRUE (page["pagination"]["hasMore"].get<bool> ());
+
+    auto [last_status, last] = vayu::http::routes::run_samples_response (*db_, "run_pages", 2, 4);
+    ASSERT_EQ (last_status, 200);
+    EXPECT_EQ (last["data"].size (), 1u);
+    EXPECT_FALSE (last["pagination"]["hasMore"].get<bool> ());
+
+    auto [missing_status, missing] =
+    vayu::http::routes::run_samples_response (*db_, "no_such_run", 50, 0);
+    EXPECT_EQ (missing_status, 404);
+    EXPECT_EQ (missing["error"]["code"].get<int> (), 404);
+}
+
+// A run that captured nothing is an empty page, not an error - the Samples tab
+// asks before it knows whether there is anything to show.
+TEST_F (ResponseCaptureTest, RunWithNoCapturesIsAnEmptyPage) {
+    seed_run ("run_empty");
+    auto [status, body] = vayu::http::routes::run_samples_response (*db_, "run_empty", 50, 0);
+    EXPECT_EQ (status, 200);
+    EXPECT_TRUE (body["data"].empty ());
+    EXPECT_EQ (body["pagination"]["total"].get<int64_t> (), 0);
+}
+
+} // namespace

--- a/engine/tests/response_capture_test.cpp
+++ b/engine/tests/response_capture_test.cpp
@@ -165,23 +165,28 @@ TEST_F (ResponseCaptureTest, ExemplarStoreKeepsOnePerStatusUpToTheLimit) {
     EXPECT_EQ (statuses, (std::set<int>{ 200, 500 }));
 }
 
-// A uniformly sampled success is deliberately body-less: that budget is a
-// slice of ordinary traffic, and a thousand identical 200s are not worth a
-// thousand bodies. Slow outliers, on the same store family, are.
-TEST_F (ResponseCaptureTest, SampledSuccessesCarryNoBodyButSlowOnesDo) {
+// The collector captures exactly when the caller hands it a source, whatever
+// budget the record is charged to. Deciding it from `trace_reason` instead
+// would tie "which store pays" to "does this deserve a body", and a record can
+// sit in the sampled budget and still deserve one (a completion that is both
+// sampled and a claimed exemplar). The *policy* - which completions get a
+// source at all - is `handle_result`'s, and load_strategy_test.cpp pins it.
+TEST_F (ResponseCaptureTest, CaptureFollowsTheCallerNotTheStore) {
     MetricsCollectorConfig config = capture_config ();
     config.store_success_traces   = true;
     MetricsCollector collector ("run_sampled", config);
 
     auto response = make_response (200, "hello");
+    // Sampled with a source: stored in the sampled budget, body kept.
     collector.record_success (200, 1.0, 0.0, "{}", SuccessTraceReason::Sampled, &response);
-    collector.record_success (200, 9000.0, 0.0, "{}", SuccessTraceReason::Slow, &response);
+    // Slow without one: stored in the slow budget, no body.
+    collector.record_success (200, 9000.0, 0.0, "{}", SuccessTraceReason::Slow, nullptr);
 
     ASSERT_EQ (collector.success_results ().size (), 1u);
-    EXPECT_FALSE (collector.success_results ()[0].capture.has_value ());
+    ASSERT_TRUE (collector.success_results ()[0].capture.has_value ());
+    EXPECT_EQ (collector.success_results ()[0].capture->body, "hello");
     ASSERT_EQ (collector.slow_results ().size (), 1u);
-    ASSERT_TRUE (collector.slow_results ()[0].capture.has_value ());
-    EXPECT_EQ (collector.slow_results ()[0].capture->body, "hello");
+    EXPECT_FALSE (collector.slow_results ()[0].capture.has_value ());
 }
 
 // A refused reservoir slot must not have cost a body-sized copy. Observable

--- a/engine/tests/sample_capture_test.cpp
+++ b/engine/tests/sample_capture_test.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file tests/sample_capture_test.cpp
+ * @brief Tests for the pure decisions behind load-run response capture.
+ *
+ * Focus: a body that cannot be stored as text must be recognised as such
+ * (`looks_binary`), and identical stored bytes must produce identical dedup
+ * keys while different bytes must not (`body_digest`). Both run at flush time,
+ * so they are unit-testable without a run.
+ *
+ * The binary rule is the one that protects a user from silently corrupted
+ * data: `error_handler_t::replace` keeps `dump()` from throwing on a gzip
+ * stream and hands back a mojibake that reads exactly like a real response.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "vayu/core/sample_capture.hpp"
+
+using vayu::core::body_digest;
+using vayu::core::looks_binary;
+using vayu::core::media_type;
+
+namespace {
+
+TEST (MediaType, StripsParametersAndLowercases) {
+    EXPECT_EQ (media_type ("application/JSON; charset=utf-8"), "application/json");
+    EXPECT_EQ (media_type ("  text/html  "), "text/html");
+    EXPECT_EQ (media_type ("image/png"), "image/png");
+    EXPECT_EQ (media_type (""), "");
+}
+
+TEST (LooksBinary, TextContentTypesAreText) {
+    EXPECT_FALSE (looks_binary ("hello", "text/plain"));
+    EXPECT_FALSE (looks_binary (R"({"ok":true})", "application/json"));
+    EXPECT_FALSE (looks_binary ("<a/>", "application/atom+xml"));
+    EXPECT_FALSE (looks_binary ("a=1&b=2", "application/x-www-form-urlencoded"));
+    EXPECT_FALSE (looks_binary ("x", "application/javascript"));
+}
+
+TEST (LooksBinary, NonTextContentTypeIsBinaryWithoutReadingBytes) {
+    // The bytes here are perfectly good ASCII; the declared type is what
+    // decides, which is what keeps classifying an image cheap.
+    EXPECT_TRUE (looks_binary ("PNGDATA", "image/png"));
+    EXPECT_TRUE (looks_binary ("x", "application/octet-stream"));
+    EXPECT_TRUE (looks_binary ("x", "application/x-protobuf"));
+}
+
+TEST (LooksBinary, InvalidUtf8IsBinaryEvenWhenLabelledText) {
+    // The realistic case: `Accept-Encoding: gzip` with no
+    // CURLOPT_ACCEPT_ENCODING, so the compressed bytes arrive under the
+    // origin's own `text/html`.
+    const std::string gzip = std::string ("\x1f\x8b\x08\x00\x00\x00\x00\x00", 8) + "\xff\xfe";
+    EXPECT_TRUE (looks_binary (gzip, "text/html"));
+
+    // A lone continuation byte is not valid UTF-8 at any position.
+    EXPECT_TRUE (looks_binary (std::string ("ok\x80there"), "text/plain"));
+}
+
+TEST (LooksBinary, EmbeddedNulIsBinary) {
+    EXPECT_TRUE (looks_binary (std::string ("ab\0cd", 5), "text/plain"));
+    EXPECT_TRUE (looks_binary (std::string ("ab\0cd", 5), ""));
+}
+
+TEST (LooksBinary, ValidMultiByteUtf8IsText) {
+    EXPECT_FALSE (looks_binary ("héllo wörld — ok", "text/plain"));
+    EXPECT_FALSE (looks_binary ("\xE2\x9C\x93 done", ""));
+    EXPECT_FALSE (looks_binary ("\xF0\x9F\x8E\x89", "")); // U+1F389
+}
+
+TEST (LooksBinary, SequenceCutByTruncationIsStillText) {
+    // A capture truncated mid-character must not be called binary: the split
+    // is our own cap, not anything about the response. Build a body whose
+    // final byte is the start of a 3-byte sequence.
+    std::string body (vayu::core::SNIFF_BYTES - 1, 'a');
+    body.push_back ('\xE2');
+    EXPECT_FALSE (looks_binary (body, "text/plain"));
+}
+
+TEST (LooksBinary, EmptyBodyIsText) {
+    EXPECT_FALSE (looks_binary ("", "image/png"));
+}
+
+TEST (BodyDigest, IdenticalBytesShareAKeyAndDifferentBytesDoNot) {
+    const std::string body = R"({"status":"ok"})";
+    EXPECT_EQ (body_digest (body), body_digest (std::string (body)));
+    EXPECT_NE (body_digest (body), body_digest (R"({"status":"OK"})"));
+    // 64 lowercase hex characters - a SHA-256 digest, the shape the dedup key
+    // column stores.
+    EXPECT_EQ (body_digest (body).size (), 64u);
+    EXPECT_EQ (body_digest (body).find_first_not_of ("0123456789abcdef"), std::string::npos);
+}
+
+TEST (BodyDigest, EmptyBodyHashesToTheKnownSha256) {
+    EXPECT_EQ (body_digest (""),
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Load runs recorded a sampled request's status, latency and timing breakdown and discarded the response headers and body. Two UI surfaces were already written to display that data and were permanently blank as a result - `RequestResponseView.tsx` read flat `trace.headers` / `trace.body` (a shape no engine writer emits at that nesting) and `SampleRequestCard.tsx` read the design-mode nesting on a load-run-only surface. Both branches were dead, and `RequestResponseView.primitives.test.tsx` hand-authored a fixture in the flat shape, so CI exercised the dead branch for as long as it existed.

**Plan (root cause, approach, alternative rejected).** The root cause is not that capture was hard but that the obvious place to put it is the wrong one: `build_result_trace` stores the whole exchange into `results.trace_data`, and `Database::get_results` loads *every* row for a run with no limit while `calculate_detailed_report` JSON-parses each `trace_data` - on every report fetch, which the dashboard polls. At 1000 samples carrying 32 KiB bodies that becomes ~32 MB read from SQLite and parsed per poll, to compute aggregates that never look at a body. So bodies go in their own tables (`result_bodies`, `body_blobs`) behind a new `GET /runs/:runId/samples`, and the renderer fetches them only when a sample is expanded. **The alternative rejected** was extending the report's `results[]` array with the bodies - one endpoint instead of two, but it puts megabytes on the one response that must stay cheap, and it is the polled one. The issue's six settled design decisions were followed as written; the one place reality differed from the issue is noted below.

**Anchors re-verified.** All of the issue's anchors still hold at `ed8fe1a` (`record_response_sample` at `metrics_collector.cpp:235-270`, `handle_result`'s gate-then-build at `load_strategy.cpp:115-143`, the two dead app reads). One correction: the issue says `picosha2` is vendored - it is not. The engine already has `vayu::utils::sha256` (libsodium) and `vayu::utils::hex_encode`, which is what the dedup digest uses, per "a hand-rolled copy of a primitive does not receive the primitive's fixes".

### What is captured

Failures and outliers, never a uniform sample - a uniform slice of 30M requests is a thousand identical 200s:

| Bucket | Bound |
|---|---|
| Every error | `maxStoredErrors` (the error store's existing cap) |
| Slow outliers | `max_slow_results`, reusing #263's slow store |
| The first 3 of each distinct status code that no other budget already stored | `max_exemplar_results` (64) |

The exemplar bucket is deliberately **not** a reservoir, unlike its neighbours: an exemplar that gets displaced is not an exemplar, so past its bound a candidate is refused and counted rather than evicting an incumbent.

It is also the **last** budget consulted rather than the first, and that ordering is load-bearing - see the fix commit below. Claiming an exemplar decides whether a **body** is captured; it never moves a record out of the store that wanted it. A completion that is both sampled and an exemplar is stored in the sampling budget *and* keeps its body.

### Hot path

Per decision 5, the completion callback does two things only. Phase 1 is `claim_status_exemplar` - a single relaxed `fetch_add` on a fixed array. Phase 2 is a bounded copy, and it happens **inside** the collector after a store has accepted the record, so a reservoir refusal costs no body-sized copy (`RefusedSlotsSpendNoBudget` pins this). Binary detection, hashing, dedup and JSON all happen at flush, after load generation has stopped. `record_error` copies before taking `errors_mutex_`, so a body-sized copy never lengthens a critical section every failing completion queues on.

### Budgets, binary bodies, dedup

`maxSampleBodyBytes` (32 KiB) caps one body; `maxSampleBytes` (2 MiB) is the whole-run budget. Both are `observability` config keys and both are overridable per run. Once the run budget is spent, samples keep their headers and metadata and lose only their bodies, counted as `sampling.sampleBodiesDropped`.

A body that cannot be text - a gzip stream under the origin's own `text/html`, an image, protobuf - is stored as a descriptor rather than as a string: `error_handler_t::replace` would keep `dump()` from throwing and hand the reader a mojibake that reads like a real response.

Bodies are deduplicated by SHA-256 within a run, so 1000 samples of one 2 KiB body store 2 KiB. The digest is over the *stored* (already truncated) bytes - two bodies differing only past the cut are byte-identical as stored.

### Credentials

No redaction, deliberately and consistently with design-mode traces, which already store request headers as sent. The mitigation is the run's persisted marker (`sampling.responseBodiesCaptured`) plus the `CapturedDataWarning` both sample surfaces render, and the run cascade, which makes `maxRunsRetained` the expiry for anything credential-shaped a capture picked up.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

**Green on the full matrix** - engine and app on ubuntu, macOS and Windows.

| Check | Result |
|---|---|
| C++ tests (ubuntu / macOS / windows) | **804 run, 804 passed, 0 failed** |
| App (ubuntu / macOS / windows) | pass |
| `pnpm test` locally | 284 files, 2467 tests |
| `pnpm type-check` / `lint` / `format:check` | clean |
| `mkdocs build --strict` | clean |

**CI caught a real regression in the first push, and it is worth reading before reviewing the diff.** Commit `3d62668` fixes it.

I originally ranked `SuccessTraceReason::Exemplar` *above* `Slow` and `Sampled`, reasoning that the other two stores are reservoirs and could displace an exemplar. I did not weigh the cost: the first few completions of a status code are usually exactly where a run's outliers are, so the exemplar bucket quietly emptied the slow store - a run with `slow_threshold_ms` set and one outlier in its opening reported no outliers at all. Two pre-existing tests failed and were right to (`SlowCompletionIsCapturedWithTimingBreakdownOff`, `OnlySampledCompletionsAreStored`).

Precedence was the wrong lever entirely. "Which budget pays" and "does this deserve a body" are separate questions, and no ordering of three enum values answers both. They are now separated: `trace_reason` keeps its original Slow-then-Sampled order with `Exemplar` last, and `handle_result` decides capture independently (`is_slow || exemplar`). **Every pre-existing retention test passes untouched**, which is the evidence the ordering is now right - the first version disturbed behaviour nobody had asked to change.

New coverage for the policy lives at the layer that owns it (`load_strategy_test.cpp`): an outlier stays in the slow store and carries a body, exemplars carry bodies, a plain 1-in-N sample does not, and capture off leaves the completion path exactly as it was. The collector test that had asserted "sampled records carry no body" was pinning `handle_result`'s policy at the wrong layer and now pins the collector's actual contract.

<details>
<summary>How this was verified before CI (the engine could not be built in the authoring environment)</summary>

The engine half was written where `python build.py -e` cannot complete: the egress proxy answers `403` for `github.com` source tarballs, so `vcpkg` cannot fetch any port, and none of curl / sqlite_orm / sodium / gtest exist system-wide. This reproduces on the base commit and is unrelated to this diff. Rather than hand the whole engine half to CI unexamined:

- **Syntax + `-Wall -Wextra`, clean**, against system headers, for every touched engine file except `database.cpp` - the one file that genuinely needs `sqlite_orm`.
- **Ran the new pure tests for real** (libsodium is apt-installable): `sample_capture_test.cpp`, 10/10.
- **Ran the capture-policy half of `response_capture_test.cpp` for real** against the actual collector with a stubbed `Database`: 7/7.
- **Mutation-checked those**: dropping the `EXEMPLARS_PER_STATUS` bound fails 3 tests, disabling the budget check fails the budget test.
- After CI reported the precedence bug, **replayed both failing sequences against the real collector** to confirm the root cause - restoring the old precedence reproduces both failures exactly.

The DB-backed half (dedup, binary storage, report isolation, the run cascade, the samples endpoint) and `database.cpp` were unverifiable locally and are covered by the green matrix above.
</details>

### Deliberate deviations from the issue

1. **`picosha2` is not vendored**, contrary to the issue's note. Used the existing `vayu::utils::sha256` / `hex_encode` (libsodium) instead.
2. **No benchmark numbers.** The issue's last acceptance criterion is "with capture disabled, achieved RPS and p99 at 60k RPS do not regress against the pre-change baseline". That needs a quiet host with a stable CPU, which this environment is not, so I have not run `bench-compare.sh` and have not guessed at numbers. The structural argument is that `capture_response_bodies: false` makes `claim_status_exemplar` return on a config read before its atomic, passes `nullptr` as the capture source everywhere, and writes no rows - which `CaptureDisabledStoresNothingExtra` and `CaptureOffLeavesTheCompletionPathUnchanged` assert. That is an argument, not a measurement. **Filed as #287** rather than closed over.

Everything else in the acceptance criteria is implemented and covered.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #174
