### PR TITLE
fix(app): guard the tree's parentId walks, surface orphans, and stop rename double-fire

### DIFF
--- a/app/src/hooks/useVariableResolver.cycle.test.tsx
+++ b/app/src/hooks/useVariableResolver.cycle.test.tsx
@@ -17,11 +17,17 @@
  * database that already went bad; the guard is three lines and the failure it
  * prevents cannot be recovered from without killing the app.
  *
- * **Why the lookup budget.** Without the guard this test would spin forever and
+ * The walk itself now lives in `modules/collections/tree-utils` and is unit
+ * tested there; what these cover is that the hook still gets the terminating
+ * one, and that the chain it produces keeps the leaf-over-root override order
+ * the preview depends on.
+ *
+ * **Why the step budget.** Without the guard this test would spin forever and
  * take the whole vitest run with it - a synchronous loop never yields, so the
- * per-test timeout can never fire. The collections array therefore counts its
- * own `find` calls and throws past a budget no correct walk can reach, which
- * turns "hangs" into "fails with a message". Mutation-check the guard by
+ * per-test timeout can never fire. Each fixture collection therefore counts
+ * reads of its own `parentId` - exactly one per step of the walk, whatever it
+ * uses to look nodes up - and throws past a budget no correct walk can reach,
+ * which turns "hangs" into "fails with a message". Mutation-check the guard by
  * deleting the `seen` set: these tests fail in milliseconds, they do not stall.
  */
 
@@ -51,25 +57,28 @@ const LOOKUP_BUDGET = 10;
 let lookups = 0;
 
 /**
- * The collections array, with `find` counting itself.
+ * The collections, each counting reads of its own `parentId`.
  *
- * An own property shadows `Array.prototype.find`, so the walk calls this one
- * without knowing; the real implementation still does the matching.
+ * One read per step of the walk, so an unterminated walk trips the budget no
+ * matter how the walk looks its nodes up - which a counter wrapped around
+ * `Array.find` did not survive, having silently stopped counting the day the
+ * walk moved to a `Map`.
  */
 function budgetedCollections(list: Array<Partial<Collection>>): Collection[] {
-	const arr = list as unknown as Collection[];
-	Object.defineProperty(arr, "find", {
-		configurable: true,
-		value: (predicate: (c: Collection) => boolean) => {
-			if (++lookups > LOOKUP_BUDGET) {
-				throw new Error(
-					`buildCollectionChain made more than ${LOOKUP_BUDGET} lookups - the parentId walk is not terminating`
-				);
-			}
-			return Array.prototype.find.call(arr, predicate);
-		},
-	});
-	return arr;
+	return list.map((collection) => {
+		const { parentId } = collection;
+		return Object.defineProperty({ ...collection }, "parentId", {
+			enumerable: true,
+			get() {
+				if (++lookups > LOOKUP_BUDGET) {
+					throw new Error(
+						`more than ${LOOKUP_BUDGET} parentId reads - the collection chain walk is not terminating`
+					);
+				}
+				return parentId;
+			},
+		});
+	}) as Collection[];
 }
 
 const v = (value: string) => ({ value, enabled: true });

--- a/app/src/hooks/useVariableResolver.ts
+++ b/app/src/hooks/useVariableResolver.ts
@@ -31,8 +31,11 @@
 import { useMemo, useCallback } from "react";
 import { useGlobalsQuery, useCollectionsQuery, useEnvironmentsQuery } from "@/queries";
 import { useSessionStore } from "@/stores";
-import type { VariableValue, ResolvedVariable, VariableOrigin, Collection } from "@/types";
+import type { VariableValue, ResolvedVariable, VariableOrigin } from "@/types";
 import { castByType } from "@/lib/variable-cast";
