### PR TITLE
fix(load-test): raise the engine's maxInFlight bound to 1,000,000 and pin UI/engine parity

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -7,9 +7,16 @@
 
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { dispatchTool, toolCatalog, TOOLS, type ToolContext } from "./tools.js";
+import {
+	dispatchTool,
+	MAX_IN_FLIGHT_BOUND,
+	toolCatalog,
+	TOOLS,
+	type ToolContext,
+} from "./tools.js";
 import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
 import { EngineRequestError, EngineTimeoutError, type EngineClient } from "./engine-client.js";
+import { LOAD_TEST_LIMITS } from "@/constants/load-test";
 
 /**
  * Default `composeRequest` fake: the engine's identity composition for an
@@ -1063,6 +1070,38 @@ describe("dispatchTool", () => {
 				parseArgs("start_load_run", { url: "https://api.example.com", [field]: 2.5 })
 			).toThrow();
 		}
+	});
+
+	test("the schema's maxInFlight ceiling is the engine's, inclusive", () => {
+		// The bound exists so an out-of-range value is named here rather than
+		// returned as an opaque 400 from POST /runs - which means it has to be
+		// the *same* bound, not a stricter guess. 500,000 is what the engine's
+		// own default formula reaches at 50k RPS, so refusing it would refuse a
+		// run the engine starts on its own.
+		for (const value of [1, 500_000, MAX_IN_FLIGHT_BOUND]) {
+			expect(() =>
+				parseArgs("start_load_run", {
+					url: "https://api.example.com",
+					maxInFlight: value,
+				})
+			).not.toThrow();
+		}
+		expect(() =>
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				maxInFlight: MAX_IN_FLIGHT_BOUND + 1,
+			})
+		).toThrow();
+	});
+
+	test("the maxInFlight ceiling is the one the load dialog advertises", () => {
+		// Third copy of the same number: engine header, renderer constant, this
+		// schema. `electron/` production code may not import `src/`, so the copy
+		// stays - and this is the half of the chain that keeps it honest, the
+		// renderer-to-engine half living in
+		// `src/constants/load-test.engine-parity.test.ts`. An agent and a human
+		// composing the same run must be accepted or refused identically.
+		expect(MAX_IN_FLIGHT_BOUND).toBe(LOAD_TEST_LIMITS.MAX_IN_FLIGHT.MAX);
 	});
 
 	test("start_load_run sends an explicit duration when the cap is under the engine default", async () => {

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -401,6 +401,20 @@ async function composeLoadRunRequest(
  */
 const DEFAULT_LOAD_MODE = "constant_concurrency";
 
+/**
+ * The engine's `maxInFlight` guard (`run_config::MAX_IN_FLIGHT` in
+ * `engine/include/vayu/core/constants.hpp`), mirrored here so the schema
+ * rejects an out-of-range value by name instead of surfacing a 400.
+ *
+ * It is a literal rather than an import because production code in `electron/`
+ * may not reach into `src/` - `tsconfig.node.json` withholds the `@/*` mapping
+ * on purpose, so the import would not type-check. The copy is kept honest from
+ * the test side, the way the dynamic-variable table already is: `tools.test.ts`
+ * ties it to the renderer's `LOAD_TEST_LIMITS`, and
+ * `src/constants/load-test.engine-parity.test.ts` ties that to this header.
+ */
+export const MAX_IN_FLIGHT_BOUND = 1_000_000;
+
 // --- Shared input schema fragments ------------------------------------------
 
 /** Optional resolution scope shared by the ad-hoc execute/load tools. */
