### PR TITLE
fix(app/engine/body): form-data and x-www-form-urlencoded bodies reach the wire

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -724,6 +724,68 @@ describe("dispatchTool", () => {
 		});
 	});
 
+	/**
+	 * Both these tools have offered `form-data` / `x-www-form-urlencoded` in
+	 * their `bodyType` description since they existed, while emitting
+	 * `{ mode, content }` - a shape the engine reads no fields out of, so the
+	 * request went out with an empty body (issue #381) and now is refused
+	 * outright. The string is split into the `fields` rows every other producer
+	 * builds, which is what makes the advertised mode real.
+	 */
+	test.each(["form-data", "x-www-form-urlencoded"])(
+		"run_request sends a %s body as fields",
+		async (bodyType) => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"run_request",
+				{
+					url: "https://api.example.com/users",
+					method: "POST",
+					body: "name=ada+lovelace&role=engineer",
+					bodyType,
+				},
+				ctxWith(client, { allowlist: ["api.example.com"] })
+			);
+			expect(res.isError).toBeFalsy();
+			const payload = (client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(payload.body).toEqual({
+				mode: bodyType,
+				fields: [
+					{ key: "name", value: "ada lovelace", enabled: true },
+					{ key: "role", value: "engineer", enabled: true },
+				],
+			});
+		}
+	);
+
+	test("create_request stores a form body as fields", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"create_request",
+			{
+				collectionId: "c1",
+				name: "New",
+				url: "https://api.example.com/x",
+				method: "POST",
+				body: "a=1&b=2",
+				bodyType: "x-www-form-urlencoded",
+			},
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.createRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload).toMatchObject({
+			body: {
+				mode: "x-www-form-urlencoded",
+				fields: [
+					{ key: "a", value: "1", enabled: true },
+					{ key: "b", value: "2", enabled: true },
+				],
+			},
+			bodyType: "x-www-form-urlencoded",
+		});
+	});
+
 	test("run_request forwards an ad-hoc pre-request script the agent supplied", async () => {
 		// Parsed through the tool's own inputSchema first, because that is the
 		// only thing standing between the agent and the engine: `registerTool`

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -245,6 +245,31 @@ function requireStr(args: Record<string, unknown>, key: string): string {
 
 class ToolArgError extends Error {}
 
+/** The body modes whose content is a field list rather than a string. */
+const FORM_BODY_MODES = new Set(["form-data", "x-www-form-urlencoded"]);
+
+/**
+ * The body an agent described, in the shape the engine reads.
+ *
+ * Both form modes carry their content as `fields` - the same
+ * `{key, value, enabled}` rows the request builder and every importer produce
+ * - so a `body` string is split on `&` into entries rather than handed over
+ * whole. These two tools have advertised both modes all along while emitting
+ * `{ mode, content }`, which the engine reads no `fields` from: before issue
+ * #381 that meant an empty body on the wire, and now it is a refusal. Either
+ * way the mode was documented and unusable; splitting here makes the schema's
+ * promise true.
+ */
+function bodyPayload(bodyType: string, content: string): Record<string, unknown> {
+	if (!FORM_BODY_MODES.has(bodyType)) return { mode: bodyType, content };
+	const fields = [...new URLSearchParams(content)].map(([key, value]) => ({
+		key,
+		value,
+		enabled: true,
+	}));
+	return { mode: bodyType, fields };
+}
+
 /**
  * A whole number greater than zero, or `fallback` when the caller omitted the
  * argument.
@@ -271,9 +296,9 @@ function optionalPositiveInt(args: Record<string, unknown>, key: string, fallbac
  *
  * Nothing here resolves `{{variables}}` anymore: composition - interpolation
  * and the `inherit` auth walk - is engine-owned (issue #226), and MCP hands
- * the engine raw strings. The body is emitted as `{ mode, content }` - the
- * shape the engine's `deserialize_request` reads (it keys off `mode`, not
- * `type`).
+ * the engine raw strings. The body is emitted in the shape the engine's
+ * `deserialize_request` reads - keyed off `mode`, not `type`, and carrying
+ * `fields` rather than `content` for the two form modes (see `bodyPayload`).
  */
 function readRequestOverrides(args: Record<string, unknown>): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
@@ -292,7 +317,7 @@ function readRequestOverrides(args: Record<string, unknown>): Record<string, unk
 	}
 	const bodyContent = str(args, "body");
 	if (bodyContent !== undefined) {
-		out.body = { mode: str(args, "bodyType") ?? "text", content: bodyContent };
+		out.body = bodyPayload(str(args, "bodyType") ?? "text", bodyContent);
 	}
 	// httpVersion is an override like any other field here: `POST /compose`
 	// always emits a stored request's protocol, so a `start_load_run
@@ -807,7 +832,7 @@ export const TOOLS: McpTool[] = [
 				.string()
 				.optional()
 				.describe(
-					"Body type: json, text, form-data, x-www-form-urlencoded (default text)."
+					"Body type: json, text, graphql, form-data, x-www-form-urlencoded (default text). For the two form types, write `body` as `key=value&key=value`; it is split into form fields. File parts are not supported."
 				),
 			auth: authInput,
 			httpVersion: z
@@ -952,7 +977,12 @@ export const TOOLS: McpTool[] = [
 			method: z.string().optional().describe("HTTP method (default GET)."),
 			headers: z.record(z.string()).optional().describe("Headers as a string map."),
 			body: z.string().optional().describe("Request body content."),
-			bodyType: z.string().optional().describe("Body type: json, text, ... (default text)."),
+			bodyType: z
+				.string()
+				.optional()
+				.describe(
+					"Body type: json, text, graphql, form-data, x-www-form-urlencoded (default text). For the two form types, write `body` as `key=value&key=value`; it is split into form fields."
+				),
 			description: z.string().optional(),
 		},
 		handler: async (args, ctx, signal) => {
@@ -976,7 +1006,7 @@ export const TOOLS: McpTool[] = [
 				// The engine stores the body blob verbatim; the canonical shape keys
 				// off `mode` (not `type`), so a `type`-keyed body would not round-trip
 				// in the app. `bodyType` mirrors it into the denormalized column.
-				payload.body = { mode: bodyType, content: body };
+				payload.body = bodyPayload(bodyType, body);
 				payload.bodyType = bodyType;
 			}
 			const description = str(args, "description");

--- a/app/src/modules/request-builder/utils/execute-mapping.test.ts
+++ b/app/src/modules/request-builder/utils/execute-mapping.test.ts
@@ -16,9 +16,10 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { execIdentity, responseFromExecuteResult } from "./execute-mapping";
+import { buildExecBody, execIdentity, responseFromExecuteResult } from "./execute-mapping";
 import { createDefaultRequestState } from "./request-state";
 import type { SanityResult } from "@/types";
+import type { KeyValueItem, RequestState } from "../types";
 
 function result(overrides: Partial<SanityResult> = {}): SanityResult {
 	return {
@@ -79,5 +80,60 @@ describe("execIdentity", () => {
 
 		expect(execIdentity(request)).toEqual({});
 		expect("requestName" in execIdentity(request)).toBe(false);
+	});
+});
+
+/**
+ * The form modes are a contract with the engine, not a renderer-local
+ * convention: `deserialize_request` (engine/src/utils/json.cpp) keys off these
+ * exact strings and reads the content out of `fields`. It matched neither
+ * spelling until issue #381, and read no `fields` at all, so every form body
+ * this builder produced went out empty. These assertions are deliberately
+ * literal - a "tidier" mode string here is a silently empty request there.
+ */
+describe("buildExecBody form modes", () => {
+	const engineFormModes = ["form-data", "x-www-form-urlencoded"] as const;
+
+	function stateWith(overrides: Partial<RequestState>): RequestState {
+		return { ...createDefaultRequestState(), ...overrides };
+	}
+
+	function row(key: string, value: string, enabled = true): KeyValueItem {
+		return { id: `${key}-row`, key, value, enabled };
+	}
+
+	it.each(engineFormModes)("sends %s as fields, not content", (mode) => {
+		const rows = [row("name", "ada"), row("off", "x", false)];
+		const request = stateWith(
+			mode === "form-data"
+				? { bodyMode: mode, formData: rows }
+				: { bodyMode: mode, urlEncoded: rows }
+		);
+
+		const body = buildExecBody(request, (s) => s);
+
+		expect(body).toEqual({
+			mode,
+			// Disabled rows travel: the engine drops them at the wire, so
+			// toggling one back on needs no re-compose.
+			fields: [
+				{ key: "name", value: "ada", enabled: true },
+				{ key: "off", value: "x", enabled: false },
+			],
+		});
+		expect(body).not.toHaveProperty("content");
+	});
+
+	it("resolves variables inside field keys and values", () => {
+		const request = stateWith({
+			bodyMode: "x-www-form-urlencoded",
+			urlEncoded: [row("{{k}}", "{{v}}")],
+		});
+
+		const body = buildExecBody(request, (s) =>
+			s.replace("{{k}}", "key").replace("{{v}}", "val")
+		);
+
+		expect(body?.fields).toEqual([{ key: "key", value: "val", enabled: true }]);
 	});
 });

--- a/app/src/services/importers/postman.test.ts
+++ b/app/src/services/importers/postman.test.ts
@@ -289,6 +289,62 @@ describe("PostmanV21Parser", () => {
 		expect(req.params).toEqual([{ key: "page", value: "2", enabled: false }]);
 	});
 
+	/**
+	 * An imported form body has to arrive in the shape the *engine* reads:
+	 * `deserialize_request` matches these mode strings exactly and takes the
+	 * content out of `fields` (issue #381). A Postman `formdata` item that
+	 * mapped to any other spelling, or to a `content` string, would import
+	 * cleanly, display correctly, and send an empty body.
+	 */
+	it("maps both form body modes to the engine's fields shape", () => {
+		const requests = parse(
+			collectionOf([
+				{
+					name: "Urlencoded",
+					request: {
+						method: "POST",
+						url: "https://x/form",
+						body: {
+							mode: "urlencoded",
+							urlencoded: [
+								{ key: "a", value: "1" },
+								{ key: "b", value: "2", disabled: true },
+							],
+						},
+					},
+				},
+				{
+					name: "Multipart",
+					request: {
+						method: "POST",
+						url: "https://x/multipart",
+						body: {
+							mode: "formdata",
+							formdata: [
+								{ key: "note", value: "hi", type: "text" },
+								{ key: "avatar", src: "/tmp/a.png", type: "file" },
+							],
+						},
+					},
+				},
+			])
+		).collections[0].requests;
+
+		expect(requests[0].body).toEqual({
+			mode: "x-www-form-urlencoded",
+			fields: [
+				{ key: "a", value: "1", enabled: true },
+				{ key: "b", value: "2", enabled: false },
+			],
+		});
+		// File parts have no engine-side representation yet, so they are counted
+		// as skipped rather than imported as empty text fields.
+		expect(requests[1].body).toEqual({
+			mode: "form-data",
+			fields: [{ key: "note", value: "hi", enabled: true }],
+		});
+	});
+
 	it("leaves a literal single-brace value alone", () => {
 		// `{beta}` is a valid literal path segment in Postman, where only `{{x}}` is
 		// template syntax. Rewriting it invented a variable that resolves to nothing.

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -104,6 +104,19 @@ The service handles transformation between frontend (snake_case) and backend (ca
 }
 ```
 
+#### Request bodies
+
+`body` goes to the engine as the discriminated union `{ mode, content }` or -
+for the two form modes - `{ mode, fields }`, built by `buildExecBody`
+(`modules/request-builder/utils/execute-mapping.ts`) and passed through
+untransformed. The mode strings are a contract: the engine matches
+`"form-data"` and `"x-www-form-urlencoded"` exactly and reads the content out
+of `fields`, so a renamed mode or a flattened `content` string sends an empty
+body rather than failing. Disabled rows are sent and dropped engine-side, the
+engine writes the Content-Type each form mode implies, and file parts are not
+supported yet. See [the engine's `body` union](../engine/api-reference.md#the-request-body-union)
+for the full contract.
+
 ### API Methods
 
 #### Health & Configuration

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -207,7 +207,7 @@ message `Invalid 'auth': must be a JSON object`.
 |---|---|
 | `variables` (collection / environment / globals) | object |
 | `auth` (collection / request) | object |
-| `body` (request) | object |
+| `body` (request) | object - see [The request `body` union](#the-request-body-union) |
 | `params` / `headers` (request) | array of `{key: string, value: string, enabled: bool}` |
 
 Object-shaped fields are stored as JSON blobs, and every reader of one degrades
@@ -216,6 +216,45 @@ is dropped, and `auth` resolves to none, so a request the caller believes carrie
 credentials goes out bare. The write is therefore rejected rather than stored:
 `{"variables": 42}` and `{"auth": "bearer"}` are `400`s, and the previously
 stored value is left untouched.
+
+### The request `body` union
+
+`body` is a discriminated union on `mode`, and the shape of what it carries
+depends on which mode it is. The same union is read on the execution endpoints
+(`POST /compose`, `POST /execute`, `POST /runs`) and stored on a request row,
+so a body that round-trips through storage sends the same bytes.
+
+| `mode` | Carries | On the wire |
+|---|---|---|
+| `none` | nothing | no body |
+| `json` / `text` / `graphql` | `content` (string) | `content`, verbatim |
+| `x-www-form-urlencoded` | `fields` | percent-encoded `key=value&…` |
+| `form-data` | `fields` | `multipart/form-data`, boundary engine-generated |
+
+`fields` is an array of `{key: string, value: string, enabled?: bool}` - the
+same row shape `params` and `headers` use. `key` is required and must be a
+string; `value` defaults to `""` and a non-boolean `enabled` reads as enabled.
+A form mode carrying no `fields` array is a `400`, as is a `fields` on a mode
+whose content is a string. Rows with `enabled: false` are stored and returned
+but never sent, so switching one back on needs no re-compose; `{{variables}}`
+resolve inside both `key` and `value` during composition.
+
+Two Content-Type rules follow from the encoding:
+
+- `x-www-form-urlencoded` sets `Content-Type: application/x-www-form-urlencoded`
+  **only when the request declares no Content-Type of its own** - an explicit
+  header wins.
+- `form-data` **always** sets its own Content-Type, and a caller-supplied one is
+  dropped. The header has to carry the boundary of the body that was actually
+  encoded, which no caller can name in advance.
+
+`form-data` supports text parts only. A file part has no representation in the
+payload yet - importers count file parts as skipped rather than importing them
+as empty text fields.
+
+The older mode spellings `form` (for `x-www-form-urlencoded`) and `formdata`
+(for `form-data`) are still accepted on input; responses always use the long
+names.
 
 ### Behavior change (pre-1.0)
 
@@ -568,7 +607,7 @@ the null-vs-absent rule.
   "params": [],                      // Optional, array of {key, value, enabled}
   "headers": [],                     // Optional, array of {key, value, enabled}
   "body": {"mode": "none"},          // Optional, request body
-  "bodyType": "none",                // Optional: "none", "json", "text", "form-data", "x-www-form-urlencoded"
+  "bodyType": "none",                // Optional, mirrors body.mode - see The request body union
   "auth": {},                        // Optional, authentication config
   "preRequestScript": "",            // Optional, JavaScript pre-request script
   "postRequestScript": "",           // Optional, JavaScript test script

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -264,6 +264,13 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   actually execute. `run_request` takes an agent-written `preRequestScript` /
   `postRequestScript` instead, since an ad-hoc call has no chain to compose
   from; `start_load_run` takes the same `postRequestScript` for a URL-only run.
+- **Bodies** - `body` is a string and `bodyType` names the mode
+  (`json` | `text` | `graphql` | `form-data` | `x-www-form-urlencoded`,
+  default `text`). The two form modes carry their content as **fields**, not as
+  a string, so `body` is written as `key=value&key=value` and split into the
+  `fields` rows the engine reads - see
+  [the `body` union](api-reference.md#the-request-body-union). `create_request`
+  stores the same shape. File parts are not supported.
 - **Protocol** - `run_request` and `start_load_run` both take an optional
   `httpVersion` Zod-enum arg (`"auto" | "http1.1" | "http2"`, default `"auto"`),
   mirroring the request builder's Settings-tab picker. `run_collection_smoke`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -269,6 +269,7 @@ add_library(vayu_core STATIC
     src/http/request_exchange.cpp
     src/http/set_cookie.cpp
     src/http/cookie_jar.cpp
+    src/http/form_body.cpp
     src/utils/json.cpp
     src/utils/logger.cpp
     src/utils/metrics_helper.cpp
@@ -432,6 +433,7 @@ if(VAYU_BUILD_TESTS)
         tests/script_send_request_test.cpp
         tests/set_cookie_test.cpp
         tests/cookie_jar_test.cpp
+        tests/form_body_test.cpp
         tests/stats_route_test.cpp
         tests/execution_timeout_test.cpp
         tests/execution_http_version_test.cpp

--- a/engine/include/vayu/http/event_loop/curl_utils.hpp
+++ b/engine/include/vayu/http/event_loop/curl_utils.hpp
@@ -102,8 +102,31 @@ Response error_response (const Error& error);
  * Shared by both clients so the two cannot drift apart again.
  *
  * Requires `validate_transferable(request)` to have passed.
+ *
+ * @return The multipart body attached to the handle, which the caller **must**
+ *         free with `curl_mime_free` once the transfer has finished, or
+ *         nullptr for every other body mode. Returned rather than owned here
+ *         because the two drivers keep per-transfer state in different places:
+ *         a local for the single-request client, `TransferData` for the loop.
  */
-void apply_method_and_body (CURL* curl, const Request& request);
+[[nodiscard]] curl_mime* apply_method_and_body (CURL* curl, const Request& request);
+
+/**
+ * @brief The "Content-Type: ..." header line the body implies, or empty.
+ *
+ * Empty when the request already declares a Content-Type (a header the user
+ * typed always wins) and empty for every mode that implies none. Both clients
+ * call this after their own header loop so the two cannot drift.
+ */
+[[nodiscard]] std::string body_content_type_header (const Request& request);
+
+/**
+ * @brief True when this request header must not be forwarded as written.
+ *
+ * Only a Content-Type on a multipart body, whose boundary libcurl owns - see
+ * `vayu::http::content_type_is_engine_owned`.
+ */
+[[nodiscard]] bool suppresses_request_header (const Request& request, const std::string& key);
 
 /**
  * @brief Record one "Key: Value" response header line into `headers`.

--- a/engine/include/vayu/http/event_loop/transfer_context.hpp
+++ b/engine/include/vayu/http/event_loop/transfer_context.hpp
@@ -50,6 +50,9 @@ struct TransferData {
     char error_buffer[CURL_ERROR_SIZE] = { 0 };
     struct curl_slist* headers_list    = nullptr;
     struct curl_slist* resolve_list    = nullptr; // DNS pre-resolution list
+    /// Multipart body attached to the handle, freed with the rest of this
+    /// transfer's curl state. Only a `form-data` body has one.
+    curl_mime* mime = nullptr;
 
     ~TransferData ();
 };

--- a/engine/include/vayu/http/form_body.hpp
+++ b/engine/include/vayu/http/form_body.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <vector>
+
+#include "vayu/types.hpp"
+
+/**
+ * @file form_body.hpp
+ * @brief The two form body modes, from the stored shape to the wire.
+ *
+ * `x-www-form-urlencoded` and `form-data` are the only modes whose content is
+ * a list of fields rather than a string, so every question the transfer setup
+ * asks about a body ("are there bytes to send?", "which Content-Type?") has a
+ * different answer for them. Those questions are answered here, once, as pure
+ * functions of the body - both HTTP drivers (the single-request client and the
+ * event loop) read the same answers, and the rules are unit-testable without a
+ * curl handle or a socket.
+ *
+ * Multipart is *not* encoded here: its body carries a boundary, which libcurl
+ * generates as part of `curl_mime`, so the encoder and the Content-Type that
+ * describes it stay together inside libcurl. See `content_type_is_engine_owned`.
+ */
+
+namespace vayu::http {
+
+/**
+ * @brief True when the mode carries its content in `Body::fields`.
+ */
+[[nodiscard]] bool is_form_mode (BodyMode mode);
+
+/**
+ * @brief The fields that go on the wire - enabled only, in order.
+ *
+ * A disabled row is stored (the user can switch it back on) but never sent,
+ * matching the rule params and headers already follow.
+ */
+[[nodiscard]] std::vector<FormField> enabled_fields (const std::vector<FormField>& fields);
+
+/**
+ * @brief Enabled fields percent-encoded as `application/x-www-form-urlencoded`.
+ *
+ * Percent-encoding is libcurl's `curl_easy_escape`, not a hand-rolled table:
+ * a private copy would not receive its fixes. Empty when no field is enabled.
+ */
+[[nodiscard]] std::string encode_urlencoded (const std::vector<FormField>& fields);
+
+/**
+ * @brief True when this body puts bytes in the request's body frame.
+ *
+ * The one predicate every caller uses, because "has a body" is mode-dependent:
+ * a content mode needs a non-empty `content`, a form mode needs at least one
+ * enabled field.
+ */
+[[nodiscard]] bool has_wire_body (const Body& body);
+
+/**
+ * @brief The Content-Type this body implies when the request declares none.
+ *
+ * Empty for every mode but `x-www-form-urlencoded`. The engine has never
+ * derived a Content-Type for json/text/graphql - clients own that header, and
+ * the request builder writes it - so adding one here would take a header away
+ * from the user who typed it. The form modes are different: their encoding is
+ * chosen engine-side, so nothing else can name it.
+ */
+[[nodiscard]] std::string implied_content_type (const Body& body);
+
+/**
+ * @brief True when the engine writes the Content-Type and a caller's is dropped.
+ *
+ * Only multipart. Its Content-Type must carry the same boundary as the body
+ * libcurl encoded, so a caller-supplied `multipart/form-data` - which has no
+ * way to name a boundary that does not exist yet - would make the body
+ * unparseable. Dropping it is what every code generator in the app already
+ * does for multipart (`services/codegen/prepare.ts`).
+ */
+[[nodiscard]] bool content_type_is_engine_owned (const Body& body);
+
+} // namespace vayu::http

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -99,6 +99,14 @@ struct CaseInsensitiveLess {
             return std::tolower (c1) < std::tolower (c2);
         });
     }
+
+    /// Header-name equality, for the callers that compare a name outside the
+    /// map - the same rule the map's ordering already applies, rather than a
+    /// private lower-casing copy at each call site.
+    static bool equal (const std::string& a, const std::string& b) {
+        const CaseInsensitiveLess less;
+        return !less (a, b) && !less (b, a);
+    }
 };
 
 /**
@@ -108,15 +116,35 @@ using Headers = std::map<std::string, std::string, CaseInsensitiveLess>;
 
 /**
  * @brief Request body content types
+ *
+ * `Form` is `x-www-form-urlencoded` and `FormData` is `multipart/form-data`.
+ * Both carry their content as `Body::fields`, never as `Body::content` - see
+ * `vayu/http/form_body.hpp` for the wire encoding of each.
  */
 enum class BodyMode { None, Json, Text, Form, FormData, Binary, GraphQL };
 
 /**
+ * @brief One entry of a form body.
+ *
+ * Mirrors the renderer's `KeyValueEntry`: a disabled row is stored and
+ * round-tripped, and dropped only when the body is put on the wire.
+ */
+struct FormField {
+    std::string key;
+    std::string value;
+    bool enabled = true;
+};
+
+/**
  * @brief Request body
+ *
+ * Exactly one of `content` and `fields` carries the body: the two form modes
+ * use `fields`, every other content-bearing mode uses `content`.
  */
 struct Body {
     BodyMode mode = BodyMode::None;
     std::string content;
+    std::vector<FormField> fields;
 };
 
 /**

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -23,6 +23,7 @@
 #include "vayu/http/curl_version_map.hpp"
 #include "vayu/http/debug_redact.hpp"
 #include "vayu/http/event_loop/curl_utils.hpp"
+#include "vayu/http/form_body.hpp"
 #include "vayu/http/status.hpp"
 
 #include <curl/curl.h>
@@ -416,13 +417,27 @@ Result<Response> Client::send (const Request& request) {
 
     // Set method and body (shared with the event loop path so the two cannot
     // disagree about what goes on the wire - see apply_method_and_body)
-    detail::apply_method_and_body (curl, request);
+    curl_mime* mime = detail::apply_method_and_body (curl, request);
 
     // Set headers
     struct curl_slist* headers_list = nullptr;
     for (const auto& [key, value] : request.headers) {
+        if (detail::suppresses_request_header (request, key)) {
+            // Not sent, so not reported as sent either - libcurl writes the
+            // multipart Content-Type, boundary and all.
+            response.request_headers.erase (key);
+            continue;
+        }
         std::string header = key + ": " + value;
         headers_list       = curl_slist_append (headers_list, header.c_str ());
+    }
+
+    // The Content-Type the body mode implies, when the request declares none.
+    if (std::string content_type = detail::body_content_type_header (request);
+        !content_type.empty ()) {
+        headers_list = curl_slist_append (headers_list, content_type.c_str ());
+        response.request_headers["Content-Type"] =
+        vayu::http::implied_content_type (request.body);
     }
 
     // Add User-Agent if not set
@@ -498,9 +513,13 @@ Result<Response> Client::send (const Request& request) {
     CURLcode res = curl_easy_perform (curl);
     auto completion = std::chrono::steady_clock::now ();
 
-    // Cleanup headers
+    // Cleanup headers and the multipart body, both of which had to outlive the
+    // transfer that just finished.
     if (headers_list) {
         curl_slist_free_all (headers_list);
+    }
+    if (mime) {
+        curl_mime_free (mime);
     }
 
     // Before any error return below: a failed transfer can still have

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -23,6 +23,7 @@
 #include "vayu/http/event_loop/curl_callbacks.hpp"
 #include "vayu/http/event_loop/event_loop_worker.hpp"
 #include "vayu/http/event_loop/transfer_context.hpp"
+#include "vayu/http/form_body.hpp"
 #include "vayu/http/status.hpp"
 #include "vayu/utils/logger.hpp"
 
@@ -155,8 +156,7 @@ int extract_port (const std::string& url) {
 }
 
 std::optional<Error> validate_transferable (const Request& request) {
-    const bool has_body =
-    request.body.mode != BodyMode::None && !request.body.content.empty ();
+    const bool has_body = vayu::http::has_wire_body (request.body);
     if (has_body && request.method == HttpMethod::HEAD) {
         Error error;
         error.code = ErrorCode::InvalidMethod;
@@ -177,16 +177,36 @@ Response error_response (const Error& error) {
     return response;
 }
 
-void apply_method_and_body (CURL* curl, const Request& request) {
-    const bool has_body =
-    request.body.mode != BodyMode::None && !request.body.content.empty ();
+curl_mime* apply_method_and_body (CURL* curl, const Request& request) {
+    const bool has_body = vayu::http::has_wire_body (request.body);
+    curl_mime* mime     = nullptr;
 
-    if (has_body) {
+    if (has_body && request.body.mode == BodyMode::FormData) {
+        // Multipart: libcurl encodes the parts and generates the boundary, so
+        // the body and the Content-Type that describes it cannot disagree.
+        // Text parts only - a file part needs a source the engine does not
+        // carry yet (issue #381 defers it explicitly).
+        mime = curl_mime_init (curl);
+        for (const auto& field : vayu::http::enabled_fields (request.body.fields)) {
+            curl_mimepart* part = curl_mime_addpart (mime);
+            curl_mime_name (part, field.key.c_str ());
+            curl_mime_data (part, field.value.c_str (), field.value.size ());
+        }
+        // Like POSTFIELDS below, this switches curl's method to POST, so the
+        // method is (re-)asserted afterwards.
+        curl_easy_setopt (curl, CURLOPT_MIMEPOST, mime);
+    } else if (has_body) {
         // Setting POSTFIELDS switches curl's method to POST, so it goes first
         // and the method is (re-)asserted below.
-        curl_easy_setopt (curl, CURLOPT_POSTFIELDS, request.body.content.c_str ());
-        curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE,
-        static_cast<long> (request.body.content.size ()));
+        //
+        // COPYPOSTFIELDS rather than POSTFIELDS because the urlencoded body is
+        // built here and dies at the end of this scope, while POSTFIELDS keeps
+        // only a pointer that has to outlive the transfer.
+        const std::string body = request.body.mode == BodyMode::Form ?
+        vayu::http::encode_urlencoded (request.body.fields) :
+        request.body.content;
+        curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, static_cast<long> (body.size ()));
+        curl_easy_setopt (curl, CURLOPT_COPYPOSTFIELDS, body.c_str ());
     }
 
     switch (request.method) {
@@ -199,7 +219,15 @@ void apply_method_and_body (CURL* curl, const Request& request) {
             curl_easy_setopt (curl, CURLOPT_HTTPGET, 1L);
         }
         break;
-    case HttpMethod::POST: curl_easy_setopt (curl, CURLOPT_POST, 1L); break;
+    case HttpMethod::POST:
+        // CURLOPT_POST would *discard* a multipart body: it switches curl back
+        // to a POSTFIELDS-style post, and the mime attached above goes with it.
+        // MIMEPOST already makes the request a POST, so re-asserting the verb
+        // is both unnecessary and destructive here.
+        if (!mime) {
+            curl_easy_setopt (curl, CURLOPT_POST, 1L);
+        }
+        break;
     case HttpMethod::PUT:
         curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "PUT");
         break;
@@ -215,6 +243,26 @@ void apply_method_and_body (CURL* curl, const Request& request) {
         curl_easy_setopt (curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
         break;
     }
+
+    return mime;
+}
+
+std::string body_content_type_header (const Request& request) {
+    const std::string implied = vayu::http::implied_content_type (request.body);
+    if (implied.empty ()) {
+        return {};
+    }
+    // A Content-Type the caller set wins - the same rule the request builder
+    // applies renderer-side, where "someone who typed this means it".
+    if (request.headers.contains ("Content-Type")) {
+        return {};
+    }
+    return "Content-Type: " + implied;
+}
+
+bool suppresses_request_header (const Request& request, const std::string& key) {
+    return vayu::http::content_type_is_engine_owned (request.body) &&
+    CaseInsensitiveLess::equal (key, "Content-Type");
 }
 
 void ingest_header_line (std::string_view line, Headers& headers) {
@@ -331,7 +379,7 @@ CURL* setup_easy_handle (CURL* curl, TransferData* data, const EventLoopConfig& 
 
     // Set method and body (shared with the single-request client - see
     // apply_method_and_body for why the two are set together and in that order)
-    apply_method_and_body (curl, request);
+    data->mime = apply_method_and_body (curl, request);
 
     // Bound what one transfer may buffer in memory. write_callback reports the
     // overrun by returning a short count, which curl turns into a failed
@@ -341,8 +389,18 @@ CURL* setup_easy_handle (CURL* curl, TransferData* data, const EventLoopConfig& 
 
     // Set headers
     for (const auto& [key, value] : request.headers) {
+        if (suppresses_request_header (request, key)) {
+            continue;
+        }
         std::string header = key + ": " + value;
         data->headers_list = curl_slist_append (data->headers_list, header.c_str ());
+    }
+
+    // The Content-Type the body mode implies, when the request declares none.
+    if (std::string content_type = body_content_type_header (request);
+        !content_type.empty ()) {
+        data->headers_list =
+        curl_slist_append (data->headers_list, content_type.c_str ());
     }
 
     // Add User-Agent if not set

--- a/engine/src/http/event_loop/transfer_context.cpp
+++ b/engine/src/http/event_loop/transfer_context.cpp
@@ -16,6 +16,12 @@ TransferData::~TransferData () {
     if (resolve_list) {
         curl_slist_free_all (resolve_list);
     }
+    // Freed after the transfer is done with the handle, which is what
+    // curl_mime_free requires; the pool's curl_easy_reset on the next acquire
+    // drops the handle's reference to it either way.
+    if (mime) {
+        curl_mime_free (mime);
+    }
 }
 
 } // namespace vayu::http::detail

--- a/engine/src/http/form_body.cpp
+++ b/engine/src/http/form_body.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/http/form_body.hpp"
+
+#include <curl/curl.h>
+
+namespace vayu::http {
+
+namespace {
+
+// libcurl's percent-encoder, with its allocation returned to it. The handle
+// argument is unused by libcurl (and documented as ignored), so this stays a
+// pure function - no easy handle has to exist to encode a body.
+std::string percent_encode (const std::string& value) {
+    char* escaped =
+    curl_easy_escape (nullptr, value.c_str (), static_cast<int> (value.size ()));
+    if (!escaped) {
+        return {};
+    }
+    std::string out (escaped);
+    curl_free (escaped);
+    return out;
+}
+
+} // namespace
+
+bool is_form_mode (BodyMode mode) {
+    return mode == BodyMode::Form || mode == BodyMode::FormData;
+}
+
+std::vector<FormField> enabled_fields (const std::vector<FormField>& fields) {
+    std::vector<FormField> out;
+    out.reserve (fields.size ());
+    for (const auto& field : fields) {
+        if (field.enabled) {
+            out.push_back (field);
+        }
+    }
+    return out;
+}
+
+std::string encode_urlencoded (const std::vector<FormField>& fields) {
+    std::string out;
+    for (const auto& field : fields) {
+        if (!field.enabled) {
+            continue;
+        }
+        if (!out.empty ()) {
+            out += '&';
+        }
+        out += percent_encode (field.key);
+        out += '=';
+        out += percent_encode (field.value);
+    }
+    return out;
+}
+
+bool has_wire_body (const Body& body) {
+    if (body.mode == BodyMode::None) {
+        return false;
+    }
+    if (is_form_mode (body.mode)) {
+        for (const auto& field : body.fields) {
+            if (field.enabled) {
+                return true;
+            }
+        }
+        return false;
+    }
+    return !body.content.empty ();
+}
+
+std::string implied_content_type (const Body& body) {
+    if (body.mode == BodyMode::Form && has_wire_body (body)) {
+        return "application/x-www-form-urlencoded";
+    }
+    return {};
+}
+
+bool content_type_is_engine_owned (const Body& body) {
+    return body.mode == BodyMode::FormData && has_wire_body (body);
+}
+
+} // namespace vayu::http

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/http/form_body.hpp"
 
 namespace vayu::json {
 
@@ -50,6 +51,19 @@ std::optional<Json> try_parse_body (const std::string& body) {
 // Request Serialization
 // ============================================================================
 
+namespace {
+
+Json serialize_form_fields (const std::vector<FormField>& fields) {
+    Json out = Json::array ();
+    for (const auto& field : fields) {
+        out.push_back (Json{ { "key", field.key }, { "value", field.value },
+        { "enabled", field.enabled } });
+    }
+    return out;
+}
+
+} // namespace
+
 Json serialize (const Request& request) {
     Json json;
 
@@ -77,13 +91,16 @@ Json serialize (const Request& request) {
             body_json["mode"]    = "text";
             body_json["content"] = request.body.content;
             break;
+        // The two form modes are emitted under the spelling every client
+        // produces (the renderer, the importers, the curl parser) and carry
+        // `fields`, so a serialized body parses back to the same request.
         case BodyMode::Form:
-            body_json["mode"]    = "form";
-            body_json["content"] = request.body.content;
+            body_json["mode"]   = "x-www-form-urlencoded";
+            body_json["fields"] = serialize_form_fields (request.body.fields);
             break;
         case BodyMode::FormData:
-            body_json["mode"]    = "formdata";
-            body_json["content"] = request.body.content;
+            body_json["mode"]   = "form-data";
+            body_json["fields"] = serialize_form_fields (request.body.fields);
             break;
         case BodyMode::Binary:
             body_json["mode"]    = "binary";
@@ -369,6 +386,73 @@ std::string serialize_variables (const vayu::Environment& env) {
     return obj.dump ();
 }
 
+namespace {
+
+// The `fields` half of a body, for the two form modes.
+//
+// A malformed field is refused rather than skipped: this endpoint's whole
+// contract is "send exactly what was built", and a silently dropped field is
+// the failure mode the form modes already had. The leniency that does exist
+// mirrors the D17 rules `parse_variables` applies to the same client shape -
+// an absent or non-boolean `enabled` means enabled, a non-string `value` means
+// "" - because those are the values a client can produce without meaning
+// anything by them. A field with no usable `key` has no wire form at all, so
+// it is an error.
+Result<std::vector<FormField>> parse_form_fields (const Json& body_json, BodyMode mode) {
+    const bool is_form = vayu::http::is_form_mode (mode);
+    const auto entry   = body_json.find ("fields");
+
+    if (entry == body_json.end () || entry->is_null ()) {
+        if (is_form) {
+            // The mode says the content is a field list and there is none.
+            // Before this was an error the request went out with an empty
+            // body, which is the same wrongness without the message.
+            return Error{ ErrorCode::InternalError,
+                "Body mode 'x-www-form-urlencoded'/'form-data' requires a "
+                "'fields' array" };
+        }
+        return std::vector<FormField>{};
+    }
+
+    if (!is_form) {
+        return Error{ ErrorCode::InternalError,
+            "Body 'fields' is only valid for the 'x-www-form-urlencoded' and "
+            "'form-data' modes" };
+    }
+    if (!entry->is_array ()) {
+        return Error{ ErrorCode::InternalError, "Body 'fields' must be an array" };
+    }
+
+    std::vector<FormField> fields;
+    fields.reserve (entry->size ());
+    for (const auto& item : *entry) {
+        if (!item.is_object ()) {
+            return Error{ ErrorCode::InternalError,
+                "Each entry of body 'fields' must be an object" };
+        }
+        const auto key = item.find ("key");
+        if (key == item.end () || !key->is_string ()) {
+            return Error{ ErrorCode::InternalError,
+                "Each entry of body 'fields' needs a string 'key'" };
+        }
+
+        FormField field;
+        field.key = key->get<std::string> ();
+        if (const auto value = item.find ("value");
+            value != item.end () && value->is_string ()) {
+            field.value = value->get<std::string> ();
+        }
+        if (const auto enabled = item.find ("enabled");
+            enabled != item.end () && enabled->is_boolean ()) {
+            field.enabled = enabled->get<bool> ();
+        }
+        fields.push_back (std::move (field));
+    }
+    return fields;
+}
+
+} // namespace
+
 Result<Request> deserialize_request (const Json& json) {
     try {
         Request request;
@@ -403,13 +487,19 @@ Result<Request> deserialize_request (const Json& json) {
             if (body_json.contains ("mode")) {
                 std::string mode = body_json["mode"].get<std::string> ();
 
+                // Both spellings of each form mode reach the same enumerator:
+                // every client produces the long one ("x-www-form-urlencoded",
+                // "form-data"), while "form"/"formdata" are the engine's own
+                // older names, still accepted so a stored or replayed payload
+                // keeps working. This table is the one place a spelling is
+                // added - same rule as read_post_request_script's.
                 if (mode == "json") {
                     request.body.mode = BodyMode::Json;
                 } else if (mode == "text") {
                     request.body.mode = BodyMode::Text;
-                } else if (mode == "form") {
+                } else if (mode == "form" || mode == "x-www-form-urlencoded") {
                     request.body.mode = BodyMode::Form;
-                } else if (mode == "formdata") {
+                } else if (mode == "formdata" || mode == "form-data") {
                     request.body.mode = BodyMode::FormData;
                 } else if (mode == "binary") {
                     request.body.mode = BodyMode::Binary;
@@ -426,6 +516,12 @@ Result<Request> deserialize_request (const Json& json) {
                     request.body.content = body_json["content"].dump ();
                 }
             }
+
+            auto fields = parse_form_fields (body_json, request.body.mode);
+            if (fields.is_error ()) {
+                return fields.error ();
+            }
+            request.body.fields = std::move (fields).value ();
         }
 
         // Options

--- a/engine/tests/form_body_test.cpp
+++ b/engine/tests/form_body_test.cpp
@@ -1,0 +1,468 @@
+/**
+ * @file form_body_test.cpp
+ * @brief The two form body modes, from the parsed shape to the bytes on the wire.
+ *
+ * The bug these pin (issue #381): a `form-data` or `x-www-form-urlencoded`
+ * body was built in the UI, stored, composed - and then sent as an **empty**
+ * body, because the engine read only `content` and recognised neither mode
+ * string. Nothing failed; the server just received nothing.
+ *
+ * So the assertions here are deliberately about the wire and not about the
+ * parsed struct: an echo server records the exact body and Content-Type it
+ * received, and both HTTP drivers (the single-request client behind
+ * `POST /execute`, and the event loop every load run generates through) are
+ * driven against it. A regression that re-broke the serialization while
+ * leaving the parse intact would still redden these.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "vayu/http/client.hpp"
+#include "vayu/http/event_loop.hpp"
+#include "vayu/http/form_body.hpp"
+#include "vayu/utils/json.hpp"
+
+namespace vayu::http {
+namespace {
+
+/// Records what the last request actually carried: its Content-Type, its raw
+/// body, and - for a multipart request - the parts httplib parsed out of it.
+///
+/// Multipart is asserted through those parsed parts rather than by matching
+/// the envelope byte for byte, because httplib parses a multipart body itself
+/// and leaves `req.body` empty. That is the better assertion anyway: httplib
+/// splits the body on the boundary it read from the *header*, so a body whose
+/// boundary disagreed with its Content-Type yields no parts at all, and a
+/// part it can read is a part a real server can read.
+class EchoServer {
+    public:
+    EchoServer () {
+        auto record = [this] (const httplib::Request& req, httplib::Response& res) {
+            {
+                std::lock_guard<std::mutex> lock (mutex_);
+                body_         = req.body;
+                content_type_ = req.get_header_value ("Content-Type");
+                parts_.clear ();
+                for (const auto& [name, field] : req.form.fields) {
+                    parts_[name] = field.content;
+                }
+            }
+            res.set_content ("{}", "application/json");
+        };
+        svr_.Post ("/echo", record);
+        svr_.Put ("/echo", record);
+
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+        svr_.wait_until_ready ();
+    }
+
+    ~EchoServer () {
+        svr_.stop ();
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+
+    std::string url () const {
+        return "http://127.0.0.1:" + std::to_string (port_) + "/echo";
+    }
+
+    std::string body () const {
+        std::lock_guard<std::mutex> lock (mutex_);
+        return body_;
+    }
+
+    std::string content_type () const {
+        std::lock_guard<std::mutex> lock (mutex_);
+        return content_type_;
+    }
+
+    /// The multipart parts, by field name. Empty for every other body.
+    std::map<std::string, std::string> parts () const {
+        std::lock_guard<std::mutex> lock (mutex_);
+        return parts_;
+    }
+
+    private:
+    httplib::Server svr_;
+    std::thread thread_;
+    int port_ = 0;
+    mutable std::mutex mutex_;
+    std::string body_;
+    std::string content_type_;
+    std::map<std::string, std::string> parts_;
+};
+
+Request form_request (const std::string& url, BodyMode mode, std::vector<FormField> fields) {
+    Request request;
+    request.method      = HttpMethod::POST;
+    request.url         = url;
+    request.body.mode   = mode;
+    request.body.fields = std::move (fields);
+    return request;
+}
+
+class FormBodyWireTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        global_init ();
+        server_ = std::make_unique<EchoServer> ();
+        client_ = std::make_unique<Client> ();
+    }
+
+    void TearDown () override {
+        client_.reset ();
+        server_.reset ();
+        global_cleanup ();
+    }
+
+    std::unique_ptr<EchoServer> server_;
+    std::unique_ptr<Client> client_;
+};
+
+// ---------------------------------------------------------------------------
+// The wire, through the single-request client (POST /execute, "Send").
+// ---------------------------------------------------------------------------
+
+TEST_F (FormBodyWireTest, UrlEncodedBodyReachesTheWire) {
+    auto request = form_request (server_->url (), BodyMode::Form,
+    { { "name", "ada lovelace", true }, { "role", "engineer", true } });
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+    EXPECT_EQ (result.value ().status_code, 200);
+
+    EXPECT_EQ (server_->body (), "name=ada%20lovelace&role=engineer");
+    EXPECT_EQ (server_->content_type (), "application/x-www-form-urlencoded");
+}
+
+// Reserved characters must survive as data rather than as separators - the
+// failure this guards is a value containing '&' or '=' splitting into extra
+// fields server-side.
+TEST_F (FormBodyWireTest, UrlEncodedEscapesReservedCharacters) {
+    auto request = form_request (server_->url (), BodyMode::Form,
+    { { "q", "a&b=c d/e", true }, { "sym+bol", "100%", true } });
+
+    ASSERT_TRUE (client_->send (request).is_ok ());
+    EXPECT_EQ (server_->body (), "q=a%26b%3Dc%20d%2Fe&sym%2Bbol=100%25");
+}
+
+TEST_F (FormBodyWireTest, UrlEncodedOmitsDisabledFields) {
+    auto request = form_request (server_->url (), BodyMode::Form,
+    { { "kept", "1", true }, { "dropped", "2", false }, { "also_kept", "3", true } });
+
+    ASSERT_TRUE (client_->send (request).is_ok ());
+    EXPECT_EQ (server_->body (), "kept=1&also_kept=3");
+}
+
+// An explicit Content-Type is the user's: the engine adds one only when the
+// request declares none.
+TEST_F (FormBodyWireTest, UrlEncodedKeepsAnExplicitContentType) {
+    auto request = form_request (server_->url (), BodyMode::Form, { { "a", "1", true } });
+    request.headers["Content-Type"] =
+    "application/x-www-form-urlencoded; charset=utf-8";
+
+    ASSERT_TRUE (client_->send (request).is_ok ());
+    EXPECT_EQ (server_->content_type (), "application/x-www-form-urlencoded; charset=utf-8");
+    EXPECT_EQ (server_->body (), "a=1");
+}
+
+TEST_F (FormBodyWireTest, MultipartBodyReachesTheWire) {
+    auto request = form_request (server_->url (), BodyMode::FormData,
+    { { "name", "ada", true }, { "note", "hello world", true } });
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    const std::string content_type = server_->content_type ();
+    EXPECT_TRUE (content_type.starts_with ("multipart/form-data; boundary=")) << content_type;
+
+    const auto parts = server_->parts ();
+    ASSERT_EQ (parts.size (), 2u);
+    EXPECT_EQ (parts.at ("name"), "ada");
+    EXPECT_EQ (parts.at ("note"), "hello world");
+}
+
+TEST_F (FormBodyWireTest, MultipartOmitsDisabledFields) {
+    auto request = form_request (server_->url (), BodyMode::FormData,
+    { { "kept", "1", true }, { "dropped", "2", false } });
+
+    ASSERT_TRUE (client_->send (request).is_ok ());
+    const auto parts = server_->parts ();
+    ASSERT_EQ (parts.size (), 1u);
+    EXPECT_EQ (parts.count ("kept"), 1u);
+    EXPECT_EQ (parts.count ("dropped"), 0u);
+}
+
+// A caller-supplied multipart Content-Type cannot name the boundary libcurl
+// has not generated yet, so honouring it would send an unparseable body. It is
+// dropped, and the report of what was sent drops it too.
+TEST_F (FormBodyWireTest, MultipartContentTypeIsEngineOwned) {
+    auto request =
+    form_request (server_->url (), BodyMode::FormData, { { "a", "1", true } });
+    request.headers["Content-Type"] = "multipart/form-data";
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    EXPECT_TRUE (
+    server_->content_type ().starts_with ("multipart/form-data; boundary="))
+    << server_->content_type ();
+    EXPECT_FALSE (result.value ().request_headers.contains ("Content-Type"));
+}
+
+// All-disabled fields are no body at all - not an empty multipart envelope,
+// and not a Content-Type the engine derived for a body that is not there.
+//
+// The methods differ deliberately: libcurl labels a bodiless POST
+// `application/x-www-form-urlencoded` on its own (its default for
+// CURLOPT_POST, and true of every empty-bodied POST this engine has ever
+// sent), so a POST cannot tell the engine's header from curl's. A PUT can -
+// curl adds nothing there.
+TEST_F (FormBodyWireTest, NoEnabledFieldsSendsNoBody) {
+    auto urlencoded =
+    form_request (server_->url (), BodyMode::Form, { { "off", "1", false } });
+    urlencoded.method = HttpMethod::PUT;
+    ASSERT_TRUE (client_->send (urlencoded).is_ok ());
+    EXPECT_EQ (server_->body (), "");
+    EXPECT_EQ (server_->content_type (), "");
+
+    auto multipart =
+    form_request (server_->url (), BodyMode::FormData, { { "off", "1", false } });
+    multipart.method = HttpMethod::PUT;
+    ASSERT_TRUE (client_->send (multipart).is_ok ());
+    EXPECT_EQ (server_->body (), "");
+    EXPECT_EQ (server_->content_type (), "");
+}
+
+// The method must survive the body: both encoders switch curl to POST, so a
+// PUT that lost its verb would arrive as a POST (the trap apply_method_and_body
+// already documents for POSTFIELDS, now shared with MIMEPOST).
+TEST_F (FormBodyWireTest, FormBodyKeepsANonPostMethod) {
+    auto request =
+    form_request (server_->url (), BodyMode::FormData, { { "a", "1", true } });
+    request.method = HttpMethod::PUT;
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+    EXPECT_EQ (result.value ().status_code, 200); // only PUT /echo answers 200
+}
+
+// ---------------------------------------------------------------------------
+// The wire, through the event loop - the driver every load run uses. Both
+// drivers share apply_method_and_body; this proves the sharing is real rather
+// than assumed, and that a load run sends the same bytes a Send does.
+// ---------------------------------------------------------------------------
+
+TEST_F (FormBodyWireTest, LoadDriverSendsTheSameUrlEncodedBody) {
+    EventLoop loop;
+    loop.start ();
+
+    auto request = form_request (server_->url (), BodyMode::Form,
+    { { "name", "ada lovelace", true }, { "off", "x", false } });
+    auto handle  = loop.submit_async (request);
+    auto result  = handle.future.get ();
+    loop.stop ();
+
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+    EXPECT_EQ (server_->body (), "name=ada%20lovelace");
+    EXPECT_EQ (server_->content_type (), "application/x-www-form-urlencoded");
+}
+
+TEST_F (FormBodyWireTest, LoadDriverSendsTheSameMultipartBody) {
+    EventLoop loop;
+    loop.start ();
+
+    auto request =
+    form_request (server_->url (), BodyMode::FormData, { { "name", "ada", true } });
+    auto handle = loop.submit_async (request);
+    auto result = handle.future.get ();
+    loop.stop ();
+
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+    EXPECT_TRUE (
+    server_->content_type ().starts_with ("multipart/form-data; boundary="))
+    << server_->content_type ();
+    EXPECT_EQ (server_->parts ().at ("name"), "ada");
+}
+
+// The multipart body is attached to a pooled handle and freed with the
+// transfer; a leak or a double free would show up as a second request that
+// sends the previous body, or as a crash. Three sends in a row through the
+// same loop is the cheapest way to exercise handle reuse.
+TEST_F (FormBodyWireTest, MultipartSurvivesHandleReuse) {
+    EventLoop loop;
+    loop.start ();
+
+    for (int i = 0; i < 3; ++i) {
+        auto request = form_request (server_->url (), BodyMode::FormData,
+        { { "n", std::to_string (i), true } });
+        auto result  = loop.submit_async (request).future.get ();
+        ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+        EXPECT_EQ (server_->parts ().at ("n"), std::to_string (i));
+    }
+
+    loop.stop ();
+}
+
+// ---------------------------------------------------------------------------
+// The encoding rules on their own - no handle, no socket.
+// ---------------------------------------------------------------------------
+
+TEST (FormBodyRules, EncodesEnabledFieldsOnly) {
+    EXPECT_EQ (encode_urlencoded ({ { "a", "1", true }, { "b", "2", false } }), "a=1");
+    EXPECT_EQ (encode_urlencoded ({}), "");
+    EXPECT_EQ (encode_urlencoded ({ { "empty", "", true } }), "empty=");
+}
+
+TEST (FormBodyRules, HasWireBodyIsModeAware) {
+    Body none;
+    EXPECT_FALSE (has_wire_body (none));
+
+    Body text;
+    text.mode = BodyMode::Text;
+    EXPECT_FALSE (has_wire_body (text));
+    text.content = "hi";
+    EXPECT_TRUE (has_wire_body (text));
+
+    // A form body's content lives in `fields`; a non-empty `content` on a form
+    // mode is not a body, which is exactly what the old `content`-only
+    // predicate got wrong in the other direction.
+    Body form;
+    form.mode    = BodyMode::Form;
+    form.content = "ignored";
+    EXPECT_FALSE (has_wire_body (form));
+    form.fields = { { "a", "1", false } };
+    EXPECT_FALSE (has_wire_body (form));
+    form.fields = { { "a", "1", true } };
+    EXPECT_TRUE (has_wire_body (form));
+}
+
+TEST (FormBodyRules, ContentTypeOwnership) {
+    Body urlencoded;
+    urlencoded.mode   = BodyMode::Form;
+    urlencoded.fields = { { "a", "1", true } };
+    EXPECT_EQ (implied_content_type (urlencoded), "application/x-www-form-urlencoded");
+    EXPECT_FALSE (content_type_is_engine_owned (urlencoded));
+
+    Body multipart;
+    multipart.mode   = BodyMode::FormData;
+    multipart.fields = { { "a", "1", true } };
+    EXPECT_EQ (implied_content_type (multipart), "");
+    EXPECT_TRUE (content_type_is_engine_owned (multipart));
+
+    // No body, nothing to describe.
+    Body empty;
+    empty.mode = BodyMode::Form;
+    EXPECT_EQ (implied_content_type (empty), "");
+    EXPECT_FALSE (content_type_is_engine_owned (empty));
+
+    // The modes the engine has never derived a Content-Type for keep it that way.
+    Body json;
+    json.mode    = BodyMode::Json;
+    json.content = "{}";
+    EXPECT_EQ (implied_content_type (json), "");
+}
+
+// ---------------------------------------------------------------------------
+// The payload shape, at the one parse point /execute and /runs share.
+// ---------------------------------------------------------------------------
+
+TEST (FormBodyPayload, AcceptsBothSpellingsOfEachMode) {
+    const auto parse = [] (const char* mode) {
+        vayu::json::Json json = { { "method", "POST" }, { "url", "http://x" },
+            { "body", { { "mode", mode }, { "fields", vayu::json::Json::array () } } } };
+        return vayu::json::deserialize_request (json);
+    };
+
+    for (const char* mode : { "x-www-form-urlencoded", "form" }) {
+        auto parsed = parse (mode);
+        ASSERT_TRUE (parsed.is_ok ()) << mode << ": " << parsed.error ().message;
+        EXPECT_EQ (parsed.value ().body.mode, BodyMode::Form) << mode;
+    }
+    for (const char* mode : { "form-data", "formdata" }) {
+        auto parsed = parse (mode);
+        ASSERT_TRUE (parsed.is_ok ()) << mode << ": " << parsed.error ().message;
+        EXPECT_EQ (parsed.value ().body.mode, BodyMode::FormData) << mode;
+    }
+}
+
+TEST (FormBodyPayload, ParsesFieldsAndTheirEnabledFlag) {
+    vayu::json::Json json = { { "method", "POST" }, { "url", "http://x" },
+        { "body",
+        { { "mode", "form-data" },
+        { "fields",
+        { { { "key", "a" }, { "value", "1" } },
+        { { "key", "b" }, { "value", "2" }, { "enabled", false } },
+        // Malformed-data leniency, matching parse_variables:
+        // a non-string value reads as "" and a non-boolean
+        // `enabled` reads as enabled.
+        { { "key", "c" }, { "value", 7 }, { "enabled", "yes" } } } } } } };
+
+    auto parsed = vayu::json::deserialize_request (json);
+    ASSERT_TRUE (parsed.is_ok ()) << parsed.error ().message;
+
+    const auto& fields = parsed.value ().body.fields;
+    ASSERT_EQ (fields.size (), 3u);
+    EXPECT_EQ (fields[0].key, "a");
+    EXPECT_EQ (fields[0].value, "1");
+    EXPECT_TRUE (fields[0].enabled);
+    EXPECT_FALSE (fields[1].enabled);
+    EXPECT_EQ (fields[2].value, "");
+    EXPECT_TRUE (fields[2].enabled);
+}
+
+// The silent-empty-body failure had exactly one symptom: nothing. Every way of
+// getting the shape wrong now says so instead.
+TEST (FormBodyPayload, RejectsAMalformedFormBody) {
+    const auto message_for = [] (const vayu::json::Json& body) {
+        vayu::json::Json json = { { "method", "POST" }, { "url", "http://x" },
+            { "body", body } };
+        auto parsed           = vayu::json::deserialize_request (json);
+        EXPECT_TRUE (parsed.is_error ()) << body.dump ();
+        return parsed.is_error () ? parsed.error ().message : std::string{};
+    };
+
+    // A form mode with no fields at all - the shape MCP used to produce, which
+    // previously went out as an empty body.
+    EXPECT_NE (message_for ({ { "mode", "form-data" }, { "content", "a=1" } }).find ("fields"),
+    std::string::npos);
+    EXPECT_NE (message_for ({ { "mode", "x-www-form-urlencoded" } }).find ("fields"),
+    std::string::npos);
+    // Wrong container, wrong entry, unnamed field.
+    message_for ({ { "mode", "form-data" }, { "fields", "a=1" } });
+    message_for ({ { "mode", "form-data" }, { "fields", { "a" } } });
+    message_for ({ { "mode", "form-data" }, { "fields", { { { "value", "1" } } } } });
+    // `fields` on a mode whose content is a string is a client bug too - it
+    // would otherwise be read by nothing.
+    message_for ({ { "mode", "json" }, { "content", "{}" },
+    { "fields", vayu::json::Json::array () } });
+}
+
+TEST (FormBodyPayload, RoundTripsThroughSerialization) {
+    vayu::Request request;
+    request.method      = HttpMethod::POST;
+    request.url         = "http://x";
+    request.body.mode   = BodyMode::Form;
+    request.body.fields = { { "a", "1", true }, { "b", "2", false } };
+
+    const vayu::json::Json json = vayu::json::serialize (request);
+    EXPECT_EQ (json["body"]["mode"], "x-www-form-urlencoded");
+
+    auto parsed = vayu::json::deserialize_request (json);
+    ASSERT_TRUE (parsed.is_ok ()) << parsed.error ().message;
+    ASSERT_EQ (parsed.value ().body.fields.size (), 2u);
+    EXPECT_EQ (parsed.value ().body.fields[1].key, "b");
+    EXPECT_FALSE (parsed.value ().body.fields[1].enabled);
+    EXPECT_EQ (parsed.value ().body.mode, BodyMode::Form);
+}
+
+} // namespace
+} // namespace vayu::http

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -357,6 +357,38 @@ TEST_F (RequestComposerTest, ComposesAnInlineRequestAgainstAScope) {
     EXPECT_EQ (payload["environmentId"], "env_1");
 }
 
+// A form body carries its content as `fields`, so resolution has to reach
+// inside them - the composer's `content` pass alone would leave a form body
+// full of literal `{{...}}` on the wire. The engine only started *sending*
+// these bodies with issue #381; this pins the half of the pipeline that was
+// already right, so the two cannot drift apart.
+TEST_F (RequestComposerTest, ResolvesVariablesInsideFormFields) {
+    seed_collection ("col", "", R"({"host":{"value":"col.test","enabled":true}})");
+    seed_environment ("env_1", R"({"secret":{"value":"s3cr3t","enabled":true}})");
+
+    const json body = {
+        { "request",
+        { { "method", "post" }, { "url", "https://{{host}}/x" },
+        { "body",
+        { { "mode", "x-www-form-urlencoded" },
+        { "fields",
+        json::array ({ { { "key", "at-{{host}}" }, { "value", "{{secret}}" }, { "enabled", true } },
+        { { "key", "off" }, { "value", "{{secret}}" }, { "enabled", false } } }) } } } } },
+        { "collectionId", "col" }, { "environmentId", "env_1" }
+    };
+
+    auto [status, payload] = vayu::http::compose_request_core (*db_, body);
+    ASSERT_EQ (status, 200) << payload.dump ();
+    EXPECT_EQ (payload["body"]["mode"], "x-www-form-urlencoded");
+    EXPECT_EQ (payload["body"]["fields"][0]["key"], "at-col.test");
+    EXPECT_EQ (payload["body"]["fields"][0]["value"], "s3cr3t");
+    // A disabled field is still resolved and still carried: it is dropped at
+    // the wire, not during composition, so switching it back on in the UI
+    // needs no re-compose.
+    EXPECT_EQ (payload["body"]["fields"][1]["value"], "s3cr3t");
+    EXPECT_EQ (payload["body"]["fields"][1]["enabled"], false);
+}
+
 TEST_F (RequestComposerTest, InlineOverlayReplacesStoredFieldsAndStillResolves) {
     seed_collection ("col", "", R"({"host":{"value":"stored.test","enabled":true}})");
     auto r = make_request ("req_1", "col");


### PR DESCRIPTION
## Description

**Plan.** Root cause: the renderer, the importers and the curl parser all produce a form body as `{mode, fields:[...]}`, but the engine's `deserialize_request` read only `content` and matched neither mode string - it knew `"form"` and `"formdata"`, never `"x-www-form-urlencoded"` or `"form-data"`. Verified still present at `d4ca67b`. Composition was already correct (`request_composer.cpp` resolves `{{vars}}` inside `fields`), so the fix is entirely at the parse-and-send end. Approach: the engine owns the encoding, because multipart needs a boundary no caller can name in advance - `x-www-form-urlencoded` via libcurl's percent-encoder and `COPYPOSTFIELDS`, `form-data` via `curl_mime`. **Rejected alternative:** hand-rolling the multipart envelope into `Body::content` so both modes flow through the existing `POSTFIELDS` path. It is simpler and keeps the body visible as a string, but it is a private copy of an encoder libcurl already owns (it would not receive libcurl's fixes) and it forecloses streamed file parts later, so the extra `curl_mime` lifetime plumbing is the right trade.

Two things the tests found rather than the issue:

- **`CURLOPT_POST` after `CURLOPT_MIMEPOST` discards the mime body.** It switches curl back to a POSTFIELDS-style post. The verb is only re-asserted for non-mime bodies now; this is the same ordering trap `apply_method_and_body` already documented for POSTFIELDS, in the other direction.
- **libcurl labels a bodiless POST `application/x-www-form-urlencoded` itself**, so a POST cannot distinguish the engine's Content-Type from curl's. The empty-fields test uses PUT, where curl adds nothing.

Beyond the engine: MCP's `run_request` / `create_request` have advertised both form modes in their `bodyType` description all along while emitting `{mode, content}` - a shape with no `fields` for the engine to read, so an agent could only ever produce the broken request. They now split `key=value&key=value` into the same `fields` rows every other producer builds.

**Consumer sweep, as the issue asked.** The renderer needed no change: `buildExecBody` already emits the exact shape and `request-transformer.ts` passes the body object through untouched, so a form body round-trips storage unchanged - both are now pinned by tests rather than asserted here. The importers (Postman, Insomnia, OpenAPI) and `parseCurl` all produce the two long mode spellings the engine now accepts; no importer divergence was found. `codegen/prepare.ts` was already the one consumer that understood `fields`.

**Deliberate non-touch:** `api-reference.md`'s `POST /execute` example still keys its body as `type` rather than `mode`. That line is explicitly claimed by #385, so fixing it here would collide with that PR.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Behaviour change worth naming: a form-mode body carrying no `fields` array is now a `400` naming the problem. Previously it was sent as an empty body - the same wrongness without the message.

## Testing

`python build.py -e -t` → `ctest --preset linux-dev`: **1014 passed, 0 failed** (19 new). `cd app && pnpm test`: **3011 passed across 325 files** (7 new). `pnpm type-check` and `pnpm lint` clean. No pre-existing failures on the base commit.

New engine coverage (`engine/tests/form_body_test.cpp`) asserts the **wire**, not the parsed struct, against an in-process echo server, through **both** HTTP drivers - the single-request client behind `POST /execute` and the event loop every load run generates through:

- exact urlencoded body and Content-Type; reserved characters escaped as data, not separators; disabled fields omitted; an explicit Content-Type kept
- multipart parts read back by an independent parser (so a body whose boundary disagreed with its header yields nothing), a caller's Content-Type dropped, disabled fields omitted
- no enabled fields → no body and no derived Content-Type; a form body keeps a non-POST verb; multipart survives three sends over the pooled handle (mime lifetime)
- the encoding rules as pure functions, and the payload shape at the parse point `/execute` and `/runs` share: both spellings per mode, the D17 malformed-data leniency, every malformed shape refused, serialization round-trip

Also: composition resolving `{{vars}}` inside `fields` (previously uncovered), the renderer's mode strings as an engine contract, Postman's two form bodies, and the MCP form shape. Mutation-checked - reverting the serialization reddens the wire tests, reverting the mode aliases reddens the payload tests, reverting the `CURLOPT_POST` guard reddens every multipart test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` gains a **The request `body` union** section (per-mode shape, the `fields` row rules, both Content-Type rules, the file-parts deferral, the legacy spellings), cross-linked from the accepted-field-shapes table; `docs/app/api-integration.md` records the mode strings as a contract; `docs/engine/mcp.md` documents how an agent writes a form body.

## Related Issues
Closes #381

---
_Generated by [Claude Code](https://claude.ai/code/session_017D6jQMHWjSmbpksyMMqkdW)_