### PR TITLE
feat(engine/app): reorder phase 1 - an atomic batch reorder/move endpoint, first-drop normalization, and the optimistic renderer mutation

### DIFF
--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -36,6 +36,10 @@ export const API_ENDPOINTS = {
 	REQUEST_BY_ID: (id: string) => `/requests/${id}`,
 	REQUESTS_UPDATE: (id: string) => `/requests/${id}`,
 
+	// Batch reorder for both entity kinds (issue #365). One drop is one call and
+	// one engine transaction; a reorder expressed as N sibling PUTs is neither.
+	REORDER: `/reorder`,
+
 	// Environments
 	ENVIRONMENTS: `/environments`,
 	ENVIRONMENT_BY_ID: (id: string) => `/environments/${id}`,

--- a/app/src/modules/collections/reorder-math.test.ts
+++ b/app/src/modules/collections/reorder-math.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The arithmetic behind a drop (issue #365).
+ *
+ * Node environment on purpose - the module is pure, and the point of extracting
+ * it was that a gesture's *result* can be pinned without a gesture.
+ *
+ * Each test states the arrangement it expects rather than the move list, where
+ * the two can differ: a plan is correct if replaying it over the siblings
+ * produces the intended order, and `applyPlan` below is that replay. Asserting
+ * only the raw moves would let an off-by-one in the shift range pass as long as
+ * the numbers looked plausible.
+ */
+
+import { describe, it, expect } from "vitest";
+import { planCollectionMove, planRequestMove, isEmptyPlan, type OrderedRow } from "./reorder-math";
+import type { ReorderRequest } from "@/types";
+
+/** A row at an explicit position. */
+const row = (id: string, order: number): OrderedRow => ({ id, order });
+
+/** The legacy shape: every row created before explicit orders existed sits at 0. */
+const legacy = (...ids: string[]): OrderedRow[] => ids.map((id) => ({ id, order: 0 }));
+
+/** A dense list, the shape a normalized scope has. */
+const dense = (...ids: string[]): OrderedRow[] => ids.map((id, index) => row(id, index));
+
+/**
+ * Replays a plan the way the engine does - normalize each named scope to
+ * `0..n-1` in display order, then apply the moves - and returns the resulting
+ * ids per scope, in display order.
+ *
+ * Scopes are keyed by their owner id (`""` for the root collections), which is
+ * how both entry shapes name one.
+ */
+function applyPlan(
+	plan: ReorderRequest,
+	initial: Record<string, readonly OrderedRow[]>
+): Record<string, string[]> {
+	const scopes = new Map<string, OrderedRow[]>();
+	for (const [key, rows] of Object.entries(initial)) {
+		scopes.set(
+			key,
+			rows.map((r) => ({ ...r }))
+		);
+	}
+	const scopeKey = (entry: { parentId?: string | null; collectionId?: string }) =>
+		entry.collectionId ?? entry.parentId ?? "";
+
+	for (const scope of plan.normalize) {
+		const rows = scopes.get(scopeKey(scope));
+		if (!rows) throw new Error(`plan normalizes an unknown scope ${JSON.stringify(scope)}`);
+		rows.forEach((r, index) => (r.order = index));
+	}
+	for (const move of plan.moves) {
+		const owner =
+			"collectionId" in move
+				? move.collectionId
+				: "parentId" in move
+					? move.parentId
+					: undefined;
+		let current: OrderedRow | undefined;
+		for (const [key, rows] of scopes) {
+			const found = rows.find((r) => r.id === move.id);
+			if (!found) continue;
+			current = found;
+			if (owner !== undefined && key !== (owner ?? "")) {
+				scopes.set(
+					key,
+					rows.filter((r) => r.id !== move.id)
+				);
+				scopes.get(owner ?? "")!.push(found);
+			}
+			break;
+		}
+		if (!current) throw new Error(`plan moves an unknown row ${move.id}`);
+		current.order = move.order;
+	}
+
+	const out: Record<string, string[]> = {};
+	for (const [key, rows] of scopes) {
+		out[key] = [...rows].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)).map((r) => r.id);
+	}
+	return out;
+}
+
+describe("planRequestMove within one collection", () => {
+	const from = { scope: { collectionId: "col_a" }, siblings: dense("a", "b", "c", "d") };
+
+	it("writes only the rows between the two positions", () => {
+		const plan = planRequestMove({ movedId: "d", from, to: from, toIndex: 1 });
+
+		// a stays at 0; b, c and d shift. Reverting the shift range to "every
+		// sibling" turns this into 4.
+		expect(plan.moves).toHaveLength(3);
+		expect(plan.normalize).toEqual([]);
+		expect(applyPlan(plan, { col_a: from.siblings }).col_a).toEqual(["a", "d", "b", "c"]);
+	});
+
+	it("writes exactly two rows for an adjacent swap", () => {
+		const plan = planRequestMove({ movedId: "a", from, to: from, toIndex: 1 });
+
+		expect(plan.moves).toHaveLength(2);
+		expect(applyPlan(plan, { col_a: from.siblings }).col_a).toEqual(["b", "a", "c", "d"]);
+	});
+
+	it("moves a row to the end", () => {
+		const plan = planRequestMove({ movedId: "a", from, to: from, toIndex: 3 });
+		expect(applyPlan(plan, { col_a: from.siblings }).col_a).toEqual(["b", "c", "d", "a"]);
+	});
+
+	it("plans nothing when the row lands back on its own slot", () => {
+		const plan = planRequestMove({ movedId: "b", from, to: from, toIndex: 1 });
+		expect(isEmptyPlan(plan)).toBe(true);
+	});
+
+	it("clamps a drop past the end of the list", () => {
+		const plan = planRequestMove({ movedId: "a", from, to: from, toIndex: 99 });
+		expect(applyPlan(plan, { col_a: from.siblings }).col_a).toEqual(["b", "c", "d", "a"]);
+	});
+
+	it("rejects a fractional index rather than silently truncating it", () => {
+		expect(() => planRequestMove({ movedId: "a", from, to: from, toIndex: 1.5 })).toThrow(
+			/integer/
+		);
+	});
+
+	it("rejects a row that is not in the list it claims to be in", () => {
+		expect(() => planRequestMove({ movedId: "zz", from, to: from, toIndex: 0 })).toThrow(/zz/);
+	});
+});
+
+describe("planRequestMove over a legacy all-zeros collection", () => {
+	// The primary case: nothing has ever been dragged, so every row is at 0 and
+	// its displayed position exists only in the sort's createdAt/id tiebreak.
+	const from = { scope: { collectionId: "col_a" }, siblings: legacy("a", "b", "c") };
+
+	it("normalizes the collection before the move", () => {
+		const plan = planRequestMove({ movedId: "c", from, to: from, toIndex: 0 });
+
+		expect(plan.normalize).toEqual([{ type: "request", collectionId: "col_a" }]);
+		// Without the normalize the shifts below land on rows that all read 0,
+		// and the arrangement is a tie lottery instead of the intended order.
+		expect(applyPlan(plan, { col_a: from.siblings }).col_a).toEqual(["c", "a", "b"]);
+	});
+
+	it("normalizes without a redundant move when the row does not actually move", () => {
+		const plan = planRequestMove({ movedId: "a", from, to: from, toIndex: 0 });
+
+		expect(plan.moves).toEqual([]);
+		expect(plan.normalize).toHaveLength(1);
+		expect(isEmptyPlan(plan)).toBe(false);
+		expect(applyPlan(plan, { col_a: from.siblings }).col_a).toEqual(["a", "b", "c"]);
+	});
+
+	it("does not normalize a list that is already dense", () => {
+		const alreadyDense = { scope: { collectionId: "col_a" }, siblings: dense("a", "b", "c") };
+		const plan = planRequestMove({
+			movedId: "c",
+			from: alreadyDense,
+			to: alreadyDense,
+			toIndex: 0,
+		});
+		expect(plan.normalize).toEqual([]);
+	});
+});
+
+describe("planRequestMove across collections", () => {
+	const from = { scope: { collectionId: "col_a" }, siblings: dense("a", "b", "c") };
+	const to = { scope: { collectionId: "col_b" }, siblings: dense("x", "y") };
+
+	it("closes the gap in the source and opens one in the target", () => {
+		const plan = planRequestMove({ movedId: "a", from, to, toIndex: 1 });
+
+		const result = applyPlan(plan, { col_a: from.siblings, col_b: to.siblings });
+		expect(result.col_a).toEqual(["b", "c"]);
+		expect(result.col_b).toEqual(["x", "a", "y"]);
+	});
+
+	it("stamps the destination collection on the moved row and on no other", () => {
+		const plan = planRequestMove({ movedId: "a", from, to, toIndex: 0 });
+
+		const owners = plan.moves.filter((m) => "collectionId" in m && m.collectionId);
+		expect(owners).toEqual([{ type: "request", id: "a", order: 0, collectionId: "col_b" }]);
+	});
+
+	it("appends when the drop lands past the end of the target", () => {
+		const plan = planRequestMove({ movedId: "a", from, to, toIndex: 5 });
+
+		const result = applyPlan(plan, { col_a: from.siblings, col_b: to.siblings });
+		expect(result.col_b).toEqual(["x", "y", "a"]);
+	});
+
+	it("normalizes both sides when both are legacy", () => {
+		const legacyFrom = { scope: { collectionId: "col_a" }, siblings: legacy("a", "b") };
+		const legacyTo = { scope: { collectionId: "col_b" }, siblings: legacy("x", "y") };
+		const plan = planRequestMove({ movedId: "a", from: legacyFrom, to: legacyTo, toIndex: 1 });
+
+		expect(plan.normalize).toEqual([
+			{ type: "request", collectionId: "col_a" },
+			{ type: "request", collectionId: "col_b" },
+		]);
+		const result = applyPlan(plan, { col_a: legacyFrom.siblings, col_b: legacyTo.siblings });
+		expect(result.col_a).toEqual(["b"]);
+		expect(result.col_b).toEqual(["x", "a", "y"]);
+	});
+
+	it("rejects a target that already holds the row", () => {
+		const confused = { scope: { collectionId: "col_b" }, siblings: dense("a") };
+		expect(() => planRequestMove({ movedId: "a", from, to: confused, toIndex: 0 })).toThrow(
+			/already contains/
+		);
+	});
+});
+
+describe("planCollectionMove", () => {
+	it("moves a folder among its siblings", () => {
+		const from = { scope: { parentId: "col_p" }, siblings: dense("f1", "f2", "f3") };
+		const plan = planCollectionMove({ movedId: "f3", from, to: from, toIndex: 0 });
+
+		expect(applyPlan(plan, { col_p: from.siblings }).col_p).toEqual(["f3", "f1", "f2"]);
+	});
+
+	it("moves a folder out to the root, which is parentId null", () => {
+		const from = { scope: { parentId: "col_p" }, siblings: dense("f1", "f2") };
+		const to = { scope: { parentId: null }, siblings: dense("r1", "r2") };
+		const plan = planCollectionMove({ movedId: "f1", from, to, toIndex: 0 });
+
+		expect(plan.moves).toContainEqual({
+			type: "collection",
+			id: "f1",
+			order: 0,
+			parentId: null,
+		});
+		const result = applyPlan(plan, { col_p: from.siblings, "": to.siblings });
+		expect(result[""]).toEqual(["f1", "r1", "r2"]);
+		expect(result.col_p).toEqual(["f2"]);
+	});
+
+	it("normalizes the root scope as `parentId: null`, not as a missing key", () => {
+		const roots = { scope: { parentId: null }, siblings: legacy("r1", "r2", "r3") };
+		const plan = planCollectionMove({ movedId: "r3", from: roots, to: roots, toIndex: 0 });
+
+		expect(plan.normalize).toEqual([{ type: "collection", parentId: null }]);
+	});
+
+	it("keeps the folder block independent of the request block", () => {
+		// Folders and requests are two separate ordered runs rendered
+		// folders-first, so a folder's indices are its own - a collection at
+		// index 1 among two folders is not "below" the requests underneath them.
+		const folders = { scope: { parentId: "col_p" }, siblings: dense("f1", "f2") };
+		const plan = planCollectionMove({ movedId: "f2", from: folders, to: folders, toIndex: 0 });
+
+		expect(plan.moves.every((m) => m.type === "collection")).toBe(true);
+		expect(plan.moves.map((m) => m.order)).toEqual([0, 1]);
+	});
+});

