### PR TITLE
feat(engine/scripting): bind pm.iterationData.has, widen the completions guard to depth 3, and declare an optional surface optional

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -32,7 +32,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Crypto              | `pm.crypto.sha256(data, encoding?)`, `.hmacSha256(key, data, encoding?)` - synchronous, see below |
 | Send from script    | `pm.sendRequest(urlOrOptions, callback)` - synchronous, callback only, refused for agent-started runs, see below |
 | Flow control        | `pm.execution.setNextRequest(name \| null)`, `.skipRequest()` - collection runs only, see below |
-| Data rows           | `pm.iterationData.get(name)`, `.toObject()` - read-only, data-driven collection runs only, see below |
+| Data rows           | `pm.iterationData.get(name)`, `.has(name)`, `.toObject()` - read-only, data-driven collection runs only, see below |
 | Base64              | `btoa(binaryString)`, `atob(base64)` - globals, standard web semantics           |
 | Console             | `console.log/info/warn/error`                                                    |
 
@@ -398,6 +398,7 @@ Details, including every case that throws, are in
 
 ```javascript
 pm.iterationData.get('username');  // this iteration's value for that column
+pm.iterationData.has('coupon');    // whether the row carries that column
 pm.iterationData.toObject();       // the whole row
 ```
 
@@ -614,6 +615,28 @@ entry - it caught `queueMicrotask`, which quickjs-ng does provide, on its first 
 
 Narrow that suppression list rather than widening it: each code on it is a real mistake
 going unreported in exchange for not crying wolf on correct code.
+
+#### Optional members, and the one thing the editor cannot yet tell you
+
+A completion entry says a member may be absent by ending its `detail` in
+` | undefined`. The generator reads that one convention in two places: a leaf keeps the
+union (`iteration: number | undefined`), and a surface that has members of its own has no
+union to carry it, so the optionality moves onto the property name -
+`pm.iterationData` is declared **`iterationData?: { ... }`**, because it is `undefined`
+outside a data-driven collection run.
+
+That marker shows in hover today, but it does **not** produce a squiggle: the worker runs
+with `strictNullChecks` off, and without it an optional property is indistinguishable from
+a required one at a use site. So a plain request script calling
+`pm.iterationData.get('x')` still gets no editor error for something that throws at run
+time - the guard the docs recommend (`pm.iterationData ? ... : ...`) is advice, not a rule
+the type system enforces. Turning `strictNullChecks` on would change that for this member
+*and* for every `T | undefined` in the surface at once (`pm.environment.get` among them),
+which is a decision about how noisy this editor should be rather than a detail of the
+declarations - so it is tracked separately, not folded in here.
+
+`pm.execution` has the mirror-image limitation and no fix at all: it is always bound, and
+its methods throw outside a collection run, which no type can express.
 
 ### The second consumer: MCP agents
 

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -803,6 +803,7 @@ reads:
 
 ```javascript
 pm.iterationData.get('username');  // this iteration's value for that column
+pm.iterationData.has('coupon');    // whether the row carries that column
 pm.iterationData.toObject();       // the whole row as a plain object
 ```
 
@@ -810,6 +811,11 @@ pm.iterationData.toObject();       // the whole row as a plain object
 `pm` scope reader does. Values keep their JSON type: a JSON file's `3` arrives
 as a number, and a CSV column arrives as a string, because that is what the
 file said.
+
+`has` answers presence, the same way `pm.environment.has` and its siblings do.
+A column whose value is `null` is `true` - the row carries it - which is the
+fact `get` alone cannot state without the reader knowing that an absent column
+comes back as `undefined` while a null one comes back as `null`.
 
 **`pm.iterationData` is `undefined` where there is no row** - a single Send, a
 load run's deferred `tests` script, and a collection run started without a data

