### PR TITLE
feat(app): the B2 shell - slim title row with a centered search bar, content-scoped tab strip, drawer header band

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -87,15 +87,20 @@ export const WINDOW_MIN_HEIGHT = 768;
  * **32px is the Windows standard**, and also the floor: `titleBarOverlay.height`
  * is what the OS draws its caption buttons at, and those are 46x32. Anything
  * smaller squeezes controls the platform requires to stay fully visible. The
- * 48px variant exists for a searchbox or a person-picture, neither of which
- * this bar has - tabs do not call for extra height.
+ * 48px variant exists for a searchbox or a person-picture; the row does hold a
+ * search bar now, but a 24px trigger inside a 32px row clears both by 4px, so
+ * the extra 16px would buy padding and nothing else.
  *
  * **macOS matches it.** 28px is the macOS standard for a title bar holding a
- * *title*; this one holds tabs, and the traffic lights are a fixed 12px object
- * that needs air as well. Safari and Chrome both use a taller bar for the same
- * reason. 32 gives the lights 10px above and below and keeps one number across
- * the three platforms - the map stays per-platform because the mechanism is
- * right even when the values agree.
+ * *title*; this one holds a search bar, and the traffic lights are a fixed 12px
+ * object that needs air as well. Safari and Chrome both use a taller bar for the
+ * same reason. 32 gives the lights 10px above and below and keeps one number
+ * across the three platforms - the map stays per-platform because the mechanism
+ * is right even when the values agree.
+ *
+ * The tab strip is no longer in this row - it sits in a second row over the
+ * content area, sized by `--tabstrip-height` in `src/index.css`. That token has
+ * no mirror here on purpose: nothing the main process draws is that tall.
  *
  * Linux follows Windows: Vayu draws its own decorations there, so there is no
  * system metric to match, and one fewer value to reason about is worth more
@@ -132,11 +137,12 @@ export const TRAFFIC_LIGHT_FRAME_HEIGHT = 14;
  */
 export const TRAFFIC_LIGHT_X = 20;
 /**
- * Width the renderer reserves for the cluster, so the first tab does not land
- * under it. A 20px lead plus three buttons on a 20px pitch ends at 84px; 104
- * leaves a 20px gutter. At 80 that gutter was 16px and the lights read as
- * crammed against the tab strip. Mirrored by `--traffic-light-inset` in
- * index.css and held to it by `titlebar-height.test.ts`.
+ * Width the renderer reserves for the cluster, so the title row's leading
+ * content does not land under it. A 20px lead plus three buttons on a 20px pitch
+ * ends at 84px; 104 leaves a 20px gutter. At 80 that gutter was 16px and the
+ * lights read as crammed against what followed. Mirrored by
+ * `--traffic-light-inset` in index.css and held to it by
+ * `titlebar-height.test.ts`.
  */
 export const TRAFFIC_LIGHT_INSET = 104;
 

--- a/app/src/components/layout/CommandSearchBar.tsx
+++ b/app/src/components/layout/CommandSearchBar.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The title row's search bar - the palette's visible entry point.
+ *
+ * **It is a trigger, never a second search implementation.** It looks like an
+ * input because that is what makes it findable (the owner's complaint was that
+ * nobody would ever discover ⌘K), but typing happens in the palette's own
+ * field: a real input here would mean two query states, two ranked lists and
+ * two sets of sources to keep in step, which is the defect this repo names most
+ * often. So it is a `<button>` wearing an input's clothes, and one click hands
+ * the whole job to `CommandPalette`.
+ *
+ * The chord it advertises comes from `PALETTE_CHORD`, the same constant the
+ * palette's own listener matches on - `constants/shortcuts.ts` exists so a
+ * control cannot claim a combination nothing listens for.
+ */
+
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useLayoutStore } from "@/stores";
+import { PALETTE_CHORD } from "@/constants/shortcuts";
+import { formatChord } from "@/lib/platform";
+
+export function CommandSearchBar({ className }: { className?: string }) {
+	const setPaletteOpen = useLayoutStore((s) => s.setPaletteOpen);
+
+	return (
+		<button
+			type="button"
+			onClick={() => setPaletteOpen(true)}
+			// The accessible name says what the control does; the placeholder text
+			// inside it is decoration for the eye, and a screen reader announcing
+			// "Search" twice is worse than announcing the action once.
+			aria-label="Search everything"
+			// The title row is a drag region; a control inside it has to opt out or
+			// the pointer moves the window instead of pressing the button.
+			style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+			className={cn(
+				// h-6 in a 32px row: 4px of air above and below, the same gutter the
+				// environment switcher opposite it leaves.
+				"group flex h-6 w-full items-center gap-2 rounded-md border border-input px-2",
+				// Sunken against --panel, so it reads as a field rather than as a
+				// button: the title row is the panel surface, and a control painted
+				// in the same colour as its bar has no edge to be found by.
+				"bg-background text-xs text-muted-foreground transition-colors",
+				"hover:bg-accent hover:text-foreground",
+				"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+				className
+			)}
+		>
+			<Search className="h-3.5 w-3.5 shrink-0" />
+			<span className="flex-1 truncate text-left">Search</span>
+			{/* The hint is the reason the bar earns its width: a user who learns the
+			    chord here never needs the bar again. */}
+			<kbd className="shrink-0 font-mono text-[10px] tracking-tight opacity-70">
+				{formatChord(PALETTE_CHORD)}
+			</kbd>
+		</button>
+	);
+}

--- a/app/src/components/layout/Shell.tsx
+++ b/app/src/components/layout/Shell.tsx
@@ -11,6 +11,7 @@ import { ImportModal } from "@/modules/collections/ImportModal";
 import { Drawer } from "./Drawer";
 import { Dock } from "./Dock";
 import { ContextBar } from "./ContextBar";
+import { TabStrip } from "./TabStrip";
 import RequestBuilder from "@/modules/request-builder";
 import CollectionDetail from "@/modules/collections/CollectionDetail";
 import LoadTestDashboard from "@/modules/dashboard";
@@ -187,12 +188,32 @@ export default function Shell() {
 			    content, and the request-only ContextBar. No tab type takes over
 			    the row, so the Dock's drawer switchers always have a Drawer to act
 			    on. */}
-			<div className="flex flex-1 overflow-hidden relative">
+			<div className="flex flex-1 overflow-hidden">
 				<Drawer />
-				<main className="flex-1 overflow-hidden flex flex-col min-w-0">
-					{renderTabContent(activeTab)}
-				</main>
-				<ContextBar mode={windowWidth >= 1200 ? "push" : "overlay"} />
+				{/*
+				 * The content column: tab strip on top, then main + ContextBar.
+				 *
+				 * The strip is scoped to this column rather than spanning the window
+				 * because that is the region tabs actually switch - the drawer is a
+				 * global navigator and keeps its own header band beside this row.
+				 * Its left edge therefore follows the drawer's resize handle for
+				 * free: the column is the drawer's flex sibling, so there is no
+				 * width to compute or keep in sync.
+				 *
+				 * `relative` moved down with the strip, onto the main+context row:
+				 * the ContextBar's overlay mode (<1200px) positions against its
+				 * nearest positioned ancestor, and from the outer row it would now
+				 * cover the tabs it belongs to.
+				 */}
+				<div className="flex flex-1 flex-col min-w-0 overflow-hidden">
+					<TabStrip />
+					<div className="flex flex-1 overflow-hidden relative">
+						<main className="flex-1 overflow-hidden flex flex-col min-w-0">
+							{renderTabContent(activeTab)}
+						</main>
+						<ContextBar mode={windowWidth >= 1200 ? "push" : "overlay"} />
+					</div>
+				</div>
 			</div>
 			<Dock />
 		</div>

--- a/app/src/components/layout/TabStrip.overflow.test.tsx
+++ b/app/src/components/layout/TabStrip.overflow.test.tsx
@@ -88,8 +88,22 @@ describe("tab strip width", () => {
 		 * measures is the width it already chose - a loop that collapses the strip
 		 * to a single tab no matter how wide the window is. There is no way to
 		 * observe that in jsdom, so the class itself is the assertion.
+		 *
+		 * `w-full`, not `flex-1`: the strip is a column item now (tab row over
+		 * main+context), where `flex-1` would grow it vertically and leave the
+		 * width to its content - the same loop, reintroduced by a class that
+		 * looks like the one that fixed it.
 		 */
-		expect(screen.getByRole("tablist").className).toMatch(/\bflex-1\b/);
+		expect(screen.getByRole("tablist").className).toMatch(/\bw-full\b/);
+	});
+
+	it("takes its height from the band token the drawer header shares", () => {
+		stubStripWidth(1200);
+		renderStrip();
+		// A bare h-8 here would drift from the drawer's header the moment either
+		// side changed, and the two are one band across the window: the strip's
+		// left edge is the drawer's right edge.
+		expect(screen.getByRole("tablist").className).toContain("h-[var(--tabstrip-height)]");
 	});
 
 	it("shows every tab when there is room", () => {
@@ -118,45 +132,34 @@ describe("tab strip width", () => {
 	});
 });
 
