### PR TITLE
fix(mcp): preserve variable metadata when update_environment overwrites

### DIFF
--- a/app/electron/mcp/config.test.ts
+++ b/app/electron/mcp/config.test.ts
@@ -118,15 +118,30 @@ describe("buildSafetyConfigFromEnv", () => {
 	});
 
 	it("falls back for every cap variable, not just RPS", () => {
-		const { config } = buildSafetyConfigFromEnv({
+		const { config, ignored } = buildSafetyConfigFromEnv({
 			VAYU_MCP_MAX_CONCURRENCY: "500rps",
 			VAYU_MCP_MAX_DURATION_SECONDS: "unset",
+			VAYU_MCP_MAX_ITERATIONS: "1e6 requests",
 		});
 
 		expect(config.maxConcurrency).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxConcurrency);
 		expect(config.maxDurationSeconds).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxDurationSeconds);
+		expect(config.maxIterations).toBe(DEFAULT_MCP_SAFETY_CONFIG.maxIterations);
 		expect(checkLoadCaps({ concurrency: 10000 }, config).ok).toBe(false);
 		expect(checkLoadCaps({ duration: "24h" }, config).ok).toBe(false);
+		// The iterations cap is the one a malformed value must not silently
+		// disable: that mode stops on a request count, so no other cap bounds it.
+		expect(checkLoadCaps({ mode: "iterations", iterations: 1_000_000 }, config).ok).toBe(false);
+		expect(ignored.map((i) => i.variable)).toContain("VAYU_MCP_MAX_ITERATIONS");
+	});
+
+	it("reads the iterations cap from the environment", () => {
+		const { config, ignored } = buildSafetyConfigFromEnv({ VAYU_MCP_MAX_ITERATIONS: "250" });
+
+		expect(ignored).toEqual([]);
+		expect(config.maxIterations).toBe(250);
+		expect(checkLoadCaps({ mode: "iterations", iterations: 251 }, config).ok).toBe(false);
+		expect(checkLoadCaps({ mode: "iterations", iterations: 250 }, config).ok).toBe(true);
 	});
 
 	it("rejects a non-positive cap the same way the Settings path does", () => {
@@ -166,18 +181,23 @@ describe("buildSafetyConfigFromEnv", () => {
 			VAYU_MCP_MAX_RPS: "50",
 			VAYU_MCP_MAX_CONCURRENCY: "10",
 			VAYU_MCP_MAX_DURATION_SECONDS: "30",
+			VAYU_MCP_MAX_ITERATIONS: "500",
 			VAYU_MCP_ALLOW_ALL: "true",
 			VAYU_MCP_ALLOW_WRITES: "true",
 			VAYU_MCP_DISABLED_TOOLS: "run_request, stop_run",
 		});
 
 		expect(ignored).toEqual([]);
+		// Exhaustive on purpose: a field added to McpSafetyConfig without an env
+		// var lands here as an unexpected key. That is how the missing
+		// VAYU_MCP_MAX_ITERATIONS was caught.
 		expect(config).toEqual({
 			allowlist: ["api.example.com"],
 			allowAll: true,
 			maxRps: 50,
 			maxConcurrency: 10,
 			maxDurationSeconds: 30,
+			maxIterations: 500,
 			allowWrites: true,
 			disabledTools: ["run_request", "stop_run"],
 		});

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -158,6 +158,7 @@ const SAFETY_ENV_VARS = {
 	maxRps: "VAYU_MCP_MAX_RPS",
 	maxConcurrency: "VAYU_MCP_MAX_CONCURRENCY",
 	maxDurationSeconds: "VAYU_MCP_MAX_DURATION_SECONDS",
+	maxIterations: "VAYU_MCP_MAX_ITERATIONS",
 	allowWrites: "VAYU_MCP_ALLOW_WRITES",
 	disabledTools: "VAYU_MCP_DISABLED_TOOLS",
 } as const satisfies Record<keyof McpSafetyConfig, string>;
@@ -189,6 +190,7 @@ function readSafetyFromEnv(env: NodeJS.ProcessEnv): Partial<McpSafetyConfig> {
 	if (env.VAYU_MCP_MAX_CONCURRENCY) cfg.maxConcurrency = Number(env.VAYU_MCP_MAX_CONCURRENCY);
 	if (env.VAYU_MCP_MAX_DURATION_SECONDS)
 		cfg.maxDurationSeconds = Number(env.VAYU_MCP_MAX_DURATION_SECONDS);
+	if (env.VAYU_MCP_MAX_ITERATIONS) cfg.maxIterations = Number(env.VAYU_MCP_MAX_ITERATIONS);
 	if (env.VAYU_MCP_ALLOW_ALL === "true") cfg.allowAll = true;
 	if (env.VAYU_MCP_ALLOW_WRITES === "true") cfg.allowWrites = true;
 	if (env.VAYU_MCP_DISABLED_TOOLS) {

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -253,6 +253,98 @@ describe("data-write tools", () => {
 		});
 	});
 
+	test("update_environment overwrites the value and keeps secret/type/createdAt", async () => {
+		// A secret-marked token rotated through MCP must stay masked: the engine
+		// replaces the variables blob wholesale, so whatever this payload drops
+		// is gone for good and the popover renders the token in plaintext.
+		const client = fakeClient({
+			getEnvironment: vi.fn().mockResolvedValue({
+				id: "env_1",
+				name: "Dev",
+				variables: {
+					apiKey: {
+						value: "old",
+						enabled: true,
+						secret: true,
+						type: "string",
+						createdAt: 42,
+					},
+				},
+			}),
+		});
+		const res = await dispatchTool(
+			"update_environment",
+			{ environmentId: "env_1", variables: { apiKey: "rotated" } },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.updateEnvironment as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		expect(payload).toMatchObject({
+			variables: {
+				apiKey: {
+					value: "rotated",
+					enabled: true,
+					secret: true,
+					type: "string",
+					createdAt: 42,
+				},
+			},
+		});
+	});
+
+	test("update_environment does not re-enable a disabled variable", async () => {
+		const client = fakeClient({
+			getEnvironment: vi.fn().mockResolvedValue({
+				id: "env_1",
+				name: "Dev",
+				variables: { host: { value: "old", enabled: false } },
+			}),
+		});
+		const res = await dispatchTool(
+			"update_environment",
+			{ environmentId: "env_1", variables: { host: "new" } },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.updateEnvironment as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		expect(payload).toMatchObject({ variables: { host: { value: "new", enabled: false } } });
+	});
+
+	test("update_environment gives a new key a sane default entry", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"update_environment",
+			{ environmentId: "env_1", variables: { brandNew: "v" } },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.updateEnvironment as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const entry = (payload as { variables: Record<string, unknown> }).variables.brandNew;
+		expect(entry).toEqual({ value: "v", enabled: true });
+	});
+
+	test("update_environment replaces a malformed stored entry instead of spreading it", async () => {
+		// A bare string off disk is a real case (D17). Spreading it would write
+		// `{0:"o",1:"l",...}` into the blob every reader then has to survive.
+		const client = fakeClient({
+			getEnvironment: vi.fn().mockResolvedValue({
+				id: "env_1",
+				name: "Dev",
+				variables: { loose: "old", listy: ["a"] },
+			}),
+		});
+		const res = await dispatchTool(
+			"update_environment",
+			{ environmentId: "env_1", variables: { loose: "new", listy: "new" } },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.updateEnvironment as ReturnType<typeof vi.fn>).mock.calls[0][1];
+		const vars = (payload as { variables: Record<string, unknown> }).variables;
+		expect(vars.loose).toEqual({ value: "new", enabled: true });
+		expect(vars.listy).toEqual({ value: "new", enabled: true });
+	});
+
 	test("update_environment is refused when writes are disabled", async () => {
 		const client = fakeClient();
 		const res = await dispatchTool(

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -856,7 +856,25 @@ export const TOOLS: McpTool[] = [
 					? { ...(existing.variables as Record<string, unknown>) }
 					: {};
 			for (const [key, value] of Object.entries(vars as Record<string, string>)) {
-				mergedVars[key] = { value: String(value), enabled: true };
+				// Overwrite the *value*, not the entry: `secret`, `type` and
+				// `createdAt` are the user's own settings (a secret rotated here
+				// must stay masked in the popover), and nothing else restores
+				// them - the engine replaces the blob wholesale. The object guard
+				// keeps a malformed stored entry (a bare string, an array) from
+				// spreading into index-keyed garbage; the renderer treats those
+				// as a real case (`lib/variable-resolution.ts`, D17), so they are
+				// replaced with a sane entry rather than merged onto.
+				const prev = mergedVars[key];
+				const base =
+					prev && typeof prev === "object" && !Array.isArray(prev)
+						? (prev as Record<string, unknown>)
+						: {};
+				// `enabled` leads the spread so a new (or malformed) entry defaults
+				// to enabled while an existing explicit flag survives - writing a
+				// value must not silently re-enable a variable the user disabled.
+				// The tool returns the updated environment, so a caller who wrote
+				// to a disabled variable sees `enabled: false` in the result.
+				mergedVars[key] = { enabled: true, ...base, value: String(value) };
 			}
 			// PUT carries the id in the path, so the body is the patch only. The
 			// name is still sent because the engine treats it as having no

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -507,6 +507,7 @@ from environment variables:
 | `VAYU_MCP_MAX_RPS`              | `1000`                  | RPS cap.                               |
 | `VAYU_MCP_MAX_CONCURRENCY`      | `200`                   | Concurrency cap.                       |
 | `VAYU_MCP_MAX_DURATION_SECONDS` | `300`                   | Duration cap.                          |
+| `VAYU_MCP_MAX_ITERATIONS`       | `10000`                 | Iterations cap (iterations mode).      |
 | `VAYU_MCP_ALLOW_WRITES`         | `false`                 | `true` enables the data-write tools.   |
 | `VAYU_MCP_DISABLED_TOOLS`       | (empty)                 | Comma-separated tool names to disable. |
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -151,7 +151,10 @@ Notes:
   value until it is restarted, so the tool says so in its text output too.
 - **`update_environment`** fetches the environment and merges the supplied
   variables (`PUT /environments/:id` replaces the whole variables blob), so
-  partial updates preserve untouched variables and the name. It is a `PUT`, not
+  partial updates preserve untouched variables and the name. Overwriting an
+  existing variable changes its value only - its `secret`, `type`, `createdAt`
+  and enabled/disabled state are preserved, so a rotated secret stays masked and
+  a disabled variable stays disabled. It is a `PUT`, not
   a `POST`: since #95 the engine's `POST /environments` is create-only, and since
   #97 it rejects a body carrying an `id` outright. `create_request` stays a
   `POST` for the same reason - it creates, and lets the engine assign the id.


### PR DESCRIPTION
Two commits: the #314 fix, plus the master CI breakage it surfaced (#327), added on request.

## Description

### `6f72bbd` - preserve variable metadata on overwrite (#314)

**Plan.** Root cause: `update_environment`'s merge loop replaced an overwritten variable's whole `VariableValue` with `{ value, enabled: true }`, so the stored `secret`, `type` and `createdAt` were dropped. Nothing restored them - the engine's `PUT /environments/:id` replaces the variables blob wholesale, and only the renderer's own save path writes those fields. A secret-marked token rotated through MCP therefore became non-secret and was rendered **unmasked** by the variable popover and context bar. The approach is a merge onto the existing entry rather than a replacement, so a write changes the value only. The alternative I rejected was normalising the incoming map into full `VariableValue` objects at the tool's schema boundary (letting the caller pass `secret`/`type`): that widens a `write`-category tool's surface beyond what the issue asks for and still needs the read-modify-write merge underneath, so it is added complexity for no correctness gain.

Verified against the code at `f55acb4`: the anchor had shifted to `tools.ts:858-860` but the defect is exactly as described. Blast radius traced - the field readers are renderer-side (`variable-popover.tsx` masks on `secret`, `VariableTableEditor.tsx` orders on `createdAt`), the engine stores the blob verbatim, so `tools.ts` is the only writer that needed changing.

Two decisions worth flagging:

- **`enabled` is now preserved, not forced.** The issue left this open. `enabled: true` leads the spread, so a genuinely new (or malformed) entry still defaults to enabled while an existing explicit flag survives. Writing a value should not silently re-enable a variable the user deliberately disabled - the issue's own Problem section lists that among the harms, and the renderer's value edit preserves it too. It is not silent from the caller's side either: the tool returns the engine's updated environment, so an agent that wrote to a disabled variable sees `enabled: false` in the result.
- **The object guard is load-bearing.** A non-object stored entry is a real case the renderer handles (`lib/variable-resolution.ts`, D17); spreading a bare string would write `{0:"o",1:"l",...}` into the blob. Those are replaced with a sane entry instead of merged onto.

### `5cc9441` - give `maxIterations` its env var (#327)

Master at `f55acb4` was red before this branch existed: #312 added `maxIterations` to `McpSafetyConfig` while #313's stdio CLI env table was branched before that field existed. Each was green alone; merged, `SAFETY_ENV_VARS` failed its `satisfies Record<keyof McpSafetyConfig, string>` constraint (TS1360) and `config.test.ts`'s exhaustive `toEqual` saw an unlisted key.

That `satisfies` clause exists to make exactly this unmissable - every safety cap must be settable by an operator running the stdio CLI - so the fix is the env var it was asking for, not a loosened constraint. An operator could cap RPS, concurrency and duration from the environment but had nothing for iterations: the one mode `maxDurationSeconds` cannot bound, and the reason #312 gave it a cap. `sanitizeSafetyInput` already handled the field and the `ignored` loop is keyed off the env table, so a malformed `VAYU_MCP_MAX_ITERATIONS` falls back to the default and is named on stderr rather than silently disabling the cap - the failure mode #313 exists to prevent.

I originally filed this separately rather than folding an unrelated subsystem in here; it was added to this branch on request to unblock CI. Happy to split it back out if you would rather review the two apart.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **290 files passed, 2594 tests passed, 0 failures.** `pnpm type-check`, `pnpm lint` and `pnpm format:check` all clean. (Formatted only the files touched; no repo-wide run.)

Mutation-checked, each guard independently:

| Reverted | Fails |
|---|---|
| the merge (fixed `{}` base) | *keeps secret/type/createdAt*, *does not re-enable a disabled variable* |
| only the object guard (spread `prev` unconditionally) | *replaces a malformed stored entry instead of spreading it* |
| the `VAYU_MCP_MAX_ITERATIONS` env read | all three config assertions |
| the `SAFETY_ENV_VARS` entry | the build outright (TS1360) |

Seven new tests total - four in `electron/mcp/tools.test.ts`, three in `electron/mcp/config.test.ts` (an exhaustive-config case, a malformed-value case asserting the cap still refuses a 1e6-iteration run, and a happy-path read).

No engine change and no rebuild - this is app-only TypeScript. `mkdocs build --strict` not run locally (mkdocs is not installed in this environment); the docs edits are one prose sentence and one table row, with no new links or anchors, and CI gates it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/engine/mcp.md` gets both: the `update_environment` note now states that overwriting an existing variable preserves its `secret`/`type`/`createdAt` and enabled state, and the `VAYU_MCP_*` table lists `VAYU_MCP_MAX_ITERATIONS`. That table was the only enumeration of those variables (grepped repo-wide; `docs/engine/cli.md` carries no copy).

## Related Issues
Closes #314
Closes #327