### PR TITLE
fix(engine): build the raw-request view from the wire, not the composed headers

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1243,6 +1243,17 @@ A client splitting a folded `Set-Cookie` must split on a comma followed by
 for the response headers stored on a design run's `trace_data.response` and on
 captured load-run samples, which come off the same parse.
 
+**`rawRequest` is the header block libcurl actually sent**, captured from the
+transfer's last outbound header frame and followed by the request body. So it
+carries what libcurl added on its own - the `Cookie` line the
+[cookie jar](architecture.md#cookie-jar) matched, `Accept`, `Content-Length`,
+and an h2 request rendered in HTTP/1 form - none of which appear in
+`requestHeaders`, which stays the *composed* headers. Values are not redacted:
+this field exists to say exactly what went out. On a followed redirect it is the
+final hop, matching the response beside it. A transfer that failed before
+sending anything (DNS failure, connection refused) has no frame to read, and
+falls back to a request synthesized from what was composed.
+
 **`consoleLogs` entries carry their own source and level.** `source` is which of
 the request's two scripts wrote the line (`"pre"` for the pre-request script,
 `"test"` for the post-request one) and `level` is the `console.*` method that was

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -210,6 +210,13 @@ makes a session survive from one design-mode request to the next.
   actually share, and a load run repeats a single request anyway.
 - **Threading:** one mutex around the scope map; every accessor copies out, so
   no reference into the storage escapes to a caller.
