### PR TITLE
fix(app): make Home/End follow the resize handle's declared bounds, not its side

### DIFF
--- a/app/src/components/layout/PanelResizeHandle.test.tsx
+++ b/app/src/components/layout/PanelResizeHandle.test.tsx
@@ -79,13 +79,26 @@ describe("PanelResizeHandle", () => {
 		expect(setWidth).toHaveBeenLastCalledWith(236);
 	});
 
-	it("sends Home and End to the bounds, which the store clamps", () => {
-		const { setWidth, handle } = setup("right");
-		fireEvent.keyDown(handle, { key: "Home" });
-		expect(setWidth).toHaveBeenCalledWith(-Infinity);
-		fireEvent.keyDown(handle, { key: "End" });
-		expect(setWidth).toHaveBeenLastCalledWith(Infinity);
-	});
+	// Home and End are absolute against the declared value model, not spatial like
+	// the arrows - so unlike the arrow cases above they must agree on both sides.
+	// Pinning only `side="right"` is how the inverted mapping shipped green: there
+	// the spatial and the absolute reading happen to coincide.
+	it.each(["right", "left"] as const)(
+		"sends Home to the min it announces and End to the max, on a %s-edge handle",
+		(side) => {
+			const { setWidth, handle } = setup(side);
+			// Read the bounds off the element rather than the constants: the defect
+			// was the keys disagreeing with the model the handle announces, so the
+			// announcement is what the assertion has to be anchored to.
+			expect(handle).toHaveAttribute("aria-valuemin", String(PANEL_MIN_WIDTH));
+			expect(handle).toHaveAttribute("aria-valuemax", String(PANEL_MAX_WIDTH));
+
+			fireEvent.keyDown(handle, { key: "Home" });
+			expect(setWidth).toHaveBeenCalledWith(Number(handle.getAttribute("aria-valuemin")));
+			fireEvent.keyDown(handle, { key: "End" });
+			expect(setWidth).toHaveBeenLastCalledWith(Number(handle.getAttribute("aria-valuemax")));
+		}
+	);
 
 	it("resets on Enter and Space - the double-click had no keyboard route", () => {
 		const { setWidth, handle } = setup("right");

--- a/app/src/components/layout/PanelResizeHandle.tsx
+++ b/app/src/components/layout/PanelResizeHandle.tsx
@@ -23,6 +23,9 @@
  * its right edge, so ArrowRight widens it; the context bar's sits on its left,
  * so ArrowLeft widens. Getting this from the prop rather than a second component
  * is the whole reason for sharing.
+ *
+ * It governs the *spatial* keys only. Home and End name a point in the value
+ * model the handle announces, so they land on the same bound from either side.
  */
 
 import { PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from "@/constants/layout";
@@ -72,11 +75,20 @@ export function PanelResizeHandle({
 	};
 
 	const onKeyDown = (e: React.KeyboardEvent) => {
+		// Arrows and Page keys are spatial: the direction they move the pointer is
+		// the direction the edge travels, so they follow `grow`.
 		const nudge = (delta: number) => {
 			e.preventDefault();
-			// The store clamps to PANEL_MIN_WIDTH / PANEL_MAX_WIDTH, so ±Infinity
-			// from Home and End needs no special case here.
 			setWidth(width + delta * grow);
+		};
+
+		// Home and End are absolute against the value model this handle declares
+		// (`aria-valuemin`/`max`), so they must NOT follow `grow` - on the context
+		// bar's left-side handle that inverted them, and a screen reader hearing
+		// "min 220, max 480" announced Home as the minimum while it jumped to 480.
+		const jumpTo = (target: number) => {
+			e.preventDefault();
+			setWidth(target);
 		};
 
 		switch (e.key) {
@@ -89,9 +101,9 @@ export function PanelResizeHandle({
 			case "PageDown":
 				return nudge(-PAGE_STEP);
 			case "Home":
-				return nudge(-Infinity);
+				return jumpTo(PANEL_MIN_WIDTH);
 			case "End":
-				return nudge(Infinity);
+				return jumpTo(PANEL_MAX_WIDTH);
 			case "Enter":
 			case " ":
 				// The keyboard equivalent of the double-click reset, which was


### PR DESCRIPTION
## Description

`PanelResizeHandle` declares an ARIA slider value model (`aria-valuenow`/`min`/`max`) and implemented Home/End as `±Infinity` nudges multiplied by the side's `grow` factor. `grow` is `-1` for `side="left"`, so on the context bar's handle the two keys inverted the announced model: a screen-reader user hearing "value 300, min 220, max 480" pressed **Home and landed on 480**.

**Plan.** The root cause is one category error - the handler treats all six movement keys as the same kind of key, when they are two kinds. Arrows and Page keys are *spatial* (left arrow widens a left-edge panel) and correctly follow `grow`; Home and End name a point in the *value model the element announces*, which has no side. So the fix splits the one `nudge` helper into `nudge` (spatial, still `grow`-multiplied) and `jumpTo` (absolute), and Home/End call `jumpTo(PANEL_MIN_WIDTH)` / `jumpTo(PANEL_MAX_WIDTH)`. The alternative rejected was keeping the single helper and passing `grow`-corrected infinities (`nudge(-Infinity * grow)`) - it produces the same widths today while leaving the two key classes indistinguishable in the code, so the next absolute key added to the switch re-earns the bug. `side="right"` is unchanged observationally; the store clamp that previously normalized the infinities is untouched and still guards drag and arrow input.

Verified against current `master` (`6d6d0e5`) before editing - the defect is present exactly as the issue describes, at `PanelResizeHandle.tsx:91` with `grow` at `:56`. Blast radius traced: the component has exactly two consumers, `Drawer.tsx:48` (`side="right"`) and `ContextBar.tsx:276` (`side="left"`), both passing the layout-store's clamped setters (`layout-store.ts:67,72`); no other reader of the handle exists.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint` - all green, plus a format check on the two touched files.

- **`pnpm test`: 296 files, 2715 tests passed.** No pre-existing failures on this base.
- **`pnpm type-check`** and **`pnpm lint`** (zero warnings) clean; `prettier --check` clean on the two files this PR touches (nothing else formatted).

The existing Home/End case pinned `side="right"` only - where the spatial and the absolute reading happen to coincide - which is precisely how the inversion shipped green. It is now an `it.each` over both sides, and it asserts against the bounds the element *announces* (`aria-valuemin`/`max` read off the node) rather than against the imported constants, since the defect was the keys disagreeing with the announcement. The two arrow tests are untouched and still pin the spatial behaviour on both sides.

Mutation-checked: restoring the `grow`-multiplied `±Infinity` nudge reddens both new cases (`expected "vi.fn()" to be called with arguments: [ 220 ]`) and nothing else - 2 failed, 8 passed in that file.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

No docs change, as the issue asked me to confirm: `rg PanelResizeHandle docs/` returns nothing, and `docs/design-system.md`'s "Layout Structure" section (line 1343) describes the Shell's separate `useResizable` sidebar handle, not this component - no keymap for it is documented anywhere, and no value moved.

## Related Issues
Closes #343

---
_Generated by [Claude Code](https://claude.ai/code/session_0117faZrA8u5NDdz76AS7zw1)_