### PR TITLE
fix(mcp): make one-click connect work on Windows, and never fail it silently

### DIFF
--- a/app/electron/mcp/connect.test.ts
+++ b/app/electron/mcp/connect.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One-click connect is a platform contract, and both halves of it fail silently.
+ *
+ * On Windows the CLI that gets resolved is usually a shim: `where` lists VS
+ * Code's extensionless POSIX script before the `code.cmd` Windows can run, and
+ * Node has refused to spawn `.cmd`/`.bat` without a shell since 20.12. Through
+ * a shell the argument array is joined with plain spaces, so the VS Code JSON
+ * blob loses its quotes and braces unless every argument is quoted by hand -
+ * which is why the exact command line is asserted here rather than "a spawn
+ * happened". On POSIX the login shell is what recovers the PATH a GUI launch
+ * stripped, but a login shell that does not speak `-lc` reported the CLI as
+ * missing rather than falling back.
+ *
+ * `process.platform` is stubbed both ways (as `updater.test.ts` does): asserting
+ * the host platform would leave whichever branch CI is not running untested.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+
+import { connectClient, type SpawnFn } from "./connect.js";
+
+const URL = "http://127.0.0.1:9877/mcp";
+
+/** Just enough of a ChildProcess for connect.ts to attach to and drain. */
+class FakeChild extends EventEmitter {
+	readonly stdout = new EventEmitter();
+	readonly stderr = new EventEmitter();
+	kill() {
+		return true;
+	}
+}
+
+interface SpawnCall {
+	command: string;
+	args: readonly string[];
+	options: SpawnOptions;
+}
+
+/**
+ * A spawn that records every call and hands each child to `respond`, which
+ * decides what that process printed and how it exited. Emission is deferred a
+ * microtask so the listeners connect.ts attaches are in place first.
+ */
+function recorder(respond: (call: SpawnCall, child: FakeChild, index: number) => void): {
+	spawnImpl: SpawnFn;
+	calls: SpawnCall[];
+} {
+	const calls: SpawnCall[] = [];
+	const spawnImpl: SpawnFn = (command, args, options) => {
+		const call = { command, args, options };
+		const index = calls.push(call) - 1;
+		const child = new FakeChild();
+		queueMicrotask(() => respond(call, child, index));
+		return child as unknown as ChildProcess;
+	};
+	return { spawnImpl, calls };
+}
+
+/** Finish a fake process: what it printed, and the code it exited with. */
+function finish(child: FakeChild, stdout: string, code = 0) {
+	if (stdout) child.stdout.emit("data", Buffer.from(stdout));
+	child.emit("close", code);
+}
+
+const realPlatform = process.platform;
+const realShell = process.env.SHELL;
+
+function setPlatform(platform: NodeJS.Platform) {
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+	delete process.env.SHELL;
+});
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+	if (realShell === undefined) delete process.env.SHELL;
+	else process.env.SHELL = realShell;
+});
+
+describe("connectClient on Windows", () => {
+	beforeEach(() => setPlatform("win32"));
+
+	const CODE_DIR = "C:\\Users\\me\\AppData\\Local\\Programs\\Microsoft VS Code\\bin";
+	// `where` order, verbatim: the POSIX script Windows cannot execute is first.
+	const WHERE_CODE = `${CODE_DIR}\\code\r\n${CODE_DIR}\\code.cmd\r\n`;
+
+	it("runs the .cmd shim through a shell, with every argument quoted", async () => {
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			finish(child, index === 0 ? WHERE_CODE : "Added.");
+		});
+
+		const res = await connectClient("vscode", URL, spawnImpl);
+
+		expect(res).toEqual({ ok: true, message: "Added." });
+		expect(calls[0]).toMatchObject({ command: "where", args: ["code"] });
+		// Under `shell: true` Node joins command and args with plain spaces, so
+		// the whole line has to arrive pre-quoted in `command` - an unquoted JSON
+		// blob loses its quotes to cmd.exe and reaches `code` as several words.
+		expect(calls[1].options.shell).toBe(true);
+		expect(calls[1].args).toEqual([]);
+		expect(calls[1].command).toBe(
+			`"${CODE_DIR}\\code.cmd" "--add-mcp" ` +
+				'"{\\"name\\":\\"vayu\\",\\"type\\":\\"http\\",\\"url\\":\\"http://127.0.0.1:9877/mcp\\"}"'
+		);
+	});
+
+	it("picks the runnable shim over the extensionless first line of `where`", async () => {
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			finish(child, index === 0 ? WHERE_CODE : "Added.");
+		});
+
+		await connectClient("vscode", URL, spawnImpl);
+
+		expect(calls[1].command.startsWith(`"${CODE_DIR}\\code.cmd"`)).toBe(true);
+		expect(calls[1].command).not.toContain(`"${CODE_DIR}\\code"`);
+	});
+
+	it("quotes an npm-shimmed `claude` the same way", async () => {
+		const NPM = "C:\\Users\\me\\AppData\\Roaming\\npm";
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			finish(child, index === 0 ? `${NPM}\\claude\r\n${NPM}\\claude.cmd\r\n` : "Added vayu.");
+		});
+
+		const res = await connectClient("claude", URL, spawnImpl);
+
+		expect(res.ok).toBe(true);
+		expect(calls[1].command).toBe(
+			`"${NPM}\\claude.cmd" "mcp" "add" "--transport" "http" ` +
+				`"--scope" "user" "vayu" "${URL}"`
+		);
+	});
+
+	it("spawns a native .exe directly, with no shell and an argument array", async () => {
+		const EXE = "C:\\Program Files\\Claude\\claude.exe";
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			finish(child, index === 0 ? `${EXE}\r\n` : "Added vayu.");
+		});
+
+		const res = await connectClient("claude", URL, spawnImpl);
+
+		expect(res.ok).toBe(true);
+		expect(calls[1].command).toBe(EXE);
+		expect(calls[1].options.shell).toBeUndefined();
+		expect(calls[1].args).toEqual([
+			"mcp",
+			"add",
+			"--transport",
+			"http",
+			"--scope",
+			"user",
+			"vayu",
+			URL,
+		]);
+	});
+
+	it("resolves a synchronous spawn throw into a failure result, not a rejection", async () => {
+		const { spawnImpl } = recorder((call, child, index) => {
+			// The resolve probe succeeds; the run throws the way Node's
+			// CVE-2024-27980 guard does - synchronously, before any event.
+			if (index === 0) finish(child, `${CODE_DIR}\\code.cmd\r\n`);
+		});
+		const throwingSpawn: SpawnFn = (command, args, options) => {
+			if (command === "where") return spawnImpl(command, args, options);
+			throw new Error("EINVAL: invalid argument, spawn");
+		};
+
+		const res = await connectClient("vscode", URL, throwingSpawn);
+
+		expect(res.ok).toBe(false);
+		expect(res.reason).toBe("error");
+		expect(res.message).toMatch(/EINVAL/);
+	});
+
+	it("reports the CLI as missing when `where` finds nothing", async () => {
+		const { spawnImpl, calls } = recorder((call, child) => finish(child, "", 1));
+
+		const res = await connectClient("claude", URL, spawnImpl);
+
+		expect(res).toEqual({ ok: false, reason: "cli-not-found" });
+		expect(calls).toHaveLength(1);
+	});
+});
+
+describe("connectClient on POSIX", () => {
+	beforeEach(() => setPlatform("darwin"));
+
+	it("probes the login shell first, since that is what sources the real PATH", async () => {
+		process.env.SHELL = "/bin/zsh";
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			finish(child, index === 0 ? "/opt/homebrew/bin/claude\n" : "Added vayu.");
+		});
+
+		const res = await connectClient("claude", URL, spawnImpl);
+
+		expect(res.ok).toBe(true);
+		expect(calls[0].command).toBe("/bin/zsh");
+		expect(calls[0].args).toEqual(["-lc", "command -v claude 2>/dev/null"]);
+		// The JSON/URL is never interpolated into a shell string off Windows.
+		expect(calls[1].command).toBe("/opt/homebrew/bin/claude");
+		expect(calls[1].options.shell).toBeUndefined();
+		expect(calls[1].args).toContain(URL);
+	});
+
+	it("falls back to /bin/sh when the login shell does not speak -lc", async () => {
+		process.env.SHELL = "/usr/local/bin/nu";
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			// nushell rejects `-lc` outright: nonzero, nothing on stdout.
+			if (index === 0) finish(child, "", 1);
+			else finish(child, index === 1 ? "/usr/local/bin/code\n" : "Added.");
+		});
+
+		const res = await connectClient("vscode", URL, spawnImpl);
+
+		expect(res.ok).toBe(true);
+		expect(calls.map((c) => c.command)).toEqual([
+			"/usr/local/bin/nu",
+			"/bin/sh",
+			"/usr/local/bin/code",
+		]);
+	});
+
+	it("does not probe twice when the login shell already is /bin/sh", async () => {
+		process.env.SHELL = "/bin/sh";
+		const { spawnImpl, calls } = recorder((call, child) => finish(child, "", 1));
+
+		const res = await connectClient("claude", URL, spawnImpl);
+
+		expect(res).toEqual({ ok: false, reason: "cli-not-found" });
+		expect(calls.map((c) => c.command)).toEqual(["/bin/sh"]);
+	});
+
+	it("survives a login shell that is not on disk at all", async () => {
+		process.env.SHELL = "/usr/bin/xonsh";
+		// The throwing shell never reaches the recorder, so /bin/sh is call 0.
+		const { spawnImpl, calls } = recorder((call, child, index) => {
+			finish(child, index === 0 ? "/usr/bin/claude\n" : "Added vayu.");
+		});
+		const throwingSpawn: SpawnFn = (command, args, options) => {
+			if (command === "/usr/bin/xonsh") throw new Error("ENOENT");
+			return spawnImpl(command, args, options);
+		};
+
+		const res = await connectClient("claude", URL, throwingSpawn);
+
+		expect(res.ok).toBe(true);
+		expect(calls[0].command).toBe("/bin/sh");
+	});
+});
+
+describe("connectClient rejects an unknown client", () => {
+	it("names the client rather than spawning anything", async () => {
+		const { spawnImpl, calls } = recorder((call, child) => finish(child, ""));
+
+		const res = await connectClient(
+			"cursor" as Parameters<typeof connectClient>[0],
+			URL,
+			spawnImpl
+		);
+
+		expect(res).toMatchObject({ ok: false, reason: "unsupported" });
+		expect(res.message).toContain("cursor");
+		expect(calls).toHaveLength(0);
+	});
+});

