### PR TITLE
feat(engine/app): recent sends - a per-request trend, and the list-row outcome it needs

### DIFF
--- a/app/src/components/layout/context-bar/RecentSendsSection.test.tsx
+++ b/app/src/components/layout/context-bar/RecentSendsSection.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The section exists to say what the response pane cannot: more than one send.
+ * So the first case below is the load-bearing one - several rows, in recency
+ * order, each with its own status and latency. Cut it back to the latest send
+ * and it is the "last result" section that was built and removed in #344.
+ *
+ * Mutation-checks: drop `resultSummary` from the row rendering and the status
+ * and latency assertions redden; render the runs in the order received without
+ * relying on the engine's `start_time DESC` and the ordering case still passes
+ * (the engine sorts, this does not re-sort), which is why that case asserts the
+ * order it was handed rather than a sort of its own.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { RecentSendsSection } from "./RecentSendsSection";
+import { useTabsStore } from "@/stores";
+import type { Run, RunListResponse } from "@/types";
+
+let response: RunListResponse | undefined;
+let loading = false;
+const listRuns = vi.fn();
+
+vi.mock("@/queries", () => ({
+	useRecentDesignRunsQuery: (requestId: string | null | undefined) => {
+		listRuns(requestId);
+		return { data: response, isLoading: loading };
+	},
+}));
+
+const TAB = { id: "t1", type: "request", entityId: "req_1" } as const;
+
+const run = (id: string, extra: Partial<Run> = {}): Run => ({
+	id,
+	type: "design",
+	status: "completed",
+	startTime: Date.now(),
+	endTime: Date.now(),
+	requestId: "req_1",
+	...extra,
+});
+
+const envelope = (runs: Run[]): RunListResponse => ({
+	data: runs,
+	pagination: {
+		total: runs.length,
+		limit: 5,
+		offset: 0,
+		hasMore: false,
+		returned: runs.length,
+	},
+});
+
+beforeEach(() => {
+	response = undefined;
+	loading = false;
+	listRuns.mockClear();
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+});
+
+describe("RecentSendsSection", () => {
+	it("shows several sends, newest first, each with its own status and latency", () => {
+		response = envelope([
+			run("run_3", { resultSummary: { statusCode: 500, latencyMs: 812 } }),
+			run("run_2", { resultSummary: { statusCode: 200, latencyMs: 34 } }),
+			run("run_1", { resultSummary: { statusCode: 200, latencyMs: 29 } }),
+		]);
+		render(<RecentSendsSection tab={TAB} />);
+
+		const rows = screen.getAllByRole("button");
+		expect(rows).toHaveLength(3);
+		// The order the engine handed over (start_time DESC) is the order shown.
+		expect(within(rows[0]).getByText("500")).toBeInTheDocument();
+		expect(within(rows[0]).getByText("812 ms")).toBeInTheDocument();
+		expect(within(rows[1]).getByText("200")).toBeInTheDocument();
+		expect(within(rows[1]).getByText("34 ms")).toBeInTheDocument();
+		expect(within(rows[2]).getByText("29 ms")).toBeInTheDocument();
+	});
+
+	it("opens the run in a History tab, leaving the request tab open", () => {
+		response = envelope([run("run_1", { resultSummary: { statusCode: 200, latencyMs: 12 } })]);
+		render(<RecentSendsSection tab={TAB} />);
+
+		fireEvent.click(screen.getByRole("button"));
+
+		const { openTabs } = useTabsStore.getState();
+		expect(openTabs.map((t) => [t.type, t.entityId])).toEqual([["run", "run_1"]]);
+	});
+
+	it("says a send is in flight rather than reporting it as a status-0 failure", () => {
+		// A run with no stored result is not a run that failed: `statusCode: 0`
+		// is the wire's word for "reached no server", and using it here would
+		// report a send that has not finished as one that did, badly.
+		response = envelope([run("run_1", { status: "running" })]);
+		render(<RecentSendsSection tab={TAB} />);
+
+		expect(screen.getByText("Sending…")).toBeInTheDocument();
+		expect(screen.queryByText("0")).not.toBeInTheDocument();
+	});
+
+	it("says a terminal run with no stored result has none", () => {
+		response = envelope([run("run_1", { status: "failed" })]);
+		render(<RecentSendsSection tab={TAB} />);
+
+		expect(screen.getByText("No result")).toBeInTheDocument();
+	});
+
+	it("says the request has not been sent yet rather than showing an empty list", () => {
+		response = envelope([]);
+		render(<RecentSendsSection tab={TAB} />);
+
+		expect(screen.getByText("This request has not been sent yet")).toBeInTheDocument();
+		expect(screen.queryByRole("button")).not.toBeInTheDocument();
+	});
+
+	it("shows the loading line only while there is nothing to show", () => {
+		loading = true;
+		render(<RecentSendsSection tab={TAB} />);
+		expect(screen.getByText("Loading…")).toBeInTheDocument();
+
+		// A refetch behind an already-loaded list must not blank it out - the
+		// section refetches after every send.
+		response = envelope([run("run_1", { resultSummary: { statusCode: 200, latencyMs: 12 } })]);
+		render(<RecentSendsSection tab={TAB} />);
+		expect(screen.getByText("200")).toBeInTheDocument();
+	});
+
+	it("asks for the runs of the tab's own request", () => {
+		response = envelope([]);
+		render(<RecentSendsSection tab={TAB} />);
+		expect(listRuns).toHaveBeenCalledWith("req_1");
+	});
+});

