### PR TITLE
chore(app/tooling): make the tsconfigs mean one thing to TypeScript 5 and 7

### DIFF
--- a/app/tsconfig.electron-test.json
+++ b/app/tsconfig.electron-test.json
@@ -26,9 +26,12 @@
 		/* Renderer sources reached from a test are DOM code; `electron/` is not. */
 		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 		"types": ["node", "vitest/globals"],
-		"baseUrl": ".",
+		/*
+		 * No `baseUrl`, so targets are written relative to this file (`app/`) -
+		 * see the longer note in tsconfig.json.
+		 */
 		"paths": {
-			"@/*": ["src/*"],
+			"@/*": ["./src/*"],
 			"@shared/*": ["../shared/*"]
 		}
 	},

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -21,17 +21,40 @@
 		"noFallthroughCasesInSwitch": true,
 		"forceConsistentCasingInFileNames": true,
 
-		/* Path aliases */
-		"baseUrl": ".",
+		/*
+		 * Ambient type packages, declared rather than inferred. TypeScript 7
+		 * defaults this to `[]`; 5.x defaults it to every package under
+		 * `node_modules/@types`. Leaving it unset therefore means two different
+		 * things to the two compilers - under 7 the source-scanning tests lose
+		 * `node:fs`, `node:path` and `__dirname` (176 errors across 48 files,
+		 * measured on 7.0.2), all of which this one line restores.
+		 *
+		 * Only `node` is listed because it is the only one used ambiently.
+		 * `@types/react`, `@types/react-dom` and `@types/js-yaml` arrive through
+		 * ordinary imports, which this option does not govern.
+		 */
+		"types": ["node"],
+
+		/*
+		 * Path aliases, with no `baseUrl` - TypeScript 7 removes that option, and
+		 * without it a target must be written relative (`./src/*`, not `src/*`)
+		 * or tsc rejects the config outright with TS5090. Relative targets
+		 * resolve against this file's directory, so each entry below points
+		 * where its `baseUrl`-rooted spelling used to.
+		 *
+		 * The bundler-side copies of this table are hand-written aliases in
+		 * `vite.config.ts` and `vitest.config.ts` - neither derives from this
+		 * file, so a new entry here has to be added there too.
+		 */
 		"paths": {
-			"@/*": ["src/*"],
-			"@/components/*": ["src/components/*"],
-			"@/modules/*": ["src/modules/*"],
-			"@/stores/*": ["src/stores/*"],
-			"@/hooks/*": ["src/hooks/*"],
-			"@/services/*": ["src/services/*"],
-			"@/types/*": ["src/types/*"],
-			"@/utils/*": ["src/utils/*"],
+			"@/*": ["./src/*"],
+			"@/components/*": ["./src/components/*"],
+			"@/modules/*": ["./src/modules/*"],
+			"@/stores/*": ["./src/stores/*"],
+			"@/hooks/*": ["./src/hooks/*"],
+			"@/services/*": ["./src/services/*"],
+			"@/types/*": ["./src/types/*"],
+			"@/utils/*": ["./src/utils/*"],
 			"@shared/*": ["../shared/*"]
 		}
 	},

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -174,7 +174,19 @@ Configuration is in `electron-builder.json`:
 - Target: ES2020
 - Module: ESNext
 - JSX: React
-- Path aliases: `@/*` → `src/*`
+- Path aliases: `@/*` → `./src/*`
+- `types: ["node"]`
+
+The last two are written the way they are because TypeScript 7 removes `baseUrl`
+and changes the default of `types` from "every package under `node_modules/@types`"
+to `[]`. Both are spelled out here so the config means the same thing to 5.x and
+7.x: alias targets are relative (a non-relative target without `baseUrl` is the
+hard error TS5090), and the one ambient type package the source-scanning tests
+rely on is named. Adding an `@types/*` package that provides globals means adding
+it to that list.
+
+The alias table is duplicated by hand in `vite.config.ts` and `vitest.config.ts`;
+neither reads this file, so a new alias has to be added in all three.
 
 ### Electron main process (`tsconfig.node.json`)
 
@@ -187,7 +199,7 @@ Configuration is in `electron-builder.json`:
 ### Electron tests (`tsconfig.electron-test.json`)
 
 - `noEmit` - it exists to type-check what `tsconfig.node.json` excludes
