### PR TITLE
feat(app/scenario): stop a running collection run from the runner tab

### DIFF
--- a/app/src/components/shared/StopRunButton.test.tsx
+++ b/app/src/components/shared/StopRunButton.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The stop control both run surfaces share. Two callers depend on this
+ * contract - the load dashboard header and the collection-run tab - and neither
+ * renders the markup itself any more, so the pending state is pinned here once
+ * rather than in each of them.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StopRunButton } from "./StopRunButton";
+
+describe("StopRunButton", () => {
+	it("calls back when clicked", () => {
+		const onStop = vi.fn();
+		render(<StopRunButton onStop={onStop} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /^stop/i }));
+
+		expect(onStop).toHaveBeenCalledTimes(1);
+	});
+
+	it("refuses a second click while a stop is in flight", () => {
+		const onStop = vi.fn();
+		render(<StopRunButton onStop={onStop} isStopping />);
+
+		const button = screen.getByRole("button", { name: /stopping/i });
+		expect((button as HTMLButtonElement).disabled).toBe(true);
+
+		fireEvent.click(button);
+		expect(onStop).not.toHaveBeenCalled();
+	});
+
+	it("labels the destructive action with the text token, never the fill", () => {
+		// `text-destructive` is the fill token used as a foreground - the colour
+		// bug this repo hits most. The pair is close enough that only the class
+		// name tells them apart.
+		const { container } = render(<StopRunButton onStop={() => {}} />);
+		const className = container.querySelector("button")!.className;
+
+		expect(className).toContain("text-destructive-text");
+		expect(className).not.toMatch(/(^|\s)text-destructive(\s|$)/);
+	});
+});

--- a/app/src/components/shared/StopRunButton.tsx
+++ b/app/src/components/shared/StopRunButton.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * StopRunButton
+ *
+ * "Stop the run that is happening right now" - the one treatment, wherever a
+ * run can be cancelled. Two places call it: the load-test dashboard header and
+ * the collection-run tab.
+ *
+ * It exists as a primitive rather than as markup each view repeats because the
+ * treatment is not a `Button` variant: a destructive *outline* over `ghost`,
+ * which no variant paints, plus the in-flight swap to a spinner and
+ * "Stopping…". A second hand-rolled copy of that would not receive this one's
+ * fixes.
+ *
+ * `destructive-text`, not `destructive`, for the label - the bare fill token as
+ * a foreground is the colour bug this repo hits most (`docs/design-system.md`).
+ *
+ * The caller owns the request and the failure path. This is a button: it says
+ * what the pending state looks like and nothing about what stopping means.
+ */
+
+import { StopCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+interface StopRunButtonProps {
+	onStop: () => void;
+	/** True while the stop request is in flight; the button disables and says so. */
+	isStopping?: boolean;
+	className?: string;
+}
+
+export function StopRunButton({ onStop, isStopping = false, className }: StopRunButtonProps) {
+	return (
+		<Button
+			size="sm"
+			variant="ghost"
+			onClick={onStop}
+			disabled={isStopping}
+			className={cn(
+				"h-7 px-2.5 text-xs text-destructive-text hover:bg-destructive/10 hover:text-destructive-text border border-destructive/30 shrink-0",
+				className
+			)}
+		>
+			{isStopping ? (
+				<>
+					<Loader2 className="w-3 h-3 animate-spin mr-1.5" />
+					Stopping…
+				</>
+			) : (
+				<>
+					<StopCircle className="w-3 h-3 mr-1.5" />
+					Stop
+				</>
+			)}
+		</Button>
+	);
+}

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -45,6 +45,9 @@ export * from "./TruncatedText";
 // Shared frame for the drawer views
 export * from "./DrawerPanel";
 
+// The one way to cancel a run in flight (load dashboard, collection runner)
+export * from "./StopRunButton";
+
 // The one way to say "there is nothing here yet"
 export * from "./EmptyState";
 

--- a/app/src/modules/dashboard/components/DashboardHeader.tsx
+++ b/app/src/modules/dashboard/components/DashboardHeader.tsx
@@ -11,11 +11,11 @@
  * Compact 52px single-row header with status, method, URL, config info, and stop button
  */
 
-import { ArrowLeft, StopCircle, Loader2 } from "lucide-react";
-import { Button, TooltipIconButton } from "@/components/ui";
+import { ArrowLeft } from "lucide-react";
+import { TooltipIconButton } from "@/components/ui";
 import { useTabsStore, useDashboardStore } from "@/stores";
 import type { DashboardHeaderProps } from "../types";
-import { MethodBadge } from "@/components/shared";
+import { MethodBadge, StopRunButton } from "@/components/shared";
 import { loadTestModeLabel, formatConcurrency } from "@/constants/load-test-modes";
 
 function formatElapsed(ms: number): string {
@@ -115,27 +115,7 @@ export default function DashboardHeader({
 			)}
 
 			{/* Stop button */}
-			{mode === "running" && (
-				<Button
-					size="sm"
-					variant="ghost"
-					onClick={onStop}
-					disabled={isStopping}
-					className="h-7 px-2.5 text-xs text-destructive-text hover:bg-destructive/10 hover:text-destructive-text border border-destructive/30 shrink-0"
-				>
-					{isStopping ? (
-						<>
-							<Loader2 className="w-3 h-3 animate-spin mr-1.5" />
-							Stopping…
-						</>
-					) : (
-						<>
-							<StopCircle className="w-3 h-3 mr-1.5" />
-							Stop
-						</>
-					)}
-				</Button>
-			)}
+			{mode === "running" && <StopRunButton onStop={onStop} isStopping={isStopping} />}
 		</div>
 	);
 }

