### PR TITLE
feat(config): make restart-required and advanced typed fields on a config entry

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -188,8 +188,18 @@ describe("engine config tools", () => {
 		const client = fakeClient({
 			getConfig: vi.fn().mockResolvedValue({
 				entries: [
-					{ key: "workers", value: "16", label: "Worker threads (Requires Restart)" },
-					{ key: "timeoutMs", value: "5000", label: "Request timeout" },
+					{
+						key: "workers",
+						value: "16",
+						label: "Worker Threads",
+						requiresRestart: true,
+					},
+					{
+						key: "timeoutMs",
+						value: "5000",
+						label: "Request timeout",
+						requiresRestart: false,
+					},
 				],
 			}),
 		});

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -807,13 +807,19 @@ const configUpdateSchema = z
 /**
  * Of the changed config keys, which require an engine restart to take effect.
  *
- * The label is the whole signal: the engine writes "… (Requires Restart)" into
- * each entry's `label` (`engine/src/db/database.cpp`) and emits no boolean
- * beside it. A `requiresRestart === true` branch used to run ahead of this
- * regex on a field nothing has ever written - a check that could not fire,
- * mirrored in `SettingsMain.tsx` and typed in `domain.ts`, which read as if the
- * engine had a second, more reliable channel. If one is ever added, this is the
- * one place that decides.
+ * The engine says so in a typed `requiresRestart` field on each entry
+ * (`engine/src/http/routes/config.cpp`), read here and in `SettingsMain.tsx`.
+ * It replaced a "… (Requires Restart)" substring in the entry's `label` that
+ * both consumers regex-matched out of the prose - so a label that fell out of
+ * step with the mechanism (the `workers` case, #197) misinformed an agent and
+ * the settings screen at once, and no rewording of the copy could be made
+ * without minding this parser.
+ *
+ * Strictly `=== true`: this decides whether the tool result tells an agent its
+ * change is live, and a payload that omits the field (an engine older than the
+ * app it is paired with) has not said that it does not need one.
+ *
+ * `update_config`'s `restartRequired` result shape is unchanged.
  */
 function restartRequiredAmong(configResponse: unknown, changedKeys: string[]): string[] {
 	const raw = Array.isArray(configResponse)
@@ -823,11 +829,7 @@ function restartRequiredAmong(configResponse: unknown, changedKeys: string[]): s
 			: [];
 	const entries = Array.isArray(raw) ? (raw as Array<Record<string, unknown>>) : [];
 	const byKey = new Map(entries.map((e) => [String(e.key), e]));
-	return changedKeys.filter((key) => {
-		const e = byKey.get(key);
-		if (!e) return false;
-		return /requires restart/i.test(String(e.label ?? ""));
-	});
+	return changedKeys.filter((key) => byKey.get(key)?.requiresRestart === true);
 }
 
 /**

--- a/app/src/components/layout/Dock.pending-restart.test.tsx
+++ b/app/src/components/layout/Dock.pending-restart.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A restart the engine is waiting for has to be visible outside Settings.
+ *
+ * `pendingRestart` was raised by the settings save path and read by exactly one
+ * screen - the one the user has already left by the time it matters. Every
+ * other setting confirms itself; the restart-required ones cannot, so the Dock
+ * says so and offers the restart from wherever the user is.
+ *
+ * Rendered, not source-scanned: the signal arrives through a store binding, and
+ * both halves are asserted - present when pending, absent when not. A component
+ * that rendered the line unconditionally would pass the first case alone.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { Dock } from "./Dock";
+import { useEngineStore, useToastStore } from "@/stores";
+import { TIMING } from "@/config/timing";
+
+vi.stubGlobal("__VAYU_VERSION__", "0.0.0-test");
+
+const restartEngine = vi.fn();
+
+const renderDock = () =>
+	render(
+		<QueryClientProvider
+			client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+		>
+			<TooltipProvider>
+				<Dock />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+
+const signal = () => screen.queryByRole("button", { name: /Restart pending/i });
+
+beforeEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+	useEngineStore.setState({
+		isEngineConnected: true,
+		engineError: null,
+		pendingRestart: false,
+		restartRequiredKeys: [],
+	});
+	useToastStore.setState({ toasts: [] });
+	restartEngine.mockResolvedValue({ success: true });
+	vi.stubGlobal("electronAPI", { restartEngine });
+	// The renderer reads it off `window`, which is what the component sees.
+	(window as unknown as { electronAPI: unknown }).electronAPI = { restartEngine };
+});
+
+describe("the Dock's pending-restart signal", () => {
+	it("stays away while nothing is pending", () => {
+		renderDock();
+		expect(signal()).toBeNull();
+	});
+
+	it("appears once a restart-required setting has been saved", () => {
+		useEngineStore.getState().addRestartRequiredKey("workers");
+		renderDock();
+		expect(signal()).not.toBeNull();
+	});
+
+	it("restarts the engine and lowers itself", async () => {
+		useEngineStore.getState().addRestartRequiredKey("workers");
+		renderDock();
+
+		fireEvent.click(signal()!);
+
+		await waitFor(() => expect(restartEngine).toHaveBeenCalledTimes(1));
+		// The hook waits for the daemon to come back before invalidating and
+		// lowering the flag, so this outlasts that wait deliberately.
+		await waitFor(() => expect(useEngineStore.getState().pendingRestart).toBe(false), {
+			timeout: TIMING.ENGINE_RESTART_WAIT_MS + 2000,
+		});
+		expect(signal()).toBeNull();
+	});
+
+	it("keeps standing when the restart fails, and says why", async () => {
+		restartEngine.mockResolvedValue({ success: false, error: "engine did not come back" });
+		useEngineStore.getState().addRestartRequiredKey("workers");
+		renderDock();
+
+		fireEvent.click(signal()!);
+
+		await waitFor(() => expect(useToastStore.getState().toasts.length).toBe(1));
+		const [toast] = useToastStore.getState().toasts;
+		expect(toast?.variant).toBe("error");
+		expect(toast?.message).toContain("engine did not come back");
+		// The signal is the user's evidence that a saved value is not live yet;
+		// a failed restart must not clear it.
+		expect(useEngineStore.getState().pendingRestart).toBe(true);
+		expect(signal()).not.toBeNull();
+	});
+});

--- a/app/src/components/layout/Dock.tsx
+++ b/app/src/components/layout/Dock.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { FolderOpen, Clock, Braces, Info, PanelRight, Settings } from "lucide-react";
+import { FolderOpen, Clock, Braces, Info, PanelRight, RefreshCw, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatChord } from "@/lib/platform";
 import {
@@ -17,6 +17,7 @@ import {
 } from "@/stores";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 import { contextBarHasContent } from "./context-bar-content";
+import { useEngineRestart } from "@/hooks/useEngineRestart";
 
 interface DrawerButton {
 	view: DrawerView;
@@ -188,6 +189,65 @@ function EngineStatus() {
 	);
 }
 
+/**
+ * A saved setting the running engine has not picked up yet.
+ *
+ * Every other setting in the app confirms itself: the value is written, the
+ * thing it governs changes. The restart-required ones cannot - the engine keeps
+ * serving the old value until it is relaunched - and until now nothing said so
+ * outside the Settings screen, which is exactly where the user is *not* once
+ * they have moved on. So the Dock carries it, beside the connection light that
+ * already answers "what is the engine doing".
+ *
+ * What it tracks, stated plainly: settings saved from this app since it
+ * connected that the engine marks `requiresRestart` (`engine-store`, written by
+ * `SettingsMain`). Not a comparison against the engine's running values - it
+ * does not report those, so any such claim would be inferred rather than known.
+ * The honest consequence is that this cannot survive a reload of the renderer,
+ * and it says "saved" rather than "in effect".
+ */
+function PendingRestart() {
+	const pendingRestart = useEngineStore((s) => s.pendingRestart);
+	// The subtree stops here on the ordinary path, so the machinery behind the
+	// action - the restart itself, and the cache invalidation that follows it -
+	// is only mounted while there is a restart to offer.
+	return pendingRestart ? <PendingRestartButton /> : null;
+}
+
+function PendingRestartButton() {
+	const { restart, isRestarting } = useEngineRestart();
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				{/*
+				 * A button, not a chip with a tooltip: the restart is the point,
+				 * and a status that can only be read is one more thing to carry
+				 * back to Settings. Warning tokens rather than a raw amber - the
+				 * `-text` variant is the pair that passes contrast at 12px, the
+				 * same rule the connection light follows above.
+				 */}
+				<button
+					onClick={() => void restart()}
+					disabled={isRestarting}
+					className="flex items-center gap-1 text-xs text-warning-text rounded-sm hover:underline disabled:no-underline disabled:opacity-70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+				>
+					<RefreshCw
+						className={cn("w-3 h-3", isRestarting && "animate-spin")}
+						aria-hidden="true"
+					/>
+					{isRestarting ? "Restarting…" : "Restart pending"}
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="top">
+				<p className="max-w-64 whitespace-normal break-words">
+					A saved setting needs an engine restart to take effect. Click to restart now.
+				</p>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 export function Dock() {
 	const { drawerOpen, drawerView, activateDrawerView, contextBarOpen, toggleContextBar } =
 		useLayoutStore();
@@ -234,6 +294,8 @@ export function Dock() {
 				{/* Middle - ambient status */}
 				<div className="flex-1 flex items-center justify-center gap-4">
 					<EngineStatus />
+
+					<PendingRestart />
 
 					{/*
 					 * "Unsaved changes" is the only place in the app that says so.

--- a/app/src/hooks/useEngineRestart.ts
+++ b/app/src/hooks/useEngineRestart.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Restarting the engine, from wherever the user is standing.
+ *
+ * Two places offer the action - the Settings banner beside the setting that
+ * asked for it, and the Dock, which is on screen when Settings is not - and the
+ * sequence is the same either way: restart, wait for the daemon to come back,
+ * refetch everything the old instance answered, then lower the pending flag.
+ * A second copy of that would be a second place for the invalidate or the flag
+ * to be forgotten.
+ *
+ * Failure is a toast, not a `window.alert`. The alert this replaced blocked the
+ * whole renderer on a modal the user could only dismiss, and from the Dock it
+ * would interrupt whatever they were doing elsewhere; every other failure in
+ * the app already reports this way.
+ */
+
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEngineStore, useToastStore } from "@/stores";
+import { TIMING } from "@/config/timing";
+
+export function useEngineRestart(): { restart: () => Promise<void>; isRestarting: boolean } {
+	const [isRestarting, setIsRestarting] = useState(false);
+	const queryClient = useQueryClient();
+	const clearRestartRequired = useEngineStore((s) => s.clearRestartRequired);
+	const showToast = useToastStore((s) => s.showToast);
+
+	const restart = useCallback(async () => {
+		if (!window.electronAPI) {
+			// The renderer runs in a plain browser in dev, where there is no
+			// daemon to restart - say so rather than appearing to have done it.
+			showToast({
+				message:
+					"Engine restart is only available in the desktop app. Restart the engine manually.",
+				variant: "warning",
+			});
+			return;
+		}
+
+		setIsRestarting(true);
+		try {
+			const result = await window.electronAPI.restartEngine();
+			if (!result.success) {
+				showToast({
+					message: `Failed to restart engine: ${result.error ?? "unknown error"}`,
+					variant: "error",
+				});
+				return;
+			}
+			// Give the daemon a moment to finish coming up before anything asks
+			// it a question; then drop every cached answer the old instance
+			// gave, since the new one may disagree with all of them.
+			await new Promise((resolve) => setTimeout(resolve, TIMING.ENGINE_RESTART_WAIT_MS));
+			await queryClient.invalidateQueries();
+			// Last, and only on the success path: the pending signal is the
+			// user's evidence that a saved value has not taken effect yet, so a
+			// failed restart must leave it standing.
+			clearRestartRequired();
+		} finally {
+			setIsRestarting(false);
+		}
+	}, [queryClient, clearRestartRequired, showToast]);
+
+	return { restart, isRestarting };
+}

--- a/app/src/hooks/useLiveChartSettings.test.tsx
+++ b/app/src/hooks/useLiveChartSettings.test.tsx
@@ -33,6 +33,8 @@ function entry(value: string, key = "liveReplayWindowMs"): ConfigEntry {
 		description: "",
 		category: "observability",
 		default: "300000",
+		requiresRestart: false,
+		advanced: false,
 		updatedAt: 0,
 	};
 }

--- a/app/src/modules/settings/main/SettingsMain.advanced-section.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.advanced-section.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Five engine entries are internals no user story reaches - a SQLite lock
+ * pragma, an OAuth watchdog's backoff, a 250ms poll cadence - and they rendered
+ * as first-class rows beside the settings people actually tune, interleaved by
+ * key order. The engine now marks them `advanced` and they render collapsed at
+ * the bottom of their category.
+ *
+ * Membership is the engine's call, not this component's: the assertions below
+ * drive it off the flag on the payload, so a key added to or removed from the
+ * group upstream needs no edit here (`config_route_test.cpp` pins which keys
+ * carry it).
+ *
+ * Rendered rather than source-scanned - the grouping is a payload-driven
+ * filter, which no scan of this file could see.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SettingsMain from "./SettingsMain";
+import type { ConfigEntry } from "@/types";
+
+const base = {
+	type: "integer" as const,
+	description: "",
+	category: "database_performance",
+	min: "1",
+	max: "100000",
+	requiresRestart: false,
+	updatedAt: 0,
+};
+
+// Deliberately ordered so key-sort alone would interleave them: "aEveryday"
+// sorts before "mInternal", which sorts before "zEveryday".
+const everydayFirst: ConfigEntry = {
+	...base,
+	key: "aEverydayFirst",
+	label: "Everyday First",
+	value: "1",
+	default: "1",
+	advanced: false,
+};
+const internal: ConfigEntry = {
+	...base,
+	key: "mInternal",
+	label: "Database Lock Wait Time",
+	value: "10000",
+	default: "10000",
+	advanced: true,
+};
+const everydayLast: ConfigEntry = {
+	...base,
+	key: "zEverydayLast",
+	label: "Everyday Last",
+	value: "2",
+	default: "2",
+	advanced: false,
+};
+
+let configEntries: ConfigEntry[] = [everydayFirst, internal, everydayLast];
+
+vi.mock("@/queries", () => ({
+	useConfigQuery: () => ({ data: { entries: configEntries }, isLoading: false, error: null }),
+	useUpdateConfigMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/modules/settings/settings-store", () => ({
+	useSettingsStore: () => ({ selectedCategory: "database_performance" }),
+}));
+
+vi.mock("@/stores", () => ({
+	useEngineStore: () => ({
+		isEngineConnected: true,
+		pendingRestart: false,
+		restartRequiredKeys: [],
+		addRestartRequiredKey: vi.fn(),
+		clearRestartRequired: vi.fn(),
+	}),
+}));
+
+vi.mock("@/stores/save-store", () => ({
+	useSaveStore: () => ({
+		startSaving: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
+		failSave: vi.fn(),
+		setStatus: vi.fn(),
+		markPendingSave: vi.fn(),
+		registerContext: vi.fn(),
+		unregisterContext: vi.fn(),
+		setActiveContext: vi.fn(),
+		updateContext: vi.fn(),
+	}),
+}));
+
+function renderSettings() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<SettingsMain />
+		</QueryClientProvider>
+	);
+}
+
+const disclosure = () => screen.queryByRole("button", { name: /Advanced/i });
+const controlFor = (entry: ConfigEntry) => screen.queryByRole("spinbutton", { name: entry.label });
+
+beforeEach(() => {
+	cleanup();
+	configEntries = [everydayFirst, internal, everydayLast];
+});
+
+describe("the Advanced group", () => {
+	it("keeps the flagged entries out of the list until asked for", () => {
+		renderSettings();
+
+		expect(controlFor(everydayFirst)).not.toBeNull();
+		expect(controlFor(everydayLast)).not.toBeNull();
+		// Not merely last - not rendered at all, which is what "collapsed" has
+		// to mean for a screen reader too.
+		expect(controlFor(internal)).toBeNull();
+		expect(disclosure()?.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("reveals exactly the flagged entries when expanded, and hides them again", () => {
+		renderSettings();
+
+		fireEvent.click(disclosure()!);
+		expect(disclosure()?.getAttribute("aria-expanded")).toBe("true");
+		expect(controlFor(internal)).not.toBeNull();
+		// The everyday rows are not moved into the group by the expansion.
+		expect(controlFor(everydayFirst)).not.toBeNull();
+
+		fireEvent.click(disclosure()!);
+		expect(controlFor(internal)).toBeNull();
+	});
+
+	it("counts what it is holding", () => {
+		renderSettings();
+		expect(disclosure()?.textContent).toContain("(1)");
+	});
+
+	it("is absent entirely from a category with no internals", () => {
+		configEntries = [everydayFirst, everydayLast];
+		renderSettings();
+
+		expect(disclosure()).toBeNull();
+		expect(controlFor(everydayFirst)).not.toBeNull();
+	});
+});

--- a/app/src/modules/settings/main/SettingsMain.enum.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.enum.test.tsx
@@ -41,6 +41,8 @@ const enumEntry: ConfigEntry = {
 	value: "auto",
 	default: "auto",
 	category: "general_engine",
+	requiresRestart: false,
+	advanced: false,
 	updatedAt: 0,
 	options: [
 		{ value: "auto", label: "Auto" },

--- a/app/src/modules/settings/main/SettingsMain.restart-banner.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.restart-banner.test.tsx
@@ -32,7 +32,7 @@ import { useEngineStore } from "@/stores";
 
 const restartEntry = {
 	key: "worker_threads",
-	label: "Worker threads (Requires Restart)",
+	label: "Worker threads",
 	description: "Threads the engine starts with",
 	type: "integer" as const,
 	value: "4",
@@ -40,14 +40,29 @@ const restartEntry = {
 	category: "general_engine",
 	min: "1",
 	max: "64",
+	// The engine's typed signal, not a parenthetical in the label. Saving an
+	// entry without it must raise nothing - covered below.
+	requiresRestart: true,
+	advanced: false,
 	updatedAt: 0,
 };
 
+/**
+ * The mutation-check twin: the old label parser would have called this
+ * restart-required, the typed flag does not. Rendered in its own case below.
+ */
+const labelSaysSoButTheFlagDoesNot = {
+	...restartEntry,
+	label: "Worker threads (Requires Restart)",
+	requiresRestart: false,
+};
+
+let configEntries: (typeof restartEntry)[] = [restartEntry];
 const mutateAsync = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@/queries", () => ({
 	useConfigQuery: () => ({
-		data: { entries: [restartEntry] },
+		data: { entries: configEntries },
 		isLoading: false,
 		error: null,
 	}),
@@ -88,6 +103,7 @@ const banner = () => screen.queryByText("Engine restart required");
 beforeEach(() => {
 	cleanup();
 	vi.clearAllMocks();
+	configEntries = [restartEntry];
 	useEngineStore.setState({ pendingRestart: false, restartRequiredKeys: [] });
 });
 
@@ -108,11 +124,9 @@ describe("the restart-required banner", () => {
 		await waitFor(() => expect(banner()).not.toBeNull());
 		expect(mutateAsync).toHaveBeenCalledWith({ entries: { worker_threads: "8" } });
 		// Read out of the banner's own line, not the page: the field's label
-		// carries the same words and would match anywhere. The banner prints the
-		// label with the "(Requires Restart)" parenthetical stripped.
+		// carries the same words and would match anywhere.
 		const detail = screen.getByText(/will take effect after restarting the engine/);
 		expect(detail.textContent).toContain("Changes to Worker threads");
-		expect(detail.textContent).not.toContain("Requires Restart");
 		// The store is what holds it, and the component reads it from there.
 		expect(useEngineStore.getState().pendingRestart).toBe(true);
 		expect(useEngineStore.getState().restartRequiredKeys).toEqual(["worker_threads"]);
@@ -144,5 +158,32 @@ describe("the restart-required banner", () => {
 
 		expect(banner()).not.toBeNull();
 		expect(useEngineStore.getState().restartRequiredKeys).toEqual(["worker_threads"]);
+	});
+
+	it("is raised by the typed flag, not by the words in the label", async () => {
+		// The exact mutation this guards: put the substring parser back and this
+		// entry - whose label still reads "(Requires Restart)" while the engine
+		// says it does not - raises a banner that lies.
+		configEntries = [labelSaysSoButTheFlagDoesNot];
+		renderSettings();
+
+		fireEvent.change(screen.getByRole("spinbutton", { name: /Worker threads/i }), {
+			target: { value: "8" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+		await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+		expect(banner()).toBeNull();
+		expect(useEngineStore.getState().pendingRestart).toBe(false);
+	});
+
+	it("shows the Restart Required chip on the entry from the flag alone", () => {
+		renderSettings();
+		expect(screen.getByText("Restart Required")).not.toBeNull();
+
+		cleanup();
+		configEntries = [labelSaysSoButTheFlagDoesNot];
+		renderSettings();
+		expect(screen.queryByText("Restart Required")).toBeNull();
 	});
 });

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -13,7 +13,6 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { useEngineStore } from "@/stores";
 import { useSaveStore } from "@/stores/save-store";
 import { useSettingsStore } from "@/modules/settings/settings-store";
@@ -25,6 +24,7 @@ import {
 	RotateCcw,
 	Loader2,
 	AlertCircle,
+	ChevronRight,
 	AlertTriangle,
 	RefreshCw,
 	X,
@@ -51,19 +51,19 @@ import { cn } from "@/lib/utils";
 import ClientSettingsPanel from "./panels/ClientSettingsPanel";
 import { getAppPanel, isClientCategory } from "./app-panels";
 import { isSizeConfig, formatBytes, formatSizeRange } from "../utils/format-size";
-import { TIMING } from "@/config/timing";
+import { useEngineRestart } from "@/hooks/useEngineRestart";
 
 /**
  * Check if a config entry requires a restart when changed
  *
- * The label is the only signal the engine sends: it writes "(Requires Restart)"
- * into the label itself (`engine/src/db/database.cpp`). A second `requiresRestart`
- * boolean was checked here and typed on `ConfigEntry`, but nothing has ever
- * written it - the MCP tool surface carried the same dead check.
+ * `requiresRestart` is a typed field the engine serializes on every entry
+ * (`engine/src/http/routes/config.cpp`). It replaced a "(Requires Restart)"
+ * substring in the label, parsed here and again in the MCP tool surface - which
+ * meant one stale label lied to both consumers at once, and said it three times
+ * per card (suffix, chip, closing description sentence). The chip below is now
+ * the single statement.
  */
-const isRestartRequired = (entry: ConfigEntry): boolean => {
-	return entry.label.includes("(Requires Restart)");
-};
+const isRestartRequired = (entry: ConfigEntry): boolean => entry.requiresRestart;
 
 // Client (app) categories render their own header via ClientSettingsPanel; only
 // the engine categories are titled here (this map drives the engine config view).
@@ -98,6 +98,63 @@ interface EditedValue {
 	error?: string;
 }
 
+/**
+ * The banner over the settings list once a restart-required value is saved.
+ *
+ * Its own component so the restart machinery - the action, and the cache
+ * invalidation that follows it - is mounted only while the banner is on
+ * screen, the same split the Dock's pending signal uses. It shares that one
+ * action through `useEngineRestart`; the two used to be a copy each.
+ */
+function RestartRequiredBanner({ labels, onDismiss }: { labels: string[]; onDismiss: () => void }) {
+	const { restart, isRestarting } = useEngineRestart();
+
+	return (
+		<div className="bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 px-6 py-3 shrink-0">
+			<div className="flex items-center justify-between max-w-3xl mx-auto w-full">
+				<div className="flex items-center gap-3">
+					<div className="flex items-center justify-center w-8 h-8 rounded-full bg-amber-100 dark:bg-amber-900/50">
+						<AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+					</div>
+					<div>
+						<p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+							Engine restart required
+						</p>
+						<p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
+							Changes to <span className="font-medium">{labels.join(", ")}</span> will
+							take effect after restarting the engine
+						</p>
+					</div>
+				</div>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onDismiss}
+						className="border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/50"
+					>
+						<X className="w-4 h-4 mr-1.5" />
+						Dismiss
+					</Button>
+					<Button
+						size="sm"
+						className="bg-amber-600 hover:bg-amber-700 text-white"
+						disabled={isRestarting}
+						onClick={() => void restart()}
+					>
+						{isRestarting ? (
+							<Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+						) : (
+							<RefreshCw className="w-4 h-4 mr-1.5" />
+						)}
+						{isRestarting ? "Restarting..." : "Restart Engine"}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 export default function SettingsMain() {
 	const { selectedCategory } = useSettingsStore();
 	const { pendingRestart, restartRequiredKeys, addRestartRequiredKey, clearRestartRequired } =
@@ -113,13 +170,14 @@ export default function SettingsMain() {
 		setActiveContext,
 		updateContext,
 	} = useSaveStore();
-	const queryClient = useQueryClient();
 	const { data: configResponse, isLoading, error } = useConfigQuery();
 	const updateConfigMutation = useUpdateConfigMutation();
 
 	// Track edited values locally
 	const [editedValues, setEditedValues] = useState<Record<string, EditedValue>>({});
-	const [isRestarting, setIsRestarting] = useState(false);
+	// Deliberately not persisted: the group is meant to be rediscovered rather
+	// than left open from a session the user has forgotten about.
+	const [advancedOpen, setAdvancedOpen] = useState(false);
 
 	// Refs for the save function and the live edits, so the category-switch
 	// cleanup below can flush without either becoming one of its dependencies.
@@ -141,6 +199,11 @@ export default function SettingsMain() {
 					.filter((entry) => entry.category === selectedCategory)
 					.sort((a, b) => a.key.localeCompare(b.key))
 			: [];
+	// The engine marks its internals - a lock pragma, a watchdog's backoff -
+	// with `advanced`. They stay reachable, but below the settings people
+	// actually tune rather than interleaved with them by key order.
+	const primaryEntries = categoryEntries.filter((entry) => !entry.advanced);
+	const advancedEntries = categoryEntries.filter((entry) => entry.advanced);
 	const categoryConfig =
 		selectedCategory && !isClientCategory(selectedCategory)
 			? CATEGORY_TITLES[selectedCategory]
@@ -269,6 +332,7 @@ export default function SettingsMain() {
 		// keeps the flush in the cleanup, where the ref still holds those edits.
 		setEditedCategory(selectedCategory);
 		setEditedValues({});
+		setAdvancedOpen(false);
 	}
 
 	useEffect(() => {
@@ -473,89 +537,215 @@ export default function SettingsMain() {
 		if (!configResponse?.entries) return restartRequiredKeys;
 		return restartRequiredKeys.map((key) => {
 			const entry = configResponse.entries.find((e) => e.key === key);
-			return entry?.label.replace(" (Requires Restart)", "") || key;
+			return entry?.label || key;
 		});
+	};
+
+	/**
+	 * One entry's card.
+	 *
+	 * Extracted so the everyday list and the collapsed Advanced section below
+	 * render from one definition: an advanced setting is the same control in a
+	 * quieter place, not a second, thinner rendering of it.
+	 */
+	const renderEntryCard = (entry: ConfigEntry) => {
+		const currentValue = getCurrentValue(entry);
+		const edited = editedValues[entry.key];
+		const isModified = edited !== undefined;
+		const hasError = edited?.error;
+		// Per entry, so `aria-describedby` never points at another
+		// setting's message - and only rendered when there is one,
+		// so the reference is never dangling.
+		const errorId = `setting-${entry.key}-error`;
+		const needsRestart = isRestartRequired(entry);
+		const isPendingRestart = restartRequiredKeys.includes(entry.key);
+
+		return (
+			<Card
+				key={entry.key}
+				className={cn(
+					"transition-colors",
+					isModified && !hasError && "border-primary/50",
+					hasError && "border-destructive/50",
+					isPendingRestart && "border-amber-400/50 bg-amber-50/30 dark:bg-amber-950/10"
+				)}
+			>
+				<CardHeader className="pb-3">
+					<div className="flex items-start justify-between">
+						<div>
+							<div className="flex items-center gap-2">
+								<CardTitle className="text-base">{entry.label}</CardTitle>
+								{needsRestart && (
+									<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
+										<RefreshCw className="w-2.5 h-2.5" />
+										Restart Required
+									</span>
+								)}
+								{isPendingRestart && (
+									/*
+									 * White on a solid `amber-500` measured 2.14 - the
+									 * worst text contrast in the app, and at 10px. It
+									 * failed in *both* themes, because a raw palette
+									 * fill and white are the same two colours whatever
+									 * the surface underneath.
+									 *
+									 * Now the wash pattern the sibling "Restart
+									 * Required" chip beside it already uses, on warning
+									 * tokens: 4.87 light / 7.45 dark. It keeps a
+									 * stronger border than that sibling so the two stay
+									 * distinguishable - "Pending" is the more urgent of
+									 * the pair and should not read as identical.
+									 */
+									<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-warning/50 bg-warning/15 text-[10px] font-medium text-warning-text">
+										Pending
+									</span>
+								)}
+							</div>
+							<CardDescription className="mt-1">{entry.description}</CardDescription>
+						</div>
+						{isModified && (
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => handleReset(entry)}
+								className="text-xs h-7 px-2"
+							>
+								Reset
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent>
+					{entry.type === "boolean" ? (
+						<div className="flex items-center gap-3">
+							<Switch
+								checked={currentValue === "true"}
+								onCheckedChange={(checked) => handleBooleanToggle(entry, checked)}
+								// The setting's name lives in the CardTitle above
+								// and is not associated with the control, so
+								// without this the switch announced as a bare
+								// "switch" - and every engine setting renders
+								// one of these.
+								aria-label={entry.label}
+							/>
+							<Label className="text-sm text-muted-foreground">
+								{currentValue === "true" ? "Enabled" : "Disabled"}
+							</Label>
+						</div>
+					) : entry.type === "enum" ? (
+						// The engine omits `options` entirely when a stored row's
+						// options fail to parse (logged there, not here) - render
+						// nothing rather than a select with no items, and never
+						// fall back to a label map kept in this file: labels come
+						// from the payload so the two sides of the boundary cannot
+						// drift apart.
+						entry.options && entry.options.length > 0 ? (
+							<Select
+								value={currentValue}
+								onValueChange={(value) => handleValueChange(entry, value)}
+							>
+								<SelectTrigger className="max-w-xs" aria-label={entry.label}>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{entry.options.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						) : null
+					) : (
+						<div className="space-y-2">
+							<div className="flex items-center gap-2">
+								<div className="relative">
+									<Input
+										type={
+											entry.type === "integer" || entry.type === "number"
+												? "number"
+												: "text"
+										}
+										value={currentValue}
+										onChange={(e) => handleValueChange(entry, e.target.value)}
+										className={cn(
+											"max-w-xs",
+											hasError && "border-destructive",
+											isSizeConfig(entry.key) && "pr-16"
+										)}
+										placeholder={
+											isSizeConfig(entry.key) ? "Enter bytes" : undefined
+										}
+										// Same as the Switch above: the name is in
+										// the CardTitle, which nothing links to this
+										// input.
+										aria-label={entry.label}
+										/*
+										 * Out-of-range values were signalled by a
+										 * red border and a line of text sitting
+										 * loose beside the field - colour alone,
+										 * and a message the field did not point
+										 * at. `aria-invalid` states it, and
+										 * `aria-describedby` reads the reason out
+										 * with the field instead of leaving it to
+										 * be found.
+										 *
+										 * `|| undefined` so valid fields carry no
+										 * attribute at all, rather than a
+										 * misleading aria-invalid="false" on every
+										 * setting on the screen.
+										 */
+										aria-invalid={hasError ? true : undefined}
+										aria-describedby={hasError ? errorId : undefined}
+										min={entry.min}
+										max={entry.max}
+									/>
+									{isSizeConfig(entry.key) && getFormattedSize(entry) && (
+										<span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">
+											{getFormattedSize(entry)}
+										</span>
+									)}
+								</div>
+								{(entry.min || entry.max) && (
+									<span className="text-xs text-muted-foreground whitespace-nowrap">
+										{isSizeConfig(entry.key)
+											? formatSizeRange(entry.min, entry.max) || ""
+											: entry.min && entry.max
+												? `${entry.min} - ${entry.max}`
+												: entry.min
+													? `Min: ${entry.min}`
+													: `Max: ${entry.max}`}
+									</span>
+								)}
+							</div>
+							{hasError && (
+								<p id={errorId} className="text-xs text-destructive-text">
+									{edited.error}
+								</p>
+							)}
+							{currentValue !== entry.default && (
+								<p className="text-xs text-muted-foreground">
+									Default:{" "}
+									{isSizeConfig(entry.key)
+										? formatBytes(parseInt(entry.default, 10) || 0)
+										: entry.default}
+								</p>
+							)}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		);
 	};
 
 	return (
 		<div className="flex-1 flex flex-col overflow-hidden">
 			{/* Restart Required Banner */}
 			{pendingRestart && (
-				<div className="bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 px-6 py-3 shrink-0">
-					<div className="flex items-center justify-between max-w-3xl mx-auto w-full">
-						<div className="flex items-center gap-3">
-							<div className="flex items-center justify-center w-8 h-8 rounded-full bg-amber-100 dark:bg-amber-900/50">
-								<AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-400" />
-							</div>
-							<div>
-								<p className="text-sm font-medium text-amber-800 dark:text-amber-200">
-									Engine restart required
-								</p>
-								<p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
-									Changes to{" "}
-									<span className="font-medium">
-										{getRestartRequiredLabels().join(", ")}
-									</span>{" "}
-									will take effect after restarting the engine
-								</p>
-							</div>
-						</div>
-						<div className="flex items-center gap-2">
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={clearRestartRequired}
-								className="border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/50"
-							>
-								<X className="w-4 h-4 mr-1.5" />
-								Dismiss
-							</Button>
-							<Button
-								size="sm"
-								className="bg-amber-600 hover:bg-amber-700 text-white"
-								disabled={isRestarting}
-								onClick={async () => {
-									if (window.electronAPI) {
-										setIsRestarting(true);
-										try {
-											const result = await window.electronAPI.restartEngine();
-											if (result.success) {
-												// Wait a moment for engine to fully initialize
-												await new Promise((resolve) =>
-													setTimeout(
-														resolve,
-														TIMING.ENGINE_RESTART_WAIT_MS
-													)
-												);
-												// Invalidate all queries to refresh data from the new engine instance
-												await queryClient.invalidateQueries();
-												clearRestartRequired();
-											} else {
-												window.alert(
-													`Failed to restart engine: ${result.error}`
-												);
-											}
-										} finally {
-											setIsRestarting(false);
-										}
-									} else {
-										// Running in browser (dev mode without electron)
-										window.alert(
-											"Engine restart is only available in the desktop app. Please restart the engine manually."
-										);
-									}
-								}}
-							>
-								{isRestarting ? (
-									<Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
-								) : (
-									<RefreshCw className="w-4 h-4 mr-1.5" />
-								)}
-								{isRestarting ? "Restarting..." : "Restart Engine"}
-							</Button>
-						</div>
-					</div>
-				</div>
+				<RestartRequiredBanner
+					labels={getRestartRequiredLabels()}
+					onDismiss={clearRestartRequired}
+				/>
 			)}
 
 			{/* Header */}
@@ -598,226 +788,35 @@ export default function SettingsMain() {
 			{/* Settings Grid */}
 			<div className="flex-1 overflow-auto p-6">
 				<div className="grid gap-4 max-w-3xl mx-auto">
-					{categoryEntries.map((entry) => {
-						const currentValue = getCurrentValue(entry);
-						const edited = editedValues[entry.key];
-						const isModified = edited !== undefined;
-						const hasError = edited?.error;
-						// Per entry, so `aria-describedby` never points at another
-						// setting's message - and only rendered when there is one,
-						// so the reference is never dangling.
-						const errorId = `setting-${entry.key}-error`;
-						const needsRestart = isRestartRequired(entry);
-						const isPendingRestart = restartRequiredKeys.includes(entry.key);
+					{primaryEntries.map(renderEntryCard)}
 
-						return (
-							<Card
-								key={entry.key}
-								className={cn(
-									"transition-colors",
-									isModified && !hasError && "border-primary/50",
-									hasError && "border-destructive/50",
-									isPendingRestart &&
-										"border-amber-400/50 bg-amber-50/30 dark:bg-amber-950/10"
-								)}
+					{advancedEntries.length > 0 && (
+						<section className="mt-2">
+							<button
+								type="button"
+								onClick={() => setAdvancedOpen((open) => !open)}
+								aria-expanded={advancedOpen}
+								className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
 							>
-								<CardHeader className="pb-3">
-									<div className="flex items-start justify-between">
-										<div>
-											<div className="flex items-center gap-2">
-												<CardTitle className="text-base">
-													{entry.label.replace(" (Requires Restart)", "")}
-												</CardTitle>
-												{needsRestart && (
-													<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
-														<RefreshCw className="w-2.5 h-2.5" />
-														Restart Required
-													</span>
-												)}
-												{isPendingRestart && (
-													/*
-													 * White on a solid `amber-500` measured 2.14 - the
-													 * worst text contrast in the app, and at 10px. It
-													 * failed in *both* themes, because a raw palette
-													 * fill and white are the same two colours whatever
-													 * the surface underneath.
-													 *
-													 * Now the wash pattern the sibling "Restart
-													 * Required" chip beside it already uses, on warning
-													 * tokens: 4.87 light / 7.45 dark. It keeps a
-													 * stronger border than that sibling so the two stay
-													 * distinguishable - "Pending" is the more urgent of
-													 * the pair and should not read as identical.
-													 */
-													<span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md border border-warning/50 bg-warning/15 text-[10px] font-medium text-warning-text">
-														Pending
-													</span>
-												)}
-											</div>
-											<CardDescription className="mt-1">
-												{entry.description}
-											</CardDescription>
-										</div>
-										{isModified && (
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => handleReset(entry)}
-												className="text-xs h-7 px-2"
-											>
-												Reset
-											</Button>
-										)}
-									</div>
-								</CardHeader>
-								<CardContent>
-									{entry.type === "boolean" ? (
-										<div className="flex items-center gap-3">
-											<Switch
-												checked={currentValue === "true"}
-												onCheckedChange={(checked) =>
-													handleBooleanToggle(entry, checked)
-												}
-												// The setting's name lives in the CardTitle above
-												// and is not associated with the control, so
-												// without this the switch announced as a bare
-												// "switch" - and every engine setting renders
-												// one of these.
-												aria-label={entry.label}
-											/>
-											<Label className="text-sm text-muted-foreground">
-												{currentValue === "true" ? "Enabled" : "Disabled"}
-											</Label>
-										</div>
-									) : entry.type === "enum" ? (
-										// The engine omits `options` entirely when a stored row's
-										// options fail to parse (logged there, not here) - render
-										// nothing rather than a select with no items, and never
-										// fall back to a label map kept in this file: labels come
-										// from the payload so the two sides of the boundary cannot
-										// drift apart.
-										entry.options && entry.options.length > 0 ? (
-											<Select
-												value={currentValue}
-												onValueChange={(value) =>
-													handleValueChange(entry, value)
-												}
-											>
-												<SelectTrigger
-													className="max-w-xs"
-													aria-label={entry.label}
-												>
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													{entry.options.map((option) => (
-														<SelectItem
-															key={option.value}
-															value={option.value}
-														>
-															{option.label}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-										) : null
-									) : (
-										<div className="space-y-2">
-											<div className="flex items-center gap-2">
-												<div className="relative">
-													<Input
-														type={
-															entry.type === "integer" ||
-															entry.type === "number"
-																? "number"
-																: "text"
-														}
-														value={currentValue}
-														onChange={(e) =>
-															handleValueChange(entry, e.target.value)
-														}
-														className={cn(
-															"max-w-xs",
-															hasError && "border-destructive",
-															isSizeConfig(entry.key) && "pr-16"
-														)}
-														placeholder={
-															isSizeConfig(entry.key)
-																? "Enter bytes"
-																: undefined
-														}
-														// Same as the Switch above: the name is in
-														// the CardTitle, which nothing links to this
-														// input.
-														aria-label={entry.label}
-														/*
-														 * Out-of-range values were signalled by a
-														 * red border and a line of text sitting
-														 * loose beside the field - colour alone,
-														 * and a message the field did not point
-														 * at. `aria-invalid` states it, and
-														 * `aria-describedby` reads the reason out
-														 * with the field instead of leaving it to
-														 * be found.
-														 *
-														 * `|| undefined` so valid fields carry no
-														 * attribute at all, rather than a
-														 * misleading aria-invalid="false" on every
-														 * setting on the screen.
-														 */
-														aria-invalid={hasError ? true : undefined}
-														aria-describedby={
-															hasError ? errorId : undefined
-														}
-														min={entry.min}
-														max={entry.max}
-													/>
-													{isSizeConfig(entry.key) &&
-														getFormattedSize(entry) && (
-															<span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">
-																{getFormattedSize(entry)}
-															</span>
-														)}
-												</div>
-												{(entry.min || entry.max) && (
-													<span className="text-xs text-muted-foreground whitespace-nowrap">
-														{isSizeConfig(entry.key)
-															? formatSizeRange(
-																	entry.min,
-																	entry.max
-																) || ""
-															: entry.min && entry.max
-																? `${entry.min} - ${entry.max}`
-																: entry.min
-																	? `Min: ${entry.min}`
-																	: `Max: ${entry.max}`}
-													</span>
-												)}
-											</div>
-											{hasError && (
-												<p
-													id={errorId}
-													className="text-xs text-destructive-text"
-												>
-													{edited.error}
-												</p>
-											)}
-											{currentValue !== entry.default && (
-												<p className="text-xs text-muted-foreground">
-													Default:{" "}
-													{isSizeConfig(entry.key)
-														? formatBytes(
-																parseInt(entry.default, 10) || 0
-															)
-														: entry.default}
-												</p>
-											)}
-										</div>
+								<ChevronRight
+									className={cn(
+										"w-4 h-4 transition-transform",
+										advancedOpen && "rotate-90"
 									)}
-								</CardContent>
-							</Card>
-						);
-					})}
+									aria-hidden="true"
+								/>
+								Advanced
+								<span className="text-xs font-normal">
+									({advancedEntries.length})
+								</span>
+							</button>
+							{advancedOpen && (
+								<div className="grid gap-4 mt-4">
+									{advancedEntries.map(renderEntryCard)}
+								</div>
+							)}
+						</section>
+					)}
 				</div>
 			</div>
 		</div>

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1360,6 +1360,19 @@ export interface ConfigEntry {
 	default: string;
 	min?: string;
 	max?: string;
+	/**
+	 * Whether the running engine keeps the old value until it is restarted.
+	 * Typed metadata the engine always sends (`config_entry_json`), replacing
+	 * the "(Requires Restart)" label substring both this app and the MCP
+	 * `update_config` tool used to parse out of the prose.
+	 */
+	requiresRestart: boolean;
+	/**
+	 * Whether the entry is an internal with no everyday user story (a lock
+	 * pragma, a watchdog backoff). Rendered collapsed under "Advanced" at the
+	 * bottom of its category rather than beside the settings people tune.
+	 */
+	advanced: boolean;
 	updatedAt: number;
 	/**
 	 * Present only on `type: "enum"` entries (e.g. `defaultHttpVersion`); the

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -189,6 +189,7 @@ Footer bar (h-8, shrink-0). Horizontal layout:
 
 - **Left - drawer switchers:** buttons for Collections (⇧⌘E), History (⇧⌘H), Variables (⇧⌘U), Settings (⌘,). Each activates its Drawer view; active state highlights when the drawer is open on that view. Settings sits here too because it is now a Drawer view like the rest.
 - **Middle - ambient status:** engine connection status (green dot + text if connected), save status (Saving… / Saved), app version. When the engine is *down* the indicator becomes a focusable tooltip carrying `engineError` - the health poll's reason, which was previously recorded and rendered nowhere, so a refused connection, a timeout and a TLS failure all read as one word. A save *failure* is not shown here - it is reported as a toast, like every other failure in the app.
+- **Middle - pending restart:** once a setting the engine marks `requiresRestart` has been saved, a "Restart pending" button appears beside the connection status and restarts the engine in place (`useEngineRestart`, shared with the Settings banner so the two cannot diverge). It tracks saves made since this renderer connected - not a comparison against the engine's running values, which it does not report - so it says *saved*, not *in effect*, and does not survive a renderer reload. A failed restart leaves the signal standing and reports the reason as a toast.
 - **Right - toggles:** Context bar toggle (⌘I). Pressed when the bar is open *and* the active tab is one it has content for, so the highlight always matches what is on screen.
 
 ## Request Builder (`modules/request-builder/`)
@@ -401,6 +402,8 @@ Same nav/content split as Variables: the category tree renders in the **Drawer**
 
 - **Sidebar (`sidebar/SettingsCategoryTree.tsx`)** - settings category navigation; rendered by the Drawer.
 - **Main (`main/`)** - `SettingsMain.tsx` (screen `"settings"`) hosts the app-settings category panels under `main/panels/`: `AppearancePanel.tsx`, `DashboardPanel.tsx`, `LoadTestingPanel.tsx`, `GeneralPanel.tsx`, and `EditorPanel.tsx`, plus the shared `ClientSettingsPanel.tsx` wrapper, `FontPicker.tsx`, and `SettingControls.tsx` primitives. `GeneralPanel` composes two cards of its own: `UpdatesCard.tsx` and `CookiesCard.tsx` (the engine's cookie jar - what it holds per environment, and the button that empties it). `app-panels.ts` is the panel registry/metadata. (The former monolithic `UISettingsPanel.tsx` was split into these panels in PR #55.)
+
+The engine categories render from `GET /config` metadata alone - no per-key branching in the component. Two flags on each entry shape the screen: `requiresRestart` draws the "Restart Required" chip (and, once saved, the "Pending" chip plus the banner and the Dock's signal), and `advanced` moves the entry into a collapsed **Advanced** section at the bottom of its category. Both are read as fields; the `"(Requires Restart)"` label substring they replaced is gone, and `config_route_test.cpp` guards it from coming back. The collapsed state is deliberately not persisted, and resets when the category changes.
 
 Adding an app panel is three edits and no branching: a member on `ClientSettingsCategory` (`types/domain.ts`), one entry in `APP_SETTINGS_PANELS`, and the panel file. The sidebar tree and `SettingsMain` both read the registry.
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -415,6 +415,8 @@ min/max/options):
       "default": "8",
       "min": "1",
       "max": "256",
+      "requiresRestart": true,
+      "advanced": false,
       "updatedAt": 1234567890
     },
     {
@@ -430,6 +432,8 @@ min/max/options):
         { "value": "http1.1", "label": "HTTP/1.x" },
         { "value": "http2", "label": "HTTP/2" }
       ],
+      "requiresRestart": false,
+      "advanced": false,
       "updatedAt": 1234567890
     }
   ]
@@ -441,6 +445,21 @@ types). `options` is present only for `type: "enum"` entries - a JSON array of
 `{value, label}`, so the renderer can draw a picker without a second,
 hand-maintained value-to-label map. `value` and `default` are always strings;
 `type` is one of `integer`, `number`, `boolean`, `string`, or `enum`.
+
+`requiresRestart` and `advanced` are booleans, always present:
+
+- **`requiresRestart`** - the running engine keeps the old value until it is
+  restarted; anything else takes effect on the next run, inbox or request that
+  reads it. It is the only statement of that fact: labels and descriptions no
+  longer spell it out, and the app renders one chip from this field (a pending
+  signal in the Dock too, once such a setting has been saved). Consumers must
+  read the field rather than parse the label - the old `(Requires Restart)`
+  suffix drifted out of step with the mechanism and misinformed the settings
+  screen and the MCP `update_config` result at the same time.
+- **`advanced`** - an internal with no everyday user story (`dbBusyTimeout`, the
+  three `oauth2Refresh*` watchdog knobs, `inboxLivePollIntervalMs`). Still
+  live and still settable; the app renders these collapsed under an "Advanced"
+  section at the bottom of their category.
 
 `defaultHttpVersion` is the only seeded `enum` entry today: the protocol a
 **newly created** request starts with (see [POST /requests](#post-requests)).

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -298,7 +298,7 @@ This matters because the seeded labels are wrong in places.
 
 | Key | Read site | When it applies |
 |---|---|---|
-| `workers` | `core/run_manager.cpp` | **Per run.** No restart, despite the "(Requires Restart)" label |
+| `workers` | `core/run_manager.cpp` | **Per run.** No restart, despite the entry's `requiresRestart: true` |
 | `eventLoopMaxPerHost` | `core/run_manager.cpp` | Per run |
 | `eventLoopMaxConcurrent` | `core/run_manager.cpp` | Per run, but **overridden** by the run's own `concurrency` |
 | `dnsCacheTimeout` | `core/run_manager.cpp` | Per run |
@@ -326,7 +326,7 @@ Tracked in [#197](https://github.com/athrvk/vayu/issues/197).
 ## Engine tuning notes
 
 Knobs that move RPS (set via `POST /config`; most are read **per run** - no
-restart needed despite the "Requires Restart" label on some):
+restart needed despite `requiresRestart: true` on some):
 
 - **run `concurrency`** - the dominant lever, and it is a property of the run,
   not the engine config. **64** on this target. Note the MCP safety cap

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -715,6 +715,17 @@ written by `POST /config`. Struct is `db::ConfigEntry`.
 | `max_value`     | TEXT    | Optional maximum (numbers)                             |
 | `options`       | TEXT    | JSON array of `{value, label}`; `"enum"` entries only  |
 | `updated_at`    | INTEGER | Unix ms                                                |
+| `requires_restart` | INTEGER | Boolean; the running engine keeps the old value until restarted |
+| `advanced`      | INTEGER | Boolean; an internal, rendered collapsed under "Advanced" |
+
+**requires_restart / advanced** are NOT NULL with a `default_value` of false, so
+`sync_schema` adds them to an existing table with `ALTER TABLE ADD COLUMN`
+rather than a copy-and-recreate. They are metadata, not user data: every startup
+re-seeds each row's metadata (values are preserved), so the backfill only holds
+between the ALTER and that upsert. `requires_restart` replaced a
+`"(Requires Restart)"` suffix in `label` that the app and the MCP tool surface
+both parsed out of the prose - one stale label misinformed both at once, and a
+test now asserts no label carries the substring.
 
 **options** is nullable and populated only for `type: "enum"` entries. It is
 JSON-in-TEXT, the same convention as every other structured column in this

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -202,9 +202,10 @@ Notes:
   regression from an improvement without knowing each metric's sense.
 - **`update_engine_config`** reads the config back after applying and flags any
   changed key that needs an engine **restart** to take effect under
-  `restartRequired` in its structured result (the engine marks these in each
-  entry's label). Such values are saved, but the running engine keeps the old
-  value until it is restarted, so the tool says so in its text output too.
+  `restartRequired` in its structured result (read from each entry's typed
+  `requiresRestart` field, not from its label). Such values are saved, but the
+  running engine keeps the old value until it is restarted, so the tool says so
+  in its text output too.
 - **The collection / request write verbs** are the CRUD an agent needs to work
   unattended: `create_collection` gives it a `collectionId` to file new requests
   under, and `update_request` / `delete_request` let it correct or remove a

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -1044,6 +1044,17 @@ struct ConfigEntry {
     std::optional<std::string> max_value; // Optional maximum (for numbers)
     std::optional<std::string> options; // JSON array of {value,label}, enum types only
     int64_t updated_at;                 // Last update timestamp
+    // Whether the running engine keeps the old value until it is restarted.
+    // Serialized as `requiresRestart`; the app and the MCP `update_config` tool
+    // both read it. It used to be spelled as a "(Requires Restart)" suffix in
+    // the label and substring-parsed by both, so a stale label lied to both at
+    // once - hence a typed field, and a test that no label carries the suffix.
+    bool requires_restart = false;
+    // Whether the setting is an internal that no everyday user story reaches
+    // (a lock pragma, a watchdog backoff). Serialized as `advanced`; the app
+    // renders these in a collapsed section at the bottom of their category
+    // rather than beside the settings people actually tune.
+    bool advanced = false;
 };
 
 /**

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -333,7 +333,14 @@ inline auto make_storage (const std::string& path) {
     make_column ("min_value", &ConfigEntry::min_value),
     make_column ("max_value", &ConfigEntry::max_value),
     make_column ("options", &ConfigEntry::options),
-    make_column ("updated_at", &ConfigEntry::updated_at)),
+    make_column ("updated_at", &ConfigEntry::updated_at),
+    // NOT NULL with a default_value, so sync_schema can ALTER TABLE ADD COLUMN
+    // these onto an existing config_entries table - the rows are re-seeded with
+    // their metadata on every startup anyway, so the backfill value is only
+    // what the row holds between the ALTER and that upsert.
+    make_column ("requires_restart", &ConfigEntry::requires_restart,
+    default_value (false)),
+    make_column ("advanced", &ConfigEntry::advanced, default_value (false))),
 
     // Globals: App-wide variables (singleton row with id="globals")
     make_table ("globals", make_column ("id", &Globals::id, primary_key ()),
@@ -1626,6 +1633,26 @@ void Database::seed_default_config () {
     std::chrono::system_clock::now ().time_since_epoch ())
                .count ();
 
+    // Metadata markers, wrapped around the entry they apply to so the flag is
+    // read at the top of the seed rather than counted out as a trailing
+    // positional `true` after `now`.
+    //
+    // restart_required: the running engine keeps the old value until restarted.
+    // The app shows one chip from this and the Dock a pending signal; nothing
+    // states it in the label or the description any more.
+    //
+    // advanced: an internal with no everyday user story. Rendered collapsed
+    // under "Advanced" at the bottom of its category, not removed - a knob that
+    // is still live is still reachable.
+    auto restart_required = [] (ConfigEntry entry) {
+        entry.requires_restart = true;
+        return entry;
+    };
+    auto advanced = [] (ConfigEntry entry) {
+        entry.advanced = true;
+        return entry;
+    };
+
     // Helper lambda: Creates or updates a config entry
     // - New entries get default values
     // - Existing entries preserve user-modified values but get updated metadata
@@ -1648,23 +1675,21 @@ void Database::seed_default_config () {
     // Core settings defining the application's base capacity and threading model
     // =========================================================================
 
-    upsert_config (ConfigEntry{ "workers",
-    std::to_string (std::thread::hardware_concurrency ()), "integer", "Worker Threads (Requires Restart)",
+    upsert_config (restart_required (ConfigEntry{ "workers",
+    std::to_string (std::thread::hardware_concurrency ()), "integer", "Worker Threads",
     "Number of background worker threads. Higher values improve throughput on "
     "multi-core systems but increase RAM usage. "
-    "Default equals CPU core count. Changes require engine restart to take "
-    "effect.",
+    "Default equals CPU core count.",
     "general_engine", std::to_string (std::thread::hardware_concurrency ()),
-    "1", "128", std::nullopt, now });
+    "1", "128", std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "maxConnections",
+    upsert_config (restart_required (ConfigEntry{ "maxConnections",
     std::to_string (vayu::core::constants::server::MAX_CONNECTIONS), "integer",
-    "Maximum Connections (Requires Restart)",
+    "Maximum Connections",
     "Global limit for simultaneous internal connections. Increasing "
-    "beyond system limits (ulimit) may cause instability. "
-    "Changes require engine restart to take effect.",
+    "beyond system limits (ulimit) may cause instability.",
     "general_engine", std::to_string (vayu::core::constants::server::MAX_CONNECTIONS),
-    "100", "100000", std::nullopt, now });
+    "100", "100000", std::nullopt, now }));
 
     upsert_config (ConfigEntry{ "defaultTimeout",
     std::to_string (vayu::core::constants::server::DEFAULT_TIMEOUT_MS), "integer", "Default Request Timeout",
@@ -1743,9 +1768,9 @@ void Database::seed_default_config () {
     // SQLite optimization settings for high-throughput load testing
     // =========================================================================
 
-    upsert_config (ConfigEntry{ "dbCacheSize",
+    upsert_config (restart_required (ConfigEntry{ "dbCacheSize",
     std::to_string (vayu::core::constants::database::CACHE_SIZE_BYTES),
-    "integer", "Database Cache Size (Requires Restart)",
+    "integer", "Database Cache Size",
     "Memory used to cache test results and metrics during high-RPS load tests. "
     "Larger values reduce disk writes when storing thousands of results per "
     "second, "
@@ -1755,11 +1780,11 @@ void Database::seed_default_config () {
     "database_performance", std::to_string (vayu::core::constants::database::CACHE_SIZE_BYTES),
     "1048576",    // min: 1MB in bytes
     "1073741824", // max: 1GB in bytes
-    std::nullopt, now });
+    std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "dbTempStore",
+    upsert_config (restart_required (ConfigEntry{ "dbTempStore",
     std::to_string (vayu::core::constants::database::TEMP_STORE), "integer",
-    "Temporary Tables Storage (Requires Restart)",
+    "Temporary Tables Storage",
     "Where temporary data is stored when generating test reports and "
     "aggregating metrics. "
     "Options: 0 = Default (file), 1 = Always use file, 2 = Always use memory. "
@@ -1768,11 +1793,11 @@ void Database::seed_default_config () {
     "active tests. "
     "Recommended for high-frequency reporting. Default: Memory.",
     "database_performance", std::to_string (vayu::core::constants::database::TEMP_STORE),
-    "0", "2", std::nullopt, now });
+    "0", "2", std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "dbMmapSize",
+    upsert_config (restart_required (ConfigEntry{ "dbMmapSize",
     std::to_string (vayu::core::constants::database::MMAP_SIZE_BYTES),
-    "integer", "Memory-Mapped I/O Size (Requires Restart)",
+    "integer", "Memory-Mapped I/O Size",
     "Amount of database file accessed directly from memory when reading "
     "test results and metrics. "
     "Example: 268435456 = 256MB. Speeds up dashboard updates and report "
@@ -1783,11 +1808,11 @@ void Database::seed_default_config () {
     "database_performance", std::to_string (vayu::core::constants::database::MMAP_SIZE_BYTES),
     "0",          // min: disabled
     "1073741824", // max: 1GB
-    std::nullopt, now });
+    std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "dbWalAutocheckpoint",
+    upsert_config (restart_required (ConfigEntry{ "dbWalAutocheckpoint",
     std::to_string (vayu::core::constants::database::WAL_AUTOCHECKPOINT),
-    "integer", "WAL Checkpoint Frequency (Requires Restart)",
+    "integer", "WAL Checkpoint Frequency",
     "How often SQLite saves accumulated test results to the main database file "
     "(in pages). "
     "During high-RPS tests, results accumulate in the WAL file. Lower values "
@@ -1797,11 +1822,11 @@ void Database::seed_default_config () {
     "grows larger). "
     "Recommended: 1000-2000 for tests with 50K+ requests. Default: 1000 pages.",
     "database_performance", std::to_string (vayu::core::constants::database::WAL_AUTOCHECKPOINT),
-    "100", "10000", std::nullopt, now });
+    "100", "10000", std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "dbBusyTimeout",
+    upsert_config (restart_required (advanced (ConfigEntry{ "dbBusyTimeout",
     std::to_string (vayu::core::constants::database::BUSY_TIMEOUT_MS),
-    "integer", "Database Lock Wait Time (Requires Restart)",
+    "integer", "Database Lock Wait Time",
     "How long SQLite waits (in milliseconds) when multiple threads try to "
     "write test results "
     "simultaneously. "
@@ -1814,11 +1839,11 @@ void Database::seed_default_config () {
     "database_performance", std::to_string (vayu::core::constants::database::BUSY_TIMEOUT_MS),
     "1000",  // min: 1 second
     "60000", // max: 60 seconds
-    std::nullopt, now });
+    std::nullopt, now })));
 
-    upsert_config (ConfigEntry{ "dbSynchronous",
+    upsert_config (restart_required (ConfigEntry{ "dbSynchronous",
     std::to_string (vayu::core::constants::database::SYNCHRONOUS), "integer",
-    "Data Safety Mode (Requires Restart)",
+    "Data Safety Mode",
     "How aggressively SQLite ensures test results are written to disk. "
     "Options: 0 = Off (fastest; the database stays consistent after a crash, "
     "but the most recent results may be lost on power failure or OS crash - "
@@ -1829,7 +1854,7 @@ void Database::seed_default_config () {
     "This setting directly impacts how fast results can be saved during "
     "high-RPS tests. Default: Off.",
     "database_performance", std::to_string (vayu::core::constants::database::SYNCHRONOUS),
-    "0", "2", std::nullopt, now });
+    "0", "2", std::nullopt, now }));
 
     // =========================================================================
     // NETWORK & CONNECTIVITY CONFIGURATION
@@ -1916,7 +1941,7 @@ void Database::seed_default_config () {
     "3600000", // 1 hour
     std::nullopt, now });
 
-    upsert_config (ConfigEntry{ "oauth2RefreshRetryMs",
+    upsert_config (advanced (ConfigEntry{ "oauth2RefreshRetryMs",
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS), "integer",
     "OAuth 2.0 Refresh Retry Delay",
     "First wait after a mid-run renewal is refused, doubled per consecutive "
@@ -1925,9 +1950,9 @@ void Database::seed_default_config () {
     "fatal - so this is about recovering from a token endpoint that blipped.",
     "network_performance",
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS),
-    "250", "600000", std::nullopt, now });
+    "250", "600000", std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "oauth2RefreshRetryMaxMs",
+    upsert_config (advanced (ConfigEntry{ "oauth2RefreshRetryMaxMs",
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS), "integer",
     "Maximum OAuth 2.0 Refresh Retry Delay",
     "Ceiling on that backoff, so a token endpoint that is down for an hour "
@@ -1935,9 +1960,9 @@ void Database::seed_default_config () {
     "seconds.",
     "network_performance",
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS),
-    "1000", "3600000", std::nullopt, now });
+    "1000", "3600000", std::nullopt, now }));
 
-    upsert_config (ConfigEntry{ "oauth2RefreshPollIntervalMs",
+    upsert_config (advanced (ConfigEntry{ "oauth2RefreshPollIntervalMs",
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
     "integer", "OAuth 2.0 Refresh Poll Interval",
     "How often the renewal watchdog wakes while it waits, to notice that the "
@@ -1949,7 +1974,7 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
     "10",   // 10ms - below this the wakeups outweigh what they save
     "5000", // 5s - past this a finished run visibly waits on the join
-    std::nullopt, now });
+    std::nullopt, now }));
 
     // Server-vitals monitor. Both are read per run - a change applies to the
     // next run started, no restart. The interval *bounds* (250-60000ms) are
@@ -2251,7 +2276,7 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::inbox::MIN_CAPTURES),
     std::to_string (vayu::core::constants::inbox::CAPTURES_CEILING), std::nullopt, now });
 
-    upsert_config (ConfigEntry{ "inboxLivePollIntervalMs",
+    upsert_config (advanced (ConfigEntry{ "inboxLivePollIntervalMs",
     std::to_string (vayu::core::constants::inbox::LIVE_POLL_INTERVAL_MS), "integer",
     "Inbox Live Poll Interval",
     "How often a watched inbox checks for newly arrived captures. This is the "
@@ -2260,7 +2285,7 @@ void Database::seed_default_config () {
     "on the capture path itself.",
     "observability", std::to_string (vayu::core::constants::inbox::LIVE_POLL_INTERVAL_MS),
     std::to_string (vayu::core::constants::inbox::MIN_LIVE_POLL_INTERVAL_MS),
-    std::to_string (vayu::core::constants::inbox::MAX_LIVE_POLL_INTERVAL_MS), std::nullopt, now });
+    std::to_string (vayu::core::constants::inbox::MAX_LIVE_POLL_INTERVAL_MS), std::nullopt, now }));
 
     if (existing.empty ()) {
         vayu::utils::log_info ("Seeded default configuration values");

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -63,7 +63,12 @@ nlohmann::json config_entry_json (const vayu::db::ConfigEntry& entry) {
             "' has malformed options JSON, omitting it: " + e.what ());
         }
     }
-    entry_json["updatedAt"] = entry.updated_at;
+    // Always present, both of them: a consumer that has to distinguish "false"
+    // from "this engine does not send it" is back to guessing, which is the
+    // habit the typed flag replaced.
+    entry_json["requiresRestart"] = entry.requires_restart;
+    entry_json["advanced"]        = entry.advanced;
+    entry_json["updatedAt"]       = entry.updated_at;
     return entry_json;
 }
 

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
 #include <string>
 #include <utility>
 
@@ -235,6 +236,110 @@ TEST_F (ConfigRouteTest, SeededDefaultHttpVersionOptionsMatchAllHttpVersionsInOr
         EXPECT_EQ (options[i]["value"], vayu::to_string (versions[i]));
         EXPECT_EQ (options[i]["label"], vayu::http_version_label (versions[i]));
     }
+}
+
+
+// ---------------------------------------------------------------------------
+// requiresRestart / advanced: typed metadata, not a label convention.
+// ---------------------------------------------------------------------------
+
+// The whole point of the field: a consumer asks the entry, not the prose. Both
+// values are asserted, because a serializer that always sent `true` would pass
+// a one-sided check.
+TEST_F (ConfigRouteTest, RestartRequiredSerializesAsATypedFlagBothWays) {
+    auto [status, body] =
+    vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"4"}})");
+    ASSERT_EQ (status, 200);
+
+    json restarts = find_entry (body, "workers");
+    ASSERT_TRUE (restarts.contains ("requiresRestart"));
+    EXPECT_TRUE (restarts["requiresRestart"].get<bool> ());
+
+    // Read per run, so a change applies to the next run started.
+    json does_not = find_entry (body, "defaultTimeout");
+    ASSERT_TRUE (does_not.contains ("requiresRestart"));
+    EXPECT_FALSE (does_not["requiresRestart"].get<bool> ());
+}
+
+// The convention this replaced, guarded against creeping back: the flag is the
+// only statement, so no label may also spell it out. Scans the whole seeded
+// catalogue and asserts it scanned something - a guard that reads an empty
+// list passes for the wrong reason.
+TEST_F (ConfigRouteTest, NoSeededLabelOrDescriptionSpellsOutTheRestartRequirement) {
+    auto entries = db_->get_all_config_entries ();
+    ASSERT_GT (entries.size (), 20u)
+    << "catalogue empty or unseeded - nothing was scanned";
+
+    size_t restart_required_count = 0;
+    for (const auto& entry : entries) {
+        EXPECT_EQ (entry.label.find ("Requires Restart"), std::string::npos)
+        << "entry '" << entry.key << "' states the restart requirement in its "
+        << "label";
+        EXPECT_EQ (entry.description.find ("require engine restart"),
+        std::string::npos)
+        << "entry '" << entry.key << "' states the restart requirement in its "
+        << "description";
+        if (entry.requires_restart) {
+            ++restart_required_count;
+        }
+    }
+    // The statement has to live somewhere: dropping the suffix without setting
+    // the flag would satisfy the scan above and tell the user nothing.
+    EXPECT_GT (restart_required_count, 0u);
+}
+
+// Membership is the recorded decision (#520), so it is pinned by key rather
+// than by count - an entry added to or dropped from the group has to say so
+// here.
+TEST_F (ConfigRouteTest, AdvancedFlagsExactlyTheRecordedInternals) {
+    const std::set<std::string> expected = { "dbBusyTimeout",
+        "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs",
+        "oauth2RefreshPollIntervalMs", "inboxLivePollIntervalMs" };
+
+    auto entries = db_->get_all_config_entries ();
+    ASSERT_FALSE (entries.empty ()) << "catalogue empty - nothing was scanned";
+
+    std::set<std::string> actual;
+    for (const auto& entry : entries) {
+        if (entry.advanced) {
+            actual.insert (entry.key);
+        }
+    }
+    EXPECT_EQ (actual, expected);
+}
+
+TEST_F (ConfigRouteTest, AdvancedSerializesOnTheWire) {
+    auto [status, body] =
+    vayu::http::routes::apply_config_update (*db_, R"({"entries":{"workers":"4"}})");
+    ASSERT_EQ (status, 200);
+
+    json internal = find_entry (body, "dbBusyTimeout");
+    ASSERT_TRUE (internal.contains ("advanced"));
+    EXPECT_TRUE (internal["advanced"].get<bool> ());
+
+    json everyday = find_entry (body, "workers");
+    ASSERT_TRUE (everyday.contains ("advanced"));
+    EXPECT_FALSE (everyday["advanced"].get<bool> ());
+}
+
+// A write must not flatten metadata it does not carry. POST /config sends only
+// values, so the update path copies the stored row - if it ever rebuilt the
+// entry instead, both flags would silently reset to false and every restart
+// chip in the app would vanish after one save.
+TEST_F (ConfigRouteTest, UpdatingAValueKeepsItsMetadataFlags) {
+    auto [status, body] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"dbBusyTimeout":"20000"}})");
+    ASSERT_EQ (status, 200);
+
+    auto stored = db_->get_config_entry ("dbBusyTimeout");
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_EQ (stored->value, "20000");
+    EXPECT_TRUE (stored->requires_restart);
+    EXPECT_TRUE (stored->advanced);
+
+    json entry = find_entry (body, "dbBusyTimeout");
+    EXPECT_TRUE (entry["requiresRestart"].get<bool> ());
+    EXPECT_TRUE (entry["advanced"].get<bool> ());
 }
 
 } // namespace


### PR DESCRIPTION
## Description

The only signal the engine sent for "this needs a restart" was the literal substring `(Requires Restart)` in an entry's **label**, regex-matched by *both* consumers - `SettingsMain.tsx:65` and `tools.ts:818` (feeding `update_config`'s `restartRequired` result) - so one stale label misinformed the settings screen and an agent at the same time, and a single card stated the fact three times over (label suffix, chip, closing description sentence). Separately, five live entries are internals no user story reaches, rendering as first-class rows beside daily-use settings because key order is the only ordering the panel has.

**Plan.** Root cause: the restart requirement was carried as prose, so it had no single owner - the copy could not be reworded without minding two parsers, and the two parsers could not be trusted without minding the copy. Approach: `ConfigEntry` gains `requires_restart` and `advanced` as real columns, serialized on every entry by the existing `config_entry_json` (the one shape both `GET /config` and `POST /config` answer with), and both consumers read the field. The alternative rejected: deriving the flag app-side from a key list, which is the "config one branch defines and another re-derives" defect `CLAUDE.md` calls out - the engine knows which values it reads at startup, and a list in the renderer would drift the moment a read site moved.

### Decisions worth reviewing

1. **`workers` keeps `requiresRestart: true`.** That is a faithful translation of the label it carried, not a new claim. Whether it is *true of the mechanism* is #197's question (`benchmarks.md` records that it is applied per run) - that doc line now points at the field instead of the label, so the discrepancy stays visible rather than being quietly resolved by this PR.
2. **Advanced membership, as recorded here:** `dbBusyTimeout`, `oauth2RefreshRetryMs`, `oauth2RefreshRetryMaxMs`, `oauth2RefreshPollIntervalMs`, `inboxLivePollIntervalMs` - the issue's list unchanged. They are hidden, never removed: each is still live and still settable. Pinned by key in a test, so amending the group has to say so.
3. **The pending signal tracks saves, and says so.** The issue asked to choose the honest source. The engine does not report its *effective* values, so a comparison against them would be inferred rather than known - the Dock therefore reports restart-required saves made since this renderer connected (the existing `engine-store` latch) and the copy says "saved", not "in effect". Consequence, stated in the code and in `COMPONENTS.md`: it does not survive a renderer reload.
4. **`window.alert` is gone from the restart path.** The restart moved into a shared `useEngineRestart` hook (banner + Dock), so the wait-then-invalidate-then-clear sequence exists once; a modal alert raised from the Dock would block the whole app over a failure every other surface reports as a toast. A failed restart now leaves the pending signal standing - it is the user's evidence the saved value is not live yet. (The `window.alert` calls in `GeneralPanel` are #523's, untouched.)
5. **Seeds carry the flags through two named markers** - `restart_required (ConfigEntry{…})` / `advanced (…)` - rather than trailing positional booleans after `now`, which would have been two unlabelled `true`s at the end of a 10-field aggregate.
6. **Migration.** Both columns are NOT NULL with a `default_value`, so `sync_schema` adds them with `ALTER TABLE ADD COLUMN` (the pattern `requests.follow_redirects` already uses) rather than a copy-and-recreate. Verified by hand, not assumed: a database written in the pre-change shape with a user-modified `workers = 7` was opened with the new binary - the value survived, the columns were added, the label lost its suffix and `GET /config` reported `requiresRestart: true`.

### App / MCP, traced

- **App (required by the issue, done):** `SettingsMain.tsx` reads the field, renders the Advanced group, and no longer strips a substring out of two labels; `Dock.tsx` gains the pending signal; `domain.ts` types both fields as required booleans (the app and engine ship together, and an optional field would have re-introduced "maybe it just was not sent").
- **MCP:** `restartRequiredAmong` reads `requiresRestart === true`; `update_config`'s result shape is unchanged, so nothing an agent consumes moves. `docs/engine/mcp.md` did name the label convention ("the engine marks these in each entry's label") and is corrected.
- **Other consumers, checked:** nothing else in the app or the CLI enumerates config keys or parses labels (`useMonitorSettings`/`useLiveChartSettings` read named keys), and `apply_config_update` copies the stored row, so a value write cannot flatten the metadata - which now has its own test.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure`: **1431/1431 passed** (178s). `cd app && pnpm test`: **4047/4047 passed** (401 files, 167s). `pnpm type-check`, `pnpm lint`, `pnpm format:check` all clean. `mkdocs build --strict -f .github/mkdocs.yml` passes (2.59s). No pre-existing failures on either side.

Engine - five new tests in `config_route_test.cpp`:

- `RestartRequiredSerializesAsATypedFlagBothWays` - asserts both values, so a serializer that always sent `true` cannot pass.
- `NoSeededLabelOrDescriptionSpellsOutTheRestartRequirement` - the grep-shaped guard the issue asked for, over the whole catalogue, asserting it scanned something non-empty (per the repo rule) *and* that at least one entry still carries the flag - dropping the suffix without setting the field would otherwise satisfy it while telling the user nothing.
- `AdvancedFlagsExactlyTheRecordedInternals` - set equality by key, not a count.
- `AdvancedSerializesOnTheWire`
- `UpdatingAValueKeepsItsMetadataFlags` - the written-never-read guard on the update path: if `apply_config_update` ever rebuilt the entry instead of copying it, every restart chip would vanish after one save.

App - two new files plus the existing banner test extended:

- `SettingsMain.advanced-section.test.tsx` (4) - collapsed by default with the flagged entry *not rendered* (not merely last, which is what "collapsed" has to mean for a screen reader), expands and collapses, counts, and is absent entirely from a category with no internals. Fixtures are keyed so key-sort alone would interleave them.
- `Dock.pending-restart.test.tsx` (4) - absent when nothing is pending, present after a save, restarts and lowers itself, and - on a failed restart - keeps standing and reports the reason as an `error` toast.
- `SettingsMain.restart-banner.test.tsx` gains the twin case: an entry whose label still reads `(Requires Restart)` while the flag says `false` must raise **nothing**.

**Mutation checks (run, not assumed):**

- `isRestartRequired` reverted to `entry.label.includes("(Requires Restart)")` → 4 of the 6 restart-banner tests **FAILED**, including both new ones; restored, all pass.
- `primaryEntries` reverted to the unfiltered `categoryEntries` → 2 of the 4 advanced-section tests **FAILED**; restored, all pass.

clang-format was applied to the changed line ranges only - the touched engine files are not clang-format clean at HEAD and `CLAUDE.md` forbids reformatting the rest. Prettier ran only on files that were already clean.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Same commit: `docs/engine/api-reference.md` (both fields in the `GET /config` shape, with what each means and why consumers must not parse the label), `docs/engine/db-schema.md` (the two columns and the ALTER-vs-recreate reason), `docs/engine/mcp.md` (the corrected `update_config` sentence), `docs/engine/benchmarks.md` (two lines that referred to the now-deleted label suffix - they would have been stale on merge), `docs/app/COMPONENTS.md` (the Dock's pending signal and how the engine categories render from metadata).

## Related Issues

Closes #520

Sub-issue 2 of #518. Wave 1, parallel-safe against #521/#522; #519 is gated on PR #517 merging (per the owner's coordination note there) and was skipped this run. The one-line overlap with #519 in the `database.cpp` seed block is the trivial rebase the issue anticipated - this edits seed *shape*, #519 edits seed *values*. #523 (wave 2) consumes this structured flag.

---
_Generated by [Claude Code](https://claude.ai/code/session_016corypqqbyAKiAw9eL9bzw)_