### PR TITLE
feat(engine/app): refresh oauth2 tokens during long load runs

### DIFF
--- a/app/src/modules/history/main/LoadTestDetail.auth.test.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.auth.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * The mid-run OAuth 2.0 refresh note in LoadTestDetail's header (#478).
+ *
+ * The wording is unit-tested in auth-refresh-note.test.ts; what this file adds
+ * is that the pane actually draws it - a note computed and never rendered is
+ * this codebase's most repeated defect, and no source scan can see it.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import type { ReactElement } from "react";
+import LoadTestDetail from "./LoadTestDetail";
+import type { RunReport } from "@/types";
+
+function renderWithClient(ui: ReactElement) {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<TooltipProvider>{ui}</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+function report(auth?: RunReport["auth"]): RunReport {
+	return {
+		metadata: {
+			runId: "r",
+			runType: "load",
+			status: "completed",
+			startTime: 0,
+			endTime: 1000,
+			requestUrl: "http://127.0.0.1:8080/x",
+			requestMethod: "GET",
+			configuration: { mode: "constant_rps", duration: "2h" },
+		},
+		summary: {
+			totalRequests: 600,
+			successfulRequests: 600,
+			failedRequests: 0,
+			errorRate: 0,
+			totalDurationSeconds: 7200,
+			avgRps: 0.08,
+		},
+		latency: {
+			min: 100,
+			max: 130,
+			avg: 101,
+			median: 101,
+			p50: 101,
+			p75: 101,
+			p90: 102,
+			p95: 103,
+			p99: 108,
+			p999: 120,
+		},
+		statusCodes: { "200": 600 },
+		errors: { total: 0, withDetails: 0, types: {} },
+		auth,
+	};
+}
+
+describe("LoadTestDetail auth-refresh note", () => {
+	it("says when the run's token was refreshed", () => {
+		renderWithClient(
+			<LoadTestDetail
+				report={report({ refreshes: [{ atSeconds: 3600 }], refreshFailures: 0 })}
+				runId="r"
+			/>
+		);
+
+		expect(screen.getByText("Access token refreshed at 1h 0m")).toBeInTheDocument();
+	});
+
+	// The case that explains a 401 storm: the run kept going on a credential it
+	// could not renew, so the reason has to reach the reader.
+	it("names the reason a refresh failed", () => {
+		renderWithClient(
+			<LoadTestDetail
+				report={report({
+					refreshes: [],
+					refreshFailures: 1,
+					lastError: "oauth2_provider_error: invalid_grant",
+				})}
+				runId="r"
+			/>
+		);
+
+		expect(
+			screen.getByText("1 refresh failure - oauth2_provider_error: invalid_grant")
+		).toBeInTheDocument();
+	});
+
+	it("stays quiet for a run that could not refresh at all", () => {
+		renderWithClient(<LoadTestDetail report={report(undefined)} runId="r" />);
+
+		expect(screen.queryByText(/refresh/i)).not.toBeInTheDocument();
+	});
+
+	it("stays quiet for a watched run that never needed a refresh", () => {
+		renderWithClient(
+			<LoadTestDetail report={report({ refreshes: [], refreshFailures: 0 })} runId="r" />
+		);
+
+		expect(screen.queryByText(/refresh/i)).not.toBeInTheDocument();
+	});
+});

--- a/app/src/modules/history/main/LoadTestDetail.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.tsx
@@ -20,6 +20,7 @@ import {
 	Settings2,
 	AlertTriangle,
 	ListOrdered,
+	KeyRound,
 } from "lucide-react";
 import {
 	Badge,
@@ -39,6 +40,7 @@ import { computeBreakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
 import { useRunTimeSeriesQuery } from "@/queries/runs";
 import { useClientSettingsStore } from "@/stores";
 import { OverviewTab, PerformanceTab, SamplesTab, ScenarioStepsTab } from "./components";
+import { authRefreshNote } from "./auth-refresh-note";
 import type { LoadTestDetailProps, TimeSeriesResponse } from "../types";
 
 export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
@@ -119,6 +121,10 @@ export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 		if (timeSeries.length < 2) return base;
 		return { ...base, breakpoint: computeBreakpoint(timeSeries, sloThresholdMs) };
 	}, [report, timeSeries, sloThresholdMs]);
+
+	// One line on whether the run's OAuth 2.0 credential was kept current - the
+	// answer to 401s that appear partway through an otherwise healthy run.
+	const authNote = useMemo(() => authRefreshNote(report.auth), [report.auth]);
 
 	const successRate =
 		report.summary.totalRequests > 0
@@ -238,6 +244,24 @@ export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 								<span className="text-foreground/90 italic">{config.comment}</span>
 							</div>
 						)}
+					</div>
+				)}
+
+				{/* What kept the run authorized. Drawn only when the engine was able to
+				    refresh at all - a run without the section reports nothing here,
+				    exactly as every run did before mid-run refresh existed. */}
+				{authNote && (
+					<div
+						className={`flex items-center gap-2 text-sm mb-3 p-3 border rounded-md bg-background/50 ${
+							authNote.warning ? "text-status-warning-text" : "text-muted-foreground"
+						}`}
+					>
+						{authNote.warning ? (
+							<AlertTriangle className="w-4 h-4 shrink-0" />
+						) : (
+							<KeyRound className="w-4 h-4 shrink-0" />
+						)}
+						<span>{authNote.text}</span>
 					</div>
 				)}
 

--- a/app/src/modules/history/main/auth-refresh-note.test.ts
+++ b/app/src/modules/history/main/auth-refresh-note.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, it, expect } from "vitest";
+import { authRefreshNote } from "./auth-refresh-note";
+
+describe("authRefreshNote", () => {
+	// The absent section is a run that could not refresh at all - it must read
+	// exactly as every run did before mid-run refresh existed.
+	it("says nothing for a run that could not refresh", () => {
+		expect(authRefreshNote(undefined)).toBeNull();
+	});
+
+	// A watched run that never needed a refresh has nothing to report either -
+	// the section exists, and is empty.
+	it("says nothing when the run was watched and never renewed", () => {
+		expect(authRefreshNote({ refreshes: [], refreshFailures: 0 })).toBeNull();
+	});
+
+	it("names when a single refresh landed", () => {
+		const note = authRefreshNote({ refreshes: [{ atSeconds: 3600 }], refreshFailures: 0 });
+		expect(note).toEqual({ text: "Access token refreshed at 1h 0m", warning: false });
+	});
+
+	it("counts and lists repeated refreshes", () => {
+		const note = authRefreshNote({
+			refreshes: [{ atSeconds: 60 }, { atSeconds: 120.4 }],
+			refreshFailures: 0,
+		});
+		expect(note?.text).toBe("Access token refreshed 2 times (1m 0s, 2m 0s)");
+		expect(note?.warning).toBe(false);
+	});
+
+	// The case that leaves 401s unexplained: the run kept going on a credential
+	// it could not renew, so the note carries the reason and reads as a warning.
+	it("reports a failure with its reason and warns", () => {
+		const note = authRefreshNote({
+			refreshes: [],
+			refreshFailures: 1,
+			lastError: "oauth2_provider_error: invalid_grant",
+		});
+		expect(note).toEqual({
+			text: "1 refresh failure - oauth2_provider_error: invalid_grant",
+			warning: true,
+		});
+	});
+
+	it("reports refreshes and failures together", () => {
+		const note = authRefreshNote({
+			refreshes: [{ atSeconds: 3600 }],
+			refreshFailures: 2,
+			lastError: "oauth2_network_error: timed out",
+		});
+		expect(note?.text).toBe(
+			"Access token refreshed at 1h 0m; 2 refresh failures - oauth2_network_error: timed out"
+		);
+		expect(note?.warning).toBe(true);
+	});
+});

--- a/app/src/modules/history/main/auth-refresh-note.ts
+++ b/app/src/modules/history/main/auth-refresh-note.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The one line a run report says about keeping its OAuth 2.0 credential alive.
+ *
+ * Pure, so the wording is unit-testable without rendering the whole detail
+ * pane, and so the component file keeps exporting only a component.
+ */
+
+import { formatDuration } from "@/modules/dashboard/utils/format";
+import type { RunReport } from "@/types";
+
+export interface AuthRefreshNote {
+	text: string;
+	/** A failed refresh is what leaves 401s unexplained - say it louder. */
+	warning: boolean;
+}
+
+/**
+ * Describe a run's mid-run token refreshes, or `null` when there is nothing to
+ * say: a run that could not refresh at all reports no section (see
+ * `RunReport.auth`), and a run that was watched and never needed a refresh has
+ * a section with nothing in it.
+ */
+export function authRefreshNote(auth: RunReport["auth"]): AuthRefreshNote | null {
+	if (!auth) return null;
+
+	const at = auth.refreshes.map((r) => formatDuration(Math.round(r.atSeconds * 1000)));
+	const failures = auth.refreshFailures;
+	if (at.length === 0 && failures === 0) return null;
+
+	const parts: string[] = [];
+	if (at.length === 1) {
+		parts.push(`Access token refreshed at ${at[0]}`);
+	} else if (at.length > 1) {
+		parts.push(`Access token refreshed ${at.length} times (${at.join(", ")})`);
+	}
+	if (failures > 0) {
+		parts.push(
+			`${failures} refresh ${failures === 1 ? "failure" : "failures"}` +
+				(auth.lastError ? ` - ${auth.lastError}` : "")
+		);
+	}
+	return { text: parts.join("; "), warning: failures > 0 };
+}

--- a/app/src/modules/request-builder/components/OAuth2LoadTestGuard.tsx
+++ b/app/src/modules/request-builder/components/OAuth2LoadTestGuard.tsx
@@ -6,14 +6,21 @@
  */
 
 /**
- * OAuth2LoadTestGuard - warns when a duration-based load test would outlive its
- * OAuth 2.0 access token. The engine acquires the token once at run start and
- * does not refresh mid-run, so a test longer than the token's remaining life
- * starts failing partway through. This is the interim guard for that gap:
+ * OAuth2LoadTestGuard - says whether a duration-based load test will stay
+ * authorized for its whole length.
  *
- *   - covered            → nothing to do
- *   - stale-but-coverable → offer Refresh (a fresh token gives a full window)
+ * The engine now refreshes a header-placed OAuth 2.0 token *during* the run
+ * (#478), so most long runs need no warning at all. What is left is the set of
+ * credentials it cannot renew - a query-placed token, `autoRefreshToken: false`,
+ * an authorization_code grant with no refresh token - where a run longer than
+ * the token still starts failing partway through:
+ *
+ *   - covered              → nothing to do (including "the engine will renew it")
+ *   - stale-but-coverable  → offer Refresh (a fresh token gives a full window)
  *   - longer-than-lifetime → block, with an explicit "start anyway" override
+ *
+ * Which case applies is `isMidRunRefreshable`, which mirrors the engine's own
+ * rule; see oauth2-load-test-coverage.ts.
  *
  * Reports whether the Start button should be gated via onGateChange.
  */
@@ -25,7 +32,7 @@ import { computeOAuth2CacheKey } from "@/services/oauth/cache-key";
 import { useOAuth2TokenStatusQuery, useFetchOAuth2TokenMutation } from "@/queries/oauth";
 import { useToastStore } from "@/stores";
 import type { OAuth2Config } from "@/types";
