### PR TITLE
refactor(engine/tests): one definition of the scratch-database file set

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -23,6 +23,10 @@ engine/
 - Install the git pre-commit hook: `bash scripts/install-git-hooks.sh`
 - vcpkg manages all C++ dependencies - do not add one without updating
   `engine/vcpkg.json`
+- A fixture that opens a scratch `Database` cleans up with
+  `vayu::tests::remove_database_files` (`engine/tests/temp_database.hpp`) - never
+  a hand-written suffix list. An opened database writes six files, not the four
+  the old copies listed, and eight of those twenty-two copies were wrong (#413).
 
 ## HTTP API
 

--- a/engine/tests/collections_route_test.cpp
+++ b/engine/tests/collections_route_test.cpp
@@ -22,13 +22,13 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <optional>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -57,9 +57,7 @@ class CollectionsRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     // Persist a collection with an optional parent. Bypasses the route so tests

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -9,12 +9,12 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/types.hpp"
 
@@ -46,9 +46,7 @@ class ConfigRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
     std::unique_ptr<vayu::db::Database> db_;
 };

--- a/engine/tests/db_concurrency_test.cpp
+++ b/engine/tests/db_concurrency_test.cpp
@@ -18,11 +18,11 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
-#include <filesystem>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 namespace vayu::db {
@@ -50,9 +50,7 @@ class DatabaseConcurrencyTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     std::unique_ptr<Database> db_;

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -13,42 +13,21 @@
 #include <utility>
 #include <vector>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 namespace vayu::db {
 namespace {
 const std::string TEST_DB_PATH = "test_vayu.db";
-const std::string TEST_DB_BACKUP_PATH = "test_vayu.db.bak";
 
 class DatabaseTest : public ::testing::Test {
     protected:
     void SetUp () override {
-        // Ensure clean state
-        if (std::filesystem::exists (TEST_DB_PATH)) {
-            std::filesystem::remove (TEST_DB_PATH);
-        }
-        if (std::filesystem::exists (TEST_DB_PATH + "-wal")) {
-            std::filesystem::remove (TEST_DB_PATH + "-wal");
-        }
-        if (std::filesystem::exists (TEST_DB_PATH + "-shm")) {
-            std::filesystem::remove (TEST_DB_PATH + "-shm");
-        }
+        vayu::tests::remove_database_files (TEST_DB_PATH);
     }
 
     void TearDown () override {
-        // Cleanup
-        if (std::filesystem::exists (TEST_DB_PATH)) {
-            std::filesystem::remove (TEST_DB_PATH);
-        }
-        if (std::filesystem::exists (TEST_DB_PATH + "-wal")) {
-            std::filesystem::remove (TEST_DB_PATH + "-wal");
-        }
-        if (std::filesystem::exists (TEST_DB_PATH + "-shm")) {
-            std::filesystem::remove (TEST_DB_PATH + "-shm");
-        }
-        if (std::filesystem::exists (TEST_DB_BACKUP_PATH)) {
-            std::filesystem::remove (TEST_DB_BACKUP_PATH);
-        }
+        vayu::tests::remove_database_files (TEST_DB_PATH);
     }
 };
 
@@ -1051,6 +1030,58 @@ TEST_F (DatabaseTest, UpdateRunSummaryForMissingRunIsIgnored) {
     // A run deleted while its worker was finishing must not create a row or throw.
     EXPECT_NO_THROW (db.update_run_summary ("run_gone", R"({"total_requests":1})"));
     EXPECT_FALSE (db.get_run ("run_gone").has_value ());
+}
+
+// ==================== Scratch-file cleanup ====================
+
+// `remove_database_files` is the single definition of what a scratch Database
+// leaves on disk, replacing ~22 hand-copied suffix lists of which eight were
+// wrong (#379, #413). Nothing else would notice if it drifted: a fixture with
+// an incomplete list still passes, it just leaks - and `engine/.gitignore` now
+// keeps those leaks out of `git status`, so the previous tell is gone too.
+//
+// The assertion deliberately does *not* name the suffixes - a second copy of
+// the list is the defect this fixes. It scans the directory instead, so a
+// Database that grows a new sidecar fails here rather than leaking quietly.
+TEST (ScratchDatabaseCleanup, RemovesEveryFileAnOpenedDatabaseLeavesBehind) {
+    namespace fs = std::filesystem;
+
+    // A directory of its own, so "everything named like the database" is an
+    // unambiguous question and a stray file cannot be mistaken for a leak.
+    const fs::path dir  = "test_scratch_cleanup_dir";
+    const fs::path stem = dir / "test_scratch.db";
+    fs::remove_all (dir);
+    fs::create_directories (dir);
+
+    auto leftovers = [&] {
+        std::set<std::string> names;
+        for (const auto& entry : fs::directory_iterator (dir))
+            names.insert (entry.path ().filename ().string ());
+        return names;
+    };
+
+    // Opened twice: the backup is written from an *existing* database, so a
+    // single open would not produce the `.bak` this is here to catch.
+    for (int i = 0; i < 2; ++i) {
+        Database db (stem.string ());
+        db.init ();
+    }
+
+    // The scan must have seen something, or "nothing left over" below is
+    // vacuously true - the failure mode CLAUDE.md calls out for source guards.
+    const auto written = leftovers ();
+    ASSERT_FALSE (written.empty ()) << "the database wrote nothing; the test proves nothing";
+    EXPECT_TRUE (written.count ("test_scratch.db.bak"))
+    << "no backup was written, so this run would not catch a missing `.bak`";
+
+    vayu::tests::remove_database_files (stem.string ());
+
+    const auto remaining = leftovers ();
+    EXPECT_TRUE (remaining.empty ())
+    << "remove_database_files left " << remaining.size ()
+    << " file(s) behind, starting with " << *remaining.begin ();
+
+    fs::remove_all (dir);
 }
 
 } // namespace

