### PR TITLE
fix(engine/scripting): a test script's pm.request.headers is the sent record

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -471,6 +471,13 @@ back and applied to the same `Request` before `client.send()`
 (`apply_pm_request_writeback`). In a **test** script it stays a read-only record: the
 request has already gone out, so nothing is written back and a mutation there is discarded.
 
+The two hooks therefore read **different header sets**, matching Postman: a pre-request
+script sees the composed headers it is there to edit, and a test script sees the ones that
+were actually sent - including the `Content-Type` the engine derives from the body mode and
+the default `User-Agent`, neither of which exists yet when the pre-request script runs
+(#483). A `form-data` `Content-Type` appears in neither, because libcurl writes that one
+itself with the boundary.
+
 ```javascript
 pm.request.headers['X-Signature'] = sign(pm.request.body);
 delete pm.request.headers['Authorization'];

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1560,7 +1560,18 @@ transfer's last outbound header frame and followed by the request body. So it
 carries what libcurl added on its own - the `Cookie` line the
 [cookie jar](architecture.md#cookie-jar) matched, `Accept`, `Content-Length`,
 and an h2 request rendered in HTTP/1 form - none of which appear in
-`requestHeaders`, which stays the *composed* headers. Values are not redacted:
+`requestHeaders`.
+
+**`requestHeaders` is the sent record**: the composed headers as the transfer
+issued them. It carries the two the engine derives at send time - the
+body-implied `Content-Type` and the default `User-Agent` - and drops a
+`form-data` `Content-Type`, which libcurl writes itself with the boundary. It
+does not carry libcurl's own additions or the jar's `Cookie` line; those are
+`rawRequest`'s alone. A test script's `pm.request.headers` reads this same set
+(see [scripting.md](scripting.md#request-object-pmrequest)), so an assertion
+about what went out and the response pane's Headers tab cannot disagree.
+
+Values in `rawRequest` are not redacted:
 this field exists to say exactly what went out. On a followed redirect it is the
 final hop, matching the response beside it. A transfer that failed before
 sending anything (DNS failure, connection refused) has no frame to read, and

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -307,6 +307,19 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   path on the user's machine, which an agent cannot choose for them or verify,
   so the tools state the limit rather than inventing a shape for it. A stored
   file part is left alone unless `body` replaces the whole body.
+- **What actually went out** - the engine adds headers an agent never wrote: the
+  body-implied `Content-Type` (a `graphql` body sends `application/json`, an
+  `x-www-form-urlencoded` one sends its own type), a default `User-Agent`, and
+  the `Cookie` line the jar matched for the environment. So the request an agent
+  composed is not the request that was sent, and asserting on the composed one
+  is how a correct request gets reported as wrong. `requestHeaders` in the
+  result is the sent record - composed plus those first two, minus a
+  `form-data` `Content-Type` libcurl writes itself - and `rawRequest` is the
+  full wire frame including the `Cookie` line and libcurl's own `Accept` /
+  `Content-Length`. Both are passed through verbatim; read them rather than the
+  request the call sent. A `postRequestScript` reads the same set as
+  `pm.request.headers` (see
+  [scripting.md](scripting.md#request-object-pmrequest)).
 - **Protocol** - `run_request` and `start_load_run` both take an optional
   `httpVersion` Zod-enum arg (`"auto" | "http1.1" | "http2"`, default `"auto"`),
   mirroring the request builder's Settings-tab picker. `run_collection_smoke`

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -270,6 +270,29 @@ pm.request.headers           // Request headers (object, with the methods below)
 pm.request.body              // Request body (string, if any)
 ```
 
+**`headers` is a different set in each hook, and that is the point.** A
+pre-request script sees the **composed** headers - the set it is there to edit,
+and the set the write-back applies back onto the request. A test script sees the
+**sent record**: those same headers as the transfer actually issued them, which
+means the ones the engine derives at send time are there too - the body-implied
+`Content-Type` (`graphql` -> `application/json`, `x-www-form-urlencoded` ->
+`application/x-www-form-urlencoded`) and the default `User-Agent`. So a test
+asserting on the Content-Type a GraphQL request sent reads the header the engine
+supplied, rather than the `undefined` it read before (#483).
+
+Three consequences worth knowing:
+
+- **An authored header is never overridden.** The engine only derives a
+  Content-Type the request does not declare, so what a script reads back is what
+  its author wrote.
+- **A `form-data` Content-Type is absent, not blank.** libcurl writes that one
+  itself, boundary and all, so the engine suppresses an authored one and does
+  not report as sent what it did not send. The script's view matches the
+  response pane's Headers tab exactly.
+- **`Cookie` is not here.** It is wire-only by design; `pm.cookies` is the
+  cookie surface, and the response's raw view is the full wire frame (which also
+  carries libcurl's own `Accept`, `Host` and `Content-Length`).
+
 `body` is a string for every mode, including the two whose content is a list of
 fields rather than text. A form body reads as its **enabled** fields encoded
 `key=value&…`:

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -444,6 +444,7 @@ if(VAYU_BUILD_TESTS)
         tests/script_variables_test.cpp
         tests/script_info_test.cpp
         tests/script_send_request_test.cpp
+        tests/script_sent_headers_test.cpp
         tests/set_cookie_test.cpp
         tests/cookie_jar_test.cpp
         tests/form_body_test.cpp

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -3092,6 +3092,42 @@ std::string script_body_view (const Body& body) {
                                          body.content;
 }
 
+/**
+ * Which header map `pm.request.headers` shows.
+ *
+ * Two records of "the request's headers" exist and they are not the same set
+ * (issue #483). `request->headers` is what the request was *composed* with;
+ * `response->request_headers` is what was *sent* - that same map minus the
+ * headers the transfer suppresses, plus the ones the engine derives at curl
+ * setup: the body-implied `Content-Type` (GraphQL -> `application/json`, Form
+ * -> `application/x-www-form-urlencoded`) and the default `User-Agent`. A test
+ * script asking which Content-Type went out for a GraphQL body is asking about
+ * the second, and the composed map structurally cannot answer - nobody wrote
+ * that header down, the engine derived it precisely so the user would not have
+ * to. It read `undefined` and the assertion went red on a request that went
+ * out right.
+ *
+ * So a **test** script reads the sent record and a **pre-request** script reads
+ * the composed map. That split is forced, not preferred: before the send there
+ * is no sent record to read, and the pre-request object is the one
+ * `apply_pm_request_writeback` applies back onto the request, so showing it
+ * anything other than the composed set would make `delete` operate on headers
+ * the request never carried.
+ *
+ * The fallback is load-bearing rather than defensive padding. A load run's
+ * deferred validation rebuilds its `Response` from a sampled response
+ * (`run_manager.cpp`), which records no sent headers at all; seeding from that
+ * empty map would take `pm.request.headers` from "missing the two derived
+ * entries" to "empty", a worse answer than the one this fixes. An empty sent
+ * record means nothing was recorded, never that nothing was sent.
+ */
+const Headers& script_request_header_view (const ContextData& data) {
+    if (data.response != nullptr && !data.response->request_headers.empty ()) {
+        return data.response->request_headers;
+    }
+    return data.request->headers;
+}
+
 void setup_pm_request (JSContext* ctx, JSValue pm) {
     auto* data = get_context_data (ctx);
 
@@ -3113,10 +3149,11 @@ void setup_pm_request (JSContext* ctx, JSValue pm) {
         JS_NewString (ctx, to_string (data->request->method)));
 
         // pm.request.headers - the object the write-back reads, so its methods
-        // and plain assignment reach the same property set.
+        // and plain assignment reach the same property set. Which set that is
+        // depends on the hook - see script_request_header_view.
         JSValue headers = JS_NewObject (ctx);
         install_header_methods (ctx, headers, /*mutators=*/true);
-        for (const auto& [key, value] : data->request->headers) {
+        for (const auto& [key, value] : script_request_header_view (*data)) {
             define_header_entry (ctx, headers, key, value);
         }
         JS_SetPropertyStr (ctx, request, "headers", headers);

--- a/engine/tests/script_sent_headers_test.cpp
+++ b/engine/tests/script_sent_headers_test.cpp
@@ -1,0 +1,298 @@
+/**
+ * @file script_sent_headers_test.cpp
+ * @brief What a test script reads as `pm.request.headers` - the sent record.
+ *
+ * Issue #483: two records of "the request's headers" exist and the test script
+ * read the wrong one. `pm.request.headers` was built from the *composed* map,
+ * while the headers the engine derives at curl setup - the body-implied
+ * `Content-Type` and the default `User-Agent` - live only on the response's
+ * `request_headers`, which is what the response viewer shows. So a GraphQL or
+ * form request whose author did not hand-write a Content-Type (the normal case,
+ * since the engine derives it precisely so they do not have to) gave a script
+ * asking "what Content-Type was sent?" the answer `undefined`, and the
+ * assertion went red on a request that went out right.
+ *
+ * The end-to-end tests below send through the real client, so they pin the
+ * whole chain rather than a hand-built map that could drift from what curl
+ * setup actually records: derive -> record on the response -> seed the script.
+ * The unit-level ones pin the boundaries the fix must not cross - the
+ * pre-request view, and a response carrying no sent record at all.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "echo_server.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/runtime/script_engine.hpp"
+#include "vayu/types.hpp"
+
+namespace vayu::runtime {
+namespace {
+
+using vayu::tests::EchoServer;
+
+/// The bare document an agent or a renderer sends for a GraphQL request. No
+/// Content-Type is authored: deriving one is the engine's job (#417).
+const char* const kBareQuery = "query Me { me { id name } }";
+
+/**
+ * A test script's whole outcome in one place. Every test here asserts on
+ * `passed` *and* on the reported message when it fails, because a script that
+ * throws before reaching its assertion also reports "not passed" - and that is
+ * a different defect from the assertion failing.
+ */
+struct ScriptOutcome {
+    bool ran_clean = false;
+    bool passed    = false;
+    std::string detail;
+};
+
+ScriptOutcome run_test_script (ScriptEngine& engine,
+const std::string& script,
+const Request& request,
+const Response& response) {
+    Environment env;
+    const ScriptResult result = engine.execute_test (script, request, response, env);
+
+    ScriptOutcome outcome;
+    outcome.ran_clean = result.success;
+    outcome.detail    = result.error_message;
+    if (!result.tests.empty ()) {
+        outcome.passed = result.tests[0].passed;
+        if (!result.tests[0].passed) {
+            outcome.detail = result.tests[0].error_message;
+        }
+    }
+    return outcome;
+}
+
+/// `pm.test` around one assertion, so a failure reports the assertion's own
+/// message rather than an execution error.
+std::string assertion (const std::string& body) {
+    return "pm.test(\"sent headers\", function() { " + body + " });";
+}
+
+class SentRequestHeadersTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        vayu::http::global_init ();
+        server_ = std::make_unique<EchoServer> ();
+        client_ = std::make_unique<vayu::http::Client> ();
+    }
+
+    void TearDown () override {
+        client_.reset ();
+        server_.reset ();
+        vayu::http::global_cleanup ();
+    }
+
+    /// Send `request` for real, then run `script` against what came back - the
+    /// same order `execute_exchange` runs them in.
+    ScriptOutcome send_then_assert (Request& request, const std::string& script) {
+        auto result = client_->send (request);
+        EXPECT_TRUE (result.is_ok ());
+        response_ = result.value ();
+        EXPECT_EQ (response_.status_code, 200);
+        return run_test_script (engine_, assertion (script), request, response_);
+    }
+
+    Request graphql_request () const {
+        Request request;
+        request.method       = HttpMethod::POST;
+        request.url          = server_->url ();
+        request.body.mode    = BodyMode::GraphQL;
+        request.body.content = kBareQuery;
+        return request;
+    }
+
+    Request form_request () const {
+        Request request;
+        request.method      = HttpMethod::POST;
+        request.url         = server_->url ();
+        request.body.mode   = BodyMode::Form;
+        request.body.fields = { FormField{ "name", "ada" } };
+        return request;
+    }
+
+    ScriptEngine engine_;
+    Response response_;
+    std::unique_ptr<EchoServer> server_;
+    std::unique_ptr<vayu::http::Client> client_;
+};
+
+// ---------------------------------------------------------------------------
+// The owner's repro, and its siblings.
+// ---------------------------------------------------------------------------
+
+// The reported failure, end to end: a bare GraphQL query goes out as
+// application/json, and the script that asks so is now told so. Mutation-check:
+// seed `pm.request.headers` from the composed map again and this fails with the
+// `undefined` the report showed.
+TEST_F (SentRequestHeadersTest, GraphQLDerivedContentTypeReachesTheTestScript) {
+    Request request = graphql_request ();
+
+    const auto outcome = send_then_assert (request,
+    R"(pm.expect(pm.request.headers.get("Content-Type")).to.include("json");)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+    // The wire agrees with the script - the assertion above would also pass
+    // against a header the engine invented and never sent.
+    EXPECT_EQ (server_->content_type (), "application/json");
+}
+
+// The same derivation for the other mode that has one. Two modes imply a
+// Content-Type and a table that only ever judged one of them would look right
+// until a form request asked.
+TEST_F (SentRequestHeadersTest, FormDerivedContentTypeReachesTheTestScript) {
+    Request request = form_request ();
+
+    const auto outcome = send_then_assert (request,
+    R"(pm.expect(pm.request.headers.get("Content-Type"))
+           .to.equal("application/x-www-form-urlencoded");)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+    EXPECT_EQ (server_->content_type (), "application/x-www-form-urlencoded");
+}
+
+// The other engine-derived header, and the one every request gets: a script
+// asserting on the User-Agent it sends is asserting on a header no request in
+// the app declares.
+TEST_F (SentRequestHeadersTest, DefaultUserAgentReachesTheTestScript) {
+    Request request;
+    request.method = HttpMethod::POST;
+    request.url    = server_->url ();
+
+    const auto outcome = send_then_assert (
+    request, R"(pm.expect(pm.request.headers.has("User-Agent")).to.be.true;)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+    EXPECT_FALSE (response_.request_headers.at ("User-Agent").empty ());
+}
+
+// The derivation only fills absence, so the sent record must show what the
+// author wrote - not what the body mode would have implied. A view that
+// overrode it would report a request the user never sent.
+TEST_F (SentRequestHeadersTest, AnAuthoredContentTypeIsNotOverridden) {
+    Request request                 = graphql_request ();
+    request.headers["Content-Type"] = "application/graphql+json";
+
+    const auto outcome = send_then_assert (request,
+    R"(pm.expect(pm.request.headers.get("Content-Type"))
+           .to.equal("application/graphql+json");)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+    EXPECT_EQ (server_->content_type (), "application/graphql+json");
+}
+
+// Authored headers still reach the script - the sent record is composed *plus*
+// derived, not derived instead of composed.
+TEST_F (SentRequestHeadersTest, AuthoredHeadersSurviveTheSentRecord) {
+    Request request                  = graphql_request ();
+    request.headers["Authorization"] = "Bearer token123";
+
+    const auto outcome = send_then_assert (request,
+    R"(pm.expect(pm.request.headers["Authorization"]).to.equal("Bearer token123");)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+}
+
+// `get()` is case-insensitive over whatever spelling the map carries, and the
+// sent record's derived entries are spelled by the engine rather than by the
+// user. A script written against Postman asks in any case it likes.
+TEST_F (SentRequestHeadersTest, TheSentRecordKeepsCaseInsensitiveLookup) {
+    Request request = graphql_request ();
+
+    const auto outcome = send_then_assert (request,
+    R"(pm.expect(pm.request.headers.get("content-TYPE")).to.include("json");)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+}
+
+// A multipart Content-Type is libcurl's to write, boundary and all, so the
+// engine suppresses an authored one rather than sending a boundary-less
+// duplicate - and does not report as sent what it did not send. The script's
+// view follows that record, which is the decision this pins: a script gets the
+// same answer as the response viewer's Headers tab, not a friendlier one.
+TEST_F (SentRequestHeadersTest, ASuppressedContentTypeIsAbsentFromTheScriptView) {
+    Request request                 = form_request ();
+    request.body.mode               = BodyMode::FormData;
+    request.headers["Content-Type"] = "multipart/form-data";
+
+    const auto outcome = send_then_assert (request,
+    R"(pm.expect(pm.request.headers.has("Content-Type")).to.be.false;)");
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+    EXPECT_FALSE (response_.request_headers.contains ("Content-Type"));
+}
+
+// ---------------------------------------------------------------------------
+// The boundaries the fix must not cross.
+// ---------------------------------------------------------------------------
+
+// A pre-request script keeps the composed view: nothing has been sent, so there
+// is no sent record to show, and the object it edits is the one the write-back
+// applies back onto the request. Showing it a derived header would offer a
+// `delete` of something the request never carried.
+TEST (SentRequestHeadersBoundaryTest, ThePreRequestViewStaysComposed) {
+    ScriptEngine engine;
+    Environment env;
+
+    Request request;
+    request.method       = HttpMethod::POST;
+    request.url          = "https://api.example.com/graphql";
+    request.body.mode    = BodyMode::GraphQL;
+    request.body.content = kBareQuery;
+
+    const auto result = engine.execute_prerequest (R"(
+        pm.test("no derived header yet", function() {
+            pm.expect(pm.request.headers.has("Content-Type")).to.be.false;
+            pm.expect(pm.request.headers.has("User-Agent")).to.be.false;
+        });
+        pm.request.headers['X-Trace'] = 'abc123';
+    )",
+    request, env);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    // The write-back still reaches the request it was shown.
+    EXPECT_EQ (request.headers.at ("X-Trace"), "abc123");
+}
+
+// A load run's deferred validation rebuilds its Response from a sampled
+// response, which records no sent headers at all. Seeding from that empty map
+// would take `pm.request.headers` from "missing two derived entries" to
+// "empty" - a worse answer than the one this issue fixes, and one no test on
+// the live path would have caught.
+TEST (SentRequestHeadersBoundaryTest, AResponseWithNoSentRecordFallsBackToComposed) {
+    ScriptEngine engine;
+
+    Request request                  = Request{};
+    request.method                   = HttpMethod::GET;
+    request.url                      = "https://api.example.com/users";
+    request.headers["Authorization"] = "Bearer token123";
+
+    Response response; // the load-run replay shape: no request_headers
+    response.status_code = 200;
+    ASSERT_TRUE (response.request_headers.empty ());
+
+    const auto outcome = run_test_script (engine,
+    assertion (R"(pm.expect(pm.request.headers.get("Authorization")).to.equal("Bearer token123");)"),
+    request, response);
+
+    EXPECT_TRUE (outcome.ran_clean) << outcome.detail;
+    EXPECT_TRUE (outcome.passed) << outcome.detail;
+}
+
+} // namespace
+} // namespace vayu::runtime


### PR DESCRIPTION
## Description

**Root cause.** Verified still live at `2b86476`, exactly as the issue describes. Two records of "the request's headers" exist and the test script read the wrong one: `setup_pm_request` built `pm.request.headers` from `data->request->headers`, the *composed* map, while the headers the engine derives at curl setup - the body-implied `Content-Type` (`implied_content_type`: GraphQL -> `application/json`, Form -> `application/x-www-form-urlencoded`) and the default `User-Agent` - are recorded onto `response.request_headers` and nowhere else. The response viewer reads that map; the script never touched it. So for every GraphQL and form request whose author did not hand-write a Content-Type - the normal case, since the engine derives it precisely so they do not have to - a script asking "what Content-Type was sent?" got `undefined`, and the test went red on a request that went out right.

**Approach.** One helper, `script_request_header_view`, decides which map seeds the JS object: the sent record when there is one, the composed map otherwise. A **test** script reads the sent record; a **pre-request** script keeps the composed view. That split is forced rather than preferred - before the send there is no sent record to read, and the pre-request object is the one `apply_pm_request_writeback` applies back onto the request, so showing it a derived header would offer a `delete` of something the request never carried. The two hooks are already disjoint in the context (`for_prerequest` sets `mutable_request` and no response; `for_test` sets the response), so the discriminator is the presence of the sent record itself.

The fallback is load-bearing, not defensive padding, and it is the part worth reviewing: a load run's deferred validation rebuilds its `Response` from a sampled response (`run_manager.cpp:91-102`), which records **no** sent headers at all. Seeding from that empty map would take `pm.request.headers` from "missing the two derived entries" to "empty" - a worse defect than the one being fixed, and one no test on the live path would have caught.

**Rejected:** overlaying only the two known derived names (`Content-Type`, `User-Agent`) onto the composed map, which the issue offers as an equivalent. It is not equivalent, and it is the hand-rolled-copy trap: the list of what curl setup adds or *removes* lives in `client.cpp`, and a second copy in the script engine would silently stop matching the moment a third derivation is added. It would also miss the removal half - a `form-data` Content-Type is suppressed, and an overlay would keep showing a header that was never sent. Seeding from `response.request_headers` wholesale means there is one rule, and it is the transfer's own.

**Decisions recorded rather than omitted**, per the issue's boundaries: `Cookie` stays out (wire-only by design, `pm.cookies` is the cookie surface, and the stored-trace half is #348's open decision); libcurl's own `Accept` / `Host` / `Content-Length` stay out for the same reason - they exist only in the `rawRequest` frame; a `form-data` `Content-Type` is **absent**, because libcurl writes that one with the boundary and the engine does not report as sent what it did not send. Each of the three is pinned by a test or stated in the docs.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **1241/1241 passed** (1232 before, +9).
- `mkdocs build --strict -f .github/mkdocs.yml`: clean.
- App side: the docs-compile guard (#463) reads `docs/engine/scripting.md` and `docs/app/pm-api-compatibility.md`, so it is the one app test this diff can move - `script-typedefs.docs-compile.test.ts` **2/2 passed**. No app source changed (see below), so the full app suite was not re-run.
- `clang-format` clean on the new file; the touched region of `script_engine.cpp` is clean (that file has pre-existing violations elsewhere, left alone).
- No pre-existing failures encountered on the base commit.

**9 new engine tests** (`script_sent_headers_test.cpp`). The first seven send through the **real client** against the echo server rather than asserting on a hand-built map, so they pin the whole chain - derive -> record on the response -> seed the script - and cannot drift from what curl setup actually does:

- the owner's repro: a bare GraphQL query's `pm.request.headers.get("Content-Type")` contains `json`, **and** the server saw `application/json` (the second assertion is what stops a header the engine invented and never sent from passing the first);
- the same for Form mode, and for the default `User-Agent`;
- an authored `Content-Type` is not overridden - the derivation only fills absence, and a view that overrode it would report a request the user never sent;
- authored headers survive: the sent record is composed **plus** derived, not derived instead of composed;
- `get()` stays case-insensitive over a map whose derived keys the engine spelled, not the user;
- a `form-data` `Content-Type` is absent from the script view, matching the response pane's Headers tab.

The last two pin the boundaries the fix must not cross:

- the pre-request view still has neither derived header, and its write-back still reaches the request;
- a `Response` with no sent record (the load-run replay shape) falls back to the composed map.

**Mutation-checked**: forcing `script_request_header_view` back to the composed map fails **5** of the 9; the other 4 are exactly the boundary tests, which must stay green under the mutation and do.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

**App changes: none, as the issue predicted, and verified rather than assumed.** The Tests-tab hint in `script-variants.tsx` reads "`pm.request` is readable here as a record of what was sent" - it stated the correct contract while the code delivered the composed draft, and it becomes true as written without an edit; it names no header specifically. The MCP path inherits the fix structurally: `run_request`'s `postRequestScript` runs engine-side through the same `execute_exchange`, whose `client.send` is what records the sent headers.

Docs updated in the same commit:

- `docs/engine/scripting.md` - the `pm.request` section states the per-hook header-set rule and its three consequences (authored headers never overridden, `form-data` absent not blank, `Cookie` elsewhere).
- `docs/engine/mcp.md` - the sent-record paragraph the issue asks for, naming the engine-added defaults and pointing an agent at `requestHeaders` / `rawRequest` in the result. The result already passed both through verbatim and nothing told an agent so.
- `docs/app/pm-api-compatibility.md` - the two views, in the request-mutation section.
- `docs/engine/api-reference.md` - **beyond the issue's list, deliberately.** Its `rawRequest` paragraph asserted that `requestHeaders` "stays the *composed* headers". That was already wrong (the derived entries have been there since they were recorded), but this PR makes it load-bearing by pointing scripts at that same field, so leaving it would have left a doc contradicting the behaviour in the commit that documents it.

## Related Issues
Closes #483

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxLFgjg4GzYc5txjYQ2N2s)_