### PR TITLE
feat(engine/app): per-phase latency histograms under load

### DIFF
--- a/app/src/components/shared/response-viewer/index.ts
+++ b/app/src/components/shared/response-viewer/index.ts
@@ -42,13 +42,25 @@ export type { ResponseActionsProps } from "./ResponseActions";
 // to mean finding all five, and two of them had already drifted. See
 // `timing-phases.ts` for what drifted and why colour lives there.
 export { PHASE_TIPS } from "./phase-tips";
-export { TIMING_PHASES, phaseColor, phasesFromTrace, phasesFromAverages } from "./timing-phases";
+export {
+	TIMING_PHASES,
+	phaseColor,
+	phasesFromTrace,
+	phasesFromAverages,
+	hasPhaseAverages,
+	phasesFromPercentiles,
+	tailRatio,
+} from "./timing-phases";
 export type {
 	TimingPhase,
 	TimingPhaseKey,
 	TimingPhaseSource,
 	TimingAverageSource,
+	TimingPhasePercentileKey,
+	TimingPhasePercentiles,
+	TimingPercentileSource,
 	ResolvedTimingPhase,
+	ResolvedPhasePercentiles,
 	MaybeResolvedTimingPhase,
 } from "./timing-phases";
 export { default as TimingPhaseTiles } from "./TimingPhaseTiles";

--- a/app/src/components/shared/response-viewer/timing-phases.ts
+++ b/app/src/components/shared/response-viewer/timing-phases.ts
@@ -56,6 +56,16 @@ export type TimingPhaseAverageKey =
 	| "avgFirstByteMs"
 	| "avgDownloadMs";
 
