### PR TITLE
refactor(app/collection-tree): decompose CollectionTree before DnD - reveal and CRUD hooks, a context in place of the 33-prop drill

### DIFF
--- a/app/src/drawer-row-hit-area.test.tsx
+++ b/app/src/drawer-row-hit-area.test.tsx
@@ -49,6 +49,7 @@ import { TooltipProvider } from "@/components/ui";
 import RequestItem from "@/modules/collections/RequestItem";
 import CollectionItem from "@/modules/collections/CollectionItem";
 import VariablesCategoryTree from "@/modules/variables/sidebar/VariablesCategoryTree";
+import { withCollectionTreeContext } from "@/test/collection-tree-context";
 import type { Collection, Environment, Request } from "@/types";
 
 const REQUEST: Request = {
@@ -134,15 +135,10 @@ function requestRow(): Row {
 	const onSelect = vi.fn();
 	const onStartRename = vi.fn();
 	const { container } = render(
-		<RequestItem
-			request={REQUEST}
-			collectionId="col_1"
-			posInSet={1}
-			setSize={1}
-			onSelect={onSelect}
-			onDelete={vi.fn()}
-			onStartRename={onStartRename}
-		/>
+		withCollectionTreeContext(
+			<RequestItem request={REQUEST} collectionId="col_1" posInSet={1} setSize={1} />,
+			{ onRequestClick: onSelect, onStartRequestRename: onStartRename }
+		)
 	);
 	return {
 		row: container.querySelector('[role="treeitem"]') as HTMLElement,
@@ -156,42 +152,10 @@ function collectionRow(): Row {
 	const onCollectionClick = vi.fn();
 	const onStartRename = vi.fn();
 	const { container } = render(
-		<CollectionItem
-			collection={COLLECTION}
-			allCollections={[COLLECTION]}
-			depth={0}
-			posInSet={1}
-			setSize={1}
-			expandedCollectionIds={new Set()}
-			selectedCollectionId={null}
-			selectedRequestId={null}
-			renamingId={null}
-			renameValue=""
-			deletingCollectionId={null}
-			deletingRequestId={null}
-			creatingSubfolder={null}
-			newSubCollectionName=""
-			isCreatingSubfolder={false}
-			renamingRequestId={null}
-			renameRequestValue=""
-			getRequestsByCollection={() => []}
-			onCollectionClick={onCollectionClick}
-			onRequestClick={vi.fn()}
-			onCollectionToggle={vi.fn()}
-			getCollectionActions={() => []}
-			onRenameChange={vi.fn()}
-			onRenameSubmit={vi.fn()}
-			onRenameCancel={vi.fn()}
-			onStartRename={onStartRename}
-			onDeleteRequest={vi.fn()}
-			onSubCollectionNameChange={vi.fn()}
-			onCreateSubfolder={vi.fn()}
-			onCancelSubfolder={vi.fn()}
-			onRequestRenameChange={vi.fn()}
-			onRequestRenameSubmit={vi.fn()}
-			onRequestRenameCancel={vi.fn()}
-			onStartRequestRename={vi.fn()}
-		/>
+		withCollectionTreeContext(
+			<CollectionItem collection={COLLECTION} depth={0} posInSet={1} setSize={1} />,
+			{ allCollections: [COLLECTION], onCollectionClick, onStartRename }
+		)
 	);
 	return {
 		row: container.querySelector('[role="treeitem"]') as HTMLElement,

--- a/app/src/modules/collections/CollectionItem.tsx
+++ b/app/src/modules/collections/CollectionItem.tsx
@@ -8,16 +8,22 @@
 import { useEffect, useRef } from "react";
 import { ChevronRight, ChevronDown, Folder, FolderOpen, Loader2 } from "lucide-react";
 import RequestItem from "./RequestItem";
-import type { Collection, Request } from "@/types";
+import { useCollectionTreeContext } from "./context/CollectionTreeContext";
+import type { Collection } from "@/types";
 import { compareTreeOrder } from "@/types";
 import { Button, Input } from "@/components/ui";
-import { RowActionsMenu, TruncatedText, type RowAction } from "@/components/shared";
+import { RowActionsMenu, TruncatedText } from "@/components/shared";
 import { cn } from "@/lib/utils";
 import { INDENT_STEP } from "@/constants/layout";
 
+/**
+ * What differs per row. Everything shared - the expanded set, the selection,
+ * the rename and delete state, every handler - comes from
+ * `CollectionTreeContext`, because this component renders itself and each prop
+ * would otherwise have to be re-threaded at every depth.
+ */
 export interface CollectionItemProps {
 	collection: Collection;
-	allCollections: Collection[];
 	depth: number;
 	/**
 	 * 1-based position among the rows this one shares a parent with, and how
@@ -28,81 +34,38 @@ export interface CollectionItemProps {
 	 */
 	posInSet: number;
 	setSize: number;
-	expandedCollectionIds: Set<string>;
-	selectedCollectionId: string | null;
-	selectedRequestId: string | null;
-	renamingId: string | null;
-	renameValue: string;
-	deletingCollectionId: string | null;
-	deletingRequestId: string | null;
-	creatingSubfolder: string | null;
-	newSubCollectionName: string;
-	isCreatingSubfolder: boolean;
-	renamingRequestId: string | null;
-	renameRequestValue: string;
-	getRequestsByCollection: (collectionId: string) => Request[];
-	onCollectionClick: (collection: Collection) => void;
-	onRequestClick: (collectionId: string, requestId: string) => void;
-	onCollectionToggle: (collection: Collection) => void;
-	/** Actions for this collection's ⋯ menu; built by CollectionTree. */
-	getCollectionActions: (collection: Collection) => RowAction[];
-	onRenameChange: (value: string) => void;
-	onRenameSubmit: (collectionId: string) => void;
-	onRenameCancel: () => void;
-	onStartRename: (collection: Collection) => void;
-	onDeleteRequest: (requestId: string) => Promise<void>;
-	onRequestDeleteClick?: (requestId: string, requestName: string) => void;
-	/** Opens the confirm dialog for this collection - the Delete key's target. */
-	onCollectionDeleteClick?: (collectionId: string, collectionName: string) => void;
-	onDuplicateRequest?: (request: Request) => void;
-	onSubCollectionNameChange: (value: string) => void;
-	onCreateSubfolder: (parentId: string) => void;
-	onCancelSubfolder: () => void;
-	onRequestRenameChange: (value: string) => void;
-	onRequestRenameSubmit: (requestId: string) => void;
-	onRequestRenameCancel: () => void;
-	onStartRequestRename: (request: Request) => void;
 }
 
 export default function CollectionItem({
 	collection,
-	allCollections,
 	depth,
 	posInSet,
 	setSize,
-	expandedCollectionIds,
-	selectedCollectionId,
-	selectedRequestId,
-	renamingId,
-	renameValue,
-	deletingCollectionId,
-	deletingRequestId,
-	creatingSubfolder,
-	newSubCollectionName,
-	isCreatingSubfolder,
-	renamingRequestId,
-	renameRequestValue,
-	getRequestsByCollection,
-	onCollectionClick,
-	onRequestClick,
-	onCollectionToggle,
-	getCollectionActions,
-	onRenameChange,
-	onRenameSubmit,
-	onRenameCancel,
-	onStartRename,
-	onDeleteRequest,
-	onRequestDeleteClick,
-	onCollectionDeleteClick,
-	onDuplicateRequest,
-	onSubCollectionNameChange,
-	onCreateSubfolder,
-	onCancelSubfolder,
-	onRequestRenameChange,
-	onRequestRenameSubmit,
-	onRequestRenameCancel,
-	onStartRequestRename,
 }: CollectionItemProps) {
+	const {
+		allCollections,
+		expandedCollectionIds,
+		selectedCollectionId,
+		renamingId,
+		renameValue,
+		deletingCollectionId,
+		creatingSubfolder,
+		newSubCollectionName,
+		isCreatingSubfolder,
+		getRequestsByCollection,
+		getCollectionActions,
+		onCollectionClick,
+		onCollectionToggle,
+		onRenameChange,
+		onRenameSubmit,
+		onRenameCancel,
+		onStartRename,
+		onCollectionDeleteClick,
+		onSubCollectionNameChange,
+		onCreateSubfolder,
+		onCancelSubfolder,
+	} = useCollectionTreeContext();
+
 	const isExpanded = expandedCollectionIds.has(collection.id);
 	// Open-folder glyph while expanded, so the folder itself echoes the chevron.
 	const FolderIcon = isExpanded ? FolderOpen : Folder;
@@ -348,7 +311,7 @@ export default function CollectionItem({
 					data-tree-delete
 					onClick={() => {
 						if (isDeleting) return;
-						onCollectionDeleteClick?.(collection.id, collection.name);
+						onCollectionDeleteClick(collection.id, collection.name);
 					}}
 				/>
 			</div>
@@ -395,47 +358,16 @@ export default function CollectionItem({
 						</div>
 					)}
 
-					{/* Child Collections (Subfolders) - Recursive */}
+					{/* Child Collections (Subfolders) - Recursive.
+					    Four props, all of them this row's own position in the tree:
+					    everything shared arrives through the context instead. */}
 					{childCollections.map((childCollection, index) => (
 						<CollectionItem
 							key={childCollection.id}
 							collection={childCollection}
-							allCollections={allCollections}
 							depth={depth + 1}
 							posInSet={index + 1}
 							setSize={childSetSize}
-							expandedCollectionIds={expandedCollectionIds}
-							selectedCollectionId={selectedCollectionId}
-							selectedRequestId={selectedRequestId}
-							renamingId={renamingId}
-							renameValue={renameValue}
-							deletingCollectionId={deletingCollectionId}
-							deletingRequestId={deletingRequestId}
-							creatingSubfolder={creatingSubfolder}
-							newSubCollectionName={newSubCollectionName}
-							isCreatingSubfolder={isCreatingSubfolder}
-							getRequestsByCollection={getRequestsByCollection}
-							onCollectionClick={onCollectionClick}
-							onCollectionToggle={onCollectionToggle}
-							onRequestClick={onRequestClick}
-							getCollectionActions={getCollectionActions}
-							onRenameChange={onRenameChange}
-							onRenameSubmit={onRenameSubmit}
-							onRenameCancel={onRenameCancel}
-							onStartRename={onStartRename}
-							onDeleteRequest={onDeleteRequest}
-							onRequestDeleteClick={onRequestDeleteClick}
-							onCollectionDeleteClick={onCollectionDeleteClick}
-							onDuplicateRequest={onDuplicateRequest}
-							onSubCollectionNameChange={onSubCollectionNameChange}
-							onCreateSubfolder={onCreateSubfolder}
-							onCancelSubfolder={onCancelSubfolder}
-							onRequestRenameChange={onRequestRenameChange}
-							onRequestRenameSubmit={onRequestRenameSubmit}
-							onRequestRenameCancel={onRequestRenameCancel}
-							onStartRequestRename={onStartRequestRename}
-							renamingRequestId={renamingRequestId}
-							renameRequestValue={renameRequestValue}
 						/>
 					))}
 
@@ -455,18 +387,6 @@ export default function CollectionItem({
 							depth={depth + 1}
 							posInSet={childCollections.length + index + 1}
 							setSize={childSetSize}
-							onSelect={onRequestClick}
-							onDelete={onDeleteRequest}
-							onBeforeDelete={onRequestDeleteClick}
-							isDeleting={deletingRequestId === request.id}
-							isSelected={selectedRequestId === request.id}
-							isRenaming={renamingRequestId === request.id}
-							renameValue={renameRequestValue}
-							onRenameChange={onRequestRenameChange}
-							onRenameSubmit={onRequestRenameSubmit}
-							onRenameCancel={onRequestRenameCancel}
-							onStartRename={onStartRequestRename}
-							onDuplicate={onDuplicateRequest}
 						/>
 					))}
 				</div>

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -5,20 +5,11 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { Folder, Plus, Trash2, Edit2, FolderPlus, Loader2, Download } from "lucide-react";
-import { useTabsStore, useSaveStore, useImportModalStore } from "@/stores";
+import { useRef, useCallback, useMemo } from "react";
+import { Folder, Plus, FolderPlus, Loader2, Download } from "lucide-react";
+import { useTabsStore, useImportModalStore } from "@/stores";
 import { useCollectionsStore } from "@/modules/collections/collections-store";
-import {
-	useCollectionsQuery,
-	useMultipleCollectionRequests,
-	useCreateCollectionMutation,
-	useUpdateCollectionMutation,
-	useDeleteCollectionMutation,
-	useCreateRequestMutation,
-	useDeleteRequestMutation,
-	useUpdateRequestMutation,
-} from "@/queries";
+import { useCollectionsQuery, useMultipleCollectionRequests } from "@/queries";
 import {
 	Button,
 	Input,
@@ -29,45 +20,27 @@ import {
 } from "@/components/ui";
 import CollectionItem from "./CollectionItem";
 import { useRovingTreeFocus } from "./useRovingTreeFocus";
-import { walkAncestors, collectDescendantEntityIds } from "./tree-utils";
+import { useRevealActiveSelection } from "./useRevealActiveSelection";
+import { useTreeCrud } from "./useTreeCrud";
+import {
+	CollectionTreeContext,
+	type CollectionTreeContextValue,
+} from "./context/CollectionTreeContext";
 import { DrawerPanel, EmptyState, ErrorState, ListSkeleton } from "@/components/shared";
-import type { RowAction } from "@/components/shared";
-import type { Collection, Request } from "@/types";
+import type { Request } from "@/types";
 import { compareTreeOrder } from "@/types";
-import { DEFAULT_REQUEST_NAME } from "@/constants/request";
-import { DEFAULT_COLLECTION_NAME, DEFAULT_FOLDER_NAME } from "@/constants/collection";
 
 export default function CollectionTree() {
 	const openImport = useImportModalStore((s) => s.open);
-	const { openTab, openTabs, activeTabId, closeTabsForEntities } = useTabsStore();
-	const { expandedCollectionIds, toggleCollectionExpanded, expandCollection, expandCollections } =
-		useCollectionsStore();
-	const { startSaving, completeSaveThenIdle, failSave } = useSaveStore();
+	const { openTabs, activeTabId } = useTabsStore();
+	const { expandedCollectionIds, expandCollections } = useCollectionsStore();
 	const treeRef = useRef<HTMLDivElement>(null);
 	const treeFocus = useRovingTreeFocus(treeRef);
-	// Both reveal and scroll are once-per-selection, and each records the
-	// selection it last acted on. They cannot share one ref: the scroll can only
-	// run a render *after* the reveal, once the expanded ancestors have put the
-	// row in the DOM.
-	const revealedSelectionRef = useRef<string | null>(null);
-	const scrolledSelectionRef = useRef<string | null>(null);
 
 	// Get selected collection and request IDs from active tab
 	const activeTab = openTabs.find((t) => t.id === activeTabId);
 	const selectedCollectionId = activeTab?.type === "collection" ? activeTab.entityId : null;
 	const selectedRequestId = activeTab?.type === "request" ? activeTab.entityId : null;
-
-	// Memoised because the callbacks below list them as dependencies: redefined
-	// each render, they would rebuild every handler that opens a tab.
-	const navigateToRequest = useCallback(
-		(_collectionId: string, requestId: string) =>
-			openTab({ type: "request", entityId: requestId }),
-		[openTab]
-	);
-	const navigateToCollection = useCallback(
-		(collectionId: string) => openTab({ type: "collection", entityId: collectionId }),
-		[openTab]
-	);
 
 	// TanStack Query hooks
 	// isError as well as isLoading. The query is destructured with `= []`, so a
@@ -86,14 +59,6 @@ export default function CollectionTree() {
 	// This ensures the UI reflects the data immediately on load
 	const allCollectionIds = collections.map((c) => c.id);
 	const { requestsByCollection } = useMultipleCollectionRequests(allCollectionIds);
-
-	// Mutation hooks
-	const createCollectionMutation = useCreateCollectionMutation();
-	const updateCollectionMutation = useUpdateCollectionMutation();
-	const deleteCollectionMutation = useDeleteCollectionMutation();
-	const createRequestMutation = useCreateRequestMutation();
-	const deleteRequestMutation = useDeleteRequestMutation();
-	const updateRequestMutation = useUpdateRequestMutation();
 
 	const getRequestsByCollection = useCallback(
 		(collectionId: string): Request[] => requestsByCollection.get(collectionId) ?? [],
@@ -115,459 +80,43 @@ export default function CollectionTree() {
 			.sort(compareTreeOrder);
 	}, [collections]);
 
-	/*
-	 * Reveal whatever the active tab points at: expand its ancestor folders so
-	 * the row is rendered, then (in the effect below) scroll it into view.
-	 *
-	 * This used to handle requests only, which is why switching to a *collection*
-	 * tab looked like the sidebar ignored it - a collection nested inside a
-	 * collapsed parent has no row in the tree at all, so there was nothing to
-	 * highlight and nothing to scroll to. `selectedCollectionId` was computed and
-	 * then only used for a label and a highlight, so nothing revealed it.
-	 *
-	 * Settings and Variables never had the problem because they own a whole
-	 * drawer view; a request did not because of this effect. A collection fell
-	 * between the two.
-	 *
-	 * Guarded by a ref so it fires once per selection - the same discipline the
-	 * scroll effect below has always had. Unguarded, it re-ran after *every*
-	 * render of the tree (it lists `requestsByCollection` and `collections`, and
-	 * the tree re-renders on any expand-state change), so collapsing a
-	 * collection that held the selected request re-expanded it in the same
-	 * frame: the chevron looked dead and every ancestor of the active tab was
-	 * pinned open. Once per selection *change* means switching tabs away and
-	 * back reveals again, which is the behaviour that was wanted all along.
-	 */
-	useEffect(() => {
-		const selectionId = selectedCollectionId ?? selectedRequestId;
-		if (!selectionId) {
-			// Settings, Variables, no tab at all: re-selecting the entity later is a
-			// fresh selection and must reveal again.
-			revealedSelectionRef.current = null;
-			scrolledSelectionRef.current = null;
-			return;
-		}
-		if (revealedSelectionRef.current === selectionId) return;
-
-		// A collection reveals itself; a request reveals the collection holding it.
-		let target: string | undefined;
-		if (selectedCollectionId) {
-			target = selectedCollectionId;
-		} else {
-			for (const [collectionId, reqs] of requestsByCollection) {
-				if (reqs.some((r) => r.id === selectedRequestId)) {
-					target = collectionId;
-					break;
-				}
-			}
-		}
-		// The owning collection's requests may not have arrived yet. Leave the ref
-		// unset so this reveals once they do, rather than counting as done.
-		if (!target) return;
-
-		// walkAncestors, not a local loop: this walk is unbounded on a `parentId`
-		// cycle, which hangs the renderer inside an effect (see tree-utils).
-		const ancestorChain = walkAncestors(target, collections).map((c) => c.id);
-		revealedSelectionRef.current = selectionId;
-		expandCollections(ancestorChain);
-	}, [
+	useRevealActiveSelection(treeRef, {
+		selectedCollectionId,
 		selectedRequestId,
+		collections,
+		requestsByCollection,
+		expandedCollectionIds,
+		expandCollections,
+	});
+
+	const { panel, rows } = useTreeCrud({
+		collections,
+		rootCollections,
 		selectedCollectionId,
 		requestsByCollection,
-		collections,
-		expandCollections,
-	]);
+		getRequestsByCollection,
+	});
 
-	/*
-	 * Once the selected row exists (after ancestors expand), scroll it into view.
-	 * Guarded by a ref so it only fires once per selection - otherwise every
-	 * expand/collapse elsewhere in the tree would yank the view back.
-	 */
-	useEffect(() => {
-		const id = selectedCollectionId ?? selectedRequestId;
-		if (!id || scrolledSelectionRef.current === id) return;
-		const attr = selectedCollectionId ? "data-collection-id" : "data-request-id";
-		const row = treeRef.current?.querySelector(`[${attr}="${CSS.escape(id)}"]`);
-		if (row) {
-			row.scrollIntoView({ block: "nearest" });
-			scrolledSelectionRef.current = id;
-		}
-	}, [selectedRequestId, selectedCollectionId, expandedCollectionIds, requestsByCollection]);
-
-	const [creatingCollection, setCreatingCollection] = useState(false);
-	const [creatingSubfolder, setCreatingSubfolder] = useState<string | null>(null); // parent collection ID
-	const [newCollectionName, setNewCollectionName] = useState(DEFAULT_COLLECTION_NAME);
-	const [newSubCollectionName, setNewSubCollectionName] = useState(DEFAULT_FOLDER_NAME);
-	const [renamingId, setRenamingId] = useState<string | null>(null);
-	const [renameValue, setRenameValue] = useState("");
-	const [renamingRequestId, setRenamingRequestId] = useState<string | null>(null);
-	const [renameRequestValue, setRenameRequestValue] = useState("");
-	const [deletingCollectionId, setDeletingCollectionId] = useState<string | null>(null);
-	const [deletingRequestId, setDeletingRequestId] = useState<string | null>(null);
-	const [deleteConfirm, setDeleteConfirm] = useState<{
-		type: "collection" | "request";
-		id: string;
-		name: string;
-	} | null>(null);
-	/**
-	 * Report a failed mutation through the same channel the rename path already
-	 * uses - `failSave` puts "Save failed" in the Dock.
-	 *
-	 * Rename was the only handler here that caught anything. Create and delete
-	 * called `mutateAsync` bare, so a rejection was an unhandled promise and
-	 * nothing else: a failed delete closed the confirm dialog, un-dimmed the row
-	 * and left the collection sitting there with no explanation, which reads as
-	 * "the click didn't register" rather than "the delete failed".
-	 */
-	const reportFailure = useCallback(
-		(error: unknown, fallback: string) =>
-			failSave(error instanceof Error ? error.message : fallback),
-		[failSave]
-	);
-
-	const handleRenameCancel = useCallback(() => {
-		setRenamingId(null);
-		setRenameValue("");
-	}, []);
-
-	const handleCancelSubfolder = useCallback(() => {
-		setCreatingSubfolder(null);
-		setNewSubCollectionName(DEFAULT_FOLDER_NAME);
-	}, []);
-
-	const handleCollectionClick = useCallback(
-		(collection: Collection) => {
-			navigateToCollection(collection.id);
-		},
-		[navigateToCollection]
-	);
-
-	const handleCollectionToggle = useCallback(
-		(collection: Collection) => {
-			toggleCollectionExpanded(collection.id);
-		},
-		[toggleCollectionExpanded]
-	);
-
-	const handleOpenNewCollectionForm = useCallback(() => {
-		setNewCollectionName(DEFAULT_COLLECTION_NAME);
-		setCreatingCollection(true);
-	}, []);
-
-	// Handle "New Request" button click - use selected collection or first root
-	const handleNewRequestClick = () => {
-		if (rootCollections.length === 0) {
-			// No collections - prompt to create one first
-			handleOpenNewCollectionForm();
-			return;
-		}
-
-		// Use selected collection only if it still exists; otherwise first root collection
-		const selectedExists =
-			selectedCollectionId && collections.some((c) => c.id === selectedCollectionId);
-		const targetCollection =
-			(selectedExists ? selectedCollectionId : null) ?? rootCollections[0].id;
-		handleCreateRequest(targetCollection);
-	};
-
-	const handleRequestClick = (collectionId: string, requestId: string) => {
-		navigateToRequest(collectionId, requestId);
-	};
-
-	const handleCreateCollection = async () => {
-		if (!newCollectionName.trim() || createCollectionMutation.isPending) return;
-
-		try {
-			await createCollectionMutation.mutateAsync({ name: newCollectionName.trim() });
-		} catch (error) {
-			reportFailure(error, "Failed to create collection");
-			return; // Keep the form open with the typed name so it can be retried.
-		}
-		setNewCollectionName("");
-		setCreatingCollection(false);
-	};
-
-	const handleCreateSubfolder = async (parentId: string) => {
-		if (!newSubCollectionName.trim() || createCollectionMutation.isPending) return;
-
-		expandCollection(parentId);
-
-		try {
-			await createCollectionMutation.mutateAsync({
-				name: newSubCollectionName.trim(),
-				parentId: parentId,
-			});
-		} catch (error) {
-			reportFailure(error, "Failed to create folder");
-			return;
-		}
-		handleCancelSubfolder();
-	};
-
-	// Memoised because `getCollectionActions` lists it: rebuilt every render, it
-	// would rebuild every collection's ⋯ menu with it.
-	const handleCreateRequest = useCallback(
-		async (collectionId: string) => {
-			if (createRequestMutation.isPending) return;
-
-			expandCollection(collectionId);
-
-			let request: Request | undefined;
-			try {
-				request = await createRequestMutation.mutateAsync({
-					collectionId: collectionId,
-					name: DEFAULT_REQUEST_NAME,
-					method: "GET",
-					url: "",
-				});
-			} catch (error) {
-				reportFailure(error, "Failed to create request");
-				return;
-			}
-
-			if (request) {
-				navigateToRequest(collectionId, request.id);
-			}
-		},
-		[createRequestMutation, expandCollection, navigateToRequest, reportFailure]
-	);
-
-	const handleRenameCollection = useCallback((collection: Collection) => {
-		setRenamingId(collection.id);
-		setRenameValue(collection.name);
-	}, []);
-
-	// Named, so the ⋯ menu's Delete and the row's hidden `data-tree-delete`
-	// control (the Delete key's target) open the very same dialog rather than
-	// being two copies of one object literal that can drift apart.
-	const handleCollectionDeleteClick = useCallback((id: string, name: string) => {
-		setDeleteConfirm({ type: "collection", id, name });
-	}, []);
-
-	const handleRenameSubmit = async (collectionId: string) => {
-		const trimmedValue = renameValue.trim();
-		// Enter submits and then blur submits again, because the field is still
-		// mounted while the PUT is in flight. Clearing the rename state *before*
-		// awaiting unmounts the field, so there is no second blur to fire - and a
-		// name that did not change never reaches the wire at all, which is the
-		// guard the request-rename path has always had and this one had not.
-		setRenamingId(null);
-		setRenameValue("");
-
-		const original = collections.find((c) => c.id === collectionId);
-		if (!trimmedValue || original?.name === trimmedValue) return;
-
-		startSaving();
-		try {
-			await updateCollectionMutation.mutateAsync({
-				id: collectionId,
-				name: trimmedValue,
-			});
-			completeSaveThenIdle();
-		} catch (error) {
-			failSave(error instanceof Error ? error.message : "Failed to rename collection");
-		}
-	};
-
-	/**
-	 * Duplicate a request, contents and all - method, URL, params, headers,
-	 * body, auth and both scripts. Collections deliberately have no equivalent:
-	 * copying one means recursing through nested folders and issuing a create
-	 * per request, which is its own feature. The previous collection "Duplicate"
-	 * only created an empty folder named "(Copy)", which read as a working clone
-	 * and was not one, so it was removed rather than left misleading.
-	 */
-	const handleDuplicateRequest = useCallback(
-		async (request: Request) => {
-			if (createRequestMutation.isPending) return;
-			try {
-				const copy = await createRequestMutation.mutateAsync({
-					collectionId: request.collectionId,
-					name: `${request.name} (Copy)`,
-					description: request.description,
-					method: request.method,
-					url: request.url,
-					params: request.params,
-					headers: request.headers,
-					body: request.body,
-					bodyType: request.bodyType,
-					auth: request.auth,
-					preRequestScript: request.preRequestScript,
-					postRequestScript: request.postRequestScript,
-					/*
-					 * The copy takes its source's `order`, which lands it directly
-					 * *after* the source: the tie falls to `createdAt` and the copy is
-					 * newer (see `compareTreeOrder`, pinned to the engine's SQL). An
-					 * omitted order would append it to the end of the collection, and
-					 * inserting it at `order + 1` would need every following sibling
-					 * renumbered - a multi-row write that belongs to the atomic batch
-					 * reorder endpoint, not to a duplicate.
-					 */
-					order: request.order,
-				});
-				openTab({ type: "request", entityId: copy.id });
-			} catch (error) {
-				reportFailure(error, "Failed to duplicate request");
-			}
-		},
-		[createRequestMutation, openTab, reportFailure]
-	);
-
-	/**
-	 * Actions for a collection's "⋯" menu. Defined here, where the handlers and
-	 * state live, and rendered by the shared RowActionsMenu - the same component
-	 * request and environment rows use, so every row menu looks and behaves
-	 * alike. This replaced a hand-rolled fixed-position popover that had to
-	 * compute its own coordinates and close itself on an outside click, and
-	 * which had no keyboard support.
-	 */
-	const getCollectionActions = useCallback(
-		(collection: Collection): RowAction[] => [
-			{
-				label: "Rename",
-				icon: Edit2,
-				onSelect: () => handleRenameCollection(collection),
-			},
-			{
-				label: "Add Request",
-				icon: Plus,
-				onSelect: () => void handleCreateRequest(collection.id),
-			},
-			{
-				label: "Add Folder",
-				icon: FolderPlus,
-				onSelect: () => {
-					expandCollection(collection.id);
-					setCreatingSubfolder(collection.id);
-				},
-			},
-			{
-				label: "Delete",
-				icon: Trash2,
-				destructive: true,
-				onSelect: () => handleCollectionDeleteClick(collection.id, collection.name),
-			},
-		],
-		// Honest deps, which is only possible now that both handlers are memoised
-		// and the expand goes through `expandCollection` rather than reading the
-		// expanded set. The suppression that used to sit here hid two callbacks
-		// captured from whichever render last rebuilt this - benign only by
-		// accident, and this is the seam the drag-and-drop work extends.
-		[expandCollection, handleCreateRequest, handleRenameCollection, handleCollectionDeleteClick]
-	);
-
-	const handleDeleteCollection = useCallback(
-		async (collectionId: string) => {
-			setDeletingCollectionId(collectionId);
-			// Gather the collection, its descendant folders, and every request they
-			// contain: deleting a collection cascades, so all their tabs go stale.
-			const affected = collectDescendantEntityIds(collectionId, collections, (id) =>
-				getRequestsByCollection(id).map((r) => r.id)
-			);
-			try {
-				await deleteCollectionMutation.mutateAsync(collectionId);
-				closeTabsForEntities(affected);
-			} catch (error) {
-				reportFailure(error, "Failed to delete collection");
-			} finally {
-				// Only now: the dialog stays up, with its confirm button spinning,
-				// for as long as the delete is actually running.
-				setDeleteConfirm(null);
-				setDeletingCollectionId(null);
-			}
-		},
-		[
-			deleteCollectionMutation,
-			closeTabsForEntities,
-			collections,
+	const treeContext = useMemo<CollectionTreeContextValue>(
+		() => ({
+			allCollections: collections,
+			expandedCollectionIds,
+			selectedCollectionId,
+			selectedRequestId,
 			getRequestsByCollection,
-			reportFailure,
+			// Phase 3 (#367) mounts the drag machinery here; see the context module.
+			dnd: null,
+			...rows,
+		}),
+		[
+			collections,
+			expandedCollectionIds,
+			selectedCollectionId,
+			selectedRequestId,
+			getRequestsByCollection,
+			rows,
 		]
 	);
-
-	const handleDeleteRequest = useCallback(
-		async (requestId: string) => {
-			setDeletingRequestId(requestId);
-			try {
-				await deleteRequestMutation.mutateAsync(requestId);
-				// Close any open tab pointing at the now-deleted request.
-				closeTabsForEntities([requestId]);
-			} catch (error) {
-				reportFailure(error, "Failed to delete request");
-			} finally {
-				setDeleteConfirm(null);
-				setDeletingRequestId(null);
-			}
-		},
-		[deleteRequestMutation, closeTabsForEntities, reportFailure]
-	);
-
-	const handleRequestDeleteClick = useCallback((requestId: string, requestName: string) => {
-		setDeleteConfirm({ type: "request", id: requestId, name: requestName });
-	}, []);
-
-	const handleConfirmDelete = useCallback(() => {
-		if (!deleteConfirm) return;
-		// The dialog now stays open while the delete runs, so its confirm button
-		// survives long enough to be clicked twice. `isDeleting` disables it from
-		// the next render on; this covers the frame before that.
-		if (deletingCollectionId || deletingRequestId) return;
-		if (deleteConfirm.type === "collection") {
-			handleDeleteCollection(deleteConfirm.id);
-		} else {
-			handleDeleteRequest(deleteConfirm.id);
-		}
-	}, [
-		deleteConfirm,
-		deletingCollectionId,
-		deletingRequestId,
-		handleDeleteCollection,
-		handleDeleteRequest,
-	]);
-
-	const handleStartRequestRename = (request: Request) => {
-		setRenamingRequestId(request.id);
-		setRenameRequestValue(request.name);
-	};
-
-	const handleRequestRenameSubmit = async (requestId: string) => {
-		const trimmedValue = renameRequestValue.trim();
-		// Cleared before the await for the same reason as the collection path:
-		// while the field is still mounted, the blur that follows Enter submits a
-		// second time.
-		setRenamingRequestId(null);
-		setRenameRequestValue("");
-
-		// Find the original request to check if name actually changed
-		// Search through all collections to find the request
-		let originalRequest: Request | undefined;
-		for (const requests of requestsByCollection.values()) {
-			const found = requests.find((r) => r.id === requestId);
-			if (found) {
-				originalRequest = found;
-				break;
-			}
-		}
-
-		// Empty name, or a name that did not change: nothing to save.
-		if (!trimmedValue || originalRequest?.name === trimmedValue) return;
-
-		startSaving();
-		try {
-			await updateRequestMutation.mutateAsync({
-				id: requestId,
-				name: trimmedValue,
-			});
-			completeSaveThenIdle();
-		} catch (error) {
-			failSave(error instanceof Error ? error.message : "Failed to rename request");
-		}
-	};
-
-	const handleRequestRenameCancel = useCallback(() => {
-		setRenamingRequestId(null);
-		setRenameRequestValue("");
-	}, []);
 
 	return (
 		<DrawerPanel
@@ -581,12 +130,12 @@ export default function CollectionTree() {
 							<Button
 								variant="ghost"
 								size="icon"
-								onClick={handleOpenNewCollectionForm}
-								disabled={createCollectionMutation.isPending}
+								onClick={panel.openNewCollectionForm}
+								disabled={panel.isCreatingCollection}
 								className="h-8 w-8"
 								aria-label="Add collection"
 							>
-								{createCollectionMutation.isPending ? (
+								{panel.isCreatingCollection ? (
 									<Loader2 className="w-4 h-4 animate-spin" />
 								) : (
 									<FolderPlus className="w-4 h-4" />
@@ -600,12 +149,12 @@ export default function CollectionTree() {
 							<Button
 								variant="ghost"
 								size="icon"
-								onClick={handleNewRequestClick}
-								disabled={createRequestMutation.isPending}
+								onClick={panel.createRequestFromToolbar}
+								disabled={panel.isCreatingRequest}
 								className="h-8 w-8"
 								aria-label="Add request"
 							>
-								{createRequestMutation.isPending ? (
+								{panel.isCreatingRequest ? (
 									<Loader2 className="w-4 h-4 animate-spin" />
 								) : (
 									<Plus className="w-4 h-4" />
@@ -645,30 +194,27 @@ export default function CollectionTree() {
 				 * ring was clipped; the padding gives it room. Same fix the History
 				 * search field uses (see HistoryList).
 				 */}
-				{creatingCollection && (
+				{panel.creatingCollection && (
 					<div className="flex gap-2 mb-2 px-3 pt-2">
 						<Input
 							type="text"
-							value={newCollectionName}
-							onChange={(e) => setNewCollectionName(e.target.value)}
+							value={panel.newCollectionName}
+							onChange={(e) => panel.setNewCollectionName(e.target.value)}
 							onKeyDown={(e) => {
-								if (e.key === "Enter") handleCreateCollection();
-								if (e.key === "Escape") {
-									setCreatingCollection(false);
-									setNewCollectionName("");
-								}
+								if (e.key === "Enter") panel.createCollection();
+								if (e.key === "Escape") panel.cancelNewCollectionForm();
 							}}
 							placeholder="Collection name"
 							className="flex-1 h-8 text-sm"
-							disabled={createCollectionMutation.isPending}
+							disabled={panel.isCreatingCollection}
 							autoFocus
 						/>
 						<Button
 							size="sm"
-							onClick={handleCreateCollection}
-							disabled={createCollectionMutation.isPending}
+							onClick={panel.createCollection}
+							disabled={panel.isCreatingCollection}
 						>
-							{createCollectionMutation.isPending && (
+							{panel.isCreatingCollection && (
 								<Loader2 className="w-3 h-3 animate-spin mr-1" />
 							)}
 							Add
@@ -676,11 +222,8 @@ export default function CollectionTree() {
 						<Button
 							variant="secondary"
 							size="sm"
-							onClick={() => {
-								setCreatingCollection(false);
-								setNewCollectionName("");
-							}}
-							disabled={createCollectionMutation.isPending}
+							onClick={panel.cancelNewCollectionForm}
+							disabled={panel.isCreatingCollection}
 						>
 							Cancel
 						</Button>
@@ -709,7 +252,7 @@ export default function CollectionTree() {
 				{!isLoadingCollections &&
 					!collectionsFailed &&
 					collections.length === 0 &&
-					!creatingCollection && (
+					!panel.creatingCollection && (
 						<EmptyState
 							icon={Folder}
 							title="No collections yet"
@@ -717,7 +260,7 @@ export default function CollectionTree() {
 							action={
 								<Button
 									variant="link"
-									onClick={handleOpenNewCollectionForm}
+									onClick={panel.openNewCollectionForm}
 									className="text-primary"
 								>
 									Add your first collection
@@ -728,7 +271,9 @@ export default function CollectionTree() {
 
 				{/* Root-level collections (no parent loaded) - sorted by order, scrollable.
 			    role="tree" + roving tabindex: the whole tree is one tab stop and
-			    arrow keys move between rows (see useRovingTreeFocus). */}
+			    arrow keys move between rows (see useRovingTreeFocus).
+			    Everything a row needs beyond its own entity comes from the
+			    context - see CollectionTreeContext for why it is not props. */}
 				{!isLoadingCollections && rootCollections.length > 0 && (
 					<div className="flex-1 min-h-0">
 						<div
@@ -738,48 +283,17 @@ export default function CollectionTree() {
 							onFocus={treeFocus.onFocus}
 							className="space-y-0.5"
 						>
-							{rootCollections.map((collection, index) => (
-								<CollectionItem
-									key={collection.id}
-									collection={collection}
-									allCollections={collections}
-									depth={0}
-									posInSet={index + 1}
-									setSize={rootCollections.length}
-									expandedCollectionIds={expandedCollectionIds}
-									selectedCollectionId={selectedCollectionId}
-									selectedRequestId={selectedRequestId}
-									renamingId={renamingId}
-									renameValue={renameValue}
-									deletingCollectionId={deletingCollectionId}
-									deletingRequestId={deletingRequestId}
-									creatingSubfolder={creatingSubfolder}
-									newSubCollectionName={newSubCollectionName}
-									isCreatingSubfolder={createCollectionMutation.isPending}
-									getRequestsByCollection={getRequestsByCollection}
-									onCollectionClick={handleCollectionClick}
-									onCollectionToggle={handleCollectionToggle}
-									onRequestClick={handleRequestClick}
-									getCollectionActions={getCollectionActions}
-									onRenameChange={setRenameValue}
-									onRenameSubmit={handleRenameSubmit}
-									onRenameCancel={handleRenameCancel}
-									onStartRename={handleRenameCollection}
-									onDeleteRequest={handleDeleteRequest}
-									onSubCollectionNameChange={setNewSubCollectionName}
-									onCreateSubfolder={handleCreateSubfolder}
-									onCancelSubfolder={handleCancelSubfolder}
-									renamingRequestId={renamingRequestId}
-									renameRequestValue={renameRequestValue}
-									onRequestRenameChange={setRenameRequestValue}
-									onRequestRenameSubmit={handleRequestRenameSubmit}
-									onRequestRenameCancel={handleRequestRenameCancel}
-									onStartRequestRename={handleStartRequestRename}
-									onRequestDeleteClick={handleRequestDeleteClick}
-									onCollectionDeleteClick={handleCollectionDeleteClick}
-									onDuplicateRequest={handleDuplicateRequest}
-								/>
-							))}
+							<CollectionTreeContext.Provider value={treeContext}>
+								{rootCollections.map((collection, index) => (
+									<CollectionItem
+										key={collection.id}
+										collection={collection}
+										depth={0}
+										posInSet={index + 1}
+										setSize={rootCollections.length}
+									/>
+								))}
+							</CollectionTreeContext.Provider>
 						</div>
 					</div>
 				)}
@@ -809,25 +323,20 @@ export default function CollectionTree() {
 				/>
 
 				<DeleteConfirmDialog
-					open={!!deleteConfirm}
-					onOpenChange={(open) => !open && setDeleteConfirm(null)}
+					open={!!panel.deleteConfirm}
+					onOpenChange={(open) => !open && panel.dismissDeleteConfirm()}
 					title={
-						deleteConfirm?.type === "collection"
+						panel.deleteConfirm?.type === "collection"
 							? "Delete collection?"
 							: "Delete request?"
 					}
 					description={
-						deleteConfirm?.type === "collection"
-							? `"${deleteConfirm?.name}" and all its requests will be permanently removed. This cannot be undone.`
-							: `"${deleteConfirm?.name}" will be permanently removed. This cannot be undone.`
+						panel.deleteConfirm?.type === "collection"
+							? `"${panel.deleteConfirm?.name}" and all its requests will be permanently removed. This cannot be undone.`
+							: `"${panel.deleteConfirm?.name}" will be permanently removed. This cannot be undone.`
 					}
-					onConfirm={handleConfirmDelete}
-					isDeleting={
-						(deleteConfirm?.type === "collection" &&
-							deletingCollectionId === deleteConfirm?.id) ||
-						(deleteConfirm?.type === "request" &&
-							deletingRequestId === deleteConfirm?.id)
-					}
+					onConfirm={panel.confirmDelete}
+					isDeleting={panel.isDeleteInFlight}
 				/>
 			</div>
 		</DrawerPanel>

--- a/app/src/modules/collections/CollectionTreeContext.test.tsx
+++ b/app/src/modules/collections/CollectionTreeContext.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The tree rows read everything shared from `CollectionTreeContext`, so a row
+ * rendered without a provider has no handlers at all. React's own failure for
+ * that is a `TypeError` deep inside the row ("onCollectionClick is not a
+ * function", and only once something is clicked) or, worse, a row that renders
+ * and silently does nothing. The context throws instead, naming what is
+ * missing, so the mistake is caught at the first render.
+ *
+ * The `dnd` slot is asserted here for the same reason it exists: phase 3 (#367)
+ * mounts the drag machinery into it, and a slot nothing reads is a slot that
+ * can quietly disappear before it is used.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import CollectionItem from "./CollectionItem";
+import RequestItem from "./RequestItem";
+import { useCollectionTreeContext } from "./context/CollectionTreeContext";
+import { withCollectionTreeContext } from "@/test/collection-tree-context";
+import type { Collection, Request } from "@/types";
+
+const COLLECTION: Collection = {
+	id: "col_1",
+	name: "Acme API",
+	description: "",
+	order: 0,
+	variables: {},
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const REQUEST: Request = {
+	id: "req_1",
+	collectionId: "col_1",
+	name: "Get user",
+	description: "",
+	method: "GET",
+	url: "https://api.test/user",
+	params: [],
+	headers: [],
+	body: { mode: "none" },
+	bodyType: "none",
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	followRedirects: true,
+	maxRedirects: 10,
+	httpVersion: "auto",
+	order: 0,
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/**
+ * React logs the thrown error to the console before it propagates. Silencing it
+ * keeps a passing run readable; the assertion below is what proves the throw.
+ */
+function expectThrowsWithoutProvider(renderRow: () => void) {
+	vi.spyOn(console, "error").mockImplementation(() => {});
+	expect(renderRow).toThrow(/must be rendered inside CollectionTreeContext.Provider/);
+}
+
+describe("collection tree rows require the provider", () => {
+	it("throws a readable error when a collection row renders outside it", () => {
+		expectThrowsWithoutProvider(() =>
+			render(<CollectionItem collection={COLLECTION} depth={0} posInSet={1} setSize={1} />)
+		);
+	});
+
+	it("throws a readable error when a request row renders outside it", () => {
+		expectThrowsWithoutProvider(() =>
+			render(<RequestItem request={REQUEST} collectionId="col_1" posInSet={1} setSize={1} />)
+		);
+	});
+});
+
+describe("the context carries the phase-3 dnd slot", () => {
+	it("exposes `dnd`, empty until the drag hook mounts into it", () => {
+		let seen: ReturnType<typeof useCollectionTreeContext> | null = null;
+		function Probe() {
+			seen = useCollectionTreeContext();
+			return null;
+		}
+
+		render(withCollectionTreeContext(<Probe />));
+
+		// `in`, not a truthiness check: the slot is deliberately null, and the
+		// point is that the field is part of the shape rather than absent.
+		expect(seen).not.toBeNull();
+		expect("dnd" in seen!).toBe(true);
+		expect(seen!.dnd).toBeNull();
+	});
+});

--- a/app/src/modules/collections/RequestItem.test.tsx
+++ b/app/src/modules/collections/RequestItem.test.tsx
@@ -23,6 +23,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import RequestItem from "./RequestItem";
+import { withCollectionTreeContext } from "@/test/collection-tree-context";
 import type { Request } from "@/types";
 
 const REQUEST: Request = {
@@ -51,15 +52,10 @@ function renderItem() {
 	const onSelect = vi.fn();
 	const onStartRename = vi.fn();
 	const { container } = render(
-		<RequestItem
-			request={REQUEST}
-			collectionId="col_1"
-			posInSet={1}
-			setSize={1}
-			onSelect={onSelect}
-			onDelete={vi.fn()}
-			onStartRename={onStartRename}
-		/>
+		withCollectionTreeContext(
+			<RequestItem request={REQUEST} collectionId="col_1" posInSet={1} setSize={1} />,
+			{ onRequestClick: onSelect, onStartRequestRename: onStartRename }
+		)
 	);
 	const target = container.querySelector("[data-tree-activate]") as HTMLElement;
 	return { onSelect, onStartRename, target, container };

--- a/app/src/modules/collections/RequestItem.tsx
+++ b/app/src/modules/collections/RequestItem.tsx
@@ -7,12 +7,18 @@
 
 import { useEffect, useRef } from "react";
 import { Loader2, Trash2, Edit2, Copy } from "lucide-react";
+import { useCollectionTreeContext } from "./context/CollectionTreeContext";
 import type { Request } from "@/types";
 import { Input } from "@/components/ui";
 import { RowActionsMenu, MethodBadge, TruncatedText } from "@/components/shared";
 import { cn } from "@/lib/utils";
 import { INDENT_STEP } from "@/constants/layout";
 
+/**
+ * What differs per row. The selection, the rename and delete state and every
+ * handler come from `CollectionTreeContext` - the same source `CollectionItem`
+ * reads, so a row's behaviour cannot drift from its parent folder's.
+ */
 export interface RequestItemProps {
 	request: Request;
 	collectionId: string;
@@ -26,18 +32,6 @@ export interface RequestItemProps {
 	 */
 	posInSet: number;
 	setSize: number;
-	onSelect: (collectionId: string, requestId: string) => void;
-	onDelete: (requestId: string) => Promise<void>;
-	onBeforeDelete?: (requestId: string, requestName: string) => void;
-	isDeleting?: boolean;
-	isSelected?: boolean;
-	isRenaming?: boolean;
-	renameValue?: string;
-	onRenameChange?: (value: string) => void;
-	onRenameSubmit?: (requestId: string) => void;
-	onRenameCancel?: () => void;
-	onStartRename?: (request: Request) => void;
-	onDuplicate?: (request: Request) => void;
 }
 
 export default function RequestItem({
@@ -46,19 +40,25 @@ export default function RequestItem({
 	depth = 1,
 	posInSet,
 	setSize,
-	onSelect,
-	onDelete,
-	onBeforeDelete,
-	isDeleting,
-	isSelected,
-	isRenaming,
-	renameValue,
-	onRenameChange,
-	onRenameSubmit,
-	onRenameCancel,
-	onStartRename,
-	onDuplicate,
 }: RequestItemProps) {
+	const {
+		selectedRequestId,
+		deletingRequestId,
+		renamingRequestId,
+		renameRequestValue,
+		onRequestClick,
+		onRequestRenameChange,
+		onRequestRenameSubmit,
+		onRequestRenameCancel,
+		onStartRequestRename,
+		onRequestDeleteClick,
+		onDuplicateRequest,
+	} = useCollectionTreeContext();
+
+	const isSelected = selectedRequestId === request.id;
+	const isDeleting = deletingRequestId === request.id;
+	const isRenaming = renamingRequestId === request.id;
+
 	const rowRef = useRef<HTMLDivElement>(null);
 	/**
 	 * Set when the rename field is about to be closed *from the keyboard*, so
@@ -85,13 +85,13 @@ export default function RequestItem({
 		// (opening is idempotent), so there is nothing to defer - and none of the
 		// 80ms delay that made a single click to open feel laggy.
 		if (e.detail > 1) return;
-		onSelect(collectionId, request.id);
+		onRequestClick(collectionId, request.id);
 	};
 
 	const handleDoubleClick = (e: React.MouseEvent) => {
 		e.stopPropagation();
 		if (isDeleting || isRenaming) return;
-		onStartRename?.(request);
+		onStartRequestRename(request);
 	};
 
 	/**
@@ -108,11 +108,11 @@ export default function RequestItem({
 	 */
 	const isRowSurface = (e: React.MouseEvent) => e.target === e.currentTarget;
 
-	// Prefer the confirmation flow when the tree supplies one.
+	// Always the confirm dialog, never a bare delete: the ⋯ menu and the hidden
+	// `data-tree-delete` control the Delete key clicks are the same one action.
 	const handleDelete = () => {
 		if (isDeleting) return;
-		if (onBeforeDelete) onBeforeDelete(request.id, request.name);
-		else void onDelete(request.id);
+		onRequestDeleteClick(request.id, request.name);
 	};
 
 	return (
@@ -154,9 +154,9 @@ export default function RequestItem({
 				tabIndex={-1}
 				data-tree-activate
 				// self-stretch: the row is `items-center`, which makes every child
-				// content-height - so this button, the only thing wired to onSelect,
-				// was ~22px tall inside a 32px row that paints a full-height hover
-				// fill and `cursor-pointer`. The top and bottom ~5px of the row
+				// content-height - so this button, the only thing wired to the open
+				// handler, was ~22px tall inside a 32px row that paints a full-height
+				// hover fill and `cursor-pointer`. The top and bottom ~5px of the row
 				// looked clickable and were not. Stretching to the row's height
 				// costs nothing (the button's own `items-center` still centres the
 				// badge and label) and `focus-row` keeps painting the ring.
@@ -167,18 +167,18 @@ export default function RequestItem({
 				{isRenaming ? (
 					<Input
 						type="text"
-						value={renameValue ?? ""}
-						onChange={(e) => onRenameChange?.(e.target.value)}
+						value={renameRequestValue}
+						onChange={(e) => onRequestRenameChange(e.target.value)}
 						onKeyDown={(e) => {
 							if (e.key === "Enter") {
 								returnFocusToRow.current = true;
-								onRenameSubmit?.(request.id);
+								onRequestRenameSubmit(request.id);
 							} else if (e.key === "Escape") {
 								returnFocusToRow.current = true;
-								onRenameCancel?.();
+								onRequestRenameCancel();
 							}
 						}}
-						onBlur={() => onRenameSubmit?.(request.id)}
+						onBlur={() => onRequestRenameSubmit(request.id)}
 						className="flex-1 h-6 text-sm"
 						autoFocus
 						onClick={(e) => e.stopPropagation()}
@@ -205,7 +205,7 @@ export default function RequestItem({
 				aria-hidden="true"
 				tabIndex={-1}
 				data-tree-rename
-				onClick={() => onStartRename?.(request)}
+				onClick={() => onStartRequestRename(request)}
 			/>
 			<button
 				type="button"
@@ -224,14 +224,12 @@ export default function RequestItem({
 						{
 							label: "Rename",
 							icon: Edit2,
-							onSelect: () => onStartRename?.(request),
-							disabled: !onStartRename,
+							onSelect: () => onStartRequestRename(request),
 						},
 						{
 							label: "Duplicate",
 							icon: Copy,
-							onSelect: () => onDuplicate?.(request),
-							disabled: !onDuplicate,
+							onSelect: () => onDuplicateRequest(request),
 						},
 						{
 							label: "Delete",

--- a/app/src/modules/collections/context/CollectionTreeContext.tsx
+++ b/app/src/modules/collections/context/CollectionTreeContext.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Collection tree context
+ *
+ * Every value a tree row needs that is not the row itself. `CollectionItem`
+ * renders itself recursively, so anything threaded as a prop had to be
+ * re-listed at four sites - the tree's map, the item's prop list, its
+ * destructure, and its recursive call. Thirty of the item's thirty-three props
+ * were the same object arriving at every depth, so a single new value (a drag
+ * id, a drop target) cost four edits before it did anything.
+ *
+ * The context carries exactly that shared slice. What stays a prop is what
+ * genuinely differs per row: the entity, its depth, and its position in the
+ * sibling set.
+ */
+
+import { createContext, useContext } from "react";
+import type { Collection, Request } from "@/types";
+import type { RowAction } from "@/components/shared";
+
+/**
+ * Where a drop would land: `inside` reparents into a folder, `before` / `after`
+ * reorder among the target's siblings.
+ */
+export interface CollectionTreeDropTarget {
+	id: string;
+	position: "before" | "after" | "inside";
+}
+
+/**
+ * The drag-and-drop slice, phase 3 of #364 (#367). Typed and present now, so
+ * the `useTreeDnd` hook lands as one provider field plus row wiring rather than
+ * as another pass through the prop thread this context exists to remove.
+ * `null` means no drag machinery is mounted - which is every render until #367.
+ */
+export interface CollectionTreeDnd {
+	/** The entity being dragged, or null when no drag is in progress. */
+	draggingId: string | null;
+	/** The row the pointer is over, and where the drop would land on it. */
+	dropTarget: CollectionTreeDropTarget | null;
+}
+
+/**
+ * The state and handlers `useTreeCrud` owns and every row reads. Split out so
+ * the hook can type its row-facing return without importing the whole context
+ * value, and so the two stay in step by construction.
+ */
+export interface CollectionTreeCrudSlice {
+	/** Collection currently being renamed inline, if any. */
+	renamingId: string | null;
+	renameValue: string;
+	/** Request currently being renamed inline, if any. */
+	renamingRequestId: string | null;
+	renameRequestValue: string;
+	/** Rows mid-delete render dimmed and refuse input. */
+	deletingCollectionId: string | null;
+	deletingRequestId: string | null;
+	/** Collection whose "new folder" form is open, if any. */
+	creatingSubfolder: string | null;
+	newSubCollectionName: string;
+	isCreatingSubfolder: boolean;
+
+	onCollectionClick: (collection: Collection) => void;
+	onCollectionToggle: (collection: Collection) => void;
+	onRequestClick: (collectionId: string, requestId: string) => void;
+	/** Actions for a collection's ⋯ menu, built where the handlers live. */
+	getCollectionActions: (collection: Collection) => RowAction[];
+
+	onRenameChange: (value: string) => void;
+	onRenameSubmit: (collectionId: string) => void;
+	onRenameCancel: () => void;
+	onStartRename: (collection: Collection) => void;
+
+	onRequestRenameChange: (value: string) => void;
+	onRequestRenameSubmit: (requestId: string) => void;
+	onRequestRenameCancel: () => void;
+	onStartRequestRename: (request: Request) => void;
+
+	/**
+	 * Opens the delete confirm dialog. Both rows go through it - the ⋯ menu and
+	 * the hidden `data-tree-delete` control the Delete key clicks - so a cascade
+	 * delete is never one keystroke.
+	 */
+	onCollectionDeleteClick: (collectionId: string, collectionName: string) => void;
+	onRequestDeleteClick: (requestId: string, requestName: string) => void;
+	onDuplicateRequest: (request: Request) => void;
+
+	onSubCollectionNameChange: (value: string) => void;
+	onCreateSubfolder: (parentId: string) => void;
+	onCancelSubfolder: () => void;
+}
+
+export interface CollectionTreeContextValue extends CollectionTreeCrudSlice {
+	/** Every loaded collection - a row filters it for its own children. */
+	allCollections: Collection[];
+	expandedCollectionIds: Set<string>;
+	selectedCollectionId: string | null;
+	selectedRequestId: string | null;
+	getRequestsByCollection: (collectionId: string) => Request[];
+	dnd: CollectionTreeDnd | null;
+}
+
+export const CollectionTreeContext = createContext<CollectionTreeContextValue | null>(null);
+
+export function useCollectionTreeContext(): CollectionTreeContextValue {
+	const context = useContext(CollectionTreeContext);
+	if (!context) {
+		throw new Error(
+			"Collection tree rows must be rendered inside CollectionTreeContext.Provider"
+		);
+	}
+	return context;
+}

--- a/app/src/modules/collections/index.ts
+++ b/app/src/modules/collections/index.ts
@@ -20,3 +20,12 @@ export { default as CollectionItem } from "./CollectionItem";
 export type { CollectionItemProps } from "./CollectionItem";
 export { default as RequestItem } from "./RequestItem";
 export type { RequestItemProps } from "./RequestItem";
+export { CollectionTreeContext, useCollectionTreeContext } from "./context/CollectionTreeContext";
+export type {
+	CollectionTreeContextValue,
+	CollectionTreeCrudSlice,
+	CollectionTreeDnd,
+	CollectionTreeDropTarget,
+} from "./context/CollectionTreeContext";
+export { useRevealActiveSelection } from "./useRevealActiveSelection";
+export { useTreeCrud } from "./useTreeCrud";

--- a/app/src/modules/collections/useRevealActiveSelection.ts
+++ b/app/src/modules/collections/useRevealActiveSelection.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { useEffect, useRef, type RefObject } from "react";
+import { walkAncestors } from "./tree-utils";
+import type { Collection, Request } from "@/types";
+
+export interface RevealActiveSelectionOptions {
+	selectedCollectionId: string | null;
+	selectedRequestId: string | null;
+	collections: Collection[];
+	requestsByCollection: Map<string, Request[]>;
+	/** Read only as a scroll trigger: a row appears when its ancestors expand. */
+	expandedCollectionIds: Set<string>;
+	expandCollections: (collectionIds: string[]) => void;
+}
+
+/**
+ * Keep the row the active tab points at both rendered and on screen.
+ *
+ * Two effects, not one, and they cannot share a ref: the scroll can only run a
+ * render *after* the reveal, once the expanded ancestors have put the row in
+ * the DOM. Each records the selection it last acted on so it fires once per
+ * selection rather than once per render.
+ */
+export function useRevealActiveSelection(
+	treeRef: RefObject<HTMLDivElement | null>,
+	{
+		selectedCollectionId,
+		selectedRequestId,
+		collections,
+		requestsByCollection,
+		expandedCollectionIds,
+		expandCollections,
+	}: RevealActiveSelectionOptions
+): void {
+	const revealedSelectionRef = useRef<string | null>(null);
+	const scrolledSelectionRef = useRef<string | null>(null);
+
+	/*
+	 * Reveal whatever the active tab points at: expand its ancestor folders so
+	 * the row is rendered, then (in the effect below) scroll it into view.
+	 *
+	 * This used to handle requests only, which is why switching to a *collection*
+	 * tab looked like the sidebar ignored it - a collection nested inside a
+	 * collapsed parent has no row in the tree at all, so there was nothing to
+	 * highlight and nothing to scroll to. `selectedCollectionId` was computed and
+	 * then only used for a label and a highlight, so nothing revealed it.
+	 *
+	 * Settings and Variables never had the problem because they own a whole
+	 * drawer view; a request did not because of this effect. A collection fell
+	 * between the two.
+	 *
+	 * Guarded by a ref so it fires once per selection - the same discipline the
+	 * scroll effect below has always had. Unguarded, it re-ran after *every*
+	 * render of the tree (it lists `requestsByCollection` and `collections`, and
+	 * the tree re-renders on any expand-state change), so collapsing a
+	 * collection that held the selected request re-expanded it in the same
+	 * frame: the chevron looked dead and every ancestor of the active tab was
+	 * pinned open. Once per selection *change* means switching tabs away and
+	 * back reveals again, which is the behaviour that was wanted all along.
+	 */
+	useEffect(() => {
+		const selectionId = selectedCollectionId ?? selectedRequestId;
+		if (!selectionId) {
+			// Settings, Variables, no tab at all: re-selecting the entity later is a
+			// fresh selection and must reveal again.
+			revealedSelectionRef.current = null;
+			scrolledSelectionRef.current = null;
+			return;
+		}
+		if (revealedSelectionRef.current === selectionId) return;
+
+		// A collection reveals itself; a request reveals the collection holding it.
+		let target: string | undefined;
+		if (selectedCollectionId) {
+			target = selectedCollectionId;
+		} else {
+			for (const [collectionId, reqs] of requestsByCollection) {
+				if (reqs.some((r) => r.id === selectedRequestId)) {
+					target = collectionId;
+					break;
+				}
+			}
+		}
+		// The owning collection's requests may not have arrived yet. Leave the ref
+		// unset so this reveals once they do, rather than counting as done.
+		if (!target) return;
+
+		// walkAncestors, not a local loop: this walk is unbounded on a `parentId`
+		// cycle, which hangs the renderer inside an effect (see tree-utils).
+		const ancestorChain = walkAncestors(target, collections).map((c) => c.id);
+		revealedSelectionRef.current = selectionId;
+		expandCollections(ancestorChain);
+	}, [
+		selectedRequestId,
+		selectedCollectionId,
+		requestsByCollection,
+		collections,
+		expandCollections,
+	]);
+
+	/*
+	 * Once the selected row exists (after ancestors expand), scroll it into view.
+	 * Guarded by a ref so it only fires once per selection - otherwise every
+	 * expand/collapse elsewhere in the tree would yank the view back.
+	 */
+	useEffect(() => {
+		const id = selectedCollectionId ?? selectedRequestId;
+		if (!id || scrolledSelectionRef.current === id) return;
+		const attr = selectedCollectionId ? "data-collection-id" : "data-request-id";
+		const row = treeRef.current?.querySelector(`[${attr}="${CSS.escape(id)}"]`);
+		if (row) {
+			row.scrollIntoView({ block: "nearest" });
+			scrolledSelectionRef.current = id;
+		}
+	}, [
+		treeRef,
+		selectedRequestId,
+		selectedCollectionId,
+		expandedCollectionIds,
+		requestsByCollection,
+	]);
+}

--- a/app/src/modules/collections/useTreeCrud.ts
+++ b/app/src/modules/collections/useTreeCrud.ts
@@ -1,0 +1,616 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { Plus, Trash2, Edit2, FolderPlus } from "lucide-react";
+import { useTabsStore, useSaveStore } from "@/stores";
+import { useCollectionsStore } from "@/modules/collections/collections-store";
+import {
+	useCreateCollectionMutation,
+	useUpdateCollectionMutation,
+	useDeleteCollectionMutation,
+	useCreateRequestMutation,
+	useDeleteRequestMutation,
+	useUpdateRequestMutation,
+} from "@/queries";
+import { collectDescendantEntityIds } from "./tree-utils";
+import type { CollectionTreeCrudSlice } from "./context/CollectionTreeContext";
+import type { RowAction } from "@/components/shared";
+import type { Collection, Request } from "@/types";
+import { DEFAULT_REQUEST_NAME } from "@/constants/request";
+import { DEFAULT_COLLECTION_NAME, DEFAULT_FOLDER_NAME } from "@/constants/collection";
+
+export interface TreeCrudOptions {
+	collections: Collection[];
+	/** Sorted roots, so "New request" with nothing selected has a target. */
+	rootCollections: Collection[];
+	selectedCollectionId: string | null;
+	requestsByCollection: Map<string, Request[]>;
+	getRequestsByCollection: (collectionId: string) => Request[];
+}
+
+/** What the tree's own chrome renders: the create form, the toolbar, the dialog. */
+export interface TreeCrudPanel {
+	creatingCollection: boolean;
+	newCollectionName: string;
+	setNewCollectionName: (value: string) => void;
+	openNewCollectionForm: () => void;
+	cancelNewCollectionForm: () => void;
+	createCollection: () => void;
+	/** "New request": into the selected collection, else the first root. */
+	createRequestFromToolbar: () => void;
+	isCreatingCollection: boolean;
+	isCreatingRequest: boolean;
+	deleteConfirm: DeleteConfirmTarget | null;
+	dismissDeleteConfirm: () => void;
+	confirmDelete: () => void;
+	/** The confirm dialog's own delete is in flight - its button spins. */
+	isDeleteInFlight: boolean;
+}
+
+export interface DeleteConfirmTarget {
+	type: "collection" | "request";
+	id: string;
+	name: string;
+}
+
+export interface TreeCrud {
+	panel: TreeCrudPanel;
+	/** The slice every row reads, shaped for the tree context. */
+	rows: CollectionTreeCrudSlice;
+}
+
+/**
+ * Create, rename, duplicate and delete for the collection tree, with the inline
+ * form state each one drives. Lifted out of `CollectionTree` so that component
+ * is layout: eleven `useState` atoms and their handlers were ~360 of its lines,
+ * and the rows only ever saw the result.
+ */
+export function useTreeCrud({
+	collections,
+	rootCollections,
+	selectedCollectionId,
+	requestsByCollection,
+	getRequestsByCollection,
+}: TreeCrudOptions): TreeCrud {
+	const { openTab, closeTabsForEntities } = useTabsStore();
+	const { expandCollection, toggleCollectionExpanded } = useCollectionsStore();
+	const { startSaving, completeSaveThenIdle, failSave } = useSaveStore();
+
+	const createCollectionMutation = useCreateCollectionMutation();
+	const updateCollectionMutation = useUpdateCollectionMutation();
+	const deleteCollectionMutation = useDeleteCollectionMutation();
+	const createRequestMutation = useCreateRequestMutation();
+	const deleteRequestMutation = useDeleteRequestMutation();
+	const updateRequestMutation = useUpdateRequestMutation();
+
+	const [creatingCollection, setCreatingCollection] = useState(false);
+	const [creatingSubfolder, setCreatingSubfolder] = useState<string | null>(null); // parent collection ID
+	const [newCollectionName, setNewCollectionName] = useState(DEFAULT_COLLECTION_NAME);
+	const [newSubCollectionName, setNewSubCollectionName] = useState(DEFAULT_FOLDER_NAME);
+	const [renamingId, setRenamingId] = useState<string | null>(null);
+	const [renameValue, setRenameValue] = useState("");
+	const [renamingRequestId, setRenamingRequestId] = useState<string | null>(null);
+	const [renameRequestValue, setRenameRequestValue] = useState("");
+	const [deletingCollectionId, setDeletingCollectionId] = useState<string | null>(null);
+	const [deletingRequestId, setDeletingRequestId] = useState<string | null>(null);
+	const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmTarget | null>(null);
+
+	// Memoised because the callbacks below list them as dependencies: redefined
+	// each render, they would rebuild every handler that opens a tab.
+	const navigateToRequest = useCallback(
+		(_collectionId: string, requestId: string) =>
+			openTab({ type: "request", entityId: requestId }),
+		[openTab]
+	);
+	const navigateToCollection = useCallback(
+		(collectionId: string) => openTab({ type: "collection", entityId: collectionId }),
+		[openTab]
+	);
+
+	/**
+	 * Report a failed mutation through the same channel the rename path already
+	 * uses - `failSave` puts "Save failed" in the Dock.
+	 *
+	 * Rename was the only handler here that caught anything. Create and delete
+	 * called `mutateAsync` bare, so a rejection was an unhandled promise and
+	 * nothing else: a failed delete closed the confirm dialog, un-dimmed the row
+	 * and left the collection sitting there with no explanation, which reads as
+	 * "the click didn't register" rather than "the delete failed".
+	 */
+	const reportFailure = useCallback(
+		(error: unknown, fallback: string) =>
+			failSave(error instanceof Error ? error.message : fallback),
+		[failSave]
+	);
+
+	const handleCollectionClick = useCallback(
+		(collection: Collection) => {
+			navigateToCollection(collection.id);
+		},
+		[navigateToCollection]
+	);
+
+	const handleCollectionToggle = useCallback(
+		(collection: Collection) => {
+			toggleCollectionExpanded(collection.id);
+		},
+		[toggleCollectionExpanded]
+	);
+
+	const handleRequestClick = useCallback(
+		(collectionId: string, requestId: string) => {
+			navigateToRequest(collectionId, requestId);
+		},
+		[navigateToRequest]
+	);
+
+	const handleOpenNewCollectionForm = useCallback(() => {
+		setNewCollectionName(DEFAULT_COLLECTION_NAME);
+		setCreatingCollection(true);
+	}, []);
+
+	// Escape and Cancel are the same dismissal; named so they cannot drift.
+	const handleCancelNewCollectionForm = useCallback(() => {
+		setCreatingCollection(false);
+		setNewCollectionName("");
+	}, []);
+
+	const handleCreateCollection = useCallback(async () => {
+		if (!newCollectionName.trim() || createCollectionMutation.isPending) return;
+
+		try {
+			await createCollectionMutation.mutateAsync({ name: newCollectionName.trim() });
+		} catch (error) {
+			reportFailure(error, "Failed to create collection");
+			return; // Keep the form open with the typed name so it can be retried.
+		}
+		handleCancelNewCollectionForm();
+	}, [newCollectionName, createCollectionMutation, reportFailure, handleCancelNewCollectionForm]);
+
+	const handleCancelSubfolder = useCallback(() => {
+		setCreatingSubfolder(null);
+		setNewSubCollectionName(DEFAULT_FOLDER_NAME);
+	}, []);
+
+	const handleCreateSubfolder = useCallback(
+		async (parentId: string) => {
+			if (!newSubCollectionName.trim() || createCollectionMutation.isPending) return;
+
+			expandCollection(parentId);
+
+			try {
+				await createCollectionMutation.mutateAsync({
+					name: newSubCollectionName.trim(),
+					parentId: parentId,
+				});
+			} catch (error) {
+				reportFailure(error, "Failed to create folder");
+				return;
+			}
+			handleCancelSubfolder();
+		},
+		[
+			newSubCollectionName,
+			createCollectionMutation,
+			expandCollection,
+			reportFailure,
+			handleCancelSubfolder,
+		]
+	);
+
+	const handleCreateRequest = useCallback(
+		async (collectionId: string) => {
+			if (createRequestMutation.isPending) return;
+
+			expandCollection(collectionId);
+
+			let request: Request | undefined;
+			try {
+				request = await createRequestMutation.mutateAsync({
+					collectionId: collectionId,
+					name: DEFAULT_REQUEST_NAME,
+					method: "GET",
+					url: "",
+				});
+			} catch (error) {
+				reportFailure(error, "Failed to create request");
+				return;
+			}
+
+			if (request) {
+				navigateToRequest(collectionId, request.id);
+			}
+		},
+		[createRequestMutation, expandCollection, navigateToRequest, reportFailure]
+	);
+
+	// Handle "New Request" button click - use selected collection or first root
+	const handleNewRequestClick = useCallback(() => {
+		if (rootCollections.length === 0) {
+			// No collections - prompt to create one first
+			handleOpenNewCollectionForm();
+			return;
+		}
+
+		// Use selected collection only if it still exists; otherwise first root collection
+		const selectedExists =
+			selectedCollectionId && collections.some((c) => c.id === selectedCollectionId);
+		const targetCollection =
+			(selectedExists ? selectedCollectionId : null) ?? rootCollections[0].id;
+		void handleCreateRequest(targetCollection);
+	}, [
+		rootCollections,
+		selectedCollectionId,
+		collections,
+		handleOpenNewCollectionForm,
+		handleCreateRequest,
+	]);
+
+	const handleRenameCollection = useCallback((collection: Collection) => {
+		setRenamingId(collection.id);
+		setRenameValue(collection.name);
+	}, []);
+
+	const handleRenameCancel = useCallback(() => {
+		setRenamingId(null);
+		setRenameValue("");
+	}, []);
+
+	const handleRenameSubmit = useCallback(
+		async (collectionId: string) => {
+			const trimmedValue = renameValue.trim();
+			// Enter submits and then blur submits again, because the field is still
+			// mounted while the PUT is in flight. Clearing the rename state *before*
+			// awaiting unmounts the field, so there is no second blur to fire - and a
+			// name that did not change never reaches the wire at all, which is the
+			// guard the request-rename path has always had and this one had not.
+			setRenamingId(null);
+			setRenameValue("");
+
+			const original = collections.find((c) => c.id === collectionId);
+			if (!trimmedValue || original?.name === trimmedValue) return;
+
+			startSaving();
+			try {
+				await updateCollectionMutation.mutateAsync({
+					id: collectionId,
+					name: trimmedValue,
+				});
+				completeSaveThenIdle();
+			} catch (error) {
+				failSave(error instanceof Error ? error.message : "Failed to rename collection");
+			}
+		},
+		[
+			renameValue,
+			collections,
+			startSaving,
+			updateCollectionMutation,
+			completeSaveThenIdle,
+			failSave,
+		]
+	);
+
+	const handleStartRequestRename = useCallback((request: Request) => {
+		setRenamingRequestId(request.id);
+		setRenameRequestValue(request.name);
+	}, []);
+
+	const handleRequestRenameCancel = useCallback(() => {
+		setRenamingRequestId(null);
+		setRenameRequestValue("");
+	}, []);
+
+	const handleRequestRenameSubmit = useCallback(
+		async (requestId: string) => {
+			const trimmedValue = renameRequestValue.trim();
+			// Cleared before the await for the same reason as the collection path:
+			// while the field is still mounted, the blur that follows Enter submits a
+			// second time.
+			setRenamingRequestId(null);
+			setRenameRequestValue("");
+
+			// Find the original request to check if name actually changed
+			// Search through all collections to find the request
+			let originalRequest: Request | undefined;
+			for (const requests of requestsByCollection.values()) {
+				const found = requests.find((r) => r.id === requestId);
+				if (found) {
+					originalRequest = found;
+					break;
+				}
+			}
+
+			// Empty name, or a name that did not change: nothing to save.
+			if (!trimmedValue || originalRequest?.name === trimmedValue) return;
+
+			startSaving();
+			try {
+				await updateRequestMutation.mutateAsync({
+					id: requestId,
+					name: trimmedValue,
+				});
+				completeSaveThenIdle();
+			} catch (error) {
+				failSave(error instanceof Error ? error.message : "Failed to rename request");
+			}
+		},
+		[
+			renameRequestValue,
+			requestsByCollection,
+			startSaving,
+			updateRequestMutation,
+			completeSaveThenIdle,
+			failSave,
+		]
+	);
+
+	/**
+	 * Duplicate a request, contents and all - method, URL, params, headers,
+	 * body, auth and both scripts. Collections deliberately have no equivalent:
+	 * copying one means recursing through nested folders and issuing a create
+	 * per request, which is its own feature. The previous collection "Duplicate"
+	 * only created an empty folder named "(Copy)", which read as a working clone
+	 * and was not one, so it was removed rather than left misleading.
+	 */
+	const handleDuplicateRequest = useCallback(
+		async (request: Request) => {
+			if (createRequestMutation.isPending) return;
+			try {
+				const copy = await createRequestMutation.mutateAsync({
+					collectionId: request.collectionId,
+					name: `${request.name} (Copy)`,
+					description: request.description,
+					method: request.method,
+					url: request.url,
+					params: request.params,
+					headers: request.headers,
+					body: request.body,
+					bodyType: request.bodyType,
+					auth: request.auth,
+					preRequestScript: request.preRequestScript,
+					postRequestScript: request.postRequestScript,
+					/*
+					 * The copy takes its source's `order`, which lands it directly
+					 * *after* the source: the tie falls to `createdAt` and the copy is
+					 * newer (see `compareTreeOrder`, pinned to the engine's SQL). An
+					 * omitted order would append it to the end of the collection, and
+					 * inserting it at `order + 1` would need every following sibling
+					 * renumbered - a multi-row write that belongs to the atomic batch
+					 * reorder endpoint, not to a duplicate.
+					 */
+					order: request.order,
+				});
+				openTab({ type: "request", entityId: copy.id });
+			} catch (error) {
+				reportFailure(error, "Failed to duplicate request");
+			}
+		},
+		[createRequestMutation, openTab, reportFailure]
+	);
+
+	// Named, so the ⋯ menu's Delete and the row's hidden `data-tree-delete`
+	// control (the Delete key's target) open the very same dialog rather than
+	// being two copies of one object literal that can drift apart.
+	const handleCollectionDeleteClick = useCallback((id: string, name: string) => {
+		setDeleteConfirm({ type: "collection", id, name });
+	}, []);
+
+	const handleRequestDeleteClick = useCallback((requestId: string, requestName: string) => {
+		setDeleteConfirm({ type: "request", id: requestId, name: requestName });
+	}, []);
+
+	const handleDeleteCollection = useCallback(
+		async (collectionId: string) => {
+			setDeletingCollectionId(collectionId);
+			// Gather the collection, its descendant folders, and every request they
+			// contain: deleting a collection cascades, so all their tabs go stale.
+			const affected = collectDescendantEntityIds(collectionId, collections, (id) =>
+				getRequestsByCollection(id).map((r) => r.id)
+			);
+			try {
+				await deleteCollectionMutation.mutateAsync(collectionId);
+				closeTabsForEntities(affected);
+			} catch (error) {
+				reportFailure(error, "Failed to delete collection");
+			} finally {
+				// Only now: the dialog stays up, with its confirm button spinning,
+				// for as long as the delete is actually running.
+				setDeleteConfirm(null);
+				setDeletingCollectionId(null);
+			}
+		},
+		[
+			deleteCollectionMutation,
+			closeTabsForEntities,
+			collections,
+			getRequestsByCollection,
+			reportFailure,
+		]
+	);
+
+	const handleDeleteRequest = useCallback(
+		async (requestId: string) => {
+			setDeletingRequestId(requestId);
+			try {
+				await deleteRequestMutation.mutateAsync(requestId);
+				// Close any open tab pointing at the now-deleted request.
+				closeTabsForEntities([requestId]);
+			} catch (error) {
+				reportFailure(error, "Failed to delete request");
+			} finally {
+				setDeleteConfirm(null);
+				setDeletingRequestId(null);
+			}
+		},
+		[deleteRequestMutation, closeTabsForEntities, reportFailure]
+	);
+
+	const handleConfirmDelete = useCallback(() => {
+		if (!deleteConfirm) return;
+		// The dialog now stays open while the delete runs, so its confirm button
+		// survives long enough to be clicked twice. `isDeleting` disables it from
+		// the next render on; this covers the frame before that.
+		if (deletingCollectionId || deletingRequestId) return;
+		if (deleteConfirm.type === "collection") {
+			void handleDeleteCollection(deleteConfirm.id);
+		} else {
+			void handleDeleteRequest(deleteConfirm.id);
+		}
+	}, [
+		deleteConfirm,
+		deletingCollectionId,
+		deletingRequestId,
+		handleDeleteCollection,
+		handleDeleteRequest,
+	]);
+
+	const dismissDeleteConfirm = useCallback(() => setDeleteConfirm(null), []);
+
+	/**
+	 * Actions for a collection's "⋯" menu. Defined here, where the handlers and
+	 * state live, and rendered by the shared RowActionsMenu - the same component
+	 * request and environment rows use, so every row menu looks and behaves
+	 * alike. This replaced a hand-rolled fixed-position popover that had to
+	 * compute its own coordinates and close itself on an outside click, and
+	 * which had no keyboard support.
+	 */
+	const getCollectionActions = useCallback(
+		(collection: Collection): RowAction[] => [
+			{
+				label: "Rename",
+				icon: Edit2,
+				onSelect: () => handleRenameCollection(collection),
+			},
+			{
+				label: "Add Request",
+				icon: Plus,
+				onSelect: () => void handleCreateRequest(collection.id),
+			},
+			{
+				label: "Add Folder",
+				icon: FolderPlus,
+				onSelect: () => {
+					expandCollection(collection.id);
+					setCreatingSubfolder(collection.id);
+				},
+			},
+			{
+				label: "Delete",
+				icon: Trash2,
+				destructive: true,
+				onSelect: () => handleCollectionDeleteClick(collection.id, collection.name),
+			},
+		],
+		// Honest deps, which is only possible now that both handlers are memoised
+		// and the expand goes through `expandCollection` rather than reading the
+		// expanded set. The suppression that used to sit here hid two callbacks
+		// captured from whichever render last rebuilt this - benign only by
+		// accident, and this is the seam the drag-and-drop work extends.
+		[expandCollection, handleCreateRequest, handleRenameCollection, handleCollectionDeleteClick]
+	);
+
+	const isCreatingCollection = createCollectionMutation.isPending;
+	const isCreatingRequest = createRequestMutation.isPending;
+
+	const panel = useMemo<TreeCrudPanel>(
+		() => ({
+			creatingCollection,
+			newCollectionName,
+			setNewCollectionName,
+			openNewCollectionForm: handleOpenNewCollectionForm,
+			cancelNewCollectionForm: handleCancelNewCollectionForm,
+			createCollection: () => void handleCreateCollection(),
+			createRequestFromToolbar: handleNewRequestClick,
+			isCreatingCollection,
+			isCreatingRequest,
+			deleteConfirm,
+			dismissDeleteConfirm,
+			confirmDelete: handleConfirmDelete,
+			isDeleteInFlight:
+				(deleteConfirm?.type === "collection" &&
+					deletingCollectionId === deleteConfirm.id) ||
+				(deleteConfirm?.type === "request" && deletingRequestId === deleteConfirm.id),
+		}),
+		[
+			creatingCollection,
+			newCollectionName,
+			handleOpenNewCollectionForm,
+			handleCancelNewCollectionForm,
+			handleCreateCollection,
+			handleNewRequestClick,
+			isCreatingCollection,
+			isCreatingRequest,
+			deleteConfirm,
+			dismissDeleteConfirm,
+			handleConfirmDelete,
+			deletingCollectionId,
+			deletingRequestId,
+		]
+	);
+
+	const rows = useMemo<CollectionTreeCrudSlice>(
+		() => ({
+			renamingId,
+			renameValue,
+			renamingRequestId,
+			renameRequestValue,
+			deletingCollectionId,
+			deletingRequestId,
+			creatingSubfolder,
+			newSubCollectionName,
+			isCreatingSubfolder: isCreatingCollection,
+			onCollectionClick: handleCollectionClick,
+			onCollectionToggle: handleCollectionToggle,
+			onRequestClick: handleRequestClick,
+			getCollectionActions,
+			onRenameChange: setRenameValue,
+			onRenameSubmit: handleRenameSubmit,
+			onRenameCancel: handleRenameCancel,
+			onStartRename: handleRenameCollection,
+			onRequestRenameChange: setRenameRequestValue,
+			onRequestRenameSubmit: handleRequestRenameSubmit,
+			onRequestRenameCancel: handleRequestRenameCancel,
+			onStartRequestRename: handleStartRequestRename,
+			onCollectionDeleteClick: handleCollectionDeleteClick,
+			onRequestDeleteClick: handleRequestDeleteClick,
+			onDuplicateRequest: handleDuplicateRequest,
+			onSubCollectionNameChange: setNewSubCollectionName,
+			onCreateSubfolder: handleCreateSubfolder,
+			onCancelSubfolder: handleCancelSubfolder,
+		}),
+		[
+			renamingId,
+			renameValue,
+			renamingRequestId,
+			renameRequestValue,
+			deletingCollectionId,
+			deletingRequestId,
+			creatingSubfolder,
+			newSubCollectionName,
+			isCreatingCollection,
+			handleCollectionClick,
+			handleCollectionToggle,
+			handleRequestClick,
+			getCollectionActions,
+			handleRenameSubmit,
+			handleRenameCancel,
+			handleRenameCollection,
+			handleRequestRenameSubmit,
+			handleRequestRenameCancel,
+			handleStartRequestRename,
+			handleCollectionDeleteClick,
+			handleRequestDeleteClick,
+			handleDuplicateRequest,
+			handleCreateSubfolder,
+			handleCancelSubfolder,
+		]
+	);
+
+	return { panel, rows };
+}

--- a/app/src/test/collection-tree-context.tsx
+++ b/app/src/test/collection-tree-context.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A collection-tree context for tests that render a single row.
+ *
+ * `CollectionItem` and `RequestItem` read their shared state and handlers from
+ * `CollectionTreeContext` and throw without it, so a test that renders one row
+ * in isolation - the hit-area guards, the click-delay guards - has to supply
+ * the value. Written once here so those tests name only the two or three fields
+ * they actually assert on, rather than restating twenty-five defaults each.
+ *
+ * Handlers default to no-ops, not spies: a test asserting a call passes its own
+ * `vi.fn()` through `overrides`, which keeps the assertion and the spy in the
+ * same file.
+ */
+
+import type { ReactNode } from "react";
+import {
+	CollectionTreeContext,
+	type CollectionTreeContextValue,
+} from "@/modules/collections/context/CollectionTreeContext";
+
+const noop = () => {};
+
+export function collectionTreeContextValue(
+	overrides: Partial<CollectionTreeContextValue> = {}
+): CollectionTreeContextValue {
+	return {
+		allCollections: [],
+		expandedCollectionIds: new Set(),
+		selectedCollectionId: null,
+		selectedRequestId: null,
+		getRequestsByCollection: () => [],
+		dnd: null,
+		renamingId: null,
+		renameValue: "",
+		renamingRequestId: null,
+		renameRequestValue: "",
+		deletingCollectionId: null,
+		deletingRequestId: null,
+		creatingSubfolder: null,
+		newSubCollectionName: "",
+		isCreatingSubfolder: false,
+		onCollectionClick: noop,
+		onCollectionToggle: noop,
+		onRequestClick: noop,
+		getCollectionActions: () => [],
+		onRenameChange: noop,
+		onRenameSubmit: noop,
+		onRenameCancel: noop,
+		onStartRename: noop,
+		onRequestRenameChange: noop,
+		onRequestRenameSubmit: noop,
+		onRequestRenameCancel: noop,
+		onStartRequestRename: noop,
+		onCollectionDeleteClick: noop,
+		onRequestDeleteClick: noop,
+		onDuplicateRequest: noop,
+		onSubCollectionNameChange: noop,
+		onCreateSubfolder: noop,
+		onCancelSubfolder: noop,
+		...overrides,
+	};
+}
+
+export function withCollectionTreeContext(
+	children: ReactNode,
+	overrides: Partial<CollectionTreeContextValue> = {}
+) {
+	return (
+		<CollectionTreeContext.Provider value={collectionTreeContextValue(overrides)}>
+			{children}
+		</CollectionTreeContext.Provider>
+	);
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -204,9 +204,12 @@ Shared, Monaco-independent modules that power the GraphQL body mode.
 
 | Component | Role |
 |---|---|
-| `CollectionTree.tsx` | Hierarchical tree of collections + requests in the sidebar; expandable folders, context menus, method badges. State from `useCollectionsStore` + `useCollectionsQuery`/`useRequestsQuery` |
-| `CollectionItem.tsx` | A collection (folder) row |
-| `RequestItem.tsx` | A request row (method badge, click → open in RequestBuilder, context menu) |
+| `CollectionTree.tsx` | Hierarchical tree of collections + requests in the sidebar; expandable folders, context menus, method badges. Layout and the panel chrome only - the reveal effects, the CRUD state and the shared row values each live in their own module below. State from `useCollectionsStore` + `useCollectionsQuery`/`useRequestsQuery` |
+| `context/CollectionTreeContext.tsx` | Everything a row needs that is not the row itself: the expanded set, the selection, the rename/delete state and every handler. `CollectionItem` renders itself recursively, so a threaded prop had to be re-listed at four sites and thirty of its thirty-three props were the same object at every depth. Rows read it through `useCollectionTreeContext()`, which throws when a row is rendered without the provider. Carries the typed `dnd` slot the drag work (#367) mounts into |
+| `useRevealActiveSelection.ts` | The two once-per-selection effects that keep the active tab's row rendered and on screen: expand its ancestors, then scroll it into view. Separate refs, because the scroll can only run a render after the reveal |
+| `useTreeCrud.ts` | Create, rename, duplicate and delete for the tree, with the inline form state each drives. Returns `panel` (what the tree's own chrome renders) and `rows` (the slice the context hands every row) |
+| `CollectionItem.tsx` | A collection (folder) row. Props are its entity, depth and position in the sibling set; everything else comes from the context |
+| `RequestItem.tsx` | A request row (method badge, click → open in RequestBuilder, context menu). Same prop rule as `CollectionItem` |
 | `ImportModal.tsx` | Import collections from file/URL/paste (Postman / Insomnia / OpenAPI). Mounted globally in `Shell`; open-state in a dedicated store. See [import-collections/](./import-collections/README.md) for the parser pipeline |
 | `tree-utils.ts` | Every `parentId` walk in the renderer: `walkAncestors` (the ancestor chain, root first), `isDescendant`, `collectDescendantEntityIds` (what a cascade delete reaches). Each carries a visited-set termination guard - the engine tolerates cycles in stored data, and an unguarded walk hangs the window rather than answering wrongly. Also used by `queries/collections.ts` and `useVariableResolver` |
 | `reorder-math.ts` | The arithmetic behind a drop: `planCollectionMove` / `planRequestMove` turn sibling lists and a target index into the `POST /reorder` batch, writing only the rows whose position changes and normalizing a scope whose rows all predate explicit orders. Pure and node-tested - the part of a drag a jsdom gesture cannot reach. Consumed by `useReorderMutation` |

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -656,9 +656,9 @@ from `@/queries/runs`); everything with more than one is in the barrel.
   **referentially stable** while the underlying results are unchanged (built in
   `useQueries`' `combine`, which TanStack memoises only for a `combine` of
   stable identity - hence the `useCallback`). Callers list it in effect
-  dependencies; when it was rebuilt on every call, `CollectionTree`'s reveal
-  effect re-ran on every render and re-expanded a collection the user had just
-  collapsed
+  dependencies; when it was rebuilt on every call, the collection tree's reveal
+  effect (`useRevealActiveSelection`) re-ran on every render and re-expanded a
+  collection the user had just collapsed
 - **`useRequestQuery(requestId)`** / **`requestDetailOptions(requestId)`** - One
   request by id (`GET /requests/:id`), used by a restored request tab and by a
   design-run copy on cold start. Only an `ApiError` with `statusCode === 404`


### PR DESCRIPTION
## Description

**Plan (root cause, approach, rejected alternative).** The blocker for phase 3 is not the size of `CollectionTree.tsx` but its shape: `CollectionItem` renders itself recursively, so each of its 33 props had to be re-listed at **four** sites - the tree's `.map`, the item's prop interface, its destructure, and its recursive call - and ~30 of them were the same object arriving unchanged at every depth. A drag id, a drop target and their two handlers would have cost sixteen edits before doing anything. The fix moves that shared slice into a `CollectionTreeContext` and lifts the two mechanically separable blocks out of the component: the reveal/scroll effects and the CRUD state. What stays a prop is what genuinely differs per row - the entity, its depth, its position in the sibling set. **Rejected:** threading a single `tree` object prop through the recursion instead of a context. It removes the prop *count* but not the re-threading (still four sites, still every row's render tied to one identity), and it leaves phase 3 editing `CollectionItem`'s signature anyway - which is the cost this issue exists to remove.

**One correction to the issue's Problem section.** The line anchors (`:46-188`, `:190-556`, `:727-765`) were already stale, as the anchor note on the issue said; `CollectionTree.tsx` was 835 lines at `d4ca67b`, not 794. The seams and the 33-prop drill were unchanged in substance, so the plan holds as written; the ranges were re-derived before cutting.

### The four seams

1. **`useRevealActiveSelection(treeRef, { ... })`** - the two once-per-selection effects and their two refs, moved verbatim. They still cannot share a ref: the scroll can only run a render *after* the reveal, once the expanded ancestors have put the row in the DOM.
2. **`useTreeCrud({ ... })`** - create, rename, duplicate and delete plus the eleven `useState` atoms driving their inline forms. It returns two groups: `panel` (what the tree's own chrome renders - the new-collection form, the two toolbar buttons, the confirm dialog) and `rows` (the slice the context hands every row). Its mutation hooks come from `@/queries`, the same module the existing tests already mock, so no test's mock needed extending.
3. **`context/CollectionTreeContext.tsx`** - `CollectionItem` is down to **4** props and `RequestItem` to **5**. Both read the rest through `useCollectionTreeContext()`, which throws a named error rather than letting a row render with no handlers. Row DOM - `role`, every `data-*`, the class lists, the hidden keyboard targets - is byte-identical, because the roving-focus hook and the hit-area rules depend on both.
4. **The `dnd` slot** is typed and present (`CollectionTreeDnd | null`, with `draggingId` and a `{ id, position }` drop target), so `useTreeDnd` lands as one provider field plus row wiring.

**Dead props removed with the thread** (each verified unreachable in the app, not merely unused here): `RequestItem`'s `onDelete` - the tree always supplies `onRequestDeleteClick`, so the bare-delete branch never ran and a delete always went through the confirm dialog; and the two `disabled: !onStartRename` / `disabled: !onDuplicate` menu guards, which could not be true. Leaving them in the context would have been a handler written and never read, which is the defect class `CLAUDE.md` names.

**Consumer sweep.** `CollectionTree` is rendered only by `Drawer.tsx`; `CollectionItem` and `RequestItem` are rendered only by the tree, by each other, and by two tests. `modules/collections/index.ts` re-exports both plus their prop types - both types changed shape, and nothing outside the module imports them (`rg` for `CollectionItemProps` / `RequestItemProps`). No engine, MCP or store change.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Pure refactor - no behaviour change, so none of the four boxes fit exactly; the docs box is checked because the module docs move with it.

## Testing

- `cd app && pnpm test` - **3007 tests / 326 files passed**, up from 3004 / 325: the three new guards in `CollectionTreeContext.test.tsx`, in one new file. Every existing tree, hit-area and roving test passes, and the six `CollectionTree.*.test.tsx` files, `useRovingTreeFocus.test.tsx` and `collections-store.test.ts` are untouched - **they are the mutation check for this diff**: rename, delete, duplicate-order, orphan, reveal, mutation-error and a11y all exercise the moved code through the same UI.
- `cd app && pnpm type-check` - clean. `pnpm lint` - clean (zero warnings; prettier runs inside it). Formatting was applied only to the files this PR touches, all of which were clean before.
- `mkdocs build --strict -f .github/mkdocs.yml` - built, no warnings.
- Mutation check on the one new behaviour: deleting the `if (!context) throw` from `useCollectionTreeContext` turns both provider guards red (2 failed / 1 passed), and restoring it turns them green. The `dnd` case asserts the field is *present* with `"dnd" in value`, not truthy - the slot is deliberately `null`, and a truthiness check would pass just as happily if the field were deleted.

No engine build or ctest run: the diff is renderer-only, so no C++ test could change colour.

**Deliberate deviation from the acceptance criteria, stated plainly.** Criterion 2 asks that every existing test pass unmodified "or with mock-only edits, listed in the PR". Two files needed a non-mock edit, and could not avoid one given criterion 1's design: `src/drawer-row-hit-area.test.tsx` and `src/modules/collections/RequestItem.test.tsx` render a single row in isolation, which now requires the provider - the same requirement criterion 2's own "throws outside the provider" test asks for. Each render is wrapped in a new shared helper, `src/test/collection-tree-context.tsx` (beside the existing `query-wrapper.tsx`), and the spies each file asserts on are passed through it. No assertion in either file changed, and the collection row's 30-prop literal became four props plus two named overrides.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/COMPONENTS.md` (the context and both hooks under the collections module, and what `CollectionTree.tsx` is now responsible for), `docs/app/state-management.md` (the `requestsByCollection` stability note named the reveal effect by its old home).

## Related Issues
Closes #366

---
_Generated by [Claude Code](https://claude.ai/code/session_016zFXk7eqLbHp9iSp2d3YEH)_