### PR TITLE
fix(app/codegen): a generated snippet can no longer read a local file

### DIFF
--- a/app/src/services/codegen/codegen.test.ts
+++ b/app/src/services/codegen/codegen.test.ts
@@ -141,9 +141,9 @@ describe("form bodies", () => {
 		},
 	};
 
-	it("emits one -F per enabled field and drops the boundary-less Content-Type", () => {
+	it("emits one --form-string per enabled field and drops the boundary-less Content-Type", () => {
 		const { code } = generateCurl(formData);
-		expect(code).toContain(`-F 'name=it'\\''s me'`);
+		expect(code).toContain(`--form-string 'name=it'\\''s me'`);
 		// curl picks the boundary; a Content-Type naming one it did not choose
 		// makes the server read the whole body as a single part.
 		expect(code).not.toContain("multipart/form-data");
@@ -492,6 +492,191 @@ describe("Python requests", () => {
 		});
 		expect(code).toContain('auth = ("ada", "p\\"ass")');
 		expect(code).toContain("auth=auth,");
+	});
+});
+
+/**
+ * The file-reference edges: a value the *shell* hands over byte for byte can
+ * still be read by the client as a path.
+ *
+ * Quoting cannot help here - the bytes arrive intact and the client interprets
+ * them. curl's `-F` reads a value starting with `@` or `<` as a file to upload
+ * and `;type=` as a per-part override; HTTPie's item grammar reads `=@` the
+ * same way, `==` as a query parameter, and a `:`/`@` in the key as a header or
+ * a file upload. So the fix is the flag and the escape, and these cases decode
+ * what the *client* will parse rather than the bytes we chose to write.
+ */
+
+/** The generated curl command's arguments, one per continuation line. */
+function curlArgs(code: string): string[] {
+	return code.split("\\\n").map((line) => line.trim());
+}
+
+/** The decoded `key=value` pairs curl receives for one flag. */
+function curlPairs(code: string, flag: string): Array<[string, string]> {
+	return curlArgs(code)
+		.filter((arg) => arg.startsWith(`${flag} `))
+		.map((arg): [string, string] => {
+			const decoded = unquoteShell(arg.slice(flag.length + 1));
+			const split = decoded.indexOf("=");
+			return [decoded.slice(0, split), decoded.slice(split + 1)];
+		});
+}
+
+/**
+ * The request items of a generated HTTPie command, unquoted from the shell.
+ *
+ * An item is a bare quoted word, which a header is too - so the requests below
+ * carry no headers, and the URL sits on the first line beside `http METHOD`.
+ */
+function httpieItems(code: string): string[] {
+	return code
+		.split("\\\n")
+		.map((line) => line.trim())
+		.filter((arg) => arg.startsWith("'"))
+		.map(unquoteShell);
+}
+
+/**
+ * Parse an HTTPie request item the way HTTPie does.
+ *
+ * A backslash escapes the character after it when that character is special,
+ * and the separator is then the *earliest* one still standing, longest first at
+ * that position. Returning the separator is the point: an item that parses with
+ * `=@` instead of `=` is a file read, and one that parses with `==` is a query
+ * parameter, both with a perfectly innocent-looking key and value.
+ */
+function parseHttpieItem(item: string): { key: string; value: string; separator: string } {
+	const special = new Set(["\\", ":", "=", "@"]);
+	const characters: Array<{ char: string; escaped: boolean }> = [];
+	for (let i = 0; i < item.length; i++) {
+		if (item[i] === "\\" && special.has(item[i + 1] ?? "")) {
+			characters.push({ char: item[i + 1], escaped: true });
+			i++;
+		} else {
+			characters.push({ char: item[i], escaped: false });
+		}
+	}
+	// An escaped character occupies one position in both strings, so an index
+	// found in `visible` addresses `literal` unchanged.
+	const visible = characters.map((c) => (c.escaped ? "\u0000" : c.char)).join("");
+	const literal = characters.map((c) => c.char).join("");
+
+	let at = -1;
+	let separator = "";
+	for (const candidate of [":=@", "=@", ":=", "==", "=", ":", "@"]) {
+		const index = visible.indexOf(candidate);
+		if (index === -1) continue;
+		if (at === -1 || index < at || (index === at && candidate.length > separator.length)) {
+			at = index;
+			separator = candidate;
+		}
+	}
+	if (at === -1) throw new Error(`no separator in item: ${item}`);
+	return { key: literal.slice(0, at), value: literal.slice(at + separator.length), separator };
+}
+
+describe("a form value is never read as a local file", () => {
+	const FILE_REFERENCE_VALUES: Array<[string, string]> = [
+		["a leading @", "@/etc/passwd"],
+		["a leading <", "</etc/passwd"],
+		["a ;type= override", "report;type=text/html"],
+		["a leading =", "=not-a-query-parameter"],
+	];
+
+	for (const [name, value] of FILE_REFERENCE_VALUES) {
+		it(`curl sends ${name} as data`, () => {
+			const { code } = generateCurl({
+				...GET,
+				method: "POST",
+				body: { mode: "form-data", fields: [{ key: "field", value }] },
+			});
+			expect(curlArgs(code).some((arg) => arg.startsWith("-F "))).toBe(false);
+			expect(curlPairs(code, "--form-string")).toEqual([["field", value]]);
+		});
+
+		it(`HTTPie sends ${name} as data`, () => {
+			const { code } = generateHttpie({
+				...GET,
+				method: "POST",
+				body: { mode: "form-data", fields: [{ key: "field", value }] },
+			});
+			expect(parseHttpieItem(httpieItems(code)[0])).toEqual({
+				key: "field",
+				value,
+				separator: "=",
+			});
+		});
+	}
+
+	const HOSTILE_KEYS: Array<[string, string]> = [
+		["a space", "field name"],
+		["an ampersand", "a&b"],
+		["an equals sign", "a=b"],
+		["an at sign", "user@host"],
+	];
+
+	for (const [name, key] of HOSTILE_KEYS) {
+		it(`curl encodes a urlencoded key containing ${name}`, () => {
+			const { code } = generateCurl({
+				...GET,
+				method: "POST",
+				body: { mode: "x-www-form-urlencoded", fields: [{ key, value: "v" }] },
+			});
+			const [[emittedKey, emittedValue]] = curlPairs(code, "--data-urlencode");
+			// curl encodes only what follows the first `=`, so any of these surviving
+			// raw in the name is the bug: `&` starts a second field, `@` is curl's
+			// `name@file` file read, and a space is simply a different name. `=` needs
+			// no case of its own - raw, it *is* the split, so the decode below fails.
+			expect(emittedKey).not.toMatch(/[ &@]/);
+			expect(decodeURIComponent(emittedKey)).toBe(key);
+			expect(emittedValue).toBe("v");
+		});
+
+		it(`HTTPie escapes a form key containing ${name}`, () => {
+			const { code } = generateHttpie({
+				...GET,
+				method: "POST",
+				body: { mode: "x-www-form-urlencoded", fields: [{ key, value: "v" }] },
+			});
+			expect(parseHttpieItem(httpieItems(code)[0])).toEqual({
+				key,
+				value: "v",
+				separator: "=",
+			});
+		});
+	}
+
+	it("HTTPie keeps a backslash instead of letting it escape the next character", () => {
+		const { code } = generateHttpie({
+			...GET,
+			method: "POST",
+			body: { mode: "form-data", fields: [{ key: "path", value: String.raw`C:\=temp` }] },
+		});
+		expect(parseHttpieItem(httpieItems(code)[0])).toEqual({
+			key: "path",
+			value: String.raw`C:\=temp`,
+			separator: "=",
+		});
+	});
+
+	it("PowerShell says -Form needs 6.1+, and says it only where -Form is used", () => {
+		const multipart = generatePowerShell({
+			...GET,
+			method: "POST",
+			body: { mode: "form-data", fields: [{ key: "a", value: "b" }] },
+		});
+		// Atop the snippet: Windows PowerShell 5.1 has no `-Form` at all, and it is
+		// the shell whose `curl` alias is why this target exists.
+		expect(multipart.code.startsWith("# requires PowerShell 6.1+ (-Form)")).toBe(true);
+		expect(multipart.code).toContain("-Form $body");
+
+		const urlencoded = generatePowerShell({
+			...GET,
+			method: "POST",
+			body: { mode: "x-www-form-urlencoded", fields: [{ key: "a", value: "b" }] },
+		});
+		expect(urlencoded.code).not.toContain("6.1+");
 	});
 });
 

