### PR TITLE
feat(engine/auth): built-in oauth2 mock issuer for offline auth flows

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1301,6 +1301,81 @@ hands it back.
 Attempts time out after 5 minutes; on success the token is written to the cache
 and `cacheKey` is returned.
 
+### Local mock issuer
+
+A built-in OAuth 2.0 issuer for developing and testing auth flows **offline** -
+no real identity provider, so no 2FA prompts, provider rate limits or
+"suspicious login" mail in the dev loop. Each issuer is an independent
+`127.0.0.1` listener serving `/token` and `/authorize`; point any OAuth 2.0
+config's `accessTokenUrl` at the `tokenUrl` it returns.
+
+It is **not an IdP**. JWKS/RS256, OIDC discovery documents, token introspection,
+consent screens and multi-tenant realms are deliberate non-goals.
+
+| Method / Path | Purpose |
+|---------------|---------|
+| `POST /mock-issuer/start` | Start one → `{issuerId, issuerUrl, tokenUrl, authorizeUrl, signingKey}` |
+| `GET /mock-issuer` | List the running issuers |
+| `PUT /mock-issuer/:id` | Update `failureMode` / `slowMs` / `expiresInSeconds` live |
+| `POST /mock-issuer/:id/stop` | Stop one → `{stopped: true}` (`404` if unknown) |
+
+**Start body** (every field optional):
+
+```json
+{
+  "port": 0,
+  "expiresInSeconds": 3600,
+  "claims": { "sub": "alice", "roles": ["admin"] },
+  "clients": [{ "clientId": "cid", "clientSecret": "s3cret" }],
+  "failureMode": "none",
+  "slowMs": 2000,
+  "issueRefreshTokens": true
+}
+```
+
+`port: 0` (the default) binds an ephemeral port. `clients` empty accepts **any**
+client id; with clients configured, an id must be one of them and one carrying a
+secret must present it (Basic header or body - both RFC 6749 §2.3.1 placements).
+A field present with the wrong type or an out-of-range value is a `400`
+(`mock_issuer_invalid_config`) rather than a silent fallback to the default - a
+mock issuer running with an expiry other than the one asked for would defeat the
+purpose. At most 8 issuers run at once (`429 mock_issuer_limit_reached`).
+
+**The issuer's own endpoints:**
+
+- `POST /token` - `client_credentials`, `password`, `authorization_code` and
+  `refresh_token` grants, `application/x-www-form-urlencoded` as RFC 6749 §3.2
+  requires. Answers `{access_token, token_type: "Bearer", expires_in,
+  refresh_token?, scope?}`. Authorization codes are single-use and expire after
+  5 minutes; a refresh grant **rotates** its token (the presented one is spent).
+- `GET /authorize` - auto-approves and `302`s straight back to `redirect_uri`
+  with `code` and `state`, so the interactive flow completes with zero human
+  steps. PKCE is verified when a `code_challenge` is present;
+  `code_challenge_method` must then be `S256` (`plain` is refused rather than
+  quietly accepted). An unknown client or a missing `redirect_uri` answers in
+  place rather than redirecting (RFC 6749 §4.1.2.1).
+
+The access token is an **HS256 JWT** signed with the per-issuer `signingKey` the
+start call returned - hand that key to the service under test as its shared
+secret and it can verify the mock's tokens. The payload is the configured
+`claims` plus `iss`, `iat`, `exp` and `jti` (these four always win, since they
+describe the token being issued), with `sub`, `client_id` and `scope` filled in
+only when the claims did not set them.
+
+`failureMode` is what makes retry and error handling testable, and can be
+flipped on a **running** issuer with the `PUT`:
+
+| Mode | `/token` answers |
+|------|------------------|
+| `none` | Normally |
+| `slow` | Normally, after `slowMs` |
+| `server_error` | `500 {"error": "temporarily_unavailable"}` |
+| `invalid_client` | `401 {"error": "invalid_client"}` |
+
+Issuers bind `127.0.0.1` only - never configurable, because they mint bearer
+tokens and the engine has no route auth. State is in-memory: a restart forgets
+every issuer, and stopping one drops its codes and refresh tokens with it.
+
 ## Execution
 
 ### POST /compose

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -274,6 +274,21 @@ applied to the outgoing request rather than being left to the UI. This lives in
   engine-hosted `127.0.0.1` loopback listener + PKCE (S256) and `state`, so the
   entire flow (including the code exchange) stays in-process; the app only opens
   the browser. Owned by the `Server` for a clean shutdown.
+- **`mock_issuer`** - the local OAuth 2.0 issuer (`routes/mock_issuer.cpp`):
+  `POST /mock-issuer/start` binds another `127.0.0.1` listener serving `/token`
+  and `/authorize`, so auth flows are exercisable offline with no real identity
+  provider. It mints HS256 JWTs with a random per-issuer key (libsodium again),
+  auto-approves `/authorize` with PKCE S256 verification, rotates refresh
+  tokens, and can be flipped between healthy and `slow` / `server_error` /
+  `invalid_client` while running. In-memory only and owned by the `Server`, on
+  the same reverse-member-order rule as the authorize manager.
+
+**Listener inventory.** The engine's own API is the only long-lived listener
+(`127.0.0.1:<port>`, `server.cpp`). Everything else is spawned, loopback-bound
+and short-lived: the interactive-auth callback (one per attempt, 5-minute TTL)
+and mock issuers (at most 8, until stopped). None of them may bind wider than
+`127.0.0.1` - the management API has no route auth and CORS `*`, and a mock
+issuer hands out bearer tokens, so a non-loopback bind would publish both.
 
 PKCE hashing uses **libsodium** (`crypto_hash_sha256`, and `sodium_bin2base64`'s
 URL-safe unpadded variant for the challenge itself; no OpenSSL). See

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -744,6 +744,10 @@ builds on the mechanism the spec is deprecating and the payoff is client-depende
 
 - **MCP-originated run tagging** - tag runs started via MCP so History shows
   provenance.
