### PR TITLE
fix(engine): four hardening loose ends from the 08-10/11 wave

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1274,7 +1274,7 @@ inbox on a free port that answers `200` with no body.
 | Field | Meaning |
 |-------|---------|
 | `port` | `0` (default) picks a free port |
-| `bind` | Default `127.0.0.1`; anything outside 127.0.0.0/8 and `::1` needs `confirmNonLoopback` |
+| `bind` | Default `127.0.0.1`; anything outside 127.0.0.0/8 and `::1` needs `confirmNonLoopback`. Loopback is decided by parsing the *address*, so a hostname that merely starts `127.` (or `localhost.example.com`) is not loopback and needs the confirmation |
 | `response.status` | 100-599 |
 | `response.headers` | String values only; a `Content-Type` here is used verbatim |
 | `response.delayMs` | 0-30000, applied before every reply |
@@ -2220,6 +2220,7 @@ row exists:
 | Input | Rejected because |
 |-------|------------------|
 | `mode: "constant_rps"` with a `scenario` | An open-loop arrival rate over a multi-step sequence is an arrival-rate executor, which Vayu does not implement. Refused rather than silently run closed-loop. |
+| `mode: "capacity"` with a `scenario` | The search judges one windowed p99 and a sequence has one per step, so which of them the knee is measured against is a question the mode does not answer. |
 | `rps` / `targetRps` above zero, on any mode | It is what selects the open-loop path regardless of the declared mode. |
 | An unknown `mode` | |
 
@@ -2342,6 +2343,8 @@ default, and whose message names the offending field and why the bound exists:
 | `max_sample_bytes` | `0`-`1073741824` | The whole-run capture budget; every byte under it is held in memory until the run flushes. Defaults to the `maxSampleBytes` setting. |
 | `max_exemplar_results` | `0`-`100000` | Each retained exemplar holds a captured exchange. `0` means unlimited. |
 | `phase_histograms` | boolean | Per-run override for the `phaseHistograms` setting. `false` skips the bank entirely, and the run's report carries no `timingBreakdown.phases`. |
+| `save_timing_breakdown` | boolean | Read as a bool inside the run-context constructor, which threw on a string *after* the row was written - the same stranded-`pending` failure `duration` had. |
+| `capture_response_bodies` | boolean | Same read, same constructor, same failure. |
 | `concurrency` | `1`-`10000` | Connections are eagerly pre-allocated per worker before any traffic flows, so `-1` (a natural "unlimited" guess) allocated until malloc failed. |
 | `startConcurrency` | `1`-`10000` | The ramp is seeded with this many in-flight requests before the first duration check, and it is read as a `size_t`, so a negative start is ~1.8e19 of them. |
 | `maxInFlight` | `1`-`1000000` | It is a pending-request ceiling read as a `size_t`, so `-1` or `0` removes the backpressure the field exists to provide instead of tightening it, and an open-loop run against a slow target then accumulates in-flight requests for its whole duration. The ceiling is **not** the `concurrency` guard: that one bounds an eager per-worker connection pre-allocation, while this bounds a counter that pre-allocates nothing, and the engine's own default - `max(targetRps × 10, 1000)` - reaches 500,000 at the load dialog's 50k RPS maximum, so a lower bound would refuse ceilings the engine picks for itself. |

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -552,17 +552,18 @@ const vayu::core::MonitorLimits& monitor_limits) {
         }
     }
 