--- a/app/src/services/codegen/curl.ts
+++ b/app/src/services/codegen/curl.ts
@@ -55,11 +55,21 @@ export function generateCurl(
 		args.push(`--data-raw ${shellQuote(prepared.body.content)}`);
 	} else if (prepared.body?.kind === "form-data") {
 		for (const [key, value] of prepared.body.fields) {
-			args.push(`-F ${shellQuote(`${key}=${value}`)}`);
+			// `--form-string`, not `-F`: `-F` reads a value beginning with `@` or
+			// `<` as a file reference and `;type=` as a per-part override, so a
+			// generated command would upload a local file the request never
+			// contained. `--form-string` takes the value literally, always.
+			args.push(`--form-string ${shellQuote(`${key}=${value}`)}`);
 		}
 	} else if (prepared.body?.kind === "urlencoded") {
 		for (const [key, value] of prepared.body.fields) {
-			args.push(`--data-urlencode ${shellQuote(`${key}=${value}`)}`);
+			// curl encodes only what follows the first `=`, so the field *name* has
+			// to arrive already encoded: a raw space, `&` or `=` in it sends a
+			// different field than the request carries, and a raw `@` hits curl's
+			// `name@file` form and reads a local file. Encoding the name here and
+			// leaving the value to curl is the split curl documents; the `%20` for a
+			// space matches what curl emits on the value side.
+			args.push(`--data-urlencode ${shellQuote(`${encodeURIComponent(key)}=${value}`)}`);
 		}
 	}
 

