### PR TITLE
fix(mcp): bound the load-run fields the safety caps could not reach

### DIFF
--- a/app/electron/mcp/config.test.ts
+++ b/app/electron/mcp/config.test.ts
@@ -57,6 +57,8 @@ describe("sanitizeSafetyInput", () => {
 		expect(
 			sanitizeSafetyInput({ maxDurationSeconds: Number.NaN }).maxDurationSeconds
 		).toBeUndefined();
+		expect(sanitizeSafetyInput({ maxIterations: 5000.7 }).maxIterations).toBe(5000);
+		expect(sanitizeSafetyInput({ maxIterations: 0 }).maxIterations).toBeUndefined();
 	});
 
 	it("keeps allowWrites only when it is a boolean", () => {

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -32,10 +32,19 @@ export interface McpSafetyConfig {
 	allowAll: boolean;
 	/** Hard ceiling on `targetRps` for `start_load_run` (constant_rps mode). */
 	maxRps: number;
-	/** Hard ceiling on `concurrency` for closed-loop load modes. */
+	/**
+	 * Hard ceiling on `concurrency` for closed-loop load modes, and on the
+	 * `startConcurrency` a ramp is seeded with.
+	 */
 	maxConcurrency: number;
 	/** Hard ceiling on a load run's duration, in seconds. */
 	maxDurationSeconds: number;
+	/**
+	 * Hard ceiling on `iterations` for an iterations-mode run. Its own cap
+	 * because that mode stops on a request count and never reads `duration`, so
+	 * `maxDurationSeconds` cannot bound it - see `checkLoadCaps`.
+	 */
+	maxIterations: number;
 	/**
 	 * Gates data-mutating tools (`create_request`, `update_environment`,
 	 * `update_engine_config`). When false (default), those tools refuse. It does
@@ -62,6 +71,10 @@ export const DEFAULT_MCP_SAFETY_CONFIG: McpSafetyConfig = {
 	maxRps: 1000,
 	maxConcurrency: 200,
 	maxDurationSeconds: 300,
+	// Ten times the engine's own default of 1000 iterations: an ordinary run an
+	// agent sizes for itself passes, and one that mistook the field for
+	// "unlimited" does not.
+	maxIterations: 10000,
 	allowWrites: false,
 	disabledTools: [],
 };
@@ -114,6 +127,9 @@ export function sanitizeSafetyInput(input: Partial<McpSafetyConfig>): Partial<Mc
 	}
 	if (isFiniteNumber(input.maxDurationSeconds) && input.maxDurationSeconds > 0) {
 		out.maxDurationSeconds = Math.floor(input.maxDurationSeconds);
+	}
+	if (isFiniteNumber(input.maxIterations) && input.maxIterations > 0) {
+		out.maxIterations = Math.floor(input.maxIterations);
 	}
 	if (typeof input.allowAll === "boolean") {
 		out.allowAll = input.allowAll;

--- a/app/electron/mcp/safety.test.ts
+++ b/app/electron/mcp/safety.test.ts
@@ -77,6 +77,14 @@ describe("parseDurationSeconds", () => {
 		expect(parseDurationSeconds("soon")).toBeNull();
 		expect(parseDurationSeconds(undefined)).toBeNull();
 	});
+	// It reads a run's `duration`, which the engine requires to be positive
+	// (`validate_run_config`), so zero is not a duration it can return.
+	test("rejects zero, which the engine 400s", () => {
+		expect(parseDurationSeconds("0")).toBeNull();
+		expect(parseDurationSeconds("0s")).toBeNull();
+		expect(parseDurationSeconds("0ms")).toBeNull();
+		expect(parseDurationSeconds(0)).toBeNull();
+	});
 });
 
 describe("checkLoadCaps", () => {

--- a/app/electron/mcp/safety.test.ts
+++ b/app/electron/mcp/safety.test.ts
@@ -6,7 +6,13 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { extractHost, checkAllowlist, parseDurationSeconds, checkLoadCaps } from "./safety.js";
+import {
+	extractHost,
+	checkAllowlist,
+	parseDurationSeconds,
+	checkLoadCaps,
+	defaultDurationUnderCap,
+} from "./safety.js";
 import { DEFAULT_MCP_SAFETY_CONFIG, resolveSafetyConfig } from "./config.js";
 
 describe("extractHost", () => {
@@ -114,5 +120,95 @@ describe("checkLoadCaps", () => {
 	test("accepts a readable rampUpDuration and an absent duration", () => {
 		expect(checkLoadCaps({ rampUpDuration: "500ms" }, config).ok).toBe(true);
 		expect(checkLoadCaps({ concurrency: 10 }, config).ok).toBe(true);
+	});
+
+	// A ramp is seeded with `startConcurrency` before its first duration check,
+	// so a cap that reads only `concurrency` bounds the value the run ends at
+	// and not the one it starts with.
+	test("rejects a startConcurrency above the concurrency cap", () => {
+		const res = checkLoadCaps(
+			{ mode: "ramp_up", concurrency: 10, startConcurrency: 5000 },
+			config
+		);
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/startConcurrency 5000 exceeds the MCP cap of 200/);
+	});
+	test("accepts a startConcurrency at the cap", () => {
+		expect(
+			checkLoadCaps({ mode: "ramp_up", concurrency: 200, startConcurrency: 200 }, config).ok
+		).toBe(true);
+	});
+
+	// An iterations run stops on a request count and never reads `duration`, so
+	// `maxDurationSeconds` cannot bound it and `maxIterations` is what does.
+	test("rejects an iterations run above the iterations cap", () => {
+		const res = checkLoadCaps({ mode: "iterations", iterations: 1_000_000_000 }, config);
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/iterations 1000000000 exceeds the MCP cap of 10000/);
+	});
+	test("accepts an iterations run at the cap", () => {
+		expect(checkLoadCaps({ mode: "iterations", iterations: 10_000 }, config).ok).toBe(true);
+	});
+	test("compares an omitted count against the engine's own default of 1000", () => {
+		// An absent `iterations` is not "no iterations" - the engine runs 1000 -
+		// so a cap under that has to refuse the run rather than wave it through.
+		const tight = resolveSafetyConfig({ maxIterations: 500 });
+		const res = checkLoadCaps({ mode: "iterations" }, tight);
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/iterations 1000 exceeds the MCP cap of 500/);
+		expect(checkLoadCaps({ mode: "iterations" }, config).ok).toBe(true);
+	});
+	test("rejects a non-positive iterations count", () => {
+		const res = checkLoadCaps({ mode: "iterations", iterations: -1 }, config);
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/must be a positive whole number/);
+	});
+	test("an unrecognised mode carrying iterations is still bounded", () => {
+		// `LoadStrategy::create` falls through to the iterations strategy for a
+		// mode it cannot parse when the config has an `iterations` field, so a
+		// guard keying on the mode string alone would wave this past.
+		const res = checkLoadCaps({ mode: "burst", iterations: 1_000_000_000 }, config);
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/exceeds the MCP cap of 10000/);
+	});
+	test("a duration-mode run is not held to the iterations cap", () => {
+		expect(
+			checkLoadCaps(
+				{ mode: "constant_rps", iterations: 1_000_000_000, duration: "30s" },
+				config
+			).ok
+		).toBe(true);
+	});
+
+	// The engine 400s a zero-length run, so the tool names the field instead of
+	// starting a run that dies on arrival.
+	test("rejects a zero duration", () => {
+		const res = checkLoadCaps({ duration: "0s" }, config);
+		expect(res.ok).toBe(false);
+		expect(res.error).toMatch(/must be greater than zero/);
+	});
+	test("still accepts a zero rampUpDuration (an instant ramp the engine allows)", () => {
+		expect(
+			checkLoadCaps({ mode: "ramp_up", rampUpDuration: "0s", duration: "30s" }, config).ok
+		).toBe(true);
+	});
+});
+
+describe("defaultDurationUnderCap", () => {
+	test("supplies the cap when the run would otherwise take the engine's 60s default", () => {
+		const config = resolveSafetyConfig({ maxDurationSeconds: 30 });
+		expect(defaultDurationUnderCap({ mode: "constant_concurrency" }, config)).toBe("30s");
+	});
+	test("supplies nothing when the engine default is already inside the cap", () => {
+		const config = resolveSafetyConfig({ maxDurationSeconds: 300 });
+		expect(defaultDurationUnderCap({ mode: "constant_concurrency" }, config)).toBeNull();
+	});
+	test("supplies nothing when the caller gave a duration", () => {
+		const config = resolveSafetyConfig({ maxDurationSeconds: 30 });
+		expect(defaultDurationUnderCap({ duration: "10s" }, config)).toBeNull();
+	});
+	test("supplies nothing for an iterations run, which never reads duration", () => {
+		const config = resolveSafetyConfig({ maxDurationSeconds: 30 });
+		expect(defaultDurationUnderCap({ mode: "iterations", iterations: 10 }, config)).toBeNull();
 	});
 });

--- a/app/electron/mcp/safety.ts
+++ b/app/electron/mcp/safety.ts
@@ -113,14 +113,66 @@ export interface LoadRunParams {
 	mode?: string;
 	targetRps?: number;
 	concurrency?: number;
+	startConcurrency?: number;
 	duration?: string | number;
 	rampUpDuration?: string | number;
 	iterations?: number;
 }
 
 /**
- * Enforce the hard load caps (RPS / concurrency / duration). Returns the first
- * violation found, with a message naming the offending value and the ceiling.
+ * Modes the engine recognises (`parse_load_test_type`, `vayu/types.hpp`).
+ * Anything else falls through `LoadStrategy::create`, so the guard mirrors that
+ * fallback rather than trusting the string it was given.
+ */
+const KNOWN_LOAD_MODES = new Set(["constant_rps", "constant_concurrency", "ramp_up", "iterations"]);
+
+/**
+ * What the engine runs when `duration` is absent - `duration_field_ms(config,
+ * "duration", 60000)` in `load_strategy.cpp`. An omitted duration is therefore
+ * not "no duration", and a cap below this one only binds if the field is sent.
+ */
+const ENGINE_DEFAULT_DURATION_SECONDS = 60;
+
+/** What the engine runs when `iterations` is absent (`IterationsLoadStrategy`). */
+const ENGINE_DEFAULT_ITERATIONS = 1000;
+
+/**
+ * Whether the engine will run these params as an iterations run - the one mode
+ * that stops on a request count and never reads `duration`, so no duration cap
+ * can bound it. Mirrors `LoadStrategy::create` (`load_strategy.cpp`): an
+ * unrecognised mode carrying an `iterations` field still lands on that
+ * strategy, so keying on the mode string alone leaves a way past the cap.
+ */
+function isIterationsRun(params: LoadRunParams): boolean {
+	// The engine's own default for an absent `mode`, which is a duration mode.
+	const mode = params.mode ?? "constant_rps";
+	if (mode === "iterations") return true;
+	if (KNOWN_LOAD_MODES.has(mode)) return false;
+	return typeof params.iterations === "number";
+}
+
+/**
+ * The `duration` to send when the caller omitted one, or null when the engine
+ * default is already inside the cap and the payload needs no field. Iterations
+ * runs get null: `duration` is not read in that mode, so injecting it would be
+ * a value written and never read.
+ */
+export function defaultDurationUnderCap(
+	params: LoadRunParams,
+	config: McpSafetyConfig
+): string | null {
+	if (params.duration !== undefined) return null;
+	if (isIterationsRun(params)) return null;
+	if (config.maxDurationSeconds >= ENGINE_DEFAULT_DURATION_SECONDS) return null;
+	return `${config.maxDurationSeconds}s`;
+}
+
+/**
+ * Enforce the hard load caps (RPS / concurrency / duration / iterations).
+ * Returns the first violation found, with a message naming the offending value
+ * and the ceiling. Every field `start_load_run` forwards to the engine that can
+ * grow a run is checked here - a forwarded field this function does not read is
+ * a cap that cannot fire.
  */
 export function checkLoadCaps(params: LoadRunParams, config: McpSafetyConfig): GuardResult {
 	if (typeof params.targetRps === "number" && params.targetRps > config.maxRps) {
@@ -129,11 +181,17 @@ export function checkLoadCaps(params: LoadRunParams, config: McpSafetyConfig): G
 			error: `targetRps ${params.targetRps} exceeds the MCP cap of ${config.maxRps}. Lower it or raise the cap in Settings.`,
 		};
 	}
-	if (typeof params.concurrency === "number" && params.concurrency > config.maxConcurrency) {
-		return {
-			ok: false,
-			error: `concurrency ${params.concurrency} exceeds the MCP cap of ${config.maxConcurrency}. Lower it or raise the cap in Settings.`,
-		};
+	// `startConcurrency` rides the same ceiling as `concurrency`: `ramp_up` seeds
+	// the run with it (`RampUpLoadStrategy`, `target_fn(0) = startConcurrency`),
+	// so an uncapped start is an uncapped run however low the target is.
+	for (const field of ["concurrency", "startConcurrency"] as const) {
+		const value = params[field];
+		if (typeof value === "number" && value > config.maxConcurrency) {
+			return {
+				ok: false,
+				error: `${field} ${value} exceeds the MCP cap of ${config.maxConcurrency}. Lower it or raise the cap in Settings.`,
+			};
+		}
 	}
 	// A duration the engine cannot read now fails the run rather than quietly
 	// becoming 60s, so say so here instead of starting a run that dies.
@@ -147,11 +205,36 @@ export function checkLoadCaps(params: LoadRunParams, config: McpSafetyConfig): G
 		}
 	}
 	const durationSeconds = parseDurationSeconds(params.duration);
+	// The engine rejects a zero-length run with a 400 (`validate_run_config`),
+	// so name the field here instead of surfacing that error. `rampUpDuration`
+	// is deliberately exempt: zero there is an instant ramp, which the engine
+	// accepts (`ramp_target_concurrency` returns the target for `ramp_ms <= 0`).
+	if (durationSeconds !== null && durationSeconds <= 0) {
+		return {
+			ok: false,
+			error: `duration ${JSON.stringify(params.duration)} must be greater than zero - the engine refuses a run with no time to run in.`,
+		};
+	}
 	if (durationSeconds !== null && durationSeconds > config.maxDurationSeconds) {
 		return {
 			ok: false,
 			error: `duration ${params.duration} (${durationSeconds}s) exceeds the MCP cap of ${config.maxDurationSeconds}s. Shorten it or raise the cap in Settings.`,
 		};
+	}
+	if (isIterationsRun(params)) {
+		const iterations = params.iterations ?? ENGINE_DEFAULT_ITERATIONS;
+		if (!Number.isFinite(iterations) || iterations <= 0) {
+			return {
+				ok: false,
+				error: `iterations ${JSON.stringify(params.iterations)} must be a positive whole number of requests.`,
+			};
+		}
+		if (iterations > config.maxIterations) {
+			return {
+				ok: false,
+				error: `iterations ${iterations} exceeds the MCP cap of ${config.maxIterations}. An iterations run stops on request count rather than time, so the duration cap cannot bound it - lower iterations, use a duration-bounded mode, or raise the cap in Settings.`,
+			};
+		}
 	}
 	return OK;
 }

--- a/app/electron/mcp/safety.ts
+++ b/app/electron/mcp/safety.ts
@@ -78,15 +78,17 @@ export function checkAllowlist(url: string, config: McpSafetyConfig): GuardResul
 }
 
 /**
- * Parse an engine duration string ("60s", "5m", "1h", or a bare number of
- * seconds) into seconds. Returns null for unparseable input.
+ * The duration *grammar* only: "60s", "5m", "1h", "500ms", or a bare number of
+ * seconds, into seconds. Null when the text is not a duration at all.
  *
- * The accepted grammar mirrors the engine's `parse_duration_ms`
+ * Mirrors the engine's `parse_duration_ms`
  * (`engine/include/vayu/core/load_pacing.hpp`): the same units, the same
- * bare-number-is-seconds rule. They must agree, or a duration this cap reads as
- * 5 minutes runs for some other length.
+ * bare-number-is-seconds rule, and the same acceptance of zero. They must
+ * agree, or a duration this cap reads as 5 minutes runs for some other length.
+ * Zero belongs here because `rampUpDuration: "0"` is a legal instant ramp - the
+ * range rule that rejects a zero *run* is `parseDurationSeconds` below.
  */