--- a/engine/tests/error_shape_route_test.cpp
+++ b/engine/tests/error_shape_route_test.cpp
@@ -23,13 +23,13 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/routes.hpp"
 
@@ -75,9 +75,7 @@ class ErrorShapeRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     /**

--- a/engine/tests/globals_route_test.cpp
+++ b/engine/tests/globals_route_test.cpp
@@ -20,13 +20,13 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -57,9 +57,7 @@ class GlobalsRouteTest : public ::testing::Test {
     }
 
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     /** The variables blob as it actually sits in the database. */

--- a/engine/tests/import_apply_route_test.cpp
+++ b/engine/tests/import_apply_route_test.cpp
@@ -31,13 +31,13 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -70,9 +70,7 @@ class ImportApplyRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     /** Total rows across the three imported resources. */

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 
 #include "mock_server.hpp"
+#include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
@@ -47,9 +48,7 @@ class LoadStrategyTest : public ::testing::Test {
     }
 
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::remove ((TEST_DB_PATH + suffix).c_str ());
-        }
+        vayu::tests::remove_database_files (TEST_DB_PATH);
     }
 
     std::unique_ptr<SlowMockServer> mock_server;

--- a/engine/tests/oauth_authorize_test.cpp
+++ b/engine/tests/oauth_authorize_test.cpp
@@ -9,12 +9,12 @@
 #include <httplib.h>
 
 #include <chrono>
-#include <filesystem>
 #include <string>
 #include <thread>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/http/oauth_authorize.hpp"
 
 using nlohmann::json;
@@ -82,8 +82,7 @@ class OAuthAuthorizeTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" })
-            std::filesystem::remove (std::string (DB_PATH) + s);
+        vayu::tests::remove_database_files (DB_PATH);
     }
     // db_ declared before the manager is used in each test so the manager (with
     // any live listener capturing db_) is torn down first.

--- a/engine/tests/oauth_client_test.cpp
+++ b/engine/tests/oauth_client_test.cpp
@@ -8,7 +8,6 @@
 #include <httplib.h>
 
 #include <chrono>
-#include <filesystem>
 #include <map>
 #include <string>
 #include <thread>
@@ -16,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/http/oauth_client.hpp"
 
 using nlohmann::json;
@@ -133,9 +133,7 @@ class OAuthClientTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     json cc_config (const MockTokenServer& idp, const std::string& path = "/token") {

--- a/engine/tests/oauth_route_test.cpp
+++ b/engine/tests/oauth_route_test.cpp
@@ -5,12 +5,12 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -37,9 +37,7 @@ class OAuthRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
     std::unique_ptr<vayu::db::Database> db_;
 };

--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -40,7 +40,6 @@
 
 #include <chrono>
 #include <condition_variable>