--- a/app/src/services/codegen/httpie.ts
+++ b/app/src/services/codegen/httpie.ts
@@ -23,6 +23,33 @@ import { shellQuote } from "./curl";
 import { prepareRequest } from "./prepare";
 import type { CodegenOptions, GeneratedSnippet, SnippetRequest } from "./types";
 
+/**
+ * Build a request item HTTPie will read back as the field it was built from.
+ *
+ * HTTPie splits an item at the *earliest* separator it finds, taking the
+ * longest one at that position, and the separators are not just `=`: `=@` reads
+ * a local file into the field, `==` makes it a query parameter, `@` uploads a
+ * file and `:` writes a header. So an unescaped leading `@` or `=` on the value
+ * side silently changes what the item means - the same file-reference hazard
+ * curl's `-F` has - and a `:`, `=` or `@` anywhere in the key is read as the
+ * separator instead of the one we emit.
+ *
+ * The fix is HTTPie's documented escape, a backslash before the character that
+ * must not be read as a separator; `\` itself is that escape character, so a
+ * literal one is doubled or it swallows the character after it. Only a
+ * *leading* separator matters on the value side - past the `=` we emit, nothing
+ * later is the earliest match - so a JSON value keeps its colons and stays
+ * readable.
+ */
+function httpieItem(key: string, value: string): string {
+	const escapedKey = key.replace(/[\\:=@]/g, "\\$&");
+	const escapedValue = value
+		.split("\\")
+		.join("\\\\")
+		.replace(/^[:=@]/, "\\$&");
+	return `${escapedKey}=${escapedValue}`;
+}
+
 export function generateHttpie(
 	request: SnippetRequest,
 	options: CodegenOptions = {}
@@ -54,7 +81,7 @@ export function generateHttpie(
 	} else if (prepared.body) {
 		if (prepared.body.kind === "urlencoded") args.push("--form");
 		for (const [key, value] of prepared.body.fields) {
-			args.push(shellQuote(`${key}=${value}`));
+			args.push(shellQuote(httpieItem(key, value)));
 		}
 	}
 

--- a/app/src/services/codegen/powershell.ts
+++ b/app/src/services/codegen/powershell.ts
@@ -59,6 +59,14 @@ export function generatePowerShell(
 		});
 	}
 
