### PR TITLE
fix(engine/scripting): a failed assertion is an AssertionError, not a TypeError

### DIFF
--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -271,6 +271,22 @@ Non-strings are coerced and `undefined` / `null` mean no message, both as in
 chai. Assertion failures carry it; a malformed call (`.to.be.above()` with no
 argument) reports its own misuse unprefixed.
 
+**A failed assertion is an `AssertionError`**, as in chai - both from
+`pm.expect` and from `pm.response.to`:
+
+```javascript
+pm.expect(1).to.equal(2);
+// AssertionError: Expected 1 to equal 2
+try { pm.response.to.have.status(200); } catch (e) { e.name === 'AssertionError'; }
+```
+
+QuickJS has no `AssertionError` class, so this is an `Error` carrying that
+`name`: `instanceof Error` holds, `e.stack` is the same one a native throw
+gets, and there is no `AssertionError` global to reference (chai's lives on the
+`chai` module, which Vayu does not ship). **A mistake in the script text stays a
+`TypeError`** - a matcher called with no argument, a name nothing implements -
+because nothing was asserted, the call itself was wrong.
+
 `have.keys` asserts *exactly* those keys. `Map` / `Set` / typed arrays are
 reported unequal by `eql` rather than compared (their contents are not
 properties); `Date` compares by instant, `RegExp` by pattern; a cyclic value

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -54,6 +54,27 @@ unchanged. It prefixes assertion failures only - a call the script wrote wrong
 (`.to.be.above()` with no argument) reports the misuse on its own, since the
 message describes a value, not a typo.
 
