### PR TITLE
chore(app): delete 21 renderer debug logs and gate the next one with no-console

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -51,6 +51,13 @@ export default [
 			// it only produces false positives. Disabling it is the typescript-eslint
 			// recommendation. (Enabled globally via js.configs.recommended above.)
 			"no-undef": "off",
+			// Debug logging is not a renderer feature. 21 `console.log` calls had
+			// accumulated before anyone counted (#428), three of them dumping whole
+			// stored requests - auth headers, tokens and scripts - into DevTools.
+			// `warn`/`error` stay: they report states a user may need to report
+			// back. The rule flags calls, not string literals, so the `console.log`
+			// inside a generated code snippet (services/codegen) is unaffected.
+			"no-console": ["error", { allow: ["warn", "error"] }],
 			"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
 			"@typescript-eslint/no-unused-vars": [
 				"error",
@@ -74,6 +81,19 @@ export default [
 		},
 		rules: {
 			"no-undef": "off",
+		},
+	},
+
+	// Main process: its console IS the app's log. `electron/` runs in Node and
+	// writes to the terminal the user launched Vayu from - the sidecar's engine
+	// lifecycle, the lock-file recovery, the updater's disabled-in-dev line.
+	// That output is diagnosed from, not left-over debug chatter, so `no-console`
+	// is off here rather than suppressed 35 times. The renderer keeps the rule:
+	// its console is DevTools, which nobody reads and everybody ships.
+	{
+		files: ["electron/**/*.{ts,tsx}"],
+		rules: {
+			"no-console": "off",
 		},
 	},
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,7 +10,6 @@ import Shell from "./components/layout/Shell";
 import TitleBar from "./components/layout/TitleBar";
 import UpdateBanner from "./components/shared/UpdateBanner";
 import Toaster from "./components/shared/Toaster";
-import { useEngineStore } from "./stores";
 import {
 	useConfigQuery,
 	useHealthQuery,
@@ -30,8 +29,6 @@ import { useMcpDataInvalidation } from "./hooks/useMcpDataInvalidation";
 import { useSaveStore } from "./stores/save-store";
 
 function App() {
-	const { isEngineConnected } = useEngineStore();
-
 	// Sync theme with OS/Electron settings
 	useElectronTheme();
 
@@ -88,11 +85,6 @@ function App() {
 			await useSaveStore.getState().flushAll();
 		});
 	}, []);