--- a/app/src/components/layout/context-bar/RecentSendsSection.tsx
+++ b/app/src/components/layout/context-bar/RecentSendsSection.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The last few sends of this request: status, latency and age, newest first.
+ *
+ * **More than one send is the whole point.** The response pane already says
+ * everything there is to say about the *latest* one - `ResponseStatusBar`
+ * paints the same status chip, the same duration and the same age, from the
+ * same stored run - so a section restating it would be a poorer copy a few
+ * hundred pixels to its left, which is why the "last result" section specced in
+ * #344 was built and then removed. What the pane structurally cannot show is a
+ * sequence: whether that 500 is the first one, whether latency has been
+ * drifting, when this last worked. That costs a trip to the History drawer and
+ * a tab switch away from the request being debugged, and this is that trip.
+ *
+ * One list call, no report fetch. Each row's status code and latency ride on
+ * the run's own list row (`resultSummary`, added to the paginated `GET /runs`
+ * for this); reading them through `GET /runs/:id/report` instead would load and
+ * JSON-parse every result's trace, per row, on every expansion.
+ *
+ * Rows open the run rather than just reporting it - a trend is where you notice
+ * the one send worth looking at, and the History tab is where you look at it.
+ */
+
+import { useRecentDesignRunsQuery } from "@/queries";
+import { useTabsStore } from "@/stores";
+import { StatusCodeBadge, formatResponseTime } from "@/components/shared";
+import { formatRelativeTime } from "@/utils";
+import { SectionEmpty, SectionLoading } from "./Section";
+import type { ContextBarSectionProps } from "./types";
+import type { Run } from "@/types";
+
+/**
+ * What a row says when the run carries no outcome: it is still in flight, or
+ * its result never made it to disk. Never a zero status - the wire uses that
+ * for a request that reached no server, and inventing it here would report a
+ * send that has not happened yet as one that failed.
+ */
+function pendingLabel(status: Run["status"]): string {
+	switch (status) {
+		case "pending":
+		case "running":
+			return "Sending…";
+		case "stopped":
+			return "Stopped";
+		default:
+			return "No result";
+	}
+}
+
+export function RecentSendsSection({ tab }: ContextBarSectionProps) {
+	const { data, isLoading } = useRecentDesignRunsQuery(tab.entityId);
+	const openTab = useTabsStore((s) => s.openTab);
+
+	if (isLoading && !data) return <SectionLoading />;
+
+	const runs = data?.data ?? [];
+	if (runs.length === 0) {
+		return <SectionEmpty>This request has not been sent yet</SectionEmpty>;
+	}
+
+	return (
+		<ul className="space-y-0.5 m-0 p-0 list-none">
+			{runs.map((run) => {
+				const outcome = run.resultSummary;
+				return (
+					<li key={run.id}>
+						<button
+							type="button"
+							onClick={() => openTab({ type: "run", entityId: run.id })}
+							aria-label={`Open send${
+								outcome ? `, status ${outcome.statusCode}` : ""
+							}, ${formatRelativeTime(run.startTime)}`}
+							className="flex w-full items-center gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							{outcome ? (
+								// The code alone, without the reason phrase: five
+								// rows read as a column of codes, and the phrase
+								// would push the latency off every one of them.
+								<StatusCodeBadge status={outcome.statusCode} />
+							) : (
+								<span className="text-xs text-muted-foreground shrink-0">
+									{pendingLabel(run.status)}
+								</span>
+							)}
+							<span className="flex-1 text-xs font-mono tabular-nums text-foreground truncate">
+								{outcome ? formatResponseTime(outcome.latencyMs) : ""}
+							</span>
+							<span className="text-[11px] font-mono tabular-nums text-muted-foreground shrink-0">
+								{formatRelativeTime(run.startTime)}
+							</span>
+						</button>
+					</li>
+				);
+			})}
+		</ul>
+	);
+}

