### PR TITLE
fix(mcp): the safety panel's copy must match its mechanism, and a cap must not exceed its ceiling

### DIFF
--- a/app/electron/mcp/config.test.ts
+++ b/app/electron/mcp/config.test.ts
@@ -9,11 +9,14 @@ import { describe, it, expect } from "vitest";
 import {
 	buildSafetyConfigFromEnv,
 	DEFAULT_MCP_SAFETY_CONFIG,
+	MCP_CAP_CEILINGS,
 	normalizeHost,
 	resolveSafetyConfig,
 	sanitizeSafetyInput,
+	type McpCapKey,
 } from "./config.js";
 import { checkAllowlist, checkLoadCaps } from "./safety.js";
+import { LOAD_TEST_CEILING_BOUNDS } from "@/constants/load-test";
 
 describe("normalizeHost", () => {
 	it("strips scheme, port, path, and query and lowercases", () => {
@@ -85,6 +88,49 @@ describe("sanitizeSafetyInput", () => {
 		).toBeUndefined();
 		expect(sanitizeSafetyInput({ maxIterations: 5000.7 }).maxIterations).toBe(5000);
 		expect(sanitizeSafetyInput({ maxIterations: 0 }).maxIterations).toBeUndefined();
+	});
+
+	/*
+	 * A cap above its ceiling used to be stored verbatim, so Settings could hold
+	 * a Max concurrency of 50,000 while the engine refuses anything over 10,000:
+	 * the panel showed a guardrail that no run could ever reach, and the run it
+	 * was meant to bound died on an engine 400 instead.
+	 */
+	it("holds each cap at its ceiling instead of storing a value no run can reach", () => {
+		const keys = Object.keys(MCP_CAP_CEILINGS) as McpCapKey[];
+		expect(keys.length).toBe(4);
+		for (const key of keys) {
+			const ceiling = MCP_CAP_CEILINGS[key];
+			expect(sanitizeSafetyInput({ [key]: ceiling + 1 })[key]).toBe(ceiling);
+			expect(sanitizeSafetyInput({ [key]: ceiling * 10 })[key]).toBe(ceiling);
+			// The ceiling itself and everything under it are the user's to set.
+			expect(sanitizeSafetyInput({ [key]: ceiling })[key]).toBe(ceiling);
+			expect(sanitizeSafetyInput({ [key]: 7 })[key]).toBe(7);
+		}
+	});
+
+	it("holds an over-ceiling cap read back from a hand-edited config file too", () => {
+		// `loadPersistedSafety` re-sanitizes what it reads, so a file edited
+		// while the app was closed cannot smuggle a cap past the ceiling.
+		const resolved = resolveSafetyConfig(sanitizeSafetyInput({ maxConcurrency: 99_999 }));
+		expect(resolved.maxConcurrency).toBe(MCP_CAP_CEILINGS.maxConcurrency);
+	});
+
+	/*
+	 * Second copy of the same four numbers: the renderer's ceiling bounds and
+	 * this sanitizer. `electron/` production code may not import `src/`, so the
+	 * copy stays - this is the half of the chain that keeps it honest, the
+	 * renderer-to-engine half living in
+	 * `src/constants/load-test.engine-parity.test.ts`. The load dialog and an
+	 * agent must not disagree about the largest run Vayu will start.
+	 */
+	it("mirrors the ceilings the load dialog itself will not exceed", () => {
+		expect(MCP_CAP_CEILINGS).toEqual({
+			maxRps: LOAD_TEST_CEILING_BOUNDS.rps.MAX,
+			maxConcurrency: LOAD_TEST_CEILING_BOUNDS.concurrency.MAX,
+			maxDurationSeconds: LOAD_TEST_CEILING_BOUNDS.durationSeconds.MAX,
+			maxIterations: LOAD_TEST_CEILING_BOUNDS.iterations.MAX,
+		});
 	});
 
 	it("keeps allowWrites only when it is a boolean", () => {
@@ -166,6 +212,18 @@ describe("buildSafetyConfigFromEnv", () => {
 		expect(config.maxIterations).toBe(250);
 		expect(checkLoadCaps({ mode: "iterations", iterations: 251 }, config).ok).toBe(false);
 		expect(checkLoadCaps({ mode: "iterations", iterations: 250 }, config).ok).toBe(true);
+	});
+
+	it("holds an over-ceiling cap the same way the Settings path does", () => {
+		const { config, ignored } = buildSafetyConfigFromEnv({
+			VAYU_MCP_MAX_CONCURRENCY: "50000",
+		});
+
+		expect(config.maxConcurrency).toBe(MCP_CAP_CEILINGS.maxConcurrency);
+		// Held, not thrown away: `ignored` is for values that fell back to a
+		// default, and this one is in force at the ceiling.
+		expect(ignored).toEqual([]);
+		expect(checkLoadCaps({ concurrency: 10_001 }, config).ok).toBe(false);
 	});
 
 	it("rejects a non-positive cap the same way the Settings path does", () => {

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -150,11 +150,58 @@ function isFiniteNumber(v: unknown): v is number {
 	return typeof v === "number" && Number.isFinite(v);
 }
 
+/** The four numeric caps, which share one range rule. */
+export type McpCapKey = "maxRps" | "maxConcurrency" | "maxDurationSeconds" | "maxIterations";
+
+const MCP_CAP_KEYS: readonly McpCapKey[] = [
+	"maxRps",
+	"maxConcurrency",
+	"maxDurationSeconds",
+	"maxIterations",
+];
+
+/**
+ * The highest value each cap may hold - the maxima of the renderer's
+ * `LOAD_TEST_CEILING_BOUNDS`, which are the engine's own guards where the engine
+ * has one (`concurrency` at 10x `event_loop::MAX_CONCURRENT`, `durationSeconds`
+ * at the per-transfer timeout guard) and the point past which a single desktop
+ * engine is the wrong tool where it does not.
+ *
+ * A cap above its ceiling is not a looser policy, it is an absent one: the value
+ * it would admit is refused by the engine or beyond anything Vayu will compose
+ * anyway, and the user is left believing a guardrail exists where none does. So
+ * the sanitizer holds each cap at its ceiling rather than storing it.
+ *
+ * Literals rather than an import because production code in `electron/` may not
+ * reach into `src/` - `tsconfig.node.json` withholds the `@/*` mapping on
+ * purpose - the same reason `MAX_IN_FLIGHT_BOUND` in `tools.ts` is a literal.
+ * The copies are kept honest from the test side: `config.test.ts` ties these to
+ * the renderer constant, and `load-test.engine-parity.test.ts` ties that to the
+ * engine header.
+ */
+export const MCP_CAP_CEILINGS = {
+	maxRps: 1_000_000,
+	maxConcurrency: 10_000,
+	maxDurationSeconds: 86_400,
+	maxIterations: 100_000_000,
+} as const satisfies Record<McpCapKey, number>;
+
+/**
+ * A cap as a whole number inside its ceiling, or undefined when the input is not
+ * a usable cap at all (non-numeric, zero, negative, NaN) - which the caller
+ * drops, leaving the default in force rather than a cap that cannot fire.
+ */
+function clampCap(key: McpCapKey, value: unknown): number | undefined {
+	if (!isFiniteNumber(value) || value <= 0) return undefined;
+	return Math.min(Math.floor(value), MCP_CAP_CEILINGS[key]);
+}
+
 /**
  * Sanitize a partial safety override arriving from the (untrusted) renderer
  * before it is applied or persisted: normalize + de-duplicate allowlist hosts,
- * clamp caps to positive integers, and drop anything malformed. Only recognized,
- * well-formed fields survive - every other input is ignored rather than trusted.
+ * hold caps to whole numbers between 1 and their ceiling, and drop anything
+ * malformed. Only recognized, well-formed fields survive - every other input is
+ * ignored rather than trusted.
  */
 export function sanitizeSafetyInput(input: Partial<McpSafetyConfig>): Partial<McpSafetyConfig> {
 	const out: Partial<McpSafetyConfig> = {};
@@ -166,17 +213,9 @@ export function sanitizeSafetyInput(input: Partial<McpSafetyConfig>): Partial<Mc
 			.filter((h) => h.length > 0);
 		out.allowlist = Array.from(new Set(hosts));
 	}
-	if (isFiniteNumber(input.maxRps) && input.maxRps > 0) {
-		out.maxRps = Math.floor(input.maxRps);
-	}
-	if (isFiniteNumber(input.maxConcurrency) && input.maxConcurrency > 0) {
-		out.maxConcurrency = Math.floor(input.maxConcurrency);
-	}
-	if (isFiniteNumber(input.maxDurationSeconds) && input.maxDurationSeconds > 0) {
-		out.maxDurationSeconds = Math.floor(input.maxDurationSeconds);
-	}
-	if (isFiniteNumber(input.maxIterations) && input.maxIterations > 0) {
-		out.maxIterations = Math.floor(input.maxIterations);
+	for (const key of MCP_CAP_KEYS) {
+		const cap = clampCap(key, input[key]);
+		if (cap !== undefined) out[key] = cap;
 	}
 	if (typeof input.allowAll === "boolean") {
 		out.allowAll = input.allowAll;

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.test.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.test.tsx
@@ -23,7 +23,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import McpSettingsPanel from "./McpSettingsPanel";
 import { useToastStore } from "@/stores";
@@ -166,7 +166,13 @@ describe("McpSettingsPanel endpoint", () => {
 
 		await renderPanel();
 
-		expect(screen.queryByText(/^https?:\/\//)).not.toBeInTheDocument();
+		// Scoped to the Connection card: that is where a URL is shown as fact and
+		// copied into an agent's config. Elsewhere on the panel a URL is sample
+		// copy (the allowlist card shows one being reduced to a host), which this
+		// guard is not about and used to fail on.
+		const connectionCard = screen.getByText("Connection").closest("[data-slot=card]");
+		expect(connectionCard).not.toBeNull();
+		expect(within(connectionCard as HTMLElement).queryByText(/^https?:\/\//)).toBeNull();
 		// The placeholder stands in wherever the URL would have been - the
 		// endpoint line and every connect snippet.
 		expect(screen.getAllByText(/unavailable - mcp status not loaded/i).length).toBeGreaterThan(
@@ -223,6 +229,106 @@ describe("McpSettingsPanel connect failures", () => {
 		});
 
 		expect(toastMessages().join(" ")).toMatch(/couldn't connect .*mcp server is off/i);
+	});
+});
+
+/**
+ * This is the one panel where wrong copy is a safety problem: a user lowering a
+ * cap against an agent is entitled to text that matches the mechanism. Max RPS
+ * read as covering "a load run" while `targetRps` exists only in Constant RPS,
+ * and Max concurrency claimed to cap "in-flight requests", which is not what it
+ * bounds. Both are asserted by what they must *not* say as well, since the
+ * defect was an over-broad sentence rather than a missing one.
+ */
+describe("McpSettingsPanel cap copy", () => {
+	/**
+	 * The description paragraph rendered beside a cap's input. Reached from the
+	 * input rather than by text, so an assertion cannot pass by matching some
+	 * other row's copy.
+	 */
+	function capDescription(label: string): string {
+		const row = screen.getByLabelText(label).closest("div");
+		const text = row?.querySelector("p")?.textContent ?? "";
+		expect(text.length).toBeGreaterThan(0);
+		return text;
+	}
+
+	it("scopes Max RPS to the mode that carries a rate", async () => {
+		await renderPanel();
+
+		const text = capDescription("Max RPS");
+		expect(text).toMatch(/only a constant rps run carries a rate/i);
+		expect(text).toMatch(/max concurrency/i);
+	});
+
+	it("says what Max concurrency bounds, and that in-flight is not it", async () => {
+		await renderPanel();
+
+		const text = capDescription("Max concurrency");
+		expect(text).toMatch(/closed-loop/i);
+		// The old text said this cap ceilings "in-flight requests for a load
+		// run". It may only appear now as the thing the cap does *not* bound.
+		expect(text).toMatch(/does not bound its in-flight requests/i);
+	});
+
+	it("advertises each cap's ceiling on the input the user types into", async () => {
+		await renderPanel();
+
+		// The main process holds each cap here on save, so an input that offered
+		// more would be an input whose value silently comes back lower.
+		expect(screen.getByLabelText("Max RPS")).toHaveAttribute("max", "1000000");
+		expect(screen.getByLabelText("Max concurrency")).toHaveAttribute("max", "10000");
+		expect(screen.getByLabelText("Max duration (seconds)")).toHaveAttribute("max", "86400");
+		expect(screen.getByLabelText("Max iterations")).toHaveAttribute("max", "100000000");
+	});
+
+	it("says a cap above that maximum is lowered rather than stored", async () => {
+		await renderPanel();
+
+		expect(
+			screen.getByText(/a cap above the most vayu itself will run is lowered/i)
+		).toBeInTheDocument();
+	});
+});
+
+/**
+ * Two switches govern the write tools - the Tools card's Write group
+ * (`disabledTools`) and the Write access toggle (`allowWrites`) - and a user who
+ * flips one and sees no effect from the other has only these two sentences to go
+ * on. Each card must name the other.
+ */
+describe("McpSettingsPanel copy that described only half its mechanism", () => {
+	it("says what the server switch gives when it is on, and that on is the default", async () => {
+		await renderPanel();
+
+		// It described only the OFF state, on a switch that ships on.
+		expect(screen.getByText(/on by default/i)).toBeInTheDocument();
+	});
+
+	it("states the allowlist rule the normalizer actually has", async () => {
+		await renderPanel();
+
+		// "no scheme or port" was a rule `normalizeHost` does not enforce - it
+		// accepts a full URL and reduces it - so a user pasting one had no way to
+		// know the entry they got was the right one.
+		expect(screen.getByText(/paste a url or type a host/i)).toBeInTheDocument();
+		expect(screen.queryByText(/no scheme or port/i)).not.toBeInTheDocument();
+	});
+});
+
+describe("McpSettingsPanel write-switch cross-references", () => {
+	it("tells the Tools card that Write access is a second switch", async () => {
+		await renderPanel();
+
+		expect(screen.getByText(/write access, below/i)).toBeInTheDocument();
+	});
+
+	it("tells the Write access card that a tool switched off in Tools stays off", async () => {
+		await renderPanel();
+
+		expect(
+			screen.getByText(/turning it on grants no tool you switched off in tools/i)
+		).toBeInTheDocument();
 	});
 });
 

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
@@ -65,6 +65,7 @@ import type {
 import { useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
 import { Callout } from "@/components/shared";
+import { LOAD_TEST_CEILING_BOUNDS } from "@/constants/load-test";
 
 /**
  * Shown until `mcp:status` reports the live URL - deliberately not a URL.
@@ -229,29 +230,47 @@ interface CapField {
 	key: "maxRps" | "maxConcurrency" | "maxDurationSeconds" | "maxIterations";
 	label: string;
 	description: string;
+	/**
+	 * The highest value this cap may be set to. The main process holds the cap
+	 * here on save (`sanitizeSafetyInput`), so the input advertises the same
+	 * number rather than letting a user type one that silently comes back lower.
+	 */
+	ceiling: number;
 }
 
+/**
+ * Each cap names the run fields it actually bounds, because a cap that reads as
+ * covering every run does not: a rate cap cannot touch a run that carries no
+ * rate. The mode names are the ones the load dialog shows (`LOAD_TEST_MODES`).
+ */
 const CAP_FIELDS: CapField[] = [
 	{
 		key: "maxRps",
 		label: "Max RPS",
-		description: "Ceiling on target requests/sec for a load run.",
+		description:
+			"Ceiling on the request rate an agent may ask for. Only a Constant RPS run carries a rate - the closed-loop modes are held by Max concurrency and Max iterations instead.",
+		ceiling: LOAD_TEST_CEILING_BOUNDS.rps.MAX,
 	},
 	{
 		key: "maxConcurrency",
 		label: "Max concurrency",
-		description: "Ceiling on in-flight requests for a load run.",
+		description:
+			"Ceiling on the connections a closed-loop run may hold: what Constant Concurrency holds, what a Ramp-Up starts from, and the top a Capacity Discovery search climbs to. A Constant RPS run is paced by its rate instead, so this cap does not bound its in-flight requests.",
+		ceiling: LOAD_TEST_CEILING_BOUNDS.concurrency.MAX,
 	},
 	{
 		key: "maxDurationSeconds",
 		label: "Max duration (seconds)",
-		description: "Ceiling on how long a load run may last.",
+		description:
+			"Ceiling on how long a load run may last. An iterations run stops on a count and never reads a duration, so Max iterations is what bounds that one.",
+		ceiling: LOAD_TEST_CEILING_BOUNDS.durationSeconds.MAX,
 	},
 	{
 		key: "maxIterations",
 		label: "Max iterations",
 		description:
 			"Ceiling on requests for an iterations run, which stops on a count rather than a duration.",
+		ceiling: LOAD_TEST_CEILING_BOUNDS.iterations.MAX,
 	},
 ];
 
@@ -566,8 +585,10 @@ export default function McpSettingsPanel() {
 						<div>
 							<Label className="text-sm">Enable MCP server</Label>
 							<p className="text-xs text-muted-foreground mt-0.5">
-								When off, the endpoint is unavailable and connected agents get a
-								clean “start Vayu” error. Persists across restarts.
+								On by default: while Vayu is running, a connected agent can reach
+								the endpoint below. When off, the endpoint stops accepting
+								connections and connected agents get a clean “start Vayu” error.
+								Your choice persists across restarts.
 							</p>
 						</div>
 						<Switch
@@ -656,7 +677,9 @@ export default function McpSettingsPanel() {
 					</div>
 					<CardDescription>
 						Choose which tools agents can use. A disabled tool is hidden from the
-						agent's tool list and rejected if called anyway.
+						agent's tool list and rejected if called anyway. The Write group has a
+						second switch of its own - Write access, below - and a write tool needs
+						both: leaving it on here does nothing while writes are off.
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-5">
@@ -741,11 +764,14 @@ export default function McpSettingsPanel() {
 					</div>
 					<CardDescription>
 						Hosts an agent is permitted to send traffic to. Empty means no outbound
-						requests are allowed - a safe default. Add a host (no scheme or port), e.g.{" "}
-						<code className="font-mono">api.example.com</code>. The list is checked
-						before Vayu sends anything, so a script an agent writes cannot reach around
-						it: <code className="font-mono">pm.sendRequest</code> is refused entirely
-						for requests an agent starts, and works normally when you Send from Vayu.
+						requests are allowed - a safe default. Paste a URL or type a host; either is
+						reduced to the host, so{" "}
+						<code className="font-mono">https://api.example.com:8080/v1</code> and{" "}
+						<code className="font-mono">api.example.com</code> are the same entry. The
+						list is checked before Vayu sends anything, so a script an agent writes
+						cannot reach around it: <code className="font-mono">pm.sendRequest</code> is
+						refused entirely for requests an agent starts, and works normally when you
+						Send from Vayu.
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-3">
@@ -846,7 +872,9 @@ export default function McpSettingsPanel() {
 					</div>
 					<CardDescription>
 						Hard ceilings on agent-started load runs. A request over any cap is rejected
-						before it reaches the engine.
+						before it reaches the engine, and each cap bounds only the runs that carry
+						the field it names. A cap above the most Vayu itself will run is lowered to
+						that maximum when you save it.
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-4">
@@ -865,6 +893,7 @@ export default function McpSettingsPanel() {
 									type="number"
 									aria-label={field.label}
 									min={1}
+									max={field.ceiling}
 									value={
 										capDrafts[field.key] ??
 										(config ? String(config[field.key]) : "")
@@ -896,15 +925,14 @@ export default function McpSettingsPanel() {
 						<CardTitle className="text-base">Write access</CardTitle>
 					</div>
 					<CardDescription>
-						When off (default), agents can read but not change saved data: every tool in
-						the <code className="font-mono">write</code> category is disabled -
-						creating, renaming and deleting collections and saved requests, plus{" "}
-						<code className="font-mono">update_environment</code> and{" "}
-						<code className="font-mono">update_engine_config</code>. A delete asks you
-						to confirm each time as well, stating how much a collection contains before
-						it goes. This does not affect <code className="font-mono">run_request</code>
-						, <code className="font-mono">run_collection_smoke</code>, or load runs,
-						which are governed by the allowlist and caps.
+						When off (default), agents can read and send requests but cannot change
+						saved data: every tool in the Write group above refuses - creating, renaming
+						and deleting collections and saved requests, and editing environments and
+						engine config. Turning it on grants no tool you switched off in Tools; the
+						two switches are separate, and a delete still asks you to confirm each time,
+						stating how much a collection contains before it goes. Sending requests and
+						load runs are unaffected either way - the allowlist and the caps govern
+						those.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -613,7 +613,11 @@ configurable in **Settings → MCP** and persisted.
   destroy a subtree.
 - **Per-tool control** - any tool or whole read/execute/write/load category can be
   switched off; a disabled tool is omitted from `tools/list` **and** rejected by
-  `tools/call`.
+  `tools/call`. This and the write toggle are **independent**, and a write tool
+  needs both: switching the write category on here does nothing while
+  `allowWrites` is off, and turning `allowWrites` on re-enables no tool that is
+  in `disabledTools`. Settings states this on both cards, because a user who
+  flips one switch and sees no change has nothing else to go on.
 - **Server on/off** - the whole server can be disabled; while off the endpoint
   does not accept connections. Persists across restarts.
 - **Transport hardening** - loopback bind, Host-header (DNS-rebinding) validation,
@@ -628,21 +632,38 @@ process did not already have.
 
 `McpSafetyConfig` (defaults in parentheses):
 
-| Field                | Default | Meaning                                       |
-| -------------------- | ------- | --------------------------------------------- |
-| `allowlist`          | `[]`    | Permitted hostnames (empty = deny all).       |
-| `allowAll`           | `false` | Bypass the allowlist for any resolvable host. |
-| `maxRps`             | `1000`  | Cap on `targetRps`.                           |
-| `maxConcurrency`     | `200`   | Cap on `concurrency` and `startConcurrency`.  |
-| `maxDurationSeconds` | `300`   | Cap on load-run duration.                     |
-| `maxIterations`      | `10000` | Cap on `iterations` (iterations mode).        |
-| `allowWrites`        | `false` | Enable the data-mutating tools.               |
-| `disabledTools`      | `[]`    | Tool names to hide/reject.                    |
+| Field                | Default | Ceiling     | Meaning                                                    |
+| -------------------- | ------- | ----------- | ---------------------------------------------------------- |
+| `allowlist`          | `[]`    | -           | Permitted hostnames (empty = deny all).                    |
+| `allowAll`           | `false` | -           | Bypass the allowlist for any resolvable host.              |
+| `maxRps`             | `1000`  | `1000000`   | Cap on `targetRps`, which only `constant_rps` carries.     |
+| `maxConcurrency`     | `200`   | `10000`     | Cap on `concurrency` and `startConcurrency` (closed-loop). |
+| `maxDurationSeconds` | `300`   | `86400`     | Cap on load-run duration.                                  |
+| `maxIterations`      | `10000` | `100000000` | Cap on `iterations` (iterations mode).                     |
+| `allowWrites`        | `false` | -           | Enable the data-mutating tools.                            |
+| `disabledTools`      | `[]`    | -           | Tool names to hide/reject.                                 |
 
 The renderer never sets these directly: `main.ts` sanitizes every change
-(`sanitizeSafetyInput` - normalizes/de-dupes hosts, clamps caps to positive
-integers, validates `disabledTools` against the tool catalog) before applying it
-live and writing it to disk.
+(`sanitizeSafetyInput` - normalizes/de-dupes hosts, holds each cap to a whole
+number between 1 and its ceiling, trims and de-dupes `disabledTools`) before
+applying it live and writing it to disk. The same sanitizer runs over the
+persisted file on load and over the CLI's `VAYU_MCP_*` variables, so no path
+reaches the guards with a cap outside that range.
+
+The **ceilings** are `MCP_CAP_CEILINGS`, mirroring the renderer's
+`LOAD_TEST_CEILING_BOUNDS` maxima - the engine's own guards where it has one
+(`concurrency` at 10x `event_loop::MAX_CONCURRENT`, `durationSeconds` at the
+per-transfer timeout guard). A cap set above its ceiling is held there rather
+than stored: the value it would admit is one the engine refuses or one no Vayu
+surface will compose, so storing it shows a guardrail that does not exist. The
+copy is tied to the renderer constant by `config.test.ts`, the way
+`MAX_IN_FLIGHT_BOUND` is - `electron/` may not import `src/`.
+
+`maxRps` and `maxConcurrency` bound **different runs**, which is why neither is a
+general "load cap": `targetRps` exists only in `constant_rps`, so `maxRps` is
+inert against a closed-loop run, and `maxConcurrency` bounds the concurrency a
+closed-loop run holds (or a ramp starts from, or a capacity search climbs to) -
+not the in-flight requests of a rate-paced run, which `maxInFlight` governs.
 
 ## Architecture
 


### PR DESCRIPTION
## Description

Sub-issue 4 of the settings overhaul #518 (Wave 1). The MCP panel is the one place where a wrong description is a safety problem, and five of its statements did not match the code they describe.

**Plan (root cause, approach, rejected alternative).** The root cause is that this panel's copy was written against the *idea* of a load cap rather than against `checkLoadCaps`: `maxRps` reads `params.targetRps`, which only a `constant_rps` run carries, and `maxConcurrency` reads `concurrency` / `startConcurrency`, which are closed-loop knobs - so "for a load run" and "in-flight requests" each described a cap that does not exist. The same drift produced two write switches that never named each other and an allowlist rule (`no scheme or port`) that `normalizeHost` does not enforce. The approach is to state each mechanism in the words the rest of the app already uses (the load-dialog mode names from `LOAD_TEST_MODES`) and to close the one structural hole behind the copy: `sanitizeSafetyInput` had no upper bound, so a cap could be stored above the value any run can reach. I took the issue's recommended **clamp** over its hint-text alternative - a hint that says "the engine refuses anything over 10,000" while still storing 50,000 leaves the panel displaying a guardrail that is not there, and the clamp is one rule the three untrusted paths (renderer, persisted file, `VAYU_MCP_*`) already share. I rejected reaching for the renderer's `LOAD_TEST_CEILING_BOUNDS` by import: `tsconfig.node.json` withholds the `@/*` mapping from `electron/` on purpose, so the mirror is a literal kept honest from the test side, exactly as `MAX_IN_FLIGHT_BOUND` in `tools.ts` already is.

**Blast radius traced before editing.** `sanitizeSafetyInput` has three callers - `main.ts`'s `mcp:updateSafety`, `loadPersistedSafety` (which re-sanitizes the file on every read), and `buildSafetyConfigFromEnv` for the stdio CLI - so the clamp covers a hand-edited config and a headless operator's env var, not just the panel. Its `ignored` reporting is unaffected: a clamped cap is in force at the ceiling, not fallen back to a default. The panel adopts whatever `updateMcpSafety` resolves, so a clamped value is visible in the input immediately rather than diverging from what is stored. The `McpSafetyConfig` field doc-comments were already accurate about scope - only the rendered copy lied - so they are unchanged.

Verified at `5abf1a4`; every anchor in the issue still held, with one correction: the issue named "engine `maxInFlight`" as an engine *setting*, but it is a per-run field (`run_config::MAX_IN_FLIGHT`, defaulting to `max(targetRps * 10, 1000)`), so the copy says a Constant RPS run "is paced by its rate instead" rather than naming a settings row that does not exist.

### What changed

- **`maxRps`** - "Ceiling on target requests/sec for a load run." → names Constant RPS as the only mode carrying a rate, and points at Max concurrency / Max iterations for the rest.
- **`maxConcurrency`** - "Ceiling on in-flight requests for a load run." → what Constant Concurrency holds, what a Ramp-Up starts from, what a Capacity Discovery search climbs to, and explicitly *not* the in-flight of a Constant RPS run.
- **Two write switches** - the Tools card names Write access as a second switch a write tool also needs; the Write access card says turning it on grants no tool disabled in Tools, and drops the four internal tool names a newcomer has not met yet.
- **Server switch** - said only what OFF does, on a switch that ships on (`loadMcpEnabled` defaults true). Now states the ON behaviour and the default.
- **Allowlist** - "Add a host (no scheme or port)" was a rule the normalizer does not have; it accepts a URL and reduces it. Now says so, with the reduction shown.
- **Clamp** - `MCP_CAP_CEILINGS` (1,000,000 / 10,000 / 86,400 / 100,000,000) mirrors the renderer's `LOAD_TEST_CEILING_BOUNDS` maxima; `sanitizeSafetyInput` holds each cap there, the inputs carry the matching `max`, and the card states that an over-ceiling value is lowered on save. The four near-identical `if (isFiniteNumber(...))` blocks collapse into one keyed loop.

### Deliberate deviations / out of scope

- `Max duration (seconds)` keeps its parenthesised unit: the unit-suffix affordance belongs to #523's `NumberSettingRow` (and #531 for the engine side), and moving it early would be re-editing a row that issue restructures.
- The stdio CLI reports env vars it *ignored* but not ones it *clamped* - a different report shape (`fallback` vs "held at"), so it is left to a follow-up rather than widened here.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green: **4059 tests across 401 files passed**, type-check clean (all three projects), ESLint 0 errors / 0 warnings, Prettier clean. No pre-existing failures. Engine untouched, so no engine build or ctest run (the issue scopes this as app-only).

New tests, mutation-checked:

- `electron/mcp/config.test.ts` - each cap clamps at ceiling+1 and at 10x, is untouched at the ceiling and below, is clamped when read back from a hand-edited file, and is clamped on the `VAYU_MCP_*` path (with `ignored` still empty, since the cap is in force). Plus the conformance test tying `MCP_CAP_CEILINGS` to `LOAD_TEST_CEILING_BOUNDS`. Reverting the clamp to a bare `Math.floor` fails 3 of them (verified, not assumed).
- `McpSettingsPanel.test.tsx` - each cap's description read from the DOM *via its own input* (so an assertion cannot pass on a neighbouring row's text), the `max` attribute on all four inputs, the lowered-on-save sentence, both write-switch cross-references, the ON-state server copy, and the allowlist rule - with `no scheme or port` asserted absent, since the defect was an over-broad sentence rather than a missing one.

One existing test changed: the endpoint guard asserted no `https?://` text anywhere on the panel, which is about the *endpoint* being shown as fact and copied into an agent's config. The allowlist card now shows a sample URL being reduced to a host, so the guard is scoped to the Connection card - it still fails if a URL appears where the endpoint would.

`mkdocs build --strict` was not run (mkdocs is not installed in this environment); the docs change adds no links, headings or nav entries - one table column and prose inside an existing section.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/engine/mcp.md` is not Prettier-clean at `master`, so it was hand-formatted rather than run through Prettier (repo rule); it also sits outside `app`'s `format:check` glob. Only `McpSettingsPanel.tsx` - clean before - was formatted.

## Related Issues

Closes #522

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJZ43mPKnGox79mGhDe4LU)_