### PR TITLE
feat(engine): resolve a collection into an immutable ScenarioPlan, and accept a scenario block on POST /runs

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1367,6 +1367,68 @@ explicit `null` is treated exactly like an absent key. An unrecognized string
 is a `400` naming the field and the valid values, the same validation
 `POST /requests` uses.
 
+#### The `scenario` block (collection runs)
+
+A run may instead state its work as an **ordered collection** - the collection
+runner's sequence primitive. The block replaces the single request, so a payload
+carrying it needs no top-level `method` / `url`, and states its iteration count
+inside the block rather than through `mode` / `duration` / `iterations`:
+
+```jsonc
+{
+  "scenario": {
+    "source": "collection",         // required; the only accepted value today
+    "collectionId": "col_123",      // required
+    "recursive": false,             // optional, default false - descend into sub-collections
+    "iterations": 1,                // optional; defaults to the data row count, else 1
+    "data": [ { "user": "a" } ]     // optional inline rows; see maxScenarioDataRows
+  },
+  "environmentId": "env_123"        // optional, and what {{variables}} resolve against
+}
+```
+
+The collection is resolved into an ordered, fully composed plan **once, before
+anything is sent**: direct requests by `requests.order`, then - with `recursive`
+- descendant collections by `collections.order`, depth-first. Each step is
+composed through the same path `POST /compose` uses, so a step's request and
+joined scripts are byte-identical to what a Send of that request would run. A
+collection edited mid-run therefore cannot change the sequence underneath
+itself, and no execution path re-reads the database for request data.
+
+> **Not executed yet.** A valid `scenario` block currently resolves, validates,
+> and answers **`501`** with `error.code: "scenario_not_implemented"`, naming
+> the step and iteration count it resolved to. The sequential runner that
+> executes a plan is a later phase. No run row is created, so a `501` leaves
+> nothing behind.
+
+**Every rejection is a `400`** with `error.code: "invalid_scenario"`, raised
+before any run row exists - an empty or oversized sequence is never silently run
+as a smaller one:
+
+| Input | Rejected because |
+|-------|------------------|
+| `source` absent, or anything but `"collection"` | The discriminator exists for a future stored scenario; an unknown value must not fall through to the collection path. |
+| `collectionId` absent, not a string, or empty | There is nothing to resolve. The id is echoed back when it names no collection. |
+| The collection (with `recursive` applied) has no requests | An empty sequence is a mistake, not a zero-step run. |
+| A step's composition fails | The message names the step index, request name and id. |
+| More steps than `maxScenarioSteps` | The whole plan is held in memory for the run's life; the message carries the count and the cap. |
+| `recursive` present and not a boolean | |
+| `iterations` present and not a whole number in `1`-`2147483647` | It is read as a count, so `0`, a fraction and a string are each a run nobody asked for. |
+| `data` present and empty | A data set that binds nothing is a mistake - omit the field to run without one. |
+| `data` not an array, or a row that is not an object | |
+| More `data` rows than `maxScenarioDataRows` | The message carries the count and the cap. |
+
+A cycle in the `collections.parent_id` tree terminates the recursive walk rather
+than hanging it, exactly as the cascade delete in `DELETE /collections/:id` does.
+
+**Two settings bound a scenario** (both in the `general_engine` category, see
+[GET /config](#get-config)):
+
+| Key                   | Default | Range      | Effect |
+|-----------------------|---------|------------|--------|
+| `maxScenarioSteps`    | `200`   | 1-10000    | Largest plan one run may resolve to. The sequence is composed up front and held in memory, and a load-mode scenario allocates a latency histogram per step, so this bounds memory rather than expressing a preference. |
+| `maxScenarioDataRows` | `1000`  | 1-1000000  | Largest inline `data` array. The app parses the CSV/JSON file and sends the rows - the engine never reads a file from disk - so this bounds the payload that decision costs. |
+
 **Response:**
 ```json
 {

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -265,6 +265,32 @@ reduced to just `{"mode": "..."}` (via `sanitize_config_snapshot` in
 `utils/json.cpp`) - an allowlist, so no current or future auth field
 (`clientSecret`, `password`, tokens) leaks into a stored run.
 
+**`config_snapshot` for a scenario run** - a run started from a `scenario` block
+(see [POST /runs](api-reference.md#post-runs)) stores a **step manifest**, never
+the resolved plan. No such row exists yet: a `scenario` payload resolves and
+answers `501`, so this describes the shape the runner will write, decided and
+pinned by `scenario_plan_test.cpp` ahead of the phase that writes it.
+
+```json
+{
+  "source": "collection", "collectionId": "col_123", "recursive": false,
+  "iterations": 3, "dataRowCount": 2,
+  "steps": [
+    { "index": 0, "requestId": "req_1", "name": "Log in",
+      "url": "https://{{host}}/login", "method": "POST" }
+  ]
+}
+```
+
+`url` is the **stored, uncomposed** one. The resolved plan is credential-grade -
+it carries resolved `Authorization` headers, and an `apikey` auth with
+`in: "query"` puts a live key in the composed URL - so persisting it would route
+around the `auth` allowlist above rather than respect it. The plan lives in
+memory for the run's life and nowhere else. Inline `data` rows are not
+snapshotted either: they are user data of unknown sensitivity, and the manifest
+records only their count. The writer is `vayu::core::build_scenario_manifest`
+(`core/scenario_plan.cpp`).
+
 **Retention** - runs are append-only in normal use (every design-mode click adds a `runs` row,
 every load run its `metric_ticks`/`results`), so `Database::prune_runs(max_runs, max_age_days)` trims
 the history. A run is a victim when it falls **beyond the `maxRunsRetained` most-recent runs**

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -274,6 +274,7 @@ add_library(vayu_core STATIC
     src/utils/id.cpp
     src/db/database.cpp
     src/core/load_strategy.cpp
+    src/core/scenario_plan.cpp
     src/core/run_manager.cpp
     src/core/metrics_collector.cpp
     src/core/sample_capture.cpp
@@ -458,6 +459,7 @@ if(VAYU_BUILD_TESTS)
         tests/http_version_support_test.cpp
         tests/http_version_test.cpp
         tests/request_composer_test.cpp
+        tests/scenario_plan_test.cpp
         src/http/routes/import.cpp
         src/http/routes/compose.cpp
         src/http/routes/config.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -243,6 +243,22 @@ constexpr size_t MAX_TRACE_BODY_BYTES = 5 * 1024 * 1024;
 } // namespace json
 
 /**
+ * @brief Collection-runner (scenario) bounds.
+ */
+namespace scenario {
+/// Largest plan one scenario run may resolve to (config key `maxScenarioSteps`).
+/// The whole plan is composed up front and held in memory for the run's life,
+/// and load-mode scenarios allocate one latency histogram per step, so plan
+/// size is a memory bound in both modes rather than a policy preference.
+constexpr size_t MAX_STEPS = 200;
+/// Largest inline `data` array one scenario run may carry (config key
+/// `maxScenarioDataRows`). The rows arrive on the run payload because the app
+/// owns file parsing and the script sandbox has no filesystem access; this is
+/// what bounds the payload that decision costs.
+constexpr size_t MAX_DATA_ROWS = 1000;
+} // namespace scenario
+
+/**
  * @brief Metrics collector configuration for high-RPS load testing
  */
 namespace metrics_collector {

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file core/scenario_plan.hpp
+ * @brief Resolve a collection into an immutable, fully composed ordered plan -
+ *        the collection-runner primitive (design doc: "The sequence model").
+ *
+ * Nothing in the engine held an ordered sequence of requests before this: the
+ * MCP smoke handler walks a collection in TypeScript over independent
+ * `POST /execute` calls, and a load run repeats one composed request. Every
+ * later phase of the collection runner - the sequential runner, flow control,
+ * data-driven iterations, load-mode scenarios - consumes the object built here,
+ * so it exists and is tested on its own before anything executes it.
+ *
+ * **Resolution happens exactly once, before the first send.** No step is
+ * composed lazily and no execution path touches SQLite for request data
+ * afterwards. Two reasons, and the second is load-bearing:
+ *
+ *  - A collection edited mid-run would otherwise change the sequence underneath
+ *    itself. A run is a record of what ran; it must resolve to one answer.
+ *  - The load-mode executor cannot query SQLite per step per virtual user. A
+ *    fully composed plan is what makes a per-VU state machine possible at all,
+ *    so resolving lazily in design mode would be a stopgap load mode has to
+ *    undo.
+ *
+ * Composition goes through `compose_request_core` / `build_request` and the
+ * script join through `read_pre_request_script` / `read_post_request_script`,
+ * which is what keeps a step byte-identical to what a Send of the same request
+ * would run. There is deliberately no second copy of resolution here.
+ */
+
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "vayu/db/database.hpp"
+#include "vayu/types.hpp"
+
+namespace vayu::core {
+
+/** One resolved step of a scenario plan: execute-ready, and never re-read. */
+struct ScenarioStep {
+    /// Position in the plan, stable for the run.
+    size_t index = 0;
+    /// The stored request this came from.
+    std::string request_id;
+    /// `requests.name` - the `setNextRequest` target a later phase resolves.
+    std::string name;
+    /// Composed and auth-resolved. Credential-grade; see `build_scenario_manifest`.
+    vayu::Request request;
+    /// Joined script parts (collection chain, then the request's own).
+    std::string pre_script;
+    std::string post_script;
+    /// The stored, uncomposed URL. Carried on the step so the snapshot manifest
+    /// can record a URL that is safe to persist without re-reading the row -
+    /// `request.url` has `{{vars}}` substituted and may carry an `apikey` auth
+    /// with `in: "query"`, i.e. a live key.
+    std::string stored_url;
+};
+
+/** An ordered, immutable sequence of composed steps. */
+struct ScenarioPlan {
+    std::vector<ScenarioStep> steps;
+};
+
+/**
+ * The validated `scenario` block of a `POST /runs` payload.
+ *
+ * `data` rows themselves are deliberately absent: they are user data of unknown
+ * sensitivity and are never snapshotted, so only their count survives
+ * validation.
+ */
+struct ScenarioRequest {
+    /// Only `"collection"` today. The discriminator exists so a future stored
+    /// scenario resolves to the same plan; an unknown value is rejected rather
+    /// than falling through to the collection path.
+    std::string source;
+    std::string collection_id;
+    /// Descend into sub-collections, depth-first by `collections.order`.
+    bool recursive = false;
+    /// Resolved: an explicit count wins, otherwise the data row count, else 1.
+    size_t iterations     = 1;
+    size_t data_row_count = 0;
+};
+
+/** Bounds a plan must respect, read from config by the caller. */
+struct ScenarioLimits {
+    size_t max_steps     = 0;
+    size_t max_data_rows = 0;
+};
+
+/**
+ * Everything resolution needs beyond the `scenario` block itself.
+ *
+ * `environment_id` is not part of the block: it is the *run's* environment, and
+ * composition needs it or every `{{env var}}` in the plan resolves to "".
+ */
+struct ScenarioResolveOptions {
+    std::string environment_id;
+    /// Applied to every composed step, exactly as `POST /execute` applies it.
+    int timeout_ms = 0;
+    ScenarioLimits limits;
+};
+
+/**
+ * The outcome of resolving a `scenario` block.
+ *
+ * Failure is always a caller-facing `400` message naming what was wrong and,
+ * where a step is at fault, which step. There is no partial plan: a resolution
+ * that cannot produce every step produces none.
+ */
+struct ScenarioResolution {
+    bool ok = false;
+    std::string error;
+    ScenarioRequest request;
+    ScenarioPlan plan;
+};
+
+/**
+ * Validate a `scenario` block and resolve it into a plan.
+ *
+ * Ordering is a collection's direct requests by `requests.order`, then - when
+ * `recursive` is set - descendant collections by `collections.order`,
+ * depth-first. The `collections` tree is not constraint-enforced, so the walk
+ * carries a visited set exactly as `Database::delete_collection`'s BFS does: a
+ * `parent_id` cycle terminates instead of growing forever under the DB mutex.
+ *
+ * Every failure below is loud, never a silently smaller run: an unknown
+ * `collectionId`, an empty sequence, a step whose composition fails, a plan
+ * over `limits.max_steps`, a `data` array that is present and empty or over
+ * `limits.max_data_rows`, and any `source` other than `"collection"`.
+ */
+ScenarioResolution resolve_scenario (vayu::db::Database& db,
+const nlohmann::json& scenario,
+const ScenarioResolveOptions& options);
+
+/**
+ * The `scenario` object a scenario run stores in `runs.config_snapshot`: the
+ * request as validated, plus `{index, requestId, name, method, url}` per step.
+ *
+ * **`url` is the stored, uncomposed one and the composed plan is never
+ * persisted.** The plan carries resolved `Authorization` headers, and an
+ * `apikey` auth with `in: "query"` puts a live key in the composed URL;
+ * `sanitize_config_snapshot` (`utils/json.cpp`) exists to keep exactly that out
+ * of the run store, and persisting a composed plan would route around its
+ * allowlist. The full plan lives in memory for the run's life and nowhere else.
+ */
+nlohmann::json build_scenario_manifest (const ScenarioRequest& request,
+const ScenarioPlan& plan);
+
+} // namespace vayu::core

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/core/scenario_plan.hpp"
+
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "vayu/http/request_builder.hpp"
+#include "vayu/http/request_composer.hpp"
+#include "vayu/http/script_parts.hpp"
+
+namespace vayu::core {
+
+namespace {
+
+ScenarioResolution invalid (std::string reason) {
+    ScenarioResolution resolution;
+    resolution.ok    = false;
+    resolution.error = std::move (reason);
+    return resolution;
+}
+
+/// The human-readable half of a compose error. `routes::error_message_of` is
+/// the shared reader for this shape, but it lives behind `routes.hpp`, which
+/// pulls in httplib - a dependency `vayu_core` deliberately does not carry. The
+/// shape itself is `error_body`'s and is pinned by `error_shape_route_test`.
+std::string compose_error_message (const nlohmann::json& body) {
+    if (auto error = body.find ("error"); error != body.end () && error->is_object ()) {
+        if (auto message = error->find ("message");
+            message != error->end () && message->is_string ()) {
+            return message->get<std::string> ();
+        }
+    }
+    return body.dump ();
+}
+
+/// How a step is named in an error message: enough to find the row in the app
+/// without opening the database.
+std::string describe_step (size_t index, const vayu::db::Request& row) {
+    return "step " + std::to_string (index) + " (request '" + row.name +
+    "', id '" + row.id + "')";
+}
+
+/**
+ * The ordered request rows a scenario covers, before anything is composed.
+ *
+ * Split from composition so the plan-size cap can reject an oversized folder
+ * for the cost of the row reads rather than after composing every step - and
+ * so the ordering rules are readable on their own.
+ */
+std::vector<vayu::db::Request>
+collect_requests (vayu::db::Database& db, const std::string& root_id, bool recursive) {
+    if (!recursive) {
+        return db.get_requests_in_collection (root_id);
+    }
+
+    // One read of the collection table, grouped by parent. `get_collections`
+    // orders by `order`, so each parent's children keep that order - and the
+    // whole descent costs one query instead of one per node.
+    std::unordered_map<std::string, std::vector<vayu::db::Collection>> children;
+    for (auto& collection : db.get_collections ()) {
+        if (collection.parent_id && !collection.parent_id->empty ()) {
+            children[*collection.parent_id].push_back (std::move (collection));
+        }
+    }
+
+    std::vector<vayu::db::Request> ordered;
+    std::unordered_set<std::string> visited;
+    std::vector<std::string> stack{ root_id };
+    while (!stack.empty ()) {
+        const std::string id = std::move (stack.back ());
+        stack.pop_back ();
+        // The visited set is what makes a corrupted `parent_id` (a self-parent,
+        // or an A -> B -> A loop written before write-time validation existed)
+        // terminate rather than grow `ordered` forever under the DB mutex -
+        // the same guard `Database::delete_collection`'s BFS carries.
+        if (!visited.insert (id).second) {
+            continue;
+        }
+
+        for (auto& row : db.get_requests_in_collection (id)) {
+            ordered.push_back (std::move (row));
+        }
+
+        if (auto it = children.find (id); it != children.end ()) {
+            // Reversed, so the stack pops them in `collections.order`: a
+            // pre-order descent visits a collection's own requests, then its
+            // first child's whole subtree, then its second child's.
+            for (auto child = it->second.rbegin (); child != it->second.rend (); ++child) {
+                stack.push_back (child->id);
+            }
+        }
+    }
+    return ordered;
+}
+
+/// Validate the block's own fields. The plan is not touched here; a malformed
+/// payload must not cost a collection walk.
+std::optional<std::string> parse_scenario_request (const nlohmann::json& scenario,
+const ScenarioLimits& limits,
+ScenarioRequest& out) {
+    if (!scenario.is_object ()) {
+        return "'scenario' must be a JSON object (got " +
+        std::string (scenario.type_name ()) + ")";
+    }
+
+    const auto source = scenario.find ("source");
+    if (source == scenario.end () || !source->is_string ()) {
+        return "'scenario.source' is required and must be the string "
+               "\"collection\"";
+    }
+    if (source->get<std::string> () != "collection") {
+        return "'scenario.source' must be \"collection\" (got " + source->dump () +
+        "). The discriminator exists for a future stored scenario; an unknown "
+        "value is not a collection run.";
+    }
+    out.source = "collection";
+
+    const auto collection_id = scenario.find ("collectionId");
+    if (collection_id == scenario.end () || !collection_id->is_string () ||
+    collection_id->get<std::string> ().empty ()) {
+        return "'scenario.collectionId' is required and must be a non-empty "
+               "string";
+    }
+    out.collection_id = collection_id->get<std::string> ();
+
+    if (auto recursive = scenario.find ("recursive");
+        recursive != scenario.end () && !recursive->is_null ()) {
+        if (!recursive->is_boolean ()) {
+            return "'scenario.recursive' must be a boolean (got " +
+            std::string (recursive->type_name ()) + ")";
+        }
+        out.recursive = recursive->get<bool> ();
+    }
+
+    // `data` rows never reach the plan or the snapshot - the app owns parsing
+    // the file they came from, and the engine only counts them (the binding
+    // that reads them lands with `pm.iterationData`).
+    bool has_data = false;
+    if (auto data = scenario.find ("data"); data != scenario.end () && !data->is_null ()) {
+        if (!data->is_array ()) {
+            return "'scenario.data' must be an array of objects (got " +
+            std::string (data->type_name ()) + ")";
+        }
+        if (data->empty ()) {
+            return "'scenario.data' is present but empty. A data set that "
+                   "binds "
+                   "nothing is a mistake, not an empty run - omit the field to "
+                   "run without one.";
+        }
+        if (data->size () > limits.max_data_rows) {
+            return "'scenario.data' has " + std::to_string (data->size ()) +
+            " rows, over the limit of " + std::to_string (limits.max_data_rows) +
+            " (raise the 'maxScenarioDataRows' setting to allow more)";
+        }
+        for (size_t i = 0; i < data->size (); ++i) {
+            if (!(*data)[i].is_object ()) {
+                return "'scenario.data' row " + std::to_string (i) +
+                " must be an object of name/value pairs (got " +
+                std::string ((*data)[i].type_name ()) + ")";
+            }
+        }
+        has_data           = true;
+        out.data_row_count = data->size ();
+    }
+
+    // An explicit count wins and the row index wraps; absent, a data set sets
+    // it to its row count (Postman's default) and everything else runs once.
+    if (auto iterations = scenario.find ("iterations");
+        iterations != scenario.end () && !iterations->is_null ()) {
+        constexpr double max_iterations =
+        static_cast<double> (std::numeric_limits<int>::max ());
+        const bool usable = iterations->is_number () &&
+        std::isfinite (iterations->get<double> ()) && iterations->get<double> () >= 1.0 &&
+        iterations->get<double> () <= max_iterations &&
+        iterations->get<double> () == std::floor (iterations->get<double> ());
+        if (!usable) {
+            return "'scenario.iterations' must be a whole number between 1 and "
+                   "2147483647 (got " +
+            iterations->dump () + ")";
+        }
+        out.iterations = static_cast<size_t> (iterations->get<double> ());
+    } else if (has_data) {
+        out.iterations = out.data_row_count;
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
+
+ScenarioResolution resolve_scenario (vayu::db::Database& db,
+const nlohmann::json& scenario,
+const ScenarioResolveOptions& options) {
+    ScenarioResolution resolution;
+    if (auto reason =
+        parse_scenario_request (scenario, options.limits, resolution.request)) {
+        return invalid (*reason);
+    }
+    const ScenarioRequest& request = resolution.request;
+
+    if (!db.get_collection (request.collection_id)) {
+        return invalid ("No collection with id '" + request.collection_id + "'");
+    }
+
+    const auto rows = collect_requests (db, request.collection_id, request.recursive);
+    if (rows.empty ()) {
+        return invalid ("Collection '" + request.collection_id + "' has no requests" +
+        std::string (request.recursive ? " in it or any sub-collection" : "") +
+        ". An empty sequence is a mistake, not a zero-step run.");
+    }
+    if (rows.size () > options.limits.max_steps) {
+        return invalid ("Scenario resolves to " + std::to_string (rows.size ()) +
+        " steps, over the limit of " + std::to_string (options.limits.max_steps) +
+        " (raise the 'maxScenarioSteps' setting to allow more)");
+    }
+
+    resolution.plan.steps.reserve (rows.size ());
+    for (size_t index = 0; index < rows.size (); ++index) {
+        const auto& row = rows[index];
+
+        // The by-id compose path: the same resolution a Send of this request
+        // performs, so a step's request and scripts cannot drift from it.
+        nlohmann::json compose_body{ { "requestId", row.id } };
+        if (!options.environment_id.empty ()) {
+            compose_body["environmentId"] = options.environment_id;
+        }
+        auto [status, payload] = vayu::http::compose_request_core (db, compose_body);
+        if (status != 200) {
+            return invalid ("Cannot compose " + describe_step (index, row) +
+            ": " + compose_error_message (payload));
+        }
+
+        // Auth is resolved into headers/url here, which is what makes the plan
+        // credential-grade and the snapshot manifest necessary.
+        auto built = vayu::http::build_request (payload, &db, options.timeout_ms);
+        if (!built.ok || built.parse_failed) {
+            return invalid ("Cannot compose " + describe_step (index, row) +
+            ": " + built.error_message);
+        }
+
+        ScenarioStep step;
+        step.index       = index;
+        step.request_id  = row.id;
+        step.name        = row.name;
+        step.request     = std::move (built.request);
+        step.pre_script  = vayu::http::read_pre_request_script (payload);
+        step.post_script = vayu::http::read_post_request_script (payload);
+        step.stored_url  = row.url;
+        resolution.plan.steps.push_back (std::move (step));
+    }
+
+    resolution.ok = true;
+    return resolution;
+}
+
+nlohmann::json build_scenario_manifest (const ScenarioRequest& request,
+const ScenarioPlan& plan) {
+    nlohmann::json steps = nlohmann::json::array ();
+    for (const auto& step : plan.steps) {
+        steps.push_back ({ { "index", step.index }, { "requestId", step.request_id },
+        { "name", step.name }, { "method", to_string (step.request.method) },
+        { "url", step.stored_url } });
+    }
+
+    return nlohmann::json{ { "source", request.source },
+        { "collectionId", request.collection_id },
+        { "recursive", request.recursive }, { "iterations", request.iterations },
+        { "dataRowCount", request.data_row_count }, { "steps", std::move (steps) } };
+}
+
+} // namespace vayu::core

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1391,6 +1391,28 @@ void Database::seed_default_config () {
     "general_engine", vayu::to_string (vayu::DEFAULT_HTTP_VERSION),
     std::nullopt, std::nullopt, http_version_options_json (), now });
 
+    upsert_config (ConfigEntry{ "maxScenarioSteps",
+    std::to_string (vayu::core::constants::scenario::MAX_STEPS), "integer",
+    "Maximum Scenario Steps",
+    "Largest number of requests one collection run may resolve to. The whole "
+    "sequence is composed before the first send and held in memory for the "
+    "run, and a load-mode scenario allocates a latency histogram per step, so "
+    "this bounds memory rather than expressing a preference. A collection that "
+    "resolves to more steps than this is rejected outright - the run is never "
+    "silently truncated.",
+    "general_engine", std::to_string (vayu::core::constants::scenario::MAX_STEPS),
+    "1", "10000", std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "maxScenarioDataRows",
+    std::to_string (vayu::core::constants::scenario::MAX_DATA_ROWS), "integer",
+    "Maximum Scenario Data Rows",
+    "Largest data set one collection run may carry. The app parses the CSV or "
+    "JSON file and sends the rows on the run payload - the engine never reads "
+    "a file from disk - so this bounds how big that payload may get. A larger "
+    "data set is rejected rather than truncated.",
+    "general_engine", std::to_string (vayu::core::constants::scenario::MAX_DATA_ROWS),
+    "1", "1000000", std::nullopt, now });
+
     // =========================================================================
     // DATABASE PERFORMANCE CONFIGURATION
     // SQLite optimization settings for high-throughput load testing

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/core/scenario_plan.hpp"
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/request_builder.hpp"
@@ -839,20 +840,31 @@ void register_execution_routes (RouteContext& ctx) {
             return;
         }
 
-        // Validate required fields
-        if (!json.contains ("method") || !json.contains ("url")) {
-            vayu::utils::log_warning (
-            "POST /runs - Missing required fields: method, url");
-            send_error (res, 400, "Missing required fields: method, url");
-            return;
-        }
+        // A scenario run states its work as an ordered collection, so it has no
+        // single method/url to require and states its iteration count inside
+        // the block. Both checks below describe the single-request payload
+        // only; the scenario block's own required fields are checked by
+        // resolve_scenario further down, beside the shared numeric validation.
+        const bool is_scenario =
+        json.contains ("scenario") && !json["scenario"].is_null ();
 
-        if (!json.contains ("mode") && !json.contains ("duration") &&
-        !json.contains ("iterations")) {
-            vayu::utils::log_warning (
-            "POST /runs - Missing mode/duration/iterations config");
-            send_error (res, 400, "Must specify either 'mode' with 'duration' or 'iterations'");
-            return;
+        // Validate required fields
+        if (!is_scenario) {
+            if (!json.contains ("method") || !json.contains ("url")) {
+                vayu::utils::log_warning (
+                "POST /runs - Missing required fields: method, url");
+                send_error (res, 400, "Missing required fields: method, url");
+                return;
+            }
+
+            if (!json.contains ("mode") && !json.contains ("duration") &&
+            !json.contains ("iterations")) {
+                vayu::utils::log_warning (
+                "POST /runs - Missing mode/duration/iterations config");
+                send_error (res, 400,
+                "Must specify either 'mode' with 'duration' or 'iterations'");
+                return;
+            }
         }
 
         // Range-check the numeric config *before* the run row exists, so a
@@ -874,6 +886,58 @@ void register_execution_routes (RouteContext& ctx) {
             "POST /runs - Invalid httpVersion: " + err->second.dump ());
             res.status = err->first;
             res.set_content (err->second.dump (), "application/json");
+            return;
+        }
+
+        // Resolve the scenario block here, with the rest of the pre-row
+        // validation: an unknown collection, an empty sequence or a step that
+        // cannot be composed must leave no run behind, and resolution is what
+        // finds all three. Nothing executes a plan yet, so this returns 501
+        // rather than starting a run - a loud placeholder in place of a run
+        // that would silently do nothing.
+        //
+        // The 501 is returned *before* `create_run` on purpose: a row written
+        // for a run no executor will ever pick up would sit `pending` until a
+        // restart's `reconcile_orphaned_runs` failed it. The sequential runner
+        // replaces this block with the create_run/start_run pair below, and
+        // writes `build_scenario_manifest`'s object into `config_snapshot` in
+        // place of the raw `scenario` block.
+        if (is_scenario) {
+            vayu::core::ScenarioResolveOptions options;
+            if (auto it = json.find ("environmentId");
+                it != json.end () && it->is_string ()) {
+                options.environment_id = it->get<std::string> ();
+            }
+            options.timeout_ms = resolve_request_timeout_ms (json,
+            ctx.db.get_config_int ("defaultTimeout",
+            vayu::core::constants::server::DEFAULT_TIMEOUT_MS));
+            options.limits.max_steps =
+            static_cast<size_t> (ctx.db.get_config_int ("maxScenarioSteps",
+            static_cast<int> (vayu::core::constants::scenario::MAX_STEPS)));
+            options.limits.max_data_rows =
+            static_cast<size_t> (ctx.db.get_config_int ("maxScenarioDataRows",
+            static_cast<int> (vayu::core::constants::scenario::MAX_DATA_ROWS)));
+
+            auto resolved =
+            vayu::core::resolve_scenario (ctx.db, json["scenario"], options);
+            if (!resolved.ok) {
+                vayu::utils::log_warning (
+                "POST /runs - Invalid scenario: " + resolved.error);
+                send_error (res, 400, resolved.error, "invalid_scenario");
+                return;
+            }
+
+            vayu::utils::log_info (
+            "POST /runs - Scenario resolved: collection=" + resolved.request.collection_id +
+            ", steps=" + std::to_string (resolved.plan.steps.size ()) +
+            ", iterations=" + std::to_string (resolved.request.iterations));
+            send_error (res, 501,
+            "Scenario runs are not executed yet. The plan resolved to " +
+            std::to_string (resolved.plan.steps.size ()) + " step(s) over " +
+            std::to_string (resolved.request.iterations) +
+            " iteration(s); the sequential runner that executes it is not in "
+            "this build.",
+            "scenario_not_implemented");
             return;
         }
 

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -1,0 +1,529 @@
+/**
+ * @file tests/scenario_plan_test.cpp
+ * @brief Tests for scenario plan resolution (issue #352, phase 1 of the
+ * collection runner).
+ *
+ * Three contracts are pinned here, and each of them is one a later phase builds
+ * on rather than a detail of this one:
+ *
+ *  - **Ordering.** Direct requests by `requests.order`, then descendant
+ *    collections by `collections.order`, depth-first - and a `parent_id` cycle
+ *    terminates instead of hanging the DB mutex.
+ *  - **No second copy of composition.** A step's request and joined scripts
+ *    equal what `POST /compose` returns for the same `requestId`, so a Send and
+ *    a scenario step cannot drift apart.
+ *  - **The snapshot manifest is credential-free.** It records the *stored* URL
+ *    and no `Authorization` header, which is the decision the whole
+ *    "never persist the composed plan" rule rests on.
+ *
+ * Plus every row of the issue's robustness table: each is a loud `400`, never a
+ * silently smaller run.
+ *
+ * DB-backed tests drive the extracted core against a real database file, no
+ * in-process HTTP server - the same shape as the suite's other route tests.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/core/scenario_plan.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/request_composer.hpp"
+#include "vayu/http/script_parts.hpp"
+
+using nlohmann::json;
+
+namespace {
+
+class ScenarioPlanTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_scenario_plan.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + s);
+        }
+    }
+
+    void seed_collection (const std::string& id,
+    const std::string& parent_id,
+    int order                     = 0,
+    const std::string& auth       = "",
+    const std::string& pre_script = "") {
+        vayu::db::Collection col;
+        col.id = id;
+        if (!parent_id.empty ()) {
+            col.parent_id = parent_id;
+        }
+        col.name               = "Collection " + id;
+        col.auth               = auth;
+        col.pre_request_script = pre_script;
+        col.order              = order;
+        col.created_at         = 1;
+        col.updated_at         = 1;
+        db_->create_collection (col);
+    }
+
+    void seed_request (const std::string& id,
+    const std::string& collection_id,
+    int order                      = 0,
+    const std::string& url         = "https://example.test/{{path}}",
+    const std::string& auth        = "",
+    const std::string& post_script = "") {
+        vayu::db::Request r;
+        r.id                  = id;
+        r.collection_id       = collection_id;
+        r.name                = "Request " + id;
+        r.method              = vayu::HttpMethod::GET;
+        r.url                 = url;
+        r.auth                = auth;
+        r.post_request_script = post_script;
+        r.order               = order;
+        r.created_at          = 1;
+        r.updated_at          = 1;
+        db_->save_request (r);
+    }
+
+    void seed_environment (const std::string& id, const std::string& variables) {
+        vayu::db::Environment env;
+        env.id         = id;
+        env.name       = "Env " + id;
+        env.variables  = variables;
+        env.created_at = 1;
+        env.updated_at = 1;
+        db_->save_environment (env);
+    }
+
+    // Generous bounds unless a test is about a bound.
+    static vayu::core::ScenarioResolveOptions
+    options (size_t max_steps = 200, size_t max_data_rows = 1000) {
+        vayu::core::ScenarioResolveOptions opts;
+        opts.timeout_ms           = 30000;
+        opts.limits.max_steps     = max_steps;
+        opts.limits.max_data_rows = max_data_rows;
+        return opts;
+    }
+
+    static json block (const std::string& collection_id, bool recursive = false) {
+        return json{ { "source", "collection" },
+            { "collectionId", collection_id }, { "recursive", recursive } };
+    }
+
+    std::vector<std::string> step_ids (const vayu::core::ScenarioPlan& plan) {
+        std::vector<std::string> ids;
+        for (const auto& step : plan.steps) {
+            ids.push_back (step.request_id);
+        }
+        return ids;
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// --- Ordering ----------------------------------------------------------------
+
+TEST_F (ScenarioPlanTest, DirectRequestsAreOrderedByRequestOrder) {
+    seed_collection ("col", "");
+    seed_request ("third", "col", /*order=*/2);
+    seed_request ("first", "col", /*order=*/0);
+    seed_request ("second", "col", /*order=*/1);
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (step_ids (resolved.plan),
+    (std::vector<std::string>{ "first", "second", "third" }));
+    // The index is the plan position, not the row's `order`.
+    for (size_t i = 0; i < resolved.plan.steps.size (); ++i) {
+        EXPECT_EQ (resolved.plan.steps[i].index, i);
+    }
+}
+
+TEST_F (ScenarioPlanTest, RecursiveDescentIsDepthFirstByCollectionOrder) {
+    //   root            [root_a, root_b]
+    //     child_b (order 1)  [b_1]
+    //     child_a (order 0)  [a_1]
+    //       grandchild       [g_1]
+    seed_collection ("root", "");
+    seed_collection ("child_b", "root", /*order=*/1);
+    seed_collection ("child_a", "root", /*order=*/0);
+    seed_collection ("grandchild", "child_a", /*order=*/0);
+    seed_request ("root_a", "root", /*order=*/0);
+    seed_request ("root_b", "root", /*order=*/1);
+    seed_request ("b_1", "child_b");
+    seed_request ("a_1", "child_a");
+    seed_request ("g_1", "grandchild");
+
+    const auto resolved = vayu::core::resolve_scenario (
+    *db_, block ("root", /*recursive=*/true), options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (step_ids (resolved.plan),
+    (std::vector<std::string>{ "root_a", "root_b", "a_1", "g_1", "b_1" }));
+}
+
+TEST_F (ScenarioPlanTest, NonRecursiveIgnoresSubCollections) {
+    seed_collection ("root", "");
+    seed_collection ("child", "root");
+    seed_request ("root_only", "root");
+    seed_request ("child_only", "child");
+
+    const auto resolved =
+    vayu::core::resolve_scenario (*db_, block ("root"), options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (step_ids (resolved.plan), (std::vector<std::string>{ "root_only" }));
+}
+
+TEST_F (ScenarioPlanTest, ParentIdCycleTerminatesAndVisitsEachCollectionOnce) {
+    // A -> B -> A. Write-time validation prevents this now, but rows predating
+    // it exist, and an unguarded walk grows forever holding the DB mutex.
+    seed_collection ("a", "b");
+    seed_collection ("b", "a");
+    seed_request ("in_a", "a");
+    seed_request ("in_b", "b");
+
+    const auto resolved =
+    vayu::core::resolve_scenario (*db_, block ("a", /*recursive=*/true), options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (step_ids (resolved.plan), (std::vector<std::string>{ "in_a", "in_b" }));
+}
+
+TEST_F (ScenarioPlanTest, SelfParentingCollectionTerminates) {
+    seed_collection ("loop", "loop");
+    seed_request ("only", "loop");
+
+    const auto resolved = vayu::core::resolve_scenario (
+    *db_, block ("loop", /*recursive=*/true), options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (step_ids (resolved.plan), (std::vector<std::string>{ "only" }));
+}
+
+// --- Composition is the engine's own, not a copy ------------------------------
+
+TEST_F (ScenarioPlanTest, StepMatchesWhatComposeReturnsForTheSameRequest) {
+    seed_collection ("col", "", /*order=*/0, /*auth=*/"",
+    /*pre_script=*/"const fromCollection = 1;");
+    seed_request ("req", "col", /*order=*/0, "https://{{host}}/orders/{{id}}",
+    /*auth=*/R"({"mode":"bearer","token":"{{token}}"})",
+    /*post_script=*/"pm.test('ok', () => {});");
+    seed_environment ("env",
+    R"({"host":{"value":"api.example.test","enabled":true},
+        "id":{"value":"42","enabled":true},
+        "token":{"value":"s3cret","enabled":true}})");
+
+    auto opts           = options ();
+    opts.environment_id = "env";
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), opts);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_EQ (resolved.plan.steps.size (), 1u);
+    const auto& step = resolved.plan.steps[0];
+
+    // The independent reference: the same by-id composition POST /compose runs.
+    auto [status, payload] = vayu::http::compose_request_core (
+    *db_, json{ { "requestId", "req" }, { "environmentId", "env" } });
+    ASSERT_EQ (status, 200) << payload.dump ();
+
+    EXPECT_EQ (step.request.url, payload["url"].get<std::string> ());
+    EXPECT_EQ (to_string (step.request.method), payload["method"].get<std::string> ());
+
+    // Non-empty, so the equalities below are comparing something.
+    const std::string expected_pre = vayu::http::read_pre_request_script (payload);
+    const std::string expected_post = vayu::http::read_post_request_script (payload);
+    ASSERT_FALSE (expected_pre.empty ());
+    ASSERT_FALSE (expected_post.empty ());
+    EXPECT_EQ (step.pre_script, expected_pre);
+    EXPECT_EQ (step.post_script, expected_post);
+
+    // Environment variables resolved, and auth applied into the plan.
+    EXPECT_EQ (step.request.url, "https://api.example.test/orders/42");
+    ASSERT_EQ (step.request.headers.count ("Authorization"), 1u);
+    EXPECT_EQ (step.request.headers.at ("Authorization"), "Bearer s3cret");
+
+    EXPECT_EQ (step.name, "Request req");
+    EXPECT_EQ (step.stored_url, "https://{{host}}/orders/{{id}}");
+}
+
+TEST_F (ScenarioPlanTest, StepsResolveAgainstTheRunsEnvironment) {
+    // Without the run's environmentId reaching composition, every {{env var}}
+    // in the plan silently resolves to "" - the failure this guards.
+    seed_collection ("col", "");
+    seed_request ("req", "col", 0, "https://{{host}}/ping");
+    seed_environment ("env", R"({"host":{"value":"api.example.test"}})");
+
+    auto opts           = options ();
+    opts.environment_id = "env";
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), opts);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (resolved.plan.steps[0].request.url, "https://api.example.test/ping");
+}
+
+// --- The snapshot manifest ----------------------------------------------------
+
+TEST_F (ScenarioPlanTest, ManifestCarriesStoredUrlsAndNoCredentialMaterial) {
+    seed_collection ("col", "");
+    // Two shapes, because they leak differently: bearer lands in a header, and
+    // an apikey with `in: "query"` puts a live key in the composed URL.
+    seed_request ("bearer_req", "col", /*order=*/0, "https://{{host}}/private",
+    R"({"mode":"bearer","token":"{{token}}"})");
+    seed_request ("apikey_req", "col", /*order=*/1, "https://{{host}}/search",
+    R"({"mode":"apikey","key":"api_key","value":"{{token}}","in":"query"})");
+    seed_environment ("env",
+    R"({"host":{"value":"api.example.test","enabled":true},
+        "token":{"value":"s3cret","enabled":true}})");
+
+    auto opts           = options ();
+    opts.environment_id = "env";
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), opts);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_EQ (resolved.plan.steps.size (), 2u);
+
+    // The plan itself is credential-grade - that is why it is never persisted.
+    ASSERT_EQ (resolved.plan.steps[0].request.headers.count ("Authorization"), 1u);
+    EXPECT_NE (resolved.plan.steps[1].request.url.find ("s3cret"), std::string::npos);
+
+    const json manifest =
+    vayu::core::build_scenario_manifest (resolved.request, resolved.plan);
+    const std::string text = manifest.dump ();
+    EXPECT_EQ (text.find ("s3cret"), std::string::npos) << text;
+    EXPECT_EQ (text.find ("Authorization"), std::string::npos) << text;
+
+    ASSERT_EQ (manifest["steps"].size (), 2u);
+    EXPECT_EQ (manifest["steps"][0]["url"], "https://{{host}}/private");
+    EXPECT_EQ (manifest["steps"][1]["url"], "https://{{host}}/search");
+    EXPECT_EQ (manifest["steps"][0]["index"], 0);
+    EXPECT_EQ (manifest["steps"][0]["requestId"], "bearer_req");
+    EXPECT_EQ (manifest["steps"][0]["name"], "Request bearer_req");
+    EXPECT_EQ (manifest["steps"][0]["method"], "GET");
+
+    EXPECT_EQ (manifest["source"], "collection");
+    EXPECT_EQ (manifest["collectionId"], "col");
+    EXPECT_EQ (manifest["recursive"], false);
+    EXPECT_EQ (manifest["iterations"], 1);
+    EXPECT_EQ (manifest["dataRowCount"], 0);
+}
+
+TEST_F (ScenarioPlanTest, ManifestRecordsOnlyTheDataRowCount) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json scenario = block ("col");
+    scenario["data"] =
+    json::array ({ json{ { "user", "alice" } }, json{ { "user", "bob" } } });
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+
+    const json manifest =
+    vayu::core::build_scenario_manifest (resolved.request, resolved.plan);
+    EXPECT_EQ (manifest["dataRowCount"], 2);
+    // Absent `iterations` with a data set means one pass per row.
+    EXPECT_EQ (manifest["iterations"], 2);
+    EXPECT_EQ (manifest.dump ().find ("alice"), std::string::npos);
+}
+
+TEST_F (ScenarioPlanTest, ExplicitIterationsWinsOverTheRowCount) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json scenario          = block ("col");
+    scenario["data"]       = json::array ({ json{ { "user", "alice" } } });
+    scenario["iterations"] = 5;
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (resolved.request.iterations, 5u);
+    EXPECT_EQ (resolved.request.data_row_count, 1u);
+}
+
+// --- The robustness table -----------------------------------------------------
+
+TEST_F (ScenarioPlanTest, UnknownCollectionIdIsRejectedAndEchoed) {
+    const auto resolved =
+    vayu::core::resolve_scenario (*db_, block ("col_missing"), options ());
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("col_missing"), std::string::npos)
+    << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, EmptyCollectionIsRejected) {
+    seed_collection ("col", "");
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("no requests"), std::string::npos)
+    << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, EmptyIsJudgedAfterRecursiveIsApplied) {
+    // Requests exist, but only below a sub-collection this run does not descend
+    // into - so the sequence really is empty.
+    seed_collection ("root", "");
+    seed_collection ("child", "root");
+    seed_request ("child_only", "child");
+
+    EXPECT_FALSE (
+    vayu::core::resolve_scenario (*db_, block ("root"), options ()).ok);
+    EXPECT_TRUE (vayu::core::resolve_scenario (
+    *db_, block ("root", /*recursive=*/true), options ())
+                 .ok);
+}
+
+TEST_F (ScenarioPlanTest, AStepThatCannotComposeNamesTheOffendingRequest) {
+    seed_collection ("col", "");
+    seed_request ("ok_req", "col", /*order=*/0);
+    // OAuth 2.0 with auto-fetch off and nothing in the token cache: the auth
+    // cannot be resolved, so this step has no execute-ready request.
+    seed_request ("broken_req", "col", /*order=*/1, "https://example.test/x",
+    R"({"mode":"oauth2","config":{"autoFetchToken":false,"tokenUrl":"https://auth.test/token","clientId":"c"}})");
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("broken_req"), std::string::npos)
+    << resolved.error;
+    EXPECT_NE (resolved.error.find ("Request broken_req"), std::string::npos)
+    << resolved.error;
+    EXPECT_NE (resolved.error.find ("step 1"), std::string::npos) << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, PlanOverMaxStepsIsRejectedWithCountAndCap) {
+    seed_collection ("col", "");
+    for (int i = 0; i < 3; ++i) {
+        seed_request ("req_" + std::to_string (i), "col", i);
+    }
+
+    const auto resolved =
+    vayu::core::resolve_scenario (*db_, block ("col"), options (/*max_steps=*/2));
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("3 steps"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ("2"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ("maxScenarioSteps"), std::string::npos)
+    << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, PresentButEmptyDataIsRejected) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json scenario    = block ("col");
+    scenario["data"] = json::array ();
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("empty"), std::string::npos) << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, DataRowsOverTheCapAreRejectedWithCountAndCap) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json rows = json::array ();
+    for (int i = 0; i < 4; ++i) {
+        rows.push_back (json{ { "n", i } });
+    }
+    json scenario    = block ("col");
+    scenario["data"] = rows;
+
+    const auto resolved = vayu::core::resolve_scenario (
+    *db_, scenario, options (/*max_steps=*/200, /*max_data_rows=*/3));
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("4 rows"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ("maxScenarioDataRows"), std::string::npos)
+    << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, ANonObjectDataRowIsRejectedByIndex) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json scenario    = block ("col");
+    scenario["data"] = json::array ({ json{ { "user", "alice" } }, "bob" });
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("row 1"), std::string::npos) << resolved.error;
+}
+
+TEST_F (ScenarioPlanTest, AnUnknownSourceDoesNotFallThroughToTheCollectionPath) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json scenario      = block ("col");
+    scenario["source"] = "stored";
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("source"), std::string::npos) << resolved.error;
+    EXPECT_TRUE (resolved.plan.steps.empty ());
+}
+
+TEST_F (ScenarioPlanTest, AMissingSourceIsRejectedRatherThanAssumed) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    json scenario = block ("col");
+    scenario.erase ("source");
+    EXPECT_FALSE (vayu::core::resolve_scenario (*db_, scenario, options ()).ok);
+}
+
+TEST_F (ScenarioPlanTest, MalformedBlockFieldsAreRejected) {
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    const auto rejected = [&] (json scenario) {
+        const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+        EXPECT_FALSE (resolved.ok) << scenario.dump ();
+        EXPECT_FALSE (resolved.error.empty ());
+    };
+
+    rejected (json ("not an object"));
+    rejected (json{ { "source", "collection" } }); // no collectionId
+    rejected (json{ { "source", "collection" }, { "collectionId", "" } });
+    rejected (json{ { "source", "collection" }, { "collectionId", 7 } });
+    {
+        json s         = block ("col");
+        s["recursive"] = "yes";
+        rejected (s);
+    }
+    {
+        json s          = block ("col");
+        s["iterations"] = 0;
+        rejected (s);
+    }
+    {
+        json s          = block ("col");
+        s["iterations"] = 1.5;
+        rejected (s);
+    }
+    {
+        json s          = block ("col");
+        s["iterations"] = "3";
+        rejected (s);
+    }
+    {
+        json s    = block ("col");
+        s["data"] = json::object ();
+        rejected (s);
+    }
+}
+
+TEST_F (ScenarioPlanTest, ResolutionNeverWritesARunRow) {
+    // The route returns before `create_run`, and resolution itself must have no
+    // way to strand a row - a rejected scenario leaves nothing behind, and so
+    // does an accepted one until the runner exists to start it.
+    seed_collection ("col", "");
+    seed_request ("req", "col");
+
+    EXPECT_FALSE (
+    vayu::core::resolve_scenario (*db_, block ("col_missing"), options ()).ok);
+    EXPECT_TRUE (vayu::core::resolve_scenario (*db_, block ("col"), options ()).ok);
+    EXPECT_TRUE (db_->get_all_runs ().empty ());
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Phase 1 of the collection runner (design doc: `docs/plans/collection-runner-design.md`
sections 2 and 3.7). Nothing executes yet.

**Plan (root cause, approach, rejected alternative).** The engine holds no object
that contains an ordered sequence of requests - `run_collection_smoke` is a
client-side TypeScript loop over independent `POST /execute` calls, and
`execute_load_test` repeats one composed request - so there is nowhere for a
sequential runner, flow control, iteration data or a per-VU state machine to
attach. The approach is a new `core/scenario_plan.{hpp,cpp}` that resolves
`{source, collectionId, recursive}` into an ordered vector of **fully composed**
steps, once, before anything is sent, and a `scenario` block on `POST /runs`
that validates and resolves it beside the existing `validate_run_config` /
`normalize_run_http_version` checks. I rejected composing steps lazily at send
time (the obvious smaller diff): it would let a collection edited mid-run change
the sequence underneath itself, and phase 6's per-VU executor cannot put SQLite
on the hot path - so lazy composition is a stopgap load mode would have to undo.

Verified against live code before writing: the anchors in the issue still hold -
`compose_request_core` at `request_composer.cpp:454`, `execute_load_test` at
`run_manager.cpp:588`, the smoke handler in `app/electron/mcp/tools.ts`.

**Blast radius traced.** `POST /runs` has three callers - the renderer's load
dialog, MCP's `start_load_run`, and the deprecated `POST /run` alias. None sends
a `scenario` key, and the branch is entered only when one is present, so every
existing payload takes exactly the path it did before. Nothing consumes
`ScenarioPlan` yet by design; the one field that could have gone unread
(`ScenarioStep::stored_url`) exists precisely so the manifest can record a
persistable URL without re-reading the row, and its reader
(`build_scenario_manifest`) is in the same commit and pinned by a test.

### What lands

- **`ScenarioPlan` resolution.** Direct requests by `requests.order`, then -
  with `recursive` - descendant collections by `collections.order`, depth-first.
  The walk carries a visited set exactly as `Database::delete_collection`'s BFS
  does, so a `parent_id` cycle terminates instead of growing forever under the
  DB mutex. Composition goes through `compose_request_core` + `build_request`
  and the script join through `read_pre_request_script` /
  `read_post_request_script` - no second copy of resolution, and a step is
  byte-identical to what a Send of the same request would run.
- **The `scenario` block on `POST /runs`,** validated before `create_run`. Every
  rejection is a `400` with `error.code: "invalid_scenario"`; a valid block
  answers `501` (`scenario_not_implemented`) naming the step and iteration count
  it resolved to.
- **`build_scenario_manifest`** - the object phase 2 writes into
  `runs.config_snapshot`: `{index, requestId, name, method, url}` per step with
  the **stored, uncomposed** URL, plus the request and the data **row count**.
  The composed plan is credential-grade, and `sanitize_config_snapshot` exists
  to keep exactly that out of the run store.
- **Config keys** `maxScenarioSteps` (200) and `maxScenarioDataRows` (1000),
  both `general_engine`, seeded with labels and ranges.

### Two deliberate deviations from the issue text

1. **The `501` is returned before `create_run`, so no run row is written.** The
   issue reads "resolves, validates, snapshots, and then returns 501", which
   implies a row. A `runs` row for a run no executor will ever pick up sits
   `pending` until a restart's `reconcile_orphaned_runs` fails it - the stranded-row
   class the codebase already guards against elsewhere - so writing one would be
   a stopgap. Phase 2 replaces the `501` with the `create_run`/`start_run` pair
   and writes `build_scenario_manifest`'s object into `config_snapshot` at that
   point; the route comment says so at the exact line. The manifest's shape is
   fully pinned by tests today, and `ResolutionNeverWritesARunRow` pins that
   resolution itself cannot strand a row.
2. **Resolution takes the run's `environmentId`.** The issue's signature is
   `{source, collectionId, recursive}` + `Database&`. Without the environment,
   every `{{env var}}` in the plan silently resolves to `""` - a wrong plan
   rather than a loud failure. It rides on `ScenarioResolveOptions`, not on the
   `scenario` block, because it is the *run's* environment;
   `StepsResolveAgainstTheRunsEnvironment` is the mutation-check for it.

`iterations` is validated and resolved here (explicit wins, else the data row
count, else 1) because §3.7 requires the snapshot to record it, and a snapshot
recording an unvalidated count would be untruthful. No new knob: the bound is
`1`-`2147483647`, a type-safety guard on a value read as a count.

No app changes - the issue's "App changes" section is `None`, and `501` is not a
state the app can reach before the phase-3 runner UI.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**932/932 passing**, of which 24 are new in `engine/tests/scenario_plan_test.cpp`.
No pre-existing failures on this base.

Each new test is mutation-checked - reverting the behaviour it covers turns it
red:

- **Ordering** - direct requests by `order`; recursive descent depth-first by
  collection `order`; non-recursive ignores sub-collections; an A→B→A cycle and
  a self-parenting collection both terminate and visit each collection once.
- **No drift from compose** - a step's `url`, `method` and both joined scripts
  equal what `compose_request_core` returns for the same `requestId` (asserted
  non-empty first, so the equality is scanning something), plus the resolved
  environment variables and the applied `Authorization` header.
- **The manifest is credential-free** - built from a plan whose steps carry a
  bearer `Authorization` header *and* an `apikey`/`in: "query"` live key in the
  composed URL (both asserted present on the plan), the manifest contains
  neither the secret nor the string `Authorization`, and both `url`s are the
  stored `{{host}}` ones. Data rows are counted, never recorded.
- **Every row of the robustness table** - unknown `collectionId` (echoed), empty
  collection, emptiness judged *after* `recursive` is applied, a step that
  cannot compose (named by index, name and id), over `maxScenarioSteps`,
  present-but-empty `data`, over `maxScenarioDataRows`, a non-object data row by
  index, an unknown `source`, a missing `source`, and every malformed field
  shape.
- **`ResolutionNeverWritesARunRow`** - the `runs` table is empty after both a
  rejected and an accepted resolution.

Format: `clang-format` clean on the three new files and on every line added to
`execution.cpp` (that file was not clang-format-clean before, so it was not
reformatted wholesale).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #352

Unblocks #353 (phase 2), and through it #354, #355, #356 and #357.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vpERTKbggUNqVR6paJoP7)_