### PR TITLE
chore(app): clear the electron written-never-read batch (#274)

### DIFF
--- a/app/electron/app-paths.test.ts
+++ b/app/electron/app-paths.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One data directory, three places that used to name it.
+ *
+ * `app:getPaths` re-derived the sidecar's dev-vs-production rule inline and
+ * hardcoded the `logs`/`db` subdirectories the engine creates, so the paths
+ * Settings - General shows the user were a second opinion rather than a
+ * readout. Nothing would have failed on drift: the panel renders whatever it is
+ * handed, and the directories it named would simply have been ones nothing
+ * writes to.
+ *
+ * So the assertions here compare the two derivations against each other rather
+ * than against expected strings - the point is that there is one source, not
+ * that it currently produces a particular path. `getAppPath()` and
+ * `getPath("userData")` are deliberately given different values, so a
+ * re-inlined copy that reaches for the wrong one fails instead of coinciding.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const APP_PATH = join("/fake", "vayu", "app");
+const USER_DATA = join("/fake", "userData", "vayu-client");
+
+vi.mock("electron", () => ({
+	app: {
+		getAppPath: () => APP_PATH,
+		getPath: (name: string) => {
+			if (name !== "userData") throw new Error(`unexpected app.getPath(${name})`);
+			return USER_DATA;
+		},
+		getVersion: () => "0.0.0-test",
+	},
+}));
+
+/**
+ * `isDev` is read at module load in both modules, so each mode needs a fresh
+ * graph. Imported through this helper rather than at the top of the file for
+ * that reason alone.
+ */
+async function loadForMode(mode: "development" | "production") {
+	process.env.NODE_ENV = mode;
+	// Only Electron sets this, and the sidecar's production binary lookup joins
+	// it in its constructor - unrelated to the paths under test, but it runs.
+	processWithResources.resourcesPath = join("/fake", "resources");
+	vi.resetModules();
+	const [{ resolveAppPaths }, { EngineSidecar, engineDataDirectory }] = await Promise.all([
+		import("./app-paths"),
+		import("./sidecar"),
+	]);
+	return { resolveAppPaths, EngineSidecar, engineDataDirectory };
+}
+
+const originalNodeEnv = process.env.NODE_ENV;
+const processWithResources = process as NodeJS.Process & { resourcesPath?: string };
+const originalResourcesPath = processWithResources.resourcesPath;
+
+beforeEach(() => {
+	vi.resetModules();
+});
+
+afterEach(() => {
+	process.env.NODE_ENV = originalNodeEnv;
+	processWithResources.resourcesPath = originalResourcesPath;
+	vi.resetModules();
+});
+
+describe("app:getPaths and the sidecar share one data directory", () => {
+	for (const mode of ["development", "production"] as const) {
+		it(`agrees with the sidecar in ${mode}`, async () => {
+			const { resolveAppPaths, EngineSidecar } = await loadForMode(mode);
+
+			const paths = resolveAppPaths();
+			const sidecarDataDir = new EngineSidecar().getDataDirectory();
+
+			expect(paths.dataDir).toBe(sidecarDataDir);
+			// Both modes must resolve somewhere; an empty agreement is not agreement.
+			expect(paths.dataDir.length).toBeGreaterThan(0);
+		});
+	}
+
+	it("takes the repo's engine/data in development and userData in production", async () => {
+		const dev = await loadForMode("development");
+		expect(dev.engineDataDirectory()).toBe(join(APP_PATH, "..", "engine", "data"));
+
+		const prod = await loadForMode("production");
+		expect(prod.engineDataDirectory()).toBe(USER_DATA);
+	});
+
+	it("puts logs and db under the data directory, and nowhere else", async () => {
+		const { resolveAppPaths } = await loadForMode("production");
+		const { ENGINE_LOGS_DIR, ENGINE_DB_DIR } = await import("./constants");
+
+		const paths = resolveAppPaths();
+		expect(paths.logsPath).toBe(join(paths.dataDir, ENGINE_LOGS_DIR));
+		expect(paths.dbPath).toBe(join(paths.dataDir, ENGINE_DB_DIR));
+		expect(paths.appDir).toBe(APP_PATH);
+	});
+});
+
+describe("the logs/db names match the engine that creates them", () => {
+	it("finds both constants in daemon.cpp's data-dir layout", async () => {
+		const { ENGINE_LOGS_DIR, ENGINE_DB_DIR } = await import("./constants");
+		const daemonPath = join(
+			dirname(fileURLToPath(import.meta.url)),
+			"..",
+			"..",
+			"engine",
+			"src",
+			"daemon.cpp"
+		);
+
+		const source = readFileSync(daemonPath, "utf-8");
+		// A scan that read nothing passes every assertion below it.
+		expect(source.length).toBeGreaterThan(0);
+
+		const joined = [...source.matchAll(/path_join\s*\(\s*data_dir\s*,\s*"([^"]+)"/g)].map(
+			(match) => match[1]
+		);
+		expect(joined).not.toHaveLength(0);
+		expect(joined).toContain(ENGINE_LOGS_DIR);
+		expect(joined).toContain(ENGINE_DB_DIR);
+	});
+});

--- a/app/electron/app-paths.ts
+++ b/app/electron/app-paths.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @file app-paths.ts
+ * @brief The directories Settings - General shows the user.
+ *
+ * Extracted from the `app:getPaths` handler, which had grown its own copy of
+ * the sidecar's data-dir rule and of the engine's `logs`/`db` layout. Two
+ * copies of a derivation drift silently here: the panel keeps rendering, it
+ * just names directories nothing writes to. The derivation now has one owner
+ * per layer - `engineDataDirectory()` for the data dir, `constants.ts` for the
+ * subdirectory names - and this module only joins them.
+ */
+
+import { app } from "electron";
+import path from "path";
+import { ENGINE_DB_DIR, ENGINE_LOGS_DIR } from "./constants.js";
+import { engineDataDirectory } from "./sidecar.js";
+
+/** Wire shape of `app:getPaths`; mirrored in `src/types/electron.d.ts`. */
+export interface AppPaths {
+	appDir: string;
+	dataDir: string;
+	logsPath: string;
+	dbPath: string;
+}
+
+export function resolveAppPaths(): AppPaths {
+	const dataDir = engineDataDirectory();
+	return {
+		appDir: app.getAppPath(),
+		dataDir,
+		logsPath: path.join(dataDir, ENGINE_LOGS_DIR),
+		dbPath: path.join(dataDir, ENGINE_DB_DIR),
+	};
+}

--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -19,6 +19,14 @@ export const ENGINE_HOST = "127.0.0.1";
 export const ENGINE_PORT = 9876;
 /** Lock file written by the engine inside its data dir. */
 export const ENGINE_LOCK_FILE = "vayu.lock";
+/**
+ * Subdirectories the engine creates inside its data dir, named here because the
+ * app shows both paths in Settings - General and the engine is what defines
+ * them (`engine/src/daemon.cpp:113-114`). Renaming one there without changing
+ * it here shows the user a directory that does not exist.
+ */
+export const ENGINE_LOGS_DIR = "logs";
+export const ENGINE_DB_DIR = "db";
 
 // MCP server (Model Context Protocol) - a TypeScript sidecar hosted in this
 // main process that exposes the engine's capabilities to agents (Claude Code,

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -9,6 +9,7 @@ import { app, BrowserWindow, dialog, ipcMain, nativeTheme, Menu, shell } from "e
 import path from "path";
 import { fileURLToPath } from "url";
 import { EngineSidecar } from "./sidecar.js";
+import { resolveAppPaths } from "./app-paths.js";
 import { setupOAuthIpcHandlers } from "./oauth.js";
 import { loadWindowState, trackWindowState } from "./window-state.js";
 import { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } from "./updater.js";
@@ -161,6 +162,35 @@ const rendererRecovery = createRendererRecovery({
 	onRecovered: () => saveFlusher.reset(),
 });
 
+/**
+ * Forward OS theme changes to whichever window is up.
+ *
+ * Installed once for the process, not per window: `nativeTheme` is a
+ * process-wide emitter and `createWindow()` runs again on every macOS
+ * dock-reopen, so registering there left one listener per reopen - Node warns
+ * at eleven, and every theme flip sent the renderer N copies of the same event.
+ * Reading the window through `liveWindow()` at send time is what makes one
+ * registration enough for every window that follows.
+ */
+function installThemeBridge() {
+	nativeTheme.on("updated", () => {
+		const win = liveWindow();
+		win?.webContents.send("theme:changed", {
+			shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+			themeSource: nativeTheme.themeSource,
+		});
+
+		// Update titlebar overlay color - Windows only
+		if (process.platform === "win32" && win) {
+			win.setTitleBarOverlay({
+				color: nativeTheme.shouldUseDarkColors ? TITLEBAR_BG_DARK : TITLEBAR_BG_LIGHT,
+				symbolColor: nativeTheme.shouldUseDarkColors ? TITLEBAR_FG_DARK : TITLEBAR_FG_LIGHT,
+				height: TITLEBAR_HEIGHT,
+			});
+		}
+	});
+}
+
 function createWindow() {
 	// A new window means a new renderer with its own unsaved work. Told to the
 	// recovery first, so a crash flag left over from the window this one
@@ -255,23 +285,6 @@ function createWindow() {
 	});
 	mainWindow.on("responsive", () => {
 		rendererRecovery.handleResponsive();
-	});
-
-	// Send theme to renderer when it changes
-	nativeTheme.on("updated", () => {
-		mainWindow?.webContents.send("theme:changed", {
-			shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
-			themeSource: nativeTheme.themeSource,
-		});
-
-		// Update titlebar overlay color - Windows only
-		if (process.platform === "win32" && mainWindow) {
-			mainWindow.setTitleBarOverlay({
-				color: nativeTheme.shouldUseDarkColors ? TITLEBAR_BG_DARK : TITLEBAR_BG_LIGHT,
-				symbolColor: nativeTheme.shouldUseDarkColors ? TITLEBAR_FG_DARK : TITLEBAR_FG_LIGHT,
-				height: TITLEBAR_HEIGHT,
-			});
-		}
 	});
 
 	// The X button destroys the renderer before `before-quit` can ask it for
@@ -455,7 +468,7 @@ function createMenu() {
 
 async function startEngine() {
 	try {
-		engineSidecar = new EngineSidecar(9876);
+		engineSidecar = new EngineSidecar();
 		await engineSidecar.start();
 		console.log("[Main] Engine started successfully at", engineSidecar.getApiUrl());
 	} catch (error) {
@@ -558,14 +571,6 @@ function setupIpcHandlers() {
 	// Handle engine restart request from renderer
 	ipcMain.handle("engine:restart", async () => {
 		return await restartEngine();
-	});
-
-	// Handle engine status check
-	ipcMain.handle("engine:status", () => {
-		return {
-			running: engineSidecar?.isRunning() ?? false,
-			url: engineSidecar?.getApiUrl() ?? null,
-		};
 	});
 
 	// MCP server status - used by Settings to show the connect URL and state.
@@ -742,29 +747,9 @@ function setupIpcHandlers() {
 		});
 	});
 
-	// Get app paths (app dir, logs path, db path)
-	ipcMain.handle("app:getPaths", () => {
-		const appDir = app.getAppPath();
-
-		// Get data directory using the same logic as EngineSidecar
-		const isDev = process.env.NODE_ENV === "development";
-		let dataDir: string;
-		if (isDev) {
-			dataDir = path.join(appDir, "..", "engine", "data");
-		} else {
-			dataDir = app.getPath("userData");
-		}
-
-		const logsPath = path.join(dataDir, "logs");
-		const dbPath = path.join(dataDir, "db");
-
-		return {
-			appDir,
-			dataDir,
-			logsPath,
-			dbPath,
-		};
-	});
+	// Get app paths (app dir, logs path, db path). Derived in app-paths.ts so
+	// this handler cannot drift from the sidecar's own data directory.
+	ipcMain.handle("app:getPaths", () => resolveAppPaths());
 }
 
 /**
@@ -835,6 +820,9 @@ app.whenReady().then(async () => {
 
 	// Create application menu
 	createMenu();
+
+	// One registration for the process, ahead of any window - see the function.
+	installThemeBridge();
 
 	// Start the engine
 	await startEngine();

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -19,8 +19,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	// Engine management
 	restartEngine: (): Promise<{ success: boolean; error?: string }> =>
 		ipcRenderer.invoke("engine:restart"),
-	getEngineStatus: (): Promise<{ running: boolean; url: string | null }> =>
-		ipcRenderer.invoke("engine:status"),
 
 	// MCP server (exposes Vayu to agents like Claude Code). See electron/mcp/.
 	getMcpStatus: (): Promise<{ running: boolean; url: string; enabled: boolean }> =>
@@ -115,7 +113,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
 	// Interface scale - real page zoom (reflows the viewport).
 	setZoomFactor: (factor: number) => webFrame.setZoomFactor(factor),
-	getZoomFactor: (): number => webFrame.getZoomFactor(),
 
 	// Platform info
 	platform: process.platform,

--- a/app/electron/sidecar.ts
+++ b/app/electron/sidecar.ts
@@ -33,6 +33,30 @@ import {
 const isDev = process.env.NODE_ENV === "development";
 
 /**
+ * The directory the engine keeps its state in - logs, database and lock file.
+ *
+ * Production:
+ *   - macOS: ~/Library/Application Support/vayu-client
+ *   - Windows: %APPDATA%/vayu-client
+ *   - Linux: ~/.config/vayu-client
+ * Development: <repo>/engine/data
+ *
+ * Module-level rather than a method because callers outside the sidecar need it
+ * when there is no sidecar instance to ask: `app:getPaths` answers Settings
+ * whether or not the engine came up. It used to re-derive this inline, so a
+ * change here silently showed the user the old directory.
+ */
+export function engineDataDirectory(): string {
+	if (isDev) {
+		// In development, use a local directory in the engine folder
+		return path.join(app.getAppPath(), "..", "engine", "data");
+	}
+	// In production, use the app's userData directory
+	// app.getPath("userData") returns platform-specific paths
+	return app.getPath("userData");
+}
+
+/**
  * Check if a port is available
  */
 function isPortAvailable(port: number): Promise<boolean> {
@@ -320,28 +344,13 @@ export class EngineSidecar {
 	constructor(port: number = ENGINE_PORT, system: SidecarSystem = defaultSidecarSystem) {
 		this.port = port;
 		this.system = system;
-		this.dataDir = this.getDataDirectory();
+		this.dataDir = engineDataDirectory();
 		this.binaryPath = this.getEngineBinaryPath();
 	}
 
-	/**
-	 * Get the user data directory for the engine
-	 * Production:
-	 *   - macOS: ~/Library/Application Support/vayu-client
-	 *   - Windows: %APPDATA%/vayu-client
-	 *   - Linux: ~/.config/vayu-client
-	 * Development: <repo>/engine/data
-	 */
-	private getDataDirectory(): string {
-		if (isDev) {
-			// In development, use a local directory in the engine folder
-			const devDataDir = path.join(app.getAppPath(), "..", "engine", "data");
-			return devDataDir;
-		} else {
-			// In production, use the app's userData directory
-			// app.getPath("userData") returns platform-specific paths
-			return app.getPath("userData");
-		}
+	/** Where this engine keeps its state. See `engineDataDirectory()`. */
+	getDataDirectory(): string {
+		return this.dataDir;
 	}
 
 	/**

--- a/app/src/types/electron.d.ts
+++ b/app/src/types/electron.d.ts
@@ -49,7 +49,6 @@ export type UpdateCheckResult =
 interface ElectronAPI {
 	// Engine management
 	restartEngine: () => Promise<{ success: boolean; error?: string }>;
-	getEngineStatus: () => Promise<{ running: boolean; url: string | null }>;
 
 	// MCP server (exposes Vayu to agents like Claude Code)
 	getMcpStatus: () => Promise<McpStatus>;
@@ -87,7 +86,6 @@ interface ElectronAPI {
 
 	// Interface scale (page zoom)
 	setZoomFactor: (factor: number) => void;
-	getZoomFactor: () => number;
 
 	// Open one of the app's own doc links in the system browser
 	openAppLink: (key: "docs" | "scripting" | "issues") => Promise<void>;

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -256,7 +256,7 @@ cross-language conformance fixture. See `variable-resolution.md`.
 
 The preload script (`electron/preload.ts`) exposes a minimal, context-isolated API bridge via `window.electronAPI`:
 
-- **Engine Management**: `restartEngine()`, `getEngineStatus()` for engine lifecycle control
+- **Engine Management**: `restartEngine()` for engine lifecycle control. Engine liveness is *not* on this bridge - the renderer polls `GET /health` directly (`src/queries/health.ts`), so there is one answer rather than two
 - **Theme Management**: `getTheme()`, `setTheme()`, `onThemeChanged()` for OS theme synchronization
 - **Window Controls**: `windowMinimize()`, `windowMaximize()`, `windowClose()`, `windowIsMaximized()`, `onWindowMaximized()` for custom titlebar
 - **Auto-update**: Listeners for `onUpdateAvailable()`, `onUpdateDownloaded()`, plus `restartToInstallUpdate()`, `openReleasePage()`


### PR DESCRIPTION
## Description

The five hygiene items from #274, one PR.

**Plan.** The root cause across all five is the same: surface that one layer writes and no layer reads, and config one place defines and another re-derives. The approach is to delete the unread surface outright rather than keep it speculatively, and to give the one item that has a real reader - the data directory Settings shows - a single owner instead of two copies. The alternative I rejected for item 3 was a public accessor on `engineSidecar` called from the handler: `engineSidecar` is null whenever the engine failed to come up, and Settings must still answer, so the derivation is module-level (`engineDataDirectory()` in `sidecar.ts`) and the instance reads it too.

1. **`engine:status`** - handler, preload `getEngineStatus`, and the `electron.d.ts` entry deleted together. Zero renderer callers (liveness comes from `GET /health` polling in `src/queries/health.ts`); worse than dead, it reported `running` from a field that is already false for an adopted engine, with nothing reading the channel to surface that.
2. **`getZoomFactor`** - deleted from preload and the type. `useAppearance` only ever calls `setZoomFactor`.
3. **`app:getPaths`** - re-implemented `EngineSidecar.getDataDirectory()` inline, re-derived `isDev` shadowing the module const, and hardcoded the `logs`/`db` names the engine defines. Now: `engineDataDirectory()` is exported module-level from `sidecar.ts` and used by the sidecar's constructor; `ENGINE_LOGS_DIR`/`ENGINE_DB_DIR` are constants comment-linked to `engine/src/daemon.cpp:113-114`; `app-paths.ts` joins them and the handler is one line. The wire shape `GeneralPanel.tsx` reads is byte-identical.
4. **Inline `9876`** - `new EngineSidecar()`; the parameter already defaults to `ENGINE_PORT`.
5. **`nativeTheme` listener** - moved from `createWindow()` to a once-per-process `installThemeBridge()` at `whenReady`. It reads the current window through `liveWindow()` at send time, which is what lets one registration serve every window a macOS dock-reopen builds.

## Type of Change
- [x] Bug fix (item 5 - listener leak; items 1-4 are hygiene)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **286 files, 2500 tests, all passing** (5 of them new, in `app/electron/app-paths.test.ts`).
- `pnpm type-check` and `pnpm lint` green. Prettier clean on every touched file.
- `pnpm format:check` was not run repo-wide per CLAUDE.md; the touched files were checked individually and were clean before.
- Engine untouched, so no engine build or ctest run - no C++ test could change colour.
- `mkdocs build --strict` not run: mkdocs is not installed in this container. The docs edit rewords one existing bullet and adds no link, heading or nav entry, so there is nothing for the strict build to reject.

New test - `app/electron/app-paths.test.ts`:
- `resolveAppPaths().dataDir` equals `new EngineSidecar().getDataDirectory()` in **both** dev and production. The mock gives `getAppPath()` and `getPath("userData")` deliberately different values, so a re-inlined copy reaching for the wrong one fails instead of coinciding. Mutation-checked: re-inlining `app.getPath("userData")` in `resolveAppPaths` fails the development case.
- `logsPath`/`dbPath` are the constants joined under `dataDir`, and a source guard reads `engine/src/daemon.cpp` and asserts both constants appear in its `path_join (data_dir, ...)` layout - the cross-language half the comment link cannot enforce. The guard asserts the file it read is non-empty first, and was mutation-checked by renaming `ENGINE_LOGS_DIR` to `"log"`.

Item 5 has no dedicated test, as the issue directs: the listener now lives at `whenReady` scope, where a source-level guard would be overkill - it is a review-verified change.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: `docs/app/architecture.md` listed `getEngineStatus()` on the preload bridge; that bullet now names only `restartEngine()` and says where liveness actually comes from.

## Acceptance criteria

- [x] `rg "engine:status|getEngineStatus|getZoomFactor" app/` returns zero hits.
- [x] `app:getPaths` and the sidecar share one data-dir derivation; `logs`/`db` are named constants referenced by both the handler and (comment-linked) `daemon.cpp`.
- [x] `rg "9876" app/electron --glob '!mcp/**'` matches only `constants.ts` - with one substring match left deliberately: `sidecar.test.ts:63` defines `TEST_PORT = 39876`, a distinct port picked so the suite never touches the real one, not a copy of `ENGINE_PORT`.
- [x] Repeated `createWindow()` calls no longer accumulate `nativeTheme` listeners - the registration moved out of `createWindow()` entirely, so the count is one for the process regardless of reopens.
- [x] `pnpm test`, `pnpm type-check`, `pnpm lint` green.

## Related Issues
Closes #274

Last of the E3 cluster and of the #278 electron wave; #269-#273 and #275-#277 have all merged, so the surface this deletes and moves is no longer under another branch's edits. Nothing was rebased around.

---
_Generated by [Claude Code](https://claude.ai/code/session_016cVZe2ViNLL4LQeDREiaE4)_