### PR TITLE
fix(engine/reorder): validate, stage and write under one lock scope

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -193,7 +193,7 @@ run of `PUT`s. Each `PUT` is its own write under its own lock, so a reorder
 expressed as N sibling `PUT`s is last-write-wins between concurrent clients, can
 be interrupted halfway (leaving two rows at one `order` and a gap where the
 moved one was), and its collection cycle guard is read-then-write across two lock
-scopes. The batch endpoint validates and writes under one transaction, which
+scopes. The batch endpoint validates and writes under one lock scope, which
 closes all three. The per-row `PUT`s remain correct for a single row - a rename,
 a move that appends - and still carry those caveats when used in a loop.
 
@@ -688,9 +688,12 @@ Delete a request.
 ### POST /reorder
 
 Reposition collections and requests in one atomic batch - the write path behind a
-drag-and-drop reorder or a cross-folder move. One drop is one call and one
-transaction: nothing partial survives a rejection, and no concurrent create can
-land inside the range the batch is renumbering.
+drag-and-drop reorder or a cross-folder move. One drop is one call, one lock
+scope and one transaction: the batch validates, stages and commits under a single
+acquisition of the engine's database lock, so nothing partial survives a
+rejection and no concurrent write - a create computing its append slot, a
+conflicting batch, a cascade delete - can land between what this batch checked
+and what it wrote.
 
 **Request:**
 ```json
@@ -744,6 +747,13 @@ reparents that each look legal alone (`A` under `B` and `B` under `A`) a
 deterministic rejection rather than a race - unlike `PUT /collections/:id`, which
 validates and writes under different locks.
 
+That rejection is deterministic **because the check and the commit share one lock
+scope**: two such batches arriving concurrently are serialized whole, and the
+second revalidates against the first's committed graph rather than against the
+shape both of them read. The rows are written as updates, never inserts, so a
+batch whose row was deleted after it staged fails with a `409` naming the row and
+writes nothing at all - it never re-creates the deleted row.
+
 **Response:** the rows as written, in the same serialized shape a list entry
 carries - not an acknowledgement. A client that drew the drop optimistically
 settles its caches on these, so a normalization the engine performed is visible
@@ -759,8 +769,9 @@ without waiting for a refetch.
 ```
 
 **Errors:** `400` for any malformed entry, a row or owner that does not exist, a
