### PR TITLE
fix(mcp): size the /execute budget to the engine's own timeout, not a flat 35s

### DIFF
--- a/app/electron/mcp/engine-client.test.ts
+++ b/app/electron/mcp/engine-client.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { EngineClient } from "./engine-client.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { EngineClient, EngineTimeoutError } from "./engine-client.js";
 
 /** A fetch that never resolves on its own but rejects when its signal aborts. */
 function abortableFetch(): { fetchImpl: typeof fetch; seen: () => AbortSignal | undefined } {
@@ -87,5 +87,128 @@ describe("EngineClient.getEnvironment", () => {
 		const { fetchImpl } = listFetch([{ id: "env_1", name: "Dev" }]);
 		const client = new EngineClient({ baseUrl: "http://127.0.0.1:9876", fetchImpl });
 		await expect(client.getEnvironment("missing")).resolves.toBeNull();
+	});
+});
+
+/**
+ * `POST /execute` waits on a third-party server, bounded engine-side by the
+ * user-configurable `defaultTimeout` (up to 300s). A flat client budget below
+ * that aborts a request the engine goes on to complete - side effects sent, run
+ * row written - so these pin the budget to the engine's own setting. Driven on
+ * fake timers: the assertion is which budget was armed, never wall-clock.
+ */
+describe("EngineClient /execute abort budget", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	/**
+	 * A fetch that answers `GET /config` from `entries` (or rejects when it is
+	 * null, standing in for an unreachable or slow config) and leaves every other
+	 * call hanging until its signal aborts.
+	 */
+	function executeFetch(entries: Array<Record<string, string>> | null) {
+		const urls: string[] = [];
+		const fetchImpl = vi.fn((url: string | URL | Request, opts?: RequestInit) => {
+			urls.push(String(url));
+			if (String(url).endsWith("/config")) {
+				return entries
+					? Promise.resolve(new Response(JSON.stringify({ entries })))
+					: Promise.reject(new TypeError("fetch failed"));
+			}
+			return new Promise<Response>((_resolve, reject) => {
+				const abort = () =>
+					reject(new DOMException("The operation was aborted.", "AbortError"));
+				// Real fetch rejects at once for a signal that is already aborted;
+				// only listening for the event would hang here instead.
+				if (opts?.signal?.aborted) abort();
+				else opts?.signal?.addEventListener("abort", abort);
+			});
+		}) as unknown as typeof fetch;
+		return { fetchImpl, urls };
+	}
+
+	/** Start an execute and let the config probe resolve before time advances. */
+	async function startExecute(
+		entries: Array<Record<string, string>> | null,
+		payload: Record<string, unknown> = { url: "https://slow.example.com" }
+	) {
+		vi.useFakeTimers();
+		const { fetchImpl, urls } = executeFetch(entries);
+		const client = new EngineClient({ baseUrl: "http://127.0.0.1:9876", fetchImpl });
+		let settled = false;
+		const pending = client.executeRequest(payload).catch((err: unknown) => {
+			settled = true;
+			throw err;
+		});
+		// Swallow the rejection until a test awaits it - the budget only arms
+		// after the probe resolves, which needs the microtask queue to drain.
+		pending.catch(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+		return { pending, urls, settled: () => settled };
+	}
+
+	it("outlives the engine's configured defaultTimeout, and reports the budget when it expires", async () => {
+		const { pending, settled } = await startExecute([
+			{ key: "defaultTimeout", value: "120000" },
+		]);
+
+		// A flat 35s budget would have aborted here, mid-request.
+		await vi.advanceTimersByTimeAsync(129_000);
+		expect(settled()).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await expect(pending).rejects.toBeInstanceOf(EngineTimeoutError);
+		await expect(pending).rejects.toMatchObject({ timeoutMs: 130_000 });
+	});
+
+	it("falls back to the engine's 300s ceiling when the config cannot be read", async () => {
+		const { pending, settled } = await startExecute(null);
+
+		await vi.advanceTimersByTimeAsync(309_000);
+		expect(settled()).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await expect(pending).rejects.toMatchObject({ timeoutMs: 310_000 });
+	});
+
+	it("takes the payload's own timeout when it exceeds the configured default", async () => {
+		const { pending } = await startExecute([{ key: "defaultTimeout", value: "120000" }], {
+			url: "https://slow.example.com",
+			timeout: 200_000,
+		});
+
+		await vi.advanceTimersByTimeAsync(211_000);
+		await expect(pending).rejects.toMatchObject({ timeoutMs: 210_000 });
+	});
+
+	it("leaves engine-local calls on the flat budget and probes no config for them", async () => {
+		vi.useFakeTimers();
+		const { fetchImpl, urls } = executeFetch([{ key: "defaultTimeout", value: "120000" }]);
+		const client = new EngineClient({ baseUrl: "http://127.0.0.1:9876", fetchImpl });
+
+		const pending = client.listCollections();
+		pending.catch(() => {});
+		await vi.advanceTimersByTimeAsync(36_000);
+
+		await expect(pending).rejects.toMatchObject({ timeoutMs: 35_000 });
+		expect(urls).toEqual(["http://127.0.0.1:9876/collections"]);
+	});
+
+	it("reports a caller's cancellation as an abort, not as a timeout", async () => {
+		const { fetchImpl } = executeFetch([{ key: "defaultTimeout", value: "120000" }]);
+		const client = new EngineClient({ baseUrl: "http://127.0.0.1:9876", fetchImpl });
+		const controller = new AbortController();
+
+		const pending = client.executeRequest(
+			{ url: "https://slow.example.com" },
+			controller.signal
+		);
+		pending.catch(() => {});
+		await Promise.resolve();
+		controller.abort();
+
+		await expect(pending).rejects.not.toBeInstanceOf(EngineTimeoutError);
+		await expect(pending).rejects.toThrow(/abort/i);
 	});
 });

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -26,6 +26,25 @@ export class EngineRequestError extends Error {
 	}
 }
 
