### PR TITLE
feat(app/scripting): keep the script editor off strictNullChecks, deliberately

### DIFF
--- a/app/src/hooks/script-type-definitions.test.tsx
+++ b/app/src/hooks/script-type-definitions.test.tsx
@@ -109,6 +109,27 @@ describe("useScriptTypeDefinitions", () => {
 		expect(options.strict).toBe(false);
 	});
 
+	/*
+	 * The null half of semantic validation is off on purpose (#443), and the
+	 * option is written down rather than inherited: Monaco does not default it
+	 * on today, but the spread above carries whatever the worker already had,
+	 * and a `strict: true` arriving there would turn it on as a side effect.
+	 *
+	 * Decided on a count, not a preference: over the 54 `pm.*` examples in the
+	 * two script docs plus three realistic scripts, turning it on adds 13
+	 * diagnostics and 8 of them land on the docs' own recommended lines. The
+	 * reasoning lives on the option itself.
+	 */
+	it("leaves strictNullChecks off, written down rather than inherited", async () => {
+		renderHook(() => useScriptTypeDefinitions(), { wrapper });
+		await waitFor(() => expect(setCompilerOptions).toHaveBeenCalled());
+
+		const options = setCompilerOptions.mock.calls[0][0] as {
+			strictNullChecks?: boolean;
+		};
+		expect(options.strictNullChecks).toBe(false);
+	});
+
 	it("turns semantic validation on - that is what squiggles a typo", async () => {
 		renderHook(() => useScriptTypeDefinitions(), { wrapper });
 		await waitFor(() => expect(setDiagnosticsOptions).toHaveBeenCalled());

--- a/app/src/hooks/useScriptTypeDefinitions.ts
+++ b/app/src/hooks/useScriptTypeDefinitions.ts
@@ -84,6 +84,36 @@ export function useScriptTypeDefinitions() {
 			// hover and signature help both need.
 			checkJs: true,
 			noEmit: true,
+			/*
+			 * Off deliberately, and *set* rather than left to Monaco's default:
+			 * the default is what it is today, and a `getCompilerOptions()` that
+			 * ever carried `strict: true` would turn this on as a side effect.
+			 *
+			 * The engine declares the surface's optionality truthfully
+			 * (`iterationData?: { ... }`, `get(name): string | undefined`), and
+			 * with this flag on the worker would report every one of those at
+			 * once. Measured against the real declarations over 57 scripts - the
+			 * 54 `pm.*` examples in `docs/engine/scripting.md` and
+			 * `docs/app/pm-api-compatibility.md`, plus three realistic ones: 13
+			 * new diagnostics, of which **8 land on the docs' own recommended
+			 * lines** (`pm.iterationData.get('username')`, correct inside the
+			 * data-driven run those examples are about). Two more are on code
+			 * that works: `pm.info.iteration > 0` is simply `false` outside a
+			 * run, and `pm.response.errorMessage` cannot be narrowed by a truthy
+			 * check on its sibling `pm.response.errorCode`.
+			 *
+			 * Suppressing the noise is not on offer, because the noise and the
+			 * catch share a code: `18048` fires for `pm.iterationData.get(...)`
+			 * - the case this was wanted for - and for `token.trim()` alike, and
+			 * the remaining code is `2345`, which is the argument checking this
+			 * whole feature exists to provide.
+			 *
+			 * So the guard the docs recommend stays advice rather than a rule.
+			 * This is the same trade SUPPRESSED_DIAGNOSTICS makes below, one
+			 * level up: a real mistake goes unreported in exchange for not
+			 * crying wolf on correct code. See issue #443.
+			 */
+			strictNullChecks: false,
 		});
 
 		/*

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -616,7 +616,7 @@ entry - it caught `queueMicrotask`, which quickjs-ng does provide, on its first 
 Narrow that suppression list rather than widening it: each code on it is a real mistake
 going unreported in exchange for not crying wolf on correct code.
 
-#### Optional members, and the one thing the editor cannot yet tell you
+#### Optional members, and why the editor states them without enforcing them
 
 A completion entry says a member may be absent by ending its `detail` in
 ` | undefined`. The generator reads that one convention in two places: a leaf keeps the
@@ -625,15 +625,38 @@ union to carry it, so the optionality moves onto the property name -
 `pm.iterationData` is declared **`iterationData?: { ... }`**, because it is `undefined`
 outside a data-driven collection run.
 
-That marker shows in hover today, but it does **not** produce a squiggle: the worker runs
-with `strictNullChecks` off, and without it an optional property is indistinguishable from
-a required one at a use site. So a plain request script calling
-`pm.iterationData.get('x')` still gets no editor error for something that throws at run
-time - the guard the docs recommend (`pm.iterationData ? ... : ...`) is advice, not a rule
-the type system enforces. Turning `strictNullChecks` on would change that for this member
-*and* for every `T | undefined` in the surface at once (`pm.environment.get` among them),
-which is a decision about how noisy this editor should be rather than a detail of the
-declarations - so it is tracked separately, not folded in here.
+That marker shows in hover, and deliberately does **not** produce a squiggle: the worker
+runs with `strictNullChecks` **off**, and without it an optional property is
+indistinguishable from a required one at a use site. So a plain request script calling
+`pm.iterationData.get('x')` gets no editor error for something that throws at run time -
+the guard the docs recommend (`pm.iterationData ? ... : ...`) is advice, not a rule the
+type system enforces.
+
+That is a decision (#443), not an oversight, and `useScriptTypeDefinitions` now sets
+`strictNullChecks: false` explicitly rather than relying on the default, so a `strict:
+true` arriving through the spread of Monaco's existing options cannot turn it on as a side
+effect. It was taken on a count. Compiling **57 scripts** against the real generated
+declarations - the 54 `pm.*` examples in this page and
+[`docs/engine/scripting.md`](../engine/scripting.md), plus three realistic ones - turning
+the flag on adds **13 diagnostics**:
+
+| What | Count | Verdict |
+|------|------:|---------|
+| `pm.iterationData.get/has/toObject` unguarded | 7 | Correct inside the data-driven run those examples are about |
+| An optional string used straight - `pm.environment.get(...)` into `.trim()` and `pm.crypto.hmacSha256`, `pm.request.body` into `JSON.parse` | 4 | A real crash when the value is absent, and the idiom every script uses |
+| `pm.info.iteration > 0` | 1 | Works: the comparison is `false` outside a run |
+| `pm.response.errorMessage` after a truthy `pm.response.errorCode` | 1 | Correlated siblings, which no narrowing can see |
+
+Eight of the thirteen land on lines these docs publish as the way to use the API. Nor can
+the noise be suppressed away while the catch is kept: `18048` is the code for
+`pm.iterationData.get(...)` - the case the flag was wanted for - *and* for `token.trim()`,
+and the remaining code is `2345`, which is the argument checking the whole feature exists
+to provide. A script editor is JavaScript, so there is no `!` for an author to say "I know
+it is set"; the escape is restructuring the code.
+
+So the trade is the one the suppression list above already makes, one level up: a real
+mistake goes unreported in exchange for not crying wolf on correct code. Revisiting it
+means re-running that count, not re-arguing it.
 
 `pm.execution` has the mirror-image limitation and no fix at all: it is always bound, and
 its methods throw outside a collection run, which no type can express.


### PR DESCRIPTION
## Description

**Plan.** Root cause: since #442 the engine *declares* optionality (`iterationData?: { ... }`, `get(name): string | undefined`) and Monaco's worker never acts on it, because `useScriptTypeDefinitions` spreads Monaco's defaults and neither `strict` nor `strictNullChecks` is among them. The issue asked which of A (turn it on), B (leave it off) or C (something narrower) is right, and said the count matters more than the argument. I measured, chose **B**, and made B a written-down decision rather than a leftover: the option is now *set* to `false` on the compiler options, so a `strict: true` arriving through that spread cannot turn it on as a side effect of something unrelated. **A** is rejected on the numbers below; **C** is rejected because it is strictly worse than B - the codes it would have to suppress are the same codes the flag was wanted for.

**Verified against the code at `91b285c` before editing.** The problem is as the issue describes: `useScriptTypeDefinitions.ts` is the only place in `app/` that calls `setCompilerOptions` (`rg setCompilerOptions|javascriptDefaults src electron` finds one site), it sets `target` / `lib` / `allowJs` / `checkJs` / `noEmit` and no strictness flag, and the marker `#442` added reaches hover and nothing else. Blast radius: the option object has exactly one consumer, Monaco's JavaScript worker, registered once in `App`; no engine change and no MCP change, as the issue states.

### The measurement

Compiled **57 scripts** against the **real generated declarations** - `GET /scripting/types` off a locally built `0.15.0` engine, 36,613 bytes - with the app's own compiler options, once with the flag off and once on, filtering the two suppressed codes (1108/2304). The corpus is the 54 `pm.*` code blocks in `docs/engine/scripting.md` and `docs/app/pm-api-compatibility.md` - the repo's own published examples, which is the least arbitrary sample of "correct code" available - plus three realistic scripts written to the issue's spec (two environment reads, a branch on `pm.info.iteration`, a data-column read).

**Baseline (flag off): 12 diagnostics. Flag on: 25.** The 13 new ones:

| What | Count | Code | Verdict |
|------|------:|------|---------|
| `pm.iterationData.get/has/toObject` unguarded | 7 | 18048 | Correct inside the data-driven run those examples are about |
| An optional string used straight - `pm.environment.get(...)` into `.trim()` / `pm.crypto.hmacSha256`, `pm.request.body` into `JSON.parse` | 4 | 2532, 2345 | A real crash when the value is absent, and the idiom every script uses |
| `pm.info.iteration > 0` | 1 | 18048 | Works: the comparison is `false` outside a run |
| `pm.response.errorMessage` after a truthy `pm.response.errorCode` | 1 | 18048 | Correlated siblings, which no narrowing can see |

**Eight of the thirteen land on lines these docs publish as the way to use the API** - `docs/engine/scripting.md`'s iteration-data block and this page's copy of it, both of which appear in sections about data-driven runs, where `pm.iterationData` is always there. Two more are on code that runs correctly. And a script editor is JavaScript, so there is no `!` for an author to say "I know it is set"; the escape is restructuring the code or `?.`, which changes semantics.

**Why C collapses.** `diagnosticCodesToIgnore` is per-code, and the codes do not separate the wolf from the catch: `18048` is what `pm.iterationData.get('x')` produces - the case the flag was wanted for - *and* what `token.trim()` produces. Suppressing it removes the motivating diagnostic and keeps 3 of the noise; the remaining code, `2345`, is the argument checking this whole feature exists to provide, and `script-type-definitions.test.tsx` already asserts 2345 must survive. So C is strictly worse than B in both directions.

That leaves the trade the file already states one level up, in its own words: *every code here is a real mistake going unreported in exchange for not crying wolf on correct code*. B keeps that rule; A breaks it for the surface's most common idiom.

**Adjacent, not fixed here.** The 12 *baseline* diagnostics are unrelated to this flag and are real defects in the generated declarations - `jar()` is emitted twice so `pm.cookies.jar().set()` errors today, `pm.info.eventName` is typed `void` so the documented `=== "prerequest"` comparison errors, and two `pm.expect` chain gaps. Filed separately rather than folded in.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check`

**376 test files, 3747 tests, all passing.** Type-check, ESLint (`--max-warnings 0`) and Prettier all clean. No pre-existing failures.

Test added: `script-type-definitions.test.tsx` - "leaves strictNullChecks off, written down rather than inherited", asserting the value the worker actually receives rather than scanning source.

**Mutation check, applied, confirmed red, reverted:** flipping the option to `true` fails that test with `expected true to be false`. Deleting the line fails it too (`undefined` is not `false`), which is the case that matters - the test exists to catch the option going *missing* and reverting to whatever Monaco defaults to.

`docs/app/pm-api-compatibility.md` was already not Prettier-clean on master and is outside the app's `format:check` glob, so per CLAUDE.md it was edited by hand and not reformatted. `mkdocs build --strict` could not be run (mkdocs is not installed in this environment); the one renamed heading has no inbound links anywhere in the tree (`rg` for both anchors finds none), and the one added relative link (`../engine/scripting.md`) matches the pattern the same file already uses.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated same-commit: `docs/app/pm-api-compatibility.md` - the "Optional members" subsection was written as an open limitation and now records the decision, the count table and the reason C is unavailable, per the issue's third acceptance criterion.

## Related Issues
Closes #443

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDo2mBdzRDYtBrLMfpre6E)_