### PR TITLE
fix(app/mcp): invalidate the renderer's queries when an MCP call writes

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -30,6 +30,7 @@ import {
 	connectClient,
 	toolCatalog,
 	type McpConnectClient,
+	type McpDataChangedEvent,
 	type McpSafetyConfig,
 } from "./mcp/index.js";
 import {
@@ -497,6 +498,7 @@ async function startMcp() {
 			port: MCP_PORT,
 			version: app.getVersion(),
 			safety: loadPersistedSafety(),
+			onDataChanged: sendMcpDataChanged,
 		});
 		await mcpService.start();
 		console.log("[Main] MCP server listening at", mcpService.getUrl());
@@ -506,6 +508,23 @@ async function startMcp() {
 		console.error("[Main] Failed to start MCP server (continuing without it):", error);
 		mcpService = null;
 	}
+}
+
+/**
+ * Forward an MCP data change to the renderer so its query cache can invalidate.
+ *
+ * One-way, main-to-renderer, and it carries no data - only which family went
+ * stale (the #278 hardening posture: nothing here takes renderer input, and a
+ * push of engine data would be a second source of truth beside the queries).
+ *
+ * The window is read at send time, not captured: the MCP server starts before
+ * the window exists and outlives a renderer reload, so a captured reference
+ * would either be null forever or point at destroyed `webContents`.
+ */
+function sendMcpDataChanged(event: McpDataChangedEvent): void {
+	const contents = mainWindow?.webContents;
+	if (!contents || contents.isDestroyed()) return;
+	contents.send("mcp:data-changed", event);
 }
 
 async function stopMcp() {

--- a/app/electron/mcp/data-changed.conformance.test.ts
+++ b/app/electron/mcp/data-changed.conformance.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Keeps the two copies of the MCP data-entity list honest.
+ *
+ * The main process owns `MCP_DATA_ENTITIES`; the renderer needs the same union
+ * to type the IPC payload and its invalidation map, and production code under
+ * `electron/` cannot import from `app/src` (the reasoning is in
+ * `tsconfig.node.json`). So the type is written twice on purpose - and a
+ * divergence would be silent in the worst possible way: the main process would
+ * emit a family the renderer's map has no entry for, and the write would stay
+ * invisible, which is the bug the channel exists to fix.
+ *
+ * This file is the one place the two meet. It reaches across the boundary the
+ * way `tools.test.ts` already reaches for `@/constants/load-test`.
+ */
+
+import { describe, expect, test } from "vitest";
+import { MCP_DATA_ENTITIES } from "./tools.js";
+import type { McpDataEntity } from "@/types/domain";
+
+/*
+ * Exhaustive by construction: TypeScript rejects this literal if the renderer's
+ * union gains a member that is not listed, and rejects a listed member the
+ * union does not have. The runtime comparison below catches the other
+ * direction - the main process gaining an entity the renderer never heard of.
+ */
+const RENDERER_ENTITIES: Record<McpDataEntity, true> = {
+	request: true,
+	environment: true,
+	run: true,
+	cookie: true,
+	config: true,
+};
+
+describe("McpDataEntity mirror", () => {
+	test("the main process and the renderer name the same entities", () => {
+		expect([...MCP_DATA_ENTITIES].sort()).toEqual(Object.keys(RENDERER_ENTITIES).sort());
+	});
+
+	test("the list it scanned is not empty", () => {
+		// A comparison of two empty lists passes while proving nothing - the
+		// failure mode CLAUDE.md records for source-scanning guards.
+		expect(MCP_DATA_ENTITIES.length).toBeGreaterThan(0);
+	});
+});

--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The `mcp:data-changed` emit at the dispatch chokepoint.
+ *
+ * `tools.test.ts` owns what each tool sends to the engine; this owns the one
+ * thing that happens *after* a call succeeds - the renderer being told what
+ * went stale. Kept in its own file because every test here needs the notifier
+ * in the context, which none of the tests over there want.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import {
+	dispatchTool,
+	MCP_DATA_ENTITIES,
+	TOOLS,
+	type McpDataChangedEvent,
+	type ToolContext,
+} from "./tools.js";
+import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
+import type { EngineClient } from "./engine-client.js";
+
+/** Minimal engine client for the calls exercised below. */
+function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}) {
+	return {
+		health: vi.fn().mockResolvedValue({ status: "ok", version: "1.2.3" }),
+		listCollections: vi.fn().mockResolvedValue([]),
+		listRuns: vi.fn().mockResolvedValue([]),
+		createRequest: vi.fn().mockResolvedValue({ id: "req_1", name: "New" }),
+		updateConfig: vi.fn().mockResolvedValue({ entries: [] }),
+		getConfig: vi.fn().mockResolvedValue({ entries: [] }),
+		getEnvironment: vi.fn().mockResolvedValue({ id: "env_1", name: "Dev", variables: {} }),
+		updateEnvironment: vi.fn().mockResolvedValue({ id: "env_1", name: "Dev" }),
+		executeRequest: vi.fn().mockResolvedValue({ statusCode: 200 }),
+		stopRun: vi.fn().mockResolvedValue({ message: "Run stopped" }),
+		composeRequest: vi
+			.fn()
+			.mockImplementation((body: { request?: object }) =>
+				Promise.resolve({ ...(body.request ?? {}) })
+			),
+		...overrides,
+	} as unknown as EngineClient;
+}
+
+/** A context plus the notifier spy, so a test can read what was emitted. */
+function ctxWithNotifier(client: EngineClient, safety?: Partial<McpSafetyConfig>) {
+	const onDataChanged = vi.fn<(event: McpDataChangedEvent) => void>();
+	const ctx: ToolContext = { client, config: resolveSafetyConfig(safety), onDataChanged };
+	return { ctx, onDataChanged };
+}
+
+const WRITES_ENABLED: Partial<McpSafetyConfig> = { allowWrites: true };
+
+describe("the registry declares its effects", () => {
+	test("every tool declares `invalidates`, using only known entities", () => {
+		for (const tool of TOOLS) {
+			expect(Array.isArray(tool.invalidates), `${tool.name} must declare invalidates`).toBe(
+				true
+			);
+			for (const entity of tool.invalidates) {
+				expect(MCP_DATA_ENTITIES, `${tool.name} declares an unknown entity`).toContain(
+					entity
+				);
+			}
+		}
+	});
+
+	test("read tools change nothing", () => {
+		for (const tool of TOOLS.filter((t) => t.category === "read")) {
+			expect(tool.invalidates, `${tool.name} is a read tool`).toEqual([]);
+		}
+	});
+
+	test("every mutating tool declares at least one entity", () => {
+		// The list is spelled out rather than derived from `category`, because
+		// which family a tool touches is exactly what `category` does not say -
+		// an `execute` tool writes a run row and refills the cookie jar.
+		const expected: Record<string, string[]> = {
+			create_request: ["request"],
+			update_environment: ["environment"],
+			update_engine_config: ["config"],
+			run_request: ["run", "cookie"],
+			run_collection_smoke: ["run", "cookie"],
+			start_load_run: ["run"],
+			stop_run: ["run"],
+		};
+		for (const [name, entities] of Object.entries(expected)) {
+			const tool = TOOLS.find((t) => t.name === name);
+			expect(tool, `${name} is missing from the registry`).toBeDefined();
+			expect(tool!.invalidates, name).toEqual(entities);
+		}
+		// Nothing else mutates: a new tool that does must be added above, or this
+		// guard would pass while its writes stayed invisible to the renderer.
+		const mutating = TOOLS.filter((t) => t.invalidates.length > 0).map((t) => t.name);
+		expect(mutating.sort()).toEqual(Object.keys(expected).sort());
+	});
+});
+
+describe("dispatch emits mcp:data-changed", () => {
+	test("a successful write emits exactly one event for its entity", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
+		const res = await dispatchTool(
+			"create_request",
+			{ collectionId: "col_1", name: "New", url: "https://api.example.com/x" },
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).toHaveBeenCalledTimes(1);
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "request", collectionId: "col_1" });
+	});
+
+	test("a failed dispatch emits nothing", async () => {
+		// Writes are off by default, so the tool refuses before touching the engine.
+		const client = fakeClient();
+		const { ctx, onDataChanged } = ctxWithNotifier(client);
+		const res = await dispatchTool(
+			"create_request",
+			{ collectionId: "col_1", name: "New", url: "https://api.example.com/x" },
+			ctx
+		);
+		expect(res.isError).toBe(true);
+		expect(client.createRequest).not.toHaveBeenCalled();
+		expect(onDataChanged).not.toHaveBeenCalled();
+	});
+
+	test("an engine error emits nothing", async () => {
+		const client = fakeClient({
+			createRequest: vi.fn().mockRejectedValue(new Error("fetch failed")),
+		});
+		const { ctx, onDataChanged } = ctxWithNotifier(client, WRITES_ENABLED);
+		const res = await dispatchTool(
+			"create_request",
+			{ collectionId: "col_1", name: "New", url: "https://api.example.com/x" },
+			ctx
+		);
+		expect(res.isError).toBe(true);
+		expect(onDataChanged).not.toHaveBeenCalled();
+	});
+
+	test("a read tool emits nothing", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
+		const res = await dispatchTool("list_collections", {}, ctx);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).not.toHaveBeenCalled();
+	});
+
+	test("a disabled tool emits nothing", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), {
+			...WRITES_ENABLED,
+			disabledTools: ["create_request"],
+		});
+		const res = await dispatchTool("create_request", { collectionId: "col_1" }, ctx);
+		expect(res.isError).toBe(true);
+		expect(onDataChanged).not.toHaveBeenCalled();
+	});
+
+	test("a tool declaring two entities emits one event each", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), {
+			allowlist: ["api.example.com"],
+		});
+		const res = await dispatchTool(
+			"run_request",
+			{ url: "https://api.example.com/users", requestId: "req_7" },
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged.mock.calls.map(([e]) => e.entity)).toEqual(["run", "cookie"]);
+	});
+
+	test("the call's own arguments become the scope hints", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), {
+			allowlist: ["api.example.com"],
+		});
+		await dispatchTool(
+			"run_request",
+			{ url: "https://api.example.com/users", requestId: "req_7" },
+			ctx
+		);
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run", requestId: "req_7" });
+	});
+
+	test("hints the call did not name are absent, not empty strings", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), {
+			allowlist: ["api.example.com"],
+		});
+		await dispatchTool("run_request", { url: "https://api.example.com/users" }, ctx);
+		const event = onDataChanged.mock.calls[0][0];
+		expect(event).toEqual({ entity: "run" });
+		expect("requestId" in event).toBe(false);
+	});
+
+	test("stop_run reports the run family", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
+		const res = await dispatchTool("stop_run", { runId: "run_1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run" });
+	});
+
+	test("a context without a notifier dispatches normally", async () => {
+		const client = fakeClient();
+		const ctx: ToolContext = { client, config: resolveSafetyConfig(WRITES_ENABLED) };
+		const res = await dispatchTool(
+			"create_request",
+			{ collectionId: "col_1", name: "New", url: "https://api.example.com/x" },
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		expect(client.createRequest).toHaveBeenCalledTimes(1);
+	});
+
+	test("a throwing listener does not fail a write the engine already applied", async () => {
+		const client = fakeClient();
+		const ctx: ToolContext = {
+			client,
+			config: resolveSafetyConfig(WRITES_ENABLED),
+			onDataChanged: () => {
+				throw new Error("renderer went away");
+			},
+		};
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const res = await dispatchTool(
+				"create_request",
+				{ collectionId: "col_1", name: "New", url: "https://api.example.com/x" },
+				ctx
+			);
+			expect(res.isError).toBeFalsy();
+			expect(client.createRequest).toHaveBeenCalledTimes(1);
+			expect(errorLog).toHaveBeenCalled();
+		} finally {
+			errorLog.mockRestore();
+		}
+	});
+});

