### PR TITLE
refactor(engine): one ManagedListener behind all three on-demand listeners

### DIFF
--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -93,7 +93,11 @@ Each on-demand listener is owned by a manager that is a **member of `Server`, de
 `server_`** (`engine/include/vayu/http/server.hpp`). Members are destroyed in reverse order, so the
 route lambdas holding references to a manager are gone before its destructor stops and joins the
 listener threads - and the `Database` those threads write to, being external to `Server`, is still
-alive at that point.
+alive at that point. All three managers run that lifecycle - bind, wait for the accept loop, stop,
+join, release - through one shared `ManagedListener`
+(`engine/include/vayu/http/managed_listener.hpp`), so a fix to it reaches every listener rather than
+one of three copies; what stays per-manager is the route registration, the error each bind failure
+answers with, and the OAuth attempt TTL sweep.
 
 ### Event Loop (`curl_multi`)
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -382,6 +382,7 @@ if(VAYU_BUILD_ENGINE)
     add_executable(vayu-engine
         src/daemon.cpp
         src/http/server.cpp
+        src/http/managed_listener.cpp
         src/http/routes/health.cpp
         src/http/routes/config.cpp
         src/http/routes/collections.cpp
@@ -483,6 +484,7 @@ if(VAYU_BUILD_TESTS)
         tests/oauth_route_test.cpp
         tests/pkce_test.cpp
         tests/debug_redact_test.cpp
+        tests/managed_listener_test.cpp
         tests/oauth_authorize_test.cpp
         tests/mock_issuer_test.cpp
         tests/inbox_test.cpp
@@ -517,6 +519,7 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/cookies.cpp
         src/http/routes/mock_issuer.cpp
         src/http/routes/inbox.cpp
+        src/http/managed_listener.cpp
     )
     
     # The cross-language conformance fixture lives in the source tree and is

