### PR TITLE
fix(mcp): sanitize the stdio CLI's safety config from the environment

### DIFF
--- a/app/electron/mcp/cli.ts
+++ b/app/electron/mcp/cli.ts
@@ -18,37 +18,20 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createMcpServer } from "./server.js";
 import { EngineClient } from "./engine-client.js";
-import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
+import { buildSafetyConfigFromEnv } from "./config.js";
 import type { ToolContext } from "./tools.js";
-
-function readSafetyFromEnv(): Partial<McpSafetyConfig> {
-	const env = process.env;
-	const cfg: Partial<McpSafetyConfig> = {};
-	if (env.VAYU_MCP_ALLOWLIST) {
-		cfg.allowlist = env.VAYU_MCP_ALLOWLIST.split(",")
-			.map((h) => h.trim())
-			.filter(Boolean);
-	}
-	if (env.VAYU_MCP_MAX_RPS) cfg.maxRps = Number(env.VAYU_MCP_MAX_RPS);
-	if (env.VAYU_MCP_MAX_CONCURRENCY) cfg.maxConcurrency = Number(env.VAYU_MCP_MAX_CONCURRENCY);
-	if (env.VAYU_MCP_MAX_DURATION_SECONDS)
-		cfg.maxDurationSeconds = Number(env.VAYU_MCP_MAX_DURATION_SECONDS);
-	if (env.VAYU_MCP_ALLOW_ALL === "true") cfg.allowAll = true;
-	if (env.VAYU_MCP_ALLOW_WRITES === "true") cfg.allowWrites = true;
-	if (env.VAYU_MCP_DISABLED_TOOLS) {
-		cfg.disabledTools = env.VAYU_MCP_DISABLED_TOOLS.split(",")
-			.map((t) => t.trim())
-			.filter(Boolean);
-	}
-	return cfg;
-}
 
 async function main(): Promise<void> {
 	const engineBaseUrl = process.env.VAYU_ENGINE_URL ?? "http://127.0.0.1:9876";
 	const version = process.env.VAYU_VERSION ?? "0.0.0";
 
 	const client = new EngineClient({ baseUrl: engineBaseUrl });
-	const config = resolveSafetyConfig(readSafetyFromEnv());
+	const { config, ignored } = buildSafetyConfigFromEnv(process.env);
+	for (const { variable, value, fallback } of ignored) {
+		console.error(
+			`[vayu-mcp] ignoring malformed ${variable}=${JSON.stringify(value)} (using default ${JSON.stringify(fallback)})`
+		);
+	}
 	const contextProvider = (): ToolContext => ({ client, config });
 
 	const server = createMcpServer({ name: "vayu", version }, contextProvider);

--- a/app/electron/mcp/config.test.ts
+++ b/app/electron/mcp/config.test.ts
@@ -7,11 +7,13 @@
 
 import { describe, it, expect } from "vitest";
 import {
+	buildSafetyConfigFromEnv,
 	DEFAULT_MCP_SAFETY_CONFIG,
 	normalizeHost,
 	resolveSafetyConfig,
 	sanitizeSafetyInput,
 } from "./config.js";
+import { checkAllowlist, checkLoadCaps } from "./safety.js";
 
 describe("normalizeHost", () => {
 	it("strips scheme, port, path, and query and lowercases", () => {
@@ -94,5 +96,105 @@ describe("sanitizeSafetyInput", () => {
 	it("round-trips cleanly through resolveSafetyConfig onto defaults", () => {
 		const resolved = resolveSafetyConfig(sanitizeSafetyInput({ allowlist: ["a.com"] }));
 		expect(resolved).toEqual({ ...DEFAULT_MCP_SAFETY_CONFIG, allowlist: ["a.com"] });
+	});
+});
+
+/*
+ * The seam the stdio CLI (`cli.ts`) builds its config from. These assert the
+ * guards downstream of it - a cap that still refuses, a host that still matches
+ * - because a `NaN` cap is not visibly wrong in the config object; it is only
+ * wrong at the `x > NaN` comparison inside `checkLoadCaps`.
+ */
+describe("buildSafetyConfigFromEnv", () => {
+	it("falls back to the default cap when a cap variable is not a number", () => {
+		const { config } = buildSafetyConfigFromEnv({ VAYU_MCP_MAX_RPS: "1,000" });
+
+		expect(config.maxRps).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxRps);
+		expect(Number.isNaN(config.maxRps)).toBe(false);
+		// The cap has to still fire - an unsanitized NaN would let this through.
+		expect(checkLoadCaps({ targetRps: 50000 }, config).ok).toBe(false);
+	});
+
+	it("falls back for every cap variable, not just RPS", () => {
+		const { config } = buildSafetyConfigFromEnv({
+			VAYU_MCP_MAX_CONCURRENCY: "500rps",
+			VAYU_MCP_MAX_DURATION_SECONDS: "unset",
+		});
+
+		expect(config.maxConcurrency).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxConcurrency);
+		expect(config.maxDurationSeconds).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxDurationSeconds);
+		expect(checkLoadCaps({ concurrency: 10000 }, config).ok).toBe(false);
+		expect(checkLoadCaps({ duration: "24h" }, config).ok).toBe(false);
+	});
+
+	it("rejects a non-positive cap the same way the Settings path does", () => {
+		const { config } = buildSafetyConfigFromEnv({ VAYU_MCP_MAX_RPS: "0" });
+
+		expect(config.maxRps).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxRps);
+	});
+
+	it("normalizes allowlist entries carrying a scheme or a port", () => {
+		const { config } = buildSafetyConfigFromEnv({
+			VAYU_MCP_ALLOWLIST: "https://api.example.com, localhost:9876 , API.EXAMPLE.COM",
+		});
+
+		expect(config.allowlist).toEqual(["api.example.com", "localhost"]);
+		expect(checkAllowlist("https://api.example.com/users", config).ok).toBe(true);
+		expect(checkAllowlist("http://localhost:9876/health", config).ok).toBe(true);
+	});
+
+	it("names each ignored variable, its raw value, and the default that applied", () => {
+		const { ignored } = buildSafetyConfigFromEnv({
+			VAYU_MCP_MAX_RPS: "1,000",
+			VAYU_MCP_MAX_CONCURRENCY: "200",
+		});
+
+		expect(ignored).toEqual([
+			{
+				variable: "VAYU_MCP_MAX_RPS",
+				value: "1,000",
+				fallback: DEFAULT_MCP_SAFETY_CONFIG.maxRps,
+			},
+		]);
+	});
+
+	it("reports nothing when every variable is well-formed", () => {
+		const { config, ignored } = buildSafetyConfigFromEnv({
+			VAYU_MCP_ALLOWLIST: "api.example.com",
+			VAYU_MCP_MAX_RPS: "50",
+			VAYU_MCP_MAX_CONCURRENCY: "10",
+			VAYU_MCP_MAX_DURATION_SECONDS: "30",
+			VAYU_MCP_ALLOW_ALL: "true",
+			VAYU_MCP_ALLOW_WRITES: "true",
+			VAYU_MCP_DISABLED_TOOLS: "run_request, stop_run",
+		});
+
+		expect(ignored).toEqual([]);
+		expect(config).toEqual({
+			allowlist: ["api.example.com"],
+			allowAll: true,
+			maxRps: 50,
+			maxConcurrency: 10,
+			maxDurationSeconds: 30,
+			allowWrites: true,
+			disabledTools: ["run_request", "stop_run"],
+		});
+	});
+
+	it("returns the safe defaults for an empty environment", () => {
+		const { config, ignored } = buildSafetyConfigFromEnv({});
+
+		expect(config).toEqual(DEFAULT_MCP_SAFETY_CONFIG);
+		expect(ignored).toEqual([]);
+	});
+
+	it('leaves the opt-in booleans off for any value other than "true"', () => {
+		const { config } = buildSafetyConfigFromEnv({
+			VAYU_MCP_ALLOW_ALL: "1",
+			VAYU_MCP_ALLOW_WRITES: "yes",
+		});
+
+		expect(config.allowAll).toBe(false);
+		expect(config.allowWrites).toBe(false);
 	});
 });

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -130,3 +130,83 @@ export function sanitizeSafetyInput(input: Partial<McpSafetyConfig>): Partial<Mc
 	}
 	return out;
 }
