### PR TITLE
feat(engine/app): per-run performance thresholds with a pass/fail verdict

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -1442,6 +1442,53 @@ describe("dispatchTool", () => {
 		expect(payload.postRequestScript).toBeUndefined();
 	});
 
+	test("start_load_run forwards thresholds under the engine's own metric keys", async () => {
+		// The keys travel verbatim to POST /runs and come back in the report's
+		// thresholdValidation, so a rename anywhere on this path is a budget
+		// the engine rejects - or worse, one it accepts and never judges.
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_load_run",
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				confirmed: true,
+				thresholds: { latencyP99Ms: 50, maxErrorRatePct: 0.1 },
+			}),
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+
+		expect(res.isError).toBeFalsy();
+		const payload = (client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload.thresholds).toEqual({ latencyP99Ms: 50, maxErrorRatePct: 0.1 });
+	});
+
+	test("start_load_run sends no thresholds key when none were declared", () => {
+		// An empty object is a 400 from POST /runs, so "no budgets" has to be
+		// an absent key rather than an empty one.
+		const parsed = parseArgs("start_load_run", { url: "https://api.example.com" });
+		expect(parsed.thresholds).toBeUndefined();
+		expect(() =>
+			parseArgs("start_load_run", { url: "https://api.example.com", thresholds: {} })
+		).toThrow(/at least one budget/i);
+	});
+
+	test("start_load_run rejects a budget the engine would reject", () => {
+		// The schema's bounds mirror the engine's so the agent is told which
+		// field is wrong, rather than meeting an HTTP 400 with no field named.
+		expect(() =>
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				thresholds: { maxErrorRatePct: 150 },
+			})
+		).toThrow();
+		expect(() =>
+			parseArgs("start_load_run", {
+				url: "https://api.example.com",
+				thresholds: { latencyP99Ms: 0 },
+			})
+		).toThrow();
+	});
+
 	test("start_load_run still accepts the engine's own `tests` spelling", async () => {
 		const client = fakeClient();
 		const res = await dispatchTool(

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1811,6 +1811,25 @@ export const TOOLS: McpTool[] = [
 				.describe(
 					`In-flight cap (constant_rps only), 1-${MAX_IN_FLIGHT_BOUND}. Default max(targetRps * 10, 1000).`
 				),
+			// Pass/fail budgets for the whole run. The bounds mirror the
+			// engine's, so a value this schema accepts is one POST /runs
+			// accepts; an empty object is rejected there rather than starting a
+			// run nothing will judge, so it is rejected here too, by name.
+			thresholds: z
+				.object({
+					latencyP50Ms: z.number().positive().max(86_400_000).optional(),
+					latencyP95Ms: z.number().positive().max(86_400_000).optional(),
+					latencyP99Ms: z.number().positive().max(86_400_000).optional(),
+					maxErrorRatePct: z.number().min(0).max(100).optional(),
+					minThroughputRps: z.number().positive().max(1_000_000_000).optional(),
+				})
+				.refine((t) => Object.keys(t).length > 0, {
+					message: "Declare at least one budget, or omit `thresholds` entirely.",
+				})
+				.optional()
+				.describe(
+					"Pass/fail budgets for this run. The report comes back with `thresholdValidation`: one check per budget plus a verdict of passed/failed. Omit for a run that is measured but not judged."
+				),
 			requestId: z
 				.string()
 				.optional()
@@ -1873,6 +1892,12 @@ export const TOOLS: McpTool[] = [
 			for (const key of ["duration", "rampUpDuration"]) {
 				const v = str(args, key);
 				if (v !== undefined) payload[key] = v;
+			}
+			// Forwarded verbatim - the keys are the engine's own metric names,
+			// and they come back unchanged in `get_run_report`'s
+			// `thresholdValidation`. Zod has already bounded every value.
+			if (args.thresholds && typeof args.thresholds === "object") {
+				payload.thresholds = args.thresholds;
 			}
 			// An omitted duration is 60s engine-side, not "unbounded" and not
 			// "capped" - so a cap under 60s has to be sent as an explicit field

--- a/app/src/components/shared/ThresholdVerdict.test.tsx
+++ b/app/src/components/shared/ThresholdVerdict.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The verdict's job is to be unambiguous about a run that failed its budget, so
+ * the cases that matter are the ways it could mislead: showing nothing for a
+ * run that was judged, showing a section for one that was not, printing a floor
+ * as if it were a ceiling, or silently dropping a check a newer engine sent.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ThresholdVerdict } from "./ThresholdVerdict";
+import type { RunReport } from "@/types/domain";
+
+type Verdict = NonNullable<RunReport["thresholdValidation"]>;
+
+const verdict = (over: Partial<Verdict> = {}): Verdict => ({
+	checks: [{ metric: "latencyP99Ms", limit: 50, actual: 47.2, passed: true }],
+	passed: 1,
+	failed: 0,
+	verdict: "passed",
+	...over,
+});
+
+describe("ThresholdVerdict", () => {
+	it("renders nothing for a run that declared no budgets", () => {
+		// Every run recorded before budgets existed is this run. "Not judged"
+		// has to read as absence, not as a card full of zeros.
+		const { container } = render(<ThresholdVerdict verdict={undefined} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing for a section carrying no checks", () => {
+		const { container } = render(
+			<ThresholdVerdict verdict={verdict({ checks: [], passed: 0, failed: 0 })} />
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("says a run passed, with the measurement beside the budget it met", () => {
+		render(<ThresholdVerdict verdict={verdict()} />);
+		expect(screen.getByText("Passed")).toBeInTheDocument();
+		expect(screen.getByText("1 of 1 budgets met.")).toBeInTheDocument();
+		expect(screen.getByText(/p99 latency/)).toBeInTheDocument();
+		expect(screen.getByText("47.20ms")).toBeInTheDocument();
+	});
+
+	it("says a run failed when any single budget was missed", () => {
+		// The whole point of the verdict: four green checks do not make a pass.
+		render(
+			<ThresholdVerdict
+				verdict={verdict({
+					checks: [
+						{ metric: "latencyP50Ms", limit: 20, actual: 10, passed: true },
+						{ metric: "maxErrorRatePct", limit: 0.1, actual: 1, passed: false },
+					],
+					passed: 1,
+					failed: 1,
+					verdict: "failed",
+				})}
+			/>
+		);
+		expect(screen.getByText("Failed")).toBeInTheDocument();
+		expect(screen.getByText("1 of 2 budgets met.")).toBeInTheDocument();
+	});
+
+	it("prints a throughput floor as a floor, not as a ceiling", () => {
+		// Every other budget is a ceiling, so a shared comparator would describe
+		// the opposite budget from the one the verdict was computed against.
+		render(
+			<ThresholdVerdict
+				verdict={verdict({
+					checks: [
+						{ metric: "minThroughputRps", limit: 1000, actual: 900, passed: false },
+					],
+					passed: 0,
+					failed: 1,
+					verdict: "failed",
+				})}
+			/>
+		);
+		expect(screen.getByText(/≥ 1000req\/s/)).toBeInTheDocument();
+	});
+
+	it("prints the ceilings with the comparator that matches them", () => {
+		render(<ThresholdVerdict verdict={verdict()} />);
+		expect(screen.getByText(/≤ 50ms/)).toBeInTheDocument();
+	});
+
+	it("shows a metric it has no label for rather than dropping it", () => {
+		// The counts come from the engine. A check rendered away would leave
+		// "1 of 2 budgets met" above a single row and no way to see the other.
+		render(
+			<ThresholdVerdict
+				verdict={verdict({
+					checks: [{ metric: "latencyP999Ms", limit: 80, actual: 90, passed: false }],
+					passed: 0,
+					failed: 1,
+					verdict: "failed",
+				})}
+			/>
+		);
+		expect(screen.getByText(/latencyP999Ms/)).toBeInTheDocument();
+		expect(screen.getByText("90")).toBeInTheDocument();
+	});
+
+	it("keeps a whole-number budget whole", () => {
+		cleanup();
+		render(
+			<ThresholdVerdict
+				verdict={verdict({
+					checks: [{ metric: "maxErrorRatePct", limit: 0, actual: 0, passed: true }],
+				})}
+			/>
+		);
+		expect(screen.getByText(/≤ 0%/)).toBeInTheDocument();
+		expect(screen.getByText("0%")).toBeInTheDocument();
+	});
+});

--- a/app/src/components/shared/ThresholdVerdict.tsx
+++ b/app/src/components/shared/ThresholdVerdict.tsx
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The run's verdict against the pass/fail budgets it declared.
+ *
+ * The aggregate half of the report's judgement: a test script asserts one
+ * response at a time and structurally cannot say whether the run's p99 or its
+ * error rate met a budget, so a run where every assertion passed can still have
+ * missed the thing it was run to check.
+ *
+ * Two surfaces show it - the live dashboard's report view and the history
+ * detail's Overview - so it lives here once rather than being written twice and
+ * drifting. Silent when the run declared no budgets: an absent section says
+ * "not judged", which is a different claim from "judged and passed nothing" and
+ * is the reason a run without budgets renders exactly as it did before.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import type { RunReport } from "@/types/domain";
+
+/**
+ * How each budget reads on screen. Keyed by the engine's metric name, which
+ * travels verbatim from `POST /runs` through the stored summary to the report -
+ * a metric this build has no row for still renders, under its raw key, rather
+ * than vanishing from a verdict whose counts include it.
+ */
+const METRIC_LABELS: Record<string, { label: string; unit: string; floor?: boolean }> = {
+	latencyP50Ms: { label: "p50 latency", unit: "ms" },
+	latencyP95Ms: { label: "p95 latency", unit: "ms" },
+	latencyP99Ms: { label: "p99 latency", unit: "ms" },
+	maxErrorRatePct: { label: "Error rate", unit: "%" },
+	minThroughputRps: { label: "Throughput", unit: "req/s", floor: true },
+};
+
+/** Trailing zeros are noise on a budget the user typed as a whole number. */
+function formatValue(value: number): string {
+	return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+export interface ThresholdVerdictProps {
+	verdict: RunReport["thresholdValidation"];
+	className?: string;
+}
+
+export function ThresholdVerdict({ verdict, className }: ThresholdVerdictProps) {
+	if (!verdict || verdict.checks.length === 0) return null;
+
+	const failed = verdict.failed > 0;
+
+	return (
+		<Card className={className}>
+			<CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+				<CardTitle className="text-base">Pass/fail budgets</CardTitle>
+				{/*
+				 * Text, not a solid chip: `--status-*` is an indicator token and
+				 * fails contrast as a label, so the three-token rule sends the
+				 * word to `-text` and leaves the fill to the tint behind it
+				 * (docs/design-system.md, "Status tokens").
+				 */}
+				<span
+					className={cn(
+						"px-2 py-0.5 text-xs font-medium",
+						failed
+							? "bg-destructive/10 text-destructive-text"
+							: "bg-status-success/10 text-status-success-text"
+					)}
+				>
+					{failed ? "Failed" : "Passed"}
+				</span>
+			</CardHeader>
+			<CardContent>
+				<p className="mb-3 text-xs text-muted-foreground">
+					{verdict.passed} of {verdict.passed + verdict.failed} budgets met.
+				</p>
+				<ul className="space-y-1.5">
+					{verdict.checks.map((check) => {
+						const meta = METRIC_LABELS[check.metric];
+						const unit = meta?.unit ?? "";
+						// The comparator has to follow the metric: a throughput
+						// floor passes *above* its limit, and printing it with a
+						// "≤" would describe the opposite budget from the one the
+						// verdict beside it was computed against.
+						const comparator = meta?.floor ? "≥" : "≤";
+
+						return (
+							<li
+								key={check.metric}
+								className="flex items-baseline justify-between gap-3 text-sm"
+							>
+								<span className="text-muted-foreground">
+									{meta?.label ?? check.metric}
+									<span className="ml-1.5 text-xs">
+										({comparator} {formatValue(check.limit)}
+										{unit})
+									</span>
+								</span>
+								<span
+									className={cn(
+										"font-mono font-medium",
+										check.passed
+											? "text-status-success-text"
+											: "text-destructive-text"
+									)}
+								>
+									{formatValue(check.actual)}
+									{unit}
+								</span>
+							</li>
+						);
+					})}
+				</ul>
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -27,6 +27,9 @@ export * from "./callout-severity";
 // "These 100 samples are 100 of 30,000" - wherever a sampled set is displayed
 export * from "./SampleRetentionNote";
 
+// "p99 was 47ms against a 50ms budget" - wherever a run's verdict is shown
+export * from "./ThresholdVerdict";
+
 // "These responses were stored verbatim" - wherever captured samples are shown
 export * from "./CapturedDataWarning";
 

--- a/app/src/modules/dashboard/components/RequestResponseView.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.tsx
@@ -26,7 +26,7 @@ import {
 	phasesFromAverages,
 	phasesFromTrace,
 } from "@/components/shared/response-viewer";
-import { SampleRetentionNote, CapturedDataWarning } from "@/components/shared";
+import { SampleRetentionNote, CapturedDataWarning, ThresholdVerdict } from "@/components/shared";
 import { useRunSamplesQuery } from "@/queries/runs";
 import { httpStatusClass, statusCodeLabel, STATUS_CLASS_STYLE } from "@/constants/http-status";
 
@@ -216,6 +216,10 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 					</CardContent>
 				</Card>
 			)}
+
+			{/* The whole-run verdict, above the per-response one: a run can meet
+			    every assertion and still miss the budget it was run to check. */}
+			<ThresholdVerdict verdict={report.thresholdValidation} />
 
 			{/* Test Validation Results */}
 			{report.testValidation && (

--- a/app/src/modules/history/main/components/OverviewTab.tsx
+++ b/app/src/modules/history/main/components/OverviewTab.tsx
@@ -15,6 +15,7 @@ import { AlertCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/utils";
+import { ThresholdVerdict } from "@/components/shared";
 import { HeroRow } from "@/modules/dashboard/components/hero/HeroRow";
 import { ModeStatsRow } from "@/modules/dashboard/components/stats/ModeStatsRow";
 import type { TabProps } from "../../types";
@@ -28,6 +29,11 @@ export default function OverviewTab({ report, derived }: TabProps) {
 			    always-visible header strip, so no separate "Test Configuration" card here. */}
 			<HeroRow d={derived} />
 			<ModeStatsRow d={derived} />
+
+			{/* Directly under the numbers it judges - the verdict is the first
+			    question a stored run is opened to answer. Absent for a run that
+			    declared no budgets, which is every run recorded before them. */}
+			<ThresholdVerdict verdict={report.thresholdValidation} />
 
 			{/* Status Codes */}
 			{report.statusCodes && Object.keys(report.statusCodes).length > 0 && (

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -404,3 +404,73 @@ describe("ceilings from Settings", () => {
 		expect(Number(connections().max)).toBe(LOAD_TEST_CEILING_BOUNDS.concurrency.MAX);
 	});
 });
+
+/**
+ * Budgets are the dialog's only control whose *absence* is meaningful: a run
+ * with none is measured and not judged, exactly as every run was before them.
+ * These pin both directions, plus the one place the feature reuses a setting
+ * the user already has rather than adding a second notion of "too slow".
+ */
+describe("pass/fail budgets", () => {
+	const openBudgets = () => fireEvent.click(screen.getByRole("button", { name: /budgets/i }));
+	const p99 = () => screen.getByLabelText(/p99 latency/i) as HTMLInputElement;
+
+	it("prefills the p99 budget from the capacity SLO rather than inventing a default", () => {
+		// `sloThresholdMs` existed as a chart annotation and never reached the
+		// engine. If this stopped reading it the setting would be written and
+		// never read - the defect class this codebase repeats most.
+		useClientSettingsStore.getState().setSloThresholdMs(345);
+		const { onStart } = open();
+		openBudgets();
+		expect(p99().value).toBe("345");
+		expect(started(onStart).thresholds).toEqual({ latencyP99Ms: 345 });
+	});
+
+	it("sends no thresholds at all once every budget is cleared", () => {
+		const { onStart } = open();
+		openBudgets();
+		fireEvent.change(p99(), { target: { value: "" } });
+		// Not `{}`: POST /runs rejects an empty object rather than starting a
+		// run nothing will judge, so the key has to be absent.
+		expect(started(onStart).thresholds).toBeUndefined();
+	});
+
+	it("sends every declared budget under the engine's own key", () => {
+		const { onStart } = open();
+		openBudgets();
+		fireEvent.change(p99(), { target: { value: "50" } });
+		fireEvent.change(screen.getByLabelText(/error rate/i), { target: { value: "0.1" } });
+		fireEvent.change(screen.getByLabelText(/throughput/i), { target: { value: "1000" } });
+		expect(started(onStart).thresholds).toEqual({
+			latencyP99Ms: 50,
+			maxErrorRatePct: 0.1,
+			minThroughputRps: 1000,
+		});
+	});
+
+	it("blocks Start on an out-of-range budget instead of dropping the field", () => {
+		const { onStart } = open();
+		openBudgets();
+		fireEvent.change(screen.getByLabelText(/error rate/i), { target: { value: "150" } });
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+		expect(onStart).not.toHaveBeenCalled();
+		expect(screen.getByText(/budget is out of range/i)).toBeInTheDocument();
+	});
+
+	it("keeps a cleared budget cleared across dialog opens", () => {
+		// The prefill seeds a first run only. Re-seeding from the setting every
+		// time would undo the user's decision to run without a latency budget,
+		// silently, on the next run.
+		useClientSettingsStore.getState().setSloThresholdMs(200);
+		const first = open();
+		openBudgets();
+		fireEvent.change(p99(), { target: { value: "" } });
+		expect(started(first.onStart).thresholds).toBeUndefined();
+
+		cleanup();
+		const second = open();
+		openBudgets();
+		expect(p99().value).toBe("");
+		expect(started(second.onStart).thresholds).toBeUndefined();
+	});
+});

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.test.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The budget draft's two rules: what it refuses, and what it sends.
+ *
+ * Both exist to keep one thing from happening - a budget the user typed that
+ * the run is never judged against. A dropped field would be silent, and an
+ * empty `thresholds` object is a 400 the user would meet as "failed to start"
+ * rather than as the field they left half-filled.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+	BUDGET_FIELDS,
+	budgetError,
+	buildThresholds,
+	emptyBudgetDraft,
+	type BudgetDraft,
+} from "./budgets";
+
+const draft = (values: Partial<BudgetDraft> = {}): BudgetDraft => ({
+	...emptyBudgetDraft(),
+	...values,
+});
+
+describe("budget validation", () => {
+	it("accepts a draft with nothing declared - budgets are opt-in", () => {
+		expect(budgetError(emptyBudgetDraft())).toBeNull();
+		expect(buildThresholds(emptyBudgetDraft())).toBeUndefined();
+	});
+
+	it("accepts blank fields beside declared ones", () => {
+		const d = draft({ latencyP99Ms: "50" });
+		expect(budgetError(d)).toBeNull();
+		expect(buildThresholds(d)).toEqual({ latencyP99Ms: 50 });
+	});
+
+	it("rejects a latency budget of zero, which nothing can meet", () => {
+		expect(budgetError(draft({ latencyP50Ms: "0" }))).toMatch(/p50/i);
+		expect(budgetError(draft({ latencyP95Ms: "-5" }))).toMatch(/p95/i);
+	});
+
+	it("accepts a zero error-rate budget, which is a real ask", () => {
+		// The one inclusive floor: "no request may fail". Treating it like the
+		// latency fields would make the strictest budget the unsayable one.
+		expect(budgetError(draft({ maxErrorRatePct: "0" }))).toBeNull();
+		expect(buildThresholds(draft({ maxErrorRatePct: "0" }))).toEqual({ maxErrorRatePct: 0 });
+	});
+
+	it("rejects an error rate outside 0-100", () => {
+		expect(budgetError(draft({ maxErrorRatePct: "101" }))).toMatch(/error rate/i);
+		expect(budgetError(draft({ maxErrorRatePct: "-1" }))).toMatch(/error rate/i);
+	});
+
+	it("rejects a throughput floor of zero", () => {
+		expect(budgetError(draft({ minThroughputRps: "0" }))).toMatch(/throughput/i);
+	});
+
+	it("rejects text rather than sending NaN", () => {
+		expect(budgetError(draft({ latencyP99Ms: "fast" }))).toMatch(/number/i);
+	});
+
+	it("names the offending budget, since five fields share one message slot", () => {
+		const message = budgetError(draft({ latencyP99Ms: "50", minThroughputRps: "-1" }));
+		expect(message).toMatch(/throughput/i);
+		expect(message).not.toMatch(/p99/i);
+	});
+});
+
+describe("the payload the dialog builds", () => {
+	it("sends every declared budget under the engine's own key", () => {
+		expect(
+			buildThresholds(
+				draft({
+					latencyP50Ms: "20",
+					latencyP95Ms: "40",
+					latencyP99Ms: "50",
+					maxErrorRatePct: "0.1",
+					minThroughputRps: "10000",
+				})
+			)
+		).toEqual({
+			latencyP50Ms: 20,
+			latencyP95Ms: 40,
+			latencyP99Ms: 50,
+			maxErrorRatePct: 0.1,
+			minThroughputRps: 10000,
+		});
+	});
+
+	it("omits the object entirely rather than sending an empty one", () => {
+		// An empty `thresholds` is a 400 from POST /runs, which the user would
+		// meet as "the run would not start" with no field to blame.
+		expect(buildThresholds(draft({ latencyP99Ms: "   " }))).toBeUndefined();
+	});
+
+	it("keys every field to a real threshold, so none can be typed and dropped", () => {
+		// The table drives the fields, the validation and the payload; a key
+		// that is not in RunThresholds would render a control and send nothing.
+		const built = buildThresholds(
+			draft(Object.fromEntries(BUDGET_FIELDS.map((f) => [f.key, "1"])) as BudgetDraft)
+		);
+		expect(Object.keys(built ?? {})).toHaveLength(BUDGET_FIELDS.length);
+	});
+});

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/budgets.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The dialog's pass/fail budgets: what the fields are, when a draft is
+ * unusable, and what payload it builds.
+ *
+ * Kept component-free so the rules can be tested without rendering, and kept in
+ * one table because the same five metrics drive the fields, the validation and
+ * the payload - three hand-written lists would drift, and the way that failure
+ * shows up is a budget the user typed and the engine never judged.
+ *
+ * The ranges mirror `engine/src/core/threshold_eval.cpp`. They are a courtesy,
+ * not the gate: the engine rejects an out-of-range budget with a 400 whatever
+ * this file thinks, and these exist so the user is told before the run rather
+ * than after it fails to start.
+ */
+
+import type { RunThresholds } from "@/types";
+
+export type BudgetKey = keyof RunThresholds;
+
+export interface BudgetField {
+	key: BudgetKey;
+	/** DOM id, so the label is associated rather than merely adjacent. */
+	id: string;
+	label: string;
+	unit: string;
+	min: number;
+	/** Whether `min` is itself a legal budget - true only for the error rate. */
+	minInclusive: boolean;
+	max: number;
+	hint?: string;
+}
+
+/** A day. Past it no request completes, so no ceiling above it is a budget. */
+const MAX_LATENCY_MS = 86_400_000;
+
+export const BUDGET_FIELDS: readonly BudgetField[] = [
+	{
+		key: "latencyP50Ms",
+		id: "lt-budget-p50",
+		label: "p50 latency at most",
+		unit: "ms",
+		min: 0,
+		minInclusive: false,
+		max: MAX_LATENCY_MS,
+	},
+	{
+		key: "latencyP95Ms",
+		id: "lt-budget-p95",
+		label: "p95 latency at most",
+		unit: "ms",
+		min: 0,
+		minInclusive: false,
+		max: MAX_LATENCY_MS,
+	},
+	{
+		key: "latencyP99Ms",
+		id: "lt-budget-p99",
+		label: "p99 latency at most",
+		unit: "ms",
+		min: 0,
+		minInclusive: false,
+		max: MAX_LATENCY_MS,
+		hint: "Prefilled from the capacity SLO in Settings - clear it to run without a latency budget.",
+	},
+	{
+		key: "maxErrorRatePct",
+		id: "lt-budget-error-rate",
+		label: "Error rate at most",
+		unit: "%",
+		// 0 is the one meaningful floor here: "no request may fail" is a real
+		// budget, where a latency ceiling or a throughput floor of 0 is a typo.
+		min: 0,
+		minInclusive: true,
+		max: 100,
+		hint: "Counts every response outside 2xx/3xx, and the connection failures that never got one.",
+	},
+	{
+		key: "minThroughputRps",
+		id: "lt-budget-throughput",
+		label: "Throughput at least",
+		unit: "req/s",
+		min: 0,
+		minInclusive: false,
+		max: 1_000_000_000,
+	},
+];
+
+/** What the user has typed, per budget. Blank means "not declared". */
+export type BudgetDraft = Record<BudgetKey, string>;
+
+export function emptyBudgetDraft(): BudgetDraft {
+	return {
+		latencyP50Ms: "",
+		latencyP95Ms: "",
+		latencyP99Ms: "",
+		maxErrorRatePct: "",
+		minThroughputRps: "",
+	};
+}
+
+/**
+ * The first budget the engine would reject, phrased for the dialog.
+ *
+ * Blank is always fine - budgets are opt-in, and clearing a field is how a user
+ * declines one. Anything else must be a number in range: a value that is not
+ * gets said out loud rather than dropped from the payload, because silently
+ * sending four of the five budgets someone typed is the worse failure.
+ */
+export function budgetError(draft: BudgetDraft): string | null {
+	for (const field of BUDGET_FIELDS) {
+		const raw = draft[field.key].trim();
+		if (raw === "") continue;
+
+		const value = Number(raw);
+		if (!Number.isFinite(value)) {
+			return `${field.label} must be a number, or blank for no budget.`;
+		}
+		const underMin = field.minInclusive ? value < field.min : value <= field.min;
+		if (underMin || value > field.max) {
+			const lower = field.minInclusive ? `${field.min}` : `more than ${field.min}`;
+			return `${field.label} must be ${lower} and at most ${field.max}${field.unit}, or blank for no budget.`;
+		}
+	}
+	return null;
+}
+
+/**
+ * The `thresholds` payload for `POST /runs`, or `undefined` when nothing was
+ * declared - never an empty object, which the engine rejects rather than
+ * starting a run no verdict will be computed for.
+ *
+ * Assumes {@link budgetError} passed; an unparseable field is skipped rather
+ * than sent as `NaN`.
+ */
+export function buildThresholds(draft: BudgetDraft): RunThresholds | undefined {
+	const thresholds: RunThresholds = {};
+	for (const field of BUDGET_FIELDS) {
+		const raw = draft[field.key].trim();
+		if (raw === "") continue;
+		const value = Number(raw);
+		if (!Number.isFinite(value)) continue;
+		thresholds[field.key] = value;
+	}
+	return Object.keys(thresholds).length > 0 ? thresholds : undefined;
+}

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -57,6 +57,13 @@ import { cn } from "@/lib/utils";
 import { Callout, SEVERITY_ORDER, type Severity } from "@/components/shared";
 import { ProfilePicker } from "./ProfilePicker";
 import { summarise } from "./summary";
+import {
+	BUDGET_FIELDS,
+	type BudgetDraft,
+	budgetError,
+	buildThresholds,
+	emptyBudgetDraft,
+} from "./budgets";
 
 interface SavedLoadTestConfig {
 	mode: LoadTestConfig["mode"];
@@ -70,6 +77,13 @@ interface SavedLoadTestConfig {
 	sampleRate: number;
 	slowThreshold: number;
 	saveTimingBreakdown: boolean;
+	/**
+	 * Budgets are memoed as typed, blanks included, so a cleared field stays
+	 * cleared. A restored draft is also what tells the p99 prefill it has
+	 * already had its turn - without it, declining the SLO budget once would be
+	 * undone by the next dialog open.
+	 */
+	budgets: BudgetDraft;
 }
 
 function loadSavedConfig(): Partial<SavedLoadTestConfig> {
@@ -231,6 +245,22 @@ export default function LoadTestConfigDialog({
 	const [saveTimingBreakdown, setSaveTimingBreakdown] = useState(
 		saved.saveTimingBreakdown ?? LOAD_TEST_DEFAULTS.SAVE_TIMING_BREAKDOWN
 	);
+	/**
+	 * Pass/fail budgets. The p99 field is seeded from the capacity SLO the user
+	 * already set (Settings -> `sloThresholdMs`), which until now only annotated
+	 * a chart - so the setting becomes the run's default budget rather than a
+	 * second, parallel notion of "too slow". Seeded only on a first run: once a
+	 * draft has been memoed, a cleared p99 stays cleared.
+	 */
+	const sloThresholdMs = useClientSettingsStore((s) => s.sloThresholdMs);
+	const [budgets, setBudgets] = useState<BudgetDraft>(
+		() =>
+			saved.budgets ?? {
+				...emptyBudgetDraft(),
+				latencyP99Ms: String(sloThresholdMs),
+			}
+	);
+	const [budgetsOpen, setBudgetsOpen] = useState(false);
 	const [comment, setComment] = useState(""); // Per-run: never restored.
 	const [oauthGated, setOauthGated] = useState(false);
 	const [recordingOpen, setRecordingOpen] = useState(false);
@@ -248,7 +278,8 @@ export default function LoadTestConfigDialog({
 
 	const rampDurationError = validateRampDuration(mode, duration, rampDuration);
 	const startConcurrencyError = validateStartConcurrency(mode, startConcurrency, concurrency);
-	const blockingError = rampDurationError ?? startConcurrencyError;
+	const budgetsError = budgetError(budgets);
+	const blockingError = rampDurationError ?? startConcurrencyError ?? budgetsError;
 
 	const notices = useMemo(() => {
 		const list: { key: string; severity: Severity; node: React.ReactNode }[] = [];
@@ -260,6 +291,18 @@ export default function LoadTestConfigDialog({
 				node: (
 					<Callout severity="blocking" title="Ramp is longer than the run">
 						{rampDurationError}
+					</Callout>
+				),
+			});
+		}
+
+		if (budgetsError) {
+			list.push({
+				key: "budgets",
+				severity: "blocking",
+				node: (
+					<Callout severity="blocking" title="A budget is out of range">
+						{budgetsError}
 					</Callout>
 				),
 			});
@@ -307,7 +350,13 @@ export default function LoadTestConfigDialog({
 		return list.sort(
 			(a, b) => SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity)
 		);
-	}, [rampDurationError, startConcurrencyError, hasPreRequestScript, hasDynamicVariables]);
+	}, [
+		rampDurationError,
+		startConcurrencyError,
+		budgetsError,
+		hasPreRequestScript,
+		hasDynamicVariables,
+	]);
 
 	const handleStart = () => {
 		if (blockingError) return;
@@ -326,6 +375,7 @@ export default function LoadTestConfigDialog({
 			sampleRate,
 			slowThreshold,
 			saveTimingBreakdown,
+			budgets,
 		});
 
 		const config: LoadTestConfig = {
@@ -337,6 +387,9 @@ export default function LoadTestConfigDialog({
 			slow_threshold_ms: slowThreshold,
 			save_timing_breakdown: saveTimingBreakdown,
 			comment: comment || undefined,
+			// Absent when nothing was declared - the engine rejects an empty
+			// object rather than starting a run no verdict can be computed for.
+			thresholds: buildThresholds(budgets),
 		};
 
 		// Omitted in `iterations` - see `usesDuration`. Sending a value the engine
@@ -600,6 +653,49 @@ export default function LoadTestConfigDialog({
 									className="h-9 text-sm"
 								/>
 							</div>
+						</CollapsibleContent>
+					</Collapsible>
+
+					{/*
+					 * Budgets, in the same card treatment as "Recording & limits"
+					 * above and for the same reason - a disclosure whose contents
+					 * sit on the dialog background reads as loose fields rather
+					 * than as the section that revealed them.
+					 */}
+					<Collapsible
+						open={budgetsOpen}
+						onOpenChange={setBudgetsOpen}
+						className="panel-clip overflow-hidden rounded-md border border-border surface-card"
+					>
+						<CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2 text-left text-xs font-medium text-foreground transition-colors hover:bg-accent">
+							<span>Pass/fail budgets</span>
+							<span className="text-[11px] font-normal text-muted-foreground">
+								{budgetsOpen ? "Hide" : "Show"}
+							</span>
+						</CollapsibleTrigger>
+						<CollapsibleContent className="space-y-4 border-t border-rule px-3 py-3">
+							<p className="text-[11px] leading-relaxed text-muted-foreground">
+								The run is judged against whatever you declare here and reports a
+								verdict. Leave a field blank to skip that budget; leave them all
+								blank and the run is measured but not judged, as before.
+							</p>
+							{BUDGET_FIELDS.map((field) => (
+								<NumberField
+									key={field.key}
+									id={field.id}
+									label={field.label}
+									unit={field.unit}
+									optional
+									value={budgets[field.key]}
+									onChange={(raw) =>
+										setBudgets((prev) => ({ ...prev, [field.key]: raw }))
+									}
+									min={field.min}
+									max={field.max}
+									placeholder="No budget"
+									hint={field.hint}
+								/>
+							))}
 						</CollapsibleContent>
 					</Collapsible>
 

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -469,6 +469,10 @@ export default function RequestBuilder() {
 					success_sample_rate: config.success_sample_period,
 					slow_threshold_ms: config.slow_threshold_ms,
 					save_timing_breakdown: config.save_timing_breakdown,
+					// Undefined when the dialog declared no budgets: the engine
+					// rejects an empty `thresholds` object rather than starting a
+					// run whose verdict nothing can compute.
+					thresholds: config.thresholds,
 				};
 
 				const result = await apiService.startLoadTest(apiRequest);

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -23,6 +23,7 @@ import type {
 	LoadTestMode,
 	ScriptPart,
 	HttpVersion,
+	RunThresholds,
 } from "./domain";
 
 // API Response wrapper
@@ -390,6 +391,12 @@ export interface StartLoadTestRequest {
 	slow_threshold_ms?: number;
 	save_timing_breakdown?: boolean;
 	tests?: ScriptPart[];
+
+	// Pass/fail budgets for the whole run. camelCase because these are the
+	// engine's own metric names, which come back unchanged in the report's
+	// `thresholdValidation`. Omitted entirely when none were declared - the
+	// engine rejects an empty object rather than starting an unjudged run.
+	thresholds?: RunThresholds;
 }
 
 export interface StartLoadTestResponse {

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -688,6 +688,24 @@ export interface RunListParams {
 /** Load-test execution strategy. Single source of truth for the mode union. */
 export type LoadTestMode = "constant_rps" | "constant_concurrency" | "iterations" | "ramp_up";
 
+/**
+ * Pass/fail budgets a run declares up front, so the engine can judge it rather
+ * than only measure it. Keys are the engine's own metric names (they travel
+ * verbatim on `POST /runs` and come back in `RunReport.thresholdValidation`),
+ * which is why they are camelCase where the rest of `LoadTestConfig` is not.
+ *
+ * Every key is optional and at least one must be present - the engine rejects
+ * an empty object rather than starting a run nothing will judge.
+ */
+export interface RunThresholds {
+	latencyP50Ms?: number;
+	latencyP95Ms?: number;
+	latencyP99Ms?: number;
+	/** Share of the run's requests allowed to fail, 0-100. */
+	maxErrorRatePct?: number;
+	minThroughputRps?: number;
+}
+
 export interface LoadTestConfig {
 	duration_seconds?: number;
 	rps?: number;
@@ -709,6 +727,8 @@ export interface LoadTestConfig {
 	comment?: string;
 	latency_percentiles?: number[];
 	max_in_flight?: number;
+	/** Absent when the run declared no budgets - never an empty object. */
+	thresholds?: RunThresholds;
 }
 
 /**
@@ -978,6 +998,30 @@ export interface RunReport {
 		testsPassed: number;
 		testsFailed: number;
 		successRate: number;
+	};
+	/**
+	 * The run's verdict against the budgets it declared ({@link RunThresholds}).
+	 *
+	 * The aggregate half of pass/fail: `testValidation` replays a script against
+	 * individual responses and structurally cannot assert a p99 or an error
+	 * rate, so a run that meets every assertion can still miss its budget.
+	 *
+	 * `undefined` is a run that declared no budgets - which is *not* the same
+	 * claim as "passed nothing", so a report without it renders exactly as it
+	 * did before budgets existed. `metric` is typed loosely on purpose: it is
+	 * the engine's key, and a newer sidecar may judge a metric this build has
+	 * no label for.
+	 */
+	thresholdValidation?: {
+		checks: {
+			metric: string;
+			limit: number;
+			actual: number;
+			passed: boolean;
+		}[];
+		passed: number;
+		failed: number;
+		verdict: "passed" | "failed";
 	};
 	/**
 	 * How many records each of the run's bounded stores thinned away.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -212,7 +212,7 @@ The request editor. Entry: `modules/request-builder/index.tsx`.
 | `components/UrlBar/` | `index`, `MethodSelector`, `UrlInput`. The method dropdown lives **inside** the URL field's border (one control, not two - it was a separate `w-[76px]` box sized for OPTIONS). Send + Load Test are one **attached** pair on the same accent: Send is `--primary-fill` with a white label, Load Test is `--primary` at 12% with `--primary-text` and a transparent left border, so the join is a step in weight rather than a seam between materials. Send owns both corners when `canStartLoadTest` is false. Both shortcuts (`⌘↵` / `⌘⇧↵`) come from `constants/shortcuts.ts` and are shown on the buttons. Pasting a curl/wget command into `UrlInput` auto-imports it (see note below) |
 | `components/RequestTabs/` | `index` + `panels/`: `InfoPanel` (**first in the row**), `ParamsPanel`, `HeadersPanel`, `BodyPanel`, `AuthPanel`, `AuthInheritBanner`, `script/ScriptPanel`, `InheritedScriptsNotice`, `ChainCard`, `SettingsPanel`. `AuthPanel` owns the mode picker (it is the only host that offers `inherit`) and delegates every field group to the shared [`AuthFields`](#shared-auth-fields-componentssharedauthfields), injecting a variable-aware `VariableInput`; OAuth 2.0 reaches [`OAuth2Form`](#shared-oauth-20-form-componentssharedoauth2form) through it. One `ScriptPanel` serves both script tabs, as `variant="pre"` and `variant="post"`; everything that differs between them - the field it binds, the two context keys it reads, the intro sentence and the quick reference - is data in `script/script-variants.tsx`. It replaced `PreScriptPanel` and `TestScriptPanel`, two ~155-line files that a normalised `diff` showed differing in three places. It renders `InheritedScriptsNotice` (the script equivalent of `AuthInheritBanner`) to name which ancestor collections contribute a pre-request or test script; that accepts an optional `entries` prop so a stored-run view can supply parts directly instead of reading the live chain. `AuthInheritBanner` and `InheritedScriptsNotice` share their chrome through `ChainCard` - the tinted box, summary row, captioned list and hairline separators - which they previously wrote out twice, identically. `InfoPanel` holds the request **name** (autosaved: committed trimmed on blur, a blank one refused out loud via `reportBlankNameRefused()` and the stored name restored through the context's `restoreStoredName()`) and its description, and is first because those are the first things you want to read about a request; it replaced `RequestDescription`, a permanent ~30px band above the tab strip that every request paid for whether or not it had one. Its badge is `1` for "there is something here", matching Body/Auth/Scripts/Settings. `SettingsPanel` holds the per-request redirect policy (**Follow redirects** + **Maximum redirects**); the tab strip badges it via `isRedirectPolicyNonDefault` (in `utils/request-state`) only when the request departs from the engine defaults |
 | `components/ResponseViewer/` | `index`, `ResponseCookies`, `ResponseTimingTab`, `TestResults`, `ConsoleOutput`, `RawRequestResponse`, `ClientErrorView` (status bar, actions and the Headers tab now come from `shared/response-viewer/`). The Console tab renders whenever the response carries console logs **or** a `preScriptError`/`postScriptError`, so a script that throws before logging still shows its error rather than a silent 200 |
-| `components/LoadTestConfigDialog.tsx` | Load-test configuration dialog (mode, duration, RPS, concurrency, …). Renders `OAuth2LoadTestGuard` when the request's effective auth is OAuth 2.0 |
+| `components/LoadTestConfigDialog/` | Load-test configuration dialog (mode, duration, RPS, concurrency, …). Renders `OAuth2LoadTestGuard` when the request's effective auth is OAuth 2.0. A second disclosure, **Pass/fail budgets**, declares the run's latency / error-rate / throughput limits; the field table and its rules are `budgets.ts`, and the p99 field is seeded from the `sloThresholdMs` client setting so that setting becomes the default budget rather than a parallel notion of "too slow". A budget out of the engine's range blocks Start with a named message instead of being dropped from the payload |
 | `components/OAuth2LoadTestGuard.tsx`, `components/oauth2-load-test-coverage.ts` | Warns when a duration-based load test would outlive its access token (the engine acquires a token once per run, no mid-run refresh): offers **Refresh** when a fresh token would cover the run, or **blocks Start** (with a "Start anyway" override) when even a fresh token can't. The pure coverage decision lives in `oauth2-load-test-coverage.ts` |
 | `shared/KeyValueEditor/` | `index`, `KeyValueRow`, `FilePartCell` - reusable key/value table (params, headers, form fields). `allowFiles` (form-data only) turns each row into a text/file switch; `FilePartCell` is the value cell of a file part - it picks a file, shows the path, and marks one an import brought in and this app never chose. `lib/file-path.ts` holds the basename rule it shares with the importers |
 | `shared/VariableInput/` | `index`, `EditableVariable`, `DynamicVariableToken` - input with `{{variable}}` highlighting + autocomplete. `EditableVariable` is the stored-variable token (hover to read, click to edit, red when nothing defines the name); `DynamicVariableToken` is the `{{$guid}}` one, which has no stored value to show or edit and must not be painted as undefined |
@@ -448,6 +448,27 @@ Renders nothing when the run displaced nothing, and nothing when the run
 reported no counts at all (an older summary): "nothing was dropped" and "we
 cannot tell" are both worse as prose than as absence. Built on `Callout`
 (`severity="info"`) rather than a hand-rolled muted row.
+
+## Threshold Verdict (`components/shared/ThresholdVerdict.tsx`)
+
+The run's verdict against the pass/fail budgets it declared
+(`RunReport.thresholdValidation`): one row per budget - the limit, what the run
+measured, and whether it met it - under a Passed/Failed header. Two surfaces
+show it, the dashboard's report view and the history detail's Overview, so it
+lives here once.
+
+It is the **aggregate** counterpart to the Test Validation card beside it: a
+`pm.test` script sees one response at a time and structurally cannot assert a
+p99 or an error rate, so a run where every assertion passed can still have
+missed the budget it was run to check.
+
+Renders nothing when the run declared no budgets - which is every run recorded
+before they existed - following the same absent-vs-zero rule as
+`SampleRetentionNote` and `CapturedDataWarning`: "not judged" is a different
+claim from "judged and passed nothing", and only absence can make the first.
+The comparator follows the metric (`≥` for the throughput floor, `≤` for the
+ceilings), and a metric key this build has no label for renders under its raw
+name rather than vanishing from a verdict whose counts still include it.
 
 ## Captured Data Warning (`components/shared/CapturedDataWarning.tsx`)
 

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -675,9 +675,25 @@ await apiService.startLoadTest({
   concurrency: 50,
   requestId: "req_123",
   environmentId: "env_456",
-  comment: "Stress test"
+  comment: "Stress test",
+  // Optional pass/fail budgets. Omitted entirely when none were declared - the
+  // engine rejects an empty object rather than starting an unjudged run.
+  thresholds: { latencyP99Ms: 50, maxErrorRatePct: 0.1 }
 });
 ```
+
+**Budgets and the verdict.** `LoadTestConfig.thresholds` (`RunThresholds`) rides
+through to `POST /runs` under the engine's own camelCase metric names, and the
+report comes back with `thresholdValidation` - one check per budget plus a
+`verdict` of `"passed"` / `"failed"` - which `ThresholdVerdict`
+(`components/shared`) renders on the dashboard report and the history Overview.
+It is the aggregate counterpart to `testValidation`: a `pm.test` script sees one
+response at a time and cannot assert a p99 or an error rate, so a run whose
+every assertion passed can still have missed its budget. `undefined` is a run
+that declared none - not a run that passed nothing - so a report without the
+section renders exactly as it did before budgets existed. The dialog seeds its
+p99 field from the client `sloThresholdMs` setting, which until then only
+annotated a chart.
 
 The engine range-checks this payload before it creates the run row and answers a
 violation with `400 invalid_run_config` (accepted ranges are tabulated under

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1662,6 +1662,7 @@ Start a load test run (Vayu Mode).
   "requestName": "Create user",       // Optional, read by the tests script as pm.info.requestName
   "environmentId": "env_1234567890",  // Optional
   "tests": "",               // Optional, deferred validation script
+  "thresholds": {},          // Optional pass/fail budgets - see below
   "followRedirects": true,   // Optional, default true - see POST /execute
   "maxRedirects": 10,        // Optional, default 10
   "httpVersion": "auto"      // Optional: "auto" | "http1.1" | "http2", default "auto" - see POST /execute
@@ -1678,6 +1679,42 @@ actually depends on this field to specify a protocol in the first place. An
 explicit `null` is treated exactly like an absent key. An unrecognized string
 is a `400` naming the field and the valid values, the same validation
 `POST /requests` uses.
+
+#### The `thresholds` block (pass/fail budgets)
+
+A run may declare budgets it must meet. The engine evaluates them once, when the
+run reaches a terminal status, and the report comes back with a
+[`thresholdValidation`](#get-runsrunidreport) section carrying one check per
+budget and a verdict. Without the block a run is measured and not judged, and
+its report has no such section at all.
+
+```jsonc
+{
+  "thresholds": {
+    "latencyP50Ms": 20,        // ceiling, ms; > 0 and <= 86400000
+    "latencyP95Ms": 40,        // ceiling, ms
+    "latencyP99Ms": 50,        // ceiling, ms
+    "maxErrorRatePct": 0.1,    // ceiling, percent of the run's requests; 0-100
+    "minThroughputRps": 10000  // floor, completed requests per second; > 0
+  }
+}
+```
+
+Every key is optional and at least one must be present. An unknown key, a
+non-numeric or out-of-range value, or an object that declares nothing is a `400`
+`invalid_run_config` naming the field - and, like every other run-config
+rejection, it happens before the run row is created, so a rejected request
+leaves no trace. A `null` value reads as absent, the same rule the flat numeric
+fields follow.
+
+`maxErrorRatePct` is measured against every response outside 2xx/3xx **plus** the
+transport failures that never got one - the same figure `summary.errorRate`
+reports. This is deliberately wider than the script-level `pm.test` view: a run
+of nothing but HTTP 500s has a transport error rate of zero.
+
+The verdict is the run's, not the process's: a run **stopped early** is judged on
+what it measured up to that point, and its status stays `completed` / `stopped`
+whatever the verdict says. A failing budget is reported, never a failed run.
 
 #### The `scenario` block (collection runs)
 
@@ -2599,7 +2636,8 @@ A run that is already finished answers `{"status": "<status>", "runId": ...,
 
 Get the final report for a completed run. The response is a **nested** object; conditional
 sections appear only when relevant (e.g. `rateControl` only for `constant_rps`, `testValidation`
-only when a test script ran).
+only when a test script ran, `thresholdValidation` only when the run declared
+[budgets](#the-thresholds-block-passfail-budgets)).
 
 The whole-run aggregates come from the run's stored `summary` (written once when the run reaches
 a terminal status - see [db-schema.md](db-schema.md#runs)), combined with the sampled `results`
@@ -2670,6 +2708,10 @@ alone rather than erroring. **The response shape is the same either way.**
     "responseBodiesCaptured": 23
   },
   "testValidation": { "samplesTested": 500, "testsPassed": 498, "testsFailed": 2, "successRate": 99.6 },
+  "thresholdValidation": {
+    "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 47.2, "passed": true } ],
+    "passed": 1, "failed": 0, "verdict": "passed"
+  },
   "results": [ { "id": 41, "...": "sampled request/response outcomes" } ]
 }
 ```

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -245,12 +245,21 @@ default, so `sync_schema()` can
   "status_codes": { "200": 90, "500": 7, "0": 3 },
   "latency": { "min": 1.0, "max": 90.0, "avg": 12.5, "p50": 10.0, "p75": 15.0,
                "p90": 20.0, "p95": 25.0, "p99": 30.0, "p999": 35.0 },
-  "tests": { "sampled": 10, "passed": 9, "failed": 1 }
+  "tests": { "sampled": 10, "passed": 9, "failed": 1 },
+  "thresholds": {
+    "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 30.0, "passed": true } ],
+    "passed": 1, "failed": 0
+  }
 }
 ```
 
 `tests` is **omitted** when deferred script validation did not run, which is what keeps the
-report's `testValidation` section absent rather than reporting zero tests. The writer is
+report's `testValidation` section absent rather than reporting zero tests. `thresholds` follows
+the same rule and for the same reason: absent when the run declared no
+[budgets](api-reference.md#the-thresholds-block-passfail-budgets), so the report's
+`thresholdValidation` section is left out rather than claiming a run passed nothing. Its `metric`
+keys are the wire names the payload declared, carried through unchanged; the report derives
+`verdict` from `failed` rather than storing it, so the two cannot contradict. The writer is
 `vayu::core::build_run_summary_payload` and the reader is `apply_run_summary`
 (`http/routes/runs.cpp`); `runs_route_test.cpp` round-trips the pair, so the key names cannot
 drift apart silently.

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -159,7 +159,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `delete_request`       | write    | `GET /requests/:id` + `DELETE /requests/:id` | write toggle + confirm     |
 | `update_environment`   | write    | `GET /environments` (scan) + `PUT /environments/:id` (fetch-merge) | write toggle |
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
-| `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm |
+| `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm; optional `thresholds` budgets |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
 
 Notes:

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -284,6 +284,7 @@ add_library(vayu_core STATIC
     src/core/run_manager.cpp
     src/core/metrics_collector.cpp
     src/core/sample_capture.cpp
+    src/core/threshold_eval.cpp
     ${PLATFORM_SOURCES}
 )
 
@@ -455,6 +456,7 @@ if(VAYU_BUILD_TESTS)
         tests/reservoir_test.cpp
         tests/sample_capture_test.cpp
         tests/load_pacing_test.cpp
+        tests/threshold_eval_test.cpp
         tests/run_manager_test.cpp
         tests/run_route_test.cpp
         tests/run_stop_test.cpp

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -24,6 +24,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/scenario_plan.hpp"
+#include "vayu/core/threshold_eval.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
 
@@ -381,6 +382,11 @@ struct RunSummaryInputs {
     // Absent when the run had no test script or no sampled responses - the
     // report then omits its testValidation section, as it always has.
     std::optional<ScriptValidationTotals> tests;
+    // The verdict on the budgets this run's config declared. Absent when it
+    // declared none, which keeps the report's thresholdValidation section out
+    // rather than reporting a run that passed zero checks. Sibling of `tests`,
+    // and the aggregate answer a per-response script structurally cannot give.
+    std::optional<ThresholdOutcome> thresholds;
     SamplingRetention retention;
     // A scenario load run's sequence tallies and per-step breakdown, stored
     // under the summary's `scenario` key. Absent for a single-request load run,

--- a/engine/include/vayu/core/threshold_eval.hpp
+++ b/engine/include/vayu/core/threshold_eval.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file threshold_eval.hpp
+ * @brief Pure core for a run's pass/fail budgets: what a `thresholds` object
+ *        may say, and what verdict the run's own numbers give it.
+ *
+ * A load run measures everything and, before this, judged nothing - the report
+ * carried percentiles and an error rate, and "did that meet the budget" was a
+ * question only a human reading numbers could answer. The two halves live
+ * together here on purpose: `validate_thresholds` (the route's gate) and
+ * `evaluate_thresholds` (the run's verdict) read the *same* metric table, so a
+ * key the route accepts cannot be one the evaluator silently ignores.
+ *
+ * Both are total functions over arbitrary JSON: the route's copy is handed a
+ * client body, and the evaluator's is handed a stored config snapshot which may
+ * have been written by an older engine or hand-edited.
+ */
+
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace vayu::core {
+
+// Declared, not included: `evaluate_thresholds` reads the same whole-run
+// results the summary is built from, and run_manager.hpp includes this header
+// for `ThresholdOutcome`. Taking it by const reference keeps that one-way.
+struct RunSummaryInputs;
+
+/// One declared budget and how the run measured against it.
+struct ThresholdCheck {
+    /// The wire key the budget was declared under, e.g. "latencyP99Ms".
+    std::string metric;
+    double limit  = 0.0;
+    double actual = 0.0;
+    bool passed   = false;
+};
+
+/// Every declared budget's verdict. `failed == 0` is the run's pass.
+struct ThresholdOutcome {
+    std::vector<ThresholdCheck> checks;
+    size_t passed = 0;
+    size_t failed = 0;
+};
+
+/**
+ * @brief Reject a `thresholds` object the run could not act on.
+ *
+ * Reads @p config (the whole run config), and looks only at its `thresholds`
+ * key - an absent one is valid, since budgets are opt-in. Present means it must
+ * be usable: an object, carrying at least one known budget, every key drawn
+ * from the metric table and every value finite and in range. A `null` value is
+ * read as absent, the same rule the flat numeric fields follow, so a client
+ * that sends its unset fields as nulls is not punished for it - but an object
+ * that says nothing after that is rejected rather than stored as a budget the
+ * report will never mention.
+ *
+ * @return Why the object is unusable, or `std::nullopt` if it is.
+ */
+[[nodiscard]] std::optional<std::string> validate_thresholds (const nlohmann::json& config);
+
+/**
+ * @brief Judge a completed run against the budgets its config declared.
+ *
+ * Evaluated off the same @ref RunSummaryInputs the stored summary is built
+ * from, so the verdict and the numbers printed beside it cannot disagree. The
+ * error rate is derived the way the report derives its own - every status
+ * outside 2xx/3xx counts as a failure, including the transport errors recorded
+ * under code 0 - rather than from the collector's transport-error-only count,
+ * which would call a run of nothing but 500s clean.
+ *
+ * @return `std::nullopt` when the config declared no usable budgets, which is
+ *         what keeps the report's section absent rather than zeroed. A run
+ *         stopped early still reports what it measured.
+ */
+[[nodiscard]] std::optional<ThresholdOutcome>
+evaluate_thresholds (const nlohmann::json& config, const RunSummaryInputs& inputs);
+
+} // namespace vayu::core

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -326,6 +326,22 @@ inline const char* to_string (ErrorCode code) {
 }
 
 /**
+ * @brief Does this status code count as a success when a run is *tallied*?
+ *
+ * 2xx and 3xx succeed; everything else - 4xx, 5xx, and the 0 a transport
+ * failure is recorded under - is a failure. Deliberately wider than
+ * `Response::is_success`, which answers a per-request question about one
+ * exchange: an aggregate must classify a code it holds no `ErrorCode` for,
+ * because a stored status distribution is all the numbers it has left.
+ *
+ * One copy so the run report, the sampled-results report and the threshold
+ * verdict cannot disagree about what "failed" counted.
+ */
+[[nodiscard]] constexpr bool is_success_status (int status_code) noexcept {
+    return status_code >= 200 && status_code < 400;
+}
+
+/**
  * @brief HTTP Response
  */
 struct Response {

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -821,6 +821,12 @@ RunManager& manager) {
                 *scenario_state, context->scenario->plan);
             }
 
+            // Judged last, off the filled inputs rather than off the collector:
+            // the verdict has to be computed from the same numbers the summary
+            // is about to store, or a report could print a p99 its own verdict
+            // disagrees with. A run stopped early is judged on what it measured.
+            inputs.thresholds = evaluate_thresholds (context->config, inputs);
+
             db.update_run_summary (
             context->run_id, build_run_summary_payload (inputs).dump ());
         } catch (const std::exception& e) {
@@ -1002,6 +1008,20 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     if (inputs.tests.has_value ()) {
         summary["tests"] = { { "sampled", inputs.tests->sampled },
             { "passed", inputs.tests->passed }, { "failed", inputs.tests->failed } };
+    }
+    // The run's verdict against the budgets it declared. Omitted when it
+    // declared none, for the same reason `tests` is: "no budget" and "a budget
+    // nothing was measured against" are different answers, and only the absent
+    // section can say the first.
+    if (inputs.thresholds.has_value ()) {
+        nlohmann::json checks = nlohmann::json::array ();
+        for (const auto& check : inputs.thresholds->checks) {
+            checks.push_back ({ { "metric", check.metric }, { "limit", check.limit },
+                { "actual", check.actual }, { "passed", check.passed } });
+        }
+        summary["thresholds"] = { { "checks", checks },
+            { "passed", inputs.thresholds->passed },
+            { "failed", inputs.thresholds->failed } };
     }
     // A scenario load run's sequence tallies, under the same key and in the
     // same shape the design-mode runner writes - one report section, two

--- a/engine/src/core/threshold_eval.cpp
+++ b/engine/src/core/threshold_eval.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/core/threshold_eval.hpp"
+
+#include <array>
+#include <cmath>
+#include <string_view>
+
+#include "vayu/core/run_manager.hpp"
+#include "vayu/types.hpp"
+
+namespace vayu::core {
+
+namespace {
+
+/// Which way a budget is breached.
+enum class Direction {
+    AtMost,  ///< passes while `actual <= limit` (a ceiling)
+    AtLeast, ///< passes while `actual >= limit` (a floor)
+};
+
+/// One budget: its wire key, the run figure it judges, and the range a client
+/// may declare it in. Kept as data so the route's validation and the run's
+/// verdict read the same row rather than two hand-written lists that drift -
+/// the failure that would produce is silent, a key accepted and never checked.
+struct ThresholdMetric {
+    const char* key;
+    Direction direction;
+    double min_limit;
+    /// Whether `min_limit` itself is a legal budget. True only for the error
+    /// rate: "no request may fail" is a real ask, where a latency ceiling or a
+    /// throughput floor of zero is a typo rather than an intent.
+    bool min_inclusive;
+    double max_limit;
+    const char* range; // the accepted span, spelled for the rejection message
+    const char* why;   // appended to a rejection, explains the bound
+    double (*measured) (const RunSummaryInputs&);
+};
+
+/// Share of this run's requests that did not succeed, as a percentage - the
+/// same figure `GET /runs/:id/report` prints, derived the same way (from the
+/// status distribution, so the transport failures recorded under code 0 count).
+double measured_error_rate (const RunSummaryInputs& inputs) {
+    if (inputs.total_requests == 0) {
+        return 0.0;
+    }
+    size_t failed = 0;
+    for (const auto& [code, count] : inputs.status_codes) {
+        if (!vayu::is_success_status (code)) {
+            failed += count;
+        }
+    }
+    return static_cast<double> (failed) * 100.0 /
+    static_cast<double> (inputs.total_requests);
+}
+
+constexpr double MAX_LATENCY_BUDGET_MS = 86400000.0; // a day; past it nothing completes
+constexpr double MAX_THROUGHPUT_BUDGET_RPS = 1e9;
+
+/// Every budget a run may declare, in the order the report lists them.
+const std::array<ThresholdMetric, 5>& metrics () {
+    static const std::array<ThresholdMetric, 5> table = { {
+    { "latencyP50Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
+    "greater than 0 and at most 86400000",
+    "It is a latency ceiling in milliseconds.",
+    [] (const RunSummaryInputs& in) { return in.latency.p50; } },
+    { "latencyP95Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
+    "greater than 0 and at most 86400000",
+    "It is a latency ceiling in milliseconds.",
+    [] (const RunSummaryInputs& in) { return in.latency.p95; } },
+    { "latencyP99Ms", Direction::AtMost, 0.0, false, MAX_LATENCY_BUDGET_MS,
+    "greater than 0 and at most 86400000",
+    "It is a latency ceiling in milliseconds.",
+    [] (const RunSummaryInputs& in) { return in.latency.p99; } },
+    { "maxErrorRatePct", Direction::AtMost, 0.0, true, 100.0, "between 0 and 100",
+    "It is a percentage of the run's requests.", measured_error_rate },
+    { "minThroughputRps", Direction::AtLeast, 0.0, false, MAX_THROUGHPUT_BUDGET_RPS,
+    "greater than 0 and at most 1000000000",
+    "It is a completed-requests-per-second floor.",
+    [] (const RunSummaryInputs& in) { return in.throughput; } },
+    } };
+    return table;
+}
+
+/// The known keys, for a rejection that tells the caller what it may send.
+std::string known_keys () {
+    std::string keys;
+    for (const auto& metric : metrics ()) {
+        if (!keys.empty ()) {
+            keys += ", ";
+        }
+        keys += metric.key;
+    }
+    return keys;
+}
+
+const ThresholdMetric* find_metric (const std::string& key) {
+    for (const auto& metric : metrics ()) {
+        if (key == metric.key) {
+            return &metric;
+        }
+    }
+    return nullptr;
+}
+
+/// The declared budgets, in table order. A key whose value is `null` or of the
+/// wrong type is skipped rather than guessed at - the route rejects both before
+/// a run exists, and a snapshot that reached here carrying one is an older or
+/// hand-edited row that must not take the whole section down with it.
+std::vector<std::pair<const ThresholdMetric*, double>>
+declared_budgets (const nlohmann::json& thresholds) {
+    std::vector<std::pair<const ThresholdMetric*, double>> declared;
+    if (!thresholds.is_object ()) {
+        return declared;
+    }
+    for (const auto& metric : metrics ()) {
+        if (!thresholds.contains (metric.key)) {
+            continue;
+        }
+        const auto& value = thresholds[metric.key];
+        if (!value.is_number ()) {
+            continue;
+        }
+        const double limit = value.get<double> ();
+        if (!std::isfinite (limit)) {
+            continue;
+        }
+        declared.emplace_back (&metric, limit);
+    }
+    return declared;
+}
+
+} // namespace
+
+std::optional<std::string> validate_thresholds (const nlohmann::json& config) {
+    if (!config.is_object () || !config.contains ("thresholds") ||
+    config["thresholds"].is_null ()) {
+        return std::nullopt; // Budgets are opt-in.
+    }
+
+    const auto& thresholds = config["thresholds"];
+    if (!thresholds.is_object ()) {
+        return "'thresholds' must be an object of budgets, e.g. "
+               "{\"latencyP99Ms\": 50} (got " +
+        std::string (thresholds.type_name ()) + ")";
+    }
+
+    size_t declared = 0;
+    for (const auto& [key, value] : thresholds.items ()) {
+        const ThresholdMetric* metric = find_metric (key);
+        if (metric == nullptr) {
+            return "'thresholds." + key +
+            "' is not a known budget - expected one of " + known_keys ();
+        }
+        // Null reads as absent, the same rule the flat numeric fields follow.
+        if (value.is_null ()) {
+            continue;
+        }
+        if (!value.is_number ()) {
+            return "'thresholds." + key + "' must be a number (got " +
+            std::string (value.type_name ()) + ")";
+        }
+        // Read as a double first: an integer read of a fractional or huge value
+        // is itself undefined, and this is the guard that has to be total.
+        const double limit    = value.get<double> ();
+        const bool under_min  = metric->min_inclusive ? limit < metric->min_limit :
+                                                        !(limit > metric->min_limit);
+        if (!std::isfinite (limit) || under_min || limit > metric->max_limit) {
+            return "'thresholds." + key + "' must be " + metric->range + " (got " +
+            value.dump () + "). " + metric->why;
+        }
+        ++declared;
+    }
+
+    // An object that says nothing is rejected rather than stored: a caller that
+    // sent it believes this run will be judged, and it is about to complete
+    // with no verdict at all.
+    if (declared == 0) {
+        return "'thresholds' declares no budget - give at least one of " +
+        known_keys () + ", or omit the object entirely";
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ThresholdOutcome>
+evaluate_thresholds (const nlohmann::json& config, const RunSummaryInputs& inputs) {
+    if (!config.is_object () || !config.contains ("thresholds")) {
+        return std::nullopt;
+    }
+
+    const auto declared = declared_budgets (config["thresholds"]);
+    if (declared.empty ()) {
+        return std::nullopt;
+    }
+
+    ThresholdOutcome outcome;
+    outcome.checks.reserve (declared.size ());
+    for (const auto& [metric, limit] : declared) {
+        ThresholdCheck check;
+        check.metric = metric->key;
+        check.limit  = limit;
+        check.actual = metric->measured (inputs);
+        check.passed = metric->direction == Direction::AtMost ?
+        check.actual <= check.limit :
+        check.actual >= check.limit;
+        if (check.passed) {
+            ++outcome.passed;
+        } else {
+            ++outcome.failed;
+        }
+        outcome.checks.push_back (std::move (check));
+    }
+    return outcome;
+}
+
+} // namespace vayu::core

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -24,6 +24,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/core/scenario_load.hpp"
 #include "vayu/core/scenario_plan.hpp"
+#include "vayu/core/threshold_eval.hpp"
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/request_builder.hpp"
@@ -526,6 +527,14 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         if (auto reason = check_numeric_field (config, field)) {
             return reason;
         }
+    }
+
+    // `thresholds` is the one nested object here, so it gets its own pass
+    // rather than a row in the flat table above. The rule lives with the
+    // evaluator (`core/threshold_eval.cpp`), which reads the same metric table
+    // - a budget this accepts is one the run will actually judge.
+    if (auto reason = vayu::core::validate_thresholds (config)) {
+        return reason;
     }
 
     return std::nullopt;

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -132,6 +132,16 @@ struct ReportExtras {
     int tests_sampled  = 0;
     int tests_passed   = 0;
     int tests_failed   = 0;
+    // The run's verdict against its declared budgets. `has_thresholds` false is
+    // a run that declared none (or one recorded before budgets existed), which
+    // leaves thresholdValidation out entirely - a run that declared nothing did
+    // not pass zero checks, it was never judged.
+    bool has_thresholds = false;
+    size_t thresholds_passed = 0;
+    size_t thresholds_failed = 0;
+    // Per-budget rows verbatim from the summary, already in the report's
+    // camelCase shape - the evaluator writes the wire keys.
+    nlohmann::json threshold_checks = nlohmann::json::array ();
     // What the run's bounded stores thinned away. `has_sampling` false is a
     // run recorded before retention was reported, which is not the same as a
     // run that dropped nothing - so the section is left out rather than shown
@@ -302,6 +312,20 @@ ReportExtras& extras) {
         read_number (summary["tests"], "sampled", extras.tests_sampled);
         read_number (summary["tests"], "passed", extras.tests_passed);
         read_number (summary["tests"], "failed", extras.tests_failed);
+    }
+
+    if (summary.contains ("thresholds") && summary["thresholds"].is_object ()) {
+        const auto& thresholds = summary["thresholds"];
+        // The checks are the section: a stored object with no readable rows
+        // says nothing a reader can act on, so it is treated as absent rather
+        // than reported as a run that passed and failed nothing.
+        if (thresholds.contains ("checks") && thresholds["checks"].is_array () &&
+        !thresholds["checks"].empty ()) {
+            extras.has_thresholds    = true;
+            extras.threshold_checks  = thresholds["checks"];
+            read_number (thresholds, "passed", extras.thresholds_passed);
+            read_number (thresholds, "failed", extras.thresholds_failed);
+        }
     }
 }
 
@@ -592,7 +616,7 @@ const std::string& run_id) {
         report.failed_requests     = 0;
         report.errors_by_status_code.clear ();
         for (const auto& [code, count] : report.status_codes) {
-            if (code >= 200 && code < 400) {
+            if (vayu::is_success_status (code)) {
                 report.successful_requests += count;
             } else {
                 report.failed_requests += count;
@@ -781,6 +805,15 @@ const std::string& run_id) {
             (static_cast<double> (extras.tests_passed) * 100.0 /
             static_cast<double> (extras.tests_passed + extras.tests_failed)) :
             0.0 } };
+    }
+
+    // The aggregate verdict, beside the per-response one. `verdict` is derived
+    // rather than stored so it cannot contradict the counts printed next to it.
+    if (extras.has_thresholds) {
+        json_report["thresholdValidation"] = { { "checks", extras.threshold_checks },
+            { "passed", extras.thresholds_passed },
+            { "failed", extras.thresholds_failed },
+            { "verdict", extras.thresholds_failed == 0 ? "passed" : "failed" } };
     }
 
     // Include sample of request/response results

--- a/engine/src/utils/metrics_helper.cpp
+++ b/engine/src/utils/metrics_helper.cpp
@@ -56,7 +56,7 @@ double duration_s) {
         report.total_requests++;
         report.status_codes[result.status_code]++;
 
-        if (result.status_code >= 200 && result.status_code < 400) {
+        if (vayu::is_success_status (result.status_code)) {
             report.successful_requests++;
         } else {
             report.failed_requests++;

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -396,3 +396,32 @@ TEST (RunConfigValidation, ZeroSlowThresholdIsAcceptedAsDisabled) {
     config["slow_threshold_ms"] = 0;
     EXPECT_FALSE (validate_run_config (config).has_value ());
 }
+
+// --- 7. Thresholds: the one nested object the route gates ------------------
+//
+// The rule itself is `vayu::core::validate_thresholds` and is tested against
+// every metric in threshold_eval_test.cpp. What matters here is that the run
+// route reaches it at all: an unusable budget must be a 400 before a run row
+// exists, not a run that completes carrying a verdict nobody can compute.
+
+TEST (RunConfigValidation, AConfigWithoutThresholdsIsStillValid) {
+    EXPECT_FALSE (validate_run_config (valid_config ()).has_value ());
+}
+
+TEST (RunConfigValidation, AValidThresholdsObjectIsAccepted) {
+    auto config          = valid_config ();
+    config["thresholds"] = { { "latencyP99Ms", 50 }, { "maxErrorRatePct", 0.1 } };
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+}
+
+TEST (RunConfigValidation, AnUnknownThresholdKeyIsRejectedByTheRunRoute) {
+    auto config          = valid_config ();
+    config["thresholds"] = { { "latencyP42Ms", 50 } };
+    expect_rejected (config, "latencyP42Ms");
+}
+
+TEST (RunConfigValidation, AnEmptyThresholdsObjectIsRejectedByTheRunRoute) {
+    auto config          = valid_config ();
+    config["thresholds"] = nlohmann::json::object ();
+    expect_rejected (config, "thresholds");
+}

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -745,6 +745,73 @@ TEST_F (RunsRouteTest, ReportOmitsTestValidationWhenNoScriptRan) {
     EXPECT_FALSE (body.contains ("testValidation"));
 }
 
+// The aggregate verdict a per-response script cannot give, round-tripped
+// through the stored summary. The property under test is not just that the
+// section survives: the error rate the verdict judged has to be the same number
+// the report prints beside it, or the two halves of the report contradict.
+TEST_F (RunsRouteTest, ReportCarriesTheThresholdVerdict) {
+    seed ({ .id = "run_budgets", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+    // p99 is 30 ms against a 50 ms budget (passes); the fixture's 10 failures
+    // in 100 requests are 10% against a 1% budget (fails).
+    const nlohmann::json config{ { "thresholds",
+    { { "latencyP99Ms", 50 }, { "maxErrorRatePct", 1 } } } };
+    inputs.thresholds = vayu::core::evaluate_thresholds (config, inputs);
+    db_->update_run_summary (
+    "run_budgets", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_budgets");
+    ASSERT_EQ (status, 200);
+
+    ASSERT_TRUE (body.contains ("thresholdValidation"));
+    const auto& verdict = body["thresholdValidation"];
+    EXPECT_EQ (verdict["verdict"].get<std::string> (), "failed");
+    EXPECT_EQ (verdict["passed"].get<size_t> (), 1u);
+    EXPECT_EQ (verdict["failed"].get<size_t> (), 1u);
+
+    ASSERT_TRUE (verdict["checks"].is_array ());
+    ASSERT_EQ (verdict["checks"].size (), 2u);
+    EXPECT_EQ (verdict["checks"][0]["metric"].get<std::string> (), "latencyP99Ms");
+    EXPECT_DOUBLE_EQ (verdict["checks"][0]["limit"].get<double> (), 50.0);
+    EXPECT_DOUBLE_EQ (verdict["checks"][0]["actual"].get<double> (), 30.0);
+    EXPECT_TRUE (verdict["checks"][0]["passed"].get<bool> ());
+    EXPECT_EQ (verdict["checks"][1]["metric"].get<std::string> (), "maxErrorRatePct");
+    EXPECT_FALSE (verdict["checks"][1]["passed"].get<bool> ());
+
+    // The one assertion that pins the two sides together.
+    EXPECT_DOUBLE_EQ (verdict["checks"][1]["actual"].get<double> (),
+    body["summary"]["errorRate"].get<double> ());
+}
+
+TEST_F (RunsRouteTest, AThresholdVerdictPassesOnlyWhenNothingFailed) {
+    seed ({ .id = "run_budgets_ok", .start_time = 1000 });
+    auto inputs       = summary_inputs ();
+    inputs.thresholds = vayu::core::evaluate_thresholds (
+    nlohmann::json{ { "thresholds", { { "latencyP99Ms", 50 }, { "maxErrorRatePct", 25 } } } },
+    inputs);
+    db_->update_run_summary (
+    "run_budgets_ok", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_budgets_ok");
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (body["thresholdValidation"]["verdict"].get<std::string> (), "passed");
+    EXPECT_EQ (body["thresholdValidation"]["failed"].get<size_t> (), 0u);
+}
+
+// A run that declared no budgets keeps the section out entirely - and so does
+// every run recorded before budgets existed, which is the same stored shape.
+TEST_F (RunsRouteTest, ReportOmitsThresholdValidationWhenNoBudgetWasDeclared) {
+    seed ({ .id = "run_no_budgets", .start_time = 1000 });
+    auto inputs       = summary_inputs ();
+    inputs.thresholds = std::nullopt;
+    db_->update_run_summary (
+    "run_no_budgets", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_no_budgets");
+    ASSERT_EQ (status, 200);
+    EXPECT_FALSE (body.contains ("thresholdValidation"));
+}
+
 // A summary that is not a JSON object is treated as absent. There is no second
 // aggregate source any more, so the report stands on the run's sampled results
 // - which is a report, not a 500 and not an empty run.

--- a/engine/tests/threshold_eval_test.cpp
+++ b/engine/tests/threshold_eval_test.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/threshold_eval_test.cpp
+ * @brief The pure core behind a run's pass/fail budgets.
+ *
+ * Two properties carry the feature. The verdict must be computed from the same
+ * numbers the summary stores - a report that prints `p99: 47` beside a failed
+ * p99 budget of 50 is worse than no verdict at all - and a run that declared no
+ * budget must produce no section, because "not judged" and "judged and passed
+ * nothing" are different answers and only absence can say the first.
+ *
+ * The error rate is the case worth reading twice: the collector's own
+ * `error_rate()` counts transport failures only, so a run of nothing but HTTP
+ * 500s scores 0% by it. The report has always counted every non-2xx/3xx status
+ * instead, and the verdict follows the report.
+ */
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "vayu/core/run_manager.hpp"
+#include "vayu/core/threshold_eval.hpp"
+
+namespace {
+
+using vayu::core::evaluate_thresholds;
+using vayu::core::RunSummaryInputs;
+using vayu::core::ThresholdOutcome;
+using vayu::core::validate_thresholds;
+
+/// A run that completed 1000 requests: 990 OK, 8 server errors, 2 transport
+/// failures (status 0). p50/p95/p99 = 10/40/47 ms at 500 rps - so the error
+/// rate is 1%, not the 0.2% the collector's transport-only count would give.
+RunSummaryInputs measured_run () {
+    RunSummaryInputs inputs;
+    inputs.total_requests = 1000;
+    inputs.throughput     = 500.0;
+    inputs.status_codes   = { { 200, 990 }, { 500, 8 }, { 0, 2 } };
+    inputs.latency.p50    = 10.0;
+    inputs.latency.p95    = 40.0;
+    inputs.latency.p99    = 47.0;
+    return inputs;
+}
+
+nlohmann::json config_with (const nlohmann::json& thresholds) {
+    return nlohmann::json{ { "url", "http://localhost/" }, { "thresholds", thresholds } };
+}
+
+/// The one check in an outcome that declared exactly one budget.
+const vayu::core::ThresholdCheck& only_check (const std::optional<ThresholdOutcome>& outcome) {
+    EXPECT_TRUE (outcome.has_value ());
+    EXPECT_EQ (outcome->checks.size (), 1u);
+    return outcome->checks.at (0);
+}
+
+/// Assert rejection and that the message names the offending key - a 400 whose
+/// body does not say which budget is wrong is barely better than silence.
+void expect_rejected (const nlohmann::json& thresholds, const std::string& key) {
+    auto reason = validate_thresholds (config_with (thresholds));
+    ASSERT_TRUE (reason.has_value ())
+    << "expected rejection for " << key << " in " << thresholds.dump ();
+    EXPECT_NE (reason->find (key), std::string::npos)
+    << "message should name '" << key << "', got: " << *reason;
+}
+
+} // namespace
+
+// --- Absence: the property that keeps the report section out --------------
+
+TEST (ThresholdEval, AConfigWithNoThresholdsIsNotJudged) {
+    nlohmann::json config{ { "url", "http://localhost/" } };
+    EXPECT_FALSE (evaluate_thresholds (config, measured_run ()).has_value ());
+    EXPECT_FALSE (validate_thresholds (config).has_value ());
+}
+
+TEST (ThresholdEval, AnEmptyThresholdsObjectIsRejectedRatherThanStored) {
+    // Accepting it would complete the run with no verdict, which is precisely
+    // what the caller believed it was asking for.
+    auto reason = validate_thresholds (config_with (nlohmann::json::object ()));
+    ASSERT_TRUE (reason.has_value ());
+    EXPECT_NE (reason->find ("no budget"), std::string::npos) << *reason;
+}
+
+TEST (ThresholdEval, AnObjectOfOnlyNullsDeclaresNothing) {
+    // Null reads as absent per the config-wide rule, so this object is empty in
+    // every sense that matters - and must be rejected as one.
+    nlohmann::json thresholds{ { "latencyP99Ms", nullptr }, { "maxErrorRatePct", nullptr } };
+    EXPECT_TRUE (validate_thresholds (config_with (thresholds)).has_value ());
+    EXPECT_FALSE (evaluate_thresholds (config_with (thresholds), measured_run ()).has_value ());
+}
+
+TEST (ThresholdEval, ANonObjectThresholdsValueIsRejected) {
+    EXPECT_TRUE (validate_thresholds (config_with (50)).has_value ());
+    EXPECT_TRUE (validate_thresholds (config_with ("fast")).has_value ());
+    EXPECT_TRUE (
+    validate_thresholds (config_with (nlohmann::json::array ({ 1, 2 }))).has_value ());
+}
+
+TEST (ThresholdEval, AnExplicitNullThresholdsKeyIsAbsent) {
+    nlohmann::json config{ { "url", "http://localhost/" }, { "thresholds", nullptr } };
+    EXPECT_FALSE (validate_thresholds (config).has_value ());
+    EXPECT_FALSE (evaluate_thresholds (config, measured_run ()).has_value ());
+}
+
+// --- Validation: an unusable budget fails loudly, before the run exists ----
+
+TEST (ThresholdEval, AnUnknownBudgetIsRejectedAndNamed) {
+    // The failure this prevents is silent: a typo'd key accepted here would be
+    // a budget the evaluator never checks and the report never mentions.
+    expect_rejected ({ { "latencyP98Ms", 50 } }, "latencyP98Ms");
+}
+
+TEST (ThresholdEval, ANonNumericBudgetIsRejected) {
+    expect_rejected ({ { "latencyP99Ms", "50ms" } }, "latencyP99Ms");
+    expect_rejected ({ { "minThroughputRps", true } }, "minThroughputRps");
+}
+
+TEST (ThresholdEval, ALatencyBudgetOfZeroOrLessIsRejected) {
+    expect_rejected ({ { "latencyP50Ms", 0 } }, "latencyP50Ms");
+    expect_rejected ({ { "latencyP95Ms", -1 } }, "latencyP95Ms");
+    expect_rejected ({ { "latencyP99Ms", 86400001 } }, "latencyP99Ms");
+}
+
+TEST (ThresholdEval, AZeroErrorRateBudgetIsAccepted) {
+    // "No request may fail" is the one zero that is an intent rather than a
+    // typo, so the error rate is the only budget whose floor is inclusive.
+    EXPECT_FALSE (validate_thresholds (config_with ({ { "maxErrorRatePct", 0 } })).has_value ());
+}
+
+TEST (ThresholdEval, AnErrorRateBudgetOutsideZeroToHundredIsRejected) {
+    expect_rejected ({ { "maxErrorRatePct", -0.1 } }, "maxErrorRatePct");
+    expect_rejected ({ { "maxErrorRatePct", 100.5 } }, "maxErrorRatePct");
+}
+
+TEST (ThresholdEval, AThroughputFloorOfZeroIsRejected) {
+    // A floor nothing can fall below is not a budget.
+    expect_rejected ({ { "minThroughputRps", 0 } }, "minThroughputRps");
+}
+
+TEST (ThresholdEval, EveryKnownBudgetIsAcceptedTogether) {
+    nlohmann::json thresholds{ { "latencyP50Ms", 20 }, { "latencyP95Ms", 40 },
+        { "latencyP99Ms", 50 }, { "maxErrorRatePct", 0.1 },
+        { "minThroughputRps", 10000 } };
+    EXPECT_FALSE (validate_thresholds (config_with (thresholds)).has_value ());
+    auto outcome = evaluate_thresholds (config_with (thresholds), measured_run ());
+    ASSERT_TRUE (outcome.has_value ());
+    EXPECT_EQ (outcome->checks.size (), 5u);
+}
+
+// --- The verdict: each budget passes and fails off the run's own numbers ---
+
+TEST (ThresholdEval, ALatencyBudgetPassesAtOrUnderTheLimit) {
+    // 47 ms measured. The boundary is a pass: a budget of "p99 under 47" that
+    // rejected exactly 47 would be reporting a breach the numbers deny.
+    EXPECT_TRUE (only_check (evaluate_thresholds (
+                 config_with ({ { "latencyP99Ms", 50 } }), measured_run ()))
+                 .passed);
+    EXPECT_TRUE (only_check (evaluate_thresholds (
+                 config_with ({ { "latencyP99Ms", 47 } }), measured_run ()))
+                 .passed);
+    EXPECT_FALSE (only_check (evaluate_thresholds (
+                  config_with ({ { "latencyP99Ms", 46.9 } }), measured_run ()))
+                  .passed);
+}
+
+TEST (ThresholdEval, EachPercentileReadsItsOwnMeasurement) {
+    // The failure this catches is a copy-paste in the metric table: three
+    // budgets all judging p99 would look correct until a run's p50 breached.
+    auto config  = config_with ({ { "latencyP50Ms", 20 }, { "latencyP95Ms", 40 },
+         { "latencyP99Ms", 50 } });
+    auto outcome = evaluate_thresholds (config, measured_run ());
+    ASSERT_TRUE (outcome.has_value ());
+    ASSERT_EQ (outcome->checks.size (), 3u);
+    EXPECT_EQ (outcome->checks[0].metric, "latencyP50Ms");
+    EXPECT_DOUBLE_EQ (outcome->checks[0].actual, 10.0);
+    EXPECT_EQ (outcome->checks[1].metric, "latencyP95Ms");
+    EXPECT_DOUBLE_EQ (outcome->checks[1].actual, 40.0);
+    EXPECT_EQ (outcome->checks[2].metric, "latencyP99Ms");
+    EXPECT_DOUBLE_EQ (outcome->checks[2].actual, 47.0);
+}
+
+TEST (ThresholdEval, TheErrorRateCountsEveryNonSuccessStatus) {
+    // 8 server errors + 2 transport failures out of 1000 = 1%. The collector's
+    // own error_rate() would say 0.2% here, and a run of nothing but 500s would
+    // score a clean 0 - which is the bug this test exists to pin.
+    auto check =
+    only_check (evaluate_thresholds (config_with ({ { "maxErrorRatePct", 5 } }),
+    measured_run ()));
+    EXPECT_DOUBLE_EQ (check.actual, 1.0);
+    EXPECT_TRUE (check.passed);
+
+    EXPECT_FALSE (only_check (evaluate_thresholds (
+                  config_with ({ { "maxErrorRatePct", 0.5 } }), measured_run ()))
+                  .passed);
+}
+
+TEST (ThresholdEval, AThroughputFloorFailsBelowTheLimit) {
+    // The one budget judged the other way round - a copy of the latency
+    // comparison here would call a starved run a pass.
+    EXPECT_TRUE (only_check (evaluate_thresholds (
+                 config_with ({ { "minThroughputRps", 500 } }), measured_run ()))
+                 .passed);
+    EXPECT_FALSE (only_check (evaluate_thresholds (
+                  config_with ({ { "minThroughputRps", 501 } }), measured_run ()))
+                  .passed);
+}
+
+TEST (ThresholdEval, TalliesSplitPassedFromFailed) {
+    auto outcome = evaluate_thresholds (
+    config_with ({ { "latencyP50Ms", 20 }, { "latencyP95Ms", 40 },
+    { "latencyP99Ms", 46 }, { "maxErrorRatePct", 0.5 }, { "minThroughputRps", 100 } }),
+    measured_run ());
+    ASSERT_TRUE (outcome.has_value ());
+    EXPECT_EQ (outcome->passed, 3u); // p50, p95, throughput
+    EXPECT_EQ (outcome->failed, 2u); // p99 (47 > 46), error rate (1% > 0.5%)
+    EXPECT_EQ (outcome->checks.size (), 5u);
+}
+
+TEST (ThresholdEval, ARunThatSentNothingHasNoErrorRate) {
+    // A run stopped before its first completion is judged on what it measured,
+    // and 0/0 is 0% - not a division that takes the summary write down with it.
+    RunSummaryInputs empty;
+    auto check =
+    only_check (evaluate_thresholds (config_with ({ { "maxErrorRatePct", 1 } }), empty));
+    EXPECT_DOUBLE_EQ (check.actual, 0.0);
+    EXPECT_TRUE (check.passed);
+}
+
+TEST (ThresholdEval, AStoredBudgetOfTheWrongTypeIsSkippedRatherThanGuessed) {
+    // The evaluator reads a persisted config snapshot, which the route gate
+    // cannot vouch for - an older or hand-edited row must not take the whole
+    // section down, nor invent a limit for an unreadable value.
+    auto outcome = evaluate_thresholds (
+    config_with ({ { "latencyP99Ms", "fast" }, { "minThroughputRps", 100 } }),
+    measured_run ());
+    ASSERT_TRUE (outcome.has_value ());
+    ASSERT_EQ (outcome->checks.size (), 1u);
+    EXPECT_EQ (outcome->checks[0].metric, "minThroughputRps");
+}


### PR DESCRIPTION
## Description

**Root cause.** A load run measures everything and judges nothing. The two pass/fail-shaped things that exist both miss: `testValidation` replays a `pm.*` script against individual sampled responses, so it structurally cannot assert an aggregate like p99 or error rate; the app's `sloThresholdMs` is a global client-only setting that never reaches the engine, is not persisted with the run, and produces a chart annotation rather than a verdict. Verified still live at `21ba739` - the report carries `latency{p50..p999}`, `summary.errorRate` and `summary.throughput` with nothing that compares them to anything.

**Approach.** Mirror the four-hop `testValidation` shape exactly: payload field → evaluated post-run → optional summary section → optional report section. The one design decision worth naming is that `validate_thresholds` (the route's gate) and `evaluate_thresholds` (the run's verdict) live in one file pair and read the **same metric table**. Two lists would drift, and the way that failure shows up is silent - a key the route accepts and the evaluator never checks, so the user declares a budget the run is never judged against. The verdict is computed from the filled `RunSummaryInputs` immediately before the summary write rather than from the collector, so the verdict and the numbers printed beside it cannot disagree.

**Rejected:** deriving the error rate from `MetricsCollector::error_rate()`, which is what "error rate" means everywhere else in the engine. It counts transport failures only, so a run of nothing but HTTP 500s scores a clean 0% - and it would contradict the `summary.errorRate` printed in the same report. The verdict follows the report's rule (every status outside 2xx/3xx, including the 0 a transport failure is recorded under). That needed a third copy of the 2xx/3xx test, so the rule is now `vayu::is_success_status` and the two existing copies call it.

**Deliberate deviation, stated.** The issue's payload spec says values must be finite and `> 0`, with `maxErrorRatePct` in `[0, 100]`. Implemented as written, and the asymmetry is load-bearing: `maxErrorRatePct: 0` ("no request may fail") is the strictest budget a user can declare, where a latency ceiling or a throughput floor of 0 is a typo nothing could meet. A `null` value reads as absent, following the config-wide rule the flat numeric fields already use - so an object of only nulls is rejected as declaring nothing, rather than accepted as a budget the report will never mention.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **1225/1225 passed**.
- `cd app && pnpm test`: **3802 passed** across 380 files. `pnpm type-check` and `pnpm lint` clean; `prettier --check` clean on the touched files.
- `mkdocs build --strict -f .github/mkdocs.yml`: clean.
- No pre-existing failures encountered on the base commit.

**24 new engine tests** (`threshold_eval_test.cpp` ×17, `runs_route_test.cpp` ×3, `run_config_validation_test.cpp` ×4):

- a config with no `thresholds`, an explicit `null`, an object of only nulls, and a non-object value each produce no section and (where present) a rejection;
- an empty object is rejected rather than stored - a caller that sent it believes the run will be judged;
- an unknown key is rejected **and named**; a non-numeric or out-of-range value likewise;
- `maxErrorRatePct: 0` is accepted where `latencyP50Ms: 0` and `minThroughputRps: 0` are not;
- each percentile reads its own measurement (catches a copy-paste in the metric table - three budgets all judging p99 would look right until a p50 breached);
- the error rate counts 4xx/5xx **and** transport failures: 8 server errors + 2 code-0 out of 1000 is 1%, not the 0.2% the collector would say;
- the throughput floor passes above its limit, where every other budget passes below;
- a run that sent nothing is judged on what it measured (0/0 is 0%, not a division that takes the summary write down);
- a stored budget of the wrong type is skipped rather than guessed at, so a hand-edited or older snapshot cannot take the whole section down;
- the report round-trip asserts the check's `actual` **equals** `summary.errorRate` - the one assertion that pins the verdict to the numbers beside it;
- `verdict` is `"passed"` only when `failed == 0`, and the section is absent for a run that declared none.

**Mutation-checked**: flipping the `AtMost`/`AtLeast` comparison in `evaluate_thresholds` fails 6 tests (4 unit, 2 route round-trip); restored, all green.

**27 new app tests** (`budgets.test.ts` ×11, `ThresholdVerdict.test.tsx` ×8, `LoadTestConfigDialog.test.tsx` ×5, `electron/mcp/tools.test.ts` ×3):

- the dialog seeds p99 from `sloThresholdMs` and sends it (this is the reader that stops the setting being written-and-never-read);
- a cleared budget stays cleared across dialog opens - re-seeding every time would silently undo the user's decision to run without a latency budget;
- an out-of-range budget blocks Start with a named message instead of being dropped from the payload;
- `thresholds` is absent, never `{}`, when nothing was declared;
- every field in the table keys to a real `RunThresholds` member, so none can be typed into a control and sent nowhere;
- the verdict renders nothing for a run that declared no budgets, prints the throughput floor as `≥` and the ceilings as `≤`, and shows a metric it has no label for rather than dropping a check whose count is still in the total;
- MCP forwards the budgets under the engine's own keys, rejects an empty object by name, and rejects a value the engine would reject.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

App changes were required and are included: `LoadTestConfig` / `StartLoadTestRequest` / `RunReport` types, a **Pass/fail budgets** disclosure in `LoadTestConfigDialog` (its field table and rules extracted to `budgets.ts`, component-free and unit-tested), forwarding through `handleConfirmLoadTest`, one shared `ThresholdVerdict` rendered by both the dashboard report and the history Overview (a second copy would not receive the first's fixes), and `thresholds` on MCP `start_load_run`.

Docs updated in the same commit: `docs/engine/api-reference.md` (the `POST /runs` payload, a new `thresholds` block section, the report shape), `docs/engine/db-schema.md` (the `summary` column), `docs/engine/mcp.md` (the tool table), `docs/app/api-integration.md` and `docs/app/COMPONENTS.md`.

## Related Issues
Closes #470