### PR TITLE
feat(engine): the cookie jar's write half - pm.cookies.jar()

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -20,7 +20,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()` |
 | Response headers    | `pm.response.headers.get(name)`, `.has(name)` - case-insensitive              |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
-| Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL, read-only, see below |
+| Cookie jar          | `pm.cookies.get(name)`, `.has(name)`, `.toObject()` - the stored session for this URL; `pm.cookies.jar()` for `get`/`set`/`unset`/`clear`, see below |
 | Response assertions | `pm.response.to.have.status(code)`, `.header(name)`, `.jsonBody()`, and the `pm.response.to.be.*` status classes below |
 | Request             | `pm.request.url`, `.method`, `.headers`, `.body`                                 |
 | Request headers     | `pm.request.headers.get/has(name)`, `.upsert({key, value})`, `.add({key, value})`, `.remove(name)` |
@@ -325,12 +325,32 @@ automatically. What these answer is matched against **this request's URL** -
 domain, path, `Secure` and expiry - so they report what will go on the wire and
 not everything stored.
 
+The write half is `pm.cookies.jar()`, Postman's own jar object:
+
+```javascript
+const jar = pm.cookies.jar();
+jar.set(pm.request.url, { name: 'session', value: token });  // or (url, name, value)
+jar.get('https://api.example.com/', 'session');              // value, or undefined
+jar.unset('https://api.example.com/', 'session');
+jar.clear();                                                 // this environment's jar
+```
+
+Every method is URL-scoped and takes an optional trailing `callback(err, value)`,
+invoked inline. A written cookie's `domain` and `path` default from the URL, and
+it is then matched by exactly the rules a received cookie is.
+
 Divergences from Postman:
 
-- **No `pm.cookies.jar()`, and no write half.** `set` / `unset` / `clear` are
-  not bound. Mutating a jar that in-flight transfers are reading needs its own
-  design; a binding that accepted a cookie and dropped it would be worse than
-  a missing one.
+- **No flat `pm.cookies.set(name, value)`.** Only the `jar()` form ships: a
+  written cookie needs a URL to take its domain and path from, which is why
+  Postman's own write half lives on the jar object.
+- **A write is applied after the transfer it was made before**, not the moment
+  it is called - so it rides that request and cannot be lost when the response's
+  cookies are captured. Details in
+  [scripting.md](../engine/scripting.md#writing-to-the-jar-pmcookiesjar).
+- **`jar.clear()` takes no URL** and empties this environment's jar. Postman's
+  clears per URL; Vayu's scope is the environment, so that is the unit here.
+- **`expires` is seconds since the epoch**, not a date string.
 - **Scope is the environment**, not the domain-with-permission model Postman
   uses. One jar per environment plus one for "no environment", in memory only,
   clearable in Settings → General → Cookies.
@@ -362,8 +382,8 @@ These Postman APIs are **not** implemented - scripts that rely on them will fail
 - `pm.iterationData.*` - data-file driven runs, and with them
   `pm.info.iteration` / `pm.info.iterationCount` (see
   [above](#script-identity-pminfo---three-fields-all-optional))
-- `pm.cookies.set(...)` / `.unset(...)` / `.clear()` / `.jar()` - the jar's
-  write half. The read half (`get` / `has` / `toObject`) is supported - see
+- `pm.cookies.set(...)` / `.unset(...)` / `.clear()` - the *flat* write half.
+  Writing goes through `pm.cookies.jar()`, which ships whole - see
   [above](#the-cookie-jar-pmcookies)
 - `pm.request.url.query` / `.path` / `.host` - and any other `url.*` accessor.
   `pm.request.url` is a writable **string** that the write-back requires to still

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -203,16 +203,28 @@ makes a session survive from one design-mode request to the next.
 - **Storage: libcurl's own lines.** The jar holds what `CURLINFO_COOKIELIST`
   exports and hands it back through `CURLOPT_COOKIELIST`, so domain matching,
   path matching, `Secure` and expiry stay inside libcurl's cookie engine. The
-  parser and matcher in `cookie_jar.cpp` serve only the two *read* views
-  (`pm.cookies`, `GET /cookies`), which need an answer without a transfer.
+  parser and matcher in `cookie_jar.cpp` serve the *read* views (`pm.cookies`,
+  `pm.cookies.jar().get`, `GET /cookies`), which need an answer without a
+  transfer, and the URL-scoped removal `jar().unset` performs. They never
+  decide what goes on the wire.
 - **Not on the load path.** `EventLoop` never touches it: a shared jar across
   workers is either a lock on the hot path or per-worker jars that do not
   actually share, and a load run repeats a single request anyway.
 - **Threading:** one mutex around the scope map; every accessor copies out, so
   no reference into the storage escapes to a caller.
+- **Script writes are staged, not applied in place** (`pm.cookies.jar()`, issue
+  #337). `capture_jar_cookies` *replaces* a scope's contents with what the
+  finishing handle held, so a write dropped into the map beside an in-flight
+  transfer would be discarded by it. Instead a write becomes a `CookieWrite`
+  that the execution's next transfer applies on top of the stored lines when it
+  seeds its handle (`ClientConfig::cookie_writes`) - the request carries it, and
+  that transfer's own capture is what persists it. A write with no transfer left
+  to ride, a post-request script's, is applied by the route through
+  `CookieJar::apply`. Either path applies it exactly once.
 
 `pm.sendRequest` shares the jar of the execute it runs inside, so a pre-request
-script can log in and leave the session where the real request will find it.
+script can log in and leave the session where the real request will find it; it
+also carries any write staged before it.
 
 ### Auth Resolution & OAuth 2.0
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -613,13 +613,77 @@ to the next one automatically, with no header to set by hand.
   `undefined`, which would read as "the cookie is gone". The jar is deliberately
   off the load path: sharing one across the event loop's workers would put a
   lock on the hot path, and a load run repeats a single request anyway.
-- **Read-only for now.** `pm.cookies.set` / `unset` / `clear` and
-  `pm.cookies.jar()` are not bound - mutating a jar that in-flight transfers are
-  reading needs its own design, and a binding that silently does nothing would
-  be worse than a missing one.
+- **Writing goes through `jar()`**, below. There is deliberately no flat
+  `pm.cookies.set(name, value)`: a written cookie needs a URL to take its
+  domain and path from, which is exactly why Postman's write half hangs off
+  the jar object.
 
 The jar is libcurl's own cookie engine underneath: matching, expiry and
 replacement are its rules, not a second implementation of RFC 6265.
+
+### Writing to the jar (`pm.cookies.jar()`)
+
+```javascript
+const jar = pm.cookies.jar();
+
+jar.set(pm.request.url, { name: 'session', value: token });
+jar.set(pm.request.url, 'session', token);            // the same, flat
+jar.get('https://api.example.com/', 'session');        // value, or undefined
+jar.unset('https://api.example.com/', 'session');
+jar.clear();                                           // this environment's jar
+```
+
+Postman's jar object, whole. Every method is **URL-scoped** - it takes the URL
+the cookie belongs to rather than assuming this request's - and each accepts an
+optional trailing `callback(err, value)`, invoked inline the way
+[`pm.sendRequest`](#sending-a-request-from-a-script-pmsendrequest)'s is,
+since the work has already happened by the time it is called. `get` also
+*returns* the value, which a synchronous implementation can do honestly.
+
+The cookie object needs `name` and `value`; everything else is optional and
+defaults from the URL:
+
+| Field | Default |
+|-------|---------|
+| `domain` | the URL's host, host-only. A leading dot (`.example.com`) means subdomains too |
+| `path` | RFC 6265 default-path - the URL's path with its last segment removed, so `/v1/orders/42` gives `/v1/orders` |
+| `secure`, `httpOnly` | `false` |
+| `expires` | `0`, a session cookie. Otherwise **seconds since the epoch** - `Math.floor(date.getTime() / 1000)` |
+
+Anything else is refused with an error rather than guessed at: a non-string
+`value`, a `secure: "yes"`, a date string in `expires`, a field carrying a tab
+or newline (the separators of the format the jar stores), or a URL that cannot
+be parsed. A cookie stored under the wrong domain reads as "the session did not
+stick" three requests later, which is a much worse afternoon than a thrown
+error.
+
+**A written cookie is matched by the same rules a received one is.** Setting it
+for one host does not send it to another, `/admin` does not reach `/`, and the
+jar's per-environment isolation holds - the write half is not a way around the
+matching the read half respects.
+
+**When the write takes effect.** A write is *staged*, not applied where it is
+made, and the next transfer of that execution carries it:
+
+- A `set` in a **pre-request script** rides the request it was made before, and
+  that request's own cookie capture is what writes it into the jar. It cannot
+  be discarded by that capture, which is the reason for the ordering: the
+  engine replaces a scope's contents with what the finishing transfer held, so
+  a write dropped into the jar beside an in-flight request would vanish with it.
+- A `set` followed by **`pm.sendRequest`** is carried by that auxiliary
+  request. A `set` *inside* a `sendRequest` callback is a sequential write -
+  `pm.sendRequest` is synchronous, so the callback runs after its transfer
+  finished and the write lands on the next one.
+- A `set` in a **post-request script** has no transfer left to ride, so it is
+  applied to the jar when the script ends.
+
+`clear()` empties **this environment's jar and no other**. Nothing is on disk,
+so the cost is a re-login; other environments, and the no-environment jar, are
+untouched. There is no confirmation gate for scripts - "reset my session" is a
+legitimate thing for a script to want, and Settings → General → Cookies shows
+the result.
+
+Load runs have no jar, so these throw there exactly as the read half does.
 
 ## Console Output
 

--- a/engine/include/vayu/http/client.hpp
+++ b/engine/include/vayu/http/client.hpp
@@ -47,6 +47,17 @@ struct ClientConfig {
      * Read only when `cookie_jar` is set.
      */
     std::string cookie_scope{ NO_ENVIRONMENT_SCOPE };
+
+    /**
+     * @brief Script jar writes this transfer carries (issue #337).
+     *
+     * Applied on top of the scope's stored lines when the handle is seeded, so
+     * a `pm.cookies.jar().set` made just before the send rides the request it
+     * was made for - and the transfer's own capture is what writes it back to
+     * the jar. See cookie_jar.hpp for why the write is not applied to the map
+     * directly. Read only when `cookie_jar` is set.
+     */
+    std::vector<CookieWrite> cookie_writes;
 };
 
 /**

--- a/engine/include/vayu/http/cookie_jar.hpp
+++ b/engine/include/vayu/http/cookie_jar.hpp
@@ -31,6 +31,19 @@
  * here" without performing a transfer, something no libcurl call offers. They
  * never decide what goes on the wire.
  *
+ * ## A script's writes are staged, not applied where they are made
+ *
+ * `pm.cookies.jar().set/unset/clear` (issue #337) do not touch the map while
+ * the script runs. They stage a `CookieWrite`, and the next transfer of that
+ * execution seeds its handle with the scope's lines *plus* the staged writes
+ * applied on top (`apply_cookie_writes`) - so the write rides the request it
+ * was made for, and the transfer's own capture is what persists it. That
+ * ordering is the point: `capture_jar_cookies` **replaces** the scope's list
+ * with what the finishing handle held, so a write applied into the live map
+ * beside an in-flight transfer would be discarded by it. A write that has no
+ * transfer left to ride (a post-request script's) is applied by the route
+ * through `CookieJar::apply`.
+ *
  * ## Scope, lifetime, persistence, threading
  *
  * - **Scope: one jar per environment**, keyed by environment id, with
@@ -128,6 +141,76 @@ bool secure_transport,
 int64_t now_seconds);
 
 /**
+ * @brief Write one cookie back as a Netscape line - the inverse of
+ *        `parse_cookie_line`, and the only place a line is built.
+ *
+ * A script-written cookie has no `Set-Cookie` to come from, so it becomes one
+ * of libcurl's own lines here and is thereafter the same kind of thing a
+ * received cookie is.
+ */
+[[nodiscard]] std::string format_cookie_line (const JarCookie& cookie);
+
+/**
+ * @brief Fill a script-supplied cookie's URL-derived defaults.
+ *
+ * `pm.cookies.jar().set(url, cookie)` carries the URL precisely so domain and
+ * path have somewhere to come from: an empty @p cookie.domain becomes @p url's
+ * host (host-only, as a `Set-Cookie` with no `Domain` attribute is), and an
+ * empty `path` becomes RFC 6265 §5.1.4's default-path - the URL's path with
+ * its last segment removed. Explicit fields are kept as given; a leading dot
+ * on the domain is libcurl's spelling of "subdomains too" and sets the
+ * tailmatch flag.
+ *
+ * `nullopt` when the result could not be stored honestly: an unparseable URL,
+ * an empty name, or a field carrying a tab or newline - the separators of the
+ * very format this is about to be written in, which would silently corrupt the
+ * line and make the cookie vanish on the next read.
+ */
+[[nodiscard]] std::optional<JarCookie>
+cookie_for_url (const std::string& url, JarCookie cookie);
+
+/**
+ * @brief One staged jar mutation from a script (issue #337).
+ *
+ * Staged rather than applied - see the file comment for why the write cannot
+ * land in the live map beside a transfer.
+ */
+struct CookieWrite {
+    enum class Kind {
+        /// Merge `line` in, replacing a cookie of the same name/domain/path.
+        Set,
+        /// Drop the cookies named `name` that would be sent to `url`.
+        Unset,
+        /// Empty the scope.
+        Clear,
+    };
+
+    Kind kind = Kind::Set;
+    /// `Set` only: the line to merge, from `format_cookie_line`.
+    std::string line;
+    /// `Unset` only: the URL the removal is scoped to, and the cookie name.
+    std::string url;
+    std::string name;
+};
+
+/**
+ * @brief @p lines with @p writes applied on top, in order. Pure - it is what
+ *        a transfer seeds its handle with and what `CookieJar::apply` stores.
+ */
+[[nodiscard]] std::vector<std::string> apply_cookie_writes (std::vector<std::string> lines,
+const std::vector<CookieWrite>& writes);
+
+/**
+ * @brief The cookies among @p lines that would be sent to @p url.
+ *
+ * `CookieJar::matching` over lines the caller already holds, so a script can
+ * read the jar *with* its own staged writes applied without those writes
+ * having to reach the map first. An unparseable URL matches nothing.
+ */
+[[nodiscard]] std::vector<JarCookie>
+matching_in (const std::vector<std::string>& lines, const std::string& url);
+
+/**
  * @brief One scope's contents, for `GET /cookies`.
  */
 struct CookieScopeView {
@@ -174,6 +257,16 @@ class CookieJar {
      */
     [[nodiscard]] std::vector<JarCookie>
     matching (const std::string& scope, const std::string& url) const;
+
+    /**
+     * @brief Apply staged script writes to @p scope.
+     *
+     * For writes with no transfer left to carry them - a post-request
+     * script's. A write made before a transfer rides that transfer instead
+     * (`ClientConfig::cookie_writes`), so it is applied exactly once either
+     * way; see the file comment.
+     */
+    void apply (const std::string& scope, const std::vector<CookieWrite>& writes);
 
     /**
      * @brief Every scope's contents, for the Settings panel. Scopes with no

--- a/engine/include/vayu/runtime/script_engine.hpp
+++ b/engine/include/vayu/runtime/script_engine.hpp
@@ -154,6 +154,22 @@ struct ScriptContext {
     std::string cookie_scope{ vayu::http::NO_ENVIRONMENT_SCOPE };
 
     /**
+     * @brief Where `pm.cookies.jar()`'s writes are staged, or null to refuse
+     *        them (issue #337).
+     *
+     * The caller owns the vector for the same reason it owns `environment`:
+     * the write has to outlive the script and be applied where the ordering is
+     * known - by the transfer that follows (`ClientConfig::cookie_writes`), or
+     * by the route through `CookieJar::apply` when no transfer follows. See
+     * cookie_jar.hpp for why a script cannot simply write into the map.
+     *
+     * Null is refused loudly rather than silently dropped: a context that
+     * never applies what a script wrote would report success for a cookie that
+     * went nowhere.
+     */
+    std::vector<vayu::http::CookieWrite>* cookie_writes = nullptr;
+
+    /**
      * @brief Expose @p req to the script as a mutable `pm.request`.
      *
      * The one supported way to opt into write-back, so the read snapshot and

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -149,11 +149,16 @@ size_t header_callback (char* buffer, size_t size, size_t nitems, void* userdata
  * From here on libcurl decides what actually goes on the wire: which cookies
  * match the URL, which expired, and what a `Set-Cookie` in the response
  * replaces. See cookie_jar.hpp for why that is deliberately not our code.
+ *
+ * A script's staged writes are applied on top of the stored lines here rather
+ * than in the jar, so the transfer carries them and its capture persists them
+ * - the ordering cookie_jar.hpp describes.
  */
 void apply_jar_cookies (CURL* curl, const ClientConfig& config) {
     curl_easy_setopt (curl, CURLOPT_COOKIEFILE, "");
     curl_easy_setopt (curl, CURLOPT_COOKIELIST, "ALL");
-    for (const auto& line : config.cookie_jar->lines_for (config.cookie_scope)) {
+    for (const auto& line : apply_cookie_writes (
+         config.cookie_jar->lines_for (config.cookie_scope), config.cookie_writes)) {
         curl_easy_setopt (curl, CURLOPT_COOKIELIST, line.c_str ());
     }
 }

--- a/engine/src/http/cookie_jar.cpp
+++ b/engine/src/http/cookie_jar.cpp
@@ -165,26 +165,126 @@ int64_t now_seconds) {
     return path_matches (cookie.path, path);
 }
 
-std::vector<std::string> CookieJar::lines_for (const std::string& scope) const {
-    const std::lock_guard<std::mutex> lock (mutex_);
-    const auto it = scopes_.find (scope);
-    return it == scopes_.end () ? std::vector<std::string>{} : it->second;
+std::string format_cookie_line (const JarCookie& cookie) {
+    std::string line;
+    if (cookie.http_only) {
+        line += HTTP_ONLY_PREFIX;
+    }
+    line += cookie.domain;
+    line += '\t';
+    line += cookie.include_subdomains ? "TRUE" : "FALSE";
+    line += '\t';
+    line += cookie.path;
+    line += '\t';
+    line += cookie.secure ? "TRUE" : "FALSE";
+    line += '\t';
+    line += std::to_string (cookie.expires);
+    line += '\t';
+    line += cookie.name;
+    line += '\t';
+    line += cookie.value;
+    return line;
 }
 
-void CookieJar::store (const std::string& scope, std::vector<std::string> lines) {
-    const std::lock_guard<std::mutex> lock (mutex_);
-    if (lines.empty ()) {
-        // Do not leave an empty scope behind: `snapshot()` reports scopes, and
-        // an environment whose cookies all expired would otherwise show up as
-        // a jar with nothing in it.
-        scopes_.erase (scope);
-        return;
+std::optional<JarCookie> cookie_for_url (const std::string& url, JarCookie cookie) {
+    if (cookie.name.empty ()) {
+        return std::nullopt;
     }
-    scopes_[scope] = std::move (lines);
+    // The line's own separators. A value carrying one would be written as a
+    // line with the wrong field count, which parse_cookie_line then refuses -
+    // the cookie would appear to have been stored and be gone on the next read.
+    for (const std::string_view field :
+    { std::string_view (cookie.name), std::string_view (cookie.value),
+    std::string_view (cookie.domain), std::string_view (cookie.path) }) {
+        if (field.find_first_of ("\t\r\n") != std::string_view::npos) {
+            return std::nullopt;
+        }
+    }
+
+    if (!cookie.domain.empty () && !cookie.path.empty ()) {
+        cookie.include_subdomains = cookie.domain.starts_with (".");
+        return cookie;
+    }
+
+    CURLU* parsed = curl_url ();
+    if (!parsed) {
+        return std::nullopt;
+    }
+    std::optional<std::string> host;
+    std::optional<std::string> path;
+    if (curl_url_set (parsed, CURLUPART_URL, url.c_str (), 0) == CURLUE_OK) {
+        host = url_part (parsed, CURLUPART_HOST);
+        path = url_part (parsed, CURLUPART_PATH);
+    }
+    curl_url_cleanup (parsed);
+    if (!host || !path) {
+        return std::nullopt;
+    }
+
+    if (cookie.domain.empty ()) {
+        // Host-only, which is what a Set-Cookie with no Domain attribute is.
+        cookie.domain = *host;
+    }
+    if (cookie.path.empty ()) {
+        // RFC 6265 §5.1.4 default-path: everything up to the last `/`, and `/`
+        // when that leaves nothing.
+        const size_t last = path->rfind ('/');
+        cookie.path =
+        (last == std::string::npos || last == 0) ? "/" : path->substr (0, last);
+    }
+    cookie.include_subdomains = cookie.domain.starts_with (".");
+    return cookie;
+}
+
+std::vector<std::string> apply_cookie_writes (std::vector<std::string> lines,
+const std::vector<CookieWrite>& writes) {
+    for (const auto& write : writes) {
+        switch (write.kind) {
+        case CookieWrite::Kind::Clear: lines.clear (); break;
+
+        case CookieWrite::Kind::Set: {
+            const auto written = parse_cookie_line (write.line);
+            if (!written) {
+                // Refused at the binding, so reaching here means a caller built
+                // a line by hand; dropping it is better than storing a line no
+                // reader can parse.
+                break;
+            }
+            // RFC 6265 §5.3: name, domain and path are a cookie's identity, so
+            // a second write of the same three replaces rather than duplicates.
+            std::erase_if (lines, [&written] (const std::string& line) {
+                const auto held = parse_cookie_line (line);
+                return held && held->name == written->name &&
+                held->domain == written->domain && held->path == written->path;
+            });
+            lines.push_back (write.line);
+            break;
+        }
+
+        case CookieWrite::Kind::Unset: {
+            // URL-scoped, like the read half: `unset` removes what a request to
+            // that URL would have carried, not every cookie sharing the name.
+            const auto doomed = matching_in (lines, write.url);
+            std::erase_if (lines, [&write, &doomed] (const std::string& line) {
+                const auto held = parse_cookie_line (line);
+                if (!held || held->name != write.name) {
+                    return false;
+                }
+                return std::any_of (doomed.begin (), doomed.end (),
+                [&held] (const JarCookie& match) {
+                    return match.name == held->name &&
+                    match.domain == held->domain && match.path == held->path;
+                });
+            });
+            break;
+        }
+        }
+    }
+    return lines;
 }
 
 std::vector<JarCookie>
-CookieJar::matching (const std::string& scope, const std::string& url) const {
+matching_in (const std::vector<std::string>& lines, const std::string& url) {
     CURLU* parsed = curl_url ();
     if (!parsed) {
         return {};
@@ -206,13 +306,53 @@ CookieJar::matching (const std::string& scope, const std::string& url) const {
     const auto now              = static_cast<int64_t> (std::time (nullptr));
 
     std::vector<JarCookie> out;
-    for (const auto& line : lines_for (scope)) {
+    for (const auto& line : lines) {
         auto cookie = parse_cookie_line (line);
         if (cookie && cookie_matches (*cookie, *host, *path, secure_transport, now)) {
             out.push_back (std::move (*cookie));
         }
     }
     return out;
+}
+
+std::vector<std::string> CookieJar::lines_for (const std::string& scope) const {
+    const std::lock_guard<std::mutex> lock (mutex_);
+    const auto it = scopes_.find (scope);
+    return it == scopes_.end () ? std::vector<std::string>{} : it->second;
+}
+
+void CookieJar::store (const std::string& scope, std::vector<std::string> lines) {
+    const std::lock_guard<std::mutex> lock (mutex_);
+    if (lines.empty ()) {
+        // Do not leave an empty scope behind: `snapshot()` reports scopes, and
+        // an environment whose cookies all expired would otherwise show up as
+        // a jar with nothing in it.
+        scopes_.erase (scope);
+        return;
+    }
+    scopes_[scope] = std::move (lines);
+}
+
+std::vector<JarCookie>
+CookieJar::matching (const std::string& scope, const std::string& url) const {
+    return matching_in (lines_for (scope), url);
+}
+
+void CookieJar::apply (const std::string& scope, const std::vector<CookieWrite>& writes) {
+    if (writes.empty ()) {
+        return;
+    }
+    const std::lock_guard<std::mutex> lock (mutex_);
+    const auto it = scopes_.find (scope);
+    auto applied  = apply_cookie_writes (
+    it == scopes_.end () ? std::vector<std::string>{} : it->second, writes);
+    if (applied.empty ()) {
+        // Same reason store() erases: an emptied scope is not a scope the
+        // Settings panel should list.
+        scopes_.erase (scope);
+        return;
+    }
+    scopes_[scope] = std::move (applied);
 }
 
 std::vector<CookieScopeView> CookieJar::snapshot () const {

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -748,6 +748,14 @@ void register_execution_routes (RouteContext& ctx) {
         const std::string cookie_scope =
         run.environment_id.value_or (std::string (vayu::http::NO_ENVIRONMENT_SCOPE));
 
+        // Where each script's `pm.cookies.jar()` writes are staged. The
+        // pre-request script's ride the send below and are persisted by its
+        // capture; the post-request script's have no transfer left to carry
+        // them, so the route applies them. Either way exactly once - see
+        // cookie_jar.hpp.
+        std::vector<vayu::http::CookieWrite> pre_cookie_writes;
+        std::vector<vayu::http::CookieWrite> post_cookie_writes;
+
         // Execute pre-request script. `for_prerequest` is what makes its
         // pm.request edits reach the wire; everything below this line - the
         // send, the stored trace, the raw request the app shows - reads the
@@ -755,6 +763,7 @@ void register_execution_routes (RouteContext& ctx) {
         auto pre_ctx = vayu::runtime::ScriptContext::for_prerequest (request);
         pre_ctx.cookie_jar          = &ctx.cookie_jar;
         pre_ctx.cookie_scope        = cookie_scope;
+        pre_ctx.cookie_writes       = &pre_cookie_writes;
         pre_ctx.environment         = &env;
         pre_ctx.globals             = &globals;
         pre_ctx.collectionVariables = &collectionVariables;
@@ -766,9 +775,10 @@ void register_execution_routes (RouteContext& ctx) {
 
         // Send HTTP request
         vayu::http::ClientConfig config;
-        config.verbose      = ctx.verbose;
-        config.cookie_jar   = &ctx.cookie_jar;
-        config.cookie_scope = cookie_scope;
+        config.verbose       = ctx.verbose;
+        config.cookie_jar    = &ctx.cookie_jar;
+        config.cookie_scope  = cookie_scope;
+        config.cookie_writes = std::move (pre_cookie_writes);
         vayu::http::Client client (config);
         const auto response = client.send (request).value ();
 
@@ -779,6 +789,7 @@ void register_execution_routes (RouteContext& ctx) {
         auto post_ctx = vayu::runtime::ScriptContext::for_test (request, response);
         post_ctx.cookie_jar          = &ctx.cookie_jar;
         post_ctx.cookie_scope        = cookie_scope;
+        post_ctx.cookie_writes       = &post_cookie_writes;
         post_ctx.environment         = &env;
         post_ctx.globals             = &globals;
         post_ctx.collectionVariables = &collectionVariables;
@@ -787,6 +798,12 @@ void register_execution_routes (RouteContext& ctx) {
         post_ctx.request_name        = script_request_name;
         auto post_script_result =
         execute_script (script_engine, post_request_script, post_ctx, "Post-request");
+
+        // The post-request script's jar writes: the transfer has already
+        // captured, so there is nothing left to carry them and the route is
+        // where they land. A write its own `pm.sendRequest` already carried is
+        // not in here - that call drains the queue.
+        ctx.cookie_jar.apply (cookie_scope, post_cookie_writes);
 
         // Persist script-set variables (design mode only; best-effort)
         persist_script_variables (ctx.db, run, env, globals, collectionVariables);

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -680,8 +680,8 @@ nlohmann::json get_script_completions () {
     "per environment, kept in memory for as long as the engine runs and "
     "clearable in Settings; requests sent with no environment selected share "
     "one jar of their own. Load runs have no jar and these throw there. "
-    "Read-only for now - use pm.response.cookies for what a single response "
-    "set." },
+    "Writing is done through pm.cookies.jar(); use pm.response.cookies for "
+    "what a single response set." },
     { "sortText", "0_pm_cookies" } });
 
     completions.push_back ({ { "label", "pm.cookies.get" }, { "kind", KIND_FUNCTION },
@@ -710,6 +710,64 @@ nlohmann::json get_script_completions () {
     "Every stored cookie that would be sent to this URL, as a name-to-value "
     "object." },
     { "sortText", "1_pm_cookies_to_object" } });
+
+    // pm.cookies.jar() - the write half (#337). Offered one level deeper than
+    // the flat reads because every method is URL-scoped: the URL is what a
+    // written cookie's domain and path come from.
+    completions.push_back ({ { "label", "pm.cookies.jar" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.jar()" }, { "detail", "pm.cookies.jar(): object" },
+    { "documentation",
+    "Postman's cookie jar object - the write half, plus a URL-scoped read. "
+    "get(url, name), set(url, cookie), unset(url, name) and clear() all take "
+    "the URL the cookie belongs to rather than assuming this request's.\n\nA "
+    "write is applied after the transfer it was made before, so the request "
+    "that follows carries it and the jar keeps it.\n\nExample:\n"
+    "pm.cookies.jar().set(pm.request.url, { name: 'session', value: token "
+    "});" },
+    { "sortText", "1_pm_cookies_jar" } });
+
+    completions.push_back ({ { "label", "pm.cookies.jar().get" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.jar().get(\"${1:https://api.example.com}\", \"${2:session}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.cookies.jar().get(url: string, name: string, callback?): string | undefined" },
+    { "documentation",
+    "The value of a stored cookie that would be sent to that URL, or "
+    "undefined. Same matching as pm.cookies.get, against the URL you pass "
+    "instead of this request's; a cookie this script has just set is "
+    "included. The value is returned and also handed to the optional "
+    "callback as (null, value)." },
+    { "sortText", "1_pm_cookies_jar_get" } });
+
+    completions.push_back ({ { "label", "pm.cookies.jar().set" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.jar().set(\"${1:https://api.example.com}\", { name: \"${2:session}\", value: ${3:token} })" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.cookies.jar().set(url: string, cookie: object, callback?): void" },
+    { "documentation",
+    "Store a cookie for that URL. The cookie object needs name and value; "
+    "domain, path, secure, httpOnly and expires (seconds since the epoch, 0 "
+    "for a session cookie) are optional and default from the URL. "
+    "set(url, name, value) is accepted too.\n\nThe cookie is matched by the "
+    "same rules a received one is, so setting it for one host does not send "
+    "it to another." },
+    { "sortText", "1_pm_cookies_jar_set" } });
+
+    completions.push_back ({ { "label", "pm.cookies.jar().unset" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.cookies.jar().unset(\"${1:https://api.example.com}\", \"${2:session}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.cookies.jar().unset(url: string, name: string, callback?): void" },
+    { "documentation",
+    "Remove the cookies of that name the URL would have carried. Cookies of "
+    "the same name stored for another host or path are left alone." },
+    { "sortText", "1_pm_cookies_jar_unset" } });
+
+    completions.push_back ({ { "label", "pm.cookies.jar().clear" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.cookies.jar().clear()" },
+    { "detail", "pm.cookies.jar().clear(callback?): void" },
+    { "documentation",
+    "Empty this environment's jar - a session reset, and nothing wider: "
+    "other environments' jars are untouched. Nothing is on disk, so this "
+    "costs a re-login and no more." },
+    { "sortText", "1_pm_cookies_jar_clear" } });
 
     // ========================================
     // pm.crypto - Hashing, and the base64 globals that go with it

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -116,6 +116,11 @@ struct ContextData {
     /// `ScriptContext::cookie_jar`, which owns the rationale.
     vayu::http::CookieJar* cookie_jar = nullptr;
     std::string cookie_scope{ vayu::http::NO_ENVIRONMENT_SCOPE };
+
+    /// Where `pm.cookies.jar()` stages its writes - see
+    /// `ScriptContext::cookie_writes`. Drained by `pm.sendRequest`, which
+    /// hands them to the auxiliary transfer.
+    std::vector<vayu::http::CookieWrite>* cookie_writes = nullptr;
 };
 
 // Get context data from JS context
@@ -4035,6 +4040,15 @@ JSValue js_pm_send_request (JSContext* ctx, JSValueConst this_val, int argc, JSV
     vayu::http::ClientConfig client_config;
     client_config.cookie_jar   = data->cookie_jar;
     client_config.cookie_scope = data->cookie_scope;
+    // Staged jar writes ride the next transfer of this execution, and this is
+    // it - so a script that sets a cookie and then sends through
+    // pm.sendRequest carries it. Drained rather than copied: this transfer's
+    // capture persists them, and applying them a second time afterwards would
+    // undo whatever its response changed.
+    if (data->cookie_writes) {
+        client_config.cookie_writes = std::move (*data->cookie_writes);
+        data->cookie_writes->clear ();
+    }
     vayu::http::Client client (client_config);
     auto sent = client.send (request);
 
@@ -4067,16 +4081,15 @@ JSValue js_pm_send_request (JSContext* ctx, JSValueConst this_val, int argc, JSV
 // pm.cookies - the jar, matched against the current request's URL
 // ============================================================================
 
-// The jar's cookies that would be sent to the request this script belongs to.
-// Returns nullopt having thrown: either there is no jar here (a load run, a
-// hand-built context - see ScriptContext::cookie_jar) or there is no request
-// to match against, and both deserve a sentence rather than an empty answer.
-std::optional<std::vector<vayu::http::JarCookie>>
-jar_cookies_from_context (JSContext* ctx, const char* member) {
+// The context behind a pm.cookies member, or nullptr having thrown the
+// sentence that says why there is no jar here (a load run, a hand-built
+// context - see ScriptContext::cookie_jar). @p member is the full spelling, so
+// the message names what the script actually wrote.
+ContextData* jar_context (JSContext* ctx, const char* member) {
     auto* data = get_context_data (ctx);
-    if (!data || !data->request) {
-        JS_ThrowInternalError (ctx, "No request available");
-        return std::nullopt;
+    if (!data) {
+        JS_ThrowInternalError (ctx, "No script context available");
+        return nullptr;
     }
     if (!data->cookie_jar) {
         JS_ThrowPlainError (ctx,
@@ -4085,9 +4098,36 @@ jar_cookies_from_context (JSContext* ctx, const char* member) {
         "pm.response.cookies for the Set-Cookie of the response in hand. See "
         "docs/engine/scripting.md.",
         member);
+        return nullptr;
+    }
+    return data;
+}
+
+// The scope's lines with this script's own staged writes applied on top. Every
+// read goes through this, so a `jar().set` followed by a read answers with what
+// was just written rather than with the map the write has not reached yet.
+std::vector<std::string> staged_jar_lines (const ContextData& data) {
+    auto lines = data.cookie_jar->lines_for (data.cookie_scope);
+    if (!data.cookie_writes) {
+        return lines;
+    }
+    return vayu::http::apply_cookie_writes (std::move (lines), *data.cookie_writes);
+}
+
+// The jar's cookies that would be sent to the request this script belongs to.
+// Returns nullopt having thrown: either there is no jar, or there is no request
+// to match against, and both deserve a sentence rather than an empty answer.
+std::optional<std::vector<vayu::http::JarCookie>>
+jar_cookies_from_context (JSContext* ctx, const char* member) {
+    auto* data = get_context_data (ctx);
+    if (!data || !data->request) {
+        JS_ThrowInternalError (ctx, "No request available");
         return std::nullopt;
     }
-    return data->cookie_jar->matching (data->cookie_scope, data->request->url);
+    if (!jar_context (ctx, member)) {
+        return std::nullopt;
+    }
+    return vayu::http::matching_in (staged_jar_lines (*data), data->request->url);
 }
 
 // Which cookie answers for a name when the jar holds it more than once - the
@@ -4157,6 +4197,301 @@ js_jar_cookies_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSVal
     return obj;
 }
 
+// ----------------------------------------------------------------------------
+// pm.cookies.jar() - the write half (issue #337)
+// ----------------------------------------------------------------------------
+
+// Where a jar write is staged, or nullptr having thrown. A jar with nowhere to
+// apply writes is refused rather than silently accepted: a call that reported
+// success for a cookie that went nowhere is the failure this whole surface
+// exists to avoid.
+std::vector<vayu::http::CookieWrite>* jar_writes (JSContext* ctx, const char* member) {
+    auto* data = jar_context (ctx, member);
+    if (!data) {
+        return nullptr;
+    }
+    if (!data->cookie_writes) {
+        JS_ThrowPlainError (ctx,
+        "pm.cookies.%s is not available here: this execution has nowhere to "
+        "apply a jar write, so accepting one would report success for a cookie "
+        "that goes nowhere. See docs/engine/scripting.md.",
+        member);
+        return nullptr;
+    }
+    return data->cookie_writes;
+}
+
+// One required string argument of a jar() method. Every one of them is
+// URL-scoped, which is the whole reason Postman's write half hangs off `jar()`
+// rather than off `pm.cookies` - so the URL is never optional.
+std::optional<std::string> read_jar_string_arg (JSContext* ctx,
+const char* member,
+const char* label,
+int index,
+int argc,
+JSValueConst* argv) {
+    if (index >= argc || !JS_IsString (argv[index])) {
+        JS_ThrowTypeError (ctx, "pm.cookies.jar().%s needs a %s string, got %s", member,
+        label, index >= argc ? "no argument" : js_type_name (ctx, argv[index]));
+        return std::nullopt;
+    }
+    std::string text = js_to_string (ctx, argv[index]);
+    if (text.empty ()) {
+        JS_ThrowTypeError (ctx, "pm.cookies.jar().%s needs a non-empty %s", member, label);
+        return std::nullopt;
+    }
+    return text;
+}
+
+// `set`'s cookie object: `{ name, value, domain?, path?, secure?, httpOnly?,
+// expires? }`. Returns the reason it was refused rather than a half-filled
+// cookie - a field misread here becomes a cookie stored under the wrong
+// domain, which reads as "the session did not stick" three requests later.
+std::optional<std::string>
+read_jar_cookie_arg (JSContext* ctx, JSValueConst arg, vayu::http::JarCookie& out) {
+    if (!JS_IsObject (arg) || JS_IsArray (arg) || JS_IsFunction (ctx, arg)) {
+        return "pm.cookies.jar().set expects (url, {name, value, ...}) or "
+               "(url, name, value), got " +
+        std::string (js_type_name (ctx, arg)) + " as its second argument";
+    }
+
+    const auto required_string = [&] (const char* key,
+                                 std::string& target) -> std::optional<std::string> {
+        ScopedValue value (ctx, JS_GetPropertyStr (ctx, arg, key));
+        if (!JS_IsString (value.get ())) {
+            return "pm.cookies.jar().set cookie." + std::string (key) +
+            " must be a string, got " + std::string (js_type_name (ctx, value.get ()));
+        }
+        target = js_to_string (ctx, value.get ());
+        return std::nullopt;
+    };
+    if (auto reason = required_string ("name", out.name)) {
+        return reason;
+    }
+    if (auto reason = required_string ("value", out.value)) {
+        return reason;
+    }
+
+    const auto optional_string = [&] (const char* key,
+                                 std::string& target) -> std::optional<std::string> {
+        ScopedValue value (ctx, JS_GetPropertyStr (ctx, arg, key));
+        if (JS_IsUndefined (value.get ()) || JS_IsNull (value.get ())) {
+            return std::nullopt;
+        }
+        if (!JS_IsString (value.get ())) {
+            return "pm.cookies.jar().set cookie." + std::string (key) +
+            " must be a string, got " + std::string (js_type_name (ctx, value.get ()));
+        }
+        target = js_to_string (ctx, value.get ());
+        return std::nullopt;
+    };
+    if (auto reason = optional_string ("domain", out.domain)) {
+        return reason;
+    }
+    if (auto reason = optional_string ("path", out.path)) {
+        return reason;
+    }
+
+    const auto optional_bool = [&] (const char* key,
+                               bool& target) -> std::optional<std::string> {
+        ScopedValue value (ctx, JS_GetPropertyStr (ctx, arg, key));
+        if (JS_IsUndefined (value.get ()) || JS_IsNull (value.get ())) {
+            return std::nullopt;
+        }
+        // Not JS_ToBool: a truthy string would make `secure: "false"` mean
+        // secure, and a cookie's flags are not a place to guess.
+        if (!JS_IsBool (value.get ())) {
+            return "pm.cookies.jar().set cookie." + std::string (key) +
+            " must be true or false, got " +
+            std::string (js_type_name (ctx, value.get ()));
+        }
+        target = JS_ToBool (ctx, value.get ()) != 0;
+        return std::nullopt;
+    };
+    if (auto reason = optional_bool ("secure", out.secure)) {
+        return reason;
+    }
+    if (auto reason = optional_bool ("httpOnly", out.http_only)) {
+        return reason;
+    }
+
+    ScopedValue js_expires (ctx, JS_GetPropertyStr (ctx, arg, "expires"));
+    if (!JS_IsUndefined (js_expires.get ()) && !JS_IsNull (js_expires.get ())) {
+        // Seconds since the epoch, which is what the jar stores and what a
+        // Netscape line carries. A Date or a date string is refused with the
+        // conversion rather than guessed at, because guessing wrong writes a
+        // cookie that expires in 1970 and is simply never sent again.
+        if (!JS_IsNumber (js_expires.get ())) {
+            return "pm.cookies.jar().set cookie.expires must be a number of "
+                   "seconds since the epoch (use Math.floor(date.getTime() / "
+                   "1000)), got " +
+            std::string (js_type_name (ctx, js_expires.get ()));
+        }
+        int64_t seconds = 0;
+        if (JS_ToInt64 (ctx, &seconds, js_expires.get ()) < 0) {
+            return std::string ("pm.cookies.jar().set cookie.expires is not a "
+                                "whole number of seconds");
+        }
+        if (seconds < 0) {
+            return std::string ("pm.cookies.jar().set cookie.expires must not "
+                                "be negative; 0 means a session cookie");
+        }
+        out.expires = seconds;
+    }
+    return std::nullopt;
+}
+
+// Postman's callback, honoured the way pm.sendRequest honours its own: the
+// work already happened synchronously, so it is invoked inline with
+// `(null, result)`. Optional, because the call is complete without it - and
+// `result` is *also* returned, which a synchronous implementation can do
+// honestly and a script reads more easily than a closure.
+//
+// Takes ownership of @p result either way.
+JSValue finish_jar_call (JSContext* ctx, int argc, JSValueConst* argv, int callback_index, JSValue result) {
+    if (callback_index >= argc || JS_IsUndefined (argv[callback_index]) ||
+    JS_IsNull (argv[callback_index])) {
+        return result;
+    }
+    if (!JS_IsFunction (ctx, argv[callback_index])) {
+        JS_FreeValue (ctx, result);
+        return JS_ThrowTypeError (ctx, "pm.cookies.jar()'s callback must be a function, got %s",
+        js_type_name (ctx, argv[callback_index]));
+    }
+
+    JSValue args[2] = { JS_NULL, JS_DupValue (ctx, result) };
+    JSValue ret = JS_Call (ctx, argv[callback_index], JS_UNDEFINED, 2, args);
+    JS_FreeValue (ctx, args[1]);
+    // A callback that threw - a failed pm.expect inside it, most likely - is
+    // the script's error, not something to swallow here.
+    if (JS_IsException (ret)) {
+        JS_FreeValue (ctx, result);
+        return JS_EXCEPTION;
+    }
+    JS_FreeValue (ctx, ret);
+    return result;
+}
+
+JSValue js_jar_get (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto url = read_jar_string_arg (ctx, "get", "URL", 0, argc, argv);
+    if (!url) {
+        return JS_EXCEPTION;
+    }
+    auto name = read_jar_string_arg (ctx, "get", "cookie name", 1, argc, argv);
+    if (!name) {
+        return JS_EXCEPTION;
+    }
+    auto* data = jar_context (ctx, "jar().get");
+    if (!data) {
+        return JS_EXCEPTION;
+    }
+
+    // Matched against the URL given here rather than the request's, which is
+    // the difference between this and the flat read half.
+    const auto cookies = vayu::http::matching_in (staged_jar_lines (*data), *url);
+    const auto* cookie = find_jar_cookie (cookies, *name);
+    return finish_jar_call (ctx, argc, argv, 2,
+    cookie ? JS_NewString (ctx, cookie->value.c_str ()) : JS_UNDEFINED);
+}
+
+JSValue js_jar_set (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto url = read_jar_string_arg (ctx, "set", "URL", 0, argc, argv);
+    if (!url) {
+        return JS_EXCEPTION;
+    }
+
+    vayu::http::JarCookie cookie;
+    int callback_index = 2;
+    if (argc > 1 && JS_IsString (argv[1])) {
+        // Postman's other spelling: set(url, name, value, cb). Both forms are
+        // URL-scoped, which is the property decision 1 of #337 required.
+        auto name = read_jar_string_arg (ctx, "set", "cookie name", 1, argc, argv);
+        if (!name) {
+            return JS_EXCEPTION;
+        }
+        if (argc < 3 || !JS_IsString (argv[2])) {
+            return JS_ThrowTypeError (ctx, "pm.cookies.jar().set(url, name, value) needs a value string, got %s",
+            argc < 3 ? "no argument" : js_type_name (ctx, argv[2]));
+        }
+        cookie.name    = std::move (*name);
+        cookie.value   = js_to_string (ctx, argv[2]);
+        callback_index = 3;
+    } else if (auto reason =
+               read_jar_cookie_arg (ctx, argc > 1 ? argv[1] : JS_UNDEFINED, cookie)) {
+        return JS_ThrowTypeError (ctx, "%s", reason->c_str ());
+    }
+
+    auto* writes = jar_writes (ctx, "jar().set");
+    if (!writes) {
+        return JS_EXCEPTION;
+    }
+
+    // One helper builds the line for a written cookie and a received one alike
+    // - see cookie_jar.hpp. It is also what fills the fields the object left
+    // out, from the URL that scopes the call.
+    const auto stored = vayu::http::cookie_for_url (*url, cookie);
+    if (!stored) {
+        return JS_ThrowTypeError (ctx,
+        "pm.cookies.jar().set could not store \"%s\" for %s: the URL must be "
+        "absolute and parseable, the name non-empty, and no field may contain "
+        "a tab or newline",
+        cookie.name.c_str (), url->c_str ());
+    }
+    writes->push_back ({ vayu::http::CookieWrite::Kind::Set,
+    vayu::http::format_cookie_line (*stored), {}, {} });
+    return finish_jar_call (ctx, argc, argv, callback_index, JS_UNDEFINED);
+}
+
+JSValue js_jar_unset (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto url = read_jar_string_arg (ctx, "unset", "URL", 0, argc, argv);
+    if (!url) {
+        return JS_EXCEPTION;
+    }
+    auto name = read_jar_string_arg (ctx, "unset", "cookie name", 1, argc, argv);
+    if (!name) {
+        return JS_EXCEPTION;
+    }
+    auto* writes = jar_writes (ctx, "jar().unset");
+    if (!writes) {
+        return JS_EXCEPTION;
+    }
+    writes->push_back ({ vayu::http::CookieWrite::Kind::Unset, {},
+    std::move (*url), std::move (*name) });
+    return finish_jar_call (ctx, argc, argv, 2, JS_UNDEFINED);
+}
+
+JSValue js_jar_clear (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto* writes = jar_writes (ctx, "jar().clear");
+    if (!writes) {
+        return JS_EXCEPTION;
+    }
+    // The current environment's jar, and no other - decision 2 of #337. The
+    // blast radius is a session reset, which Settings shows and a script can
+    // legitimately want; it is not the whole process's cookies.
+    writes->push_back ({ vayu::http::CookieWrite::Kind::Clear, {}, {}, {} });
+    return finish_jar_call (ctx, argc, argv, 0, JS_UNDEFINED);
+}
+
+// pm.cookies.jar() - Postman's jar object, built per call as Postman's is.
+// Deliberately does *not* throw where there is no jar: it is an accessor, and
+// the sentence explaining the absence belongs on the method the script
+// actually called, so `typeof pm.cookies.jar().set` stays answerable.
+JSValue js_cookies_jar (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    JSValue jar = JS_NewObject (ctx);
+    JS_SetPropertyStr (ctx, jar, "get", JS_NewCFunction (ctx, js_jar_get, "get", 3));
+    JS_SetPropertyStr (ctx, jar, "set", JS_NewCFunction (ctx, js_jar_set, "set", 4));
+    JS_SetPropertyStr (ctx, jar, "unset", JS_NewCFunction (ctx, js_jar_unset, "unset", 3));
+    JS_SetPropertyStr (ctx, jar, "clear", JS_NewCFunction (ctx, js_jar_clear, "clear", 1));
+    return jar;
+}
+
 // pm.cookies - always bound, like pm.sendRequest, so a script that reaches for
 // it where there is no jar is told why instead of meeting "not a function".
 void setup_pm_cookies (JSContext* ctx, JSValue pm) {
@@ -4167,6 +4502,8 @@ void setup_pm_cookies (JSContext* ctx, JSValue pm) {
     JS_NewCFunction (ctx, js_jar_cookies_has, "has", 1));
     JS_SetPropertyStr (ctx, cookies, "toObject",
     JS_NewCFunction (ctx, js_jar_cookies_to_object, "toObject", 0));
+    JS_SetPropertyStr (
+    ctx, cookies, "jar", JS_NewCFunction (ctx, js_cookies_jar, "jar", 0));
     JS_SetPropertyStr (ctx, pm, "cookies", cookies);
 }
 
@@ -4209,9 +4546,8 @@ void setup_pm_object (JSContext* ctx) {
     // pm.crypto
     setup_pm_crypto (ctx, pm);
 
-    // pm.cookies - the jar (issue #301). Read-only for now: the write half
-    // (`set`/`unset`/`clear`) mutates a jar in-flight transfers are reading,
-    // which needs its own design.
+    // pm.cookies - the jar's flat read half (issue #301) and, through
+    // `jar()`, its write half (issue #337).
     setup_pm_cookies (ctx, pm);
 
     // pm.sendRequest - always bound, even when the capability is off, so a
@@ -4369,6 +4705,7 @@ class ScriptEngine::Impl {
         ctx_data.send_request_count = 0;
         ctx_data.cookie_jar         = ctx.cookie_jar;
         ctx_data.cookie_scope       = ctx.cookie_scope;
+        ctx_data.cookie_writes      = ctx.cookie_writes;
         JS_SetContextOpaque (js_ctx, &ctx_data);
 
         // Refresh pm.request, pm.response and pm.info with new data

--- a/engine/tests/cookie_jar_test.cpp
+++ b/engine/tests/cookie_jar_test.cpp
@@ -478,6 +478,503 @@ TEST (CookieJarScript, SendRequestSharesTheJarWithTheRequestAroundIt) {
 }
 
 // ============================================================================
+// The write half - pm.cookies.jar() (issue #337)
+//
+// The assertions that matter here are on the *wire*, for the same reason the
+// isolation test is: a written cookie's failure mode is not "nothing was
+// stored", it is "it was stored and is now being sent somewhere it should not
+// go". Only the receiving end can answer that.
+// ============================================================================
+
+namespace {
+
+/// What `send_after_script` observed, so a test can assert on the script and
+/// on the wire without two helpers.
+struct ScriptedSend {
+    bool script_ok = true;
+    std::string script_error;
+    /// The Cookie header the server saw, for the /echo endpoint.
+    std::string echoed;
+};
+
+/// The route's sequence in miniature (execution.cpp): run a pre-request script
+/// that may stage jar writes, then send the request those writes were made
+/// before - the transfer carries them and its capture is what persists them.
+/// The send happens even when the script failed, exactly as the route's does.
+ScriptedSend send_after_script (CookieJar& jar,
+const std::string& scope,
+const std::string& script,
+const std::string& url,
+vayu::Environment& env) {
+    vayu::runtime::ScriptConfig script_config;
+    script_config.allow_send_request = true;
+    vayu::runtime::ScriptEngine engine (script_config);
+
+    vayu::Request request = get_request (url);
+    std::vector<vayu::http::CookieWrite> writes;
+
+    vayu::runtime::ScriptContext ctx =
+    vayu::runtime::ScriptContext::for_prerequest (request);
+    ctx.environment   = &env;
+    ctx.cookie_jar    = &jar;
+    ctx.cookie_scope  = scope;
+    ctx.cookie_writes = &writes;
+
+    const auto result = engine.execute (script, ctx);
+
+    ClientConfig config;
+    config.cookie_jar    = &jar;
+    config.cookie_scope  = scope;
+    config.cookie_writes = std::move (writes);
+    Client client (config);
+    return { result.success, result.error_message,
+        client.send (request).value ().body };
+}
+
+/// The same, for a script with no send after it - a post-request script's
+/// writes, which the route applies itself.
+std::string apply_after_script (CookieJar& jar,
+const std::string& scope,
+const std::string& script,
+const std::string& url,
+vayu::Environment& env) {
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request = get_request (url);
+    vayu::Response response;
+    std::vector<vayu::http::CookieWrite> writes;
+
+    vayu::runtime::ScriptContext ctx;
+    ctx.request       = &request;
+    ctx.response      = &response;
+    ctx.environment   = &env;
+    ctx.cookie_jar    = &jar;
+    ctx.cookie_scope  = scope;
+    ctx.cookie_writes = &writes;
+
+    const auto result = engine.execute (script, ctx);
+    jar.apply (scope, writes);
+    return result.error_message;
+}
+
+} // namespace
+
+TEST (CookieJarWrite, ACookieAScriptSetIsOnTheWireOfTheRequestItWasSetFor) {
+    // The write is staged, not applied where it is made - so this is also the
+    // test that it rides the transfer it was made before rather than only
+    // reaching the one after.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") + "', { name: 'session', value: 'written' });",
+    server.url ("/echo"), env);
+
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+    EXPECT_NE (sent.echoed.find ("session=written"), std::string::npos)
+    << "the cookie the script set did not go out; got: " << sent.echoed;
+
+    // And it survived the transfer's capture, so the next request has it too.
+    EXPECT_NE (send_in_scope (jar, "env_a", server.url ("/echo")).find ("session=written"),
+    std::string::npos)
+    << "the write did not survive the enclosing transfer's capture";
+}
+
+TEST (CookieJarWrite, TheFlatPostmanSpellingSetsTheSameCookie) {
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") + "', 'session', 'flat');",
+    server.url ("/echo"), env);
+
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+    EXPECT_NE (sent.echoed.find ("session=flat"), std::string::npos)
+    << "got: " << sent.echoed;
+}
+
+TEST (CookieJarWrite, AWrittenCookieIsMatchedByTheSameRulesAReceivedOneIs) {
+    // The write half must not be a way around the matching the read half
+    // respects - a cookie written for one host, path or scheme must not leak
+    // onto a request that does not match it.
+    CookieServer server;
+    vayu::Environment env;
+
+    CookieJar other_host;
+    const auto wrong_host = send_after_script (other_host,
+    "env_a", "pm.cookies.jar().set('https://example.com/', { name: 'session', value: 'x' });",
+    server.url ("/echo"), env);
+    ASSERT_TRUE (wrong_host.script_ok) << wrong_host.script_error;
+    EXPECT_EQ (wrong_host.echoed, "")
+    << "a cookie written for another host was sent: " << wrong_host.echoed;
+
+    CookieJar wrong_path_jar;
+    const auto wrong_path = send_after_script (wrong_path_jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") + "', { name: 'session', value: 'x', path: '/admin' });",
+    server.url ("/echo"), env);
+    ASSERT_TRUE (wrong_path.script_ok) << wrong_path.script_error;
+    EXPECT_EQ (wrong_path.echoed, "")
+    << "a cookie written for /admin was sent to /echo: " << wrong_path.echoed;
+}
+
+TEST (CookieJarWrite, ASecureFlagOnAWrittenCookieIsStoredAndHonouredByTheReadViews) {
+    // Asserted through the read views rather than the wire, because the wire
+    // cannot show it from a test: libcurl treats a loopback host as a
+    // trustworthy origin (RFC 6265bis §4.1.2.5), so it sends a Secure cookie
+    // to http://127.0.0.1 *by design*. What is testable here is that the flag
+    // survives the write at all - a set() that dropped it would produce a
+    // cookie that then goes to any cleartext host.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") + "', { name: 'session', value: 'x', secure: true });",
+    server.url ("/echo"), env);
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+
+    const auto held = vayu::http::routes::cookies_response (jar);
+    ASSERT_EQ (held["scopes"].size (), 1u);
+    ASSERT_EQ (held["scopes"][0]["cookies"].size (), 1u);
+    EXPECT_EQ (held["scopes"][0]["cookies"][0]["secure"], true)
+    << "the Secure flag did not survive the write";
+
+    // And the matcher behind pm.cookies refuses it over cleartext, exactly as
+    // it does for a received Secure cookie.
+    const std::string host = "127.0.0.1";
+    EXPECT_TRUE (jar.matching ("env_a", "http://" + host + "/").empty ());
+    EXPECT_FALSE (jar.matching ("env_a", "https://" + host + "/").empty ());
+}
+
+TEST (CookieJarWrite, AWriteSurvivesTheEnclosingTransfersCapture) {
+    // The ordering decision this whole surface turns on. `capture_jar_cookies`
+    // *replaces* the scope with what the finishing handle held, and /logout
+    // rewrites that list by expiring the session - a write applied into the
+    // live map beside the transfer would go with it.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    send_in_scope (jar, "env_a", server.url ("/login"));
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") + "', { name: 'kept', value: 'yes' });",
+    server.url ("/logout"), env);
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+
+    const std::string after = send_in_scope (jar, "env_a", server.url ("/echo"));
+    EXPECT_NE (after.find ("kept=yes"), std::string::npos)
+    << "the staged write was discarded by the transfer's capture; got: " << after;
+    EXPECT_EQ (after.find ("session="), std::string::npos)
+    << "the logout's expiry stopped working; got: " << after;
+}
+
+TEST (CookieJarWrite, SendRequestCarriesAWriteStagedBeforeIt) {
+    // The queue applies before an auxiliary transfer injects, so a login call
+    // made through pm.sendRequest after a set() carries what was set.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") +
+    "', { name: 'staged', value: 'first' });"
+    "pm.sendRequest('" +
+    server.url ("/echo") + "', function (err, res) { pm.environment.set('aux', res.text()); });",
+    server.url ("/echo"), env);
+
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+    EXPECT_NE (env["aux"].value.find ("staged=first"), std::string::npos)
+    << "the auxiliary transfer did not carry the staged write; got: "
+    << env["aux"].value;
+    // And it is not applied twice: the main request still has it, once.
+    EXPECT_NE (sent.echoed.find ("staged=first"), std::string::npos)
+    << "got: " << sent.echoed;
+}
+
+TEST (CookieJarWrite, ASetInsideASendRequestCallbackIsASequentialWrite) {
+    // pm.sendRequest is synchronous, so a callback runs *after* its transfer
+    // finished - a set() there cannot reach that transfer, and lands on the
+    // next one. Pinned rather than assumed, since the opposite reading is
+    // exactly what an async mental model would predict.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.sendRequest('" + server.url ("/echo") +
+    "', function (err, res) {"
+    "  pm.environment.set('aux', res.text());"
+    "  pm.cookies.jar().set('" +
+    server.url ("/") +
+    "', { name: 'late', value: 'yes' });"
+    "});",
+    server.url ("/echo"), env);
+
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+    EXPECT_EQ (env["aux"].value.find ("late=yes"), std::string::npos)
+    << "the callback's write reached the transfer it ran after: " << env["aux"].value;
+    EXPECT_NE (sent.echoed.find ("late=yes"), std::string::npos)
+    << "the callback's write did not reach the request that followed; got: "
+    << sent.echoed;
+}
+
+TEST (CookieJarWrite, AReadSeesThisScriptsOwnStagedWrite) {
+    // Otherwise `set` followed by `get` reports the value the write replaced,
+    // which reads as "the write did not happen".
+    CookieJar jar;
+    vayu::Environment env;
+
+    const std::string error = apply_after_script (jar, "env_a",
+    "pm.cookies.jar().set('http://example.com/', { name: 'session', value: "
+    "'fresh' });"
+    "pm.environment.set('jar_get', "
+    "String(pm.cookies.jar().get('http://example.com/', 'session')));"
+    "pm.environment.set('flat_get', String(pm.cookies.get('session')));",
+    "http://example.com/users", env);
+
+    EXPECT_TRUE (error.empty ()) << error;
+    EXPECT_EQ (env["jar_get"].value, "fresh");
+    EXPECT_EQ (env["flat_get"].value, "fresh")
+    << "the flat read half did not see the write staged beside it";
+}
+
+TEST (CookieJarWrite, UnsetRemovesOnlyWhatTheUrlWouldHaveCarried) {
+    CookieJar jar;
+    vayu::Environment env;
+    jar.store ("env_a",
+    { netscape_line ("example.com", "FALSE", "/", "FALSE",
+      std::to_string (FAR_FUTURE), "session", "here"),
+    netscape_line ("other.example.org", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "session", "elsewhere") });
+
+    const std::string error = apply_after_script (jar, "env_a",
+    "pm.cookies.jar().unset('http://example.com/', 'session');",
+    "http://example.com/users", env);
+    EXPECT_TRUE (error.empty ()) << error;
+
+    EXPECT_TRUE (jar.matching ("env_a", "http://example.com/users").empty ());
+    const auto elsewhere = jar.matching ("env_a", "http://other.example.org/users");
+    ASSERT_EQ (elsewhere.size (), 1u)
+    << "unset removed a cookie of the same name on another host";
+    EXPECT_EQ (elsewhere[0].value, "elsewhere");
+}
+
+TEST (CookieJarWrite, ClearEmptiesOnlyThisEnvironmentsJar) {
+    CookieJar jar;
+    vayu::Environment env;
+    const auto line = netscape_line ("example.com", "FALSE", "/", "FALSE",
+    std::to_string (FAR_FUTURE), "session", "abc");
+    jar.store ("env_a", { line });
+    jar.store ("env_b", { line });
+
+    const std::string error = apply_after_script (
+    jar, "env_a", "pm.cookies.jar().clear();", "http://example.com/users", env);
+    EXPECT_TRUE (error.empty ()) << error;
+
+    const auto scopes = jar.snapshot ();
+    ASSERT_EQ (scopes.size (), 1u)
+    << "clear() reached beyond its own environment";
+    ASSERT_TRUE (scopes[0].environment_id.has_value ());
+    EXPECT_EQ (*scopes[0].environment_id, "env_b");
+}
+
+TEST (CookieJarWrite, AWrittenCookieDoesNotCrossAnEnvironmentBoundary) {
+    // The isolation guarantee has to hold for written cookies too, or the
+    // write half becomes the way a staging session reaches production.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_staging",
+    "pm.cookies.jar().set('" + server.url ("/") + "', { name: 'session', value: 'staging' });",
+    server.url ("/echo"), env);
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+
+    EXPECT_EQ (send_in_scope (jar, "env_production", server.url ("/echo")), "")
+    << "a script-written cookie leaked out of its environment";
+}
+
+TEST (CookieJarWrite, AScriptWrittenCookieShowsUpInTheSettingsPanelsView) {
+    // The app needs no change for this - CookiesCard renders whatever
+    // GET /cookies reports - but "no change needed" is a claim worth pinning.
+    CookieServer server;
+    CookieJar jar;
+    vayu::Environment env;
+
+    const auto sent = send_after_script (jar, "env_a",
+    "pm.cookies.jar().set('" + server.url ("/") + "', { name: 'written', value: 'v', httpOnly: true });",
+    server.url ("/echo"), env);
+    ASSERT_TRUE (sent.script_ok) << sent.script_error;
+
+    const auto body = vayu::http::routes::cookies_response (jar);
+    ASSERT_EQ (body["scopes"].size (), 1u);
+    ASSERT_EQ (body["scopes"][0]["cookies"].size (), 1u);
+    EXPECT_EQ (body["scopes"][0]["cookies"][0]["name"], "written");
+    EXPECT_EQ (body["scopes"][0]["cookies"][0]["httpOnly"], true);
+}
+
+TEST (CookieJarWrite, BadInputIsRefusedLoudlyRatherThanStoredWrong) {
+    CookieJar jar;
+    vayu::Environment env;
+
+    struct Case {
+        const char* script;
+        const char* expected;
+    };
+    const Case cases[] = {
+        { "pm.cookies.jar().set('http://example.com/', { value: 'v' });", "name" },
+        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: 1 "
+          "});",
+        "value" },
+        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
+          "'v', secure: 'yes' });",
+        "true or false" },
+        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
+          "'v', expires: '2030' });",
+        "seconds since the epoch" },
+        // A tab is the Netscape line's own separator: stored, the cookie would
+        // be unreadable on the next parse and would simply vanish.
+        { "pm.cookies.jar().set('http://example.com/', { name: 'n', value: "
+          "'a\\tb' });",
+        "tab or newline" },
+        { "pm.cookies.jar().set('not a url', { name: 'n', value: 'v' });", "parseable" },
+        { "pm.cookies.jar().set();", "URL string" },
+        { "pm.cookies.jar().unset('http://example.com/');", "cookie name string" },
+        { "pm.cookies.jar().clear('nope');", "callback must be a function" },
+    };
+
+    for (const auto& one : cases) {
+        vayu::Environment scratch = env;
+        const std::string error   = apply_after_script (
+        jar, "env_a", one.script, "http://example.com/users", scratch);
+        EXPECT_NE (error.find (one.expected), std::string::npos)
+        << "script: " << one.script << "\ngot: " << error;
+    }
+    EXPECT_TRUE (jar.snapshot ().empty ())
+    << "a refused write was stored anyway";
+}
+
+TEST (CookieJarWrite, TheWriteHalfSaysWhyWhenThereIsNoJarAndWhenThereIsNowhereToApply) {
+    vayu::runtime::ScriptEngine engine;
+    vayu::Request request = get_request ("http://example.com/users");
+    vayu::Response response;
+    vayu::Environment env;
+
+    // A load run: no jar at all.
+    vayu::runtime::ScriptContext no_jar;
+    no_jar.request     = &request;
+    no_jar.response    = &response;
+    no_jar.environment = &env;
+    auto result        = engine.execute (
+    "pm.cookies.jar().set('http://example.com/', { name: 'n', value: 'v' });", no_jar);
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("design-mode"), std::string::npos)
+    << result.error_message;
+
+    // A jar, but a caller that never applies what is written to it - accepting
+    // the write would report success for a cookie that goes nowhere.
+    CookieJar jar;
+    vayu::runtime::ScriptContext no_sink;
+    no_sink.request     = &request;
+    no_sink.response    = &response;
+    no_sink.environment = &env;
+    no_sink.cookie_jar  = &jar;
+    result              = engine.execute (
+    "pm.cookies.jar().set('http://example.com/', { name: 'n', value: 'v' });", no_sink);
+    EXPECT_FALSE (result.success);
+    EXPECT_NE (result.error_message.find ("nowhere to apply"), std::string::npos)
+    << result.error_message;
+
+    // The read half of jar() needs no sink - it is a read.
+    result = engine.execute (
+    "pm.environment.set('r', "
+    "String(pm.cookies.jar().get('http://example.com/', 'n')));",
+    no_sink);
+    EXPECT_TRUE (result.success) << result.error_message;
+    EXPECT_EQ (env["r"].value, "undefined");
+}
+
+TEST (CookieJarWrite, TheCallbackIsInvokedAndItsThrowIsTheScriptsError) {
+    CookieJar jar;
+    vayu::Environment env;
+
+    const std::string ok = apply_after_script (jar, "env_a",
+    "pm.cookies.jar().set('http://example.com/', { name: 'n', value: 'v' },"
+    "  function (err) { pm.environment.set('err', String(err)); });"
+    "pm.cookies.jar().get('http://example.com/', 'n',"
+    "  function (err, value) { pm.environment.set('value', String(value)); });",
+    "http://example.com/users", env);
+    EXPECT_TRUE (ok.empty ()) << ok;
+    EXPECT_EQ (env["err"].value, "null") << "the callback was not invoked";
+    EXPECT_EQ (env["value"].value, "v");
+
+    const std::string threw = apply_after_script (jar,
+    "env_a", "pm.cookies.jar().clear(function () { throw new Error('from the callback'); });",
+    "http://example.com/users", env);
+    EXPECT_NE (threw.find ("from the callback"), std::string::npos)
+    << "a throwing callback was swallowed: " << threw;
+}
+
+// ============================================================================
+// The staged write, as a value - the pure half, without a transfer
+// ============================================================================
+
+TEST (CookieJarWriteValue, ADefaultedCookieTakesItsDomainAndPathFromTheUrl) {
+    const auto defaulted =
+    vayu::http::cookie_for_url ("https://api.example.com/v1/orders/42",
+    JarCookie{ "", false, "", false, false, 0, "session", "abc" });
+    ASSERT_TRUE (defaulted.has_value ());
+    EXPECT_EQ (defaulted->domain, "api.example.com");
+    EXPECT_FALSE (defaulted->include_subdomains)
+    << "a defaulted domain is host-only, as a Set-Cookie without Domain is";
+    // RFC 6265 §5.1.4 default-path: the URL's path minus its last segment.
+    EXPECT_EQ (defaulted->path, "/v1/orders");
+
+    // An explicit leading dot is libcurl's spelling of "subdomains too".
+    const auto explicit_domain =
+    vayu::http::cookie_for_url ("https://api.example.com/",
+    JarCookie{ ".example.com", false, "/", false, false, 0, "session", "abc" });
+    ASSERT_TRUE (explicit_domain.has_value ());
+    EXPECT_TRUE (explicit_domain->include_subdomains);
+
+    // A round trip through the line is the point of formatting one: a written
+    // cookie and a received one must be the same kind of thing.
+    const auto round_tripped =
+    parse_cookie_line (vayu::http::format_cookie_line (*defaulted));
+    ASSERT_TRUE (round_tripped.has_value ());
+    EXPECT_EQ (round_tripped->domain, "api.example.com");
+    EXPECT_EQ (round_tripped->path, "/v1/orders");
+    EXPECT_EQ (round_tripped->value, "abc");
+}
+
+TEST (CookieJarWriteValue, ASecondWriteOfTheSameNameDomainAndPathReplaces) {
+    const auto line_for = [] (const std::string& path, const std::string& value) {
+        return vayu::http::format_cookie_line (
+        JarCookie{ "example.com", false, path, false, false, 0, "session", value });
+    };
+
+    std::vector<std::string> lines = { line_for ("/", "first") };
+    lines = vayu::http::apply_cookie_writes (std::move (lines),
+    { { vayu::http::CookieWrite::Kind::Set, line_for ("/", "second"), {}, {} } });
+    ASSERT_EQ (lines.size (), 1u) << "the same cookie was stored twice";
+    EXPECT_NE (lines[0].find ("second"), std::string::npos);
+
+    // A different path is a different cookie (RFC 6265 §5.3), so it is added.
+    lines = vayu::http::apply_cookie_writes (std::move (lines),
+    { { vayu::http::CookieWrite::Kind::Set, line_for ("/admin", "third"), {}, {} } });
+    EXPECT_EQ (lines.size (), 2u);
+
+    // And clear takes everything in the scope, in order with what came before.
+    lines = vayu::http::apply_cookie_writes (std::move (lines),
+    { { vayu::http::CookieWrite::Kind::Clear, {}, {}, {} },
+    { vayu::http::CookieWrite::Kind::Set, line_for ("/", "after"), {}, {} } });
+    ASSERT_EQ (lines.size (), 1u);
+    EXPECT_NE (lines[0].find ("after"), std::string::npos);
+}
+
+// ============================================================================
 // GET /cookies and DELETE /cookies - what Settings shows and clears
 // ============================================================================
 

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -252,6 +252,26 @@ TEST (ScriptCompletions, EveryOfferedCookieMemberIsCallableInTheRuntime) {
     EXPECT_GE (offered, 6) << "the cookie accessors are missing from the completion list";
 }
 
