### PR TITLE
fix(app): let a collection on the selected tab's path stay collapsed

### DIFF
--- a/app/src/modules/collections/CollectionTree.reveal.test.tsx
+++ b/app/src/modules/collections/CollectionTree.reveal.test.tsx
@@ -26,10 +26,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
 import { useTabsStore } from "@/stores";
+import type { Tab } from "@/stores/tabs-store";
 import { useCollectionsStore } from "./collections-store";
 import CollectionTree from "./CollectionTree";
 
@@ -124,5 +125,93 @@ describe("revealing the active tab in the tree", () => {
 		});
 		renderTree();
 		expect(expanded()).toEqual([]);
+	});
+});
+
+/**
+ * The reveal has to be once per *selection*, not once per render.
+ *
+ * The mock above returns a new `Map` on every call, which is what
+ * `useMultipleCollectionRequests` used to do for real - and the tree re-renders
+ * on any expand-state change, so the reveal effect re-ran and re-expanded the
+ * chain a frame after the chevron collapsed it. Every ancestor of the active
+ * tab's entity was pinned open and the chevron looked dead.
+ */
+describe("collapsing a collection on the selected tab's ancestor path", () => {
+	const collapse = (container: HTMLElement, collectionId: string) => {
+		const toggle = container.querySelector(
+			`[data-collection-id="${collectionId}"] [data-tree-toggle]`
+		);
+		expect(toggle).not.toBeNull();
+		fireEvent.click(toggle!);
+	};
+
+	const selectTab = (tab: Tab) =>
+		act(() => {
+			useTabsStore.setState({ openTabs: [tab], activeTabId: tab.id });
+		});
+
+	it("stays collapsed while the selected request is unchanged", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		const { container } = renderTree();
+		expect(expanded()).toContain("grand");
+
+		collapse(container, "grand");
+
+		// Before the ref guard this re-expanded in the same frame.
+		expect(expanded()).not.toContain("grand");
+		// The rest of the chain is untouched - collapsing one folder is not a
+		// reason to close its parents.
+		expect(expanded()).toContain("root");
+		expect(expanded()).toContain("child");
+	});
+
+	it("stays collapsed while the selected collection is unchanged", () => {
+		// The ancestor case: `child` holds the selected collection `grand`.
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "collection", entityId: "grand" }],
+			activeTabId: "t1",
+		});
+		const { container } = renderTree();
+		expect(expanded()).toContain("child");
+
+		collapse(container, "child");
+
+		expect(expanded()).not.toContain("child");
+	});
+
+	it("re-reveals after the selection moves away and back", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		const { container } = renderTree();
+		collapse(container, "grand");
+		expect(expanded()).not.toContain("grand");
+
+		// Once per selection means once per selection *change*: a tab that points
+		// at nothing in the tree, then back to the request, is a new selection.
+		selectTab({ id: "t2", type: "settings", entityId: null });
+		selectTab({ id: "t1", type: "request", entityId: "r1" });
+
+		expect(expanded()).toContain("grand");
+	});
+
+	it("re-reveals when the selection moves to a different entity", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		const { container } = renderTree();
+		collapse(container, "child");
+		expect(expanded()).not.toContain("child");
+
+		selectTab({ id: "t2", type: "collection", entityId: "grand" });
+
+		expect(expanded()).toContain("child");
+		expect(expanded()).toContain("grand");
 	});
 });

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -45,7 +45,12 @@ export default function CollectionTree() {
 	const { startSaving, completeSave, failSave, setStatus } = useSaveStore();
 	const treeRef = useRef<HTMLDivElement>(null);
 	const treeFocus = useRovingTreeFocus(treeRef);
-	const scrolledRequestRef = useRef<string | null>(null);
+	// Both reveal and scroll are once-per-selection, and each records the
+	// selection it last acted on. They cannot share one ref: the scroll can only
+	// run a render *after* the reveal, once the expanded ancestors have put the
+	// row in the DOM.
+	const revealedSelectionRef = useRef<string | null>(null);
+	const scrolledSelectionRef = useRef<string | null>(null);
 
 	// Get selected collection and request IDs from active tab
 	const activeTab = openTabs.find((t) => t.id === activeTabId);
@@ -113,15 +118,32 @@ export default function CollectionTree() {
 	 * Settings and Variables never had the problem because they own a whole
 	 * drawer view; a request did not because of this effect. A collection fell
 	 * between the two.
+	 *
+	 * Guarded by a ref so it fires once per selection - the same discipline the
+	 * scroll effect below has always had. Unguarded, it re-ran after *every*
+	 * render of the tree (it lists `requestsByCollection` and `collections`, and
+	 * the tree re-renders on any expand-state change), so collapsing a
+	 * collection that held the selected request re-expanded it in the same
+	 * frame: the chevron looked dead and every ancestor of the active tab was
+	 * pinned open. Once per selection *change* means switching tabs away and
+	 * back reveals again, which is the behaviour that was wanted all along.
 	 */
 	useEffect(() => {
-		if (!selectedRequestId) scrolledRequestRef.current = null;
+		const selectionId = selectedCollectionId ?? selectedRequestId;
+		if (!selectionId) {
+			// Settings, Variables, no tab at all: re-selecting the entity later is a
+			// fresh selection and must reveal again.
+			revealedSelectionRef.current = null;
+			scrolledSelectionRef.current = null;
+			return;
+		}
+		if (revealedSelectionRef.current === selectionId) return;
 
 		// A collection reveals itself; a request reveals the collection holding it.
 		let target: string | undefined;
 		if (selectedCollectionId) {
 			target = selectedCollectionId;
-		} else if (selectedRequestId) {
+		} else {
 			for (const [collectionId, reqs] of requestsByCollection) {
 				if (reqs.some((r) => r.id === selectedRequestId)) {
 					target = collectionId;
@@ -129,6 +151,8 @@ export default function CollectionTree() {
 				}
 			}
 		}
+		// The owning collection's requests may not have arrived yet. Leave the ref
+		// unset so this reveals once they do, rather than counting as done.
 		if (!target) return;
 
 		const ancestorChain: string[] = [];
@@ -137,6 +161,7 @@ export default function CollectionTree() {
 			ancestorChain.push(cursor);
 			cursor = collections.find((c) => c.id === cursor)?.parentId ?? undefined;
 		}
+		revealedSelectionRef.current = selectionId;
 		expandCollections(ancestorChain);
 	}, [
 		selectedRequestId,
@@ -153,12 +178,12 @@ export default function CollectionTree() {
 	 */
 	useEffect(() => {
 		const id = selectedCollectionId ?? selectedRequestId;
-		if (!id || scrolledRequestRef.current === id) return;
+		if (!id || scrolledSelectionRef.current === id) return;
 		const attr = selectedCollectionId ? "data-collection-id" : "data-request-id";
 		const row = treeRef.current?.querySelector(`[${attr}="${CSS.escape(id)}"]`);
 		if (row) {
 			row.scrollIntoView({ block: "nearest" });
-			scrolledRequestRef.current = id;
+			scrolledSelectionRef.current = id;
 		}
 	}, [selectedRequestId, selectedCollectionId, expandedCollectionIds, requestsByCollection]);
 

--- a/app/src/queries/collections.requests-map.test.tsx
+++ b/app/src/queries/collections.requests-map.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `useMultipleCollectionRequests` must hand back the *same* map while the
+ * underlying results are unchanged.
+ *
+ * It used to build the `Map` inline on every call, so its identity churned on
+ * every render of every caller. `CollectionTree` lists it in the dependency
+ * array of the effect that reveals the active tab, which therefore re-ran after
+ * every render and re-expanded a collection the user had just collapsed. The
+ * ref guard in that effect is the fix for the collapse; this is the fix for the
+ * churn itself, which also rebuilt `getRequestsByCollection` and every
+ * `CollectionItem` prop chain each render.
+ *
+ * Callers pass a freshly-built id array every render (the tree derives it from
+ * the collections query with `.map`), so these tests do the same - a hook that
+ * only stays stable for a caller who remembers to memoise its argument would
+ * not have fixed anything.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useMultipleCollectionRequests } from "./collections";
+import type { Request } from "@/types";
+
+const listRequests = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		listRequests: (...a: unknown[]) => listRequests(...a),
+	},
+}));
+
+const req = (id: string, collectionId: string, extra: Partial<Request> = {}) =>
+	({
+		id,
+		collectionId,
+		name: id,
+		method: "GET",
+		url: "",
+		...extra,
+	}) as Request;
+
+const wrapper = (client: QueryClient) =>
+	function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+	};
+
+const newClient = () =>
+	new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+
+beforeEach(() => {
+	listRequests.mockReset();
+	listRequests.mockImplementation(({ collectionId }: { collectionId: string }) =>
+		Promise.resolve(collectionId === "c1" ? [req("r1", "c1")] : [])
+	);
+});
+
+describe("useMultipleCollectionRequests", () => {
+	it("returns the same map across a re-render with unchanged data", async () => {
+		const { result, rerender } = renderHook(
+			// A new array literal every render, exactly as CollectionTree builds it.
+			() => useMultipleCollectionRequests(["c1", "c2"]),
+			{ wrapper: wrapper(newClient()) }
+		);
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		const first = result.current.requestsByCollection;
+		rerender();
+		rerender();
+
+		expect(result.current.requestsByCollection).toBe(first);
+	});
+
+	it("returns a new map when the id list changes", async () => {
+		const { result, rerender } = renderHook(
+			({ ids }: { ids: string[] }) => useMultipleCollectionRequests(ids),
+			{ wrapper: wrapper(newClient()), initialProps: { ids: ["c1"] } }
+		);
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		const first = result.current.requestsByCollection;
+
+		rerender({ ids: ["c1", "c2"] });
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(result.current.requestsByCollection).not.toBe(first);
+		expect([...result.current.requestsByCollection.keys()]).toEqual(["c1", "c2"]);
+	});
+
+	it("keys every requested collection, sorted by order then createdAt", async () => {
+		listRequests.mockImplementation(({ collectionId }: { collectionId: string }) =>
+			Promise.resolve(
+				collectionId === "c1"
+					? [
+							req("late", "c1", { order: 1 }),
+							req("older", "c1", { order: 0, createdAt: "2026-01-01T00:00:00Z" }),
+							req("newer", "c1", { order: 0, createdAt: "2026-02-01T00:00:00Z" }),
+						]
+					: []
+			)
+		);
+		const { result } = renderHook(() => useMultipleCollectionRequests(["c1", "c2"]), {
+			wrapper: wrapper(newClient()),
+		});
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(result.current.requestsByCollection.get("c1")?.map((r) => r.id)).toEqual([
+			"older",
+			"newer",
+			"late",
+		]);
+		// An empty collection is present with an empty list, not missing: callers
+		// distinguish "no requests" from "not asked for".
+		expect(result.current.requestsByCollection.get("c2")).toEqual([]);
+	});
+});

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -12,7 +12,8 @@
  */
 
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 import { apiService } from "@/services/api";
 import { ApiError } from "@/services";
 import { queryKeys } from "./keys";