@@ -1182,12 +1196,17 @@ export const TOOLS: McpTool[] = [
 			targetRps: z.number().optional().describe("Target RPS (constant_rps)."),
 			// A pending-request ceiling read as a `size_t`, so `-1` - the natural
 			// "unlimited" spelling - removes the ceiling instead of tightening it.
+			// The upper bound is the engine's, so a value this schema accepts is
+			// one `POST /runs` accepts.
 			maxInFlight: z
 				.number()
 				.int()
 				.positive()
+				.max(MAX_IN_FLIGHT_BOUND)
 				.optional()
-				.describe("In-flight cap (constant_rps only)."),
+				.describe(
+					`In-flight cap (constant_rps only), 1-${MAX_IN_FLIGHT_BOUND}. Default max(targetRps * 10, 1000).`
+				),
 			requestId: z
 				.string()
 				.optional()

--- a/app/src/constants/load-test.engine-parity.test.ts
+++ b/app/src/constants/load-test.engine-parity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The dialog promises a range; the engine enforces one. When they disagree the
+ * user finds out at submit time, as a 400 with no field on it.
+ *
+ * `load-test.ts` states the invariant - every advertised range sits inside the
+ * engine's guard - but nothing checked it, and `maxInFlight` drifted the moment
+ * the engine grew an explicit bound (#324): the dialog offered up to 1,000,000
+ * against an engine ceiling of 10,000, and `NumberField` passes min/max through
+ * as HTML attributes without clamping, so typing 20,000 into a field labelled
+ * "up to 1,000,000" was a rejected run.
+ *
+ * This reads the engine's own header rather than a hand-copied number, which is
+ * what makes it a drift guard instead of a restatement: move either side and it
+ * fails.
+ *
+ * The MCP schema holds a third copy of the `maxInFlight` bound and cannot be
+ * checked from here - `src/` may not import from `electron/`, and the type-check
+ * enforces it. That link is pinned from the other end, in
+ * `electron/mcp/tools.test.ts`, which may import `@/constants` and so ties the
+ * schema to the ceiling this file ties to the engine.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { LOAD_TEST_CEILING_BOUNDS, LOAD_TEST_LIMITS } from "./load-test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const constantsHpp = readFileSync(
+	join(repoRoot, "engine", "include", "vayu", "core", "constants.hpp"),
+	"utf8"
+);
+const executionCpp = readFileSync(
+	join(repoRoot, "engine", "src", "http", "routes", "execution.cpp"),
+	"utf8"
+);
+
+/**
+ * One `constexpr <type> NAME = <expr>;` from the engine header, evaluated.
+ *
+ * The expression grammar is deliberately tiny - a product of integer literals
+ * and other constants in this header, with `static_cast<>` and namespace
+ * qualifiers stripped - because that is all the run-config guards use, and
+ * anything richer should fail loudly here rather than be guessed at. It has to
+ * evaluate rather than pattern-match a literal: `MAX_CONCURRENCY` is written as
+ * `10 * event_loop::MAX_CONCURRENT`, and a guard that could not read it would
+ * simply not guard the field it names.
+ */
+function engineConstant(name: string, seen: string[] = []): number {
+	expect(seen, `cyclic definition reaching ${name} in constants.hpp`).not.toContain(name);
+	const match = constantsHpp.match(
+		new RegExp(String.raw`constexpr\s+\w+\s+${name}\s*=\s*([^;]+);`)
+	);
+	expect(match, `${name} not found as a constexpr in constants.hpp`).not.toBeNull();
+	const factors = match![1]
+		.replace(/static_cast<[^>]*>/g, "")
+		.split("*")
+		.map((factor) => factor.replace(/[()\s]/g, ""));
+	return factors.reduce((product, factor) => {
+		if (/^\d[\d']*$/.test(factor)) return product * Number(factor.replace(/'/g, ""));
+		const referenced = factor.split("::").pop() ?? "";
+		expect(referenced, `unsupported expression "${match![1].trim()}" for ${name}`).toMatch(
+			/^[A-Za-z_]\w*$/
+		);
+		return product * engineConstant(referenced, [...seen, name]);
+	}, 1);
+}
+
+describe("load-test limits parity with the engine", () => {
+	it("read non-empty engine sources", () => {
+		// CLAUDE.md's documented failure mode: a source-scanning guard that reads
+		// "" passes every assertion below without checking anything.
+		expect(constantsHpp.length).toBeGreaterThan(0);
+		expect(executionCpp.length).toBeGreaterThan(0);
+	});
+
+	it("advertises exactly the engine's maxInFlight ceiling", () => {
+		// Exact, not "inside": maxInFlight is a backpressure ceiling, and the
+		// engine's own default is max(targetRps * 10, 1000) - 500,000 at the
+		// dialog's 50k RPS maximum - so a UI ceiling below the engine's would
+		// refuse ceilings the engine picks for itself when the field is omitted.
+		expect(LOAD_TEST_LIMITS.MAX_IN_FLIGHT.MAX).toBe(engineConstant("MAX_IN_FLIGHT"));
+	});
+
+	it("uses that constant as the route's maxInFlight bound", () => {
+		// The constant existing is not the same as the validator reading it; a
+		// bound left on MAX_CONCURRENCY is the exact defect this issue is about.
+		expect(executionCpp).toMatch(/\{\s*"maxInFlight",\s*1,\s*limits::MAX_IN_FLIGHT\b/);
+	});
+
+	it("keeps the backpressure ceiling distinct from the connection guard", () => {
+		// They bound different things - an eager curl-handle pre-allocation
+		// versus a counter of outstanding requests - so collapsing them back
+		// into one number is a regression even if both sides move together.
+		expect(engineConstant("MAX_IN_FLIGHT")).toBeGreaterThan(engineConstant("MAX_CONCURRENCY"));
+	});
+
+	it("lets a user's connection ceiling reach the engine's guard and no further", () => {
+		// `concurrency` is the one dialog ceiling the user can move, and
+		// LOAD_TEST_CEILING_BOUNDS.MAX is documented as the engine's own guard.
+		expect(LOAD_TEST_CEILING_BOUNDS.concurrency.MAX).toBe(engineConstant("MAX_CONCURRENCY"));
+	});
+
+	it("keeps every shipped connection range inside that guard", () => {
+		const guard = engineConstant("MAX_CONCURRENCY");
+		for (const key of ["CONCURRENCY", "START_CONCURRENCY"] as const) {
+			expect(LOAD_TEST_LIMITS[key].MAX).toBeLessThanOrEqual(guard);
+		}
+	});
+});

--- a/app/src/constants/load-test.ts
+++ b/app/src/constants/load-test.ts
@@ -12,13 +12,21 @@
  *
  *   - **`LOAD_TEST_LIMITS`** - the range each control in the load dialog
  *     offers. The ceilings are *this app's* policy, not the engine's, and four
- *     of them are user-adjustable (Settings -> Load testing). They sit well
- *     inside what the engine accepts, which is deliberate: the engine's own
- *     bounds are crash guards, so hitting one should be impossible from the UI
- *     rather than merely unlikely.
+ *     of them are user-adjustable (Settings -> Load testing). They sit inside
+ *     what the engine accepts, which is deliberate: the engine's own bounds are
+ *     crash guards, so hitting one should be impossible from the UI rather than
+ *     merely unlikely. `MAX_IN_FLIGHT` is the one that sits *on* the engine's
+ *     bound rather than under it - a backpressure ceiling is not a crash guard,
+ *     and the engine's own default reaches 500,000 at the RPS maximum offered
+ *     here, so a lower dialog ceiling would hide ceilings the engine picks for
+ *     itself.
  *   - **`LOAD_TEST_CEILING_BOUNDS`** - how far the user may move those
  *     ceilings. The upper end of each is the engine's guard, so no Settings
  *     value can produce a request the engine rejects.
+ *
+ * Both invariants are pinned against the engine's own header by
+ * `load-test.engine-parity.test.ts`, because stating them here is what was
+ * already being done when `maxInFlight` drifted.
  */
 
 export const LOAD_TEST_DEFAULTS = {

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1406,7 +1406,7 @@ default, and whose message names the offending field and why the bound exists:
 | `max_exemplar_results` | `0`-`100000` | Each retained exemplar holds a captured exchange. `0` means unlimited. |
 | `concurrency` | `1`-`10000` | Connections are eagerly pre-allocated per worker before any traffic flows, so `-1` (a natural "unlimited" guess) allocated until malloc failed. |
 | `startConcurrency` | `1`-`10000` | The ramp is seeded with this many in-flight requests before the first duration check, and it is read as a `size_t`, so a negative start is ~1.8e19 of them. |
-| `maxInFlight` | `1`-`10000` | It is a pending-request ceiling read as a `size_t`, so `-1` or `0` removes the backpressure the field exists to provide instead of tightening it, and an open-loop run against a slow target then accumulates in-flight requests for its whole duration. |
+| `maxInFlight` | `1`-`1000000` | It is a pending-request ceiling read as a `size_t`, so `-1` or `0` removes the backpressure the field exists to provide instead of tightening it, and an open-loop run against a slow target then accumulates in-flight requests for its whole duration. The ceiling is **not** the `concurrency` guard: that one bounds an eager per-worker connection pre-allocation, while this bounds a counter that pre-allocates nothing, and the engine's own default - `max(targetRps × 10, 1000)` - reaches 500,000 at the load dialog's 50k RPS maximum, so a lower bound would refuse ceilings the engine picks for itself. |
 | `timeout` | `1`-`86400000` ms | A transfer that never times out never completes, leaving the run stuck `running` and unstoppable. |
 | `duration` | string, positive, optional unit (`ms`\|`s`\|`m`\|`h`) | A JSON *number* threw out of the run-context constructor *after* the row was written, stranding it `pending` forever behind an opaque `500`. |
 
@@ -1485,8 +1485,12 @@ regardless of how fast responses return.
 **`maxInFlight`.** A hard cap on concurrent in-flight requests. It applies
 **only to `constant_rps`** (the open-loop rate mode), where it bounds how many
 requests may be outstanding before the engine drops new ones; default
-≈ `max(targetRps × 10, 1000)`. For the closed-loop modes the `concurrency`
-target *is* the in-flight bound, so `maxInFlight` is ignored there.
+≈ `max(targetRps × 10, 1000)`, accepted range `1`-`1000000`. That range holds
+the default formula across the whole advertised RPS span (50k RPS → 500,000),
+which is why it is not the `concurrency` guard - a ceiling of 10,000 would
+reject explicitly what the engine already does implicitly. For the closed-loop
+modes the `concurrency` target *is* the in-flight bound, so `maxInFlight` is
+ignored there.
 
 **Durations.** `duration` and `rampUpDuration` take a number with an optional
 unit: **`ms`, `s`, `m`, `h`**, matched as a whole suffix (`"500ms"` is half a

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -468,7 +468,9 @@ configurable in **Settings → MCP** and persisted.
   an in-flight ceiling (see the accepted ranges under
   [POST /runs](api-reference.md#post-runs)). `maxInFlight` is the one that bounds
   work *downward*, so there is no separate cap setting for it - the enormous
-  value is the one that removes the backpressure the caller asked for.
+  value is the one that removes the backpressure the caller asked for; its
+  schema additionally carries the engine's own ceiling of `1000000`, so a value
+  this tool accepts is one `POST /runs` accepts.
   `duration` / `rampUpDuration` are also rejected when they are not durations at
   all (`ms`/`s`/`m`/`h`, or a bare number of seconds - the same grammar the
   engine parses), since the engine now fails such a run rather than quietly

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -112,6 +112,16 @@ namespace run_config {
 /// allocates until malloc fails. Ten times the per-worker ceiling leaves every
 /// realistic run untouched while keeping the pre-allocation finite.
 constexpr int64_t MAX_CONCURRENCY = 10 * static_cast<int64_t> (event_loop::MAX_CONCURRENT);
+/// Upper bound on `maxInFlight`, the open-loop backpressure ceiling. It is
+/// deliberately **not** `MAX_CONCURRENCY`: that bounds an eager curl-handle
+/// pre-allocation, while this bounds a counter of outstanding requests that
+/// allocates nothing up front. Reusing the connection guard here refused
+/// configurations the engine already runs implicitly - the default ceiling is
+/// `max(targetRps * 10, 1000)` (`load_strategy.cpp`), which reaches 500,000 at
+/// the load dialog's 50k RPS maximum. A million covers the default formula
+/// across the whole advertised RPS range and still keeps a negative value -
+/// ~1.8e19 once cast to `size_t` - from removing the backpressure entirely.
+constexpr int64_t MAX_IN_FLIGHT = 1000000;
 /// Upper bound on `max_response_samples` (each retained sample holds a full
 /// response body, and the vector is reserved up front).
 constexpr int64_t MAX_RESPONSE_SAMPLES = 1000000;

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -591,7 +591,7 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         "A ramp is seeded with this many in-flight requests before the first "
         "duration check, and it is read as a size_t, so a negative start is "
         "~1.8e19 of them." },
-        { "maxInFlight", 1, limits::MAX_CONCURRENCY,
+        { "maxInFlight", 1, limits::MAX_IN_FLIGHT,
         "It is a pending-request ceiling read as a size_t, so a negative value "
         "is ~1.8e19 - it removes the backpressure the field exists to provide "
         "rather than tightening it." },

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -186,10 +186,27 @@ TEST (RunConfigValidation, MaxInFlightBoundsAreInclusive) {
     auto config           = valid_config ();
     config["maxInFlight"] = 1;
     EXPECT_FALSE (validate_run_config (config).has_value ());
-    config["maxInFlight"] = vayu::core::constants::run_config::MAX_CONCURRENCY;
+    config["maxInFlight"] = vayu::core::constants::run_config::MAX_IN_FLIGHT;
     EXPECT_FALSE (validate_run_config (config).has_value ());
-    config["maxInFlight"] = vayu::core::constants::run_config::MAX_CONCURRENCY + 1;
+    config["maxInFlight"] = vayu::core::constants::run_config::MAX_IN_FLIGHT + 1;
     expect_rejected (config, "maxInFlight");
+}
+
+// The backpressure ceiling is not the connection guard, and the two are not
+// interchangeable: `MAX_CONCURRENCY` bounds an eager per-worker curl-handle
+// pre-allocation, `maxInFlight` bounds a counter that pre-allocates nothing.
+// Borrowing the connection guard for it refused, with a 400, exactly the
+// ceilings the engine's own default formula reaches on its own.
+TEST (RunConfigValidation, MaxInFlightAcceptsWhatTheDefaultFormulaReaches) {
+    // `max(targetRps * 10, 1000)` (load_strategy.cpp) at the load dialog's
+    // 50k RPS maximum. Omitted, this ceiling is used without complaint; asking
+    // for it explicitly must not be a 400.
+    auto config           = valid_config ();
+    config["maxInFlight"] = 500000;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+    EXPECT_GT (config["maxInFlight"].get<int64_t> (),
+    vayu::core::constants::run_config::MAX_CONCURRENCY)
+    << "the case no longer covers the asymmetry it was written for";
 }
 
 // --- 3. Timeout: <= 0 left transfers that never expire ---------------------


### PR DESCRIPTION
## Description

**Root cause.** `validate_run_config` borrowed `run_config::MAX_CONCURRENCY` (10,000) for `maxInFlight`, but the two limits bound different things: the connection guard bounds an *eager* per-worker curl-handle pre-allocation, while `maxInFlight` bounds a counter of outstanding requests that pre-allocates nothing. The engine's own default ceiling is `max(targetRps * 10, 1000)` (`load_strategy.cpp:341`), which reaches 500,000 at the load dialog's 50k RPS maximum - so requesting explicitly what the engine picks implicitly was a 400, and the renderer's advertised `MAX_IN_FLIGHT.MAX` of 1,000,000 (with `NumberField` passing min/max through as HTML attributes, no clamping) promised a range the engine refused. **Approach:** a dedicated named constant `run_config::MAX_IN_FLIGHT = 1000000` beside `MAX_CONCURRENCY`, read by the field table, plus the same ceiling on the MCP schema and a test that reads the engine header so the three copies cannot drift apart again. **Rejected alternative:** lowering the UI ceiling to 10,000 (option A on the issue) - it would have hidden ceilings the engine already selects for itself when the field is omitted, making the explicit and implicit paths disagree in the opposite direction.

Verified at `f703eaa`: the mismatch was real and user-reachable. One anchor in the issue had drifted - the dialog is `app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx`, not `modules/load-test/...`. It needed no change either way (it reads the constant).

**Blast radius traced.** `maxInFlight` has four consumers: the validator (`execution.cpp:594`), the strategy that reads it (`load_strategy.cpp:341`), the dialog (via `limits.MAX_IN_FLIGHT`), and the MCP schema. `MAX_CONCURRENCY` keeps every other use - `concurrency` and `startConcurrency` still bound by it, unchanged and untouched.

**One deviation from the issue spec, with reason.** The issue suggested `app/src/constants/load-test.ts` as a shared source for the MCP bound. It cannot be: `tsconfig.node.json` deliberately withholds the `@/*` mapping so production code in `electron/` cannot reach into `src/`, and the import fails type-check (confirmed - the first draft did exactly this). The bound stays a named exported literal in `tools.ts`, and the chain is pinned from the test side instead, the way the dynamic-variable table already is: `tools.test.ts` (which *may* use `@/*`) ties the schema to the renderer's constant, and the new parity test ties that constant to the engine header.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **888/888 passed**.
  - `MaxInFlightBoundsAreInclusive` now runs against `MAX_IN_FLIGHT`: accepted at 1 and 1,000,000, rejected at 1,000,001 (0 and -1 keep their own cases).
  - New `MaxInFlightAcceptsWhatTheDefaultFormulaReaches` pins 500,000 - what the default formula reaches at 50k RPS - as accepted, and asserts it is above `MAX_CONCURRENCY` so the case cannot quietly stop covering the asymmetry it was written for.
- `pnpm test` - **2700/2700 passed, 295 files**; `pnpm type-check`, `pnpm lint`, `prettier --check` on touched files all clean.
  - New `src/constants/load-test.engine-parity.test.ts` reads `constants.hpp` and `execution.cpp` directly: the advertised ceiling equals the engine constant, the route actually reads that constant, the backpressure ceiling stays above the connection guard, and the connection ranges stay inside it. It asserts the sources were non-empty first, per CLAUDE.md.
  - **Mutation-checked**: reverting both engine edits (constant back to 10,000, table back to `MAX_CONCURRENCY`) fails 4 of its assertions. The constant-reader evaluates expressions rather than matching literals, because `MAX_CONCURRENCY` is written as `10 * event_loop::MAX_CONCURRENT` and a guard that could not read it would not guard the field it names - this was caught by the test failing on first run.
  - `tools.test.ts` adds inclusive-ceiling cases (1 / 500,000 / 1,000,000 accepted, 1,000,001 rejected) and the MCP-to-renderer parity assertion.
- `mkdocs build --strict` was not run - mkdocs is not installed in this environment. The docs edits are prose inside existing tables and paragraphs; no page, heading, or link was added or moved.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the `maxInFlight` range becomes `1`-`1000000`, with the backpressure-ceiling rationale and the note that the default formula sits inside it) and `docs/engine/mcp.md` (the schema now carries the engine's ceiling). `load-test.ts`'s own doc comment is corrected - `MAX_IN_FLIGHT` sits *on* the engine's bound rather than under it, and that is deliberate.

## Related Issues
Closes #338

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ke7NKKQ1RZWb4k96VCjw6)_