-describe("title bar drag region", () => {
+describe("drag regions", () => {
 	/*
-	 * The empty space to the right of the last tab has to move the window. It
-	 * stopped doing so when the strip gained `flex-1`: the root carried
-	 * `app-region: no-drag`, which was harmless while the element sized to its
-	 * content - the slack belonged to the draggable parent - and swallowed the
-	 * whole bar once it spanned the full width.
+	 * The strip used to live in the title bar, where the row was a drag region
+	 * and every interactive child had to opt out of it - a tab that did not was
+	 * simply unclickable, because a drag area ignores pointer events.
 	 *
-	 * So the container must NOT opt out, and every interactive child must.
+	 * It does not live there any more. Nothing in the content area drags the
+	 * window, so an `app-region` marker down here guards against a rule that no
+	 * longer reaches this subtree, and reads as though it still does. The
+	 * title-row half of the invariant - the header drags, its controls do not -
+	 * moved with the geometry to `TitleBar.search-bar.test.tsx`.
 	 */
 	const appRegion = (el: HTMLElement) =>
 		(el.style as CSSStyleDeclaration & { WebkitAppRegion?: string }).WebkitAppRegion;
 
-	it("leaves the strip itself draggable", () => {
-		stubStripWidth(2000);
-		renderStrip();
-		expect(appRegion(screen.getByRole("tablist"))).toBeFalsy();
-	});
-
-	it("opts every tab out, so tabs stay clickable", () => {
-		stubStripWidth(2000);
-		renderStrip();
-		for (const tab of screen.getAllByRole("tab")) {
-			expect(appRegion(tab)).toBe("no-drag");
-		}
-	});
-
-	it("opts the new-tab button out", () => {
-		stubStripWidth(2000);
-		renderStrip();
-		expect(appRegion(screen.getByLabelText("New tab"))).toBe("no-drag");
-	});
-
-	it("opts the overflow control out", () => {
+	it("declares no drag region on the strip or anything in it", () => {
 		stubStripWidth(320);
 		renderStrip();
 		const shown = screen.getAllByRole("tab").length;
-		expect(appRegion(screen.getByLabelText(`${TABS.length - shown} more tabs`))).toBe(
-			"no-drag"
-		);
+		// Non-empty by construction: the strip is stubbed narrow so it renders
+		// tabs *and* the overflow control, and a scan of nothing passes anything.
+		const marked = [
+			screen.getByRole("tablist"),
+			...screen.getAllByRole("tab"),
+			screen.getByLabelText("New tab"),
+			screen.getByLabelText(`${TABS.length - shown} more tabs`),
+		];
+		expect(marked.length).toBeGreaterThan(3);
+		for (const el of marked) expect(appRegion(el)).toBeFalsy();
 	});
 });

--- a/app/src/components/layout/TabStrip.tsx
+++ b/app/src/components/layout/TabStrip.tsx
@@ -8,8 +8,11 @@
 /**
  * TabStrip Component
  *
- * The horizontal row of open tabs rendered in the title bar. Reads from
- * tabs-store; one TabItem per open tab plus a "+" button that opens a
+ * The horizontal row of open tabs, rendered over the content area - main plus
+ * the context bar - with the drawer to its left. It sits there rather than
+ * across the window because that is the region tabs actually switch: the drawer
+ * is a global navigator and keeps its own header band beside this row. Reads
+ * from tabs-store; one TabItem per open tab plus a "+" button that opens a
  * welcome tab. No unsaved-dot - autosave is the safety net.
  *
  * **A tab is as wide as its own name, and the strip overflows rather than
@@ -80,8 +83,7 @@ function TabItem({
 			tabIndex={rovingTabIndex}
 			data-tab-id={tab.id}
 			title={descriptor.title}
-			// Opts out of the title bar's drag region so the tab is clickable.
-			style={{ width, minWidth: width, WebkitAppRegion: "no-drag" } as React.CSSProperties}
+			style={{ width, minWidth: width }}
 			onClick={() => focusTab(tab.id)}
 			onKeyDown={(e) => {
 				if (e.key === "Enter" || e.key === " ") {
@@ -230,26 +232,25 @@ export function TabStrip() {
 			role="tablist"
 			onKeyDown={onKeyDown}
 			/*
-			 * `flex-1` is load-bearing, not cosmetic. The strip is a flex item, so
-			 * without it it sizes to its own content - and since it measures its own
-			 * clientWidth to decide how many tabs fit, that is a feedback loop:
+			 * `w-full` is load-bearing, not cosmetic - it is the `flex-1` this
+			 * carried while the strip was a row item in the title bar, restated for
+			 * a column. Sized to its own content, the strip measures its own
+			 * clientWidth to decide how many tabs fit, which is a feedback loop:
 			 * measure the tabs, trim to fit "the space", the content shrinks, trim
 			 * again. It settled on a single tab with everything else in the overflow
 			 * menu regardless of how wide the window was. It has to be told to fill
 			 * the parent so the measurement is of available space, not of itself.
-			 */
-			className="panel-clip flex h-full min-w-0 flex-1 items-stretch overflow-hidden"
-			/*
-			 * No `app-region` here on purpose - the root inherits `drag` from the
-			 * wrapper in TitleBar, and each interactive child opts out individually
-			 * below.
 			 *
-			 * It used to be `no-drag` on this element, which was harmless only while
-			 * the strip sized to its content: the slack to the right of the last tab
-			 * belonged to the parent and stayed draggable. `flex-1` (needed so the
-			 * strip measures available space rather than its own tabs) made this
-			 * element span that slack, so the whole area stopped moving the window.
+			 * The strip owns its height, from the token the drawer's header band
+			 * reads too - the two are one band across the window, and a step in it
+			 * is what a second literal would produce.
+			 *
+			 * No `app-region` anywhere in this file any more. It used to live in the
+			 * title bar, where the row was a drag region and every interactive child
+			 * had to opt out; down here nothing drags the window, so the opt-outs
+			 * were guarding against a rule that no longer applies to this subtree.
 			 */
+			className="panel-clip flex h-[var(--tabstrip-height)] w-full shrink-0 items-stretch overflow-hidden border-b border-border bg-panel"
 		>
 			{visible.map((i) => (
 				<TabItem
@@ -271,7 +272,6 @@ export function TabStrip() {
 					<DropdownMenuTrigger asChild>
 						<button
 							className="flex shrink-0 items-center gap-1 border-l border-border/40 px-2 text-xs font-mono text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-							style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
 							aria-label={`${overflowed.length} more tabs`}
 						>
 							+{overflowed.length}
@@ -311,12 +311,7 @@ export function TabStrip() {
 			<button
 				onClick={() => openTab({ type: "welcome", entityId: null })}
 				aria-label="New tab"
-				style={
-					{
-						width: TAB_NEW_BUTTON_WIDTH,
-						WebkitAppRegion: "no-drag",
-					} as React.CSSProperties
-				}
+				style={{ width: TAB_NEW_BUTTON_WIDTH }}
 				className="flex shrink-0 items-center justify-center text-muted-foreground hover:bg-muted/50 hover:text-foreground"
 			>
 				<Plus className="w-3.5 h-3.5" />

--- a/app/src/components/layout/TitleBar.search-bar.test.tsx
+++ b/app/src/components/layout/TitleBar.search-bar.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The title row: what it holds now, and what still has to drag the window.
+ *
+ * The row lost the tab strip and gained the search bar. Two things follow that
+ * a rendered test can hold:
+ *
+ * - **The bar advertises the chord the palette listens for.** `shortcuts.ts`
+ *   exists so a control cannot claim a combination nothing handles; the bar
+ *   reads `PALETTE_CHORD`, the same constant `CommandPalette` matches on, and
+ *   clicking it opens the palette through the store rather than through a
+ *   second search implementation of its own.
+ * - **The row drags and its controls do not.** A `-webkit-app-region: drag`
+ *   area ignores pointer events entirely, so a control that forgets to opt out
+ *   is not merely awkward - it is dead. That invariant used to be asserted in
+ *   `TabStrip.overflow.test.tsx`, because the strip was the row's big
+ *   interactive child; it moved here with the geometry.
+ *
+ * The platform flags are module-level constants read at import time, so the
+ * platform is stubbed *before* the import - the same dynamic-import shape
+ * `app-icon-system-menu.test.tsx` uses, and for the same reason.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PALETTE_CHORD } from "@/constants/shortcuts";
+import { formatChord } from "@/lib/platform";
+
+vi.mock("@/queries", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/queries")>()),
+	useEnvironmentsQuery: () => ({ data: [] }),
+}));
+
+/**
+ * `-webkit-app-region` is not on CSSStyleDeclaration in TypeScript's DOM lib,
+ * and jsdom keeps it as a style property without serialising it into the style
+ * attribute - so it is read as a property, never matched as markup.
+ */
+const appRegion = (el: HTMLElement) =>
+	(el.style as CSSStyleDeclaration & { WebkitAppRegion?: string }).WebkitAppRegion;
+
+/**
+ * What the compositor would use for an element: its own declaration, or the
+ * nearest ancestor's. A control is safe if *either* it opts out or the cluster
+ * around it did - asserting only the element itself would fail the correct
+ * markup.
+ */
+function effectiveRegion(el: HTMLElement | null): string | undefined {
+	for (let node = el; node; node = node.parentElement) {
+		const region = appRegion(node);
+		if (region) return region;
+	}
+	return undefined;
+}
+
+function stubPlatform(platform: string | null) {
+	Object.defineProperty(window, "electronAPI", {
+		value:
+			platform === null
+				? undefined
+				: {
+						platform,
+						windowIsMaximized: () => Promise.resolve(false),
+						onWindowMaximized: () => () => {},
+						windowMinimize: () => {},
+						windowMaximize: () => {},
+						windowClose: () => {},
+					},
+		writable: true,
+		configurable: true,
+	});
+}
+
+/**
+ * Fresh module graph, so the platform flags are recomputed against the stub.
+ *
+ * The store comes back with it: `resetModules` gives the re-imported TitleBar a
+ * *new* `@/stores` instance, so a store imported at the top of this file is not
+ * the one the rendered bar writes to - it would sit at `false` for ever while
+ * the click worked perfectly.
+ */
+async function renderFor(platform: string | null) {
+	stubPlatform(platform);
+	vi.resetModules();
+	const [{ default: TitleBar }, { useLayoutStore }] = await Promise.all([
+		import("./TitleBar"),
+		import("@/stores"),
+	]);
+	useLayoutStore.setState({ paletteOpen: false });
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return {
+		...render(
+			<QueryClientProvider client={client}>
+				<TitleBar />
+			</QueryClientProvider>
+		),
+		useLayoutStore,
+	};
+}
+
+const searchBar = () => screen.getByRole("button", { name: /search everything/i });
+
+beforeEach(cleanup);
+afterEach(() => vi.resetModules());
+
+describe("title-row search bar", () => {
+	it("shows a search bar carrying the palette's own chord", async () => {
+		await renderFor("linux");
+		expect(searchBar()).toHaveTextContent("Search");
+		// The rendered hint, not the constant: a bar showing "⌘P" while the
+		// handler matches ⌘K is precisely what shortcuts.ts was written to stop.
+		expect(searchBar()).toHaveTextContent(formatChord(PALETTE_CHORD));
+	});
+
+	it("opens the palette when clicked, and does not search on its own", async () => {
+		const { useLayoutStore } = await renderFor("linux");
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
+		fireEvent.click(searchBar());
+		expect(useLayoutStore.getState().paletteOpen).toBe(true);
+		// It is a trigger. A real input here would be a second query state and a
+		// second ranked list to keep in step with the palette's.
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+	});
+
+	it("centres the bar on the window rather than on the space left over", async () => {
+		await renderFor("linux");
+		// Equal side columns are the only way to centre on the window when the
+		// two clusters are different widths - with flex spacers the bar drifts by
+		// half the difference, and drifts again whenever the environment name
+		// changes length.
+		expect(screen.getByRole("banner").className).toContain("grid-cols-[1fr_auto_1fr]");
+	});
+
+	it("is present on every platform that draws the row", async () => {
+		// Not "on this machine": the row's contents differ per platform (traffic
+		// lights, native overlay, HTML buttons) and the bar must survive all three.
+		for (const platform of ["darwin", "win32", "linux"]) {
+			await renderFor(platform);
+			expect(searchBar(), `missing on ${platform}`).toBeInTheDocument();
+			cleanup();
+		}
+	});
+
+	it("draws nothing at all outside Electron, where there is no chrome to draw", async () => {
+		const { container } = await renderFor(null);
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+
+describe("title-row drag regions", () => {
+	it("drags by the row and not by its controls", async () => {
+		// Linux, because it is the platform that draws its own window buttons in
+		// HTML - the largest opted-out cluster, and the one a regression would
+		// make unclickable rather than merely awkward.
+		await renderFor("linux");
+		expect(appRegion(screen.getByRole("banner"))).toBe("drag");
+
+		const controls = [
+			searchBar(),
+			screen.getByRole("button", { name: /switch environment/i }),
+			screen.getByRole("button", { name: /minimize/i }),
+			screen.getByRole("button", { name: /close/i }),
+		];
+		// A loop over an empty list passes every assertion inside it.
+		expect(controls).toHaveLength(4);
+		for (const el of controls) {
+			expect(
+				effectiveRegion(el),
+				`${el.getAttribute("aria-label")} is inside the drag region`
+			).toBe("no-drag");
+		}
+	});
+});

--- a/app/src/components/layout/TitleBar.tsx
+++ b/app/src/components/layout/TitleBar.tsx
@@ -8,11 +8,18 @@
 /**
  * Custom TitleBar Component
  *
+ * The window's own row: app identity, the search bar, the environment switcher
+ * and the window controls. The document tabs are *not* here - they moved to a
+ * second row scoped to the content area (`Shell`), because this row could not
+ * hold both. Tabs are content-width and overflow into a dropdown, so every
+ * pixel another control took converted directly into overflowed tabs, and a
+ * real search bar is worth ~360 of them.
+ *
  * Height comes from --titlebar-height, not a bare h-[38px], because the toast
  * viewport subtracts it when the stack is anchored to the top of the window.
  * The value must still match TITLEBAR_HEIGHT in electron/constants.ts, which
  * sizes the real window frame and cannot read a CSS variable.
- * macOS: traffic lights inset (~80px), no HTML controls
+ * macOS: traffic lights inset (~104px), no HTML controls
  * Windows: native overlay handles controls - no HTML buttons
  * Linux: custom HTML min/max/close buttons
  */
@@ -28,7 +35,7 @@ import {
 	DropdownMenuItem,
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
-import { TabStrip } from "./TabStrip";
+import { CommandSearchBar } from "./CommandSearchBar";
 import iconUrl from "@shared/icon_png/vayu_icon_256x256.png";
 
 const isElectron = !!window.electronAPI;
@@ -264,33 +271,37 @@ export default function TitleBar() {
 	return (
 		// <header>: the app's banner region, so it is reachable as a landmark
 		// rather than being an unnamed div in the accessibility tree.
+		//
+		// A 3-column grid rather than flex-with-spacers: the search bar is centred
+		// on the *window*, which is what "command center" means in every app that
+		// has one, and equal 1fr side columns are the only way to get that when the
+		// two clusters are different widths. Both sides carry `min-w-0` so a long
+		// environment name truncates instead of pushing the bar off centre.
 		<header
-			className="titlebar h-[var(--titlebar-height)] flex items-center bg-panel border-b border-border shrink-0 select-none"
+			className="titlebar h-[var(--titlebar-height)] grid grid-cols-[1fr_auto_1fr] items-center bg-panel border-b border-border shrink-0 select-none"
 			style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
 		>
-			{/* macOS: space for native traffic lights */}
-			{/* Reserved for the traffic lights; the width is a token so it cannot
-			    drift from the position Electron gives them. */}
-			{isMac && <div className="shrink-0 w-[var(--traffic-light-inset)]" />}
+			<div className="flex min-w-0 items-center h-full">
+				{/* macOS: space for native traffic lights */}
+				{/* Reserved for the traffic lights; the width is a token so it cannot
+				    drift from the position Electron gives them. */}
+				{isMac && <div className="shrink-0 w-[var(--traffic-light-inset)]" />}
 
-			{/* Logo - all platforms. The icon is imported as a module, not referenced
-			    as "/icon.png": `base: "./"` means a root-absolute path does not
-			    resolve under the packaged file:// build. */}
-			<AppIcon />
-
-			{/* TabStrip - fills available width. This wrapper stays a drag region so
-			    the empty space to the right of the last tab moves the window on every
-			    platform; TabStrip marks its own tab row `no-drag`. */}
-			<div
-				className="flex-1 flex overflow-hidden h-full"
-				style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-			>
-				<TabStrip />
+				{/* Logo - Windows only (it is the system-menu control there). The icon
+				    is imported as a module, not referenced as "/icon.png": `base: "./"`
+				    means a root-absolute path does not resolve under the packaged
+				    file:// build. */}
+				<AppIcon />
 			</div>
+
+			{/* The palette's entry point. Bounded rather than fluid: a search field
+			    the width of the window reads as a document title, and the row's whole
+			    remaining area stays draggable. */}
+			<CommandSearchBar className="w-[min(44vw,28rem)]" />
 
 			{/* Right controls */}
 			<div
-				className="flex items-center gap-2 px-3 shrink-0"
+				className="flex min-w-0 items-center justify-end gap-2 px-3 h-full"
 				style={
 					{
 						WebkitAppRegion: "no-drag",

--- a/app/src/components/layout/app-icon-system-menu.test.tsx
+++ b/app/src/components/layout/app-icon-system-menu.test.tsx
@@ -28,8 +28,9 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-// Spread the real module: TitleBar's subtree (TabStrip) reaches for several
-// queries, and listing them by hand breaks whenever that changes.
+// Spread the real module: the environment switcher reaches for more than the
+// one query stubbed here, and listing them by hand breaks whenever that
+// changes.
 vi.mock("@/queries", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@/queries")>()),
 	useEnvironmentsQuery: () => ({ data: [] }),
@@ -70,8 +71,8 @@ async function renderFor(platform: string) {
 	renderTitleBar(TitleBar);
 }
 
-/** TabStrip resolves every tab's label through `useQueries`, so the title bar
- *  needs a client even when the test is about the icon or the env switcher. */
+/** The environment switcher's mutation runs through react-query, so the title
+ *  bar needs a client even when the test is about the icon. */
 function renderTitleBar(TitleBar: () => React.ReactNode) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(

--- a/app/src/components/layout/shell-tab-identity.test.tsx
+++ b/app/src/components/layout/shell-tab-identity.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Moving the tab strip into the content column must not remount tab content.
+ *
+ * The strip now lives in a column over main + context, with the drawer as that
+ * column's flex sibling - which means drawer state (open, width) is upstream of
+ * the element tree the active tab renders into. That is exactly the shape where
+ * a plausible-looking `key={drawerOpen}` or a wrapper mounted only when the
+ * drawer is closed throws away everything React was holding for the tab: an
+ * unsaved request body, a scroll position, a Monaco model. The GraphQL body's
+ * keyed-siblings lesson is the same defect one layer down.
+ *
+ * So the assertion is on identity, not on markup: the same DOM node, and the
+ * component state living in it, have to survive collapsing and resizing the
+ * drawer. A stateful stub stands in for the request builder - it is what the
+ * real editor would be losing.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useState } from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import Shell from "./Shell";
+import { useTabsStore, useLayoutStore } from "@/stores";
+
+vi.mock("./Drawer", () => ({
+	Drawer: () => <div data-testid="drawer" />,
+}));
+vi.mock("./Dock", () => ({ Dock: () => <div data-testid="dock" /> }));
+vi.mock("./ContextBar", () => ({ ContextBar: () => <div data-testid="context-bar" /> }));
+vi.mock("@/modules/collections/ImportModal", () => ({
+	ImportModal: () => <div data-testid="import-modal" />,
+}));
+vi.mock("@/modules/collections/CollectionDetail", () => ({ default: () => null }));
+vi.mock("@/modules/dashboard", () => ({ default: () => null }));
+vi.mock("@/modules/history/main", () => ({ HistoryDetail: () => null }));
+vi.mock("@/modules/welcome/WelcomeScreen", () => ({ default: () => null }));
+vi.mock("@/modules/settings", () => ({ SettingsMain: () => null }));
+vi.mock("@/modules/variables/main/VariablesMain", () => ({ default: () => null }));
+
+/** Stands in for the request builder, holding the state an unsaved body is. */
+vi.mock("@/modules/request-builder", () => ({
+	default: function DraftEditor() {
+		const [body, setBody] = useState("");
+		return (
+			<input
+				data-testid="draft"
+				aria-label="body"
+				value={body}
+				onChange={(e) => setBody(e.target.value)}
+			/>
+		);
+	},
+}));
+
+function renderShell() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<Shell />
+		</QueryClientProvider>
+	);
+}
+
+describe("tab content identity across the drawer", () => {
+	beforeEach(() => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+		});
+		useLayoutStore.setState({ drawerOpen: true, drawerWidth: 260 });
+	});
+
+	it("survives the drawer collapsing, reopening and resizing", () => {
+		renderShell();
+		const draft = screen.getByTestId("draft");
+		fireEvent.change(draft, { target: { value: '{"unsaved": true}' } });
+
+		act(() => useLayoutStore.getState().setDrawerOpen(false));
+		act(() => useLayoutStore.getState().setDrawerOpen(true));
+		act(() => useLayoutStore.getState().setDrawerWidth(400));
+
+		// The same node, not merely an equivalent one: a remount would produce a
+		// fresh element with a fresh useState, and the value is what proves the
+		// difference matters.
+		expect(screen.getByTestId("draft")).toBe(draft);
+		expect(screen.getByTestId("draft")).toHaveValue('{"unsaved": true}');
+	});
+
+	it("puts the tab strip inside the column the drawer sits beside", () => {
+		// The geometry claim itself: the strip is a *sibling of main*, under the
+		// same column, rather than a row spanning the window. Anything else and
+		// its left edge stops tracking the drawer's resize handle.
+		renderShell();
+		const strip = screen.getByRole("tablist");
+		const main = screen.getByRole("main");
+		expect(strip.parentElement).toBe(main.parentElement?.parentElement);
+		expect(strip.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+});

--- a/app/src/components/shared/DrawerPanel.test.tsx
+++ b/app/src/components/shared/DrawerPanel.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The drawer's header band - the left half of the second chrome row.
+ *
+ * The tab strip sits over the content area with the drawer beside it, so the
+ * panel's header and the strip meet at the resize handle and read as one band
+ * across the window. That only holds while both take their height from
+ * `--tabstrip-height`: an `h-10` here (what this was, back when the strip was
+ * up in the title bar and the two never met) puts an 8px step in the rule.
+ *
+ * Rendered rather than source-scanned - the class list goes through `cn()`, and
+ * a scan cannot see what tailwind-merge does to it.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { DrawerPanel } from "./DrawerPanel";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = join(here, "..", "..");
+
+/** The four drawer views, and the file each one's panel is declared in. */
+const VIEWS = {
+	collections: join(src, "modules", "collections", "CollectionTree.tsx"),
+	history: join(src, "modules", "history", "sidebar", "HistoryList.tsx"),
+	variables: join(src, "modules", "variables", "sidebar", "VariablesCategoryTree.tsx"),
+	settings: join(src, "modules", "settings", "sidebar", "SettingsCategoryTree.tsx"),
+} as const;
+
+describe("drawer header band", () => {
+	afterEach(cleanup);
+
+	it("sizes the header to the band token, not to a literal", () => {
+		render(
+			<DrawerPanel title="Collections">
+				<div />
+			</DrawerPanel>
+		);
+		const header = screen.getByRole("heading", { name: "Collections" }).parentElement!;
+		expect(header.className).toContain("h-[var(--tabstrip-height)]");
+		// The rule that continues across the resize handle into the tab strip.
+		expect(header.className).toContain("border-b");
+	});
+
+	it("keeps the tools slot beside the title, and optional", () => {
+		const { rerender } = render(
+			<DrawerPanel title="History" actions={<button>Pin</button>}>
+				<div />
+			</DrawerPanel>
+		);
+		expect(screen.getByRole("button", { name: "Pin" })).toBeInTheDocument();
+		rerender(
+			<DrawerPanel title="History">
+				<div />
+			</DrawerPanel>
+		);
+		// Titled always, tooled sometimes: a view with no tools must not lose the
+		// band, or switching views moves the content's vertical start again.
+		expect(screen.getByRole("heading", { name: "History" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Pin" })).not.toBeInTheDocument();
+	});
+
+	it("is what every drawer view renders its own header through", () => {
+		// Source-scanned deliberately: the alternative is mounting four trees that
+		// each fetch, and the claim here is only "no view hand-rolls a header",
+		// which is a fact about the imports. Each file is checked non-empty first
+		// - a scan of nothing satisfies every assertion made of it.
+		for (const [view, path] of Object.entries(VIEWS)) {
+			const source = readFileSync(path, "utf8");
+			expect(source.length, `${view} source`).toBeGreaterThan(500);
+			expect(source, `${view} must render a DrawerPanel`).toContain("<DrawerPanel");
+			expect(source, `${view} must title its band`).toMatch(
+				/<DrawerPanel[\s\S]{0,200}title=/
+			);
+		}
+	});
+});

--- a/app/src/components/shared/DrawerPanel.tsx
+++ b/app/src/components/shared/DrawerPanel.tsx
@@ -19,6 +19,13 @@
  * The frame owns the header padding; the body is deliberately flush so rows can
  * run edge to edge - the sidebar convention, and it buys back the ~32px of row
  * width the old inset cost. Rows supply their own internal padding.
+ *
+ * **The header is the drawer's half of the second chrome row.** It sizes to
+ * `--tabstrip-height` and carries the same bottom rule as the tab strip on the
+ * other side of the resize handle, so the two read as one band across the
+ * window rather than as two headers that happen to be adjacent. That is the
+ * only reason the height is a token here and not an `h-8`: the strip has to
+ * agree with it, and the two files cannot see each other.
  */
 
 import { cn } from "@/lib/utils";
@@ -35,9 +42,9 @@ interface DrawerPanelProps {
 export function DrawerPanel({ title, actions, children, className }: DrawerPanelProps) {
 	return (
 		<div className={cn("flex h-full w-full flex-col", className)}>
-			{/* Header is the only padded region; h-10 keeps the body starting at the
-			    same offset in every view. */}
-			<div className="flex h-10 shrink-0 items-center justify-between gap-2 px-3">
+			{/* Header is the only padded region; one height for every view keeps the
+			    body starting at the same offset whichever view is showing. */}
+			<div className="flex h-[var(--tabstrip-height)] shrink-0 items-center justify-between gap-2 border-b border-border px-3">
 				<h2 className="truncate text-sm font-semibold text-foreground">{title}</h2>
 				{actions && <div className="flex shrink-0 items-center gap-1">{actions}</div>}
 			</div>

--- a/app/src/components/ui/toast-position.test.tsx
+++ b/app/src/components/ui/toast-position.test.tsx
@@ -40,6 +40,7 @@ const src = join(here, "..", "..");
 const css = readFileSync(join(src, "index.css"), "utf8");
 const dock = readFileSync(join(src, "components", "layout", "Dock.tsx"), "utf8");
 const titleBar = readFileSync(join(src, "components", "layout", "TitleBar.tsx"), "utf8");
+const tabStrip = readFileSync(join(src, "components", "layout", "TabStrip.tsx"), "utf8");
 const electronConstants = readFileSync(join(src, "..", "electron", "constants.ts"), "utf8");
 
 describe("toast stack position", () => {
@@ -50,6 +51,7 @@ describe("toast stack position", () => {
 		expect(css.length).toBeGreaterThan(1000);
 		expect(dock.length).toBeGreaterThan(1000);
 		expect(titleBar.length).toBeGreaterThan(1000);
+		expect(tabStrip.length).toBeGreaterThan(1000);
 		expect(electronConstants.length).toBeGreaterThan(500);
 	});
 
@@ -78,10 +80,18 @@ describe("toast stack position", () => {
 		// The whole point of making position configurable is that there is no
 		// longer a single corner to check. A new entry reaching for `bottom-4`
 		// reintroduces exactly the bug this file was opened for.
+		//
+		// The top edge is two bands, not one: the title row, and the tab strip
+		// beside the drawer's header band under it. Clearing only the first put
+		// the stack back on the chrome - the same defect, 32px lower.
 		expect(TOAST_POSITIONS.length).toBeGreaterThan(1);
 		for (const p of TOAST_POSITIONS) {
-			const edge = p.value.startsWith("bottom") ? "--dock-height" : "--titlebar-height";
-			expect(p.className, `${p.value} must offset by ${edge}`).toContain(`var(${edge})`);
+			const edges = p.value.startsWith("bottom")
+				? ["--dock-height"]
+				: ["--titlebar-height", "--tabstrip-height"];
+			for (const edge of edges) {
+				expect(p.className, `${p.value} must offset by ${edge}`).toContain(`var(${edge})`);
+			}
 			expect(p.className, `${p.value} uses a bare offset`).not.toMatch(/\b(bottom|top)-\d/);
 		}
 	});
@@ -117,8 +127,14 @@ describe("toast stack position", () => {
 
 	it("keeps the title bar's own height on the same token", () => {
 		// Same drift risk as the Dock: a bare h-[38px] here and a top-anchored
-		// stack would keep offsetting by a value the strip no longer has.
+		// stack would keep offsetting by a value the row no longer has.
 		expect(titleBar).toContain("h-[var(--titlebar-height)]");
+	});
+
+	it("keeps the tab strip's own height on the token the toasts subtract", () => {
+		// The second band the top offset clears. A bare h-8 in the strip and the
+		// stack drifts onto it the moment either number moves.
+		expect(tabStrip).toContain("h-[var(--tabstrip-height)]");
 	});
 
 	it("keeps the Dock's own height on the same token", () => {

--- a/app/src/constants/layout.ts
+++ b/app/src/constants/layout.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CONTEXT_BAR_WIDTH = 252;
  */
 export const INDENT_STEP = 12;
 
-/* ── Document tab strip (TitleBar) ───────────────────────────────────────── */
+/* ── Document tab strip (over the content column) ────────────────────────── */
 
 /**
  * A document tab sizes to its own name, between these bounds, and the strip

--- a/app/src/constants/toast.ts
+++ b/app/src/constants/toast.ts
@@ -46,8 +46,9 @@ export type ToastPosition =
  * because the offsets are not interchangeable: the viewport is `position:
  * fixed`, so it anchors to the window and not to the layout, and both the top
  * and bottom edges of the window are occupied by app chrome. A bottom position
- * has to clear the Dock and a top position has to clear the title bar, so each
- * edge carries its own token - never a round number. See
+ * has to clear the Dock and a top position has to clear the title row *and* the
+ * tab strip under it, so each edge carries its own tokens - never a round
+ * number. See
  * `toast-position.test.tsx`, which exists because a plain `bottom-4` once put
  * the stack on top of the Dock.
  *
@@ -62,7 +63,14 @@ export interface ToastPositionOption extends LabeledOption<ToastPosition> {
 }
 
 const BOTTOM = "bottom-[calc(var(--dock-height)+1rem)]";
-const TOP = "top-[calc(var(--titlebar-height)+1rem)]";
+/*
+ * Both chrome rows, not just the title bar. The top of the window is two bands
+ * now - the title row, and the tab strip beside the drawer's header - and a
+ * stack that cleared only the first landed on whichever of the two was under
+ * it. Every top position crosses at least one of them: left over the drawer
+ * band, centre and right over the tabs.
+ */
+const TOP = "top-[calc(var(--titlebar-height)+var(--tabstrip-height)+1rem)]";
 
 /*
  * Order matters: this array is rendered straight into a 3-column grid, so the

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -385,11 +385,11 @@
 		--dock-height: 2rem;
 
 		/*
-		 * Height of the TitleBar, the strip holding the document tabs.
+		 * Height of the TitleBar, the window row holding the search bar.
 		 *
 		 * Same reason as --dock-height, at the other edge. The toast stack can
 		 * now be anchored to the top of the window, and `position: fixed` means
-		 * it would sit on top of the tab strip unless it subtracts this. Two
+		 * it would sit on top of the title row unless it subtracts this. Two
 		 * files had the 38px independently - TitleBar.tsx and TITLEBAR_HEIGHT in
 		 * electron/constants.ts - and the toast viewport would have been a third.
 		 * Theme-independent, so declared once.
@@ -399,6 +399,23 @@
 		 * and `toast-position.test.tsx` holds the two together.
 		 */
 		--titlebar-height: 32px;
+
+		/*
+		 * Height of the second chrome row: the tab strip over the content area,
+		 * and the drawer's header band beside it.
+		 *
+		 * One token for both because they are one band - the strip's left edge
+		 * is the drawer's right edge, so a drawer header of a different height
+		 * puts a visible step in the rule that runs across the window. It is
+		 * also the third thing a top-anchored toast has to clear, after the
+		 * title row (see --titlebar-height and constants/toast.ts).
+		 *
+		 * No mirror in electron/constants.ts, unlike the title row above - nothing
+		 * the main process draws is this tall. The frame, the Windows caption
+		 * overlay and the macOS traffic lights all size to the title row alone,
+		 * so a constant there would have no reader.
+		 */
+		--tabstrip-height: 32px;
 	}
 
 	/*
@@ -421,10 +438,10 @@
 		 * platforms diverge again. */
 		--titlebar-height: 32px;
 		/*
-		 * Width reserved for the traffic lights, so the first tab does not sit
-		 * under them. A 20px lead plus three 12px buttons on a 20px pitch ends at
-		 * 84px; 104 leaves a 20px gutter before the first tab. At 80 it was 16px,
-		 * which read as the lights being crammed against the tab strip. Mirrors TRAFFIC_LIGHT_INSET in
+		 * Width reserved for the traffic lights, so the title row's leading
+		 * content does not sit under them. A 20px lead plus three 12px buttons on
+		 * a 20px pitch ends at 84px; 104 leaves a 20px gutter after the cluster.
+		 * At 80 it was 16px, which read as crammed. Mirrors TRAFFIC_LIGHT_INSET in
 		 * electron/constants.ts, which positions the buttons themselves -
 		 * titlebar-height.test.ts holds the two together.
 		 */

--- a/app/src/modules/collections/CollectionTree.tsx
+++ b/app/src/modules/collections/CollectionTree.tsx
@@ -147,6 +147,10 @@ export default function CollectionTree() {
 	return (
 		<DrawerPanel
 			title="Collections"
+			// h-7, not h-8: the header is the drawer's half of the 32px chrome
+			// band now (it was a 40px header while the tab strip was up in the
+			// title bar), and a 32px control in it fills the band edge to edge -
+			// the hover fill lands on the rule underneath.
 			actions={
 				<>
 					{/* No TooltipProvider - a bare nested one would reset this
@@ -158,7 +162,7 @@ export default function CollectionTree() {
 								size="icon"
 								onClick={panel.openNewCollectionForm}
 								disabled={panel.isCreatingCollection}
-								className="h-8 w-8"
+								className="h-7 w-7"
 								aria-label="Add collection"
 							>
 								{panel.isCreatingCollection ? (
@@ -177,7 +181,7 @@ export default function CollectionTree() {
 								size="icon"
 								onClick={panel.createRequestFromToolbar}
 								disabled={panel.isCreatingRequest}
-								className="h-8 w-8"
+								className="h-7 w-7"
 								aria-label="Add request"
 							>
 								{panel.isCreatingRequest ? (
@@ -199,7 +203,7 @@ export default function CollectionTree() {
 								variant="ghost"
 								size="icon"
 								onClick={openImport}
-								className="h-8 w-8"
+								className="h-7 w-7"
 								aria-label="Import collection"
 							>
 								<Download className="w-4 h-4" />

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -53,8 +53,8 @@ export function CommandPalette() {
 	 * last moment the previous focus still exists.
 	 *
 	 * It also catches every opener, not just the chord: the welcome Launcher's
-	 * Search tile and (later) the title bar's search bar both flip this flag
-	 * through the store.
+	 * Search tile and the title bar's search bar both flip this flag through the
+	 * store.
 	 */
 	useEffect(
 		() =>

--- a/app/src/titlebar-height.test.ts
+++ b/app/src/titlebar-height.test.ts
@@ -27,6 +27,14 @@
  * pre-paint window background before any stylesheet exists, so it has to name
  * them; they had drifted to `#f2f0eb`, a warm cream from a palette two
  * revisions old, against a `--panel` of `#fafafa`.
+ *
+ * The second chrome row - `--tabstrip-height`, shared by the tab strip and the
+ * drawer's header band - is held here too, for the third variant of the same
+ * problem: those two files cannot import each other either, and they meet at
+ * the drawer's resize handle where a disagreement is a visible step. It has no
+ * Electron mirror, and that absence is asserted rather than left to be noticed:
+ * nothing the main process draws is that tall, so a constant there would be one
+ * more value written and never read.
  */
 
 import { describe, it, expect } from "vitest";
@@ -119,6 +127,38 @@ describe("title bar height", () => {
 		// x clears the window's rounded top corner (~10-12px). At 12 the close
 		// button sat inside the curve, which no amount of vertical centring fixes.
 		expect(num("TRAFFIC_LIGHT_X")).toBeGreaterThanOrEqual(20);
+	});
+
+	it("declares the tab-strip band once, theme- and platform-independently", () => {
+		// The second chrome row: the tab strip over the content area and the
+		// drawer's header band beside it. One declaration, because the two halves
+		// meet at the drawer's resize handle and a second value is a visible step
+		// in the rule that runs across the window.
+		const declarations = [...css.matchAll(/--tabstrip-height:\s*(\d+px)\s*;/g)].map(
+			(m) => m[1]
+		);
+		expect(declarations).toEqual(["32px"]);
+		// Unlike --titlebar-height, deliberately *not* mirrored in
+		// electron/constants.ts: the frame, the Windows caption overlay and the
+		// traffic lights all size to the title row alone, so a constant there
+		// would have no reader - the defect this repo has found nine times.
+		expect(constants).not.toContain("TABSTRIP_HEIGHT");
+	});
+
+	it("keeps both halves of the band on that one token", () => {
+		const tabStrip = readFileSync(join(here, "components", "layout", "TabStrip.tsx"), "utf8");
+		const drawerPanel = readFileSync(
+			join(here, "components", "shared", "DrawerPanel.tsx"),
+			"utf8"
+		);
+		// Non-empty first: a scan of nothing satisfies every assertion made of it.
+		expect(tabStrip.length).toBeGreaterThan(1000);
+		expect(drawerPanel.length).toBeGreaterThan(500);
+		// The frame's header was `h-10` while the strip was in the title bar and
+		// the two never met. They meet now.
+		expect(tabStrip).toContain("h-[var(--tabstrip-height)]");
+		expect(drawerPanel).toContain("h-[var(--tabstrip-height)]");
+		expect(drawerPanel).not.toMatch(/className="flex h-10\b/);
 	});
 
 	it("reserves the same inset in both files", () => {

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -13,9 +13,9 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
 
 ```
 <App />                                  // App.tsx - mounts providers, kicks off health/prefetch queries, OS theme sync
-├── <TitleBar />                         // components/layout/TitleBar.tsx - h-[38px] drag region + logo + tabs + env pill
-│   ├── Logo (all platforms)
-│   ├── <TabStrip />                     // Open tabs + "+" button
+├── <TitleBar />                         // components/layout/TitleBar.tsx - --titlebar-height drag region: icon + centered search bar + env pill
+│   ├── AppIcon (Windows only - the system-menu control)
+│   ├── <CommandSearchBar />             // Input-shaped trigger for the ⌘K palette; never its own search
 │   └── EnvPill + WindowControls (Linux only; Windows native overlay; macOS traffic lights)
 ├── <UpdateBanner />
 └── <Shell />                            // components/layout/Shell.tsx - tab-centric layout with drawer + context bar
@@ -26,6 +26,7 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
     │   ├── <HistoryList />              //   history view
     │   ├── <VariablesCategoryTree />    //   variables view
     │   └── <SettingsCategoryTree />     //   settings view
+    ├── <TabStrip />                     // Open tabs + "+" button - over main+context, left edge = drawer edge
     ├── main content (switched on active tab type)
     │   ├── <WelcomeScreen />            // type="welcome"     modules/welcome/
     │   ├── <RequestBuilder />           // type="request"     modules/request-builder/
@@ -45,22 +46,43 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
 
 Root component. Renders `<TitleBar />` over `<Shell />`. On mount it wires up app-wide concerns via hooks/queries: OS/Electron theme sync (`useElectronTheme`), engine health polling (`useHealthQuery`), and prefetching of server state (`usePrefetchCollectionsAndRequests`, `useRunsQuery`, `useScriptCompletionsQuery`).
 
+### The two chrome rows
+
+Top chrome is 32px + 32px, and the split is what makes both halves work:
+
+```
+[ icon | ............ centered search bar ............ | env switcher | controls ]  <- title row, --titlebar-height
+[ drawer header band | tab strip over main + context, left edge = drawer edge    ]  <- --tabstrip-height
+[ drawer body        | main content                    | context bar             ]
+[ dock                                                                           ]
+```
+
+The title row belongs to the **window** (it is what drags it, and what the macOS traffic lights and the Windows caption overlay are drawn into); the second row belongs to the **content**. Tabs switch the main area and the context bar and never the drawer, so the strip is scoped to that column and its left edge follows the drawer's resize handle - it is the drawer's flex sibling, so there is no width to keep in sync. The drawer's own half of the row is `DrawerPanel`'s header band.
+
+Both rows are tokenized: `--titlebar-height` (mirrored in `electron/constants.ts`, which sizes the real window frame and cannot read CSS) and `--tabstrip-height` (renderer-only - nothing the main process draws is that tall). `titlebar-height.test.ts` holds each token to its readers, and a top-anchored toast subtracts **both** (`constants/toast.ts`).
+
+Tabs used to live in the title row. They are content-width and overflow into a dropdown, so every pixel another control took there converted directly into overflowed tabs - which is why a search bar could not simply be added beside them.
+
 ### `TitleBar` (`components/layout/TitleBar.tsx`)
 
-Custom window title bar (Electron frameless window, h-[38px]). Platform-specific controls:
+Custom window title bar (Electron frameless window, `--titlebar-height`). Renders nothing outside Electron - there is no window chrome to draw. A 3-column grid (`1fr auto 1fr`), so the search bar is centred on the *window* rather than on whatever space the two clusters leave.
 
-- **All platforms:** Logo (left), `<TabStrip />` (center, flexes to fill).
-- **macOS:** Native traffic light inset (~80px left); no HTML window controls.
-- **Windows:** Native window overlay; no HTML controls in the bar.
-- **Linux:** Custom HTML min/max/close buttons (right); `EnvPill` showing active environment.
+- **All platforms:** `<CommandSearchBar />` (centre), `EnvPill` (right).
+- **macOS:** Native traffic light inset (`--traffic-light-inset`, 104px left); no HTML window controls.
+- **Windows:** App icon as the system-menu control (left); native window overlay, no HTML controls in the bar.
+- **Linux:** Custom HTML min/max/close buttons (right).
 
-The entire bar is marked as a drag region (`WebkitAppRegion: "drag"`) except for interactive elements, which explicitly set `no-drag`. Keep `no-drag` on the interactive elements themselves, never on a layout wrapper: the `TabStrip` wrapper flexes to fill the bar, so marking *it* `no-drag` turns all the empty space right of the last tab into a dead zone the window can't be dragged by. `TabStrip` sets `no-drag` on its own tab row for this reason.
+The entire bar is marked as a drag region (`WebkitAppRegion: "drag"`) except for interactive elements, which explicitly set `no-drag` - a drag area ignores every pointer event, so a control that forgets is dead rather than merely awkward. Opting out per control or per cluster is fine; opting out a wrapper that spans the row's slack is not, because that slack is what the window is dragged by. → `TitleBar.search-bar.test.tsx`.
 
 The logo is imported as a module (`@shared/icon_png/...`), not referenced as `/icon.png`. With `base: "./"`, a root-absolute path resolves against the filesystem root under the packaged `file://` build and silently fails to load - it only appears to work in dev, where Vite serves it over HTTP.
 
+### `CommandSearchBar` (`components/layout/CommandSearchBar.tsx`)
+
+The palette's visible entry point, in the title row. A `<button>` styled as an input: it looks like a field because that is what makes ⌘K discoverable, but typing happens in the palette's own input - a real field here would be a second query state and a second ranked list to keep in step. Clicking sets `paletteOpen`; the hint it prints comes from `PALETTE_CHORD` (`constants/shortcuts.ts`), the same constant `CommandPalette`'s listener matches, so the bar cannot advertise a chord nothing handles.
+
 ### `TabStrip` (`components/layout/TabStrip.tsx`)
 
-Horizontal row of open tabs plus a "+" button. Reads from `useTabsStore` (open tabs, active tab, add/close/focus methods).
+Horizontal row of open tabs plus a "+" button, rendered by `Shell` over the content column (not in the title bar). Reads from `useTabsStore` (open tabs, active tab, add/close/focus methods). Takes its height from `--tabstrip-height` and carries no `app-region` markers - nothing down here drags the window.
 
 Labels and icons come from `tab-descriptors.ts`, a sibling module rather than this file, because the command palette lists the same tabs and must name them identically - a tab that reads "GET /v1/orders" in the strip and "Request" in the palette is two answers to one question.
 
@@ -74,23 +96,26 @@ Labels and icons come from `tab-descriptors.ts`, a sibling module rather than th
 
 Main layout: tab-centric with resizable drawer, split/overlay context bar, and docked footer.
 
-- **One uniform layout for every tab** - `Drawer` (left) + main content + `ContextBar` (right). No tab type takes over the row. This is deliberate: the Dock's drawer switchers always have a Drawer to act on, so they can never be dead. (Settings used to full-take-over and suppress the Drawer, which left those buttons doing nothing while Settings was open.)
+- **One uniform layout for every tab** - `Drawer` (left) + a content column holding `TabStrip` over main + `ContextBar`. No tab type takes over the row. This is deliberate: the Dock's drawer switchers always have a Drawer to act on, so they can never be dead. (Settings used to full-take-over and suppress the Drawer, which left those buttons doing nothing while Settings was open.)
 - **Left navigation is always the Drawer.** Every main view that needs a category/entity list uses the shared Drawer for it - never its own left rail. `SettingsMain` and `VariablesMain` are pure content panes; their category trees live in the Drawer (`settings` / `variables` views). Follow this pattern for any new view - do not add a second sidebar inside the main area.
 - **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab). ⌘K (command palette) is **not** in this map - it is owned by `CommandPalette`, on the capture phase, because Monaco swallows the key on the bubble.
 - **Drawer:** toggles visibility via `toggleDrawer()` (state in `useLayoutStore`); always resizable 220–480px.
 - **Content routing:** switches main area based on `activeTab.type` (welcome | request | collection | dashboard | run | variables | settings). Default is `WelcomeScreen`.
 - **Drawer-view sync:** an effect points the Drawer at the view matching the active tab - `variables`→variables, `settings`→settings, `request`/`collection`→collections - and opens it.
-- **ContextBar mode:** picks "push" (≥1200px width) or "overlay" based on window width. It renders on the tab types the section registry has entries for - request, collection and run - and nothing on the other four.
+- **ContextBar mode:** picks "push" (≥1200px width) or "overlay" based on window width. It renders on the tab types the section registry has entries for - request, collection and run - and nothing on the other four. `relative` sits on the main+context row rather than on the outer one, so the overlay stops at the tab strip instead of covering the tabs it belongs to.
+- **The restructure must not remount tab content.** Drawer state is upstream of the column the active tab renders into, so a `key` derived from it - or a wrapper mounted only while the drawer is closed - throws away an unsaved body, a scroll position, a Monaco model. → `shell-tab-identity.test.tsx`.
 - **`<ImportModal />`** and **`<CommandPalette />`** mounted once each as global overlays; visibility in a store rather than in the Shell.
 
 ### `Drawer` (`components/layout/Drawer.tsx`)
 
-Resizable sidebar (220–480px default, per view). The single left navigation for the whole app - one of four views per `useLayoutStore.drawerView`:
+Resizable sidebar (220–480px default, per view). The single left navigation for the whole app - one of four views per `useLayoutStore.drawerView`. Every view is titled: its `DrawerPanel` header is the drawer's half of the second chrome row, sharing `--tabstrip-height` and its bottom rule with the tab strip across the resize handle, with an optional tools slot beside the title.
 
-- **`collections`** - `CollectionTree` (hierarchical collections + requests).
-- **`history`** - `HistoryList` (past runs, filtered/sorted).
-- **`variables`** - `VariablesCategoryTree` (variable scopes: globals, collections, environments).
-- **`settings`** - `SettingsCategoryTree` (app + engine setting categories).
+| View | Component | Band tools today |
+|------|-----------|------------------|
+| **`collections`** | `CollectionTree` (hierarchical collections + requests) | add collection, add request, import |
+| **`history`** | `HistoryList` (past runs, filtered/sorted) | run count |
+| **`variables`** | `VariablesCategoryTree` (globals, collections, environments) | - |
+| **`settings`** | `SettingsCategoryTree` (app + engine setting categories) | - |
 
 Both `variables` and `settings` follow the same nav/content split: the tree lives here in the Drawer, the editor is the corresponding tab (`VariablesMain` / `SettingsMain`), and selecting a category sets the shared store selection **and** opens/focuses that tab.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1148,8 +1148,15 @@ their content.
 The four views had drifted into two different panel designs - Collections and
 History used a 16px padded container with a heading, Variables and Settings were
 flush with no heading at all. Switching views moved the content's vertical start
-*and* made the title appear or vanish. All four now match exactly: heading at
-11px from the panel top, body at 40px.
+*and* made the title appear or vanish. All four now match exactly: one 32px
+header band, body below it.
+
+- **The header is the drawer's half of the second chrome row.** It takes its
+  height from `--tabstrip-height` and carries the same bottom rule as the tab
+  strip on the other side of the resize handle, so the two read as one band
+  across the window rather than as two adjacent headers. That is the only reason
+  the height is a token and not an `h-8`: `TabStrip.tsx` and `DrawerPanel.tsx`
+  cannot see each other, and `titlebar-height.test.ts` holds them together.
 
 - **The frame owns header padding; the body is flush.** Rows run edge to edge -
   the sidebar convention, and it recovers the ~32px of row width the old inset
@@ -1579,7 +1586,10 @@ away. `never` resolves to a 24h sentinel rather than `Infinity`, because the
 primitive arms a real `setTimeout` and a non-finite delay there is coerced to 1.
 
 **Every position clears the chrome on its own edge**, via `--dock-height` at the
-bottom and `--titlebar-height` at the top - never a round number. The stack is
+bottom and `--titlebar-height` **plus** `--tabstrip-height` at the top - never a
+round number. The top edge is two bands since the shell split the title row from
+the tab strip, and clearing only the first put the stack back on the chrome
+32px lower. The stack is
 `position: fixed`, so it anchors to the window rather than the layout, and a
 plain `bottom-4` once put it on top of the Dock. `toast-position.test.tsx`
 checks all six.


### PR DESCRIPTION
## Description

Phase 0 of #524: the shell the palette's entry point needs.

**The plan.** Root cause: the 32px title row already carried the menu button, the whole tab strip, the environment switcher and (on Windows) the reserved caption-overlay width - and tabs there are content-width with dropdown overflow (`fitTabs`), so every pixel another control takes converts directly into overflowed tabs. A search bar wants ~360 of them, which is why "add a search field to the bar" was geometrically impossible rather than merely tight. The approach is the decided B2 split: the title row keeps the window's own business and gains a centred search bar; the tab strip moves to a second row scoped to the content column, mounted as the drawer's flex sibling so its left edge tracks the drawer's resize handle with no width to compute. The alternative I rejected is B1 (a full-width tab row): it is structurally simpler, but the strip would then visually claim the drawer it does not control, and it gives the drawer no header band - which is where the collections tools, History's count and #523's settings search already want to live.

**Reality check against the issue's constraint map** (files drift; two things had):

- The issue describes mounting the strip "inside the existing `ResizablePanelGroup`". There is no panel group in the shell - `Drawer` is an `<aside>` with an inline width plus `PanelResizeHandle`. That makes the restructure smaller than specced: one column wrapper, no panel surgery.
- The drawer header band is not new surface. `DrawerPanel` has been the single frame every view renders through (title + tools slot + scroll region) since the four views were unified. So the band is that header sized to `--tabstrip-height` with the strip's bottom rule - **not** a second header stacked above it, which would have been a hand-rolled copy of a primitive that already exists. Every view was already titled; the tools slot was already there. `CollectionTree`'s action buttons drop `h-8` → `h-7` so a 32px control does not fill a 32px band edge to edge.

**Deliberate deviation from the spec:** `--tabstrip-height` is declared in `index.css` with **no mirror in `electron/constants.ts`**, though the issue asks for the token+mirror+test discipline. The mirror exists for `--titlebar-height` because Electron sizes the real window frame, the Windows caption overlay and the traffic-light inset and cannot read CSS. Nothing the main process draws is `--tabstrip-height` tall, so a constant there would be one more value written and never read - this repo's most-repeated defect. The token half and the test half of the discipline are kept in full, and the absence of the mirror is asserted (`expect(constants).not.toContain("TABSTRIP_HEIGHT")`) so it stays a decision rather than an oversight.

**The rest of the couplings, all handled.** The strip sheds every `WebkitAppRegion: "no-drag"` marker - those existed because the title bar was a drag region, and nothing in the content area drags the window; the title row's half of that invariant moved with the geometry to `TitleBar.search-bar.test.tsx`. `relative` moved down onto the main+context row, so the ContextBar's overlay mode (<1200px) stops at the strip instead of covering the tabs it belongs to. A top-anchored toast now subtracts **both** bands - clearing only the first would have put the stack back on the chrome, 32px lower. The search bar is a `<button>` styled as an input, never a second search implementation, and prints `PALETTE_CHORD` - the same constant `CommandPalette`'s listener matches, per `constants/shortcuts.ts`. #525 has landed, so it wires the real `openPalette` (via `setPaletteOpen`) rather than shipping a dead control.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **App suite: 414 files, 4192 tests passed** (176s). No pre-existing failures.
- `pnpm type-check`, `pnpm lint` (zero warnings), `pnpm format:check` clean.
- Engine untouched (`Engine: none. MCP: none.` per the issue), so no engine build or ctest run - nothing there could change colour.
- `mkdocs build --strict` not run: mkdocs is not installed in this environment. The docs change adds no page, no relative link and no renamed heading (checked: nothing links into either file by anchor), so the strict gate has nothing new to resolve.

New and changed tests, each mutation-checked (mutation applied, failure observed, mutation reverted):

- `TitleBar.search-bar.test.tsx` (6, new) - the bar renders on all three platforms, carries the rendered `PALETTE_CHORD` hint (print `Ctrl+P` instead → fails), opens the palette on click while exposing no textbox of its own, is centred by a `1fr auto 1fr` grid (swap to `flex` → fails), the row drags while the bar, env switcher and both window buttons do not (walking up for the effective region, since jsdom keeps `-webkit-app-region` off the style attribute), and the whole row draws nothing outside Electron. Platform is stubbed and re-imported per case - the flags are module-level.
- `shell-tab-identity.test.tsx` (2, new) - an edited unsaved body survives the drawer collapsing, reopening and resizing, asserted as the *same DOM node* plus its retained state (`key={String(drawerOpen)}` on the column → fails), and the strip is a sibling of `main`'s row inside the drawer's column rather than a row spanning the window.
- `DrawerPanel.test.tsx` (3, new) - the header sizes to the band token and carries the rule (`h-10` → fails), the tools slot stays optional without the band vanishing, and all four drawer views render their header through the frame.
- `titlebar-height.test.ts` (+2) - the band token is declared exactly once, theme- and platform-independently; both halves read it (`DrawerPanel` back to `h-10` → fails); no Electron mirror.
- `toast-position.test.tsx` (+1, 1 widened) - every top position clears both tokens (drop `--tabstrip-height` from the offset → fails); the strip keeps its height on the token.
- `TabStrip.overflow.test.tsx` - the fill assertion follows the strip into a column (`flex-1` → `w-full`, plus the band-height guard), and the four title-bar drag-region cases collapse into one asserting the strip declares no app-region at all, over a deliberately non-empty element list.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Same commit: `docs/app/COMPONENTS.md` gains a **two chrome rows** section (the geometry diagram, which row belongs to the window and which to the content, both tokens and their readers), rewrites the `TitleBar` section, documents `CommandSearchBar`, re-homes `TabStrip`, and turns the drawer views list into a table with each view's band tools. `docs/design-system.md` updates the Drawer Panel Frame section (the band, its token, why it is not an `h-8`) and the toast rule (both tokens at the top edge).

## Related Issues
Closes #529

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY8t79JWwcRKbzcjxMzCuE)_