### PR TITLE
fix(engine/app): make the order column real - append on create, pin the tie rule, validate moves

### DIFF
--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -8,7 +8,7 @@
 import { ChevronRight, ChevronDown, Folder, FolderOpen, Loader2 } from "lucide-react";
 import RequestItem from "./RequestItem";
 import type { Collection, Request } from "@/types";
-import { compareCollectionOrder } from "@/types";
+import { compareTreeOrder } from "@/types";
 import { Button, Input } from "@/components/ui";
 import { RowActionsMenu, TruncatedText, type RowAction } from "@/components/shared";
 import { cn } from "@/lib/utils";
@@ -97,7 +97,7 @@ export default function CollectionItem({
 	const isDeleting = deletingCollectionId === collection.id;
 	const childCollections = allCollections
 		.filter((c) => c.parentId === collection.id)
-		.sort(compareCollectionOrder);
+		.sort(compareTreeOrder);
 
 	const handleClick = (e: React.MouseEvent) => {
 		if (isDeleting || isRenaming) return;

--- a/app/src/modules/collections/CollectionTree.duplicate-order.test.tsx
+++ b/app/src/modules/collections/CollectionTree.duplicate-order.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A duplicated request lands next to the one it was copied from (issue #360).
+ *
+ * The engine now appends a created request that states no `order`, which is
+ * right for "New request" and wrong for "Duplicate" - a copy that jumps to the
+ * bottom of a long collection reads as a failed action. The copy therefore
+ * states its source's own `order`, and the shared tie rule (`compareTreeOrder`:
+ * order, then createdAt, then id) puts the newer row immediately after. No
+ * sibling is renumbered, so this needs no multi-row write.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useCollectionsStore } from "./collections-store";
+import { compareTreeOrder } from "@/types";
+import CollectionTree from "./CollectionTree";
+
+const createRequest = vi.fn();
+
+const collection = { id: "c1", name: "Acme API", order: 0 };
+// The source sits in the middle, so "appended" and "adjacent" are different
+// outcomes rather than the same one by accident.
+const first = { id: "r0", collectionId: "c1", name: "First", method: "GET", order: 0 };
+const source = {
+	id: "r1",
+	collectionId: "c1",
+	name: "Get users",
+	method: "GET",
+	order: 1,
+	description: "d",
+	createdAt: "2026-01-01T00:00:00.000Z",
+};
+const last = { id: "r2", collectionId: "c1", name: "Last", method: "GET", order: 2 };
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({
+		data: [collection],
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({
+		requestsByCollection: new Map([["c1", [first, source, last]]]),
+	}),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: createRequest, isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderTree() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	createRequest.mockReset();
+	createRequest.mockResolvedValue({ id: "r1_copy", collectionId: "c1" });
+	useCollectionsStore.setState({ expandedCollectionIds: new Set(["c1"]) });
+});
+
+describe("duplicating a request", () => {
+	it("sends the source's order rather than leaving it to the engine's append", async () => {
+		renderTree();
+
+		const row = document.querySelector<HTMLElement>('[data-request-id="r1"]')!;
+		// Radix opens its dropdown on pointerdown, not click.
+		fireEvent.pointerDown(
+			within(row, /more/i),
+			new PointerEvent("pointerdown", { bubbles: true, button: 0 })
+		);
+		fireEvent.click(await screen.findByText("Duplicate"));
+
+		await waitFor(() => expect(createRequest).toHaveBeenCalled());
+		const sent = createRequest.mock.calls[0][0];
+		expect(sent.order).toBe(source.order);
+		expect(sent.name).toBe("Get users (Copy)");
+	});
+
+	it("that order places the copy directly after its source, not at the end", () => {
+		// The rule the choice above relies on, applied to what the engine would
+		// send back: same order, newer createdAt.
+		const copy = {
+			id: "r1_copy",
+			order: source.order,
+			createdAt: "2026-06-01T00:00:00.000Z",
+		};
+		const sorted = [first, source, last, copy].sort(compareTreeOrder);
+		expect(sorted.map((r) => r.id)).toEqual(["r0", "r1", "r1_copy", "r2"]);
+	});
+});
+
+/** The row's "⋯" trigger - it is the only button in the row besides the row itself. */
+function within(row: HTMLElement, name: RegExp): HTMLElement {
+	const buttons = Array.from(row.querySelectorAll("button"));
+	const match = buttons.find((b) => name.test(b.getAttribute("aria-label") ?? ""));
+	if (!match) {
+		throw new Error(
+			`no button matching ${name} in row; saw: ${buttons
+				.map((b) => b.getAttribute("aria-label"))
+				.join(", ")}`
+		);
+	}
+	return match;
+}

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -32,7 +32,7 @@ import { useRovingTreeFocus } from "./useRovingTreeFocus";
 import { DrawerPanel, EmptyState, ErrorState, ListSkeleton } from "@/components/shared";
 import type { RowAction } from "@/components/shared";
 import type { Collection, Request } from "@/types";
-import { compareCollectionOrder } from "@/types";
+import { compareTreeOrder } from "@/types";
 import { TIMING } from "@/config/timing";
 import { DEFAULT_REQUEST_NAME } from "@/constants/request";
 import { DEFAULT_COLLECTION_NAME, DEFAULT_FOLDER_NAME } from "@/constants/collection";
@@ -101,7 +101,7 @@ export default function CollectionTree() {
 	);
 
 	const rootCollections = useMemo(
-		() => [...collections].filter((c) => !c.parentId).sort(compareCollectionOrder),
+		() => [...collections].filter((c) => !c.parentId).sort(compareTreeOrder),
 		[collections]
 	);
 
@@ -379,6 +379,16 @@ export default function CollectionTree() {
 					auth: request.auth,
 					preRequestScript: request.preRequestScript,
 					postRequestScript: request.postRequestScript,
+					/*
+					 * The copy takes its source's `order`, which lands it directly
+					 * *after* the source: the tie falls to `createdAt` and the copy is
+					 * newer (see `compareTreeOrder`, pinned to the engine's SQL). An
+					 * omitted order would append it to the end of the collection, and
+					 * inserting it at `order + 1` would need every following sibling
+					 * renumbered - a multi-row write that belongs to the atomic batch
+					 * reorder endpoint, not to a duplicate.
+					 */
+					order: request.order,
 				});
 				openTab({ type: "request", entityId: copy.id });
 			} catch (error) {

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -27,7 +27,7 @@ import type {
 	CreateRequestRequest,
 	UpdateRequestRequest,
 } from "@/types";
-import { compareCollectionOrder } from "@/types";
+import { compareTreeOrder } from "@/types";
 
 // ============ Collection Queries ============
 
@@ -86,15 +86,6 @@ export function useRequestsQuery(collectionId: string | null) {
 	});
 }
 
-/** Requests within a collection are ordered by `order`, then by creation time. */
-function compareRequestOrder(a: Request, b: Request): number {
-	const orderDiff = (a.order ?? 0) - (b.order ?? 0);
-	if (orderDiff !== 0) return orderDiff;
-	const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-	const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-	return aTime - bTime;
-}
-
 /**
  * Fetch requests for multiple collections (e.g., all expanded ones)
  * Uses TanStack Query's useQueries for parallel fetching.
@@ -130,7 +121,7 @@ export function useMultipleCollectionRequests(collectionIds: string[]) {
 				const requests = query.data ?? [];
 				requestsByCollection.set(
 					stableCollectionIds[index],
-					[...requests].sort(compareRequestOrder)
+					[...requests].sort(compareTreeOrder)
 				);
 			});
 			return {
@@ -271,7 +262,7 @@ export function useCreateCollectionMutation() {
 		onSuccess: (newCollection) => {
 			queryClient.setQueryData<Collection[]>(queryKeys.collections.list(), (old) => {
 				const next = old ? [...old, newCollection] : [newCollection];
-				return next.sort(compareCollectionOrder);
+				return next.sort(compareTreeOrder);
 			});
 			// The warm-cache pass is a query like any other: it succeeded once at
 			// startup and would stay fresh forever, so a collection created
@@ -293,7 +284,7 @@ export function useUpdateCollectionMutation() {
 			queryClient.setQueryData<Collection[]>(queryKeys.collections.list(), (old) => {
 				const next =
 					old?.map((c) => (c.id === updatedCollection.id ? updatedCollection : c)) ?? [];
-				return next.sort(compareCollectionOrder);
+				return next.sort(compareTreeOrder);
 			});
 		},
 	});
@@ -364,11 +355,29 @@ export function useUpdateRequestMutation() {
 	return useMutation({
 		mutationFn: (data: UpdateRequestRequest) => apiService.updateRequest(data),
 		onSuccess: (updatedRequest) => {
-			// Update in cache - need to find which collection it belongs to
-			// Invalidate all request lists to be safe
-			queryClient.invalidateQueries({
-				queryKey: queryKeys.requests.lists(),
-			});
+			/*
+			 * Only the lists that can have changed. This used to invalidate every
+			 * collection's list on any single-request update, so a rename refetched
+			 * the whole tree - and the sibling PUTs a reorder issues would storm the
+			 * engine once per row.
+			 *
+			 * A cross-collection move touches two lists. The response carries only
+			 * the *new* collectionId, so the source is read from the detail cache,
+			 * which still holds the pre-update row until the write below - the one
+			 * place the old owner is knowable. An uncached detail (nothing had the
+			 * request open) leaves the source list to its normal staleness rather
+			 * than reinstating the fan-out.
+			 */
+			const previous = queryClient.getQueryData<Request>(
+				queryKeys.requests.detail(updatedRequest.id)
+			);
+			const affected = new Set([updatedRequest.collectionId]);
+			if (previous?.collectionId) affected.add(previous.collectionId);
+			for (const collectionId of affected) {
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.requests.listByCollection(collectionId),
+				});
+			}
 			// Update detail cache
 			queryClient.setQueryData(queryKeys.requests.detail(updatedRequest.id), updatedRequest);
 		},

