### PR TITLE
feat(engine/app): server-vitals overlay for load runs

### DIFF
--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -108,6 +108,12 @@ export const API_ENDPOINTS = {
 	STATS_TIME_SERIES: (runId: string, limit = STATS_PAGE_LIMIT, offset = 0) =>
 		`/runs/${runId}/metrics?limit=${limit}&offset=${offset}`,
 
+	// Server vitals scraped during the run (JSON, paginated, same envelope).
+	// Its own endpoint rather than extra keys on the tick objects: those keys
+	// are the /metrics contract, and scrapes land on the user's own cadence.
+	RUN_MONITOR: (runId: string, limit = STATS_PAGE_LIMIT, offset = 0) =>
+		`/runs/${runId}/monitor?limit=${limit}&offset=${offset}`,
+
 	// Import. FETCH proxies a remote collection past CORS; APPLY persists the
 	// whole parsed tree in one atomic call and returns the temp-id -> real-id map
 	// (the import path no longer creates items one POST at a time).

--- a/app/src/constants/monitor.ts
+++ b/app/src/constants/monitor.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Server-monitoring bounds, mirroring `constants::monitor` engine-side.
+ *
+ * The interval **bounds** are fixed on both sides - they exist to stop a
+ * cadence that measures the scraper rather than the target. `DEFAULT` and
+ * `MONITOR_MAX_SERIES` are only the pre-config seeds: the live values come from
+ * the `monitorIntervalMs` / `monitorMaxSeries` engine settings via
+ * {@link useMonitorSettings}, and these stand in until that query resolves.
+ */
+export const MONITOR_INTERVAL_MS = { MIN: 250, MAX: 60_000, DEFAULT: 1000 } as const;
+
+/** Seed for `monitorMaxSeries`; the engine rejects a longer list with a 400. */
+export const MONITOR_MAX_SERIES = 8;

--- a/app/src/hooks/useMonitorSettings.ts
+++ b/app/src/hooks/useMonitorSettings.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * useMonitorSettings
+ *
+ * The two server-monitoring limits a user can move: the default scrape cadence
+ * and how many metrics one run may chart.
+ *
+ * They live **engine-side** (`monitorIntervalMs` / `monitorMaxSeries`), like
+ * the live-chart settings beside them, and for the same reason: the engine
+ * applies the cadence to any run that names none and rejects a series list over
+ * the cap with a 400. A renderer-local copy could only drift - and it would
+ * drift in the two directions that hurt most, a dialog that always sends an
+ * explicit interval (so the setting would never apply to a run started here)
+ * and one that refuses a metric list the engine would have accepted.
+ *
+ * Read-only: both are edited from the engine settings list, and this hook is
+ * how the load-test dialog seeds and bounds its own fields from them. Until the
+ * config query resolves, the module defaults stand - the same numbers the
+ * engine seeds, so the gap changes nothing.
+ */
+
+import { useConfigQuery } from "@/queries";
+import { MONITOR_INTERVAL_MS, MONITOR_MAX_SERIES } from "@/constants/monitor";
+
+export interface MonitorSettings {
+	/** Cadence to seed a fresh draft with, in ms. */
+	defaultIntervalMs: number;
+	/** How many metric names the dialog accepts before it blocks Start. */
+	maxSeries: number;
+}
+
+export function useMonitorSettings(): MonitorSettings {
+	const { data: config } = useConfigQuery();
+
+	const entryValue = (key: string): string | undefined =>
+		config?.entries?.find((e) => e.key === key)?.value;
+
+	// Entry values are strings. An absent key - config still loading, or an
+	// engine older than these settings - leaves the default rather than parsing
+	// `undefined` to NaN.
+	const rawInterval = Number(entryValue("monitorIntervalMs"));
+	const defaultIntervalMs =
+		Number.isFinite(rawInterval) &&
+		rawInterval >= MONITOR_INTERVAL_MS.MIN &&
+		rawInterval <= MONITOR_INTERVAL_MS.MAX
+			? rawInterval
+			: MONITOR_INTERVAL_MS.DEFAULT;
+
+	const rawMaxSeries = Number(entryValue("monitorMaxSeries"));
+	const maxSeries =
+		Number.isFinite(rawMaxSeries) && rawMaxSeries > 0 ? rawMaxSeries : MONITOR_MAX_SERIES;
+
+	return { defaultIntervalMs, maxSeries };
+}

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -48,6 +48,7 @@ import {
 	StatusCodesOverTimeChart,
 	ResponseTimeVsConcurrencyChart,
 	HdrPercentileChart,
+	ServerVitalsChart,
 	CHART_SYNC,
 } from "./charts/uplot";
 import { SkeletonHdrPlot } from "./charts/HdrPercentilePlot";
@@ -93,6 +94,9 @@ function MetricsView({
 	// of an O(n) scan over the full historicalMetrics buffer.
 	const peakConcurrency = useDashboardStore((s) => s.peakConcurrency);
 	const breakpoint = useDashboardStore((s) => s.breakpoint);
+	// Empty for a run that configured no monitor - the row below reads that
+	// rather than the config, so it is right for a replayed run too.
+	const monitorSamples = useDashboardStore((s) => s.monitorSamples);
 
 	// Only the latest tick's elapsed_seconds is consumed below - depending on the
 	// whole historicalMetrics array would rebuild `derived` every tick (10 Hz) and
@@ -419,6 +423,28 @@ function MetricsView({
 					</div>
 					<StatusCodesOverTimeChart
 						history={chartWindow}
+						isCompleted={isCompleted}
+						syncKey={CHART_SYNC.live}
+					/>
+				</div>
+			)}
+
+			{/* Server vitals - only for a run that scraped an endpoint, so a run
+			    without a monitor block keeps the dashboard it always had. */}
+			{monitorSamples.length > 0 && chartWindow.length > 1 && (
+				<div className="bg-card border border-border rounded-md p-3.5">
+					<div className="flex items-baseline justify-between mb-3">
+						<h3 className="text-xs font-semibold text-foreground">
+							Server vitals
+							<InfoChip tip={TOOLTIPS.serverVitals} />
+						</h3>
+						<span className="text-[10px] font-mono text-muted-foreground">
+							scraped from the target
+						</span>
+					</div>
+					<ServerVitalsChart
+						history={chartWindow}
+						samples={monitorSamples}
 						isCompleted={isCompleted}
 						syncKey={CHART_SYNC.live}
 					/>

--- a/app/src/modules/dashboard/components/charts/uplot/TimeSeriesCharts.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/TimeSeriesCharts.tsx
@@ -16,13 +16,14 @@
 
 import { useMemo } from "react";
 import type uPlot from "uplot";
-import type { LoadTestMetrics } from "@/types";
+import type { LoadTestMetrics, MonitorSample } from "@/types";
 import {
 	buildLatencyChartData,
 	buildPercentileChartData,
 	type RampOverlay,
 } from "../../../utils/metricsTransforms";
 import type { Breakpoint } from "../../../utils/computeBreakpoint";
+import { joinMonitorToTimeline } from "../../../utils/monitorSeries";
 import { UPlotChart, type UPlotSeriesSpec, type Marker } from "./UPlotChart";
 import {
 	bucketColumns,
@@ -32,7 +33,17 @@ import {
 	pickConcurrency,
 	pickErrorRate,
 } from "./buildData";
-import { axisMs, axisRate, axisPct, fmtMs, fmtRate, fmtCount, fmtPct } from "./formatters";
+import {
+	axisMs,
+	axisRate,
+	axisPct,
+	axisVitals,
+	fmtMs,
+	fmtRate,
+	fmtCount,
+	fmtPct,
+	fmtVitals,
+} from "./formatters";
 import { useClientSettingsStore } from "@/stores";
 
 interface BaseProps {
@@ -268,6 +279,69 @@ export function ErrorRateChart({ history, isCompleted, syncKey, height, breakpoi
 			isLive={!isCompleted}
 			syncKey={syncKey}
 			markers={breakpointMarker(breakpoint)}
+		/>
+	);
+}
+
+/**
+ * The categorical hues legible as a line on both grounds, in the order the
+ * vitals overlay assigns them. A run names its own metrics, so a series gets a
+ * colour by position - there is no semantic mapping to make. A run may name up
+ * to eight metrics, so past four the cycle repeats; the tooltip names every
+ * series, which is what keeps a repeated hue readable.
+ */
+const VITALS_ROLES: UPlotSeriesSpec["role"][] = [
+	"categorical",
+	"categorical-2",
+	"categorical-3",
+	"categorical-4",
+];
+
+/**
+ * Server vitals scraped from the target during the run, on the run's own
+ * timeline.
+ *
+ * Not bucketed like the charts above: those average a metric the engine emits
+ * every tick, while these are point readings on the user's scrape cadence -
+ * averaging two of them into a bucket would report a number the target never
+ * exported. The resampling onto the tick x axis (and the gaps where a scrape
+ * failed) is `joinMonitorToTimeline`'s, so this component only paints.
+ *
+ * Renders nothing when the run scraped nothing, which is what keeps the row out
+ * of a dashboard for a run that configured no monitor.
+ */
+export function ServerVitalsChart({
+	history,
+	samples,
+	isCompleted,
+	syncKey,
+	height,
+}: BaseProps & { samples: MonitorSample[] }) {
+	const { data, series } = useMemo(() => {
+		const joined = joinMonitorToTimeline(history, samples);
+		const aligned: uPlot.AlignedData = [
+			joined.times,
+			...joined.columns.map((col) => col as (number | null)[]),
+		] as uPlot.AlignedData;
+		const spec: UPlotSeriesSpec[] = joined.names.map((name, i) => ({
+			label: name,
+			role: VITALS_ROLES[i % VITALS_ROLES.length],
+			width: 1.8,
+			format: fmtVitals,
+		}));
+		return { data: aligned, series: spec };
+	}, [history, samples]);
+
+	if (series.length === 0 || data[0].length < 2) return null;
+	return (
+		<UPlotChart
+			data={data}
+			series={series}
+			xTime
+			height={height}
+			yFormat={axisVitals}
+			isLive={!isCompleted}
+			syncKey={syncKey}
 		/>
 	);
 }

--- a/app/src/modules/dashboard/components/charts/uplot/charts.smoke.test.tsx
+++ b/app/src/modules/dashboard/components/charts/uplot/charts.smoke.test.tsx
@@ -28,6 +28,7 @@ import {
 	ResponseTimeVsConcurrencyChart,
 	StatusCodesOverTimeChart,
 	HdrPercentileChart,
+	ServerVitalsChart,
 } from "./index";
 
 function series(n: number): LoadTestMetrics[] {
@@ -67,6 +68,14 @@ describe("centralized uPlot charts - smoke", () => {
 			<ResponseTimeVsConcurrencyChart key="f" history={history} />,
 			<StatusCodesOverTimeChart key="g" history={history} />,
 			<HdrPercentileChart key="h" report={report} />,
+			<ServerVitalsChart
+				key="i"
+				history={history}
+				samples={history.map((m) => ({
+					timestamp: m.timestamp,
+					series: { cpu: m.current_concurrency / 10, rss: 1e9 + m.timestamp },
+				}))}
+			/>,
 		];
 		for (const node of cases) {
 			const { unmount } = render(node);
@@ -95,6 +104,13 @@ describe("centralized uPlot charts - smoke", () => {
 		);
 		expect(container.querySelector("div")).not.toBeNull();
 		unmount();
+	});
+
+	// The row must disappear for a run that scraped nothing, rather than render
+	// an empty plot frame on every dashboard.
+	it("renders nothing when the run has no monitor samples", () => {
+		const { container } = render(<ServerVitalsChart history={history} samples={[]} />);
+		expect(container.innerHTML).toBe("");
 	});
 
 	it("returns null below 2 points", () => {

--- a/app/src/modules/dashboard/components/charts/uplot/formatters.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/formatters.ts
@@ -28,3 +28,29 @@ export const fmtPct = (v: number | null | undefined): string =>
 export const axisPct = (v: number): string => `${Math.round(v)}%`;
 
 export const fmtSeconds = (v: number): string => `${v.toFixed(1)}s`;
+
+/**
+ * Server-vitals values, whose unit this app does not know: a run may scrape a
+ * CPU fraction (0.42), a byte count (1.4e9) and a queue depth (7) onto the same
+ * chart, so the formatter has to stay readable across all three rather than
+ * assume one. Large values are abbreviated, small ones keep the precision that
+ * is the whole signal.
+ */
+export const fmtVitals = (v: number | null | undefined): string => {
+	if (v == null) return "-";
+	const abs = Math.abs(v);
+	if (abs >= 1e9) return `${(v / 1e9).toFixed(2)}G`;
+	if (abs >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+	if (abs >= 1e3) return `${(v / 1e3).toFixed(2)}k`;
+	if (abs >= 10) return v.toFixed(1);
+	return v.toFixed(3);
+};
+
+export const axisVitals = (v: number): string => {
+	const abs = Math.abs(v);
+	if (abs >= 1e9) return `${(v / 1e9).toFixed(1)}G`;
+	if (abs >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+	if (abs >= 1e3) return `${(v / 1e3).toFixed(1)}k`;
+	if (abs >= 10) return `${Math.round(v)}`;
+	return `${v.toFixed(2)}`;
+};

--- a/app/src/modules/dashboard/components/charts/uplot/index.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/index.ts
@@ -20,6 +20,7 @@ export {
 	RequestRateChart,
 	ConnectionsChart,
 	ErrorRateChart,
+	ServerVitalsChart,
 } from "./TimeSeriesCharts";
 export { ResponseTimeVsConcurrencyChart, HdrPercentileChart } from "./ScatterAndDistribution";
 export { StatusCodesOverTimeChart } from "./StatusCodesOverTimeChart";

--- a/app/src/modules/dashboard/components/charts/uplot/uplotTheme.ts
+++ b/app/src/modules/dashboard/components/charts/uplot/uplotTheme.ts
@@ -51,6 +51,21 @@ export type ColorRole =
 	 * of the categorical palette from success/warning/destructive.
 	 */
 	| "categorical"
+	/**
+	 * The rest of the categorical set - teal, rose, moss - for a plot whose
+	 * series count is decided by the user rather than by this app.
+	 *
+	 * The server-vitals overlay is the only such plot: a run names its own
+	 * metrics, so the wrapper cycles these rather than hand-picking a role per
+	 * series. `--chart-1` stays out for the reason given above `categorical`,
+	 * and so does **`--chart-4` (amber)**: it measures 2.38 against a light card,
+	 * under the 3.0 a series has to clear to be seen at all
+	 * (`status-token-contrast.test.ts`). It is fine as a *fill* in the timing
+	 * waterfall, where the shape carries the meaning; a 1.8px line is not that.
+	 */
+	| "categorical-2"
+	| "categorical-3"
+	| "categorical-4"
 	/*
 	 * HTTP status classes, resolving to the same `--status-*` family the badges
 	 * and history tiles use.
@@ -95,6 +110,9 @@ export const ROLE_TOKEN: Record<ColorRole, string> = {
 	muted: "--muted-foreground",
 	subtle: "--subtle-foreground",
 	categorical: "--chart-3",
+	"categorical-2": "--chart-2",
+	"categorical-3": "--chart-5",
+	"categorical-4": "--chart-6",
 	"status-success": STATUS_CLASS_CSS_VAR.success,
 	"status-redirect": STATUS_CLASS_CSS_VAR.redirect,
 	"status-client-error": STATUS_CLASS_CSS_VAR["client-error"],

--- a/app/src/modules/dashboard/components/tooltips.tsx
+++ b/app/src/modules/dashboard/components/tooltips.tsx
@@ -96,6 +96,9 @@ export const TOOLTIPS = {
 	statusCodesOverTime:
 		"Per-interval count of responses by status class, stacked. A healthy run is a solid 2xx field; 4xx/5xx or connection-error bands rising out of it pinpoint when failures happened. Derived by diffing the cumulative status-code map between ticks.",
 
+	serverVitals:
+		"Metrics scraped from the target itself during the run, drawn on the run's own timeline so a climb in p99 can be read against the server's CPU, memory or connection count. Each reading holds until the next scrape; a break in a line is a scrape that failed. Configure the endpoint under Server monitoring when starting the run.",
+
 	// ---- Other existing cards ----
 	rampDeviation:
 		"Mean absolute gap between achieved (measured) and configured concurrency, as a percent of target. Counts both undershoot and overshoot, so a ramp that runs over target reads high.",

--- a/app/src/modules/dashboard/utils/monitorSeries.test.ts
+++ b/app/src/modules/dashboard/utils/monitorSeries.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { LoadTestMetrics, MonitorSample } from "@/types";
+import { joinMonitorToTimeline, monitorSeriesNames, stalenessWindowMs } from "./monitorSeries";
+
+function tick(timestamp: number, elapsed: number): LoadTestMetrics {
+	return {
+		timestamp,
+		elapsed_seconds: elapsed,
+		requests_completed: 0,
+		requests_failed: 0,
+		current_rps: 0,
+		current_concurrency: 0,
+		latency_p50_ms: 0,
+		latency_p95_ms: 0,
+		latency_p99_ms: 0,
+		avg_latency_ms: 0,
+		bytes_sent: 0,
+		bytes_received: 0,
+	};
+}
+
+function sample(timestamp: number, series: Record<string, number>): MonitorSample {
+	return { timestamp, series };
+}
+
+describe("monitorSeriesNames", () => {
+	it("unions the names across samples, sorted", () => {
+		expect(monitorSeriesNames([sample(1, { rss: 1 }), sample(2, { cpu: 2, rss: 3 })])).toEqual([
+			"cpu",
+			"rss",
+		]);
+	});
+
+	it("is empty for no samples", () => {
+		expect(monitorSeriesNames([])).toEqual([]);
+	});
+});
+
+describe("stalenessWindowMs", () => {
+	it("scales with the observed scrape cadence", () => {
+		const scraped5s = [0, 5000, 10000, 15000].map((t) => sample(t, { cpu: 1 }));
+		expect(stalenessWindowMs(scraped5s)).toBe(12500);
+	});
+
+	it("floors at 2s so a fast cadence still bridges one tick", () => {
+		const scraped250ms = [0, 250, 500].map((t) => sample(t, { cpu: 1 }));
+		expect(stalenessWindowMs(scraped250ms)).toBe(2000);
+	});
+});
+
+describe("joinMonitorToTimeline", () => {
+	it("is empty when either side has nothing", () => {
+		expect(joinMonitorToTimeline([], [sample(1, { cpu: 1 })]).times).toEqual([]);
+		expect(joinMonitorToTimeline([tick(1000, 0)], []).times).toEqual([]);
+	});
+
+	it("holds each reading across the ticks it covers", () => {
+		// Scraped every 2s, ticked every 1s: the reading stands for the tick it
+		// landed on and the one after it, which is what makes the line continuous
+		// rather than every-other-point.
+		const history = [0, 1, 2, 3].map((i) => tick(10_000 + i * 1000, i));
+		const samples = [sample(10_000, { cpu: 10 }), sample(12_000, { cpu: 30 })];
+
+		const joined = joinMonitorToTimeline(history, samples);
+		expect(joined.names).toEqual(["cpu"]);
+		expect(joined.times).toEqual([0, 1, 2, 3]);
+		expect(joined.columns[0]).toEqual([10, 10, 30, 30]);
+	});
+
+	it("leaves ticks before the first scrape null rather than back-filling", () => {
+		const history = [0, 1, 2].map((i) => tick(10_000 + i * 1000, i));
+		const samples = [sample(12_000, { cpu: 30 })];
+
+		expect(joinMonitorToTimeline(history, samples).columns[0]).toEqual([null, null, 30]);
+	});
+
+	it("breaks the line where the scrape stopped answering", () => {
+		// A 5s cadence against 1s ticks, then a 25s hole. The reading has to
+		// carry across the cadence (or the line is four-fifths gaps) and stop
+		// carrying across the outage (or a flat line covers exactly the window
+		// the overlay exists to expose). The window is derived from the observed
+		// cadence, so both fall out of one rule.
+		const history = Array.from({ length: 40 }, (_, i) => tick(10_000 + i * 1000, i));
+		const samples = [
+			sample(10_000, { cpu: 10 }),
+			sample(15_000, { cpu: 12 }),
+			sample(20_000, { cpu: 14 }),
+			sample(45_000, { cpu: 20 }),
+		];
+
+		const column = joinMonitorToTimeline(history, samples).columns[0];
+		expect(column[0]).toBe(10); // t=10000, its own reading
+		expect(column[4]).toBe(10); // t=14000, held across the 5s cadence
+		expect(column[10]).toBe(14); // t=20000, the next reading
+		expect(column[25]).toBeNull(); // t=35000, well past any real cadence
+		expect(column[34]).toBeNull(); // ...and still null in the hole
+		expect(column[35]).toBe(20); // t=45000, the scrape came back
+	});
+
+	it("joins uneven cadences without reordering the columns", () => {
+		const history = [0, 1, 2].map((i) => tick(1000 + i * 1000, i));
+		const samples = [sample(2500, { rss: 200, cpu: 2 }), sample(900, { cpu: 1, rss: 100 })];
+
+		const joined = joinMonitorToTimeline(history, samples);
+		expect(joined.names).toEqual(["cpu", "rss"]);
+		expect(joined.columns[0]).toEqual([1, 1, 2]);
+		expect(joined.columns[1]).toEqual([100, 100, 200]);
+	});
+
+	it("nulls a name a scrape did not carry instead of holding a stale one", () => {
+		// The engine omits a series the target stopped exporting; a chart that
+		// carried the previous value forward would claim a reading that was
+		// never taken.
+		const history = [0, 1].map((i) => tick(1000 + i * 1000, i));
+		const samples = [sample(1000, { cpu: 1, rss: 100 }), sample(2000, { cpu: 2 })];
+
+		const joined = joinMonitorToTimeline(history, samples);
+		expect(joined.columns[0]).toEqual([1, 2]);
+		expect(joined.columns[1]).toEqual([100, null]);
+	});
+});

--- a/app/src/modules/dashboard/utils/monitorSeries.ts
+++ b/app/src/modules/dashboard/utils/monitorSeries.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Joining scraped server vitals onto the run's own timeline.
+ *
+ * The two series are sampled by different clocks: ticks land on the engine's
+ * cadence (100ms live, 1s persisted) and monitor samples on whatever scrape
+ * interval the user chose, which may be slower, faster, or drifting against it.
+ * `uPlot.AlignedData` has one shared x column, so a chart that draws both needs
+ * the vitals resampled onto the ticks' x axis - that resampling is here, pure
+ * and unit-tested, rather than inside a chart component.
+ */
+
+import type { LoadTestMetrics, MonitorSample } from "@/types";
+
+/** Vitals resampled onto a run's tick timeline, ready for `uPlot.AlignedData`. */
+export interface JoinedMonitorSeries {
+	/** Elapsed seconds, one entry per tick - the shared x column. */
+	times: number[];
+	/** Series names, in the order `columns` holds them. */
+	names: string[];
+	/** One column per name; `null` where no reading covers that tick. */
+	columns: (number | null)[][];
+}
+
+const EMPTY: JoinedMonitorSeries = { times: [], names: [], columns: [] };
+
+/**
+ * How long a reading is allowed to stand in for later ticks, derived from the
+ * scrape cadence the samples actually show.
+ *
+ * A gauge read every 5s must still draw across the four 1s ticks after it, or
+ * the line would be four fifths holes. But a reading must not be held across a
+ * scrape that *failed*: that would draw a flat line over an outage, which is
+ * the one thing the overlay exists to make visible. So the window is a small
+ * multiple of the observed median spacing - long enough to bridge the cadence,
+ * short enough that a missed scrape shows as a gap.
+ */
+export function stalenessWindowMs(samples: MonitorSample[]): number {
+	const FLOOR_MS = 2000;
+	if (samples.length < 2) return FLOOR_MS;
+	const gaps: number[] = [];
+	for (let i = 1; i < samples.length; i++) {
+		gaps.push(samples[i].timestamp - samples[i - 1].timestamp);
+	}
+	gaps.sort((a, b) => a - b);
+	const median = gaps[Math.floor(gaps.length / 2)];
+	return Math.max(FLOOR_MS, Math.round(median * 2.5));
+}
+
+/** Every series name the samples carry, sorted so column order is stable. */
+export function monitorSeriesNames(samples: MonitorSample[]): string[] {
+	const names = new Set<string>();
+	for (const sample of samples) {
+		for (const name of Object.keys(sample.series ?? {})) names.add(name);
+	}
+	return [...names].sort();
+}
+
+/**
+ * Resample @p samples onto @p history's tick timeline.
+ *
+ * Each tick takes the newest reading at or before it (a gauge holds its value
+ * until the next scrape - interpolating between two readings would invent
+ * numbers the target never reported), or `null` when the newest reading is
+ * older than {@link stalenessWindowMs} - which is what makes a failed scrape
+ * read as a gap rather than a plateau. Ticks before the first scrape are `null`
+ * for the same reason.
+ *
+ * Both inputs are time-ordered by their producers; the samples are sorted
+ * defensively because they arrive from two sources (live SSE frames and a
+ * paginated history fetch).
+ */
+export function joinMonitorToTimeline(
+	history: LoadTestMetrics[],
+	samples: MonitorSample[]
+): JoinedMonitorSeries {
+	if (history.length === 0 || samples.length === 0) return EMPTY;
+
+	const ordered = [...samples].sort((a, b) => a.timestamp - b.timestamp);
+	const names = monitorSeriesNames(ordered);
+	if (names.length === 0) return EMPTY;
+
+	const maxAgeMs = stalenessWindowMs(ordered);
+	const times: number[] = [];
+	const columns: (number | null)[][] = names.map(() => []);
+
+	// Two pointers over two ascending series - the join is linear, not a scan
+	// per tick, because a long run pairs thousands of ticks with thousands of
+	// samples on every render.
+	let cursor = -1;
+	for (const tick of history) {
+		while (cursor + 1 < ordered.length && ordered[cursor + 1].timestamp <= tick.timestamp) {
+			cursor++;
+		}
+		times.push(tick.elapsed_seconds);
+		const current = cursor >= 0 ? ordered[cursor] : null;
+		const fresh = current !== null && tick.timestamp - current.timestamp <= maxAgeMs;
+		names.forEach((name, i) => {
+			const value = fresh ? current.series?.[name] : undefined;
+			columns[i].push(typeof value === "number" ? value : null);
+		});
+	}
+
+	return { times, names, columns };
+}

--- a/app/src/modules/history/main/LoadTestDetail.scenario.test.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.scenario.test.tsx
@@ -35,6 +35,12 @@ vi.mock("@/queries/runs", () => ({
 		fetchNextPage: vi.fn(),
 		hasNextPage: false,
 	}),
+	useRunMonitorSeriesQuery: () => ({
+		data: undefined,
+		isFetchingNextPage: false,
+		fetchNextPage: vi.fn(),
+		hasNextPage: false,
+	}),
 }));
 
 function renderReport(ui: ReactElement) {

--- a/app/src/modules/history/main/LoadTestDetail.tsx
+++ b/app/src/modules/history/main/LoadTestDetail.tsx
@@ -36,10 +36,10 @@ import { HTTP_VERSIONS, isHttpVersion } from "@/constants/request";
 import type { LoadTestConfig } from "@/types";
 import { reportToDerived } from "@/modules/dashboard/utils/reportToDerived";
 import { computeBreakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
-import { useRunTimeSeriesQuery } from "@/queries/runs";
+import { useRunMonitorSeriesQuery, useRunTimeSeriesQuery } from "@/queries/runs";
 import { useClientSettingsStore } from "@/stores";
 import { OverviewTab, PerformanceTab, SamplesTab, ScenarioStepsTab } from "./components";
-import type { LoadTestDetailProps, TimeSeriesResponse } from "../types";
+import type { LoadTestDetailProps, MonitorSeriesResponse, TimeSeriesResponse } from "../types";
 
 export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 	const [activeTab, setActiveTab] = useState("overview");
@@ -101,6 +101,29 @@ export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 	const timeSeries = useMemo(
 		() => timeSeriesData?.pages?.flatMap((page: TimeSeriesResponse) => page.data) ?? [],
 		[timeSeriesData]
+	);
+
+	// Server vitals, only for a run that actually recorded some: the report's
+	// `monitor` section is the run's own record of what the scrape did, so a run
+	// that monitored nothing (or whose every scrape failed) never issues the
+	// fetch at all.
+	const hasMonitorSamples = (report.monitor?.samples ?? 0) > 0;
+	const {
+		data: monitorData,
+		isFetchingNextPage: isFetchingMonitorPage,
+		hasNextPage: hasMoreMonitor,
+		fetchNextPage: fetchMoreMonitor,
+	} = useRunMonitorSeriesQuery(runId ?? null, hasMonitorSamples);
+
+	useEffect(() => {
+		if (hasMoreMonitor && !isFetchingMonitorPage) {
+			fetchMoreMonitor();
+		}
+	}, [hasMoreMonitor, isFetchingMonitorPage, fetchMoreMonitor]);
+
+	const monitorSamples = useMemo(
+		() => monitorData?.pages?.flatMap((page: MonitorSeriesResponse) => page.data) ?? [],
+		[monitorData]
 	);
 
 	const seriesProgress = useMemo(() => {
@@ -319,6 +342,7 @@ export default function LoadTestDetail({ report, runId }: LoadTestDetailProps) {
 								runId={runId}
 								derived={derived}
 								timeSeries={timeSeries}
+								monitorSamples={monitorSamples}
 								isLoadingSeries={isLoadingSeries}
 								isFetchingMore={isFetchingNextPage}
 								progress={seriesProgress}

--- a/app/src/modules/history/main/components/HistoricalChartsSection.tsx
+++ b/app/src/modules/history/main/components/HistoricalChartsSection.tsx
@@ -15,17 +15,20 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { Loader2 } from "lucide-react";
-import type { LoadTestMetrics } from "@/types";
+import type { LoadTestMetrics, MonitorSample } from "@/types";
 import type { Breakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
 import {
 	RequestRateChart,
 	ConnectionsChart,
 	StatusCodesOverTimeChart,
+	ServerVitalsChart,
 	CHART_SYNC,
 } from "@/modules/dashboard/components/charts/uplot";
 
 interface HistoricalChartsSectionProps {
 	data: LoadTestMetrics[];
+	/** Server vitals scraped during the run; empty when it monitored nothing. */
+	monitorSamples?: MonitorSample[];
 	isLoading?: boolean;
 	isFetchingMore?: boolean;
 	progress?: { loaded: number; total: number };
@@ -36,6 +39,7 @@ const SYNC_KEY = CHART_SYNC.history;
 
 export default function HistoricalChartsSection({
 	data,
+	monitorSamples = [],
 	isLoading,
 	isFetchingMore,
 	progress,
@@ -116,6 +120,24 @@ export default function HistoricalChartsSection({
 					<StatusCodesOverTimeChart history={data} isCompleted syncKey={SYNC_KEY} />
 				</CardContent>
 			</Card>
+
+			{/* The same row the live dashboard draws, on the same sync group -
+			    absent for a run that scraped nothing rather than an empty card. */}
+			{monitorSamples.length > 0 && (
+				<Card>
+					<CardHeader className="pb-2">
+						<CardTitle className="text-base">Server Vitals</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<ServerVitalsChart
+							history={data}
+							samples={monitorSamples}
+							isCompleted
+							syncKey={SYNC_KEY}
+						/>
+					</CardContent>
+				</Card>
+			)}
 		</div>
 	);
 }

--- a/app/src/modules/history/main/components/PerformanceTab.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.tsx
@@ -33,6 +33,7 @@ export default function PerformanceTab({
 	runId,
 	derived,
 	timeSeries,
+	monitorSamples,
 	isLoadingSeries,
 	isFetchingMore,
 	progress,
@@ -51,6 +52,7 @@ export default function PerformanceTab({
 			{runId && (
 				<HistoricalChartsSection
 					data={timeSeries}
+					monitorSamples={monitorSamples}
 					isLoading={isLoadingSeries}
 					isFetchingMore={isFetchingMore}
 					progress={progress}

--- a/app/src/modules/history/types.ts
+++ b/app/src/modules/history/types.ts
@@ -9,7 +9,7 @@
  * History Component Types
  */
 
-import type { RunReport, LoadTestMetrics } from "@/types";
+import type { RunReport, LoadTestMetrics, MonitorSample } from "@/types";
 import type { DashboardDerived } from "@/modules/dashboard/types";
 
 export interface TabProps {
@@ -25,6 +25,8 @@ export interface TabProps {
  */
 export interface PerformanceTabProps extends TabProps {
 	timeSeries: LoadTestMetrics[];
+	/** Server vitals scraped during the run; empty when it monitored nothing. */
+	monitorSamples: MonitorSample[];
 	isLoadingSeries?: boolean;
 	isFetchingMore?: boolean;
 	progress?: { loaded: number; total: number };
@@ -48,6 +50,21 @@ export type SampleResult = NonNullable<RunReport["results"]>[number];
  */
 export interface TimeSeriesResponse {
 	data: LoadTestMetrics[];
+	pagination: {
+		total: number;
+		limit: number;
+		offset: number;
+		hasMore: boolean;
+		returned: number;
+	};
+}
+
+/**
+ * Server-vitals response from GET /runs/:runId/monitor - the same envelope the
+ * tick series uses, so one pagination reader covers both.
+ */
+export interface MonitorSeriesResponse {
+	data: MonitorSample[];
 	pagination: {
 		total: number;
 		limit: number;

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -28,6 +28,18 @@ vi.mock("../OAuth2LoadTestGuard", () => ({
 	default: () => null,
 }));
 
+/**
+ * The dialog seeds its scrape cadence and metric cap from the engine's
+ * `monitorIntervalMs` / `monitorMaxSeries` settings, so it reads the config
+ * query. Mocked rather than wrapped in a provider, the convention the hook
+ * tests use - and `configEntries` is mutable so a test can move a setting and
+ * assert the dialog followed it.
+ */
+let configEntries: { key: string; value: string }[] = [];
+vi.mock("@/queries", () => ({
+	useConfigQuery: () => ({ data: { entries: configEntries } }),
+}));
+
 function open(props: Partial<React.ComponentProps<typeof LoadTestConfigDialog>> = {}) {
 	const onStart = vi.fn();
 	render(
@@ -55,6 +67,7 @@ const started = (onStart: ReturnType<typeof vi.fn>): LoadTestConfig => {
 beforeEach(() => {
 	cleanup();
 	localStorage.clear();
+	configEntries = [];
 	// The ceilings store is module-level and persists across tests in this
 	// file; clearing localStorage does not roll it back.
 	useClientSettingsStore.getState().setLoadTestCeilings(DEFAULT_LOAD_TEST_CEILINGS);
@@ -562,6 +575,46 @@ describe("server monitoring", () => {
 
 		expect(onStart).not.toHaveBeenCalled();
 		expect(screen.getByText(/server monitoring is incomplete/i)).toBeInTheDocument();
+	});
+
+	it("seeds the interval from the engine setting rather than its own number", () => {
+		// `monitorIntervalMs` would otherwise be a setting with no reader on this
+		// path: the dialog always sends an explicit interval, so a hardcoded
+		// default here means the engine's copy never applies to a run started
+		// from the app.
+		configEntries = [{ key: "monitorIntervalMs", value: "5000" }];
+		const { onStart } = open();
+		openMonitoring();
+		fireEvent.change(url(), { target: { value: "http://localhost:9100/metrics" } });
+		fireEvent.change(metrics(), { target: { value: "up" } });
+
+		expect(started(onStart).monitor?.intervalMs).toBe(5000);
+	});
+
+	it("accepts as many metrics as the engine setting allows", () => {
+		// The cap is `monitorMaxSeries`; a dialog holding its own 8 would refuse a
+		// list the engine was just configured to accept.
+		configEntries = [{ key: "monitorMaxSeries", value: "12" }];
+		const { onStart } = open();
+		openMonitoring();
+		fireEvent.change(url(), { target: { value: "http://localhost:9100/metrics" } });
+		fireEvent.change(metrics(), {
+			target: { value: Array.from({ length: 10 }, (_, i) => `m${i}`).join("\n") },
+		});
+
+		expect(started(onStart).monitor?.series).toHaveLength(10);
+	});
+
+	it("blocks Start past the configured cap", () => {
+		configEntries = [{ key: "monitorMaxSeries", value: "2" }];
+		const { onStart } = open();
+		openMonitoring();
+		fireEvent.change(url(), { target: { value: "http://localhost:9100/metrics" } });
+		fireEvent.change(metrics(), { target: { value: "a\nb\nc" } });
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+		expect(onStart).not.toHaveBeenCalled();
+		expect(screen.getByText(/at most 2 metrics/i)).toBeInTheDocument();
 	});
 
 	it("remembers the endpoint across dialog opens - it is a property of the target", () => {

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/LoadTestConfigDialog.test.tsx
@@ -474,3 +474,63 @@ describe("pass/fail budgets", () => {
 		expect(started(second.onStart).thresholds).toBeUndefined();
 	});
 });
+
+/**
+ * Server monitoring: the run's optional second data source. The rules live in
+ * `monitor.ts` and are tested there; these pin the wiring - that what the user
+ * types reaches the payload, that an incomplete block stops the run here rather
+ * than at the engine's 400, and that a run without one is unchanged.
+ */
+describe("server monitoring", () => {
+	const openMonitoring = () =>
+		fireEvent.click(screen.getByRole("button", { name: /server monitoring/i }));
+	const url = () => screen.getByLabelText(/metrics endpoint/i) as HTMLInputElement;
+	const metrics = () => screen.getByLabelText(/metrics to chart/i) as HTMLTextAreaElement;
+
+	it("sends nothing when no endpoint is given", () => {
+		const { onStart } = open();
+		expect(started(onStart).monitor).toBeUndefined();
+	});
+
+	it("sends the block the user typed", () => {
+		const { onStart } = open();
+		openMonitoring();
+		fireEvent.change(url(), { target: { value: "http://localhost:9100/metrics" } });
+		fireEvent.change(metrics(), {
+			target: { value: "node_cpu_seconds_total\nprocess_resident_memory_bytes" },
+		});
+
+		expect(started(onStart).monitor).toEqual({
+			url: "http://localhost:9100/metrics",
+			intervalMs: 1000,
+			format: "prometheus",
+			series: ["node_cpu_seconds_total", "process_resident_memory_bytes"],
+		});
+	});
+
+	it("blocks Start on an endpoint with no metrics instead of dropping the block", () => {
+		// The engine rejects `series: []`, so a silently dropped block would be a
+		// run the user believes is monitored and a chart that never appears.
+		const { onStart } = open();
+		openMonitoring();
+		fireEvent.change(url(), { target: { value: "http://localhost:9100/metrics" } });
+		fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+		expect(onStart).not.toHaveBeenCalled();
+		expect(screen.getByText(/server monitoring is incomplete/i)).toBeInTheDocument();
+	});
+
+	it("remembers the endpoint across dialog opens - it is a property of the target", () => {
+		const first = open();
+		openMonitoring();
+		fireEvent.change(url(), { target: { value: "http://localhost:9100/metrics" } });
+		fireEvent.change(metrics(), { target: { value: "up" } });
+		expect(started(first.onStart).monitor?.series).toEqual(["up"]);
+
+		cleanup();
+		open();
+		openMonitoring();
+		expect(url().value).toBe("http://localhost:9100/metrics");
+		expect(metrics().value).toBe("up");
+	});
+});

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -43,6 +43,9 @@ import {
 	Input,
 	Label,
 	Switch,
+	Textarea,
+	ToggleGroup,
+	ToggleGroupItem,
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
@@ -64,6 +67,13 @@ import {
 	buildThresholds,
 	emptyBudgetDraft,
 } from "./budgets";
+import {
+	MONITOR_INTERVAL_MS,
+	type MonitorDraft,
+	buildMonitor,
+	emptyMonitorDraft,
+	monitorError,
+} from "./monitor";
 
 interface SavedLoadTestConfig {
 	mode: LoadTestConfig["mode"];
@@ -84,6 +94,13 @@ interface SavedLoadTestConfig {
 	 * undone by the next dialog open.
 	 */
 	budgets: BudgetDraft;
+	/**
+	 * The monitoring endpoint, memoed for the same reason the budgets are: it is
+	 * a property of the *target* rather than of one run, so retyping a
+	 * `/metrics` URL and its metric names for every run is the same friction the
+	 * memo exists to remove.
+	 */
+	monitor: MonitorDraft;
 }
 
 function loadSavedConfig(): Partial<SavedLoadTestConfig> {
@@ -261,6 +278,10 @@ export default function LoadTestConfigDialog({
 			}
 	);
 	const [budgetsOpen, setBudgetsOpen] = useState(false);
+	const [monitor, setMonitor] = useState<MonitorDraft>(
+		() => saved.monitor ?? emptyMonitorDraft()
+	);
+	const [monitorOpen, setMonitorOpen] = useState(false);
 	const [comment, setComment] = useState(""); // Per-run: never restored.
 	const [oauthGated, setOauthGated] = useState(false);
 	const [recordingOpen, setRecordingOpen] = useState(false);
@@ -279,7 +300,9 @@ export default function LoadTestConfigDialog({
 	const rampDurationError = validateRampDuration(mode, duration, rampDuration);
 	const startConcurrencyError = validateStartConcurrency(mode, startConcurrency, concurrency);
 	const budgetsError = budgetError(budgets);
-	const blockingError = rampDurationError ?? startConcurrencyError ?? budgetsError;
+	const monitoringError = monitorError(monitor);
+	const blockingError =
+		rampDurationError ?? startConcurrencyError ?? budgetsError ?? monitoringError;
 
 	const notices = useMemo(() => {
 		const list: { key: string; severity: Severity; node: React.ReactNode }[] = [];
@@ -303,6 +326,18 @@ export default function LoadTestConfigDialog({
 				node: (
 					<Callout severity="blocking" title="A budget is out of range">
 						{budgetsError}
+					</Callout>
+				),
+			});
+		}
+
+		if (monitoringError) {
+			list.push({
+				key: "monitor",
+				severity: "blocking",
+				node: (
+					<Callout severity="blocking" title="Server monitoring is incomplete">
+						{monitoringError}
 					</Callout>
 				),
 			});
@@ -354,6 +389,7 @@ export default function LoadTestConfigDialog({
 		rampDurationError,
 		startConcurrencyError,
 		budgetsError,
+		monitoringError,
 		hasPreRequestScript,
 		hasDynamicVariables,
 	]);
@@ -376,6 +412,7 @@ export default function LoadTestConfigDialog({
 			slowThreshold,
 			saveTimingBreakdown,
 			budgets,
+			monitor,
 		});
 
 		const config: LoadTestConfig = {
@@ -390,6 +427,8 @@ export default function LoadTestConfigDialog({
 			// Absent when nothing was declared - the engine rejects an empty
 			// object rather than starting a run no verdict can be computed for.
 			thresholds: buildThresholds(budgets),
+			// Absent when no endpoint was given, for the same reason.
+			monitor: buildMonitor(monitor),
 		};
 
 		// Omitted in `iterations` - see `usesDuration`. Sending a value the engine
@@ -696,6 +735,118 @@ export default function LoadTestConfigDialog({
 									hint={field.hint}
 								/>
 							))}
+						</CollapsibleContent>
+					</Collapsible>
+
+					{/*
+					 * Server monitoring, in the same card treatment as the two
+					 * disclosures above. Last of the three because it is about the
+					 * *target* rather than about the load: a run is fully specified
+					 * without it, and it adds a second series to the charts rather
+					 * than changing what is sent.
+					 */}
+					<Collapsible
+						open={monitorOpen}
+						onOpenChange={setMonitorOpen}
+						className="panel-clip overflow-hidden rounded-md border border-border surface-card"
+					>
+						<CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2 text-left text-xs font-medium text-foreground transition-colors hover:bg-accent">
+							<span>Server monitoring</span>
+							<span className="text-[11px] font-normal text-muted-foreground">
+								{monitorOpen ? "Hide" : "Show"}
+							</span>
+						</CollapsibleTrigger>
+						<CollapsibleContent className="space-y-4 border-t border-rule px-3 py-3">
+							<p className="text-[11px] leading-relaxed text-muted-foreground">
+								Scrape the target&apos;s own metrics during the run and chart them
+								on the same timeline as p99 and throughput - so a climb in latency
+								can be read against the server&apos;s CPU or memory. Leave the URL
+								blank to run without it.
+							</p>
+							<div className="space-y-1.5">
+								<Label htmlFor="lt-monitor-url" className="text-xs">
+									Metrics endpoint
+									<span className="ml-1 font-normal text-muted-foreground">
+										(optional)
+									</span>
+								</Label>
+								<Input
+									id="lt-monitor-url"
+									type="text"
+									value={monitor.url}
+									onChange={(e) =>
+										setMonitor((prev) => ({ ...prev, url: e.target.value }))
+									}
+									placeholder="http://localhost:9100/metrics"
+									className="h-9 text-sm"
+								/>
+							</div>
+
+							<NumberField
+								id="lt-monitor-interval"
+								label="Scrape interval"
+								unit="ms"
+								value={monitor.intervalMs}
+								onChange={(raw) =>
+									setMonitor((prev) => ({ ...prev, intervalMs: Number(raw) }))
+								}
+								min={MONITOR_INTERVAL_MS.MIN}
+								max={MONITOR_INTERVAL_MS.MAX}
+								hint="Each scrape is one request to the endpoint, on its own thread - it never delays the run's own metrics."
+							/>
+
+							<div className="space-y-1.5">
+								<Label className="text-xs">Response format</Label>
+								{/*
+								    A segmented control rather than a two-row select:
+								    it is a binary choice, and `ToggleGroup` is the
+								    app's primitive for one (roving focus and the
+								    `data-[state=]` variants come with it).
+								 */}
+								<ToggleGroup
+									size="sm"
+									value={monitor.format}
+									onValueChange={(value) => {
+										// Radix emits "" when the active item is
+										// clicked again; a format is not optional, so
+										// that deselection is ignored rather than
+										// leaving the draft with no format at all.
+										if (value === "prometheus" || value === "json") {
+											setMonitor((prev) => ({ ...prev, format: value }));
+										}
+									}}
+								>
+									<ToggleGroupItem value="prometheus">
+										Prometheus text
+									</ToggleGroupItem>
+									<ToggleGroupItem value="json">Flat JSON</ToggleGroupItem>
+								</ToggleGroup>
+							</div>
+
+							<div className="space-y-1.5">
+								<Label htmlFor="lt-monitor-series" className="text-xs">
+									Metrics to chart
+									<span className="ml-1.5 font-normal text-muted-foreground">
+										one name per line, up to 8
+									</span>
+								</Label>
+								<Textarea
+									id="lt-monitor-series"
+									value={monitor.series}
+									onChange={(e) =>
+										setMonitor((prev) => ({ ...prev, series: e.target.value }))
+									}
+									rows={3}
+									placeholder={
+										"node_cpu_seconds_total\nprocess_resident_memory_bytes"
+									}
+									className="font-mono text-xs"
+								/>
+								<p className="text-[11px] text-muted-foreground">
+									A Prometheus name is matched across its labels and the values
+									summed, so a whole family charts as one line.
+								</p>
+							</div>
 						</CollapsibleContent>
 					</Collapsible>
 

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -71,13 +71,9 @@ import {
 	buildThresholds,
 	emptyBudgetDraft,
 } from "./budgets";
-import {
-	MONITOR_INTERVAL_MS,
-	type MonitorDraft,
-	buildMonitor,
-	emptyMonitorDraft,
-	monitorError,
-} from "./monitor";
+import { type MonitorDraft, buildMonitor, emptyMonitorDraft, monitorError } from "./monitor";
+import { MONITOR_INTERVAL_MS } from "@/constants/monitor";
+import { useMonitorSettings } from "@/hooks/useMonitorSettings";
 
 interface SavedLoadTestConfig {
 	mode: LoadTestConfig["mode"];
@@ -296,8 +292,18 @@ export default function LoadTestConfigDialog({
 			}
 	);
 	const [budgetsOpen, setBudgetsOpen] = useState(false);
+	/**
+	 * Server monitoring. The cadence and the metric cap are engine settings
+	 * (`monitorIntervalMs` / `monitorMaxSeries`), so the dialog seeds and bounds
+	 * itself from them rather than from its own numbers - otherwise the cadence
+	 * setting would never apply to a run started here (this dialog always sends
+	 * an explicit interval) and a raised cap would still be refused locally.
+	 * Seeded only on a first run, like the p99 budget above: once a draft has
+	 * been memoed, the interval the user set stays set.
+	 */
+	const monitorSettings = useMonitorSettings();
 	const [monitor, setMonitor] = useState<MonitorDraft>(
-		() => saved.monitor ?? emptyMonitorDraft()
+		() => saved.monitor ?? emptyMonitorDraft(monitorSettings.defaultIntervalMs)
 	);
 	const [monitorOpen, setMonitorOpen] = useState(false);
 	const [comment, setComment] = useState(""); // Per-run: never restored.
@@ -319,7 +325,7 @@ export default function LoadTestConfigDialog({
 	const startConcurrencyError = validateStartConcurrency(mode, startConcurrency, concurrency);
 	const capacityRangeError = validateCapacityRange(mode, startConcurrency, concurrency);
 	const budgetsError = budgetError(budgets);
-	const monitoringError = monitorError(monitor);
+	const monitoringError = monitorError(monitor, monitorSettings.maxSeries);
 	const blockingError =
 		rampDurationError ??
 		startConcurrencyError ??
@@ -923,7 +929,7 @@ export default function LoadTestConfigDialog({
 								<Label htmlFor="lt-monitor-series" className="text-xs">
 									Metrics to chart
 									<span className="ml-1.5 font-normal text-muted-foreground">
-										one name per line, up to 8
+										one name per line, up to {monitorSettings.maxSeries}
 									</span>
 								</Label>
 								<Textarea

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.test.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.test.ts
@@ -98,3 +98,23 @@ describe("buildMonitor", () => {
 		});
 	});
 });
+
+describe("configured limits", () => {
+	it("seeds a blank draft with the cadence the caller resolved", () => {
+		// `monitorIntervalMs` is an engine setting; a draft that ignored it would
+		// leave the setting with no reader on the path this dialog takes, since
+		// it always sends an explicit interval.
+		expect(emptyMonitorDraft(5000).intervalMs).toBe(5000);
+		expect(emptyMonitorDraft().intervalMs).toBe(1000);
+	});
+
+	it("judges the metric list against the configured cap, not a fixed 8", () => {
+		const twelve = Array.from({ length: 12 }, (_, i) => `m${i}`).join("\n");
+		const withTwelve = draft({ url: "http://localhost:9100/metrics", series: twelve });
+
+		expect(monitorError(withTwelve)).toMatch(/at most 8/i);
+		expect(monitorError(withTwelve, 12)).toBeNull();
+		// ...and a lowered cap binds too.
+		expect(monitorError(draft({ url: "http://x/m", series: "a\nb" }), 1)).toMatch(/at most 1/i);
+	});
+});

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.test.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+	buildMonitor,
+	emptyMonitorDraft,
+	monitorError,
+	monitorSeriesList,
+	type MonitorDraft,
+} from "./monitor";
+
+function draft(over: Partial<MonitorDraft> = {}): MonitorDraft {
+	return { ...emptyMonitorDraft(), ...over };
+}
+
+describe("monitorError", () => {
+	it("accepts an empty draft - monitoring is opt-in", () => {
+		expect(monitorError(emptyMonitorDraft())).toBeNull();
+		// ...and a series list typed then abandoned does not turn it on.
+		expect(monitorError(draft({ series: "node_cpu_seconds_total" }))).toBeNull();
+	});
+
+	it("accepts a complete block", () => {
+		expect(
+			monitorError(
+				draft({ url: "http://localhost:9100/metrics", series: "node_cpu_seconds_total" })
+			)
+		).toBeNull();
+	});
+
+	it("rejects a URL the engine could not fetch", () => {
+		expect(monitorError(draft({ url: "localhost:9100/metrics", series: "up" }))).toMatch(
+			/http:\/\//
+		);
+	});
+
+	it("rejects an endpoint with nothing to read", () => {
+		// The engine 400s a block with an empty `series`, so this must stop the
+		// run here rather than after the dialog closes.
+		expect(monitorError(draft({ url: "http://localhost:9100/metrics" }))).toMatch(
+			/at least one metric/i
+		);
+	});
+
+	it("rejects an interval outside the engine's range", () => {
+		const base = { url: "http://localhost:9100/metrics", series: "up" };
+		expect(monitorError(draft({ ...base, intervalMs: 100 }))).toMatch(/interval/i);
+		expect(monitorError(draft({ ...base, intervalMs: 90_000 }))).toMatch(/interval/i);
+		expect(monitorError(draft({ ...base, intervalMs: 250 }))).toBeNull();
+	});
+
+	it("rejects more series than the chart can carry", () => {
+		const nine = Array.from({ length: 9 }, (_, i) => `m${i}`).join("\n");
+		expect(monitorError(draft({ url: "http://localhost:9100/metrics", series: nine }))).toMatch(
+			/at most 8/i
+		);
+	});
+});
+
+describe("monitorSeriesList", () => {
+	it("drops blank lines and surrounding whitespace", () => {
+		expect(monitorSeriesList(draft({ series: "  a  \n\n b\n\n" }))).toEqual(["a", "b"]);
+	});
+});
+
+describe("buildMonitor", () => {
+	it("is undefined without a URL, so the payload omits the block entirely", () => {
+		expect(buildMonitor(emptyMonitorDraft())).toBeUndefined();
+		expect(buildMonitor(draft({ series: "up" }))).toBeUndefined();
+	});
+
+	it("is undefined with a URL and no metrics rather than an empty series", () => {
+		// The engine rejects `series: []`; sending it would fail the run instead
+		// of starting one without monitoring.
+		expect(buildMonitor(draft({ url: "http://localhost:9100/metrics" }))).toBeUndefined();
+	});
+
+	it("builds the engine's block, trimmed", () => {
+		expect(
+			buildMonitor(
+				draft({
+					url: "  http://localhost:9100/metrics  ",
+					intervalMs: 2000,
+					format: "json",
+					series: "cpu\n rss ",
+				})
+			)
+		).toEqual({
+			url: "http://localhost:9100/metrics",
+			intervalMs: 2000,
+			format: "json",
+			series: ["cpu", "rss"],
+		});
+	});
+});

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.ts
@@ -17,9 +17,7 @@
  */
 
 import type { RunMonitorConfig } from "@/types";
-
-export const MONITOR_INTERVAL_MS = { MIN: 250, MAX: 60_000, DEFAULT: 1000 } as const;
-export const MONITOR_MAX_SERIES = 8;
+import { MONITOR_INTERVAL_MS, MONITOR_MAX_SERIES } from "@/constants/monitor";
 
 /** What the user has typed. `url` blank means "monitor nothing". */
 export interface MonitorDraft {
@@ -30,10 +28,15 @@ export interface MonitorDraft {
 	series: string;
 }
 
-export function emptyMonitorDraft(): MonitorDraft {
+/**
+ * A blank draft. @p intervalMs is the configured default (`monitorIntervalMs`),
+ * passed in rather than read here so this stays a pure function - the dialog
+ * resolves it from engine config, and the seed stands in until that resolves.
+ */
+export function emptyMonitorDraft(intervalMs: number = MONITOR_INTERVAL_MS.DEFAULT): MonitorDraft {
 	return {
 		url: "",
-		intervalMs: MONITOR_INTERVAL_MS.DEFAULT,
+		intervalMs,
 		format: "prometheus",
 		series: "",
 	};
@@ -55,7 +58,7 @@ export function monitorSeriesList(draft: MonitorDraft): string[] {
  * said out loud rather than dropped: a run started with a monitor the client
  * quietly discarded is a chart the user waits the whole run for and never gets.
  */
-export function monitorError(draft: MonitorDraft): string | null {
+export function monitorError(draft: MonitorDraft, maxSeries = MONITOR_MAX_SERIES): string | null {
 	const url = draft.url.trim();
 	if (url === "") return null;
 
@@ -73,8 +76,8 @@ export function monitorError(draft: MonitorDraft): string | null {
 	if (series.length === 0) {
 		return "Name at least one metric to read from the endpoint, one per line.";
 	}
-	if (series.length > MONITOR_MAX_SERIES) {
-		return `At most ${MONITOR_MAX_SERIES} metrics can be charted; you named ${series.length}.`;
+	if (series.length > maxSeries) {
+		return `At most ${maxSeries} metrics can be charted; you named ${series.length}. Raise "Server Monitoring Metric Limit" in Settings to chart more.`;
 	}
 	return null;
 }

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.ts
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/monitor.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The dialog's server-monitoring block: what the user types, when it is
+ * unusable, and what payload it builds.
+ *
+ * Kept component-free so the rules can be tested without rendering, exactly as
+ * the budgets beside it are. The bounds mirror `engine/src/core/monitor.cpp`.
+ * They are a courtesy, not the gate: the engine rejects an unusable block with
+ * a 400 whatever this file thinks, and these exist so the user is told before
+ * the run rather than after it fails to start.
+ */
+
+import type { RunMonitorConfig } from "@/types";
+
+export const MONITOR_INTERVAL_MS = { MIN: 250, MAX: 60_000, DEFAULT: 1000 } as const;
+export const MONITOR_MAX_SERIES = 8;
+
+/** What the user has typed. `url` blank means "monitor nothing". */
+export interface MonitorDraft {
+	url: string;
+	intervalMs: number;
+	format: "prometheus" | "json";
+	/** Metric names, one per line - the shape a `/metrics` body is read in. */
+	series: string;
+}
+
+export function emptyMonitorDraft(): MonitorDraft {
+	return {
+		url: "",
+		intervalMs: MONITOR_INTERVAL_MS.DEFAULT,
+		format: "prometheus",
+		series: "",
+	};
+}
+
+/** The typed metric names, blanks and surrounding whitespace removed. */
+export function monitorSeriesList(draft: MonitorDraft): string[] {
+	return draft.series
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line !== "");
+}
+
+/**
+ * The reason the engine would reject this block, phrased for the dialog.
+ *
+ * A blank URL is always fine - monitoring is opt-in, and clearing the field is
+ * how a user turns it off. Once a URL is there the rest must hold, and it is
+ * said out loud rather than dropped: a run started with a monitor the client
+ * quietly discarded is a chart the user waits the whole run for and never gets.
+ */
+export function monitorError(draft: MonitorDraft): string | null {
+	const url = draft.url.trim();
+	if (url === "") return null;
+
+	if (!/^https?:\/\//i.test(url)) {
+		return "The monitoring endpoint must be an http:// or https:// URL.";
+	}
+	if (
+		!Number.isFinite(draft.intervalMs) ||
+		draft.intervalMs < MONITOR_INTERVAL_MS.MIN ||
+		draft.intervalMs > MONITOR_INTERVAL_MS.MAX
+	) {
+		return `The scrape interval must be between ${MONITOR_INTERVAL_MS.MIN} and ${MONITOR_INTERVAL_MS.MAX}ms.`;
+	}
+	const series = monitorSeriesList(draft);
+	if (series.length === 0) {
+		return "Name at least one metric to read from the endpoint, one per line.";
+	}
+	if (series.length > MONITOR_MAX_SERIES) {
+		return `At most ${MONITOR_MAX_SERIES} metrics can be charted; you named ${series.length}.`;
+	}
+	return null;
+}
+
+/**
+ * The `monitor` payload for `POST /runs`, or `undefined` when no endpoint was
+ * given - never a block with an empty `series`, which the engine rejects.
+ *
+ * Assumes {@link monitorError} passed.
+ */
+export function buildMonitor(draft: MonitorDraft): RunMonitorConfig | undefined {
+	const url = draft.url.trim();
+	if (url === "") return undefined;
+	const series = monitorSeriesList(draft);
+	if (series.length === 0) return undefined;
+	return {
+		url,
+		intervalMs: draft.intervalMs,
+		format: draft.format,
+		series,
+	};
+}

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -473,6 +473,10 @@ export default function RequestBuilder() {
 					// rejects an empty `thresholds` object rather than starting a
 					// run whose verdict nothing can compute.
 					thresholds: config.thresholds,
+					// Undefined when the dialog named no metrics endpoint, for the
+					// same reason - and a run without it behaves exactly as it did
+					// before server monitoring existed.
+					monitor: config.monitor,
 				};
 
 				const result = await apiService.startLoadTest(apiRequest);

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -71,6 +71,9 @@ export const queryKeys = {
 		detail: (id: string) => [...queryKeys.runs.details(), id] as const,
 		report: (id: string) => [...queryKeys.runs.all, "report", id] as const,
 		timeSeries: (id: string) => [...queryKeys.runs.all, "timeSeries", id] as const,
+		// The run's scraped server vitals - its own family, cached like the time
+		// series (a finished run's samples never change).
+		monitorSeries: (id: string) => [...queryKeys.runs.all, "monitorSeries", id] as const,
 		// Captured response headers/bodies for a run's samples. Its own family,
 		// not part of `report`, because it is fetched lazily - only once a
 		// reader expands a sample - and must not ride on the report's cache.

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -24,7 +24,7 @@ import { queryKeys } from "./keys";
 import { QUERY_CACHE } from "@/config/cache";
 import { STATS_PAGE_LIMIT, RUNS_PAGE_LIMIT } from "@/config/network";
 import type { Run, RunListResponse, StartScenarioRunRequest } from "@/types";
-import type { TimeSeriesResponse } from "@/modules/history/types";
+import type { MonitorSeriesResponse, TimeSeriesResponse } from "@/modules/history/types";
 
 // ============ Run Queries ============
 
@@ -214,6 +214,35 @@ export function useRunTimeSeriesQuery(runId: string | null) {
 			}),
 		enabled: !!runId,
 		// Historical data never changes
+		staleTime: Infinity,
+		gcTime: QUERY_CACHE.RUNS_GC_TIME_MS,
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) =>
+			lastPage.pagination.hasMore
+				? lastPage.pagination.offset + lastPage.pagination.limit
+				: undefined,
+	});
+}
+
+/**
+ * Fetch the server vitals scraped during a run (paginated, auto-fetches all
+ * pages), for the history view's overlay.
+ *
+ * Its own query beside {@link useRunTimeSeriesQuery} rather than a field on it:
+ * the two series come from different endpoints and different cadences, and a
+ * run that configured no monitor must not pay a second fetch it would only ever
+ * read as empty - which is what `enabled` expresses at the call site.
+ */
+export function useRunMonitorSeriesQuery(runId: string | null, enabled = true) {
+	return useInfiniteQuery<MonitorSeriesResponse, Error>({
+		queryKey: queryKeys.runs.monitorSeries(runId ?? ""),
+		queryFn: ({ pageParam = 0 }) =>
+			apiService.getRunMonitorSeries(runId!, {
+				limit: STATS_PAGE_LIMIT,
+				offset: pageParam as number,
+			}),
+		enabled: !!runId && enabled,
+		// A finished run's scrapes never change, like its time series.
 		staleTime: Infinity,
 		gcTime: QUERY_CACHE.RUNS_GC_TIME_MS,
 		initialPageParam: 0,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -65,7 +65,7 @@ import type {
 	OAuth2AuthorizeStartResponse,
 	OAuth2AuthorizeStatusResponse,
 } from "@/types";
-import type { TimeSeriesResponse } from "@/modules/history/types";
+import type { MonitorSeriesResponse, TimeSeriesResponse } from "@/modules/history/types";
 import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import {
@@ -411,6 +411,16 @@ export const apiService = {
 		const { limit = STATS_PAGE_LIMIT, offset = 0 } = options;
 		return await httpClient.get<TimeSeriesResponse>(
 			API_ENDPOINTS.STATS_TIME_SERIES(id, limit, offset)
+		);
+	},
+
+	async getRunMonitorSeries(
+		id: string,
+		options: { limit?: number; offset?: number } = {}
+	): Promise<MonitorSeriesResponse> {
+		const { limit = STATS_PAGE_LIMIT, offset = 0 } = options;
+		return await httpClient.get<MonitorSeriesResponse>(
+			API_ENDPOINTS.RUN_MONITOR(id, limit, offset)
 		);
 	},
 

--- a/app/src/services/load-test-service.test.ts
+++ b/app/src/services/load-test-service.test.ts
@@ -54,6 +54,11 @@ describe("LoadTestService", () => {
 			"run_1",
 			expect.any(Function),
 			expect.any(Function),
+			expect.any(Function),
+			// No step handler - a load run emits none - but a monitor handler,
+			// because a run configured with a `monitor` block streams its
+			// scrapes on this same connection.
+			undefined,
 			expect.any(Function)
 		);
 	});

--- a/app/src/services/load-test-service.ts
+++ b/app/src/services/load-test-service.ts
@@ -19,7 +19,7 @@ import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/queries/keys";
 import { QUERY_CACHE } from "@/config/cache";
 import { useDashboardStore, useClientSettingsStore } from "@/stores";
-import type { LoadTestMetrics } from "@/types";
+import type { LoadTestMetrics, MonitorSample } from "@/types";
 // Engine emits at 10 Hz (100ms cadence - see engine/src/http/routes/metrics.cpp).
 // We throttle UI commits to keep render cost bounded, but BUFFER every tick the
 // engine sends so historicalMetrics keeps the full 10 Hz signal.
@@ -30,6 +30,10 @@ class LoadTestService {
 	private isConnected: boolean = false;
 	private lastMetricsPushTime = 0;
 	private pendingBuffer: LoadTestMetrics[] = [];
+	// Scrapes ride the same throttle as the ticks: they arrive on the same
+	// stream and are drawn on the same chart row, so committing them separately
+	// would render the overlay a frame out of step with the series under it.
+	private pendingMonitor: MonitorSample[] = [];
 	private throttleTimer: ReturnType<typeof setTimeout> | null = null;
 
 	/**
@@ -67,7 +71,9 @@ class LoadTestService {
 			runId,
 			this.handleMetrics.bind(this),
 			this.handleError.bind(this),
-			this.handleClose.bind(this)
+			this.handleClose.bind(this),
+			undefined,
+			this.handleMonitorSample.bind(this)
 		);
 	}
 
@@ -85,6 +91,7 @@ class LoadTestService {
 			this.throttleTimer = null;
 		}
 		this.pendingBuffer = [];
+		this.pendingMonitor = [];
 		this.lastMetricsPushTime = 0;
 		this.activeRunId = null;
 		this.isConnected = false;
@@ -127,13 +134,24 @@ class LoadTestService {
 		}
 	}
 
+	private handleMonitorSample(sample: MonitorSample): void {
+		this.pendingMonitor.push(sample);
+		// No timer of its own: the next metrics flush carries it. A run always
+		// ticks at least as often as the slowest scrape interval, so a sample
+		// waits one tick at most - and the final flush in handleClose drains
+		// whatever the last tick left behind.
+	}
+
 	private flushMetrics(): void {
-		if (this.pendingBuffer.length === 0) return;
+		if (this.pendingBuffer.length === 0 && this.pendingMonitor.length === 0) return;
 		this.lastMetricsPushTime = Date.now();
 		const batch = this.pendingBuffer;
+		const monitor = this.pendingMonitor;
 		this.pendingBuffer = [];
+		this.pendingMonitor = [];
 		const store = useDashboardStore.getState();
 		store.addMetricsBatch(batch);
+		store.addMonitorSamples(monitor);
 	}
 
 	private handleError(error: Error): void {

--- a/app/src/services/sse-client.test.ts
+++ b/app/src/services/sse-client.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { mapSseMetrics, parseStepEvent } from "./sse-client";
+import { mapSseMetrics, parseMonitorEvent, parseStepEvent } from "./sse-client";
 
 describe("mapSseMetrics", () => {
 	it("maps bytes and the full status-code map", () => {
@@ -107,5 +107,33 @@ describe("parseStepEvent", () => {
 		// means everywhere else in the app.
 		expect(step?.statusCode).toBe(0);
 		expect(step?.latencyMs).toBe(0);
+	});
+});
+
+describe("parseMonitorEvent", () => {
+	it("reads a scrape", () => {
+		expect(parseMonitorEvent({ timestamp: 1700, series: { cpu: 0.5, rss: 1024 } })).toEqual({
+			timestamp: 1700,
+			series: { cpu: 0.5, rss: 1024 },
+		});
+	});
+
+	it("drops a frame with no usable timestamp or series", () => {
+		// A sample defaulted to timestamp 0 would join onto the very start of the
+		// run's timeline and draw a reading at a moment it was never taken.
+		expect(parseMonitorEvent({ series: { cpu: 1 } })).toBeNull();
+		expect(parseMonitorEvent({ timestamp: "1700", series: { cpu: 1 } })).toBeNull();
+		expect(parseMonitorEvent({ timestamp: 1700 })).toBeNull();
+		expect(parseMonitorEvent({ timestamp: 1700, series: {} })).toBeNull();
+		expect(parseMonitorEvent(null)).toBeNull();
+	});
+
+	it("drops non-numeric readings but keeps the rest of the scrape", () => {
+		expect(
+			parseMonitorEvent({
+				timestamp: 1700,
+				series: { cpu: 0.5, name: "web-1", broken: Number.NaN },
+			})
+		).toEqual({ timestamp: 1700, series: { cpu: 0.5 } });
 	});
 });

--- a/app/src/services/sse-client.ts
+++ b/app/src/services/sse-client.ts
@@ -9,7 +9,7 @@
 
 import { API_ENDPOINTS } from "@/config/api-endpoints";
 import { STEP_OUTCOMES } from "@/types";
-import type { LoadTestMetrics, ScenarioStepEvent, StepOutcome } from "@/types";
+import type { LoadTestMetrics, MonitorSample, ScenarioStepEvent, StepOutcome } from "@/types";
 
 /** Raw camelCase metrics blob as emitted by the engine SSE stream. */
 interface RawSseMetrics {
@@ -90,11 +90,35 @@ export function parseStepEvent(raw: unknown): ScenarioStepEvent | null {
 	};
 }
 
+/**
+ * Narrow a raw `monitor` frame to one scrape, or reject it.
+ *
+ * Same rule as {@link parseStepEvent}: a frame this client cannot read is
+ * dropped rather than coerced. A sample defaulted to `timestamp: 0` would join
+ * onto the very start of the run's timeline and draw a reading the target never
+ * gave at a moment it was never asked; non-numeric series entries are dropped
+ * individually, because the rest of the scrape is still real data.
+ */
+export function parseMonitorEvent(raw: unknown): MonitorSample | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const e = raw as Record<string, unknown>;
+	if (typeof e.timestamp !== "number") return null;
+	if (typeof e.series !== "object" || e.series === null) return null;
+	const series: Record<string, number> = {};
+	for (const [name, value] of Object.entries(e.series as Record<string, unknown>)) {
+		if (typeof value === "number" && Number.isFinite(value)) series[name] = value;
+	}
+	if (Object.keys(series).length === 0) return null;
+	return { timestamp: e.timestamp, series };
+}
+
 export type SSEMessageHandler = (metrics: LoadTestMetrics) => void;
 export type SSEErrorHandler = (error: Error) => void;
 export type SSECloseHandler = () => void;
 /** One step execution of a scenario run, from the `step` event. */
 export type SSEStepHandler = (step: ScenarioStepEvent) => void;
+/** One scrape of the run's monitored endpoint, from the `monitor` event. */
+export type SSEMonitorHandler = (sample: MonitorSample) => void;
 
 export class SSEClient {
 	private eventSource: EventSource | null = null;
@@ -133,15 +157,18 @@ export class SSEClient {
 	 * One client for both run types, because there is one stream: a load run
 	 * publishes `metrics` ticks and a scenario run publishes `step` events, on
 	 * the same ring with the same monotonic ids, and both end with `complete`.
-	 * `onStep` is optional so a load-test caller says nothing about steps rather
-	 * than passing a handler it has no use for.
+	 * `onStep` and `onMonitor` are optional so a caller says nothing about the
+	 * events it has no use for rather than passing handlers it will not read: a
+	 * load run emits no steps, and only a run configured with a `monitor` block
+	 * emits scrapes.
 	 */
 	connect(
 		runId: string,
 		onMessage: SSEMessageHandler,
 		onError: SSEErrorHandler,
 		onClose: SSECloseHandler,
-		onStep?: SSEStepHandler
+		onStep?: SSEStepHandler,
+		onMonitor?: SSEMonitorHandler
 	): void {
 		// Close existing connection
 		this.disconnect();
@@ -188,6 +215,20 @@ export class SSEClient {
 						if (step) onStep(step);
 					} catch (error) {
 						console.error("Failed to parse step:", error);
+					}
+				});
+			}
+
+			// Server vitals scraped alongside the run. Registered only when a
+			// caller asked for them - a run without a monitor block never
+			// emits one, so an unconditional listener would be dead wiring.
+			if (onMonitor) {
+				this.eventSource.addEventListener("monitor", (event) => {
+					try {
+						const sample = parseMonitorEvent(JSON.parse(event.data));
+						if (sample) onMonitor(sample);
+					} catch (error) {
+						console.error("Failed to parse monitor sample:", error);
 					}
 				});
 			}

--- a/app/src/stores/dashboard-store.test.ts
+++ b/app/src/stores/dashboard-store.test.ts
@@ -91,3 +91,45 @@ describe("dashboard-store live retention window", () => {
 		expect(state.breakpoint.p99Ms).toBe(250);
 	});
 });
+
+describe("dashboard-store monitor samples", () => {
+	beforeEach(() => {
+		useDashboardStore.getState().startRun("r");
+	});
+
+	it("starts empty, so a run without a monitor draws no vitals row", () => {
+		expect(useDashboardStore.getState().monitorSamples).toEqual([]);
+	});
+
+	it("appends scrapes in arrival order", () => {
+		const s = useDashboardStore.getState();
+		s.addMonitorSamples([{ timestamp: 1000, series: { cpu: 1 } }]);
+		s.addMonitorSamples([{ timestamp: 2000, series: { cpu: 2 } }]);
+
+		expect(useDashboardStore.getState().monitorSamples.map((m) => m.timestamp)).toEqual([
+			1000, 2000,
+		]);
+	});
+
+	it("bounds the buffer by the retained-tick ceiling", () => {
+		// A scrape can be configured faster than the tick cadence, so this array
+		// needs its own cap - an overnight soak at 250ms would otherwise grow
+		// without limit beside a series that is trimmed.
+		const s = useDashboardStore.getState();
+		s.setMaxRetainedTicks(5);
+		s.addMonitorSamples(
+			Array.from({ length: 12 }, (_, i) => ({ timestamp: i, series: { cpu: i } }))
+		);
+
+		const kept = useDashboardStore.getState().monitorSamples;
+		expect(kept).toHaveLength(5);
+		expect(kept[0].timestamp).toBe(7);
+	});
+
+	it("clears the samples when a new run starts", () => {
+		const s = useDashboardStore.getState();
+		s.addMonitorSamples([{ timestamp: 1000, series: { cpu: 1 } }]);
+		useDashboardStore.getState().startRun("r2");
+		expect(useDashboardStore.getState().monitorSamples).toEqual([]);
+	});
+});

--- a/app/src/stores/dashboard-store.ts
+++ b/app/src/stores/dashboard-store.ts
@@ -8,7 +8,7 @@
 // Dashboard State Store (Load Test Metrics)
 
 import { create } from "zustand";
-import type { LoadTestMetrics, RunReport } from "@/types";
+import type { LoadTestMetrics, MonitorSample, RunReport } from "@/types";
 import { type Breakpoint } from "@/modules/dashboard/utils/computeBreakpoint";
 import { useClientSettingsStore } from "./client-settings-store";
 import {
@@ -61,6 +61,17 @@ interface DashboardState {
 	isStreaming: boolean;
 	currentMetrics: LoadTestMetrics | null;
 	historicalMetrics: LoadTestMetrics[];
+	/**
+	 * Server vitals scraped during this run, oldest first. Kept beside the ticks
+	 * rather than merged into them: the two are sampled by different clocks, and
+	 * the join onto the tick timeline happens at render time
+	 * ({@link joinMonitorToTimeline}) so a changing retention window cannot
+	 * strand a reading on a tick that has rolled out.
+	 *
+	 * Empty for a run that configured no monitor, which is what the chart row
+	 * reads to stay out of the way entirely.
+	 */
+	monitorSamples: MonitorSample[];
 	finalReport: RunReport | null;
 	error: string | null;
 	activeView: DashboardView;
@@ -105,6 +116,7 @@ interface DashboardState {
 	setLiveWindowSeconds: (seconds: number | null) => void;
 	setMaxRetainedTicks: (ticks: number) => void;
 	addMetricsBatch: (batch: LoadTestMetrics[]) => void;
+	addMonitorSamples: (batch: MonitorSample[]) => void;
 	setFinalReport: (report: RunReport) => void;
 	setError: (error: string | null) => void;
 	setActiveView: (view: DashboardView) => void;
@@ -117,6 +129,7 @@ export const useDashboardStore = create<DashboardState>((set) => ({
 	isStreaming: false,
 	currentMetrics: null,
 	historicalMetrics: [],
+	monitorSamples: [],
 	finalReport: null,
 	error: null,
 	activeView: "metrics",
@@ -136,6 +149,7 @@ export const useDashboardStore = create<DashboardState>((set) => ({
 			isStreaming: true,
 			currentMetrics: null,
 			historicalMetrics: [],
+			monitorSamples: [],
 			finalReport: null,
 			error: null,
 			activeView: "metrics",
@@ -212,6 +226,22 @@ export const useDashboardStore = create<DashboardState>((set) => ({
 				peakConcurrency: peak,
 				breakpoint: bp,
 			};
+		}),
+
+	/**
+	 * Append scrapes, bounded by the same tick ceiling the series is.
+	 *
+	 * A scrape can be configured faster than the tick cadence, so the bound is
+	 * on this array's own length rather than derived from the ticks - otherwise
+	 * a 250ms scrape over an overnight soak would grow without limit beside a
+	 * series that is trimmed.
+	 */
+	addMonitorSamples: (batch) =>
+		set((state) => {
+			if (batch.length === 0) return state;
+			const merged = [...state.monitorSamples, ...batch];
+			const cap = state.maxRetainedTicks;
+			return { monitorSamples: merged.length > cap ? merged.slice(-cap) : merged };
 		}),
 
 	setFinalReport: (report) =>

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -24,6 +24,7 @@ import type {
 	ScriptPart,
 	HttpVersion,
 	RunThresholds,
+	RunMonitorConfig,
 } from "./domain";
 
 // API Response wrapper
@@ -397,6 +398,12 @@ export interface StartLoadTestRequest {
 	// `thresholdValidation`. Omitted entirely when none were declared - the
 	// engine rejects an empty object rather than starting an unjudged run.
 	thresholds?: RunThresholds;
+
+	// The server-vitals endpoint to scrape during the run. camelCase for the
+	// same reason `thresholds` is - these are the engine's own field names.
+	// Omitted entirely when no endpoint was given; the engine rejects a block
+	// with no `series` rather than starting a run that scrapes nothing.
+	monitor?: RunMonitorConfig;
 }
 
 export interface StartLoadTestResponse {

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -706,6 +706,26 @@ export interface RunThresholds {
 	minThroughputRps?: number;
 }
 
+/**
+ * The server-vitals endpoint a run scrapes alongside its own metrics, so the
+ * target's CPU or memory can be read on the same timeline as p99 and rps.
+ *
+ * Keys are the engine's own (`monitor` on `POST /runs`), which is why they are
+ * camelCase where the rest of `LoadTestConfig` is not - the same reason
+ * {@link RunThresholds} is. The engine rejects a block with no `series`, so the
+ * whole object is omitted rather than sent empty when monitoring is off.
+ */
+export interface RunMonitorConfig {
+	/** http(s) URL of a Prometheus `/metrics` or flat-JSON status endpoint. */
+	url: string;
+	/** Scrape cadence; the engine accepts 250-60000, defaulting to 1000. */
+	intervalMs?: number;
+	/** `prometheus` (text exposition) or `json` (flat object of numbers). */
+	format?: "prometheus" | "json";
+	/** Metric names to read out of the body - at least one, at most eight. */
+	series: string[];
+}
+
 export interface LoadTestConfig {
 	duration_seconds?: number;
 	rps?: number;
@@ -729,6 +749,23 @@ export interface LoadTestConfig {
 	max_in_flight?: number;
 	/** Absent when the run declared no budgets - never an empty object. */
 	thresholds?: RunThresholds;
+	/** Absent when the run monitors no endpoint - never an empty object. */
+	monitor?: RunMonitorConfig;
+}
+
+/**
+ * One scrape of a run's monitored endpoint, as `GET /runs/:id/monitor` returns
+ * it and as the live `monitor` SSE frame carries it - one shape for both, so
+ * the live overlay and the history overlay are drawn from identical rows.
+ *
+ * `timestamp` (Unix ms) rather than an elapsed offset is what the join onto the
+ * run's own timeline uses: a tick's `elapsed_seconds` is measured from the
+ * first *persisted* tick, while the scrape starts with the run.
+ */
+export interface MonitorSample {
+	timestamp: number;
+	/** Metric name -> value, for the names the run asked for. */
+	series: Record<string, number>;
 }
 
 /**
@@ -1013,6 +1050,20 @@ export interface RunReport {
 		testsPassed: number;
 		testsFailed: number;
 		successRate: number;
+	};
+	/**
+	 * What the run's server-vitals scrape recorded ({@link RunMonitorConfig}).
+	 *
+	 * `undefined` is a run that monitored nothing - not a target that reported
+	 * zeros - so a report without it renders exactly as it did before the
+	 * monitor existed. `samples` is what the history view gates its
+	 * `GET /runs/:id/monitor` fetch on: a run whose every scrape failed has a
+	 * section, a `failures` count, and no series to draw.
+	 */
+	monitor?: {
+		samples: number;
+		failures: number;
+		series: Record<string, { min: number; max: number; avg: number; count: number }>;
 	};
 	/**
 	 * The run's verdict against the budgets it declared ({@link RunThresholds}).

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -418,13 +418,18 @@ collection run's per-step progress.
   so a `CLOSED` readyState is treated as terminal. Transient `CONNECTING` errors are left to the
   browser's built-in `EventSource` retry. At run end the app converges on the stored report
   (`GET /runs/:id/report`) rather than reconnecting to the stream.
-- **Event Handling**: `metrics` events, `step` events, `complete` event, `error` handling
+- **Event Handling**: `metrics` events, `step` events, `monitor` events, `complete` event,
+  `error` handling
 - **Metrics Parsing**: `mapSseMetrics()` transforms the engine's camelCase blob to the frontend
   `LoadTestMetrics` shape (includes drops, queue-wait, percentiles, bytes, status-code map)
 - **Step Parsing**: `parseStepEvent()` narrows a scenario run's `step` payload and returns `null`
   for one it cannot read. A malformed event is **dropped, never defaulted** - the step list keys
   on `(iteration, stepIndex)`, so a defaulted `0:0` would collide with the real first step's row
   rather than merely say nothing.
+- **Monitor Parsing**: `parseMonitorEvent()` narrows a `monitor` frame the same way and returns
+  `null` for one it cannot read. A sample defaulted to `timestamp: 0` would join onto the very
+  start of the run's timeline and draw a reading at a moment it was never taken; individual
+  non-numeric entries are dropped, because the rest of the scrape is still real data.
 
 ### Usage
 
@@ -434,7 +439,8 @@ sseClient.connect(
   onMessage: (metrics: LoadTestMetrics) => void,
   onError: (error: Error) => void,
   onClose: () => void,
-  onStep?: (step: ScenarioStepEvent) => void   // scenario runs only
+  onStep?: (step: ScenarioStepEvent) => void,     // scenario runs only
+  onMonitor?: (sample: MonitorSample) => void     // runs with a `monitor` block only
 );
 
 sseClient.disconnect();
@@ -448,6 +454,9 @@ sseClient.isConnected(): boolean
 - **`step`**: One step execution of a scenario run - `{iteration, stepIndex, name, outcome,
   statusCode, latencyMs}`. Listened for only when `onStep` is passed, since a load run never
   emits one.
+- **`monitor`**: One scrape of the run's monitored endpoint - `{timestamp, series}`. Listened
+  for only when `onMonitor` is passed. Interleaved with `metrics` ticks on one id space, so
+  `Last-Event-ID` resume replays both in the order they happened.
 - **`complete`**: The run reached a terminal status
 - **`error`**: Connection error (triggers reconnection)
 - **`open`**: Connection established
@@ -503,6 +512,11 @@ export const API_ENDPOINTS = {
   // Time-series metrics (JSON, paginated) - used to hydrate history
   STATS_TIME_SERIES: (runId: string, limit = 5000, offset = 0) =>
     `/runs/${runId}/metrics?limit=${limit}&offset=${offset}`,
+
+  // Server vitals scraped during the run (JSON, paginated, same envelope).
+  // Fetched by the history view only when the report says the run recorded some.
+  RUN_MONITOR: (runId: string, limit = 5000, offset = 0) =>
+    `/runs/${runId}/monitor?limit=${limit}&offset=${offset}`,
 };
 ```
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -478,6 +478,7 @@ Because the value arrives asynchronously, the store seeds `liveWindowSeconds` wi
   isStreaming: boolean
   currentMetrics: LoadTestMetrics | null
   historicalMetrics: LoadTestMetrics[]  // Trimmed to liveWindowSeconds (cap: maxRetainedTicks)
+  monitorSamples: MonitorSample[]       // Server vitals scraped this run (cap: maxRetainedTicks)
   liveWindowSeconds: number | null             // Live retention window; null = full run
   finalReport: RunReport | null
   error: string | null
@@ -495,11 +496,21 @@ Because the value arrives asynchronously, the store seeds `liveWindowSeconds` wi
 const {
   startRun, stopRun, setStreaming,
   addMetricsBatch,  // Efficiently fold batch into history and update aggregates
+  addMonitorSamples, // Append scraped server vitals, bounded by maxRetainedTicks
   setFinalReport, setError, setActiveView, setStopping,
   setLiveWindowSeconds,  // Update the live retention window (from useLiveChartSettings)
   setMaxRetainedTicks
 } = useDashboardStore();
 ```
+
+`monitorSamples` is kept **beside** the ticks rather than merged into them: the
+two are sampled by different clocks (the engine's tick cadence and the user's
+scrape interval), so they are joined onto one x axis at render time by
+`joinMonitorToTimeline` - which is also where a failed scrape becomes a gap in
+the line rather than a plateau. The array is empty for a run that configured no
+monitor, and that emptiness is what keeps the vitals chart row off the dashboard
+entirely. It carries its own copy of the tick ceiling because a scrape can be
+configured faster than the tick cadence.
 
 There is deliberately no store-wide `reset`: `startRun` already wipes the series,
 the report and the aggregates, and a reset on top of it nulls `currentRunId` -
@@ -1058,6 +1069,7 @@ runs: {
   detail: (id) => ["runs", "detail", id],
   report: (id) => ["runs", "report", id],
   timeSeries: (id) => ["runs", "timeSeries", id],
+  monitorSeries: (id) => ["runs", "monitorSeries", id],   // scraped server vitals, when the run had a monitor
   samples: (id) => ["runs", "samples", id],               // captured response bodies, fetched lazily
 },
 // environments mirrors collections; globals / cookies / health / config /

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -503,6 +503,13 @@ const {
 } = useDashboardStore();
 ```
 
+The load-test dialog seeds its scrape cadence and bounds its metric list from
+the engine's `monitorIntervalMs` / `monitorMaxSeries` settings, through
+`useMonitorSettings` - the same read-the-engine's-copy arrangement
+`useLiveChartSettings` uses above, and for a sharper reason: this dialog always
+sends an explicit `intervalMs`, so a renderer-local default would mean the
+setting never applied to a run started here at all.
+
 `monitorSamples` is kept **beside** the ticks rather than merged into them: the
 two are sampled by different clocks (the engine's tick cadence and the user's
 scrape interval), so they are joined onto one x axis at render time by

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -459,6 +459,8 @@ on disk, one in memory:
 | `maxSampleBytes`    | `2097152` | 0–1073741824 | Total captured body bytes one load run may store. Once spent, samples keep their headers and metadata and only their bodies are dropped; the report counts them as `sampling.sampleBodiesDropped`. |
 | `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results, **including captured response bodies**) are pruned at startup and after each run finishes. `0` = unlimited. Captured data is stored verbatim, so this doubles as its expiry. |
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
+| `monitorIntervalMs` | `1000`    | 250–60000    | Scrape cadence for a [`monitor` block](#the-monitor-block-server-vitals) that names no `intervalMs` of its own. Read per run, so a change applies to the next run started. The *bounds* on a block's own `intervalMs` are fixed at 250–60000 either way - they exist to stop a cadence that measures the scraper rather than the target. |
+| `monitorMaxSeries`  | `8`       | 1–64         | How many metric names one run may chart from its monitored endpoint. A longer `series` list is a `400`. Raising it past 4 repeats chart colours (the categorical palette has four line-legible hues). |
 
 In-progress (`running`/`pending`) runs are never pruned.
 
@@ -1743,9 +1745,9 @@ of those three carry anything.
 {
   "monitor": {
     "url": "http://localhost:9100/metrics",  // required; http(s), loopback and private allowed
-    "intervalMs": 1000,                      // optional, default 1000; 250-60000
+    "intervalMs": 1000,                      // optional, defaults to `monitorIntervalMs`; 250-60000
     "format": "prometheus",                  // optional, default "prometheus"; or "json"
-    "series": [                              // required; 1-8 metric names
+    "series": [                              // required; 1 to `monitorMaxSeries` names
       "node_cpu_seconds_total",
       "process_resident_memory_bytes"
     ]
@@ -1770,11 +1772,18 @@ counted as a gap in the report's `monitor.failures`. A failing scrape never
 fails the run; after five consecutive failures the engine logs once and backs
 off to twice the configured interval until one succeeds.
 
+Two of the limits are settings rather than constants: `intervalMs` defaults to
+**`monitorIntervalMs`** when the block omits it, and the `series` ceiling is
+**`monitorMaxSeries`** (see [GET /config](#get-config)). Both are read per run,
+so a change applies to the next run started - no restart. The interval *bounds*
+are fixed, because a cadence below 250ms measures the scraper rather than the
+target and one above a minute records nothing on a short run.
+
 Loopback and private addresses are deliberately allowed: this is a local tool
 scraping the user's own infrastructure. An unusable block (no `url`, a
-non-http(s) scheme, no `series`, more than eight, an out-of-range `intervalMs`,
-an unknown `format`) is a `400` `invalid_run_config` naming the field, before
-the run row is created.
+non-http(s) scheme, no `series`, more than `monitorMaxSeries`, an out-of-range
+`intervalMs`, an unknown `format`) is a `400` `invalid_run_config` naming the
+field, before the run row is created.
 
 #### The `scenario` block (collection runs)
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1674,6 +1674,7 @@ Start a load test run (Vayu Mode).
   "environmentId": "env_1234567890",  // Optional
   "tests": "",               // Optional, deferred validation script
   "thresholds": {},          // Optional pass/fail budgets - see below
+  "monitor": {},             // Optional server-vitals scrape - see below
   "followRedirects": true,   // Optional, default true - see POST /execute
   "maxRedirects": 10,        // Optional, default 10
   "httpVersion": "auto"      // Optional: "auto" | "http1.1" | "http2", default "auto" - see POST /execute
@@ -1726,6 +1727,52 @@ of nothing but HTTP 500s has a transport error rate of zero.
 The verdict is the run's, not the process's: a run **stopped early** is judged on
 what it measured up to that point, and its status stays `completed` / `stopped`
 whatever the verdict says. A failing budget is reported, never a failed run.
+
+#### The `monitor` block (server vitals)
+
+A run may name a metrics endpoint on the target, which the engine scrapes for
+the life of the run on **its own thread**. The samples are stored per run and
+served by [`GET /runs/:runId/monitor`](#get-runsrunidmonitor), streamed live as
+`monitor` frames on [`GET /runs/:runId/live`](#get-runsrunidlive), and summarised
+in the report's `monitor` section. Without the block nothing is scraped and none
+of those three carry anything.
+
+```jsonc
+{
+  "monitor": {
+    "url": "http://localhost:9100/metrics",  // required; http(s), loopback and private allowed
+    "intervalMs": 1000,                      // optional, default 1000; 250-60000
+    "format": "prometheus",                  // optional, default "prometheus"; or "json"
+    "series": [                              // required; 1-8 metric names
+      "node_cpu_seconds_total",
+      "process_resident_memory_bytes"
+    ]
+  }
+}
+```
+
+`format` decides how the body is read:
+
+- **`prometheus`** - the text exposition format. Comment and blank lines are
+  skipped, a trailing exposition timestamp is ignored, and a value that is not a
+  finite number (`NaN`, `+Inf`) is dropped. **Samples sharing a name across
+  label sets are summed**, so `node_cpu_seconds_total{cpu="0"}` and
+  `{cpu="1"}` chart as one series.
+- **`json`** - a flat object of numbers, where `series` lists the keys to read.
+  A key that is absent or non-numeric is skipped.
+
+A name the body does not carry is **absent** from that sample rather than zero,
+and a scrape that reads nothing at all - a transport failure, an unreadable
+body, or a body carrying none of the requested names - stores no row and is
+counted as a gap in the report's `monitor.failures`. A failing scrape never
+fails the run; after five consecutive failures the engine logs once and backs
+off to twice the configured interval until one succeeds.
+
+Loopback and private addresses are deliberately allowed: this is a local tool
+scraping the user's own infrastructure. An unusable block (no `url`, a
+non-http(s) scheme, no `series`, more than eight, an out-of-range `intervalMs`,
+an unknown `format`) is a `400` `invalid_run_config` naming the field, before
+the run row is created.
 
 #### The `scenario` block (collection runs)
 
@@ -2268,6 +2315,40 @@ engine writes the tick object once, at write time. Two things follow:
 A run with no ticks returns `200` with an empty `data` array - only a run that
 does not exist is a `404`.
 
+### GET /runs/:runId/monitor
+
+Paginated **server vitals** scraped during the run - the samples the
+[`monitor` block](#the-monitor-block-server-vitals) collected. Same
+`{data, pagination}` envelope and the same `limit` / `offset` rules as
+`GET /runs/:runId/metrics`, so one pagination reader covers both.
+
+Its own endpoint rather than extra keys on the tick objects: that key set is the
+`/metrics` contract, and these samples land on the user's scrape cadence rather
+than the tick cadence, so they do not line up row for row.
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "timestamp": 1234567890,
+      "series": { "node_cpu_seconds_total": 3.75, "process_resident_memory_bytes": 1048576 }
+    }
+  ],
+  "pagination": { "total": 1, "limit": 5000, "offset": 0, "hasMore": false, "returned": 1 }
+}
+```
+
+`timestamp` is wall-clock Unix ms - when the engine scraped, not an elapsed
+offset - because a tick's `elapsed_seconds` is measured from the run's first
+*persisted* tick while the scrape starts with the run; joining the two series
+onto one timeline is what the wall clock is for. A series the target did not
+report in that scrape is **absent** from its `series` object rather than zero.
+
+A run that configured no monitor returns `200` with an empty `data` array; only
+a run that does not exist is a `404`. Samples are deleted with the run, like
+every other child row.
+
 ### GET /stats/:runId (deprecated)
 
 > **Prefer `GET /runs/:runId/live`** (above) for live dashboards - it replays a retained
@@ -2356,6 +2437,23 @@ data: {"event":"complete","runId":"run_1234567890"}
 and after a reload. A scenario run publishes no `metrics` ticks:
 its work is sequential, so per-tick aggregates would be a rate of one request at
 a time rather than anything about the sequence.
+
+**A run with a [`monitor` block](#the-monitor-block-server-vitals) also streams
+`monitor` events**, one per successful scrape, interleaved with its `metrics`
+ticks on the same ring and the same monotonic `id:` numbering - so
+`Last-Event-ID` resume replays both kinds in the order they happened:
+
+```
+event: monitor
+id: 12
+data: {"timestamp":1234567890,
+       "series":{"node_cpu_seconds_total":3.75,"process_resident_memory_bytes":1048576}}
+```
+
+The payload is byte-identical to one `data[]` entry of
+[`GET /runs/:runId/monitor`](#get-runsrunidmonitor), so the live overlay and the
+history overlay are drawn from the same rows. A scrape that read nothing emits
+no frame.
 
 **Field reference** (all keys emitted by `MetricsCollector::get_current_stats()`):
 
@@ -2735,6 +2833,12 @@ alone rather than erroring. **The response shape is the same either way.**
     "exemplarsDropped": 0, "sampleBodiesDropped": 12,
     "responseBodiesCaptured": 23
   },
+  "monitor": {
+    "samples": 60, "failures": 0,
+    "series": {
+      "node_cpu_seconds_total": { "min": 1.2, "max": 3.9, "avg": 2.6, "count": 60 }
+    }
+  },
   "testValidation": { "samplesTested": 500, "testsPassed": 498, "testsFailed": 2, "successRate": 99.6 },
   "thresholdValidation": {
     "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 47.2, "passed": true } ],
@@ -2795,6 +2899,16 @@ spent. `exemplarsDropped` counts per-status exemplars refused because
 `max_exemplar_results` was full, which only a target answering with more
 distinct status codes than that limit can reach. All three are absent on runs
 recorded before 0.15.0.
+
+`monitor` is present only for a run that declared a
+[`monitor` block](#the-monitor-block-server-vitals) - absent is "this run
+scraped nothing", never "the target reported zeros". `samples` counts successful
+scrapes and `failures` counts the ones that read nothing, so a section with
+`samples: 0` and a non-zero `failures` says the endpoint was unreachable for the
+whole run rather than that the run was not monitored. A series that never
+produced a reading is absent from `series` for the same reason. The per-sample
+readings are served separately by
+[`GET /runs/:runId/monitor`](#get-runsrunidmonitor).
 
 `results[].id` is the `results` row id, and the join key against
 `GET /runs/:runId/samples`. It is absent on reports served by an engine older

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -659,13 +659,19 @@ row exists - and the executor is the only thing that differs.
 - **Main Thread**: HTTP server, request routing
 - **Worker Threads**: One per active load test (executes load strategy)
 - **Metrics Thread**: One per active load test (aggregates and streams metrics)
+- **Monitor Thread**: One per load test that declared a `monitor` block - it
+  scrapes the target's metrics endpoint on its own interval. Separate from the
+  metrics thread because that one is a fixed-cadence sampler with no deadline
+  compensation: a blocking HTTP call inside it would delay every subsequent tick
+  by the scrape's latency, and a hanging endpoint would end live metrics for the
+  whole run.
 - **Event Loop Threads**: One per CPU core (handles curl_multi I/O)
 
 Shutdown unwinds that in a fixed order, because every one of these threads
 holds references to state `main` owns: HTTP server stopped → run workers
-signalled and joined (each joins its own metrics thread and stops its event
-loop first) → `curl_global_cleanup` → `Database` / `RunManager` destroyed at
-scope exit. Nothing is detached.
+signalled and joined (each joins its own metrics and monitor threads and stops
+its event loop first) → `curl_global_cleanup` → `Database` / `RunManager`
+destroyed at scope exit. Nothing is detached.
 
 ## Performance Characteristics
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -326,7 +326,7 @@ the history. A run is a victim when it falls **beyond the `maxRunsRetained` most
 (ordered by `start_time`) **or** its `start_time` is older than **`runRetentionDays`** days;
 either knob is disabled by `0`. Runs still `running`/`pending` are never pruned and never count
 toward the cap. Deletion goes through the `delete_run` cascade (runs + their `metric_ticks` +
-their `results`), batched inside transactions that release the DB mutex between batches so a large
+their `monitor_samples` + their `results`), batched inside transactions that release the DB mutex between batches so a large
 backlog cannot stall `/health`, SSE, or the runs poll. The cascade itself lives in one function
 (`remove_run_cascade_locked`), which both `delete_run` and `prune_runs` call, so a new child table
 is wired into both at once. `prune_runs_configured()` reads the two
@@ -400,6 +400,44 @@ Two consequences of the row being the tick:
 Latency percentiles in a tick are the **windowed** (rolling) values sampled from the
 `hdr_interval_recorder` for that interval - the whole-run cumulative ones live in
 [`runs.summary`](#runs), never here.
+
+---
+
+### `monitor_samples`
+
+The **server vitals** a run scraped from a target endpoint it was configured to
+watch (`monitor` on `POST /runs`): one row per successful scrape, written by the
+run's own scrape thread. Struct is `db::MonitorSample`. Auto-created by
+`sync_schema()`.
+
+| Column      | Type       | Notes                                          |
+|-------------|------------|------------------------------------------------|
+| `id`        | INTEGER PK | Autoincrement                                  |
+| `run_id`    | TEXT       | FK → `runs.id`                                 |
+| `timestamp` | INTEGER    | Unix ms - when the engine scraped              |
+| `payload`   | TEXT       | JSON: the sample object (below)                |
+
+`payload` **is** one `data[]` entry of `GET /runs/:runId/monitor`, and the
+`data:` of a live `monitor` SSE frame - one shape for both, built by
+`vayu::core::build_monitor_sample_payload`:
+
+```json
+{
+  "timestamp": 1730000001000,
+  "series": { "node_cpu_seconds_total": 3.75, "process_resident_memory_bytes": 1048576 }
+}
+```
+
+**Its own table rather than wider `metric_ticks` rows.** That payload's key set
+is the `GET /runs/:runId/metrics` contract, pinned by `stats_route_test.cpp`;
+and a scrape lands on the user's own cadence (250-60000ms), which does not line
+up row for row with the 1/s tick. A scrape that read nothing writes no row at
+all - a stored sample with no readings would draw a line through a hole in the
+data - so gaps are counted in the run summary's `monitor.failures` instead.
+
+Deleted with the run by the same cascade (`remove_run_cascade_locked`).
+
+---
 
 **The EAV `metrics` table this replaced is gone.** It stored one row per
 (`run_id`, `name`, `timestamp`) sample, ~20 rows per second of a run, and was kept read-only
@@ -625,6 +663,7 @@ for fresh **and** pre-existing databases, so adding an index is additive and nee
 | Index                        | Column                  | Query paths that rely on it                                                                                                                       |
 |------------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | `idx_metric_ticks_run_id`    | `metric_ticks.run_id`   | `get_metric_ticks_paginated` / `count_metric_ticks` (every `GET /runs/:id/metrics`), `get_metric_ticks_since` (the legacy SSE poll), and the `remove_all` in the run cascade |
+| `idx_monitor_samples_run_id` | `monitor_samples.run_id`| `get_monitor_samples_paginated` / `count_monitor_samples` (every `GET /runs/:id/monitor`) and the `remove_all` in the run cascade                  |
 | `idx_results_run_id`         | `results.run_id`        | `get_results` and the `remove_all` in `delete_run`                                                                                                |
 | `idx_result_bodies_run_id`   | `result_bodies.run_id`  | `get_result_bodies_paginated` / `count_result_bodies` (every `GET /runs/:id/samples`) and the `remove_all` in the run cascade                     |
 | `idx_body_blobs_run_id`      | `body_blobs.run_id`     | The `remove_all` in the run cascade                                                                                                               |

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -285,6 +285,7 @@ add_library(vayu_core STATIC
     src/core/metrics_collector.cpp
     src/core/sample_capture.cpp
     src/core/threshold_eval.cpp
+    src/core/monitor.cpp
     ${PLATFORM_SOURCES}
 )
 
@@ -459,6 +460,7 @@ if(VAYU_BUILD_TESTS)
         tests/sample_capture_test.cpp
         tests/load_pacing_test.cpp
         tests/threshold_eval_test.cpp
+        tests/monitor_test.cpp
         tests/run_manager_test.cpp
         tests/run_route_test.cpp
         tests/run_stop_test.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -263,6 +263,32 @@ constexpr int64_t OAUTH2_REFRESH_POLL_INTERVAL_MS = 100;
 } // namespace server
 
 /**
+ * @brief The server-vitals monitor a run may scrape alongside its own metrics.
+ *
+ * The two a user reaches for are config-backed (`monitorIntervalMs`,
+ * `monitorMaxSeries`) and these are their seeds. The other three are rails
+ * rather than preferences: the interval bounds exist to stop a cadence that
+ * measures the scraper instead of the target, and the backoff threshold is how
+ * politely the loop gives up on a dead endpoint - the same reason
+ * `threshold_eval`'s budget ranges are constants.
+ */
+namespace monitor {
+/// Floor on `monitor.intervalMs`. Below this the scrape's own latency is a
+/// large share of the interval, so the series measures the scraper.
+constexpr int MIN_INTERVAL_MS = 250;
+/// Ceiling on it. A run shorter than one interval would record nothing.
+constexpr int MAX_INTERVAL_MS = 60000;
+/// Cadence for a block that names no `intervalMs` (config `monitorIntervalMs`).
+constexpr int DEFAULT_INTERVAL_MS = 1000;
+/// How many metrics one run may chart (config `monitorMaxSeries`). Each is a
+/// line on one overlay and a name matched against every exposition line.
+constexpr size_t MAX_SERIES = 8;
+/// Consecutive failed scrapes before the loop logs once and backs off. Below
+/// this a scrape failure is a gap in the series and nothing else.
+constexpr int FAILURES_BEFORE_BACKOFF = 5;
+} // namespace monitor
+
+/**
  * @brief Server-Sent Events (SSE) configuration
  */
 namespace sse {

--- a/engine/include/vayu/core/monitor.hpp
+++ b/engine/include/vayu/core/monitor.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file monitor.hpp
+ * @brief Pure core for a run's server-vitals monitor: what a `monitor` block
+ *        may say, how a scraped body becomes numbers, and what the run reports
+ *        about the whole scrape.
+ *
+ * A run knows everything about the client side and nothing about the target.
+ * The monitor closes that gap by sampling a metrics endpoint the user already
+ * exposes, on its own cadence, beside the run's own ticks.
+ *
+ * The halves live together for the same reason `threshold_eval.hpp`'s do:
+ * `validate_monitor_config` (the route's gate) and `monitor_config_from` (what
+ * the run actually executes) read one description of the block, so a field the
+ * route accepts cannot be one the run silently ignores. Both are total over
+ * arbitrary JSON - the route's copy is handed a client body, and the run's is
+ * handed a stored config snapshot which may have been written by an older
+ * engine or hand-edited.
+ */
+
+#include <map>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace vayu::core {
+
+/** Which exposition format the scraped endpoint speaks. */
+enum class MonitorFormat {
+    /// Prometheus text exposition: `name{labels} value [timestamp]` lines.
+    Prometheus,
+    /// A flat JSON object of numbers, keyed by the requested series names.
+    Json,
+};
+
+/** Bounds the route enforces and the run relies on. */
+namespace monitor_limits {
+constexpr int MIN_INTERVAL_MS     = 250;
+constexpr int MAX_INTERVAL_MS     = 60000;
+constexpr int DEFAULT_INTERVAL_MS = 1000;
+/// Each named series is charted on one overlay; past a handful the chart is
+/// unreadable and every extra name costs a scan of the exposition body.
+constexpr size_t MAX_SERIES = 8;
+/// Consecutive failed scrapes before the loop logs once and backs off. Below
+/// this a scrape failure is a gap in the series and nothing else.
+constexpr int FAILURES_BEFORE_BACKOFF = 5;
+} // namespace monitor_limits
+
+/** A validated monitor block, ready for the scrape loop. */
+struct MonitorConfig {
+    std::string url;
+    int interval_ms      = monitor_limits::DEFAULT_INTERVAL_MS;
+    MonitorFormat format = MonitorFormat::Prometheus;
+    std::vector<std::string> series;
+};
+
+/**
+ * @brief Reject a `monitor` block the run could not act on.
+ *
+ * Reads @p config (the whole run config) and looks only at its `monitor` key -
+ * an absent or null one is valid, since monitoring is opt-in. Present means it
+ * must be an object naming an http(s) URL and at least one series.
+ *
+ * @return The reason the block is unusable, or `std::nullopt`.
+ */
+[[nodiscard]] std::optional<std::string> validate_monitor_config (
+const nlohmann::json& config);
+
+/**
+ * @brief The monitor block a run should execute, or `std::nullopt` for a run
+ *        that configured none (or configured one this engine cannot read).
+ *
+ * Total over arbitrary JSON: it applies the same rules as
+ * `validate_monitor_config` and returns nothing rather than throwing, so a
+ * hand-edited snapshot yields "no monitor" instead of a dead run thread.
+ */
+[[nodiscard]] std::optional<MonitorConfig> monitor_config_from (const nlohmann::json& config);
+
+/**
+ * @brief Pull the requested series out of one Prometheus exposition body.
+ *
+ * Comments (`#`) and blank lines are skipped, as is any line whose value is not
+ * a finite number (`NaN`, `+Inf`, a trailing timestamp is ignored). **Samples
+ * sharing a name across label sets are summed**: a labelled family
+ * (`node_cpu_seconds_total{cpu="0",…}`) is one series here, because a chart of
+ * the whole family is the reading the overlay exists to give.
+ *
+ * A name the body does not carry is absent from the result, never zero - "the
+ * target stopped exporting it" and "it is zero" are different answers.
+ */
+[[nodiscard]] std::map<std::string, double>
+parse_prometheus_exposition (const std::string& body, const std::vector<std::string>& series);
+
+/**
+ * @brief Pull the requested series out of a flat JSON object of numbers.
+ *
+ * A key that is absent, non-numeric or non-finite is skipped, for the same
+ * reason the Prometheus parser skips one. A body that is not a JSON object
+ * yields nothing rather than throwing.
+ */
+[[nodiscard]] std::map<std::string, double>
+parse_json_metrics (const std::string& body, const std::vector<std::string>& series);
+
+/// Dispatch to the parser @p format names.
+[[nodiscard]] std::map<std::string, double> parse_monitor_body (MonitorFormat format,
+const std::string& body,
+const std::vector<std::string>& series);
+
+/**
+ * @brief The stored `monitor_samples.payload` object, returned verbatim as one
+ *        `data[]` entry by `GET /runs/:id/monitor` and as the `data:` of a live
+ *        `monitor` SSE frame.
+ *
+ * One shape for both, so the live overlay and the history overlay are drawn
+ * from identical rows. The join onto the run's own timeline is by `timestamp`
+ * (wall clock) rather than an elapsed offset, because the tick series measures
+ * its elapsed seconds from the first *persisted* tick and the scrape loop
+ * starts with the run.
+ */
+[[nodiscard]] nlohmann::json build_monitor_sample_payload (int64_t timestamp,
+const std::map<std::string, double>& values);
+
+/**
+ * @brief Per-series min/max/avg over a whole run, plus what the scrape missed.
+ *
+ * Written by the monitor thread and read once the worker has joined it - the
+ * join is the happens-before edge, exactly as it is for the metrics collector.
+ */
+class MonitorTotals {
+    public:
+    /// Fold one successful scrape in. A series absent from @p values is left
+    /// untouched rather than counted as a zero sample.
+    void add (const std::map<std::string, double>& values);
+    /// Record a scrape that produced nothing (transport error, unreadable body).
+    void record_failure ();
+
+    [[nodiscard]] size_t samples () const {
+        return samples_;
+    }
+    [[nodiscard]] size_t failures () const {
+        return failures_;
+    }
+
+    /**
+     * @brief The run report's `monitor` section, in its wire shape.
+     *
+     * `{"samples":n,"failures":n,"series":{"<name>":{"min","max","avg","count"}}}`.
+     * A series that never produced a reading is absent, so the section never
+     * claims a measurement that was not taken.
+     */
+    [[nodiscard]] nlohmann::json to_summary () const;
+
+    private:
+    struct Accumulator {
+        double min   = 0.0;
+        double max   = 0.0;
+        double sum   = 0.0;
+        size_t count = 0;
+    };
+    std::map<std::string, Accumulator> series_;
+    size_t samples_  = 0;
+    size_t failures_ = 0;
+};
+
+} // namespace vayu::core

--- a/engine/include/vayu/core/monitor.hpp
+++ b/engine/include/vayu/core/monitor.hpp
@@ -32,6 +32,15 @@
 #include <string>
 #include <vector>
 
+#include "vayu/core/constants.hpp"
+
+namespace vayu::db {
+// Only `read_monitor_limits` touches a database, and only by reference - the
+// decision functions below hold none, which is what keeps them total over
+// arbitrary JSON.
+class Database;
+} // namespace vayu::db
+
 namespace vayu::core {
 
 /** Which exposition format the scraped endpoint speaks. */
@@ -42,18 +51,26 @@ enum class MonitorFormat {
     Json,
 };
 
-/** Bounds the route enforces and the run relies on. */
-namespace monitor_limits {
-constexpr int MIN_INTERVAL_MS     = 250;
-constexpr int MAX_INTERVAL_MS     = 60000;
-constexpr int DEFAULT_INTERVAL_MS = 1000;
-/// Each named series is charted on one overlay; past a handful the chart is
-/// unreadable and every extra name costs a scan of the exposition body.
-constexpr size_t MAX_SERIES = 8;
-/// Consecutive failed scrapes before the loop logs once and backs off. Below
-/// this a scrape failure is a gap in the series and nothing else.
-constexpr int FAILURES_BEFORE_BACKOFF = 5;
-} // namespace monitor_limits
+/// The bounds and seeds themselves live in `constants::monitor`, beside every
+/// other tunable's; this is the local spelling.
+namespace monitor_limits = constants::monitor;
+
+/**
+ * @brief The two limits a user can move, resolved from engine config.
+ *
+ * Passed in rather than read here so the functions below stay pure over
+ * arbitrary JSON and hold no `Database` - the same split
+ * `resolve_request_timeout_ms` draws in the execution route, where the caller
+ * resolves the configured default and the decision function only takes a
+ * number. The member defaults are the compile-time seeds, which is what lets a
+ * test (or any caller without a database to hand) omit the argument entirely.
+ */
+struct MonitorLimits {
+    /// Cadence for a block that names no `intervalMs` (`monitorIntervalMs`).
+    int default_interval_ms = monitor_limits::DEFAULT_INTERVAL_MS;
+    /// How many metric names one run may chart (`monitorMaxSeries`).
+    size_t max_series = monitor_limits::MAX_SERIES;
+};
 
 /** A validated monitor block, ready for the scrape loop. */
 struct MonitorConfig {
@@ -64,6 +81,19 @@ struct MonitorConfig {
 };
 
 /**
+ * @brief Read the `monitorIntervalMs` / `monitorMaxSeries` settings, falling
+ *        back to their compile-time seeds.
+ *
+ * One reader for both keys, so the route's gate and the run's own reader cannot
+ * disagree about which limits are in force - the same reason
+ * `read_auth_refresh_tuning` exists. A value outside the range `POST /config`
+ * enforces can only come from a hand-edited row, and is discarded rather than
+ * trusted: a zero interval is a tight scrape loop and a zero cap would reject
+ * every block a user could write.
+ */
+[[nodiscard]] MonitorLimits read_monitor_limits (vayu::db::Database& db);
+
+/**
  * @brief Reject a `monitor` block the run could not act on.
  *
  * Reads @p config (the whole run config) and looks only at its `monitor` key -
@@ -72,8 +102,8 @@ struct MonitorConfig {
  *
  * @return The reason the block is unusable, or `std::nullopt`.
  */
-[[nodiscard]] std::optional<std::string> validate_monitor_config (
-const nlohmann::json& config);
+[[nodiscard]] std::optional<std::string>
+validate_monitor_config (const nlohmann::json& config, const MonitorLimits& limits = {});
 
 /**
  * @brief The monitor block a run should execute, or `std::nullopt` for a run
@@ -83,7 +113,8 @@ const nlohmann::json& config);
  * `validate_monitor_config` and returns nothing rather than throwing, so a
  * hand-edited snapshot yields "no monitor" instead of a dead run thread.
  */
-[[nodiscard]] std::optional<MonitorConfig> monitor_config_from (const nlohmann::json& config);
+[[nodiscard]] std::optional<MonitorConfig>
+monitor_config_from (const nlohmann::json& config, const MonitorLimits& limits = {});
 
 /**
  * @brief Pull the requested series out of one Prometheus exposition body.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -23,6 +23,7 @@
 
 #include "vayu/core/constants.hpp"
 #include "vayu/core/metrics_collector.hpp"
+#include "vayu/core/monitor.hpp"
 #include "vayu/core/scenario_plan.hpp"
 #include "vayu/core/threshold_eval.hpp"
 #include "vayu/db/database.hpp"
@@ -35,6 +36,20 @@ class CookieJar;
 } // namespace vayu::http
 
 namespace vayu::core {
+
+/**
+ * @brief One wire-ready SSE frame: `event: <name>`, `id: <offset>`, `data:`.
+ *
+ * The single framing copy. `RunContext::append_event` builds through it under
+ * the ring's lock, and the extracted-for-testing `build_tick_payload` /
+ * `build_step_payload` delegate to it - so a run's `metrics`, `step` and
+ * `monitor` frames cannot drift into three shapes, and a consumer resuming from
+ * `Last-Event-ID` sees one id space across all of them.
+ */
+[[nodiscard]] inline std::string
+build_sse_frame (const std::string& event_name, const std::string& data, size_t offset) {
+    return "event: " + event_name + "\nid: " + std::to_string (offset) + "\ndata: " + data + "\n\n";
+}
 
 /**
  * @brief Ring capacity for a run's live tick topic: how many ticks fit in
@@ -97,6 +112,22 @@ struct RunContext {
     // itself and terminate. RunManager owns the handle instead - see
     // `run_workers_` - and joins it from a thread that is never the worker.
     std::thread metrics_thread;
+    /**
+     * The server-vitals scrape loop, spawned only for a run whose config
+     * carries a usable `monitor` block. Owned and joined exactly like
+     * `metrics_thread` - both exit on `is_running` and are joined by the worker
+     * before it writes the summary, which is what makes `monitor_totals`
+     * readable without a lock.
+     *
+     * It is a second thread rather than work on the metrics thread because that
+     * one is a fixed-cadence sampler with no deadline compensation: a blocking
+     * HTTP call inside it delays every subsequent tick by the scrape's latency,
+     * and a hanging endpoint would stop live metrics for the whole run.
+     */
+    std::thread monitor_thread;
+    /// Per-series totals for the report's `monitor` section; null when the run
+    /// configured no monitor. Written by `monitor_thread`, read after its join.
+    std::unique_ptr<MonitorTotals> monitor_totals;
     std::atomic<bool> should_stop{ false };
     std::atomic<bool> is_running{ false };
     nlohmann::json config;
@@ -207,6 +238,36 @@ struct RunContext {
 
     void append_tick (std::string payload) {
         std::lock_guard<std::mutex> lock (tick_mtx);
+        append_locked (std::move (payload));
+    }
+
+    /**
+     * @brief Frame one SSE event and publish it, assigning its id under the
+     *        ring's own lock.
+     *
+     * The id must be the slot the frame lands in, and a run with a monitor has
+     * **two** producers on this ring - the metrics thread and the scrape loop.
+     * Reading `published_count` and appending as two steps would hand both the
+     * same id under interleaving, which breaks `Last-Event-ID` resume (a
+     * consumer that saw the duplicate skips whichever frame it did not read).
+     * Framing here makes that impossible rather than unlikely.
+     */
+    void append_event (const std::string& event_name, const std::string& data) {
+        std::lock_guard<std::mutex> lock (tick_mtx);
+        size_t offset = tick_base_offset + tick_buffer.size ();
+        append_locked (build_sse_frame (event_name, data, offset));
+    }
+    [[nodiscard]] TickBatch ticks_since (size_t from) const {
+        std::lock_guard<std::mutex> lock (tick_mtx);
+        size_t end = tick_base_offset + tick_buffer.size ();
+        if (from >= end) return { {}, from };
+        size_t start = from < tick_base_offset ? tick_base_offset : from;
+        auto begin_it =
+        tick_buffer.begin () + static_cast<std::ptrdiff_t> (start - tick_base_offset);
+        return { { begin_it, tick_buffer.end () }, end };
+    }
+    /// Push one already-framed payload and trim the ring. Caller holds `tick_mtx`.
+    void append_locked (std::string payload) {
         tick_buffer.push_back (std::move (payload));
         // A loop, not an `if`: the cap can drop between appends, and one
         // eviction per append would take the whole run to converge on it.
@@ -218,15 +279,7 @@ struct RunContext {
         published_count.store (tick_base_offset + tick_buffer.size (),
         std::memory_order_release);
     }
-    [[nodiscard]] TickBatch ticks_since (size_t from) const {
-        std::lock_guard<std::mutex> lock (tick_mtx);
-        size_t end = tick_base_offset + tick_buffer.size ();
-        if (from >= end) return { {}, from };
-        size_t start = from < tick_base_offset ? tick_base_offset : from;
-        auto begin_it =
-        tick_buffer.begin () + static_cast<std::ptrdiff_t> (start - tick_base_offset);
-        return { { begin_it, tick_buffer.end () }, end };
-    }
+
     [[nodiscard]] size_t tick_count () const {
         std::lock_guard<std::mutex> lock (tick_mtx);
         return tick_buffer.size ();
@@ -455,6 +508,10 @@ struct RunSummaryInputs {
     // which leaves the report's scenario section out entirely rather than
     // showing it zeros - the section exists to say what a sequence did.
     std::optional<nlohmann::json> scenario;
+    // What the server-vitals scrape recorded, under the summary's `monitor`
+    // key. Absent for a run that configured no monitor - the report then omits
+    // the section entirely rather than showing a run that scraped nothing.
+    std::optional<nlohmann::json> monitor;
 };
 
 /**
@@ -629,5 +686,25 @@ vayu::db::Database* db_ptr,
 bool verbose,
 RunManager& manager);
 void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* db_ptr);
+
+/**
+ * @brief Scrape @p config's metrics endpoint for the life of the run.
+ *
+ * Runs on `RunContext::monitor_thread`. Each pass GETs the URL with a timeout
+ * well under the interval, stores what it read as a `monitor_samples` row and
+ * publishes it as a live `monitor` SSE frame, then sleeps out the rest of the
+ * interval in short slices so a finishing run is never held up by a long one.
+ *
+ * A failed scrape is a **gap**: it is counted, it never throws outward, and it
+ * never fails the run. After `FAILURES_BEFORE_BACKOFF` consecutive failures it
+ * logs once and keeps trying on a doubled interval, so an endpoint that went
+ * away for the whole run costs one log line rather than one per scrape.
+ *
+ * Declared here so a test can drive the loop against a mock endpoint without an
+ * HTTP server in front of it; the production caller is `RunManager::start_run`.
+ */
+void collect_monitor (std::shared_ptr<RunContext> context,
+vayu::db::Database* db_ptr,
+MonitorConfig config);
 
 } // namespace vayu::core

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -228,6 +228,15 @@ class Database {
     std::vector<MetricTick> get_metric_ticks_since (const std::string& run_id, int64_t last_id);
     int64_t count_metric_ticks (const std::string& run_id);
 
+    // Monitor samples - one wide row per scrape of a run's configured
+    // server-vitals endpoint. Deliberately not part of `metric_ticks`: that
+    // payload's key set is the GET /runs/:id/metrics contract.
+    void add_monitor_sample (const MonitorSample& sample);
+    // Ordered (timestamp, id) so a page boundary never splits a sample.
+    std::vector<MonitorSample>
+    get_monitor_samples_paginated (const std::string& run_id, int64_t limit, int64_t offset);
+    int64_t count_monitor_samples (const std::string& run_id);
+
     // Results
     void add_result (const Result& result);
     /**

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -894,6 +894,22 @@ struct MetricTick {
     std::string payload; // JSON object (see build_metric_tick_payload)
 };
 
+/**
+ * @brief One scrape of the run's configured server-vitals endpoint.
+ *
+ * Shaped exactly like `MetricTick` and stored in its own table on purpose: the
+ * tick payload's key set is the `GET /runs/:id/metrics` contract, and external
+ * numbers arriving at their own cadence are not part of it. `payload` is the
+ * object `GET /runs/:id/monitor` returns verbatim (see
+ * `build_monitor_sample_payload`).
+ */
+struct MonitorSample {
+    int id;
+    std::string run_id;
+    int64_t timestamp;   // Unix ms - when the engine scraped it
+    std::string payload; // JSON object: {timestamp, series:{name: value}}
+};
+
 struct Result {
     int id;
     std::string run_id;

--- a/engine/src/core/monitor.cpp
+++ b/engine/src/core/monitor.cpp
@@ -13,6 +13,8 @@
 #include <set>
 #include <string_view>
 
+#include "vayu/db/database.hpp"
+
 namespace vayu::core {
 
 namespace {
@@ -34,8 +36,13 @@ bool starts_with_ci (const std::string& text, std::string_view prefix) {
  * the block is unusable, or nullopt. Both public entry points go through here,
  * so the route's gate and the run's reader cannot disagree about a field.
  */
-std::optional<std::string>
-read_monitor_block (const nlohmann::json& monitor, MonitorConfig& out) {
+std::optional<std::string> read_monitor_block (const nlohmann::json& monitor,
+const MonitorLimits& limits,
+MonitorConfig& out) {
+    // The configured cadence stands until the block names its own, so a user
+    // who set `monitorIntervalMs` to 5000 gets 5000 for every run that does not
+    // override it - including one started by a client that omits the field.
+    out.interval_ms = limits.default_interval_ms;
     if (!monitor.is_object ()) {
         return "'monitor' must be an object with a 'url' and a 'series' list";
     }
@@ -95,10 +102,10 @@ read_monitor_block (const nlohmann::json& monitor, MonitorConfig& out) {
         return "'monitor.series' must name at least one metric - a scrape with "
                "nothing to read would record empty samples for the whole run";
     }
-    if (series.size () > monitor_limits::MAX_SERIES) {
-        return "'monitor.series' may name at most " +
-        std::to_string (monitor_limits::MAX_SERIES) + " metrics (got " +
-        std::to_string (series.size ()) + ")";
+    if (series.size () > limits.max_series) {
+        return "'monitor.series' may name at most " + std::to_string (limits.max_series) +
+        " metrics (got " + std::to_string (series.size ()) +
+        ") - raise 'monitorMaxSeries' in settings to chart more";
     }
     for (const auto& entry : series) {
         if (!entry.is_string () || entry.get<std::string> ().empty ()) {
@@ -121,22 +128,43 @@ const nlohmann::json& monitor_block (const nlohmann::json& config) {
 
 } // namespace
 
-std::optional<std::string> validate_monitor_config (const nlohmann::json& config) {
-    const auto& monitor = monitor_block (config);
-    if (monitor.is_null ()) {
-        return std::nullopt;
-    }
-    MonitorConfig parsed;
-    return read_monitor_block (monitor, parsed);
+MonitorLimits read_monitor_limits (vayu::db::Database& db) {
+    const MonitorLimits defaults;
+    MonitorLimits limits;
+
+    const int interval =
+    db.get_config_int ("monitorIntervalMs", defaults.default_interval_ms);
+    limits.default_interval_ms = (interval >= monitor_limits::MIN_INTERVAL_MS &&
+                                 interval <= monitor_limits::MAX_INTERVAL_MS) ?
+    interval :
+    defaults.default_interval_ms;
+
+    const int max_series =
+    db.get_config_int ("monitorMaxSeries", static_cast<int> (defaults.max_series));
+    limits.max_series =
+    max_series > 0 ? static_cast<size_t> (max_series) : defaults.max_series;
+
+    return limits;
 }
 
-std::optional<MonitorConfig> monitor_config_from (const nlohmann::json& config) {
+std::optional<std::string> validate_monitor_config (const nlohmann::json& config,
+const MonitorLimits& limits) {
     const auto& monitor = monitor_block (config);
     if (monitor.is_null ()) {
         return std::nullopt;
     }
     MonitorConfig parsed;
-    if (read_monitor_block (monitor, parsed)) {
+    return read_monitor_block (monitor, limits, parsed);
+}
+
+std::optional<MonitorConfig>
+monitor_config_from (const nlohmann::json& config, const MonitorLimits& limits) {
+    const auto& monitor = monitor_block (config);
+    if (monitor.is_null ()) {
+        return std::nullopt;
+    }
+    MonitorConfig parsed;
+    if (read_monitor_block (monitor, limits, parsed)) {
         return std::nullopt;
     }
     return parsed;

--- a/engine/src/core/monitor.cpp
+++ b/engine/src/core/monitor.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/core/monitor.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <set>
+#include <string_view>
+
+namespace vayu::core {
+
+namespace {
+
+/// Case-insensitive prefix test, for the scheme check (a URL may be typed
+/// `HTTP://localhost:9100/metrics`).
+bool starts_with_ci (const std::string& text, std::string_view prefix) {
+    if (text.size () < prefix.size ()) {
+        return false;
+    }
+    return std::equal (prefix.begin (), prefix.end (), text.begin (), [] (char a, char b) {
+        return std::tolower (static_cast<unsigned char> (a)) ==
+        std::tolower (static_cast<unsigned char> (b));
+    });
+}
+
+/**
+ * The one description of a `monitor` block: fills @p out and returns the reason
+ * the block is unusable, or nullopt. Both public entry points go through here,
+ * so the route's gate and the run's reader cannot disagree about a field.
+ */
+std::optional<std::string>
+read_monitor_block (const nlohmann::json& monitor, MonitorConfig& out) {
+    if (!monitor.is_object ()) {
+        return "'monitor' must be an object with a 'url' and a 'series' list";
+    }
+
+    if (!monitor.contains ("url") || !monitor["url"].is_string ()) {
+        return "'monitor.url' is required and must be a string";
+    }
+    out.url = monitor["url"].get<std::string> ();
+    if (!starts_with_ci (out.url, "http://") && !starts_with_ci (out.url, "https://")) {
+        // Loopback and private addresses are deliberately allowed: this is a
+        // local tool scraping the user's own infrastructure, so the only thing
+        // worth rejecting is a scheme the client cannot fetch at all.
+        return "'monitor.url' must be an http:// or https:// URL (got \"" + out.url + "\")";
+    }
+
+    if (monitor.contains ("intervalMs") && !monitor["intervalMs"].is_null ()) {
+        const auto& interval = monitor["intervalMs"];
+        if (!interval.is_number ()) {
+            return "'monitor.intervalMs' must be a number of milliseconds "
+                   "(got " +
+            std::string (interval.type_name ()) + ")";
+        }
+        const double value = interval.get<double> ();
+        if (!(value >= monitor_limits::MIN_INTERVAL_MS) ||
+        !(value <= monitor_limits::MAX_INTERVAL_MS)) {
+            return "'monitor.intervalMs' must be between " +
+            std::to_string (monitor_limits::MIN_INTERVAL_MS) + " and " +
+            std::to_string (monitor_limits::MAX_INTERVAL_MS) +
+            " - the scrape is one blocking request per interval, and a faster "
+            "one measures the scraper rather than the target";
+        }
+        out.interval_ms = static_cast<int> (value);
+    }
+
+    if (monitor.contains ("format") && !monitor["format"].is_null ()) {
+        if (!monitor["format"].is_string ()) {
+            return "'monitor.format' must be \"prometheus\" or \"json\"";
+        }
+        const std::string format = monitor["format"].get<std::string> ();
+        if (format == "prometheus") {
+            out.format = MonitorFormat::Prometheus;
+        } else if (format == "json") {
+            out.format = MonitorFormat::Json;
+        } else {
+            return "'monitor.format' must be \"prometheus\" or \"json\" (got "
+                   "\"" +
+            format + "\")";
+        }
+    }
+
+    if (!monitor.contains ("series") || !monitor["series"].is_array ()) {
+        return "'monitor.series' is required and must be an array of metric "
+               "names";
+    }
+    const auto& series = monitor["series"];
+    if (series.empty ()) {
+        return "'monitor.series' must name at least one metric - a scrape with "
+               "nothing to read would record empty samples for the whole run";
+    }
+    if (series.size () > monitor_limits::MAX_SERIES) {
+        return "'monitor.series' may name at most " +
+        std::to_string (monitor_limits::MAX_SERIES) + " metrics (got " +
+        std::to_string (series.size ()) + ")";
+    }
+    for (const auto& entry : series) {
+        if (!entry.is_string () || entry.get<std::string> ().empty ()) {
+            return "'monitor.series' entries must be non-empty metric names";
+        }
+        out.series.push_back (entry.get<std::string> ());
+    }
+
+    return std::nullopt;
+}
+
+/// The `monitor` value on a run config, or null when the run declared none.
+const nlohmann::json& monitor_block (const nlohmann::json& config) {
+    static const nlohmann::json absent = nlohmann::json ();
+    if (!config.is_object () || !config.contains ("monitor")) {
+        return absent;
+    }
+    return config["monitor"];
+}
+
+} // namespace
+
+std::optional<std::string> validate_monitor_config (const nlohmann::json& config) {
+    const auto& monitor = monitor_block (config);
+    if (monitor.is_null ()) {
+        return std::nullopt;
+    }
+    MonitorConfig parsed;
+    return read_monitor_block (monitor, parsed);
+}
+
+std::optional<MonitorConfig> monitor_config_from (const nlohmann::json& config) {
+    const auto& monitor = monitor_block (config);
+    if (monitor.is_null ()) {
+        return std::nullopt;
+    }
+    MonitorConfig parsed;
+    if (read_monitor_block (monitor, parsed)) {
+        return std::nullopt;
+    }
+    return parsed;
+}
+
+std::map<std::string, double> parse_prometheus_exposition (const std::string& body,
+const std::vector<std::string>& series) {
+    const std::set<std::string> wanted (series.begin (), series.end ());
+    std::map<std::string, double> values;
+
+    size_t line_start = 0;
+    while (line_start <= body.size ()) {
+        size_t line_end = body.find ('\n', line_start);
+        if (line_end == std::string::npos) {
+            line_end = body.size ();
+        }
+        std::string_view line (body.data () + line_start, line_end - line_start);
+        line_start = line_end + 1;
+
+        // Trim both ends: exposition files are frequently CRLF, and a trailing
+        // '\r' would otherwise ride into the value token.
+        while (!line.empty () &&
+        std::isspace (static_cast<unsigned char> (line.front ()))) {
+            line.remove_prefix (1);
+        }
+        while (!line.empty () && std::isspace (static_cast<unsigned char> (line.back ()))) {
+            line.remove_suffix (1);
+        }
+        if (line.empty () || line.front () == '#') {
+            continue;
+        }
+
+        const size_t name_end = line.find_first_of ("{ \t");
+        if (name_end == std::string_view::npos) {
+            continue; // a name with no value is not a sample
+        }
+        const std::string name (line.substr (0, name_end));
+        if (wanted.find (name) == wanted.end ()) {
+            continue;
+        }
+
+        size_t cursor = name_end;
+        if (line[cursor] == '{') {
+            // Scan to the closing brace, honouring quoted label values - a
+            // label may legally contain '}' inside its quotes.
+            bool in_quotes = false;
+            bool escaped   = false;
+            ++cursor;
+            for (; cursor < line.size (); ++cursor) {
+                const char ch = line[cursor];
+                if (escaped) {
+                    escaped = false;
+                } else if (ch == '\\') {
+                    escaped = true;
+                } else if (ch == '"') {
+                    in_quotes = !in_quotes;
+                } else if (ch == '}' && !in_quotes) {
+                    break;
+                }
+            }
+            if (cursor >= line.size ()) {
+                continue; // unterminated label set - not a sample this can read
+            }
+            ++cursor; // step over '}'
+        }
+
+        while (cursor < line.size () &&
+        std::isspace (static_cast<unsigned char> (line[cursor]))) {
+            ++cursor;
+        }
+        if (cursor >= line.size ()) {
+            continue;
+        }
+        size_t value_end = cursor;
+        while (value_end < line.size () &&
+        !std::isspace (static_cast<unsigned char> (line[value_end]))) {
+            ++value_end;
+        }
+        // A trailing exposition timestamp (the token after the value) is
+        // deliberately ignored: the sample's time is when this engine scraped
+        // it, which is the axis the overlay joins on.
+        const std::string token (line.substr (cursor, value_end - cursor));
+        try {
+            size_t consumed  = 0;
+            const double val = std::stod (token, &consumed);
+            if (consumed != token.size () || !std::isfinite (val)) {
+                continue; // NaN, +Inf, or trailing garbage
+            }
+            auto [it, inserted] = values.emplace (name, val);
+            if (!inserted) {
+                it->second += val; // one labelled family is one series
+            }
+        } catch (const std::exception&) {
+            continue;
+        }
+    }
+
+    return values;
+}
+
+std::map<std::string, double> parse_json_metrics (const std::string& body,
+const std::vector<std::string>& series) {
+    std::map<std::string, double> values;
+    nlohmann::json parsed;
+    try {
+        parsed = nlohmann::json::parse (body);
+    } catch (const std::exception&) {
+        return values;
+    }
+    if (!parsed.is_object ()) {
+        return values;
+    }
+    for (const auto& name : series) {
+        if (!parsed.contains (name) || !parsed[name].is_number ()) {
+            continue;
+        }
+        const double value = parsed[name].get<double> ();
+        if (std::isfinite (value)) {
+            values[name] = value;
+        }
+    }
+    return values;
+}
+
+std::map<std::string, double> parse_monitor_body (MonitorFormat format,
+const std::string& body,
+const std::vector<std::string>& series) {
+    return format == MonitorFormat::Json ? parse_json_metrics (body, series) :
+                                           parse_prometheus_exposition (body, series);
+}
+
+nlohmann::json build_monitor_sample_payload (int64_t timestamp,
+const std::map<std::string, double>& values) {
+    nlohmann::json series = nlohmann::json::object ();
+    for (const auto& [name, value] : values) {
+        series[name] = value;
+    }
+    nlohmann::json payload;
+    payload["timestamp"] = timestamp;
+    payload["series"]    = series;
+    return payload;
+}
+
+void MonitorTotals::add (const std::map<std::string, double>& values) {
+    ++samples_;
+    for (const auto& [name, value] : values) {
+        auto& acc = series_[name];
+        if (acc.count == 0) {
+            acc.min = value;
+            acc.max = value;
+        } else {
+            acc.min = std::min (acc.min, value);
+            acc.max = std::max (acc.max, value);
+        }
+        acc.sum += value;
+        ++acc.count;
+    }
+}
+
+void MonitorTotals::record_failure () {
+    ++failures_;
+}
+
+nlohmann::json MonitorTotals::to_summary () const {
+    nlohmann::json series = nlohmann::json::object ();
+    for (const auto& [name, acc] : series_) {
+        if (acc.count == 0) {
+            continue;
+        }
+        series[name] = { { "min", acc.min }, { "max", acc.max },
+            { "avg", acc.sum / static_cast<double> (acc.count) }, { "count", acc.count } };
+    }
+    nlohmann::json summary;
+    summary["samples"]  = samples_;
+    summary["failures"] = failures_;
+    summary["series"]   = series;
+    return summary;
+}
+
+} // namespace vayu::core

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -15,6 +15,7 @@
 #include "vayu/core/load_strategy.hpp"
 #include "vayu/core/scenario_load.hpp"
 #include "vayu/core/scenario_runner.hpp"
+#include "vayu/http/client.hpp"
 #include "vayu/http/request_builder.hpp"
 #include "vayu/http/script_parts.hpp"
 #include "vayu/runtime/script_engine.hpp"
@@ -33,6 +34,20 @@ inline int64_t now_ms () {
 /// Snapshot what each bounded store thinned away, for the run summary. One
 /// copy so the completed-run and crashed-run summaries cannot report retention
 /// differently.
+/// Join the run's auxiliary threads - the tick producer and, when the run
+/// configured one, the server-vitals scrape. Both exit on `is_running` and both
+/// must be joined before the worker reads what they wrote; there are four ways
+/// out of a load run, so the pair lives here rather than being remembered four
+/// times.
+void join_run_threads (const std::shared_ptr<RunContext>& context) {
+    if (context->metrics_thread.joinable ()) {
+        context->metrics_thread.join ();
+    }
+    if (context->monitor_thread.joinable ()) {
+        context->monitor_thread.join ();
+    }
+}
+
 SamplingRetention read_retention (const MetricsCollector& mc) {
     SamplingRetention retention;
     retention.errors_dropped           = mc.errors_dropped ();
@@ -444,6 +459,11 @@ RunContext::~RunContext () {
     if (metrics_thread.joinable ()) {
         metrics_thread.join ();
     }
+    // Same reasoning for the scrape loop: a joinable thread left on a
+    // destroyed context is std::terminate, not a leak.
+    if (monitor_thread.joinable ()) {
+        monitor_thread.join ();
+    }
 }
 
 void RunManager::register_run (const std::string& run_id, std::shared_ptr<RunContext> context) {
@@ -732,6 +752,19 @@ std::shared_ptr<const ScenarioExecution> scenario) {
         // joined by the worker thread below.
         context->metrics_thread =
         std::thread ([context, &db] () { collect_metrics (context, &db); });
+        // Server vitals, when this run asked for them. Read from the config the
+        // route already validated; `monitor_config_from` returning nothing here
+        // means the run declared no monitor (or a snapshot this engine cannot
+        // read), and the run proceeds exactly as it did before the block
+        // existed. The totals live on the context so the summary can read them
+        // once this thread has been joined.
+        if (auto monitor = monitor_config_from (context->config)) {
+            context->monitor_totals = std::make_unique<MonitorTotals> ();
+            context->monitor_thread = std::thread (
+            [context, &db, cfg = std::move (*monitor)] () mutable {
+                collect_monitor (context, &db, std::move (cfg));
+            });
+        }
         return std::thread ([context, &db, verbose, this] () {
             execute_load_test (context, &db, verbose, *this);
         });
@@ -829,8 +862,7 @@ RunManager& manager) {
                 : "Load test auth resolution failed: " + built.error_message);
                 db.update_run_status (context->run_id, vayu::RunStatus::Failed);
                 context->is_running = false;
-                if (context->metrics_thread.joinable ())
-                    context->metrics_thread.join ();
+                join_run_threads (context);
                 manager.retain_run (context->run_id);
                 return;
             }
@@ -852,7 +884,7 @@ RunManager& manager) {
             vayu::utils::log_error ("Load test failed: " + std::string (e.what ()));
             db.update_run_status (context->run_id, vayu::RunStatus::Failed);
             context->is_running = false;
-            if (context->metrics_thread.joinable ()) context->metrics_thread.join ();
+            join_run_threads (context);
             manager.retain_run (context->run_id);
             return;
         }
@@ -886,13 +918,13 @@ RunManager& manager) {
         // (not after cleanup/metrics thread join)
         db.update_run_end_time (context->run_id);
 
-        // Stop background metrics collection and wait for thread to finish
+        // Stop background collection and wait for the threads to finish
         context->is_running = false;
 
-        // Properly join the metrics thread to ensure it's done writing to DB
-        if (context->metrics_thread.joinable ()) {
-            context->metrics_thread.join ();
-        }
+        // Properly join them to ensure they are done writing to the DB - and,
+        // for the scrape loop, that `monitor_totals` is final before the
+        // summary below reads it.
+        join_run_threads (context);
 
         // Calculate cleanup overhead (time from test end to after cleanup)
         auto cleanup_end = std::chrono::steady_clock::now ();
@@ -955,6 +987,11 @@ RunManager& manager) {
             context->metrics_collector->http_version_downgraded ();
             inputs.tests     = validation.run;
             inputs.retention = read_retention (*context->metrics_collector);
+            // Safe to read unlocked: the scrape thread is its only writer and
+            // was joined above, which is the happens-before edge.
+            if (context->monitor_totals) {
+                inputs.monitor = context->monitor_totals->to_summary ();
+            }
             // Read only now, after the drain above: a completion callback can
             // still be advancing a VU while the strategy's own frame has
             // already returned, so the tallies are only final here.
@@ -1013,7 +1050,7 @@ RunManager& manager) {
         // failure paths do. Deferring the join to ~RunContext instead would run
         // it under RunManager::mutex_ during a later sweep eviction.
         context->is_running = false;
-        if (context->metrics_thread.joinable ()) context->metrics_thread.join ();
+        join_run_threads (context);
 
         vayu::utils::log_error ("Load test error: " + std::string (e.what ()));
 
@@ -1076,8 +1113,7 @@ RunManager& manager) {
 }
 
 std::string build_tick_payload (const nlohmann::json& stats, size_t offset) {
-    return "event: metrics\nid: " + std::to_string (offset) + "\ndata: " +
-    stats.dump () + "\n\n";
+    return build_sse_frame ("metrics", stats.dump (), offset);
 }
 
 nlohmann::json build_metric_tick_payload (const MetricTickSample& sample) {
@@ -1175,6 +1211,12 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     if (inputs.scenario.has_value ()) {
         summary["scenario"] = *inputs.scenario;
     }
+    // What the server-vitals scrape recorded. Omitted for a run that configured
+    // no monitor, so the report's section is absent rather than showing a run
+    // that scraped nothing as one whose target reported zeros.
+    if (inputs.monitor.has_value ()) {
+        summary["monitor"] = *inputs.monitor;
+    }
     return summary;
 }
 
@@ -1256,8 +1298,10 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
         stats["requestsSent"]     = requests_sent;
         stats["requestsExpected"] = requests_expected;
 
-        size_t offset = context->published_count.load ();
-        context->append_tick (build_tick_payload (stats, offset));
+        // Framed by the ring, which assigns the id under its own lock: a run
+        // with a monitor has a second producer appending to it, and reading the
+        // offset here would race that thread for the same id.
+        context->append_event ("metrics", stats.dump ());
     };
 
     // Guard the entire body so that any exception (std::bad_alloc, json error,
@@ -1417,6 +1461,104 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
     // Unconditional: always signal consumers so they terminate cleanly,
     // even if the producer threw.
     context->closed.store (true, std::memory_order_release);
+}
+
+void collect_monitor (std::shared_ptr<RunContext> context,
+vayu::db::Database* db_ptr,
+MonitorConfig config) {
+    auto& db = *db_ptr;
+
+    // A scrape must not outlive its own cadence: the sample a late answer
+    // carries is no longer about the moment it was asked for, and the loop
+    // would spend the whole run behind itself. Three quarters of the interval
+    // leaves room to store the row and come back round.
+    const int timeout_ms = std::max (100, config.interval_ms * 3 / 4);
+
+    // No cookie jar: this is the engine talking on its own behalf, like the
+    // OAuth token call and the update check (see ClientConfig::cookie_jar).
+    vayu::http::Client client{ vayu::http::ClientConfig{} };
+
+    int consecutive_failures = 0;
+    bool backoff_logged      = false;
+    int interval_ms          = config.interval_ms;
+
+    // Guarded whole, for the same reason collect_metrics is: an exception out
+    // of a thread function calls std::terminate, and a scrape failure must
+    // never take the run with it.
+    try {
+        while (context->is_running) {
+            const auto scrape_started = std::chrono::steady_clock::now ();
+
+            vayu::Request request;
+            request.method     = vayu::HttpMethod::GET;
+            request.url        = config.url;
+            request.timeout_ms = timeout_ms;
+
+            std::map<std::string, double> values;
+            auto sent = client.send (request);
+            if (sent.is_ok () && !sent.value ().has_error () && sent.value ().is_success ()) {
+                values = parse_monitor_body (config.format, sent.value ().body, config.series);
+            }
+
+            // A scrape that read nothing is a gap, whether the transport failed
+            // or the body carried none of the requested names: both mean this
+            // moment went unmeasured, and a stored sample with no readings
+            // would draw a line through a hole in the data.
+            if (values.empty ()) {
+                ++consecutive_failures;
+                if (context->monitor_totals) {
+                    context->monitor_totals->record_failure ();
+                }
+                if (consecutive_failures == monitor_limits::FAILURES_BEFORE_BACKOFF) {
+                    if (!backoff_logged) {
+                        vayu::utils::log_warning ("Monitor scrape for run " + context->run_id +
+                        " has failed " + std::to_string (consecutive_failures) +
+                        " times in a row (" + config.url +
+                        "); backing off, the series will show gaps");
+                        backoff_logged = true;
+                    }
+                    // Doubled once, not per failure: the point is to stop
+                    // hammering an endpoint that is gone, not to drift so far
+                    // out that a recovered one is noticed minutes later.
+                    interval_ms = std::min (config.interval_ms * 2, monitor_limits::MAX_INTERVAL_MS);
+                }
+            } else {
+                consecutive_failures = 0;
+                backoff_logged       = false;
+                interval_ms          = config.interval_ms;
+
+                const int64_t sample_wall_ms = now_ms ();
+                auto payload = build_monitor_sample_payload (sample_wall_ms, values);
+                if (context->monitor_totals) {
+                    context->monitor_totals->add (values);
+                }
+                try {
+                    db.add_monitor_sample (
+                    { 0, context->run_id, sample_wall_ms, payload.dump () });
+                } catch (const std::exception& e) {
+                    // The live frame below still goes out: a row this run could
+                    // not store is worth less than a series that stops drawing.
+                    vayu::utils::log_warning ("Failed to store monitor sample for run " +
+                    context->run_id + ": " + e.what ());
+                }
+                context->append_event ("monitor", payload.dump ());
+            }
+
+            // Sleep out the remainder of the interval in short slices. A run
+            // that finishes joins this thread, so a single sleep_for would hold
+            // the whole run open for up to a minute at the maximum interval.
+            const auto deadline =
+            scrape_started + std::chrono::milliseconds (interval_ms);
+            while (context->is_running && std::chrono::steady_clock::now () < deadline) {
+                std::this_thread::sleep_for (std::chrono::milliseconds (
+                std::min (50, interval_ms)));
+            }
+        }
+    } catch (const std::exception& e) {
+        vayu::utils::log_error ("collect_monitor: " + std::string (e.what ()));
+    } catch (...) {
+        vayu::utils::log_error ("collect_monitor: unknown exception");
+    }
 }
 
 } // namespace vayu::core

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -751,7 +751,7 @@ std::shared_ptr<const ScenarioExecution> scenario) {
         // read), and the run proceeds exactly as it did before the block
         // existed. The totals live on the context so the summary can read them
         // once this thread has been joined.
-        if (auto monitor = monitor_config_from (context->config)) {
+        if (auto monitor = monitor_config_from (context->config, read_monitor_limits (db))) {
             context->monitor_totals = std::make_unique<MonitorTotals> ();
             context->monitor_thread = std::thread (
             [context, &db, cfg = std::move (*monitor)] () mutable {
@@ -1554,7 +1554,7 @@ MonitorConfig config) {
                 if (context->monitor_totals) {
                     context->monitor_totals->record_failure ();
                 }
-                if (consecutive_failures == monitor_limits::FAILURES_BEFORE_BACKOFF) {
+                if (consecutive_failures == constants::monitor::FAILURES_BEFORE_BACKOFF) {
                     if (!backoff_logged) {
                         vayu::utils::log_warning ("Monitor scrape for run " + context->run_id +
                         " has failed " + std::to_string (consecutive_failures) +
@@ -1565,7 +1565,8 @@ MonitorConfig config) {
                     // Doubled once, not per failure: the point is to stop
                     // hammering an endpoint that is gone, not to drift so far
                     // out that a recovered one is noticed minutes later.
-                    interval_ms = std::min (config.interval_ms * 2, monitor_limits::MAX_INTERVAL_MS);
+                    interval_ms =
+                    std::min (config.interval_ms * 2, constants::monitor::MAX_INTERVAL_MS);
                 }
             } else {
                 consecutive_failures = 0;

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -259,7 +259,7 @@ std::string build_step_payload (const StepRecord& record, size_t offset) {
     if (record.data_row_index) {
         data["dataRowIndex"] = *record.data_row_index;
     }
-    return "event: step\nid: " + std::to_string (offset) + "\ndata: " + data.dump () + "\n\n";
+    return build_sse_frame ("step", data.dump (), offset);
 }
 
 nlohmann::json build_scenario_summary_payload (const ScenarioSummaryInputs& inputs) {

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -167,6 +167,9 @@ inline auto make_storage (const std::string& path) {
     // every run ever recorded, not just the current one.
     // get_metric_ticks_since is polled every 500ms by the legacy SSE loop.
     make_index ("idx_metric_ticks_run_id", &MetricTick::run_id),
+    // monitor_samples grows with the run too (one row per scrape interval), and
+    // both its reader and the run cascade filter on run_id.
+    make_index ("idx_monitor_samples_run_id", &MonitorSample::run_id),
     make_index ("idx_results_run_id", &Result::run_id),
     // GET /runs/:id/samples pages result_bodies by run, and the run cascade
     // deletes both new tables by run_id.
@@ -255,6 +258,16 @@ inline auto make_storage (const std::string& path) {
     make_column ("run_id", &MetricTick::run_id),
     make_column ("timestamp", &MetricTick::timestamp),
     make_column ("payload", &MetricTick::payload)), // JSON: the whole tick object
+
+    // Monitor samples: one row per scrape of the run's configured server-vitals
+    // endpoint. Its own table rather than a wider metric_ticks row - the tick
+    // payload's key set is the GET /runs/:id/metrics contract, and these arrive
+    // on the user's scrape cadence, not the tick cadence.
+    make_table ("monitor_samples",
+    make_column ("id", &MonitorSample::id, primary_key ().autoincrement ()),
+    make_column ("run_id", &MonitorSample::run_id),
+    make_column ("timestamp", &MonitorSample::timestamp),
+    make_column ("payload", &MonitorSample::payload)), // JSON: {timestamp, series}
 
     // Results: Individual request outcomes with timing breakdown
     make_table ("results", make_column ("id", &Result::id, primary_key ().autoincrement ()),
@@ -1000,6 +1013,7 @@ int64_t Database::count_runs (const RunFilter& filter) {
 // was added to both by editing only this function). Caller holds the mutex.
 void Database::remove_run_cascade_locked (const std::string& id) {
     impl_->storage.remove_all<MetricTick> (where (c (&MetricTick::run_id) == id));
+    impl_->storage.remove_all<MonitorSample> (where (c (&MonitorSample::run_id) == id));
     // Captured bodies before the results they hang off, so a delete interrupted
     // between the two leaves results without bodies rather than body rows
     // pointing at nothing. `maxRunsRetained` doubles as the expiry for anything
@@ -1168,6 +1182,31 @@ Database::get_metric_ticks_since (const std::string& run_id, int64_t last_id) {
 int64_t Database::count_metric_ticks (const std::string& run_id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     return impl_->storage.count<MetricTick> (where (c (&MetricTick::run_id) == run_id));
+}
+
+// ============================================================================
+// Monitor samples - external server vitals scraped alongside a run
+// ============================================================================
+
+void Database::add_monitor_sample (const MonitorSample& sample) {
+    retry_on_busy ("add monitor sample", 5, std::chrono::milliseconds (100),
+    [&] { impl_->storage.insert (sample); });
+}
+
+// Ordered (timestamp, id) for the same reason the tick reader is: a page
+// boundary falls between two whole samples, never inside one.
+std::vector<MonitorSample>
+Database::get_monitor_samples_paginated (const std::string& run_id, int64_t limit, int64_t offset) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.get_all<MonitorSample> (
+    where (c (&MonitorSample::run_id) == run_id),
+    multi_order_by (order_by (&MonitorSample::timestamp), order_by (&MonitorSample::id)),
+    sqlite_orm::limit (offset, limit));
+}
+
+int64_t Database::count_monitor_samples (const std::string& run_id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.count<MonitorSample> (where (c (&MonitorSample::run_id) == run_id));
 }
 
 // ============================================================================

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1815,6 +1815,33 @@ void Database::seed_default_config () {
     "5000", // 5s - past this a finished run visibly waits on the join
     std::nullopt, now });
 
+    // Server-vitals monitor. Both are read per run - a change applies to the
+    // next run started, no restart. The interval *bounds* (250-60000ms) are
+    // deliberately not settings: they exist to stop a cadence that measures the
+    // scraper rather than the target.
+    upsert_config (ConfigEntry{ "monitorIntervalMs",
+    std::to_string (vayu::core::constants::monitor::DEFAULT_INTERVAL_MS), "integer",
+    "Server Monitoring Scrape Interval",
+    "How often a load test scrapes the metrics endpoint it was pointed at, "
+    "when the run does not set its own interval. Each scrape is one request on "
+    "the run's monitor thread, so it never delays the run's own metrics - but a "
+    "cadence faster than the target's own collection interval only re-reads the "
+    "same numbers. Raise it for an endpoint that is expensive to render.",
+    "observability",
+    std::to_string (vayu::core::constants::monitor::DEFAULT_INTERVAL_MS),
+    std::to_string (vayu::core::constants::monitor::MIN_INTERVAL_MS),
+    std::to_string (vayu::core::constants::monitor::MAX_INTERVAL_MS), std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "monitorMaxSeries",
+    std::to_string (vayu::core::constants::monitor::MAX_SERIES), "integer",
+    "Server Monitoring Metric Limit",
+    "How many metric names one run may chart from its monitored endpoint. Each "
+    "is a line on a single overlay and a name matched against every line of the "
+    "exposition body, so the ceiling is about a readable chart rather than a "
+    "hard cost. The chart has four distinct colours and repeats them past that.",
+    "observability", std::to_string (vayu::core::constants::monitor::MAX_SERIES),
+    "1", "64", std::nullopt, now });
+
     // =========================================================================
     // SCRIPTING ENVIRONMENT CONFIGURATION
     // Configuration for the QuickJS sandbox execution, limits, and debugging

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "vayu/core/constants.hpp"
+#include "vayu/core/monitor.hpp"
 #include "vayu/core/scenario_load.hpp"
 #include "vayu/core/scenario_plan.hpp"
 #include "vayu/core/threshold_eval.hpp"
@@ -534,6 +535,13 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
     // evaluator (`core/threshold_eval.cpp`), which reads the same metric table
     // - a budget this accepts is one the run will actually judge.
     if (auto reason = vayu::core::validate_thresholds (config)) {
+        return reason;
+    }
+
+    // `monitor` is the other nested object, and its rule lives with the scrape
+    // loop for the same reason: `core/monitor.cpp` holds one description of the
+    // block, so a field this accepts is one the run will actually read.
+    if (auto reason = vayu::core::validate_monitor_config (config)) {
         return reason;
     }
 

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -475,7 +475,8 @@ const vayu::Response& response) {
  *
  * @return The reason the config is invalid, or `std::nullopt` if it is usable.
  */
-std::optional<std::string> validate_run_config (const nlohmann::json& config) {
+std::optional<std::string> validate_run_config (const nlohmann::json& config,
+const vayu::core::MonitorLimits& monitor_limits) {
     if (!config.is_object ()) {
         return "Run config must be a JSON object";
     }
@@ -561,8 +562,10 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
 
     // `monitor` is the other nested object, and its rule lives with the scrape
     // loop for the same reason: `core/monitor.cpp` holds one description of the
-    // block, so a field this accepts is one the run will actually read.
-    if (auto reason = vayu::core::validate_monitor_config (config)) {
+    // block, so a field this accepts is one the run will actually read. Its two
+    // movable limits arrive resolved from the caller, which is what keeps this
+    // function - and the core it delegates to - free of a `Database`.
+    if (auto reason = vayu::core::validate_monitor_config (config, monitor_limits)) {
         return reason;
     }
 
@@ -837,7 +840,8 @@ void register_execution_routes (RouteContext& ctx) {
         // Range-check the numeric config *before* the run row exists, so a
         // rejected request leaves nothing behind. `invalid_run_config` is the
         // specific code this failure carries in place of the per-status default.
-        if (auto invalid = validate_run_config (json)) {
+        if (auto invalid =
+            validate_run_config (json, vayu::core::read_monitor_limits (ctx.db))) {
             vayu::utils::log_warning ("POST /runs - Invalid run config: " + *invalid);
             send_error (res, 400, *invalid, "invalid_run_config");
             return;

--- a/engine/src/http/routes/metrics.cpp
+++ b/engine/src/http/routes/metrics.cpp
@@ -43,17 +43,17 @@ size_t returned) {
  * construction - a page boundary can no longer land inside a tick and hand the
  * client a half-populated bucket.
  */
-nlohmann::json tick_time_series (vayu::db::Database& db,
+template <typename Row>
+nlohmann::json stored_payload_series (const std::vector<Row>& rows,
+const char* kind,
 const std::string& run_id,
 int64_t total_count,
 int64_t limit,
 int64_t offset) {
-    auto ticks = db.get_metric_ticks_paginated (run_id, limit, offset);
-
     nlohmann::json data_array = nlohmann::json::array ();
-    for (const auto& tick : ticks) {
+    for (const auto& row : rows) {
         try {
-            auto payload = nlohmann::json::parse (tick.payload);
+            auto payload = nlohmann::json::parse (row.payload);
             if (!payload.is_object ()) {
                 throw std::runtime_error ("payload is not an object");
             }
@@ -62,12 +62,21 @@ int64_t offset) {
             // A payload this engine wrote always parses; a corrupt one is a
             // damaged row, not a client error - skip it loudly rather than
             // failing the whole page.
-            vayu::utils::log_warning ("Skipping unreadable metric tick for run " +
-            run_id + " (id=" + std::to_string (tick.id) + "): " + e.what ());
+            vayu::utils::log_warning (std::string ("Skipping unreadable ") + kind +
+            " for run " + run_id + " (id=" + std::to_string (row.id) + "): " + e.what ());
         }
     }
     return time_series_envelope (
-    std::move (data_array), total_count, limit, offset, ticks.size ());
+    std::move (data_array), total_count, limit, offset, rows.size ());
+}
+
+nlohmann::json tick_time_series (vayu::db::Database& db,
+const std::string& run_id,
+int64_t total_count,
+int64_t limit,
+int64_t offset) {
+    return stored_payload_series (db.get_metric_ticks_paginated (run_id, limit, offset),
+    "metric tick", run_id, total_count, limit, offset);
 }
 
 } // namespace
@@ -100,6 +109,30 @@ const std::string& run_id, int64_t limit, int64_t offset) {
     // pagination total, so this is not an extra query.
     const int64_t tick_count = db.count_metric_ticks (run_id);
     return { 200, tick_time_series (db, run_id, tick_count, limit, offset) };
+}
+
+/**
+ * Testable core of `GET /runs/:id/monitor` - the external server vitals scraped
+ * during a run, in the same `{data, pagination}` envelope the tick series uses.
+ *
+ * Its own endpoint rather than extra keys on the tick objects: those keys are
+ * the `GET /runs/:id/metrics` contract, and monitor samples arrive on the
+ * user's scrape cadence rather than the tick cadence, so they do not line up
+ * row for row. A run that configured no monitor returns an empty `data` array,
+ * not a 404 - the run exists and simply scraped nothing. A missing run is the
+ * same definitive 404 the tick series returns.
+ */
+std::pair<int, nlohmann::json> run_monitor_series_response (vayu::db::Database& db,
+const std::string& run_id, int64_t limit, int64_t offset) {
+    auto run = db.get_run (run_id);
+    if (!run) {
+        return { 404, error_body (404, "Run not found") };
+    }
+
+    const int64_t sample_count = db.count_monitor_samples (run_id);
+    return { 200,
+        stored_payload_series (db.get_monitor_samples_paginated (run_id, limit, offset),
+        "monitor sample", run_id, sample_count, limit, offset) };
 }
 
 namespace {
@@ -200,6 +233,37 @@ void register_metrics_routes (RouteContext& ctx) {
         } catch (const std::exception& e) {
             vayu::utils::log_error (
             "GET /runs/:id/metrics - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+
+    /**
+     * GET /runs/:runId/monitor
+     * Returns the paginated server-vitals series scraped during the run, for
+     * the same charts the live `monitor` SSE frames feed.
+     *
+     * Query Parameters:
+     * - limit: Max records per page (default 5000, capped at 50000)
+     * - offset: Skip N records (default 0)
+     */
+    ctx.server.Get (R"(/runs/([^/]+)/monitor)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        std::string run_id = req.matches[1];
+        vayu::utils::log_info (
+        "GET /runs/:id/monitor - Fetching monitor samples for run: " + run_id);
+        auto [limit, offset] = parse_time_series_pagination (req);
+        try {
+            auto [status, body] =
+            run_monitor_series_response (ctx.db, run_id, limit, offset);
+            if (status == 404) {
+                vayu::utils::log_warning (
+                "GET /runs/:id/monitor - Run not found: " + run_id);
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "GET /runs/:id/monitor - Error: " + std::string (e.what ()));
             send_error (res, 500, e.what ());
         }
     });

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -182,6 +182,12 @@ struct ReportExtras {
     // Capture does not redact, by decision, so the Samples tab reads this to
     // warn rather than leaving the reader to infer it.
     size_t response_bodies_captured = 0;
+    // What the run's server-vitals scrape recorded, verbatim from the summary
+    // (per-series min/max/avg plus the sample and gap counts). `has_monitor`
+    // false leaves the section out entirely - a run that configured no monitor
+    // did not measure a target reporting zeros.
+    bool has_monitor = false;
+    nlohmann::json monitor = nlohmann::json::object ();
     // How many of this run's transfers asked for HTTP/2 and negotiated
     // something older. Not a performance number - it is what tells the reader
     // whether the protocol the report is labelled with is the one the numbers
@@ -305,6 +311,11 @@ ReportExtras& extras) {
         if (scenario.contains ("steps") && scenario["steps"].is_array ()) {
             extras.step_breakdown = scenario["steps"];
         }
+    }
+
+    if (summary.contains ("monitor") && summary["monitor"].is_object ()) {
+        extras.has_monitor = true;
+        extras.monitor     = summary["monitor"];
     }
 
     if (summary.contains ("tests") && summary["tests"].is_object ()) {
@@ -794,6 +805,13 @@ const std::string& run_id) {
         if (!extras.step_breakdown.empty ()) {
             json_report["scenario"]["steps"] = extras.step_breakdown;
         }
+    }
+
+    // Server vitals beside the run's own numbers. Passed through as stored:
+    // the totals are written in the report's own shape, so there is one
+    // description of the section rather than a writer and a translator.
+    if (extras.has_monitor) {
+        json_report["monitor"] = extras.monitor;
     }
 
     if (extras.has_tests) {

--- a/engine/tests/mock_server.hpp
+++ b/engine/tests/mock_server.hpp
@@ -34,6 +34,28 @@ class SlowMockServer {
         svr.Get ("/fast", [] (const httplib::Request&, httplib::Response& res) {
             res.set_content ("{}", "application/json");
         });
+        // A Prometheus-style exposition endpoint, for the server-vitals
+        // monitor. The counter climbs by one per scrape so a test can assert
+        // the loop actually ran; `cpu` is exported as a labelled family, which
+        // is what the parser's sum-per-name rule is about.
+        svr.Get ("/vitals", [this] (const httplib::Request&, httplib::Response& res) {
+            const int n = ++scrapes;
+            res.set_content ("# HELP vayu_test_cpu Test CPU seconds\n"
+                             "# TYPE vayu_test_cpu counter\n"
+                             "vayu_test_cpu{cpu=\"0\"} 1.5\n"
+                             "vayu_test_cpu{cpu=\"1\"} 2.5\n"
+                             "vayu_test_rss_bytes " + std::to_string (n * 1000) + "\n"
+                             "vayu_test_unused 7\n",
+            "text/plain");
+        });
+        // The same numbers as a flat JSON object, for `format: "json"`.
+        svr.Get ("/vitals.json", [this] (const httplib::Request&, httplib::Response& res) {
+            const int n = ++scrapes;
+            res.set_content ("{\"vayu_test_cpu\":4.0,\"vayu_test_rss_bytes\":" +
+            std::to_string (n * 1000) + ",\"vayu_test_unused\":7}",
+            "application/json");
+        });
+
         // An upstream that never answers on its own - what a stop must not wait
         // for. The handler only returns once the fixture is torn down (or after
         // a hard cap, so a leaked handler cannot wedge the test binary).
@@ -78,10 +100,24 @@ class SlowMockServer {
         return "http://127.0.0.1:" + std::to_string (port) + "/hang";
     }
 
+    std::string vitals_url () const {
+        return "http://127.0.0.1:" + std::to_string (port) + "/vitals";
+    }
+
+    std::string vitals_json_url () const {
+        return "http://127.0.0.1:" + std::to_string (port) + "/vitals.json";
+    }
+
+    /// How many times either vitals endpoint has been scraped.
+    int scrape_count () const {
+        return scrapes.load ();
+    }
+
     httplib::Server svr;
     std::thread thread;
     int port = 0;
     std::atomic<bool> released{ false };
+    std::atomic<int> scrapes{ 0 };
 };
 
 } // namespace vayu::tests

--- a/engine/tests/monitor_test.cpp
+++ b/engine/tests/monitor_test.cpp
@@ -1,0 +1,439 @@
+/**
+ * @file monitor_test.cpp
+ * @brief The server-vitals monitor: what a `monitor` block may say, what a
+ *        scraped body becomes, and what the scrape loop does to a live run.
+ *
+ * The parser tests are the ones worth mutating against: every rule here
+ * (comments skipped, labelled families summed, non-finite values dropped)
+ * decides what a chart shows, and a body that parses "nearly right" draws a
+ * plausible line rather than failing.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+#include "mock_server.hpp"
+#include "temp_database.hpp"
+#include "vayu/core/monitor.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
+
+namespace {
+
+using nlohmann::json;
+using vayu::core::monitor_config_from;
+using vayu::core::MonitorFormat;
+using vayu::core::MonitorTotals;
+using vayu::core::parse_json_metrics;
+using vayu::core::parse_prometheus_exposition;
+using vayu::core::validate_monitor_config;
+using vayu::tests::SlowMockServer;
+using Clock = std::chrono::steady_clock;
+
+json monitor_config (json monitor) {
+    return json{ { "mode", "constant_rps" }, { "monitor", std::move (monitor) } };
+}
+
+// ---------------------------------------------------------------------------
+// Validation - the route's gate
+// ---------------------------------------------------------------------------
+
+TEST (MonitorConfigValidation, AbsentAndNullAreBothValid) {
+    EXPECT_FALSE (validate_monitor_config (json::object ()).has_value ());
+    EXPECT_FALSE (validate_monitor_config (json{ { "monitor", nullptr } }).has_value ());
+    // ...and neither yields a monitor to run.
+    EXPECT_FALSE (monitor_config_from (json::object ()).has_value ());
+    EXPECT_FALSE (monitor_config_from (json{ { "monitor", nullptr } }).has_value ());
+}
+
+TEST (MonitorConfigValidation, AMinimalBlockIsAcceptedAndDefaulted) {
+    auto config = monitor_config (json{ { "url", "http://localhost:9100/metrics" },
+    { "series", json::array ({ "up" }) } });
+    ASSERT_FALSE (validate_monitor_config (config).has_value ());
+
+    auto parsed = monitor_config_from (config);
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->url, "http://localhost:9100/metrics");
+    EXPECT_EQ (parsed->interval_ms, vayu::core::monitor_limits::DEFAULT_INTERVAL_MS);
+    EXPECT_EQ (parsed->format, MonitorFormat::Prometheus);
+    ASSERT_EQ (parsed->series.size (), 1u);
+    EXPECT_EQ (parsed->series[0], "up");
+}
+
+TEST (MonitorConfigValidation, RejectsAnUnusableBlock) {
+    struct Case {
+        json monitor;
+        const char* what;
+    };
+    const Case cases[] = {
+        { json::array (), "not an object" },
+        { json{ { "series", json::array ({ "up" }) } }, "no url" },
+        { json{ { "url", "ftp://localhost/metrics" }, { "series", json::array ({ "up" }) } },
+        "not http(s)" },
+        { json{ { "url", "http://x/m" } }, "no series" },
+        { json{ { "url", "http://x/m" }, { "series", json::array () } }, "empty series" },
+        { json{ { "url", "http://x/m" }, { "series", json::array ({ "" }) } }, "empty series name" },
+        { json{ { "url", "http://x/m" },
+          { "series", json::array ({ "a", "b", "c", "d", "e", "f", "g", "h", "i" }) } },
+        "too many series" },
+        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
+          { "intervalMs", 10 } },
+        "interval below the floor" },
+        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
+          { "intervalMs", 90000 } },
+        "interval above the ceiling" },
+        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
+          { "intervalMs", "1s" } },
+        "interval not a number" },
+        { json{ { "url", "http://x/m" }, { "series", json::array ({ "up" }) },
+          { "format", "influx" } },
+        "unknown format" },
+    };
+    for (const auto& c : cases) {
+        auto config = monitor_config (c.monitor);
+        EXPECT_TRUE (validate_monitor_config (config).has_value ())
+        << "accepted a block with " << c.what;
+        // A block the route would reject is one the run must not execute
+        // either - that is what makes the pair one description, not two.
+        EXPECT_FALSE (monitor_config_from (config).has_value ())
+        << "would have run a block with " << c.what;
+    }
+}
+
+TEST (MonitorConfigValidation, LoopbackAndPrivateTargetsAreAllowed) {
+    // Deliberate: this is a local tool scraping the user's own infrastructure.
+    for (const char* url : { "http://127.0.0.1:9100/metrics", "http://192.168.1.4:9090/metrics",
+         "https://localhost/metrics", "HTTP://LOCALHOST/metrics" }) {
+        auto config =
+        monitor_config (json{ { "url", url }, { "series", json::array ({ "up" }) } });
+        EXPECT_FALSE (validate_monitor_config (config).has_value ()) << url;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prometheus exposition parsing
+// ---------------------------------------------------------------------------
+
+TEST (PrometheusParser, ReadsPlainAndLabelledSamples) {
+    const std::string body =
+    "# HELP node_cpu_seconds_total Seconds\n"
+    "# TYPE node_cpu_seconds_total counter\n"
+    "node_cpu_seconds_total{cpu=\"0\",mode=\"user\"} 1.5\n"
+    "node_cpu_seconds_total{cpu=\"1\",mode=\"user\"} 2.25\n"
+    "process_resident_memory_bytes 1.048576e+06\n"
+    "unrequested_metric 99\n";
+    auto values = parse_prometheus_exposition (
+    body, { "node_cpu_seconds_total", "process_resident_memory_bytes" });
+
+    ASSERT_EQ (values.size (), 2u);
+    // One labelled family is one series: 1.5 + 2.25.
+    EXPECT_DOUBLE_EQ (values["node_cpu_seconds_total"], 3.75);
+    EXPECT_DOUBLE_EQ (values["process_resident_memory_bytes"], 1048576.0);
+    EXPECT_EQ (values.count ("unrequested_metric"), 0u);
+}
+
+TEST (PrometheusParser, SkipsCommentsBlankLinesAndNonFiniteValues) {
+    const std::string body =
+    "\n"
+    "   # a comment that mentions wanted 5\n"
+    "wanted NaN\n"
+    "also_wanted +Inf\n"
+    "third_wanted 4\r\n"                // CRLF: exposition files often are
+    "fourth_wanted 12 1700000000000\n"; // trailing timestamp
+    auto values = parse_prometheus_exposition (
+    body, { "wanted", "also_wanted", "third_wanted", "fourth_wanted" });
+
+    // NaN and +Inf are not chartable numbers, and a name the body did not carry
+    // as a readable sample is absent rather than zero.
+    EXPECT_EQ (values.count ("wanted"), 0u);
+    EXPECT_EQ (values.count ("also_wanted"), 0u);
+    ASSERT_EQ (values.count ("third_wanted"), 1u);
+    EXPECT_DOUBLE_EQ (values["third_wanted"], 4.0);
+    // The exposition timestamp is ignored; the value is still the value.
+    ASSERT_EQ (values.count ("fourth_wanted"), 1u);
+    EXPECT_DOUBLE_EQ (values["fourth_wanted"], 12.0);
+}
+
+TEST (PrometheusParser, ABraceInsideALabelValueDoesNotEndTheLabelSet) {
+    // The naive "find the next '}'" scan reads `5}` as the value and drops the
+    // sample; the quote-aware one reads 5.
+    const std::string body = "queue_depth{name=\"a}b\"} 5\n";
+    auto values = parse_prometheus_exposition (body, { "queue_depth" });
+    ASSERT_EQ (values.count ("queue_depth"), 1u);
+    EXPECT_DOUBLE_EQ (values["queue_depth"], 5.0);
+}
+
+TEST (PrometheusParser, AnUnreadableLineCostsOnlyItself) {
+    const std::string body = "broken{unterminated 1\n"
+                             "good 2\n"
+                             "alsobroken\n"
+                             "trailing_garbage 3x\n";
+    auto values            = parse_prometheus_exposition (
+    body, { "broken", "good", "alsobroken", "trailing_garbage" });
+    ASSERT_EQ (values.size (), 1u);
+    EXPECT_DOUBLE_EQ (values["good"], 2.0);
+}
+
+TEST (JsonMetricsParser, ReadsTheRequestedKeysOnly) {
+    const std::string body = R"({"cpu": 0.25, "rss": 1024, "name": "web-1", "nan": null})";
+    auto values = parse_json_metrics (body, { "cpu", "rss", "name", "nan", "absent" });
+    ASSERT_EQ (values.size (), 2u);
+    EXPECT_DOUBLE_EQ (values["cpu"], 0.25);
+    EXPECT_DOUBLE_EQ (values["rss"], 1024.0);
+}
+
+TEST (JsonMetricsParser, AnUnparseableOrNonObjectBodyYieldsNothing) {
+    EXPECT_TRUE (parse_json_metrics ("not json", { "cpu" }).empty ());
+    EXPECT_TRUE (parse_json_metrics ("[1,2,3]", { "cpu" }).empty ());
+}
+
+// ---------------------------------------------------------------------------
+// Whole-run totals (the report's `monitor` section)
+// ---------------------------------------------------------------------------
+
+TEST (MonitorTotalsTest, SummarisesEachSeriesAndCountsGaps) {
+    MonitorTotals totals;
+    totals.add ({ { "cpu", 1.0 }, { "rss", 100.0 } });
+    totals.add ({ { "cpu", 3.0 } }); // rss missing this scrape
+    totals.record_failure ();
+
+    auto summary = totals.to_summary ();
+    EXPECT_EQ (summary["samples"], 2u);
+    EXPECT_EQ (summary["failures"], 1u);
+
+    const auto& cpu = summary["series"]["cpu"];
+    EXPECT_DOUBLE_EQ (cpu["min"].get<double> (), 1.0);
+    EXPECT_DOUBLE_EQ (cpu["max"].get<double> (), 3.0);
+    EXPECT_DOUBLE_EQ (cpu["avg"].get<double> (), 2.0);
+    EXPECT_EQ (cpu["count"], 2u);
+
+    // A series absent from a scrape is not a zero sample - averaging it in
+    // would report a memory figure the target never reported.
+    const auto& rss = summary["series"]["rss"];
+    EXPECT_EQ (rss["count"], 1u);
+    EXPECT_DOUBLE_EQ (rss["avg"].get<double> (), 100.0);
+}
+
+TEST (MonitorTotalsTest, ASeriesThatNeverReadIsAbsentFromTheSummary) {
+    MonitorTotals totals;
+    totals.record_failure ();
+    auto summary = totals.to_summary ();
+    EXPECT_EQ (summary["samples"], 0u);
+    EXPECT_TRUE (summary["series"].empty ());
+}
+
+// ---------------------------------------------------------------------------
+// The scrape loop, against a live run
+// ---------------------------------------------------------------------------
+
+class MonitorRunTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_monitor_run.db";
+
+    void SetUp () override {
+        vayu::http::global_init ();
+        server = std::make_unique<SlowMockServer> ();
+        cleanup ();
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+    void TearDown () override {
+        db.reset ();
+        cleanup ();
+        server.reset ();
+        vayu::http::global_cleanup ();
+    }
+
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    void create_run_row (const std::string& run_id) {
+        vayu::db::Run row;
+        row.id              = run_id;
+        row.type            = vayu::RunType::Load;
+        row.status          = vayu::RunStatus::Pending;
+        row.config_snapshot = "{}";
+        row.start_time = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                         .count ();
+        row.end_time = 0;
+        db->create_run (row);
+    }
+
+    // A short run against the fast endpoint, with the monitor block under test.
+    json run_config (json monitor) const {
+        return json{ { "mode", "constant_rps" }, { "duration", "3s" },
+            { "targetRps", 20.0 }, { "url", server->fast_url () },
+            { "method", "GET" }, { "timeout", 5000 }, { "workers", 1 },
+            { "monitor", std::move (monitor) } };
+    }
+
+    // Let the run reach its own end rather than cutting it short: these tests
+    // are about what the scrape did *over* a run, so shutting the manager down
+    // straight after start_run would measure its first 300ms.
+    void wait_for_terminal (const std::string& run_id, int budget_ms) {
+        auto start = Clock::now ();
+        while (std::chrono::duration_cast<std::chrono::milliseconds> (Clock::now () - start)
+               .count () < budget_ms) {
+            auto stored = db->get_run (run_id);
+            if (stored && stored->status != vayu::RunStatus::Pending &&
+            stored->status != vayu::RunStatus::Running) {
+                return;
+            }
+            std::this_thread::sleep_for (std::chrono::milliseconds (50));
+        }
+        ADD_FAILURE () << "run " << run_id << " never reached a terminal status";
+    }
+
+    std::unique_ptr<SlowMockServer> server;
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+TEST_F (MonitorRunTest, AConfiguredRunRecordsSamplesForItsWholeDuration) {
+    const std::string run_id = "run-monitor-records";
+    create_run_row (run_id);
+
+    vayu::core::RunManager manager;
+    ASSERT_TRUE (manager.start_run (run_id,
+    run_config (json{ { "url", server->vitals_url () }, { "intervalMs", 250 },
+    { "series", json::array ({ "vayu_test_cpu", "vayu_test_rss_bytes" }) } }),
+    *db, false));
+    wait_for_terminal (run_id, 20000);
+    manager.shutdown (std::chrono::milliseconds (15000));
+
+    auto samples = db->get_monitor_samples_paginated (run_id, 5000, 0);
+    // ~3s at 250ms; the floor is deliberately loose, the point is "for the
+    // whole run" rather than "once at the start".
+    ASSERT_GE (samples.size (), 4u) << "only " << samples.size () << " scrapes landed";
+    EXPECT_EQ (db->count_monitor_samples (run_id), static_cast<int64_t> (samples.size ()));
+
+    auto payload = json::parse (samples.front ().payload);
+    EXPECT_GT (payload["timestamp"].get<int64_t> (), 0);
+    // Summed across the two labelled cpu samples the endpoint exports.
+    EXPECT_DOUBLE_EQ (payload["series"]["vayu_test_cpu"].get<double> (), 4.0);
+    EXPECT_GT (payload["series"]["vayu_test_rss_bytes"].get<double> (), 0.0);
+    // A name the exposition carries but the run did not ask for stays out.
+    EXPECT_FALSE (payload["series"].contains ("vayu_test_unused"));
+
+    // The report's section, from the same scrape.
+    auto stored = db->get_run (run_id);
+    ASSERT_TRUE (stored.has_value ());
+    auto summary = json::parse (stored->summary);
+    ASSERT_TRUE (summary.contains ("monitor")) << stored->summary;
+    EXPECT_GE (summary["monitor"]["samples"].get<size_t> (), 4u);
+    EXPECT_DOUBLE_EQ (
+    summary["monitor"]["series"]["vayu_test_cpu"]["max"].get<double> (), 4.0);
+
+    // And the live topic carried them beside the metrics ticks, on one id space.
+    auto context = manager.get_run_or_retained (run_id);
+    ASSERT_NE (context, nullptr);
+    auto batch      = context->ticks_since (0);
+    size_t monitors = 0;
+    for (size_t i = 0; i < batch.payloads.size (); ++i) {
+        if (batch.payloads[i].rfind ("event: monitor\n", 0) == 0) {
+            ++monitors;
+        }
+    }
+    EXPECT_GT (monitors, 0u) << "no monitor frame reached the live stream";
+}
+
+TEST_F (MonitorRunTest, AJsonEndpointIsReadWithTheSamePipeline) {
+    const std::string run_id = "run-monitor-json";
+    create_run_row (run_id);
+
+    vayu::core::RunManager manager;
+    ASSERT_TRUE (manager.start_run (run_id,
+    run_config (json{ { "url", server->vitals_json_url () }, { "intervalMs", 250 },
+    { "format", "json" }, { "series", json::array ({ "vayu_test_cpu" }) } }),
+    *db, false));
+    wait_for_terminal (run_id, 20000);
+    manager.shutdown (std::chrono::milliseconds (15000));
+
+    auto samples = db->get_monitor_samples_paginated (run_id, 5000, 0);
+    ASSERT_FALSE (samples.empty ());
+    auto payload = json::parse (samples.front ().payload);
+    EXPECT_DOUBLE_EQ (payload["series"]["vayu_test_cpu"].get<double> (), 4.0);
+}
+
+// The acceptance criterion the design is built around: the scrape is a separate
+// thread precisely so a hanging endpoint cannot hold the tick cadence. Run
+// against /hang, the run must still finish on time and still produce its
+// per-second ticks.
+TEST_F (MonitorRunTest, AHangingEndpointStallsNeitherTheRunNorTheTicks) {
+    const std::string run_id = "run-monitor-hang";
+    create_run_row (run_id);
+
+    vayu::core::RunManager manager;
+    auto started = Clock::now ();
+    ASSERT_TRUE (manager.start_run (run_id,
+    run_config (json{ { "url", server->hang_url () }, { "intervalMs", 500 },
+    { "series", json::array ({ "vayu_test_cpu" }) } }),
+    *db, false));
+    wait_for_terminal (run_id, 25000);
+    manager.shutdown (std::chrono::milliseconds (20000));
+    auto elapsed =
+    std::chrono::duration_cast<std::chrono::milliseconds> (Clock::now () - started)
+    .count ();
+
+    // The 3s run plus teardown, nowhere near /hang's 30s hold.
+    EXPECT_LT (elapsed, 15000) << "the run waited on the monitor endpoint";
+
+    // Ticks are persisted once a second and are what the charts draw; a scrape
+    // blocking the metrics thread would show up as missing ticks.
+    EXPECT_GE (db->count_metric_ticks (run_id), 2)
+    << "the tick cadence was disturbed by the scrape";
+    EXPECT_EQ (db->count_monitor_samples (run_id), 0)
+    << "a hung scrape stored a sample";
+
+    // The gaps are counted, so the report says the scrape found nothing rather
+    // than silently showing an empty chart.
+    auto stored = db->get_run (run_id);
+    ASSERT_TRUE (stored.has_value ());
+    auto summary = json::parse (stored->summary);
+    ASSERT_TRUE (summary.contains ("monitor"));
+    EXPECT_EQ (summary["monitor"]["samples"].get<size_t> (), 0u);
+    EXPECT_GT (summary["monitor"]["failures"].get<size_t> (), 0u);
+}
+
+TEST_F (MonitorRunTest, ARunWithoutAMonitorScrapesNothingAndReportsNoSection) {
+    const std::string run_id = "run-monitor-absent";
+    create_run_row (run_id);
+
+    json config = json{ { "mode", "constant_rps" }, { "duration", "1s" },
+        { "targetRps", 10.0 }, { "url", server->fast_url () },
+        { "method", "GET" }, { "timeout", 5000 }, { "workers", 1 } };
+
+    vayu::core::RunManager manager;
+    ASSERT_TRUE (manager.start_run (run_id, config, *db, false));
+    wait_for_terminal (run_id, 20000);
+    manager.shutdown (std::chrono::milliseconds (15000));
+
+    EXPECT_EQ (db->count_monitor_samples (run_id), 0);
+    auto stored = db->get_run (run_id);
+    ASSERT_TRUE (stored.has_value ());
+    auto summary = json::parse (stored->summary);
+    EXPECT_FALSE (summary.contains ("monitor"))
+    << "a run that configured no monitor reported one";
+}
+
+TEST_F (MonitorRunTest, DeletingARunRemovesItsMonitorSamples) {
+    const std::string run_id = "run-monitor-cascade";
+    create_run_row (run_id);
+    db->add_monitor_sample (
+    { 0, run_id, 1700000000000, R"({"timestamp":1,"series":{"cpu":1}})" });
+    ASSERT_EQ (db->count_monitor_samples (run_id), 1);
+
+    db->delete_run (run_id);
+    EXPECT_EQ (db->count_monitor_samples (run_id), 0)
+    << "monitor samples outlived the run they belong to";
+}
+
+} // namespace

--- a/engine/tests/monitor_test.cpp
+++ b/engine/tests/monitor_test.cpp
@@ -118,6 +118,90 @@ TEST (MonitorConfigValidation, LoopbackAndPrivateTargetsAreAllowed) {
 }
 
 // ---------------------------------------------------------------------------
+// The two limits a user can move
+// ---------------------------------------------------------------------------
+
+class MonitorLimitsTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_monitor_limits.db";
+
+    void SetUp () override {
+        vayu::tests::remove_database_files (DB_PATH);
+        db = std::make_unique<vayu::db::Database> (DB_PATH);
+        db->init ();
+    }
+    void TearDown () override {
+        db.reset ();
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    void set_config (const std::string& key, const std::string& value) {
+        auto entry = db->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << "seed_default_config did not seed " << key;
+        entry->value = value;
+        db->save_config_entry (*entry);
+    }
+
+    std::unique_ptr<vayu::db::Database> db;
+};
+
+TEST_F (MonitorLimitsTest, AFreshDatabaseYieldsTheSeededDefaults) {
+    const auto limits = vayu::core::read_monitor_limits (*db);
+    EXPECT_EQ (limits.default_interval_ms, vayu::core::monitor_limits::DEFAULT_INTERVAL_MS);
+    EXPECT_EQ (limits.max_series, vayu::core::monitor_limits::MAX_SERIES);
+}
+
+// The setting has to reach a block that named no interval of its own, or it
+// would be a knob nothing reads on the path clients actually take.
+TEST_F (MonitorLimitsTest, TheConfiguredIntervalIsWhatABlockWithoutOneScrapesAt) {
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorIntervalMs", "5000"));
+    const auto limits = vayu::core::read_monitor_limits (*db);
+    ASSERT_EQ (limits.default_interval_ms, 5000);
+
+    auto config = monitor_config (json{ { "url", "http://localhost:9100/metrics" },
+    { "series", json::array ({ "up" }) } });
+    auto parsed = monitor_config_from (config, limits);
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->interval_ms, 5000);
+
+    // ...and a block that states its own still wins.
+    config["monitor"]["intervalMs"] = 250;
+    EXPECT_EQ (monitor_config_from (config, limits)->interval_ms, 250);
+}
+
+TEST_F (MonitorLimitsTest, TheConfiguredCapIsWhatTheSeriesListIsJudgedAgainst) {
+    auto nine_names = json::array ();
+    for (int i = 0; i < 9; ++i) {
+        nine_names.push_back ("metric_" + std::to_string (i));
+    }
+    auto config = monitor_config (
+    json{ { "url", "http://localhost:9100/metrics" }, { "series", nine_names } });
+
+    // Nine is over the seeded cap of eight...
+    EXPECT_TRUE (
+    validate_monitor_config (config, vayu::core::read_monitor_limits (*db)).has_value ());
+
+    // ...and under a raised one.
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorMaxSeries", "12"));
+    const auto raised = vayu::core::read_monitor_limits (*db);
+    ASSERT_EQ (raised.max_series, 12u);
+    EXPECT_FALSE (validate_monitor_config (config, raised).has_value ());
+    EXPECT_TRUE (monitor_config_from (config, raised).has_value ());
+}
+
+// `POST /config` range-checks both keys, so a value outside the range can only
+// arrive from a hand-edited row - where a 0 interval is a tight scrape loop and
+// a 0 cap rejects every block a user could write.
+TEST_F (MonitorLimitsTest, AHandEditedValueOutOfRangeFallsBackToTheSeed) {
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorIntervalMs", "0"));
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorMaxSeries", "0"));
+
+    const auto limits = vayu::core::read_monitor_limits (*db);
+    EXPECT_EQ (limits.default_interval_ms, vayu::core::monitor_limits::DEFAULT_INTERVAL_MS);
+    EXPECT_EQ (limits.max_series, vayu::core::monitor_limits::MAX_SERIES);
+}
+
+// ---------------------------------------------------------------------------
 // Prometheus exposition parsing
 // ---------------------------------------------------------------------------
 

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -425,3 +425,36 @@ TEST (RunConfigValidation, AnEmptyThresholdsObjectIsRejectedByTheRunRoute) {
     config["thresholds"] = nlohmann::json::object ();
     expect_rejected (config, "thresholds");
 }
+
+// --- 8. Monitor: the other nested object the route gates -------------------
+//
+// Same split as thresholds above: the rule lives with the scrape loop
+// (`vayu::core::validate_monitor_config`, exercised field by field in
+// monitor_test.cpp), and what matters here is that the run route reaches it -
+// an unusable monitor block must be a 400 before a run row exists, not a run
+// that starts a scrape thread with nothing to read.
+
+TEST (RunConfigValidation, AConfigWithoutAMonitorIsStillValid) {
+    auto config = valid_config ();
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+}
+
+TEST (RunConfigValidation, AValidMonitorBlockIsAccepted) {
+    auto config       = valid_config ();
+    config["monitor"] = { { "url", "http://127.0.0.1:9100/metrics" }, { "intervalMs", 1000 },
+        { "series", nlohmann::json::array ({ "node_cpu_seconds_total" }) } };
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+}
+
+TEST (RunConfigValidation, AMonitorWithoutSeriesIsRejectedByTheRunRoute) {
+    auto config       = valid_config ();
+    config["monitor"] = { { "url", "http://127.0.0.1:9100/metrics" } };
+    expect_rejected (config, "monitor.series");
+}
+
+TEST (RunConfigValidation, AMonitorIntervalOutOfRangeIsRejectedByTheRunRoute) {
+    auto config       = valid_config ();
+    config["monitor"] = { { "url", "http://127.0.0.1:9100/metrics" }, { "intervalMs", 10 },
+        { "series", nlohmann::json::array ({ "up" }) } };
+    expect_rejected (config, "monitor.intervalMs");
+}

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -29,12 +29,14 @@
 
 #include "vayu/core/constants.hpp"
 #include "vayu/core/metrics_collector.hpp"
+#include "vayu/core/monitor.hpp"
 
 namespace vayu::http::routes {
 // Declared here rather than in routes.hpp, matching apply_config_update in
 // config_route_test.cpp: the extracted core is an implementation detail of the
 // route, and only its test needs the prototype.
-std::optional<std::string> validate_run_config (const nlohmann::json& config);
+std::optional<std::string> validate_run_config (const nlohmann::json& config,
+const vayu::core::MonitorLimits& monitor_limits = {});
 } // namespace vayu::http::routes
 
 namespace {

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -731,6 +731,41 @@ TEST_F (RunsRouteTest, ReportOmitsSamplingWhenTheSummaryPredatesIt) {
     EXPECT_FALSE (body.contains ("sampling"));
 }
 
+// Server vitals survive the summary -> report round trip in the shape the
+// scrape wrote them, so the section a reader sees is the one the run recorded.
+TEST_F (RunsRouteTest, ReportCarriesTheMonitorSummary) {
+    seed ({ .id = "run_monitor", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+    vayu::core::MonitorTotals totals;
+    totals.add ({ { "node_cpu", 1.0 } });
+    totals.add ({ { "node_cpu", 3.0 } });
+    totals.record_failure ();
+    inputs.monitor = totals.to_summary ();
+    db_->update_run_summary (
+    "run_monitor", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_monitor");
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body.contains ("monitor"));
+    EXPECT_EQ (body["monitor"]["samples"].get<size_t> (), 2u);
+    EXPECT_EQ (body["monitor"]["failures"].get<size_t> (), 1u);
+    EXPECT_DOUBLE_EQ (body["monitor"]["series"]["node_cpu"]["avg"].get<double> (), 2.0);
+}
+
+// The absence twin: a run that configured no monitor reports no section, rather
+// than a target that reported nothing.
+TEST_F (RunsRouteTest, ReportOmitsMonitorWhenNoneWasConfigured) {
+    seed ({ .id = "run_no_monitor", .start_time = 1000 });
+    auto inputs    = summary_inputs ();
+    inputs.monitor = std::nullopt;
+    db_->update_run_summary (
+    "run_no_monitor", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_no_monitor");
+    ASSERT_EQ (status, 200);
+    EXPECT_FALSE (body.contains ("monitor"));
+}
+
 // A run without script validation keeps the section out entirely, rather than
 // reporting a run of zero tests that all passed.
 TEST_F (RunsRouteTest, ReportOmitsTestValidationWhenNoScriptRan) {

--- a/engine/tests/stats_route_test.cpp
+++ b/engine/tests/stats_route_test.cpp
@@ -36,6 +36,8 @@ namespace vayu::http::routes {
 // Defined in metrics.cpp; returns {http_status, json_body}.
 std::pair<int, nlohmann::json> run_time_series_response (vayu::db::Database& db,
 const std::string& run_id, int64_t limit, int64_t offset);
+std::pair<int, nlohmann::json> run_monitor_series_response (vayu::db::Database& db,
+const std::string& run_id, int64_t limit, int64_t offset);
 } // namespace vayu::http::routes
 
 namespace {
@@ -273,6 +275,47 @@ TEST_F (StatsRouteTest, UnreadableTickPayloadIsSkippedNotFatal) {
     // The row still counts for pagination - the page really did consume it.
     EXPECT_EQ (body["pagination"]["total"].get<int64_t> (), 2);
     EXPECT_EQ (body["pagination"]["returned"].get<int64_t> (), 2);
+}
+
+// ============================================================================
+// The server-vitals series (monitor_samples)
+// ============================================================================
+
+// Same envelope as the tick series, from its own table - so a client that can
+// page one can page the other.
+TEST_F (StatsRouteTest, MonitorSeriesReturnsStoredSamplesInTheSharedEnvelope) {
+    const std::string id = seed_run ();
+    db_->add_monitor_sample ({ 0, id, 1000,
+    vayu::core::build_monitor_sample_payload (1000, { { "cpu", 0.5 } }).dump () });
+    db_->add_monitor_sample ({ 0, id, 2000,
+    vayu::core::build_monitor_sample_payload (2000, { { "cpu", 0.75 } }).dump () });
+
+    auto [status, body] =
+    vayu::http::routes::run_monitor_series_response (*db_, id, 5000, 0);
+    ASSERT_EQ (status, 200);
+    ASSERT_EQ (body["data"].size (), 2u);
+    EXPECT_EQ (body["data"][0]["timestamp"].get<int64_t> (), 1000);
+    EXPECT_DOUBLE_EQ (body["data"][1]["series"]["cpu"].get<double> (), 0.75);
+    EXPECT_EQ (body["pagination"]["total"].get<int64_t> (), 2);
+    EXPECT_FALSE (body["pagination"]["hasMore"].get<bool> ());
+}
+
+// A run that configured no monitor is an empty series, not a 404: the run
+// exists and simply scraped nothing.
+TEST_F (StatsRouteTest, MonitorSeriesIsEmptyForARunWithoutAMonitor) {
+    const std::string id = seed_run ();
+    auto [status, body] =
+    vayu::http::routes::run_monitor_series_response (*db_, id, 5000, 0);
+    EXPECT_EQ (status, 200);
+    EXPECT_EQ (body["data"].size (), 0u);
+    EXPECT_EQ (body["pagination"]["total"].get<int64_t> (), 0);
+}
+
+TEST_F (StatsRouteTest, MonitorSeriesMissingRunIs404) {
+    auto [status, body] =
+    vayu::http::routes::run_monitor_series_response (*db_, "run_nope", 5000, 0);
+    EXPECT_EQ (status, 404);
+    EXPECT_EQ (body["error"]["message"], "Run not found");
 }
 
 } // namespace


### PR DESCRIPTION
## Description

A run knew everything about the client side and nothing about the target: when p99 climbed, nothing said whether the server's CPU climbed with it. A run may now declare a `monitor` block naming a metrics endpoint, which the engine scrapes for the life of the run and both dashboards chart on the same timeline as p99 and throughput.

**Plan.** The root cause is that the per-tick series (`MetricTickSample`) has no channel for external data and the dashboard can only draw what it produces itself. The approach follows the existing per-run auxiliary-thread precedent: a `monitor_thread` on `RunContext` beside the metrics thread, its own `monitor_samples` table shaped exactly like `metric_ticks`, its own `GET /runs/:id/monitor` endpoint in the shared envelope, live `monitor` frames on the ring the SSE endpoint already drains, and a `monitor` report section through the standard four-hop. **The alternative I rejected was widening `metric_ticks`** - either as extra payload keys or by scraping on the metrics thread. Both fail for the same reason from two directions: that payload's key set *is* the `GET /runs/:id/metrics` contract (pinned by `stats_route_test.cpp`), and the metrics thread is a fixed-cadence sampler with no deadline compensation, so a blocking scrape inside it delays every later tick and a hanging endpoint would end live metrics for the whole run.

Two design points worth a reviewer's eye:

- **Frames are framed under the ring's lock.** `RunContext::append_event` assigns the SSE id inside `tick_mtx`, because a monitored run has *two* producers on that ring and the previous `published_count.load()`-then-`append_tick` pattern would hand both the same id, breaking `Last-Event-ID` resume. I verified the assumption the issue asked about: `live_metrics` (`metrics.cpp`) replays pre-framed strings and terminates on `closed && offset >= published_count`, so interleaved `monitor` frames sharing that id space replay correctly. `build_tick_payload` / `build_step_payload` now delegate to the same framing helper, so there is one copy of the wire shape.
- **Samples are joined by wall clock, not elapsed seconds.** A tick's `elapsed_seconds` starts at the first *persisted* tick while the scrape starts with the run, so joining on it would offset the two series by ~1s. `joinMonitorToTimeline` joins on `timestamp` and holds each reading until the next scrape, going null once it is older than the observed cadence allows - which is what makes a failed scrape a gap rather than a plateau over the outage.

### Settings (review follow-up)

Two of the five constants this feature introduced are things a user would reach for, and are seeded as engine settings the way #478's `oauth2Refresh*` keys are, so the Settings panel renders them with no app change:

| Key | Default | Range | What it does |
|---|---|---|---|
| `monitorIntervalMs` | 1000 | 250–60000 | Cadence a run scrapes at when its `monitor` block names none |
| `monitorMaxSeries` | 8 | 1–64 | How many metrics one run may chart |

Both are read per run - a change applies to the next run started. The other three stay constants deliberately: the interval *bounds* stop a cadence that measures the scraper rather than the target, and the backoff threshold is how politely the loop gives up on a dead endpoint. `read_monitor_limits(db)` is the single reader, and the decision functions take a resolved `MonitorLimits` rather than a `Database` - the split `resolve_request_timeout_ms` already draws in the execution route. The app reads the same two entries through `useMonitorSettings`, because this dialog always sends an explicit `intervalMs`, so a renderer-local default would leave the engine's copy with no reader on the UI path.

### Deliberate deviations

Both tracked in #491 rather than left silent:

- **`start_load_run` (MCP) does not grow the block**, which the issue listed as conditional ("if"). Keeping it out holds this diff to the app's own path - and the monitor URL is a second host an ad-hoc agent run would contact, which is an allowlist decision that deserves its own review rather than a footnote here.
- **The app's `RunReport` type carries the report's `monitor` section but nothing renders it as a panel.** It has a reader - the history view gates its `GET /runs/:id/monitor` fetch on `report.monitor.samples` - so it is not the repo's "written but never read" defect; a per-series summary panel beside the chart is deferred.

Also: three categorical chart roles were added for a plot whose series count the *user* decides. `--chart-4` (amber) is deliberately excluded - it measures 2.38 against a light card, under the 3.0 a series must clear (`status-token-contrast.test.ts`, which derives its list from `ROLE_TOKEN` and caught this).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally on the merged branch (base `9880a02`, which includes #488 and #478):

- **Engine** - `python build.py -e -t && cd engine && ctest --preset linux-dev`: **1330/1330 passed** (159s). New: `engine/tests/monitor_test.cpp` (26 tests - validation gate and run-reader parity, Prometheus parsing incl. labelled-family summing, `NaN`/`+Inf`, CRLF, a `}` inside a quoted label value, JSON parsing, `MonitorTotals`, the four config-limit tests, plus five whole-run tests driving `RunManager::start_run` against a canned `/vitals` endpoint). The acceptance test is `AHangingEndpointStallsNeitherTheRunNorTheTicks`: the run points its monitor at `/hang` (30s hold), still finishes in time, still persists its per-second ticks, stores no sample, and reports the gaps. Also added: 2 report round-trip/absence tests (`runs_route_test.cpp`), 3 series-endpoint tests (`stats_route_test.cpp`), 4 route-validation tests (`run_config_validation_test.cpp`), 1 cascade test.
- **App** - `pnpm test`: **3889/3889 passed** (386 files). New: `monitorSeries.test.ts` (10), `monitor.test.ts` (12), plus cases in the SSE, store, chart-smoke and dialog suites. `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean.
- **Docs** - `mkdocs build --strict` clean.

Two config-backed behaviours are mutation-checked rather than merely asserted: reverting the configured-cadence line turns `TheConfiguredIntervalIsWhatABlockWithoutOneScrapesAt` red, and the cap test binds in both directions (9 names rejected at 8, accepted at 12).

One pre-existing flake, unrelated and not touched: `SentRequestHeadersTest.DefaultUserAgentReachesTheTestScript` timed out once under a loaded parallel run and passes in isolation and on re-run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #475
Follow-ups deferred here: #491