--- a/app/src/modules/collections/reorder-math.ts
+++ b/app/src/modules/collections/reorder-math.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The arithmetic behind a drop: which rows a move actually has to rewrite.
+ *
+ * A pure module with no React, no query client and no network, because the
+ * interesting part of a drag interaction is this and nothing else - and it is
+ * the part a jsdom test cannot reach through a gesture. The component wiring
+ * (issue #367) hands it sibling lists it already has on screen and sends the
+ * result straight to `POST /reorder`.
+ *
+ * Two rules shape everything below:
+ *
+ * 1. **Only rows whose position changes are written.** A drop inside a dense
+ *    list shifts a contiguous run, so an adjacent swap writes two rows rather
+ *    than renumbering the whole folder. The engine's batch is atomic either
+ *    way; a minimal batch is what keeps a drag in a 200-request collection from
+ *    being a 200-row write.
+ * 2. **A list that is not already dense is normalized first.** Every row
+ *    created before explicit orders existed sits at `0`, so its displayed
+ *    position lives only in the sort's `createdAt`/`id` tiebreak - there are no
+ *    slots to shift into. `normalize` materializes that displayed order as
+ *    `0..n-1` in the same batch, before the moves land, which is why nothing
+ *    visibly jumps on the first drop into a legacy collection.
+ *
+ * Callers pass **siblings in the order the tree displays them** (already sorted
+ * with `compareTreeOrder`), which is the order the engine's normalization
+ * produces - the two must agree or a normalized drop lands somewhere the user
+ * did not point at. Subfolders and requests are separate ordered blocks
+ * rendered folders-first, so a caller passes one block, never both: the `order`
+ * column cannot interleave a request between two folders.
+ */
+
+import type { ReorderMove, ReorderNormalize, ReorderRequest } from "@/types";
+
+/** The minimum a plan needs from a sibling row. `Collection`/`Request` satisfy it. */
+export interface OrderedRow {
+	id: string;
+	order?: number;
+}
+
+/** Where a collection lives: under a parent, or `null` at the root. */
+export interface CollectionScope {
+	parentId: string | null;
+}
+
+/** Where a request lives. */
+export interface RequestScope {
+	collectionId: string;
+}
+
+/** One end of a move: the scope, and the rows in it as the tree displays them. */
+interface Side<TScope> {
+	scope: TScope;
+	siblings: readonly OrderedRow[];
+}
+
+/**
+ * A list is dense when every row's stored `order` already equals its displayed
+ * index. Only then can a move be expressed as a shift; anything else needs the
+ * normalization pass first.
+ */
+function isDense(siblings: readonly OrderedRow[]): boolean {
+	return siblings.every((row, index) => row.order === index);
+}
+
+/** Index of `id` in `siblings`, or -1. */
+function indexOf(siblings: readonly OrderedRow[], id: string): number {
+	return siblings.findIndex((row) => row.id === id);
+}
+
+/**
+ * `value` confined to `[0, max]`.
+ *
+ * A drop index comes from a pointer position, so it is bounded by geometry the
+ * caller measured rather than by the list - past the last row is a legitimate
+ * gesture meaning "put it at the end", not a bug worth throwing over. An id that
+ * is not in the list it claims to be in *is* a bug, and throws.
+ */
+function clamp(value: number, max: number): number {
+	if (!Number.isInteger(value)) {
+		throw new Error(`Reorder index must be an integer, got ${value}`);
+	}
+	return Math.max(0, Math.min(value, max));
+}
+
+/**
+ * The whole computation, once, over positions - the two public wrappers only
+ * differ in which owner field they stamp on the moved row.
+ *
+ * `makeMove` builds one entry for a row that is *not* changing owner;
+ * `makeOwnerMove` builds the entry for the moved row itself, carrying the
+ * destination scope.
+ */
+function planMove<TScope>(params: {
+	movedId: string;
+	from: Side<TScope>;
+	to: Side<TScope>;
+	toIndex: number;
+	sameScope: (a: TScope, b: TScope) => boolean;
+	normalizeOf: (scope: TScope) => ReorderNormalize;
+	makeMove: (id: string, order: number) => ReorderMove;
+	makeOwnerMove: (id: string, order: number, scope: TScope) => ReorderMove;
+}): ReorderRequest {
+	const { movedId, from, to, sameScope, normalizeOf, makeMove, makeOwnerMove } = params;
+
+	const fromIndex = indexOf(from.siblings, movedId);
+	if (fromIndex < 0) {
+		throw new Error(`Reorder source does not contain '${movedId}'`);
+	}
+
+	if (sameScope(from.scope, to.scope)) {
+		const toIndex = clamp(params.toIndex, from.siblings.length - 1);
+		const normalize = isDense(from.siblings) ? [] : [normalizeOf(from.scope)];
+		// A drop back onto the row's own slot moves nothing. It can still be
+		// worth a round trip: if the list was not dense, the normalization is
+		// the whole point, and it lands without a redundant move restating a
+		// position the renumber already assigns.
+		if (toIndex === fromIndex) {
+			return { moves: [], normalize };
+		}
+
+		// After normalization every row sits at its displayed index, so the
+		// resulting arrangement is just the array with the row spliced across -
+		// and the rows that moved are exactly the ones between the two indices.
+		const next = from.siblings.filter((row) => row.id !== movedId);
+		next.splice(toIndex, 0, from.siblings[fromIndex]);
+
+		const moves: ReorderMove[] = [];
+		for (let i = Math.min(fromIndex, toIndex); i <= Math.max(fromIndex, toIndex); i++) {
+			moves.push(makeMove(next[i].id, i));
+		}
+		return { moves, normalize };
+	}
+
+	if (indexOf(to.siblings, movedId) >= 0) {
+		throw new Error(`Reorder target already contains '${movedId}'`);
+	}
+	const toIndex = clamp(params.toIndex, to.siblings.length);
+
+	const normalize: ReorderNormalize[] = [];
+	if (!isDense(from.siblings)) normalize.push(normalizeOf(from.scope));
+	if (!isDense(to.siblings)) normalize.push(normalizeOf(to.scope));
+
+	const moves: ReorderMove[] = [];
+	// The source closes the gap the row left; the destination opens one for it.
+	// Rows before either index keep the index they already have.
+	for (let i = fromIndex + 1; i < from.siblings.length; i++) {
+		moves.push(makeMove(from.siblings[i].id, i - 1));
+	}
+	for (let i = toIndex; i < to.siblings.length; i++) {
+		moves.push(makeMove(to.siblings[i].id, i + 1));
+	}
+	moves.push(makeOwnerMove(movedId, toIndex, to.scope));
+	return { moves, normalize };
+}
+
+/**
+ * The batch that moves a collection to `toIndex` among the children of
+ * `to.scope`.
+ *
+ * `from` and `to` may name the same parent (a reorder) or different ones (a
+ * move, including to and from the root, which is `parentId: null`).
+ */
+export function planCollectionMove(params: {
+	movedId: string;
+	from: Side<CollectionScope>;
+	to: Side<CollectionScope>;
+	toIndex: number;
+}): ReorderRequest {
+	return planMove<CollectionScope>({
+		...params,
+		sameScope: (a, b) => a.parentId === b.parentId,
+		normalizeOf: (scope) => ({ type: "collection", parentId: scope.parentId }),
+		makeMove: (id, order) => ({ type: "collection", id, order }),
+		makeOwnerMove: (id, order, scope) => ({
+			type: "collection",
+			id,
+			order,
+			parentId: scope.parentId,
+		}),
+	});
+}
+
+/**
+ * The batch that moves a request to `toIndex` among the requests of
+ * `to.scope` - the same shape as `planCollectionMove`, over the other block.
+ */
+export function planRequestMove(params: {
+	movedId: string;
+	from: Side<RequestScope>;
+	to: Side<RequestScope>;
+	toIndex: number;
+}): ReorderRequest {
+	return planMove<RequestScope>({
+		...params,
+		sameScope: (a, b) => a.collectionId === b.collectionId,
+		normalizeOf: (scope) => ({ type: "request", collectionId: scope.collectionId }),
+		makeMove: (id, order) => ({ type: "request", id, order }),
+		makeOwnerMove: (id, order, scope) => ({
+			type: "request",
+			id,
+			order,
+			collectionId: scope.collectionId,
+		}),
+	});
+}
+
+/** True when a plan would write nothing, so the caller can skip the round trip. */
+export function isEmptyPlan(plan: ReorderRequest): boolean {
+	return plan.moves.length === 0 && plan.normalize.length === 0;
+}

--- a/app/src/queries/collections.ts
+++ b/app/src/queries/collections.ts
@@ -19,6 +19,7 @@ import { ApiError } from "@/services";
 import { queryKeys } from "./keys";
 import { QUERY_CACHE } from "@/config/cache";
 import { useResponseStore } from "@/stores/response-store";
+import { useSaveStore } from "@/stores/save-store";
 import { walkAncestors } from "@/modules/collections/tree-utils";
 import type {
 	Collection,
@@ -27,6 +28,7 @@ import type {
 	UpdateCollectionRequest,
 	CreateRequestRequest,
 	UpdateRequestRequest,
+	ReorderRequest,
 } from "@/types";
 import { compareTreeOrder } from "@/types";
 
@@ -376,6 +378,236 @@ export function useUpdateRequestMutation() {
 			}
 			// Update detail cache
 			queryClient.setQueryData(queryKeys.requests.detail(updatedRequest.id), updatedRequest);
+		},
+	});
+}
+
+// ============ Reorder ============
+
+/**
+ * Every cache key a plan can touch, worked out before anything is written.
+ *
+ * A request move that states no `collectionId` stays where it is, but the plan
+ * does not say where that is - so the owner is read out of the list caches the
+ * tree is already showing. An uncached one simply contributes no key: nothing
+ * on screen is displaying it, so nothing on screen can go stale.
+ */
+function affectedKeys(queryClient: ReturnType<typeof useQueryClient>, plan: ReorderRequest) {
+	let touchesCollections = false;
+	const requestScopes = new Set<string>();
+	const movedRequestIds: string[] = [];
+
+	const ownerOf = (requestId: string): string | undefined => {
+		for (const [key, rows] of queryClient.getQueriesData<Request[]>({
+			queryKey: queryKeys.requests.lists(),
+		})) {
+			void key;
+			const found = rows?.find((row) => row.id === requestId);
+			if (found) return found.collectionId;
+		}
+		return undefined;
+	};
+
+	for (const scope of plan.normalize) {
+		if (scope.type === "collection") touchesCollections = true;
+		else requestScopes.add(scope.collectionId);
+	}
+	for (const move of plan.moves) {
+		if (move.type === "collection") {
+			touchesCollections = true;
+			continue;
+		}
+		movedRequestIds.push(move.id);
+		const current = ownerOf(move.id);
+		if (current) requestScopes.add(current);
+		if (move.collectionId) requestScopes.add(move.collectionId);
+	}
+	return { touchesCollections, requestScopes, movedRequestIds };
+}
+
+/** The collections of one scope, renumbered dense in display order. */
+function normalizeCollectionScope(list: Collection[], parentId: string | null): Collection[] {
+	const positions = new Map(
+		list
+			.filter((c) => (c.parentId ?? null) === parentId)
+			.sort(compareTreeOrder)
+			.map((c, index) => [c.id, index] as const)
+	);
+	return list.map((c) => {
+		const order = positions.get(c.id);
+		return order === undefined || order === c.order ? c : { ...c, order };
+	});
+}
+
+/**
+ * Draws the plan into the caches, exactly as the engine will apply it -
+ * normalize each named scope, then position each move.
+ *
+ * Every write goes through `setQueryData` with a fresh array. The maps
+ * `useMultipleCollectionRequests` builds are referentially compared by the
+ * reveal effect (see the comment on that hook), so mutating a cached array in
+ * place would move a row on screen without the tree ever noticing.
+ */
+function drawPlan(queryClient: ReturnType<typeof useQueryClient>, plan: ReorderRequest) {
+	for (const scope of plan.normalize) {
+		if (scope.type === "collection") {
+			queryClient.setQueryData<Collection[]>(queryKeys.collections.list(), (old) =>
+				old ? normalizeCollectionScope(old, scope.parentId) : old
+			);
+		} else {
+			queryClient.setQueryData<Request[]>(
+				queryKeys.requests.listByCollection(scope.collectionId),
+				(old) => old?.map((r, index) => ({ ...r, order: index }))
+			);
+		}
+	}
+
+	for (const move of plan.moves) {
+		if (move.type === "collection") {
+			queryClient.setQueryData<Collection[]>(queryKeys.collections.list(), (old) =>
+				old
+					?.map((c) =>
+						c.id === move.id
+							? {
+									...c,
+									order: move.order,
+									...("parentId" in move
+										? { parentId: move.parentId ?? undefined }
+										: {}),
+								}
+							: c
+					)
+					.sort(compareTreeOrder)
+			);
+			continue;
+		}
+		placeRequest(queryClient, move.id, move.order, move.collectionId);
+	}
+}
+
+/**
+ * Puts one request at `order`, moving it between list caches when `collectionId`
+ * names a different owner. Shared by the optimistic draw and by the settle on
+ * the engine's response, so a move cannot be applied one way going out and
+ * another coming back.
+ */
+function placeRequest(
+	queryClient: ReturnType<typeof useQueryClient>,
+	requestId: string,
+	order: number,
+	collectionId: string | undefined
+) {
+	let moved: Request | undefined;
+	for (const [key, rows] of queryClient.getQueriesData<Request[]>({
+		queryKey: queryKeys.requests.lists(),
+	})) {
+		const found = rows?.find((row) => row.id === requestId);
+		if (!found) continue;
+		moved = found;
+		if (collectionId && collectionId !== found.collectionId) {
+			queryClient.setQueryData<Request[]>(key, (old) =>
+				old?.filter((row) => row.id !== requestId)
+			);
+		}
+		break;
+	}
+
+	const owner = collectionId ?? moved?.collectionId;
+	if (!owner) return; // Nothing cached is showing it; nothing on screen to fix.
+	const next: Request = { ...(moved as Request), id: requestId, collectionId: owner, order };
+	queryClient.setQueryData<Request[]>(queryKeys.requests.listByCollection(owner), (old) => {
+		if (!old) return old;
+		const without = old.filter((row) => row.id !== requestId);
+		return [...without, next].sort(compareTreeOrder);
+	});
+	// Only if something already held it: `staleTime: Infinity` means an entry
+	// written here would never be refetched, and a half-built row from a list
+	// entry is not the full request a restored tab reads.
+	queryClient.setQueryData<Request>(queryKeys.requests.detail(requestId), (old) =>
+		old ? { ...old, collectionId: owner, order } : old
+	);
+}
+
+/**
+ * Apply one atomic batch reorder - the write path behind a drop.
+ *
+ * One `POST /reorder` per drop, not one `PUT` per displaced sibling: the engine
+ * validates the whole batch and writes it in a single transaction, so a drop
+ * that displaces N rows cannot half-land, cannot race a concurrent create into
+ * the middle of its range, and costs one round trip instead of N.
+ *
+ * The cache work is three passes over the same helpers:
+ *
+ *  - `onMutate` snapshots every key the plan can touch and draws the plan into
+ *    the caches, so the row is where the user dropped it before the request
+ *    leaves.
+ *  - `onSuccess` re-applies the rows the engine actually wrote. They are
+ *    normally what was drawn, but a normalization the client planned and the
+ *    engine performed is authoritative here, so the tree settles on real
+ *    positions rather than on a guess that happens to sort the same.
+ *  - `onError` restores the snapshots wholesale and reports through `failSave`,
+ *    the one channel every save failure in the app reaches the Dock and the
+ *    toast through.
+ *
+ * `onSettled` then invalidates the affected keys once - not per row, which is
+ * the invalidation storm the per-row path produced.
+ */
+export function useReorderMutation() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (plan: ReorderRequest) => apiService.reorder(plan),
+		onMutate: async (plan: ReorderRequest) => {
+			const keys = affectedKeys(queryClient, plan);
+			const listKeys = [...keys.requestScopes].map((id) =>
+				queryKeys.requests.listByCollection(id)
+			);
+			const snapshotKeys = [
+				...(keys.touchesCollections ? [queryKeys.collections.list()] : []),
+				...listKeys,
+				...keys.movedRequestIds.map((id) => queryKeys.requests.detail(id)),
+			];
+
+			// An in-flight refetch would otherwise land after the optimistic
+			// draw and overwrite it with the pre-drop order.
+			await Promise.all(
+				snapshotKeys.map((queryKey) => queryClient.cancelQueries({ queryKey }))
+			);
+			const snapshots = snapshotKeys.map(
+				(queryKey) => [queryKey, queryClient.getQueryData(queryKey)] as const
+			);
+
+			drawPlan(queryClient, plan);
+			return { snapshots, keys };
+		},
+		onSuccess: (result) => {
+			if (result.collections.length > 0) {
+				const written = new Map(result.collections.map((c) => [c.id, c]));
+				queryClient.setQueryData<Collection[]>(queryKeys.collections.list(), (old) =>
+					old?.map((c) => written.get(c.id) ?? c).sort(compareTreeOrder)
+				);
+			}
+			for (const request of result.requests) {
+				placeRequest(queryClient, request.id, request.order, request.collectionId);
+			}
+		},
+		onError: (error, _plan, context) => {
+			for (const [queryKey, data] of context?.snapshots ?? []) {
+				queryClient.setQueryData(queryKey, data);
+			}
+			useSaveStore
+				.getState()
+				.failSave(error instanceof Error ? error.message : "Failed to reorder");
+		},
+		onSettled: (_data, _error, _plan, context) => {
+			if (context?.keys.touchesCollections) {
+				queryClient.invalidateQueries({ queryKey: queryKeys.collections.list() });
+			}
+			for (const collectionId of context?.keys.requestScopes ?? []) {
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.requests.listByCollection(collectionId),
+				});
+			}
 		},
 	});
 }

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -29,6 +29,7 @@ export {
 	useCreateRequestMutation,
 	useUpdateRequestMutation,
 	useDeleteRequestMutation,
+	useReorderMutation,
 	isRequestNotFound,
 } from "./collections";
 export { RequestNotFoundError } from "./collections";