--- a/app/electron/mcp/connect.ts
+++ b/app/electron/mcp/connect.ts
@@ -14,13 +14,29 @@
  *        the UI falls back to a copyable snippet for those.
  *
  *        A GUI-launched Electron app often has a stripped PATH, so the target
- *        binary is resolved through a login shell (`command -v`) before it is
- *        spawned directly with an argument array (so the URL/JSON is never
- *        interpolated into a shell string). If the CLI cannot be found, the
- *        caller gets `reason: "cli-not-found"` and shows the copy snippet.
+ *        binary is resolved first (`where` / `command -v`) and only then spawned.
+ *        Resolution and spawning both differ per platform, and getting either
+ *        wrong looks identical to "the CLI is not installed":
+ *
+ *        - **Windows.** `where` lists every match and puts the extensionless
+ *          POSIX script first (VS Code ships `code` next to `code.cmd`), which
+ *          Node cannot execute at all; and since Node 20.12 it refuses to spawn
+ *          a `.cmd`/`.bat` without `shell: true` (the CVE-2024-27980 fix). So
+ *          the match is picked by extension and a shim is run through cmd.exe
+ *          with every argument quoted by hand - the VS Code argument is a JSON
+ *          blob, and an unquoted one loses its braces and quotes.
+ *        - **POSIX.** `-lc` sources the login profile, which is what recovers
+ *          the PATH a GUI launch stripped, so the login shell is tried first;
+ *          `/bin/sh` is the fallback for a login shell that does not speak `-lc`
+ *          (nushell, xonsh), which would otherwise report the CLI as missing.
+ *
+ *        If the CLI cannot be found, the caller gets `reason: "cli-not-found"`
+ *        and shows the copy snippet. Nothing here rejects: every failure is a
+ *        `McpConnectResult`, because the renderer distinguishes the reasons.
  */
 
 import { spawn } from "node:child_process";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 
 export type McpConnectClient = "claude" | "vscode";
 