--- a/app/src/components/layout/context-bar/registry.test.tsx
+++ b/app/src/components/layout/context-bar/registry.test.tsx
@@ -47,13 +47,14 @@ const entitylessTab = (type: TabType): Tab => ({ id: "t1", type, entityId: null 
 const OTHER_TYPES: TabType[] = ["welcome", "dashboard", "variables", "settings"];
 
 describe("the context-bar section registry", () => {
-	it("ships the Phase 1 sections for a request tab, in reading order", () => {
+	it("ships the request-tab sections, in reading order", () => {
 		expect(sectionsForTab(tab("request")).map((s) => s.id)).toEqual([
 			"variables",
 			"auth",
 			"cookies",
 			"code",
 			"environment",
+			"recent-sends",
 		]);
 	});
 
@@ -86,9 +87,13 @@ describe("the context-bar section registry", () => {
 		// `ResponseStatusBar` paints the same status chip, duration and age in
 		// the response pane on the same screen, from the same stored run - so a
 		// section here could only ever be a poorer copy of it. Re-adding one is
-		// the regression this guards; the trend version (#380) is a different
-		// section with a different id.
-		expect(CONTEXT_BAR_SECTIONS.map((s) => s.id)).not.toContain("last-result");
+		// the regression this guards; `recent-sends` (#380) is a different
+		// section with a different id, and its own entry keeps this one honest -
+		// renaming it back to `last-result` fails here rather than silently
+		// retiring the guard.
+		const ids = CONTEXT_BAR_SECTIONS.map((s) => s.id);
+		expect(ids).not.toContain("last-result");
+		expect(ids).toContain("recent-sends");
 	});
 
 	it("gives every section a unique id, since the id is the persisted key", () => {

--- a/app/src/components/layout/context-bar/registry.ts
+++ b/app/src/components/layout/context-bar/registry.ts
@@ -26,6 +26,7 @@ import { CollectionContentsSection } from "./CollectionContentsSection";
 import { CollectionVariablesSection } from "./CollectionVariablesSection";
 import { CookiesSection } from "./CookiesSection";
 import { EnvironmentSection } from "./EnvironmentSection";
+import { RecentSendsSection } from "./RecentSendsSection";
 import { RunConfigSection } from "./RunConfigSection";
 import { RunSourceSection } from "./RunSourceSection";
 import { VariablesSection } from "./VariablesSection";
@@ -45,17 +46,18 @@ const onRunTab = (tab: Tab) => tab.type === "run" && tab.entityId !== null;
 
 /**
  * Order is the reading order on screen: what is in scope, who you are, what
- * rides along, and how to take it elsewhere.
+ * rides along, how to take it elsewhere, and what happened last time.
  *
- * There is deliberately no "last result" section. It would show the status,
- * duration and age of the last send - which is exactly what `ResponseStatusBar`
- * already paints in the response pane on the same screen, from the same
- * `StatusCodeBadge` and the same stored run (the builder restores that run into
- * the pane whenever nothing is in memory). A section with no state in which it
- * says something the pane does not say better is a duplicate, not a summary.
- * The version that would earn the slot is a *trend* across recent sends, which
- * the pane structurally cannot show - see #380 for that and the engine change
- * it needs first.
+ * There is still deliberately no "last result" section. It would show the
+ * status, duration and age of the last send - which is exactly what
+ * `ResponseStatusBar` already paints in the response pane on the same screen,
+ * from the same `StatusCodeBadge` and the same stored run (the builder restores
+ * that run into the pane whenever nothing is in memory). A section with no
+ * state in which it says something the pane does not say better is a duplicate,
+ * not a summary. `recent-sends` below is the version that earns the slot: a
+ * *trend* across several sends, which the pane structurally cannot show. It is
+ * a different section with a different id, and the guard against the old one
+ * stays.
  */
 export const CONTEXT_BAR_SECTIONS: readonly ContextBarSection[] = [
 	{
@@ -77,6 +79,12 @@ export const CONTEXT_BAR_SECTIONS: readonly ContextBarSection[] = [
 		title: "Environment",
 		appliesTo: onRequestTab,
 		Component: EnvironmentSection,
+	},
+	{
+		id: "recent-sends",
+		title: "Recent sends",
+		appliesTo: onRequestTab,
+		Component: RecentSendsSection,
 	},
 
 	/*

--- a/app/src/components/shared/response-viewer/index.ts
+++ b/app/src/components/shared/response-viewer/index.ts
@@ -66,6 +66,11 @@ export {
 	detectBodyType,
 	formatBody,
 	formatSize,
+	// The response pane's own latency wording ("34 ms", "5.00 s"). Exported so a
+	// surface outside the viewer - the context bar's Recent sends rows - states
+	// a latency the way the pane states it, instead of growing a second rule for
+	// when milliseconds become seconds.
+	formatResponseTime,
 	getMonacoLanguage,
 	buildRawRequest,
 	buildRawResponse,

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -95,10 +95,11 @@ const INVALIDATORS: Record<
 
 	/*
 	 * The history list polls on its own, so this is about immediacy there - but
-	 * `allRuns` (Settings' count) and `lastDesign` (a request tab's restored
-	 * response) are not polled at all, and an MCP-run request left both stale
-	 * indefinitely. Reports and time series are keyed per run and describe runs
-	 * that already existed, so they are deliberately not touched.
+	 * `allRuns` (Settings' count), `lastDesign` (a request tab's restored
+	 * response) and `recentDesign` (its Recent sends section) are not polled at
+	 * all, and an MCP-run request left them stale indefinitely. Reports and time
+	 * series are keyed per run and describe runs that already existed, so they
+	 * are deliberately not touched.
 	 */
 	run: (queryClient, event) => {
 		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
@@ -106,6 +107,9 @@ const INVALIDATORS: Record<
 		if (event.requestId) {
 			void queryClient.invalidateQueries({
 				queryKey: queryKeys.runs.lastDesign(event.requestId),
+			});
+			void queryClient.invalidateQueries({
+				queryKey: queryKeys.runs.recentDesign(event.requestId),
 			});
 		}
 	},

--- a/app/src/modules/history/main/DesignRunView.tsx
+++ b/app/src/modules/history/main/DesignRunView.tsx
@@ -248,6 +248,14 @@ export default function DesignRunView({ run }: DesignRunViewProps) {
 				// A resend is a new run, so History has to hear about it.
 				queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
 				queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
+				// And so does the request's Recent sends list, which is not
+				// polled - a replay from here is one of its rows. Only when the
+				// run links a request: a detached replay belongs to none.
+				if (run.requestId) {
+					queryClient.invalidateQueries({
+						queryKey: queryKeys.runs.recentDesign(run.requestId),
+					});
+				}
 				// Same gate as the builder's send path, from the same helper.
 				if (scriptsMayWriteVariables(preScriptParts, postScriptParts)) {
 					queryClient.invalidateQueries({ queryKey: queryKeys.environments.all });

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -264,6 +264,14 @@ export default function RequestBuilder() {
 					);
 				}
 
+				// This send is a new design run, and the context bar's Recent
+				// sends list is not polled - without this it would keep showing
+				// the sends from before this one for as long as the tab is open.
+				// The history list has its own 5s poll and needs nothing here.
+				queryClient.invalidateQueries({
+					queryKey: queryKeys.runs.recentDesign(fetchedRequest.id),
+				});
+
 				// Refresh variables so script-set values (e.g. pm.environment.set)
 				// appear in the UI - post-request scripts write them too, see the
 				// helper's note.

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -44,6 +44,8 @@ export {
 	runDetailOptions,
 	useRunReportQuery,
 	useLastDesignRunQuery,
+	useRecentDesignRunsQuery,
+	RECENT_DESIGN_RUN_LIMIT,
 	useDeleteRunMutation,
 	useStartScenarioRunMutation,
 	useInvalidateRuns,

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -48,6 +48,15 @@ export const queryKeys = {
 		// tab. Its own family keeps the two apart at the root.
 		lastDesign: (requestId: string) =>
 			[...queryKeys.runs.all, "lastDesign", requestId] as const,
+		// The last N design runs of one request, for the context bar's Recent
+		// sends section. Its own family for the same reason `lastDesign` has
+		// one: it caches a plain `RunListResponse`, and the delete-run patch
+		// walks everything under `lists()` as `InfiniteData`. `recentDesigns()`
+		// is the prefix to invalidate when the run set changes without a known
+		// request (a delete, a history clear).
+		recentDesigns: () => [...queryKeys.runs.all, "recentDesign"] as const,
+		recentDesign: (requestId: string) =>
+			[...queryKeys.runs.recentDesigns(), requestId] as const,
 		allRuns: () => [...queryKeys.runs.all, "allRuns"] as const,
 		details: () => [...queryKeys.runs.all, "detail"] as const,
 		detail: (id: string) => [...queryKeys.runs.details(), id] as const,

--- a/app/src/queries/runs.query.test.tsx
+++ b/app/src/queries/runs.query.test.tsx
@@ -14,6 +14,8 @@
  * - `useLastDesignRunQuery` must ask the server for exactly one row
  *   (`requestId` + `type=design` + `status=completed` + `limit=1`) and trust
  *   its start_time DESC order - no download-the-whole-list-and-filter.
+ * - `useRecentDesignRunsQuery` asks the same way for the last few, and
+ *   deliberately without the status filter - see its case below.
  * - `useRunsQuery` is an infinite query over the `{data, pagination}` envelope:
  *   `fetchNextPage` advances the offset, and `flattenRunPages` de-dupes rows
  *   that a head insertion can momentarily place in two refetched pages.
@@ -25,6 +27,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import {
 	useLastDesignRunQuery,
+	useRecentDesignRunsQuery,
+	RECENT_DESIGN_RUN_LIMIT,
 	useRunsQuery,
 	flattenRunPages,
 	runsPollInterval,
@@ -110,6 +114,44 @@ describe("useLastDesignRunQuery", () => {
 	it("does not fetch when there is no request id", () => {
 		renderHook(() => useLastDesignRunQuery(null), { wrapper: wrapper(makeClient()) });
 		expect(listRuns).not.toHaveBeenCalled();
+	});
+});
+
+describe("useRecentDesignRunsQuery", () => {
+	it("asks for one page of this request's design runs, with no status filter", async () => {
+		// No `status`: it takes one value, so filtering to `completed` would
+		// hide every failed send - which is most of what a trend is read for.
+		listRuns.mockResolvedValue(page([runRow("run_9")]));
+
+		const { result } = renderHook(() => useRecentDesignRunsQuery("req_1"), {
+			wrapper: wrapper(makeClient()),
+		});
+
+		await waitFor(() => expect(result.current.data?.data[0].id).toBe("run_9"));
+		expect(listRuns).toHaveBeenCalledTimes(1);
+		expect(listRuns).toHaveBeenCalledWith({
+			requestId: "req_1",
+			type: "design",
+			limit: RECENT_DESIGN_RUN_LIMIT,
+		});
+	});
+
+	it("does not fetch when there is no request id", () => {
+		renderHook(() => useRecentDesignRunsQuery(null), { wrapper: wrapper(makeClient()) });
+		expect(listRuns).not.toHaveBeenCalled();
+	});
+
+	it("keys itself outside the infinite-list prefix, like the last-design lookup", () => {
+		// It caches a plain `RunListResponse`, and the delete-run patch walks
+		// everything under `lists()` as `InfiniteData` - the exact shape clash
+		// that made `lastDesign` its own family.
+		const lists = queryKeys.runs.lists() as readonly unknown[];
+		const recent = queryKeys.runs.recentDesign("req_1") as readonly unknown[];
+		expect(recent.slice(0, lists.length)).not.toEqual([...lists]);
+		// ...and under the prefix a delete *does* invalidate, so a deleted run
+		// cannot linger in a section keyed by a request the delete never saw.
+		const family = queryKeys.runs.recentDesigns() as readonly unknown[];
+		expect(recent.slice(0, family.length)).toEqual([...family]);
 	});
 });
 

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -256,6 +256,42 @@ export function useLastDesignRunQuery(requestId: string | null | undefined) {
 	};
 }
 
+/**
+ * How many recent sends the context bar's trend shows. Small on purpose: the
+ * section answers "has this been failing, is it getting slower" at a glance,
+ * and History is where a longer list belongs.
+ */
+export const RECENT_DESIGN_RUN_LIMIT = 5;
+
+/**
+ * The last few design runs of one request, newest first - the rows behind the
+ * context bar's Recent sends section.
+ *
+ * **One list call and no report fetch.** Each row carries its own
+ * `resultSummary` (status code + latency) from the engine, which is the change
+ * that made this section affordable: the alternative was one `GET /runs/:id/report`
+ * per row, and that path loads and parses every result's `trace_data`.
+ *
+ * Deliberately **unfiltered by status**, unlike {@link useLastDesignRunQuery}:
+ * a failed send is exactly what a trend is for, and `status` takes one value,
+ * so filtering to `completed` would hide every failure. A run still in flight
+ * comes back too, with no `resultSummary`; the section renders its status
+ * rather than inventing an outcome for it.
+ */
+export function useRecentDesignRunsQuery(requestId: string | null | undefined) {
+	return useQuery({
+		// Its own key family, not `runs.list(...)` - see `queryKeys.runs.recentDesigns`.
+		queryKey: queryKeys.runs.recentDesign(requestId ?? ""),
+		queryFn: () =>
+			apiService.listRuns({
+				requestId: requestId!,
+				type: "design",
+				limit: RECENT_DESIGN_RUN_LIMIT,
+			}),
+		enabled: !!requestId,
+	});
+}
+
 // ============ Run Mutations ============
 
 /**
@@ -332,13 +368,19 @@ export function useDeleteRunMutation() {
 			queryClient.removeQueries({
 				queryKey: queryKeys.runs.report(deletedId),
 			});
+			// The Recent sends caches are keyed by request, and a deleted run
+			// gives no way back to one - so the whole family is invalidated
+			// rather than patched. Refetching a five-row list is cheaper than
+			// carrying a run-to-request map just to patch it.
+			void queryClient.invalidateQueries({ queryKey: queryKeys.runs.recentDesigns() });
 		},
 	});
 }
 
 /**
- * Invalidate every runs list (trigger refetch) - both the polled infinite list
- * and the all-runs Settings query.
+ * Invalidate every runs list (trigger refetch) - the polled infinite list, the
+ * all-runs Settings query, and the per-request Recent sends lists, which are
+ * their own family and would otherwise survive a cleared history.
  */
 export function useInvalidateRuns() {
 	const queryClient = useQueryClient();
@@ -346,5 +388,6 @@ export function useInvalidateRuns() {
 	return () => {
 		queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
 		queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
+		queryClient.invalidateQueries({ queryKey: queryKeys.runs.recentDesigns() });
 	};
 }

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -602,6 +602,29 @@ export interface Run {
 	environmentId?: string | null;
 	/** The exchange, present only for a design run once it has completed or failed. */
 	result?: RunResult;
+	/**
+	 * What a **design run's** list row says about its exchange - see
+	 * {@link RunResultSummary}. Never present on a load or collection run's row,
+	 * and never on `GET /runs/:id`, which attaches the whole {@link result}.
+	 */
+	resultSummary?: RunResultSummary;
+}
+
+/**
+ * The outcome of a design run's single exchange, carried by its **list row**
+ * from the paginated `GET /runs` (`get_runs_response`,
+ * `engine/src/http/routes/runs.cpp`).
+ *
+ * Two numbers rather than the whole {@link RunResult}: that one carries the
+ * exchange's `trace` - request and response bodies included - which is a
+ * per-row cost a list cannot take. A row with no outcome recorded (a send still
+ * in flight, or a result whose write failed) has **no `resultSummary` at all**,
+ * which is not the same as `statusCode: 0` - the wire uses that for a request
+ * that never reached a server.
+ */
+export interface RunResultSummary {
+	statusCode: number;
+	latencyMs: number;
 }
 
 /** The `{data, pagination}` envelope the paginated `GET /runs` returns. */

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -118,6 +118,7 @@ Sections are leaf components over the existing query layer - no bar-wide shared 
 | Cookies for this host (`cookies`) | `CookiesSection.tsx` - the active environment's jar filtered to the request's host, with a per-scope clear. Host filtering is an **approximation**, stated in the UI: libcurl applies the real domain/path/secure rules at transfer time. |
 | Code (`code`) | `CodeSection.tsx` - copy-as-curl / copy-as-fetch (below). |
 | Environment (`environment`) | `EnvironmentSection.tsx` - the active environment's name and a way into the Variables drawer. |
+| Recent sends (`recent-sends`) | `RecentSendsSection.tsx` - the last five design runs of this request, newest first: status chip, latency and age, each row opening that run in a History tab. One `GET /runs` call and no report fetch - status and latency ride on each row as `resultSummary` (see below). A run with no stored result reads "Sending…" or "No result" rather than a status-0 chip, which the wire uses for "reached no server". |
 
 **Collection tab**
 
@@ -143,7 +144,11 @@ The collection and run sections gate on `tab.entityId` as well as the type: a ta
 
 **There is deliberately no "last run" section on a collection tab**, still, now that the runner exists (#354). A collection's runs are not addressable: `GET /runs` filters by `requestId`, and a collection run's row links no request, so finding one means a substring search of every stored snapshot for the collection id - a scan per open bar, for a number History already shows. It earns the slot once the runs list can be filtered by collection.
 
-**There is deliberately no "last result" section.** Status, duration and age of the last send are what `ResponseStatusBar` already paints in the response pane on the same screen - same `StatusCodeBadge`, same stored run, since the builder restores that run into the pane whenever nothing is in memory. A section with no state in which it says something the pane does not say better is a duplicate, not a summary. What would earn the slot is a *trend* across recent sends, which the pane structurally cannot show; that needs the paginated `GET /runs` to carry each design run's result first (today only `GET /runs/:id` attaches it), so it is tracked separately in #380.
+**There is still deliberately no "last result" section**, and `recent-sends` is not one. Status, duration and age of the *last* send are what `ResponseStatusBar` already paints in the response pane on the same screen - same `StatusCodeBadge`, same stored run, since the builder restores that run into the pane whenever nothing is in memory. A section with no state in which it says something the pane does not say better is a duplicate, not a summary, which is why the specced one was built and removed in #344. What the pane structurally cannot show is *more than one send*, and that is the whole content of `recent-sends`: if it ever narrows to the latest run it is the removed section again. Its id is new rather than reused, so the `last-result` guard in `registry.test.tsx` keeps guarding.
+
+That section is affordable because the paginated `GET /runs` now carries each design run's outcome on its row (`resultSummary`: `statusCode` + `latencyMs`), added for it in #380. Before that, N rows meant N `GET /runs/:id/report` calls, and that path loads and JSON-parses every result's `trace_data`. Load and collection runs carry no `resultSummary` - their results are unbounded - and the engine's query cannot read them even if asked.
+
+**Freshness is wiring, not polling.** `runs.recentDesign(requestId)` is its own key family (like `runs.lastDesign`, and for the same `InfiniteData` shape-clash reason), so nothing under `runs.lists()` refreshes it: the builder's send path, the run view's replay, the MCP `run` event and the delete/clear-history paths each invalidate it explicitly. A new invalidation point for runs needs to touch it too, or the section silently shows the sends from before.
 
 #### Variables section
 

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -274,6 +274,13 @@ and instead carries `summary.scenario`
 only; the history row reads it because a collection run has no `url` or `method`
 for the ordinary row to show.
 
+A **design run's** list row carries one thing the detail route says at greater
+length: `resultSummary` (`{statusCode, latencyMs}`), the outcome of its single
+exchange. `GET /runs/:id` attaches the whole `result` instead, trace and bodies
+included, which is why the list carries the two numbers rather than that - and
+why the context bar's Recent sends section is one list call and no report fetch.
+Load and collection runs carry no `resultSummary`: their results are unbounded.
+
 `composeRequest` (`POST /compose`, issue #226) resolves `{{variables}}` and
 `inherit` auth engine-side and returns the payload the other two accept
 unchanged - every send site composes first, so nothing is interpolated twice.

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -803,6 +803,20 @@ sibling lists and a drop index into the minimal set of rows to rewrite.
   open request tab, and the delete-run patch walks that prefix as
   `InfiniteData`. Keeping the two shapes apart at the root is the rule - a
   prefix patch must never meet a cache shape it did not write.
+- **`useRecentDesignRunsQuery(requestId)`** - The last `RECENT_DESIGN_RUN_LIMIT`
+  (5) design runs of a request, newest first, behind the context bar's **Recent
+  sends** section. One filtered call (`?requestId=&type=design&limit=5`) and
+  **no report fetch**: each row carries its own `resultSummary` (`statusCode` +
+  `latencyMs`) from the engine, and the report path would load and JSON-parse
+  every result's `trace_data`, per row. Deliberately **unfiltered by status**,
+  unlike `useLastDesignRunQuery` - `status` takes one value, so filtering to
+  `completed` would hide every failed send, which is most of what a trend is
+  read for. Own key family (`queryKeys.runs.recentDesign(requestId)`) under the
+  `recentDesigns()` prefix, outside `runs.lists()`, for the same shape reason as
+  `lastDesign`. Not polled: the builder's send path, `DesignRunView`'s replay,
+  the MCP `run` event, `useDeleteRunMutation` and `useInvalidateRuns` (Settings'
+  *Clear run history*) each invalidate it, and a new run-writing path has to as
+  well or the section keeps showing the sends from before it.
 - **`useRunQuery(runId)`** / **`runDetailOptions(runId)`** - Fetch a single run
   (full `configSnapshot`). Same 404 contract as `requestDetailOptions`: only an
   `ApiError` with `statusCode === 404` becomes **`RunNotFoundError`** (test it
@@ -830,7 +844,10 @@ sibling lists and a drop index into the minimal set of rows to rewrite.
 - **`useDeleteRunMutation()`** - Delete a run. Patches every infinite-list cache
   variant in place (drops the row, decrements the mirrored `total`) plus the
   all-runs cache, and evicts the run's report. The list updater shape-guards
-  (`!Array.isArray(old.pages)`) as a belt to `lastDesign`'s braces.
+  (`!Array.isArray(old.pages)`) as a belt to `lastDesign`'s braces. The
+  `recentDesigns()` family is **invalidated rather than patched**: a deleted run
+  gives no way back to the request its section is keyed by, and refetching five
+  rows beats carrying a run-to-request map to patch them.
 
 **Deleting a run closes its tabs.** Both delete flows - `HistoryList`'s row
 delete and Settings' *Clear run history* - call
@@ -893,6 +910,8 @@ runs: {
   lists: () => ["runs", "list"],
   list: (filters = {}) => ["runs", "list", filters],      // keyed by its server-side filters (q)
   lastDesign: (requestId) => ["runs", "lastDesign", requestId],
+  recentDesigns: () => ["runs", "recentDesign"],           // prefix: invalidate every request's list
+  recentDesign: (requestId) => ["runs", "recentDesign", requestId],
   allRuns: () => ["runs", "allRuns"],
   detail: (id) => ["runs", "detail", id],
   report: (id) => ["runs", "report", id],
@@ -904,8 +923,9 @@ runs: {
 ```
 
 The `lists()` / `details()` levels exist to be invalidated as prefixes; what a
-query is keyed on is `list()` / `detail(id)`. `runs.lastDesign` sits under
-`runs.all` but deliberately **not** under `runs.lists()` - see below.
+query is keyed on is `list()` / `detail(id)`. `runs.lastDesign` and
+`runs.recentDesign` sit under `runs.all` but deliberately **not** under
+`runs.lists()` - see below.
 
 **Automatic Invalidation:**
 - Mutations automatically invalidate related queries (e.g., creating a request invalidates the collection's request list)
@@ -946,7 +966,7 @@ to keys through `lib/mcp-invalidation.ts`:
 | `collection` | `collections.all`, `requests.all` | A `delete_collection` cascades through descendants and their requests, and which rows those were is engine-side knowledge - the same reason `useDeleteCollectionMutation` invalidates coarsely |
 | `request` | `requests.listByCollection(collectionId)`, or `requests.lists()` when the call named no collection, plus `requests.detail(requestId)` when the call named one row | The same narrowing `useUpdateRequestMutation` does; without a named owner the owner is unknowable here. The detail key is for `update_request` / `delete_request`: it is `staleTime: Infinity`, so a restored tab would otherwise keep serving the copy it read on open |
 | `environment` | `environments.all`, `compose.all` | Variables are read through the detail cache as well as the list; `POST /compose` substitutes those same variables, and nothing refetches a composition on its own |
-| `run` | `runs.lists()`, `runs.allRuns()`, plus `runs.lastDesign(requestId)` when the call named one | The history list polls, but Settings' count and a request tab's restored response do not |
+| `run` | `runs.lists()`, `runs.allRuns()`, plus `runs.lastDesign(requestId)` and `runs.recentDesign(requestId)` when the call named one | The history list polls, but Settings' count, a request tab's restored response and its Recent sends list do not |
 | `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
 | `config` | `config.all` | |
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2216,6 +2216,19 @@ itself - a row that shipped every step's name, method and URL would undo the
 reason `summary` exists. The manifest stays on `GET /runs/:runId`. Each of the
 four keys is omitted when the stored snapshot has no such key.
 
+**`resultSummary`** is what a **design run's** row says about the exchange:
+`statusCode` and `latencyMs`, and nothing else. A design run is one request and
+one response, so its outcome fits on the row and a page of them costs one extra
+query; a load or collection run's results are many and unbounded, so its row
+carries no `resultSummary` at all and its result rows are never read to build
+one - the same split [GET /runs/:runId](#get-runsrunid) draws when it attaches
+`result`. The two numbers rather than that whole `result`: it carries the
+exchange's `trace`, request and response bodies included, which is a per-row
+cost a list cannot take. A design run with no stored result - still running, or
+one whose result write failed - **omits the key** rather than reporting
+`statusCode: 0`, which is the wire's own way of saying the request never reached
+a server.
+
 **Response (envelope):**
 ```json
 {
@@ -2239,6 +2252,17 @@ four keys is omitted when the stored snapshot has no such key.
         "maxRedirects": 10,
         "httpVersion": "auto"
       }
+    },
+    {
+      "id": "run_1234567891",
+      "requestId": "req_1234567890",
+      "environmentId": null,
+      "type": "design",
+      "status": "completed",
+      "startTime": 1234567892,
+      "endTime": 1234567893,
+      "summary": { "url": "https://api.example.com/users", "method": "GET", "httpVersion": "auto" },
+      "resultSummary": { "statusCode": 200, "latencyMs": 34.2 }
     }
   ],
   "pagination": { "total": 812, "limit": 50, "offset": 0, "hasMore": true, "returned": 50 }

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -13,6 +13,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <sqlite_orm/sqlite_orm.h>
@@ -32,6 +33,20 @@ struct RunFilter {
     std::optional<RunStatus> status;
     std::optional<std::string> request_id;
     std::optional<std::string> q;
+};
+
+/**
+ * The narrow outcome of a design run's single exchange: what came back and how
+ * long it took, and nothing else.
+ *
+ * Deliberately not `Result`. The paginated GET /runs list reads this for a
+ * whole page of rows at once, and a `Result` carries `trace_data` - the entire
+ * exchange, request and response bodies included - which would turn a list page
+ * into megabytes for a readout of two numbers.
+ */
+struct DesignResultOutcome {
+    int status_code;
+    double latency_ms;
 };
 
 /**
@@ -224,6 +239,27 @@ class Database {
     void add_results_batch (const std::vector<Result>& results,
     const std::vector<PendingResultBody>& bodies = {});
     std::vector<Result> get_results (const std::string& run_id);
+    /**
+     * @brief Status code and latency for a page of **design** runs, in one query.
+     *
+     * The paginated GET /runs list attaches each design run's outcome to its
+     * row (`resultSummary`), the way GET /runs/:id attaches the whole exchange.
+     * Three properties make that affordable, and all three are why this is not
+     * `get_results` in a loop:
+     *
+     * - Two columns, so `trace_data` is never read.
+     * - One statement for the whole page, so a page of 50 is one query.
+     * - The statement itself only ever matches results whose run is a design
+     *   run, so a load run's unbounded error rows cannot be pulled - by the
+     *   query, not by the caller remembering to filter (the guard at
+     *   GET /runs/:id is a caller-side one, and it has to be).
+     *
+     * A run with no result row yet (still running, or one whose write failed)
+     * is absent from the map rather than present with zeroes - "no outcome
+     * recorded" and "HTTP 0 in 0ms" are different answers.
+     */
+    std::unordered_map<std::string, DesignResultOutcome>
+    get_design_result_outcomes (const std::vector<std::string>& run_ids);
 
     // Captured response bodies for a run's sampled results. Deliberately not
     // reachable from get_results: the report path loads and parses every

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1216,6 +1216,32 @@ std::vector<Result> Database::get_results (const std::string& run_id) {
     return impl_->storage.get_all<Result> (where (c (&Result::run_id) == run_id));
 }
 
+std::unordered_map<std::string, DesignResultOutcome>
+Database::get_design_result_outcomes (const std::vector<std::string>& run_ids) {
+    std::unordered_map<std::string, DesignResultOutcome> outcomes;
+    if (run_ids.empty ()) {
+        return outcomes; // No statement at all rather than `IN ()`.
+    }
+
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    // The design-run subquery is inside the statement on purpose: it is what
+    // makes "a load run's results are never read" a property of the query
+    // rather than of every caller passing the right ids. Three columns, so a
+    // page of rows costs no trace_data.
+    auto rows = impl_->storage.select (
+    columns (&Result::run_id, &Result::status_code, &Result::latency_ms),
+    where (in (&Result::run_id, run_ids) &&
+    in (&Result::run_id, select (&Run::id, where (c (&Run::type) == RunType::Design)))));
+
+    for (const auto& row : rows) {
+        // A design run has exactly one result; keep the first if a row ever
+        // duplicates rather than letting the last write win silently.
+        outcomes.emplace (std::get<0> (row),
+        DesignResultOutcome{ std::get<1> (row), std::get<2> (row) });
+    }
+    return outcomes;
+}
+
 // ============================================================================
 // Captured response bodies - read only by GET /runs/:id/samples
 // ============================================================================

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -317,7 +317,9 @@ nlohmann::json serialize_run_row (const vayu::db::Run& run) {
  * default 50, capped at 500; offset floored at 0); `filter` holds the already
  * validated type/status/requestId/q constraints. Rows carry the compact
  * `summary` (nine keys) instead of the full `config_snapshot`, wrapped in the
- * same `{data, pagination}` envelope GET /runs/:id/metrics uses (post-#86).
+ * same `{data, pagination}` envelope GET /runs/:id/metrics uses (post-#86); a
+ * design run's row also carries `resultSummary` (statusCode + latencyMs), which
+ * is what a reader would otherwise fetch a report per row to learn.
  *
  * Extracted so the envelope shape, clamping and filtering are covered without
  * an in-process HTTP server - see runs_route_test.cpp. Exceptions propagate to
@@ -328,9 +330,27 @@ const vayu::db::RunFilter& filter, int64_t limit, int64_t offset) {
     const int64_t total = db.count_runs (filter);
     auto runs           = db.get_runs_paginated (filter, limit, offset);
 
+    // A design run is one exchange, so its outcome fits on its row and the page
+    // pays one extra query for all of them (get_design_result_outcomes). A load
+    // or scenario run's results are many and unbounded, so its row carries none
+    // - the same split GET /runs/:id draws with attach_design_result, and the
+    // reason `resultSummary` is the two numbers rather than the exchange.
+    std::vector<std::string> design_run_ids;
+    for (const auto& run : runs) {
+        if (run.type == vayu::RunType::Design) {
+            design_run_ids.push_back (run.id);
+        }
+    }
+    const auto outcomes = db.get_design_result_outcomes (design_run_ids);
+
     nlohmann::json data = nlohmann::json::array ();
     for (const auto& run : runs) {
-        data.push_back (serialize_run_row (run));
+        auto row = serialize_run_row (run);
+        if (const auto found = outcomes.find (run.id); found != outcomes.end ()) {
+            row["resultSummary"]["statusCode"] = found->second.status_code;
+            row["resultSummary"]["latencyMs"]  = found->second.latency_ms;
+        }
+        data.push_back (std::move (row));
     }
 
     nlohmann::json response;
@@ -778,7 +798,8 @@ void register_run_routes (RouteContext& ctx) {
      * concurrency/comment/httpVersion/followRedirects/maxRedirects) instead of
      * the full config_snapshot, wrapped in the `{data, pagination}` envelope.
      * See build_run_summary for the authoritative key list - keep this in step
-     * with it.
+     * with it. A design run's row also carries `resultSummary`
+     * (statusCode + latencyMs); see get_runs_response.
      *
      * Query params:
      * - limit: page size, default 50, capped at 500

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -85,6 +85,20 @@ class RunsRouteTest : public ::testing::Test {
         db_->create_run (run);
     }
 
+    /// One stored exchange for @p run_id. `trace_data` is deliberately large:
+    /// the list must never read this column, and a row that does shows up as a
+    /// payload, not as a failure.
+    void seed_result (const std::string& run_id, int status_code, double latency_ms) {
+        vayu::db::Result result;
+        result.run_id      = run_id;
+        result.timestamp   = 1000;
+        result.status_code = status_code;
+        result.status_text = "OK";
+        result.latency_ms  = latency_ms;
+        result.trace_data = R"({"response":{"body":")" + std::string (4096, 'x') + R"("}})";
+        db_->add_result (result);
+    }
+
     std::unique_ptr<vayu::db::Database> db_;
 };
 
@@ -234,6 +248,75 @@ TEST_F (RunsRouteTest, SummaryOmitsScenarioOnANonScenarioRun) {
 
     auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
     EXPECT_FALSE (body["data"][0]["summary"].contains ("scenario"));
+}
+
+// A design run is one exchange, so its row says what came back. Without this a
+// reader wanting a status code per row had to fetch a report per row, which
+// loads and parses every result's trace_data - the cost that kept this off the
+// list (#380).
+TEST_F (RunsRouteTest, DesignRowCarriesItsStatusCodeAndLatency) {
+    seed ({ .id = "run_design", .type = vayu::RunType::Design });
+    seed_result ("run_design", 503, 42.5);
+
+    auto [status, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    EXPECT_EQ (status, 200);
+    ASSERT_EQ (body["data"].size (), 1u);
+
+    const auto& row = body["data"][0];
+    ASSERT_TRUE (row.contains ("resultSummary"));
+    EXPECT_EQ (row["resultSummary"]["statusCode"], 503);
+    EXPECT_DOUBLE_EQ (row["resultSummary"]["latencyMs"].get<double> (), 42.5);
+    // The two numbers, not the exchange: `result` (with its trace) stays on
+    // GET /runs/:id, where one row's worth of bodies is one row's worth.
+    EXPECT_FALSE (row.contains ("result"));
+    EXPECT_FALSE (row["resultSummary"].contains ("trace"));
+    EXPECT_EQ (row["resultSummary"].size (), 2u);
+}
+
+// Each design row gets its own outcome - the page is one query, so a wrong key
+// here would show one run's status against another's row.
+TEST_F (RunsRouteTest, EachDesignRowGetsItsOwnOutcome) {
+    seed ({ .id = "run_first", .type = vayu::RunType::Design, .start_time = 1 });
+    seed ({ .id = "run_second", .type = vayu::RunType::Design, .start_time = 2 });
+    seed_result ("run_first", 200, 10.0);
+    seed_result ("run_second", 404, 20.0);
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    ASSERT_EQ (body["data"].size (), 2u);
+    EXPECT_EQ (body["data"][0]["id"], "run_second");
+    EXPECT_EQ (body["data"][0]["resultSummary"]["statusCode"], 404);
+    EXPECT_EQ (body["data"][1]["id"], "run_first");
+    EXPECT_EQ (body["data"][1]["resultSummary"]["statusCode"], 200);
+}
+
+// The load-run guard, at the level that enforces it. A load run's results are
+// unbounded (one row per error), so they must not be read to be discarded - and
+// that is a property of the statement, not of the caller remembering to filter:
+// asking for a load run's outcome by id returns nothing.
+TEST_F (RunsRouteTest, LoadRowCarriesNoOutcomeAndItsResultsAreNeverRead) {
+    seed ({ .id = "run_load", .type = vayu::RunType::Load });
+    seed ({ .id = "run_scenario", .type = vayu::RunType::Scenario, .start_time = 1 });
+    seed_result ("run_load", 500, 99.0);
+    seed_result ("run_load", 500, 98.0);
+    seed_result ("run_scenario", 200, 5.0);
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    ASSERT_EQ (body["data"].size (), 2u);
+    EXPECT_FALSE (body["data"][0].contains ("resultSummary"));
+    EXPECT_FALSE (body["data"][1].contains ("resultSummary"));
+
+    EXPECT_TRUE (
+    db_->get_design_result_outcomes ({ "run_load", "run_scenario" }).empty ());
+}
+
+// Still running, or a result whose write failed: absent, not `statusCode: 0`,
+// which is the wire's own way of saying "the request never reached a server".
+TEST_F (RunsRouteTest, DesignRowWithNoStoredResultOmitsTheKey) {
+    seed ({ .id = "run_running", .type = vayu::RunType::Design, .status = vayu::RunStatus::Running });
+
+    auto [_, body] = vayu::http::routes::get_runs_response (*db_, {}, 50, 0);
+    ASSERT_EQ (body["data"].size (), 1u);
+    EXPECT_FALSE (body["data"][0].contains ("resultSummary"));
 }
 
 TEST_F (RunsRouteTest, MalformedSnapshotYieldsEmptySummaryNot500) {


### PR DESCRIPTION
## Description

**Plan.** Root cause: the paginated `GET /runs` serializes rows without their exchange - `attach_design_result` is called only on `GET /runs/:id` - so a per-request trend built app-side would be `1` list call plus `N` report fetches, and the report path loads every result row for a run and JSON-parses each `trace_data`. That cost is why #344's "last result" section was app-only, and why it ended up a strictly poorer duplicate of `ResponseStatusBar` (built, found redundant, removed in PR #376). Approach: attach each **design** run's outcome to its list row as a narrowed `resultSummary` (`statusCode` + `latencyMs`), read for a whole page in one query, then add a `recent-sends` context-bar section over it. Rejected alternative: attaching the full `RunResult` the way `GET /runs/:id` does - it carries the exchange's `trace`, request and response bodies included, so a 50-row page becomes megabytes for a readout of two numbers. Also rejected: keeping the load-run guard purely caller-side (as `GET /runs/:id` must, since it fetches by id). Here the design-run filter lives *inside* the statement, so a load run's unbounded error rows cannot be read even if its id is passed in - verified by a test that asks for one and gets nothing.

**Engine.**
- `Database::get_design_result_outcomes(run_ids)` - three columns, one statement per page, self-guarding subquery on `runs.type = design`. `trace_data` is never read. A run with no result row is absent from the map rather than present with zeroes.
- `get_runs_response` collects the page's design-run ids, fetches once, and attaches `resultSummary` to those rows. Load and collection rows are unchanged.

**App (the "App changes" section of the issue).**
- `recent-sends` section (`RecentSendsSection.tsx`) on the request tab: the last 5 design runs, newest first, status chip + latency + age, each row opening that run in a History tab. **New id**, not `last-result` - the removed section's guard in `registry.test.tsx` tests that id specifically, and the test now also asserts `recent-sends` is present, so renaming it back fails rather than silently retiring the guard.
- `useRecentDesignRunsQuery` in its own key family (`queryKeys.runs.recentDesigns()` / `recentDesign(requestId)`), **not** under `runs.lists()` - the delete-run patch walks that prefix as `InfiniteData`, the reason `runs.lastDesign` was given its own family.
- Deliberately **unfiltered by status**, unlike `useLastDesignRunQuery`: `status` takes one value, so filtering to `completed` would hide every failed send - most of what a trend is read for. A row with no `resultSummary` reads "Sending…" / "No result" rather than a status-0 chip, which the wire uses for "reached no server".
- Because the family is outside `lists()`, nothing polls it: the builder's send path, `DesignRunView`'s replay, the MCP `run` event, `useDeleteRunMutation` and `useInvalidateRuns` (Settings' *Clear run history*) each invalidate it. Without that wiring the section would show the sends from before the current one for as long as the tab stayed open.
- `formatResponseTime` is now exported from the response-viewer barrel so the rows word a latency exactly as the response pane does, instead of a second ms-to-s rule living here.

No deviation from the issue spec.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green on this branch (`129edb6` base):

- Engine: `python build.py -e -t` then `ctest --preset linux-dev` - **1093/1093 passed** (123.66s). Four new cases in `runs_route_test.cpp`: a design row carries its status code and latency (and only those two keys, no `result`, no trace); each design row gets its own outcome; a load and a scenario row carry none *and* `get_design_result_outcomes` returns nothing when handed their ids; a design run with no stored result omits the key.
- App: `pnpm test` - **3307/3307 passed, 344 files**; `pnpm type-check`, `pnpm lint`, `pnpm format:check` (touched files) clean. New: `RecentSendsSection.test.tsx` (7 cases) and 3 cases in `runs.query.test.tsx`; `registry.test.tsx` updated for the new entry.
- Mutation-checked, both engine halves rebuilt and re-run: removing the subquery from the DB statement reddens `LoadRowCarriesNoOutcomeAndItsResultsAreNeverRead`; removing the row attachment reddens `DesignRowCarriesItsStatusCodeAndLatency` and `EachDesignRowGetsItsOwnOutcome`. Both restored afterwards.
- Not run locally: `mkdocs build --strict` (mkdocs is not installed in this environment). The docs edits add no page, link or anchor - prose, one table row and one JSON block - so CI's docs gate is the check on them.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the `GET /runs` row shape, `resultSummary` and why it is not `result`), `docs/app/COMPONENTS.md` (the section table row, and the "no last result section" paragraph rewritten rather than left contradicting the new entry), `docs/app/state-management.md` (the hook, the key families, the delete/invalidations), `docs/app/api-integration.md` (what a design row carries that the detail route says at greater length).

## Related Issues
Closes #380

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxKU1AcgN4hifkrkUGUAAZ)_