+/**
+ * Raised when *this client's* abort budget expired before the engine answered -
+ * distinct from the caller cancelling and from an unreachable engine. The
+ * engine is still working on the call when this throws, so a caller must not
+ * report it as "engine not running" or advise a blind retry: the request may
+ * already have been sent and recorded. Carries the budget so the message can
+ * name it.
+ */
+export class EngineTimeoutError extends Error {
+	constructor(
+		method: string,
+		path: string,
+		readonly timeoutMs: number
+	) {
+		super(`No response from the engine within ${timeoutMs}ms for ${method} ${path}`);
+		this.name = "EngineTimeoutError";
+	}
+}
+
 export interface EngineClientOptions {
 	/** Base URL of the engine, e.g. `http://127.0.0.1:9876`. */
 	baseUrl: string;
@@ -35,7 +54,37 @@ export interface EngineClientOptions {
 	fetchImpl?: typeof fetch;
 }
 
+/**
+ * Budget for engine-local calls - reads, writes, composition, run bookkeeping.
+ * These never wait on a third-party server, so a stall here is a stuck engine.
+ */
 const DEFAULT_TIMEOUT_MS = 35_000;
+
+/**
+ * The three values below mirror `app/src/config/network.ts` (the renderer
+ * derives the same budget for its proxied calls); the main process cannot
+ * import renderer modules, so they are duplicated here. Keep them in sync.
+ *
+ * Grace on top of the engine's own timeout, so the engine's TIMEOUT error -
+ * which carries a proper error code and a recorded run - always arrives before
+ * this client gives up.
+ */
+const PROXIED_TIMEOUT_GRACE_MS = 10_000;
+
+/**
+ * Ceiling of the engine's `defaultTimeout` setting (`seed_default_config` in
+ * engine/src/db/database.cpp caps it at 300000). Used when the setting cannot
+ * be read, so an unreadable config never shortens the budget below what the
+ * engine may legitimately take.
+ */
+const ENGINE_MAX_DEFAULT_TIMEOUT_MS = 300_000;
+
+/**
+ * Budget for the `GET /config` probe that derives the one above. Deliberately
+ * short: it reads a local SQLite-backed row, and a slow answer must not delay
+ * the call it is sizing - a failed probe falls back to the ceiling.
+ */
+const CONFIG_PROBE_TIMEOUT_MS = 2_000;
 
 /** A single decoded live-metrics tick (shape mirrors the engine SSE payload). */
 export type MetricsTick = Record<string, unknown>;
@@ -59,10 +108,15 @@ export class EngineClient {
 		method: string,
 		path: string,
 		body?: unknown,
-		signal?: AbortSignal
+		signal?: AbortSignal,
+		timeoutMs = this.timeoutMs
 	): Promise<T> {
 		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+		let expired = false;
+		const timer = setTimeout(() => {
+			expired = true;
+			controller.abort();
+		}, timeoutMs);
 		// Abort on either our timeout or the caller's signal (MCP tool cancellation).
 		const combined = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
 		try {
@@ -81,9 +135,49 @@ export class EngineClient {
 				);
 			}
 			return (text ? JSON.parse(text) : null) as T;
+		} catch (err) {
+			// Only *our* timer expiring is a timeout; the caller's cancellation
+			// aborts the same fetch and must stay distinguishable from it.
+			if (expired && isAbortError(err)) throw new EngineTimeoutError(method, path, timeoutMs);
+			throw err;
 		} finally {
 			clearTimeout(timer);
 		}
+	}
+
+	/**
+	 * Abort budget for a call that proxies a third-party server. Such a call is
+	 * bounded engine-side by the payload's own `timeout` or, absent one, the
+	 * user-configurable `defaultTimeout` setting (`resolve_request_timeout_ms`,
+	 * engine/src/http/routes/execution.cpp) - which reaches 300s, far past the
+	 * engine-local default. Sizing the client budget off that setting is what
+	 * keeps a legitimately slow request from being aborted here while the engine
+	 * completes it there, with the side effects and the run row already real.
+	 *
+	 * MCP-composed payloads carry no `timeout` of their own (`payload_from_stored`
+	 * emits none), so the config read - not the payload - is what does the work;
+	 * the `max` covers an inline payload that does carry a larger one.
+	 */
+	private async proxiedTimeoutMs(payload: unknown, signal?: AbortSignal): Promise<number> {
+		let configured = 0;
+		try {
+			const cfg = await this.request<unknown>(
+				"GET",
+				"/config",
+				undefined,
+				signal,
+				CONFIG_PROBE_TIMEOUT_MS
+			);
+			configured = readDefaultTimeoutMs(cfg);
+		} catch {
+			// Unreachable, slow or malformed config: fall back to the ceiling
+			// rather than to a budget shorter than the engine may take.
+		}
+		const base = Math.max(
+			readPayloadTimeoutMs(payload),
+			configured > 0 ? configured : ENGINE_MAX_DEFAULT_TIMEOUT_MS
+		);
+		return base + PROXIED_TIMEOUT_GRACE_MS;
 	}
 
 	// --- Health & metadata ---------------------------------------------------