+- **Shown as sent.** Because libcurl attaches the matching cookies itself, the
+  composed header map never sees them - so the raw-request view is built from
+  the transfer's last `CURLINFO_HEADER_OUT` frame (`client.cpp`) rather than
+  from `request_headers`, and shows the `Cookie` line the wire carried, value
+  plain. The verbose transfer log keeps its redaction (`debug_redact.hpp`): a
+  log gets exported and shared, the raw view is read on the machine whose
+  Settings already display the same value.
 
 `pm.sendRequest` shares the jar of the execute it runs inside, so a pre-request
 script can log in and leave the session where the real request will find it.

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -45,9 +45,40 @@ namespace vayu::http {
 
 namespace {
 
+/**
+ * @brief What a transfer's debug stream leaves behind for the caller.
+ *
+ * `verbose` gates the *logging* only - the outbound header frame is captured on
+ * every send, because the raw-request view is built from it (issue #339). Since
+ * the cookie jar, libcurl synthesizes headers we never composed (`Cookie`, from
+ * CURLOPT_COOKIELIST), so the composed header map no longer describes what went
+ * on the wire and only libcurl can say what did.
+ *
+ * The captured frame is deliberately **not** redacted. It backs the raw-request
+ * view, which exists to show exactly what was sent and whose values the user can
+ * already read in Settings; the verbose log below keeps its redaction because
+ * logs get exported and shared. Two surfaces, two audiences, two policies.
+ */
+struct TransferDebug {
+    bool verbose = false;
+    /// The last CURLINFO_HEADER_OUT frame, verbatim. Last, not first, so a
+    /// followed redirect reports the request that produced the response the
+    /// caller is looking at.
+    std::string last_header_out;
+};
+
 int debug_callback (CURL* handle, curl_infotype type, char* data, size_t size, void* userptr) {
     (void)handle;
-    (void)userptr;
+    auto* debug = static_cast<TransferDebug*> (userptr);
+
+    if (debug != nullptr && type == CURLINFO_HEADER_OUT) {
+        debug->last_header_out.assign (data, size);
+    }
+    // Nothing else to do when the caller only wanted the capture: the frames
+    // below are logging, and DATA_OUT can be a whole request body.
+    if (debug == nullptr || !debug->verbose) {
+        return 0;
+    }
 
     std::string text (data, size);
     // Remove trailing newlines
@@ -182,6 +213,108 @@ void capture_jar_cookies (CURL* curl, const ClientConfig& config) {
 }
 
 /**
+ * @brief The raw-request view, built from the header block libcurl actually sent.
+ *
+ * @p header_frame is a whole CURLINFO_HEADER_OUT frame - request line included,
+ * terminated by its own blank line - so the body is all that has to be added.
+ * Being the wire's own bytes, it carries what libcurl added on our behalf
+ * (`Cookie` from the jar, `Accept`, `Content-Length`, and the h2 pseudo-headers
+ * rendered in HTTP/1 form) rather than what we composed and hoped matched.
+ *
+ * The terminator is re-normalized rather than trusted: whether a frame ends in
+ * one CRLF or two is libcurl's business, and the body must not run into the
+ * last header line.
+ */
+std::string raw_request_from_wire (std::string header_frame, const std::string& body) {
+    while (!header_frame.empty () &&
+    (header_frame.back () == '\r' || header_frame.back () == '\n')) {
+        header_frame.pop_back ();
+    }
+    header_frame += "\r\n\r\n";
+    header_frame += body;
+    return header_frame;
+}
+
+/**
+ * @brief The raw-request view when there is no wire to read it off.
+ *
+ * The fallback for a transfer that failed before libcurl sent anything - DNS
+ * failure, connection refused, a timeout during connect. Synthesized from the
+ * composed request, which is what this view was built from throughout before
+ * #339, so an unreachable host still shows the request that was attempted.
+ */
+std::string synthesize_raw_request (const Request& request, const Response& response) {
+    std::stringstream raw_req;
+
+    // Parse URL to extract host and path
+    std::string host;
+    std::string path = "/";
+    std::string url  = request.url;
+
+    // Remove protocol prefix
+    size_t proto_end = url.find ("://");
+    if (proto_end != std::string::npos) {
+        url = url.substr (proto_end + 3);
+    }
+
+    // Split host and path
+    size_t path_start = url.find ('/');
+    if (path_start != std::string::npos) {
+        host = url.substr (0, path_start);
+        path = url.substr (path_start);
+    } else {
+        host = url;
+        // Check for query string without path
+        size_t query_start = host.find ('?');
+        if (query_start != std::string::npos) {
+            path = "/" + host.substr (query_start);
+            host = host.substr (0, query_start);
+        }
+    }
+
+    // Request line: METHOD /path <version>. Normally the negotiated version.
+    // When nothing was negotiated (connection refused, DNS failure) this line
+    // still has to read as syntactically valid HTTP, so it cannot be blank the
+    // way response.http_version is - but it falls back to what was *requested*
+    // rather than a flat HTTP/1.1. Printing HTTP/1.1 after the user asked for
+    // http2 and never reached a server would contradict both their intent and
+    // the outcome, which is the kind of confident wrong answer this whole task
+    // exists to remove. The fallback never reaches response.http_version.
+    std::string display_version = response.http_version;
+    if (display_version.empty ()) {
+        display_version =
+        request.http_version == HttpVersion::Http2 ? "HTTP/2" : "HTTP/1.1";
+    }
+    raw_req << to_string (request.method) << " " << path << " " << display_version << "\r\n";
+
+    // Host header (required for HTTP/1.1)
+    raw_req << "Host: " << host << "\r\n";
+
+    // Add all request headers
+    for (const auto& [key, value] : response.request_headers) {
+        // Skip if it's a Host header (we already added it)
+        if (key == "Host" || key == "host")
+            continue;
+        raw_req << key << ": " << value << "\r\n";
+    }
+
+    // Add Content-Length for body
+    if (!request.body.content.empty ()) {
+        raw_req << "Content-Length: " << request.body.content.size () << "\r\n";
+    }
+
+    // End of headers
+    raw_req << "\r\n";
+
+    // Body
+    if (!request.body.content.empty ()) {
+        raw_req << request.body.content;
+    }
+
+    return raw_req.str ();
+}
+
+/**
  * @brief Convert curl error code to our ErrorCode
  */
 Error curl_to_error (CURLcode code, const char* error_buffer) {
@@ -300,9 +433,8 @@ Result<Response> Client::send (const Request& request) {
         curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers_list);
     }
 
-    // rawRequest's request line names the negotiated protocol, so it can only
-    // be built after the transfer completes - see below, just before the
-    // error-path early return.
+    // rawRequest is read off the wire, so it can only be built after the
+    // transfer completes - see below, just before the error-path early return.
 
     // Set callbacks
     curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, write_callback);
@@ -332,11 +464,15 @@ Result<Response> Client::send (const Request& request) {
     curl_easy_setopt (curl, CURLOPT_HTTP_VERSION,
     vayu::http::to_curl_http_version (request.http_version));
 
-    // Verbose output for debugging
-    if (impl_->config.verbose) {
-        curl_easy_setopt (curl, CURLOPT_VERBOSE, 1L);
-        curl_easy_setopt (curl, CURLOPT_DEBUGFUNCTION, debug_callback);
-    }
+    // The debug stream is always on, verbose or not: the raw-request view is
+    // built from the outbound header frame it carries, which is the only place
+    // libcurl's own additions (jar cookies above all) can be read from. The
+    // config flag decides whether the frames are also logged - see TransferDebug.
+    TransferDebug transfer_debug;
+    transfer_debug.verbose = impl_->config.verbose;
+    curl_easy_setopt (curl, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt (curl, CURLOPT_DEBUGFUNCTION, debug_callback);
+    curl_easy_setopt (curl, CURLOPT_DEBUGDATA, &transfer_debug);
 
     // Proxy
     if (!impl_->config.proxy_url.empty ()) {
@@ -407,77 +543,16 @@ Result<Response> Client::send (const Request& request) {
                      ""));
     }
 
-    // Build raw request string. Only buildable now: the request line names
-    // the negotiated protocol, which isn't known until after curl_easy_perform
-    // returns. Everything else here (host/path/headers/body) was already
-    // fixed before the transfer ran.
-    std::stringstream raw_req;
-
-    // Parse URL to extract host and path
-    std::string host;
-    std::string path = "/";
-    std::string url  = request.url;
-
-    // Remove protocol prefix
-    size_t proto_end = url.find ("://");
-    if (proto_end != std::string::npos) {
-        url = url.substr (proto_end + 3);
-    }
-
-    // Split host and path
-    size_t path_start = url.find ('/');
-    if (path_start != std::string::npos) {
-        host = url.substr (0, path_start);
-        path = url.substr (path_start);
-    } else {
-        host = url;
-        // Check for query string without path
-        size_t query_start = host.find ('?');
-        if (query_start != std::string::npos) {
-            path = "/" + host.substr (query_start);
-            host = host.substr (0, query_start);
-        }
-    }
-
-    // Request line: METHOD /path <version>. Normally the negotiated version.
-    // When nothing was negotiated (connection refused, DNS failure) this line
-    // still has to read as syntactically valid HTTP, so it cannot be blank the
-    // way response.http_version is - but it falls back to what was *requested*
-    // rather than a flat HTTP/1.1. Printing HTTP/1.1 after the user asked for
-    // http2 and never reached a server would contradict both their intent and
-    // the outcome, which is the kind of confident wrong answer this whole task
-    // exists to remove. The fallback never reaches response.http_version.
-    std::string display_version = response.http_version;
-    if (display_version.empty ()) {
-        display_version =
-        request.http_version == HttpVersion::Http2 ? "HTTP/2" : "HTTP/1.1";
-    }
-    raw_req << to_string (request.method) << " " << path << " " << display_version << "\r\n";
-
-    // Host header (required for HTTP/1.1)
-    raw_req << "Host: " << host << "\r\n";
-
-    // Add all request headers
-    for (const auto& [key, value] : response.request_headers) {
-        // Skip if it's a Host header (we already added it)
-        if (key == "Host" || key == "host")
-            continue;
-        raw_req << key << ": " << value << "\r\n";
-    }
-
-    // Add Content-Length for body
-    if (!request.body.content.empty ()) {
-        raw_req << "Content-Length: " << request.body.content.size () << "\r\n";
-    }
-
-    // End of headers
-    raw_req << "\r\n";
-
-    // Body
-    if (!request.body.content.empty ()) {
-        raw_req << request.body.content;
-    }
-    response.raw_request = raw_req.str ();
+    // The raw-request view: what libcurl put on the wire, read off the last
+    // outbound header frame it handed the debug callback. Built here rather
+    // than before the transfer because there is nothing to read until the
+    // transfer has run - and because only the wire knows about the headers
+    // libcurl adds itself, which since the cookie jar includes `Cookie`
+    // (issue #339). A transfer that never sent anything has no frame; it falls
+    // back to the composed request, which is all that ever existed for it.
+    response.raw_request = transfer_debug.last_header_out.empty () ?
+    synthesize_raw_request (request, response) :
+    raw_request_from_wire (transfer_debug.last_header_out, request.body.content);
 
     // Check for errors
     if (res != CURLE_OK) {

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -119,13 +119,20 @@ vayu::Request get_request (const std::string& url) {
     return request;
 }
 
-/// Send @p url in @p scope through @p jar and return the response body.
-std::string send_in_scope (CookieJar& jar, const std::string& scope, const std::string& url) {
+/// Send @p url in @p scope through @p jar and return the whole response - the
+/// raw-request view is as much a subject of these tests as the body is.
+vayu::Response
+response_in_scope (CookieJar& jar, const std::string& scope, const std::string& url) {
     ClientConfig config;
     config.cookie_jar   = &jar;
     config.cookie_scope = scope;
     Client client (config);
-    return client.send (get_request (url)).value ().body;
+    return client.send (get_request (url)).value ();
+}
+
+/// Send @p url in @p scope through @p jar and return the response body.
+std::string send_in_scope (CookieJar& jar, const std::string& scope, const std::string& url) {
+    return response_in_scope (jar, scope, url).body;
 }
 
 } // namespace
@@ -386,6 +393,31 @@ TEST (CookieJarTransfer, AServerExpiringACookieRemovesItFromTheJar) {
     // than merging into what was there is what makes this stick.
     send_in_scope (jar, "env_a", server.url ("/logout"));
     EXPECT_EQ (send_in_scope (jar, "env_a", server.url ("/echo")), "");
+}
+
+// The jar attaches cookies inside libcurl, so the raw-request view had no way
+// to know about them and said nothing was sent (issue #339) - silent
+// misinformation in the surface whose whole job is showing what went out. The
+// value is shown plainly: this view exists to be exact, and the same value is
+// already readable in Settings. The verbose log keeps its redaction.
+TEST (CookieJarTransfer, TheRawRequestViewShowsTheCookieThatWasSent) {
+    CookieServer server;
+    CookieJar jar;
+
+    send_in_scope (jar, "env_a", server.url ("/login"));
+    const auto sent = response_in_scope (jar, "env_a", server.url ("/echo"));
+
+    EXPECT_EQ (sent.body, "session=abc123") << "the cookie never reached the server";
+    EXPECT_NE (sent.raw_request.find ("Cookie: session=abc123"), std::string::npos)
+    << "the wire carried the cookie and the raw view denied it:\n"
+    << sent.raw_request;
+
+    // The other half of the claim: the view reports what was sent, so a scope
+    // with no matching cookie must not gain a Cookie line it never had.
+    const auto none = response_in_scope (jar, "env_b", server.url ("/echo"));
+    EXPECT_EQ (none.raw_request.find ("Cookie:"), std::string::npos)
+    << "a cookie appeared in a scope that sent none:\n"
+    << none.raw_request;
 }
 
 // ============================================================================

--- a/engine/tests/http_client_test.cpp
+++ b/engine/tests/http_client_test.cpp
@@ -192,6 +192,10 @@ TEST_F (HttpClientTest, UnreachableHostsRawRequestNamesWhatWasAskedFor) {
     // they can produce - reverting the fix would leave them all green. Here
     // nothing is negotiated at all, so the line can only come from what was
     // requested, and a stale literal would print HTTP/1.1 instead.
+    //
+    // Since #339 this also pins the synthesized fallback: a connection refused
+    // at port 1 never produces an outbound header frame, so this is the raw
+    // view built from the composed request rather than off the wire.
     Request request;
     request.method       = HttpMethod::GET;
     request.url          = "http://127.0.0.1:1/"; // port 1: connection refused
@@ -205,6 +209,61 @@ TEST_F (HttpClientTest, UnreachableHostsRawRequestNamesWhatWasAskedFor) {
     EXPECT_EQ (response.http_version, ""); // nothing negotiated - still honest
     EXPECT_TRUE (response.raw_request.rfind ("GET / HTTP/2\r\n", 0) == 0)
     << "raw_request began: " << response.raw_request.substr (0, 40);
+}
+
+// The raw view is the wire's own header block (issue #339), not a rebuild of
+// the composed headers. `Accept: */*` is what proves it: libcurl adds that
+// itself and it appears in no composed header map, so a view rebuilt from
+// `request_headers` cannot contain it.
+TEST_F (HttpClientTest, RawRequestIsTheHeaderBlockThatWentOnTheWire) {
+    Headers headers = { { "X-Trace", "abc" } };
+
+    auto result = client_->get (mock_->url ("/headers"), headers);
+
+    ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
+    const auto& raw = result.value ().raw_request;
+    EXPECT_TRUE (raw.starts_with ("GET /headers HTTP/1.1\r\n")) << raw;
+    EXPECT_NE (raw.find ("Host: 127.0.0.1:"), std::string::npos) << raw;
+    EXPECT_NE (raw.find ("X-Trace: abc"), std::string::npos) << raw;
+    EXPECT_NE (raw.find ("User-Agent: "), std::string::npos) << raw;
+    EXPECT_NE (raw.find ("Accept: */*"), std::string::npos)
+    << "the view was rebuilt from the composed headers, not read off the wire:\n"
+    << raw;
+    EXPECT_TRUE (raw.ends_with ("\r\n\r\n")) << "header block is unterminated:\n" << raw;
+}
+
+// A followed redirect sends two requests; the view describes the one that
+// produced the response being looked at, which is the last frame.
+TEST_F (HttpClientTest, RawRequestOfAFollowedRedirectShowsTheFinalHop) {
+    Request request;
+    request.method           = HttpMethod::GET;
+    request.url              = mock_->url ("/redirect/1"); // 302 -> /get
+    request.follow_redirects = true;
+    request.timeout_ms       = 5000;
+
+    auto result = client_->send (request);
+
+    ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
+    const auto& response = result.value ();
+    EXPECT_EQ (response.status_code, 200);
+    EXPECT_TRUE (response.raw_request.starts_with ("GET /get HTTP/1.1\r\n"))
+    << "the raw view named the hop that redirected, not the one that answered:\n"
+    << response.raw_request;
+}
+
+// The body is ours, not libcurl's - the frame stops at the blank line, so the
+// two halves have to be joined without swallowing or duplicating it.
+TEST_F (HttpClientTest, RawRequestKeepsTheBodyAfterTheWireHeaders) {
+    auto result = client_->post (mock_->url ("/post"), R"({"name": "test"})",
+    { { "Content-Type", "application/json" } });
+
+    ASSERT_TRUE (result.is_ok ()) << "Error: " << result.error ().message;
+    const auto& raw = result.value ().raw_request;
+    // libcurl's own Accept again, so this pins the joined halves of the wire
+    // view rather than a synthesized block that happens to have the same shape.
+    EXPECT_NE (raw.find ("Accept: */*"), std::string::npos) << raw;
+    EXPECT_NE (raw.find ("Content-Length: 16\r\n"), std::string::npos) << raw;
+    EXPECT_TRUE (raw.ends_with ("\r\n\r\n" R"({"name": "test"})")) << raw;
 }
 
 TEST_F (HttpClientTest, SendsPostRequest) {


### PR DESCRIPTION
## Description

**Plan.** Root cause: `response.request_headers` is the *composed* header map, and the cookie jar hands its cookies to libcurl through `CURLOPT_COOKIELIST` - libcurl synthesizes the `Cookie` header on the wire itself, so the raw-request builder (which read `request_headers`) could not see it and reported a request that was never sent. Approach, per the issue's decision: capture the transfer's last `CURLINFO_HEADER_OUT` frame in the debug callback and use it as the raw view's header block, so the view is the wire by construction - which also removes every future divergence (`Accept`, `Content-Length`, h2 rendered in HTTP/1 form) rather than just this one. The rejected alternative is the one the issue records: merging the jar's matched cookies into the view synthetically would re-implement libcurl's domain/path/`Secure`/expiry matching and drift from it - the exact trap the jar's design avoided by letting libcurl own matching.

Verified the problem still exists as described at `f703eaa`; the anchors in the issue (`client.cpp:154-157`, `:271`, `:296`, the builder at `:410-480`) were all accurate.

Changes:

- `debug_callback` now carries a `TransferDebug` through `CURLOPT_DEBUGDATA` and keeps the **last** outbound header frame verbatim. Last, not first, so a followed redirect describes the hop that produced the response beside it.
- The debug stream is always on; `ClientConfig::verbose` now gates only the *logging*. The capture is unredacted (the raw view exists to be exact, and the same value is already readable in Settings); the verbose log keeps `debug_redact` because logs get exported and shared. Two surfaces, two audiences, two policies - stated in the docs.
- The old builder is extracted as `synthesize_raw_request` and kept as the fallback for a transfer that never reached the wire (DNS failure, connection refused), which is all that ever existed for those.
- `raw_request_from_wire` re-normalizes the frame's terminator before appending the body, so the body cannot run into the last header line.

**`response.request_headers` is unchanged** - still the composed headers plus the injected `User-Agent`. Consumers, verified by grep: engine `utils/json.cpp:497` (`requestHeaders`), and on the app side `execute-mapping.ts`, `restore-response.ts`, `response-store.ts` and `HeadersViewer`/`ResponseHeadersPanel`. None of them read `rawRequest` for header data.

**App changes: none, verified.** `RawRequestResponse` renders the engine's string as-is (`ResponseViewer/index.tsx:350`). **MCP:** `run_request` returns the engine's `/execute` response unshaped (`app/electron/mcp/tools.ts`, `callEngine(... executeRequest ...)`), so `rawRequest` reaches MCP clients too and now includes the cookie line - noted rather than changed, since that is the same disclosure the decision made for the raw view.

**One divergence worth naming, not fixed here:** a *restored* trace (history) rebuilds its raw string client-side with `buildRawRequest` from the stored composed request, so it will still show no `Cookie` line. Closing that would mean persisting the sent cookie in `trace_data`, which is credential-grade material the jar deliberately keeps in memory only - an owner decision, filed separately rather than smuggled into this diff.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

CI could not run on this branch: GitHub Actions is in a declared major outage (incident opened 15:22 UTC, still `major_outage` at 22:18 UTC, webhook triggers throttled so pushes create no workflow runs). Verified locally at this branch head against base `f703eaa`:

- `python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **891/891 passed** (887 before this change).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.
- No app file changed and no renderer expectation moved, so the app suite is untouched by this diff.
- `clang-format --dry-run` on the three touched files reports only pre-existing violations on lines this diff does not touch; nothing was reformatted (repo rule).

Mutation-checked by forcing `synthesize_raw_request` on every path and rebuilding: `CookieJarTransfer.TheRawRequestViewShowsTheCookieThatWasSent`, `HttpClientTest.RawRequestIsTheHeaderBlockThatWentOnTheWire` and `HttpClientTest.RawRequestOfAFollowedRedirectShowsTheFinalHop` all fail (the cookie test prints the header block with no `Cookie` line - the bug itself). The POST test asserts libcurl's `Accept: */*` alongside the body join for the same reason: no composed header map contains it, so it cannot pass against a synthesized block.

New tests:

- `CookieJarTransfer.TheRawRequestViewShowsTheCookieThatWasSent` - a jar cookie appears in the raw view with its value; a scope with no matching cookie gains no `Cookie` line.
- `HttpClientTest.RawRequestIsTheHeaderBlockThatWentOnTheWire` - pins the new form (request line, `Host`, the composed header, the injected `User-Agent`, libcurl's `Accept`, terminated block).
- `HttpClientTest.RawRequestOfAFollowedRedirectShowsTheFinalHop` - `/redirect/1` → the view names `GET /get`.
- `HttpClientTest.RawRequestKeepsTheBodyAfterTheWireHeaders` - the body survives the join exactly once.

`UnreachableHostsRawRequestNamesWhatWasAskedFor` now also pins the synthesized fallback; its comment says so.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/architecture.md` (Cookie Jar - the display story and the two-surface redaction policy) and `docs/engine/api-reference.md` (what `rawRequest` is, how it differs from `requestHeaders`, redirects, and the failed-transfer fallback).

## Related Issues
Closes #339

---
_Generated by [Claude Code](https://claude.ai/code/session_016XtsB6kAJ6AM7TWzdGaBit)_