+/**
+ * Key on a run report's `timingBreakdown.phases` (per-run percentiles).
+ *
+ * Not the same spelling as {@link TimingPhaseKey}: the engine writes the phase's
+ * wire name, and TTFB's is `firstByte`. Keeping both on the descriptor is what
+ * stops a renderer from reaching for `phases[phase.key]` and silently finding
+ * nothing for TTFB.
+ */
+export type TimingPhasePercentileKey = "dns" | "connect" | "tls" | "firstByte" | "download";
+
 export interface TimingPhase {
 	key: TimingPhaseKey;
 	/** What tiles, legend rows and waterfall rows print. */
@@ -73,6 +83,7 @@ export interface TimingPhase {
 	tip: string;
 	traceKey: TimingPhaseTraceKey;
 	averageKey: TimingPhaseAverageKey;
+	percentileKey: TimingPhasePercentileKey;
 }
 
 /** The phases in wire order. This ordering is the render order everywhere. */
@@ -85,6 +96,7 @@ export const TIMING_PHASES: readonly TimingPhase[] = [
 		tip: PHASE_TIPS.dns,
 		traceKey: "dnsMs",
 		averageKey: "avgDnsMs",
+		percentileKey: "dns",
 	},
 	{
 		key: "connect",
@@ -94,6 +106,7 @@ export const TIMING_PHASES: readonly TimingPhase[] = [
 		tip: PHASE_TIPS.connect,
 		traceKey: "connectMs",
 		averageKey: "avgConnectMs",
+		percentileKey: "connect",
 	},
 	{
 		key: "tls",
@@ -103,6 +116,7 @@ export const TIMING_PHASES: readonly TimingPhase[] = [
 		tip: PHASE_TIPS.tls,
 		traceKey: "tlsMs",
 		averageKey: "avgTlsMs",
+		percentileKey: "tls",
 	},
 	{
 		key: "ttfb",
@@ -112,6 +126,7 @@ export const TIMING_PHASES: readonly TimingPhase[] = [
 		tip: PHASE_TIPS.ttfb,
 		traceKey: "firstByteMs",
 		averageKey: "avgFirstByteMs",
+		percentileKey: "firstByte",
 	},
 	{
 		key: "download",
@@ -121,6 +136,7 @@ export const TIMING_PHASES: readonly TimingPhase[] = [
 		tip: PHASE_TIPS.download,
 		traceKey: "downloadMs",
 		averageKey: "avgDownloadMs",
+		percentileKey: "download",
 	},
 ];
 
@@ -171,4 +187,70 @@ export function phasesFromAverages(
 	source: TimingAverageSource | null | undefined
 ): MaybeResolvedTimingPhase[] {
 	return TIMING_PHASES.map((phase) => ({ ...phase, value: source?.[phase.averageKey] }));
+}
+
+/**
+ * Whether a `timingBreakdown` carries the averages half at all.
+ *
+ * `timingBreakdown` holds two independently-present halves - averages over the
+ * retained trace sample, and `phases` percentiles over every completion - so
+ * the object existing says nothing about the averages. Every renderer of the
+ * averages asks this instead of testing the object, which is what keeps a
+ * phases-only report from painting five zeroed bars and a "0 ms" total.
+ */
+export function hasPhaseAverages(source: TimingAverageSource | null | undefined): boolean {
+	return TIMING_PHASES.some((phase) => source?.[phase.averageKey] !== undefined);
+}
+
+/** One phase's whole-run distribution, as the engine writes it. */
+export interface TimingPhasePercentiles {
+	p50: number;
+	p95: number;
+	p99: number;
+	max: number;
+	/** Completions behind this distribution; identical across the five. */
+	count: number;
+}
+
+/** Any object carrying per-run percentiles: a report's `timingBreakdown.phases`. */
+export type TimingPercentileSource = Partial<
+	Record<TimingPhasePercentileKey, TimingPhasePercentiles | undefined>
+>;
+
+/** A phase paired with its whole-run distribution. */
+export interface ResolvedPhasePercentiles extends TimingPhase {
+	percentiles: TimingPhasePercentiles;
+}
+
+/**
+ * The phases a run reported percentiles for, in wire order.
+ *
+ * Filters like `phasesFromTrace` and unlike `phasesFromAverages`: this table is
+ * only rendered at all when the section exists, and a phase the engine did not
+ * write is one it did not measure. Returns an empty list for an absent section,
+ * which is the caller's signal to render nothing rather than an empty table.
+ */
+export function phasesFromPercentiles(
+	source: TimingPercentileSource | null | undefined
+): ResolvedPhasePercentiles[] {
+	return TIMING_PHASES.map((phase) => ({
+		...phase,
+		percentiles: source?.[phase.percentileKey],
+	})).filter((phase): phase is ResolvedPhasePercentiles => phase.percentiles !== undefined);
+}
+
+/**
+ * Ratio of a phase's p99 to its p50, or `null` when the tail cannot be read.
+ *
+ * A phase whose p99 towers over its p50 is the signal the percentile table
+ * exists to surface - the classic case is TLS, where a p50 of 0 (connections
+ * reused) beside a large p99 means the run was re-handshaking under load, which
+ * an average over both flattens into a number that looks merely mediocre.
+ *
+ * `null` for a p50 of 0: the ratio is unbounded there, and "infinitely worse
+ * than instant" is not a figure to print. Callers that care about that case
+ * read `p99` directly - a zero p50 with a real p99 is itself the finding.
+ */
+export function tailRatio(percentiles: TimingPhasePercentiles): number | null {
+	return percentiles.p50 > 0 ? percentiles.p99 / percentiles.p50 : null;
 }

--- a/app/src/modules/dashboard/components/MetricsView.tsx
+++ b/app/src/modules/dashboard/components/MetricsView.tsx
@@ -52,6 +52,8 @@ import {
 } from "./charts/uplot";
 import { SkeletonHdrPlot } from "./charts/HdrPercentilePlot";
 import { TimingWaterfall } from "./charts/TimingWaterfall";
+import { PhasePercentiles } from "./charts/PhasePercentiles";
+import { hasPhaseAverages } from "@/components/shared/response-viewer/timing-phases";
 
 function MetricsView({
 	metrics,
@@ -467,10 +469,27 @@ function MetricsView({
 							<InfoChip tip={TOOLTIPS.avgRequestTiming} />
 						</h3>
 						<span className="text-[10px] font-mono text-muted-foreground">
-							{finalReport?.timingBreakdown ? "from timing samples" : "-"}
+							{hasPhaseAverages(finalReport?.timingBreakdown)
+								? "from timing samples"
+								: "-"}
 						</span>
 					</div>
 					<TimingWaterfall report={finalReport} />
+					{/* Percentiles under the averages, separated by a rule and its
+					    own heading: they are the same five phases measured over a
+					    different population (every completion, not the trace
+					    sample), so running them together as more rows would invite
+					    a column-to-column comparison that is not valid. Renders
+					    nothing when the run recorded no distributions. */}
+					{finalReport?.timingBreakdown?.phases && (
+						<div className="mt-3.5 pt-3.5 border-t border-border">
+							<h3 className="text-xs font-semibold text-foreground mb-3">
+								Phase percentiles
+								<InfoChip tip={TOOLTIPS.phasePercentiles} />
+							</h3>
+							<PhasePercentiles report={finalReport} />
+						</div>
+					)}
 				</div>
 			</div>
 

--- a/app/src/modules/dashboard/components/RequestResponseView.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.tsx
@@ -23,6 +23,7 @@ import {
 	CapturedResponseNotice,
 	ResponseBody,
 	SampledExchange,
+	hasPhaseAverages,
 	phasesFromAverages,
 	phasesFromTrace,
 } from "@/components/shared/response-viewer";
@@ -144,8 +145,11 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 				</Card>
 			)}
 
-			{/* Timing Breakdown */}
-			{report.timingBreakdown && (
+			{/* Timing Breakdown. Gated on the averages themselves, not on the
+			    object: `timingBreakdown` also carries the per-phase percentiles,
+			    which exist for runs that stored no traces - and this card renders
+			    averages only, so it would print five dashes for them. */}
+			{hasPhaseAverages(report.timingBreakdown) && (
 				<Card>
 					<CardHeader>
 						<CardTitle className="text-lg">Timing Breakdown</CardTitle>

--- a/app/src/modules/dashboard/components/charts/PhasePercentiles.test.tsx
+++ b/app/src/modules/dashboard/components/charts/PhasePercentiles.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Issue #476: `timingBreakdown` carries two halves that are present
+ * independently - averages over the retained trace sample, and `phases`
+ * percentiles over every completion.
+ *
+ * The defect this file guards is the one the split introduced: a renderer that
+ * tests `report.timingBreakdown` rather than the half it actually reads. For a
+ * run that stored no traces the object now exists with only `phases`, so such a
+ * renderer paints five empty average bars and a confident "0 ms" total.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TooltipProvider } from "@/components/ui";
+import type { RunReport } from "@/types";
+import { PhasePercentiles } from "./PhasePercentiles";
+import { TimingWaterfall } from "./TimingWaterfall";
+
+function withTooltips(node: React.ReactNode) {
+	return render(<TooltipProvider>{node}</TooltipProvider>);
+}
+
+type Breakdown = NonNullable<RunReport["timingBreakdown"]>;
+
+function reportWith(timingBreakdown: Breakdown | undefined): RunReport {
+	return {
+		summary: {
+			totalRequests: 1,
+			successfulRequests: 1,
+			failedRequests: 0,
+			errorRate: 0,
+			totalDurationSeconds: 1,
+			avgRps: 1,
+		},
+		latency: { min: 5, max: 5, avg: 5, p50: 5, p90: 5, p95: 5, p99: 5 },
+		statusCodes: {},
+		errors: { total: 0, withDetails: 0, types: {} },
+		timingBreakdown,
+	} as RunReport;
+}
+
+/** Healthy: every phase's tail sits close to its body. */
+const CALM_PHASES: NonNullable<Breakdown["phases"]> = {
+	dns: { p50: 2, p95: 3, p99: 4, max: 6, count: 4321 },
+	connect: { p50: 5, p95: 6, p99: 8, max: 11, count: 4321 },
+	tls: { p50: 12, p95: 14, p99: 18, max: 25, count: 4321 },
+	firstByte: { p50: 30, p95: 40, p99: 55, max: 90, count: 4321 },
+	download: { p50: 2, p95: 3, p99: 4, max: 7, count: 4321 },
+};
+
+describe("PhasePercentiles", () => {
+	it("renders a row per phase with its percentiles", () => {
+		withTooltips(<PhasePercentiles report={reportWith({ phases: CALM_PHASES })} />);
+
+		for (const label of ["DNS", "Connect", "TLS", "TTFB", "Download"]) {
+			expect(screen.getByText(label)).toBeTruthy();
+		}
+		for (const header of ["p50", "p95", "p99", "max"]) {
+			expect(screen.getByText(header)).toBeTruthy();
+		}
+		// The population is named, so a reader does not read these as the
+		// averages card's sample.
+		expect(screen.getByText(/4,321/)).toBeTruthy();
+	});
+
+	// Absent section = nothing rendered. An empty table would claim the run
+	// measured phases and found nothing.
+	it("renders nothing when the run recorded no distributions", () => {
+		const { container } = withTooltips(
+			<PhasePercentiles report={reportWith({ avgDnsMs: 1, avgTlsMs: 2 })} />
+		);
+		expect(container.textContent).toBe("");
+	});
+
+	it("renders nothing without a report at all", () => {
+		const { container } = withTooltips(<PhasePercentiles report={null} />);
+		expect(container.textContent).toBe("");
+	});
+
+	// The reason a percentile view beats an average one. A TLS p50 of 0 with a
+	// large p99 is connection churn: most requests reused a connection, a few
+	// re-handshaked, and the mean of the two looks merely unremarkable.
+	//
+	// Mutation check: drop the `p50 === 0` branch from `isTailHeavy` and this
+	// case stops being flagged, because `tailRatio` is null for a zero p50.
+	it("calls out a phase whose tail towers over its body", () => {
+		withTooltips(
+			<PhasePercentiles
+				report={reportWith({
+					phases: {
+						...CALM_PHASES,
+						tls: { p50: 0, p95: 0, p99: 40, max: 61, count: 4321 },
+					},
+				})}
+			/>
+		);
+		expect(screen.getByText(/TLS.*p99 far above the p50/s)).toBeTruthy();
+	});
+
+	// A phase that is simply fast is not a finding: 0.01ms to 0.4ms is a 40x
+	// ratio over four tenths of a millisecond.
+	it("does not call out a large ratio over sub-millisecond values", () => {
+		withTooltips(
+			<PhasePercentiles
+				report={reportWith({
+					phases: {
+						...CALM_PHASES,
+						dns: { p50: 0.01, p95: 0.2, p99: 0.4, max: 0.9, count: 4321 },
+					},
+				})}
+			/>
+		);
+		expect(screen.queryByText(/p99 far above the p50/)).toBeNull();
+	});
+
+	it("says nothing when every phase's tail is proportionate", () => {
+		withTooltips(<PhasePercentiles report={reportWith({ phases: CALM_PHASES })} />);
+		expect(screen.queryByText(/p99 far above the p50/)).toBeNull();
+	});
+});
+
+describe("TimingWaterfall reads the averages half, not the object", () => {
+	// The regression the split would otherwise introduce. A run that stored no
+	// traces now has a `timingBreakdown` - with only `phases` in it - and the
+	// waterfall renders averages.
+	//
+	// Mutation check: restore `hasData = !!report?.timingBreakdown` and the
+	// total below reads "0 ms" instead of "- ms".
+	it("shows the empty state for a phases-only report", () => {
+		withTooltips(<TimingWaterfall report={reportWith({ phases: CALM_PHASES })} />);
+
+		expect(screen.getByText("- ms")).toBeTruthy();
+		expect(screen.queryByText("0 ms")).toBeNull();
+	});
+
+	it("shows the averages when they are there", () => {
+		withTooltips(
+			<TimingWaterfall
+				report={reportWith({
+					avgDnsMs: 1,
+					avgConnectMs: 2,
+					avgTlsMs: 3,
+					avgFirstByteMs: 4,
+					avgDownloadMs: 5,
+					phases: CALM_PHASES,
+				})}
+			/>
+		);
+		expect(screen.getByText("15 ms")).toBeTruthy();
+	});
+});

--- a/app/src/modules/dashboard/components/charts/PhasePercentiles.tsx
+++ b/app/src/modules/dashboard/components/charts/PhasePercentiles.tsx
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import type { RunReport } from "@/types";
+import { InfoChip } from "../shared";
+import { formatPhaseDuration } from "@/components/shared/response-viewer/utils";
+import {
+	phaseColor,
+	phasesFromPercentiles,
+	tailRatio,
+	type ResolvedPhasePercentiles,
+} from "@/components/shared/response-viewer/timing-phases";
+
+/**
+ * Per-phase percentiles - from `report.timingBreakdown.phases`.
+ *
+ * The companion to `TimingWaterfall`, and deliberately a separate component
+ * rather than more rows inside it: the waterfall shows *averages over the
+ * retained trace sample* and this shows *percentiles over every completion*.
+ * They are different populations, so stacking them in one table would invite
+ * the reader to compare a column against its neighbour.
+ *
+ * Renders nothing at all when the section is absent - a run whose engine had
+ * `phaseHistograms` off, or one recorded before the bank existed, has no
+ * distribution to show and an empty table would claim otherwise.
+ *
+ * The tail callout is the reason a percentile view beats an average one: a TLS
+ * p50 of 0 beside a p99 of 40ms is a run re-handshaking under load, and the
+ * mean of the two is a number that looks merely unremarkable.
+ */
+export function PhasePercentiles({ report }: { report: RunReport | null }) {
+	const phases = phasesFromPercentiles(report?.timingBreakdown?.phases);
+	if (phases.length === 0) {
+		return null;
+	}
+
+	const flagged = phases.filter(isTailHeavy);
+	// Identical across the five (they are fed together), so the first answers
+	// for the run. Printed once rather than per row.
+	const sampleCount = phases[0].percentiles.count;
+
+	return (
+		<div className="space-y-2.5">
+			<div className="grid grid-cols-[68px_repeat(4,1fr)] gap-2.5 text-[11px] text-muted-foreground">
+				<span />
+				<span className="text-right font-medium">p50</span>
+				<span className="text-right font-medium">p95</span>
+				<span className="text-right font-medium">p99</span>
+				<span className="text-right font-medium">max</span>
+			</div>
+
+			{phases.map((phase) => (
+				<div
+					key={phase.key}
+					className="grid grid-cols-[68px_repeat(4,1fr)] items-center gap-2.5"
+				>
+					<span className="text-[11px] text-muted-foreground flex items-center">
+						<span
+							aria-hidden
+							className="inline-block size-2 rounded-full mr-1.5 shrink-0"
+							style={{ background: phaseColor(phase) }}
+						/>
+						{phase.label}
+						<InfoChip tip={phase.tip} />
+					</span>
+					<PhaseValue value={phase.percentiles.p50} />
+					<PhaseValue value={phase.percentiles.p95} />
+					<PhaseValue value={phase.percentiles.p99} emphasis />
+					<PhaseValue value={phase.percentiles.max} />
+				</div>
+			))}
+
+			<p className="pt-2.5 border-t border-dashed border-border text-[11px] text-muted-foreground">
+				Every completion ({sampleCount.toLocaleString()}), not the trace sample.
+			</p>
+
+			{flagged.length > 0 && (
+				<p className="text-[11px] text-warning-text">
+					{flagged.map((phase) => phase.label).join(" and ")}{" "}
+					{flagged.length === 1 ? "has" : "have"} a p99 far above the p50 - a minority of
+					requests paid this phase while most skipped it. For TLS or Connect that is
+					connection churn under load rather than a slow server.
+				</p>
+			)}
+		</div>
+	);
+}
+
+/**
+ * A phase whose tail is worth naming: p99 at least an order of magnitude over
+ * p50, or a p50 of zero with a p99 that is not.
+ *
+ * The zero-p50 branch is not an edge case to tolerate - it is the *strongest*
+ * form of the finding. A reused connection does no handshake, so a run with
+ * healthy pooling has a TLS p50 of exactly 0; a non-zero p99 beside it means
+ * some requests did handshake, and `tailRatio` cannot express that as a number.
+ *
+ * The sub-millisecond floor keeps the callout off phases that are simply fast:
+ * a p50 of 0.01ms and a p99 of 0.4ms is a 40x ratio and 0.4ms of nothing.
+ */
+const TAIL_RATIO_THRESHOLD = 10;
+const TAIL_FLOOR_MS = 1;
+
+function isTailHeavy(phase: ResolvedPhasePercentiles): boolean {
+	const { p50, p99 } = phase.percentiles;
+	if (p99 < TAIL_FLOOR_MS) {
+		return false;
+	}
+	const ratio = tailRatio(phase.percentiles);
+	return ratio === null ? p50 === 0 : ratio >= TAIL_RATIO_THRESHOLD;
+}
+
+function PhaseValue({ value, emphasis }: { value: number; emphasis?: boolean }) {
+	const duration = formatPhaseDuration(value);
+	return (
+		<span className="text-right font-mono tabular-nums text-[11px]">
+			<span className={emphasis ? "text-foreground font-medium" : "text-foreground"}>
+				{duration.value}
+			</span>
+			<span className="text-subtle-foreground ml-0.5">{duration.unit}</span>
+		</span>
+	);
+}

--- a/app/src/modules/dashboard/components/charts/TimingWaterfall.tsx
+++ b/app/src/modules/dashboard/components/charts/TimingWaterfall.tsx
@@ -8,7 +8,11 @@
 import type { RunReport } from "@/types";
 import { InfoChip } from "../shared";
 import { formatPhaseDuration } from "@/components/shared/response-viewer/utils";
-import { phaseColor, phasesFromAverages } from "@/components/shared/response-viewer/timing-phases";
+import {
+	hasPhaseAverages,
+	phaseColor,
+	phasesFromAverages,
+} from "@/components/shared/response-viewer/timing-phases";
 
 /**
  * Timing waterfall - from report.timingBreakdown. Always renders 5 rows so the
@@ -30,9 +34,15 @@ import { phaseColor, phasesFromAverages } from "@/components/shared/response-vie
  *
  * Values format through `formatPhaseDuration` rather than `.toFixed(0)`, which
  * rendered any sub-millisecond average as a flat "0".
+ *
+ * `hasData` asks whether the *averages* are there, not whether
+ * `timingBreakdown` is. The object now also carries `phases` (percentiles over
+ * every completion, from the histogram bank), which is present for runs that
+ * stored no traces at all - testing the object would paint five empty bars and
+ * a confident "0 ms" total for exactly those runs.
  */
 export function TimingWaterfall({ report }: { report: RunReport | null }) {
-	const hasData = !!report?.timingBreakdown;
+	const hasData = hasPhaseAverages(report?.timingBreakdown);
 	const stages = phasesFromAverages(report?.timingBreakdown);
 
 	const total = stages.reduce((s, x) => s + (x.value ?? 0), 0);

--- a/app/src/modules/dashboard/components/tooltips.tsx
+++ b/app/src/modules/dashboard/components/tooltips.tsx
@@ -103,6 +103,8 @@ export const TOOLTIPS = {
 		"HDR percentile plot. X is percentile (log-scaled so the tail dominates); Y is latency. The curve's steepness from p95 → p99 is the tail story. Sourced from the engine's HdrHistogram.",
 	avgRequestTiming:
 		"Average breakdown of where each HTTP request spent time, in flight order. Computed across the timing-sampled subset of requests (enable save_timing_breakdown to populate). Helps isolate whether latency lives in DNS, network setup, or the server.",
+	phasePercentiles:
+		"The same five phases as percentiles rather than averages, over every completion instead of the stored sample. A phase whose p99 towers over its p50 is one a minority of requests paid: TLS or Connect behaving that way is connection churn under load, which an average hides. Requires the engine's phaseHistograms setting.",
 } satisfies Record<string, ReactNode>;
 
 export type TooltipKey = keyof typeof TOOLTIPS;

--- a/app/src/modules/history/main/components/PerformanceTab.tsx
+++ b/app/src/modules/history/main/components/PerformanceTab.tsx
@@ -24,6 +24,7 @@ import {
 	ResponseTimeVsConcurrencyChart,
 	CHART_SYNC,
 } from "@/modules/dashboard/components/charts/uplot";
+import { PhasePercentiles } from "@/modules/dashboard/components/charts/PhasePercentiles";
 import LatencyMetric from "./LatencyMetric";
 import HistoricalChartsSection from "./HistoricalChartsSection";
 import type { PerformanceTabProps } from "../../types";
@@ -125,6 +126,21 @@ export default function PerformanceTab({
 					</div>
 				</CardContent>
 			</Card>
+
+			{/* Per-phase percentiles. Its own card rather than rows inside Latency
+			    Distribution: those are whole-request percentiles and these split
+			    one request across five phases, so a p99 here is not comparable to
+			    the p99 above. Absent section = no card, as everywhere else. */}
+			{report.timingBreakdown?.phases && (
+				<Card>
+					<CardHeader>
+						<CardTitle className="text-base">Phase Latency Percentiles</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<PhasePercentiles report={report} />
+					</CardContent>
+				</Card>
+			)}
 
 			{/* Rate Control */}
 			{report.rateControl && isRateLimitedRun(derived.mode, derived.targetRps) && (

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1010,12 +1010,37 @@ export interface RunReport {
 		actualRps: number;
 		achievement: number;
 	};
+	/**
+	 * Two independent halves, either of which can be present without the other.
+	 *
+	 * The `avg*` fields are means over the run's **retained trace sample** (the
+	 * 1-in-N successes `save_timing_breakdown` stores, plus any slow-request
+	 * outliers), so they are absent for a run that stored no traces. `phases`
+	 * comes from histograms fed by **every** completion, so it is present for
+	 * such a run and absent only when the engine's `phaseHistograms` setting was
+	 * off, nothing succeeded, or the run predates the bank.
+	 *
+	 * Read each half by its own key. Treating the object's presence as proof of
+	 * either is what makes a phases-only report render as five zeroed averages.
+	 */
 	timingBreakdown?: {
-		avgDnsMs: number;
-		avgConnectMs: number;
-		avgTlsMs: number;
-		avgFirstByteMs: number;
-		avgDownloadMs: number;
+		avgDnsMs?: number;
+		avgConnectMs?: number;
+		avgTlsMs?: number;
+		avgFirstByteMs?: number;
+		avgDownloadMs?: number;
+		/**
+		 * Whole-run percentiles per network phase, over every completion rather
+		 * than over the trace sample. `count` is how many completions each
+		 * distribution holds - identical across the five, since they are fed
+		 * together.
+		 */
+		phases?: Partial<
+			Record<
+				"dns" | "connect" | "tls" | "firstByte" | "download",
+				{ p50: number; p95: number; p99: number; max: number; count: number }
+			>
+		>;
 	};
 	slowRequests?: {
 		count: number;

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -457,6 +457,7 @@ on disk, one in memory:
 | `maxResponseBodyBytes` | `33554432` | 1024–1073741824 | Largest response body a **load-test** transfer reads into memory. A bigger response fails that request (see `POST /runs`). Not a storage cap and unrelated to `maxTraceBodyBytes`, which truncates what a *completed* design request writes to the database. |
 | `maxSampleBodyBytes` | `32768`  | 0–104857600  | Largest response body kept for a single captured **load-run** sample. Bigger bodies are stored truncated and marked. Deliberately far below `maxTraceBodyBytes`: a design run stores one exchange the user asked for, a load run stores tens nobody asked for individually. `0` keeps headers and metadata and no body. |
 | `maxSampleBytes`    | `2097152` | 0–1073741824 | Total captured body bytes one load run may store. Once spent, samples keep their headers and metadata and only their bodies are dropped; the report counts them as `sampling.sampleBodiesDropped`. |
+| `phaseHistograms`   | `true`    | boolean      | Record DNS/connect/TLS/first-byte/download times for **every** load-test completion into five HdrHistograms, so the report can carry `timingBreakdown.phases` percentiles instead of averages over the retained trace sample. Costs five atomic histogram writes per completion; see [benchmarks](benchmarks.md). |
 | `maxRunsRetained`   | `200`     | 0–100000     | Keep at most this many most-recent runs; older runs (and their metrics/results, **including captured response bodies**) are pruned at startup and after each run finishes. `0` = unlimited. Captured data is stored verbatim, so this doubles as its expiry. |
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
 
@@ -2058,6 +2059,7 @@ default, and whose message names the offending field and why the bound exists:
 | `max_sample_body_bytes` | `0`-`104857600` | A captured body is copied on the completion callback, so the cap bounds hot-path work. `0` keeps headers and metadata and no body. Defaults to the `maxSampleBodyBytes` setting. |
 | `max_sample_bytes` | `0`-`1073741824` | The whole-run capture budget; every byte under it is held in memory until the run flushes. Defaults to the `maxSampleBytes` setting. |
 | `max_exemplar_results` | `0`-`100000` | Each retained exemplar holds a captured exchange. `0` means unlimited. |
+| `phase_histograms` | boolean | Per-run override for the `phaseHistograms` setting. `false` skips the bank entirely, and the run's report carries no `timingBreakdown.phases`. |
 | `concurrency` | `1`-`10000` | Connections are eagerly pre-allocated per worker before any traffic flows, so `-1` (a natural "unlimited" guess) allocated until malloc failed. |
 | `startConcurrency` | `1`-`10000` | The ramp is seeded with this many in-flight requests before the first duration check, and it is read as a `size_t`, so a negative start is ~1.8e19 of them. |
 | `maxInFlight` | `1`-`1000000` | It is a pending-request ceiling read as a `size_t`, so `-1` or `0` removes the backpressure the field exists to provide instead of tightening it, and an open-loop run against a slow target then accumulates in-flight requests for its whole duration. The ceiling is **not** the `concurrency` guard: that one bounds an eager per-worker connection pre-allocation, while this bounds a counter that pre-allocates nothing, and the engine's own default - `max(targetRps × 10, 1000)` - reaches 500,000 at the load dialog's 50k RPS maximum, so a lower bound would refuse ceilings the engine picks for itself. |
@@ -2094,6 +2096,12 @@ independent budgets:
 | Slow-request traces | any completion at or past `slow_threshold_ms`, **regardless** of `save_timing_breakdown` | `max_slow_results` |
 | Response samples (post-run test scripts) | 1 in `response_sample_rate` completions | `max_response_samples` |
 | Per-status exemplars (captured responses) | the first three completions of each distinct status code **that no other budget already stored** | `max_exemplar_results` |
+
+None of these budgets bound the report's `timingBreakdown.phases`: the per-phase
+histograms are fed by every completion and hold counts rather than records, so
+the phase distribution is the whole population no matter how hard the stores
+above thin. That is what they are for - the `avg*` fields beside them *are*
+computed over the sampled subset.
 
 Two properties are worth relying on. An outlier **never consumes a sampling
 slot**: a run whose target degrades does not silently stop sampling ordinary
@@ -2757,7 +2765,14 @@ alone rather than erroring. **The response shape is the same either way.**
   },
   "timingBreakdown": {
     "avgDnsMs": 5.2, "avgConnectMs": 12.3, "avgTlsMs": 45.1,
-    "avgFirstByteMs": 180.2, "avgDownloadMs": 2.7
+    "avgFirstByteMs": 180.2, "avgDownloadMs": 2.7,
+    "phases": {
+      "dns":       { "p50": 0.1, "p95": 0.2, "p99": 1.4,  "max": 12.0, "count": 6000 },
+      "connect":   { "p50": 0.3, "p95": 0.9, "p99": 8.2,  "max": 40.1, "count": 6000 },
+      "tls":       { "p50": 0.0, "p95": 0.0, "p99": 22.0, "max": 61.0, "count": 6000 },
+      "firstByte": { "p50": 2.9, "p95": 4.0, "p99": 6.1,  "max": 30.0, "count": 6000 },
+      "download":  { "p50": 0.1, "p95": 0.3, "p99": 0.9,  "max": 4.2,  "count": 6000 }
+    }
   },
   "slowRequests": { "count": 12, "thresholdMs": 1000, "percentage": 0.2 },
   "sampling": {
@@ -2775,6 +2790,22 @@ alone rather than erroring. **The response shape is the same either way.**
   "results": [ { "id": 41, "...": "sampled request/response outcomes" } ]
 }
 ```
+
+**`timingBreakdown` holds two independently-present halves.** The `avg*` fields
+are means over the run's *retained trace sample* - the 1-in-`success_sample_rate`
+completions stored while `save_timing_breakdown` is on, plus any slow-request
+outliers - so they are absent for a run that stored no traces. `phases` comes
+from five HdrHistograms fed by **every** successful completion, so it is present
+for exactly such a run, and absent only when `phaseHistograms` was off, nothing
+succeeded, or the run predates the bank. Read each half by its own key: the
+object's presence proves neither, and the two are drawn from different
+populations, so a `phases.tls.p50` is not comparable to an `avgTlsMs`.
+
+`phases` is what answers "was the latency the server or the connection path".
+A `tls.p50` of 0 beside a large `tls.p99` is a run re-handshaking under load -
+most requests reused a connection, a minority did not - which the average over
+both flattens into a number that looks merely mediocre. `count` is the number of
+completions behind each distribution and is identical across the five.
 
 **A capacity run adds a `capacity` section** and no other mode carries one:
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -156,6 +156,13 @@ High-performance in-memory metrics collection optimized for 60k+ RPS:
   concurrency - silently, since the run still reports percentiles, just computed from fewer
   samples than it served. The interval recorder's phaser orders the once-per-tick reader against
   writers; it is not mutual exclusion *between* writers, so it does not make the plain write safe.
+- **Per-phase histogram bank**: five more HdrHistograms (DNS, connect, TLS, first-byte, download),
+  fed by every successful completion and read once after the drain, behind the report's
+  `timingBreakdown.phases`. Deliberately **not** gated on the trace-retention decision: the
+  averages beside them are computed over the ~1% of completions a trace is stored for, and
+  escaping that biased sample is the whole point. Off - `phaseHistograms`, or a run's own
+  `phase_histograms` - leaves the bank unallocated, so the cost on the completion path is one null
+  check. Written through `hdr_record_value_atomic` for the same reason the two above are.
 - **Perceived latency**: Latency is measured as `completion − submitted_at` (the full time a
   request spent inside the engine), not just libcurl's wire time. Wire time and the
   generator-internal `queue_wait` are tracked separately.

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -144,6 +144,59 @@ events once connections are established, and the log grew only 5,256 bytes
 across 3.4 M requests. Gating the debug callback on log level remains worthwhile
 hygiene; it is not a performance lever.
 
+### Per-phase histograms cost under 2% (2026-08-11, engine 0.15.0)
+
+`phaseHistograms` (issue #476) adds **five `hdr_record_value_atomic` calls per
+successful completion** - the DNS/connect/TLS/first-byte/download bank behind
+the report's `timingBreakdown.phases`. It defaults **on**, and this is the
+measurement that decides that.
+
+**Different hardware from every other figure on this page.** Measured on a
+4-core Linux container, not the M3 Pro, with the mock server sharing those same
+4 cores - so the ceiling is **~18.9k req/s**, a third of the M3 Pro's. Read the
+A/B ratio, not the absolute numbers.
+
+Same daemon, same target, same run config; only the run's own
+`phase_histograms` override differs, so no restart separates the arms.
+`constant_concurrency` 64, 20 s per run, 4 s cooldown, 19 runs per arm - 14
+with ON first in each pair and 5 with the order reversed, because a fixed
+within-pair order would let any drift land entirely on one arm.
+
+| statistic | ON | OFF | delta |
+|---|---:|---:|---:|
+| median req/s | 18,578 | 18,869 | **-1.54%** |
+| mean req/s | 18,242 | 18,694 | -2.42% |
+| mean, lowest run per arm dropped | - | - | -1.78% |
+
+The raw mean is the only figure past 2%, and one run does all of that work: a
+single ON rep landed at 14,641 req/s, 21% under the next-lowest run in either
+arm. Per-arm spread is 12-25%, so a 1.5% difference is at the edge of what this
+box resolves at all - and the two orderings disagree in size (-1.83% ON-first,
+-0.97% OFF-first).
+
+**What the bank actually costs, measured without the shared-core confound.**
+Timing the five records directly against the same vendored HdrHistogram, with
+the value mix a real run produces (mostly zeros - a reused connection does no
+DNS and no handshake, so the writes concentrate on one bucket and contend
+maximally):
+
+| writer threads | latency histogram only | plus 5 phases | marginal |
+|---|---:|---:|---:|
+| 1 | 36 ns | 196 ns | **160 ns** / completion |
+| 2 | 76 ns | 357 ns | 281 ns / completion |
+| 4 | 91 ns | 440 ns | **349 ns** / completion |
+
+At the measured 18.9k req/s ceiling, 349 ns per completion is **6.5 ms of CPU
+per second - 0.65% of one core, 0.16% of this 4-core box.** That is an order of
+magnitude below the end-to-end spread, which is the strongest evidence that the
+1.5% seen there is this container's variance rather than the bank.
+
+**Verdict: default stays on.** Every outlier-robust statistic is under the 2%
+line the issue set, and the direct measurement accounts for a sixth of even
+that. `phaseHistograms` (engine config) and `phase_histograms` (per run) turn it
+off for anyone whose target proves otherwise; off leaves the bank unallocated,
+so the completion path pays one null check.
+
 ### The in-app proof run
 
 Started from the app's own Load Test panel (not the CLI, not MCP), 60 s,

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -245,6 +245,13 @@ default, so `sync_schema()` can
   "status_codes": { "200": 90, "500": 7, "0": 3 },
   "latency": { "min": 1.0, "max": 90.0, "avg": 12.5, "p50": 10.0, "p75": 15.0,
                "p90": 20.0, "p95": 25.0, "p99": 30.0, "p999": 35.0 },
+  "phases": {
+    "dns":       { "p50": 0.1, "p95": 0.2, "p99": 1.4,  "max": 12.0, "count": 100 },
+    "connect":   { "p50": 0.3, "p95": 0.9, "p99": 8.2,  "max": 40.1, "count": 100 },
+    "tls":       { "p50": 0.0, "p95": 0.0, "p99": 22.0, "max": 61.0, "count": 100 },
+    "firstByte": { "p50": 2.9, "p95": 4.0, "p99": 6.1,  "max": 30.0, "count": 100 },
+    "download":  { "p50": 0.1, "p95": 0.3, "p99": 0.9,  "max": 4.2,  "count": 100 }
+  },
   "tests": { "sampled": 10, "passed": 9, "failed": 1 },
   "thresholds": {
     "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 30.0, "passed": true } ],
@@ -252,6 +259,17 @@ default, so `sync_schema()` can
   }
 }
 ```
+
+`phases` carries the whole-run distribution of each network phase, drained from the collector's
+five per-phase HdrHistograms - which every successful completion feeds, unlike the sampled
+`results` rows the report's `timingBreakdown` averages come from. Keyed by wire name (`firstByte`,
+not `ttfb`), and the only section here written in camelCase, because the report passes it through
+verbatim rather than translating it. **Omitted** when the run recorded no distribution - the
+`phaseHistograms` setting (or the run's own `phase_histograms`) off, or nothing successful
+completed - which keeps the report's `timingBreakdown.phases` absent rather than showing five
+zeroed rows; a zeroed TLS row would claim the handshake was free, which is a different statement
+from "this run did not measure it". A zero *inside* a present section is meaningful and kept: a
+run over reused connections genuinely has a TLS p50 of 0.
 
 `tests` is **omitted** when deferred script validation did not run, which is what keeps the
 report's `testValidation` section absent rather than reporting zero tests. `thresholds` follows

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -439,6 +439,14 @@ constexpr size_t DEFAULT_MAX_EXEMPLAR_RESULTS = 64;
 constexpr int HISTOGRAM_SIGNIFICANT_FIGURES = 3;
 /// HdrHistogram max trackable latency in microseconds (1 hour)
 constexpr int64_t HISTOGRAM_MAX_LATENCY_US = 3600LL * 1000LL * 1000LL;
+/// Whether a load run feeds the five per-phase histograms (config key
+/// `phaseHistograms`). On by default: the phase values are computed for every
+/// completion anyway, and without this bank they survive only for the ~1% of
+/// completions a trace is retained for - so "was it the server or the
+/// connection path" is answered off a biased sample. The escape hatch exists
+/// because the feed is five atomic histogram records on the completion path;
+/// see docs/engine/benchmarks.md for the measured cost.
+constexpr bool DEFAULT_PHASE_HISTOGRAMS = true;
 } // namespace metrics_collector
 
 /**

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -175,6 +175,36 @@ struct MetricsCollectorConfig {
 
     /// Ceiling on the per-status exemplar store, 0 = unlimited.
     size_t max_exemplar_results = constants::metrics_collector::DEFAULT_MAX_EXEMPLAR_RESULTS;
+
+    /// Whether the five per-phase histograms are allocated and fed. Off makes
+    /// the collector byte-for-byte what it was before them: no bank is
+    /// allocated, nothing is recorded, and `phase_percentiles()` answers
+    /// nullopt - which is what keeps the report's `phases` section absent
+    /// rather than showing five zeroed distributions.
+    bool phase_histograms = constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS;
+};
+
+/**
+ * @brief The five network phases of a transfer, in wire order.
+ *
+ * Indexes the per-phase histogram bank and the array `phase_percentiles()`
+ * returns; `TIMING_PHASE_KEYS` gives the wire name of each, so the enum and
+ * the JSON cannot drift apart.
+ */
+enum class TimingPhase : size_t {
+    Dns       = 0,
+    Connect   = 1,
+    Tls       = 2,
+    FirstByte = 3,
+    Download  = 4
+};
+
+inline constexpr size_t TIMING_PHASE_COUNT = 5;
+
+/// Wire names, indexed by TimingPhase. The report's `timingBreakdown.phases`
+/// object is keyed by these.
+inline constexpr std::array<const char*, TIMING_PHASE_COUNT> TIMING_PHASE_KEYS = {
+    "dns", "connect", "tls", "firstByte", "download"
 };
 
 /**
@@ -268,13 +298,24 @@ class MetricsCollector {
      *                   the caller decides what deserves a body (see
      *                   handle_result), because the store a record lands in is
      *                   not what makes its body worth keeping.
+     * @param phases the completion's phase breakdown, fed to the per-phase
+     *                   histograms. Recorded **unconditionally** - it is
+     *                   deliberately not coupled to @p trace_reason, because
+     *                   escaping the ~1% retention sample is the entire point
+     *                   of the bank. Pass the live `response.timing` rather
+     *                   than five doubles: five adjacent parameters of the
+     *                   same type is a transposition waiting to happen, and
+     *                   the caller already holds the struct. nullptr, or a
+     *                   collector built with `phase_histograms` off, records
+     *                   nothing.
      */
     void record_success (int status_code,
     double latency_ms,
     double queue_wait_ms,
     const std::string& trace_data     = "",
     SuccessTraceReason trace_reason   = SuccessTraceReason::None,
-    const Response* capture_source    = nullptr);
+    const Response* capture_source    = nullptr,
+    const Timing* phases              = nullptr);
 
     /**
      * @brief Record a response sample for deferred script validation
@@ -531,6 +572,21 @@ class MetricsCollector {
     [[nodiscard]] Percentiles calculate_percentiles ();
 
     /**
+     * @brief Whole-run percentiles for each of the five network phases.
+     *
+     * Indexed by @ref TimingPhase. Read once, after the run has drained - the
+     * bank is written concurrently by every event-loop worker and only this
+     * post-run read is single-threaded, exactly like `calculate_percentiles`.
+     *
+     * `nullopt` says the run has no phase distribution to report at all:
+     * either `phase_histograms` was off, or nothing successful completed.
+     * Distinguishing that from "five phases that all measured 0ms" is why the
+     * whole return is optional rather than an array of empty Percentiles - a
+     * report showing a zeroed TLS row would claim the handshake was free.
+     */
+    [[nodiscard]] std::optional<std::array<Percentiles, TIMING_PHASE_COUNT>> phase_percentiles () const;
+
+    /**
      * @brief Sample the rolling (windowed) latency percentiles for the interval
      *        that has elapsed since the previous call, then reset the window.
      *
@@ -707,6 +763,17 @@ class MetricsCollector {
     // exclusion between writers, so the write itself must be the atomic variant.
     struct hdr_interval_recorder interval_recorder_{};
     bool interval_recorder_ready_{ false };
+
+    // One cumulative histogram per network phase, indexed by TimingPhase. Same
+    // range and precision as latency_histogram_, so a phase's p99 and the
+    // run's are read on the same scale rather than at two resolutions.
+    //
+    // All-null when `phase_histograms` is off - the null check in
+    // record_success is then the whole cost of the feature on the completion
+    // path, and phase_percentiles() answers nullopt. Written from every
+    // event-loop worker, so records go through hdr_record_value_atomic for the
+    // same reason latency_histogram_'s do; read once after the drain.
+    std::array<struct hdr_histogram*, TIMING_PHASE_COUNT> phase_histograms_{};
 
     mutable std::mutex errors_mutex_;
     std::vector<ResultRecord> errors_;

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -84,10 +84,17 @@ size_t max_ticks = constants::server::DEFAULT_MAX_LIVE_TICKS) {
  * anything whose default lives in `config_entries` is resolved by the caller
  * and handed in, the way `maxStoredErrors` always has been. A run's own config
  * still overrides these; they are only what it falls back to.
+ *
+ * Named for that role rather than for capture, which is what the first two
+ * fields happen to be about - `phase_histograms` reaches RunContext by the
+ * same route for the same reason and is not a capture knob.
  */
-struct CaptureDefaults {
+struct EngineDefaults {
     size_t max_sample_body_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES;
     size_t max_sample_bytes = constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES;
+    /// Config key `phaseHistograms`. Whether the run feeds the five per-phase
+    /// histograms behind the report's `timingBreakdown.phases`.
+    bool phase_histograms = constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS;
 };
 
 struct RunContext {
@@ -343,7 +350,7 @@ struct RunContext {
     RunContext (const std::string& id,
     nlohmann::json cfg,
     size_t max_errors                = constants::metrics_collector::DEFAULT_MAX_ERRORS,
-    CaptureDefaults capture_defaults = {});
+    EngineDefaults engine_defaults = {});
     ~RunContext ();
 
     /**
@@ -517,6 +524,12 @@ struct RunSummaryInputs {
     std::map<int, size_t> status_codes;
     MetricsCollector::Percentiles latency; // min/max/p50..p999, whole-run
     double latency_avg_ms = 0.0; // Mean latency; the histogram does not carry it
+    // Whole-run percentiles for each of the five network phases, indexed by
+    // TimingPhase. Absent when the run recorded none (the `phaseHistograms`
+    // toggle off, or nothing successful completed), which keeps the report's
+    // `timingBreakdown.phases` object out rather than showing five zeroed
+    // distributions - the same absent-not-zeros rule `capacity` follows.
+    std::optional<std::array<MetricsCollector::Percentiles, TIMING_PHASE_COUNT>> phases;
     // Transfers that asked for HTTP/2 and negotiated something older. The one
     // figure here that is about the report's own validity rather than about
     // performance - see MetricsCollector::record_http_version_downgrade.

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -188,9 +188,13 @@ const ResultAnnotations& annotations) {
         // keeps its body, which is the case the old precedence-based version
         // could only express by moving the record.
         const bool capture_body = context->capture_response_bodies && (is_slow || exemplar);
+        // The phase breakdown goes in whatever the retention gate above
+        // decided: `trace_data` carries these same five numbers for the ~1% of
+        // completions something retains, and the histograms are how the other
+        // 99% reach the report.
         context->metrics_collector->record_success (response.status_code, latency,
         response.timing.queue_wait_ms, trace_data, trace_reason,
-        capture_body ? &response : nullptr);
+        capture_body ? &response : nullptr, &response.timing);
         context->metrics_collector->record_bytes (
         response.timing.bytes_up, response.timing.bytes_down);
 

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -105,6 +105,29 @@ MetricsCollector::MetricsCollector (const std::string& run_id, MetricsCollectorC
     }
     interval_recorder_ready_ = true;
 
+    // Per-phase bank. Allocated only when enabled, so "off" is a null pointer
+    // rather than a flag consulted per completion, and phase_percentiles() has
+    // nothing to report from. A partial failure closes what it built and
+    // leaves the bank null: the run is still fully measurable without phase
+    // percentiles, which is not true of the two histograms above.
+    if (config_.phase_histograms) {
+        for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
+            if (hdr_init (1, constants::metrics_collector::HISTOGRAM_MAX_LATENCY_US,
+                constants::metrics_collector::HISTOGRAM_SIGNIFICANT_FIGURES,
+                &phase_histograms_[i]) != 0 ||
+            phase_histograms_[i] == nullptr) {
+                for (size_t j = 0; j < i; ++j) {
+                    hdr_close (phase_histograms_[j]);
+                }
+                phase_histograms_.fill (nullptr);
+                vayu::utils::log_warning ("Run " + run_id_ +
+                ": failed to initialize per-phase histograms; the report will "
+                "carry averages only");
+                break;
+            }
+        }
+    }
+
     // Pre-allocate vectors to avoid reallocation during test
     size_t expected = config_.expected_requests;
 
@@ -158,6 +181,12 @@ MetricsCollector::~MetricsCollector () {
     if (interval_recorder_ready_) {
         hdr_interval_recorder_destroy (&interval_recorder_);
         interval_recorder_ready_ = false;
+    }
+    for (auto*& histogram : phase_histograms_) {
+        if (histogram != nullptr) {
+            hdr_close (histogram);
+            histogram = nullptr;
+        }
     }
 }
 
@@ -229,7 +258,8 @@ double latency_ms,
 double queue_wait_ms,
 const std::string& trace_data,
 SuccessTraceReason trace_reason,
-const Response* capture_source) {
+const Response* capture_source,
+const Timing* phases) {
     // Update atomic counters (lock-free)
     total_requests_.fetch_add (1, std::memory_order_relaxed);
     atomic_add_double (total_latency_sum_, latency_ms);
@@ -249,6 +279,28 @@ const Response* capture_source) {
     hdr_record_value_atomic (latency_histogram_, latency_us);
     // Also feed the rolling-window recorder for the live per-tick percentiles.
     hdr_interval_recorder_record_value_atomic (&interval_recorder_, latency_us);
+
+    // Per-phase bank, fed before the retention gate below and independently of
+    // it: a phase distribution drawn from the completions that happened to be
+    // sampled is the biased answer this bank exists to replace.
+    //
+    // A phase that did not happen still records its 0. That is not the same
+    // claim as "TLS was free" - a run over plain HTTP records five million
+    // zeroes into the TLS histogram and its p99 is 0, which is the truthful
+    // reading of "this run did no handshakes". The distinction the report has
+    // to keep is present-vs-absent *section*, which phase_percentiles() owns.
+    if (phases != nullptr && phase_histograms_[0] != nullptr) {
+        const std::array<double, TIMING_PHASE_COUNT> values = { phases->dns_ms,
+            phases->connect_ms, phases->tls_ms, phases->first_byte_ms, phases->download_ms };
+        for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
+            // Clamped at 0 rather than at 1 like the latency histogram above:
+            // a 0ms phase is the common case (a reused connection does no DNS
+            // and no handshake), so flooring it to 1us would inflate every
+            // percentile of the phases that legitimately did not run.
+            hdr_record_value_atomic (phase_histograms_[i],
+            static_cast<int64_t> (std::max (0.0, values[i]) * 1000.0));
+        }
+    }
 
     // Store the trace the caller built, in whichever budget asked for it. The
     // sampling decision happened before the trace was serialised (see
@@ -537,6 +589,36 @@ MetricsCollector::Percentiles MetricsCollector::calculate_percentiles () {
     result.p99  = us_to_ms (hdr_value_at_percentile (latency_histogram_, 99.0));
     result.p999 = us_to_ms (hdr_value_at_percentile (latency_histogram_, 99.9));
 
+    return result;
+}
+
+std::optional<std::array<MetricsCollector::Percentiles, TIMING_PHASE_COUNT>>
+MetricsCollector::phase_percentiles () const {
+    // The five are allocated and fed together, so the first answers for all of
+    // them: a null bank is the toggle off, an empty one is a run where nothing
+    // successful completed. Both are "no distribution to report", which is
+    // what the absent section says.
+    if (phase_histograms_[0] == nullptr || phase_histograms_[0]->total_count == 0) {
+        return std::nullopt;
+    }
+
+    auto us_to_ms = [] (int64_t us) -> double {
+        return static_cast<double> (us) / 1000.0;
+    };
+
+    std::array<Percentiles, TIMING_PHASE_COUNT> result;
+    for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
+        auto* histogram  = phase_histograms_[i];
+        result[i].count = static_cast<size_t> (histogram->total_count);
+        result[i].min   = us_to_ms (hdr_min (histogram));
+        result[i].max   = us_to_ms (hdr_max (histogram));
+        result[i].p50   = us_to_ms (hdr_value_at_percentile (histogram, 50.0));
+        result[i].p75   = us_to_ms (hdr_value_at_percentile (histogram, 75.0));
+        result[i].p90   = us_to_ms (hdr_value_at_percentile (histogram, 90.0));
+        result[i].p95   = us_to_ms (hdr_value_at_percentile (histogram, 95.0));
+        result[i].p99   = us_to_ms (hdr_value_at_percentile (histogram, 99.0));
+        result[i].p999  = us_to_ms (hdr_value_at_percentile (histogram, 99.9));
+    }
     return result;
 }
 

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -357,7 +357,7 @@ const std::vector<std::optional<ScriptValidationTotals>>& per_step) {
 RunContext::RunContext (const std::string& id,
 nlohmann::json cfg,
 size_t max_errors,
-CaptureDefaults capture_defaults)
+EngineDefaults engine_defaults)
 : run_id (id), config (cfg.is_object () ? std::move (cfg) : nlohmann::json::object ()), start_time_ms (0) {
     // Initialize MetricsCollector with configuration from test config
     MetricsCollectorConfig mc_config;
@@ -406,9 +406,14 @@ CaptureDefaults capture_defaults)
     mc_config.capture_response_bodies = config.value ("capture_response_bodies",
     constants::metrics_collector::DEFAULT_CAPTURE_RESPONSE_BODIES);
     mc_config.max_sample_body_bytes = static_cast<size_t> (config.value (
-    "max_sample_body_bytes", static_cast<int64_t> (capture_defaults.max_sample_body_bytes)));
+    "max_sample_body_bytes", static_cast<int64_t> (engine_defaults.max_sample_body_bytes)));
     mc_config.max_sample_bytes = static_cast<size_t> (
-    config.value ("max_sample_bytes", static_cast<int64_t> (capture_defaults.max_sample_bytes)));
+    config.value ("max_sample_bytes", static_cast<int64_t> (engine_defaults.max_sample_bytes)));
+    // Per-phase histograms. Engine-config default, per-run override like the
+    // caps above - a run that only wants the cheapest possible completion path
+    // can switch them off without changing the setting for every other run.
+    mc_config.phase_histograms =
+    config.value ("phase_histograms", engine_defaults.phase_histograms);
     mc_config.max_exemplar_results =
     static_cast<size_t> (config.value ("max_exemplar_results",
     static_cast<int64_t> (constants::metrics_collector::DEFAULT_MAX_EXEMPLAR_RESULTS)));
@@ -687,17 +692,19 @@ const std::function<std::thread (const std::shared_ptr<RunContext>&)>& spawn) {
         // The config-backed defaults RunContext cannot read for itself - it
         // holds no Database - resolved here, the way `maxStoredErrors` always
         // has been. A run's own config still overrides each of them.
-        CaptureDefaults capture_defaults;
-        capture_defaults.max_sample_body_bytes =
+        EngineDefaults engine_defaults;
+        engine_defaults.max_sample_body_bytes =
         static_cast<size_t> (db.get_config_int ("maxSampleBodyBytes",
         static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES)));
-        capture_defaults.max_sample_bytes = static_cast<size_t> (db.get_config_int ("maxSampleBytes",
+        engine_defaults.phase_histograms = db.get_config_bool ("phaseHistograms",
+        vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS);
+        engine_defaults.max_sample_bytes = static_cast<size_t> (db.get_config_int ("maxSampleBytes",
         static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES)));
 
         auto context = std::make_shared<RunContext> (run_id, config,
         static_cast<size_t> (db.get_config_int ("maxStoredErrors",
         static_cast<int> (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS))),
-        capture_defaults);
+        engine_defaults);
         register_run (run_id, context);
 
         // Sweep stale retained runs on each new registration so that headless /
@@ -977,6 +984,7 @@ RunManager& manager) {
             inputs.status_codes    = context->metrics_collector->status_code_distribution ();
             inputs.latency         = percentiles;
             inputs.latency_avg_ms  = avg_latency;
+            inputs.phases          = context->metrics_collector->phase_percentiles ();
             inputs.http_version_downgraded =
             context->metrics_collector->http_version_downgraded ();
             inputs.tests     = validation.run;
@@ -1080,6 +1088,7 @@ RunManager& manager) {
             inputs.status_codes     = mc.status_code_distribution ();
             inputs.latency          = mc.calculate_percentiles ();
             inputs.latency_avg_ms   = mc.average_latency ();
+            inputs.phases           = mc.phase_percentiles ();
             inputs.retention               = read_retention (mc);
             inputs.http_version_downgraded = mc.http_version_downgraded ();
             if (context->auth_refresh) {
@@ -1205,6 +1214,19 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
         summary["thresholds"] = { { "checks", checks },
             { "passed", inputs.thresholds->passed },
             { "failed", inputs.thresholds->failed } };
+    }
+    // Per-phase latency distributions, keyed by wire name so a reader does not
+    // have to know the enum's order. Omitted when the run recorded none - a
+    // reader that finds no `phases` key is looking at a run whose phase data
+    // was never collected, not at a target with a free TLS handshake.
+    if (inputs.phases.has_value ()) {
+        nlohmann::json phases = nlohmann::json::object ();
+        for (size_t i = 0; i < TIMING_PHASE_COUNT; ++i) {
+            const auto& p        = (*inputs.phases)[i];
+            phases[TIMING_PHASE_KEYS[i]] = { { "p50", p.p50 }, { "p95", p.p95 },
+                { "p99", p.p99 }, { "max", p.max }, { "count", p.count } };
+        }
+        summary["phases"] = phases;
     }
     // What a capacity run's search found, level by level. Omitted for every
     // other mode - a fixed-target run measured a point, not a curve, and has

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1951,6 +1951,19 @@ void Database::seed_default_config () {
     "1073741824", // 1GB
     std::nullopt, now });
 
+    upsert_config (ConfigEntry{ "phaseHistograms",
+    vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",
+    "boolean", "Per-Phase Latency Histograms",
+    "Record DNS, connect, TLS, first-byte and download times for every "
+    "load-test completion, so the report can give each phase real percentiles "
+    "instead of an average over the small sample it stores traces for. This is "
+    "what answers whether a slow p99 came from the server or from connection "
+    "setup. Costs five histogram writes per completion; turn it off only if a "
+    "run at your throughput ceiling measurably suffers.",
+    "observability",
+    vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",
+    std::nullopt, std::nullopt, std::nullopt, now });
+
     upsert_config (ConfigEntry{ "maxResponseBodyBytes",
     std::to_string (vayu::core::constants::event_loop::MAX_RESPONSE_BODY_BYTES),
     "integer", "Maximum Load-Test Response Body",

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -550,6 +550,19 @@ std::optional<std::string> validate_run_config (const nlohmann::json& config) {
         }
     }
 
+    // `phase_histograms` is read with `config.value (..., bool)` inside
+    // RunContext's constructor, which throws `type_error.302` on a string -
+    // after the run row exists, which is the stranded-`pending` failure this
+    // whole function is here to prevent. One field rather than a table: its two
+    // boolean siblings (`save_timing_breakdown`, `capture_response_bodies`)
+    // carry the same exposure and predate this guard, so widening it to them is
+    // a behaviour change for existing callers and belongs in its own change.
+    if (config.contains ("phase_histograms") && !config["phase_histograms"].is_null () &&
+    !config["phase_histograms"].is_boolean ()) {
+        return std::string ("'phase_histograms' must be a boolean (got ") +
+        config["phase_histograms"].type_name () + ")";
+    }
+
     // `thresholds` is the one nested object here, so it gets its own pass
     // rather than a row in the flat table above. The rule lives with the
     // evaluator (`core/threshold_eval.cpp`), which reads the same metric table

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -202,6 +202,15 @@ struct ReportExtras {
     // whether the protocol the report is labelled with is the one the numbers
     // were measured over (issue #215).
     double http_version_downgraded = 0.0;
+    // Per-phase latency distributions, verbatim from the summary and already in
+    // the report's shape. Empty for a run that recorded none - the toggle off,
+    // nothing successful completed, or an engine older than the phase bank -
+    // which leaves `timingBreakdown.phases` out. The averages beside it are
+    // computed over the retained sample and stay whatever they were; these are
+    // the whole population, so a reader comparing the two is comparing a
+    // sample's mean against every completion's distribution, not two views of
+    // the same rows.
+    nlohmann::json phases = nlohmann::json::object ();
 };
 
 // Read a number out of a JSON object, leaving @p out untouched when the key is
@@ -406,6 +415,15 @@ ReportExtras& extras) {
 
     if (summary.contains ("capacity") && summary["capacity"].is_object ()) {
         read_capacity_section (summary["capacity"], extras);
+    }
+
+    // Per-phase distributions, passed through rather than re-keyed: the
+    // producer writes the report's own wire names (TIMING_PHASE_KEYS), so a
+    // translation table here would be a second place to keep them. An empty
+    // object is treated as absent - it names no phase a reader can act on.
+    if (summary.contains ("phases") && summary["phases"].is_object () &&
+    !summary["phases"].empty ()) {
+        extras.phases = summary["phases"];
     }
 
     if (summary.contains ("thresholds") && summary["thresholds"].is_object ()) {
@@ -836,12 +854,26 @@ const std::string& run_id) {
     }
     json_report["errors"] = errors_obj;
 
+    // Two independent halves under one key, and either can be present without
+    // the other. The averages come from the retained trace sample, so they are
+    // absent for a run that stored no traces; `phases` comes from the
+    // histograms every completion fed, so it is present for a run that stored
+    // none and absent for one recorded before the bank existed. Clients read
+    // each half by its own key rather than treating the object's presence as
+    // proof of either.
+    nlohmann::json timing_breakdown = nlohmann::json::object ();
     if (report.has_timing_data) {
-        json_report["timingBreakdown"] = { { "avgDnsMs", report.avg_dns_ms },
-            { "avgConnectMs", report.avg_connect_ms },
-            { "avgTlsMs", report.avg_tls_ms },
-            { "avgFirstByteMs", report.avg_first_byte_ms },
-            { "avgDownloadMs", report.avg_download_ms } };
+        timing_breakdown["avgDnsMs"]       = report.avg_dns_ms;
+        timing_breakdown["avgConnectMs"]   = report.avg_connect_ms;
+        timing_breakdown["avgTlsMs"]       = report.avg_tls_ms;
+        timing_breakdown["avgFirstByteMs"] = report.avg_first_byte_ms;
+        timing_breakdown["avgDownloadMs"]  = report.avg_download_ms;
+    }
+    if (!extras.phases.empty ()) {
+        timing_breakdown["phases"] = extras.phases;
+    }
+    if (!timing_breakdown.empty ()) {
+        json_report["timingBreakdown"] = timing_breakdown;
     }
 
     if (report.slow_threshold_ms > 0) {

--- a/engine/tests/load_strategy_test.cpp
+++ b/engine/tests/load_strategy_test.cpp
@@ -1006,3 +1006,77 @@ TEST_F (LoadStrategyTest, CapacityStopsOnItsDeadline) {
     ASSERT_TRUE (summary.max_healthy.has_value ());
     EXPECT_EQ (summary.max_healthy->concurrency, 2u);
 }
+
+// ============================================================================
+// Per-phase histograms on the completion path (issue #476)
+// ============================================================================
+
+namespace {
+/// A completion whose TTFB is set independently of its total, so a test can
+/// make the sampled subset differ from the population on purpose.
+vayu::Result<vayu::Response> completion_with_ttfb (double latency_ms, double first_byte_ms) {
+    vayu::Response response;
+    vayu::Result<vayu::Response> result = completion (latency_ms);
+    response                            = result.value ();
+    response.timing.first_byte_ms       = first_byte_ms;
+    return vayu::Result<vayu::Response> (response);
+}
+} // namespace
+
+// The point of the bank: the phase distribution covers every completion, not
+// the ~1% a trace is retained for. The population here is deliberately
+// bimodal, and the 1-in-10 sampler selects exactly the minority - so a feed
+// gated on retention would report the *fast* value as the median.
+//
+// Mutation check: move the record_success phase argument inside the
+// `sampled || is_slow || exemplar` branch in handle_result and both assertions
+// below fail - the count drops to 50 and the p50 to 5ms.
+TEST_F (LoadStrategyTest, PhaseHistogramsEscapeTheRetentionSample) {
+    nlohmann::json config = {
+        { "mode", "constant_rps" },
+        { "slow_threshold_ms", 100000 }, // nothing here is an outlier
+        { "save_timing_breakdown", true },
+        { "success_sample_rate", 10 },
+    };
+    auto context = std::make_shared<vayu::core::RunContext> ("test-phase-escape", config);
+    vayu::db::Database db (TEST_DB_PATH);
+
+    // The sampler keeps completions 0, 10, 20, ... - the fast ones.
+    for (int i = 0; i < 500; ++i) {
+        vayu::core::handle_result (context, db,
+        completion_with_ttfb (10.0, i % 10 == 0 ? 5.0 : 200.0));
+    }
+
+    EXPECT_EQ (context->metrics_collector->success_results ().size (), 50u);
+
+    auto phases = context->metrics_collector->phase_percentiles ();
+    ASSERT_TRUE (phases.has_value ());
+    const auto& ttfb = (*phases)[static_cast<size_t> (vayu::core::TimingPhase::FirstByte)];
+    EXPECT_EQ (ttfb.count, 500u);
+    EXPECT_NEAR (ttfb.p50, 200.0, 1.0);
+    // The retained sample is 90% of the way off; that gap is the feature.
+    EXPECT_NEAR (ttfb.min, 5.0, 1.0);
+}
+
+// The per-run override reaches the collector, and off means no section at all.
+TEST_F (LoadStrategyTest, PhaseHistogramsCanBeDisabledPerRun) {
+    nlohmann::json config = {
+        { "mode", "constant_rps" },
+        { "phase_histograms", false },
+    };
+    auto context = std::make_shared<vayu::core::RunContext> ("test-phase-off", config);
+    vayu::db::Database db (TEST_DB_PATH);
+
+    for (int i = 0; i < 20; ++i) {
+        vayu::core::handle_result (context, db, completion (10.0));
+    }
+
+    EXPECT_EQ (context->metrics_collector->total_requests (), 20u);
+    EXPECT_FALSE (context->metrics_collector->phase_percentiles ().has_value ());
+
+    // On by default, so a run that says nothing still gets the distribution.
+    nlohmann::json bare = { { "mode", "constant_rps" } };
+    auto stock = std::make_shared<vayu::core::RunContext> ("test-phase-default", bare);
+    vayu::core::handle_result (stock, db, completion (10.0));
+    EXPECT_TRUE (stock->metrics_collector->phase_percentiles ().has_value ());
+}

--- a/engine/tests/metrics_collector_test.cpp
+++ b/engine/tests/metrics_collector_test.cpp
@@ -991,3 +991,140 @@ TEST (MetricsCollectorRetention, ResponseSamplesStayBoundedUnderConcurrentWriter
     EXPECT_EQ (collector.response_samples ().size () + collector.response_samples_dropped (),
     8u * 2000u);
 }
+
+// ============================================================================
+// Per-Phase Histograms (issue #476)
+// ============================================================================
+
+namespace {
+
+/// A completion's phase breakdown, spelled out so a test reads as the five
+/// numbers it is asserting on rather than as five positional doubles.
+vayu::Timing phase_timing (double dns, double connect, double tls, double first_byte, double download) {
+    vayu::Timing timing;
+    timing.dns_ms        = dns;
+    timing.connect_ms    = connect;
+    timing.tls_ms        = tls;
+    timing.first_byte_ms = first_byte;
+    timing.download_ms   = download;
+    return timing;
+}
+
+constexpr size_t kDns       = static_cast<size_t> (TimingPhase::Dns);
+constexpr size_t kConnect   = static_cast<size_t> (TimingPhase::Connect);
+constexpr size_t kTls       = static_cast<size_t> (TimingPhase::Tls);
+constexpr size_t kFirstByte = static_cast<size_t> (TimingPhase::FirstByte);
+constexpr size_t kDownload  = static_cast<size_t> (TimingPhase::Download);
+
+} // namespace
+
+// Each phase's values must land in its own histogram. Driving five distinct
+// magnitudes is what makes a transposition (connect written into the tls slot,
+// say) fail here rather than in a report nobody re-derives.
+TEST_F (MetricsCollectorTest, PhaseValuesLandInTheirOwnHistogram) {
+    for (int i = 0; i < 100; ++i) {
+        const auto timing = phase_timing (1.0, 10.0, 100.0, 200.0, 4.0);
+        collector->record_success (200, 315.0, 0.0, "", SuccessTraceReason::None, nullptr, &timing);
+    }
+
+    auto phases = collector->phase_percentiles ();
+    ASSERT_TRUE (phases.has_value ());
+
+    constexpr double tolerance = 1.0;
+    EXPECT_NEAR ((*phases)[kDns].p50, 1.0, tolerance);
+    EXPECT_NEAR ((*phases)[kConnect].p50, 10.0, tolerance);
+    EXPECT_NEAR ((*phases)[kTls].p50, 100.0, tolerance);
+    EXPECT_NEAR ((*phases)[kFirstByte].p50, 200.0, tolerance);
+    EXPECT_NEAR ((*phases)[kDownload].p50, 4.0, tolerance);
+
+    // Fed together, so every phase holds the whole run.
+    for (const auto& phase : *phases) {
+        EXPECT_EQ (phase.count, 100u);
+    }
+}
+
+// The distribution, not just the middle: a tail that only 1% of completions
+// paid is exactly what the averages this replaces could not show.
+TEST_F (MetricsCollectorTest, PhasePercentilesSeparateTailFromBody) {
+    // 95 reused connections (no handshake) and 5 that re-handshaked for 50ms.
+    // The split is 95/5 rather than 99/1 so the outliers sit *inside* p99: with
+    // a single outlier in 100 the p99 is legitimately 0 and only `max` sees it,
+    // which would make this test assert the histogram's rank arithmetic rather
+    // than the behaviour it is here for.
+    for (int i = 0; i < 95; ++i) {
+        const auto timing = phase_timing (0.0, 0.0, 0.0, 5.0, 1.0);
+        collector->record_success (200, 6.0, 0.0, "", SuccessTraceReason::None, nullptr, &timing);
+    }
+    for (int i = 0; i < 5; ++i) {
+        const auto slow = phase_timing (0.0, 3.0, 50.0, 5.0, 1.0);
+        collector->record_success (200, 59.0, 0.0, "", SuccessTraceReason::None, nullptr, &slow);
+    }
+
+    auto phases = collector->phase_percentiles ();
+    ASSERT_TRUE (phases.has_value ());
+
+    // A zero p50 is the truthful reading of "most requests did no handshake" -
+    // it must not be mistaken for a dropped record, which is why zeros are
+    // recorded rather than skipped.
+    EXPECT_DOUBLE_EQ ((*phases)[kTls].p50, 0.0);
+    EXPECT_DOUBLE_EQ ((*phases)[kTls].p95, 0.0);
+    EXPECT_EQ ((*phases)[kTls].count, 100u);
+    EXPECT_NEAR ((*phases)[kTls].max, 50.0, 1.0);
+    // The mean this replaces would have read 2.5ms - a number that looks like a
+    // uniformly slightly-slow handshake rather than 5% of requests paying 50ms.
+    EXPECT_NEAR ((*phases)[kTls].p99, 50.0, 1.0);
+}
+
+// The escape hatch has to actually cost nothing: off means no bank, and a
+// report with no `phases` section rather than one full of zeros.
+TEST_F (MetricsCollectorTest, PhaseHistogramsOffRecordsNothing) {
+    MetricsCollectorConfig config;
+    config.phase_histograms = false;
+    MetricsCollector off ("phases_off", config);
+
+    const auto timing = phase_timing (1.0, 10.0, 100.0, 200.0, 4.0);
+    off.record_success (200, 315.0, 0.0, "", SuccessTraceReason::None, nullptr, &timing);
+
+    EXPECT_EQ (off.total_requests (), 1u);
+    EXPECT_FALSE (off.phase_percentiles ().has_value ());
+}
+
+// Absent, not zeros: a run where nothing succeeded reports no distribution, so
+// a reader cannot mistake it for a target whose every phase was instant.
+TEST_F (MetricsCollectorTest, PhasePercentilesAbsentWithoutCompletions) {
+    EXPECT_FALSE (collector->phase_percentiles ().has_value ());
+
+    // A success recorded without a breakdown (the record_success overloads that
+    // predate the bank, and every non-load caller) leaves it absent too.
+    collector->record_success (200, 10.0, 0.0);
+    EXPECT_FALSE (collector->phase_percentiles ().has_value ());
+}
+
+// Written from every event-loop worker, so the records must be the atomic
+// variant - the plain one is a read-modify-write on counts[] and loses
+// increments. A lost increment shows up here as a count below the total.
+TEST_F (MetricsCollectorTest, PhaseHistogramsSafeUnderConcurrentWriters) {
+    constexpr int kThreads   = 4;
+    constexpr int kPerThread = 5000;
+
+    std::vector<std::thread> writers;
+    writers.reserve (kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        writers.emplace_back ([this] () {
+            for (int i = 0; i < kPerThread; ++i) {
+                const auto timing = phase_timing (1.0, 2.0, 3.0, 4.0, 5.0);
+                collector->record_success (200, 15.0, 0.0, "",
+                SuccessTraceReason::None, nullptr, &timing);
+            }
+        });
+    }
+    for (auto& writer : writers) {
+        writer.join ();
+    }
+
+    auto phases = collector->phase_percentiles ();
+    ASSERT_TRUE (phases.has_value ());
+    for (const auto& phase : *phases) {
+        EXPECT_EQ (phase.count, static_cast<size_t> (kThreads * kPerThread));
+    }
+}

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -474,3 +474,32 @@ TEST (RunConfigValidation, AnOutOfRangeSloIsRejected) {
         expect_rejected (config, "sloMs");
     }
 }
+
+// --- 8. Per-phase histograms (issue #476) ---------------------------------
+
+// Read as a bool inside RunContext's constructor, which throws on a string -
+// after the run row exists. Rejected here so a rejected request leaves no
+// trace, like every other field in this function.
+//
+// Mutation check: delete the `phase_histograms` guard from validate_run_config
+// and the string case below is accepted.
+TEST (RunConfigValidation, ANonBooleanPhaseHistogramsIsRejected) {
+    for (const nlohmann::json bad :
+    { nlohmann::json ("true"), nlohmann::json (1), nlohmann::json (nlohmann::json::array ()) }) {
+        auto config                = valid_config ();
+        config["phase_histograms"] = bad;
+        expect_rejected (config, "phase_histograms");
+    }
+}
+
+TEST (RunConfigValidation, BothPhaseHistogramSettingsAreAccepted) {
+    for (const bool value : { true, false }) {
+        auto config                = valid_config ();
+        config["phase_histograms"] = value;
+        EXPECT_FALSE (validate_run_config (config).has_value ());
+    }
+    // Absent and null both mean "use the engine setting".
+    auto config                = valid_config ();
+    config["phase_histograms"] = nullptr;
+    EXPECT_FALSE (validate_run_config (config).has_value ());
+}

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -927,6 +927,60 @@ TEST_F (RunsRouteTest, ReportOmitsCapacityForEveryOtherMode) {
     EXPECT_FALSE (body.contains ("capacity"));
 }
 
+// Per-phase percentiles round-trip from the histogram bank into the report,
+// under `timingBreakdown` beside the averages (issue #476).
+TEST_F (RunsRouteTest, ReportCarriesPerPhasePercentiles) {
+    seed ({ .id = "run_phases", .start_time = 1000 });
+    auto inputs = summary_inputs ();
+
+    std::array<vayu::core::MetricsCollector::Percentiles, vayu::core::TIMING_PHASE_COUNT> phases{};
+    // Five distinct magnitudes, so a phase written into the wrong key fails here.
+    const double p50s[] = { 0.1, 0.3, 0.0, 2.9, 0.1 };
+    const double p99s[] = { 1.4, 8.2, 22.0, 6.1, 0.9 };
+    for (size_t i = 0; i < vayu::core::TIMING_PHASE_COUNT; ++i) {
+        phases[i].count = 4321;
+        phases[i].p50   = p50s[i];
+        phases[i].p95   = p50s[i] * 2.0;
+        phases[i].p99   = p99s[i];
+        phases[i].max   = p99s[i] * 3.0;
+    }
+    inputs.phases = phases;
+    db_->update_run_summary (
+    "run_phases", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_phases");
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body.contains ("timingBreakdown"));
+    const auto& breakdown = body["timingBreakdown"];
+    ASSERT_TRUE (breakdown.contains ("phases"));
+    const auto& reported = breakdown["phases"];
+
+    // Keyed by wire name - `firstByte`, not `ttfb`, and not an array index.
+    EXPECT_DOUBLE_EQ (reported["dns"]["p50"].get<double> (), 0.1);
+    EXPECT_DOUBLE_EQ (reported["connect"]["p99"].get<double> (), 8.2);
+    EXPECT_DOUBLE_EQ (reported["tls"]["p99"].get<double> (), 22.0);
+    EXPECT_DOUBLE_EQ (reported["firstByte"]["p50"].get<double> (), 2.9);
+    EXPECT_DOUBLE_EQ (reported["download"]["max"].get<double> (), 2.7);
+    EXPECT_EQ (reported["tls"]["count"].get<size_t> (), 4321u);
+}
+
+// The absence twin. A run that recorded no distribution reports no `phases`
+// key - five zeroed rows would claim every phase was instant. The averages
+// half is unaffected, which is what keeps the two independently present.
+TEST_F (RunsRouteTest, ReportOmitsPhasesWhenNoneWereRecorded) {
+    seed ({ .id = "run_no_phases", .start_time = 1000 });
+    auto inputs   = summary_inputs ();
+    inputs.phases = std::nullopt;
+    db_->update_run_summary (
+    "run_no_phases", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_no_phases");
+    ASSERT_EQ (status, 200);
+    if (body.contains ("timingBreakdown")) {
+        EXPECT_FALSE (body["timingBreakdown"].contains ("phases"));
+    }
+}
+
 // A summary that is not a JSON object is treated as absent. There is no second
 // aggregate source any more, so the report stands on the run's sampled results
 // - which is a report, not a 500 and not an empty run.


### PR DESCRIPTION
## Description

**Plan.** The root cause is that `apply_phase_timings` fills all five phase values on every completion and `handle_result` then serialises them into `trace_data` **only** for a retained record - so `timingBreakdown` was averages over a biased ~1% sample, and a p99 dominated by TLS re-handshakes read identically to a slow server. The approach is the `StepHistograms` precedent: five `hdr_histogram*` beside the run's latency histogram, written with `hdr_record_value_atomic` from the completion path and drained once post-run through the existing four-hop (`RunSummaryInputs` → `build_run_summary_payload` → `apply_run_summary` → `run_report_response`). The feed is deliberately **not** coupled to the `sampled || is_slow || exemplar` gate, because escaping that sample is the entire point. **Rejected:** recording the phases inside the retention branch, which would have been a one-line change and would have reproduced the exact defect being fixed - the `PhaseHistogramsEscapeTheRetentionSample` test is written so that shape fails it.

Two decisions worth review, both flagged rather than assumed:

- **`record_success` takes `const Timing*`, not five doubles.** The issue suggested plain doubles; five adjacent parameters of the same type is a transposition nobody would catch, and the caller already holds the struct. Success only, as the issue allows - the error-with-response branch is untouched.
- **`CaptureDefaults` is renamed `EngineDefaults`** (4 references). Its own docstring already described the general role ("engine-config-backed defaults a run needs at construction time"); `phase_histograms` reaches `RunContext` by that route and is not a capture knob, so the name had to stop being narrower than the struct.

Also here because the split created it: `timingBreakdown` now holds **two independently-present halves**. The averages come from the retained trace sample; `phases` comes from histograms every completion fed, so it is present precisely for a run that stored no traces. Three renderers tested `report.timingBreakdown` and would have painted five zeroed bars and a confident "0 ms" total for exactly those runs - they now ask the shared `hasPhaseAverages()`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green on this branch, from a clean build.

- **Engine: 1311/1311** (`python build.py -e -t && ctest --preset linux-dev`), 177s. 11 new: 5 in `metrics_collector_test.cpp` (per-phase isolation with five distinct magnitudes so a transposition fails; tail-vs-body separation; toggle off records nothing; absent without completions; 4x5000-thread concurrency, where a non-atomic record shows as a short count), 2 in `load_strategy_test.cpp`, 2 in `runs_route_test.cpp` (round-trip + absence twin), 2 in `run_config_validation_test.cpp`.
- **App: 3857/3857** (`pnpm test`), plus `pnpm type-check`, `pnpm lint` and `prettier --check` on the touched files (all were prettier-clean before; nothing else was formatted).
- **`mkdocs build --strict`** clean.

**Mutation checks run, not just asserted.** Reverting `hasData` to `!!report?.timingBreakdown` and dropping the zero-p50 branch from `isTailHeavy` each failed exactly their intended test and nothing else (2 failed / 6 passed). Making `avgDnsMs` etc. optional is what surfaced the three average-renderers through `type-check`.

One test of mine was wrong on first run and the code was right: with 99 zeros and one outlier the p99 is legitimately 0, so the fixture is now 95/5 to put the outliers inside p99 rather than asserting the histogram's rank arithmetic.

### Benchmark (the acceptance gate)

Full write-up and method in `docs/engine/benchmarks.md`. **Different hardware from every other figure on that page**: a 4-core container with the mock server sharing the same cores, so the ceiling is ~18.9k req/s rather than the M3 Pro's ~57k. Read the ratio.

19 runs per arm at `constant_concurrency` 64, 20s each - 14 with ON first in each pair and 5 with the order reversed, because a fixed within-pair order would let drift land entirely on one arm.

| statistic | ON | OFF | delta |
|---|---:|---:|---:|
| median req/s | 18,578 | 18,869 | **-1.54%** |
| mean req/s | 18,242 | 18,694 | -2.42% |
| mean, lowest run per arm dropped | - | - | -1.78% |

The raw mean is the only figure past 2% and one rep does all of that work (14,641 req/s, 21% under the next-lowest run in either arm). Per-arm spread is 12-25%, and the two orderings disagree in size (-1.83% vs -0.97%).

Timing the five records in isolation against the same vendored HdrHistogram, with the value mix a real run produces (mostly zeros, so the writes concentrate on one bucket and contend maximally): **160 ns/completion uncontended, 349 ns at 4 threads**. At 18.9k req/s that is 6.5 ms of CPU per second - **0.65% of one core, 0.16% of the box** - an order of magnitude under the end-to-end spread, which is the strongest evidence that the 1.5% there is this container's variance.

**Verdict: default stays on**, per the issue's rule. Every outlier-robust statistic is under the 2% line.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `api-reference.md` (the setting, the per-run override, the report shape, and prose on the two halves + why no retention budget bounds `phases`), `db-schema.md` (stored `phases`, and why it is the one camelCase section), `architecture.md` (the collector's histogram inventory), `benchmarks.md` (above).

## Related Issues

Closes #476

Notes for whoever lands second, not blockers:

- **Conflict surface, as the issue predicted:** #472/#475/#477 (PRs #495/#490/#494) extend the same report four-hop in `run_manager.cpp`/`runs.cpp`, and #475/#477 also touch `PerformanceTab.tsx`. This branch is cut from `9880a02`, so it will need the merge.
- **Adjacent, deliberately left alone:** `save_timing_breakdown` and `capture_response_bodies` are read with `config.value(..., bool)` in `RunContext`'s constructor and carry the same throw-after-the-row-exists exposure that `validate_run_config` now guards for `phase_histograms`. Widening the guard to them changes behaviour for existing callers, so it belongs in its own change - happy to file it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGNnz85cdjVeMX1ba55c22)_