--- a/app/src/queries/reorder-mutation.test.tsx
+++ b/app/src/queries/reorder-mutation.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The optimistic half of a drop (issue #365).
+ *
+ * A drag is only believable if the row is where the pointer left it *before*
+ * the write returns, and only trustworthy if it goes back when the write fails.
+ * Both are cache behaviour, so both are pinned here rather than left to the
+ * gesture work in #367.
+ *
+ * Each test is mutation-checked in the same shape: remove the `onMutate` draw
+ * and the first group reddens; remove the `onError` restore and the second
+ * group reddens; remove the `onSettled` invalidation and the third does.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useReorderMutation } from "./collections";
+import { queryKeys } from "./keys";
+import { useSaveStore } from "@/stores/save-store";
+import type { Collection, Request, ReorderRequest } from "@/types";
+
+const reorder = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		reorder: (...a: unknown[]) => reorder(...a),
+	},
+}));
+
+const req = (id: string, collectionId: string, order: number): Request =>
+	({ id, collectionId, name: id, order, createdAt: "2026-01-01T00:00:00.000Z" }) as Request;
+
+const col = (id: string, order: number, parentId?: string): Collection =>
+	({ id, name: id, order, parentId, createdAt: "2026-01-01T00:00:00.000Z" }) as Collection;
+
+function makeClient() {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: Infinity },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+/** `col_a` holds a, b, c; `col_b` holds x. Two root collections alongside. */
+function seed(client: QueryClient) {
+	client.setQueryData(queryKeys.requests.listByCollection("col_a"), [
+		req("a", "col_a", 0),
+		req("b", "col_a", 1),
+		req("c", "col_a", 2),
+	]);
+	client.setQueryData(queryKeys.requests.listByCollection("col_b"), [req("x", "col_b", 0)]);
+	client.setQueryData(queryKeys.collections.list(), [col("col_a", 0), col("col_b", 1)]);
+	client.setQueryData(queryKeys.requests.detail("a"), req("a", "col_a", 0));
+}
+
+/** Ids of a collection's cached requests, in cache order. */
+const ids = (client: QueryClient, collectionId: string) =>
+	(client.getQueryData<Request[]>(queryKeys.requests.listByCollection(collectionId)) ?? []).map(
+		(r) => r.id
+	);
+
+/** A within-collection swap of the first two requests. */
+const swapPlan: ReorderRequest = {
+	moves: [
+		{ type: "request", id: "b", order: 0 },
+		{ type: "request", id: "a", order: 1 },
+	],
+	normalize: [],
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useSaveStore.setState({ status: "idle" });
+});
+
+describe("useReorderMutation draws the drop before the write returns", () => {
+	it("reorders the cached list while the request is still in flight", async () => {
+		let release: (value: unknown) => void = () => {};
+		reorder.mockImplementation(() => new Promise((resolve) => (release = resolve)));
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		result.current.mutate(swapPlan);
+
+		// The assertion that matters: this is true *before* the mock resolves.
+		await waitFor(() => expect(ids(client, "col_a")).toEqual(["b", "a", "c"]));
+		release({ collections: [], requests: [] });
+	});
+
+	it("moves a request between list caches and updates its detail entry", async () => {
+		reorder.mockResolvedValue({ collections: [], requests: [] });
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync({
+			moves: [
+				{ type: "request", id: "a", order: 0, collectionId: "col_b" },
+				{ type: "request", id: "x", order: 1 },
+				{ type: "request", id: "b", order: 0 },
+				{ type: "request", id: "c", order: 1 },
+			],
+			normalize: [],
+		});
+
+		expect(ids(client, "col_a")).toEqual(["b", "c"]);
+		expect(ids(client, "col_b")).toEqual(["a", "x"]);
+		// The detail cache carries `staleTime: Infinity`, so a stale
+		// `collectionId` there outlives every refetch the tree performs.
+		expect(client.getQueryData<Request>(queryKeys.requests.detail("a"))?.collectionId).toBe(
+			"col_b"
+		);
+	});
+
+	it("renumbers a normalized scope dense in display order", async () => {
+		reorder.mockResolvedValue({ collections: [], requests: [] });
+		const client = makeClient();
+		// The legacy shape: every row at 0, position living only in the tiebreak.
+		client.setQueryData(queryKeys.requests.listByCollection("col_a"), [
+			req("a", "col_a", 0),
+			req("b", "col_a", 0),
+			req("c", "col_a", 0),
+		]);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync({
+			moves: [],
+			normalize: [{ type: "request", collectionId: "col_a" }],
+		});
+
+		expect(
+			client
+				.getQueryData<Request[]>(queryKeys.requests.listByCollection("col_a"))
+				?.map((r) => r.order)
+		).toEqual([0, 1, 2]);
+	});
+
+	it("reparents a collection and renumbers its new scope", async () => {
+		reorder.mockResolvedValue({ collections: [], requests: [] });
+		const client = makeClient();
+		client.setQueryData(queryKeys.collections.list(), [
+			col("col_a", 0),
+			col("col_b", 1),
+			col("col_c", 0, "col_a"),
+		]);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync({
+			moves: [{ type: "collection", id: "col_c", order: 0, parentId: null }],
+			normalize: [],
+		});
+
+		const stored = client
+			.getQueryData<Collection[]>(queryKeys.collections.list())
+			?.find((c) => c.id === "col_c");
+		expect(stored?.parentId).toBeUndefined();
+		expect(stored?.order).toBe(0);
+	});
+});
+
+describe("useReorderMutation settles on the rows the engine wrote", () => {
+	it("takes the engine's positions over the ones it drew", async () => {
+		// The client guessed 0/1; the engine normalized to 4/5 (a scope it found
+		// denser than the client's cache knew). The tree must show the engine's.
+		reorder.mockResolvedValue({
+			collections: [],
+			requests: [req("b", "col_a", 4), req("a", "col_a", 5)],
+		});
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync(swapPlan);
+
+		const rows = client.getQueryData<Request[]>(queryKeys.requests.listByCollection("col_a"));
+		expect(rows?.find((r) => r.id === "b")?.order).toBe(4);
+		expect(rows?.find((r) => r.id === "a")?.order).toBe(5);
+	});
+});
+
+describe("useReorderMutation rolls back a failed drop", () => {
+	it("restores every touched cache and reports through failSave", async () => {
+		reorder.mockRejectedValue(new Error("engine said no"));
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await expect(result.current.mutateAsync(swapPlan)).rejects.toThrow("engine said no");
+
+		expect(ids(client, "col_a")).toEqual(["a", "b", "c"]);
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+
+	it("puts a cross-collection move back in its source list", async () => {
+		reorder.mockRejectedValue(new Error("engine said no"));
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await expect(
+			result.current.mutateAsync({
+				moves: [{ type: "request", id: "a", order: 0, collectionId: "col_b" }],
+				normalize: [],
+			})
+		).rejects.toThrow();
+
+		expect(ids(client, "col_a")).toEqual(["a", "b", "c"]);
+		expect(ids(client, "col_b")).toEqual(["x"]);
+		expect(client.getQueryData<Request>(queryKeys.requests.detail("a"))?.collectionId).toBe(
+			"col_a"
+		);
+	});
+});
+
+describe("useReorderMutation invalidates only what the plan touched", () => {
+	it("invalidates both sides of a cross-collection move and nothing else", async () => {
+		reorder.mockResolvedValue({ collections: [], requests: [] });
+		const client = makeClient();
+		seed(client);
+		client.setQueryData(queryKeys.requests.listByCollection("col_untouched"), []);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync({
+			moves: [{ type: "request", id: "a", order: 0, collectionId: "col_b" }],
+			normalize: [],
+		});
+
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_a"))?.isInvalidated
+		).toBe(true);
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_b"))?.isInvalidated
+		).toBe(true);
+		// A request-only plan must not invalidate the collections list, and must
+		// not reach a collection it never named.
+		expect(
+			client.getQueryState(queryKeys.requests.listByCollection("col_untouched"))
+				?.isInvalidated
+		).toBe(false);
+		expect(client.getQueryState(queryKeys.collections.list())?.isInvalidated).toBe(false);
+	});
+
+	it("invalidates the collections list for a collection move", async () => {
+		reorder.mockResolvedValue({ collections: [], requests: [] });
+		const client = makeClient();
+		seed(client);
+
+		const { result } = renderHook(() => useReorderMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync({
+			moves: [{ type: "collection", id: "col_b", order: 0 }],
+			normalize: [],
+		});
+
+		expect(client.getQueryState(queryKeys.collections.list())?.isInvalidated).toBe(true);
+	});
+});

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -37,6 +37,8 @@ import type {
 	ListRequestsParams,
 	CreateRequestRequest,
 	UpdateRequestRequest,
+	ReorderRequest,
+	ReorderResponse,
 	CreateEnvironmentRequest,
 	UpdateEnvironmentRequest,
 	ComposeRequestRequest,
@@ -191,6 +193,25 @@ export const apiService = {
 
 	async deleteRequest(id: string): Promise<void> {
 		await httpClient.delete(API_ENDPOINTS.REQUEST_BY_ID(id));
+	},
+
+	/**
+	 * Reposition collections and requests in one atomic batch.
+	 *
+	 * The response is the rows as written, not an acknowledgement: the caller
+	 * has already drawn the drop optimistically and settles its caches on these
+	 * rows, so a normalization the engine performed is visible immediately
+	 * rather than only after the refetch lands.
+	 */
+	async reorder(data: ReorderRequest): Promise<ReorderResponse> {
+		const response = await httpClient.post<{
+			collections: RawCollection[];
+			requests: RawRequest[];
+		}>(API_ENDPOINTS.REORDER, data);
+		return {
+			collections: response.collections.map(CollectionTransformer.toFrontend),
+			requests: response.requests.map(RequestTransformer.toFrontend),
+		};
 	},
 
 	// Environments

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -177,6 +177,42 @@ export interface UpdateRequestRequest {
 	order?: number;
 }
 
+// Reorder API (POST /reorder)
+
+/**
+ * One row's new position in a batch reorder, and - when it changes owner - its
+ * new owner.
+ *
+ * `parentId` / `collectionId` follow the same merge-patch rule the single-row
+ * `PUT`s use: omitted keeps the current owner, present states a move. Unlike
+ * those, an owner that resolves to no stored collection is a `400` rather than
+ * a tolerated forward reference, because nothing here is bulk-created.
+ */
+export type ReorderMove =
+	| { type: "collection"; id: string; order: number; parentId?: string | null }
+	| { type: "request"; id: string; order: number; collectionId?: string };
+
+/**
+ * A scope whose children are renumbered dense `0..n-1` in display order before
+ * the moves apply. `parentId: null` is the root collections, and is stated
+ * rather than omitted - the engine rejects an absent `parentId` so a renumber
+ * can never land on a scope the caller did not mean.
+ */
+export type ReorderNormalize =
+	| { type: "collection"; parentId: string | null }
+	| { type: "request"; collectionId: string };
+
+export interface ReorderRequest {
+	moves: ReorderMove[];
+	normalize: ReorderNormalize[];
+}
+
+/** The rows as written - one drop is one transaction, so this is all of them. */
+export interface ReorderResponse {
+	collections: Collection[];
+	requests: Request[];
+}
+
 // Environments API
 export interface ListEnvironmentsResponse {
 	environments: Environment[];

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -167,6 +167,7 @@ Shared, Monaco-independent modules that power the GraphQL body mode.
 | `RequestItem.tsx` | A request row (method badge, click → open in RequestBuilder, context menu) |
 | `ImportModal.tsx` | Import collections from file/URL/paste (Postman / Insomnia / OpenAPI). Mounted globally in `Shell`; open-state in a dedicated store. See [import-collections/](./import-collections/README.md) for the parser pipeline |
 | `tree-utils.ts` | Every `parentId` walk in the renderer: `walkAncestors` (the ancestor chain, root first), `isDescendant`, `collectDescendantEntityIds` (what a cascade delete reaches). Each carries a visited-set termination guard - the engine tolerates cycles in stored data, and an unguarded walk hangs the window rather than answering wrongly. Also used by `queries/collections.ts` and `useVariableResolver` |
+| `reorder-math.ts` | The arithmetic behind a drop: `planCollectionMove` / `planRequestMove` turn sibling lists and a target index into the `POST /reorder` batch, writing only the rows whose position changes and normalizing a scope whose rows all predate explicit orders. Pure and node-tested - the part of a drag a jsdom gesture cannot reach. Consumed by `useReorderMutation` |
 | `CollectionDetail/` | The collection editor screen (see below) |
 
 ### `CollectionDetail/` (screen `"collection-detail"`)

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -174,6 +174,28 @@ apiService.updateRequest(data): Promise<Request>         // PUT  /requests/:id
 apiService.deleteRequest(id): Promise<void>
 ```
 
+#### Reorder
+
+```typescript
+apiService.reorder(data: ReorderRequest): Promise<ReorderResponse>  // POST /reorder
+```
+
+The write path behind a drop. One call repositions any number of collections and
+requests, and the engine applies the whole batch in one transaction - so a drop
+that displaces N siblings is one round trip, not N `updateRequest` calls that can
+half-land and race a concurrent create into the middle of their range.
+
+The payload carries `moves` (each row's new `order`, plus `parentId` /
+`collectionId` when it changes owner) and `normalize` (scopes to renumber dense
+`0..n-1` in display order first, for a collection whose rows all predate explicit
+orders). `modules/collections/reorder-math.ts` computes both from the sibling
+lists the tree is already showing; the full contract is in
+[engine/api-reference.md](../engine/api-reference.md) under `POST /reorder`.
+
+Unlike the other writes, the response is **read**: it is the rows as written, and
+`useReorderMutation` settles its caches on them so a normalization the engine
+performed shows up without waiting for the refetch.
+
 #### Environments
 
 ```typescript
@@ -357,6 +379,9 @@ export const API_ENDPOINTS = {
   // Requests
   REQUESTS: "/requests",
   REQUEST_BY_ID: (id: string) => `/requests/${id}`,
+
+  // Batch reorder for both entity kinds - one drop, one call, one transaction
+  REORDER: "/reorder",
   
   // Cookie jar - GET reads every scope, DELETE clears one or all
   COOKIES: "/cookies",

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -667,8 +667,37 @@ engine's SQL by `engine/tests/fixtures/tree-order-conformance.json`, read by
 - **`useUpdateRequestMutation()`** - Update request (invalidates only the lists
   that can have changed, see below)
 - **`useDeleteRequestMutation()`** - Delete request (also clears the response)
+- **`useReorderMutation()`** - Reposition collections and requests through
+  `POST /reorder` in one transaction, optimistically (see below)
 - **`useImportMutation()`** (`queries/import.ts`) - Apply a parsed import through
   `POST /import/apply` in one transaction
+
+**Reordering (`useReorderMutation`)** is the one mutation that writes its caches
+three times, because a drag is only believable if the row is where the pointer
+left it before the write returns:
+
+- `onMutate` snapshots every key the plan can touch and *draws the plan* into the
+  caches - the same two steps the engine performs, normalize each named scope to
+  `0..n-1` in display order, then position each move. A cross-collection move
+  crosses list caches and updates `requests.detail` (which carries
+  `staleTime: Infinity`, so a stale `collectionId` there would outlive every
+  refetch).
+- `onSuccess` re-applies the rows the engine actually wrote, which the response
+  carries. They are normally what was drawn, but a normalization is authoritative
+  from the engine, so the tree settles on real positions rather than a guess.
+- `onError` restores the snapshots wholesale and reports through
+  `useSaveStore.failSave` - the one channel every save failure reaches the Dock
+  and the toast through. The mutation owns this rather than its caller, so the
+  gesture layer cannot forget it.
+- `onSettled` invalidates the affected keys **once** - the collections list only
+  if a collection moved, and only the request lists the plan named.
+
+Every write goes through `setQueryData` with a fresh array, never a mutation in
+place: the map `useMultipleCollectionRequests` builds is compared by reference by
+the reveal effect, so an in-place edit would move a row on screen that the tree
+never notices. The plan itself comes from
+`modules/collections/reorder-math.ts` - a pure module, node-tested, that turns
+sibling lists and a drop index into the minimal set of rows to rewrite.
 
 #### Environments & Variables
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -188,11 +188,14 @@ writes rows that cannot see each other yet, so an omitted `order` gives the
 payload's items consecutive slots starting from the append point - see
 [POST /import/apply](#post-importapply).
 
-**Concurrency caveat.** Each `PUT` is its own write under its own lock, so a
-reorder expressed as N sibling `PUT`s is last-write-wins between concurrent
-clients, and the collection cycle guard is read-then-write across two lock
-scopes. Neither is fixed by a per-row endpoint; both are the job of the atomic
-batch reorder endpoint (issue #364).
+**Repositioning several rows at once** is [`POST /reorder`](#post-reorder), not a
+run of `PUT`s. Each `PUT` is its own write under its own lock, so a reorder
+expressed as N sibling `PUT`s is last-write-wins between concurrent clients, can
+be interrupted halfway (leaving two rows at one `order` and a gap where the
+moved one was), and its collection cycle guard is read-then-write across two lock
+scopes. The batch endpoint validates and writes under one transaction, which
+closes all three. The per-row `PUT`s remain correct for a single row - a rename,
+a move that appends - and still carry those caveats when used in a loop.
 
 ### Accepted field shapes
 
@@ -640,6 +643,85 @@ Delete a request.
   "id": "req_1234567890"
 }
 ```
+
+## Reorder
+
+### POST /reorder
+
+Reposition collections and requests in one atomic batch - the write path behind a
+drag-and-drop reorder or a cross-folder move. One drop is one call and one
+transaction: nothing partial survives a rejection, and no concurrent create can
+land inside the range the batch is renumbering.
+
+**Request:**
+```json
+{
+  "normalize": [
+    {"type": "request", "collectionId": "col_1234567890"}
+  ],
+  "moves": [
+    {"type": "request",    "id": "req_1", "order": 0, "collectionId": "col_2"},
+    {"type": "collection", "id": "col_3", "order": 1, "parentId": null}
+  ]
+}
+```
+
+Both arrays are optional (absent or `null` means none); an empty batch is a
+`200` that writes nothing.
+
+**`moves`** - each entry names one row and the position it takes:
+
+| Field | Rule |
+|---|---|
+| `type` | `"collection"` or `"request"`; anything else is a `400` |
+| `id` | Non-empty string naming a **stored** row of that type |
+| `order` | Required, a non-negative integer. Not a float, not negative - this endpoint writes dense positions, and either would be a silently truncated or unreachable slot |
+| `parentId` (collection) | Absent keeps the current parent; `null` moves to the root; a string moves under that collection, which must exist |
+| `collectionId` (request) | Absent keeps the current owner; a string moves to that collection, which must exist |
+
+A row may appear in `moves` at most once - two positions for one row is a `400`
+naming it, not a last-writer-wins accident of iteration order.
+
+**`normalize`** - each entry names a scope whose children are renumbered dense
+`0..n-1` in the [pinned display order](#ordering) **before** any move applies. A
+collection scope states `parentId` (`null` for the root collections) and a
+request scope states `collectionId`; the named collection must exist, and for a
+collection scope `parentId` must be *stated* rather than omitted, so a renumber
+can never land on a scope the caller did not mean.
+
+Normalization exists for the first drop into a collection whose rows predate
+explicit orders: every row sits at `0`, so its displayed position lives only in
+the tiebreak and there are no slots to shift into. Materializing that order in
+the same batch is what keeps the other siblings from appearing to jump. It is
+idempotent - a scope already dense writes nothing at all.
+
+Where a row is named by both lists, the move wins.
+
+**Validation is complete before the first write.** Entry shapes, the existence of
+every named row and owner, and the acyclicity of the **post-move** collection
+graph are all checked first; a failure is a `400` naming the offending row with
+nothing written. The cycle check reading the post-move shape is what makes two
+reparents that each look legal alone (`A` under `B` and `B` under `A`) a
+deterministic rejection rather than a race - unlike `PUT /collections/:id`, which
+validates and writes under different locks.
+
+**Response:** the rows as written, in the same serialized shape a list entry
+carries - not an acknowledgement. A client that drew the drop optimistically
+settles its caches on these, so a normalization the engine performed is visible
+without waiting for a refetch.
+
+```json
+{
+  "collections": [],
+  "requests": [
+    {"id": "req_1", "collectionId": "col_2", "order": 0, "name": "Get users", "...": "..."}
+  ]
+}
+```
+
+**Errors:** `400` for any malformed entry, a row or owner that does not exist, a
+duplicate move, a cycle, or a batch over 10000 entries - in every case nothing at
+all was written. Body that is not JSON or not an object is also a `400`.
 
 ## Import
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -367,6 +367,7 @@ if(VAYU_BUILD_ENGINE)
         src/http/routes/config.cpp
         src/http/routes/collections.cpp
         src/http/routes/requests.cpp
+        src/http/routes/reorder.cpp
         src/http/routes/environments.cpp
         src/http/routes/globals.cpp
         src/http/routes/runs.cpp
@@ -461,10 +462,12 @@ if(VAYU_BUILD_TESTS)
         tests/request_composer_test.cpp
         tests/scenario_plan_test.cpp
         tests/tree_order_test.cpp
+        tests/reorder_route_test.cpp
         src/http/routes/import.cpp
         src/http/routes/compose.cpp
         src/http/routes/config.cpp
         src/http/routes/requests.cpp
+        src/http/routes/reorder.cpp
         src/http/routes/runs.cpp
         src/http/routes/collections.cpp
         src/http/routes/environments.cpp

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -67,6 +67,23 @@ class Database {
     const std::vector<Request>& requests,
     const std::vector<Environment>& environments);
 
+    /**
+     * @brief Persist a whole batch reorder in one transaction (issue #365).
+     *
+     * The rows carry positions (and, for a move, owners) that the caller has
+     * already validated against each other; either every one lands or none
+     * does. A reorder expressed as N sibling `PUT`s could be interrupted
+     * halfway, leaving a parent with two rows at the same `order` and a gap
+     * where the moved one used to be - a shape no read repairs, because the tie
+     * rule then decides the display order.
+     *
+     * Separate from `import_apply` despite the shared shape: this writes rows
+     * that already exist and must not touch environments, and the two callers
+     * validate entirely different things beforehand.
+     */
+    void apply_reorder (const std::vector<Collection>& collections,
+    const std::vector<Request>& requests);
+
     void save_environment (const Environment& e);
     std::vector<Environment> get_environments ();
     std::optional<Environment> get_environment (const std::string& id);

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -497,6 +497,7 @@ void register_health_routes (RouteContext& ctx);
 void register_config_routes (RouteContext& ctx);
 void register_collection_routes (RouteContext& ctx);
 void register_request_routes (RouteContext& ctx);
+void register_reorder_routes (RouteContext& ctx);
 void register_environment_routes (RouteContext& ctx);
 void register_globals_routes (RouteContext& ctx);
 void register_run_routes (RouteContext& ctx);

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -733,6 +733,36 @@ const std::vector<Environment>& environments) {
 }
 
 // ============================================================================
+// Batch reorder - repositioned collections + requests in one transaction
+// ============================================================================
+
+// Same shape as import_apply: retry_on_busy holds the recursive mutex while the
+// lambda runs, and the lambda only touches the same storage handle. Collections
+// first so a request that moved into a collection this batch also reparented
+// still lands after its owner's row.
+void Database::apply_reorder (const std::vector<Collection>& collections,
+const std::vector<Request>& requests) {
+    if (collections.empty () && requests.empty ()) {
+        return;
+    }
+
+    vayu::utils::log_debug ("Applying reorder: " + std::to_string (collections.size ()) +
+    " collections, " + std::to_string (requests.size ()) + " requests");
+
+    retry_on_busy ("apply reorder", 5, std::chrono::milliseconds (100), [&] {
+        impl_->storage.transaction ([&] {
+            for (const auto& c : collections) {
+                impl_->storage.replace (c);
+            }
+            for (const auto& r : requests) {
+                impl_->storage.replace (r);
+            }
+            return true; // Commit
+        });
+    });
+}
+
+// ============================================================================
 // Environments - Named variable sets (dev, staging, prod)
 // ============================================================================
 

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/routes/reorder.cpp
+ * @brief POST /reorder - the atomic batch reorder/move for collections and
+ *        requests (issue #365).
+ */
+
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/json.hpp"
+#include "vayu/utils/logger.hpp"
+
+#include <map>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace vayu::http::routes {
+
+namespace {
+
+/**
+ * Cap on entries per call, mirroring `/import/apply`'s. Every row is loaded and
+ * built before anything is written, so an unbounded batch is an unbounded
+ * allocation; a drop writes a handful of rows and a whole-workspace renumber
+ * stays far below this.
+ */
+constexpr size_t MAX_REORDER_ENTRIES = 10000;
+
+/** A 400 about the payload as a whole. */
+std::pair<int, nlohmann::json> body_error (const std::string& message) {
+    return { 400, error_body (400, message) };
+}
+
+/** The two entity kinds this endpoint moves. */
+enum class Kind { Collection, Request };
+
+/**
+ * One scope whose children are renumbered dense before the moves apply: the
+ * children of a collection (`parent` empty means the roots), or the requests of
+ * a collection.
+ */
+struct Scope {
+    Kind kind;
+    std::optional<std::string> parent; // collection scope: nullopt = the roots
+    std::string collection;            // request scope
+
+    bool operator< (const Scope& other) const {
+        if (kind != other.kind) {
+            return kind < other.kind;
+        }
+        if (kind == Kind::Collection) {
+            return parent < other.parent;
+        }
+        return collection < other.collection;
+    }
+};
+
+/** One row's new position, and - when it changes owner - its new owner. */
+struct Move {
+    Kind kind;
+    std::string id;
+    int order         = 0;
+    bool states_owner = false; // parentId / collectionId present in the body
+    std::optional<std::string> parent; // collection move
+    std::string collection;            // request move
+};
+
+/** Reads and validates `type`, the one field both entry shapes share. */
+std::optional<std::pair<int, nlohmann::json>>
+read_kind (const nlohmann::json& entry, const std::string& at, Kind& out) {
+    if (!entry.is_object ()) {
+        return body_error ("Invalid " + at + ": must be an object");
+    }
+    if (!entry.contains ("type") || !entry["type"].is_string ()) {
+        return body_error ("Invalid " + at + ": 'type' must be \"collection\" or \"request\"");
+    }
+    const std::string type = entry["type"].get<std::string> ();
+    if (type == "collection") {
+        out = Kind::Collection;
+        return std::nullopt;
+    }
+    if (type == "request") {
+        out = Kind::Request;
+        return std::nullopt;
+    }
+    return body_error ("Invalid " + at + ": unknown type '" + type + "'");
+}
+
+/**
+ * Reads one `normalize` entry.
+ *
+ * A collection scope must *state* `parentId` (`null` for the roots) rather than
+ * omitting it: absent would have to mean either "the roots" or "whatever parent
+ * you infer", and a renumber that silently picked the wrong scope is a whole
+ * folder reshuffled. A named parent or owning collection must exist - unlike the
+ * single-row `PUT`, which tolerates an unresolvable parent because bulk import
+ * writes rows that cannot see each other yet. Nothing here is bulk-created, so a
+ * scope that resolves to no row is a client bug, not an ordering artifact.
+ */
+std::optional<std::pair<int, nlohmann::json>>
+read_scope (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Scope& out) {
+    const std::string at = "normalize entry at index " + std::to_string (index);
+    if (auto err = read_kind (entry, at, out.kind)) {
+        return err;
+    }
+    if (out.kind == Kind::Collection) {
+        if (!entry.contains ("parentId")) {
+            return body_error ("Invalid " +
+            at + ": 'parentId' must be stated (null normalizes the root collections)");
+        }
+        const auto& parent = entry["parentId"];
+        if (parent.is_null ()) {
+            out.parent = std::nullopt;
+            return std::nullopt;
+        }
+        if (!parent.is_string ()) {
+            return body_error ("Invalid " + at + ": 'parentId' must be a string or null");
+        }
+        out.parent = parent.get<std::string> ();
+        if (!db.get_collection (*out.parent).has_value ()) {
+            return body_error ("Collection '" + *out.parent + "' does not exist");
+        }
+        return std::nullopt;
+    }
+    if (!entry.contains ("collectionId") || !entry["collectionId"].is_string ()) {
+        return body_error ("Invalid " + at + ": 'collectionId' must be a string");
+    }
+    out.collection = entry["collectionId"].get<std::string> ();
+    if (!db.get_collection (out.collection).has_value ()) {
+        return body_error ("Collection '" + out.collection + "' does not exist");
+    }
+    return std::nullopt;
+}
+
+/**
+ * Reads one `moves` entry and checks that the row it names is stored.
+ *
+ * `order` is required and must be a non-negative integer: this endpoint exists
+ * to write dense positions, and a float or a negative would be a silently
+ * truncated or unreachable slot. The owner fields follow the merge-patch rule
+ * the single-row endpoints use - absent keeps the current owner, present states
+ * a move - except that a stated owner must exist, for the reason in `read_scope`.
+ */
+std::optional<std::pair<int, nlohmann::json>>
+read_move (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Move& out) {
+    const std::string at = "move at index " + std::to_string (index);
+    if (auto err = read_kind (entry, at, out.kind)) {
+        return err;
+    }
+    if (!entry.contains ("id") || !entry["id"].is_string () ||
+    entry["id"].get<std::string> ().empty ()) {
+        return body_error ("Invalid " + at + ": 'id' must be a non-empty string");
+    }
+    out.id = entry["id"].get<std::string> ();
+
+    if (!entry.contains ("order") || !entry["order"].is_number_integer () ||
+    entry["order"].get<int64_t> () < 0) {
+        return body_error ("Invalid " + at + ": 'order' must be a non-negative integer");
+    }
+    out.order = entry["order"].get<int> ();
+
+    if (out.kind == Kind::Collection) {
+        if (!db.get_collection (out.id).has_value ()) {
+            return body_error ("Collection '" + out.id + "' does not exist");
+        }
+        if (entry.contains ("parentId")) {
+            out.states_owner   = true;
+            const auto& parent = entry["parentId"];
+            if (parent.is_null ()) {
+                out.parent = std::nullopt;
+            } else if (parent.is_string ()) {
+                out.parent = parent.get<std::string> ();
+                if (!db.get_collection (*out.parent).has_value ()) {
+                    return body_error ("Collection '" + *out.parent + "' does not exist");
+                }
+            } else {
+                return body_error ("Invalid " + at + ": 'parentId' must be a string or null");
+            }
+        }
+        return std::nullopt;
+    }
+
+    if (!db.get_request (out.id).has_value ()) {
+        return body_error ("Request '" + out.id + "' does not exist");
+    }
+    if (entry.contains ("collectionId")) {
+        if (!entry["collectionId"].is_string ()) {
+            return body_error ("Invalid " + at + ": 'collectionId' must be a string");
+        }
+        out.states_owner = true;
+        out.collection   = entry["collectionId"].get<std::string> ();
+        if (!db.get_collection (out.collection).has_value ()) {
+            return body_error ("Collection '" + out.collection + "' does not exist");
+        }
+    }
+    return std::nullopt;
+}
+
+/**
+ * Rejects a batch that would leave a collection as its own ancestor.
+ *
+ * The walk runs over the shape the batch *would* produce - stored parents with
+ * every move's `parentId` applied on top - which is what makes this endpoint
+ * close the TOCTOU race the per-row `PUT` has: validation and write share one
+ * transaction here, so two concurrent reparents that each look legal alone
+ * cannot both land. `PUT /collections/:id` validates against the shape it read
+ * before writing, under a different lock than the write.
+ *
+ * Only moved collections start a walk: a cycle in the post-move graph must pass
+ * through an edge this batch changed, so a chain that reaches a root or an
+ * already-visited node is proof enough. The visited set also keeps a
+ * pre-existing corrupt cycle (written before write-time validation existed, and
+ * explicitly tolerated by `validate_parent_assignment`) from hanging the
+ * validator.
+ */
+std::optional<std::pair<int, nlohmann::json>>
+reject_post_move_cycles (vayu::db::Database& db, const std::vector<Move>& moves) {
+    std::unordered_map<std::string, std::optional<std::string>> parent_of;
+    for (const auto& c : db.get_collections ()) {
+        parent_of[c.id] = c.parent_id;
+    }
+    for (const auto& move : moves) {
+        if (move.kind == Kind::Collection && move.states_owner) {
+            parent_of[move.id] = move.parent;
+        }
+    }
+
+    for (const auto& move : moves) {
+        if (move.kind != Kind::Collection || !move.states_owner) {
+            continue;
+        }
+        if (move.parent.has_value () && *move.parent == move.id) {
+            return body_error ("Collection '" + move.id + "' cannot be its own parent");
+        }
+        std::unordered_set<std::string> seen;
+        std::optional<std::string> cursor = move.parent;
+        while (cursor.has_value ()) {
+            if (*cursor == move.id) {
+                return body_error (
+                "Cannot move collection '" + move.id + "' into its own descendant");
+            }
+            if (!seen.insert (*cursor).second) {
+                break; // Pre-existing corrupt cycle; bounded, and not this batch's.
+            }
+            auto next = parent_of.find (*cursor);
+            if (next == parent_of.end ()) {
+                break;
+            }
+            cursor = next->second;
+        }
+    }
+    return std::nullopt;
+}
+
+/**
+ * The rows a batch will write, keyed by id so a row named by both a
+ * normalization and a move is written once, with the move's position winning.
+ *
+ * Ordered maps rather than hash maps: the response lists what was written, and
+ * a client diffing two responses should not have to sort them first.
+ */
+struct WriteSet {
+    std::map<std::string, vayu::db::Collection> collections;
+    std::map<std::string, vayu::db::Request> requests;
+
+    bool empty () const {
+        return collections.empty () && requests.empty ();
+    }
+};
+
+/**
+ * Renumbers one scope's children dense `0..n-1` in the pinned display order
+ * (`order`, `createdAt`, `id` - the reads below already apply it).
+ *
+ * Only rows whose position actually changes are added, which is what makes the
+ * operation observably idempotent: normalizing an already-dense scope writes
+ * nothing at all. It is also the whole point of the `normalize` list - a
+ * collection whose rows all sit at the legacy `0` has a display order that
+ * exists nowhere but the sort, and the first drop into it has to materialize
+ * that order before it can name a slot, or every sibling appears to jump.
+ */
+void normalize_scope (vayu::db::Database& db, const Scope& scope, int64_t now, WriteSet& out) {
+    if (scope.kind == Kind::Collection) {
+        int index = 0;
+        for (const auto& c : db.get_collections ()) {
+            if (c.parent_id != scope.parent) {
+                continue;
+            }
+            if (c.order != index) {
+                vayu::db::Collection row = c;
+                row.order                = index;
+                row.updated_at           = now;
+                out.collections[row.id]  = std::move (row);
+            }
+            ++index;
+        }
+        return;
+    }
+    int index = 0;
+    for (const auto& r : db.get_requests_in_collection (scope.collection)) {
+        if (r.order != index) {
+            vayu::db::Request row = r;
+            row.order             = index;
+            row.updated_at        = now;
+            out.requests[row.id]  = std::move (row);
+        }
+        ++index;
+    }
+}
+
+/** Applies one move on top of whatever the normalization pass already staged. */
+void stage_move (vayu::db::Database& db, const Move& move, int64_t now, WriteSet& out) {
+    if (move.kind == Kind::Collection) {
+        auto staged              = out.collections.find (move.id);
+        vayu::db::Collection row = staged != out.collections.end () ?
+        staged->second :
+        *db.get_collection (move.id);
+        row.order                = move.order;
+        if (move.states_owner) {
+            row.parent_id = move.parent;
+        }
+        row.updated_at          = now;
+        out.collections[row.id] = std::move (row);
+        return;
+    }
+    auto staged = out.requests.find (move.id);
+    vayu::db::Request row =
+    staged != out.requests.end () ? staged->second : *db.get_request (move.id);
+    row.order = move.order;
+    if (move.states_owner) {
+        row.collection_id = move.collection;
+    }
+    row.updated_at       = now;
+    out.requests[row.id] = std::move (row);
+}
+
+} // namespace
+
+/**
+ * Testable core of POST /reorder - one drop, one round trip, one transaction
+ * (issue #365), returning {http_status, json_body}.
+ *
+ * A drop that displaces N siblings used to have no sane write path: the only
+ * write verbs are one row per `PUT`, so a renumber was N sequential requests -
+ * non-atomic (a crash mid-sequence half-renumbers a parent), racy against a
+ * concurrent create computing `max_order + 1` between two of them and against
+ * `POST /import/apply`'s own transactional order slots, and an invalidation
+ * storm on the client. This endpoint takes the whole batch instead.
+ *
+ * The order of business is fixed and load-bearing:
+ *
+ *  1. **Everything is validated first** - entry shapes, that every named row and
+ *     owner exists, and that the *post-move* collection graph is acyclic. A
+ *     failure is a 400 naming the offending row, with nothing written; the
+ *     partial batch that per-row PUTs could leave behind is unreachable here.
+ *  2. **`normalize` renumbers, then `moves` position.** Normalization
+ *     materializes a scope's displayed order as dense `0..n-1` so a first drop
+ *     into a legacy all-zeros collection has real slots to name; the moves then
+ *     state the positions the drop actually produced, and win over the
+ *     renumber for any row named by both.
+ *  3. **One transaction under the DB mutex** (`Database::apply_reorder`), so the
+ *     validation above and the write share a lock scope - which is what closes
+ *     the read-then-write race `PUT /collections/:id`'s cycle guard still has.
+ *
+ * The response carries the rows as written, because the client that drew the
+ * drop optimistically needs the authoritative positions to settle its caches on
+ * - a count would tell it nothing it could use.
+ *
+ * Extracted for reorder_route_test.cpp, following the suite's route-test
+ * convention (no in-process HTTP server).
+ */
+std::pair<int, nlohmann::json>
+reorder_response (vayu::db::Database& db, const nlohmann::json& body) {
+    if (!body.is_object ()) {
+        return body_error ("Body must be a JSON object");
+    }
+
+    const nlohmann::json empty     = nlohmann::json::array ();
+    const nlohmann::json* moves_in = &empty;
+    const nlohmann::json* norm_in  = &empty;
+    if (body.contains ("moves") && !body["moves"].is_null ()) {
+        if (!body["moves"].is_array ()) {
+            return body_error ("Invalid 'moves': must be an array");
+        }
+        moves_in = &body["moves"];
+    }
+    if (body.contains ("normalize") && !body["normalize"].is_null ()) {
+        if (!body["normalize"].is_array ()) {
+            return body_error ("Invalid 'normalize': must be an array");
+        }
+        norm_in = &body["normalize"];
+    }
+
+    const size_t total = moves_in->size () + norm_in->size ();
+    if (total > MAX_REORDER_ENTRIES) {
+        return body_error ("Reorder too large: " + std::to_string (total) +
+        " entries exceeds the limit of " + std::to_string (MAX_REORDER_ENTRIES) + " per call");
+    }
+
+    std::vector<Scope> scopes;
+    scopes.reserve (norm_in->size ());
+    for (size_t i = 0; i < norm_in->size (); ++i) {
+        Scope scope;
+        if (auto err = read_scope (db, (*norm_in)[i], i, scope)) {
+            return *err;
+        }
+        scopes.push_back (std::move (scope));
+    }
+
+    std::vector<Move> moves;
+    moves.reserve (moves_in->size ());
+    std::unordered_set<std::string> claimed;
+    for (size_t i = 0; i < moves_in->size (); ++i) {
+        Move move;
+        if (auto err = read_move (db, (*moves_in)[i], i, move)) {
+            return *err;
+        }
+        // Two positions for one row is not a resolvable batch - whichever won
+        // would be an accident of iteration order, and the client that sent it
+        // has a bug the 400 names.
+        if (!claimed.insert (move.id).second) {
+            return body_error ("Duplicate move for '" + move.id + "'");
+        }
+        moves.push_back (std::move (move));
+    }
+
+    if (auto err = reject_post_move_cycles (db, moves)) {
+        return *err;
+    }
+
+    const int64_t now = now_ms ();
+    WriteSet writes;
+    for (const auto& scope : scopes) {
+        normalize_scope (db, scope, now, writes);
+    }
+    for (const auto& move : moves) {
+        stage_move (db, move, now, writes);
+    }
+
+    std::vector<vayu::db::Collection> collection_rows;
+    std::vector<vayu::db::Request> request_rows;
+    collection_rows.reserve (writes.collections.size ());
+    request_rows.reserve (writes.requests.size ());
+    nlohmann::json collections_out = nlohmann::json::array ();
+    nlohmann::json requests_out    = nlohmann::json::array ();
+    for (const auto& [id, row] : writes.collections) {
+        collections_out.push_back (vayu::json::serialize (row));
+        collection_rows.push_back (row);
+    }
+    for (const auto& [id, row] : writes.requests) {
+        requests_out.push_back (vayu::json::serialize (row));
+        request_rows.push_back (row);
+    }
+
+    if (!writes.empty ()) {
+        db.apply_reorder (collection_rows, request_rows);
+    }
+    return { 200, nlohmann::json{ { "collections", collections_out }, { "requests", requests_out } } };
+}
+
+void register_reorder_routes (RouteContext& ctx) {
+    /**
+     * POST /reorder
+     * Repositions collections and requests in one atomic batch - the write path
+     * behind a drag-and-drop reorder or a cross-folder move.
+     * Body params: `moves` (array of {type, id, order, parentId? |
+     * collectionId?}) and `normalize` (array of {type, parentId |
+     * collectionId}); both optional, an empty batch is a no-op. Normalization
+     * renumbers a scope's children dense 0..n-1 in display order before the
+     * moves apply. Returns: 200 `{"collections": [...], "requests": [...]}` -
+     * the rows as written - or 400 naming the offending row, in which case
+     * nothing at all was written.
+     */
+    ctx.server.Post ("/reorder", [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        nlohmann::json body;
+        try {
+            body = nlohmann::json::parse (req.body);
+        } catch (const std::exception& e) {
+            vayu::utils::log_warning (
+            "POST /reorder - invalid JSON body: " + std::string (e.what ()));
+            send_error (res, 400, "Invalid JSON body");
+            return;
+        }
+        // A validation failure is the core's 400; only a write or serialization
+        // failure reaches this catch, and that is a 500, not the client's fault.
+        try {
+            auto [status, response] = reorder_response (ctx.db, body);
+            if (status != 200) {
+                vayu::utils::log_warning ("POST /reorder - " +
+                std::to_string (status) + ": " + error_message_of (response));
+            } else {
+                vayu::utils::log_info ("POST /reorder - wrote " +
+                std::to_string (response["collections"].size ()) + " collections, " +
+                std::to_string (response["requests"].size ()) + " requests");
+            }
+            res.status = status;
+            res.set_content (response.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("POST /reorder - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+}
+
+} // namespace vayu::http::routes

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -122,6 +122,7 @@ void Server::setup_routes () {
     routes::register_config_routes (*route_ctx_);
     routes::register_collection_routes (*route_ctx_);
     routes::register_request_routes (*route_ctx_);
+    routes::register_reorder_routes (*route_ctx_);
     routes::register_environment_routes (*route_ctx_);
     routes::register_globals_routes (*route_ctx_);
     routes::register_run_routes (*route_ctx_);

--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -1,0 +1,492 @@
+/**
+ * @file tests/reorder_route_test.cpp
+ * @brief POST /reorder - the atomic batch reorder/move (issue #365).
+ *
+ * What is pinned here:
+ *
+ *  - **Atomicity.** A batch with one invalid member is a 400 and leaves every
+ *    row exactly where it was. This is the assertion that would have caught
+ *    what a reorder expressed as N sibling `PUT`s does when it fails halfway,
+ *    so each failure case checks the stored positions, not just the status.
+ *
+ *  - **Validation is complete before the first write, and names the offender.**
+ *    A missing row, a missing owner, a duplicate move, a bad `order` - each is
+ *    a 400 carrying the id a client can act on.
+ *
+ *  - **The cycle check runs against the shape the batch would produce**, not
+ *    the shape on disk. Two reparents that each look legal alone but form a
+ *    loop together are rejected as one batch - the race `PUT /collections/:id`
+ *    cannot close, because it validates and writes under different locks.
+ *
+ *  - **Normalization materializes the displayed order** of a legacy all-zeros
+ *    scope as dense 0..n-1, in the pinned `order`/`createdAt`/`id` rule, and is
+ *    idempotent - a second call writes nothing.
+ *
+ *  - **A create concurrent with a batch cannot land inside it.** The append
+ *    scan reads `max_order + 1`, so a request created after a dense renumber
+ *    sits past the batch's range rather than tying with a row inside it.
+ *
+ * Route cores are exercised directly, no in-process HTTP server, matching the
+ * suite's other route tests.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "vayu/db/database.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in reorder.cpp / collections.cpp / requests.cpp; each returns
+// {http_status, json_body} - the same pair the HTTP handler writes out.
+std::pair<int, nlohmann::json>
+reorder_response (vayu::db::Database& db, const nlohmann::json& body);
+std::pair<int, nlohmann::json>
+create_collection_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+create_request_response (vayu::db::Database& db, const nlohmann::json& json);
+} // namespace vayu::http::routes
+
+namespace {
+
+using vayu::http::routes::create_collection_response;
+using vayu::http::routes::create_request_response;
+using vayu::http::routes::reorder_response;
+
+class ReorderRouteTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_reorder_route.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        for (const char* suffix : { "", "-wal", "-shm" }) {
+            std::filesystem::remove (std::string (DB_PATH) + suffix);
+        }
+    }
+
+    /** Creates a collection through the real create core and returns its id. */
+    std::string make_collection (const std::string& name,
+    const std::optional<std::string>& parent = std::nullopt) {
+        json body{ { "name", name } };
+        if (parent.has_value ()) {
+            body["parentId"] = *parent;
+        }
+        auto [status, response] = create_collection_response (*db_, body);
+        EXPECT_EQ (status, 200) << response.dump ();
+        return response["id"].get<std::string> ();
+    }
+
+    /** Creates a request through the real create core and returns its id. */
+    std::string make_request (const std::string& collection_id, const std::string& name) {
+        auto [status, response] = create_request_response (*db_,
+        json{ { "collectionId", collection_id }, { "name", name },
+        { "method", "GET" }, { "url", "https://example.com" } });
+        EXPECT_EQ (status, 200) << response.dump ();
+        return response["id"].get<std::string> ();
+    }
+
+    /** Forces a row to a stored `order`, bypassing the routes - the legacy shape. */
+    void set_request_order (const std::string& id, int order) {
+        auto row = db_->get_request (id);
+        ASSERT_TRUE (row.has_value ());
+        row->order = order;
+        db_->save_request (*row);
+    }
+
+    /** Request ids of a collection, in the engine's pinned display order. */
+    std::vector<std::string> request_ids (const std::string& collection_id) {
+        std::vector<std::string> ids;
+        for (const auto& r : db_->get_requests_in_collection (collection_id)) {
+            ids.push_back (r.id);
+        }
+        return ids;
+    }
+
+    /** Stored `order` of each request in a collection, in display order. */
+    std::vector<int> request_orders (const std::string& collection_id) {
+        std::vector<int> orders;
+        for (const auto& r : db_->get_requests_in_collection (collection_id)) {
+            orders.push_back (r.order);
+        }
+        return orders;
+    }
+
+    static json move_request (const std::string& id, int order) {
+        return json{ { "type", "request" }, { "id", id }, { "order", order } };
+    }
+
+    static json normalize_requests (const std::string& collection_id) {
+        return json{ { "type", "request" }, { "collectionId", collection_id } };
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+// Atomicity
+// ---------------------------------------------------------------------------
+
+TEST_F (ReorderRouteTest, AnInvalidMemberWritesNothingAtAll) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+    const std::string c   = make_request (col, "c");
+    ASSERT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2 }));
+
+    // The first two moves are perfectly legal; the third names a row that does
+    // not exist. Nothing may land - including the two that would have.
+    json body{ { "moves",
+    json::array (
+    { move_request (c, 0), move_request (a, 1), move_request ("req_missing", 2) }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 400) << response.dump ();
+    EXPECT_NE (
+    response["error"]["message"].get<std::string> ().find ("req_missing"), std::string::npos)
+    << response.dump ();
+    EXPECT_EQ (request_ids (col), (std::vector<std::string>{ a, b, c }));
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2 }));
+}
+
+TEST_F (ReorderRouteTest, ANormalizationIsAbandonedWhenAMoveIsInvalid) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+    set_request_order (a, 0);
+    set_request_order (b, 0); // The legacy all-zeros shape.
+
+    json body{ { "normalize", json::array ({ normalize_requests (col) }) },
+        { "moves", json::array ({ move_request (b, -1) }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 400) << response.dump ();
+    // The renumber the normalize list would have performed must not survive the
+    // move's rejection: validation completes before the first write.
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 0 }));
+}
+
+// ---------------------------------------------------------------------------
+// Validation - each failure names the row a client can act on
+// ---------------------------------------------------------------------------
+
+TEST_F (ReorderRouteTest, RejectsAMoveIntoACollectionThatDoesNotExist) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+
+    json body{ { "moves",
+    json::array ({ json{ { "type", "request" }, { "id", a }, { "order", 0 },
+    { "collectionId", "col_gone" } } }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 400) << response.dump ();
+    EXPECT_NE (
+    response["error"]["message"].get<std::string> ().find ("col_gone"), std::string::npos);
+    // The row stays where it was rather than being stranded under a missing owner.
+    EXPECT_EQ (db_->get_request (a)->collection_id, col);
+}
+
+TEST_F (ReorderRouteTest, RejectsTwoPositionsForOneRow) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    make_request (col, "b");
+
+    json body{ { "moves", json::array ({ move_request (a, 0), move_request (a, 1) }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 400) << response.dump ();
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find (a), std::string::npos);
+}
+
+TEST_F (ReorderRouteTest, RejectsANonIntegerOrAbsentOrder) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+
+    for (const json& bad : { json (1.5), json ("2"), json (nullptr) }) {
+        json move{ { "type", "request" }, { "id", a }, { "order", bad } };
+        auto [status, response] =
+        reorder_response (*db_, json{ { "moves", json::array ({ move }) } });
+        EXPECT_EQ (status, 400) << bad.dump () << " -> " << response.dump ();
+    }
+    json without{ { "type", "request" }, { "id", a } };
+    auto [status, response] =
+    reorder_response (*db_, json{ { "moves", json::array ({ without }) } });
+    EXPECT_EQ (status, 400) << response.dump ();
+}
+
+TEST_F (ReorderRouteTest, RejectsAnUnknownTypeAndAMalformedNormalizeScope) {
+    const std::string col = make_collection ("Billing");
+
+    auto [type_status, type_body] = reorder_response (*db_,
+    json{ { "moves",
+    json::array ({ json{ { "type", "folder" }, { "id", col }, { "order", 0 } } }) } });
+    EXPECT_EQ (type_status, 400) << type_body.dump ();
+
+    // A collection scope must *state* parentId - absent cannot be read as "the
+    // roots" without a renumber occasionally landing on the wrong folder.
+    auto [scope_status, scope_body] = reorder_response (*db_,
+    json{ { "normalize", json::array ({ json{ { "type", "collection" } } }) } });
+    EXPECT_EQ (scope_status, 400) << scope_body.dump ();
+}
+
+// ---------------------------------------------------------------------------
+// Cycles, validated against the post-move shape
+// ---------------------------------------------------------------------------
+
+TEST_F (ReorderRouteTest, RejectsACycleFormedOnlyByTheBatchAsAWhole) {
+    const std::string a = make_collection ("A");
+    const std::string b = make_collection ("B");
+
+    // Each move alone is legal against the stored shape - A under B is fine
+    // while B is a root, and B under A is fine while A is a root. Together they
+    // are a loop, and only a validator that reads the post-move shape sees it.
+    json body{ { "moves",
+    json::array ({ json{ { "type", "collection" }, { "id", a }, { "order", 0 }, { "parentId", b } },
+    json{ { "type", "collection" }, { "id", b }, { "order", 0 }, { "parentId", a } } }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 400) << response.dump ();
+    EXPECT_FALSE (db_->get_collection (a)->parent_id.has_value ());
+    EXPECT_FALSE (db_->get_collection (b)->parent_id.has_value ());
+}
+
+TEST_F (ReorderRouteTest, RejectsASelfParentAndAMoveIntoOwnDescendant) {
+    const std::string parent = make_collection ("parent");
+    const std::string child  = make_collection ("child", parent);
+
+    auto [self_status, self_body] = reorder_response (*db_,
+    json{ { "moves",
+    json::array ({ json{ { "type", "collection" }, { "id", parent },
+    { "order", 0 }, { "parentId", parent } } }) } });
+    EXPECT_EQ (self_status, 400) << self_body.dump ();
+
+    auto [desc_status, desc_body] = reorder_response (*db_,
+    json{ { "moves",
+    json::array ({ json{ { "type", "collection" }, { "id", parent },
+    { "order", 0 }, { "parentId", child } } }) } });
+    EXPECT_EQ (desc_status, 400) << desc_body.dump ();
+    EXPECT_FALSE (db_->get_collection (parent)->parent_id.has_value ());
+}
+
+TEST_F (ReorderRouteTest, AcceptsAReparentThatBreaksAnExistingChain) {
+    const std::string root = make_collection ("root");
+    const std::string mid  = make_collection ("mid", root);
+    const std::string leaf = make_collection ("leaf", mid);
+
+    // Moving `mid` under `leaf` is only legal because the same batch lifts
+    // `leaf` out to the root first - the post-move shape is root/leaf/mid.
+    json body{ { "moves",
+    json::array ({ json{ { "type", "collection" }, { "id", leaf }, { "order", 0 }, { "parentId", root } },
+    json{ { "type", "collection" }, { "id", mid }, { "order", 0 }, { "parentId", leaf } } }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (*db_->get_collection (leaf)->parent_id, root);
+    EXPECT_EQ (*db_->get_collection (mid)->parent_id, leaf);
+}
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+TEST_F (ReorderRouteTest, NormalizationMaterializesTheDisplayedOrderOfALegacyScope) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+    const std::string c   = make_request (col, "c");
+    for (const auto& id : { a, b, c }) {
+        set_request_order (id, 0); // Every row created before explicit orders existed.
+    }
+    const std::vector<std::string> displayed = request_ids (col);
+
+    auto [status, response] = reorder_response (
+    *db_, json{ { "normalize", json::array ({ normalize_requests (col) }) } });
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    // Dense, and in exactly the order the client was already showing - nothing
+    // may visibly jump when the first drop lands.
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2 }));
+    EXPECT_EQ (request_ids (col), displayed);
+}
+
+TEST_F (ReorderRouteTest, NormalizationIsIdempotent) {
+    const std::string col = make_collection ("Billing");
+    for (const auto& name : { "a", "b", "c" }) {
+        set_request_order (make_request (col, name), 0);
+    }
+    json body{ { "normalize", json::array ({ normalize_requests (col) }) } };
+
+    auto [first_status, first] = reorder_response (*db_, body);
+    ASSERT_EQ (first_status, 200) << first.dump ();
+    EXPECT_EQ (first["requests"].size (), 2u); // The row already at 0 needs no write.
+
+    auto [second_status, second] = reorder_response (*db_, body);
+    ASSERT_EQ (second_status, 200) << second.dump ();
+    // Nothing left to change, so nothing is written - the observable form of
+    // idempotence, and what keeps a repeated normalize off the write path.
+    EXPECT_EQ (second["requests"].size (), 0u);
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2 }));
+}
+
+TEST_F (ReorderRouteTest, NormalizationRunsBeforeTheMovesAndTheMovesWin) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+    const std::string c   = make_request (col, "c");
+    for (const auto& id : { a, b, c }) {
+        set_request_order (id, 0);
+    }
+
+    // The first drop into a legacy collection: normalize to 0,1,2 and, in the
+    // same batch, move `c` to the head - which is only expressible because the
+    // renumber gave the other two real slots to shift into.
+    json body{ { "normalize", json::array ({ normalize_requests (col) }) },
+        { "moves",
+        json::array ({ move_request (c, 0), move_request (a, 1), move_request (b, 2) }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (request_ids (col), (std::vector<std::string>{ c, a, b }));
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2 }));
+}
+
+TEST_F (ReorderRouteTest, NormalizesTheRootCollectionsWhenParentIdIsNull) {
+    const std::string a     = make_collection ("A");
+    const std::string b     = make_collection ("B");
+    const std::string child = make_collection ("child", a);
+
+    auto root_row   = db_->get_collection (b);
+    root_row->order = 0; // Tie the two roots, the pre-#360 shape.
+    db_->create_collection (*root_row);
+
+    auto [status, response] = reorder_response (*db_,
+    json{ { "normalize",
+    json::array ({ json{ { "type", "collection" }, { "parentId", nullptr } } }) } });
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (db_->get_collection (a)->order, 0);
+    EXPECT_EQ (db_->get_collection (b)->order, 1);
+    // A nested collection is in a different scope and must be left alone.
+    EXPECT_EQ (db_->get_collection (child)->order, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Moves
+// ---------------------------------------------------------------------------
+
+TEST_F (ReorderRouteTest, AnAdjacentSwapWritesExactlyTwoRows) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+    make_request (col, "c");
+
+    auto [status, response] = reorder_response (*db_,
+    json{ { "moves", json::array ({ move_request (b, 0), move_request (a, 1) }) } });
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (response["requests"].size (), 2u);
+    EXPECT_EQ (response["collections"].size (), 0u);
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2 }));
+    EXPECT_EQ (request_ids (col)[0], b);
+}
+
+TEST_F (ReorderRouteTest, MovesARequestAcrossCollectionsInOneBatch) {
+    const std::string source = make_collection ("source");
+    const std::string target = make_collection ("target");
+    const std::string a      = make_request (source, "a");
+    const std::string b      = make_request (source, "b");
+    const std::string t      = make_request (target, "t");
+
+    // `a` lands at the head of `target`; `t` shifts down; `b` closes the gap.
+    json body{ { "moves",
+    json::array ({ json{ { "type", "request" }, { "id", a }, { "order", 0 }, { "collectionId", target } },
+    move_request (t, 1), move_request (b, 0) }) } };
+    auto [status, response] = reorder_response (*db_, body);
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (request_ids (source), (std::vector<std::string>{ b }));
+    EXPECT_EQ (request_ids (target), (std::vector<std::string>{ a, t }));
+    EXPECT_EQ (request_orders (source), (std::vector<int>{ 0 }));
+    EXPECT_EQ (request_orders (target), (std::vector<int>{ 0, 1 }));
+}
+
+TEST_F (ReorderRouteTest, AMoveWithoutAnOwnerKeepsTheOneItHas) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+
+    auto [status, response] = reorder_response (
+    *db_, json{ { "moves", json::array ({ move_request (a, 7) }) } });
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (db_->get_request (a)->collection_id, col);
+    EXPECT_EQ (db_->get_request (a)->order, 7);
+}
+
+TEST_F (ReorderRouteTest, AnEmptyBatchIsANoOp) {
+    const std::string col = make_collection ("Billing");
+    make_request (col, "a");
+
+    auto [status, response] = reorder_response (*db_, json::object ());
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (response["collections"].size (), 0u);
+    EXPECT_EQ (response["requests"].size (), 0u);
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0 }));
+}
+
+TEST_F (ReorderRouteTest, TheResponseCarriesTheRowsAsWritten) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+
+    auto [status, response] = reorder_response (*db_,
+    json{ { "moves", json::array ({ move_request (b, 0), move_request (a, 1) }) } });
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    // The client draws the drop optimistically and settles its caches on these
+    // rows, so they must be the full serialized shape a list entry carries.
+    for (const auto& row : response["requests"]) {
+        ASSERT_TRUE (row.contains ("id")) << row.dump ();
+        EXPECT_EQ (row["collectionId"].get<std::string> (), col);
+        EXPECT_EQ (row["order"].get<int> (), db_->get_request (row["id"])->order);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interleaving with a concurrent create
+// ---------------------------------------------------------------------------
+
+TEST_F (ReorderRouteTest, ACreateAfterABatchAppendsPastItRatherThanIntoIt) {
+    const std::string col = make_collection ("Billing");
+    for (const auto& name : { "a", "b", "c" }) {
+        set_request_order (make_request (col, name), 0);
+    }
+
+    auto [status, response] = reorder_response (
+    *db_, json{ { "normalize", json::array ({ normalize_requests (col) }) } });
+    ASSERT_EQ (status, 200) << response.dump ();
+
+    // The create's append scan reads `max_order + 1` under the same DB mutex the
+    // batch committed under, so it cannot tie with a row inside the dense range.
+    const std::string late = make_request (col, "late");
+    EXPECT_EQ (db_->get_request (late)->order, 3);
+    EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2, 3 }));
+    EXPECT_EQ (request_ids (col).back (), late);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Phase 1 of the drag-and-reorder track (#364): the write path a drop needs, and nothing above it. No UI - that is sub 3 (#367).

**Plan (root cause, approach, rejected alternative).** The root cause is that the only write verbs are one row per `PUT`, so a drop that displaces N siblings is N sequential requests: non-atomic (a crash mid-sequence leaves two rows at one `order` and a gap where the moved one was - a shape no read repairs, because the tie rule then decides the display), racy against a concurrent create computing `max_order + 1` between two of them, TOCTOU-exposed for concurrent reparents (`PUT /collections/:id` validates its cycle guard and writes under different locks), and an invalidation storm client-side. The approach is one `POST /reorder` that validates the whole batch - including the acyclicity of the **post-move** graph - and writes it in a single `storage.transaction` under the DB mutex, copying `import_apply`'s shape. The alternative I rejected is the one the parent issue already rejected for a different reason and which is also tempting here: making the *renderer* smarter about batching `PUT`s (a queue, a debounce, a retry). It fixes none of the four defects - atomicity, the create race and the TOCTOU window are all properties of the lock scope, not of the caller's pacing - so it would be exactly the stopgap `CLAUDE.md` forbids. Fractional orders were rejected in the parent (decision 5): they need a schema rebuild through sqlite_orm.

**Verified against live code first.** The problem is as #365 describes it, at `0111b14`. #360 and #361 both landed, so the two type gaps this endpoint's single-row fallback needs are already there: `UpdateRequestRequest.collectionId` and `UpdateCollectionRequest.parentId: string | null` (`types/api.ts:108-178`) - no change needed, confirmed rather than assumed. The pinned tiebreak this normalizes into is #360's `order, created_at, id` (`database.cpp:596-606`, `:678-684`).

### Engine - `POST /reorder`

Order of business is fixed and load-bearing:

1. **Everything is validated first.** Entry shapes, that every named row and owner is stored, no duplicate move, and the acyclicity of the post-move collection graph. A failure is a `400` naming the offending row with **nothing written**.
2. **`normalize` renumbers, then `moves` position**, the move winning where a row is named by both.
3. **One transaction** (`Database::apply_reorder`) under the DB mutex, so the validation above and the write share a lock scope - which is what closes the read-then-write race the per-row cycle guard still has.

Two deliberate divergences from the single-row endpoints, both because their reason does not apply here:

- **A stated owner must exist.** `apply_collection_fields` deliberately tolerates an unresolvable `parentId` because bulk import writes rows that cannot see each other yet. Nothing in a reorder is bulk-created, so an owner that resolves to no row is a client bug, and stranding a subtree under it is the same defect #360 fixed for requests.
- **A collection `normalize` scope must *state* `parentId`** (`null` for the roots) rather than omitting it. Absent would have to mean either "the roots" or "whatever you infer", and a renumber that silently picked the wrong scope is a whole folder reshuffled.

Normalization writes only the rows whose position actually changes, which makes idempotence observable: a second call over a dense scope writes zero rows.

### App

- **`modules/collections/reorder-math.ts`** - pure, node-tested. `planCollectionMove` / `planRequestMove` turn sibling lists (in the order the tree displays them) and a drop index into the **minimal** batch: dense renumber only when the list is not already dense, an adjacent swap writes two rows, a cross-scope move writes only the tail of the source and the tail of the target. The all-zero legacy input is the primary case. A drop index past the end clamps (a legitimate "put it at the end" gesture); a fractional index or a row that is not in the list it claims to be in throws.
- **`useReorderMutation`** - `onMutate` snapshots every key the plan can touch and draws the plan into the caches (the same two steps the engine performs), `onSuccess` re-applies the rows the engine actually wrote, `onError` restores the snapshots and reports through `useSaveStore.failSave`, `onSettled` invalidates the affected keys **once**. Every cache write goes through `setQueryData` with a fresh array - the map `useMultipleCollectionRequests` builds is compared by reference by the reveal effect, so an in-place edit would move a row on screen the tree never notices.
- **The response is read, not discarded.** It carries the rows as written, and `onSuccess` settles on them, so a normalization the engine performed is visible without waiting for the refetch. That is why it is the rows rather than a count - a count would have been a field with no reader.

**MCP: none.** MCP has no reorder tool (verified - no match for "reorder" under `app/electron/mcp/`). One added later reuses this endpoint rather than looping `PUT`s.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

All green locally on `0111b14 + this branch`. No pre-existing failures.

| Suite | Result |
|---|---|
| `python build.py -e -t` | clean build, no warnings |
| `ctest --preset linux-dev --output-on-failure` | **974 passed, 0 failed** (19 new in `reorder_route_test.cpp`) |
| `pnpm test` | **2823 passed, 0 failed** (19 new in `reorder-math.test.ts`, 9 new in `reorder-mutation.test.tsx`) |
| `pnpm type-check` / `pnpm lint` / `prettier --check` (touched files) | clean |
| `clang-format --dry-run -Werror` (new C++) | clean |
| `mkdocs build --strict` | clean |

**Mutation checks** - each reverted, the build/suite re-run, then restored:

| Reverted | Reddens |
|---|---|
| the post-move cycle check | `RejectsACycleFormedOnlyByTheBatchAsAWhole`, `RejectsASelfParentAndAMoveIntoOwnDescendant` |
| normalization's "only changed rows" filter | `NormalizationIsIdempotent` |
| normalize-before-moves ordering | `NormalizationRunsBeforeTheMovesAndTheMovesWin` |
| `onMutate`'s optimistic draw | 4 tests in "draws the drop before the write returns" |
| `onError`'s snapshot restore | 2 tests in "rolls back a failed drop" |
| `onSuccess`'s settle on the response | "takes the engine's positions over the ones it drew" |
| `onSettled`'s targeted invalidation | "invalidates both sides of a cross-collection move" |

The engine tests check **stored positions** on every failure case, not just the status code - that is the assertion that would have caught the half-renumber the per-row path leaves behind. The math tests assert the *arrangement* a plan produces (replayed the way the engine applies it) rather than the raw move list, so an off-by-one in a shift range cannot pass by looking plausible.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the `POST /reorder` section, plus the Ordering section's concurrency caveat, which said this endpoint did not exist yet), `docs/app/state-management.md` (the mutation and its three-pass cache strategy), `docs/app/api-integration.md` (`apiService.reorder`, the endpoint constant), `docs/app/COMPONENTS.md` (`reorder-math.ts`).

## Related Issues
Closes #365

Unblocks #366 (sub 2, the decomposition) and #367 (sub 3, the interaction, which consumes this endpoint). Sub-issue of #364.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwU7LMy4vFf7ZQZH3BA7zp)_