--- a/engine/include/vayu/http/managed_listener.hpp
+++ b/engine/include/vayu/http/managed_listener.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <httplib.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace vayu::http {
+
+/**
+ * One on-demand listener: an `httplib::Server`, the thread accepting on it, and
+ * the start/stop discipline both need to be correct.
+ *
+ * The engine opens a listener per OAuth callback attempt, per mock issuer and
+ * per webhook inbox (see docs/engine/architecture.md#listeners). Each of those
+ * managers used to hand-roll the same four steps, and the steps are subtle:
+ *
+ * - **Bind before listening.** `bind_to_any_port` / `bind_to_port` report the
+ *   failure a `listen()` on a taken port would only ever log, so the caller can
+ *   answer its own error rather than leaving a thread spinning.
+ * - **Return only once the accept loop is live.** `stop()` racing ahead of
+ *   `listen()` is *missed* by cpp-httplib, and the `join()` that follows then
+ *   hangs forever. `start()` therefore does not return until the server reports
+ *   itself running (or the spin bound elapses).
+ * - **Stop, then join, then drop the server.** A request still in a handler
+ *   holds the listener thread, so the join is the thing that makes "stopped"
+ *   mean "nothing is touching my state any more".
+ * - **Own the listener last.** Whatever a handler reaches for - a canned
+ *   response, an issuer's token maps, an attempt's config - must outlive the
+ *   thread reading it, so the `ManagedListener` member is declared **last** in
+ *   its owner and is therefore destroyed **first**. The same reverse-member-order
+ *   rule puts the three managers before `server_` in server.hpp.
+ *
+ * Thread-safe against concurrent `stop()`s and `is_listening()` reads only in
+ * the sense each manager needs: `start()` and `stop()` are called under the
+ * owning manager's lock (or on an object no other thread can reach yet), while
+ * `is_listening()` is a plain atomic read.
+ */
+class ManagedListener {
+    public:
+    ManagedListener ();
+    /// Stops and joins, so a manager destroying its records never leaks a thread.
+    ~ManagedListener ();
+
+    ManagedListener (const ManagedListener&)            = delete;
+    ManagedListener& operator= (const ManagedListener&) = delete;
+
+    /**
+     * The server to register routes and options on, before `start()`.
+     *
+     * Throws `std::logic_error` after `stop()` has run: the server is released
+     * there, and a route registered on a listener that no longer exists would
+     * otherwise be a silent no-op (or worse, a null dereference).
+     */
+    httplib::Server& server ();
+
+    /**
+     * Bind @p bind_address (@p port, or an ephemeral port when 0) and start
+     * accepting.
+     *
+     * @return the bound port, or 0 when the bind failed or this listener was
+     *         already started - nothing is running in either case, and the
+     *         caller owns the error it reports.
+     */
+    int start (const std::string& bind_address, int port = 0);
+
+    /**
+     * Stop accepting, join the listener thread, release the server. Idempotent
+     * and safe on a listener that never started; returns only once no handler
+     * is still running, which can take as long as the slowest one.
+     */
+    void stop ();
+
+    /// True between a successful `start()` and `stop()`.
+    bool is_listening () const;
+
+    private:
+    std::unique_ptr<httplib::Server> server_;
+    std::thread listen_thread_;
+    std::atomic<bool> listening_{ false };
+};
+
+} // namespace vayu::http

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -45,22 +45,21 @@ class Server {
     vayu::core::RunManager& run_manager_;
     int port_;
     bool verbose_;
-    // Declared before server_ so it is destroyed *after* server_ (reverse member
-    // order): the httplib lambdas that reference it are gone before its dtor
-    // stops and joins any live loopback listeners, and db_ (external) is still
-    // alive at that point. Previously a function-local static outliving db_.
+    // Everything from here down to server_ is declared *before* it so it is
+    // destroyed *after* it (reverse member order): the httplib lambdas that
+    // reference these members are gone with server_, and db_ - external, so
+    // outliving all of this - is still alive when their destructors run.
+    //
+    // That matters most for the three listener-owning managers: each holds one
+    // ManagedListener per attempt / issuer / inbox, and each destructor stops
+    // and joins those listener threads while a handler may still be writing to
+    // db_. The one rule they all run on lives on the helper - see
+    // managed_listener.hpp. The cookie jar is here for the first half of the
+    // reason alone: an in-flight /execute holds a reference to it, and it is
+    // process-lifetime by design (see cookie_jar.hpp).
     OAuth2AuthorizeManager oauth_authorize_manager_;
-    // Same reverse-order reasoning as oauth_authorize_manager_ above: the
-    // route lambdas and any in-flight /execute hold a reference to it, so it
-    // must outlive server_. Process-lifetime by design - see cookie_jar.hpp.
     CookieJar cookie_jar_;
-    // Same reverse-order reasoning again: its dtor stops and joins every live
-    // mock-issuer listener, and the route lambdas that reach it must be gone by
-    // then - so it is declared before server_ and destroyed after it.
     MockIssuerManager mock_issuer_manager_;
-    // And once more, for the third listener family: each inbox is an independent
-    // listener whose handlers hold a reference to db_, and the route lambdas that
-    // start and stop them must be gone before this dtor joins their threads.
     InboxManager inbox_manager_;
     httplib::Server server_;
     std::thread server_thread_;

--- a/engine/src/http/managed_listener.cpp
+++ b/engine/src/http/managed_listener.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file managed_listener.cpp
+ * @brief The one copy of the on-demand listener lifecycle (issue #505). The
+ *        OAuth callback, mock issuer and webhook inbox managers all run on it.
+ */
+
+#include "vayu/http/managed_listener.hpp"
+
+#include <chrono>
+#include <stdexcept>
+
+namespace vayu::http {
+
+namespace {
+
+/// How long `start()` waits for the accept loop, in 1ms steps. A local bind is
+/// live in well under a millisecond; the bound only matters so a pathological
+/// scheduler cannot hang a route handler indefinitely.
+constexpr int kListenSpinAttempts = 200;
+
+} // namespace
+
+ManagedListener::ManagedListener ()
+: server_ (std::make_unique<httplib::Server> ()) {
+}
+
+ManagedListener::~ManagedListener () {
+    stop ();
+}
+
+httplib::Server& ManagedListener::server () {
+    if (!server_) {
+        throw std::logic_error (
+        "ManagedListener::server() after stop() - the listener is gone");
+    }
+    return *server_;
+}
+
+int ManagedListener::start (const std::string& bind_address, int port) {
+    if (!server_ || listening_.load ()) {
+        return 0;
+    }
+
+    // bind_to_any_port answers -1 on failure, bind_to_port a bool; both become
+    // 0 here so every caller has one "nothing is listening" check.
+    const int bound = port > 0 ?
+    (server_->bind_to_port (bind_address, port) ? port : 0) :
+    server_->bind_to_any_port (bind_address);
+    if (bound <= 0) {
+        return 0;
+    }
+
+    httplib::Server* svr = server_.get ();
+    listening_.store (true);
+    listen_thread_ = std::thread ([svr] { svr->listen_after_bind (); });
+    // Return only once the accept loop is live: a stop() that races ahead of
+    // listen() is missed, and the join in stop() then hangs.
+    for (int i = 0; i < kListenSpinAttempts && !svr->is_running (); ++i) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (1));
+    }
+    return bound;
+}
+
+void ManagedListener::stop () {
+    if (server_) {
+        server_->stop ();
+    }
+    // A handler still running - a capture inside its configured delay, a token
+    // exchange mid-flight - holds this thread, so the join is what makes
+    // "stopped" mean "nothing is reading my owner's state any more".
+    if (listen_thread_.joinable ()) {
+        listen_thread_.join ();
+    }
+    server_.reset ();
+    listening_.store (false);
+}
+
+bool ManagedListener::is_listening () const {
+    return listening_.load ();
+}
+
+} // namespace vayu::http

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -16,6 +16,7 @@
 #include "vayu/http/inbox.hpp"
 
 #include "vayu/core/constants.hpp"