+// The guard above is offered-implies-callable only, so a method the runtime
+// binds and the list forgets fails nothing there - which is how the write half
+// could ship invisible to every user who discovers the API through completions.
+// These are the entries #337 requires, named.
+TEST (ScriptCompletions, TheCookieJarsWriteHalfIsOffered) {
+    const auto completions = get_script_completions ();
+
+    std::vector<std::string> labels;
+    for (const auto& item : completions) {
+        labels.push_back (item.value ("label", std::string{}));
+    }
+    ASSERT_FALSE (labels.empty ());
+
+    for (const char* expected : { "pm.cookies.jar", "pm.cookies.jar().get",
+         "pm.cookies.jar().set", "pm.cookies.jar().unset", "pm.cookies.jar().clear" }) {
+        EXPECT_NE (std::find (labels.begin (), labels.end (), expected), labels.end ())
+        << expected << " is bound by the runtime but not offered";
+    }
+}
+
 // The same drift, on the variable scopes: `pm.variables` was offered by
 // `scripting.md` for months while the runtime had no such object, and every
 // scope method added in #184 is invisible in the editor until it is listed


### PR DESCRIPTION
## Description

The jar could be read but not written to. This ships Postman's `pm.cookies.jar()` whole - `get` / `set` / `unset` / `clear` - per the three decisions recorded on #337.

