### PR TITLE
feat(engine/app): capacity-discovery run mode

### DIFF
--- a/app/electron/mcp/safety.test.ts
+++ b/app/electron/mcp/safety.test.ts
@@ -248,3 +248,34 @@ describe("defaultDurationUnderCap", () => {
 		expect(defaultDurationUnderCap({ mode: "iterations", iterations: 10 }, config)).toBeNull();
 	});
 });
+
+describe("capacity discovery", () => {
+	const config = resolveSafetyConfig({ maxConcurrency: 500, maxDurationSeconds: 300 });
+
+	test("caps the ceiling the search climbs toward, not just a fixed target", () => {
+		// `concurrency` is the ceiling in this mode rather than a level held, so
+		// it is exactly the field that decides how large the run can get.
+		expect(checkLoadCaps({ mode: "capacity", concurrency: 5000 }, config).ok).toBe(false);
+		expect(checkLoadCaps({ mode: "capacity", startConcurrency: 5000 }, config).ok).toBe(false);
+		expect(
+			checkLoadCaps({ mode: "capacity", startConcurrency: 4, concurrency: 256 }, config).ok
+		).toBe(true);
+	});
+
+	test("rejects a step duration the engine cannot read", () => {
+		// It goes through the same string parser `duration` does, so a value the
+		// engine would throw on has to fail here rather than at run time.
+		expect(checkLoadCaps({ mode: "capacity", stepDuration: "a bit" }, config).ok).toBe(false);
+		expect(checkLoadCaps({ mode: "capacity", stepDuration: "5s" }, config).ok).toBe(true);
+	});
+
+	test("is a duration mode, so the duration cap still reaches it", () => {
+		// The guard mirrors `LoadStrategy::create`: an unrecognised mode with no
+		// `iterations` falls through to a duration strategy. `capacity` is a
+		// duration mode either way - the check is that adding it to the known
+		// set did not accidentally route it to the iterations branch, which
+		// takes no duration cap at all.
+		const tight = resolveSafetyConfig({ maxDurationSeconds: 30 });
+		expect(defaultDurationUnderCap({ mode: "capacity" }, tight)).toBe("30s");
+	});
+});

--- a/app/electron/mcp/safety.test.ts
+++ b/app/electron/mcp/safety.test.ts
@@ -5,6 +5,9 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
 	extractHost,
@@ -277,5 +280,48 @@ describe("capacity discovery", () => {
 		// takes no duration cap at all.
 		const tight = resolveSafetyConfig({ maxDurationSeconds: 30 });
 		expect(defaultDurationUnderCap({ mode: "capacity" }, tight)).toBe("30s");
+	});
+
+	test("caps an omitted duration against this mode's own engine default", () => {
+		// The regression: `capacity` falls back to 300s engine-side, not the 60s
+		// every other mode uses. A 120s cap is *above* 60 and *below* 300, so a
+		// guard keyed on one default injected nothing and let the search run
+		// 2.5x over the ceiling. `checkLoadCaps` cannot catch it either - with
+		// `duration` omitted there is nothing for it to check.
+		const cap = resolveSafetyConfig({ maxDurationSeconds: 120 });
+		expect(defaultDurationUnderCap({ mode: "capacity" }, cap)).toBe("120s");
+		// The same cap over a 60s-default mode still needs no field.
+		expect(defaultDurationUnderCap({ mode: "constant_concurrency" }, cap)).toBeNull();
+	});
+
+	test("supplies nothing once the cap clears the capacity default", () => {
+		const roomy = resolveSafetyConfig({ maxDurationSeconds: 600 });
+		expect(defaultDurationUnderCap({ mode: "capacity" }, roomy)).toBeNull();
+	});
+
+	test("mirrors the engine's own capacity deadline", () => {
+		// A drift guard, not a restatement: the number above is only a cap if it
+		// is the number the engine actually falls back to, and nothing else
+		// connects the two files. Same pattern as
+		// `src/constants/load-test.engine-parity.test.ts`.
+		const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+		const constantsHpp = readFileSync(
+			join(repoRoot, "engine", "include", "vayu", "core", "constants.hpp"),
+			"utf8"
+		);
+		// CLAUDE.md's documented failure mode: a source scan reading "" passes.
+		expect(constantsHpp.length).toBeGreaterThan(0);
+
+		const match = constantsHpp.match(/constexpr\s+int64_t\s+DEADLINE_MS\s*=\s*(\d+);/);
+		expect(match, "capacity::DEADLINE_MS not found in constants.hpp").not.toBeNull();
+		const engineSeconds = Number(match![1]) / 1000;
+
+		// Read through the exported behaviour rather than the private table: a
+		// cap one second under the engine's default must produce a field, and a
+		// cap exactly at it must not.
+		const under = resolveSafetyConfig({ maxDurationSeconds: engineSeconds - 1 });
+		const at = resolveSafetyConfig({ maxDurationSeconds: engineSeconds });
+		expect(defaultDurationUnderCap({ mode: "capacity" }, under)).toBe(`${engineSeconds - 1}s`);
+		expect(defaultDurationUnderCap({ mode: "capacity" }, at)).toBeNull();
 	});
 });

--- a/app/electron/mcp/safety.ts
+++ b/app/electron/mcp/safety.ts
@@ -142,6 +142,7 @@ export interface LoadRunParams {
 	startConcurrency?: number;
 	duration?: string | number;
 	rampUpDuration?: string | number;
+	stepDuration?: string | number;
 	iterations?: number;
 }
 
