### PR TITLE
fix(engine): refuse a port another engine listener already holds

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1281,9 +1281,19 @@ inbox on a free port that answers `200` with no body.
 
 An out-of-range value is a `400` naming the field rather than a fallback to the
 default: a listener quietly answering something other than what it was asked to
-is invisible on both sides of the wire. A bind that fails (port in use) is a
-`409` with code `inbox_bind_failed`; a non-loopback bind without confirmation is
-a `400` with code `inbox_non_loopback_bind`.
+is invisible on both sides of the wire. A bind that fails is a `409` with code
+`inbox_bind_failed`; a non-loopback bind without confirmation is a `400` with
+code `inbox_non_loopback_bind`.
+
+A `port` another engine listener is already running on - an inbox or a mock
+issuer - is refused with that same `409`, naming the holder ("`inbox inbox_2f1c`
+is already listening there"). The engine checks that itself rather than letting
+the bind report it: listeners are bound with `SO_REUSEPORT`, so on Linux a
+second bind on the same address and port *succeeds* and the kernel then splits
+arriving connections between the two listeners, each capturing an effectively
+random half. A port held by a process outside the engine is still reported by
+the bind, with the "in use or unavailable" wording; `port: 0` is never refused
+this way, since the kernel does not hand out a port it is already using.
 
 **Response:**
 ```json
@@ -1487,7 +1497,10 @@ consent screens and multi-tenant realms are deliberate non-goals.
 }
 ```
 
-`port: 0` (the default) binds an ephemeral port. `clients` empty accepts **any**
+`port: 0` (the default) binds an ephemeral port; an explicit `port` another
+engine listener already holds is a `500` with code `mock_issuer_bind_failed`
+naming that listener, for the [same `SO_REUSEPORT`
+reason](#webhook-inbox) the inbox refuses one. `clients` empty accepts **any**
 client id; with clients configured, an id must be one of them and one carrying a
 secret must present it (Basic header or body - both RFC 6749 §2.3.1 placements).
 A field present with the wrong type or an out-of-range value is a `400`

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -99,6 +99,14 @@ join, release - through one shared `ManagedListener`
 one of three copies; what stays per-manager is the route registration, the error each bind failure
 answers with, and the OAuth attempt TTL sweep.
 
+That shared listener is also what keeps two of them off one port. Every live listener claims its
+address:port there, and an **explicitly requested** port a live listener already holds is refused
+before the bind, naming the holder. The bind cannot report it: cpp-httplib sets `SO_REUSEPORT`, so
+on Linux a second bind on the same `127.0.0.1:port` succeeds and the kernel load-balances arriving
+connections across both accept loops - two inboxes on one port, each capturing a random half of the
+webhooks and neither list showing the rest. An ephemeral request needs no check, since the kernel
+does not hand out a port it is already using.
+
 ### Event Loop (`curl_multi`)
 
 The event loop manages concurrent HTTP request execution using libcurl's multi interface.

--- a/engine/include/vayu/http/managed_listener.hpp
+++ b/engine/include/vayu/http/managed_listener.hpp
@@ -27,6 +27,13 @@ namespace vayu::http {
  * - **Bind before listening.** `bind_to_any_port` / `bind_to_port` report the
  *   failure a `listen()` on a taken port would only ever log, so the caller can
  *   answer its own error rather than leaving a thread spinning.
+ * - **Refuse a port another listener holds.** The bind cannot do it:
+ *   cpp-httplib sets `SO_REUSEPORT`, so on Linux a second bind on the same
+ *   `127.0.0.1:port` succeeds and the kernel then splits arriving connections
+ *   between the two accept loops - two inboxes, each capturing a random half of
+ *   the webhooks (issue #512). Every live listener therefore claims its
+ *   address:port here, and an explicitly requested port that is already claimed
+ *   is refused before the bind, naming the holder.
  * - **Return only once the accept loop is live.** `stop()` racing ahead of
  *   `listen()` is *missed* by cpp-httplib, and the `join()` that follows then
  *   hangs forever. `start()` therefore does not return until the server reports
@@ -63,20 +70,39 @@ class ManagedListener {
      */
     httplib::Server& server ();
 
-    /**
-     * Bind @p bind_address (@p port, or an ephemeral port when 0) and start
-     * accepting.
-     *
-     * @return the bound port, or 0 when the bind failed or this listener was
-     *         already started - nothing is running in either case, and the
-     *         caller owns the error it reports.
-     */
-    int start (const std::string& bind_address, int port = 0);
+    /// What `start()` did. Nothing is listening whenever `port` is 0, and the
+    /// caller owns the error it reports either way; `held_by` is what separates
+    /// the two reasons it can be 0 by the time a socket was tried.
+    struct StartOutcome {
+        /// The bound port, or 0 when nothing is listening.
+        int port = 0;
+        /// Names the listener already holding the requested address:port (e.g.
+        /// `"inbox inbox_2f1c"`) when that is why `port` is 0. Empty for every
+        /// other outcome, so a caller can tell a port this engine already holds
+        /// from a bind that failed for any other reason.
+        std::string held_by;
+    };
 
     /**
-     * Stop accepting, join the listener thread, release the server. Idempotent
-     * and safe on a listener that never started; returns only once no handler
-     * is still running, which can take as long as the slowest one.
+     * Bind @p bind_address (@p port, or an ephemeral port when 0) and start
+     * accepting, claiming the bound address:port for as long as this listener
+     * runs. @p owner_label names this listener in the refusal another manager
+     * gets when it asks for the same port.
+     *
+     * An explicitly requested port already claimed by a live listener is
+     * refused without touching a socket - see the class comment on
+     * `SO_REUSEPORT`. An ephemeral request is not checked: the kernel does not
+     * hand out a port it is already using.
+     */
+    StartOutcome start (const std::string& bind_address,
+    int port                       = 0,
+    const std::string& owner_label = {});
+
+    /**
+     * Stop accepting, join the listener thread, release the server and the port
+     * claim. Idempotent and safe on a listener that never started; returns only
+     * once no handler is still running, which can take as long as the slowest
+     * one - and once the port is claimable again.
      */
     void stop ();
 

--- a/engine/src/http/managed_listener.cpp
+++ b/engine/src/http/managed_listener.cpp
@@ -13,8 +13,11 @@
 
 #include "vayu/http/managed_listener.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <mutex>
 #include <stdexcept>
+#include <vector>
 
 namespace vayu::http {
 
@@ -24,6 +27,30 @@ namespace {
 /// live in well under a millisecond; the bound only matters so a pathological
 /// scheduler cannot hang a route handler indefinitely.
 constexpr int kListenSpinAttempts = 200;
+
+/// One live listener's hold on an address:port.
+struct PortClaim {
+    /// Identity, not ownership: the claim is released by `stop()` before the
+    /// listener is destroyed, so this pointer is never dereferenced.
+    const ManagedListener* owner = nullptr;
+    std::string address;
+    int port = 0;
+    std::string label;
+};
+
+/// What every live listener in this process holds, so an explicitly requested
+/// port can be refused before the bind that would silently share it (#512).
+/// A handful of listeners run at once - the OAuth callback, at most eight mock
+/// issuers, the inboxes - so a linear scan is the whole data structure.
+struct ClaimRegistry {
+    std::mutex mutex;
+    std::vector<PortClaim> claims;
+};
+
+ClaimRegistry& registry () {
+    static ClaimRegistry instance;
+    return instance;
+}
 
 } // namespace
 
@@ -43,18 +70,40 @@ httplib::Server& ManagedListener::server () {
     return *server_;
 }
 
-int ManagedListener::start (const std::string& bind_address, int port) {
+ManagedListener::StartOutcome ManagedListener::start (const std::string& bind_address,
+int port,
+const std::string& owner_label) {
+    StartOutcome out;
     if (!server_ || listening_.load ()) {
-        return 0;
+        return out;
     }
 
-    // bind_to_any_port answers -1 on failure, bind_to_port a bool; both become
-    // 0 here so every caller has one "nothing is listening" check.
-    const int bound = port > 0 ?
-    (server_->bind_to_port (bind_address, port) ? port : 0) :
-    server_->bind_to_any_port (bind_address);
-    if (bound <= 0) {
-        return 0;
+    int bound = 0;
+    {
+        // Held across the bind, not just the scan: the managers start listeners
+        // under their own separate locks, so a check released before binding
+        // would let two of them claim one port anyway.
+        std::lock_guard<std::mutex> lock (registry ().mutex);
+        if (port > 0) {
+            const auto& claims = registry ().claims;
+            const auto held    = std::find_if (
+            claims.begin (), claims.end (), [&] (const PortClaim& claim) {
+                return claim.port == port && claim.address == bind_address;
+            });
+            if (held != claims.end ()) {
+                out.held_by = held->label.empty () ? "another listener" : held->label;
+                return out;
+            }
+        }
+
+        // bind_to_any_port answers -1 on failure, bind_to_port a bool; both
+        // become 0 here so every caller has one "nothing is listening" check.
+        bound = port > 0 ? (server_->bind_to_port (bind_address, port) ? port : 0) :
+                           server_->bind_to_any_port (bind_address);
+        if (bound <= 0) {
+            return out;
+        }
+        registry ().claims.push_back (PortClaim{ this, bind_address, bound, owner_label });
     }
 
     httplib::Server* svr = server_.get ();
@@ -65,7 +114,8 @@ int ManagedListener::start (const std::string& bind_address, int port) {
     for (int i = 0; i < kListenSpinAttempts && !svr->is_running (); ++i) {
         std::this_thread::sleep_for (std::chrono::milliseconds (1));
     }
-    return bound;
+    out.port = bound;
+    return out;
 }
 
 void ManagedListener::stop () {
@@ -80,6 +130,14 @@ void ManagedListener::stop () {
     }
     server_.reset ();
     listening_.store (false);
+
+    // Released only after the socket is gone, so the next listener that asks
+    // for this port gets a bind that can actually succeed.
+    std::lock_guard<std::mutex> lock (registry ().mutex);
+    auto& claims = registry ().claims;
+    claims.erase (std::remove_if (claims.begin (), claims.end (),
+                  [this] (const PortClaim& claim) { return claim.owner == this; }),
+    claims.end ());
 }
 
 bool ManagedListener::is_listening () const {

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -466,17 +466,20 @@ InboxManager::start (vayu::db::Database& db, const InboxStartRequest& request) {
     svr.Delete (".*", capture);
     svr.Options (".*", capture);
 
-    const int bound = inbox->listener.start (request.bind, request.port);
-    if (bound <= 0) {
+    const auto started =
+    inbox->listener.start (request.bind, request.port, "inbox " + inbox->id);
+    if (started.port <= 0) {
+        const std::string where = request.bind + ":" +
+        (request.port > 0 ? std::to_string (request.port) : std::string ("(any)"));
         out.ok            = false;
         out.http_status   = 409;
         out.error_code    = "inbox_bind_failed";
-        out.error_message = "Could not bind " + request.bind + ":" +
-        (request.port > 0 ? std::to_string (request.port) : std::string ("(any)")) +
-        " - the address may be in use or unavailable";
+        out.error_message = started.held_by.empty () ?
+        "Could not bind " + where + " - the address may be in use or unavailable" :
+        "Could not bind " + where + " - " + started.held_by + " is already listening there";
         return out;
     }
-    inbox->port = bound;
+    inbox->port = started.port;
 
     {
         std::lock_guard<std::mutex> lock (mutex_);

--- a/engine/src/http/routes/mock_issuer.cpp
+++ b/engine/src/http/routes/mock_issuer.cpp
@@ -668,18 +668,26 @@ MockIssuerStart MockIssuerManager::start (const nlohmann::json& body) {
 
     // 127.0.0.1 only, never configurable: the issuer mints bearer tokens and
     // the engine has no route auth, so a wider bind would hand them to the LAN.
-    const int port = issuer->listener.start ("127.0.0.1", issuer->settings.port);
-    if (port <= 0) {
-        out.ok            = false;
-        out.http_status   = 500;
-        out.error_code    = "mock_issuer_bind_failed";
-        out.error_message = issuer->settings.port == 0 ?
-        "Could not bind a local port for the mock issuer" :
+    const auto started = issuer->listener.start (
+    "127.0.0.1", issuer->settings.port, "mock issuer " + issuer->id);
+    if (started.port <= 0) {
+        const std::string requested =
         "Could not bind 127.0.0.1:" + std::to_string (issuer->settings.port);
+        out.ok          = false;
+        out.http_status = 500;
+        out.error_code  = "mock_issuer_bind_failed";
+        if (!started.held_by.empty ()) {
+            out.error_message =
+            requested + " - " + started.held_by + " is already listening there";
+        } else {
+            out.error_message = issuer->settings.port == 0 ?
+            "Could not bind a local port for the mock issuer" :
+            requested;
+        }
         return out;
     }
-    issuer->port       = port;
-    issuer->issuer_url = "http://127.0.0.1:" + std::to_string (port);
+    issuer->port       = started.port;
+    issuer->issuer_url = "http://127.0.0.1:" + std::to_string (started.port);
 
     out.issuer_id     = issuer->id;
     out.issuer_url    = issuer->issuer_url;

--- a/engine/src/http/routes/oauth_authorize.cpp
+++ b/engine/src/http/routes/oauth_authorize.cpp
@@ -240,7 +240,10 @@ const nlohmann::json& config, const std::string& mode) {
             res.set_content (body, "text/html");
         });
 
-        const int port = attempt->listener.start ("127.0.0.1");
+        // Ephemeral only, so the port guard never refuses this one; the label
+        // is what another listener asking for this port would be told.
+        const int port =
+        attempt->listener.start ("127.0.0.1", 0, "OAuth callback " + attempt_id).port;
         if (port <= 0) {
             out.ok            = false;
             out.http_status   = 500;

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -330,6 +330,39 @@ TEST_F (InboxListenerTest, StopFreesTheListenerAndKeepsTheHistory) {
     << "a stopped inbox must refuse further connections";
 }
 
+TEST_F (InboxListenerTest, ASecondInboxCannotShareARunningInboxsPort) {
+    // Without the listener's port guard this second start succeeds on Linux -
+    // cpp-httplib binds with SO_REUSEPORT - and the kernel then splits the
+    // webhooks between the two inboxes, each list silently missing half (#512).
+    auto first = start ();
+
+    InboxStartRequest contender;
+    contender.port     = first.info.port;
+    const auto refused = manager_->start (*db_, contender);
+    EXPECT_FALSE (refused.ok);
+    EXPECT_EQ (refused.http_status, 409);
+    EXPECT_EQ (refused.error_code, "inbox_bind_failed");
+    EXPECT_NE (refused.error_message.find (first.info.inbox_id), std::string::npos)
+    << "the refusal must name the holder: " << refused.error_message;
+    EXPECT_EQ (manager_->list ().size (), 1u)
+    << "a refused start left a record";
+
+    // Nothing was split away: every request sent to that port is in the one
+    // inbox that owns it.
+    auto client = client_for (first.info);
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_TRUE (client.Post ("/hook", "{}", "application/json")) << i;
+    }
+    EXPECT_EQ (db_->count_inbox_requests (first.info.inbox_id), 8);
+
+    // The claim lasts exactly as long as the listener: once it stops, the same
+    // explicit port starts a new inbox.
+    ASSERT_TRUE (manager_->stop (first.info.inbox_id));
+    const auto reused = manager_->start (*db_, contender);
+    EXPECT_TRUE (reused.ok) << reused.error_message;
+    EXPECT_EQ (reused.info.port, first.info.port);
+}
+
 TEST_F (InboxListenerTest, TearsDownCleanlyWithAListenerStillRunning) {
     auto started = start ();
     auto client  = client_for (started.info);

--- a/engine/tests/managed_listener_test.cpp
+++ b/engine/tests/managed_listener_test.cpp
@@ -27,7 +27,7 @@ TEST (ManagedListener, StartsAcceptingOnAnEphemeralPort) {
         res.set_content ("pong", "text/plain");
     });
 
-    const int port = listener.start ("127.0.0.1");
+    const int port = listener.start ("127.0.0.1").port;
     ASSERT_GT (port, 0);
     EXPECT_TRUE (listener.is_listening ());
 
@@ -40,30 +40,94 @@ TEST (ManagedListener, StartsAcceptingOnAnEphemeralPort) {
 
 TEST (ManagedListener, StartReturnsTheRequestedPortWhenOneIsAsked) {
     ManagedListener first;
-    const int port = first.start ("127.0.0.1");
+    const int port = first.start ("127.0.0.1").port;
     ASSERT_GT (port, 0);
     first.stop ();
 
-    // The port is free again, so an explicit request for it is honoured
-    // verbatim - the mock issuer's `port` setting rides on this.
+    // The port is free again - and the claim stop() released with it - so an
+    // explicit request for it is honoured verbatim; the mock issuer's `port`
+    // setting rides on this.
     ManagedListener second;
-    EXPECT_EQ (second.start ("127.0.0.1", port), port);
+    const auto outcome = second.start ("127.0.0.1", port);
+    EXPECT_EQ (outcome.port, port);
+    EXPECT_EQ (outcome.held_by, "");
 }
 
 TEST (ManagedListener, ABindFailureStartsNothingAndReportsZero) {
     // TEST-NET-3 (RFC 5737): documentation-only, so it is never an address this
     // host holds and the bind fails the same way on all three platforms. A
-    // port already in use is *not* the case to pin here - cpp-httplib binds
-    // with SO_REUSEPORT, so a second listener on the same port succeeds on
-    // Linux.
+    // port already in use is a *different* outcome - see the port-guard tests
+    // below - because cpp-httplib binds with SO_REUSEPORT and the kernel would
+    // otherwise accept the second bind on Linux.
     ManagedListener contender;
-    EXPECT_EQ (contender.start ("203.0.113.9"), 0);
+    const auto outcome = contender.start ("203.0.113.9");
+    EXPECT_EQ (outcome.port, 0);
+    EXPECT_EQ (outcome.held_by, "") << "no listener holds this address";
     EXPECT_FALSE (contender.is_listening ());
     // Nothing was started, so the caller's own error path is the only outcome -
     // and stopping the failed listener must not hang on a thread that is not
     // there.
     contender.stop ();
     EXPECT_FALSE (contender.is_listening ());
+}
+
+TEST (ManagedListener, AnExplicitPortAnotherListenerHoldsIsRefusedAndNamesTheHolder) {
+    // The bug this guard exists for (#512): without it the second bind succeeds
+    // on Linux and the kernel splits arriving connections between the two
+    // accept loops, so each listener answers a random half of the traffic.
+    ManagedListener holder;
+    holder.server ().Get ("/who", [] (const httplib::Request&, httplib::Response& res) {
+        res.set_content ("holder", "text/plain");
+    });
+    const int port = holder.start ("127.0.0.1", 0, "inbox inbox_first").port;
+    ASSERT_GT (port, 0);
+
+    ManagedListener contender;
+    contender.server ().Get ("/who", [] (const httplib::Request&, httplib::Response& res) {
+        res.set_content ("contender", "text/plain");
+    });
+    const auto refused = contender.start ("127.0.0.1", port, "inbox inbox_second");
+    EXPECT_EQ (refused.port, 0);
+    EXPECT_EQ (refused.held_by, "inbox inbox_first");
+    EXPECT_FALSE (contender.is_listening ());
+
+    // The holder still answers everything sent to the port - the split is what
+    // makes the missing captures invisible, so pin that it did not happen.
+    httplib::Client client ("127.0.0.1", port);
+    for (int i = 0; i < 8; ++i) {
+        auto response = client.Get ("/who");
+        ASSERT_TRUE (response) << "request " << i << " reached nothing";
+        EXPECT_EQ (response->body, "holder") << "request " << i << " was split away";
+    }
+}
+
+TEST (ManagedListener, ThePortGuardSpansListenerFamilies) {
+    // The two managers that accept an explicit port are separate objects with
+    // separate locks, so the claim has to be process-wide rather than per
+    // manager - an issuer must not land on an inbox's port either.
+    ManagedListener inbox;
+    const int port = inbox.start ("127.0.0.1", 0, "inbox inbox_x").port;
+    ASSERT_GT (port, 0);
+
+    ManagedListener issuer;
+    EXPECT_EQ (issuer.start ("127.0.0.1", port, "mock issuer issuer_y").held_by, "inbox inbox_x");
+
+    // And the claim goes away with its listener, not with the process.
+    inbox.stop ();
+    ManagedListener later;
+    EXPECT_EQ (later.start ("127.0.0.1", port, "inbox inbox_z").port, port);
+}
+
+TEST (ManagedListener, AnUnlabelledHolderIsStillNamedSomething) {
+    // Nothing in the engine starts a listener without a label, but a caller
+    // that forgets one must not produce "Could not bind ... -  is already
+    // listening there".
+    ManagedListener holder;
+    const int port = holder.start ("127.0.0.1").port;
+    ASSERT_GT (port, 0);
+
+    ManagedListener contender;
+    EXPECT_EQ (contender.start ("127.0.0.1", port, "inbox inbox_b").held_by, "another listener");
 }
 
 TEST (ManagedListener, StopJoinsAHandlerThatIsStillRunning) {
@@ -81,7 +145,7 @@ TEST (ManagedListener, StopJoinsAHandlerThatIsStillRunning) {
         res.set_content ("done", "text/plain");
     });
 
-    const int port = listener.start ("127.0.0.1");
+    const int port = listener.start ("127.0.0.1").port;
     ASSERT_GT (port, 0);
 
     std::thread caller ([port] {
@@ -112,7 +176,7 @@ TEST (ManagedListener, StopIsIdempotentAndSafeWithoutAStart) {
     EXPECT_FALSE (never_started.is_listening ());
 
     ManagedListener started;
-    ASSERT_GT (started.start ("127.0.0.1"), 0);
+    ASSERT_GT (started.start ("127.0.0.1").port, 0);
     started.stop ();
     started.stop ();
     EXPECT_FALSE (started.is_listening ());
@@ -122,18 +186,18 @@ TEST (ManagedListener, RegisteringARouteAfterStopFailsLoudly) {
     // A route registered on a released listener would silently never be served;
     // saying so at the call site is the only way a caller can learn of it.
     ManagedListener listener;
-    ASSERT_GT (listener.start ("127.0.0.1"), 0);
+    ASSERT_GT (listener.start ("127.0.0.1").port, 0);
     listener.stop ();
     EXPECT_THROW (listener.server (), std::logic_error);
 }
 
 TEST (ManagedListener, StartingATwiceStartedListenerRefusesRatherThanLeaking) {
     ManagedListener listener;
-    const int port = listener.start ("127.0.0.1");
+    const int port = listener.start ("127.0.0.1").port;
     ASSERT_GT (port, 0);
     // A second start would overwrite the thread handle and leak the first
     // accept loop; it reports "nothing started" instead.
-    EXPECT_EQ (listener.start ("127.0.0.1"), 0);
+    EXPECT_EQ (listener.start ("127.0.0.1").port, 0);
     EXPECT_TRUE (listener.is_listening ());
 
     httplib::Client client ("127.0.0.1", port);

--- a/engine/tests/mock_issuer_test.cpp
+++ b/engine/tests/mock_issuer_test.cpp
@@ -513,6 +513,32 @@ TEST_F (MockIssuerTest, UpdateAndStopReportUnknownIds) {
     EXPECT_FALSE (mgr.update ("issuer_nope", json{ { "failureMode", "none" } }).found);
 }
 
+TEST_F (MockIssuerTest, ASecondIssuerCannotShareARunningIssuersPort) {
+    // SO_REUSEPORT makes the bind itself succeed on Linux, so without the
+    // listener's port guard both issuers would run on one port and the kernel
+    // would hand each of them a random half of the token requests (#512).
+    MockIssuerManager mgr;
+    const auto first = mgr.start (json::object ());
+    ASSERT_TRUE (first.ok) << first.error_message;
+    const int port = mgr.list ()["issuers"][0]["port"].get<int> ();
+
+    const auto refused = mgr.start (json{ { "port", port } });
+    EXPECT_FALSE (refused.ok);
+    EXPECT_EQ (refused.http_status, 500);
+    EXPECT_EQ (refused.error_code, "mock_issuer_bind_failed");
+    EXPECT_NE (refused.error_message.find (first.issuer_id), std::string::npos)
+    << "the refusal must name the holder: " << refused.error_message;
+    EXPECT_EQ (mgr.list ()["issuers"].size (), 1u)
+    << "a refused start left a record";
+
+    // An explicitly requested port that is genuinely free still starts: the
+    // guard holds the port only while its issuer runs.
+    ASSERT_TRUE (mgr.stop (first.issuer_id));
+    const auto restarted = mgr.start (json{ { "port", port } });
+    EXPECT_TRUE (restarted.ok) << restarted.error_message;
+    EXPECT_EQ (mgr.list ()["issuers"][0]["port"].get<int> (), port);
+}
+
 TEST_F (MockIssuerTest, RefusesMoreIssuersThanTheBudget) {
     MockIssuerManager mgr;
     for (size_t i = 0; i < vayu::core::constants::mock_issuer::MAX_ISSUERS; ++i) {


### PR DESCRIPTION
## Description

`POST /inbox/start` with an explicit `port` a running inbox already held answered `200` on Linux instead of `409 inbox_bind_failed`. cpp-httplib binds with `SO_REUSEPORT`, so the second `bind()` on the same `127.0.0.1:port` succeeds and the kernel then load-balances arriving connections across both accept loops - two inboxes on one port, each capturing an effectively random half of the webhooks, with neither list showing the rest. The mock issuer's explicit `port` had the same unreachable `mock_issuer_bind_failed` arm.

**Plan.** Root cause: the refusal was expected from the bind, and the bind cannot give it - the socket option makes the second bind legal, and the damage (a silent traffic split) is worse than the refused start the code intended. The fix is option 1 from the issue: the check becomes the manager's, and since all three managers now run on `ManagedListener` (#505 / #511), it lives there once. Every live listener claims its `address:port` in a process-wide registry; an **explicitly requested** port a live listener already holds is refused before any socket is touched, and `StartOutcome::held_by` carries the holder's label so each route can name it in its own existing error shape. The claim is taken under one lock **held across the bind** - the managers start listeners under their own separate locks, so a check released before binding would let two of them through anyway - and released by `stop()` once the socket is gone, so an immediate rebind after stop still works. Ephemeral requests are not checked: the kernel does not hand out a port it is already using.

Rejected alternative: turning `SO_REUSEPORT` off via cpp-httplib's `set_socket_options` hook (option 2). It would make the existing error path real for *any* holder, engine-owned or not, but it changes the socket semantics of every managed listener at once - including the immediate-rebind-after-stop behaviour several tests rely on - to fix a case that in practice is two of the engine's own listeners. A port held by a process outside the engine is still reported by the bind, with the unchanged "in use or unavailable" wording.

Blast radius checked: `ManagedListener::start` has exactly three callers (inbox, mock issuer, OAuth callback). The return type changed from `int` to `StartOutcome`, so all three were updated; the OAuth callback is ephemeral-only and so is never refused, but now passes a label, since it is a holder another listener can collide with. `held_by` is read by both routes that can produce it - no field written and never read. No renderer change: the renderer starts inboxes with `port: 0` and surfaces the engine's message verbatim in its error toast, so the new sentence reads correctly there as-is.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1422/1422 passed**, 0 failed (177s). No pre-existing failures on this base.

New tests (5), all mutation-checked - with the guard's match forced to `false` and the engine rebuilt, all 5 fail and the pre-existing `StartReturnsTheRequestedPortWhenOneIsAsked` still passes:

- `ManagedListener.AnExplicitPortAnotherListenerHoldsIsRefusedAndNamesTheHolder` - the refusal names the holder, and 8 requests to that port all reach the first listener. Under the mutation the second listener starts and the requests split.
- `ManagedListener.ThePortGuardSpansListenerFamilies` - an issuer is refused an inbox's port, and the port is claimable again once the inbox stops.
- `ManagedListener.AnUnlabelledHolderIsStillNamedSomething` - an unlabelled holder reads as "another listener" rather than producing `- is already listening there`.
- `InboxListenerTest.ASecondInboxCannotShareARunningInboxsPort` - `409 inbox_bind_failed` naming the holder, no record left behind, all 8 webhooks land in the one inbox, and the port starts a new inbox after the holder stops. Under the mutation this is the bug verbatim: 5 of 8 captures arrive, 3 are split away.
- `MockIssuerTest.ASecondIssuerCannotShareARunningIssuersPort` - same shape for `500 mock_issuer_bind_failed`.

Docs: `mkdocs build --strict` passes. `clang-format` clean on every file that was clean before (`inbox.cpp` and `oauth_authorize.cpp` carry pre-existing violations and were not reformatted, per the repo rule).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #512

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvrQnjSRZxAAC1bz5JrZj2)_