+// The chain this hook used to build itself, guard and all - see tree-utils for
+// why every `parentId` walk in the renderer now comes from one place.
+import { walkAncestors } from "@/modules/collections/tree-utils";
 import {
 	coerceVariableValue,
 	isEnabledDefinition,
@@ -56,30 +59,6 @@ interface UseVariableResolverReturn {
 	 * `VariableOrigin` for why the losers are worth keeping.
 	 */
 	getVariableOrigins: (name: string) => VariableOrigin[];
-}
-
-/**
- * Build root-first ancestor chain for a collection (inclusive of the collection itself).
- *
- * The `seen` set is a termination guard, not deduplication: a `parentId` cycle
- * would otherwise walk forever inside a `useMemo`, which is a synchronous hang
- * of the renderer rather than a wrong preview. The engine rejects cycles on
- * write (#79), so this only fires on a database that already went bad - but the
- * cost of surviving it is one `Set`, and the cost of not is a frozen window.
- */
-function buildCollectionChain(startId: string, collections: Collection[]): Collection[] {
-	const chain: Collection[] = [];
-	const seen = new Set<string>();
-	let currentId: string | undefined = startId;
-	while (currentId) {
-		if (seen.has(currentId)) break;
-		seen.add(currentId);
-		const col = collections.find((c) => c.id === currentId);
-		if (!col) break;
-		chain.unshift(col); // root first
-		currentId = col.parentId;
-	}
-	return chain;
 }
 
 export function useVariableResolver(
@@ -147,7 +126,7 @@ export function useVariableResolver(
 		//    have scope "collection", and collapsing them by scope would hide the
 		//    override that actually happened.
 		if (activeCollectionId) {
-			for (const col of buildCollectionChain(activeCollectionId, collections)) {
+			for (const col of walkAncestors(activeCollectionId, collections)) {
 				for (const [key, val] of Object.entries(col.variables ?? {})) {
 					push(key, val as VariableValue, "collection", { id: col.id, name: col.name });
 				}

--- a/app/src/modules/collections/CollectionTree.delete.test.tsx
+++ b/app/src/modules/collections/CollectionTree.delete.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the confirm dialog does while the delete it confirmed is running.
+ *
+ * `DeleteConfirmDialog` takes an `isDeleting` prop and spends it on a spinner
+ * and a disabled pair of buttons - and it could never be true here, because both
+ * delete handlers closed the dialog as their very first act. The user confirmed
+ * a cascade delete of a folder and got an instantly-empty dialog with the tree
+ * unchanged until the round trip landed.
+ *
+ * The cascade list is the other half: closing tabs for a deleted folder has to
+ * reach requests nested two levels down, which the walk in `tree-utils` is now
+ * responsible for.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabsStore } from "@/stores";
+import { useCollectionsStore } from "./collections-store";
+import CollectionTree from "./CollectionTree";
+
+const deleteCollection = vi.fn();
+
+// root > mid > leaf, each holding one request. Deleting `root` cascades over
+// all of it.
+const collections = [
+	{ id: "root", name: "Acme", order: 0 },
+	{ id: "mid", name: "Billing", parentId: "root", order: 0 },
+	{ id: "leaf", name: "Invoices", parentId: "mid", order: 0 },
+];
+const requests = new Map([
+	["root", [{ id: "r-root", collectionId: "root", name: "Ping", method: "GET", order: 0 }]],
+	["mid", [{ id: "r-mid", collectionId: "mid", name: "Charge", method: "POST", order: 0 }]],
+	["leaf", [{ id: "r-leaf", collectionId: "leaf", name: "List", method: "GET", order: 0 }]],
+]);
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({
+		data: collections,
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: requests }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: deleteCollection, isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderTree() {
+	return render(
+		<QueryClientProvider
+			client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+		>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+/**
+ * Delete from the row's ⋯ menu - the only way in on a collection row today, the
+ * keyboard path being dead until the accessibility batch (#362) wires
+ * `data-tree-delete` on `CollectionItem` the way `RequestItem` already has it.
+ * Radix opens on pointerdown, not click.
+ */
+async function askToDelete(collectionName: string) {
+	fireEvent.pointerDown(
+		screen.getByRole("button", { name: `More actions for ${collectionName}` }),
+		{ button: 0, ctrlKey: false, pointerType: "mouse" }
+	);
+	fireEvent.click(await screen.findByRole("menuitem", { name: /Delete/ }));
+}
+
+const confirmButton = () => screen.findByRole("button", { name: /^Delete$/ });
+const cancelButton = () => screen.queryByRole("button", { name: /^Cancel$/ });
+
+beforeEach(() => {
+	// jsdom implements no scrolling; the reveal effect calls it for an open tab.
+	Element.prototype.scrollIntoView = vi.fn();
+	deleteCollection.mockReset().mockResolvedValue(undefined);
+	useCollectionsStore.setState({ expandedCollectionIds: new Set(["root", "mid", "leaf"]) });
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+});
+
+describe("confirming a collection delete", () => {
+	it("keeps the dialog up, with both actions disabled, until the delete settles", async () => {
+		let settle: () => void = () => {};
+		deleteCollection.mockReturnValue(
+			new Promise<void>((resolve) => {
+				settle = resolve;
+			})
+		);
+		renderTree();
+		await askToDelete("Invoices");
+
+		fireEvent.click(await confirmButton());
+
+		// In flight: the dialog is the only thing on screen saying so, and its
+		// buttons are disabled - which `isDeleting` could never make them, because
+		// the dialog was already unmounted by this point.
+		await waitFor(() => expect(cancelButton()).toBeDisabled());
+
+		settle();
+
+		await waitFor(() => expect(cancelButton()).not.toBeInTheDocument());
+	});
+
+	it("closes the dialog when the delete fails, having reported it", async () => {
+		deleteCollection.mockRejectedValue(new Error("database is locked"));
+		renderTree();
+		await askToDelete("Invoices");
+
+		fireEvent.click(await confirmButton());
+
+		await waitFor(() => expect(cancelButton()).not.toBeInTheDocument());
+	});
+
+	it("cannot fire the same delete twice from a double click", async () => {
+		let settle: () => void = () => {};
+		deleteCollection.mockReturnValue(
+			new Promise<void>((resolve) => {
+				settle = resolve;
+			})
+		);
+		renderTree();
+		await askToDelete("Invoices");
+		const confirm = await confirmButton();
+
+		// Both clicks land before React can re-render the button as disabled -
+		// the frame the dialog now stays open for.
+		fireEvent.click(confirm);
+		fireEvent.click(confirm);
+		settle();
+
+		await waitFor(() => expect(deleteCollection).toHaveBeenCalledTimes(1));
+	});
+
+	it("closes the tabs of every descendant folder and request, not just the top level", async () => {
+		useTabsStore.setState({
+			openTabs: [
+				{ id: "t1", type: "collection", entityId: "root" },
+				{ id: "t2", type: "collection", entityId: "leaf" },
+				{ id: "t3", type: "request", entityId: "r-leaf" },
+				{ id: "t4", type: "request", entityId: "r-mid" },
+			],
+			activeTabId: "t1",
+		});
+		renderTree();
+		await askToDelete("Acme");
+
+		fireEvent.click(await confirmButton());
+
+		// The nested request two levels down is the one a single-level cascade
+		// would leave open on a row the engine has already removed.
+		await waitFor(() => expect(useTabsStore.getState().openTabs).toEqual([]));
+	});
+});

--- a/app/src/modules/collections/CollectionTree.orphan.test.tsx
+++ b/app/src/modules/collections/CollectionTree.orphan.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A collection whose parent is not among the loaded collections used to render
+ * nowhere at all: it failed the roots filter (`!c.parentId`) and no parent row
+ * existed to list it as a child. That is exactly the state a bad or half-applied
+ * reparent leaves behind, and the symptom was a collection - with its requests -
+ * silently vanishing from the sidebar while still existing in the database.
+ *
+ * Degrading visibly beats degrading invisibly: the row appears at the top level,
+ * where it can be opened, renamed or deleted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useCollectionsStore } from "./collections-store";
+import CollectionTree from "./CollectionTree";
+
+// `stray` points at a parent that is not in the list; `child` points at one that
+// is, and must keep rendering where it belongs rather than doubling up at root.
+const collections = [
+	{ id: "root", name: "Acme", order: 0 },
+	{ id: "child", name: "Billing", parentId: "root", order: 0 },
+	{ id: "stray", name: "Orphaned", parentId: "deleted-parent", order: 1 },
+];
+const requests = new Map([
+	["stray", [{ id: "r-stray", collectionId: "stray", name: "Lost", method: "GET", order: 0 }]],
+]);
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({
+		data: collections,
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: requests }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderTree() {
+	return render(
+		<QueryClientProvider client={new QueryClient()}>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	useCollectionsStore.setState({ expandedCollectionIds: new Set(["root", "stray"]) });
+});
+
+describe("a collection whose parent is not loaded", () => {
+	it("renders at the top level instead of vanishing", () => {
+		const { container } = renderTree();
+
+		const rows = container.querySelectorAll('[role="tree"] > * > [data-collection-id]');
+		expect([...rows].map((r) => r.getAttribute("data-collection-id"))).toEqual([
+			"root",
+			"stray",
+		]);
+	});
+
+	it("brings its requests with it", () => {
+		const { container } = renderTree();
+
+		expect(container.querySelector('[data-request-id="r-stray"]')).not.toBeNull();
+	});
+
+	it("does not promote a collection whose parent is loaded", () => {
+		const { container } = renderTree();
+
+		// One row for `child`, and it is not a root: a filter that read "no parent
+		// row rendered *yet*" rather than "no parent loaded" would duplicate it.
+		expect(container.querySelectorAll('[data-collection-id="child"]')).toHaveLength(1);
+		expect(
+			container.querySelector('[role="tree"] > * > [data-collection-id="child"]')
+		).toBeNull();
+	});
+});

--- a/app/src/modules/collections/CollectionTree.rename.test.tsx
+++ b/app/src/modules/collections/CollectionTree.rename.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Renaming a row in the tree, and what it is allowed to send.
+ *
+ * Two defects lived here. The rename field submits on Enter *and* on blur, and
+ * both handlers cleared their rename state only after awaiting the mutation - so
+ * the field was still mounted when Enter's PUT went out, and the blur that
+ * followed sent a second one. The collection path additionally had no
+ * unchanged-name check, so opening a rename and clicking away PUT the name it
+ * already had.
+ *
+ * The third case is the status timer: both paths armed a bare
+ * `setTimeout(() => setStatus("idle"))`, which fires two seconds later no matter
+ * what happened in between - clearing a failure another surface had published to
+ * the Dock.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useSaveStore, useToastStore } from "@/stores";
+import { useCollectionsStore } from "./collections-store";
+import CollectionTree from "./CollectionTree";
+import { TIMING } from "@/config/timing";
+
+const updateCollection = vi.fn();
+const updateRequest = vi.fn();
+
+const collection = { id: "c1", name: "Acme API", order: 0 };
+const request = { id: "r1", collectionId: "c1", name: "Get users", method: "GET", order: 0 };
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({
+		data: [collection],
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({
+		requestsByCollection: new Map([["c1", [request]]]),
+	}),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: updateCollection, isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: updateRequest, isPending: false }),
+}));
+
+function renderTree() {
+	return render(
+		<QueryClientProvider
+			client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+		>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+/** F2 on a focused row is the keyboard path into the same rename handlers. */
+function startRename(selector: string) {
+	const row = document.querySelector<HTMLElement>(selector)!;
+	row.focus();
+	fireEvent.keyDown(row, { key: "F2" });
+	const field = document.querySelector<HTMLInputElement>(`${selector} input`);
+	expect(field).not.toBeNull();
+	return field!;
+}
+
+beforeEach(() => {
+	updateCollection.mockReset().mockResolvedValue(collection);
+	updateRequest.mockReset().mockResolvedValue(request);
+	useSaveStore.setState({ status: "idle" });
+	useToastStore.setState({ toasts: [] });
+	useCollectionsStore.setState({ expandedCollectionIds: new Set(["c1"]) });
+});
+
+describe("renaming a collection", () => {
+	it("sends nothing when the name is unchanged", async () => {
+		renderTree();
+		const field = startRename('[data-collection-id="c1"]');
+
+		fireEvent.blur(field);
+
+		await waitFor(() =>
+			expect(document.querySelector('[data-collection-id="c1"] input')).toBeNull()
+		);
+		expect(updateCollection).not.toHaveBeenCalled();
+		// Nothing was saved, so nothing may claim it was.
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("sends nothing when the name is only whitespace", async () => {
+		renderTree();
+		const field = startRename('[data-collection-id="c1"]');
+
+		fireEvent.change(field, { target: { value: "   " } });
+		fireEvent.keyDown(field, { key: "Enter" });
+
+		await waitFor(() =>
+			expect(document.querySelector('[data-collection-id="c1"] input')).toBeNull()
+		);
+		expect(updateCollection).not.toHaveBeenCalled();
+	});
+
+	it("sends exactly one PUT when Enter is followed by the blur it causes", async () => {
+		renderTree();
+		const field = startRename('[data-collection-id="c1"]');
+
+		fireEvent.change(field, { target: { value: "Payments" } });
+		fireEvent.keyDown(field, { key: "Enter" });
+		// The real field blurs as it unmounts; firing it explicitly is the
+		// worst case, and the one that used to send a second PUT.
+		fireEvent.blur(field);
+
+		await waitFor(() => expect(updateCollection).toHaveBeenCalledTimes(1));
+		expect(updateCollection).toHaveBeenCalledWith({ id: "c1", name: "Payments" });
+	});
+
+	it("reports a failed rename", async () => {
+		updateCollection.mockRejectedValue(new Error("database is locked"));
+		renderTree();
+		const field = startRename('[data-collection-id="c1"]');
+
+		fireEvent.change(field, { target: { value: "Payments" } });
+		fireEvent.keyDown(field, { key: "Enter" });
+
+		await waitFor(() => expect(useSaveStore.getState().status).toBe("error"));
+		expect(useToastStore.getState().toasts[0]?.message).toMatch(/database is locked/i);
+	});
+});
+
+describe("renaming a request", () => {
+	it("sends nothing when the name is unchanged", async () => {
+		renderTree();
+		const field = startRename('[data-request-id="r1"]');
+
+		fireEvent.blur(field);
+
+		await waitFor(() =>
+			expect(document.querySelector('[data-request-id="r1"] input')).toBeNull()
+		);
+		expect(updateRequest).not.toHaveBeenCalled();
+	});
+
+	it("sends exactly one PUT when Enter is followed by the blur it causes", async () => {
+		renderTree();
+		const field = startRename('[data-request-id="r1"]');
+
+		fireEvent.change(field, { target: { value: "List users" } });
+		fireEvent.keyDown(field, { key: "Enter" });
+		fireEvent.blur(field);
+
+		await waitFor(() => expect(updateRequest).toHaveBeenCalledTimes(1));
+		expect(updateRequest).toHaveBeenCalledWith({ id: "r1", name: "List users" });
+	});
+});
+
+describe("the status timer a rename arms", () => {
+	beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+	afterEach(() => vi.useRealTimers());
+
+	it("returns the Dock to idle when nothing else has happened", async () => {
+		renderTree();
+		const field = startRename('[data-collection-id="c1"]');
+		fireEvent.change(field, { target: { value: "Payments" } });
+		fireEvent.keyDown(field, { key: "Enter" });
+
+		await waitFor(() => expect(useSaveStore.getState().status).toBe("saved"));
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.STATUS_RESET_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("leaves a failure that arrived meanwhile on screen", async () => {
+		renderTree();
+		const field = startRename('[data-collection-id="c1"]');
+		fireEvent.change(field, { target: { value: "Payments" } });
+		fireEvent.keyDown(field, { key: "Enter" });
+		await waitFor(() => expect(useSaveStore.getState().status).toBe("saved"));
+
+		// Anything else failing before the timer fires: an unrelated delete, an
+		// editor's autosave. The Dock is now showing that error.
+		act(() => useSaveStore.getState().failSave("delete failed"));
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.STATUS_RESET_MS);
+		});
+
+		// The rename's timer used to clear it and leave the Dock saying nothing at
+		// all, next to a toast about a failure.
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+});

--- a/app/src/modules/collections/CollectionTree.reveal.test.tsx
+++ b/app/src/modules/collections/CollectionTree.reveal.test.tsx
@@ -40,6 +40,13 @@ const child = { id: "child", name: "Billing", parentId: "root", order: 0 };
 const grandchild = { id: "grand", name: "Invoices", parentId: "child", order: 0 };
 const request = { id: "r1", collectionId: "grand", name: "Get invoice", method: "GET", order: 0 };
 
+/**
+ * Mutable so a test can render before the per-collection request lists have
+ * arrived and swap them in afterwards - the state every cold start passes
+ * through, and the one the reveal has to survive.
+ */
+let requestsByCollection = new Map<string, Array<typeof request>>();
+
 vi.mock("@/queries", () => ({
 	useCollectionsQuery: () => ({
 		data: [root, child, grandchild],
@@ -48,8 +55,10 @@ vi.mock("@/queries", () => ({
 		error: null,
 		refetch: vi.fn(),
 	}),
+	// A fresh Map per call, exactly as the real hook once did - which is what
+	// made the reveal effect re-run after every render.
 	useMultipleCollectionRequests: () => ({
-		requestsByCollection: new Map([["grand", [request]]]),
+		requestsByCollection: new Map(requestsByCollection),
 	}),
 	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
 	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -74,11 +83,15 @@ const expanded = () => [...useCollectionsStore.getState().expandedCollectionIds]
 
 // jsdom implements no scrolling. The reveal effect calls this once a row
 // exists, which these tests are the first to actually reach.
+const scrollIntoView = vi.fn();
+
 beforeEach(() => {
-	Element.prototype.scrollIntoView = vi.fn();
+	scrollIntoView.mockClear();
+	Element.prototype.scrollIntoView = scrollIntoView;
 	// Everything collapsed: the state in which the bug is visible at all.
 	useCollectionsStore.setState({ expandedCollectionIds: new Set<string>() });
 	useTabsStore.setState({ openTabs: [], activeTabId: null });
+	requestsByCollection = new Map([["grand", [request]]]);
 });
 
 describe("revealing the active tab in the tree", () => {
@@ -200,6 +213,35 @@ describe("collapsing a collection on the selected tab's ancestor path", () => {
 		expect(expanded()).toContain("grand");
 	});
 
+	it("does not scroll again when an unrelated folder is collapsed", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		const { container } = renderTree();
+		expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+		// `root` holds no part of the selection's row; collapsing it re-renders
+		// the tree, and an unguarded scroll effect would yank the view back to a
+		// row the user just navigated away from.
+		collapse(container, "root");
+
+		expect(scrollIntoView).toHaveBeenCalledTimes(1);
+	});
+
+	it("scrolls again once the selection actually changes", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		renderTree();
+		expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+		selectTab({ id: "t2", type: "collection", entityId: "child" });
+
+		expect(scrollIntoView).toHaveBeenCalledTimes(2);
+	});
+
 	it("re-reveals when the selection moves to a different entity", () => {
 		useTabsStore.setState({
 			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
@@ -211,6 +253,41 @@ describe("collapsing a collection on the selected tab's ancestor path", () => {
 
 		selectTab({ id: "t2", type: "collection", entityId: "grand" });
 
+		expect(expanded()).toContain("child");
+		expect(expanded()).toContain("grand");
+	});
+});
+
+/**
+ * On a cold start the tabs are restored before the per-collection request lists
+ * land, so the owning collection of a selected request is unknown for the first
+ * render or two. The effect must treat that as "not yet", not as "done" - it
+ * leaves its ref unset so the reveal happens when the data arrives.
+ */
+describe("revealing a request whose collection has not loaded yet", () => {
+	it("expands nothing while the lists are empty, then reveals when they arrive", () => {
+		requestsByCollection = new Map();
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		const { rerender } = renderTree();
+
+		// Nothing to walk up from: the request belongs to no known collection.
+		expect(expanded()).toEqual([]);
+
+		requestsByCollection = new Map([["grand", [request]]]);
+		act(() => {
+			rerender(
+				<QueryClientProvider client={new QueryClient()}>
+					<TooltipProvider>
+						<CollectionTree />
+					</TooltipProvider>
+				</QueryClientProvider>
+			);
+		});
+
+		expect(expanded()).toContain("root");
 		expect(expanded()).toContain("child");
 		expect(expanded()).toContain("grand");
 	});

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -29,20 +29,20 @@ import {
 } from "@/components/ui";
 import CollectionItem from "./CollectionItem";
 import { useRovingTreeFocus } from "./useRovingTreeFocus";
+import { walkAncestors, collectDescendantEntityIds } from "./tree-utils";
 import { DrawerPanel, EmptyState, ErrorState, ListSkeleton } from "@/components/shared";
 import type { RowAction } from "@/components/shared";
 import type { Collection, Request } from "@/types";
 import { compareCollectionOrder } from "@/types";
-import { TIMING } from "@/config/timing";
 import { DEFAULT_REQUEST_NAME } from "@/constants/request";
 import { DEFAULT_COLLECTION_NAME, DEFAULT_FOLDER_NAME } from "@/constants/collection";
 
 export default function CollectionTree() {
 	const openImport = useImportModalStore((s) => s.open);
 	const { openTab, openTabs, activeTabId, closeTabsForEntities } = useTabsStore();
-	const { expandedCollectionIds, toggleCollectionExpanded, expandCollections } =
+	const { expandedCollectionIds, toggleCollectionExpanded, expandCollection, expandCollections } =
 		useCollectionsStore();
-	const { startSaving, completeSave, failSave, setStatus } = useSaveStore();
+	const { startSaving, completeSaveThenIdle, failSave } = useSaveStore();
 	const treeRef = useRef<HTMLDivElement>(null);
 	const treeFocus = useRovingTreeFocus(treeRef);
 	// Both reveal and scroll are once-per-selection, and each records the
@@ -100,10 +100,20 @@ export default function CollectionTree() {
 		[requestsByCollection]
 	);
 
-	const rootCollections = useMemo(
-		() => [...collections].filter((c) => !c.parentId).sort(compareCollectionOrder),
-		[collections]
-	);
+	/*
+	 * Roots are the collections with no parent *and* the ones whose parent is not
+	 * loaded. An orphan used to match neither the roots filter nor any parent's
+	 * children, so it rendered nowhere at all - which is precisely the shape a bad
+	 * or half-applied reparent leaves behind, and the user saw a collection
+	 * silently disappear rather than a tree that looked wrong. Degrading visibly
+	 * is the point: the row is reachable, so it can be moved or deleted.
+	 */
+	const rootCollections = useMemo(() => {
+		const loadedIds = new Set(collections.map((c) => c.id));
+		return collections
+			.filter((c) => !c.parentId || !loadedIds.has(c.parentId))
+			.sort(compareCollectionOrder);
+	}, [collections]);
 
 	/*
 	 * Reveal whatever the active tab points at: expand its ancestor folders so
@@ -155,12 +165,9 @@ export default function CollectionTree() {
 		// unset so this reveals once they do, rather than counting as done.
 		if (!target) return;
 
-		const ancestorChain: string[] = [];
-		let cursor: string | undefined = target;
-		while (cursor) {
-			ancestorChain.push(cursor);
-			cursor = collections.find((c) => c.id === cursor)?.parentId ?? undefined;
-		}
+		// walkAncestors, not a local loop: this walk is unbounded on a `parentId`
+		// cycle, which hangs the renderer inside an effect (see tree-utils).
+		const ancestorChain = walkAncestors(target, collections).map((c) => c.id);
 		revealedSelectionRef.current = selectionId;
 		expandCollections(ancestorChain);
 	}, [
@@ -283,10 +290,7 @@ export default function CollectionTree() {
 	const handleCreateSubfolder = async (parentId: string) => {
 		if (!newSubCollectionName.trim() || createCollectionMutation.isPending) return;
 
-		// Ensure parent collection is expanded
-		if (!expandedCollectionIds.has(parentId)) {
-			toggleCollectionExpanded(parentId);
-		}
+		expandCollection(parentId);
 
 		try {
 			await createCollectionMutation.mutateAsync({
@@ -300,58 +304,62 @@ export default function CollectionTree() {
 		handleCancelSubfolder();
 	};
 
-	const handleCreateRequest = async (collectionId: string) => {
-		if (createRequestMutation.isPending) return;
+	// Memoised because `getCollectionActions` lists it: rebuilt every render, it
+	// would rebuild every collection's ⋯ menu with it.
+	const handleCreateRequest = useCallback(
+		async (collectionId: string) => {
+			if (createRequestMutation.isPending) return;
 
-		if (!expandedCollectionIds.has(collectionId)) {
-			toggleCollectionExpanded(collectionId);
-		}
+			expandCollection(collectionId);
 
-		let request: Request | undefined;
-		try {
-			request = await createRequestMutation.mutateAsync({
-				collectionId: collectionId,
-				name: DEFAULT_REQUEST_NAME,
-				method: "GET",
-				url: "",
-			});
-		} catch (error) {
-			reportFailure(error, "Failed to create request");
-			return;
-		}
+			let request: Request | undefined;
+			try {
+				request = await createRequestMutation.mutateAsync({
+					collectionId: collectionId,
+					name: DEFAULT_REQUEST_NAME,
+					method: "GET",
+					url: "",
+				});
+			} catch (error) {
+				reportFailure(error, "Failed to create request");
+				return;
+			}
 
-		if (request) {
-			navigateToRequest(collectionId, request.id);
-		}
-	};
+			if (request) {
+				navigateToRequest(collectionId, request.id);
+			}
+		},
+		[createRequestMutation, expandCollection, navigateToRequest, reportFailure]
+	);
 
-	const handleRenameCollection = (collection: Collection) => {
+	const handleRenameCollection = useCallback((collection: Collection) => {
 		setRenamingId(collection.id);
 		setRenameValue(collection.name);
-	};
+	}, []);
 
 	const handleRenameSubmit = async (collectionId: string) => {
-		if (!renameValue.trim()) {
-			setRenamingId(null);
-			setRenameValue("");
-			return;
-		}
+		const trimmedValue = renameValue.trim();
+		// Enter submits and then blur submits again, because the field is still
+		// mounted while the PUT is in flight. Clearing the rename state *before*
+		// awaiting unmounts the field, so there is no second blur to fire - and a
+		// name that did not change never reaches the wire at all, which is the
+		// guard the request-rename path has always had and this one had not.
+		setRenamingId(null);
+		setRenameValue("");
+
+		const original = collections.find((c) => c.id === collectionId);
+		if (!trimmedValue || original?.name === trimmedValue) return;
 
 		startSaving();
 		try {
 			await updateCollectionMutation.mutateAsync({
 				id: collectionId,
-				name: renameValue.trim(),
+				name: trimmedValue,
 			});
-			completeSave();
-			// Reset to idle after showing "saved" status
-			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+			completeSaveThenIdle();
 		} catch (error) {
 			failSave(error instanceof Error ? error.message : "Failed to rename collection");
 		}
-
-		setRenamingId(null);
-		setRenameValue("");
 	};
 
 	/**
@@ -412,9 +420,7 @@ export default function CollectionTree() {
 				label: "Add Folder",
 				icon: FolderPlus,
 				onSelect: () => {
-					if (!expandedCollectionIds.has(collection.id)) {
-						toggleCollectionExpanded(collection.id);
-					}
+					expandCollection(collection.id);
 					setCreatingSubfolder(collection.id);
 				},
 			},
@@ -430,34 +436,31 @@ export default function CollectionTree() {
 					}),
 			},
 		],
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[expandedCollectionIds, toggleCollectionExpanded]
+		// Honest deps, which is only possible now that both handlers are memoised
+		// and the expand goes through `expandCollection` rather than reading the
+		// expanded set. The suppression that used to sit here hid two callbacks
+		// captured from whichever render last rebuilt this - benign only by
+		// accident, and this is the seam the drag-and-drop work extends.
+		[expandCollection, handleCreateRequest, handleRenameCollection]
 	);
 
 	const handleDeleteCollection = useCallback(
 		async (collectionId: string) => {
 			setDeletingCollectionId(collectionId);
-			setDeleteConfirm(null);
 			// Gather the collection, its descendant folders, and every request they
 			// contain: deleting a collection cascades, so all their tabs go stale.
-			const affected = new Set<string>([collectionId]);
-			const stack = [collectionId];
-			while (stack.length > 0) {
-				const current = stack.pop()!;
-				for (const req of getRequestsByCollection(current)) affected.add(req.id);
-				for (const child of collections) {
-					if (child.parentId === current) {
-						affected.add(child.id);
-						stack.push(child.id);
-					}
-				}
-			}
+			const affected = collectDescendantEntityIds(collectionId, collections, (id) =>
+				getRequestsByCollection(id).map((r) => r.id)
+			);
 			try {
 				await deleteCollectionMutation.mutateAsync(collectionId);
 				closeTabsForEntities(affected);
 			} catch (error) {
 				reportFailure(error, "Failed to delete collection");
 			} finally {
+				// Only now: the dialog stays up, with its confirm button spinning,
+				// for as long as the delete is actually running.
+				setDeleteConfirm(null);
 				setDeletingCollectionId(null);
 			}
 		},
@@ -473,7 +476,6 @@ export default function CollectionTree() {
 	const handleDeleteRequest = useCallback(
 		async (requestId: string) => {
 			setDeletingRequestId(requestId);
-			setDeleteConfirm(null);
 			try {
 				await deleteRequestMutation.mutateAsync(requestId);
 				// Close any open tab pointing at the now-deleted request.
@@ -481,6 +483,7 @@ export default function CollectionTree() {
 			} catch (error) {
 				reportFailure(error, "Failed to delete request");
 			} finally {
+				setDeleteConfirm(null);
 				setDeletingRequestId(null);
 			}
 		},
@@ -493,12 +496,22 @@ export default function CollectionTree() {
 
 	const handleConfirmDelete = useCallback(() => {
 		if (!deleteConfirm) return;
+		// The dialog now stays open while the delete runs, so its confirm button
+		// survives long enough to be clicked twice. `isDeleting` disables it from
+		// the next render on; this covers the frame before that.
+		if (deletingCollectionId || deletingRequestId) return;
 		if (deleteConfirm.type === "collection") {
 			handleDeleteCollection(deleteConfirm.id);
 		} else {
 			handleDeleteRequest(deleteConfirm.id);
 		}
-	}, [deleteConfirm, handleDeleteCollection, handleDeleteRequest]);
+	}, [
+		deleteConfirm,
+		deletingCollectionId,
+		deletingRequestId,
+		handleDeleteCollection,
+		handleDeleteRequest,
+	]);
 
 	const handleStartRequestRename = (request: Request) => {
 		setRenamingRequestId(request.id);
@@ -507,13 +520,11 @@ export default function CollectionTree() {
 
 	const handleRequestRenameSubmit = async (requestId: string) => {
 		const trimmedValue = renameRequestValue.trim();
-
-		// Validate: name cannot be empty
-		if (!trimmedValue) {
-			setRenamingRequestId(null);
-			setRenameRequestValue("");
-			return;
-		}
+		// Cleared before the await for the same reason as the collection path:
+		// while the field is still mounted, the blur that follows Enter submits a
+		// second time.
+		setRenamingRequestId(null);
+		setRenameRequestValue("");
 
 		// Find the original request to check if name actually changed
 		// Search through all collections to find the request
@@ -526,12 +537,8 @@ export default function CollectionTree() {
 			}
 		}
 
-		// Skip save if name hasn't actually changed
-		if (originalRequest && originalRequest.name === trimmedValue) {
-			setRenamingRequestId(null);
-			setRenameRequestValue("");
-			return;
-		}
+		// Empty name, or a name that did not change: nothing to save.
+		if (!trimmedValue || originalRequest?.name === trimmedValue) return;
 
 		startSaving();
 		try {
@@ -539,15 +546,10 @@ export default function CollectionTree() {
 				id: requestId,
 				name: trimmedValue,
 			});
-			completeSave();
-			// Reset to idle after showing "saved" status
-			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+			completeSaveThenIdle();
 		} catch (error) {
 			failSave(error instanceof Error ? error.message : "Failed to rename request");
 		}
-
-		setRenamingRequestId(null);
-		setRenameRequestValue("");
 	};
 
 	const handleRequestRenameCancel = useCallback(() => {
@@ -712,7 +714,7 @@ export default function CollectionTree() {
 						/>
 					)}
 
-				{/* Root-level collections (no parentId) - sorted by order, scrollable.
+				{/* Root-level collections (no parent loaded) - sorted by order, scrollable.
 			    role="tree" + roving tabindex: the whole tree is one tab stop and
 			    arrow keys move between rows (see useRovingTreeFocus). */}
 				{!isLoadingCollections && rootCollections.length > 0 && (

--- a/app/src/modules/collections/collections-store.test.ts
+++ b/app/src/modules/collections/collections-store.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The tree's expansion store - untested until now, which is how it came to hold
+ * three actions with no callers at all while the tree hand-rolled two of them.
+ *
+ * No jsdom pragma: this store is a plain `create` with no `persist`, so nothing
+ * here reaches `localStorage`.
+ *
+ * The identity assertions are the load-bearing ones. `expandedCollectionIds` is
+ * a `Set` passed down the whole tree and listed in effect dependencies, so an
+ * action that returns a fresh Set for a no-op re-renders every row and re-runs
+ * the reveal effect - which is the exact shape of the bug that once pinned a
+ * collection open.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useCollectionsStore } from "./collections-store";
+
+const ids = () => [...useCollectionsStore.getState().expandedCollectionIds];
+const set = () => useCollectionsStore.getState().expandedCollectionIds;
+
+beforeEach(() => {
+	useCollectionsStore.setState({ expandedCollectionIds: new Set<string>() });
+});
+
+describe("toggleCollectionExpanded", () => {
+	it("expands then collapses the same id", () => {
+		const { toggleCollectionExpanded } = useCollectionsStore.getState();
+
+		toggleCollectionExpanded("c1");
+		expect(ids()).toEqual(["c1"]);
+
+		toggleCollectionExpanded("c1");
+		expect(ids()).toEqual([]);
+	});
+
+	it("leaves other ids alone", () => {
+		const { toggleCollectionExpanded } = useCollectionsStore.getState();
+
+		toggleCollectionExpanded("c1");
+		toggleCollectionExpanded("c2");
+		toggleCollectionExpanded("c1");
+
+		expect(ids()).toEqual(["c2"]);
+	});
+});
+
+describe("expandCollection", () => {
+	it("expands an id that was collapsed", () => {
+		useCollectionsStore.getState().expandCollection("c1");
+
+		expect(ids()).toEqual(["c1"]);
+	});
+
+	it("is a no-op on an already expanded id, down to the Set's identity", () => {
+		const { expandCollection } = useCollectionsStore.getState();
+		expandCollection("c1");
+		const before = set();
+
+		expandCollection("c1");
+
+		// Not just equal contents: the same object, so every consumer that
+		// compares by reference skips the re-render.
+		expect(set()).toBe(before);
+	});
+
+	it("never toggles - the caller that wanted expand only cannot get a collapse", () => {
+		const { expandCollection } = useCollectionsStore.getState();
+
+		expandCollection("c1");
+		expandCollection("c1");
+
+		expect(ids()).toEqual(["c1"]);
+	});
+});
+
+describe("expandCollections", () => {
+	it("adds a whole ancestor chain at once, keeping what was already open", () => {
+		const { expandCollection, expandCollections } = useCollectionsStore.getState();
+		expandCollection("other");
+
+		expandCollections(["root", "mid", "leaf"]);
+
+		expect(ids().sort()).toEqual(["leaf", "mid", "other", "root"]);
+	});
+
+	it("keeps the same Set when every id is already expanded", () => {
+		const { expandCollections } = useCollectionsStore.getState();
+		expandCollections(["root", "mid"]);
+		const before = set();
+
+		expandCollections(["root", "mid"]);
+
+		expect(set()).toBe(before);
+	});
+
+	it("replaces the Set when even one id is new", () => {
+		const { expandCollections } = useCollectionsStore.getState();
+		expandCollections(["root"]);
+		const before = set();
+
+		expandCollections(["root", "mid"]);
+
+		expect(set()).not.toBe(before);
+		expect(ids().sort()).toEqual(["mid", "root"]);
+	});
+
+	it("does nothing at all for an empty chain", () => {
+		const before = set();
+
+		useCollectionsStore.getState().expandCollections([]);
+
+		expect(set()).toBe(before);
+	});
+});
+
+describe("the store's surface", () => {
+	it("exposes no action nothing calls", () => {
+		// `collapseCollection` and `reset` sat here with zero callers app-wide -
+		// collapsing goes through `toggleCollectionExpanded`, and nothing has ever
+		// wanted to clear the whole set. A new action belongs here when its caller
+		// does.
+		expect(Object.keys(useCollectionsStore.getState()).sort()).toEqual([
+			"expandCollection",
+			"expandCollections",
+			"expandedCollectionIds",
+			"toggleCollectionExpanded",
+		]);
+	});
+});

--- a/app/src/modules/collections/collections-store.ts
+++ b/app/src/modules/collections/collections-store.ts
@@ -16,10 +16,17 @@ interface CollectionsUIState {
 
 	// Actions
 	toggleCollectionExpanded: (collectionId: string) => void;
+	/**
+	 * Expand one collection, idempotently.
+	 *
+	 * The tree used to hand-roll `if (!expanded.has(id)) toggle(id)` at three
+	 * sites while this sat here with no callers - a toggle guarded by a read of
+	 * the set it toggles, which is this action with an extra dependency on
+	 * `expandedCollectionIds` bolted on. That dependency is why the ⋯ menu's
+	 * actions had to be rebuilt on every expand.
+	 */
 	expandCollection: (collectionId: string) => void;
 	expandCollections: (collectionIds: string[]) => void;
-	collapseCollection: (collectionId: string) => void;
-	reset: () => void;
 }
 
 export const useCollectionsStore = create<CollectionsUIState>((set) => ({
@@ -38,6 +45,9 @@ export const useCollectionsStore = create<CollectionsUIState>((set) => ({
 
 	expandCollection: (collectionId) =>
 		set((state) => {
+			// Same skip as `expandCollections`: expanding what is already expanded
+			// must not produce a new Set, or every caller re-renders the tree.
+			if (state.expandedCollectionIds.has(collectionId)) return state;
 			const newExpanded = new Set(state.expandedCollectionIds);
 			newExpanded.add(collectionId);
 			return { expandedCollectionIds: newExpanded };
@@ -52,17 +62,5 @@ export const useCollectionsStore = create<CollectionsUIState>((set) => ({
 			const newExpanded = new Set(state.expandedCollectionIds);
 			for (const id of collectionIds) newExpanded.add(id);
 			return { expandedCollectionIds: newExpanded };
-		}),
-
-	collapseCollection: (collectionId) =>
-		set((state) => {
-			const newExpanded = new Set(state.expandedCollectionIds);
-			newExpanded.delete(collectionId);
-			return { expandedCollectionIds: newExpanded };
-		}),
-
-	reset: () =>
-		set({
-			expandedCollectionIds: new Set<string>(),
 		}),
 }));

--- a/app/src/modules/collections/tree-utils.test.ts
+++ b/app/src/modules/collections/tree-utils.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The tree walks, and the cycle that used to freeze the window.
+ *
+ * **Why the step budgets.** Without a termination guard these tests would spin
+ * forever and take the whole vitest run with them - a synchronous loop never
+ * yields, so the per-test timeout can never fire. Each walk is therefore given a
+ * fixture that counts the one thing it does exactly once per step and throws
+ * past a budget no correct walk can reach: `parentId` reads for the ancestor
+ * walk, and a request lookup per visited collection for the descendant walk.
+ * That turns "hangs" into "fails with a message" - mutation-check by deleting
+ * the `seen` set in `walkAncestors` or the `visited` set in
+ * `collectDescendantEntityIds`, and these fail in milliseconds rather than
+ * stalling.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	walkAncestors,
+	isDescendant,
+	collectDescendantEntityIds,
+	type TreeNode,
+} from "./tree-utils";
+
+/** No fixture chain here is longer than four, so twenty is unreachable. */
+const STEP_BUDGET = 20;
+
+let steps = 0;
+
+beforeEach(() => {
+	steps = 0;
+});
+
+/**
+ * The nodes, with every `parentId` read counted.
+ *
+ * A getter rather than a wrapped array method, because the walks are free to
+ * look their nodes up however they like (`Array.find`, a `Map`) - what no
+ * terminating walk can do is read one node's parent an unbounded number of
+ * times.
+ */
+function budgeted<T extends TreeNode>(nodes: T[]): T[] {
+	return nodes.map((node) => {
+		const { parentId } = node;
+		return Object.defineProperty({ ...node }, "parentId", {
+			enumerable: true,
+			get() {
+				if (++steps > STEP_BUDGET) {
+					throw new Error(
+						`more than ${STEP_BUDGET} parentId reads - the walk is not terminating`
+					);
+				}
+				return parentId;
+			},
+		}) as T;
+	});
+}
+
+const named = (id: string, parentId?: string) => ({ id, name: id, parentId });
+
+describe("walkAncestors", () => {
+	it("returns the chain root first, inclusive of the start node", () => {
+		const nodes = budgeted([named("leaf", "mid"), named("mid", "root"), named("root")]);
+
+		expect(walkAncestors("leaf", nodes).map((n) => n.id)).toEqual(["root", "mid", "leaf"]);
+	});
+
+	it("terminates on a two-node cycle, visiting each node once", () => {
+		const nodes = budgeted([named("a", "b"), named("b", "a")]);
+
+		// Not deduplication: both nodes are still reported, in the order the
+		// override rules downstream depend on. Only the *repeat* stops the walk.
+		expect(walkAncestors("a", nodes).map((n) => n.id)).toEqual(["b", "a"]);
+	});
+
+	it("terminates on a node that is its own parent", () => {
+		const nodes = budgeted([named("self", "self")]);
+
+		expect(walkAncestors("self", nodes).map((n) => n.id)).toEqual(["self"]);
+	});
+
+	it("stops at an unloaded parent instead of inventing one", () => {
+		const nodes = budgeted([named("orphan", "gone")]);
+
+		expect(walkAncestors("orphan", nodes).map((n) => n.id)).toEqual(["orphan"]);
+	});
+
+	it("returns nothing for a start id that is not loaded", () => {
+		expect(walkAncestors("ghost", budgeted([named("root")]))).toEqual([]);
+	});
+
+	it("stays well under the budget on an honest chain", () => {
+		// Guards the guard: a budget the correct walk could trip would make the
+		// cycle cases above pass for the wrong reason.
+		const nodes = budgeted([named("leaf", "root"), named("root")]);
+
+		walkAncestors("leaf", nodes);
+
+		expect(steps).toBeGreaterThan(0);
+		expect(steps).toBeLessThanOrEqual(STEP_BUDGET);
+	});
+});
+
+describe("isDescendant", () => {
+	const nodes = () =>
+		budgeted([named("leaf", "mid"), named("mid", "root"), named("root"), named("other")]);
+
+	it("is true through any depth of nesting", () => {
+		expect(isDescendant("leaf", "root", nodes())).toBe(true);
+		expect(isDescendant("mid", "root", nodes())).toBe(true);
+	});
+
+	it("is false upwards, sideways, and for a node against itself", () => {
+		expect(isDescendant("root", "leaf", nodes())).toBe(false);
+		expect(isDescendant("other", "root", nodes())).toBe(false);
+		expect(isDescendant("root", "root", nodes())).toBe(false);
+	});
+
+	it("terminates on a cycle rather than looping", () => {
+		expect(isDescendant("a", "outside", budgeted([named("a", "b"), named("b", "a")]))).toBe(
+			false
+		);
+	});
+});
+
+describe("collectDescendantEntityIds", () => {
+	// root > mid > leaf, plus an unrelated branch that must stay untouched.
+	const tree = () =>
+		budgeted([named("root"), named("mid", "root"), named("leaf", "mid"), named("elsewhere")]);
+	const requests: Record<string, string[]> = {
+		root: ["r-root"],
+		mid: ["r-mid"],
+		leaf: ["r-leaf-1", "r-leaf-2"],
+		elsewhere: ["r-elsewhere"],
+	};
+	/**
+	 * One call per collection the walk visits - the descendant walk's own step
+	 * counter, since it reads each `parentId` once while indexing and then never
+	 * again.
+	 */
+	const requestIdsIn = (id: string) => {
+		if (++steps > STEP_BUDGET) {
+			throw new Error(
+				`more than ${STEP_BUDGET} collections visited - the walk is not terminating`
+			);
+		}
+		return requests[id] ?? [];
+	};
+
+	it("collects the collection, every descendant folder, and all their requests", () => {
+		const affected = collectDescendantEntityIds("root", tree(), requestIdsIn);
+
+		// The nested-folder case: `leaf` is two levels down, and its requests are
+		// the ones a single-level cascade would leave with stale tabs open.
+		expect([...affected].sort()).toEqual(
+			["leaf", "mid", "r-leaf-1", "r-leaf-2", "r-mid", "r-root", "root"].sort()
+		);
+	});
+
+	it("leaves an unrelated branch alone", () => {
+		const affected = collectDescendantEntityIds("mid", tree(), requestIdsIn);
+
+		expect(affected.has("elsewhere")).toBe(false);
+		expect(affected.has("r-elsewhere")).toBe(false);
+		expect(affected.has("root")).toBe(false);
+		expect(affected.has("r-root")).toBe(false);
+	});
+
+	it("terminates when the subtree loops back on itself", () => {
+		// `b` is a child of `a` and `a` a child of `b`: the pre-existing BFS pushed
+		// each of them again on every visit and never emptied its stack.
+		const affected = collectDescendantEntityIds(
+			"a",
+			budgeted([named("a", "b"), named("b", "a")]),
+			requestIdsIn
+		);
+
+		expect([...affected].sort()).toEqual(["a", "b"]);
+		// Guards the guard: the counter above did run, so a budget that could
+		// never trip is not what made this pass.
+		expect(steps).toBeGreaterThan(0);
+	});
+
+	it("returns just the collection when it holds nothing", () => {
+		expect([...collectDescendantEntityIds("elsewhere", tree(), () => [])]).toEqual([
+			"elsewhere",
+		]);
+	});
+});

--- a/app/src/modules/collections/tree-utils.ts
+++ b/app/src/modules/collections/tree-utils.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Tree walks over `parentId`, in one place.
+ *
+ * Every walk here carries a visited-set termination guard, and that is the
+ * reason the module exists. The engine rejects cycles on write but explicitly
+ * tolerates them in data that is already stored (`collections.cpp`), so a
+ * `parentId` cycle is reachable - and an unguarded walk in the renderer is not a
+ * wrong answer, it is a synchronous hang of the window. The resolver's own walk
+ * had grown the guard with a comment saying exactly that; the three copies in
+ * the tree and the query layer never received it, which is this repo's
+ * hand-rolled-copy-of-a-primitive failure in its usual shape.
+ *
+ * Deliberately typed on `TreeNode` rather than `Collection`: the walks need an
+ * id and a parent and nothing else, which keeps them testable without building
+ * whole collections and lets a caller pass any narrowed row it already holds.
+ */
+
+/** The minimum a walk needs from a row. `Collection` satisfies it structurally. */
+export interface TreeNode {
+	id: string;
+	parentId?: string | null;
+}
+
+/**
+ * The ancestor chain of `startId`, root first and inclusive of the start node.
+ *
+ * Stops at the first id that resolves to no loaded node, so a walk from an
+ * orphan yields just the orphan rather than pretending it has a parent, and
+ * stops at the first id it has already visited, so a cycle terminates instead
+ * of looping. Returns `[]` when `startId` itself is not loaded.
+ */
+export function walkAncestors<T extends TreeNode>(startId: string, nodes: readonly T[]): T[] {
+	const byId = new Map(nodes.map((node) => [node.id, node]));
+	const chain: T[] = [];
+	const seen = new Set<string>();
+	let currentId: string | null | undefined = startId;
+	while (currentId) {
+		if (seen.has(currentId)) break;
+		seen.add(currentId);
+		const node = byId.get(currentId);
+		if (!node) break;
+		chain.unshift(node); // root first
+		currentId = node.parentId;
+	}
+	return chain;
+}
+
+/**
+ * Whether `candidateId` sits anywhere below `ancestorId`.
+ *
+ * Strict: a node is not its own descendant. Drop-target validation wants both
+ * answers ("into itself" and "into its own subtree") but they are different
+ * refusals, so the identity case stays the caller's to name.
+ */
+export function isDescendant(
+	candidateId: string,
+	ancestorId: string,
+	nodes: readonly TreeNode[]
+): boolean {
+	if (candidateId === ancestorId) return false;
+	return walkAncestors(candidateId, nodes).some((node) => node.id === ancestorId);
+}
+
+/**
+ * Every entity id a cascade delete of `rootId` reaches: the collection itself,
+ * its descendant folders, and the requests all of them hold.
+ *
+ * The engine performs the cascade; this is only the client's list of what has
+ * gone stale (open tabs pointing at those rows), so it takes the request ids
+ * from the caller's cache rather than re-deriving anything server-side.
+ */
+export function collectDescendantEntityIds(
+	rootId: string,
+	nodes: readonly TreeNode[],
+	requestIdsIn: (collectionId: string) => readonly string[]
+): Set<string> {
+	const childrenOf = new Map<string, string[]>();
+	for (const node of nodes) {
+		if (!node.parentId) continue;
+		const siblings = childrenOf.get(node.parentId);
+		if (siblings) siblings.push(node.id);
+		else childrenOf.set(node.parentId, [node.id]);
+	}
+
+	const affected = new Set<string>([rootId]);
+	// Separate from `affected`, which also holds request ids: only collections
+	// are walked, and only once each even if the tree loops back on itself.
+	const visited = new Set<string>([rootId]);
+	const stack = [rootId];
+	while (stack.length > 0) {
+		const current = stack.pop()!;
+		for (const requestId of requestIdsIn(current)) affected.add(requestId);
+		for (const childId of childrenOf.get(current) ?? []) {
+			if (visited.has(childId)) continue;
+			visited.add(childId);
+			affected.add(childId);
+			stack.push(childId);
+		}
+	}
+	return affected;
+}

--- a/app/src/modules/collections/useRovingTreeFocus.test.tsx
+++ b/app/src/modules/collections/useRovingTreeFocus.test.tsx
@@ -190,6 +190,32 @@ describe("useRovingTreeFocus", () => {
 		expect(rename).toHaveBeenCalledTimes(2);
 	});
 
+	// The click path, which nothing asserted: `onFocus` re-anchors the roving
+	// tabindex so Tab returns to the row the pointer left off at, rather than to
+	// whichever row happened to be seeded first.
+	it("re-anchors the tabbable row when a row is clicked into", () => {
+		render(<Tree expanded />);
+		expect(items().filter((i) => i.tabIndex === 0)).toEqual([byName("demo")]);
+
+		// A click focuses the control inside the row, not the row itself - so the
+		// handler has to walk up to the treeitem.
+		fireEvent.focus(byName("req-2"));
+
+		expect(items().filter((i) => i.tabIndex === 0)).toEqual([byName("req-2")]);
+	});
+
+	it("re-seeds a tabbable row when the one holding it is collapsed away", () => {
+		const { rerender } = render(<Tree expanded />);
+		fireEvent.focus(byName("req-1"));
+		expect(items().filter((i) => i.tabIndex === 0)).toEqual([byName("req-1")]);
+
+		// `req-1` is unmounted by the collapse. Without the re-seed the tree owns
+		// no tabbable row at all and drops out of the tab order entirely.
+		rerender(<Tree expanded={false} />);
+
+		expect(items().filter((i) => i.tabIndex === 0)).toEqual([byName("demo")]);
+	});
+
 	it("ignores arrow keys while renaming in a text field", () => {
 		render(
 			<>

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -19,6 +19,7 @@ import { ApiError } from "@/services";
 import { queryKeys } from "./keys";
 import { QUERY_CACHE } from "@/config/cache";
 import { useResponseStore } from "@/stores/response-store";
+import { walkAncestors } from "@/modules/collections/tree-utils";
 import type {
 	Collection,
 	Request,
@@ -244,18 +245,13 @@ export function useRequestQuery(requestId: string | null) {
 export function useCollectionAncestors(collectionId: string | null | undefined): Collection[] {
 	const { data: collections = [] } = useCollectionsQuery();
 
-	return useMemo(() => {
-		if (!collectionId) return [];
-		const chain: Collection[] = [];
-		let currentId: string | undefined = collectionId;
-		while (currentId) {
-			const col = collections.find((c) => c.id === currentId);
-			if (!col) break;
-			chain.unshift(col); // root first
-			currentId = col.parentId;
-		}
-		return chain;
-	}, [collections, collectionId]);
+	// `walkAncestors` carries the cycle guard this loop was missing: it runs
+	// inside a `useMemo`, so a `parentId` cycle hangs the renderer rather than
+	// producing a wrong chain (see modules/collections/tree-utils).
+	return useMemo(
+		() => (collectionId ? walkAncestors(collectionId, collections) : []),
+		[collections, collectionId]
+	);
 }
 
 // ============ Collection Mutations ============

--- a/app/src/stores/save-store.ts
+++ b/app/src/stores/save-store.ts
@@ -19,6 +19,7 @@
 
 import { create } from "zustand";
 
+import { TIMING } from "@/config/timing";
 import { useToastStore } from "./toast-store";
 
 export type SaveStatus = "idle" | "pending" | "saving" | "saved" | "error";
@@ -75,6 +76,17 @@ interface SaveState {
 	markPendingSave: () => void;
 	startSaving: () => void;
 	completeSave: () => void;
+	/**
+	 * `completeSave`, plus the return to `idle` that every caller wants after it -
+	 * and the guard that only the context which set a status clears it.
+	 *
+	 * A bare `setTimeout(() => setStatus("idle"))` fires two seconds later
+	 * regardless of what happened in between, so it clears a failure another
+	 * surface published to the Dock, or wipes a `pending` from an edit made since.
+	 * `triggerSave` has always guarded its own reset this way; the callers that
+	 * hand-rolled the timer did not.
+	 */
+	completeSaveThenIdle: () => void;
 	failSave: (error: string) => void;
 	reset: () => void;
 
@@ -105,11 +117,7 @@ export const useSaveStore = create<SaveState>((set, get) => {
 			// all do), so overwriting unconditionally turned a failed Cmd+S into
 			// "Saved" - with the failure toast still on screen next to it.
 			if (get().status === "error") return;
-			set({ status: "saved" });
-			setTimeout(() => {
-				// Only reset to idle if we're still in the "saved" state
-				if (get().status === "saved") get().setStatus("idle");
-			}, 2000);
+			get().completeSaveThenIdle();
 		} catch (error) {
 			get().failSave(error instanceof Error ? error.message : "Save failed");
 		}
@@ -127,6 +135,14 @@ export const useSaveStore = create<SaveState>((set, get) => {
 		startSaving: () => set({ status: "saving" }),
 
 		completeSave: () => set({ status: "saved" }),
+
+		completeSaveThenIdle: () => {
+			set({ status: "saved" });
+			setTimeout(() => {
+				// Only reset to idle if this "saved" is still the status on screen.
+				if (get().status === "saved") get().setStatus("idle");
+			}, TIMING.STATUS_RESET_MS);
+		},
 
 		failSave: (error) => {
 			set({ status: "error" });

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -166,6 +166,7 @@ Shared, Monaco-independent modules that power the GraphQL body mode.
 | `CollectionItem.tsx` | A collection (folder) row |
 | `RequestItem.tsx` | A request row (method badge, click → open in RequestBuilder, context menu) |
 | `ImportModal.tsx` | Import collections from file/URL/paste (Postman / Insomnia / OpenAPI). Mounted globally in `Shell`; open-state in a dedicated store. See [import-collections/](./import-collections/README.md) for the parser pipeline |
+| `tree-utils.ts` | Every `parentId` walk in the renderer: `walkAncestors` (the ancestor chain, root first), `isDescendant`, `collectDescendantEntityIds` (what a cascade delete reaches). Each carries a visited-set termination guard - the engine tolerates cycles in stored data, and an unguarded walk hangs the window rather than answering wrongly. Also used by `queries/collections.ts` and `useVariableResolver` |
 | `CollectionDetail/` | The collection editor screen (see below) |
 
 ### `CollectionDetail/` (screen `"collection-detail"`)

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -267,6 +267,16 @@ included mount - so merely opening Settings wiped an `error` another context had
 just published to the Dock. It now tracks whether the `pending` on screen is its
 own and leaves anything else alone.
 
+The same rule is why **`completeSaveThenIdle` exists**: it sets `saved` and
+arms the return to `idle` behind a check that the status is still the `saved` it
+set. A bare `completeSave()` followed by
+`setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS)` fires regardless of
+what happened in the meantime, so a rename that succeeded two seconds ago cleared
+the failure a delete had just published. `triggerSave` has always guarded its own
+reset this way; the collection tree now shares that one implementation rather
+than a copy of the timer. `useSaveManager`, `SettingsMain` and
+`VariableTableEditor` still hand-roll theirs - see issue #369.
+
 There is no `errorMessage` field. The reason travels in the toast; the store
 holds only the status the Dock renders. The field used to exist and its sole
 reader was the Dock's error line, which the toast replaced.
@@ -524,10 +534,19 @@ UI-only: Which collections are expanded/collapsed in the tree.
 ```typescript
 const {
   expandedCollectionIds,
-  toggleCollectionExpanded, expandCollection, collapseCollection,
-  reset
+  toggleCollectionExpanded, expandCollection, expandCollections
 } = useCollectionsStore();
 ```
+
+**Every action here has a caller, and expanding is idempotent.** `expandCollection`
+(one id) and `expandCollections` (an ancestor chain) both return the *same* Set
+when nothing changes, because it is passed down the whole tree and listed in
+effect dependencies - a fresh Set for a no-op re-renders every row and re-runs
+the reveal effect. That is why the tree calls them instead of hand-rolling
+`if (!expanded.has(id)) toggle(id)`, which reads the set it writes and so drags
+`expandedCollectionIds` into the dependencies of everything that expands.
+`collapseCollection` and `reset` used to live here with no callers at all;
+collapsing goes through `toggleCollectionExpanded`.
 
 #### `modules/history/history-store.ts` - History Filter & Sort
 


### PR DESCRIPTION
## Description

The collection-tree correctness batch - the cluster that lands before the a11y batch (#362) and before the DnD decomposition, which restructures what this fixes.

**Plan.** The root cause of the biggest item is a primitive that was copied instead of shared: `useVariableResolver` had grown a visited-set guard on its `parentId` walk, with a comment saying an unguarded walk inside a `useMemo` is a synchronous hang of the renderer rather than a wrong answer - and the three other walks in the renderer (the tree's reveal, `useCollectionAncestors`, the delete-cascade BFS) never received it. The engine rejects cycles on write but explicitly tolerates them in data that is already stored, so the state is reachable. The approach is one module, `modules/collections/tree-utils.ts`, holding every walk with its guard, imported by all four call sites; the rest of the batch is component fixes that share those files. The alternative I rejected was leaving each walk in place and adding a guard to each - three more copies of the thing that had already drifted once, and no home for the drop-target validation the DnD track needs next.

**Verified against the code.** Every anchor in the issue still described the code as written, with one correction: the issue calls the delete BFS "re-pushes but terminates". It does not - `for (const child of collections) if (child.parentId === current) { affected.add(...); stack.push(...) }` pushes an already-visited child again on every visit, so a two-collection cycle spins forever. The shared walk guards it, and a test pins that.

### The shared module

`walkAncestors` (chain root-first, stops at an unloaded parent and at the first repeat), `isDescendant` (strict), `collectDescendantEntityIds` (what a cascade delete reaches - collections plus the requests they hold, request ids supplied by the caller's cache so nothing re-derives engine-side knowledge). Typed on a structural `TreeNode` rather than `Collection`, so the walks are testable without whole collections.

`isDescendant` ships here with tests but no production caller yet - it is the drop-target validation primitive the issue asks to build once, and #365/#367 are its consumers. Called out because "written but never read" is the defect this repo hits most.

### Component and store fixes

1. **Orphans render at the top level.** Roots are now "no parent *or* no parent loaded". A collection whose `parentId` resolves to nothing matched neither the roots filter nor any parent's child list, so it - and its requests - disappeared from the sidebar while still in the database.
2. **The delete confirm dialog stays up until the mutation settles.** Both handlers nulled `deleteConfirm` as their first act, so `DeleteConfirmDialog`'s `isDeleting` (spinner, disabled actions) could never be true. Kept the prop and made it mean something rather than deleting it: a cascade delete of a folder is exactly when a user needs to see that something is happening. A double click can no longer fire two deletes.
3. **Rename cannot no-op or double-fire.** The collection path had no unchanged-name check, and both paths cleared their rename state only *after* awaiting - so the field was still mounted when Enter's PUT went out and the blur that followed sent a second one. Both now clear first, which unmounts the field and leaves no second blur.
4. **Status timers cannot stomp.** `completeSaveThenIdle` in `save-store.ts` sets `saved` and arms the reset behind a check that the status is still the one it set - the guard `triggerSave` has always had, and which the store's own docs state as a rule ("only the context that set a status clears it"). `runSave` now shares it rather than holding the only copy.
5. **`expandCollection` is wired** at the three sites that hand-rolled `if (!expanded.has(id)) toggle(id)`, and made idempotent down to the Set's identity. `collapseCollection` and `reset` had zero callers app-wide and are gone (collapsing goes through `toggleCollectionExpanded`); the store now has a test file.
6. **`getCollectionActions` lists honest dependencies** and the `exhaustive-deps` suppression is gone, which needed both handlers memoised and the expand to stop reading the set it writes.

### Deliberate deviations from the issue

- **`save-store.ts` is touched, which the issue's "App changes" does not list.** Item 5 says to reuse the save store's own run-token pattern; the store is where that pattern lives, so the fix is one shared action rather than a third and fourth copy of the timer. Additive - no existing caller changes behaviour. **#369** (filed) tracks the three call sites still hand-rolling it: `useSaveManager`, `SettingsMain`, `VariableTableEditor`.
- **`useVariableResolver` is touched too.** Its guarded walk was the primitive the others were missing; leaving it as a fourth implementation would keep the drift alive. Its cycle test's instrumentation had to change with it - it counted `Array.find` calls, which the shared walk (a `Map`) does not make, so the "budget" assertion was passing while measuring nothing. It now counts `parentId` reads, which any walk must do once per step.
- **`collections-store.test.ts` is node env, not jsdom.** The issue expects jsdom because zustand `persist` touches `localStorage`; this store has no `persist`.

**Engine: no change. MCP: none, verified** - no MCP tool reads the tree's expansion state or these walks.

### Merged with master after #360 landed

#368 merged while this was being written and renamed `compareCollectionOrder` to `compareTreeOrder`. `origin/master` is merged in here: the roots filter keeps the orphan rule on the new comparator, and the `TIMING` import master still needs for the status timers is dropped, because this PR removes those timers. The other overlap the issue predicted - `queries/collections.ts` - merged cleanly: #368 rewrote `useUpdateRequestMutation`'s invalidation, this PR replaces the walk inside `useCollectionAncestors`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally on the merged head (`73a88b3`), no pre-existing failures.

- `cd app && pnpm test`: **2795 passed across 306 files** (2752 / 301 on `6e6a4c9`, the merge base).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` clean. `mkdocs build --strict` passes.
- No engine change, so neither the C++ build nor `ctest` was run - CI skips both jobs for the same reason.

New files: `tree-utils.test.ts` (13), `collections-store.test.ts` (10), `CollectionTree.rename.test.tsx` (8), `CollectionTree.delete.test.tsx` (4), `CollectionTree.orphan.test.tsx` (3), plus 2 reveal and 2 roving-focus cases.

Mutation-checked, each fix reverted and confirmed red:

| Reverted | What reddened |
|---|---|
| the `seen` set in `walkAncestors` | 4 tree-utils cases + 2 resolver cycle cases, in milliseconds - they fail, they do not stall |
| the `visited` set in `collectDescendantEntityIds` | 2 cases, same |
| `stack.push` on descendants | the nested-cascade unit case + the tab-closing integration case |
| the orphan roots filter | 2 orphan cases |
| the late `setDeleteConfirm(null)` | the dialog-stays-open case |
| clearing rename state before the await | 3 rename cases |
| the `status === "saved"` guard | the status-stomp case |
| the roving hook's re-seed | 3 focus cases |

The cycle tests deserve a note: they cannot simply assert termination, because an unterminated walk never yields and the per-test timeout can never fire - so each fixture counts the one thing a walk does exactly once per step (`parentId` reads, or a request lookup per visited collection) and throws past a budget no correct walk can reach. That turns "hangs the whole run" into "fails with a message", and each budget is itself asserted to have been exercised.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #361