### PR TITLE
feat(app/collections): script tabs autosave; auth keeps its button, and says so

### DIFF
--- a/app/src/hooks/useDraftSaveContext.ts
+++ b/app/src/hooks/useDraftSaveContext.ts
@@ -14,10 +14,11 @@
  * flush, tab eviction) could not see them at all. A collection's auth, its
  * description, its scripts - all dirty, all invisible, all gone on quit.
  *
- * This is registration only. It does not schedule anything, and the Save button
- * stays the primary affordance: the manual model is a deliberate choice for
- * these editors (see `useEntityDraft`), and the defect was that the *other*
- * ways to save could not reach them.
+ * This is registration only. It does not schedule anything: each editor decides
+ * when to call its own `save` - `AuthTab` on its Save button, `InfoTab` and
+ * `ScriptTab` when focus leaves the field (see `useEntityDraft` for why auth is
+ * the one that waits). The defect this fixes is orthogonal to that choice: the
+ * *other* ways to save could not reach any of them.
  *
  * A failure on this path toasts through `failSave` rather than resolving
  * quietly. The editors render their own inline `SaveFailed` callout for a

--- a/app/src/hooks/useEntityDraft.ts
+++ b/app/src/hooks/useEntityDraft.ts
@@ -10,14 +10,24 @@
  *
  * Two save models exist in this app. `useSaveManager` is the autosave one the
  * request builder uses. This is the other one: an editable draft, a Save button
- * gated on `isDirty`, and a Reset that throws the draft away. `AuthTab` and
- * `ScriptTab` use it because a credential or a script is a deliberate act with
- * a button, not a keystroke that persists itself.
+ * gated on `isDirty`, and a Reset that throws the draft away. `AuthTab` is its
+ * one remaining button user.
  *
- * `InfoTab` no longer does. Its name and description commit on blur like the
- * request builder's, so it takes the draft, the resync and the mutation reset
- * from here and simply never renders a Save button - which is why `reset` has
- * one caller fewer than `draft` does.
+ * `InfoTab` and `ScriptTab` take the draft, the resync and the mutation reset
+ * from here and render no Save button at all - they commit when focus leaves
+ * the field, like the request builder. `reset` therefore has one caller, where
+ * `draft` has three.
+ *
+ * **Why auth alone kept the button (#446).** Not because a credential is
+ * grander than a script - the request builder autosaves its own auth. Because a
+ * blur inside `AuthFields` is not a completion signal: an OAuth 2.0 config with
+ * Advanced open renders 20 focus stops, 9 of them non-value controls (pickers,
+ * switches, the reveal toggle, Get Token), and clicking reveal to check a
+ * half-typed password fires `focusout` while the draft is dirty. The fields
+ * only make sense written together. A script tab has exactly one focus stop, so
+ * leaving it means the same thing leaving a description does. If collection
+ * auth is ever to persist by itself, the mechanism is `useSaveManager`'s
+ * debounce, not a blur - a different change from this one.
  *
  * The mechanism was hand-rolled once per tab (`AuthTab`, `InfoTab`,
  * `ScriptTab`) with the same five moving parts each time, and the copies had

--- a/app/src/modules/collections/CollectionDetail/AuthTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/AuthTab.test.tsx
@@ -169,6 +169,49 @@ describe("AuthTab with an editable auth mode", () => {
 	});
 });
 
