### PR TITLE
fix(engine/app): run a folder in the order the sidebar shows it

### DIFF
--- a/.github/release-notes/v0.15.0.md
+++ b/.github/release-notes/v0.15.0.md
@@ -1,9 +1,0 @@
-## [0.15.0] - 2026-08-09
-
-In-progress notes for the next release. Entries are added as the changes land and the lead paragraph is written when the version is cut.
-
-### Changed
-
-- **A recursive collection run executes in the order the sidebar shows.** "Include sub-folders" walked a folder's *own* requests first and descended afterwards, while the tree renders every sub-folder above every request - so a folder holding both ran in a sequence that appeared nowhere in the UI. The run now follows the tree: each sub-folder's whole subtree, then the folder's own requests, sub-folders by their own order and requests by theirs. **This changes the order existing collections execute in** - a run of a folder with both sub-folders and requests will visit its steps in a different sequence than before this release, so a scenario whose steps depend on each other through variables or cookies is worth re-checking. Folders holding only requests, only sub-folders, or run without "Include sub-folders" are unaffected. The two consumers can no longer drift: one fixture now pins the rendered order and the engine's plan against each other.
-
-[0.15.0]: https://github.com/athrvk/vayu/compare/v0.14.0...v0.15.0

--- a/.github/release-notes/v0.15.0.md
+++ b/.github/release-notes/v0.15.0.md
@@ -1,0 +1,9 @@
+## [0.15.0] - 2026-08-09
+
+In-progress notes for the next release. Entries are added as the changes land and the lead paragraph is written when the version is cut.
+
+### Changed
+
+- **A recursive collection run executes in the order the sidebar shows.** "Include sub-folders" walked a folder's *own* requests first and descended afterwards, while the tree renders every sub-folder above every request - so a folder holding both ran in a sequence that appeared nowhere in the UI. The run now follows the tree: each sub-folder's whole subtree, then the folder's own requests, sub-folders by their own order and requests by theirs. **This changes the order existing collections execute in** - a run of a folder with both sub-folders and requests will visit its steps in a different sequence than before this release, so a scenario whose steps depend on each other through variables or cookies is worth re-checking. Folders holding only requests, only sub-folders, or run without "Include sub-folders" are unaffected. The two consumers can no longer drift: one fixture now pins the rendered order and the engine's plan against each other.
+
+[0.15.0]: https://github.com/athrvk/vayu/compare/v0.14.0...v0.15.0

