### PR TITLE
feat(app/mcp): store pre/post-request scripts through create_request and update_request

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -249,6 +249,95 @@ describe("data-write tools", () => {
 	});
 
 	/*
+	 * Stored pre/post-request scripts through the CRUD tools (#419). An agent
+	 * could already *run* a script ad hoc through `run_request` but could not
+	 * persist one onto the request it had just created, so scripts travelled in
+	 * the description for a human to paste into the Pre-request or Tests tab.
+	 *
+	 * These are the whole contract: written verbatim on create, patched one at a
+	 * time on update, and cleared by an explicit empty string - which works only
+	 * because the engine's merge-patch tells absent and `""` apart. Drop the
+	 * field mapping and every one of them reddens.
+	 */
+	test("create_request stores the pre-request and test scripts verbatim", async () => {
+		const client = fakeClient();
+		const pre = "pm.request.headers.add({ key: 'X-Sig', value: pm.variables.get('sig') });";
+		const post = "pm.test('ok', () => pm.response.to.have.status(200));";
+		const res = await dispatchTool(
+			"create_request",
+			{
+				collectionId: "c1",
+				name: "Signed",
+				url: "https://api.example.com/x",
+				preRequestScript: pre,
+				postRequestScript: post,
+			},
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.createRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload).toMatchObject({ preRequestScript: pre, postRequestScript: post });
+	});
+
+	test("create_request sends no script key when the caller named none", async () => {
+		// The engine defaults an absent field to empty on a create; sending `""`
+		// anyway would make the payload claim the agent asked for a blank script.
+		const client = fakeClient();
+		await dispatchTool(
+			"create_request",
+			{ collectionId: "c1", name: "Plain", url: "https://api.example.com/x" },
+			ctxWith(client, { allowWrites: true })
+		);
+		const payload = (client.createRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(Object.keys(payload as object)).not.toContain("preRequestScript");
+		expect(Object.keys(payload as object)).not.toContain("postRequestScript");
+	});
+
+	test("update_request patches one script and keeps the other stored", async () => {
+		const client = fakeClient();
+		const post = "pm.test('created', () => pm.response.to.have.status(201));";
+		const res = await dispatchTool(
+			"update_request",
+			{ requestId: "req_1", postRequestScript: post },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const [, payload] = (client.updateRequest as ReturnType<typeof vi.fn>).mock.calls[0];
+		// Absent keeps: a `preRequestScript: ""` filler here would blank a signing
+		// script the caller never mentioned. Also proves a script alone satisfies
+		// the empty-patch refusal, which counts the payload's keys.
+		expect(payload).toEqual({ postRequestScript: post });
+	});
+
+	test("update_request clears a script when passed an empty string", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"update_request",
+			{ requestId: "req_1", preRequestScript: "" },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		const [, payload] = (client.updateRequest as ReturnType<typeof vi.fn>).mock.calls[0];
+		// `""` is a value the merge-patch stores, not an omission - the difference
+		// between "leave my script alone" and "delete it".
+		expect(payload).toEqual({ preRequestScript: "" });
+	});
+
+	test("the CRUD tools name a stored script once, without the run tools' alias", () => {
+		// `tests` is the engine's spelling for an ad-hoc run body; a second name
+		// for a stored field would be a second name to keep in step.
+		const byName = new Map(TOOLS.map((t) => [t.name, t]));
+		for (const name of ["create_request", "update_request"]) {
+			const schema = byName.get(name)?.inputSchema;
+			expect(schema, name).toBeDefined();
+			expect(Object.keys(schema!), name).toEqual(
+				expect.arrayContaining(["preRequestScript", "postRequestScript"])
+			);
+			expect(Object.keys(schema!), name).not.toContain("tests");
+		}
+	});
+
+	/*
 	 * Collection + request CRUD (#378). The write surface used to be create-only,
 	 * so an agent could file a request into a collection a human had made and
 	 * could never correct or remove it. These cover the two things that make the

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -648,6 +648,36 @@ const validationScriptAliasInput = z
 	);
 
 /**
+ * A saved request's stored scripts, as `create_request` and `update_request`
+ * write them - the two fields the engine keeps on the row
+ * (`preRequestScript` / `postRequestScript`) and the app's **Pre-request** and
+ * **Tests** tabs edit.
+ *
+ * One name per script here, deliberately. The `tests` alias exists on the *run*
+ * tools because the engine spells an ad-hoc run body that way
+ * (`readValidationScript`); a second name for a stored field would be a second
+ * name to keep in step and a second way for an agent to half-write a script.
+ *
+ * `clearable` appends the merge-patch rule, which is `update_request`'s alone -
+ * on a create there is no stored script to keep.
+ */
+function storedScriptInput(which: "pre" | "post", clearable: boolean) {
+	const what =
+		which === "pre"
+			? "JavaScript stored on the request and run before it is sent - the app's Pre-request tab. Use it to sign or otherwise rewrite the request through pm.request."
+			: "JavaScript stored on the request and run after its response arrives - the app's Tests tab. Use pm.test(...) for assertions. Same script `run_request` takes under this name, but persisted onto the request rather than supplied per call.";
+	return z
+		.string()
+		.optional()
+		.describe(
+			`${what} Read the \`vayu://scripting/completions\` resource for the sandbox's surface rather than assuming what exists.` +
+				(clearable
+					? " Leave it out to keep the stored script; pass an empty string to clear it."
+					: "")
+		);
+}
+
+/**
  * Optional auth block. Callers can copy a saved request's `auth` object verbatim
  * (read via list_requests). The engine applies it - bearer/basic/apikey and
  * oauth2 (using its token cache) - after `{{variables}}` inside it are resolved;
@@ -1299,7 +1329,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			"Create a saved request inside a collection (stores it; does not send it). GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed.",
+			"Create a saved request inside a collection (stores it; does not send it), optionally with its pre-request and test scripts. GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed, and a stored script runs only when the request is later sent.",
 		annotations: {
 			title: "Create saved request",
 			readOnlyHint: false,
@@ -1320,6 +1350,8 @@ export const TOOLS: McpTool[] = [
 					"Body type: json, text, graphql, form-data, x-www-form-urlencoded (default text). For the two form types, write `body` as `key=value&key=value`; it is split into form fields. File parts are not supported here - a multipart file part names a path on the user's machine, which an agent cannot choose for them; author it in the app."
 				),
 			description: z.string().optional(),
+			preRequestScript: storedScriptInput("pre", false),
+			postRequestScript: storedScriptInput("post", false),
 		},
 		handler: async (args, ctx, signal) => {
 			const refused = writesDisabled(ctx);
@@ -1342,8 +1374,12 @@ export const TOOLS: McpTool[] = [
 				payload.body = bodyPayload(bodyType, body);
 				payload.bodyType = bodyType;
 			}
-			const description = str(args, "description");
-			if (description !== undefined) payload.description = description;
+			// Pass-through strings: absent leaves the engine's own default (empty),
+			// so only what the caller actually named is sent.
+			for (const field of ["description", "preRequestScript", "postRequestScript"] as const) {
+				const value = str(args, field);
+				if (value !== undefined) payload[field] = value;
+			}
 			return callEngine(() => ctx.client.createRequest(payload, signal));
 		},
 	},
@@ -1352,7 +1388,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			"Correct a saved request: its name, URL, method, headers, body or description. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - anything you leave out keeps its stored value, including the request's auth and its pre/post-request scripts. Passing `headers` replaces the whole header list, so send every header the request should end up with.",
+			"Correct a saved request: its name, URL, method, headers, body, description or pre/post-request scripts. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - anything you leave out keeps its stored value, including the request's auth. Passing `headers` replaces the whole header list, so send every header the request should end up with; passing a script replaces that script, and an empty string clears it.",
 		annotations: {
 			title: "Update saved request",
 			readOnlyHint: false,
@@ -1377,6 +1413,8 @@ export const TOOLS: McpTool[] = [
 					"Body type for `body`: json, text, graphql, form-data, x-www-form-urlencoded. Only meaningful alongside `body`. File parts are not supported here; a stored one is left alone unless `body` replaces the whole body."
 				),
 			description: z.string().optional().describe("New description."),
+			preRequestScript: storedScriptInput("pre", true),
+			postRequestScript: storedScriptInput("post", true),
 		},
 		handler: async (args, ctx, signal) => {
 			const refused = writesDisabled(ctx);
@@ -1389,7 +1427,16 @@ export const TOOLS: McpTool[] = [
 			 * `method: "GET"` filler would silently rewrite the stored verb.
 			 */
 			const payload: Record<string, unknown> = {};
-			for (const field of ["name", "url", "method", "description"] as const) {
+			for (const field of [
+				"name",
+				"url",
+				"method",
+				"description",
+				// An empty string is a value here, not an omission: the engine's
+				// merge-patch stores it, which is how a script gets cleared.
+				"preRequestScript",
+				"postRequestScript",
+			] as const) {
 				const value = str(args, field);
 				if (value !== undefined) payload[field] = value;
 			}
@@ -1412,7 +1459,7 @@ export const TOOLS: McpTool[] = [
 			}
 			if (Object.keys(payload).length === 0) {
 				return errorResult(
-					"Pass at least one field to change (name, url, method, headers, body or description)."
+					"Pass at least one field to change (name, url, method, headers, body, description, preRequestScript or postRequestScript)."
 				);
 			}
 			return callEngine(() => ctx.client.updateRequest(requestId, payload, signal));

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -288,6 +288,10 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   actually execute. `run_request` takes an agent-written `preRequestScript` /
   `postRequestScript` instead, since an ad-hoc call has no chain to compose
   from; `start_load_run` takes the same `postRequestScript` for a URL-only run.
+  Those two are supplied per call and are not stored - `create_request` and
+  `update_request` take the same two names to write a script onto the saved
+  request itself, which is what lets an agent-authored script outlive the call
+  that wrote it (see *Storing a request's scripts* below).
 - **Bodies** - `body` is a string and `bodyType` names the mode
   (`json` | `text` | `graphql` | `form-data` | `x-www-form-urlencoded`,
   default `text`). The two form modes carry their content as **fields**, not as
@@ -322,6 +326,19 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   fixed order and the first non-blank wins; they are never merged. MCP still
   shows the agent a single name (see *One validation script, one name* above) -
   that is now a courtesy rather than a translation the wire depends on.
+- **Storing a request's scripts** - `create_request` and `update_request` both
+  take `preRequestScript` and `postRequestScript` (strings, optional), written
+  through to the engine's own field names on the request row, so the app's
+  **Pre-request** and **Tests** tabs open on exactly what the agent wrote.
+  `update_request` merge-patches them like every other field: **leave one out
+  and the stored script is kept; pass an empty string and it is cleared.** The
+  `tests` alias is deliberately absent here - it is the engine's spelling for an
+  *ad-hoc run body*, and a stored field answering to two names is a second name
+  to keep in step. Storing a script adds persistence, not execution capability:
+  an agent could already run arbitrary scripts through `run_request`, and a
+  stored one runs only when the request is later sent. Both tools already
+  declare `invalidates: ["request"]`, so the renderer refetches the row and
+  picks the scripts up without a further entity.
 - **Load-testing a saved request** - `start_load_run` with a `requestId`
   composes it by id, exactly as `run_collection_smoke` and the app do:
   variables resolved, stored auth applied through the collection chain, and the


### PR DESCRIPTION
## Description

MCP could not author a stored request's scripts: `create_request` and `update_request` carried no `preRequestScript` / `postRequestScript`, while the *run* tools already accepted `postRequestScript`. An agent could execute a script ad hoc but not persist it onto the request it had just created, so scripts travelled in the request description for a human to paste into the Pre-request or Tests tab.

**Plan.** Root cause is a gap in the CRUD tools' schemas, not in the storage: the engine has stored both fields on the request row all along (`apply_request_fields`, `requests.cpp:206-207`), and the renderer reads them back through `request-transformer.ts` - so the reader exists and this adds no unread field. The fix adds the two fields to both tool schemas and writes them through under the engine's own names, folding them into each handler's existing string-passthrough loop rather than adding a second code path. `update_request` inherits the merge-patch rule for free: absent keeps the stored script, an empty string clears it, because `apply_string_field` tells absent and `""` apart. The alternative rejected was accepting `tests` as an alias here, mirroring the run tools - declined because `tests` is the engine's spelling for an *ad-hoc run body*, and a stored field answering to two names is a second name to keep in step and a second way for an agent to half-write a script. The tool descriptions state which name to use.

Verified the issue's premise against HEAD first: both schemas were still script-less, and the run tools' `postRequestScript` naming (`readValidationScript`) is what the new fields match.

**Security posture** (as the issue states it): storing a script adds persistence, not execution capability. Agents can already run arbitrary scripts through `run_request`; a stored script runs only when the request is later sent. Both tools already declare `invalidates: ["request"]`, so the renderer refetches the row and picks the scripts up without a further entity - verified, no change needed there.

Renderer: none. Engine: none.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint` - all green:

- **353 test files, 3469 tests passed** (full app suite), including 112 in `electron/mcp/tools.test.ts` (5 new).
- `pnpm type-check` and `pnpm lint` clean; `prettier --check` clean on the two touched TS files (only files this PR touches were checked, per the repo rule).
- `mkdocs build --strict -f .github/mkdocs.yml` builds clean for the docs edit.

New tests, mutation-checked - removing the two field names from the create and update passthrough loops reddens 3 of them (`create_request stores the pre-request and test scripts verbatim`, `update_request patches one script and keeps the other stored`, `update_request clears a script when passed an empty string`), confirmed by reverting and re-running:

- create stores both scripts verbatim;
- create sends **no** script key when the caller named none (the engine's own default stands);
- update patches one script and leaves the other stored - which also proves a script-only patch satisfies the empty-patch refusal, since that check counts payload keys;
- update clears a script on an explicit empty string;
- both schemas offer the two names and **not** `tests`.

No pre-existing failures observed on this base.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/engine/mcp.md` updated in the same commit: a *Storing a request's scripts* bullet covering the two fields, the keep/clear semantics, why there is no `tests` alias, and the persistence-not-execution note; plus a pointer from the existing **Scripts** bullet, which previously described the per-call scripts as the only ones MCP could write.

No deviation from the issue spec. The issue lists no app-renderer or engine work, and none was needed.

## Related Issues
Closes #419

---
_Generated by [Claude Code](https://claude.ai/code/session_01DA6qduqM7z3CbJcoCUwuPL)_