-    // `phase_histograms` is read with `config.value (..., bool)` inside
-    // RunContext's constructor, which throws `type_error.302` on a string -
-    // after the run row exists, which is the stranded-`pending` failure this
-    // whole function is here to prevent. One field rather than a table: its two
-    // boolean siblings (`save_timing_breakdown`, `capture_response_bodies`)
-    // carry the same exposure and predate this guard, so widening it to them is
-    // a behaviour change for existing callers and belongs in its own change.
-    if (config.contains ("phase_histograms") && !config["phase_histograms"].is_null () &&
-    !config["phase_histograms"].is_boolean ()) {
-        return std::string ("'phase_histograms' must be a boolean (got ") +
-        config["phase_histograms"].type_name () + ")";
+    // Each is read with `config.value (..., bool)` inside RunContext's
+    // constructor, which throws `type_error.302` on a string - after the run
+    // row exists, which is the stranded-`pending` failure this whole function
+    // is here to prevent. Absent and `null` both mean "use the engine setting",
+    // matching the null-vs-absent rule the resource routes follow.
+    for (const char* key :
+    { "phase_histograms", "save_timing_breakdown", "capture_response_bodies" }) {
+        const auto it = config.find (key);
+        if (it != config.end () && !it->is_null () && !it->is_boolean ()) {
+            return "'" + std::string (key) + "' must be a boolean (got " +
+            it->type_name () + ")";
+        }
     }
 
     // `thresholds` is the one nested object here, so it gets its own pass

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -25,7 +25,11 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <charconv>
 #include <chrono>
+#include <cstddef>
+#include <optional>
+#include <string_view>
 #include <thread>
 
 namespace vayu::http {
@@ -107,12 +111,56 @@ InboxLimits read_inbox_limits (vayu::db::Database& db) {
     return limits;
 }
 
+namespace {
+
+/**
+ * The first octet of @p bind when it is a dotted-quad IPv4 literal, otherwise
+ * `std::nullopt`.
+ *
+ * A parse rather than a prefix match: a *hostname* like `127.example.com` also
+ * starts with `127.` but resolves wherever DNS says, so treating it as loopback
+ * would bind wide while reporting `loopback: true` and skipping the
+ * confirmation gate. Shorthand forms (`127.1`) are not addresses here either -
+ * they only cost their user an explicit `confirmNonLoopback`, which is the safe
+ * direction to be wrong in.
+ */
+std::optional<unsigned> ipv4_first_octet (std::string_view bind) {
+    unsigned first    = 0;
+    std::size_t start = 0;
+    for (int octet = 0; octet < 4; ++octet) {
+        const std::size_t dot = bind.find ('.', start);
+        const bool is_last    = octet == 3;
+        if (is_last == (dot != std::string_view::npos)) {
+            return std::nullopt; // A missing separator, or a fifth octet.
+        }
+        const std::string_view part =
+        bind.substr (start, is_last ? std::string_view::npos : dot - start);
+        if (part.empty () || part.size () > 3) {
+            return std::nullopt;
+        }
+        unsigned value        = 0;
+        const auto* const end = part.data () + part.size ();
+        const auto [ptr, ec]  = std::from_chars (part.data (), end, value);
+        if (ec != std::errc () || ptr != end || value > 255) {
+            return std::nullopt;
+        }
+        if (octet == 0) {
+            first = value;
+        }
+        start = dot + 1;
+    }
+    return first;
+}
+
+} // namespace
+
 bool is_loopback_bind (const std::string& bind) {
     if (bind == "localhost" || bind == "::1" || bind == "[::1]") {
         return true;
     }
     // The whole of 127.0.0.0/8 is loopback, not just the canonical address.
-    return bind.rfind ("127.", 0) == 0;
+    const auto first = ipv4_first_octet (bind);
+    return first.has_value () && *first == 127;
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/tests/auth_refresh_test.cpp
+++ b/engine/tests/auth_refresh_test.cpp
@@ -13,7 +13,6 @@
 #include <gtest/gtest.h>
 #include <httplib.h>
 
-#include <atomic>
 #include <chrono>
 #include <memory>
 #include <set>
@@ -29,6 +28,7 @@
 #include "vayu/db/database.hpp"
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
+#include "vayu/http/mock_issuer.hpp"
 #include "vayu/http/oauth_client.hpp"
 
 using nlohmann::json;
@@ -47,30 +47,19 @@ int64_t now_ms () {
 }
 
 /**
- * A mock identity provider and target in one process.
+ * The target of the run: `/api` records every distinct `Authorization` value it
+ * is sent, in the order they first appeared. That ordering is the assertion -
+ * the run must move from the first token to the second while it is still going,
+ * not merely end up on the second.
  *
- * `/token` mints a new access token per call with a short, configurable
- * lifetime; `/api` records every distinct `Authorization` value it is sent, in
- * the order they first appeared. That ordering is the assertion: the run must
- * move from AT1 to AT2 while it is still going, not merely end up on AT2.
+ * The identity provider it used to carry alongside is now `MockIssuerManager`
+ * (#479), the engine's own mock issuer, so there is one mock IdP in the tree
+ * rather than a copy here that never receives its fixes.
  */
-class MockIdpAndTarget {
+class MockTarget {
     public:
-    explicit MockIdpAndTarget (int64_t expires_in_s)
-    : expires_in_s_ (expires_in_s) {
+    MockTarget () {
         svr_.new_task_queue = [] { return new httplib::ThreadPool (16); };
-
-        svr_.Post ("/token", [this] (const httplib::Request&, httplib::Response& res) {
-            if (token_endpoint_fails_.load ()) {
-                res.status = 400;
-                res.set_content (R"({"error":"invalid_grant"})", "application/json");
-                return;
-            }
-            const int minted = ++minted_;
-            res.set_content ("{\"access_token\":\"AT" + std::to_string (minted) +
-            "\",\"token_type\":\"Bearer\",\"expires_in\":" + std::to_string (expires_in_s_) + "}",
-            "application/json");
-        });
 
         svr_.Get ("/api", [this] (const httplib::Request& req, httplib::Response& res) {
             const std::string auth = req.get_header_value ("Authorization");
@@ -88,18 +77,15 @@ class MockIdpAndTarget {
         svr_.wait_until_ready ();
     }
 
-    ~MockIdpAndTarget () {
+    ~MockTarget () {
         svr_.stop ();
         if (thread_.joinable ())
             thread_.join ();
     }
 
-    MockIdpAndTarget (const MockIdpAndTarget&)            = delete;
-    MockIdpAndTarget& operator= (const MockIdpAndTarget&) = delete;
+    MockTarget (const MockTarget&)            = delete;
+    MockTarget& operator= (const MockTarget&) = delete;
 
-    std::string token_url () const {
-        return "http://127.0.0.1:" + std::to_string (port_) + "/token";
-    }
     std::string api_url () const {
         return "http://127.0.0.1:" + std::to_string (port_) + "/api";
     }
@@ -110,17 +96,10 @@ class MockIdpAndTarget {
         return seen_;
     }
 
-    void fail_token_endpoint (bool fail) {
-        token_endpoint_fails_.store (fail);
-    }
-
     private:
     httplib::Server svr_;
     std::thread thread_;
     int port_ = 0;
-    int64_t expires_in_s_;
-    std::atomic<int> minted_{ 0 };
-    std::atomic<bool> token_endpoint_fails_{ false };
     mutable std::mutex mutex_;
     std::vector<std::string> seen_;
 };
@@ -566,17 +545,23 @@ class MidRunRefreshTest : public ::testing::Test {
 // report says when it changed. Mutation check - drop the sync_auth_header call
 // from the submission path and `credentials_seen` stays at one entry.
 TEST_F (MidRunRefreshTest, ARunOutlivingItsTokenSendsARefreshedOne) {
-    MockIdpAndTarget idp (/*expires_in_s=*/3);
-    const json oauth2 = oauth2_config (idp.token_url ());
+    MockTarget target;
+    vayu::http::MockIssuerManager issuers;
+    const auto issuer = issuers.start (json{ { "expiresInSeconds", 3 } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+    const json oauth2 = oauth2_config (issuer.token_url);
 
     const json summary =
-    execute ("run-auth-refresh", run_config (idp.api_url (), oauth2));
+    execute ("run-auth-refresh", run_config (target.api_url (), oauth2));
 
-    const auto seen = idp.credentials_seen ();
+    const auto seen = target.credentials_seen ();
     ASSERT_GE (seen.size (), 2u)
     << "the run sent one credential for its whole life: " << seen.size ();
-    EXPECT_EQ (seen[0], "Bearer AT1");
-    EXPECT_EQ (seen[1], "Bearer AT2");
+    // Each mint carries its own `jti`, so a second distinct value is a second
+    // token rather than the same one re-sent.
+    EXPECT_EQ (seen[0].rfind ("Bearer ", 0), 0u) << seen[0];
+    EXPECT_EQ (seen[1].rfind ("Bearer ", 0), 0u) << seen[1];
+    EXPECT_NE (seen[0], seen[1]) << "the run re-sent its first token";
 
     ASSERT_TRUE (summary.contains ("auth")) << summary.dump ();
     const auto& auth = summary["auth"];
@@ -590,13 +575,16 @@ TEST_F (MidRunRefreshTest, ARunOutlivingItsTokenSendsARefreshedOne) {
 // A token endpoint that stops answering must not fail the run: the target's own
 // status codes plus this section are the honest report.
 TEST_F (MidRunRefreshTest, AFailedRefreshIsRecordedAndTheRunStillCompletes) {
-    MockIdpAndTarget idp (/*expires_in_s=*/3);
-    const json oauth2 = oauth2_config (idp.token_url ());
+    MockTarget target;
+    vayu::http::MockIssuerManager issuers;
+    const auto issuer = issuers.start (json{ { "expiresInSeconds", 3 } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+    const json oauth2 = oauth2_config (issuer.token_url);
 
     create_run_row ("run-auth-refresh-fails");
     vayu::core::RunManager manager;
-    ASSERT_TRUE (manager.start_run (
-    "run-auth-refresh-fails", run_config (idp.api_url (), oauth2), *db, false));
+    ASSERT_TRUE (manager.start_run ("run-auth-refresh-fails",
+    run_config (target.api_url (), oauth2), *db, false));
 
     // Only once the run is on the wire has it resolved its first token - auth
     // is resolved on the worker, after start_run has returned. Breaking the
@@ -610,7 +598,9 @@ TEST_F (MidRunRefreshTest, AFailedRefreshIsRecordedAndTheRunStillCompletes) {
     }
     ASSERT_GT (context->requests_sent.load (), 0u)
     << "the run never started sending";
-    idp.fail_token_endpoint (true);
+    const auto broken =
+    issuers.update (issuer.issuer_id, json{ { "failureMode", "server_error" } });
+    ASSERT_TRUE (broken.found && broken.ok) << broken.error;
     await_completion ("run-auth-refresh-fails");
     manager.shutdown (std::chrono::milliseconds (15000));
 
@@ -628,14 +618,27 @@ TEST_F (MidRunRefreshTest, AFailedRefreshIsRecordedAndTheRunStillCompletes) {
 
 // A run that cannot refresh spawns no watchdog and reports no section - the
 // absent section is what says "this run was never watching".
+//
+// The inert shape driven here is the user's explicit opt-out, and the token
+// still expires mid-run: the opt-out has to hold even when a refresh would
+// otherwise have been due. The other inert shapes - an unknown expiry, a
+// query-placed token, an uncached one - are pinned directly on
+// plan_auth_refresh by InertForEveryUnrefreshableShape, which is where the
+// expiry-less one now lives: the engine's mock issuer always states an expiry,
+// so no run against it can be missing one.
 TEST_F (MidRunRefreshTest, ANonRefreshableRunReportsNoAuthSection) {
-    MockIdpAndTarget idp (/*expires_in_s=*/0); // no expiry information
-    const json oauth2 = oauth2_config (idp.token_url ());
+    MockTarget target;
+    vayu::http::MockIssuerManager issuers;
+    const auto issuer = issuers.start (json{ { "expiresInSeconds", 3 } });
+    ASSERT_TRUE (issuer.ok) << issuer.error_message;
+    json oauth2                = oauth2_config (issuer.token_url);
+    oauth2["autoRefreshToken"] = false;
 
-    const json summary = execute ("run-auth-inert", run_config (idp.api_url (), oauth2));
+    const json summary =
+    execute ("run-auth-inert", run_config (target.api_url (), oauth2));
 
     EXPECT_FALSE (summary.contains ("auth")) << summary.dump ();
-    const auto seen = idp.credentials_seen ();
+    const auto seen = target.credentials_seen ();
     ASSERT_EQ (seen.size (), 1u);
-    EXPECT_EQ (seen[0], "Bearer AT1");
+    EXPECT_EQ (seen[0].rfind ("Bearer ", 0), 0u) << seen[0];
 }

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -112,6 +112,36 @@ TEST (InboxParseStart, NonLoopbackBindNeedsExplicitConfirmation) {
     EXPECT_FALSE (vayu::http::is_loopback_bind ("192.168.1.4"));
 }
 
+// A hostname is not an address, however it starts (issue #504). Classifying
+// `127.example.com` by its prefix bound it wherever DNS pointed while the
+// response - and the UI badge reading it - said `loopback: true`.
+//
+// Mutation check: restore `bind.rfind ("127.", 0) == 0` and both halves fail.
+TEST (InboxParseStart, ALoopbackLookingHostnameIsNotLoopback) {
+    for (const char* host : { "127.example.com", "127.0.0.1.evil.test", "127.", "127",
+         "127.0.0", "127.0.0.1.2", "127.0.0.256", "1270.0.0.1", "notlocalhost" }) {
+        EXPECT_FALSE (vayu::http::is_loopback_bind (host))
+        << host << " was classified as loopback";
+    }
+    // The gate follows the classification: a non-loopback bind is refused
+    // without confirmation and accepted with it.
+    InboxStartRequest out;
+    auto refused =
+    vayu::http::parse_inbox_start (json{ { "bind", "127.example.com" } }, out);
+    ASSERT_TRUE (refused.has_value ())
+    << "a hostname starting 127. was bound without confirmation";
+    EXPECT_EQ (refused->code, "inbox_non_loopback_bind");
+
+    auto accepted = vayu::http::parse_inbox_start (
+    json{ { "bind", "127.example.com" }, { "confirmNonLoopback", true } }, out);
+    EXPECT_FALSE (accepted.has_value ());
+    EXPECT_EQ (out.bind, "127.example.com");
+
+    // The whole of 127.0.0.0/8 still needs no confirmation.
+    EXPECT_TRUE (vayu::http::is_loopback_bind ("127.255.255.254"));
+    EXPECT_TRUE (vayu::http::is_loopback_bind ("127.000.000.001"));
+}
+
 TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
     InboxCannedResponse current;
     current.status   = 500;

--- a/engine/tests/run_config_validation_test.cpp
+++ b/engine/tests/run_config_validation_test.cpp
@@ -510,31 +510,39 @@ TEST (RunConfigValidation, AnOutOfRangeSloIsRejected) {
     }
 }
 
-// --- 8. Per-phase histograms (issue #476) ---------------------------------
+// --- 8. The boolean run-config settings (issues #476, #504) ---------------
 
-// Read as a bool inside RunContext's constructor, which throws on a string -
-// after the run row exists. Rejected here so a rejected request leaves no
-// trace, like every other field in this function.
+// Each is read as a bool inside RunContext's constructor, which throws on a
+// string - after the run row exists. Rejected here so a rejected request leaves
+// no trace, like every other field in this function.
 //
-// Mutation check: delete the `phase_histograms` guard from validate_run_config
-// and the string case below is accepted.
-TEST (RunConfigValidation, ANonBooleanPhaseHistogramsIsRejected) {
-    for (const nlohmann::json bad :
-    { nlohmann::json ("true"), nlohmann::json (1), nlohmann::json (nlohmann::json::array ()) }) {
-        auto config                = valid_config ();
-        config["phase_histograms"] = bad;
-        expect_rejected (config, "phase_histograms");
+// Mutation check: delete any one key from the guard's list in
+// validate_run_config and that key's string case below is accepted.
+TEST (RunConfigValidation, ANonBooleanBooleanSettingIsRejected) {
+    for (const char* key :
+    { "phase_histograms", "save_timing_breakdown", "capture_response_bodies" }) {
+        for (const nlohmann::json bad : { nlohmann::json ("true"),
+             nlohmann::json (1), nlohmann::json (nlohmann::json::array ()) }) {
+            auto config = valid_config ();
+            config[key] = bad;
+            expect_rejected (config, key);
+        }
     }
 }
 
-TEST (RunConfigValidation, BothPhaseHistogramSettingsAreAccepted) {
-    for (const bool value : { true, false }) {
-        auto config                = valid_config ();
-        config["phase_histograms"] = value;
-        EXPECT_FALSE (validate_run_config (config).has_value ());
+TEST (RunConfigValidation, BothValuesOfEveryBooleanSettingAreAccepted) {
+    for (const char* key :
+    { "phase_histograms", "save_timing_breakdown", "capture_response_bodies" }) {
+        for (const bool value : { true, false }) {
+            auto config = valid_config ();
+            config[key] = value;
+            EXPECT_FALSE (validate_run_config (config).has_value ())
+            << key << " = " << value << " was refused";
+        }
+        // Absent and null both mean "use the engine setting".
+        auto config = valid_config ();
+        config[key] = nullptr;
+        EXPECT_FALSE (validate_run_config (config).has_value ())
+        << "a null " << key << " was refused";
     }
-    // Absent and null both mean "use the engine setting".
-    auto config                = valid_config ();
-    config["phase_histograms"] = nullptr;
-    EXPECT_FALSE (validate_run_config (config).has_value ());
 }

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -249,6 +249,19 @@ TEST (ScenarioLoadConfig, ConstantRpsIsRefusedForAScenario) {
     << "the refusal must name the mode it refused: " << *refusal;
 }
 
+TEST (ScenarioLoadConfig, CapacityIsRefusedForAScenario) {
+    const json config = { { "scenario", { { "collectionId", "c" } } },
+        { "mode", "capacity" }, { "duration", "10s" } };
+
+    ASSERT_TRUE (vayu::core::is_scenario_load_run (config));
+    const auto refusal = vayu::core::validate_scenario_load_config (config);
+    ASSERT_TRUE (refusal.has_value ())
+    << "capacity with a scenario must be refused: the search judges one "
+       "windowed p99 and a sequence has one per step";
+    EXPECT_NE (refusal->find ("capacity"), std::string::npos)
+    << "the refusal must name the mode it refused: " << *refusal;
+}
+
 TEST (ScenarioLoadConfig, AnArrivalRateIsRefusedOnEveryScenarioMode) {
     // `rps` is what puts ConstantLoadStrategy on its open-loop path regardless
     // of the declared mode, so refusing only `mode: constant_rps` would leave


### PR DESCRIPTION
## Description

The four items from #504, verified against master `3a7c937` before touching anything - all four still existed exactly as the issue described.

**Plan.** Root cause of the one real bug: `validate_run_config` guards `phase_histograms` against a non-boolean, but its two siblings (`save_timing_breakdown`, `capture_response_bodies`) are read the same way - `config.value (..., bool)` inside `RunContext`'s constructor, which throws `type_error.302` *after* `create_run` has written the row, stranding the run `pending`. The guard's own comment named them and deferred. Approach: turn the hand-written single check into a list of the three keys, so the next boolean field is a one-word edit rather than a fourth copy. **Rejected: widening the numeric `NumericRunField` table to carry a type column** - it exists to range-check numbers and every row would gain a field only three of them use; a three-line loop beside it says the same thing without reshaping a table for a type it does not model.

### 1. Two unguarded run-config booleans (medium)

`execution.cpp` now refuses a non-boolean `save_timing_breakdown` or `capture_response_bodies` with a `400` naming the field, before any run row exists. Absent and `null` still mean "use the engine setting", matching the null-vs-absent rule the resource routes follow.

This is a behaviour change for a raw `POST /runs` client that was sending, say, `"true"`: it used to get a `500` and a stranded run, and now gets a `400`. The app always sends booleans, so nothing app-side changes.

### 2. The capacity refusal arm (hygiene)

`CapacityIsRefusedForAScenario` sits beside the existing `constant_rps` case and asserts the refusal names the mode. No production change - the arm already worked, it was simply unpinned.

### 3. `is_loopback_bind` classified by prefix (low)

`bind.rfind ("127.", 0) == 0` treated `127.example.com` as loopback. That is a *hostname* - it resolves wherever DNS says - so the inbox bound wide while reporting `loopback: true`, skipping the `confirmNonLoopback` gate and badging itself loopback in the UI. It now parses the address: four decimal octets, each 0-255, first one `127`. `::1`, `[::1]` and `localhost` are unchanged, and the whole of 127.0.0.0/8 still needs no confirmation.

Shorthand forms (`127.1`) are no longer loopback either. That costs their user one explicit `confirmNonLoopback` and is the safe direction to be wrong in - the unsafe direction is what this fixes.

**Not reused: `looks_like_ipv4_literal`** in `curl_utils.cpp`. It lives in an anonymous namespace in another translation unit, and it answers a different question - "is this a literal at all", accepting `999.1` and `1.2.3.4.5` - which is right for its caller (deciding whether to pin a DNS cache entry) and wrong for a trust boundary.

### 4. The hand-rolled mock IdP (hygiene)

`auth_refresh_test.cpp`'s `MockIdpAndTarget` served `/token` and `/api` from one listener. The IdP half is gone; the three end-to-end tests now run against `MockIssuerManager` (#479), whose Sequencing anticipated this. The target half stays as `MockTarget` - recording the credentials a run sent is not an issuer's job.

**One deliberate deviation from the issue.** `MockIssuerManager` cannot express "no expiry information": `expiresInSeconds` has a floor of 1 and `/token` always emits `expires_in`. `ANonRefreshableRunReportsNoAuthSection` used a `expires_in: 0` response to make the run non-refreshable, so it now drives the user's explicit `autoRefreshToken: false` opt-out instead, with the token still expiring mid-run - so the opt-out has to hold even when a refresh would otherwise have been due. The unknown-expiry arm stays pinned directly on `plan_auth_refresh` by `InertForEveryUnrefreshableShape` (`cache_token (config, "AT1", 0)`), which is the only place it can still be expressed. The alternative - widening a shipped endpoint's contract so a test could ask for a spec-violating token response - was rejected as the wrong direction of dependency.

The two token-identity assertions (`Bearer AT1` / `Bearer AT2`) became "two distinct `Bearer` values": the mock issuer mints signed JWTs with a per-token `jti`, so a second distinct value is a second token rather than the same one re-sent.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1410 tests, 100% passed** (1408 at base; +2 new). No pre-existing failures observed.

**Mutation-checked** - each fix reverted, the test confirmed red, then restored:

| Mutation | Result |
|---|---|
| Drop `save_timing_breakdown` from the guard's key list | `ANonBooleanBooleanSettingIsRejected` **fails** |
| Neuter the `LoadTestType::Capacity` refusal | `CapacityIsRefusedForAScenario` **fails** |
| Restore `bind.rfind ("127.", 0) == 0` | `ALoopbackLookingHostnameIsNotLoopback` **fails** |
| Drop the `sync_auth_header` call from the submission path | `ARunOutlivingItsTokenSendsARefreshedOne` **fails** |

That last one is the mutation the original test documented, re-run against the ported version: the refresh test kept its teeth across the swap to `MockIssuerManager`.

New coverage: the three boolean keys refused as string/number/array and accepted as `true`/`false`/`null`; the capacity refusal naming its mode; nine non-loopback spellings (`127.example.com`, `127.0.0.1.evil.test`, `127.`, `127`, `127.0.0`, `127.0.0.1.2`, `127.0.0.256`, `1270.0.0.1`, `notlocalhost`) plus the confirm gate firing for a `127.`-prefixed hostname, and `127.255.255.254` / `127.000.000.001` still loopback.

`clang-format` applied to `inbox_test.cpp` and `auth_refresh_test.cpp` (clean at HEAD) and to the touched line ranges only in `execution.cpp` and `run_config_validation_test.cpp` (already unformatted at HEAD), per the repo's no-repo-wide-formatting rule. `mkdocs` is not installed in this environment, so `mkdocs build --strict` was not run; the docs edits are text inside three existing tables, adding no links, anchors, headings or nav entries.

No app or MCP change: the app sends well-typed run configs, never binds a non-literal host, and the tests are engine-internal. Verified rather than assumed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #504

---
_Generated by [Claude Code](https://claude.ai/code/session_013GzoGbEjhFgWWBoHtSJVsv)_