+- **`start_mock_issuer`** - a tool over the engine's local OAuth 2.0 mock issuer
+  ([API reference](./api-reference.md#local-mock-issuer)), so an agent asked to
+  "test this auth flow" can mint its own tokens. Deliberately out of scope of
+  the engine-side feature (#479); the routes are reachable today.
 - **`vayu mcp` bin** - package the stdio CLI as a first-class command (backlog M1).
 - **Live push over HTTP** - stateful sessions (see Design notes).
 - **Hosted MCP for Vayu Cloud** - OAuth-gated, remote.

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -398,6 +398,7 @@ if(VAYU_BUILD_ENGINE)
         src/http/routes/oauth.cpp
         src/http/routes/oauth_authorize.cpp
         src/http/routes/cookies.cpp
+        src/http/routes/mock_issuer.cpp
     )
 
     target_link_libraries(vayu-engine PRIVATE
@@ -479,6 +480,7 @@ if(VAYU_BUILD_TESTS)
         tests/pkce_test.cpp
         tests/debug_redact_test.cpp
         tests/oauth_authorize_test.cpp
+        tests/mock_issuer_test.cpp
         tests/id_test.cpp
         tests/curl_utils_test.cpp
         tests/curl_transfer_test.cpp
@@ -508,6 +510,7 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/scripting.cpp
         src/http/routes/script_types.cpp
         src/http/routes/cookies.cpp
+        src/http/routes/mock_issuer.cpp
     )
     
     # The cross-language conformance fixture lives in the source tree and is

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -460,6 +460,37 @@ constexpr int SPIN_COUNT = 2000;
 } // namespace queue
 
 /**
+ * @brief Local OAuth 2.0 mock issuer bounds
+ *
+ * Rails rather than preferences: every one of these bounds a resource the
+ * *caller* does not pay for - listener threads, and two maps a long-lived
+ * daemon would otherwise grow one entry per authorize call that never came
+ * back for its code. The issuer's actual behaviour (expiry, claims, failure
+ * mode, cadence of nothing) is per-issuer request payload, not config.
+ */
+namespace mock_issuer {
+/// Concurrently running issuers. Each owns a listener thread plus cpp-httplib's
+/// own accept loop, so this is a thread budget more than anything else.
+constexpr size_t MAX_ISSUERS = 8;
+/// Clients one issuer may be configured with.
+constexpr size_t MAX_CLIENTS = 32;
+/// Authorization codes held awaiting their exchange (oldest evicted first).
+constexpr size_t MAX_PENDING_CODES = 256;
+/// Live refresh tokens held per issuer (oldest evicted first). Rotation spends
+/// one and mints one, so this only binds when many are issued and never used.
+constexpr size_t MAX_REFRESH_TOKENS = 256;
+/// How long an authorization code stays exchangeable. RFC 6749 §4.1.2 asks for
+/// a short lifetime; this matches the interactive attempt TTL in
+/// oauth_authorize.cpp so the two halves of one flow expire together.
+constexpr int64_t CODE_TTL_MS = 5 * 60 * 1000;
+/// Ceiling on the `slow` failure mode's delay. Past a minute the caller is
+/// testing its own timeout, and the sleep holds a cpp-httplib pool thread.
+constexpr int64_t MAX_SLOW_MS = 60000;
+/// Ceiling on a minted token's lifetime (31 days).
+constexpr int64_t MAX_EXPIRES_IN_SECONDS = 31LL * 86400LL;
+} // namespace mock_issuer
+
+/**
  * @brief Database optimization configuration
  */
 namespace database {

--- a/engine/include/vayu/http/mock_issuer.hpp
+++ b/engine/include/vayu/http/mock_issuer.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace vayu::http {
+
+/**
+ * A client the mock issuer will authenticate. An empty `client_secret` marks a
+ * public client - one that authenticates with its id alone.
+ */
+struct MockIssuerClient {
+    std::string client_id;
+    std::string client_secret;
+};
+
+/**
+ * What a mock issuer runs with. `failure_mode`, `slow_ms` and
+ * `expires_in_seconds` are the live-updatable half (PUT /mock-issuer/:id); the
+ * rest is fixed at start, because changing a port or a client list underneath a
+ * bound listener is a restart, not an update.
+ */
+struct MockIssuerSettings {
+    int port                   = 0; // 0 = ephemeral
+    int64_t expires_in_seconds = 3600;
+    nlohmann::json claims      = nlohmann::json::object ();
+    std::vector<MockIssuerClient> clients; // empty = accept any client id
+    std::string failure_mode  = "none"; // none|slow|server_error|invalid_client
+    int64_t slow_ms           = 2000;
+    bool issue_refresh_tokens = true;
+};
+
+/**
+ * The outcome of reading a start payload or an update patch. `ok == false`
+ * carries the message a `400` should state; the settings are only meaningful
+ * when ok.
+ */
+struct MockIssuerConfig {
+    bool ok = true;
+    std::string error;
+    MockIssuerSettings settings;
+};
+
+/**
+ * Read a `POST /mock-issuer/start` payload into settings, defaults filling in
+ * for absent fields. A field present with the wrong type or an out-of-range
+ * value is an error rather than a silently ignored write - a mock issuer that
+ * quietly ran with a different expiry than asked for would be worse than no
+ * issuer at all, since the whole point is testing expiry behaviour.
+ */
+MockIssuerConfig parse_mock_issuer_settings (const nlohmann::json& body);
+
+/**
+ * Apply a `PUT /mock-issuer/:id` patch to @p current. Only `failureMode`,
+ * `slowMs` and `expiresInSeconds` are updatable; any other key is a `400`
+ * naming it, so a caller that expected a live port or client change learns that
+ * it did not happen.
+ */
+MockIssuerConfig apply_mock_issuer_patch (const nlohmann::json& body,
+const MockIssuerSettings& current);
+
+/**
+ * Result of starting a mock issuer.
+ */
+struct MockIssuerStart {
+    bool ok = true;
+    std::string issuer_id;
+    std::string issuer_url;
+    std::string token_url;
+    std::string authorize_url;
+    /// The HS256 secret this issuer signs with. Returned because a service
+    /// under test needs it to verify the tokens the mock mints; it is
+    /// throwaway, per-issuer and in-memory only.
+    std::string signing_key;
+    // error (when !ok)
+    int http_status = 400;
+    std::string error_code;
+    std::string error_message;
+};
+
+namespace detail {
+/// One running issuer: its settings, its issued codes and refresh tokens, and
+/// the listener serving them. Defined in mock_issuer.cpp so this header stays
+/// clear of httplib.
+struct MockIssuerState;
+} // namespace detail
+
+/**
+ * Owns local OAuth 2.0 mock issuers: each is an independent `127.0.0.1`
+ * listener serving `/token` and `/authorize`, so auth flows are exercisable
+ * offline without a real identity provider.
+ *
+ * Not an IdP. JWKS/RS256, OIDC discovery, token introspection, consent screens
+ * and multi-tenant realms are deliberate non-goals - this is a dev-loop tool.
+ *
+ * State is in-memory only: a restart forgets every issuer. Thread-safe; the
+ * destructor stops and joins every live listener, so the manager must outlive
+ * nothing it captures (it captures only itself).
+ */
+class MockIssuerManager {
+    public:
+    // Defined out-of-line: the map holds unique_ptr<Issuer> and Issuer is an
+    // incomplete type here (it owns an httplib::Server, kept out of this header).
+    MockIssuerManager ();
+    ~MockIssuerManager ();
+
+    MockIssuerManager (const MockIssuerManager&)            = delete;
+    MockIssuerManager& operator= (const MockIssuerManager&) = delete;
+
+    MockIssuerStart start (const nlohmann::json& body);
+
+    /// @return false when no issuer has that id.
+    bool stop (const std::string& issuer_id);
+
+    /// `{"issuers": [...]}` - one object per running issuer.
+    nlohmann::json list () const;
+
+    struct UpdateResult {
+        bool found = false;
+        bool ok    = true;
+        std::string error;
+        nlohmann::json issuer; // the updated description, when ok
+    };
+    UpdateResult update (const std::string& issuer_id, const nlohmann::json& body);
+
+    private:
+    mutable std::mutex mutex_;
+    std::map<std::string, std::unique_ptr<detail::MockIssuerState>> issuers_;
+
+    /// Stop and join one issuer's listener. Touches no manager state, so it is
+    /// called both under `mutex_` (the destructor) and outside it (`stop`,
+    /// where joining a listener thread must not block every other caller).
+    static void teardown (detail::MockIssuerState& issuer);
+};
+
+} // namespace vayu::http

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -31,6 +31,9 @@ namespace vayu::http {
 // oauth_authorize.hpp. Forward-declared here so RouteContext can carry a
 // reference without every route TU pulling in the loopback listener machinery.
 class OAuth2AuthorizeManager;
+// Owns the local OAuth 2.0 mock issuers; defined in mock_issuer.hpp. Forward-
+// declared for the same reason as the manager above.
+class MockIssuerManager;
 } // namespace vayu::http
 
 namespace vayu::http::routes {
@@ -487,6 +490,9 @@ struct RouteContext {
     /// `/execute` (which sends through it) and by `/cookies` (which shows and
     /// clears it). Not reachable from the load path - see cookie_jar.hpp.
     vayu::http::CookieJar& cookie_jar;
+    /// The local OAuth 2.0 mock issuers (issue #479). Owned by Server; see
+    /// server.hpp for why it is declared before server_.
+    vayu::http::MockIssuerManager& mock_issuer_manager;
 };
 
 // Route registration functions (implemented in separate files)
@@ -505,6 +511,7 @@ void register_scripting_routes (RouteContext& ctx);
 void register_import_routes (RouteContext& ctx);
 void register_oauth_routes (RouteContext& ctx);
 void register_cookie_routes (RouteContext& ctx);
+void register_mock_issuer_routes (RouteContext& ctx);
 
 /**
  * @brief Generate the TypeScript declarations for the `pm.*` script surface.

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -15,6 +15,7 @@
 
 #include "vayu/core/run_manager.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/mock_issuer.hpp"
 #include "vayu/http/oauth_authorize.hpp"
 #include "vayu/http/routes.hpp"
 
@@ -52,6 +53,10 @@ class Server {
     // route lambdas and any in-flight /execute hold a reference to it, so it
     // must outlive server_. Process-lifetime by design - see cookie_jar.hpp.
     CookieJar cookie_jar_;
+    // Same reverse-order reasoning again: its dtor stops and joins every live
+    // mock-issuer listener, and the route lambdas that reach it must be gone by
+    // then - so it is declared before server_ and destroyed after it.
+    MockIssuerManager mock_issuer_manager_;
     httplib::Server server_;
     std::thread server_thread_;
     std::atomic<bool> is_running_{ false };

--- a/engine/src/http/routes/mock_issuer.cpp
+++ b/engine/src/http/routes/mock_issuer.cpp
@@ -1,0 +1,843 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/routes/mock_issuer.cpp
+ * @brief The local OAuth 2.0 mock issuer - manager, spawned listener, and the
+ *        `/mock-issuer` lifecycle routes.
+ *
+ * Lives with the routes for the same reason `oauth_authorize.cpp` does: the
+ * spawned listener needs httplib, which is linked into the engine and the test
+ * binary but not into `vayu_core`.
+ */
+
+#include "vayu/http/mock_issuer.hpp"
+
+#include "vayu/core/constants.hpp"
+#include "vayu/http/pkce.hpp"
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/encoding.hpp"
+#include "vayu/utils/id.hpp"
+#include "vayu/utils/logger.hpp"
+#include "vayu/utils/sha256.hpp"
+
+#include <httplib.h>
+
+#include <chrono>
+#include <string_view>
+#include <thread>
+
+namespace vayu::http {
+
+namespace mi = vayu::core::constants::mock_issuer;
+
+namespace {
+
+int64_t now_ms () {
+    return vayu::http::routes::now_ms ();
+}
+
+// ---------------------------------------------------------------------------
+// Payload reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read an integer field. Absent leaves @p out alone; present with a non-integer
+ * type or outside [min,max] is an error, never a silent fallback to the default.
+ */
+bool read_int (const nlohmann::json& body,
+const char* key,
+int64_t min,
+int64_t max,
+int64_t& out,
+std::string& error) {
+    const auto it = body.find (key);
+    if (it == body.end () || it->is_null ()) {
+        return true;
+    }
+    if (!it->is_number_integer ()) {
+        error = std::string (key) + " must be an integer";
+        return false;
+    }
+    const auto value = it->get<int64_t> ();
+    if (value < min || value > max) {
+        error = std::string (key) + " must be between " + std::to_string (min) +
+        " and " + std::to_string (max);
+        return false;
+    }
+    out = value;
+    return true;
+}
+
+bool read_bool (const nlohmann::json& body, const char* key, bool& out, std::string& error) {
+    const auto it = body.find (key);
+    if (it == body.end () || it->is_null ()) {
+        return true;
+    }
+    if (!it->is_boolean ()) {
+        error = std::string (key) + " must be a boolean";
+        return false;
+    }
+    out = it->get<bool> ();
+    return true;
+}
+
+bool read_failure_mode (const nlohmann::json& body, std::string& out, std::string& error) {
+    const auto it = body.find ("failureMode");
+    if (it == body.end () || it->is_null ()) {
+        return true;
+    }
+    if (!it->is_string ()) {
+        error = "failureMode must be a string";
+        return false;
+    }
+    const auto mode = it->get<std::string> ();
+    if (mode != "none" && mode != "slow" && mode != "server_error" && mode != "invalid_client") {
+        error =
+        "failureMode must be one of none, slow, server_error, invalid_client";
+        return false;
+    }
+    out = mode;
+    return true;
+}
+
+bool read_clients (const nlohmann::json& body,
+std::vector<MockIssuerClient>& out,
+std::string& error) {
+    const auto it = body.find ("clients");
+    if (it == body.end () || it->is_null ()) {
+        return true;
+    }
+    if (!it->is_array ()) {
+        error = "clients must be an array";
+        return false;
+    }
+    if (it->size () > mi::MAX_CLIENTS) {
+        error = "clients may hold at most " + std::to_string (mi::MAX_CLIENTS) + " entries";
+        return false;
+    }
+    std::vector<MockIssuerClient> clients;
+    for (const auto& entry : *it) {
+        if (!entry.is_object ()) {
+            error = "each clients entry must be an object";
+            return false;
+        }
+        const auto id = entry.find ("clientId");
+        if (id == entry.end () || !id->is_string () || id->get<std::string> ().empty ()) {
+            error = "each clients entry needs a non-empty clientId";
+            return false;
+        }
+        MockIssuerClient client;
+        client.client_id = id->get<std::string> ();
+        if (const auto secret = entry.find ("clientSecret");
+            secret != entry.end () && !secret->is_null ()) {
+            if (!secret->is_string ()) {
+                error = "clientSecret must be a string";
+                return false;
+            }
+            client.client_secret = secret->get<std::string> ();
+        }
+        clients.push_back (std::move (client));
+    }
+    out = std::move (clients);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// JWT
+// ---------------------------------------------------------------------------
+
+std::string base64url_json (const nlohmann::json& value) {
+    return vayu::utils::base64url_encode (value.dump ());
+}
+
+/**
+ * `base64url(header).base64url(payload).base64url(HMAC-SHA256(key, ...))`.
+ *
+ * The signing key is this issuer's own random secret, so the engine only ever
+ * *produces* a tag here - nothing compares an attacker-supplied one, which is
+ * the case sha256.hpp warns needs sodium_memcmp.
+ */
+std::string mint_jwt (const std::string& key, const nlohmann::json& payload) {
+    static const nlohmann::json header = { { "alg", "HS256" }, { "typ", "JWT" } };
+    const std::string signing_input =
+    base64url_json (header) + "." + base64url_json (payload);
+    const auto tag = vayu::utils::hmac_sha256 (key, signing_input);
+    return signing_input + "." +
+    vayu::utils::base64url_encode (
+    std::string_view (reinterpret_cast<const char*> (tag.data ()), tag.size ()));
+}
+
+// ---------------------------------------------------------------------------
+// Issuer-side helpers
+// ---------------------------------------------------------------------------
+
+/// Client credentials as the token endpoint received them, from either of the
+/// two placements RFC 6749 §2.3.1 allows (and `apply_client_auth` sends).
+struct ClientAuth {
+    std::string client_id;
+    std::string client_secret;
+};
+
+ClientAuth read_client_auth (const httplib::Request& req) {
+    ClientAuth out;
+    const std::string header = req.get_header_value ("Authorization");
+    if (header.rfind ("Basic ", 0) == 0) {
+        if (const auto decoded = vayu::utils::base64_decode (header.substr (6))) {
+            const auto colon = decoded->find (':');
+            if (colon != std::string::npos) {
+                // §2.3.1 form-encodes both halves before the base64.
+                out.client_id = vayu::utils::url_decode (decoded->substr (0, colon));
+                out.client_secret =
+                vayu::utils::url_decode (decoded->substr (colon + 1));
+                return out;
+            }
+        }
+    }
+    out.client_id     = req.get_param_value ("client_id");
+    out.client_secret = req.get_param_value ("client_secret");
+    return out;
+}
+
+/**
+ * A client id is always required. With no `clients` configured any id is
+ * accepted (the common "I just need a token" case); with clients configured the
+ * id must be one of them, and one carrying a secret must present it.
+ */
+bool authenticate_client (const MockIssuerSettings& settings, const ClientAuth& auth) {
+    if (auth.client_id.empty ()) {
+        return false;
+    }
+    if (settings.clients.empty ()) {
+        return true;
+    }
+    for (const auto& client : settings.clients) {
+        if (client.client_id != auth.client_id) {
+            continue;
+        }
+        return client.client_secret.empty () || client.client_secret == auth.client_secret;
+    }
+    return false;
+}
+
+void send_oauth_error (httplib::Response& res,
+int status,
+const char* error,
+const std::string& description = {}) {
+    nlohmann::json body = { { "error", error } };
+    if (!description.empty ()) {
+        body["error_description"] = description;
+    }
+    res.status = status;
+    res.set_content (body.dump (), "application/json");
+}
+
+/// Evict the oldest entries until @p map holds at most @p cap. Codes and
+/// refresh tokens are keyed by a random string, so age is the only ordering
+/// there is - and the bound is what keeps a long-lived daemon's mock issuer
+/// from growing a map per authorize call that never completed.
+template <typename Map> void bound_by_age (Map& map, size_t cap) {
+    while (map.size () > cap) {
+        auto oldest = map.begin ();
+        for (auto it = map.begin (); it != map.end (); ++it) {
+            if (it->second.issued_at < oldest->second.issued_at) {
+                oldest = it;
+            }
+        }
+        map.erase (oldest);
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Settings parsing (pure - the testable core)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+MockIssuerConfig read_mutable_settings (const nlohmann::json& body, MockIssuerSettings settings) {
+    MockIssuerConfig out;
+    std::string error;
+    if (!read_int (body, "expiresInSeconds", 1, mi::MAX_EXPIRES_IN_SECONDS,
+        settings.expires_in_seconds, error) ||
+    !read_int (body, "slowMs", 0, mi::MAX_SLOW_MS, settings.slow_ms, error) ||
+    !read_failure_mode (body, settings.failure_mode, error)) {
+        out.ok    = false;
+        out.error = error;
+        return out;
+    }
+    out.settings = std::move (settings);
+    return out;
+}
+
+} // namespace
+
+MockIssuerConfig parse_mock_issuer_settings (const nlohmann::json& body) {
+    MockIssuerConfig out;
+    if (!body.is_object ()) {
+        out.ok    = false;
+        out.error = "Body must be a JSON object";
+        return out;
+    }
+
+    out = read_mutable_settings (body, MockIssuerSettings{});
+    if (!out.ok) {
+        return out;
+    }
+
+    std::string error;
+    int64_t port = 0;
+    if (!read_int (body, "port", 0, 65535, port, error) ||
+    !read_bool (body, "issueRefreshTokens", out.settings.issue_refresh_tokens, error) ||
+    !read_clients (body, out.settings.clients, error)) {
+        out.ok    = false;
+        out.error = error;
+        return out;
+    }
+    out.settings.port = static_cast<int> (port);
+
+    if (const auto claims = body.find ("claims");
+        claims != body.end () && !claims->is_null ()) {
+        if (!claims->is_object ()) {
+            out.ok    = false;
+            out.error = "claims must be an object";
+            return out;
+        }
+        out.settings.claims = *claims;
+    }
+    return out;
+}
+
+MockIssuerConfig apply_mock_issuer_patch (const nlohmann::json& body,
+const MockIssuerSettings& current) {
+    MockIssuerConfig out;
+    if (!body.is_object ()) {
+        out.ok    = false;
+        out.error = "Body must be a JSON object";
+        return out;
+    }
+    // A port, client list or claim set cannot change under a bound listener, so
+    // asking for one is refused rather than half-applied.
+    for (const char* immutable : { "port", "clients", "claims", "issueRefreshTokens" }) {
+        if (body.contains (immutable)) {
+            out.ok = false;
+            out.error = std::string (immutable) + " cannot be updated on a running issuer - stop it and start a new one";
+            return out;
+        }
+    }
+    return read_mutable_settings (body, current);
+}
+
+// ---------------------------------------------------------------------------
+// Issuer + manager
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+struct MockIssuerState {
+    std::string id;
+    int port = 0;
+    std::string signing_key;
+    std::string issuer_url;
+    int64_t created_at = 0;
+
+    struct IssuedCode {
+        std::string client_id;
+        std::string redirect_uri;
+        std::string code_challenge; // empty = the authorize call used no PKCE
+        std::string scope;
+        int64_t issued_at = 0;
+    };
+    struct IssuedRefresh {
+        std::string client_id;
+        std::string scope;
+        std::string subject;
+        int64_t issued_at = 0;
+    };
+
+    // Guards everything the listener threads touch: the settings a PUT can
+    // change under them, and the two issued-credential maps.
+    std::mutex state_mutex;
+    MockIssuerSettings settings;
+    std::map<std::string, IssuedCode> codes;
+    std::map<std::string, IssuedRefresh> refresh_tokens;
+
+    std::unique_ptr<httplib::Server> server;
+    std::thread listen_thread;
+
+    std::string token_url () const {
+        return issuer_url + "/token";
+    }
+    std::string authorize_url () const {
+        return issuer_url + "/authorize";
+    }
+
+    /// Description shared by `GET /mock-issuer` and the `PUT` reply.
+    nlohmann::json describe () {
+        std::lock_guard<std::mutex> lock (state_mutex);
+        return nlohmann::json{ { "issuerId", id }, { "issuerUrl", issuer_url },
+            { "tokenUrl", token_url () }, { "authorizeUrl", authorize_url () },
+            { "signingKey", signing_key }, { "port", port },
+            { "expiresInSeconds", settings.expires_in_seconds },
+            { "failureMode", settings.failure_mode }, { "slowMs", settings.slow_ms },
+            { "issueRefreshTokens", settings.issue_refresh_tokens },
+            { "clientCount", settings.clients.size () }, { "createdAt", created_at } };
+    }
+};
+
+} // namespace detail
+
+namespace {
+
+using Issuer = detail::MockIssuerState;
+
+/**
+ * Build the access token for one grant. Called with the issuer's state lock
+ * held, so `settings` cannot change between the expiry stamped in the payload
+ * and the `expires_in` reported beside it.
+ */
+nlohmann::json mint_token_response (Issuer& issuer,
+const std::string& subject,
+const std::string& client_id,
+const std::string& scope) {
+    const MockIssuerSettings& settings = issuer.settings;
+    const int64_t issued_at_s          = now_ms () / 1000;
+
+    nlohmann::json claims = settings.claims;
+    // The configured claims are the base; the four below describe *this* token
+    // and would contradict the response beside them if a claim set overrode
+    // them, so they win. `sub`/`client_id`/`scope` yield to a configured value.
+    claims["iss"] = issuer.issuer_url;
+    claims["iat"] = issued_at_s;
+    claims["exp"] = issued_at_s + settings.expires_in_seconds;
+    claims["jti"] = pkce::random_token (12);
+    if (!claims.contains ("sub") && !subject.empty ()) {
+        claims["sub"] = subject;
+    }
+    if (!claims.contains ("client_id") && !client_id.empty ()) {
+        claims["client_id"] = client_id;
+    }
+    if (!claims.contains ("scope") && !scope.empty ()) {
+        claims["scope"] = scope;
+    }
+
+    nlohmann::json body = { { "access_token", mint_jwt (issuer.signing_key, claims) },
+        { "token_type", "Bearer" }, { "expires_in", settings.expires_in_seconds } };
+    if (!scope.empty ()) {
+        body["scope"] = scope;
+    }
+    if (settings.issue_refresh_tokens) {
+        const std::string refresh = pkce::random_token (24);
+        issuer.refresh_tokens[refresh] =
+        Issuer::IssuedRefresh{ client_id, scope, subject, now_ms () };
+        bound_by_age (issuer.refresh_tokens, mi::MAX_REFRESH_TOKENS);
+        body["refresh_token"] = refresh;
+    }
+    return body;
+}
+
+void handle_token (Issuer& issuer, const httplib::Request& req, httplib::Response& res) {
+    // The failure mode is read (and `slow` slept) before anything else, so a
+    // caller testing retry behaviour sees the same reply whatever it asked for.
+    std::string failure_mode;
+    int64_t slow_ms = 0;
+    {
+        std::lock_guard<std::mutex> lock (issuer.state_mutex);
+        failure_mode = issuer.settings.failure_mode;
+        slow_ms      = issuer.settings.slow_ms;
+    }
+    if (failure_mode == "server_error") {
+        send_oauth_error (res, 500, "temporarily_unavailable");
+        return;
+    }
+    if (failure_mode == "invalid_client") {
+        send_oauth_error (res, 401, "invalid_client");
+        return;
+    }
+    if (failure_mode == "slow" && slow_ms > 0) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (slow_ms));
+    }
+
+    const std::string grant = req.get_param_value ("grant_type");
+    if (grant.empty ()) {
+        // Either no grant_type, or a body the endpoint cannot read: RFC 6749
+        // §3.2 requires application/x-www-form-urlencoded and that is the only
+        // shape parsed here, so say so rather than reporting a missing field.
+        send_oauth_error (res, 400, "invalid_request",
+        "grant_type is required, sent as application/x-www-form-urlencoded");
+        return;
+    }
+
+    const ClientAuth auth = read_client_auth (req);
+
+    std::lock_guard<std::mutex> lock (issuer.state_mutex);
+    if (!authenticate_client (issuer.settings, auth)) {
+        send_oauth_error (res, 401, "invalid_client",
+        auth.client_id.empty () ? "client_id is required" : "Unknown client or bad secret");
+        return;
+    }
+
+    std::string subject = auth.client_id;
+    std::string scope   = req.get_param_value ("scope");
+
+    if (grant == "client_credentials") {
+        // Nothing further to check.
+    } else if (grant == "password") {
+        const std::string username = req.get_param_value ("username");
+        if (username.empty () || !req.has_param ("password")) {
+            send_oauth_error (res, 400, "invalid_request",
+            "password grant needs username and password");
+            return;
+        }
+        subject = username;
+    } else if (grant == "authorization_code") {
+        const std::string code = req.get_param_value ("code");
+        const auto it          = issuer.codes.find (code);
+        if (code.empty () || it == issuer.codes.end ()) {
+            send_oauth_error (res, 400, "invalid_grant", "Unknown or already-used code");
+            return;
+        }
+        const Issuer::IssuedCode issued = it->second;
+        issuer.codes.erase (it); // single use, whatever happens below
+        if (now_ms () > issued.issued_at + mi::CODE_TTL_MS) {
+            send_oauth_error (res, 400, "invalid_grant", "Authorization code expired");
+            return;
+        }
+        if (issued.client_id != auth.client_id) {
+            send_oauth_error (res, 400, "invalid_grant", "Code was issued to another client");
+            return;
+        }
+        if (const std::string redirect = req.get_param_value ("redirect_uri");
+            redirect != issued.redirect_uri) {
+            send_oauth_error (res, 400, "invalid_grant",
+            "redirect_uri does not match the authorize call");
+            return;
+        }
+        if (!issued.code_challenge.empty ()) {
+            const std::string verifier = req.get_param_value ("code_verifier");
+            if (verifier.empty () || pkce::code_challenge (verifier) != issued.code_challenge) {
+                send_oauth_error (res, 400, "invalid_grant", "PKCE verification failed");
+                return;
+            }
+        }
+        if (scope.empty ()) {
+            scope = issued.scope;
+        }
+    } else if (grant == "refresh_token") {
+        const std::string token = req.get_param_value ("refresh_token");
+        const auto it           = issuer.refresh_tokens.find (token);
+        if (token.empty () || it == issuer.refresh_tokens.end ()) {
+            send_oauth_error (res, 400, "invalid_grant",
+            "Unknown or already-rotated refresh token");
+            return;
+        }
+        const Issuer::IssuedRefresh issued = it->second;
+        // Rotation: the presented token is spent here, and mint_token_response
+        // issues its replacement - so a client that keeps the old one fails,
+        // which is exactly the path worth being able to exercise locally.
+        issuer.refresh_tokens.erase (it);
+        if (issued.client_id != auth.client_id) {
+            send_oauth_error (res, 400, "invalid_grant",
+            "Refresh token was issued to another client");
+            return;
+        }
+        if (!issued.subject.empty ()) {
+            subject = issued.subject;
+        }
+        if (scope.empty ()) {
+            scope = issued.scope;
+        }
+    } else {
+        send_oauth_error (res, 400, "unsupported_grant_type", grant);
+        return;
+    }
+
+    const auto body = mint_token_response (issuer, subject, auth.client_id, scope);
+    res.status = 200;
+    res.set_content (body.dump (), "application/json");
+}
+
+void handle_authorize (Issuer& issuer, const httplib::Request& req, httplib::Response& res) {
+    const std::string client_id    = req.get_param_value ("client_id");
+    const std::string redirect_uri = req.get_param_value ("redirect_uri");
+    const std::string state        = req.get_param_value ("state");
+    const std::string challenge    = req.get_param_value ("code_challenge");
+
+    if (redirect_uri.empty ()) {
+        // An invalid redirect target must never be redirected to (RFC 6749
+        // §4.1.2.1), so this and the client failure below answer in place.
+        send_oauth_error (res, 400, "invalid_request", "redirect_uri is required");
+        return;
+    }
+    if (const std::string response_type = req.get_param_value ("response_type");
+        !response_type.empty () && response_type != "code") {
+        send_oauth_error (res, 400, "unsupported_response_type", response_type);
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock (issuer.state_mutex);
+    if (!authenticate_client (issuer.settings, ClientAuth{ client_id, {} })) {
+        send_oauth_error (res, 400, "invalid_client",
+        client_id.empty () ? "client_id is required" : "Unknown client");
+        return;
+    }
+    if (!challenge.empty () && req.get_param_value ("code_challenge_method") != "S256") {
+        // S256 is the only method implemented; `plain` would let a test pass
+        // that a real provider rejects, which is worse than refusing it here.
+        send_oauth_error (res, 400, "invalid_request", "code_challenge_method must be S256");
+        return;
+    }
+
+    const std::string code = pkce::random_token (24);
+    issuer.codes[code] = Issuer::IssuedCode{ client_id, redirect_uri, challenge,
+        req.get_param_value ("scope"), now_ms () };
+    bound_by_age (issuer.codes, mi::MAX_PENDING_CODES);
+
+    std::string location = redirect_uri;
+    location.push_back (location.find ('?') == std::string::npos ? '?' : '&');
+    location += "code=" + vayu::utils::url_encode (code);
+    if (!state.empty ()) {
+        location += "&state=" + vayu::utils::url_encode (state);
+    }
+    res.set_redirect (location, 302);
+}
+
+} // namespace
+
+MockIssuerManager::MockIssuerManager () = default;
+
+MockIssuerManager::~MockIssuerManager () {
+    std::lock_guard<std::mutex> lock (mutex_);
+    for (auto& [id, issuer] : issuers_) {
+        teardown (*issuer);
+    }
+    issuers_.clear ();
+}
+
+void MockIssuerManager::teardown (Issuer& issuer) {
+    if (issuer.server) {
+        issuer.server->stop ();
+    }
+    if (issuer.listen_thread.joinable ()) {
+        issuer.listen_thread.join ();
+    }
+    issuer.server.reset ();
+}
+
+MockIssuerStart MockIssuerManager::start (const nlohmann::json& body) {
+    MockIssuerStart out;
+
+    auto parsed = parse_mock_issuer_settings (body);
+    if (!parsed.ok) {
+        out.ok            = false;
+        out.error_code    = "mock_issuer_invalid_config";
+        out.error_message = parsed.error;
+        return out;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock (mutex_);
+        if (issuers_.size () >= mi::MAX_ISSUERS) {
+            out.ok            = false;
+            out.http_status   = 429;
+            out.error_code    = "mock_issuer_limit_reached";
+            out.error_message = "At most " + std::to_string (mi::MAX_ISSUERS) +
+            " mock issuers may run at once - stop one first";
+            return out;
+        }
+    }
+
+    auto issuer        = std::make_unique<Issuer> ();
+    issuer->id         = vayu::utils::generate_id ("issuer_");
+    issuer->created_at = now_ms ();
+    issuer->settings   = std::move (parsed.settings);
+    // The signing key is base64url text rather than raw bytes so it can be
+    // handed to a service under test as a shared secret verbatim.
+    issuer->signing_key = pkce::random_token (32);
+    issuer->server      = std::make_unique<httplib::Server> ();
+
+    Issuer* raw = issuer.get ();
+    raw->server->Post ("/token", [raw] (const httplib::Request& req, httplib::Response& res) {
+        handle_token (*raw, req, res);
+    });
+    raw->server->Get (
+    "/authorize", [raw] (const httplib::Request& req, httplib::Response& res) {
+        handle_authorize (*raw, req, res);
+    });
+
+    // 127.0.0.1 only, never configurable: the issuer mints bearer tokens and
+    // the engine has no route auth, so a wider bind would hand them to the LAN.
+    const int port = issuer->settings.port == 0 ?
+    issuer->server->bind_to_any_port ("127.0.0.1") :
+    (issuer->server->bind_to_port ("127.0.0.1", issuer->settings.port) ?
+    issuer->settings.port :
+    0);
+    if (port <= 0) {
+        out.ok            = false;
+        out.http_status   = 500;
+        out.error_code    = "mock_issuer_bind_failed";
+        out.error_message = issuer->settings.port == 0 ?
+        "Could not bind a local port for the mock issuer" :
+        "Could not bind 127.0.0.1:" + std::to_string (issuer->settings.port);
+        return out;
+    }
+    issuer->port       = port;
+    issuer->issuer_url = "http://127.0.0.1:" + std::to_string (port);
+
+    httplib::Server* svr  = issuer->server.get ();
+    issuer->listen_thread = std::thread ([svr] { svr->listen_after_bind (); });
+    // Same reason as the authorize listener: a stop() that races ahead of
+    // listen() is missed and the join below would hang.
+    for (int i = 0; i < 200 && !svr->is_running (); ++i) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (1));
+    }
+
+    out.issuer_id     = issuer->id;
+    out.issuer_url    = issuer->issuer_url;
+    out.token_url     = issuer->token_url ();
+    out.authorize_url = issuer->authorize_url ();
+    out.signing_key   = issuer->signing_key;
+
+    vayu::utils::log_info (
+    "Mock OAuth2 issuer started at " + issuer->issuer_url + " (" + issuer->id + ")");
+    {
+        std::lock_guard<std::mutex> lock (mutex_);
+        issuers_[out.issuer_id] = std::move (issuer);
+    }
+    return out;
+}
+
+bool MockIssuerManager::stop (const std::string& issuer_id) {
+    std::unique_ptr<Issuer> issuer;
+    {
+        std::lock_guard<std::mutex> lock (mutex_);
+        const auto it = issuers_.find (issuer_id);
+        if (it == issuers_.end ()) {
+            return false;
+        }
+        issuer = std::move (it->second);
+        issuers_.erase (it);
+    }
+    // Torn down outside the manager lock: stop() joins the listener thread, and
+    // a handler still in flight there would otherwise block every other caller.
+    teardown (*issuer);
+    vayu::utils::log_info ("Mock OAuth2 issuer stopped (" + issuer_id + ")");
+    return true;
+}
+
+nlohmann::json MockIssuerManager::list () const {
+    std::lock_guard<std::mutex> lock (mutex_);
+    auto issuers = nlohmann::json::array ();
+    for (const auto& [id, issuer] : issuers_) {
+        issuers.push_back (issuer->describe ());
+    }
+    return nlohmann::json{ { "issuers", std::move (issuers) } };
+}
+
+MockIssuerManager::UpdateResult
+MockIssuerManager::update (const std::string& issuer_id, const nlohmann::json& body) {
+    UpdateResult out;
+    std::lock_guard<std::mutex> lock (mutex_);
+    const auto it = issuers_.find (issuer_id);
+    if (it == issuers_.end ()) {
+        return out;
+    }
+    out.found      = true;
+    Issuer& issuer = *it->second;
+
+    MockIssuerConfig parsed;
+    {
+        std::lock_guard<std::mutex> state_lock (issuer.state_mutex);
+        parsed = apply_mock_issuer_patch (body, issuer.settings);
+        if (parsed.ok) {
+            issuer.settings = std::move (parsed.settings);
+        }
+    }
+    if (!parsed.ok) {
+        out.ok    = false;
+        out.error = parsed.error;
+        return out;
+    }
+    out.issuer = issuer.describe ();
+    return out;
+}
+
+namespace routes {
+
+void register_mock_issuer_routes (RouteContext& ctx) {
+    ctx.server.Post ("/mock-issuer/start",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        vayu::utils::log_info ("POST /mock-issuer/start");
+        nlohmann::json body = nlohmann::json::object ();
+        if (!req.body.empty ()) {
+            try {
+                body = nlohmann::json::parse (req.body);
+            } catch (const nlohmann::json::exception& e) {
+                send_error (res, 400, std::string ("Invalid JSON: ") + e.what (),
+                "mock_issuer_invalid_config");
+                return;
+            }
+        }
+        const auto result = ctx.mock_issuer_manager.start (body);
+        if (!result.ok) {
+            send_error (res, result.http_status, result.error_message, result.error_code);
+            return;
+        }
+        res.status = 200;
+        res.set_content (
+        nlohmann::json{ { "issuerId", result.issuer_id },
+        { "issuerUrl", result.issuer_url }, { "tokenUrl", result.token_url },
+        { "authorizeUrl", result.authorize_url }, { "signingKey", result.signing_key } }
+        .dump (),
+        "application/json");
+    });
+
+    ctx.server.Get ("/mock-issuer", [&ctx] (const httplib::Request&, httplib::Response& res) {
+        res.status = 200;
+        res.set_content (ctx.mock_issuer_manager.list ().dump (), "application/json");
+    });
+
+    ctx.server.Post (R"(/mock-issuer/([^/]+)/stop)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string id = req.matches[1];
+        if (!ctx.mock_issuer_manager.stop (id)) {
+            send_error (res, 404, "Mock issuer not found: " + id);
+            return;
+        }
+        res.status = 200;
+        res.set_content (R"({"stopped":true})", "application/json");
+    });
+
+    ctx.server.Put (R"(/mock-issuer/([^/]+))",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string id = req.matches[1];
+        nlohmann::json body;
+        try {
+            body = nlohmann::json::parse (req.body);
+        } catch (const nlohmann::json::exception& e) {
+            send_error (res, 400, std::string ("Invalid JSON: ") + e.what (),
+            "mock_issuer_invalid_config");
+            return;
+        }
+        const auto result = ctx.mock_issuer_manager.update (id, body);
+        if (!result.found) {
+            send_error (res, 404, "Mock issuer not found: " + id);
+            return;
+        }
+        if (!result.ok) {
+            send_error (res, 400, result.error, "mock_issuer_invalid_config");
+            return;
+        }
+        res.status = 200;
+        res.set_content (result.issuer.dump (), "application/json");
+    });
+}
+
+} // namespace routes
+
+} // namespace vayu::http

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -114,9 +114,9 @@ void Server::setup_routes () {
     // Register Modular Routes
     // ==========================================
     // Note: route_ctx_ is a class member, ensuring it outlives the lambdas
-    route_ctx_ = std::make_unique<routes::RouteContext> (routes::RouteContext{
-        server_, db_, run_manager_, verbose_, shutdown_callback_,
-        oauth_authorize_manager_, cookie_jar_ });
+    route_ctx_ = std::make_unique<routes::RouteContext> (
+    routes::RouteContext{ server_, db_, run_manager_, verbose_, shutdown_callback_,
+    oauth_authorize_manager_, cookie_jar_, mock_issuer_manager_ });
 
     routes::register_health_routes (*route_ctx_);
     routes::register_config_routes (*route_ctx_);
@@ -133,6 +133,7 @@ void Server::setup_routes () {
     routes::register_import_routes (*route_ctx_);
     routes::register_oauth_routes (*route_ctx_);
     routes::register_cookie_routes (*route_ctx_);
+    routes::register_mock_issuer_routes (*route_ctx_);
 }
 
 } // namespace vayu::http