+
+/**
+ * The environment variable each safety field is read from by the stdio CLI.
+ * Lives beside the sanitizer so a value it drops can be named back to the
+ * operator without re-parsing the environment.
+ */
+const SAFETY_ENV_VARS = {
+	allowlist: "VAYU_MCP_ALLOWLIST",
+	allowAll: "VAYU_MCP_ALLOW_ALL",
+	maxRps: "VAYU_MCP_MAX_RPS",
+	maxConcurrency: "VAYU_MCP_MAX_CONCURRENCY",
+	maxDurationSeconds: "VAYU_MCP_MAX_DURATION_SECONDS",
+	allowWrites: "VAYU_MCP_ALLOW_WRITES",
+	disabledTools: "VAYU_MCP_DISABLED_TOOLS",
+} as const satisfies Record<keyof McpSafetyConfig, string>;
+
+/** An environment variable the sanitizer rejected, so the CLI can say so. */
+export interface IgnoredSafetyEnvVar {
+	/** The `VAYU_MCP_*` variable name. */
+	variable: string;
+	/** Its raw value, as it appeared in the environment. */
+	value: string;
+	/** The default that applies in its place. */
+	fallback: McpSafetyConfig[keyof McpSafetyConfig];
+}
+
+/** A safety config built from the environment, plus what was thrown away. */
+export interface EnvSafetyConfig {
+	config: McpSafetyConfig;
+	ignored: IgnoredSafetyEnvVar[];
+}
+
+function readSafetyFromEnv(env: NodeJS.ProcessEnv): Partial<McpSafetyConfig> {
+	const cfg: Partial<McpSafetyConfig> = {};
+	if (env.VAYU_MCP_ALLOWLIST) {
+		cfg.allowlist = env.VAYU_MCP_ALLOWLIST.split(",")
+			.map((h) => h.trim())
+			.filter(Boolean);
+	}
+	if (env.VAYU_MCP_MAX_RPS) cfg.maxRps = Number(env.VAYU_MCP_MAX_RPS);
+	if (env.VAYU_MCP_MAX_CONCURRENCY) cfg.maxConcurrency = Number(env.VAYU_MCP_MAX_CONCURRENCY);
+	if (env.VAYU_MCP_MAX_DURATION_SECONDS)
+		cfg.maxDurationSeconds = Number(env.VAYU_MCP_MAX_DURATION_SECONDS);
+	if (env.VAYU_MCP_ALLOW_ALL === "true") cfg.allowAll = true;
+	if (env.VAYU_MCP_ALLOW_WRITES === "true") cfg.allowWrites = true;
+	if (env.VAYU_MCP_DISABLED_TOOLS) {
+		cfg.disabledTools = env.VAYU_MCP_DISABLED_TOOLS.split(",")
+			.map((t) => t.trim())
+			.filter(Boolean);
+	}
+	return cfg;
+}
+
+/**
+ * Build the stdio CLI's safety config from environment variables. The env is an
+ * untrusted source exactly like the renderer and the persisted config file, so
+ * it passes through `sanitizeSafetyInput` for the same reason they do: without
+ * it, `Number("1,000")` is `NaN` and every `checkLoadCaps` comparison against
+ * that cap is `false`, i.e. the cap silently stops existing rather than falling
+ * back to its default.
+ *
+ * Anything the sanitizer rejects is reported in `ignored` so the CLI can tell a
+ * headless operator which default applied, rather than leaving them to discover
+ * it from an uncapped run.
+ */
+export function buildSafetyConfigFromEnv(env: NodeJS.ProcessEnv): EnvSafetyConfig {
+	const raw = readSafetyFromEnv(env);
+	const sanitized = sanitizeSafetyInput(raw);
+	const ignored: IgnoredSafetyEnvVar[] = [];
+	for (const key of Object.keys(raw) as (keyof McpSafetyConfig)[]) {
+		if (sanitized[key] !== undefined) continue;
+		const variable = SAFETY_ENV_VARS[key];
+		ignored.push({
+			variable,
+			value: env[variable] ?? "",
+			fallback: DEFAULT_MCP_SAFETY_CONFIG[key],
+		});
+	}
+	return { config: resolveSafetyConfig(sanitized), ignored };
+}

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -491,6 +491,22 @@ from environment variables:
 | `VAYU_MCP_ALLOW_WRITES`         | `false`                 | `true` enables the data-write tools.   |
 | `VAYU_MCP_DISABLED_TOOLS`       | (empty)                 | Comma-separated tool names to disable. |
 