@@ -150,7 +151,13 @@ export interface LoadRunParams {
  * Anything else falls through `LoadStrategy::create`, so the guard mirrors that
  * fallback rather than trusting the string it was given.
  */
-const KNOWN_LOAD_MODES = new Set(["constant_rps", "constant_concurrency", "ramp_up", "iterations"]);
+const KNOWN_LOAD_MODES = new Set([
+	"constant_rps",
+	"constant_concurrency",
+	"ramp_up",
+	"iterations",
+	"capacity",
+]);
 
 /**
  * What the engine runs when `duration` is absent - `duration_field_ms(config,
@@ -209,7 +216,10 @@ export function checkLoadCaps(params: LoadRunParams, config: McpSafetyConfig): G
 	}
 	// `startConcurrency` rides the same ceiling as `concurrency`: `ramp_up` seeds
 	// the run with it (`RampUpLoadStrategy`, `target_fn(0) = startConcurrency`),
-	// so an uncapped start is an uncapped run however low the target is.
+	// so an uncapped start is an uncapped run however low the target is. For
+	// `capacity` the same pair is what bounds the search - `concurrency` is the
+	// ceiling it climbs toward rather than a target it holds - so capping both
+	// is exactly what stops an adaptive run from outgrowing the cap.
 	for (const field of ["concurrency", "startConcurrency"] as const) {
 		const value = params[field];
 		if (typeof value === "number" && value > config.maxConcurrency) {
@@ -221,7 +231,7 @@ export function checkLoadCaps(params: LoadRunParams, config: McpSafetyConfig): G
 	}
 	// A duration the engine cannot read now fails the run rather than quietly
 	// becoming 60s, so say so here instead of starting a run that dies.
-	for (const field of ["duration", "rampUpDuration"] as const) {
+	for (const field of ["duration", "rampUpDuration", "stepDuration"] as const) {
 		const value = params[field];
 		if (value !== undefined && parseDurationGrammar(value) === null) {
 			return {

--- a/app/electron/mcp/safety.ts
+++ b/app/electron/mcp/safety.ts
@@ -160,11 +160,32 @@ const KNOWN_LOAD_MODES = new Set([
 ]);
 
 /**
- * What the engine runs when `duration` is absent - `duration_field_ms(config,
- * "duration", 60000)` in `load_strategy.cpp`. An omitted duration is therefore
- * not "no duration", and a cap below this one only binds if the field is sent.
+ * What the engine runs when `duration` is absent, **per mode**.
+ *
+ * An omitted duration is not "no duration": each strategy passes its own
+ * fallback to `duration_field_ms`, so a cap only binds when the field is sent
+ * *or* when the cap is under the default the engine would otherwise use.
+ *
+ * This was a single number, on the assumption that every mode falls back to
+ * 60s. `capacity` does not - it walks a level every `stepDuration`, so its
+ * `constants::capacity::DEADLINE_MS` is 300s - and the assumption became a
+ * hole: with the cap set to 120s and an agent omitting `duration`,
+ * `checkLoadCaps` had nothing to check and this function returned null because
+ * 120 >= 60, so the search ran for 300s against a 120s cap. Keyed by mode, the
+ * guard now models what the engine actually does rather than one mode's version
+ * of it, and `safety.test.ts` reads `constants.hpp` to keep the numbers in step.
  */
-const ENGINE_DEFAULT_DURATION_SECONDS = 60;
+const ENGINE_DEFAULT_DURATION_SECONDS: Readonly<Record<string, number>> = {
+	capacity: 300,
+};
+
+/** The fallback for every mode that has no entry of its own. */
+const ENGINE_FALLBACK_DURATION_SECONDS = 60;
+
+/** What the engine would run for, in seconds, if `duration` were omitted. */
+function engineDefaultDurationSeconds(mode: string): number {
+	return ENGINE_DEFAULT_DURATION_SECONDS[mode] ?? ENGINE_FALLBACK_DURATION_SECONDS;
+}
 
 /** What the engine runs when `iterations` is absent (`IterationsLoadStrategy`). */
 const ENGINE_DEFAULT_ITERATIONS = 1000;
@@ -196,7 +217,11 @@ export function defaultDurationUnderCap(
 ): string | null {
 	if (params.duration !== undefined) return null;
 	if (isIterationsRun(params)) return null;
-	if (config.maxDurationSeconds >= ENGINE_DEFAULT_DURATION_SECONDS) return null;
+	// The engine's own default for an absent `mode` is a duration mode, and the
+	// same string `isIterationsRun` reads - the two must agree about which run
+	// this is or the cap lands on the wrong strategy.
+	const mode = params.mode ?? "constant_rps";
+	if (config.maxDurationSeconds >= engineDefaultDurationSeconds(mode)) return null;
 	return `${config.maxDurationSeconds}s`;
 }
 

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1759,7 +1759,7 @@ export const TOOLS: McpTool[] = [
 			mode: z
 				.string()
 				.optional()
-				.describe("constant_rps | constant_concurrency | ramp_up | iterations."),
+				.describe("constant_rps | constant_concurrency | ramp_up | iterations | capacity."),
 			// Positive, because an agent's natural guess for "unlimited" is -1 or
 			// 0, and the engine reads concurrency as an eager per-worker
 			// pre-allocation count. It rejects those with a 400; failing here
@@ -1789,6 +1789,23 @@ export const TOOLS: McpTool[] = [
 				.string()
 				.optional()
 				.describe("Ramp time (ramp_up), same units as `duration`."),
+			// Capacity discovery reuses `startConcurrency` (where the search
+			// begins), `concurrency` (the ceiling it will not climb past) and
+			// `duration` (the whole search's deadline), so it adds only these
+			// two. The `sloMs` bound is the engine's, so a value this schema
+			// accepts is one POST /runs accepts.
+			sloMs: z
+				.number()
+				.positive()
+				.max(60_000)
+				.optional()
+				.describe("p99 budget the capacity search looks for the edge of, in ms."),
+			stepDuration: z
+				.string()
+				.optional()
+				.describe(
+					"How long each concurrency level is held before it is judged (capacity), same units as `duration`."
+				),
 			// An iterations run stops on this count and reads no duration, so it
 			// is the only thing bounding the run; `-1` would cast to ~1.8e19.
 			iterations: z
@@ -1872,6 +1889,7 @@ export const TOOLS: McpTool[] = [
 				iterations: typeof args.iterations === "number" ? args.iterations : undefined,
 				duration: (args.duration as string | number | undefined) ?? undefined,
 				rampUpDuration: (args.rampUpDuration as string | number | undefined) ?? undefined,
+				stepDuration: (args.stepDuration as string | number | undefined) ?? undefined,
 			};
 			const caps = checkLoadCaps(loadParams, ctx.config);
 			if (!caps.ok) return errorResult(caps.error!);
@@ -1886,10 +1904,11 @@ export const TOOLS: McpTool[] = [
 				"iterations",
 				"targetRps",
 				"maxInFlight",
+				"sloMs",
 			]) {
 				if (typeof args[key] === "number") payload[key] = args[key];
 			}
-			for (const key of ["duration", "rampUpDuration"]) {
+			for (const key of ["duration", "rampUpDuration", "stepDuration"]) {
 				const v = str(args, key);
 				if (v !== undefined) payload[key] = v;
 			}

--- a/app/src/components/shared/CapacitySummary.test.tsx
+++ b/app/src/components/shared/CapacitySummary.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The capacity card exists to answer "what can my service take" without the
+ * reader assembling it from a stat grid, so the ways it could mislead are the
+ * cases worth pinning: claiming a sustained capacity for a search that found
+ * none, naming a knee for a run that never watched the target give out, or
+ * showing anything at all for a mode that never looked.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { CapacitySummary } from "./CapacitySummary";
+import type { RunReport } from "@/types/domain";
+
+type Capacity = NonNullable<RunReport["capacity"]>;
+
+const capacity = (over: Partial<Capacity> = {}): Capacity => ({
+	sloMs: 200,
+	stopReason: "slo_exceeded",
+	maxHealthyConcurrency: 48,
+	maxHealthyRps: 23400,
+	p99AtMaxHealthyMs: 41.2,
+	kneeConcurrency: 64,
+	kneeP99Ms: 312,
+	levels: [
+		{ concurrency: 48, rps: 23400, p99Ms: 41.2 },
+		{ concurrency: 64, rps: 23000, p99Ms: 312 },
+	],
+	...over,
+});
+
+describe("CapacitySummary", () => {
+	it("renders nothing for a run that was not a capacity search", () => {
+		// Every fixed-target run is this run: it measured a point, not a curve,
+		// and an empty shell would claim it looked for a limit and found none.
+		const { container } = render(<CapacitySummary capacity={undefined} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("states the sustained capacity and the level that gave out", () => {
+		render(<CapacitySummary capacity={capacity()} />);
+		const headline = screen.getByText(/Sustained/).textContent ?? "";
+		expect(headline).toContain("48");
+		expect(headline).toContain("23,400");
+		expect(headline).toContain("41.2ms");
+		expect(headline).toContain("200ms budget");
+
+		const knee = screen.getByText(/It gave out at/).textContent ?? "";
+		expect(knee).toContain("64");
+		expect(knee).toContain("312ms");
+		cleanup();
+	});
+
+	it("says no level held rather than reporting a capacity of zero", () => {
+		// The first level already breached, so `maxHealthy*` is absent. Rendering
+		// it as 0 would read as a service that sustains nothing at all - a
+		// different and much stronger claim than "we never found a level under
+		// the budget".
+		render(
+			<CapacitySummary
+				capacity={capacity({
+					maxHealthyConcurrency: undefined,
+					maxHealthyRps: undefined,
+					p99AtMaxHealthyMs: undefined,
+				})}
+			/>
+		);
+		expect(screen.getByText(/No level met the 200ms budget/)).toBeTruthy();
+		expect(screen.queryByText(/Sustained/)).toBeNull();
+		cleanup();
+	});
+
+	it("omits the knee for a search that never watched the target break", () => {
+		render(
+			<CapacitySummary
+				capacity={capacity({
+					stopReason: "cap_reached",
+					kneeConcurrency: undefined,
+					kneeP99Ms: undefined,
+					levels: [{ concurrency: 48, rps: 23400, p99Ms: 41.2 }],
+				})}
+			/>
+		);
+		expect(screen.queryByText(/It gave out at/)).toBeNull();
+		expect(screen.getByText("Reached the concurrency ceiling")).toBeTruthy();
+		cleanup();
+	});
+
+	it("shows a stop reason it has no words for rather than dropping it", () => {
+		// A newer sidecar may stop for a reason this build predates; the levels
+		// below still say what happened, so the badge falls back to the raw key.
+		render(<CapacitySummary capacity={capacity({ stopReason: "thermal_throttle" })} />);
+		expect(screen.getByText("thermal_throttle")).toBeTruthy();
+		cleanup();
+	});
+
+	it("keeps a re-measured level as its own row in the audit trail", () => {
+		// A level that breached once and was held to re-measure appears twice.
+		// Keying the table by concurrency would collapse the pair and lose the
+		// evidence for why the search stopped where it did.
+		const { container } = render(
+			<CapacitySummary
+				capacity={capacity({
+					levels: [
+						{ concurrency: 48, rps: 23400, p99Ms: 41.2 },
+						{ concurrency: 64, rps: 23000, p99Ms: 300 },
+						{ concurrency: 64, rps: 22800, p99Ms: 312 },
+					],
+				})}
+			/>
+		);
+		const rows = Array.from(container.querySelectorAll("tbody tr"));
+		expect(rows).toHaveLength(3);
+		expect(rows.map((row) => row.querySelector("td")?.textContent)).toEqual(["48", "64", "64"]);
+		cleanup();
+	});
+
+	it("marks only the levels that broke the budget", () => {
+		const { container } = render(<CapacitySummary capacity={capacity()} />);
+		const cells = Array.from(container.querySelectorAll("td"));
+		const p99Cells = cells.filter((cell) => cell.textContent?.endsWith("ms"));
+		expect(p99Cells).toHaveLength(2);
+		// Mutation check: compare against `>=` instead of `>` and the healthy
+		// 41.2ms row starts wearing the warning colour too.
+		expect(p99Cells[0].className).not.toContain("text-warning-text");
+		expect(p99Cells[1].className).toContain("text-warning-text");
+		cleanup();
+	});
+});

--- a/app/src/components/shared/CapacitySummary.test.tsx
+++ b/app/src/components/shared/CapacitySummary.test.tsx
@@ -124,6 +124,33 @@ describe("CapacitySummary", () => {
 		cleanup();
 	});
 
+	it("claims no measurement when the search judged nothing", () => {
+		// `stepDuration` longer than `duration` - both accepted by the dialog and
+		// the engine - ends the run before the first level closes. The engine
+		// still reports the section (that the search judged nothing is itself
+		// the finding), with `levels: []` and no `maxHealthy*`. Falling into the
+		// "no level met the budget" branch would claim the target breached at
+		// the lowest concurrency tried, contradicting the badge beside it.
+		render(
+			<CapacitySummary
+				capacity={capacity({
+					stopReason: "deadline",
+					maxHealthyConcurrency: undefined,
+					maxHealthyRps: undefined,
+					p99AtMaxHealthyMs: undefined,
+					kneeConcurrency: undefined,
+					kneeP99Ms: undefined,
+					levels: [],
+				})}
+			/>
+		);
+		expect(screen.getByText(/nothing to report about this target/)).toBeTruthy();
+		expect(screen.queryByText(/No level met/)).toBeNull();
+		expect(screen.queryByText(/Sustained/)).toBeNull();
+		expect(screen.getByText("Ran out of time")).toBeTruthy();
+		cleanup();
+	});
+
 	it("marks only the levels that broke the budget", () => {
 		const { container } = render(<CapacitySummary capacity={capacity()} />);
 		const cells = Array.from(container.querySelectorAll("td"));

--- a/app/src/components/shared/CapacitySummary.test.tsx
+++ b/app/src/components/shared/CapacitySummary.test.tsx
@@ -162,4 +162,15 @@ describe("CapacitySummary", () => {
 		expect(p99Cells[1].className).toContain("text-warning-text");
 		cleanup();
 	});
+
+	it("paints the stop-reason chip through the Badge primitive, radius included", () => {
+		// Same guard as `ThresholdVerdict`'s, for the same reason: the colour is
+		// bound from `stop.degraded`, so only a render can see the class list,
+		// and a missing radius class is invisible to any source scan.
+		render(<CapacitySummary capacity={capacity()} />);
+		const chip = screen.getByText("Latency budget exceeded");
+		expect(chip.className).toMatch(/\brounded-(sm|md|lg)\b/);
+		expect(chip.className).toContain("text-warning-text");
+		cleanup();
+	});
 });

--- a/app/src/components/shared/CapacitySummary.tsx
+++ b/app/src/components/shared/CapacitySummary.tsx
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What a capacity-discovery run found: the highest concurrency the target held
+ * inside its latency budget, the level it gave out at, and the per-level trail
+ * the search left behind.
+ *
+ * The headline is a sentence rather than a stat grid because the mode exists to
+ * answer one question in words - "what can my service take" - and four numbers
+ * side by side make the reader assemble that answer themselves. The levels
+ * table below it is the evidence, so a reader who distrusts the headline can
+ * see the shape of the curve it came from.
+ *
+ * Silent for every other mode. A fixed-target run measured a point rather than
+ * a curve, so an empty shell here would imply it looked for a limit and found
+ * none.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import type { RunReport } from "@/types/domain";
+
+/**
+ * Why the search stopped, in words, and whether that reading is bad news.
+ *
+ * `slo_exceeded` is the only stop that observed the target give out - the rest
+ * ended on a bound the *caller* set, which is not a fault. Unknown reasons
+ * render under their raw key rather than vanishing: a newer sidecar may stop
+ * for a reason this build has no words for, and the levels below still say what
+ * happened.
+ */
+const STOP_REASONS: Record<string, { label: string; detail: string; degraded: boolean }> = {
+	slo_exceeded: {
+		label: "Latency budget exceeded",
+		detail: "p99 stayed above the budget across two consecutive windows.",
+		degraded: true,
+	},
+	plateau: {
+		label: "Throughput plateaued",
+		detail: "More concurrency stopped buying more throughput, while latency still held.",
+		degraded: true,
+	},
+	cap_reached: {
+		label: "Reached the concurrency ceiling",
+		detail: "The target held its budget all the way up. Raise the ceiling to find the limit.",
+		degraded: false,
+	},
+	deadline: {
+		label: "Ran out of time",
+		detail: "The run's deadline passed before the search found a limit.",
+		degraded: false,
+	},
+	stopped: {
+		label: "Stopped by hand",
+		detail: "The run was stopped before the search reached a conclusion.",
+		degraded: false,
+	},
+};
+
+/** Trailing zeros are noise on a latency the search measured to the ms. */
+function formatMs(value: number): string {
+	return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function formatRps(value: number): string {
+	return Math.round(value).toLocaleString("en-US");
+}
+
+export interface CapacitySummaryProps {
+	capacity: RunReport["capacity"];
+	className?: string;
+}
+
+export function CapacitySummary({ capacity, className }: CapacitySummaryProps) {
+	if (!capacity) return null;
+
+	const stop = STOP_REASONS[capacity.stopReason];
+	const sustained = capacity.maxHealthyConcurrency !== undefined;
+
+	return (
+		<Card className={className}>
+			<CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+				<CardTitle className="text-base">Capacity</CardTitle>
+				{/*
+				 * Text on a tint, never the bare `--status-*` fill as a
+				 * foreground - the three-token rule (docs/design-system.md,
+				 * "Status tokens").
+				 */}
+				<span
+					className={cn(
+						"px-2 py-0.5 text-xs font-medium",
+						stop?.degraded
+							? "bg-warning/10 text-warning-text"
+							: "bg-status-success/10 text-status-success-text"
+					)}
+				>
+					{stop?.label ?? capacity.stopReason}
+				</span>
+			</CardHeader>
+			<CardContent>
+				<p className="text-sm text-foreground">
+					{sustained ? (
+						<>
+							Sustained{" "}
+							<span className="font-mono font-semibold">
+								{capacity.maxHealthyConcurrency}
+							</span>{" "}
+							concurrent connections at{" "}
+							<span className="font-mono font-semibold">
+								{formatRps(capacity.maxHealthyRps ?? 0)}
+							</span>{" "}
+							req/s, with a p99 of{" "}
+							<span className="font-mono font-semibold">
+								{formatMs(capacity.p99AtMaxHealthyMs ?? 0)}ms
+							</span>{" "}
+							against a {formatMs(capacity.sloMs)}ms budget.
+						</>
+					) : (
+						<>
+							No level met the {formatMs(capacity.sloMs)}ms budget - the target was
+							already over it at the lowest concurrency the search tried.
+						</>
+					)}
+				</p>
+				{capacity.kneeConcurrency !== undefined && (
+					<p className="mt-1.5 text-sm text-muted-foreground">
+						It gave out at{" "}
+						<span className="font-mono font-medium text-foreground">
+							{capacity.kneeConcurrency}
+						</span>{" "}
+						connections, where p99 reached{" "}
+						<span className="font-mono font-medium text-warning-text">
+							{formatMs(capacity.kneeP99Ms ?? 0)}ms
+						</span>
+						.
+					</p>
+				)}
+				{stop && <p className="mt-1.5 text-xs text-muted-foreground">{stop.detail}</p>}
+
+				{capacity.levels.length > 0 && (
+					<div className="mt-3 overflow-x-auto">
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="border-b border-rule text-xs text-muted-foreground">
+									<th className="py-1.5 pr-3 text-left font-medium">
+										Connections
+									</th>
+									<th className="py-1.5 pr-3 text-right font-medium">
+										Throughput
+									</th>
+									<th className="py-1.5 text-right font-medium">p99</th>
+								</tr>
+							</thead>
+							<tbody>
+								{capacity.levels.map((level, index) => {
+									const overBudget = level.p99Ms > capacity.sloMs;
+									return (
+										// Index, not concurrency: a level the search
+										// re-measured after one bad window appears
+										// twice, and that repeat is the audit trail
+										// doing its job rather than a duplicate key.
+										<tr
+											key={`${level.concurrency}-${index}`}
+											className="border-b border-rule last:border-b-0"
+										>
+											<td className="py-1.5 pr-3 font-mono">
+												{level.concurrency}
+											</td>
+											<td className="py-1.5 pr-3 text-right font-mono text-muted-foreground">
+												{formatRps(level.rps)}
+											</td>
+											<td
+												className={cn(
+													"py-1.5 text-right font-mono",
+													overBudget
+														? "text-warning-text"
+														: "text-muted-foreground"
+												)}
+											>
+												{formatMs(level.p99Ms)}ms
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/src/components/shared/CapacitySummary.tsx
+++ b/app/src/components/shared/CapacitySummary.tsx
@@ -21,7 +21,7 @@
  * none.
  */
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import { Badge, Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { RunReport } from "@/types/domain";
 
@@ -81,30 +81,53 @@ export function CapacitySummary({ capacity, className }: CapacitySummaryProps) {
 
 	const stop = STOP_REASONS[capacity.stopReason];
 	const sustained = capacity.maxHealthyConcurrency !== undefined;
+	// A search can end before its first level closed - `stepDuration` longer
+	// than `duration`, or a run stopped seconds after it started - and the
+	// engine reports the section anyway, because "judged nothing" is itself the
+	// finding that says to lengthen the run or shorten the step. Absent levels
+	// and absent `maxHealthy*` are therefore two different states, and only this
+	// flag separates them: without it the "no level met the budget" sentence
+	// below claims a measurement at the lowest concurrency that was never taken,
+	// directly contradicting the "Ran out of time" badge beside it.
+	const judgedNothing = capacity.levels.length === 0;
 
 	return (
 		<Card className={className}>
 			<CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
 				<CardTitle className="text-base">Capacity</CardTitle>
 				{/*
-				 * Text on a tint, never the bare `--status-*` fill as a
-				 * foreground - the three-token rule (docs/design-system.md,
-				 * "Status tokens").
+				 * `Badge variant="chip"`, not a hand-rolled span. The variant is
+				 * the one that lets a caller own the colour without inheriting a
+				 * `hover:bg-*` it cannot override, and going through the
+				 * primitive is also what supplies the radius: a box with no
+				 * radius class at all is pinned square for a user who chose the
+				 * Rounded setting (app/CLAUDE.md, "No bare `rounded`").
+				 *
+				 * The colour is a tint plus a `-text` token, never the bare
+				 * `--status-*` fill as a foreground - the three-token rule
+				 * (docs/design-system.md, "Status tokens").
 				 */}
-				<span
+				<Badge
+					variant="chip"
 					className={cn(
-						"px-2 py-0.5 text-xs font-medium",
+						"font-medium",
 						stop?.degraded
 							? "bg-warning/10 text-warning-text"
 							: "bg-status-success/10 text-status-success-text"
 					)}
 				>
 					{stop?.label ?? capacity.stopReason}
-				</span>
+				</Badge>
 			</CardHeader>
 			<CardContent>
 				<p className="text-sm text-foreground">
-					{sustained ? (
+					{judgedNothing ? (
+						<>
+							The search ended before it finished measuring a single level, so it has
+							nothing to report about this target. Give the run longer than one step,
+							or shorten the step.
+						</>
+					) : sustained ? (
 						<>
 							Sustained{" "}
 							<span className="font-mono font-semibold">

--- a/app/src/components/shared/ThresholdVerdict.test.tsx
+++ b/app/src/components/shared/ThresholdVerdict.test.tsx
@@ -124,4 +124,24 @@ describe("ThresholdVerdict", () => {
 		expect(screen.getByText(/≤ 0%/)).toBeInTheDocument();
 		expect(screen.getByText("0%")).toBeInTheDocument();
 	});
+
+	it("paints the verdict chip through the Badge primitive, radius included", () => {
+		// Rendered and read off `className`, not source-scanned: the colour
+		// arrives in a variable, and a box with *no* radius class is exactly
+		// what no scan can see (app/CLAUDE.md). Mutation check: revert the
+		// `<Badge variant="chip">` to the hand-rolled `<span>` this used to be
+		// and the radius assertion fails - the box was pinned square for anyone
+		// on the Rounded setting.
+		render(<ThresholdVerdict verdict={verdict({ failed: 1, passed: 0, verdict: "failed" })} />);
+		const chip = screen.getByText("Failed");
+		expect(chip.className).toMatch(/\brounded-(sm|md|lg)\b/);
+		// The tint plus a `-text` token, never the bare indicator fill as a
+		// foreground - the three-token rule the status guards enforce.
+		expect(chip.className).toContain("text-destructive-text");
+		// Lookahead, not a bare word boundary: `-` is a word boundary, so
+		// `\btext-destructive\b` matches the prefix of `text-destructive-text`
+		// and the assertion would fail on the correct token.
+		expect(chip.className).not.toMatch(/\btext-destructive(?!-text)\b/);
+		cleanup();
+	});
 });

--- a/app/src/components/shared/ThresholdVerdict.tsx
+++ b/app/src/components/shared/ThresholdVerdict.tsx
@@ -20,7 +20,7 @@
  * is the reason a run without budgets renders exactly as it did before.
  */
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import { Badge, Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { RunReport } from "@/types/domain";
 
@@ -58,21 +58,32 @@ export function ThresholdVerdict({ verdict, className }: ThresholdVerdictProps) 
 			<CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
 				<CardTitle className="text-base">Pass/fail budgets</CardTitle>
 				{/*
-				 * Text, not a solid chip: `--status-*` is an indicator token and
-				 * fails contrast as a label, so the three-token rule sends the
-				 * word to `-text` and leaves the fill to the tint behind it
+				 * `Badge variant="chip"`, not a hand-rolled span. `chip` is the
+				 * one variant that lets a caller own the background without
+				 * inheriting a `hover:bg-*` it cannot override - `cn()` is
+				 * tailwind-merge, which replaces `bg-*` but treats `hover:bg-*`
+				 * as a different group - and going through the primitive is also
+				 * what supplies the radius. A box with *no* radius class at all
+				 * is pinned square for a user who chose the Rounded setting, and
+				 * no source scan can flag that (app/CLAUDE.md, "No bare
+				 * `rounded`").
+				 *
+				 * Text on a tint, never the bare fill as a foreground:
+				 * `--status-*` is an indicator token and fails contrast as a
+				 * label, so the three-token rule sends the word to `-text`
 				 * (docs/design-system.md, "Status tokens").
 				 */}
-				<span
+				<Badge
+					variant="chip"
 					className={cn(
-						"px-2 py-0.5 text-xs font-medium",
+						"font-medium",
 						failed
 							? "bg-destructive/10 text-destructive-text"
 							: "bg-status-success/10 text-status-success-text"
 					)}
 				>
 					{failed ? "Failed" : "Passed"}
-				</span>
+				</Badge>
 			</CardHeader>
 			<CardContent>
 				<p className="mb-3 text-xs text-muted-foreground">

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -29,6 +29,7 @@ export * from "./SampleRetentionNote";
 
 // "p99 was 47ms against a 50ms budget" - wherever a run's verdict is shown
 export * from "./ThresholdVerdict";
+export * from "./CapacitySummary";
 
 // "These responses were stored verbatim" - wherever captured samples are shown
 export * from "./CapturedDataWarning";

--- a/app/src/constants/load-test-modes.test.ts
+++ b/app/src/constants/load-test-modes.test.ts
@@ -34,6 +34,7 @@ describe("load test mode vocabulary", () => {
 			"constant_concurrency",
 			"iterations",
 			"ramp_up",
+			"capacity",
 		]);
 	});
 

--- a/app/src/constants/load-test-modes.ts
+++ b/app/src/constants/load-test-modes.ts
@@ -51,6 +51,11 @@ export const LOAD_TEST_MODES: readonly LoadTestModeInfo[] = [
 		label: "Ramp-Up",
 		description: "Climb to the target concurrency over a ramp.",
 	},
+	{
+		value: "capacity",
+		label: "Capacity Discovery",
+		description: "Step up until latency breaks its budget, then report the limit.",
+	},
 ];
 
 const BY_VALUE = new Map<string, LoadTestModeInfo>(LOAD_TEST_MODES.map((m) => [m.value, m]));

--- a/app/src/constants/load-test.ts
+++ b/app/src/constants/load-test.ts
@@ -42,6 +42,11 @@ export const LOAD_TEST_DEFAULTS = {
 	SAMPLE_RATE_PCT: 10,
 	/** Responses slower than this are flagged and saved. */
 	SLOW_THRESHOLD_MS: 1000,
+	/**
+	 * Capacity Discovery: how long each concurrency level is held before its
+	 * window is judged. Matches the engine's `constants::capacity`.
+	 */
+	STEP_DURATION_S: 5,
 	SAVE_TIMING_BREAKDOWN: true,
 } as const;
 
@@ -59,7 +64,9 @@ export type LoadTestLimitKey =
 	| "RAMP_DURATION_S"
 	| "START_CONCURRENCY"
 	| "SAMPLE_RATE_PCT"
-	| "SLOW_THRESHOLD_MS";
+	| "SLOW_THRESHOLD_MS"
+	| "SLO_MS"
+	| "STEP_DURATION_S";
 
 export type LoadTestLimits = Record<LoadTestLimitKey, LimitRange>;
 
@@ -87,6 +94,19 @@ export const LOAD_TEST_LIMITS: LoadTestLimits = {
 	 */
 	SAMPLE_RATE_PCT: { MIN: 1, MAX: 100 },
 	SLOW_THRESHOLD_MS: { MIN: 0, MAX: 60_000 },
+	/**
+	 * The latency budget a Capacity Discovery run searches for the edge of. The
+	 * ceiling is the engine's own guard on `sloMs`, and the same one the client
+	 * SLO setting clamps to - the two are the same number wearing two hats, so
+	 * they must accept the same range.
+	 */
+	SLO_MS: { MIN: 1, MAX: 60_000 },
+	/**
+	 * MIN is 1 second: the engine discards the first few ticks of every level as
+	 * the transition they measure, so a step shorter than that has nothing left
+	 * to judge and the search would stall waiting for a window it never fills.
+	 */
+	STEP_DURATION_S: { MIN: 1, MAX: 600 },
 };
 
 /**

--- a/app/src/modules/dashboard/components/hero/HeroRow.tsx
+++ b/app/src/modules/dashboard/components/hero/HeroRow.tsx
@@ -67,6 +67,22 @@ function renderModeCards(d: DashboardDerived) {
 					<ThroughputCard throughput={d.throughput} meanLatency={d.meanLatency} />
 				</>
 			);
+		// Capacity discovery climbs toward the ceiling the user set, so the
+		// question its hero answers is "how far up is it, and has the target
+		// given out yet" - the same pair `ramp_up` asks, read against the cap
+		// rather than against a planned curve. `CurrentConcurrencyCard` is
+		// deliberately not reused here: its subtitle states a ramp duration and
+		// a ramp lag, and a search has neither.
+		case "capacity":
+			return (
+				<>
+					<ConcurrencyUtilCard
+						currentConcurrency={activeConcurrency}
+						configuredConcurrency={d.configuredConcurrency}
+					/>
+					<SaturationCard breakpoint={d.breakpoint} failedRequests={d.failedRequests} />
+				</>
+			);
 		case "ramp_up":
 			return (
 				<>

--- a/app/src/modules/dashboard/components/stats/ModeStatsRow.tsx
+++ b/app/src/modules/dashboard/components/stats/ModeStatsRow.tsx
@@ -14,8 +14,9 @@
  *   constant_concurrency Duration · Total requests · Throughput / VU   · p99
  *   iterations           Elapsed  · Remaining (ETA) · Mean iter time   · p99
  *   ramp_up              Peak concurrency · Breakpoint · p99 at peak · Total requests
+ *   capacity             Peak concurrency · Breakpoint · p99 at peak · Total requests
  *
- * ramp_up is the lone exception: its 4th stat is Total requests, not p99, so
+ * ramp_up and capacity are the exception: their 4th stat is Total requests, not p99, so
  * that branch renders all four cards itself. Shared cards (Duration / Total /
  * Peak) and the universal p99 card live here; the mode-only cards live in
  * ModeStatCards.tsx. Consumes {@link DashboardDerived}; never re-derives from
@@ -66,6 +67,10 @@ function renderModeStats(d: DashboardDerived) {
 					<P99StatCard d={d} />
 				</>
 			);
+		// Capacity discovery asks the same four questions `ramp_up` does - how
+		// high did it get, where did it break, how slow was it there - which is
+		// the whole of what the mode exists to answer.
+		case "capacity":
 		case "ramp_up":
 			return (
 				<>

--- a/app/src/modules/dashboard/hooks/useMode.test.ts
+++ b/app/src/modules/dashboard/hooks/useMode.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `resolveMode` is a funnel every mode-adaptive component reads through, and
+ * its failure mode is silent: an unrecognised mode is *normalised*, not
+ * rejected, so a mode missing from `KNOWN_MODES` renders the constant_rps
+ * dashboard and looks merely wrong rather than broken.
+ *
+ * That is exactly what happened to `capacity` - it reached the union, the
+ * profile picker and both mode-adaptive rows while this set still listed four
+ * modes, leaving every `case "capacity"` arm downstream unreachable. The first
+ * test below is the guard that makes a repeat impossible: it walks the shipped
+ * vocabulary rather than a list written here, so a mode added to
+ * `LOAD_TEST_MODES` and forgotten here fails without anyone thinking to add a
+ * case.
+ */
+
+import { describe, expect, it } from "vitest";
+import { LOAD_TEST_MODES } from "@/constants/load-test-modes";
+import { resolveMode } from "./useMode";
+
+describe("resolveMode", () => {
+	it("resolves every shipped mode to itself", () => {
+		// Non-empty first: a guard that iterates an empty list passes forever.
+		expect(LOAD_TEST_MODES.length).toBeGreaterThan(0);
+		for (const mode of LOAD_TEST_MODES) {
+			expect(resolveMode(mode.value), mode.value).toBe(mode.value);
+		}
+	});
+
+	it("keeps capacity distinct from the open-loop default", () => {
+		// The specific regression: `capacity` is closed-loop and adaptive, and
+		// falling back to `constant_rps` hands it Target-RPS hero cards for a
+		// target it never had.
+		expect(resolveMode("capacity")).toBe("capacity");
+	});
+
+	it("falls back to constant_rps for a mode it does not know", () => {
+		// Runs predating explicit mode tagging, and runs from a newer sidecar.
+		expect(resolveMode(undefined)).toBe("constant_rps");
+		expect(resolveMode("")).toBe("constant_rps");
+		expect(resolveMode("some_future_mode")).toBe("constant_rps");
+	});
+});

--- a/app/src/modules/dashboard/hooks/useMode.ts
+++ b/app/src/modules/dashboard/hooks/useMode.ts
@@ -14,17 +14,31 @@
  * the mapping lives in exactly one place (Plan 4 code-quality gate #5).
  */
 
+import { LOAD_TEST_MODES } from "@/constants/load-test-modes";
 import type { LoadTestMode } from "@/types";
 
 /** Dashboard-facing alias of the canonical {@link LoadTestMode}. */
 export type LoadMode = LoadTestMode;
 
-const KNOWN_MODES: ReadonlySet<LoadMode> = new Set<LoadMode>([
-	"constant_rps",
-	"constant_concurrency",
-	"iterations",
-	"ramp_up",
-]);
+/**
+ * Derived from `LOAD_TEST_MODES`, not hand-listed.
+ *
+ * This was a third copy of the mode vocabulary - after the `LoadTestMode` union
+ * and `LOAD_TEST_MODES` itself - and a hand-written `Set<LoadMode>` literal is
+ * invisible to the type checker when a member is *missing*, only when one is
+ * spurious. So `capacity` shipped in the union, in the picker and in both
+ * mode-adaptive rows while this set still had four entries: `resolveMode`
+ * normalised it to `constant_rps`, and every `case "capacity"` arm downstream
+ * was dead code that rendered open-loop cards for a closed-loop search.
+ *
+ * Deriving it makes that unrepresentable. A mode a user can *start* is now by
+ * construction a mode the dashboard can *render*, and `LOAD_TEST_MODES` is
+ * already pinned to the union by `load-test-modes.test.ts`, so the whole chain
+ * has one guard rather than three lists to keep in step.
+ */
+const KNOWN_MODES: ReadonlySet<LoadMode> = new Set<LoadMode>(
+	LOAD_TEST_MODES.map((mode) => mode.value)
+);
 
 /**
  * Normalise a raw run-config mode string into a {@link LoadMode}.

--- a/app/src/modules/history/main/components/OverviewTab.tsx
+++ b/app/src/modules/history/main/components/OverviewTab.tsx
@@ -15,7 +15,7 @@ import { AlertCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/utils";
-import { ThresholdVerdict } from "@/components/shared";
+import { CapacitySummary, ThresholdVerdict } from "@/components/shared";
 import { HeroRow } from "@/modules/dashboard/components/hero/HeroRow";
 import { ModeStatsRow } from "@/modules/dashboard/components/stats/ModeStatsRow";
 import type { TabProps } from "../../types";
@@ -34,6 +34,11 @@ export default function OverviewTab({ report, derived }: TabProps) {
 			    question a stored run is opened to answer. Absent for a run that
 			    declared no budgets, which is every run recorded before them. */}
 			<ThresholdVerdict verdict={report.thresholdValidation} />
+
+			{/* What the search found, for a capacity run. Beside the verdict
+			    rather than below the charts: "what can it take" is the question
+			    the run was started to answer. Absent for every other mode. */}
+			<CapacitySummary capacity={report.capacity} />
 
 			{/* Status Codes */}
 			{report.statusCodes && Object.keys(report.statusCodes).length > 0 && (

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -22,6 +22,7 @@ import type { LoadTestConfig } from "@/types";
 import { STORAGE_KEYS } from "@/constants/storage-keys";
 import { useClientSettingsStore } from "@/stores";
 import { DEFAULT_LOAD_TEST_CEILINGS, LOAD_TEST_CEILING_BOUNDS } from "@/constants/load-test";
+import { LOAD_TEST_MODES } from "@/constants/load-test-modes";
 
 vi.mock("../OAuth2LoadTestGuard", () => ({
 	default: () => null,
@@ -86,6 +87,18 @@ describe("load profile → fields", () => {
 		expect(screen.queryByLabelText(/duration/i)).not.toBeInTheDocument();
 	});
 
+	it("shows the budget, the step and both bounds for Capacity Discovery", () => {
+		open();
+		pickProfile("Capacity Discovery");
+		expect(screen.getByLabelText(/latency budget/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/hold each level for/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/start from/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/stop climbing at/i)).toBeInTheDocument();
+		expect(screen.getByLabelText(/give up after/i)).toBeInTheDocument();
+		// The ramp's own field belongs to the ramp; a search has no ramp curve.
+		expect(screen.queryByLabelText(/ramp duration/i)).not.toBeInTheDocument();
+	});
+
 	it("shows target, total and ramp for Ramp-Up", () => {
 		open();
 		pickProfile("Ramp-Up");
@@ -108,7 +121,7 @@ describe("payload", () => {
 	// `it.each`, not a loop with a manual teardown: the dialog renders through a
 	// Radix portal, so removing its node by hand throws and leaves the next
 	// iteration asserting against a half-torn-down DOM.
-	it.each(["Constant RPS", "Constant Concurrency", "Ramp-Up"])(
+	it.each(["Constant RPS", "Constant Concurrency", "Ramp-Up", "Capacity Discovery"])(
 		"sends duration_seconds for %s",
 		(profile) => {
 			const { onStart } = open();
@@ -116,6 +129,35 @@ describe("payload", () => {
 			expect(started(onStart).duration_seconds).toBeGreaterThan(0);
 		}
 	);
+
+	it("sends the search bounds and budget for Capacity Discovery", () => {
+		const { onStart } = open();
+		pickProfile("Capacity Discovery");
+		// The default start (1) is below the default ceiling (10), so the
+		// picked profile starts valid; anything else and Start is disabled and
+		// `started` would fail on the call count rather than on the payload.
+		const config = started(onStart);
+		expect(config.mode).toBe("capacity");
+		// `concurrency` is the ceiling and `start_concurrency` the first level -
+		// the ramp's two fields reused, so one Settings cap bounds both modes.
+		expect(config.concurrency).toBeGreaterThan(0);
+		expect(config.start_concurrency).toBeGreaterThan(0);
+		expect(config.slo_ms).toBeGreaterThan(0);
+		expect(config.step_duration_seconds).toBeGreaterThan(0);
+		// `duration` is the search's deadline in this mode, not a run length.
+		expect(config.duration_seconds).toBeGreaterThan(0);
+	});
+
+	it("sends no capacity fields for any other profile", () => {
+		// The mirror of the test above, and the one that would catch the
+		// fields being set unconditionally: a ramp carrying an sloMs would make
+		// its stored config claim a search it never ran.
+		const { onStart } = open();
+		pickProfile("Ramp-Up");
+		const config = started(onStart);
+		expect(config).not.toHaveProperty("slo_ms");
+		expect(config).not.toHaveProperty("step_duration_seconds");
+	});
 
 	it("keeps the recording options even though they are folded away", () => {
 		const { onStart } = open();
@@ -242,7 +284,9 @@ describe("keyboard", () => {
 		open();
 		const group = screen.getByRole("radiogroup", { name: /load profile/i });
 		const radios = within(group).getAllByRole("radio");
-		expect(radios).toHaveLength(4);
+		// One card per entry in LOAD_TEST_MODES - the picker renders from that
+		// list, so hardcoding a count here would fail on every mode added.
+		expect(radios).toHaveLength(LOAD_TEST_MODES.length);
 		expect(radios.filter((r) => r.getAttribute("tabindex") === "0")).toHaveLength(1);
 
 		radios[0].focus();
@@ -257,7 +301,7 @@ describe("keyboard", () => {
 		const radios = within(group).getAllByRole("radio");
 		radios[0].focus();
 		fireEvent.keyDown(group, { key: "ArrowLeft" });
-		expect(radios[3]).toHaveAttribute("aria-checked", "true");
+		expect(radios[radios.length - 1]).toHaveAttribute("aria-checked", "true");
 	});
 
 	it("labels every field, so none is named by its placeholder alone", () => {

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/ProfilePicker.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/ProfilePicker.tsx
@@ -6,19 +6,19 @@
  */
 
 /**
- * The four load profiles, as a radio group rather than a `<Select>`.
+ * The load profiles, as a radio group rather than a `<Select>`.
  *
- * They are four different strategies with four different forms behind them, and
- * a select shows one label at a time - so choosing meant opening a menu and
- * reading options you could not compare. As cards, all four are visible with a
- * line of description each, which also retires most of the old "What will
- * happen" prose.
+ * They are different strategies with different forms behind them, and a select
+ * shows one label at a time - so choosing meant opening a menu and reading
+ * options you could not compare. As cards, all of them are visible with a line
+ * of description each, which also retires most of the old "What will happen"
+ * prose. The list comes from `LOAD_TEST_MODES`, so adding a mode adds a card.
  *
  * Keyboard follows the WAI-ARIA radio group pattern, which is stricter than it
  * looks: the whole group is **one** Tab stop, arrows move *and* select (wrapping
  * at the ends), and Space selects the focused option. Roving tabindex is what
- * makes the single stop work - anything else would put four stops in the middle
- * of a form.
+ * makes the single stop work - anything else would put one stop per card in the
+ * middle of a form.
  */
 
 import { useRef } from "react";

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -29,7 +29,11 @@ import { useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import type { LoadTestConfig, OAuth2Config } from "@/types";
 import OAuth2LoadTestGuard from "../OAuth2LoadTestGuard";
-import { validateRampDuration, validateStartConcurrency } from "../../utils/loadTestValidation";
+import {
+	validateCapacityRange,
+	validateRampDuration,
+	validateStartConcurrency,
+} from "../../utils/loadTestValidation";
 import {
 	LOAD_TEST_DEFAULTS,
 	clampToRange,
@@ -73,6 +77,8 @@ interface SavedLoadTestConfig {
 	iterations: number;
 	rampDuration: number;
 	startConcurrency: number;
+	stepDuration: number;
+	sloMs: number;
 	maxInFlight: number | null;
 	sampleRate: number;
 	slowThreshold: number;
@@ -230,6 +236,9 @@ export default function LoadTestConfigDialog({
 	const [startConcurrency, setStartConcurrency] = useState(() =>
 		restore(saved.startConcurrency, LOAD_TEST_DEFAULTS.START_CONCURRENCY, "START_CONCURRENCY")
 	);
+	const [stepDuration, setStepDuration] = useState(() =>
+		restore(saved.stepDuration, LOAD_TEST_DEFAULTS.STEP_DURATION_S, "STEP_DURATION_S")
+	);
 	const [maxInFlight, setMaxInFlight] = useState<string>(
 		saved.maxInFlight != null ? String(saved.maxInFlight) : ""
 	);
@@ -253,6 +262,15 @@ export default function LoadTestConfigDialog({
 	 * draft has been memoed, a cleared p99 stays cleared.
 	 */
 	const sloThresholdMs = useClientSettingsStore((s) => s.sloThresholdMs);
+	/**
+	 * Capacity Discovery searches for the edge of this budget. Seeded from the
+	 * same `sloThresholdMs` setting the p99 budget below is - the search and the
+	 * chart annotation are two readings of one number, and giving the mode its
+	 * own default would be a third notion of "too slow".
+	 */
+	const [sloMs, setSloMs] = useState(() =>
+		restore(saved.sloMs ?? sloThresholdMs, sloThresholdMs, "SLO_MS")
+	);
 	const [budgets, setBudgets] = useState<BudgetDraft>(
 		() =>
 			saved.budgets ?? {
@@ -278,8 +296,10 @@ export default function LoadTestConfigDialog({
 
 	const rampDurationError = validateRampDuration(mode, duration, rampDuration);
 	const startConcurrencyError = validateStartConcurrency(mode, startConcurrency, concurrency);
+	const capacityRangeError = validateCapacityRange(mode, startConcurrency, concurrency);
 	const budgetsError = budgetError(budgets);
-	const blockingError = rampDurationError ?? startConcurrencyError ?? budgetsError;
+	const blockingError =
+		rampDurationError ?? startConcurrencyError ?? capacityRangeError ?? budgetsError;
 
 	const notices = useMemo(() => {
 		const list: { key: string; severity: Severity; node: React.ReactNode }[] = [];
@@ -303,6 +323,18 @@ export default function LoadTestConfigDialog({
 				node: (
 					<Callout severity="blocking" title="A budget is out of range">
 						{budgetsError}
+					</Callout>
+				),
+			});
+		}
+
+		if (capacityRangeError) {
+			list.push({
+				key: "capacity-range",
+				severity: "blocking",
+				node: (
+					<Callout severity="blocking" title="The search has nowhere to climb">
+						{capacityRangeError}
 					</Callout>
 				),
 			});
@@ -353,6 +385,7 @@ export default function LoadTestConfigDialog({
 	}, [
 		rampDurationError,
 		startConcurrencyError,
+		capacityRangeError,
 		budgetsError,
 		hasPreRequestScript,
 		hasDynamicVariables,
@@ -371,6 +404,8 @@ export default function LoadTestConfigDialog({
 			iterations,
 			rampDuration,
 			startConcurrency,
+			stepDuration,
+			sloMs,
 			maxInFlight: maxInFlightValue,
 			sampleRate,
 			slowThreshold,
@@ -410,6 +445,15 @@ export default function LoadTestConfigDialog({
 			config.concurrency = concurrency;
 			config.ramp_duration_seconds = rampDuration;
 			config.start_concurrency = startConcurrency;
+		} else if (mode === "capacity") {
+			// `concurrency` is the ceiling the search will not climb past and
+			// `start_concurrency` is where it begins - the same two fields the
+			// ramp owns, reused rather than respelled, so one cap in Settings
+			// bounds both modes.
+			config.concurrency = concurrency;
+			config.start_concurrency = startConcurrency;
+			config.slo_ms = sloMs;
+			config.step_duration_seconds = stepDuration;
 		}
 
 		onStart(config);
@@ -454,11 +498,22 @@ export default function LoadTestConfigDialog({
 						{mode !== "constant_rps" && (
 							<NumberField
 								id="lt-concurrency"
-								label={mode === "ramp_up" ? "Target connections" : "Connections"}
+								label={
+									mode === "ramp_up"
+										? "Target connections"
+										: mode === "capacity"
+											? "Stop climbing at"
+											: "Connections"
+								}
 								value={concurrency}
 								onChange={num(setConcurrency)}
 								min={limits.CONCURRENCY.MIN}
 								max={limits.CONCURRENCY.MAX}
+								hint={
+									mode === "capacity"
+										? "The ceiling the search will not climb past. Reaching it ends the run."
+										: undefined
+								}
 							/>
 						)}
 
@@ -476,7 +531,13 @@ export default function LoadTestConfigDialog({
 						{usesDuration && (
 							<NumberField
 								id="lt-duration"
-								label={mode === "ramp_up" ? "Total duration" : "Duration"}
+								label={
+									mode === "ramp_up"
+										? "Total duration"
+										: mode === "capacity"
+											? "Give up after"
+											: "Duration"
+								}
 								unit="sec"
 								value={duration}
 								onChange={num(setDuration)}
@@ -485,7 +546,33 @@ export default function LoadTestConfigDialog({
 							/>
 						)}
 
-						{mode === "ramp_up" && (
+						{mode === "capacity" && (
+							<NumberField
+								id="lt-slo"
+								label="Latency budget"
+								unit="ms"
+								value={sloMs}
+								onChange={num(setSloMs)}
+								min={limits.SLO_MS.MIN}
+								max={limits.SLO_MS.MAX}
+								hint="The p99 the search looks for the edge of. Prefilled from your SLO setting."
+							/>
+						)}
+
+						{mode === "capacity" && (
+							<NumberField
+								id="lt-step-duration"
+								label="Hold each level for"
+								unit="sec"
+								value={stepDuration}
+								onChange={num(setStepDuration)}
+								min={limits.STEP_DURATION_S.MIN}
+								max={limits.STEP_DURATION_S.MAX}
+								hint="Longer steps measure each level more steadily; shorter ones search faster."
+							/>
+						)}
+
+						{(mode === "ramp_up" || mode === "capacity") && (
 							<NumberField
 								id="lt-start-concurrency"
 								label="Start from"
@@ -493,7 +580,11 @@ export default function LoadTestConfigDialog({
 								onChange={num(setStartConcurrency)}
 								min={limits.START_CONCURRENCY.MIN}
 								max={limits.START_CONCURRENCY.MAX}
-								hint="Connections at the start of the ramp. The engine climbs from here to the target."
+								hint={
+									mode === "capacity"
+										? "The first level the search measures. It steps up from here while latency holds."
+										: "Connections at the start of the ramp. The engine climbs from here to the target."
+								}
 							/>
 						)}
 
@@ -520,6 +611,8 @@ export default function LoadTestConfigDialog({
 								iterations,
 								rampDuration,
 								startConcurrency,
+								stepDuration,
+								sloMs,
 							},
 							blockingError !== null
 						)}

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/summary.test.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/summary.test.ts
@@ -15,6 +15,8 @@ const base = {
 	iterations: 1000,
 	rampDuration: 30,
 	startConcurrency: 1,
+	stepDuration: 5,
+	sloMs: 200,
 };
 
 describe("summarise", () => {
@@ -58,5 +60,16 @@ describe("summarise", () => {
 		expect(summarise({ ...base, mode: "iterations", iterations: 1, concurrency: 1 })).toContain(
 			"exactly 1 request using 1 connection"
 		);
+	});
+
+	it("describes the capacity search's shape, its budget and its ceiling", () => {
+		const s = summarise({ ...base, mode: "capacity", startConcurrency: 4, concurrency: 256 });
+		expect(s).toContain("Steps up from 4 connections");
+		expect(s).toContain("holding each level for 5s");
+		expect(s).toContain("p99 passes 200ms");
+		expect(s).toContain("256 connections");
+		// The count no field shows is exactly the count nothing can predict
+		// here - how many levels the search holds is the target's answer.
+		expect(s).not.toMatch(/in total/);
 	});
 });

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/summary.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/summary.ts
@@ -15,9 +15,9 @@
  *     the total, so a 30s ramp in a 60s run means 30s ramping and 30s at target.
  *   - **It can state the total request count**, which no single field shows.
  *
- * The count is only stated where it is knowable. `constant_concurrency` and
- * `ramp_up` send as many requests as the target can answer, which depends on
- * latency - guessing there would be worse than saying nothing.
+ * The count is only stated where it is knowable. `constant_concurrency`,
+ * `ramp_up` and `capacity` send as many requests as the target can answer,
+ * which depends on latency - guessing there would be worse than saying nothing.
  */
 
 import type { LoadTestConfig } from "@/types";
@@ -30,6 +30,10 @@ export interface SummaryInput {
 	iterations: number;
 	rampDuration: number;
 	startConcurrency: number;
+	/** Capacity only: how long each concurrency level is held. */
+	stepDuration: number;
+	/** Capacity only: the p99 the search looks for the edge of. */
+	sloMs: number;
 }
 
 /** `6000` → `"6,000"`. Grouped because these run to five and six figures. */
@@ -47,7 +51,29 @@ function plural(n: number, one: string, many = `${one}s`): string {
  *                 printed as a confident falsehood.
  */
 export function summarise(input: SummaryInput, blocked = false): string {
-	const { mode, duration, rps, concurrency, iterations, rampDuration, startConcurrency } = input;
+	const {
+		mode,
+		duration,
+		rps,
+		concurrency,
+		iterations,
+		rampDuration,
+		startConcurrency,
+		stepDuration,
+		sloMs,
+	} = input;
+
+	if (mode === "capacity") {
+		// No count, for the same reason constant_concurrency has none - and one
+		// more: how many levels the search holds is decided by the target, not
+		// by anything on this form.
+		return `Steps up from ${count(startConcurrency)} connections, holding each level for ${count(
+			stepDuration
+		)}s, until p99 passes ${count(sloMs)}ms or the run reaches ${plural(
+			concurrency,
+			"connection"
+		)}. Gives up after ${count(duration)}s and reports the highest level the target held.`;
+	}
 
 	if (mode === "iterations") {
 		return `Sends exactly ${plural(iterations, "request")} using ${plural(

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -462,6 +462,14 @@ export default function RequestBuilder() {
 					// engine and read back into the dashboard, but nothing set it, so
 					// every ramp started from the engine default of 1.
 					startConcurrency: config.start_concurrency,
+					// Capacity only. `startConcurrency` above is where the search
+					// begins and `concurrency` is its ceiling, so the mode adds
+					// only these two rather than a second spelling of bounds the
+					// ramp already owns.
+					sloMs: config.slo_ms,
+					stepDuration: config.step_duration_seconds
+						? `${config.step_duration_seconds}s`
+						: undefined,
 					maxInFlight: config.max_in_flight,
 					requestId: fetchedRequest.id,
 					environmentId: activeEnvironmentId || undefined,

--- a/app/src/modules/request-builder/utils/loadTestValidation.test.ts
+++ b/app/src/modules/request-builder/utils/loadTestValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateRampDuration } from "./loadTestValidation";
+import { validateCapacityRange, validateRampDuration } from "./loadTestValidation";
 
 describe("validateRampDuration", () => {
 	it("returns null for non-ramp_up modes regardless of durations", () => {
@@ -21,5 +21,26 @@ describe("validateRampDuration", () => {
 		expect(msg).not.toBeNull();
 		expect(msg).toContain("6");
 		expect(msg).toContain("10");
+	});
+});
+
+describe("validateCapacityRange", () => {
+	it("rejects a search whose start is already at its ceiling", () => {
+		// The engine runs it - one level, then `cap_reached` - which is exactly
+		// the run the profile does not exist to do.
+		expect(validateCapacityRange("capacity", 64, 64)).toContain("one level");
+		expect(validateCapacityRange("capacity", 100, 64)).toContain("one level");
+	});
+
+	it("accepts a start below the ceiling", () => {
+		expect(validateCapacityRange("capacity", 4, 256)).toBeNull();
+	});
+
+	it("says nothing about any other mode", () => {
+		// `ramp_up` allows a start above its target on purpose - that is a ramp
+		// down - so this rule must not reach it.
+		expect(validateCapacityRange("ramp_up", 100, 10)).toBeNull();
+		expect(validateCapacityRange("constant_concurrency", 100, 10)).toBeNull();
+		expect(validateCapacityRange(undefined, 100, 10)).toBeNull();
 	});
 });

--- a/app/src/modules/request-builder/utils/loadTestValidation.ts
+++ b/app/src/modules/request-builder/utils/loadTestValidation.ts
@@ -48,3 +48,25 @@ export function validateStartConcurrency(
 	}
 	return null;
 }
+
+/**
+ * Capacity Discovery climbs from `startConcurrency` toward `concurrency`. A
+ * start at or above the ceiling is a search with nothing to search: the engine
+ * measures the one level and stops `cap_reached`, which is a legitimate run but
+ * never the one the user meant when they picked the profile whose whole job is
+ * to find a limit.
+ *
+ * Returns a user-facing message when invalid, or null (including for every
+ * non-capacity mode).
+ */
+export function validateCapacityRange(
+	mode: string | undefined,
+	startConcurrency: number,
+	concurrency: number
+): string | null {
+	if (mode !== "capacity") return null;
+	if (startConcurrency >= concurrency) {
+		return `The search starts at ${startConcurrency} and stops at ${concurrency}, so it has only one level to measure and cannot find a limit. Lower the start or raise the ceiling.`;
+	}
+	return null;
+}

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -373,6 +373,15 @@ export interface StartLoadTestRequest {
 	rampUpDuration?: string;
 	startConcurrency?: number;
 
+	// For "capacity" mode. `startConcurrency` is where the search begins and
+	// `concurrency` is the ceiling it will not climb past - both fields the ramp
+	// already owns, reused rather than respelled. `duration` is the whole
+	// search's deadline.
+	/** p99 budget the search looks for the edge of, in ms. */
+	sloMs?: number;
+	/** How long each concurrency level is held before it is judged, e.g. `"5s"`. */
+	stepDuration?: string;
+
 	// Optional linking
 	requestId?: string;
 	environmentId?: string;

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -686,7 +686,12 @@ export interface RunListParams {
 }
 
 /** Load-test execution strategy. Single source of truth for the mode union. */
-export type LoadTestMode = "constant_rps" | "constant_concurrency" | "iterations" | "ramp_up";
+export type LoadTestMode =
+	| "constant_rps"
+	| "constant_concurrency"
+	| "iterations"
+	| "ramp_up"
+	| "capacity";
 
 /**
  * Pass/fail budgets a run declares up front, so the engine can judge it rather
@@ -729,6 +734,15 @@ export interface LoadTestConfig {
 	max_in_flight?: number;
 	/** Absent when the run declared no budgets - never an empty object. */
 	thresholds?: RunThresholds;
+	/**
+	 * Capacity only: the p99 budget the search looks for the edge of, in ms.
+	 * Prefilled from the client-side `sloThresholdMs` setting, so the number
+	 * the dashboard already annotates its charts with becomes the number the
+	 * search is steered by rather than a second, unrelated one.
+	 */
+	slo_ms?: number;
+	/** Capacity only: how long each concurrency level is held before it is judged. */
+	step_duration_seconds?: number;
 }
 
 /**
@@ -1037,6 +1051,29 @@ export interface RunReport {
 		passed: number;
 		failed: number;
 		verdict: "passed" | "failed";
+	};
+	/**
+	 * What a capacity run's adaptive search found: the highest concurrency the
+	 * service held inside its latency budget, the level it gave out at, and the
+	 * per-level audit trail behind both.
+	 *
+	 * `undefined` for every other mode - a fixed-target run measured a point,
+	 * not a curve, so there is no knee to show. `maxHealthy*` is absent when the
+	 * very first level already breached (the search found no sustainable
+	 * capacity) and `knee*` when the search ended for a reason other than
+	 * latency, so neither can be read as a measured zero. `stopReason` is typed
+	 * loosely for the same reason `thresholdValidation.metric` is: a newer
+	 * sidecar may stop for a reason this build has no words for.
+	 */
+	capacity?: {
+		sloMs: number;
+		stopReason: string;
+		maxHealthyConcurrency?: number;
+		maxHealthyRps?: number;
+		p99AtMaxHealthyMs?: number;
+		kneeConcurrency?: number;
+		kneeP99Ms?: number;
+		levels: { concurrency: number; rps: number; p99Ms: number }[];
 	};
 	/**
 	 * How many records each of the run's bounded stores thinned away.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -470,6 +470,40 @@ The comparator follows the metric (`≥` for the throughput floor, `≤` for the
 ceilings), and a metric key this build has no label for renders under its raw
 name rather than vanishing from a verdict whose counts still include it.
 
+## Capacity Summary (`components/shared/CapacitySummary.tsx`)
+
+What a `mode: "capacity"` run's adaptive search found (`RunReport.capacity`):
+the highest concurrency the target held inside its latency budget, the level it
+gave out at, and the per-level table both were read off. Shown in the history
+detail's Overview, beside `ThresholdVerdict`.
+
+The headline is a **sentence**, not a stat grid, because the mode exists to
+answer one question in words - "what can my service take" - and four numbers
+side by side make the reader assemble that answer themselves. The table below
+is the evidence, for a reader who wants to see the shape of the curve rather
+than trust the summary of it.
+
+Three states, not two, and the distinction is the whole point of the component
+(same absent-vs-zero discipline as `ThresholdVerdict`, one level deeper):
+
+- **Sustained a level** - the usual reading, with the knee beside it when
+  latency is what ended the search.
+- **No level held the budget** - the first level already breached. The search
+  found no sustainable capacity, which is *not* the claim "this service
+  sustains zero".
+- **Judged nothing at all** - the run ended before its first level closed
+  (`stepDuration` longer than `duration`, or a hand stop seconds in). The
+  engine still reports the section, because "the search measured nothing" is
+  the finding that says to lengthen the run or shorten the step - but the card
+  must say that rather than fall into the second state and claim a measurement
+  at a concurrency it never reached.
+
+A level the search re-measured after one bad window appears **twice** in the
+table, at the same concurrency; that repeat is the audit trail doing its job,
+so the rows are keyed by index rather than by level. A `stopReason` this build
+has no words for renders under its raw key, as `ThresholdVerdict` does with an
+unknown metric.
+
 ## Captured Data Warning (`components/shared/CapturedDataWarning.tsx`)
 
 Wherever a run's captured response exchanges are on screen: the run stored those

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,8 +234,9 @@ Variables are resolved with priority: **Environment > Collection > Global**
 - **Lock-Free Design**: High-performance metrics collection with minimal contention
 - **Async I/O**: Uses `curl_multi` for concurrent request handling
 - **Load models**: `constant_rps` is open-loop (dispatch at a fixed rate); `constant_concurrency`,
-  `ramp_up`, and `iterations` are closed-loop (hold a target in-flight count). See
-  [Engine Architecture](engine/architecture.md#load-test-strategies).
+  `ramp_up`, `iterations` and `capacity` are closed-loop (hold a target in-flight count).
+  `capacity` is the one whose target adapts to what the run measured, stepping up until latency
+  breaks its budget. See [Engine Architecture](engine/architecture.md#load-test-strategies).
 - **Efficient Caching**: TanStack Query caches server responses in Manager
 
 ## File Locations

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1661,11 +1661,13 @@ Start a load test run (Vayu Mode).
     "mode": "none",
     "content": ""
   },
-  "mode": "constant_rps",    // "constant_rps", "constant_concurrency", "ramp_up", or "iterations"
-  "concurrency": 100,        // Target in-flight requests (constant_concurrency / ramp_up target / iterations)
-  "startConcurrency": 1,     // Ramp start concurrency (ramp_up mode)
-  "duration": "60s",         // Duration, ms/s/m/h (constant_rps / constant_concurrency / ramp_up)
+  "mode": "constant_rps",    // "constant_rps", "constant_concurrency", "ramp_up", "iterations", or "capacity"
+  "concurrency": 100,        // Target in-flight requests (constant_concurrency / ramp_up target / iterations); the ceiling for capacity
+  "startConcurrency": 1,     // Ramp start concurrency (ramp_up); first level searched (capacity)
+  "duration": "60s",         // Duration, ms/s/m/h (constant_rps / constant_concurrency / ramp_up); the deadline for capacity
   "rampUpDuration": "10s",   // Ramp time, ms/s/m/h (ramp_up mode; start may be above target)
+  "sloMs": 200,              // p99 budget the search looks for the edge of (capacity mode)
+  "stepDuration": "5s",      // How long each level is held before it is judged (capacity mode)
   "iterations": 0,           // Number of iterations (iterations mode)
   "targetRps": 1000,         // Target requests per second (constant_rps mode)
   "maxInFlight": 10000,      // Optional; see "maxInFlight" note below - constant_rps only
@@ -2061,6 +2063,8 @@ default, and whose message names the offending field and why the bound exists:
 | `maxInFlight` | `1`-`1000000` | It is a pending-request ceiling read as a `size_t`, so `-1` or `0` removes the backpressure the field exists to provide instead of tightening it, and an open-loop run against a slow target then accumulates in-flight requests for its whole duration. The ceiling is **not** the `concurrency` guard: that one bounds an eager per-worker connection pre-allocation, while this bounds a counter that pre-allocates nothing, and the engine's own default - `max(targetRps × 10, 1000)` - reaches 500,000 at the load dialog's 50k RPS maximum, so a lower bound would refuse ceilings the engine picks for itself. |
 | `timeout` | `1`-`86400000` ms | A transfer that never times out never completes, leaving the run stuck `running` and unstoppable. |
 | `duration` | string, positive, optional unit (`ms`\|`s`\|`m`\|`h`) | A JSON *number* threw out of the run-context constructor *after* the row was written, stranding it `pending` forever behind an opaque `500`. |
+| `stepDuration` | string, positive, optional unit (`ms`\|`s`\|`m`\|`h`) | `capacity` only, and read by the same parser `duration` is - so it is gated by the same rule rather than by a second copy of it. |
+| `sloMs` | `1`-`60000` ms | `capacity` only. A non-positive budget has no edge to find, and one past a minute is longer than the transfers any realistic run measures. Matches the app's own clamp on the SLO setting. |
 
 An **absent** field, or an explicit `null`, is always accepted - every one of
 them has a default. The ceilings are crash guards, not policy: each client caps
@@ -2170,6 +2174,24 @@ floored to a multiple of 1000. Requests that come due while in-flight is at
 wall-clock `duration`, and `droppedRequests` (in the run summary and per-tick
 metrics) carries what the rate owed but could not issue. `sent + dropped` is
 therefore what `targetRps × duration` asked for.
+
+**Capacity semantics.** `capacity` is the one mode whose target is not a
+function of elapsed time. It holds `startConcurrency` for `stepDuration`, judges
+that window's windowed p99 and throughput, and then steps up by 25% (at least
++1) while the level stayed inside `sloMs`. It stops - and names the reason in
+the report - when p99 exceeds `sloMs` across **two consecutive** windows
+(`slo_exceeded`; one breaching window re-measures the same level rather than
+ending the search), when two step-ups buy under 5% more throughput
+(`plateau`), when `concurrency` is reached (`cap_reached`), when `duration`
+runs out (`deadline`), or when the operator stops the run (`stopped`).
+
+The search steers by the published metric tick - the same numbers `GET
+/runs/:id/live` streams - rather than sampling the collector itself, so the
+controller and the dashboard cannot disagree about a level. Windows in which
+nothing completed are not judged: their percentiles are the empty-window zeros
+and reading those as "answered instantly" would climb straight past the limit.
+`capacity` is rejected on a **scenario** run with a `400`: the search judges one
+windowed p99 and a sequence has one per step.
 
 **Ramp semantics.** `ramp_up` interpolates linearly from `startConcurrency` to
 `concurrency` over `rampUpDuration`, then holds `concurrency` for the rest of
@@ -2665,7 +2687,8 @@ A run that is already finished answers `{"status": "<status>", "runId": ...,
 Get the final report for a completed run. The response is a **nested** object; conditional
 sections appear only when relevant (e.g. `rateControl` only for `constant_rps`, `testValidation`
 only when a test script ran, `thresholdValidation` only when the run declared
-[budgets](#the-thresholds-block-passfail-budgets)).
+[budgets](#the-thresholds-block-passfail-budgets), `capacity` only for a
+`capacity` run).
 
 The whole-run aggregates come from the run's stored `summary` (written once when the run reaches
 a terminal status - see [db-schema.md](db-schema.md#runs)), combined with the sampled `results`
@@ -2743,6 +2766,34 @@ alone rather than erroring. **The response shape is the same either way.**
   "results": [ { "id": 41, "...": "sampled request/response outcomes" } ]
 }
 ```
+
+**A capacity run adds a `capacity` section** and no other mode carries one:
+
+```json
+"capacity": {
+  "sloMs": 200,
+  "stopReason": "slo_exceeded",
+  "maxHealthyConcurrency": 48, "maxHealthyRps": 23400, "p99AtMaxHealthyMs": 41.2,
+  "kneeConcurrency": 64, "kneeP99Ms": 312.0,
+  "levels": [ { "concurrency": 1, "rps": 980, "p99Ms": 1.4 } ]
+}
+```
+
+`stopReason` is one of `slo_exceeded`, `plateau`, `cap_reached`, `deadline` or
+`stopped` - see [Capacity semantics](#post-runs). The two optional halves are
+**omitted rather than zeroed**, and the distinction carries information:
+
+- `maxHealthy*` is absent when the very first level already breached the budget.
+  The search found no sustainable capacity, which is not the same claim as a
+  capacity of zero.
+- `knee*` is absent unless `stopReason` is `slo_exceeded`. A run that ended at
+  its ceiling, its deadline, or on a plateau inside the budget never watched the
+  target give out, so it has no knee to report.
+
+`levels[]` is one entry per level *judged*, in order - bounded by construction
+(a search holds tens of levels, not thousands). A level that breached once and
+was re-measured appears twice, at the same concurrency; the level still being
+measured when the run ended does not appear at all, because it was never judged.
 
 **A scenario run adds a `scenario` section** and no other run type carries one:
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2185,6 +2185,13 @@ ending the search), when two step-ups buy under 5% more throughput
 (`plateau`), when `concurrency` is reached (`cap_reached`), when `duration`
 runs out (`deadline`), or when the operator stops the run (`stopped`).
 
+An **omitted `duration`** on a capacity run defaults to **5 minutes**, not the
+60 seconds every other mode falls back to: this mode walks a level every
+`stepDuration`, so a minute is a dozen levels and a search that almost always
+ends `deadline` rather than finding anything. Any client enforcing its own
+duration ceiling has to account for that per-mode default rather than assuming
+one number - the MCP tool's cap does.
+
 The search steers by the published metric tick - the same numbers `GET
 /runs/:id/live` streams - rather than sampling the collector itself, so the
 controller and the dashboard cannot disagree about a level. Windows in which

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -538,7 +538,7 @@ is fast-forwarded to the oldest retained tick rather than replaying from 0.
 
 ## Load Test Strategies
 
-Four load test modes are supported (`LoadTestType` in `types.hpp`). Three are **closed-loop** -
+Five load test modes are supported (`LoadTestType` in `types.hpp`). Four are **closed-loop** -
 the engine holds in-flight requests at a target and issues a new request as each completes, so
 throughput is a *result* (`concurrency ÷ latency`), not an input. One is **open-loop**.
 
@@ -579,12 +579,56 @@ run end.
 { "mode": "iterations", "concurrency": 10, "iterations": 1000 }
 ```
 
+### 5. `capacity` (closed-loop, adaptive)
+
+Steps the concurrency target up while latency holds, and stops itself at the
+knee. It answers "what can this service sustain" without a human bisecting
+concurrency by hand.
+
+```json
+{ "mode": "capacity", "startConcurrency": 1, "concurrency": 512,
+  "sloMs": 200, "stepDuration": "5s", "duration": "5m" }
+```
+
+Each level is held for `stepDuration`, then judged on the mean of that window's
+windowed p99 and throughput. Healthy levels step up 25% (at least +1); a single
+breaching window **holds** the level and re-measures rather than ending the
+search. The stop reasons are `slo_exceeded` (two consecutive breaching windows),
+`plateau` (two step-ups bought under 5% more throughput), `cap_reached`,
+`deadline` and `stopped`, and the report's `capacity` section names which fired.
+
 ### Closed-loop controller
 
-`constant_concurrency`, `ramp_up`, and `iterations` share a `maintain_concurrency` loop driven by
-a pure `compute_refill_deficit` primitive: each tick, refill exactly `target − in_flight` new
-requests (where `in_flight = requests_sent − completed`). On stop the controller is notified for
-prompt cancellation rather than waiting for in-flight requests to drain.
+`constant_concurrency`, `ramp_up`, `iterations` and `capacity` share a `maintain_concurrency`
+loop driven by a pure `compute_refill_deficit` primitive: each tick, refill exactly
+`target − in_flight` new requests (where `in_flight = requests_sent − completed`). On stop the
+controller is notified for prompt cancellation rather than waiting for in-flight requests to drain.
+
+**The `target_fn` invariant, restated.** Every mode but `capacity` passes a
+`target_fn` that is a pure function of `elapsed_ms` and constants fixed when the
+run started - which is what makes a ramp reproducible and a constant run flat.
+`capacity` is the deliberate exception: its target is a function of what the run
+has *measured*, so the invariant is now "the target depends only on elapsed time
+**and the published metric tick**", and nothing else.
+
+That feedback path has exactly one shape, and it matters which. The strategy
+must **not** call `MetricsCollector::sample_window_percentiles()`: that call is
+single-reader and *resets* the rolling window on read, and the metrics thread
+already consumes it once per tick in `emit_live_tick`. A second consumer would
+silently halve both readers' sample counts, and neither the live chart nor the
+search would look wrong. So the metrics thread publishes what it already
+computed - `RunContext::publish_live_tick()`, one writer - and the strategy
+copies it out through `latest_live_tick()`. The controller therefore steers by
+exactly the numbers the dashboard is drawing. A guard in
+`capacity_controller_test.cpp` pins the single production caller, because the
+wrong version still runs; it just measures less.
+
+The tick carries a `latency_samples` count for the same reason: an idle window's
+percentiles are zeros, and averaging those in with real ones would read "nothing
+completed" as "answered instantly" and climb straight past the limit the search
+exists to find. The controller's policy itself lives in
+`core/capacity_controller.hpp` as pure functions over a level history - no clock,
+no collector, no run context - so it is unit-tested without a server.
 
 ### Scenario load runs - the virtual-user state machine
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -170,7 +170,10 @@ Notes:
   search's *ceiling* (`concurrency`) and its starting level
   (`startConcurrency`), which is what stops an adaptive run from outgrowing it;
   `sloMs` and `stepDuration` are that mode's own two fields, and
-  `get_run_report` returns the search's findings under `capacity`. `get_live_metrics` is a **bounded snapshot** (SSE
+  `get_run_report` returns the search's findings under `capacity`. The duration
+  cap accounts for the mode's own engine-side default deadline (5 minutes, not
+  the 60s other modes fall back to), so a cap between those two values still
+  injects an explicit `duration` when the agent omits one. `get_live_metrics` is a **bounded snapshot** (SSE
   read with a time budget), not a stream - `tools/call` stays request/response.
 - **`update_engine_config`** reads the config back after applying and flags any
   changed key that needs an engine **restart** to take effect under

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -159,14 +159,18 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `delete_request`       | write    | `GET /requests/:id` + `DELETE /requests/:id` | write toggle + confirm     |
 | `update_environment`   | write    | `GET /environments` (scan) + `PUT /environments/:id` (fetch-merge) | write toggle |
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
-| `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm; optional `thresholds` budgets |
+| `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm; optional `thresholds` budgets; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity` |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
 
 Notes:
 
 - **`start_load_run`** requires confirmation - via elicitation when the client
   supports it, otherwise a `confirmed: true` flag - and enforces the RPS /
-  concurrency / duration caps. `get_live_metrics` is a **bounded snapshot** (SSE
+  concurrency / duration caps. In `capacity` mode the concurrency cap bounds the
+  search's *ceiling* (`concurrency`) and its starting level
+  (`startConcurrency`), which is what stops an adaptive run from outgrowing it;
+  `sloMs` and `stepDuration` are that mode's own two fields, and
+  `get_run_report` returns the search's findings under `capacity`. `get_live_metrics` is a **bounded snapshot** (SSE
   read with a time budget), not a stream - `tools/call` stays request/response.
 - **`update_engine_config`** reads the config back after applying and flags any
   changed key that needs an engine **restart** to take effect under

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -285,6 +285,7 @@ add_library(vayu_core STATIC
     src/core/metrics_collector.cpp
     src/core/sample_capture.cpp
     src/core/threshold_eval.cpp
+    src/core/capacity_controller.cpp
     ${PLATFORM_SOURCES}
 )
 
@@ -459,6 +460,7 @@ if(VAYU_BUILD_TESTS)
         tests/sample_capture_test.cpp
         tests/load_pacing_test.cpp
         tests/threshold_eval_test.cpp
+        tests/capacity_controller_test.cpp
         tests/run_manager_test.cpp
         tests/run_route_test.cpp
         tests/run_stop_test.cpp

--- a/engine/include/vayu/core/capacity_controller.hpp
+++ b/engine/include/vayu/core/capacity_controller.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file capacity_controller.hpp
+ * @brief Pure core for the capacity-discovery run mode: given what each
+ *        concurrency level measured, what level to run next and when to stop.
+ *
+ * Finding a service's capacity used to be manual bisection - guess a
+ * `concurrency`, run a ramp, read the dashboard, adjust, repeat. Every other
+ * strategy's `target_fn` is a pure function of elapsed time and constants, so
+ * none of them can react to what latency is doing; this file is the feedback
+ * half that lets one of them.
+ *
+ * The controller is deliberately split out of the strategy the way
+ * `load_pacing` and `threshold_eval` are: it holds no clock, no metrics
+ * collector and no run context, so its whole policy is unit-testable without a
+ * server. The strategy owns the clock (the deadline stop lives there, because
+ * only it knows elapsed time) and feeds one @ref CapacityWindow per completed
+ * level in here.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace vayu::core {
+
+/// What one concurrency level measured while it was held.
+struct CapacityWindow {
+    size_t concurrency = 0;
+    /// Mean throughput observed over the level's settled ticks.
+    double rps = 0.0;
+    /// Mean of the level's windowed p99 samples - the signal the SLO is judged
+    /// against, and the same number the dashboard's live chart shows.
+    double p99_ms = 0.0;
+};
+
+/// The search's tunables. The first five come off the run config; the rest are
+/// policy constants (`constants::capacity`) exposed as fields so the tests can
+/// vary them without a config knob nobody asked for.
+struct CapacityConfig {
+    /// Latency budget the search is looking for the edge of, in ms.
+    double slo_ms = 200.0;
+    /// How long each level is held before its window is judged.
+    int64_t step_duration_ms = 5000;
+    /// The level the search starts at.
+    size_t start_concurrency = 1;
+    /// The ceiling the search will not climb past.
+    size_t max_concurrency = 100;
+    /// Wall-clock budget for the whole search. Enforced by the strategy, not
+    /// here - this struct carries it so one object describes the whole run.
+    int64_t deadline_ms = 60000;
+    /// Fractional growth per healthy step, floored at +1 concurrency.
+    double step_growth = 0.25;
+    /// Below this percentage of throughput gained across the last two step-ups,
+    /// the service is saturated even though it is still inside the SLO.
+    double plateau_gain_pct = 5.0;
+    /// Consecutive breaching windows before the search stops. Two, not one, so
+    /// a single noisy window re-measures instead of ending the run.
+    size_t slo_breach_windows = 2;
+};
+
+enum class CapacityAction { Hold, StepUp, Stop };
+
+/// Stop reasons, as they appear in the report's `capacity.stopReason`. Named
+/// constants rather than string literals at each `return`, so the report, the
+/// tests and the logs cannot spell them three ways.
+namespace capacity_stop {
+inline constexpr const char* SLO_EXCEEDED = "slo_exceeded";
+inline constexpr const char* PLATEAU      = "plateau";
+inline constexpr const char* CAP_REACHED  = "cap_reached";
+inline constexpr const char* DEADLINE     = "deadline";
+/// The operator stopped the run before the search reached a conclusion. Not one
+/// of the four the search decides for itself, and deliberately distinct from
+/// `deadline`: a cancelled search found no limit, and saying it ran out of
+/// clock would claim a measurement that was never taken.
+inline constexpr const char* STOPPED = "stopped";
+} // namespace capacity_stop
+
+struct CapacityDecision {
+    CapacityAction action = CapacityAction::StepUp;
+    /// The level to run next. Meaningful for `Hold` and `StepUp`; left at the
+    /// last level for `Stop`.
+    size_t next_concurrency = 0;
+    /// Set iff `action == Stop`; one of `capacity_stop::*`. A `const char*`
+    /// because every value is a literal with static storage duration.
+    const char* stop_reason = nullptr;
+};
+
+/**
+ * @brief Decide what the search does after the windows in @p history.
+ *
+ * Total over any history, including an empty one (which answers "start at
+ * `start_concurrency`"), so the strategy has no special first-step branch.
+ *
+ * The policy, in the order it is applied:
+ * - `slo_breach_windows` consecutive breaching windows → stop `slo_exceeded`.
+ * - a single breaching window → **hold** the same level and re-measure. The
+ *   consecutive requirement is the whole reason `Hold` exists: one unlucky
+ *   window (a GC pause, a cold cache) is not a capacity limit.
+ * - throughput gained across the last two step-ups below `plateau_gain_pct`
+ *   → stop `plateau`. The service is inside its latency budget and no longer
+ *   converting concurrency into work, which is a capacity limit too.
+ * - already at `max_concurrency` → stop `cap_reached`.
+ * - otherwise step up by `step_growth`, at least +1, clamped to the cap.
+ *
+ * The `deadline` stop is not decided here - it is time, and this function
+ * holds no clock. @ref summarize_capacity takes the reason from the caller for
+ * the same reason.
+ */
+[[nodiscard]] CapacityDecision
+decide_next_level (const CapacityConfig& config, const std::vector<CapacityWindow>& history);
+
+/// The answer a capacity run exists to give, plus the audit trail behind it.
+struct CapacitySummary {
+    double slo_ms           = 0.0;
+    std::string stop_reason;
+    /// The highest level that stayed inside the SLO, and what it did there.
+    /// Absent when the very first level already breached - the search never
+    /// found a healthy level, and reporting zero would read like one.
+    std::optional<CapacityWindow> max_healthy;
+    /// The level the service gave out at: the first breaching level above
+    /// `max_healthy`. Absent when the search ended for a reason other than
+    /// latency (a cap, a deadline, a plateau inside the budget) - there is no
+    /// knee to report, and inventing one from the last level would claim a
+    /// limit that was never observed.
+    std::optional<CapacityWindow> knee;
+    /// One entry per level held, in order, including a re-measured hold.
+    std::vector<CapacityWindow> levels;
+};
+
+/**
+ * @brief Derive the headline numbers from the levels the search held.
+ *
+ * @param stop_reason Why the search ended, one of `capacity_stop::*`. Taken
+ *        rather than re-derived: only the caller knows whether the run ran out
+ *        of clock, and re-deriving it here could disagree with the decision
+ *        that actually ended the loop.
+ */
+[[nodiscard]] CapacitySummary summarize_capacity (const CapacityConfig& config,
+const std::vector<CapacityWindow>& history,
+const char* stop_reason);
+
+/// Serialize a summary into the object stored under the run summary's
+/// `capacity` key (snake_case, like every other stored section).
+[[nodiscard]] nlohmann::json build_capacity_summary_payload (const CapacitySummary& summary);
+
+/**
+ * @brief Read the capacity fields off a run config, clamped to something the
+ *        search can actually run.
+ *
+ * Total over arbitrary JSON: the route validates a client body, but a stored
+ * config snapshot may have been written by an older engine or hand-edited, and
+ * a start above the cap is a search with nowhere to go rather than an error the
+ * run thread can usefully throw on. `duration` and `stepDuration` are read by
+ * the caller (they go through `duration_field_ms`, which throws on a malformed
+ * unit) and passed in.
+ */
+[[nodiscard]] CapacityConfig capacity_config_from (const nlohmann::json& config,
+int64_t step_duration_ms,
+int64_t deadline_ms);
+
+} // namespace vayu::core

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -165,6 +165,16 @@ constexpr int64_t SLO_MS = 200;
 /// windowed percentiles to settle at the stock 100ms tick cadence, short enough
 /// that a search over tens of levels finishes inside a normal run duration.
 constexpr int64_t STEP_DURATION_MS = 5000;
+/// Deadline for the whole search when the run config names no `duration`.
+///
+/// Deliberately **not** the 60s every other mode falls back to: at the default
+/// step this mode walks a level every 5s, so a minute is a dozen levels and a
+/// search that almost always ends `deadline` rather than finding anything. It
+/// is a named constant rather than a literal because the MCP duration cap has
+/// to know it - a guard assuming one default for every mode let a capacity run
+/// past a cap it was under - and `safety.test.ts` reads this line to stay in
+/// step.
+constexpr int64_t DEADLINE_MS = 300000;
 /// Ticks discarded at the start of each level: the in-flight count is still
 /// climbing to the new target, so those windows measure the transition rather
 /// than the level. At the stock cadence this is the first 300ms of every step.

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -142,7 +142,44 @@ constexpr int64_t MAX_SAMPLE_BYTES = 1073741824; // 1GB
 /// Upper bound on `max_exemplar_results`. Each retained exemplar holds a
 /// captured exchange, bounded in turn by the two budgets above.
 constexpr int64_t MAX_EXEMPLAR_RESULTS = 100000;
+/// Upper bound on a capacity run's `sloMs`. Mirrors the app's own clamp on the
+/// client-side SLO setting (`app/src/constants/client-settings.ts`), so a
+/// budget the dialog can express is one the engine accepts.
+constexpr int64_t MAX_SLO_MS = 60000;
 } // namespace run_config
+
+/**
+ * @brief Defaults for the capacity-discovery search.
+ *
+ * Only the first three are settable per run (`sloMs`, `stepDuration`, and the
+ * `startConcurrency`/`concurrency` bounds the other modes already own). The
+ * rest are the controller's policy: they live here rather than as run-config
+ * keys because a user asking "what can my service take" is not also choosing a
+ * step-growth factor, and a knob nobody sets is a knob nobody maintains.
+ */
+namespace capacity {
+/// Default latency budget the search looks for the edge of, in ms. Matches the
+/// app's `DEFAULT_SLO_THRESHOLD_MS` so the dialog's prefill is the same number.
+constexpr int64_t SLO_MS = 200;
+/// How long each level is held before its window is judged. Long enough for the
+/// windowed percentiles to settle at the stock 100ms tick cadence, short enough
+/// that a search over tens of levels finishes inside a normal run duration.
+constexpr int64_t STEP_DURATION_MS = 5000;
+/// Ticks discarded at the start of each level: the in-flight count is still
+/// climbing to the new target, so those windows measure the transition rather
+/// than the level. At the stock cadence this is the first 300ms of every step.
+constexpr size_t SETTLE_TICKS = 3;
+/// Concurrency cap when the run config names none.
+constexpr int64_t MAX_CONCURRENCY = 100;
+/// Fractional growth per healthy step (+25%), floored at +1 concurrency.
+constexpr double STEP_GROWTH = 0.25;
+/// Below this percentage of throughput gained across the last two step-ups, the
+/// service is saturated even though it is still inside its latency budget.
+constexpr double PLATEAU_GAIN_PCT = 5.0;
+/// Consecutive breaching windows before the search stops. Two, not one, so a
+/// single noisy window re-measures instead of ending the run.
+constexpr size_t SLO_BREACH_WINDOWS = 2;
+} // namespace capacity
 
 /**
  * @brief Server configuration

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -508,6 +508,16 @@ class MetricsCollector {
      * @note Call after test completion - sorts the latencies vector
      */
     struct Percentiles {
+        /**
+         * How many completions the histogram these came from held.
+         *
+         * Zero is the only way to tell "nothing completed in this window" from
+         * "everything completed instantly" - both report percentiles of 0. A
+         * capacity search averages a level's windowed p99 across ticks, and
+         * without this it would average in every idle window and conclude a
+         * 500ms endpoint was meeting a 100ms budget.
+         */
+        size_t count = 0;
         double p50  = 0.0;
         double p75  = 0.0;
         double p90  = 0.0;

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "vayu/core/capacity_controller.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -238,6 +239,63 @@ struct RunContext {
         refill_cv.notify_one ();
     }
 
+    // ---- Published metric tick (the strategies' one feedback path) --------
+    /**
+     * The numbers of the most recent live tick, as the dashboard sees them.
+     *
+     * The capacity strategy needs windowed percentiles to steer by, and it must
+     * NOT call `MetricsCollector::sample_window_percentiles()` for them: that
+     * call is documented single-reader and *resets* the window on read, and the
+     * metrics thread already consumes it once per tick in `emit_live_tick`. A
+     * second consumer would silently halve both readers' sample counts.
+     *
+     * So the producer publishes what it already computed, and the strategy
+     * copies it out. One writer (the metrics thread), cheap reads, and the
+     * controller steers by exactly the figures the live chart is drawing.
+     */
+    struct LiveTick {
+        /// Monotonic per run, starting at 1. A reader compares it against the
+        /// last one it saw to tell a fresh tick from a re-read of the same one;
+        /// a wall-clock timestamp cannot, since two ticks can share a
+        /// millisecond and the clock can step.
+        uint64_t sequence     = 0;
+        double latency_p50_ms = 0.0;
+        double latency_p95_ms = 0.0;
+        double latency_p99_ms = 0.0;
+        double current_rps    = 0.0;
+        size_t in_flight      = 0;
+        /// Completions the percentiles above were computed over. Zero means an
+        /// idle window, whose percentiles are zeros and must not be read as a
+        /// service answering instantly.
+        size_t latency_samples = 0;
+    };
+    mutable std::mutex live_tick_mtx;
+    std::optional<LiveTick> live_tick_; // live_tick_mtx
+
+    /// Publish this tick's numbers. Called once per tick by the metrics thread
+    /// and by nothing else.
+    void publish_live_tick (const LiveTick& tick) {
+        std::lock_guard<std::mutex> lock (live_tick_mtx);
+        LiveTick published = tick;
+        published.sequence = live_tick_ ? live_tick_->sequence + 1 : 1;
+        live_tick_         = published;
+    }
+
+    /// The most recently published tick, or `nullopt` before the first one.
+    [[nodiscard]] std::optional<LiveTick> latest_live_tick () const {
+        std::lock_guard<std::mutex> lock (live_tick_mtx);
+        return live_tick_;
+    }
+
+    /**
+     * What a capacity run's search found, written by `CapacityLoadStrategy`
+     * once its loop ends and read by `execute_load_test` when it builds the
+     * summary - both on the worker thread, after the strategy's frame has
+     * returned, so it needs no lock of its own. Absent for every other mode,
+     * which is what keeps the report's `capacity` section out.
+     */
+    std::optional<CapacitySummary> capacity;
+
     // Legacy accessors for backward compatibility (delegate to metrics_collector)
     [[nodiscard]] size_t total_requests () const {
         return metrics_collector ? metrics_collector->total_requests () : 0;
@@ -449,6 +507,10 @@ struct RunSummaryInputs {
     // rather than reporting a run that passed zero checks. Sibling of `tests`,
     // and the aggregate answer a per-response script structurally cannot give.
     std::optional<ThresholdOutcome> thresholds;
+    // What a capacity run's adaptive search found. Absent for every other mode,
+    // which keeps the report's `capacity` section out rather than showing a
+    // fixed-target run a knee it never looked for.
+    std::optional<CapacitySummary> capacity;
     SamplingRetention retention;
     // A scenario load run's sequence tallies and per-step breakdown, stored
     // under the summary's `scenario` key. Absent for a single-request load run,

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -738,7 +738,15 @@ inline std::optional<RunType> parse_run_type (const std::string& str) {
     return std::nullopt;
 }
 
-enum class LoadTestType { ConstantRps, ConstantConcurrency, RampUp, Iterations };
+/**
+ * @brief How a load run decides what to send.
+ *
+ * `Capacity` is the one member that is not a fixed shape chosen up front: it
+ * is an adaptive step-ramp steered by the run's own latency, so it reads the
+ * published metric tick and stops itself. Every other member's target is a
+ * pure function of elapsed time.
+ */
+enum class LoadTestType { ConstantRps, ConstantConcurrency, RampUp, Iterations, Capacity };
 
 inline const char* to_string (LoadTestType type) {
     switch (type) {
@@ -746,6 +754,7 @@ inline const char* to_string (LoadTestType type) {
     case LoadTestType::ConstantConcurrency: return "constant_concurrency";
     case LoadTestType::RampUp: return "ramp_up";
     case LoadTestType::Iterations: return "iterations";
+    case LoadTestType::Capacity: return "capacity";
     }
     return "unknown";
 }
@@ -759,6 +768,8 @@ inline std::optional<LoadTestType> parse_load_test_type (const std::string& str)
         return LoadTestType::RampUp;
     if (str == "iterations")
         return LoadTestType::Iterations;
+    if (str == "capacity")
+        return LoadTestType::Capacity;
     return std::nullopt;
 }
 

--- a/engine/src/core/capacity_controller.cpp
+++ b/engine/src/core/capacity_controller.cpp
@@ -189,11 +189,21 @@ int64_t deadline_ms) {
 
     out.slo_ms = number ("sloMs", static_cast<double> (defaults::SLO_MS));
 
-    const double start = number ("startConcurrency", 1.0);
-    const double cap   = number ("concurrency", static_cast<double> (defaults::MAX_CONCURRENCY));
+    // Clamped to the route's own connection guard *before* the cast, not after.
+    // Narrowing a double past `SIZE_MAX` to `size_t` is undefined behaviour, and
+    // finite-and-positive is not enough to rule it out: a hand-edited snapshot
+    // carrying `1e30` clears both checks and then converts to 0 or to some
+    // arbitrary huge value depending on the platform, so the search would run at
+    // a garbage level. The route rejects such a value with a 400, but this
+    // function is documented total over stored snapshots no route ever saw.
+    auto concurrency_level = [&number] (const char* key, double fallback) -> size_t {
+        constexpr double kGuard = static_cast<double> (constants::run_config::MAX_CONCURRENCY);
+        return static_cast<size_t> (std::min (number (key, fallback), kGuard));
+    };
 
-    out.start_concurrency = static_cast<size_t> (start);
-    out.max_concurrency   = static_cast<size_t> (cap);
+    out.start_concurrency = concurrency_level ("startConcurrency", 1.0);
+    out.max_concurrency =
+    concurrency_level ("concurrency", static_cast<double> (defaults::MAX_CONCURRENCY));
     // A cap below the start is a search with nowhere to go; it runs the one
     // level and stops `cap_reached` rather than climbing past the ceiling.
     out.max_concurrency = std::max (out.max_concurrency, out.start_concurrency);

--- a/engine/src/core/capacity_controller.cpp
+++ b/engine/src/core/capacity_controller.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/core/capacity_controller.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "vayu/core/constants.hpp"
+
+namespace vayu::core {
+
+namespace {
+
+bool breaches (const CapacityWindow& window, double slo_ms) {
+    return window.p99_ms > slo_ms;
+}
+
+/**
+ * The history with each level represented once, by its *last* window.
+ *
+ * A held level appears twice - the window that breached and the re-measure
+ * that cleared it - and the plateau check compares throughput across step-ups,
+ * so counting a hold as a step would compare a level against itself and call
+ * every re-measure a plateau.
+ */
+std::vector<CapacityWindow> per_level (const std::vector<CapacityWindow>& history) {
+    std::vector<CapacityWindow> levels;
+    for (const auto& window : history) {
+        if (!levels.empty () && levels.back ().concurrency == window.concurrency) {
+            levels.back () = window;
+        } else {
+            levels.push_back (window);
+        }
+    }
+    return levels;
+}
+
+/// True when the last two step-ups bought less than `plateau_gain_pct` more
+/// throughput. Needs three distinct, strictly increasing levels; anything less
+/// is not yet an answer, and a non-positive baseline rps has no percentage.
+bool plateaued (const CapacityConfig& config, const std::vector<CapacityWindow>& levels) {
+    if (levels.size () < 3) {
+        return false;
+    }
+    const auto& base = levels[levels.size () - 3];
+    const auto& mid  = levels[levels.size () - 2];
+    const auto& top  = levels[levels.size () - 1];
+    if (!(base.concurrency < mid.concurrency && mid.concurrency < top.concurrency)) {
+        return false;
+    }
+    if (!(base.rps > 0.0)) {
+        return false;
+    }
+    const double gain_pct = (top.rps - base.rps) * 100.0 / base.rps;
+    return gain_pct < config.plateau_gain_pct;
+}
+
+size_t next_level_above (const CapacityConfig& config, size_t current) {
+    const double grown = static_cast<double> (current) * (1.0 + config.step_growth);
+    size_t next        = current + 1;
+    if (std::isfinite (grown) && grown > static_cast<double> (next)) {
+        next = static_cast<size_t> (grown);
+    }
+    return std::min (next, config.max_concurrency);
+}
+
+} // namespace
+
+CapacityDecision
+decide_next_level (const CapacityConfig& config, const std::vector<CapacityWindow>& history) {
+    if (history.empty ()) {
+        return { CapacityAction::StepUp, config.start_concurrency, nullptr };
+    }
+
+    const CapacityWindow& last = history.back ();
+
+    size_t trailing_breaches = 0;
+    for (auto it = history.rbegin (); it != history.rend (); ++it) {
+        if (!breaches (*it, config.slo_ms)) {
+            break;
+        }
+        ++trailing_breaches;
+    }
+
+    if (trailing_breaches >= config.slo_breach_windows) {
+        return { CapacityAction::Stop, last.concurrency, capacity_stop::SLO_EXCEEDED };
+    }
+    if (trailing_breaches > 0) {
+        // One breaching window is a suspicion, not a verdict: re-measure the
+        // same level rather than ending the search on a GC pause.
+        return { CapacityAction::Hold, last.concurrency, nullptr };
+    }
+
+    // Plateau is checked before the cap because it says something about the
+    // *service* - it stopped converting concurrency into work - while the cap
+    // only says the search ran out of room the caller gave it. When both hold,
+    // the first is the more useful answer.
+    if (plateaued (config, per_level (history))) {
+        return { CapacityAction::Stop, last.concurrency, capacity_stop::PLATEAU };
+    }
+    if (last.concurrency >= config.max_concurrency) {
+        return { CapacityAction::Stop, last.concurrency, capacity_stop::CAP_REACHED };
+    }
+
+    return { CapacityAction::StepUp, next_level_above (config, last.concurrency), nullptr };
+}
+
+CapacitySummary summarize_capacity (const CapacityConfig& config,
+const std::vector<CapacityWindow>& history,
+const char* stop_reason) {
+    CapacitySummary summary;
+    summary.slo_ms      = config.slo_ms;
+    summary.stop_reason = stop_reason != nullptr ? stop_reason : "";
+    summary.levels      = history;
+
+    for (const auto& window : history) {
+        if (breaches (window, config.slo_ms)) {
+            continue;
+        }
+        if (!summary.max_healthy || window.concurrency >= summary.max_healthy->concurrency) {
+            summary.max_healthy = window;
+        }
+    }
+
+    // A knee is only ever reported for the stop that observed one. A run that
+    // ended at its cap, its deadline, or on a plateau inside the budget never
+    // saw the service give out, and naming its last level "the knee" would
+    // claim a limit nothing measured.
+    if (summary.stop_reason == capacity_stop::SLO_EXCEEDED && !history.empty ()) {
+        summary.knee = history.back ();
+    }
+
+    return summary;
+}
+
+nlohmann::json build_capacity_summary_payload (const CapacitySummary& summary) {
+    nlohmann::json levels = nlohmann::json::array ();
+    for (const auto& level : summary.levels) {
+        levels.push_back ({ { "concurrency", level.concurrency }, { "rps", level.rps },
+            { "p99_ms", level.p99_ms } });
+    }
+
+    nlohmann::json payload;
+    payload["slo_ms"]      = summary.slo_ms;
+    payload["stop_reason"] = summary.stop_reason;
+    payload["levels"]      = levels;
+    // Both halves are omitted rather than zeroed when they were not observed -
+    // "the first level already breached" and "the service sustained nothing"
+    // are different findings, and only the absent key can say the first.
+    if (summary.max_healthy) {
+        payload["max_healthy_concurrency"] = summary.max_healthy->concurrency;
+        payload["max_healthy_rps"]         = summary.max_healthy->rps;
+        payload["p99_at_max_healthy_ms"]   = summary.max_healthy->p99_ms;
+    }
+    if (summary.knee) {
+        payload["knee_concurrency"] = summary.knee->concurrency;
+        payload["knee_p99_ms"]      = summary.knee->p99_ms;
+    }
+    return payload;
+}
+
+CapacityConfig capacity_config_from (const nlohmann::json& config,
+int64_t step_duration_ms,
+int64_t deadline_ms) {
+    namespace defaults = constants::capacity;
+
+    CapacityConfig out;
+    out.step_duration_ms = step_duration_ms > 0 ? step_duration_ms : defaults::STEP_DURATION_MS;
+    out.deadline_ms      = deadline_ms;
+    out.step_growth      = defaults::STEP_GROWTH;
+    out.plateau_gain_pct = defaults::PLATEAU_GAIN_PCT;
+    out.slo_breach_windows = defaults::SLO_BREACH_WINDOWS;
+
+    // Read through an explicit type check rather than `json::value`, which
+    // *throws* on a key holding the wrong type. The route rejects those, but
+    // this also reads stored config snapshots, which no route ever saw.
+    auto number = [&config] (const char* key, double fallback) {
+        if (!config.is_object () || !config.contains (key) || !config[key].is_number ()) {
+            return fallback;
+        }
+        const double value = config[key].get<double> ();
+        return std::isfinite (value) && value > 0.0 ? value : fallback;
+    };
+
+    out.slo_ms = number ("sloMs", static_cast<double> (defaults::SLO_MS));
+
+    const double start = number ("startConcurrency", 1.0);
+    const double cap   = number ("concurrency", static_cast<double> (defaults::MAX_CONCURRENCY));
+
+    out.start_concurrency = static_cast<size_t> (start);
+    out.max_concurrency   = static_cast<size_t> (cap);
+    // A cap below the start is a search with nowhere to go; it runs the one
+    // level and stops `cap_reached` rather than climbing past the ceiling.
+    out.max_concurrency = std::max (out.max_concurrency, out.start_concurrency);
+    return out;
+}
+
+} // namespace vayu::core

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -700,7 +700,8 @@ class CapacityLoadStrategy : public LoadStrategy {
     const vayu::Request& request) override {
         const auto& config = context->config;
 
-        const int64_t deadline_ms = duration_field_ms (config, "duration", 300000);
+        const int64_t deadline_ms =
+        duration_field_ms (config, "duration", constants::capacity::DEADLINE_MS);
         const int64_t step_ms = duration_field_ms (config, "stepDuration",
         constants::capacity::STEP_DURATION_MS);
         const CapacityConfig capacity_config =

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -547,6 +547,199 @@ class RampUpLoadStrategy : public LoadStrategy {
 };
 
 // ============================================================================
+// Capacity Discovery Load Strategy
+// ============================================================================
+
+namespace {
+
+/**
+ * The moving parts of a capacity search that the pure controller deliberately
+ * does not hold: the clock, the tick feed, and the window being accumulated.
+ *
+ * All of it is touched from the `maintain_concurrency` closures, which run on
+ * the strategy thread and nowhere else - `target_fn` is evaluated inside the
+ * refill condition-variable predicate, but a predicate runs on the waiting
+ * thread, so there is one thread here and no lock is owed.
+ */
+class CapacitySearch {
+    public:
+    CapacitySearch (CapacityConfig config, std::shared_ptr<RunContext> context)
+    : config_ (config), context_ (std::move (context)) {
+    }
+
+    /// The level to hold right now. Zero before the first window opens, which
+    /// only happens if `advance` has not been called yet.
+    [[nodiscard]] size_t level () const {
+        return current_;
+    }
+
+    /**
+     * Drive the search one step. Returns whether the run should keep going -
+     * this is `maintain_concurrency`'s `should_continue`, so returning false
+     * ends the run.
+     */
+    bool advance (int64_t elapsed_ms) {
+        if (stop_reason_ != nullptr) {
+            return false;
+        }
+        // The deadline lives here rather than in the controller because it is
+        // the one stop condition that is about time rather than about what the
+        // service did, and the controller holds no clock.
+        if (elapsed_ms >= config_.deadline_ms) {
+            stop_reason_ = capacity_stop::DEADLINE;
+            return false;
+        }
+
+        collect_tick ();
+
+        if (current_ == 0) {
+            open_level (decide_next_level (config_, history_).next_concurrency, elapsed_ms);
+            return true;
+        }
+        if (elapsed_ms - level_started_ms_ < config_.step_duration_ms) {
+            return true;
+        }
+        if (latency_windows_ == 0) {
+            // Not one completion landed in the whole step, so every windowed
+            // percentile it saw was the empty-window zero. Judging the level on
+            // those would read a service that answered nothing as one that
+            // answered instantly, and the search would climb straight past the
+            // limit it exists to find. The level stays open instead; a search
+            // that never gets a completion ends on its deadline having reported
+            // only the levels it actually measured.
+            return true;
+        }
+
+        history_.push_back ({ current_,
+        rps_windows_ > 0 ? rps_sum_ / static_cast<double> (rps_windows_) : 0.0,
+        p99_sum_ / static_cast<double> (latency_windows_) });
+
+        const CapacityDecision decision = decide_next_level (config_, history_);
+        switch (decision.action) {
+        case CapacityAction::Stop: stop_reason_ = decision.stop_reason; return false;
+        case CapacityAction::Hold:
+        case CapacityAction::StepUp: open_level (decision.next_concurrency, elapsed_ms); return true;
+        }
+        return true;
+    }
+
+    /// What the search found. The level still being measured when the run ended
+    /// is dropped: `levels[]` holds judged windows only, and a partial one
+    /// would sit in the audit trail looking like a measurement.
+    [[nodiscard]] CapacitySummary finish () const {
+        const char* reason = stop_reason_;
+        if (reason == nullptr) {
+            reason = context_->should_stop ? capacity_stop::STOPPED : capacity_stop::DEADLINE;
+        }
+        return summarize_capacity (config_, history_, reason);
+    }
+
+    private:
+    void open_level (size_t level, int64_t now_ms) {
+        current_          = level;
+        level_started_ms_ = now_ms;
+        ticks_seen_       = 0;
+        rps_windows_      = 0;
+        latency_windows_  = 0;
+        rps_sum_          = 0.0;
+        p99_sum_          = 0.0;
+        // Adopt the newest published sequence so the first tick this level
+        // counts is one produced after the target moved, not the one already
+        // sitting there describing the previous level.
+        if (auto tick = context_->latest_live_tick ()) {
+            last_sequence_ = tick->sequence;
+        }
+    }
+
+    void collect_tick () {
+        auto tick = context_->latest_live_tick ();
+        if (!tick || tick->sequence <= last_sequence_) {
+            return;
+        }
+        last_sequence_ = tick->sequence;
+        ++ticks_seen_;
+        // The first ticks after a target change measure the transition - the
+        // in-flight count is still climbing - so they are watched but not
+        // counted.
+        if (ticks_seen_ <= constants::capacity::SETTLE_TICKS) {
+            return;
+        }
+        rps_sum_ += tick->current_rps;
+        ++rps_windows_;
+        // An idle window reports percentiles of zero, which averaged in with
+        // real ones would understate the level's latency by however much of the
+        // step went quiet - at one completion per 500ms against a 100ms tick,
+        // by a factor of five. Throughput has no such problem: an idle window
+        // really is zero requests per second.
+        if (tick->latency_samples > 0) {
+            p99_sum_ += tick->latency_p99_ms;
+            ++latency_windows_;
+        }
+    }
+
+    CapacityConfig config_;
+    std::shared_ptr<RunContext> context_;
+    std::vector<CapacityWindow> history_;
+    size_t current_           = 0;
+    int64_t level_started_ms_ = 0;
+    uint64_t last_sequence_   = 0;
+    size_t ticks_seen_        = 0;
+    size_t rps_windows_       = 0;
+    size_t latency_windows_   = 0;
+    double rps_sum_           = 0.0;
+    double p99_sum_           = 0.0;
+    const char* stop_reason_  = nullptr;
+};
+
+} // namespace
+
+class CapacityLoadStrategy : public LoadStrategy {
+    public:
+    void execute (std::shared_ptr<RunContext> context,
+    vayu::db::Database& db,
+    const vayu::Request& request) override {
+        const auto& config = context->config;
+
+        const int64_t deadline_ms = duration_field_ms (config, "duration", 300000);
+        const int64_t step_ms = duration_field_ms (config, "stepDuration",
+        constants::capacity::STEP_DURATION_MS);
+        const CapacityConfig capacity_config =
+        capacity_config_from (config, step_ms, deadline_ms);
+
+        vayu::utils::log_info ("Starting Capacity Discovery Load Test");
+        vayu::utils::log_info ("  SLO: p99 < " + std::to_string (capacity_config.slo_ms) + " ms");
+        vayu::utils::log_info (
+        "  Step duration: " + std::to_string (capacity_config.step_duration_ms) + " ms");
+        vayu::utils::log_info ("  Concurrency: " +
+        std::to_string (capacity_config.start_concurrency) + " -> " +
+        std::to_string (capacity_config.max_concurrency));
+        vayu::utils::log_info ("  Deadline: " + std::to_string (deadline_ms) + " ms");
+
+        auto submit_one = [&context, &db, &request] () {
+            context->event_loop->submit (request,
+            [context, &db] (size_t, vayu::Result<vayu::Response> result) {
+                handle_result (context, db, std::move (result));
+            });
+            context->requests_sent++;
+        };
+
+        CapacitySearch search (capacity_config, context);
+
+        maintain_concurrency (
+        context, submit_one, [&search] (int64_t) { return search.level (); },
+        [] () { return std::numeric_limits<size_t>::max (); },
+        [&search] (int64_t el) { return search.advance (el); });
+
+        // Written before this frame returns, and read by execute_load_test
+        // after it - same thread, so the summary sees a complete search.
+        context->capacity = search.finish ();
+        vayu::utils::log_info (
+        "Capacity search stopped: " + context->capacity->stop_reason + " (" +
+        std::to_string (context->capacity->levels.size ()) + " levels measured)");
+    }
+};
+
+// ============================================================================
 // Factory
 // ============================================================================
 
@@ -568,6 +761,7 @@ std::unique_ptr<LoadStrategy> LoadStrategy::create (const nlohmann::json& config
     case LoadTestType::Iterations:
         return std::make_unique<IterationsLoadStrategy> ();
     case LoadTestType::RampUp: return std::make_unique<RampUpLoadStrategy> ();
+    case LoadTestType::Capacity: return std::make_unique<CapacityLoadStrategy> ();
     }
 
     return std::make_unique<ConstantLoadStrategy> ();

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -527,6 +527,7 @@ MetricsCollector::Percentiles MetricsCollector::calculate_percentiles () {
         return static_cast<double> (us) / 1000.0;
     };
 
+    result.count = static_cast<size_t> (latency_histogram_->total_count);
     result.min  = us_to_ms (hdr_min (latency_histogram_));
     result.max  = us_to_ms (hdr_max (latency_histogram_));
     result.p50  = us_to_ms (hdr_value_at_percentile (latency_histogram_, 50.0));
@@ -560,6 +561,7 @@ MetricsCollector::Percentiles MetricsCollector::sample_window_percentiles () {
         return static_cast<double> (us) / 1000.0;
     };
 
+    result.count = static_cast<size_t> (interval->total_count);
     result.min  = us_to_ms (hdr_min (interval));
     result.max  = us_to_ms (hdr_max (interval));
     result.p50  = us_to_ms (hdr_value_at_percentile (interval, 50.0));

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -954,6 +954,9 @@ RunManager& manager) {
             inputs.http_version_downgraded =
             context->metrics_collector->http_version_downgraded ();
             inputs.tests     = validation.run;
+            // Written by the capacity strategy before its execute() returned,
+            // so it is already final here; absent for every other mode.
+            inputs.capacity  = context->capacity;
             inputs.retention = read_retention (*context->metrics_collector);
             // Read only now, after the drain above: a completion callback can
             // still be advancing a VU while the strategy's own frame has
@@ -1169,6 +1172,12 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
             { "passed", inputs.thresholds->passed },
             { "failed", inputs.thresholds->failed } };
     }
+    // What a capacity run's search found, level by level. Omitted for every
+    // other mode - a fixed-target run measured a point, not a curve, and has
+    // no knee to report.
+    if (inputs.capacity.has_value ()) {
+        summary["capacity"] = build_capacity_summary_payload (*inputs.capacity);
+    }
     // A scenario load run's sequence tallies, under the same key and in the
     // same shape the design-mode runner writes - one report section, two
     // executors. Omitted for a single-request load run, which has no sequence.
@@ -1255,6 +1264,12 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         stats["timestamp"]        = now_wall_ms;
         stats["requestsSent"]     = requests_sent;
         stats["requestsExpected"] = requests_expected;
+
+        // Publish the same numbers to the strategies' feedback path, before
+        // the SSE payload rather than after: a capacity search polls this every
+        // tick, and the serialize-and-append below is the slower half.
+        context->publish_live_tick ({ 0, win_p50, win_p95, win_p99, live_current_rps,
+        backpressure, window.count });
 
         size_t offset = context->published_count.load ();
         context->append_tick (build_tick_payload (stats, offset));

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -60,6 +60,14 @@ std::optional<std::string> validate_scenario_load_config (const nlohmann::json& 
         "'iterations'";
     }
 
+    if (*type == LoadTestType::Capacity) {
+        return "'capacity' is not available for scenario runs: the search "
+               "judges one windowed p99, and a sequence has one per step - "
+               "which of them is 'the' latency the knee is measured against is "
+               "a question the mode does not answer. Use "
+               "'constant_concurrency', 'ramp_up' or 'iterations'.";
+    }
+
     if (*type == LoadTestType::ConstantRps) {
         return "'constant_rps' is not available for scenario runs: an "
                "open-loop "
@@ -219,7 +227,8 @@ const ScenarioExecution& execution) {
 
     const std::string mode = config.value ("mode", std::string{});
     const auto type        = parse_load_test_type (mode);
-    if (!type || *type == LoadTestType::ConstantRps || requested_rps (config) > 0.0) {
+    if (!type || *type == LoadTestType::ConstantRps || *type == LoadTestType::Capacity ||
+    requested_rps (config) > 0.0) {
         // The route rejects both with a 400 before the run row exists; this is
         // the same rule stated where the executor would otherwise have to guess.
         throw std::invalid_argument (validate_scenario_load_config (config).value_or (

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -340,6 +340,48 @@ const NumericRunField& field) {
     return std::nullopt;
 }
 
+// Reject a duration-shaped field that is present but not a positive magnitude
+// with an optional ms/s/m/h unit. Absent or null is always fine - every such
+// field has a default. Shared by `duration` and `stepDuration` rather than
+// copied, so the two cannot drift into accepting different spellings.
+std::optional<std::string> check_duration_field (const nlohmann::json& config, const char* key) {
+    if (!config.contains (key) || config[key].is_null ()) {
+        return std::nullopt;
+    }
+    const auto& value = config[key];
+    if (!value.is_string ()) {
+        return std::string ("'") + key +
+        "' must be a string with a unit, e.g. \"60s\" (got " +
+        std::string (value.type_name ()) + ")";
+    }
+    // Accept an optional unit: the unit-aware parser is #126's, and a bare
+    // "60" is what a client that never read the docs sends. This only has to
+    // separate "parses to something positive" from "wedges the run".
+    static const std::regex duration_pattern (
+    R"(^\s*(\d+(?:\.\d+)?)\s*(ms|s|m|h)?\s*$)", std::regex::icase);
+    std::smatch match;
+    const std::string text = value.get<std::string> ();
+    if (!std::regex_match (text, match, duration_pattern)) {
+        return std::string ("'") + key +
+        "' must be a number with an optional unit (ms|s|m|h), e.g. \"60s\" "
+        "(got \"" +
+        text + "\")";
+    }
+    // The regex already proved group 1 is a plain decimal, so `stod` cannot
+    // fail on it - but this guard exists precisely because a conversion threw
+    // somewhere nobody was catching, so it stays total here too.
+    double magnitude = 0.0;
+    try {
+        magnitude = std::stod (match[1].str ());
+    } catch (const std::exception&) {
+        magnitude = 0.0; // out of double's range; falls into the check below
+    }
+    if (!(magnitude > 0.0)) {
+        return std::string ("'") + key + "' must be greater than zero (got \"" + text + "\")";
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 /**
@@ -448,38 +490,13 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
                "only, because a run is identified by the row it creates";
     }
 
-    // `duration` is the one non-numeric field here, and the only one whose bad
-    // value throws rather than miscomputes: `RunContext` reads it as a string.
-    if (config.contains ("duration") && !config["duration"].is_null ()) {
-        const auto& duration = config["duration"];
-        if (!duration.is_string ()) {
-            return "'duration' must be a string with a unit, e.g. \"60s\" "
-                   "(got " +
-            std::string (duration.type_name ()) + ")";
-        }
-        // Accept an optional unit: the unit-aware parser is #126's, and a bare
-        // "60" is what a client that never read the docs sends. This only has
-        // to separate "parses to something positive" from "wedges the run".
-        static const std::regex duration_pattern (
-        R"(^\s*(\d+(?:\.\d+)?)\s*(ms|s|m|h)?\s*$)", std::regex::icase);
-        std::smatch match;
-        const std::string text = duration.get<std::string> ();
-        if (!std::regex_match (text, match, duration_pattern)) {
-            return "'duration' must be a number with an optional unit "
-                   "(ms|s|m|h), e.g. \"60s\" (got \"" +
-            text + "\")";
-        }
-        // The regex already proved group 1 is a plain decimal, so `stod` cannot
-        // fail on it - but this guard exists precisely because a conversion
-        // threw somewhere nobody was catching, so it stays total here too.
-        double magnitude = 0.0;
-        try {
-            magnitude = std::stod (match[1].str ());
-        } catch (const std::exception&) {
-            magnitude = 0.0; // out of double's range; falls into the check below
-        }
-        if (!(magnitude > 0.0)) {
-            return "'duration' must be greater than zero (got \"" + text + "\")";
+    // The duration-shaped fields are the only non-numeric ones here, and the
+    // only ones whose bad value throws rather than miscomputes: they are read
+    // as strings by `duration_field_ms`, which rejects an unknown unit at run
+    // time - far too late, since the run row already exists by then.
+    for (const char* key : { "duration", "stepDuration" }) {
+        if (auto reason = check_duration_field (config, key)) {
+            return reason;
         }
     }
 
@@ -518,6 +535,10 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         "It is a pending-request ceiling read as a size_t, so a negative value "
         "is ~1.8e19 - it removes the backpressure the field exists to provide "
         "rather than tightening it." },
+        { "sloMs", 1, limits::MAX_SLO_MS,
+        "It is the latency budget a capacity search looks for the edge of; a "
+        "non-positive budget has no edge, and one past a minute is longer than "
+        "the transfers any realistic run measures." },
         { "timeout", 1, 86400000,
         "A transfer with no timeout never completes, so the run can never "
         "reach "

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -142,6 +142,12 @@ struct ReportExtras {
     // Per-budget rows verbatim from the summary, already in the report's
     // camelCase shape - the evaluator writes the wire keys.
     nlohmann::json threshold_checks = nlohmann::json::array ();
+    // What a capacity run's search found, already translated into the report's
+    // camelCase shape. `has_capacity` false is every other mode - a run with a
+    // fixed target measured a point, not a curve, and reporting a knee of zero
+    // would name a limit nothing observed.
+    bool has_capacity       = false;
+    nlohmann::json capacity = nlohmann::json::object ();
     // What the run's bounded stores thinned away. `has_sampling` false is a
     // run recorded before retention was reported, which is not the same as a
     // run that dropped nothing - so the section is left out rather than shown
@@ -198,6 +204,69 @@ void read_number (const nlohmann::json& obj, const char* key, T& out) {
     if (obj.contains (key) && obj[key].is_number ()) {
         out = obj[key].get<T> ();
     }
+}
+
+// Translate a stored `capacity` section (snake_case, like every stored section)
+// into the report's camelCase shape.
+//
+// Every field is optional on the way in: `max_healthy_*` is absent when the
+// very first level already breached the SLO, `knee_*` when the search ended for
+// a reason other than latency, and a summary written by an older engine has
+// none of them. Only a section that carries at least the levels it measured is
+// reported at all - an empty one says nothing a reader can act on, the same
+// rule the thresholds section follows.
+void read_capacity_section (const nlohmann::json& stored, ReportExtras& extras) {
+    if (!stored.contains ("levels") || !stored["levels"].is_array ()) {
+        return;
+    }
+
+    nlohmann::json levels = nlohmann::json::array ();
+    for (const auto& level : stored["levels"]) {
+        if (!level.is_object ()) {
+            continue;
+        }
+        size_t concurrency = 0;
+        double rps         = 0.0;
+        double p99_ms      = 0.0;
+        read_number (level, "concurrency", concurrency);
+        read_number (level, "rps", rps);
+        read_number (level, "p99_ms", p99_ms);
+        levels.push_back (
+        { { "concurrency", concurrency }, { "rps", rps }, { "p99Ms", p99_ms } });
+    }
+
+    nlohmann::json capacity;
+    double slo_ms = 0.0;
+    read_number (stored, "slo_ms", slo_ms);
+    capacity["sloMs"] = slo_ms;
+    capacity["stopReason"] =
+    stored.contains ("stop_reason") && stored["stop_reason"].is_string () ?
+    stored["stop_reason"].get<std::string> () :
+    std::string{};
+    capacity["levels"] = levels;
+
+    if (stored.contains ("max_healthy_concurrency")) {
+        size_t concurrency = 0;
+        double rps         = 0.0;
+        double p99_ms      = 0.0;
+        read_number (stored, "max_healthy_concurrency", concurrency);
+        read_number (stored, "max_healthy_rps", rps);
+        read_number (stored, "p99_at_max_healthy_ms", p99_ms);
+        capacity["maxHealthyConcurrency"] = concurrency;
+        capacity["maxHealthyRps"]         = rps;
+        capacity["p99AtMaxHealthyMs"]     = p99_ms;
+    }
+    if (stored.contains ("knee_concurrency")) {
+        size_t concurrency = 0;
+        double p99_ms      = 0.0;
+        read_number (stored, "knee_concurrency", concurrency);
+        read_number (stored, "knee_p99_ms", p99_ms);
+        capacity["kneeConcurrency"] = concurrency;
+        capacity["kneeP99Ms"]       = p99_ms;
+    }
+
+    extras.has_capacity = true;
+    extras.capacity     = std::move (capacity);
 }
 
 /**
@@ -312,6 +381,10 @@ ReportExtras& extras) {
         read_number (summary["tests"], "sampled", extras.tests_sampled);
         read_number (summary["tests"], "passed", extras.tests_passed);
         read_number (summary["tests"], "failed", extras.tests_failed);
+    }
+
+    if (summary.contains ("capacity") && summary["capacity"].is_object ()) {
+        read_capacity_section (summary["capacity"], extras);
     }
 
     if (summary.contains ("thresholds") && summary["thresholds"].is_object ()) {
@@ -805,6 +878,12 @@ const std::string& run_id) {
             (static_cast<double> (extras.tests_passed) * 100.0 /
             static_cast<double> (extras.tests_passed + extras.tests_failed)) :
             0.0 } };
+    }
+
+    // What the capacity search found. Present only for a capacity run, so every
+    // other report renders exactly as it did before the mode existed.
+    if (extras.has_capacity) {
+        json_report["capacity"] = extras.capacity;
     }
 
     // The aggregate verdict, beside the per-response one. `verdict` is derived

--- a/engine/tests/capacity_controller_test.cpp
+++ b/engine/tests/capacity_controller_test.cpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/capacity_controller_test.cpp
+ * @brief The pure core behind capacity discovery: what level to run next, and
+ *        when the search has its answer.
+ *
+ * The whole policy of the mode lives in `decide_next_level`, deliberately free
+ * of a clock, a metrics collector and a run context, so every branch of it can
+ * be driven here from a hand-written history rather than from a real server
+ * that has to be persuaded to saturate.
+ *
+ * Two properties are the feature. A *single* breaching window must not end the
+ * search - it re-measures the same level, because one GC pause is not a
+ * capacity limit - and the knee must be attributed to the level that gave out
+ * while the headline stays on the last level that held, or the report answers
+ * "what can my service take" with a number it could not take.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#include "vayu/core/capacity_controller.hpp"
+#include "vayu/core/constants.hpp"
+
+namespace {
+
+using vayu::core::CapacityAction;
+using vayu::core::CapacityConfig;
+using vayu::core::CapacityWindow;
+using vayu::core::decide_next_level;
+using vayu::core::summarize_capacity;
+namespace stop = vayu::core::capacity_stop;
+
+/// A search for the edge of a 100ms p99 budget, starting at 10 and capped at
+/// 100. Growth, plateau and breach-count are left at their production values -
+/// the tests that care about one of them override that one field only, so a
+/// changed default shows up here rather than passing silently.
+CapacityConfig search () {
+    CapacityConfig config;
+    config.slo_ms            = 100.0;
+    config.start_concurrency = 10;
+    config.max_concurrency   = 100;
+    return config;
+}
+
+CapacityWindow window (size_t concurrency, double rps, double p99_ms) {
+    return CapacityWindow{ concurrency, rps, p99_ms };
+}
+
+TEST (CapacityControllerTest, EmptyHistoryStartsAtStartConcurrency) {
+    const auto decision = decide_next_level (search (), {});
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+    EXPECT_EQ (decision.next_concurrency, 10u);
+    EXPECT_EQ (decision.stop_reason, nullptr);
+}
+
+TEST (CapacityControllerTest, HealthyWindowStepsUpByGrowthFactor) {
+    const auto decision = decide_next_level (search (), { window (40, 4000, 20.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+    // +25% of 40.
+    EXPECT_EQ (decision.next_concurrency, 50u);
+}
+
+TEST (CapacityControllerTest, GrowthIsAtLeastOneConcurrency) {
+    CapacityConfig config = search ();
+    config.start_concurrency = 1;
+    // +25% of 1 rounds back to 1, which would search forever at one connection.
+    const auto decision = decide_next_level (config, { window (1, 900, 2.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+    EXPECT_EQ (decision.next_concurrency, 2u);
+}
+
+TEST (CapacityControllerTest, StepUpNeverExceedsTheCap) {
+    const auto decision = decide_next_level (search (), { window (90, 9000, 20.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+    EXPECT_EQ (decision.next_concurrency, 100u); // not 112
+}
+
+// The mutation check for the consecutive requirement: drop it from
+// decide_next_level and this test starts reporting Stop.
+TEST (CapacityControllerTest, OneBreachingWindowHoldsRatherThanStopping) {
+    const auto decision =
+    decide_next_level (search (), { window (40, 4000, 20.0), window (50, 4200, 180.0) });
+    EXPECT_EQ (decision.action, CapacityAction::Hold);
+    EXPECT_EQ (decision.next_concurrency, 50u); // re-measures the same level
+    EXPECT_EQ (decision.stop_reason, nullptr);
+}
+
+TEST (CapacityControllerTest, TwoConsecutiveBreachesStopSloExceeded) {
+    const auto decision = decide_next_level (search (),
+    { window (40, 4000, 20.0), window (50, 4200, 180.0), window (50, 4100, 210.0) });
+    EXPECT_EQ (decision.action, CapacityAction::Stop);
+    EXPECT_STREQ (decision.stop_reason, stop::SLO_EXCEEDED);
+}
+
+TEST (CapacityControllerTest, ARecoveredHoldResumesTheSearch) {
+    // The hold cleared: the breach was noise, so the search climbs again rather
+    // than holding at a level it has now measured as healthy twice.
+    const auto decision = decide_next_level (search (),
+    { window (40, 4000, 20.0), window (50, 4200, 180.0), window (50, 5000, 30.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+    EXPECT_EQ (decision.next_concurrency, 62u);
+}
+
+TEST (CapacityControllerTest, ExactlyAtTheSloIsHealthy) {
+    // The budget is "p99 under 100ms"; a p99 *of* 100ms has not breached it.
+    const auto decision = decide_next_level (search (), { window (40, 4000, 100.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+}
+
+TEST (CapacityControllerTest, PlateauStopsWhileStillInsideTheSlo) {
+    // Throughput gained 2% across two step-ups while concurrency grew 56%:
+    // the service is inside its latency budget and no longer converting
+    // concurrency into work.
+    const auto decision = decide_next_level (search (),
+    { window (32, 10000, 30.0), window (40, 10100, 40.0), window (50, 10200, 60.0) });
+    EXPECT_EQ (decision.action, CapacityAction::Stop);
+    EXPECT_STREQ (decision.stop_reason, stop::PLATEAU);
+}
+
+TEST (CapacityControllerTest, HealthyThroughputGrowthIsNotAPlateau) {
+    const auto decision = decide_next_level (search (),
+    { window (32, 10000, 30.0), window (40, 12000, 40.0), window (50, 14000, 60.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+}
+
+TEST (CapacityControllerTest, AHoldIsNotCountedAsAStepUpForPlateau) {
+    // Without collapsing the repeated level, the last three windows read as
+    // 40 / 50 / 50 with flat throughput and the search would stop `plateau`
+    // on a level it merely re-measured.
+    const auto decision = decide_next_level (search (),
+    { window (40, 10000, 30.0), window (50, 10100, 180.0), window (50, 10150, 40.0) });
+    EXPECT_EQ (decision.action, CapacityAction::StepUp);
+}
+
+TEST (CapacityControllerTest, ReachingTheCapStops) {
+    const auto decision = decide_next_level (search (), { window (100, 20000, 30.0) });
+    EXPECT_EQ (decision.action, CapacityAction::Stop);
+    EXPECT_STREQ (decision.stop_reason, stop::CAP_REACHED);
+}
+
+TEST (CapacityControllerTest, ACapBreachStillReportsTheLatencyLimitFirst) {
+    // At the cap *and* breaching: the SLO is what the service did, the cap is
+    // only where the search ran out of room.
+    const auto decision =
+    decide_next_level (search (), { window (100, 20000, 300.0), window (100, 19000, 320.0) });
+    EXPECT_EQ (decision.action, CapacityAction::Stop);
+    EXPECT_STREQ (decision.stop_reason, stop::SLO_EXCEEDED);
+}
+
+// ---------------------------------------------------------------------------
+// Summarizing what the search found
+// ---------------------------------------------------------------------------
+
+TEST (CapacityControllerTest, KneeIsTheLevelThatGaveOutAndHeadlineIsTheLastThatHeld) {
+    const std::vector<CapacityWindow> history{ window (10, 1000, 5.0), window (48, 23400, 41.2),
+        window (64, 23000, 300.0), window (64, 22800, 312.0) };
+    const auto summary = summarize_capacity (search (), history, stop::SLO_EXCEEDED);
+
+    ASSERT_TRUE (summary.max_healthy.has_value ());
+    EXPECT_EQ (summary.max_healthy->concurrency, 48u);
+    EXPECT_DOUBLE_EQ (summary.max_healthy->rps, 23400.0);
+    EXPECT_DOUBLE_EQ (summary.max_healthy->p99_ms, 41.2);
+
+    ASSERT_TRUE (summary.knee.has_value ());
+    EXPECT_EQ (summary.knee->concurrency, 64u);
+    EXPECT_DOUBLE_EQ (summary.knee->p99_ms, 312.0);
+    EXPECT_GT (summary.knee->p99_ms, summary.slo_ms);
+
+    EXPECT_EQ (summary.stop_reason, stop::SLO_EXCEEDED);
+    EXPECT_EQ (summary.levels.size (), 4u); // the audit trail keeps the hold
+}
+
+TEST (CapacityControllerTest, NoKneeWhenTheSearchNeverSawTheServiceGiveOut) {
+    const std::vector<CapacityWindow> history{ window (10, 1000, 5.0), window (100, 9000, 40.0) };
+    const auto summary = summarize_capacity (search (), history, stop::CAP_REACHED);
+
+    ASSERT_TRUE (summary.max_healthy.has_value ());
+    EXPECT_EQ (summary.max_healthy->concurrency, 100u);
+    EXPECT_FALSE (summary.knee.has_value ());
+}
+
+TEST (CapacityControllerTest, NoHeadlineWhenTheFirstLevelAlreadyBreached) {
+    const std::vector<CapacityWindow> history{ window (10, 90, 400.0), window (10, 88, 420.0) };
+    const auto summary = summarize_capacity (search (), history, stop::SLO_EXCEEDED);
+
+    EXPECT_FALSE (summary.max_healthy.has_value ());
+    ASSERT_TRUE (summary.knee.has_value ());
+    EXPECT_EQ (summary.knee->concurrency, 10u);
+}
+
+TEST (CapacityControllerTest, PayloadOmitsWhatWasNotObserved) {
+    const auto summary =
+    summarize_capacity (search (), { window (10, 90, 400.0), window (10, 88, 420.0) },
+    stop::SLO_EXCEEDED);
+    const auto payload = build_capacity_summary_payload (summary);
+
+    EXPECT_FALSE (payload.contains ("max_healthy_concurrency"));
+    EXPECT_TRUE (payload.contains ("knee_concurrency"));
+    EXPECT_EQ (payload["stop_reason"], "slo_exceeded");
+    EXPECT_EQ (payload["levels"].size (), 2u);
+    EXPECT_EQ (payload["levels"][0]["concurrency"], 10u);
+}
+
+// ---------------------------------------------------------------------------
+// Reading the config off a run body
+// ---------------------------------------------------------------------------
+
+TEST (CapacityControllerTest, ConfigReadsTheDeclaredBounds) {
+    const nlohmann::json config = { { "mode", "capacity" }, { "sloMs", 50 },
+        { "startConcurrency", 4 }, { "concurrency", 512 } };
+    const auto parsed = vayu::core::capacity_config_from (config, 3000, 120000);
+
+    EXPECT_DOUBLE_EQ (parsed.slo_ms, 50.0);
+    EXPECT_EQ (parsed.start_concurrency, 4u);
+    EXPECT_EQ (parsed.max_concurrency, 512u);
+    EXPECT_EQ (parsed.step_duration_ms, 3000);
+    EXPECT_EQ (parsed.deadline_ms, 120000);
+}
+
+TEST (CapacityControllerTest, ACapBelowTheStartBecomesASingleLevelSearch) {
+    // Reachable from a hand-edited config snapshot, where there is no route to
+    // reject it. The search runs the start level once and stops `cap_reached`
+    // rather than climbing past a ceiling it was given.
+    const nlohmann::json config = { { "startConcurrency", 64 }, { "concurrency", 8 } };
+    const auto parsed = vayu::core::capacity_config_from (config, 5000, 60000);
+
+    EXPECT_EQ (parsed.start_concurrency, 64u);
+    EXPECT_EQ (parsed.max_concurrency, 64u);
+
+    const auto decision = decide_next_level (parsed, { window (64, 5000, 10.0) });
+    EXPECT_EQ (decision.action, CapacityAction::Stop);
+    EXPECT_STREQ (decision.stop_reason, stop::CAP_REACHED);
+}
+
+TEST (CapacityControllerTest, AnUnusableSloFallsBackToTheDefault) {
+    const nlohmann::json config = { { "sloMs", "fast" } };
+    EXPECT_DOUBLE_EQ (vayu::core::capacity_config_from (config, 5000, 60000).slo_ms,
+    static_cast<double> (vayu::core::constants::capacity::SLO_MS));
+}
+
+// ---------------------------------------------------------------------------
+// The feedback path's one rule
+// ---------------------------------------------------------------------------
+
+/**
+ * `sample_window_percentiles()` is documented single-reader and *resets* the
+ * rolling window on read, so a second production caller silently halves both
+ * readers' sample counts - the live chart and the capacity search would each
+ * see about half the run's completions and neither would look wrong.
+ *
+ * That is why the strategy steers by `RunContext::latest_live_tick()` rather
+ * than sampling the collector itself, and it is a property no behavioural test
+ * can see: the wrong version still runs, it just measures less. So it is
+ * scanned for, and the scan asserts it read something first - a guard reading
+ * an empty string passes forever.
+ */
+TEST (CapacityControllerTest, TheWindowedPercentilesHaveExactlyOneProductionCaller) {
+    const std::filesystem::path root = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) / "src";
+    ASSERT_TRUE (std::filesystem::exists (root));
+
+    size_t files_scanned = 0;
+    size_t total_bytes   = 0;
+    std::vector<std::string> callers;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator (root)) {
+        if (!entry.is_regular_file () || entry.path ().extension () != ".cpp") {
+            continue;
+        }
+        std::ifstream file (entry.path ());
+        std::stringstream buffer;
+        buffer << file.rdbuf ();
+        const std::string source = buffer.str ();
+        ++files_scanned;
+        total_bytes += source.size ();
+
+        // The definition itself is not a call site.
+        if (entry.path ().filename () == "metrics_collector.cpp") {
+            continue;
+        }
+        if (source.find ("sample_window_percentiles (") != std::string::npos) {
+            callers.push_back (entry.path ().filename ().string ());
+        }
+    }
+
+    ASSERT_GT (files_scanned, 10u) << "the scan found no sources to read";
+    ASSERT_GT (total_bytes, 1000u) << "the scan read empty files";
+    ASSERT_EQ (callers.size (), 1u)
+    << "expected only run_manager.cpp's metrics thread to sample the rolling "
+       "window; the capacity strategy must read RunContext::latest_live_tick()";
+    EXPECT_EQ (callers.front (), "run_manager.cpp");
+}
+
+} // namespace

--- a/engine/tests/capacity_controller_test.cpp
+++ b/engine/tests/capacity_controller_test.cpp
@@ -242,6 +242,25 @@ TEST (CapacityControllerTest, ACapBelowTheStartBecomesASingleLevelSearch) {
     EXPECT_STREQ (decision.stop_reason, stop::CAP_REACHED);
 }
 
+TEST (CapacityControllerTest, AnAbsurdConcurrencyIsClampedRatherThanCastPastSizeMax) {
+    // Reachable only from a hand-edited config snapshot - the route rejects it -
+    // but this function is documented total over stored snapshots. `1e30` is
+    // finite and positive, so the type guard passes it through; narrowing it to
+    // `size_t` is undefined behaviour, and in practice yields 0 or an arbitrary
+    // huge value depending on the platform. Either way the search would run at a
+    // level nobody asked for.
+    const nlohmann::json config = { { "startConcurrency", 1e30 }, { "concurrency", 1e30 } };
+    const auto parsed = vayu::core::capacity_config_from (config, 5000, 60000);
+
+    const auto guard =
+    static_cast<size_t> (vayu::core::constants::run_config::MAX_CONCURRENCY);
+    EXPECT_EQ (parsed.start_concurrency, guard);
+    EXPECT_EQ (parsed.max_concurrency, guard);
+    // The point of the clamp: a usable level, not a zero the search would spin
+    // at forever nor a number no allocator can honour.
+    EXPECT_GT (parsed.start_concurrency, 0u);
+}
+
 TEST (CapacityControllerTest, AnUnusableSloFallsBackToTheDefault) {
     const nlohmann::json config = { { "sloMs", "fast" } };
     EXPECT_DOUBLE_EQ (vayu::core::capacity_config_from (config, 5000, 60000).slo_ms,

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -869,3 +869,140 @@ TEST_F (LoadStrategyTest, CaptureOffLeavesTheCompletionPathUnchanged) {
     EXPECT_FALSE (context->metrics_collector->slow_results ()[0].capture.has_value ());
     EXPECT_EQ (context->metrics_collector->captured_body_bytes (), 0u);
 }
+
+// ---------------------------------------------------------------------------
+// Capacity discovery
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/**
+ * Run a capacity search end to end against the mock server.
+ *
+ * The metrics thread is spawned here rather than left out as the other
+ * strategy tests leave it, because it is the search's only sensor: the
+ * controller steers by `RunContext::latest_live_tick()`, which nothing else
+ * publishes. A capacity test without it measures a search that never sees a
+ * window close - which is itself the documented behaviour, but not the one
+ * these tests are about.
+ */
+vayu::core::CapacitySummary run_capacity_search (const nlohmann::json& config,
+const std::string& url,
+const std::string& run_id,
+vayu::db::Database& db) {
+    auto context = std::make_shared<vayu::core::RunContext> (run_id, config);
+
+    vayu::http::EventLoopConfig loop_config;
+    loop_config.max_concurrent = 2000;
+    loop_config.max_per_host   = 2000;
+    context->event_loop = std::make_unique<vayu::http::EventLoop> (loop_config);
+    context->event_loop->start ();
+
+    vayu::Request request;
+    request.method     = vayu::HttpMethod::GET;
+    request.url        = url;
+    request.timeout_ms = 30000;
+
+    context->is_running = true;
+    context->start_time_ms =
+    std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+    .count ();
+    std::thread metrics ([context, &db] () { vayu::core::collect_metrics (context, &db); });
+
+    auto strategy = vayu::core::LoadStrategy::create (config);
+    EXPECT_NE (strategy, nullptr);
+    strategy->execute (context, db, request);
+
+    context->is_running = false;
+    metrics.join ();
+    context->event_loop->stop (false);
+
+    EXPECT_TRUE (context->capacity.has_value ());
+    return context->capacity.value_or (vayu::core::CapacitySummary{});
+}
+
+} // namespace
+
+TEST_F (LoadStrategyTest, CapacityModeIsSelectedByTheFactory) {
+    nlohmann::json config = { { "mode", "capacity" } };
+    EXPECT_NE (vayu::core::LoadStrategy::create (config), nullptr);
+    EXPECT_EQ (vayu::parse_load_test_type ("capacity"), vayu::LoadTestType::Capacity);
+    EXPECT_STREQ (vayu::to_string (vayu::LoadTestType::Capacity), "capacity");
+}
+
+// A 500ms endpoint cannot meet a 100ms p99 at any concurrency, so the search
+// gives up at its very first level - and says so with the level that breached,
+// not with a headline it never measured.
+TEST_F (LoadStrategyTest, CapacityStopsOnTheSloAgainstASlowEndpoint) {
+    nlohmann::json config = {
+        { "mode", "capacity" },
+        { "duration", "20s" }, // far above what the SLO stop needs
+        { "stepDuration", "1s" },
+        { "sloMs", 100 },
+        { "startConcurrency", 4 },
+        { "concurrency", 64 },
+    };
+
+    vayu::db::Database db (TEST_DB_PATH);
+    const auto summary =
+    run_capacity_search (config, mock_server->slow_url (), "test-capacity-slo", db);
+
+    EXPECT_EQ (summary.stop_reason, "slo_exceeded");
+    ASSERT_TRUE (summary.knee.has_value ());
+    EXPECT_GT (summary.knee->p99_ms, summary.slo_ms);
+    EXPECT_EQ (summary.knee->concurrency, 4u) << "the search should not have climbed";
+    EXPECT_FALSE (summary.max_healthy.has_value ())
+    << "no level held the budget, so there is no sustainable capacity to report";
+    // The breach plus the re-measure that confirmed it.
+    EXPECT_EQ (summary.levels.size (), 2u);
+}
+
+// A fast endpoint inside its budget climbs until it runs out of room, and the
+// report says the search ended on the caller's ceiling rather than inventing a
+// knee it never observed.
+TEST_F (LoadStrategyTest, CapacityStopsAtTheCapAgainstAFastEndpoint) {
+    nlohmann::json config = {
+        { "mode", "capacity" },
+        { "duration", "30s" },
+        { "stepDuration", "1s" },
+        { "sloMs", 2000 }, // far above anything /fast can produce
+        { "startConcurrency", 2 },
+        { "concurrency", 3 }, // one step-up and the search is at its ceiling
+    };
+
+    vayu::db::Database db (TEST_DB_PATH);
+    const auto summary =
+    run_capacity_search (config, mock_server->fast_url (), "test-capacity-cap", db);
+
+    EXPECT_EQ (summary.stop_reason, "cap_reached");
+    ASSERT_TRUE (summary.max_healthy.has_value ());
+    EXPECT_EQ (summary.max_healthy->concurrency, 3u);
+    EXPECT_GT (summary.max_healthy->rps, 0.0);
+    EXPECT_FALSE (summary.knee.has_value ());
+    EXPECT_EQ (summary.levels.size (), 2u);
+}
+
+// The deadline is the strategy's own stop, not the controller's - it is the one
+// condition that is about the clock rather than about what the service did.
+TEST_F (LoadStrategyTest, CapacityStopsOnItsDeadline) {
+    nlohmann::json config = {
+        { "mode", "capacity" },
+        { "duration", "1200ms" }, // ends inside the second window
+        { "stepDuration", "1s" },
+        { "sloMs", 2000 },
+        { "startConcurrency", 2 },
+        { "concurrency", 1000 },
+    };
+
+    vayu::db::Database db (TEST_DB_PATH);
+    const auto summary =
+    run_capacity_search (config, mock_server->fast_url (), "test-capacity-deadline", db);
+
+    EXPECT_EQ (summary.stop_reason, "deadline");
+    // One window closed before the clock ran out; the partial second one is not
+    // in the audit trail, because it was never judged.
+    EXPECT_EQ (summary.levels.size (), 1u);
+    ASSERT_TRUE (summary.max_healthy.has_value ());
+    EXPECT_EQ (summary.max_healthy->concurrency, 2u);
+}

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -425,3 +425,52 @@ TEST (RunConfigValidation, AnEmptyThresholdsObjectIsRejectedByTheRunRoute) {
     config["thresholds"] = nlohmann::json::object ();
     expect_rejected (config, "thresholds");
 }
+
+// --- Capacity discovery: the two fields the mode adds ----------------------
+//
+// `stepDuration` reads through the same string parser `duration` does, so it
+// has to be gated by the same rule - it went through a shared helper for
+// exactly that reason. `sloMs` is a plain numeric field, and the bound it gets
+// is the app's own clamp on the SLO setting, so a budget the dialog can express
+// is one the engine accepts.
+
+TEST (RunConfigValidation, AValidCapacityConfigIsAccepted) {
+    auto config             = valid_config ();
+    config["mode"]          = "capacity";
+    config["sloMs"]         = 250;
+    config["stepDuration"]  = "5s";
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+}
+
+TEST (RunConfigValidation, AnUnparseableStepDurationIsRejected) {
+    for (const nlohmann::json bad : { nlohmann::json (5000), nlohmann::json ("soon"),
+    nlohmann::json ("0s"), nlohmann::json ("-1s"), nlohmann::json (true) }) {
+        auto config            = valid_config ();
+        config["stepDuration"] = bad;
+        expect_rejected (config, "stepDuration");
+    }
+}
+
+TEST (RunConfigValidation, StepDurationAcceptsTheSameSpellingsAsDuration) {
+    for (const std::string good : { "5s", "500ms", "1m", "5", "2.5s" }) {
+        auto config            = valid_config ();
+        config["stepDuration"] = good;
+        EXPECT_FALSE (validate_run_config (config).has_value ())
+        << "expected '" << good << "' to be accepted";
+    }
+}
+
+TEST (RunConfigValidation, ANullStepDurationIsAcceptedAsAbsent) {
+    auto config            = valid_config ();
+    config["stepDuration"] = nullptr;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+}
+
+TEST (RunConfigValidation, AnOutOfRangeSloIsRejected) {
+    for (const nlohmann::json bad :
+    { nlohmann::json (0), nlohmann::json (-1), nlohmann::json (60001), nlohmann::json ("fast") }) {
+        auto config     = valid_config ();
+        config["sloMs"] = bad;
+        expect_rejected (config, "sloMs");
+    }
+}

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -812,6 +812,80 @@ TEST_F (RunsRouteTest, ReportOmitsThresholdValidationWhenNoBudgetWasDeclared) {
     EXPECT_FALSE (body.contains ("thresholdValidation"));
 }
 
+// What a capacity search found, round-tripped through the stored summary. The
+// property under test is the translation: the search stores snake_case like
+// every other section, and the report speaks camelCase, so a key added on one
+// side and forgotten on the other reaches the renderer as an absent field
+// rather than as a build error.
+TEST_F (RunsRouteTest, ReportCarriesWhatTheCapacitySearchFound) {
+    seed ({ .id = "run_capacity", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+
+    vayu::core::CapacityConfig search;
+    search.slo_ms          = 100.0;
+    search.max_concurrency = 256;
+    const std::vector<vayu::core::CapacityWindow> levels{ { 8, 900.0, 12.0 },
+        { 16, 1700.0, 20.0 }, { 32, 1750.0, 180.0 }, { 32, 1720.0, 210.0 } };
+    inputs.capacity = vayu::core::summarize_capacity (search, levels,
+    vayu::core::capacity_stop::SLO_EXCEEDED);
+    db_->update_run_summary (
+    "run_capacity", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_capacity");
+    ASSERT_EQ (status, 200);
+
+    ASSERT_TRUE (body.contains ("capacity"));
+    const auto& capacity = body["capacity"];
+    EXPECT_DOUBLE_EQ (capacity["sloMs"].get<double> (), 100.0);
+    EXPECT_EQ (capacity["stopReason"].get<std::string> (), "slo_exceeded");
+    EXPECT_EQ (capacity["maxHealthyConcurrency"].get<size_t> (), 16u);
+    EXPECT_DOUBLE_EQ (capacity["maxHealthyRps"].get<double> (), 1700.0);
+    EXPECT_DOUBLE_EQ (capacity["p99AtMaxHealthyMs"].get<double> (), 20.0);
+    EXPECT_EQ (capacity["kneeConcurrency"].get<size_t> (), 32u);
+    EXPECT_DOUBLE_EQ (capacity["kneeP99Ms"].get<double> (), 210.0);
+
+    ASSERT_EQ (capacity["levels"].size (), 4u);
+    EXPECT_EQ (capacity["levels"][0]["concurrency"].get<size_t> (), 8u);
+    EXPECT_DOUBLE_EQ (capacity["levels"][0]["rps"].get<double> (), 900.0);
+    EXPECT_DOUBLE_EQ (capacity["levels"][0]["p99Ms"].get<double> (), 12.0);
+}
+
+// A search that ran out of room never watched the service give out, so the
+// report carries the headline without a knee - rather than naming the last
+// level it happened to reach as the limit.
+TEST_F (RunsRouteTest, ReportOmitsTheKneeWhenNoLevelBreached) {
+    seed ({ .id = "run_capacity_cap", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+
+    vayu::core::CapacityConfig search;
+    search.slo_ms   = 100.0;
+    inputs.capacity = vayu::core::summarize_capacity (search, { { 8, 900.0, 12.0 } },
+    vayu::core::capacity_stop::CAP_REACHED);
+    db_->update_run_summary (
+    "run_capacity_cap", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_capacity_cap");
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body.contains ("capacity"));
+    EXPECT_FALSE (body["capacity"].contains ("kneeConcurrency"));
+    EXPECT_EQ (body["capacity"]["maxHealthyConcurrency"].get<size_t> (), 8u);
+}
+
+// Every other mode. The section is absent, not zeroed - a fixed-target run
+// measured a point, and a knee of 0 would read as a service that collapses at
+// no concurrency at all.
+TEST_F (RunsRouteTest, ReportOmitsCapacityForEveryOtherMode) {
+    seed ({ .id = "run_not_capacity", .start_time = 1000 });
+    auto inputs     = summary_inputs ();
+    inputs.capacity = std::nullopt;
+    db_->update_run_summary (
+    "run_not_capacity", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_not_capacity");
+    ASSERT_EQ (status, 200);
+    EXPECT_FALSE (body.contains ("capacity"));
+}
+
 // A summary that is not a JSON object is treated as absent. There is no second
 // aggregate source any more, so the report stands on the run's sampled results
 // - which is a report, not a 500 and not an empty run.


### PR DESCRIPTION
## Description

`mode: "capacity"` - an adaptive step-ramp that finds the latency knee and reports what the service can sustain, instead of a human bisecting concurrency by hand.

**Plan.** The root cause is that no strategy had a feedback path: every `target_fn` passed to `maintain_concurrency` is a pure function of `elapsed_ms` and constants, so the tool that can outrun the server could not tell you where the server gives out. The pieces of an answer all existed (`MetricTickSample` carries the windowed percentiles, `computeBreakpoint` detects the knee client-side and post-hoc) and none of them closed the loop. The approach is the one the issue lays out: a pure controller core (`decide_next_level` over a level history, no clock and no collector, unit-tested without a server) driving a strategy that reads metrics through a **published** tick. The alternative I rejected is the obvious one - having the strategy call `MetricsCollector::sample_window_percentiles()` directly. That call is documented single-reader and *resets* the rolling window on read, and the metrics thread already consumes it once per tick; a second consumer would silently halve both readers' sample counts, and neither the live chart nor the search would look wrong. So the metrics thread publishes what it already computed (`RunContext::publish_live_tick()`, one writer) and the strategy copies it out - which also means the controller steers by exactly the numbers the dashboard is drawing.

I verified the problem still exists as described; the anchors in the issue were accurate. Three things are worth calling out as deviations, all noted inline in the code:

1. **`Percentiles` gained a `count` field.** Not in the issue's plan, but required for correctness: an empty window returns all zeros, so averaging a level's per-tick p99s pulled a 500ms endpoint's measured p99 well under a 100ms budget. The first integration test caught it - the search climbed 4 → 64 against `/slow` and stopped `cap_reached`. The controller now ignores windows in which nothing completed.
2. **A fifth stop reason, `stopped`.** The issue names four. An operator-cancelled search has not run out of clock, and reporting `deadline` for it would claim a measurement never taken.
3. **The `deadline` stop lives in the strategy, not `decide_next_level`.** It is the one condition that is about the clock rather than about what the service did, and the pure core holds no clock. `summarize_capacity` takes the reason from the caller for the same reason.

The `target_fn` invariant this breaks is restated explicitly in `docs/engine/architecture.md` rather than left to be rediscovered.

**Engine**
- `core/capacity_controller.{hpp,cpp}` - step up 25% (min +1) while healthy; a *single* breaching window `Hold`s and re-measures the same level; stop on two consecutive breaches (`slo_exceeded`), a sub-5% throughput gain across two step-ups (`plateau`), the ceiling (`cap_reached`), the deadline, or an operator stop. Growth/plateau/breach-count are constants in `constants::capacity`, not new wire fields.
- Report gains an optional `capacity` section. `maxHealthy*` is omitted when the first level already breached and `knee*` unless latency ended the search - a search that ran out of room never watched the target give out.
- `sloMs` (1-60000, the app's own clamp) and `stepDuration` validated in the run route; `duration` and `stepDuration` now share one parser rather than a copy. `capacity` on a scenario run is a 400.

**App**
- Capacity Discovery profile in the load dialog: latency budget (prefilled from `sloThresholdMs`), step duration, start/ceiling, deadline. Blocked when the start is already at the ceiling - the engine would run it, but a one-level search is never what the profile was picked for.
- `HeroRow` / `ModeStatsRow` capacity arms; `CurrentConcurrencyCard` is deliberately *not* reused (its subtitle states a ramp duration and lag, and a search has neither).
- `CapacitySummary` card in the history Overview: the finding as a sentence, over the levels table it came from.
- MCP `start_load_run` accepts the mode and forwards `sloMs` / `stepDuration`; the existing concurrency cap already bounds both `concurrency` (the ceiling) and `startConcurrency`, which is exactly what stops an adaptive run from outgrowing it.

**#197 (high-RPS default re-tune), as the issue asks:** no defaults were touched. `workers` / `maxInFlight` are untouched by this PR - a capacity run leans on them harder than a fixed run does, but re-tuning them is #197's scope and mixing it in would make both changes harder to attribute.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

All green on this branch; no pre-existing failures observed.

- **Engine:** `python build.py -e -t && ctest --preset linux-dev` - **1282/1282 passed** (128.9s). 34 of those are new or capacity-related:
  - `capacity_controller_test.cpp` (20) - step-up, growth floor, cap clamp, the consecutive-breach requirement (mutation check: drop it and `OneBreachingWindowHoldsRatherThanStopping` reports `Stop`), plateau detection, a hold not counting as a step-up, knee attribution, payload omissions, config clamping, plus the source scan pinning `sample_window_percentiles()`'s single production caller (the scan asserts it read >10 files and >1000 bytes first).
  - `load_strategy_test.cpp` (4) - end-to-end against `SlowMockServer` with a real metrics thread: `/slow` at `sloMs: 100` stops `slo_exceeded` with `kneeP99Ms` over the SLO and no `maxHealthy`; `/fast` stops `cap_reached`; a short deadline stops `deadline` with the partial window absent from the trail.
  - `run_config_validation_test.cpp` (5) and `runs_route_test.cpp` (3) - field validation and the summary → report round-trip plus its two absence twins.
- **App:** `pnpm test` - **3823/3823 passed** (381 files); `pnpm type-check`, `pnpm lint`, `pnpm format:check` clean. New: `CapacitySummary.test.tsx` (7, incl. a mutation check on the over-budget row colour), dialog field/payload tests, `validateCapacityRange`, summary prose, and MCP safety caps. The `load-test-modes` vocabulary guard caught the new mode and was updated.
- **Docs:** `mkdocs build --strict` clean.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #471

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMERxmB31k3ih8XYgVztHg)_