### PR TITLE
feat(app/palette): the ⌘K command palette - fuzzy navigation over tabs, requests, collections and views

### DIFF
--- a/app/src/components/layout/Shell.tsx
+++ b/app/src/components/layout/Shell.tsx
@@ -19,6 +19,7 @@ import WelcomeScreen from "@/modules/welcome/WelcomeScreen";
 import { SettingsMain } from "@/modules/settings";
 import VariablesMain from "@/modules/variables/main/VariablesMain";
 import InboxView from "@/modules/inbox";
+import { CommandPalette } from "@/modules/palette";
 
 function renderTabContent(tab: Tab | null): React.ReactNode {
 	if (!tab) return <WelcomeScreen />;
@@ -176,6 +177,11 @@ export default function Shell() {
 	return (
 		<div className="flex flex-col h-full bg-background overflow-hidden">
 			<ImportModal />
+			{/* Mounted once, like the import modal: it is summoned from a chord
+			    rather than from anything on screen, and its own ⌘K listener is
+			    what opens it. It owns that chord rather than the keydown map
+			    below - see the capture-phase note in CommandPalette. */}
+			<CommandPalette />
 			{/* Every tab uses the same shell: one left Drawer (its view switches
 			    with the tab - collections/history/variables/settings), the main
 			    content, and the request-only ContextBar. No tab type takes over

--- a/app/src/components/layout/TabStrip.tsx
+++ b/app/src/components/layout/TabStrip.tsx
@@ -38,15 +38,9 @@
  */
 
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-// `Zap` stays: here it is the load-test mark, which is what the bolt means
-// throughout the app. `Braces` is the variables mark (see `Dock.tsx`).
-import { X, Plus, Folder, Zap, Braces, Clock, Settings, ChevronDown, Inbox } from "lucide-react";
+import { X, Plus, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTabsStore, type Tab } from "@/stores";
-import { useQueries } from "@tanstack/react-query";
-import { requestDetailOptions, runDetailOptions, useCollectionsQuery } from "@/queries";
-import { useVariableResolver } from "@/hooks/useVariableResolver";
-import { DEFAULT_REQUEST_NAME } from "@/constants/request";
 import { TAB_NEW_BUTTON_WIDTH } from "@/constants/layout";
 import { ScrollOnOverflow } from "@/components/shared";
 import {
@@ -56,169 +50,10 @@ import {
 	DropdownMenuItem,
 } from "@/components/ui";
 import { fitTabs, makeTextMeasurer, naturalTabWidth } from "./tab-fit";
+// Labels and icons live beside this file, not in it: the command palette lists
+// the same tabs and must name them identically. See tab-descriptors.ts.
+import { useTabDescriptors, type TabDescriptor } from "./tab-descriptors";
 import { getMethodColor } from "@/utils";
-
-/**
- * Extract a short display path from a request URL. URLs may contain
- * {{variables}} or be malformed mid-edit, so this never throws.
- */
-function pathLabel(url: string): string {
-	if (!url) return "";
-	try {
-		return decodeURIComponent(new URL(url).pathname) || "/";
-	} catch {
-		// Strip scheme+host if present, otherwise show the raw string
-		const stripped = url.replace(/^[a-z]+:\/\/[^/]*/i, "");
-		return decodeURIComponent(stripped) || decodeURIComponent(url);
-	}
-}
-
-/**
- * Title for a request tab: the user-set name when there is one, otherwise the
- * request path. A blank or still-default placeholder name counts as "not set".
- */
-function requestTabTitle(name: string, resolvedUrl: string): string {
-	const trimmed = name.trim();
-	if (trimmed && trimmed !== DEFAULT_REQUEST_NAME) return trimmed;
-	return pathLabel(resolvedUrl) || trimmed;
-}
-
-/**
- * What a tab draws, resolved from the store plus whatever queries name it.
- *
- * Split out from rendering so the strip can measure a tab without laying it
- * out - see tab-fit.ts for why measuring the DOM would be circular.
- */
-interface TabDescriptor {
-	/** The name shown in the strip. */
-	label: string;
-	/** Plain-text form, for the native tooltip when the label is truncated. */
-	title: string;
-	/** HTTP method, when the tab has one. Drawn as the leading colour rail. */
-	method?: string;
-	/** Leading glyph, for tab types that are not a plain request. */
-	icon?: typeof Folder;
-	/** True when the label is a URL path, which is cut from the left instead. */
-	isPath?: boolean;
-}
-
-/**
- * Icons carry the tab's *kind*; the rail carries its method.
- *
- * Freeing the icon from repeating the method is what lets a run say which kind
- * of run it is. Both kinds used to be `Clock`, and the old comment conceded the
- * point - "the tooltip says which kind" - which a glance cannot read. A
- * finished load test now takes the same `Zap` as the live dashboard, because it
- * is the same thing at a later time.
- */
-function iconForTab(tab: Tab, runType?: string): typeof Folder | undefined {
-	switch (tab.type) {
-		case "collection":
-			return Folder;
-		case "dashboard":
-			return Zap;
-		case "run":
-			return runType === "load" ? Zap : Clock;
-		case "variables":
-			// The Dock and the welcome Launcher both open this view from a `Braces`
-			// control; the tab it opened carried no icon at all, so the glyph the
-			// user pressed vanished on arrival. See the note in `Dock.tsx`.
-			return Braces;
-		case "settings":
-			return Settings;
-		case "inbox":
-			// The same glyph the Launcher tile that opens it carries.
-			return Inbox;
-		default:
-			return undefined;
-	}
-}
-
-/**
- * Resolves what every open tab is called, in one hook.
- *
- * It has to be one hook for the whole list, not one per tab: the strip must
- * know each label *before* it can decide how many fit, and a hook inside a map
- * is a variable number of hooks. `useQueries` is the supported primitive for a
- * dynamic list, fed the same options objects `useRequestQuery` and
- * `useRunQuery` use, so the retry and 404 rules are not restated here.
- *
- * **The resolver is called once, without a collection id.** It previously ran
- * per tab with that tab's own `collectionId`, which cannot survive the move to
- * a single hook. It only affects the label of a request that has *no name of
- * its own* and whose URL uses a collection-scoped variable from a collection
- * other than the session's active one; that tab shows the unresolved
- * `{{var}}/path` instead of the concrete path. Globals, the environment and the
- * active collection all still resolve.
- */
-function useTabDescriptors(tabs: Tab[]): TabDescriptor[] {
-	const requests = useQueries({
-		queries: tabs.map((t) => requestDetailOptions(t.type === "request" ? t.entityId : null)),
-	});
-	const runs = useQueries({
-		queries: tabs.map((t) => runDetailOptions(t.type === "run" ? t.entityId : null)),
-	});
-	const { data: collections = [] } = useCollectionsQuery();
-	const { resolveString } = useVariableResolver();
-
-	return tabs.map((tab, i) => {
-		const request = requests[i]?.data;
-		const run = runs[i]?.data;
-		const icon = iconForTab(tab, run?.type);
-
-		switch (tab.type) {
-			case "welcome":
-				return { label: "Vayu", title: "Vayu" };
-			case "settings":
-				return { label: "Settings", title: "Settings", icon };
-			case "variables":
-				return { label: "Variables", title: "Variables", icon };
-			case "inbox":
-				return { label: "Inbox", title: "Webhook Inbox", icon };
-			case "dashboard":
-				return { label: "Load Test", title: "Load Test", icon };
-			case "collection": {
-				const name = collections.find((c) => c.id === tab.entityId)?.name ?? "Collection";
-				return { label: name, title: name, icon };
-			}
-			case "request": {
-				if (!request) return { label: "Request", title: "Request" };
-				const name = requestTabTitle(request.name, resolveString(request.url));
-				return {
-					label: name,
-					title: `${request.method} ${name}`,
-					method: request.method,
-					// A request with no name of its own falls back to its path, so
-					// path labels are not confined to run tabs.
-					isPath: name.startsWith("/"),
-				};
-			}
-			case "run": {
-				// A run tab is a past design run or load test. "Run" told none of
-				// them apart. Show what actually ran: the snapshot's method and
-				// path, the same shape a request tab uses. The path comes from the
-				// stored snapshot (resolved when it was sent), so it survives the
-				// request being renamed or deleted.
-				const snapshot = run?.configSnapshot;
-				const kind = run?.type === "load" ? "Load test" : "Design run";
-				const path = snapshot?.url ? pathLabel(snapshot.url) : "";
-				if (run && (snapshot?.method || path)) {
-					const label = path || kind;
-					return {
-						label,
-						title: `${kind}: ${[snapshot?.method, path].filter(Boolean).join(" ")}`,
-						...(snapshot?.method ? { method: snapshot.method } : {}),
-						icon,
-						isPath: Boolean(path),
-					};
-				}
-				// Still loading, or a run with no snapshot to name it by.
-				const fallback = run ? kind : "Run";
-				return { label: fallback, title: fallback, icon };
-			}
-		}
-	});
-}
 
 function TabItem({
 	tab,

--- a/app/src/components/layout/tab-descriptors.ts
+++ b/app/src/components/layout/tab-descriptors.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What every open tab is called, and which glyph carries its kind.
+ *
+ * Lives beside `TabStrip` rather than inside it because a second surface asks
+ * the same question: the command palette lists open tabs, and a tab that reads
+ * "GET /v1/orders" in the strip and "Request" in the palette is two answers to
+ * one question. A hand-rolled copy would also never receive this file's fixes -
+ * the run-tab naming below took three passes to get right.
+ */
+
+// `Zap` stays: here it is the load-test mark, which is what the bolt means
+// throughout the app. `Braces` is the variables mark (see `Dock.tsx`).
+import { Folder, Zap, Braces, Clock, Settings, Inbox } from "lucide-react";
+import { useQueries } from "@tanstack/react-query";
+import { requestDetailOptions, runDetailOptions, useCollectionsQuery } from "@/queries";
+import { useVariableResolver } from "@/hooks/useVariableResolver";
+import { DEFAULT_REQUEST_NAME } from "@/constants/request";
+import type { Tab } from "@/stores";
+
+/**
+ * Extract a short display path from a request URL. URLs may contain
+ * {{variables}} or be malformed mid-edit, so this never throws.
+ */
+export function pathLabel(url: string): string {
+	if (!url) return "";
+	try {
+		return decodeURIComponent(new URL(url).pathname) || "/";
+	} catch {
+		// Strip scheme+host if present, otherwise show the raw string
+		const stripped = url.replace(/^[a-z]+:\/\/[^/]*/i, "");
+		return decodeURIComponent(stripped) || decodeURIComponent(url);
+	}
+}
+
+/**
+ * Title for a request tab: the user-set name when there is one, otherwise the
+ * request path. A blank or still-default placeholder name counts as "not set".
+ */
+export function requestTabTitle(name: string, resolvedUrl: string): string {
+	const trimmed = name.trim();
+	if (trimmed && trimmed !== DEFAULT_REQUEST_NAME) return trimmed;
+	return pathLabel(resolvedUrl) || trimmed;
+}
+
+/**
+ * What a tab draws, resolved from the store plus whatever queries name it.
+ *
+ * Split out from rendering so the strip can measure a tab without laying it
+ * out - see tab-fit.ts for why measuring the DOM would be circular.
+ */
+export interface TabDescriptor {
+	/** The name shown in the strip. */
+	label: string;
+	/** Plain-text form, for the native tooltip when the label is truncated. */
+	title: string;
+	/** HTTP method, when the tab has one. Drawn as the leading colour rail. */
+	method?: string;
+	/** Leading glyph, for tab types that are not a plain request. */
+	icon?: typeof Folder;
+	/** True when the label is a URL path, which is cut from the left instead. */
+	isPath?: boolean;
+}
+
+/**
+ * Icons carry the tab's *kind*; the rail carries its method.
+ *
+ * Freeing the icon from repeating the method is what lets a run say which kind
+ * of run it is. Both kinds used to be `Clock`, and the old comment conceded the
+ * point - "the tooltip says which kind" - which a glance cannot read. A
+ * finished load test now takes the same `Zap` as the live dashboard, because it
+ * is the same thing at a later time.
+ */
+export function iconForTab(tab: Tab, runType?: string): typeof Folder | undefined {
+	switch (tab.type) {
+		case "collection":
+			return Folder;
+		case "dashboard":
+			return Zap;
+		case "run":
+			return runType === "load" ? Zap : Clock;
+		case "variables":
+			// The Dock and the welcome Launcher both open this view from a `Braces`
+			// control; the tab it opened carried no icon at all, so the glyph the
+			// user pressed vanished on arrival. See the note in `Dock.tsx`.
+			return Braces;
+		case "settings":
+			return Settings;
+		case "inbox":
+			// The same glyph the Launcher tile that opens it carries.
+			return Inbox;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Resolves what every open tab is called, in one hook.
+ *
+ * It has to be one hook for the whole list, not one per tab: the strip must
+ * know each label *before* it can decide how many fit, and a hook inside a map
+ * is a variable number of hooks. `useQueries` is the supported primitive for a
+ * dynamic list, fed the same options objects `useRequestQuery` and
+ * `useRunQuery` use, so the retry and 404 rules are not restated here.
+ *
+ * **The resolver is called once, without a collection id.** It previously ran
+ * per tab with that tab's own `collectionId`, which cannot survive the move to
+ * a single hook. It only affects the label of a request that has *no name of
+ * its own* and whose URL uses a collection-scoped variable from a collection
+ * other than the session's active one; that tab shows the unresolved
+ * `{{var}}/path` instead of the concrete path. Globals, the environment and the
+ * active collection all still resolve.
+ */
+export function useTabDescriptors(tabs: Tab[]): TabDescriptor[] {
+	const requests = useQueries({
+		queries: tabs.map((t) => requestDetailOptions(t.type === "request" ? t.entityId : null)),
+	});
+	const runs = useQueries({
+		queries: tabs.map((t) => runDetailOptions(t.type === "run" ? t.entityId : null)),
+	});
+	const { data: collections = [] } = useCollectionsQuery();
+	const { resolveString } = useVariableResolver();
+
+	return tabs.map((tab, i) => {
+		const request = requests[i]?.data;
+		const run = runs[i]?.data;
+		const icon = iconForTab(tab, run?.type);
+
+		switch (tab.type) {
+			case "welcome":
+				return { label: "Vayu", title: "Vayu" };
+			case "settings":
+				return { label: "Settings", title: "Settings", icon };
+			case "variables":
+				return { label: "Variables", title: "Variables", icon };
+			case "inbox":
+				return { label: "Inbox", title: "Webhook Inbox", icon };
+			case "dashboard":
+				return { label: "Load Test", title: "Load Test", icon };
+			case "collection": {
+				const name = collections.find((c) => c.id === tab.entityId)?.name ?? "Collection";
+				return { label: name, title: name, icon };
+			}
+			case "request": {
+				if (!request) return { label: "Request", title: "Request" };
+				const name = requestTabTitle(request.name, resolveString(request.url));
+				return {
+					label: name,
+					title: `${request.method} ${name}`,
+					method: request.method,
+					// A request with no name of its own falls back to its path, so
+					// path labels are not confined to run tabs.
+					isPath: name.startsWith("/"),
+				};
+			}
+			case "run": {
+				// A run tab is a past design run or load test. "Run" told none of
+				// them apart. Show what actually ran: the snapshot's method and
+				// path, the same shape a request tab uses. The path comes from the
+				// stored snapshot (resolved when it was sent), so it survives the
+				// request being renamed or deleted.
+				const snapshot = run?.configSnapshot;
+				const kind = run?.type === "load" ? "Load test" : "Design run";
+				const path = snapshot?.url ? pathLabel(snapshot.url) : "";
+				if (run && (snapshot?.method || path)) {
+					const label = path || kind;
+					return {
+						label,
+						title: `${kind}: ${[snapshot?.method, path].filter(Boolean).join(" ")}`,
+						...(snapshot?.method ? { method: snapshot.method } : {}),
+						icon,
+						isPath: Boolean(path),
+					};
+				}
+				// Still loading, or a run with no snapshot to name it by.
+				const fallback = run ? kind : "Run";
+				return { label: fallback, title: fallback, icon };
+			}
+		}
+	});
+}

--- a/app/src/components/layout/tab-type-coverage.test.ts
+++ b/app/src/components/layout/tab-type-coverage.test.ts
@@ -34,7 +34,10 @@ function read(path: string): string {
 
 const tabsStore = read("../../stores/tabs-store.ts");
 const shell = read("./Shell.tsx");
-const tabStrip = read("./TabStrip.tsx");
+// The descriptor switch moved out of `TabStrip.tsx` when the command palette
+// needed the same labels - see tab-descriptors.ts. Reading the file it actually
+// lives in is what keeps this guard from passing vacuously on the wrong one.
+const tabDescriptors = read("./tab-descriptors.ts");
 
 /** The members of `export type TabType = "a" | "b" | ...`. */
 function tabTypes(source: string): string[] {
@@ -61,12 +64,20 @@ describe("TabType coverage", () => {
 		}
 	});
 
-	it("gives every type a branch in TabStrip's descriptor switch", () => {
+	it("gives every type a branch in the tab-descriptor switch", () => {
 		for (const type of types) {
-			expect(tabStrip, `TabStrip has no descriptor case for "${type}"`).toContain(
-				`case "${type}":`
-			);
+			expect(
+				tabDescriptors,
+				`tab-descriptors has no descriptor case for "${type}"`
+			).toContain(`case "${type}":`);
 		}
+	});
+
+	it("reads the descriptor module it scans", () => {
+		// Same vacuity guard as the union above: a renamed file would otherwise
+		// throw here rather than pass silently, but the length check states it.
+		expect(tabDescriptors.length).toBeGreaterThan(1000);
+		expect(tabDescriptors).toContain("export function useTabDescriptors");
 	});
 
 	it("gives every type an explicit answer in isTabDirty", () => {

--- a/app/src/components/layout/variables-icon.test.tsx
+++ b/app/src/components/layout/variables-icon.test.tsx
@@ -145,6 +145,7 @@ describe("the variables icon", () => {
 				collectionCount={0}
 				onImport={() => {}}
 				onNewRequest={() => {}}
+				onSearch={() => {}}
 				onHistory={() => {}}
 				onVariables={() => {}}
 				onInbox={() => {}}

--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -13,7 +13,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Kbd } from "@/components/ui/kbd";
 
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
@@ -29,10 +29,32 @@ function Command({ className, ...props }: React.ComponentProps<typeof CommandPri
 	);
 }
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+interface CommandDialogProps extends DialogProps {
+	/**
+	 * Names the dialog for assistive tech. Radix requires a `DialogTitle`, and
+	 * a palette has no visible heading - its search field is the whole header -
+	 * so the title is rendered `sr-only` rather than omitted.
+	 */
+	title: string;
+	/** One line saying what typing here does, also `sr-only`. */
+	description: string;
+	className?: string;
+}
+
+const CommandDialog = ({
+	children,
+	title,
+	description,
+	className,
+	...props
+}: CommandDialogProps) => {
 	return (
 		<Dialog {...props}>
-			<DialogContent className="overflow-hidden p-0">
+			{/* No corner close button: it would land on top of the search field,
+			    and Escape or a click outside is how a palette is dismissed. */}
+			<DialogContent showClose={false} className={cn("overflow-hidden p-0", className)}>
+				<DialogTitle className="sr-only">{title}</DialogTitle>
+				<DialogDescription className="sr-only">{description}</DialogDescription>
 				<Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
 					{children}
 				</Command>

--- a/app/src/components/ui/dialog.tsx
+++ b/app/src/components/ui/dialog.tsx
@@ -37,11 +37,18 @@ function DialogOverlay({
 	);
 }
 
-function DialogContent({
-	className,
-	children,
-	...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+interface DialogContentProps extends React.ComponentProps<typeof DialogPrimitive.Content> {
+	/**
+	 * Draw the corner close button. On by default, and off for exactly one
+	 * shape: a command palette, whose top-right corner is occupied by its own
+	 * search field and which closes on Escape or a click outside like the
+	 * overlay it is. A dialog with a form or a decision keeps it - the button is
+	 * the discoverable way out.
+	 */
+	showClose?: boolean;
+}
+
+function DialogContent({ className, children, showClose = true, ...props }: DialogContentProps) {
 	return (
 		<DialogPortal>
 			<DialogOverlay />
@@ -58,10 +65,12 @@ function DialogContent({
 				{...props}
 			>
 				{children}
-				<DialogPrimitive.Close className="absolute right-4 top-4 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-					<X className="h-4 w-4" />
-					<span className="sr-only">Close</span>
-				</DialogPrimitive.Close>
+				{showClose && (
+					<DialogPrimitive.Close className="absolute right-4 top-4 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+						<X className="h-4 w-4" />
+						<span className="sr-only">Close</span>
+					</DialogPrimitive.Close>
+				)}
 			</DialogPrimitive.Content>
 		</DialogPortal>
 	);

--- a/app/src/constants/shortcuts.ts
+++ b/app/src/constants/shortcuts.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * The request builder's send shortcuts, in one place.
+ * App-wide keyboard shortcuts, in one place.
  *
  * Each is defined once as a `Chord` and read by both the handler that fires it
  * and the label that advertises it, so a button cannot claim a key combination
@@ -26,18 +26,38 @@ export const SEND_CHORD: Chord = { mod: true, key: "↵" };
 export const LOAD_TEST_CHORD: Chord = { mod: true, shift: true, key: "↵" };
 
 /**
+ * Open the command palette.
+ *
+ * ⌘K/Ctrl+K is the cross-app convention for "search everything" (VS Code,
+ * Slack, Linear, GitHub), which is the whole reason it is worth taking: the
+ * chord is the one users already try.
+ *
+ * Declared here rather than inline in `Shell` because a second surface reads
+ * it - the palette's own hint, and the title-bar search bar that will show the
+ * chord it triggers. That is exactly the pairing this file exists to keep
+ * honest.
+ */
+export const PALETTE_CHORD: Chord = { mod: true, key: "K" };
+
+/**
  * Does this event match a chord?
  *
  * `shift` is compared strictly rather than ignored: without that,
  * Ctrl+Shift+Enter satisfies Send's `mod + Enter` too and both fire, which is
  * the one thing a modifier-distinguished pair must not do.
+ *
+ * The key itself is compared case-insensitively, because a letter chord is
+ * declared in the case it is *displayed* in ("K", so the hint reads ⌘K) while
+ * `KeyboardEvent.key` reports the character the keyboard produced - "k"
+ * unmodified, "K" under Caps Lock. Case is never what distinguishes two chords
+ * here; `shift` is, and it is still compared exactly.
  */
 export function matchesChord(
 	e: Pick<KeyboardEvent, "key" | "shiftKey" | "altKey" | "metaKey" | "ctrlKey">,
 	chord: Chord
 ): boolean {
 	const key = chord.key === "↵" ? "Enter" : chord.key;
-	if (e.key !== key) return false;
+	if (e.key.toLowerCase() !== key.toLowerCase()) return false;
 	if (!!chord.mod !== (e.metaKey || e.ctrlKey)) return false;
 	if (!!chord.shift !== e.shiftKey) return false;
 	if (!!chord.alt !== e.altKey) return false;

--- a/app/src/modules/README.md
+++ b/app/src/modules/README.md
@@ -83,6 +83,21 @@ Some modules have components displayed in both the sidebar and main content area
     import WelcomeScreen from "@/modules/welcome/WelcomeScreen";
     ```
 
+### Overlay Modules
+
+#### `palette/`
+
+- **Location:** neither sidebar nor main - a dialog mounted once by `Shell`, like `ImportModal`.
+- **Components:** `CommandPalette.tsx` (dialog, ⌘K chord, focus restoration), `PaletteResults.tsx`
+  (grouping and rendering, mounted only while open), `sources/` (one hook per result family).
+- **Extending it:** add a `sources/use*Items.ts` returning `PaletteItem[]` and list it in
+  `PaletteResults`. Nothing else changes - the dialog knows nothing about where a result came
+  from. Perform the action through the same call the sidebar makes rather than a new one.
+- **Usage:**
+    ```tsx
+    import { CommandPalette } from "@/modules/palette";
+    ```
+
 ## Import Guidelines
 
 1. **For modules with sidebar/main split:** Use explicit paths (`/sidebar` or `/main`) for clarity

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What the palette promises: the chord reaches it from anywhere, typing part of
+ * a name finds the thing, Enter opens it, and Escape puts focus back where it
+ * was.
+ *
+ * Two of those are guards against a specific way of failing:
+ *
+ * - **Capture phase.** Monaco consumes ⌘K as a chord prefix and stops it
+ *   propagating, so a bubble-phase listener never sees the key while the caret
+ *   is in an editor. The test dispatches through an element that calls
+ *   `stopPropagation`, which is what an editor does; move the listener to the
+ *   bubble and it fails.
+ * - **Focus restoration.** Radix restores to a dialog's trigger, and a palette
+ *   opened by a chord has none, so the module captures and restores it itself.
+ *   Drop that and this fails with focus on `<body>` - which is what it did
+ *   before the capture was added.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { CommandPalette } from "./CommandPalette";
+import { useLayoutStore, useTabsStore } from "@/stores";
+
+const COLLECTIONS = [
+	{ id: "c1", name: "Payments", parentId: undefined },
+	{ id: "c2", name: "Auth", parentId: "c1" },
+];
+
+const REQUESTS = new Map([
+	[
+		"c1",
+		[
+			{ id: "r1", collectionId: "c1", name: "Charge card", method: "POST", url: "/charges" },
+			{ id: "r2", collectionId: "c1", name: "Refund", method: "POST", url: "/refunds" },
+		],
+	],
+	["c2", [{ id: "r3", collectionId: "c2", name: "Issue token", method: "GET", url: "/token" }]],
+]);
+
+/** Runs, newest-first, as the infinite query hands them over. */
+let runPages: { data: { id: string; requestId: string | null; startTime: number }[] }[] = [
+	{ data: [] },
+];
+
+vi.mock("@/queries", () => ({
+	requestDetailOptions: () => ({
+		queryKey: ["request"],
+		queryFn: async () => undefined,
+		enabled: false,
+	}),
+	runDetailOptions: () => ({ queryKey: ["run"], queryFn: async () => undefined, enabled: false }),
+	useCollectionsQuery: () => ({ data: COLLECTIONS }),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: REQUESTS, isLoading: false }),
+	useRunsQuery: () => ({ data: { pages: runPages } }),
+	flattenRunPages: (data?: { pages: { data: unknown[] }[] }) =>
+		data ? data.pages.flatMap((p) => p.data) : [],
+}));
+vi.mock("@/hooks/useVariableResolver", () => ({
+	useVariableResolver: () => ({ resolveString: (s: string) => s }),
+}));
+
+function renderPalette() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			{/* A focusable neighbour, so "focus goes back where it was" has
+			    somewhere to go back to. */}
+			<input aria-label="outside" />
+			<CommandPalette />
+		</QueryClientProvider>
+	);
+}
+
+/** Dispatch ⌘K the way an editor does: swallowed before it can bubble. */
+function pressPaletteChordInsideAnEditor() {
+	const editor = document.createElement("div");
+	editor.addEventListener("keydown", (e) => e.stopPropagation());
+	document.body.appendChild(editor);
+	act(() =>
+		editor.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "k",
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			})
+		)
+	);
+	editor.remove();
+}
+
+/** Open it the way the store does, inside `act` so the dialog mounts. */
+function open() {
+	act(() => useLayoutStore.getState().setPaletteOpen(true));
+}
+
+/** The palette's search field. */
+function input(): HTMLInputElement {
+	return screen.getByPlaceholderText(/Search tabs/) as HTMLInputElement;
+}
+
+function typeQuery(text: string) {
+	fireEvent.change(input(), { target: { value: text } });
+}
+
+/** Enter on the highlighted row - cmdk handles the key on its root. */
+function pressEnter() {
+	fireEvent.keyDown(input(), { key: "Enter" });
+}
+
+beforeEach(() => {
+	// cmdk scrolls the highlighted row into view; jsdom has no such method.
+	Element.prototype.scrollIntoView = vi.fn();
+	runPages = [{ data: [] }];
+	useLayoutStore.setState({ paletteOpen: false, drawerOpen: false, drawerView: "collections" });
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+});
+afterEach(cleanup);
+
+describe("the ⌘K chord", () => {
+	it("opens the palette even when an editor swallows the key", () => {
+		renderPalette();
+		pressPaletteChordInsideAnEditor();
+		expect(useLayoutStore.getState().paletteOpen).toBe(true);
+	});
+
+	it("closes it again, so the chord that opened it dismisses it", () => {
+		renderPalette();
+		pressPaletteChordInsideAnEditor();
+		pressPaletteChordInsideAnEditor();
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+	});
+
+	it("ignores the key without the modifier, and ⇧⌘K", () => {
+		renderPalette();
+		window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", bubbles: true }));
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "K", metaKey: true, shiftKey: true, bubbles: true })
+		);
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+	});
+
+	it("matches the chord under Caps Lock, which reports an upper-case key", () => {
+		renderPalette();
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "K", metaKey: true, bubbles: true })
+		);
+		expect(useLayoutStore.getState().paletteOpen).toBe(true);
+	});
+});
+
+describe("searching", () => {
+	it("finds a request by part of its name and opens its tab on Enter", async () => {
+		renderPalette();
+		open();
+
+		typeQuery("refu");
+		pressEnter();
+
+		const { openTabs, activeTabId } = useTabsStore.getState();
+		expect(openTabs).toHaveLength(1);
+		expect(openTabs[0]).toMatchObject({ type: "request", entityId: "r2" });
+		expect(activeTabId).toBe(openTabs[0].id);
+		// A pick always closes it - a palette left open over the thing it just
+		// opened is in the way.
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+	});
+
+	it("finds a request by its URL, which its name need not mention", async () => {
+		renderPalette();
+		open();
+
+		typeQuery("/token");
+		expect(screen.getByText("Issue token")).toBeInTheDocument();
+		expect(screen.queryByText("Charge card")).not.toBeInTheDocument();
+	});
+
+	it("shows a collection's path, so two same-named requests are told apart", async () => {
+		renderPalette();
+		open();
+		// "Auth" is nested under "Payments", and its request says so.
+		expect(screen.getByText("Payments / Auth")).toBeInTheDocument();
+	});
+
+	it("says so when nothing matches", async () => {
+		renderPalette();
+		open();
+		typeQuery("zzzzz");
+		expect(screen.getByText("No matches.")).toBeInTheDocument();
+	});
+
+	it("switches to an open tab rather than opening a second one", async () => {
+		useTabsStore.setState({
+			openTabs: [
+				{ id: "t1", type: "settings", entityId: null },
+				{ id: "t2", type: "inbox", entityId: null },
+			],
+			activeTabId: "t2",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+
+		typeQuery("Settings");
+		pressEnter();
+
+		const state = useTabsStore.getState();
+		expect(state.openTabs).toHaveLength(2);
+		expect(state.activeTabId).toBe("t1");
+	});
+});
+
+describe("the empty query", () => {
+	it("puts the most recently focused tab first", async () => {
+		useTabsStore.setState({
+			openTabs: [
+				{ id: "t1", type: "settings", entityId: null },
+				{ id: "t2", type: "inbox", entityId: null },
+				{ id: "t3", type: "variables", entityId: null },
+			],
+			activeTabId: "t1",
+			// Insertion order is t1, t2, t3; attention order is t2, t3, t1.
+			tabFocusedAt: { t1: 1000, t2: 3000, t3: 2000 },
+		});
+		renderPalette();
+		open();
+
+		const tabsGroup = screen.getByText("Tabs").closest("[cmdk-group]")!;
+		const labels = [...tabsGroup.querySelectorAll("[cmdk-item]")].map(
+			(el) => el.querySelector("span.flex-1")?.textContent
+		);
+		expect(labels).toEqual(["Inbox", "Variables", "Settings"]);
+	});
+
+	it("puts the most recently sent request first", async () => {
+		runPages = [
+			{
+				data: [
+					{ id: "run2", requestId: "r2", startTime: 5000 },
+					{ id: "run1", requestId: "r1", startTime: 1000 },
+				],
+			},
+		];
+		renderPalette();
+		open();
+
+		const group = screen.getByText("Requests").closest("[cmdk-group]")!;
+		const labels = [...group.querySelectorAll("[cmdk-item]")].map(
+			(el) => el.querySelector("span.flex-1")?.textContent
+		);
+		// Tree order is Charge card, Refund, Issue token; Refund ran last.
+		expect(labels[0]).toBe("Refund");
+	});
+
+	it("keeps the groups in a fixed order", async () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "settings", entityId: null }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+
+		expect(screen.getByText("Tabs")).toBeInTheDocument();
+		const headings = [...document.querySelectorAll("[cmdk-group-heading]")].map(
+			(el) => el.textContent
+		);
+		expect(headings).toEqual(["Tabs", "Requests", "Collections", "Views"]);
+	});
+});
+
+describe("closing", () => {
+	it("puts focus back where it was", async () => {
+		renderPalette();
+		const outside = screen.getByLabelText("outside");
+		outside.focus();
+		expect(document.activeElement).toBe(outside);
+
+		open();
+		expect(input()).toBeInTheDocument();
+		fireEvent.keyDown(document, { key: "Escape" });
+
+		await waitFor(() => expect(useLayoutStore.getState().paletteOpen).toBe(false));
+		await waitFor(() => expect(document.activeElement).toBe(outside));
+	});
+
+	it("starts empty on the next open rather than restoring the last query", async () => {
+		renderPalette();
+		open();
+		typeQuery("refu");
+		fireEvent.keyDown(document, { key: "Escape" });
+		await waitFor(() => expect(useLayoutStore.getState().paletteOpen).toBe(false));
+
+		pressPaletteChordInsideAnEditor();
+		expect(input().value).toBe("");
+	});
+});
+
+describe("cost", () => {
+	it("renders no results at all while shut", () => {
+		renderPalette();
+		expect(screen.queryByText("Views")).not.toBeInTheDocument();
+	});
+});

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The ⌘K command palette.
+ *
+ * Reaching anything by name. Before this, a request meant the collections
+ * drawer plus tree expansion, a run meant the history drawer plus scrolling,
+ * and a settings section meant ⌘, plus its sidebar - so Vayu was navigated with
+ * a mouse or not at all.
+ *
+ * Two things it deliberately is not:
+ *
+ * - **Not its own search implementation.** Results come from source hooks
+ *   (`sources/`), each returning the same `PaletteItem` shape and performing
+ *   its action through the very call the sidebar makes. Adding settings,
+ *   environments or runs later is a source, not a change here.
+ * - **Not a second copy of the tab strip's naming.** Tab rows are labelled by
+ *   `tab-descriptors`, the hook the strip itself uses.
+ *
+ * Focus goes back where it came from on close, and that is this file's job, not
+ * Radix's: `FocusScope` restores to the dialog's *trigger*, and a palette
+ * summoned by a chord has none - measured, focus lands on `<body>`, so the caret
+ * is gone from the editor the user was typing in. See `focusBefore` below.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { CommandDialog, CommandInput } from "@/components/ui";
+import { useLayoutStore } from "@/stores";
+import { PALETTE_CHORD, matchesChord } from "@/constants/shortcuts";
+import { formatChord } from "@/lib/platform";
+import { PaletteResults } from "./PaletteResults";
+import type { PaletteItem } from "./types";
+
+export function CommandPalette() {
+	const paletteOpen = useLayoutStore((s) => s.paletteOpen);
+	const setPaletteOpen = useLayoutStore((s) => s.setPaletteOpen);
+	const [query, setQuery] = useState("");
+	/** Where focus was when the palette opened, to give it back on close. */
+	const focusBefore = useRef<HTMLElement | null>(null);
+
+	/*
+	 * Read from a store subscription rather than from an effect on `paletteOpen`.
+	 *
+	 * An effect would be too late: child effects run before the parent's, so by
+	 * the time this component's effect fires, the dialog below it has already
+	 * moved focus to its own search field and `document.activeElement` is that
+	 * field. A subscription runs inside `set()`, before React re-renders - the
+	 * last moment the previous focus still exists.
+	 *
+	 * It also catches every opener, not just the chord: the welcome Launcher's
+	 * Search tile and (later) the title bar's search bar both flip this flag
+	 * through the store.
+	 */
+	useEffect(
+		() =>
+			useLayoutStore.subscribe((state, previous) => {
+				if (!state.paletteOpen || previous.paletteOpen) return;
+				const active = document.activeElement;
+				focusBefore.current = active instanceof HTMLElement ? active : null;
+				// Every open starts empty, like Spotlight - a palette reopened with
+				// the last query still in it shows yesterday's search. Here rather
+				// than in `onOpenChange` so it holds for every opener, including the
+				// ones that flip the store flag directly.
+				setQuery("");
+			}),
+		[]
+	);
+
+	/*
+	 * Restoring focus has to wait for the commit that unmounts the dialog: doing
+	 * it in the subscription above would run before React re-renders, and Radix's
+	 * own unmount handling would then move focus off again.
+	 */
+	useEffect(() => {
+		if (paletteOpen) return;
+		const previous = focusBefore.current;
+		focusBefore.current = null;
+		// `isConnected` because whatever had focus may have been unmounted by the
+		// very thing the palette just did - picking a request replaces the main
+		// pane, and focusing a detached node throws focus to `<body>` instead.
+		if (previous?.isConnected) previous.focus();
+	}, [paletteOpen]);
+
+	/*
+	 * Capture phase, unlike the rest of the app's shortcuts, which listen on the
+	 * bubble in `Shell`.
+	 *
+	 * Monaco treats Ctrl/⌘+K as the start of a chord (⌘K ⌘C and friends) and
+	 * calls `stopPropagation` on it, so a bubble-phase listener on `window`
+	 * never sees the key while the caret is in a body or script editor - which
+	 * is most of the time in this app, and exactly when reaching another
+	 * request by name is worth the most. Capture runs before the editor gets
+	 * the event.
+	 *
+	 * The scope of the divergence is one chord: everything else stays on the
+	 * bubble, where a focused control still gets first refusal.
+	 */
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (!matchesChord(e, PALETTE_CHORD)) return;
+			e.preventDefault();
+			// Toggling rather than only opening: the chord that summoned it is
+			// the one a user presses again to dismiss it.
+			setPaletteOpen(!useLayoutStore.getState().paletteOpen);
+		};
+		window.addEventListener("keydown", onKeyDown, { capture: true });
+		return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+	}, [setPaletteOpen]);
+
+	const pick = (item: PaletteItem) => {
+		item.perform();
+		setPaletteOpen(false);
+	};
+
+	return (
+		<CommandDialog
+			open={paletteOpen}
+			onOpenChange={setPaletteOpen}
+			title="Command palette"
+			description="Search open tabs, requests, collections and views."
+			className="max-w-xl"
+		>
+			<CommandInput
+				value={query}
+				onValueChange={setQuery}
+				placeholder={`Search tabs, requests, collections… (${formatChord(PALETTE_CHORD)})`}
+			/>
+			{/*
+			 * Mounted only while open, so a shut palette holds no query observers
+			 * on collections, requests and run history - the same rule the
+			 * context bar applies to a collapsed section.
+			 */}
+			{paletteOpen && <PaletteResults query={query} onPick={pick} />}
+		</CommandDialog>
+	);
+}

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The palette's list: every source, grouped and ranked.
+ *
+ * Mounted only while the palette is open - the same cost model the context
+ * bar's sections use. The sources read collections, requests and run history,
+ * and a palette that is shut has no business holding query observers on any of
+ * it.
+ */
+
+import { useMemo } from "react";
+import {
+	CommandEmpty,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+	CommandSeparator,
+} from "@/components/ui";
+import { getMethodColor } from "@/utils";
+import { PALETTE_GROUPS, PALETTE_GROUP_LABELS, rankForEmptyQuery, type PaletteItem } from "./types";
+import { useTabItems } from "./sources/useTabItems";
+import { useEntityItems } from "./sources/useEntityItems";
+import { useViewItems } from "./sources/useViewItems";
+
+interface PaletteResultsProps {
+	/** The live query, so ranking can tell "nothing typed" from "no match". */
+	query: string;
+	/** Run the item and close - the palette never stays open after a pick. */
+	onPick: (item: PaletteItem) => void;
+}
+
+export function PaletteResults({ query, onPick }: PaletteResultsProps) {
+	const tabs = useTabItems();
+	const entities = useEntityItems();
+	const views = useViewItems();
+
+	const grouped = useMemo(() => {
+		const all = [...tabs, ...entities, ...views];
+		return PALETTE_GROUPS.map((kind) => ({
+			kind,
+			items: rankForEmptyQuery(all.filter((item) => item.kind === kind)),
+		})).filter((group) => group.items.length > 0);
+	}, [tabs, entities, views]);
+
+	/*
+	 * cmdk hides a group whose items all filter out, so the count has to come
+	 * from the rendered list rather than from `grouped`. `aria-live="polite"`
+	 * on an sr-only line is the announcement: a listbox that silently swaps its
+	 * contents as you type tells a screen-reader user nothing about whether the
+	 * query narrowed anything.
+	 */
+	const total = grouped.reduce((n, group) => n + group.items.length, 0);
+
+	return (
+		<>
+			<span aria-live="polite" className="sr-only">
+				{query ? `${total} searchable results` : `${total} results`}
+			</span>
+			<CommandList>
+				<CommandEmpty>No matches.</CommandEmpty>
+				{grouped.map((group, index) => (
+					<div key={group.kind}>
+						{index > 0 && <CommandSeparator />}
+						<CommandGroup heading={PALETTE_GROUP_LABELS[group.kind]}>
+							{group.items.map((item) => (
+								<PaletteRow key={item.id} item={item} onPick={onPick} />
+							))}
+						</CommandGroup>
+					</div>
+				))}
+			</CommandList>
+		</>
+	);
+}
+
+function PaletteRow({ item, onPick }: { item: PaletteItem; onPick: (item: PaletteItem) => void }) {
+	const Icon = item.icon;
+	return (
+		<CommandItem
+			// cmdk matches against `value` plus `keywords`, so the value is what
+			// the row *reads* as and the keywords are what else should find it.
+			// The id is deliberately not in either: it is a uuid, and a query of
+			// "b7" would then match rows at random.
+			value={[item.title, item.subtitle].filter(Boolean).join(" ")}
+			keywords={item.keywords}
+			onSelect={() => onPick(item)}
+			className="gap-2"
+		>
+			{item.method && (
+				<span
+					aria-hidden="true"
+					// The same 2px rail the tab strip draws, for the same reason:
+					// the method is a colour everywhere else in the app.
+					className="h-3.5 w-0.5 shrink-0 rounded-full"
+					style={{ background: `hsl(${getMethodColor(item.method)})` }}
+				/>
+			)}
+			{Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+			<span className="min-w-0 flex-1 truncate">{item.title}</span>
+			{item.subtitle && (
+				<span className="ml-auto shrink-0 truncate pl-3 text-xs text-muted-foreground">
+					{item.subtitle}
+				</span>
+			)}
+		</CommandItem>
+	);
+}

--- a/app/src/modules/palette/index.ts
+++ b/app/src/modules/palette/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+export { CommandPalette } from "./CommandPalette";
+export { PALETTE_GROUPS, PALETTE_GROUP_LABELS, rankForEmptyQuery } from "./types";
+export type { PaletteItem, PaletteKind } from "./types";

--- a/app/src/modules/palette/sources/useEntityItems.ts
+++ b/app/src/modules/palette/sources/useEntityItems.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Saved requests and collections, as palette results.
+ *
+ * The point of the whole feature: reaching a request today means opening the
+ * collections drawer and expanding a tree, and a request four folders deep is
+ * several clicks from anywhere.
+ *
+ * Both kinds open through the same `openTab` calls the tree uses (see
+ * `useTreeCrud`'s `navigateToRequest` / `navigateToCollection`), so a request
+ * opened from here is indistinguishable from one opened from the sidebar.
+ *
+ * Reads come straight from the cache `usePrefetchCollectionsAndRequests` warms
+ * at startup, so opening the palette fetches nothing.
+ */
+
+import { useMemo } from "react";
+import { Folder } from "lucide-react";
+import { useTabsStore } from "@/stores";
+import { useCollectionsQuery, useMultipleCollectionRequests, useRunsQuery } from "@/queries";
+import { flattenRunPages } from "@/queries";
+import type { Collection } from "@/types";
+import type { PaletteItem } from "../types";
+
+/**
+ * "Payments / Auth" for a nested collection, "" for a root one.
+ *
+ * Built iteratively with a visited set rather than by recursion: `parentId`
+ * comes off the wire, and a cycle in it would otherwise hang the renderer
+ * rather than mislabel one row.
+ */
+function collectionPath(id: string, byId: Map<string, Collection>): string {
+	const names: string[] = [];
+	const seen = new Set<string>();
+	let current = byId.get(id);
+	while (current && !seen.has(current.id)) {
+		seen.add(current.id);
+		names.unshift(current.name);
+		current = current.parentId ? byId.get(current.parentId) : undefined;
+	}
+	return names.join(" / ");
+}
+
+/** When each request was last sent, from the run history already in cache. */
+function lastSentByRequest(runs: { requestId?: string | null; startTime: number }[]) {
+	const latest = new Map<string, number>();
+	for (const run of runs) {
+		if (!run.requestId) continue;
+		const previous = latest.get(run.requestId);
+		if (previous === undefined || run.startTime > previous) {
+			latest.set(run.requestId, run.startTime);
+		}
+	}
+	return latest;
+}
+
+export function useEntityItems(): PaletteItem[] {
+	const openTab = useTabsStore((s) => s.openTab);
+	const { data: collections = [] } = useCollectionsQuery();
+	const collectionIds = collections.map((c) => c.id);
+	const { requestsByCollection } = useMultipleCollectionRequests(collectionIds);
+	const { data: runsData } = useRunsQuery();
+
+	// `runsData` is the query's own object and `collections` is stable while the
+	// query is; the map rebuilds only when one of them actually changes.
+	const lastSent = useMemo(() => lastSentByRequest(flattenRunPages(runsData)), [runsData]);
+	const byId = useMemo(() => new Map(collections.map((c) => [c.id, c])), [collections]);
+
+	const items: PaletteItem[] = [];
+
+	for (const collection of collections) {
+		const path = collectionPath(collection.id, byId);
+		// Where it sits, not what it is called - a root collection has no parent
+		// to state, so it gets no subtitle rather than an empty one.
+		const parentPath = collection.parentId ? collectionPath(collection.parentId, byId) : "";
+		items.push({
+			id: `collection:${collection.id}`,
+			kind: "collection",
+			title: collection.name,
+			...(parentPath ? { subtitle: parentPath } : {}),
+			icon: Folder,
+			perform: () => openTab({ type: "collection", entityId: collection.id }),
+		});
+
+		for (const request of requestsByCollection.get(collection.id) ?? []) {
+			items.push({
+				id: `request:${request.id}`,
+				kind: "request",
+				title: request.name,
+				subtitle: path,
+				// The URL finds a request whose name says nothing about it - and
+				// it is a keyword rather than the subtitle because the collection
+				// is what the eye needs to tell two "Get user"s apart.
+				keywords: [request.method, request.url],
+				method: request.method,
+				...(lastSent.has(request.id) ? { recencyAt: lastSent.get(request.id) } : {}),
+				perform: () => openTab({ type: "request", entityId: request.id }),
+			});
+		}
+	}
+
+	return items;
+}

--- a/app/src/modules/palette/sources/useTabItems.ts
+++ b/app/src/modules/palette/sources/useTabItems.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Open tabs, as palette results.
+ *
+ * The cheapest win in the palette: with a dozen tabs open the strip has already
+ * pushed half of them into the overflow menu, and this reaches any of them by
+ * name.
+ *
+ * Labels come from `tab-descriptors`, the same hook the strip itself uses - a
+ * tab must not read "GET /v1/orders" in one place and "Request" in the other.
+ */
+
+import { useTabsStore } from "@/stores";
+import { useTabDescriptors } from "@/components/layout/tab-descriptors";
+import type { PaletteItem } from "../types";
+
+export function useTabItems(): PaletteItem[] {
+	const openTabs = useTabsStore((s) => s.openTabs);
+	const focusTab = useTabsStore((s) => s.focusTab);
+	const tabFocusedAt = useTabsStore((s) => s.tabFocusedAt);
+	const descriptors = useTabDescriptors(openTabs);
+
+	return openTabs.map((tab, i) => {
+		const d = descriptors[i];
+		return {
+			id: `tab:${tab.id}`,
+			kind: "tab" as const,
+			title: d.label,
+			// The descriptor's `title` is the strip's tooltip - "GET /v1/orders",
+			// "Design run: POST /login" - which is exactly the disambiguator two
+			// same-named tabs need here.
+			subtitle: d.title === d.label ? undefined : d.title,
+			keywords: [tab.type],
+			...(d.icon ? { icon: d.icon } : {}),
+			...(d.method ? { method: d.method } : {}),
+			...(tabFocusedAt[tab.id] !== undefined ? { recencyAt: tabFocusedAt[tab.id] } : {}),
+			perform: () => focusTab(tab.id),
+		};
+	});
+}

--- a/app/src/modules/palette/sources/useViewItems.ts
+++ b/app/src/modules/palette/sources/useViewItems.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The app's own surfaces - drawer views and the tabs that are one of a kind.
+ *
+ * Two mechanisms behind one group, because the user is not asked to know the
+ * difference: Collections/History/Variables/Settings switch the drawer
+ * (`activateDrawerView`, the same call the Dock's buttons make), while
+ * Variables/Settings/Inbox are singleton *tabs*. Variables and Settings are
+ * both - the drawer holds the tree, the tab holds the editor - so their entry
+ * does what the Dock and the tree together do: open the tab and point the
+ * drawer at it.
+ *
+ * `activateDrawerView` *toggles* when the drawer is already on that view, which
+ * is right for a button pressed twice and wrong for a search result: picking
+ * "History" from the palette must show History, never hide it. So the entries
+ * here set the view explicitly instead.
+ */
+
+import { Braces, Clock, Folder, Inbox, Settings } from "lucide-react";
+import { useLayoutStore, useTabsStore, type DrawerView, type TabType } from "@/stores";
+import type { PaletteItem } from "../types";
+
+interface ViewEntry {
+	title: string;
+	keywords: string[];
+	icon: PaletteItem["icon"];
+	/** The drawer view to reveal, when this surface has one. */
+	drawerView?: DrawerView;
+	/** The singleton tab to open, when this surface has one. */
+	tabType?: Extract<TabType, "variables" | "settings" | "inbox">;
+}
+
+/**
+ * Fixed order, matching the Dock's switchers left to right so the two lists do
+ * not disagree about what the app is made of.
+ */
+const VIEWS: ViewEntry[] = [
+	{
+		title: "Collections",
+		keywords: ["requests", "tree", "sidebar"],
+		icon: Folder,
+		drawerView: "collections",
+	},
+	{ title: "History", keywords: ["runs", "past", "results"], icon: Clock, drawerView: "history" },
+	{
+		title: "Variables",
+		keywords: ["environment", "globals", "{{", "substitution"],
+		icon: Braces,
+		drawerView: "variables",
+		tabType: "variables",
+	},
+	{
+		title: "Settings",
+		keywords: ["preferences", "options", "config"],
+		icon: Settings,
+		drawerView: "settings",
+		tabType: "settings",
+	},
+	// No drawer view of its own: an inbox is engine state, not a stored record,
+	// so the tab is the whole surface (see the Launcher tile's note).
+	{ title: "Inbox", keywords: ["webhook", "receive", "callback"], icon: Inbox, tabType: "inbox" },
+];
+
+export function useViewItems(): PaletteItem[] {
+	const openTab = useTabsStore((s) => s.openTab);
+	const setDrawerOpen = useLayoutStore((s) => s.setDrawerOpen);
+	const setDrawerView = useLayoutStore((s) => s.setDrawerView);
+
+	return VIEWS.map((view) => ({
+		id: `view:${view.title.toLowerCase()}`,
+		kind: "view" as const,
+		title: view.title,
+		keywords: view.keywords,
+		icon: view.icon,
+		perform: () => {
+			if (view.drawerView) {
+				setDrawerOpen(true);
+				setDrawerView(view.drawerView);
+			}
+			if (view.tabType) openTab({ type: view.tabType, entityId: null });
+		},
+	}));
+}

--- a/app/src/modules/palette/types.ts
+++ b/app/src/modules/palette/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One row in the command palette, whatever produced it.
+ *
+ * Every source returns this shape and nothing else, so the dialog knows how to
+ * render and rank a result without knowing where it came from - which is what
+ * lets a later phase add settings, environments and runs as sources without
+ * touching the dialog.
+ */
+
+import type { LucideIcon } from "lucide-react";
+
+/**
+ * Which group a result renders under. The order here is the order on screen:
+ * groups are fixed so the list does not reshuffle as you type.
+ */
+export const PALETTE_GROUPS = ["tab", "request", "collection", "view"] as const;
+
+export type PaletteKind = (typeof PALETTE_GROUPS)[number];
+
+/** Heading shown above each group. */
+export const PALETTE_GROUP_LABELS: Record<PaletteKind, string> = {
+	tab: "Tabs",
+	request: "Requests",
+	collection: "Collections",
+	view: "Views",
+};
+
+export interface PaletteItem {
+	/** Unique across all sources - used as the React key. */
+	id: string;
+	kind: PaletteKind;
+	/** What the row reads as. Matched against the query. */
+	title: string;
+	/** Where it lives - a collection path, a tab's kind. Also matched. */
+	subtitle?: string;
+	/** Extra terms that should find this row but do not belong on screen. */
+	keywords?: string[];
+	icon?: LucideIcon;
+	/** HTTP method, drawn as the same colour rail the tab strip uses. */
+	method?: string;
+	/**
+	 * When this last mattered to the user, in epoch ms; `undefined` when
+	 * nothing knows. Orders the empty query - see `rankForEmptyQuery`.
+	 */
+	recencyAt?: number;
+	/** What Enter (or a click) does. The palette closes itself afterwards. */
+	perform: () => void;
+}
+
+/**
+ * Order for the empty query: most recent first, then the source's own order.
+ *
+ * Only for the empty query. Once there is something typed, cmdk's match score
+ * decides - a result that matches better has to win over one that is merely
+ * more recent, or typing stops feeling like searching.
+ *
+ * Stable: `Array.prototype.sort` is specified as stable, so items with no
+ * recency at all keep the order their source produced (strip order for tabs,
+ * tree order for requests).
+ */
+export function rankForEmptyQuery(items: PaletteItem[]): PaletteItem[] {
+	return [...items].sort((a, b) => (b.recencyAt ?? 0) - (a.recencyAt ?? 0));
+}

--- a/app/src/modules/welcome/Launcher.tsx
+++ b/app/src/modules/welcome/Launcher.tsx
@@ -16,7 +16,7 @@
 // `Braces` is the app-wide mark for variables - see the note in
 // `components/layout/Dock.tsx`. It was `Database` here, which reads as stored
 // records rather than `{{name}}` substitutions.
-import { Download, Plus, Braces, History, Inbox } from "lucide-react";
+import { Download, Plus, Braces, History, Inbox, Search } from "lucide-react";
 import { Eyebrow } from "@/components/ui";
 import type { Run } from "@/types";
 import { ActionTile } from "./components/ActionTile";
@@ -28,6 +28,7 @@ interface LauncherProps {
 	collectionCount: number;
 	onImport: () => void;
 	onNewRequest: () => void;
+	onSearch: () => void;
 	onHistory: () => void;
 	onVariables: () => void;
 	onInbox: () => void;
@@ -42,6 +43,7 @@ export function Launcher({
 	collectionCount,
 	onImport,
 	onNewRequest,
+	onSearch,
 	onHistory,
 	onVariables,
 	onInbox,
@@ -50,11 +52,18 @@ export function Launcher({
 		<div className="flex flex-col gap-8">
 			<section>
 				<Eyebrow className="mb-2">Start</Eyebrow>
-				{/* Five columns since the webhook inbox joined the row: the tiles
-				    are equal-weight starting points, and a 4-column grid holding
-				    five would strand one on a line of its own. */}
-				<div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+				{/* Six columns since Search joined the row: the tiles are
+				    equal-weight starting points, and a grid narrower than the
+				    count would strand one on a line of its own. */}
+				<div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
 					<ActionTile icon={Plus} label="New request" onClick={onNewRequest} />
+					{/*
+					 * The command palette's visible half. The chord alone is
+					 * undiscoverable - nobody presses ⌘K in an app they have not
+					 * been told has a palette - and this grid is where the app
+					 * teaches its own surfaces.
+					 */}
+					<ActionTile icon={Search} label="Search" onClick={onSearch} />
 					<ActionTile icon={Download} label="Import" onClick={onImport} />
 					<ActionTile icon={History} label="History" onClick={onHistory} />
 					<ActionTile icon={Braces} label="Variables" onClick={onVariables} />

--- a/app/src/modules/welcome/LauncherSkeleton.tsx
+++ b/app/src/modules/welcome/LauncherSkeleton.tsx
@@ -26,11 +26,14 @@ import { Skeleton } from "@/components/ui";
 export function LauncherSkeleton() {
 	return (
 		<div className="flex flex-col gap-8" role="status" aria-label="Loading">
-			{/* Start - label + the 2x4 action tile grid */}
+			{/* Start - label + the action tile grid. Column counts and tile count
+			    both track Launcher's grid: a skeleton one tile short reflows the
+			    row the moment the real content arrives, which is the one thing a
+			    skeleton exists to prevent. */}
 			<section aria-hidden="true">
 				<Skeleton className="mb-2 h-3 w-10 rounded-md" />
-				<div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-					{Array.from({ length: 4 }, (_, i) => (
+				<div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+					{Array.from({ length: 6 }, (_, i) => (
 						// Matches ActionTile: bordered card, icon over label.
 						<div
 							key={i}

--- a/app/src/modules/welcome/WelcomeScreen.test.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import WelcomeScreen from "./WelcomeScreen";
-import { useTabsStore, useSessionStore } from "@/stores";
+import { useTabsStore, useSessionStore, useLayoutStore } from "@/stores";
 import type { Run } from "@/types";
 
 const mocks = vi.hoisted(() => ({
@@ -25,6 +25,13 @@ vi.mock("@/queries", () => ({
 	useCreateCollectionMutation: () => ({ mutateAsync: mocks.createCollection }),
 	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map() }),
 }));
+
+/**
+ * How many tiles the populated Launcher shows. Asserted from both sides - the
+ * real grid and the skeleton's - because the skeleton silently drifted a tile
+ * behind the Launcher once already, which is the one thing it exists to avoid.
+ */
+const LAUNCHER_TILES = 6;
 
 function run(over: Partial<Run> = {}): Run {
 	return {
@@ -54,6 +61,7 @@ describe("WelcomeScreen", () => {
 		mocks.createCollection = vi.fn().mockResolvedValue({ id: "new-col" });
 		useTabsStore.setState({ openTabs: [], activeTabId: null });
 		useSessionStore.setState({ lastCollectionId: null });
+		useLayoutStore.setState({ paletteOpen: false });
 	});
 
 	describe("empty workspace", () => {
@@ -84,6 +92,24 @@ describe("WelcomeScreen", () => {
 			expect(screen.getByRole("button", { name: /New request/i })).toBeInTheDocument();
 			expect(screen.getByRole("button", { name: /^History$/i })).toBeInTheDocument();
 			expect(screen.getByText(/Recent runs/i)).toBeInTheDocument();
+		});
+
+		/*
+		 * The palette's visible half. ⌘K is undiscoverable on its own - nobody
+		 * presses it in an app they have not been told has a palette - so the
+		 * tile is what teaches the feature exists, and it has to open the same
+		 * palette the chord does rather than a second search of its own.
+		 */
+		it("opens the command palette from the Search tile", () => {
+			renderScreen();
+			expect(useLayoutStore.getState().paletteOpen).toBe(false);
+			fireEvent.click(screen.getByRole("button", { name: /^Search$/i }));
+			expect(useLayoutStore.getState().paletteOpen).toBe(true);
+		});
+
+		it("shows one tile per action, and the skeleton matches", () => {
+			const { container } = renderScreen();
+			expect(container.querySelectorAll(".grid > button")).toHaveLength(LAUNCHER_TILES);
 		});
 
 		it("has no Load test action - a load test needs an existing request", () => {
@@ -200,9 +226,9 @@ describe("WelcomeScreen", () => {
 		mocks.runs = { data: [], isLoading: true };
 		const { container } = renderScreen();
 		expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
-		// Holds the Launcher shape: four action tiles so the real content lands
-		// in place rather than pushing a blank page around.
-		expect(container.querySelectorAll(".grid > div")).toHaveLength(4);
+		// Holds the Launcher shape: one skeleton tile per real action tile, so
+		// the content lands in place rather than pushing a blank page around.
+		expect(container.querySelectorAll(".grid > div")).toHaveLength(LAUNCHER_TILES);
 	});
 
 	it("drops the skeleton once the queries settle", () => {

--- a/app/src/modules/welcome/WelcomeScreen.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.tsx
@@ -48,6 +48,7 @@ export default function WelcomeScreen() {
 	const showToast = useToastStore((s) => s.showToast);
 	const { openTab } = useTabsStore();
 	const activateDrawerView = useLayoutStore((s) => s.activateDrawerView);
+	const setPaletteOpen = useLayoutStore((s) => s.setPaletteOpen);
 	const lastCollectionId = useSessionStore((s) => s.lastCollectionId);
 	const {
 		data: collections = [],
@@ -160,6 +161,7 @@ export default function WelcomeScreen() {
 						collectionCount={collections.length}
 						onImport={openImport}
 						onNewRequest={handleNewRequest}
+						onSearch={() => setPaletteOpen(true)}
 						onHistory={() => activateDrawerView("history")}
 						onVariables={() => openTab({ type: "variables", entityId: null })}
 						onInbox={() => openTab({ type: "inbox", entityId: null })}

--- a/app/src/stores/layout-store.ts
+++ b/app/src/stores/layout-store.ts
@@ -59,6 +59,16 @@ interface LayoutState {
 	graphqlVariablesCollapsed: boolean;
 	graphqlVariablesSize: number;
 
+	/**
+	 * Whether the ⌘K command palette is showing.
+	 *
+	 * Here rather than as local state in the palette because the two things that
+	 * open it are in different subtrees: the chord handler in `Shell`, and the
+	 * title bar's search bar. Deliberately absent from `partialize` - a dialog
+	 * that reopened itself on every launch is not a layout preference.
+	 */
+	paletteOpen: boolean;
+
 	// Actions
 	setDrawerOpen: (open: boolean) => void;
 	toggleDrawer: () => void;
@@ -76,6 +86,8 @@ interface LayoutState {
 
 	setGraphqlVariablesCollapsed: (collapsed: boolean) => void;
 	setGraphqlVariablesSize: (size: number) => void;
+
+	setPaletteOpen: (open: boolean) => void;
 }
 
 export const useLayoutStore = create<LayoutState>()(
@@ -90,6 +102,7 @@ export const useLayoutStore = create<LayoutState>()(
 			requestSplitRatio: 0.5,
 			graphqlVariablesCollapsed: false,
 			graphqlVariablesSize: DEFAULT_GRAPHQL_VARIABLES_SIZE,
+			paletteOpen: false,
 
 			setDrawerOpen: (open) => set({ drawerOpen: open }),
 			toggleDrawer: () => set((s) => ({ drawerOpen: !s.drawerOpen })),
@@ -131,6 +144,8 @@ export const useLayoutStore = create<LayoutState>()(
 						Math.min(GRAPHQL_VARIABLES_MAX_SIZE, size)
 					),
 				}),
+
+			setPaletteOpen: (open) => set({ paletteOpen: open }),
 		}),
 		{
 			name: STORAGE_KEYS.LAYOUT_STORE,

--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -11,7 +11,7 @@ import { useSaveStore, type SaveContext } from "./save-store";
 import { useResponseStore } from "./response-store";
 
 beforeEach(() => {
-	useTabsStore.setState({ openTabs: [], activeTabId: null });
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
 	useSaveStore.setState({ contexts: new Map() });
 });
 
@@ -326,5 +326,71 @@ describe("closeTabsForEntities evicts stored responses", () => {
 		storeResponse("r1");
 		useTabsStore.getState().closeTabsForEntities([]);
 		expect(useResponseStore.getState().getResponse("r1")).not.toBeNull();
+	});
+});
+
+/**
+ * `openTabs` is insertion order, so the tab you were just in sits wherever it
+ * was opened. The command palette lists open tabs most-recently-used first,
+ * which needs a second signal - this one.
+ */
+describe("tabFocusedAt", () => {
+	const ids = () => useTabsStore.getState().openTabs.map((t) => t.id);
+	const byRecency = () => {
+		const { openTabs, tabFocusedAt } = useTabsStore.getState();
+		return [...openTabs]
+			.sort((a, b) => (tabFocusedAt[b.id] ?? 0) - (tabFocusedAt[a.id] ?? 0))
+			.map((t) => t.id);
+	};
+
+	it("ranks a re-focused tab ahead of one opened after it", async () => {
+		const store = useTabsStore.getState();
+		store.openTab({ type: "settings", entityId: null });
+		store.openTab({ type: "variables", entityId: null });
+		store.openTab({ type: "inbox", entityId: null });
+		const [settings, variables, inbox] = ids();
+
+		// Date.now() has millisecond resolution and three opens can share one.
+		await new Promise((r) => setTimeout(r, 2));
+		useTabsStore.getState().focusTab(settings);
+
+		expect(byRecency()[0]).toBe(settings);
+		expect(byRecency()).toContain(variables);
+		expect(byRecency()).toContain(inbox);
+	});
+
+	it("stamps a singleton that was already open, since that is a focus too", async () => {
+		const store = useTabsStore.getState();
+		store.openTab({ type: "settings", entityId: null });
+		store.openTab({ type: "inbox", entityId: null });
+		const [settings] = ids();
+
+		await new Promise((r) => setTimeout(r, 2));
+		// Deduped to a focus of the existing tab, not a second Settings tab.
+		useTabsStore.getState().openTab({ type: "settings", entityId: null });
+
+		expect(useTabsStore.getState().openTabs).toHaveLength(2);
+		expect(byRecency()[0]).toBe(settings);
+	});
+
+	it("forgets a tab once it is closed and something else is focused", () => {
+		const store = useTabsStore.getState();
+		store.openTab({ type: "settings", entityId: null });
+		store.openTab({ type: "inbox", entityId: null });
+		const [settings, inbox] = ids();
+
+		useTabsStore.getState().closeTab(inbox);
+		useTabsStore.getState().focusTab(settings);
+
+		expect(Object.keys(useTabsStore.getState().tabFocusedAt)).toEqual([settings]);
+	});
+
+	it("ignores a focus of a tab that is not open", () => {
+		useTabsStore.getState().openTab({ type: "settings", entityId: null });
+		const before = useTabsStore.getState().tabFocusedAt;
+
+		useTabsStore.getState().focusTab("nope");
+
+		expect(useTabsStore.getState().tabFocusedAt).toBe(before);
 	});
 });

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -38,6 +38,22 @@ const LRU_EXEMPT_TYPES: TabType[] = ["dashboard"];
 interface TabsState {
 	openTabs: Tab[];
 	activeTabId: string | null;
+	/**
+	 * When each open tab was last focused, in epoch ms.
+	 *
+	 * Read by the command palette, which lists open tabs most-recently-used
+	 * first - the order a switcher has to have, and one `openTabs` cannot give:
+	 * that array is insertion order, so the tab you were just in sits wherever
+	 * it was opened.
+	 *
+	 * Session-scoped by design (absent from `partialize`). Tabs *are* restored
+	 * across launches, so a persisted copy would rank a restored list by
+	 * yesterday's attention; an empty map falls back to strip order, which is
+	 * what the user sees on screen anyway. Entries for closed tabs are dropped
+	 * on the next focus rather than in every close path - nothing reads a
+	 * stamp for a tab that is no longer open.
+	 */
+	tabFocusedAt: Record<string, number>;
 
 	openTab: (tab: Omit<Tab, "id">) => void;
 	closeTab: (tabId: string) => void;
@@ -148,6 +164,27 @@ function migrateTabs(persisted: unknown): PersistedTabs {
 	};
 }
 
+/**
+ * Stamp `focusedId` as focused now, keeping only the tabs that still exist.
+ *
+ * Pruning here rather than in each close path is what keeps the close paths
+ * unchanged: a stamp for a closed tab is unreachable (the palette only ranks
+ * open tabs) and is dropped the next time anything is focused.
+ */
+function stampFocus(
+	previous: Record<string, number>,
+	tabs: Tab[],
+	focusedId: string
+): Record<string, number> {
+	const live: Record<string, number> = {};
+	for (const tab of tabs) {
+		const at = previous[tab.id];
+		if (at !== undefined) live[tab.id] = at;
+	}
+	live[focusedId] = Date.now();
+	return live;
+}
+
 function makeId() {
 	return typeof crypto !== "undefined" && crypto.randomUUID
 		? crypto.randomUUID()
@@ -159,9 +196,10 @@ export const useTabsStore = create<TabsState>()(
 		(set, get) => ({
 			openTabs: [],
 			activeTabId: null,
+			tabFocusedAt: {},
 
 			openTab: (tabDef) => {
-				const { openTabs, activeTabId } = get();
+				const { openTabs, activeTabId, tabFocusedAt } = get();
 
 				// Dedupe: singletons and entity-keyed tabs
 				const isSingleton = SINGLETON_TYPES.includes(tabDef.type);
@@ -171,7 +209,10 @@ export const useTabsStore = create<TabsState>()(
 						: t.type === tabDef.type && t.entityId === tabDef.entityId
 				);
 				if (existing) {
-					set({ activeTabId: existing.id });
+					set({
+						activeTabId: existing.id,
+						tabFocusedAt: stampFocus(tabFocusedAt, openTabs, existing.id),
+					});
 					return;
 				}
 
@@ -196,7 +237,11 @@ export const useTabsStore = create<TabsState>()(
 					}
 				}
 
-				set({ openTabs: tabs, activeTabId: newTab.id });
+				set({
+					openTabs: tabs,
+					activeTabId: newTab.id,
+					tabFocusedAt: stampFocus(tabFocusedAt, tabs, newTab.id),
+				});
 			},
 
 			closeTab: (tabId) => {
@@ -261,8 +306,12 @@ export const useTabsStore = create<TabsState>()(
 			},
 
 			focusTab: (tabId) => {
-				if (get().openTabs.find((t) => t.id === tabId)) {
-					set({ activeTabId: tabId });
+				const { openTabs, tabFocusedAt } = get();
+				if (openTabs.find((t) => t.id === tabId)) {
+					set({
+						activeTabId: tabId,
+						tabFocusedAt: stampFocus(tabFocusedAt, openTabs, tabId),
+					});
 				}
 			},
 		}),

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -20,6 +20,7 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
 ├── <UpdateBanner />
 └── <Shell />                            // components/layout/Shell.tsx - tab-centric layout with drawer + context bar
     ├── <ImportModal />                  // modules/collections/ImportModal.tsx - global overlay, open-state in a store
+    ├── <CommandPalette />               // modules/palette/ - ⌘K overlay; open-state in layout-store
     ├── <Drawer />                       // components/layout/Drawer.tsx - resizable 220–480px; single left nav; switches views
     │   ├── <CollectionTree />           //   collections view (default)
     │   ├── <HistoryList />              //   history view
@@ -61,6 +62,8 @@ The logo is imported as a module (`@shared/icon_png/...`), not referenced as `/i
 
 Horizontal row of open tabs plus a "+" button. Reads from `useTabsStore` (open tabs, active tab, add/close/focus methods).
 
+Labels and icons come from `tab-descriptors.ts`, a sibling module rather than this file, because the command palette lists the same tabs and must name them identically - a tab that reads "GET /v1/orders" in the strip and "Request" in the palette is two answers to one question.
+
 - **One tab per open entity**, deduplicated per type and `entityId`. Tabs show: icon (method badge for requests, folder for collections, lightning for dashboard, etc.), label (request method + URL path / collection name / screen name).
 - **Max 12 tabs** with LRU eviction when exceeding; dashboard tabs are exempt from eviction. Dirty tabs (unsaved) are skipped during eviction (autosave is the safety net).
 - **Middle-click closes** a tab (browser-like).
@@ -73,12 +76,12 @@ Main layout: tab-centric with resizable drawer, split/overlay context bar, and d
 
 - **One uniform layout for every tab** - `Drawer` (left) + main content + `ContextBar` (right). No tab type takes over the row. This is deliberate: the Dock's drawer switchers always have a Drawer to act on, so they can never be dead. (Settings used to full-take-over and suppress the Drawer, which left those buttons doing nothing while Settings was open.)
 - **Left navigation is always the Drawer.** Every main view that needs a category/entity list uses the shared Drawer for it - never its own left rail. `SettingsMain` and `VariablesMain` are pure content panes; their category trees live in the Drawer (`settings` / `variables` views). Follow this pattern for any new view - do not add a second sidebar inside the main area.
-- **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab).
+- **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab). ⌘K (command palette) is **not** in this map - it is owned by `CommandPalette`, on the capture phase, because Monaco swallows the key on the bubble.
 - **Drawer:** toggles visibility via `toggleDrawer()` (state in `useLayoutStore`); always resizable 220–480px.
 - **Content routing:** switches main area based on `activeTab.type` (welcome | request | collection | dashboard | run | variables | settings). Default is `WelcomeScreen`.
 - **Drawer-view sync:** an effect points the Drawer at the view matching the active tab - `variables`→variables, `settings`→settings, `request`/`collection`→collections - and opens it.
 - **ContextBar mode:** picks "push" (≥1200px width) or "overlay" based on window width. It renders on the tab types the section registry has entries for - request, collection and run - and nothing on the other four.
-- **`<ImportModal />`** mounted once as a global overlay; visibility in a dedicated store.
+- **`<ImportModal />`** and **`<CommandPalette />`** mounted once each as global overlays; visibility in a store rather than in the Shell.
 
 ### `Drawer` (`components/layout/Drawer.tsx`)
 
@@ -454,12 +457,53 @@ It is **not** a resume screen: `openTabs`/`activeTabId` are persisted and restor
 - `WelcomeScreen.tsx` - container: queries, `handleNewRequest`, picks the state. Holds on `isLoading` so the first-run screen never flashes at a returning user.
 - `EmptyState.tsx` - fresh workspace. Import leads (people arrive carrying Postman/Insomnia/OpenAPI collections). The only state with branding.
 - `Launcher.tsx` - populated. Action row, recent runs, workspace counts. No branding; the logo is in the title bar.
-- `components/` - `ActionTile`, `RecentRuns`, `FooterLinks`. The action row is five tiles: New
-  request, Import, History, Variables, Inbox.
+- `components/` - `ActionTile`, `RecentRuns`, `FooterLinks`. The action row is six tiles: New
+  request, Search, Import, History, Variables, Inbox. Search opens the command palette - the
+  chord alone is undiscoverable, and this grid is where the app teaches its own surfaces.
+- `LauncherSkeleton.tsx` - one skeleton tile per real tile. It has drifted a tile behind the
+  Launcher before; `WelcomeScreen.test.tsx` now asserts both grids against one constant.
 
 Doc links go through `window.electronAPI.openAppLink(key)`, a keyed IPC channel - the renderer cannot open arbitrary URLs, and a plain `<a target="_blank">` would spawn an unmanaged Electron window.
 
 Design rationale: `app/src/modules/welcome/README.md`
+
+## Command Palette (`modules/palette/`)
+
+The ⌘K/Ctrl+K overlay: reach any open tab, saved request, collection or app view by name.
+Mounted once by `Shell`, alongside `ImportModal`.
+
+- **`CommandPalette.tsx`** - the dialog, the chord, focus restoration, and the open flag
+  (`useLayoutStore.paletteOpen` / `setPaletteOpen`, deliberately not persisted).
+- **`sources/`** - one hook per family, each returning `PaletteItem[]`: `useTabItems` (open
+  tabs), `useEntityItems` (requests + collections), `useViewItems` (drawer views and singleton
+  tabs). Adding settings, environments or runs later is a new source and nothing else.
+- **`types.ts`** - the `PaletteItem` shape, the fixed group order, and `rankForEmptyQuery`.
+- **`PaletteResults.tsx`** - grouping and rendering. **Mounted only while the palette is open**,
+  the same cost rule the context bar applies to a collapsed section: a shut palette holds no
+  query observers on collections, requests or run history.
+
+Three things about it are load-bearing:
+
+- **The chord is on the capture phase**, unlike every other shortcut in the app (which lives in
+  `Shell`'s bubble-phase keydown map). Monaco treats ⌘K as the start of a chord and stops it
+  propagating, so a bubble listener never sees the key while the caret is in an editor.
+  `PALETTE_CHORD` lives in `constants/shortcuts.ts` so the handler and every label that
+  advertises the chord read one definition.
+- **Focus goes back where it came from**, and that is the palette's own code: Radix's
+  `FocusScope` restores to a dialog's *trigger*, and a palette summoned by a chord has none, so
+  focus would land on `<body>`. The previous element is captured from a store subscription
+  rather than an effect - child effects run first, so by the time an effect here fires the
+  dialog has already taken focus.
+- **Tab rows are named by `components/layout/tab-descriptors.ts`**, the same hook `TabStrip`
+  uses. A tab must not read "GET /v1/orders" in the strip and "Request" in the palette.
+
+Ranking: cmdk's own match score once anything is typed; on the empty query, `rankForEmptyQuery`
+puts the most recent first - focus time for tabs (`tabFocusedAt` in `tabs-store`, session-scoped),
+last-run time for requests (from the run history already in cache). Groups render in a fixed
+order (Tabs, Requests, Collections, Views) so the list does not reshuffle as you type.
+
+**Entry points:** the chord, and the `Search` tile on the welcome Launcher. The title bar's
+search bar (#529) is the third and becomes the primary one - it flips the same store flag.
 
 ## Toaster (`components/shared/Toaster.tsx`)
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -48,8 +48,9 @@ Manages all open tabs (welcome, request, collection, dashboard, run, variables, 
 **State:**
 ```typescript
 {
-  openTabs: Tab[]          // Each tab has unique id, type, and optional entityId
+  openTabs: Tab[]                        // Each tab has unique id, type, and optional entityId
   activeTabId: string | null
+  tabFocusedAt: Record<string, number>   // Tab id -> when it was last focused (epoch ms)
 }
 ```
 
@@ -68,6 +69,14 @@ Manages all open tabs (welcome, request, collection, dashboard, run, variables, 
 - Response eviction: `closeTabsForEntities` clears each id's entry in
   `response-store`. Both callers reach it after a delete, and nothing else
   evicts from that map
+- Focus recency: `tabFocusedAt` stamps `openTab` and `focusTab`, and is read by
+  the command palette, which lists open tabs most-recently-used first. It cannot
+  come from `openTabs`, which is insertion order - the tab you were just in sits
+  wherever it was opened. Session-scoped on purpose (absent from `partialize`):
+  tabs *are* restored across launches, so a persisted copy would rank a restored
+  list by yesterday's attention, and an empty map falls back to strip order.
+  Entries for closed tabs are dropped on the next focus rather than in every
+  close path - nothing reads a stamp for a tab that is not open
 - Persistence: `vayu.tabs` (v1), with a pass-through `migrate`. zustand discards
   a payload whose *stamped* version differs from the store's when no `migrate`
   is supplied, so the stub is where the next bump goes; it also refuses a
@@ -94,6 +103,7 @@ Manages the left drawer (collections/history/variables/settings), the right cont
   contextBarWidth: number
   contextBarCollapsedSections: string[]  // Section ids the user collapsed
   requestSplitRatio: number              // 0–1; left/request pane fraction
+  paletteOpen: boolean                   // Is the ⌘K command palette showing?
 }
 ```
 
@@ -118,6 +128,12 @@ migration collapses them onto a single `drawerWidth`, keeping whatever
 Collections (the default view) had. Re-introducing a per-view width re-introduces
 that bug. `setRequestSplitRatio` clamps to [0.2, 0.8]; both panel widths clamp to
 `PANEL_MIN_WIDTH` / `PANEL_MAX_WIDTH`.
+
+**`paletteOpen` is here, and is not persisted.** The palette lives in `Shell`
+while the things that open it - the welcome Launcher's Search tile, the title
+bar's search bar - are in other subtrees, so the flag has to be shared state
+rather than the dialog's own. It is deliberately absent from `partialize`: a
+dialog that reopened itself on every launch is not a layout preference.
 
 **Context-bar sections are collapsed by exception.** The store holds the ids the
 user closed (`contextBarCollapsedSections`); anything not listed is expanded. Two


### PR DESCRIPTION
## Description

**Plan.** Root cause: nothing in the app is reachable by name - every entity lives behind a drawer plus a tree, so navigation is mouse-only. The approach is a dialog mounted once by `Shell` over a set of source hooks, each returning one `PaletteItem` shape and performing its action through the *same* call the sidebar already makes (`openTab`, `setDrawerView`), so a request opened from the palette is indistinguishable from one opened from the tree, and phases 2/3 add a source rather than touching the dialog. The alternative I rejected was letting each source own its own rendering and ranking - it reads as more modular, but it is how two surfaces end up disagreeing about what a thing is called, which this repo already has a rule about; instead the palette borrows `TabStrip`'s naming wholesale (see below).

Three decisions worth review:

- **The chord listens on the capture phase**, unlike every other shortcut in the app (which live in `Shell`'s bubble-phase keydown map). Monaco treats ⌘K as the start of a chord (⌘K ⌘C and friends) and calls `stopPropagation`, so a bubble listener on `window` never sees the key while the caret is in a body or script editor - which is most of the time here, and exactly when reaching another request by name is worth the most. The divergence is scoped to this one chord. `PALETTE_CHORD` lives in `constants/shortcuts.ts` so the handler and every label advertising the chord read one definition - `matchesChord` now compares the key case-insensitively, which also fixes any letter chord under Caps Lock.
- **Focus restoration is the palette's own code, not Radix's.** `FocusScope` restores to a dialog's *trigger*, and a palette summoned by a chord has none - measured, focus landed on `<body>`, i.e. the caret was gone from the editor the user was typing in. The previous element is captured from a **store subscription** rather than an effect: child effects run before the parent's, so by the time an effect here fires the dialog has already taken focus.
- **Tab labels moved out of `TabStrip.tsx` into `tab-descriptors.ts`** (a verbatim move, no behaviour change). The palette lists the same tabs and must name them identically - a hand-rolled copy would also never receive that code's fixes, and the run-tab naming in it took three passes to get right.

**Deviations from the issue spec, both deliberate:**

1. **No persisted palette-pick LRU.** The issue suggests one in the client-settings store "to round out" ranking. That store's own doc says it holds renderer *preferences* and explicitly not workspace state, and `resetAll` wipes it - so a pick history would vanish with "Reset app settings". It would also be a third recency mechanism next to two real ones already available for free: tab focus time, and last-run time from the run history already in cache. Empty-query recency works today from those. If you want palette recency to survive a relaunch, that is a small follow-up and I'll file it on request.
2. **`CommandDialog` gained required `title`/`description` props and `DialogContent` an optional `showClose`.** Radix requires a `DialogTitle`; a palette has no visible heading, so it is `sr-only`. `showClose={false}` exists because the corner X would land on top of the search field. `CommandDialog` had no other consumers, so neither is a breaking change in practice.

Also fixed, in files this touches: `LauncherSkeleton` had already drifted a tile behind `Launcher` (4 vs 5); both grids now derive from one constant asserted in the test.

**Not in scope:** the title-bar search bar. It is #529's, and it now has a real `openPalette` to call - flip `useLayoutStore.paletteOpen`, one line. I released my claim on #529 with the reasoning: shipping the bar first would mean shipping a control that advertises ⌘K with nothing listening, which `constants/shortcuts.ts` exists to forbid, plus a click target that does nothing.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All commands run on this branch; all green, no pre-existing failures encountered.

- `cd app && pnpm test` - **402 files / 4081 tests passed**
- `cd app && pnpm type-check` - clean
- `cd app && pnpm lint` - clean (zero warnings)
- `cd app && pnpm format:check` - clean

New coverage:

- `modules/palette/CommandPalette.test.tsx` - **15 tests**: the chord opens/closes/toggles and survives an element that swallows the key; ignores bare `k` and ⇧⌘K; matches under Caps Lock; typing part of a name and Enter opens the right tab (spied through the store); a request found by URL; the collection path as disambiguator; "no matches"; switching to an open tab rather than opening a second; empty-query recency for tabs and for requests; fixed group order; focus restored on Escape; the query cleared on reopen; nothing rendered while shut.
- `stores/tabs-store.test.ts` - **4 tests** for `tabFocusedAt`: a re-focused tab outranks a later-opened one, a deduped singleton open counts as a focus, closed tabs are forgotten, an unknown id changes nothing.
- `modules/welcome/WelcomeScreen.test.tsx` - the Search tile opens the palette; tile count asserted from both the Launcher and the skeleton.
- `components/layout/tab-type-coverage.test.ts` - repointed at `tab-descriptors.ts` with a non-empty-read guard, so it cannot pass vacuously on the wrong file.

Mutation-checked (reverted the fix, confirmed red, restored):

| Reverted | Result |
|---|---|
| capture phase → bubble | 3 failed |
| focus restore removed | 1 failed |
| `rankForEmptyQuery` sort removed | 2 failed |

Engine untouched, so no engine build or ctest run - nothing there could change colour.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/COMPONENTS.md` (new Command Palette section, hierarchy entry, Shell shortcut line noting ⌘K is *not* in Shell's map and why, TabStrip's descriptor note, the Launcher's six tiles), `docs/app/state-management.md` (`tabFocusedAt`, `paletteOpen` and why neither is persisted), `app/src/modules/README.md` (overlay modules, and how to add a source).

## Related Issues
Closes #525

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKtoz1j9UXYKaYLvSYCVoG)_