### PR TITLE
feat(engine): read the response's Set-Cookie through pm.response.cookies

### DIFF
--- a/app/src/modules/request-builder/components/ResponseViewer/parse-set-cookie.conformance.test.ts
+++ b/app/src/modules/request-builder/components/ResponseViewer/parse-set-cookie.conformance.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Cross-language conformance: this parser against the engine's copy
+ * (`engine/src/http/set_cookie.cpp`, behind `pm.response.cookies`), over the
+ * fixture both suites read.
+ *
+ * The two parse the same `Set-Cookie` off the same response - one for the
+ * Cookies tab, one for a script - so a case answered two ways is a user reading
+ * one thing on screen and asserting another in a test. Adding a case here fails
+ * whichever side does not handle it, the same arrangement
+ * `variable-resolution.conformance.test.ts` uses for `{{variable}}` resolution.
+ *
+ * Read from the engine tree on purpose: one file, two readers, no copy to drift.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parseSetCookie, type ParsedCookie } from "./parse-set-cookie";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(
+	here,
+	"..",
+	"..",
+	"..",
+	"..",
+	"..",
+	"..",
+	"engine",
+	"tests",
+	"fixtures",
+	"set-cookie-conformance.json"
+);
+
+interface ConformanceCase {
+	name: string;
+	header: string;
+	expected: ParsedCookie[];
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+	cases: ConformanceCase[];
+};
+
+describe("set-cookie conformance fixture", () => {
+	it("scanned a non-empty fixture (guards the scan itself)", () => {
+		expect(fixture.cases.length).toBeGreaterThan(10);
+	});
+
+	it.each(fixture.cases.map((c) => [c.name, c] as const))("%s", (_name, c) => {
+		expect(parseSetCookie(c.header)).toEqual(c.expected);
+	});
+});

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -19,6 +19,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Core                | `pm`, `pm.test(name, fn)`, `pm.expect(value)`                                    |
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()` |
 | Response headers    | `pm.response.headers.get(name)`, `.has(name)` - case-insensitive              |
+| Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
 | Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url`, `.method`, `.headers`, `.body`                                 |
 | Request headers     | `pm.request.headers.get/has(name)`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
@@ -174,6 +175,37 @@ chain - a misspelling, or an idiom Vayu does not implement such as the negated
 expression statement, so a name that merely evaluated to `undefined` would
 report PASS against a broken API.
 
+### Response cookies (`pm.response.cookies`)
+
+```javascript
+pm.response.cookies.get('session');   // value, or undefined
+pm.response.cookies.has('session');   // boolean
+pm.response.cookies.toObject();       // { session: 'abc' }
+pm.response.cookies[0].attrs;         // ['Path=/', 'HttpOnly'] - raw chunks
+```
+
+An array of `{ name, value, attrs }` in wire order, parsed from that one
+response's `Set-Cookie`. It is **not** Postman's `CookieList` and its entries
+are not `postman-collection` `Cookie` objects: there is no `key`, no `path`,
+no `secure`, no `expires`, because the engine keeps no cookie jar and those
+fields would be a restatement of the attribute string rather than state
+anything holds. `attrs` is that string, split on `;` and untouched otherwise.
+
+Three divergences worth knowing before porting a script:
+
+- **No jar.** A cookie a response sets is not sent on the next request
+  (`pm.cookies.*` is absent for the same reason). Reuse a session by reading
+  the value here and setting the header yourself.
+- **Names are case-sensitive**, unlike header names - `get('SESSION')` does not
+  find the `session` cookie. RFC 6265 says they differ, and answering anyway
+  would be a wrong value dressed as a right one.
+- **A repeated name answers with its last value** from `get()` / `toObject()`,
+  which is the one a browser's jar would keep, while the array still lists both.
+
+The parse is shared with the response Cookies tab in the UI through
+`engine/tests/fixtures/set-cookie-conformance.json`, so a cookie cannot read one
+way on screen and another in a script.
+
 ---
 
 ## Not (yet) supported