@@ -107,23 +201,8 @@ export class EngineClient {
 		);
 	}
 
-	/**
-	 * Fetch a single saved request. Unlike environments, the engine does have a
-	 * `GET /requests/:id` route, so this is one round trip rather than a scan of
-	 * every collection's list. A `404` surfaces as an `EngineRequestError`, which
-	 * is what distinguishes "that request was deleted" from an unreachable engine.
-	 */
-	getRequest(id: string, signal?: AbortSignal): Promise<unknown> {
-		return this.request("GET", `/requests/${encodeURIComponent(id)}`, undefined, signal);
-	}
-
 	listEnvironments(signal?: AbortSignal): Promise<unknown> {
 		return this.request("GET", "/environments", undefined, signal);
-	}
-
-	/** Global variables (the lowest-precedence layer of variable resolution). */
-	getGlobals(signal?: AbortSignal): Promise<unknown> {
-		return this.request("GET", "/globals", undefined, signal);
 	}
 
 	/**
@@ -204,8 +283,15 @@ export class EngineClient {
 		return this.request("POST", "/compose", payload, signal);
 	}
 
-	executeRequest(payload: unknown, signal?: AbortSignal): Promise<unknown> {
-		return this.request("POST", "/execute", payload, signal);
+	/**
+	 * Send a composed request. This is the one call that waits on a third-party
+	 * server, so it gets the derived budget (see {@link proxiedTimeoutMs}) rather
+	 * than the engine-local default. `/compose` and `POST /runs` stay on the
+	 * default: both return as soon as the engine has done local work.
+	 */
+	async executeRequest(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		const timeoutMs = await this.proxiedTimeoutMs(payload, signal);
+		return this.request("POST", "/execute", payload, signal, timeoutMs);
 	}
 
 	startRun(payload: unknown, signal?: AbortSignal): Promise<unknown> {
@@ -289,6 +375,34 @@ export class EngineClient {
 		}
 		return ticks.slice(-limit);
 	}