+Both entry points sanitize their input through the same function
+(`sanitizeSafetyInput` in `electron/mcp/config.ts`), so the environment is held to
+exactly the rules Settings is held to:
+
+- **A malformed cap falls back to its default, never to "no cap".**
+  `VAYU_MCP_MAX_RPS="1,000"` is not a number, so the `1000` default applies and
+  still refuses an over-cap run. The CLI names what it dropped on stderr:
+  `[vayu-mcp] ignoring malformed VAYU_MCP_MAX_RPS="1,000" (using default 1000)`.
+  Non-positive values (`0`, `-5`) are treated the same way; fractional values are
+  floored.
+- **Allowlist entries are reduced to a bare hostname**, so
+  `https://api.example.com` and `api.example.com:8080` both match the
+  `api.example.com` the guard compares against. Entries are de-duplicated.
+- The two opt-in booleans stay off for any value other than the exact string
+  `true`.
+
 ## Design notes
 
 Rationale behind the load-bearing decisions.


### PR DESCRIPTION
## Description

**Plan.** Root cause: the stdio CLI was the one entry point that fed its config into `resolveSafetyConfig` without `sanitizeSafetyInput` - the sanitizer Settings (`main.ts:625`) and the persisted store (`store.ts:38-41`) both pass through. `Number("1,000")` is `NaN`, `resolveSafetyConfig` spreads it over the defaults, and every `checkLoadCaps` comparison is then `x > NaN` = `false`, so the cap silently stopped existing instead of falling back to its default. Approach: move the env-reading step beside the sanitizer as an exported `buildSafetyConfigFromEnv(env)` that reads, sanitizes and resolves in one place, and returns what it dropped so the CLI can name it on stderr. Alternative rejected: adding a `Number.isFinite` guard inside `checkLoadCaps` - it papers over the real gap (the sanitizer is the single source of truth, and a second guard would leave the next entry point free to skip it).