--- a/app/electron/mcp/index.ts
+++ b/app/electron/mcp/index.ts
@@ -16,7 +16,7 @@
 import { EngineClient } from "./engine-client.js";
 import { McpHttpServer } from "./http.js";
 import { resolveSafetyConfig, type McpSafetyConfig } from "./config.js";
-import type { ToolContext } from "./tools.js";
+import type { McpDataChangedEvent, ToolContext } from "./tools.js";
 
 export interface VayuMcpServiceOptions {
 	engineBaseUrl: string;
@@ -24,6 +24,11 @@ export interface VayuMcpServiceOptions {
 	port: number;
 	version: string;
 	safety?: Partial<McpSafetyConfig>;
+	/**
+	 * Called when a successful tool call changed engine data, so the owner can
+	 * forward it to the renderer. Omitted when there is no renderer to tell.
+	 */
+	onDataChanged?: (event: McpDataChangedEvent) => void;
 }
 
 export class VayuMcpService {
@@ -38,7 +43,11 @@ export class VayuMcpService {
 			host: opts.host,
 			port: opts.port,
 			info: { name: "vayu", version: opts.version },
-			contextProvider: (): ToolContext => ({ client: this.client, config: this.config }),
+			contextProvider: (): ToolContext => ({
+				client: this.client,
+				config: this.config,
+				onDataChanged: opts.onDataChanged,
+			}),
 		});
 	}
 