-import { coverageState, fmtDuration } from "./oauth2-load-test-coverage";
+import { coverageState, fmtDuration, isMidRunRefreshable } from "./oauth2-load-test-coverage";
 import { Callout } from "@/components/shared";
 
 interface OAuth2LoadTestGuardProps {
@@ -57,8 +64,14 @@ export default function OAuth2LoadTestGuard({
 
 	// Compute the coverage state (pure decision - see coverageState).
 	const state = useMemo(
-		() => coverageState(durationSeconds, cacheKey != null, token),
-		[durationSeconds, cacheKey, token]
+		() =>
+			coverageState(
+				durationSeconds,
+				cacheKey != null,
+				token,
+				isMidRunRefreshable(config, token)
+			),
+		[durationSeconds, cacheKey, token, config]
 	);
 
 	// Reset the override whenever the situation changes. This is the render-phase
@@ -98,7 +111,9 @@ export default function OAuth2LoadTestGuard({
 			<Callout severity="info" positive>
 				{state.nonExpiring
 					? "Access token does not expire - it covers the full test."
-					: "Access token covers the full test duration."}
+					: state.viaRefresh
+						? "Access token expires during the test - the engine refreshes it mid-run."
+						: "Access token covers the full test duration."}
 			</Callout>
 		);
 	}
@@ -175,8 +190,9 @@ export default function OAuth2LoadTestGuard({
 					this provider&apos;s tokens last only{" "}
 					<strong>{fmtDuration(state.lifetimeMs)}</strong>, shorter than the{" "}
 					<strong>{fmtDuration(state.durationMs)}</strong> test. Requests will fail once
-					it expires - mid-run refresh isn&apos;t supported yet, so shorten the run to
-					avoid failures.
+					it expires - this credential cannot be renewed mid-run (a query-placed token,
+					auto-refresh turned off, or an authorization-code grant with no refresh token),
+					so shorten the run to avoid failures.
 				</>
 			)}
 		</Callout>

--- a/app/src/modules/request-builder/components/oauth2-load-test-coverage.test.ts
+++ b/app/src/modules/request-builder/components/oauth2-load-test-coverage.test.ts
@@ -6,39 +6,46 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { coverageState, fmtDuration } from "./oauth2-load-test-coverage";
+import { coverageState, fmtDuration, isMidRunRefreshable } from "./oauth2-load-test-coverage";
 
 const NOW = 1_000_000_000_000;
 // A token minted now, valid `lifetimeS` seconds, with `remainingS` left.
-const token = (lifetimeS: number, remainingS: number) => ({
+const token = (lifetimeS: number, remainingS: number, hasRefreshToken = true) => ({
 	expiresIn: lifetimeS,
 	expiresAt: NOW + remainingS * 1000,
+	hasRefreshToken,
 });
 
 describe("coverageState", () => {
 	it("is inert without a fixed duration (iterations mode)", () => {
-		expect(coverageState(null, true, token(3600, 3600), NOW).kind).toBe("inert");
-		expect(coverageState(0, true, token(3600, 3600), NOW).kind).toBe("inert");
+		expect(coverageState(null, true, token(3600, 3600), false, NOW).kind).toBe("inert");
+		expect(coverageState(0, true, token(3600, 3600), false, NOW).kind).toBe("inert");
 	});
 
 	it("reports no-config / no-token when it cannot decide", () => {
-		expect(coverageState(60, false, undefined, NOW).kind).toBe("no-config");
-		expect(coverageState(60, true, undefined, NOW).kind).toBe("no-token");
+		expect(coverageState(60, false, undefined, false, NOW).kind).toBe("no-config");
+		expect(coverageState(60, true, undefined, false, NOW).kind).toBe("no-token");
 	});
 
 	it("treats a non-expiring token as covered", () => {
-		const s = coverageState(100_000, true, { expiresIn: 0, expiresAt: null }, NOW);
+		const s = coverageState(
+			100_000,
+			true,
+			{ expiresIn: 0, expiresAt: null, hasRefreshToken: false },
+			false,
+			NOW
+		);
 		expect(s).toEqual({ kind: "covered", nonExpiring: true });
 	});
 
 	it("is covered when the remaining life exceeds the duration", () => {
 		// 10-min test, token has 1h left → covered
-		expect(coverageState(600, true, token(3600, 3600), NOW).kind).toBe("covered");
+		expect(coverageState(600, true, token(3600, 3600), false, NOW).kind).toBe("covered");
 	});
 
 	it("suggests refresh when a fresh token would cover but the cached one won't", () => {
 		// 50-min test, token lifetime 1h but only 20m left → refresh clears it
-		const s = coverageState(50 * 60, true, token(3600, 20 * 60), NOW);
+		const s = coverageState(50 * 60, true, token(3600, 20 * 60), false, NOW);
 		expect(s.kind).toBe("refresh");
 		if (s.kind === "refresh") {
 			expect(s.durationMs).toBe(50 * 60 * 1000);
@@ -49,7 +56,7 @@ describe("coverageState", () => {
 
 	it("flags too-long when even a fresh token cannot cover the test", () => {
 		// 2h test, token lifetime only 1h → uncoverable
-		const s = coverageState(2 * 3600, true, token(3600, 3600), NOW);
+		const s = coverageState(2 * 3600, true, token(3600, 3600), false, NOW);
 		expect(s.kind).toBe("too-long");
 		if (s.kind === "too-long") {
 			expect(s.lifetimeMs).toBe(3600 * 1000);
@@ -58,7 +65,77 @@ describe("coverageState", () => {
 	});
 
 	it("boundary: duration exactly equal to remaining is covered", () => {
-		expect(coverageState(3600, true, token(3600, 3600), NOW).kind).toBe("covered");
+		expect(coverageState(3600, true, token(3600, 3600), false, NOW).kind).toBe("covered");
+	});
+
+	// The #478 branch: what used to gate the Start button is the engine's job
+	// now. Both states that blocked a run become covered when it can renew.
+	it("is covered when the engine renews the token mid-run", () => {
+		const stale = coverageState(50 * 60, true, token(3600, 20 * 60), true, NOW);
+		expect(stale).toEqual({
+			kind: "covered",
+			nonExpiring: false,
+			remainingMs: 20 * 60 * 1000,
+			viaRefresh: true,
+		});
+
+		const longer = coverageState(2 * 3600, true, token(3600, 3600), true, NOW);
+		expect(longer.kind).toBe("covered");
+		if (longer.kind === "covered") expect(longer.viaRefresh).toBe(true);
+	});
+
+	it("does not claim a refresh when the cached token covers the run anyway", () => {
+		const s = coverageState(600, true, token(3600, 3600), true, NOW);
+		expect(s.kind).toBe("covered");
+		if (s.kind === "covered") expect(s.viaRefresh).toBeUndefined();
+	});
+});
+
+// Mirrors plan_auth_refresh in the engine; a divergence here either promises a
+// refresh that never happens or blocks a run the engine could have carried.
+describe("isMidRunRefreshable", () => {
+	const clientCredentials = { grantType: "client_credentials" } as const;
+
+	it("renews a header-placed expiring token", () => {
+		expect(isMidRunRefreshable(clientCredentials, token(3600, 600))).toBe(true);
+	});
+
+	it("cannot renew a query-placed token", () => {
+		expect(
+			isMidRunRefreshable({ ...clientCredentials, tokenPlacement: "query" }, token(3600, 600))
+		).toBe(false);
+		expect(
+			isMidRunRefreshable(
+				{ ...clientCredentials, tokenPlacement: "header" },
+				token(3600, 600)
+			)
+		).toBe(true);
+	});
+
+	it("honours the autoRefreshToken opt-out", () => {
+		expect(
+			isMidRunRefreshable({ ...clientCredentials, autoRefreshToken: false }, token(3600, 600))
+		).toBe(false);
+		expect(
+			isMidRunRefreshable({ ...clientCredentials, autoRefreshToken: true }, token(3600, 600))
+		).toBe(true);
+	});
+
+	it("needs a refresh token for an authorization_code grant", () => {
+		const authCode = { grantType: "authorization_code" } as const;
+		expect(isMidRunRefreshable(authCode, token(3600, 600, false))).toBe(false);
+		expect(isMidRunRefreshable(authCode, token(3600, 600, true))).toBe(true);
+	});
+
+	it("has nothing to renew without an expiring token", () => {
+		expect(isMidRunRefreshable(clientCredentials, undefined)).toBe(false);
+		expect(
+			isMidRunRefreshable(clientCredentials, {
+				expiresIn: 0,
+				expiresAt: null,
+				hasRefreshToken: true,
+			})
+		).toBe(false);
 	});
 });
 

--- a/app/src/modules/request-builder/components/oauth2-load-test-coverage.ts
+++ b/app/src/modules/request-builder/components/oauth2-load-test-coverage.ts
@@ -20,28 +20,65 @@ export function fmtDuration(ms: number): string {
 	return h < 48 ? `${h}h` : `${Math.round(h / 24)}d`;
 }
 
+import type { OAuth2Config } from "@/types";
+
 /** Minimal token shape the coverage decision needs. */
 export interface CoverageToken {
 	expiresAt: number | null;
 	expiresIn: number;
+	hasRefreshToken: boolean;
 }
 
 export type CoverageState =
 	| { kind: "inert" }
 	| { kind: "no-config" }
 	| { kind: "no-token" }
-	| { kind: "covered"; nonExpiring: boolean; remainingMs?: number }
+	| {
+			kind: "covered";
+			nonExpiring: boolean;
+			remainingMs?: number;
+			/** Covered because the engine renews the token mid-run, not because
+			 *  the cached one outlives the test. */
+			viaRefresh?: boolean;
+	  }
 	| { kind: "refresh"; remainingMs: number; lifetimeMs: number; durationMs: number }
 	| { kind: "too-long"; lifetimeMs: number; durationMs: number };
 
 /**
+ * Whether the engine will keep this credential current for the whole run.
+ *
+ * Mirrors `plan_auth_refresh` (engine/src/http/auth_resolver.cpp) case for
+ * case - the guard must not promise a refresh the engine will not perform, and
+ * must not block a run the engine can carry. Change one, change both.
+ */
+export function isMidRunRefreshable(
+	config: Pick<OAuth2Config, "grantType" | "tokenPlacement" | "autoRefreshToken">,
+	token: CoverageToken | undefined
+): boolean {
+	if (!token || token.expiresIn <= 0) return false;
+	// A query-placed token is baked into the URL of every transfer; no header
+	// swap reaches it.
+	if (config.tokenPlacement === "query") return false;
+	if (config.autoRefreshToken === false) return false;
+	// This grant's only non-interactive way back is a refresh token, and a run
+	// must never pop a browser mid-flight.
+	if (config.grantType === "authorization_code" && !token.hasRefreshToken) return false;
+	return true;
+}
+
+/**
  * Decide whether a duration-based test is covered by the token. Pure so the
  * state machine can be unit-tested without React. `now` is injectable for tests.
+ *
+ * @param refreshable Whether the engine renews the token mid-run
+ *                    ({@link isMidRunRefreshable}). When it does, a test longer
+ *                    than the token is covered rather than blocked.
  */
 export function coverageState(
 	durationSeconds: number | null,
 	hasCacheKey: boolean,
 	token: CoverageToken | undefined,
+	refreshable: boolean,
 	now: number = Date.now()
 ): CoverageState {
 	if (durationSeconds == null || durationSeconds <= 0) return { kind: "inert" };
@@ -54,6 +91,11 @@ export function coverageState(
 	const remainingMs = token.expiresAt - now;
 	const lifetimeMs = token.expiresIn * 1000;
 	if (durationMs <= remainingMs) return { kind: "covered", nonExpiring: false, remainingMs };
+	// The token dies mid-run, and the engine renews it there: nothing to warn
+	// about, and nothing for the user to do.
+	if (refreshable) {
+		return { kind: "covered", nonExpiring: false, remainingMs, viaRefresh: true };
+	}
 	if (durationMs <= lifetimeMs) return { kind: "refresh", remainingMs, lifetimeMs, durationMs };
 	return { kind: "too-long", lifetimeMs, durationMs };
 }

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1039,6 +1039,27 @@ export interface RunReport {
 		verdict: "passed" | "failed";
 	};
 	/**
+	 * Whether the run's OAuth 2.0 credential was renewed while it ran.
+	 *
+	 * A run longer than its access token used to turn into a 401 storm the
+	 * report never explained; the engine now refreshes header-placed tokens
+	 * mid-run and records each swap here. `refreshFailures` with a `lastError`
+	 * is the other half of that answer: the run kept going with the credential
+	 * it had, so the 401s in `statusCodes` are explained by this, not by the
+	 * target.
+	 *
+	 * `undefined` is a run that could not refresh at all - no OAuth 2.0 auth, a
+	 * non-expiring or query-placed token, the user's `autoRefreshToken`
+	 * opt-out, or a sidecar older than mid-run refresh - which is *not* the
+	 * same claim as "watched and never needed to".
+	 */
+	auth?: {
+		/** Seconds into the run at which each successful refresh landed. */
+		refreshes: { atSeconds: number }[];
+		refreshFailures: number;
+		lastError?: string;
+	};
+	/**
 	 * How many records each of the run's bounded stores thinned away.
 	 *
 	 * Every store the engine keeps is capped, so a long run retains a *sample*

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -647,6 +647,19 @@ a run that dropped nothing, so the note stays out rather than asserting a
 completeness it cannot verify - the same absent-vs-zero rule
 `httpVersionDowngraded` follows above.
 
+`report.auth` follows that rule too. The engine refreshes a header-placed
+OAuth 2.0 token *while a load run is going*, and this section is what it did:
+`refreshes[].atSeconds` per renewal, plus `refreshFailures` and a `lastError`
+when one was refused. `LoadTestDetail` renders it as a one-line note in the
+header (`authRefreshNote`), a warning when a refresh failed - that failure is
+what explains 401s appearing partway through an otherwise healthy run. Absent
+means the run could never refresh (no OAuth 2.0 auth, a non-expiring or
+query-placed token, `autoRefreshToken: false`, or an older sidecar); present
+with an empty `refreshes` means it was watched and never needed to. The same
+eligibility rule decides whether `OAuth2LoadTestGuard` still blocks a run
+longer than its token - `isMidRunRefreshable` mirrors the engine's
+`plan_auth_refresh`, and the two must change together.
+
 ### Load Test Execution
 
 1. **User Action**: Configures and starts load test

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2665,7 +2665,8 @@ A run that is already finished answers `{"status": "<status>", "runId": ...,
 Get the final report for a completed run. The response is a **nested** object; conditional
 sections appear only when relevant (e.g. `rateControl` only for `constant_rps`, `testValidation`
 only when a test script ran, `thresholdValidation` only when the run declared
-[budgets](#the-thresholds-block-passfail-budgets)).
+[budgets](#the-thresholds-block-passfail-budgets), `auth` only when the run's
+OAuth 2.0 credential could be refreshed mid-run).
 
 The whole-run aggregates come from the run's stored `summary` (written once when the run reaches
 a terminal status - see [db-schema.md](db-schema.md#runs)), combined with the sampled `results`
@@ -2740,9 +2741,20 @@ alone rather than erroring. **The response shape is the same either way.**
     "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 47.2, "passed": true } ],
     "passed": 1, "failed": 0, "verdict": "passed"
   },
+  "auth": { "refreshes": [ { "atSeconds": 3620.4 } ], "refreshFailures": 0 },
   "results": [ { "id": 41, "...": "sampled request/response outcomes" } ]
 }
 ```
+
+**`auth`** appears only for a run whose OAuth 2.0 credential could be renewed
+while it ran - a header-placed, expiring token with `autoRefreshToken` on (see
+[db-schema.md](db-schema.md#oauth_tokens) for the full eligibility list). Each
+entry in `refreshes` is when a renewal landed, in seconds from the run's start.
+`refreshFailures` plus a `lastError` string is the other half of the answer: the
+run kept sending the credential it had, so 401s in `statusCodes` from that point
+on are explained here rather than by the target. The section is **absent** for a
+run that could never refresh, which is not the same claim as a run that watched
+and never needed to (that one reports an empty `refreshes` array).
 
 **A scenario run adds a `scenario` section** and no other run type carries one:
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -533,7 +533,7 @@ starts, so a run longer than its OAuth 2.0 access token used to turn into a 401
 storm the report never explained. The watchdog closes that: it sleeps until
 `oauth2RefreshLeadMs` (default 60s) before the token expires, re-acquires it with
 a forced refresh, and publishes the new `Authorization` value on the run's
-`AuthRefreshState`. Its four `oauth2Refresh*` settings are read once, when the
+`AuthRefreshState`. Its five `oauth2Refresh*` settings are read once, when the
 run arms it (`read_auth_refresh_tuning`), so a run's schedule cannot change
 under it half way through. The *submitting* thread - the strategy, which is the
 event loop's sole producer - copies it onto its own `Request` when the cell's

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -533,8 +533,10 @@ starts, so a run longer than its OAuth 2.0 access token used to turn into a 401
 storm the report never explained. The watchdog closes that: it sleeps until
 `oauth2RefreshLeadMs` (default 60s) before the token expires, re-acquires it with
 a forced refresh, and publishes the new `Authorization` value on the run's
-`AuthRefreshState`. The *submitting* thread - the strategy, which is the event
-loop's sole producer - copies it onto its own `Request` when the cell's
+`AuthRefreshState`. Its four `oauth2Refresh*` settings are read once, when the
+run arms it (`read_auth_refresh_tuning`), so a run's schedule cannot change
+under it half way through. The *submitting* thread - the strategy, which is the
+event loop's sole producer - copies it onto its own `Request` when the cell's
 generation moves, and `EventLoop::submit` copies that request wholesale into
 each transfer. So the swap needs no lock on the submission path and cannot race
 a transfer already queued. Runs it deliberately leaves alone (query-placed

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -130,9 +130,15 @@ Manages the lifecycle of load test runs:
   destroy. A run started while the drain is in progress is refused with a `503`.
 - **Finished workers are reaped on the next `start_run`**: a thread cannot join itself, so
   its handle outlives it until another thread collects it.
+- **Per-run auxiliary threads**: a load run has a metrics thread
+  (`collect_metrics`) and, when its auth is a header-placed expiring oauth2
+  token, an auth-refresh watchdog (`run_auth_refresh`, see below). Both watch
+  `is_running` and are joined together through `RunContext::join_aux_threads` -
+  the worker has four exit paths, and a thread joined at only some of them
+  outlives the `Database` it writes through.
 - **Two kinds of worker, one lifecycle**: `start_run` spawns the load executor
-  plus its metrics thread, `start_scenario_run` spawns the sequential collection
-  runner. Both go through the same `spawn_run` registration - the
+  plus its auxiliary threads, `start_scenario_run` spawns the sequential
+  collection runner. Both go through the same `spawn_run` registration - the
   shutting-down check, the reap and the handle insert all happen under one lock,
   and a copy of that reasoning per run kind is exactly how a worker outlives a
   drain that already declared its state safe to destroy.
@@ -254,10 +260,12 @@ applied to the outgoing request rather than being left to the UI. This lives in
 - **`request_builder`** (`build_request`) - the single request-construction
   pipeline: deserialize the payload, apply the resolved timeout, then resolve
   auth. Both `POST /execute` and `POST /runs` go through it.
-- **`auth_resolver`** (`apply_auth` / `preflight_auth`) - a typed `Auth` variant
-  with an exhaustive per-mode handler: bearer/basic/api-key are injected inline;
-  `oauth2` delegates to the token client. A user-supplied `Authorization` header
-  always wins.
+- **`auth_resolver`** (`apply_auth` / `preflight_auth` / `plan_auth_refresh`) - a
+  typed `Auth` variant with an exhaustive per-mode handler: bearer/basic/api-key
+  are injected inline; `oauth2` delegates to the token client. A user-supplied
+  `Authorization` header always wins. `plan_auth_refresh` decides afterwards
+  whether the credential a *load* run just resolved can be kept current past its
+  expiry - see the run lifecycle below.
 - **`oauth_client`** (`acquire_token`) - grant handling (client_credentials,
   password, authorization_code), the [`oauth_tokens`](db-schema.md#oauth_tokens)
   cache (45s expiry skew, refresh-token rotation), and RFC 6749 client auth. It
@@ -497,7 +505,8 @@ continue-on-failure policy** beyond "an errored step ends its iteration".
    ↓
 5. Start worker thread (execute_load_test)
    ↓
-6. Start metrics thread (collect_metrics)
+6. Start metrics thread (collect_metrics), and - for a run whose auth is a
+   refreshable oauth2 token - the auth-refresh watchdog (run_auth_refresh)
    ↓
 7. Strategy submits requests via SPSC queue → event loop
    ↓
@@ -518,6 +527,21 @@ clears `is_running` afterwards. Exiting on `should_stop` emitted the final tick
 and set `closed` while requests were still settling, so the live view froze at
 the stop click while the stored report - written after the worker returned -
 counted everything that landed in between.
+
+**Auth outlives its token.** A run resolves auth once, before the strategy
+starts, so a run longer than its OAuth 2.0 access token used to turn into a 401
+storm the report never explained. The watchdog closes that: it sleeps until
+`oauth2RefreshLeadMs` (default 60s) before the token expires, re-acquires it with
+a forced refresh, and publishes the new `Authorization` value on the run's
+`AuthRefreshState`. The *submitting* thread - the strategy, which is the event
+loop's sole producer - copies it onto its own `Request` when the cell's
+generation moves, and `EventLoop::submit` copies that request wholesale into
+each transfer. So the swap needs no lock on the submission path and cannot race
+a transfer already queued. Runs it deliberately leaves alone (query-placed
+tokens, `autoRefreshToken: false`, `authorization_code` with no refresh token,
+non-expiring tokens, scenario runs) behave exactly as they did before it
+existed - see `plan_auth_refresh`. A refresh that fails is retried with a
+backoff and recorded in the report's `auth` section; it never fails the run.
 
 The tick topic itself is a bounded ring. Run duration is user-controlled with no
 upper bound, so an append-only buffer is a slow OOM on an overnight soak. The

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -252,7 +252,7 @@ This matters because the seeded labels are wrong in places.
 | `scriptEnableConsole` | `core/run_manager.cpp` | Per run |
 | `liveTickIntervalMs` | `core/run_manager.cpp` | Per run |
 | `maxResponseBodyBytes` | `core/run_manager.cpp` | Per run |
-| `oauth2RefreshLeadMs` | `core/run_manager.cpp` | Per run. Not seeded - how far ahead of expiry a run renews its OAuth 2.0 token (default 60000) |
+| `oauth2RefreshLeadMs`, `oauth2RefreshMinIntervalMs`, `oauth2RefreshRetryMs`, `oauth2RefreshRetryMaxMs` | `core/auth_refresh.cpp` (read at `core/run_manager.cpp`) | Per run. Mid-run OAuth 2.0 renewal: lead time, floor between renewals, and the retry backoff's first wait and ceiling |
 | `dbSynchronous`, `dbBusyTimeout`, `dbCacheSize`, `dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint` | `db/database.cpp` | DB open. **Restart required** |
 | `maxConnections` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |
 | `statsInterval` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -252,6 +252,7 @@ This matters because the seeded labels are wrong in places.
 | `scriptEnableConsole` | `core/run_manager.cpp` | Per run |
 | `liveTickIntervalMs` | `core/run_manager.cpp` | Per run |
 | `maxResponseBodyBytes` | `core/run_manager.cpp` | Per run |
+| `oauth2RefreshLeadMs` | `core/run_manager.cpp` | Per run. Not seeded - how far ahead of expiry a run renews its OAuth 2.0 token (default 60000) |
 | `dbSynchronous`, `dbBusyTimeout`, `dbCacheSize`, `dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint` | `db/database.cpp` | DB open. **Restart required** |
 | `maxConnections` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |
 | `statsInterval` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -252,7 +252,7 @@ This matters because the seeded labels are wrong in places.
 | `scriptEnableConsole` | `core/run_manager.cpp` | Per run |
 | `liveTickIntervalMs` | `core/run_manager.cpp` | Per run |
 | `maxResponseBodyBytes` | `core/run_manager.cpp` | Per run |
-| `oauth2RefreshLeadMs`, `oauth2RefreshMinIntervalMs`, `oauth2RefreshRetryMs`, `oauth2RefreshRetryMaxMs` | `core/auth_refresh.cpp` (read at `core/run_manager.cpp`) | Per run. Mid-run OAuth 2.0 renewal: lead time, floor between renewals, and the retry backoff's first wait and ceiling |
+| `oauth2RefreshLeadMs`, `oauth2RefreshMinIntervalMs`, `oauth2RefreshRetryMs`, `oauth2RefreshRetryMaxMs`, `oauth2RefreshPollIntervalMs` | `core/auth_refresh.cpp` (read at `core/run_manager.cpp`) | Per run. Mid-run OAuth 2.0 renewal: lead time, floor between renewals, the retry backoff's first wait and ceiling, and how often the watchdog wakes to notice the run ended |
 | `dbSynchronous`, `dbBusyTimeout`, `dbCacheSize`, `dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint` | `db/database.cpp` | DB open. **Restart required** |
 | `maxConnections` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |
 | `statsInterval` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -355,8 +355,21 @@ Auto-created by `sync_schema()`.
 
 Expiry is `now > created_at + expires_in*1000 − 45s` (skew). On refresh the
 `refresh_token` rotates when the provider issues a new one; a rejected refresh
-token clears the row and falls back to a fresh grant. There is **no** mid-run
-refresh. Tokens are plaintext at rest (v1 posture); the row is cleared via
+token clears the row and falls back to a fresh grant.
+
+A load run **does** refresh mid-run: a run whose auth resolves to a
+header-placed, expiring oauth2 token gets a watchdog thread that re-acquires
+`oauth2RefreshLeadMs` (default 60s) before expiry, writes the new row here and
+republishes the header onto every later transfer. It stays out of the way for
+the shapes it cannot renew - `tokenPlacement: "query"` (the credential is in the
+URL every transfer copies), `autoRefreshToken: false`, an `authorization_code`
+grant with no refresh token, a non-expiring token, and a scenario load run
+(whose steps each resolved their own auth at plan time). Each refresh, and any
+failure, is reported in the run's `auth` section; a failed refresh never fails
+the run. See `plan_auth_refresh` (`engine/src/http/auth_resolver.cpp`) and
+`run_auth_refresh` (`engine/src/core/auth_refresh.cpp`).
+
+Tokens are plaintext at rest (v1 posture); the row is cleared via
 `DELETE /oauth2/token`.
 
 ---

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -360,8 +360,12 @@ token clears the row and falls back to a fresh grant.
 A load run **does** refresh mid-run: a run whose auth resolves to a
 header-placed, expiring oauth2 token gets a watchdog thread that re-acquires
 `oauth2RefreshLeadMs` (default 60s) before expiry, writes the new row here and
-republishes the header onto every later transfer. It stays out of the way for
-the shapes it cannot renew - `tokenPlacement: "query"` (the credential is in the
+republishes the header onto every later transfer. That lead, the floor between
+two renewals (`oauth2RefreshMinIntervalMs`) and the retry backoff after a
+refused renewal (`oauth2RefreshRetryMs` doubling to `oauth2RefreshRetryMaxMs`)
+are all settings under **Network & Connectivity**, read once when a run arms its
+watchdog, so a change applies to the next run started. It stays out of the way
+for the shapes it cannot renew - `tokenPlacement: "query"` (the credential is in the
 URL every transfer copies), `autoRefreshToken: false`, an `authorization_code`
 grant with no refresh token, a non-expiring token, and a scenario load run
 (whose steps each resolved their own auth at plan time). Each refresh, and any

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -361,10 +361,12 @@ A load run **does** refresh mid-run: a run whose auth resolves to a
 header-placed, expiring oauth2 token gets a watchdog thread that re-acquires
 `oauth2RefreshLeadMs` (default 60s) before expiry, writes the new row here and
 republishes the header onto every later transfer. That lead, the floor between
-two renewals (`oauth2RefreshMinIntervalMs`) and the retry backoff after a
-refused renewal (`oauth2RefreshRetryMs` doubling to `oauth2RefreshRetryMaxMs`)
-are all settings under **Network & Connectivity**, read once when a run arms its
-watchdog, so a change applies to the next run started. It stays out of the way
+two renewals (`oauth2RefreshMinIntervalMs`), the retry backoff after a refused
+renewal (`oauth2RefreshRetryMs` doubling to `oauth2RefreshRetryMaxMs`) and how
+often the watchdog wakes to notice the run ended (`oauth2RefreshPollIntervalMs`,
+which bounds how long a finished run waits to join it) are all settings under
+**Network & Connectivity**, read once when a run arms its watchdog, so a change
+applies to the next run started. It stays out of the way
 for the shapes it cannot renew - `tokenPlacement: "query"` (the credential is in the
 URL every transfer copies), `autoRefreshToken: false`, an `authorization_code`
 grant with no refresh token, a non-expiring token, and a scenario load run

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -276,6 +276,7 @@ add_library(vayu_core STATIC
     src/utils/metrics_helper.cpp
     src/utils/id.cpp
     src/db/database.cpp
+    src/core/auth_refresh.cpp
     src/core/load_strategy.cpp
     src/core/scenario_data.cpp
     src/core/scenario_load.cpp
@@ -469,6 +470,7 @@ if(VAYU_BUILD_TESTS)
         tests/script_compose_test.cpp
         tests/encoding_test.cpp
         tests/auth_resolver_test.cpp
+        tests/auth_refresh_test.cpp
         tests/request_builder_test.cpp
         tests/oauth_client_test.cpp
         tests/oauth_route_test.cpp

--- a/engine/include/vayu/core/auth_refresh.hpp
+++ b/engine/include/vayu/core/auth_refresh.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/http/auth_resolver.hpp"
+#include "vayu/types.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace vayu::core {
+
+/**
+ * @brief A run's live OAuth 2.0 credential, refreshed while the run is going.
+ *
+ * A load run used to resolve auth exactly once, so a run outliving its token
+ * turned into a 401 storm the report never explained. This is the shared cell
+ * that fixes it: the run's refresh watchdog re-acquires the token before it
+ * expires and publishes the new header value here, and the *submitting* thread
+ * copies it onto the request it hands to the event loop.
+ *
+ * Only header-placed tokens are covered - see `http::plan_auth_refresh` for
+ * every case that stays inert.
+ *
+ * Threading: exactly one publisher (the watchdog) and one reader (the strategy
+ * thread, which is the event loop's sole producer). The reader's hot path is a
+ * relaxed load of `generation`; it takes the mutex only on the tick after a
+ * refresh actually happened, which is once per token lifetime.
+ */
+class AuthRefreshState {
+    public:
+    explicit AuthRefreshState (vayu::http::AuthRefreshPlan plan);
+
+    /// The oauth2 config the watchdog re-acquires with.
+    [[nodiscard]] const nlohmann::json& config () const {
+        return plan_.config;
+    }
+    /// Header the token is placed on (`Authorization` today).
+    [[nodiscard]] const std::string& header_name () const {
+        return plan_.header_name;
+    }
+    /// Absolute expiry (ms since epoch) of the token currently published.
+    [[nodiscard]] int64_t expires_at_ms () const {
+        return expires_at_ms_.load (std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Bumped on every successful swap; the reader's change detector.
+     *
+     * Read relaxed on the hot path: it is the only thing the submitting thread
+     * looks at per request, and a swap seen one submission late is a request
+     * sent with a credential that is still valid (the lead exists for exactly
+     * that slack).
+     */
+    [[nodiscard]] uint64_t generation () const {
+        return generation_.load (std::memory_order_acquire);
+    }
+
+    /// The value to send now. Locks - not for the per-request path.
+    [[nodiscard]] std::string header_value () const;
+
+    /**
+     * @brief Publish a refreshed credential.
+     *
+     * @param value        The new header value.
+     * @param at_seconds   Seconds into the run, for the report.
+     * @param expires_at_ms Absolute expiry of the new token, 0 when it does not
+     *                      expire (the watchdog then stops).
+     */
+    void publish (std::string value, double at_seconds, int64_t expires_at_ms);
+
+    /// Record a refresh that did not happen. The run continues either way.
+    void record_failure (const std::string& error);
+
+    /**
+     * @brief The report's `auth` section: when the run refreshed, and what went
+     *        wrong if anything did.
+     *
+     * Written whenever the watchdog was armed, including the zero case - "we
+     * were watching and never needed to" is an answer, and an absent section
+     * already means "this run could not refresh at all".
+     */
+    [[nodiscard]] nlohmann::json summary () const;
+
+    private:
+    vayu::http::AuthRefreshPlan plan_;
+    std::atomic<int64_t> expires_at_ms_{ 0 };
+    std::atomic<uint64_t> generation_{ 0 };
+
+    mutable std::mutex mutex_;
+    std::string header_value_;
+    std::vector<double> refreshed_at_seconds_;
+    size_t failures_ = 0;
+    std::string last_error_;
+};
+
+/**
+ * @brief Copy the run's current credential onto @p request when it has moved.
+ *
+ * Called by the submitting thread immediately before each `EventLoop::submit`,
+ * which copies the request wholesale into the transfer - so a value written
+ * here reaches every subsequent transfer and none of the ones already queued.
+ *
+ * @param state           The run's refresh cell, or null for a run with none.
+ * @param request         The submitting thread's own copy of the request.
+ * @param seen_generation In/out: the generation this copy already carries.
+ */
+void sync_auth_header (const std::shared_ptr<AuthRefreshState>& state,
+vayu::Request& request,
+uint64_t& seen_generation);
+
+/**
+ * @brief How long to sleep before refreshing a token that expires at
+ *        @p expires_at_ms, refreshing @p lead_ms early.
+ *
+ * Floored at `constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS` rather than at
+ * zero: a token whose whole lifetime is shorter than the lead is always inside
+ * its refresh window, and an unfloored schedule would re-acquire in a tight
+ * loop. Extracted from the watchdog so the schedule is testable without a clock.
+ */
+[[nodiscard]] int64_t
+auth_refresh_delay_ms (int64_t expires_at_ms, int64_t now_ms, int64_t lead_ms);
+
+} // namespace vayu::core

--- a/engine/include/vayu/core/auth_refresh.hpp
+++ b/engine/include/vayu/core/auth_refresh.hpp
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "vayu/core/constants.hpp"
+#include "vayu/db/database.hpp"
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/types.hpp"
 
@@ -105,6 +107,33 @@ class AuthRefreshState {
 };
 
 /**
+ * @brief The knobs a run's refresh watchdog reads, resolved once when it arms.
+ *
+ * Every field is a user setting (`oauth2Refresh*`, seeded in
+ * `seed_default_config`), read at arm time rather than per iteration so a run's
+ * schedule cannot change under it half way through - a change applies to the
+ * next run started.
+ */
+struct AuthRefreshTuning {
+    /// How far ahead of expiry to renew.
+    int64_t lead_ms = constants::server::OAUTH2_REFRESH_LEAD_MS;
+    /// Floor on the wait between two renewals - see auth_refresh_delay_ms.
+    int64_t min_interval_ms = constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS;
+    /// First wait after a refused renewal, doubled per consecutive failure.
+    int64_t retry_ms = constants::server::OAUTH2_REFRESH_RETRY_MS;
+    /// Ceiling on that backoff.
+    int64_t retry_max_ms = constants::server::OAUTH2_REFRESH_RETRY_MAX_MS;
+};
+
+/**
+ * @brief Read the `oauth2Refresh*` settings, falling back to their defaults.
+ *
+ * One reader for the four keys, so the run and any future caller cannot
+ * disagree about which key names or defaults are in force.
+ */
+[[nodiscard]] AuthRefreshTuning read_auth_refresh_tuning (vayu::db::Database& db);
+
+/**
  * @brief Copy the run's current credential onto @p request when it has moved.
  *
  * Called by the submitting thread immediately before each `EventLoop::submit`,
@@ -121,14 +150,15 @@ uint64_t& seen_generation);
 
 /**
  * @brief How long to sleep before refreshing a token that expires at
- *        @p expires_at_ms, refreshing @p lead_ms early.
+ *        @p expires_at_ms, refreshing `tuning.lead_ms` early.
  *
- * Floored at `constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS` rather than at
- * zero: a token whose whole lifetime is shorter than the lead is always inside
- * its refresh window, and an unfloored schedule would re-acquire in a tight
- * loop. Extracted from the watchdog so the schedule is testable without a clock.
+ * Floored at `tuning.min_interval_ms` rather than at zero: a token whose whole
+ * lifetime is shorter than the lead is always inside its refresh window, and an
+ * unfloored schedule would re-acquire in a tight loop. Extracted from the
+ * watchdog so the schedule is testable without a clock.
  */
-[[nodiscard]] int64_t
-auth_refresh_delay_ms (int64_t expires_at_ms, int64_t now_ms, int64_t lead_ms);
+[[nodiscard]] int64_t auth_refresh_delay_ms (int64_t expires_at_ms,
+int64_t now_ms,
+const AuthRefreshTuning& tuning);
 
 } // namespace vayu::core

--- a/engine/include/vayu/core/auth_refresh.hpp
+++ b/engine/include/vayu/core/auth_refresh.hpp
@@ -123,6 +123,9 @@ struct AuthRefreshTuning {
     int64_t retry_ms = constants::server::OAUTH2_REFRESH_RETRY_MS;
     /// Ceiling on that backoff.
     int64_t retry_max_ms = constants::server::OAUTH2_REFRESH_RETRY_MAX_MS;
+    /// How often the watchdog wakes while waiting, to notice the run has ended
+    /// - what bounds how long a finished run waits to join it.
+    int64_t poll_interval_ms = constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS;
 };
 
 /**

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -207,6 +207,12 @@ constexpr int64_t OAUTH2_REFRESH_RETRY_MS = 5000;
 /// Ceiling on that backoff, so a token endpoint that is down for an hour costs
 /// the run a bounded number of attempts rather than one every five seconds.
 constexpr int64_t OAUTH2_REFRESH_RETRY_MAX_MS = 60000;
+/// How often the refresh watchdog wakes while waiting, to notice that the run
+/// has ended. The worker joins the thread on its way out, so this is what
+/// bounds how long a finished run waits for it: without the slice, a watchdog
+/// asleep until the next expiry would hold the run open for the rest of the
+/// token's life. Lower costs a few more wakeups per second on one thread.
+constexpr int64_t OAUTH2_REFRESH_POLL_INTERVAL_MS = 100;
 } // namespace server
 
 /**

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -189,6 +189,24 @@ constexpr size_t DEFAULT_MAX_LIVE_TICKS = 50000;
 /// the use-after-free the drain exists to prevent. Matches the 5s the daemon
 /// waited before the drain was ordered.
 constexpr int64_t RUN_SHUTDOWN_GRACE_MS = 5000;
+/// How far ahead of an OAuth 2.0 token's expiry a run refreshes it (config key
+/// `oauth2RefreshLeadMs`). Comfortably wider than the 45s skew
+/// `oauth::is_expired` already applies, so the new credential is published
+/// while the old one is still being accepted and no request falls in the gap.
+constexpr int64_t OAUTH2_REFRESH_LEAD_MS = 60000;
+/// Floor on the wait between two mid-run refreshes. A token whose whole
+/// lifetime is shorter than the lead is always inside its refresh window, so
+/// without a floor the watchdog would re-acquire in a tight loop and hammer the
+/// token endpoint on the run's behalf.
+constexpr int64_t OAUTH2_REFRESH_MIN_INTERVAL_MS = 1000;
+/// First wait after a failed mid-run refresh, doubled per consecutive failure
+/// up to OAUTH2_REFRESH_RETRY_MAX_MS. The run keeps sending the credential it
+/// has - a failed refresh is reported, never fatal - so retrying is about
+/// recovering from a token endpoint that blipped, not about the run's fate.
+constexpr int64_t OAUTH2_REFRESH_RETRY_MS = 5000;
+/// Ceiling on that backoff, so a token endpoint that is down for an hour costs
+/// the run a bounded number of attempts rather than one every five seconds.
+constexpr int64_t OAUTH2_REFRESH_RETRY_MAX_MS = 60000;
 } // namespace server
 
 /**

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "vayu/core/auth_refresh.hpp"
 #include "vayu/core/constants.hpp"
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/scenario_plan.hpp"
@@ -97,6 +98,16 @@ struct RunContext {
     // itself and terminate. RunManager owns the handle instead - see
     // `run_workers_` - and joins it from a thread that is never the worker.
     std::thread metrics_thread;
+    // Refreshes the run's OAuth 2.0 credential before it expires. Spawned only
+    // when the run's auth can actually be refreshed (see
+    // `http::plan_auth_refresh`), joined everywhere metrics_thread is - it
+    // holds a shared_ptr to this context and calls a blocking HTTP client, so
+    // an unjoined one outlives the database it acquires through.
+    std::thread auth_refresh_thread;
+    // The credential that thread publishes and the strategy thread sends. Null
+    // for every run without mid-run refresh, which is the inert case
+    // everywhere: no thread, no swap, no report section.
+    std::shared_ptr<AuthRefreshState> auth_refresh;
     std::atomic<bool> should_stop{ false };
     std::atomic<bool> is_running{ false };
     nlohmann::json config;
@@ -276,6 +287,17 @@ struct RunContext {
     size_t max_errors                = constants::metrics_collector::DEFAULT_MAX_ERRORS,
     CaptureDefaults capture_defaults = {});
     ~RunContext ();
+
+    /**
+     * @brief Join the run's auxiliary threads (metrics tick, auth refresh).
+     *
+     * Both watch `is_running`, so the caller clears it first. They are joined
+     * through one helper because the run has four exit paths - two inner
+     * failure returns, the normal end, and the outer catch - and a thread added
+     * to the spawn site but missed at one of them outlives the database it
+     * writes through.
+     */
+    void join_aux_threads ();
 };
 
 /**
@@ -455,6 +477,12 @@ struct RunSummaryInputs {
     // which leaves the report's scenario section out entirely rather than
     // showing it zeros - the section exists to say what a sequence did.
     std::optional<nlohmann::json> scenario;
+    // When and whether this run's OAuth 2.0 credential was refreshed while it
+    // ran, under the summary's `auth` key. Absent for every run that could not
+    // refresh at all (no oauth2 auth, a non-expiring or query-placed token, the
+    // user's opt-out) - which is what distinguishes "never needed to" from
+    // "was never watching".
+    std::optional<nlohmann::json> auth;
 };
 
 /**
@@ -629,5 +657,22 @@ vayu::db::Database* db_ptr,
 bool verbose,
 RunManager& manager);
 void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* db_ptr);
+
+/**
+ * @brief Keep a run's OAuth 2.0 credential valid for as long as the run lasts.
+ *
+ * Sleeps until @p lead_ms before the published token expires, re-acquires
+ * (forced, so the cache cannot hand back the one that is about to die),
+ * publishes the new header on `context->auth_refresh` and re-arms from the new
+ * expiry. A failed refresh is recorded and retried with a backoff; it never
+ * fails the run, because the honest report of a 401 storm is the target's own
+ * status codes plus the `auth` section saying the refresh did not happen.
+ *
+ * Returns as soon as the run stops, or once the published token no longer
+ * expires. Inert (returns immediately) when the run has no `auth_refresh`.
+ */
+void run_auth_refresh (std::shared_ptr<RunContext> context,
+vayu::db::Database* db_ptr,
+int64_t lead_ms);
 
 } // namespace vayu::core

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -661,18 +661,21 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 /**
  * @brief Keep a run's OAuth 2.0 credential valid for as long as the run lasts.
  *
- * Sleeps until @p lead_ms before the published token expires, re-acquires
+ * Sleeps until `tuning.lead_ms` before the published token expires, re-acquires
  * (forced, so the cache cannot hand back the one that is about to die),
  * publishes the new header on `context->auth_refresh` and re-arms from the new
  * expiry. A failed refresh is recorded and retried with a backoff; it never
  * fails the run, because the honest report of a 401 storm is the target's own
  * status codes plus the `auth` section saying the refresh did not happen.
  *
+ * @p tuning is the run's snapshot of the user's `oauth2Refresh*` settings, read
+ * once when the watchdog arms (`read_auth_refresh_tuning`).
+ *
  * Returns as soon as the run stops, or once the published token no longer
  * expires. Inert (returns immediately) when the run has no `auth_refresh`.
  */
 void run_auth_refresh (std::shared_ptr<RunContext> context,
 vayu::db::Database* db_ptr,
-int64_t lead_ms);
+const AuthRefreshTuning& tuning);
 
 } // namespace vayu::core

--- a/engine/include/vayu/http/auth_resolver.hpp
+++ b/engine/include/vayu/http/auth_resolver.hpp
@@ -11,6 +11,7 @@
 #include "vayu/types.hpp"
 
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -90,5 +91,54 @@ vayu::db::Database* db);
  *        other mode.
  */
 AuthApplyResult preflight_auth (const nlohmann::json& auth, vayu::db::Database& db);
+
+/**
+ * @brief The `Authorization` value an oauth2 config places for an access token.
+ *
+ * One copy of the `headerPrefix` rule, shared by the initial resolution and by
+ * every mid-run refresh - a second copy would let a run's later headers drift
+ * in shape from its first.
+ */
+std::string oauth2_header_value (const nlohmann::json& config,
+const std::string& access_token);
+
+/**
+ * @brief What a long run needs in order to keep its OAuth 2.0 header valid
+ *        past the token's expiry.
+ *
+ * Filled from the token `apply_auth` just placed on @p request, so it describes
+ * the credential the run is actually sending - not what the config asks for.
+ * The run's refresh watchdog re-acquires with this config and republishes
+ * `header_value`; see `vayu::core::run_auth_refresh`.
+ */
+struct AuthRefreshPlan {
+    nlohmann::json config;      ///< The oauth2 config block, as acquire_token takes it.
+    std::string header_name;    ///< Header the token was placed on.
+    std::string header_value;   ///< Value currently on the built request.
+    int64_t expires_at_ms = 0;  ///< Absolute expiry (ms since epoch) of that token.
+};
+
+/**
+ * @brief Decide whether a built request's auth can be refreshed mid-run.
+ *
+ * Returns nothing - the run then behaves exactly as it did before mid-run
+ * refresh existed - when any of these hold:
+ *   - the mode is not `oauth2`, or the token cache has no token for it;
+ *   - the token never expires (`expires_in <= 0`);
+ *   - `autoRefreshToken` is false (the user's explicit opt-out);
+ *   - `tokenPlacement` is `query` - the value is baked into the URL every
+ *     transfer copies, which no header swap can reach;
+ *   - the grant is `authorization_code` with no refresh token, which cannot be
+ *     re-obtained without a browser;
+ *   - the request does not actually carry the token (a user-supplied
+ *     `Authorization` header won, so refreshing it would change nothing).
+ *
+ * @param request The request `apply_auth` has already resolved.
+ * @param auth    The same raw `auth` object that was applied.
+ * @param db      Token-cache handle; null yields nothing.
+ */
+std::optional<AuthRefreshPlan> plan_auth_refresh (const vayu::Request& request,
+const nlohmann::json& auth,
+vayu::db::Database* db);
 
 } // namespace vayu::http

--- a/engine/src/core/auth_refresh.cpp
+++ b/engine/src/core/auth_refresh.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/core/auth_refresh.hpp"
+
+#include "vayu/core/constants.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/http/oauth_client.hpp"
+#include "vayu/utils/logger.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+#include <utility>
+#include <variant>
+
+namespace vayu::core {
+
+namespace {
+
+int64_t now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+    .count ();
+}
+
+/// Sleep in slices so a stop is honoured promptly: the worker joins this thread
+/// on the way out, and a watchdog asleep until the next expiry would hold a
+/// finished run open for the rest of the token's life.
+constexpr int64_t SLICE_MS = 100;
+
+/// @return false if the run ended while waiting.
+bool wait_while_running (const std::shared_ptr<RunContext>& context, int64_t delay_ms) {
+    int64_t waited = 0;
+    while (waited < delay_ms) {
+        if (!context->is_running.load () || context->should_stop.load ()) {
+            return false;
+        }
+        const int64_t slice = std::min (SLICE_MS, delay_ms - waited);
+        std::this_thread::sleep_for (std::chrono::milliseconds (slice));
+        waited += slice;
+    }
+    return context->is_running.load () && !context->should_stop.load ();
+}
+
+} // namespace
+
+AuthRefreshState::AuthRefreshState (vayu::http::AuthRefreshPlan plan)
+: plan_ (std::move (plan)), header_value_ (plan_.header_value) {
+    expires_at_ms_.store (plan_.expires_at_ms, std::memory_order_relaxed);
+}
+
+std::string AuthRefreshState::header_value () const {
+    const std::lock_guard<std::mutex> lock (mutex_);
+    return header_value_;
+}
+
+void AuthRefreshState::publish (std::string value, double at_seconds, int64_t expires_at_ms) {
+    {
+        const std::lock_guard<std::mutex> lock (mutex_);
+        header_value_ = std::move (value);
+        refreshed_at_seconds_.push_back (at_seconds);
+    }
+    expires_at_ms_.store (expires_at_ms, std::memory_order_relaxed);
+    // Release: the reader acquires this counter and then takes the mutex, so
+    // the value written above is what it finds there.
+    generation_.fetch_add (1, std::memory_order_release);
+}
+
+void AuthRefreshState::record_failure (const std::string& error) {
+    const std::lock_guard<std::mutex> lock (mutex_);
+    ++failures_;
+    last_error_ = error;
+}
+
+nlohmann::json AuthRefreshState::summary () const {
+    const std::lock_guard<std::mutex> lock (mutex_);
+    nlohmann::json refreshes = nlohmann::json::array ();
+    for (const double at : refreshed_at_seconds_) {
+        refreshes.push_back ({ { "atSeconds", at } });
+    }
+    nlohmann::json out;
+    out["refreshes"]       = refreshes;
+    out["refreshFailures"] = failures_;
+    if (!last_error_.empty ()) {
+        out["lastError"] = last_error_;
+    }
+    return out;
+}
+
+void sync_auth_header (const std::shared_ptr<AuthRefreshState>& state,
+vayu::Request& request,
+uint64_t& seen_generation) {
+    if (!state) {
+        return;
+    }
+    const uint64_t current = state->generation ();
+    if (current == seen_generation) {
+        return;
+    }
+    request.headers[state->header_name ()] = state->header_value ();
+    seen_generation                        = current;
+}
+
+int64_t auth_refresh_delay_ms (int64_t expires_at_ms, int64_t now_ms, int64_t lead_ms) {
+    return std::max (constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS,
+    expires_at_ms - lead_ms - now_ms);
+}
+
+void run_auth_refresh (std::shared_ptr<RunContext> context,
+vayu::db::Database* db_ptr,
+int64_t lead_ms) {
+    const auto state = context->auth_refresh;
+    if (!state || db_ptr == nullptr) {
+        return;
+    }
+    auto& db = *db_ptr;
+
+    int64_t retry_ms = constants::server::OAUTH2_REFRESH_RETRY_MS;
+
+    while (context->is_running.load () && !context->should_stop.load ()) {
+        const int64_t expires_at = state->expires_at_ms ();
+        if (expires_at <= 0) {
+            return; // The published token does not expire - nothing left to do.
+        }
+        if (!wait_while_running (
+            context, auth_refresh_delay_ms (expires_at, now_ms (), lead_ms))) {
+            return;
+        }
+
+        auto result = vayu::http::oauth::acquire_token (db, state->config (),
+        /*force_refresh=*/true, std::nullopt);
+
+        if (const auto* err = std::get_if<vayu::http::oauth::TokenError> (&result)) {
+            // Reported, never fatal: the run keeps sending the credential it
+            // has, and the report's auth section plus the target's own 401s
+            // say what happened.
+            const std::string message = err->code + ": " + err->message;
+            state->record_failure (message);
+            vayu::utils::log_warning ("OAuth2 mid-run refresh failed for run " +
+            context->run_id + " - " + message);
+            if (!wait_while_running (context, retry_ms)) {
+                return;
+            }
+            retry_ms = std::min (retry_ms * 2, constants::server::OAUTH2_REFRESH_RETRY_MAX_MS);
+            continue;
+        }
+
+        retry_ms                = constants::server::OAUTH2_REFRESH_RETRY_MS;
+        const auto& token       = std::get<vayu::db::OAuthToken> (result);
+        const double at_seconds = context->start_time_ms > 0 ?
+        static_cast<double> (now_ms () - context->start_time_ms) / 1000.0 :
+        0.0;
+        state->publish (
+        vayu::http::oauth2_header_value (state->config (), token.access_token), at_seconds,
+        token.expires_in > 0 ? token.created_at + token.expires_in * 1000 : 0);
+        vayu::utils::log_info ("OAuth2: refreshed the token for run " + context->run_id);
+    }
+}
+
+} // namespace vayu::core

--- a/engine/src/core/auth_refresh.cpp
+++ b/engine/src/core/auth_refresh.cpp
@@ -28,19 +28,18 @@ int64_t now_ms () {
     .count ();
 }
 
-/// Sleep in slices so a stop is honoured promptly: the worker joins this thread
-/// on the way out, and a watchdog asleep until the next expiry would hold a
-/// finished run open for the rest of the token's life.
-constexpr int64_t SLICE_MS = 100;
-
+/// Sleep in slices of `poll_ms` so a stop is honoured promptly: the worker
+/// joins this thread on the way out, and a watchdog asleep until the next
+/// expiry would hold a finished run open for the rest of the token's life.
+///
 /// @return false if the run ended while waiting.
-bool wait_while_running (const std::shared_ptr<RunContext>& context, int64_t delay_ms) {
+bool wait_while_running (const std::shared_ptr<RunContext>& context, int64_t delay_ms, int64_t poll_ms) {
     int64_t waited = 0;
     while (waited < delay_ms) {
         if (!context->is_running.load () || context->should_stop.load ()) {
             return false;
         }
-        const int64_t slice = std::min (SLICE_MS, delay_ms - waited);
+        const int64_t slice = std::min (poll_ms, delay_ms - waited);
         std::this_thread::sleep_for (std::chrono::milliseconds (slice));
         waited += slice;
     }
@@ -123,6 +122,8 @@ AuthRefreshTuning read_auth_refresh_tuning (vayu::db::Database& db) {
     tuning.min_interval_ms = read ("oauth2RefreshMinIntervalMs", defaults.min_interval_ms);
     tuning.retry_ms = read ("oauth2RefreshRetryMs", defaults.retry_ms);
     tuning.retry_max_ms = read ("oauth2RefreshRetryMaxMs", defaults.retry_max_ms);
+    tuning.poll_interval_ms =
+    read ("oauth2RefreshPollIntervalMs", defaults.poll_interval_ms);
     return tuning;
 }
 
@@ -146,8 +147,8 @@ const AuthRefreshTuning& tuning) {
         if (expires_at <= 0) {
             return; // The published token does not expire - nothing left to do.
         }
-        if (!wait_while_running (
-            context, auth_refresh_delay_ms (expires_at, now_ms (), tuning))) {
+        if (!wait_while_running (context,
+            auth_refresh_delay_ms (expires_at, now_ms (), tuning), tuning.poll_interval_ms)) {
             return;
         }
 
@@ -162,7 +163,7 @@ const AuthRefreshTuning& tuning) {
             state->record_failure (message);
             vayu::utils::log_warning ("OAuth2 mid-run refresh failed for run " +
             context->run_id + " - " + message);
-            if (!wait_while_running (context, retry_ms)) {
+            if (!wait_while_running (context, retry_ms, tuning.poll_interval_ms)) {
                 return;
             }
             retry_ms = std::min (retry_ms * 2, tuning.retry_max_ms);

--- a/engine/src/core/auth_refresh.cpp
+++ b/engine/src/core/auth_refresh.cpp
@@ -106,21 +106,40 @@ uint64_t& seen_generation) {
     seen_generation                        = current;
 }
 
-int64_t auth_refresh_delay_ms (int64_t expires_at_ms, int64_t now_ms, int64_t lead_ms) {
-    return std::max (constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS,
-    expires_at_ms - lead_ms - now_ms);
+AuthRefreshTuning read_auth_refresh_tuning (vayu::db::Database& db) {
+    const AuthRefreshTuning defaults;
+    // A non-positive value is not a setting - POST /config rejects one against
+    // each key's seeded minimum - so it can only reach here from a hand-edited
+    // row, and a zero floor would turn the schedule into a tight loop against
+    // the token endpoint. Fall back rather than trust it, as live_ring_size
+    // does for the same reason.
+    auto read = [&db] (const char* key, int64_t fallback) {
+        const auto value =
+        static_cast<int64_t> (db.get_config_int (key, static_cast<int> (fallback)));
+        return value > 0 ? value : fallback;
+    };
+    AuthRefreshTuning tuning;
+    tuning.lead_ms = read ("oauth2RefreshLeadMs", defaults.lead_ms);
+    tuning.min_interval_ms = read ("oauth2RefreshMinIntervalMs", defaults.min_interval_ms);
+    tuning.retry_ms = read ("oauth2RefreshRetryMs", defaults.retry_ms);
+    tuning.retry_max_ms = read ("oauth2RefreshRetryMaxMs", defaults.retry_max_ms);
+    return tuning;
+}
+
+int64_t auth_refresh_delay_ms (int64_t expires_at_ms, int64_t now_ms, const AuthRefreshTuning& tuning) {
+    return std::max (tuning.min_interval_ms, expires_at_ms - tuning.lead_ms - now_ms);
 }
 
 void run_auth_refresh (std::shared_ptr<RunContext> context,
 vayu::db::Database* db_ptr,
-int64_t lead_ms) {
+const AuthRefreshTuning& tuning) {
     const auto state = context->auth_refresh;
     if (!state || db_ptr == nullptr) {
         return;
     }
     auto& db = *db_ptr;
 
-    int64_t retry_ms = constants::server::OAUTH2_REFRESH_RETRY_MS;
+    int64_t retry_ms = tuning.retry_ms;
 
     while (context->is_running.load () && !context->should_stop.load ()) {
         const int64_t expires_at = state->expires_at_ms ();
@@ -128,7 +147,7 @@ int64_t lead_ms) {
             return; // The published token does not expire - nothing left to do.
         }
         if (!wait_while_running (
-            context, auth_refresh_delay_ms (expires_at, now_ms (), lead_ms))) {
+            context, auth_refresh_delay_ms (expires_at, now_ms (), tuning))) {
             return;
         }
 
@@ -146,11 +165,11 @@ int64_t lead_ms) {
             if (!wait_while_running (context, retry_ms)) {
                 return;
             }
-            retry_ms = std::min (retry_ms * 2, constants::server::OAUTH2_REFRESH_RETRY_MAX_MS);
+            retry_ms = std::min (retry_ms * 2, tuning.retry_max_ms);
             continue;
         }
 
-        retry_ms                = constants::server::OAUTH2_REFRESH_RETRY_MS;
+        retry_ms                = tuning.retry_ms;
         const auto& token       = std::get<vayu::db::OAuthToken> (result);
         const double at_seconds = context->start_time_ms > 0 ?
         static_cast<double> (now_ms () - context->start_time_ms) / 1000.0 :

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -251,6 +251,32 @@ inline void update_peak (const std::shared_ptr<RunContext>& context) {
     }
 }
 
+// The request every submission copies, plus the credential swap that keeps it
+// current. Owned by the strategy because the strategy thread is the event
+// loop's sole producer and `EventLoop::submit` copies the request wholesale at
+// submit time: a value written here reaches every later transfer and none of
+// the ones already queued, with no lock on the submission path.
+//
+// A run without mid-run refresh (the common case - see plan_auth_refresh) never
+// enters the swap at all: `current()` is then a relaxed load short-circuited on
+// a null state.
+class SubmissionRequest {
+    public:
+    SubmissionRequest (const std::shared_ptr<RunContext>& context, const vayu::Request& request)
+    : state_ (context->auth_refresh), request_ (request) {
+    }
+
+    const vayu::Request& current () {
+        sync_auth_header (state_, request_, seen_generation_);
+        return request_;
+    }
+
+    private:
+    std::shared_ptr<AuthRefreshState> state_;
+    vayu::Request request_;
+    uint64_t seen_generation_ = 0;
+};
+
 } // namespace
 
 // Declared in load_strategy.hpp - the scenario load executor drives the same
@@ -319,6 +345,7 @@ class ConstantLoadStrategy : public LoadStrategy {
     const vayu::Request& request) override {
         const auto& config  = context->config;
         int64_t duration_ms = duration_field_ms (config, "duration", 60000);
+        SubmissionRequest live (context, request);
 
         // Check for targetRps - if specified, use rate-limited mode
         double target_rps = config.value ("rps", 0.0);
@@ -387,7 +414,7 @@ class ConstantLoadStrategy : public LoadStrategy {
                     }
 
                     for (size_t i = 0; i < to_submit && !context->should_stop; ++i) {
-                        context->event_loop->submit (request,
+                        context->event_loop->submit (live.current (),
                         [context, &db] (size_t, vayu::Result<vayu::Response> result) {
                             handle_result (context, db, std::move (result));
                         });
@@ -436,8 +463,8 @@ class ConstantLoadStrategy : public LoadStrategy {
             vayu::utils::log_info ("  Duration: " + std::to_string (duration_ms) + " ms");
             vayu::utils::log_info ("  Concurrency: " + std::to_string (concurrency));
 
-            auto submit_one = [&context, &db, &request] () {
-                context->event_loop->submit (request,
+            auto submit_one = [&context, &db, &live] () {
+                context->event_loop->submit (live.current (),
                 [context, &db] (size_t, vayu::Result<vayu::Response> result) {
                     handle_result (context, db, std::move (result));
                 });
@@ -463,6 +490,7 @@ class IterationsLoadStrategy : public LoadStrategy {
     vayu::db::Database& db,
     const vayu::Request& request) override {
         const auto& config = context->config;
+        SubmissionRequest live (context, request);
         size_t iterations = static_cast<size_t> (config.value ("iterations", 1000));
         size_t concurrency = static_cast<size_t> (config.value ("concurrency", 10));
 
@@ -472,8 +500,8 @@ class IterationsLoadStrategy : public LoadStrategy {
 
         context->requests_expected = iterations;
 
-        auto submit_one = [&context, &db, &request] () {
-            context->event_loop->submit (request,
+        auto submit_one = [&context, &db, &live] () {
+            context->event_loop->submit (live.current (),
             [context, &db] (size_t, vayu::Result<vayu::Response> result) {
                 handle_result (context, db, std::move (result));
             });
@@ -506,6 +534,7 @@ class RampUpLoadStrategy : public LoadStrategy {
     vayu::db::Database& db,
     const vayu::Request& request) override {
         const auto& config = context->config;
+        SubmissionRequest live (context, request);
 
         int64_t duration_ms = duration_field_ms (config, "duration", 60000);
         int64_t ramp_duration_ms = duration_field_ms (config, "rampUpDuration", 10000);
@@ -522,8 +551,8 @@ class RampUpLoadStrategy : public LoadStrategy {
         vayu::utils::log_info ("  Start Concurrency: " + std::to_string (start_concurrency));
         vayu::utils::log_info ("  Target Concurrency: " + std::to_string (target_concurrency));
 
-        auto submit_one = [&context, &db, &request] () {
-            context->event_loop->submit (request,
+        auto submit_one = [&context, &db, &live] () {
+            context->event_loop->submit (live.current (),
             [context, &db] (size_t, vayu::Result<vayu::Response> result) {
                 handle_result (context, db, std::move (result));
             });

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -437,12 +437,19 @@ RunContext::~RunContext () {
     // Wake the closed-loop controller so it observes should_stop without
     // waiting for its 50ms safety-net timeout before the join below.
     notify_refill ();
-    // The worker joins this itself before it returns; the join here only covers
-    // a context destroyed before its worker ever ran. The *worker* thread is
-    // owned by RunManager (run_workers_), never by the context - see the
-    // declaration for why.
+    // The worker joins these itself before it returns; the join here only
+    // covers a context destroyed before its worker ever ran. The *worker*
+    // thread is owned by RunManager (run_workers_), never by the context - see
+    // the declaration for why.
+    join_aux_threads ();
+}
+
+void RunContext::join_aux_threads () {
     if (metrics_thread.joinable ()) {
         metrics_thread.join ();
+    }
+    if (auth_refresh_thread.joinable ()) {
+        auth_refresh_thread.join ();
     }
 }
 
@@ -829,12 +836,32 @@ RunManager& manager) {
                 : "Load test auth resolution failed: " + built.error_message);
                 db.update_run_status (context->run_id, vayu::RunStatus::Failed);
                 context->is_running = false;
-                if (context->metrics_thread.joinable ())
-                    context->metrics_thread.join ();
+                context->join_aux_threads ();
                 manager.retain_run (context->run_id);
                 return;
             }
             request = std::move (built.request);
+
+            // A run that outlives its OAuth 2.0 token used to become a 401
+            // storm the report never explained. Armed here, while the token
+            // this run just resolved is still the one in the cache, and inert
+            // for every auth that cannot be refreshed mid-run - see
+            // plan_auth_refresh for that list.
+            //
+            // A scenario load run is deliberately not covered: each of its
+            // steps resolved its own auth at plan time, before this run row
+            // existed, so there is no single credential to keep current.
+            if (auto plan = vayu::http::plan_auth_refresh (
+                request, config.value ("auth", nlohmann::json ()), db_ptr)) {
+                context->auth_refresh =
+                std::make_shared<AuthRefreshState> (std::move (*plan));
+                const auto lead_ms = static_cast<int64_t> (db.get_config_int (
+                "oauth2RefreshLeadMs",
+                static_cast<int> (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS)));
+                context->auth_refresh_thread = std::thread ([context, db_ptr, lead_ms] () {
+                    run_auth_refresh (context, db_ptr, lead_ms);
+                });
+            }
         }
 
         // Execute Load Strategy
@@ -852,7 +879,7 @@ RunManager& manager) {
             vayu::utils::log_error ("Load test failed: " + std::string (e.what ()));
             db.update_run_status (context->run_id, vayu::RunStatus::Failed);
             context->is_running = false;
-            if (context->metrics_thread.joinable ()) context->metrics_thread.join ();
+            context->join_aux_threads ();
             manager.retain_run (context->run_id);
             return;
         }
@@ -889,10 +916,9 @@ RunManager& manager) {
         // Stop background metrics collection and wait for thread to finish
         context->is_running = false;
 
-        // Properly join the metrics thread to ensure it's done writing to DB
-        if (context->metrics_thread.joinable ()) {
-            context->metrics_thread.join ();
-        }
+        // Properly join the auxiliary threads to ensure the tick thread is
+        // done writing to the DB and the refresh watchdog has let go of it.
+        context->join_aux_threads ();
 
         // Calculate cleanup overhead (time from test end to after cleanup)
         auto cleanup_end = std::chrono::steady_clock::now ();
@@ -972,6 +998,11 @@ RunManager& manager) {
             // is about to store, or a report could print a p99 its own verdict
             // disagrees with. A run stopped early is judged on what it measured.
             inputs.thresholds = evaluate_thresholds (context->config, inputs);
+            // What the refresh watchdog did, for a run that had one. Read after
+            // the join above, so the tallies are final.
+            if (context->auth_refresh) {
+                inputs.auth = context->auth_refresh->summary ();
+            }
 
             db.update_run_summary (
             context->run_id, build_run_summary_payload (inputs).dump ());
@@ -1013,7 +1044,7 @@ RunManager& manager) {
         // failure paths do. Deferring the join to ~RunContext instead would run
         // it under RunManager::mutex_ during a later sweep eviction.
         context->is_running = false;
-        if (context->metrics_thread.joinable ()) context->metrics_thread.join ();
+        context->join_aux_threads ();
 
         vayu::utils::log_error ("Load test error: " + std::string (e.what ()));
 
@@ -1048,6 +1079,9 @@ RunManager& manager) {
             inputs.latency_avg_ms   = mc.average_latency ();
             inputs.retention               = read_retention (mc);
             inputs.http_version_downgraded = mc.http_version_downgraded ();
+            if (context->auth_refresh) {
+                inputs.auth = context->auth_refresh->summary ();
+            }
 
             db.update_run_summary (
             context->run_id, build_run_summary_payload (inputs).dump ());
@@ -1174,6 +1208,13 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     // executors. Omitted for a single-request load run, which has no sequence.
     if (inputs.scenario.has_value ()) {
         summary["scenario"] = *inputs.scenario;
+    }
+    // Whether this run's OAuth 2.0 credential was kept current, and at what
+    // cost. Omitted for every run that could not refresh at all, so an absent
+    // section reads as "this run was never watching" rather than as a run that
+    // watched and saw nothing.
+    if (inputs.auth.has_value ()) {
+        summary["auth"] = *inputs.auth;
     }
     return summary;
 }

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -855,11 +855,11 @@ RunManager& manager) {
                 request, config.value ("auth", nlohmann::json ()), db_ptr)) {
                 context->auth_refresh =
                 std::make_shared<AuthRefreshState> (std::move (*plan));
-                const auto lead_ms = static_cast<int64_t> (db.get_config_int (
-                "oauth2RefreshLeadMs",
-                static_cast<int> (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS)));
-                context->auth_refresh_thread = std::thread ([context, db_ptr, lead_ms] () {
-                    run_auth_refresh (context, db_ptr, lead_ms);
+                // The user's oauth2Refresh* settings, read once here: a run's
+                // schedule must not change under it half way through.
+                const AuthRefreshTuning tuning = read_auth_refresh_tuning (db);
+                context->auth_refresh_thread = std::thread ([context, db_ptr, tuning] () {
+                    run_auth_refresh (context, db_ptr, tuning);
                 });
             }
         }

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1762,6 +1762,20 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS),
     "1000", "3600000", std::nullopt, now });
 
+    upsert_config (ConfigEntry{ "oauth2RefreshPollIntervalMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
+    "integer", "OAuth 2.0 Refresh Poll Interval",
+    "How often the renewal watchdog wakes while it waits, to notice that the "
+    "run has ended. A finished run joins that thread before it writes its "
+    "report, so this is what bounds how long the run's last moments take. "
+    "Lower costs a few more wakeups per second on one sleeping thread and "
+    "nothing on the request path; raise it only to quiet a very long soak.",
+    "network_performance",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
+    "10",   // 10ms - below this the wakeups outweigh what they save
+    "5000", // 5s - past this a finished run visibly waits on the join
+    std::nullopt, now });
+
     // =========================================================================
     // SCRIPTING ENVIRONMENT CONFIGURATION
     // Configuration for the QuickJS sandbox execution, limits, and debugging

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1709,6 +1709,59 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::event_loop::TCP_KEEPALIVE_INTERVAL_SECONDS),
     "1", "300", std::nullopt, now });
 
+    // Mid-run OAuth 2.0 refresh. A load run renews a header-placed access token
+    // before it expires, so a run longer than its token does not turn into a
+    // 401 storm. All four are read once when the run arms its watchdog, so a
+    // change applies to the next run started - no restart.
+    upsert_config (ConfigEntry{ "oauth2RefreshLeadMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS), "integer",
+    "OAuth 2.0 Refresh Lead Time",
+    "How far ahead of an access token's expiry a running load test renews it. "
+    "Wider than the 45s skew the token cache already applies, so the new "
+    "credential is published while the old one is still accepted and no "
+    "request falls in the gap. Raise it for a provider that is slow to issue "
+    "tokens.",
+    "network_performance",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS),
+    "1000",    // 1 second
+    "3600000", // 1 hour
+    std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "oauth2RefreshMinIntervalMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS), "integer",
+    "Minimum OAuth 2.0 Refresh Interval",
+    "Floor on the wait between two mid-run renewals. A token whose whole "
+    "lifetime is shorter than the lead time above is always inside its refresh "
+    "window, so without this floor a run would re-acquire in a tight loop and "
+    "hammer the token endpoint. Lower it only when testing against a provider "
+    "that issues very short-lived tokens.",
+    "network_performance",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS),
+    "100",     // 0.1 second - a floor, never 0: that is the tight loop
+    "3600000", // 1 hour
+    std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "oauth2RefreshRetryMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS), "integer",
+    "OAuth 2.0 Refresh Retry Delay",
+    "First wait after a mid-run renewal is refused, doubled per consecutive "
+    "failure up to the ceiling below. The run keeps sending the credential it "
+    "already has - a failed renewal is reported in the run's report, never "
+    "fatal - so this is about recovering from a token endpoint that blipped.",
+    "network_performance",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS),
+    "250", "600000", std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "oauth2RefreshRetryMaxMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS), "integer",
+    "Maximum OAuth 2.0 Refresh Retry Delay",
+    "Ceiling on that backoff, so a token endpoint that is down for an hour "
+    "costs the run a bounded number of attempts rather than one every few "
+    "seconds.",
+    "network_performance",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS),
+    "1000", "3600000", std::nullopt, now });
+
     // =========================================================================
     // SCRIPTING ENVIRONMENT CONFIGURATION
     // Configuration for the QuickJS sandbox execution, limits, and debugging

--- a/engine/src/http/auth_resolver.cpp
+++ b/engine/src/http/auth_resolver.cpp
@@ -42,6 +42,14 @@ const std::string& value) {
     url += fragment;
 }
 
+// Fetch a boolean field, tolerating a missing key or non-boolean value.
+bool flag (const nlohmann::json& obj, const char* key, bool fallback) {
+    if (auto it = obj.find (key); it != obj.end () && it->is_boolean ()) {
+        return it->get<bool> ();
+    }
+    return fallback;
+}
+
 // Map a token-acquisition failure onto the auth-resolution result shape.
 AuthApplyResult from_token_error (const oauth::TokenError& err) {
     AuthApplyResult out;
@@ -98,19 +106,72 @@ vayu::db::Database* db) {
             }
             append_query_param (req->url, param, token.access_token);
         } else if (req->headers.count ("Authorization") == 0) {
-            std::string prefix = "Bearer";
-            if (auto it = config.find ("headerPrefix");
-                it != config.end () && it->is_string ()) {
-                prefix = it->get<std::string> ();
-            }
             req->headers["Authorization"] =
-            prefix.empty () ? token.access_token : prefix + " " + token.access_token;
+            oauth2_header_value (config, token.access_token);
         }
     }
     return {};
 }
 
 } // namespace
+
+std::string oauth2_header_value (const nlohmann::json& config,
+const std::string& access_token) {
+    std::string prefix = "Bearer";
+    if (auto it = config.find ("headerPrefix"); it != config.end () && it->is_string ()) {
+        prefix = it->get<std::string> ();
+    }
+    return prefix.empty () ? access_token : prefix + " " + access_token;
+}
+
+std::optional<AuthRefreshPlan> plan_auth_refresh (const vayu::Request& request,
+const nlohmann::json& auth,
+vayu::db::Database* db) {
+    if (db == nullptr) {
+        return std::nullopt;
+    }
+    const Auth parsed  = parse_auth (auth);
+    const auto* oauth2 = std::get_if<OAuth2Auth> (&parsed);
+    if (oauth2 == nullptr || !oauth2->config.is_object ()) {
+        return std::nullopt;
+    }
+    const auto& config = oauth2->config;
+
+    // A query-placed token was written into the URL that every transfer copies;
+    // republishing a header would leave the stale one in the query string.
+    if (field (config, "tokenPlacement") == "query") {
+        return std::nullopt;
+    }
+    if (!flag (config, "autoRefreshToken", true)) {
+        return std::nullopt;
+    }
+
+    auto cached = db->get_oauth_token (oauth::cache_key (config));
+    if (!cached || cached->expires_in <= 0) {
+        return std::nullopt;
+    }
+    // A refresh token is the only non-interactive way back for this grant; the
+    // others can simply re-run their grant.
+    if (field (config, "grantType") == "authorization_code" &&
+        cached->refresh_token.empty ()) {
+        return std::nullopt;
+    }
+
+    AuthRefreshPlan plan;
+    plan.config        = config;
+    plan.header_name   = "Authorization";
+    plan.header_value  = oauth2_header_value (config, cached->access_token);
+    plan.expires_at_ms = cached->created_at + cached->expires_in * 1000;
+
+    // A user-supplied Authorization header wins over the token (see
+    // resolve_oauth2), and this run is sending that one - swapping the token
+    // under it would change nothing on the wire.
+    const auto it = request.headers.find (plan.header_name);
+    if (it == request.headers.end () || it->second != plan.header_value) {
+        return std::nullopt;
+    }
+    return plan;
+}
 
 Auth parse_auth (const nlohmann::json& auth) {
     if (!auth.is_object ()) {

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -142,6 +142,15 @@ struct ReportExtras {
     // Per-budget rows verbatim from the summary, already in the report's
     // camelCase shape - the evaluator writes the wire keys.
     nlohmann::json threshold_checks = nlohmann::json::array ();
+    // Whether the run's OAuth 2.0 credential was refreshed while it ran.
+    // `has_auth` false is a run that could not refresh at all (no oauth2 auth,
+    // a non-expiring or query-placed token, or an engine older than mid-run
+    // refresh), which is not the same as a run that watched and never needed to
+    // - so the section is left out rather than reported as zero refreshes.
+    bool has_auth = false;
+    nlohmann::json auth_refreshes = nlohmann::json::array ();
+    size_t auth_refresh_failures  = 0;
+    std::string auth_last_error;
     // What the run's bounded stores thinned away. `has_sampling` false is a
     // run recorded before retention was reported, which is not the same as a
     // run that dropped nothing - so the section is left out rather than shown
@@ -312,6 +321,18 @@ ReportExtras& extras) {
         read_number (summary["tests"], "sampled", extras.tests_sampled);
         read_number (summary["tests"], "passed", extras.tests_passed);
         read_number (summary["tests"], "failed", extras.tests_failed);
+    }
+
+    if (summary.contains ("auth") && summary["auth"].is_object ()) {
+        const auto& auth  = summary["auth"];
+        extras.has_auth   = true;
+        if (auth.contains ("refreshes") && auth["refreshes"].is_array ()) {
+            extras.auth_refreshes = auth["refreshes"];
+        }
+        read_number (auth, "refreshFailures", extras.auth_refresh_failures);
+        if (auth.contains ("lastError") && auth["lastError"].is_string ()) {
+            extras.auth_last_error = auth["lastError"].get<std::string> ();
+        }
     }
 
     if (summary.contains ("thresholds") && summary["thresholds"].is_object ()) {
@@ -814,6 +835,18 @@ const std::string& run_id) {
             { "passed", extras.thresholds_passed },
             { "failed", extras.thresholds_failed },
             { "verdict", extras.thresholds_failed == 0 ? "passed" : "failed" } };
+    }
+
+    // When the run's credential was renewed under it, and what stopped a
+    // renewal that did not happen. A run whose token expired mid-flight shows
+    // up as 401s in the status distribution; this is the section that says why.
+    if (extras.has_auth) {
+        nlohmann::json auth = { { "refreshes", extras.auth_refreshes },
+            { "refreshFailures", extras.auth_refresh_failures } };
+        if (!extras.auth_last_error.empty ()) {
+            auth["lastError"] = extras.auth_last_error;
+        }
+        json_report["auth"] = auth;
     }
 
     // Include sample of request/response results

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -1,0 +1,537 @@
+/**
+ * @file auth_refresh_test.cpp
+ * @brief Mid-run OAuth 2.0 refresh (#478): a load run that outlives its token
+ *        keeps sending a valid one, and says so in its summary.
+ *
+ * The engine used to resolve auth exactly once per run, so a run longer than
+ * its token turned into a 401 storm nothing explained. Three layers are covered
+ * here: which runs are eligible at all (plan_auth_refresh), the swap the
+ * submitting thread performs (sync_auth_header), and a whole run against a mock
+ * IdP that expires tokens in seconds.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "temp_database.hpp"
+#include "vayu/core/auth_refresh.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/auth_resolver.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/http/oauth_client.hpp"
+
+using nlohmann::json;
+using vayu::core::auth_refresh_delay_ms;
+using vayu::core::AuthRefreshState;
+using vayu::core::sync_auth_header;
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+int64_t now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+    .count ();
+}
+
+/**
+ * A mock identity provider and target in one process.
+ *
+ * `/token` mints a new access token per call with a short, configurable
+ * lifetime; `/api` records every distinct `Authorization` value it is sent, in
+ * the order they first appeared. That ordering is the assertion: the run must
+ * move from AT1 to AT2 while it is still going, not merely end up on AT2.
+ */
+class MockIdpAndTarget {
+    public:
+    explicit MockIdpAndTarget (int64_t expires_in_s)
+    : expires_in_s_ (expires_in_s) {
+        svr_.new_task_queue = [] { return new httplib::ThreadPool (16); };
+
+        svr_.Post ("/token", [this] (const httplib::Request&, httplib::Response& res) {
+            if (token_endpoint_fails_.load ()) {
+                res.status = 400;
+                res.set_content (R"({"error":"invalid_grant"})", "application/json");
+                return;
+            }
+            const int minted = ++minted_;
+            res.set_content ("{\"access_token\":\"AT" + std::to_string (minted) +
+            "\",\"token_type\":\"Bearer\",\"expires_in\":" + std::to_string (expires_in_s_) + "}",
+            "application/json");
+        });
+
+        svr_.Get ("/api", [this] (const httplib::Request& req, httplib::Response& res) {
+            const std::string auth = req.get_header_value ("Authorization");
+            {
+                const std::lock_guard<std::mutex> lock (mutex_);
+                if (seen_.empty () || seen_.back () != auth) {
+                    seen_.push_back (auth);
+                }
+            }
+            res.set_content ("{}", "application/json");
+        });
+
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+        svr_.wait_until_ready ();
+    }
+
+    ~MockIdpAndTarget () {
+        svr_.stop ();
+        if (thread_.joinable ())
+            thread_.join ();
+    }
+
+    MockIdpAndTarget (const MockIdpAndTarget&)            = delete;
+    MockIdpAndTarget& operator= (const MockIdpAndTarget&) = delete;
+
+    std::string token_url () const {
+        return "http://127.0.0.1:" + std::to_string (port_) + "/token";
+    }
+    std::string api_url () const {
+        return "http://127.0.0.1:" + std::to_string (port_) + "/api";
+    }
+
+    /// Every Authorization value the target saw, de-duplicated consecutively.
+    std::vector<std::string> credentials_seen () const {
+        const std::lock_guard<std::mutex> lock (mutex_);
+        return seen_;
+    }
+
+    void fail_token_endpoint (bool fail) {
+        token_endpoint_fails_.store (fail);
+    }
+
+    private:
+    httplib::Server svr_;
+    std::thread thread_;
+    int port_ = 0;
+    int64_t expires_in_s_;
+    std::atomic<int> minted_{ 0 };
+    std::atomic<bool> token_endpoint_fails_{ false };
+    mutable std::mutex mutex_;
+    std::vector<std::string> seen_;
+};
+
+json oauth2_config (const std::string& token_url) {
+    return json{ { "grantType", "client_credentials" }, { "accessTokenUrl", token_url },
+        { "clientId", "cid" }, { "clientSecret", "secret" } };
+}
+
+vayu::http::AuthRefreshPlan plan_for (std::string value, int64_t expires_at_ms) {
+    vayu::http::AuthRefreshPlan plan;
+    plan.config        = json::object ();
+    plan.header_name   = "Authorization";
+    plan.header_value  = std::move (value);
+    plan.expires_at_ms = expires_at_ms;
+    return plan;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The schedule
+// ---------------------------------------------------------------------------
+
+TEST (AuthRefreshDelay, RefreshesTheConfiguredLeadBeforeExpiry) {
+    // 1000s of life left, refreshing 60s early -> sleep 940s.
+    EXPECT_EQ (auth_refresh_delay_ms (1'000'000, 0, 60'000), 940'000);
+}
+
+// A token whose whole lifetime is shorter than the lead is *always* inside its
+// refresh window. Without the floor the watchdog would re-acquire in a tight
+// loop and hammer the token endpoint on the run's behalf.
+TEST (AuthRefreshDelay, FloorsTheWaitForATokenShorterThanTheLead) {
+    EXPECT_EQ (auth_refresh_delay_ms (2'000, 0, 60'000),
+    vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
+    // Already expired: same floor, not a negative sleep.
+    EXPECT_EQ (auth_refresh_delay_ms (1'000, 5'000, 60'000),
+    vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
+}
+
+// ---------------------------------------------------------------------------
+// The swap the submitting thread performs
+// ---------------------------------------------------------------------------
+
+TEST (SyncAuthHeader, LeavesARunWithoutRefreshUntouched) {
+    vayu::Request request;
+    request.headers["Authorization"] = "Bearer ORIGINAL";
+    uint64_t seen                    = 0;
+
+    sync_auth_header (nullptr, request, seen);
+
+    EXPECT_EQ (request.headers["Authorization"], "Bearer ORIGINAL");
+    EXPECT_EQ (seen, 0u);
+}
+
+TEST (SyncAuthHeader, CopiesAPublishedCredentialOnceAndThenStopsWorking) {
+    auto state = std::make_shared<AuthRefreshState> (plan_for ("Bearer AT1", 1000));
+    vayu::Request request;
+    request.headers["Authorization"] = "Bearer AT1";
+    uint64_t seen                    = 0;
+
+    // Nothing published yet: the request already carries the first credential.
+    sync_auth_header (state, request, seen);
+    EXPECT_EQ (request.headers["Authorization"], "Bearer AT1");
+
+    state->publish ("Bearer AT2", 12.5, 2000);
+    sync_auth_header (state, request, seen);
+    EXPECT_EQ (request.headers["Authorization"], "Bearer AT2");
+    EXPECT_EQ (seen, state->generation ());
+
+    // A second call with no new publish must not re-read the cell - the header
+    // is already current, and this is the per-request hot path.
+    request.headers["Authorization"] = "Bearer SENTINEL";
+    sync_auth_header (state, request, seen);
+    EXPECT_EQ (request.headers["Authorization"], "Bearer SENTINEL");
+}
+
+TEST (AuthRefreshState, SummaryCarriesEveryRefreshAndTheLastFailure) {
+    auto state = std::make_shared<AuthRefreshState> (plan_for ("Bearer AT1", 1000));
+
+    EXPECT_EQ (state->summary ()["refreshes"].size (), 0u);
+    EXPECT_EQ (state->summary ()["refreshFailures"], 0u);
+    EXPECT_FALSE (state->summary ().contains ("lastError"));
+
+    state->publish ("Bearer AT2", 60.5, 2000);
+    state->record_failure ("oauth2_provider_error: nope");
+
+    const auto summary = state->summary ();
+    ASSERT_EQ (summary["refreshes"].size (), 1u);
+    EXPECT_DOUBLE_EQ (summary["refreshes"][0]["atSeconds"].get<double> (), 60.5);
+    EXPECT_EQ (summary["refreshFailures"], 1u);
+    EXPECT_EQ (summary["lastError"], "oauth2_provider_error: nope");
+    EXPECT_EQ (state->expires_at_ms (), 2000);
+}
+
+// ---------------------------------------------------------------------------
+// Which runs are eligible at all
+// ---------------------------------------------------------------------------
+
+class PlanAuthRefreshTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_auth_refresh_plan.db";
+
+    void SetUp () override {
+        vayu::tests::remove_database_files (DB_PATH);
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+    void TearDown () override {
+        db.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    /// Seed the token cache exactly as a resolved run would have left it.
+    void cache_token (const json& config,
+    const std::string& access_token,
+    int64_t expires_in,
+    const std::string& refresh_token = "RT1") {
+        vayu::db::OAuthToken token;
+        token.cache_key     = vayu::http::oauth::cache_key (config);
+        token.access_token  = access_token;
+        token.token_type    = "Bearer";
+        token.refresh_token = refresh_token;
+        token.expires_in    = expires_in;
+        token.created_at    = now_ms ();
+        db->save_oauth_token (token);
+    }
+
+    static vayu::Request request_with (const std::string& authorization) {
+        vayu::Request request;
+        request.url = "https://example.test/api";
+        if (!authorization.empty ()) {
+            request.headers["Authorization"] = authorization;
+        }
+        return request;
+    }
+
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+TEST_F (PlanAuthRefreshTest, PlansForAHeaderPlacedExpiringToken) {
+    const json config = oauth2_config ("https://idp.test/token");
+    cache_token (config, "AT1", 3600);
+    const json auth = { { "mode", "oauth2" }, { "config", config } };
+
+    const auto plan =
+    vayu::http::plan_auth_refresh (request_with ("Bearer AT1"), auth, db.get ());
+
+    ASSERT_TRUE (plan.has_value ());
+    EXPECT_EQ (plan->header_name, "Authorization");
+    EXPECT_EQ (plan->header_value, "Bearer AT1");
+    EXPECT_GT (plan->expires_at_ms, now_ms ());
+    EXPECT_EQ (plan->config["clientId"], "cid");
+}
+
+TEST_F (PlanAuthRefreshTest, HonoursACustomHeaderPrefix) {
+    json config            = oauth2_config ("https://idp.test/token");
+    config["headerPrefix"] = "Token";
+    cache_token (config, "AT1", 3600);
+    const json auth = { { "mode", "oauth2" }, { "config", config } };
+
+    const auto plan =
+    vayu::http::plan_auth_refresh (request_with ("Token AT1"), auth, db.get ());
+
+    ASSERT_TRUE (plan.has_value ());
+    EXPECT_EQ (plan->header_value, "Token AT1");
+}
+
+// Everything below is a run that keeps exactly the behaviour it had before
+// mid-run refresh existed: no plan, so no thread, no swap, no report section.
+TEST_F (PlanAuthRefreshTest, InertForEveryUnrefreshableShape) {
+    const json base = oauth2_config ("https://idp.test/token");
+
+    {
+        // Not oauth2 at all.
+        const json auth = { { "mode", "bearer" }, { "token", "static" } };
+        EXPECT_FALSE (vayu::http::plan_auth_refresh (
+        request_with ("Bearer static"), auth, db.get ())
+                      .has_value ());
+    }
+    {
+        // A token with no expiry cannot outlive anything.
+        json config        = base;
+        config["clientId"] = "no-expiry";
+        cache_token (config, "AT1", 0);
+        const json auth = { { "mode", "oauth2" }, { "config", config } };
+        EXPECT_FALSE (
+        vayu::http::plan_auth_refresh (request_with ("Bearer AT1"), auth, db.get ())
+        .has_value ());
+    }
+    {
+        // Nothing cached: this run never resolved a token to keep current.
+        json config        = base;
+        config["clientId"] = "uncached";
+        const json auth    = { { "mode", "oauth2" }, { "config", config } };
+        EXPECT_FALSE (
+        vayu::http::plan_auth_refresh (request_with ("Bearer AT1"), auth, db.get ())
+        .has_value ());
+    }
+    {
+        // The user's explicit opt-out.
+        json config                = base;
+        config["clientId"]         = "no-auto-refresh";
+        config["autoRefreshToken"] = false;
+        cache_token (config, "AT1", 3600);
+        const json auth = { { "mode", "oauth2" }, { "config", config } };
+        EXPECT_FALSE (
+        vayu::http::plan_auth_refresh (request_with ("Bearer AT1"), auth, db.get ())
+        .has_value ());
+    }
+    {
+        // Query placement: the credential is in the URL every transfer copies,
+        // which no header swap can reach.
+        json config              = base;
+        config["clientId"]       = "query-placed";
+        config["tokenPlacement"] = "query";
+        cache_token (config, "AT1", 3600);
+        const json auth = { { "mode", "oauth2" }, { "config", config } };
+        EXPECT_FALSE (
+        vayu::http::plan_auth_refresh (request_with (""), auth, db.get ()).has_value ());
+    }
+    {
+        // authorization_code with no refresh token needs a browser, and a run
+        // must never pop interactive auth mid-flight.
+        json config         = base;
+        config["clientId"]  = "interactive";
+        config["grantType"] = "authorization_code";
+        cache_token (config, "AT1", 3600, /*refresh_token=*/"");
+        const json auth = { { "mode", "oauth2" }, { "config", config } };
+        EXPECT_FALSE (
+        vayu::http::plan_auth_refresh (request_with ("Bearer AT1"), auth, db.get ())
+        .has_value ());
+    }
+    {
+        // A user-supplied Authorization header won over the token, so the run
+        // is not sending the token at all.
+        json config        = base;
+        config["clientId"] = "user-header";
+        cache_token (config, "AT1", 3600);
+        const json auth = { { "mode", "oauth2" }, { "config", config } };
+        EXPECT_FALSE (
+        vayu::http::plan_auth_refresh (request_with ("Bearer MINE"), auth, db.get ())
+        .has_value ());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A whole run against a mock IdP
+// ---------------------------------------------------------------------------
+
+class MidRunRefreshTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_auth_refresh_run.db";
+    /// Refresh 1s before expiry, against 3s tokens: the first refresh lands
+    /// ~2s in, well inside a run this test can afford to wait out.
+    static constexpr int LEAD_MS = 1000;
+
+    void SetUp () override {
+        vayu::http::global_init ();
+        vayu::tests::remove_database_files (DB_PATH);
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+        set_config ("oauth2RefreshLeadMs", std::to_string (LEAD_MS));
+    }
+    void TearDown () override {
+        db.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+        vayu::http::global_cleanup ();
+    }
+
+    void set_config (const std::string& key, const std::string& value) {
+        vayu::db::ConfigEntry entry;
+        entry.key           = key;
+        entry.value         = value;
+        entry.type          = "integer";
+        entry.label         = key;
+        entry.category      = "server";
+        entry.default_value = value;
+        entry.updated_at    = now_ms ();
+        db->save_config_entry (entry);
+    }
+
+    void create_run_row (const std::string& run_id) {
+        vayu::db::Run row;
+        row.id              = run_id;
+        row.type            = vayu::RunType::Load;
+        row.status          = vayu::RunStatus::Pending;
+        row.config_snapshot = "{}";
+        row.start_time      = now_ms ();
+        row.end_time        = 0;
+        db->create_run (row);
+    }
+
+    /// A 5s run at a gentle rate - long enough to outlive a 3s token, short
+    /// enough to stay well inside the suite's per-test budget.
+    json run_config (const std::string& url, const json& oauth2) const {
+        return json{ { "mode", "constant_rps" }, { "duration", "5s" },
+            { "targetRps", 10.0 }, { "url", url }, { "method", "GET" },
+            { "timeout", 5000 }, { "workers", 1 },
+            { "auth", { { "mode", "oauth2" }, { "config", oauth2 } } } };
+    }
+
+    /// Let a run finish on its own. `shutdown` would *stop* it, which is a
+    /// different behaviour: the point here is a run that reaches its natural
+    /// end having outlived its token.
+    void await_completion (const std::string& run_id) {
+        const auto deadline = Clock::now () + std::chrono::seconds (30);
+        while (Clock::now () < deadline) {
+            const auto stored = db->get_run (run_id);
+            if (stored && stored->status != vayu::RunStatus::Running &&
+            stored->status != vayu::RunStatus::Pending) {
+                return;
+            }
+            std::this_thread::sleep_for (std::chrono::milliseconds (50));
+        }
+        ADD_FAILURE () << "run " << run_id << " never reached a terminal status";
+    }
+
+    /// Run to completion and return the stored summary.
+    json execute (const std::string& run_id, const json& config) {
+        create_run_row (run_id);
+        vayu::core::RunManager manager;
+        EXPECT_TRUE (manager.start_run (run_id, config, *db, false));
+        await_completion (run_id);
+        manager.shutdown (std::chrono::milliseconds (15000));
+
+        const auto stored = db->get_run (run_id);
+        EXPECT_TRUE (stored.has_value ());
+        if (!stored || stored->summary.empty ()) {
+            return json::object ();
+        }
+        return json::parse (stored->summary, nullptr, false);
+    }
+
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+// The acceptance criterion: the run keeps sending a valid credential, and the
+// report says when it changed. Mutation check - drop the sync_auth_header call
+// from the submission path and `credentials_seen` stays at one entry.
+TEST_F (MidRunRefreshTest, ARunOutlivingItsTokenSendsARefreshedOne) {
+    MockIdpAndTarget idp (/*expires_in_s=*/3);
+    const json oauth2 = oauth2_config (idp.token_url ());
+
+    const json summary =
+    execute ("run-auth-refresh", run_config (idp.api_url (), oauth2));
+
+    const auto seen = idp.credentials_seen ();
+    ASSERT_GE (seen.size (), 2u)
+    << "the run sent one credential for its whole life: " << seen.size ();
+    EXPECT_EQ (seen[0], "Bearer AT1");
+    EXPECT_EQ (seen[1], "Bearer AT2");
+
+    ASSERT_TRUE (summary.contains ("auth")) << summary.dump ();
+    const auto& auth = summary["auth"];
+    ASSERT_TRUE (auth["refreshes"].is_array ());
+    EXPECT_GE (auth["refreshes"].size (), 1u);
+    EXPECT_GT (auth["refreshes"][0]["atSeconds"].get<double> (), 0.0);
+    EXPECT_EQ (auth["refreshFailures"], 0u);
+    EXPECT_FALSE (auth.contains ("lastError"));
+}
+
+// A token endpoint that stops answering must not fail the run: the target's own
+// status codes plus this section are the honest report.
+TEST_F (MidRunRefreshTest, AFailedRefreshIsRecordedAndTheRunStillCompletes) {
+    MockIdpAndTarget idp (/*expires_in_s=*/3);
+    const json oauth2 = oauth2_config (idp.token_url ());
+
+    create_run_row ("run-auth-refresh-fails");
+    vayu::core::RunManager manager;
+    ASSERT_TRUE (manager.start_run (
+    "run-auth-refresh-fails", run_config (idp.api_url (), oauth2), *db, false));
+
+    // Only once the run is on the wire has it resolved its first token - auth
+    // is resolved on the worker, after start_run has returned. Breaking the
+    // endpoint before that would fail the run's *initial* resolution, which is
+    // a different behaviour from the one under test.
+    const auto context = manager.get_run ("run-auth-refresh-fails");
+    ASSERT_NE (context, nullptr);
+    const auto deadline = Clock::now () + std::chrono::seconds (10);
+    while (context->requests_sent.load () == 0 && Clock::now () < deadline) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (10));
+    }
+    ASSERT_GT (context->requests_sent.load (), 0u)
+    << "the run never started sending";
+    idp.fail_token_endpoint (true);
+    await_completion ("run-auth-refresh-fails");
+    manager.shutdown (std::chrono::milliseconds (15000));
+
+    const auto stored = db->get_run ("run-auth-refresh-fails");
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_EQ (stored->status, vayu::RunStatus::Completed)
+    << "a refusal to refresh must not fail the run";
+
+    const auto summary = json::parse (stored->summary, nullptr, false);
+    ASSERT_TRUE (summary.is_object () && summary.contains ("auth")) << stored->summary;
+    EXPECT_EQ (summary["auth"]["refreshes"].size (), 0u);
+    EXPECT_GE (summary["auth"]["refreshFailures"].get<size_t> (), 1u);
+    EXPECT_NE (summary["auth"]["lastError"].get<std::string> (), "");
+}
+
+// A run that cannot refresh spawns no watchdog and reports no section - the
+// absent section is what says "this run was never watching".
+TEST_F (MidRunRefreshTest, ANonRefreshableRunReportsNoAuthSection) {
+    MockIdpAndTarget idp (/*expires_in_s=*/0); // no expiry information
+    const json oauth2 = oauth2_config (idp.token_url ());
+
+    const json summary = execute ("run-auth-inert", run_config (idp.api_url (), oauth2));
+
+    EXPECT_FALSE (summary.contains ("auth")) << summary.dump ();
+    const auto seen = idp.credentials_seen ();
+    ASSERT_EQ (seen.size (), 1u);
+    EXPECT_EQ (seen[0], "Bearer AT1");
+}

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -146,19 +146,33 @@ vayu::http::AuthRefreshPlan plan_for (std::string value, int64_t expires_at_ms) 
 // ---------------------------------------------------------------------------
 
 TEST (AuthRefreshDelay, RefreshesTheConfiguredLeadBeforeExpiry) {
+    vayu::core::AuthRefreshTuning tuning;
+    tuning.lead_ms = 60'000;
     // 1000s of life left, refreshing 60s early -> sleep 940s.
-    EXPECT_EQ (auth_refresh_delay_ms (1'000'000, 0, 60'000), 940'000);
+    EXPECT_EQ (auth_refresh_delay_ms (1'000'000, 0, tuning), 940'000);
 }
 
 // A token whose whole lifetime is shorter than the lead is *always* inside its
 // refresh window. Without the floor the watchdog would re-acquire in a tight
 // loop and hammer the token endpoint on the run's behalf.
 TEST (AuthRefreshDelay, FloorsTheWaitForATokenShorterThanTheLead) {
-    EXPECT_EQ (auth_refresh_delay_ms (2'000, 0, 60'000),
-    vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
+    vayu::core::AuthRefreshTuning tuning;
+    tuning.lead_ms         = 60'000;
+    tuning.min_interval_ms = 1'500;
+
+    EXPECT_EQ (auth_refresh_delay_ms (2'000, 0, tuning), 1'500);
     // Already expired: same floor, not a negative sleep.
-    EXPECT_EQ (auth_refresh_delay_ms (1'000, 5'000, 60'000),
-    vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
+    EXPECT_EQ (auth_refresh_delay_ms (1'000, 5'000, tuning), 1'500);
+}
+
+// The floor is the user's setting, not a constant baked into the schedule -
+// mutation check for reading `min_interval_ms` rather than the default.
+TEST (AuthRefreshDelay, TheFloorFollowsTheConfiguredMinimumInterval) {
+    vayu::core::AuthRefreshTuning tuning;
+    tuning.lead_ms         = 60'000;
+    tuning.min_interval_ms = 250;
+
+    EXPECT_EQ (auth_refresh_delay_ms (2'000, 0, tuning), 250);
 }
 
 // ---------------------------------------------------------------------------
@@ -214,6 +228,93 @@ TEST (AuthRefreshState, SummaryCarriesEveryRefreshAndTheLastFailure) {
     EXPECT_EQ (summary["refreshFailures"], 1u);
     EXPECT_EQ (summary["lastError"], "oauth2_provider_error: nope");
     EXPECT_EQ (state->expires_at_ms (), 2000);
+}
+
+// ---------------------------------------------------------------------------
+// The settings behind the schedule
+// ---------------------------------------------------------------------------
+
+class AuthRefreshTuningTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_auth_refresh_tuning.db";
+
+    void SetUp () override {
+        vayu::tests::remove_database_files (DB_PATH);
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+    void TearDown () override {
+        db.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+// Every knob the watchdog reads is a seeded setting, so the Settings UI - which
+// renders engine entries dynamically from GET /config - offers all four rather
+// than leaving them hardcoded.
+TEST_F (AuthRefreshTuningTest, EveryKnobIsSeededAsAUserSetting) {
+    for (const char* key : { "oauth2RefreshLeadMs", "oauth2RefreshMinIntervalMs",
+         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs" }) {
+        const auto entry = db->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key << " is not offered in Settings";
+        EXPECT_EQ (entry->type, "integer") << key;
+        EXPECT_FALSE (entry->label.empty ()) << key;
+        EXPECT_FALSE (entry->description.empty ()) << key;
+        // A range is what stops a hand-typed 0 from turning the retry loop into
+        // a hot loop against the token endpoint.
+        EXPECT_TRUE (entry->min_value.has_value ()) << key;
+        EXPECT_TRUE (entry->max_value.has_value ()) << key;
+    }
+
+    // Seeded defaults are the constants, not a second set of numbers.
+    const auto tuning = vayu::core::read_auth_refresh_tuning (*db);
+    EXPECT_EQ (tuning.lead_ms, vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS);
+    EXPECT_EQ (tuning.min_interval_ms,
+    vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
+    EXPECT_EQ (tuning.retry_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS);
+    EXPECT_EQ (tuning.retry_max_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS);
+}
+
+// Mutation check for the reader: revert any one key to its constant and the
+// value the user stored stops reaching the run.
+TEST_F (AuthRefreshTuningTest, TheStoredValuesAreWhatARunReads) {
+    const std::pair<const char*, int> edits[] = { { "oauth2RefreshLeadMs", 12'345 },
+        { "oauth2RefreshMinIntervalMs", 321 }, { "oauth2RefreshRetryMs", 777 },
+        { "oauth2RefreshRetryMaxMs", 99'000 } };
+    for (const auto& [key, value] : edits) {
+        auto entry = db->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key;
+        entry->value = std::to_string (value);
+        db->save_config_entry (*entry);
+    }
+
+    const auto tuning = vayu::core::read_auth_refresh_tuning (*db);
+    EXPECT_EQ (tuning.lead_ms, 12'345);
+    EXPECT_EQ (tuning.min_interval_ms, 321);
+    EXPECT_EQ (tuning.retry_ms, 777);
+    EXPECT_EQ (tuning.retry_max_ms, 99'000);
+}
+
+// A hand-edited row is the only way a non-positive value reaches the reader
+// (POST /config rejects one against the seeded minimum), and a zero floor would
+// make the schedule a tight loop against the token endpoint.
+TEST_F (AuthRefreshTuningTest, ANonPositiveStoredValueFallsBackToTheDefault) {
+    for (const char* key : { "oauth2RefreshLeadMs", "oauth2RefreshMinIntervalMs",
+         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs" }) {
+        auto entry = db->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key;
+        entry->value = "0";
+        db->save_config_entry (*entry);
+    }
+
+    const auto tuning = vayu::core::read_auth_refresh_tuning (*db);
+    EXPECT_EQ (tuning.lead_ms, vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS);
+    EXPECT_EQ (tuning.min_interval_ms,
+    vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
+    EXPECT_EQ (tuning.retry_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS);
+    EXPECT_EQ (tuning.retry_max_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS);
 }
 
 // ---------------------------------------------------------------------------
@@ -391,16 +492,14 @@ class MidRunRefreshTest : public ::testing::Test {
         vayu::http::global_cleanup ();
     }
 
+    /// Change a *seeded* setting the way POST /config does: read the row, edit
+    /// the value, write it back - so the test drives the same key the Settings
+    /// UI offers rather than inventing a row beside it.
     void set_config (const std::string& key, const std::string& value) {
-        vayu::db::ConfigEntry entry;
-        entry.key           = key;
-        entry.value         = value;
-        entry.type          = "integer";
-        entry.label         = key;
-        entry.category      = "server";
-        entry.default_value = value;
-        entry.updated_at    = now_ms ();
-        db->save_config_entry (entry);
+        auto entry = db->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        entry->value = value;
+        db->save_config_entry (*entry);
     }
 
     void create_run_row (const std::string& run_id) {

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -252,11 +252,11 @@ class AuthRefreshTuningTest : public ::testing::Test {
 };
 
 // Every knob the watchdog reads is a seeded setting, so the Settings UI - which
-// renders engine entries dynamically from GET /config - offers all four rather
+// renders engine entries dynamically from GET /config - offers all five rather
 // than leaving them hardcoded.
 TEST_F (AuthRefreshTuningTest, EveryKnobIsSeededAsAUserSetting) {
     for (const char* key : { "oauth2RefreshLeadMs", "oauth2RefreshMinIntervalMs",
-         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs" }) {
+         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs", "oauth2RefreshPollIntervalMs" }) {
         const auto entry = db->get_config_entry (key);
         ASSERT_TRUE (entry.has_value ()) << key << " is not offered in Settings";
         EXPECT_EQ (entry->type, "integer") << key;
@@ -275,6 +275,8 @@ TEST_F (AuthRefreshTuningTest, EveryKnobIsSeededAsAUserSetting) {
     vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
     EXPECT_EQ (tuning.retry_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS);
     EXPECT_EQ (tuning.retry_max_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS);
+    EXPECT_EQ (tuning.poll_interval_ms,
+    vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS);
 }
 
 // Mutation check for the reader: revert any one key to its constant and the
@@ -282,7 +284,7 @@ TEST_F (AuthRefreshTuningTest, EveryKnobIsSeededAsAUserSetting) {
 TEST_F (AuthRefreshTuningTest, TheStoredValuesAreWhatARunReads) {
     const std::pair<const char*, int> edits[] = { { "oauth2RefreshLeadMs", 12'345 },
         { "oauth2RefreshMinIntervalMs", 321 }, { "oauth2RefreshRetryMs", 777 },
-        { "oauth2RefreshRetryMaxMs", 99'000 } };
+        { "oauth2RefreshRetryMaxMs", 99'000 }, { "oauth2RefreshPollIntervalMs", 42 } };
     for (const auto& [key, value] : edits) {
         auto entry = db->get_config_entry (key);
         ASSERT_TRUE (entry.has_value ()) << key;
@@ -295,6 +297,7 @@ TEST_F (AuthRefreshTuningTest, TheStoredValuesAreWhatARunReads) {
     EXPECT_EQ (tuning.min_interval_ms, 321);
     EXPECT_EQ (tuning.retry_ms, 777);
     EXPECT_EQ (tuning.retry_max_ms, 99'000);
+    EXPECT_EQ (tuning.poll_interval_ms, 42);
 }
 
 // A hand-edited row is the only way a non-positive value reaches the reader
@@ -302,7 +305,7 @@ TEST_F (AuthRefreshTuningTest, TheStoredValuesAreWhatARunReads) {
 // make the schedule a tight loop against the token endpoint.
 TEST_F (AuthRefreshTuningTest, ANonPositiveStoredValueFallsBackToTheDefault) {
     for (const char* key : { "oauth2RefreshLeadMs", "oauth2RefreshMinIntervalMs",
-         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs" }) {
+         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs", "oauth2RefreshPollIntervalMs" }) {
         auto entry = db->get_config_entry (key);
         ASSERT_TRUE (entry.has_value ()) << key;
         entry->value = "0";
@@ -315,6 +318,8 @@ TEST_F (AuthRefreshTuningTest, ANonPositiveStoredValueFallsBackToTheDefault) {
     vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS);
     EXPECT_EQ (tuning.retry_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS);
     EXPECT_EQ (tuning.retry_max_ms, vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS);
+    EXPECT_EQ (tuning.poll_interval_ms,
+    vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS);
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -812,6 +812,47 @@ TEST_F (RunsRouteTest, ReportOmitsThresholdValidationWhenNoBudgetWasDeclared) {
     EXPECT_FALSE (body.contains ("thresholdValidation"));
 }
 
+// Mid-run OAuth 2.0 refresh (#478), round-tripped through the stored summary:
+// the section is what explains 401s that appear partway through a run, so it
+// has to survive the write/read pair, not merely be produced.
+TEST_F (RunsRouteTest, ReportCarriesTheAuthRefreshSection) {
+    seed ({ .id = "run_auth", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+    inputs.auth = nlohmann::json{ { "refreshes", { { { "atSeconds", 3620.4 } } } },
+        { "refreshFailures", 1 }, { "lastError", "oauth2_provider_error: invalid_grant" } };
+    db_->update_run_summary (
+    "run_auth", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_auth");
+    ASSERT_EQ (status, 200);
+
+    ASSERT_TRUE (body.contains ("auth"));
+    const auto& auth = body["auth"];
+    ASSERT_TRUE (auth["refreshes"].is_array ());
+    ASSERT_EQ (auth["refreshes"].size (), 1u);
+    EXPECT_DOUBLE_EQ (auth["refreshes"][0]["atSeconds"].get<double> (), 3620.4);
+    EXPECT_EQ (auth["refreshFailures"].get<size_t> (), 1u);
+    EXPECT_EQ (auth["lastError"].get<std::string> (),
+    "oauth2_provider_error: invalid_grant");
+}
+
+// A run that could not refresh at all keeps the section out entirely - and so
+// does every run recorded before mid-run refresh existed. "Never watching" and
+// "watched and never needed to" are different answers; only the absent section
+// can say the first.
+TEST_F (RunsRouteTest, ReportOmitsAuthWhenTheRunCouldNotRefresh) {
+    seed ({ .id = "run_no_auth_section", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+    inputs.auth = std::nullopt;
+    db_->update_run_summary (
+    "run_no_auth_section", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] =
+    vayu::http::routes::run_report_response (*db_, "run_no_auth_section");
+    ASSERT_EQ (status, 200);
+    EXPECT_FALSE (body.contains ("auth"));
+}
+
 // A summary that is not a JSON object is treated as absent. There is no second
 // aggregate source any more, so the report stands on the run's sampled results
 // - which is a report, not a 500 and not an empty run.


### PR DESCRIPTION
## Description

A load run resolved auth exactly once, before the strategy started (`execute_load_test` → `build_request`), so a run outliving its OAuth 2.0 access token turned into a 401 storm the report never explained. The app could only warn up front and gate the Start button; the engine did nothing.

**Plan.** Root cause: the credential is resolved into a single `vayu::Request` that every transfer copies, and nothing re-checks its expiry. The fix arms a per-run refresh watchdog (beside the existing `metrics_thread`) that re-acquires the token `oauth2RefreshLeadMs` (default 60s) before expiry and publishes the new `Authorization` value on `RunContext::auth_refresh`; the **strategy thread** - the event loop's sole producer - copies it onto its own `Request` when the cell's generation moves, immediately before `EventLoop::submit`, which copies the request wholesale into the transfer. So a swap reaches every later transfer, none already queued, and costs one relaxed atomic load per submission with no lock on the hot path.

The alternative I rejected is the one the issue sketched: reading a `shared_ptr<const std::string>` through the event loop's own header-attach site (`curl_utils.cpp:418`). That site works on the transfer's *copy* of the request, and `EventLoop` is deliberately run-agnostic - wiring a `RunContext` (or a run-specific field on `vayu::Request`, which every non-load caller would then carry) into it puts run policy inside the generic transport for no gain. `SubmissionRequest` in `load_strategy.cpp` keeps the swap where the copy is made. The exact copy site is `EventLoopImpl::submit` (`event_loop_impl.cpp:106`, `data->request = request`), on the calling thread.

Deliberate scope notes, all documented:
- Only header-placed credentials are renewed. `plan_auth_refresh` returns nothing - and the run behaves exactly as before - for `tokenPlacement: "query"`, `autoRefreshToken: false`, an `authorization_code` grant with no refresh token, a non-expiring token, a request whose `Authorization` header the user supplied, and scenario load runs (each step resolved its own auth at plan time, so there is no single credential).
- `auth_refresh_delay_ms` is floored at 1s: a token whose whole lifetime is shorter than the lead is always inside its refresh window, and an unfloored schedule would hammer the token endpoint.
- A failed refresh is recorded, retried with a 5s→60s backoff, and **never** fails the run; an `authorization_code` refusal never pops interactive auth.
- The four worker exit paths now join through `RunContext::join_aux_threads` rather than four copies of a per-thread join.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally on this branch (base `ec194d1`).

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1262/1262 passed**. New `auth_refresh_test.cpp` (12 tests) covers the schedule, the swap, the eligibility matrix, and three whole runs against an in-process mock IdP minting 3s tokens: a run that outlives its token sends `Bearer AT1` then `Bearer AT2` (mutation check: drop the `sync_auth_header` call and the target only ever sees one credential), a refused refresh is recorded while the run still completes, and a non-expiring token spawns no watchdog and reports no section. `runs_route_test.cpp` gains the `auth` summary round-trip plus its absence twin.
- `cd app && pnpm test` - **382 files / 3822 tests passed**, including the reworked `coverageState` matrix (refreshable long run → covered; query-placed / opted-out / interactive → still gated) and `LoadTestDetail.auth.test.tsx`, which renders the note rather than scanning source for it.
- `pnpm type-check`, `pnpm lint`, `prettier --check` on the touched files - clean. `clang-tidy -p build` on the new/changed engine sources - only the pre-existing `missing-field-initializers` warning at `auth_resolver.cpp:84`, which this change does not touch.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/db-schema.md` (the "There is **no** mid-run refresh" sentence is gone, replaced by the eligibility list), `docs/engine/api-reference.md` (report `auth` section + the conditional-sections line), `docs/engine/architecture.md` (per-run thread inventory, the swap's threading contract, `plan_auth_refresh` in the auth-resolver bullet), `docs/engine/benchmarks.md` (the `oauth2RefreshLeadMs` key), `docs/app/api-integration.md` (`report.auth` and the guard's mirrored rule).

## Related Issues
Closes #478

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrsuygKbeyS7AzFfApz8SF)_