--- a/app/src/queries/request-update-invalidation.test.tsx
+++ b/app/src/queries/request-update-invalidation.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Updating one request invalidates the lists that can have changed, and no
+ * others (issue #360).
+ *
+ * `useUpdateRequestMutation` used to invalidate `requests.lists()` - *every*
+ * collection's list - on any single-request write, so renaming one request
+ * refetched the whole tree. Reorder is a run of sibling PUTs, which turned that
+ * into one full-tree refetch per row.
+ *
+ * "Invalidated" is the assertion, not "absent": invalidation is what sends the
+ * next read back to the engine, and `getQueryData` looks identical either way
+ * (same shape as `collection-cascade-delete.test.tsx`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useUpdateRequestMutation } from "./collections";
+import { queryKeys } from "./keys";
+import type { Request } from "@/types";
+
+const updateRequest = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		updateRequest: (...a: unknown[]) => updateRequest(...a),
+	},
+}));
+
+const req = (id: string, collectionId: string): Request =>
+	({ id, collectionId, name: id, order: 0 }) as unknown as Request;
+
+function makeClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+/** Three collections with a cached list each, plus the request's detail entry. */
+function seed(client: QueryClient) {
+	for (const id of ["col_a", "col_b", "col_c"]) {
+		client.setQueryData(queryKeys.requests.listByCollection(id), []);
+	}
+	client.setQueryData(queryKeys.requests.detail("req_1"), req("req_1", "col_a"));
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("useUpdateRequestMutation invalidates only the affected lists", () => {
+	it("touches one list when a request is renamed in place", async () => {
+		updateRequest.mockResolvedValue({ ...req("req_1", "col_a"), name: "Renamed" });
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useUpdateRequestMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync({ id: "req_1", name: "Renamed" });
+
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_a"))?.isInvalidated
+		).toBe(true);
+		// The two uninvolved collections. Reverting to `invalidateQueries(lists())`
+		// turns both of these true.
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_b"))?.isInvalidated
+		).toBe(false);
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_c"))?.isInvalidated
+		).toBe(false);
+	});
+
+	it("touches both sides of a cross-collection move", async () => {
+		updateRequest.mockResolvedValue(req("req_1", "col_b"));
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useUpdateRequestMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync({ id: "req_1", collectionId: "col_b" });
+
+		// Destination, from the response; source, from the detail cache's
+		// pre-update row - the only place the old owner is still knowable.
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_b"))?.isInvalidated
+		).toBe(true);
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_a"))?.isInvalidated
+		).toBe(true);
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_c"))?.isInvalidated
+		).toBe(false);
+	});
+
+	it("writes the updated row into the detail cache", async () => {
+		const updated = { ...req("req_1", "col_a"), name: "Renamed" };
+		updateRequest.mockResolvedValue(updated);
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useUpdateRequestMutation(), {
+			wrapper: wrapper(client),
+		});
+		await result.current.mutateAsync({ id: "req_1", name: "Renamed" });
+
+		expect(client.getQueryData(queryKeys.requests.detail("req_1"))).toEqual(updated);
+	});
+});

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -183,7 +183,6 @@ export const apiService = {
 	},
 
 	async updateRequest(data: UpdateRequestRequest): Promise<Request> {
-		console.log("Updating request with data:", data);
 		// PUT, not POST - see updateCollection above for why.
 		const { id, ...patch } = data;
 		const response = await httpClient.put<RawRequest>(API_ENDPOINTS.REQUESTS_UPDATE(id), patch);

--- a/app/src/services/api.write-verbs.test.ts
+++ b/app/src/services/api.write-verbs.test.ts
@@ -70,6 +70,20 @@ describe("resource writes use POST to create and PUT to update", () => {
 		expect(put.mock.calls[0][1]).not.toHaveProperty("id");
 	});
 
+	it("sends parentId: null through to the wire for a move to the root", async () => {
+		// Absent means "keep the parent" to the engine, so a move out of a folder
+		// exists only as a null that survives serialization. `UpdateCollectionRequest.parentId`
+		// was typed `string`, which made this call unwriteable rather than wrong.
+		await apiService.updateCollection({ id: "col_1", parentId: null });
+		expect(put).toHaveBeenCalledWith("/collections/col_1", { parentId: null });
+		expect(JSON.stringify(put.mock.calls[0][1])).toContain('"parentId":null');
+	});
+
+	it("sends collectionId on a request update, so a move reaches the engine", async () => {
+		await apiService.updateRequest({ id: "req_1", collectionId: "col_2" });
+		expect(put).toHaveBeenCalledWith("/requests/req_1", { collectionId: "col_2" });
+	});
+
 	it("creates a request with POST /requests", async () => {
 		await apiService.createRequest({
 			collectionId: "col_1",

--- a/app/src/services/importers/orchestrator.fixture-parity.test.ts
+++ b/app/src/services/importers/orchestrator.fixture-parity.test.ts
@@ -41,13 +41,22 @@ function legacyCreates(result: ImportResult, options: ImportOptions) {
 	const requests: Record<string, unknown>[] = [];
 	const environments: Record<string, unknown>[] = [];
 
-	const createTree = (c: CollectionDraft, parentId: string | undefined, order: number) => {
+	const createTree = (
+		c: CollectionDraft,
+		parentId: string | undefined,
+		order: number | undefined
+	) => {
 		collections.push({
 			id: c.tempId,
 			name: c.name,
 			description: c.description,
 			parentId,
-			order,
+			// One deliberate divergence from the per-item path (issue #360): a root
+			// states no order, so the engine appends it after the workspace's
+			// existing roots instead of colliding with their 0, 1, 2... Everything
+			// below a root still carries its index, and that is what this walk is
+			// still guarding.
+			...(order !== undefined ? { order } : {}),
 			variables: c.variables,
 			auth: c.auth,
 			preRequestScript: c.preRequestScript,
@@ -75,8 +84,7 @@ function legacyCreates(result: ImportResult, options: ImportOptions) {
 		for (let i = 0; i < c.children.length; i++) createTree(c.children[i], c.tempId, i);
 	};
 
-	for (let i = 0; i < result.collections.length; i++)
-		createTree(result.collections[i], undefined, i);
+	for (const root of result.collections) createTree(root, undefined, undefined);
 	if (options.importEnvironments) {
 		for (const e of result.environments) {
 			environments.push({

--- a/app/src/services/importers/orchestrator.test.ts
+++ b/app/src/services/importers/orchestrator.test.ts
@@ -165,9 +165,18 @@ describe("ImportOrchestrator", () => {
 		const root = collections[0];
 		const child = collections[1];
 		expect(root.parentTempId).toBeNull();
-		expect(root.order).toBe(0);
+		/*
+		 * A root states no order at all (issue #360). The engine's create path
+		 * appends after the roots already in the workspace; sending the payload
+		 * index collided with their 0, 1, 2... and an import into a non-empty
+		 * workspace interleaved itself through the user's tree by tie lottery.
+		 * Asserted as an absent *key*, not `undefined`: the field appliers read
+		 * presence, and `order: undefined` would serialize away in a way this
+		 * assertion could not tell from the real thing.
+		 */
+		expect("order" in root).toBe(false);
 		expect(child.parentTempId).toBe(root.tempId);
-		expect(child.order).toBe(0); // first child of its own parent
+		expect(child.order).toBe(0); // first child of its own parent, no collision
 
 		const r1 = requests.find((r) => r.name === "r1")!;
 		const r2 = requests.find((r) => r.name === "r2")!;

--- a/app/src/services/importers/orchestrator.ts
+++ b/app/src/services/importers/orchestrator.ts
@@ -49,8 +49,18 @@ export class ImportOrchestrator {
 
 		// Note: opts.importScripts is applied at PARSE time by the parsers (they emit empty scripts
 		// when false). The orchestrator only needs importEnvironments.
-		for (let i = 0; i < result.collections.length; i++) {
-			flatten(result.collections[i], null, i, collections, requests);
+		/*
+		 * Root collections state no `order`. They are joining a list that already
+		 * has occupants, and the engine's create path appends after the stored
+		 * roots (handing out consecutive slots from there for a bulk payload).
+		 * Sending the payload index instead collided head-on with the existing
+		 * roots' 0, 1, 2..., so an import into a non-empty workspace interleaved
+		 * itself through the user's tree by tie lottery instead of landing at the
+		 * end. Everything below a root keeps its explicit index - those parents
+		 * are new in this payload, so there is nothing to collide with.
+		 */
+		for (const root of result.collections) {
+			flatten(root, null, undefined, collections, requests);
 		}
 
 		const environments: ImportApplyEnvironment[] = opts.importEnvironments
@@ -107,11 +117,19 @@ export class ImportOrchestrator {
 	}
 }
 
-/** Depth-first, parents before their requests before their children - the tree order the preview shows. */
+/**
+ * Depth-first, parents before their requests before their children - the tree
+ * order the preview shows.
+ *
+ * `order` is `undefined` for a root, which leaves the slot to the engine's
+ * append path (see `run`). Spread rather than assigned, for the same reason the
+ * redirect fields below are: "absent" is the state the engine's field appliers
+ * read, and the payload is compared structurally in tests.
+ */
 function flatten(
 	c: CollectionDraft,
 	parentTempId: string | null,
-	order: number,
+	order: number | undefined,
 	collections: ImportApplyCollection[],
 	requests: ImportApplyRequestItem[]
 ): void {
@@ -121,7 +139,7 @@ function flatten(
 		parentTempId,
 		name: c.name,
 		description: c.description,
-		order,
+		...(order !== undefined ? { order } : {}),
 		variables: c.variables,
 		auth: c.auth,
 		preRequestScript: c.preRequestScript,

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -109,7 +109,12 @@ export interface UpdateCollectionRequest {
 	id: string;
 	name?: string;
 	description?: string;
-	parentId?: string;
+	/**
+	 * `string | null`, not `string`: the engine reads absent as "keep the current
+	 * parent" and an explicit JSON `null` as "move to the root", so a move out of
+	 * a folder is only expressible as a null that survives to the wire.
+	 */
+	parentId?: string | null;
 	order?: number;
 	variables?: Record<string, VariableValue>;
 	auth?: Exclude<RequestAuth, { mode: "inherit" }>;
@@ -149,6 +154,12 @@ export interface CreateRequestRequest {
 
 export interface UpdateRequestRequest {
 	id: string;
+	/**
+	 * The collection this request should belong to - a cross-collection move.
+	 * The engine 400s an id that resolves to no collection rather than stranding
+	 * the row, and a move that states no `order` appends in the destination.
+	 */
+	collectionId?: string;
 	name?: string;
 	description?: string;
 	method?: string;

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -141,11 +141,47 @@ export interface Collection {
 	updatedAt: string;
 }
 
-/** Stable comparator for sorting collections by order, then by id. */
-export function compareCollectionOrder(a: Collection, b: Collection): number {
+/** A row the sidebar places in a tree - a {@link Collection} or a {@link Request}. */
+export interface OrderedTreeRow {
+	order?: number;
+	createdAt?: string;
+	id?: string;
+}
+
+/**
+ * The one ordering rule for collections and requests alike: `order` ascending,
+ * ties by creation time, remaining ties by id.
+ *
+ * There used to be two comparators with two different tie rules - collections
+ * tiebroke by id, requests by `createdAt` - while the engine tiebroke by
+ * neither, leaving ties to a rowid that `INSERT OR REPLACE` reassigns on every
+ * edit. So "run this folder" could execute in a different order than the
+ * sidebar showed, and either order could change after an unrelated rename.
+ *
+ * The rule is now identical on both sides, pinned by
+ * `engine/tests/fixtures/tree-order-conformance.json` (issue #360). Two details
+ * are load-bearing rather than incidental:
+ *
+ *  - **`createdAt` before `id`.** Every request created before explicit orders
+ *    existed sits at `order: 0`, so creation time is what the user has been
+ *    seeing; making the id primary would visibly reshuffle their tree.
+ *  - **`<` rather than `localeCompare`.** The engine's tiebreak is SQLite's
+ *    BINARY collation, which is byte-wise; locale collation disagrees with it
+ *    on case ("Row-A" vs "row-a"), and this comparator's job is to match the
+ *    engine exactly.
+ */
+export function compareTreeOrder(a: OrderedTreeRow, b: OrderedTreeRow): number {
 	const orderDiff = (a.order ?? 0) - (b.order ?? 0);
 	if (orderDiff !== 0) return orderDiff;
-	return (a.id ?? "").localeCompare(b.id ?? "");
+
+	const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+	const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+	if (aTime !== bTime) return aTime - bTime;
+
+	const aId = a.id ?? "";
+	const bId = b.id ?? "";
+	if (aId === bId) return 0;
+	return aId < bId ? -1 : 1;
 }
 
 /**
@@ -199,13 +235,6 @@ export interface Request {
 	order: number;
 	createdAt: string;
 	updatedAt: string;
-}
-
-/** Stable comparator for sorting requests within a collection. */
-export function compareRequestOrder(a: Request, b: Request): number {
-	const orderDiff = (a.order ?? 0) - (b.order ?? 0);
-	if (orderDiff !== 0) return orderDiff;
-	return (a.id ?? "").localeCompare(b.id ?? "");
 }
 
 export interface Environment {

--- a/app/src/types/tree-order.conformance.test.ts
+++ b/app/src/types/tree-order.conformance.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Cross-language conformance: `compareTreeOrder` against the same fixture the
+ * engine's `tree_order_test.cpp` drives through `Database::get_collections` and
+ * `get_requests_in_collection` (issue #360).
+ *
+ * The sidebar sorts client-side and a scenario run reads the engine's SQL
+ * order. When those two rules disagreed, "run this folder" executed in an order
+ * the user had never seen - and neither side had a test that could notice,
+ * because each was self-consistent. One table, two readers, no copy to drift.
+ *
+ * Read from the engine tree on purpose, the same way
+ * `variable-resolution.conformance.test.ts` does.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { compareTreeOrder, type OrderedTreeRow } from "./domain";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(
+	here,
+	"..",
+	"..",
+	"..",
+	"engine",
+	"tests",
+	"fixtures",
+	"tree-order-conformance.json"
+);
+
+interface ConformanceCase {
+	name: string;
+	rows: Array<{ id: string; order: number; createdAt: number }>;
+	expected: string[];
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+	description: string;
+	cases: ConformanceCase[];
+};
+
+/**
+ * The renderer holds `createdAt` as the ISO string its transformers produce
+ * from the engine's epoch-millisecond column, so the fixture is fed in through
+ * that same conversion rather than compared in a shape the app never has.
+ */
+function toRow(row: ConformanceCase["rows"][number]): OrderedTreeRow {
+	return { id: row.id, order: row.order, createdAt: new Date(row.createdAt).toISOString() };
+}
+
+describe("tree-order conformance fixture", () => {
+	it("scanned a non-empty fixture (guards the scan itself)", () => {
+		expect(fixture.cases.length).toBeGreaterThanOrEqual(5);
+		for (const c of fixture.cases) {
+			expect(c.rows.length).toBeGreaterThan(1);
+			expect(c.expected).toHaveLength(c.rows.length);
+		}
+	});
+
+	it.each(fixture.cases.map((c) => [c.name, c] as const))("%s", (_name, c) => {
+		const sorted = c.rows.map(toRow).sort(compareTreeOrder);
+		expect(sorted.map((r) => r.id)).toEqual(c.expected);
+	});
+
+	it("sorts the same regardless of the input order", () => {
+		for (const c of fixture.cases) {
+			const reversed = [...c.rows].reverse().map(toRow).sort(compareTreeOrder);
+			expect(reversed.map((r) => r.id)).toEqual(c.expected);
+		}
+	});
+});
+
+describe("compareTreeOrder edge cases the fixture cannot express", () => {
+	it("treats a missing order as 0 and a missing createdAt as the epoch", () => {
+		const rows: OrderedTreeRow[] = [
+			{ id: "b", createdAt: new Date(1_700_000_000_000).toISOString() },
+			{ id: "a" },
+		];
+		expect(rows.sort(compareTreeOrder).map((r) => r.id)).toEqual(["a", "b"]);
+	});
+
+	it("returns 0 for two rows that agree on every key", () => {
+		const row: OrderedTreeRow = { id: "same", order: 1, createdAt: "2026-01-01T00:00:00.000Z" };
+		expect(compareTreeOrder(row, { ...row })).toBe(0);
+	});
+});

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -630,13 +630,23 @@ from `@/queries/runs`); everything with more than one is in the barrel.
 - **`usePrefetchCollectionsAndRequests()`** - Warm-cache pass over every
   collection's requests at startup
 
+**Sorting:** every tree list - roots, a collection's children, a collection's
+requests - sorts with the single exported `compareTreeOrder` (`types/domain.ts`):
+`order`, then `createdAt`, then `id` byte-wise. There were two comparators with
+two different tie rules and neither matched the engine's, so "run this folder"
+could execute in an order the sidebar had never shown. The rule is pinned to the
+engine's SQL by `engine/tests/fixtures/tree-order-conformance.json`, read by
+`types/tree-order.conformance.test.ts` and by the engine's `tree_order_test.cpp`
+- change one side and the other suite fails.
+
 **Mutations:**
 - **`useCreateCollectionMutation()`** - Create collection
 - **`useUpdateCollectionMutation()`** - Update collection (with cache update)
 - **`useDeleteCollectionMutation()`** - Delete collection (invalidates coarsely,
   see below)
 - **`useCreateRequestMutation()`** - Create request
-- **`useUpdateRequestMutation()`** - Update request
+- **`useUpdateRequestMutation()`** - Update request (invalidates only the lists
+  that can have changed, see below)
 - **`useDeleteRequestMutation()`** - Delete request (also clears the response)
 - **`useImportMutation()`** (`queries/import.ts`) - Apply a parsed import through
   `POST /import/apply` in one transaction
@@ -798,6 +808,15 @@ query is keyed on is `list()` / `detail(id)`. `runs.lastDesign` sits under
   `collections.all` + `requests.all` wholesale. `requests.detail` entries carry
   `staleTime: Infinity`, so without this a deleted request stays fresh forever
   and keeps feeding restored tabs.
+- **A single-request update invalidates narrowly, for the same reason.** Which
+  lists a request write can affect *is* client-side knowledge: the request's own
+  collection, plus the one it left if the write was a move. So
+  `useUpdateRequestMutation` invalidates `requests.listByCollection(id)` per
+  affected collection rather than `requests.lists()`. It used to refetch every
+  collection's list on any rename, which a reorder (a run of sibling PUTs) turns
+  into one full-tree refetch per row. The source collection of a move is read
+  from the `requests.detail` cache, which still holds the pre-update row at that
+  point - the response carries only the new owner.
 - **The warm-cache prefetch is a query too.** `usePrefetchCollectionsAndRequests`
   is keyed as `queryKeys.prefetch.allRequests()` rather than an inline key, so
   creating a collection can invalidate it - it succeeds once at startup and

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -131,8 +131,12 @@ One rule, identical for every field of all three resources:
 The defaults are `{}` for `variables`, the resource's own default for `auth`
 (`{"mode":"none"}` for a collection, `{"mode":"inherit"}` for a request), `[]`
 for `params` / `headers`, `""` for `description` and the two script fields,
-`{"mode":"none"}` for a request `body`, `0` for `order` on update, `true` for
-`followRedirects`, `10` for `maxRedirects`, and `false` for `isActive`.
+`{"mode":"none"}` for a request `body`, `true` for `followRedirects`, `10` for
+`maxRedirects`, and `false` for `isActive`.
+
+`order` is the one default that is computed rather than constant: it means
+"append after the current siblings", on both resources and on both verbs - see
+[Ordering](#ordering) below.
 
 A request's `httpVersion` is the one field whose default is not fixed: absent
 or `null` seeds it from the live `defaultHttpVersion` config entry (`"auto"`
@@ -146,6 +150,49 @@ A field that has **no** default cannot be reset, so `null` is a `400` on either
 verb rather than a silently discarded write. Those fields are a collection's
 `name`, an environment's `name`, and a request's `collectionId`, `name`,
 `method` and `url`. Each is also required on create.
+
+### Ordering
+
+Collections and requests both carry an `order` column that fixes their position
+among their siblings - a collection among the children of its `parentId`, a
+request among the requests of its `collectionId`.
+
+**Reading.** `GET /collections` and `GET /requests` sort by `order` ascending,
+then `createdAt` ascending, then `id` ascending. All three keys are load-bearing:
+`order` alone is not a total order (every request created before explicit orders
+existed sits at `0`), and rows are stored with `INSERT OR REPLACE` on a TEXT
+primary key, which hands the row a *new* rowid on every edit - so without an
+explicit tiebreak, renaming a request silently moved it among its ties. Clients
+must apply the same rule if they sort locally; the app's `compareTreeOrder` is
+pinned to this one by
+`engine/tests/fixtures/tree-order-conformance.json`, read by both test suites.
+
+**Writing.** `order` defaults to "append after the current siblings" - one past
+the highest `order` any sibling holds:
+
+| Write | `order` |
+|---|---|
+| Create, `order` absent or `null` | appended |
+| Create, `order` stated | as given |
+| Update, `order` stated | as given |
+| Update, `order` absent, no move | unchanged |
+| Update, `order` absent or `null`, **and** the row changes parent (a collection's `parentId`, a request's `collectionId`) | appended in the destination |
+| Update, `order` `null`, no move | appended among its current siblings |
+
+A move that states no order therefore lands at the end of the destination rather
+than at whatever slot its position in the *old* list happened to name. Ordering
+*within* a list is always the caller's to state.
+
+**Bulk import** is the one exception to the append scan: `POST /import/apply`
+writes rows that cannot see each other yet, so an omitted `order` gives the
+payload's items consecutive slots starting from the append point - see
+[POST /import/apply](#post-importapply).
+
+**Concurrency caveat.** Each `PUT` is its own write under its own lock, so a
+reorder expressed as N sibling `PUT`s is last-write-wins between concurrent
+clients, and the collection cycle guard is read-then-write across two lock
+scopes. Neither is fixed by a per-row endpoint; both are the job of the atomic
+batch reorder endpoint (issue #364).
 
 ### Accepted field shapes
 
@@ -351,7 +398,7 @@ the null-vs-absent rule.
 {
   "name": "My API",        // Required, no default (null is a 400)
   "parentId": null,         // Optional, null for root
-  "order": 0,               // Optional, appended after siblings if omitted
+  "order": 0,               // Optional, appended after siblings if omitted - see Ordering
   "variables": {}           // Optional, collection-scoped variables
 }
 ```
@@ -373,9 +420,14 @@ its value, an explicit `null` resets it to the default.
 {
   "name": "Renamed",       // Optional; null is a 400 (no default)
   "parentId": null,         // Optional, null moves it to the root
+  "order": 3,               // Optional; a move with no order appends - see Ordering
   "variables": null         // Optional, null resets to {}
 }
 ```
+
+A `parentId` that changes the collection's parent and states no `order` appends
+the collection among its new siblings, rather than carrying a position from the
+list it just left. See [Ordering](#ordering).
 
 **Response:** The updated collection object.
 
@@ -413,8 +465,9 @@ terminates even if the stored `parent_id` tree contains a cycle (see
 
 ### GET /requests
 
-List requests in a collection. Results are ordered by the requests' `order`
-field (ascending), the same contract `GET /collections` has for collections.
+List requests in a collection. Results are ordered by `order`, then `createdAt`,
+then `id` - the same contract `GET /collections` has for collections. See
+[Ordering](#ordering) for why the tiebreak is part of the contract.
 
 **Query Parameters:**
 - `collectionId` (required): Collection ID to fetch requests from
@@ -516,7 +569,8 @@ the null-vs-absent rule.
   "auth": {},                        // Optional, authentication config
   "preRequestScript": "",            // Optional, JavaScript pre-request script
   "postRequestScript": "",           // Optional, JavaScript test script
-  "order": 0,                        // Optional, position within the collection
+  "order": 0,                        // Optional, appended after the collection's requests if
+                                      // omitted - see Ordering
   "followRedirects": true,           // Optional, follow 3xx responses. Default true
   "maxRedirects": 10,                // Optional, hops while following, clamped to 0..100. Default 10
   "httpVersion": "auto"              // Optional: "auto" | "http1.1" | "http2". Absent/null seeds
@@ -528,10 +582,18 @@ the null-vs-absent rule.
 
 **Errors:** `400` if the body carries an `id`
 ([the engine owns it](#the-engine-owns-every-id)), if a
-required field is missing or `null`, on an unrecognized `method`, on a
+required field is missing or `null`, if `collectionId` names a collection that
+does not exist (message `Collection '<id>' does not exist`), on an unrecognized
+`method`, on a
 `params` / `headers` entry that is not `{key: string, value: string, enabled: bool}`,
 or on an `httpVersion` that is not `"auto"` / `"http1.1"` / `"http2"` (the body
 names the field and lists the valid values).
+
+Unlike a collection's `parentId`, a request's `collectionId` **must** resolve to
+a stored collection. A request under no collection is unreachable: no
+per-collection `GET` lists it, and no cascade delete ever reaps it. Bulk import
+is unaffected - `POST /import/apply` resolves owners from the payload's own temp
+ids before any row is written.
 
 ### PUT /requests/:id
 
@@ -539,8 +601,14 @@ Update an existing request. **Update only** - a `404` when the id does not
 exist, never a silent create. Merge-patch body, same rule as collections.
 
 **Request:** any subset of the `POST /requests` fields, minus `id` (it is the
-path). Omitting `followRedirects` / `maxRedirects` leaves the stored values
-untouched; sending `null` resets them to `true` / `10`. A non-boolean
+path). Sending `collectionId` moves the request to another collection; the id
+must resolve to a stored collection (`400` otherwise), and a move that states no
+`order` appends in the destination - see [Ordering](#ordering). An update that
+states no `collectionId` is not checked against the request's stored one, so a
+row stranded before this validation existed stays editable, and repairable by a
+`PUT` that moves it somewhere real. Omitting `followRedirects` / `maxRedirects`
+leaves the stored values untouched; sending `null` resets them to `true` / `10`.
+A non-boolean
 `followRedirects` or a non-integer `maxRedirects` is ignored rather than
 rejected. `maxRedirects` is clamped to `0..100` on the way in.
 
@@ -556,7 +624,8 @@ request re-seeds it.
 **Response:** The updated request object.
 
 **Errors:** `404` if the request does not exist; `400` on a `null`
-`collectionId` / `name` / `method` / `url`, an unrecognized `method`, a
+`collectionId` / `name` / `method` / `url`, a `collectionId` naming a collection
+that does not exist, an unrecognized `method`, a
 malformed `params` / `headers` entry, or an `httpVersion` that is not
 `"auto"` / `"http1.1"` / `"http2"`.
 
@@ -657,8 +726,13 @@ accepted a client-supplied `id` - which they no longer do (see
 - `order` is optional. For collections, an omitted `order` appends after the
   existing siblings and then in payload order (each sibling gets the next slot -
   the per-item default cannot do this in bulk, because none of the payload's own
-  siblings are stored yet). For requests it defaults to `0`, as with
-  `POST /requests`; clients that care about request order should send it.
+  siblings are stored yet). For requests it defaults to `0` on this path only:
+  `POST /requests` appends by scanning the collection's stored rows, which a bulk
+  write cannot do for a collection it is creating in the same call, so a client
+  that cares about request order must state it here. The app's importer does -
+  and deliberately omits `order` on its **root** collections, so an import into a
+  non-empty workspace lands after the roots already there instead of colliding
+  with their `0, 1, 2...`.
 - Up to **10,000 items** per call (collections + requests + environments).
 
 **Response:** `200`
@@ -1389,7 +1463,9 @@ inside the block rather than through `mode` / `duration` / `iterations`:
 
 The collection is resolved into an ordered, fully composed plan **once, before
 anything is sent**: direct requests by `requests.order`, then - with `recursive`
-- descendant collections by `collections.order`, depth-first. Each step is
+- descendant collections by `collections.order`, depth-first, each list under
+the tiebreak in [Ordering](#ordering), which is what makes a run's sequence the
+one the sidebar shows. Each step is
 composed through the same path `POST /compose` uses, so a step's request and
 joined scripts are byte-identical to what a Send of that request would run. A
 collection edited mid-run therefore cannot change the sequence underneath

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -460,6 +460,7 @@ if(VAYU_BUILD_TESTS)
         tests/http_version_test.cpp
         tests/request_composer_test.cpp
         tests/scenario_plan_test.cpp
+        tests/tree_order_test.cpp
         src/http/routes/import.cpp
         src/http/routes/compose.cpp
         src/http/routes/config.cpp

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -594,7 +594,17 @@ void Database::create_collection (const Collection& c) {
 
 std::vector<Collection> Database::get_collections () {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    return impl_->storage.get_all<Collection> (order_by (&Collection::order));
+    // The tie rule is pinned to three keys, not left to the implicit rowid.
+    // `INSERT OR REPLACE` on a TEXT primary key reassigns the rowid on every
+    // edit, so a single-key ORDER BY let an unrelated rename silently reshuffle
+    // a collection among its equal-`order` siblings - and the sidebar, the MCP
+    // smoke tool and a scenario plan each saw a different shuffle. `created_at`
+    // second matches what the renderer displays; `id` last makes the result a
+    // total order even for rows written in the same millisecond. The renderer's
+    // comparator applies the identical rule, pinned by
+    // tests/fixtures/tree-order-conformance.json.
+    return impl_->storage.get_all<Collection> (multi_order_by (order_by (&Collection::order),
+    order_by (&Collection::created_at), order_by (&Collection::id)));
 }
 
 std::optional<Collection> Database::get_collection (const std::string& id) {
@@ -668,8 +678,11 @@ std::optional<Request> Database::get_request (const std::string& id) {
 
 std::vector<Request> Database::get_requests_in_collection (const std::string& collection_id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    return impl_->storage.get_all<Request> (
-    where (c (&Request::collection_id) == collection_id), order_by (&Request::order));
+    // Same three-key tie rule as get_collections - see the comment there for why
+    // the implicit rowid cannot be the tiebreak.
+    return impl_->storage.get_all<Request> (where (c (&Request::collection_id) == collection_id),
+    multi_order_by (order_by (&Request::order), order_by (&Request::created_at),
+    order_by (&Request::id)));
 }
 
 void Database::delete_request (const std::string& id) {

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -15,7 +15,9 @@
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
+#include <algorithm>
 #include <optional>
+#include <string>
 #include <unordered_set>
 #include <utility>
 
@@ -75,6 +77,26 @@ const std::optional<std::string>& parent_id) {
 }
 
 /**
+ * The `order` a collection takes when the caller states none: one past the
+ * highest already held by a sibling under @p parent_id.
+ *
+ * @p self_id is excluded so a collection asked to reset its own order lands
+ * after its *other* siblings rather than one past itself. On a create the id is
+ * not stored yet, so the exclusion is a no-op there.
+ */
+static int next_sibling_order (vayu::db::Database& db,
+const std::optional<std::string>& parent_id,
+const std::string& self_id) {
+    int max_order = -1;
+    for (const auto& col : db.get_collections ()) {
+        if (col.id != self_id && col.parent_id == parent_id) {
+            max_order = std::max (max_order, col.order);
+        }
+    }
+    return max_order + 1;
+}
+
+/**
  * Applies the request body onto `c` under the one null-vs-absent rule (see the
  * helpers in routes.hpp). Shared by the create and update cores so the two
  * verbs cannot drift apart on what a field means - the only thing that differs
@@ -97,6 +119,7 @@ bool is_create) {
 
     apply_string_field (json, "description", c.description, "", is_create);
 
+    const std::optional<std::string> previous_parent = c.parent_id;
     if (json.contains ("parentId")) {
         c.parent_id = json["parentId"].is_null () ?
         std::nullopt :
@@ -104,22 +127,20 @@ bool is_create) {
     } else if (is_create) {
         c.parent_id = std::nullopt;
     }
+    // A collection that changed parent is a newcomer among its new siblings; its
+    // stored `order` was a position in a list it has left.
+    const bool reparented = !is_create && c.parent_id != previous_parent;
 
     if (json.contains ("order") && !json["order"].is_null ()) {
         c.order = json["order"].get<int> ();
-    } else if (is_create) {
-        // Absent or null on create: append after the current siblings so a new
-        // collection lands at the end rather than colliding on 0.
-        auto all      = db.get_collections ();
-        int max_order = -1;
-        for (const auto& col : all) {
-            if (col.parent_id == c.parent_id && col.order > max_order) {
-                max_order = col.order;
-            }
-        }
-        c.order = max_order + 1;
-    } else if (json.contains ("order")) {
-        c.order = 0; // Explicit null on update -> reset to the column default.
+    } else if (is_create || reparented || json.contains ("order")) {
+        // "Append after the current siblings" *is* this field's default, so the
+        // one null-vs-absent rule lands all three of these on it: create (absent
+        // or null), a reparent that states no order, and an explicit null on
+        // update ("reset to the default"). Null used to reset to 0 instead,
+        // which collided with the first sibling rather than resetting anything;
+        // a reparent used to keep a position from the list it had just left.
+        c.order = next_sibling_order (db, c.parent_id, c.id);
     }
 
     if (auto err = apply_json_field (json, "variables", c.variables, "{}", is_create)) {

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -50,9 +50,13 @@ const std::string& id) {
 /**
  * Testable core of GET /requests: one DB fetch, one serialized JSON array.
  *
- * The rows arrive already ordered by `order` (get_requests_in_collection has
- * the ORDER BY), matching the ordering contract collections have had all
- * along. Each row is serialized into its own buffer inside the try, so a row
+ * The rows arrive already ordered by `order`, then `created_at`, then `id`
+ * (get_requests_in_collection has the ORDER BY), matching the ordering contract
+ * collections have had all along - see the ordering section of
+ * `docs/engine/api-reference.md` for why the tiebreak is part of the contract
+ * rather than a detail.
+ *
+ * Each row is serialized into its own buffer inside the try, so a row
  * that fails to serialize is skipped whole - it cannot leave a half-written
  * item behind and corrupt the array, and one bad row does not fail the whole
  * response. Extracted for requests_route_test.cpp, same as
@@ -222,6 +226,54 @@ bool is_create) {
 }
 
 /**
+ * Rejects a write that would park a request under a collection that does not
+ * exist. Without it a stale or mistyped `collectionId` succeeded and stranded
+ * the row invisibly: no per-collection GET lists it, and the cascade delete of
+ * any real collection never reaps it. This is the endpoint a cross-collection
+ * move uses, so the check guards the move as much as the create.
+ *
+ * Lives in the route cores rather than in `apply_request_fields`, because
+ * `POST /import/apply` runs the shared applier against collection rows it has
+ * not written yet - every id would look missing there.
+ */
+static std::optional<std::pair<int, nlohmann::json>>
+reject_missing_collection (vayu::db::Database& db, const std::string& collection_id) {
+    if (db.get_collection (collection_id).has_value ()) {
+        return std::nullopt;
+    }
+    return std::make_pair (400,
+    error_body (400, "Collection '" + collection_id + "' does not exist"));
+}
+
+/**
+ * The `order` a new request takes when the caller states none: one past the
+ * highest among the collection's current requests, so a created or duplicated
+ * request lands at the *end* of its collection.
+ *
+ * It used to default to 0 (`apply_int_field`), which tied every UI-created
+ * request with every other and meant the stored column encoded nothing. The
+ * moment explicit orders existed - the first drag - every new request would
+ * have jumped to the top.
+ *
+ * Mirrors the sibling scan `apply_collection_fields` already does for
+ * collections, and sits here for the same reason `reject_missing_collection`
+ * does: bulk import sends explicit orders and cannot scan rows it has yet to
+ * write.
+ */
+static int next_request_order (vayu::db::Database& db, const std::string& collection_id) {
+    int max_order = -1;
+    for (const auto& existing : db.get_requests_in_collection (collection_id)) {
+        max_order = std::max (max_order, existing.order);
+    }
+    return max_order + 1;
+}
+
+/** True when the body leaves `order` to the engine - absent, or an explicit null. */
+static bool order_is_defaulted (const nlohmann::json& json) {
+    return !json.contains ("order") || json["order"].is_null ();
+}
+
+/**
  * Testable core of POST /requests - **create only**, returning
  * {http_status, json_body}. An id that already exists is a 409 pointing at PUT;
  * POST never updates (issue #95). A body `id` is rejected outright (#97) - see
@@ -249,6 +301,12 @@ create_request_response (vayu::db::Database& db, const nlohmann::json& json) {
     if (auto err = apply_request_fields (db, r, json, /*is_create=*/true)) {
         return *err;
     }
+    if (auto err = reject_missing_collection (db, r.collection_id)) {
+        return *err;
+    }
+    if (order_is_defaulted (json)) {
+        r.order = next_request_order (db, r.collection_id);
+    }
 
     db.save_request (r);
     return { 200, vayu::json::serialize (r) };
@@ -274,6 +332,21 @@ const nlohmann::json& json) {
     vayu::db::Request r = *existing;
     if (auto err = apply_request_fields (db, r, json, /*is_create=*/false)) {
         return *err;
+    }
+    // Only when the write states a collection: an already-stranded row (written
+    // before this check existed) must stay repairable by a PUT that moves it
+    // somewhere real, rather than becoming unwritable.
+    if (json.contains ("collectionId")) {
+        if (auto err = reject_missing_collection (db, r.collection_id)) {
+            return *err;
+        }
+    }
+    // A move that states no `order` appends in the destination. Carrying the
+    // source position across would drop the request into an arbitrary slot among
+    // its new siblings - the same defect a collection reparent had. Ordering
+    // *within* a collection is still the caller's to state.
+    if (r.collection_id != existing->collection_id && order_is_defaulted (json)) {
+        r.order = next_request_order (db, r.collection_id);
     }
     r.updated_at = now_ms ();
 

--- a/engine/tests/fixtures/tree-order-conformance.json
+++ b/engine/tests/fixtures/tree-order-conformance.json
@@ -1,0 +1,64 @@
+{
+	"description": "The one sidebar/scenario ordering rule, read by both suites. Rows sort by `order` ascending, ties by `createdAt` ascending, remaining ties by `id` ascending under byte-wise (SQLite BINARY) comparison. Engine side: engine/tests/tree_order_test.cpp inserts each case's rows into the collections and the requests table and reads them back through Database::get_collections / get_requests_in_collection, so the SQL ORDER BY is what is being asserted. Renderer side: app/src/types/tree-order.conformance.test.ts sorts the same rows with compareTreeOrder. A rule that changes on one side and not the other fails here or in ctest, never in a user's sidebar.",
+	"cases": [
+		{
+			"name": "explicit order wins over both creation time and id",
+			"rows": [
+				{ "id": "row-a", "order": 1, "createdAt": 1700000000000 },
+				{ "id": "row-z", "order": 0, "createdAt": 1700000009000 }
+			],
+			"expected": ["row-z", "row-a"]
+		},
+		{
+			"name": "a tie on order falls to the older createdAt, not to the id",
+			"rows": [
+				{ "id": "row-a", "order": 3, "createdAt": 1700000005000 },
+				{ "id": "row-z", "order": 3, "createdAt": 1700000001000 }
+			],
+			"expected": ["row-z", "row-a"]
+		},
+		{
+			"name": "all-zero orders (the pre-drag world) sort by creation time, not by id",
+			"rows": [
+				{ "id": "row-alpha", "order": 0, "createdAt": 1700000003000 },
+				{ "id": "row-gamma", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "row-beta", "order": 0, "createdAt": 1700000002000 }
+			],
+			"expected": ["row-gamma", "row-beta", "row-alpha"]
+		},
+		{
+			"name": "a full tie on order and createdAt falls to the id",
+			"rows": [
+				{ "id": "row-z", "order": 2, "createdAt": 1700000004000 },
+				{ "id": "row-m", "order": 2, "createdAt": 1700000004000 },
+				{ "id": "row-c", "order": 2, "createdAt": 1700000004000 }
+			],
+			"expected": ["row-c", "row-m", "row-z"]
+		},
+		{
+			"name": "the id tiebreak is byte-wise, not locale-aware (uppercase sorts first)",
+			"rows": [
+				{ "id": "row-a", "order": 0, "createdAt": 1700000000000 },
+				{ "id": "Row-A", "order": 0, "createdAt": 1700000000000 }
+			],
+			"expected": ["Row-A", "row-a"]
+		},
+		{
+			"name": "negative orders sort ahead of zero",
+			"rows": [
+				{ "id": "row-zero", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "row-pinned", "order": -1, "createdAt": 1700000009000 }
+			],
+			"expected": ["row-pinned", "row-zero"]
+		},
+		{
+			"name": "order is the primary key even when creation time disagrees on every row",
+			"rows": [
+				{ "id": "row-1", "order": 10, "createdAt": 1700000001000 },
+				{ "id": "row-2", "order": 5, "createdAt": 1700000002000 },
+				{ "id": "row-3", "order": 7, "createdAt": 1700000003000 }
+			],
+			"expected": ["row-2", "row-3", "row-1"]
+		}
+	]
+}

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -175,6 +175,29 @@ TEST_F (ScenarioPlanTest, RecursiveDescentIsDepthFirstByCollectionOrder) {
     (std::vector<std::string>{ "root_a", "root_b", "a_1", "g_1", "b_1" }));
 }
 
+TEST_F (ScenarioPlanTest, TiedOrdersRunInTheSameSequenceTheSidebarShows) {
+    // Every request created before explicit orders existed sits at 0, so this is
+    // the common case, not an edge one: what "run this folder" executes must be
+    // what the tree displays. The rule is `order`, then `created_at`, then `id`
+    // (issue #360, pinned by fixtures/tree-order-conformance.json) - not the
+    // rowid, which an unrelated edit reassigns.
+    seed_collection ("root", "");
+    seed_request ("later", "root", /*order=*/0);
+    seed_request ("earlier", "root", /*order=*/0);
+    auto make_older = [&] (const std::string& id, int64_t created_at) {
+        auto row       = db_->get_request (id);
+        ASSERT_TRUE (row.has_value ());
+        row->created_at = created_at;
+        db_->save_request (*row);
+    };
+    make_older ("earlier", 1000);
+    make_older ("later", 2000);
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("root"), options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (step_ids (resolved.plan), (std::vector<std::string>{ "earlier", "later" }));
+}
+
 TEST_F (ScenarioPlanTest, NonRecursiveIgnoresSubCollections) {
     seed_collection ("root", "");
     seed_collection ("child", "root");

--- a/engine/tests/tree_order_test.cpp
+++ b/engine/tests/tree_order_test.cpp
@@ -1,0 +1,447 @@
+/**
+ * @file tests/tree_order_test.cpp
+ * @brief The ordering foundation the sidebar, the MCP smoke tool and a scenario
+ *        plan all read (issue #360).
+ *
+ * Four contracts, each of which was a real defect before this file existed:
+ *
+ *  - **A created request appends.** `order` defaulted to 0, so every
+ *    UI-created request tied with every other one and the stored column
+ *    encoded nothing. The moment explicit orders exist - the first drag -
+ *    every new or duplicated request would have jumped to the top.
+ *  - **The tie rule is pinned, and stable across an edit.** A single-key
+ *    `ORDER BY` left ties to the implicit rowid, and `INSERT OR REPLACE` on a
+ *    TEXT primary key reassigns that rowid on every write - so renaming a
+ *    request silently reshuffled it among its ties. The stability test is the
+ *    mutation check: drop `created_at` from either ORDER BY and it reddens.
+ *  - **A write cannot strand a row.** `collectionId` pointing at nothing used
+ *    to succeed; no per-collection GET lists such a row and no cascade delete
+ *    ever reaps it.
+ *  - **A reparented collection appends among its new siblings** instead of
+ *    keeping a position from the list it just left.
+ *
+ * The tie rule itself is driven from `fixtures/tree-order-conformance.json`,
+ * which `app/src/types/tree-order.conformance.test.ts` also reads - the sidebar
+ * and the engine cannot disagree without one of the two suites failing.
+ *
+ * Route cores are exercised directly, no in-process HTTP server, matching the
+ * suite's other route tests.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/db/database.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in collections.cpp / requests.cpp; each returns {http_status, body}.
+std::pair<int, nlohmann::json>
+create_collection_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+create_request_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+} // namespace vayu::http::routes
+
+namespace {
+
+json load_fixture () {
+    const std::filesystem::path path = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
+    "tests" / "fixtures" / "tree-order-conformance.json";
+    std::ifstream in (path);
+    EXPECT_TRUE (in.good ()) << "fixture missing: " << path;
+    return json::parse (in);
+}
+
+class TreeOrderTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_tree_order.db";
+    // Owns the request rows in the conformance cases, and is filtered out of the
+    // collection assertions so only the case's own rows are compared.
+    static constexpr const char* HOLDER = "col-holder";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+        seed_collection (HOLDER, /*order=*/0, /*created_at=*/1);
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
+            std::filesystem::remove (std::string (DB_PATH) + s);
+        }
+    }
+
+    void seed_collection (const std::string& id,
+    int order,
+    int64_t created_at,
+    const std::string& parent_id = "") {
+        vayu::db::Collection c;
+        c.id = id;
+        if (!parent_id.empty ()) {
+            c.parent_id = parent_id;
+        }
+        c.name       = "Collection " + id;
+        c.order      = order;
+        c.created_at = created_at;
+        c.updated_at = created_at;
+        db_->create_collection (c);
+    }
+
+    void seed_request (const std::string& id,
+    const std::string& collection_id,
+    int order,
+    int64_t created_at) {
+        vayu::db::Request r;
+        r.id            = id;
+        r.collection_id = collection_id;
+        r.name          = "Request " + id;
+        r.method        = vayu::HttpMethod::GET;
+        r.url           = "https://example.test/";
+        r.order         = order;
+        r.created_at    = created_at;
+        r.updated_at    = created_at;
+        db_->save_request (r);
+    }
+
+    // The minimum body POST /requests accepts, so a test states only the field
+    // it is about.
+    static json request_body (const std::string& collection_id, const std::string& name) {
+        return json{ { "collectionId", collection_id }, { "name", name },
+            { "method", "GET" }, { "url", "https://example.test/" } };
+    }
+
+    std::vector<std::string> request_ids (const std::string& collection_id) {
+        std::vector<std::string> ids;
+        for (const auto& r : db_->get_requests_in_collection (collection_id)) {
+            ids.push_back (r.id);
+        }
+        return ids;
+    }
+
+    // Every collection except the request holder, in stored order.
+    std::vector<std::string> collection_ids () {
+        std::vector<std::string> ids;
+        for (const auto& c : db_->get_collections ()) {
+            if (c.id != HOLDER) {
+                ids.push_back (c.id);
+            }
+        }
+        return ids;
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// --- The shared tie rule ------------------------------------------------------
+
+TEST_F (TreeOrderTest, ConformanceFixtureIsNonEmpty) {
+    const json fixture = load_fixture ();
+    // Guards the scan itself: a fixture that failed to load would otherwise make
+    // every case below vacuously pass.
+    ASSERT_TRUE (fixture.contains ("cases"));
+    EXPECT_GE (fixture["cases"].size (), 5u);
+}
+
+TEST_F (TreeOrderTest, RequestsFollowTheConformanceOrder) {
+    // Named, not `load_fixture ()["cases"]` inline: the subscript returns a
+    // reference into a temporary the full expression then destroys, so the loop
+    // would walk freed memory - and in practice walk nothing, passing whatever
+    // the ORDER BY did. `cases_run` is the guard against exactly that.
+    const json fixture = load_fixture ();
+    size_t cases_run   = 0;
+    for (const auto& c : fixture["cases"]) {
+        const std::string name = c["name"].get<std::string> ();
+        std::vector<std::string> expected;
+        for (const auto& row : c["rows"]) {
+            seed_request (row["id"].get<std::string> (), HOLDER,
+            row["order"].get<int> (), row["createdAt"].get<int64_t> ());
+        }
+        for (const auto& id : c["expected"]) {
+            expected.push_back (id.get<std::string> ());
+        }
+
+        EXPECT_EQ (request_ids (HOLDER), expected) << "case: " << name;
+        ++cases_run;
+
+        for (const auto& row : c["rows"]) {
+            db_->delete_request (row["id"].get<std::string> ());
+        }
+    }
+    EXPECT_GE (cases_run, 5u) << "the fixture loop asserted nothing";
+}
+
+TEST_F (TreeOrderTest, CollectionsFollowTheConformanceOrder) {
+    const json fixture = load_fixture ();
+    size_t cases_run   = 0;
+    for (const auto& c : fixture["cases"]) {
+        const std::string name = c["name"].get<std::string> ();
+        std::vector<std::string> expected;
+        for (const auto& row : c["rows"]) {
+            seed_collection (row["id"].get<std::string> (), row["order"].get<int> (),
+            row["createdAt"].get<int64_t> ());
+        }
+        for (const auto& id : c["expected"]) {
+            expected.push_back (id.get<std::string> ());
+        }
+
+        EXPECT_EQ (collection_ids (), expected) << "case: " << name;
+        ++cases_run;
+
+        for (const auto& row : c["rows"]) {
+            db_->delete_collection (row["id"].get<std::string> ());
+        }
+    }
+    EXPECT_GE (cases_run, 5u) << "the fixture loop asserted nothing";
+}
+
+// --- Stability across an edit (the rowid-churn mutation check) -----------------
+
+TEST_F (TreeOrderTest, EditingATiedRequestDoesNotMoveIt) {
+    seed_request ("req-a", HOLDER, /*order=*/0, /*created_at=*/1000);
+    seed_request ("req-b", HOLDER, /*order=*/0, /*created_at=*/2000);
+    seed_request ("req-c", HOLDER, /*order=*/0, /*created_at=*/3000);
+    const std::vector<std::string> before{ "req-a", "req-b", "req-c" };
+    ASSERT_EQ (request_ids (HOLDER), before);
+
+    // A rename is an INSERT OR REPLACE, which hands the row a fresh rowid. With
+    // the rowid as the tiebreak this moved "req-a" to the end of the tie group.
+    const auto [status, body] = vayu::http::routes::update_request_response (*db_,
+    "req-a", json{ { "name", "Renamed" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    EXPECT_EQ (request_ids (HOLDER), before);
+}
+
+TEST_F (TreeOrderTest, EditingATiedCollectionDoesNotMoveIt) {
+    seed_collection ("col-a", /*order=*/0, /*created_at=*/1000);
+    seed_collection ("col-b", /*order=*/0, /*created_at=*/2000);
+    const std::vector<std::string> before{ "col-a", "col-b" };
+    ASSERT_EQ (collection_ids (), before);
+
+    const auto [status, body] = vayu::http::routes::update_collection_response (*db_,
+    "col-a", json{ { "name", "Renamed" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    EXPECT_EQ (collection_ids (), before);
+}
+
+// --- Request create appends ---------------------------------------------------
+
+TEST_F (TreeOrderTest, FirstRequestInACollectionGetsOrderZero) {
+    const auto [status, body] =
+    vayu::http::routes::create_request_response (*db_, request_body (HOLDER, "First"));
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 0);
+}
+
+TEST_F (TreeOrderTest, ACreatedRequestAppendsAfterItsSiblings) {
+    seed_request ("req-0", HOLDER, /*order=*/0, /*created_at=*/1000);
+    seed_request ("req-1", HOLDER, /*order=*/1, /*created_at=*/2000);
+    seed_request ("req-2", HOLDER, /*order=*/2, /*created_at=*/3000);
+
+    const auto [status, body] =
+    vayu::http::routes::create_request_response (*db_, request_body (HOLDER, "Appended"));
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 3);
+    EXPECT_EQ (request_ids (HOLDER).back (), body["id"].get<std::string> ());
+}
+
+TEST_F (TreeOrderTest, TheAppendedOrderIsPerCollectionNotGlobal) {
+    seed_collection ("col-other", /*order=*/1, /*created_at=*/1);
+    seed_request ("req-x", "col-other", /*order=*/9, /*created_at=*/1000);
+
+    const auto [status, body] =
+    vayu::http::routes::create_request_response (*db_, request_body (HOLDER, "Fresh"));
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 0);
+}
+
+TEST_F (TreeOrderTest, AnExplicitOrderOnCreateIsHonoured) {
+    seed_request ("req-0", HOLDER, /*order=*/0, /*created_at=*/1000);
+
+    json body_json     = request_body (HOLDER, "Pinned");
+    body_json["order"] = 42;
+    const auto [status, body] = vayu::http::routes::create_request_response (*db_, body_json);
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 42);
+}
+
+TEST_F (TreeOrderTest, ANullOrderOnCreateAppends) {
+    seed_request ("req-0", HOLDER, /*order=*/4, /*created_at=*/1000);
+
+    json body_json     = request_body (HOLDER, "Defaulted");
+    body_json["order"] = nullptr;
+    const auto [status, body] = vayu::http::routes::create_request_response (*db_, body_json);
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 5);
+}
+
+// --- A write cannot strand a row ----------------------------------------------
+
+TEST_F (TreeOrderTest, CreatingUnderAMissingCollectionIs400) {
+    const auto [status, body] =
+    vayu::http::routes::create_request_response (*db_, request_body ("col-nope", "Orphan"));
+    EXPECT_EQ (status, 400);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("col-nope"), std::string::npos)
+    << body.dump ();
+    // Nothing persisted: the 400 is a rejection, not a rejection-after-write.
+    EXPECT_TRUE (db_->get_requests_in_collection ("col-nope").empty ());
+}
+
+TEST_F (TreeOrderTest, MovingToAMissingCollectionIs400AndKeepsTheRowWhereItWas) {
+    seed_request ("req-a", HOLDER, /*order=*/0, /*created_at=*/1000);
+
+    const auto [status, body] = vayu::http::routes::update_request_response (*db_,
+    "req-a", json{ { "collectionId", "col-nope" } });
+    EXPECT_EQ (status, 400) << body.dump ();
+    EXPECT_EQ (request_ids (HOLDER), (std::vector<std::string>{ "req-a" }));
+}
+
+TEST_F (TreeOrderTest, AnUpdateThatStatesNoCollectionStillWritesAStrandedRow) {
+    // A row written before the check existed must stay editable - and repairable
+    // by a PUT that moves it somewhere real - rather than becoming unwritable.
+    seed_request ("req-stranded", "col-gone", /*order=*/0, /*created_at=*/1000);
+
+    const auto renamed = vayu::http::routes::update_request_response (*db_,
+    "req-stranded", json{ { "name", "Still editable" } });
+    EXPECT_EQ (renamed.first, 200) << renamed.second.dump ();
+
+    const auto repaired = vayu::http::routes::update_request_response (*db_,
+    "req-stranded", json{ { "collectionId", HOLDER } });
+    ASSERT_EQ (repaired.first, 200) << repaired.second.dump ();
+    EXPECT_EQ (request_ids (HOLDER), (std::vector<std::string>{ "req-stranded" }));
+}
+
+// --- Moves append in the destination ------------------------------------------
+
+TEST_F (TreeOrderTest, MovingARequestToAnotherCollectionAppendsThere) {
+    seed_collection ("col-target", /*order=*/1, /*created_at=*/1);
+    seed_request ("req-there-0", "col-target", /*order=*/0, /*created_at=*/1000);
+    seed_request ("req-there-1", "col-target", /*order=*/1, /*created_at=*/2000);
+    seed_request ("req-moving", HOLDER, /*order=*/0, /*created_at=*/3000);
+
+    const auto [status, body] = vayu::http::routes::update_request_response (*db_,
+    "req-moving", json{ { "collectionId", "col-target" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 2);
+    EXPECT_EQ (request_ids ("col-target"),
+    (std::vector<std::string>{ "req-there-0", "req-there-1", "req-moving" }));
+}
+
+TEST_F (TreeOrderTest, AMoveThatStatesAnOrderKeepsIt) {
+    seed_collection ("col-target", /*order=*/1, /*created_at=*/1);
+    seed_request ("req-there", "col-target", /*order=*/5, /*created_at=*/1000);
+    seed_request ("req-moving", HOLDER, /*order=*/0, /*created_at=*/2000);
+
+    const auto [status, body] = vayu::http::routes::update_request_response (*db_,
+    "req-moving", json{ { "collectionId", "col-target" }, { "order", 3 } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 3);
+}
+
+TEST_F (TreeOrderTest, AnUpdateWithinTheSameCollectionKeepsItsOrder) {
+    seed_request ("req-a", HOLDER, /*order=*/7, /*created_at=*/1000);
+
+    const auto [status, body] = vayu::http::routes::update_request_response (*db_,
+    "req-a", json{ { "name", "Renamed" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 7);
+}
+
+TEST_F (TreeOrderTest, ReparentingACollectionAppendsAmongItsNewSiblings) {
+    seed_collection ("col-parent", /*order=*/0, /*created_at=*/1);
+    seed_collection ("col-child-0", /*order=*/0, /*created_at=*/2, "col-parent");
+    seed_collection ("col-child-1", /*order=*/1, /*created_at=*/3, "col-parent");
+    seed_collection ("col-moving", /*order=*/0, /*created_at=*/4);
+
+    const auto [status, body] = vayu::http::routes::update_collection_response (*db_,
+    "col-moving", json{ { "parentId", "col-parent" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 2);
+}
+
+TEST_F (TreeOrderTest, AReparentThatStatesAnOrderKeepsIt) {
+    seed_collection ("col-parent", /*order=*/0, /*created_at=*/1);
+    seed_collection ("col-child", /*order=*/0, /*created_at=*/2, "col-parent");
+    seed_collection ("col-moving", /*order=*/0, /*created_at=*/3);
+
+    const auto [status, body] = vayu::http::routes::update_collection_response (*db_,
+    "col-moving", json{ { "parentId", "col-parent" }, { "order", 0 } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 0);
+}
+
+TEST_F (TreeOrderTest, MovingACollectionToTheRootAppendsAmongTheRoots) {
+    seed_collection ("col-root-0", /*order=*/0, /*created_at=*/1);
+    seed_collection ("col-root-1", /*order=*/1, /*created_at=*/2);
+    seed_collection ("col-nested", /*order=*/0, /*created_at=*/3, "col-root-0");
+
+    // Explicit JSON null on parentId is how a client says "move to the root";
+    // absent would mean "keep the parent".
+    const auto [status, body] = vayu::http::routes::update_collection_response (*db_,
+    "col-nested", json{ { "parentId", nullptr } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_TRUE (body["parentId"].is_null ()) << body.dump ();
+    // HOLDER (order 0), col-root-0 (0) and col-root-1 (1) are the stored roots.
+    EXPECT_EQ (body["order"].get<int> (), 2);
+}
+
+TEST_F (TreeOrderTest, AnUpdateThatKeepsTheSameParentKeepsTheOrder) {
+    seed_collection ("col-parent", /*order=*/0, /*created_at=*/1);
+    seed_collection ("col-child-0", /*order=*/0, /*created_at=*/2, "col-parent");
+    seed_collection ("col-child-1", /*order=*/1, /*created_at=*/3, "col-parent");
+
+    // Restating the current parent is not a move, so the position is untouched.
+    const auto [status, body] = vayu::http::routes::update_collection_response (*db_,
+    "col-child-0", json{ { "parentId", "col-parent" }, { "name", "Renamed" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 0);
+}
+
+TEST_F (TreeOrderTest, AnExplicitNullOrderOnUpdateAppendsRatherThanCollidingOnZero) {
+    seed_collection ("col-a", /*order=*/0, /*created_at=*/1);
+    seed_collection ("col-b", /*order=*/1, /*created_at=*/2);
+    seed_collection ("col-c", /*order=*/2, /*created_at=*/3);
+
+    // "Reset to the default" - and this field's default is "append", which is
+    // what create does. It used to reset to 0 and tie with the first sibling.
+    const auto [status, body] = vayu::http::routes::update_collection_response (*db_,
+    "col-a", json{ { "order", nullptr } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    // HOLDER (0), col-b (1) and col-c (2) are the other roots; col-a itself is
+    // excluded from the scan, so it lands one past the highest of those.
+    EXPECT_EQ (body["order"].get<int> (), 3);
+    EXPECT_EQ (collection_ids (), (std::vector<std::string>{ "col-b", "col-c", "col-a" }));
+}
+
+TEST_F (TreeOrderTest, ACreatedCollectionStillAppendsAmongItsSiblings) {
+    seed_collection ("col-root-0", /*order=*/0, /*created_at=*/1);
+    seed_collection ("col-root-1", /*order=*/3, /*created_at=*/2);
+
+    const auto [status, body] = vayu::http::routes::create_collection_response (*db_,
+    json{ { "name", "Appended" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["order"].get<int> (), 4);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

The ordering foundation the sidebar, `run_collection_smoke` and `ScenarioPlan` all read.

**Plan.** The root cause is that `requests.order` was never a real column: it defaulted to `0` on create (`apply_int_field`) and no renderer call site sent one, so every UI-created request tied at `0` and the stored value encoded nothing - the first drag would have sent every new request to the top of its collection. The tie was then resolved by three different rules: SQL left it to the implicit rowid, which `INSERT OR REPLACE` on a TEXT primary key reassigns on **every** edit (so a rename silently reshuffled a row among its ties); the renderer tiebroke requests by `createdAt` and collections by `id`; and the engine consumers took the raw SQL order. Net effect: "run this folder" could execute in an order the sidebar had never shown, and either order could change after an unrelated edit. The approach is to make the default *computed* ("append after the current siblings") on both resources and both verbs, pin the read order to `(order, created_at, id)` in SQL, and unify the renderer on one comparator pinned to the engine's rule by a cross-language fixture. The alternative I rejected was making `id` the tiebreak on both sides, which is simpler to state but would visibly reshuffle every existing user's tree: ids are random UUIDs, and every pre-drag request sits at `order: 0`, so `createdAt` is what people have actually been looking at.

Verified at `0f7d975` - every anchor in the issue still described the code as written.

### Engine

1. **`POST /requests` appends** when `order` is absent or null (`max+1` over the target collection). In `create_request_response`, not the shared applier: `POST /import/apply` sends explicit orders and cannot scan collection rows it has yet to write.
2. **`get_collections` / `get_requests_in_collection` order by `(order, created_at, id)`.** `created_at` second matches what the renderer already displayed, so no stored tree visibly reshuffles on upgrade.
3. **`collectionId` must resolve to a stored collection** on request create and update - a `400` naming it, rather than a row no per-collection GET lists and no cascade delete reaps. An update that states *no* `collectionId` is deliberately unchecked, so a row stranded before this existed stays editable and repairable by a PUT that moves it somewhere real.
4. **A move appends in its destination** when it states no order: a collection changing `parentId`, and a request changing `collectionId`. `order: null` on update now means "reset to the default", and this field's default is append - it used to reset to `0` and collide with the first sibling.

### App

5. **One exported `compareTreeOrder`** (`types/domain.ts`) replaces `compareCollectionOrder` and the dead `compareRequestOrder`, carrying the engine's rule - including `<` rather than `localeCompare`, because SQLite's tiebreak is BINARY and locale collation disagrees on case.
6. **`UpdateRequestRequest.collectionId`** and **`UpdateCollectionRequest.parentId: string | null`** - a cross-collection move and a move-to-root were previously unexpressible in the type. `apiService.updateCollection` already passed a null through to the wire; a test now pins that.
7. **The importer omits `order` on root collections**, so an import into a non-empty workspace appends after the existing roots instead of interleaving through them by tie lottery. Everything below a root keeps its index (those parents are new in the payload).
8. **`useUpdateRequestMutation` invalidates only the affected lists** - the request's collection, plus the one it left on a move, read from the detail cache's pre-update row. Dropped the full-body `console.log` in `apiService.updateRequest`.

### Two deliberate deviations from the issue

- **Requests get the reparent-append too.** The issue's item 4 specifies it only for collections. A request moved with no `order` had the identical defect, the fix is the same line, and one rule is easier to document than two. Called out in `docs/engine/api-reference.md`.
- **Duplicate lands adjacent, via the tie rule.** The acceptance criterion asked me to state which. The copy sends its *source's* `order`, which the pinned tiebreak places directly after the source, because the copy is newer. Inserting at `order + 1` would need every following sibling renumbered - a multi-row write that belongs to the atomic batch reorder endpoint (#364), not to a duplicate.

**MCP: verified no change needed.** `run_collection_smoke` (`electron/mcp/tools.ts`) iterates `ctx.client.listRequests(collectionId)` with no client-side sort, so it consumes the now-stable engine order - which is the point.

**Documented, not fixed here** (per the issue): per-row PUTs are last-write-wins across two lock scopes and the cycle guard is TOCTOU-racy across concurrent reparents. Both are the atomic batch reorder endpoint's job; the caveat is now written down in the API reference.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally, no pre-existing failures.

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **955 passed, 0 failed**. New `engine/tests/tree_order_test.cpp` (22 tests) plus one added to `scenario_plan_test.cpp`.
- `cd app && pnpm test`: **2752 passed across 301 files** (was 2747/299). `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean; `clang-tidy -p engine/build` clean on both changed route files.
- `mkdocs build --strict` passes.

Mutation-checked, each fix reverted and confirmed red:

| Reverted | What reddened |
|---|---|
| the multi-key `ORDER BY` | `EditingATiedRequestDoesNotMoveIt`, `EditingATiedCollectionDoesNotMoveIt`, and both conformance tests |
| `compareTreeOrder`'s `createdAt` key + byte-wise id | 2 conformance cases |
| targeted invalidation | both `request-update-invalidation` cases |
| the importer's root-order omission | the orchestrator payload test |
| `order: request.order` on duplicate | the duplicate-order test |

Worth flagging: the first draft of the conformance gtest bound `for (const auto& c : load_fixture ()["cases"])` - a reference into a temporary the full expression destroys - and passed under the mutation because it iterated nothing. It now binds the fixture to a named value and counts the cases it ran, which is what caught it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #360

---
_Generated by [Claude Code](https://claude.ai/code/session_016U6K94aNccHiwEyC5JJSLd)_