### PR TITLE
feat(app/context-bar): phase 2 - collection and run tab sections on the existing section registry

### DIFF
--- a/app/src/components/layout/Dock.context-toggle.test.tsx
+++ b/app/src/components/layout/Dock.context-toggle.test.tsx
@@ -11,13 +11,13 @@
 /**
  * The context-bar toggle reports what is on screen, not what is stored.
  *
- * The Dock button and Ctrl/Cmd+I flip `contextBarOpen` on every tab type, while
- * the bar renders null off a request tab - so on six of the seven types the
- * button lit up and nothing appeared, and because the flag is persisted the bar
- * then popped out later on the next request tab.
+ * The Dock button and Ctrl/Cmd+I flipped `contextBarOpen` on every tab type
+ * while the bar rendered null wherever it had no sections - so the button lit
+ * up and nothing appeared, and because the flag is persisted the bar then
+ * popped out later on the next request tab.
  *
  * Mutation-check: drive `active` from `contextBarOpen` alone again and the
- * non-request cases redden.
+ * section-less cases redden.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -37,9 +37,11 @@ function renderDock() {
 	);
 }
 
-function openTabOfType(type: TabType) {
+const ENTITY_TYPES: TabType[] = ["request", "collection", "run"];
+
+function openTabOfType(type: TabType, entityId = ENTITY_TYPES.includes(type) ? `${type}_1` : null) {
 	useTabsStore.setState({
-		openTabs: [{ id: "t1", type, entityId: type === "request" ? "req_1" : null }],
+		openTabs: [{ id: "t1", type, entityId }],
 		activeTabId: "t1",
 	});
 }
@@ -66,7 +68,29 @@ describe("Dock - the context-bar toggle's pressed state", () => {
 		expect(toggle()).toHaveAttribute("aria-pressed", "false");
 	});
 
-	it.each<TabType>(["welcome", "collection", "dashboard", "run", "variables", "settings"])(
+	// `collection` and `run` moved out of this list when they grew sections, and
+	// the Dock was not touched to make that happen - which is the derivation
+	// working. Put a hardcoded `type === "request"` back in
+	// `contextBarHasContent` and the two cases below redden.
+	it.each<TabType>(["collection", "run"])(
+		"is pressed on a %s tab with the bar open, off the registry alone",
+		(type) => {
+			openTabOfType(type);
+			renderDock();
+			expect(toggle()).toHaveAttribute("aria-pressed", "true");
+		}
+	);
+
+	it.each<TabType>(["collection", "run"])(
+		"is not pressed on a %s tab that is not open on an entity",
+		(type) => {
+			openTabOfType(type, null);
+			renderDock();
+			expect(toggle()).toHaveAttribute("aria-pressed", "false");
+		}
+	);
+
+	it.each<TabType>(["welcome", "dashboard", "variables", "settings"])(
 		"is not pressed on a %s tab even with the flag set",
 		(type) => {
 			openTabOfType(type);

--- a/app/src/components/layout/context-bar/CollectionAuthSection.test.tsx
+++ b/app/src/components/layout/context-bar/CollectionAuthSection.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What a collection hands down, and to whom.
+ *
+ * The four answers below are genuinely different outcomes, and the one worth
+ * the section is the third: a collection that configures nothing does not mean
+ * "no auth" - a request under it inherits from further up, and naming that
+ * ancestor is the difference between a five-minute 401 and an afternoon one.
+ *
+ * The walk is `resolveAuthSource`, shared with the Auth tab's chain and with
+ * what is actually sent. Mutation-check: answer from `collection.auth` alone
+ * and the inheriting cases redden.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CollectionAuthSection } from "./CollectionAuthSection";
+import type { Collection, RequestAuth } from "@/types";
+
+let collections: Collection[] = [];
+
+vi.mock("@/queries", async () => {
+	const { walkAncestors } = await vi.importActual<
+		typeof import("@/modules/collections/tree-utils")
+	>("@/modules/collections/tree-utils");
+	return {
+		useCollectionsQuery: () => ({ data: collections, isLoading: false }),
+		// The real hook is `walkAncestors` over the same list - kept rather than
+		// stubbed so the chain this section reasons about is a real chain.
+		useCollectionAncestors: (id: string | null) => (id ? walkAncestors(id, collections) : []),
+	};
+});
+
+const TAB = { id: "t1", type: "collection", entityId: "col_leaf" } as const;
+
+const collection = (
+	id: string,
+	auth: Collection["auth"],
+	parentId?: string,
+	name = id
+): Collection => ({
+	id,
+	name,
+	description: "",
+	order: 0,
+	variables: {},
+	auth,
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "",
+	updatedAt: "",
+	...(parentId ? { parentId } : {}),
+});
+
+const bearer: Exclude<RequestAuth, { mode: "inherit" }> = { mode: "bearer", token: "t" };
+
+beforeEach(() => {
+	collections = [];
+});
+
+describe("CollectionAuthSection", () => {
+	it("names the auth this collection configures", () => {
+		collections = [collection("col_leaf", bearer)];
+		render(<CollectionAuthSection tab={TAB} />);
+
+		expect(screen.getByText("Bearer Token")).toBeInTheDocument();
+		expect(screen.getByText("Requests set to Inherit send this.")).toBeInTheDocument();
+	});
+
+	it("names the ancestor a request under it would inherit from instead", () => {
+		collections = [
+			collection("col_root", bearer, undefined, "Billing"),
+			collection("col_leaf", { mode: "none" }, "col_root"),
+		];
+		render(<CollectionAuthSection tab={TAB} />);
+
+		expect(
+			screen.getByText("Requests below inherit Bearer Token from Billing.")
+		).toBeInTheDocument();
+	});
+
+	it("says which ancestor blocks inheriting rather than implying nobody set any", () => {
+		collections = [
+			collection("col_root", bearer, undefined, "Billing"),
+			collection("col_mid", { mode: "noauth" }, "col_root", "Sandbox"),
+			collection("col_leaf", { mode: "none" }, "col_mid"),
+		];
+		render(<CollectionAuthSection tab={TAB} />);
+
+		expect(
+			screen.getByText("Sandbox is set to No Auth, so nothing is inherited past it.")
+		).toBeInTheDocument();
+	});
+
+	it("says the walk stops here when this collection is the blocker", () => {
+		collections = [
+			collection("col_root", bearer, undefined, "Billing"),
+			collection("col_leaf", { mode: "noauth" }, "col_root"),
+		];
+		render(<CollectionAuthSection tab={TAB} />);
+
+		expect(screen.getByText("No Auth (blocks inheriting)")).toBeInTheDocument();
+		expect(
+			screen.getByText("Requests below inherit nothing - the walk stops here.")
+		).toBeInTheDocument();
+	});
+
+	it("says so when nothing in the chain defines auth", () => {
+		collections = [collection("col_leaf", { mode: "none" })];
+		render(<CollectionAuthSection tab={TAB} />);
+
+		expect(screen.getByText("No ancestor collection defines auth either.")).toBeInTheDocument();
+	});
+
+	it("says the collection is gone rather than reporting No Auth for it", () => {
+		collections = [collection("col_other", bearer)];
+		render(<CollectionAuthSection tab={TAB} />);
+
+		expect(screen.getByText("This collection is no longer available")).toBeInTheDocument();
+	});
+});

--- a/app/src/components/layout/context-bar/CollectionAuthSection.tsx
+++ b/app/src/components/layout/context-bar/CollectionAuthSection.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What this collection hands down to the requests under it.
+ *
+ * The request tab's twin of this section answers "what am I sending"; here the
+ * subject is the other end of the same walk - a collection is always a source,
+ * never an inheritor (`Collection.auth` excludes `inherit`), so what matters is
+ * what a descendant set to Inherit would pick up.
+ *
+ * A collection that configures nothing is not the end of the answer: the walk
+ * carries on to *its* ancestors, and one of them set to No Auth stops it. That
+ * is `resolveAuthSource` - the same function the Auth tab's inheritance chain
+ * and both send paths use, so this cannot claim a source execution would not.
+ */
+
+import { useCollectionsQuery, useCollectionAncestors } from "@/queries";
+import { AUTH_MODE_LABELS } from "@/constants/auth-modes";
+import { resolveAuthSource } from "@/modules/request-builder/utils/auth-resolution";
+import { SectionEmpty, SectionLoading } from "./Section";
+import type { ContextBarSectionProps } from "./types";
+
+export function CollectionAuthSection({ tab }: ContextBarSectionProps) {
+	const { data: collections = [], isLoading } = useCollectionsQuery();
+	const ancestors = useCollectionAncestors(tab.entityId);
+
+	const collection = collections.find((c) => c.id === tab.entityId);
+
+	// `resolveAuthSource` is called unconditionally on the chain, which includes
+	// this collection: when it configures auth it is its own answer, and when it
+	// is set to plain `none` the walk steps over it to the nearest ancestor that
+	// does - the same result a descendant's Inherit would land on.
+	const { source, blockedBy } = resolveAuthSource(ancestors);
+
+	if (isLoading && !collection) return <SectionLoading />;
+	if (!collection) return <SectionEmpty>This collection is no longer available</SectionEmpty>;
+
+	const own = collection.auth.mode;
+	const label = AUTH_MODE_LABELS[own];
+
+	const origin =
+		own === "noauth"
+			? "Requests below inherit nothing - the walk stops here."
+			: own !== "none"
+				? "Requests set to Inherit send this."
+				: source
+					? `Requests below inherit ${AUTH_MODE_LABELS[source.auth.mode]} from ${source.name}.`
+					: blockedBy
+						? `${blockedBy.name} is set to No Auth, so nothing is inherited past it.`
+						: "No ancestor collection defines auth either.";
+
+	return (
+		<div className="space-y-2">
+			<p className="text-xs text-foreground m-0">
+				Set to <span className="font-semibold text-primary">{label}</span>
+			</p>
+			<p className="text-[11px] text-muted-foreground m-0">{origin}</p>
+		</div>
+	);
+}

