### PR TITLE
feat(app): one command registry for the palette and the native menu

### DIFF
--- a/app/src/hooks/useCommandContext.ts
+++ b/app/src/hooks/useCommandContext.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The command context, for a surface that renders.
+ *
+ * What the registry cannot read from a store: which tab is active and what the
+ * strip calls it, which collection that tab shows, and the dialog host the
+ * caller is offering. `baseCommandContext` is the React-free version for the
+ * native-menu bridge.
+ *
+ * The label comes from `useTabDescriptors` - the hook the tab strip itself uses
+ * - so "Close 'GET /v1/orders'" in the palette and the tab it closes cannot read
+ * differently. Only the active tab is passed, so this costs one descriptor, not
+ * a strip's worth.
+ */
+
+import { useMemo } from "react";
+import { useTabsStore } from "@/stores";
+import { useCollectionsQuery } from "@/queries";
+import { useTabDescriptors } from "@/components/layout/tab-descriptors";
+import type { CommandContext, CommandSurfaces } from "@/lib/commands";
+
+export function useCommandContext(surfaces?: CommandSurfaces): CommandContext {
+	const openTabs = useTabsStore((s) => s.openTabs);
+	const activeTabId = useTabsStore((s) => s.activeTabId);
+	const { data: collections = [] } = useCollectionsQuery();
+
+	const activeTab = openTabs.find((tab) => tab.id === activeTabId) ?? null;
+	const descriptors = useTabDescriptors(activeTab ? [activeTab] : []);
+	const activeTabLabel = descriptors[0]?.label ?? null;
+
+	const activeCollection =
+		activeTab?.type === "collection" && activeTab.entityId
+			? (collections.find((c) => c.id === activeTab.entityId) ?? null)
+			: null;
+
+	return useMemo(
+		() => ({ activeTab, activeTabLabel, activeCollection, surfaces }),
+		[activeTab, activeTabLabel, activeCollection, surfaces]
+	);
+}

--- a/app/src/hooks/useMenuActions.ts
+++ b/app/src/hooks/useMenuActions.ts
@@ -6,26 +6,29 @@
  */
 
 import { useEffect } from "react";
