### PR TITLE
fix(config): retire eleven dead engine settings and wire the twelfth

### DIFF
--- a/app/src/modules/settings/utils/format-size.ts
+++ b/app/src/modules/settings/utils/format-size.ts
@@ -69,15 +69,13 @@ export function parseSizeToBytes(sizeStr: string): number | null {
 
 /**
  * Check if a config key is size-related
+ *
+ * Engine keys only, and only ones the engine still seeds - `maxJsonFieldSize`
+ * and `dbMmapSize` were retired in #519 and dropped from here with them, since
+ * an entry naming a key that no longer arrives can never match.
  */
 export function isSizeConfig(key: string): boolean {
-	const sizeKeys = [
-		"scriptMemoryLimit",
-		"scriptStackSize",
-		"maxJsonFieldSize",
-		"dbCacheSize",
-		"dbMmapSize",
-	];
+	const sizeKeys = ["scriptMemoryLimit", "scriptStackSize", "dbCacheSize"];
 	return sizeKeys.includes(key);
 }
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -410,11 +410,11 @@ min/max/options):
       "value": "8",
       "type": "integer",
       "label": "Worker Threads",
-      "description": "Number of worker threads for load generation.",
-      "category": "performance",
+      "description": "Number of background worker threads. Higher values improve throughput on multi-core systems but increase RAM usage. Default equals CPU core count.",
+      "category": "general_engine",
       "default": "8",
       "min": "1",
-      "max": "256",
+      "max": "128",
       "requiresRestart": true,
       "advanced": false,
       "updatedAt": 1234567890
@@ -461,10 +461,13 @@ hand-maintained value-to-label map. `value` and `default` are always strings;
   live and still settable; the app renders these collapsed under an "Advanced"
   section at the bottom of their category.
 
