### PR TITLE
fix(mcp): a corrupt mcp-config.json must not cost the user their window

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -484,11 +484,13 @@ async function startEngine() {
 }
 
 async function startMcp() {
-	if (!loadMcpEnabled()) {
-		console.log("[Main] MCP server disabled by preference; not starting.");
-		return;
-	}
 	try {
+		// Inside the try, not ahead of it: this is the first thing in the whole app
+		// to touch the persisted MCP config, so it is where a store failure lands.
+		if (!loadMcpEnabled()) {
+			console.log("[Main] MCP server disabled by preference; not starting.");
+			return;
+		}
 		mcpService = new VayuMcpService({
 			engineBaseUrl: `http://${ENGINE_HOST}:${ENGINE_PORT}`,
 			host: MCP_HOST,
@@ -827,10 +829,11 @@ app.whenReady().then(async () => {
 	// Start the engine
 	await startEngine();
 
-	// Start the MCP server (best-effort; never blocks app startup)
-	await startMcp();
-
-	// Then create the window
+	// Then create the window. Nothing below this line may sit between the engine
+	// and the window: the MCP server used to, and because it reads a config file
+	// at that point, a corrupt one left the app with a headless engine and no
+	// window at all. MCP is an optional convenience with no UI depending on it,
+	// so it starts after everything the user can see is up and wired.
 	createWindow();
 
 	// Start checking for updates once a window exists to receive events. The
@@ -844,6 +847,11 @@ app.whenReady().then(async () => {
 			createWindow();
 		}
 	});
+
+	// Start the MCP server last (best-effort; it never blocks app startup). It
+	// swallows its own failures, and starting it here means even one that escaped
+	// that guard would cost the user nothing but MCP.
+	await startMcp();
 });
 
 app.on("window-all-closed", () => {

--- a/app/electron/mcp/store.test.ts
+++ b/app/electron/mcp/store.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * An optional subsystem's config file must never be able to stop the app from
+ * starting - the same rule window-state.ts is held to, for a worse blast radius.
+ *
+ * conf parses the file inside the Store constructor and rethrows a SyntaxError
+ * unless told otherwise, and this store is first touched by main.ts's `startMcp`
+ * during startup. A corrupt mcp-config.json therefore rejected the `whenReady`
+ * handler before it ever reached `createWindow()`: no window, on every launch,
+ * with the engine sidecar already running headless behind it.
+ *
+ * These drive the real electron-store against a temp userData directory rather
+ * than a mock, because the defect is in what the library does with a file we
+ * hand it - a mocked store would have "passed" against the bug. `electron`
+ * itself is faked, since that is the part vitest cannot provide.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFAULT_MCP_SAFETY_CONFIG } from "./config.js";
+
+/** Mutable because the mock is hoisted above every test that retargets it. */
+const fake = vi.hoisted(() => ({ userData: "" }));
+
+vi.mock("electron", () => {
+	const api = {
+		app: {
+			getPath: () => fake.userData,
+			getVersion: () => "0.0.0-test",
+		},
+		ipcMain: { on: () => {} },
+		shell: { openPath: async () => "" },
+	};
+	// electron-store reaches for the default export.
+	return { ...api, default: api };
+});
+
+/** Seed the userData directory the next import will read, with raw file bytes. */
+function seedStore(contents?: string): void {
+	fake.userData = mkdtempSync(join(tmpdir(), "vayu-mcp-config-"));
+	mkdirSync(fake.userData, { recursive: true });
+	if (contents !== undefined) {
+		writeFileSync(join(fake.userData, "mcp-config.json"), contents);
+	}
+}
+
+function storeFile(): string {
+	return readFileSync(join(fake.userData, "mcp-config.json"), "utf8");
+}
+
+/**
+ * A fresh module instance, so the module's lazily-built `new Store(...)` runs
+ * against the directory just seeded rather than reusing a cached store.
+ */
+async function importStore() {
+	vi.resetModules();
+	return import("./store.js");
+}
+
+afterEach(() => {
+	if (fake.userData) rmSync(fake.userData, { recursive: true, force: true });
+	fake.userData = "";
+});
+
+describe("a corrupt mcp-config.json", () => {
+	it.each([
+		["truncated JSON", '{"enabled": tr'],
+		["not JSON at all", "this is not json at all"],
+		["an empty file", ""],
+	])("still resolves the default safety config when the file is %s", async (_label, contents) => {
+		seedStore(contents);
+
+		const { loadPersistedSafety } = await importStore();
+
+		expect(loadPersistedSafety()).toEqual(DEFAULT_MCP_SAFETY_CONFIG);
+	});
+
+	it("leaves the server enabled rather than throwing on the preference read", async () => {
+		seedStore('{"enabled": fal');
+
+		const { loadMcpEnabled } = await importStore();
+
+		expect(loadMcpEnabled()).toBe(true);
+	});
+
+	it("is replaced by a valid file on the next save", async () => {
+		seedStore('{"safety": {"maxRps": 5');
+
+		const { savePersistedSafety, loadPersistedSafety } = await importStore();
+		savePersistedSafety({ ...DEFAULT_MCP_SAFETY_CONFIG, maxRps: 42 });
+
+		expect(JSON.parse(storeFile())).toEqual({
+			safety: { ...DEFAULT_MCP_SAFETY_CONFIG, maxRps: 42 },
+		});
+		expect(loadPersistedSafety().maxRps).toBe(42);
+	});
+});
+
+describe("a readable mcp-config.json", () => {
+	it("is not discarded - a saved override survives", async () => {
+		seedStore(
+			JSON.stringify({
+				safety: {
+					...DEFAULT_MCP_SAFETY_CONFIG,
+					allowlist: ["api.example.com"],
+					maxRps: 25,
+				},
+				enabled: false,
+			})
+		);
+
+		const { loadPersistedSafety, loadMcpEnabled } = await importStore();
+
+		expect(loadPersistedSafety()).toMatchObject({
+			allowlist: ["api.example.com"],
+			maxRps: 25,
+		});
+		expect(loadMcpEnabled()).toBe(false);
+	});
+
+	/*
+	 * Syntactically valid but wrong-shaped: clearInvalidConfig cannot see this,
+	 * only the sanitizer can, so it is the half of the guard that does not move
+	 * when the flag does.
+	 */
+	it.each([
+		["a string cap", { maxRps: "abc" }],
+		["a negative cap", { maxRps: -5 }],
+		["a non-array allowlist", { allowlist: "api.example.com" }],
+		["a null safety block", null],
+	])("falls back to the defaults for %s", async (_label, safety) => {
+		seedStore(JSON.stringify({ safety }));
+
+		const { loadPersistedSafety } = await importStore();
+
+		expect(loadPersistedSafety()).toEqual(DEFAULT_MCP_SAFETY_CONFIG);
+	});
+
+	it("coerces a non-boolean enabled to on", async () => {
+		seedStore(JSON.stringify({ enabled: "yes" }));
+
+		const { loadMcpEnabled } = await importStore();
+
+		expect(loadMcpEnabled()).toBe(true);
+	});
+});
+
+/*
+ * main.ts creates windows and starts the engine at import time, so the startup
+ * ordering it encodes can only be read - the same constraint (and the same
+ * remedy) as renderer-recovery.test.ts.
+ */
+describe("main.ts startup ordering", () => {
+	const main = readFileSync(
+		join(dirname(fileURLToPath(import.meta.url)), "..", "main.ts"),
+		"utf8"
+	);
+
+	/** The `app.whenReady()` handler body, up to the first listener after it. */
+	function whenReadyBody(): string {
+		const start = main.indexOf("app.whenReady()");
+		const end = main.indexOf('app.on("window-all-closed"', start);
+		expect(start).toBeGreaterThan(-1);
+		expect(end).toBeGreaterThan(start);
+		return main.slice(start, end);
+	}
+
+	/** The body of `startMcp`, up to the next top-level function. */
+	function startMcpBody(): string {
+		const start = main.indexOf("async function startMcp()");
+		const end = main.indexOf("async function stopMcp()", start);
+		expect(start).toBeGreaterThan(-1);
+		expect(end).toBeGreaterThan(start);
+		return main.slice(start, end);
+	}
+
+	it("creates the window before starting MCP", () => {
+		const body = whenReadyBody();
+		const window = body.indexOf("createWindow();");
+		const mcp = body.indexOf("await startMcp();");
+
+		expect(window).toBeGreaterThan(-1);
+		expect(mcp).toBeGreaterThan(-1);
+		expect(window).toBeLessThan(mcp);
+	});
+
+	it("reads the enabled preference inside startMcp's try, not ahead of it", () => {
+		const body = startMcpBody();
+		const guard = body.indexOf("try {");
+		const read = body.indexOf("loadMcpEnabled()");
+
+		expect(guard).toBeGreaterThan(-1);
+		expect(read).toBeGreaterThan(-1);
+		expect(guard).toBeLessThan(read);
+	});
+});

--- a/app/electron/mcp/store.ts
+++ b/app/electron/mcp/store.ts
@@ -27,7 +27,21 @@ let store: Store<McpStoreShape> | null = null;
 // Lazily created so the store is only touched once Electron's `app` is ready and
 // `userData` resolves - mirrors how window-state is persisted.
 function getStore(): Store<McpStoreShape> {
-	if (!store) store = new Store<McpStoreShape>({ name: "mcp-config" });
+	if (!store)
+		store = new Store<McpStoreShape>({
+			name: "mcp-config",
+			/*
+			 * conf reads and parses the file inside its constructor and rethrows the
+			 * SyntaxError when this flag is off - and this store is first touched
+			 * during startup, before the window exists (main.ts's startMcp). A corrupt
+			 * mcp-config.json would therefore leave the user with an engine running
+			 * headless and no window at all, on every launch until they found and
+			 * deleted a hidden file. Same fix, same reason as window-state.ts: an
+			 * empty store is the right failure mode here, because both readers below
+			 * resolve safe defaults from one (locked-down safety config, server on).
+			 */
+			clearInvalidConfig: true,
+		});
 	return store;
 }
 


### PR DESCRIPTION
## Description

**Plan.** Root cause: `store.ts` built its electron-store without `clearInvalidConfig`, the exact omission #276 fixed for `window-state.ts`. conf parses the config file inside the constructor and rethrows the `SyntaxError`, and this store is first touched by `startMcp()` during startup - which was `await`ed *before* `createWindow()`, inside an `app.whenReady` handler with no `.catch`. A corrupt `mcp-config.json` therefore rejected that handler before any window existed, on every launch, with the engine sidecar already running headless behind it. The approach is two layers, because the flag alone only closes this one file: the flag itself, plus making the window's creation depend on no MCP work at all. The alternative I rejected was a `try`/`catch` around the `await startMcp()` call site - `startMcp` already swallows everything it can throw, so that guard is unreachable today and reads as protection it does not give; moving the call after `createWindow()` makes the ordering itself the guarantee, and a source-scan test can hold it.

Verified against `f55acb4`: the anchors had shifted (`store.ts:29`, `main.ts:487/831`) but the defect is exactly as described - `new Store({ name: "mcp-config" })` with no flag, `loadMcpEnabled()` sitting one line above `startMcp`'s `try`, and the whenReady chain unguarded. Blast radius traced: `getStore()` has four callers, all in this file; the four exported functions are read by `main.ts` only (`startMcp` and the `mcp:*` IPC handlers), re-exported through `mcp/index.ts` for the barrel and imported by no test before this one. The stdio CLI never touches the store (it builds its config from the environment), so nothing outside the desktop app is affected.

### `clearInvalidConfig: true` (`store.ts`)

An empty store is the correct failure mode here, because both readers already resolve safe values from one: `loadPersistedSafety` returns `resolveSafetyConfig(sanitizeSafetyInput({}))` - the locked-down defaults, empty allowlist and no writes - and `loadMcpEnabled` defaults to `true`. Losing a hand-corrupted MCP config costs the user their allowlist, not their safety posture.

### The window no longer waits on MCP (`main.ts`)

`await startMcp()` moves to the end of the `whenReady` handler - after `createWindow()`, `initAutoUpdater` and the `activate` listener - so an MCP failure that escaped `startMcp`'s own guard would cost the user MCP and nothing else. `loadMcpEnabled()` moves *inside* that guard; it was the one MCP config read the existing `try` did not cover. Ordering note for reviewers: `mcp:status` now answers `running: false` for the few hundred ms between the window appearing and the server binding. Nothing reads it in that window - the Settings panel queries on open - and the previous ordering delayed the window by exactly that interval instead.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **291 files, 2602 tests, 1 failure**, and that one failure is master's, not this branch's (see below). `pnpm lint` and `pnpm format:check` clean. `pnpm type-check` fails only on the same master breakage. No engine change and no rebuild - this is app-only TypeScript.

New `app/electron/mcp/store.test.ts`, 13 tests. It drives the **real** electron-store against a temp `userData` directory rather than a mock, the way `window-state.test.ts:17-20` does, because the defect is in what the library does with a file we hand it - a mocked store would have "passed" against the bug.

Mutation-checked, each guard independently:

| Reverted | Fails |
|---|---|
| `clearInvalidConfig` | 5 tests - all three corrupt-file shapes, the enabled-preference read, and the replaced-on-next-save case |
| `createWindow()` moved back after `startMcp()` | *creates the window before starting MCP* |
| `loadMcpEnabled()` moved back outside the `try` | *reads the enabled preference inside startMcp's try, not ahead of it* |

The valid-config cases matter as much as the corrupt ones: *a saved override survives* fails if `clearInvalidConfig` is ever mistaken for "always start empty". The malformed-but-syntactically-valid cases (a string cap, a negative cap, a non-array allowlist, a null safety block) cover the half of the guard the flag cannot see - only the sanitizer can - so they stay green under all three mutations above.

The two `main.ts` assertions are source scans, since main.ts creates windows and starts the engine at import time; both extract a named region first and assert it was found (`renderer-recovery.test.ts` sets the precedent). A scan that read an empty string would fail on the region assertions, not pass vacuously.

### Pre-existing failure, reproduced on the base commit

`electron/mcp/config.test.ts > reports nothing when every variable is well-formed` fails, and `pnpm type-check` reports `TS1360` at `electron/mcp/config.ts:163` - both are #327 (`maxIterations` missing from `SAFETY_ENV_VARS`), already red on master at `f55acb4` before this branch existed. Not fixed or hidden here: #326 carries the fix and closes #327, so CI on this PR goes green once that merges or this branch is rebased onto it. Say the word and I will rebase.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

No docs change. I grepped `docs/` for `mcp-config`, `window-state.json`, `clearInvalidConfig`, `startMcp` and `createWindow`: nothing describes the MCP config file's failure behaviour or the startup ordering, so there is no doc to keep in step - matching the issue's own "Docs: none" note.

## Related Issues
Closes #315

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFqUoYmUhgsdnbhx9gZgTT)_