### PR TITLE
fix(engine/scenario): refuse a collection run whose steps carry `{{data.*}}` and that has no data set

### DIFF
--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -58,6 +58,13 @@ written, and appears unresolved in the UI, which is the honest reading: there
 is no row. `{{data.}}` with nothing after the dot names no column and follows
 the ordinary unknown-name rule (resolves to `""`) instead.
 
+A **collection run** is the one place that reading is not left to the user: a
+run started without a data file whose plan still carries a `data.*` token is
+refused with a `400` naming the step and the token, rather than sending the
+literal text once per iteration (issue #415). The single Send above keeps its
+behaviour - a token someone typed into a request they are editing is not yet a
+run.
+
 The conformance fixture pins all three cases, so the two resolvers cannot
 drift on them. See
 [api-reference.md](../engine/api-reference.md#scenario-runs) for what the

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1739,6 +1739,7 @@ as a smaller one:
 | `data` not an array, or a row that is not an object | |
 | More `data` rows than `maxScenarioDataRows` | The message carries the count and the cap. |
 | A `data` array larger than `maxScenarioDataBytes` | The row count cannot catch a few very large rows, and the transport's own body cap would drop the connection instead of explaining itself. |
+| A step carrying a `{{data.*}}` token in a run sent without `data` | Nothing would bind it, so the literal token would be sent. The message names the step and the token. |
 
 A cycle in the `collections.parent_id` tree terminates the recursive walk rather
 than hanging it, exactly as the cascade delete in `DELETE /collections/:id` does.
@@ -1813,8 +1814,14 @@ A token naming a column the bound row does not carry **errors the step before
 anything is sent**, with a message naming the token, the row index and the
 columns the row does have. Substituting an empty string would send a request
 quietly pointing somewhere else, which is the failure this namespace exists to
-remove. Outside a run with `data`, nothing binds the token and it reaches the
-wire as written - visible, rather than silently blank.
+remove.
+
+A run sent **without a `data` set at all** whose plan still carries a `data.*`
+token is refused outright, before any run row exists: nothing would bind the
+token, so every iteration would send the literal text `{{data.id}}`. The `400`
+names the step and the token. Starting such a collection as a quick smoke check
+means running it with a data file - a one-row set is enough - because the run
+this refuses would not have exercised the endpoint either.
 
 **Each step execution writes one `results` row** carrying the design-mode trace
 plus `iteration`, `stepIndex`, `stepName`, `requestId` and `outcome`, and -

--- a/engine/include/vayu/core/scenario_data.hpp
+++ b/engine/include/vayu/core/scenario_data.hpp
@@ -30,10 +30,17 @@
  * request with a silently blank field is the failure mode this namespace
  * exists to remove. The runner turns that into an errored step, before the
  * request is sent.
+ *
+ * A run started with **no data set at all** is the same failure one step
+ * earlier, and is refused one step earlier too: plan resolution scans the
+ * composed steps through `find_data_token` and returns a `400` rather than
+ * starting a run whose every iteration would send the literal token (issue
+ * #415).
  */
 
 #include <cstddef>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 #include "vayu/types.hpp"
@@ -75,5 +82,24 @@ struct DataBindResult {
  */
 [[nodiscard]] DataBindResult
 bind_data_row (vayu::Request& request, const nlohmann::json& row, size_t row_index);
+
+/**
+ * The first `{{data.column}}` token still standing in a composed @p request,
+ * written back with its braces (`{{data.id}}`), or `nullopt` for a request that
+ * carries none (issue #415).
+ *
+ * This is what lets plan resolution refuse a run whose steps carry data tokens
+ * and whose payload has no `data` set: nothing would bind them, so they would
+ * reach the wire written as they stand.
+ *
+ * It walks **exactly** the fields `bind_data_row` substitutes, because it is
+ * that walk driven against no row at all. A separate scanner would be a second
+ * copy of the field list, and a field only one of the two covered would be a
+ * token that passes the scan and still goes out literal. The request is copied
+ * for it - the walk rewrites in place - which is affordable because plan
+ * resolution runs once per run, before the first send, over a plan already
+ * bounded by `maxScenarioSteps`.
+ */
+[[nodiscard]] std::optional<std::string> find_data_token (const vayu::Request& request);
 
 } // namespace vayu::core

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -174,7 +174,9 @@ struct ScenarioResolution {
  * `collectionId`, an empty sequence, a step whose composition fails, a plan
  * over `limits.max_steps`, a `data` array that is present and empty or over
  * `limits.max_data_rows` or `limits.max_data_bytes`, and any `source` other
- * than `"collection"`.
+ * than `"collection"`. A step carrying a `{{data.*}}` token in a run sent
+ * *without* `data` joins that list (issue #415): nothing would bind it, so it
+ * would be sent as the literal token.
  */
 ScenarioResolution resolve_scenario (vayu::db::Database& db,
 const nlohmann::json& scenario,

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -38,7 +38,11 @@ std::string describe_columns (const nlohmann::json& row) {
  */
 class RowBinder {
     public:
-    RowBinder (const nlohmann::json& row, size_t row_index)
+    /// @p row is `nullptr` for the pre-run scan (`find_data_token`), which has
+    /// no data set to bind against: every `data.*` token is then recorded and
+    /// left written as it stands rather than substituted or reported as an
+    /// absent column.
+    RowBinder (const nlohmann::json* row, size_t row_index)
     : row_ (row), row_index_ (row_index) {
     }
 
@@ -51,15 +55,21 @@ class RowBinder {
             if (!vayu::http::is_data_variable_name (name)) {
                 return std::nullopt; // not ours - composition already had its turn
             }
+            if (!first_token_) {
+                first_token_ = "{{" + name + "}}";
+            }
+            if (row_ == nullptr) {
+                return std::nullopt; // scanning; the caller decides what it means
+            }
             const std::string column =
             name.substr (vayu::http::DATA_NAMESPACE_PREFIX.size ());
-            auto cell = row_.find (column);
-            if (cell == row_.end ()) {
+            auto cell = row_->find (column);
+            if (cell == row_->end ()) {
                 if (result_.ok) {
                     result_.ok    = false;
                     result_.error = "{{" + name +
                     "}} names a column data row " + std::to_string (row_index_) +
-                    " does not have (columns: " + describe_columns (row_) + ")";
+                    " does not have (columns: " + describe_columns (*row_) + ")";
                 }
                 return std::nullopt;
             }
@@ -71,33 +81,33 @@ class RowBinder {
         return result_;
     }
 
+    [[nodiscard]] const std::optional<std::string>& first_token () const {
+        return first_token_;
+    }
+
     private:
-    const nlohmann::json& row_;
-    size_t row_index_ = 0;
+    const nlohmann::json* row_ = nullptr;
+    size_t row_index_          = 0;
     DataBindResult result_{ true, {} };
+    std::optional<std::string> first_token_;
 };
 
-} // namespace
-
-std::string render_data_value (const nlohmann::json& value) {
-    if (value.is_string ()) {
-        return value.get<std::string> ();
-    }
-    if (value.is_null ()) {
-        return {};
-    }
-    return value.dump ();
-}
-
-DataBindResult bind_data_row (vayu::Request& request, const nlohmann::json& row, size_t row_index) {
-    RowBinder binder (row, row_index);
-
+/**
+ * The one list of strings a data row binds: URL, header names and values, raw
+ * body, and both halves of every form field.
+ *
+ * Binding and scanning both drive it, so neither can cover a field the other
+ * does not - a field only the binder walked would be a token that passes
+ * `find_data_token` and still reaches the wire.
+ *
+ * Header *names* are substituted too, because composition substitutes them: the
+ * payload carries headers as `[{key, value}]`, and `resolve_json_strings`
+ * resolves every string value in that array, key included. A map cannot have
+ * its keys rewritten in place, so this rebuilds it.
+ */
+void walk_bindable_fields (vayu::Request& request, RowBinder& binder) {
     binder.apply (request.url);
 
-    // Header *names* are substituted too, because composition substitutes them:
-    // the payload carries headers as `[{key, value}]`, and `resolve_json_strings`
-    // resolves every string value in that array, key included. A map cannot have
-    // its keys rewritten in place, so this rebuilds it.
     if (!request.headers.empty ()) {
         vayu::Headers rebound;
         for (const auto& [name, value] : request.headers) {
@@ -115,8 +125,34 @@ DataBindResult bind_data_row (vayu::Request& request, const nlohmann::json& row,
         binder.apply (field.key);
         binder.apply (field.value);
     }
+}
 
+} // namespace
+
+std::string render_data_value (const nlohmann::json& value) {
+    if (value.is_string ()) {
+        return value.get<std::string> ();
+    }
+    if (value.is_null ()) {
+        return {};
+    }
+    return value.dump ();
+}
+
+DataBindResult bind_data_row (vayu::Request& request, const nlohmann::json& row, size_t row_index) {
+    RowBinder binder (&row, row_index);
+    walk_bindable_fields (request, binder);
     return binder.result ();
+}
+
+std::optional<std::string> find_data_token (const vayu::Request& request) {
+    // Copied because the walk rewrites in place; nothing is actually rewritten
+    // here, since a scan substitutes no token. Sharing the walk is what the copy
+    // buys - see the header for why a second scanner would be the wrong trade.
+    vayu::Request scratch = request;
+    RowBinder binder (nullptr, 0);
+    walk_bindable_fields (scratch, binder);
+    return binder.first_token ();
 }
 
 } // namespace vayu::core

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -14,6 +14,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "vayu/core/scenario_data.hpp"
 #include "vayu/http/request_builder.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/script_parts.hpp"
@@ -263,6 +264,10 @@ const ScenarioResolveOptions& options) {
         " (raise the 'maxScenarioSteps' setting to allow more)");
     }
 
+    // A `data` array that is present and empty was already refused above, so an
+    // empty `data_rows` here means the payload carried no `data` block at all.
+    const bool has_data = !resolution.data_rows.empty ();
+
     resolution.plan.steps.reserve (rows.size ());
     for (size_t index = 0; index < rows.size (); ++index) {
         const auto& row = rows[index];
@@ -285,6 +290,24 @@ const ScenarioResolveOptions& options) {
         if (!built.ok || built.parse_failed) {
             return invalid ("Cannot compose " + describe_step (index, row) +
             ": " + built.error_message);
+        }
+
+        // A `{{data.*}}` token with no data set behind it can never bind. The
+        // namespace is reserved, so composition deliberately left the token
+        // written as it stands, and a run without rows has nothing to
+        // substitute it from - it would reach the wire as the literal text
+        // `{{data.id}}`, which is not a request anyone meant to send. Refused
+        // here, beside every other unrunnable scenario and before a run row
+        // exists, rather than rediscovered per step per iteration once it has
+        // started (issue #415).
+        if (!has_data) {
+            if (auto token = find_data_token (built.request)) {
+                return invalid (describe_step (index, row) + " carries " + *token +
+                ", but this run has no 'scenario.data' set. A data token has "
+                "no row to bind to and would reach the wire written as it "
+                "stands - run the collection with a data file, or remove the "
+                "token from the request.");
+            }
         }
 
         ScenarioStep step;

--- a/engine/tests/scenario_data_test.cpp
+++ b/engine/tests/scenario_data_test.cpp
@@ -193,3 +193,76 @@ TEST (ScenarioDataBindTest, ASubstitutedValueIsNeverRescanned) {
     ASSERT_TRUE (result.ok) << result.error;
     EXPECT_EQ (request.url, "https://api.test/{{data.b}}");
 }
+
+// ---------------------------------------------------------------------------
+// The pre-run scan: a token nothing can bind (issue #415)
+// ---------------------------------------------------------------------------
+
+TEST (ScenarioDataScanTest, ARequestWithNoDataTokenScansClean) {
+    auto request = request_with_url ("https://api.test/{{host}}/users");
+    request.headers["Accept"] = "application/json";
+    request.body.mode         = vayu::BodyMode::Json;
+    request.body.content      = R"({"n":1})";
+    request.body.fields       = { { "k", "v", true } };
+
+    EXPECT_FALSE (vayu::core::find_data_token (request).has_value ());
+}
+
+TEST (ScenarioDataScanTest, EveryFieldTheBinderSubstitutesIsAFieldTheScanSees) {
+    // The pairing that matters: a field the binder would bind and the scan
+    // would miss is a token that survives the refusal and reaches the wire.
+    // Each case seeds exactly one field, so a hole names itself.
+    const auto seen = [] (const vayu::Request& request) {
+        return vayu::core::find_data_token (request).value_or ("<none>");
+    };
+
+    EXPECT_EQ (seen (request_with_url ("https://api.test/{{data.id}}")), "{{data.id}}");
+
+    {
+        auto request = request_with_url ("https://api.test/");
+        request.headers["X-{{data.hn}}"] = "plain";
+        EXPECT_EQ (seen (request), "{{data.hn}}");
+    }
+    {
+        auto request                = request_with_url ("https://api.test/");
+        request.headers["X-Tenant"] = "{{data.token}}";
+        EXPECT_EQ (seen (request), "{{data.token}}");
+    }
+    {
+        auto request         = request_with_url ("https://api.test/");
+        request.body.content = R"({"email":"{{data.email}}"})";
+        EXPECT_EQ (seen (request), "{{data.email}}");
+    }
+    {
+        auto request        = request_with_url ("https://api.test/");
+        request.body.fields = { { "{{data.field}}", "v", true } };
+        EXPECT_EQ (seen (request), "{{data.field}}");
+    }
+    {
+        auto request        = request_with_url ("https://api.test/");
+        request.body.fields = { { "k", "{{data.value}}", true } };
+        EXPECT_EQ (seen (request), "{{data.value}}");
+    }
+}
+
+TEST (ScenarioDataScanTest, TheScanLeavesTheRequestAlone) {
+    // It answers a question; it must not be a substitution pass with no row.
+    auto request = request_with_url ("https://api.test/{{data.id}}");
+    request.headers["X-{{data.hn}}"] = "{{data.token}}";
+    request.body.content             = "{{data.body}}";
+    const auto before                = request.url;
+
+    EXPECT_TRUE (vayu::core::find_data_token (request).has_value ());
+    EXPECT_EQ (request.url, before);
+    EXPECT_EQ (request.headers.at ("X-{{data.hn}}"), "{{data.token}}");
+    EXPECT_EQ (request.body.content, "{{data.body}}");
+}
+
+TEST (ScenarioDataScanTest, ThePrefixAloneIsNotSomethingToRefuse) {
+    // `{{data.}}` names no column, so composition already resolved it to "" and
+    // there is nothing left to send literally. Refusing it would block a run
+    // over a token that never reaches the wire.
+    EXPECT_FALSE (vayu::core::find_data_token (
+    request_with_url ("https://api.test/{{data.}}"))
+                  .has_value ());
+}

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -110,13 +110,17 @@ class ScenarioPlanTest : public ::testing::Test {
     const std::string& url         = "https://example.test/{{path}}",
     const std::string& auth        = "",
     const std::string& post_script = "",
-    int64_t created_at             = 1) {
+    int64_t created_at             = 1,
+    const std::string& headers     = "",
+    const std::string& body        = "") {
         vayu::db::Request r;
         r.id                  = id;
         r.collection_id       = collection_id;
         r.name                = "Request " + id;
         r.method              = vayu::HttpMethod::GET;
         r.url                 = url;
+        r.headers             = headers;
+        r.body                = body;
         r.auth                = auth;
         r.post_request_script = post_script;
         r.order               = order;
@@ -635,6 +639,82 @@ TEST_F (ScenarioPlanTest, ADataBlockInsideTheByteBoundResolves) {
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
     EXPECT_EQ (resolved.data_rows.size (), 1u);
+}
+
+// --- A data token with no data set (issue #415) -------------------------------
+
+TEST_F (ScenarioPlanTest, ADataTokenWithNoDataSetIsRefusedNamingTheStepAndTheToken) {
+    // Composition leaves `{{data.id}}` written as it stands on purpose, so a run
+    // started without rows has nothing to bind it and would put the literal text
+    // on the wire. Revert the scan in `resolve_scenario` and this resolves,
+    // which is the shipped-through-to-the-server behaviour the issue reports.
+    seed_collection ("col", "");
+    seed_request ("clean", "col", /*order=*/0, "https://example.test/health");
+    seed_request ("bound", "col", /*order=*/1, "https://example.test/u/{{data.id}}");
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+
+    EXPECT_FALSE (resolved.ok);
+    // The step it names is the offending one, not the first one composed.
+    EXPECT_NE (resolved.error.find ("step 1"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ("Request bound"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ("{{data.id}}"), std::string::npos) << resolved.error;
+    EXPECT_NE (resolved.error.find ("scenario.data"), std::string::npos) << resolved.error;
+    // No partial plan, exactly as every other resolution failure leaves none.
+    EXPECT_TRUE (resolved.plan.steps.empty ());
+}
+
+TEST_F (ScenarioPlanTest, TheSameCollectionResolvesWhenTheRunCarriesADataSet) {
+    // The other half of the rule: the refusal is about the *absent* data set, not
+    // about the token. A run with rows still resolves, and the token still
+    // survives composition - the runner binds it per iteration, not here.
+    seed_collection ("col", "");
+    seed_request ("bound", "col", /*order=*/0, "https://example.test/u/{{data.id}}");
+
+    json scenario    = block ("col");
+    scenario["data"] = json::array ({ json{ { "id", "7" } } });
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_EQ (resolved.plan.steps.size (), 1u);
+    EXPECT_NE (resolved.plan.steps[0].request.url.find ("{{data.id}}"), std::string::npos)
+    << resolved.plan.steps[0].request.url;
+}
+
+TEST_F (ScenarioPlanTest, ADataTokenOutsideTheUrlIsRefusedToo) {
+    // The scan walks what `bind_data_row` substitutes, so every field the binder
+    // would have bound must be a field the refusal sees. One field per case, so a
+    // hole names itself instead of hiding behind the URL.
+    const auto refused = [&] (const std::string& headers, const std::string& body) {
+        reset_database ();
+        seed_collection ("col", "");
+        seed_request ("req", "col", /*order=*/0, "https://example.test/ok",
+        /*auth=*/"", /*post_script=*/"", /*created_at=*/1, headers, body);
+
+        const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+        EXPECT_FALSE (resolved.ok) << headers << " | " << body;
+        EXPECT_NE (resolved.error.find ("{{data.id}}"), std::string::npos) << resolved.error;
+    };
+
+    refused (R"([{"key":"X-Id","value":"{{data.id}}","enabled":true}])", "");
+    refused (R"([{"key":"{{data.id}}","value":"x","enabled":true}])", "");
+    refused ("", R"({"mode":"json","content":"{\"id\":\"{{data.id}}\"}"})");
+    refused ("",
+    R"({"mode":"form-data","fields":[{"key":"id","value":"{{data.id}}","enabled":true}]})");
+}
+
+TEST_F (ScenarioPlanTest, ThePrefixAloneDoesNotBlockARunWithoutData) {
+    // `{{data.}}` names no column, so composition resolves it to "" like any
+    // other unknown name and nothing survives for the scan to find. Refusing it
+    // would block a run over a token that never reaches the wire.
+    seed_collection ("col", "");
+    seed_request ("req", "col", /*order=*/0, "https://example.test/u/{{data.}}");
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (resolved.plan.steps[0].request.url, "https://example.test/u/");
 }
 
 TEST_F (ScenarioPlanTest, AnUnknownSourceDoesNotFallThroughToTheCollectionPath) {


### PR DESCRIPTION
## Description

**Option A - a `400` at plan resolution**, which the issue named as the one to beat.

**Plan.** The root cause is that the `data.*` namespace is reserved on purpose: composition leaves `{{data.id}}` written exactly as it stands so the runner can bind it per iteration. A run started without a `data` block has no row, so nothing binds it and the token survives to the transfer as `GET /users/%7B%7Bdata.id%7D%7D`. The fix scans each composed step at plan resolution - where the plan is fully in hand, the payload's `data` block is known, and no run row exists yet - and refuses with a `400` naming the step and the token. **I rejected option C** (error the step at run time, reusing the absent-column path): it costs no new concept, but it discovers the same fact after the run has started and re-discovers it once per step per iteration, and the information needed to decide was already available before any of that. **Option B** (a `warnings` array on the `202`) would add wire surface nothing else uses, for a message that is not a warning - there is no run behind it worth starting.

**The smoke-run objection, answered rather than dismissed.** A now cannot run a data-driven collection without a file, including as a quick smoke check. That is a real cost, and it is smaller than it looks: the run it blocks would have sent `/users/{{data.id}}` to the server, so it does not smoke-test the endpoint either - it tests that the engine can reach a 404. A user who wants the smoke run has a cheap path that A does not take away: run it with a one-row data set. Weighed against a run that silently wastes an iteration count against a wrong URL, refusing is the better trade, and it is what the rest of `resolve_scenario` already does with an empty collection, an uncomposable step and an oversized plan.

**Verified at `d0e412c`** before the first edit: the problem still exists as described. `resolve_scenario` (`engine/src/core/scenario_plan.cpp`) composes every step and never looks at what the composed request still carries; `http::is_data_variable_name` and `core::bind_data_row` exist exactly as the issue says.

**Blast radius traced.** `resolve_scenario` has one caller, `start_load_test` in `engine/src/http/routes/execution.cpp`, which already turns a failed resolution into `400 {error.code: "invalid_scenario"}`. That endpoint has one scenario client - `RunCollectionDialog` - and it already renders the engine's message (`startRun.error`, extracted from `error.message` by `http-client.ts`), which is why this needs no app change. `rg` finds no MCP tool that starts a scenario run. Load-mode scenarios (#402 phase B / #357) do not exist on master, so nothing else reaches this path.

**One design decision worth the reviewer's attention.** The scan does **not** re-list the fields to look at. `find_data_token` is `bind_data_row`'s own walk driven against no row at all (`RowBinder` now takes `const json*`, `nullptr` meaning "scanning"), because a second field list is the "hand-rolled copy of a primitive" defect in its most damaging form here: a field only the *binder* covered would be a token that passes the scan and still reaches the wire. The walk was extracted to `walk_bindable_fields` and both drive it. The cost is one `vayu::Request` copy per step - the walk rewrites in place - paid once per run at resolution time, on a plan already bounded by `maxScenarioSteps`, never on a send path. The mutation check below confirms the pairing is real, not just asserted in a comment.

`{{data.}}` is unaffected: it names no column, so composition already resolved it to `""` under the ordinary unknown-name rule and there is nothing left for the scan to find. Refusing it would block a run over a token that never reaches the wire.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**1158/1158 passed**, including the 8 tests added here. No pre-existing failures - the whole suite is green on this branch, so a failure that predated it would still be failing.

Added, in `scenario_plan_test.cpp` (the refusal) and `scenario_data_test.cpp` (the scan primitive):

- `ADataTokenWithNoDataSetIsRefusedNamingTheStepAndTheToken` - two steps, only the second carrying a token; the error names `step 1`, the request, `{{data.id}}` and `scenario.data`, and leaves no partial plan.
- `TheSameCollectionResolvesWhenTheRunCarriesADataSet` - the other half: the refusal is about the absent data set, not the token. The token still survives composition, because the runner binds it, not resolution.
- `ADataTokenOutsideTheUrlIsRefusedToo` - one field per case (header value, header *name*, raw body, form field), so a hole names itself instead of hiding behind the URL.
- `ThePrefixAloneDoesNotBlockARunWithoutData` - `{{data.}}` resolves to `""` and the run proceeds.
- `EveryFieldTheBinderSubstitutesIsAFieldTheScanSees`, `ARequestWithNoDataTokenScansClean`, `TheScanLeavesTheRequestAlone` (it answers a question; it is not a substitution pass), `ThePrefixAloneIsNotSomethingToRefuse`.

**Mutation-checked, twice**, applied, confirmed red, reverted:

1. Disabled the refusal in `resolve_scenario` → `ADataTokenWithNoDataSetIsRefusedNamingTheStepAndTheToken` and `ADataTokenOutsideTheUrlIsRefusedToo` both fail; everything else stays green. This is master's behaviour, i.e. the reported bug.
2. Dropped the header branch from the shared `walk_bindable_fields` → `ScenarioDataBindTest.HeaderNamesAndValuesBothBind`, `ScenarioDataScanTest.EveryFieldTheBinderSubstitutesIsAFieldTheScanSees`, `ScenarioPlanTest.ADataTokenOutsideTheUrlIsRefusedToo` and `ScenarioRunnerTest.ADataTokenInAHeaderResolvesPerIteration` fail **together** - which is the point of sharing the walk: the binder and the scan cannot drift apart without the suite saying so.

The existing `{{data.*}}` tests are untouched and green - a run *with* rows is not what this changes.

`mkdocs build --strict` could not be run (mkdocs is not installed in this environment); the docs edits add no link, heading or nav entry, so there is no anchor for it to break.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`scenario_data.cpp`, `scenario_plan.cpp` and `scenario_data_test.cpp` were clang-format clean on master and are formatted; `scenario_plan_test.cpp` was already not clean on master, so per CLAUDE.md it was left alone and the added tests match the file's prevailing style.

Docs updated in the same commit: `docs/engine/api-reference.md` - the sentence that stated today's behaviour ("Outside a run with `data`, nothing binds the token and it reaches the wire as written") now states the refusal and answers the smoke-run question, plus a row in the `invalid_scenario` `400` table. `docs/app/variable-resolution.md` - the same claim in its `data.*` section, narrowed to the single Send that still behaves that way.

## Related Issues
Closes #415

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGPXom5DRwXKBEuLySrq5R)_