### PR TITLE
fix(mcp/engine): range-check maxInFlight instead of reading -1 as ~1.8e19

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -883,8 +883,10 @@ describe("dispatchTool", () => {
 
 	test("the schema refuses load counts the engine reads as enormous", () => {
 		// `-1` is the natural "unlimited" guess and casts to ~1.8e19 engine-side,
-		// where it is a request count and a ramp seed, not an error.
-		for (const field of ["startConcurrency", "iterations"]) {
+		// where it is a request count, a ramp seed and an in-flight ceiling, not
+		// an error. `maxInFlight` bounds in-flight *downward*, so the enormous
+		// value is the one that removes the backpressure it was asked for.
+		for (const field of ["startConcurrency", "iterations", "maxInFlight"]) {
 			expect(() =>
 				parseArgs("start_load_run", { url: "https://api.example.com", [field]: -1 })
 			).toThrow();

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1079,7 +1079,14 @@ export const TOOLS: McpTool[] = [
 				.optional()
 				.describe("Iteration count (iterations mode)."),
 			targetRps: z.number().optional().describe("Target RPS (constant_rps)."),
-			maxInFlight: z.number().optional().describe("In-flight cap (constant_rps only)."),
+			// A pending-request ceiling read as a `size_t`, so `-1` - the natural
+			// "unlimited" spelling - removes the ceiling instead of tightening it.
+			maxInFlight: z
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe("In-flight cap (constant_rps only)."),
 			requestId: z
 				.string()
 				.optional()

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1341,6 +1341,7 @@ default, and whose message names the offending field and why the bound exists:
 | `max_exemplar_results` | `0`-`100000` | Each retained exemplar holds a captured exchange. `0` means unlimited. |
 | `concurrency` | `1`-`10000` | Connections are eagerly pre-allocated per worker before any traffic flows, so `-1` (a natural "unlimited" guess) allocated until malloc failed. |
 | `startConcurrency` | `1`-`10000` | The ramp is seeded with this many in-flight requests before the first duration check, and it is read as a `size_t`, so a negative start is ~1.8e19 of them. |
+| `maxInFlight` | `1`-`10000` | It is a pending-request ceiling read as a `size_t`, so `-1` or `0` removes the backpressure the field exists to provide instead of tightening it, and an open-loop run against a slow target then accumulates in-flight requests for its whole duration. |
 | `timeout` | `1`-`86400000` ms | A transfer that never times out never completes, leaving the run stuck `running` and unstoppable. |
 | `duration` | string, positive, optional unit (`ms`\|`s`\|`m`\|`h`) | A JSON *number* threw out of the run-context constructor *after* the row was written, stranding it `pending` forever behind an opaque `500`. |
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -410,11 +410,14 @@ configurable in **Settings → MCP** and persisted.
     - An **omitted** `duration` is 60s engine-side, not "unbounded" and not
       "capped". When `maxDurationSeconds` is under 60, the tool sends the cap as
       an explicit duration so the run is actually bounded by it.
-  `concurrency`, `startConcurrency` and `iterations` are additionally constrained
-  to positive integers by the tool's own schema, because "unlimited" is an
-  obvious guess to spell `-1` or `0` and the engine reads them as an eager
-  per-worker pre-allocation count, a ramp seed, and a request budget (see the
-  accepted ranges under [POST /runs](api-reference.md#post-runs)).
+  `concurrency`, `startConcurrency`, `iterations` and `maxInFlight` are
+  additionally constrained to positive integers by the tool's own schema, because
+  "unlimited" is an obvious guess to spell `-1` or `0` and the engine reads them
+  as an eager per-worker pre-allocation count, a ramp seed, a request budget, and
+  an in-flight ceiling (see the accepted ranges under
+  [POST /runs](api-reference.md#post-runs)). `maxInFlight` is the one that bounds
+  work *downward*, so there is no separate cap setting for it - the enormous
+  value is the one that removes the backpressure the caller asked for.
   `duration` / `rampUpDuration` are also rejected when they are not durations at
   all (`ms`/`s`/`m`/`h`, or a bare number of seconds - the same grammar the
   engine parses), since the engine now fails such a run rather than quietly

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -591,6 +591,10 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         "A ramp is seeded with this many in-flight requests before the first "
         "duration check, and it is read as a size_t, so a negative start is "
         "~1.8e19 of them." },
+        { "maxInFlight", 1, limits::MAX_CONCURRENCY,
+        "It is a pending-request ceiling read as a size_t, so a negative value "
+        "is ~1.8e19 - it removes the backpressure the field exists to provide "
+        "rather than tightening it." },
         { "timeout", 1, 86400000,
         "A transfer with no timeout never completes, so the run can never "
         "reach "

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -164,6 +164,34 @@ TEST (RunConfigValidation, StartConcurrencyBoundsAreInclusive) {
     expect_rejected (config, "startConcurrency");
 }
 
+// `maxInFlight` is the only field here that bounds work *downward*: the harm of
+// a bad value is not an allocation, it is the ceiling silently disappearing, so
+// an open-loop run against a hanging target accumulates in-flight requests for
+// its whole duration.
+TEST (RunConfigValidation, NegativeMaxInFlightIsRejected) {
+    auto config           = valid_config ();
+    config["maxInFlight"] = -1;
+    expect_rejected (config, "maxInFlight");
+}
+
+TEST (RunConfigValidation, ZeroMaxInFlightIsRejected) {
+    // 0 would be "drop everything", not "no cap" - either reading is a run that
+    // does not do what the caller asked, so it is rejected rather than guessed.
+    auto config           = valid_config ();
+    config["maxInFlight"] = 0;
+    expect_rejected (config, "maxInFlight");
+}
+
+TEST (RunConfigValidation, MaxInFlightBoundsAreInclusive) {
+    auto config           = valid_config ();
+    config["maxInFlight"] = 1;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    config["maxInFlight"] = vayu::core::constants::run_config::MAX_CONCURRENCY;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    config["maxInFlight"] = vayu::core::constants::run_config::MAX_CONCURRENCY + 1;
+    expect_rejected (config, "maxInFlight");
+}
+
 // --- 3. Timeout: <= 0 left transfers that never expire ---------------------
 
 TEST (RunConfigValidation, ZeroTimeoutIsRejected) {


### PR DESCRIPTION
## Description

**Plan.** Root cause: `start_load_run` declared `maxInFlight` as a bare `z.number().optional()` and forwarded it to `POST /runs` whenever numeric, while `validate_run_config` had no entry for it - so `load_strategy.cpp` read it straight into a `size_t`. `-1` (the natural "unlimited" spelling) became ~1.8e19, which does not crash: it *removes* the backpressure ceiling the field exists to provide, and an open-loop `constant_rps` run against a slow or hanging target then accumulates in-flight requests for its whole duration. Approach: give the field the same positive-integer schema its siblings got in #312, and add it to the engine's numeric field table (range `1`-`MAX_CONCURRENCY`) so a bad value is a `400` naming the field and the reason, before any run row is created. Alternative rejected: a fourth MCP safety cap for it - `maxInFlight` bounds in-flight *downward*, so `maxConcurrency` is not its ceiling and a new setting would be surface for no protection.

Anchors re-verified against master `e50d540` (the issue cites `10c8193`): `tools.ts` still forwarded the field unvalidated, `validate_run_config` still had no entry, and `load_strategy.cpp:341` still reads it unguarded. Blast radius traced: the only other producer is the renderer's load-test dialog, which already guards `maxInFlightValue > 0` before setting `config.max_in_flight` (`LoadTestConfigDialog/index.tsx:348`), so no existing UI path can now be rejected. No consumer reads the value other than the `constant_rps` strategy.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally on this branch:

- `python build.py -e -t` - engine builds clean.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **865/865 passed** (3 new).
- `cd app && pnpm test` - **2640 passed, 292 files**.
- `cd app && pnpm type-check`, `pnpm lint`, and prettier on the two touched files - clean.

Mutation-checked both sides, not assumed:

- Reverting the `validate_run_config` entry and rebuilding fails all three new engine tests (`NegativeMaxInFlightIsRejected`, `ZeroMaxInFlightIsRejected`, `MaxInFlightBoundsAreInclusive`); restored, 30/30 `RunConfigValidation.*` pass.
- Reverting the schema to `z.number()` fails `the schema refuses load counts the engine reads as enormous` ("expected [Function] to throw an error").

No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: a `maxInFlight` row in the accepted-ranges table under `POST /runs` (`docs/engine/api-reference.md`), and the MCP caps section (`docs/engine/mcp.md`) now lists it among the schema-constrained positive integers, noting why it gets no cap setting of its own.

Note on formatting: the local clang-format 18 reflows unrelated regions of `execution.cpp`, so that file carries only the 4-line table addition; the new test block is clang-format clean.

## Related Issues
Closes #324

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoiHWHV3FwGi8NKGYocD2T)_