-export function parseDurationSeconds(value: string | number | undefined): number | null {
+function parseDurationGrammar(value: string | number | undefined): number | null {
 	if (value === undefined || value === null) return null;
 	if (typeof value === "number") return Number.isFinite(value) && value >= 0 ? value : null;
 	const trimmed = value.trim().toLowerCase();
@@ -106,6 +108,17 @@ export function parseDurationSeconds(value: string | number | undefined): number
 		default:
 			return n;
 	}
+}
+
+/**
+ * A run `duration` in seconds, or null when the engine would refuse it: the
+ * grammar above plus the engine's own range rule, which requires a positive
+ * magnitude (`validate_run_config`, `execution.cpp`). Zero is therefore not a
+ * duration here, the same way `POST /runs` 400s it.
+ */
+export function parseDurationSeconds(value: string | number | undefined): number | null {
+	const seconds = parseDurationGrammar(value);
+	return seconds === null || seconds <= 0 ? null : seconds;
 }
 
 /** Parameters extracted from a `start_load_run` request, for cap checking. */
@@ -197,19 +210,20 @@ export function checkLoadCaps(params: LoadRunParams, config: McpSafetyConfig): G
 	// becoming 60s, so say so here instead of starting a run that dies.
 	for (const field of ["duration", "rampUpDuration"] as const) {
 		const value = params[field];
-		if (value !== undefined && parseDurationSeconds(value) === null) {
+		if (value !== undefined && parseDurationGrammar(value) === null) {
 			return {
 				ok: false,
 				error: `${field} ${JSON.stringify(value)} is not a duration. Use a non-negative number with an optional ms/s/m/h unit, e.g. "500ms", "30s", "5m", "2h".`,
 			};
 		}
 	}
+	// Past the grammar, `duration` still has a range rule `rampUpDuration` does
+	// not: the engine 400s a zero-length run (`validate_run_config`) while a
+	// zero ramp is an instant one it accepts (`ramp_target_concurrency` returns
+	// the target for `ramp_ms <= 0`). So only this field goes through the
+	// stricter parse, and a null here can only mean zero.
 	const durationSeconds = parseDurationSeconds(params.duration);
-	// The engine rejects a zero-length run with a 400 (`validate_run_config`),
-	// so name the field here instead of surfacing that error. `rampUpDuration`
-	// is deliberately exempt: zero there is an instant ramp, which the engine
-	// accepts (`ramp_target_concurrency` returns the target for `ramp_ms <= 0`).
-	if (durationSeconds !== null && durationSeconds <= 0) {
+	if (params.duration !== undefined && durationSeconds === null) {
 		return {
 			ok: false,
 			error: `duration ${JSON.stringify(params.duration)} must be greater than zero - the engine refuses a run with no time to run in.`,

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -727,6 +727,93 @@ describe("dispatchTool", () => {
 		expect(client.startRun).toHaveBeenCalledTimes(1);
 	});
 
+	// --- Load caps reach every field the run is actually built from (#312) ---
+
+	test("start_load_run refuses a startConcurrency over the cap", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_load_run",
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				mode: "ramp_up",
+				concurrency: 10,
+				startConcurrency: 900,
+				duration: "30s",
+				confirmed: true,
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"], maxConcurrency: 200 })
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/startConcurrency 900 exceeds/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("start_load_run refuses an unbounded iterations run", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_load_run",
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				mode: "iterations",
+				iterations: 1_000_000_000,
+				confirmed: true,
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"], maxIterations: 10000 })
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/iterations 1000000000 exceeds the MCP cap of 10000/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("the schema refuses load counts the engine reads as enormous", () => {
+		// `-1` is the natural "unlimited" guess and casts to ~1.8e19 engine-side,
+		// where it is a request count and a ramp seed, not an error.
+		for (const field of ["startConcurrency", "iterations"]) {
+			expect(() =>
+				parseArgs("start_load_run", { url: "https://api.example.com", [field]: -1 })
+			).toThrow();
+			expect(() =>
+				parseArgs("start_load_run", { url: "https://api.example.com", [field]: 0 })
+			).toThrow();
+			expect(() =>
+				parseArgs("start_load_run", { url: "https://api.example.com", [field]: 2.5 })
+			).toThrow();
+		}
+	});
+
+	test("start_load_run sends an explicit duration when the cap is under the engine default", async () => {
+		// An omitted duration is 60s engine-side, so a 30s cap that says nothing
+		// gets a 60s run.
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_load_run",
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				concurrency: 10,
+				confirmed: true,
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"], maxDurationSeconds: 30 })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload.duration).toBe("30s");
+	});
+
+	test("start_load_run leaves the duration alone when the cap is above the engine default", async () => {
+		const client = fakeClient();
+		await dispatchTool(
+			"start_load_run",
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				concurrency: 10,
+				confirmed: true,
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"], maxDurationSeconds: 300 })
+		);
+		const payload = (client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload.duration).toBeUndefined();
+	});
+
 	test("start_load_run forwards an agent-supplied httpVersion", async () => {
 		const client = fakeClient();
 		const res = await dispatchTool(

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -21,7 +21,8 @@ import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { EngineClient } from "./engine-client.js";
 import { EngineRequestError } from "./engine-client.js";
 import type { McpSafetyConfig } from "./config.js";
-import { checkAllowlist, checkLoadCaps } from "./safety.js";
+import type { LoadRunParams } from "./safety.js";
+import { checkAllowlist, checkLoadCaps, defaultDurationUnderCap } from "./safety.js";
 import { compareReports } from "./compare.js";
 import { HTTP_VERSIONS } from "./http-versions.js";
 
@@ -355,6 +356,12 @@ async function composeLoadRunRequest(
 
 	return { payload, droppedPreRequestScripts };
 }
+
+/**
+ * Mode `start_load_run` sends when the agent names none. Closed-loop and
+ * duration-bounded, so an unspecified run is one the duration cap can hold.
+ */
+const DEFAULT_LOAD_MODE = "constant_concurrency";
 
 // --- Shared input schema fragments ------------------------------------------
 
@@ -1026,8 +1033,13 @@ export const TOOLS: McpTool[] = [
 				.positive()
 				.optional()
 				.describe("Target in-flight requests."),
+			// Positive for the same reason `concurrency` is: the ramp is seeded
+			// with this count, so a negative casts to ~1.8e19 engine-side and a
+			// zero start is a ramp that begins with no traffic at all.
 			startConcurrency: z
 				.number()
+				.int()
+				.positive()
 				.optional()
 				.describe("Ramp start concurrency (ramp_up). Above `concurrency` ramps down."),
 			duration: z
@@ -1040,7 +1052,14 @@ export const TOOLS: McpTool[] = [
 				.string()
 				.optional()
 				.describe("Ramp time (ramp_up), same units as `duration`."),
-			iterations: z.number().optional().describe("Iteration count (iterations mode)."),
+			// An iterations run stops on this count and reads no duration, so it
+			// is the only thing bounding the run; `-1` would cast to ~1.8e19.
+			iterations: z
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe("Iteration count (iterations mode)."),
 			targetRps: z.number().optional().describe("Target RPS (constant_rps)."),
 			maxInFlight: z.number().optional().describe("In-flight cap (constant_rps only)."),
 			requestId: z
@@ -1077,10 +1096,17 @@ export const TOOLS: McpTool[] = [
 			const gate = checkAllowlist(url, ctx.config);
 			if (!gate.ok) return errorResult(gate.error!);
 
-			const loadParams = {
-				mode: str(args, "mode"),
+			// One mode string for both the guard and the payload: which strategy
+			// the engine picks decides which cap applies, so a guard reading a
+			// different mode than the run uses is a guard reading the wrong run.
+			const mode = str(args, "mode") ?? DEFAULT_LOAD_MODE;
+			const loadParams: LoadRunParams = {
+				mode,
 				targetRps: typeof args.targetRps === "number" ? args.targetRps : undefined,
 				concurrency: typeof args.concurrency === "number" ? args.concurrency : undefined,
+				startConcurrency:
+					typeof args.startConcurrency === "number" ? args.startConcurrency : undefined,
+				iterations: typeof args.iterations === "number" ? args.iterations : undefined,
 				duration: (args.duration as string | number | undefined) ?? undefined,
 				rampUpDuration: (args.rampUpDuration as string | number | undefined) ?? undefined,
 			};
@@ -1089,7 +1115,7 @@ export const TOOLS: McpTool[] = [
 
 			const payload: Record<string, unknown> = {
 				...composed.payload,
-				mode: str(args, "mode") ?? "constant_concurrency",
+				mode,
 			};
 			for (const key of [
 				"concurrency",
@@ -1104,6 +1130,11 @@ export const TOOLS: McpTool[] = [
 				const v = str(args, key);
 				if (v !== undefined) payload[key] = v;
 			}
+			// An omitted duration is 60s engine-side, not "unbounded" and not
+			// "capped" - so a cap under 60s has to be sent as an explicit field
+			// or it never reaches the run.
+			const cappedDuration = defaultDurationUnderCap(loadParams, ctx.config);
+			if (cappedDuration !== null) payload.duration = cappedDuration;
 
 			// A saved request's pre-request script cannot run under load - the
 			// engine has no such hook on POST /runs. Say so rather than let an agent

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
@@ -154,7 +154,7 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
 }
 
 interface CapField {
-	key: "maxRps" | "maxConcurrency" | "maxDurationSeconds";
+	key: "maxRps" | "maxConcurrency" | "maxDurationSeconds" | "maxIterations";
 	label: string;
 	description: string;
 }
@@ -174,6 +174,12 @@ const CAP_FIELDS: CapField[] = [
 		key: "maxDurationSeconds",
 		label: "Max duration (seconds)",
 		description: "Ceiling on how long a load run may last.",
+	},
+	{
+		key: "maxIterations",
+		label: "Max iterations",
+		description:
+			"Ceiling on requests for an iterations run, which stops on a count rather than a duration.",
 	},
 ];
 

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -931,6 +931,11 @@ export interface McpSafetyConfig {
 	maxConcurrency: number;
 	/** Hard ceiling on a load run's duration, in seconds. */
 	maxDurationSeconds: number;
+	/**
+	 * Hard ceiling on `iterations` for an iterations-mode run, which stops on a
+	 * request count and so cannot be bounded by `maxDurationSeconds`.
+	 */
+	maxIterations: number;
 	/** When false (default), collection/environment write tools are disabled. */
 	allowWrites: boolean;
 	/** Tool names the user has switched off (omitted from tools/list + rejected). */

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1340,6 +1340,7 @@ default, and whose message names the offending field and why the bound exists:
 | `max_sample_bytes` | `0`-`1073741824` | The whole-run capture budget; every byte under it is held in memory until the run flushes. Defaults to the `maxSampleBytes` setting. |
 | `max_exemplar_results` | `0`-`100000` | Each retained exemplar holds a captured exchange. `0` means unlimited. |
 | `concurrency` | `1`-`10000` | Connections are eagerly pre-allocated per worker before any traffic flows, so `-1` (a natural "unlimited" guess) allocated until malloc failed. |
+| `startConcurrency` | `1`-`10000` | The ramp is seeded with this many in-flight requests before the first duration check, and it is read as a `size_t`, so a negative start is ~1.8e19 of them. |
 | `timeout` | `1`-`86400000` ms | A transfer that never times out never completes, leaving the run stuck `running` and unstoppable. |
 | `duration` | string, positive, optional unit (`ms`\|`s`\|`m`\|`h`) | A JSON *number* threw out of the run-context constructor *after* the row was written, stranding it `pending` forever behind an opaque `500`. |
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -385,17 +385,32 @@ configurable in **Settings → MCP** and persisted.
   from inside a script could not be checked at all - so `pm.sendRequest` is
   refused outright for runs this server starts. See
   [The script sandbox surface](#pmsendrequest-is-refused-for-mcp-started-runs).
-- **Hard caps** - max RPS / concurrency / duration on `start_load_run`; over-cap
-  requests are rejected. With the allowlist, these are the real limits on load.
-  The caps bound values from above; `concurrency` is additionally constrained to
-  a positive integer by the tool's own schema, because "unlimited" is an obvious
-  guess to spell `-1` or `0` and the engine reads it as an eager per-worker
-  pre-allocation count (see the accepted ranges under
-  [POST /runs](api-reference.md#post-runs)).
+- **Hard caps** - max RPS / concurrency / duration / iterations on
+  `start_load_run`; over-cap requests are rejected. With the allowlist, these are
+  the real limits on load, and they cover **every** field the tool forwards:
+    - `concurrency` **and** `startConcurrency` are both held to the concurrency
+      cap. A ramp is seeded with `startConcurrency` before its first duration
+      check, so capping only the target would bound where a run ends and not
+      where it starts.
+    - An **iterations** run stops on a request count and never reads `duration`,
+      so no duration cap can bound it. **Max iterations** is its own setting for
+      that reason (10000 by default). An omitted `iterations` is compared as the
+      engine's own default of 1000, and an unrecognised `mode` carrying an
+      `iterations` field is capped the same way, because the engine runs that as
+      an iterations run too.
+    - An **omitted** `duration` is 60s engine-side, not "unbounded" and not
+      "capped". When `maxDurationSeconds` is under 60, the tool sends the cap as
+      an explicit duration so the run is actually bounded by it.
+  `concurrency`, `startConcurrency` and `iterations` are additionally constrained
+  to positive integers by the tool's own schema, because "unlimited" is an
+  obvious guess to spell `-1` or `0` and the engine reads them as an eager
+  per-worker pre-allocation count, a ramp seed, and a request budget (see the
+  accepted ranges under [POST /runs](api-reference.md#post-runs)).
   `duration` / `rampUpDuration` are also rejected when they are not durations at
   all (`ms`/`s`/`m`/`h`, or a bare number of seconds - the same grammar the
   engine parses), since the engine now fails such a run rather than quietly
-  substituting 60s.
+  substituting 60s; a zero `duration` is rejected here for the same reason the
+  engine `400`s it, while a zero `rampUpDuration` stays legal (an instant ramp).
 - **Load-run confirmation** - anti-accident, not anti-adversary: it stops a stray
   tool call from starting load, but on HTTP it is agent-side (the caps/allowlist
   are the enforcement). Elicitation upgrades it to a human prompt where supported.
@@ -424,8 +439,9 @@ process did not already have.
 | `allowlist`          | `[]`    | Permitted hostnames (empty = deny all).       |
 | `allowAll`           | `false` | Bypass the allowlist for any resolvable host. |
 | `maxRps`             | `1000`  | Cap on `targetRps`.                           |
-| `maxConcurrency`     | `200`   | Cap on `concurrency`.                         |
+| `maxConcurrency`     | `200`   | Cap on `concurrency` and `startConcurrency`.  |
 | `maxDurationSeconds` | `300`   | Cap on load-run duration.                     |
+| `maxIterations`      | `10000` | Cap on `iterations` (iterations mode).        |
 | `allowWrites`        | `false` | Enable the data-mutating tools.               |
 | `disabledTools`      | `[]`    | Tool names to hide/reject.                    |
 

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -587,6 +587,10 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         "Each retained exemplar holds a captured exchange." },
         { "concurrency", 1, limits::MAX_CONCURRENCY,
         "Connections are pre-allocated per worker before any traffic flows." },
+        { "startConcurrency", 1, limits::MAX_CONCURRENCY,
+        "A ramp is seeded with this many in-flight requests before the first "
+        "duration check, and it is read as a size_t, so a negative start is "
+        "~1.8e19 of them." },
         { "timeout", 1, 86400000,
         "A transfer with no timeout never completes, so the run can never "
         "reach "

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -144,6 +144,26 @@ TEST (RunConfigValidation, ConcurrencyBoundsAreInclusive) {
     expect_rejected (config, "concurrency");
 }
 
+// `startConcurrency` seeds the ramp before the first duration check, and the
+// MCP cap could not see it at all until it was checked here too.
+TEST (RunConfigValidation, NegativeStartConcurrencyIsRejected) {
+    auto config                = valid_config ();
+    config["mode"]             = "ramp_up";
+    config["startConcurrency"] = -1;
+    expect_rejected (config, "startConcurrency");
+}
+
+TEST (RunConfigValidation, StartConcurrencyBoundsAreInclusive) {
+    auto config                = valid_config ();
+    config["mode"]             = "ramp_up";
+    config["startConcurrency"] = 1;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    config["startConcurrency"] = vayu::core::constants::run_config::MAX_CONCURRENCY;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    config["startConcurrency"] = vayu::core::constants::run_config::MAX_CONCURRENCY + 1;
+    expect_rejected (config, "startConcurrency");
+}
+
 // --- 3. Timeout: <= 0 left transfers that never expire ---------------------
 
 TEST (RunConfigValidation, ZeroTimeoutIsRejected) {


### PR DESCRIPTION
## Description

**Plan.** Root cause: `checkLoadCaps` bounded `targetRps` / `concurrency` / `duration`, but `start_load_run` forwards `startConcurrency` and `iterations` to `POST /runs` as well, and an omitted `duration` is 60s engine-side rather than "unbounded" - so a forwarded field the guard never read is a cap that cannot fire. Approach: make the guard read every field the run is actually built from, give the one mode that no duration cap can bound (`iterations`, which stops on a request count) its own cap, and inject an explicit duration when the engine default would outrun a sub-60s cap. Alternative rejected: bounding an iterations run by requiring or injecting a `duration` - `IterationsLoadStrategy` never reads `duration` (its stop predicate is the request count alone), so that would have enforced nothing.

What changed:

- **`startConcurrency`** rides the concurrency cap (`max(concurrency, startConcurrency) <= maxConcurrency`), its schema is `.int().positive()` like its sibling, and the engine's `validate_run_config` field table range-checks it beside `concurrency`. A ramp is seeded with this value before its first duration check, so capping only the target bounded where a run ends and not where it starts.
- **`maxIterations`** is a new `McpSafetyConfig` cap (default `10000`, ten times the engine's own default of 1000): type + default + sanitizer clause in `config.ts`, mirrored in `app/src/types/domain.ts`, and a row in `McpSettingsPanel.tsx` (the panel maps `CAP_FIELDS` generically, so the row reads and writes through the existing `commitCap` path). An omitted `iterations` is compared as the engine default of 1000, and an unrecognised `mode` carrying an `iterations` field is capped too, because `LoadStrategy::create` falls through to the iterations strategy for exactly that shape.
- **Omitted `duration`**: the handler sends `duration: "<cap>s"` when `maxDurationSeconds` is under the engine's 60s default and the mode is not `iterations` (where the field is never read, so injecting it would be written-never-read).
- **Zero `duration`** is rejected by `parseDurationSeconds` itself, as the issue's Tests section asks. The two rules that were sharing that function are now split: `parseDurationGrammar` (module-private) mirrors the engine's `parse_duration_ms` and still accepts zero, which is what the Fix section's `rampUpDuration: "0"` case needs - a zero ramp is an instant one the engine allows; `parseDurationSeconds` layers the engine's own positive-magnitude rule (`validate_run_config`) on top, so a zero *run* is not a duration it can return. `checkLoadCaps` reads the grammar for both fields when deciding "is this a duration at all", and the strict parse for `duration` alone. A test pins that `rampUpDuration: "0s"` still passes.
- The handler now resolves the load mode **once** for both the guard and the payload. It previously defaulted the payload to `constant_concurrency` while handing the guard an undefined mode, so the guard could reason about a different run than the one that started.

**One deviation from the literal issue text**, noted deliberately: bounding an unrecognised `mode` that carries `iterations` is slightly beyond the `mode: "iterations"` wording, but it mirrors `LoadStrategy::create` and closes the obvious way around the new cap.

Out of scope and left alone: `maxInFlight` is still forwarded unvalidated. It is a backpressure ceiling rather than a traffic multiplier (RPS and duration still bound that run), but a negative value casts to ~1.8e19 engine-side, i.e. no backpressure at all. Filed as #324 rather than widened into this diff.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **2581 passed / 290 files**, including 157 in `electron/mcp/`.
- `cd app && pnpm type-check`, `pnpm lint`, prettier on the touched files - all clean.
- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **862/862 passed**, `RunConfigValidation` 27/27 including the two new `startConcurrency` cases.
- **Mutation-checked**, each fix reverted and the suite re-run:
  - dropping `startConcurrency` from the cap loop, disabling the iterations cap, disabling the zero-duration check and the duration injection → **10 app tests fail**;
  - deleting the `maxIterations` sanitizer clause and the cap read → **5 fail**;
  - collapsing `parseDurationSeconds` back onto the bare grammar → **2 fail** (the parser test and the guard's zero-duration test);
  - removing the `startConcurrency` entry from the engine field table and rebuilding → **both new gtests fail**.
  All restored and green afterwards.
- No pre-existing failures observed on this base (`10c8193`).

`mkdocs build --strict` was not run locally (mkdocs is not installed in this environment); the docs edits add no pages, anchors or new links, and CI gates it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #312