### PR TITLE
fix(mcp): an allowlisted host:port URL and an IPv6 target must match

### DIFF
--- a/app/electron/mcp/config.test.ts
+++ b/app/electron/mcp/config.test.ts
@@ -35,6 +35,23 @@ describe("normalizeHost", () => {
 	it("returns empty string for empty input", () => {
 		expect(normalizeHost("   ")).toBe("");
 	});
+
+	// Splitting the port off at the first colon reduced these to "" or "[", so no
+	// stored entry could contain a colon and no IPv6 host could ever match.
+	it.each(["::1", "[::1]", "[::1]:9876", "http://[::1]:8080", "[0:0:0:0:0:0:0:1]"])(
+		"normalizes the IPv6 target %s to the canonical bracketed form",
+		(raw) => {
+			expect(normalizeHost(raw)).toBe("[::1]");
+		}
+	);
+
+	it("canonicalizes a bare IPv6 address the way URL.hostname does", () => {
+		expect(normalizeHost("2001:DB8::1")).toBe("[2001:db8::1]");
+	});
+
+	it.each(["[", "[]", "[::1]junk", ":::"])("drops the malformed bracket form %s", (raw) => {
+		expect(normalizeHost(raw)).toBe("");
+	});
 });
 
 describe("sanitizeSafetyInput", () => {
@@ -43,6 +60,13 @@ describe("sanitizeSafetyInput", () => {
 			allowlist: ["https://api.example.com/x", "API.EXAMPLE.COM", "  ", "localhost:9876"],
 		});
 		expect(out.allowlist).toEqual(["api.example.com", "localhost"]);
+	});
+
+	it("keeps an IPv6 host through the sanitizer every allowlist edit passes", () => {
+		const out = sanitizeSafetyInput({
+			allowlist: ["::1", "[::1]:9876", "[", "localhost:9876"],
+		});
+		expect(out.allowlist).toEqual(["[::1]", "localhost"]);
 	});
 
 	it("drops non-string allowlist entries", () => {

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -17,10 +17,12 @@
 export interface McpSafetyConfig {
 	/**
 	 * Hosts an agent is permitted to send traffic to (hostnames, no scheme or
-	 * port), e.g. `["api.example.com", "localhost"]`. **Empty by default** - an
-	 * empty allowlist denies all outbound requests, so a fresh install cannot be
-	 * used to hit arbitrary targets. The agent receives an actionable error and
-	 * asks the user to add the host.
+	 * port), e.g. `["api.example.com", "localhost"]`. An IPv6 target is stored in
+	 * the bracketed form `URL.hostname` produces, e.g. `["[::1]"]` - see
+	 * `normalizeHost`. **Empty by default** - an empty allowlist denies all
+	 * outbound requests, so a fresh install cannot be used to hit arbitrary
+	 * targets. The agent receives an actionable error and asks the user to add
+	 * the host.
 	 */
 	allowlist: string[];
 	/**
@@ -85,16 +87,59 @@ export function resolveSafetyConfig(override?: Partial<McpSafetyConfig>): McpSaf
 }
 
 /**
+ * Whether `host` (scheme, path and query already stripped) is meant as an IPv6
+ * literal rather than a name with a port: either it is bracketed, or it is bare
+ * with more than one colon, which no `name:port` can be.
+ */
+function isIpv6Candidate(host: string): boolean {
+	return host.startsWith("[") || (host.match(/:/g)?.length ?? 0) > 1;
+}
+
+/**
+ * The bracketed IPv6 literal `host` denotes, canonicalized the way WHATWG
+ * `URL.hostname` serializes it (`[0:0:0:0:0:0:0:1]` → `[::1]`) - which is what
+ * `extractHost` compares against, so a stored entry has to be in that exact
+ * form to ever match. `""` for anything unparseable, which the sanitizer's
+ * empty filter then drops rather than persisting garbage.
+ */
+function normalizeIpv6(host: string): string {
+	let literal = host;
+	if (literal.startsWith("[")) {
+		const close = literal.indexOf("]");
+		if (close === -1) return "";
+		// Only a port may follow the literal; anything else is malformed input.
+		const trailing = literal.slice(close + 1);
+		if (trailing !== "" && !/^:\d*$/.test(trailing)) return "";
+		literal = literal.slice(0, close + 1);
+	} else {
+		// A bare address is the whole input: RFC 3986 has no unbracketed form
+		// that could carry a port, so there is nothing here to strip.
+		literal = `[${host}]`;
+	}
+	try {
+		return new URL(`http://${literal}`).hostname;
+	} catch {
+		return "";
+	}
+}
+
+/**
  * Reduce a user-entered value to a bare hostname: strip scheme, path, query,
  * and port, then lowercase. `"https://api.example.com:8080/v1"` → `"api.example.com"`.
  * Matches the exact-hostname comparison the allowlist guard performs, so what the
  * user types in Settings lines up with what an agent's request URL resolves to.
+ *
+ * An IPv6 target normalizes to its **bracketed** canonical form (`"::1"`,
+ * `"[::1]:9876"` and `"http://[::1]:8080"` all → `"[::1]"`), because that is how
+ * `URL.hostname` serializes it on the guard's side. Stripping the port by the
+ * first colon would leave `""` or `"["` and no such entry could ever match.
  */
 export function normalizeHost(raw: string): string {
 	let host = raw.trim().toLowerCase();
 	if (host === "") return "";
 	host = host.replace(/^[a-z][a-z0-9+.-]*:\/\//, ""); // scheme://
 	host = host.split("/")[0].split("?")[0]; // path / query
+	if (isIpv6Candidate(host)) return normalizeIpv6(host);
 	host = host.split(":")[0]; // port
 	return host.trim();
 }

--- a/app/electron/mcp/safety.test.ts
+++ b/app/electron/mcp/safety.test.ts
@@ -13,7 +13,7 @@ import {
 	checkLoadCaps,
 	defaultDurationUnderCap,
 } from "./safety.js";
-import { DEFAULT_MCP_SAFETY_CONFIG, resolveSafetyConfig } from "./config.js";
+import { DEFAULT_MCP_SAFETY_CONFIG, normalizeHost, resolveSafetyConfig } from "./config.js";
 
 describe("extractHost", () => {
 	test("parses hostname from a full URL, lowercased", () => {
@@ -27,6 +27,24 @@ describe("extractHost", () => {
 	});
 	test("returns null for empty input", () => {
 		expect(extractHost("")).toBeNull();
+	});
+	// These parse *successfully* with the host taken for a scheme and an empty
+	// hostname, so the scheme-less retry only runs if emptiness triggers it too.
+	test.each([
+		["localhost:3000/api", "localhost"],
+		["api.example.com:8080/x", "api.example.com"],
+		["localhost:3000", "localhost"],
+		["localhost:3000//api", "localhost"],
+	])("handles scheme-less %s (host:port)", (url, host) => {
+		expect(extractHost(url)).toBe(host);
+	});
+	test("keeps a genuinely host-less URL unresolvable rather than inventing one", () => {
+		// The empty hostname here is the URL's own answer, not a misparse - the
+		// scheme-less retry would turn it into the host "file".
+		expect(extractHost("file:///etc/passwd")).toBeNull();
+	});
+	test("returns an IPv6 host in the bracketed form the allowlist stores", () => {
+		expect(extractHost("http://[::1]:8080/x")).toBe("[::1]");
 	});
 });
 
@@ -45,6 +63,16 @@ describe("checkAllowlist", () => {
 		const res = checkAllowlist("https://evil.test/x", config);
 		expect(res.ok).toBe(false);
 		expect(res.error).toMatch(/not on Vayu's MCP allowlist/i);
+	});
+	test("allows a scheme-less host:port URL whose host is on the list", () => {
+		// The refusal this replaces named unresolved {{variables}}, sending the
+		// user hunting a resolution bug in a URL that resolved fine.
+		const config = resolveSafetyConfig({ allowlist: ["localhost"] });
+		expect(checkAllowlist("localhost:3000/api/users", config).ok).toBe(true);
+	});
+	test("matches an allowlisted IPv6 literal against its target", () => {
+		const config = resolveSafetyConfig({ allowlist: [normalizeHost("::1")] });
+		expect(checkAllowlist("http://[::1]:9876/x", config).ok).toBe(true);
 	});
 	test("denies when the host cannot be determined", () => {
 		const config = resolveSafetyConfig({ allowlist: ["api.example.com"] });

--- a/app/electron/mcp/safety.ts
+++ b/app/electron/mcp/safety.ts
@@ -22,6 +22,15 @@ export interface GuardResult {
 
 const OK: GuardResult = { ok: true };
 
+/** The lowercased hostname `candidate` parses to, or null if it yields none. */
+function parseHostname(candidate: string): string | null {
+	try {
+		return new URL(candidate).hostname.toLowerCase() || null;
+	} catch {
+		return null;
+	}
+}
+
 /**
  * Extract the lowercased hostname from a request URL. Returns null when the URL
  * cannot be parsed - which notably includes URLs still containing unresolved
@@ -31,16 +40,20 @@ export function extractHost(url: string): string | null {
 	if (typeof url !== "string" || url.trim() === "") return null;
 	// Unresolved template variables cannot be safety-checked.
 	if (url.includes("{{") || url.includes("}}")) return null;
-	try {
-		return new URL(url).hostname.toLowerCase();
-	} catch {
-		// Allow scheme-less inputs like "api.example.com/users".
-		try {
-			return new URL(`http://${url}`).hostname.toLowerCase();
-		} catch {
-			return null;
-		}
-	}
+	const parsed = parseHostname(url);
+	if (parsed) return parsed;
+	// A scheme-less "localhost:3000/api" does not throw: "localhost" is a legal
+	// scheme, so it parses with an empty hostname. An empty hostname is therefore
+	// as unparsed as a throw, and the scheme-less retry has to cover both cases
+	// or every host:port URL is refused as "unresolvable" - the shape the user
+	// reads as a variable-resolution bug.
+	//
+	// Not for input carrying an explicit "://" though: there the empty hostname
+	// is the URL's own answer ("file:///etc/passwd" is host-less), and prefixing
+	// a scheme would turn it into the host "file" - a target the allowlist could
+	// then be talked into permitting. Unknown hosts stay refused.
+	if (url.includes("://")) return null;
+	return parseHostname(`http://${url}`);
 }
 
 /**

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -399,6 +399,30 @@ describe("run_collection_smoke", () => {
 		expect((client.executeRequest as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
 	});
 
+	test("does not skip a scheme-less host:port request whose host is allowlisted", async () => {
+		// A collection saved against "localhost:3000/..." had every request
+		// skipped, with a reason blaming unresolved {{variables}} in a URL that
+		// carried none.
+		const client = fakeClient({
+			listRequests: vi
+				.fn()
+				.mockResolvedValue([
+					{ id: "r1", name: "local", method: "GET", url: "localhost:3000/health" },
+				]),
+			composeRequest: vi
+				.fn()
+				.mockResolvedValue({ method: "GET", url: "localhost:3000/health" }),
+			executeRequest: vi.fn().mockResolvedValue({ status: 200, testResults: [] }),
+		});
+		const res = await dispatchTool(
+			"run_collection_smoke",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["localhost"] })
+		);
+		expect(res.structuredContent).toMatchObject({ total: 1, passed: 1, skipped: 0 });
+		expect(client.executeRequest).toHaveBeenCalledTimes(1);
+	});
+
 	test("composes each request engine-side and executes the composed payload unchanged", async () => {
 		// Canned engine output mirroring what POST /compose returns for a saved
 		// request: variables resolved, inherited auth applied, chain + own script

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -384,6 +384,12 @@ configurable in **Settings → MCP** and persisted.
 - **Target allowlist** (default empty ⇒ deny all). Network-touching tools refuse
   off-list hosts with an actionable error. An **"Allow all hosts"** opt-in
   bypasses the list (still rejects unresolved `{{variables}}`); off by default.
+  Entries are hostnames, matched exactly: what you type in Settings is reduced to
+  a host (`https://api.example.com:8080/v1` and `api.example.com` are the same
+  entry), and the request URL is matched by its host whether or not it carries a
+  scheme (`localhost:3000/api` matches the entry `localhost`). An IPv6 target is
+  stored and shown in its canonical bracketed form - typing `::1` stores `[::1]`,
+  which is what a URL parses to.
   Because the check happens here, before the engine is called, a request sent
   from inside a script could not be checked at all - so `pm.sendRequest` is
   refused outright for runs this server starts. See


### PR DESCRIPTION
## Description

Two host-parsing bugs in the MCP safety layer refused traffic to hosts the user *had* allowlisted, and both surfaced as the same misleading error - "may be empty or contain unresolved `{{variables}}`" - pointing at a variable-resolution bug that does not exist.

**Plan.** The root cause in both cases is that host parsing and host *storage* disagree with the WHATWG parser the guard compares against. `extractHost` only fell back to the `http://` prefix when `new URL()` **threw**, but a scheme-less `localhost:3000/api` does not throw - `localhost` is a legal scheme, so it parses with an empty hostname and the scheme-less fallback that exists for exactly this input never ran. `normalizeHost` stripped the port with `split(":")[0]`, which reduces `::1` to `""` and `[::1]` to `"["`, while the guard compares against `URL.hostname`, which serializes IPv6 *bracketed* - so no sanitized entry could ever match an IPv6 host. The approach is to make each side speak the parser's own language: treat an empty hostname as unparsed, and round-trip an IPv6 candidate through the parser to its canonical bracketed form. The alternative I rejected was hand-rolling an IPv6 grammar in `normalizeHost` (validate hextets, compress `::` myself): it would have to reproduce WHATWG's canonicalization exactly - `[0:0:0:0:0:0:0:1]` → `[::1]`, lowercasing, IPv4-mapped forms - or produce entries that look right and still never match, which is the bug it is meant to fix.

Both problems were re-verified against current `master` before any edit; the anchors in the issue are still accurate.

### `extractHost` (`app/electron/mcp/safety.ts`)

An empty hostname now counts as unparsed, so the scheme-less retry covers it. Deliberate carve-out beyond the issue spec: the retry is **skipped** when the input carries an explicit `://`. There an empty hostname is the parser's own answer (`file:///etc/passwd` is host-less), and a blind `http://` prefix would turn it into the host `file` - a target the allowlist could then be talked into permitting. Unknown hosts stay refused; the fix only widens acceptance for input that was misparsed, never for input that genuinely has no host.

### `normalizeHost` (`app/electron/mcp/config.ts`)

An IPv6 candidate - bracketed, or bare with more than one colon, which no `name:port` can be - is normalized by round-tripping through the WHATWG parser, giving exactly the form `extractHost` produces. Malformed brackets return `""` so `sanitizeSafetyInput`'s existing empty filter drops them, instead of today's behavior of persisting garbage like `"["`. Doc comments on `McpSafetyConfig.allowlist` and `normalizeHost` updated, since bracketed IPv6 is now a legal stored form.

**Blast radius traced:** `normalizeHost` has one caller (`sanitizeSafetyInput`), which every allowlist path funnels through - Settings update (`main.ts:627`), config load (`store.ts:54`), and the stdio CLI's env (`buildSafetyConfigFromEnv`) - which is why `allowAll` was previously the only way to reach an IPv6 target. `extractHost` has one caller (`checkAllowlist`), reached from the three gates in `tools.ts` (`run_request`, `run_collection_smoke`, `start_load_run`). The renderer sends the raw typed string and main sanitizes it, so no renderer change is needed; that also keeps this diff clear of `McpSettingsPanel.tsx`, which #329 is currently rewriting.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **291 files, 2627 tests, all passing**. `pnpm type-check`, `pnpm lint` and `pnpm format:check` green. No engine change, so the C++ build and `ctest` were not run. No pre-existing failures.

New tests, all mutation-checked - reverting either fix fails **18** of them:

- `safety.test.ts` - `localhost:3000/api`, `api.example.com:8080/x`, `localhost:3000`, `localhost:3000//api` all extract their host; `file:///etc/passwd` stays `null` (guards the carve-out above); `http://[::1]:8080/x` extracts `[::1]`; `checkAllowlist` accepts a scheme-less `host:port` URL and an allowlisted IPv6 literal.
- `config.test.ts` - `::1`, `[::1]`, `[::1]:9876`, `http://[::1]:8080` and `[0:0:0:0:0:0:0:1]` all normalize to `[::1]`; `2001:DB8::1` → `[2001:db8::1]`; `[`, `[]`, `[::1]junk` and `:::` are dropped; an IPv6 host survives the sanitizer every allowlist edit passes through.
- `tools.test.ts` - a `run_collection_smoke` over a `localhost:3000/health` request on an allowlisted `localhost` is executed rather than skipped.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

The issue listed no docs change, but the bracketed IPv6 form is user-visible (type `::1` in Settings, see `[::1]`), so the "Target allowlist" bullet in `docs/engine/mcp.md` now states how entries are matched and how an IPv6 target is stored. Prose only - no new links or headings. `mkdocs` is not installed in this environment, so `mkdocs build --strict` was not run locally; CI covers it.

## Related Issues
Closes #317

---
_Generated by [Claude Code](https://claude.ai/code/session_015fWtiXtkJdKFJtVW1Tjzjt)_