--- a/app/src/modules/collections/CollectionTree.run-order.conformance.test.tsx
+++ b/app/src/modules/collections/CollectionTree.run-order.conformance.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Cross-consumer conformance: the request sequence the sidebar *displays* for a
+ * recursive run against the sequence the engine's plan *executes* (issue #431).
+ *
+ * `CollectionTree.folders-first.test.tsx` pins the relationship between one
+ * folder's two blocks, and `tree-order-conformance.json` pins the order within a
+ * block. Neither could notice the case this file exists for: the engine's walk
+ * was pre-order (a folder's own requests, then its subfolders'), the tree renders
+ * subfolders above requests at every depth, and each side had a test asserting
+ * its own order. "Run this folder" therefore executed in a sequence the user had
+ * never seen - the #360 defect one level up.
+ *
+ * So the fixture is read by both sides:
+ * `engine/tests/scenario_plan_test.cpp` seeds each case and reads
+ * `resolve_scenario`'s step ids; this file renders the same tree fully expanded
+ * and reads the request rows top to bottom out of the DOM. The render is the
+ * assertion subject, not a re-derivation of it - a comparator copy here would be
+ * the second source of truth the fixture exists to prevent.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabsStore } from "@/stores";
+import { compareTreeOrder } from "@/types";
+import { useCollectionsStore } from "./collections-store";
+import CollectionTree from "./CollectionTree";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(
+	here,
+	"..",
+	"..",
+	"..",
+	"..",
+	"engine",
+	"tests",
+	"fixtures",
+	"recursive-run-order-conformance.json"
+);
+
+interface FixtureCollection {
+	id: string;
+	parentId: string | null;
+	order: number;
+	createdAt: number;
+}
+interface FixtureRequest {
+	id: string;
+	collectionId: string;
+	order: number;
+	createdAt: number;
+}
+interface ConformanceCase {
+	name: string;
+	rootId: string;
+	collections: FixtureCollection[];
+	requests: FixtureRequest[];
+	expected: string[];
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+	description: string;
+	cases: ConformanceCase[];
+};
+
+/**
+ * The rows the mocked query layer serves. The renderer holds `createdAt` as the
+ * ISO string its transformers produce from the engine's epoch-millisecond
+ * column, so the fixture is fed in through that conversion rather than in a
+ * shape the app never has.
+ */
+interface TreeData {
+	collections: Array<{
+		id: string;
+		name: string;
+		parentId?: string;
+		order: number;
+		createdAt: string;
+	}>;
+	requestsByCollection: Map<
+		string,
+		Array<{
+			id: string;
+			collectionId: string;
+			name: string;
+			method: string;
+			order: number;
+			createdAt: string;
+		}>
+	>;
+}
+
+let current: TreeData = { collections: [], requestsByCollection: new Map() };
+
+vi.mock("@/queries", () => ({
+	useReorderMutation: () => ({ mutate: vi.fn(), isPending: false }),
+	useCollectionsQuery: () => ({
+		data: current.collections,
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	}),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: current.requestsByCollection }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteCollectionMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateRequestMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+/**
+ * `reverseInput` feeds the collections list back to front. The tree sorts roots
+ * and each folder's children itself, so a case that only passes in fixture order
+ * would be reading the array rather than applying the rule. The request lists
+ * are *not* reversed: the tree renders them as the query layer hands them over,
+ * and that layer's sort is pinned by `tree-order.conformance.test.ts`.
+ */
+function toTreeData(c: ConformanceCase, reverseInput = false): TreeData {
+	const collections = c.collections.map((col) => ({
+		id: col.id,
+		name: `Collection ${col.id}`,
+		...(col.parentId ? { parentId: col.parentId } : {}),
+		order: col.order,
+		createdAt: new Date(col.createdAt).toISOString(),
+	}));
+
+	const requestsByCollection: TreeData["requestsByCollection"] = new Map();
+	for (const req of c.requests) {
+		const row = {
+			id: req.id,
+			collectionId: req.collectionId,
+			name: `Request ${req.id}`,
+			method: "GET",
+			order: req.order,
+			createdAt: new Date(req.createdAt).toISOString(),
+		};
+		requestsByCollection.set(req.collectionId, [
+			...(requestsByCollection.get(req.collectionId) ?? []),
+			row,
+		]);
+	}
+	// The query layer hands each collection's list out already sorted
+	// (`queries/collections.ts`, pinned by tree-order.conformance.test.ts); only
+	// the folders/requests split and the child order are this file's subject.
+	for (const [id, rows] of requestsByCollection) {
+		requestsByCollection.set(id, [...rows].sort(compareTreeOrder));
+	}
+
+	return {
+		collections: reverseInput ? [...collections].reverse() : collections,
+		requestsByCollection,
+	};
+}
+
+/** The request rows the tree displays, top to bottom. */
+function displayedRequestIds(c: ConformanceCase, reverseInput = false): string[] {
+	current = toTreeData(c, reverseInput);
+	useCollectionsStore.setState({
+		expandedCollectionIds: new Set(c.collections.map((col) => col.id)),
+	});
+	const { container } = render(
+		<QueryClientProvider
+			client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+		>
+			<TooltipProvider>
+				<CollectionTree />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+	return Array.from(container.querySelectorAll("[data-request-id]")).map(
+		(row) => row.getAttribute("data-request-id") ?? ""
+	);
+}
+
+beforeEach(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+});
+
+describe("recursive-run-order conformance fixture", () => {
+	it("scanned a non-empty fixture (guards the scan itself)", () => {
+		expect(fixture.cases.length).toBeGreaterThanOrEqual(5);
+		for (const c of fixture.cases) {
+			expect(c.collections.length).toBeGreaterThan(1);
+			expect(c.expected.length).toBe(c.requests.length);
+			// Every case is a folder that holds subfolders, which is the only shape
+			// the two blocks can disagree about.
+			expect(c.collections.some((col) => col.parentId === c.rootId)).toBe(true);
+		}
+	});
+
+	it.each(fixture.cases.map((c) => [c.name, c] as const))(
+		"displays the run order: %s",
+		(_name, c) => {
+			expect(displayedRequestIds(c)).toEqual(c.expected);
+		}
+	);
+
+	it("displays the same order whatever order the rows arrive in", () => {
+		for (const c of fixture.cases) {
+			expect(displayedRequestIds(c, /*reverseInput=*/ true)).toEqual(c.expected);
+		}
+	});
+});

--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -9,11 +9,12 @@
  * RunCollectionDialog
  *
  * Starts a collection run. Two options and nothing else, because the scenario
- * *is* the folder: the sequence is `requests.order` (then, with Recursive,
- * descendant collections by `collections.order`, depth-first), which is the
- * order the sidebar already shows. There is no step list to author here, and
- * inventing one would be a second source of truth for an ordering the tree
- * already owns.
+ * *is* the folder: the sequence is `requests.order` (and, with Recursive,
+ * descendant collections by `collections.order`, depth-first, each subfolder's
+ * subtree ahead of its parent's own requests), which is the order the sidebar
+ * already shows - top to bottom, subfolders above requests at every depth. There
+ * is no step list to author here, and inventing one would be a second source of
+ * truth for an ordering the tree already owns.
  *
  * The engine resolves the whole plan before it answers, so a collection with no
  * requests, a step that will not compose, or a plan over `maxScenarioSteps` all
@@ -156,7 +157,8 @@ export default function RunCollectionDialog({
 						<Label htmlFor="run-collection-recursive" className="leading-snug">
 							Include sub-folders
 							<span className="block text-xs font-normal text-muted-foreground">
-								Descend into nested collections, depth-first.
+								Descend into nested collections. Each sub-folder runs before this
+								folder&apos;s own requests, top to bottom as the sidebar shows them.
 							</span>
 						</Label>
 						<Switch

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -420,7 +420,10 @@ export interface StartScenarioRunRequest {
 		 */
 		source: "collection";
 		collectionId: string;
-		/** Descend into sub-collections, depth-first. Default false. */
+		/**
+		 * Descend into sub-collections, depth-first, each subtree ahead of its
+		 * parent's own requests - the order the sidebar shows. Default false.
+		 */
 		recursive?: boolean;
 		/**
 		 * Passes over the plan. Whole number, 1 or more.

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -713,6 +713,17 @@ engine's SQL by `engine/tests/fixtures/tree-order-conformance.json`, read by
 `types/tree-order.conformance.test.ts` and by the engine's `tree_order_test.cpp`
 - change one side and the other suite fails.
 
+That rule orders **one block**. A folder's sub-collections and its requests are
+two separately ordered blocks, so their `order` values can collide, and where the
+blocks sit relative to each other is the render's rule: `CollectionItem` puts
+every subfolder above every request, at every depth
+(`CollectionTree.folders-first.test.tsx`). A recursive collection run has to
+execute in that same sequence - each subfolder's whole subtree, then the folder's
+own requests - which is pinned across the render and the engine's plan by
+`engine/tests/fixtures/recursive-run-order-conformance.json`, read by
+`modules/collections/CollectionTree.run-order.conformance.test.tsx` and by the
+engine's `scenario_plan_test.cpp` (issue #431).
+
 **Mutations:**
 - **`useCreateCollectionMutation()`** - Create collection
 - **`useUpdateCollectionMutation()`** - Update collection (with cache update)

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -167,6 +167,14 @@ must apply the same rule if they sort locally; the app's `compareTreeOrder` is
 pinned to this one by
 `engine/tests/fixtures/tree-order-conformance.json`, read by both test suites.
 
+A collection's sub-collections and its requests are **two separate blocks**, so
+`order` never interleaves them - a request and a subfolder in one folder can hold
+the same value. Where the two blocks sit relative to each other is the tree's
+rule rather than the column's: subfolders first, which is also the order a
+recursive [collection run](#the-scenario-block-collection-runs) executes in,
+pinned across both consumers by
+`engine/tests/fixtures/recursive-run-order-conformance.json`.
+
 **Writing.** `order` defaults to "append after the current siblings" - one past
 the highest `order` any sibling holds:
 
@@ -1692,10 +1700,14 @@ inside the block rather than through `mode` / `duration` / `iterations`:
 ```
 
 The collection is resolved into an ordered, fully composed plan **once, before
-anything is sent**: direct requests by `requests.order`, then - with `recursive`
-- descendant collections by `collections.order`, depth-first, each list under
-the tiebreak in [Ordering](#ordering), which is what makes a run's sequence the
-one the sidebar shows. Each step is
+anything is sent**, in the order the sidebar displays top to bottom: direct
+requests by `requests.order` and - with `recursive` - descendant collections by
+`collections.order`, depth-first, each sub-collection's whole subtree running
+**before** its parent's own requests, and each list under the tiebreak in
+[Ordering](#ordering). Subfolders ahead of own requests is the tree's rule, not
+the column's: a folder's sub-collections and its requests are separately ordered
+blocks, so the two `order` values are free to collide, and the run follows the
+render (issue #431). Each step is
 composed through the same path `POST /compose` uses, so a step's request and
 joined scripts are byte-identical to what a Send of that request would run. A
 collection edited mid-run therefore cannot change the sequence underneath

--- a/docs/plans/collection-runner-design.md
+++ b/docs/plans/collection-runner-design.md
@@ -54,7 +54,9 @@ even the ordering that does exist is not something a script participates in.
 
 A scenario is not a new stored entity. It is a *resolution* of one that exists: a
 collection, its direct requests ordered by `requests.order`, optionally including
-descendant collections ordered by `collections.order`, depth-first.
+descendant collections ordered by `collections.order`, depth-first - each
+sub-collection's subtree ahead of its parent's own requests, because that is the
+order the sidebar renders (issue #431).
 
 At run start the engine resolves that into a **scenario plan**: an ordered,
 immutable vector of fully composed steps. Each step is the payload

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -87,7 +87,8 @@ struct ScenarioRequest {
     /// than falling through to the collection path.
     std::string source;
     std::string collection_id;
-    /// Descend into sub-collections, depth-first by `collections.order`.
+    /// Descend into sub-collections, depth-first by `collections.order`, each
+    /// subtree ahead of the parent's own requests - the sidebar's order.
     bool recursive = false;
     /// Resolved: an explicit count wins, otherwise the data row count, else 1.
     size_t iterations     = 1;
@@ -160,10 +161,13 @@ struct ScenarioResolution {
 /**
  * Validate a `scenario` block and resolve it into a plan.
  *
- * Ordering is a collection's direct requests by `requests.order`, then - when
- * `recursive` is set - descendant collections by `collections.order`,
- * depth-first. The `collections` tree is not constraint-enforced, so the walk
- * carries a visited set exactly as `Database::delete_collection`'s BFS does: a
+ * Ordering is the order the sidebar displays, top to bottom. A collection's
+ * direct requests run by `requests.order`; with `recursive` set, each
+ * sub-collection's whole subtree runs *before* the parent's own requests,
+ * sub-collections themselves by `collections.order`, depth-first - because the
+ * tree renders every subfolder above every request at each depth (issue #431).
+ * The `collections` tree is not constraint-enforced, so the walk carries a
+ * visited set exactly as `Database::delete_collection`'s BFS does: a
  * `parent_id` cycle terminates instead of growing forever under the DB mutex.
  *
  * Every failure below is loud, never a silently smaller run: an unknown

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -73,30 +73,49 @@ collect_requests (vayu::db::Database& db, const std::string& root_id, bool recur
         }
     }
 
+    // Two entry kinds share one stack. `Descend` queues a collection's subtree,
+    // `Emit` appends that collection's own requests - and because the marker is
+    // pushed *underneath* the children, every subfolder's subtree is emitted
+    // before the folder's own requests. That is the sidebar's order, which
+    // renders `childCollections` above `requests` at every depth
+    // (`CollectionItem.tsx`), and a recursive run has to execute in the order
+    // the user is looking at (issue #431, the #360 rule one level up).
+    enum class Step { Descend, Emit };
+    struct Entry {
+        Step step;
+        std::string id;
+    };
+
     std::vector<vayu::db::Request> ordered;
     std::unordered_set<std::string> visited;
-    std::vector<std::string> stack{ root_id };
+    std::vector<Entry> stack{ { Step::Descend, root_id } };
     while (!stack.empty ()) {
-        const std::string id = std::move (stack.back ());
+        const Entry entry = std::move (stack.back ());
         stack.pop_back ();
-        // The visited set is what makes a corrupted `parent_id` (a self-parent,
-        // or an A -> B -> A loop written before write-time validation existed)
-        // terminate rather than grow `ordered` forever under the DB mutex -
-        // the same guard `Database::delete_collection`'s BFS carries.
-        if (!visited.insert (id).second) {
+
+        if (entry.step == Step::Emit) {
+            for (auto& row : db.get_requests_in_collection (entry.id)) {
+                ordered.push_back (std::move (row));
+            }
             continue;
         }
 
-        for (auto& row : db.get_requests_in_collection (id)) {
-            ordered.push_back (std::move (row));
+        // The visited set is what makes a corrupted `parent_id` (a self-parent,
+        // or an A -> B -> A loop written before write-time validation existed)
+        // terminate rather than grow `ordered` forever under the DB mutex -
+        // the same guard `Database::delete_collection`'s BFS carries. An `Emit`
+        // is only queued past this point, so a cycle cannot double-emit either.
+        if (!visited.insert (entry.id).second) {
+            continue;
         }
+        stack.push_back ({ Step::Emit, entry.id });
 
-        if (auto it = children.find (id); it != children.end ()) {
-            // Reversed, so the stack pops them in `collections.order`: a
-            // pre-order descent visits a collection's own requests, then its
-            // first child's whole subtree, then its second child's.
+        if (auto it = children.find (entry.id); it != children.end ()) {
+            // Reversed, so the stack pops them in `collections.order`: the
+            // first child's whole subtree, then the second's, then - last -
+            // this collection's own requests.
             for (auto child = it->second.rbegin (); child != it->second.rend (); ++child) {
-                stack.push_back (child->id);
+                stack.push_back ({ Step::Descend, child->id });
             }
         }
     }

--- a/engine/tests/fixtures/recursive-run-order-conformance.json
+++ b/engine/tests/fixtures/recursive-run-order-conformance.json
@@ -1,0 +1,84 @@
+{
+	"description": "The recursive run order, read by both suites (issue #431). A folder's sub-collections and its requests are two separately ordered blocks - `tree-order-conformance.json` pins each block, this pins the sequence the two blocks produce when a folder holding both is run recursively. The rule is the sidebar's: every subfolder's whole subtree runs before the folder's own requests, subfolders by `collections.order` and requests by `requests.order`, each under the `order, createdAt, id` tiebreak. Engine side: engine/tests/scenario_plan_test.cpp seeds each case's rows and reads `resolve_scenario`'s step ids, so the real SQL and the real walk are what is asserted. Renderer side: app/src/modules/collections/CollectionTree.run-order.conformance.test.tsx renders the same tree fully expanded and reads the request rows top to bottom out of the DOM, so the real render is what is asserted. A rule that changes on one side and not the other fails here or in ctest, never in a user's run. `collections` is listed parent-first so a case reads as a tree; neither consumer depends on that order, and `expected` names every request in the tree, so a row a reader forgets to seed fails rather than passes.",
+	"cases": [
+		{
+			"name": "the deepest subtree runs first and the root's own requests last",
+			"rootId": "top",
+			"collections": [
+				{ "id": "top", "parentId": null, "order": 0, "createdAt": 1700000000000 },
+				{ "id": "mid", "parentId": "top", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "leaf", "parentId": "mid", "order": 0, "createdAt": 1700000002000 }
+			],
+			"requests": [
+				{ "id": "top_r", "collectionId": "top", "order": 0, "createdAt": 1700000003000 },
+				{ "id": "mid_r", "collectionId": "mid", "order": 0, "createdAt": 1700000004000 },
+				{ "id": "leaf_r", "collectionId": "leaf", "order": 0, "createdAt": 1700000005000 }
+			],
+			"expected": ["leaf_r", "mid_r", "top_r"]
+		},
+		{
+			"name": "two subfolders in collections.order, then the parent's own requests in requests.order",
+			"rootId": "root",
+			"collections": [
+				{ "id": "root", "parentId": null, "order": 0, "createdAt": 1700000000000 },
+				{ "id": "child_a", "parentId": "root", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "child_b", "parentId": "root", "order": 1, "createdAt": 1700000002000 },
+				{ "id": "grandchild", "parentId": "child_a", "order": 0, "createdAt": 1700000003000 }
+			],
+			"requests": [
+				{ "id": "root_a", "collectionId": "root", "order": 0, "createdAt": 1700000004000 },
+				{ "id": "root_b", "collectionId": "root", "order": 1, "createdAt": 1700000005000 },
+				{ "id": "a_1", "collectionId": "child_a", "order": 0, "createdAt": 1700000006000 },
+				{ "id": "b_1", "collectionId": "child_b", "order": 0, "createdAt": 1700000007000 },
+				{ "id": "g_1", "collectionId": "grandchild", "order": 0, "createdAt": 1700000008000 }
+			],
+			"expected": ["g_1", "a_1", "b_1", "root_a", "root_b"]
+		},
+		{
+			"name": "colliding orders across the two blocks (the post-densify shape) do not interleave",
+			"rootId": "acme",
+			"collections": [
+				{ "id": "acme", "parentId": null, "order": 0, "createdAt": 1700000000000 },
+				{ "id": "billing", "parentId": "acme", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "shipping", "parentId": "acme", "order": 1, "createdAt": 1700000002000 }
+			],
+			"requests": [
+				{ "id": "ping", "collectionId": "acme", "order": 0, "createdAt": 1700000003000 },
+				{ "id": "pong", "collectionId": "acme", "order": 1, "createdAt": 1700000004000 },
+				{ "id": "invoice", "collectionId": "billing", "order": 0, "createdAt": 1700000005000 },
+				{ "id": "label", "collectionId": "shipping", "order": 0, "createdAt": 1700000006000 }
+			],
+			"expected": ["invoice", "label", "ping", "pong"]
+		},
+		{
+			"name": "all-zero orders in both blocks fall to createdAt, block by block",
+			"rootId": "legacy",
+			"collections": [
+				{ "id": "legacy", "parentId": null, "order": 0, "createdAt": 1700000000000 },
+				{ "id": "zeta", "parentId": "legacy", "order": 0, "createdAt": 1700000002000 },
+				{ "id": "alpha", "parentId": "legacy", "order": 0, "createdAt": 1700000001000 }
+			],
+			"requests": [
+				{ "id": "later", "collectionId": "legacy", "order": 0, "createdAt": 1700000004000 },
+				{ "id": "earlier", "collectionId": "legacy", "order": 0, "createdAt": 1700000003000 },
+				{ "id": "in_zeta", "collectionId": "zeta", "order": 0, "createdAt": 1700000005000 },
+				{ "id": "in_alpha", "collectionId": "alpha", "order": 0, "createdAt": 1700000006000 }
+			],
+			"expected": ["in_alpha", "in_zeta", "earlier", "later"]
+		},
+		{
+			"name": "an empty subfolder contributes nothing and shifts nothing",
+			"rootId": "orders",
+			"collections": [
+				{ "id": "orders", "parentId": null, "order": 0, "createdAt": 1700000000000 },
+				{ "id": "drafts", "parentId": "orders", "order": 0, "createdAt": 1700000001000 },
+				{ "id": "archive", "parentId": "orders", "order": 1, "createdAt": 1700000002000 }
+			],
+			"requests": [
+				{ "id": "list_orders", "collectionId": "orders", "order": 0, "createdAt": 1700000003000 },
+				{ "id": "list_archive", "collectionId": "archive", "order": 0, "createdAt": 1700000004000 }
+			],
+			"expected": ["list_archive", "list_orders"]
+		}
+	]
+}

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -6,9 +6,14 @@
  * Three contracts are pinned here, and each of them is one a later phase builds
  * on rather than a detail of this one:
  *
- *  - **Ordering.** Direct requests by `requests.order`, then descendant
- *    collections by `collections.order`, depth-first - and a `parent_id` cycle
- *    terminates instead of hanging the DB mutex.
+ *  - **Ordering.** The order the sidebar displays: direct requests by
+ *    `requests.order`, and - recursively - each sub-collection's whole subtree
+ *    ahead of its parent's own requests, sub-collections by `collections.order`,
+ *    depth-first. Driven case by case from
+ *    `fixtures/recursive-run-order-conformance.json`, which the renderer's
+ *    `CollectionTree.run-order.conformance.test.tsx` reads as well, so the run
+ *    and the tree cannot disagree without one of the two suites failing (issue
+ *    #431). A `parent_id` cycle terminates instead of hanging the DB mutex.
  *  - **No second copy of composition.** A step's request and joined scripts
  *    equal what `POST /compose` returns for the same `requestId`, so a Send and
  *    a scenario step cannot drift apart.
@@ -25,6 +30,8 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -42,11 +49,27 @@ using nlohmann::json;
 
 namespace {
 
+json load_run_order_fixture () {
+    const std::filesystem::path path = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
+    "tests" / "fixtures" / "recursive-run-order-conformance.json";
+    std::ifstream in (path);
+    EXPECT_TRUE (in.good ()) << "fixture missing: " << path;
+    return json::parse (in);
+}
+
 class ScenarioPlanTest : public ::testing::Test {
     protected:
     static constexpr const char* DB_PATH = "test_scenario_plan.db";
 
     void SetUp () override {
+        reset_database ();
+    }
+    /// A fresh database on one path. The old handle is closed *before* the
+    /// files are removed and the new one opens, so a test that needs a clean
+    /// tree mid-run (the fixture loop, whose cases repeat ids) cannot end up
+    /// with two connections to a file one of them has already deleted.
+    void reset_database () {
+        db_.reset ();
         cleanup ();
         db_ = std::make_unique<vayu::db::Database> (DB_PATH);
         db_->init ();
@@ -59,11 +82,14 @@ class ScenarioPlanTest : public ::testing::Test {
         vayu::tests::remove_database_files (DB_PATH);
     }
 
+    // `created_at` is the second sort key, so only a test about a tie needs to
+    // state it; everything else shares one timestamp and sorts on `order`.
     void seed_collection (const std::string& id,
     const std::string& parent_id,
     int order                     = 0,
     const std::string& auth       = "",
-    const std::string& pre_script = "") {
+    const std::string& pre_script = "",
+    int64_t created_at            = 1) {
         vayu::db::Collection col;
         col.id = id;
         if (!parent_id.empty ()) {
@@ -73,8 +99,8 @@ class ScenarioPlanTest : public ::testing::Test {
         col.auth               = auth;
         col.pre_request_script = pre_script;
         col.order              = order;
-        col.created_at         = 1;
-        col.updated_at         = 1;
+        col.created_at         = created_at;
+        col.updated_at         = created_at;
         db_->create_collection (col);
     }
 
@@ -83,7 +109,8 @@ class ScenarioPlanTest : public ::testing::Test {
     int order                      = 0,
     const std::string& url         = "https://example.test/{{path}}",
     const std::string& auth        = "",
-    const std::string& post_script = "") {
+    const std::string& post_script = "",
+    int64_t created_at             = 1) {
         vayu::db::Request r;
         r.id                  = id;
         r.collection_id       = collection_id;
@@ -93,8 +120,8 @@ class ScenarioPlanTest : public ::testing::Test {
         r.auth                = auth;
         r.post_request_script = post_script;
         r.order               = order;
-        r.created_at          = 1;
-        r.updated_at          = 1;
+        r.created_at          = created_at;
+        r.updated_at          = created_at;
         db_->save_request (r);
     }
 
@@ -154,11 +181,18 @@ TEST_F (ScenarioPlanTest, DirectRequestsAreOrderedByRequestOrder) {
     }
 }
 
-TEST_F (ScenarioPlanTest, RecursiveDescentIsDepthFirstByCollectionOrder) {
+TEST_F (ScenarioPlanTest, RecursiveDescentRunsEachSubtreeBeforeTheFoldersOwnRequests) {
     //   root            [root_a, root_b]
     //     child_b (order 1)  [b_1]
     //     child_a (order 0)  [a_1]
     //       grandchild       [g_1]
+    //
+    // The sidebar renders every subfolder above every request at each depth
+    // (`CollectionItem.tsx`), so `g_1` (deepest) is the first row a user sees
+    // under `root` and the root's own requests are the last two. The walk used
+    // to be pre-order - `root_a, root_b, a_1, g_1, b_1` - which is an order the
+    // tree never showed (issue #431). Mutation check: restore the pre-order push
+    // in `collect_requests` and this reddens, along with every fixture case.
     seed_collection ("root", "");
     seed_collection ("child_b", "root", /*order=*/1);
     seed_collection ("child_a", "root", /*order=*/0);
@@ -173,7 +207,60 @@ TEST_F (ScenarioPlanTest, RecursiveDescentIsDepthFirstByCollectionOrder) {
     *db_, block ("root", /*recursive=*/true), options ());
     ASSERT_TRUE (resolved.ok) << resolved.error;
     EXPECT_EQ (step_ids (resolved.plan),
-    (std::vector<std::string>{ "root_a", "root_b", "a_1", "g_1", "b_1" }));
+    (std::vector<std::string>{ "g_1", "a_1", "b_1", "root_a", "root_b" }));
+}
+
+// --- The cross-consumer order (fixture-driven) --------------------------------
+
+TEST_F (ScenarioPlanTest, RunOrderConformanceFixtureIsNonEmpty) {
+    // Guards the scan itself: a fixture that failed to load would make every
+    // case below vacuously pass.
+    const json fixture = load_run_order_fixture ();
+    ASSERT_TRUE (fixture.contains ("cases"));
+    EXPECT_GE (fixture["cases"].size (), 5u);
+}
+
+TEST_F (ScenarioPlanTest, RecursiveRunFollowsTheSidebarOrderInEveryFixtureCase) {
+    // The other half of this fixture is
+    // app/src/modules/collections/CollectionTree.run-order.conformance.test.tsx,
+    // which renders the same trees and reads the request rows out of the DOM. A
+    // rule that changes on one side only fails there or here.
+    //
+    // Named, not subscripted inline: `load_run_order_fixture ()["cases"]`
+    // returns a reference into a temporary the full expression destroys, so
+    // the loop would walk freed memory - and in practice walk nothing.
+    // `cases_run` guards against exactly that.
+    const json fixture = load_run_order_fixture ();
+    size_t cases_run   = 0;
+    for (const auto& c : fixture["cases"]) {
+        const std::string name = c["name"].get<std::string> ();
+        reset_database (); // Ids repeat across cases.
+
+        for (const auto& col : c["collections"]) {
+            seed_collection (col["id"].get<std::string> (),
+            col["parentId"].is_null () ? "" : col["parentId"].get<std::string> (),
+            col["order"].get<int> (), /*auth=*/"", /*pre_script=*/"",
+            col["createdAt"].get<int64_t> ());
+        }
+        for (const auto& req : c["requests"]) {
+            seed_request (req["id"].get<std::string> (),
+            req["collectionId"].get<std::string> (), req["order"].get<int> (),
+            /*url=*/"https://example.test/", /*auth=*/"", /*post_script=*/"",
+            req["createdAt"].get<int64_t> ());
+        }
+
+        std::vector<std::string> expected;
+        for (const auto& id : c["expected"]) {
+            expected.push_back (id.get<std::string> ());
+        }
+
+        const auto resolved = vayu::core::resolve_scenario (*db_,
+        block (c["rootId"].get<std::string> (), /*recursive=*/true), options ());
+        ASSERT_TRUE (resolved.ok) << "case: " << name << ": " << resolved.error;
+        EXPECT_EQ (step_ids (resolved.plan), expected) << "case: " << name;
+        ++cases_run;
+    }
+    EXPECT_GE (cases_run, 5u) << "the fixture loop asserted nothing";
 }
 
 TEST_F (ScenarioPlanTest, TiedOrdersRunInTheSameSequenceTheSidebarShows) {
@@ -222,7 +309,11 @@ TEST_F (ScenarioPlanTest, ParentIdCycleTerminatesAndVisitsEachCollectionOnce) {
     const auto resolved =
     vayu::core::resolve_scenario (*db_, block ("a", /*recursive=*/true), options ());
     ASSERT_TRUE (resolved.ok) << resolved.error;
-    EXPECT_EQ (step_ids (resolved.plan), (std::vector<std::string>{ "in_a", "in_b" }));
+    // What is pinned is termination and each collection contributing once. The
+    // sequence follows from the subfolders-first rule - "b" is a child of "a",
+    // so its request runs first - and a cycle has no displayed order to agree
+    // with, since the sidebar renders such a row as an orphaned root.
+    EXPECT_EQ (step_ids (resolved.plan), (std::vector<std::string>{ "in_b", "in_a" }));
 }
 
 TEST_F (ScenarioPlanTest, SelfParentingCollectionTerminates) {


### PR DESCRIPTION
## Description

Option **A** from the issue: the engine's recursive walk now matches the sidebar, and the mismatch is pinned across both consumers by one fixture.

**Root cause.** `collect_requests` (`engine/src/core/scenario_plan.cpp`) was pre-order: it pushed `get_requests_in_collection(id)` for the current node, *then* descended. `CollectionItem.tsx` renders `childCollections.map(...)` before `requests.map(...)` at every depth. Both were internally consistent and each had a test asserting its own order, so a folder holding both its own requests and subfolders ran in a sequence that appeared nowhere in the UI.

**Approach.** The walk keeps one stack and gains an explicit `Emit` marker, pushed *underneath* a node's children - so each sub-collection's whole subtree is emitted before the parent's own requests, sub-collections still by `collections.order`. The `visited` guard against a corrupt `parent_id` is unchanged, and because an `Emit` is only queued past that guard, a cycle still cannot double-emit. The cross-consumer half had no home, which is why neither side noticed: a new fixture, `engine/tests/fixtures/recursive-run-order-conformance.json`, is read by the engine (`scenario_plan_test.cpp` seeds the tree and reads the plan's `step_ids`) and by the renderer (`CollectionTree.run-order.conformance.test.tsx` renders the same tree fully expanded and reads the request rows out of the DOM). The render itself is the assertion subject - a comparator copy in the app test would be the second source of truth the fixture exists to prevent.

**Rejected.** **B** (render requests above subfolders) reaches the same agreement from the other end, but every file tree users know is folders-first, and `drop-position.ts` plus `reorder-math.ts` already plan drags against the folders-first two-block model - it would trade a correct run order for a sidebar that reads as wrong and a DnD model to rework. **C** (document the divergence) is cheapest and keeps a user-visible mismatch #360 already decided was unacceptable one level down.

**Cost, stated plainly.** This changes the order existing collections execute in. A recursive run of a folder with both sub-folders and requests visits its steps in a different sequence than before, so a scenario whose steps depend on each other through variables or cookies is worth re-checking. Folders holding only requests, only sub-folders, or run without "Include sub-folders" are unaffected.

**Two notes on the issue text.**
- The issue's sidebar column reads `a_1, g_1, b_1, root_a, root_b`, which is off by one level: folders-first applies at *every* depth, so `child_a`'s subfolder renders above `child_a`'s own request and the displayed order is `g_1, a_1, b_1, root_a, root_b`. The fix produces that (deepest-subtree-first), not the issue's sequence - verified by rendering the tree, not by reading the code.
- `MCP run_collection_smoke` was re-verified as direct-requests-only, so it has no cross-block order to disagree about, and the app has no second recursive walk to update.

**Deliberate deviation from the issue spec.** Its last acceptance criterion asks for a release note alongside the docs. One was written and then removed at the reviewer's request (`.github/release-notes/vX.Y.Z.md` is authored when a release is planned, from `git log`, so a file started mid-cycle is not the repo's flow). The behaviour change is recorded in the commit history and here instead, for whoever writes the 0.15.0 notes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change (behaviour change: the sequence a recursive collection run executes in)
- [x] Documentation update

## Testing

All green on this branch, run from a clean tree:

- `python build.py -e -t` then `ctest --preset linux-dev` - **1139/1139 passed**. Three of those are new/changed: `RecursiveDescentRunsEachSubtreeBeforeTheFoldersOwnRequests` (restated for the new order), `RunOrderConformanceFixtureIsNonEmpty`, `RecursiveRunFollowsTheSidebarOrderInEveryFixtureCase` (5 fixture cases), plus `ParentIdCycleTerminatesAndVisitsEachCollectionOnce` whose degenerate sequence follows from the new rule.
- `cd app && pnpm test` - **3448/3448 passed across 353 files**, including the new `CollectionTree.run-order.conformance.test.tsx` (7 tests).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.
- `mkdocs build --strict` - clean (docs changed).
- No pre-existing failures reproduced on the base commit.

**Mutation-checked both halves.** Restoring the pre-order push in `collect_requests` and rebuilding reddens exactly the three ordering tests and nothing else (1136/1139 pass), so no other engine test was silently relying on the old order. Flipping `CollectionItem`'s two render blocks reddens 6 of the 7 new app tests plus the `folders-first` pair - the app test reads the real render, not a copy of the rule.

Fixture cases: a three-level tree (deepest subtree first), two subfolders plus own requests, colliding `order` values across the two blocks (the post-densify shape, both blocks dense `0..n-1`), all-zero orders falling to `createdAt` block by block, and an empty subfolder contributing nothing.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the scenario block's ordering paragraph, plus a two-block note in **Ordering**), `docs/plans/collection-runner-design.md`, `docs/app/state-management.md` (the sorting paragraph gains the cross-block sentence the issue asked about), the `recursive` doc comments in `scenario_plan.hpp` / `app/src/types/api.ts`, and the Run dialog's module comment plus its user-facing "Include sub-folders" hint.

## Related Issues
Closes #431