### PR TITLE
fix(app/save-status): route every save success through completeSaveThenIdle

### DIFF
--- a/app/src/components/layout/ContextBar.save-status.test.tsx
+++ b/app/src/components/layout/ContextBar.save-status.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A committed variable used to leave "Saved" in the Dock forever.
+ *
+ * The context bar is the app's one non-draft commit path: it fires the mutation
+ * on blur and reported success with a bare `completeSave()` - `saved`, and no
+ * reset armed at all. Nothing else was going to clear it, so the Dock kept
+ * claiming a save that had happened minutes ago until some unrelated surface
+ * published a status of its own. It reports through `completeSaveThenIdle` now,
+ * like every other saving surface, which also means it cannot stomp a failure
+ * that arrives in the two seconds after.
+ *
+ * The harness is `ContextBar.save-error.test.tsx`'s.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { TIMING } from "@/config/timing";
+import { ContextBar } from "./ContextBar";
+import { TooltipProvider } from "@/components/ui";
+import { queryKeys } from "@/queries/keys";
+import { useSaveStore } from "@/stores/save-store";
+import { useToastStore } from "@/stores/toast-store";
+import type { ResolvedVariable } from "@/types";
+
+const globalsMutate = vi.fn(
+	(_payload: unknown, opts: { onSuccess?: () => void; onSettled: () => void }) => {
+		opts.onSuccess?.();
+		opts.onSettled();
+	}
+);
+
+vi.mock("@/queries", () => ({
+	useRequestQuery: () => ({ data: { id: "req_1", collectionId: null } }),
+	useUpdateGlobalsMutation: () => ({ mutate: globalsMutate }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+}));
+
+const resolved: Record<string, ResolvedVariable> = {
+	host: { value: "example.com", scope: "global" },
+};
+
+vi.mock("@/hooks/useVariableResolver", () => ({
+	useVariableResolver: () => ({ getAllVariables: () => resolved }),
+}));
+
+const layoutStore = {
+	contextBarOpen: true,
+	setContextBarOpen: vi.fn(),
+	contextBarWidth: 280,
+	setContextBarWidth: vi.fn(),
+};
+const tabsStore = {
+	openTabs: [{ id: "t1", type: "request", entityId: "req_1" }],
+	activeTabId: "t1",
+};
+
+vi.mock("@/stores", async () => {
+	const saveStore =
+		await vi.importActual<typeof import("@/stores/save-store")>("@/stores/save-store");
+	return {
+		useLayoutStore: () => layoutStore,
+		useTabsStore: () => tabsStore,
+		useSaveStore: saveStore.useSaveStore,
+	};
+});
+
+function renderBar() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	client.setQueryData(queryKeys.globals.all, {
+		id: "globals",
+		updatedAt: "",
+		variables: {
+			host: { value: "example.com", enabled: true, secret: false, type: "string" },
+		},
+	});
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<ContextBar />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+/** Commit an edit to the one variable on screen. */
+function commitOnce() {
+	renderBar();
+	const input = screen.getByDisplayValue("example.com") as HTMLInputElement;
+	act(() => {
+		fireEvent.change(input, { target: { value: "example.org" } });
+		fireEvent.blur(input);
+	});
+	expect(globalsMutate).toHaveBeenCalledTimes(1);
+	expect(useSaveStore.getState().status).toBe("saved");
+}
+
+describe("the status a context-bar commit publishes", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		globalsMutate.mockClear();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns the Dock to idle instead of leaving 'Saved' up indefinitely", async () => {
+		commitOnce();
+
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("leaves a failure that arrived meanwhile on screen", async () => {
+		commitOnce();
+
+		act(() => useSaveStore.getState().failSave("delete failed"));
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+});

--- a/app/src/components/layout/ContextBar.tsx
+++ b/app/src/components/layout/ContextBar.tsx
@@ -112,7 +112,9 @@ function usePendingCommits(): () => () => void {
 			// A failed commit already reported itself through `failSave`; painting
 			// "Saved" over it is the same defect `runSave` guards against in the
 			// save store.
-			if (useSaveStore.getState().status !== "error") useSaveStore.getState().completeSave();
+			if (useSaveStore.getState().status !== "error") {
+				useSaveStore.getState().completeSaveThenIdle();
+			}
 		};
 	}, [updateContext]);
 }

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -30,10 +30,16 @@ export const TIMING = {
 	 * granularity the formatter has (a minute), which is all it needs to be.
 	 */
 	RELATIVE_TIME_TICK_MS: 30_000,
-	/** How long the "Saved" indicator stays visible after a save. */
+	/**
+	 * How long the "Saved" indicator stays visible after a save.
+	 *
+	 * Read in exactly one place - `completeSaveThenIdle` in `save-store.ts`, which
+	 * is the only way a success is reported - so every saving surface in the app
+	 * shows it for the same time.
+	 */
 	SAVED_STATUS_DURATION_MS: 3000,
 
-	/** Transient status feedback (copied / saved / error chips) reset delay. */
+	/** Transient in-component status feedback (the response viewer's copy tick). */
 	STATUS_RESET_MS: 2000,
 
 	/**

--- a/app/src/hooks/useSaveManager.status-stomp.test.tsx
+++ b/app/src/hooks/useSaveManager.status-stomp.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * An auto-save's "Saved" must not take an unrelated failure down with it.
+ *
+ * `performSave` reported success as `completeSave()` plus its own
+ * `setTimeout(() => setStatus("idle"))`. That timer fired regardless of what
+ * had happened since: a failed delete published to the Dock in the meantime was
+ * simply erased, leaving the Dock blank beside the failure's toast. It goes
+ * through `completeSaveThenIdle` now, which resets only its own `saved`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { TIMING } from "@/config/timing";
+import { useClientSettingsStore } from "@/stores";
+import { useSaveStore } from "@/stores/save-store";
+import { useToastStore } from "@/stores/toast-store";
+import { useSaveManager } from "./useSaveManager";
+
+function mountManager(onSave: () => Promise<void>) {
+	return renderHook(() =>
+		useSaveManager({ entityId: "req_1", contextName: "Request", onSave, hasChanges: true })
+	);
+}
+
+describe("the status timer a request save arms", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+		// Auto-save off, so the only save in the test is the explicit one.
+		useClientSettingsStore.setState({ autoSave: { enabled: false, delayMs: 5000 } });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function saveOnce() {
+		const { result } = mountManager(() => Promise.resolve());
+		await act(async () => {
+			await result.current.forceSave();
+		});
+		expect(useSaveStore.getState().status).toBe("saved");
+	}
+
+	it("returns the Dock to idle when nothing else has happened", async () => {
+		await saveOnce();
+
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("leaves a failure that arrived meanwhile on screen", async () => {
+		await saveOnce();
+
+		// Anything else failing before the timer fires - a delete in the tree, a
+		// settings write. The Dock is showing that error now.
+		act(() => useSaveStore.getState().failSave("delete failed"));
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+});

--- a/app/src/hooks/useSaveManager.ts
+++ b/app/src/hooks/useSaveManager.ts
@@ -18,9 +18,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import { useSaveStore } from "@/stores/save-store";
 import { useClientSettingsStore } from "@/stores";
-import { TIMING } from "@/config/timing";
-
-const { SAVED_STATUS_DURATION_MS } = TIMING;
 
 interface UseSaveManagerOptions {
 	/** Unique identifier for this save context (e.g., request ID) */
@@ -55,9 +52,8 @@ export function useSaveManager({
 		status,
 		markPendingSave,
 		startSaving,
-		completeSave,
+		completeSaveThenIdle,
 		failSave,
-		setStatus,
 		reset,
 		registerContext,
 		unregisterContext,
@@ -69,7 +65,6 @@ export function useSaveManager({
 	const autoSaveDelayMs = useClientSettingsStore((s) => s.autoSave.delayMs);
 
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-	const savedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 	// Saves are queued, never dropped - see performSave.
 	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
 	const onSaveRef = useRef(onSave);
@@ -91,15 +86,15 @@ export function useSaveManager({
 		enabledRef.current = enabled;
 	}, [enabled]);
 
-	// Clear timeouts on unmount
+	// Clear the pending auto-save on unmount. The "saved" indicator's own reset
+	// is the store's now, and deliberately survives this component: the Dock
+	// outlives the request pane, so the status it is showing has to be cleared by
+	// whoever set it, not by whichever pane happened to unmount.
 	useEffect(() => {
 		return () => {
 			if (timeoutRef.current) {
 				clearTimeout(timeoutRef.current);
 				timeoutRef.current = null;
-			}
-			if (savedTimeoutRef.current) {
-				clearTimeout(savedTimeoutRef.current);
 			}
 		};
 	}, []);
@@ -131,15 +126,7 @@ export function useSaveManager({
 			startSaving();
 			try {
 				await save();
-				completeSave();
-
-				// Reset to idle after showing "saved" status
-				if (savedTimeoutRef.current) {
-					clearTimeout(savedTimeoutRef.current);
-				}
-				savedTimeoutRef.current = setTimeout(() => {
-					setStatus("idle");
-				}, SAVED_STATUS_DURATION_MS);
+				completeSaveThenIdle();
 			} catch (error) {
 				console.error("Save failed:", error);
 				failSave(error instanceof Error ? error.message : "Save failed");
@@ -147,7 +134,7 @@ export function useSaveManager({
 		});
 		saveQueueRef.current = run;
 		return run;
-	}, [entityId, startSaving, completeSave, failSave, setStatus]);
+	}, [entityId, startSaving, completeSaveThenIdle, failSave]);
 
 	// Register/unregister with centralized save context
 	useEffect(() => {

--- a/app/src/modules/collections/CollectionTree.rename.test.tsx
+++ b/app/src/modules/collections/CollectionTree.rename.test.tsx
@@ -19,9 +19,8 @@
  * already had.
  *
  * The third case is the status timer: both paths armed a bare
- * `setTimeout(() => setStatus("idle"))`, which fires two seconds later no matter
- * what happened in between - clearing a failure another surface had published to
- * the Dock.
+ * `setTimeout(() => setStatus("idle"))`, which fires no matter what happened in
+ * between - clearing a failure another surface had published to the Dock.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -181,7 +180,7 @@ describe("the status timer a rename arms", () => {
 
 		await waitFor(() => expect(useSaveStore.getState().status).toBe("saved"));
 		await act(async () => {
-			vi.advanceTimersByTime(TIMING.STATUS_RESET_MS);
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
 		});
 
 		expect(useSaveStore.getState().status).toBe("idle");
@@ -198,7 +197,7 @@ describe("the status timer a rename arms", () => {
 		// editor's autosave. The Dock is now showing that error.
 		act(() => useSaveStore.getState().failSave("delete failed"));
 		await act(async () => {
-			vi.advanceTimersByTime(TIMING.STATUS_RESET_MS);
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
 		});
 
 		// The rename's timer used to clear it and leave the Dock saying nothing at

--- a/app/src/modules/settings/main/SettingsMain.category-switch.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.category-switch.test.tsx
@@ -82,7 +82,7 @@ const setStatus = vi.fn();
 vi.mock("@/stores/save-store", () => ({
 	useSaveStore: () => ({
 		startSaving: vi.fn(),
-		completeSave: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
 		failSave: vi.fn(),
 		setStatus: (...args: unknown[]) => setStatus(...args),
 		markPendingSave: vi.fn(),

--- a/app/src/modules/settings/main/SettingsMain.enum.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.enum.test.tsx
@@ -86,7 +86,7 @@ vi.mock("@/stores/save-store", () => ({
 	// one it calls, which is easy to mistake for a defect in the component.
 	useSaveStore: () => ({
 		startSaving: vi.fn(),
-		completeSave: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
 		failSave: vi.fn(),
 		setStatus: vi.fn(),
 		markPendingSave: vi.fn(),

--- a/app/src/modules/settings/main/SettingsMain.restart-banner.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.restart-banner.test.tsx
@@ -63,7 +63,7 @@ vi.mock("@/modules/settings/settings-store", () => ({
 vi.mock("@/stores/save-store", () => ({
 	useSaveStore: () => ({
 		startSaving: vi.fn(),
-		completeSave: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
 		failSave: vi.fn(),
 		setStatus: vi.fn(),
 		markPendingSave: vi.fn(),

--- a/app/src/modules/settings/main/SettingsMain.status-stomp.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.status-stomp.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A settings write's "Saved" must not take an unrelated failure down with it.
+ *
+ * `saveEntries` reported success as `completeSave()` plus its own
+ * `setTimeout(() => setStatus("idle"))` - the same unguarded timer the panel's
+ * *other* status bug was about, where an unconditional `setStatus("idle")` on
+ * every clean render wiped an error just by opening Settings. The pending
+ * tracking (`markedPendingRef`) fixed that one; this is the success path, and it
+ * goes through `completeSaveThenIdle` now.
+ *
+ * The panel is driven through the category-switch flush rather than the Save
+ * button because it is the same `saveEntries` call and needs no mocked click
+ * target - see `SettingsMain.category-switch.test.tsx`, whose harness this is.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { TIMING } from "@/config/timing";
+import { useSaveStore } from "@/stores/save-store";
+import { useToastStore } from "@/stores/toast-store";
+import SettingsMain from "./SettingsMain";
+
+const entries = [
+	{
+		key: "max_connections",
+		label: "Max connections",
+		description: "Upper bound on concurrent connections",
+		type: "integer" as const,
+		value: "10",
+		default: "10",
+		category: "network_performance",
+		min: "1",
+		max: "100",
+		updatedAt: 0,
+	},
+];
+
+const mutateAsync = vi.fn((_payload: { entries: Record<string, string> }) => Promise.resolve({}));
+
+vi.mock("@/queries", () => ({
+	useConfigQuery: () => ({ data: { entries }, isLoading: false, error: null }),
+	useUpdateConfigMutation: () => ({ mutateAsync, isPending: false }),
+}));
+
+vi.mock("@/modules/settings/settings-store", () => ({
+	useSettingsStore: () => ({ selectedCategory: "network_performance", restartRequiredKeys: [] }),
+}));
+
+vi.mock("@/stores", () => ({
+	useEngineStore: () => ({
+		isEngineConnected: true,
+		pendingRestart: false,
+		restartRequiredKeys: [],
+		addRestartRequiredKey: vi.fn(),
+		clearRestartRequired: vi.fn(),
+	}),
+}));
+
+// `@/stores/save-store` is deliberately not mocked: the status this panel
+// publishes is the whole subject, and the panel imports it from there directly.
+
+function Panel() {
+	return (
+		<QueryClientProvider client={new QueryClient()}>
+			<SettingsMain />
+		</QueryClientProvider>
+	);
+}
+
+/** Edit a value, then unmount - the cleanup flushes it through `saveEntries`. */
+async function saveOnce() {
+	const { unmount } = render(<Panel />);
+	fireEvent.change(screen.getByLabelText("Max connections"), { target: { value: "42" } });
+	await act(async () => {
+		unmount();
+	});
+	expect(mutateAsync).toHaveBeenCalledTimes(1);
+	expect(useSaveStore.getState().status).toBe("saved");
+}
+
+describe("the status timer a settings write arms", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		mutateAsync.mockClear();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns the Dock to idle when nothing else has happened", async () => {
+		await saveOnce();
+
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("leaves a failure that arrived meanwhile on screen", async () => {
+		await saveOnce();
+
+		act(() => useSaveStore.getState().failSave("delete failed"));
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+});

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -104,7 +104,7 @@ export default function SettingsMain() {
 		useEngineStore();
 	const {
 		startSaving,
-		completeSave,
+		completeSaveThenIdle,
 		failSave,
 		setStatus,
 		markPendingSave,
@@ -217,15 +217,12 @@ export default function SettingsMain() {
 					}
 					return next;
 				});
-				completeSave();
+				completeSaveThenIdle();
 
 				// Track restart-required configs
 				for (const key of restartKeys) {
 					addRestartRequiredKey(key);
 				}
-
-				// Reset to idle after showing "saved" status
-				setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
 			} catch (err) {
 				console.error("Failed to save settings:", err);
 				failSave(err instanceof Error ? err.message : "Failed to save settings");
@@ -235,9 +232,8 @@ export default function SettingsMain() {
 			configResponse,
 			updateConfigMutation,
 			startSaving,
-			completeSave,
+			completeSaveThenIdle,
 			failSave,
-			setStatus,
 			addRestartRequiredKey,
 		]
 	);

--- a/app/src/modules/settings/main/SettingsMain.validation.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.validation.test.tsx
@@ -69,7 +69,7 @@ vi.mock("@/stores/save-store", () => ({
 	// one it calls, which is easy to mistake for a defect in the component.
 	useSaveStore: () => ({
 		startSaving: vi.fn(),
-		completeSave: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
 		failSave: vi.fn(),
 		setStatus: vi.fn(),
 		markPendingSave: vi.fn(),

--- a/app/src/modules/variables/main/VariableTableEditor.status-stomp.test.tsx
+++ b/app/src/modules/variables/main/VariableTableEditor.status-stomp.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A variable save's "Saved" must not take an unrelated failure down with it.
+ *
+ * `finishSave` reported success as `completeSave()` plus its own
+ * `setTimeout(() => setStatus("idle"))`, which fired regardless of what had
+ * happened since - clearing an error another surface had published to the Dock,
+ * or a `pending` from an edit typed in the meantime. It goes through
+ * `completeSaveThenIdle` now, which resets only its own `saved`.
+ *
+ * The harness is `concurrent-edit-clobber.test.tsx`'s, with the real save store
+ * in place of the mocked one.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, screen, act } from "@testing-library/react";
+
+import { TIMING } from "@/config/timing";
+import { TooltipProvider } from "@/components/ui";
+import { useSaveStore } from "@/stores/save-store";
+import { useToastStore } from "@/stores/toast-store";
+import VariableTableEditor from "./VariableTableEditor";
+import type { Collection, VariableValue } from "@/types";
+
+interface MutateOptions {
+	onSuccess: () => void;
+	onError: (error: Error) => void;
+}
+
+/** The save in flight - resolved by hand, so the test owns when it lands. */
+let pendingSave: { opts: MutateOptions };
+const updateCollection = vi.fn((_payload: unknown, opts: MutateOptions) => {
+	pendingSave = { opts };
+});
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: undefined, isLoading: false, error: null }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+	useSetActiveEnvironmentMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+	useDeleteEnvironmentMutation: () => ({
+		mutate: vi.fn(),
+		mutateAsync: vi.fn(),
+		isPending: false,
+	}),
+	useUpdateCollectionMutation: () => ({
+		mutate: (...args: unknown[]) =>
+			updateCollection(...(args as Parameters<typeof updateCollection>)),
+		mutateAsync: vi.fn(),
+	}),
+}));
+
+const sessionStore = { activeEnvironmentId: null, setActiveEnvironmentId: vi.fn() };
+
+// The editor reads the save store through `@/stores`, so the barrel is mocked
+// with the real store rather than a set of spies.
+vi.mock("@/stores", async () => {
+	const saveStore =
+		await vi.importActual<typeof import("@/stores/save-store")>("@/stores/save-store");
+	return {
+		useSaveStore: saveStore.useSaveStore,
+		useSessionStore: Object.assign(() => sessionStore, { getState: () => sessionStore }),
+	};
+});
+
+vi.mock("@/modules/variables/variables-store", () => ({
+	useVariablesStore: () => ({ selectedCategory: null, setSelectedCategory: vi.fn() }),
+}));
+
+const collection: Collection = {
+	id: "col_1",
+	name: "demo",
+	description: "",
+	order: 0,
+	variables: {
+		host: {
+			value: "example.com",
+			enabled: true,
+			secret: false,
+			type: "string",
+			createdAt: 1000,
+		} as VariableValue,
+	},
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: new Date(0).toISOString(),
+	updatedAt: new Date(0).toISOString(),
+};
+
+/** Edit a row and blur it, which is what starts a save, then land the save. */
+function saveOnce() {
+	render(
+		<TooltipProvider>
+			<VariableTableEditor config={{ type: "collection", collection }} />
+		</TooltipProvider>
+	);
+
+	const [hostValue] = screen.getAllByPlaceholderText("value") as HTMLInputElement[];
+	fireEvent.change(hostValue, { target: { value: "example.org" } });
+	fireEvent.blur(hostValue);
+	expect(updateCollection).toHaveBeenCalledTimes(1);
+
+	act(() => pendingSave.opts.onSuccess());
+	expect(useSaveStore.getState().status).toBe("saved");
+}
+
+describe("the status timer a variable save arms", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		updateCollection.mockClear();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns the Dock to idle when nothing else has happened", async () => {
+		saveOnce();
+
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("leaves a failure that arrived meanwhile on screen", async () => {
+		saveOnce();
+
+		act(() => useSaveStore.getState().failSave("delete failed"));
+		await act(async () => {
+			vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+		});
+
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+});

--- a/app/src/modules/variables/main/VariableTableEditor.tsx
+++ b/app/src/modules/variables/main/VariableTableEditor.tsx
@@ -56,7 +56,6 @@ import {
 	TooltipIconButton,
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
-import { TIMING } from "@/config/timing";
 import type { VariableType } from "@/lib/variable-cast";
 
 const VARIABLE_TYPES: { value: VariableType; label: string }[] = [
@@ -191,9 +190,8 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 		setActiveContext,
 		markPendingSave,
 		startSaving,
-		completeSave,
+		completeSaveThenIdle,
 		failSave,
-		setStatus,
 	} = useSaveStore();
 
 	const [variables, setVariables] = useState<VariableRow[]>([]);
@@ -282,10 +280,9 @@ export default function VariableEditor({ config, embedded = false }: VariableEdi
 				hasPendingChangesRef.current = false;
 				setHasPendingChanges(false);
 			}
-			completeSave();
-			setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS);
+			completeSaveThenIdle();
 		},
-		[completeSave, setStatus]
+		[completeSaveThenIdle]
 	);
 
 	// Auto-save function (payload order by createdAt so round-trip preserves order)

--- a/app/src/modules/variables/main/concurrent-edit-clobber.test.tsx
+++ b/app/src/modules/variables/main/concurrent-edit-clobber.test.tsx
@@ -76,7 +76,7 @@ const saveStore = {
 	setActiveContext: vi.fn(),
 	markPendingSave: vi.fn(),
 	startSaving: vi.fn(),
-	completeSave: vi.fn(),
+	completeSaveThenIdle: vi.fn(),
 	failSave: vi.fn(),
 	setStatus: vi.fn(),
 };

--- a/app/src/modules/variables/main/created-at-ordering.test.tsx
+++ b/app/src/modules/variables/main/created-at-ordering.test.tsx
@@ -63,7 +63,7 @@ vi.mock("@/stores", () => ({
 		setActiveContext: vi.fn(),
 		markPendingSave: vi.fn(),
 		startSaving: vi.fn(),
-		completeSave: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
 		failSave: vi.fn(),
 		setStatus: vi.fn(),
 	}),

--- a/app/src/modules/variables/main/focus-ring-clipping.test.tsx
+++ b/app/src/modules/variables/main/focus-ring-clipping.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@/stores", () => ({
 		setActiveContext: vi.fn(),
 		markPendingSave: vi.fn(),
 		startSaving: vi.fn(),
-		completeSave: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
 		failSave: vi.fn(),
 		setStatus: vi.fn(),
 	}),

--- a/app/src/stores/save-store.test.ts
+++ b/app/src/stores/save-store.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The store holds one status for the whole app, so the rule is that only the
+ * context which set a status clears it.
+ *
+ * `completeSaveThenIdle` is where that rule lives for a *success*, and it has
+ * two halves. The status check keeps its reset off anything another surface
+ * published in the meantime - the failure case below is what the Dock looked
+ * like before: blank, next to a toast about a failure that had just happened.
+ * The generation check keeps it off a *later* save's "saved", which is the half
+ * `useSaveManager` used to hand-roll by clearing its own timer before arming the
+ * next one; the four other callers never had it at all.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { TIMING } from "@/config/timing";
+import { useSaveStore } from "./save-store";
+import { useToastStore } from "./toast-store";
+
+describe("completeSaveThenIdle", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useSaveStore.setState({ status: "idle", contexts: new Map(), activeContextId: null });
+		useToastStore.setState({ toasts: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("shows 'saved' and returns to idle once nothing else has happened", () => {
+		useSaveStore.getState().completeSaveThenIdle();
+		expect(useSaveStore.getState().status).toBe("saved");
+
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS - 1);
+		expect(useSaveStore.getState().status).toBe("saved");
+
+		vi.advanceTimersByTime(1);
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+
+	it("leaves a failure another context published on screen", () => {
+		useSaveStore.getState().completeSaveThenIdle();
+
+		useSaveStore.getState().failSave("delete failed");
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+
+		expect(useSaveStore.getState().status).toBe("error");
+	});
+
+	it("leaves a 'pending' from an edit made since", () => {
+		// "Unsaved changes" in the Dock is the only thing in the app that says so
+		// when auto-save is off, and it is not this save's to clear.
+		useSaveStore.getState().completeSaveThenIdle();
+
+		useSaveStore.getState().markPendingSave();
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS);
+
+		expect(useSaveStore.getState().status).toBe("pending");
+	});
+
+	it("does not let an earlier save cut a later one's indicator short", () => {
+		useSaveStore.getState().completeSaveThenIdle();
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS / 2);
+
+		// A second save lands while the first indicator is still up. It gets the
+		// full duration, measured from itself.
+		useSaveStore.getState().completeSaveThenIdle();
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS / 2);
+		expect(useSaveStore.getState().status).toBe("saved");
+
+		vi.advanceTimersByTime(TIMING.SAVED_STATUS_DURATION_MS / 2);
+		expect(useSaveStore.getState().status).toBe("idle");
+	});
+});

--- a/app/src/stores/save-store.ts
+++ b/app/src/stores/save-store.ts
@@ -75,16 +75,16 @@ interface SaveState {
 	setStatus: (status: SaveStatus) => void;
 	markPendingSave: () => void;
 	startSaving: () => void;
-	completeSave: () => void;
 	/**
-	 * `completeSave`, plus the return to `idle` that every caller wants after it -
-	 * and the guard that only the context which set a status clears it.
+	 * Report a successful save: `saved`, then back to `idle` once the indicator
+	 * has been on screen for `TIMING.SAVED_STATUS_DURATION_MS`.
 	 *
-	 * A bare `setTimeout(() => setStatus("idle"))` fires two seconds later
+	 * This is the only way to report a success, because the reset is the half
+	 * every caller got wrong. A bare `setTimeout(() => setStatus("idle"))` fires
 	 * regardless of what happened in between, so it clears a failure another
 	 * surface published to the Dock, or wipes a `pending` from an edit made since.
-	 * `triggerSave` has always guarded its own reset this way; the callers that
-	 * hand-rolled the timer did not.
+	 * `triggerSave` has always guarded its own reset this way; the five callers
+	 * that hand-rolled the timer did not.
 	 */
 	completeSaveThenIdle: () => void;
 	failSave: (error: string) => void;
@@ -105,6 +105,12 @@ interface SaveState {
 }
 
 export const useSaveStore = create<SaveState>((set, get) => {
+	// Bumped by every `completeSaveThenIdle`, so an armed reset can tell whether
+	// it is still the most recent one. Module-local rather than store state: no
+	// renderer reads it, and a field nothing renders is the defect this file's
+	// history is made of.
+	let idleResetGeneration = 0;
+
 	// Internal helper - runs a save for the given context and updates store state.
 	// Caller must own the in-progress guard if needed.
 	const runSave = async (context: SaveContext) => {
@@ -134,14 +140,20 @@ export const useSaveStore = create<SaveState>((set, get) => {
 
 		startSaving: () => set({ status: "saving" }),
 
-		completeSave: () => set({ status: "saved" }),
-
 		completeSaveThenIdle: () => {
 			set({ status: "saved" });
+			const armed = ++idleResetGeneration;
 			setTimeout(() => {
-				// Only reset to idle if this "saved" is still the status on screen.
+				// Two conditions, and both are load-bearing. The status check keeps
+				// this timer off a status somebody else published meanwhile. The
+				// generation check keeps it off a *later* save's "saved": two saves
+				// a second apart would otherwise have the first timer end the second
+				// one's indicator early. `useSaveManager` hand-rolled the second half
+				// as a `clearTimeout` of its own timer; it lives here now, so every
+				// caller gets it.
+				if (armed !== idleResetGeneration) return;
 				if (get().status === "saved") get().setStatus("idle");
-			}, TIMING.STATUS_RESET_MS);
+			}, TIMING.SAVED_STATUS_DURATION_MS);
 		},
 
 		failSave: (error) => {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -267,15 +267,24 @@ included mount - so merely opening Settings wiped an `error` another context had
 just published to the Dock. It now tracks whether the `pending` on screen is its
 own and leaves anything else alone.
 
-The same rule is why **`completeSaveThenIdle` exists**: it sets `saved` and
-arms the return to `idle` behind a check that the status is still the `saved` it
-set. A bare `completeSave()` followed by
-`setTimeout(() => setStatus("idle"), TIMING.STATUS_RESET_MS)` fires regardless of
-what happened in the meantime, so a rename that succeeded two seconds ago cleared
-the failure a delete had just published. `triggerSave` has always guarded its own
-reset this way; the collection tree now shares that one implementation rather
-than a copy of the timer. `useSaveManager`, `SettingsMain` and
-`VariableTableEditor` still hand-roll theirs - see issue #369.
+The same rule is why **`completeSaveThenIdle` is the only way to report a
+success**: it sets `saved` and arms the return to `idle` behind two checks - that
+the status is still the `saved` it set, and that no later save has re-armed the
+reset since. A bare `completeSave()` followed by
+`setTimeout(() => setStatus("idle"), …)` fires regardless of what happened in the
+meantime, so a rename that succeeded two seconds ago cleared the failure a delete
+had just published; and two saves a second apart had the first one's timer end
+the second one's indicator early. `triggerSave` has always guarded the first way,
+`useSaveManager` hand-rolled the second as a `clearTimeout` of its own timer.
+Both live in the store now, and the six call sites (`useSaveManager`,
+`SettingsMain`, `VariableTableEditor`, `ContextBar`, both collection-tree
+renames) share that one implementation rather than five copies of the timer.
+
+`completeSave` is gone with them. It set `saved` and armed nothing, so every
+caller either paired it with a hand-rolled timer or - `ContextBar`, the one
+non-draft commit path - left "Saved" in the Dock until something else happened to
+change it. The indicator's lifetime is `TIMING.SAVED_STATUS_DURATION_MS`, in one
+place, for every surface that saves.
 
 There is no `errorMessage` field. The reason travels in the toast; the store
 holds only the status the Dock renders. The field used to exist and its sole


### PR DESCRIPTION
## Description

The rest of the unguarded idle timers (#369). All three call sites the issue names reproduce on `e1b3592` exactly as described, and `ContextBar` is the fourth case the issue asked to decide on.

**The plan.** Root cause is the repo's hand-rolled-copy-of-a-primitive shape: the store holds **one** status for the whole app and documents the rule as "only the context that set a status clears it", but four callers reported success as `completeSave()` plus their own `setTimeout(() => setStatus("idle"))` - a timer that fires regardless of what happened since, so it clears an `error` another surface published to the Dock, or a `pending` from an edit made since. #361 added `completeSaveThenIdle` and moved `runSave` and both collection-tree renames onto it; this moves the remaining three, plus `ContextBar`. The approach is subtraction, not new API: the action already exists, so the diff deletes four timers and one now-callerless store action rather than adding anything. **The alternative I rejected** was leaving `completeSave` in place as the "no reset" primitive for `ContextBar` - but `ContextBar` is not a case that wants no reset, it is the one path where nobody noticed "Saved" never went away, and keeping an action whose only correct use is to pair it with a hand-rolled timer is how these five copies happened in the first place.

### The three call sites

`useSaveManager.ts`, `SettingsMain.tsx` and `VariableTableEditor.tsx` now call `completeSaveThenIdle()`. `rg 'setTimeout\([^)]*setStatus\("idle"\)' app/src` returns nothing.

`SettingsMain`'s own pending tracking (`markedPendingRef`) still reads correctly against the shared action rather than around it: `saveEntries` clears the flag *before* `startSaving()`, so the status sequence from that point is the save's, and the pending effect keeps its hands off it. Unchanged, and the existing `SettingsMain.category-switch.test.tsx` guard on it is untouched and green.

### `ContextBar`: migrated, not justified

It called `completeSave()` with **no reset at all** - a committed variable left "Saved" in the Dock until some unrelated surface happened to publish a status. Deliberate is not the reading the code supports: it is simply the one non-draft commit path, so it was the one place nobody paired the timer. It goes through the same action now. The `status !== "error"` guard in front of the call stays - that is a different rule (do not paint "Saved" over a failure the commit already reported).

### `completeSave` is deleted

With all five callers migrated it had none left, and an action that sets `saved` with nothing to clear it is exactly the defect. Seven test files mocked it; they now mock `completeSaveThenIdle` - prop-only edits, no assertion changed.

### One duration, and the second guard

`completeSaveThenIdle` now reads `TIMING.SAVED_STATUS_DURATION_MS` (3000) rather than `STATUS_RESET_MS` (2000). The former is the constant named for exactly this ("how long the 'Saved' indicator stays visible after a save") and was previously read only by `useSaveManager` - which this PR would otherwise have orphaned. `STATUS_RESET_MS` keeps its other reader, the response viewer's copy tick, and its comment no longer claims saves. The user-visible effect is that collection-tree renames and Cmd+S show "Saved" for 3s instead of 2s, matching what request auto-save has always done. `CollectionTree.rename.test.tsx` advances by the new constant; its assertions are unchanged.

The action also picks up the one guard `useSaveManager` had and the store did not: it cleared its own timer before arming the next, so two saves a second apart each got the full indicator. Without it the first timer ends the second save's "Saved" early. Implemented as a generation counter, module-local rather than store state - no renderer reads it, and a field nothing renders is the defect this file's history is made of. `useSaveManager`'s `savedTimeoutRef` and its unmount clear are gone with it; the reset deliberately survives the component now, because the Dock outlives the request pane.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **`pnpm test`: 313 files, 2835 tests passed.** (Base `e1b3592`: 309 files, 2822 tests - no pre-existing failures.)
- `pnpm type-check`, `pnpm lint`, `pnpm format:check`: clean. Only files this PR touched were formatted; `docs/app/state-management.md` was already not prettier-clean before this change and is outside `app/`'s `format:check`, so it is left alone per CLAUDE.md.
- Engine untouched - no engine build or `ctest` run.

**New:** `save-store.test.ts` (4) - the action itself: idle return at the right moment, an `error` published meanwhile left alone, a `pending` from an edit made since left alone, and an earlier save not cutting a later one's indicator short. Plus one status-stomp file per call site: `useSaveManager.status-stomp.test.tsx`, `SettingsMain.status-stomp.test.tsx`, `VariableTableEditor.status-stomp.test.tsx`, `ContextBar.save-status.test.tsx` (2 each) - a completed save, a `failSave` published from another context, timers advanced past the duration, status still `error`; and for `ContextBar` the reset that never existed.

Every one is mutation-checked - each guard and each call site reverted individually, confirmed its test reddens, restored:

| Mutation | Result |
|---|---|
| drop the generation check | 1 failed |
| drop the `status === "saved"` check | 2 failed |
| `useSaveManager` back to the raw timer | 1 failed |
| `SettingsMain` back to the raw timer | 1 failed |
| `VariableTableEditor` back to the raw timer | 1 failed |
| `ContextBar` back to a bare `saved` | 2 failed |

**Seven existing test files** swap `completeSave: vi.fn()` for `completeSaveThenIdle: vi.fn()` in their save-store mocks - required, since the components now call it. No assertion changed in any of them.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Docs

`docs/app/state-management.md` - the save-store section named the three remaining hand-rolled copies and pointed here; it now describes `completeSaveThenIdle` as the only way to report a success, both of its guards, and why `completeSave` is gone. Same commit. `config/timing.ts`'s two comments updated to match their readers.

## Related Issues

Closes #369


---
_Generated by [Claude Code](https://claude.ai/code/session_01YStxNJUyeTiXieVVXYKPEH)_