### PR TITLE
docs: name the sampled-results fallback in two httpVersionDowngraded notes

### DIFF
--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -707,11 +707,12 @@ export interface RunReport {
 		 *
 		 * `0` is "none recorded", not "none happened" - an engine from 0.15.0
 		 * always emits the key, including for a run whose stored summary
-		 * predates the count and for one reported from the legacy metric rows,
-		 * neither of which can produce a figure. `undefined` therefore only
-		 * means the sidecar itself is older than 0.15.0, and reads the same way
-		 * as 0 here: no warning. Weaker than the per-response
-		 * `httpVersionDowngraded` above, which is exact for its exchange.
+		 * predates the count and for one reported from its sampled results
+		 * because that summary was malformed or never written, neither of which
+		 * can produce a figure. `undefined` therefore only means the sidecar
+		 * itself is older than 0.15.0, and reads the same way as 0 here: no
+		 * warning. Weaker than the per-response `httpVersionDowngraded` above,
+		 * which is exact for its exchange.
 		 */
 		httpVersionDowngraded?: number;
 	};

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1910,10 +1910,11 @@ protocol other than the one `metadata.configuration.httpVersion` names.
 
 **`0` is "none recorded", not "none happened".** An engine from 0.15.0 always
 emits the key - including for a run whose stored summary predates the count, and
-for one that fell back to the legacy metric rows, neither of which can produce a
-figure. The key is absent only from an engine older than 0.15.0. That is
-deliberately a weaker guarantee than the per-response
-`httpVersionDowngraded`, which is exact for the exchange it describes.
+for one reported from its sampled results because that summary was malformed or
+never written, neither of which can produce a figure. The key is absent only
+from an engine older than 0.15.0. That is deliberately a weaker guarantee than
+the per-response `httpVersionDowngraded`, which is exact for the exchange it
+describes.
 
 `sampling` says how much each bounded store thinned away: all zeros means the
 `results[]` array and the tested responses are the complete set, and a non-zero


### PR DESCRIPTION
## Description

Two notes explaining why `summary.httpVersionDowngraded` can be `0` listed, as one of the two runs that cannot produce a figure, "one that fell back to the legacy metric rows" - a source that no longer exists.

**Plan.** Root cause: #177 deleted the legacy EAV read path, but these two sentences survived it. Verified against master `6b5cc15` before editing - `apply_run_summary` (`engine/src/http/routes/runs.cpp:148-166`) now logs "reporting from the sampled results alone" and leaves the report standing on the run's sampled `results` when the stored summary is malformed or absent, pinned by `MalformedSummaryReportsFromSampledResults` and `RunWithNoSummaryReportsFromSampledResults`. The conclusion each note draws is still correct - `http_version_downgraded` is only ever read off the stored summary (`runs.cpp:183`), so the sampled-results path cannot produce a count either - so the approach is to rename the fallback and leave both sentences otherwise intact, keeping them mirrors of each other as the issue asks. The alternative I rejected was dropping the clause entirely: the sentence needs both cases to justify "`0` is 'none recorded'", and deleting one would weaken a guarantee that has not changed.

Blast radius: the TSDoc sits on `LoadTestReport['summary']['httpVersionDowngraded']`. That field is read (`RunSummaryCards`, the report view) but the comment is documentation only - no type, value or behaviour changes, so there is no consumer to update.

Scope note: `rg -i "legacy metric rows"` also hits `engine/tests/runs_route_test.cpp:345`. That one is **already fixed by #297** (open, green), which #298 was deliberately split from - I left it alone rather than create a conflicting edit. After both land the phrase is gone repo-wide.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Per CLAUDE.md this is a doc page plus a TSDoc comment - no test could change colour, so no suites were run.

- `rg -i "legacy metric rows" docs/ app/` returns nothing (acceptance criterion 1).
- `pnpm type-check` - passes (3 tsc projects, clean).
- `prettier --check app/src/types/domain.ts` - clean.
- `docs/engine/api-reference.md` is **not** prettier-clean, and was not on master either (verified by stashing and re-checking), so per CLAUDE.md's "format only files you touched that were clean before" it was left unformatted. It is outside `pnpm format:check`'s glob, which is rooted at `app/`.
- `mkdocs build --strict` was not run - mkdocs is not installed in this container. No link, heading or nav entry is touched, so as the issue notes this is a formality here; CI's docs gate covers it.

No pre-existing failures encountered.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - N/A, comment/doc text only
- [x] I have updated documentation - this PR *is* the documentation update

## Related Issues

Closes #298

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5Q11NowzzVqzEh652w89y)_