-import { useTabsStore, useAppearanceStore } from "@/stores";
+import { useAppearanceStore } from "@/stores";
+import { baseCommandContext, commandById } from "@/lib/commands";
 
 /**
  * Bridges native menu items (Preferences… / Settings, View → zoom) to in-app
  * state. No-op outside Electron.
+ *
+ * Preferences… points at the `open-settings` command rather than repeating its
+ * two lines, so the menu and the palette cannot drift into opening settings
+ * differently - the whole reason `lib/commands` exists.
  *
  * Zoom lives here rather than in `useAppearance` because this hook is mounted
  * exactly once, in `App`: `useAppearance` runs in the Appearance panel too, and
  * a second subscription would move the scale two steps per keypress.
  */
 export function useMenuActions(): void {
-	const openTab = useTabsStore((s) => s.openTab);
-
 	useEffect(() => {
 		// Optional-chain the call too: an older preload build may not expose
 		// onOpenSettings yet, and `?.` on electronAPI alone wouldn't guard that.
 		return window.electronAPI?.onOpenSettings?.(() =>
-			openTab({ type: "settings", entityId: null })
+			commandById("open-settings").perform(baseCommandContext())
 		);
-	}, [openTab]);
+	}, []);
 
 	useEffect(() => {
 		// The menu no longer zooms Chromium itself - it nudges the persisted

--- a/app/src/hooks/useNewRequest.ts
+++ b/app/src/hooks/useNewRequest.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * "New request" - the whole flow, once.
+ *
+ * It lived inside `WelcomeScreen`, which was fine while the Launcher tile was
+ * the only way to ask for one. The command palette is the second, and a second
+ * copy of "decide where it lands, create a collection if there is none, ask when
+ * it is ambiguous" is how two entry points end up disagreeing about where a
+ * request goes.
+ *
+ * A hook rather than a store because the flow can *ask*: the picker is a dialog,
+ * and a dialog needs a component to render it. Each caller renders its own from
+ * `pickerProps`, so two surfaces never fight over one dialog's open state.
+ */
+
+import { useCallback, useState } from "react";
+import {
+	useCollectionsQuery,
+	useCreateCollectionMutation,
+	useCreateRequestMutation,
+} from "@/queries";
+import { useSessionStore, useTabsStore, useToastStore } from "@/stores";
+import { DEFAULT_REQUEST_NAME } from "@/constants/request";
+import { DEFAULT_COLLECTION_NAME } from "@/constants/collection";
+import { resolveNewRequestTarget } from "@/modules/welcome/targetCollection";
+import type { Collection } from "@/types";
+
+const CREATE_FAILED = "Could not create the request. Check that the engine is running.";
+
+/** Everything `CollectionPicker` needs, so a caller spreads it and nothing else. */
+export interface NewRequestPickerProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	collections: Collection[];
+	onSelect: (collectionId: string) => void;
+}
+
+export interface UseNewRequestReturn {
+	/** Start the flow. Opens the picker only when the target is ambiguous. */
+	newRequest: () => void;
+	pickerProps: NewRequestPickerProps;
+}
+
+export function useNewRequest(): UseNewRequestReturn {
+	const openTab = useTabsStore((s) => s.openTab);
+	const showToast = useToastStore((s) => s.showToast);
+	const lastCollectionId = useSessionStore((s) => s.lastCollectionId);
+	const { data: collections = [] } = useCollectionsQuery();
+	const createRequestMutation = useCreateRequestMutation();
+	const createCollectionMutation = useCreateCollectionMutation();
+	const [pickerOpen, setPickerOpen] = useState(false);
+
+	const createRequestIn = useCallback(
+		async (collectionId: string) => {
+			try {
+				const newRequest = await createRequestMutation.mutateAsync({
+					collectionId,
+					name: DEFAULT_REQUEST_NAME,
+					method: "GET",
+					url: "",
+				});
+				openTab({ type: "request", entityId: newRequest.id });
+			} catch (error) {
+				// Without this the click looks dead - the old code only logged.
+				console.error("Failed to create new request:", error);
+				showToast(CREATE_FAILED, "error");
+			}
+		},
+		[createRequestMutation, openTab, showToast]
+	);
+
+	const newRequest = useCallback(() => {
+		const target = resolveNewRequestTarget(lastCollectionId, collections);
+		if (target.kind === "pick") {
+			setPickerOpen(true);
+			return;
+		}
+		if (target.kind === "collection") {
+			void createRequestIn(target.collectionId);
+			return;
+		}
+		// No collections yet - requests must belong to one, so make it first.
+		void (async () => {
+			try {
+				const newCollection = await createCollectionMutation.mutateAsync({
+					name: DEFAULT_COLLECTION_NAME,
+				});
+				await createRequestIn(newCollection.id);
+			} catch (error) {
+				console.error("Failed to create collection:", error);
+				showToast(CREATE_FAILED, "error");
+			}
+		})();
+	}, [collections, createCollectionMutation, createRequestIn, lastCollectionId, showToast]);
+
+	const onSelect = useCallback(
+		(collectionId: string) => {
+			setPickerOpen(false);
+			void createRequestIn(collectionId);
+		},
+		[createRequestIn]
+	);
+
+	return {
+		newRequest,
+		pickerProps: { open: pickerOpen, onOpenChange: setPickerOpen, collections, onSelect },
+	};
+}

--- a/app/src/lib/commands/context.ts
+++ b/app/src/lib/commands/context.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The context a caller with no React of its own can still build.
+ *
+ * The native-menu bridge runs inside an Electron callback, not a render, and it
+ * offers exactly one command rather than the roster - so it needs a context
+ * without a tab label, a collection lookup or a dialog host. Everything a
+ * command reads from a store is still true here, because stores are singletons;
+ * what is missing is what only a mounted host knows, and the commands that need
+ * that declare themselves unavailable.
+ *
+ * `useCommandContext` is the full version, for surfaces that render.
+ */
+
+import { useTabsStore } from "@/stores";
+import type { CommandContext } from "./types";
+
+export function baseCommandContext(): CommandContext {
+	const { openTabs, activeTabId } = useTabsStore.getState();
+	return {
+		activeTab: openTabs.find((tab) => tab.id === activeTabId) ?? null,
+		activeTabLabel: null,
+		activeCollection: null,
+	};
+}

--- a/app/src/lib/commands/index.ts
+++ b/app/src/lib/commands/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+export { COMMANDS, availableCommands, commandById } from "./registry";
+export { baseCommandContext } from "./context";
+export { commandTitle } from "./types";
+export type { Command, CommandContext, CommandGroup, CommandSurfaces } from "./types";

--- a/app/src/lib/commands/registry.test.ts
+++ b/app/src/lib/commands/registry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The registry's guards.
+ *
+ * Three things can go wrong with a registry nobody renders in a test: an entry
+ * that says nothing (no title, no keywords), an entry that does nothing
+ * (`perform` pointing at a surface the caller cannot open), and a roster that
+ * has quietly stopped covering what it generates from. Each has a test here.
+ *
+ * jsdom because a `perform` reaches the real stores, and the tabs store
+ * persists - a node environment has no `localStorage` for it to seed from.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { COMMANDS, availableCommands, commandById } from "./registry";
+import { baseCommandContext } from "./context";
+import { commandTitle, type Command, type CommandContext, type CommandSurfaces } from "./types";
+import { useImportModalStore, useTabsStore } from "@/stores";
+import { useSettingsStore } from "@/modules/settings/settings-store";
+import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
+import { ENGINE_SETTINGS_CATEGORIES } from "@/modules/settings/engine-categories";
+import type { Collection } from "@/types";
+
+const COLLECTION: Collection = { id: "c1", name: "Payments" } as Collection;
+
+function surfaces(): CommandSurfaces {
+	return { newRequest: () => {}, runCollection: () => {}, toggleThemeMode: () => {} };
+}
+
+/** A context with a host and a collection open - everything is available. */
+function fullContext(): CommandContext {
+	return {
+		activeTab: { id: "t1", type: "collection", entityId: "c1" },
+		activeTabLabel: "Payments",
+		activeCollection: COLLECTION,
+		surfaces: surfaces(),
+	};
+}
+
+/**
+ * The rule every entry has to satisfy. Written as a predicate rather than
+ * inline assertions so the same rule can be turned on a deliberately broken
+ * command below - a walk that only ever sees good data proves nothing.
+ */
+function isWellFormed(command: Command, ctx: CommandContext): boolean {
+	return (
+		command.id.trim() !== "" &&
+		commandTitle(command, ctx).trim() !== "" &&
+		command.keywords.length > 0 &&
+		command.keywords.every((keyword) => keyword.trim() !== "") &&
+		typeof command.perform === "function"
+	);
+}
+
+beforeEach(() => {
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+	useSettingsStore.setState({ selectedCategory: "appearance", highlightedKey: null });
+	useImportModalStore.setState({ isOpen: false });
+});
+
+describe("the roster", () => {
+	it("walks something, and every entry says what it is", () => {
+		// The scanned-something-non-empty rule: a walk over an empty array is a
+		// green test that checked nothing.
+		expect(COMMANDS.length).toBeGreaterThan(10);
+		const ctx = fullContext();
+		for (const command of COMMANDS) {
+			expect(isWellFormed(command, ctx), `command "${command.id}"`).toBe(true);
+		}
+	});
+
+	it("rejects an entry with a blank title or no keywords", () => {
+		const ctx = fullContext();
+		const [good] = COMMANDS;
+		expect(isWellFormed({ ...good, title: "   " }, ctx)).toBe(false);
+		expect(isWellFormed({ ...good, title: () => "" }, ctx)).toBe(false);
+		expect(isWellFormed({ ...good, keywords: [] }, ctx)).toBe(false);
+		expect(isWellFormed({ ...good, id: "" }, ctx)).toBe(false);
+	});
+
+	it("gives every entry a unique id", () => {
+		const ids = COMMANDS.map((c) => c.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("covers every settings section the sidebar renders", () => {
+		const ids = new Set(COMMANDS.map((c) => c.id));
+		for (const panel of APP_SETTINGS_PANELS) {
+			expect(ids.has(`settings:${panel.id}`), panel.label).toBe(true);
+		}
+		for (const category of ENGINE_SETTINGS_CATEGORIES) {
+			expect(ids.has(`settings:${category.id}`), category.label).toBe(true);
+		}
+	});
+});
+
+describe("availability", () => {
+	it("hides everything that needs a host the caller has not offered", () => {
+		const ids = availableCommands(baseCommandContext()).map((c) => c.id);
+		expect(ids).not.toContain("new-request");
+		expect(ids).not.toContain("run-collection");
+		expect(ids).not.toContain("toggle-theme");
+		// Nothing is open, so there is no tab to close either.
+		expect(ids).not.toContain("close-tab");
+		// These two need only stores, so the menu bridge can offer them.
+		expect(ids).toContain("open-settings");
+		expect(ids).toContain("import-collection");
+	});
+
+	it("hides the collection command until a collection tab is open", () => {
+		const withHost: CommandContext = {
+			activeTab: null,
+			activeTabLabel: null,
+			activeCollection: null,
+			surfaces: surfaces(),
+		};
+		expect(availableCommands(withHost).map((c) => c.id)).not.toContain("run-collection");
+		expect(availableCommands(fullContext()).map((c) => c.id)).toContain("run-collection");
+	});
+
+	it("names the target of a contextual command, so Enter holds no surprise", () => {
+		const ctx = fullContext();
+		expect(commandTitle(commandById("run-collection"), ctx)).toBe('Run "Payments"');
+		expect(commandTitle(commandById("close-tab"), ctx)).toBe('Close "Payments"');
+	});
+
+	it("falls back to a generic close title when nothing knows the label", () => {
+		const ctx: CommandContext = {
+			activeTab: { id: "t1", type: "request", entityId: "r1" },
+			activeTabLabel: null,
+			activeCollection: null,
+		};
+		expect(commandTitle(commandById("close-tab"), ctx)).toBe("Close tab");
+	});
+});
+
+describe("performing", () => {
+	it("opens the settings tab, the way the menu's Preferences… item does", () => {
+		commandById("open-settings").perform(baseCommandContext());
+		expect(useTabsStore.getState().openTabs).toHaveLength(1);
+		expect(useTabsStore.getState().openTabs[0]).toMatchObject({ type: "settings" });
+	});
+
+	it("reveals a settings section by selecting it before opening the tab", () => {
+		commandById("settings:mcp").perform(baseCommandContext());
+		expect(useSettingsStore.getState().selectedCategory).toBe("mcp");
+		expect(useTabsStore.getState().openTabs[0]).toMatchObject({ type: "settings" });
+	});
+
+	it("reveals an engine category through the same command shape", () => {
+		commandById("settings:database_performance").perform(baseCommandContext());
+		expect(useSettingsStore.getState().selectedCategory).toBe("database_performance");
+	});
+
+	it("opens the import modal through its store, not a copy of it", () => {
+		commandById("import-collection").perform(baseCommandContext());
+		expect(useImportModalStore.getState().isOpen).toBe(true);
+	});
+
+	it("closes the active tab", () => {
+		useTabsStore.getState().openTab({ type: "settings", entityId: null });
+		const ctx = baseCommandContext();
+		expect(ctx.activeTab).not.toBeNull();
+
+		commandById("close-tab").perform(ctx);
+		expect(useTabsStore.getState().openTabs).toHaveLength(0);
+	});
+
+	it("hands the collection to the host rather than running it itself", () => {
+		const runs: Collection[] = [];
+		const ctx: CommandContext = {
+			...fullContext(),
+			surfaces: { ...surfaces(), runCollection: (c) => runs.push(c) },
+		};
+		commandById("run-collection").perform(ctx);
+		expect(runs).toEqual([COLLECTION]);
+	});
+});
+
+describe("commandById", () => {
+	it("throws on an id nothing declares, so a dead menu item cannot be silent", () => {
+		expect(() => commandById("open-the-pod-bay-doors")).toThrow(/Unknown command id/);
+	});
+});

--- a/app/src/lib/commands/registry.ts
+++ b/app/src/lib/commands/registry.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The command registry - every action the app offers by name, declared once.
+ *
+ * Before this, an action's definition was wherever it happened to be invoked
+ * from: "open settings" existed in the native-menu bridge, in the Dock, in the
+ * settings sidebar and in a keydown case, each a separate spelling of the same
+ * intent. Nothing kept them in step, and nothing could enumerate them - which is
+ * why the palette could not offer "do Y" at all.
+ *
+ * The rule this file exists to enforce: **a new user-facing action is declared
+ * here, and its surfaces point at it.** A menu item, a tile or a palette row is
+ * a way of reaching a command, never a second definition of one.
+ *
+ * Each `perform` calls the very function the pre-existing surface calls, so a
+ * command is a pointer rather than a reimplementation. The settings roster is
+ * generated from the two settings registries for the same reason: a category
+ * added there appears here without an edit, and cannot be named differently.
+ */
+
+import { Download, Play, Plus, Settings, SunMoon, X } from "lucide-react";
+import { useImportModalStore, useTabsStore } from "@/stores";
+import { useSettingsStore } from "@/modules/settings/settings-store";
+import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
+import { ENGINE_SETTINGS_CATEGORIES } from "@/modules/settings/engine-categories";
+import type { SettingsCategory } from "@/types";
+import type { Command, CommandContext } from "./types";
+
+/** Open the Settings tab. The Shell's own effect brings its drawer view with it. */
+function openSettingsTab(): void {
+	useTabsStore.getState().openTab({ type: "settings", entityId: null });
+}
+
+/**
+ * Reveal one settings section - the same two calls the sidebar's `selectCategory`
+ * makes, in the same order: select first, then open, so the tab renders the
+ * asked-for panel rather than the previous selection for one frame.
+ */
+function revealSettingsCategory(category: SettingsCategory): void {
+	useSettingsStore.getState().setSelectedCategory(category);
+	openSettingsTab();
+}
+
+const ACTION_COMMANDS: readonly Command[] = [
+	{
+		id: "new-request",
+		title: "New request",
+		keywords: ["create", "add", "http", "endpoint"],
+		group: "action",
+		icon: Plus,
+		// The flow can need a collection picker, and a picker needs a host to
+		// render it - see `CommandSurfaces`.
+		available: (ctx) => ctx.surfaces !== undefined,
+		perform: (ctx) => ctx.surfaces?.newRequest(),
+	},
+	{
+		id: "import-collection",
+		title: "Import collection",
+		keywords: ["postman", "openapi", "insomnia", "curl", "har", "file"],
+		group: "action",
+		icon: Download,
+		// The import modal is mounted in the Shell and driven by a store, so this
+		// one needs nothing from the caller.
+		perform: () => useImportModalStore.getState().open(),
+	},
+	{
+		id: "run-collection",
+		// Named, not generic: a palette row that reads "Run collection" makes the
+		// user guess which one Enter will start.
+		title: (ctx) => `Run "${ctx.activeCollection?.name ?? ""}"`,
+		keywords: ["scenario", "sequence", "start", "execute", "folder"],
+		group: "action",
+		icon: Play,
+		available: (ctx) => ctx.surfaces !== undefined && ctx.activeCollection !== null,
+		perform: (ctx) => {
+			if (ctx.activeCollection) ctx.surfaces?.runCollection(ctx.activeCollection);
+		},
+	},
+	{
+		id: "close-tab",
+		title: (ctx) => (ctx.activeTabLabel ? `Close "${ctx.activeTabLabel}"` : "Close tab"),
+		keywords: ["dismiss", "shut"],
+		group: "action",
+		icon: X,
+		available: (ctx) => ctx.activeTab !== null,
+		perform: (ctx) => {
+			if (ctx.activeTab) useTabsStore.getState().closeTab(ctx.activeTab.id);
+		},
+	},
+	{
+		id: "toggle-theme",
+		title: "Toggle theme mode",
+		keywords: ["dark", "light", "appearance", "colour", "color"],
+		group: "action",
+		icon: SunMoon,
+		available: (ctx) => ctx.surfaces !== undefined,
+		perform: (ctx) => ctx.surfaces?.toggleThemeMode(),
+	},
+	{
+		id: "open-settings",
+		title: "Open settings",
+		keywords: ["preferences", "options", "config"],
+		group: "action",
+		icon: Settings,
+		perform: openSettingsTab,
+	},
+];
+
+/**
+ * One command per settings section, generated from the registries the sidebar
+ * renders - so the palette cannot offer a section name the screen never shows,
+ * nor miss one that was added there.
+ */
+const SETTINGS_COMMANDS: readonly Command[] = [
+	...APP_SETTINGS_PANELS.map(
+		(panel): Command => ({
+			id: `settings:${panel.id}`,
+			title: panel.label,
+			// The panel's own description, split into words: it is the sentence
+			// the screen prints, so it is also what a user is likely to type.
+			keywords: [panel.id, "settings", "preferences", ...panel.description.split(/\s+/)],
+			group: "settings",
+			icon: panel.icon,
+			subtitle: "Settings",
+			perform: () => revealSettingsCategory(panel.id),
+		})
+	),
+	...ENGINE_SETTINGS_CATEGORIES.map(
+		(category): Command => ({
+			id: `settings:${category.id}`,
+			title: category.label,
+			keywords: [
+				category.id,
+				"settings",
+				"engine",
+				"preferences",
+				...category.description.split(/\s+/),
+			],
+			group: "settings",
+			icon: category.icon,
+			subtitle: "Engine settings",
+			perform: () => revealSettingsCategory(category.id),
+		})
+	),
+];
+
+/** Every command the app declares, in palette order. */
+export const COMMANDS: readonly Command[] = [...ACTION_COMMANDS, ...SETTINGS_COMMANDS];
+
+/** The subset that can run right now. */
+export function availableCommands(ctx: CommandContext): Command[] {
+	return COMMANDS.filter((command) => command.available?.(ctx) ?? true);
+}
+
+/**
+ * Look one up by id, for a surface that offers a single named command (the
+ * native menu's Preferences… item) rather than the whole roster.
+ *
+ * Throws on an unknown id: a menu item pointing at a command that no longer
+ * exists is a dead menu item, and a silent no-op is exactly how the drift this
+ * registry removes got in.
+ */
+export function commandById(id: string): Command {
+	const command = COMMANDS.find((c) => c.id === id);
+	if (!command) throw new Error(`Unknown command id: ${id}`);
+	return command;
+}

--- a/app/src/lib/commands/types.ts
+++ b/app/src/lib/commands/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What a command *is*, and what it is allowed to know.
+ *
+ * A command is a definition, not a component: `id`, what it reads as, and one
+ * `perform`. That is what lets the palette, the native menu and (later) any
+ * other surface offer the same action without each hand-rolling its own copy of
+ * "what this action is" - the defect that made a menu item and a tile drift
+ * apart in the first place.
+ *
+ * **Stores are not in the context.** They are module singletons, so a `perform`
+ * reaches `useTabsStore.getState()` directly rather than being handed an
+ * `openTab`. The context carries only what `getState()` cannot answer: what the
+ * user is looking at, and the surfaces a caller can open.
+ */
+
+import type { LucideIcon } from "lucide-react";
+import type { Tab } from "@/stores";
+import type { Collection } from "@/types";
+
+/**
+ * Which palette group a command renders under.
+ *
+ * Two, not one: the settings roster is twelve entries wide (seven app panels
+ * plus five engine categories) and would otherwise bury the five actions it
+ * sits next to.
+ */
+export type CommandGroup = "action" | "settings";
+
+/**
+ * Dialogs and flows a command cannot open on its own.
+ *
+ * Everything else a `perform` needs is in a store, but a collection picker, a
+ * run dialog and the theme hook are React - they exist only where something has
+ * mounted them. A caller that has not (the native menu bridge) simply omits
+ * this, and the commands that need it declare themselves unavailable rather
+ * than throwing when picked.
+ */
+export interface CommandSurfaces {
+	/** Create a request, asking which collection when that is ambiguous. */
+	newRequest: () => void;
+	/** Open the run dialog for a collection. */
+	runCollection: (collection: Collection) => void;
+	/** Flip the app between light and dark. */
+	toggleThemeMode: () => void;
+}
+
+/**
+ * What the app looks like right now, from the point of view of a command.
+ *
+ * Built fresh each time the roster is asked for - availability is a question
+ * about this moment ("is a collection open?"), not a subscription.
+ */
+export interface CommandContext {
+	/** The tab the user is looking at, or `null` when none is. */
+	activeTab: Tab | null;
+	/**
+	 * How the tab strip labels that tab. From `tab-descriptors`, the hook the
+	 * strip itself uses, so a command names a tab the way the tab is named.
+	 */
+	activeTabLabel: string | null;
+	/** The collection the active tab shows, when it shows one. */
+	activeCollection: Collection | null;
+	surfaces?: CommandSurfaces;
+}
+
+export interface Command {
+	/** Stable and unique. Used as the palette row's key and in tests. */
+	id: string;
+	/**
+	 * What the row reads as. A function when the command names its target -
+	 * "Run 'payments'" tells you what Enter will do, where "Run collection"
+	 * leaves you to guess which one.
+	 */
+	title: string | ((ctx: CommandContext) => string);
+	/** Extra match terms that do not belong on screen. Never empty. */
+	keywords: readonly string[];
+	group: CommandGroup;
+	icon: LucideIcon;
+	/** Where the row says this action already lives, when that is not obvious. */
+	subtitle?: string;
+	/**
+	 * Whether this command can run at all right now. Omitted means always -
+	 * spelled that way rather than `() => true` so the roster reads as "these
+	 * five are contextual" at a glance.
+	 */
+	available?: (ctx: CommandContext) => boolean;
+	perform: (ctx: CommandContext) => void;
+}
+
+/** The title for this moment - resolves the contextual form. */
+export function commandTitle(command: Command, ctx: CommandContext): string {
+	return typeof command.title === "function" ? command.title(ctx) : command.title;
+}

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -31,7 +31,8 @@ import { render, screen, cleanup, waitFor, fireEvent, act } from "@testing-libra
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { CommandPalette } from "./CommandPalette";
-import { useLayoutStore, useTabsStore } from "@/stores";
+import { useImportModalStore, useLayoutStore, useTabsStore } from "@/stores";
+import { useSettingsStore } from "@/modules/settings/settings-store";
 
 const COLLECTIONS = [
 	{ id: "c1", name: "Payments", parentId: undefined },
@@ -66,6 +67,11 @@ vi.mock("@/queries", () => ({
 	useRunsQuery: () => ({ data: { pages: runPages } }),
 	flattenRunPages: (data?: { pages: { data: unknown[] }[] }) =>
 		data ? data.pages.flatMap((p) => p.data) : [],
+	// Reached through the command surfaces the palette now hosts: the shared
+	// new-request flow and the run dialog.
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn() }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn() }),
+	useStartScenarioRunMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 vi.mock("@/hooks/useVariableResolver", () => ({
 	useVariableResolver: () => ({ resolveString: (s: string) => s }),
@@ -126,6 +132,8 @@ beforeEach(() => {
 	runPages = [{ data: [] }];
 	useLayoutStore.setState({ paletteOpen: false, drawerOpen: false, drawerView: "collections" });
 	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+	useImportModalStore.setState({ isOpen: false });
+	useSettingsStore.setState({ selectedCategory: "appearance", highlightedKey: null });
 });
 afterEach(cleanup);
 
@@ -278,7 +286,79 @@ describe("the empty query", () => {
 		const headings = [...document.querySelectorAll("[cmdk-group-heading]")].map(
 			(el) => el.textContent
 		);
-		expect(headings).toEqual(["Tabs", "Requests", "Collections", "Views"]);
+		expect(headings).toEqual([
+			"Tabs",
+			"Requests",
+			"Collections",
+			"Views",
+			"Commands",
+			"Settings",
+		]);
+	});
+});
+
+/**
+ * The registry's half of the palette. The point of these is that the palette
+ * *offers* the roster and runs it - the commands themselves are held to their
+ * behaviour in `lib/commands/registry.test.ts`, and duplicating that here would
+ * be two tests for one rule.
+ */
+describe("commands", () => {
+	it("finds a command by name and performs it on Enter", () => {
+		renderPalette();
+		open();
+
+		typeQuery("import");
+		pressEnter();
+
+		expect(useImportModalStore.getState().isOpen).toBe(true);
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+	});
+
+	it("finds a settings section by name and reveals it", () => {
+		renderPalette();
+		open();
+
+		typeQuery("notificat");
+		pressEnter();
+
+		expect(useSettingsStore.getState().selectedCategory).toBe("notifications");
+		expect(useTabsStore.getState().openTabs[0]).toMatchObject({ type: "settings" });
+	});
+
+	it("offers the collection command only while a collection tab is active", () => {
+		renderPalette();
+		open();
+		expect(screen.queryByText(/^Run "/)).not.toBeInTheDocument();
+		cleanup();
+
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "collection", entityId: "c1" }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+		// Named after its target, so Enter holds no surprise.
+		expect(screen.getByText('Run "Payments"')).toBeInTheDocument();
+	});
+
+	it("keeps the run dialog on screen after the pick closes the palette", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "collection", entityId: "c1" }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+
+		typeQuery('Run "Pay');
+		pressEnter();
+
+		// The dialog is hosted beside the palette, not inside it - inside, the
+		// pick that opened it would unmount it in the same commit.
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+		expect(screen.getByRole("dialog", { name: /Run Payments/ })).toBeInTheDocument();
 	});
 });
 

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -13,12 +13,17 @@
  * and a settings section meant ⌘, plus its sidebar - so Vayu was navigated with
  * a mouse or not at all.
  *
- * Two things it deliberately is not:
+ * Three things it deliberately is not:
  *
  * - **Not its own search implementation.** Results come from source hooks
  *   (`sources/`), each returning the same `PaletteItem` shape and performing
  *   its action through the very call the sidebar makes. Adding settings,
  *   environments or runs later is a source, not a change here.
+ * - **Not its own list of actions.** The Commands and Settings groups are
+ *   `lib/commands`, the registry the native menu points at too. What this file
+ *   does own is the *host* for the dialogs those commands open - see
+ *   `useCommandSurfaces` for why the picker and the run dialog are mounted here
+ *   rather than left to surfaces that are not always on screen.
  * - **Not a second copy of the tab strip's naming.** Tab rows are labelled by
  *   `tab-descriptors`, the hook the strip itself uses.
  *
@@ -33,13 +38,19 @@ import { CommandDialog, CommandInput } from "@/components/ui";
 import { useLayoutStore } from "@/stores";
 import { PALETTE_CHORD, matchesChord } from "@/constants/shortcuts";
 import { formatChord } from "@/lib/platform";
+import { useCommandContext } from "@/hooks/useCommandContext";
+import RunCollectionDialog from "@/modules/collections/RunCollectionDialog";
+import { CollectionPicker } from "@/modules/welcome/components/CollectionPicker";
 import { PaletteResults } from "./PaletteResults";
+import { useCommandSurfaces } from "./useCommandSurfaces";
 import type { PaletteItem } from "./types";
 
 export function CommandPalette() {
 	const paletteOpen = useLayoutStore((s) => s.paletteOpen);
 	const setPaletteOpen = useLayoutStore((s) => s.setPaletteOpen);
 	const [query, setQuery] = useState("");
+	const { surfaces, pickerProps, runTarget, dismissRunDialog } = useCommandSurfaces();
+	const commandContext = useCommandContext(surfaces);
 	/** Where focus was when the palette opened, to give it back on close. */
 	const focusBefore = useRef<HTMLElement | null>(null);
 
@@ -118,24 +129,38 @@ export function CommandPalette() {
 	};
 
 	return (
-		<CommandDialog
-			open={paletteOpen}
-			onOpenChange={setPaletteOpen}
-			title="Command palette"
-			description="Search open tabs, requests, collections and views."
-			className="max-w-xl"
-		>
-			<CommandInput
-				value={query}
-				onValueChange={setQuery}
-				placeholder={`Search tabs, requests, collections… (${formatChord(PALETTE_CHORD)})`}
-			/>
-			{/*
-			 * Mounted only while open, so a shut palette holds no query observers
-			 * on collections, requests and run history - the same rule the
-			 * context bar applies to a collapsed section.
-			 */}
-			{paletteOpen && <PaletteResults query={query} onPick={pick} />}
-		</CommandDialog>
+		<>
+			<CommandDialog
+				open={paletteOpen}
+				onOpenChange={setPaletteOpen}
+				title="Command palette"
+				description="Search open tabs, requests, collections, views and commands."
+				className="max-w-xl"
+			>
+				<CommandInput
+					value={query}
+					onValueChange={setQuery}
+					placeholder={`Search tabs, requests, commands… (${formatChord(PALETTE_CHORD)})`}
+				/>
+				{/*
+				 * Mounted only while open, so a shut palette holds no query observers
+				 * on collections, requests and run history - the same rule the
+				 * context bar applies to a collapsed section.
+				 */}
+				{paletteOpen && (
+					<PaletteResults query={query} onPick={pick} commandContext={commandContext} />
+				)}
+			</CommandDialog>
+			{/* Outside the palette on purpose: a command closes the palette as it
+			    runs, so a dialog rendered inside it would be unmounted by the very
+			    pick that opened it. */}
+			<CollectionPicker {...pickerProps} />
+			{runTarget && (
+				<RunCollectionDialog
+					collection={runTarget}
+					onOpenChange={(open) => !open && dismissRunDialog()}
+				/>
+			)}
+		</>
 	);
 }

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -23,30 +23,39 @@ import {
 	CommandSeparator,
 } from "@/components/ui";
 import { getMethodColor } from "@/utils";
+import type { CommandContext } from "@/lib/commands";
 import { PALETTE_GROUPS, PALETTE_GROUP_LABELS, rankForEmptyQuery, type PaletteItem } from "./types";
 import { useTabItems } from "./sources/useTabItems";
 import { useEntityItems } from "./sources/useEntityItems";
 import { useViewItems } from "./sources/useViewItems";
+import { commandItems } from "./sources/commandItems";
 
 interface PaletteResultsProps {
 	/** The live query, so ranking can tell "nothing typed" from "no match". */
 	query: string;
 	/** Run the item and close - the palette never stays open after a pick. */
 	onPick: (item: PaletteItem) => void;
+	/**
+	 * What the commands can see. Built by the palette rather than here, because
+	 * the dialogs it carries have to outlive the list: picking "Run" closes the
+	 * palette, and this component with it.
+	 */
+	commandContext: CommandContext;
 }
 
-export function PaletteResults({ query, onPick }: PaletteResultsProps) {
+export function PaletteResults({ query, onPick, commandContext }: PaletteResultsProps) {
 	const tabs = useTabItems();
 	const entities = useEntityItems();
 	const views = useViewItems();
+	const commands = commandItems(commandContext);
 
 	const grouped = useMemo(() => {
-		const all = [...tabs, ...entities, ...views];
+		const all = [...tabs, ...entities, ...views, ...commands];
 		return PALETTE_GROUPS.map((kind) => ({
 			kind,
 			items: rankForEmptyQuery(all.filter((item) => item.kind === kind)),
 		})).filter((group) => group.items.length > 0);
-	}, [tabs, entities, views]);
+	}, [tabs, entities, views, commands]);
 
 	/*
 	 * cmdk hides a group whose items all filter out, so the count has to come

--- a/app/src/modules/palette/sources/commandItems.ts
+++ b/app/src/modules/palette/sources/commandItems.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The command registry, as palette results.
+ *
+ * The "do Y" half of the palette. A plain function rather than a hook like its
+ * siblings, because it owns no data: it maps `lib/commands` onto `PaletteItem`,
+ * which is the whole point - the palette is a way of reaching a command, not a
+ * second place actions are defined.
+ *
+ * Unavailable commands never reach the list. A row that cannot do anything is
+ * worse than a missing one: it looks like the app is broken rather than like the
+ * action wants a collection open.
+ */
+
+import { availableCommands, commandTitle, type CommandContext } from "@/lib/commands";
+import type { PaletteItem } from "../types";
+
+export function commandItems(ctx: CommandContext): PaletteItem[] {
+	return availableCommands(ctx).map((command) => ({
+		id: `command:${command.id}`,
+		kind: command.group === "settings" ? ("settings" as const) : ("command" as const),
+		title: commandTitle(command, ctx),
+		...(command.subtitle ? { subtitle: command.subtitle } : {}),
+		keywords: [...command.keywords],
+		icon: command.icon,
+		perform: () => command.perform(ctx),
+	}));
+}

--- a/app/src/modules/palette/types.ts
+++ b/app/src/modules/palette/types.ts
@@ -20,7 +20,14 @@ import type { LucideIcon } from "lucide-react";
  * Which group a result renders under. The order here is the order on screen:
  * groups are fixed so the list does not reshuffle as you type.
  */
-export const PALETTE_GROUPS = ["tab", "request", "collection", "view"] as const;
+export const PALETTE_GROUPS = [
+	"tab",
+	"request",
+	"collection",
+	"view",
+	"command",
+	"settings",
+] as const;
 
 export type PaletteKind = (typeof PALETTE_GROUPS)[number];
 
@@ -30,6 +37,10 @@ export const PALETTE_GROUP_LABELS: Record<PaletteKind, string> = {
 	request: "Requests",
 	collection: "Collections",
 	view: "Views",
+	command: "Commands",
+	// Its own group rather than more Commands: twelve sections would bury the
+	// five things the palette can actually *do*.
+	settings: "Settings",
 };
 
 export interface PaletteItem {

--- a/app/src/modules/palette/useCommandSurfaces.ts
+++ b/app/src/modules/palette/useCommandSurfaces.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The dialogs and flows the palette's commands open.
+ *
+ * Three commands need something React owns rather than something a store holds:
+ * a collection picker, the run dialog, and the theme hook. Their existing hosts
+ * are not always on screen - the welcome screen's picker exists only on the
+ * welcome tab, and the collections tree's run dialog is unmounted the moment the
+ * drawer closes - so the palette hosts its own. Each is the same component the
+ * original surface renders, driven by the same call, so a run started from here
+ * is the run the tree starts.
+ *
+ * The theme comes from `useElectronTheme`, which keeps its state per instance
+ * and syncs instances through Electron's `theme-changed` event - so a toggle
+ * from here reaches the Appearance panel's radio group the same way an OS theme
+ * change does.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { useNewRequest } from "@/hooks/useNewRequest";
+import { useElectronTheme } from "@/hooks/useElectronTheme";
+import type { CommandSurfaces } from "@/lib/commands";
+import type { Collection } from "@/types";
+import type { NewRequestPickerProps } from "@/hooks/useNewRequest";
+
+export interface UseCommandSurfacesReturn {
+	surfaces: CommandSurfaces;
+	pickerProps: NewRequestPickerProps;
+	/** The collection whose run dialog is open, or `null` when none is. */
+	runTarget: Collection | null;
+	dismissRunDialog: () => void;
+}
+
+export function useCommandSurfaces(): UseCommandSurfacesReturn {
+	const { newRequest, pickerProps } = useNewRequest();
+	const { isDark, setTheme } = useElectronTheme();
+	const [runTarget, setRunTarget] = useState<Collection | null>(null);
+
+	const dismissRunDialog = useCallback(() => setRunTarget(null), []);
+
+	// Light and dark only. "System" is a third *source*, not a third mode, and a
+	// toggle that landed on it would leave the user unable to say which way the
+	// next press goes - the Appearance panel is where the OS is opted back into.
+	const toggleThemeMode = useCallback(
+		() => void setTheme(isDark ? "light" : "dark"),
+		[isDark, setTheme]
+	);
+
+	const surfaces = useMemo<CommandSurfaces>(
+		() => ({ newRequest, runCollection: setRunTarget, toggleThemeMode }),
+		[newRequest, toggleThemeMode]
+	);
+
+	return { surfaces, pickerProps, runTarget, dismissRunDialog };
+}

--- a/app/src/modules/welcome/WelcomeScreen.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.tsx
@@ -17,39 +17,23 @@
  * to show. See app/src/modules/welcome/README.md for what belongs on this screen.
  */
 
-import { useState } from "react";
-import {
-	useTabsStore,
-	useImportModalStore,
-	useToastStore,
-	useLayoutStore,
-	useSessionStore,
-} from "@/stores";
-import {
-	useCollectionsQuery,
-	useRunsQuery,
-	flattenRunPages,
-	useCreateRequestMutation,
-	useCreateCollectionMutation,
-} from "@/queries";
+import { useTabsStore, useImportModalStore, useLayoutStore } from "@/stores";
+import { useCollectionsQuery, useRunsQuery, flattenRunPages } from "@/queries";
 import { ErrorState } from "@/components/shared";
-import { DEFAULT_REQUEST_NAME } from "@/constants/request";
-import { DEFAULT_COLLECTION_NAME } from "@/constants/collection";
-import { resolveNewRequestTarget } from "./targetCollection";
+import { useNewRequest } from "@/hooks/useNewRequest";
 import { CollectionPicker } from "./components/CollectionPicker";
 import { FirstRunWelcome } from "./FirstRunWelcome";
 import { Launcher } from "./Launcher";
 import { LauncherSkeleton } from "./LauncherSkeleton";
 
-const CREATE_FAILED = "Could not create the request. Check that the engine is running.";
-
 export default function WelcomeScreen() {
 	const openImport = useImportModalStore((s) => s.open);
-	const showToast = useToastStore((s) => s.showToast);
 	const { openTab } = useTabsStore();
 	const activateDrawerView = useLayoutStore((s) => s.activateDrawerView);
 	const setPaletteOpen = useLayoutStore((s) => s.setPaletteOpen);
-	const lastCollectionId = useSessionStore((s) => s.lastCollectionId);
+	// The flow itself lives in `useNewRequest`, shared with the command palette's
+	// "New request" - this screen renders its picker, nothing more.
+	const { newRequest, pickerProps } = useNewRequest();
 	const {
 		data: collections = [],
 		isLoading: collectionsLoading,
@@ -66,53 +50,6 @@ export default function WelcomeScreen() {
 	} = useRunsQuery();
 	// Flatten the loaded pages; the Launcher only shows the most recent handful.
 	const runs = flattenRunPages(runsData);
-	const createRequestMutation = useCreateRequestMutation();
-	const createCollectionMutation = useCreateCollectionMutation();
-
-	const [pickerOpen, setPickerOpen] = useState(false);
-
-	const createRequestIn = async (collectionId: string) => {
-		try {
-			const newRequest = await createRequestMutation.mutateAsync({
-				collectionId,
-				name: DEFAULT_REQUEST_NAME,
-				method: "GET",
-				url: "",
-			});
-			openTab({ type: "request", entityId: newRequest.id });
-		} catch (error) {
-			// Without this the click looks dead - the old code only logged.
-			console.error("Failed to create new request:", error);
-			showToast(CREATE_FAILED, "error");
-		}
-	};
-
-	const handleNewRequest = async () => {
-		const target = resolveNewRequestTarget(lastCollectionId, collections);
-		if (target.kind === "pick") {
-			setPickerOpen(true);
-			return;
-		}
-		if (target.kind === "collection") {
-			void createRequestIn(target.collectionId);
-			return;
-		}
-		// No collections yet - requests must belong to one, so make it first.
-		try {
-			const newCollection = await createCollectionMutation.mutateAsync({
-				name: DEFAULT_COLLECTION_NAME,
-			});
-			await createRequestIn(newCollection.id);
-		} catch (error) {
-			console.error("Failed to create collection:", error);
-			showToast(CREATE_FAILED, "error");
-		}
-	};
-
-	const handlePick = (collectionId: string) => {
-		setPickerOpen(false);
-		void createRequestIn(collectionId);
-	};
 
 	// Both queries start as [] while loading, which would read as an empty
 	// workspace and flash the first-run screen at returning users - hence the
@@ -153,14 +90,14 @@ export default function WelcomeScreen() {
 							onRetry={retry}
 						/>
 					) : (
-						<FirstRunWelcome onImport={openImport} onNewRequest={handleNewRequest} />
+						<FirstRunWelcome onImport={openImport} onNewRequest={newRequest} />
 					)
 				) : (
 					<Launcher
 						runs={runs}
 						collectionCount={collections.length}
 						onImport={openImport}
-						onNewRequest={handleNewRequest}
+						onNewRequest={newRequest}
 						onSearch={() => setPaletteOpen(true)}
 						onHistory={() => activateDrawerView("history")}
 						onVariables={() => openTab({ type: "variables", entityId: null })}
@@ -168,12 +105,7 @@ export default function WelcomeScreen() {
 					/>
 				)}
 			</div>
-			<CollectionPicker
-				open={pickerOpen}
-				onOpenChange={setPickerOpen}
-				collections={collections}
-				onSelect={handlePick}
-			/>
+			<CollectionPicker {...pickerProps} />
 		</div>
 	);
 }

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -481,7 +481,7 @@ Vayu's new-tab surface - rendered for the `welcome` tab (opened by TabStrip's `+
 
 It is **not** a resume screen: `openTabs`/`activeTabId` are persisted and restored, so returning users land back on their own tabs. Its job is to start something new. Keep marketing content off it - a feature pitch and static perf claims were removed for exactly that reason. Anything already visible in the Collections sidebar or History drawer is a duplicate and does not belong here either.
 
-- `WelcomeScreen.tsx` - container: queries, `handleNewRequest`, picks the state. Holds on `isLoading` so the first-run screen never flashes at a returning user.
+- `WelcomeScreen.tsx` - container: queries, picks the state. Holds on `isLoading` so the first-run screen never flashes at a returning user. The new-request flow itself is `hooks/useNewRequest.ts`, shared with the palette's `new-request` command - two entry points must not disagree about where a request lands. This screen renders that hook's `pickerProps` and nothing more.
 - `EmptyState.tsx` - fresh workspace. Import leads (people arrive carrying Postman/Insomnia/OpenAPI collections). The only state with branding.
 - `Launcher.tsx` - populated. Action row, recent runs, workspace counts. No branding; the logo is in the title bar.
 - `components/` - `ActionTile`, `RecentRuns`, `FooterLinks`. The action row is six tiles: New
@@ -496,14 +496,21 @@ Design rationale: `app/src/modules/welcome/README.md`
 
 ## Command Palette (`modules/palette/`)
 
-The ⌘K/Ctrl+K overlay: reach any open tab, saved request, collection or app view by name.
-Mounted once by `Shell`, alongside `ImportModal`.
+The ⌘K/Ctrl+K overlay: reach any open tab, saved request, collection or app view by name, and
+run any command by name. Mounted once by `Shell`, alongside `ImportModal`.
 
-- **`CommandPalette.tsx`** - the dialog, the chord, focus restoration, and the open flag
-  (`useLayoutStore.paletteOpen` / `setPaletteOpen`, deliberately not persisted).
+- **`CommandPalette.tsx`** - the dialog, the chord, focus restoration, the open flag
+  (`useLayoutStore.paletteOpen` / `setPaletteOpen`, deliberately not persisted), and the host
+  for the dialogs its commands open (see `useCommandSurfaces.ts` below).
 - **`sources/`** - one hook per family, each returning `PaletteItem[]`: `useTabItems` (open
   tabs), `useEntityItems` (requests + collections), `useViewItems` (drawer views and singleton
-  tabs). Adding settings, environments or runs later is a new source and nothing else.
+  tabs). `commandItems.ts` is the fourth and is a plain function, not a hook: it owns no data,
+  it maps the [command registry](#command-registry-libcommands) onto the same shape. Adding
+  environments or runs later is a new source and nothing else.
+- **`useCommandSurfaces.ts`** - the collection picker, the run dialog and the theme hook, which
+  three commands need and no store can hold. Their original hosts are not always on screen (the
+  welcome screen's picker only on the welcome tab, the tree's run dialog only while the drawer
+  is open), so the palette mounts its own - the same components, driven by the same calls.
 - **`types.ts`** - the `PaletteItem` shape, the fixed group order, and `rankForEmptyQuery`.
 - **`PaletteResults.tsx`** - grouping and rendering. **Mounted only while the palette is open**,
   the same cost rule the context bar applies to a collapsed section: a shut palette holds no
@@ -527,10 +534,44 @@ Three things about it are load-bearing:
 Ranking: cmdk's own match score once anything is typed; on the empty query, `rankForEmptyQuery`
 puts the most recent first - focus time for tabs (`tabFocusedAt` in `tabs-store`, session-scoped),
 last-run time for requests (from the run history already in cache). Groups render in a fixed
-order (Tabs, Requests, Collections, Views) so the list does not reshuffle as you type.
+order (Tabs, Requests, Collections, Views, Commands, Settings) so the list does not reshuffle as
+you type. Settings is its own group rather than more Commands: twelve sections would bury the
+handful of things the palette can actually *do*.
 
 **Entry points:** the chord, and the `Search` tile on the welcome Launcher. The title bar's
 search bar (#529) is the third and becomes the primary one - it flips the same store flag.
+
+## Command Registry (`lib/commands/`)
+
+Every user-facing *action* the app offers by name, declared once. **A new action is declared
+here, and its surfaces point at it** - a menu item, a tile or a palette row is a way of reaching
+a command, never a second definition of one. Before this, "open settings" existed separately in
+the native-menu bridge, the Dock, the settings sidebar and a keydown case, and nothing kept them
+in step or could enumerate them.
+
+- **`types.ts`** - `Command` (`id`, `title`, `keywords`, `group`, `icon`, `available?`,
+  `perform`) and `CommandContext`. A `title` may be a function of the context, which is how a
+  contextual command names its target: `Run "payments"`, not `Run collection`.
+- **`registry.ts`** - the roster. Actions (new request, import, run collection, close tab,
+  toggle theme, open settings) plus one command per settings section, **generated** from
+  `app-panels.ts` and `engine-categories.ts` so a section added there appears here without an
+  edit and cannot be named differently.
+- **`context.ts`** - `baseCommandContext()`, the React-free snapshot for a caller that is not a
+  render (the native-menu bridge). `hooks/useCommandContext.ts` is the full version.
+
+Two rules make it work without a dependency-injection tangle:
+
+- **Stores are not in the context.** They are module singletons, so a `perform` calls
+  `useTabsStore.getState().openTab(...)` directly. The context carries only what `getState()`
+  cannot answer: the active tab and its label, the collection that tab shows, and the surfaces.
+- **A command that needs a surface the caller cannot offer declares itself unavailable** rather
+  than throwing when picked. `CommandSurfaces` is optional on the context; the menu bridge omits
+  it, so "New request" is simply not among the commands it can run.
+
+Consumers: `modules/palette/sources/commandItems.ts` (the Commands and Settings groups) and
+`hooks/useMenuActions.ts` (Preferences… → `open-settings`). `lib/commands/registry.test.ts` walks
+the roster and asserts every entry says something and that the settings roster still covers both
+catalogues.
 
 ## Toaster (`components/shared/Toaster.tsx`)
 


### PR DESCRIPTION
## Description

Phase 2 of the command palette: the "do Y" half, and the piece with value beyond the palette.

**The plan.** Root cause: an action's definition was wherever it happened to be invoked from - "open settings" existed separately in `useMenuActions.ts`, the Dock, the settings sidebar and a `Shell` keydown case, and "new request" lived inside `WelcomeScreen` and was reachable only from the welcome tab. Nothing kept those copies in step and nothing could enumerate them, so the palette could offer "go to X" but not "do Y". The approach is a declarative registry (`lib/commands/`) that every surface points at rather than restates, with two rules that keep it from becoming a dependency-injection tangle: stores stay **out** of the context (they are module singletons, so a `perform` calls `useTabsStore.getState().openTab(...)` itself and the context carries only what `getState()` cannot answer), and a command whose surface the caller cannot open **declares itself unavailable** rather than throwing when picked. The alternative I rejected was a context carrying every store action, injected by each caller: it makes the native-menu bridge - which runs inside an Electron callback, not a render - have to fabricate a full context to open settings, and it puts the same `openTab` in twenty closures instead of one call.

**The roster.** New request, import, run collection, close tab, toggle theme, open settings, plus one command per settings section **generated** from `app-panels.ts` and `engine-categories.ts` (7 app panels + 5 engine categories), so a section added there appears in the palette without an edit and cannot be named differently. Contextual commands name their target - `Run "payments"`, not `Run collection`.

**Where the dialogs live.** Three commands need something React owns rather than something a store holds, and their original hosts are not always on screen: the welcome screen's collection picker exists only on the welcome tab, and the collections tree's run dialog is unmounted the moment the drawer closes (`Drawer` returns `null`). So the palette hosts its own - the same components, driven by the same calls - beside the dialog rather than inside it, since a command closes the palette as it runs. The new-request flow moves out of `WelcomeScreen` into `hooks/useNewRequest.ts`, shared with the Launcher tile so two entry points cannot disagree about where a request lands; `WelcomeScreen` loses ~60 lines and keeps rendering its own picker from `pickerProps`.

**Menu re-point.** `useMenuActions.ts`'s Preferences… handler now performs `open-settings` from the registry instead of repeating its two lines.

### Deliberate deviations from the issue spec

- **"Start load test (the dialog opener on the active request)" is not in the roster.** Traced the blast radius: `handleStartLoadTest` in `modules/request-builder/index.tsx` takes a `RequestState` - the *live editor draft*, including unsaved URL, headers and body - which exists only inside that component and behind `RequestBuilderProvider`, and the palette is a sibling in `Shell`, outside it. A registry command could only start a run against the last **saved** version of the request, which is not "behaves identically to its pre-existing surface". Filed as a follow-up rather than shipped as a near-miss.
- **"New/start inbox (via #502's surface once it exists - guard on availability)" is not in the roster.** #502 has not landed, so the command would be permanently unavailable - dead code. The palette's Views group already opens the Inbox tab today.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **App suite: 412 files, 4198 tests passed** (177s). No pre-existing failures.
- `pnpm type-check`, `pnpm lint` (zero warnings) and `pnpm format:check` clean.
- Engine untouched (`Engine: none. MCP: none.` per the issue), so no engine build or ctest run - nothing there could change colour.

New tests:

- `app/src/lib/commands/registry.test.ts` (15 tests) - the **registry walk guard**, written as a predicate so the same rule can be turned on a deliberately broken command: blanking a title, emptying the keywords or clearing the id each make it return `false`, which is the mutation check the walk itself cannot provide. It also asserts the roster is non-empty before walking it (the scanned-something rule), that ids are unique, that the settings roster still covers **both** catalogues, the **availability matrix** (a bare context hides every command needing a host; `run-collection` appears only with a collection open), contextual titles and their fallback, `perform` wiring against the real stores, and that `commandById` throws on an unknown id so a dead menu item cannot be silent.
- `CommandPalette.test.tsx` (+4) - finds and performs a command, finds and reveals a settings section, hides the collection command until a collection tab is active, and keeps the run dialog on screen after the pick closes the palette (revert the host to inside `CommandDialog` and that last one fails).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

`docs/app/COMPONENTS.md` in the same commit: a new **Command Registry (`lib/commands/`)** section (the two rules, the file map, the consumers), the palette section's new sources and surfaces, the fixed group order, and `WelcomeScreen`'s entry now pointing at `useNewRequest`.

## Related Issues
Closes #526

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGQg57FkBxpA5X6pLHTTeL)_