### PR TITLE
ci(engine): require a test report before publishing the C++ Tests check

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -318,12 +318,29 @@ jobs:
         shell: bash
         run: ctest --preset ${{ matrix.preset }} --output-on-failure --output-junit "$GITHUB_WORKSPACE/engine/test-results.xml"
 
+      # `always()` so a suite that ran and failed is still reported - but on its
+      # own that also reports a *pass* for a job that never got as far as
+      # running a test. When `Build engine` fails or the job is cancelled,
+      # `Run engine tests` is skipped, no report file is written, and the action
+      # defaults to publishing a green `C++ Tests ()` check over nothing at all
+      # (seen on runs 31379169990 and 31378525863, where the Windows engine had
+      # not compiled). `require_tests` is what closes that: a missing report
+      # fails this step instead of inventing a pass, and the action returns
+      # before creating any check run. The legitimate no-report case - a
+      # docs-only change - never reaches here, because `changes.outputs.code`
+      # skips the whole job.
+      #
+      # `fail_on_failure` stays off deliberately, so the pair is a decision and
+      # not a default: `Run engine tests` above already fails the job on a red
+      # suite, and turning this on would make one failing test fail two steps.
       - name: Publish C++ test results
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: 'engine/test-results.xml'
           check_name: 'C++ Tests (${{ matrix.os }})'
+          require_tests: true
+          fail_on_failure: false
 
   installer:
     name: Installer script on ${{ matrix.os }}


### PR DESCRIPTION
## Description

**Root cause.** `pr-tests.yml`'s `Publish C++ test results` step runs with
`if: always()`, which is right - a suite that ran and failed must still be
reported. But `mikepenz/action-junit-report` defaults `require_tests` to
`false`, so when the step *before* it never wrote `engine/test-results.xml` the
action logs `No test results found!` and creates the `C++ Tests ()` check with
conclusion **success** anyway. A failed or cancelled `Build engine` skips
`Run engine tests`, so a pull request could carry a green C++ Tests check for a
platform whose engine had not compiled (runs
[31379169990](https://github.com/athrvk/vayu/actions/runs/31379169990) and
[31378525863](https://github.com/athrvk/vayu/actions/runs/31378525863)).

**Approach.** Set `require_tests: true`. A missing report now fails the step,
and the action returns *before* creating any check run - so the reviewer sees
no C++ Tests entry for that platform rather than a green one. The only
legitimate no-report path, a docs-only change, never reaches this step:
`changes.outputs.code == 'false'` skips the entire engine job, so the reporter
does not run at all. `fail_on_failure` is now written out explicitly as `false`
so the pair reads as a decision rather than a pair of defaults.

**Alternative rejected.** Gating the step on
`steps.<run-tests>.conclusion != 'skipped'` instead. It also stops the false
green, but it does so silently: a job that lost its report for an unexpected
reason would publish nothing and nobody would learn why. `require_tests` fails
loudly with `❌ No test results found for C++ Tests ()` in the log, which is
the difference between a missing signal and a diagnosed one.

**App side, checked rather than assumed.** The `app` job runs `pnpm test` with
plain reporter output and publishes no JUnit report at all - there is no second
reporter carrying this shape. Consistent with that, only the `engine` job
requests `checks: write`.

**Note on required checks.** `C++ Tests ()` is not a required check;
`CI gate` is (see the header comment in `pr-tests.yml`). Suppressing the check
entirely on a no-report job therefore cannot deadlock a pull request the way a
never-reporting *required* check would.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

CI configuration has no unit test, so the check is the deliberate one-off the
issue prescribes. It was arranged to produce both halves of the evidence in a
single run: a temporary `#error` in `engine/src/cli.cpp` guarded by
`#if defined(__linux__)`, so `Engine on ubuntu-latest` failed to compile while
`macos-latest` built and ran its suite normally. That commit has since been
removed from this branch - the diff here is the workflow file alone.

**Verification run: [31384927222](https://github.com/athrvk/vayu/actions/runs/31384927222)** (at `f9808e1`, the now-removed break commit).

| Job | Build | `C++ Tests ()` check |
|---|---|---|
| [Engine on ubuntu-latest](https://github.com/athrvk/vayu/actions/runs/31384927222/job/93443125015) | failed (deliberate `#error`) | **none created** - step failed with `##[error]❌ No test results found for C++ Tests (ubuntu-latest)` |
| [Engine on macos-latest](https://github.com/athrvk/vayu/actions/runs/31384927222/job/93443125009) | passed | [`C++ Tests (macos-latest)`](https://github.com/athrvk/vayu/runs/93446092291) **success** |

The first row is the mutation check: on the pre-fix workflow this exact
situation is what produced check run
[93427704836](https://github.com/athrvk/vayu/runs/93427704836) with conclusion
success. The second row is the guard against over-correcting - `require_tests`
does not fire on a job that did run its tests.

The Windows engine job of that run was cancelled by the force-push that removed
the break, so its result is not part of the evidence above; the macOS row
already covers the healthy path.

No local suite was run: the diff is a single workflow file, and no engine or
app test can change colour from it (per the verification-scaling rule in
`CLAUDE.md`).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: none. `CONTRIBUTING.md` describes the pull-request process and does not
name the reporter or its checks (verified by grep); no check a contributor is
told to read changes name or meaning.

## Related Issues
Closes #465