**The plan.** The root cause is not a missing binding, it is the ordering: `capture_jar_cookies` **replaces** a scope's contents with what the finishing handle held (`client.cpp`), so a write dropped into the live map beside an in-flight transfer is discarded by it. So a write is *staged* rather than applied where it is made - `jar().set` pushes a `CookieWrite`, and the execution's next transfer applies the staged list on top of the stored lines when it seeds its handle (`ClientConfig::cookie_writes`). The write therefore rides the request it was made before, and that transfer's own capture is what persists it; a write with no transfer left to ride (a post-request script's) is applied by the route through `CookieJar::apply`. Exactly once either way. **The alternative I rejected** was the simpler "route applies the writes after `client.send()` returns": it is one line shorter, but the write then does not ride the request it was made for (a pre-request `set` would not be on that request's wire, which is what a Postman user expects), and a staged `clear()` would be applied twice - once by the transfer's capture and again afterwards - wiping the cookies the response had just set.

**The `pm.sendRequest` non-case**, stated so the next reader does not re-derive it: `pm.sendRequest` is synchronous (PR #309), so a script cannot write *during* an auxiliary transfer. It drains the queue into that transfer, which is why a `set` before it is carried by it, and a `set` inside its callback is a sequential write that lands on the next transfer instead. Both are pinned by tests rather than left emergent.

**Shape.** No flat `pm.cookies.set(name, value)` - a written cookie needs a URL to take its domain and path from, which is why Postman's write half hangs off `jar()`. `set(url, name, value)` *is* accepted alongside `set(url, cookie)` because both are URL-scoped and it is the spelling half of Postman's own docs use; the property decision 1 required is preserved. `cookie_for_url` + `format_cookie_line` build the Netscape line beside `parse_cookie_line`, so a written cookie and a received one are the same kind of thing.

Deviations from the issue text, both deliberate:

- **`jar()` itself does not throw where there is no jar.** It is an accessor; the sentence explaining the absence belongs on the method the script actually called. This also keeps `typeof pm.cookies.jar().set` answerable, which is what lets the existing offered-implies-callable completions guard cover the new methods for free.
- **The Secure case is asserted through the read views, not the wire.** libcurl treats a loopback host as a trustworthy origin (RFC 6265bis §4.1.2.5), so it sends a `Secure` cookie to `http://127.0.0.1` by design and no local test can show otherwise. The test asserts the flag survives the write and that the matcher behind `pm.cookies` refuses it over cleartext, with the reason in a comment.

**Robustness.** Bad input is refused with an error naming the field rather than stored wrong: a non-string `value`, `secure: "yes"`, a date string in `expires`, an unparseable URL, or a field carrying a tab or newline - the Netscape format's own separators, which would corrupt the line and make the cookie vanish on the next read. `clear()` is scoped to the current environment's jar (decision 2).

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **910/910 passed** on the merged tree (891 on the current base `1d7b6c0`; 19 new). No pre-existing failures.

New coverage in `cookie_jar_test.cpp` (16 wire/script tests, 2 pure-value tests) and `script_completions_test.cpp` (1):

- A `jar().set` is on the wire of the request it was set for, survives that transfer's capture, and appears in the raw-request view.
- It is **not** sent to the wrong host or the wrong path; the `Secure` flag survives the write and the read views honour it.
- The ordering itself: a write staged before a transfer whose response rewrites the whole jar (a `/logout` expiry) still survives.
- `pm.sendRequest` carries a write staged before it; a `set` inside its callback does not reach that transfer and does reach the next one.
- A read - both `jar().get` and the flat `pm.cookies.get` - sees this script's own staged write.
- `unset` removes only what the URL would have carried; `clear` empties only this environment's jar; a written cookie does not cross an environment boundary.
- Nine bad-input cases, each asserting the message names the problem, plus "no jar" and "nowhere to apply" both saying why.
- A script-written cookie appears in `GET /cookies`, which is what makes "no app change" a checked claim rather than an assumption.
- The four new completion entries are asserted by name - the existing guard is offered-implies-callable only, so forgetting them would have failed nothing.

**Mutation-checked**, both directions of the ordering: reverting the transfer's application of staged writes reddens 7 tests; reverting the `pm.sendRequest` drain and the staged-read view reddens 3 more. Restored and re-run green.

`mkdocs build --strict -f .github/mkdocs.yml` clean. `clang-format` clean on every file that was clean at the base commit, and unchanged-in-count on the four that were not (formatted my added lines only, per the repo's no-repo-wide-formatting rule).

**The app suite was not run**: no file under `app/` is touched by this branch and no renderer expectation moves, so no test there could change colour.

## Merge with master

Master moved while this was open (#345, #346, #347 all landed). Merged in: the only conflict was the Cookie Jar section of `docs/engine/architecture.md`, which #347 also extended. Both bullets belong, so both are kept - and since #347 makes the raw-request view read the transfer's own header frame, a script-written cookie now shows up there too. That is asserted rather than left as a doc claim. `client.cpp` merged cleanly: #347's wire capture and this branch's staged-write injection are different parts of the send path.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/scripting.md` (the read-only paragraph rewritten, plus a "Writing to the jar" section covering the field defaults, the refusals, when a write takes effect and the `clear()` policy), `docs/app/pm-api-compatibility.md` (moved out of "Not (yet) supported", with the four divergences from Postman named), and `docs/engine/architecture.md` (the Cookie Jar section's threading/write story).

## Related Issues
Closes #337


---
_Generated by [Claude Code](https://claude.ai/code/session_01JDXiPXGaip7yQJVipoMeD8)_