+**A failed assertion throws an `AssertionError`**, the name chai uses, so a
+script that inspects what it caught takes the same branch it does in Postman:
+
+```javascript
+try {
+  pm.expect(1).to.equal(2);        // AssertionError: Expected 1 to equal 2
+} catch (e) {
+  e.name;                          // 'AssertionError'
+  e instanceof Error;              // true
+}
+```
+
+QuickJS has no `AssertionError` class, so this is an `Error` with that `name`
+and the stack a native throw carries; no `AssertionError` global is exposed,
+because chai's is a property of the `chai` module rather than a global and Vayu
+does not ship that module. The same name comes off the
+[response assertions](#response-assertions), which are chai in Postman too.
+**A mistake in the script text is still a `TypeError`** - a matcher called with
+no argument, a name nothing implements - because nothing was asserted: the call
+itself was wrong.
+
 **`equal` is strict, `eql` is deep.** `equal` is `===`, so two objects with the
 same contents are *not* equal - only the same reference is. `eql` (and its alias
 `deep.equal`) compares contents recursively and does not care about key order.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -426,6 +426,7 @@ if(VAYU_BUILD_TESTS)
         tests/json_test.cpp
         tests/script_engine_test.cpp
         tests/script_expect_message_test.cpp
+        tests/script_assertion_error_test.cpp
         tests/script_completions_test.cpp
         tests/script_types_test.cpp
         tests/event_loop_test.cpp

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -372,6 +372,42 @@ JSClassDef expect_class = { .class_name = "Expectation",
     .exotic                             = nullptr };
 
 /**
+ * @brief Throw a failed assertion the way chai does - as an `AssertionError`.
+ *
+ * `pm.expect` is chai, and chai reports a broken assertion as an
+ * `AssertionError`. Vayu threw a `TypeError` instead, which is wrong in two
+ * ways a user can see (issue #487): the report and the console prefix every
+ * failure with `TypeError:`, which reads as an engine fault rather than the
+ * assertion doing its job, and a script that inspects what it caught -
+ * `catch (e) { if (e.name === "AssertionError") ... }` - takes the other branch
+ * than it does in Postman.
+ *
+ * QuickJS has no `AssertionError` class, so the error is a plain `Error` with
+ * the name replaced: `instanceof Error` still holds, `JS_NewError` gives it the
+ * same backtrace a native throw would, and `message` is defined with the
+ * native errors' attributes (writable, configurable, **not** enumerable) so
+ * `JSON.stringify(e)` answers what it always did. No `AssertionError` global is
+ * exposed - chai's lives on the `chai` module, which Vayu does not ship, and a
+ * bare global would be a name Postman scripts cannot rely on either.
+ *
+ * Only *assertion* failures come through here. A script-text mistake - a
+ * matcher called with no argument, a misspelled name under `pm.response.to` -
+ * stays a `TypeError`, in chai as much as here: nothing was asserted, the call
+ * itself was wrong.
+ */
+JSValue throw_assertion_failure (JSContext* ctx, const std::string& message) {
+    JSValue error = JS_NewError (ctx);
+    if (JS_IsException (error)) {
+        return JS_EXCEPTION;
+    }
+    JS_DefinePropertyValueStr (ctx, error, "name", JS_NewString (ctx, "AssertionError"),
+    JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
+    JS_DefinePropertyValueStr (ctx, error, "message", JS_NewString (ctx, message.c_str ()),
+    JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
+    return JS_Throw (ctx, error);
+}
+
+/**
  * @brief Report a failed assertion, prefixed with the expectation's message.
  *
  * chai's `expect(value, message)` puts the script's own words in front of
@@ -390,10 +426,9 @@ JSClassDef expect_class = { .class_name = "Expectation",
  */
 JSValue throw_expect_failure (JSContext* ctx, const ExpectState* state, const std::string& failure) {
     if (state != nullptr && !state->message.empty ()) {
-        const std::string prefixed = state->message + ": " + failure;
-        return JS_ThrowTypeError (ctx, "%s", prefixed.c_str ());
+        return throw_assertion_failure (ctx, state->message + ": " + failure);
     }
-    return JS_ThrowTypeError (ctx, "%s", failure.c_str ());
+    return throw_assertion_failure (ctx, failure);
 }
 
 // ----------------------------------------------------------------------------
@@ -2140,6 +2175,13 @@ void install_response_body_readers (JSContext* ctx, JSValue response, const std:
 // pm.response.to.have Assertions (Postman-compatible)
 // ============================================================================
 
+// These are chai assertions in Postman exactly as `pm.expect` is, so their
+// failures throw through `throw_assertion_failure` too - a report that named
+// one form `AssertionError` and the other `TypeError` would be a distinction
+// with nothing behind it. They carry no chai message argument (`status(200)`
+// takes a status code, not a message), so they call the helper directly rather
+// than through `throw_expect_failure`, which exists to apply that prefix.
+
 JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv) {
     if (argc < 1) {
         return JS_ThrowTypeError (ctx, "status() requires an expected status code");
@@ -2158,7 +2200,7 @@ JSValue js_response_have_status (JSContext* ctx, JSValueConst this_val, int argc
     if (data->response->status_code != expected_status) {
         std::string msg = "Expected status code " + std::to_string (expected_status) +
         " but got " + std::to_string (data->response->status_code);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_assertion_failure (ctx, msg);
     }
 
     return JS_UNDEFINED;
@@ -2194,7 +2236,7 @@ JSValue js_response_have_header (JSContext* ctx, JSValueConst this_val, int argc
 
     if (!found) {
         std::string msg = "Expected response to have header '" + header_name + "'";
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_assertion_failure (ctx, msg);
     }
 
     // If a second argument is provided, check the value
@@ -2203,7 +2245,7 @@ JSValue js_response_have_header (JSContext* ctx, JSValueConst this_val, int argc
         if (found_value != expected_value) {
             std::string msg = "Expected header '" + header_name + "' to be '" +
             expected_value + "' but got '" + found_value + "'";
-            return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+            return throw_assertion_failure (ctx, msg);
         }
     }
 
@@ -2224,7 +2266,7 @@ JSValue js_response_have_body (JSContext* ctx, JSValueConst this_val, int argc, 
 
     if (data->response->body.find (expected) == std::string::npos) {
         std::string msg = "Expected response body to contain '" + expected + "'";
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_assertion_failure (ctx, msg);
     }
 
     return JS_UNDEFINED;
@@ -2242,7 +2284,7 @@ JSValue js_response_have_jsonBody (JSContext* ctx, JSValueConst this_val, int ar
     if (JS_IsException (json)) {
         // Swallow the parse exception so we report a clean assertion failure.
         JS_FreeValue (ctx, JS_GetException (ctx));
-        return JS_ThrowTypeError (ctx, "Response body is not valid JSON");
+        return throw_assertion_failure (ctx, "Response body is not valid JSON");
     }
 
     // No-arg form asserts only that the body is valid JSON (Postman semantics).
@@ -2274,7 +2316,7 @@ JSValue js_response_have_jsonBody (JSContext* ctx, JSValueConst this_val, int ar
         if (JS_IsUndefined (current)) {
             JS_FreeValue (ctx, json);
             std::string msg = "Expected response body to have property '" + prop_path + "'";
-            return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+            return throw_assertion_failure (ctx, msg);
         }
 
         if (end == std::string::npos)
@@ -2340,7 +2382,7 @@ int magic) {
     if (code < matcher.lo || code > matcher.hi) {
         std::string msg = std::string ("Expected response to have ") +
         matcher.expectation + " but got " + std::to_string (code);
-        return JS_ThrowTypeError (ctx, "%s", msg.c_str ());
+        return throw_assertion_failure (ctx, msg);
     }
 
     return JS_UNDEFINED;
@@ -2358,7 +2400,7 @@ JSValue js_response_be_json (JSContext* ctx, JSValueConst this_val, int argc, JS
     JSValue json = JS_ParseJSON (ctx, data->response->body.c_str (),
     data->response->body.size (), "<response>");
     if (JS_IsException (json)) {
-        return JS_ThrowTypeError (ctx, "Expected response body to be valid JSON");
+        return throw_assertion_failure (ctx, "Expected response body to be valid JSON");
     }
     JS_FreeValue (ctx, json);
 
@@ -2375,7 +2417,7 @@ JSValue js_response_be_with_body (JSContext* ctx, JSValueConst this_val, int arg
     }
 
     if (data->response->body.empty ()) {
-        return JS_ThrowTypeError (ctx, "Expected response to have a body");
+        return throw_assertion_failure (ctx, "Expected response to have a body");
     }
 
     return JS_UNDEFINED;

--- a/engine/tests/script_assertion_error_test.cpp
+++ b/engine/tests/script_assertion_error_test.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file tests/script_assertion_error_test.cpp
+ * @brief A failed assertion is an `AssertionError`, not a `TypeError` (#487).
+ *
+ * `pm.expect` is chai, and chai names a broken assertion `AssertionError`.
+ * Throwing `TypeError` cost two things a script author can see: the report
+ * prefixed every failure with the name of an engine fault, and a script that
+ * branches on `e.name` - the form imported Postman scripts use - took the wrong
+ * branch. So the assertions here are on the *name*, from both directions: what
+ * the report prints, and what the script catches.
+ *
+ * The boundary is the other half of the contract and is tested just as hard: a
+ * mistake in the script text (a matcher called with no argument, a name that
+ * does not exist) is still a `TypeError`, because nothing was asserted - the
+ * call itself was wrong. A change that renamed those too would pass every
+ * name-is-AssertionError test here and still be wrong.
+ *
+ * Mutation-check: point `throw_assertion_failure` back at `JS_ThrowTypeError`
+ * and every test in the first two sections fails while the boundary section
+ * stays green.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "vayu/runtime/script_engine.hpp"
+#include "vayu/types.hpp"
+
+using namespace vayu;
+using namespace vayu::runtime;
+
+namespace {
+
+class AssertionErrorTest : public ::testing::Test {
+    protected:
+    ScriptEngine engine;
+    Request request;
+    Response response;
+    Environment env;
+
+    void SetUp () override {
+        request.method       = HttpMethod::GET;
+        request.url          = "https://api.example.com/users";
+        response.status_code = 200;
+        response.headers     = { { "Content-Type", "application/json" } };
+        response.body        = R"({"id": 1})";
+    }
+
+    /** Runs one assertion inside a `pm.test` and returns what the report shows. */
+    std::string failure_of (const std::string& assertion) {
+        const std::string script = "pm.test(\"t\", function() {\n" + assertion + ";\n});";
+        auto result = engine.execute_test (script, request, response, env);
+        if (result.tests.size () != 1u) {
+            return "<no test recorded for: " + assertion + ">";
+        }
+        if (result.tests[0].passed) {
+            return "<passed, expected a failure: " + assertion + ">";
+        }
+        return result.tests[0].error_message;
+    }
+
+    /**
+     * Runs one assertion and reports what a *script* sees of the thrown error,
+     * as `name|instanceof Error|message`. This is the branch imported Postman
+     * scripts take, so it is checked from inside the sandbox rather than
+     * inferred from the printed string.
+     */
+    std::string caught_shape_of (const std::string& assertion) {
+        const std::string script = "try { " + assertion +
+        "; console.log(\"<did not throw>\"); } catch (e) { console.log("
+        "e.name + \"|\" + (e instanceof Error) + \"|\" + e.message); }";
+        auto result = engine.execute_test (script, request, response, env);
+        if (result.console_output.empty ()) {
+            return "<nothing logged for: " + assertion + ">";
+        }
+        return result.console_output[0].message;
+    }
+
+    static bool starts_with (const std::string& haystack, const std::string& prefix) {
+        return haystack.rfind (prefix, 0) == 0;
+    }
+};
+
+// ----------------------------------------------------------------------------
+// pm.expect
+// ----------------------------------------------------------------------------
+
+/** The owner's case from #487: the report reads as a failed assertion. */
+TEST_F (AssertionErrorTest, ExpectFailureIsReportedAsAnAssertionError) {
+    EXPECT_EQ (failure_of (R"(pm.expect(1).to.equal(2))"),
+    "AssertionError: Expected 1 to equal 2");
+}
+
+/** The other visible consequence: `catch (e) { if (e.name === ...) }`. */
+TEST_F (AssertionErrorTest, AScriptCatchesAnErrorNamedAssertionError) {
+    EXPECT_EQ (caught_shape_of (R"(pm.expect(1).to.equal(2))"),
+    "AssertionError|true|Expected 1 to equal 2");
+}
+
+/**
+ * Every matcher, not one. The name is applied in a single helper, so a matcher
+ * that threw around it would be invisible to a test that checked one chain -
+ * the same argument the #484 message sweep is built on.
+ */
+TEST_F (AssertionErrorTest, EveryMatcherFailsWithTheAssertionErrorName) {
+    const std::vector<std::string> failing_assertions = {
+        R"(pm.expect(1).to.equal(2))",
+        R"(pm.expect({a:1}).to.eql({a:2}))",
+        R"(pm.expect({a:1}).to.deep.equal({a:2}))",
+        R"(pm.expect(undefined).to.exist)",
+        R"(pm.expect(false).to.be.true)",
+        R"(pm.expect(true).to.be.false)",
+        R"(pm.expect(1).to.be.null)",
+        R"(pm.expect(1).to.be.undefined)",
+        R"(pm.expect(0).to.be.ok)",
+        R"(pm.expect([1]).to.be.empty)",
+        R"(pm.expect(1).to.be.above(2))",
+        R"(pm.expect(2).to.be.below(1))",
+        R"(pm.expect(1).to.be.at.least(2))",
+        R"(pm.expect(2).to.be.at.most(1))",
+        R"(pm.expect(1).to.be.a("string"))",
+        R"(pm.expect(1).to.be.an("array"))",
+        R"(pm.expect(1).to.be.instanceOf(Array))",
+        R"(pm.expect(1).to.be.oneOf([2, 3]))",
+        R"(pm.expect(1).to.be.closeTo(5, 0.1))",
+        R"(pm.expect([1]).to.include(2))",
+        R"(pm.expect("ab").to.have.string("zz"))",
+        R"(pm.expect("ab").to.match(/zz/))",
+        R"(pm.expect([1]).to.have.length(2))",
+        R"(pm.expect({a:1}).to.have.property("b"))",
+        R"(pm.expect({a:{b:1}}).to.have.nested.property("a.c"))",
+        R"(pm.expect([1]).to.have.members([2]))",
+        R"(pm.expect(function() {}).to.throw())",
+    };
+
+    for (const auto& assertion : failing_assertions) {
+        const std::string reported = failure_of (assertion);
+        EXPECT_TRUE (starts_with (reported, "AssertionError: "))
+        << assertion << " -> " << reported;
+    }
+}
+
+/** Negated chains fail through the same helper, so they carry the name too. */
+TEST_F (AssertionErrorTest, ANegatedChainFailsWithTheAssertionErrorName) {
+    EXPECT_EQ (failure_of (R"(pm.expect(1).to.not.equal(1))"),
+    "AssertionError: Expected 1 to not equal 1");
+}
+
+/**
+ * #484's custom message still prefixes the failure. Renaming the error must not
+ * cost the context the script wrote - both survive together or the fix traded
+ * one report defect for another.
+ */
+TEST_F (AssertionErrorTest, TheCustomMessagePrefixSurvivesTheRename) {
+    EXPECT_EQ (failure_of (R"(pm.expect(false, "user 42").to.be.true)"),
+    "AssertionError: user 42: Expected value to be truthy");
+    EXPECT_EQ (caught_shape_of (R"(pm.expect(false, "user 42").to.be.true)"),
+    "AssertionError|true|user 42: Expected value to be truthy");
+}
+
+// ----------------------------------------------------------------------------
+// pm.response.to - chai in Postman as much as pm.expect is
+// ----------------------------------------------------------------------------
+
+TEST_F (AssertionErrorTest, ResponseAssertionsFailWithTheAssertionErrorName) {
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.status(404))"),
+    "AssertionError: Expected status code 404 but got 200");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.header("X-Missing"))"),
+    "AssertionError: Expected response to have header 'X-Missing'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.header("Content-Type", "text/plain"))"),
+    "AssertionError: Expected header 'Content-Type' to be 'text/plain' but got "
+    "'application/json'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.body("nope"))"),
+    "AssertionError: Expected response body to contain 'nope'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.jsonBody("missing"))"),
+    "AssertionError: Expected response body to have property 'missing'");
+    EXPECT_EQ (failure_of (R"(pm.response.to.be.notFound)"),
+    "AssertionError: Expected response to have status 404 but got 200");
+}
+
+/** The body-shape assertions read the body rather than the status. */
+TEST_F (AssertionErrorTest, BodyShapeAssertionsFailWithTheAssertionErrorName) {
+    response.body = "not json";
+
+    EXPECT_EQ (failure_of (R"(pm.response.to.be.json)"),
+    "AssertionError: Expected response body to be valid JSON");
+    EXPECT_EQ (failure_of (R"(pm.response.to.have.jsonBody())"),
+    "AssertionError: Response body is not valid JSON");
+
+    response.body = "";
+    EXPECT_EQ (failure_of (R"(pm.response.to.be.withBody)"),
+    "AssertionError: Expected response to have a body");
+}
+
+// ----------------------------------------------------------------------------
+// The boundary: a mistake in the script is not a failed assertion
+// ----------------------------------------------------------------------------
+
+/**
+ * A matcher called wrongly asserted nothing, so naming it `AssertionError`
+ * would report a passing API as a failing one. chai draws the line in the same
+ * place, and `throw_expect_failure`'s comment has said so since #484.
+ */
+TEST_F (AssertionErrorTest, AMisusedMatcherIsStillATypeError) {
+    const std::vector<std::string> usage_errors = {
+        R"(pm.expect(1).to.equal())",
+        R"(pm.expect(1).to.be.above())",
+        R"(pm.expect(1).to.be.below())",
+        R"(pm.expect(1).to.be.a())",
+        R"(pm.expect([1]).to.have.members("nope"))",
+        R"(pm.expect(1).to.be.instanceOf("Array"))",
+        R"(pm.expect(1).to.throw())",
+        R"(pm.response.to.have.status())",
+    };
+
+    for (const auto& usage_error : usage_errors) {
+        const std::string reported = failure_of (usage_error);
+        EXPECT_TRUE (starts_with (reported, "TypeError: "))
+        << usage_error << " -> " << reported;
+    }
+}
+
+/**
+ * A name nothing implements is a misspelling, not a failure - the loud throw
+ * that stops `pm.response.to.not.be.ok` from silently passing keeps reporting
+ * itself as the script-text mistake it is.
+ */
+TEST_F (AssertionErrorTest, AnUnsupportedResponseAssertionIsStillATypeError) {
+    EXPECT_TRUE (starts_with (
+    failure_of (R"(pm.response.to.be.definitelyNotAMatcher)"), "TypeError: "))
+    << failure_of (R"(pm.response.to.be.definitelyNotAMatcher)");
+    EXPECT_TRUE (starts_with (failure_of (R"(pm.response.to.not.be.ok)"), "TypeError: "))
+    << failure_of (R"(pm.response.to.not.be.ok)");
+}
+
+/**
+ * `pm.response.json()` is a reader, not an assertion: a body that does not
+ * parse is the same `TypeError` Postman throws there, and renaming it would
+ * claim an assertion the script never wrote.
+ */
+TEST_F (AssertionErrorTest, ResponseJsonParseFailureIsStillATypeError) {
+    response.body = "not json";
+    EXPECT_EQ (caught_shape_of (R"(pm.response.json())"),
+    "TypeError|true|Response body is not valid JSON");
+}
+
+// ----------------------------------------------------------------------------
+// Shape of the error object
+// ----------------------------------------------------------------------------
+
+/**
+ * The renamed error is a real `Error`: it keeps the stack a native throw gets,
+ * and `message` stays non-enumerable the way every built-in error's is, so a
+ * script that serializes what it caught sees what it always did.
+ */
+TEST_F (AssertionErrorTest, TheAssertionErrorKeepsTheShapeOfANativeError) {
+    const std::string script =
+    R"(try { pm.expect(1).to.equal(2); } catch (e) {
+         console.log("stack=" + (typeof e.stack === "string" && e.stack.length > 0));
+         console.log("json=" + JSON.stringify(e));
+         console.log("string=" + String(e));
+       })";
+
+    auto result = engine.execute_test (script, request, response, env);
+    ASSERT_EQ (result.console_output.size (), 3u);
+    EXPECT_EQ (result.console_output[0].message, "stack=true");
+    EXPECT_EQ (result.console_output[1].message, "json={}");
+    EXPECT_EQ (result.console_output[2].message, "string=AssertionError: Expected 1 to equal 2");
+}
+
+} // namespace

--- a/engine/tests/script_expect_message_test.cpp
+++ b/engine/tests/script_expect_message_test.cpp
@@ -145,10 +145,13 @@ TEST_F (ExpectMessageTest, TheMessageSurvivesNegationAndChaining) {
 // separator, no empty prefix.
 TEST_F (ExpectMessageTest, TheOneArgumentFormIsUnchanged) {
     // Whole-string equality rather than a substring: what this pins is that
-    // nothing was added, which a `contains` cannot see.
+    // nothing was added, which a `contains` cannot see. The leading
+    // `AssertionError:` is chai's name for a failed assertion (#487), not a
+    // prefix this feature adds.
     EXPECT_EQ (failure_of (R"(pm.expect(false).to.be.true)"),
-    "TypeError: Expected value to be truthy");
-    EXPECT_EQ (failure_of (R"(pm.expect(1).to.equal(2))"), "TypeError: Expected 1 to equal 2");
+    "AssertionError: Expected value to be truthy");
+    EXPECT_EQ (failure_of (R"(pm.expect(1).to.equal(2))"),
+    "AssertionError: Expected 1 to equal 2");
 }
 
 // chai coerces the message instead of demanding a string, and a caller that
@@ -163,7 +166,8 @@ TEST_F (ExpectMessageTest, ANonStringMessageIsCoercedAndAnAbsentOneIsNotPrefixed
 
     for (const char* absent : { R"(pm.expect(false, undefined).to.be.true)",
          R"(pm.expect(false, null).to.be.true)", R"(pm.expect(false, "").to.be.true)" }) {
-        EXPECT_EQ (failure_of (absent), "TypeError: Expected value to be truthy") << absent;
+        EXPECT_EQ (failure_of (absent), "AssertionError: Expected value to be truthy")
+        << absent;
     }
 }
 


### PR DESCRIPTION
## Description

#487 asked for a decision first: **A** - throw a real `AssertionError` - or **B** - keep `TypeError` and document the divergence. **This PR takes A.**

**The plan.** Root cause: every `pm.expect` failure went out through `JS_ThrowTypeError`, so chai's `AssertionError` name never existed - the report prefixed each failure with the name of an engine fault, and `catch (e) { if (e.name === "AssertionError") ... }`, the form imported Postman scripts use, took the wrong branch. Approach: one helper, `throw_assertion_failure`, builds an `Error` with that `name` and every assertion failure throws through it (`throw_expect_failure` now delegates); `JS_NewError` supplies the same backtrace a native throw has, and `name`/`message` are defined with the native errors' attributes (writable, configurable, **not** enumerable) so `JSON.stringify(e)` answers what it always did. **Rejected B** - a doc line is ten minutes cheaper and locks in a difference a script can observe, for no gain; the pm surface's whole point is Postman parity, and #484 shipped chai's message argument for exactly that reason. Also rejected within A: defining an `AssertionError` class in a sandbox bootstrap and exposing it as a global - chai's `AssertionError` is a property of the `chai` module, which Vayu does not ship, so a global would be a name Postman scripts cannot rely on either way, and the C-level `name` (the option #487 lists first) is the smaller surface.

**One deliberate widening of the issue's scope**, called out because #487's Problem section names `pm.expect` only: `pm.response.to.have.*` and `pm.response.to.be.*` failures route through the same helper. They are chai in Postman exactly as `pm.expect` is, and the acceptance criterion is "all assertion failures". Fixing only half would have left a report where `pm.expect(res.code).to.equal(200)` says `AssertionError` and `pm.response.to.have.status(200)` says `TypeError` - a distinction with nothing behind it, and a doc line that had to explain it.

**The boundary is unchanged and tested as hard as the rename.** A mistake in the script text stays a `TypeError`: a matcher called with no argument, a name nothing implements under `pm.response.to`, and `pm.response.json()` on an unparseable body (a reader, not an assertion). Nothing was asserted in those cases - the call itself was wrong - and chai draws the line in the same place. This is the line `throw_expect_failure`'s comment has documented since #484.

Verified the issue's premise against master `9880a02` before editing: the code is where #487 says it is, and `rg AssertionError app/src` still finds no branch on the error name - the one hit is an unrelated fixture string in `boxed-surfaces.test.tsx`. **No app changes**, as the issue predicted: the renderer renders the message string.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Behaviour change worth naming even though nothing in-repo reads the name: a script that branched on `e.name === "TypeError"` for an assertion failure now takes the other branch - which is the point of the issue.

## Testing

`python build.py -e -t && ctest --preset linux-dev` - **1311 tests, all green** (the three that failed mid-work were the two #484 assertions pinning the old prefix, updated here, plus one wrong expected string of my own).

New `engine/tests/script_assertion_error_test.cpp`, 11 tests:

- the report reads `AssertionError: Expected 1 to equal 2`, and a script catching it sees `name`, `instanceof Error` and `message` (checked from **inside** the sandbox via `console.log`, not inferred from the printed string)
- all **27** `pm.expect` chains, negated chains, and every `pm.response.to` assertion carry the name
- #484's custom message still prefixes the failure - the rename must not cost the context the script wrote
- the boundary: 8 misused matchers, 2 unsupported names, and `pm.response.json()` are still `TypeError`
- the object's shape: `e.stack` is a non-empty string, `JSON.stringify(e)` is still `{}` (this is what pins the non-enumerable attributes), `String(e)` is the report line

Mutation-check: pointing `throw_assertion_failure` back at `JS_ThrowTypeError` fails every name test while the whole boundary section stays green - so the tests distinguish the fix from its absence, in both directions.

Also run: `pnpm vitest run src/hooks/script-typedefs.docs-compile.test.ts` (2 passed - it compiles the new doc examples against the engine's declarations) and `mkdocs build --strict` (clean; `mkdocs` was not installed in this environment, installed to run it).

## Checklist

- [x] My code follows the style guidelines - clang-format applied to the two test files, which were clean before; `script_engine.cpp` has pre-existing violations under clang-format 18 and was deliberately not reformatted
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - same commit: `docs/engine/scripting.md` (pm.expect + a cross-link to the response assertions) and `docs/app/pm-api-compatibility.md` (assertion chains). Both state the `TypeError` boundary; the existing lines that say a misspelled matcher throws `TypeError` remain correct.

## Related Issues

Closes #487


---
_Generated by [Claude Code](https://claude.ai/code/session_01NdS8CYyzyswh9cPkWA8MVw)_