### PR TITLE
docs(engine): drop two comments describing the EAV read path deleted by #177

### DIFF
--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -291,9 +291,12 @@ struct MetricTickSample {
 /**
  * @brief Serialize a tick sample into the stored `metric_ticks.payload` object.
  *
- * Key set and value types are the contract `GET /runs/:id/metrics` returns; the
- * legacy EAV reader in `http/routes/metrics.cpp` builds the same object from
- * ~18 rows, and stats_route_test.cpp pins the two against each other.
+ * Key set and value types are the contract `GET /runs/:id/metrics` returns:
+ * `http/routes/metrics.cpp` serves each stored row as one `data[]` entry, so
+ * whatever this writes is what the app reads. Since issue #177 there is no
+ * second implementation of the object to cross-check against, so
+ * stats_route_test.cpp pins this payload directly against the shape the app's
+ * `LoadTestMetrics` expects - see its comment above the pinning test.
  */
 [[nodiscard]] nlohmann::json build_metric_tick_payload (const MetricTickSample& sample);
 

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -342,7 +342,8 @@ TEST (RunReportConfigTest, OmitsFollowRedirectsAndMaxRedirectsWhenAbsent) {
 }
 
 // ============================================================================
-// GET /runs/:id/report - the stored summary vs the legacy metric rows
+// GET /runs/:id/report - the stored whole-run summary, and the sampled-results
+// fallback when it is malformed or absent
 // ============================================================================
 
 // The whole-run results a completed load run stores on its row.


### PR DESCRIPTION
## Description

Two comments still described the legacy EAV metrics read path that #177 deleted.

**Plan.** Root cause: #177 removed the second implementation of the tick object (the EAV reader) but left behind the comments that pointed at it, so the header comment on `build_metric_tick_payload` sends a reader looking for a cross-check that no longer exists - it is actively misleading, not merely stale. Approach: state the contract's real source in each place - `http/routes/metrics.cpp` serves each stored `metric_ticks` row as one `data[]` entry, and `stats_route_test.cpp` pins the payload directly against the app's `LoadTestMetrics` shape (its own comment at `:144-149` already says this correctly, so the header now points there rather than restating it). The alternative I rejected was deleting the second paragraph outright: the comment's job is to tell the next reader where the contract is enforced, and dropping it would trade a wrong answer for no answer.

Verified at master `6b5cc15` that the problem still exists as the issue anchors it: `run_manager.hpp:293-296` still named the EAV reader, and `metrics.cpp` reads only `metric_ticks` (`:51` `get_metric_ticks_paginated`, `:99-101` "metric_ticks is the only time series").

The `runs_route_test.cpp` banner claimed "the stored summary vs the legacy metric rows"; the section compares nothing against legacy rows. Its tests cover the stored whole-run summary (`ReportReadsTheStoredSummary`, retention/omission cases) and the sampled-results fallback when that summary is malformed or absent (`MalformedSummaryReportsFromSampledResults`, `RunWithNoSummaryReportsFromSampledResults`), so the banner now names both.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (comment-only)

## Testing

No tests run, and none could change colour: the diff is two comment blocks, one in a header and one a test section banner - no statement, signature or assertion is touched. This is the repo's verification-scaling rule (a comment edit does not warrant an engine rebuild or a ctest run).

Checks that do apply:

- Acceptance criterion re-run on the branch: `rg -i "legacy EAV|legacy metric rows" engine/` now returns two hits, both correct as written and both deliberately kept - `stats_route_test.cpp:145` (the intentional historical note that describes the deletion) and `database.cpp:515` (the comment on `drop_table_if_exists("metrics")`, which describes live migration code, not a reader). Nothing left claims the reader exists.
- `clang-format --dry-run` on both files: the touched lines are clean. Both files carry pre-existing formatting drift under clang-format 18 elsewhere (`run_manager.hpp:147-206`, `runs_route_test.cpp:266-391`, etc.) which reproduces on the base commit - not touched, not hidden.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable, comment-only
- [x] I have updated documentation - this is the documentation change; no `docs/` page describes these comments

## Related Issues
Closes #293

Noted while verifying, deliberately left out of this diff (same defect class, different files, outside the issue's engine-only acceptance criterion): `docs/engine/api-reference.md:1913` and `app/src/types/domain.ts:710` both say a report can "fall back to the legacy metric rows", which is no longer a path that exists - the fallback is the run's sampled results. Filed separately rather than widening this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014r7JhrLcNF2mwDEZWoT6J8)_