@@ -79,5 +88,5 @@ export {
 } from "./store.js";
 export { connectClient } from "./connect.js";
 export type { McpConnectClient, McpConnectResult } from "./connect.js";
-export { toolCatalog } from "./tools.js";
-export type { McpToolInfo, ToolCategory } from "./tools.js";
+export { toolCatalog, MCP_DATA_ENTITIES } from "./tools.js";
+export type { McpToolInfo, ToolCategory, McpDataEntity, McpDataChangedEvent } from "./tools.js";

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -49,6 +49,42 @@ export interface ElicitOutcome {
 /** Ask the human via the client; throws if the client can't elicit. */
 export type ElicitFn = (params: ElicitParams) => Promise<ElicitOutcome>;
 
+// --- Data-change notification ------------------------------------------------
+
+/**
+ * The data families an MCP call can change, named as the renderer's query cache
+ * groups them. An MCP call mutates the engine from the main process, so the
+ * renderer learns about it only if it is told: `refetchOnWindowFocus` is off
+ * app-wide, and nothing else crosses the process boundary.
+ *
+ * Mirrored as `McpDataEntity` in `app/src/types/domain.ts`, because production
+ * code under `electron/` cannot import from `app/src` (see the rationale in
+ * `tsconfig.node.json`). `data-changed.conformance.test.ts` keeps the two
+ * copies honest, and the renderer's mapping is exhaustive over this union, so
+ * a new entity fails to compile until it has a reader.
+ */
+export const MCP_DATA_ENTITIES = ["request", "environment", "run", "cookie", "config"] as const;
+
+export type McpDataEntity = (typeof MCP_DATA_ENTITIES)[number];
+
+/**
+ * One thing changed. Invalidation only - no data rides across, the renderer
+ * refetches through its normal query layer.
+ *
+ * The two scope hints are read from the call's own arguments and narrow the
+ * invalidation to the caches that can have gone stale; both are absent when the
+ * call named neither. They are hints, not identity: `requestId` on a
+ * `run` event is the saved request a design run was linked to (the key
+ * `runs.lastDesign` uses), not the run's own id.
+ */
+export interface McpDataChangedEvent {
+	entity: McpDataEntity;
+	/** The collection the call named, when it named one. */
+	collectionId?: string;
+	/** The saved request the call named, when it named one. */
+	requestId?: string;
+}
+
 export interface ToolContext {
 	client: EngineClient;
 	config: McpSafetyConfig;
@@ -58,6 +94,12 @@ export interface ToolContext {
 	 * agent-side gate (e.g. the `confirmed` flag).
 	 */
 	elicit?: ElicitFn;
+	/**
+	 * Called once per entity a successful call changed, so the renderer can
+	 * invalidate the matching queries. Absent when there is nothing to notify -
+	 * the stdio CLI has no window.
+	 */
+	onDataChanged?: (event: McpDataChangedEvent) => void;
 }
 
 export interface ToolResult {
@@ -91,6 +133,15 @@ export interface McpTool {
 	 * but its own test - the client-facing hint is `annotations.readOnlyHint`.
 	 */
 	category: ToolCategory;
+	/**
+	 * The data families a successful call changes. Required rather than
+	 * defaulted, and deliberately not derived from `category`: an `execute` tool
+	 * writes a history row and refills the cookie jar without being a "write",
+	 * and a `load` tool writes run rows. A default would let a new tool ship
+	 * silently invisible to the renderer, which is the bug this field exists to
+	 * close; `[]` is a statement that the tool only reads.
+	 */
+	invalidates: readonly McpDataEntity[];
 	handler: (
 		args: Record<string, unknown>,
 		ctx: ToolContext,
@@ -613,6 +664,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "get_engine_health",
 		category: "read",
+		invalidates: [],
 		description:
 			"Check the Vayu engine's status and version. Use this first to confirm Vayu is running.",
 		annotations: {
@@ -645,6 +697,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "list_collections",
 		category: "read",
+		invalidates: [],
 		description: "List all request collections (folders that organize saved requests).",
 		annotations: {
 			title: "List collections",
@@ -658,6 +711,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "list_requests",
 		category: "read",
+		invalidates: [],
 		description: "List the saved requests inside a collection.",
 		annotations: {
 			title: "List requests",
@@ -672,6 +726,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "list_environments",
 		category: "read",
+		invalidates: [],
 		description: "List all environments (named sets of variables like baseUrl, apiKey).",
 		annotations: {
 			title: "List environments",
@@ -685,6 +740,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "list_runs",
 		category: "read",
+		invalidates: [],
 		description:
 			"List recent past runs (both single Design-mode requests and load tests), " +
 			"newest first. Returns a {data, pagination} envelope bounded to the first " +
@@ -702,6 +758,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "get_run_report",
 		category: "read",
+		invalidates: [],
 		description:
 			"Get the full report for a completed run: summary, latency percentiles (p50/p95/p99), status codes, errors, and timing breakdown. Ideal input for analyzing performance.",
 		annotations: {
@@ -717,6 +774,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "get_engine_config",
 		category: "read",
+		invalidates: [],
 		description:
 			"Get the engine's tunable configuration entries (workers, timeouts, connection limits, buffer sizes, etc.), each with its current value, default, type, and allowed range.",
 		annotations: {
@@ -731,6 +789,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "run_request",
 		category: "execute",
+		invalidates: ["run", "cookie"],
 		description:
 			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app (environment > collection chain > globals). Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.)",
 		annotations: {
@@ -814,6 +873,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "update_engine_config",
 		category: "write",
+		invalidates: ["config"],
 		description:
 			"Update one or more engine configuration entries. GUARDED: requires write access to be enabled in Vayu Settings. Pass `entries` as a map of config key to new value; the engine validates types/ranges and rejects the whole batch on any invalid value. Some keys require an engine RESTART to take effect - the result lists those under `restartRequired`; they are saved but the running engine keeps the old value until the user restarts it (Vayu Settings → restart engine, or relaunch).",
 		annotations: {
@@ -876,6 +936,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "create_request",
 		category: "write",
+		invalidates: ["request"],
 		description:
 			"Create a saved request inside a collection (stores it; does not send it). GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed.",
 		annotations: {
@@ -926,6 +987,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "update_environment",
 		category: "write",
+		invalidates: ["environment"],
 		description:
 			"Set or overwrite variables on an environment (merges with the existing variables - other variables are preserved). GUARDED: requires write access to be enabled in Vayu Settings.",
 		annotations: {
@@ -1000,6 +1062,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "run_collection_smoke",
 		category: "execute",
+		invalidates: ["run", "cookie"],
 		description:
 			"Execute a collection's own saved requests once each and return a pass/fail matrix (a request passes on a 2xx/3xx status with all its tests passing). Scope is the collection's DIRECT requests: nested sub-collections are not run, and the result discloses how many were left out - call this tool on each of them to cover them. Requests run one at a time, so a large collection takes as long as its requests do added together. Each request is composed exactly as the app would send it: {{variables}} resolved (environment > collection chain > globals), the request's stored auth applied (inheriting from the collection chain, incl. OAuth2), and its collection-chain + own pre/post scripts run. Each request's resolved host must be on the allowlist; requests whose host still cannot be verified (e.g. a variable did not resolve and allow-all is off) are skipped. Sends real traffic but does not modify Vayu data.",
 		annotations: {
@@ -1126,6 +1189,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "start_load_run",
 		category: "load",
+		invalidates: ["run"],
 		description:
 			"Start a load test against a URL, or against a saved request via `requestId` - which composes it exactly as the app does, including the collection chain's and its own test scripts, so a load run checks the same assertions a Send does. GUARDED: the host must be on the allowlist, and RPS/concurrency/duration must be within Vayu's caps. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given; pass an `auth` block to authenticate the load (bearer/basic/apikey/oauth2, applied engine-side). Pass a `postRequestScript` - the same assertions you would give run_request - to validate responses under load; it runs against sampled responses. A pre-request script is not offered here: the engine runs one on a single request only, never on a load run. Confirmation is required: if the client supports elicitation the user is prompted directly; otherwise call once for a preview, then again with `confirmed: true`.",
 		annotations: {
@@ -1334,6 +1398,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "stop_run",
 		category: "load",
+		invalidates: ["run"],
 		description: "Stop an in-progress load test.",
 		annotations: {
 			title: "Stop run",
@@ -1349,6 +1414,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "get_live_metrics",
 		category: "read",
+		invalidates: [],
 		description:
 			"Get a snapshot of the most recent live metrics ticks for a run (RPS, latency percentiles, error rate, status mix). Returns the last N ticks; does not stream.",
 		annotations: {
@@ -1380,6 +1446,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "compare_runs",
 		category: "read",
+		invalidates: [],
 		description:
 			"Compare two completed runs and return the deltas in latency percentiles, throughput, error rate, and status-code mix. Use to answer 'did this change regress performance?'.",
 		annotations: {
@@ -1452,10 +1519,45 @@ export async function dispatchTool(
 	if (ctx.config.disabledTools.includes(name)) {
 		return errorResult(`Tool "${name}" is disabled in Vayu Settings → MCP.`);
 	}
+	let result: ToolResult;
 	try {
-		return await tool.handler(args, ctx, signal);
+		result = await tool.handler(args, ctx, signal);
 	} catch (err) {
 		if (err instanceof ToolArgError) return errorResult(err.message);
 		return errorResult(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+	}
+	// Only a call that succeeded changed anything. A tool that returned an error
+	// result may still have got as far as the engine, but it cannot say so, and
+	// an invalidation storm on every rejected call would be worse than the one
+	// stale list a genuinely-partial failure leaves behind.
+	if (!result.isError) notifyDataChanged(tool, args, ctx);
+	return result;
+}
+
+/**
+ * Tell the renderer what a successful call changed, one event per declared
+ * entity. The scope hints come from the call's own arguments: every tool in the
+ * registry spells these two the same way, so reading them here is what keeps a
+ * new write tool from having to remember an emit of its own.
+ *
+ * Notification failure must not fail a write the engine has already applied -
+ * the same rule `update_engine_config`'s best-effort read-back follows - so a
+ * throwing listener is logged and swallowed rather than turned into a tool
+ * error the agent would read as "the write did not happen".
+ */
+function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: ToolContext): void {
+	if (!ctx.onDataChanged || tool.invalidates.length === 0) return;
+	const collectionId = str(args, "collectionId");
+	const requestId = str(args, "requestId");
+	for (const entity of tool.invalidates) {
+		try {
+			ctx.onDataChanged({
+				entity,
+				...(collectionId !== undefined ? { collectionId } : {}),
+				...(requestId !== undefined ? { requestId } : {}),
+			});
+		} catch (err) {
+			console.error(`[MCP] Failed to notify "${entity}" change from ${tool.name}:`, err);
+		}
 	}
 }

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -29,6 +29,22 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	setMcpEnabled: (enabled: boolean) => ipcRenderer.invoke("mcp:setEnabled", enabled),
 	connectMcpClient: (client: "claude" | "vscode") =>
 		ipcRenderer.invoke("mcp:connectClient", client),
+	// An agent's write reached the engine from the main process, so the renderer
+	// is told which data family to invalidate. One-way and data-free; the shape
+	// mirrors `McpDataChangedEvent` in electron/mcp/tools.ts, inlined because
+	// this file is a CommonJS script and must not grow imports.
+	onMcpDataChanged: (
+		callback: (event: {
+			entity: "request" | "environment" | "run" | "cookie" | "config";
+			collectionId?: string;
+			requestId?: string;
+		}) => void
+	) => {
+		const handler = (_event: unknown, change: unknown) =>
+			callback(change as Parameters<typeof callback>[0]);
+		ipcRenderer.on("mcp:data-changed", handler);
+		return () => ipcRenderer.removeListener("mcp:data-changed", handler);
+	},
 
 	// Theme management
 	getTheme: (): Promise<{ shouldUseDarkColors: boolean; themeSource: string }> =>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -26,6 +26,7 @@ import { useVariableCompletionProvider } from "./hooks/useVariableCompletionProv
 import { useScriptVariableCompletionProvider } from "./hooks/useScriptVariableCompletionProvider";
 import { useScriptTypeDefinitions } from "./hooks/useScriptTypeDefinitions";
 import { useMenuActions } from "./hooks/useMenuActions";
+import { useMcpDataInvalidation } from "./hooks/useMcpDataInvalidation";
 import { useSaveStore } from "./stores/save-store";
 
 function App() {
@@ -75,6 +76,10 @@ function App() {
 
 	// Bridge native menu items (Preferences…/Settings) to in-app navigation
 	useMenuActions();
+
+	// An agent writing over MCP mutates the engine from the main process, which
+	// no query can see. This is the channel that tells the cache to refetch.
+	useMcpDataInvalidation();
 
 	// Register Electron before-quit handler to flush pending saves
 	useEffect(() => {

--- a/app/src/hooks/useMcpDataInvalidation.test.tsx
+++ b/app/src/hooks/useMcpDataInvalidation.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import type { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useMcpDataInvalidation } from "./useMcpDataInvalidation";
+import { queryKeys } from "@/queries/keys";
+import type { McpDataChangedEvent } from "@/types/domain";
+
+type ChangedCb = (event: McpDataChangedEvent) => void;
+
+let changedCb: ChangedCb | null;
+let unsubscribed: boolean;
+
+beforeEach(() => {
+	changedCb = null;
+	unsubscribed = false;
+	(window as unknown as { electronAPI: unknown }).electronAPI = {
+		onMcpDataChanged: (cb: ChangedCb) => {
+			changedCb = cb;
+			return () => {
+				unsubscribed = true;
+				changedCb = null;
+			};
+		},
+	};
+});
+
+afterEach(() => {
+	delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+	vi.restoreAllMocks();
+});
+
+function setup() {
+	const queryClient = new QueryClient();
+	const spy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	const view = renderHook(() => useMcpDataInvalidation(), { wrapper });
+	return { view, spy };
+}
+
+describe("useMcpDataInvalidation", () => {
+	test("an event from the main process reaches the query cache", () => {
+		const { spy } = setup();
+		expect(changedCb).not.toBeNull();
+
+		act(() => changedCb!({ entity: "request", collectionId: "col_1" }));
+
+		expect(spy).toHaveBeenCalledWith({
+			queryKey: queryKeys.requests.listByCollection("col_1"),
+		});
+	});
+
+	test("it unsubscribes on unmount", () => {
+		const { view } = setup();
+		view.unmount();
+		expect(unsubscribed).toBe(true);
+	});
+
+	test("it is inert outside Electron", () => {
+		// A browser dev server has no `electronAPI`, and no MCP server to hear
+		// from - registering must not throw there.
+		delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+		expect(() => setup()).not.toThrow();
+	});
+});

--- a/app/src/hooks/useMcpDataInvalidation.ts
+++ b/app/src/hooks/useMcpDataInvalidation.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateForMcpEvent } from "@/lib/mcp-invalidation";
+
+/**
+ * Keep the query cache in step with writes an agent makes over MCP.
+ *
+ * One listener for the whole app, registered at the root: the events name a
+ * data family rather than a screen, so a second subscriber would only duplicate
+ * every invalidation. Absent outside Electron (`electronAPI` is undefined in a
+ * browser dev server), where there is no MCP server to hear from.
+ */
+export function useMcpDataInvalidation(): void {
+	const queryClient = useQueryClient();
+
+	useEffect(() => {
+		if (!window.electronAPI?.onMcpDataChanged) return;
+		return window.electronAPI.onMcpDataChanged((event) => {
+			invalidateForMcpEvent(queryClient, event);
+		});
+	}, [queryClient]);
+}

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, expect, test, vi, afterEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { invalidateForMcpEvent } from "./mcp-invalidation";
+import { queryKeys } from "@/queries/keys";
+import type { McpDataChangedEvent } from "@/types/domain";
+
+/** Apply one event against a spied client and return the keys it invalidated. */
+function keysFor(event: McpDataChangedEvent) {
+	const queryClient = new QueryClient();
+	const spy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+	const handled = invalidateForMcpEvent(queryClient, event);
+	return { handled, keys: spy.mock.calls.map(([filters]) => filters?.queryKey) };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("invalidateForMcpEvent", () => {
+	test("a created request invalidates only its own collection's list", () => {
+		const { handled, keys } = keysFor({ entity: "request", collectionId: "col_1" });
+		expect(handled).toBe(true);
+		expect(keys).toEqual([queryKeys.requests.listByCollection("col_1")]);
+	});
+
+	test("a request change with no named collection invalidates every list", () => {
+		// The owner is unknowable from here, and a per-collection key would leave
+		// whichever list actually changed stale.
+		const { keys } = keysFor({ entity: "request" });
+		expect(keys).toEqual([queryKeys.requests.lists()]);
+	});
+
+	test("an environment change invalidates the list and the details", () => {
+		const { keys } = keysFor({ entity: "environment" });
+		expect(keys).toEqual([queryKeys.environments.all]);
+	});
+
+	test("a run invalidates both list families", () => {
+		const { keys } = keysFor({ entity: "run" });
+		expect(keys).toEqual([queryKeys.runs.lists(), queryKeys.runs.allRuns()]);
+	});
+
+	test("a run linked to a saved request also invalidates its last design run", () => {
+		const { keys } = keysFor({ entity: "run", requestId: "req_7" });
+		expect(keys).toContainEqual(queryKeys.runs.lastDesign("req_7"));
+	});
+
+	test("a run leaves per-run reports alone", () => {
+		// A new run cannot have changed an existing run's report, and those are
+		// the expensive fetches in this family.
+		const { keys } = keysFor({ entity: "run", requestId: "req_7" });
+		expect(keys).not.toContainEqual(queryKeys.runs.report("req_7"));
+		expect(keys).not.toContainEqual(queryKeys.runs.all);
+	});
+
+	test("a cookie change invalidates the single jar key", () => {
+		const { keys } = keysFor({ entity: "cookie" });
+		expect(keys).toEqual([queryKeys.cookies.all]);
+	});
+
+	test("a config change invalidates the config query", () => {
+		const { keys } = keysFor({ entity: "config" });
+		expect(keys).toEqual([queryKeys.config.all]);
+	});
+
+	test("an unknown entity is reported, not thrown", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { handled, keys } = keysFor({
+			entity: "sasquatch",
+		} as unknown as McpDataChangedEvent);
+		expect(handled).toBe(false);
+		expect(keys).toEqual([]);
+		expect(warn).toHaveBeenCalled();
+	});
+});

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * MCP data-change invalidation.
+ *
+ * An MCP tool call mutates the engine from the Electron main process, so the
+ * renderer's caches have no way to notice: `refetchOnWindowFocus` is off
+ * app-wide (see `lib/query-client.ts`), and until now nothing crossed the
+ * process boundary. The main process sends one `mcp:data-changed` per family a
+ * successful call touched; this maps that family to the query keys that read it.
+ *
+ * Invalidation only - no engine data rides over IPC, so there is exactly one
+ * path by which a row reaches the UI and it is the query layer.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/queries/keys";
+import type { McpDataChangedEvent, McpDataEntity } from "@/types/domain";
+
+/**
+ * Which caches each family invalidates.
+ *
+ * A `Record` over the union rather than a `switch`: a new entity added to
+ * `McpDataEntity` fails to compile until it names a reader here, which is the
+ * check that keeps this from becoming a channel that writes events nothing
+ * listens for.
+ */
+const INVALIDATORS: Record<
+	McpDataEntity,
+	(queryClient: QueryClient, event: McpDataChangedEvent) => void
+> = {
+	/*
+	 * The tree reads one list per collection, so a created request only needs its
+	 * owner's list - the same narrowing `useUpdateRequestMutation` does rather
+	 * than refetching every collection on one row's change. Without a named
+	 * collection the owner is unknowable from here, so the whole `lists()` prefix
+	 * goes; that prefix also covers the reorder pass, which reads at `lists()`
+	 * itself and would be missed by a per-collection key alone.
+	 */
+	request: (queryClient, event) => {
+		void queryClient.invalidateQueries({
+			queryKey: event.collectionId
+				? queryKeys.requests.listByCollection(event.collectionId)
+				: queryKeys.requests.lists(),
+		});
+	},
+
+	/*
+	 * `all`, not `list()`: an environment's variables are read through the detail
+	 * cache as well as the list, and `update_environment` changes exactly those.
+	 */
+	environment: (queryClient) => {
+		void queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });
+	},
+
+	/*
+	 * The history list polls on its own, so this is about immediacy there - but
+	 * `allRuns` (Settings' count) and `lastDesign` (a request tab's restored
+	 * response) are not polled at all, and an MCP-run request left both stale
+	 * indefinitely. Reports and time series are keyed per run and describe runs
+	 * that already existed, so they are deliberately not touched.
+	 */
+	run: (queryClient, event) => {
+		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
+		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
+		if (event.requestId) {
+			void queryClient.invalidateQueries({
+				queryKey: queryKeys.runs.lastDesign(event.requestId),
+			});
+		}
+	},
+
+	/*
+	 * One key for every jar - the engine reports them together and the panel
+	 * shows them together (see `queries/cookies.ts`).
+	 */
+	cookie: (queryClient) => {
+		void queryClient.invalidateQueries({ queryKey: queryKeys.cookies.all });
+	},
+
+	config: (queryClient) => {
+		void queryClient.invalidateQueries({ queryKey: queryKeys.config.all });
+	},
+};
+
+/**
+ * Apply one `mcp:data-changed` event.
+ *
+ * An unknown entity is dropped rather than thrown: the event crosses a process
+ * boundary, so a main process newer than the renderer bundle (a hot reload
+ * against a rebuilt main) can legitimately name a family this build has never
+ * heard of, and losing one invalidation is a stale list while throwing inside
+ * an IPC listener is an unhandled rejection with the same stale list.
+ */
+export function invalidateForMcpEvent(
+	queryClient: QueryClient,
+	event: McpDataChangedEvent
+): boolean {
+	const invalidate = INVALIDATORS[event.entity];
+	if (!invalidate) {
+		console.warn("[MCP] Ignoring data-changed event for unknown entity:", event.entity);
+		return false;
+	}
+	invalidate(queryClient, event);
+	return true;
+}

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -997,6 +997,27 @@ export interface McpConnectResult {
 	message?: string;
 }
 
+/**
+ * A data family an MCP call can change. Mirrors `MCP_DATA_ENTITIES` in
+ * `electron/mcp/tools.ts` - the main process owns the list, and production code
+ * there cannot import from here (see `tsconfig.node.json`), so the duplication
+ * is deliberate and pinned by `electron/mcp/data-changed.conformance.test.ts`.
+ */
+export type McpDataEntity = "request" | "environment" | "run" | "cookie" | "config";
+
+/**
+ * What the main process sends over `mcp:data-changed`. Invalidation only - the
+ * renderer refetches through its normal query layer rather than being handed
+ * engine data over IPC. See `lib/mcp-invalidation.ts` for the key mapping.
+ */
+export interface McpDataChangedEvent {
+	entity: McpDataEntity;
+	/** The collection the call named, when it named one. */
+	collectionId?: string;
+	/** The saved request the call named, when it named one. */
+	requestId?: string;
+}
+
 export interface ScriptCompletion {
 	label: string;
 	kind: number;

--- a/app/src/types/electron.d.ts
+++ b/app/src/types/electron.d.ts
@@ -11,6 +11,7 @@
 
 import type { ThemeSource } from "./ui";
 import type {
+	McpDataChangedEvent,
 	McpSafetyConfig,
 	McpStatus,
 	McpConnectClient,
@@ -57,6 +58,8 @@ interface ElectronAPI {
 	updateMcpSafety: (partial: Partial<McpSafetyConfig>) => Promise<McpSafetyConfig>;
 	setMcpEnabled: (enabled: boolean) => Promise<McpStatus>;
 	connectMcpClient: (client: McpConnectClient) => Promise<McpConnectResult>;
+	/** An agent's write landed engine-side; invalidate the named family. */
+	onMcpDataChanged: (callback: (event: McpDataChangedEvent) => void) => () => void;
 
 	// Theme management
 	getTheme: () => Promise<ThemeInfo>;

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -870,6 +870,34 @@ query is keyed on is `list()` / `detail(id)`. `runs.lastDesign` sits under
   creating a collection can invalidate it - it succeeds once at startup and
   would otherwise never re-run for a collection created mid-session.
 
+**Writes from outside the renderer: `mcp:data-changed`.** An MCP tool call
+mutates the engine from the Electron **main** process, so no mutation runs here
+and no query notices - and with `refetchOnWindowFocus: false` (below) nothing
+ever catches up on its own. A request an agent created stayed invisible in the
+collection tree until some unrelated renderer mutation happened to invalidate
+the lists. The main process now sends one event per data family a successful
+call touched; `useMcpDataInvalidation()` (registered once, in `App.tsx`) maps it
+to keys through `lib/mcp-invalidation.ts`:
+
+| Entity | Invalidates | Why that key |
+|--------|-------------|--------------|
+| `request` | `requests.listByCollection(collectionId)`, or `requests.lists()` when the call named no collection | The same narrowing `useUpdateRequestMutation` does; without a named owner the owner is unknowable here |
+| `environment` | `environments.all` | Variables are read through the detail cache as well as the list |
+| `run` | `runs.lists()`, `runs.allRuns()`, plus `runs.lastDesign(requestId)` when the call named one | The history list polls, but Settings' count and a request tab's restored response do not |
+| `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
+| `config` | `config.all` | |
+
+The event carries no engine data, only which family went stale, so a row still
+reaches the UI by exactly one path: the query layer. Per-run reports and time
+series are deliberately left alone - a new run cannot have changed an existing
+run's report. The entity list is duplicated across the process boundary
+(`MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`, `McpDataEntity` in
+`types/domain.ts`) because production code under `electron/` cannot import from
+`app/src`; `data-changed.conformance.test.ts` is what keeps the copies equal,
+and the map above is a `Record` over the union so a new family fails to compile
+until it names a reader. The emitting side is documented in
+[`docs/engine/mcp.md`](../engine/mcp.md).
+
 **Retry policy:** the shared default is `shouldRetryQuery` (`lib/query-client.ts`),
 not a bare count. A 4xx from the engine is a verdict, not a hiccup - a 404 for a
 deleted row answers identically every time, so retrying it only delays the error

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -551,6 +551,30 @@ on quit, and exposes IPC the Settings panel uses:
 | `mcp:getTools`      | IPC-safe tool catalog (name/description/category).           |
 | `mcp:connectClient` | Run a client's add-CLI (`claude` / `code`).                 |
 
+One channel runs the other way, main → renderer:
+
+| Channel            | Purpose                                                       |
+| ------------------ | ------------------------------------------------------------- |
+| `mcp:data-changed` | A successful call changed engine data; invalidate its queries. |
+
+**The UI reflects MCP writes live.** An MCP call mutates the engine from the
+main process, which no renderer query can observe (`refetchOnWindowFocus` is off
+app-wide), so a request an agent created used to stay invisible in the
+collection tree until some unrelated mutation happened to refetch the lists.
+Each tool declares the data families it changes (`invalidates` in `tools.ts`)
+and `dispatchTool` - the single dispatch path - sends one `mcp:data-changed` per
+family after a call that did **not** return an error. The event names a family
+(`request`, `environment`, `run`, `cookie`, `config`) plus the `collectionId` /
+`requestId` the call itself named; it carries no engine data, so the renderer
+still reads every row through its query layer. The renderer side, including
+which query keys each family maps to, is in
+[`docs/app/state-management.md`](../app/state-management.md).
+
+Declaring the families per tool rather than deriving them from `category` is
+deliberate: an `execute` tool writes a run row and refills the cookie jar
+without being a "write", and the field is required, so a new tool cannot ship
+silently invisible to the UI.
+
 The panel (`app/src/modules/settings/main/panels/McpSettingsPanel.tsx`) is a
 registered app-settings panel; it talks to `window.electronAPI` directly since
 MCP config is app-level, not engine-level.


### PR DESCRIPTION
## Description

The main-to-renderer invalidation channel #363 asks for. Every anchor in the issue reproduces on `e1b3592` exactly as described.

**The plan.** Root cause is that an MCP tool call mutates the engine from the Electron **main** process, so no renderer mutation runs and no query notices - and with `refetchOnWindowFocus` globally off (`lib/query-client.ts:36-42`) nothing ever catches up on its own. A request an agent created stayed invisible in the collection tree until some unrelated renderer mutation happened to blanket-invalidate the lists. The approach is the issue's: a minimal invalidation event at the single dispatch chokepoint, keyed off a per-tool declaration so a new write tool cannot forget to emit; the renderer maps the family to keys and refetches through its normal query layer. **The alternative I rejected** was pushing the written row over IPC - it is one call shorter, but it gives a row a second way to reach the UI, and the two paths drift the moment the engine's response shape and the renderer's normalization disagree. Also rejected: keying the emit off `category`, see below.

### The declaration is per tool, not derived from `category`

`McpTool` gains a **required** `invalidates: readonly McpDataEntity[]`. Deriving it from `category` would have been free and wrong: `run_request` and `run_collection_smoke` are `execute`, yet each writes a design-run row **and** refills the cookie jar (`queries/cookies.ts` states the jar changes exactly when a request is sent), and `start_load_run` / `stop_run` are `load` and write run rows. Required rather than optional is the point of the field - a default would let a new tool ship silently invisible to the UI, which is the bug being fixed. `[]` on the nine read tools is a statement, and a test asserts read tools declare it.

| Tool | Declares |
|---|---|
| `create_request` | `request` |
| `update_environment` | `environment` |
| `update_engine_config` | `config` |
| `run_request`, `run_collection_smoke` | `run`, `cookie` |
| `start_load_run`, `stop_run` | `run` |
| the nine read tools | *(nothing)* |

### The emit

`dispatchTool` sends one event per declared family after a handler that did **not** return an error result. A rejected call emits nothing - it may have reached the engine, but it cannot say so, and invalidating on every rejection is worse than the one stale list a genuinely-partial failure leaves. A throwing listener is logged and swallowed rather than turned into a tool error: notification failure must not fail a write the engine already applied, the rule `update_engine_config`'s best-effort read-back already follows.

The event's two scope hints (`collectionId`, `requestId`) are read from the call's own arguments at the chokepoint. Every tool in the registry spells those two the same way, which is precisely what keeps a new write tool from needing an emit of its own. A hint the call did not name is **absent**, not an empty string - pinned by a test, since `{ collectionId: "" }` would key an invalidation at a collection that does not exist.

### The renderer side

`useMcpDataInvalidation()` registers one listener in `App.tsx` (one per app - the events name a data family, not a screen, so a second subscriber only duplicates work) and maps through `lib/mcp-invalidation.ts`:

| Entity | Invalidates | Why that key |
|---|---|---|
| `request` | `requests.listByCollection(collectionId)`, else `requests.lists()` | The same narrowing `useUpdateRequestMutation` does; without a named owner the owner is unknowable here |
| `environment` | `environments.all` | Variables are read through the detail cache as well as the list |
| `run` | `runs.lists()`, `runs.allRuns()`, `+ runs.lastDesign(requestId)` | The history list polls on its own, so this is immediacy there - but Settings' count and a request tab's restored response are **not** polled and stayed stale indefinitely |
| `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
| `config` | `config.all` | |

Per-run reports and time series are deliberately untouched: a new run cannot have changed an existing run's report, and those are the expensive fetches in that family. The map is a `Record` over the union, so a new entity fails to compile until it names a reader - the "written but never read" guard the issue's own framing asks for. An unknown entity arriving over IPC is warned and dropped rather than thrown: a main process newer than the renderer bundle can legitimately name a family this build has not heard of, and throwing inside an IPC listener buys an unhandled rejection on top of the same stale list.

**Two deliberate notes.**

1. **The entity union is duplicated on purpose.** Production code under `electron/` cannot import from `app/src` - `tsconfig.node.json` withholds the `@/*` mapping for stated reasons - so `MCP_DATA_ENTITIES` (main) and `McpDataEntity` (renderer) are written twice. A silent divergence is the worst possible failure here: main emits a family the renderer's map has no entry for, and the write stays invisible, which is the bug. `data-changed.conformance.test.ts` is the one place the two meet, following the pattern `tsconfig.electron-test.json` documents.
2. **Deviation from the issue spec, in two places.** The issue names a `collection` entity and an `id?` field. No tool in the registry creates or deletes a collection, so a `collection` branch would be a mapping with no emitter - dead wiring of exactly the kind this repo keeps finding - and it is left out until a tool needs it. `id?` is replaced by the two named hints `collectionId` / `requestId`, because "the entity's id" is ambiguous on a `run` event (the `requestId` there is the saved request the run was *linked to*, the key `runs.lastDesign` uses, not the run's own id) and both named fields have concrete readers.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint` - all green.

- **`pnpm test`: 312 files, 2851 tests passed.** Base `e1b3592`, measured on this machine: **308 files, 2823 tests** - no pre-existing failures.
- `pnpm type-check` (all three projects), `pnpm lint`: clean.
- `prettier --check` on the 13 files this PR touches: clean. Repo-wide formatting untouched.
- **Engine untouched, so no engine build or `ctest` run** - per CLAUDE.md, no C++ test could change colour.
- `mkdocs` is not installed in this environment. The docs edits add no page, no heading and no anchor - two cross-directory relative links between existing pages, in the style `docs/app/pm-api-compatibility.md` already uses - so nothing `--strict` gates structurally changed.

**New (28 tests, 4 files):**

- `electron/mcp/data-changed.test.ts` (13) - the registry declares its effects (every tool has `invalidates`, read tools declare `[]`, and the mutating set is spelled out so a new mutating tool must be added or the guard notices); and the emit itself: a successful write emits exactly one event with its scope, a guard-rejected dispatch emits none, an engine error emits none, a read tool emits none, a disabled tool emits none, a two-entity tool emits one event each in order, unnamed hints are absent rather than empty, a context with no notifier dispatches normally, and a throwing listener leaves the write successful.
- `electron/mcp/data-changed.conformance.test.ts` (2) - the two copies of the entity list name the same families, plus the non-empty assertion CLAUDE.md requires of a scanning guard.
- `src/lib/mcp-invalidation.test.ts` (9) - one per entity, both `request` branches, the `lastDesign` addition, the report family staying untouched, and an unknown entity reported rather than thrown.
- `src/hooks/useMcpDataInvalidation.test.tsx` (3) - an event from main reaches the query cache, the listener unsubscribes on unmount, and the hook is inert with no `electronAPI`.

Every guard is mutation-checked - each reverted individually, its tests confirmed red, then restored (verified byte-identical with `cmp`):

| Mutation | Result |
|---|---|
| drop the emit entirely | 6 failed |
| emit even on an error result | 2 failed |
| `request` ignores the collection scope | 2 failed |
| `run` drops `lastDesign` | 1 failed |
| main-process entity list drifts from the renderer | 1 failed |
| the hook never registers | 2 failed |

No existing test file needed an edit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Docs

Same commit. `docs/engine/mcp.md` - the `mcp:data-changed` channel beside the existing IPC table, that the UI now reflects MCP writes live, and why the families are declared per tool rather than derived from `category`. `docs/app/state-management.md` - the entity-to-key table above, in the Query Keys & Cache Invalidation section that already documents why the cascade delete invalidates coarsely and the single-request update narrowly.

## Related Issues

Closes #363

---
_Generated by [Claude Code](https://claude.ai/code/session_015G8iWhQVdNmPaP8kyLv4k1)_