-
-	// Log connection status for debugging
-	if (isEngineConnected) {
-		console.log("App: Engine connected, data queries active");
-	}
 
 	return (
 		<div className="flex flex-col h-full">

--- a/app/src/errors/error-logger.ts
+++ b/app/src/errors/error-logger.ts
@@ -54,6 +54,11 @@ export function logError(
 			console.warn("[WARN]", logEntry);
 			break;
 		case "low":
+			// The bottom rung of a severity ladder, not debug chatter: this branch
+			// exists so a low entry does not shout as a warning. Raising it to
+			// `console.warn` to satisfy `no-console` would erase the distinction
+			// the switch is here to make.
+			// eslint-disable-next-line no-console
 			console.info("[INFO]", logEntry);
 			break;
 	}

--- a/app/src/modules/dashboard/index.tsx
+++ b/app/src/modules/dashboard/index.tsx
@@ -83,14 +83,10 @@ export default function LoadTestDashboard() {
 						const status = report.metadata.status;
 						if (status === "completed" || status === "stopped" || status === "failed") {
 							// Run finished while we were away - update state
-							console.log(
-								`Run ${currentRunId} finished while away (status: ${status})`
-							);
 							setFinalReport(report);
 							loadTestService.stopMonitoring();
 						} else if (!loadTestService.isMonitoring(currentRunId)) {
 							// Run is still running but service is not connected - reconnect
-							console.log(`Reconnecting to run ${currentRunId}`);
 							loadTestService.startMonitoring(currentRunId);
 						}
 					}
@@ -115,7 +111,6 @@ export default function LoadTestDashboard() {
 		if (mode !== "running" || isStreaming || !currentRunId || finalReport) return;
 		// Streaming stopped but mode is still "running" - the test completed naturally
 		// Fetch the final report to get the actual completion status
-		console.log("Streaming stopped, fetching final report...");
 		// The fetch runs from its own async function, not the effect body: the
 		// loading flag and the result then land as callbacks (what the sibling
 		// report-retry effect below already does), and the cancel flag keeps a
@@ -171,9 +166,6 @@ export default function LoadTestDashboard() {
 							setFinalReport(report);
 							loadAttemptRef.current = 0;
 						} else if (loadAttemptRef.current < TIMING.REPORT_MAX_ATTEMPTS) {
-							console.log(
-								`Report has zero data, retrying... (attempt ${loadAttemptRef.current + 1})`
-							);
 							loadAttemptRef.current++;
 							setIsLoadingReport(false);
 						} else {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -130,9 +130,7 @@ export const apiService = {
 
 	// Collections
 	async listCollections(): Promise<Collection[]> {
-		console.log("API: Fetching collections from", API_ENDPOINTS.COLLECTIONS);
 		const response = await httpClient.get<RawCollection[]>(API_ENDPOINTS.COLLECTIONS);
-		console.log("API: Received collections:", response);
 		return response.map(CollectionTransformer.toFrontend);
 	},
 
@@ -166,21 +164,16 @@ export const apiService = {
 		const queryParams = params?.collectionId
 			? { collectionId: params.collectionId }
 			: undefined;
-		console.log("API: Fetching requests from", API_ENDPOINTS.REQUESTS, queryParams);
 		const response = await httpClient.get<RawRequest[]>(API_ENDPOINTS.REQUESTS, queryParams);
-		console.log("API: Received requests:", response);
 		return response.map(RequestTransformer.toFrontend);
 	},
 
 	async getRequest(id: string): Promise<Request> {
-		console.log("API: Fetching request from", API_ENDPOINTS.REQUEST_BY_ID(id));
 		const response = await httpClient.get<RawRequest>(API_ENDPOINTS.REQUEST_BY_ID(id));
-		console.log("API: Received request:", response);
 		return RequestTransformer.toFrontend(response);
 	},
 
 	async createRequest(data: CreateRequestRequest): Promise<Request> {
-		console.log("Creating request with data:", data);
 		const response = await httpClient.post<RawRequest>(API_ENDPOINTS.REQUESTS, withoutId(data));
 		return RequestTransformer.toFrontend(response);
 	},

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -39,17 +39,14 @@ class LoadTestService {
 	startMonitoring(runId: string): void {
 		// If already monitoring this run, do nothing
 		if (this.activeRunId === runId && this.isConnected) {
-			console.log(`[LoadTestService] Already monitoring run ${runId}`);
 			return;
 		}
 
 		// If monitoring a different run, stop it first
 		if (this.activeRunId && this.activeRunId !== runId) {
-			console.log(`[LoadTestService] Switching from run ${this.activeRunId} to ${runId}`);
 			this.stopMonitoring();
 		}
 
-		console.log(`[LoadTestService] Starting monitoring for run ${runId}`);
 		this.activeRunId = runId;
 		this.isConnected = true;
 
@@ -89,7 +86,6 @@ class LoadTestService {
 		}
 		this.pendingBuffer = [];
 		this.lastMetricsPushTime = 0;
-		console.log(`[LoadTestService] Stopping monitoring for run ${this.activeRunId}`);
 		this.activeRunId = null;
 		this.isConnected = false;
 		sseClient.disconnect();
@@ -147,7 +143,6 @@ class LoadTestService {
 	}
 
 	private async handleClose(): Promise<void> {
-		console.log("[LoadTestService] SSE closed - converging on stored report");
 		const runId = this.activeRunId;
 		if (this.throttleTimer) {
 			clearTimeout(this.throttleTimer);

--- a/app/src/services/sse-client.ts
+++ b/app/src/services/sse-client.ts
@@ -152,7 +152,6 @@ export class SSEClient {
 
 		const endpoint = API_ENDPOINTS.METRICS_LIVE(runId);
 		const url = `${API_ENDPOINTS.BASE_URL}${endpoint}`;
-		console.log("Connecting to live endpoint:", url);
 
 		try {
 			this.eventSource = new EventSource(url);
@@ -194,7 +193,6 @@ export class SSEClient {
 			}
 
 			this.eventSource.addEventListener("complete", () => {
-				console.log("Load test completed");
 				// Send final metrics before closing
 				onMessage({ ...this.currentMetrics });
 				this.disconnect();
@@ -216,15 +214,16 @@ export class SSEClient {
 				// canonical recovery is to converge on `GET /runs/:id/report`, which
 				// the load-test service does in its onClose handler.
 				if (this.eventSource?.readyState === EventSource.CLOSED) {
-					console.log("SSE connection closed unexpectedly - treating as terminal");
+					// A warn, not chatter: the stream ended without the engine's
+					// `complete`, so the metrics shown are whatever arrived before
+					// the drop and the caller is about to converge on the stored
+					// report. That is the one SSE lifecycle state worth a line in
+					// the console.
+					console.warn("SSE connection closed unexpectedly - treating as terminal");
 					this.disconnect();
 					onClose();
 				}
 				// For CONNECTING state errors, wait - the browser will retry.
-			});
-
-			this.eventSource.addEventListener("open", () => {
-				console.log("SSE connection established");
 			});
 		} catch (error) {
 			onError(error instanceof Error ? error : new Error("Failed to connect to SSE"));

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -107,10 +107,16 @@ The app will:
 **Renderer Process (React):**
 - Open DevTools: `mainWindow.webContents.openDevTools()` in `main.ts`
 - Or use React DevTools extension
+- `console.log()` is a lint error under `app/src` (`no-console`, `warn` and
+  `error` allowed): it is for reading while you work, not for committing, and
+  the calls that accumulated this way were dumping stored requests with their
+  auth headers into DevTools. Delete the call before you commit, or keep it as
+  a `console.warn` if the state it reports is genuinely abnormal.
 
 **Main Process (Electron):**
 - Use VS Code debugger with launch configuration
-- Or use `console.log()` (outputs to terminal)
+- Or use `console.log()` (outputs to terminal) - the rule above is renderer-only,
+  because the main process console is the log the user actually reads
 
 **Engine:**
 - Engine logs appear in Electron main process console


### PR DESCRIPTION
## Description

**Root cause.** The renderer had no rule against `console.log`, so debug statements accumulated one commit at a time - 21 of them, verified at `c7fea40`, exactly the inventory the issue lists. Three dump whole stored requests (`api.ts` requests carry headers, auth and scripts) into DevTools. #360 deleted the `updateRequest` log because that one line was in its scope; its exact sibling in `createRequest` sat one function away and survived. That is the shape of the defect: the instance keeps getting fixed and the class never does.

**Approach.** Delete all 21, then close the class - `no-console` (allowing `warn`/`error`) on the `**/*.{ts,tsx}` block, where CI's existing zero-warning gate (#189) turns the next one into a build failure. The rule flags calls, not string literals, so the `console.log` inside the generated fetch snippet and the user-script fixtures are untouched.

**Rejected.** Scoping the rule to `src/**` instead of the shared block. It reads as narrower and safer, but it means a future top-level directory is unguarded by default - the same "the class stays open" failure this PR exists to close. Deny-by-default with two named exemptions is the version a later contributor can reason about.

## Two carve-outs the issue did not anticipate

The issue's step 2 puts the rule on the `**/*.{ts,tsx}` block, which also covers `electron/` and the tests. Tests turned out clean (their `console.log` hits are all script-content string literals, not calls), but two real cases needed a decision, and both are explicit rather than implied:

- **`electron/**` turns the rule off** - 35 calls across `sidecar.ts`, `main.ts`, `updater.ts`, `preload.ts`. The main process writes to the terminal the user launched Vayu from: engine lifecycle, lock-file recovery, the updater's disabled-in-dev line. That output is diagnosed from, not shipped-and-forgotten, and suppressing it 35 times would say the same thing worse. The override carries the reason.
- **`error-logger.ts:57`'s `console.info`** is the bottom rung of a severity ladder (`critical/high → error`, `medium → warn`, `low → info`), not chatter. It takes a one-line `eslint-disable-next-line` with the reason, per the app convention and `CONTRIBUTING.md:207`. Raising it to `console.warn` to satisfy the rule would erase the distinction the switch exists to make.

## Judgement calls inside the sweep

- **`sse-client.ts:219` becomes `console.warn`**, the one case the issue left to the implementer. The stream ended without the engine's `complete` event, so the metrics on screen are whatever arrived before the drop and the caller is about to converge on the stored report - a genuinely abnormal state, not lifecycle noise.
- **`sse-client.ts`'s `open` listener is removed entirely**, not emptied: its body was only the log, and an empty listener is the dead wiring the file's own comment at `:180` warns about. No test referenced it.
- **`App.tsx`: the log was the only reader of `isEngineConnected`.** Removing it leaves an unused destructure, and with it the file's only `useEngineStore()` call - an unscoped whole-store subscription that re-rendered `App` (and cascaded to its children) on every engine state change. Nothing in that render used the value; children that need connection state subscribe themselves. The `./stores` import goes too. Called out because it is a re-render change, not a pure deletion.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Hygiene / lint gate

## Testing

All run on this branch from a clean tree.

- `cd app && pnpm lint` - **green**. This is the regression test; there is no behavioural test that could change colour on a deletion of write-only statements.
- **Mutation-checked, both directions.** Re-adding one `console.log` to `App.tsx` reddens lint with `Unexpected console statement` at that exact line; removing it restores green. The `eslint-disable` is itself mutation-proof - `--report-unused-disable-directives` is already on, and it caught my first attempt at the `error-logger` suppression when the directive was not immediately above the call.
- `cd app && pnpm test` - **3441 passed across 352 files**, 0 failed. Proves no adjacent expression was deleted with a log (the `listCollections` / `listRequests` / `getRequest` bodies all had a log either side of the awaited call).
- `cd app && pnpm type-check` - clean (all three projects, including `tsconfig.electron-test.json`).
- `pnpm prettier --check` on every touched file - clean. `docs/app/building.md` was already prettier-dirty on master, so per CLAUDE.md it is left unformatted rather than reflowed.
- `mkdocs build --strict` - clean (docs changed).
- Engine untouched, so no engine build or ctest run: no C++ file is in the diff and no test there could change colour.
- No pre-existing failures reproduced on the base commit.

Acceptance scan, `rg -n "console\.log" app/src --glob '!**/*.test.*'` - six hits, **zero call sites**: the codegen snippet string, a fixture's script content, and four comments (`domain.ts`, `useGrowingWindow.ts`, `index.css`, `parse-logs.ts`). `console.warn`/`console.error` sites are untouched, and the script-console feature that renders *user* script logs is not in the diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable - the lint rule is the test)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/building.md`. The issue said no docs change was needed, and that is right about `CONTRIBUTING.md` (it describes ESLint as CI-enforced without enumerating rules) - but its Debugging section advises `console.log`, under a **Main Process** bullet that stays correct and next to a **Renderer Process** bullet that now would have walked a contributor into a CI failure. The renderer bullet states the rule and what to do instead; the main-process bullet says the rule does not reach it.

## Related Issues
Closes #428

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8WZXt3xw9V1nSfWyYRkWe)_