### PR TITLE
feat(mcp): name a clamped VAYU_MCP_* cap on the stdio CLI's own output

### DIFF
--- a/app/electron/mcp/cli.ts
+++ b/app/electron/mcp/cli.ts
@@ -18,7 +18,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createMcpServer } from "./server.js";
 import { EngineClient } from "./engine-client.js";
-import { buildSafetyConfigFromEnv } from "./config.js";
+import { buildSafetyConfigFromEnv, formatSafetyEnvNotices } from "./config.js";
 import type { ToolContext } from "./tools.js";
 
 async function main(): Promise<void> {
@@ -26,11 +26,10 @@ async function main(): Promise<void> {
 	const version = process.env.VAYU_VERSION ?? "0.0.0";
 
 	const client = new EngineClient({ baseUrl: engineBaseUrl });
-	const { config, ignored } = buildSafetyConfigFromEnv(process.env);
-	for (const { variable, value, fallback } of ignored) {
-		console.error(
-			`[vayu-mcp] ignoring malformed ${variable}=${JSON.stringify(value)} (using default ${JSON.stringify(fallback)})`
-		);
+	const envSafety = buildSafetyConfigFromEnv(process.env);
+	const { config } = envSafety;
+	for (const notice of formatSafetyEnvNotices(envSafety)) {
+		console.error(notice);
 	}
 	const contextProvider = (): ToolContext => ({ client, config });
 

--- a/app/electron/mcp/config.test.ts
+++ b/app/electron/mcp/config.test.ts
@@ -5,10 +5,12 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import {
 	buildSafetyConfigFromEnv,
 	DEFAULT_MCP_SAFETY_CONFIG,
+	formatSafetyEnvNotices,
 	MCP_CAP_CEILINGS,
 	normalizeHost,
 	resolveSafetyConfig,
@@ -215,15 +217,71 @@ describe("buildSafetyConfigFromEnv", () => {
 	});
 
 	it("holds an over-ceiling cap the same way the Settings path does", () => {
-		const { config, ignored } = buildSafetyConfigFromEnv({
+		const { config, ignored, clamped } = buildSafetyConfigFromEnv({
 			VAYU_MCP_MAX_CONCURRENCY: "50000",
 		});
 
 		expect(config.maxConcurrency).toBe(MCP_CAP_CEILINGS.maxConcurrency);
 		// Held, not thrown away: `ignored` is for values that fell back to a
-		// default, and this one is in force at the ceiling.
+		// default, and this one is in force at the ceiling - so it is reported
+		// through the other channel, with the value that actually applies.
 		expect(ignored).toEqual([]);
+		expect(clamped).toEqual([
+			{
+				variable: "VAYU_MCP_MAX_CONCURRENCY",
+				value: "50000",
+				applied: MCP_CAP_CEILINGS.maxConcurrency,
+			},
+		]);
 		expect(checkLoadCaps({ concurrency: 10_001 }, config).ok).toBe(false);
+	});
+
+	it("reports a clamped cap for every cap variable, never for an in-range one", () => {
+		const { clamped } = buildSafetyConfigFromEnv({
+			VAYU_MCP_MAX_RPS: "2000000",
+			VAYU_MCP_MAX_CONCURRENCY: "50000",
+			VAYU_MCP_MAX_DURATION_SECONDS: "300",
+			VAYU_MCP_MAX_ITERATIONS: "999000000",
+		});
+
+		expect(clamped.map((c) => c.variable)).toEqual([
+			"VAYU_MCP_MAX_RPS",
+			"VAYU_MCP_MAX_CONCURRENCY",
+			"VAYU_MCP_MAX_ITERATIONS",
+		]);
+		expect(clamped.map((c) => c.applied)).toEqual([
+			MCP_CAP_CEILINGS.maxRps,
+			MCP_CAP_CEILINGS.maxConcurrency,
+			MCP_CAP_CEILINGS.maxIterations,
+		]);
+	});
+
+	it("keeps the clamped and ignored channels from blurring", () => {
+		const { ignored, clamped } = buildSafetyConfigFromEnv({
+			VAYU_MCP_MAX_RPS: "1,000",
+			VAYU_MCP_MAX_CONCURRENCY: "50000",
+		});
+
+		// A malformed variable fell back and is only `ignored`; a clamped one is
+		// in force and is only `clamped`. An operator reading one channel must
+		// not be told the other thing happened.
+		expect(ignored.map((i) => i.variable)).toEqual(["VAYU_MCP_MAX_RPS"]);
+		expect(clamped.map((c) => c.variable)).toEqual(["VAYU_MCP_MAX_CONCURRENCY"]);
+	});
+
+	it("does not call a floored fractional cap clamped", () => {
+		const { config, clamped } = buildSafetyConfigFromEnv({
+			// Floored to 999, which is not a ceiling being applied - saying "above
+			// the maximum of 1000000" here would name a limit it never came near.
+			VAYU_MCP_MAX_RPS: "999.7",
+			// Fractional too, but over the ceiling once floored, so this one is
+			// reported and the ceiling is what applies.
+			VAYU_MCP_MAX_ITERATIONS: "100000001.5",
+		});
+
+		expect(config.maxRps).toBe(999);
+		expect(config.maxIterations).toBe(MCP_CAP_CEILINGS.maxIterations);
+		expect(clamped.map((c) => c.variable)).toEqual(["VAYU_MCP_MAX_ITERATIONS"]);
 	});
 
 	it("rejects a non-positive cap the same way the Settings path does", () => {
@@ -258,7 +316,7 @@ describe("buildSafetyConfigFromEnv", () => {
 	});
 
 	it("reports nothing when every variable is well-formed", () => {
-		const { config, ignored } = buildSafetyConfigFromEnv({
+		const { config, ignored, clamped } = buildSafetyConfigFromEnv({
 			VAYU_MCP_ALLOWLIST: "api.example.com",
 			VAYU_MCP_MAX_RPS: "50",
 			VAYU_MCP_MAX_CONCURRENCY: "10",
@@ -270,6 +328,7 @@ describe("buildSafetyConfigFromEnv", () => {
 		});
 
 		expect(ignored).toEqual([]);
+		expect(clamped).toEqual([]);
 		// Exhaustive on purpose: a field added to McpSafetyConfig without an env
 		// var lands here as an unexpected key. That is how the missing
 		// VAYU_MCP_MAX_ITERATIONS was caught.
@@ -286,10 +345,11 @@ describe("buildSafetyConfigFromEnv", () => {
 	});
 
 	it("returns the safe defaults for an empty environment", () => {
-		const { config, ignored } = buildSafetyConfigFromEnv({});
+		const { config, ignored, clamped } = buildSafetyConfigFromEnv({});
 
 		expect(config).toEqual(DEFAULT_MCP_SAFETY_CONFIG);
 		expect(ignored).toEqual([]);
+		expect(clamped).toEqual([]);
 	});
 
 	it('leaves the opt-in booleans off for any value other than "true"', () => {
@@ -300,5 +360,51 @@ describe("buildSafetyConfigFromEnv", () => {
 
 		expect(config.allowAll).toBe(false);
 		expect(config.allowWrites).toBe(false);
+	});
+});
+
+/*
+ * What the stdio operator actually sees. A channel nothing prints is the
+ * "written but never read" defect, so these assert the lines, and the last one
+ * asserts `cli.ts` is what emits them.
+ */
+describe("formatSafetyEnvNotices", () => {
+	it("names a clamped cap, its raw value, and the value in force", () => {
+		const notices = formatSafetyEnvNotices(
+			buildSafetyConfigFromEnv({ VAYU_MCP_MAX_CONCURRENCY: "50000" })
+		);
+
+		expect(notices).toEqual([
+			'[vayu-mcp] VAYU_MCP_MAX_CONCURRENCY="50000" is above the maximum of 10000; running with 10000',
+		]);
+	});
+
+	it("prints both channels, ignored first, and keeps their wording distinct", () => {
+		const notices = formatSafetyEnvNotices(
+			buildSafetyConfigFromEnv({
+				VAYU_MCP_MAX_RPS: "1,000",
+				VAYU_MCP_MAX_CONCURRENCY: "50000",
+			})
+		);
+
+		expect(notices).toEqual([
+			'[vayu-mcp] ignoring malformed VAYU_MCP_MAX_RPS="1,000" (using default 1000)',
+			'[vayu-mcp] VAYU_MCP_MAX_CONCURRENCY="50000" is above the maximum of 10000; running with 10000',
+		]);
+	});
+
+	it("says nothing when the environment survived intact", () => {
+		expect(
+			formatSafetyEnvNotices(buildSafetyConfigFromEnv({ VAYU_MCP_MAX_RPS: "50" }))
+		).toEqual([]);
+	});
+
+	it("is what the CLI prints, so neither channel can go unread", () => {
+		const source = readFileSync(new URL("./cli.ts", import.meta.url), "utf8");
+
+		// Guard the guard: an empty read would pass every assertion below.
+		expect(source.length).toBeGreaterThan(0);
+		expect(source).toContain("formatSafetyEnvNotices");
+		expect(source).toContain("console.error(notice)");
 	});
 });

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -259,10 +259,31 @@ export interface IgnoredSafetyEnvVar {
 	fallback: McpSafetyConfig[keyof McpSafetyConfig];
 }
 
-/** A safety config built from the environment, plus what was thrown away. */
+/**
+ * An environment variable whose cap the sanitizer held at its ceiling. Its own
+ * shape rather than a reuse of `IgnoredSafetyEnvVar`: nothing fell back here, so
+ * that type's `fallback` would have to name a default that never applied.
+ */
+export interface ClampedSafetyEnvVar {
+	/** The `VAYU_MCP_*` variable name. */
+	variable: string;
+	/** Its raw value, as it appeared in the environment. */
+	value: string;
+	/** The cap actually in force - the key's ceiling. */
+	applied: number;
+}
+
+/**
+ * A safety config built from the environment, plus every way it differs from
+ * what was asked for: `ignored` for variables that fell back to their default,
+ * `clamped` for caps that are in force at a lower value than requested. The two
+ * are separate channels because they are separate outcomes - a reader that
+ * merged them could not tell an operator which of the two happened.
+ */
 export interface EnvSafetyConfig {
 	config: McpSafetyConfig;
 	ignored: IgnoredSafetyEnvVar[];
+	clamped: ClampedSafetyEnvVar[];
 }
 
 function readSafetyFromEnv(env: NodeJS.ProcessEnv): Partial<McpSafetyConfig> {
@@ -297,7 +318,10 @@ function readSafetyFromEnv(env: NodeJS.ProcessEnv): Partial<McpSafetyConfig> {
  *
  * Anything the sanitizer rejects is reported in `ignored` so the CLI can tell a
  * headless operator which default applied, rather than leaving them to discover
- * it from an uncapped run.
+ * it from an uncapped run. A cap held at its ceiling is reported in `clamped`
+ * for the same reason one step further along: the run is bounded at a value the
+ * operator did not type, and without a line saying so the first evidence is a
+ * refused run.
  */
 export function buildSafetyConfigFromEnv(env: NodeJS.ProcessEnv): EnvSafetyConfig {
 	const raw = readSafetyFromEnv(env);
@@ -312,5 +336,38 @@ export function buildSafetyConfigFromEnv(env: NodeJS.ProcessEnv): EnvSafetyConfi
 			fallback: DEFAULT_MCP_SAFETY_CONFIG[key],
 		});
 	}
-	return { config: resolveSafetyConfig(sanitized), ignored };
+	const clamped: ClampedSafetyEnvVar[] = [];
+	for (const key of MCP_CAP_KEYS) {
+		const requested = raw[key];
+		const applied = sanitized[key];
+		if (applied === undefined || !isFiniteNumber(requested)) continue;
+		// Against the *floored* request, not the raw one: flooring `1000.7` to
+		// `1000` is not a ceiling being applied, and reporting it as one would
+		// name a maximum the value never came near. Derived from the sanitizer's
+		// own output rather than re-compared against `MCP_CAP_CEILINGS`, so the
+		// ceilings keep exactly one definition.
+		if (applied >= Math.floor(requested)) continue;
+		const variable = SAFETY_ENV_VARS[key];
+		clamped.push({ variable, value: env[variable] ?? "", applied });
+	}
+	return { config: resolveSafetyConfig(sanitized), ignored, clamped };
+}
+
+/**
+ * The stderr lines the stdio CLI prints for an environment that did not survive
+ * sanitization intact - one per ignored variable, then one per clamped cap.
+ * Separate from `cli.ts` because that module runs a server on import and so
+ * cannot be exercised by a test; this is the part worth pinning.
+ */
+export function formatSafetyEnvNotices({ ignored, clamped }: EnvSafetyConfig): string[] {
+	return [
+		...ignored.map(
+			({ variable, value, fallback }) =>
+				`[vayu-mcp] ignoring malformed ${variable}=${JSON.stringify(value)} (using default ${JSON.stringify(fallback)})`
+		),
+		...clamped.map(
+			({ variable, value, applied }) =>
+				`[vayu-mcp] ${variable}=${JSON.stringify(value)} is above the maximum of ${applied}; running with ${applied}`
+		),
+	];
 }

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -765,6 +765,13 @@ exactly the rules Settings is held to:
   `[vayu-mcp] ignoring malformed VAYU_MCP_MAX_RPS="1,000" (using default 1000)`.
   Non-positive values (`0`, `-5`) are treated the same way; fractional values are
   floored.
+- **A cap above its ceiling is named too, through its own channel.** It did not
+  fall back - it is in force, held at the ceiling - so the CLI says which value
+  actually applies rather than which default did:
+  `[vayu-mcp] VAYU_MCP_MAX_CONCURRENCY="50000" is above the maximum of 10000; running with 10000`.
+  Without it the operator believes the policy is 50000 and learns otherwise from
+  a refused run. Flooring alone is not reported: `999.7` becomes `999` and names
+  no maximum, because it came near none.
 - **Allowlist entries are reduced to a bare hostname**, so
   `https://api.example.com` and `api.example.com:8080` both match the
   `api.example.com` the guard compares against. Entries are de-duplicated.


### PR DESCRIPTION
## Description

**Plan.** Root cause: `sanitizeSafetyInput` holds an over-ceiling cap *at* its ceiling rather than storing a value no run can reach, and the Settings panel states that - but the stdio CLI has no such surface. It already reports a variable it **ignored** (`IgnoredSafetyEnvVar`, so a malformed `VAYU_MCP_MAX_RPS=1,000` does not silently become the default), while a **clamped** one produces nothing: `VAYU_MCP_MAX_CONCURRENCY=50000` is in force at 10000 with no line said about it, and the operator's first evidence is a refused run. The approach is a second array beside `ignored` - `clamped: { variable, value, applied }[]` - filled by comparing the sanitized cap against the request `readSafetyFromEnv` read, and printed beside the existing notice in the same voice. The alternative I rejected was overloading `IgnoredSafetyEnvVar`: its `fallback` names the default that applied, which is not what happened here, so the field would have to lie and the two outcomes would become indistinguishable to any reader.

Two details worth review:

- **The comparison is against the *floored* request, not the raw one.** `applied >= Math.floor(requested)` skips, so `999.7 -> 999` is not reported as clamped: flooring is not a ceiling being applied, and a line reading "above the maximum of 1000000" would name a limit the value never came near (the docs already describe flooring separately). It also derives the verdict from the sanitizer's own output rather than re-testing `MCP_CAP_CEILINGS` inline, so the ceilings keep exactly one definition - the `SCOPE_CONFIG.global` failure mode CLAUDE.md lists.
- **Deliberate deviation from the issue spec:** the issue puts the printer in `cli.ts`, and the acceptance criteria ask that the printer be *verified* to read the new field. `cli.ts` calls `main()` at import and connects a stdio server, so importing it in a test is not possible. The message construction therefore moved into `formatSafetyEnvNotices` in `config.ts` (beside `SAFETY_ENV_VARS`, whose comment already frames naming a value back to the operator as this module's job); `cli.ts` keeps the loop and the `console.error`. That makes the output assertable, and a source guard pins that `cli.ts` is what emits it - a channel nothing prints is exactly the "written but never read" defect this issue exists to prevent.

Blast radius checked: `EnvSafetyConfig` / `buildSafetyConfigFromEnv` have exactly two consumers, `cli.ts` and `config.test.ts`. The Electron-hosted server reads Settings, not the environment, and the renderer panel already states the clamp - so no renderer change, per the issue.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All commands run on this branch; all green, no pre-existing failures encountered.

- `cd app && pnpm test` - **401 files / 4066 tests passed**
- `cd app && pnpm type-check` - clean
- `cd app && pnpm lint` - clean (zero warnings)
- `cd app && pnpm format:check` - clean

Engine untouched, so no engine build or ctest run - nothing there could change colour.

New coverage in `electron/mcp/config.test.ts` (**+7 tests**, 44 in the file):

- every cap variable reports when clamped and an in-range one never does; the clamped and ignored channels do not blur (a malformed variable lands only in `ignored`, a held one only in `clamped`); a floored fractional cap is not called clamped, while one that is fractional *and* over the ceiling is.
- `formatSafetyEnvNotices`: the clamped line names the variable, its raw value and the value in force; both channels print with ignored first; nothing prints for an intact environment; and `cli.ts` is asserted to call the formatter (with a non-empty-read guard, so it cannot pass vacuously).
- The existing "holds an over-ceiling cap the same way the Settings path does" test keeps `expect(ignored).toEqual([])` and now also asserts the new array, per the issue.

Mutation-checked (reverted, confirmed red, restored):

| Reverted | Result |
|---|---|
| printer stops formatting `clamped` | 2 failed |
| builder stops populating `clamped` | 6 failed |
| compare against the raw request instead of the floored one | 1 failed |
| `cli.ts` stops calling the formatter | 1 failed |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/mcp.md` gains the clamped-cap notice beside the ignored-variable behaviour it already documents, including why flooring is not reported. The file is not prettier-clean at `master` and is outside the app-scoped `format:check`, so it was edited by hand and left unformatted, per the repo rule about formatting only files that were clean before.

## Related Issues
Closes #533

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzgKh83jp9PMS91qhw5Lfo)_