### PR TITLE
fix(app/import): import OpenAPI file parts instead of empty text rows

### DIFF
--- a/app/src/modules/collections/ImportModal.test.tsx
+++ b/app/src/modules/collections/ImportModal.test.tsx
@@ -72,6 +72,46 @@ describe("ImportModal", () => {
 		expect(screen.queryByText(/file_body/)).not.toBeInTheDocument();
 	});
 
+	/**
+	 * An OpenAPI upload imports as a file part with nothing attached (#425). The
+	 * request looks complete in the preview tree, so the count is the only place
+	 * that says the user still has to pick files before those requests can be sent.
+	 */
+	it("counts file parts that still need a file", async () => {
+		const spec = JSON.stringify({
+			openapi: "3.0.0",
+			info: { title: "Upload API" },
+			paths: {
+				"/avatar": {
+					post: {
+						summary: "Upload avatar",
+						requestBody: {
+							content: {
+								"multipart/form-data": {
+									schema: {
+										type: "object",
+										properties: {
+											avatar: { type: "string", format: "binary" },
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		renderModal();
+		selectTab(/Paste JSON/i);
+		fireEvent.change(screen.getByPlaceholderText(/Paste/i), { target: { value: spec } });
+		fireEvent.click(screen.getByRole("button", { name: /Detect & Preview/i }));
+
+		await waitFor(() =>
+			expect(screen.getByText(/1 file part needs a file/i)).toBeInTheDocument()
+		);
+	});
+
 	it("renders the File drop zone when open", () => {
 		renderModal();
 		expect(screen.getByText(/Drop a file here/i)).toBeInTheDocument();

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -515,13 +515,26 @@ function PreviewView({
 					Existing globals are kept; a variable of the same name is overwritten.
 				</p>
 			)}
-			{(meta.skipped.length > 0 || meta.nonExecutableAuth > 0) && (
+			{(meta.skipped.length > 0 ||
+				meta.nonExecutableAuth > 0 ||
+				meta.unattachedFileParts > 0) && (
 				<p className="flex items-center gap-1.5 text-[11px] text-destructive-text">
 					<AlertTriangle className="h-3.5 w-3.5" />
 					{[
 						...meta.skipped.map((s) => `${s.count} ${skippedLabel(s.kind, s.count)}`),
 						...(meta.nonExecutableAuth > 0
 							? [`${meta.nonExecutableAuth} auth not executed`]
+							: []),
+						// An OpenAPI upload imports as a file row with nothing attached -
+						// the user has to pick the file before the request can be sent, so
+						// the preview says how many are waiting rather than letting them be
+						// discovered one 400 at a time.
+						...(meta.unattachedFileParts > 0
+							? [
+									`${meta.unattachedFileParts} file ${
+										meta.unattachedFileParts === 1 ? "part needs" : "parts need"
+									} a file`,
+								]
 							: []),
 					].join(" · ")}
 				</p>

--- a/app/src/queries/import.test.ts
+++ b/app/src/queries/import.test.ts
@@ -78,6 +78,7 @@ const COLLECTION_ONLY: ImportResult = {
 		globalCount: 0,
 		skipped: [],
 		nonExecutableAuth: 0,
+		unattachedFileParts: 0,
 	},
 };
 
@@ -114,6 +115,7 @@ describe("useImportMutation", () => {
 				globalCount: 1,
 				skipped: [],
 				nonExecutableAuth: 0,
+				unattachedFileParts: 0,
 			},
 		};
 		await result.current.mutateAsync({

--- a/app/src/services/importers/assign-ids.test.ts
+++ b/app/src/services/importers/assign-ids.test.ts
@@ -63,6 +63,7 @@ function fixture(): ImportResult {
 			globalCount: 0,
 			skipped: [],
 			nonExecutableAuth: 0,
+			unattachedFileParts: 0,
 		},
 	};
 }

--- a/app/src/services/importers/failure-message.test.ts
+++ b/app/src/services/importers/failure-message.test.ts
@@ -67,6 +67,7 @@ function result(): ImportResult {
 			globalCount: 0,
 			skipped: [],
 			nonExecutableAuth: 0,
+			unattachedFileParts: 0,
 		},
 	};
 }

--- a/app/src/services/importers/insomnia-v4.ts
+++ b/app/src/services/importers/insomnia-v4.ts
@@ -16,7 +16,13 @@ import type {
 	SkippedItem,
 } from "./types";
 import { asRecord, asStr, prop, type JsonRecord } from "@/lib/json-node";
-import { asString, importedFilePart, mapKeyValues, withRequiredContentType } from "./shared";
+import {
+	asString,
+	importedFilePart,
+	mapKeyValues,
+	unattachedFileParts,
+	withRequiredContentType,
+} from "./shared";
 import { toGraphQLEnvelope } from "@/lib/graphql/graphql-body";
 import { normalizeVars } from "./var-normalize";
 import { mapInsomniaOAuth2 } from "./oauth2-import";
@@ -395,6 +401,7 @@ export class InsomniaV4Parser implements ImportParser {
 				globalCount: 0,
 				skipped,
 				nonExecutableAuth: ctx.nonExec,
+				unattachedFileParts: unattachedFileParts(collections),
 			},
 		};
 	}

--- a/app/src/services/importers/openapi-v2.test.ts
+++ b/app/src/services/importers/openapi-v2.test.ts
@@ -205,6 +205,54 @@ describe("OpenApiV2Parser", () => {
 		expect(p.parse(parsed, raw, opts).meta.skipped).toEqual([]);
 	});
 
+	const uploadSpec = (consumes?: string[]) => ({
+		swagger: "2.0",
+		info: { title: "Upload API" },
+		paths: {
+			"/avatar": {
+				post: {
+					summary: "Upload avatar",
+					...(consumes ? { consumes } : {}),
+					parameters: [
+						{ name: "caption", in: "formData", type: "string" },
+						{ name: "avatar", in: "formData", type: "file" },
+					],
+				},
+			},
+		},
+	});
+
+	const uploadResult = (consumes?: string[]) => {
+		const spec = uploadSpec(consumes);
+		return p.parse(spec, JSON.stringify(spec), opts);
+	};
+
+	it("imports a `type: file` formData param as a file part, not an empty text row", () => {
+		const result = uploadResult(["multipart/form-data"]);
+		expect(result.collections[0].requests[0].body).toEqual({
+			mode: "form-data",
+			fields: [
+				{ key: "caption", value: "", enabled: true },
+				// No path: a spec documents the upload, never the file. Not `unresolved`
+				// either - there is no path here that could have gone unverified.
+				{ key: "avatar", value: "", enabled: true, type: "file", src: "" },
+			],
+		});
+		expect(result.meta.unattachedFileParts).toBe(1);
+	});
+
+	it("forces multipart for a file param a urlencoded-only consumes contradicts", () => {
+		// Only multipart has a file form on the wire, so the encoding follows the part.
+		expect(
+			uploadResult(["application/x-www-form-urlencoded"]).collections[0].requests[0].body
+		).toMatchObject({ mode: "form-data" });
+	});
+
+	it("counts no unattached file part for a spec whose form is all text", () => {
+		const spec = formSpec(["multipart/form-data"]);
+		expect(p.parse(spec, JSON.stringify(spec), opts).meta.unattachedFileParts).toBe(0);
+	});
+
 	it("treats charset json consume as json body", () => {
 		const spec = {
 			swagger: "2.0",

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import type { HttpMethod, KeyValueEntry, RequestAuth, RequestBody } from "@/types";
+import type { FormFieldEntry, HttpMethod, KeyValueEntry, RequestAuth, RequestBody } from "@/types";
 import type {
 	CollectionDraft,
 	ImportOptions,
@@ -18,6 +18,7 @@ import { sampleSchema } from "./schema-sampler";
 import { normalizeVars } from "./var-normalize";
 import { mapSwaggerOAuth2 } from "./oauth2-import";
 import { resolvePathItem, SkipTally } from "./openapi-shared";
+import { importedFilePart, unattachedFileParts } from "./shared";
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
 
@@ -140,6 +141,7 @@ export class OpenApiV2Parser implements ImportParser {
 				globalCount: 0,
 				skipped: tally.items(),
 				nonExecutableAuth: 0,
+				unattachedFileParts: unattachedFileParts([root]),
 			},
 		};
 	}
@@ -157,7 +159,7 @@ function buildSwaggerOp(
 	const params: KeyValueEntry[] = [];
 	const headers: KeyValueEntry[] = [];
 	let body: RequestBody = { mode: "none" };
-	const formFields: KeyValueEntry[] = [];
+	const formFields: FormFieldEntry[] = [];
 
 	const consumes = (Array.isArray(op.consumes) ? op.consumes : asArray(spec.consumes)).map(
 		(c) => asStr(c) ?? ""
@@ -211,12 +213,23 @@ function buildSwaggerOp(
 					: { mode: "text", content: JSON.stringify(sample, null, 2) };
 				break;
 			}
-			case "formData":
-				formFields.push({ key: name, value: "", enabled: true });
+			case "formData": {
+				const entry = { key: name, value: "", enabled: true };
+				// A spec names the upload, never the file - the part imports with no
+				// path and the user attaches one. Left as a text row (what this did
+				// until #425) it looked like a healthy field and sent nothing.
+				formFields.push(param.type === "file" ? importedFilePart(entry, "") : entry);
 				break;
+			}
 		}
 	}
-	if (formFields.length > 0) body = { mode: formMode, fields: formFields };
+	if (formFields.length > 0) {
+		// A file part has no urlencoded wire form, so a spec that declares one under
+		// a urlencoded-only `consumes` contradicts itself; multipart is the half of
+		// that contradiction which can carry the field.
+		const mode = formFields.some((f) => f.type === "file") ? "form-data" : formMode;
+		body = { mode, fields: formFields };
+	}
 
 	return {
 		name: asStr(op.summary) ?? asStr(op.operationId) ?? `${method.toUpperCase()} ${path}`,

--- a/app/src/services/importers/openapi-v3.test.ts
+++ b/app/src/services/importers/openapi-v3.test.ts
@@ -202,6 +202,70 @@ describe("OpenApiV3Parser", () => {
 		});
 	});
 
+	const uploadSpec = (contentType: string) => ({
+		openapi: "3.0.0",
+		paths: {
+			"/avatar": {
+				post: {
+					summary: "Upload avatar",
+					requestBody: {
+						content: {
+							[contentType]: {
+								schema: {
+									type: "object",
+									properties: {
+										caption: { type: "string" },
+										avatar: { type: "string", format: "binary" },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+
+	it("imports a `format: binary` multipart property as a file part, not an empty text row", () => {
+		const spec = uploadSpec("multipart/form-data");
+		const result = p.parse(spec, JSON.stringify(spec), opts);
+		expect(result.collections[0].requests[0].body).toEqual({
+			mode: "form-data",
+			fields: [
+				{ key: "caption", value: "", enabled: true },
+				// No path: a spec documents the upload, never the file. Not `unresolved`
+				// either - there is no path here that could have gone unverified.
+				{ key: "avatar", value: "", enabled: true, type: "file", src: "" },
+			],
+		});
+		expect(result.meta.unattachedFileParts).toBe(1);
+	});
+
+	it("leaves a binary property under urlencoded as text - that wire form has no file", () => {
+		const spec = uploadSpec("application/x-www-form-urlencoded");
+		const result = p.parse(spec, JSON.stringify(spec), opts);
+		expect(result.collections[0].requests[0].body).toEqual({
+			mode: "x-www-form-urlencoded",
+			fields: [
+				{ key: "caption", value: "", enabled: true },
+				{ key: "avatar", value: "", enabled: true },
+			],
+		});
+		expect(result.meta.unattachedFileParts).toBe(0);
+	});
+
+	it("counts unattached file parts across tagged and untagged operations", () => {
+		const upload = uploadSpec("multipart/form-data").paths["/avatar"].post;
+		const spec = {
+			openapi: "3.0.0",
+			paths: {
+				"/avatar": { post: upload },
+				"/docs": { post: { ...upload, summary: "Upload doc", tags: ["docs"] } },
+			},
+		};
+		expect(p.parse(spec, JSON.stringify(spec), opts).meta.unattachedFileParts).toBe(2);
+	});
+
 	it("records a TRACE operation as an unsupported method instead of omitting it", () => {
 		const spec = {
 			openapi: "3.0.0",

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -14,10 +14,11 @@ import type {
 	RequestDraft,
 } from "./types";
 import { asArray, asRecord, asStr, prop, type JsonRecord } from "@/lib/json-node";
-import { sampleSchema, schemaFieldNames } from "./schema-sampler";
+import { sampleSchema, schemaFormFields } from "./schema-sampler";
 import { normalizeVars } from "./var-normalize";
 import { mapOpenApiV3OAuth2 } from "./oauth2-import";
 import { resolvePathItem, SkipTally } from "./openapi-shared";
+import { importedFilePart, unattachedFileParts } from "./shared";
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
 
@@ -126,6 +127,7 @@ export class OpenApiV3Parser implements ImportParser {
 				globalCount: 0,
 				skipped: tally.items(),
 				nonExecutableAuth: 0,
+				unattachedFileParts: unattachedFileParts([root]),
 			},
 		};
 	}
@@ -222,15 +224,17 @@ function buildBody(requestBody: unknown, resolveRef: (r: string) => unknown): Re
 	if (content["text/plain"]) return { mode: "text", content: "" };
 	for (const ct of ["application/x-www-form-urlencoded", "multipart/form-data"] as const) {
 		if (content[ct]) {
-			const fields = schemaFieldNames(prop(content[ct], "schema"), resolveRef).map((k) => ({
-				key: k,
-				value: "",
-				enabled: true,
-			}));
-			return {
-				mode: ct === "multipart/form-data" ? "form-data" : "x-www-form-urlencoded",
-				fields,
-			};
+			const multipart = ct === "multipart/form-data";
+			const fields = schemaFormFields(prop(content[ct], "schema"), resolveRef).map((f) => {
+				const entry = { key: f.name, value: "", enabled: true };
+				// A spec names the upload, never the file - the part imports with no
+				// path and the user attaches one. Left as a text row (what this did
+				// until #425) it looked like a healthy field and sent nothing.
+				// Only under multipart: urlencoded has no file form on the wire, so a
+				// `format: binary` there is a spec that cannot mean what it says.
+				return multipart && f.file ? importedFilePart(entry, "") : entry;
+			});
+			return { mode: multipart ? "form-data" : "x-www-form-urlencoded", fields };
 		}
 	}
 	return { mode: "none" };

--- a/app/src/services/importers/orchestrator.test.ts
+++ b/app/src/services/importers/orchestrator.test.ts
@@ -120,6 +120,7 @@ function fixture(): ImportResult {
 			globalCount: 0,
 			skipped: [],
 			nonExecutableAuth: 0,
+			unattachedFileParts: 0,
 		},
 	});
 }
@@ -241,6 +242,7 @@ describe("ImportOrchestrator", () => {
 				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
+				unattachedFileParts: 0,
 			},
 		};
 		await expect(new ImportOrchestrator(api).run(result, opts)).rejects.toThrow(
@@ -264,6 +266,7 @@ describe("ImportOrchestrator", () => {
 					globalCount: Object.keys(globals).length,
 					skipped: [],
 					nonExecutableAuth: 0,
+					unattachedFileParts: 0,
 				},
 			});
 		}

--- a/app/src/services/importers/postman-environment.test.ts
+++ b/app/src/services/importers/postman-environment.test.ts
@@ -89,6 +89,7 @@ describe("PostmanEnvironmentParser", () => {
 				globalCount: 0,
 				skipped: [],
 				nonExecutableAuth: 0,
+				unattachedFileParts: 0,
 			});
 		});
 
@@ -144,6 +145,7 @@ describe("PostmanEnvironmentParser", () => {
 				globalCount: 4,
 				skipped: [],
 				nonExecutableAuth: 0,
+				unattachedFileParts: 0,
 			});
 		});
 

--- a/app/src/services/importers/postman-environment.ts
+++ b/app/src/services/importers/postman-environment.ts
@@ -84,6 +84,7 @@ export class PostmanEnvironmentParser implements ImportParser {
 				globalCount: Object.keys(globals).length,
 				skipped: [],
 				nonExecutableAuth: 0,
+				unattachedFileParts: 0, // an environment export carries no requests
 			},
 		};
 	}

--- a/app/src/services/importers/postman.ts
+++ b/app/src/services/importers/postman.ts
@@ -23,6 +23,7 @@ import {
 	mapPostmanAuth,
 	rawBody,
 	toVarRecord,
+	unattachedFileParts,
 	withRequiredContentType,
 } from "./shared";
 import { normalizeVars } from "./var-normalize";
@@ -324,6 +325,7 @@ function parsePostman(parsed: unknown, opts: ImportOptions, formatName: string):
 			globalCount: 0,
 			skipped,
 			nonExecutableAuth: ctx.nonExecutableAuth,
+			unattachedFileParts: unattachedFileParts([root]),
 		},
 	};
 }

--- a/app/src/services/importers/schema-sampler.test.ts
+++ b/app/src/services/importers/schema-sampler.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { sampleSchema, schemaFieldNames } from "./schema-sampler";
+import { sampleSchema, schemaFormFields } from "./schema-sampler";
+
+/** The field names alone - what most of these cases are about. */
+const names = (schema: unknown, resolve = resolver): string[] =>
+	schemaFormFields(schema, resolve).map((f) => f.name);
 
 const resolver = (ref: string): unknown =>
 	({
@@ -77,33 +81,93 @@ describe("sampleSchema", () => {
 	});
 });
 
-describe("schemaFieldNames", () => {
+describe("schemaFormFields", () => {
 	it("resolves a $ref'd form schema to its property names", () => {
-		expect(schemaFieldNames({ $ref: "#/components/schemas/Pet" }, resolver)).toEqual([
+		expect(names({ $ref: "#/components/schemas/Pet" })).toEqual(["id", "name", "tags"]);
+	});
+	it("reads an inline schema's own properties, in order", () => {
+		expect(
+			names({ type: "object", properties: { grant_type: {}, username: {}, password: {} } })
+		).toEqual(["grant_type", "username", "password"]);
+	});
+	it("follows the first allOf branch, as JSON bodies do", () => {
+		expect(names({ allOf: [{ $ref: "#/components/schemas/Pet" }, {}] })).toEqual([
 			"id",
 			"name",
 			"tags",
 		]);
 	});
-	it("reads an inline schema's own properties, in order", () => {
-		expect(
-			schemaFieldNames(
-				{ type: "object", properties: { grant_type: {}, username: {}, password: {} } },
-				resolver
-			)
-		).toEqual(["grant_type", "username", "password"]);
-	});
-	it("follows the first allOf branch, as JSON bodies do", () => {
-		expect(
-			schemaFieldNames({ allOf: [{ $ref: "#/components/schemas/Pet" }, {}] }, resolver)
-		).toEqual(["id", "name", "tags"]);
-	});
-	it("has no field names for a missing schema or one that samples to a non-object", () => {
-		expect(schemaFieldNames(undefined, resolver)).toEqual([]);
-		expect(schemaFieldNames({ type: "string" }, resolver)).toEqual([]);
-		expect(schemaFieldNames({ type: "array", items: { type: "string" } }, resolver)).toEqual(
+	it("has no fields for a missing schema or one that samples to a non-object", () => {
+		expect(schemaFormFields(undefined, resolver)).toEqual([]);
+		expect(schemaFormFields({ type: "string" }, resolver)).toEqual([]);
+		expect(schemaFormFields({ type: "array", items: { type: "string" } }, resolver)).toEqual(
 			[]
 		);
-		expect(schemaFieldNames({ example: "not an object" }, resolver)).toEqual([]);
+		expect(schemaFormFields({ example: "not an object" }, resolver)).toEqual([]);
+	});
+
+	it("marks a `format: binary` property as a file and leaves text fields alone", () => {
+		expect(
+			schemaFormFields(
+				{
+					type: "object",
+					properties: {
+						caption: { type: "string" },
+						avatar: { type: "string", format: "binary" },
+					},
+				},
+				resolver
+			)
+		).toEqual([
+			{ name: "caption", file: false },
+			{ name: "avatar", file: true },
+		]);
+	});
+
+	it("marks an array of binary items as a file - one row for a multi-file field", () => {
+		expect(
+			schemaFormFields(
+				{
+					type: "object",
+					properties: {
+						pages: { type: "array", items: { type: "string", format: "binary" } },
+						tags: { type: "array", items: { type: "string" } },
+					},
+				},
+				resolver
+			)
+		).toEqual([
+			{ name: "pages", file: true },
+			{ name: "tags", file: false },
+		]);
+	});
+
+	it("sees a binary property through a $ref and through the first allOf branch", () => {
+		const resolve = (ref: string): unknown =>
+			({
+				"#/components/schemas/Upload": {
+					type: "object",
+					properties: { doc: { $ref: "#/components/schemas/Binary" } },
+				},
+				"#/components/schemas/Binary": { type: "string", format: "binary" },
+			})[ref];
+		expect(schemaFormFields({ $ref: "#/components/schemas/Upload" }, resolve)).toEqual([
+			{ name: "doc", file: true },
+		]);
+		expect(
+			schemaFormFields({ allOf: [{ $ref: "#/components/schemas/Upload" }] }, resolve)
+		).toEqual([{ name: "doc", file: true }]);
+	});
+
+	it("reads no file out of an `example`, which carries no property schemas", () => {
+		expect(schemaFormFields({ example: { avatar: "" } }, resolver)).toEqual([
+			{ name: "avatar", file: false },
+		]);
+	});
+
+	it("survives a cyclic $ref rather than recursing forever", () => {
+		expect(schemaFormFields({ $ref: "#/components/schemas/Node" }, resolver)).toEqual([
+			{ name: "next", file: false },
+		]);
 	});
 });

--- a/app/src/services/importers/schema-sampler.ts
+++ b/app/src/services/importers/schema-sampler.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { asRecord } from "@/lib/json-node";
+import { asRecord, prop } from "@/lib/json-node";
 
 type Schema = Record<string, unknown>;
 export type RefResolver = (ref: string) => unknown;
@@ -20,20 +20,89 @@ export function sampleSchema(schema: unknown, resolveRef: RefResolver): unknown 
 	return walk(schema, resolveRef, 0, new Set<string>());
 }
 
+/** One field of a form body: its name, and whether it uploads a file rather than text. */
+export interface SchemaFormField {
+	name: string;
+	/** `format: "binary"`, or an array of it - the only way OpenAPI 3 spells "a file". */
+	file: boolean;
+}
+
 /**
- * Field names for a form body, read off the sampled stub rather than `schema.properties`.
+ * Fields for a form body, read off the sampled stub rather than `schema.properties`.
  * Going through `sampleSchema` is the point: a form schema written as `{$ref: ...}` or
  * `allOf` (what generators emit) has no literal `properties`, and reading that key
  * directly produced an empty field list. Form bodies now resolve exactly as far as JSON
  * bodies do - first branch only for `allOf`/`oneOf`/`anyOf`, since that is what the
  * sampler does for both. A schema that samples to a non-object (a scalar, an array, or an
- * `example` that is not an object) has no field names to give.
+ * `example` that is not an object) has no fields to give.
+ *
+ * `file` is resolved separately, against the property schemas: the sampler flattens a
+ * `format: binary` string to `""`, which is indistinguishable from a text field - the
+ * reason issue #425's uploads imported as empty text rows. The property lookup follows
+ * the same first-branch rule, so it agrees with the names; a schema whose fields came
+ * from an `example` has no property schemas to consult and every field reads as text.
  */
-export function schemaFieldNames(schema: unknown, resolveRef: RefResolver): string[] {
+export function schemaFormFields(schema: unknown, resolveRef: RefResolver): SchemaFormField[] {
 	if (schema == null) return [];
 	const sample = sampleSchema(schema, resolveRef);
 	if (!sample || typeof sample !== "object" || Array.isArray(sample)) return [];
-	return Object.keys(sample);
+	const props = asRecord(prop(resolveToSchema(schema, resolveRef, 0, new Set()), "properties"));
+	return Object.keys(sample).map((name) => ({
+		name,
+		file: isBinary(props?.[name], resolveRef, 0, new Set()),
+	}));
+}
+
+/**
+ * The schema a node ultimately denotes: `$ref` and the first `allOf`/`oneOf`/`anyOf`
+ * branch followed, under the sampler's own depth cap and cycle guard. Split out of
+ * `walk` because `walk` returns a *value* and the caller needs the declaration.
+ */
+function resolveToSchema(
+	node: unknown,
+	resolveRef: RefResolver,
+	depth: number,
+	seenRefs: Set<string>
+): Schema | undefined {
+	if (depth > MAX_DEPTH || node == null || typeof node !== "object") return undefined;
+	const schema = node as Schema;
+	if ("$ref" in schema && typeof schema.$ref === "string") {
+		if (seenRefs.has(schema.$ref)) return undefined;
+		let resolved: unknown;
+		try {
+			resolved = resolveRef(schema.$ref);
+		} catch {
+			return undefined;
+		}
+		return resolveToSchema(
+			resolved,
+			resolveRef,
+			depth + 1,
+			new Set([...seenRefs, schema.$ref])
+		);
+	}
+	const branch = schema.allOf ?? schema.oneOf ?? schema.anyOf;
+	if (Array.isArray(branch) && branch.length > 0) {
+		return resolveToSchema(branch[0], resolveRef, depth + 1, seenRefs);
+	}
+	return schema;
+}
+
+/**
+ * Whether a property schema declares a file upload. `type: array` of binary items is
+ * the multi-file field, and Vayu's one-file-per-row model imports it as a single file
+ * row - one file the user can attach beats a text row that sends nothing.
+ */
+function isBinary(
+	node: unknown,
+	resolveRef: RefResolver,
+	depth: number,
+	seenRefs: Set<string>
+): boolean {
+	const schema = resolveToSchema(node, resolveRef, depth, seenRefs);
+	if (!schema) return false;
+	if (schema.format === "binary") return true;
+	return schema.type === "array" && isBinary(schema.items, resolveRef, depth + 1, seenRefs);
 }
 
 function walk(

--- a/app/src/services/importers/shared.test.ts
+++ b/app/src/services/importers/shared.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { toVarRecord, mapPostmanAuth, rawBody, joinExec, asString, mapKeyValues } from "./shared";
+import type { CollectionDraft } from "./types";
+import {
+	toVarRecord,
+	mapPostmanAuth,
+	rawBody,
+	joinExec,
+	asString,
+	mapKeyValues,
+	importedFilePart,
+	unattachedFileParts,
+} from "./shared";
 
 describe("toVarRecord", () => {
 	it("builds a VariableValue record, stringifying values, defaulting enabled", () => {
@@ -135,6 +145,77 @@ describe("asString", () => {
 		expect(asString(true)).toBe("true");
 		expect(asString({ a: 1 })).toBe('{"a":1}');
 		expect(asString([1, 2])).toBe("[1,2]");
+	});
+});
+
+describe("importedFilePart", () => {
+	const entry = { key: "avatar", value: "leftover", enabled: true };
+
+	it("marks a part that carries a path as unresolved, and names the file", () => {
+		expect(importedFilePart(entry, "/home/other/avatar.png", "image/png")).toEqual({
+			key: "avatar",
+			value: "",
+			enabled: true,
+			type: "file",
+			src: "/home/other/avatar.png",
+			fileName: "avatar.png",
+			contentType: "image/png",
+			unresolved: true,
+		});
+	});
+
+	it("leaves a part with no path unmarked - nothing there could be unverified", () => {
+		const part = importedFilePart(entry, "");
+		expect(part).toEqual({ key: "avatar", value: "", enabled: true, type: "file", src: "" });
+		// Not `unresolved: false` either: the editor's warning reads the flag's
+		// presence, and a row showing "Choose file" claims nothing to warn about.
+		expect("unresolved" in part).toBe(false);
+	});
+});
+
+describe("unattachedFileParts", () => {
+	const collection = (requests: CollectionDraft["requests"]): CollectionDraft => ({
+		name: "c",
+		description: "",
+		variables: {},
+		auth: { mode: "none" },
+		preRequestScript: "",
+		postRequestScript: "",
+		children: [],
+		requests,
+	});
+	const request = (body: CollectionDraft["requests"][number]["body"]) => ({
+		name: "r",
+		description: "",
+		method: "POST" as const,
+		url: "https://x",
+		params: [],
+		headers: [],
+		body,
+		auth: { mode: "inherit" as const },
+		preRequestScript: "",
+		postRequestScript: "",
+	});
+
+	it("counts only form-data file rows with no file, at every depth", () => {
+		const withUpload = request({
+			mode: "form-data",
+			fields: [
+				{ key: "caption", value: "", enabled: true },
+				importedFilePart({ key: "a", value: "", enabled: true }, ""),
+				// A part that names a path is the user's to re-point, not to attach.
+				importedFilePart({ key: "b", value: "", enabled: true }, "/tmp/b.png"),
+			],
+		});
+		const nested = collection([withUpload]);
+		const root = collection([withUpload, request({ mode: "json", content: "{}" })]);
+		root.children = [nested];
+		expect(unattachedFileParts([root])).toBe(2);
+	});
+
+	it("is zero for an import with no form bodies at all", () => {
+		expect(unattachedFileParts([collection([request({ mode: "none" })])])).toBe(0);
+		expect(unattachedFileParts([])).toBe(0);
 	});
 });
 

--- a/app/src/services/importers/shared.ts
+++ b/app/src/services/importers/shared.ts
@@ -12,6 +12,7 @@ import type {
 	RequestBody,
 	VariableValue,
 } from "@/types";
+import type { CollectionDraft } from "./types";
 import { asArray, asRecord, asStr, prop } from "@/lib/json-node";
 import { fileBaseName } from "@/lib/file-path";
 import { normalizeVars } from "./var-normalize";
@@ -71,12 +72,19 @@ export function mapKeyValues(rows: unknown): KeyValueEntry[] {
 /**
  * An imported multipart part that uploads a file.
  *
- * The path is kept exactly as the source file wrote it, and the row is marked
- * **unresolved**: it names a file on whoever's machine produced the export, so
- * it will usually not exist here. That flag is what the editor's warning reads;
- * picking a file clears it. Dropping the part instead - which both importers
- * did until issue #393 - turned an upload into a request that silently posted
- * nothing.
+ * The path is kept exactly as the source file wrote it, and a row that has one
+ * is marked **unresolved**: it names a file on whoever's machine produced the
+ * export, so it will usually not exist here. That flag is what the editor's
+ * warning reads; picking a file clears it. Dropping the part instead - which
+ * both importers did until issue #393 - turned an upload into a request that
+ * silently posted nothing.
+ *
+ * A source that declares a file part *without* naming a file - an OpenAPI spec
+ * documents the upload, never the path (#425) - passes `src: ""`, and that row
+ * is **not** unresolved: the flag warns that something which looks filled in
+ * cannot be sent, and a row showing "Choose file" makes no such claim. It is
+ * the same shape the editor produces when a user turns a row into a file part,
+ * which is exactly what this is: an upload the user still has to complete.
  *
  * `value` is cleared because a file part has no typed value; whatever the
  * source stored in that slot (Insomnia leaves it "") is not sent.
@@ -93,8 +101,29 @@ export function importedFilePart(
 		src,
 		...(fileBaseName(src) ? { fileName: fileBaseName(src) } : {}),
 		...(contentType ? { contentType } : {}),
-		unresolved: true,
+		...(src ? { unresolved: true } : {}),
 	};
+}
+
+/**
+ * File parts the import produced that name no file yet, counted for the preview.
+ *
+ * Derived from the drafts rather than tallied while building them: the count and
+ * the rows cannot then disagree, and a parser that starts emitting such a row
+ * gets a truthful number without remembering to increment anything. Only the
+ * OpenAPI parsers produce any today - Postman and Insomnia file rows always
+ * carry a path, and one without is skipped as a `file_body` instead.
+ */
+export function unattachedFileParts(collections: CollectionDraft[]): number {
+	let count = 0;
+	for (const collection of collections) {
+		for (const request of collection.requests) {
+			if (request.body.mode !== "form-data") continue;
+			count += request.body.fields.filter((f) => f.type === "file" && !f.src).length;
+		}
+		count += unattachedFileParts(collection.children);
+	}
+	return count;
 }
 
 /** Read a Postman auth detail array/object into a flat {key:value} map (handles v2.1 + v2.0). */

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -48,6 +48,16 @@ export interface ImportMeta {
 	// letting items silently vanish. See ImportModal Preview state.
 	skipped: SkippedItem[];
 	nonExecutableAuth: number;
+	/**
+	 * Form-data file parts that arrived without a file to send. An OpenAPI spec
+	 * documents that a field is an upload and never which file it uploads, so the
+	 * row imports complete-but-empty and the user attaches the file. Surfaced in
+	 * the preview beside the skip counters: a row the user must finish is honest,
+	 * a field that looks filled in and sends nothing is the defect (#425).
+	 * Required rather than optional so every parser states its answer - all of
+	 * them get it from `unattachedFileParts`, which reads the drafts.
+	 */
+	unattachedFileParts: number;
 }
 
 export interface RequestDraft {

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -161,7 +161,14 @@ app-wide setting, not a per-request field, see [insomnia-v4.md](./insomnia-v4.md
 **`EnvironmentDraft`** - `name`, `description`, `variables: Record<string, VariableValue>`.
 
 **`ImportMeta`** - `format`, `fileName?`, `requestCount`, `folderCount`,
-`environmentCount`, `globalCount`, `skipped: SkippedItem[]`, `nonExecutableAuth: number`.
+`environmentCount`, `globalCount`, `skipped: SkippedItem[]`, `nonExecutableAuth: number`,
+`unattachedFileParts: number`.
+
+`unattachedFileParts` counts form-data file rows the import produced with no file attached -
+an OpenAPI spec documents *that* a field is an upload, never *which* file, so those rows
+import complete-but-empty and the user picks the file. Every parser gets it from
+`unattachedFileParts(collections)` in `shared.ts`, which reads the finished drafts rather
+than tallying while building them, so the number and the rows cannot disagree.
 
 **`SkippedItem`** - `{ kind: "websocket" | "grpc" | "api_spec" | "unit_test" | "file_body" |
 "malformed_item" | "unsupported_method" | "malformed_spec", count }`.
@@ -304,10 +311,12 @@ used to build request-body stubs. It is **bounded and resilient**, not a naive o
   `false`, `null` → `null`, `array` → `[sample(items)]` (or `[]`), `object`/untyped → expands
   `properties` recursively (else `{}`).
 
-`schemaFieldNames(schema, resolveRef)` in the same module returns the sampled stub's own keys
-(`[]` when it samples to a non-object). It is how the v3 parser reads urlencoded / multipart
-field names, so a form schema behind `$ref` or `allOf` resolves as far as a JSON body does
-instead of reading a `properties` key that isn't there.
+`schemaFormFields(schema, resolveRef)` in the same module returns the sampled stub's own keys
+(`[]` when it samples to a non-object), each flagged `file` or not. It is how the v3 parser
+reads urlencoded / multipart field names, so a form schema behind `$ref` or `allOf` resolves
+as far as a JSON body does instead of reading a `properties` key that isn't there. The `file`
+flag comes from the property schema (`format: binary`, or an array of it) rather than the
+sampled value, which flattens a binary string to `""` and cannot be told from a text field.
 
 (`schema-sampler.ts`)
 
@@ -322,6 +331,7 @@ instead of reading a `properties` key that isn't there.
    **most-specific-first** position so its `detect()` doesn't shadow (or get shadowed by)
    another format.
 4. Populate `meta.skipped` / `meta.nonExecutableAuth` for anything Vayu can't execute or
-   represent, so the Preview can warn the user.
+   represent, and `meta.unattachedFileParts` (via the `shared.ts` helper) for uploads the
+   user still has to attach, so the Preview can warn the user.
 5. Add a `docs/app/import-collections/<format>.md` following the structure of the existing
    per-format docs, and a row in the table at the top of this file.

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -135,7 +135,7 @@ Swagger 2.0 has **no `requestBody` object** (unlike v3). Request bodies are expr
 | `query` | push to `params` | `{ key, value: "", enabled: true, description? }`; `description` only when present |
 | `header` | push to `headers` | `{ key, value: "", enabled: true }`; skipped when `name.toLowerCase()` is `authorization` or `content-type` |
 | `body` | set `body` | `sample = param.schema ? sampleSchema(param.schema, resolveRef) : {}`; serialized with `JSON.stringify(sample, null, 2)`. Mode is JSON or text per `consumes` (below). |
-| `formData` | collect into `formFields` | `{ key: name, value: "", enabled: true }` per field |
+| `formData` | collect into `formFields` | `{ key: name, value: "", enabled: true }` per field; a `type: file` parameter becomes a **file part** instead (see [`type: file` fields](#type-file-fields)) |
 | (anything else) | ignored | no `default` case action |
 
 After the loop, **form data wins**: if any `formData` fields were collected, `body` is unconditionally replaced with `{ mode: formMode, fields: formFields }` - overriding any body set by an `in: "body"` parameter. (A spec mixing both would be unusual, but the code resolves it in favor of the form.) `formMode` comes from `consumes`, below.
@@ -172,7 +172,17 @@ Swagger 2.0 ties `formData` encoding to `consumes`, and `application/x-www-form-
 | lists **both** | `form-data` - only multipart can carry a `type: file` field |
 | absent, or names neither | `form-data` (the historical default is preserved) |
 
-Entries are compared on the media type alone, so a `charset`/`boundary` parameter (`application/x-www-form-urlencoded; charset=utf-8`) still matches. `type: file` fields themselves are not imported as files - a `formData` parameter always becomes an empty-value text row.
+Entries are compared on the media type alone, so a `charset`/`boundary` parameter (`application/x-www-form-urlencoded; charset=utf-8`) still matches.
+
+One case overrides the table: **a form carrying a file part is always `form-data`**, whatever `consumes` says. Only multipart has a file form on the wire, so a spec that declares `type: file` under a urlencoded-only `consumes` contradicts itself, and multipart is the half of the contradiction that can carry the field.
+
+#### `type: file` fields
+
+A `formData` parameter with `type: file` imports as a **file part** - `{ key, value: "", enabled: true, type: "file", src: "" }` - not as a text row. Until this landed it became an ordinary empty-value text row, so an operation documenting an upload produced a request that looked healthy and sent nothing (the silent-loss class fixed for the other importers by the [file-part mapping](./postman.md), and on the wire before that).
+
+The part carries **no path**: a spec documents *that* a field is an upload, never *which* file it uploads. The user picks the file in the request editor, and the engine refuses the send by field name until they do (`Form field 'avatar' is a file part with no file selected`). The row is deliberately **not** marked `unresolved` - that flag warns that a path came from somewhere else and was never verified here, and there is no path to warn about; the row reads "Choose file", exactly like one a user turned into a file part by hand.
+
+The import preview counts these as `N file parts need a file`, beside the skip counters, so a spec full of uploads says so before the import rather than one failed send at a time.
 
 ## `$ref` & schema sampling
 
@@ -196,7 +206,7 @@ Body schemas are turned into stub values by `sampleSchema(schema, resolveRef)` (
   | `array` | `[ sample(items) ]` if `items` is present, else `[]` (one element) |
   | `object` (or no/unknown `type`) | walks each entry of `properties`, producing `{ key: sample }`; `{}` if no `properties` |
 
-`sampleSchema` is shared verbatim with the v3 parser - same depth cap, cycle guard, and branch handling. Its `schemaFieldNames` companion is v3-only: Swagger 2.0 form fields come from `formData` parameters, not from a schema.
+`sampleSchema` is shared verbatim with the v3 parser - same depth cap, cycle guard, and branch handling. Its `schemaFormFields` companion is v3-only: Swagger 2.0 form fields come from `formData` parameters, not from a schema, so this parser reads `param.type === "file"` where v3 reads `format: binary`.
 
 ## `collectionFormat` for array query params
 
@@ -248,10 +258,9 @@ Dropped / not represented:
 - **`authorization` / `content-type` header parameters:** dropped (Vayu manages them).
 - **Path parameters as params:** not emitted (path params live in the URL only).
 - **Multi-tag grouping:** only the first tag groups an operation.
-- **`type: file` form fields:** imported as ordinary empty-value rows, not as file parts.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
 
-`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `nonExecutableAuth = 0` (oauth2 is now executable), and `skipped` from the shared `SkipTally` - `malformed_spec` is the only kind this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). Nothing to report still yields `[]`.
+`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec` is the only kind this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). Nothing to report still yields `[]`.
 
 ## Differences from OpenAPI 3.0
 
@@ -265,6 +274,7 @@ See [OpenAPI v3](./openapi-v3.md) for the v3 reference. Key contrasts:
 | Body content-type decision | `consumes` (op → spec → JSON default) | media-type keys of `requestBody.content` |
 | Text/non-JSON body | sampled schema serialized as JSON text | `text/plain` → empty string |
 | Form bodies | `in: "formData"` params → urlencoded or multipart per `consumes` (overrides body param) | `multipart/form-data` / `x-www-form-urlencoded` from `content`, field names resolved through the sampler |
+| File parts | `type: "file"` formData parameter | `format: "binary"` (or an array of it) property under `multipart/form-data` |
 | Unsupported methods | none - Swagger 2.0 defines no `trace` | `trace` counted as `unsupported_method` |
 | `$ref` namespace | `#/definitions/...` | `#/components/schemas/...` (resolver is generic in both) |
 | Auth schemes | `securityDefinitions` (`basic`, `apiKey`, `oauth2`) | `components.securitySchemes` (`http`/bearer/basic, `apiKey`, `oauth2`) |

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -109,13 +109,23 @@ Both lists go through `SkipTally.params` (`openapi-shared.ts`) first. `parameter
 |----------------------|--------------------|-------------------------|
 | `application/json` (also any key starting with `application/json` or ending in `+json`, via `findJsonMedia`) | `{ mode: "json", content }` | `content = JSON.stringify(media.example ?? sampleSchema(media.schema), null, 2)`. The media-object `example` wins over the schema; if neither exists, `{}`. |
 | `text/plain` | `{ mode: "text", content: "" }` | empty string (the schema is not sampled for text bodies) |
-| `application/x-www-form-urlencoded` | `{ mode: "x-www-form-urlencoded", fields }` | `fields` = one `{ key, value: "", enabled: true }` per field name from `schemaFieldNames(schema)` |
-| `multipart/form-data` | `{ mode: "form-data", fields }` | same as urlencoded |
+| `application/x-www-form-urlencoded` | `{ mode: "x-www-form-urlencoded", fields }` | `fields` = one `{ key, value: "", enabled: true }` per field from `schemaFormFields(schema)` |
+| `multipart/form-data` | `{ mode: "form-data", fields }` | same as urlencoded, except a `format: binary` field becomes a **file part** (see [File parts](#file-parts)) |
 | no `content`, or none of the above | `{ mode: "none" }` | |
 
-JSON is preferred: `findJsonMedia` is checked first and takes precedence over text/form variants. The `x-www-form-urlencoded` / `multipart/form-data` branch only reads property **names** - property schemas, `required`, and nested structure are not sampled into form fields.
+### File parts
 
-**Form field names resolve `$ref` and `allOf`, exactly as far as a JSON body does.** `schemaFieldNames(schema, resolveRef)` (`schema-sampler.ts`) samples the schema and returns the stub's own keys, rather than reading `schema.properties` directly. That key does not exist on a schema written as `{"$ref": "#/components/schemas/TokenRequest"}` or as an `allOf` - the shape generators emit - which used to yield the right body mode with an **empty** field list and no warning anywhere. Consequences of going through the sampler: composition follows the **first** branch only (the same rule JSON bodies get, not an `allOf` merge), and a schema that samples to a non-object (a scalar, an array, or an `example` that is not an object) contributes no field names.
+A multipart property declared `format: "binary"` - OpenAPI 3's only spelling of "a file" - imports as a **file part**: `{ key, value: "", enabled: true, type: "file", src: "" }`. `type: array` of binary items (the multi-file field) maps to one file row, since Vayu's model is one file per row; one file the user can attach beats a text row that sends nothing. Until this landed both became ordinary empty-value text rows, so an operation documenting an upload produced a request that looked healthy and sent nothing.
+
+The part carries **no path**: a spec documents *that* a field is an upload, never *which* file it uploads. The user picks the file in the request editor, and the engine refuses the send by field name until they do (`Form field 'avatar' is a file part with no file selected`). The row is deliberately **not** marked `unresolved` - that flag warns that a path came from somewhere else and was never verified here, and there is no path to warn about; the row reads "Choose file", exactly like one a user turned into a file part by hand.
+
+Only under `multipart/form-data`. `application/x-www-form-urlencoded` has no file form on the wire, so a `format: binary` property there is a spec that cannot mean what it says; the field stays a text row rather than becoming a part the body could never carry.
+
+The import preview counts these as `N file parts need a file`, beside the skip counters, so a spec full of uploads says so before the import rather than one failed send at a time.
+
+JSON is preferred: `findJsonMedia` is checked first and takes precedence over text/form variants. The `x-www-form-urlencoded` / `multipart/form-data` branch reads property **names**, plus each property's `format` to tell an upload from a text field - `required`, defaults and nested structure are not sampled into form fields.
+
+**Form field names resolve `$ref` and `allOf`, exactly as far as a JSON body does.** `schemaFormFields(schema, resolveRef)` (`schema-sampler.ts`) samples the schema and returns the stub's own keys, rather than reading `schema.properties` directly. That key does not exist on a schema written as `{"$ref": "#/components/schemas/TokenRequest"}` or as an `allOf` - the shape generators emit - which used to yield the right body mode with an **empty** field list and no warning anywhere. Consequences of going through the sampler: composition follows the **first** branch only (the same rule JSON bodies get, not an `allOf` merge), and a schema that samples to a non-object (a scalar, an array, or an `example` that is not an object) contributes no field names.
 
 ### `sampleSchema` (schema → stub value)
 
@@ -142,7 +152,7 @@ JSON is preferred: `findJsonMedia` is checked first and takes precedence over te
 
   The `object`/default branch is the same fallback used for untyped schemas - a node with `properties` but no `type` is still expanded.
 
-`schemaFieldNames(schema, resolveRef)` is the form-body wrapper over this: it samples the schema and returns `Object.keys()` of the result (`[]` for a non-object sample). See [Request body generation](#request-body-generation).
+`schemaFormFields(schema, resolveRef)` is the form-body wrapper over this: it samples the schema, returns `Object.keys()` of the result (`[]` for a non-object sample), and marks each field text or file. The file flag is read off the **property schema**, not the sampled value: the sampler turns a `format: binary` string into `""`, which no longer says anything about the field. See [Request body generation](#request-body-generation).
 
 > Older notes claimed sampling was "one level only" and "`oneOf` → `{}`". That is **not** what the code does: sampling recurses to depth 6, resolves and cycle-guards `$ref`s, honors `example`, and follows the first branch of `oneOf`/`anyOf`/`allOf`.
 
@@ -182,9 +192,10 @@ Dropped / not represented:
 - **Multi-tag grouping:** only the first tag groups an operation.
 - **`trace` operations:** dropped - `HttpMethod` has no `"TRACE"`. Counted as `unsupported_method` (see [Tree structure](#tree-structure)), not silently omitted.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
-- **Form-field property schemas:** only field **names** are imported; `required`, types, and nested structure are not.
+- **Form-field property schemas:** only field **names** and whether the field is a file (`format: binary`) are imported; `required`, other types, and nested structure are not.
+- **A whole-body binary** (`application/octet-stream` and other non-form, non-JSON, non-text media types): no body is produced (`{ mode: "none" }`) and nothing is counted - unlike a multipart file part, which imports (see [File parts](#file-parts)).
 
-`meta` population: `format = "OpenAPI 3.0"`, `requestCount` = total operations built (TRACE excluded), `folderCount` = number of tag collections, `environmentCount = 0`, `nonExecutableAuth = 0` (oauth2 is now executable), and `skipped` from the `SkipTally`:
+`meta` population: `format = "OpenAPI 3.0"`, `requestCount` = total operations built (TRACE excluded), `folderCount` = number of tag collections, `environmentCount = 0`, `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the `SkipTally`:
 
 | `SkippedItem.kind` | Counted when |
 |--------------------|--------------|
@@ -199,10 +210,11 @@ An import with nothing to report still yields `skipped: []` - only non-zero kind
 |--------|--------|--------------------|
 | [`normalizeVars`](./README.md#normalizevars) | `var-normalize.ts` | convert OpenAPI `{param}` path templates → Vayu `{{param}}` in request URLs |
 | `sampleSchema` | `schema-sampler.ts` | generate a sample JSON body from a request `schema` (bounded, ref-resolving) |
-| `schemaFieldNames` | `schema-sampler.ts` | field names for an urlencoded / multipart body, resolved through the sampler |
+| `schemaFormFields` | `schema-sampler.ts` | field names for an urlencoded / multipart body, resolved through the sampler, each flagged text or file |
+| `importedFilePart`, `unattachedFileParts` | `shared.ts` | build a file form row; count the rows that still need a file, for `meta` |
 | `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve a `$ref`'d path item; guard `parameters` and tally what was dropped |
 
-This parser does **not** use the Postman/Insomnia helpers in `shared.ts` (`asString`, `toVarRecord`, `mapKeyValues`, `mapPostmanAuth`, `rawBody`, `joinExec`); it builds drafts directly. See the [index](./README.md#shared-helpers) for the full shared-helper reference.
+This parser does **not** use the Postman/Insomnia-shaped helpers in `shared.ts` (`asString`, `toVarRecord`, `mapKeyValues`, `mapPostmanAuth`, `rawBody`, `joinExec`); it builds drafts directly. See the [index](./README.md#shared-helpers) for the full shared-helper reference.
 
 ## Related
 


### PR DESCRIPTION
## Description

**Plan.** Root cause: `#393` taught the curl and Postman/Insomnia importers to map multipart file parts but never swept the OpenAPI ones, so Swagger 2.0 `type: file` formData params (`openapi-v2.ts:214`) and OpenAPI 3 `format: binary` multipart properties (`openapi-v3.ts:223-233`) still became plain text rows with empty values - a request that looks healthy and posts nothing. Verified still present at `e5d40bb`. Approach: map both to file form rows through the existing `importedFilePart` primitive, with no `src` (a spec documents *that* a field is an upload, never *which* file), and count the rows that still need a file in `meta` so the preview says so. The alternative I rejected was marking those rows `unresolved` like the #393 imports: that flag means "a path came from elsewhere and was never verified here", and setting it with no path renders a warning triangle whose tooltip claims a path that does not exist. A pathless file row is exactly what the editor produces when a user turns a row into a file part - it reads "Choose file" and claims nothing - so `importedFilePart` now sets the flag only when it has a path.

Detail worth flagging: v3 could not read file-ness off the sampled stub, because the sampler flattens a `format: binary` string to `""` - precisely why these fields were indistinguishable from text. `schemaFieldNames` becomes `schemaFormFields`, which still reads names off the sample (so `$ref` / `allOf` form schemas resolve as before) and resolves each property's `format` under the same first-branch rule, so names and flags cannot disagree.

Behaviour changes:

- **v2:** a `type: file` formData param imports as `{ key, value: "", enabled: true, type: "file", src: "" }`. A form carrying a file part is forced to `form-data` whatever `consumes` says - only multipart has a file form on the wire, so a `type: file` under a urlencoded-only `consumes` is a self-contradicting spec and multipart is the half that can carry the field.
- **v3:** a `format: binary` property under `multipart/form-data` imports as a file part; `type: array` of binary items (the multi-file field) maps to one file row, since the model is one file per row. Under `application/x-www-form-urlencoded` it stays a text row - that wire form has no file.
- **Preview:** a new required `ImportMeta.unattachedFileParts` renders as `N file parts need a file` beside the existing skip counters. Every parser gets it from `unattachedFileParts(collections)` in `shared.ts`, which reads the finished drafts rather than tallying while building them, so the count and the rows cannot drift apart; Postman/Insomnia return 0 by construction (their file rows always carry a path) rather than by a hardcoded literal.

Failure path is the engine's existing one, not a new concept: a file part with no file is refused by name (`Form field 'avatar' is a file part with no file selected - choose a file or remove the part`, `engine/src/http/form_body.cpp:181`). Nothing is silently dropped at any layer.

No engine change (the #393 wire path already carries file parts); no MCP change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, from the branch tip:

- `pnpm test` - **353 files, 3464 tests, all passing**
- `pnpm type-check` - clean
- `pnpm lint` - clean (0 errors, 0 warnings)
- `pnpm exec prettier --check` on the touched files - clean (only files this PR touched were formatted)
- `mkdocs build --strict -f .github/mkdocs.yml` - builds clean, no broken links or anchors

No pre-existing failures observed on the base commit.

New behavioural tests, all mutation-checked (each fix reverted, each test confirmed to redden, then restored):

| Test | Reverting… |
|---|---|
| `openapi-v2` imports `type: file` as a file part, not an empty text row | the v2 mapping |
| `openapi-v2` forces multipart for a file param a urlencoded-only `consumes` contradicts | the mode override |
| `openapi-v3` imports `format: binary` as a file part, not an empty text row | the v3 mapping |
| `openapi-v3` counts unattached parts across tagged and untagged operations | the v3 mapping |
| `shared` leaves a part with no path unmarked | the conditional `unresolved` |
| `ImportModal` counts file parts that still need a file | the preview branch |

Plus non-mutation coverage for the cases that would otherwise regress silently: a binary property under urlencoded stays text, an all-text form counts zero, `schemaFormFields` resolves binary through `$ref` and the first `allOf` branch, an array of binary items reads as a file, an `example`-derived field list has no property schemas and reads as text, and a cyclic `$ref` terminates.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #425

---
_Generated by [Claude Code](https://claude.ai/code/session_018a4KRbZUgcegYBZY3fWKRt)_