@@ -196,7 +228,10 @@ These Postman APIs are **not** implemented - scripts that rely on them will fail
   below) or writes the JavaScript for it. The supported set and the reasoning
   are in [variable resolution](./variable-resolution.md#dynamic-variables)
 - `pm.iterationData.*` - data-file driven runs
-- `pm.cookies.*`, and `pm.response.cookies`
+- `pm.cookies.*` - the cookie jar. Vayu keeps none, so there is nothing to read
+  or set, and a cookie a response sets is not carried into the next request.
+  `pm.response.cookies` **is** supported (see above); it reads that one
+  response's `Set-Cookie` and nothing more
 - `pm.request.url.query` / `.path` / `.host` - and any other `url.*` accessor.
   `pm.request.url` is a writable **string** that the write-back requires to still
   be one, and a JS string primitive cannot carry properties; boxing it would

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -138,6 +138,7 @@ pm.response.text()            // Body as string
 pm.response.json()            // Parse JSON (throws if invalid)
 pm.response.reason()          // Status reason phrase ('OK', 'Not Found')
 pm.response.size()            // { body, header, total } in bytes
+pm.response.cookies           // Set-Cookie, parsed - see below
 ```
 
 `reason()` reports the reason phrase from the status line. Where none was
@@ -167,6 +168,42 @@ works. Prefer the methods unless you know the exact key.
 
 The response object has **no** `add`/`upsert`/`remove` - the response has
 already arrived, so a mutator there would only appear to change something.
+
+### Reading response cookies
+
+```javascript
+pm.response.cookies.get('session');    // value, or undefined if unset
+pm.response.cookies.has('session');    // boolean
+pm.response.cookies.toObject();        // { session: 'abc', tracker: 't1' }
+pm.response.cookies.length;            // it is an array, in wire order
+pm.response.cookies[0].name;           // 'session'
+pm.response.cookies[0].value;          // 'abc'
+pm.response.cookies[0].attrs;          // ['Path=/', 'HttpOnly'] - raw chunks
+```
+
+`cookies` is what the response's `Set-Cookie` header carried, parsed - an array
+of `{ name, value, attrs }` with `get()` / `has()` / `toObject()` over it.
+Attributes are the raw `;`-separated chunks in wire order; there are no
+`path` / `secure` / `expires` fields, because the engine keeps no cookie jar
+and would only be re-stating the string.
+
+Three things follow from that, and they are the ones worth knowing:
+
+- **Nothing here is sent.** Vayu has no cookie jar (issue #301 step 2), so a
+  cookie a response sets is not carried into the next request. Reading it and
+  setting a header yourself is the way to reuse a session today.
+- **Cookie names are case-sensitive**, unlike header names: `get('SESSION')`
+  does not answer the `session` cookie. That is what RFC 6265 says, and
+  answering otherwise would be a wrong value dressed as a right one.
+- **A name set twice answers with the last value** from `get()` and
+  `toObject()` - the one a browser's jar would keep - while the array still
+  lists both, because that is what came off the wire.
+
+The parse is shared with the app's response Cookies tab through a conformance
+fixture (`engine/tests/fixtures/set-cookie-conformance.json`), so the value a
+script asserts on and the value shown in the UI cannot drift. It handles the two
+cases a naive split corrupts: a comma inside `Expires=Wed, 21 Oct ...` is not a
+cookie boundary, and the `=` padding on a base64 value stays in the value.
 
 ### Response Assertions
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -266,6 +266,7 @@ add_library(vayu_core STATIC
     src/http/thread_pool.cpp
     src/http/rate_limiter.cpp
     src/http/script_parts.cpp
+    src/http/set_cookie.cpp
     src/utils/json.cpp
     src/utils/logger.cpp
     src/utils/metrics_helper.cpp
@@ -421,6 +422,7 @@ if(VAYU_BUILD_TESTS)
         tests/error_shape_route_test.cpp
         tests/globals_route_test.cpp
         tests/script_variables_test.cpp
+        tests/set_cookie_test.cpp
         tests/stats_route_test.cpp
         tests/execution_timeout_test.cpp
         tests/execution_http_version_test.cpp

--- a/engine/include/vayu/http/set_cookie.hpp
+++ b/engine/include/vayu/http/set_cookie.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/set_cookie.hpp
+ * @brief Parse a response's `Set-Cookie` header into name / value / attributes.
+ *
+ * The renderer has had this parser since the response Cookies tab was fixed
+ * (`app/src/modules/request-builder/components/ResponseViewer/parse-set-cookie.ts`);
+ * this is the engine's copy, for `pm.response.cookies`. Two copies of a parser
+ * drift, so they are pinned to each other by the cross-language fixture
+ * `tests/fixtures/set-cookie-conformance.json`, read by
+ * `tests/set_cookie_test.cpp` (gtest) and
+ * `parse-set-cookie.conformance.test.ts` (vitest) - the same arrangement
+ * `variable-resolution-conformance.json` uses for `{{variable}}` resolution.
+ *
+ * The two cases a naive `split(",")` / `split("=")` corrupts - and that the
+ * fixture exists to keep both sides handling - are documented on
+ * `parse_set_cookie` below.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace vayu::http {
+
+/**
+ * @brief One cookie read off a `Set-Cookie` header.
+ */
+struct SetCookie {
+    std::string name;
+    std::string value;
+    /// Everything after the name=value pair, one entry per `;` chunk, in wire
+    /// order and unparsed ("Path=/", "HttpOnly"). Structured attribute
+    /// accessors wait for the cookie jar (#301 step 2) - a script that needs
+    /// one reads the string today rather than being handed a field the engine
+    /// does not really keep.
+    std::vector<std::string> attrs;
+};
+
+/**
+ * @brief Parse a `Set-Cookie` header value.
+ *
+ * Handles the two cases that make this more than a split:
+ *
+ *   - **The expiry comma.** Multiple `Set-Cookie` headers reach a single
+ *     header value joined by ", ", so a comma is a cookie boundary - except
+ *     inside `Expires=Wed, 21 Oct 2015 07:28:00 GMT`. A new cookie only starts
+ *     where a comma is followed by `name=`, which the remainder of a date
+ *     never matches.
+ *   - **The `=` in a value.** Session cookies are routinely base64 and end in
+ *     `=` padding, so the pair splits at the *first* `=` and the rest of the
+ *     chunk is the value verbatim.
+ *
+ * A chunk with no `=`, or one whose `=` is the first character (an unnamed
+ * cookie), is dropped rather than reported as a cookie with an empty name.
+ *
+ * @param header Raw header value, e.g. `id=a3fWa; Path=/; HttpOnly`.
+ * @return The cookies in wire order; empty for a header that names none.
+ */
+std::vector<SetCookie> parse_set_cookie (std::string_view header);
+
+} // namespace vayu::http

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -141,6 +141,41 @@ nlohmann::json get_script_completions () {
     { "documentation", "Whether the response carries a header of that name, case-insensitively." },
     { "sortText", "1_pm_response_headers_has" } });
 
+    completions.push_back ({ { "label", "pm.response.cookies" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.response.cookies" }, { "detail", "object" },
+    { "documentation",
+    "The response's Set-Cookie header, parsed: an array of { name, value, "
+    "attrs } in wire order, with get()/has()/toObject() over it. `attrs` "
+    "holds the raw attribute chunks ('Path=/', 'HttpOnly'). Read-only - vayu "
+    "keeps no cookie jar, so nothing here is sent on a later request." },
+    { "sortText", "1_pm_response_cookies" } });
+
+    completions.push_back ({ { "label", "pm.response.cookies.get" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.cookies.get(\"${1:session}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.response.cookies.get(name: string): string | undefined" },
+    { "documentation",
+    "The value of a cookie the response set, or undefined when it set none of "
+    "that name. Cookie names are case-sensitive. A name set twice answers with "
+    "the last value, which is the one a browser would keep.\n\nExample:\nconst "
+    "session = pm.response.cookies.get('session');" },
+    { "sortText", "1_pm_response_cookies_get" } });
+
+    completions.push_back ({ { "label", "pm.response.cookies.has" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.cookies.has(\"${1:session}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.response.cookies.has(name: string): boolean" },
+    { "documentation", "Whether the response set a cookie of that name (case-sensitive)." },
+    { "sortText", "1_pm_response_cookies_has" } });
+
+    completions.push_back ({ { "label", "pm.response.cookies.toObject" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.response.cookies.toObject()" },
+    { "detail", "pm.response.cookies.toObject(): object" },
+    { "documentation",
+    "Every cookie the response set, as a name-to-value object. Attributes are "
+    "not included - read them off the array entries' `attrs`." },
+    { "sortText", "1_pm_response_cookies_to_object" } });
+
     completions.push_back ({ { "label", "pm.response.reason" }, { "kind", KIND_FUNCTION },
     { "insertText", "pm.response.reason()" }, { "detail", "pm.response.reason(): string" },
     { "documentation",

--- a/engine/src/http/set_cookie.cpp
+++ b/engine/src/http/set_cookie.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/set_cookie.cpp
+ * @brief `Set-Cookie` parsing. See `vayu/http/set_cookie.hpp` for why this
+ *        exists twice (here and in the renderer) and what pins the two copies.
+ */
+
+#include "vayu/http/set_cookie.hpp"
+
+#include <cctype>
+
+namespace vayu::http {
+
+namespace {
+
+bool is_space (char c) {
+    return std::isspace (static_cast<unsigned char> (c)) != 0;
+}
+
+std::string trim (std::string_view s) {
+    size_t begin = 0;
+    size_t end   = s.size ();
+    while (begin < end && is_space (s[begin])) {
+        begin++;
+    }
+    while (end > begin && is_space (s[end - 1])) {
+        end--;
+    }
+    return std::string (s.substr (begin, end - begin));
+}
+
+/**
+ * @brief Whether the comma at @p comma starts a new cookie.
+ *
+ * The renderer spells this as a lookahead - `/,\s*(?=[^;,\s=]+=)/` - and this
+ * is the same rule read by hand: skip whitespace, then require at least one
+ * character that is not `;`, `,`, whitespace or `=`, then an `=`. A date's
+ * " 21 Oct 2015 07:28:00 GMT" fails at the first space before any `=`, so an
+ * `Expires` comma is not a boundary.
+ */
+bool starts_new_cookie (std::string_view header, size_t comma) {
+    size_t i = comma + 1;
+    while (i < header.size () && is_space (header[i])) {
+        i++;
+    }
+    const size_t name_start = i;
+    while (i < header.size () && !is_space (header[i]) && header[i] != ';' &&
+    header[i] != ',' && header[i] != '=') {
+        i++;
+    }
+    return i > name_start && i < header.size () && header[i] == '=';
+}
+
+/// Read one `name=value; attr; attr` chunk. Returns false for a chunk that
+/// names no cookie, so the caller drops it.
+bool parse_chunk (std::string_view chunk, SetCookie& out) {
+    const size_t first_semicolon = chunk.find (';');
+    const std::string_view pair  = chunk.substr (0, first_semicolon);
+
+    const size_t equals = pair.find ('=');
+    if (equals == 0 || equals == std::string_view::npos) {
+        return false;
+    }
+
+    out.name = trim (pair.substr (0, equals));
+    // The remainder verbatim, not a second split - a base64 value's `=`
+    // padding is part of the value.
+    out.value = trim (pair.substr (equals + 1));
+
+    size_t at = first_semicolon;
+    while (at != std::string_view::npos) {
+        const size_t next           = chunk.find (';', at + 1);
+        const std::string_view attr = chunk.substr (at + 1,
+        next == std::string_view::npos ? std::string_view::npos : next - at - 1);
+        std::string trimmed         = trim (attr);
+        if (!trimmed.empty ()) {
+            out.attrs.push_back (std::move (trimmed));
+        }
+        at = next;
+    }
+    return true;
+}
+
+} // namespace
+
+std::vector<SetCookie> parse_set_cookie (std::string_view header) {
+    std::vector<SetCookie> cookies;
+
+    size_t chunk_start = 0;
+    for (size_t i = 0; i <= header.size (); i++) {
+        const bool at_end = i == header.size ();
+        if (!at_end && (header[i] != ',' || !starts_new_cookie (header, i))) {
+            continue;
+        }
+        SetCookie cookie;
+        if (parse_chunk (header.substr (chunk_start, i - chunk_start), cookie)) {
+            cookies.push_back (std::move (cookie));
+        }
+        chunk_start = i + 1;
+    }
+
+    return cookies;
+}
+
+} // namespace vayu::http

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "vayu/http/request_composer.hpp"
+#include "vayu/http/set_cookie.hpp"
 #include "vayu/http/status.hpp"
 #include "vayu/utils/encoding.hpp"
 #include "vayu/utils/json.hpp"
@@ -2718,6 +2719,168 @@ JSValue js_response_size (JSContext* ctx, JSValueConst this_val, int argc, JSVal
     return size;
 }
 
+// ============================================================================
+// pm.response.cookies
+// ============================================================================
+
+// Methods hang off the list without being enumerable, so Object.keys() and a
+// spread over it see cookies and nothing else.
+constexpr int COOKIE_METHOD_FLAGS = JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE;
+
+// Cookie names are case-sensitive (RFC 6265 §4.1.1) - unlike header names, so
+// this is an exact match and not `header_names_equal`.
+//
+// The last definition wins: a response that sets the same name twice leaves the
+// later value in a browser's jar, so that is the one a script asking "what is
+// the session cookie now" has to be told.
+const vayu::http::SetCookie*
+find_cookie (const std::vector<vayu::http::SetCookie>& cookies, const std::string& name) {
+    for (auto it = cookies.rbegin (); it != cookies.rend (); ++it) {
+        if (it->name == name) {
+            return &*it;
+        }
+    }
+    return nullptr;
+}
+
+// The list methods read the response rather than the array they were reached
+// through, so editing the array cannot make get() disagree with the wire. The
+// re-parse is bounded by one header and only happens when a script calls one.
+std::optional<std::vector<vayu::http::SetCookie>> cookies_from_context (JSContext* ctx) {
+    auto* data = get_context_data (ctx);
+    if (!data || !data->response) {
+        JS_ThrowInternalError (ctx, "No response available");
+        return std::nullopt;
+    }
+    auto it = data->response->headers.find ("set-cookie");
+    if (it == data->response->headers.end ()) {
+        return std::vector<vayu::http::SetCookie>{};
+    }
+    return vayu::http::parse_set_cookie (it->second);
+}
+
+// A cookie name is a non-empty string or nothing - the same rule the header
+// methods apply, for the same reason: coercing a number would invent a name.
+std::optional<std::string>
+read_cookie_name_arg (JSContext* ctx, const char* member, int argc, JSValueConst* argv) {
+    if (argc < 1 || !JS_IsString (argv[0])) {
+        JS_ThrowTypeError (ctx, "cookies.%s(name) needs a cookie name string, got %s",
+        member, argc < 1 ? "no argument" : js_type_name (ctx, argv[0]));
+        return std::nullopt;
+    }
+    std::string name = js_to_string (ctx, argv[0]);
+    if (name.empty ()) {
+        JS_ThrowTypeError (ctx, "cookies.%s(name) needs a non-empty cookie name", member);
+        return std::nullopt;
+    }
+    return name;
+}
+
+JSValue js_cookies_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto name = read_cookie_name_arg (ctx, "get", argc, argv);
+    if (!name) {
+        return JS_EXCEPTION;
+    }
+    auto cookies = cookies_from_context (ctx);
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    const auto* cookie = find_cookie (*cookies, *name);
+    // Postman answers undefined for an absent cookie; a throw would make the
+    // common `if (cookies.get(x))` guard unwritable.
+    return cookie ? JS_NewString (ctx, cookie->value.c_str ()) : JS_UNDEFINED;
+}
+
+JSValue js_cookies_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto name = read_cookie_name_arg (ctx, "has", argc, argv);
+    if (!name) {
+        return JS_EXCEPTION;
+    }
+    auto cookies = cookies_from_context (ctx);
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    return JS_NewBool (ctx, find_cookie (*cookies, *name) != nullptr);
+}
+
+JSValue js_cookies_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    auto cookies = cookies_from_context (ctx);
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    // Plain assignment, so a name set twice ends on its last value - the same
+    // answer get() gives.
+    JSValue obj = JS_NewObject (ctx);
+    for (const auto& cookie : *cookies) {
+        JS_SetPropertyStr (ctx, obj, cookie.name.c_str (),
+        JS_NewString (ctx, cookie.value.c_str ()));
+    }
+    return obj;
+}
+
+JSValue create_cookie_list (JSContext* ctx, const std::vector<vayu::http::SetCookie>& cookies) {
+    JSValue list = JS_NewArray (ctx);
+    if (JS_IsException (list)) {
+        return list;
+    }
+
+    uint32_t index = 0;
+    for (const auto& cookie : cookies) {
+        JSValue entry = JS_NewObject (ctx);
+        JS_SetPropertyStr (ctx, entry, "name", JS_NewString (ctx, cookie.name.c_str ()));
+        JS_SetPropertyStr (ctx, entry, "value", JS_NewString (ctx, cookie.value.c_str ()));
+        JSValue attrs = JS_NewArray (ctx);
+        uint32_t attr_index = 0;
+        for (const auto& attr : cookie.attrs) {
+            JS_SetPropertyUint32 (ctx, attrs, attr_index++, JS_NewString (ctx, attr.c_str ()));
+        }
+        JS_SetPropertyStr (ctx, entry, "attrs", attrs);
+        JS_SetPropertyUint32 (ctx, list, index++, entry);
+    }
+
+    JS_DefinePropertyValueStr (ctx, list, "get",
+    JS_NewCFunction (ctx, js_cookies_get, "get", 1), COOKIE_METHOD_FLAGS);
+    JS_DefinePropertyValueStr (ctx, list, "has",
+    JS_NewCFunction (ctx, js_cookies_has, "has", 1), COOKIE_METHOD_FLAGS);
+    JS_DefinePropertyValueStr (ctx, list, "toObject",
+    JS_NewCFunction (ctx, js_cookies_to_object, "toObject", 0), COOKIE_METHOD_FLAGS);
+    return list;
+}
+
+// pm.response.cookies - the response's Set-Cookie header, parsed.
+//
+// Registered as a getter that replaces itself with the parsed list on first
+// read. A load run executes a test script per completed request, and eager
+// parsing would charge every one of them for a header no script asked about;
+// caching the result keeps `pm.response.cookies[0] === pm.response.cookies[0]`
+// true within a script, which a fresh array per access would not.
+JSValue js_response_cookies (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)argc;
+    (void)argv;
+    auto cookies = cookies_from_context (ctx);
+    if (!cookies) {
+        return JS_EXCEPTION;
+    }
+    JSValue list = create_cookie_list (ctx, *cookies);
+    if (JS_IsException (list)) {
+        return list;
+    }
+    if (JS_IsObject (this_val)) {
+        if (JS_DefinePropertyValueStr (ctx, this_val, "cookies", JS_DupValue (ctx, list),
+            JS_PROP_C_W_E) < 0) {
+            // Caching is an optimisation - a rejected redefinition must not
+            // fail the read the script actually asked for.
+            JS_FreeValue (ctx, JS_GetException (ctx));
+        }
+    }
+    return list;
+}
+
 void setup_pm_response (JSContext* ctx, JSValue pm) {
     auto* data = get_context_data (ctx);
 
@@ -2781,6 +2944,18 @@ void setup_pm_response (JSContext* ctx, JSValue pm) {
             define_header_entry (ctx, headers, key, value);
         }
         JS_SetPropertyStr (ctx, response, "headers", headers);
+
+        // pm.response.cookies - a getter, so a script that never mentions
+        // cookies never pays for the parse. Configurable because the getter
+        // replaces itself with the list it built.
+        JSAtom cookies_atom = JS_NewAtom (ctx, "cookies");
+        // Enumerable like every other member of pm.response, so
+        // console.log(pm.response) and JSON.stringify show it rather than
+        // hiding a documented property behind its own laziness.
+        JS_DefinePropertyGetSet (ctx, response, cookies_atom,
+        JS_NewCFunction (ctx, js_response_cookies, "cookies", 0), JS_UNDEFINED,
+        JS_PROP_CONFIGURABLE | JS_PROP_ENUMERABLE);
+        JS_FreeAtom (ctx, cookies_atom);
 
         // pm.response.to.have chain for Postman-compatible assertions
         JS_SetPropertyStr (ctx, response, "to", create_response_to_object (ctx));

--- a/engine/tests/fixtures/set-cookie-conformance.json
+++ b/engine/tests/fixtures/set-cookie-conformance.json
@@ -1,0 +1,113 @@
+{
+  "$comment": "Cross-language conformance fixture for Set-Cookie parsing (issue #301). Read by BOTH the engine gtest suite (set_cookie_test.cpp, via VAYU_ENGINE_SOURCE_DIR) and the app's vitest suite (app/src/modules/request-builder/components/ResponseViewer/parse-set-cookie.conformance.test.ts). The engine parses for pm.response.cookies, the renderer for the response Cookies tab; both read the same header off the same response, so a case answered two ways is a user seeing one thing in the UI and asserting another in a script. Every case is a raw header value exactly as it reaches a client - the two documented corruptions (a comma inside Expires, `=` padding inside a base64 value) are the reason this parser is not a split.",
+  "cases": [
+    {
+      "name": "a single cookie with attributes",
+      "header": "session=abc123; Path=/; HttpOnly",
+      "expected": [{ "name": "session", "value": "abc123", "attrs": ["Path=/", "HttpOnly"] }]
+    },
+    {
+      "name": "the comma inside Expires is not a cookie boundary",
+      "header": "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly",
+      "expected": [
+        {
+          "name": "id",
+          "value": "a3fWa",
+          "attrs": ["Expires=Wed, 21 Oct 2015 07:28:00 GMT", "Secure", "HttpOnly"]
+        }
+      ]
+    },
+    {
+      "name": "a base64 value keeps its = padding",
+      "header": "session=dGhpcyBpcyBhIHRlc3Q=; Path=/",
+      "expected": [
+        { "name": "session", "value": "dGhpcyBpcyBhIHRlc3Q=", "attrs": ["Path=/"] }
+      ]
+    },
+    {
+      "name": "a base64 value keeps both = of its padding",
+      "header": "token=YWJjZA==; Secure",
+      "expected": [{ "name": "token", "value": "YWJjZA==", "attrs": ["Secure"] }]
+    },
+    {
+      "name": "multiple Set-Cookie headers arrive joined by a comma",
+      "header": "a=1; Path=/, b=2; Path=/api",
+      "expected": [
+        { "name": "a", "value": "1", "attrs": ["Path=/"] },
+        { "name": "b", "value": "2", "attrs": ["Path=/api"] }
+      ]
+    },
+    {
+      "name": "joined cookies where the first carries an expiry comma",
+      "header": "a=1; Expires=Wed, 21 Oct 2015 07:28:00 GMT, b=2; HttpOnly",
+      "expected": [
+        { "name": "a", "value": "1", "attrs": ["Expires=Wed, 21 Oct 2015 07:28:00 GMT"] },
+        { "name": "b", "value": "2", "attrs": ["HttpOnly"] }
+      ]
+    },
+    {
+      "name": "joined cookies with no space after the comma",
+      "header": "a=1,b=2",
+      "expected": [
+        { "name": "a", "value": "1", "attrs": [] },
+        { "name": "b", "value": "2", "attrs": [] }
+      ]
+    },
+    {
+      "name": "a comma inside a value is kept when no name= follows it",
+      "header": "pref=dark,compact; Path=/",
+      "expected": [{ "name": "pref", "value": "dark,compact", "attrs": ["Path=/"] }]
+    },
+    {
+      "name": "a cookie cleared by the server has an empty value",
+      "header": "logged_out=; Path=/; Max-Age=0",
+      "expected": [{ "name": "logged_out", "value": "", "attrs": ["Path=/", "Max-Age=0"] }]
+    },
+    {
+      "name": "surrounding whitespace belongs to neither name nor value",
+      "header": "  a = 1 ;  Path=/  ",
+      "expected": [{ "name": "a", "value": "1", "attrs": ["Path=/"] }]
+    },
+    {
+      "name": "empty attribute chunks are dropped",
+      "header": "a=1;;Path=/;",
+      "expected": [{ "name": "a", "value": "1", "attrs": ["Path=/"] }]
+    },
+    {
+      "name": "an attribute-only header names no cookie",
+      "header": "HttpOnly; Secure",
+      "expected": []
+    },
+    {
+      "name": "a header with no = at all names no cookie",
+      "header": "garbage",
+      "expected": []
+    },
+    {
+      "name": "an unnamed cookie is not a cookie",
+      "header": "=orphan; Path=/",
+      "expected": []
+    },
+    {
+      "name": "an empty header",
+      "header": "",
+      "expected": []
+    },
+    {
+      "name": "a nameless chunk is no boundary, so it stays inside the value before it",
+      "header": "a=1, =orphan, b=2",
+      "expected": [
+        { "name": "a", "value": "1, =orphan", "attrs": [] },
+        { "name": "b", "value": "2", "attrs": [] }
+      ]
+    },
+    {
+      "name": "the same name set twice - both are reported, in wire order",
+      "header": "sid=old; Path=/, sid=new; Path=/",
+      "expected": [
+        { "name": "sid", "value": "old", "attrs": ["Path=/"] },
+        { "name": "sid", "value": "new", "attrs": ["Path=/"] }
+      ]
+    }
+  ]
+}

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -214,6 +214,40 @@ TEST (ScriptCompletions, EveryOfferedHeaderMemberIsCallableInTheRuntime) {
     EXPECT_GE (offered, 7) << "the header accessors are missing from the completion list";
 }
 
+// Same guard for the cookie list (#301). It is offered one level down
+// (`pm.response.cookies.get`), so a member the runtime lacks would only show up
+// when a user accepts the suggestion and the script throws.
+TEST (ScriptCompletions, EveryOfferedCookieMemberIsCallableInTheRuntime) {
+    const auto completions = get_script_completions ();
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request;
+    vayu::Response response;
+    vayu::Environment env;
+    request.method       = vayu::HttpMethod::GET;
+    request.url          = "https://api.example.com/users";
+    response.status_code = 200;
+    response.headers     = { { "set-cookie", "session=abc; Path=/" } };
+    response.body        = R"({"ok": true})";
+
+    int offered = 0;
+    for (const auto& item : completions) {
+        const std::string label = item.value ("label", std::string{});
+        if (label.rfind ("pm.response.cookies.", 0) != 0) {
+            continue;
+        }
+        offered++;
+
+        const std::string script = "pm.environment.set('t', typeof " + label + ");";
+        auto result              = engine.execute_test (script, request, response, env);
+        ASSERT_TRUE (result.success) << label << ": " << result.error_message;
+        EXPECT_EQ (env["t"].value, "function")
+        << label << " is offered as a call but the runtime does not implement it";
+    }
+
+    EXPECT_GE (offered, 3) << "the cookie accessors are missing from the completion list";
+}
+
 // The same drift, on the variable scopes: `pm.variables` was offered by
 // `scripting.md` for months while the runtime had no such object, and every
 // scope method added in #184 is invisible in the editor until it is listed

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -2630,6 +2630,134 @@ TEST_F (ScriptEngineTest, ResponseExposesTextNotABodyProperty) {
 }
 
 // ============================================================================
+// pm.response.cookies (issue #301)
+// ============================================================================
+//
+// Parsing lives in `vayu::http::parse_set_cookie` and is pinned case-by-case
+// against the renderer's copy by `set_cookie_test.cpp` and the shared fixture.
+// What these tests own is the *script surface*: that the header reaches the
+// sandbox at all, in the shape the docs teach, and that a bad call fails loudly
+// rather than reading as "no such cookie".
+
+TEST_F (ScriptEngineTest, ResponseCookiesExposeNameValueAndAttributes) {
+    response.headers["set-cookie"] =
+    "session=dGhpcyBpcyBhIHRlc3Q=; Path=/; HttpOnly, "
+    "tracker=t1; Expires=Wed, 21 Oct 2015 07:28:00 GMT";
+
+    auto result = engine.execute_test (R"JS(
+        var cookies = pm.response.cookies;
+        pm.environment.set('count', String(cookies.length));
+        pm.environment.set('names', cookies.map(function (c) { return c.name; }).join(','));
+        // The base64 padding survives - a split('=') would have cut it off.
+        pm.environment.set('session', String(cookies.get('session')));
+        pm.environment.set('attrs', cookies[0].attrs.join('|'));
+        // The expiry comma is not a cookie boundary, so tracker keeps its date.
+        pm.environment.set('trackerAttrs', cookies[1].attrs.join('|'));
+        pm.environment.set('has', String(cookies.has('tracker')));
+        pm.environment.set('missing', String(cookies.has('nope')));
+        pm.environment.set('absent', String(cookies.get('nope')));
+        pm.environment.set('flat', JSON.stringify(cookies.toObject()));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["count"].value, "2");
+    EXPECT_EQ (env["names"].value, "session,tracker");
+    EXPECT_EQ (env["session"].value, "dGhpcyBpcyBhIHRlc3Q=");
+    EXPECT_EQ (env["attrs"].value, "Path=/|HttpOnly");
+    EXPECT_EQ (env["trackerAttrs"].value, "Expires=Wed, 21 Oct 2015 07:28:00 GMT");
+    EXPECT_EQ (env["has"].value, "true");
+    EXPECT_EQ (env["missing"].value, "false");
+    EXPECT_EQ (env["absent"].value, "undefined");
+    EXPECT_EQ (env["flat"].value, R"({"session":"dGhpcyBpcyBhIHRlc3Q=","tracker":"t1"})");
+}
+
+// A response that set nothing still has to answer `.length` and `.get()` -
+// `if (pm.response.cookies.has('session'))` is the first line anyone writes,
+// and it cannot throw on the common case.
+TEST_F (ScriptEngineTest, ResponseCookiesAreAnEmptyListWithoutASetCookieHeader) {
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('isArray', String(Array.isArray(pm.response.cookies)));
+        pm.environment.set('count', String(pm.response.cookies.length));
+        pm.environment.set('has', String(pm.response.cookies.has('session')));
+        pm.environment.set('keys', Object.keys(pm.response.cookies.toObject()).join(','));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["isArray"].value, "true");
+    EXPECT_EQ (env["count"].value, "0");
+    EXPECT_EQ (env["has"].value, "false");
+    EXPECT_EQ (env["keys"].value, "");
+}
+
+// A response may set the same name twice; a browser keeps the last one, so a
+// script asking "what is the session cookie now" has to be told the same.
+TEST_F (ScriptEngineTest, ResponseCookiesAnswerTheLastDefinitionOfARepeatedName) {
+    response.headers["set-cookie"] = "sid=old; Path=/, sid=new; Path=/";
+
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('get', String(pm.response.cookies.get('sid')));
+        pm.environment.set('count', String(pm.response.cookies.length));
+        pm.environment.set('flat', JSON.stringify(pm.response.cookies.toObject()));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["get"].value, "new");
+    // Both are still listed - the list is what the wire carried.
+    EXPECT_EQ (env["count"].value, "2");
+    EXPECT_EQ (env["flat"].value, R"({"sid":"new"})");
+}
+
+// Cookie names, unlike header names, are case-sensitive. Answering `SESSION`
+// with the `session` cookie would be a wrong value dressed as a right one.
+TEST_F (ScriptEngineTest, ResponseCookieNamesAreCaseSensitive) {
+    response.headers["set-cookie"] = "session=lower";
+
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('exact', String(pm.response.cookies.get('session')));
+        pm.environment.set('shouted', String(pm.response.cookies.get('SESSION')));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["exact"].value, "lower");
+    EXPECT_EQ (env["shouted"].value, "undefined");
+}
+
+// An unusable argument throws instead of reading as "no such cookie" - the
+// silent-false-answer defect the pm.* sweep (#180) exists to keep out.
+TEST_F (ScriptEngineTest, ResponseCookieLookupRejectsANonStringName) {
+    response.headers["set-cookie"] = "session=abc";
+
+    for (const char* call : { "pm.response.cookies.get(1)",
+         "pm.response.cookies.has()", "pm.response.cookies.get('')" }) {
+        auto result =
+        engine.execute_test (std::string (call) + ";", request, response, env);
+        EXPECT_FALSE (result.success) << call << " was accepted";
+        EXPECT_NE (result.error_message.find ("cookie name"), std::string::npos)
+        << call << " threw, but not about the name: " << result.error_message;
+    }
+}
+
+// The property is a getter that caches, so that a load run's per-request test
+// script does not parse a header it never reads. Identity is the observable
+// half of that: a fresh array per access would make this false and would
+// quietly discard anything a script stashed on the list.
+TEST_F (ScriptEngineTest, ResponseCookiesAreTheSameListThroughoutAScript) {
+    response.headers["set-cookie"] = "session=abc";
+
+    auto result = engine.execute_test (R"JS(
+        pm.environment.set('same', String(pm.response.cookies === pm.response.cookies));
+    )JS",
+    request, response, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["same"].value, "true");
+}
+
+// ============================================================================
 // Header accessors (pm.response.headers / pm.request.headers)
 // ============================================================================
 //

--- a/engine/tests/set_cookie_test.cpp
+++ b/engine/tests/set_cookie_test.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file tests/set_cookie_test.cpp
+ * @brief Set-Cookie parsing (issue #301), driven by the cross-language
+ *        conformance fixture.
+ *
+ * `tests/fixtures/set-cookie-conformance.json` is the contract between this
+ * suite and the app's vitest suite
+ * (`app/src/modules/request-builder/components/ResponseViewer/parse-set-cookie.conformance.test.ts`):
+ * the engine parses the header for `pm.response.cookies`, the renderer parses
+ * the same header for the response Cookies tab, and a case answered two ways
+ * is a user reading one thing on screen and asserting another in a script.
+ * Add a case to the fixture and whichever side does not handle it goes red.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/http/set_cookie.hpp"
+
+using nlohmann::json;
+
+namespace {
+
+json load_fixture () {
+    const std::filesystem::path path = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
+    "tests" / "fixtures" / "set-cookie-conformance.json";
+    std::ifstream in (path);
+    EXPECT_TRUE (in.good ()) << "fixture missing: " << path;
+    return json::parse (in);
+}
+
+} // namespace
+
+TEST (SetCookieConformance, EveryFixtureCasePasses) {
+    const json fixture = load_fixture ();
+    ASSERT_FALSE (fixture["cases"].empty ())
+    << "conformance fixture scanned nothing";
+
+    for (const auto& c : fixture["cases"]) {
+        const std::string name = c["name"].get<std::string> ();
+        const auto parsed =
+        vayu::http::parse_set_cookie (c["header"].get<std::string> ());
+        const auto& expected = c["expected"];
+
+        ASSERT_EQ (parsed.size (), expected.size ()) << "case: " << name;
+        for (size_t i = 0; i < parsed.size (); i++) {
+            EXPECT_EQ (parsed[i].name, expected[i]["name"].get<std::string> ())
+            << "case: " << name << " [" << i << "]";
+            EXPECT_EQ (parsed[i].value, expected[i]["value"].get<std::string> ())
+            << "case: " << name << " [" << i << "]";
+            EXPECT_EQ (parsed[i].attrs,
+            expected[i]["attrs"].get<std::vector<std::string>> ())
+            << "case: " << name << " [" << i << "]";
+        }
+    }
+}
+
+// The fixture is a table of headers; this is the rule behind it, stated once so
+// a case added later cannot be "fixed" by loosening the boundary back into the
+// naive split the renderer's parser was written to replace.
+TEST (SetCookie, ACommaOnlyEndsACookieWhenAnAssignmentFollowsIt) {
+    // Every comma here sits inside a date, so a naive split would report six
+    // cookies with names like "21 Oct 2015 07:28:00 GMT".
+    const auto parsed =
+    vayu::http::parse_set_cookie ("a=1; Expires=Wed, 21 Oct 2015 07:28:00 GMT, "
+                                  "b=2; Expires=Thu, 22 Oct 2015 07:28:00 GMT");
+    ASSERT_EQ (parsed.size (), 2U);
+    EXPECT_EQ (parsed[0].name, "a");
+    EXPECT_EQ (parsed[0].value, "1");
+    EXPECT_EQ (parsed[1].name, "b");
+    EXPECT_EQ (parsed[1].value, "2");
+}


### PR DESCRIPTION
## Description

Step 1 of #301: `pm.response.cookies`, read-only, over the `Set-Cookie` header the response already carries. **The cookie jar (step 2) is deliberately not in this PR** - see Deviations.

**The plan.** Root cause: the header was already on `Response::headers` (`types.hpp:238`) and nothing surfaced it, so a script could not see a cookie a response set. The approach is an accessor over state the engine already holds, with the parse shared with the renderer's existing `parse-set-cookie.ts` through a conformance fixture rather than re-derived - a second C++ parser that did not know the two cases the first one documents (a comma inside `Expires=Wed, 21 Oct ...`, `=` padding in a base64 value) would show one value in the Cookies tab and assert another in a script, which is exactly the drift `variable-resolution-conformance.json` exists to prevent. The alternative I rejected was porting the regex into C++ and testing each side separately: that is two tables of cases that agree today and diverge on the next edit, and the fixture costs one file to make divergence a failing test instead.

**Surface.** `pm.response.cookies` is an array of `{ name, value, attrs }` in wire order with `get()` / `has()` / `toObject()` over it:

```javascript
pm.response.cookies.get('session');   // value, or undefined
pm.response.cookies.has('session');   // boolean
pm.response.cookies.toObject();       // { session: 'abc' }
pm.response.cookies[0].attrs;         // ['Path=/', 'HttpOnly'] - raw chunks
```

Three decisions worth reviewing, all documented and tested:

- **A self-replacing getter, not an eager property.** A load run executes a test script per completed request; eager parsing would charge every one of them for a header no script asked about. First read parses and caches, so `pm.response.cookies === pm.response.cookies` stays true.
- **Cookie names are case-sensitive** (RFC 6265), unlike header names - `get('SESSION')` does not answer the `session` cookie. Answering anyway would be a wrong value dressed as a right one.
- **A repeated name answers with its last value** from `get()` / `toObject()` (what a browser's jar would keep) while the array still lists both, because that is what came off the wire.

Entries are not `postman-collection` `Cookie` objects - no `key`, `path`, `secure`, `expires`, because the engine keeps no jar and those fields would restate the attribute string rather than name state anything holds. `attrs` is that string split on `;`. The divergence is written down in `pm-api-compatibility.md` rather than half-emulated.

Bad input fails loudly: `get(1)`, `has()` and `get('')` throw a `TypeError` naming the argument instead of reading as "no such cookie".

Completions gain the three members (`pm.response.cookies` / `.get` / `.has` / `.toObject`), which is also where the editor's `.d.ts` comes from since `script_types.cpp` derives it from that table, plus a guard that every offered cookie member is callable in the runtime - the `#182` drift, one level down.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

Re-run on the merge commit, after master moved (#300 / PR #305 landed in the same three files):

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **831 / 831 pass**.
- `cd app && pnpm test` - **2557 / 2557 pass** in 289 files, including the 18 new conformance cases.
- `cd app && pnpm type-check`, `pnpm lint`, `prettier --check` on the new file - clean.

(The pre-merge run had one failure, `HttpClientTest.UnnegotiatedConnectionReportsEmptyHttpVersion`: this container's `HTTPS_PROXY` makes libcurl route `http://127.0.0.1:1/` through the proxy instead of failing fast with connection-refused, so it hits the 2 s timeout. It passed on the re-run, and passes with the proxy variables unset either way. Environmental, untouched by this diff.)

New tests (9 in the engine, 18 in the app):

- `set_cookie_test.cpp` - drives all 17 fixture cases, plus the boundary rule stated on its own so a later case cannot be "fixed" by loosening it back into the naive split. Both assert the fixture scanned something non-empty.
- `parse-set-cookie.conformance.test.ts` - the same fixture against the renderer's parser.
- `script_engine_test.cpp` - six over the script surface: the shape and both corruption cases end-to-end, an empty list without the header, the repeated-name rule, case-sensitivity, the throw on an unusable name, and list identity (which is the observable half of the caching getter - revert the cache and it goes red).
- `script_completions_test.cpp` - every offered cookie member is a function at run time.

Mutation-checked: reverting the boundary rule to `split(",")` fails the expiry cases on both sides; reverting the value slice to `split("=")` fails the base64 cases; dropping the reverse search fails the repeated-name test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs in the same commit: `docs/engine/scripting.md` (the `pm` surface and the three rules above), `docs/app/pm-api-compatibility.md` (moved out of "Not (yet) supported" with the divergences from Postman spelled out; `pm.cookies.*` stays listed as absent, now saying the *jar* is what is missing).

## Deviations from the issue spec

- **Step 2 (the cookie jar) is not here, deliberately.** The issue says to consider stopping after step 1 if the jar's questions are unsettled, and they are: scope / lifetime / persistence / thread-safety have no answer yet, a jar is credential-grade state that should reuse whatever auth storage already does rather than open a new path, and the load path it would touch (`event_loop_worker.cpp`) is what #197 is currently re-tuning. Shipping a jar to make a deadline is exactly the stopgap `CLAUDE.md` says not to accept. `pm.cookies.*` therefore stays in "Not (yet) supported" and #301 stays open for it.
- **No app UI change**, per the issue: with only step 1 landing there is no jar to inspect or clear, so the app change is the doc line and nothing else. The MCP question (does a jar cross `run_request` calls) is a step-2 question and is untouched.
- **Anchor drift found while reading.** #301 says `pm-api-compatibility.md` no longer carries the unread-cookie-attributes defect - correct, `attrs` is rendered, and I did not go looking for it.
- **Adjacent defect, filed rather than fixed here**: `header_callback` does `headers[key] = value` in both HTTP paths, so a response sending **two** `Set-Cookie` headers keeps only the last - the parser handles the comma-joined form the renderer documents, but the engine never produces it from separate headers. That is a `Response::headers` semantics change with a blast radius across every header consumer, so it does not belong in this diff. Filed as #307.

## Related Issues

Refs #301 (step 1 of two; the jar keeps it open), part of #188.
