### PR TITLE
fix(engine/scripting): offer pm.iterationData, and close the callable-implies-offered hole

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -140,7 +140,14 @@ pm.response.reason()          // Status reason phrase ('OK', 'Not Found')
 pm.response.size()            // { body, header, total } in bytes
 pm.response.cookies           // Set-Cookie, parsed - see below
                               // (the stored session is pm.cookies)
+pm.response.errorCode         // string | undefined - TIMEOUT, DNS_ERROR, ...
+pm.response.errorMessage      // string | undefined - the same failure in words
 ```
+
+`errorCode` and `errorMessage` are present **only when the send failed before a
+response arrived**, so `if (pm.response.errorCode)` is the test for a transport
+failure - the status code in that case is vayu's synthetic `0`. A response that
+reached the script from a server carries neither.
 
 `reason()` reports the reason phrase from the status line. Where none was
 received it falls back to the canonical text for the code, so a client-side

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -312,12 +312,13 @@ std::string field_type (const std::string& detail) {
     // undefined` and not `number | undefined`, which silently declared
     // `pm.info.iteration` as `void` and made `pm.info.iteration + 1` an error
     // in the editor.
-    static constexpr std::string_view OPTIONAL = " | undefined";
-    bool optional                              = false;
-    if (base.size () > OPTIONAL.size () &&
-    base.compare (base.size () - OPTIONAL.size (), OPTIONAL.size (), OPTIONAL) == 0) {
+    static constexpr std::string_view OPTIONAL_SUFFIX = " | undefined";
+    bool optional                                     = false;
+    if (base.size () > OPTIONAL_SUFFIX.size () &&
+    base.compare (base.size () - OPTIONAL_SUFFIX.size (),
+    OPTIONAL_SUFFIX.size (), OPTIONAL_SUFFIX) == 0) {
         optional = true;
-        base     = trim (base.substr (0, base.size () - OPTIONAL.size ()));
+        base = trim (base.substr (0, base.size () - OPTIONAL_SUFFIX.size ()));
     }
 
     std::string resolved;
@@ -331,7 +332,7 @@ std::string field_type (const std::string& detail) {
         // `void | undefined` is not a type, so the suffix goes with it.
         return "void";
     }
-    return optional ? resolved + std::string (OPTIONAL) : resolved;
+    return optional ? resolved + std::string (OPTIONAL_SUFFIX) : resolved;
 }
 
 void append_doc (std::string& out, const TypeNode& node, const std::string& indent) {

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "vayu/http/routes.hpp"
@@ -305,14 +306,32 @@ std::string field_type (const std::string& detail) {
     if (paren != std::string::npos) {
         base = trim (base.substr (0, paren));
     }
-    if (base == "number" || base == "string" || base == "boolean" ||
-    base == "any" || base == "string | undefined") {
-        return base;
+
+    // `T | undefined` is T, optional - so the suffix is split off and put back
+    // rather than every pair being listed. The list form had `string |
+    // undefined` and not `number | undefined`, which silently declared
+    // `pm.info.iteration` as `void` and made `pm.info.iteration + 1` an error
+    // in the editor.
+    static constexpr std::string_view OPTIONAL = " | undefined";
+    bool optional                              = false;
+    if (base.size () > OPTIONAL.size () &&
+    base.compare (base.size () - OPTIONAL.size (), OPTIONAL.size (), OPTIONAL) == 0) {
+        optional = true;
+        base     = trim (base.substr (0, base.size () - OPTIONAL.size ()));
     }
-    if (base == "object") {
-        return ANY_OBJECT;
+
+    std::string resolved;
+    if (base == "number" || base == "string" || base == "boolean" || base == "any") {
+        resolved = base;
+    } else if (base == "object") {
+        resolved = ANY_OBJECT;
+    } else {
+        // Prose rather than a type - an assertion getter restating its own
+        // name, or a description. `void` is the honest answer, and
+        // `void | undefined` is not a type, so the suffix goes with it.
+        return "void";
     }
-    return "void";
+    return optional ? resolved + std::string (OPTIONAL) : resolved;
 }
 
 void append_doc (std::string& out, const TypeNode& node, const std::string& indent) {

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -116,6 +116,25 @@ nlohmann::json get_script_completions () {
     "Near-zero for single-shot sends." },
     { "sortText", "1_pm_response_time_queue" } });
 
+    completions.push_back ({ { "label", "pm.response.errorCode" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.response.errorCode" }, { "detail", "string | undefined" },
+    { "documentation",
+    "Why the send failed before a response arrived - TIMEOUT, "
+    "CONNECTION_FAILED, "
+    "DNS_ERROR, SSL_ERROR and friends. Absent when the request reached the "
+    "server, so its presence is the test for a transport failure; the status "
+    "code in that case is the synthetic 0.\n\nExample:\nif "
+    "(pm.response.errorCode) { console.log('never sent: ' + "
+    "pm.response.errorCode); }" },
+    { "sortText", "1_pm_response_errorCode" } });
+
+    completions.push_back ({ { "label", "pm.response.errorMessage" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.response.errorMessage" }, { "detail", "string | undefined" },
+    { "documentation",
+    "The transport failure in words, alongside errorCode. Absent for the same "
+    "reason errorCode is - a response that arrived did not fail." },
+    { "sortText", "1_pm_response_errorMessage" } });
+
     completions.push_back ({ { "label", "pm.response.headers" }, { "kind", KIND_FIELD },
     { "insertText", "pm.response.headers" }, { "detail", "object" },
     { "documentation",
@@ -423,9 +442,10 @@ nlohmann::json get_script_completions () {
     "What this script is attached to and which hook it is running in. Every "
     "field is optional - an ad-hoc request has no id, and an unsaved one has a "
     "name no stored request carries - so test with typeof rather than assuming "
-    "a value.\n\niteration / iterationCount are deliberately absent: Vayu runs "
-    "a load test's Tests script once per sampled response, not once per "
-    "iteration, so there is no iteration number to report." },
+    "a value.\n\niteration / iterationCount are set by the collection runner "
+    "and by nothing else. A load test's Tests script runs once per sampled "
+    "response rather than once per iteration, so it has no iteration number to "
+    "report and reads undefined for both." },
     { "sortText", "0_pm_info" } });
 
     completions.push_back ({ { "label", "pm.info.requestId" }, { "kind", KIND_FIELD },
@@ -452,6 +472,66 @@ nlohmann::json get_script_completions () {
     "from.\n\nExample:\nif (pm.info.eventName === 'prerequest') { /* sign the "
     "request */ }" },
     { "sortText", "1_pm_info_eventName" } });
+
+    completions.push_back ({ { "label", "pm.info.iteration" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.info.iteration" }, { "detail", "number | undefined" },
+    { "documentation",
+    "Which pass of a collection run this step belongs to, 0-based. undefined "
+    "everywhere else - a single Send and a load run's Tests script have no "
+    "iteration to report.\n\nExample:\nif (pm.info.iteration === 0) { /* "
+    "first pass only */ }" },
+    { "sortText", "1_pm_info_iteration" } });
+
+    completions.push_back ({ { "label", "pm.info.iterationCount" }, { "kind", KIND_FIELD },
+    { "insertText", "pm.info.iterationCount" }, { "detail", "number | undefined" },
+    { "documentation",
+    "How many passes the collection run will make in total. undefined outside "
+    "a collection run, and set by the runner alone.\n\nExample:\nconsole.log("
+    "'pass ' + (pm.info.iteration + 1) + ' of ' + pm.info.iterationCount);" },
+    { "sortText", "1_pm_info_iterationCount" } });
+
+    // ========================================
+    // pm.iterationData - this iteration's data row (#356)
+    // ========================================
+    completions.push_back ({ { "label", "pm.iterationData" },
+    { "kind", KIND_VARIABLE }, { "insertText", "pm.iterationData" },
+    { "detail", "This iteration's data row | undefined" },
+    { "documentation",
+    "The row a data-driven collection run bound to this iteration - row "
+    "i % rows for iteration i - read through get() and "
+    "toObject().\n\nundefined "
+    "wherever there is no row: a single Send, a load run's Tests script, and a "
+    "collection run started without a data set. That is the opposite treatment "
+    "to pm.execution, and it is deliberate - a row is data, so \"this run is "
+    "not data-driven\" is a fact a script may branch on.\n\nExample:\nconst "
+    "user = pm.iterationData ? pm.iterationData.get('username') : "
+    "'default-user';\n\nRead-only: set, unset and clear throw. To put the row "
+    "into the request itself, use a {{data.column}} token instead." },
+    { "sortText", "0_pm_iterationData" } });
+
+    completions.push_back ({ { "label", "pm.iterationData.get" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.iterationData.get(\"${1:column}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.iterationData.get(column: string): any" },
+    { "documentation",
+    "This iteration's value for that column. A column the row does not carry "
+    "returns undefined, as every other pm scope reader does.\n\nValues keep "
+    "their JSON type: a JSON file's 3 arrives as a number, a CSV column "
+    "arrives as a string.\n\nOnly inside a data-driven collection run - "
+    "elsewhere pm.iterationData is undefined, so guard with it before "
+    "calling.\n\nExample:\nconst user = pm.iterationData.get('username');" },
+    { "sortText", "1_pm_iterationData_get" } });
+
+    completions.push_back ({ { "label", "pm.iterationData.toObject" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.iterationData.toObject()" },
+    { "detail", "pm.iterationData.toObject(): object" },
+    { "documentation",
+    "The whole row as a plain object, for spreading into a body or logging "
+    "the iteration's inputs.\n\nOnly inside a data-driven collection run - "
+    "elsewhere pm.iterationData is undefined, so guard with it before "
+    "calling.\n\nExample:\npm.request.body = "
+    "JSON.stringify(pm.iterationData.toObject());" },
+    { "sortText", "1_pm_iterationData_toObject" } });
 
     // ========================================
     // pm.environment - Environment variables

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "vayu/runtime/script_engine.hpp"
 #include "vayu/types.hpp"
@@ -599,6 +600,179 @@ TEST (ScriptCompletions, TheContentTypeSnippetPassesAgainstAJsonResponse) {
     EXPECT_TRUE (result.tests[0].passed)
     << "the offered Content-Type snippet fails against a JSON response: "
     << result.tests[0].error_message;
+}
+
+// ---------------------------------------------------------------------------
+// The general callable-implies-offered guard (#418).
+//
+// Every guard above this line is either offered-implies-callable, or the
+// reverse for one named surface (the cookie jar's write half, the variable
+// scopes, the expect matchers). So a whole new `pm.*` surface could be bound
+// and listed nowhere and nothing failed - which is exactly what happened to
+// `pm.iterationData`: shipped by #356, documented in scripting.md, and absent
+// from all 126 completion entries. The #337 closure verification predicted it
+// in those words, and the very next surface fell through.
+//
+// This closes the direction rather than the instance. It asks the *runtime*
+// what it bound rather than comparing against a list written out here, because
+// a hand-maintained list of expected names is a second copy that drifts the
+// same way the completions did - a new surface would have to be added to it
+// too, and forgetting that fails nothing again.
+// ---------------------------------------------------------------------------
+
+// A context with every optional surface populated, so the enumeration below
+// sees the *largest* `pm` the runtime ever builds. Several members are bound
+// conditionally - `pm.iterationData` only with a data row, `pm.info.iteration`
+// only in a scenario run, `pm.response.errorCode` only on a transport failure -
+// and a guard run against a bare context would silently not check them.
+struct FullyBoundContext {
+    vayu::Request request;
+    vayu::Response response;
+    vayu::Environment env;
+    vayu::Environment globals;
+    vayu::Environment collection_variables;
+    nlohmann::json row = nlohmann::json{ { "username", "ada" }, { "id", 7 } };
+    vayu::runtime::ScriptContext ctx;
+
+    FullyBoundContext () {
+        request.method  = vayu::HttpMethod::GET;
+        request.url     = "https://api.example.com/users";
+        request.headers = { { "Authorization", "Bearer t" } };
+
+        response.status_code = 200;
+        response.headers     = { { "content-type", "application/json" },
+                { "set-cookie", "session=abc; Path=/" } };
+        response.body        = R"({"ok": true})";
+        // Binds pm.response.errorCode / errorMessage, which exist only here.
+        response.error_code    = vayu::ErrorCode::Timeout;
+        response.error_message = "timed out";
+
+        ctx.request             = &request;
+        ctx.response            = &response;
+        ctx.environment         = &env;
+        ctx.globals             = &globals;
+        ctx.collectionVariables = &collection_variables;
+        ctx.iteration           = 0;
+        ctx.iteration_count     = 4;
+        ctx.iteration_data      = &row;
+        ctx.in_scenario         = true;
+    }
+};
+
+// Members the runtime binds and the editor must not offer, each with the reason
+// it is not a completion. Anything not on this list has to be in the list the
+// endpoint serves.
+bool is_deliberately_uncompletable (const std::string& name) {
+    return
+    // Bound only to throw, naming the three real scopes - offering it would be
+    // suggesting a call that cannot work.
+    name == "pm.variables.set" ||
+    // Bound only to throw: the rows are a run input, not a scope, so a write
+    // has nowhere to land (#356). Same reasoning as pm.variables.set.
+    name == "pm.iterationData.set" || name == "pm.iterationData.unset" ||
+    name == "pm.iterationData.clear" ||
+    // The assertion chain root and everything hanging off it. It is offered as
+    // the terminal `pm.response.to.be.*` labels instead, which is what an
+    // author types and what EveryOfferedResponseStatusClassExistsInTheRuntime
+    // checks; `pm.response.to` on its own asserts nothing, so a completion for
+    // it would suggest an expression with no effect.
+    name == "pm.response.to" || name.rfind ("pm.response.to.", 0) == 0;
+}
+
+// Objects whose members are *data*, not API: the header maps carry one property
+// per header on the wire, so descending into them would demand a completion
+// entry for `Authorization`. Their accessors are guarded by
+// EveryOfferedHeaderMemberIsCallableInTheRuntime above.
+bool is_data_map (const std::string& name) {
+    return name == "pm.request.headers" || name == "pm.response.headers" ||
+    name == "pm.response.cookies";
+}
+
+TEST (ScriptCompletions, EveryPmMemberTheRuntimeBindsIsOffered) {
+    const auto completions = get_script_completions ();
+
+    FullyBoundContext bound;
+    vayu::runtime::ScriptEngine engine;
+
+    // Walk `pm` two levels deep and report what is there. Two levels is what
+    // the surfaces are shaped like - `pm.<namespace>.<member>` - and going
+    // deeper reaches only the header maps and the assertion chain, both
+    // excluded above and both guarded separately.
+    auto enumerated = engine.execute (R"JS(
+        var names = [];
+        var top = Object.getOwnPropertyNames(pm).sort();
+        for (var i = 0; i < top.length; i++) {
+            var key = top[i];
+            names.push('pm.' + key);
+            var value = pm[key];
+            if (value === null || typeof value !== 'object') continue;
+            var members = Object.getOwnPropertyNames(value).sort();
+            for (var j = 0; j < members.length; j++) {
+                names.push('pm.' + key + '.' + members[j]);
+            }
+        }
+        pm.environment.set('bound', names.join(','));
+    )JS",
+    bound.ctx);
+    ASSERT_TRUE (enumerated.success) << enumerated.error_message;
+
+    const std::string bound_names = bound.env["bound"].value;
+    ASSERT_FALSE (bound_names.empty ())
+    << "the runtime enumeration found nothing, so this guard proved nothing";
+
+    std::vector<std::string> missing;
+    int checked = 0;
+    for (size_t start = 0; start <= bound_names.size ();) {
+        const size_t comma = bound_names.find (',', start);
+        const std::string name = bound_names.substr (
+        start, comma == std::string::npos ? std::string::npos : comma - start);
+        if (!name.empty () && !is_deliberately_uncompletable (name) && !is_data_map (name)) {
+            checked++;
+            if (find_by_label (completions, name) == nullptr) {
+                missing.push_back (name);
+            }
+        }
+        if (comma == std::string::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+
+    EXPECT_GT (checked, 40)
+    << "far fewer pm members than the runtime binds - the walk above is broken, "
+       "not the completion list";
+
+    std::string report;
+    for (const auto& name : missing) {
+        report += (report.empty () ? "" : ", ") + name;
+    }
+    EXPECT_TRUE (missing.empty ())
+    << "the runtime binds these but the completion list never offers them, so "
+       "no user can discover them in the editor: "
+    << report;
+}
+
+// The named half of the same check. The guard above reads the runtime, so a
+// surface deleted from both sides at once would pass it; this pins the entries
+// #418 requires by name, the way the cookie jar's write half is pinned.
+TEST (ScriptCompletions, TheIterationDataAccessorsAreOffered) {
+    const auto completions = get_script_completions ();
+
+    for (const char* expected : { "pm.iterationData", "pm.iterationData.get",
+         "pm.iterationData.toObject" }) {
+        const auto* item = find_by_label (completions, expected);
+        ASSERT_NE (item, nullptr) << expected << " is bound by the runtime but not offered";
+        // A completion that does not say so would promise a row in a plain
+        // request script, where pm.iterationData is undefined (#300/#356).
+        const std::string documentation = item->value ("documentation", std::string{});
+        EXPECT_NE (documentation.find ("undefined"), std::string::npos)
+        << expected << " does not say it is absent outside a data-driven run: " << documentation;
+    }
+
+    // `has` is not offered because the runtime does not bind it - the row
+    // accessors are get / toObject. Offering it would be the #182 defect.
+    EXPECT_EQ (find_by_label (completions, "pm.iterationData.has"), nullptr)
+    << "pm.iterationData.has is offered but the runtime binds only get/toObject";
 }
 
 } // namespace

--- a/engine/tests/script_types_test.cpp
+++ b/engine/tests/script_types_test.cpp
@@ -119,6 +119,22 @@ TEST (ScriptTypesTest, TerminalAssertionGettersAreVoid) {
     EXPECT_TRUE (contains (dts, "exist: void;"));
 }
 
+// An optional field is `T | undefined` for any T the reader knows, not for the
+// one pair someone happened to list. The list form carried `string | undefined`
+// alone, so `pm.info.iteration` - documented as `number | undefined` - was
+// declared `void`, and `pm.info.iteration + 1` was an error in the editor for a
+// script the runtime runs happily.
+TEST (ScriptTypesTest, OptionalFieldsKeepTheirUnderlyingType) {
+    const std::string dts = generate_script_typedefs ();
+    EXPECT_TRUE (contains (dts, "iteration: number | undefined;"));
+    EXPECT_TRUE (contains (dts, "iterationCount: number | undefined;"));
+    // The pair that already worked must not regress on the way through.
+    EXPECT_TRUE (contains (dts, "requestId: string | undefined;"));
+    EXPECT_TRUE (contains (dts, "errorCode: string | undefined;"));
+    // Prose is still not a type, and `void | undefined` is not one either.
+    EXPECT_FALSE (contains (dts, "void | undefined"));
+}
+
 TEST (ScriptTypesTest, ReadsReturnTypesFromTheDetailString) {
     const std::string dts = generate_script_typedefs ();
     EXPECT_TRUE (contains (dts, "get(name: string): string | undefined;"));


### PR DESCRIPTION
## Description

**Plan.** The root cause is not the missing `pm.iterationData` entries - it is that the completions guards only ever ran *offered-implies-callable*, plus by-name spot checks for three surfaces, so an entire `pm.*` surface could be bound and listed nowhere and nothing reddened. #356 shipped `pm.iterationData`, `scripting.md` documented it, and all 126 completion entries missed it. So this adds the entries **and** closes the direction: a new guard asks the *runtime* what it bound and requires a completion for each. I rejected the issue's other suggested shape - exporting a static table of bound `pm.*` names from the runtime for the binding code and the completions route to share - because that table is itself a second copy that can drift from the actual `JS_SetPropertyStr` calls, and maintaining it is the same act of remembering that failed here. Enumerating the live `pm` object cannot drift from what the runtime bound, because it *is* what the runtime bound.

Verified at `afbfaba`: zero `iterationData` hits in `scripting.cpp`, 126 entries. Blast radius traced - the completion table has two consumers, `GET /scripting/completions` (rendered by `useScriptCompletionProvider`) and `GET /scripting/types`, whose `.d.ts` is *generated from the same table* by `script_types.cpp`. No renderer or MCP code hardcodes the list, and no doc states the entry count, so both claims in the issue hold.

**What the guard found, beyond the reported instance.** Rather than weaken it, each was fixed:

- `pm.info.iteration` / `pm.info.iterationCount` - bound by the collection runner since #356, never offered. `pm.info`'s own completion text also still claimed they are "deliberately absent", which stopped being true when the runner started setting them.
- `pm.response.errorCode` / `pm.response.errorMessage` - bound on a transport failure, never offered, and undocumented in `scripting.md`.
- `pm.response.to` - the assertion chain root, allowlisted with its reason (it is offered as the terminal `.to.be.*` labels, and reading it asserts nothing).

**Deliberate deviations from the issue spec**, both stated because the issue asked me to read rather than guess:

1. The issue expected `get` / `has` / `toObject`. The runtime binds **`get` and `toObject`** only (`script_engine.cpp:4820+`) - there is no `has`. Offering one would be the #182 defect, so a test asserts `pm.iterationData.has` is *not* offered.
2. `set` / `unset` / `clear` are bound but throw by design, so they are allowlisted as deliberately-uncompletable alongside the existing `pm.variables.set`, not offered.

**One fix outside the issue's stated files, caused by it.** Adding the `pm.info` entries exposed the same drift one layer down: `field_type` in `script_types.cpp` matched a hand-listed set that contained `string | undefined` but not `number | undefined`, so `pm.info.iteration` was declared **`void`** in the generated `.d.ts` and `pm.info.iteration + 1` was an error in the editor for a script the runtime runs happily. Shipping the completions without this would have shipped that defect, so it is fixed here by splitting the `| undefined` suffix off and re-attaching it rather than enumerating the pairs.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**1142/1142 passed** (1139 on the base commit, plus the 3 tests added here). No pre-existing failures on the base commit.

Three tests added:

- `ScriptCompletions.EveryPmMemberTheRuntimeBindsIsOffered` - the general guard. Walks `pm` two levels deep against a context with **every conditional surface populated** (a data row, a scenario iteration, a transport error), because a guard run against a bare context would silently not check the members that only exist in those cases. Asserts it inspected more than 40 members, so it cannot pass by scanning nothing.
- `ScriptCompletions.TheIterationDataAccessorsAreOffered` - the named half, pinning the three entries and asserting each says it is `undefined` outside a data-driven run, plus that `has` is not offered.
- `ScriptTypesTest.OptionalFieldsKeepTheirUnderlyingType` - pins `number | undefined` and `string | undefined` through the generator, and that `void | undefined` is never emitted.

**Mutation check, both directions** (the acceptance criterion), applied together and confirmed red, then reverted:

- Removed the `pm.iterationData.get` entry → `the runtime binds these but the completion list never offers them: pm.iterationData.get, ...`
- Added a `pm.mutationFakeSurface` binding with no entry → same test named it. The next `pm.*` surface cannot repeat this silently.

Generated `.d.ts` verified against a running engine (`GET /scripting/types`) before and after: `iteration: number | undefined;`, `iterationCount: number | undefined;`, `errorCode: string | undefined;`, `iterationData: { get(column: string): any; ... }`.

No app changes - the renderer consumes both endpoints as data. `mkdocs build --strict` could not be run (mkdocs is not installed in this environment); the docs edit adds no link, heading or nav entry, so there is no anchor for it to break.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`scripting.cpp` was clang-format clean before and is formatted; `script_completions_test.cpp` was already not clang-format clean on master, so per CLAUDE.md it was left alone and the added code matches the file's prevailing style.

## Related Issues
Closes #418

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoyTt72zJgqNEWhbPC8Kng)_