### PR TITLE
fix(app): one UI-font default, and a reset dialog that names what it clears

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -53,7 +53,7 @@
 									? cf
 									: '"' +
 											cf.replace(/["']/g, "") +
-											'", Inter, system-ui, sans-serif'
+											'", "Space Grotesk", system-ui, sans-serif'
 							);
 						}
 					} else if (fonts[font]) {

--- a/app/src/constants/appearance.default-font.test.ts
+++ b/app/src/constants/appearance.default-font.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The default UI face is stated in four places, and they must agree.
+ *
+ * `index.css` assigns `--font-sans` and is what paints before any script runs.
+ * The pre-paint block in `index.html` overrides that property for a *stored*
+ * preference, and deliberately carries no entry for the default - selecting the
+ * default means "leave the stylesheet alone". `DEFAULT_UI_FONT` is what the
+ * appearance store re-asserts on mount when nothing is stored. The picker
+ * captions one option "Default - ...".
+ *
+ * When `DEFAULT_UI_FONT` was `"inter"` all four disagreed: a fresh install
+ * painted Space Grotesk from the stylesheet, then swapped to Inter the moment
+ * React mounted, under a picker whose Space Grotesk option said "Default" and a
+ * `docs/design-system.md` that named Space Grotesk as the UI face. Only the
+ * cross-file check catches that - each file alone is self-consistent.
+ *
+ * Read from disk rather than imported: vitest stubs a CSS import to `""`, and a
+ * guard that scans an empty string passes for weeks while proving nothing (see
+ * the repo CLAUDE.md). Hence the non-empty assertions before every scan.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+import { DEFAULT_MONO_FONT, DEFAULT_UI_FONT, MONO_FONTS, UI_FONTS, fontStack } from "./appearance";
+
+const read = (relative: string): string => readFileSync(new URL(relative, import.meta.url), "utf8");
+
+const indexCss = read("../index.css");
+const indexHtml = read("../../index.html");
+
+describe("the default UI font", () => {
+	it("scanned non-empty sources", () => {
+		// Without this the two scans below are vacuous.
+		expect(indexCss.length).toBeGreaterThan(0);
+		expect(indexHtml.length).toBeGreaterThan(0);
+	});
+
+	it("is the stack index.css already assigns to --font-sans", () => {
+		const declared = /--font-sans:\s*([^;]+);/.exec(indexCss)?.[1].trim();
+		expect(declared).toBeDefined();
+		expect(fontStack(DEFAULT_UI_FONT)).toBe(declared);
+	});
+
+	it("has no entry in the pre-paint override map", () => {
+		// The map exists only to override the stylesheet. An entry for the
+		// default would be dead weight; a *missing* entry for a non-default face
+		// is the real bug, so assert the complement too.
+		const map = /var fonts = \{([\s\S]*?)\};/.exec(indexHtml)?.[1];
+		expect(map).toBeDefined();
+		const overridden = [...(map ?? "").matchAll(/^\s*(\w[\w-]*):/gm)].map((m) => m[1]);
+		expect(overridden.length).toBeGreaterThan(0);
+		expect(overridden).not.toContain(DEFAULT_UI_FONT);
+		expect([...overridden].sort()).toEqual(
+			UI_FONTS.map((f) => f.value)
+				.filter((v) => v !== DEFAULT_UI_FONT)
+				.sort()
+		);
+	});
+
+	it("is the option the picker captions Default", () => {
+		const captioned = UI_FONTS.filter((f) => f.description.startsWith("Default"));
+		expect(captioned.map((f) => f.value)).toEqual([DEFAULT_UI_FONT]);
+	});
+});
+
+describe("the default code font", () => {
+	// Same invariant, minus the pre-paint leg: `--font-mono` is never stamped
+	// before React mounts, so only the caption and the constant can drift.
+	it("is the option the picker captions Default", () => {
+		const captioned = MONO_FONTS.filter((f) => f.description.startsWith("Default"));
+		expect(captioned.map((f) => f.value)).toEqual([DEFAULT_MONO_FONT]);
+	});
+});

--- a/app/src/constants/appearance.test.ts
+++ b/app/src/constants/appearance.test.ts
@@ -7,6 +7,8 @@
 
 import { describe, it, expect } from "vitest";
 import {
+	DEFAULT_MONO_FONT,
+	DEFAULT_UI_FONT,
 	DEFAULT_UI_SCALE,
 	UI_SCALE_MAX,
 	UI_SCALE_MIN,
@@ -14,7 +16,9 @@ import {
 	customFontStack,
 	customMonoStack,
 	customSansStack,
+	fontStack,
 	formatScale,
+	monoFontStack,
 	nudgeScale,
 	parseScale,
 } from "./appearance";
@@ -40,7 +44,16 @@ describe("customFontStack", () => {
 	it("mono/sans wrappers apply their respective fallbacks", () => {
 		expect(customMonoStack("Iosevka")).toContain('"Iosevka",');
 		expect(customMonoStack("Iosevka")).toContain("monospace");
-		expect(customSansStack("Georgia")).toBe('"Georgia", Inter, system-ui, sans-serif');
+		expect(customSansStack("Georgia")).toBe(
+			'"Georgia", "Space Grotesk", system-ui, sans-serif'
+		);
+	});
+
+	// A custom family that fails to load must land on the same face a user who
+	// never opened the picker sees, not on a second, parallel default.
+	it("falls back to the default preset's own stack", () => {
+		expect(customSansStack("Georgia").endsWith(fontStack(DEFAULT_UI_FONT))).toBe(true);
+		expect(customMonoStack("Iosevka").endsWith(monoFontStack(DEFAULT_MONO_FONT))).toBe(true);
 	});
 });
 

--- a/app/src/constants/appearance.ts
+++ b/app/src/constants/appearance.ts
@@ -12,8 +12,9 @@
  * persisted to localStorage and applied to the document. This file is the
  * single source of truth: types, the settings controls, and the runtime guards
  * all derive from the arrays (font, radius) and the scale range below. Font
- * stacks reference faces already loaded by index.html (Space Grotesk, JetBrains
- * Mono) or system fonts, so switching never triggers a network fetch.
+ * stacks reference faces already loaded by index.html (Space Grotesk, Inter and
+ * the four mono faces) or system fonts, so switching never triggers a network
+ * fetch.
  */
 
 export interface FontOption {
@@ -52,7 +53,17 @@ export const UI_FONTS = [
 
 /** UI font preference, applied by overriding the `--font-sans` custom property. */
 export type UiFont = (typeof UI_FONTS)[number]["value"];
-export const DEFAULT_UI_FONT: UiFont = "inter";
+
+/**
+ * The default UI face, and it must stay the one `index.css` already assigns to
+ * `--font-sans`: the pre-paint script in index.html deliberately carries no
+ * entry for it, so a fresh install paints the stylesheet's face and the store's
+ * mount-time `applyFont` re-asserts the same stack. When this constant named a
+ * different face than the stylesheet, a fresh install painted Space Grotesk and
+ * then swapped to Inter once React mounted. `appearance.default-font.test.ts`
+ * holds the three - constant, stylesheet, pre-paint map - together.
+ */
+export const DEFAULT_UI_FONT: UiFont = "grotesk";
 
 /** A preset UI font, or "custom" - a user-typed family (see {@link customSansStack}). */
 export type UiFontChoice = UiFont | "custom";
@@ -226,5 +237,5 @@ export function customMonoStack(family: string): string {
 
 /** Custom UI (sans) stack, falling back to the default sans faces. */
 export function customSansStack(family: string): string {
-	return customFontStack(family, "Inter, system-ui, sans-serif");
+	return customFontStack(family, '"Space Grotesk", system-ui, sans-serif');
 }

--- a/app/src/constants/load-test.ts
+++ b/app/src/constants/load-test.ts
@@ -29,6 +29,19 @@
  * already being done when `maxInFlight` drifted.
  */
 
+/**
+ * Starting values, deliberately fixed - the Settings panel offers ceilings, not
+ * defaults, and that asymmetry is the policy (recorded for #521).
+ *
+ * A ceiling is a standing rule about what this machine may be asked to do, so it
+ * belongs in Settings. A starting value is only ever seen once per request: the
+ * load dialog memoes each request's draft and reopens on it
+ * (`restore(saved.rps, LOAD_TEST_DEFAULTS.RPS, "RPS")` and its siblings in
+ * `LoadTestConfigDialog`), so a user-set default would apply to a request's
+ * first run and never again. The
+ * one number that genuinely spans runs - the p99 SLO - is already a setting
+ * (`sloThresholdMs`) and seeds the dialog from there.
+ */
 export const LOAD_TEST_DEFAULTS = {
 	MODE: "constant_rps",
 	DURATION_S: 60,

--- a/app/src/constants/storage-keys.ts
+++ b/app/src/constants/storage-keys.ts
@@ -17,7 +17,7 @@ export const STORAGE_KEYS = {
 	THEME_SOURCE: "vayu-theme-source",
 	/** Accent color scheme name (sunset/sky/…). Read pre-paint in index.html. */
 	COLOR_SCHEME: "vayu-color-scheme",
-	/** UI font preference (grotesk/system/mono/custom). Read pre-paint in index.html. */
+	/** UI font preference (grotesk/inter/system/mono/custom). Read pre-paint in index.html. */
 	UI_FONT: "vayu-ui-font",
 	/** Custom UI font family, used when UI_FONT === "custom". Read pre-paint. */
 	UI_FONT_CUSTOM: "vayu-ui-font-custom",

--- a/app/src/modules/settings/main/panels/AppearancePanel.tsx
+++ b/app/src/modules/settings/main/panels/AppearancePanel.tsx
@@ -105,7 +105,10 @@ export default function AppearancePanel() {
 						<SunMoon className="w-5 h-5 text-muted-foreground" />
 						<CardTitle className="text-base">Theme Mode</CardTitle>
 					</div>
-					<CardDescription>Choose between light, dark, or system theme.</CardDescription>
+					<CardDescription>
+						Sets the app&apos;s light or dark palette. System follows your operating
+						system and switches automatically.
+					</CardDescription>
 				</CardHeader>
 				<CardContent>
 					{isLoading ? (

--- a/app/src/modules/settings/main/panels/DashboardPanel.tsx
+++ b/app/src/modules/settings/main/panels/DashboardPanel.tsx
@@ -79,9 +79,10 @@ export default function DashboardPanel() {
 						<CardTitle className="text-base">Capacity SLO threshold</CardTitle>
 					</div>
 					<CardDescription>
-						The p99 latency at which a run is considered saturated. Drives the
+						The p99 latency at which a run is considered saturated. It marks the
 						breakpoint stat, the Saturation card, and the SLO line on the latency
-						charts.
+						charts, and prefills the p99 budget and the Capacity Discovery target when
+						you open the load-test dialog.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>

--- a/app/src/modules/settings/main/panels/EditorPanel.tsx
+++ b/app/src/modules/settings/main/panels/EditorPanel.tsx
@@ -110,6 +110,7 @@ export default function EditorPanel() {
 						/>
 						<ToggleRow
 							label="Line numbers"
+							description="Number every line in the editor gutter"
 							checked={editor.lineNumbers}
 							onChange={(lineNumbers) => setEditor({ lineNumbers })}
 						/>

--- a/app/src/modules/settings/main/panels/GeneralPanel.reset.test.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.reset.test.tsx
@@ -86,3 +86,58 @@ describe("Reset app settings", () => {
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 	});
 });
+
+/**
+ * The copy has to name everything `resetAll` clears.
+ *
+ * It used to say "appearance, editor and dashboard preferences", but the reset
+ * removes `STORAGE_KEYS.CLIENT_SETTINGS` wholesale - so notification
+ * preferences, the auto-save setting and the load-test ceilings went with it,
+ * unannounced. Undersold scope on an irreversible action is the defect; a
+ * partial reset would be its own surprise, so the text is what moved.
+ *
+ * Each term below is checked against both the card and the confirm dialog,
+ * because a user can read either one before committing.
+ */
+describe("Reset app settings copy", () => {
+	const CLEARED = [
+		"appearance",
+		"editor",
+		"dashboard",
+		"notifications",
+		"auto-save",
+		"load-test limits",
+	];
+
+	const text = (el: Element | null) => el?.textContent?.toLowerCase() ?? "";
+
+	it("the card names every category the reset clears", () => {
+		render(<GeneralPanel />);
+		const card = screen.getByText(/^Reset app settings$/).closest("div[data-slot='card']");
+		const copy = text(card);
+		expect(copy.length).toBeGreaterThan(0);
+		for (const term of CLEARED) expect(copy).toContain(term);
+	});
+
+	it("the confirm dialog names them too, and says the app reloads", () => {
+		render(<GeneralPanel />);
+		openReset();
+		const copy = text(screen.getByRole("dialog"));
+		expect(copy.length).toBeGreaterThan(0);
+		for (const term of CLEARED) expect(copy).toContain(term);
+		// `resetAll` ends in window.location.reload(); losing the tab you are on
+		// is worth stating before the click, not after.
+		expect(copy).toContain("reloads");
+	});
+
+	it("still promises what the reset does not touch", () => {
+		render(<GeneralPanel />);
+		openReset();
+		const copy = text(screen.getByRole("dialog"));
+		// SETTINGS_STORAGE_KEYS holds no workspace or engine-side key, so these
+		// three survive - the reassurance is load-bearing, not filler.
+		for (const kept of ["collections", "requests", "run history"]) {
+			expect(copy).toContain(kept);
+		}
+	});
+});

--- a/app/src/modules/settings/main/panels/GeneralPanel.tsx
+++ b/app/src/modules/settings/main/panels/GeneralPanel.tsx
@@ -142,6 +142,7 @@ export default function GeneralPanel() {
 				<CardContent className="space-y-4">
 					<ToggleRow
 						label="Auto-save edits"
+						description="Off leaves an edited request marked unsaved until you save it"
 						checked={autoSave.enabled}
 						onChange={(enabled) => setAutoSave({ enabled })}
 					/>
@@ -248,8 +249,9 @@ export default function GeneralPanel() {
 						<CardTitle className="text-base">Reset app settings</CardTitle>
 					</div>
 					<CardDescription>
-						Restore appearance, editor, and dashboard preferences to their defaults.
-						Collections, requests, and run history are not affected.
+						Restore every app preference to its default: appearance, editor, dashboard,
+						notifications, auto-save, and the load-test limits. Collections, requests,
+						and run history are not affected.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -269,7 +271,7 @@ export default function GeneralPanel() {
 				open={confirmReset}
 				onOpenChange={setConfirmReset}
 				title="Reset app settings?"
-				description="Appearance, editor and dashboard preferences go back to their defaults and the app reloads. Collections, requests and run history are not affected."
+				description="Every app preference goes back to its default - appearance, editor, dashboard, notifications, auto-save and the load-test limits - and the app reloads. Collections, requests and run history are not affected."
 				onConfirm={resetSettings}
 				confirmLabel="Reset"
 				confirmVariant="default"


### PR DESCRIPTION
## Description

Sub-issue 3 of the settings overhaul #518 - the app-side copy pass plus its one hard defect.

**Plan.** The root cause of the font defect is that the default face is stated in four places and only one of them was wrong. `index.css` assigns `--font-sans: "Space Grotesk", ...`; the pre-paint script in `index.html` overrides that property only for a *stored* preference and deliberately carries no entry for the default; the picker captions Space Grotesk `"Default - geometric sans"`; `docs/design-system.md:818,827` names Space Grotesk as the UI/body face. Only `DEFAULT_UI_FONT = "inter"` disagreed - and because the appearance store's `applyAll()` re-asserts `fontStack(DEFAULT_UI_FONT)` on mount, the contradiction was visible: **a fresh install painted Space Grotesk from the stylesheet and swapped to Inter the moment React mounted.** So the decision writes itself - Space Grotesk - and the fix is the constant, not the three sites that already agreed. The alternative I rejected was flipping the caption and the doc to Inter: that keeps the fresh-install swap (the stylesheet would still paint Space Grotesk first), and would mean editing `index.css`, the pre-paint map and a published doc to preserve the one outlier. Guarding it needed a *cross-file* test, since each file alone is self-consistent.

**Owner decision recorded (issue item 1): the intended default is Space Grotesk.** User-visible consequence: anyone who never opened the font picker (no `vayu-ui-font` key stored) has been seeing Inter after mount and will now see Space Grotesk throughout - and stops seeing the swap. Anyone who explicitly picked a face is untouched; their stored value still wins.

**Recorded decision (issue item 4): `LOAD_TEST_DEFAULTS` stays fixed, and the gap closes as a non-goal.** A ceiling is a standing rule about what this machine may be asked to do, so it belongs in Settings. A starting value is seen once per request - the load dialog memoes each request's draft and reopens on it (`restore(saved.rps, LOAD_TEST_DEFAULTS.RPS, "RPS")` and siblings), so a user-set default would apply to a request's first run and never again. The one number that genuinely spans runs, the p99 SLO, is already a setting and already seeds the dialog. Written as a comment above the constant so the next reader finds it without this issue open.

**What changed**

- `constants/appearance.ts` - `DEFAULT_UI_FONT: "inter"` → `"grotesk"`; `customSansStack`'s fallback follows the same face, so a missing custom family lands where a fresh install does instead of on a second, parallel default (`index.html`'s pre-paint mirror of that string moves with it); the header comment's list of loaded faces was wrong and is corrected.
- `GeneralPanel.tsx` - the reset card and its confirm dialog said "appearance, editor, and dashboard preferences" while `resetAll` removes `STORAGE_KEYS.CLIENT_SETTINGS` wholesale. Both now enumerate all six: appearance, editor, dashboard, notifications, auto-save, load-test limits. Text fix, not a scoped reset, per the issue's recommendation.
- Rewords per the #518 voice conventions - `themeSource` no longer restates the three option labels beneath it; the capacity SLO description states the load-dialog prefill it gained in #470 (verified live at `LoadTestConfigDialog/index.tsx:277-291`: `sloThresholdMs` seeds both the Capacity Discovery target and the p99 budget); `Line numbers` and `Auto-save edits` get the row descriptions their siblings carried.
- `constants/load-test.ts`, `constants/storage-keys.ts` - the recorded decision, and a doc comment that omitted `inter` from the key's value list.

**Deliberate deviation from the issue spec:** the two new `ToggleRow` descriptions carry no trailing period, against #518 convention 1. All four existing row descriptions in this family are period-less fragments, and normalizing them is a wider sweep that belongs to #523, which rebuilds these rows. Adding a period to only the new ones would read as a typo. Flagging rather than silently splitting the difference.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **App suite: 403 files, 4097 tests passed** (no pre-existing failures on this base, `2246055`).
- Type-check, ESLint (`--max-warnings 0`) and `format:check` clean. Prettier was run on the touched files only, never repo-wide.

New tests, both mutation-checked:

- `constants/appearance.default-font.test.ts` (5 cases) - the default is the stack `index.css` assigns to `--font-sans`; it has no entry in the pre-paint override map, and the map covers exactly the non-default faces; the option captioned "Default" is the default, sans and mono. Reverting `DEFAULT_UI_FONT` to `"inter"` fails 3 of the 5. It reads `index.css` and `index.html` from disk and asserts both are non-empty before scanning, since vitest stubs a CSS import to `""` (the empty-scan trap in the repo `CLAUDE.md`).
- `GeneralPanel.reset.test.tsx` (+3 cases) - the card and the dialog each name all six cleared categories, the dialog says the app reloads, and both still promise what survives. Restoring the old copy fails 2 of the 3.

Engine untouched, so no engine build or ctest run - nothing there could change colour.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: no change, deliberately. The issue scopes `docs/design-system.md` to "ONLY the font-default line and ONLY if the decision changes it" - the decision *confirms* what the doc already says, so it stays untouched. `docs/app/COMPONENTS.md` untouched per the issue.

## Related Issues
Closes #521

---
_Generated by [Claude Code](https://claude.ai/code/session_016VmiWHa1mqNpqaAKRepodK)_