--- a/app/src/components/layout/context-bar/CollectionContentsSection.test.tsx
+++ b/app/src/components/layout/context-bar/CollectionContentsSection.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * How much is in the collection, counted the way the tree beside it counts.
+ *
+ * Direct children only: a subtree total would disagree with the rows the user
+ * can see under the folder. Mutation-check: count descendants instead of
+ * children and the nested case reddens.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CollectionContentsSection } from "./CollectionContentsSection";
+import type { Collection, Request } from "@/types";
+
+let collections: Collection[] = [];
+let requests: Request[] = [];
+let loading = false;
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({ data: collections, isLoading: loading }),
+	useRequestsQuery: (collectionId: string | null) => ({
+		data: requests.filter((r) => r.collectionId === collectionId),
+		isLoading: loading,
+	}),
+}));
+
+const TAB = { id: "t1", type: "collection", entityId: "col_1" } as const;
+
+const collection = (id: string, parentId?: string): Collection => ({
+	id,
+	name: id,
+	description: "",
+	order: 0,
+	variables: {},
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "",
+	updatedAt: "",
+	...(parentId ? { parentId } : {}),
+});
+
+const request = (id: string, collectionId: string) =>
+	({ id, collectionId, name: id, method: "GET", url: "" }) as unknown as Request;
+
+beforeEach(() => {
+	collections = [];
+	requests = [];
+	loading = false;
+});
+
+describe("CollectionContentsSection", () => {
+	it("counts the requests and folders directly inside it", () => {
+		collections = [collection("col_1"), collection("col_child", "col_1")];
+		requests = [request("r1", "col_1"), request("r2", "col_1")];
+		render(<CollectionContentsSection tab={TAB} />);
+
+		expect(screen.getByText(/2 requests/)).toBeInTheDocument();
+		expect(screen.getByText(/1 sub-collection$/)).toBeInTheDocument();
+	});
+
+	it("does not count a grandchild folder as a child", () => {
+		collections = [
+			collection("col_1"),
+			collection("col_child", "col_1"),
+			collection("col_grandchild", "col_child"),
+		];
+		render(<CollectionContentsSection tab={TAB} />);
+
+		expect(screen.getByText(/1 sub-collection$/)).toBeInTheDocument();
+	});
+
+	it("says zero rather than nothing when the collection is empty", () => {
+		collections = [collection("col_1")];
+		render(<CollectionContentsSection tab={TAB} />);
+
+		expect(screen.getByText(/0 requests/)).toBeInTheDocument();
+		expect(screen.getByText(/0 sub-collections$/)).toBeInTheDocument();
+	});
+
+	it("says the collection is gone rather than counting it as empty", () => {
+		collections = [collection("col_other")];
+		render(<CollectionContentsSection tab={TAB} />);
+
+		expect(screen.getByText("This collection is no longer available")).toBeInTheDocument();
+	});
+
+	it("waits rather than declaring a collection missing while the lists are in flight", () => {
+		loading = true;
+		render(<CollectionContentsSection tab={TAB} />);
+
+		expect(screen.getByText("Loading…")).toBeInTheDocument();
+	});
+});

--- a/app/src/components/layout/context-bar/CollectionContentsSection.tsx
+++ b/app/src/components/layout/context-bar/CollectionContentsSection.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * How much is in this collection, one level down.
+ *
+ * Direct children only, deliberately: the tree beside the bar draws the same
+ * two numbers as the rows under a folder, and a subtree total would disagree
+ * with what the user can see there. The pane's own header counts requests but
+ * says nothing about nested folders, which is the half this adds.
+ */
+
+import { useCollectionsQuery, useRequestsQuery } from "@/queries";
+import { SectionEmpty, SectionLoading } from "./Section";
+import type { ContextBarSectionProps } from "./types";
+
+/** "1 request" / "3 requests" - the pane header's wording, not a second one. */
+function count(n: number, noun: string): string {
+	return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
+export function CollectionContentsSection({ tab }: ContextBarSectionProps) {
+	const { data: collections = [], isLoading: collectionsLoading } = useCollectionsQuery();
+	const { data: requests = [], isLoading: requestsLoading } = useRequestsQuery(tab.entityId);
+
+	const collection = collections.find((c) => c.id === tab.entityId);
+
+	if ((collectionsLoading || requestsLoading) && !collection) return <SectionLoading />;
+	if (!collection) return <SectionEmpty>This collection is no longer available</SectionEmpty>;
+
+	const children = collections.filter((c) => c.parentId === collection.id);
+
+	return (
+		<p className="text-xs text-foreground m-0">
+			{count(requests.length, "request")}
+			<span className="text-muted-foreground"> · </span>
+			{count(children.length, "sub-collection")}
+		</p>
+	);
+}

--- a/app/src/components/layout/context-bar/CollectionVariablesSection.test.tsx
+++ b/app/src/components/layout/context-bar/CollectionVariablesSection.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The collection tab's variables section: what it lists, and where an edit
+ * lands.
+ *
+ * The commit path itself is pinned once, on the request tab
+ * (`VariablesSection.commit-scope.test.tsx`) - both sections call the same
+ * `useVariableCommit`. What is this section's own is the list it feeds it: its
+ * rows are this collection's *definitions*, not a resolved set, so the target
+ * of an edit is this collection and no ancestor of it. Mutation-check: point
+ * the row's `sourceId` at anything else and the commit case reddens.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CollectionVariablesSection } from "./CollectionVariablesSection";
+import { queryKeys } from "@/queries/keys";
+import type { Collection, VariableValue } from "@/types";
+
+const collectionMutate = vi.fn();
+
+let collections: Collection[] = [];
+let collectionsLoading = false;
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({ data: collections, isLoading: collectionsLoading }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useUpdateCollectionMutation: () => ({ mutate: collectionMutate }),
+}));
+
+// Only the save store is read by the commit path; the real one is kept so the
+// registration it performs is the real registration.
+vi.mock("@/stores", async () => {
+	const saveStore =
+		await vi.importActual<typeof import("@/stores/save-store")>("@/stores/save-store");
+	return { useSaveStore: saveStore.useSaveStore };
+});
+
+const TAB = { id: "t1", type: "collection", entityId: "col_1" } as const;
+
+const def = (value: string, extra: Partial<VariableValue> = {}): VariableValue => ({
+	value,
+	enabled: true,
+	...extra,
+});
+
+const collection = (id: string, variables: Record<string, VariableValue>): Collection => ({
+	id,
+	name: id,
+	description: "",
+	order: 0,
+	variables,
+	auth: { mode: "none" },
+	preRequestScript: "",
+	postRequestScript: "",
+	createdAt: "",
+	updatedAt: "",
+});
+
+function renderSection() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	client.setQueryData(queryKeys.collections.list(), collections);
+	return render(
+		<QueryClientProvider client={client}>
+			<CollectionVariablesSection tab={TAB} />
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	collectionMutate.mockClear();
+	collectionsLoading = false;
+	collections = [];
+});
+
+describe("CollectionVariablesSection - what it lists", () => {
+	it("lists this collection's own definitions, not an ancestor's", () => {
+		collections = [
+			collection("col_parent", { host: def("parent.example.com") }),
+			collection("col_1", { host: def("child.example.com"), token: def("t") }),
+		];
+		renderSection();
+
+		expect(screen.getByRole("textbox", { name: "Value of host" })).toHaveValue(
+			"child.example.com"
+		);
+		expect(screen.getByRole("textbox", { name: "Value of token" })).toHaveValue("t");
+	});
+
+	it("keeps a disabled definition on screen and says it is off", () => {
+		// It is still defined here - the section's question - it is simply not
+		// sent. Dropping it would answer the question wrongly.
+		collections = [collection("col_1", { legacy: def("x", { enabled: false }) })];
+		renderSection();
+
+		expect(screen.getByRole("textbox", { name: "Value of legacy" })).toHaveValue("x");
+		expect(screen.getByText("off")).toBeInTheDocument();
+	});
+
+	it("masks a secret read-only, as the request tab's list does", () => {
+		collections = [collection("col_1", { key: def("s3cret", { secret: true }) })];
+		renderSection();
+
+		const input = screen.getByRole("textbox", { name: "Value of key" });
+		expect(input).toHaveAttribute("readonly");
+		expect(screen.queryByDisplayValue("s3cret")).not.toBeInTheDocument();
+	});
+
+	it("says so when the collection defines none", () => {
+		collections = [collection("col_1", {})];
+		renderSection();
+		expect(screen.getByText("This collection defines no variables")).toBeInTheDocument();
+	});
+
+	it("says the collection is gone rather than claiming it has no variables", () => {
+		collections = [collection("col_other", { host: def("x") })];
+		renderSection();
+		expect(screen.getByText("This collection is no longer available")).toBeInTheDocument();
+	});
+
+	it("waits rather than declaring a collection missing while the list is in flight", () => {
+		collectionsLoading = true;
+		renderSection();
+		expect(screen.getByText("Loading…")).toBeInTheDocument();
+	});
+});
+
+describe("CollectionVariablesSection - where an edit lands", () => {
+	it("commits into this collection, carrying its other definitions verbatim", () => {
+		collections = [
+			collection("col_parent", { host: def("parent.example.com") }),
+			collection("col_1", {
+				host: def("child.example.com"),
+				token: def("t", { secret: false, enabled: true }),
+			}),
+		];
+		renderSection();
+
+		const input = screen.getByRole("textbox", { name: "Value of host" });
+		act(() => {
+			fireEvent.change(input, { target: { value: "edited.example.com" } });
+			fireEvent.blur(input);
+		});
+
+		expect(collectionMutate).toHaveBeenCalledTimes(1);
+		const [payload] = collectionMutate.mock.calls[0] as [
+			{ id: string; variables: Record<string, VariableValue> },
+		];
+		expect(payload.id).toBe("col_1");
+		expect(payload.variables.host.value).toBe("edited.example.com");
+		expect(payload.variables.token).toEqual(def("t", { secret: false, enabled: true }));
+	});
+
+	it("leaves a disabled definition disabled when its value is edited", () => {
+		// The commit spreads the stored definition, so the row's own flags ride
+		// along. An edit that quietly re-enabled it would send a variable the
+		// user had switched off.
+		collections = [collection("col_1", { legacy: def("x", { enabled: false }) })];
+		renderSection();
+
+		const input = screen.getByRole("textbox", { name: "Value of legacy" });
+		act(() => {
+			fireEvent.change(input, { target: { value: "y" } });
+			fireEvent.blur(input);
+		});
+
+		const [payload] = collectionMutate.mock.calls[0] as [
+			{ variables: Record<string, VariableValue> },
+		];
+		expect(payload.variables.legacy).toEqual({ value: "y", enabled: false });
+	});
+
+	it("sends nothing when the value comes back unchanged", () => {
+		collections = [collection("col_1", { host: def("example.com") })];
+		renderSection();
+
+		const input = screen.getByRole("textbox", { name: "Value of host" });
+		act(() => {
+			fireEvent.change(input, { target: { value: "other" } });
+			fireEvent.change(input, { target: { value: "example.com" } });
+			fireEvent.blur(input);
+		});
+
+		expect(collectionMutate).not.toHaveBeenCalled();
+	});
+});