-duplicate move, a cycle, or a batch over 10000 entries - in every case nothing at
-all was written. Body that is not JSON or not an object is also a `400`.
+duplicate move, a cycle, or a batch over 10000 entries. `409` if a staged row is
+gone by the time the batch commits. In every case nothing at all was written.
+Body that is not JSON or not an object is also a `400`.
 
 ## Import
 

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,23 @@ struct RunFilter {
     std::optional<RunStatus> status;
     std::optional<std::string> request_id;
     std::optional<std::string> q;
+};
+
+/**
+ * Thrown by `apply_reorder` when a row it was told to write is not stored at
+ * commit time. The batch is rolled back whole, and the row stays deleted.
+ *
+ * A reorder only ever repositions rows that already exist, so a missing one is
+ * never something to create: the previous `replace` would have resurrected a
+ * row a concurrent cascade had just deleted, silently, inside an endpoint whose
+ * contract is "all or nothing". The message names the row so the 409 the
+ * `/reorder` route turns this into is actionable.
+ */
+class MissingRowError : public std::runtime_error {
+    public:
+    MissingRowError (const std::string& kind, const std::string& id)
+    : std::runtime_error (kind + " '" + id + "' no longer exists") {
+    }
 };
 
 class Database {
@@ -77,12 +95,36 @@ class Database {
      * where the moved one used to be - a shape no read repairs, because the tie
      * rule then decides the display order.
      *
+     * Every row is **updated, never inserted**: one that is not stored at
+     * commit time throws `MissingRowError` and rolls the batch back (issue
+     * #386). Repositioning is by definition an operation on existing rows, so
+     * an insert here could only ever be a resurrection.
+     *
      * Separate from `import_apply` despite the shared shape: this writes rows
      * that already exist and must not touch environments, and the two callers
      * validate entirely different things beforehand.
      */
     void apply_reorder (const std::vector<Collection>& collections,
     const std::vector<Request>& requests);
+
+    /**
+     * @brief Run @p fn with the DB mutex held for the whole of it (issue #386).
+     *
+     * Every other method here takes the lock per call, which is enough while a
+     * write depends only on its own arguments. It is not enough for a composite
+     * that *reads, decides, then writes*: `POST /reorder` validates a batch
+     * against the stored graph and only then commits it, and between those two
+     * steps another client's write can move the ground - two reparents that are
+     * each legal alone both commit and leave a cycle, or a create computes
+     * `max_order + 1` inside the range the batch is renumbering. Wrapping the
+     * whole composite makes the validation the write is based on still true
+     * when the write lands.
+     *
+     * The mutex is recursive, so @p fn may call any method on this Database.
+     * Hold it only for a bounded composite: everything else serializing on this
+     * lock - `/health`, the runs poll, SSE - waits for the whole of @p fn.
+     */
+    void with_lock (const std::function<void ()>& fn);
 
     void save_environment (const Environment& e);
     std::vector<Environment> get_environments ();

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -740,6 +740,13 @@ const std::vector<Environment>& environments) {
 // lambda runs, and the lambda only touches the same storage handle. Collections
 // first so a request that moved into a collection this batch also reparented
 // still lands after its owner's row.
+//
+// `update` behind an existence check rather than `replace` (issue #386): a
+// reorder only repositions rows that already exist, so the upsert half of
+// `replace` could only ever re-create a row something else deleted - silently,
+// and inside a transaction the endpoint advertises as all-or-nothing. Throwing
+// out of the transaction lambda leaves the guard uncommitted, so the rows
+// updated before the missing one roll back with it.
 void Database::apply_reorder (const std::vector<Collection>& collections,
 const std::vector<Request>& requests) {
     if (collections.empty () && requests.empty ()) {
@@ -751,15 +758,31 @@ const std::vector<Request>& requests) {
 
     retry_on_busy ("apply reorder", 5, std::chrono::milliseconds (100), [&] {
         impl_->storage.transaction ([&] {
-            for (const auto& c : collections) {
-                impl_->storage.replace (c);
+            for (const auto& row : collections) {
+                if (impl_->storage.count<Collection> (
+                    where (c (&Collection::id) == row.id)) == 0) {
+                    throw MissingRowError ("Collection", row.id);
+                }
+                impl_->storage.update (row);
             }
-            for (const auto& r : requests) {
-                impl_->storage.replace (r);
+            for (const auto& row : requests) {
+                if (impl_->storage.count<Request> (
+                    where (c (&Request::id) == row.id)) == 0) {
+                    throw MissingRowError ("Request", row.id);
+                }
+                impl_->storage.update (row);
             }
             return true; // Commit
         });
     });
+}
+
+// The one place a caller can scope the DB mutex around more than a single call.
+// Deliberately `std::function` rather than a template: the mutex lives behind
+// the pImpl, and a header-inlined template would have to expose it.
+void Database::with_lock (const std::function<void ()>& fn) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    fn ();
 }
 
 // ============================================================================

--- a/engine/src/http/routes/reorder.cpp
+++ b/engine/src/http/routes/reorder.cpp
@@ -15,6 +15,7 @@
 #include "vayu/utils/json.hpp"
 #include "vayu/utils/logger.hpp"
 
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -210,10 +211,12 @@ read_move (vayu::db::Database& db, const nlohmann::json& entry, size_t index, Mo
  *
  * The walk runs over the shape the batch *would* produce - stored parents with
  * every move's `parentId` applied on top - which is what makes this endpoint
- * close the TOCTOU race the per-row `PUT` has: validation and write share one
- * transaction here, so two concurrent reparents that each look legal alone
- * cannot both land. `PUT /collections/:id` validates against the shape it read
- * before writing, under a different lock than the write.
+ * close the TOCTOU race the per-row `PUT` has: this walk and the write it
+ * guards run under one acquisition of the DB mutex (see `reorder_response`), so
+ * two concurrent reparents that each look legal alone cannot both land - the
+ * second one revalidates against the first one's committed graph and is
+ * rejected. `PUT /collections/:id` validates against the shape it read before
+ * writing, under a different lock than the write.
  *
  * Only moved collections start a walk: a cycle in the post-move graph must pass
  * through an edge this batch changed, so a chain that reaches a root or an
@@ -343,11 +346,9 @@ void stage_move (vayu::db::Database& db, const Move& move, int64_t now, WriteSet
     out.requests[row.id] = std::move (row);
 }
 
-} // namespace
-
 /**
- * Testable core of POST /reorder - one drop, one round trip, one transaction
- * (issue #365), returning {http_status, json_body}.
+ * The batch, from validation to commit. Runs with the DB mutex already held by
+ * `reorder_response` - see there for why the whole of it has to.
  *
  * A drop that displaces N siblings used to have no sane write path: the only
  * write verbs are one row per `PUT`, so a renumber was N sequential requests -
@@ -367,19 +368,17 @@ void stage_move (vayu::db::Database& db, const Move& move, int64_t now, WriteSet
  *     into a legacy all-zeros collection has real slots to name; the moves then
  *     state the positions the drop actually produced, and win over the
  *     renumber for any row named by both.
- *  3. **One transaction under the DB mutex** (`Database::apply_reorder`), so the
- *     validation above and the write share a lock scope - which is what closes
- *     the read-then-write race `PUT /collections/:id`'s cycle guard still has.
+ *  3. **One transaction** (`Database::apply_reorder`), whose rows are updates,
+ *     never inserts - a row deleted out from under the batch is a 409 naming it
+ *     and a whole rollback, not a silent resurrection.
  *
  * The response carries the rows as written, because the client that drew the
  * drop optimistically needs the authoritative positions to settle its caches on
  * - a count would tell it nothing it could use.
- *
- * Extracted for reorder_route_test.cpp, following the suite's route-test
- * convention (no in-process HTTP server).
  */
-std::pair<int, nlohmann::json>
-reorder_response (vayu::db::Database& db, const nlohmann::json& body) {
+std::pair<int, nlohmann::json> reorder_locked (vayu::db::Database& db,
+const nlohmann::json& body,
+const std::function<void ()>& before_write) {
     if (!body.is_object ()) {
         return body_error ("Body must be a JSON object");
     }
@@ -461,10 +460,64 @@ reorder_response (vayu::db::Database& db, const nlohmann::json& body) {
         request_rows.push_back (row);
     }
 
+    if (before_write) {
+        before_write ();
+    }
+
     if (!writes.empty ()) {
-        db.apply_reorder (collection_rows, request_rows);
+        try {
+            db.apply_reorder (collection_rows, request_rows);
+        } catch (const vayu::db::MissingRowError& e) {
+            // Unreachable while every writer takes the DB mutex - the lock this
+            // runs under is what makes it so. It stays because `apply_reorder`
+            // is a public method whose no-resurrection rule holds for any
+            // caller, and a 409 is the honest answer to "the row you staged is
+            // gone": the client's tree is behind, and a retry is what fixes it.
+            return { 409, error_body (409, e.what ()) };
+        }
     }
     return { 200, nlohmann::json{ { "collections", collections_out }, { "requests", requests_out } } };
+}
+
+} // namespace
+
+/**
+ * Testable core of POST /reorder - one drop, one round trip, one lock scope
+ * (issues #365, #386), returning {http_status, json_body}.
+ *
+ * A drop that displaces N siblings used to have no sane write path: the only
+ * write verbs are one row per `PUT`, so a renumber was N sequential requests -
+ * non-atomic (a crash mid-sequence half-renumbers a parent), racy against a
+ * concurrent create computing `max_order + 1` between two of them and against
+ * `POST /import/apply`'s own transactional order slots, and an invalidation
+ * storm on the client. This endpoint takes the whole batch instead.
+ *
+ * **The whole batch runs under one acquisition of the DB mutex**, not one per
+ * call into `Database`. cpp-httplib serves on a thread pool and the renderer and
+ * MCP are genuinely concurrent clients, so a batch that validated under one lock
+ * and committed under another left three windows open (#386): two conflicting
+ * reparents both passing an acyclicity check neither one's commit was visible
+ * to, a create reading `max_order + 1` from inside the range being renumbered,
+ * and a cascade deleting a staged row between the read and the write. Holding
+ * the lock across the composite is what makes the validation still true when the
+ * write lands; `Database::with_lock` documents the cost of holding it.
+ *
+ * @param before_write Test seam, invoked inside the lock once the batch is
+ *        staged and immediately before it commits. It is the only way to
+ *        observe the window this issue closed: a probe that starts a competing
+ *        writer proves that writer waits, and one that mutates the DB directly
+ *        (the mutex is recursive) stages the delete-at-commit case. Production
+ *        callers omit it.
+ *
+ * Extracted for reorder_route_test.cpp, following the suite's route-test
+ * convention (no in-process HTTP server).
+ */
+std::pair<int, nlohmann::json> reorder_response (vayu::db::Database& db,
+const nlohmann::json& body,
+const std::function<void ()>& before_write = nullptr) {
+    std::pair<int, nlohmann::json> result{ 500, nlohmann::json::object () };
+    db.with_lock ([&] { result = reorder_locked (db, body, before_write); });
+    return result;
 }
 
 void register_reorder_routes (RouteContext& ctx) {

--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -22,9 +22,15 @@
  *    scope as dense 0..n-1, in the pinned `order`/`createdAt`/`id` rule, and is
  *    idempotent - a second call writes nothing.
  *
- *  - **A create concurrent with a batch cannot land inside it.** The append
- *    scan reads `max_order + 1`, so a request created after a dense renumber
- *    sits past the batch's range rather than tying with a row inside it.
+ *  - **The lock scope spans validate + stage + write** (issue #386). The three
+ *    tests at the bottom of this file each drive a genuinely concurrent writer
+ *    into the window between a batch's validation and its commit, through the
+ *    `before_write` seam, and assert the writer cannot get in: a conflicting
+ *    reparent batch waits and is then rejected against the committed graph, a
+ *    create waits and appends past the renumbered range rather than into it,
+ *    and a row deleted mid-batch fails the batch with a 409 instead of being
+ *    resurrected by the write. Before #386 each of those held only within one
+ *    batch, while the endpoint's contract claimed otherwise.
  *
  * Route cores are exercised directly, no in-process HTTP server, matching the
  * suite's other route tests.
@@ -32,9 +38,15 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
+#include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -47,8 +59,11 @@ using nlohmann::json;
 namespace vayu::http::routes {
 // Defined in reorder.cpp / collections.cpp / requests.cpp; each returns
 // {http_status, json_body} - the same pair the HTTP handler writes out.
-std::pair<int, nlohmann::json>
-reorder_response (vayu::db::Database& db, const nlohmann::json& body);
+// `before_write` is reorder.cpp's test seam: invoked inside the batch's lock
+// scope once it has staged and immediately before it commits.
+std::pair<int, nlohmann::json> reorder_response (vayu::db::Database& db,
+const nlohmann::json& body,
+const std::function<void ()>& before_write = nullptr);
 std::pair<int, nlohmann::json>
 create_collection_response (vayu::db::Database& db, const nlohmann::json& json);
 std::pair<int, nlohmann::json>
@@ -133,6 +148,12 @@ class ReorderRouteTest : public ::testing::Test {
 
     static json normalize_requests (const std::string& collection_id) {
         return json{ { "type", "request" }, { "collectionId", collection_id } };
+    }
+
+    /** A collection move; `parent_id` is a collection id or `json(nullptr)`. */
+    static json move_collection (const std::string& id, int order, const json& parent_id) {
+        return json{ { "type", "collection" }, { "id", id }, { "order", order },
+            { "parentId", parent_id } };
     }
 
     std::unique_ptr<vayu::db::Database> db_;
@@ -468,25 +489,136 @@ TEST_F (ReorderRouteTest, TheResponseCarriesTheRowsAsWritten) {
 }
 
 // ---------------------------------------------------------------------------
-// Interleaving with a concurrent create
+// The lock scope: validate + stage + write (issue #386)
 // ---------------------------------------------------------------------------
 
-TEST_F (ReorderRouteTest, ACreateAfterABatchAppendsPastItRatherThanIntoIt) {
+/**
+ * A writer started from inside a batch's `before_write` seam - that is, on
+ * another thread, while the batch holds the DB lock - and given a window to
+ * finish before the batch commits.
+ *
+ * The window is what makes these tests decide in both directions, and it cannot
+ * be designed away: the defect *is* an interleaving, so a test for it has to
+ * produce one. With the lock scope spanning the batch, the writer blocks on the
+ * DB mutex, the wait runs its full timeout every time, and the batch commits
+ * first deterministically - there is no ordering in which it does not. Remove
+ * the lock scope and the writer proceeds immediately against the pre-write
+ * state, the wait returns as soon as it is done, and each test below sees the
+ * interleaving it forbids.
+ */
+class CompetingWriter {
+    public:
+    explicit CompetingWriter (std::function<void ()> work)
+    : work_ (std::move (work)) {
+    }
+    ~CompetingWriter () {
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+    CompetingWriter (const CompetingWriter&)            = delete;
+    CompetingWriter& operator= (const CompetingWriter&) = delete;
+
+    /** The `before_write` probe: starts the writer, then waits out the window. */
+    std::function<void ()> probe () {
+        return [this] {
+            thread_ = std::thread ([this] {
+                work_ ();
+                {
+                    std::lock_guard<std::mutex> guard (mutex_);
+                    done_ = true;
+                }
+                cv_.notify_all ();
+            });
+            std::unique_lock<std::mutex> guard (mutex_);
+            cv_.wait_for (
+            guard, std::chrono::milliseconds (300), [this] { return done_; });
+        };
+    }
+
+    void join () {
+        thread_.join ();
+    }
+
+    private:
+    std::function<void ()> work_;
+    std::thread thread_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool done_ = false;
+};
+
+TEST_F (ReorderRouteTest, AConflictingBatchWaitsAndIsRejectedAgainstTheCommittedGraph) {
+    const std::string a = make_collection ("A");
+    const std::string b = make_collection ("B");
+
+    // The mirror image of RejectsACycleFormedOnlyByTheBatchAsAWhole, split
+    // across two clients: A-under-B and B-under-A are each legal against the
+    // shape both of them read, and only the loser revalidating against the
+    // winner's committed graph rejects the second.
+    int other_status = 0;
+    json other_body;
+    CompetingWriter other ([&] {
+        auto result = reorder_response (
+        *db_, json{ { "moves", json::array ({ move_collection (b, 0, a) }) } });
+        other_status = result.first;
+        other_body   = result.second;
+    });
+
+    auto [status, response] = reorder_response (*db_,
+    json{ { "moves", json::array ({ move_collection (a, 0, b) }) } }, other.probe ());
+    ASSERT_EQ (status, 200) << response.dump ();
+    other.join ();
+
+    EXPECT_EQ (other_status, 400) << other_body.dump ();
+    EXPECT_EQ (db_->get_collection (a)->parent_id, std::optional<std::string> (b));
+    EXPECT_FALSE (db_->get_collection (b)->parent_id.has_value ());
+}
+
+TEST_F (ReorderRouteTest, ACreateDuringABatchWaitsAndAppendsPastTheRenumberedRange) {
     const std::string col = make_collection ("Billing");
     for (const auto& name : { "a", "b", "c" }) {
         set_request_order (make_request (col, name), 0);
     }
 
-    auto [status, response] = reorder_response (
-    *db_, json{ { "normalize", json::array ({ normalize_requests (col) }) } });
-    ASSERT_EQ (status, 200) << response.dump ();
+    std::string late;
+    CompetingWriter creator ([&] { late = make_request (col, "late"); });
 
-    // The create's append scan reads `max_order + 1` under the same DB mutex the
-    // batch committed under, so it cannot tie with a row inside the dense range.
-    const std::string late = make_request (col, "late");
+    auto [status, response] = reorder_response (*db_,
+    json{ { "normalize", json::array ({ normalize_requests (col) }) } },
+    creator.probe ());
+    ASSERT_EQ (status, 200) << response.dump ();
+    creator.join ();
+
+    // The create's append scan reads `max_order + 1`. Let it run inside the
+    // batch's window and it reads the pre-renumber rows - every one at 0 - and
+    // takes slot 1, tying with the row the batch is renumbering to 1.
     EXPECT_EQ (db_->get_request (late)->order, 3);
     EXPECT_EQ (request_orders (col), (std::vector<int>{ 0, 1, 2, 3 }));
     EXPECT_EQ (request_ids (col).back (), late);
+}
+
+TEST_F (ReorderRouteTest, ARowDeletedAfterStagingFailsTheBatchRatherThanBeingResurrected) {
+    const std::string col = make_collection ("Billing");
+    const std::string a   = make_request (col, "a");
+    const std::string b   = make_request (col, "b");
+    ASSERT_EQ (request_orders (col), (std::vector<int>{ 0, 1 }));
+
+    // No other thread can reach this window - that is the point of the lock -
+    // so the delete runs on this one, from inside the seam. The DB mutex is
+    // recursive, so it lands in the batch's own lock scope: the exact state
+    // `apply_reorder` must refuse to write over, whoever produced it.
+    json body{ { "moves", json::array ({ move_request (a, 1), move_request (b, 0) }) } };
+    auto [status, response] =
+    reorder_response (*db_, body, [&] { db_->delete_request (b); });
+
+    ASSERT_EQ (status, 409) << response.dump ();
+    EXPECT_NE (response["error"]["message"].get<std::string> ().find (b), std::string::npos)
+    << response.dump ();
+    // `replace` would have written the staged row straight back.
+    EXPECT_FALSE (db_->get_request (b).has_value ());
+    // And the rows the batch had already updated roll back with it.
+    EXPECT_EQ (db_->get_request (a)->order, 0);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

All four findings reproduce on master at `43efd1b`, exactly as #386 describes: `reorder_response` took the DB mutex once per call into `Database` (`reorder.cpp:228`, `:326`, `:337`), and only `apply_reorder`'s write ran inside a transaction.

**Plan.** Root cause is that "atomic" was scoped to the *write* while the decision the write encodes - is this graph acyclic, which rows exist, what are their positions - was read under earlier, separate acquisitions. The approach is the one the issue names: a `Database::with_lock` seam that scopes the existing recursive mutex around a composite, with validation + staging + `apply_reorder` inside it, plus existence-checked updates in place of `storage.replace`. The alternative I rejected was a narrower fix - keeping the per-call locking and re-validating inside `apply_reorder`'s transaction - which would have duplicated the cycle walk and the existence checks into the DB layer, put route-shaped 400s behind a layer that cannot build them, and still left the create-interleave window open, since that one is not about rows the batch names.

**Per window**

| Window | Before | After |
|---|---|---|
| Two conflicting reparents (`A` under `B`, `B` under `A`) | both validate against the pre-write graph, both commit, cycle stored | serialized whole; the second revalidates against the first's committed graph and 400s |
| A create during a batch | `max_order + 1` computed between staging and commit, landing inside the renumbered range | the create waits and appends past the range |
| A staged row deleted before the write | `storage.replace` resurrects it, inside an all-or-nothing transaction | `MissingRowError` -> whole rollback -> **409** naming the row |

`with_lock` is `std::function`-typed rather than a template because the mutex lives behind the pImpl and a header-inlined template would have to expose it. Its doc states the cost: everything else serializing on that lock (`/health`, the runs poll, SSE) waits for the whole callable, so it is for bounded composites only. One consequence worth naming: `retry_on_busy`'s backoff sleep used to release the mutex between attempts, and inside a `with_lock` scope it no longer can - a busy retry now stalls the outer scope. That only fires when another *process* holds the SQLite file, which is not a shape this single-daemon engine has.

**Why the 409 is unreachable in practice, and stays anyway.** With every writer taking the DB mutex, no delete can land inside the batch's scope - the lock is what makes it so. The check stays because `apply_reorder` is a public method whose no-resurrection rule has to hold for any caller, and because a reorder repositions rows that already exist: the upsert half of `replace` had no legitimate use there. The route comment says exactly this, so a future reader does not delete it as dead code.

**Blast radius traced.** `apply_reorder` and `reorder_response` each have exactly one caller (`rg` across `engine/src`, `engine/include`, `app/electron`) - the route and its HTTP handler; MCP has no reorder tool. On the app side the single consumer is `apiService.reorder` -> `useReorderMutation`. Its `onError` is status-agnostic: `http-client.ts` turns any non-2xx into `ApiError` carrying the engine's message, and `onError` restores the optimistic snapshots and reports through `failSave`. **A 409 is therefore handled exactly as a 400 already is, and no app change is needed** - as the issue expected.

**The three overstated claims** are now true as written: `reorder.cpp`'s "share a lock scope", the `reorder_route_test.cpp` header, and `api-reference.md`. The doc gained the real guarantee and the new 409 in the same commit.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

- **Full engine suite: 1029 tests, 0 failures** (94s). 3 new, all in `reorder_route_test.cpp`.
- The old `ACreateAfterABatchAppendsPastItRatherThanIntoIt` was strictly sequential - it created the request *after* the batch returned, so it staged nothing. It is replaced by the interleaved version rather than kept alongside it.

The three tests drive a real concurrent writer into the window through `before_write`, a seam invoked inside the lock once the batch has staged. A `CompetingWriter` helper starts the writer on another thread and waits out a 300ms window. That window is what makes the tests decide in both directions and cannot be designed away - the defect *is* an interleaving. With the lock scope, the writer blocks on the mutex and the wait always runs its full timeout, so the batch commits first in every ordering; without it, the writer proceeds against pre-write state and the wait returns early. The delete case needs no second thread: the mutex is recursive, so the seam deletes the row on the same thread, landing in the batch's own lock scope.

Mutation-checked by reverting and rebuilding, not by inspection:

| Mutation | Reddens |
|---|---|
| the outer `with_lock` removed | 2 (`AConflictingBatchWaits...`, `ACreateDuringABatchWaits...`) |
| `update` + existence check back to `replace` | 1 (`ARowDeletedAfterStaging...`) |

App suite not run: no app source changed. `mkdocs build --strict` was not run (mkdocs is not installed in this environment); the change adds no page, no heading and no link - only prose inside three existing paragraphs of `api-reference.md`. clang-format: `reorder.cpp` and `reorder_route_test.cpp` were clean on master and remain clean; `database.cpp` and `database.hpp` were already unformatted on master, so only my changed lines were formatted (`git clang-format --diff origin/master` reports no remaining drift).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #386

---
_Generated by [Claude Code](https://claude.ai/code/session_018MD3EVMNTdpUkVieomg2Fo)_