--- a/app/src/modules/history/main/ScenarioRunView.test.tsx
+++ b/app/src/modules/history/main/ScenarioRunView.test.tsx
@@ -11,17 +11,18 @@
 /**
  * The collection-run tab.
  *
- * Four things are worth pinning here and none of them are layout: that a live
+ * Five things are worth pinning here and none of them are layout: that a live
  * `step` event reaches the list, that all four outcomes render distinctly and
  * `skipped` is counted apart from `passed`, that a stored step's response comes
  * back through the shared restore path rather than a second reading of the
- * trace, and that a run whose step store filled says so.
+ * trace, that a run whose step store filled says so, and that a live run can be
+ * stopped from here while a finished one offers nothing to stop.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, within, fireEvent, act } from "@testing-library/react";
+import { render, screen, within, fireEvent, act, waitFor } from "@testing-library/react";
 import ScenarioRunView from "./ScenarioRunView";
-import { useScenarioRunStore } from "@/stores";
+import { useScenarioRunStore, useToastStore } from "@/stores";
 import type { Run, RunReport, StepOutcome } from "@/types";
 
 const reportQuery = {
@@ -31,6 +32,14 @@ const reportQuery = {
 
 vi.mock("@/queries", () => ({
 	useRunReportQuery: () => reportQuery,
+}));
+
+const stopRun = vi.fn<(id: string) => Promise<unknown>>();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		stopRun: (id: string) => stopRun(id),
+	},
 }));
 
 // Monaco under the response body is irrelevant to every question here and
@@ -95,7 +104,15 @@ beforeEach(() => {
 	reportQuery.data = undefined;
 	reportQuery.isLoading = false;
 	useScenarioRunStore.setState({ runId: null, steps: [], isStreaming: false, error: null });
+	stopRun.mockReset();
+	stopRun.mockResolvedValue({});
+	useToastStore.setState({ toasts: [] });
 });
+
+/** The Stop control, or null when the tab is not offering one. */
+function stopButton(): HTMLElement | null {
+	return screen.queryByRole("button", { name: /^stop/i });
+}
 
 describe("live progress", () => {
 	it("advances the list as step events arrive", () => {
@@ -390,6 +407,93 @@ describe("thinned results", () => {
 		render(<ScenarioRunView run={RUN} />);
 
 		expect(screen.queryByText(/bounded step storage/i)).toBeNull();
+	});
+});
+
+describe("stopping a live run", () => {
+	it("stops the run this tab is streaming", async () => {
+		render(<ScenarioRunView run={{ ...RUN, status: "running" }} />);
+		act(() => {
+			useScenarioRunStore.getState().startRun("run-1");
+		});
+
+		await act(async () => {
+			fireEvent.click(stopButton()!);
+		});
+
+		expect(stopRun).toHaveBeenCalledWith("run-1");
+	});
+
+	it("stops a running run this tab never attached a stream to", async () => {
+		// The relaunch case: the engine is still executing, the tab was reopened
+		// from History, and there is no stream to read "live" from. Gate the
+		// control on the stream alone and this run becomes uncancellable -
+		// which is the case the issue is actually about.
+		render(<ScenarioRunView run={{ ...RUN, status: "running" }} />);
+
+		expect(useScenarioRunStore.getState().isStreaming).toBe(false);
+		await act(async () => {
+			fireEvent.click(stopButton()!);
+		});
+
+		expect(stopRun).toHaveBeenCalledWith("run-1");
+	});
+
+	it("offers nothing to stop once the run is terminal", () => {
+		reportQuery.data = report({ results: [storedStep(0, 0, "passed", { name: "Done" })] });
+
+		render(<ScenarioRunView run={{ ...RUN, status: "completed" }} />);
+
+		expect(stopButton()).toBeNull();
+	});
+
+	it("disables itself and says so while the stop is in flight", async () => {
+		let settle: () => void = () => {};
+		stopRun.mockImplementation(
+			() =>
+				new Promise<unknown>((resolve) => {
+					settle = () => resolve({});
+				})
+		);
+
+		render(<ScenarioRunView run={{ ...RUN, status: "running" }} />);
+		fireEvent.click(stopButton()!);
+
+		// A second click while the first is unanswered would send a second stop.
+		const pending = stopButton()!;
+		expect(pending.textContent).toContain("Stopping");
+		expect((pending as HTMLButtonElement).disabled).toBe(true);
+
+		await act(async () => {
+			settle();
+		});
+	});
+
+	it("reports a failed stop as a retryable toast rather than silently", async () => {
+		stopRun.mockRejectedValue(new Error("Engine unreachable"));
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		render(<ScenarioRunView run={{ ...RUN, status: "running" }} />);
+		await act(async () => {
+			fireEvent.click(stopButton()!);
+		});
+
+		await waitFor(() => expect(useToastStore.getState().toasts).toHaveLength(1));
+		const toast = useToastStore.getState().toasts[0];
+		expect(toast.variant).toBe("error");
+		expect(toast.message).toContain("Engine unreachable");
+
+		// The run is still sending requests, so the retry is the point of the
+		// toast - not the message.
+		stopRun.mockResolvedValue({});
+		await act(async () => {
+			toast.action!.onClick();
+		});
+		expect(stopRun).toHaveBeenCalledTimes(2);
+
+		// And the button is back, so the failure did not leave the tab stuck on
+		// "Stopping…" with nothing to click.
+		expect((stopButton() as HTMLButtonElement).disabled).toBe(false);
 	});
 });
 

--- a/app/src/modules/history/main/ScenarioRunView.tsx
+++ b/app/src/modules/history/main/ScenarioRunView.tsx
@@ -29,9 +29,12 @@
 import { useMemo, useState } from "react";
 import { ListOrdered, Loader2 } from "lucide-react";
 import { useRunReportQuery } from "@/queries";
-import { useScenarioRunStore } from "@/stores";
+import { queryClient } from "@/lib/query-client";
+import { queryKeys } from "@/queries/keys";
+import { apiService } from "@/services/api";
+import { useScenarioRunStore, useToastStore } from "@/stores";
 import { Badge } from "@/components/ui";
-import { EmptyState, Callout } from "@/components/shared";
+import { EmptyState, Callout, StopRunButton } from "@/components/shared";
 import { cn } from "@/lib/utils";
 import ScenarioStepCard from "./components/ScenarioStepCard";
 import {
@@ -87,6 +90,54 @@ export default function ScenarioRunView({ run }: ScenarioRunViewProps) {
 
 	const inProgress = run.status === "running" || run.status === "pending";
 
+	/*
+	 * Stoppable while the engine still owns the run, and that is two signals
+	 * rather than one. The stream says so for the tab that started the run; the
+	 * run's own status says so for a tab reopened onto a run that is still
+	 * executing - after a relaunch, or from History - which has no stream at all
+	 * and is exactly the case where waiting the run out hurts most.
+	 */
+	const isLive = isStreaming || inProgress;
+
+	const showToast = useToastStore((s) => s.showToast);
+	const [isStopping, setIsStopping] = useState(false);
+
+	const handleStop = async () => {
+		setIsStopping(true);
+		try {
+			await apiService.stopRun(run.id);
+			/*
+			 * The streaming tab hears this again through `complete`: the engine
+			 * drives a stopped scenario to a terminal status and closes the
+			 * topic, and `ScenarioRunService` refreshes the run and its report on
+			 * close. A tab that is *not* attached to the stream gets no such
+			 * event, so without this its run would sit on "running" - still
+			 * offering a Stop for something already stopped, and never loading
+			 * the step rows the run just wrote.
+			 */
+			await queryClient.invalidateQueries({ queryKey: queryKeys.runs.detail(run.id) });
+			await queryClient.invalidateQueries({ queryKey: queryKeys.runs.report(run.id) });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
+		} catch (error) {
+			// The run keeps executing and the button comes back, so without this
+			// a click that failed is indistinguishable from one that did nothing.
+			console.error("Failed to stop scenario run:", error);
+			showToast({
+				message: error instanceof Error ? error.message : "Couldn't stop the run",
+				variant: "error",
+				// The sequence is still sending requests, so the retry is the
+				// reason for telling them at all.
+				action: {
+					label: "Try again",
+					altText: "Try stopping the run again",
+					onClick: () => void handleStop(),
+				},
+			});
+		} finally {
+			setIsStopping(false);
+		}
+	};
+
 	// One iteration is the common case and "Iteration 1" on every row is noise;
 	// more than one and which pass a step belongs to is the whole point.
 	const showIteration = steps.some((s) => s.iteration > 0);
@@ -133,6 +184,13 @@ export default function ScenarioRunView({ run }: ScenarioRunViewProps) {
 						</Badge>
 					))}
 				</span>
+
+				{/* Last, and only while the run is live. A terminal run has
+				    nothing to stop, and a Stop that lingers on a finished run
+				    reads as a run that never ended. */}
+				{isLive && (
+					<StopRunButton onStop={() => void handleStop()} isStopping={isStopping} />
+				)}
 			</header>
 
 			<div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-3">

--- a/app/src/services/scenario-run-service.ts
+++ b/app/src/services/scenario-run-service.ts
@@ -53,9 +53,11 @@ class ScenarioRunService {
 	/*
 	 * There is deliberately no `stopMonitoring` here, unlike `LoadTestService`.
 	 * The stream ends on its own - the engine sends `complete` when the run
-	 * reaches a terminal status - and nothing in the app stops a collection run
-	 * mid-flight yet. A detach method with no caller is surface that cannot be
-	 * verified; it belongs with the stop control that needs it.
+	 * reaches a terminal status - and that holds for a *stopped* run too: the
+	 * scenario runner observes `should_stop` per step, settles the run to
+	 * `Stopped` and closes the topic, so the runner tab's Stop control gets its
+	 * terminal event through the same path a run that finished normally does.
+	 * A detach method with no caller is surface that cannot be verified.
 	 */
 
 	private handleError(error: Error): void {

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -335,6 +335,8 @@ Three rules the list holds, each pinned by a mutation-checked test:
 - **`skipped` is never `passed`.** It has its own count and its own row treatment (`SampledExchange`'s `state` prop, below). Nothing produces `skipped` until flow control lands, so it is built to render correctly before it can occur.
 - **Thinned results say so.** A run that filled `maxScenarioStoredSteps` reports fewer rows than it ran, with every non-passing step among the ones kept - so a non-zero `stepsDropped` means *successes* are missing. `ScenarioRunView` discloses the three numbers rather than letting `results[]` read as the whole run.
 
+A live run can be **stopped** from this tab (`StopRunButton`, below), which matters most for a data-driven run of hundreds of iterations. The control is shown while `isStreaming || run.status is running|pending` - two signals rather than one, because a tab reopened onto a run that is still executing (after a relaunch, or from History) has no stream at all, and is exactly the case where waiting the run out hurts most. It calls `POST /runs/:id/stop`, which needs nothing new engine-side: the scenario runner already checks `should_stop` per *step*, settles the run to `Stopped` and closes the SSE topic, so the streaming tab flips to the stored rows through the same `complete` a normal finish takes. The handler also invalidates the run and its report itself, because a tab that is not the streaming one never receives that event.
+
 `components/ScenarioStepCard.tsx` renders one step on the shared `SampledExchange`, restoring the response through `restore-response.ts` - the same path a design run's response pane uses, not a second reading of `trace_data`. `SampledExchange` gained an optional `state` (`success | error | slow | skipped`) and a `title` slot for this: its state is otherwise derived from the status code, which would read a `failed` assertion over a `200` as a success and a `skipped` step as a connection failure.
 
 The entry point is `modules/collections/RunCollectionDialog.tsx`, opened from a collection row's ⋯ menu. Three options - Recursive, Iterations and a data file - because the scenario **is** the folder: the sequence is the tree's own ordering, and a step list authored here would be a second source of truth for it. Invalid iterations are refused in the dialog; the engine's own rejection (which names the step that would not compose) is shown in place rather than as a toast that scrolls away.
@@ -398,6 +400,20 @@ the user took, including save failures (see `save-store.failSave`). Four
 variants - `info`, `success`, `warning`, `error` - each carried by an icon and a
 left rail rather than colour alone; tokens and durations in
 `docs/design-system.md` -> Toasts.
+
+## Stop Run Button (`components/shared/StopRunButton.tsx`)
+
+"Stop the run that is happening right now", in the one treatment, for the two
+places a run can be cancelled: the load dashboard header and the collection-run
+tab. A primitive rather than markup each view repeats, because the treatment is
+not a `Button` variant - a destructive *outline* over `ghost`, which no variant
+paints, plus the in-flight swap to a spinner and "Stopping…". The label is
+`destructive-text`, never the bare `destructive` fill.
+
+The caller owns the request and the failure path: both call sites `await
+apiService.stopRun(runId)` and, on failure, raise an **error toast with a Try
+again action** rather than a Callout - the run is still generating work, so the
+retry is the reason for saying anything.
 
 ## Sample Retention Note (`components/shared/SampleRetentionNote.tsx`)
 


### PR DESCRIPTION
## Description

**Plan.** The root cause is not a missing engine capability - `POST /runs/:id/stop` has always existed and `apiService.stopRun` has always called it, but the only caller was the load dashboard, so a collection run had no way out once started. I verified the engine half rather than assuming it: `scenario_runner.cpp` checks `context->should_stop` **per step** (`:381`, with the comment explaining that a per-iteration check would keep sending for minutes), breaks the iteration loop on it (`:358`), settles `final_status` to `RunStatus::Stopped` (`:582`), still writes its step rows, and sets `closed` after the last step event - so a stopped scenario reaches the view through the same `complete` a normal finish takes. That makes this pure UI wiring, exactly as the issue guessed, and `ScenarioRunService` needs no `stopMonitoring` (its comment deferring one "to the stop control that needs it" is now resolved in place: the stream still ends on its own).

The one non-obvious decision is the visibility gate. The obvious reading - "show it while streaming" - is what I **rejected**: `ScenarioRunView`'s own comment already names the case where a tab is open on a run that is still executing with no stream attached (after a relaunch, or reopened from History), and that is precisely the run you most want to cancel and least can. So the gate is `isStreaming || run.status is running|pending`, and because that tab receives no `complete` either, the handler invalidates the run detail, its report and the runs list itself instead of leaning on `ScenarioRunService.handleClose`.

The dashboard's stop button was inline markup in `DashboardHeader`, not a `Button` variant - a destructive *outline* over `ghost` plus the in-flight "Stopping…" swap. Per CLAUDE.md ("a hand-rolled copy of a primitive does not receive the primitive's fixes") I extracted it to `components/shared/StopRunButton.tsx` and pointed both surfaces at it rather than pasting the class blob into a second view. It has two callers on arrival, so it is not speculative abstraction.

**Engine changes: none.** Verified, not assumed - see above.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

All run locally on this branch. This is an app-only change, so the engine suite was not rebuilt or run (CLAUDE.md's "scale the verification to what the change could actually break" - no C++ was touched and no engine test could change colour).

| Command | Result |
|---|---|
| `cd app && pnpm test` | **354 files, 3477 tests passed** |
| `cd app && pnpm type-check` | clean |
| `cd app && pnpm lint` | clean (0 errors, 0 warnings) |
| `python -m mkdocs build --strict -f .github/mkdocs.yml` | built, no warnings |

Nine new tests, five in `ScenarioRunView.test.tsx` and three in a new `StopRunButton.test.tsx` (plus one existing file re-verified). Each was mutation-checked by reverting the fix and confirming the red:

- Narrowing the gate to `isStreaming` alone → **3 failures**, led by *"stops a running run this tab never attached a stream to"*.
- Making the button unconditional → **1 failure**, *"offers nothing to stop once the run is terminal"*.
- Dropping `disabled={isStopping}` and swapping `text-destructive-text` for the bare fill token → **2 failures** in the primitive's own suite.

The failure path is tested, not assumed: a rejecting `stopRun` raises an **error toast carrying a working "Try again" action** (the test clicks it and asserts a second call), and the button returns enabled rather than stranding the tab on "Stopping…".

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/COMPONENTS.md` gains the stop paragraph in the `ScenarioRunView` section and a `## Stop Run Button` section for the new shared primitive. The stale comment in `services/scenario-run-service.ts` ("nothing in the app stops a collection run mid-flight yet") is corrected in the same diff.

**No deliberate deviation from the issue spec.** The issue's step 2 asked me to verify whether the engine honours stop for scenario runs before assuming pure UI wiring; it does, and the verification is quoted above.

## Related Issues
Closes #427

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXvYSJ8n3NqiYB2q3dRAwP)_