--- a/app/src/components/layout/context-bar/CollectionVariablesSection.tsx
+++ b/app/src/components/layout/context-bar/CollectionVariablesSection.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What this collection itself defines, editable in place.
+ *
+ * Not the same list as the request tab's: that one shows what *resolved* for a
+ * request, across all three scopes and with ancestors overriding each other.
+ * This one shows the definitions that live on this collection - the rows the
+ * Variables tab beside it edits - because on a collection tab the question is
+ * "what does this collection contribute", not "what would win".
+ *
+ * A definition here is already the winner for its own scope, so the commit path
+ * is handed a `ResolvedVariable` naming this collection as the source and lands
+ * in the same place `useVariableCommit` sends a collection-scope edit from the
+ * request tab.
+ */
+
+import { useCollectionsQuery } from "@/queries";
+import { SectionEmpty, SectionLoading } from "./Section";
+import { VariableRow } from "./VariableRow";
+import { useVariableCommit } from "./variable-commit";
+import type { ContextBarSectionProps } from "./types";
+import type { ResolvedVariable } from "@/types";
+
+export function CollectionVariablesSection({ tab }: ContextBarSectionProps) {
+	const { data: collections = [], isLoading } = useCollectionsQuery();
+	const commitValue = useVariableCommit();
+
+	const collection = collections.find((c) => c.id === tab.entityId);
+
+	if (isLoading && !collection) return <SectionLoading />;
+	if (!collection) return <SectionEmpty>This collection is no longer available</SectionEmpty>;
+
+	// Stored order, which is the order the Variables tab shows: its save payload
+	// is written oldest-`createdAt` first precisely so the round trip preserves
+	// it (`VariableTableEditor`). Re-sorting here would be a second copy of that
+	// rule, free to drift from it.
+	const entries = Object.entries(collection.variables ?? {});
+
+	if (entries.length === 0) {
+		return <SectionEmpty>This collection defines no variables</SectionEmpty>;
+	}
+
+	return (
+		<div className="space-y-1">
+			{entries.map(([name, definition]) => {
+				const resolved: ResolvedVariable = {
+					value: definition.value,
+					scope: "collection",
+					sourceId: collection.id,
+					sourceName: collection.name,
+					secret: definition.secret,
+					type: definition.type,
+				};
+				return (
+					<VariableRow
+						key={name}
+						name={name}
+						resolved={resolved}
+						// A disabled definition still exists here - it is simply not
+						// sent - so hiding it would answer the section's question
+						// wrongly. Said in text rather than by colour alone, and not
+						// in a `title`, which a keyboard user never sees.
+						marker={
+							definition.enabled ? undefined : (
+								<span className="text-[10px] uppercase tracking-wide text-muted-foreground shrink-0">
+									off
+								</span>
+							)
+						}
+						onCommit={(input) => commitValue(name, resolved, input)}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/src/components/layout/context-bar/RunConfigSection.test.tsx
+++ b/app/src/components/layout/context-bar/RunConfigSection.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the run was asked to do, in the words the rest of the app uses.
+ *
+ * The naming cases are the ones with history: `loadTestModeLabel` and
+ * `formatConcurrency` exist because the same run was described three different
+ * ways depending on the screen (`constant_rps` raw in one header, "workers" in
+ * the sidebar, "VUs" in another). Mutation-check: print `config.mode` or a
+ * hand-written unit here and those two cases redden.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RunConfigSection } from "./RunConfigSection";
+import type { Run } from "@/types";
+
+let run: Run | undefined;
+let loading = false;
+
+vi.mock("@/queries", () => ({
+	useRunQuery: () => ({ data: run, isLoading: loading }),
+}));
+
+const TAB = { id: "t1", type: "run", entityId: "run_1" } as const;
+
+const makeRun = (type: Run["type"], configSnapshot: Run["configSnapshot"]): Run => ({
+	id: "run_1",
+	type,
+	status: "completed",
+	startTime: 0,
+	endTime: 0,
+	configSnapshot,
+});
+
+beforeEach(() => {
+	run = undefined;
+	loading = false;
+});
+
+describe("RunConfigSection", () => {
+	it("names a load run's mode from the shared label list, never the raw token", () => {
+		run = makeRun("load", { mode: "constant_rps", duration: "30s", targetRps: 200 });
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.getByText("Constant RPS")).toBeInTheDocument();
+		expect(screen.queryByText("constant_rps")).not.toBeInTheDocument();
+		expect(screen.getByText("30s")).toBeInTheDocument();
+		expect(screen.getByText("200")).toBeInTheDocument();
+	});
+
+	it("speaks the app's one unit for concurrency", () => {
+		run = makeRun("load", { mode: "ramp_up", concurrency: 64, startConcurrency: 8 });
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.getByText("64 VUs")).toBeInTheDocument();
+		expect(screen.getByText("8 VUs")).toBeInTheDocument();
+	});
+
+	it("calls a design run a single send instead of reporting no configuration", () => {
+		// A design run's snapshot has no `mode` key - there is no strategy to
+		// record for one send - so a mode-only section would read as "nothing
+		// was recorded" on every design run there is.
+		run = makeRun("design", { method: "GET", url: "https://example.com" });
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.getByText("Single send")).toBeInTheDocument();
+	});
+
+	it("shows the protocol the run asked for", () => {
+		run = makeRun("load", { mode: "iterations", iterations: 50, httpVersion: "http2" });
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.getByText("50")).toBeInTheDocument();
+		expect(screen.getByText("HTTP/2")).toBeInTheDocument();
+	});
+
+	it("leaves out a cap the run did not set", () => {
+		run = makeRun("load", { mode: "constant_rps", duration: "10s" });
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.queryByText("Target RPS")).not.toBeInTheDocument();
+		expect(screen.queryByText("Concurrency")).not.toBeInTheDocument();
+		expect(screen.queryByText("Iterations")).not.toBeInTheDocument();
+	});
+
+	it("says so when a load run stored no readable configuration", () => {
+		run = makeRun("load", undefined);
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.getByText("No configuration was recorded for this run")).toBeInTheDocument();
+	});
+
+	it("waits rather than declaring the run gone while it is in flight", () => {
+		loading = true;
+		render(<RunConfigSection tab={TAB} />);
+
+		expect(screen.getByText("Loading…")).toBeInTheDocument();
+	});
+
+	it("says the run is gone when it no longer exists", () => {
+		render(<RunConfigSection tab={TAB} />);
+		expect(screen.getByText("This run is no longer available")).toBeInTheDocument();
+	});
+});

--- a/app/src/components/layout/context-bar/RunConfigSection.tsx
+++ b/app/src/components/layout/context-bar/RunConfigSection.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What this run was asked to do: its mode, its target, and its caps.
+ *
+ * Read from the run's stored `configSnapshot` - the sanitized copy of the body
+ * that started it - so it says what ran, not what the request holds now.
+ *
+ * The load-test pane draws a config strip of its own, so on a load run this
+ * section restates part of it. That is deliberate rather than overlooked: a
+ * *design* run has no config view anywhere, and a bar that changed shape
+ * between the two kinds of run tab would be the worse answer. Names come from
+ * `loadTestModeLabel` / `formatConcurrency`, the same helpers that strip uses,
+ * so the two cannot word the same run differently.
+ */
+
+import { useRunQuery } from "@/queries";
+import { loadTestModeLabel, formatConcurrency } from "@/constants/load-test-modes";
+import { HTTP_VERSIONS, isHttpVersion } from "@/constants/request";
+import { SectionEmpty, SectionLoading } from "./Section";
+import type { ContextBarSectionProps } from "./types";
+import type { ReactNode } from "react";
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+	return (
+		<div className="flex items-baseline justify-between gap-2">
+			<span className="text-[11px] text-muted-foreground shrink-0">{label}</span>
+			<span className="text-xs font-mono text-foreground truncate">{children}</span>
+		</div>
+	);
+}
+
+export function RunConfigSection({ tab }: ContextBarSectionProps) {
+	const { data: run, isLoading } = useRunQuery(tab.entityId);
+
+	if (isLoading && !run) return <SectionLoading />;
+	if (!run) return <SectionEmpty>This run is no longer available</SectionEmpty>;
+
+	const config = run.configSnapshot;
+	// A design run's snapshot carries no `mode` key - there is no strategy to
+	// record for one send. Naming it here rather than leaving the row out keeps
+	// the section from reading as "nothing was recorded" on every design run.
+	const mode = run.type === "design" ? "Single send" : loadTestModeLabel(config?.mode);
+	const protocol = isHttpVersion(config?.httpVersion)
+		? HTTP_VERSIONS.find((v) => v.value === config.httpVersion)?.label
+		: undefined;
+
+	const rows: ReactNode[] = [];
+	if (mode)
+		rows.push(
+			<Row key="mode" label="Mode">
+				{mode}
+			</Row>
+		);
+	if (config?.duration)
+		rows.push(
+			<Row key="duration" label="Duration">
+				{config.duration}
+			</Row>
+		);
+	if (config?.targetRps != null && config.targetRps > 0) {
+		rows.push(
+			<Row key="rps" label="Target RPS">
+				{config.targetRps}
+			</Row>
+		);
+	}
+	if (config?.concurrency != null && config.concurrency > 0) {
+		rows.push(
+			<Row key="concurrency" label="Concurrency">
+				{formatConcurrency(config.concurrency)}
+			</Row>
+		);
+	}
+	if (config?.iterations != null && config.iterations > 0) {
+		rows.push(
+			<Row key="iterations" label="Iterations">
+				{config.iterations}
+			</Row>
+		);
+	}
+	if (config?.rampUpDuration) {
+		rows.push(
+			<Row key="ramp" label="Ramp">
+				{config.rampUpDuration}
+			</Row>
+		);
+	}
+	if (config?.startConcurrency != null && config.startConcurrency > 0) {
+		rows.push(
+			<Row key="start" label="Starting at">
+				{formatConcurrency(config.startConcurrency)}
+			</Row>
+		);
+	}
+	// The protocol the run *asked for*. The negotiated one is per exchange and
+	// has no single value across a load run - see `LoadTestDetail`.
+	if (protocol)
+		rows.push(
+			<Row key="protocol" label="Protocol">
+				{protocol}
+			</Row>
+		);
+
+	if (rows.length === 0) {
+		return <SectionEmpty>No configuration was recorded for this run</SectionEmpty>;
+	}
+
+	return <div className="space-y-1">{rows}</div>;
+}

