### PR TITLE
feat(engine): `pm.sendRequest` - synchronous, bounded, and refused for MCP-started runs

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -464,6 +464,38 @@ describe("dispatchTool", () => {
 		expect(payload.postRequestScript).toBe("pm.test('ok', function () {});");
 	});
 
+	test("no execute tool asks the engine for pm.sendRequest, and an agent cannot ask for it", async () => {
+		// The allowlist is checked here, before the engine is called, so a
+		// request issued from inside a script could never be checked (issue
+		// #302). The engine therefore denies script-issued requests unless the
+		// payload says otherwise - and this layer must never say otherwise.
+		//
+		// Both halves matter. The first is that nothing here sets the field.
+		// The second is that an agent cannot set it either: the tool builds its
+		// request from named arguments, and the inputSchema does not declare
+		// `allowScriptRequests`, so zod strips it before it can ride through
+		// composition. Asserting only the first would stay green if the handler
+		// ever started spreading raw args into the payload.
+		const tool = TOOLS.find((t) => t.name === "run_request");
+		const args = z.object(tool!.inputSchema as Record<string, z.ZodTypeAny>).parse({
+			url: "https://api.example.com/users",
+			allowScriptRequests: true,
+			preRequestScript: "pm.sendRequest('https://evil.example.com', function () {});",
+		});
+		expect(args).not.toHaveProperty("allowScriptRequests");
+
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"run_request",
+			args,
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+
+		expect(res.isError).toBeFalsy();
+		const payload = (client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload).not.toHaveProperty("allowScriptRequests");
+	});
+
 	test("start_load_run does not offer a pre-request script", () => {
 		// POST /runs never runs one - only the deferred `tests` script - so
 		// offering the field would promise a hook that silently does nothing.

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/script-variants.tsx
@@ -84,6 +84,7 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 			'delete pm.request.headers["Authorization"]',
 			'pm.request.url = pm.request.url + "?trace=1"',
 			"pm.request.body = JSON.stringify({ n: 2 })",
+			"pm.sendRequest(url, (err, res) => { ... })",
 			"pm.info.requestName",
 		],
 		notes: [
@@ -118,6 +119,14 @@ export const SCRIPT_VARIANTS: Record<ScriptVariant, ScriptVariantConfig> = {
 				<code className={CODE_CLASS}>btoa</code> / <code className={CODE_CLASS}>atob</code>{" "}
 				are there too. No <code className={CODE_CLASS}>URL</code> parser in the sandbox, and
 				load tests do not run pre-request scripts at all.
+			</>,
+			<>
+				<code className={CODE_CLASS}>pm.sendRequest</code> fetches a token before the
+				request goes out. It is synchronous - the callback runs before it returns, and there
+				is no promise form - and bounded: its timeout is capped at whatever is left of the
+				script&apos;s time budget, and one script may send at most 10 requests. Connection,
+				DNS and timeout failures arrive as the callback&apos;s first argument rather than
+				throwing.
 			</>,
 			<>
 				<code className={CODE_CLASS}>pm.info</code> says where the script is running:{" "}

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
@@ -553,7 +553,10 @@ export default function McpSettingsPanel() {
 					<CardDescription>
 						Hosts an agent is permitted to send traffic to. Empty means no outbound
 						requests are allowed - a safe default. Add a host (no scheme or port), e.g.{" "}
-						<code className="font-mono">api.example.com</code>.
+						<code className="font-mono">api.example.com</code>. The list is checked
+						before Vayu sends anything, so a script an agent writes cannot reach around
+						it: <code className="font-mono">pm.sendRequest</code> is refused entirely
+						for requests an agent starts, and works normally when you Send from Vayu.
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-3">

--- a/app/src/services/api.script-requests.test.ts
+++ b/app/src/services/api.script-requests.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The renderer's opt-in to `pm.sendRequest` (issue #302).
+ *
+ * The engine denies script-issued requests unless the payload carries
+ * `allowScriptRequests`, because Vayu's MCP target allowlist is checked in the
+ * MCP server *before* the engine is called - a request sent from inside a
+ * script never passes that gate. The renderer is the surface whose scripts the
+ * user wrote, so it asks; the MCP server never does (asserted in
+ * `electron/mcp/tools.test.ts`).
+ *
+ * Asserted on the captured body rather than on behaviour, for the same reason
+ * `api.write-verbs.test.ts` is: nothing about a Send changes shape when this
+ * regresses. The field would simply stop being sent and `pm.sendRequest` would
+ * start throwing at runtime with every other test still green - so the payload
+ * is the only layer that can catch it.
+ *
+ * Set inside the service rather than at each call site, so this also pins that
+ * a caller does not have to know about it: the two callers below pass no such
+ * field.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { apiService } from "./api";
+import { httpClient } from "./http-client";
+
+vi.mock("./http-client", () => ({
+	httpClient: {
+		get: vi.fn(),
+		post: vi.fn(),
+		put: vi.fn(),
+		delete: vi.fn(),
+	},
+}));
+
+const post = vi.mocked(httpClient.post);
+
+describe("the renderer opts its own executions into pm.sendRequest", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		post.mockResolvedValue({} as never);
+	});
+
+	it("sends allowScriptRequests on execute, without the caller passing it", async () => {
+		await apiService.executeRequest({ method: "GET", url: "https://example.com" });
+
+		expect(post).toHaveBeenCalledTimes(1);
+		const [, body] = post.mock.calls[0];
+		expect(body).toMatchObject({
+			url: "https://example.com",
+			allowScriptRequests: true,
+		});
+	});
+
+	it("sends allowScriptRequests on a load run - one Tests script, one behaviour", async () => {
+		await apiService.startLoadTest({ method: "GET", url: "https://example.com" } as never);
+
+		expect(post).toHaveBeenCalledTimes(1);
+		const [, body] = post.mock.calls[0];
+		expect(body).toMatchObject({ allowScriptRequests: true });
+	});
+
+	it("does not disturb the fields the caller did send", async () => {
+		await apiService.executeRequest({
+			method: "POST",
+			url: "https://example.com",
+			headers: { "X-A": "1" },
+			httpVersion: "http2",
+		});
+
+		const [, body] = post.mock.calls[0];
+		expect(body).toMatchObject({
+			method: "POST",
+			headers: { "X-A": "1" },
+			httpVersion: "http2",
+			allowScriptRequests: true,
+		});
+	});
+});

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -240,14 +240,35 @@ export const apiService = {
 		return await httpClient.post<ComposedRequest>(API_ENDPOINTS.COMPOSE_REQUEST, data);
 	},
 
+	/**
+	 * `allowScriptRequests` opts this execution's scripts into `pm.sendRequest`
+	 * (issue #302). The engine denies it unless asked, because Vayu's MCP target
+	 * allowlist is checked in the MCP server *before* it calls the engine - a
+	 * request issued from inside a script never passes that gate. The renderer
+	 * is the surface whose scripts the user wrote, so it asks; the MCP server
+	 * never does, and an agent cannot smuggle the field in because every MCP
+	 * tool builds its request from named arguments.
+	 *
+	 * Set here rather than at each call site, so a new caller cannot forget it
+	 * and quietly lose the feature - the same single-choke-point reason
+	 * `httpVersion` and the redirect policy are sent on every execute rather
+	 * than elided when they match a default.
+	 */
 	async executeRequest(data: ExecuteRequestRequest): Promise<SanityResult> {
-		return await httpClient.post<SanityResult>(API_ENDPOINTS.EXECUTE_REQUEST, data, {
-			timeout: proxiedRequestTimeoutMs(),
-		});
+		return await httpClient.post<SanityResult>(
+			API_ENDPOINTS.EXECUTE_REQUEST,
+			{ ...data, allowScriptRequests: true },
+			{ timeout: proxiedRequestTimeoutMs() }
+		);
 	},
 
+	/** A run's `tests` script is the same script Send runs - see executeRequest. */
+
 	async startLoadTest(data: StartLoadTestRequest): Promise<StartLoadTestResponse> {
-		return await httpClient.post<StartLoadTestResponse>(API_ENDPOINTS.START_LOAD_TEST, data);
+		return await httpClient.post<StartLoadTestResponse>(API_ENDPOINTS.START_LOAD_TEST, {
+			...data,
+			allowScriptRequests: true,
+		});
 	},
 
 	// Run Management

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -29,6 +29,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Merged variables    | `pm.variables.get(name)`, `.has(name)`, `.toObject()`, `.replaceIn(template)` - read-only, see below |
 | Script identity     | `pm.info.requestId`, `.requestName`, `.eventName` - each optional, see below     |
 | Crypto              | `pm.crypto.sha256(data, encoding?)`, `.hmacSha256(key, data, encoding?)` - synchronous, see below |
+| Send from script    | `pm.sendRequest(urlOrOptions, callback)` - synchronous, callback only, refused for agent-started runs, see below |
 | Base64              | `btoa(binaryString)`, `atob(base64)` - globals, standard web semantics           |
 | Console             | `console.log/info/warn/error`                                                    |
 
@@ -109,6 +110,75 @@ test's Tests script runs **once per sampled response, after the run
 finishes**, and samples are a reservoir rather than the first N iterations, so
 any number reported there would not be an iteration count. They return when
 there is a runner to count (issue #303).
+
+### `pm.sendRequest` is synchronous, callback-only, and not available to agents
+
+Three divergences from Postman, each for a reason the sandbox forces.
+
+**No promise form.** Postman offers both a callback and a promise-returning
+overload. Vayu ships only the callback, for the same reason `pm.crypto` is not
+`crypto.subtle`: nothing drains the job queue, so the promise could only never
+resolve. The callback is honoured **synchronously** - the send blocks and the
+callback runs inline, before `pm.sendRequest` returns - so the call shape a
+Postman user writes is unchanged and the semantics are honest.
+
+```javascript
+// Pre-request: fetch a token and put it where the request will find it.
+pm.sendRequest(
+	{
+		url: "https://auth.example.com/token",
+		method: "POST",
+		header: { "Content-Type": "application/json" },
+		body: { mode: "raw", raw: JSON.stringify({ client_id: "abc" }) },
+	},
+	function (err, res) {
+		if (err) {
+			return; // refused, DNS, or timeout - res is null
+		}
+		pm.environment.set("token", res.json().access_token);
+	}
+);
+```
+
+The callback receives `(err, res)`. A transport failure - connection refused, a
+host that does not resolve, a timeout - is the network's answer rather than the
+script's mistake, so it arrives as `err` (an `Error` carrying `.code`, e.g.
+`TIMEOUT`) with `res` null. The script's own mistakes throw instead: an
+unreadable argument, an unsupported body mode, the request cap, and the
+capability being off. `res` carries `code`, `status`, `responseTime`,
+`headers.get()/has()`, `json()` and `text()` - a subset of `pm.response`, with
+no assertion chain. `status` is the numeric code there too, so the two objects
+called a response do not disagree inside one sandbox.
+
+**It is bounded, and both bounds throw.** The request's timeout is clamped to
+whatever is left of the script's own time budget (`scriptTimeout`, 5s by
+default), because QuickJS only checks its deadline *between* bytecode
+operations - a blocking call never yields to it, so without the clamp a 5s
+script would hold its thread for the request's 30s timeout. One script may
+issue at most **10** requests; a load run's Tests script runs once per sampled
+response, so an uncapped loop would turn post-run validation into minutes of
+apparent hang.
+
+**Agents cannot use it.** Vayu's MCP target allowlist is enforced in the MCP
+server, against the composed URL, *before* it calls the engine - so a request
+issued from inside a script never passes that gate. Rather than leave a hole in
+a control the user configured in Settings, the engine refuses script-issued
+requests unless the caller explicitly asks for them: Vayu's own Send and load
+runs ask, and the MCP server never does. See
+[`docs/engine/mcp.md`](../engine/mcp.md#the-script-sandbox-surface).
+
+Only `raw` bodies are supported. Postman's `formdata` / `urlencoded` modes are
+refused by name rather than sent as an empty body - serialise the payload
+yourself and set the `Content-Type` header, which is the header that goes out
+either way since no content type is inferred from the mode. Headers may be
+Postman's `header` array of `{ key, value }` or a plain object under either
+`header` or `headers`; sending both spellings at once is refused rather than
+resolved by precedence.
+
+`{{variables}}` in a script-supplied URL are **not** resolved. Interpolation
+happens strictly before the pre-request script and a payload is resolved exactly
+once; a second pass inside the script would break that. Use
+`pm.variables.replaceIn(template)`.
 
 ### Hashing (`pm.crypto`) is Vayu's own name, and it is synchronous
 
@@ -238,7 +308,6 @@ way on screen and another in a script.
 
 These Postman APIs are **not** implemented - scripts that rely on them will fail:
 
-- `pm.sendRequest(...)` - sending auxiliary requests from a script
 - `pm.variables.set(...)` - throws; Vayu has no local scope to write to, so name
   one of the three scoped setters instead. The read half (`get`/`has`/`toObject`)
   is supported - see above

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1044,6 +1044,7 @@ If a non-interactive OAuth 2.0 token cannot be obtained, the engine still return
   "environmentId": "env_1234567890",  // Optional, uses environment variables
   "preRequestScript": "",              // Optional
   "postRequestScript": "pm.test('Status is 200', () => pm.expect(pm.response.code).to.equal(200));",
+  "allowScriptRequests": false,        // Optional, default false - see below
   "followRedirects": true,             // Optional, default true
   "maxRedirects": 10,                  // Optional, default 10
   "verifySSL": true,                   // Optional, default true
@@ -1060,6 +1061,17 @@ an id is enough. An empty string is treated as absent - a script reads
 `undefined` rather than `""` - and a non-string is a **400**
 (`'requestName' must be a string`). See
 [scripting.md](scripting.md#script-identity-pminfo).
+
+**`allowScriptRequests` lets this payload's scripts use `pm.sendRequest`.**
+Absent, `null` or non-boolean all mean `false`, and that default is a security
+control rather than a convenience (issue #302): Vayu's MCP target allowlist is
+checked in the MCP server, before it calls this endpoint, so a request issued
+from inside a script never passes that gate. Denying unless a caller asks means
+a client that forgets gets a script that cannot send rather than unchecked
+egress. The app's Send and load runs send `true`; the MCP server never does.
+`POST /runs` reads the same field for its deferred `tests` validation, so one
+script behaves the same on both. See
+[scripting.md](scripting.md#sending-a-request-from-a-script-pmsendrequest).
 
 **Script parts.** `preRequestScript` / `postRequestScript` above are the legacy
 single-string form and still work. The engine also accepts `preRequestScripts`

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -296,12 +296,52 @@ IDs).
 ### The script sandbox surface
 
 `preRequestScript` and `postRequestScript` run in the engine's QuickJS sandbox,
-which is the same sandbox the app's editors target - there is no per-client
-capability gate, so an agent can do anything a script in the app can. What an
-agent lacked was any way to *know* that: until issue #233 the entire script
-surface it could see was the two sentences in those fields' descriptions, so
-`pm.expect` chains, `pm.response.to.*`, the variable scopes and `pm.crypto` were
-invisible and simply never attempted.
+which is the same sandbox the app's editors target. There is exactly one
+per-client capability gate - `pm.sendRequest`, below - and an agent can do
+anything else a script in the app can. What an agent lacked was any way to
+*know* that: until issue #233 the entire script surface it could see was the two
+sentences in those fields' descriptions, so `pm.expect` chains,
+`pm.response.to.*`, the variable scopes and `pm.crypto` were invisible and
+simply never attempted.
+
+#### `pm.sendRequest` is refused for MCP-started runs
+
+The sandbox can send an auxiliary request (issue #302). That would be a hole in
+the allowlist if it applied here, and the reason is structural rather than an
+oversight: **the allowlist is checked in this server, against the composed URL,
+before it calls the engine.** A request issued from inside a script never goes
+through the MCP server at all, so it could never be checked - an agent that can
+write a script would otherwise reach any host, defeating a control the user set
+in Settings.
+
+Three ways to close that were available, and this is which one and why:
+
+- *Move the allowlist engine-side for script-issued requests.* Rejected. The
+  allowlist lives in the app's config, and the engine has no channel to it; the
+  engine would need a second implementation of host matching alongside
+  `safety.ts`'s - two copies of a security check, which drift. It would also
+  leave the engine enforcing an allowlist for one kind of request and not the
+  others, which is harder to reason about than either extreme.
+- *Gate the feature off by default behind a setting.* Rejected. It adds a knob
+  whose safe position is the only correct one for MCP, and the hole reopens the
+  moment anyone flips it for an unrelated reason.
+- **Refuse script-issued requests unless the caller explicitly asks.** Chosen.
+  The engine denies `pm.sendRequest` unless the execute/run payload carries
+  `allowScriptRequests: true`. The app's own Send and load runs ask for it, in
+  one place each (`apiService.executeRequest` / `startLoadTest`); this server
+  never does. The allowlist stays exactly where the user configured it, and the
+  engine gains a capability bit rather than a policy copy.
+
+Denying by **default** is the load-bearing half: a new tool here, or any future
+engine client, gets a script that cannot send rather than unchecked egress.
+An agent cannot set the field either - every tool builds its request from named
+arguments, so an `allowScriptRequests` in the arguments is dropped before
+composition, and Zod strips what a tool does not declare.
+
+A script that calls `pm.sendRequest` under MCP throws a message saying why, so
+an agent is told rather than left with a silently missing global. The
+completion entry states the same thing, so the surface an agent reads and the
+surface it gets agree.
 
 `vayu://scripting/completions` closes that. It re-serves the engine's own
 `GET /scripting/completions` - the single source of truth that also feeds Monaco,
@@ -333,12 +373,18 @@ Server-provided starting points a user picks in their client (`prompts.ts`):
 
 ## Safety model
 
-Enforced entirely in the MCP layer (`safety.ts`, `config.ts`); the engine is
-never modified. All configurable in **Settings → MCP** and persisted.
+Enforced in the MCP layer (`safety.ts`, `config.ts`), with one exception noted
+below: script-issued requests are refused engine-side, because this layer cannot
+see them. Nothing here changes engine *behaviour* for other clients. All
+configurable in **Settings → MCP** and persisted.
 
 - **Target allowlist** (default empty ⇒ deny all). Network-touching tools refuse
   off-list hosts with an actionable error. An **"Allow all hosts"** opt-in
   bypasses the list (still rejects unresolved `{{variables}}`); off by default.
+  Because the check happens here, before the engine is called, a request sent
+  from inside a script could not be checked at all - so `pm.sendRequest` is
+  refused outright for runs this server starts. See
+  [The script sandbox surface](#pmsendrequest-is-refused-for-mcp-started-runs).
 - **Hard caps** - max RPS / concurrency / duration on `start_load_run`; over-cap
   requests are rejected. With the allowlist, these are the real limits on load.
   The caps bound values from above; `concurrency` is additionally constrained to

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -497,6 +497,84 @@ payload holds the generated *value* and no scope has ever heard of the name.
 `pm.variables.get("$guid")` reads as any other undefined name does - reach the
 generators through `replaceIn`.
 
+## Sending a request from a script (`pm.sendRequest`)
+
+The one part of the sandbox that touches the network. Its reason for existing is
+the token fetch: a pre-request script that needs a credential the request itself
+cannot supply.
+
+```javascript
+pm.sendRequest(
+  {
+    url: "https://auth.example.com/token",
+    method: "POST",
+    header: { "Content-Type": "application/json" },
+    body: { mode: "raw", raw: JSON.stringify({ client_id: "abc" }) },
+  },
+  function (err, res) {
+    if (err) {
+      console.error("token fetch failed: " + err.message);
+      return;
+    }
+    pm.environment.set("token", res.json().access_token);
+  }
+);
+```
+
+The first argument is a URL string or an options object; the second is required
+and must be a function.
+
+| Option | Shape |
+| ------ | ----- |
+| `url` | string, required. Postman's URL-object form is not accepted |
+| `method` | string, default `GET`; case-insensitive, an unknown verb throws |
+| `header` / `headers` | `{ name: value }` or Postman's `[{ key, value }]`. Both names read; sending both at once throws |
+| `body` | a string, or `{ mode: 'raw', raw }`. Only `raw` - other modes throw |
+| `timeout` | milliseconds, clamped to the script's remaining budget (below) |
+
+**Synchronous, and callback-shaped for that reason.** The send blocks and the
+callback runs inline, before `pm.sendRequest` returns. There is no promise
+overload: `Promise` exists in the sandbox but nothing drains its job queue, so
+one could only never resolve - the same reason hashing is `pm.crypto` rather
+than `crypto.subtle`.
+
+**Which failures throw and which reach the callback.** Transport failures are
+the network's answer, so they arrive as the callback's `err` - an `Error` with
+a `.code` (`CONNECTION_FAILED`, `DNS_ERROR`, `TIMEOUT`, …) and `res` null. The
+script's own mistakes throw out of the call instead: an unusable argument, an
+unsupported body mode, exceeding the request cap, and the capability being off.
+
+`res` carries `code`, `status` (the numeric code, as on `pm.response`),
+`responseTime`, `headers` with `get()`/`has()`, `json()` and `text()`. It is a
+subset of `pm.response` and has no `to.*` assertion chain.
+
+**Two bounds, both hard.**
+
+- *The script's deadline.* The wall-clock limit is enforced by a QuickJS
+  interrupt handler, and QuickJS only calls it **between bytecode operations** -
+  a blocking C function never yields to it. So the request's timeout is clamped
+  to whatever is left of the script's budget; without that, a 5s script calling
+  `pm.sendRequest` at the default 30s request timeout would hold its thread for
+  30s with no error and no way to interrupt it. When `scriptTimeout` is `0`
+  there is no budget and nothing to clamp to.
+- *A request cap.* One script execution may issue at most **10** requests, then
+  throws. A load run's `tests` script runs once per *sampled* response, serially,
+  on the run's worker thread, so an uncapped loop would turn post-run validation
+  into minutes of apparent hang.
+
+**Not available to agents.** Vayu's MCP target allowlist is checked in the MCP
+server, against the composed URL, before it calls the engine - so a script-issued
+request never passes that gate. The engine therefore refuses script-issued
+requests unless the caller explicitly asks for them (`allowScriptRequests` on
+`POST /execute` / `POST /runs`); Vayu's own Send and load runs ask, and the MCP
+server never does. Calling it from an agent-started run throws a message saying
+so. See [MCP](mcp.md#the-script-sandbox-surface).
+
+**No `{{variable}}` resolution.** A script-supplied URL is sent as written.
+Interpolation happens strictly before the pre-request script and a payload is
+resolved exactly once; a second pass here would break that invariant. Use
+`pm.variables.replaceIn(template)`.
+
 ## Console Output
 
 Log messages that appear in test results:
@@ -787,6 +865,7 @@ and the rest of the ES2020 built-ins, plus:
 | ---- | ----- |
 | `pm.crypto.sha256(data, encoding?)` | SHA-256; `data` is a string (UTF-8) or `Uint8Array` |
 | `pm.crypto.hmacSha256(key, data, encoding?)` | HMAC-SHA256; key and data take the same types |
+| `pm.sendRequest(urlOrOptions, callback)` | Send an auxiliary request, synchronously - see [above](#sending-a-request-from-a-script-pmsendrequest) |
 | `btoa(binaryString)` | base64-encode one byte per code unit |
 | `atob(base64)` | decode to a binary string; throws on invalid base64 |
 
@@ -800,7 +879,9 @@ consequences: no URL parsing helper - which is why `pm.request.url` has no
 `.query` / `.path` accessors either, see
 [URL parts are not exposed](#url-parts-are-not-exposed-deferred) - no hash
 other than SHA-256 (no MD5, no SHA-1, nothing asymmetric), and nothing
-asynchronous.
+asynchronous. There is no `fetch`, but there **is**
+[`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest), which is
+synchronous and bounded rather than a Promise-returning stand-in.
 
 **Why the hashing surface is not called `crypto`.** Web Crypto's `crypto.subtle`
 is Promise-based. `Promise` exists here, but nothing drains the job queue - there
@@ -830,12 +911,17 @@ The **language** is current; what is missing is the **host environment**:
   `structuredClone` or `crypto.subtle` - see the table above for what replaces
   the ones that have a replacement.
 - **No Node.js APIs**: No `require()`, `fs`, `http`, etc.
-- **Sandboxed**: No filesystem or network access
+- **Sandboxed**: No filesystem access. The only network access is
+  [`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest) - capped at
+  10 requests per script, bounded by the script's own deadline, and refused
+  outright for agent-started runs.
 - **Memory limit**: 64MB per script execution
 - **Timeout**: 5 seconds per script (default), enforced by a wall-clock deadline - an
   infinite-loop script is aborted and reported as an error rather than hanging the
   engine. Configurable via the `scriptTimeout` setting (milliseconds); `0` disables
-  the limit.
+  the limit. The deadline is checked *between bytecode operations*, so it cannot
+  interrupt a blocking call - which is why `pm.sendRequest` clamps its own
+  timeout to the budget that is left rather than relying on it.
 
 ## Script Execution Context
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -423,6 +423,7 @@ if(VAYU_BUILD_TESTS)
         tests/globals_route_test.cpp
         tests/script_variables_test.cpp
         tests/script_info_test.cpp
+        tests/script_send_request_test.cpp
         tests/set_cookie_test.cpp
         tests/stats_route_test.cpp
         tests/execution_timeout_test.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -205,6 +205,18 @@ constexpr uint64_t TIMEOUT_MS = 5000;
 constexpr size_t STACK_SIZE = 256 * 1024;
 /// Whether to enable console output from scripts
 constexpr bool ENABLE_CONSOLE = true;
+/**
+ * @brief How many requests one script execution may issue via
+ *        `pm.sendRequest`.
+ *
+ * A cap rather than a knob because the failure it bounds is not the single
+ * script a user is watching: a load run's `tests` script runs once per
+ * *sampled* response, serially, on the run's worker thread, so an uncapped
+ * loop turns post-run validation into minutes of apparent hang. Ten is well
+ * above the token-fetch case the feature exists for and far below the point
+ * where a sampled run stops looking finished.
+ */
+constexpr int SEND_REQUEST_LIMIT = 10;
 } // namespace script_engine
 
 /**

--- a/engine/include/vayu/http/script_parts.hpp
+++ b/engine/include/vayu/http/script_parts.hpp
@@ -56,4 +56,21 @@ std::string read_pre_request_script (const nlohmann::json& json);
  */
 std::string read_post_request_script (const nlohmann::json& json);
 
+/**
+ * Whether this payload's scripts may issue requests through `pm.sendRequest`.
+ *
+ * Read under `allowScriptRequests`. **Absent, null or non-boolean all mean
+ * false**, which is the point: the MCP target allowlist is enforced in the MCP
+ * server, before it calls the engine, so a request issued from inside a script
+ * never passes that gate. Denying unless a caller explicitly asks puts the
+ * failure on the safe side - a client that forgets gets a script that cannot
+ * send rather than unchecked egress (issue #302).
+ *
+ * Lives here, beside the script readers, because `POST /execute` and the load
+ * path's deferred `tests` validation both read it and must agree: the same
+ * Tests script runs on a Send and on a run, so it cannot have the network in
+ * one and not the other.
+ */
+bool read_allow_script_requests (const nlohmann::json& json);
+
 } // namespace vayu::http

--- a/engine/include/vayu/runtime/script_engine.hpp
+++ b/engine/include/vayu/runtime/script_engine.hpp
@@ -34,6 +34,28 @@ struct ScriptConfig {
     uint64_t timeout_ms = vayu::core::constants::script_engine::TIMEOUT_MS;
     size_t stack_size   = vayu::core::constants::script_engine::STACK_SIZE;
     bool enable_console = vayu::core::constants::script_engine::ENABLE_CONSOLE;
+
+    /**
+     * @brief Whether scripts may issue requests through `pm.sendRequest`.
+     *
+     * **Defaults to false, and that default is the security control** (issue
+     * #302). The MCP target allowlist is enforced client-side, in the MCP
+     * server, against the composed URL before it calls `POST /execute` - a
+     * request issued from inside a script never passes that gate, because it
+     * never goes through the MCP server at all. So an agent that can write a
+     * script would otherwise reach any host, defeating a control the user
+     * configured in Settings.
+     *
+     * Denying by default puts the failure on the safe side: a client that
+     * forgets to ask - a new MCP tool, a future caller, a bare `curl` against
+     * the daemon - gets a script that cannot send, not silent egress. The
+     * app's own execute/run paths ask for it explicitly, exactly the way they
+     * send `followRedirects` rather than leaning on an engine default.
+     *
+     * `pm.sendRequest` is bound either way: when this is false it throws a
+     * message that names why, which is a better answer than a missing global.
+     */
+    bool allow_send_request = false;
 };
 
 /**

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -83,6 +83,13 @@ validate_scripts (std::shared_ptr<RunContext> context, vayu::db::Database& db, b
     "scriptStackSize", vayu::core::constants::script_engine::STACK_SIZE));
     script_config.enable_console = db.get_config_bool (
     "scriptEnableConsole", vayu::core::constants::script_engine::ENABLE_CONSOLE);
+    // Read off the run's own payload, through the same reader `POST /execute`
+    // uses. The `tests` script here is the same script a Send runs, so it must
+    // not have pm.sendRequest in one and not the other - and a run's script
+    // runs once per *sampled* response, which is what the per-script request
+    // cap is there to bound.
+    script_config.allow_send_request =
+    vayu::http::read_allow_script_requests (context->config);
 
     vayu::runtime::ScriptEngine engine (script_config);
     vayu::Environment env;

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -696,6 +696,10 @@ void register_execution_routes (RouteContext& ctx) {
         "scriptStackSize", vayu::core::constants::script_engine::STACK_SIZE));
         script_config.enable_console = ctx.db.get_config_bool (
         "scriptEnableConsole", vayu::core::constants::script_engine::ENABLE_CONSOLE);
+        // Payload-level, not config-level: whether a script may send is a
+        // property of *who asked for this execution*, not of the installation.
+        // Absent means no - see ScriptConfig::allow_send_request.
+        script_config.allow_send_request = vayu::http::read_allow_script_requests (json);
 
         vayu::runtime::ScriptEngine script_engine (script_config);
 

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -638,6 +638,36 @@ nlohmann::json get_script_completions () {
     { "sortText", "1_pm_variables_replaceIn" } });
 
     // ========================================
+    // pm.sendRequest - the one thing in the sandbox that touches the network
+    // ========================================
+    completions.push_back ({ { "label", "pm.sendRequest" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.sendRequest(${1:url}, function (err, res) {\n\t$0\n})" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail",
+    "pm.sendRequest(urlOrOptions: string | { url: string; method?: string; "
+    "header?: object; body?: string | { mode: 'raw'; raw: string }; timeout?: "
+    "number }, callback: (err: Error | null, res: any) => void): void" },
+    { "documentation",
+    "Send an auxiliary request - fetching a token in a pre-request script is "
+    "what it is for.\n\nSynchronous despite the callback: the sandbox has no "
+    "event loop, so the send blocks and the callback runs inline before "
+    "sendRequest returns. Postman's promise-returning overload is deliberately "
+    "absent - it could only never resolve.\n\nThe callback gets (err, res). "
+    "Transport failures - refused, DNS, timeout - arrive as err with a .code; "
+    "res is null then. res carries code, status, responseTime, headers.get() "
+    "and json()/text() - a subset of pm.response, not the assertion "
+    "chain.\n\nBounded on purpose: the request's timeout is capped "
+    "at whatever is left of the script's own time budget, and one script may "
+    "issue at most 10 requests. Both throw when exceeded.\n\n**Not available "
+    "to agents.** Vayu's MCP target allowlist is checked before the engine is "
+    "called, so a request sent from inside a script would bypass it. When a "
+    "run comes from the MCP server this throws instead of "
+    "sending.\n\nExample:\npm.sendRequest('https://auth.example.com/token', "
+    "function (err, res) {\n  if (err) { return; }\n  "
+    "pm.environment.set('token', res.json().access_token);\n});" },
+    { "sortText", "0_pm_sendRequest" } });
+
+    // ========================================
     // pm.crypto - Hashing, and the base64 globals that go with it
     // ========================================
     completions.push_back ({ { "label", "pm.crypto" }, { "kind", KIND_VARIABLE },

--- a/engine/src/http/script_parts.cpp
+++ b/engine/src/http/script_parts.cpp
@@ -83,4 +83,9 @@ std::string read_post_request_script (const nlohmann::json& json) {
     { "tests", "tests" } });
 }
 
+bool read_allow_script_requests (const nlohmann::json& json) {
+    auto field = json.find ("allowScriptRequests");
+    return field != json.end () && field->is_boolean () && field->get<bool> ();
+}
+
 } // namespace vayu::http

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+#include "vayu/http/client.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/set_cookie.hpp"
 #include "vayu/http/status.hpp"
@@ -60,6 +61,22 @@ namespace vayu::runtime {
 
 #ifdef VAYU_HAS_QUICKJS
 
+// Per-runtime deadline state for the interrupt handler. One instance is owned by
+// each pooled JSRuntime (stored as its runtime opaque) and refreshed before every
+// execution. QuickJS runtimes are single-threaded, and each pooled context pair is
+// used by one thread at a time, so no synchronization is needed here.
+//
+// Declared up here rather than beside the interrupt handler below because
+// `pm.sendRequest` reads the same deadline to bound a blocking call: QuickJS
+// only calls the interrupt handler *between bytecode operations*, so a C
+// function that blocks never yields to it and the deadline has to be consulted
+// by hand. One struct, so the budget the handler enforces and the budget the
+// clamp reads cannot drift.
+struct RuntimeState {
+    bool enabled = false; // false => no wall-clock limit (timeout_ms == 0)
+    std::chrono::steady_clock::time_point deadline{};
+};
+
 // ============================================================================
 // QuickJS Helper Functions
 // ============================================================================
@@ -80,11 +97,38 @@ struct ContextData {
     std::optional<ScriptEvent> event;
     bool has_error = false;
     std::string error_message;
+
+    /**
+     * Whether `pm.sendRequest` may send - see
+     * `ScriptConfig::allow_send_request` for why the default is deny.
+     */
+    bool allow_send_request = false;
+
+    /**
+     * How many requests this execution has already issued. Per-execution
+     * state, not per-context: contexts are pooled and reused, so a counter
+     * living on the context would let the first script spend the second
+     * script's budget.
+     */
+    int send_request_count = 0;
 };
 
 // Get context data from JS context
 ContextData* get_context_data (JSContext* ctx) {
     return static_cast<ContextData*> (JS_GetContextOpaque (ctx));
+}
+
+// Milliseconds left of this execution's wall-clock budget, or nullopt when the
+// engine was configured without one (timeout_ms == 0). May be negative: the
+// caller decides whether an already-blown budget is an error or a clamp.
+std::optional<int64_t> remaining_script_budget_ms (JSContext* ctx) {
+    auto* state = static_cast<RuntimeState*> (JS_GetRuntimeOpaque (JS_GetRuntime (ctx)));
+    if (!state || !state->enabled) {
+        return std::nullopt;
+    }
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    state->deadline - std::chrono::steady_clock::now ())
+    .count ();
 }
 
 // Convert JS string to C++ string
@@ -1965,28 +2009,62 @@ JSValue js_pm_expect (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
     return create_expectation (ctx, argv[0]);
 }
 
-JSValue js_response_json (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
-    auto* data = get_context_data (ctx);
-    if (!data->response) {
-        return JS_ThrowInternalError (ctx, "No response available");
-    }
+// json() and text() read the body bound to the function at build time rather
+// than the response hanging off the context, so `pm.response` and the response
+// a pm.sendRequest callback receives are served by one implementation instead
+// of two that can drift. Both are installed by `install_response_body_readers`.
+JSValue js_response_json (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
 
-    JSValue json = JS_ParseJSON (ctx, data->response->body.c_str (),
-    data->response->body.size (), "<response>");
+    size_t length    = 0;
+    const char* body = JS_ToCStringLen (ctx, &length, func_data[0]);
+    if (!body) {
+        return JS_EXCEPTION;
+    }
+    JSValue json = JS_ParseJSON (ctx, body, length, "<response>");
+    JS_FreeCString (ctx, body);
     if (JS_IsException (json)) {
+        // Replaces QuickJS's parse error, which names an offset into a string
+        // the script never sees.
+        JS_FreeValue (ctx, JS_GetException (ctx));
         return JS_ThrowTypeError (ctx, "Response body is not valid JSON");
     }
 
     return json;
 }
 
-JSValue js_response_text (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
-    auto* data = get_context_data (ctx);
-    if (!data->response) {
-        return JS_ThrowInternalError (ctx, "No response available");
-    }
+JSValue js_response_text (JSContext* ctx,
+JSValueConst this_val,
+int argc,
+JSValueConst* argv,
+int magic,
+JSValue* func_data) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
 
-    return JS_NewString (ctx, data->response->body.c_str ());
+    return JS_DupValue (ctx, func_data[0]);
+}
+
+// Install json()/text() on @p response, bound to @p body.
+void install_response_body_readers (JSContext* ctx, JSValue response, const std::string& body) {
+    JSValue bound = JS_NewStringLen (ctx, body.data (), body.size ());
+
+    JS_SetPropertyStr (ctx, response, "json",
+    JS_NewCFunctionData (ctx, js_response_json, 0, 0, 1, &bound));
+    JS_SetPropertyStr (ctx, response, "text",
+    JS_NewCFunctionData (ctx, js_response_text, 0, 0, 1, &bound));
+
+    JS_FreeValue (ctx, bound);
 }
 
 // ============================================================================
@@ -2922,13 +3000,8 @@ void setup_pm_response (JSContext* ctx, JSValue pm) {
             JS_NewString (ctx, data->response->error_message.c_str ()));
         }
 
-        // pm.response.json()
-        JS_SetPropertyStr (ctx, response, "json",
-        JS_NewCFunction (ctx, js_response_json, "json", 0));
-
-        // pm.response.text()
-        JS_SetPropertyStr (ctx, response, "text",
-        JS_NewCFunction (ctx, js_response_text, "text", 0));
+        // pm.response.json() and pm.response.text()
+        install_response_body_readers (ctx, response, data->response->body);
 
         // pm.response.reason()
         JS_SetPropertyStr (ctx, response, "reason",
@@ -3071,13 +3144,21 @@ class ScopedValue {
     JSValue value_;
 };
 
-// Read the header object the script left behind into `out`.
+// Read a header object into `out`, naming it @p label in every message it can
+// reject with. Two callers - the pm.request write-back and pm.sendRequest's
+// object header form - because the rules below (empty name, non-primitive
+// value, a case-insensitive clash) are properties of HTTP headers rather than
+// of either surface. @p suggest_delete adds the removal hint that only means
+// something for a live pm.request.headers object.
 // @return why the headers were rejected, or nullopt when `out` is filled.
-std::optional<std::string>
-read_pm_request_headers (JSContext* ctx, JSValueConst js_headers, Headers& out) {
+std::optional<std::string> read_header_object (JSContext* ctx,
+JSValueConst js_headers,
+const char* label,
+bool suggest_delete,
+Headers& out) {
     if (!JS_IsObject (js_headers) || JS_IsArray (js_headers) ||
     JS_IsFunction (ctx, js_headers)) {
-        return "pm.request.headers must be an object, got " +
+        return std::string (label) + " must be an object, got " +
         std::string (js_type_name (ctx, js_headers));
     }
 
@@ -3085,7 +3166,7 @@ read_pm_request_headers (JSContext* ctx, JSValueConst js_headers, Headers& out) 
     uint32_t count        = 0;
     if (JS_GetOwnPropertyNames (ctx, &props, &count, js_headers,
         JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) != 0) {
-        return std::string ("pm.request.headers could not be enumerated");
+        return std::string (label) + " could not be enumerated";
     }
 
     std::optional<std::string> error;
@@ -3102,7 +3183,7 @@ read_pm_request_headers (JSContext* ctx, JSValueConst js_headers, Headers& out) 
         // than dropped, because a silently missing header is the very defect
         // this write-back exists to fix.
         if (key.empty ()) {
-            error = "pm.request.headers has an empty header name";
+            error = std::string (label) + " has an empty header name";
         } else if (JS_IsString (value.get ()) || JS_IsNumber (value.get ()) ||
         JS_IsBool (value.get ())) {
             // JS object keys are case-sensitive; HTTP header names are not. So
@@ -3111,7 +3192,8 @@ read_pm_request_headers (JSContext* ctx, JSValueConst js_headers, Headers& out) 
             // silently win. Which one the script meant is unknowable, and one
             // of them is an Authorization header - refuse instead of guessing.
             if (auto clash = out.find (key); clash != out.end () && clash->first != key) {
-                error = "pm.request.headers has both '" + clash->first + "' and '" + key +
+                error = std::string (label) + " has both '" + clash->first +
+                "' and '" + key +
                 "' - HTTP header names are case-insensitive, so these are one "
                 "header. "
                 "Keep one.";
@@ -3119,9 +3201,11 @@ read_pm_request_headers (JSContext* ctx, JSValueConst js_headers, Headers& out) 
                 out[key] = js_to_string (ctx, value.get ());
             }
         } else {
-            error = "pm.request.headers['" + key + "'] must be a string, got " +
-            std::string (js_type_name (ctx, value.get ())) +
-            " (use delete pm.request.headers['" + key + "'] to remove it)";
+            error = std::string (label) + "['" + key + "'] must be a string, got " +
+            std::string (js_type_name (ctx, value.get ()));
+            if (suggest_delete) {
+                error = *error + " (use delete " + label + "['" + key + "'] to remove it)";
+            }
         }
     }
 
@@ -3200,7 +3284,8 @@ std::optional<std::string> apply_pm_request_writeback (JSContext* ctx, Request& 
 
     ScopedValue js_headers (ctx, JS_GetPropertyStr (ctx, js_request.get (), "headers"));
     staged.headers.clear ();
-    if (auto reason = read_pm_request_headers (ctx, js_headers.get (), staged.headers)) {
+    if (auto reason = read_header_object (ctx, js_headers.get (), "pm.request.headers",
+        /*suggest_delete=*/true, staged.headers)) {
         return reason;
     }
 
@@ -3627,6 +3712,346 @@ void setup_pm_variables (JSContext* ctx, JSValue pm) {
     JS_SetPropertyStr (ctx, pm, "variables", variables);
 }
 
+// ============================================================================
+// pm.sendRequest
+// ============================================================================
+
+// One entry of Postman's array header form: { key, value }.
+std::optional<std::string>
+read_header_pair (JSContext* ctx, JSValueConst entry, Headers& out) {
+    if (!JS_IsObject (entry) || JS_IsArray (entry) || JS_IsFunction (ctx, entry)) {
+        return "pm.sendRequest header entries must be { key, value } objects, "
+               "got " +
+        std::string (js_type_name (ctx, entry));
+    }
+    ScopedValue key (ctx, JS_GetPropertyStr (ctx, entry, "key"));
+    ScopedValue value (ctx, JS_GetPropertyStr (ctx, entry, "value"));
+    if (!JS_IsString (key.get ())) {
+        return "pm.sendRequest header entries need a string 'key', got " +
+        std::string (js_type_name (ctx, key.get ()));
+    }
+    if (!JS_IsString (value.get ()) && !JS_IsNumber (value.get ()) &&
+    !JS_IsBool (value.get ())) {
+        return "pm.sendRequest header '" + js_to_string (ctx, key.get ()) +
+        "' needs a string value, got " + std::string (js_type_name (ctx, value.get ()));
+    }
+    std::string name = js_to_string (ctx, key.get ());
+    if (name.empty ()) {
+        return std::string ("pm.sendRequest has a header with an empty name");
+    }
+    out[name] = js_to_string (ctx, value.get ());
+    return std::nullopt;
+}
+
+// pm.sendRequest's headers, in either shape Postman accepts: an array of
+// { key, value } or a plain object. Both, because the array is what a Postman
+// script carries over and the object is what `pm.request.headers` reads as in
+// this same sandbox - a user copying from one to the other should not have a
+// header silently vanish.
+std::optional<std::string>
+read_send_request_headers (JSContext* ctx, JSValueConst value, Headers& out) {
+    if (JS_IsArray (value)) {
+        int64_t length = 0;
+        if (JS_GetLength (ctx, value, &length) < 0) {
+            return std::string (
+            "pm.sendRequest headers could not be enumerated");
+        }
+        for (int64_t i = 0; i < length; i++) {
+            ScopedValue entry (ctx, JS_GetPropertyInt64 (ctx, value, i));
+            if (auto reason = read_header_pair (ctx, entry.get (), out)) {
+                return reason;
+            }
+        }
+        return std::nullopt;
+    }
+    return read_header_object (
+    ctx, value, "pm.sendRequest headers", /*suggest_delete=*/false, out);
+}
+
+// pm.sendRequest's body: a raw string, or Postman's { mode: 'raw', raw }.
+//
+// No Content-Type is inferred from the mode - the engine's send path derives
+// none either, so the header the script sets is the header that goes out. An
+// inferred one would silently disagree with an explicit one.
+std::optional<std::string>
+read_send_request_body (JSContext* ctx, JSValueConst value, Body& out) {
+    if (JS_IsUndefined (value) || JS_IsNull (value)) {
+        return std::nullopt;
+    }
+    if (JS_IsString (value)) {
+        out.mode    = BodyMode::Text;
+        out.content = js_to_string (ctx, value);
+        return std::nullopt;
+    }
+    if (!JS_IsObject (value) || JS_IsArray (value) || JS_IsFunction (ctx, value)) {
+        return "pm.sendRequest options.body must be a string or "
+               "{ mode: 'raw', raw: '...' }, got " +
+        std::string (js_type_name (ctx, value));
+    }
+
+    ScopedValue mode (ctx, JS_GetPropertyStr (ctx, value, "mode"));
+    const std::string mode_text =
+    JS_IsString (mode.get ()) ? js_to_string (ctx, mode.get ()) : "";
+    // Postman's formdata / urlencoded / file modes are refused by name rather
+    // than sent as an empty body: a request that goes out without the payload
+    // the script wrote is worse than one that does not go out.
+    if (mode_text != "raw") {
+        return "pm.sendRequest supports only options.body.mode 'raw' (got " +
+        (mode_text.empty () ? std::string ("none") : "\"" + mode_text + "\"") +
+        "). Serialise the body yourself and set the Content-Type header.";
+    }
+
+    ScopedValue raw (ctx, JS_GetPropertyStr (ctx, value, "raw"));
+    if (!JS_IsString (raw.get ())) {
+        return "pm.sendRequest options.body.raw must be a string, got " +
+        std::string (js_type_name (ctx, raw.get ()));
+    }
+    out.mode    = BodyMode::Text;
+    out.content = js_to_string (ctx, raw.get ());
+    return std::nullopt;
+}
+
+// Translate pm.sendRequest's first argument into a Request.
+// @return why it was rejected, or nullopt when `out` is filled.
+std::optional<std::string>
+build_send_request (JSContext* ctx, JSValueConst arg, Request& out) {
+    if (JS_IsString (arg)) {
+        out.url = js_to_string (ctx, arg);
+        if (out.url.empty ()) {
+            return std::string ("pm.sendRequest was given an empty URL");
+        }
+        return std::nullopt;
+    }
+
+    if (!JS_IsObject (arg) || JS_IsArray (arg) || JS_IsFunction (ctx, arg)) {
+        return "pm.sendRequest expects a URL string or an options object, "
+               "got " +
+        std::string (js_type_name (ctx, arg));
+    }
+
+    ScopedValue js_url (ctx, JS_GetPropertyStr (ctx, arg, "url"));
+    if (!JS_IsString (js_url.get ())) {
+        return "pm.sendRequest options.url must be a string, got " +
+        std::string (js_type_name (ctx, js_url.get ())) +
+        " (Postman's URL-object form is not supported)";
+    }
+    out.url = js_to_string (ctx, js_url.get ());
+    if (out.url.empty ()) {
+        return std::string ("pm.sendRequest options.url is empty");
+    }
+
+    ScopedValue js_method (ctx, JS_GetPropertyStr (ctx, arg, "method"));
+    if (!JS_IsUndefined (js_method.get ()) && !JS_IsNull (js_method.get ())) {
+        if (!JS_IsString (js_method.get ())) {
+            return "pm.sendRequest options.method must be a string, got " +
+            std::string (js_type_name (ctx, js_method.get ()));
+        }
+        std::string method_text = js_to_string (ctx, js_method.get ());
+        // Same normalisation pm.request's write-back applies: 'post' clearly
+        // means POST, while an unrecognised verb below still fails loudly.
+        std::transform (method_text.begin (), method_text.end (), method_text.begin (),
+        [] (unsigned char c) { return static_cast<char> (std::toupper (c)); });
+        if (auto parsed = parse_method (method_text)) {
+            out.method = *parsed;
+        } else {
+            return "pm.sendRequest options.method must be one of GET, POST, "
+                   "PUT, "
+                   "DELETE, PATCH, HEAD, OPTIONS (got \"" +
+            js_to_string (ctx, js_method.get ()) + "\")";
+        }
+    }
+
+    // `header` is Postman's spelling, `headers` is the one pm.request uses.
+    // Both are read, neither is preferred: given both there is no way to know
+    // which the script meant, and dropping either would send a request missing
+    // headers the script wrote.
+    ScopedValue js_header (ctx, JS_GetPropertyStr (ctx, arg, "header"));
+    ScopedValue js_headers (ctx, JS_GetPropertyStr (ctx, arg, "headers"));
+    const auto present = [] (JSValueConst v) {
+        return !JS_IsUndefined (v) && !JS_IsNull (v);
+    };
+    if (present (js_header.get ()) && present (js_headers.get ())) {
+        return std::string (
+        "pm.sendRequest was given both options.header and "
+        "options.headers - they are one slot under two names. Keep one.");
+    }
+    if (present (js_header.get ()) || present (js_headers.get ())) {
+        JSValueConst chosen =
+        present (js_header.get ()) ? js_header.get () : js_headers.get ();
+        if (auto reason = read_send_request_headers (ctx, chosen, out.headers)) {
+            return reason;
+        }
+    }
+
+    ScopedValue js_body (ctx, JS_GetPropertyStr (ctx, arg, "body"));
+    if (auto reason = read_send_request_body (ctx, js_body.get (), out.body)) {
+        return reason;
+    }
+
+    ScopedValue js_timeout (ctx, JS_GetPropertyStr (ctx, arg, "timeout"));
+    if (present (js_timeout.get ())) {
+        if (!JS_IsNumber (js_timeout.get ())) {
+            return "pm.sendRequest options.timeout must be a number of "
+                   "milliseconds, got " +
+            std::string (js_type_name (ctx, js_timeout.get ()));
+        }
+        double ms = 0.0;
+        JS_ToFloat64 (ctx, &ms, js_timeout.get ());
+        if (!std::isfinite (ms) || ms <= 0.0) {
+            return "pm.sendRequest options.timeout must be a positive number "
+                   "of "
+                   "milliseconds (got " +
+            js_to_string (ctx, js_timeout.get ()) + ")";
+        }
+        out.timeout_ms = static_cast<int> (
+        std::min (ms, static_cast<double> (std::numeric_limits<int>::max ())));
+    }
+
+    return std::nullopt;
+}
+
+// The response a pm.sendRequest callback receives.
+//
+// A deliberate subset of pm.response: code, status, responseTime, headers,
+// json() and text(). `status` is the numeric code, as it is on pm.response -
+// Postman spells the reason phrase there instead, but two objects called a
+// response inside one sandbox disagreeing about what `status` means is the
+// worse divergence. The body readers are the same two functions pm.response
+// installs, so the two cannot drift.
+JSValue build_send_response (JSContext* ctx, const Response& response) {
+    JSValue result = JS_NewObject (ctx);
+
+    JS_SetPropertyStr (ctx, result, "code", JS_NewInt32 (ctx, response.status_code));
+    JS_SetPropertyStr (ctx, result, "status", JS_NewInt32 (ctx, response.status_code));
+    JS_SetPropertyStr (
+    ctx, result, "responseTime", JS_NewFloat64 (ctx, response.timing.total_ms));
+
+    JSValue headers = JS_NewObject (ctx);
+    install_header_methods (ctx, headers, /*mutators=*/false);
+    for (const auto& [key, value] : response.headers) {
+        define_header_entry (ctx, headers, key, value);
+    }
+    JS_SetPropertyStr (ctx, result, "headers", headers);
+
+    install_response_body_readers (ctx, result, response.body);
+
+    return result;
+}
+
+// The error a pm.sendRequest callback receives: a real Error, carrying the
+// engine's own error code so a script can tell a timeout from a refusal
+// without matching on message text.
+JSValue build_send_error (JSContext* ctx, ErrorCode code, const std::string& message) {
+    JSValue error = JS_NewError (ctx);
+    JS_SetPropertyStr (ctx, error, "message", JS_NewString (ctx, message.c_str ()));
+    JS_SetPropertyStr (ctx, error, "code", JS_NewString (ctx, vayu::to_string (code)));
+    return error;
+}
+
+/**
+ * pm.sendRequest(urlOrOptions, callback)
+ *
+ * Synchronous by construction, and callback-shaped rather than promise-shaped.
+ * The sandbox has a Promise but nothing drains its job queue - no event loop,
+ * no setTimeout - so an awaited value never resumes and the script reports a
+ * timeout instead of a result. Postman's own signature is callback-based, and
+ * a callback can be honoured honestly: block on the send, then invoke
+ * callback(err, res) inline. The promise-returning overload Postman also
+ * offers is deliberately absent; it could only never resolve.
+ *
+ * Three things are refused by throwing rather than by calling the callback,
+ * because they are the script's mistakes and not the network's: the feature
+ * being off, the per-script request cap, and an unusable argument. Transport
+ * failures - refused, DNS, timeout - are the network's answer and reach the
+ * callback as an error, which is where a Postman script looks for them.
+ */
+JSValue js_pm_send_request (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+
+    auto* data = get_context_data (ctx);
+    if (!data) {
+        return JS_ThrowInternalError (ctx, "No script context available");
+    }
+
+    if (!data->allow_send_request) {
+        return JS_ThrowPlainError (ctx,
+        "pm.sendRequest is not available here. Vayu's MCP target allowlist is "
+        "checked by the MCP server before it calls the engine, so a request "
+        "issued from inside a script would bypass a control you configured in "
+        "Settings; script-issued requests are refused unless the caller asks "
+        "for them, and the MCP server never does. See docs/engine/mcp.md.");
+    }
+
+    if (argc < 2) {
+        return JS_ThrowTypeError (
+        ctx, "pm.sendRequest requires a URL (or options object) and a callback");
+    }
+    if (!JS_IsFunction (ctx, argv[1])) {
+        return JS_ThrowTypeError (ctx,
+        "pm.sendRequest requires a callback function as its second argument - "
+        "it has no promise form, because this sandbox never resolves one");
+    }
+
+    constexpr int limit = vayu::core::constants::script_engine::SEND_REQUEST_LIMIT;
+    if (data->send_request_count >= limit) {
+        return JS_ThrowPlainError (ctx,
+        "pm.sendRequest may issue at most %d requests per script; this is "
+        "request %d",
+        limit, data->send_request_count + 1);
+    }
+
+    Request request;
+    if (auto reason = build_send_request (ctx, argv[0], request)) {
+        return JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+    }
+
+    // The script's wall-clock budget is enforced by a QuickJS interrupt handler
+    // that only runs *between bytecode operations*, so a blocking C function
+    // never yields to it: without this clamp a 5s script could hold its thread
+    // for the request's 30s timeout, six times the budget the user set, with
+    // no error and no way to interrupt it.
+    if (auto remaining = remaining_script_budget_ms (ctx)) {
+        if (*remaining <= 0) {
+            return JS_ThrowPlainError (ctx,
+            "pm.sendRequest was called with none of the script's time budget "
+            "left");
+        }
+        request.timeout_ms = static_cast<int> (
+        std::min (static_cast<int64_t> (request.timeout_ms), *remaining));
+    }
+
+    // Counted before the send, so a request that fails still spends budget -
+    // otherwise a loop against a refusing host would never reach the cap.
+    data->send_request_count++;
+
+    vayu::http::Client client;
+    auto sent = client.send (request);
+
+    JSValue err = JS_NULL;
+    JSValue res = JS_NULL;
+    if (sent.is_error ()) {
+        err = build_send_error (ctx, sent.error ().code, sent.error ().message);
+    } else if (const Response& response = sent.value (); response.has_error ()) {
+        err = build_send_error (ctx, response.error_code, response.error_message);
+    } else {
+        res = build_send_response (ctx, sent.value ());
+    }
+
+    JSValue args[2] = { err, res };
+    JSValue ret     = JS_Call (ctx, argv[1], JS_UNDEFINED, 2, args);
+    JS_FreeValue (ctx, err);
+    JS_FreeValue (ctx, res);
+
+    // A callback that threw - a failed pm.expect inside it, most likely - must
+    // surface as the script's error rather than be swallowed here.
+    if (JS_IsException (ret)) {
+        return JS_EXCEPTION;
+    }
+    JS_FreeValue (ctx, ret);
+
+    return JS_UNDEFINED;
+}
+
 void setup_pm_object (JSContext* ctx) {
     JSValue global = JS_GetGlobalObject (ctx);
     JSValue pm     = JS_NewObject (ctx);
@@ -3666,6 +4091,12 @@ void setup_pm_object (JSContext* ctx) {
     // pm.crypto
     setup_pm_crypto (ctx, pm);
 
+    // pm.sendRequest - always bound, even when the capability is off, so a
+    // script that calls it gets a sentence explaining why rather than
+    // "not a function".
+    JS_SetPropertyStr (ctx, pm, "sendRequest",
+    JS_NewCFunction (ctx, js_pm_send_request, "sendRequest", 2));
+
     JS_SetPropertyStr (ctx, global, "pm", pm);
     JS_FreeValue (ctx, global);
 }
@@ -3675,15 +4106,6 @@ void setup_pm_object (JSContext* ctx) {
 // ============================================================================
 // ScriptEngine Implementation
 // ============================================================================
-
-// Per-runtime deadline state for the interrupt handler. One instance is owned by
-// each pooled JSRuntime (stored as its runtime opaque) and refreshed before every
-// execution. QuickJS runtimes are single-threaded, and each pooled context pair is
-// used by one thread at a time, so no synchronization is needed here.
-struct RuntimeState {
-    bool enabled = false; // false => no wall-clock limit (timeout_ms == 0)
-    std::chrono::steady_clock::time_point deadline{};
-};
 
 // QuickJS calls this periodically during evaluation. Returning non-zero aborts
 // the current JS_Eval with an InternalError, which the execute() exception path
@@ -3817,6 +4239,11 @@ class ScriptEngine::Impl {
         ctx_data.request_id          = ctx.request_id;
         ctx_data.request_name        = ctx.request_name;
         ctx_data.event               = ctx.event;
+        // Both per-execution: the capability is this caller's, and the request
+        // budget starts full for every script rather than carrying over
+        // through a pooled context.
+        ctx_data.allow_send_request = config.allow_send_request;
+        ctx_data.send_request_count = 0;
         JS_SetContextOpaque (js_ctx, &ctx_data);
 
         // Refresh pm.request, pm.response and pm.info with new data

--- a/engine/tests/script_send_request_test.cpp
+++ b/engine/tests/script_send_request_test.cpp
@@ -1,0 +1,549 @@
+/**
+ * @file tests/script_send_request_test.cpp
+ * @brief `pm.sendRequest` (issue #302): the capability gate, the argument
+ *        shapes, and the two boundaries that bound a blocking call - the
+ *        script's wall-clock budget and the per-script request cap.
+ *
+ * The failure paths carry most of the weight here. `pm.sendRequest` is the
+ * first thing in the sandbox that blocks on the network, and the ways that can
+ * go wrong are the ways a user actually meets it: a refused connection, a host
+ * that does not resolve, a server that never answers. Each has to reach the
+ * callback as an error rather than throw out of the script or hang the thread,
+ * and none of them may outlive the budget the user set for the script.
+ *
+ * A local mock server rather than `mock_server.hpp`'s `SlowMockServer`: these
+ * cases need routes it has no reader for (a token payload, a request echo, a
+ * hit counter), and the suite's convention is that test-specific routes live
+ * with their tests - `curl_transfer_test.cpp` does the same.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "vayu/core/constants.hpp"
+#include "vayu/runtime/script_engine.hpp"
+#include "vayu/types.hpp"
+
+using vayu::runtime::ScriptConfig;
+using vayu::runtime::ScriptContext;
+using vayu::runtime::ScriptEngine;
+
+namespace {
+
+constexpr int REQUEST_CAP = vayu::core::constants::script_engine::SEND_REQUEST_LIMIT;
+
+// How long /slow holds a connection. Comfortably longer than every "this
+// returned promptly" assertion below, so a missing clamp shows up as a failure
+// rather than as a slow pass.
+constexpr int SLOW_MS = 3000;
+
+class SendRequestServer {
+    public:
+    SendRequestServer () {
+        svr.new_task_queue = [] { return new httplib::ThreadPool (16); };
+
+        svr.Get ("/token", [this] (const httplib::Request&, httplib::Response& res) {
+            hits.fetch_add (1, std::memory_order_relaxed);
+            res.set_content (R"({"access_token":"tok_123","expires_in":3600})",
+            "application/json");
+        });
+
+        // Echoes what arrived, so a test can assert the method, body and
+        // headers the script asked for are the ones that went on the wire.
+        svr.Post ("/echo", [this] (const httplib::Request& req, httplib::Response& res) {
+            hits.fetch_add (1, std::memory_order_relaxed);
+            nlohmann::json echo;
+            echo["method"] = req.method;
+            echo["body"]   = req.body;
+            echo["marker"] = req.get_header_value ("X-Marker");
+            echo["type"]   = req.get_header_value ("Content-Type");
+            res.set_content (echo.dump (), "application/json");
+        });
+
+        svr.Get ("/slow", [this] (const httplib::Request&, httplib::Response& res) {
+            hits.fetch_add (1, std::memory_order_relaxed);
+            auto deadline =
+            std::chrono::steady_clock::now () + std::chrono::milliseconds (SLOW_MS);
+            while (!released.load (std::memory_order_relaxed) &&
+            std::chrono::steady_clock::now () < deadline) {
+                std::this_thread::sleep_for (std::chrono::milliseconds (10));
+            }
+            res.set_content ("{}", "application/json");
+        });
+
+        port   = svr.bind_to_any_port ("127.0.0.1");
+        thread = std::thread ([this] () { svr.listen_after_bind (); });
+        svr.wait_until_ready ();
+    }
+
+    ~SendRequestServer () {
+        // httplib's stop() does not interrupt a handler already running, so
+        // /slow is released first or teardown waits out SLOW_MS.
+        released.store (true, std::memory_order_relaxed);
+        svr.stop ();
+        if (thread.joinable ())
+            thread.join ();
+    }
+
+    std::string url (const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string (port) + path;
+    }
+
+    int hit_count () const {
+        return hits.load (std::memory_order_relaxed);
+    }
+
+    private:
+    httplib::Server svr;
+    std::thread thread;
+    int port = 0;
+    std::atomic<int> hits{ 0 };
+    std::atomic<bool> released{ false };
+};
+
+// Port 1: connection refused, fast fail. The suite's existing spelling for an
+// unreachable endpoint (`http_client_test.cpp`, `event_loop_test.cpp`) rather
+// than a locally bound-then-dropped port - httplib's Server leaves its listener
+// open when it was never started, so connections to it queue in the backlog and
+// time out instead of being refused.
+constexpr const char* REFUSED_URL = "http://127.0.0.1:1/";
+
+class SendRequestTest : public ::testing::Test {
+    protected:
+    // A test script, run with pm.sendRequest allowed. The default is deny, so
+    // every test that expects a send has to say so - which is the point.
+    vayu::ScriptResult run (const std::string& script, uint64_t timeout_ms = 5000) {
+        ScriptConfig config;
+        config.timeout_ms         = timeout_ms;
+        config.allow_send_request = true;
+        ScriptEngine engine (config);
+        return execute (engine, script);
+    }
+
+    // The same script with the engine left at its defaults - what a caller
+    // that never asked for the capability gets, MCP included.
+    vayu::ScriptResult run_denied (const std::string& script) {
+        ScriptEngine engine{ ScriptConfig{} };
+        return execute (engine, script);
+    }
+
+    vayu::Request request;
+    vayu::Response response;
+    vayu::Environment env;
+
+    private:
+    vayu::ScriptResult execute (ScriptEngine& engine, const std::string& script) {
+        response.status_code = 200;
+        auto ctx             = ScriptContext::for_test (request, response);
+        ctx.environment      = &env;
+        return engine.execute (script, ctx);
+    }
+};
+
+// Milliseconds a callable took, for the assertions that a bounded call really
+// is bounded.
+template <typename Fn> int64_t elapsed_ms (Fn&& fn) {
+    const auto start = std::chrono::steady_clock::now ();
+    fn ();
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - start)
+    .count ();
+}
+
+// ============================================================================
+// The capability gate
+// ============================================================================
+
+// The whole security argument in one test: the MCP allowlist is checked in the
+// MCP server before it calls the engine, so a script-issued request would
+// bypass it. A caller that does not ask for the capability - MCP never does -
+// must get nothing on the wire.
+TEST_F (SendRequestTest, DeniedByDefaultAndNothingReachesTheServer) {
+    SendRequestServer server;
+
+    auto result = run_denied ("pm.sendRequest('" + server.url ("/token") +
+    "', function (err, res) { pm.test('unreachable', function () {}); });");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("pm.sendRequest is not available"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0)
+    << "a denied script still reached the network";
+    EXPECT_TRUE (result.tests.empty ())
+    << "the callback ran despite the denial";
+}
+
+// A missing global would report "TypeError: not a function", which names
+// nothing (issue #134). The binding exists so the denial can explain itself.
+TEST_F (SendRequestTest, IsBoundEvenWhenDenied) {
+    auto result =
+    run_denied ("pm.test('bound', function () { "
+                "  pm.expect(typeof pm.sendRequest).to.equal('function'); "
+                "});");
+
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// ============================================================================
+// The success path
+// ============================================================================
+
+TEST_F (SendRequestTest, DeliversTheResponseToTheCallback) {
+    SendRequestServer server;
+
+    auto result = run ("var seen = {}; "
+                       "pm.sendRequest('" +
+    server.url ("/token") +
+    "', function (err, res) { "
+    "  seen.err = err; seen.code = res.code; seen.status = res.status; "
+    "  seen.token = res.json().access_token; "
+    "  seen.text = res.text(); "
+    "  seen.type = res.headers.get('content-type'); "
+    "}); "
+    "pm.test('shape', function () { "
+    "  pm.expect(seen.err).to.equal(null); "
+    "  pm.expect(seen.code).to.equal(200); "
+    "  pm.expect(seen.status).to.equal(200); "
+    "  pm.expect(seen.token).to.equal('tok_123'); "
+    "  pm.expect(seen.type).to.equal('application/json'); "
+    "  pm.expect(seen.text.length > 0).to.equal(true); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_EQ (server.hit_count (), 1);
+}
+
+TEST_F (SendRequestTest, OptionsObjectCarriesMethodHeadersAndBody) {
+    SendRequestServer server;
+
+    auto result = run ("var echo = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'post', "
+    "  header: { 'X-Marker': 'from-script', 'Content-Type': 'application/json' "
+    "}, "
+    "  body: { mode: 'raw', raw: '{\"a\":1}' } "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.method).to.equal('POST'); "
+    "  pm.expect(echo.body).to.equal('{\"a\":1}'); "
+    "  pm.expect(echo.marker).to.equal('from-script'); "
+    "  pm.expect(echo.type).to.equal('application/json'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// Postman's array form, which is what a script copied out of Postman carries.
+TEST_F (SendRequestTest, PostmanArrayHeaderFormIsAccepted) {
+    SendRequestServer server;
+
+    auto result = run ("var echo = null; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/echo") +
+    "', method: 'POST', "
+    "  header: [{ key: 'X-Marker', value: 'array-form' }], "
+    "  body: 'plain' "
+    "}, function (err, res) { echo = res.json(); }); "
+    "pm.test('sent', function () { "
+    "  pm.expect(echo.marker).to.equal('array-form'); "
+    "  pm.expect(echo.body).to.equal('plain'); "
+    "});");
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// ============================================================================
+// Arguments that cannot be honoured fail loudly rather than sending something
+// the script did not write
+// ============================================================================
+
+TEST_F (SendRequestTest, BothHeaderSpellingsAtOnceIsRejected) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest({ url: '" + server.url ("/echo") +
+    "', header: {}, headers: {} }, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("one slot under two names"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0);
+}
+
+TEST_F (SendRequestTest, AnUnsupportedBodyModeIsRejected) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest({ url: '" +
+    server.url ("/echo") + "', method: 'POST', body: { mode: 'formdata', formdata: [] } }, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("'raw'"), std::string::npos) << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0)
+    << "an unreadable body was sent as nothing at all";
+}
+
+TEST_F (SendRequestTest, AnUnknownMethodIsRejected) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest({ url: '" + server.url ("/token") +
+    "', method: 'FETCH' }, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("FETCH"), std::string::npos) << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0);
+}
+
+// There is no promise form - the sandbox has a Promise but nothing drains its
+// job queue - so a missing callback has to say that rather than return one.
+TEST_F (SendRequestTest, ACallbackIsRequired) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest('" + server.url ("/token") + "');");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("callback"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0);
+}
+
+TEST_F (SendRequestTest, ANonFunctionCallbackIsRejected) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest('" + server.url ("/token") + "', 'not a function');");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("promise form"), std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), 0);
+}
+
+TEST_F (SendRequestTest, AnUnusableFirstArgumentIsRejected) {
+    auto result = run ("pm.sendRequest(42, function () {});");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("URL string or an options object"), std::string::npos)
+    << result.error_message;
+}
+
+// ============================================================================
+// Transport failures reach the callback - they are the network's answer, not
+// the script's mistake
+// ============================================================================
+
+TEST_F (SendRequestTest, ConnectionRefusedReachesTheCallbackAsAnError) {
+    auto result = run ("var seen = {}; "
+                       "pm.sendRequest('" +
+    std::string (REFUSED_URL) +
+    "', function (err, res) { seen.err = err; seen.res = res; }); "
+    "pm.test('refused', function () { "
+    "  pm.expect(seen.err === null).to.equal(false); "
+    "  pm.expect(seen.res).to.equal(null); "
+    "  pm.expect(seen.err.code).to.equal('CONNECTION_FAILED'); "
+    "  pm.expect(seen.err.message.length > 0).to.equal(true); "
+    "});");
+
+    EXPECT_TRUE (result.success)
+    << "a refused connection threw out of the script: " << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// `.invalid` is reserved by RFC 2606 and never resolves. The error code is not
+// asserted, only that one arrived: a runner behind a proxy fails this at the
+// proxy rather than in the resolver, and either way the script must see an
+// error and keep running.
+TEST_F (SendRequestTest, DnsFailureReachesTheCallbackAsAnError) {
+    auto result =
+    run ("var seen = {}; "
+         "pm.sendRequest('http://vayu-no-such-host.invalid/token', "
+         "function (err, res) { seen.err = err; seen.res = res; }); "
+         "pm.test('unresolvable', function () { "
+         "  pm.expect(seen.err === null).to.equal(false); "
+         "  pm.expect(seen.res).to.equal(null); "
+         "  pm.expect(seen.err.message.length > 0).to.equal(true); "
+         "});");
+
+    EXPECT_TRUE (result.success)
+    << "an unresolvable host threw out of the script: " << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+TEST_F (SendRequestTest, ARequestTimeoutReachesTheCallbackAsAnError) {
+    SendRequestServer server;
+
+    auto result = run ("var seen = {}; "
+                       "pm.sendRequest({ url: '" +
+    server.url ("/slow") +
+    "', timeout: 150 }, function (err, res) { seen.err = err; seen.res = res; "
+    "}); "
+    "pm.test('timed out', function () { "
+    "  pm.expect(seen.err === null).to.equal(false); "
+    "  pm.expect(seen.res).to.equal(null); "
+    "  pm.expect(seen.err.code).to.equal('TIMEOUT'); "
+    "});",
+    /*timeout_ms=*/30000);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// ============================================================================
+// The script's budget bounds a blocking call
+// ============================================================================
+
+// The defect this clamp exists for: QuickJS only calls its interrupt handler
+// between bytecode operations, so a blocking C function never yields to it.
+// Without the clamp a script with a 400ms budget holds its thread for the
+// request's timeout - the mutation check is the elapsed assertion, since
+// removing the clamp makes this wait out SLOW_MS instead.
+TEST_F (SendRequestTest, AnAuxiliaryRequestCannotOutliveTheScriptBudget) {
+    SendRequestServer server;
+
+    vayu::ScriptResult result;
+    const int64_t took = elapsed_ms ([&] {
+        result = run ("pm.sendRequest('" + server.url ("/slow") + "', function () {});",
+        /*timeout_ms=*/400);
+    });
+
+    EXPECT_LT (took, SLOW_MS / 2) << "the request outlived the script budget - "
+                                     "is the deadline clamp still there?";
+    EXPECT_EQ (server.hit_count (), 1)
+    << "the request never went out, so nothing was bounded";
+}
+
+// A budget already spent must not turn into an unbounded request. The clamp
+// alone would compute a timeout of zero or less, and libcurl reads a timeout
+// of zero as "no timeout at all" - so the guard above it is load-bearing, and
+// removing it makes this wait out SLOW_MS.
+TEST_F (SendRequestTest, ASpentBudgetDoesNotIssueAnUnboundedRequest) {
+    SendRequestServer server;
+
+    vayu::ScriptResult result;
+    const int64_t took = elapsed_ms ([&] {
+        result = run ("pm.sendRequest('" + server.url ("/slow") + "', function () {});",
+        /*timeout_ms=*/1);
+    });
+
+    EXPECT_FALSE (result.success)
+    << "a script with no budget left reported success";
+    EXPECT_LT (took, SLOW_MS / 2)
+    << "an exhausted budget still issued an unbounded request";
+}
+
+// Turning the budget off entirely (timeout_ms == 0) must not be read as "no
+// time left" - there is simply nothing to clamp to.
+TEST_F (SendRequestTest, NoConfiguredBudgetMeansNoClamp) {
+    SendRequestServer server;
+
+    auto result = run ("var code = 0; "
+                       "pm.sendRequest('" +
+    server.url ("/token") +
+    "', function (err, res) { code = res.code; }); "
+    "pm.test('sent', function () { pm.expect(code).to.equal(200); });",
+    /*timeout_ms=*/0);
+
+    EXPECT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// ============================================================================
+// The per-script request cap
+// ============================================================================
+
+// Asserted at the cap rather than by counting side effects: the message names
+// the limit and the offending call, and the server confirms exactly the cap
+// went out.
+TEST_F (SendRequestTest, TheRequestCapIsEnforcedAtTheCap) {
+    SendRequestServer server;
+
+    auto result = run ("for (var i = 0; i < " + std::to_string (REQUEST_CAP + 1) +
+    "; i++) { pm.sendRequest('" + server.url ("/token") + "', function () {}); }",
+    /*timeout_ms=*/30000);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("at most " + std::to_string (REQUEST_CAP)),
+    std::string::npos)
+    << result.error_message;
+    EXPECT_EQ (server.hit_count (), REQUEST_CAP);
+}
+
+// A failed request still spends budget, or a loop against a refusing host
+// would never reach the cap - and that loop is the one that spins a run's
+// worker thread.
+TEST_F (SendRequestTest, AFailedRequestStillSpendsBudget) {
+    auto result = run ("for (var i = 0; i < " + std::to_string (REQUEST_CAP + 1) +
+    "; i++) { pm.sendRequest('" + REFUSED_URL + "', function () {}); }",
+    /*timeout_ms=*/30000);
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("at most " + std::to_string (REQUEST_CAP)),
+    std::string::npos)
+    << result.error_message;
+}
+
+// Contexts are pooled and reused, so a counter living on the context rather
+// than on the execution would let the first script spend the second's budget.
+// Both scripts run on the same engine, which is what makes the reuse real.
+TEST_F (SendRequestTest, TheCapResetsBetweenExecutions) {
+    SendRequestServer server;
+
+    ScriptConfig config;
+    config.timeout_ms         = 30000;
+    config.allow_send_request = true;
+    ScriptEngine engine (config);
+
+    response.status_code = 200;
+    auto ctx             = ScriptContext::for_test (request, response);
+    ctx.environment      = &env;
+
+    const std::string spend_the_cap = "for (var i = 0; i < " +
+    std::to_string (REQUEST_CAP) + "; i++) { pm.sendRequest('" +
+    server.url ("/token") + "', function () {}); }";
+    auto first = engine.execute (spend_the_cap, ctx);
+    ASSERT_TRUE (first.success) << first.error_message;
+    ASSERT_EQ (server.hit_count (), REQUEST_CAP);
+
+    auto second = engine.execute ("var code = 0; pm.sendRequest('" + server.url ("/token") +
+    "', function (err, res) { code = res.code; }); "
+    "pm.test('fresh budget', function () { pm.expect(code).to.equal(200); });",
+    ctx);
+
+    EXPECT_TRUE (second.success) << second.error_message;
+    ASSERT_EQ (second.tests.size (), 1u);
+    EXPECT_TRUE (second.tests[0].passed) << second.tests[0].error_message;
+    EXPECT_EQ (server.hit_count (), REQUEST_CAP + 1);
+}
+
+// ============================================================================
+// The callback is the script's code, so its failures are the script's
+// ============================================================================
+
+TEST_F (SendRequestTest, AThrowingCallbackSurfacesAsTheScriptsError) {
+    SendRequestServer server;
+
+    auto result = run ("pm.sendRequest('" + server.url ("/token") +
+    "', function () { throw new Error('from the callback'); });");
+
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("from the callback"), std::string::npos)
+    << result.error_message;
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Adds `pm.sendRequest(urlOrOptions, callback)` - the sandbox's only network access. Anchors in #302 re-verified against current master; the one drift is line numbers (`setup_pm_object` has moved since #300 and #306 landed), the code reads as described.

**The plan.** Root cause is a gap rather than a bug: `setup_pm_object` binds no such name, so the canonical token-fetch has no in-script equivalent. The issue said three questions had to be answered first, and the answers drive the design.

*Sync vs callback* was already settled by precedent, not open. The sandbox has `Promise` but nothing drains its job queue, so an awaited value never resumes - the reason Web Crypto shipped as a synchronous `pm.crypto`. Postman's own `sendRequest` signature is callback-based, and a callback can be honoured honestly: block on `http::Client::send`, then invoke `callback(err, res)` inline. The promise-returning overload Postman also offers is deliberately absent - it could only never resolve.

*The deadline* is the real hazard. The script budget is a QuickJS interrupt handler, and QuickJS only calls it **between bytecode operations**, so a blocking C function never yields to it - a 5s script would hold its thread for the request's 30s timeout with no error. The auxiliary request's timeout is therefore clamped to the script's remaining budget, with a guard above it for a budget already spent: libcurl reads a timeout of **zero as "no timeout at all"**, so clamping alone would turn a blown budget into an unbounded request. A per-script cap of 10 bounds the other direction, since a load run's `tests` script runs once per *sampled* response, serially, on the run's worker thread.

*The MCP allowlist* is answered below - it is the one that shaped the API.

**The alternatives I rejected.** For the response object, I did not refactor `setup_pm_response` wholesale to share every member; `json()`/`text()` are now bound to the body at build time so both surfaces use one implementation, but `reason()`/`size()` stay context-bound and the sendRequest response documents itself as a subset. Converting the whole of `pm.response` would be a "while I'm here" refactor on the most heavily-tested surface in the file for no acceptance criterion. Likewise `read_pm_request_headers` was **parameterised** into `read_header_object` rather than copied, since the rules it enforces (empty name, non-primitive value, a case-insensitive clash) are properties of HTTP headers, not of either caller.

## The MCP allowlist decision

The allowlist is checked **in the MCP server, against the composed URL, before it calls the engine** (`app/electron/mcp/safety.ts`). A request issued from inside a script never goes through the MCP server at all, so it could never be checked - `pm.sendRequest` as a bare capability turns any agent that can write a script into an agent that can reach any host.

Of the three options #302 lists, this takes the third, and the reasoning is in `docs/engine/mcp.md` as well as here:

- **Move the allowlist engine-side.** Rejected. The allowlist lives in the app's config and the engine has no channel to it, so the engine would need a second implementation of host matching beside `safety.ts` - two copies of a security check, which drift. It would also leave the engine enforcing an allowlist for one kind of request and not the others.
- **A settings toggle, off by default.** Rejected. It adds a knob whose safe position is the only correct one for MCP, and the hole reopens the moment anyone flips it for an unrelated reason.
- **Refuse unless the caller explicitly asks.** Chosen. The engine denies `pm.sendRequest` unless the `/execute` or `/runs` payload carries `allowScriptRequests: true`. `apiService.executeRequest` / `startLoadTest` ask, in one place each; the MCP server never does.

**Denying by default is the load-bearing half.** A new MCP tool, a future engine client or a bare `curl` gets a script that cannot send rather than silent egress - the failure lands on the safe side. The precedent is the repo's own rule about `followRedirects`: clients send the behaviour-relevant boolean explicitly rather than leaning on an engine default. And an agent cannot set the field itself - every tool builds its request from named arguments and a Zod object strips what it does not declare, which is asserted rather than assumed (`tools.test.ts`).

`pm.sendRequest` is bound **even when denied**, so calling it throws a sentence naming the reason instead of `TypeError: not a function`, which names nothing (#134). The completion entry says the same thing, so the surface an agent reads and the surface it gets agree.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` - clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **852 / 852 pass**.
- `cd app && pnpm test` - **2561 / 2561 pass** in 290 files.
- `cd app && pnpm type-check` - clean. `pnpm lint` - clean (0 warnings).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.

No pre-existing failures reproduced on this base. One environment limitation, not a code failure: `scripts/pre-commit` cannot run here, because this container's clang-tidy is older than the repo's `.clang-tidy` (`unknown key 'ExcludeHeaderFilterRegex'`). That reproduces on an unmodified checkout and is unrelated to this diff; CI runs its own matrix.

**21 new gtests** in `engine/tests/script_send_request_test.cpp`, plus **4 new app tests**. The failure paths carry the weight - this is the first thing in the sandbox that blocks on the network:

- The gate: denied by default with **nothing reaching the server**, and bound anyway so the denial can explain itself.
- The success path: `(err, res)` shape, `res.json()`, `res.headers.get()`; an options object carrying method/headers/body; Postman's `[{key, value}]` header array.
- Refused loudly, nothing sent: both header spellings at once, an unsupported body mode, an unknown verb, a missing or non-function callback, an unusable first argument.
- Reaching the callback rather than throwing or hanging: connection refused, DNS failure, request timeout.
- The bounds: the clamp, the spent budget, `scriptTimeout = 0` meaning no clamp rather than no time, the cap asserted *at* the cap, a failed request still spending budget, and the cap resetting between executions on one pooled engine.

**Mutation-checked**, each reddening exactly its own test and leaving its neighbour green:

| Reverted | Goes red |
|---|---|
| the deadline clamp | `AnAuxiliaryRequestCannotOutliveTheScriptBudget` (waits out the 3s endpoint) |
| the zero-budget guard | `ASpentBudgetDoesNotIssueAnUnboundedRequest` (curl reads timeout 0 as none) |
| the per-execution counter reset | `TheCapResetsBetweenExecutions` |
| `allow_send_request = false` | `DeniedByDefaultAndNothingReachesTheServer` |
| the renderer's opt-in | both `api.script-requests.test.ts` payload tests |
| declaring the field in the MCP schema | the MCP "an agent cannot ask for it" test |

One test bug found and fixed while writing: a hand-rolled `closed_port()` helper bound a port through httplib and dropped it, but `Server::stop()` only closes when the server was started - so connections queued in the backlog and *timed out* instead of being refused, and the refusal test passed for the wrong reason. Replaced with the suite's existing `http://127.0.0.1:1/` spelling.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs in the same commit, all three the issue named plus one it did not: `docs/engine/scripting.md` (the `pm` surface, the sandbox-limits list - "No filesystem or network access" was about to become false - and the deadline interaction), `docs/app/pm-api-compatibility.md` (moved out of "Not (yet) supported", with the divergences stated where `pm.crypto`'s naming divergence already is), `docs/engine/mcp.md` (the decision, its rejected alternatives, and the correction that the safety model is no longer enforced *entirely* app-side), and `docs/engine/api-reference.md`, which the engine's `CLAUDE.md` requires for **any** payload change.

`git clang-format` was used so only the lines this diff touches were reformatted: `script_engine.cpp`, `execution.cpp` and `run_manager.cpp` carry pre-existing format drift (67, 59 and 279 lines) in regions this diff does not touch, and it is unchanged. The docs files were already prettier-dirty before this branch, so they were not reformatted; the four app files that were clean, were.

## Deviations from the issue spec

- **The Settings panel text was corrected rather than weakened.** The issue anticipated "if script-issued requests are not covered, that text is now wrong". They *are* covered - by refusal - so the allowlist card now states that a script an agent writes cannot reach around the list, instead of admitting a gap.
- **The completion table gained an entry, which the issue did not ask for.** Without it `pm.sendRequest` would be red-underlined in Vayu's own Tests editor: the `.d.ts` Monaco loads is *generated from that table*. The same entry feeds the `vayu://scripting/completions` MCP resource, so its documentation states the agent restriction - otherwise this would ship the #109 defect (an advertised API that is not there) pointed at agents.
- **`status` on a sendRequest response is the numeric code**, where Postman puts the reason phrase there. Vayu's `pm.response.status` is already numeric, and two objects called a response disagreeing about what `status` means inside one sandbox is the worse divergence. Documented.
- **Only `raw` bodies.** `formdata` / `urlencoded` are refused by name rather than sent as an empty body.
- **A load run may use it too.** The narrower option was to allow it only on `/execute`. Rejected: a run's `tests` script is the same script Send runs (the principle #300 established for `pm.info`), and the per-script cap is what #302 itself identifies as the containment for the per-sample cost.

## Related Issues

Closes #302

---
_Generated by [Claude Code](https://claude.ai/code/session_01Po1h686ifseKYNMww7gcGX)_