+/**
+ * The other half of #446's decision. Info and both script tabs on this screen
+ * commit when focus leaves the field; this one does not, and the reason is
+ * measurable rather than a preference - a blur inside `AuthFields` is not a
+ * completion signal. If a later change wires blur-commit in here, these two fail
+ * and the decision gets revisited rather than drifting.
+ */
+describe("AuthTab keeps its button, and says so", () => {
+	it("does not write when a field blurs - including on the reveal toggle", () => {
+		renderTab(makeCollection({ mode: "basic", username: "acme", password: "" }));
+		const password = screen.getByPlaceholderText("Password");
+		fireEvent.change(password, { target: { value: "hunt" } });
+
+		// Clicking the eye to check a half-typed secret moves focus off the field.
+		// That is the gesture a commit-on-blur would write a partial credential
+		// on, and it is why this tab kept its button.
+		fireEvent.blur(password, {
+			relatedTarget: screen.getByRole("button", { name: /show value/i }),
+		});
+		fireEvent.blur(password);
+
+		expect(mutation.mutateAsync).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: /save auth/i }));
+		expect(mutation.mutateAsync).toHaveBeenCalledWith({
+			id: "c1",
+			auth: { mode: "basic", username: "acme", password: "hunt" },
+		});
+	});
+
+	it("says the fields are saved together, where the typing is", () => {
+		// A button further down the page is not the same as knowing before the
+		// first keystroke, which is the whole of what C's half owed.
+		renderTab(makeCollection({ mode: "bearer", token: "" }));
+		expect(screen.getByText(/saved together, when you press Save Auth/i)).toBeInTheDocument();
+	});
+
+	it("says nothing on a mode with no fields to type into", () => {
+		renderTab(makeCollection({ mode: "none" }));
+		expect(screen.queryByText(/saved together/i)).not.toBeInTheDocument();
+	});
+});
+
 describe("AuthTab when the save fails", () => {
 	it("surfaces the rejection instead of quietly re-enabling the button", () => {
 		mutation.isError = true;

--- a/app/src/modules/collections/CollectionDetail/AuthTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/AuthTab.tsx
@@ -14,9 +14,26 @@
  * same component the request builder's Auth tab renders. The bottom shows the
  * inheritance chain so the user can see which ancestor a child request would
  * resolve to.
+ *
+ * **This is the one tab on the screen that still waits for a button, and that is
+ * a decision (#446), not a leftover.** Info and both Script tabs commit when
+ * focus leaves the field, because each is one text buffer and leaving it means
+ * you are done with it. This form is not one buffer: an OAuth 2.0 config with
+ * Advanced open is 20 focus stops, 9 of which are not value fields at all - the
+ * grant-type and Add-to pickers, three switches, the secret's reveal toggle, the
+ * Advanced disclosure, Get Token. Measured: clicking reveal to check a
+ * half-typed password fires `focusout` on that field while the draft is dirty,
+ * so a blur-commit would write half a credential to the record every descendant
+ * request inherits from. The fields only make sense saved together, which is
+ * what the button means here.
+ *
+ * A form that saves differently from its neighbours has to say so where the
+ * typing is, not only through a button further down the page - hence the note
+ * above the fields.
  */
 
 import { useCallback } from "react";
+import { Lock } from "lucide-react";
 
 import {
 	Button,
@@ -119,6 +136,10 @@ export default function AuthTab({ collection, active = false }: AuthTabProps) {
 	// `mode === null` is exactly the digest/aws/ntlm set.
 	const uneditableLabel = uneditableAuthLabel(auth.mode);
 	const hint = mode ? AUTH_MODE_HINTS[mode] : undefined;
+	// The modes with credentials to type. `none`/`noauth` render an empty state
+	// and are saved by the picker alone, so they get neither the note nor the
+	// always-visible button row.
+	const hasCredentialFields = mode !== null && mode !== "none" && mode !== "noauth";
 
 	const persist = useCallback(async () => {
 		if (!isDirty) return;
@@ -194,6 +215,19 @@ export default function AuthTab({ collection, active = false }: AuthTabProps) {
 			</div>
 
 			{/*
+			 * Where the typing is, not only at the button. Info and the script
+			 * tabs on this same screen persist on their own, so the one form that
+			 * does not has to say which kind it is before the first keystroke
+			 * rather than after the user goes looking for a way to keep it.
+			 */}
+			{hasCredentialFields && (
+				<p className="text-[11px] text-muted-foreground mb-2 flex items-center gap-1.5">
+					<Lock className="w-3 h-3 shrink-0" aria-hidden="true" />
+					These fields are saved together, when you press Save Auth - not as you type.
+				</p>
+			)}
+
+			{/*
 			 * The same fields the request builder's Auth tab renders. No
 			 * `TextInput` is injected: a collection has no per-request variable
 			 * scope to resolve against at edit time, so the shared default -
@@ -225,7 +259,7 @@ export default function AuthTab({ collection, active = false }: AuthTabProps) {
 
 			<SaveFailed mutation={updateCollection} what="auth" className="mt-6" />
 
-			{mode !== null && mode !== "none" && mode !== "noauth" && (
+			{hasCredentialFields && (
 				<div className="flex gap-2 mt-6">
 					<Button
 						onClick={handleSave}

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.autosave.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.autosave.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The collection's script tabs save the way its Info tab does, and this is the
+ * change (#446).
+ *
+ * A script is a text buffer, and the two other places you edit one - the request
+ * builder's script panels and this screen's own description - both persist it
+ * without being asked. These two demanded "Save Script", so the same act on the
+ * same kind of field either stuck or did not depending on which pane you were
+ * in.
+ *
+ * What the button was carrying, asserted rather than assumed:
+ *
+ *   - **the commit**, now the editor losing focus;
+ *   - **Clear's write**, which used to be a Clear press followed by a Save press
+ *     and now has no later blur to ride on - focus is on the button, not in the
+ *     editor.
+ *
+ * The absence of the Save button is asserted directly: leaving it in place while
+ * adding blur-commit would save twice and look entirely fine on screen.
+ *
+ * The Auth tab deliberately did not move (see `AuthTab.test.tsx`, which pins the
+ * other half of the same decision).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { Collection } from "@/types";
+
+const mutation = {
+	mutateAsync: vi.fn(() => Promise.resolve()),
+	mutate: vi.fn(),
+	reset: vi.fn(),
+	isPending: false,
+	isError: false,
+	error: null as Error | null,
+};
+
+vi.mock("@/queries/collections", () => ({
+	useUpdateCollectionMutation: () => mutation,
+}));
+
+/*
+ * Monaco does not run in jsdom. The stub is a real focusable element inside the
+ * editor's container, which is the part under test: the tab listens for
+ * `focusout` on the container rather than on Monaco's own blur, so what has to
+ * be right is the DOM, and a stub that could not take focus would test nothing.
+ */
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: ({ value, onChange }: { value: string; onChange?: (v: string) => void }) => (
+		<textarea
+			data-testid="code-editor"
+			aria-label="Script"
+			value={value}
+			onChange={(e) => onChange?.(e.target.value)}
+		/>
+	),
+}));
+
+const { default: ScriptTab } = await import("./ScriptTab");
+
+function makeCollection(script: string): Collection {
+	return {
+		id: "c1",
+		name: "Acme API",
+		description: "",
+		order: 0,
+		variables: {},
+		auth: { mode: "none" },
+		preRequestScript: script,
+		postRequestScript: script,
+		createdAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+	};
+}
+
+const editor = () => screen.getByTestId("code-editor") as HTMLTextAreaElement;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe.each([
+	["pre", "preRequestScript"],
+	["post", "postRequestScript"],
+] as const)("the %s-request script tab saves like the request builder", (kind, field) => {
+	it("has no Save button", () => {
+		render(<ScriptTab collection={makeCollection("")} kind={kind} />);
+
+		expect(screen.queryByRole("button", { name: /save/i })).toBeNull();
+	});
+
+	it("commits when focus leaves the editor", () => {
+		render(<ScriptTab collection={makeCollection("")} kind={kind} />);
+		fireEvent.change(editor(), { target: { value: "pm.test('ok', () => {});" } });
+		fireEvent.blur(editor());
+
+		expect(mutation.mutateAsync).toHaveBeenCalledWith({
+			id: "c1",
+			[field]: "pm.test('ok', () => {});",
+		});
+	});
+
+	it("does not save a script that did not change", () => {
+		render(<ScriptTab collection={makeCollection("console.log(1);")} kind={kind} />);
+		// Tabbing through the panel is not an edit, and `persist` gates on
+		// `isDirty` for exactly this.
+		fireEvent.blur(editor());
+
+		expect(mutation.mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("ignores focus moving inside the editor", () => {
+		// Monaco's find widget takes focus on Ctrl+F without the user having
+		// finished anything, and `focusout` bubbles to the container either way -
+		// so the handler reads `relatedTarget` rather than trusting the event.
+		render(<ScriptTab collection={makeCollection("")} kind={kind} />);
+		const field = editor();
+		fireEvent.change(field, { target: { value: "pm.test('ok', () => {});" } });
+
+		const sibling = document.createElement("input");
+		field.parentElement?.appendChild(sibling);
+		fireEvent.blur(field, { relatedTarget: sibling });
+
+		expect(mutation.mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("writes the empty script when Clear is pressed", () => {
+		// Clear used to be half a gesture - press Clear, then press Save. With no
+		// Save button and focus on Clear rather than in the editor, no blur is
+		// coming, so the press has to carry the write itself.
+		render(<ScriptTab collection={makeCollection("console.log(1);")} kind={kind} />);
+		fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
+
+		expect(mutation.mutateAsync).toHaveBeenCalledWith({ id: "c1", [field]: "" });
+		expect(editor().value).toBe("");
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/ScriptTab.tsx
@@ -20,6 +20,14 @@
  * own. The banner below said so to users, which is worse than saying it here.
  *
  * Used by both the Pre-request and Post-request tabs in CollectionDetail.
+ *
+ * **It used to demand an explicit Save.** A script is a text buffer, and the two
+ * other places you edit one - the request builder's script panels and this
+ * screen's own description field - both persist it without being asked. Both
+ * kinds now commit when focus leaves the editor, like `InfoTab`. The Auth tab
+ * deliberately did *not* follow: its form is up to 20 focus stops, 9 of which
+ * are not value fields, so a blur there is not a completion signal (see #446 and
+ * `useEntityDraft`). This editor has exactly one.
  */
 
 import { useCallback, useMemo, useState } from "react";
@@ -75,10 +83,20 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 	// landed in the helper never reached the pre- and post-request tabs here.
 	const usedVars = useMemo(() => referencedVariables(script), [script]);
 
+	// Takes the text rather than reading the draft, so Clear can write the empty
+	// script on the same tick it sets it - `setScript` has not landed yet when
+	// the handler runs, and a `persist()` there would save the old text.
+	const persistText = useCallback(
+		async (text: string) => {
+			await updateCollection.mutateAsync({ id: collection.id, [fieldKey]: text });
+		},
+		[updateCollection, collection.id, fieldKey]
+	);
+
 	const persist = useCallback(async () => {
 		if (!isDirty) return;
-		await updateCollection.mutateAsync({ id: collection.id, [fieldKey]: script });
-	}, [isDirty, updateCollection, collection.id, fieldKey, script]);
+		await persistText(script);
+	}, [isDirty, persistText, script]);
 
 	useDraftSaveContext({
 		id: `collection-${collection.id}-${fieldKey}`,
@@ -90,10 +108,35 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 
 	// A rejection here is rendered by <SaveFailed> below; the store-driven paths
 	// toast instead, since this callout may not be on screen at all.
-	const handleSave = () => void persist().catch(() => {});
+	const commit = () => void persist().catch(() => {});
 
+	/*
+	 * Commit when focus leaves the editor - the blur Monaco does not expose.
+	 *
+	 * `focusout` bubbles, so the wrapper hears the internal textarea losing
+	 * focus; `relatedTarget` inside the wrapper means focus only moved *within*
+	 * the editor (the find widget takes focus on Ctrl+F) and nothing has been
+	 * finished. Leaving to nowhere - a click on empty page - reports a null
+	 * relatedTarget, which `contains` correctly reads as "outside".
+	 *
+	 * The alternative was an `onBlur` prop on `CodeEditor` wired to Monaco's
+	 * `onDidBlurEditorWidget`. Rejected: every suite that mounts the editor
+	 * stubs the instance, so a shared primitive reaching for one more method
+	 * makes each stub a place the next method can be forgotten - and the
+	 * container's own focusout answers the same question in the DOM, where the
+	 * tests already live.
+	 */
+	const handleEditorFocusOut = (event: React.FocusEvent<HTMLDivElement>) => {
+		if (event.currentTarget.contains(event.relatedTarget)) return;
+		commit();
+	};
+
+	// Clearing is a button press, so it persists on the press - there is no
+	// later blur to carry it (focus is on the button, not the editor). Monaco's
+	// undo stack still holds the text, and undoing re-commits it on the way out.
 	const handleClear = () => {
 		setScript("");
+		void persistText("").catch(() => {});
 	};
 
 	return (
@@ -128,7 +171,10 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 				</div>
 			)}
 
-			<div className="border border-border rounded-md overflow-hidden">
+			<div
+				className="border border-border rounded-md overflow-hidden"
+				onBlur={handleEditorFocusOut}
+			>
 				<div className="flex items-center gap-2.5 px-3 py-1.5 bg-panel border-b border-border">
 					<span className="text-[11px] font-mono text-muted-foreground">
 						{isPre ? "pre-request.js" : "post-request.js"}
@@ -179,13 +225,6 @@ export default function ScriptTab({ collection, kind, active = false }: ScriptTa
 			<SaveFailed mutation={updateCollection} what="the script" />
 
 			<div className="flex gap-2">
-				<Button
-					onClick={handleSave}
-					disabled={!isDirty || updateCollection.isPending}
-					className="font-semibold"
-				>
-					{updateCollection.isPending ? "Saving…" : "Save Script"}
-				</Button>
 				<Button
 					variant="outline"
 					onClick={handleClear}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -275,16 +275,18 @@ Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows n
 | Tab | Component | Notes |
 |---|---|---|
 | Info | `InfoTab.tsx` | Name, description, request count. **Autosaves** - no Save/Cancel |
-| Auth | `AuthTab.tsx` | Collection-level auth (concrete; never `inherit`). Mode picker + hints only - the fields are the shared [`AuthFields`](#shared-auth-fields-componentssharedauthfields) |
-| Pre-request | `ScriptTab.tsx` (`kind="pre"`) | Collection pre-request script |
-| Post-request | `ScriptTab.tsx` (`kind="post"`) | Collection post-request script |
+| Auth | `AuthTab.tsx` | Collection-level auth (concrete; never `inherit`). Mode picker + hints only - the fields are the shared [`AuthFields`](#shared-auth-fields-componentssharedauthfields). **The one tab with a Save button**, and it says so above the fields |
+| Pre-request | `ScriptTab.tsx` (`kind="pre"`) | Collection pre-request script. **Autosaves** on editor blur - no Save |
+| Post-request | `ScriptTab.tsx` (`kind="post"`) | Collection post-request script. **Autosaves** on editor blur - no Save |
 | Variables | `VariablesTab.tsx` | Collection-scoped variables (count badge) |
 
 `InheritanceChain.tsx` and `shared.tsx` are helpers used by these tabs (e.g. visualizing the auth/variable inheritance chain); `format.ts` holds the relative-timestamp helper, kept out of `shared.tsx` so a file of components exports nothing else (fast refresh).
 
-Auth and both Script tabs share one save model: an editable draft with a Save button gated on `isDirty` and a Reset, held by [`useEntityDraft()`](./state-management.md#useentitydraft---manual-draftsave-model). It is the manual counterpart to the request builder's `useSaveManager()` autosave, and it owns the mutation reset on a collection switch - that part had been hand-rolled per tab and one tab had omitted it.
+All five tabs hold their edits in a draft; four of them commit it without being asked. Info commits on blur (name) and on `onCommit` (description); both Script tabs commit when focus leaves the editor; Variables autosaves through `VariableTableEditor`. Info and the Script tabs take the draft, the resync and the mutation reset from [`useEntityDraft()`](./state-management.md#useentitydraft---manual-draftsave-model) and render no Save button at all - the hook owns the mutation reset on a collection switch, which had been hand-rolled per tab with one tab omitting it.
 
-**Info is the exception, deliberately.** It takes the draft, the resync and the mutation reset from the same hook but commits on blur (name) and on `onCommit` (description) and renders no Save or Cancel - the request builder's model, because two Info tabs with opposite save models is a coherence bug rather than two defensible choices. The blank-name rule survives the buttons' removal by being spoken instead: `reportBlankNameRefused()` (`lib/blank-name.ts`) puts the stored name back and reports through `failSave`, the same channel and the same wording the request builder's Info tab uses.
+Info's blank-name rule survives the buttons' removal by being spoken instead: `reportBlankNameRefused()` (`lib/blank-name.ts`) puts the stored name back and reports through `failSave`, the same channel and the same wording the request builder's Info tab uses. The Script tabs' `Clear` writes on the press rather than waiting for a blur that is not coming - focus lands on the button, not in the editor.
+
+**Auth is the exception, and it is a decision (#446), not a leftover.** Not because a credential outranks a script - the request builder autosaves its own auth - but because a blur inside `AuthFields` is not a completion signal. Measured on this tab: an OAuth 2.0 config with Advanced open renders 20 focus stops, 9 of them non-value controls (the grant-type and Add-to pickers, three switches, the secret reveal toggle, the Advanced disclosure, Get Token), and clicking reveal to check a half-typed password fires `focusout` while the draft is dirty. The fields only make sense written together, which is what the button means. A script tab has exactly one focus stop. Because the tab therefore differs from its neighbours, it states its save model above the fields rather than only through a button further down the page. If collection auth is ever to persist by itself, the mechanism is `useSaveManager`'s debounce, not a blur.
 
 ## Load Test Dashboard (`modules/dashboard/`)
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -338,8 +338,9 @@ const {
 } = useSaveStore();
 ```
 
-**Non-persisted**. See `useSaveManager` (autosave editors) and
-`useDraftSaveContext` (manual save-button editors) for registration details.
+**Non-persisted**. See `useSaveManager` (debounced-autosave editors) and
+`useDraftSaveContext` (draft editors, whether they commit on blur or on a
+button) for registration details.
 Between them every dirty editor in the app is in this registry, which is what
 `flushAll` walks on quit - a surface that is not registered is not merely
 unsaved on quit, it is invisible.
@@ -1421,9 +1422,11 @@ const { forceSave, status, isSaving } = useSaveManager({
 
 ### `useEntityDraft()` - Manual Draft/Save Model
 
-The other save model, and the counterpart to `useSaveManager()`: an editable draft, a Save button gated on `isDirty`, and a Reset that discards it. Located in `app/src/hooks/useEntityDraft.ts`. Used by `CollectionDetail`'s `AuthTab` and `ScriptTab`, where a save is a deliberate button press rather than a keystroke that persists itself.
+The other save model, and the counterpart to `useSaveManager()`: an editable draft, a Save button gated on `isDirty`, and a Reset that discards it. Located in `app/src/hooks/useEntityDraft.ts`. `CollectionDetail`'s `AuthTab` is its one remaining button user.
 
-`InfoTab` uses the hook without the button: it wants the draft, the resync and the mutation reset, but commits on blur like the request builder. `reset` therefore has one caller fewer than `draft` does.
+`InfoTab` and `ScriptTab` use the hook without the button: they want the draft, the resync and the mutation reset, but commit when focus leaves the field, like the request builder. `reset` therefore has one caller where `draft` has three.
+
+**Why auth alone kept the button (#446).** Not because a credential outranks a script - the request builder autosaves its own auth through `useSaveManager`. Because a blur inside `AuthFields` is not a completion signal: an OAuth 2.0 config with Advanced open renders 20 focus stops, 9 of them non-value controls (pickers, switches, the reveal toggle, Get Token), and clicking reveal to check a half-typed password fires `focusout` while the draft is dirty - so a blur-commit would write half a credential to the record every descendant request inherits from. The fields only make sense written together. A script tab has one focus stop, so leaving it means what leaving a description means. Should collection auth ever persist by itself, the mechanism is the debounce, not a blur - a different change from this one. `AuthTab` states its save model above the fields, since it is the tab on that screen that differs.
 
 **API:**
 ```typescript
@@ -1484,10 +1487,12 @@ useDraftSaveContext({
 ```
 
 **Behaviour:**
-- **Registration only.** It schedules nothing; the Save button stays the primary
-  affordance. The defect it fixes is that the *other* ways to save - Ctrl/Cmd+S,
-  the quit flush, tab eviction - could not reach these editors at all, because
-  none of the three tabs ever called `registerContext`.
+- **Registration only.** It schedules nothing; each editor decides when to call
+  its own `save` - `AuthTab` on its Save button, `InfoTab` and `ScriptTab` when
+  focus leaves the field. The defect it fixes is orthogonal to that choice: the
+  *other* ways to save - Ctrl/Cmd+S, the quit flush, tab eviction - could not
+  reach these editors at all, because none of the three tabs ever called
+  `registerContext`.
 - **`isActive` decides who owns Ctrl/Cmd+S.** `triggerSave` prefers the active
   context, and these editors stay mounted while hidden, so without it the last
   sibling to mount would answer for the panel on screen.
@@ -1596,7 +1601,7 @@ starts the engine at import time.
 
 3. **TanStack Query for server state:** Use TanStack Query for collections, requests, environments, globals, runs, and reports. It is the single source of truth and ensures consistency across the app.
 
-4. **Save manager integration:** Use `useSaveManager()` in any component that edits a persistable entity (request, environment, etc.) that autosaves. It handles debouncing, context registration, and centralized save state. Do not manually call `useSaveStore()` for auto-save. For an editor that saves on an explicit button instead, use `useEntityDraft()` **plus `useDraftSaveContext()`** - the first owns the draft, the second puts it in the registry - and do not hand-roll the draft/resync/`isDirty`/mutation-reset parts again.
+4. **Save manager integration:** Use `useSaveManager()` in any component that edits a persistable entity (request, environment, etc.) that autosaves. It handles debouncing, context registration, and centralized save state. Do not manually call `useSaveStore()` for auto-save. For an editor that holds a draft instead - committing it on blur or on an explicit button - use `useEntityDraft()` **plus `useDraftSaveContext()`** - the first owns the draft, the second puts it in the registry - and do not hand-roll the draft/resync/`isDirty`/mutation-reset parts again.
 
 5. **Centralized save on app quit:** On Electron's `before-quit` event, call `useSaveStore().flushAll()` to persist any pending changes before the app closes. An editor that is not registered is not merely unsaved here, it is invisible - which is how the collection tabs lost drafts silently for as long as they existed.
 


### PR DESCRIPTION
## Description

**Direction chosen: B** - both Script tabs follow `InfoTab` onto commit-on-blur, Auth keeps its Save button, and C's "say so" half lands on Auth because the screen now permanently holds two models.

**Plan.** Root cause: #445 moved `InfoTab` onto the request builder's save model and left the collection screen answering the same gesture two ways, with nothing on screen saying which kind you were on. The approach is to move the tabs whose blur is a completion signal and leave the one whose blur is not, then make the difference visible where the typing happens. The alternative I rejected is **A** (both tabs autosave): rejected not because a credential outranks a script - the request builder autosaves its own auth through `useSaveManager` - but because a blur inside `AuthFields` does not mean "done", measured below. **C** (leave both, say so) was rejected for the script tabs alone, since a one-buffer editor has no reason to differ from the description field two tabs over. If collection auth should ever persist by itself, the mechanism is the debounce, not a blur - a different change from the one this issue asked about, and I have left the door named in `useEntityDraft`'s header rather than half-opened here.

**Verified against reality before editing.** `AuthFields` exposes no blur channel at all - it is a pure controlled `onChange` component shared with the request builder's `AuthPanel` - so "Auth commits on blur" was never a prop away; it would have meant a container-level `focusout`, which is what made the measurement worth taking. `CodeEditor` likewise has no `onBlur`.

### The measurement the issue asked for, not an estimate

Instrumented by rendering `AuthTab` per mode and counting focusable controls, excluding the Save/Reset pair (which A would delete):

| Mode | Focus stops in `AuthFields` | Text fields | Non-value controls |
|---|---:|---:|---|
| `none` / `noauth` | 0 | 0 | - |
| `bearer` | 1 | 1 | - |
| `basic` | 3 | 2 | reveal toggle |
| `apikey` | 3 | 2 | "Add to" picker |
| `oauth2` (`client_credentials`, Advanced closed) | 8 | 4 | grant picker, reveal, Advanced, Get Token |
| `oauth2` (`client_credentials`, Advanced open) | 17 | 9 | 3 pickers, 2 switches, reveal, Advanced, Get Token |
| `oauth2` (`authorization_code` / `password`, Advanced open) | **20** | 11 | **9** |

And the failure mode A is judged on, asserted rather than reasoned about: focusing the reveal toggle after typing four characters of a password fires `focusout` on that field **while the draft is dirty**. A blur-commit there writes half a credential to the record every descendant request inherits from, on a gesture that means "let me check what I typed". The fields only make sense written together - which is what the button means.

A script tab has **one** focus stop. Leaving it means what leaving a description means.

### What moved

- **`ScriptTab`** - `Save Script` deleted; the editor's container listens for `focusout` and commits, ignoring a `relatedTarget` still inside it (Monaco's find widget takes focus on Ctrl+F without anything being finished). `Clear` now writes on the press: focus lands on the button, not in the editor, so no blur is coming to carry it - `persistText` takes the text rather than reading the draft, since `setScript` has not landed on that tick. Monaco's undo stack still holds the cleared text and undoing re-commits it on the way out.
  - Rejected alternative: an `onBlur` prop on `CodeEditor` wired to `onDidBlurEditorWidget`. Every suite that mounts the editor stubs the instance (the shared `monaco-editor-stub`, plus an inline one in `GraphQLBody.diagnostics.test.tsx`), so a shared primitive reaching for one more method makes each stub a place the next method can be forgotten - and the container's `focusout` answers the same question in the DOM, where the tests already are.
- **`AuthTab`** - unchanged save model; gains one line above the fields stating that they save together on `Save Auth`, rendered only for the modes with credentials to type. The duplicated `mode !== null && mode !== "none" && mode !== "noauth"` condition is now one named `hasCredentialFields`.
- **`useEntityDraft` / `useDraftSaveContext`** headers - the claim #445 left asserted ("a credential or a script is a deliberate act with a button") is retired and replaced with the decision and its number. `reset` now has one caller where `draft` has three.

### Blast radius

`ScriptTab` has two callers, both in `CollectionDetail` (`kind="pre"` / `"post"`), and the change is confined to the component - no store, no query, no shared primitive. `useEntityDraft` and `useDraftSaveContext` are comment-only edits; their behaviour is untouched, so `draft-survival.test.tsx` is unchanged and green as the issue requires. The quit flush and Ctrl/Cmd+S still reach both script tabs through the same `useDraftSaveContext` registration, which is why removing the button costs nothing on those paths. `AuthFields` itself is untouched, so the request builder's `AuthPanel` is unaffected. No engine change; no MCP change (`rg` finds no MCP surface reading either tab).

Out of scope, as the issue directs: the Variables tab and `useEntityDraft` itself.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **3773 passed across 377 files**, up from 3760/377 (13 new cases: 10 in `ScriptTab.autosave.test.tsx`, which runs `describe.each` over both kinds, and 3 in `AuthTab.test.tsx`).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.
- No engine change, so no engine build or ctest run: no C++ or engine test could change colour.
- `mkdocs build --strict` was **not** run - mkdocs is not installed in this container. Both docs edits are prose inside existing pages; the diff adds no heading, no page and no link (the two links on changed lines are pre-existing targets), so there is nothing new for a strict build to resolve.
- No pre-existing failures on the base commit (`698297e`).

**Mutation-checked**, each by reverting the fix and confirming the failure, then restoring:

| Reverted | Fails |
|---|---|
| `onBlur` off the editor container | "commits when focus leaves the editor" (both kinds) |
| the `relatedTarget` containment guard | "ignores focus moving inside the editor" (both kinds) |
| `Clear`'s write | "writes the empty script when Clear is pressed" (both kinds) |
| Auth wired to commit on blur (`onBlur={handleSave}` on the tab root) | "does not write when a field blurs - including on the reveal toggle" |

That last one is the point of the negative pin: it exists so a later change that quietly moves Auth onto blur has to revisit the decision rather than drift past it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #446

---
_Generated by [Claude Code](https://claude.ai/code/session_017VZweCiWE2hnWjJwi47TLM)_