--- a/app/src/components/layout/context-bar/RunSourceSection.test.tsx
+++ b/app/src/components/layout/context-bar/RunSourceSection.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which environment a run used, and which request it came from.
+ *
+ * `Run.environmentId` was stored by every send and read by nothing, so a run
+ * measured against Staging looked identical to one measured against
+ * Production. The case that matters is the first below: the name shown is the
+ * run's own environment, not the one that happens to be active now.
+ * Mutation-check: read the session store's active environment instead and it
+ * reddens.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RunSourceSection } from "./RunSourceSection";
+import { useTabsStore } from "@/stores";
+import { RequestNotFoundError } from "@/queries/collections";
+import type { Environment, Run } from "@/types";
+
+let run: Run | undefined;
+let loading = false;
+let requestData: { id: string; name: string } | undefined;
+let requestError: unknown;
+let environments: Environment[] = [];
+
+vi.mock("@/queries", async () => {
+	const { isRequestNotFound } =
+		await vi.importActual<typeof import("@/queries/collections")>("@/queries/collections");
+	return {
+		useRunQuery: () => ({ data: run, isLoading: loading }),
+		useRequestQuery: () => ({ data: requestData, error: requestError }),
+		useEnvironmentsQuery: () => ({ data: environments }),
+		isRequestNotFound,
+	};
+});
+
+const TAB = { id: "t1", type: "run", entityId: "run_1" } as const;
+
+const makeRun = (extra: Partial<Run> = {}): Run => ({
+	id: "run_1",
+	type: "load",
+	status: "completed",
+	startTime: 0,
+	endTime: 0,
+	...extra,
+});
+
+const environment = (id: string, name: string): Environment =>
+	({ id, name, variables: {} }) as unknown as Environment;
+
+beforeEach(() => {
+	run = undefined;
+	loading = false;
+	requestData = undefined;
+	requestError = undefined;
+	environments = [];
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+});
+
+describe("RunSourceSection - the environment the run used", () => {
+	it("names the run's own environment, not whichever one is active now", () => {
+		environments = [environment("env_stage", "Staging"), environment("env_prod", "Production")];
+		run = makeRun({ environmentId: "env_stage" });
+		render(<RunSourceSection tab={TAB} />);
+
+		expect(screen.getByText("Staging")).toBeInTheDocument();
+		expect(screen.queryByText("Production")).not.toBeInTheDocument();
+	});
+
+	it("says none was active rather than leaving the row blank", () => {
+		run = makeRun({ environmentId: null });
+		render(<RunSourceSection tab={TAB} />);
+
+		expect(screen.getByText("No environment")).toBeInTheDocument();
+	});
+
+	it("distinguishes a deleted environment from none at all", () => {
+		// The run kept the id either way, and "No environment" would assert
+		// something about the run that is not true.
+		run = makeRun({ environmentId: "env_gone" });
+		render(<RunSourceSection tab={TAB} />);
+
+		expect(screen.getByText("env_gone (deleted)")).toBeInTheDocument();
+	});
+});
+
+describe("RunSourceSection - the request it ran from", () => {
+	it("opens the request in its own tab, leaving the run tab open", () => {
+		run = makeRun({ requestId: "req_1" });
+		requestData = { id: "req_1", name: "Create user" };
+		render(<RunSourceSection tab={TAB} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Create user" }));
+
+		const { openTabs } = useTabsStore.getState();
+		expect(openTabs.map((t) => [t.type, t.entityId])).toEqual([["request", "req_1"]]);
+	});
+
+	it("says the request was deleted instead of offering a tab that cannot open", () => {
+		run = makeRun({ requestId: "req_1" });
+		requestError = new RequestNotFoundError("req_1");
+		render(<RunSourceSection tab={TAB} />);
+
+		expect(screen.getByText("Deleted")).toBeInTheDocument();
+		expect(screen.queryByRole("button")).not.toBeInTheDocument();
+	});
+
+	it("keeps the link for a transport failure, which is not a deletion", () => {
+		// `isRequestNotFound` is the discriminator precisely so an unreachable
+		// engine does not read as "your request is gone".
+		run = makeRun({ requestId: "req_1" });
+		requestError = new Error("Failed to fetch");
+		render(<RunSourceSection tab={TAB} />);
+
+		expect(screen.queryByText("Deleted")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Open request" })).toBeInTheDocument();
+	});
+
+	it("says a run that was never linked to a saved request is not saved", () => {
+		run = makeRun({ requestId: null });
+		render(<RunSourceSection tab={TAB} />);
+
+		expect(screen.getByText("Not saved")).toBeInTheDocument();
+	});
+
+	it("says the run is gone when it no longer exists", () => {
+		render(<RunSourceSection tab={TAB} />);
+		expect(screen.getByText("This run is no longer available")).toBeInTheDocument();
+	});
+});

--- a/app/src/components/layout/context-bar/RunSourceSection.tsx
+++ b/app/src/components/layout/context-bar/RunSourceSection.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Where this run came from: the request that was sent, and the environment it
+ * was sent with.
+ *
+ * Both are stored on the run and neither had a reader anywhere in the app -
+ * `Run.environmentId` in particular was written by every send and displayed by
+ * nothing, so a run measured against Staging looked exactly like one measured
+ * against Production. It is the first question asked of a result that surprises
+ * you, and the run tab could not answer it.
+ *
+ * The request link opens the tab rather than navigating in place: a run is
+ * often opened to compare against the request as it is now, and closing the run
+ * to look would lose the comparison.
+ */
+
+import { useRunQuery, useRequestQuery, useEnvironmentsQuery, isRequestNotFound } from "@/queries";
+import { useTabsStore } from "@/stores";
+import { Button } from "@/components/ui";
+import { SectionEmpty, SectionLoading } from "./Section";
+import type { ContextBarSectionProps } from "./types";
+
+export function RunSourceSection({ tab }: ContextBarSectionProps) {
+	const { data: run, isLoading } = useRunQuery(tab.entityId);
+	const { data: request, error: requestError } = useRequestQuery(run?.requestId ?? null);
+	const { data: environments = [] } = useEnvironmentsQuery();
+	const openTab = useTabsStore((s) => s.openTab);
+
+	if (isLoading && !run) return <SectionLoading />;
+	if (!run) return <SectionEmpty>This run is no longer available</SectionEmpty>;
+
+	const environmentId = run.environmentId ?? null;
+	const environment = environmentId
+		? environments.find((e) => e.id === environmentId)
+		: undefined;
+	// A deleted environment is not the same answer as "none was active", and the
+	// run kept the id either way - so say which of the two it is rather than
+	// folding both into "No environment".
+	const environmentLabel = !environmentId
+		? "No environment"
+		: (environment?.name ?? `${environmentId} (deleted)`);
+
+	const requestGone = isRequestNotFound(requestError);
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-[11px] text-muted-foreground shrink-0">Request</span>
+				{!run.requestId ? (
+					<span className="text-xs text-muted-foreground truncate">Not saved</span>
+				) : requestGone ? (
+					<span className="text-xs text-muted-foreground truncate">Deleted</span>
+				) : (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-6 text-xs min-w-0 max-w-full"
+						onClick={() => openTab({ type: "request", entityId: run.requestId! })}
+					>
+						<span className="truncate">{request?.name || "Open request"}</span>
+					</Button>
+				)}
+			</div>
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-[11px] text-muted-foreground shrink-0">Environment</span>
+				<span className="text-xs font-mono text-foreground truncate">
+					{environmentLabel}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/app/src/components/layout/context-bar/VariableRow.tsx
+++ b/app/src/components/layout/context-bar/VariableRow.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One editable variable in the context bar: its name, a marker beside it, and
+ * the input its edits are typed into.
+ *
+ * Shared by the request tab's resolved list and the collection tab's own
+ * definitions. The two differ only in the marker - a scope badge on one, an
+ * "off" note on the other - and in where the commit lands; everything subtle
+ * here (the remount key, the Escape restore, the uncontrolled input a rejected
+ * save relies on) is the same act on both, so it is written once.
+ */
+
+import { Input } from "@/components/ui";
+import { TruncatedText } from "@/components/shared";
+import type { ReactNode } from "react";
+import type { ResolvedVariable } from "@/types";
+
+interface VariableRowProps {
+	name: string;
+	/** The definition on screen - the one a commit is allowed to write back to. */
+	resolved: ResolvedVariable;
+	/** Drawn after the name. The scope badge, or nothing. */
+	marker?: ReactNode;
+	/** Called on blur and on Enter with the input itself - see `useVariableCommit`. */
+	onCommit: (input: HTMLInputElement) => void;
+}
+
+export function VariableRow({ name, resolved, marker, onCommit }: VariableRowProps) {
+	return (
+		<div className="grid grid-cols-2 gap-2 items-center">
+			{/* The scope decides where an edit lands, so it is visible
+			    rather than hidden in a mouse-only `title`;
+			    `VariableScopeBadge` is the primitive the variable popover
+			    already uses to say it. */}
+			<div className="flex items-center gap-1.5 min-w-0 px-1">
+				<TruncatedText className="text-xs font-mono text-foreground">{name}</TruncatedText>
+				{marker}
+			</div>
+			{resolved.secret ? (
+				<Input
+					value="••••••"
+					readOnly
+					aria-label={`Value of ${name}`}
+					className="h-7 text-xs font-mono text-muted-foreground"
+					title="Secret values can be edited from the Variables page"
+				/>
+			) : (
+				<Input
+					/*
+					 * Scope and source belong in the key, not just the
+					 * value. On the value alone, an environment switch
+					 * or a Ctrl+N tab switch mid-edit that happens to
+					 * resolve the same string kept the DOM node alive
+					 * and let the blur write into the *newly* resolved
+					 * definition. Including the source remounts the
+					 * node instead, so an abandoned edit is dropped -
+					 * the lesser outcome, and never a mistargeted one.
+					 */
+					key={`${name}:${resolved.scope}:${resolved.sourceId}:${resolved.value}`}
+					defaultValue={resolved.value}
+					aria-label={`Value of ${name}`}
+					className="h-7 text-xs font-mono"
+					onBlur={(e) => onCommit(e.target)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.currentTarget.blur();
+						} else if (e.key === "Escape") {
+							e.currentTarget.value = resolved.value;
+							e.currentTarget.blur();
+						}
+					}}
+				/>
+			)}
+		</div>
+	);
+}

--- a/app/src/components/layout/context-bar/VariablesSection.commit-scope.test.tsx
+++ b/app/src/components/layout/context-bar/VariablesSection.commit-scope.test.tsx
@@ -242,15 +242,21 @@ describe("VariablesSection - the commit target is the resolver's winner", () => 
 		expect(useToastStore.getState().toasts).toHaveLength(1);
 	});
 
-	it("keeps no unguarded parentId walk in the component", () => {
+	it("keeps no unguarded parentId walk in the component or the commit path", () => {
 		// `buildLeafFirstChain` re-implemented `buildCollectionChain` without its
 		// cycle guard, so a bad database froze the window on the first blur. The
 		// fix is that the component walks nothing at all - it is handed the winner.
-		// The guard reads the file it names: a scan of an empty string passes
+		// The guard reads the files it names: a scan of an empty string passes
 		// vacuously, which is how one of these shipped green for weeks.
-		const source = readFileSync(join(__dirname, "VariablesSection.tsx"), "utf8");
-		expect(source.length).toBeGreaterThan(1000);
-		expect(source).not.toContain("parentId");
+		//
+		// Both files, because the commit moved out of the component into
+		// `variable-commit.ts` - scanning only the shrunken component would let
+		// the walk come back in the half that actually writes.
+		for (const file of ["VariablesSection.tsx", "variable-commit.ts"]) {
+			const source = readFileSync(join(__dirname, file), "utf8");
+			expect(source.length).toBeGreaterThan(1000);
+			expect(source).not.toContain("parentId");
+		}
 	});
 });
 

--- a/app/src/components/layout/context-bar/VariablesSection.tsx
+++ b/app/src/components/layout/context-bar/VariablesSection.tsx
@@ -6,126 +6,23 @@
  */
 
 /**
- * Variables in scope, and the quick editor over them.
+ * Variables in scope on a request tab, and the quick editor over them.
  *
  * This was the whole of `ContextBar.tsx` before the bar grew a section
- * registry; it moved here unchanged, commit path and all. The comments below
- * describe defects this code already fixed - keep them with the code they
- * explain.
+ * registry. What is left here is the *list*: which definitions won, and the
+ * badge naming the scope each won from. The row and the commit path moved to
+ * `VariableRow` / `useVariableCommit` when the collection tab grew a variables
+ * section of its own - the comments describing the defects they fixed moved
+ * with the code they explain.
  */
 