-`defaultHttpVersion` is the only seeded `enum` entry today: the protocol a
+Two entries are seeded as `enum` today. `defaultHttpVersion` is the protocol a
 **newly created** request starts with (see [POST /requests](#post-requests)).
 It is a write-time seed only - changing it never alters a request that already
-exists, and it is never consulted at execution time.
+exists, and it is never consulted at execution time. `dbSynchronous` is
+SQLite's durability level, whose three values (`"0"` Off, `"1"` Normal, `"2"`
+Full) are an enumeration rather than a range; it is stored as an `enum` so the
+panel draws a picker instead of an integer box the description has to explain.
 
 The Settings panel renders entries dynamically, so new keys appear without app
 changes. These `observability` keys govern how much a run keeps - most of them
@@ -510,7 +513,7 @@ entries, its `min`/`max` range; `boolean` entries must be `"true"` or `"false"`;
 range, nothing is applied and the response is `400` with the specific reason(s):
 
 ```json
-{ "error": { "code": "invalid_config", "message": "'workers' must be at most 256 (got 9999)" } }
+{ "error": { "code": "invalid_config", "message": "'workers' must be at most 128 (got 9999)" } }
 ```
 
 **Success response:** `200` - the full updated entries array (same shape as

--- a/docs/engine/benchmarks.md
+++ b/docs/engine/benchmarks.md
@@ -291,7 +291,7 @@ DB. Note this is the same direction as, but far smaller than, the 30-40% UI
 contention figure this page previously carried - that larger figure was not
 reproduced and should not be quoted.
 
-## Config semantics: live, restart-gated, and dead
+## Config semantics: live, restart-gated, and retired
 
 Every entry below was verified by locating the read site in the engine source.
 This matters because the seeded labels are wrong in places.
@@ -307,9 +307,15 @@ This matters because the seeded labels are wrong in places.
 | `maxResponseBodyBytes` | `core/run_manager.cpp` | Per run |
 | `oauth2RefreshLeadMs`, `oauth2RefreshMinIntervalMs`, `oauth2RefreshRetryMs`, `oauth2RefreshRetryMaxMs`, `oauth2RefreshPollIntervalMs` | `core/auth_refresh.cpp` (read at `core/run_manager.cpp`) | Per run. Mid-run OAuth 2.0 renewal: lead time, floor between renewals, the retry backoff's first wait and ceiling, and how often the watchdog wakes to notice the run ended |
 | `inboxMaxBodyBytes`, `inboxMaxCaptures`, `inboxLivePollIntervalMs` | `http/routes/inbox.cpp` (`read_inbox_limits`) | **Per inbox.** Resolved when `POST /inbox/start` runs; a running inbox keeps what it was started with |
-| `dbSynchronous`, `dbBusyTimeout`, `dbCacheSize`, `dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint` | `db/database.cpp` | DB open. **Restart required** |
-| `maxConnections` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |
-| `statsInterval` | **none** - only the seed | **Dead config**, tracked in [#112](https://github.com/athrvk/vayu/issues/112) |
+| `dbSynchronous`, `dbBusyTimeout`, `dbCacheSize` | `db/database.cpp` | DB open. **Restart required.** `dbCacheSize` is per-connection state, so it is re-applied to every connection from the value read at startup |
+
+The dead entries this table used to list - `maxConnections` and `statsInterval`,
+plus `tcpKeepAliveIdle` / `tcpKeepAliveInterval`, `maxJsonFieldSize`, the three
+`sse*` keys, and the three database PRAGMAs with no tuning story
+(`dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint`) - were retired in
+[#519](https://github.com/athrvk/vayu/issues/519). They no longer seed, and an
+upgraded database sheds the rows. The behaviour they claimed to control is
+unchanged: each one's constant is still what the engine applies.
 
 `loop_config.max_concurrent` is set from the run's `concurrency`, which is why
 `eventLoopMaxConcurrent` acts only as a default for runs that do not specify one.
@@ -374,7 +380,7 @@ For load testing this class of target on this machine:
 | `eventLoopMaxPerHost` | 500 | Not binding at c=64; removes any doubt |
 | `dnsCacheTimeout` | 3600 | Target hostname never needs re-resolution |
 | `scriptEnableConsole` | false | Matters only when scripts run |
-| `dbSynchronous` / `dbTempStore` | 0 / 2 | Already optimal by default |
+| `dbSynchronous` | 0 (Off) | Already optimal by default |
 | measurement method | standalone engine | Worth ~9% versus running through the app |
 
 ## Reproduce it

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -704,7 +704,7 @@ written by `POST /config`. Struct is `db::ConfigEntry`.
 
 | Column          | Type    | Notes                                                  |
 |-----------------|---------|--------------------------------------------------------|
-| `key`           | TEXT PK | e.g. `workers`, `maxConnections`, `liveTickIntervalMs` |
+| `key`           | TEXT PK | e.g. `workers`, `dbCacheSize`, `liveTickIntervalMs` |
 | `value`         | TEXT    | Current value (parsed per `type`)                      |
 | `type`          | TEXT    | `"integer"` / `"string"` / `"boolean"` / `"number"` / `"enum"` |
 | `label`         | TEXT    | Display label                                          |

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -195,8 +195,6 @@ constexpr size_t SLO_BREACH_WINDOWS = 2;
  * @brief Server configuration
  */
 namespace server {
-/// Maximum total connections allowed
-constexpr size_t MAX_CONNECTIONS = 10000;
 /// Default request timeout in milliseconds
 constexpr int DEFAULT_TIMEOUT_MS = 30000;
 /// Interval for collecting statistics in milliseconds
@@ -294,18 +292,6 @@ constexpr int DEFAULT_SCRAPE_TIMEOUT_MS = 0;
 /// three quarters of it would time out before a loopback endpoint could answer.
 constexpr int MIN_DERIVED_SCRAPE_TIMEOUT_MS = 100;
 } // namespace monitor
-
-/**
- * @brief Server-Sent Events (SSE) configuration
- */
-namespace sse {
-/// Maximum retry interval for SSE reconnection in milliseconds
-constexpr int MAX_RETRY_MS = 30000;
-/// Connection timeout for SSE in milliseconds
-constexpr int CONNECT_TIMEOUT_MS = 30000;
-/// Whether to send Last-Event-ID header on reconnect
-constexpr bool SEND_LAST_EVENT_ID = true;
-} // namespace sse
 
 /**
  * @brief Script engine configuration

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -346,6 +346,18 @@ class Database {
     std::vector<ConfigEntry> get_all_config_entries ();
     void seed_default_config (); // Initialize default config values if empty
 
+    /**
+     * @brief SQLite page-cache size in force on the last connection opened, in
+     * bytes (0 before the first one).
+     *
+     * `cache_size` is per-connection state, so the value from `dbCacheSize` is
+     * re-applied every time sqlite_orm opens a connection and then read back
+     * from SQLite - this reports the answer, not the request. It is the only
+     * way to observe that the setting reached the database, which is what makes
+     * the wiring testable and the startup line honest about what it applied.
+     */
+    int applied_cache_size_bytes () const;
+
     // Type-safe config getters (replaces ConfigManager)
     int get_config_int (const std::string& key, int default_value = 0);
     std::string get_config_string (const std::string& key,

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -35,6 +35,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <functional>
@@ -369,31 +370,40 @@ struct Database::Impl {
     Storage storage;
     std::recursive_mutex mutex;
 
+    /// Page cache the open callback gives every connection, in bytes. Seeded
+    /// with the compile-time default and overwritten once, from `dbCacheSize`,
+    /// while `init` runs - which is exactly why that entry is restart-required:
+    /// a later write to the config row never reaches this member.
+    /// Atomic because sqlite_orm opens connections from whichever thread needs
+    /// one, so the callback reads this concurrently with that one write.
+    std::atomic<int> cache_size_bytes{ vayu::core::constants::database::CACHE_SIZE_BYTES };
+
+    /// What SQLite reported back after the most recent open, in bytes (0 until
+    /// the first connection). Read back rather than echoed, so it states the
+    /// size in force instead of the size requested.
+    std::atomic<int> applied_cache_size_bytes{ 0 };
+
     Impl (const std::string& path) : storage (make_storage (path)) {
         std::filesystem::path db_path (path);
         if (db_path.has_parent_path ()) {
             std::filesystem::create_directories (db_path.parent_path ());
         }
 
-        // Set on_open callback to apply database optimizations when connection is established
-        // Note: These use default constants. To use custom values from UI settings,
-        // users must restart the engine after changing settings.
-        storage.on_open = [] (sqlite3* db) {
+        // Applied on every connection sqlite_orm opens, since a PRAGMA is
+        // per-connection state. Only `cache_size` is configurable; the other
+        // three are engine defaults with no user story (their config entries
+        // were retired in #519) and stay compile-time constants.
+        storage.on_open = [this] (sqlite3* db) {
             char* err_msg = nullptr;
             std::stringstream sql;
 
-            // Use default constants for database optimizations
-            // These settings require engine restart to take effect and are
-            // applied from constants at startup. Users can change them via
-            // Settings UI, but changes only apply after restarting the engine.
-            int cache_size_bytes = vayu::core::constants::database::CACHE_SIZE_BYTES;
             int temp_store   = vayu::core::constants::database::TEMP_STORE;
             size_t mmap_size = vayu::core::constants::database::MMAP_SIZE_BYTES;
             int wal_checkpoint = vayu::core::constants::database::WAL_AUTOCHECKPOINT;
 
             // Apply optimizations
             // SQLite cache_size PRAGMA uses negative KB values (e.g., -64000 = 64MB)
-            int cache_size_kb = -(cache_size_bytes / 1024);
+            int cache_size_kb = -(cache_size_bytes.load () / 1024);
             sql << "PRAGMA cache_size = " << cache_size_kb << ";";
             int rc = sqlite3_exec (db, sql.str ().c_str (), nullptr, nullptr, &err_msg);
             if (rc != SQLITE_OK && err_msg) {
@@ -403,6 +413,20 @@ struct Database::Impl {
                 err_msg = nullptr;
             }
             sql.str ("");
+
+            // Read the size back instead of trusting the write: a rejected
+            // PRAGMA is silent, and only the connection can say what it holds.
+            sqlite3_stmt* stmt = nullptr;
+            if (sqlite3_prepare_v2 (db, "PRAGMA cache_size;", -1, &stmt, nullptr) == SQLITE_OK) {
+                if (sqlite3_step (stmt) == SQLITE_ROW) {
+                    // Negative means KB, positive means pages - we always set
+                    // the negative form, so a positive answer means the write
+                    // did not take and the size in bytes is not knowable here.
+                    const int reported = sqlite3_column_int (stmt, 0);
+                    applied_cache_size_bytes.store (reported < 0 ? -reported * 1024 : 0);
+                }
+                sqlite3_finalize (stmt);
+            }
 
             sql << "PRAGMA temp_store = " << temp_store << ";";
             rc = sqlite3_exec (db, sql.str ().c_str (), nullptr, nullptr, &err_msg);
@@ -571,9 +595,16 @@ void Database::init () {
     // Seed default configuration values if empty (must be before reading config)
     seed_default_config ();
 
-    // Apply database optimizations from config (or use defaults)
-    // Note: These settings require engine restart to take effect
-    // The on_open callback applies defaults; config values are read here for runtime adjustments
+    // Apply the three configurable database PRAGMAs. All are read once, here,
+    // so a later write to any of them reaches the engine on the next start -
+    // which is what their restart-required flag promises.
+    //
+    // `cache_size` is per-connection state, so it cannot be applied once like
+    // the other two: it is handed to the open callback, which re-applies it to
+    // every connection sqlite_orm opens. Setting it before the first read below
+    // means that read already carries it.
+    impl_->cache_size_bytes.store (
+    get_config_int ("dbCacheSize", vayu::core::constants::database::CACHE_SIZE_BYTES));
 
     // Get synchronous mode (0=OFF, 1=NORMAL, 2=FULL)
     int synchronous =
@@ -585,21 +616,8 @@ void Database::init () {
     get_config_int ("dbBusyTimeout", vayu::core::constants::database::BUSY_TIMEOUT_MS);
     impl_->storage.pragma.busy_timeout (busy_timeout);
 
-    // Log current configuration (other PRAGMAs are set in on_open callback and require restart)
-    int cache_size_bytes =
-    get_config_int ("dbCacheSize", vayu::core::constants::database::CACHE_SIZE_BYTES);
-    int temp_store =
-    get_config_int ("dbTempStore", vayu::core::constants::database::TEMP_STORE);
-    int mmap_size      = get_config_int ("dbMmapSize",
-         static_cast<int> (vayu::core::constants::database::MMAP_SIZE_BYTES));
-    int wal_checkpoint = get_config_int (
-    "dbWalAutocheckpoint", vayu::core::constants::database::WAL_AUTOCHECKPOINT);
-
     vayu::utils::log_debug ("Database initialized with WAL mode (cache=" +
-    std::to_string (cache_size_bytes / 1024) +
-    "KB, mmap=" + std::to_string (mmap_size / 1024 / 1024) + "MB, " +
-    "temp_store=" + std::to_string (temp_store) + ", " +
-    "wal_checkpoint=" + std::to_string (wal_checkpoint) + " pages, " +
+    std::to_string (applied_cache_size_bytes () / 1024) + "KB, " +
     "busy_timeout=" + std::to_string (busy_timeout) + "ms, " +
     "synchronous=" + std::to_string (synchronous) + ")");
 
@@ -1540,6 +1558,12 @@ std::vector<ConfigEntry> Database::get_all_config_entries () {
     return impl_->storage.get_all<ConfigEntry> ();
 }
 
+int Database::applied_cache_size_bytes () const {
+    // No DB mutex: the value is an atomic the open callback writes, and taking
+    // the mutex here would order this read behind whatever query is running.
+    return impl_->applied_cache_size_bytes.load ();
+}
+
 // Type-safe config getters (replaces ConfigManager)
 int Database::get_config_int (const std::string& key, int default_value) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
@@ -1603,6 +1627,17 @@ std::string http_version_options_json () {
     }
     return options.dump ();
 }
+
+// The `{value,label}` array for "dbSynchronous". SQLite's synchronous levels
+// are its own enumeration, not ours, so the list is literal - but it belongs in
+// the `options` column rather than spelled out as "0 = Off, 1 = ..." prose over
+// an integer input, which is what the entry used to do.
+std::string db_synchronous_options_json () {
+    const nlohmann::json options = { { { "value", "0" }, { "label", "Off" } },
+        { { "value", "1" }, { "label", "Normal" } },
+        { { "value", "2" }, { "label", "Full" } } };
+    return options.dump ();
+}
 } // namespace
 
 void Database::seed_default_config () {
@@ -1617,7 +1652,35 @@ void Database::seed_default_config () {
     //                      script context pool is grown lazily and never read a
     //                      bound (issue #112). A user could set it 1..256 and
     //                      change nothing.
-    for (const char* retired : { "requestBatchSize", "contextPoolSize" }) {
+    //
+    // The 2026-08 sweep (#519) retired eleven more. Each was verified by
+    // searching the engine for a reader; where the constant behind the key kept
+    // its own callers, the constant stayed and only the knob went.
+    //
+    //   maxConnections       - no reader anywhere; the server enforces no such
+    //                          global limit.
+    //   tcpKeepAliveIdle     - curl_utils sets both CURL keep-alive options from
+    //   tcpKeepAliveInterval   constants and never consults the config.
+    //   statsInterval        - superseded by liveTickIntervalMs, which shares its
+    //                          default and its purpose and is the one that is
+    //                          read. Two rows, one mechanism.
+    //   maxJsonFieldSize     - json.cpp caps stored fields at the constant, so
+    //                          the "increase only if..." escape hatch the
+    //                          description offered did not exist.
+    //   sseConnectTimeout    - the dashboard's reconnect logic is renderer-side
+    //   sseMaxRetry            and never asked the engine for these; the sse::*
+    //   sseSendLastEventId     constants existed only to seed them.
+    //   dbTempStore          - all three are PRAGMAs the open callback applies
+    //   dbMmapSize             from constants. Wiring them buys nothing: the
+    //   dbWalAutocheckpoint    defaults are already the measured optimum (see
+    //                          docs/engine/benchmarks.md) and none has a user
+    //                          story. dbCacheSize, the one that does, is wired
+    //                          instead of retired.
+    for (const char* retired : { "requestBatchSize", "contextPoolSize",
+             "maxConnections", "tcpKeepAliveIdle", "tcpKeepAliveInterval",
+             "statsInterval", "maxJsonFieldSize", "sseConnectTimeout",
+             "sseMaxRetry", "sseSendLastEventId", "dbTempStore", "dbMmapSize",
+             "dbWalAutocheckpoint" }) {
         impl_->storage.remove_all<ConfigEntry> (
         where (c (&ConfigEntry::key) == std::string (retired)));
     }
@@ -1682,14 +1745,6 @@ void Database::seed_default_config () {
     "Default equals CPU core count.",
     "general_engine", std::to_string (std::thread::hardware_concurrency ()),
     "1", "128", std::nullopt, now }));
-
-    upsert_config (restart_required (ConfigEntry{ "maxConnections",
-    std::to_string (vayu::core::constants::server::MAX_CONNECTIONS), "integer",
-    "Maximum Connections",
-    "Global limit for simultaneous internal connections. Increasing "
-    "beyond system limits (ulimit) may cause instability.",
-    "general_engine", std::to_string (vayu::core::constants::server::MAX_CONNECTIONS),
-    "100", "100000", std::nullopt, now }));
 
     upsert_config (ConfigEntry{ "defaultTimeout",
     std::to_string (vayu::core::constants::server::DEFAULT_TIMEOUT_MS), "integer", "Default Request Timeout",
@@ -1771,90 +1826,38 @@ void Database::seed_default_config () {
     upsert_config (restart_required (ConfigEntry{ "dbCacheSize",
     std::to_string (vayu::core::constants::database::CACHE_SIZE_BYTES),
     "integer", "Database Cache Size",
-    "Memory used to cache test results and metrics during high-RPS load tests. "
-    "Larger values reduce disk writes when storing thousands of results per "
-    "second, "
-    "improving test throughput. "
-    "Recommended: 64-128MB for tests generating 10K+ results/second. Default: "
-    "64MB.",
+    "Memory SQLite keeps per connection for recently used database pages. A "
+    "larger cache spares repeated reads while a high-RPS run writes results and "
+    "the dashboard queries them. 64 to 128 megabytes suits runs storing 10,000 "
+    "or more results a second.",
     "database_performance", std::to_string (vayu::core::constants::database::CACHE_SIZE_BYTES),
     "1048576",    // min: 1MB in bytes
     "1073741824", // max: 1GB in bytes
     std::nullopt, now }));
 
-    upsert_config (restart_required (ConfigEntry{ "dbTempStore",
-    std::to_string (vayu::core::constants::database::TEMP_STORE), "integer",
-    "Temporary Tables Storage",
-    "Where temporary data is stored when generating test reports and "
-    "aggregating metrics. "
-    "Options: 0 = Default (file), 1 = Always use file, 2 = Always use memory. "
-    "Memory (2) significantly speeds up report generation and metric "
-    "calculations during "
-    "active tests. "
-    "Recommended for high-frequency reporting. Default: Memory.",
-    "database_performance", std::to_string (vayu::core::constants::database::TEMP_STORE),
-    "0", "2", std::nullopt, now }));
-
-    upsert_config (restart_required (ConfigEntry{ "dbMmapSize",
-    std::to_string (vayu::core::constants::database::MMAP_SIZE_BYTES),
-    "integer", "Memory-Mapped I/O Size",
-    "Amount of database file accessed directly from memory when reading "
-    "test results and metrics. "
-    "Example: 268435456 = 256MB. Speeds up dashboard updates and report "
-    "generation by avoiding disk reads. "
-    "Larger values improve real-time metric streaming performance. "
-    "Recommended: 256-512MB for large test runs. "
-    "Default: 256MB.",
-    "database_performance", std::to_string (vayu::core::constants::database::MMAP_SIZE_BYTES),
-    "0",          // min: disabled
-    "1073741824", // max: 1GB
-    std::nullopt, now }));
-
-    upsert_config (restart_required (ConfigEntry{ "dbWalAutocheckpoint",
-    std::to_string (vayu::core::constants::database::WAL_AUTOCHECKPOINT),
-    "integer", "WAL Checkpoint Frequency",
-    "How often SQLite saves accumulated test results to the main database file "
-    "(in pages). "
-    "During high-RPS tests, results accumulate in the WAL file. Lower values "
-    "save more "
-    "frequently (reduces WAL size, but may slow writes). "
-    "Higher values batch saves less often (faster result storage, but WAL file "
-    "grows larger). "
-    "Recommended: 1000-2000 for tests with 50K+ requests. Default: 1000 pages.",
-    "database_performance", std::to_string (vayu::core::constants::database::WAL_AUTOCHECKPOINT),
-    "100", "10000", std::nullopt, now }));
-
     upsert_config (restart_required (advanced (ConfigEntry{ "dbBusyTimeout",
     std::to_string (vayu::core::constants::database::BUSY_TIMEOUT_MS),
     "integer", "Database Lock Wait Time",
-    "How long SQLite waits (in milliseconds) when multiple threads try to "
-    "write test results "
-    "simultaneously. "
-    "During high-concurrency load tests, result storage threads compete for "
-    "database access. "
-    "Higher values prevent 'database is locked' errors but may delay error "
-    "reporting. "
-    "Recommended: 10-30 seconds for tests with 100+ concurrent requests. "
-    "Default: 10 seconds. ",
+    "How long a thread waits for the database when another one is writing to "
+    "it. Result-storage threads compete for it during a high-concurrency run, "
+    "and a longer wait turns a 'database is locked' failure into a pause "
+    "instead. 10 to 30 seconds suits runs at 100 or more concurrent requests.",
     "database_performance", std::to_string (vayu::core::constants::database::BUSY_TIMEOUT_MS),
     "1000",  // min: 1 second
     "60000", // max: 60 seconds
     std::nullopt, now })));
 
     upsert_config (restart_required (ConfigEntry{ "dbSynchronous",
-    std::to_string (vayu::core::constants::database::SYNCHRONOUS), "integer",
+    std::to_string (vayu::core::constants::database::SYNCHRONOUS), "enum",
     "Data Safety Mode",
-    "How aggressively SQLite ensures test results are written to disk. "
-    "Options: 0 = Off (fastest; the database stays consistent after a crash, "
-    "but the most recent results may be lost on power failure or OS crash - "
-    "acceptable for test telemetry), 1 = Normal (balanced), 2 = Full (safest, "
-    "slowest). "
-    "For load testing, Off (0) is recommended - it maximizes write throughput "
-    "for storing results while keeping the database uncorrupted. "
-    "This setting directly impacts how fast results can be saved during "
-    "high-RPS tests. Default: Off.",
+    "How hard SQLite works to get results onto disk before reporting them "
+    "written. Off is the fastest and the default: the database stays "
+    "uncorrupted through a crash, but the last few results may be lost to a "
+    "power cut, which is an acceptable trade for test telemetry. Normal and "
+    "Full buy durability back at the cost of write throughput during a "
+    "high-RPS run.",
     "database_performance", std::to_string (vayu::core::constants::database::SYNCHRONOUS),
-    "0", "2", std::nullopt, now }));
+    std::nullopt, std::nullopt, db_synchronous_options_json (), now }));
 
     // =========================================================================
     // NETWORK & CONNECTIVITY CONFIGURATION
@@ -1870,7 +1873,8 @@ void Database::seed_default_config () {
     "1", "10000", std::nullopt, now });
 
     upsert_config (ConfigEntry{ "eventLoopMaxPerHost",
-    std::to_string (vayu::core::constants::event_loop::MAX_PER_HOST), "integer", "Max connections per host (per worker)",
+    std::to_string (vayu::core::constants::event_loop::MAX_PER_HOST), "integer",
+    "Max Connections Per Host (Per Worker)",
     "Concurrency limit for a specific target API host. Critical for respecting "
     "target rate limits. "
     "Lower values are gentler on the target; higher values maximize "
@@ -1889,25 +1893,6 @@ void Database::seed_default_config () {
     "0",    // Disable cache
     "3600", // 1 hour
     std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "tcpKeepAliveIdle",
-    std::to_string (vayu::core::constants::event_loop::TCP_KEEPALIVE_IDLE_SECONDS),
-    "integer", "TCP Keep-Alive Idle Time",
-    "Time before sending keep-alive probes on idle connections. Prevents "
-    "firewall drops. "
-    "Lower values detect dead connections faster.",
-    "network_performance",
-    std::to_string (vayu::core::constants::event_loop::TCP_KEEPALIVE_IDLE_SECONDS),
-    "1", "300", std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "tcpKeepAliveInterval",
-    std::to_string (vayu::core::constants::event_loop::TCP_KEEPALIVE_INTERVAL_SECONDS),
-    "integer", "TCP Keep-Alive Interval",
-    "Frequency of probes after idle timeout is reached. "
-    "Usually set to the same value as Keep-Alive Idle Time.",
-    "network_performance",
-    std::to_string (vayu::core::constants::event_loop::TCP_KEEPALIVE_INTERVAL_SECONDS),
-    "1", "300", std::nullopt, now });
 
     // Mid-run OAuth 2.0 refresh. A load run renews a header-placed access token
     // before it expires, so a run longer than its token does not turn into a
@@ -2067,15 +2052,6 @@ void Database::seed_default_config () {
     // Settings for real-time dashboards (SSE), metrics aggregation, and data parsing limits
     // =========================================================================
 
-    upsert_config (ConfigEntry{ "statsInterval",
-    std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
-    "integer", "Statistics Collection Interval",
-    "Frequency of metric aggregation. Lower values = smoother UI but higher "
-    "CPU overhead. "
-    "Recommended: 100-500ms for most use cases.",
-    "observability", std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
-    "10", "10000", std::nullopt, now });
-
     upsert_config (ConfigEntry{ "liveTickIntervalMs",
     std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
     "integer", "Live Metrics Tick Interval (ms)",
@@ -2095,8 +2071,8 @@ void Database::seed_default_config () {
     "mid-run. One setting drives both, so they cannot disagree; the dashboard's "
     "Live Dashboard panel edits this same value. Expressed as time, so it "
     "survives a change to the tick interval. 0 means the full run (no time "
-    "limit). Memory is bounded at 20,000 ticks per run either way, so a fast "
-    "tick interval reaches that ceiling before a long window does.",
+    "limit). Live Metrics Tick Ceiling is the memory backstop either way, so a "
+    "fast tick interval reaches that ceiling before a long window does.",
     "observability",
     std::to_string (vayu::core::constants::server::DEFAULT_LIVE_REPLAY_WINDOW_MS),
     "0", "3600000", std::nullopt, now });
@@ -2141,19 +2117,6 @@ void Database::seed_default_config () {
     "stored report immediately).",
     "observability", "60000",
     "0", "600000", std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "maxJsonFieldSize",
-    std::to_string (vayu::core::constants::json::MAX_FIELD_SIZE), "integer", "Maximum JSON Field Size",
-    "Maximum size for JSON strings stored in saved requests (params, "
-    "headers, body, auth) when loading from database. "
-    "Fields exceeding this limit are returned as empty objects or "
-    "strings to prevent out-of-memory errors. "
-    "Default 10MB. Increase only if saved requests with very large JSON "
-    "fields fail to load properly.",
-    "observability", std::to_string (vayu::core::constants::json::MAX_FIELD_SIZE),
-    "1024",      // 1KB
-    "104857600", // 100MB
-    std::nullopt, now });
 
     upsert_config (ConfigEntry{ "maxTraceBodyBytes",
     std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES), "integer",
@@ -2241,28 +2204,6 @@ void Database::seed_default_config () {
     "file on disk. In-progress runs are never pruned. Default 30.",
     "observability", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
     "0", "3650", std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "sseConnectTimeout",
-    std::to_string (vayu::core::constants::sse::CONNECT_TIMEOUT_MS), "integer", "SSE Connection Timeout",
-    "Timeout for establishing dashboard live streams. "
-    "Increase if the UI shows connection errors during heavy load tests. "
-    "Value is in milliseconds (30000 = 30 seconds).",
-    "observability", std::to_string (vayu::core::constants::sse::CONNECT_TIMEOUT_MS),
-    "1000", "300000", std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "sseMaxRetry",
-    std::to_string (vayu::core::constants::sse::MAX_RETRY_MS), "integer", "SSE Max Retry Interval",
-    "Max exponential backoff wait time for dashboard reconnection. "
-    "Lower values reconnect faster but may cause rapid retries if the engine "
-    "is busy.",
-    "observability", std::to_string (vayu::core::constants::sse::MAX_RETRY_MS),
-    "1000", "300000", std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "sseSendLastEventId",
-    vayu::core::constants::sse::SEND_LAST_EVENT_ID ? "true" : "false", "boolean",
-    "SSE Send Last Event ID", "Resumes data streams from the last received event. Disable if using incompatible proxies.",
-    "observability", vayu::core::constants::sse::SEND_LAST_EVENT_ID ? "true" : "false",
-    std::nullopt, std::nullopt, std::nullopt, now });
 
     // Webhook inbox. All three are read once when an inbox starts, so a change
     // applies to the next inbox started - no restart. The running listener keeps

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
 #include "vayu/db/database.hpp"
 
 namespace vayu::db {
@@ -258,6 +259,75 @@ TEST_F (DatabaseTest, SeedRemovesRetiredContextPoolSizeEntry) {
     db.seed_default_config ();
 
     EXPECT_FALSE (db.get_config_entry ("contextPoolSize").has_value ());
+}
+
+// The 2026-08 sweep (#519) retired eleven more keys at once: nothing read them,
+// so a user could turn any of them and change nothing. Pinned as a list rather
+// than one test per key - the guarantee is identical for all of them, and a key
+// added to the retirement list without its row being deleted is the only way
+// this can regress.
+TEST_F (DatabaseTest, SeedRemovesTheSweepRetiredEntries) {
+    const std::vector<std::string> retired = { "maxConnections", "tcpKeepAliveIdle",
+        "tcpKeepAliveInterval", "statsInterval", "maxJsonFieldSize",
+        "sseConnectTimeout", "sseMaxRetry", "sseSendLastEventId", "dbTempStore",
+        "dbMmapSize", "dbWalAutocheckpoint" };
+
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    for (const auto& key : retired) {
+        EXPECT_FALSE (db.get_config_entry (key).has_value ())
+        << "a fresh seed must not create the retired key '" << key << "'";
+
+        ConfigEntry stale;
+        stale.key           = key;
+        stale.value         = "1";
+        stale.type          = "integer";
+        stale.label         = "Left behind";
+        stale.description   = "left behind by an older version";
+        stale.category      = "general_engine";
+        stale.default_value = "1";
+        stale.updated_at    = 1;
+        db.save_config_entry (stale);
+        ASSERT_TRUE (db.get_config_entry (key).has_value ());
+    }
+
+    db.seed_default_config ();
+
+    for (const auto& key : retired) {
+        EXPECT_FALSE (db.get_config_entry (key).has_value ())
+        << "an upgraded database must shed the retired key '" << key << "'";
+    }
+}
+
+// "dbCacheSize" survived the sweep by being wired: it is the one database
+// PRAGMA with a tuning story, and until #519 the seed logged the configured
+// value while the connection got the compile-time constant. `cache_size` is
+// per-connection state, so the check is on a *reopened* database - which is
+// also the restart the entry's flag demands.
+TEST_F (DatabaseTest, CacheSizeConfigReachesTheConnection) {
+    constexpr int kConfigured = 128 * 1024 * 1024;
+    constexpr int kDefault    = vayu::core::constants::database::CACHE_SIZE_BYTES;
+    static_assert (kConfigured != kDefault, "the test value must differ from the default");
+
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+        EXPECT_EQ (db.applied_cache_size_bytes (), kDefault)
+        << "an unconfigured database opens at the compile-time default";
+
+        auto entry = db.get_config_entry ("dbCacheSize");
+        ASSERT_TRUE (entry.has_value ()) << "the entry survived the sweep";
+        entry->value = std::to_string (kConfigured);
+        db.save_config_entry (*entry);
+
+        EXPECT_EQ (db.applied_cache_size_bytes (), kDefault)
+        << "the running engine keeps the old size - that is what requiresRestart means";
+    }
+
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    EXPECT_EQ (reopened.applied_cache_size_bytes (), kConfigured);
 }
 
 // The "options" column is new (Task 4); an existing on-disk database predates


### PR DESCRIPTION
## Description

**Plan.** Root cause: twelve of the 51 seeded engine config entries had no reader. Eight were written-never-read (`maxConnections`, `tcpKeepAliveIdle`, `tcpKeepAliveInterval`, `statsInterval`, `maxJsonFieldSize`, `sseConnectTimeout`, `sseMaxRetry`, `sseSendLastEventId`); four database PRAGMAs (`dbCacheSize`, `dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint`) were read into a startup log line while the connection callback applied compile-time constants, so a user could change a value, restart as the label demanded, and get the constant anyway. Approach: retire eleven through the delete list `seed_default_config` already carries for `requestBatchSize` / `contextPoolSize`, and wire the twelfth - `dbCacheSize`, the one PRAGMA with a tuning story - by reading it once into an atomic the open callback applies to every connection. Rejected alternative: wiring all four PRAGMAs. `dbTempStore` / `dbMmapSize` / `dbWalAutocheckpoint` are already at their measured optimum (`docs/engine/benchmarks.md`) and none has a user story, so wiring them would keep four knobs alive to buy nothing - a knob whose only correct value is its default is a knob that should not exist. Their behaviour is untouched; only the settings rows go.

Verified against master `24fb4bf` rather than the issue's `298e174`: #517 and #528 have since merged, so `ConfigEntry` now carries typed `requires_restart` / `advanced` fields. All twelve defects still reproduce as described; the copy fixes are written against the new flags (no description restates the restart requirement).

**Wiring detail.** `cache_size` is per-connection state, so one application at startup would not survive - sqlite_orm opens a connection per operation. The value is read once into `Impl::cache_size_bytes` (atomic; the callback runs on whichever thread needs a connection) and re-applied on every open. Reading it once is exactly what the restart-required flag promises. The callback reads the size back from SQLite instead of echoing what it wrote, so `Database::applied_cache_size_bytes()` reports the size in force - that is what makes the wiring observable to a test, and the startup log line now states it instead of four values it was not applying.

**Constants.** `server::MAX_CONNECTIONS` and the whole `sse::*` namespace had no callers left once the seeds went, and are deleted. The keep-alive, stats-interval and JSON-field-size constants keep their real readers (`curl_utils.cpp`, `run_manager.cpp`, `json.cpp`) and stay.

**Copy** (per #518 voice conventions, only on entries this commit already touches):
- `liveReplayWindowMs` no longer claims memory is bounded at 20,000 ticks - that contradicted its neighbour; Live Metrics Tick Ceiling owns the bound (default 50,000, configurable) and the text now defers to it.
- `dbBusyTimeout`: trailing space and four sentences gone.
- `eventLoopMaxPerHost`: Title Case label.
- `dbSynchronous` becomes an `enum` with `{value,label}` options rather than "0 = Off, 1 = Normal, 2 = Full" prose over an integer box (convention 5). Existing stored values (`"0"`/`"1"`/`"2"`) validate unchanged against the new options.

**Deviation from the issue spec.** The issue records "App changes: None, verified". That is very nearly right - the panel renders the catalogue dynamically - but one app-side list names keys by hand: `isSizeConfig` (`format-size.ts`) listed `maxJsonFieldSize` and `dbMmapSize`, which can no longer arrive. Both dropped; `dbCacheSize` stays. Nothing else in `app/` or `app/electron/` references a retired key, and MCP `update_config` rejects unknown keys already.

**Wire-or-retire decision, recorded:** wire `dbCacheSize`; retire `dbTempStore`, `dbMmapSize`, `dbWalAutocheckpoint`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **1438 of 1439 passed**. The one failure is `ThreadPoolTest.SubmitTask` (Timeout), which passes on its own and in a re-run - a scheduling flake under a 1439-test parallel run in this container, unrelated to this change and not touched by it.

`cd app && pnpm test` - 4047 passed across 401 files. `pnpm type-check`, `pnpm lint`, `pnpm format:check` all clean.

Two new tests in `engine/tests/db_test.cpp`:
- `SeedRemovesTheSweepRetiredEntries` - all eleven keys: a fresh seed never creates them, and a database carrying the row loses it on re-seed (the upgrade path).
- `CacheSizeConfigReachesTheConnection` - an unconfigured database opens at the compile-time default; writing `dbCacheSize` does **not** move the running instance (which is what `requiresRestart` means); a reopened database reports the configured size. **Mutation-checked**: reverting the open callback to the constant fails this test and only this test.

`mkdocs build --strict` was not run - mkdocs is not installed in this environment. The docs edits add no page, link or anchor (table rows, one prose paragraph, one heading whose anchor nothing links to), so there is nothing for the strict gate to break; CI covers it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the `GET /config` example's `workers` entry drifted from the seed on max, category and description - aligned to 128 / `general_engine` / the seeded text, with the matching `400` example; the "only seeded enum" line now names `dbSynchronous` too), `docs/engine/benchmarks.md` (config-semantics table and recommended-settings row; the two "Dead config, tracked in #112" rows become one paragraph covering all eleven retirements), `docs/engine/db-schema.md` (the `config_entries` key example named `maxConnections`).

## Related Issues
Closes #519

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBAd1THznDEkZmqx81M1ZM)_