+	if (isFormData) {
+		// `-Form` arrived in PowerShell 6.1. Windows PowerShell 5.1 - the shell
+		// whose `curl` alias is why this target exists at all - has no such
+		// parameter and fails the call outright, so the snippet says so in the one
+		// place the reader is already looking.
+		lines.push("# requires PowerShell 6.1+ (-Form)", "");
+	}
+
 	if (headers.length > 0) {
 		lines.push("$headers = @{");
 		for (const { name, expression } of headers) {

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -158,13 +158,15 @@ Snippets are generated from **`POST /compose`'s output** - the request with `{{v
 
 | Target | String rule | Multipart vs urlencoded |
 |---|---|---|
-| `curl` | POSIX single quotes, `'` → `'\''` | `-F` vs `--data-urlencode` |
+| `curl` | POSIX single quotes, `'` → `'\''` | `--form-string` vs `--data-urlencode` |
 | `fetch` | `JSON.stringify` (it *is* the JS literal grammar) | `FormData` vs `URLSearchParams` |
 | `python` | `JSON.stringify` - JSON's escapes are a strict subset of Python 3's | `files=` vs `data=` (a multipart body passed as `data=` is silently urlencoded) |
 | `httpie` | POSIX, shared with curl | `--multipart` vs `--form` (`--form` alone is urlencoded) |
 | `powershell` | Single quotes, `'` → `''`; a POSIX `'\''` would put a backslash in the data | `-Form` vs `-Body` |
 
-HTTPie takes headers as bare `Name:value` words and a body as `--raw`, so the composed bytes go out unchanged rather than HTTPie building a new JSON object from `key=value`. PowerShell emits `Invoke-RestMethod`, not `curl` - on Windows PowerShell `curl` is an alias for that cmdlet, so a snippet saying `curl` runs something else than the reader expects.
+HTTPie takes headers as bare `Name:value` words and a body as `--raw`, so the composed bytes go out unchanged rather than HTTPie building a new JSON object from `key=value`. PowerShell emits `Invoke-RestMethod`, not `curl` - on Windows PowerShell `curl` is an alias for that cmdlet, so a snippet saying `curl` runs something else than the reader expects, and a multipart snippet carries a `# requires PowerShell 6.1+ (-Form)` line because 5.1 has no `-Form` at all.
+
+**Quoting is not the end of it: a client can read its own argument as a path.** The bytes survive the shell and the *client* then interprets them, so curl's `-F` uploads a local file for any value starting with `@` or `<`, and HTTPie's item grammar reads `=@` the same way (plus `==` as a query parameter, and a `:` or `@` in a key as a header or a file upload). curl form fields therefore use `--form-string`, which has no such grammar, and HTTPie items escape with a backslash on the key and on a leading separator in the value. `--data-urlencode` encodes only what follows the first `=`, so the field *name* is percent-encoded here and the value is left to curl.
 
 **Secrets are masked by default in resolved output**, revealing is explicit, and masking happens *before* quoting - after it, a value containing a quote no longer matches itself. What is masked: every variable the resolver marks secret, plus the credential the auth mode carries. Jar cookies are never in a snippet (libcurl attaches them at transfer time) and the section says so.
 


### PR DESCRIPTION
## Description

**Plan.** The root cause is that quoting ends where the client's own grammar begins: every generator already gets its bytes past the shell intact, and then curl and HTTPie re-read those bytes as a path. So the fix is not more escaping at the shell layer but the flag and the item escape at the client layer - `--form-string` instead of `-F` (it has no file-reference grammar at all), percent-encoding the `--data-urlencode` field *name* while leaving the value to curl (the split curl documents), and HTTPie's documented backslash escape on the key plus a leading separator in the value. The alternative I rejected was detecting hazardous values and emitting a warning comment beside `-F`: it leaves the loaded command in the snippet, and a comment is not a guarantee - the acceptance criterion asks that no value *can* cause a file read, which only a grammar-free flag delivers.

Verified against the code first: all three defects are still present as described (`curl.ts` emitted `-F` and a raw urlencoded key; `powershell.ts` had the 6.1+ constraint only in a source comment). Blast radius is contained - `CodeSection.tsx` is the single consumer and renders whatever the generators emit, and generation is pure.

The three edges:

- **curl multipart used `-F`**, which reads a value starting with `@` or `<` as a file to upload and `;type=` as a per-part override. Now `--form-string`.
- **`--data-urlencode` encodes only what follows the first `=`**, so a field name carrying a space, `&` or `=` went out raw as a different field, and one carrying `@` hit curl's `name@file` form and read a file. The name is now percent-encoded; `%20` for a space matches what curl emits on the value side.
- **HTTPie's item grammar shares the hazard**: `=@` reads a file into the field, `==` makes it a query parameter, and a `:` or `@` in a key is a header or a file upload. Items now use HTTPie's documented backslash escape on the key and on a leading separator in the value; a literal backslash is doubled, since `\` is that escape character and would otherwise swallow the character after it.

PowerShell multipart snippets now open with `# requires PowerShell 6.1+ (-Form)` - 5.1 has no `-Form`, and 5.1 is the shell whose `curl` alias is why the target exists.

**Deliberate deviation from the issue spec:** the issue offered a `-F` fallback with a warning comment "where a value genuinely cannot be expressed (binary file parts, once those exist)". No such value exists today - every field is a string - so no fallback path is written. Adding an unreachable branch now would be the speculative abstraction the repo asks to avoid; it belongs with #393, which introduces file parts.

**Adjacent, deliberately not in this diff:** curl has no escape for an `=` inside a *multipart field name* (`--form-string 'a=b=c'` names the field `a`). That is a wrong-field-name bug, not a file read, and unlike the urlencoded case it has no expressible fix - only a note would be possible. Left alone rather than widened into here.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **331 files, 3079 tests, all passing.** `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on the touched files. No engine change, so no engine build or ctest run.

The codegen suite went from 78 to **99 tests**. New cases decode what the *client* will parse rather than comparing to an expected byte string, following the file's established technique - a `parseHttpieItem` helper reproduces HTTPie's tokenize-then-earliest-separator rule and returns the separator it landed on, because an item parsing with `=@` instead of `=` is precisely the file read.

All four fixes mutation-checked by reverting each in turn:

| Reverted fix | Failing tests |
|---|---|
| `--form-string` back to `-F` | 5 |
| urlencoded key left unencoded | 4 |
| HTTPie item left unescaped | 5 |
| PowerShell 6.1+ line removed | 1 |

Restoring each returned the suite to 99 passing. The urlencoded case was tightened after the first pass caught only 2 of 4 keys: a raw `&` or space round-trips through `decodeURIComponent` unchanged, so the test now also asserts no reserved character survives raw into the emitted name.

No pre-existing failures encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #390

Docs: the issue predicted no doc change, but reality disagreed - the target table in `docs/app/COMPONENTS.md` names curl's multipart flag as `-F`, so it is updated in the same commit, along with a paragraph on why quoting alone is not enough and the PowerShell 6.1+ line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF7aR1aQbn1383oLA6hR1b)_