-- Adds the `@/*` → `src/*` alias, which the main-process config deliberately
+- Adds the `@/*` → `./src/*` alias, which the main-process config deliberately
   lacks: only a test may cross into `app/src/` (`resolve.test.ts` compares the
   renderer's dynamic-variable table against the main-process copy)
 - Run by `pnpm type-check`; without it nothing checked these files, and a


### PR DESCRIPTION
## Description

Stage 0 of #467 - take the config changes TypeScript 7 forces, early and independently, while staying on `typescript@^5.9.3`. Which compiler runs is unchanged; this is config only.

**Plan (root cause, approach, rejected alternative).** The root cause is that two `compilerOptions` mean different things to TS 5 and TS 7, so the same tsconfig describes two different projects depending on which compiler reads it - and the divergence is invisible until someone swaps the compiler and gets a wall of errors they then have to triage under time pressure. The approach is to pin both options to the meaning they already have under 5.9, so the file is unambiguous now and the eventual 7.x swap is a one-line dependency bump rather than a migration. **I rejected taking Stage 1** (the `tsc7: npm:typescript@^7` dual install pointed at the type-check gate) even though I measured it working and 6.4x faster: it is by construction a stopgap meant to be deleted at Stage 2, which is exactly what CLAUDE.md's core principle rules out, and it would leave the CI gate on a compiler that contributors' editors and `typescript-eslint` do not use. The issue itself calls skipping it "a defensible call". The measurements that would have justified it are recorded below instead, so Stage 2 starts with data rather than a 2026-08-10 snapshot.

### One correction to the issue

The issue states removing `baseUrl` is "the only config change TS 7 forces" and a "mechanical removal". Verified against reality, both halves are wrong:

1. **`baseUrl` removal is not mechanical.** Without `baseUrl`, a `paths` target must be written relative or tsc rejects the entire config with `TS5090: Non-relative paths are not allowed when 'baseUrl' is not set` - before checking a single line of source. All eight `./src/*` targets needed the prefix; `@shared/*` was already relative.
2. **There is a second forced change: `types`.** It defaults to every package under `node_modules/@types` in 5.x and to `[]` in 7. Left unset, the two compilers get different ambient scopes. Under 7.0.2 that costs the source-scanning tests `node:fs`, `node:path` and `__dirname`: **176 errors across 48 files**. `"types": ["node"]` restores every one of them.

With both settled, **TS 7.0.2 reports zero diagnostics on all three configs**. That is the diagnostics-parity result the issue asked for: the 176 errors were the default change alone, not type-checking differences, so the remaining adoption work is a tooling question and not a code one.

`node` is the only entry because it is the only package used *ambiently*. `@types/react`, `@types/react-dom` and `@types/js-yaml` arrive through ordinary imports, which `types` does not govern.

### Blast radius traced

- **tsc** - the three configs in `pnpm type-check`. `tsconfig.node.json` needed no change (clean under 7 with the `[]` default); `tsconfig.electron-test.json` already declared its `types` explicitly and only needed the `baseUrl`/relative-target fix.
- **vite / vitest** - unaffected. `vite-tsconfig-paths` is **not** installed (the issue hedged on this); both configs hand-write their own alias tables and read no tsconfig. That also means a new alias must be added in all three files, which was undocumented and now is.
- **eslint** - unaffected, and worth stating precisely rather than claiming a proof: `eslint.config.mjs` sets no `parserOptions.project` and installs no import resolver, so it never consumes tsconfig `paths` at all. `pnpm lint` green shows nothing regressed; it is not evidence of alias resolution.

## Type of Change
- [x] Bug fix - `<!-- no -->`
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Neither box fits cleanly: this is a build-tooling config change with a docs update. No runtime behaviour changes.

## Testing

Everything below run on this branch. TS 7.0.2 was installed **outside the repo** as a throwaway measurement - `package.json` and the lockfile are untouched.

| Check | Result |
|---|---|
| `pnpm type-check` (TS 5.9.3, 3 configs) | **0 errors**, 25.2s |
| `pnpm test` | **3849 passed / 3849, 384 files** |
| `pnpm lint` | clean (0 errors, 0 warnings) |
| `pnpm format:check` | clean |
| `pnpm build` (`tsc && vite build`) | built in 9.41s |
| `mkdocs build --strict` | built in 3.22s |

**Alias resolution mutation-checked**, per the acceptance criterion: pointing `@/*` at `./srcWRONG/*` fails **1288** imports with `TS2307`, restoring it returns to 0. So the relative target is genuinely what resolves them, not an accident of some other lookup.

**TypeScript 7.0.2 parity and timing** (4-core cloud container, treat timings as order-of-magnitude):

| | TS 5.9.3 | TS 7.0.2 |
|---|---|---|
| `tsconfig.json` | 0 errors | 0 errors |
| `tsconfig.node.json` | 0 errors | 0 errors |
| `tsconfig.electron-test.json` | 0 errors | 0 errors |
| Full gate, wall clock | 25.2s | **4.0s** (6.4x) |

Before the `types` fix, TS 7.0.2 reported 176 errors: 124x `TS2591`, 27x `TS7006`, 21x `TS2304`, 3x `TS7031`, 1x `TS2503` - the last two categories cascading implicit-anys off the first.

**Ecosystem claims re-verified 2026-08-11** (the issue's snapshot was 2026-08-10), against npm dist-tags: `latest` is **7.0.2**, `next` is **7.1.0-dev.20260810.1**. **TS 7.1 has not shipped a stable release**, so Stage 2 remains blocked exactly as the issue predicted, and `@typescript-eslint/*` stays on `^8.61.0` against `typescript@^5.9.3`.

No new tests. The suites are the test, as the issue specifies; the mutation-check above is the behavioural proof. A source-scan guard asserting "no `baseUrl` in the tsconfigs" would be the kind of test CLAUDE.md warns about - it would restate the diff rather than protect behaviour, and reintroducing `baseUrl` is harmless under 5.9 anyway.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - n/a, see above
- [x] I have updated documentation

`docs/app/building.md` updated in the same commit: it documents both tsconfigs' settings, so the alias spelling, the new `types` line, the reason both are spelled out, and the hand-duplicated vite/vitest alias tables are all recorded there. `docs/building.md` and `CONTRIBUTING.md` verified as not needing changes - neither names a TypeScript version (the issue asked for this check).

## Related Issues

Refs #467 - deliberately **not** `Closes`.

#467 is a staged issue and this is Stage 0 of three. It completes the first acceptance criterion (`baseUrl` gone, `@/` resolution proven) and the fourth (ecosystem claims re-verified). Stage 1 is declined above with reasons; **Stage 2 is blocked on a TypeScript 7.1 stable release that does not exist yet**, so closing the issue now would drop the only tracker for it. Happy to close it and open a narrower "adopt typescript@7 at 7.1" issue carrying the measurements above instead - your call, say the word on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxxymCHz1K5WqGSEAeCuVj)_