-#include <filesystem>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -52,6 +51,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -90,9 +90,7 @@ class ReorderRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     /** Creates a collection through the real create core and returns its id. */

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -28,6 +28,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/utils/json.hpp"
@@ -141,9 +142,7 @@ class RequestComposerTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void seed_collection (const std::string& id,

--- a/engine/tests/requests_route_test.cpp
+++ b/engine/tests/requests_route_test.cpp
@@ -16,12 +16,12 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -50,9 +50,7 @@ class RequestsRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     // Persist a minimal request under a known collection and return its id.

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -41,7 +41,6 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
@@ -49,6 +48,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/types.hpp"
 
@@ -112,10 +112,7 @@ class ResourceWriteRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::error_code ec;
-            std::filesystem::remove (std::string (DB_PATH) + suffix, ec);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     /** Creates a collection and returns its id - the parent most tests need. */

--- a/engine/tests/response_capture_test.cpp
+++ b/engine/tests/response_capture_test.cpp
@@ -21,7 +21,6 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <set>
 #include <string>
@@ -29,6 +28,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/db/database.hpp"
 
@@ -81,9 +81,7 @@ class ResponseCaptureTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void seed_run (const std::string& id) {

--- a/engine/tests/run_manager_test.cpp
+++ b/engine/tests/run_manager_test.cpp
@@ -2,9 +2,9 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <filesystem>
 #include <thread>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
 
@@ -257,8 +257,7 @@ TEST (BuildTickPayload, WrapsStatsAsSseEventWithOffsetId) {
 // keeps ticking and stays open until is_running goes false.
 TEST (CollectMetrics, StaysOpenUntilTheStopDrainCompletes) {
     const std::string db_path = "test_collect_metrics_drain.db";
-    for (const char* s : { "", "-wal", "-shm", ".bak" })
-        std::filesystem::remove (db_path + s);
+    vayu::tests::remove_database_files (db_path);
 
     vayu::db::Database db (db_path);
     db.init ();
@@ -292,8 +291,7 @@ TEST (CollectMetrics, StaysOpenUntilTheStopDrainCompletes) {
 
     EXPECT_TRUE (ctx->closed.load ());
     ctx->event_loop.reset ();
-    for (const char* s : { "", "-wal", "-shm", ".bak" })
-        std::filesystem::remove (db_path + s);
+    vayu::tests::remove_database_files (db_path);
 }
 
 // The window is only useful if the run actually reads it. collect_metrics must
@@ -301,8 +299,7 @@ TEST (CollectMetrics, StaysOpenUntilTheStopDrainCompletes) {
 // every run keeps the built-in default however the user configured it.
 TEST (CollectMetrics, SizesTheReplayRingFromTheConfiguredWindow) {
     const std::string db_path = "test_collect_metrics_window.db";
-    for (const char* s : { "", "-wal", "-shm", ".bak" })
-        std::filesystem::remove (db_path + s);
+    vayu::tests::remove_database_files (db_path);
 
     vayu::db::Database db (db_path);
     db.init ();
@@ -335,8 +332,7 @@ TEST (CollectMetrics, SizesTheReplayRingFromTheConfiguredWindow) {
     ctx->is_running = false;
     metrics.join ();
     ctx->event_loop.reset ();
-    for (const char* s : { "", "-wal", "-shm", ".bak" })
-        std::filesystem::remove (db_path + s);
+    vayu::tests::remove_database_files (db_path);
 }
 
 TEST (RunManagerRetention, BackgroundSweeperEvictsWithoutExternalTriggers) {

--- a/engine/tests/run_shutdown_test.cpp
+++ b/engine/tests/run_shutdown_test.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <thread>
@@ -26,6 +25,7 @@
 #include <nlohmann/json.hpp>
 
 #include "mock_server.hpp"
+#include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
@@ -59,9 +59,7 @@ class RunShutdownTest : public ::testing::Test {
     }
 
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     // A row for the run, so the worker's status writes have something to land

--- a/engine/tests/run_stop_test.cpp
+++ b/engine/tests/run_stop_test.cpp
@@ -20,7 +20,6 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <thread>
@@ -30,6 +29,7 @@
 #include <nlohmann/json.hpp>
 
 #include "mock_server.hpp"
+#include "temp_database.hpp"
 #include "vayu/core/load_strategy.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
@@ -199,15 +199,13 @@ class RunStopAccountingTest : public EventLoopStopTest {
 
     void SetUp () override {
         EventLoopStopTest::SetUp ();
-        std::filesystem::remove (DB_PATH);
+        vayu::tests::remove_database_files (DB_PATH);
         db = std::make_unique<vayu::db::Database> (DB_PATH);
         db->init ();
     }
     void TearDown () override {
         db.reset ();
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
         EventLoopStopTest::TearDown ();
     }
 
@@ -339,9 +337,7 @@ class DeleteRunTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void seed (const std::string& id, vayu::RunStatus status) {

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -16,12 +16,12 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/utils/json.hpp"
@@ -58,9 +58,7 @@ class RunsRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     struct RunSpec {

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -25,13 +25,13 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/scenario_plan.hpp"
 #include "vayu/db/database.hpp"
@@ -56,9 +56,7 @@ class ScenarioPlanTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void seed_collection (const std::string& id,

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -23,7 +23,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <filesystem>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -35,6 +34,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -147,9 +147,7 @@ class ScenarioRunnerTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void seed_collection (const std::string& id, const std::string& variables = "") {

--- a/engine/tests/script_info_test.cpp
+++ b/engine/tests/script_info_test.cpp
@@ -17,12 +17,12 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/routes.hpp"
@@ -75,10 +75,7 @@ class ScriptRequestNameTest : public ::testing::Test {
     }
 
     static void cleanup () {
-        std::error_code ec;
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix, ec);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     std::unique_ptr<vayu::db::Database> db_;

--- a/engine/tests/script_variables_test.cpp
+++ b/engine/tests/script_variables_test.cpp
@@ -22,12 +22,12 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/routes.hpp"
@@ -176,9 +176,7 @@ class PersistScriptVariablesTest : public ::testing::Test {
     }
 
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     std::string stored_collection_variables () {
@@ -368,9 +366,7 @@ class ScriptVariableScopesTest : public ::testing::Test {
     }
 
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void add_collection (const std::string& id,

--- a/engine/tests/stats_route_test.cpp
+++ b/engine/tests/stats_route_test.cpp
@@ -20,13 +20,13 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
 
@@ -54,9 +54,7 @@ class StatsRouteTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     // Persist a load run with the given id and return it.

--- a/engine/tests/temp_database.hpp
+++ b/engine/tests/temp_database.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+/**
+ * @file temp_database.hpp
+ * @brief The scratch-database file set, in one place.
+ *
+ * A `vayu::db::Database` opened at `p` writes `p` plus SQLite's `-wal` / `-shm`
+ * sidecars, and its constructor copies all three to a `p.bak` backup at open
+ * time (`Database::Database`, `engine/src/db/database.cpp`) - so a test that
+ * merely *opens* one has already written a second trio.
+ *
+ * That set used to be hand-copied into every fixture's `cleanup()`, and eight
+ * of the twenty-two copies were missing `.bak` (#379, #413) - each one leaking
+ * a file per run, one of which reached `master` as a tracked artifact. The set
+ * lives here now so a fixture cannot get it wrong by copying a neighbour that
+ * already had.
+ */
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+namespace vayu::tests {
+
+/**
+ * Removes every file a `vayu::db::Database` opened at @p path can leave behind.
+ *
+ * Absent files are not an error, so this is equally usable from `SetUp` (before
+ * anything exists) and `TearDown`. Filesystem errors are swallowed rather than
+ * thrown: this runs on teardown paths, where an exception would abort the
+ * binary instead of failing one test.
+ *
+ * Close the `Database` first - on Windows an open handle blocks the delete.
+ */
+inline void remove_database_files (const std::string& path) {
+    // The backup is a full copy, sidecars included, so the set is the SQLite
+    // trio twice over - `path` and `path.bak`. The hand-copied lists this
+    // replaced all stopped at a bare `.bak`, which leaves `.bak-wal` /
+    // `.bak-shm` behind whenever a WAL exists at open time.
+    for (const std::string& base : { path, path + ".bak" }) {
+        for (const char* suffix : { "", "-wal", "-shm" }) {
+            std::error_code ec;
+            std::filesystem::remove (base + suffix, ec);
+        }
+    }
+}
+
+} // namespace vayu::tests

--- a/engine/tests/transient_execute_test.cpp
+++ b/engine/tests/transient_execute_test.cpp
@@ -39,13 +39,13 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/types.hpp"
@@ -116,9 +116,7 @@ class RecordDesignResultTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* suffix : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + suffix);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     // A run row in the state `POST /execute` leaves it in before the exchange.

--- a/engine/tests/tree_order_test.cpp
+++ b/engine/tests/tree_order_test.cpp
@@ -40,6 +40,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "temp_database.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -86,9 +87,7 @@ class TreeOrderTest : public ::testing::Test {
         cleanup ();
     }
     static void cleanup () {
-        for (const char* s : { "", "-wal", "-shm", ".bak" }) {
-            std::filesystem::remove (std::string (DB_PATH) + s);
-        }
+        vayu::tests::remove_database_files (DB_PATH);
     }
 
     void seed_collection (const std::string& id,


### PR DESCRIPTION
## Description

**Plan.** The root cause is that "what a scratch `Database` leaves on disk" had ~22 copies under `engine/tests/`, in three spellings, and 8 were wrong - the repo's own "a hand-rolled copy of a primitive does not receive the primitive's fixes" rule with a measured 36% failure rate. The approach is the issue's preferred one: a header-only free function beside `mock_server.hpp` / `echo_server.hpp`, and every fixture's `cleanup()` becomes a call to it. I rejected the RAII `TempDatabase` alternative because the defect is a *wrong suffix list*, not a *forgotten call* - RAII fixes the failure mode that wasn't happening, at the cost of reshaping every fixture's member layout on top of an already-wide sweep.

**The set is six files, not four.** Tracing `Database`'s constructor before editing turned up something the issue's snapshot didn't have: the backup goes through `copy_db_files`, which copies the `-wal` and `-shm` sidecars alongside the main file (`engine/src/db/database.cpp:416-425`). So `p.bak-wal` / `p.bak-shm` are reachable whenever a WAL exists at open time, and *every* hand-copied list - all 22, including the 8 that PR #412 corrected - stopped at a bare `.bak`. `.gitignore`'s backstop patterns (`test_*.db`, `-wal`, `-shm`, `.db.bak`) stop there too, so unlike the `.bak` leak these two would have shown up as untracked files rather than being hidden. The helper expresses the set as the SQLite trio twice over rather than a flat list of four, so it cannot be short again. I left the ignore patterns alone - the issue puts them out of scope, and with the helper removing the files they never reach `git status`.

**Blast radius.** Test-only: no production code, no `CMakeLists` change (header-only, included relatively like `mock_server.hpp`). 31 call sites across 26 files, plus two irregular ones the mechanical sweep couldn't reach - `db_test.cpp`, which spelled the same set as guarded `exists()`-then-`remove` calls with `.bak` split into its own constant, and `RunStopAccountingTest::SetUp`, which removed only the main file and so opened on top of a previous run's sidecars.

## Type of Change

- [x] Bug fix (a latent one - leaked files, not a wrong result)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (one line in `engine/CLAUDE.md`)

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**1125/1125 passed** - 1124 before this change, plus the one test described below. No test was added or removed by the sweep itself (`git diff` shows 0 added and 0 removed `TEST`/`TEST_F` macros).

A full run from a clean tree leaves **nothing** behind: `find . -name 'test_*.db*'` returns empty, which is a stronger check than `git status` because `find` ignores the ignore patterns entirely.

**Mutation check.** Dropping `.bak` from the single definition and re-running: the suite still reports **31/31 passed**, and `test_delete_run.db.bak`, `test_reorder_route.db.bak` and `test_globals_route.db.bak` are left in `engine/build`. That is the whole problem in one result - a wrong list is invisible to the suite, and since PR #412 it is invisible to `git status` too.

**Deliberate deviation from the issue spec.** The issue says "no new test" and "same test count". I added exactly one, `ScratchDatabaseCleanup.RemovesEveryFileAnOpenedDatabaseLeavesBehind`, because the mutation check above shows the helper would otherwise be completely unguarded: consolidating 22 wrong-able copies into 1 wrong-able copy is a real improvement, but the remaining copy still has no way to fail loudly. The test opens a database twice (the backup is written from an *existing* database, so one open would not produce a `.bak`) in a directory of its own, asserts the scan saw something non-empty - including the `.bak` specifically, so a run that wrote no backup fails rather than passing vacuously - then calls the helper and asserts the directory is empty. It deliberately does **not** name the suffixes; it scans, so it cannot drift from the helper the way the fixtures did, and a `Database` that grows a new sidecar fails here instead of leaking quietly.

**Pre-existing warnings, not fixed.** Two `-Wall` warnings appear when the test TUs recompile: `import_apply_route_test.cpp` (`-Wrange-loop-construct` on `for (const json bad_shape : ...)`) and `script_variables_test.cpp` (`-Wmissing-field-initializers` on `vayu::Variable::created_at`). Both reproduce verbatim on the base commit - confirmed by stashing this branch and rebuilding - at lines 399 and 285, which this PR shifts to 397 and 283 purely by inserting an include. Untouched here.

Formatting: the same 16 files were clang-format-dirty before and after this change, so nothing newly diverged and nothing pre-existing was reformatted, per the repo rule against formatting files that were not already clean.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (one, justified above)
- [x] I have updated documentation (`engine/CLAUDE.md` names the helper as the convention for new fixtures, as the issue anticipated)

## Related Issues

Closes #413

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHK5uiyt3c1dXdbJbcRUdK)_