-import { useCallback, useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { useSaveStore } from "@/stores";
 import { useVariableResolver } from "@/hooks/useVariableResolver";
-import {
-	useRequestQuery,
-	useUpdateGlobalsMutation,
-	useUpdateEnvironmentMutation,
-	useUpdateCollectionMutation,
-} from "@/queries";
-import { queryKeys } from "@/queries/keys";
-import { Input, VariableScopeBadge } from "@/components/ui";
-import { TruncatedText } from "@/components/shared";
+import { useRequestQuery } from "@/queries";
+import { VariableScopeBadge } from "@/components/ui";
 import { SectionEmpty } from "./Section";
+import { VariableRow } from "./VariableRow";
+import { useVariableCommit } from "./variable-commit";
 import type { ContextBarSectionProps } from "./types";
-import type {
-	Collection,
-	Environment,
-	GlobalVariables,
-	ResolvedVariable,
-	VariableValue,
-} from "@/types";
-
-type VariableMap = Record<string, VariableValue>;
-
-/**
- * Where one scope's variables live and how a commit gets written back.
- *
- * The three scopes differ only in those two things, so they are named once
- * rather than spelled out three times. `read` deliberately goes to the query
- * cache rather than to a hook's `data`: a commit built from the render closure
- * is a snapshot of the cache as it was when the input was drawn, and the
- * transport replaces the whole map - so blurring a second variable before the
- * first mutation settled re-sent the first one's pre-edit value and silently
- * reverted it.
- */
-interface CommitScope {
-	/** The stored map as of now, not as of the render that drew the input. */
-	read: () => VariableMap | undefined;
-	/** Patch the cache so a later commit's `read` already sees this one. */
-	write: (next: VariableMap) => void;
-	/** Send the map to the engine. */
-	mutate: (
-		next: VariableMap,
-		handlers: { onError: (e: unknown) => void; onSettled: () => void }
-	) => void;
-}
-
-/** The bar's single entry in the save-context registry. */
-const SAVE_CONTEXT_ID = "context-bar-variables";
-
-/**
- * Track in-flight commits so the quit-time flush waits for them.
- *
- * `onBeforeQuit` awaits `flushAll` (`App.tsx`), which only knows about
- * *registered* save contexts - the bar registered none, so the renderer could be
- * torn down mid-PUT with the input already showing the value as committed. One
- * context covers the whole bar: `hasPendingChanges` says whether any commit is
- * outstanding, and `save()` resolves when the last one settles.
- *
- * Returns a function that opens a commit and hands back its `settle` callback,
- * for the mutation's `onSettled`. Commits are held as promises rather than
- * counted so `save()` can await the requests themselves.
- */
-function usePendingCommits(): () => () => void {
-	const registerContext = useSaveStore((s) => s.registerContext);
-	const unregisterContext = useSaveStore((s) => s.unregisterContext);
-	const updateContext = useSaveStore((s) => s.updateContext);
-	const pending = useRef<Set<Promise<void>>>(new Set());
-
-	useEffect(() => {
-		const inFlight = pending.current;
-		registerContext({
-			id: SAVE_CONTEXT_ID,
-			name: "Variables",
-			save: async () => {
-				await Promise.all([...inFlight]);
-			},
-			hasPendingChanges: false,
-		});
-		return () => unregisterContext(SAVE_CONTEXT_ID);
-	}, [registerContext, unregisterContext]);
-
-	return useCallback(() => {
-		let settle: () => void = () => {};
-		const commit = new Promise<void>((resolve) => {
-			settle = resolve;
-		});
-		pending.current.add(commit);
-		updateContext(SAVE_CONTEXT_ID, { hasPendingChanges: true });
-		useSaveStore.getState().startSaving();
-
-		return () => {
-			pending.current.delete(commit);
-			settle();
-			if (pending.current.size > 0) return;
-			updateContext(SAVE_CONTEXT_ID, { hasPendingChanges: false });
-			// A failed commit already reported itself through `failSave`; painting
-			// "Saved" over it is the same defect `runSave` guards against in the
-			// save store.
-			//
-			// `completeSaveThenIdle`, not a success plus a hand-rolled reset timer:
-			// the store holds one status for the whole app, so a bare
-			// `setTimeout(() => setStatus("idle"))` clears whatever is current when
-			// it lands. This path armed no reset at all before #369, which left
-			// "Saved" in the Dock until something else changed it.
-			if (useSaveStore.getState().status !== "error") {
-				useSaveStore.getState().completeSaveThenIdle();
-			}
-		};
-	}, [updateContext]);
-}
 
 export function VariablesSection({ tab }: ContextBarSectionProps) {
 	// Resolve the active request's collection so collection-scope variables show up
@@ -134,137 +31,7 @@ export function VariablesSection({ tab }: ContextBarSectionProps) {
 		collectionId: request?.collectionId || undefined,
 	});
 	const variables = getAllVariables();
-
-	const queryClient = useQueryClient();
-	const updateGlobalsMutation = useUpdateGlobalsMutation();
-	const updateEnvironmentMutation = useUpdateEnvironmentMutation();
-	const updateCollectionMutation = useUpdateCollectionMutation();
-	const failSave = useSaveStore((s) => s.failSave);
-	const beginCommit = usePendingCommits();
-
-	/**
-	 * The scope that owns the definition the bar *displayed*, or null if that
-	 * source is gone.
-	 *
-	 * Keyed off `resolved.sourceId`, which the resolver emits precisely to name
-	 * the winning source (`useVariableResolver`, `ResolvedVariable`). The bar used
-	 * to re-derive the target instead - walking the collection chain for the first
-	 * definition with a truthy `enabled` - which disagrees with the resolver's
-	 * `isEnabledDefinition` wherever `enabled` is absent (D17: absent counts as
-	 * enabled). A leaf definition with no `enabled` key therefore displayed while
-	 * an *ancestor's* definition took the write, silently and cross-collection.
-	 * Re-deriving a winner someone else already picked is the whole bug; there is
-	 * no version of that walk that cannot drift from the resolver again.
-	 */
-	const commitScopeFor = (resolved: ResolvedVariable): CommitScope | null => {
-		if (resolved.scope === "global") {
-			return {
-				read: () =>
-					queryClient.getQueryData<GlobalVariables>(queryKeys.globals.all)?.variables,
-				write: (next) =>
-					queryClient.setQueryData<GlobalVariables>(queryKeys.globals.all, (old) =>
-						old ? { ...old, variables: next } : old
-					),
-				mutate: (next, handlers) =>
-					updateGlobalsMutation.mutate({ variables: next }, handlers),
-			};
-		}
-
-		// Every non-global winner carries the id of the environment or collection
-		// it came from. One without is a resolver that changed shape, not a
-		// variable to guess a home for.
-		const sourceId = resolved.sourceId;
-		if (!sourceId) return null;
-
-		if (resolved.scope === "environment") {
-			const key = queryKeys.environments.list();
-			const source = queryClient
-				.getQueryData<Environment[]>(key)
-				?.find((e) => e.id === sourceId);
-			if (!source) return null;
-			return {
-				read: () =>
-					queryClient.getQueryData<Environment[]>(key)?.find((e) => e.id === sourceId)
-						?.variables,
-				write: (next) =>
-					queryClient.setQueryData<Environment[]>(key, (old) =>
-						old?.map((e) => (e.id === sourceId ? { ...e, variables: next } : e))
-					),
-				mutate: (next, handlers) =>
-					updateEnvironmentMutation.mutate({ id: sourceId, variables: next }, handlers),
-			};
-		}
-
-		const key = queryKeys.collections.list();
-		const source = queryClient.getQueryData<Collection[]>(key)?.find((c) => c.id === sourceId);
-		if (!source) return null;
-		return {
-			read: () =>
-				queryClient.getQueryData<Collection[]>(key)?.find((c) => c.id === sourceId)
-					?.variables,
-			write: (next) =>
-				queryClient.setQueryData<Collection[]>(key, (old) =>
-					old?.map((c) => (c.id === sourceId ? { ...c, variables: next } : c))
-				),
-			mutate: (next, handlers) =>
-				updateCollectionMutation.mutate({ id: sourceId, variables: next }, handlers),
-		};
-	};
-
-	/**
-	 * Write the edited value back to the definition the bar displayed.
-	 *
-	 * Takes the input element, not the string, because every failure below has to
-	 * put the old value back on screen. These inputs are uncontrolled -
-	 * `defaultValue` with a `key` derived from the stored value - so a rejected
-	 * save changes nothing: the cache is untouched, therefore the key is
-	 * untouched, therefore React keeps the DOM node and the typed text sits there
-	 * looking committed. Failures used to end here entirely (no `onError`, no
-	 * `isError` reader, and there is no global `MutationCache.onError` either),
-	 * which is the same defect `CollectionDetail/shared.tsx` documents for the
-	 * collection tabs.
-	 */
-	const commitValue = (name: string, resolved: ResolvedVariable, input: HTMLInputElement) => {
-		const newValue = input.value;
-		if (newValue === resolved.value) return;
-
-		const rollBack = (message: string) => {
-			input.value = resolved.value;
-			failSave(message);
-		};
-		// `failSave` is the app's one save-failure surface (it toasts and sets the
-		// Dock's status) - see the note on it in save-store.
-		// The definition this bar resolved against is gone - deleted from its
-		// scope, or its environment or collection removed, between render and blur.
-		// Writing it back would resurrect it, so the edit is refused; saying so
-		// is the difference between "refused" and "silently swallowed".
-		const gone = () =>
-			rollBack(`{{${name}}} is no longer defined in its ${resolved.scope} scope`);
-
-		const scope = commitScopeFor(resolved);
-		if (!scope) return gone();
-
-		const stored = scope.read();
-		const previous = stored?.[name];
-		if (!previous) return gone();
-
-		const next = { ...stored, [name]: { ...previous, value: newValue } };
-		scope.write(next);
-
-		const settle = beginCommit();
-		scope.mutate(next, {
-			onError: (error: unknown) => {
-				// Restore this name alone rather than the whole snapshot: another
-				// variable's commit may have patched the map in the meantime, and
-				// replacing it wholesale would revert that one too - the very
-				// staleness the fresh read exists to avoid.
-				const current = scope.read();
-				if (current) scope.write({ ...current, [name]: previous });
-				rollBack(error instanceof Error ? error.message : `Couldn't save {{${name}}}`);
-			},
-			onSettled: settle,
-		});
-	};
+	const commitValue = useVariableCommit();
 
 	const entries = Object.entries(variables);
 
@@ -273,53 +40,13 @@ export function VariablesSection({ tab }: ContextBarSectionProps) {
 	return (
 		<div className="space-y-1">
 			{entries.map(([name, resolved]) => (
-				<div key={name} className="grid grid-cols-2 gap-2 items-center">
-					{/* The scope decides where an edit lands, so it is visible
-					    rather than hidden in a mouse-only `title`;
-					    `VariableScopeBadge` is the primitive the variable popover
-					    already uses to say it. */}
-					<div className="flex items-center gap-1.5 min-w-0 px-1">
-						<TruncatedText className="text-xs font-mono text-foreground">
-							{name}
-						</TruncatedText>
-						<VariableScopeBadge scope={resolved.scope} className="shrink-0" />
-					</div>
-					{resolved.secret ? (
-						<Input
-							value="••••••"
-							readOnly
-							aria-label={`Value of ${name}`}
-							className="h-7 text-xs font-mono text-muted-foreground"
-							title="Secret values can be edited from the Variables page"
-						/>
-					) : (
-						<Input
-							/*
-							 * Scope and source belong in the key, not just the
-							 * value. On the value alone, an environment switch
-							 * or a Ctrl+N tab switch mid-edit that happens to
-							 * resolve the same string kept the DOM node alive
-							 * and let the blur write into the *newly* resolved
-							 * definition. Including the source remounts the
-							 * node instead, so an abandoned edit is dropped -
-							 * the lesser outcome, and never a mistargeted one.
-							 */
-							key={`${name}:${resolved.scope}:${resolved.sourceId}:${resolved.value}`}
-							defaultValue={resolved.value}
-							aria-label={`Value of ${name}`}
-							className="h-7 text-xs font-mono"
-							onBlur={(e) => commitValue(name, resolved, e.target)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") {
-									e.currentTarget.blur();
-								} else if (e.key === "Escape") {
-									e.currentTarget.value = resolved.value;
-									e.currentTarget.blur();
-								}
-							}}
-						/>
-					)}
-				</div>
+				<VariableRow
+					key={name}
+					name={name}
+					resolved={resolved}
+					marker={<VariableScopeBadge scope={resolved.scope} className="shrink-0" />}
+					onCommit={(input) => commitValue(name, resolved, input)}
+				/>
 			))}
 		</div>
 	);

