### PR TITLE
fix(inbox): a transient SSE disconnect no longer permanently demotes Live to Running

### DIFF
--- a/app/src/modules/inbox/InboxView.test.tsx
+++ b/app/src/modules/inbox/InboxView.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the surface says when the live stream gives up (issue #506).
+ *
+ * The badge alone cannot carry this: a stream that died reads exactly like an
+ * inbox nobody has sent anything to yet, and the state is permanent until the
+ * tab is switched away and back. So a stream that is out of retries states
+ * itself and offers the way back.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Inbox } from "@/types";
+import type { InboxLiveState } from "./useInboxLive";
+
+const inbox: Inbox = {
+	inboxId: "inbox_a",
+	url: "http://127.0.0.1:4100/",
+	bind: "127.0.0.1",
+	port: 4100,
+	running: true,
+	loopback: true,
+	response: { status: 200, body: "", delayMs: 0, headers: {} },
+};
+
+const noop = { mutate: vi.fn(), isPending: false };
+
+vi.mock("@/queries", () => ({
+	useInboxesQuery: () => ({ data: [inbox], isError: false, error: null, refetch: vi.fn() }),
+	useInboxCapturesQuery: () => ({
+		data: {
+			data: [],
+			pagination: { total: 0, limit: 50, offset: 0, returned: 0, hasMore: false },
+		},
+	}),
+	useStartInboxMutation: () => noop,
+	useStopInboxMutation: () => noop,
+	useUpdateInboxResponseMutation: () => noop,
+	useClearInboxCapturesMutation: () => noop,
+}));
+
+const live: InboxLiveState = { watching: false, stopped: false, resume: vi.fn() };
+vi.mock("./useInboxLive", () => ({ useInboxLive: () => live }));
+
+const { default: InboxView } = await import("./index");
+
+beforeEach(() => {
+	live.watching = false;
+	live.stopped = false;
+	vi.clearAllMocks();
+});
+
+describe("InboxView live state", () => {
+	it("says nothing while the stream is healthy", () => {
+		live.watching = true;
+		render(<InboxView />);
+
+		expect(screen.getByText("Live")).toBeInTheDocument();
+		expect(screen.queryByText(/Live updates stopped/)).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Resume" })).not.toBeInTheDocument();
+	});
+
+	it("states a stream that gave up, and resumes it on request", () => {
+		live.stopped = true;
+		render(<InboxView />);
+
+		// The badge on its own would read "Running" - a listener with nothing
+		// arriving - which is exactly the silent demotion this callout replaces.
+		expect(screen.getByText("Running")).toBeInTheDocument();
+		expect(screen.getByText(/Live updates stopped/)).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Resume" }));
+		expect(live.resume).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/src/modules/inbox/index.tsx
+++ b/app/src/modules/inbox/index.tsx
@@ -20,9 +20,9 @@
  */
 
 import { useState } from "react";
-import { Copy, Inbox as InboxIcon, Play, Square, Trash2 } from "lucide-react";
+import { Copy, Inbox as InboxIcon, Play, RotateCw, Square, Trash2 } from "lucide-react";
 import { Badge, Button } from "@/components/ui";
-import { EmptyState, ErrorState } from "@/components/shared";
+import { Callout, EmptyState, ErrorState } from "@/components/shared";
 import {
 	useClearInboxCapturesMutation,
 	useInboxCapturesQuery,
@@ -93,7 +93,7 @@ export default function InboxView() {
 
 	const capturesQuery = useInboxCapturesQuery(inbox?.inboxId ?? null);
 	const captures = capturesQuery.data?.data ?? [];
-	const watching = useInboxLive(inbox?.inboxId ?? null, inbox?.running === true);
+	const live = useInboxLive(inbox?.inboxId ?? null, inbox?.running === true);
 
 	const selectedCapture = captures.find((c) => c.id === selectedCaptureId) ?? captures[0] ?? null;
 
@@ -187,7 +187,7 @@ export default function InboxView() {
 					</Badge>
 				)}
 				<Badge variant="outline">
-					{inbox.running ? (watching ? "Live" : "Running") : "Stopped"}
+					{inbox.running ? (live.watching ? "Live" : "Running") : "Stopped"}
 				</Badge>
 
 				<div className="ml-auto flex items-center gap-2">
@@ -227,6 +227,30 @@ export default function InboxView() {
 				pending={updateResponse.isPending}
 				onApply={applyResponse}
 			/>
+
+			{/*
+			 * The stream stopped, not the listener - the inbox is still
+			 * recording, this list has only stopped hearing about it. Saying so
+			 * is the whole point: the badge alone would read "Running" forever
+			 * and look like an inbox nothing is sending to (issue #506).
+			 */}
+			{live.stopped && (
+				<div className="px-3 pt-2">
+					<Callout
+						severity="warning"
+						title="Live updates stopped"
+						action={
+							<Button variant="outline" size="sm" onClick={live.resume}>
+								<RotateCw className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+								Resume
+							</Button>
+						}
+					>
+						the reconnects were refused. Captures are still being recorded and this list
+						will catch up on the ones it missed.
+					</Callout>
+				</div>
+			)}
 
 			<div className="flex min-h-0 flex-1">
 				<aside className="flex w-72 min-h-0 shrink-0 flex-col border-r border-border">

--- a/app/src/modules/inbox/useInboxLive.test.tsx
+++ b/app/src/modules/inbox/useInboxLive.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The inbox live stream owns its reconnect (issue #506).
+ *
+ * `EventSource` treats a non-200 as fatal and never retries it, and a reconnect
+ * landing inside the engine's dead-socket detection window meets a 409 from the
+ * previous stream's claim - so a single unlucky disconnect used to end the
+ * stream for the life of the tab with nothing said. These pin both halves of the
+ * fix: the stream comes back on its own, and when it cannot, it says so instead
+ * of leaving the badge on `Running`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { queryKeys } from "@/queries";
+import type { InboxCapturesResponse } from "@/types";
+import {
+	INBOX_LIVE_MAX_RETRIES,
+	INBOX_LIVE_RETRY_BASE_MS,
+	INBOX_LIVE_RETRY_MAX_MS,
+	inboxLiveRetryDelayMs,
+	useInboxLive,
+} from "./useInboxLive";
+
+/** Every source the hook opened, in order, with its callbacks reachable. */
+class MockEventSource {
+	static instances: MockEventSource[] = [];
+	onopen: (() => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onerror: (() => void) | null = null;
+	closed = false;
+
+	constructor(readonly url: string) {
+		MockEventSource.instances.push(this);
+	}
+
+	close() {
+		this.closed = true;
+	}
+}
+
+function sources() {
+	return MockEventSource.instances;
+}
+
+function latest() {
+	const all = sources();
+	expect(all.length).toBeGreaterThan(0);
+	return all[all.length - 1];
+}
+
+function makeClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+/** Fail the open stream and let its scheduled retry fire. */
+function dropAndWait() {
+	act(() => latest().onerror?.());
+	act(() => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 2));
+}
+
+beforeEach(() => {
+	MockEventSource.instances = [];
+	vi.stubGlobal("EventSource", MockEventSource);
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe("inboxLiveRetryDelayMs", () => {
+	it("clears the engine's default 250ms claim window on the first attempt", () => {
+		// The app cannot read `inboxLivePollIntervalMs`, so the first step has to
+		// outlast the default cadence on its own or the retry meets the same 409.
+		expect(inboxLiveRetryDelayMs(1, () => 0)).toBeGreaterThan(250);
+		expect(inboxLiveRetryDelayMs(1, () => 0)).toBe(INBOX_LIVE_RETRY_BASE_MS);
+	});
+
+	it("doubles up to the cap, and jitters within the step", () => {
+		expect(inboxLiveRetryDelayMs(3, () => 0)).toBe(INBOX_LIVE_RETRY_BASE_MS * 4);
+		expect(inboxLiveRetryDelayMs(20, () => 0)).toBe(INBOX_LIVE_RETRY_MAX_MS);
+		// Jitter only ever adds, so a delay never drops back inside the window
+		// the previous step was chosen to clear.
+		const jittered = inboxLiveRetryDelayMs(1, () => 1);
+		expect(jittered).toBeGreaterThan(INBOX_LIVE_RETRY_BASE_MS);
+		expect(jittered).toBe(INBOX_LIVE_RETRY_BASE_MS * 1.5);
+	});
+});
+
+describe("useInboxLive", () => {
+	it("reports Live only while a stream is open", () => {
+		const { result } = renderHook(() => useInboxLive("inbox_a", true), {
+			wrapper: wrapper(makeClient()),
+		});
+
+		expect(sources()).toHaveLength(1);
+		expect(result.current.watching).toBe(false);
+		act(() => latest().onopen?.());
+		expect(result.current.watching).toBe(true);
+		expect(result.current.stopped).toBe(false);
+	});
+
+	it("merges a streamed capture into the list the first fetch filled", () => {
+		const client = makeClient();
+		client.setQueryData<InboxCapturesResponse>(queryKeys.inbox.captures("inbox_a"), {
+			data: [],
+			pagination: { total: 0, limit: 50, offset: 0, returned: 0, hasMore: false },
+		});
+		renderHook(() => useInboxLive("inbox_a", true), { wrapper: wrapper(client) });
+
+		act(() =>
+			latest().onmessage?.(
+				new MessageEvent("message", {
+					lastEventId: "7",
+					data: JSON.stringify({
+						id: 7,
+						inboxId: "inbox_a",
+						method: "POST",
+						path: "/hook",
+					}),
+				})
+			)
+		);
+
+		const cached = client.getQueryData<InboxCapturesResponse>(
+			queryKeys.inbox.captures("inbox_a")
+		);
+		expect(cached?.data.map((c) => c.id)).toEqual([7]);
+	});
+
+	it("reconnects after a drop and comes back to Live", () => {
+		const { result } = renderHook(() => useInboxLive("inbox_a", true), {
+			wrapper: wrapper(makeClient()),
+		});
+		act(() => latest().onopen?.());
+
+		const dropped = latest();
+		dropAndWait();
+
+		// The dead source is closed rather than left to a browser retry that a
+		// 409 has already made fatal, and a fresh one takes its place.
+		expect(dropped.closed).toBe(true);
+		expect(sources()).toHaveLength(2);
+		expect(result.current.stopped).toBe(false);
+
+		act(() => latest().onopen?.());
+		expect(result.current.watching).toBe(true);
+	});
+
+	it("resumes from the last capture it saw, so the gap is not lost", () => {
+		renderHook(() => useInboxLive("inbox_a", true), { wrapper: wrapper(makeClient()) });
+		act(() => latest().onopen?.());
+		expect(latest().url).not.toContain("lastEventId");
+
+		act(() =>
+			latest().onmessage?.(
+				new MessageEvent("message", {
+					lastEventId: "12",
+					data: JSON.stringify({
+						id: 12,
+						inboxId: "inbox_a",
+						method: "GET",
+						path: "/hook",
+					}),
+				})
+			)
+		);
+		dropAndWait();
+
+		// A header is not settable on a fresh EventSource, so the resume point
+		// travels as the query parameter the engine reads on the same terms.
+		expect(latest().url).toContain("lastEventId=12");
+	});
+
+	it("gives up after a bounded number of refusals and offers a resume", () => {
+		const { result } = renderHook(() => useInboxLive("inbox_a", true), {
+			wrapper: wrapper(makeClient()),
+		});
+
+		// A persistent 409 never opens, so every attempt fails the same way.
+		for (let attempt = 0; attempt <= INBOX_LIVE_MAX_RETRIES; attempt++) {
+			dropAndWait();
+		}
+
+		expect(sources()).toHaveLength(INBOX_LIVE_MAX_RETRIES + 1);
+		expect(result.current.watching).toBe(false);
+		expect(result.current.stopped).toBe(true);
+
+		// And it stays given up on: no further source appears on its own.
+		act(() => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 10));
+		expect(sources()).toHaveLength(INBOX_LIVE_MAX_RETRIES + 1);
+
+		act(() => result.current.resume());
+		expect(sources()).toHaveLength(INBOX_LIVE_MAX_RETRIES + 2);
+		expect(result.current.stopped).toBe(false);
+		act(() => latest().onopen?.());
+		expect(result.current.watching).toBe(true);
+	});
+
+	it("cancels a scheduled retry on unmount", () => {
+		const { unmount } = renderHook(() => useInboxLive("inbox_a", true), {
+			wrapper: wrapper(makeClient()),
+		});
+		act(() => latest().onopen?.());
+		act(() => latest().onerror?.());
+
+		const openedBeforeUnmount = sources().length;
+		unmount();
+		act(() => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 10));
+
+		expect(sources()).toHaveLength(openedBeforeUnmount);
+	});
+
+	it("cancels a scheduled retry when the inbox changes, and starts the new one clean", () => {
+		const { result, rerender } = renderHook(
+			({ id }: { id: string }) => useInboxLive(id, true),
+			{ wrapper: wrapper(makeClient()), initialProps: { id: "inbox_a" } }
+		);
+		act(() => latest().onopen?.());
+		act(() =>
+			latest().onmessage?.(
+				new MessageEvent("message", {
+					lastEventId: "3",
+					data: JSON.stringify({
+						id: 3,
+						inboxId: "inbox_a",
+						method: "GET",
+						path: "/hook",
+					}),
+				})
+			)
+		);
+		act(() => latest().onerror?.());
+		const openedForA = sources().length;
+
+		rerender({ id: "inbox_b" });
+		act(() => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 10));
+
+		// One new source, for the new inbox - the old inbox's pending retry did
+		// not fire - and no resume point, since a capture id belongs to the
+		// inbox that recorded it.
+		expect(sources()).toHaveLength(openedForA + 1);
+		expect(latest().url).toContain("inbox_b");
+		expect(latest().url).not.toContain("lastEventId");
+		expect(result.current.watching).toBe(false);
+	});
+
+	it("opens nothing for a stopped inbox", () => {
+		const { result } = renderHook(() => useInboxLive("inbox_a", false), {
+			wrapper: wrapper(makeClient()),
+		});
+		expect(sources()).toHaveLength(0);
+		expect(result.current.watching).toBe(false);
+		expect(result.current.stopped).toBe(false);
+	});
+});

--- a/app/src/modules/inbox/useInboxLive.ts
+++ b/app/src/modules/inbox/useInboxLive.ts
@@ -20,7 +20,7 @@
  * would decide which of them was the truth.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { API_ENDPOINTS } from "@/config/api-endpoints";
 import { queryKeys } from "@/queries";
@@ -81,50 +81,168 @@ export function mergeCapture(
 	};
 }
 
+/** Reconnect attempts before the surface says so and waits to be told. */
+export const INBOX_LIVE_MAX_RETRIES = 5;
+/** First backoff step; each attempt doubles it, up to the cap. */
+export const INBOX_LIVE_RETRY_BASE_MS = 400;
+export const INBOX_LIVE_RETRY_MAX_MS = 5000;
+
 /**
- * Watch one inbox. Returns whether the stream is currently open, which is what
- * the surface badges - a listener that is running while nothing is watching it
- * is still capturing, and the two states are not the same.
+ * How long to wait before reconnect attempt @p attempt (1-based).
+ *
+ * The first step has to outlast the engine's dead-socket detection - the
+ * previous stream's claim is held until its poll loop notices, one
+ * `inboxLivePollIntervalMs` later - because a reconnect inside that window is
+ * refused with a 409. The app cannot read that setting, so the backoff doubles
+ * rather than guessing it: 400ms clears the 250ms default on the first attempt
+ * and a raised cadence is covered within two or three. Jitter keeps several
+ * watchers from retrying in lockstep.
  */
-export function useInboxLive(inboxId: string | null, enabled: boolean): boolean {
+export function inboxLiveRetryDelayMs(attempt: number, random: () => number = Math.random): number {
+	const step = Math.min(
+		INBOX_LIVE_RETRY_BASE_MS * 2 ** Math.max(0, attempt - 1),
+		INBOX_LIVE_RETRY_MAX_MS
+	);
+	return Math.round(step + random() * step * 0.5);
+}
+
+/** One subscription's stream state, stamped with the subscription it belongs to. */
+interface LiveStatus {
+	subscription: string;
+	open: boolean;
+	stopped: boolean;
+}
+
+/** Not yet open and not yet given up on - what every subscription starts as. */
+const FRESH: LiveStatus = { subscription: "", open: false, stopped: false };
+
+/** What the surface renders from {@link useInboxLive}. */
+export interface InboxLiveState {
+	/**
+	 * Whether the stream is open. A listener that is running while nothing is
+	 * watching it is still capturing, and the two states are not the same - the
+	 * badge tells them apart.
+	 */
+	watching: boolean;
+	/**
+	 * Set once the reconnects are spent. Captures are still being recorded; the
+	 * list has simply stopped hearing about them, which is worth saying out loud
+	 * rather than leaving the badge to read `Running` forever.
+	 */
+	stopped: boolean;
+	/** Re-subscribe now, resetting the retry budget. */
+	resume: () => void;
+}
+
+/**
+ * Watch one inbox.
+ *
+ * The retry is ours rather than the browser's (issue #506). `EventSource` treats
+ * any non-200 as fatal and never retries it, and a reconnect that lands inside
+ * the engine's dead-socket detection window meets a `409 inbox_live_in_use` from
+ * the claim the previous stream is still holding - so a single unlucky
+ * disconnect used to end the stream for the life of the tab, with nothing said.
+ *
+ * `SSEClient` deliberately does *not* reconnect, but its reason does not apply
+ * here: a run's stream would replay its whole retained ring and clobber the live
+ * visuals, whereas an inbox resume is addressed by capture id and
+ * {@link mergeCapture} is idempotent on it, so at worst a resume re-delivers
+ * rows the list already has.
+ */
+export function useInboxLive(inboxId: string | null, enabled: boolean): InboxLiveState {
 	const queryClient = useQueryClient();
-	// Only the EventSource's own callbacks write this; whether a stream should
-	// exist at all is derived below, so switching inboxes needs no setState of
-	// its own.
-	const [streamOpen, setStreamOpen] = useState(false);
+	// Bumping this re-runs the effect, which is what a manual resume is: the
+	// same subscription, from the same resume point, with a fresh budget.
+	const [resumeNonce, setResumeNonce] = useState(0);
+	// Which subscription the state below describes. A status left by an earlier
+	// one says nothing about this one, so it is discarded while rendering rather
+	// than reset by an effect - the reset would otherwise land a render late,
+	// showing the previous inbox's badge on the new one.
+	const subscription = `${inboxId ?? ""}:${resumeNonce}`;
+	// Only the EventSource's own callbacks write this.
+	const [status, setStatus] = useState<LiveStatus>(FRESH);
+	const current = status.subscription === subscription ? status : FRESH;
+
+	// Survives the effect re-running (a resume), and is discarded when the
+	// inbox changes - a capture id belongs to the inbox that recorded it.
+	const resumeFrom = useRef<{ inboxId: string | null; lastEventId: string }>({
+		inboxId: null,
+		lastEventId: "",
+	});
+
+	// The nonce alone clears the given-up state: it names a new subscription,
+	// and the old one's status stops being the one rendered.
+	const resume = useCallback(() => setResumeNonce((n) => n + 1), []);
 
 	useEffect(() => {
 		if (!inboxId || !enabled) {
 			return;
 		}
+		if (resumeFrom.current.inboxId !== inboxId) {
+			resumeFrom.current = { inboxId, lastEventId: "" };
+		}
 
-		const source = new EventSource(
-			`${API_ENDPOINTS.BASE_URL}${API_ENDPOINTS.INBOX_LIVE(inboxId)}`
-		);
-		source.onopen = () => setStreamOpen(true);
-		source.onmessage = (event) => {
-			let parsed: unknown;
-			try {
-				parsed = JSON.parse(event.data);
-			} catch {
-				return; // A frame this engine wrote always parses.
-			}
-			const capture = parseCaptureEvent(parsed);
-			if (!capture) return;
-			queryClient.setQueryData<InboxCapturesResponse>(
-				queryKeys.inbox.captures(inboxId),
-				(cached) => mergeCapture(cached, capture)
+		let source: EventSource | null = null;
+		let retryTimer: ReturnType<typeof setTimeout> | null = null;
+		let attempts = 0;
+		let cancelled = false;
+
+		const connect = () => {
+			// `Last-Event-ID` is a header the browser sets on its own reconnect
+			// and that no API lets us set on a fresh connection, so ours travels
+			// as a query parameter the engine reads on the same terms.
+			const { lastEventId } = resumeFrom.current;
+			const query = lastEventId ? `?lastEventId=${encodeURIComponent(lastEventId)}` : "";
+			source = new EventSource(
+				`${API_ENDPOINTS.BASE_URL}${API_ENDPOINTS.INBOX_LIVE(inboxId)}${query}`
 			);
-		};
-		source.onerror = () => {
-			// EventSource reconnects on its own with Last-Event-ID, which the
-			// engine honours - so this reports the gap rather than tearing the
-			// stream down. A closed source is terminal and stays reported.
-			setStreamOpen(false);
+			source.onopen = () => {
+				attempts = 0;
+				setStatus({ subscription, open: true, stopped: false });
+			};
+			source.onmessage = (event) => {
+				if (event.lastEventId) {
+					resumeFrom.current = { inboxId, lastEventId: event.lastEventId };
+				}
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(event.data);
+				} catch {
+					return; // A frame this engine wrote always parses.
+				}
+				const capture = parseCaptureEvent(parsed);
+				if (!capture) return;
+				queryClient.setQueryData<InboxCapturesResponse>(
+					queryKeys.inbox.captures(inboxId),
+					(cached) => mergeCapture(cached, capture)
+				);
+			};
+			source.onerror = () => {
+				const exhausted = !cancelled && attempts >= INBOX_LIVE_MAX_RETRIES;
+				setStatus({ subscription, open: false, stopped: exhausted });
+				// Closed rather than left to the browser: a 409 is fatal to it,
+				// and a source it has already given up on holds no retry of its
+				// own. Everything after this point is our reconnect.
+				source?.close();
+				source = null;
+				if (cancelled || exhausted) return;
+				attempts += 1;
+				retryTimer = setTimeout(connect, inboxLiveRetryDelayMs(attempts));
+			};
 		};
 
-		return () => source.close();
-	}, [inboxId, enabled, queryClient]);
+		connect();
 
-	return streamOpen && enabled && inboxId !== null;
+		return () => {
+			cancelled = true;
+			if (retryTimer !== null) clearTimeout(retryTimer);
+			source?.close();
+		};
+	}, [inboxId, enabled, queryClient, subscription]);
+
+	return {
+		watching: current.open && enabled && inboxId !== null,
+		stopped: current.stopped && enabled && inboxId !== null,
+		resume,
+	};
 }

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -424,6 +424,12 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
 - `useInboxLive.ts` - the SSE stream. New captures are merged into the same query cache
   `useInboxCapturesQuery` fills, not kept in a second list beside it - two lists would need
   reconciling on every clear, and whichever the detail pane read would decide which was true.
+  The reconnect is the hook's own, not the browser's: `EventSource` treats a non-200 as fatal,
+  and a reconnect landing inside the engine's dead-socket window meets a `409`, so a single
+  drop used to end the stream for the life of the tab. It retries with a jittered backoff,
+  resumes from the last capture id it saw (`?lastEventId=`, since no API sets a header on a
+  fresh connection), and once the retries are spent reports `stopped` so the surface can say
+  so and offer a Resume rather than leave the badge reading `Running`.
 - `utils.ts` - `captureUrl`, which rebuilds the absolute URL from the stored path and raw query.
 
 **One tab, not one per inbox.** An inbox is engine-process state with no id worth restoring into a

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1367,9 +1367,26 @@ list above and an SSE `id:` equal to the capture's `id`. A reconnect that sends
 `Last-Event-ID` resumes after that capture, so nothing is missed across a drop.
 The stream ends when the inbox is stopped.
 
+**`?lastEventId=<id>` is the same resume point as a query parameter**, for a
+client that reconnects by hand: browser `EventSource` sets `Last-Event-ID` only
+on its *own* retry and exposes no way to set a header on a fresh connection. The
+header wins when both are given, being the more recent of the two. A value that
+is not a non-negative capture id is refused with `400` and code
+`invalid_last_event_id` rather than resumed from the start, which would replay
+every retained capture as though it had just arrived.
+
 **One stream per inbox.** A second concurrent watcher is refused with `409` and
 code `inbox_live_in_use`: each SSE handler occupies a cpp-httplib pool thread
 for its whole life, so N watchers on one inbox is N parked threads.
+
+**A claim whose holder stopped writing is taken over, not refused.** A stream
+learns its socket died only when its next write fails, up to one
+`inboxLivePollIntervalMs` later, so a client reconnecting inside that window used
+to meet a `409` it could not recover from. A holder that has not written
+successfully for two poll intervals (at least 100ms) is not writing, and its slot
+goes to the newcomer; the evicted stream ends on its next write. Every live
+stream writes at least a keep-alive each interval, so a genuinely live watcher is
+never evicted and a second concurrent one is still refused.
 
 ## Authentication
 

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -508,6 +508,15 @@ constexpr int LIVE_POLL_INTERVAL_MS = 250;
 constexpr int MIN_LIVE_POLL_INTERVAL_MS = 25;
 constexpr int MAX_LIVE_POLL_INTERVAL_MS = 5000;
 
+/// How many poll intervals a live stream may go without a successful write
+/// before its claim is considered dead and a reconnect may take it over. A
+/// healthy stream writes at least a keep-alive every interval, so two elapsed
+/// intervals means it is not writing - see InboxManager::try_claim_live.
+constexpr int LIVE_CLAIM_STALE_INTERVALS = 2;
+/// Floor under that window, so a 25ms cadence does not make ordinary scheduler
+/// jitter look like a dead holder.
+constexpr int MIN_LIVE_CLAIM_STALE_MS = 100;
+
 /// Transport limit on one inbound request. Past this the listener answers 413
 /// and records nothing - a payload this size is not a webhook. A rail rather
 /// than a setting: it bounds what an unauthenticated *remote* caller can make

--- a/engine/include/vayu/http/inbox.hpp
+++ b/engine/include/vayu/http/inbox.hpp
@@ -10,6 +10,7 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/db/database.hpp"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -125,11 +126,39 @@ std::optional<InboxParseError> parse_inbox_response_update (const nlohmann::json
 const InboxCannedResponse& current,
 InboxCannedResponse& out);
 
+/**
+ * Resolve where `GET /inbox/:id/live` resumes from.
+ *
+ * @p header_value is `Last-Event-ID`, which the browser sets on its own
+ * reconnect; @p param_value is `?lastEventId=`, which is how a client owning
+ * its retry says the same thing - `EventSource` cannot set a header on a fresh
+ * connection, and a 409 is fatal to it, so the app reconnects by hand (#506).
+ * The header wins when both are present, being the more recent of the two.
+ * Either may be empty, meaning absent: resume from the start.
+ *
+ * A present-but-unreadable value is an error rather than a silent 0. The engine
+ * only ever emits non-negative integer ids, so anything else is a caller's bug,
+ * and resuming from the start would replay every retained capture as though it
+ * had just arrived.
+ */
+std::optional<InboxParseError> parse_live_resume_point (const std::string& header_value,
+const std::string& param_value,
+int64_t& out);
+
 /** The wire shape of an inbox, shared by start, list and update. */
 nlohmann::json inbox_info_json (const InboxInfo& info);
 
 /** The wire shape of one capture, shared by the list and the live stream. */
 nlohmann::json inbox_capture_json (const vayu::db::InboxRequest& capture);
+
+/**
+ * Identifies one live-stream claim on one inbox.
+ *
+ * Never zero and never reused, so a stream that was evicted while it was not
+ * writing cannot act on the claim that replaced it - see
+ * InboxManager::try_claim_live.
+ */
+using LiveClaim = std::uint64_t;
 
 /**
  * Owns the engine's webhook inbox listeners (issue #480).
@@ -186,17 +215,46 @@ class InboxManager {
      *
      * Each SSE stream occupies one cpp-httplib pool thread for as long as it is
      * open (the server uses the default task queue), so an unbounded number of
-     * watchers on one inbox is an unbounded number of parked threads. Returns
-     * false when the inbox does not exist or is already watched; the caller
-     * must `release_live` whatever it claimed.
+     * watchers on one inbox is an unbounded number of parked threads.
+     *
+     * A claim held by a **provably dead** stream is taken over rather than
+     * refused (issue #506): the holder only notices its socket died when the
+     * next write fails, up to one poll interval later, so a client reconnecting
+     * inside that window used to meet a 409 - which `EventSource` treats as
+     * fatal, killing the stream for good. A holder that has not written
+     * successfully for `LIVE_CLAIM_STALE_INTERVALS` poll intervals is not
+     * writing, so its slot is given to the newcomer. Every live holder writes
+     * at least a keep-alive each interval, so a genuinely live stream is never
+     * evicted and a second concurrent watcher is still refused.
+     *
+     * Returns the claim, or nullopt when the inbox does not exist or is watched
+     * by a live stream. The claim identifies *which* claim the caller holds:
+     * an evicted holder passing its own token to `note_live_write` /
+     * `release_live` is a no-op there, so it can neither keep its successor's
+     * clock alive nor release its successor's slot.
      */
-    bool try_claim_live (const std::string& inbox_id);
-    void release_live (const std::string& inbox_id);
+    std::optional<LiveClaim> try_claim_live (const std::string& inbox_id);
+
+    /**
+     * Record that @p claim just wrote to its socket, and report whether it is
+     * still the holder.
+     *
+     * False means the claim was taken over while this stream was not writing -
+     * the caller must end its stream without releasing, since the slot now
+     * belongs to someone else.
+     */
+    bool note_live_write (const std::string& inbox_id, LiveClaim claim);
+
+    /// Release @p claim's slot. A no-op when @p claim is no longer the holder.
+    void release_live (const std::string& inbox_id, LiveClaim claim);
 
     private:
     struct Inbox;
     std::mutex mutex_;
     std::map<std::string, std::unique_ptr<Inbox>> inboxes_;
+    /// Source of claim tokens; monotonic so a token is never reused, and
+    /// therefore never mistaken for a later claim on the same inbox.
+    LiveClaim next_live_claim_ = 1;
 
     void teardown_locked (Inbox& inbox);
 };

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -24,7 +24,6 @@
 #include <httplib.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cctype>
 #include <charconv>
 #include <chrono>
@@ -312,6 +311,30 @@ nlohmann::json inbox_info_json (const InboxInfo& info) {
     return out;
 }
 
+std::optional<InboxParseError> parse_live_resume_point (const std::string& header_value,
+const std::string& param_value,
+int64_t& out) {
+    out = 0;
+    // The header is the browser's own reconnect and therefore the more recent
+    // of the two; an empty one is absent, not a resume point of "".
+    const std::string& value = header_value.empty () ? param_value : header_value;
+    const char* source = header_value.empty () ? "lastEventId" : "Last-Event-ID";
+    if (value.empty ()) {
+        return std::nullopt;
+    }
+
+    int64_t parsed_id = 0;
+    const char* begin = value.data ();
+    const char* end   = begin + value.size ();
+    const auto parsed = std::from_chars (begin, end, parsed_id);
+    if (parsed.ec != std::errc{} || parsed.ptr != end || parsed_id < 0) {
+        return InboxParseError{ 400, "invalid_last_event_id",
+            std::string (source) + " must be a non-negative capture id" };
+    }
+    out = parsed_id;
+    return std::nullopt;
+}
+
 nlohmann::json inbox_capture_json (const vayu::db::InboxRequest& capture) {
     nlohmann::json out;
     out["id"]         = capture.id;
@@ -344,8 +367,15 @@ struct InboxManager::Inbox {
     /// Resolved once at start and const thereafter, so every capture in one
     /// inbox was truncated and retained by the same rules.
     InboxLimits limits;
-    /// One live SSE stream per inbox; see InboxManager::try_claim_live.
-    std::atomic<bool> live_claimed{ false };
+    /// One live SSE stream per inbox; see InboxManager::try_claim_live. Both
+    /// fields are guarded by InboxManager::mutex_ - every accessor locks it -
+    /// and `live_claim == 0` means unclaimed.
+    LiveClaim live_claim = 0;
+    /// When the holder last wrote to its socket successfully. A holder writes
+    /// at least a keep-alive every poll interval, so a long gap here is the
+    /// only evidence available that its socket is gone: cpp-httplib reports
+    /// that only through the next failing write.
+    std::chrono::steady_clock::time_point live_last_write{};
 
     /// Guards `response` only. The capture handler takes this and never the
     /// manager's lock, so a teardown holding the manager lock can always join.
@@ -383,8 +413,8 @@ InboxManager::~InboxManager () {
 
 void InboxManager::teardown_locked (Inbox& inbox) {
     // A capture in its configured delay is still holding a listener thread, so
-    // the join inside stop() waits up to inbox::MAX_RESPONSE_DELAY_MS - which is
-    // why that bound exists.
+    // the join inside stop() waits up to inbox::MAX_RESPONSE_DELAY_MS - which
+    // is why that bound exists.
     inbox.listener.stop ();
 }
 
@@ -552,20 +582,54 @@ const InboxCannedResponse& response) {
     return it->second->info_locked ();
 }
 
-bool InboxManager::try_claim_live (const std::string& inbox_id) {
+namespace {
+
+/// How long a claim may go without a successful write before it is takeable.
+/// Two poll intervals, floored so that the shortest permitted cadence does not
+/// make ordinary scheduler jitter look like a dead stream.
+std::chrono::milliseconds live_claim_stale_after (const InboxLimits& limits) {
+    const int window = std::max (constants::inbox::MIN_LIVE_CLAIM_STALE_MS,
+    limits.live_poll_interval_ms * constants::inbox::LIVE_CLAIM_STALE_INTERVALS);
+    return std::chrono::milliseconds (window);
+}
+
+} // namespace
+
+std::optional<LiveClaim> InboxManager::try_claim_live (const std::string& inbox_id) {
     std::lock_guard<std::mutex> lock (mutex_);
     auto it = inboxes_.find (inbox_id);
     if (it == inboxes_.end ()) {
-        return false;
+        return std::nullopt;
     }
-    bool expected = false;
-    return it->second->live_claimed.compare_exchange_strong (expected, true);
+    Inbox& inbox = *it->second;
+    if (inbox.live_claim != 0) {
+        const auto since = std::chrono::steady_clock::now () - inbox.live_last_write;
+        if (since < live_claim_stale_after (inbox.limits)) {
+            return std::nullopt;
+        }
+        // Held by a stream that is not writing. Take it over rather than refuse:
+        // the refusal is what strands a reconnecting client (issue #506).
+    }
+    inbox.live_claim      = next_live_claim_++;
+    inbox.live_last_write = std::chrono::steady_clock::now ();
+    return inbox.live_claim;
 }
 
-void InboxManager::release_live (const std::string& inbox_id) {
+bool InboxManager::note_live_write (const std::string& inbox_id, LiveClaim claim) {
     std::lock_guard<std::mutex> lock (mutex_);
-    if (auto it = inboxes_.find (inbox_id); it != inboxes_.end ()) {
-        it->second->live_claimed.store (false);
+    auto it = inboxes_.find (inbox_id);
+    if (it == inboxes_.end () || it->second->live_claim != claim) {
+        return false;
+    }
+    it->second->live_last_write = std::chrono::steady_clock::now ();
+    return true;
+}
+
+void InboxManager::release_live (const std::string& inbox_id, LiveClaim claim) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    if (auto it = inboxes_.find (inbox_id);
+        it != inboxes_.end () && it->second->live_claim == claim) {
+        it->second->live_claim = 0;
     }
 }
 
@@ -814,9 +878,10 @@ void register_inbox_routes (RouteContext& ctx) {
     /**
      * GET /inbox/:id/live
      * One SSE event per capture, `id:` carrying the capture id so a reconnect
-     * resumes with `Last-Event-ID`. One stream per inbox: each holds a
-     * cpp-httplib pool thread for its whole life, so a second is a 409 rather
-     * than a quietly parked thread.
+     * resumes from where it left off. One stream per inbox: each holds a
+     * cpp-httplib pool thread for its whole life, so a second live watcher is a
+     * 409 rather than a quietly parked thread - but a claim whose holder has
+     * stopped writing is taken over instead of refused (issue #506).
      */
     ctx.server.Get (R"(/inbox/([^/]+)/live)",
     [&ctx] (const httplib::Request& req, httplib::Response& res) {
@@ -826,24 +891,25 @@ void register_inbox_routes (RouteContext& ctx) {
             return;
         }
         const auto limits = ctx.inbox_manager.limits (inbox_id).value_or (InboxLimits{});
-        if (!ctx.inbox_manager.try_claim_live (inbox_id)) {
+
+        int64_t last_id = 0;
+        if (auto error =
+            parse_live_resume_point (req.get_header_value ("Last-Event-ID"),
+            req.get_param_value ("lastEventId"), last_id)) {
+            send_error (res, error->http_status, error->message, error->code);
+            return;
+        }
+
+        const auto claim = ctx.inbox_manager.try_claim_live (inbox_id);
+        if (!claim) {
             send_error (res, 409,
             "This inbox is already being watched; close the other stream first",
             "inbox_live_in_use");
             return;
         }
 
-        int64_t last_id = 0;
-        if (req.has_header ("Last-Event-ID")) {
-            try {
-                last_id = std::stoll (req.get_header_value ("Last-Event-ID"));
-            } catch (...) {
-                last_id = 0;
-            }
-        }
-
         res.set_content_provider ("text/event-stream",
-        [&ctx, inbox_id, last_id, limits] (size_t, httplib::DataSink& sink) mutable {
+        [&ctx, inbox_id, last_id, limits, claim = *claim] (size_t, httplib::DataSink& sink) mutable {
             while (true) {
                 if (!sink.is_writable ()) {
                     break;
@@ -860,10 +926,17 @@ void register_inbox_routes (RouteContext& ctx) {
                     const std::string payload = "id: " + std::to_string (capture.id) +
                     "\ndata: " + inbox_capture_json (capture).dump () + "\n\n";
                     if (!sink.write (payload.data (), payload.size ())) {
-                        ctx.inbox_manager.release_live (inbox_id);
+                        ctx.inbox_manager.release_live (inbox_id, claim);
                         return false;
                     }
                     last_id = capture.id;
+                }
+                // A write that lands is the only evidence this socket is alive,
+                // and therefore what holds the claim. Losing it means a
+                // reconnect already took the slot over, so this stream ends
+                // without releasing what is no longer its own.
+                if (!fresh.empty () && !ctx.inbox_manager.note_live_write (inbox_id, claim)) {
+                    return false;
                 }
                 if (fresh.empty ()) {
                     // A stopped inbox captures nothing more, but the record and
@@ -875,14 +948,17 @@ void register_inbox_routes (RouteContext& ctx) {
                     }
                     const std::string keep_alive = ": keep-alive\n\n";
                     if (!sink.write (keep_alive.data (), keep_alive.size ())) {
-                        ctx.inbox_manager.release_live (inbox_id);
+                        ctx.inbox_manager.release_live (inbox_id, claim);
+                        return false;
+                    }
+                    if (!ctx.inbox_manager.note_live_write (inbox_id, claim)) {
                         return false;
                     }
                     std::this_thread::sleep_for (
                     std::chrono::milliseconds (limits.live_poll_interval_ms));
                 }
             }
-            ctx.inbox_manager.release_live (inbox_id);
+            ctx.inbox_manager.release_live (inbox_id, claim);
             return false;
         });
     });

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -172,6 +172,44 @@ TEST (InboxParseUpdate, AbsentFieldKeepsTheLiveValue) {
 }
 
 // ---------------------------------------------------------------------------
+// Where a live stream resumes from
+// ---------------------------------------------------------------------------
+
+TEST (InboxLiveResumePoint, AbsentMeansFromTheStartAndTheHeaderWinsOverTheParam) {
+    int64_t last_id = -1;
+    ASSERT_FALSE (vayu::http::parse_live_resume_point ("", "", last_id).has_value ());
+    EXPECT_EQ (last_id, 0);
+
+    // The query parameter is the app's own reconnect - EventSource cannot set a
+    // header on a fresh connection - and is read exactly like the header.
+    ASSERT_FALSE (vayu::http::parse_live_resume_point ("", "42", last_id).has_value ());
+    EXPECT_EQ (last_id, 42);
+
+    // The browser's reconnect header is the more recent of the two.
+    ASSERT_FALSE (vayu::http::parse_live_resume_point ("77", "42", last_id).has_value ());
+    EXPECT_EQ (last_id, 77);
+}
+
+TEST (InboxLiveResumePoint, RejectsAValueThatIsNotACaptureId) {
+    int64_t last_id = 0;
+    for (const char* bad : { "abc", "12x", "", "-1", " 7", "1.5" }) {
+        const std::string value = bad;
+        // Empty is absence, not a bad value - it is in this list to pin that.
+        const auto error = vayu::http::parse_live_resume_point ("", value, last_id);
+        if (value.empty ()) {
+            EXPECT_FALSE (error.has_value ());
+            continue;
+        }
+        ASSERT_TRUE (error.has_value ()) << bad;
+        EXPECT_EQ (error->http_status, 400) << bad;
+        EXPECT_EQ (error->code, "invalid_last_event_id") << bad;
+        // Silently resuming from 0 would replay every retained capture as
+        // though it had just arrived, which is what the loud failure prevents.
+        EXPECT_EQ (last_id, 0) << bad;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // A live listener
 // ---------------------------------------------------------------------------
 
@@ -374,13 +412,64 @@ TEST_F (InboxListenerTest, TearsDownCleanlyWithAListenerStillRunning) {
 }
 
 TEST_F (InboxListenerTest, OneLiveStreamPerInbox) {
-    auto started = start ();
-    EXPECT_TRUE (manager_->try_claim_live (started.info.inbox_id));
-    EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id))
+    auto started     = start ();
+    const auto claim = manager_->try_claim_live (started.info.inbox_id);
+    ASSERT_TRUE (claim.has_value ());
+    EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id).has_value ())
     << "a second watcher would park a second pool thread on the same inbox";
-    manager_->release_live (started.info.inbox_id);
-    EXPECT_TRUE (manager_->try_claim_live (started.info.inbox_id));
-    EXPECT_FALSE (manager_->try_claim_live ("inbox_nope"));
+    manager_->release_live (started.info.inbox_id, *claim);
+    const auto second = manager_->try_claim_live (started.info.inbox_id);
+    ASSERT_TRUE (second.has_value ());
+    EXPECT_NE (*second, *claim)
+    << "a reused token would let a stale holder act on it";
+    EXPECT_FALSE (manager_->try_claim_live ("inbox_nope").has_value ());
+}
+
+// A stream that keeps writing is live, whatever the wall clock says - the whole
+// point of the takeover window is that it never evicts one of these.
+TEST_F (InboxListenerTest, AWritingStreamKeepsItsClaimPastTheStaleWindow) {
+    // The default cadence, so the window under test (two intervals, 500ms) is
+    // an order of magnitude above the loop's own sleep - a scheduling hiccup
+    // must not read as a dead holder here or the test is flaky by design.
+    auto started     = start ();
+    const auto claim = manager_->try_claim_live (started.info.inbox_id);
+    ASSERT_TRUE (claim.has_value ());
+
+    const auto deadline = std::chrono::steady_clock::now () +
+    std::chrono::milliseconds (inbox_constants::LIVE_POLL_INTERVAL_MS * 4);
+    while (std::chrono::steady_clock::now () < deadline) {
+        ASSERT_TRUE (manager_->note_live_write (started.info.inbox_id, *claim));
+        EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id).has_value ())
+        << "a stream that is still writing was evicted";
+        std::this_thread::sleep_for (std::chrono::milliseconds (50));
+    }
+    EXPECT_TRUE (manager_->note_live_write (started.info.inbox_id, *claim));
+}
+
+// The #506 race: the browser reconnects before the previous stream's poll loop
+// has noticed its socket died, and the refusal is what strands it for good.
+TEST_F (InboxListenerTest, AReconnectTakesOverAClaimThatStoppedWriting) {
+    set_config ("inboxLivePollIntervalMs", inbox_constants::MIN_LIVE_POLL_INTERVAL_MS);
+    auto started    = start ();
+    const auto dead = manager_->try_claim_live (started.info.inbox_id);
+    ASSERT_TRUE (dead.has_value ());
+
+    // Immediately after the last write the holder is presumed alive.
+    EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id).has_value ());
+
+    std::this_thread::sleep_for (
+    std::chrono::milliseconds (inbox_constants::MIN_LIVE_CLAIM_STALE_MS + 50));
+    const auto reconnect = manager_->try_claim_live (started.info.inbox_id);
+    ASSERT_TRUE (reconnect.has_value ())
+    << "a reconnect met a 409 it cannot recover from";
+
+    // The evicted holder learns it lost the slot the next time it writes, and
+    // can neither keep the new claim's clock alive nor release it.
+    EXPECT_FALSE (manager_->note_live_write (started.info.inbox_id, *dead));
+    manager_->release_live (started.info.inbox_id, *dead);
+    EXPECT_FALSE (manager_->try_claim_live (started.info.inbox_id).has_value ())
+    << "the evicted holder released a slot that was no longer its own";
+    EXPECT_TRUE (manager_->note_live_write (started.info.inbox_id, *reconnect));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

**Plan.** Root cause: the engine's one-stream-per-inbox claim is released only when the holder's *next write* fails, up to one `inboxLivePollIntervalMs` later, so a browser reconnect inside that window lands a `409 inbox_live_in_use` - and `EventSource` treats any non-200 as fatal, never retrying. `useInboxLive`'s `onerror` kept the dead source and the effect's deps never re-ran, so the capture list (deliberately unpolled) stopped updating and the badge read `Running` forever. Verified still present at `bf005cd`. Both halves of the issue landed: the app owns its reconnect, and the engine hands a claim over when its holder is provably not writing. The alternative considered and rejected for the engine half was widening the one-stream invariant (allow N watchers, drop the claim): each SSE handler parks a cpp-httplib pool thread for its whole life, which is the reason the invariant exists - so the fix evicts only a holder that has gone two poll intervals without a successful write, and leaves the invariant intact for live ones.

**App** - `app/src/modules/inbox/useInboxLive.ts` closes the source on error and reconnects itself: jittered doubling backoff (`400ms` first, which clears the `250ms` default claim window without the app having to read the engine's cadence - a raised cadence is covered within two or three attempts), 5 attempts, then `stopped` and a "Live updates stopped" callout with a Resume in `modules/inbox/index.tsx`. The retry is cancelled on unmount and on an inbox switch, and a new inbox never inherits the previous one's badge or resume point. The hook now returns `{ watching, stopped, resume }` instead of a bare boolean; `index.tsx` is its only caller.

`SSEClient` was checked first and deliberately not reused: its documented no-reconnect decision is about a run stream replaying its whole retained ring and clobbering live visuals. That does not apply here - an inbox resume is addressed by capture id and `mergeCapture` is already idempotent on it, so at worst a resume re-delivers rows the list has.

**Engine** - `try_claim_live` returns a monotonic `LiveClaim` token instead of a bool, and takes over a claim whose holder has not written for `max(2 x pollInterval, 100ms)`. The token is what makes the takeover safe: an evicted holder passing its own token to `note_live_write` / `release_live` is a no-op there, so it can neither keep its successor's clock alive nor release its successor's slot - it learns it lost the slot on its next write and ends. A live holder writes at least a keep-alive every interval, so it is never evicted and a second concurrent watcher is still a 409.

`GET /inbox/:inboxId/live` also accepts `?lastEventId=`, since `EventSource` cannot set a header on a fresh connection - without it the acceptance criterion "no capture is lost across a resume" is unreachable from the renderer. The `Last-Event-ID` header still wins when both are present. Parsing moved into a testable core, `parse_live_resume_point`, and a present-but-unreadable value is now a `400 invalid_last_event_id` rather than a silent resume from 0, which would replay every retained capture as though it had just arrived. That tightens the existing header path, which swallowed a bad value; the engine only ever emits integer ids, so nothing legitimate sends one.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green at `a49dce0`.

- `python build.py -e -t && ctest --preset linux-dev --output-on-failure` - **1426 passed, 0 failed**. New: `AReconnectTakesOverAClaimThatStoppedWriting` (takeover, plus the evicted holder failing to release its successor), `AWritingStreamKeepsItsClaimPastTheStaleWindow` (a still-writing stream is never evicted - the other direction), and two `InboxLiveResumePoint` cases (header wins over param, absent means from the start, a non-id refused). `OneLiveStreamPerInbox` extended to pin that a token is never reused.
- `cd app && pnpm test` - **4037 passed** across 399 files; `pnpm type-check`, `pnpm lint`, `pnpm format:check` clean. New: `useInboxLive.test.tsx` (10 cases: reconnect-and-resume, resume point on the URL, bounded give-up then Resume, unmount cancels, inbox switch cancels and starts clean, backoff shape) and `InboxView.test.tsx` (the callout is absent while healthy, present with a working Resume when stopped).
- Mutation checks: removing the retry `setTimeout` fails 3 hook tests including the resume-affordance one; the takeover assertion only passes with the dead-claim branch present.
- One unrelated flake seen on the first run: `RunShutdownTest.ShutdownStopsAndJoinsAWorkerMidRun` segfaulted under parallel load, then passed 3/3 in isolation and in the full suite above. Untouched by this diff; not fixed or hidden here.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/api-reference.md` (the `?lastEventId=` parameter, the `400`, and the dead-claim replacement semantics on the 409 paragraph) and `docs/app/COMPONENTS.md` (the `useInboxLive.ts` entry now describes the owned reconnect).

## Related Issues
Closes #506


---
_Generated by [Claude Code](https://claude.ai/code/session_016X2SqKSVrtmMFwpG9SdD8e)_