--- a/engine/src/http/routes/script_types.cpp
+++ b/engine/src/http/routes/script_types.cpp
@@ -37,6 +37,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "vayu/http/routes.hpp"
@@ -144,6 +145,9 @@ struct TypeNode {
     std::string documentation;
     int kind    = 0;
     bool listed = false; // false for an interior node the labels only imply
+    // The member may be absent at run time - see split_optional_suffix. Only
+    // read for a node that has children; a leaf carries it in its own type.
+    bool optional = false;
     // Set only where the table cannot say it: `pm.expect` is the entry point
     // into the chain, and its `detail` documents no return type because the
     // completion popup has nothing useful to show there.
@@ -172,6 +176,33 @@ std::string trim (const std::string& s) {
     }
     const auto last = s.find_last_not_of (" \t\n");
     return s.substr (first, last - first + 1);
+}
+
+constexpr std::string_view OPTIONAL_SUFFIX = " | undefined";
+
+/**
+ * @brief The table's one way of saying "this member may not be there".
+ *
+ * A `detail` ending in ` | undefined` marks the member optional, with the same
+ * spelling for a leaf (`pm.info.iteration` is `number | undefined`) and for a
+ * whole surface (`pm.iterationData` is `undefined` outside a data-driven
+ * collection run). Only the rendering differs: a leaf keeps the union, and a
+ * surface that has members has no union to put it in, so it becomes a `?` on
+ * the property name.
+ *
+ * One reader of the convention rather than two, so `field_type` and
+ * `render_member` cannot come to disagree about what the suffix means.
+ *
+ * @return the detail with the suffix removed, and whether it was there.
+ */
+std::pair<std::string, bool> split_optional_suffix (const std::string& detail) {
+    const std::string base = trim (detail);
+    if (base.size () > OPTIONAL_SUFFIX.size () &&
+    base.compare (base.size () - OPTIONAL_SUFFIX.size (),
+    OPTIONAL_SUFFIX.size (), OPTIONAL_SUFFIX) == 0) {
+        return { trim (base.substr (0, base.size () - OPTIONAL_SUFFIX.size ())), true };
+    }
+    return { base, false };
 }
 
 /**
@@ -312,14 +343,8 @@ std::string field_type (const std::string& detail) {
     // undefined` and not `number | undefined`, which silently declared
     // `pm.info.iteration` as `void` and made `pm.info.iteration + 1` an error
     // in the editor.
-    static constexpr std::string_view OPTIONAL_SUFFIX = " | undefined";
-    bool optional                                     = false;
-    if (base.size () > OPTIONAL_SUFFIX.size () &&
-    base.compare (base.size () - OPTIONAL_SUFFIX.size (),
-    OPTIONAL_SUFFIX.size (), OPTIONAL_SUFFIX) == 0) {
-        optional = true;
-        base = trim (base.substr (0, base.size () - OPTIONAL_SUFFIX.size ()));
-    }
+    const auto [stripped, optional] = split_optional_suffix (base);
+    base                            = stripped;
 
     std::string resolved;
     if (base == "number" || base == "string" || base == "boolean" || base == "any") {
@@ -389,7 +414,11 @@ bool in_chain) {
     append_doc (out, node, indent);
 
     if (!node.children.empty ()) {
-        out += indent + name + ": {\n";
+        // `pm.iterationData?: {...}` - the surface is undefined outside a
+        // data-driven collection run, and an object type has nowhere else to
+        // say so. Under the renderer's current compiler options this shows in
+        // hover rather than producing a diagnostic; see useScriptTypeDefinitions.
+        out += indent + name + (node.optional ? "?: {\n" : ": {\n");
         out += render_body (node, indent + "\t", in_chain);
         out += indent + "};\n";
         return out;
@@ -455,6 +484,7 @@ std::string generate_script_typedefs () {
         node->documentation = item.value ("documentation", "");
         node->kind          = kind;
         node->listed        = true;
+        node->optional      = split_optional_suffix (node->detail).second;
     }
 
     // `pm.expect(value)` opens the chain the `to.*` entries continue. Nothing

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -498,7 +498,7 @@ nlohmann::json get_script_completions () {
     { "detail", "This iteration's data row | undefined" },
     { "documentation",
     "The row a data-driven collection run bound to this iteration - row "
-    "i % rows for iteration i - read through get() and "
+    "i % rows for iteration i - read through get(), has() and "
     "toObject().\n\nundefined "
     "wherever there is no row: a single Send, a load run's Tests script, and a "
     "collection run started without a data set. That is the opposite treatment "
@@ -521,6 +521,19 @@ nlohmann::json get_script_completions () {
     "elsewhere pm.iterationData is undefined, so guard with it before "
     "calling.\n\nExample:\nconst user = pm.iterationData.get('username');" },
     { "sortText", "1_pm_iterationData_get" } });
+
+    completions.push_back ({ { "label", "pm.iterationData.has" },
+    { "kind", KIND_FUNCTION }, { "insertText", "pm.iterationData.has(\"${1:column}\")" },
+    { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.iterationData.has(column: string): boolean" },
+    { "documentation",
+    "Whether this iteration's row carries that column. true for a column whose "
+    "value is null - the row has it - which is the one answer get() cannot "
+    "give directly.\n\nOnly inside a data-driven collection run - "
+    "elsewhere pm.iterationData is undefined, so guard with it before "
+    "calling.\n\nExample:\nif (pm.iterationData.has('coupon')) { /* the column "
+    "is in this row */ }" },
+    { "sortText", "1_pm_iterationData_has" } });
 
     completions.push_back ({ { "label", "pm.iterationData.toObject" },
     { "kind", KIND_FUNCTION }, { "insertText", "pm.iterationData.toObject()" },

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -4773,6 +4773,32 @@ JSValue js_iteration_data_get (JSContext* ctx, JSValueConst this_val, int argc, 
     return js_from_json (ctx, *found, key.c_str ());
 }
 
+// pm.iterationData.has(key) - whether the row carries that column.
+//
+// Every other scope reader in the pm surface answers `has` - pm.environment,
+// pm.globals, pm.collectionVariables, pm.variables and pm.cookies all do - and
+// Postman's pm.iterationData is a VariableScope, which has one too. Absent, the
+// question has to be asked as `get(key) !== undefined`, which is both indirect
+// and easy to write wrongly for a column whose value is JSON `null`.
+//
+// A column that is present and null is `true` here: the row carries it. That is
+// the one answer `get` cannot phrase as a presence check without the reader
+// knowing that a null column comes back as JS `null` rather than `undefined`.
+JSValue js_iteration_data_has (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
+    (void)this_val;
+    auto* data = iteration_data_context (ctx, "has");
+    if (!data) {
+        return JS_EXCEPTION;
+    }
+    // No argument is "no such column", the same answer pm.variables.has gives.
+    if (argc < 1) {
+        return JS_NewBool (ctx, 0);
+    }
+
+    const std::string key = js_to_string (ctx, argv[0]);
+    return JS_NewBool (ctx, data->iteration_data->contains (key) ? 1 : 0);
+}
+
 // pm.iterationData.toObject() - the whole row, as a plain object.
 JSValue js_iteration_data_to_object (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     (void)this_val;
@@ -4829,6 +4855,8 @@ void setup_pm_iteration_data (JSContext* ctx, JSValue pm) {
     JSValue iteration_data = JS_NewObject (ctx);
     JS_SetPropertyStr (ctx, iteration_data, "get",
     JS_NewCFunction (ctx, js_iteration_data_get, "get", 1));
+    JS_SetPropertyStr (ctx, iteration_data, "has",
+    JS_NewCFunction (ctx, js_iteration_data_has, "has", 1));
     JS_SetPropertyStr (ctx, iteration_data, "toObject",
     JS_NewCFunction (ctx, js_iteration_data_to_object, "toObject", 0));
     for (const char* writer : { "set", "unset", "clear" }) {

--- a/engine/tests/script_completions_test.cpp
+++ b/engine/tests/script_completions_test.cpp
@@ -679,14 +679,100 @@ bool is_deliberately_uncompletable (const std::string& name) {
     name == "pm.response.to" || name.rfind ("pm.response.to.", 0) == 0;
 }
 
-// Objects whose members are *data*, not API: the header maps carry one property
-// per header on the wire, so descending into them would demand a completion
-// entry for `Authorization`. Their accessors are guarded by
-// EveryOfferedHeaderMemberIsCallableInTheRuntime above.
-bool is_data_map (const std::string& name) {
-    return name == "pm.request.headers" || name == "pm.response.headers" ||
-    name == "pm.response.cookies";
+std::vector<std::string> split_commas (const std::string& joined) {
+    std::vector<std::string> parts;
+    for (size_t start = 0; start <= joined.size ();) {
+        const size_t comma = joined.find (',', start);
+        const std::string part = joined.substr (
+        start, comma == std::string::npos ? std::string::npos : comma - start);
+        if (!part.empty ()) {
+            parts.push_back (part);
+        }
+        if (comma == std::string::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+    return parts;
 }
+
+// The walk, as JavaScript. Two levels of plain property reads, plus the two
+// shapes a plain walk cannot reach:
+//
+// - **The data maps.** `pm.request.headers`, `pm.response.headers` and
+//   `pm.response.cookies` carry one property per header or cookie on the wire
+//   *and* their accessors, so descending naively would demand a completion
+//   entry for `Authorization`. The runtime already separates the two, and not
+//   in a side table this test would have to keep in step:
+//   `install_header_methods` defines the accessors **non-enumerable**
+//   (HEADER_METHOD_FLAGS omits JS_PROP_ENUMERABLE) while `define_header_entry`
+//   defines the wire entries with JS_PROP_C_W_E. So the walk descends and
+//   requires exactly the non-enumerable functions - an accessor added tomorrow
+//   is required, a header named `Authorization` is not, and a wire header that
+//   happens to be named `get` overwrites the method as an enumerable string and
+//   is data again, which is what those flags exist to produce.
+// - **The cookie jar**, which is behind a *call* (`pm.cookies.jar()`) and so is
+//   not reachable by property reads at all. There is exactly one such factory,
+//   so it is named here rather than generalised into a machine for finding
+//   factories.
+//
+// `data` collects what was classified as wire data, so the test beside this can
+// assert the split happened rather than a widening that quietly requires
+// everything or nothing.
+constexpr const char* ENUMERATE_PM = R"JS(
+    var names = [];
+    var data = [];
+    var DATA_MAPS = ['pm.request.headers', 'pm.response.headers', 'pm.response.cookies'];
+
+    function descend(path, value) {
+        var isDataMap = DATA_MAPS.indexOf(path) !== -1;
+        var members = Object.getOwnPropertyNames(value).sort();
+        for (var i = 0; i < members.length; i++) {
+            var member = members[i];
+            if (!isDataMap) {
+                names.push(path + '.' + member);
+                continue;
+            }
+            // API on a data map is what the runtime hid from enumeration and
+            // bound as a function; everything else is a header, a cookie, an
+            // array index or `length`.
+            var descriptor = Object.getOwnPropertyDescriptor(value, member);
+            if (!descriptor.enumerable && typeof value[member] === 'function') {
+                names.push(path + '.' + member);
+            } else {
+                data.push(path + '.' + member);
+            }
+        }
+    }
+
+    var top = Object.getOwnPropertyNames(pm).sort();
+    for (var t = 0; t < top.length; t++) {
+        var key = top[t];
+        names.push('pm.' + key);
+        var value = pm[key];
+        if (value === null || typeof value !== 'object') continue;
+        descend('pm.' + key, value);
+
+        // One more level, which is where the data maps and the header
+        // accessors live.
+        var members = Object.getOwnPropertyNames(value).sort();
+        for (var m = 0; m < members.length; m++) {
+            var nested = value[members[m]];
+            if (nested === null || typeof nested !== 'object') continue;
+            descend('pm.' + key + '.' + members[m], nested);
+        }
+    }
+
+    // The jar, reached the only way it can be.
+    var jar = pm.cookies.jar();
+    var jarMembers = Object.getOwnPropertyNames(jar).sort();
+    for (var j = 0; j < jarMembers.length; j++) {
+        names.push('pm.cookies.jar().' + jarMembers[j]);
+    }
+
+    pm.environment.set('bound', names.join(','));
+    pm.environment.set('data', data.join(','));
+)JS";
 
 TEST (ScriptCompletions, EveryPmMemberTheRuntimeBindsIsOffered) {
     const auto completions = get_script_completions ();
@@ -694,48 +780,23 @@ TEST (ScriptCompletions, EveryPmMemberTheRuntimeBindsIsOffered) {
     FullyBoundContext bound;
     vayu::runtime::ScriptEngine engine;
 
-    // Walk `pm` two levels deep and report what is there. Two levels is what
-    // the surfaces are shaped like - `pm.<namespace>.<member>` - and going
-    // deeper reaches only the header maps and the assertion chain, both
-    // excluded above and both guarded separately.
-    auto enumerated = engine.execute (R"JS(
-        var names = [];
-        var top = Object.getOwnPropertyNames(pm).sort();
-        for (var i = 0; i < top.length; i++) {
-            var key = top[i];
-            names.push('pm.' + key);
-            var value = pm[key];
-            if (value === null || typeof value !== 'object') continue;
-            var members = Object.getOwnPropertyNames(value).sort();
-            for (var j = 0; j < members.length; j++) {
-                names.push('pm.' + key + '.' + members[j]);
-            }
-        }
-        pm.environment.set('bound', names.join(','));
-    )JS",
-    bound.ctx);
+    auto enumerated = engine.execute (ENUMERATE_PM, bound.ctx);
     ASSERT_TRUE (enumerated.success) << enumerated.error_message;
 
-    const std::string bound_names = bound.env["bound"].value;
+    const auto bound_names = split_commas (bound.env["bound"].value);
     ASSERT_FALSE (bound_names.empty ())
     << "the runtime enumeration found nothing, so this guard proved nothing";
 
     std::vector<std::string> missing;
     int checked = 0;
-    for (size_t start = 0; start <= bound_names.size ();) {
-        const size_t comma = bound_names.find (',', start);
-        const std::string name = bound_names.substr (
-        start, comma == std::string::npos ? std::string::npos : comma - start);
-        if (!name.empty () && !is_deliberately_uncompletable (name) && !is_data_map (name)) {
-            checked++;
-            if (find_by_label (completions, name) == nullptr) {
-                missing.push_back (name);
-            }
+    for (const auto& name : bound_names) {
+        if (is_deliberately_uncompletable (name)) {
+            continue;
         }
-        if (comma == std::string::npos) {
-            break;
+        checked++;
+        if (find_by_label (completions, name) == nullptr) {
+            missing.push_back (name);
         }
-        start = comma + 1;
     }
 
     EXPECT_GT (checked, 40)
@@ -752,14 +813,68 @@ TEST (ScriptCompletions, EveryPmMemberTheRuntimeBindsIsOffered) {
     << report;
 }
 
+// The widening above trades one silent hole for a noisy false positive unless
+// both halves hold, so both are asserted rather than left to the suite being
+// green: the depth-3 accessors have to be *reached* (a walk that stops at two
+// levels passes the guard by checking nothing there), and a header name on the
+// wire must not be demanded as a completion (a walk that descends
+// indiscriminately would demand `Authorization`).
+TEST (ScriptCompletions, TheWalkSeparatesDepthThreeAccessorsFromWireEntries) {
+    FullyBoundContext bound;
+    vayu::runtime::ScriptEngine engine;
+
+    auto enumerated = engine.execute (ENUMERATE_PM, bound.ctx);
+    ASSERT_TRUE (enumerated.success) << enumerated.error_message;
+
+    const auto required = split_commas (bound.env["bound"].value);
+    const auto wire     = split_commas (bound.env["data"].value);
+    ASSERT_FALSE (required.empty ());
+    ASSERT_FALSE (wire.empty ())
+    << "nothing was classified as wire data, so the split below proves nothing";
+
+    auto is_required = [&required] (const std::string& name) {
+        return std::find (required.begin (), required.end (), name) != required.end ();
+    };
+    auto is_wire = [&wire] (const std::string& name) {
+        return std::find (wire.begin (), wire.end (), name) != wire.end ();
+    };
+
+    // The API three levels down, which the two-level walk never saw.
+    for (const char* accessor : { "pm.request.headers.get", "pm.request.headers.has",
+         "pm.request.headers.add", "pm.request.headers.upsert",
+         "pm.request.headers.remove", "pm.response.headers.get",
+         "pm.response.headers.has", "pm.response.cookies.get",
+         "pm.response.cookies.has", "pm.response.cookies.toObject",
+         "pm.cookies.jar().get", "pm.cookies.jar().set",
+         "pm.cookies.jar().unset", "pm.cookies.jar().clear" }) {
+        EXPECT_TRUE (is_required (accessor))
+        << accessor << " is bound by the runtime but the walk never required it";
+    }
+
+    // And the data beside it, which must not be. FullyBoundContext puts each of
+    // these on the wire, so a walk that stopped classifying would fail here.
+    for (const char* entry : { "pm.request.headers.Authorization",
+         "pm.response.headers.content-type", "pm.response.headers.set-cookie",
+         "pm.response.cookies.0", "pm.response.cookies.length" }) {
+        EXPECT_TRUE (is_wire (entry))
+        << entry << " is a wire entry but the walk did not classify it as one";
+        EXPECT_FALSE (is_required (entry))
+        << entry << " is on the wire, not API - demanding a completion for it "
+                    "would make every response header a false positive";
+    }
+}
+
 // The named half of the same check. The guard above reads the runtime, so a
 // surface deleted from both sides at once would pass it; this pins the entries
 // #418 requires by name, the way the cookie jar's write half is pinned.
 TEST (ScriptCompletions, TheIterationDataAccessorsAreOffered) {
     const auto completions = get_script_completions ();
 
+    // `has` joined get / toObject in #435 - every other scope reader in the pm
+    // surface answers it, and it is the one way to ask about a column whose
+    // value is null without knowing how a null column comes back.
     for (const char* expected : { "pm.iterationData", "pm.iterationData.get",
-         "pm.iterationData.toObject" }) {
+         "pm.iterationData.has", "pm.iterationData.toObject" }) {
         const auto* item = find_by_label (completions, expected);
         ASSERT_NE (item, nullptr) << expected << " is bound by the runtime but not offered";
         // A completion that does not say so would promise a row in a plain
@@ -768,11 +883,6 @@ TEST (ScriptCompletions, TheIterationDataAccessorsAreOffered) {
         EXPECT_NE (documentation.find ("undefined"), std::string::npos)
         << expected << " does not say it is absent outside a data-driven run: " << documentation;
     }
-
-    // `has` is not offered because the runtime does not bind it - the row
-    // accessors are get / toObject. Offering it would be the #182 defect.
-    EXPECT_EQ (find_by_label (completions, "pm.iterationData.has"), nullptr)
-    << "pm.iterationData.has is offered but the runtime binds only get/toObject";
 }
 
 } // namespace

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -3832,6 +3832,55 @@ TEST_F (ScriptEngineTest, IterationDataGetOnAnUnknownKeyIsUndefined) {
     EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
 }
 
+// `has` exists for parity with every other scope reader in the pm surface
+// (pm.environment, pm.globals, pm.collectionVariables, pm.variables, pm.cookies)
+// and with Postman, whose pm.iterationData is a VariableScope. The case it is
+// the only clean answer to is the null column: the row *has* it, which is a
+// different fact from the row not carrying it at all.
+TEST_F (ScriptEngineTest, IterationDataHasAnswersPresenceIncludingANullColumn) {
+    const nlohmann::json row{ { "username", "ada" }, { "nickname", nullptr } };
+    auto ctx = data_test (request, response, env, row);
+
+    auto result = engine.execute (R"JS(
+        pm.test("presence", function() {
+            pm.expect(pm.iterationData.has("username")).to.equal(true);
+            pm.expect(pm.iterationData.has("missing")).to.equal(false);
+            // Present and null: `has` says the row carries it, and `get`
+            // answers null rather than the undefined an absent column gives -
+            // so the two agree and neither has to be read as the other.
+            pm.expect(pm.iterationData.has("nickname")).to.equal(true);
+            pm.expect(pm.iterationData.get("nickname")).to.equal(null);
+            pm.expect(typeof pm.iterationData.get("missing")).to.equal("undefined");
+            // No argument is no such column, the answer pm.variables.has gives.
+            pm.expect(pm.iterationData.has()).to.equal(false);
+        });
+    )JS",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+}
+
+// The same refusal `get` gives, for the same reason: a stashed pm.iterationData
+// called from a later script in a pooled context must not answer about a run
+// that has finished.
+TEST_F (ScriptEngineTest, IterationDataHasThrowsOutsideADataDrivenRun) {
+    const nlohmann::json row{ { "username", "ada" } };
+    auto first = data_test (request, response, env, row);
+    auto first_result = engine.execute ("globalThis.stashed = pm.iterationData;", first);
+    ASSERT_TRUE (first_result.success) << first_result.error_message;
+
+    auto second_result = engine.execute_test (
+    "globalThis.stashed.has('username');", request, response, env);
+
+    EXPECT_FALSE (second_result.success);
+    // Named, so the message points at the call the script actually made.
+    EXPECT_NE (second_result.error_message.find ("pm.iterationData.has is not available here"),
+    std::string::npos)
+    << second_result.error_message;
+}
+
 TEST_F (ScriptEngineTest, IterationDataToObjectReturnsTheWholeRow) {
     const nlohmann::json row{ { "username", "ada" }, { "attempts", 3 } };
     auto ctx = data_test (request, response, env, row);

--- a/engine/tests/script_types_test.cpp
+++ b/engine/tests/script_types_test.cpp
@@ -135,6 +135,30 @@ TEST (ScriptTypesTest, OptionalFieldsKeepTheirUnderlyingType) {
     EXPECT_FALSE (contains (dts, "void | undefined"));
 }
 
+// A surface that has members has no union to carry `| undefined` in, so the
+// optionality moves onto the property name. `pm.iterationData` is undefined
+// outside a data-driven collection run - the documented, deliberate design -
+// and the generated declarations described it as always present, so a plain
+// request script calling `pm.iterationData.get('x')` got no squiggle for
+// something that throws at run time.
+TEST (ScriptTypesTest, AnOptionalSurfaceIsDeclaredOptional) {
+    const std::string dts = generate_script_typedefs ();
+    EXPECT_TRUE (contains (dts, "iterationData?: {"))
+    << "pm.iterationData is undefined outside a data-driven run and the "
+       "declarations do not say so";
+
+    // And the marker is not sprayed over every surface: the ones that are
+    // always bound must stay required, or the declarations would invite a
+    // needless guard on `pm.response` and `pm.info`.
+    for (const char* required : { "response: {", "request: {", "info: {",
+         "environment: {", "cookies: {", "execution: {" }) {
+        EXPECT_TRUE (contains (dts, required))
+        << required << " lost its always-present declaration";
+    }
+    EXPECT_FALSE (contains (dts, "response?: {"));
+    EXPECT_FALSE (contains (dts, "info?: {"));
+}
+
 TEST (ScriptTypesTest, ReadsReturnTypesFromTheDetailString) {
     const std::string dts = generate_script_typedefs ();
     EXPECT_TRUE (contains (dts, "get(name: string): string | undefined;"));


### PR DESCRIPTION
## Description

**Plan.** The three items #418 deliberately left uncovered, all engine-side and independent of each other. The root cause common to 1 and 3 is that `pm.iterationData` was shipped as a partial copy of a shape the rest of the surface already has - it reads like the other scopes but answers one fewer question, and it is the only surface that can be *absent* while being declared as always present. Item 2 is the same class of defect one layer up: the guard added in PR #434 closed the callable-implies-offered direction only as deep as the surfaces it was written for.

For each I took the option that removes a special case rather than adding one, and the alternative I rejected is stated inline below.

**Verified against the code at `cc8b015` before editing.** `setup_pm_iteration_data` binds `get` / `toObject` / the three throwing writers and no `has`; the walk in `EveryPmMemberTheRuntimeBindsIsOffered` skips `is_data_map` objects wholesale; `render_member` emits `iterationData: {` unconditionally. Blast radius traced: the completion table has exactly two consumers, `GET /scripting/completions` (rendered by `useScriptCompletionProvider`) and `GET /scripting/types` (whose `.d.ts` is generated from the same table by `script_types.cpp`), plus the MCP `vayu://scripting/completions` resource which re-serves the endpoint. No renderer or MCP code hardcodes the list, so adding an entry reaches all three.

**One correction to the issue's premise, stated because it changes the argument and not the outcome.** The issue says the `get(col) !== undefined` workaround "cannot tell an absent column from a column whose value is JSON `null`". In vayu it can: `js_from_json` round-trips through `JS_ParseJSON`, so a null column arrives as JS `null` and an absent one as `undefined`. So the workaround is correct here - it is just non-obvious, and it requires the reader to know that fact. The case for `has` is therefore parity (five sibling scopes and Postman all have one) and directness, not reachability. A test now pins both halves of that null behaviour so the claim stops being folklore.

### 1. `pm.iterationData.has(column)` - option A, bind it

Chosen over **B, leave it and document the divergence**: `pm-api-compatibility.md` would have to carry a row explaining why one scope reader lacks the method the other five have, which is more words than the function, and every reader of that row would still want the method. `has` answers `true` for a present-but-null column - the row carries it - which is the fact `get` can only state if you already know how a null column comes back. No argument is `false`, matching `pm.variables.has`. Outside a data-driven run it throws through the same `iteration_data_context` guard `get` uses, naming itself in the message.

`set` / `unset` / `clear` are untouched and stay allowlisted as deliberately-uncompletable, as the issue instructed.

### 2. The guard now walks three levels

Rather than skipping the data maps, the walk descends into them and asks the runtime which members are API. **It does not need a new marking to do that** - the distinction is already in the object model, and load-bearing for a different reason: `install_header_methods` defines the accessors with `HEADER_METHOD_FLAGS` (configurable + writable, *not* enumerable) while `define_header_entry` defines wire entries with `JS_PROP_C_W_E`. So a non-enumerable own property that is a function is API and must be offered; everything else - a header, a cookie, an array index, `length` - is data and must not be. A wire header literally named `get` overwrites the method as an enumerable string and is classified as data, which is exactly what those flags exist to produce.

I rejected the issue's suggested side table of marked accessors for the reason PR #434 rejected the static name table: a second record of what the runtime bound drifts from the binding calls, and keeping it in step is the same act of remembering that failed in the first place.

`pm.cookies.jar()` is behind a call and unreachable by property reads, so it is named explicitly - there is exactly one such factory, and a general mechanism for discovering factories would be more machinery than the one case is worth.

**The widening found no new omissions** - all fourteen depth-3 accessors are already offered. That is the expected result: this closes the direction, it does not fix an instance.

### 3. Optionality in the generated `.d.ts`

`pm.iterationData` is `undefined` outside a data-driven collection run, and the declarations said otherwise. The table already had a way to say "may be absent" - a `detail` ending in ` | undefined`, which `field_type` reads for leaves - so this extends that one convention instead of adding a second: the suffix detection moves into `split_optional_suffix`, used by both readers, and a node that has children renders `iterationData?: { ... }` because an object type has no union to carry the suffix in.

**The `strictNullChecks` check the issue asked for, and its outcome.** `useScriptTypeDefinitions` spreads Monaco's defaults and sets `target` / `lib` / `allowJs` / `checkJs` / `noEmit`; neither `strict` nor `strictNullChecks` is set, and Monaco does not default them on. So the marker shows in hover but produces no squiggle today. I did **not** turn `strictNullChecks` on in this PR: it would apply to every `T | undefined` in the surface at once - `pm.environment.get`, `pm.response.errorCode`, `pm.info.iteration` - so `pm.environment.get('token').trim()` would newly error. That is a decision about how noisy this editor should be for all script authors, and the file it lives in explicitly warns against trading false positives for coverage. It is filed separately as #443 rather than folded in here. The limitation is documented alongside the marker.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`

**1162/1162 passed**, including the 4 tests added here. No failures anywhere in the suite.

Tests added:

- `ScriptEngineTest.IterationDataHasAnswersPresenceIncludingANullColumn` - true for a present column, false for an absent one, **true for a column whose value is `null`**, and `get` on those same two columns answers `null` vs `undefined` so the two methods are pinned as agreeing. No argument is `false`.
- `ScriptEngineTest.IterationDataHasThrowsOutsideADataDrivenRun` - a stashed `pm.iterationData` called from a later script in the pooled context refuses, and the message names `pm.iterationData.has`.
- `ScriptCompletions.TheWalkSeparatesDepthThreeAccessorsFromWireEntries` - both halves of the widening, since it trades a silent hole for a noisy false positive if either fails: all fourteen depth-3 accessors are *reached and required*, and five wire entries the fixture puts on the wire are classified as data and demanded of nobody.
- `ScriptTypesTest.AnOptionalSurfaceIsDeclaredOptional` - `iterationData?: {` is emitted, and six always-bound surfaces keep their required declarations so the marker is not sprayed over everything.

`ScriptCompletions.TheIterationDataAccessorsAreOffered` flips: it asserted `pm.iterationData.has` is *not* offered (correct while the runtime lacked it) and now requires it alongside the others.

**Mutation checks, all four applied, confirmed red, reverted:**

| Mutation | Result |
|---|---|
| Unbind `has`, keep the completion entry | both `IterationDataHas*` tests fail |
| Stop the walk at two levels | `TheWalkSeparatesDepthThreeAccessorsFromWireEntries` fails - "nothing was classified as wire data, so the split below proves nothing" |
| Descend into data maps indiscriminately | that test fails *and* `EveryPmMemberTheRuntimeBindsIsOffered` fails naming `pm.request.headers.Authorization`, `pm.response.headers.content-type`, `pm.response.cookies.length` - the false positive the classification exists to prevent |
| Drop the `?` from the optional render | `AnOptionalSurfaceIsDeclaredOptional` fails |

Generated declarations verified against a running engine (`GET /scripting/types`): `iterationData?: {` is the only property in the file that gained a `?`, and it contains `get(column: string): any;`, `has(column: string): boolean;`, `toObject(): object;`.

No app changes. Item 3's app-side work was the `strictNullChecks` *check* the issue asked for, which is a read of `useScriptTypeDefinitions.ts`; its outcome is documented rather than coded. `mkdocs build --strict` could not be run (mkdocs is not installed in this environment) - the docs edits add no link and no nav entry; the one new heading has no inbound link.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`script_types.cpp` was clang-format clean before and is formatted. `script_engine.cpp`, `script_completions_test.cpp` and `script_engine_test.cpp` were already not clang-format clean on master, so per CLAUDE.md they were left alone and the added code matches each file's prevailing style. `scripting.cpp` and `script_types_test.cpp` were clean and remain clean.

Docs updated same-commit: `docs/engine/scripting.md` (the `pm.iterationData` code block and the `has` semantics including the null column), `docs/app/pm-api-compatibility.md` (the summary-table row, the code block, and a new subsection under Type declarations covering the optional-member convention and the `strictNullChecks` limitation).

## Related Issues
Closes #435

Follow-up filed: #443 (whether the script editor should run with `strictNullChecks`, which is what would make item 3's marker produce a diagnostic rather than only hover text).