### PR TITLE
test(app): scan APP_NAME from install.sh instead of inventing it

### DIFF
--- a/app/electron/appimage-stamp.layout.test.ts
+++ b/app/electron/appimage-stamp.layout.test.ts
@@ -112,6 +112,18 @@ const home = "/home/tester";
 const xdg = "/home/tester/xdg-data";
 
 /**
+ * Scanned rather than supplied, because `LINUX_APP_BIN` is
+ * `$LINUX_APP_DIR/${APP_NAME}.AppImage`: a test-invented `APP_NAME` would keep
+ * expanding to today's name after install.sh renamed it, still match the
+ * `Vayu.AppImage` that `appimage-stamp.ts` hardcodes, and leave this guard green
+ * while the installer wrote a differently named binary.
+ *
+ * HOME and XDG_DATA_HOME stay invented - they are the shell's environment, not
+ * install.sh's definitions, and each case exists to pick one of their branches.
+ */
+const appName = shellValue("APP_NAME");
+
+/**
  * Both halves of `LINUX_DATA_HOME`'s `${XDG_DATA_HOME:-...}`. Each case names
  * the shell environment and the `resolveStampPath` environment together, so a
  * scenario cannot describe one side of the duplication and not the other.
@@ -119,13 +131,13 @@ const xdg = "/home/tester/xdg-data";
 const cases = [
 	{
 		what: "with XDG_DATA_HOME unset, so the layout falls back to $HOME",
-		shell: { APP_NAME: "Vayu", HOME: home },
+		shell: { APP_NAME: appName, HOME: home },
 		app: { platform: "linux", home },
 		expectedDataHome: `${home}/.local/share`,
 	},
 	{
 		what: "with XDG_DATA_HOME set, which the installer honours",
-		shell: { APP_NAME: "Vayu", HOME: home, XDG_DATA_HOME: xdg },
+		shell: { APP_NAME: appName, HOME: home, XDG_DATA_HOME: xdg },
 		app: { platform: "linux", home, xdgDataHome: xdg },
 		expectedDataHome: xdg,
 	},
@@ -137,9 +149,13 @@ describe("the Linux layout, as install.sh defines it", () => {
 		// every assertion below would compare "" to "" and pass.
 		expect(installer.length).toBeGreaterThan(1000);
 		expect(shellValue("LINUX_DATA_HOME")).toContain("XDG_DATA_HOME");
+		expect(appName).not.toBe("");
 		const linux = layoutFor(cases[0].shell);
 		expect(linux.LINUX_DATA_HOME).toBe(`${home}/.local/share`);
 		expect(linux.LINUX_APP_DIR).toContain("/vayu");
+		// A pin, not an invented constant: only one side of this comparison is
+		// scanned, so it fails when install.sh renames APP_NAME - which is the
+		// point, since `appimage-stamp.ts` spells the same name in source.
 		expect(linux.LINUX_APP_BIN).toContain("Vayu.AppImage");
 		expect(linux.LINUX_VERSION_FILE).toContain("/vayu/");
 	});


### PR DESCRIPTION
## Description

`app/electron/appimage-stamp.layout.test.ts` guards the "move one, move both" duplication between `install.sh` and `appimage-stamp.ts`, and since #277 it scans `LINUX_DATA_HOME` and the rest of the layout out of the installer via `shellValue()`. Both cases still supplied `APP_NAME` as a test-invented `"Vayu"` - and `APP_NAME` is the one variable `LINUX_APP_BIN` interpolates (`$LINUX_APP_DIR/${APP_NAME}.AppImage`).

**Plan.** Root cause: the invented constant sits on *both* sides of the assertion chain. If `install.sh` renamed `APP_NAME`, the test would keep expanding `LINUX_APP_BIN` with the stale name, that stale name would still match the `"Vayu.AppImage"` hardcoded at `appimage-stamp.ts:70`, and the guard would stay green while the installer wrote a differently named binary - the exact invented-constant class the file's own header forbids. Approach: scan `APP_NAME` with the existing `shellValue()` helper and feed it into both cases, so one side of the comparison now tracks the installer. The alternative I rejected was deriving `appimage-stamp.ts:70`'s `"Vayu.AppImage"` from a shared constant the test also pins; the issue explicitly scopes that out, and it would not add coverage here - the assertion chain through `LINUX_APP_BIN` is what fails on a rename either way, and a shared constant would only move the literal rather than remove a hole.

The `"Vayu.AppImage"` literal in the `scans definitions rather than nothing` sanity test is kept deliberately: only one side of that comparison is scanned now, so it is a pin (it fails on a rename), not a hole. A comment says so, since a future reader could otherwise "fix" it into a tautology.

Verified the problem still exists as described at master `6b5cc15` - the invented literals were at `:122` and `:128`, as the issue anchors them.

## Type of Change
- [x] Bug fix (a test guard that could not fail)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Mutation check in both directions, per the issue - `APP_NAME="Vayu"` renamed to `"VayuRenamed"` in `install.sh`, then restored:

| | old test | this PR |
|---|---|---|
| `APP_NAME` renamed in `install.sh` | **7 passed** (the hole) | **5 failed / 2 passed** |
| `install.sh` unmodified | 7 passed | 7 passed |

The old guard passing 7/7 under the rename is the defect; `resolveStampPath` now correctly returns `null` for the renamed binary and the layout assertions fail.

Full suite on the restored tree:

- `cd app && pnpm test` - **288 files, 2537 tests, all passed**
- `cd app && pnpm type-check` - clean
- `cd app && pnpm lint` - clean (zero warnings)
- `pnpm prettier --check` on the touched file - clean

No engine build or ctest run: the diff is one app-side test file, so no C++ test could change colour (repo verification-scaling rule). No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - this is the test change
- [x] I have updated documentation - none applies; no doc describes this guard's internals

## Related Issues
Closes #294

---
_Generated by [Claude Code](https://claude.ai/code/session_016Gq5atw4KXUYzPeY4QYaKo)_