+}
+
+/** True for the rejection a fetch produces when its signal aborts. */
+function isAbortError(err: unknown): boolean {
+	return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Read the engine's `defaultTimeout` (milliseconds) out of a `GET /config`
+ * body. Values arrive as strings. Returns 0 when the entry is absent or not a
+ * positive number, which the caller reads as "unknown".
+ */
+function readDefaultTimeoutMs(config: unknown): number {
+	const raw =
+		config && typeof config === "object" ? (config as Record<string, unknown>).entries : null;
+	const entries = Array.isArray(raw) ? (raw as Array<Record<string, unknown>>) : [];
+	const entry = entries.find((e) => e && typeof e === "object" && e.key === "defaultTimeout");
+	const value = Number(entry?.value);
+	return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/** A payload's own `timeout` override in milliseconds, or 0 when it carries none. */
+function readPayloadTimeoutMs(payload: unknown): number {
+	const value =
+		payload && typeof payload === "object"
+			? (payload as Record<string, unknown>).timeout
+			: undefined;
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
 }
 
 /** Parse one SSE event block ("event: x\ndata: y") into its fields. */

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { dispatchTool, toolCatalog, TOOLS, type ToolContext } from "./tools.js";
 import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
-import { EngineRequestError, type EngineClient } from "./engine-client.js";
+import { EngineRequestError, EngineTimeoutError, type EngineClient } from "./engine-client.js";
 
 /**
  * Default `composeRequest` fake: the engine's identity composition for an
@@ -47,8 +47,6 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		getLiveMetricsSnapshot: vi.fn().mockResolvedValue([{ currentRps: 100 }]),
 		getConfig: vi.fn().mockResolvedValue({ entries: [{ key: "workers", value: "8" }] }),
 		updateConfig: vi.fn().mockResolvedValue({ entries: [{ key: "workers", value: "16" }] }),
-		getGlobals: vi.fn().mockResolvedValue({ variables: {} }),
-		getRequest: vi.fn().mockResolvedValue(null),
 		createRequest: vi.fn().mockResolvedValue({ id: "req_1", name: "New" }),
 		getEnvironment: vi.fn().mockResolvedValue({
 			id: "env_1",
@@ -1231,5 +1229,52 @@ describe("start_load_run rejects an unusable concurrency at the schema", () => {
 	test("accepts an ordinary concurrency, and its absence", () => {
 		expect(concurrencySchema().safeParse(50).success).toBe(true);
 		expect(concurrencySchema().safeParse(undefined).success).toBe(true);
+	});
+});
+
+/**
+ * An abort is the one transport failure that means the engine *was* reachable
+ * and busy: it may already have sent the request and written the run row. The
+ * old handling matched `/abort/i` alongside ECONNREFUSED and answered "engine
+ * not running, retry", which is wrong twice over and talks an agent into
+ * re-firing a request that already ran.
+ */
+describe("engine transport failures are told apart", () => {
+	async function runRequestFailingWith(err: unknown) {
+		const client = fakeClient({ executeRequest: vi.fn().mockRejectedValue(err) });
+		return dispatchTool(
+			"run_request",
+			{ url: "https://api.example.com/slow" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+	}
+
+	test("a client-budget timeout names the budget and sends the agent to run history", async () => {
+		const res = await runRequestFailingWith(
+			new EngineTimeoutError("POST", "/execute", 130_000)
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/130s budget/);
+		expect(firstText(res)).toMatch(/may still have completed/i);
+		expect(firstText(res)).toMatch(/list_runs/);
+		expect(firstText(res)).not.toMatch(/Make sure the Vayu app is running/);
+	});
+
+	test("a cancelled call is not reported as an unreachable engine either", async () => {
+		const res = await runRequestFailingWith(
+			new DOMException("The operation was aborted.", "AbortError")
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/cancelled/i);
+		expect(firstText(res)).toMatch(/list_runs/);
+		expect(firstText(res)).not.toMatch(/Make sure the Vayu app is running/);
+	});
+
+	test("a genuinely unreachable engine still says so", async () => {
+		const res = await runRequestFailingWith(
+			new TypeError("fetch failed: connect ECONNREFUSED 127.0.0.1:9876")
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/Make sure the Vayu app is running/);
 	});
 });

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -19,7 +19,7 @@
 import { z } from "zod";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { EngineClient } from "./engine-client.js";
-import { EngineRequestError } from "./engine-client.js";
+import { EngineRequestError, EngineTimeoutError } from "./engine-client.js";
 import type { McpSafetyConfig } from "./config.js";
 import type { LoadRunParams } from "./safety.js";
 import { checkAllowlist, checkLoadCaps, defaultDurationUnderCap } from "./safety.js";
@@ -143,7 +143,24 @@ function engineErrorResult(err: unknown): ToolResult {
 		return errorResult(`Engine error (${err.status}): ${err.body || err.message}`);
 	}
 	const msg = err instanceof Error ? err.message : String(err);
-	if (/ECONNREFUSED|fetch failed|abort/i.test(msg)) {
+	// An abort means the engine was reachable and working - the opposite of the
+	// "not running, retry" advice below. Whatever was in flight may well have
+	// completed engine-side, so say so instead of inviting a second send.
+	if (err instanceof EngineTimeoutError) {
+		return errorResult(
+			`The engine did not answer within this client's ${Math.round(err.timeoutMs / 1000)}s budget. ` +
+				`It may still have completed the call - check run history (list_runs) before retrying. ` +
+				`For a target that is legitimately this slow, raise the engine's "defaultTimeout" ` +
+				`with update_engine_config.`
+		);
+	}
+	if (err instanceof Error && (err.name === "AbortError" || /abort/i.test(msg))) {
+		return errorResult(
+			`The call was cancelled before the engine answered. It may still have completed - ` +
+				`check run history (list_runs) before retrying. (${msg})`
+		);
+	}
+	if (/ECONNREFUSED|fetch failed/i.test(msg)) {
 		return errorResult(
 			`Could not reach the Vayu engine. Make sure the Vayu app is running, then retry. (${msg})`
 		);

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -130,12 +130,12 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `get_engine_config`    | read     | `GET /config`                                | -                          |
 | `get_live_metrics`     | read     | SSE snapshot of last N ticks                 | -                          |
 | `compare_runs`         | read     | 2× `GET /runs/:id/report` → diff (structured)| -                          |
-| `run_request`          | execute  | `POST /execute`                              | allowlist                  |
-| `run_collection_smoke` | execute  | `GET /requests?…` + `POST /execute` (×N)     | allowlist per host         |
+| `run_request`          | execute  | `POST /compose` + `POST /execute`            | allowlist                  |
+| `run_collection_smoke` | execute  | `GET /requests?…` + `POST /compose` + `POST /execute` (×N) | allowlist per host |
 | `create_request`       | write    | `POST /requests`                             | write toggle               |
-| `update_environment`   | write    | `GET`+`PUT /environments/:id` (fetch-merge)  | write toggle               |
+| `update_environment`   | write    | `GET /environments` (scan) + `PUT /environments/:id` (fetch-merge) | write toggle |
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
-| `start_load_run`       | load     | `POST /runs` (+ `GET /requests/:id` with `requestId`) | allowlist + caps + confirm |
+| `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
 
 Notes:
@@ -167,6 +167,15 @@ Notes:
   did not resolve and allow-all is off) are skipped, not sent.
 - **Cancellation:** each tool call's `AbortSignal` is threaded into the engine
   `fetch`, so a client cancelling an in-flight call actually aborts it.
+- **Timeouts:** engine-local calls are bounded at 35s, but `POST /execute` waits
+  on a third-party server, so its budget is derived from the engine's own
+  `defaultTimeout` setting (read per call from `GET /config`, up to its 300s
+  ceiling) plus 10s of grace - the same rule the renderer uses for its proxied
+  calls. That way the engine's own `TIMEOUT` error, with its error code and its
+  run row, arrives before this client gives up. If the budget does expire, the
+  tool says the call may still have completed and points at `list_runs`; it is
+  never reported as an unreachable engine, because a retry could re-send a
+  request that already went out.
 
 ### Request composition
 


### PR DESCRIPTION
## Description

**Plan.** Root cause: `EngineClient` armed one flat `DEFAULT_TIMEOUT_MS = 35_000` for every call, including `POST /execute` - the only call that waits on a third-party server. The engine bounds that call by the payload's `timeout` or, absent one, the user-configurable `defaultTimeout` (`resolve_request_timeout_ms`, `execution.cpp:44`), which the config schema lets a user or an agent raise to 300s. When it exceeds 35s the client aborted a request the engine went on to complete - traffic sent, run row written - and `engineErrorResult` matched `/abort/i` alongside `ECONNREFUSED` and answered "engine not running, retry", talking the agent into re-firing a request that already ran. Approach: derive the budget for `/execute` the way the renderer already does for its proxied calls (`proxiedRequestTimeoutMs` in `app/src/services/api.ts`) - `max(payload timeout, configured defaultTimeout) + 10s grace`, falling back to the 300s ceiling when the config read fails - and give an expired budget its own error type carrying the number, so the message can name it. **Alternative rejected:** deriving the budget from the composed payload's `timeout` alone. It is a no-op in exactly this scenario - MCP-composed payloads carry no `timeout` (`payload_from_stored` emits none, `readRequestOverrides` reads none), so the config read is what does the work.

Anchors re-verified against master `e50d540` (the issue cites `10c8193`): the flat constant, the `/abort/i` branch and both dead methods were all still present as described. Blast radius traced: `EngineClient` has two construction sites (`index.ts:35`, `cli.ts:28`), neither passing `timeoutMs`, so both pick up the new behavior; `executeRequest` has two callers (`run_request`, `run_collection_smoke`) and both go through `engineErrorResult`; `getRequest`/`getGlobals` had zero production callers - type-check now proves it.

Changes:

- **`engine-client.ts`** - `request()` takes a per-call budget and distinguishes *its* timer expiring from the caller's cancellation, throwing the new `EngineTimeoutError` (carrying `timeoutMs`) only for the former. `executeRequest` awaits `proxiedTimeoutMs()`, which probes `GET /config` on a short 2s budget and falls back to the ceiling. `/compose` and `POST /runs` deliberately stay on the flat budget - both return once the engine has done local work. `getRequest` and `getGlobals` deleted.
- **`tools.ts`** - `engineErrorResult` answers a timeout with "may still have completed - check run history (`list_runs`) before retrying", plus how to raise `defaultTimeout`; a cancellation gets its own message; only `ECONNREFUSED`/`fetch failed` still reads as an unreachable engine.
- **`tools.test.ts`** - the two unused `vi.fn()` stubs removed.
- **`docs/engine/mcp.md`** - the `run_request`, `run_collection_smoke`, `start_load_run` and `update_environment` rows now name `POST /compose` and the real environment routes, and a new bullet documents the timeout rule.

Deliberate deviation from the issue spec: none.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

New tests, driven on fake timers so the assertion is *which budget was armed*, never wall-clock:

- `engine-client.test.ts` (+5): a `/execute` with `defaultTimeout: 120000` is still in flight at 129s and fails at 130s with `EngineTimeoutError { timeoutMs: 130_000 }`; an unreadable config falls back to 310s; a payload `timeout` of 200s raises the budget to 210s; `listCollections` stays on 35s and probes no config; a caller's cancellation is *not* an `EngineTimeoutError`. (One mock fidelity fix: the fake fetch now rejects at once for an already-aborted signal, as real fetch does.)
- `tools.test.ts` (+3): a timeout names the budget and points at `list_runs` without saying "Make sure the Vayu app is running"; a cancellation likewise; a real `ECONNREFUSED` still says it.

Mutation-checked, each fix reverted in turn:

| Reverted | Fails |
|---|---|
| `executeRequest` back to the flat budget | the 3 budget-derivation tests |
| `engineErrorResult` back to the `/abort/i` branch | the timeout and cancellation tests |

All green on this branch:

- `cd app && pnpm test` - **292 files, 2648 tests passed** (2640 before this change)
- `cd app && pnpm type-check` - clean, which is what proves the two deleted methods had no callers
- `cd app && pnpm lint` - clean (zero warnings)
- `cd app && pnpm format:check` - clean

No engine change, so the C++ build and `ctest` were not run - nothing in this diff can change their colour. `mkdocs build --strict` could not be run (mkdocs is not installed here); the docs edit adds no links, headings or nav entries - four table cells and one bullet inside an existing section. No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #318

Sub-issue of #321 (Wave M-robustness). Coordination note for #319, which lands in the same files: it touches `engine-client.ts` at `getLiveMetricsSnapshot`'s `slice` and `tools.ts` at the individual handlers, both disjoint from the `request()`/`engineErrorResult` regions changed here. #319's `run_collection_smoke` serial-runtime caveat should now quote the derived budget rather than "35s per request".

---
_Generated by [Claude Code](https://claude.ai/code/session_015wToqaFpirxLjgLxga8tjN)_