--- a/engine/tests/mock_issuer_test.cpp
+++ b/engine/tests/mock_issuer_test.cpp
@@ -1,0 +1,540 @@
+/**
+ * @file tests/mock_issuer_test.cpp
+ * @brief Tests for the local OAuth 2.0 mock issuer: payload validation, the
+ *        four grants driven through the engine's *own* token client, PKCE,
+ *        rotation, the switchable failure modes, and lifecycle.
+ *
+ * The round trips deliberately go through `oauth::acquire_token` rather than a
+ * hand-written httplib client: the point of the issuer is that the engine's own
+ * OAuth path works against it offline, so anything it accepts that
+ * `acquire_token` cannot drive would be a mock of the wrong thing.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
+#include "vayu/http/mock_issuer.hpp"
+#include "vayu/http/oauth_client.hpp"
+#include "vayu/http/pkce.hpp"
+#include "vayu/utils/encoding.hpp"
+#include "vayu/utils/sha256.hpp"
+
+using nlohmann::json;
+using vayu::http::MockIssuerManager;
+using vayu::http::MockIssuerStart;
+
+namespace {
+
+std::vector<std::string> split_jwt (const std::string& jwt) {
+    std::vector<std::string> parts;
+    size_t pos = 0;
+    while (true) {
+        const auto dot = jwt.find ('.', pos);
+        parts.push_back (
+        jwt.substr (pos, dot == std::string::npos ? std::string::npos : dot - pos));
+        if (dot == std::string::npos) {
+            break;
+        }
+        pos = dot + 1;
+    }
+    return parts;
+}
+
+/// Recomputed independently of the issuer's own minting, so the assertion is a
+/// real signature check rather than a restatement of the implementation.
+bool signature_verifies (const std::string& jwt, const std::string& key) {
+    const auto parts = split_jwt (jwt);
+    if (parts.size () != 3) {
+        return false;
+    }
+    const auto tag = vayu::utils::hmac_sha256 (key, parts[0] + "." + parts[1]);
+    return parts[2] ==
+    vayu::utils::base64url_encode (
+    std::string_view (reinterpret_cast<const char*> (tag.data ()), tag.size ()));
+}
+
+json decode_jwt_payload (const std::string& jwt) {
+    const auto parts = split_jwt (jwt);
+    if (parts.size () != 3) {
+        return json ();
+    }
+    std::string standard = parts[1];
+    for (char& c : standard) {
+        c = c == '-' ? '+' : (c == '_' ? '/' : c);
+    }
+    const auto decoded = vayu::utils::base64_decode (standard);
+    if (!decoded) {
+        return json ();
+    }
+    return json::parse (*decoded, nullptr, false);
+}
+
+/// Follow one `/authorize` call and hand back the `code` it redirected with.
+/// Returns an empty string when the issuer answered anything but a redirect.
+std::string authorize_for_code (const MockIssuerStart& issuer,
+const std::string& client_id,
+const std::string& redirect_uri,
+const std::string& challenge) {
+    httplib::Client cli (issuer.issuer_url);
+    std::string target =
+    "/authorize?response_type=code&client_id=" + vayu::utils::url_encode (client_id) +
+    "&redirect_uri=" + vayu::utils::url_encode (redirect_uri) + "&state=STATE";
+    if (!challenge.empty ()) {
+        target += "&code_challenge=" + challenge + "&code_challenge_method=S256";
+    }
+    auto res = cli.Get (target);
+    if (res == nullptr || res->status != 302) {
+        return {};
+    }
+    const std::string location = res->get_header_value ("Location");
+    const auto code_at         = location.find ("code=");
+    if (code_at == std::string::npos) {
+        return {};
+    }
+    const auto end = location.find ('&', code_at);
+    return vayu::utils::url_decode (location.substr (code_at + 5,
+    end == std::string::npos ? std::string::npos : end - code_at - 5));
+}
+
+json client_credentials_config (const MockIssuerStart& issuer,
+const char* client_id = "cid",
+const char* secret    = "sec") {
+    return json{ { "grantType", "client_credentials" },
+        { "accessTokenUrl", issuer.token_url }, { "clientId", client_id },
+        { "clientSecret", secret } };
+}
+
+class MockIssuerTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_mock_issuer.db";
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+// Payload validation (pure)
+// ---------------------------------------------------------------------------
+
+TEST (MockIssuerSettings, DefaultsWhenNothingIsAskedFor) {
+    const auto parsed = vayu::http::parse_mock_issuer_settings (json::object ());
+    ASSERT_TRUE (parsed.ok) << parsed.error;
+    EXPECT_EQ (parsed.settings.port, 0);
+    EXPECT_EQ (parsed.settings.expires_in_seconds, 3600);
+    EXPECT_EQ (parsed.settings.failure_mode, "none");
+    EXPECT_TRUE (parsed.settings.issue_refresh_tokens);
+    EXPECT_TRUE (parsed.settings.clients.empty ());
+    EXPECT_TRUE (parsed.settings.claims.is_object ());
+}
+
+TEST (MockIssuerSettings, ReadsEveryField) {
+    const auto parsed = vayu::http::parse_mock_issuer_settings (
+    json{ { "expiresInSeconds", 60 }, { "claims", { { "sub", "alice" } } },
+    { "clients",
+    json::array ({ json{ { "clientId", "a" }, { "clientSecret", "s" } },
+    json{ { "clientId", "public" } } }) },
+    { "failureMode", "slow" }, { "slowMs", 10 }, { "issueRefreshTokens", false } });
+    ASSERT_TRUE (parsed.ok) << parsed.error;
+    EXPECT_EQ (parsed.settings.expires_in_seconds, 60);
+    EXPECT_EQ (parsed.settings.claims["sub"], "alice");
+    ASSERT_EQ (parsed.settings.clients.size (), 2u);
+    EXPECT_EQ (parsed.settings.clients[0].client_secret, "s");
+    EXPECT_TRUE (parsed.settings.clients[1].client_secret.empty ());
+    EXPECT_EQ (parsed.settings.failure_mode, "slow");
+    EXPECT_EQ (parsed.settings.slow_ms, 10);
+    EXPECT_FALSE (parsed.settings.issue_refresh_tokens);
+}
+
+TEST (MockIssuerSettings, BadInputIsRefusedRatherThanDefaulted) {
+    const std::vector<json> bad = {
+        json{ { "expiresInSeconds", "3600" } },       // wrong type
+        json{ { "expiresInSeconds", 0 } },            // out of range
+        json{ { "expiresInSeconds", 40LL * 86400 } }, // past the ceiling
+        json{ { "slowMs", -1 } },
+        json{ { "failureMode", "explode" } },
+        json{ { "failureMode", 3 } },
+        json{ { "port", 70000 } },
+        json{ { "claims", "sub=alice" } },
+        json{ { "clients", "a,b" } },
+        json{ { "clients", json::array ({ json{ { "name", "a" } } }) } }, // no clientId
+        json{ { "clients", json::array ({ json{ { "clientId", "" } } }) } },
+        json{ { "clients",
+        json::array ({ json{ { "clientId", "a" }, { "clientSecret", 7 } } }) } },
+        json{ { "issueRefreshTokens", "yes" } },
+    };
+    for (const auto& body : bad) {
+        const auto parsed = vayu::http::parse_mock_issuer_settings (body);
+        EXPECT_FALSE (parsed.ok) << "accepted: " << body.dump ();
+        EXPECT_FALSE (parsed.error.empty ());
+    }
+    EXPECT_FALSE (vayu::http::parse_mock_issuer_settings (json::array ()).ok);
+}
+
+TEST (MockIssuerSettings, PatchTouchesOnlyTheLiveFields) {
+    vayu::http::MockIssuerSettings current;
+    current.clients.push_back ({ "a", "s" });
+
+    const auto ok = vayu::http::apply_mock_issuer_patch (
+    json{ { "failureMode", "server_error" }, { "expiresInSeconds", 30 } }, current);
+    ASSERT_TRUE (ok.ok) << ok.error;
+    EXPECT_EQ (ok.settings.failure_mode, "server_error");
+    EXPECT_EQ (ok.settings.expires_in_seconds, 30);
+    EXPECT_EQ (ok.settings.clients.size (), 1u); // untouched half carried over
+
+    for (const char* immutable : { "port", "clients", "claims", "issueRefreshTokens" }) {
+        json patch;
+        patch[immutable] = json::object ();
+        const auto result = vayu::http::apply_mock_issuer_patch (patch, current);
+        EXPECT_FALSE (result.ok) << immutable;
+        EXPECT_NE (result.error.find (immutable), std::string::npos);
+    }
+    EXPECT_FALSE (
+    vayu::http::apply_mock_issuer_patch (json{ { "slowMs", -5 } }, current).ok);
+}
+
+// ---------------------------------------------------------------------------
+// The grants, through the engine's own client
+// ---------------------------------------------------------------------------
+
+TEST_F (MockIssuerTest, ClientCredentialsMintsAVerifiableJwt) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{ { "expiresInSeconds", 120 } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    auto result = vayu::http::oauth::acquire_token (
+    *db_, client_credentials_config (issuer), false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (result));
+    const auto token = std::get<vayu::db::OAuthToken> (result);
+
+    EXPECT_EQ (token.token_type, "Bearer");
+    EXPECT_EQ (token.expires_in, 120);
+    ASSERT_EQ (split_jwt (token.access_token).size (), 3u);
+    EXPECT_TRUE (signature_verifies (token.access_token, issuer.signing_key));
+
+    const auto payload = decode_jwt_payload (token.access_token);
+    ASSERT_TRUE (payload.is_object ());
+    EXPECT_EQ (payload["iss"], issuer.issuer_url);
+    EXPECT_EQ (payload["client_id"], "cid");
+    EXPECT_EQ (payload["exp"].get<int64_t> () - payload["iat"].get<int64_t> (), 120);
+}
+
+TEST_F (MockIssuerTest, ConfiguredClaimsRideAlong) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{
+    { "claims", { { "sub", "alice" }, { "roles", json::array ({ "admin" }) } } } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    auto result = vayu::http::oauth::acquire_token (
+    *db_, client_credentials_config (issuer), false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (result));
+    const auto payload =
+    decode_jwt_payload (std::get<vayu::db::OAuthToken> (result).access_token);
+    EXPECT_EQ (payload["sub"], "alice");
+    EXPECT_EQ (payload["roles"][0], "admin");
+}
+
+TEST_F (MockIssuerTest, PasswordGrantSubjectIsTheUser) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    json config = { { "grantType", "password" }, { "accessTokenUrl", issuer.token_url },
+        { "clientId", "cid" }, { "clientSecret", "sec" }, { "username", "bob" },
+        { "password", "hunter2" }, { "scope", "read" } };
+    auto result = vayu::http::oauth::acquire_token (*db_, config, false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (result));
+    const auto token = std::get<vayu::db::OAuthToken> (result);
+    EXPECT_EQ (token.scope, "read");
+    EXPECT_EQ (decode_jwt_payload (token.access_token)["sub"], "bob");
+}
+
+TEST_F (MockIssuerTest, AuthorizationCodeWithPkceRoundTrips) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const std::string redirect = "http://127.0.0.1:9/callback";
+    const std::string verifier = vayu::http::pkce::random_token (32);
+    const std::string code     = authorize_for_code (
+    issuer, "cid", redirect, vayu::http::pkce::code_challenge (verifier));
+    ASSERT_FALSE (code.empty ());
+
+    json config = { { "grantType", "authorization_code" },
+        { "accessTokenUrl", issuer.token_url }, { "clientId", "cid" },
+        { "clientSecret", "sec" } };
+    auto result = vayu::http::oauth::acquire_token (*db_, config, false,
+    vayu::http::oauth::InteractiveExchange{ code, verifier, redirect });
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (result))
+    << std::get<vayu::http::oauth::TokenError> (result).message;
+    EXPECT_TRUE (signature_verifies (
+    std::get<vayu::db::OAuthToken> (result).access_token, issuer.signing_key));
+}
+
+TEST_F (MockIssuerTest, AuthorizationCodeRejectsAWrongVerifier) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const std::string redirect = "http://127.0.0.1:9/callback";
+    const std::string verifier = vayu::http::pkce::random_token (32);
+    const std::string code     = authorize_for_code (
+    issuer, "cid", redirect, vayu::http::pkce::code_challenge (verifier));
+    ASSERT_FALSE (code.empty ());
+
+    json config = { { "grantType", "authorization_code" },
+        { "accessTokenUrl", issuer.token_url }, { "clientId", "cid" },
+        { "clientSecret", "sec" } };
+    auto result = vayu::http::oauth::acquire_token (*db_, config, false,
+    vayu::http::oauth::InteractiveExchange{
+    code, vayu::http::pkce::random_token (32), redirect });
+    ASSERT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (result));
+    EXPECT_EQ (std::get<vayu::http::oauth::TokenError> (result).code, "oauth2_provider_error");
+}
+
+TEST_F (MockIssuerTest, AuthorizationCodeIsSingleUse) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const std::string redirect = "http://127.0.0.1:9/callback";
+    const std::string code = authorize_for_code (issuer, "cid", redirect, "");
+    ASSERT_FALSE (code.empty ());
+
+    json config = { { "grantType", "authorization_code" },
+        { "accessTokenUrl", issuer.token_url }, { "clientId", "cid" },
+        { "clientSecret", "sec" } };
+    const vayu::http::oauth::InteractiveExchange exchange{ code, "", redirect };
+
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (
+    vayu::http::oauth::acquire_token (*db_, config, false, exchange)));
+    // The cached token would answer a second acquire, so force past it: the
+    // *code* is what must be spent.
+    db_->delete_oauth_token (vayu::http::oauth::cache_key (config));
+    EXPECT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (
+    vayu::http::oauth::acquire_token (*db_, config, false, exchange)));
+}
+
+TEST_F (MockIssuerTest, AuthorizeRefusesAMismatchedRedirectUri) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const std::string code =
+    authorize_for_code (issuer, "cid", "http://127.0.0.1:9/callback", "");
+    ASSERT_FALSE (code.empty ());
+
+    json config = { { "grantType", "authorization_code" },
+        { "accessTokenUrl", issuer.token_url }, { "clientId", "cid" },
+        { "clientSecret", "sec" } };
+    auto result = vayu::http::oauth::acquire_token (*db_, config, false,
+    vayu::http::oauth::InteractiveExchange{ code, "", "http://127.0.0.1:9/elsewhere" });
+    EXPECT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (result));
+}
+
+TEST_F (MockIssuerTest, RefreshRotatesAndSpendsTheOldToken) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const auto config = client_credentials_config (issuer);
+    auto first = vayu::http::oauth::acquire_token (*db_, config, false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (first));
+    const std::string original_refresh = std::get<vayu::db::OAuthToken> (first).refresh_token;
+    ASSERT_FALSE (original_refresh.empty ());
+
+    auto refreshed = vayu::http::oauth::acquire_token (*db_, config, true, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (refreshed))
+    << std::get<vayu::http::oauth::TokenError> (refreshed).message;
+    const auto rotated = std::get<vayu::db::OAuthToken> (refreshed);
+    EXPECT_FALSE (rotated.refresh_token.empty ());
+    EXPECT_NE (rotated.refresh_token, original_refresh);
+
+    // The spent token is gone: replaying it is rejected by the issuer, which is
+    // the behaviour a client's rotation handling has to survive.
+    httplib::Client cli (issuer.issuer_url);
+    auto replay = cli.Post ("/token",
+    "grant_type=refresh_token&client_id=cid&refresh_token=" +
+    vayu::utils::url_encode (original_refresh),
+    "application/x-www-form-urlencoded");
+    ASSERT_TRUE (replay != nullptr);
+    EXPECT_EQ (replay->status, 400);
+}
+
+TEST_F (MockIssuerTest, RefreshTokensCanBeTurnedOff) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{ { "issueRefreshTokens", false } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    auto result = vayu::http::oauth::acquire_token (
+    *db_, client_credentials_config (issuer), false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (result));
+    EXPECT_TRUE (std::get<vayu::db::OAuthToken> (result).refresh_token.empty ());
+}
+
+// ---------------------------------------------------------------------------
+// Client authentication
+// ---------------------------------------------------------------------------
+
+TEST_F (MockIssuerTest, ConfiguredClientsGateTheTokenEndpoint) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{ { "clients",
+    json::array ({ json{ { "clientId", "known" }, { "clientSecret", "s3cret" } } }) } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    // Right id, right secret, both placements RFC 6749 §2.3.1 allows.
+    for (const char* placement : { "basic_auth_header", "body" }) {
+        json config = client_credentials_config (issuer, "known", "s3cret");
+        config["credentialsPlacement"] = placement;
+        config["credentialsId"]        = placement; // distinct cache keys
+        auto ok = vayu::http::oauth::acquire_token (*db_, config, false, std::nullopt);
+        EXPECT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (ok)) << placement;
+    }
+
+    auto wrong_secret = vayu::http::oauth::acquire_token (*db_,
+    client_credentials_config (issuer, "known", "nope"), false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (wrong_secret));
+    EXPECT_EQ (std::get<vayu::http::oauth::TokenError> (wrong_secret).provider_status, 401);
+
+    auto unknown_client = vayu::http::oauth::acquire_token (*db_,
+    client_credentials_config (issuer, "stranger", "s3cret"), false, std::nullopt);
+    EXPECT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (unknown_client));
+}
+
+// ---------------------------------------------------------------------------
+// Failure modes
+// ---------------------------------------------------------------------------
+
+TEST_F (MockIssuerTest, ServerErrorModeClassifiesAsAProviderError) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{ { "failureMode", "server_error" } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    auto result = vayu::http::oauth::acquire_token (
+    *db_, client_credentials_config (issuer), false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (result));
+    const auto err = std::get<vayu::http::oauth::TokenError> (result);
+    EXPECT_EQ (err.code, "oauth2_provider_error");
+    EXPECT_EQ (err.provider_status, 500);
+    EXPECT_EQ (err.provider_error, "temporarily_unavailable");
+}
+
+TEST_F (MockIssuerTest, InvalidClientModeFailsCleanly) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{ { "failureMode", "invalid_client" } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    auto result = vayu::http::oauth::acquire_token (
+    *db_, client_credentials_config (issuer), false, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (result));
+    const auto err = std::get<vayu::http::oauth::TokenError> (result);
+    EXPECT_EQ (err.provider_status, 401);
+    EXPECT_EQ (err.provider_error, "invalid_client");
+}
+
+TEST_F (MockIssuerTest, SlowModeDelaysTheTokenEndpoint) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json{ { "failureMode", "slow" }, { "slowMs", 300 } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const auto started = std::chrono::steady_clock::now ();
+    auto result        = vayu::http::oauth::acquire_token (
+    *db_, client_credentials_config (issuer), false, std::nullopt);
+    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - started)
+                            .count ();
+    EXPECT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (result));
+    EXPECT_GE (elapsed_ms, 300); // bounded below only - no flaky upper bound
+}
+
+TEST_F (MockIssuerTest, FailureModeFlipsOnALiveIssuer) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+    const auto config = client_credentials_config (issuer);
+
+    ASSERT_TRUE (std::holds_alternative<vayu::db::OAuthToken> (
+    vayu::http::oauth::acquire_token (*db_, config, false, std::nullopt)));
+
+    const auto updated =
+    mgr.update (issuer.issuer_id, json{ { "failureMode", "server_error" } });
+    ASSERT_TRUE (updated.found);
+    ASSERT_TRUE (updated.ok) << updated.error;
+    EXPECT_EQ (updated.issuer["failureMode"], "server_error");
+
+    // force past the cached token so the request actually reaches the issuer
+    auto after = vayu::http::oauth::acquire_token (*db_, config, true, std::nullopt);
+    ASSERT_TRUE (std::holds_alternative<vayu::http::oauth::TokenError> (after));
+    EXPECT_EQ (std::get<vayu::http::oauth::TokenError> (after).provider_status, 500);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_F (MockIssuerTest, ListsAndStops) {
+    MockIssuerManager mgr;
+    const auto issuer = mgr.start (json::object ());
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+
+    const auto listed = mgr.list ();
+    ASSERT_EQ (listed["issuers"].size (), 1u);
+    EXPECT_EQ (listed["issuers"][0]["issuerId"], issuer.issuer_id);
+    EXPECT_EQ (listed["issuers"][0]["tokenUrl"], issuer.token_url);
+
+    EXPECT_TRUE (mgr.stop (issuer.issuer_id));
+    EXPECT_FALSE (mgr.stop (issuer.issuer_id)); // idempotent-by-absence
+    EXPECT_EQ (mgr.list ()["issuers"].size (), 0u);
+
+    httplib::Client cli (issuer.issuer_url);
+    cli.set_connection_timeout (1, 0);
+    EXPECT_EQ (cli.Get ("/authorize"), nullptr); // nothing is listening any more
+}
+
+TEST_F (MockIssuerTest, UpdateAndStopReportUnknownIds) {
+    MockIssuerManager mgr;
+    EXPECT_FALSE (mgr.stop ("issuer_nope"));
+    EXPECT_FALSE (mgr.update ("issuer_nope", json{ { "failureMode", "none" } }).found);
+}
+
+TEST_F (MockIssuerTest, RefusesMoreIssuersThanTheBudget) {
+    MockIssuerManager mgr;
+    for (size_t i = 0; i < vayu::core::constants::mock_issuer::MAX_ISSUERS; ++i) {
+        ASSERT_TRUE (mgr.start (json::object ()).ok) << i;
+    }
+    const auto refused = mgr.start (json::object ());
+    EXPECT_FALSE (refused.ok);
+    EXPECT_EQ (refused.error_code, "mock_issuer_limit_reached");
+    EXPECT_EQ (refused.http_status, 429);
+}
+
+TEST_F (MockIssuerTest, DestructorStopsALiveIssuer) {
+    std::string issuer_url;
+    {
+        MockIssuerManager mgr;
+        const auto issuer = mgr.start (json::object ());
+        ASSERT_TRUE (issuer.ok) << issuer.error_message;
+        issuer_url = issuer.issuer_url;
+    }
+    httplib::Client cli (issuer_url);
+    cli.set_connection_timeout (1, 0);
+    EXPECT_EQ (cli.Get ("/authorize"), nullptr);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

**Plan.** Root cause: `acquire_token` (`oauth_client.cpp:201-293`) always POSTs to a config's `accessTokenUrl`, and the repo has nothing local to point it at - so OAuth2-authed collections are dead offline, and expiry/refresh/provider-500 behaviour is only testable against a cooperative real provider. Verified still true at `9880a02`. The approach follows the second-listener precedent the engine already owns: a `MockIssuerManager` member on `Server` (declared before `server_`, so its dtor stops and joins every listener after the route lambdas are gone - the same reverse-member-order rule `server.hpp:46-54` documents for `OAuth2AuthorizeManager`), each issuer an independent `127.0.0.1` `httplib::Server` serving `/token` and `/authorize`. **The alternative I rejected**: hosting the mock endpoints on the *main* engine server under a `/mock-issuer/:id/token` prefix. It needs no second listener, but it makes the mock's URL indistinguishable from the management API, so any future decision to bind the engine wider would publish a token minter with it - and it could not be stopped independently. A separate listener keeps the trust boundary where it can be reasoned about.

`POST /mock-issuer/start` returns `{issuerId, issuerUrl, tokenUrl, authorizeUrl, signingKey}`; paste `tokenUrl` into the existing OAuth2 form and "Get Token" works with no network.

- **All four grants** - `client_credentials`, `password`, `authorization_code`, `refresh_token` - with both RFC 6749 §2.3.1 client-auth placements, so the engine's own `apply_client_auth` exercises the paths it actually takes.
- **HS256 JWTs** signed with a random per-issuer key. The key is returned as `signingKey` because a service under test needs it as its shared secret to verify the mock's tokens - without it the tokens are unverifiable and the mock is half a tool.
- **`/authorize` auto-approves** and 302s back with a single-use code, verifying PKCE S256 when a `code_challenge` is present. `plain` is refused rather than quietly accepted (it would let a test pass that a real provider rejects). An unknown client or missing `redirect_uri` answers in place rather than redirecting (§4.1.2.1).
- **Failure modes** `slow` / `server_error` / `invalid_client`, flippable on a **running** issuer via `PUT /mock-issuer/:id`, producing the three client-side classifications `TokenError` already distinguishes.

**Boundaries.** Loopback-only bind, not configurable - the issuer mints bearer tokens and the engine has no route auth and CORS `*`. In-memory only; a restart forgets every issuer. Bad input fails loudly: a field present with the wrong type or out of range is a `400 mock_issuer_invalid_config`, never a silent fallback (a mock running with a different expiry than asked for defeats the point), and a `PUT` naming an immutable field says so instead of half-applying. Bounds live in `constants::mock_issuer` - 8 concurrent issuers (a thread budget), and the code / refresh-token maps evict oldest so a long-lived daemon cannot grow one entry per authorize call that never came back.

**Non-goals, named on purpose** (per the issue): JWKS/RS256, OIDC discovery documents, token introspection, consent UI, multi-tenant realms. `start_mock_issuer` is recorded in `docs/engine/mcp.md`'s Deferred section rather than built, as the issue directs. No app changes - the issue states none are required for v1, and the existing OAuth2 form plus `TokenStatusRow`'s "Get Token" drive it as-is.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && ctest --preset linux-dev --output-on-failure` → **1322/1322 passed** (1300 before this branch, so 22 new), 180s. No pre-existing failures. `mkdocs build --strict` clean. clang-tidy clean via `scripts/pre-commit` on every touched file, clang-format applied, zero compiler warnings.

New `engine/tests/mock_issuer_test.cpp` (22): payload validation including 13 malformed bodies each refused; every grant driven through `oauth::acquire_token` rather than a hand-written client (anything the issuer accepts that the engine's own path cannot drive would be a mock of the wrong thing); the JWT signature recomputed independently from `signingKey` rather than by calling the minting helper; configured claims riding along; both client-auth placements plus wrong-secret and unknown-client rejection; the three failure modes and a live flip; lifecycle (list, stop, unknown ids, the 8-issuer budget, and a destructor with an issuer still running).

**Mutation-checked** (reverted, confirmed red, restored): skipping PKCE verification → `AuthorizationCodeRejectsAWrongVerifier` fails; not spending the authorization code → `AuthorizationCodeIsSingleUse` fails; not spending the refresh token on rotation → `RefreshRotatesAndSpendsTheOldToken` fails.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #479

---
_Generated by [Claude Code](https://claude.ai/code/session_018MXKkhaQPQdtHB6xJEivnn)_