@@ -85,38 +86,69 @@ export function useRequestsQuery(collectionId: string | null) {
 	});
 }
 
+/** Requests within a collection are ordered by `order`, then by creation time. */
+function compareRequestOrder(a: Request, b: Request): number {
+	const orderDiff = (a.order ?? 0) - (b.order ?? 0);
+	if (orderDiff !== 0) return orderDiff;
+	const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+	const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+	return aTime - bTime;
+}
+
 /**
  * Fetch requests for multiple collections (e.g., all expanded ones)
- * Uses TanStack Query's useQueries for parallel fetching
+ * Uses TanStack Query's useQueries for parallel fetching.
+ *
+ * The returned `requestsByCollection` is **referentially stable** while the
+ * underlying query results are unchanged, and callers depend on that: an effect
+ * that lists it in its dependency array must fire when the requests change and
+ * not merely because the tree re-rendered. This used to build the map inline on
+ * every call, which is what pinned a collection open in the sidebar - the
+ * reveal effect in `CollectionTree` re-ran after every render and undid the
+ * chevron click that had just collapsed it.
  */
 export function useMultipleCollectionRequests(collectionIds: string[]) {
+	// Callers build this array inline from the collections query, so it is a new
+	// array on every render. Pin it to its contents: it is what `combine` closes
+	// over, and `combine` has to keep a stable identity (see below).
+	const idsKey = collectionIds.join(",");
+	// eslint-disable-next-line react-hooks/exhaustive-deps -- `idsKey` is the contents of `collectionIds`
+	const stableCollectionIds = useMemo(() => collectionIds, [idsKey]);
+
+	/*
+	 * `combine` is memoised by TanStack: it re-runs only when the query results
+	 * or the query hashes change - *and* only if the function itself is the same
+	 * reference as last render (`QueriesObserver` compares `combine` by
+	 * identity). An inline arrow would therefore rebuild the map every render
+	 * and defeat the whole point, so this is a `useCallback`.
+	 */
+	const combine = useCallback(
+		(results: Array<UseQueryResult<Request[]>>) => {
+			// Map of collectionId -> requests, sorted by order then createdAt.
+			const requestsByCollection = new Map<string, Request[]>();
+			results.forEach((query, index) => {
+				const requests = query.data ?? [];
+				requestsByCollection.set(
+					stableCollectionIds[index],
+					[...requests].sort(compareRequestOrder)
+				);
+			});
+			return {
+				requestsByCollection,
+				isLoading: results.some((q) => q.isLoading),
+			};
+		},
+		[stableCollectionIds]
+	);
+
 	// Create a query for each collection
-	const queries = useQueries({
-		queries: collectionIds.map((collectionId) => ({
+	return useQueries({
+		queries: stableCollectionIds.map((collectionId) => ({
 			queryKey: queryKeys.requests.listByCollection(collectionId),
 			queryFn: () => apiService.listRequests({ collectionId: collectionId }),
 		})),
+		combine,
 	});
-
-	// Build a map of collectionId -> requests, sorted by order then createdAt
-	const requestsByCollection = new Map<string, Request[]>();
-	queries.forEach((query, index) => {
-		const collectionId = collectionIds[index];
-		const requests = query.data ?? [];
-		const sortedRequests = [...requests].sort((a, b) => {
-			const orderDiff = (a.order ?? 0) - (b.order ?? 0);
-			if (orderDiff !== 0) return orderDiff;
-			const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-			const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-			return aTime - bTime;
-		});
-		requestsByCollection.set(collectionId, sortedRequests);
-	});
-
-	return {
-		requestsByCollection,
-		isLoading: queries.some((q) => q.isLoading),
-	};
 }
 
 /**

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -603,7 +603,13 @@ from `@/queries/runs`); everything with more than one is in the barrel.
   single-collection query: a collection is read out of this list)
 - **`useRequestsQuery(collectionId)`** - Fetch requests in a collection
 - **`useMultipleCollectionRequests(collectionIds)`** - The same list for several
-  collections at once, as parallel queries
+  collections at once, as parallel queries. Its `requestsByCollection` map is
+  **referentially stable** while the underlying results are unchanged (built in
+  `useQueries`' `combine`, which TanStack memoises only for a `combine` of
+  stable identity - hence the `useCallback`). Callers list it in effect
+  dependencies; when it was rebuilt on every call, `CollectionTree`'s reveal
+  effect re-ran on every render and re-expanded a collection the user had just
+  collapsed
 - **`useRequestQuery(requestId)`** / **`requestDetailOptions(requestId)`** - One
   request by id (`GET /requests/:id`), used by a restored request tab and by a
   design-run copy on cold start. Only an `ApiError` with `statusCode === 404`


### PR DESCRIPTION
## Description

Collapsing a collection that holds the active tab's request - or is the selected collection, or an ancestor of either - did nothing: the chevron collapsed it and it re-expanded in the same frame.

**Plan (root cause, approach, rejected alternative).** The root cause is that the reveal effect in `CollectionTree.tsx` had no once-per-selection guard: it lists `requestsByCollection` and `collections` in its dependency array, `useMultipleCollectionRequests` built a fresh `Map` on every call, and the tree re-renders on any expand-state change - so the collapse's own render re-fired the reveal, which re-added the id. (`expandCollections`' "skip when every id is already expanded" guard stops the render loop, not the re-expand.) The approach is the one the scroll effect directly below has always used: a ref recording the last-revealed selection, so the reveal fires once per selection *change*. The map is memoised at the source as a ride-along, since its unstable identity also churned `getRequestsByCollection` and every `CollectionItem` prop chain. The alternative I rejected is the one the issue names: making `collapseCollection`/`toggleCollectionExpanded` selection-aware. The store is not the layer that knows *why* an expand was requested, and pinning behaviour there would break legitimate programmatic collapse. Memoisation alone was also rejected as insufficient - a background refetch on window focus would still re-fire the effect and undo a collapse minutes later, which is why the ref guard is the fix and the memo is the ride-along.

Verified at master `0dbbb9c`: the mechanism is exactly as the issue describes, no drift.

**`CollectionTree.tsx`**
- The reveal effect is guarded by `revealedSelectionRef`. When there is no selection (Settings, Variables, no tab) both refs reset, so re-selecting the entity later counts as a fresh selection and reveals again.
- When the owning collection's requests have not arrived yet, the ref is left unset so the reveal runs once they do, rather than counting as done.
- `scrolledRequestRef` renamed `scrolledSelectionRef` - it has tracked collection ids as well as request ids since the reveal was generalised, and the reveal effect no longer clears it on every render of a collection tab.

**`queries/collections.ts`**
- The map moves into `useQueries`' `combine`. `QueriesObserver` memoises `combine` against the raw results *and* compares the function by identity, so it is a `useCallback` - an inline arrow would re-run it every render and defeat the point. `collectionIds` is pinned to its contents first (callers build it inline with `.map`), so the hook is stable regardless of whether the caller memoises its argument.
- The sort comparator is extracted as `compareRequestOrder`, so `combine` stays a thin closure.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **288 files, 2537 tests, all passing**. `pnpm type-check`, `pnpm lint` (zero warnings) and `pnpm format:check` on the touched files are green. No engine change, so no `build.py -t` / `ctest` run - nothing in `engine/` could change colour. No pre-existing failures observed.

New tests, all mutation-checked:

`CollectionTree.reveal.test.tsx` (+4, the existing 4 reveal cases stay green). The file's mock already returns a new `Map` per call, which is precisely the churn the bug rode on.
- collapsing the collection holding the selected request stays collapsed, and its parents are left alone
- collapsing an ancestor of the selected *collection* stays collapsed
- selection away to a tab pointing at nothing in the tree and back re-reveals
- selection moving to a different entity re-reveals

`queries/collections.requests-map.test.tsx` (new, 3). Passes a fresh array literal each render, as the real caller does.
- same map identity across re-renders with unchanged data
- new map when the id list changes, keyed by the new list
- every requested collection keyed, sorted by `order` then `createdAt`; an empty collection is present with `[]`, not missing

Mutation checks run: deleting the ref guard fails all 4 new reveal tests; wrapping `combine` in an inline arrow fails the stability test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

**Docs.** The issue predicted "none", and `docs/app/COMPONENTS.md` indeed only lists the module - I verified nothing there describes the reveal behaviour. But `docs/app/state-management.md:605` documents `useMultipleCollectionRequests`, and referential stability is now a contract callers depend on, so that bullet is updated in the same commit. No headings or links changed (`mkdocs` is not installed in this container; the edit is prose inside an existing bullet).

## Acceptance criteria
- [x] A collection holding the selected request can be collapsed and stays collapsed while that selection is unchanged; same for a selected collection and for ancestors of either
- [x] Selecting a tab still reveals and scrolls to its entity, including entities nested under collapsed parents
- [x] Switching tabs away and back re-reveals the entity's chain
- [x] `requestsByCollection` is referentially stable across renders with unchanged data
- [x] New tests pass, mutation-checked; `pnpm test`, `pnpm type-check`, `pnpm lint` green

No deliberate deviation from the issue spec.

## Related Issues
Closes #292

---
_Generated by [Claude Code](https://claude.ai/code/session_018NeKcsnGgMYvQfZCHvYqKf)_