### PR TITLE
test(engine/app): extend the tree-order fixture with post-drag shapes

### DIFF
--- a/app/src/modules/collections/CollectionTree.folders-first.test.tsx
+++ b/app/src/modules/collections/CollectionTree.folders-first.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A folder's subfolders and its requests are two separately ordered blocks, and
+ * the tree renders every subfolder above every request (issue #364's fourth
+ * tracking criterion, #426).
+ *
+ * This is what keeps a drag honest. `reorder-math.ts` plans against one block at
+ * a time and renumbers it dense `0..n-1`, so after a reorder a request and a
+ * subfolder in the same folder hold the *same* `order` values - the column
+ * cannot say which of the two comes first, and only the render decides. Sorting
+ * the two blocks together on `order` is therefore not a near-miss but a
+ * different tree: here the request holds a lower `order` than the subfolder, so
+ * a merged sort would lift it above the folder, and a drop planned against the
+ * block the user saw would land somewhere else.
+ *
+ * The engine cannot express this - collections and requests are different
+ * tables, so `tree-order-conformance.json` pins one block at a time and this
+ * pins the relationship between them.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabsStore } from "@/stores";
+import { useCollectionsStore } from "./collections-store";
+import CollectionTree from "./CollectionTree";
+
+// The post-drag collision: inside "acme", the request sits at order 0 and the
+// subfolder at order 1. Both blocks are dense, which is exactly what a reorder
+// leaves behind - the numbers agree only because they count different things.
+const collections = [
+	{ id: "acme", name: "Acme", order: 0 },
+	{ id: "billing", name: "Billing", parentId: "acme", order: 1 },
+];
+const requests = new Map([
+	["acme", [{ id: "r-ping", collectionId: "acme", name: "Ping", method: "GET", order: 0 }]],
+]);
+
+vi.mock("@/queries", () => ({
+	useReorderMutation: () => ({ mutate: vi.fn(), isPending: false }),
+	useCollectionsQuery: () => ({
+		data: collections,
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: requests }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderTree() {
+	return render(
+		<QueryClientProvider
+			client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+		>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	useCollectionsStore.setState({ expandedCollectionIds: new Set(["acme"]) });
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+});
+
+describe("subfolders and requests are separate blocks, folders first", () => {
+	it("renders a subfolder above a request that holds a lower order", () => {
+		renderTree();
+
+		const folder = document.querySelector<HTMLElement>('[data-collection-id="billing"]')!;
+		const request = document.querySelector<HTMLElement>('[data-request-id="r-ping"]')!;
+		expect(folder).not.toBeNull();
+		expect(request).not.toBeNull();
+
+		// DOCUMENT_POSITION_FOLLOWING: the request comes after the folder in the
+		// rendered tree, despite ordering ahead of it on the column alone.
+		expect(
+			folder.compareDocumentPosition(request) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	});
+
+	it("keeps both rows in the same group, so the split is render-order only", () => {
+		renderTree();
+
+		// If the blocks were merged and sorted, or split into two groups, the
+		// numbering below would not be a single run of two.
+		const folder = document.querySelector<HTMLElement>('[data-collection-id="billing"]')!;
+		const request = document.querySelector<HTMLElement>('[data-request-id="r-ping"]')!;
+		expect(folder).toHaveAttribute("aria-posinset", "1");
+		expect(request).toHaveAttribute("aria-posinset", "2");
+		expect(folder).toHaveAttribute("aria-setsize", "2");
+		expect(request).toHaveAttribute("aria-setsize", "2");
+	});
+});

--- a/app/src/types/tree-order.conformance.test.ts
+++ b/app/src/types/tree-order.conformance.test.ts
@@ -59,7 +59,7 @@ function toRow(row: ConformanceCase["rows"][number]): OrderedTreeRow {
 
 describe("tree-order conformance fixture", () => {
 	it("scanned a non-empty fixture (guards the scan itself)", () => {
-		expect(fixture.cases.length).toBeGreaterThanOrEqual(5);
+		expect(fixture.cases.length).toBeGreaterThanOrEqual(12);
 		for (const c of fixture.cases) {
 			expect(c.rows.length).toBeGreaterThan(1);
 			expect(c.expected).toHaveLength(c.rows.length);

--- a/engine/tests/fixtures/tree-order-conformance.json
+++ b/engine/tests/fixtures/tree-order-conformance.json
@@ -1,5 +1,5 @@
 {
-	"description": "The one sidebar/scenario ordering rule, read by both suites. Rows sort by `order` ascending, ties by `createdAt` ascending, remaining ties by `id` ascending under byte-wise (SQLite BINARY) comparison. Engine side: engine/tests/tree_order_test.cpp inserts each case's rows into the collections and the requests table and reads them back through Database::get_collections / get_requests_in_collection, so the SQL ORDER BY is what is being asserted. Renderer side: app/src/types/tree-order.conformance.test.ts sorts the same rows with compareTreeOrder. A rule that changes on one side and not the other fails here or in ctest, never in a user's sidebar.",
+	"description": "The one sidebar/scenario ordering rule, read by both suites. Rows sort by `order` ascending, ties by `createdAt` ascending, remaining ties by `id` ascending under byte-wise (SQLite BINARY) comparison. Engine side: engine/tests/tree_order_test.cpp inserts each case's rows into the collections and the requests table and reads them back through Database::get_collections / get_requests_in_collection, so the SQL ORDER BY is what is being asserted. Renderer side: app/src/types/tree-order.conformance.test.ts sorts the same rows with compareTreeOrder. A rule that changes on one side and not the other fails here or in ctest, never in a user's sidebar. The first seven cases are the pre-drag ordering contract (#360); the rest are shapes drag-and-drop actually produces (#364/#426), each derived from app/src/modules/collections/reorder-math.ts and the renumber in engine/src/http/routes/reorder.cpp rather than invented - a drop leaves the block dense with distinct orders, so what these pin is that the two former tiebreaks stop mattering on exactly the rows a drag rewrote. A case holds one block: subfolders and requests are separately ordered, so the `order` column never interleaves them.",
 	"cases": [
 		{
 			"name": "explicit order wins over both creation time and id",
@@ -59,6 +59,57 @@
 				{ "id": "row-3", "order": 7, "createdAt": 1700000003000 }
 			],
 			"expected": ["row-2", "row-3", "row-1"]
+		},
+		{
+			"name": "post-drag: an adjacent swap leaves the block dense, with creation time out of sequence",
+			"comment": "Dragging req-third from index 2 to index 1 in a dense block. planRequestMove writes only the run between the two indices - req-third to 1, req-second to 2 - so the block stays 0..n-1 while createdAt no longer ascends with it. Sorting on creation time would give first, second, third.",
+			"rows": [
+				{ "id": "req-first", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "req-third", "order": 1, "createdAt": 1700000003000 },
+				{ "id": "req-second", "order": 2, "createdAt": 1700000002000 }
+			],
+			"expected": ["req-first", "req-third", "req-second"]
+		},
+		{
+			"name": "pre-drag: the display order a first drop has to renumber into, all three keys at once",
+			"comment": "The input side of normalization, which is the half that has to agree: normalize_scope renumbers in the order get_requests_in_collection returns, while the renderer plans against its own compareTreeOrder-sorted list. If the two disagreed, a normalized drop would land where the user did not point. A legacy all-zeros block with a createdAt tie inside it exercises order, createdAt and id in one case.",
+			"rows": [
+				{ "id": "leg-zulu", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "leg-bravo", "order": 0, "createdAt": 1700000002000 },
+				{ "id": "leg-alpha", "order": 0, "createdAt": 1700000002000 }
+			],
+			"expected": ["leg-zulu", "leg-alpha", "leg-bravo"]
+		},
+		{
+			"name": "post-drag: the same legacy block once the first drop renumbered it, both former tiebreaks now inert",
+			"comment": "Normalization materializes the case above as zulu 0, alpha 1, bravo 2; the drop of leg-bravo onto index 0 then writes bravo 0, zulu 1, alpha 2 and wins over the renumber. Creation time would put leg-zulu first and the id tiebreak would put leg-alpha first, so both legs are pinned as inert at once.",
+			"rows": [
+				{ "id": "leg-bravo", "order": 0, "createdAt": 1700000002000 },
+				{ "id": "leg-zulu", "order": 1, "createdAt": 1700000001000 },
+				{ "id": "leg-alpha", "order": 2, "createdAt": 1700000002000 }
+			],
+			"expected": ["leg-bravo", "leg-zulu", "leg-alpha"]
+		},
+		{
+			"name": "post-drag: a cross-parent landing, where the destination opened a slot for a row newer than every sibling",
+			"comment": "A row moved in from another parent at toIndex 1: the destination's rows from that index shift up (dst-1 to 2, dst-2 to 3) and the arrival takes 1. A moved row keeps its own createdAt, which here is newer than every row it lands among - the one shape where the pre-drag world's creation-time order is guaranteed wrong.",
+			"rows": [
+				{ "id": "dst-0", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "moved-in", "order": 1, "createdAt": 1700000009000 },
+				{ "id": "dst-1", "order": 2, "createdAt": 1700000002000 },
+				{ "id": "dst-2", "order": 3, "createdAt": 1700000003000 }
+			],
+			"expected": ["dst-0", "moved-in", "dst-1", "dst-2"]
+		},
+		{
+			"name": "post-drag: the source block after a second drag, the gap closed and creation time still scrambled",
+			"comment": "Two drags deep, which is what \"after any sequence of drags\" means. The block was already src-a, src-d, src-b, src-c from an earlier swap; src-b then leaves for another parent, so the rows past it close the gap (src-c to 2) and the block is dense again with creation time in neither ascending nor descending order.",
+			"rows": [
+				{ "id": "src-a", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "src-d", "order": 1, "createdAt": 1700000004000 },
+				{ "id": "src-c", "order": 2, "createdAt": 1700000003000 }
+			],
+			"expected": ["src-a", "src-d", "src-c"]
 		}
 	]
 }

--- a/engine/tests/tree_order_test.cpp
+++ b/engine/tests/tree_order_test.cpp
@@ -159,7 +159,7 @@ TEST_F (TreeOrderTest, ConformanceFixtureIsNonEmpty) {
     // Guards the scan itself: a fixture that failed to load would otherwise make
     // every case below vacuously pass.
     ASSERT_TRUE (fixture.contains ("cases"));
-    EXPECT_GE (fixture["cases"].size (), 5u);
+    EXPECT_GE (fixture["cases"].size (), 12u);
 }
 
 TEST_F (TreeOrderTest, RequestsFollowTheConformanceOrder) {
@@ -187,7 +187,7 @@ TEST_F (TreeOrderTest, RequestsFollowTheConformanceOrder) {
             db_->delete_request (row["id"].get<std::string> ());
         }
     }
-    EXPECT_GE (cases_run, 5u) << "the fixture loop asserted nothing";
+    EXPECT_GE (cases_run, 12u) << "the fixture loop asserted nothing";
 }
 
 TEST_F (TreeOrderTest, CollectionsFollowTheConformanceOrder) {
@@ -211,7 +211,7 @@ TEST_F (TreeOrderTest, CollectionsFollowTheConformanceOrder) {
             db_->delete_collection (row["id"].get<std::string> ());
         }
     }
-    EXPECT_GE (cases_run, 5u) << "the fixture loop asserted nothing";
+    EXPECT_GE (cases_run, 12u) << "the fixture loop asserted nothing";
 }
 
 // --- Stability across an edit (the rowid-churn mutation check) -----------------


### PR DESCRIPTION
## Description

**Plan.** The root cause is that `tree-order-conformance.json` was written for #360, before drags existed, so its seven cases pin the *pre-drag* contract - all-zero legacy blocks and hand-authored ties - and none of them is a shape a drop actually writes. The approach is the issue's: derive the new cases from the real post-states rather than invent them, by reading `app/src/modules/collections/reorder-math.ts` (which rows a drop rewrites) and `normalize_scope` / `stage_move` in `engine/src/http/routes/reorder.cpp` (what the renumber commits), then add the shapes those two produce. I rejected the alternative of generating cases from a simulated drag in the test itself - it would pin the fixture to the reorder implementation, so a bug in `reorder-math.ts` would produce cases that agree with the bug, and the fixture's whole job is to be a rule two implementations are checked *against*.

**The gap still reproduces as described, at `25f7fd6`.** The fixture is untouched since `e79ec42`, and the guards on both sides asserted only `>= 5` cases.

**What the post-drag shapes actually are - traced, not assumed.** Every drop leaves its block dense with distinct `order` values: an in-scope reorder writes only the run between the two indices (`planMove`'s splice loop), a cross-parent move closes the gap in the source (`i - 1`) and opens one in the destination (`i + 1`), and normalization renumbers `0..n-1` in the pinned display order before the moves land and win. So what these cases pin is not a new tie rule but the opposite: on exactly the rows a drag rewrote, **both former tiebreaks stop mattering**, and `createdAt` is now routinely out of sequence with `order`. That is what would break if either side reordered its keys.

The five cases, each named for the drag that produces it:

| Case | The drag behind it |
|---|---|
| adjacent swap, block still dense | `req-third` from index 2 to 1: only two rows written, `createdAt` now 1, 3, 2 |
| the display order a first drop renumbers into | the *input* to `normalize_scope`, with a `createdAt` tie inside the legacy block so all three keys resolve in one case |
| that same block after the drop lands | normalize gives zulu 0 / alpha 1 / bravo 2, then the move wins - creation time would put zulu first, the id tiebreak alpha first, and both are wrong |
| a cross-parent landing | the arrival keeps its own `createdAt`, newer than every row it lands among |
| the source block two drags deep | "after any sequence of drags": already scrambled by an earlier swap, then a row leaves and the gap closes |

**Mutation checks, run rather than reasoned about:**

| Reverted | Result |
|---|---|
| `createdAt` moved ahead of `order` in `compareTreeOrder` | 8 red, **4 of them the new post-drag cases** (3 of the original 7 catch it) |
| the id tiebreak reversed (`aId > bId`) | 4 red, including the new all-three-keys case |
| `CollectionItem` rendering requests before subfolders | the folders-first render assertion reddens |

**One thing the fixture structurally cannot express, so it is a test instead.** The issue's fourth shape - "a mixed folders-first block ... must not interleave with subfolders" - is not expressible as a fixture case: a case is one flat block, and the engine keeps collections and requests in *different tables*, so `get_requests_in_collection` cannot interleave a subfolder no matter what the fixture says. The risk is renderer-side, and it is real precisely because of the reorder math: both blocks are densified `0..n-1` independently, so a request and a subfolder in the same folder legitimately hold the **same** `order`, and only the render decides which comes first. `CollectionTree.folders-first.test.tsx` pins that with the request holding a *lower* order than the subfolder, so a merged sort would visibly lift it above the folder. The existing a11y test has both at order 0, where folders-first and an order-based merge are indistinguishable.

**Blast radius, traced.** The fixture has exactly two readers - `tree_order_test.cpp` (through the real SQL, as both requests and collections) and `tree-order.conformance.test.ts` (through `compareTreeOrder`) - and both iterate it, so the new cases are picked up without wiring. The new cases carry a `comment` key the readers ignore; the app's `ConformanceCase` interface does not declare it, which is fine for a `JSON.parse` cast and `pnpm type-check` is clean. `scenario_plan_test.cpp` only *references* the fixture in a comment. The guards move 5 -> 12 on both sides so a fixture that failed to load still cannot pass vacuously.

**No disagreement surfaced between the SQL and the comparator** on any of the new shapes - the criterion for that was "fix it, do not paper over it", and there was nothing to fix. All 12 cases were also checked against an independent Python implementation of the three-key byte-wise rule before the suites ran.

## Type of Change

- [x] Bug fix (a missing regression guard on shipped behaviour)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1124/1124 passed**. (An earlier run against a still-linking binary failed ~15 `ReorderRouteTest` cases; it reproduces on a mid-link tree and is gone once the build completes.)

`cd app && pnpm test` - **3441 passed / 352 files** (3434 / 351 on the base commit, plus the 5 new fixture cases and 2 new render tests). `pnpm type-check` clean. ESLint and Prettier clean on the two app files touched, both of which were clean before.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (none needed - see below)

**Docs: none, verified.** The issue asked to confirm no doc quotes the case count. Neither reference does: `docs/engine/api-reference.md:168` and `docs/app/state-management.md:712` both name the fixture as the pinning mechanism without a count, and the rule they state is unchanged. `reorder-math.ts`'s existing docstring already documents the separate-blocks rationale the new render test pins.

**Pre-existing, not fixed.** `engine/tests/tree_order_test.cpp` carries 48 clang-format violations on the base commit; this PR changes three integer literals in it and adds none, so per the repo rule the file is left as it was.

## Related Issues

Closes #426

Satisfies #364's fourth tracking criterion for the fixture half. **It does not fully close #364**, and I would rather say so than let it look covered: verifying that criterion turned up a genuine cross-block disagreement that is *drag-independent*, so it is out of this issue's scope. The engine's recursive scenario walk (`collect_requests`, `scenario_plan.cpp:89-101`) is pre-order - a collection's own requests run **before** its subfolders' - while the sidebar renders **subfolders above requests** (`CollectionItem.tsx:400-425`). For the tree in `RecursiveDescentIsDepthFirstByCollectionOrder` the sidebar shows `a_1, g_1, b_1, root_a, root_b` and the run executes `root_a, root_b, a_1, g_1, b_1`. That is the #360 defect class one level up, it is true with zero drags, and which side should move is your call - filed separately rather than changed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcvongSNyLRV1en9X8sZ8A)_