--- a/app/src/components/layout/context-bar/registry.test.tsx
+++ b/app/src/components/layout/context-bar/registry.test.tsx
@@ -25,20 +25,26 @@ import { CONTEXT_BAR_SECTIONS, sectionsForTab } from "./registry";
 import { contextBarHasContent } from "../context-bar-content";
 import type { Tab, TabType } from "@/stores";
 
+const ENTITY_TYPES: TabType[] = ["request", "collection", "run"];
+
+/**
+ * The tab types whose sections are gated on the tab being open on something -
+ * `appliesTo` in the registry. The request tab predates that gate and is
+ * deliberately left as it was: `Shell` shows the welcome screen for one with no
+ * entity, and narrowing it is not this change's business.
+ */
+const ENTITY_GATED_TYPES: TabType[] = ["collection", "run"];
+
 const tab = (type: TabType): Tab => ({
 	id: "t1",
 	type,
-	entityId: type === "request" ? "req_1" : null,
+	entityId: ENTITY_TYPES.includes(type) ? `${type}_1` : null,
 });
 
-const OTHER_TYPES: TabType[] = [
-	"welcome",
-	"collection",
-	"dashboard",
-	"run",
-	"variables",
-	"settings",
-];
+/** The same tab, but never opened on anything - see `appliesTo` in the registry. */
+const entitylessTab = (type: TabType): Tab => ({ id: "t1", type, entityId: null });
+
+const OTHER_TYPES: TabType[] = ["welcome", "dashboard", "variables", "settings"];
 
 describe("the context-bar section registry", () => {
 	it("ships the Phase 1 sections for a request tab, in reading order", () => {
@@ -49,6 +55,31 @@ describe("the context-bar section registry", () => {
 			"code",
 			"environment",
 		]);
+	});
+
+	it("ships the collection sections for a collection tab, in reading order", () => {
+		expect(sectionsForTab(tab("collection")).map((s) => s.id)).toEqual([
+			"collection-variables",
+			"collection-auth",
+			"collection-contents",
+		]);
+	});
+
+	it("ships the run sections for a run tab, in reading order", () => {
+		expect(sectionsForTab(tab("run")).map((s) => s.id)).toEqual(["run-config", "run-source"]);
+	});
+
+	it("has nothing for a collection or run tab that is not on an entity", () => {
+		// `Shell` renders no pane for one of these either. A section here would
+		// query nothing and light the Dock toggle over an empty bar.
+		expect(sectionsForTab(entitylessTab("collection"))).toEqual([]);
+		expect(sectionsForTab(entitylessTab("run"))).toEqual([]);
+	});
+
+	it("has no collection-run section, which nothing in the app can answer yet", () => {
+		// A collection has no runs of its own until the collection runner (#354)
+		// exists; a section claiming one could only invent it.
+		expect(CONTEXT_BAR_SECTIONS.map((s) => s.id)).not.toContain("collection-last-run");
 	});
 
 	it("has no last-result section, which the response pane already is", () => {
@@ -72,7 +103,7 @@ describe("the context-bar section registry", () => {
 		}
 	});
 
-	it("has no sections for the other tab types yet", () => {
+	it("has no sections for the four tab types that deliberately show nothing", () => {
 		for (const type of OTHER_TYPES) {
 			expect(sectionsForTab(tab(type))).toEqual([]);
 		}
@@ -85,7 +116,12 @@ describe("the context-bar section registry", () => {
 
 describe("contextBarHasContent reads the registry", () => {
 	it("is true exactly where the registry has sections", () => {
-		expect(contextBarHasContent(tab("request"))).toBe(true);
+		for (const type of ENTITY_TYPES) {
+			expect(contextBarHasContent(tab(type))).toBe(true);
+		}
+		for (const type of ENTITY_GATED_TYPES) {
+			expect(contextBarHasContent(entitylessTab(type))).toBe(false);
+		}
 		for (const type of OTHER_TYPES) {
 			expect(contextBarHasContent(tab(type))).toBe(false);
 		}
@@ -96,8 +132,10 @@ describe("contextBarHasContent reads the registry", () => {
 		// The derivation, not the current answer: every tab type is checked
 		// against `sectionsForTab` itself, so a hardcoded predicate that happens
 		// to match today would still fail the moment the two disagree.
-		for (const type of [...OTHER_TYPES, "request" as const]) {
-			expect(contextBarHasContent(tab(type))).toBe(sectionsForTab(tab(type)).length > 0);
+		for (const type of [...OTHER_TYPES, ...ENTITY_TYPES]) {
+			for (const t of [tab(type), entitylessTab(type)]) {
+				expect(contextBarHasContent(t)).toBe(sectionsForTab(t).length > 0);
+			}
 		}
 	});
 });

--- a/app/src/components/layout/context-bar/registry.ts
+++ b/app/src/components/layout/context-bar/registry.ts
@@ -14,19 +14,34 @@
  * another, and keeping them in step by hand is exactly the "config one branch
  * defines and another re-derives inline" defect the repo keeps finding.
  *
- * Phase 1 is the request tab. Phase 2's collection and run sections are entries
- * in this array and nothing else - which is the point of the registry.
+ * The collection and run sections arrived as entries in this array and nothing
+ * else - no framework change, which is what the registry was for.
  */
 
 import type { Tab } from "@/stores";
 import { AuthContextSection } from "./AuthContextSection";
 import { CodeSection } from "./CodeSection";
+import { CollectionAuthSection } from "./CollectionAuthSection";
+import { CollectionContentsSection } from "./CollectionContentsSection";
+import { CollectionVariablesSection } from "./CollectionVariablesSection";
 import { CookiesSection } from "./CookiesSection";
 import { EnvironmentSection } from "./EnvironmentSection";
+import { RunConfigSection } from "./RunConfigSection";
+import { RunSourceSection } from "./RunSourceSection";
 import { VariablesSection } from "./VariablesSection";
 import type { ContextBarSection } from "./types";
 
 const onRequestTab = (tab: Tab) => tab.type === "request";
+
+/**
+ * A collection or run tab with no entity is a tab with no subject: `Shell`
+ * renders nothing for one, and every section below would have nothing to query.
+ * Testing the entity as well as the type is why `appliesTo` takes the whole tab
+ * - it also keeps the Dock's toggle dark rather than lighting it for an empty
+ * bar.
+ */
+const onCollectionTab = (tab: Tab) => tab.type === "collection" && tab.entityId !== null;
+const onRunTab = (tab: Tab) => tab.type === "run" && tab.entityId !== null;
 
 /**
  * Order is the reading order on screen: what is in scope, who you are, what
@@ -63,6 +78,37 @@ export const CONTEXT_BAR_SECTIONS: readonly ContextBarSection[] = [
 		appliesTo: onRequestTab,
 		Component: EnvironmentSection,
 	},
+
+	/*
+	 * The collection tab, in the same reading order: what it contributes, what
+	 * it hands down, then how much is in it.
+	 *
+	 * There is no "last run of this collection" section. A collection has no
+	 * runs to summarise - the collection runner is #354, and until it exists
+	 * such a section could only invent a number.
+	 */
+	{
+		id: "collection-variables",
+		title: "Variables in this collection",
+		appliesTo: onCollectionTab,
+		Component: CollectionVariablesSection,
+	},
+	{
+		id: "collection-auth",
+		title: "Auth",
+		appliesTo: onCollectionTab,
+		Component: CollectionAuthSection,
+	},
+	{
+		id: "collection-contents",
+		title: "Contents",
+		appliesTo: onCollectionTab,
+		Component: CollectionContentsSection,
+	},
+
+	/* The run tab: what was asked for, and what it was asked of. */
+	{ id: "run-config", title: "Run config", appliesTo: onRunTab, Component: RunConfigSection },
+	{ id: "run-source", title: "Source", appliesTo: onRunTab, Component: RunSourceSection },
 ];
 
 /** The sections that have something to say about this tab, in registry order. */

--- a/app/src/components/layout/context-bar/variable-commit.ts
+++ b/app/src/components/layout/context-bar/variable-commit.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Where a context-bar variable edit lands, and what it carries when it gets
+ * there.
+ *
+ * This was `VariablesSection`'s own code until the collection tab grew a
+ * variables section of its own. The two show different sets - the request tab
+ * shows what resolved, the collection tab shows what that collection defines -
+ * but a commit is the same act either way, and the comments below describe
+ * defects that took a while to find. A second copy of them is exactly the
+ * "hand-rolled copy does not receive the primitive's fixes" trap.
+ *
+ * The caller supplies the `ResolvedVariable` whose definition it displayed;
+ * nothing here re-derives a target. That is the whole point - see the note on
+ * `commitScopeFor`.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSaveStore } from "@/stores";
+import {
+	useUpdateGlobalsMutation,
+	useUpdateEnvironmentMutation,
+	useUpdateCollectionMutation,
+} from "@/queries";
+import { queryKeys } from "@/queries/keys";
+import type {
+	Collection,
+	Environment,
+	GlobalVariables,
+	ResolvedVariable,
+	VariableValue,
+} from "@/types";
+
+type VariableMap = Record<string, VariableValue>;
+
+/**
+ * Where one scope's variables live and how a commit gets written back.
+ *
+ * The three scopes differ only in those two things, so they are named once
+ * rather than spelled out three times. `read` deliberately goes to the query
+ * cache rather than to a hook's `data`: a commit built from the render closure
+ * is a snapshot of the cache as it was when the input was drawn, and the
+ * transport replaces the whole map - so blurring a second variable before the
+ * first mutation settled re-sent the first one's pre-edit value and silently
+ * reverted it.
+ */
+interface CommitScope {
+	/** The stored map as of now, not as of the render that drew the input. */
+	read: () => VariableMap | undefined;
+	/** Patch the cache so a later commit's `read` already sees this one. */
+	write: (next: VariableMap) => void;
+	/** Send the map to the engine. */
+	mutate: (
+		next: VariableMap,
+		handlers: { onError: (e: unknown) => void; onSettled: () => void }
+	) => void;
+}
+
+/**
+ * The bar's single entry in the save-context registry.
+ *
+ * One id for the whole bar, not one per section: the registry gives a tab at
+ * most one variables section (the request tab's resolved set, or the collection
+ * tab's own definitions), so two of them are never mounted at once, and the
+ * quit-time flush has one thing to wait for either way.
+ */
+const SAVE_CONTEXT_ID = "context-bar-variables";
+
+/**
+ * Track in-flight commits so the quit-time flush waits for them.
+ *
+ * `onBeforeQuit` awaits `flushAll` (`App.tsx`), which only knows about
+ * *registered* save contexts - the bar registered none, so the renderer could be
+ * torn down mid-PUT with the input already showing the value as committed. One
+ * context covers the whole bar: `hasPendingChanges` says whether any commit is
+ * outstanding, and `save()` resolves when the last one settles.
+ *
+ * Returns a function that opens a commit and hands back its `settle` callback,
+ * for the mutation's `onSettled`. Commits are held as promises rather than
+ * counted so `save()` can await the requests themselves.
+ */
+function usePendingCommits(): () => () => void {
+	const registerContext = useSaveStore((s) => s.registerContext);
+	const unregisterContext = useSaveStore((s) => s.unregisterContext);
+	const updateContext = useSaveStore((s) => s.updateContext);
+	const pending = useRef<Set<Promise<void>>>(new Set());
+
+	useEffect(() => {
+		const inFlight = pending.current;
+		registerContext({
+			id: SAVE_CONTEXT_ID,
+			name: "Variables",
+			save: async () => {
+				await Promise.all([...inFlight]);
+			},
+			hasPendingChanges: false,
+		});
+		return () => unregisterContext(SAVE_CONTEXT_ID);
+	}, [registerContext, unregisterContext]);
+
+	return useCallback(() => {
+		let settle: () => void = () => {};
+		const commit = new Promise<void>((resolve) => {
+			settle = resolve;
+		});
+		pending.current.add(commit);
+		updateContext(SAVE_CONTEXT_ID, { hasPendingChanges: true });
+		useSaveStore.getState().startSaving();
+
+		return () => {
+			pending.current.delete(commit);
+			settle();
+			if (pending.current.size > 0) return;
+			updateContext(SAVE_CONTEXT_ID, { hasPendingChanges: false });
+			// A failed commit already reported itself through `failSave`; painting
+			// "Saved" over it is the same defect `runSave` guards against in the
+			// save store.
+			//
+			// `completeSaveThenIdle`, not a success plus a hand-rolled reset timer:
+			// the store holds one status for the whole app, so a bare
+			// `setTimeout(() => setStatus("idle"))` clears whatever is current when
+			// it lands. This path armed no reset at all before #369, which left
+			// "Saved" in the Dock until something else changed it.
+			if (useSaveStore.getState().status !== "error") {
+				useSaveStore.getState().completeSaveThenIdle();
+			}
+		};
+	}, [updateContext]);
+}
+
+/**
+ * Commit an edited value back to the definition the bar displayed.
+ *
+ * The returned function takes the input element, not the string, because every
+ * failure below has to put the old value back on screen. These inputs are
+ * uncontrolled - `defaultValue` with a `key` derived from the stored value - so
+ * a rejected save changes nothing: the cache is untouched, therefore the key is
+ * untouched, therefore React keeps the DOM node and the typed text sits there
+ * looking committed. Failures used to end here entirely (no `onError`, no
+ * `isError` reader, and there is no global `MutationCache.onError` either),
+ * which is the same defect `CollectionDetail/shared.tsx` documents for the
+ * collection tabs.
+ */
+export function useVariableCommit(): (
+	name: string,
+	resolved: ResolvedVariable,
+	input: HTMLInputElement
+) => void {
+	const queryClient = useQueryClient();
+	const updateGlobalsMutation = useUpdateGlobalsMutation();
+	const updateEnvironmentMutation = useUpdateEnvironmentMutation();
+	const updateCollectionMutation = useUpdateCollectionMutation();
+	const failSave = useSaveStore((s) => s.failSave);
+	const beginCommit = usePendingCommits();
+
+	/**
+	 * The scope that owns the definition the bar *displayed*, or null if that
+	 * source is gone.
+	 *
+	 * Keyed off `resolved.sourceId`, which the resolver emits precisely to name
+	 * the winning source (`useVariableResolver`, `ResolvedVariable`). The bar used
+	 * to re-derive the target instead - walking the collection chain for the first
+	 * definition with a truthy `enabled` - which disagrees with the resolver's
+	 * `isEnabledDefinition` wherever `enabled` is absent (D17: absent counts as
+	 * enabled). A leaf definition with no `enabled` key therefore displayed while
+	 * an *ancestor's* definition took the write, silently and cross-collection.
+	 * Re-deriving a winner someone else already picked is the whole bug; there is
+	 * no version of that walk that cannot drift from the resolver again.
+	 */
+	const commitScopeFor = (resolved: ResolvedVariable): CommitScope | null => {
+		if (resolved.scope === "global") {
+			return {
+				read: () =>
+					queryClient.getQueryData<GlobalVariables>(queryKeys.globals.all)?.variables,
+				write: (next) =>
+					queryClient.setQueryData<GlobalVariables>(queryKeys.globals.all, (old) =>
+						old ? { ...old, variables: next } : old
+					),
+				mutate: (next, handlers) =>
+					updateGlobalsMutation.mutate({ variables: next }, handlers),
+			};
+		}
+
+		// Every non-global winner carries the id of the environment or collection
+		// it came from. One without is a resolver that changed shape, not a
+		// variable to guess a home for.
+		const sourceId = resolved.sourceId;
+		if (!sourceId) return null;
+
+		if (resolved.scope === "environment") {
+			const key = queryKeys.environments.list();
+			const source = queryClient
+				.getQueryData<Environment[]>(key)
+				?.find((e) => e.id === sourceId);
+			if (!source) return null;
+			return {
+				read: () =>
+					queryClient.getQueryData<Environment[]>(key)?.find((e) => e.id === sourceId)
+						?.variables,
+				write: (next) =>
+					queryClient.setQueryData<Environment[]>(key, (old) =>
+						old?.map((e) => (e.id === sourceId ? { ...e, variables: next } : e))
+					),
+				mutate: (next, handlers) =>
+					updateEnvironmentMutation.mutate({ id: sourceId, variables: next }, handlers),
+			};
+		}
+
+		const key = queryKeys.collections.list();
+		const source = queryClient.getQueryData<Collection[]>(key)?.find((c) => c.id === sourceId);
+		if (!source) return null;
+		return {
+			read: () =>
+				queryClient.getQueryData<Collection[]>(key)?.find((c) => c.id === sourceId)
+					?.variables,
+			write: (next) =>
+				queryClient.setQueryData<Collection[]>(key, (old) =>
+					old?.map((c) => (c.id === sourceId ? { ...c, variables: next } : c))
+				),
+			mutate: (next, handlers) =>
+				updateCollectionMutation.mutate({ id: sourceId, variables: next }, handlers),
+		};
+	};
+
+	return (name: string, resolved: ResolvedVariable, input: HTMLInputElement) => {
+		const newValue = input.value;
+		if (newValue === resolved.value) return;
+
+		const rollBack = (message: string) => {
+			input.value = resolved.value;
+			failSave(message);
+		};
+		// `failSave` is the app's one save-failure surface (it toasts and sets the
+		// Dock's status) - see the note on it in save-store.
+		// The definition this bar resolved against is gone - deleted from its
+		// scope, or its environment or collection removed, between render and blur.
+		// Writing it back would resurrect it, so the edit is refused; saying so
+		// is the difference between "refused" and "silently swallowed".
+		const gone = () =>
+			rollBack(`{{${name}}} is no longer defined in its ${resolved.scope} scope`);
+
+		const scope = commitScopeFor(resolved);
+		if (!scope) return gone();
+
+		const stored = scope.read();
+		const previous = stored?.[name];
+		if (!previous) return gone();
+
+		const next = { ...stored, [name]: { ...previous, value: newValue } };
+		scope.write(next);
+
+		const settle = beginCommit();
+		scope.mutate(next, {
+			onError: (error: unknown) => {
+				// Restore this name alone rather than the whole snapshot: another
+				// variable's commit may have patched the map in the meantime, and
+				// replacing it wholesale would revert that one too - the very
+				// staleness the fresh read exists to avoid.
+				const current = scope.read();
+				if (current) scope.write({ ...current, [name]: previous });
+				rollBack(error instanceof Error ? error.message : `Couldn't save {{${name}}}`);
+			},
+			onSettled: settle,
+		});
+	};
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -76,7 +76,7 @@ Main layout: tab-centric with resizable drawer, split/overlay context bar, and d
 - **Drawer:** toggles visibility via `toggleDrawer()` (state in `useLayoutStore`); always resizable 220–480px.
 - **Content routing:** switches main area based on `activeTab.type` (welcome | request | collection | dashboard | run | variables | settings). Default is `WelcomeScreen`.
 - **Drawer-view sync:** an effect points the Drawer at the view matching the active tab - `variables`→variables, `settings`→settings, `request`/`collection`→collections - and opens it.
-- **ContextBar mode:** picks "push" (≥1200px width) or "overlay" based on window width. Context bar is request-tab–only.
+- **ContextBar mode:** picks "push" (≥1200px width) or "overlay" based on window width. It renders on the tab types the section registry has entries for - request, collection and run - and nothing on the other four.
 - **`<ImportModal />`** mounted once as a global overlay; visibility in a dedicated store.
 
 ### `Drawer` (`components/layout/Drawer.tsx`)
@@ -105,9 +105,11 @@ Resize handle on the right edge (double-click resets to defaults). Visibility to
 
 `CONTEXT_BAR_SECTIONS` is one ordered list of `{ id, title, appliesTo(tab), Component }`. `sectionsForTab(tab)` filters it, and `contextBarHasContent(tab)` is `sectionsForTab(tab).length > 0` - so the bar's visibility and the Dock toggle's pressed state read the same list and cannot drift. Adding a section for another tab type is one entry here and nothing else.
 
-**A section's component is mounted only while its section is expanded** (`context-bar/Section.tsx`), which is the whole cost model: the bar is open on every request tab, so a collapsed section must register no queries. Collapse state persists per section id in `layout-store` (`contextBarCollapsedSections`, collapsed-by-exception).
+**A section's component is mounted only while its section is expanded** (`context-bar/Section.tsx`), which is the whole cost model: the bar is open on every tab that has sections, so a collapsed section must register no queries. Collapse state persists per section id in `layout-store` (`contextBarCollapsedSections`, collapsed-by-exception).
 
 Sections are leaf components over the existing query layer - no bar-wide shared state - each with its own loading and empty body (`SectionEmpty`, `SectionLoading`).
+
+**Request tab**
 
 | Section (`id`) | What it shows |
 |---|---|
@@ -117,6 +119,25 @@ Sections are leaf components over the existing query layer - no bar-wide shared 
 | Code (`code`) | `CodeSection.tsx` - copy-as-curl / copy-as-fetch (below). |
 | Environment (`environment`) | `EnvironmentSection.tsx` - the active environment's name and a way into the Variables drawer. |
 
+**Collection tab**
+
+| Section (`id`) | What it shows |
+|---|---|
+| Variables in this collection (`collection-variables`) | `CollectionVariablesSection.tsx` - the definitions this collection owns (not a resolved set), editable through the same commit path as the request tab's list. A disabled definition is shown and marked `off` rather than hidden. |
+| Auth (`collection-auth`) | `CollectionAuthSection.tsx` - the mode this collection is set to, and what a descendant set to Inherit would pick up: the same `resolveAuthSource` walk, so a collection set to plain No Auth names the ancestor that answers instead. |
+| Contents (`collection-contents`) | `CollectionContentsSection.tsx` - direct child counts (requests, sub-collections), matching what the tree shows under the folder. |
+
+**Run tab**
+
+| Section (`id`) | What it shows |
+|---|---|
+| Run config (`run-config`) | `RunConfigSection.tsx` - mode, duration, target RPS, concurrency, iterations, ramp and requested protocol, read from the run's stored `configSnapshot`. Words come from `loadTestModeLabel` / `formatConcurrency`. A design run has no `mode` key and reads as "Single send". |
+| Source (`run-source`) | `RunSourceSection.tsx` - the environment the run used (`Run.environmentId`, which nothing rendered before) and a link opening the request it ran from. A deleted environment is named as deleted rather than folded into "No environment"; a deleted request (`isRequestNotFound`, never a transport failure) drops the link. |
+
+The collection and run sections gate on `tab.entityId` as well as the type: a tab open on nothing renders no pane either, and a section there would query nothing while lighting the Dock toggle over an empty bar.
+
+**There is deliberately no "last run" section on a collection tab.** A collection has no runs of its own until the collection runner exists (#354); a section claiming one could only invent it.
+
 **There is deliberately no "last result" section.** Status, duration and age of the last send are what `ResponseStatusBar` already paints in the response pane on the same screen - same `StatusCodeBadge`, same stored run, since the builder restores that run into the pane whenever nothing is in memory. A section with no state in which it says something the pane does not say better is a duplicate, not a summary. What would earn the slot is a *trend* across recent sends, which the pane structurally cannot show; that needs the paginated `GET /runs` to carry each design run's result first (today only `GET /runs/:id` attaches it), so it is tracked separately in #380.
 
 #### Variables section
@@ -124,6 +145,8 @@ Sections are leaf components over the existing query layer - no bar-wide shared 
 Resolves the active request's variables (global + collection-scoped + environment) via `useVariableResolver`; each row shows the name (`TruncatedText`), its winning scope (`VariableScopeBadge`) and the value (secrets masked). Value inputs are named `Value of <name>`.
 
 **Editing:** a blur (or Enter) commits the value back to the definition the resolver picked - looked up by `ResolvedVariable.sourceId`, not re-derived (see [variable resolution](./variable-resolution.md#getvariableoriginsname)). The payload is read from the query cache at commit time and patched into it optimistically, so a second blur before the first mutation settles cannot re-send the first one's old value. Commits register with the save store, so a quit flush waits for one in flight.
+
+The row and the commit are shared, not per section: `VariableRow.tsx` draws it (the remount key, the Escape restore, the uncontrolled input a rejected save depends on) and `variable-commit.ts`'s `useVariableCommit` writes it, so the collection tab's list gets the same fixes. Its rows are the collection's own definitions with that collection named as the source, which lands in the same place a collection-scope edit from the request tab does.
 
 #### Code section and `services/codegen/`
 

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -180,7 +180,8 @@ and a `return null` in another, and they drifted.
 A section is a leaf component over the ordinary query layer - no bar-wide shared
 state - and is **mounted only while its section is expanded**, so a collapsed
 section registers no queries. That is what makes it safe for the bar to stay open
-on every request tab. See `docs/app/COMPONENTS.md` for the sections themselves.
+on every tab the registry has entries for - request, collection and run. See
+`docs/app/COMPONENTS.md` for the sections themselves.
 
 #### Services Layer
 


### PR DESCRIPTION
## Description

Phase 2 of #344: the context bar drew five sections on a request tab and nothing on the other six tab types. This adds the collection and run sections as **five entries in `CONTEXT_BAR_SECTIONS` plus five leaf components** - no framework change, which is what the registry was for.

**Plan.** Root cause is simply that Phase 1 shipped the registry with request-tab entries only, so `appliesTo` was never exercised past the tab type. The approach is one entry per section and one leaf component beside the existing five, each gating on `tab.type` **and** `tab.entityId` (a collection or run tab open on nothing renders no pane either, so a section there would query nothing while lighting the Dock toggle over an empty bar). The alternative I rejected was giving the collection and run tabs one combined section each: fewer entries, but it would have made the collapse state all-or-nothing for content with very different cost - the variables list is editable and the contents count is a cheap line - and the registry's per-section mount gating is the whole cost model.

**Collection tab**

| Section | What it shows |
|---|---|
| `collection-variables` | The definitions this collection owns (not a resolved set), editable in place. A disabled definition stays on screen marked `off` - it is still defined here, it is simply not sent. |
| `collection-auth` | The mode this collection is set to, plus what a descendant set to Inherit picks up. One set to plain No Auth names the ancestor that answers instead, via the shared `resolveAuthSource` walk, so it cannot claim a source execution would not use. |
| `collection-contents` | Direct child counts (requests, sub-collections), matching what the tree shows under the folder. A subtree total would disagree with the rows the user can see. |

**Run tab**

| Section | What it shows |
|---|---|
| `run-config` | Mode, duration, target RPS, concurrency, iterations, ramp and requested protocol from the run's stored `configSnapshot`, worded by `loadTestModeLabel` / `formatConcurrency` so the same run is never described two ways. A design run has no `mode` key and reads as "Single send" rather than "nothing was recorded". |
| `run-source` | The environment the run used and a link opening the request it ran from. |

**Reuse over a second copy.** The row markup and the commit path moved out of `VariablesSection` into `VariableRow.tsx` and `variable-commit.ts` (`useVariableCommit`) rather than being duplicated - the remount key, the Escape restore, the uncontrolled input a rejected save depends on, and the read-the-cache-at-commit-time rule are the same act on both lists, and a hand-rolled copy would not receive their fixes. The collection list hands the commit a `ResolvedVariable` naming this collection as the source, so an edit lands exactly where a collection-scope edit from the request tab lands. `VariablesSection`'s behaviour is unchanged; its existing four test files pass untouched apart from the source-scan guard, which now scans both halves (scanning only the shrunken component would let the unguarded `parentId` walk back into the half that actually writes).

**A field that had no reader.** `Run.environmentId` was written by every send and rendered nowhere, so a run measured against Staging looked identical to one against Production. `run-source` is its first reader. A deleted environment is named as deleted rather than folded into "No environment" (the run kept the id either way), and a deleted *request* drops the link via `isRequestNotFound` - never for a transport failure, which is not a deletion.

**Deliberate deviations from the issue, both stated rather than quietly dropped:**

1. **No "last smoke outcome" section on the collection tab.** There is no such thing in the app to read: a collection has no runs of its own until the collection runner (#354) lands, and a section claiming one could only invent the number. Pinned by a registry test so it is a decision, not an omission.
2. **`RunSummary.followRedirects` / `maxRedirects` stay unrendered.** The issue offered the run section as a plausible home. I left them alone: they are list-row fields on a type that mirrors the wire, the run tab reads `configSnapshot` instead, and "mode, target, caps" is what the section was asked for. The existing note on the type still describes the situation accurately.
3. **The `run-config` section restates part of the load-test pane's config strip.** Accepted deliberately: a *design* run has no config view anywhere, and a bar that changed shape between the two kinds of run tab would be the worse answer. Both read the same helpers, so they cannot word one run differently.

**Dock:** no edit. The toggle lights up on collection and run tabs off `contextBarHasContent` alone; the two cases that moved out of the "not pressed" `it.each` are the mutation-check for that derivation, and two new cases assert it stays dark on an entity-less tab.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint` - all green.

- **Full app suite: 331 files, 3054 tests, 0 failures** (127s).
- New: `CollectionVariablesSection.test.tsx` (9), `CollectionAuthSection.test.tsx` (6), `CollectionContentsSection.test.tsx` (5), `RunConfigSection.test.tsx` (8), `RunSourceSection.test.tsx` (7).
- Updated: `registry.test.tsx` (ordering per tab type, the entity gate, the absent collection-run section), `Dock.context-toggle.test.tsx` (collection/run moved from "not pressed" to "pressed", plus entity-less cases), `VariablesSection.commit-scope.test.tsx` (the source-scan guard now reads both files, each asserted non-empty).

Mutation-checked by actually reverting, not by inspection:

| Mutation | Reddens |
|---|---|
| `contextBarHasContent` back to a hardcoded `tab.type === "request"` | 4 tests (both Dock pressed cases, both registry derivation cases) |
| The collection row's `sourceId` pointed at another collection | the commit-target test |
| `config.mode` printed raw / a hand-written concurrency unit | the two naming tests |

No engine change, so no engine build or ctest run - nothing there could change colour. `pnpm format:check` is clean for every file touched; `docs/app/COMPONENTS.md` was already not prettier-clean before this change and was left that way per CLAUDE.md. `mkdocs build --strict` was not run (mkdocs is not installed in this environment); the docs edits add table rows and prose to existing pages, with no new headings, anchors or relative links.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/COMPONENTS.md` (per-tab section tables, the entity gate, the shared row/commit note, the "no last run" decision) and `docs/app/architecture.md` (the bar is no longer request-tab-only). The registry's own "Phase 1 is the request tab" header comment is updated where it lives, in `registry.ts`.

## Related Issues
Closes #377

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp51E9xWg1CHzeMKCUviKF)_