### PR TITLE
feat(monitor): make the scrape budget a setting, not a derivation

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -462,6 +462,7 @@ on disk, one in memory:
 | `runRetentionDays`  | `30`      | 0–3650       | Delete runs older than this many days. `0` = unlimited. |
 | `monitorIntervalMs` | `1000`    | 250–60000    | Scrape cadence for a [`monitor` block](#the-monitor-block-server-vitals) that names no `intervalMs` of its own. Read per run, so a change applies to the next run started. The *bounds* on a block's own `intervalMs` are fixed at 250–60000 either way - they exist to stop a cadence that measures the scraper rather than the target. |
 | `monitorMaxSeries`  | `8`       | 1–64         | How many metric names one run may chart from its monitored endpoint. A longer `series` list is a `400`. Raising it past 4 repeats chart colours (the categorical palette has four line-legible hues). |
+| `monitorScrapeTimeoutMs` | `0`  | 0–60000      | How long one scrape may take before it counts as a gap. `0` derives it from the cadence in force for that run - three quarters of the interval. Set it explicitly for an exposition that is slow to render: one taking longer than three quarters of the interval fails *every* scrape otherwise, and the only other way out is a slower cadence, which also thins the data. A value longer than the interval a run scrapes at is shortened to it (logged once per run), because a scrape that outlives its own cadence puts the loop behind itself. |
 
 In-progress (`running`/`pending`) runs are never pruned, and neither are runs
 pinned as baselines (see
@@ -2029,12 +2030,19 @@ counted as a gap in the report's `monitor.failures`. A failing scrape never
 fails the run; after five consecutive failures the engine logs once and backs
 off to twice the configured interval until one succeeds.
 
-Two of the limits are settings rather than constants: `intervalMs` defaults to
-**`monitorIntervalMs`** when the block omits it, and the `series` ceiling is
-**`monitorMaxSeries`** (see [GET /config](#get-config)). Both are read per run,
-so a change applies to the next run started - no restart. The interval *bounds*
-are fixed, because a cadence below 250ms measures the scraper rather than the
-target and one above a minute records nothing on a short run.
+Three of the limits are settings rather than constants: `intervalMs` defaults to
+**`monitorIntervalMs`** when the block omits it, the `series` ceiling is
+**`monitorMaxSeries`**, and how long a single scrape may take is
+**`monitorScrapeTimeoutMs`** (see [GET /config](#get-config)). All three are read
+per run, so a change applies to the next run started - no restart. The interval
+*bounds* are fixed, because a cadence below 250ms measures the scraper rather
+than the target and one above a minute records nothing on a short run.
+
+The scrape budget has no field on the block: it is about the endpoint being
+scraped, which is the same one run after run, so it lives with the other engine
+settings. Left at its default of `0` it tracks the cadence at three quarters of
+it - raise it when a heavyweight `/metrics` renders too slowly for that, and the
+cadence stays where you set it.
 
 Loopback and private addresses are deliberately allowed: this is a local tool
 scraping the user's own infrastructure. An unusable block (no `url`, a

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -265,12 +265,12 @@ constexpr int64_t OAUTH2_REFRESH_POLL_INTERVAL_MS = 100;
 /**
  * @brief The server-vitals monitor a run may scrape alongside its own metrics.
  *
- * The two a user reaches for are config-backed (`monitorIntervalMs`,
- * `monitorMaxSeries`) and these are their seeds. The other three are rails
- * rather than preferences: the interval bounds exist to stop a cadence that
- * measures the scraper instead of the target, and the backoff threshold is how
- * politely the loop gives up on a dead endpoint - the same reason
- * `threshold_eval`'s budget ranges are constants.
+ * The three a user reaches for are config-backed (`monitorIntervalMs`,
+ * `monitorMaxSeries`, `monitorScrapeTimeoutMs`) and these are their seeds. The
+ * rest are rails rather than preferences: the interval bounds exist to stop a
+ * cadence that measures the scraper instead of the target, and the backoff
+ * threshold is how politely the loop gives up on a dead endpoint - the same
+ * reason `threshold_eval`'s budget ranges are constants.
  */
 namespace monitor {
 /// Floor on `monitor.intervalMs`. Below this the scrape's own latency is a
@@ -286,6 +286,13 @@ constexpr size_t MAX_SERIES = 8;
 /// Consecutive failed scrapes before the loop logs once and backs off. Below
 /// this a scrape failure is a gap in the series and nothing else.
 constexpr int FAILURES_BEFORE_BACKOFF = 5;
+/// `monitorScrapeTimeoutMs` seed. Zero is the sentinel for "derive from the
+/// interval", which is what keeps the timeout tracking a cadence the user
+/// changes later; see `resolve_scrape_timeout_ms`.
+constexpr int DEFAULT_SCRAPE_TIMEOUT_MS = 0;
+/// Floor the derivation never goes below, for an interval small enough that
+/// three quarters of it would time out before a loopback endpoint could answer.
+constexpr int MIN_DERIVED_SCRAPE_TIMEOUT_MS = 100;
 } // namespace monitor
 
 /**

--- a/engine/include/vayu/core/monitor.hpp
+++ b/engine/include/vayu/core/monitor.hpp
@@ -56,7 +56,7 @@ enum class MonitorFormat {
 namespace monitor_limits = constants::monitor;
 
 /**
- * @brief The two limits a user can move, resolved from engine config.
+ * @brief The three limits a user can move, resolved from engine config.
  *
  * Passed in rather than read here so the functions below stay pure over
  * arbitrary JSON and hold no `Database` - the same split
@@ -70,6 +70,9 @@ struct MonitorLimits {
     int default_interval_ms = monitor_limits::DEFAULT_INTERVAL_MS;
     /// How many metric names one run may chart (`monitorMaxSeries`).
     size_t max_series = monitor_limits::MAX_SERIES;
+    /// How long one scrape may take (`monitorScrapeTimeoutMs`), `0` meaning
+    /// "derive from the interval" - see `resolve_scrape_timeout_ms`.
+    int scrape_timeout_ms = monitor_limits::DEFAULT_SCRAPE_TIMEOUT_MS;
 };
 
 /** A validated monitor block, ready for the scrape loop. */
@@ -78,20 +81,45 @@ struct MonitorConfig {
     int interval_ms      = monitor_limits::DEFAULT_INTERVAL_MS;
     MonitorFormat format = MonitorFormat::Prometheus;
     std::vector<std::string> series;
+    /// The configured `monitorScrapeTimeoutMs`, carried unresolved so the loop
+    /// resolves it against the interval this block actually runs at. `0` is the
+    /// derive sentinel, which is why a default-constructed config scrapes on
+    /// exactly the timeout the loop used before the setting existed.
+    int scrape_timeout_ms = monitor_limits::DEFAULT_SCRAPE_TIMEOUT_MS;
 };
 
 /**
- * @brief Read the `monitorIntervalMs` / `monitorMaxSeries` settings, falling
- *        back to their compile-time seeds.
+ * @brief Read the `monitorIntervalMs` / `monitorMaxSeries` /
+ *        `monitorScrapeTimeoutMs` settings, falling back to their compile-time
+ *        seeds.
  *
- * One reader for both keys, so the route's gate and the run's own reader cannot
- * disagree about which limits are in force - the same reason
+ * One reader for all three keys, so the route's gate and the run's own reader
+ * cannot disagree about which limits are in force - the same reason
  * `read_auth_refresh_tuning` exists. A value outside the range `POST /config`
  * enforces can only come from a hand-edited row, and is discarded rather than
  * trusted: a zero interval is a tight scrape loop and a zero cap would reject
  * every block a user could write.
  */
 [[nodiscard]] MonitorLimits read_monitor_limits (vayu::db::Database& db);
+
+/**
+ * @brief How long one scrape of a @p interval_ms cadence may take.
+ *
+ * @p configured_timeout_ms is `monitorScrapeTimeoutMs` as the user set it.
+ * Zero - the seeded default - derives the timeout from the cadence at three
+ * quarters of it, so a user who slows the interval gets a proportionally longer
+ * scrape without touching a second setting. Any positive value is honoured as
+ * written, because how long you are willing to wait for your own metrics
+ * endpoint is not something this engine can second-guess; the one thing it may
+ * not do is outlive its own cadence, so it is capped at @p interval_ms. Past
+ * that the loop would spend the run behind itself, carrying samples that are no
+ * longer about the moment they were asked for.
+ *
+ * Pure and total: a nonsensical interval yields a nonsensical-but-safe timeout
+ * rather than a division by zero, because a hand-edited snapshot reaches the
+ * loop through `monitor_config_from`.
+ */
+[[nodiscard]] int resolve_scrape_timeout_ms (int interval_ms, int configured_timeout_ms);
 
 /**
  * @brief Reject a `monitor` block the run could not act on.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -793,10 +793,12 @@ void collect_metrics (std::shared_ptr<RunContext> context, vayu::db::Database* d
 /**
  * @brief Scrape @p config's metrics endpoint for the life of the run.
  *
- * Runs on `RunContext::monitor_thread`. Each pass GETs the URL with a timeout
- * well under the interval, stores what it read as a `monitor_samples` row and
- * publishes it as a live `monitor` SSE frame, then sleeps out the rest of the
- * interval in short slices so a finishing run is never held up by a long one.
+ * Runs on `RunContext::monitor_thread`. Each pass GETs the URL on the budget
+ * `resolve_scrape_timeout_ms` settles (three quarters of the interval, or
+ * `monitorScrapeTimeoutMs` where the user set one), stores what it read as a
+ * `monitor_samples` row and publishes it as a live `monitor` SSE frame, then
+ * sleeps out the rest of the interval in short slices so a finishing run is
+ * never held up by a long one.
  *
  * A failed scrape is a **gap**: it is counted, it never throws outward, and it
  * never fails the run. After `FAILURES_BEFORE_BACKOFF` consecutive failures it

--- a/engine/src/core/monitor.cpp
+++ b/engine/src/core/monitor.cpp
@@ -43,6 +43,10 @@ MonitorConfig& out) {
     // who set `monitorIntervalMs` to 5000 gets 5000 for every run that does not
     // override it - including one started by a client that omits the field.
     out.interval_ms = limits.default_interval_ms;
+    // The block has no timeout field of its own to override this: the scrape
+    // budget is an engine setting because it is about the endpoint being
+    // scraped, which is the same one run after run.
+    out.scrape_timeout_ms = limits.scrape_timeout_ms;
     if (!monitor.is_object ()) {
         return "'monitor' must be an object with a 'url' and a 'series' list";
     }
@@ -144,7 +148,28 @@ MonitorLimits read_monitor_limits (vayu::db::Database& db) {
     limits.max_series =
     max_series > 0 ? static_cast<size_t> (max_series) : defaults.max_series;
 
+    // A negative budget is not a shorter one, and a value past the longest
+    // cadence the engine will scrape at could never be reached anyway - both
+    // fall back to the derive sentinel rather than to a timeout the user did
+    // not choose.
+    const int scrape_timeout =
+    db.get_config_int ("monitorScrapeTimeoutMs", defaults.scrape_timeout_ms);
+    limits.scrape_timeout_ms =
+    (scrape_timeout >= 0 && scrape_timeout <= monitor_limits::MAX_INTERVAL_MS) ?
+    scrape_timeout :
+    defaults.scrape_timeout_ms;
+
     return limits;
+}
+
+int resolve_scrape_timeout_ms (int interval_ms, int configured_timeout_ms) {
+    if (configured_timeout_ms <= 0) {
+        // Three quarters of the interval leaves room to store the row and come
+        // back round.
+        return std::max (
+        monitor_limits::MIN_DERIVED_SCRAPE_TIMEOUT_MS, interval_ms * 3 / 4);
+    }
+    return std::min (configured_timeout_ms, interval_ms);
 }
 
 std::optional<std::string> validate_monitor_config (const nlohmann::json& config,

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -1537,9 +1537,23 @@ MonitorConfig config) {
 
     // A scrape must not outlive its own cadence: the sample a late answer
     // carries is no longer about the moment it was asked for, and the loop
-    // would spend the whole run behind itself. Three quarters of the interval
-    // leaves room to store the row and come back round.
-    const int timeout_ms = std::max (100, config.interval_ms * 3 / 4);
+    // would spend the whole run behind itself. Derived from the interval unless
+    // `monitorScrapeTimeoutMs` says otherwise - an exposition that takes longer
+    // to render than the derivation allows would otherwise fail every scrape,
+    // and the only way out was slowing the cadence, which also thins the data.
+    const int timeout_ms =
+    resolve_scrape_timeout_ms (config.interval_ms, config.scrape_timeout_ms);
+    if (config.scrape_timeout_ms > timeout_ms) {
+        // Said once, at the top: the setting is engine-wide but the cap is the
+        // interval of *this* block, so a value that is fine for a slow run is
+        // shortened on a fast one, and silence would look like the setting had
+        // not taken.
+        vayu::utils::log_warning ("Monitor scrape timeout for run " +
+        context->run_id + " capped at the scrape interval (" +
+        std::to_string (timeout_ms) + "ms); 'monitorScrapeTimeoutMs' is " +
+        std::to_string (config.scrape_timeout_ms) + "ms, which is longer than this run's " +
+        std::to_string (config.interval_ms) + "ms cadence");
+    }
 
     // No cookie jar: this is the engine talking on its own behalf, like the
     // OAuth token call and the update check (see ClientConfig::cookie_jar).

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -1951,8 +1951,8 @@ void Database::seed_default_config () {
     "5000", // 5s - past this a finished run visibly waits on the join
     std::nullopt, now });
 
-    // Server-vitals monitor. Both are read per run - a change applies to the
-    // next run started, no restart. The interval *bounds* (250-60000ms) are
+    // Server-vitals monitor. All three are read per run - a change applies to
+    // the next run started, no restart. The interval *bounds* (250-60000ms) are
     // deliberately not settings: they exist to stop a cadence that measures the
     // scraper rather than the target.
     upsert_config (ConfigEntry{ "monitorIntervalMs",
@@ -1977,6 +1977,22 @@ void Database::seed_default_config () {
     "hard cost. The chart has four distinct colours and repeats them past that.",
     "observability", std::to_string (vayu::core::constants::monitor::MAX_SERIES),
     "1", "64", std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "monitorScrapeTimeoutMs",
+    std::to_string (vayu::core::constants::monitor::DEFAULT_SCRAPE_TIMEOUT_MS),
+    "integer", "Server Monitoring Scrape Timeout",
+    "How long one scrape of the metrics endpoint may take before it counts as "
+    "a gap in the series. Leave it at 0 to derive the budget from the scrape "
+    "interval - three quarters of it - which is what most endpoints want. Set "
+    "it explicitly for an exposition that is slow to render: one that takes "
+    "longer than three quarters of the interval fails every scrape today, and "
+    "the only other way out is a slower cadence, which also thins the data. A "
+    "value longer than the interval a run scrapes at is shortened to it, "
+    "because a scrape that outlives its own cadence puts the loop behind "
+    "itself.",
+    "observability", std::to_string (vayu::core::constants::monitor::DEFAULT_SCRAPE_TIMEOUT_MS),
+    "0", std::to_string (vayu::core::constants::monitor::MAX_INTERVAL_MS),
+    std::nullopt, now });
 
     // =========================================================================
     // SCRIPTING ENVIRONMENT CONFIGURATION

--- a/engine/tests/mock_server.hpp
+++ b/engine/tests/mock_server.hpp
@@ -56,6 +56,19 @@ class SlowMockServer {
             "application/json");
         });
 
+        // The same exposition, rendered slowly - the heavyweight `/metrics` a
+        // loaded target serves, which is exactly when a run wants vitals. The
+        // delay sits between three quarters of `VITALS_SLOW_INTERVAL_MS` and
+        // the interval itself, so the derived scrape budget times it out and a
+        // configured one does not.
+        svr.Get ("/vitals-slow", [this] (const httplib::Request&, httplib::Response& res) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (VITALS_SLOW_DELAY_MS));
+            const int n = ++scrapes;
+            res.set_content ("vayu_test_cpu 4\n"
+                             "vayu_test_rss_bytes " + std::to_string (n * 1000) + "\n",
+            "text/plain");
+        });
+
         // An upstream that never answers on its own - what a stop must not wait
         // for. The handler only returns once the fixture is torn down (or after
         // a hard cap, so a leaked handler cannot wedge the test binary).
@@ -107,6 +120,18 @@ class SlowMockServer {
     std::string vitals_json_url () const {
         return "http://127.0.0.1:" + std::to_string (port) + "/vitals.json";
     }
+
+    std::string vitals_slow_url () const {
+        return "http://127.0.0.1:" + std::to_string (port) + "/vitals-slow";
+    }
+
+    /// The cadence `/vitals-slow` is meant to be scraped at, and the delay it
+    /// answers on. Three quarters of the interval is 1500ms, so the derived
+    /// budget times the endpoint out with 200ms to spare, and a configured
+    /// budget of anything up to the interval clears it with 300ms to spare -
+    /// margins wide enough that a loaded CI host does not flip either verdict.
+    static constexpr int VITALS_SLOW_INTERVAL_MS = 2000;
+    static constexpr int VITALS_SLOW_DELAY_MS    = 1700;
 
     /// How many times either vitals endpoint has been scraped.
     int scrape_count () const {

--- a/engine/tests/monitor_test.cpp
+++ b/engine/tests/monitor_test.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -33,6 +34,7 @@ using vayu::core::MonitorFormat;
 using vayu::core::MonitorTotals;
 using vayu::core::parse_json_metrics;
 using vayu::core::parse_prometheus_exposition;
+using vayu::core::resolve_scrape_timeout_ms;
 using vayu::core::validate_monitor_config;
 using vayu::tests::SlowMockServer;
 using Clock = std::chrono::steady_clock;
@@ -118,7 +120,7 @@ TEST (MonitorConfigValidation, LoopbackAndPrivateTargetsAreAllowed) {
 }
 
 // ---------------------------------------------------------------------------
-// The two limits a user can move
+// The limits a user can move
 // ---------------------------------------------------------------------------
 
 class MonitorLimitsTest : public ::testing::Test {
@@ -149,6 +151,68 @@ TEST_F (MonitorLimitsTest, AFreshDatabaseYieldsTheSeededDefaults) {
     const auto limits = vayu::core::read_monitor_limits (*db);
     EXPECT_EQ (limits.default_interval_ms, vayu::core::monitor_limits::DEFAULT_INTERVAL_MS);
     EXPECT_EQ (limits.max_series, vayu::core::monitor_limits::MAX_SERIES);
+    EXPECT_EQ (limits.scrape_timeout_ms, 0)
+    << "the seeded scrape timeout must be the derive sentinel, or an upgraded "
+       "install would silently change the budget its runs already scrape on";
+}
+
+// The setting is worth nothing if it stops at `MonitorLimits`: the loop reads
+// it off the `MonitorConfig` the run is started with.
+TEST_F (MonitorLimitsTest, TheConfiguredScrapeTimeoutReachesTheBlockTheRunExecutes) {
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorScrapeTimeoutMs", "1800"));
+    const auto limits = vayu::core::read_monitor_limits (*db);
+    ASSERT_EQ (limits.scrape_timeout_ms, 1800);
+
+    auto config = monitor_config (json{ { "url", "http://localhost:9100/metrics" },
+    { "series", json::array ({ "up" }) } });
+    auto parsed = monitor_config_from (config, limits);
+    ASSERT_TRUE (parsed.has_value ());
+    EXPECT_EQ (parsed->scrape_timeout_ms, 1800);
+}
+
+// `POST /config` range-checks the key, so anything outside 0-60000 is a
+// hand-edited row: a negative budget is not a shorter one, and one past the
+// longest cadence the engine scrapes at could never be reached.
+TEST_F (MonitorLimitsTest, AHandEditedScrapeTimeoutOutOfRangeFallsBackToTheSentinel) {
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorScrapeTimeoutMs", "-1"));
+    EXPECT_EQ (vayu::core::read_monitor_limits (*db).scrape_timeout_ms, 0);
+
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorScrapeTimeoutMs", "60001"));
+    EXPECT_EQ (vayu::core::read_monitor_limits (*db).scrape_timeout_ms, 0);
+}
+
+// ---------------------------------------------------------------------------
+// The scrape budget itself
+// ---------------------------------------------------------------------------
+
+// The sentinel must reproduce the hardcoded formula exactly: an install that
+// never touches the setting has to scrape on the budget it always did.
+TEST (ScrapeTimeout, ZeroDerivesThreeQuartersOfTheIntervalAsItAlwaysDid) {
+    for (const int interval : { 250, 500, 1000, 2000, 60000 }) {
+        EXPECT_EQ (resolve_scrape_timeout_ms (interval, 0),
+        std::max (100, interval * 3 / 4))
+        << "interval " << interval;
+    }
+    // The floor, for an interval only a hand-edited snapshot could carry.
+    EXPECT_EQ (resolve_scrape_timeout_ms (10, 0), 100);
+}
+
+// The whole point of the setting: an exposition slower than three quarters of
+// the interval gets the budget it needs without the cadence moving.
+TEST (ScrapeTimeout, AConfiguredBudgetIsHonouredAsWritten) {
+    EXPECT_EQ (resolve_scrape_timeout_ms (2000, 1950), 1950);
+    EXPECT_EQ (resolve_scrape_timeout_ms (2000, 1600), 1600);
+    // Shorter than the derivation is a choice too - a user who would rather
+    // have a gap than a stale sample.
+    EXPECT_EQ (resolve_scrape_timeout_ms (2000, 200), 200);
+}
+
+// A scrape may not outlive its own cadence, whatever the setting says: past
+// that the loop spends the run behind itself.
+TEST (ScrapeTimeout, ABudgetLongerThanTheCadenceIsCappedAtIt) {
+    EXPECT_EQ (resolve_scrape_timeout_ms (1000, 5000), 1000);
+    EXPECT_EQ (resolve_scrape_timeout_ms (1000, 1000), 1000);
+    EXPECT_EQ (resolve_scrape_timeout_ms (250, 60000), 250);
 }
 
 // The setting has to reach a block that named no interval of its own, or it
@@ -352,6 +416,13 @@ class MonitorRunTest : public ::testing::Test {
         db->create_run (row);
     }
 
+    void set_config (const std::string& key, const std::string& value) {
+        auto entry = db->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << "seed_default_config did not seed " << key;
+        entry->value = value;
+        db->save_config_entry (*entry);
+    }
+
     // A short run against the fast endpoint, with the monitor block under test.
     json run_config (json monitor) const {
         return json{ { "mode", "constant_rps" }, { "duration", "3s" },
@@ -485,6 +556,60 @@ TEST_F (MonitorRunTest, AHangingEndpointStallsNeitherTheRunNorTheTicks) {
     ASSERT_TRUE (summary.contains ("monitor"));
     EXPECT_EQ (summary["monitor"]["samples"].get<size_t> (), 0u);
     EXPECT_GT (summary["monitor"]["failures"].get<size_t> (), 0u);
+}
+
+// The failure the setting exists for, both halves of it. An exposition that
+// takes longer to render than three quarters of the interval reads as
+// permanently down, and the only way out used to be a slower cadence - which
+// also thins the data. Raising `monitorScrapeTimeoutMs` clears it at the same
+// cadence. Mutation-check: put the hardcoded `max(100, interval*3/4)` back in
+// `collect_monitor` and the second half of this test records nothing.
+TEST_F (MonitorRunTest, ASlowExpositionScrapesOnceTheBudgetIsRaisedAtTheSameCadence) {
+    const json monitor = json{ { "url", server->vitals_slow_url () },
+        { "intervalMs", SlowMockServer::VITALS_SLOW_INTERVAL_MS },
+        { "series", json::array ({ "vayu_test_cpu" }) } };
+
+    // Derived (the seeded sentinel): three quarters of 2000ms is less than the
+    // 1700ms the endpoint takes, so every scrape is a gap.
+    const std::string derived_run = "run-monitor-slow-derived";
+    create_run_row (derived_run);
+    {
+        vayu::core::RunManager manager;
+        ASSERT_TRUE (manager.start_run (derived_run, run_config (monitor), *db, false));
+        wait_for_terminal (derived_run, 25000);
+        manager.shutdown (std::chrono::milliseconds (20000));
+    }
+    EXPECT_EQ (db->count_monitor_samples (derived_run), 0)
+    << "the derived budget outlasted an exposition slower than three quarters "
+       "of the interval";
+
+    // Raised, with the cadence untouched.
+    ASSERT_NO_FATAL_FAILURE (set_config ("monitorScrapeTimeoutMs",
+    std::to_string (SlowMockServer::VITALS_SLOW_INTERVAL_MS - 50)));
+
+    const std::string raised_run = "run-monitor-slow-raised";
+    create_run_row (raised_run);
+    {
+        vayu::core::RunManager manager;
+        ASSERT_TRUE (manager.start_run (raised_run, run_config (monitor), *db, false));
+        wait_for_terminal (raised_run, 25000);
+        manager.shutdown (std::chrono::milliseconds (20000));
+    }
+    EXPECT_GE (db->count_monitor_samples (raised_run), 1)
+    << "the raised budget did not reach the scrape loop";
+
+    auto samples = db->get_monitor_samples_paginated (raised_run, 5000, 0);
+    ASSERT_FALSE (samples.empty ());
+    EXPECT_DOUBLE_EQ (
+    json::parse (samples.front ().payload)["series"]["vayu_test_cpu"].get<double> (), 4.0);
+
+    // The cadence is the one the run asked for either way: the setting buys a
+    // longer scrape, not a slower one.
+    auto stored = db->get_run (raised_run);
+    ASSERT_TRUE (stored.has_value ());
+    auto summary = json::parse (stored->summary);
+    ASSERT_TRUE (summary.contains ("monitor")) << stored->summary;
+    EXPECT_GE (summary["monitor"]["samples"].get<size_t> (), 1u);
 }
 
 TEST_F (MonitorRunTest, ARunWithoutAMonitorScrapesNothingAndReportsNoSection) {


### PR DESCRIPTION
## Description

The server-vitals scrape loop timed out at `max(100, interval * 3 / 4)`, hardcoded at `run_manager.cpp:1542`. An exposition that takes longer than three quarters of the interval to render - a heavyweight `/metrics` on a loaded target, which is exactly when you want vitals - failed *every* scrape, and the only way out was slowing the cadence, which also thins the data.

`monitorScrapeTimeoutMs` now names that budget: an `observability` config entry, range `0-60000`, seeded `0`.

**Plan.** Root cause: the scrape budget was a derivation with no way to override it, so the one failure mode it has (an exposition slower than the derivation) had no fix that did not also cost data. Approach: one config entry read through the existing `read_monitor_limits` reader, carried to the loop on `MonitorConfig` - the same route `monitorIntervalMs` already takes, so the route's gate and the run's reader cannot disagree - and resolved by one pure `resolve_scrape_timeout_ms(interval, configured)`. `0` is the derive sentinel and reproduces the old formula exactly, so an upgraded install scrapes on the budget it always did. The alternative rejected: making the timeout a field on the `monitor` block. The budget is about the *endpoint being scraped*, which is the same one run after run, so it belongs with the engine settings rather than being retyped into every run config - and a block field would have needed a fourth spelling in the route gate, the run reader, the docs and the MCP schema for no gain.

### Decisions worth reviewing

1. **The `>= 100` validation the issue asked for is not there, deliberately.** `POST /config` validates purely from the entry's `min`/`max` metadata, with no per-key hook, so "0 or >= 100" cannot be expressed - it would have to live in the reader, where it becomes a silent clamp, which is the class `CLAUDE.md` calls out. Adding a bespoke validator hook for one key is complexity the issue explicitly warns against. So the range is `0-60000` and a positive value is honoured as written: how long you are willing to wait for your own metrics endpoint is not something the engine can second-guess, and a budget shorter than the derivation is a legitimate choice (a gap rather than a stale sample). The 100ms floor stays exactly where it was - inside the *derivation*, guarding a hand-edited interval.
2. **The overlap guard is a cap at the interval, applied per run, and logged.** A timeout longer than the interval cannot actually overlap two scrapes - the loop is one thread, blocking send then sleep-to-deadline - so what it really causes is cadence drift. The cap is at `interval_ms` exactly (a maximally slow scrape then consumes its whole slot and the next starts on time), and it cannot be enforced at `POST /config` because the interval is per run. Since a value that is fine for a slow run is shortened on a fast one, the loop logs it once at the top rather than shortening in silence.
3. **`FAILURES_BEFORE_BACKOFF` stays a constant**, per the issue's "do not gold-plate": it has a sane value and no observed failure mode, unlike the timeout.
4. **The 50ms poll slice stays internal**, as the issue specified - non-goal.

### App / MCP, verified

- **App: none.** The engine settings panel is metadata-driven - `SettingsMain.tsx:141` filters `entry.category === selectedCategory` and renders each entry from its own label/description/min/max; `CATEGORY_TITLES` is keyed by category, not by key. The new entry renders under **Observability & Data** with no app change. No app-side reader enumerates config keys (`useMonitorSettings.ts` reads the two keys it needs by name).
- **MCP: reached for free.** `update_engine_config` takes an arbitrary `entries` map and does not enumerate keys, so nothing in `tools.ts` changes. `docs/engine/mcp.md` does **not** enumerate config keys (its only monitor mention is `monitorMaxSeries` inside a tool description that is unaffected), so it is untouched - correcting the issue's "verify" note.
- `docs/engine/architecture.md` does not name the 3/4 rule (checked: its monitor paragraph is about thread separation), so it is untouched too.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure`: **1432/1432 passed** (191s). No pre-existing failures. App suite not run and not needed - no app file is touched and no app test could change colour (the engine is not started by vitest).

Six new tests, and one new fixture endpoint (`/vitals-slow`, which renders the exposition after 1700ms against a 2000ms cadence - a margin of 200ms on the failing side and 300ms on the passing side, so a loaded host does not flip either verdict):

- `ScrapeTimeout.ZeroDerivesThreeQuartersOfTheIntervalAsItAlwaysDid` - the sentinel against the old formula across five intervals plus the floor case.
- `ScrapeTimeout.AConfiguredBudgetIsHonouredAsWritten`
- `ScrapeTimeout.ABudgetLongerThanTheCadenceIsCappedAtIt`
- `MonitorLimitsTest.TheConfiguredScrapeTimeoutReachesTheBlockTheRunExecutes` - the written-never-read guard: the setting has to land on the `MonitorConfig` the run is started with, not stop at `MonitorLimits`.
- `MonitorLimitsTest.AHandEditedScrapeTimeoutOutOfRangeFallsBackToTheSentinel`
- `MonitorRunTest.ASlowExpositionScrapesOnceTheBudgetIsRaisedAtTheSameCadence` - the acceptance criterion end to end: a slow exposition records **0** samples on the derived budget and records samples once `monitorScrapeTimeoutMs` is raised, with the run's `intervalMs` identical in both halves.

`AFreshDatabaseYieldsTheSeededDefaults` also gained an assertion that the seed is the sentinel, so an upgrade cannot silently move an existing install's budget.

**Mutation check (run, not assumed):** the hardcoded `max(100, config.interval_ms * 3 / 4)` was put back in `collect_monitor` and the binary rebuilt - `ASlowExpositionScrapesOnceTheBudgetIsRaisedAtTheSameCadence` **FAILED**; the fix restored, it passes again.

`mkdocs build --strict -f .github/mkdocs.yml` passes (2.81s).

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/engine/api-reference.md`, same commit: the config-entries table gains the key with its derive-when-zero semantics and the cap, and the `monitor` block section's "two of the limits are settings" paragraph becomes three, with a note on why the budget has no block field. clang-format was applied to the changed line ranges only (the touched files are not clang-format clean at HEAD, and `CLAUDE.md` forbids reformatting the rest).

## Related Issues

Closes #508

---
_Generated by [Claude Code](https://claude.ai/code/session_018K5dS9zoAm78zsBLrw46Vv)_