+#include "vayu/http/managed_listener.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/id.hpp"
 #include "vayu/utils/logger.hpp"
@@ -292,9 +293,6 @@ struct InboxManager::Inbox {
     std::string id;
     std::string bind;
     int port = 0;
-    std::unique_ptr<httplib::Server> server;
-    std::thread listen_thread;
-    std::atomic<bool> running{ false };
     /// Resolved once at start and const thereafter, so every capture in one
     /// inbox was truncated and retained by the same rules.
     InboxLimits limits;
@@ -306,13 +304,19 @@ struct InboxManager::Inbox {
     std::mutex response_mutex;
     InboxCannedResponse response;
 
+    /// Declared last so it is destroyed first: the capture handler reads the
+    /// limits and the canned response above it while the accept loop is alive.
+    /// Its listening state *is* the inbox's `running` - a stopped inbox keeps
+    /// its record, so there is nothing else for `running` to mean.
+    ManagedListener listener;
+
     InboxInfo info_locked () const {
         InboxInfo info;
         info.inbox_id = id;
         info.bind     = bind;
         info.port     = port;
         info.url      = "http://" + bind + ":" + std::to_string (port) + "/";
-        info.running  = running.load ();
+        info.running  = listener.is_listening ();
         info.loopback = is_loopback_bind (bind);
         info.response = response;
         return info;
@@ -330,17 +334,10 @@ InboxManager::~InboxManager () {
 }
 
 void InboxManager::teardown_locked (Inbox& inbox) {
-    if (inbox.server) {
-        inbox.server->stop ();
-    }
     // A capture in its configured delay is still holding a listener thread, so
-    // this join waits up to inbox::MAX_RESPONSE_DELAY_MS - which is why that
-    // bound exists.
-    if (inbox.listen_thread.joinable ()) {
-        inbox.listen_thread.join ();
-    }
-    inbox.server.reset ();
-    inbox.running.store (false);
+    // the join inside stop() waits up to inbox::MAX_RESPONSE_DELAY_MS - which is
+    // why that bound exists.
+    inbox.listener.stop ();
 }
 
 InboxManager::StartResult
@@ -352,10 +349,9 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
     inbox->id       = vayu::utils::generate_id ("inbox_");
     inbox->bind     = request.bind;
     inbox->response = request.response;
-    inbox->server   = std::make_unique<httplib::Server> ();
     // Reject an oversized upload at the transport rather than buffering it:
     // the handler below only ever stores a prefix anyway.
-    inbox->server->set_payload_max_length (constants::inbox::MAX_PAYLOAD_BYTES);
+    inbox->listener.server ().set_payload_max_length (constants::inbox::MAX_PAYLOAD_BYTES);
 
     Inbox* raw                       = inbox.get ();
     httplib::Server::Handler capture = [raw, &db] (const httplib::Request& req,
@@ -414,16 +410,15 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
 
     // Every method cpp-httplib will route, on every path. CONNECT, TRACE and
     // PRI are the remainder and are not routable - a webhook is never one.
-    inbox->server->Get (".*", capture); // also serves HEAD
-    inbox->server->Post (".*", capture);
-    inbox->server->Put (".*", capture);
-    inbox->server->Patch (".*", capture);
-    inbox->server->Delete (".*", capture);
-    inbox->server->Options (".*", capture);
+    httplib::Server& svr = inbox->listener.server ();
+    svr.Get (".*", capture); // also serves HEAD
+    svr.Post (".*", capture);
+    svr.Put (".*", capture);
+    svr.Patch (".*", capture);
+    svr.Delete (".*", capture);
+    svr.Options (".*", capture);
 
-    const int bound = request.port > 0 ?
-    (inbox->server->bind_to_port (request.bind, request.port) ? request.port : -1) :
-    inbox->server->bind_to_any_port (request.bind);
+    const int bound = inbox->listener.start (request.bind, request.port);
     if (bound <= 0) {
         out.ok            = false;
         out.http_status   = 409;
@@ -434,15 +429,6 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
         return out;
     }
     inbox->port = bound;
-
-    httplib::Server* svr = inbox->server.get ();
-    inbox->running.store (true);
-    inbox->listen_thread = std::thread ([svr] { svr->listen_after_bind (); });
-    // Return only once the accept loop is live: a stop() that races ahead of
-    // listen() is missed, and the join then hangs.
-    for (int i = 0; i < 200 && !svr->is_running (); ++i) {
-        std::this_thread::sleep_for (std::chrono::milliseconds (1));
-    }
 
     {
         std::lock_guard<std::mutex> lock (mutex_);

--- a/engine/src/http/routes/mock_issuer.cpp
+++ b/engine/src/http/routes/mock_issuer.cpp
@@ -18,6 +18,7 @@
 #include "vayu/http/mock_issuer.hpp"
 
 #include "vayu/core/constants.hpp"
+#include "vayu/http/managed_listener.hpp"
 #include "vayu/http/pkce.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/encoding.hpp"
@@ -367,8 +368,9 @@ struct MockIssuerState {
     std::map<std::string, IssuedCode> codes;
     std::map<std::string, IssuedRefresh> refresh_tokens;
 
-    std::unique_ptr<httplib::Server> server;
-    std::thread listen_thread;
+    /// Declared last so it is destroyed first: `/token` and `/authorize` read
+    /// every field above it while the accept loop is alive.
+    ManagedListener listener;
 
     std::string token_url () const {
         return issuer_url + "/token";
@@ -620,13 +622,7 @@ MockIssuerManager::~MockIssuerManager () {
 }
 
 void MockIssuerManager::teardown (Issuer& issuer) {
-    if (issuer.server) {
-        issuer.server->stop ();
-    }
-    if (issuer.listen_thread.joinable ()) {
-        issuer.listen_thread.join ();
-    }
-    issuer.server.reset ();
+    issuer.listener.stop ();
 }
 
 MockIssuerStart MockIssuerManager::start (const nlohmann::json& body) {
@@ -659,24 +655,20 @@ MockIssuerStart MockIssuerManager::start (const nlohmann::json& body) {
     // The signing key is base64url text rather than raw bytes so it can be
     // handed to a service under test as a shared secret verbatim.
     issuer->signing_key = pkce::random_token (32);
-    issuer->server      = std::make_unique<httplib::Server> ();
 
     Issuer* raw = issuer.get ();
-    raw->server->Post ("/token", [raw] (const httplib::Request& req, httplib::Response& res) {
+    raw->listener.server ().Post (
+    "/token", [raw] (const httplib::Request& req, httplib::Response& res) {
         handle_token (*raw, req, res);
     });
-    raw->server->Get (
+    raw->listener.server ().Get (
     "/authorize", [raw] (const httplib::Request& req, httplib::Response& res) {
         handle_authorize (*raw, req, res);
     });
 
     // 127.0.0.1 only, never configurable: the issuer mints bearer tokens and
     // the engine has no route auth, so a wider bind would hand them to the LAN.
-    const int port = issuer->settings.port == 0 ?
-    issuer->server->bind_to_any_port ("127.0.0.1") :
-    (issuer->server->bind_to_port ("127.0.0.1", issuer->settings.port) ?
-    issuer->settings.port :
-    0);
+    const int port = issuer->listener.start ("127.0.0.1", issuer->settings.port);
     if (port <= 0) {
         out.ok            = false;
         out.http_status   = 500;
@@ -688,14 +680,6 @@ MockIssuerStart MockIssuerManager::start (const nlohmann::json& body) {
     }
     issuer->port       = port;
     issuer->issuer_url = "http://127.0.0.1:" + std::to_string (port);
-
-    httplib::Server* svr  = issuer->server.get ();
-    issuer->listen_thread = std::thread ([svr] { svr->listen_after_bind (); });
-    // Same reason as the authorize listener: a stop() that races ahead of
-    // listen() is missed and the join below would hang.
-    for (int i = 0; i < 200 && !svr->is_running (); ++i) {
-        std::this_thread::sleep_for (std::chrono::milliseconds (1));
-    }
 
     out.issuer_id     = issuer->id;
     out.issuer_url    = issuer->issuer_url;

--- a/engine/src/http/routes/oauth_authorize.cpp
+++ b/engine/src/http/routes/oauth_authorize.cpp
@@ -14,6 +14,7 @@
 
 #include "vayu/http/oauth_authorize.hpp"
 
+#include "vayu/http/managed_listener.hpp"
 #include "vayu/http/oauth_client.hpp"
 #include "vayu/http/pkce.hpp"
 #include "vayu/utils/encoding.hpp"
@@ -24,7 +25,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <thread>
 #include <variant>
 
 namespace vayu::http {
@@ -119,8 +119,10 @@ struct OAuth2AuthorizeManager::Attempt {
     std::string error;
     std::string cache_key;
 
-    std::unique_ptr<httplib::Server> server; // loopback mode only
-    std::thread listen_thread;
+    /// Loopback mode only - an embedded-mode attempt never starts it, and
+    /// stopping an unstarted listener is a no-op. Declared last so it is
+    /// destroyed first: the callback handler reads every field above it.
+    ManagedListener listener;
 };
 
 OAuth2AuthorizeManager::OAuth2AuthorizeManager () = default;
@@ -134,13 +136,7 @@ OAuth2AuthorizeManager::~OAuth2AuthorizeManager () {
 }
 
 void OAuth2AuthorizeManager::teardown_locked (Attempt& attempt) {
-    if (attempt.server) {
-        attempt.server->stop ();
-    }
-    if (attempt.listen_thread.joinable ()) {
-        attempt.listen_thread.join ();
-    }
-    attempt.server.reset ();
+    attempt.listener.stop ();
 }
 
 void OAuth2AuthorizeManager::reap_timed_out_locked () {
@@ -202,10 +198,9 @@ const nlohmann::json& config, const std::string& mode) {
         attempt->redirect_uri = callback;
     } else {
         // Loopback: bind a one-shot listener on an ephemeral 127.0.0.1 port.
-        attempt->server = std::make_unique<httplib::Server> ();
-        Attempt* raw    = attempt.get ();
+        Attempt* raw = attempt.get ();
 
-        attempt->server->Get ("/callback",
+        attempt->listener.server ().Get ("/callback",
         [raw, &db] (const httplib::Request& req, httplib::Response& res) {
             const auto params = parse_query (req.target.find ('?') != std::string::npos
                     ? req.target.substr (req.target.find ('?') + 1)
@@ -245,7 +240,7 @@ const nlohmann::json& config, const std::string& mode) {
             res.set_content (body, "text/html");
         });
 
-        const int port = attempt->server->bind_to_any_port ("127.0.0.1");
+        const int port = attempt->listener.start ("127.0.0.1");
         if (port <= 0) {
             out.ok            = false;
             out.http_status   = 500;
@@ -255,14 +250,6 @@ const nlohmann::json& config, const std::string& mode) {
         }
         attempt->redirect_uri =
         "http://127.0.0.1:" + std::to_string (port) + "/callback";
-        httplib::Server* svr   = attempt->server.get ();
-        attempt->listen_thread = std::thread ([svr] { svr->listen_after_bind (); });
-
-        // Wait until the accept loop is live before returning; otherwise a
-        // stop() that races ahead of listen() is missed and join() hangs.
-        for (int i = 0; i < 200 && !svr->is_running (); ++i) {
-            std::this_thread::sleep_for (std::chrono::milliseconds (1));
-        }
     }
 
     out.attempt_id    = attempt_id;

--- a/engine/tests/managed_listener_test.cpp
+++ b/engine/tests/managed_listener_test.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file tests/managed_listener_test.cpp
+ * @brief Tests for the shared on-demand listener lifecycle (issue #505): the
+ *        bind/accept/stop contract every listener-owning manager runs on, and
+ *        the case each of them used to pin separately - tearing down while a
+ *        handler is still in flight.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "vayu/http/managed_listener.hpp"
+
+using vayu::http::ManagedListener;
+
+namespace {
+
+TEST (ManagedListener, StartsAcceptingOnAnEphemeralPort) {
+    ManagedListener listener;
+    listener.server ().Get ("/ping", [] (const httplib::Request&, httplib::Response& res) {
+        res.set_content ("pong", "text/plain");
+    });
+
+    const int port = listener.start ("127.0.0.1");
+    ASSERT_GT (port, 0);
+    EXPECT_TRUE (listener.is_listening ());
+
+    httplib::Client client ("127.0.0.1", port);
+    auto response = client.Get ("/ping");
+    ASSERT_TRUE (response);
+    EXPECT_EQ (response->status, 200);
+    EXPECT_EQ (response->body, "pong");
+}
+
+TEST (ManagedListener, StartReturnsTheRequestedPortWhenOneIsAsked) {
+    ManagedListener first;
+    const int port = first.start ("127.0.0.1");
+    ASSERT_GT (port, 0);
+    first.stop ();
+
+    // The port is free again, so an explicit request for it is honoured
+    // verbatim - the mock issuer's `port` setting rides on this.
+    ManagedListener second;
+    EXPECT_EQ (second.start ("127.0.0.1", port), port);
+}
+
+TEST (ManagedListener, ABindFailureStartsNothingAndReportsZero) {
+    // TEST-NET-3 (RFC 5737): documentation-only, so it is never an address this
+    // host holds and the bind fails the same way on all three platforms. A
+    // port already in use is *not* the case to pin here - cpp-httplib binds
+    // with SO_REUSEPORT, so a second listener on the same port succeeds on
+    // Linux.
+    ManagedListener contender;
+    EXPECT_EQ (contender.start ("203.0.113.9"), 0);
+    EXPECT_FALSE (contender.is_listening ());
+    // Nothing was started, so the caller's own error path is the only outcome -
+    // and stopping the failed listener must not hang on a thread that is not
+    // there.
+    contender.stop ();
+    EXPECT_FALSE (contender.is_listening ());
+}
+
+TEST (ManagedListener, StopJoinsAHandlerThatIsStillRunning) {
+    // The case every manager needs and each used to pin on its own: a request
+    // is inside its handler when teardown starts. stop() must not return - and
+    // must not tear the server out from under the handler - until it finishes.
+    ManagedListener listener;
+    std::atomic<bool> handler_entered{ false };
+    std::atomic<bool> handler_finished{ false };
+
+    listener.server ().Get ("/slow", [&] (const httplib::Request&, httplib::Response& res) {
+        handler_entered.store (true);
+        std::this_thread::sleep_for (std::chrono::milliseconds (300));
+        handler_finished.store (true);
+        res.set_content ("done", "text/plain");
+    });
+
+    const int port = listener.start ("127.0.0.1");
+    ASSERT_GT (port, 0);
+
+    std::thread caller ([port] {
+        httplib::Client client ("127.0.0.1", port);
+        client.set_read_timeout (5, 0);
+        client.Get ("/slow");
+    });
+
+    for (int i = 0; i < 500 && !handler_entered.load (); ++i) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (1));
+    }
+    ASSERT_TRUE (handler_entered.load ()) << "the handler never ran";
+
+    listener.stop ();
+    // The join is the whole point: after stop() returns, no handler is still
+    // reading the state its owner is about to destroy.
+    EXPECT_TRUE (handler_finished.load ());
+    EXPECT_FALSE (listener.is_listening ());
+    caller.join ();
+}
+
+TEST (ManagedListener, StopIsIdempotentAndSafeWithoutAStart) {
+    // The authorize manager tears down on every terminal status() poll, so a
+    // second stop() must be a no-op rather than a double join.
+    ManagedListener never_started;
+    never_started.stop ();
+    never_started.stop ();
+    EXPECT_FALSE (never_started.is_listening ());
+
+    ManagedListener started;
+    ASSERT_GT (started.start ("127.0.0.1"), 0);
+    started.stop ();
+    started.stop ();
+    EXPECT_FALSE (started.is_listening ());
+}
+
+TEST (ManagedListener, RegisteringARouteAfterStopFailsLoudly) {
+    // A route registered on a released listener would silently never be served;
+    // saying so at the call site is the only way a caller can learn of it.
+    ManagedListener listener;
+    ASSERT_GT (listener.start ("127.0.0.1"), 0);
+    listener.stop ();
+    EXPECT_THROW (listener.server (), std::logic_error);
+}
+
+TEST (ManagedListener, StartingATwiceStartedListenerRefusesRatherThanLeaking) {
+    ManagedListener listener;
+    const int port = listener.start ("127.0.0.1");
+    ASSERT_GT (port, 0);
+    // A second start would overwrite the thread handle and leak the first
+    // accept loop; it reports "nothing started" instead.
+    EXPECT_EQ (listener.start ("127.0.0.1"), 0);
+    EXPECT_TRUE (listener.is_listening ());
+
+    httplib::Client client ("127.0.0.1", port);
+    EXPECT_TRUE (client.Get ("/"))
+    << "the original listener is still accepting";
+}
+
+} // namespace


### PR DESCRIPTION
## Description

**Plan.** Root cause: the OAuth callback, mock issuer and webhook inbox managers each hand-rolled the same listener lifecycle - build an `httplib::Server`, bind (explicit port or ephemeral), spawn the accept thread, spin until it reports running, and on teardown stop → join → release. Verified at `3a7c937`: `server.hpp` carried three sibling manager members, each with its own copy, and `grep` found no shared abstraction; #481 phase 2 would add a fourth. The approach is the one the issue names: extract a `ManagedListener` owning the server, the thread and the start/stop discipline, and rebase the three managers onto it, keeping route registration and per-service state as the variable part. The alternative I rejected was a CRTP base that also owned the manager's map, `mutex_` and teardown policy - the three diverge exactly there (the authorize manager reaps on a TTL and tears down on a terminal `status()` poll, the issuer tears down *outside* its lock, the inbox keeps a stopped record and its captures), so a base wide enough to hold all three would have had more per-manager hooks than shared body.

**What stayed out of the helper**, deliberately:

- **Route registration** - the variable part by definition.
- **The bind-failure error** each manager answers with (`409 inbox_bind_failed`, `500 mock_issuer_bind_failed`, `500 oauth2_loopback_failed`). `start()` reports "nothing is listening" as `0` and the caller owns its own wire error.
- **The OAuth attempt TTL sweep** (`reap_timed_out_locked`) and the issuer's teardown-outside-the-lock rule - both are manager policy about *when* to stop, not about *how*.
- **Per-service state** - the inbox's limits, canned response and live-stream claim; the issuer's issued codes and refresh tokens; the attempt's config and result.

Two behavioural details worth naming: the inbox's separate `running` atomic is gone, because the listener's own listening state is exactly what `running` meant (a stopped inbox keeps its record, so there was nothing else for it to say); and a bind failure is now uniformly `start() == 0` where the inbox's explicit-port arm used to answer `-1` - every call site checked `<= 0`, so no status or message changed. The `ManagedListener` member is declared **last** in each owning struct so it is destroyed **first**: the handler reads every field above it. `server.hpp`'s four near-identical member-order comments collapse into one that names the helper.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor (no behaviour change)

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1415/1415 passed** (1408 before, plus 7 new). No pre-existing failures on this base.

The three managers' suites are the regression net and pass **unchanged** - 51 tests across the inbox, mock issuer and authorize suites plus the new helper suite, green. New `engine/tests/managed_listener_test.cpp`:

- accepts on an ephemeral port and serves a route;
- honours an explicitly requested port (the issuer's `port` setting rides on this);
- a bind failure starts nothing and reports `0`;
- **`stop()` joins a handler that is still running** - the case each copy pinned separately. Mutation-checked: swapping the `join()` for a `detach()` fails this test, restored green;
- `stop()` is idempotent and safe without a start (the authorize manager tears down on every terminal `status()` poll);
- `server()` after `stop()` throws rather than silently registering a route on a released listener;
- a second `start()` refuses instead of leaking the first accept loop.

The bind-failure test binds `203.0.113.9` (RFC 5737 TEST-NET-3) rather than a port already in use: cpp-httplib binds with `SO_REUSEPORT`, so on Linux a second listener on the same port *succeeds*. That is a real finding about the inbox's `inbox_bind_failed` 409 - out of scope here, filed separately as #512.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (`docs/engine/architecture.md`, same commit)

## Related Issues
Closes #505