### PR TITLE
fix(app/collection-tree): a row's ⋯ menu is not a press on the row

### DIFF
--- a/app/src/modules/collections/CollectionTree.dnd.test.tsx
+++ b/app/src/modules/collections/CollectionTree.dnd.test.tsx
@@ -388,6 +388,38 @@ describe("the keyboard move", () => {
 	});
 });
 
+describe("the row's own ⋯ menu", () => {
+	it("is not a press on the row, even though its items bubble through it", async () => {
+		// Radix renders the menu through a *portal*: a React child of the row
+		// whose DOM lives on `body`. React bubbles synthetic events through the
+		// component tree rather than the DOM tree, so a press on a menu item
+		// arrives at the row's own pointer handlers. Taking it captures the
+		// pointer, and the capture retargets the `pointerup` the item needed -
+		// every action in the menu stops working, which is not something a test
+		// that clicks the item directly can see.
+		renderTree();
+		const source = requestRow("r1");
+		const trigger = Array.from(source.querySelectorAll("button")).find((b) =>
+			/more actions/i.test(b.getAttribute("aria-label") ?? "")
+		)!;
+		fireEvent.pointerDown(
+			trigger,
+			new PointerEvent("pointerdown", { bubbles: true, button: 0 })
+		);
+
+		const item = await screen.findByText("Move to...");
+		fireEvent.pointerDown(item, { button: 0, pointerId: 9, clientX: 200, clientY: 200 });
+
+		expect(source.hasPointerCapture(9)).toBe(false);
+
+		// And no amount of movement over the open menu starts a drag.
+		fireEvent.pointerMove(item, { pointerId: 9, clientX: 200, clientY: 260 });
+		expect(document.querySelector("[data-drop-indicator]")).toBeNull();
+		fireEvent.pointerUp(item, { pointerId: 9, clientX: 200, clientY: 260 });
+		expect(reorderMutate).not.toHaveBeenCalled();
+	});
+});
+
 describe("Move to...", () => {
 	it("moves the row and offers an undo that puts it back", async () => {
 		renderTree();

--- a/app/src/modules/collections/useTreeDnd.ts
+++ b/app/src/modules/collections/useTreeDnd.ts
@@ -120,6 +120,25 @@ function entityFromRow(el: Element | null): TreeEntity | null {
 }
 
 /**
+ * Whether an event that reached a row's handler actually happened on that row.
+ *
+ * A row renders its own ⋯ menu, and Radix renders the menu's items through a
+ * **portal** - a React child of the row whose DOM lives on `document.body`.
+ * React bubbles synthetic events through the component tree rather than the DOM
+ * tree, so pressing "Delete" arrives here as a press on the row.
+ *
+ * Treating it as one is not a cosmetic bug: the press captures the pointer on
+ * the row, and the capture retargets the `pointerup` the menu item needed, so
+ * every action in every row menu silently stops working. A DOM containment
+ * check is the difference between the two, and it is the *only* difference -
+ * `closest("[data-tree-menu]")` cannot see it, because portalled content is not
+ * inside the trigger it belongs to.
+ */
+function isOwnEvent(e: { target: EventTarget | null; currentTarget: HTMLElement }): boolean {
+	return e.target instanceof Node && e.currentTarget.contains(e.target);
+}
+
+/**
  * The index a destination names, in the block *without* the moved row - which
  * is the index `reorder-math` splices into. `null` when the anchor is not in
  * the block, which means the tree changed under the drag.
@@ -467,6 +486,8 @@ export function useTreeDnd({
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLElement>, entity: TreeEntity) => {
 			if (e.button !== 0) return;
+			// An open row menu is a React child of this row but not a DOM one.
+			if (!isOwnEvent(e)) return;
 			// The chevron, the ⋯ menu and a rename field are their own controls;
 			// a press on one of them is not a press on the row.
 			if (
@@ -496,7 +517,10 @@ export function useTreeDnd({
 	const onPointerMove = useCallback(
 		(e: React.PointerEvent<HTMLElement>) => {
 			const pressed = pressedRef.current;
-			if (!pressed) return;
+			// `isOwnEvent` again for the same reason as the press: while a drag is
+			// live the row holds the pointer capture, so every real move targets
+			// the row - anything else reaching here came through a portal.
+			if (!pressed || !isOwnEvent(e)) return;
 
 			const next = moveGesture(gestureRef.current, { x: e.clientX, y: e.clientY });
 			if (next !== gestureRef.current) {
@@ -540,25 +564,32 @@ export function useTreeDnd({
 		[armSpring, indicatorFor, isRowBusy, updateAutoScroll]
 	);
 
-	const onPointerUp = useCallback(() => {
-		const pressed = pressedRef.current;
-		if (!pressed) return;
-		const dropped = gestureRef.current.phase === "dragging";
-		gestureRef.current = releaseGesture(gestureRef.current);
-		const destination = destinationRef.current;
-		endDrag();
-		if (!dropped || !destination) return;
+	const onPointerUp = useCallback(
+		(e: React.PointerEvent<HTMLElement>) => {
+			const pressed = pressedRef.current;
+			if (!pressed || !isOwnEvent(e)) return;
+			const dropped = gestureRef.current.phase === "dragging";
+			gestureRef.current = releaseGesture(gestureRef.current);
+			const destination = destinationRef.current;
+			endDrag();
+			if (!dropped || !destination) return;
 
-		const siblings =
-			destination.block === "collections"
-				? collectionSiblings(dataRef.current.collections, destination.ownerId)
-				: destination.ownerId
-					? requestSiblings(destination.ownerId)
-					: [];
-		const index = indexInBlock(siblings, pressed.entity.id, destination);
-		if (index === null) return;
-		applyPlacement(pressed.entity, { ownerId: destination.ownerId, index }, { undoable: true });
-	}, [applyPlacement, endDrag, requestSiblings]);
+			const siblings =
+				destination.block === "collections"
+					? collectionSiblings(dataRef.current.collections, destination.ownerId)
+					: destination.ownerId
+						? requestSiblings(destination.ownerId)
+						: [];
+			const index = indexInBlock(siblings, pressed.entity.id, destination);
+			if (index === null) return;
+			applyPlacement(
+				pressed.entity,
+				{ ownerId: destination.ownerId, index },
+				{ undoable: true }
+			);
+		},
+		[applyPlacement, endDrag, requestSiblings]
+	);
 
 	const onPointerCancel = useCallback(() => {
 		gestureRef.current = cancelGesture(gestureRef.current);
@@ -566,6 +597,10 @@ export function useTreeDnd({
 	}, [endDrag]);
 
 	const onClickCapture = useCallback((e: React.MouseEvent<HTMLElement>) => {
+		// A menu item's click bubbles through the row it belongs to. Swallowing
+		// it would be the drag eating the very action the user chose *because*
+		// the drag before it left a suppression armed.
+		if (!isOwnEvent(e)) return;
 		const { gesture, suppressed } = consumeClick(gestureRef.current);
 		gestureRef.current = gesture;
 		if (!suppressed) return;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1319,6 +1319,16 @@ before, so every click affordance survives - and the completed drag swallows the
 one click the browser fires after it, or the row it was just dropped on would
 open. Never a timer: `RequestItem.test.tsx` pins that opening is synchronous.
 
+**A row's pointer handlers must ignore what its own menu sends them.** The ⋯
+menu is a React child of the row and a *portal* in the DOM, and React bubbles
+synthetic events through the component tree - so a press on "Delete" arrives at
+the row's `onPointerDown`. Taking it captures the pointer on the row, the
+capture retargets the `pointerup` the menu item was waiting for, and every
+action in every row menu stops working while looking perfectly normal.
+`closest("[data-tree-menu]")` does not catch it (portalled content is not inside
+its trigger); a DOM containment check - `currentTarget.contains(target)` - does,
+and is the guard on every pointer handler a row spreads.
+
 **Drop indicators are classes on rows that already exist.** A line between two
 rows is a 2px `bg-primary` span positioned inside the target row and indented to
 that row's own depth - the depth is the only thing separating "after this


### PR DESCRIPTION
## Description

Every action in every collection-tree row menu stopped working when #367 landed (#403). "Run collection" and "Move to..." are simply the two most recently added, so they are the two that got noticed - Rename, Duplicate, Add Request, Add Folder and Delete were dead in the same way and for the same reason.

**Root cause.** A row renders its own ⋯ menu, and Radix renders that menu's items through a **portal**: a React child of the row whose DOM lives on `document.body`. React bubbles synthetic events through the *component* tree, not the DOM tree, so pressing a menu item arrives at the row's own `onPointerDown` - which #367 added. That handler starts a press and calls `setPointerCapture` on the row, and the capture retargets the `pointerup` the menu item was waiting for. The item never activates.

Nothing looks broken while it happens: the menu opens, the item highlights, the menu closes on dismissal. Only the action is missing.

**The fix.** `closest("[data-tree-menu]")`, which already excluded the trigger, cannot catch this - portalled content is not inside the trigger it belongs to. DOM containment is exactly the distinction between "this row's own box" and "this row's portalled child", so `currentTarget.contains(target)` now guards every pointer handler a row spreads. The click-capture takes the same guard: a suppression left armed by a finished drag would otherwise swallow the very menu action the user chose next.

**The alternative I rejected** was stopping propagation inside `RowActionsMenu`. It fixes the symptom for this one menu and leaves the trap set for the next portal a row ever contains (a tooltip, a popover, a context menu), and it puts the knowledge in the shared primitive rather than in the handler that actually has the constraint.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - **343 files, 3265 tests, all passing** (137s). One new test; the baseline was 3264. `mkdocs build --strict -f .github/mkdocs.yml` passes. No engine files touched, so no engine run.

**Why the existing suite was green through all of this.** Both the runner's tests and the drag tests activate a menu item with `fireEvent.click(item)`, which dispatches a click straight at the item - and jsdom does not retarget captured pointer events, so the capture that breaks the real browser is invisible to that style of test. The regression test therefore presses a real menu item and asserts **the row did not capture the pointer**, which is the mechanism itself rather than a proxy for it:

| Mutation | Reddens |
|---|---|
| remove the containment guard from the press (i.e. restore the bug) | 1 - the new test, and only it |

Verified by actually reverting the guard and re-running, not by inspection.

Verification is by mechanism plus that test, **not** by driving the packaged app: the repo has no e2e harness and I did not stand one up for this. The chain being asserted - portalled press reaches the row, row captures the pointer, capture eats the item's `pointerup` - is the whole of the defect, and the guard is what breaks it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Regression from #367 (PR #403). No issue was filed - this was reported directly.

Docs: `docs/design-system.md`'s collection-tree section gains the rule, since any future pointer handler on those rows walks into the same trap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQFx5Moex7nYN6j7V7uZAZ)_