### PR TITLE
fix(engine/scripting): pm.expect carries chai's failure message

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -16,7 +16,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 
 | Group               | API                                                                              |
 | ------------------- | -------------------------------------------------------------------------------- |
-| Core                | `pm`, `pm.test(name, fn)`, `pm.expect(value)`                                    |
+| Core                | `pm`, `pm.test(name, fn)`, `pm.expect(value[, message])` - the message prefixes the failure, as in chai |
 | Response            | `pm.response.code`, `.status`, `.responseTime`, `.headers`, `.json()`, `.text()`, `.reason()`, `.size()` |
 | Response headers    | `pm.response.headers.get(name)`, `.has(name)` - case-insensitive              |
 | Response cookies    | `pm.response.cookies` (array of `{ name, value, attrs }`), `.get(name)`, `.has(name)`, `.toObject()` - read-only, see below |
@@ -257,6 +257,19 @@ these:
 `expect({a:1,b:2}).to.eql({b:2,a:1})` **passes**: key order is not part of deep
 equality. `include`, `property(name, value)`, `members` and `oneOf` compare
 strictly too, unless a `deep` appears in the chain.
+
+**The second argument is chai's failure message.** `pm.expect(value, 'context')`
+prefixes `context: ` to whatever the failing matcher reports, so an assertion
+that runs more than once says which value it was about:
+
+```javascript
+pm.expect(user.active, 'user ' + user.id).to.be.true;
+// user 42: Expected value to be truthy
+```
+
+Non-strings are coerced and `undefined` / `null` mean no message, both as in
+chai. Assertion failures carry it; a malformed call (`.to.be.above()` with no
+argument) reports its own misuse unprefixed.
 
 `have.keys` asserts *exactly* those keys. `Map` / `Set` / typed arrays are
 reported unequal by `eql` rather than compared (their contents are not

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -33,6 +33,27 @@ pm.test('Test name', function() {
 
 Create Chai-style expectations for assertions.
 
+```javascript
+pm.expect(value);                  // the usual form
+pm.expect(value, 'context');       // chai's second argument, see below
+```
+
+**The optional second argument is prefixed to the failure.** It is chai's
+`expect(value, message)`, and it exists for the moment the assertion fails: the
+matcher says *what* broke and the message says *which* value it was - the third
+item in a loop, the request that came from the MCP path rather than the app.
+
+```javascript
+pm.expect(user.active, 'user ' + user.id).to.be.true;
+// fails with: user 42: Expected value to be truthy
+```
+
+The message is coerced like chai's, and `undefined` / `null` mean "no message",
+so a conditionally built one that came out absent leaves the failure text
+unchanged. It prefixes assertion failures only - a call the script wrote wrong
+(`.to.be.above()` with no argument) reports the misuse on its own, since the
+message describes a value, not a typo.
+
 **`equal` is strict, `eql` is deep.** `equal` is `===`, so two objects with the
 same contents are *not* equal - only the same reference is. `eql` (and its alias
 `deep.equal`) compares contents recursively and does not care about key order.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -423,6 +423,7 @@ if(VAYU_BUILD_TESTS)
         tests/http_client_test.cpp
         tests/json_test.cpp
         tests/script_engine_test.cpp
+        tests/script_expect_message_test.cpp
         tests/script_completions_test.cpp
         tests/script_types_test.cpp
         tests/event_loop_test.cpp

--- a/engine/src/http/routes/scripting.cpp
+++ b/engine/src/http/routes/scripting.cpp
@@ -61,11 +61,13 @@ nlohmann::json get_script_completions () {
     // ========================================
     // pm.expect() - Chai-style assertions
     // ========================================
-    completions.push_back ({ { "label", "pm.expect" },
-    { "kind", KIND_FUNCTION }, { "insertText", "pm.expect(${1:value})" },
-    { "insertTextRules", INSERT_AS_SNIPPET }, { "detail", "pm.expect(value: any)" },
+    completions.push_back ({ { "label", "pm.expect" }, { "kind", KIND_FUNCTION },
+    { "insertText", "pm.expect(${1:value})" }, { "insertTextRules", INSERT_AS_SNIPPET },
+    { "detail", "pm.expect(value: any, message?: string)" },
     { "documentation",
-    "Create a Chai-style expectation for assertions.\n\nChain with:\n- "
+    "Create a Chai-style expectation for assertions.\n\nThe optional second "
+    "argument is prefixed to the failure message, so a failing assertion says "
+    "which value it was about.\n\nChain with:\n- "
     ".to.equal(expected) - strict (===), so two objects with the same contents "
     "are not equal\n- .to.eql(expected) / .to.deep.equal(expected) - deep "
     "equality, key order insensitive\n- .to.be.true / "

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -343,6 +343,9 @@ struct ExpectState {
     // the same matcher compares rather than needing matchers of their own.
     bool deep   = false;
     bool nested = false;
+    // chai's second argument to `expect(value, message)`, empty when the script
+    // passed one argument. Read only by `throw_expect_failure`.
+    std::string message;
 };
 
 JSClassID expect_class_id = 0;
@@ -367,6 +370,31 @@ JSClassDef expect_class = { .class_name = "Expectation",
     .gc_mark                            = expect_gc_mark,
     .call                               = nullptr,
     .exotic                             = nullptr };
+
+/**
+ * @brief Report a failed assertion, prefixed with the expectation's message.
+ *
+ * chai's `expect(value, message)` puts the script's own words in front of
+ * whatever the matcher reports, which is the whole reason to pass one: the
+ * generic text ("Expected value to be truthy") says what broke and the prefix
+ * says which value it was - the third item in a loop, the MCP path rather than
+ * the app path. Postman scripts use the two-argument form routinely.
+ *
+ * Every matcher throws its failure through here rather than concatenating the
+ * prefix itself, so the prefix is one rule in one place: a matcher added later
+ * gets it by throwing the way its neighbours do, and cannot report a bare
+ * message by forgetting a concatenation. Usage errors - `above()` with no
+ * argument, `members()` against a non-array - deliberately do **not** come
+ * through here: they name a mistake in the script text, not the value under
+ * test, and their message already names the matcher that rejected the call.
+ */
+JSValue throw_expect_failure (JSContext* ctx, const ExpectState* state, const std::string& failure) {
+    if (state != nullptr && !state->message.empty ()) {
+        const std::string prefixed = state->message + ": " + failure;
+        return JS_ThrowTypeError (ctx, "%s", prefixed.c_str ());
+    }
+    return JS_ThrowTypeError (ctx, "%s", failure.c_str ());
+}
 
 // ----------------------------------------------------------------------------
 // Value comparison for the equality matchers.
@@ -685,7 +713,7 @@ expect_equality (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* 
         (deep ? "deeply equal " : "equal ");
         const std::string msg = "Expected " + js_describe (ctx, state->actual) +
         relation + js_describe (ctx, argv[0]);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -711,7 +739,7 @@ JSValue expect_exist (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
     if (!pass) {
         const char* msg = state->negated ? "Expected value to not exist" :
                                            "Expected value to exist";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -729,7 +757,7 @@ JSValue expect_true (JSContext* ctx, JSValueConst this_val, int argc, JSValueCon
     if (!pass) {
         const char* msg = state->negated ? "Expected value to be falsy" :
                                            "Expected value to be truthy";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -747,7 +775,7 @@ JSValue expect_false (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
     if (!pass) {
         const char* msg = state->negated ? "Expected value to not be false" :
                                            "Expected value to be false";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -777,7 +805,7 @@ JSValue expect_above (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
         " to not be above " + std::to_string (expected) :
                                            "Expected " +
         std::to_string (actual) + " to be above " + std::to_string (expected);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -807,7 +835,7 @@ JSValue expect_below (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
         " to not be below " + std::to_string (expected) :
                                            "Expected " +
         std::to_string (actual) + " to be below " + std::to_string (expected);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -855,7 +883,7 @@ JSValue expect_include (JSContext* ctx, JSValueConst this_val, int argc, JSValue
         const std::string msg = "Expected " + js_describe (ctx, state->actual) +
         (state->negated ? " to not include " : " to include ") +
         js_describe (ctx, argv[0]);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -955,7 +983,7 @@ JSValue expect_have_property (JSContext* ctx, JSValueConst this_val, int argc, J
         if (argc >= 2) {
             msg += " equal to " + js_describe (ctx, argv[1]);
         }
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -979,7 +1007,7 @@ JSValue expect_null_getter (JSContext* ctx, JSValueConst this_val, int argc, JSV
     if (!pass) {
         const char* msg = state->negated ? "Expected value to not be null" :
                                            "Expected value to be null";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return JS_DupValue (ctx, this_val);
@@ -1000,7 +1028,7 @@ JSValue expect_undefined_getter (JSContext* ctx, JSValueConst this_val, int argc
         const char* msg = state->negated ?
         "Expected value to not be undefined" :
         "Expected value to be undefined";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return JS_DupValue (ctx, this_val);
@@ -1020,7 +1048,7 @@ JSValue expect_ok_getter (JSContext* ctx, JSValueConst this_val, int argc, JSVal
     if (!pass) {
         const char* msg = state->negated ? "Expected value to not be truthy" :
                                            "Expected value to be truthy";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return JS_DupValue (ctx, this_val);
@@ -1061,7 +1089,7 @@ JSValue expect_empty_getter (JSContext* ctx, JSValueConst this_val, int argc, JS
     if (!pass) {
         const char* msg = state->negated ? "Expected value to not be empty" :
                                            "Expected value to be empty";
-        return JS_ThrowTypeError (ctx, "%s", msg);
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return JS_DupValue (ctx, this_val);
@@ -1092,7 +1120,7 @@ JSValue expect_least (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
         std::string msg = "Expected " + std::to_string (actual) +
         (state->negated ? " to not be at least " : " to be at least ") +
         std::to_string (expected);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1121,7 +1149,7 @@ JSValue expect_most (JSContext* ctx, JSValueConst this_val, int argc, JSValueCon
         std::string msg = "Expected " + std::to_string (actual) +
         (state->negated ? " to not be at most " : " to be at most ") +
         std::to_string (expected);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1156,7 +1184,7 @@ JSValue expect_length (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
     if (!pass) {
         std::string msg = "Expected length " + std::to_string (actual_len) +
         (state->negated ? " to not equal " : " to equal ") + std::to_string (expected);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1204,7 +1232,7 @@ JSValue expect_a (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst*
     if (!pass) {
         std::string msg = "Expected type " + type_name +
         (state->negated ? " to not be " : " to be ") + expected;
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1245,7 +1273,7 @@ JSValue expect_match (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
         std::string msg = state->negated ?
         "Expected '" + subject + "' to not match the pattern" :
         "Expected '" + subject + "' to match the pattern";
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1287,7 +1315,7 @@ JSValue expect_one_of (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
         const std::string msg = "Expected " + js_describe (ctx, state->actual) +
         (state->negated ? " to not be one of " : " to be one of ") +
         js_describe (ctx, argv[0]);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1342,7 +1370,7 @@ JSValue expect_keys (JSContext* ctx, JSValueConst this_val, int argc, JSValueCon
         }
         const std::string msg = std::string ("Expected object to ") +
         (state->negated ? "not have" : "have") + " exactly the keys " + listed;
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1404,7 +1432,7 @@ JSValue expect_members (JSContext* ctx, JSValueConst this_val, int argc, JSValue
         const std::string msg = "Expected " + js_describe (ctx, state->actual) +
         (state->negated ? " to not have members " : " to have members ") +
         js_describe (ctx, argv[0]);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1461,7 +1489,7 @@ JSValue expect_throw (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
         if (threw) {
             msg += ", but it threw " + thrown;
         }
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1489,7 +1517,7 @@ JSValue expect_instance_of (JSContext* ctx, JSValueConst this_val, int argc, JSV
         JS_FreeValue (ctx, name_val);
         const std::string msg = "Expected " + js_describe (ctx, state->actual) +
         (state->negated ? " to not be an instance of " : " to be an instance of ") + ctor_name;
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1521,7 +1549,7 @@ JSValue expect_close_to (JSContext* ctx, JSValueConst this_val, int argc, JSValu
         const std::string msg = "Expected " + std::to_string (actual) +
         (state->negated ? " to not be within " : " to be within ") +
         std::to_string (delta) + " of " + std::to_string (expected);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1551,7 +1579,7 @@ JSValue expect_satisfy (JSContext* ctx, JSValueConst this_val, int argc, JSValue
     if (!pass) {
         const std::string msg = "Expected " + js_describe (ctx, state->actual) +
         (state->negated ? " to not satisfy the predicate" : " to satisfy the predicate");
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
@@ -1579,19 +1607,20 @@ JSValue expect_string (JSContext* ctx, JSValueConst this_val, int argc, JSValueC
     if (!pass) {
         const std::string msg = "Expected '" + subject +
         (state->negated ? "' to not contain '" : "' to contain '") + needle + "'";
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_expect_failure (ctx, state, msg);
     }
 
     return expect_chained (ctx, this_val);
 }
 
-JSValue create_expectation (JSContext* ctx, JSValue actual) {
+JSValue create_expectation (JSContext* ctx, JSValue actual, std::string message) {
     JSValue obj = JS_NewObjectClass (ctx, static_cast<int> (expect_class_id));
     if (JS_IsException (obj)) {
         return obj;
     }
 
-    auto* state = new ExpectState{ JS_DupValue (ctx, actual), false };
+    auto* state    = new ExpectState{ JS_DupValue (ctx, actual), false };
+    state->message = std::move (message);
     JS_SetOpaque (obj, state);
 
     // Add "to" getter for chaining
@@ -2031,7 +2060,22 @@ JSValue js_pm_expect (JSContext* ctx, JSValueConst this_val, int argc, JSValueCo
         return JS_ThrowTypeError (ctx, "pm.expect requires a value");
     }
 
-    return create_expectation (ctx, argv[0]);
+    // chai coerces the message rather than demanding a string, and treats an
+    // absent one and an explicit `undefined` / `null` alike - both are how a
+    // caller that computes the message conditionally spells "no message". A
+    // value whose conversion throws (a Symbol, a throwing `toString`) is a real
+    // error and propagates rather than being swallowed into an empty prefix.
+    std::string message;
+    if (argc >= 2 && !JS_IsUndefined (argv[1]) && !JS_IsNull (argv[1])) {
+        const char* str = JS_ToCString (ctx, argv[1]);
+        if (!str) {
+            return JS_EXCEPTION;
+        }
+        message = str;
+        JS_FreeCString (ctx, str);
+    }
+
+    return create_expectation (ctx, argv[0], std::move (message));
 }
 
 // json() and text() read the body bound to the function at build time rather

--- a/engine/tests/fixtures/script-typedefs.d.ts
+++ b/engine/tests/fixtures/script-typedefs.d.ts
@@ -495,6 +495,8 @@ declare const pm: {
 	/**
 	 * Create a Chai-style expectation for assertions.
 	 * 
+	 * The optional second argument is prefixed to the failure message, so a failing assertion says which value it was about.
+	 * 
 	 * Chain with:
 	 * - .to.equal(expected) - strict (===), so two objects with the same contents are not equal
 	 * - .to.eql(expected) / .to.deep.equal(expected) - deep equality, key order insensitive
@@ -504,7 +506,7 @@ declare const pm: {
 	 * - .to.include(value)
 	 * - .and to continue a chain
 	 */
-	expect(value: any): VayuExpectation;
+	expect(value: any, message?: string): VayuExpectation;
 	/**
 	 * Access and modify global variables. Changes persist to global variables.
 	 */

--- a/engine/tests/script_expect_message_test.cpp
+++ b/engine/tests/script_expect_message_test.cpp
@@ -1,0 +1,211 @@
+/**
+ * @file tests/script_expect_message_test.cpp
+ * @brief `pm.expect(value, message)` - chai's second argument (issue #484).
+ *
+ * The custom message exists for exactly one moment: the failure. A script that
+ * asserts the same shape in a loop, or from two code paths, writes the message
+ * to say *which* one broke - the generic matcher text ("Expected value to be
+ * truthy") never can. Dropping it silently is worse than rejecting it, because
+ * the script looks correct and the report is merely useless.
+ *
+ * So the assertions here are on the reported error text, per matcher. The
+ * per-matcher sweep is the point rather than padding: the prefix is applied in
+ * one helper (`throw_expect_failure`) and a matcher that threw around it would
+ * be invisible to a test that only checked one matcher. Mutation-check: make
+ * that helper ignore `state->message` and `EveryMatcherCarriesTheMessage`
+ * fails for all 26 chains, while the boundary tests below stay green.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "vayu/runtime/script_engine.hpp"
+#include "vayu/types.hpp"
+
+using namespace vayu;
+using namespace vayu::runtime;
+
+namespace {
+
+class ExpectMessageTest : public ::testing::Test {
+    protected:
+    ScriptEngine engine;
+    Request request;
+    Response response;
+    Environment env;
+
+    void SetUp () override {
+        request.method       = HttpMethod::GET;
+        request.url          = "https://api.example.com/users";
+        response.status_code = 200;
+        response.body        = R"({"id": 1})";
+    }
+
+    /** Runs one assertion inside a `pm.test` and returns what the report shows. */
+    std::string failure_of (const std::string& assertion) {
+        const std::string script = "pm.test(\"t\", function() {\n" + assertion + ";\n});";
+        auto result = engine.execute_test (script, request, response, env);
+        if (result.tests.size () != 1u) {
+            return "<no test recorded for: " + assertion + ">";
+        }
+        if (result.tests[0].passed) {
+            return "<passed, expected a failure: " + assertion + ">";
+        }
+        return result.tests[0].error_message;
+    }
+
+    static bool contains (const std::string& haystack, const std::string& needle) {
+        return haystack.find (needle) != std::string::npos;
+    }
+};
+
+/**
+ * The owner's repro from #484: the message the script wrote reaches the report,
+ * and the generic text it explains is still there. Both halves matter - a fix
+ * that replaced the matcher's own text with the custom message would lose what
+ * actually failed.
+ */
+TEST_F (ExpectMessageTest, TheCustomMessagePrefixesTheGenericFailure) {
+    const std::string reported =
+    failure_of (R"(pm.expect(false, "this is the MCP-path gap").to.be.true)");
+
+    EXPECT_TRUE (contains (reported, "this is the MCP-path gap")) << reported;
+    EXPECT_TRUE (contains (reported, "Expected value to be truthy")) << reported;
+    // chai's order and separator: the context, then what went wrong.
+    EXPECT_TRUE (contains (reported, "this is the MCP-path gap: Expected value to be truthy"))
+    << reported;
+}
+
+/**
+ * Every matcher, because the helper they share is only load-bearing if they all
+ * go through it. One chain per assertion-failure site in the expectation
+ * surface; `equal` and `eql` share a site and are both listed because the
+ * message they build differs.
+ */
+TEST_F (ExpectMessageTest, EveryMatcherCarriesTheMessage) {
+    struct Case {
+        const char* assertion;
+        const char* generic; // a fragment of the matcher's own failure text
+    };
+
+    const Case cases[] = {
+        { R"(pm.expect(1, "M").to.equal(2))", "to equal" },
+        { R"(pm.expect({ a: 1 }, "M").to.eql({ a: 2 }))", "deeply equal" },
+        { R"(pm.expect(undefined, "M").to.exist)", "to exist" },
+        { R"(pm.expect(false, "M").to.be.true)", "truthy" },
+        { R"(pm.expect(true, "M").to.be.false)", "to be false" },
+        { R"(pm.expect(1, "M").to.be.above(2))", "to be above" },
+        { R"(pm.expect(2, "M").to.be.below(1))", "to be below" },
+        { R"(pm.expect([1], "M").to.include(2))", "to include" },
+        { R"(pm.expect({}, "M").to.have.property("a"))", "to have property" },
+        { R"(pm.expect(1, "M").to.be.null)", "to be null" },
+        { R"(pm.expect(1, "M").to.be.undefined)", "to be undefined" },
+        { R"(pm.expect(0, "M").to.be.ok)", "truthy" },
+        { R"(pm.expect([1], "M").to.be.empty)", "to be empty" },
+        { R"(pm.expect(1, "M").to.be.at.least(2))", "at least" },
+        { R"(pm.expect(3, "M").to.be.at.most(2))", "at most" },
+        { R"(pm.expect([1], "M").to.have.length(2))", "Expected length" },
+        { R"(pm.expect(1, "M").to.be.a("string"))", "Expected type" },
+        { R"(pm.expect("abc", "M").to.match(/z/))", "to match the pattern" },
+        { R"(pm.expect(1, "M").to.be.oneOf([2, 3]))", "to be one of" },
+        { R"(pm.expect({ a: 1 }, "M").to.have.keys("b"))", "exactly the keys" },
+        { R"(pm.expect([1], "M").to.have.members([2]))", "to have members" },
+        { R"(pm.expect(function () {}, "M").to.throw())", "to throw" },
+        { R"(pm.expect({}, "M").to.be.instanceOf(Array))", "instance of" },
+        { R"(pm.expect(1, "M").to.be.closeTo(5, 0.1))", "to be within" },
+        { R"(pm.expect(1, "M").to.satisfy(function (v) { return v > 2; }))", "satisfy the predicate" },
+        { R"(pm.expect("abc", "M").to.have.string("z"))", "to contain" },
+    };
+
+    for (const auto& c : cases) {
+        const std::string reported = failure_of (c.assertion);
+        // Every matcher's own text opens with "Expected", so the prefix and
+        // what it explains are adjacent - checking them apart would pass on a
+        // message appended somewhere else in the report.
+        EXPECT_TRUE (contains (reported, "M: Expected")) << c.assertion << " -> " << reported;
+        EXPECT_TRUE (contains (reported, c.generic)) << c.assertion << " -> " << reported;
+    }
+}
+
+// The flags a chain sets do not change who reports the failure, so the message
+// has to survive them - a negated or continued chain is where a loop's
+// assertions usually live.
+TEST_F (ExpectMessageTest, TheMessageSurvivesNegationAndChaining) {
+    EXPECT_TRUE (contains (failure_of (R"(pm.expect(1, "M").to.not.equal(1))"),
+    "M: Expected 1 to not equal 1"))
+    << failure_of (R"(pm.expect(1, "M").to.not.equal(1))");
+
+    EXPECT_TRUE (contains (
+    failure_of (R"(pm.expect(5, "M").to.be.above(1).and.to.be.below(3))"), "M: Expected 5"));
+}
+
+// The one-argument form is the overwhelming majority of scripts in the wild and
+// its report must read exactly as it did before the message existed - no stray
+// separator, no empty prefix.
+TEST_F (ExpectMessageTest, TheOneArgumentFormIsUnchanged) {
+    // Whole-string equality rather than a substring: what this pins is that
+    // nothing was added, which a `contains` cannot see.
+    EXPECT_EQ (failure_of (R"(pm.expect(false).to.be.true)"),
+    "TypeError: Expected value to be truthy");
+    EXPECT_EQ (failure_of (R"(pm.expect(1).to.equal(2))"), "TypeError: Expected 1 to equal 2");
+}
+
+// chai coerces the message instead of demanding a string, and a caller that
+// builds one conditionally spells "none" as `undefined` or `null`. Both are the
+// no-prefix path, so a computed message that came out empty cannot leave a bare
+// ": " in front of the failure.
+TEST_F (ExpectMessageTest, ANonStringMessageIsCoercedAndAnAbsentOneIsNotPrefixed) {
+    EXPECT_TRUE (contains (failure_of (R"(pm.expect(false, 42).to.be.true)"),
+    "42: Expected value to be truthy"));
+    EXPECT_TRUE (contains (failure_of (R"(pm.expect(false, { a: 1 }).to.be.true)"),
+    "[object Object]: Expected value to be truthy"));
+
+    for (const char* absent : { R"(pm.expect(false, undefined).to.be.true)",
+         R"(pm.expect(false, null).to.be.true)", R"(pm.expect(false, "").to.be.true)" }) {
+        EXPECT_EQ (failure_of (absent), "TypeError: Expected value to be truthy") << absent;
+    }
+}
+
+// A message that cannot be converted is a script bug, and swallowing it would
+// hide it behind whatever the assertion reported next - including a PASS, when
+// the assertion holds.
+TEST_F (ExpectMessageTest, AMessageThatCannotBeConvertedFailsLoudly) {
+    auto result = engine.execute_test (
+    R"(pm.test("t", function() { pm.expect(true, Symbol("s")).to.be.true; });)",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_FALSE (result.tests[0].passed)
+    << "a symbol message must not be dropped silently";
+    EXPECT_TRUE (contains (result.tests[0].error_message, "symbol"))
+    << result.tests[0].error_message;
+}
+
+// A passing assertion is a passing assertion; the message is failure-only, so
+// carrying one must not change the result or leave anything in the report.
+TEST_F (ExpectMessageTest, APassingTwoArgumentAssertionBehavesLikeTheOneArgumentForm) {
+    auto result = engine.execute_test (R"(
+        pm.test("two-arg passes", function() {
+            pm.expect(pm.response.code, "status").to.equal(200);
+            pm.expect(pm.response.json(), "body").to.have.property("id");
+        });
+    )",
+    request, response, env);
+
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests[0].passed) << result.tests[0].error_message;
+    EXPECT_TRUE (result.tests[0].error_message.empty ());
+}
+
+// The documented boundary: a message explains a value that failed, not a call
+// the script wrote wrong. A usage error names the matcher that rejected it,
+// which is the information needed to fix the script, and it is reported
+// unprefixed so the two kinds stay distinguishable in a report.
+TEST_F (ExpectMessageTest, AUsageErrorIsReportedWithoutThePrefix) {
+    const std::string reported = failure_of (R"(pm.expect(1, "M").to.be.above())");
+    EXPECT_TRUE (contains (reported, "above() requires an argument")) << reported;
+    EXPECT_FALSE (contains (reported, "M: ")) << reported;
+}
+
+} // namespace

--- a/engine/tests/script_types_test.cpp
+++ b/engine/tests/script_types_test.cpp
@@ -129,7 +129,7 @@ TEST (ScriptTypesTest, ChainContinuationsReturnTheChain) {
     const std::string dts = generate_script_typedefs ();
     // `expect` opens the chain, `.and` continues it, `.not` re-enters the `to`
     // node it sits in - none of which the table says.
-    EXPECT_TRUE (contains (dts, "expect(value: any): VayuExpectation;"));
+    EXPECT_TRUE (contains (dts, "expect(value: any, message?: string): VayuExpectation;"));
     EXPECT_TRUE (contains (dts, "and: VayuExpectation;"));
     EXPECT_TRUE (contains (dts, "not: VayuExpectTo;"));
     EXPECT_TRUE (contains (dts, "interface VayuExpectTo {"));


### PR DESCRIPTION
## Description

**Root cause.** Verified still live at `2b86476`, exactly as the issue describes (the issue anchored at `c21f562`; the region is unchanged since). `js_pm_expect` called `create_expectation (ctx, argv[0])` - a second argument was accepted by the JS calling convention and silently discarded, and no matcher had anywhere to read one from, since each builds its own failure text and throws it directly. So `pm.expect(value, "this is the MCP-path gap").to.be.true` failed with the bare `Expected value to be truthy`: the script's own words, written precisely to make the failure self-explaining, existed nowhere in the report. The editor half is the same defect one layer out - the generated `.d.ts` declares what the runtime accepts, so `expect(value: any)` was a faithful description of the deficient runtime, and Monaco red-lined the valid call with TS2554.

**Approach.** The message lives on `ExpectState`, and every matcher's failure throw goes through one helper, `throw_expect_failure (ctx, state, msg)`, which applies chai's `message: ` prefix. That single seam is the point rather than a convenience: the alternative - each of the 25 failure sites concatenating its own prefix - is the hand-rolled-copy shape this repo documents, and the 26th matcher would report a bare message by forgetting one line. The sites already shared a pattern (`JS_ThrowTypeError (ctx, "%s", msg)` with `state` in scope), so routing them is mechanical and the helper is the only thing that knows the prefix rule exists.

**Rejected:** intercepting at the install point instead - wrapping every matcher in a thunk that catches the exception and rewrites its message. It covers even a matcher added later without touching it, which is genuinely more robust, and it is wrong here: the only way to prefix a caught exception is to rewrite the error object, which would also rewrite errors that are not the matcher's - a `satisfy` predicate's own throw, a `throw()` target's error - relabelling a user's error with an assertion's context. One rule that is honest about which throws it owns beat one rule that owns throws it cannot identify.

**The scope boundary, stated because it is a decision and not an omission:** usage errors (`.to.be.above()` with no argument, `.to.have.members()` against a non-array) do **not** get the prefix. chai does prefix those, and the divergence is deliberate - they report a mistake in the script *text*, not a verdict on the value under test, and their message already names the matcher that rejected the call, which is the information needed to fix the script. Keeping them unprefixed keeps the two kinds distinguishable in a report. Pinned by a test and stated in both docs.

**Message coercion follows chai:** a non-string is coerced (`42` -> `42: Expected ...`), and `undefined` / `null` mean "no message" - which is how a caller that builds one conditionally spells absence, so a computed message that came out empty cannot leave a bare `": "` in front of the failure. A value whose conversion throws (a Symbol, a throwing `toString`) propagates the exception rather than being swallowed into an empty prefix: silently dropping it would hide the bug behind whatever the assertion reported next, **including a PASS** when the assertion holds.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **1240/1240 passed** (1232 before, +8).
- `cd app && pnpm test`: **3805 passed, 380 files** - the run that matters is the #463 docs-compile guard, since the new two-arg example in `docs/engine/scripting.md` now compiles against the regenerated declarations.
- `cd app && pnpm type-check`: clean.
- `python -m mkdocs build --strict -f .github/mkdocs.yml`: clean.
- `git clang-format --diff origin/master`: no changes (the two touched source files have pre-existing violations elsewhere, left alone).
- No pre-existing failures encountered on the base commit.

**8 new engine tests** (`script_expect_message_test.cpp`), assertions on the reported error text:

- the owner's repro: the message and the generic text are both in the report, in chai's order and separator - a fix that *replaced* the matcher text with the message would lose what actually failed;
- **every matcher** - 26 chains over the 25 failure sites (`equal` and `eql` share a site and build different text). A test that checked one matcher would be blind to a matcher that threw around the helper;
- the message survives `not` and `.and`, which is where a loop's assertions live;
- the one-arg form is **byte-identical** to before - whole-string equality, not `contains`, because what it pins is that nothing was added;
- coercion and the two absent spellings;
- a Symbol message fails loudly rather than being dropped;
- a passing two-arg assertion passes with an empty error, like the one-arg form;
- a usage error is reported without the prefix.

**Mutation-checked**: making `throw_expect_failure` ignore `state->message` fails **4** of the 8 (the repro, the 26-chain sweep, the chaining test, the coercion test); the other 4 are the boundary tests, which must stay green under the mutation and do.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

**App changes: none, as the issue predicted, and verified rather than assumed.** Monaco consumes the declarations and completions from the engine's `GET /scripting/*` routes; no renderer code names the expect arity (`script-completion-insert.ts` / `script-completion-range.ts` operate on the completion payload generically, and the snippet is unchanged - it stays one-arg, the common case). The two app-side tests that could move are the docs-compile guard and the completion tests; both were run in the full suite above.

One engine test was updated rather than added: `ScriptTypesTest.ChainContinuationsReturnTheChain` asserted the old `expect(value: any): VayuExpectation;` line. That declaration is what this issue changes, so the assertion moves with it. The checked-in `script-typedefs.d.ts` was regenerated the documented way (`VAYU_UPDATE_SCRIPT_TYPEDEFS=1`), not hand-edited.

Docs updated in the same commit:

- `docs/engine/scripting.md` - the `pm.expect` section gains the `(value, message?)` form, a failing example showing the exact report line, and the coercion and usage-error boundaries.
- `docs/app/pm-api-compatibility.md` - the Core row and the assertion-chains section, since the two-arg form is core Postman usage and this page is the compatibility surface.

Both examples are fenced `javascript` blocks containing `pm.`, so they are now part of the #463 compile-the-docs corpus - the exact regression this fixes becomes a compile failure if the declaration ever narrows again, which is what the issue asked for.

## Related Issues
Closes #484

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvWT6T9dEFAB3YSgsXbSFr)_