Verified against `10c8193`: both anchors still hold as described.

What changed:

- **`buildSafetyConfigFromEnv(env)` in `config.ts`** - `readSafetyFromEnv` moves out of `cli.ts` (unchanged parsing), now takes the environment as a parameter, and its output goes through `sanitizeSafetyInput` before `resolveSafetyConfig`. A malformed cap falls back to its default, never to `NaN`; allowlist entries get `normalizeHost`'d, so `https://api.example.com` and `localhost:9876` now match the bare-hostname comparison in `checkAllowlist`.
- **It reports what it dropped.** `ignored` carries `{ variable, value, fallback }` per rejected env var, derived exactly as the issue specifies - a key present in the raw partial and absent from the sanitized result. `cli.ts` prints each to stderr (`[vayu-mcp] ignoring malformed VAYU_MCP_MAX_RPS="1,000" (using default 1000)`), so the field has a reader rather than being written and never read.
- **Placement.** The issue offered `cli.ts` or "beside the sanitizer in `config.ts`"; I took the latter. Keeping the seam in `cli.ts` would have required an entry-point guard (`import.meta.url` vs `argv[1]`) before a test could import the module without `main()` running, and that guard silently no-ops the headless server when the path resolves differently (a symlinked bin). `config.ts` needs no such trick and puts all three untrusted sources - renderer, config file, environment - on the same sanitizer.
- `cli.ts` keeps its import-time `main()`; it is now a thin entry point over the seam.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **2569 passed / 290 files**, 9 of them new in `electron/mcp/config.test.ts`.
- `cd app && pnpm type-check`, `pnpm lint`, `pnpm format:check` - all clean.
- **Mutation-checked**: replacing `sanitizeSafetyInput(raw)` with `raw` in `buildSafetyConfigFromEnv` turns **5 tests red** - the `NaN` cap letting a 50000 RPS run through, the concurrency/duration caps, the non-positive cap, the scheme/port allowlist entries, and the `ignored` report. Restored and green afterwards.
- The new tests assert the guards *downstream* of the seam (`checkLoadCaps` still refuses, `checkAllowlist` still matches), because a `NaN` cap looks fine in the config object and is only wrong at the comparison.
- No engine build or `ctest` run: this is app-only (`cli.ts` / `config.ts` / a test / a doc), so no C++ test could change colour. No pre-existing failures observed on this base (`10c8193`).

`docs/engine/mcp.md` was already not prettier-clean on master (its tables reflow), so only the added paragraph is in the diff - the file is outside the `app/` glob that `pnpm format:check` gates. `mkdocs build --strict` was not run locally (mkdocs is not installed here); the edit adds no page, anchor or link, and CI gates it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #313

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWfAkn1TG5FSoUG8XMUxA2)_