@@ -32,59 +48,159 @@ export interface McpConnectResult {
 	message?: string;
 }
 
+/**
+ * Injection seam for the tests, matching `EngineClient`'s `fetchImpl`: the
+ * behaviour worth pinning is which command gets spawned on which platform, and
+ * that cannot be observed by running real CLIs the test machine does not have.
+ */
+export type SpawnFn = (
+	command: string,
+	args: readonly string[],
+	options: SpawnOptions
+) => ChildProcess;
+
 const RESOLVE_TIMEOUT_MS = 8000;
 const RUN_TIMEOUT_MS = 20000;
 
-/** Resolve a CLI to an absolute path via the user's login shell, or null. */
-function resolveBin(bin: string): Promise<string | null> {
-	return new Promise((resolve) => {
-		const isWin = process.platform === "win32";
-		const cmd = isWin ? "where" : process.env.SHELL || "/bin/bash";
-		// `-lc` sources the login profile so PATH matches a real terminal.
-		const args = isWin ? [bin] : ["-lc", `command -v ${bin} 2>/dev/null`];
+/**
+ * Login shell first (it sources the profile that holds the real PATH), then
+ * `/bin/sh`, which POSIX guarantees exists and understands `-lc`. Deduplicated
+ * so the common `SHELL=/bin/sh` case does not probe twice.
+ */
+function posixShells(): string[] {
+	const shells = [process.env.SHELL || "/bin/bash"];
+	if (!shells.includes("/bin/sh")) shells.push("/bin/sh");
+	return shells;
+}
 
+/** Run a probe and return its stdout lines, trimmed and empties dropped. */
+function capture(spawnImpl: SpawnFn, cmd: string, args: string[]): Promise<string[]> {
+	return new Promise((resolve) => {
 		let out = "";
 		let settled = false;
-		const done = (value: string | null) => {
+		let timer: NodeJS.Timeout | undefined;
+		const done = (value: string[]) => {
 			if (settled) return;
 			settled = true;
-			clearTimeout(timer);
+			if (timer) clearTimeout(timer);
 			resolve(value);
 		};
 
-		const child = spawn(cmd, args, { env: process.env });
-		const timer = setTimeout(() => {
+		let child: ChildProcess;
+		try {
+			child = spawnImpl(cmd, args, { env: process.env });
+		} catch {
+			// A shell that is not on disk throws here rather than emitting "error".
+			resolve([]);
+			return;
+		}
+		timer = setTimeout(() => {
 			child.kill();
-			done(null);
+			done([]);
 		}, RESOLVE_TIMEOUT_MS);
 
 		child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
-		child.on("error", () => done(null));
-		child.on("close", () => {
-			const first = out
-				.split(/\r?\n/)
-				.map((s) => s.trim())
-				.find(Boolean);
-			done(first ?? null);
-		});
+		child.on("error", () => done([]));
+		child.on("close", () =>
+			done(
+				out
+					.split(/\r?\n/)
+					.map((s) => s.trim())
+					.filter(Boolean)
+			)
+		);
 	});
 }
 
-/** Spawn an already-resolved binary with an argument array (no shell). */
-function run(bin: string, args: string[]): Promise<McpConnectResult> {
+/**
+ * `where` lists every match and orders them by PATH, so the extensionless
+ * POSIX script VS Code ships (`code`) comes before the `code.cmd` Windows can
+ * actually run. Pick by extension instead of taking the first line.
+ */
+function pickWindowsBin(paths: string[]): string | null {
+	const withExt = (exts: string[]) =>
+		paths.find((p) => exts.some((e) => p.toLowerCase().endsWith(e)));
+	return withExt([".exe", ".com"]) ?? withExt([".cmd", ".bat"]) ?? paths[0] ?? null;
+}
+
+/** Resolve a CLI to an absolute path, or null when it is not installed. */
+async function resolveBin(bin: string, spawnImpl: SpawnFn): Promise<string | null> {
+	if (process.platform === "win32") {
+		return pickWindowsBin(await capture(spawnImpl, "where", [bin]));
+	}
+	for (const shell of posixShells()) {
+		const [first] = await capture(spawnImpl, shell, ["-lc", `command -v ${bin} 2>/dev/null`]);
+		if (first) return first;
+	}
+	return null;
+}
+
+/** Node >= 20.12 refuses to spawn these without a shell (CVE-2024-27980). */
+function needsShell(bin: string): boolean {
+	return process.platform === "win32" && /\.(cmd|bat)$/i.test(bin);
+}
+
+/**
+ * Quote one argument for `cmd.exe /d /s /c "..."`, which Node builds when
+ * `shell: true` is set on Windows.
+ *
+ * Two parsers read this string in turn: cmd.exe, then the target program's own
+ * command-line splitter. Double quotes neutralise cmd's metacharacters
+ * (`& | < > ^`) and hand the splitter a single argument; backslashes only need
+ * doubling where they precede a quote (the MSVCRT rule). `%` is the one
+ * character quotes do not protect - cmd expands `%VAR%` before anything else
+ * sees the line, and there is no escape for it outside a batch file - so an
+ * argument carrying one is refused rather than silently mangled.
+ */
+function quoteForCmd(arg: string): string {
+	if (arg.includes("%")) {
+		throw new Error(`Cannot pass an argument containing "%" through cmd.exe: ${arg}`);
+	}
+	const escaped = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, "$1$1");
+	return `"${escaped}"`;
+}
+
+/** Spawn an already-resolved binary, through cmd.exe when it is a shim. */
+function run(bin: string, args: string[], spawnImpl: SpawnFn): Promise<McpConnectResult> {
 	return new Promise((resolve) => {
 		let out = "";
 		let err = "";
 		let settled = false;
+		let timer: NodeJS.Timeout | undefined;
 		const done = (value: McpConnectResult) => {
 			if (settled) return;
 			settled = true;
-			clearTimeout(timer);
+			if (timer) clearTimeout(timer);
 			resolve(value);
 		};
 
-		const child = spawn(bin, args, { env: process.env });
-		const timer = setTimeout(() => {
+		let command = bin;
+		let spawnArgs: string[] = args;
+		let options: SpawnOptions = { env: process.env };
+		if (needsShell(bin)) {
+			try {
+				// The whole line goes in `command`: Node joins command and args
+				// with plain spaces under `shell: true`, so anything left in
+				// `args` would arrive unquoted.
+				command = [bin, ...args].map(quoteForCmd).join(" ");
+			} catch (e) {
+				done({ ok: false, reason: "error", message: (e as Error).message });
+				return;
+			}
+			spawnArgs = [];
+			options = { env: process.env, shell: true };
+		}
+
+		let child: ChildProcess;
+		try {
+			child = spawnImpl(command, spawnArgs, options);
+		} catch (e) {
+			// EINVAL for a shim spawned without a shell throws synchronously -
+			// a rejection here would reach the renderer as an unhandled invoke.
+			done({ ok: false, reason: "error", message: (e as Error).message });
+			return;
+		}
+		timer = setTimeout(() => {
 			child.kill();
 			done({ ok: false, reason: "error", message: "Timed out running the client CLI." });
 		}, RUN_TIMEOUT_MS);
@@ -112,18 +228,27 @@ function run(bin: string, args: string[]): Promise<McpConnectResult> {
  */
 export async function connectClient(
 	client: McpConnectClient,
-	url: string
+	url: string,
+	spawnImpl: SpawnFn = spawn
 ): Promise<McpConnectResult> {
 	if (client === "claude") {
-		const bin = await resolveBin("claude");
+		const bin = await resolveBin("claude", spawnImpl);
 		if (!bin) return { ok: false, reason: "cli-not-found" };
 		// `--scope user` makes it available across all projects (not just cwd).
-		return run(bin, ["mcp", "add", "--transport", "http", "--scope", "user", "vayu", url]);
+		return run(
+			bin,
+			["mcp", "add", "--transport", "http", "--scope", "user", "vayu", url],
+			spawnImpl
+		);
 	}
 	if (client === "vscode") {
-		const bin = await resolveBin("code");
+		const bin = await resolveBin("code", spawnImpl);
 		if (!bin) return { ok: false, reason: "cli-not-found" };
-		return run(bin, ["--add-mcp", JSON.stringify({ name: "vayu", type: "http", url })]);
+		return run(
+			bin,
+			["--add-mcp", JSON.stringify({ name: "vayu", type: "http", url })],
+			spawnImpl
+		);
 	}
 	return { ok: false, reason: "unsupported", message: `Unsupported client: ${String(client)}` };
 }

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.test.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.test.tsx
@@ -182,6 +182,19 @@ describe("McpSettingsPanel write failures", () => {
 	});
 });
 
+describe("McpSettingsPanel connect failures", () => {
+	it("surfaces a rejected connect instead of only stopping the spinner", async () => {
+		await renderPanel();
+		connectMcpClient.mockRejectedValue(new Error("mcp server is off"));
+
+		await act(async () => {
+			fireEvent.click(screen.getAllByRole("button", { name: /^connect$/i })[0]);
+		});
+
+		expect(toastMessages().join(" ")).toMatch(/couldn't connect .*mcp server is off/i);
+	});
+});
+
 describe("McpSettingsPanel tool list", () => {
 	it("renders a tool whose category the copy table does not describe", async () => {
 		getMcpTools.mockResolvedValue([

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
@@ -396,6 +396,15 @@ export default function McpSettingsPanel() {
 				} else {
 					showToast(res.message || `Couldn't connect ${CLIENT_LABEL[client]}.`, "error");
 				}
+			} catch (err) {
+				// Without this the rejected invoke only stopped the spinner, so a
+				// connect that never reached the CLI looked like nothing happened.
+				showToast(
+					err instanceof Error
+						? `Couldn't connect ${CLIENT_LABEL[client]}: ${err.message}`
+						: `Couldn't connect ${CLIENT_LABEL[client]}.`,
+					"error"
+				);
 			} finally {
 				setConnecting(null);
 			}

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -33,6 +33,15 @@ Ensure Vayu is running, then register the endpoint once per machine. In the app,
 **Settings → MCP** offers a one-click **Connect** for Claude Code and VS Code
 (shells out to their CLIs) and copyable snippets for the rest.
 
+Connect resolves the client CLI before running it, because a GUI-launched app
+often has a stripped PATH. On macOS and Linux that means the login shell
+(`$SHELL -lc`, falling back to `/bin/sh -lc` for a shell that does not accept
+`-lc`); on Windows it means `where`, preferring an `.exe` and then a `.cmd`
+shim over the extensionless POSIX script VS Code also installs. A `.cmd`/`.bat`
+shim is run through `cmd.exe`, which Node has required since 20.12. If the CLI
+is not installed, or the run fails for any reason, Connect says so and the
+snippet below it is the manual path.
+
 ```bash
 # Claude Code (or click Connect in Settings → MCP)
 claude mcp add --transport http vayu http://127.0.0.1:9877/mcp
@@ -477,7 +486,7 @@ Everything lives under `app/electron/mcp/` and is managed by `main.ts` alongside
 | `server.ts`        | Builds the SDK `McpServer`; registers tools/resources/prompts.              |
 | `http.ts`          | Stateless Streamable HTTP host (DNS-rebinding on).                          |
 | `cli.ts`           | Standalone stdio server (env-configured).                                   |
-| `connect.ts`       | One-click connect: shells out to `claude` / `code` CLIs.                    |
+| `connect.ts`       | One-click connect: resolves and runs the `claude` / `code` CLIs.            |
 | `store.ts`         | Persist safety config + enabled preference (`electron-store`).              |
 | `index.ts`         | `VayuMcpService` facade consumed by `main.ts`.                              |
 


### PR DESCRIPTION
## Description

**Plan.** The root cause is that `connect.ts` treated CLI resolution and spawning as platform-independent when neither is. `where` lists every match ordered by PATH, so VS Code's extensionless POSIX script comes before the `code.cmd` Windows can actually run; and Node has refused to spawn `.cmd`/`.bat` without `shell: true` since 20.12 (the CVE-2024-27980 fix), which also breaks an npm-installed `claude`. A native `claude.exe` was the one configuration that worked. Both failures surfaced as nothing at all, because the renderer's `handleConnect` was `try`/`finally` with no `catch`. The approach is to pick the resolved binary by extension, run a shim through `cmd.exe` with every argument quoted by hand, and add the missing `catch`. **Alternative rejected:** always spawning with `shell: true` on Windows - simpler, but it puts a `.exe`'s arguments through cmd.exe's parser for no benefit and widens the quoting surface to the one case that already worked. Quoting only where a shell is unavoidable keeps the `.exe` path a plain argument array.

Anchors re-verified against master `e50d540` (the issue was written against `10c8193`; `#316` and `#317` have landed since, moving `handleConnect` to `McpSettingsPanel.tsx:383` but leaving it unchanged, and `connect.ts` is byte-identical to the issue's description).

Changes:

- **`app/electron/mcp/connect.ts`**
  - `pickWindowsBin` prefers `.exe`/`.com`, then `.cmd`/`.bat`, then the first `where` match.
  - A `.cmd`/`.bat` runs through `shell: true` with the whole line pre-quoted in `command` and an empty `args` array - Node joins command and args with plain spaces under a shell, so anything left in `args` arrives unquoted and the VS Code JSON blob loses its quotes and braces. `%` has no escape outside a batch file, so an argument carrying one is rejected with a named error rather than silently mangled.
  - Both spawns are wrapped so a synchronous throw becomes `{ ok: false, reason: "error" }` instead of rejecting across the IPC boundary.
  - POSIX resolution tries `$SHELL -lc` first (that is what recovers a GUI-stripped PATH) and then `/bin/sh -lc`, so a login shell that does not accept `-lc` (nushell, xonsh) no longer reports the CLI as missing. Deduplicated, so `SHELL=/bin/sh` does not probe twice.
  - `connectClient` takes an optional `spawnImpl`, defaulting to `spawn` - the same injection seam `EngineClient` uses for `fetchImpl`. No production caller changes.
- **`McpSettingsPanel.tsx`** - `handleConnect` gains a `catch` that toasts the error.
- **`docs/engine/mcp.md`** - the Connecting section now states the per-platform resolution and the cmd.exe requirement; the `connect.ts` row in the file table no longer says "shells out to".

Deliberate deviation from the issue spec: none. The issue's note about `docs/engine/mcp.md` was conditional ("if it claims Windows support that does not currently work") - it did not claim it either way, so the section gained a paragraph describing the corrected behavior rather than a correction.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

New `app/electron/mcp/connect.test.ts` (the file had no tests at all): 11 tests, `process.platform` stubbed both ways as `updater.test.ts` does, driving a recording `spawnImpl`. Windows: the `.cmd` shim spawns with `shell: true` and the **exact** quoted command line asserted (VS Code JSON and the npm `claude` shim), the runnable shim is picked over the extensionless first `where` line, a `.exe` spawns directly with an argument array and no shell, a synchronous spawn throw resolves to a failure result, and an empty `where` gives `cli-not-found` after one spawn. POSIX: the login shell is probed first, `/bin/sh` follows when it fails, `SHELL=/bin/sh` probes once, and a login shell that is not on disk (a synchronous throw) still falls through. Plus one jsdom test in `McpSettingsPanel.test.tsx` for the rejected-invoke toast.

Mutation-checked, each fix reverted in turn:

| Reverted | Fails |
|---|---|
| `needsShell` → `false` | 3 Windows tests |
| `/bin/sh` fallback removed | 2 POSIX tests |
| `pickWindowsBin` → `paths[0]` | 3 Windows tests |
| renderer `catch` removed | the panel toast test |

Full suites, all green on this branch:

- `cd app && pnpm test` - **293 files, 2652 tests passed** (was 2641 before this change)
- `cd app && pnpm type-check` - clean
- `cd app && pnpm lint` - clean (zero warnings)
- `cd app && pnpm format:check` - clean

No engine change, so the C++ build and `ctest` were not run - nothing in this diff can change their colour. `mkdocs build --strict` could not be run (mkdocs is not installed in this environment); the docs edit adds no links, headings or nav entries, only prose inside an existing section and one table cell. No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #322

Sub-issue of #321 (Wave M-robustness). Shares `McpSettingsPanel.tsx` with #316, which has since merged - the `handleConnect` hunk here is disjoint from it and applied cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeboGzPyGhSwrjXoRzL3wJ)_