### PR TITLE
fix(engine): the Content-Type completion snippet reads a header key that never matches

### DIFF
--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -1075,10 +1075,15 @@ nlohmann::json get_script_completions () {
 
     completions.push_back ({ { "label", "Test: Content-Type JSON" }, { "kind", KIND_SNIPPET },
     { "insertText",
+    // get() rather than an index: response header keys are lower-cased by the
+    // HTTP client, so headers["Content-Type"] reads back undefined and this
+    // fails as an assertion, which reads as a server fault rather than a bad
+    // example. get() is case-insensitive, so the name stays spelled the way the
+    // to.have.header line above spells it.
     "pm.test(\"Content-Type is JSON\", function() "
     "{\n\tpm.response.to.have.header(\"Content-Type\");\n\tpm.expect(pm."
-    "response.headers["
-    "\"Content-Type\"]).to.include(\"application/json\");\n});" },
+    "response.headers.get("
+    "\"Content-Type\")).to.include(\"application/json\");\n});" },
     { "insertTextRules", INSERT_AS_SNIPPET }, { "detail", "Test template" },
     { "documentation", "Quick template for Content-Type header test." },
     { "sortText", "3_snippet_content_type" } });

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <set>
 #include <string>
 
@@ -500,6 +502,81 @@ TEST (ScriptCompletions, EveryOfferedCryptoMemberIsCallableInTheRuntime) {
 
     EXPECT_EQ (offered, 4)
     << "the signing surface changed - update this test and the docs it backs";
+}
+
+// A different drift from the ones above: the member exists, the spelling of the
+// key does not. Response header names are lower-cased by the HTTP client and
+// indexing `pm.response.headers` is a plain property read, so an offered
+// example spelled `["Content-Type"]` reads back `undefined` (#310). `get()` and
+// `has()` are case-insensitive and unaffected - only the index form can be
+// wrong this way.
+TEST (ScriptCompletions, NoOfferedResponseHeaderIndexUsesAMixedCaseKey) {
+    const auto completions = get_script_completions ();
+
+    const std::string index_prefix = "pm.response.headers[";
+    int indexed                    = 0;
+    for (const auto& item : completions) {
+        for (const char* field : { "insertText", "documentation", "detail" }) {
+            const std::string text = item.value (field, std::string{});
+            for (size_t at = text.find (index_prefix); at != std::string::npos;
+                 at        = text.find (index_prefix, at + 1)) {
+                const size_t open = at + index_prefix.size ();
+                ASSERT_LT (open, text.size ()) << text;
+                const char quote = text[open];
+                ASSERT_TRUE (quote == '"' || quote == '\'')
+                << "index example with no quoted key: " << text;
+                const size_t close = text.find (quote, open + 1);
+                ASSERT_NE (close, std::string::npos) << text;
+
+                const std::string key = text.substr (open + 1, close - open - 1);
+                indexed++;
+
+                std::string lowered = key;
+                std::transform (lowered.begin (), lowered.end (), lowered.begin (),
+                [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+                EXPECT_EQ (key, lowered)
+                << item.value ("label", std::string{})
+                << " indexes pm.response.headers with '" << key
+                << "', which never matches - the HTTP client lower-cases "
+                   "response header names";
+            }
+        }
+    }
+
+    ASSERT_GT (indexed, 0)
+    << "nothing offered indexes pm.response.headers at all, so this scan proved nothing";
+}
+
+// The executable half of the same guard, and the one that would have caught
+// #310: the snippet Monaco inserts is run against a JSON response and has to
+// pass. A shape check could not catch it - the broken form was valid JS that
+// failed as an *assertion*, so it read as "the server sent the wrong
+// Content-Type" rather than "the example is wrong".
+TEST (ScriptCompletions, TheContentTypeSnippetPassesAgainstAJsonResponse) {
+    const auto completions = get_script_completions ();
+    const auto* snippet    = find_by_label (completions, "Test: Content-Type JSON");
+    ASSERT_NE (snippet, nullptr) << "the Content-Type snippet is no longer offered";
+
+    const std::string insert = snippet->value ("insertText", std::string{});
+    ASSERT_EQ (insert.find ("${"), std::string::npos)
+    << "the snippet gained a placeholder, so it is no longer runnable as written";
+
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request;
+    vayu::Response response;
+    vayu::Environment env;
+    request.method       = vayu::HttpMethod::GET;
+    request.url          = "https://api.example.com/users";
+    response.status_code = 200;
+    // Spelled the way the HTTP client stores it, which is the whole point.
+    response.headers = { { "content-type", "application/json; charset=utf-8" } };
+    response.body    = R"({"ok": true})";
+
+    auto result = engine.execute_test (insert, request, response, env);
+    ASSERT_EQ (result.tests.size (), 1u) << result.error_message;
+    EXPECT_TRUE (result.tests[0].passed)
+    << "the offered Content-Type snippet fails against a JSON response: "
+    << result.tests[0].error_message;
 }
 
 } // namespace


### PR DESCRIPTION
## Description

The **"Test: Content-Type JSON"** completion snippet (`engine/src/http/routes/scripting.cpp`) is inserted straight into the user's editor and could never pass:

```js
pm.test("Content-Type is JSON", function() {
	pm.response.to.have.header("Content-Type");     // fine - case-insensitive
	pm.expect(pm.response.headers["Content-Type"])  // always undefined
		.to.include("application/json");
});
```

**Plan (root cause, approach, rejected alternative).** `pm.response.headers` is a plain object whose keys are the lower-cased names the HTTP client parsed (`script_engine.cpp:3014-3022`), and `define_header_entry` (`:2508-2514`) defines each key verbatim with no case aliasing, so `["Content-Type"]` is an ordinary property read returning `undefined`. The comment at `script_engine.cpp:2523-2527` records this exact hazard as the reason `find_header_key` exists. The two lines of the snippet therefore disagree: the header **is** present, and the snippet reports the response is not JSON - failing as an *assertion*, so it reads as "the server sent the wrong Content-Type" rather than "the example is wrong". The fix routes the read through `pm.response.headers.get("Content-Type")`, the case-insensitive primitive already installed on that object (`install_header_methods`, `:3016`), which is also the form the app's Tests panel teaches (`script-variants.tsx:159`) and keeps the header spelled the way the `to.have.header` line directly above it spells it. **Rejected:** lower-casing the index to `["content-type"]`. It works, but it teaches a spelling that silently breaks the moment someone copies the line to `pm.request.headers`, whose keys keep whatever the user typed - and it would hand-roll around the primitive rather than use it.

**Blast radius traced.** The completion list has one producer and two consumers: Monaco via `useScriptCompletionProvider`, and MCP agents via `vayu://scripting/completions`, which `docs/engine/mcp.md:346-349` describes as "the single source of truth that also feeds Monaco" - so the broken line reached agents too. The app holds no copy of this snippet (`"Content-Type is JSON"` appears only in `scripting.cpp`), so there is no second place to fix.

**Deviations from the issue spec:** none.

**Note on provenance:** #310 was filed and picked up in the same run. Every other open issue was ineligible - #180/#188 are parent/tracking issues, #134 is explicitly parked, #197 and #287 both need a quiet benchmark host, and #301's remaining step (the cookie jar) is gated on unanswered scope/lifetime/persistence questions plus #197's re-tune of `event_loop_worker.cpp`. This bug was already recorded on #180 as work worth doing ("Worth a small sub-issue: fix both strings, and add a `script_completions_test.cpp` case") and was never filed. Half of it had since been fixed - the `pm.response.headers` documentation string at `:123` is already lower-case - so this is the residual half.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**860/860 engine tests pass**, including the two added here (`ScriptCompletions` suite: 10 -> 12).

Both new tests are mutation-checked - with the `["Content-Type"]` index restored and rebuilt, both go red, and the executable one fails with the exact symptom a user would see:

```
the offered Content-Type snippet fails against a JSON response:
TypeError: Expected undefined to include 'application/json'
```

- `TheContentTypeSnippetPassesAgainstAJsonResponse` - runs the offered snippet against a 200 `content-type: application/json; charset=utf-8` response and requires the `pm.test` to pass. A shape check could not have caught this: the broken form was valid JS that failed as an assertion.
- `NoOfferedResponseHeaderIndexUsesAMixedCaseKey` - scans every offered `insertText` / `documentation` / `detail` for `pm.response.headers[...]` and requires the key to be lower-case, asserting the scan found at least one occurrence so it cannot pass by scanning nothing (per CLAUDE.md).

No app-side test run: the diff is engine-only C++ and no TypeScript test could change colour.

**Pre-existing, reproduces on the base commit, not touched here:** `scripts/pre-commit` reports two `unused-lambda-capture` warnings at `scripting.cpp:1116` and `:1141` (route registrations, unrelated to this diff), and local clang-tidy 18.1.3 cannot parse `engine/.clang-tidy`'s `ExcludeHeaderFilterRegex` key. The test file also carries 600 pre-existing clang-format violations, so per CLAUDE.md's "format only files you touched that were clean before" it was not reformatted; the added code follows the file's existing style.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Documentation: **no change needed, verified.** No doc reproduces the snippet, and no `pm.*` capability changes, so `docs/app/pm-api-compatibility.md` and `docs/engine/scripting.md` are correct as they stand.

## Related Issues
Closes #310

Sub-issue of #180; the finding was originally recorded in [this comment](https://github.com/athrvk/vayu/issues/180#issuecomment-5120771644) while doing #182 (PR #203).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3J89bTMpifs314Js8w5ye)_