### PR TITLE
docs(plans): decide the collection runner / scenario primitive, design-first

### DIFF
--- a/.github/mkdocs.yml
+++ b/.github/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
   - Design Notes:
       - Request Storage: request-storage-design.md
       - Lock Files: lock-file-handling.md
+      - Collection Runner: plans/collection-runner-design.md
       - Deferred Work: plans/pending-backlog.md
 
 markdown_extensions:

--- a/docs/plans/collection-runner-design.md
+++ b/docs/plans/collection-runner-design.md
@@ -1,0 +1,445 @@
+# Collection Runner / Scenario Primitive - Design
+
+**Status:** approved design, not yet implemented.
+**Tracks:** issue #340. Flow control (`pm.execution`, `pm.iterationData`) is #303.
+**Anchors verified at master `d5899bb` (2026-08-07).**
+
+Vayu's product target is the Postman + JMeter + k6 combination. The single
+largest capability gap against that target, on both halves at once, is an
+engine-side **ordered-sequence primitive**: Postman's collection run, and the
+multi-step sequence a k6 virtual user repeats. This document is the design
+decision for that primitive, made once, before any code.
+
+Every section below states a **decision** and the alternative it declines. Where
+a decision constrains something that is not being built yet - load-mode
+scenarios, stored scenario entities - it says so explicitly, because the point of
+designing first is that mode 1 must not be built in a way mode 2 has to undo.
+
+---
+
+## 1. Why Vayu has nothing today
+
+Two things look like runners and are not:
+
+- **`run_collection_smoke`** is a **client-side TypeScript loop** over
+  independent `POST /execute` calls (the smoke handler in
+  `app/electron/mcp/tools.ts`; composition described at `docs/engine/mcp.md`).
+  The engine sees N unrelated design-mode executes and holds no object that
+  contains them, so a script running inside execute #3 has nothing to say about
+  execute #4 and nowhere to put the instruction.
+- **Load runs repeat a single composed request**
+  (`engine/src/core/run_manager.cpp`, `execute_load_test`). Test scripts there
+  run **deferred, once per sampled response, after the run finishes**
+  (`validate_scripts`, `run_manager.cpp:55`, called at `:747`), so even the
+  ordering that exists is not something a script participates in.
+
+So "log in, then browse, then check out" - the workflow that makes a collection
+more than a folder tree, and the unit a serious load evaluation reaches for
+first - cannot be expressed at all.
+
+---
+
+## 2. The sequence model
+
+### Decision 2.1 - a scenario is a folder-derived ordered sequence, resolved once into an immutable plan
+
+A **scenario** is not a new stored entity. It is a *resolution* of an existing
+one: a collection (folder), its direct requests ordered by `requests.order`,
+optionally including descendant collections ordered by `collections.order`,
+depth-first.
+
+At run start the engine resolves that into a **`ScenarioPlan`**: an ordered,
+immutable vector of **fully composed steps**. Each step is the exact payload
+`POST /execute` accepts - `{{variables}}` substituted, `inherit` auth walked and
+applied, the ordered script-part lists from the collection chain plus the
+request's own - produced by the composition the engine already owns
+(`compose_request_core`, `engine/src/http/request_composer.cpp:454`).
+
+```
+ScenarioStep {
+  index          size_t          // position in the plan, stable for the run
+  request_id     string          // the stored request this came from
+  name           string          // requests.name, the setNextRequest target
+  request        vayu::Request   // composed, execute-ready
+  pre_script     string          // joined parts (script_parts.cpp::read_script)
+  post_script    string          // joined parts
+}
+ScenarioPlan { vector<ScenarioStep> steps; ... }
+```
+
+**Why folder-derived rather than a `scenarios` table.** The collection tree with
+its `order` columns *already is* an ordered sequence. A parallel `scenarios`
+table would be a second source of truth for that ordering, needing its own
+answer to "a request in this scenario was deleted" and its own reconciliation on
+every collection edit. This repo's most repeated defect is state one layer
+records and another re-derives; a scenario entity in v1 would be exactly that,
+bought before anyone has asked for the thing it enables.
+
+**Declined: a first-class `scenarios` table (v1).** It becomes necessary the
+moment a user wants a sequence that is *not* a folder - steps drawn from several
+folders, one request appearing twice, a step disabled for one scenario but not
+another. The design must not preclude it, and does not: the run payload carries
+a `source` discriminator, and plan resolution is the seam.
+
+```jsonc
+"scenario": {
+  "source": "collection",          // the only value in v1
+  "collectionId": "col_...",
+  "recursive": false,              // descend into sub-collections
+  "iterations": 1,
+  "data": [ { "user": "a" }, ... ] // optional; see 2.3
+}
+```
+
+A future stored scenario is `{"source": "stored", "scenarioId": "scn_..."}` and
+resolves to the same `ScenarioPlan`. Nothing downstream of resolution changes.
+
+### Decision 2.2 - the plan is resolved exactly once, before the first send
+
+No step is composed lazily, and no execution path touches SQLite for request
+data after resolution. Two reasons, and the second is the load-bearing one:
+
+- A collection edited mid-run would otherwise change the sequence underneath
+  itself. A run is a record of what ran; it must be resolvable to one answer.
+- **Load mode cannot query SQLite per step per virtual user.** The plan being
+  fully composed up front is what makes decision 5 possible at all. Resolving
+  lazily in mode 1 would be a stopgap mode 2 has to undo.
+
+Resolution failures are loud and pre-run: an empty collection, a step whose
+composition fails, a plan exceeding `maxScenarioSteps` - all `400` with the
+offending request named, before any `runs` row exists. This matches the existing
+`POST /runs` discipline, where `validate_run_config` and
+`normalize_run_http_version` both run before `create_run`
+(`engine/src/http/routes/execution.cpp`).
+
+### Decision 2.3 - an iteration is one full pass over the plan; data rows come in on the payload
+
+`iterations` (default `1`) is how many times the plan is executed end to end.
+
+`data` is an **inline JSON array of objects** on the run payload. Row `i % rows`
+binds to iteration `i` as `pm.iterationData`. When `data` is present and
+`iterations` is absent, `iterations` defaults to the row count - the Postman
+default. When both are given, the explicit count wins and the row index wraps;
+the wrap is **not silent**, because every per-iteration record carries its
+`dataRowIndex` and `pm.info.iteration`. An empty `data` array is a `400`: a data
+set that binds nothing is a mistake, not an empty run.
+
+**Declined: the engine reading a data file from disk.** The script sandbox has
+no filesystem access by design, and giving the daemon a user-supplied path is a
+new trust boundary (traversal, arbitrary reads) bought for a parsing job the app
+already does well - it owns the Postman/Insomnia/OpenAPI import parsers. The app
+picks the file, parses CSV/JSON, and sends rows. The cost is payload size, which
+is why `maxScenarioDataRows` and a payload byte cap exist (5.4).
+
+---
+
+## 3. The execution model - design mode
+
+### Decision 3.1 - a scenario run is a third `runs.type`, not a design run
+
+`runs.type` gains `"scenario"` beside `"design"` and `"load"`.
+
+It cannot reuse `"design"`: **a design run has exactly one `results` row**, and
+`GET /runs/:runId` serves it as `result` on that assumption
+(`docs/engine/db-schema.md`, `results`). A scenario run has one row per step
+execution. Overloading `design` would break a documented reader - the exact
+"written but never read" inverse this repo keeps finding.
+
+### Decision 3.2 - asynchronous, run-record-backed, SSE-streamed - same lifecycle as a load run
+
+`POST /runs` accepts a `scenario` block and answers `202 { runId }`, exactly as a
+load run does. The run gets a worker thread from `RunManager::start_run`, is
+registered/retained/swept by the existing machinery, streams over
+`GET /runs/:runId/live`, stops through the existing stop path, and reports
+through `GET /runs/:runId/report`.
+
+**Declined: a synchronous `POST /scenarios/run`.** A 50-request folder takes as
+long as its requests added together - `run_collection_smoke`'s own description
+says so - and holding a cpp-httplib worker thread for minutes is not viable. A
+second async endpoint would need its own copy of stop, retention, SSE resume and
+the `DELETE /runs/:id` cascade; there is no second lifecycle here, only a second
+executor.
+
+The live stream gains a `step` event beside `metrics`, carrying
+`{iteration, stepIndex, name, outcome, statusCode, latencyMs}`. It rides the
+existing bounded tick ring (`RunContext::append_tick`) and its monotonic
+`id:` numbering, so `Last-Event-ID` resume works unchanged.
+
+### Decision 3.3 - steps execute sequentially through `http::Client`, not the event loop
+
+The design-mode runner is, per iteration, per step:
+
+```
+compose (already done at plan time)
+  -> pre-request script   (ScriptContext::for_prerequest, pm.request writes back)
+  -> Client::send         (through the environment cookie jar)
+  -> post-request script  (ScriptContext::for_test)
+  -> record step result
+  -> apply flow control   (section 4)
+```
+
+That is the `POST /execute` handler's body, lifted. It must be `http::Client`
+and not `EventLoop`, because design-mode fidelity needs the cookie jar and
+inline per-step scripts, and the event loop deliberately has neither ("Not on
+the load path", `engine/include/vayu/http/cookie_jar.hpp`).
+
+**This is the point where the two modes diverge, and the divergence is the
+design.** The *plan* is shared; the *executor* is not. Section 5 specifies mode
+2's executor against the same plan.
+
+### Decision 3.4 - state flows between steps through the scopes that already exist
+
+- **Variables.** The environment / globals / collection scopes are loaded once
+  at run start (`load_script_variable_scopes`), mutated in memory by every
+  step's scripts across every iteration, and persisted **once at run end**
+  through the existing diff-based `persist_script_variables`. This is what makes
+  "step 1 logs in and `pm.environment.set`s the token, step 2 sends it" work.
+  Persisting per step would be N x M diff-and-write cycles against the DB mutex
+  for a value only the run's own later steps read.
+- **Cookies.** The existing per-environment jar, scope = `environmentId`,
+  unchanged. It was already scoped this way partly for this feature, and it
+  already gives "log in once, reuse the session" for free.
+- **Nothing else.** There is no scenario-scoped variable bag. A fourth scope
+  would need precedence rules, a persistence story and a UI, to hold what the
+  environment scope already holds for the run's lifetime.
+
+### Decision 3.5 - `pm.info` gains `iteration` / `iterationCount`, set only by the runner
+
+`ScriptContext` gains two optional fields. The scenario runner sets them; every
+other caller leaves them unset and they reach the script as `undefined`.
+
+This does **not** reopen #300. That issue's ruling stands verbatim: a load run's
+`tests` script runs once per *sampled* response, and a reservoir sample index
+reported as an iteration number would be a binding that cannot fail. A scenario
+run has a real iteration index, so it reports one; `validate_scripts` still
+sets neither. The `ScriptContext` comment recording #300's rationale is kept and
+extended rather than replaced.
+
+### Decision 3.6 - one `results` row per step execution, bounded
+
+Each step execution writes a `results` row with the design-mode `trace_data`
+subset (the one `restore-response.ts` already restores from), plus
+`iteration`, `stepIndex`, `stepName`, `requestId`, `outcome`.
+
+Bodies are capped by the existing `maxTraceBodyBytes`. The **row count** is
+bounded by a new `maxScenarioStoredSteps` (default 5,000), and the bound is
+biased the way `maxStoredErrors` is: **every failed and every skipped step is
+kept first**, successes are sampled into what remains, and what was thinned is
+disclosed in the summary the way `SamplingRetention` already discloses it.
+`Database::get_results` loads every row of a run with no limit and the report
+parses each `trace_data`, so an unbounded 200-step x 500-iteration run would
+make the report path quadratic in a way the dashboard polls.
+
+### Decision 3.7 - the stored snapshot carries a step manifest, never the composed plan
+
+`runs.config_snapshot` holds the scenario *request* (`source`, `collectionId`,
+`recursive`, `iterations`, row count) plus a manifest of
+`{index, requestId, name, method, url}` per step - where `url` is the **stored,
+uncomposed** URL from the request row.
+
+The composed plan is credential-grade: it carries resolved `Authorization`
+headers, and an `apikey` auth with `in: "query"` puts a live key in the composed
+URL. `sanitize_config_snapshot` already reduces a run's `auth` object to
+`{mode}` for exactly this reason; persisting a composed plan would route around
+that allowlist. The full plan lives in memory for the run's life and nowhere
+else.
+
+`data` rows are **not** snapshotted either - they are user data of unknown
+sensitivity, and the manifest records only the row count.
+
+---
+
+## 4. Flow control as a value, not a side effect
+
+### Decision 4.1 - `ScriptResult` carries the intent; the runner decides
+
+```cpp
+struct ScriptControl {
+    enum class Kind { None, Next, Skip, EndIteration };
+    Kind kind = Kind::None;
+    std::string target;   // request name, for Kind::Next
+};
+// ScriptResult gains: ScriptControl control;
+```
+
+`pm.execution.setNextRequest(name)` and `pm.execution.skipRequest()` **record**
+an intent on the result. They reach into nothing. `ScriptResult`
+(`engine/include/vayu/types.hpp:515`) is already the channel a script speaks to
+its caller through, and the caller is the only thing that knows what a sequence
+is. This is the channel #303 prescribed and it is honoured here unchanged.
+
+Last call wins within one script, which is Postman's behaviour.
+
+### Decision 4.2 - `pm.execution` throws where there is no sequence
+
+`ScriptContext` gains `bool in_scenario`, set only by the scenario runner. With
+it false - a `POST /execute` send, a load run's deferred `tests` script - both
+methods **throw** a sentence naming why, rather than accepting a call and doing
+nothing.
+
+A binding that cannot fail is worse than a missing one (#188's standing rule).
+`setNextRequest("checkout")` silently ignored in a single send is precisely the
+false-success that rule exists to prevent.
+
+### Decision 4.3 - every ambiguous or unbounded case fails loudly
+
+| Case | Behaviour |
+|------|-----------|
+| `setNextRequest(name)` naming no step in the plan | Step fails with a named error; iteration ends |
+| `setNextRequest(name)` naming a **duplicated** step name | Step fails - ambiguous target, both indices named. Resolution records the duplicate set at plan time, so the error can be precise |
+| `setNextRequest(null)` | `Kind::EndIteration` - ends this iteration, continues to the next. Postman's convention |
+| `skipRequest()` in a **pre-request** script | This step is skipped; `outcome: "skipped"` |
+| `skipRequest()` in a **test** script | Error - the request has already gone out, there is nothing left to skip |
+| A `setNextRequest` cycle | Bounded by `maxStepsPerIteration` (default `10 x steps`, floor 100). Exceeding it fails the iteration with the cycle's step names |
+
+The cycle bound is not optional. `setNextRequest` makes an infinite loop a
+two-line script, and Postman's runner simply runs forever.
+
+### Decision 4.4 - skipped is never passed
+
+A step's `outcome` is one of `passed | failed | skipped | errored`, counted
+separately everywhere: the step result row, the SSE `step` event, the run
+summary, and the app's step list. `run_collection_smoke`'s matrix already
+carries a distinct `skipped` count and must keep it.
+
+A skipped request counted as a pass is the false-pass class #180 exists to
+eliminate, and #303 names this explicitly as a condition of its acceptance.
+
+---
+
+## 5. The load-mode convergence path
+
+Not built first. Designed now, so mode 1's structures need no rework.
+
+### Decision 5.1 - the plan is shared; the executor is a per-virtual-user state machine
+
+A scenario load run does not spawn a thread per virtual user. A **VU** is a
+small value:
+
+```
+VirtualUser { const ScenarioPlan* plan; size_t step; size_t iteration;
+              VariableOverlay vars; CookieState cookies; }
+```
+
+`concurrency` becomes **the number of virtual users** - which is what k6 and
+JMeter mean by it anyway. On each completion, the existing per-completion
+callback (`handle_result`, `engine/src/core/load_strategy.cpp`) advances that
+VU's state machine and submits its next step to the same worker.
+
+This is the existing closed-loop controller with one substitution: the
+`maintain_concurrency` refill (`load_strategy.cpp:249`) issues "the next step of
+VU *k*" instead of "another copy of the one request". The pure
+`compute_refill_deficit` primitive, the SPSC submission path and the
+single-producer discipline are all unchanged.
+
+### Decision 5.2 - per-VU cookie state, never the shared jar
+
+Each VU owns a private cookie list, empty at the start of each iteration. The
+environment jar is not touched.
+
+This *strengthens* the existing constraint rather than fighting it: a shared jar
+across workers is either a lock on the 60k-RPS hot path or per-worker jars that
+do not actually share (`cookie_jar.hpp`). It is also the semantically correct
+answer - 1,000 VUs are 1,000 users, and one session shared between them is not
+the thing being measured.
+
+### Decision 5.3 - scripts stay deferred and sampled in load mode, and flow control is unavailable there
+
+Load-mode scripts keep the existing `validate_scripts` discipline - deferred,
+run against sampled responses after the run - extended only by being keyed
+**per step index** rather than per run. Running QuickJS inline per step at
+60k RPS is not viable, and that architecture is documented, load-bearing, and
+out of scope for this design.
+
+The consequence is stated rather than hidden: **`pm.execution` throws in a load
+run** (decision 4.2 already covers it, since `in_scenario` is false for a
+deferred script). A script that has already run against a recorded response
+cannot redirect a sequence that already happened. Flow control is a design-mode
+capability.
+
+**Declined: inline scripts in load mode.** The escape hatch, if it is ever
+wanted, is a bounded pool of QuickJS contexts per worker evaluated only for
+iterations the sampler already selected - real work, its own benchmark, and its
+own issue. Naming it here is what keeps it from being smuggled in as a side
+effect of this feature.
+
+### Decision 5.4 - scenario load runs are closed-loop only, with bounded per-step metrics
+
+- **Modes:** `constant_concurrency`, `ramp_up`, `iterations`. `constant_rps` is
+  **out** for scenarios - an open-loop arrival rate over a multi-step sequence
+  is k6's arrival-rate executor, a named non-goal (section 6).
+- **`maxInFlight` is moot for scenario runs.** In-flight is bounded by the VU
+  count by construction, so `concurrency` is the only knob. This is a
+  coordination point with **#197**, which re-tunes `workers`, the per-host
+  budget and the `maxInFlight` default: #197's `maxInFlight` formula work does
+  not apply to scenario runs and should not be generalised over them.
+- **Per-step metrics:** one latency histogram per step, allocated once from the
+  plan's step count, plus the existing whole-run aggregate as the scenario
+  total. An HdrHistogram is not free, which is why `maxScenarioSteps` (default
+  200) bounds the plan in both modes.
+
+### New config keys this design introduces
+
+| Key | Default | Bounds |
+|-----|---------|--------|
+| `maxScenarioSteps` | 200 | Plan size, both modes. Also bounds per-step histograms |
+| `maxScenarioDataRows` | 1,000 | Inline `data` rows per run |
+| `maxScenarioStoredSteps` | 5,000 | `results` rows per scenario run (failures kept first) |
+| `maxStepsPerIteration` | `10 x steps`, floor 100 | `setNextRequest` cycle bound |
+
+---
+
+## 6. Explicit non-goals
+
+Named so the design has a boundary, and so none of them arrives sideways:
+
+- **JMeter's logic-controller zoo** - if/while/switch/loop/interleave
+  controllers. `setNextRequest` covers the workflows people actually build.
+- **k6's open-model / arrival-rate executors for scenarios** (5.4).
+- **Distributed load.**
+- **The engine reading data files from disk** (2.3).
+- **Parallel steps within an iteration.** An iteration is ordered; that is the
+  whole primitive.
+- **A scenario-level test script** asserting across steps.
+- **`pm.visualizer`** - unrelated to sequencing, still `undefined`.
+- **Replacing `run_collection_smoke`.** A smoke matrix over independent executes
+  is a different tool - unordered, share-nothing, agent-facing - and stays.
+- **Inline scripts on the load path** (5.3).
+
+---
+
+## 7. Phasing
+
+Each phase is an implementer-ready sub-issue of #340. Phase 1 is the only one
+with no user-visible surface; it exists separately because plan resolution is
+what every later phase consumes, and it is testable on its own.
+
+| Phase | Deliverable | Depends on |
+|-------|-------------|------------|
+| 1 | `ScenarioPlan` resolution + `scenario` block on `POST /runs` + snapshot manifest. No execution | this design |
+| 2 | Design-mode sequential runner: steps, iterations, per-step `results`, `runs.type = scenario`, SSE `step` events | 1 |
+| 3 | App: runner UI - run a folder, live per-step progress, per-step results | 2 |
+| 4 | Flow control: `ScriptControl` on `ScriptResult`, `pm.execution.setNextRequest` / `skipRequest` (**this is #303's first half**) | 2 |
+| 5 | `pm.iterationData` + data rows: engine binding, app file picker and parser (**#303's second half**) | 2, 4 |
+| 6 | Load-mode scenarios: VU state machine, per-VU cookies, per-step histograms | 2, and coordinate with #197 |
+
+Test strategy per phase: engine gtest for plan resolution (ordering, recursion,
+duplicate names, every loud-failure case in 4.3), for sequence semantics
+(state carried between steps, iteration boundaries, the cycle bound), and for
+flow-control values (a returned instruction actually changes the sequence);
+app vitest for the runner UI and the skip-vs-pass matrix rule (4.4). Phase 6
+additionally needs a benchmark on a quiet host, which is #197's constraint too.
+
+---
+
+## 8. What this design does not decide
+
+Recorded so a later reader knows these were left open on purpose, not missed:
+
+- **The runner UI's shape** beyond "per-step results with live progress" -
+  phase 3's issue owns it against `docs/app/COMPONENTS.md`.
+- **Whether a stored `scenarios` entity ever lands** (2.1). The seam exists; the
+  demand does not yet.
+- **Retry / continue-on-failure policy.** Today an errored step ends its
+  iteration. A per-step `continueOnFailure` is an obvious ask and is deliberately
+  not invented ahead of someone asking for it.

--- a/docs/plans/collection-runner-design.md
+++ b/docs/plans/collection-runner-design.md
@@ -1,59 +1,63 @@
-# Collection Runner / Scenario Primitive - Design
+# Collection Runner Design
 
-**Status:** approved design, not yet implemented.
-**Tracks:** issue #340. Flow control (`pm.execution`, `pm.iterationData`) is #303.
-**Anchors verified at master `d5899bb` (2026-08-07).**
+## Overview
 
-Vayu's product target is the Postman + JMeter + k6 combination. The single
-largest capability gap against that target, on both halves at once, is an
-engine-side **ordered-sequence primitive**: Postman's collection run, and the
-multi-step sequence a k6 virtual user repeats. This document is the design
-decision for that primitive, made once, before any code.
+This document records the design decisions behind Vayu's collection runner - the
+engine-side primitive that executes an **ordered sequence** of requests, rather
+than the single sends and single-request load runs Vayu has today.
 
-Every section below states a **decision** and the alternative it declines. Where
-a decision constrains something that is not being built yet - load-mode
-scenarios, stored scenario entities - it says so explicitly, because the point of
-designing first is that mode 1 must not be built in a way mode 2 has to undo.
+One primitive serves both halves of Vayu's target. In design mode it is
+Postman's collection run: a folder executed in order, with per-request scripts
+and state flowing between steps. In load mode it is the multi-step sequence a k6
+virtual user or a JMeter thread group repeats: log in, then browse, then check
+out.
 
----
+**This design is decided but not yet built.** Each section below states a
+decision and the alternative it declines, so that the implementation does not
+relitigate them. Sections describing load-mode behaviour are decided ahead of
+being scheduled, so that design-mode structures need no rework when load mode
+arrives.
 
-## 1. Why Vayu has nothing today
+**Lifecycle of this page.** It is a plan, and plans get consumed: as each phase
+ships, its decisions fold into `docs/engine/architecture.md` beside the Cookie
+Jar and request-composition sections, which is where rationale for *shipped*
+behaviour lives. When the last phase lands this page is deleted, the same way
+backlog entries are removed from `pending-backlog.md` once they ship. Until then
+nothing here describes behaviour the engine has. Scheduling and phase status are
+tracked in the issues, not on this page, so that a closed issue cannot leave a
+stale line here.
 
-Two things look like runners and are not:
+## What Vayu has today
 
-- **`run_collection_smoke`** is a **client-side TypeScript loop** over
-  independent `POST /execute` calls (the smoke handler in
-  `app/electron/mcp/tools.ts`; composition described at `docs/engine/mcp.md`).
-  The engine sees N unrelated design-mode executes and holds no object that
-  contains them, so a script running inside execute #3 has nothing to say about
-  execute #4 and nowhere to put the instruction.
-- **Load runs repeat a single composed request**
-  (`engine/src/core/run_manager.cpp`, `execute_load_test`). Test scripts there
-  run **deferred, once per sampled response, after the run finishes**
-  (`validate_scripts`, `run_manager.cpp:55`, called at `:747`), so even the
-  ordering that exists is not something a script participates in.
+Two things look like runners and are not.
 
-So "log in, then browse, then check out" - the workflow that makes a collection
-more than a folder tree, and the unit a serious load evaluation reaches for
-first - cannot be expressed at all.
+**`run_collection_smoke` is a client-side loop.** The MCP smoke handler
+(`app/electron/mcp/tools.ts`) walks a collection in TypeScript, calling
+`POST /compose` and `POST /execute` per request. The engine sees N unrelated
+design-mode executes and holds no object that contains them, so a script running
+inside execute #3 has nothing to say about execute #4 and nowhere to put the
+instruction.
 
----
+**Load runs repeat a single composed request.** `execute_load_test`
+(`engine/src/core/run_manager.cpp`) builds one request and the strategy submits
+copies of it. Test scripts there run deferred, once per *sampled* response, after
+the run finishes (`validate_scripts`, `run_manager.cpp:55`, called at `:747`), so
+even the ordering that does exist is not something a script participates in.
 
-## 2. The sequence model
+## The sequence model
 
-### Decision 2.1 - a scenario is a folder-derived ordered sequence, resolved once into an immutable plan
+### A scenario is a folder, resolved once into an immutable plan
 
-A **scenario** is not a new stored entity. It is a *resolution* of an existing
-one: a collection (folder), its direct requests ordered by `requests.order`,
-optionally including descendant collections ordered by `collections.order`,
-depth-first.
+A scenario is not a new stored entity. It is a *resolution* of one that exists: a
+collection, its direct requests ordered by `requests.order`, optionally including
+descendant collections ordered by `collections.order`, depth-first.
 
-At run start the engine resolves that into a **`ScenarioPlan`**: an ordered,
-immutable vector of **fully composed steps**. Each step is the exact payload
+At run start the engine resolves that into a **scenario plan**: an ordered,
+immutable vector of fully composed steps. Each step is the payload
 `POST /execute` accepts - `{{variables}}` substituted, `inherit` auth walked and
 applied, the ordered script-part lists from the collection chain plus the
 request's own - produced by the composition the engine already owns
-(`compose_request_core`, `engine/src/http/request_composer.cpp:454`).
+(`compose_request_core`, `engine/src/http/request_composer.cpp`).
 
 ```
 ScenarioStep {
@@ -64,110 +68,104 @@ ScenarioStep {
   pre_script     string          // joined parts (script_parts.cpp::read_script)
   post_script    string          // joined parts
 }
-ScenarioPlan { vector<ScenarioStep> steps; ... }
 ```
 
-**Why folder-derived rather than a `scenarios` table.** The collection tree with
-its `order` columns *already is* an ordered sequence. A parallel `scenarios`
-table would be a second source of truth for that ordering, needing its own
-answer to "a request in this scenario was deleted" and its own reconciliation on
-every collection edit. This repo's most repeated defect is state one layer
-records and another re-derives; a scenario entity in v1 would be exactly that,
-bought before anyone has asked for the thing it enables.
+**Declined: a first-class `scenarios` table.** The collection tree with its
+`order` columns already *is* an ordered sequence. A second table would be a
+second source of truth for that ordering, needing its own answer to "a request in
+this scenario was deleted" and its own reconciliation on every collection edit -
+state one layer records and another re-derives, which is this codebase's most
+repeated defect.
 
-**Declined: a first-class `scenarios` table (v1).** It becomes necessary the
-moment a user wants a sequence that is *not* a folder - steps drawn from several
-folders, one request appearing twice, a step disabled for one scenario but not
-another. The design must not preclude it, and does not: the run payload carries
-a `source` discriminator, and plan resolution is the seam.
+A stored scenario becomes necessary the moment someone wants a sequence that is
+*not* a folder: steps drawn from several folders, one request appearing twice, a
+step disabled for one scenario but not another. The design does not preclude it.
+The run payload carries a `source` discriminator, and plan resolution is the
+seam:
 
 ```jsonc
 "scenario": {
-  "source": "collection",          // the only value in v1
+  "source": "collection",          // the only value at first
   "collectionId": "col_...",
   "recursive": false,              // descend into sub-collections
   "iterations": 1,
-  "data": [ { "user": "a" }, ... ] // optional; see 2.3
+  "data": [ { "user": "a" }, ... ] // optional; see below
 }
 ```
 
 A future stored scenario is `{"source": "stored", "scenarioId": "scn_..."}` and
-resolves to the same `ScenarioPlan`. Nothing downstream of resolution changes.
+resolves to the same plan. Nothing downstream of resolution changes.
 
-### Decision 2.2 - the plan is resolved exactly once, before the first send
+### Resolution happens exactly once, before the first send
 
-No step is composed lazily, and no execution path touches SQLite for request
-data after resolution. Two reasons, and the second is the load-bearing one:
+No step is composed lazily, and no execution path touches SQLite for request data
+after resolution. Two reasons, and the second is load-bearing:
 
 - A collection edited mid-run would otherwise change the sequence underneath
-  itself. A run is a record of what ran; it must be resolvable to one answer.
-- **Load mode cannot query SQLite per step per virtual user.** The plan being
-  fully composed up front is what makes decision 5 possible at all. Resolving
-  lazily in mode 1 would be a stopgap mode 2 has to undo.
+  itself. A run is a record of what ran; it must resolve to one answer.
+- **Load mode cannot query SQLite per step per virtual user.** A fully composed
+  plan is what makes the per-VU executor possible at all. Resolving lazily in
+  design mode would be a stopgap that load mode has to undo.
 
 Resolution failures are loud and pre-run: an empty collection, a step whose
-composition fails, a plan exceeding `maxScenarioSteps` - all `400` with the
-offending request named, before any `runs` row exists. This matches the existing
+composition fails, a plan exceeding `maxScenarioSteps`. All are a `400` naming
+the offending request, before any `runs` row exists. This matches the existing
 `POST /runs` discipline, where `validate_run_config` and
 `normalize_run_http_version` both run before `create_run`
 (`engine/src/http/routes/execution.cpp`).
 
-### Decision 2.3 - an iteration is one full pass over the plan; data rows come in on the payload
+### An iteration is one pass over the plan; data rows arrive on the payload
 
-`iterations` (default `1`) is how many times the plan is executed end to end.
+`iterations` (default `1`) is how many times the plan executes end to end.
 
-`data` is an **inline JSON array of objects** on the run payload. Row `i % rows`
+`data` is an inline JSON array of objects on the run payload. Row `i % rows`
 binds to iteration `i` as `pm.iterationData`. When `data` is present and
-`iterations` is absent, `iterations` defaults to the row count - the Postman
-default. When both are given, the explicit count wins and the row index wraps;
-the wrap is **not silent**, because every per-iteration record carries its
+`iterations` is absent, `iterations` defaults to the row count, which is
+Postman's default. When both are given the explicit count wins and the row index
+wraps; the wrap is not silent, because every per-iteration record carries its
 `dataRowIndex` and `pm.info.iteration`. An empty `data` array is a `400`: a data
 set that binds nothing is a mistake, not an empty run.
 
-**Declined: the engine reading a data file from disk.** The script sandbox has
-no filesystem access by design, and giving the daemon a user-supplied path is a
-new trust boundary (traversal, arbitrary reads) bought for a parsing job the app
-already does well - it owns the Postman/Insomnia/OpenAPI import parsers. The app
-picks the file, parses CSV/JSON, and sends rows. The cost is payload size, which
-is why `maxScenarioDataRows` and a payload byte cap exist (5.4).
+**Declined: the engine reading a data file from disk.** The script sandbox has no
+filesystem access by design, and giving the daemon a user-supplied path is a new
+trust boundary - traversal, arbitrary reads - bought for a parsing job the app
+already does well, since it owns the Postman/Insomnia/OpenAPI import parsers. The
+app picks the file, parses CSV or JSON, and sends rows. The cost is payload size,
+which is what `maxScenarioDataRows` bounds.
 
----
+## Design-mode execution
 
-## 3. The execution model - design mode
-
-### Decision 3.1 - a scenario run is a third `runs.type`, not a design run
+### A scenario run is a third `runs.type`
 
 `runs.type` gains `"scenario"` beside `"design"` and `"load"`.
 
-It cannot reuse `"design"`: **a design run has exactly one `results` row**, and
-`GET /runs/:runId` serves it as `result` on that assumption
-(`docs/engine/db-schema.md`, `results`). A scenario run has one row per step
-execution. Overloading `design` would break a documented reader - the exact
-"written but never read" inverse this repo keeps finding.
+It cannot reuse `"design"`: a design run has **exactly one `results` row**, and
+`GET /runs/:runId` serves it as `result` on that assumption (see
+[Database Schema](../engine/db-schema.md)). A scenario run has one row per step
+execution, so overloading `design` would break a documented reader.
 
-### Decision 3.2 - asynchronous, run-record-backed, SSE-streamed - same lifecycle as a load run
+### The lifecycle is a load run's; only the executor differs
 
-`POST /runs` accepts a `scenario` block and answers `202 { runId }`, exactly as a
+`POST /runs` accepts a `scenario` block and answers `202 {runId}`, exactly as a
 load run does. The run gets a worker thread from `RunManager::start_run`, is
-registered/retained/swept by the existing machinery, streams over
+registered, retained and swept by the existing machinery, streams over
 `GET /runs/:runId/live`, stops through the existing stop path, and reports
 through `GET /runs/:runId/report`.
 
 **Declined: a synchronous `POST /scenarios/run`.** A 50-request folder takes as
-long as its requests added together - `run_collection_smoke`'s own description
-says so - and holding a cpp-httplib worker thread for minutes is not viable. A
-second async endpoint would need its own copy of stop, retention, SSE resume and
-the `DELETE /runs/:id` cascade; there is no second lifecycle here, only a second
-executor.
+long as its requests added together, and holding a cpp-httplib worker thread for
+minutes is not viable. A second asynchronous endpoint would need its own copy of
+stop, retention, SSE resume and the `DELETE /runs/:id` cascade; there is no
+second lifecycle here, only a second executor.
 
 The live stream gains a `step` event beside `metrics`, carrying
 `{iteration, stepIndex, name, outcome, statusCode, latencyMs}`. It rides the
-existing bounded tick ring (`RunContext::append_tick`) and its monotonic
-`id:` numbering, so `Last-Event-ID` resume works unchanged.
+existing bounded tick ring (`RunContext::append_tick`) and its monotonic `id:`
+numbering, so `Last-Event-ID` resume works unchanged.
 
-### Decision 3.3 - steps execute sequentially through `http::Client`, not the event loop
+### Steps run sequentially through `http::Client`
 
-The design-mode runner is, per iteration, per step:
+Per iteration, per step, this is the `POST /execute` handler's body:
 
 ```
 compose (already done at plan time)
@@ -175,83 +173,80 @@ compose (already done at plan time)
   -> Client::send         (through the environment cookie jar)
   -> post-request script  (ScriptContext::for_test)
   -> record step result
-  -> apply flow control   (section 4)
+  -> apply flow control
 ```
 
-That is the `POST /execute` handler's body, lifted. It must be `http::Client`
-and not `EventLoop`, because design-mode fidelity needs the cookie jar and
-inline per-step scripts, and the event loop deliberately has neither ("Not on
-the load path", `engine/include/vayu/http/cookie_jar.hpp`).
+It must be `http::Client` and not `EventLoop`, because design-mode fidelity needs
+the cookie jar and inline per-step scripts, and the event loop deliberately has
+neither (see [Cookie Jar](../engine/architecture.md#cookie-jar), "Not on the load
+path").
 
-**This is the point where the two modes diverge, and the divergence is the
-design.** The *plan* is shared; the *executor* is not. Section 5 specifies mode
-2's executor against the same plan.
+**This is where the two modes diverge, and the divergence is the design.** The
+plan is shared; the executor is not.
 
-### Decision 3.4 - state flows between steps through the scopes that already exist
+### State flows between steps through the scopes that already exist
 
-- **Variables.** The environment / globals / collection scopes are loaded once
-  at run start (`load_script_variable_scopes`), mutated in memory by every
-  step's scripts across every iteration, and persisted **once at run end**
-  through the existing diff-based `persist_script_variables`. This is what makes
-  "step 1 logs in and `pm.environment.set`s the token, step 2 sends it" work.
-  Persisting per step would be N x M diff-and-write cycles against the DB mutex
-  for a value only the run's own later steps read.
-- **Cookies.** The existing per-environment jar, scope = `environmentId`,
-  unchanged. It was already scoped this way partly for this feature, and it
-  already gives "log in once, reuse the session" for free.
-- **Nothing else.** There is no scenario-scoped variable bag. A fourth scope
-  would need precedence rules, a persistence story and a UI, to hold what the
-  environment scope already holds for the run's lifetime.
+**Variables.** The environment, globals and collection scopes are loaded once at
+run start (`load_script_variable_scopes`), mutated in memory by every step's
+scripts across every iteration, and persisted **once at run end** through the
+existing diff-based `persist_script_variables`. This is what makes "step 1 logs
+in and `pm.environment.set`s the token, step 2 sends it" work. Persisting per
+step would be N x M diff-and-write cycles against the DB mutex for a value only
+the run's own later steps read.
 
-### Decision 3.5 - `pm.info` gains `iteration` / `iterationCount`, set only by the runner
+**Cookies.** The existing per-environment jar, scope = `environmentId`,
+unchanged. It was scoped this way partly for this feature, and it already gives
+"log in once, reuse the session" for free.
+
+**Nothing else.** There is no scenario-scoped variable bag. A fourth scope would
+need precedence rules, a persistence story and a UI, to hold what the environment
+scope already holds for the run's lifetime.
+
+### `pm.info` gains `iteration` and `iterationCount`, set only by the runner
 
 `ScriptContext` gains two optional fields. The scenario runner sets them; every
 other caller leaves them unset and they reach the script as `undefined`.
 
-This does **not** reopen #300. That issue's ruling stands verbatim: a load run's
-`tests` script runs once per *sampled* response, and a reservoir sample index
-reported as an iteration number would be a binding that cannot fail. A scenario
-run has a real iteration index, so it reports one; `validate_scripts` still
-sets neither. The `ScriptContext` comment recording #300's rationale is kept and
-extended rather than replaced.
+This does not reopen the ruling that kept them out (issue #300), which stands
+verbatim: a load run's `tests` script runs once per *sampled* response, and a
+reservoir sample index reported as an iteration number would be a binding that
+cannot fail. A scenario run has a real iteration index, so it reports one;
+`validate_scripts` still sets neither.
 
-### Decision 3.6 - one `results` row per step execution, bounded
+### One bounded `results` row per step execution
 
 Each step execution writes a `results` row with the design-mode `trace_data`
-subset (the one `restore-response.ts` already restores from), plus
-`iteration`, `stepIndex`, `stepName`, `requestId`, `outcome`.
+subset - the one `restore-response.ts` already restores from - plus `iteration`,
+`stepIndex`, `stepName`, `requestId` and `outcome`.
 
-Bodies are capped by the existing `maxTraceBodyBytes`. The **row count** is
-bounded by a new `maxScenarioStoredSteps` (default 5,000), and the bound is
-biased the way `maxStoredErrors` is: **every failed and every skipped step is
-kept first**, successes are sampled into what remains, and what was thinned is
-disclosed in the summary the way `SamplingRetention` already discloses it.
-`Database::get_results` loads every row of a run with no limit and the report
-parses each `trace_data`, so an unbounded 200-step x 500-iteration run would
-make the report path quadratic in a way the dashboard polls.
+Bodies are capped by the existing `maxTraceBodyBytes`. The row count is bounded
+by `maxScenarioStoredSteps`, and the bound is biased the way `maxStoredErrors`
+is: **every failed and every skipped step is kept first**, successes are sampled
+into what remains, and what was thinned is disclosed the way `SamplingRetention`
+already discloses it. `Database::get_results` loads every row of a run with no
+limit and the report parses each `trace_data`, so an unbounded 200-step by
+500-iteration run would make the report path quadratic in a way the dashboard
+polls.
 
-### Decision 3.7 - the stored snapshot carries a step manifest, never the composed plan
+### The stored snapshot carries a step manifest, never the composed plan
 
-`runs.config_snapshot` holds the scenario *request* (`source`, `collectionId`,
-`recursive`, `iterations`, row count) plus a manifest of
-`{index, requestId, name, method, url}` per step - where `url` is the **stored,
+`runs.config_snapshot` holds the scenario request - `source`, `collectionId`,
+`recursive`, `iterations`, row count - plus a manifest of
+`{index, requestId, name, method, url}` per step, where `url` is the **stored,
 uncomposed** URL from the request row.
 
 The composed plan is credential-grade: it carries resolved `Authorization`
 headers, and an `apikey` auth with `in: "query"` puts a live key in the composed
-URL. `sanitize_config_snapshot` already reduces a run's `auth` object to
-`{mode}` for exactly this reason; persisting a composed plan would route around
-that allowlist. The full plan lives in memory for the run's life and nowhere
-else.
+URL. `sanitize_config_snapshot` already reduces a run's `auth` object to `{mode}`
+for exactly this reason, and persisting a composed plan would route around that
+allowlist. The full plan lives in memory for the run's life and nowhere else.
 
-`data` rows are **not** snapshotted either - they are user data of unknown
+`data` rows are not snapshotted either. They are user data of unknown
 sensitivity, and the manifest records only the row count.
 
----
+## Flow control
 
-## 4. Flow control as a value, not a side effect
-
-### Decision 4.1 - `ScriptResult` carries the intent; the runner decides
+### The script returns an intent; the runner decides
 
 ```cpp
 struct ScriptControl {
@@ -262,123 +257,116 @@ struct ScriptControl {
 // ScriptResult gains: ScriptControl control;
 ```
 
-`pm.execution.setNextRequest(name)` and `pm.execution.skipRequest()` **record**
-an intent on the result. They reach into nothing. `ScriptResult`
-(`engine/include/vayu/types.hpp:515`) is already the channel a script speaks to
-its caller through, and the caller is the only thing that knows what a sequence
-is. This is the channel #303 prescribed and it is honoured here unchanged.
-
+`pm.execution.setNextRequest(name)` and `pm.execution.skipRequest()` **record** an
+intent on the result and reach into nothing. `ScriptResult`
+(`engine/include/vayu/types.hpp`) is already the channel a script speaks to its
+caller through, and the caller is the only thing that knows what a sequence is.
 Last call wins within one script, which is Postman's behaviour.
 
-### Decision 4.2 - `pm.execution` throws where there is no sequence
+### `pm.execution` throws where there is no sequence
 
 `ScriptContext` gains `bool in_scenario`, set only by the scenario runner. With
 it false - a `POST /execute` send, a load run's deferred `tests` script - both
-methods **throw** a sentence naming why, rather than accepting a call and doing
+methods throw a sentence naming why, rather than accepting a call and doing
 nothing.
 
-A binding that cannot fail is worse than a missing one (#188's standing rule).
-`setNextRequest("checkout")` silently ignored in a single send is precisely the
-false-success that rule exists to prevent.
+A binding that cannot fail is worse than a missing one (issue #188's standing
+rule). `setNextRequest("checkout")` silently ignored in a single send is
+precisely the false success that rule exists to prevent.
 
-### Decision 4.3 - every ambiguous or unbounded case fails loudly
+### Every ambiguous or unbounded case fails loudly
 
 | Case | Behaviour |
 |------|-----------|
 | `setNextRequest(name)` naming no step in the plan | Step fails with a named error; iteration ends |
 | `setNextRequest(name)` naming a **duplicated** step name | Step fails - ambiguous target, both indices named. Resolution records the duplicate set at plan time, so the error can be precise |
-| `setNextRequest(null)` | `Kind::EndIteration` - ends this iteration, continues to the next. Postman's convention |
+| `setNextRequest(null)` | Ends this iteration, continues to the next. Postman's convention |
 | `skipRequest()` in a **pre-request** script | This step is skipped; `outcome: "skipped"` |
 | `skipRequest()` in a **test** script | Error - the request has already gone out, there is nothing left to skip |
-| A `setNextRequest` cycle | Bounded by `maxStepsPerIteration` (default `10 x steps`, floor 100). Exceeding it fails the iteration with the cycle's step names |
+| A `setNextRequest` cycle | Bounded by `maxStepsPerIteration`. Exceeding it fails the iteration with the cycle's step names |
 
 The cycle bound is not optional. `setNextRequest` makes an infinite loop a
 two-line script, and Postman's runner simply runs forever.
 
-### Decision 4.4 - skipped is never passed
+### Skipped is never passed
 
-A step's `outcome` is one of `passed | failed | skipped | errored`, counted
-separately everywhere: the step result row, the SSE `step` event, the run
-summary, and the app's step list. `run_collection_smoke`'s matrix already
-carries a distinct `skipped` count and must keep it.
+A step's `outcome` is one of `passed`, `failed`, `skipped` or `errored`, counted
+separately everywhere: the step result row, the SSE `step` event, the run summary
+and the app's step list. `run_collection_smoke`'s matrix already carries a
+distinct `skipped` count and keeps it.
 
-A skipped request counted as a pass is the false-pass class #180 exists to
-eliminate, and #303 names this explicitly as a condition of its acceptance.
+A skipped request counted as a pass is the false-pass class issue #180 exists to
+eliminate.
 
----
+## Load-mode convergence
 
-## 5. The load-mode convergence path
+Decided ahead of being scheduled, so that design-mode structures need no rework.
 
-Not built first. Designed now, so mode 1's structures need no rework.
+### The plan is shared; the executor is a per-virtual-user state machine
 
-### Decision 5.1 - the plan is shared; the executor is a per-virtual-user state machine
-
-A scenario load run does not spawn a thread per virtual user. A **VU** is a
-small value:
+A scenario load run does not spawn a thread per virtual user. A VU is a small
+value:
 
 ```
 VirtualUser { const ScenarioPlan* plan; size_t step; size_t iteration;
               VariableOverlay vars; CookieState cookies; }
 ```
 
-`concurrency` becomes **the number of virtual users** - which is what k6 and
-JMeter mean by it anyway. On each completion, the existing per-completion
-callback (`handle_result`, `engine/src/core/load_strategy.cpp`) advances that
-VU's state machine and submits its next step to the same worker.
+`concurrency` becomes **the number of virtual users**, which is what k6 and
+JMeter mean by it anyway. On each completion the existing per-completion callback
+(`handle_result`, `engine/src/core/load_strategy.cpp`) advances that VU's state
+machine and submits its next step to the same worker.
 
 This is the existing closed-loop controller with one substitution: the
-`maintain_concurrency` refill (`load_strategy.cpp:249`) issues "the next step of
-VU *k*" instead of "another copy of the one request". The pure
-`compute_refill_deficit` primitive, the SPSC submission path and the
-single-producer discipline are all unchanged.
+`maintain_concurrency` refill issues "the next step of VU *k*" instead of "another
+copy of the one request". The pure `compute_refill_deficit` primitive, the SPSC
+submission path and the single-producer discipline are unchanged.
 
-### Decision 5.2 - per-VU cookie state, never the shared jar
+### Cookie state is per-VU, never the shared jar
 
 Each VU owns a private cookie list, empty at the start of each iteration. The
 environment jar is not touched.
 
-This *strengthens* the existing constraint rather than fighting it: a shared jar
+This strengthens the existing constraint rather than fighting it: a shared jar
 across workers is either a lock on the 60k-RPS hot path or per-worker jars that
-do not actually share (`cookie_jar.hpp`). It is also the semantically correct
-answer - 1,000 VUs are 1,000 users, and one session shared between them is not
-the thing being measured.
+do not actually share. It is also the semantically correct answer, since 1,000
+VUs are 1,000 users and one session shared between them is not the thing being
+measured.
 
-### Decision 5.3 - scripts stay deferred and sampled in load mode, and flow control is unavailable there
+### Scripts stay deferred, so flow control is design-mode only
 
-Load-mode scripts keep the existing `validate_scripts` discipline - deferred,
-run against sampled responses after the run - extended only by being keyed
-**per step index** rather than per run. Running QuickJS inline per step at
-60k RPS is not viable, and that architecture is documented, load-bearing, and
-out of scope for this design.
+Load-mode scripts keep the existing `validate_scripts` discipline - deferred, run
+against sampled responses after the run - extended only by being keyed per step
+index rather than per run. Running QuickJS inline per step at 60k RPS is not
+viable, and that architecture is documented and load-bearing.
 
 The consequence is stated rather than hidden: **`pm.execution` throws in a load
-run** (decision 4.2 already covers it, since `in_scenario` is false for a
-deferred script). A script that has already run against a recorded response
-cannot redirect a sequence that already happened. Flow control is a design-mode
-capability.
+run**, which the `in_scenario` rule above already covers. A script that has
+already run against a recorded response cannot redirect a sequence that already
+happened.
 
 **Declined: inline scripts in load mode.** The escape hatch, if it is ever
 wanted, is a bounded pool of QuickJS contexts per worker evaluated only for
-iterations the sampler already selected - real work, its own benchmark, and its
-own issue. Naming it here is what keeps it from being smuggled in as a side
-effect of this feature.
+iterations the sampler already selected. That is real work with its own benchmark
+and its own issue; naming it here is what keeps it from being smuggled in as a
+side effect of this feature.
 
-### Decision 5.4 - scenario load runs are closed-loop only, with bounded per-step metrics
+### Closed-loop only, with bounded per-step metrics
 
-- **Modes:** `constant_concurrency`, `ramp_up`, `iterations`. `constant_rps` is
-  **out** for scenarios - an open-loop arrival rate over a multi-step sequence
-  is k6's arrival-rate executor, a named non-goal (section 6).
+- **Modes:** `constant_concurrency`, `ramp_up` and `iterations`. `constant_rps`
+  is out for scenarios, because an open-loop arrival rate over a multi-step
+  sequence is k6's arrival-rate executor, a non-goal below. Requesting it with a
+  scenario is a `400`, not a silent fallback.
 - **`maxInFlight` is moot for scenario runs.** In-flight is bounded by the VU
-  count by construction, so `concurrency` is the only knob. This is a
-  coordination point with **#197**, which re-tunes `workers`, the per-host
-  budget and the `maxInFlight` default: #197's `maxInFlight` formula work does
-  not apply to scenario runs and should not be generalised over them.
+  count by construction, so `concurrency` is the only knob. The high-RPS default
+  re-tune tracked in `pending-backlog.md` (P1) covers single-request load runs;
+  its `maxInFlight` formula should not be generalised over scenarios.
 - **Per-step metrics:** one latency histogram per step, allocated once from the
-  plan's step count, plus the existing whole-run aggregate as the scenario
-  total. An HdrHistogram is not free, which is why `maxScenarioSteps` (default
-  200) bounds the plan in both modes.
+  plan's step count, plus the existing whole-run aggregate as the scenario total.
+  An HdrHistogram is not free, which is why `maxScenarioSteps` bounds the plan in
+  both modes.
 
-### New config keys this design introduces
+## New configuration keys
 
 | Key | Default | Bounds |
 |-----|---------|--------|
@@ -387,59 +375,63 @@ effect of this feature.
 | `maxScenarioStoredSteps` | 5,000 | `results` rows per scenario run (failures kept first) |
 | `maxStepsPerIteration` | `10 x steps`, floor 100 | `setNextRequest` cycle bound |
 
----
-
-## 6. Explicit non-goals
+## Non-goals
 
 Named so the design has a boundary, and so none of them arrives sideways:
 
-- **JMeter's logic-controller zoo** - if/while/switch/loop/interleave
+- **JMeter's logic-controller zoo** - if, while, switch, loop and interleave
   controllers. `setNextRequest` covers the workflows people actually build.
-- **k6's open-model / arrival-rate executors for scenarios** (5.4).
+- **k6's open-model and arrival-rate executors for scenarios.**
 - **Distributed load.**
-- **The engine reading data files from disk** (2.3).
+- **The engine reading data files from disk.**
 - **Parallel steps within an iteration.** An iteration is ordered; that is the
   whole primitive.
 - **A scenario-level test script** asserting across steps.
-- **`pm.visualizer`** - unrelated to sequencing, still `undefined`.
+- **`pm.visualizer`** - unrelated to sequencing, and still `undefined`.
 - **Replacing `run_collection_smoke`.** A smoke matrix over independent executes
   is a different tool - unordered, share-nothing, agent-facing - and stays.
-- **Inline scripts on the load path** (5.3).
+- **Inline scripts on the load path.**
 
----
+## Implementation phases
 
-## 7. Phasing
+The work splits into six phases, ordered by what each one unblocks rather than by
+size. Plan resolution comes first and alone, because every later phase consumes
+the plan and it is testable with nothing executing:
 
-Each phase is an implementer-ready sub-issue of #340. Phase 1 is the only one
-with no user-visible surface; it exists separately because plan resolution is
-what every later phase consumes, and it is testable on its own.
+1. Plan resolution, the `scenario` block on `POST /runs`, and the snapshot
+   manifest. No execution.
+2. The design-mode sequential runner: steps, iterations, per-step results, the
+   third `runs.type`, and `step` SSE events.
+3. The app runner UI: run a folder, live per-step progress, per-step results.
+4. Flow control - `ScriptControl` on `ScriptResult`, and the `pm.execution`
+   bindings.
+5. `pm.iterationData` and data rows, engine binding plus the app's file picker.
+6. Load-mode scenarios: the VU state machine, per-VU cookies, per-step
+   histograms. This phase shares the hot path with the high-RPS default re-tune
+   and lands after or with it.
 
-| Phase | Deliverable | Depends on |
-|-------|-------------|------------|
-| 1 | `ScenarioPlan` resolution + `scenario` block on `POST /runs` + snapshot manifest. No execution | this design |
-| 2 | Design-mode sequential runner: steps, iterations, per-step `results`, `runs.type = scenario`, SSE `step` events | 1 |
-| 3 | App: runner UI - run a folder, live per-step progress, per-step results | 2 |
-| 4 | Flow control: `ScriptControl` on `ScriptResult`, `pm.execution.setNextRequest` / `skipRequest` (**this is #303's first half**) | 2 |
-| 5 | `pm.iterationData` + data rows: engine binding, app file picker and parser (**#303's second half**) | 2, 4 |
-| 6 | Load-mode scenarios: VU state machine, per-VU cookies, per-step histograms | 2, and coordinate with #197 |
+Phases 3 through 6 depend only on phase 2, not on each other. Flow control and
+iteration data are design-mode capabilities by decision, not by ordering.
 
-Test strategy per phase: engine gtest for plan resolution (ordering, recursion,
-duplicate names, every loud-failure case in 4.3), for sequence semantics
-(state carried between steps, iteration boundaries, the cycle bound), and for
-flow-control values (a returned instruction actually changes the sequence);
-app vitest for the runner UI and the skip-vs-pass matrix rule (4.4). Phase 6
-additionally needs a benchmark on a quiet host, which is #197's constraint too.
+Per-phase test strategy: engine gtest for plan resolution (ordering, recursion,
+duplicate names, every loud-failure case above), for sequence semantics (state
+carried between steps, iteration boundaries, the cycle bound) and for
+flow-control values (a returned instruction actually changes the sequence); app
+vitest for the runner UI and the skip-versus-pass rule. Phase 6 additionally
+needs a benchmark on a quiet host.
 
----
+Scheduling, dependencies and status live in the issues. Issue #340 carries the
+phase breakdown and its sub-issues; this page deliberately holds no issue numbers
+for them, so that closing one cannot leave a stale line here.
 
-## 8. What this design does not decide
+## Deliberately left open
 
 Recorded so a later reader knows these were left open on purpose, not missed:
 
-- **The runner UI's shape** beyond "per-step results with live progress" -
-  phase 3's issue owns it against `docs/app/COMPONENTS.md`.
-- **Whether a stored `scenarios` entity ever lands** (2.1). The seam exists; the
-  demand does not yet.
-- **Retry / continue-on-failure policy.** Today an errored step ends its
-  iteration. A per-step `continueOnFailure` is an obvious ask and is deliberately
-  not invented ahead of someone asking for it.
+- **The runner UI's shape** beyond "per-step results with live progress". The
+  phase-3 issue owns it against `docs/app/COMPONENTS.md`.
+- **Whether a stored scenario entity ever lands.** The seam exists; the demand
+  does not yet.
+- **Retry and continue-on-failure policy.** An errored step ends its iteration. A
+  per-step `continueOnFailure` is an obvious ask and is deliberately not invented
+  ahead of someone asking for it.

--- a/docs/plans/pending-backlog.md
+++ b/docs/plans/pending-backlog.md
@@ -2,7 +2,7 @@
 
 Living backlog of deferred / surfaced work. Each item notes **why** it's pending and **what** it needs so it can be picked up as a focused plan.
 
-_Last updated: 2026-08-01. Recently shipped: **N2** (app lint sweep, now CI-enforced) via issue #189; **A1** (engine-owned request composition) via issue #226. Previously shipped and removed from this list: **W1** (windowed percentiles) via PR #54; **N3** (uPlot chart unification) + the four-category app-settings overhaul via PR #55 (0.8.0); **P2** (`/config` validation message) via PR #50._
+_Last updated: 2026-08-07. Recently shipped: **N2** (app lint sweep, now CI-enforced) via issue #189; **A1** (engine-owned request composition) via issue #226. Previously shipped and removed from this list: **W1** (windowed percentiles) via PR #54; **N3** (uPlot chart unification) + the four-category app-settings overhaul via PR #55 (0.8.0); **P2** (`/config` validation message) via PR #50._
 
 ---
 
@@ -48,6 +48,24 @@ by-id compose path now also builds the part list engine-side. See
 `docs/engine/api-reference.md` → *POST /compose*, `docs/engine/architecture.md`
 → *Request composition boundary*, and `docs/engine/mcp.md` → *Request
 composition* for the current state.
+
+---
+
+## Approved multi-phase designs (not deferred - scheduled)
+
+### Collection runner / scenario primitive
+
+Approved design-first via issue #340; the decisions live in
+[collection-runner-design.md](collection-runner-design.md), which phases the
+work into six implementer-ready sub-issues (plan resolution -> design-mode
+runner -> runner UI -> flow control -> `pm.iterationData` -> load-mode
+scenarios). Listed here because the phases stretch past one release, not because
+anything is deferred. Two coordination points worth knowing from this file's
+side: phase 6 (load-mode scenarios) shares the hot path **P1** re-tunes and must
+land after or with it, and the design rules `maxInFlight` moot for scenario runs
+- so P1's `maxInFlight` bound applies to single-request load runs only, not to
+scenarios. Flow control (#303) is phases 4-5 and is no longer blocked on a
+product decision.
 
 ---
 


### PR DESCRIPTION
## Description

The design deliverable for #340: `docs/plans/collection-runner-design.md`, plus
its nav entry and a pointer from `pending-backlog.md`. No implementation, per the
issue's last acceptance criterion.

**Plan (root cause, approach, rejected alternative).** Nothing in the engine holds
an ordered sequence: `run_collection_smoke` is a client-side TypeScript loop over
independent `POST /execute` calls, so the engine never sees one, and load runs
repeat a single composed request with scripts deferred to post-run validation
(`validate_scripts`, `run_manager.cpp:55`). Both halves of the Postman + JMeter +
k6 target stop there. The approach is **one shared plan, two executors**: a
scenario resolves once, at run start, into an immutable vector of fully composed
steps; design mode walks it sequentially through `http::Client` (for the cookie
jar and inline per-step scripts, which the event loop deliberately lacks), and
load mode drives the *same plan* from a per-VU state machine on the existing
closed-loop refill. The alternative I rejected is a **stored `scenarios` table**:
the collection tree with its `order` columns already *is* an ordered sequence, so
a table would be a second source of truth needing its own reconciliation on every
collection edit - this repo's most repeated defect class, bought before anyone has
asked for the thing it enables. The seam is kept (`{"source": "collection"}` is a
discriminator), so a stored scenario can land later without changing anything
downstream of resolution.

The load-bearing constraint that falls out: **the plan must be fully composed up
front**, because a lazily composed step would put SQLite on the 60k-RPS hot path
in mode 2. That is what "design first so mode 1 is not built in a way mode 2 has
to undo" actually cashes out to here.

Decisions made, each with its declined alternative recorded in the doc:

| § | Decision |
|---|----------|
| 2.1 | Folder-derived sequence, not a `scenarios` table |
| 2.2 | Plan resolved exactly once, before the first send |
| 2.3 | Data rows on the payload; the engine never opens a file (the sandbox has no filesystem access by design, and a user-supplied path is a new trust boundary for a parsing job the app already does) |
| 3.1 | A third `runs.type` - reusing `design` would break the documented "a design run has exactly one `results` row" contract that `GET /runs/:runId` serves on |
| 3.2 | Async, run-record-backed, SSE-streamed - one lifecycle, two executors |
| 3.3 | Sequential through `http::Client`, not `EventLoop` |
| 3.4 | Variables loaded once and persisted once; the existing per-environment cookie jar unchanged |
| 3.5 | `pm.info.iteration` set only by the runner - **#300's ruling is preserved verbatim**, `validate_scripts` still sets neither |
| 3.6 | One bounded `results` row per step, failures kept first, thinning disclosed |
| 3.7 | The snapshot carries a step manifest with **stored** URLs, never the composed plan - a composed plan carries resolved `Authorization` headers, and `apikey`/`in: query` puts a live key in the composed URL, which is what `sanitize_config_snapshot` exists to keep out |
| 4 | Flow control as a `ScriptResult` value (#303's prescribed channel); `pm.execution` throws where there is no sequence; every ambiguous case is loud; `setNextRequest` cycles are bounded; skipped is never passed |
| 5 | Per-VU state machine over the shared plan; per-VU cookies (which strengthens `cookie_jar.hpp`'s "not on the load path" rather than fighting it); scripts stay deferred; closed-loop only; `maxInFlight` moot for scenarios |
| 6 | Nine explicit non-goals |

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Docs-only - every changed line is Markdown or a nav entry, so no test could go
from green to red (CLAUDE.md's "Concrete cases where the answer is simply
don't"). The one check that *can* fail on a docs change is the site build:

```
mkdocs build --strict -f .github/mkdocs.yml   # what CI runs
Documentation built in 3.02 seconds           # exit 0
```

No engine or app suite was run, deliberately. No pre-existing failures observed.

## Checklist

- [x] My code follows the style guidelines (no em-dashes; the one en-dash left in
      `pending-backlog.md` is pre-existing text in the **P1** section, which #197
      owns - not touched)
- [x] I have performed a self-review
- [x] I have added tests (N/A - design document, no behaviour)
- [x] I have updated documentation (the doc *is* the change; nav entry added in
      the same commit per the docs-site rules, and `pending-backlog.md` gains the
      pointer #340's Docs section asked for. Only the backlog's "Last updated"
      date was touched beyond the new section - **P1/D8/D9/M1 are #197's to
      refresh** and were left alone)

## Related Issues

Closes #340.

Decomposed into six implementer-ready sub-issues, all linked under #340:

| Phase | Issue |
|-------|-------|
| 1 | #352 - `ScenarioPlan` resolution + `scenario` on `POST /runs` + snapshot manifest |
| 2 | #353 - design-mode sequential runner |
| 3 | #354 - app runner UI |
| 4 | #355 - flow control (**#303's first half**) |
| 5 | #356 - `pm.iterationData` (**#303's second half**) |
| 6 | #357 - load-mode scenarios (coordinates with #197) |

#303 is re-anchored to #355/#356 in a comment on the issue and closes when both
land.

**Deliberate deviations from the issue spec, with reasons:**

1. #340 offered "a section in `docs/engine/architecture.md` if small enough - the
   design decides". It is not small enough: five decision areas with declined
   alternatives, plus a phase table, would have doubled a document that describes
   *shipped* behaviour with one describing unshipped behaviour. A separate page
   under `docs/plans/` keeps the "architecture.md describes what exists" property.
2. #340 named four candidate sub-issues; the decomposition has **six**. Plan
   resolution (#352) is split from the runner (#353) because every later phase
   consumes the plan and it is testable with nothing executing, and flow control
   (#355) is split from `pm.iterationData` (#356) because they gate differently
   and `pm-api-compatibility.md` then moves in two clean steps rather than one
   tangled one.
3. The sub-issues are filed **now**, before this PR merges, since filing them is
   an acceptance criterion of the issue this PR closes. Each is gated on the
   design landing; if review changes a decision, the affected issue is edited
   rather than the design drifting from its children.