### PR TITLE
feat(app/palette): phase 3 - deep search over settings, variables and runs

### DIFF
--- a/app/src/modules/history/sidebar/RunItem.tsx
+++ b/app/src/modules/history/sidebar/RunItem.tsx
@@ -8,6 +8,7 @@
 import type React from "react";
 import { formatRelativeTime, loadTestTypeToLabel } from "@/utils";
 import type { Run } from "@/types";
+import { RUN_KIND_LABEL } from "@/modules/history/types";
 import { Badge, Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { MethodBadge } from "@/components/shared";
@@ -30,16 +31,6 @@ import {
 	Pin,
 	PinOff,
 } from "lucide-react";
-
-/**
- * How each run type is announced. One map so the row cannot name a type in the
- * label that it does not draw an icon for.
- */
-const RUN_KIND_LABEL: Record<Run["type"], string> = {
-	load: "load test",
-	design: "request",
-	scenario: "collection",
-};
 
 interface RunItemProps {
 	run: Run;

--- a/app/src/modules/history/types.ts
+++ b/app/src/modules/history/types.ts
@@ -9,9 +9,22 @@
  * History Component Types
  */
 
-import type { RunReport, LoadTestMetrics, MonitorSample } from "@/types";
+import type { Run, RunReport, LoadTestMetrics, MonitorSample } from "@/types";
 import type { DashboardDerived } from "@/modules/dashboard/types";
 import type { Anomaly } from "@/modules/dashboard/utils/detectAnomalies";
+
+/**
+ * How each run type is announced in words.
+ *
+ * Module-level rather than inside `RunItem` because the command palette's Runs
+ * group names them too, and a run that is a "collection" run in the sidebar and
+ * a "scenario" run in the palette is two answers to one question.
+ */
+export const RUN_KIND_LABEL: Record<Run["type"], string> = {
+	load: "load test",
+	design: "request",
+	scenario: "collection",
+};
 
 export interface TabProps {
 	report: RunReport;

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -65,6 +65,12 @@ vi.mock("@/queries", () => ({
 	useCollectionsQuery: () => ({ data: COLLECTIONS }),
 	useMultipleCollectionRequests: () => ({ requestsByCollection: REQUESTS, isLoading: false }),
 	useRunsQuery: () => ({ data: { pages: runPages } }),
+	// The deep sources (phase 3). Their own behaviour lives in
+	// `deep-sources.test.tsx`; here they only have to exist so the list renders.
+	useConfigQuery: () => ({ data: { entries: [] } }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useGlobalsQuery: () => ({ data: undefined }),
+	useRunSearchQuery: () => ({ data: undefined, isError: false }),
 	flattenRunPages: (data?: { pages: { data: unknown[] }[] }) =>
 		data ? data.pages.flatMap((p) => p.data) : [],
 	// Reached through the command surfaces the palette now hosts: the shared

--- a/app/src/modules/palette/CommandPalette.tsx
+++ b/app/src/modules/palette/CommandPalette.tsx
@@ -17,8 +17,8 @@
  *
  * - **Not its own search implementation.** Results come from source hooks
  *   (`sources/`), each returning the same `PaletteItem` shape and performing
- *   its action through the very call the sidebar makes. Adding settings,
- *   environments or runs later is a source, not a change here.
+ *   its action through the very call the sidebar makes. Settings entries,
+ *   variables and runs joined as three more sources and changed nothing here.
  * - **Not its own list of actions.** The Commands and Settings groups are
  *   `lib/commands`, the registry the native menu points at too. What this file
  *   does own is the *host* for the dialogs those commands open - see
@@ -134,13 +134,13 @@ export function CommandPalette() {
 				open={paletteOpen}
 				onOpenChange={setPaletteOpen}
 				title="Command palette"
-				description="Search open tabs, requests, collections, views and commands."
+				description="Search open tabs, requests, collections, views, commands, settings, variables and past runs."
 				className="max-w-xl"
 			>
 				<CommandInput
 					value={query}
 					onValueChange={setQuery}
-					placeholder={`Search tabs, requests, commands… (${formatChord(PALETTE_CHORD)})`}
+					placeholder={`Search tabs, requests, settings, runs… (${formatChord(PALETTE_CHORD)})`}
 				/>
 				{/*
 				 * Mounted only while open, so a shut palette holds no query observers

--- a/app/src/modules/palette/PaletteResults.tsx
+++ b/app/src/modules/palette/PaletteResults.tsx
@@ -9,9 +9,16 @@
  * The palette's list: every source, grouped and ranked.
  *
  * Mounted only while the palette is open - the same cost model the context
- * bar's sections use. The sources read collections, requests and run history,
- * and a palette that is shut has no business holding query observers on any of
- * it.
+ * bar's sections use. The sources read collections, requests, settings,
+ * variables and run history, and a palette that is shut has no business holding
+ * query observers on any of it.
+ *
+ * Two shapes of source meet here. The shallow ones return everything they know
+ * and let cmdk filter it; the deep ones (settings, variables, runs) search
+ * corpora too large to render - so they take the query, rank and cap it
+ * themselves, and offer an escape row into the surface that browses the rest.
+ * An escape row renders in a group of its own below the results, which is what
+ * keeps cmdk's score sort from lifting it above them - see `PaletteItem.escape`.
  */
 
 import { useMemo } from "react";
@@ -29,6 +36,9 @@ import { useTabItems } from "./sources/useTabItems";
 import { useEntityItems } from "./sources/useEntityItems";
 import { useViewItems } from "./sources/useViewItems";
 import { commandItems } from "./sources/commandItems";
+import { useSettingsItems } from "./sources/useSettingsItems";
+import { useVariableItems } from "./sources/useVariableItems";
+import { useRunItems } from "./sources/useRunItems";
 
 interface PaletteResultsProps {
 	/** The live query, so ranking can tell "nothing typed" from "no match". */
@@ -48,14 +58,29 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 	const entities = useEntityItems();
 	const views = useViewItems();
 	const commands = commandItems(commandContext);
+	const settings = useSettingsItems(query);
+	const variables = useVariableItems(query);
+	const runs = useRunItems(query);
 
 	const grouped = useMemo(() => {
-		const all = [...tabs, ...entities, ...views, ...commands];
-		return PALETTE_GROUPS.map((kind) => ({
-			kind,
-			items: rankForEmptyQuery(all.filter((item) => item.kind === kind)),
-		})).filter((group) => group.items.length > 0);
-	}, [tabs, entities, views, commands]);
+		const all = [
+			...tabs,
+			...entities,
+			...views,
+			...commands,
+			...settings,
+			...variables,
+			...runs,
+		];
+		return PALETTE_GROUPS.map((kind) => {
+			const ofKind = all.filter((item) => item.kind === kind);
+			return {
+				kind,
+				items: rankForEmptyQuery(ofKind.filter((item) => !item.escape)),
+				escapes: ofKind.filter((item) => item.escape),
+			};
+		}).filter((group) => group.items.length > 0 || group.escapes.length > 0);
+	}, [tabs, entities, views, commands, settings, variables, runs]);
 
 	/*
 	 * cmdk hides a group whose items all filter out, so the count has to come
@@ -81,6 +106,17 @@ export function PaletteResults({ query, onPick, commandContext }: PaletteResults
 								<PaletteRow key={item.id} item={item} onPick={onPick} />
 							))}
 						</CommandGroup>
+						{/* Its own group, not the last row of the one above: cmdk
+						    sorts a group's items by score, and an escape row has
+						    to carry the query verbatim to survive the filter -
+						    which would score it above every result it escapes. */}
+						{group.escapes.length > 0 && (
+							<CommandGroup>
+								{group.escapes.map((item) => (
+									<PaletteRow key={item.id} item={item} onPick={onPick} />
+								))}
+							</CommandGroup>
+						)}
 					</div>
 				))}
 			</CommandList>

--- a/app/src/modules/palette/deep-sources.test.tsx
+++ b/app/src/modules/palette/deep-sources.test.tsx
@@ -1,0 +1,462 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Phase 3's three sources: settings entries, variables, and runs.
+ *
+ * Through the palette rather than through each hook, because what they promise
+ * is a *landing*: a settings hit selects a category and leaves an anchor for
+ * `useRevealedSetting`, a variable hit scopes the Variables tab, a run hit opens
+ * that run's tab. A hook test could assert the items and still let the wiring
+ * rot, which is this codebase's most repeated defect.
+ *
+ * Three of these are guards against a specific way of failing:
+ *
+ * - **The secrets invariant's visible half.** A variable's value never reaches
+ *   the screen. Its searchable half belongs to `useVariableItems.test.ts` - see
+ *   the note on that test for why the DOM cannot hold it.
+ * - **The cap and its escape.** A corpus larger than the group hands off to the
+ *   surface that browses it, and does so *pre-filtered* - the assertions read
+ *   the destination's own store, not the palette's.
+ * - **Idle typing never errors.** An engine that is down hides the Runs group;
+ *   drop the `isError` branch and the group renders rows from `undefined`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { CommandPalette } from "./CommandPalette";
+import { useLayoutStore, useTabsStore } from "@/stores";
+import { useSettingsStore } from "@/modules/settings/settings-store";
+import { useVariablesStore } from "@/modules/variables/variables-store";
+import { useHistoryStore } from "@/modules/history/history-store";
+import { DEEP_GROUP_LIMIT } from "./types";
+import type { Run, RunListResponse } from "@/types";
+
+const COLLECTIONS: {
+	id: string;
+	name: string;
+	parentId?: string;
+	variables?: Record<string, { value: string; secret?: boolean }>;
+}[] = [
+	{
+		id: "c1",
+		name: "Payments",
+		variables: { chargeBaseUrl: { value: "https://pay.example" } },
+	},
+];
+
+const ENVIRONMENTS: {
+	id: string;
+	name: string;
+	variables: Record<string, { value: string; secret?: boolean }>;
+}[] = [
+	{
+		id: "e1",
+		name: "Production",
+		// The value below must never reach the palette - see the secrets test.
+		variables: { apiToken: { value: "s3cr3t-bearer-value", secret: true } },
+	},
+];
+
+const GLOBALS = { id: "globals", variables: { retryBudget: { value: "3" } } };
+
+/** Engine `/config` entries, controllable per test. */
+let engineEntries: {
+	key: string;
+	label: string;
+	description: string;
+	category: string;
+	keywords: readonly string[];
+}[] = [];
+
+/** What the palette's run search resolves to, and whether it failed. */
+let runSearch: { data: RunListResponse | undefined; isError: boolean } = {
+	data: undefined,
+	isError: false,
+};
+
+/** Every query string `useRunSearchQuery` was called with, in order. */
+const runSearchCalls: string[] = [];
+
+vi.mock("@/queries", () => ({
+	requestDetailOptions: () => ({
+		queryKey: ["request"],
+		queryFn: async () => undefined,
+		enabled: false,
+	}),
+	runDetailOptions: () => ({ queryKey: ["run"], queryFn: async () => undefined, enabled: false }),
+	useCollectionsQuery: () => ({ data: COLLECTIONS }),
+	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map(), isLoading: false }),
+	useRunsQuery: () => ({ data: { pages: [{ data: [] }] } }),
+	flattenRunPages: () => [],
+	useConfigQuery: () => ({ data: { entries: engineEntries } }),
+	useEnvironmentsQuery: () => ({ data: ENVIRONMENTS }),
+	useGlobalsQuery: () => ({ data: GLOBALS }),
+	useRunSearchQuery: (q: string) => {
+		runSearchCalls.push(q);
+		return q === "" ? { data: undefined, isError: false } : runSearch;
+	},
+	useCreateRequestMutation: () => ({ mutateAsync: vi.fn() }),
+	useCreateCollectionMutation: () => ({ mutateAsync: vi.fn() }),
+	useStartScenarioRunMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/useVariableResolver", () => ({
+	useVariableResolver: () => ({ resolveString: (s: string) => s }),
+}));
+
+function renderPalette() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<CommandPalette />
+		</QueryClientProvider>
+	);
+}
+
+function open() {
+	act(() => useLayoutStore.getState().setPaletteOpen(true));
+}
+
+function input(): HTMLInputElement {
+	return screen.getByPlaceholderText(/Search tabs/) as HTMLInputElement;
+}
+
+/** Type, then let the run debounce elapse so every source has answered. */
+function typeQuery(text: string) {
+	fireEvent.change(input(), { target: { value: text } });
+	act(() => void vi.advanceTimersByTime(400));
+}
+
+/**
+ * The visible rows of one group, by its heading.
+ *
+ * Matched on the heading element, not on the text: "Settings" and "Variables"
+ * are each both a group heading and a row in the Views group, so a plain text
+ * lookup finds two elements and is ambiguous by construction.
+ */
+function groupByHeading(heading: string): Element | null {
+	const headings = [...document.querySelectorAll("[cmdk-group-heading]")];
+	return headings.find((el) => el.textContent === heading)?.closest("[cmdk-group]") ?? null;
+}
+
+function rowsUnder(heading: string): string[] {
+	const group = groupByHeading(heading);
+	if (!group) return [];
+	return [...group.querySelectorAll("[cmdk-item]")].map(
+		(el) => el.querySelector("span.flex-1")?.textContent ?? ""
+	);
+}
+
+/** Pick one row by its visible title - `pressEnter` takes whatever cmdk highlighted. */
+function pickRow(title: string) {
+	fireEvent.click(screen.getByText(title));
+}
+
+function runRow(overrides: Partial<Run> = {}): Run {
+	return {
+		id: "run1",
+		type: "design",
+		status: "completed",
+		startTime: 1_700_000_000_000,
+		endTime: 1_700_000_001_000,
+		summary: { url: "https://api.example/checkout", method: "POST" },
+		...overrides,
+	};
+}
+
+function runPage(data: Run[], total = data.length): RunListResponse {
+	return {
+		data,
+		pagination: {
+			total,
+			limit: DEEP_GROUP_LIMIT,
+			offset: 0,
+			hasMore: false,
+			returned: data.length,
+		},
+	};
+}
+
+beforeEach(() => {
+	vi.useFakeTimers({ shouldAdvanceTime: true });
+	Element.prototype.scrollIntoView = vi.fn();
+	engineEntries = [];
+	runSearch = { data: undefined, isError: false };
+	runSearchCalls.length = 0;
+	useLayoutStore.setState({ paletteOpen: false, drawerOpen: false, drawerView: "collections" });
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+	useSettingsStore.setState({
+		selectedCategory: "appearance",
+		highlightedKey: null,
+		searchQuery: "",
+	});
+	useVariablesStore.setState({ selectedCategory: null });
+	useHistoryStore.getState().resetFilters();
+});
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+});
+
+describe("settings entries", () => {
+	it("finds an engine entry by its key and reveals it in its category", () => {
+		engineEntries = [
+			{
+				key: "dbCacheSize",
+				label: "Cache Size",
+				description: "SQLite page cache.",
+				category: "database_performance",
+				keywords: [],
+			},
+		];
+		renderPalette();
+		open();
+
+		// The key, not the label - what every doc, log line and MCP call names it.
+		typeQuery("dbCacheSize");
+		pickRow("Cache Size");
+
+		const settings = useSettingsStore.getState();
+		expect(settings.selectedCategory).toBe("database_performance");
+		// The anchor is what `useRevealedSetting` scrolls to and outlines.
+		expect(settings.highlightedKey).toBe("dbCacheSize");
+		expect(useTabsStore.getState().openTabs[0]).toMatchObject({ type: "settings" });
+	});
+
+	it("finds an app setting by a word its panel prints but its name does not", () => {
+		renderPalette();
+		open();
+
+		// "Theme Mode" lives in Appearance; "dark mode" is in its keywords only.
+		typeQuery("dark mode");
+
+		expect(rowsUnder("Settings")).toContain("Theme Mode");
+	});
+
+	it("does not list a panel twice - the registry already offers every section", () => {
+		renderPalette();
+		open();
+
+		typeQuery("Appearance");
+
+		// One row for the Appearance section (the registry's command), and no
+		// second one from the index's `panel` entries.
+		const appearanceRows = rowsUnder("Settings").filter((row) => row === "Appearance");
+		expect(appearanceRows).toHaveLength(1);
+	});
+
+	it("caps the group and hands the rest to the sidebar, pre-filtered", () => {
+		engineEntries = Array.from({ length: 12 }, (_, i) => ({
+			key: `zzTimeoutSetting${i}`,
+			label: `Zz Timeout Setting ${i}`,
+			description: "A timeout.",
+			category: "general_engine",
+			keywords: [],
+		}));
+		renderPalette();
+		open();
+
+		typeQuery("zzTimeoutSetting");
+
+		const rows = rowsUnder("Settings");
+		expect(rows).toHaveLength(DEEP_GROUP_LIMIT);
+		// The escape row lives in its own group, below the results, so cmdk's
+		// score sort cannot lift it above them.
+		const escape = screen.getByText(/^Search settings for/);
+		expect(escape).toBeInTheDocument();
+
+		fireEvent.click(escape);
+
+		// The destination opens already filtered - the palette finds, the
+		// sidebar browses.
+		expect(useSettingsStore.getState().searchQuery).toBe("zzTimeoutSetting");
+		expect(useLayoutStore.getState().drawerView).toBe("settings");
+		expect(useLayoutStore.getState().drawerOpen).toBe(true);
+	});
+
+	it("offers no escape row when the group already shows everything", () => {
+		engineEntries = [
+			{
+				key: "zzOnlyOne",
+				label: "Zz Only One",
+				description: "Alone.",
+				category: "general_engine",
+				keywords: [],
+			},
+		];
+		renderPalette();
+		open();
+
+		typeQuery("zzOnlyOne");
+
+		expect(screen.queryByText(/^Search settings for/)).not.toBeInTheDocument();
+	});
+});
+
+describe("variables", () => {
+	it("finds a variable key and opens the Variables tab on the scope that defines it", () => {
+		renderPalette();
+		open();
+
+		typeQuery("apiToken");
+		pickRow("apiToken");
+
+		expect(useVariablesStore.getState().selectedCategory).toEqual({
+			type: "environment",
+			environmentId: "e1",
+		});
+		expect(useTabsStore.getState().openTabs[0]).toMatchObject({ type: "variables" });
+	});
+
+	it("finds a globals key, and says which scope it came from", () => {
+		renderPalette();
+		open();
+
+		typeQuery("retryBudget");
+
+		const group = groupByHeading("Variables")!;
+		expect(group.textContent).toContain("retryBudget");
+		expect(group.textContent).toContain("Globals");
+	});
+
+	it("finds an environment by its own name", () => {
+		renderPalette();
+		open();
+
+		typeQuery("Production");
+		pickRow("Production");
+
+		expect(useVariablesStore.getState().selectedCategory).toEqual({
+			type: "environment",
+			environmentId: "e1",
+		});
+	});
+
+	it("shows a key without ever printing what it holds", () => {
+		renderPalette();
+		open();
+
+		typeQuery("apiToken");
+
+		expect(screen.getByText("apiToken")).toBeInTheDocument();
+		expect(document.body.textContent).not.toContain("s3cr3t-bearer-value");
+		// The searchable half of this invariant cannot be asserted here - cmdk
+		// filters the rendered list again, so an indexed value would be
+		// invisible on screen and still be in the items. `useVariableItems.test.ts`
+		// holds that half, against what the source returns.
+	});
+});
+
+describe("runs", () => {
+	it("waits for typing to stop before asking the engine", () => {
+		renderPalette();
+		open();
+
+		fireEvent.change(input(), { target: { value: "check" } });
+		// Mid-word: the palette has asked for nothing but the empty query.
+		expect(runSearchCalls.every((q) => q === "")).toBe(true);
+
+		act(() => void vi.advanceTimersByTime(400));
+		expect(runSearchCalls).toContain("check");
+	});
+
+	it("lists a matching run and opens its tab", () => {
+		runSearch = { data: runPage([runRow()]), isError: false };
+		renderPalette();
+		open();
+
+		typeQuery("checkout");
+		expect(rowsUnder("Runs")).toEqual(["https://api.example/checkout"]);
+
+		pickRow("https://api.example/checkout");
+		expect(useTabsStore.getState().openTabs[0]).toMatchObject({
+			type: "run",
+			entityId: "run1",
+		});
+	});
+
+	it("names a collection run by its collection, which has no url to print", () => {
+		runSearch = {
+			data: runPage([
+				runRow({
+					id: "run2",
+					type: "scenario",
+					summary: { scenario: { collectionId: "c1", stepCount: 3 } },
+				}),
+			]),
+			isError: false,
+		};
+		renderPalette();
+		open();
+
+		typeQuery("Payments");
+		expect(rowsUnder("Runs")).toEqual(["Payments"]);
+	});
+
+	it("hides the group when the engine is down, without erroring", () => {
+		// With a page still in hand, as TanStack leaves it after a failed
+		// refetch - so the group can only disappear because of `isError`.
+		runSearch = { data: runPage([runRow()]), isError: true };
+		renderPalette();
+		open();
+
+		typeQuery("checkout");
+
+		expect(groupByHeading("Runs")).toBeNull();
+		// Idle typing must not raise anything the user has to dismiss.
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("hands the rest to History, pre-filtered and unfiltered by anything else", () => {
+		useHistoryStore.getState().setFilterType("load");
+		runSearch = { data: runPage([runRow()], 42), isError: false };
+		renderPalette();
+		open();
+
+		typeQuery("checkout");
+		fireEvent.click(screen.getByText(/^Search runs for/));
+
+		const history = useHistoryStore.getState();
+		expect(history.searchQuery).toBe("checkout");
+		// The stale type filter would have hidden the design run the palette
+		// just promised, so the escape resets it.
+		expect(history.filterType).toBe("all");
+		expect(useLayoutStore.getState().drawerView).toBe("history");
+		expect(useLayoutStore.getState().drawerOpen).toBe(true);
+	});
+});
+
+describe("the empty query", () => {
+	it("contributes nothing from the deep sources", () => {
+		engineEntries = [
+			{
+				key: "dbCacheSize",
+				label: "Cache Size",
+				description: "SQLite page cache.",
+				category: "database_performance",
+				keywords: [],
+			},
+		];
+		runSearch = { data: runPage([runRow()]), isError: false };
+		renderPalette();
+		open();
+		act(() => void vi.advanceTimersByTime(400));
+
+		// Settings still renders - the registry's twelve sections - but none of
+		// its entries, and the two server-shaped groups are absent entirely.
+		expect(rowsUnder("Settings")).not.toContain("Cache Size");
+		expect(groupByHeading("Variables")).toBeNull();
+		expect(groupByHeading("Runs")).toBeNull();
+		// And nothing was asked of the engine for a palette nobody typed into.
+		expect(runSearchCalls.every((q) => q === "")).toBe(true);
+	});
+});

--- a/app/src/modules/palette/sources/useRunItems.ts
+++ b/app/src/modules/palette/sources/useRunItems.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Past runs, as palette results.
+ *
+ * The only server-backed source. The others read caches the app has already
+ * warmed; the run archive has no bound and lives in the engine's database, so
+ * this one asks - `GET /runs?q=`, the same server-side substring filter the
+ * History sidebar's search box drives, capped to one small page.
+ *
+ * Three consequences the other sources do not have:
+ *
+ * - **The query is debounced.** A keystroke is not a search. Without this every
+ *   character of "checkout" is its own request, and seven of the eight answers
+ *   are thrown away.
+ * - **An engine that is down hides the group, silently.** Typing is idle input,
+ *   and a toast fired by idle input is the palette shouting at someone who did
+ *   not ask it anything. The query does not retry either - a typist should not
+ *   wait out a retry budget for a group that is about to disappear.
+ * - **cmdk cannot re-judge these rows.** The engine matched against the whole
+ *   stored snapshot, which includes text no row prints, so the rendered list's
+ *   own filter would drop rows that legitimately matched. Each row carries the
+ *   query in its keywords, which is how it says "the match is real, you just
+ *   cannot see it from here".
+ */
+
+/* global setTimeout, clearTimeout */
+
+import { useEffect, useMemo, useState } from "react";
+import { Clock, FolderTree, Search, Zap } from "lucide-react";
+import { useLayoutStore, useTabsStore } from "@/stores";
+import { useCollectionsQuery, useRunSearchQuery } from "@/queries";
+import { useHistoryStore } from "@/modules/history/history-store";
+import { RUN_KIND_LABEL } from "@/modules/history/types";
+import { formatRelativeTime } from "@/utils";
+import type { Collection, Run } from "@/types";
+import { type PaletteItem } from "../types";
+
+/**
+ * How long typing has to stop before the palette asks the engine. Matches the
+ * History sidebar's own search debounce - one search box behaviour, two boxes.
+ */
+export const RUN_SEARCH_DEBOUNCE_MS = 300;
+
+/** Open a run's tab - the same call the History sidebar's rows make. */
+function openRunTab(runId: string): void {
+	useTabsStore.getState().openTab({ type: "run", entityId: runId });
+}
+
+/** What the row reads as: the target, or the collection for a run that has none. */
+function runTitle(run: Run, collectionsById: Map<string, Collection>): string {
+	const scenario = run.summary?.scenario;
+	if (scenario) {
+		// The name while the collection is still there, the id when it is not -
+		// the same fallback ladder `RunItem` walks, and never a blank row.
+		const name = scenario.collectionId
+			? (collectionsById.get(scenario.collectionId)?.name ?? scenario.collectionId)
+			: undefined;
+		return name ?? "Collection run";
+	}
+	const url = run.summary?.url;
+	return url ?? RUN_KIND_LABEL[run.type];
+}
+
+export function useRunItems(query: string): PaletteItem[] {
+	const trimmed = query.trim();
+	const [debounced, setDebounced] = useState("");
+
+	useEffect(() => {
+		const timer = setTimeout(() => setDebounced(trimmed), RUN_SEARCH_DEBOUNCE_MS);
+		return () => clearTimeout(timer);
+	}, [trimmed]);
+
+	// Clearing the box empties the group at once rather than 300ms later: the
+	// debounce exists to spare the engine requests, not to leave stale rows on
+	// screen under a query that no longer asks for them.
+	const search = trimmed === "" ? "" : debounced;
+	const { data, isError } = useRunSearchQuery(search);
+	const { data: collections = [] } = useCollectionsQuery();
+
+	const collectionsById = useMemo(
+		() => new Map(collections.map((collection) => [collection.id, collection])),
+		[collections]
+	);
+
+	return useMemo(() => {
+		if (search === "" || isError || !data) return [];
+
+		const items: PaletteItem[] = data.data.map((run) => ({
+			id: `run:${run.id}`,
+			kind: "run" as const,
+			title: runTitle(run, collectionsById),
+			subtitle: `${RUN_KIND_LABEL[run.type]} · ${run.status} · ${formatRelativeTime(run.startTime)}`,
+			// The engine already decided this row matches; cmdk filters the
+			// rendered list again and cannot see the snapshot text that matched,
+			// so the query itself is what keeps the row alive.
+			keywords: [search, run.summary?.method ?? "", run.type, run.status],
+			icon: run.type === "load" ? Zap : run.summary?.scenario ? FolderTree : Clock,
+			...(run.summary?.method ? { method: run.summary.method } : {}),
+			recencyAt: run.startTime,
+			perform: () => openRunTab(run.id),
+		}));
+
+		// Only when the page did not hold everything - see `useSettingsItems`.
+		if (data.pagination.total > data.data.length) {
+			items.push({
+				id: "run:search-more",
+				kind: "run" as const,
+				title: `Search runs for “${search}”…`,
+				subtitle: `${data.pagination.total} runs`,
+				icon: Search,
+				escape: true,
+				keywords: [search],
+				perform: () => {
+					const history = useHistoryStore.getState();
+					// Reset first: type, status and pin filters are applied over
+					// the fetched rows, so a filter left from an earlier visit
+					// could hide the very run this row just promised to show.
+					history.resetFilters();
+					history.setSearchQuery(search);
+					useLayoutStore.getState().setDrawerOpen(true);
+					useLayoutStore.getState().setDrawerView("history");
+				},
+			});
+		}
+
+		return items;
+	}, [search, isError, data, collectionsById]);
+}

--- a/app/src/modules/palette/sources/useSettingsItems.ts
+++ b/app/src/modules/palette/sources/useSettingsItems.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Individual settings, as palette results.
+ *
+ * The registry already offers one command per settings *section*, which reaches
+ * the twelve screens. This reaches the ~65 entries on them: a user who knows
+ * the app has a request timeout should not have to guess which of five engine
+ * categories owns it, and `dbCacheSize` - the name every doc, log line and MCP
+ * call uses - should find its row even though the screen labels it "Cache Size".
+ *
+ * Two things it deliberately does not do:
+ *
+ * - **It does not index panels.** `SettingsIndexEntry` has a `panel` kind, and
+ *   the command registry already generates a command per panel from the same
+ *   registry; indexing them here would put every settings screen in the group
+ *   twice, under two rows that do the same thing.
+ * - **It does not own a matcher.** `searchSettings` is the sidebar's ranking,
+ *   and a palette that ranked settings differently from the settings sidebar
+ *   would be two answers to one question. One index, one ranking, two UIs.
+ */
+
+import { useMemo } from "react";
+import { Search } from "lucide-react";
+import { useLayoutStore, useTabsStore } from "@/stores";
+import { useSettingsStore } from "@/modules/settings/settings-store";
+import { useSettingsIndex } from "@/modules/settings/useSettingsIndex";
+import { searchSettings, type SettingsIndexEntry } from "@/lib/settings-index";
+import { DEEP_GROUP_LIMIT, type PaletteItem } from "../types";
+
+/**
+ * Reveal one settings entry - the same two calls in the same order as the
+ * sidebar's own result rows and the registry's section commands: select first,
+ * then open, so the tab renders the asked-for panel rather than the previous
+ * selection for one frame. The anchor is what `useRevealedSetting` scrolls to
+ * and outlines.
+ */
+function reveal(entry: SettingsIndexEntry): void {
+	useSettingsStore.getState().setSelectedCategory(entry.category, entry.anchor);
+	useTabsStore.getState().openTab({ type: "settings", entityId: null });
+}
+
+export function useSettingsItems(query: string): PaletteItem[] {
+	const index = useSettingsIndex();
+	const needle = query.trim();
+
+	return useMemo(() => {
+		// Deep search is search. The palette's empty state answers "what was I
+		// just doing", and sixty-five settings rows are not that.
+		if (needle === "") return [];
+
+		const matches = searchSettings(index, needle).filter((entry) => entry.kind !== "panel");
+		const shown = matches.slice(0, DEEP_GROUP_LIMIT);
+
+		const items: PaletteItem[] = shown.map((entry) => ({
+			id: `setting:${entry.kind}:${entry.id}`,
+			kind: "settings" as const,
+			title: entry.label,
+			// The engine key is part of what the row says, because that is what
+			// docs, logs and MCP calls name the setting; an app setting has no
+			// such name, so its subtitle is just the panel that holds it.
+			subtitle:
+				entry.kind === "engine"
+					? `${entry.categoryLabel} · ${entry.id}`
+					: entry.categoryLabel,
+			// Everything `searchSettings` matched on, so cmdk - which filters the
+			// rendered list a second time - cannot hide a row this source has
+			// already decided matches. Its own `value` covers label and subtitle.
+			keywords: [entry.id, ...entry.keywords, entry.description],
+			perform: () => reveal(entry),
+		}));
+
+		// Only when there is more, and never as a consolation prize: an escape
+		// row over an exhausted result set would send the user to a surface that
+		// shows them the same rows again.
+		if (matches.length > shown.length) {
+			items.push({
+				id: "setting:search-more",
+				kind: "settings" as const,
+				title: `Search settings for “${needle}”…`,
+				subtitle: `${matches.length} matches`,
+				icon: Search,
+				escape: true,
+				keywords: [needle],
+				perform: () => {
+					// The sidebar's box reads this, so the drawer opens already
+					// filtered - the palette finds, the destination browses.
+					useSettingsStore.getState().setSearchQuery(needle);
+					useLayoutStore.getState().setDrawerOpen(true);
+					useLayoutStore.getState().setDrawerView("settings");
+					useTabsStore.getState().openTab({ type: "settings", entityId: null });
+				},
+			});
+		}
+
+		return items;
+	}, [index, needle]);
+}

--- a/app/src/modules/palette/sources/useVariableItems.test.ts
+++ b/app/src/modules/palette/sources/useVariableItems.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The secrets invariant, held at the source rather than at the screen.
+ *
+ * A rendered assertion cannot hold this one. cmdk filters the palette's list a
+ * second time, on the row's own value and keywords, so a source that indexed
+ * values would still show nothing for a query that matched only a value - the
+ * leak would sit in the produced items, invisible to the DOM and one keyword
+ * change away from being searchable. So this reads what the hook returns.
+ *
+ * Mutation check: make `matchRank` fall back to the variable's value, or append
+ * values to `keywords`, and the assertions below fail.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useVariableItems } from "./useVariableItems";
+import type { PaletteItem } from "../types";
+
+/** Distinct enough that finding it anywhere in the output is unambiguous. */
+const SECRET_VALUE = "s3cr3t-bearer-value";
+const PLAIN_VALUE = "https://pay.example";
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({
+		data: [
+			{
+				id: "c1",
+				name: "Payments",
+				// Not flagged secret, and still never indexed: `secret` is a
+				// masking hint, so a rule that trusted it would leak every token
+				// nobody remembered to flag.
+				variables: { chargeBaseUrl: { value: PLAIN_VALUE } },
+			},
+		],
+	}),
+	useEnvironmentsQuery: () => ({
+		data: [
+			{
+				id: "e1",
+				name: "Production",
+				variables: { apiToken: { value: SECRET_VALUE, secret: true } },
+			},
+		],
+	}),
+	useGlobalsQuery: () => ({
+		data: { id: "globals", variables: { retryBudget: { value: "3" } } },
+	}),
+}));
+
+/** Everything a row could carry a value in - the whole item bar its handler. */
+function indexedText(items: PaletteItem[]): string {
+	return JSON.stringify(items.map(({ perform: _perform, icon: _icon, ...rest }) => rest));
+}
+
+function items(query: string): PaletteItem[] {
+	return renderHook(() => useVariableItems(query)).result.current;
+}
+
+describe("the secrets invariant", () => {
+	it("indexes a variable's key, and nothing of its value", () => {
+		const found = items("apiToken");
+
+		expect(found.map((item) => item.title)).toEqual(["apiToken"]);
+		expect(found[0].subtitle).toBe("Production");
+		expect(indexedText(found)).not.toContain(SECRET_VALUE);
+	});
+
+	it("cannot be searched by a value, secret or not", () => {
+		expect(items("s3cr3t")).toEqual([]);
+		expect(items("pay.example")).toEqual([]);
+	});
+
+	it("carries no value on any row, whatever the query matched", () => {
+		for (const query of ["apiToken", "chargeBaseUrl", "retryBudget", "Production"]) {
+			const text = indexedText(items(query));
+			expect(text).not.toContain(SECRET_VALUE);
+			expect(text).not.toContain(PLAIN_VALUE);
+		}
+	});
+});
+
+describe("scoping", () => {
+	it("names the scope that defines each key", () => {
+		expect(items("retryBudget")[0].subtitle).toBe("Globals");
+		expect(items("chargeBaseUrl")[0].subtitle).toBe("Payments");
+	});
+
+	it("contributes nothing to the empty query", () => {
+		expect(items("")).toEqual([]);
+		expect(items("   ")).toEqual([]);
+	});
+
+	it("puts a scope whose own name matches above a key in another scope", () => {
+		// "Production" is an environment name; nothing else here matches it.
+		const found = items("Production");
+		expect(found[0].title).toBe("Production");
+		expect(found[0].subtitle).toBe("Environment");
+	});
+});

--- a/app/src/modules/palette/sources/useVariableItems.ts
+++ b/app/src/modules/palette/sources/useVariableItems.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Environments and variable keys, as palette results.
+ *
+ * A `{{token}}` that resolves to the wrong thing is one of the app's easiest
+ * mistakes to make and hardest to find, because answering "where is this
+ * defined" means opening the Variables tab and clicking through every scope.
+ * This makes the key itself the thing you search for, and lands on the scope
+ * that defines it.
+ *
+ * **Values are never indexed, secret or not.** A variable's value is the one
+ * piece of this data that can be a bearer token, and the palette is a surface
+ * that renders whatever it matches - so this source reads keys and scope names
+ * and never touches `.value`. `secret` is only a masking hint (see
+ * `VariableValue`), so a rule that trusted it would leak every token nobody
+ * remembered to flag. `useVariableItems.test.ts` holds the invariant.
+ *
+ * Client-side throughout: collections, environments and globals are all in
+ * cache, so typing here costs nothing.
+ */
+
+import { useMemo } from "react";
+import { Braces, Cloud, Globe, Layers } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useTabsStore } from "@/stores";
+import { useCollectionsQuery, useEnvironmentsQuery, useGlobalsQuery } from "@/queries";
+import { useVariablesStore, type VariableCategory } from "@/modules/variables/variables-store";
+import { DEEP_GROUP_LIMIT, type PaletteItem } from "../types";
+
+/** One scope's identity: what it is called, what opens it, how it is drawn. */
+interface Scope {
+	/** Stable within a run of the app - the scope's own id, or "globals". */
+	key: string;
+	label: string;
+	icon: LucideIcon;
+	category: VariableCategory;
+	/** The keys defined in this scope. Never their values. */
+	variableKeys: string[];
+}
+
+/**
+ * Open the Variables tab on one scope - the two calls the variables tree's own
+ * `selectCategory` makes, in that order.
+ */
+function openScope(category: VariableCategory): void {
+	useVariablesStore.getState().setSelectedCategory(category);
+	useTabsStore.getState().openTab({ type: "variables", entityId: null });
+}
+
+/**
+ * Prefix matches before contained ones, and everything else in scope order.
+ *
+ * Lower sorts first; `null` means no match. Deliberately smaller than
+ * `searchSettings`' ranking: a variable has a key and a scope name and nothing
+ * else to weigh.
+ */
+function matchRank(haystack: string, needle: string): number | null {
+	const value = haystack.toLowerCase();
+	if (value.startsWith(needle)) return 0;
+	if (value.includes(needle)) return 1;
+	return null;
+}
+
+export function useVariableItems(query: string): PaletteItem[] {
+	const { data: collections = [] } = useCollectionsQuery();
+	const { data: environments = [] } = useEnvironmentsQuery();
+	const { data: globals } = useGlobalsQuery();
+	const needle = query.trim().toLowerCase();
+
+	const scopes = useMemo<Scope[]>(() => {
+		// Resolution order runs environment > collection > global, and the tree
+		// lists the scopes that way round; this follows it, so the palette agrees
+		// with the screen about which scope wins.
+		const built: Scope[] = environments.map((environment) => ({
+			key: environment.id,
+			label: environment.name,
+			icon: Cloud,
+			category: { type: "environment", environmentId: environment.id },
+			variableKeys: Object.keys(environment.variables ?? {}),
+		}));
+		for (const collection of collections) {
+			built.push({
+				key: collection.id,
+				label: collection.name,
+				icon: Layers,
+				category: { type: "collection", collectionId: collection.id },
+				variableKeys: Object.keys(collection.variables ?? {}),
+			});
+		}
+		built.push({
+			key: "globals",
+			label: "Globals",
+			icon: Globe,
+			category: { type: "globals" },
+			variableKeys: Object.keys(globals?.variables ?? {}),
+		});
+		return built;
+	}, [collections, environments, globals]);
+
+	return useMemo(() => {
+		// Deep search is search - see `useSettingsItems` for why the empty query
+		// contributes nothing.
+		if (needle === "") return [];
+
+		const ranked: { item: PaletteItem; rank: number }[] = [];
+
+		for (const scope of scopes) {
+			// An environment is findable by its own name, not only by what it
+			// defines - it is the thing a user switches between.
+			if (scope.category.type === "environment") {
+				const rank = matchRank(scope.label, needle);
+				if (rank !== null) {
+					ranked.push({
+						rank,
+						item: {
+							id: `variable-scope:${scope.key}`,
+							kind: "variable",
+							title: scope.label,
+							subtitle: "Environment",
+							keywords: ["environment", "env", "scope"],
+							icon: scope.icon,
+							perform: () => openScope(scope.category),
+						},
+					});
+				}
+			}
+
+			for (const variableKey of scope.variableKeys) {
+				const rank = matchRank(variableKey, needle);
+				if (rank === null) continue;
+				ranked.push({
+					// +2 so a scope whose *name* matches outranks a key inside
+					// some other scope that merely contains the same letters.
+					rank: rank + 2,
+					item: {
+						id: `variable:${scope.key}:${variableKey}`,
+						kind: "variable",
+						title: variableKey,
+						subtitle: scope.label,
+						keywords: ["variable", `{{${variableKey}}}`],
+						icon: Braces,
+						perform: () => openScope(scope.category),
+					},
+				});
+			}
+		}
+
+		// Stable sort, so ties keep scope order (environments, collections,
+		// globals) rather than reshuffling as the query grows.
+		ranked.sort((a, b) => a.rank - b.rank);
+		// No escape row: unlike settings and runs there is no surface that
+		// browses variables across scopes - the Variables tab edits one scope at
+		// a time - so a "see all" row would have nowhere to go.
+		return ranked.slice(0, DEEP_GROUP_LIMIT).map((entry) => entry.item);
+	}, [scopes, needle]);
+}

--- a/app/src/modules/palette/types.ts
+++ b/app/src/modules/palette/types.ts
@@ -27,6 +27,8 @@ export const PALETTE_GROUPS = [
 	"view",
 	"command",
 	"settings",
+	"variable",
+	"run",
 ] as const;
 
 export type PaletteKind = (typeof PALETTE_GROUPS)[number];
@@ -41,7 +43,20 @@ export const PALETTE_GROUP_LABELS: Record<PaletteKind, string> = {
 	// Its own group rather than more Commands: twelve sections would bury the
 	// five things the palette can actually *do*.
 	settings: "Settings",
+	variable: "Variables",
+	run: "Runs",
 };
+
+/**
+ * How many rows a deep-search group shows before handing off to its escape row.
+ *
+ * The deep sources index corpora the shallow ones do not have: ~65 settings
+ * entries, every variable key in every scope, and a run archive that has no
+ * bound at all. Un-capped, one of them would own the whole list for any query
+ * broad enough to hit it - so each shows its best few and offers a row that
+ * opens the surface built for browsing the rest.
+ */
+export const DEEP_GROUP_LIMIT = 7;
 
 export interface PaletteItem {
 	/** Unique across all sources - used as the React key. */
@@ -61,6 +76,19 @@ export interface PaletteItem {
 	 * nothing knows. Orders the empty query - see `rankForEmptyQuery`.
 	 */
 	recencyAt?: number;
+	/**
+	 * A "search the rest of these over there" row rather than a result: it
+	 * leaves the palette for the surface that browses this corpus properly,
+	 * carrying the query with it.
+	 *
+	 * Rendered in a group of its own, below its results, and that placement is
+	 * the reason for the flag. cmdk re-sorts a group's items by match score, and
+	 * an escape row has to carry the query in its keywords to survive that same
+	 * filter - which would score it *above* every result it is an escape from.
+	 * A separate group has its own item container, so nothing sorts across the
+	 * boundary.
+	 */
+	escape?: boolean;
 	/** What Enter (or a click) does. The palette closes itself afterwards. */
 	perform: () => void;
 }

--- a/app/src/modules/settings/settings-store.ts
+++ b/app/src/modules/settings/settings-store.ts
@@ -26,17 +26,30 @@ interface SettingsState {
 	 */
 	highlightedKey: string | null;
 
+	/**
+	 * What the settings sidebar's search box holds.
+	 *
+	 * Store state rather than the tree's own `useState` because the palette's
+	 * "Search settings for …" escape row hands its query over: the palette
+	 * finds, the sidebar browses, and the browse surface has to open already
+	 * filtered. A user still only ever types into the tree's own box.
+	 */
+	searchQuery: string;
+
 	// Actions
 	setSelectedCategory: (category: SettingsCategory | null, highlightedKey?: string) => void;
 	clearHighlight: () => void;
+	setSearchQuery: (query: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
 	// Default to a real category so the settings tab opens with content
 	selectedCategory: "appearance",
 	highlightedKey: null,
+	searchQuery: "",
 
 	setSelectedCategory: (category, highlightedKey) =>
 		set({ selectedCategory: category, highlightedKey: highlightedKey ?? null }),
 	clearHighlight: () => set({ highlightedKey: null }),
+	setSearchQuery: (query) => set({ searchQuery: query }),
 }));

--- a/app/src/modules/settings/sidebar/SettingsCategoryTree.tsx
+++ b/app/src/modules/settings/sidebar/SettingsCategoryTree.tsx
@@ -14,15 +14,19 @@
  *
  * Plus the search that spans both: ~45 engine entries and 7 app panels used to
  * be findable only by guessing which category owned them. Typing filters the
- * shared settings index (`lib/settings-index.ts`) over labels, descriptions and
- * engine keys; picking a result selects the owning category and asks the main
- * view to reveal that entry.
+ * shared settings index (`useSettingsIndex`, over `lib/settings-index.ts`) by
+ * labels, descriptions and engine keys; picking a result selects the owning
+ * category and asks the main view to reveal that entry.
+ *
+ * The box's text lives in `settings-store` rather than here, so the command
+ * palette's "Search settings for …" row can hand its query over and land the
+ * user on an already-filtered sidebar.
  *
  * Category rows share a single selected treatment (the app's `--primary`
  * accent); there is no per-category color.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useSettingsStore } from "@/modules/settings/settings-store";
 import { useTabsStore } from "@/stores";
 import { DrawerPanel, ErrorState } from "@/components/shared";
@@ -33,9 +37,9 @@ import { Search, Settings, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button, Input, Skeleton } from "@/components/ui";
 import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
-import { APP_SETTINGS } from "@/modules/settings/main/app-settings";
 import { ENGINE_SETTINGS_CATEGORIES } from "@/modules/settings/engine-categories";
-import { buildSettingsIndex, searchSettings } from "@/lib/settings-index";
+import { useSettingsIndex } from "@/modules/settings/useSettingsIndex";
+import { searchSettings } from "@/lib/settings-index";
 
 interface CategoryMeta {
 	label: string;
@@ -64,10 +68,10 @@ function SectionHeading({ children, icon: Icon }: { children: string; icon?: Luc
 }
 
 export default function SettingsCategoryTree() {
-	const { selectedCategory, setSelectedCategory } = useSettingsStore();
+	const { selectedCategory, setSelectedCategory, searchQuery: query } = useSettingsStore();
+	const setQuery = useSettingsStore((s) => s.setSearchQuery);
 	const { openTab } = useTabsStore();
-	const { data: configResponse, isLoading, error, refetch } = useConfigQuery();
-	const [query, setQuery] = useState("");
+	const { isLoading, error, refetch } = useConfigQuery();
 
 	// Selecting a category shows its panel in the settings tab. The tree now
 	// lives in the Drawer (not inside the settings tab), so it must open/focus
@@ -77,16 +81,9 @@ export default function SettingsCategoryTree() {
 		openTab({ type: "settings", entityId: null });
 	};
 
-	const index = useMemo(
-		() =>
-			buildSettingsIndex({
-				panels: APP_SETTINGS_PANELS,
-				appSettings: APP_SETTINGS,
-				engineEntries: configResponse?.entries ?? [],
-				engineCategories: ENGINE_SETTINGS_CATEGORIES,
-			}),
-		[configResponse]
-	);
+	// The same corpus the palette's settings source searches - see
+	// `useSettingsIndex`.
+	const index = useSettingsIndex();
 
 	const trimmedQuery = query.trim();
 	const results = useMemo(

--- a/app/src/modules/settings/useSettingsIndex.ts
+++ b/app/src/modules/settings/useSettingsIndex.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The settings search corpus, assembled once.
+ *
+ * `lib/settings-index.ts` is the pure half - it flattens catalogues and ranks
+ * matches, and knows nothing about React. This is the half that says *which*
+ * catalogues: the app-panel registry, the app-settings catalogue, the engine
+ * category registry, and the engine entries the `/config` query holds.
+ *
+ * A hook rather than four imports repeated at each call site, because there are
+ * now two call sites - the settings sidebar's search box and the palette's
+ * settings source - and "one branch defines it, the other re-derives it inline"
+ * is this codebase's most repeated wiring defect. One index, two UIs.
+ */
+
+import { useMemo } from "react";
+import { useConfigQuery } from "@/queries";
+import { buildSettingsIndex, type SettingsIndexEntry } from "@/lib/settings-index";
+import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
+import { APP_SETTINGS } from "@/modules/settings/main/app-settings";
+import { ENGINE_SETTINGS_CATEGORIES } from "@/modules/settings/engine-categories";
+
+/**
+ * Every searchable settings entry: the seven client panels, the settings inside
+ * them, and the engine entries.
+ *
+ * The engine half is empty until `/config` answers, and empty is the honest
+ * answer while it has not - the app half is client-side and searchable
+ * immediately, which is why Settings stays usable with the engine down.
+ */
+export function useSettingsIndex(): SettingsIndexEntry[] {
+	const { data: configResponse } = useConfigQuery();
+
+	return useMemo(
+		() =>
+			buildSettingsIndex({
+				panels: APP_SETTINGS_PANELS,
+				appSettings: APP_SETTINGS,
+				engineEntries: configResponse?.entries ?? [],
+				engineCategories: ENGINE_SETTINGS_CATEGORIES,
+			}),
+		[configResponse]
+	);
+}

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -37,6 +37,8 @@ export { RequestNotFoundError } from "./collections";
 // Runs (History)
 export {
 	useRunsQuery,
+	useRunSearchQuery,
+	RUN_SEARCH_LIMIT,
 	useAllRunsQuery,
 	flattenRunPages,
 	runsTotal,

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -74,6 +74,12 @@ export const queryKeys = {
 		// moves, or when the run set changes without a known request.
 		baselines: () => [...queryKeys.runs.all, "baseline"] as const,
 		baseline: (requestId: string) => [...queryKeys.runs.baselines(), requestId] as const,
+		// One small page of runs matching a palette query. Its own family for the
+		// fifth time and the same reason as the four above: it caches a plain
+		// `RunListResponse`, and the delete-run patch walks everything under
+		// `lists()` as `InfiniteData`.
+		searches: () => [...queryKeys.runs.all, "search"] as const,
+		search: (q: string) => [...queryKeys.runs.searches(), q] as const,
 		allRuns: () => [...queryKeys.runs.all, "allRuns"] as const,
 		details: () => [...queryKeys.runs.all, "detail"] as const,
 		detail: (id: string) => [...queryKeys.runs.details(), id] as const,

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -103,6 +103,38 @@ export function runsTotal(data: InfiniteData<RunListResponse> | undefined): numb
 	return data?.pages[0]?.pagination.total ?? 0;
 }
 
+/** How many run rows the command palette's Runs group asks the engine for. */
+export const RUN_SEARCH_LIMIT = 7;
+
+/**
+ * One small page of runs matching a free-text query - the command palette's
+ * Runs group.
+ *
+ * Its own hook rather than {@link useRunsQuery} with a `q`, for three reasons
+ * that all come from the caller being a search box rather than a list: it wants
+ * one page and never pages further, it must not install a 5s poll for every
+ * query a user types through, and its rows must not join the infinite-list
+ * caches the delete patch walks (see `queryKeys.runs.searches`).
+ *
+ * No `staleTime`: the palette mounts its sources only while it is open, so a
+ * refetch on open is one small request and is what keeps a run deleted since
+ * the last search out of the list. `retry: false` because an engine that is
+ * down is an answer here - the group hides rather than making a typist wait
+ * through a retry budget.
+ *
+ * Disabled on an empty query: the palette's empty state is "what you were just
+ * doing", which is the job of the tab and request sources.
+ */
+export function useRunSearchQuery(q: string) {
+	const search = q.trim();
+	return useQuery({
+		queryKey: queryKeys.runs.search(search),
+		queryFn: () => apiService.listRuns({ q: search, limit: RUN_SEARCH_LIMIT }),
+		enabled: search !== "",
+		retry: false,
+	});
+}
+
 /**
  * Fetch every run (all pages) as a flat list. For callers that need the whole
  * set rather than a polled page - counting and clearing history in Settings.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -439,7 +439,9 @@ Adding an app panel is three edits and no branching: a member on `ClientSettings
 
 ### Search
 
-`lib/settings-index.ts` is a **pure** module: `buildSettingsIndex` flattens three catalogues into one list - the app panels (`app-panels.ts`), the settings inside them (`app-settings.ts`) and the engine entries from `GET /config` - and `searchSettings` filters and ranks it (label, then id, then keywords, then description, then category label; an empty query means "not searching" and returns everything). It is deliberately free of React and stores so the sidebar's search box and the command palette's settings source share one corpus.
+`lib/settings-index.ts` is a **pure** module: `buildSettingsIndex` flattens three catalogues into one list - the app panels (`app-panels.ts`), the settings inside them (`app-settings.ts`) and the engine entries from `GET /config` - and `searchSettings` filters and ranks it (label, then id, then keywords, then description, then category label; an empty query means "not searching" and returns everything). It is deliberately free of React and stores.
+
+`modules/settings/useSettingsIndex.ts` is the half that names the catalogues and reads the `/config` query. Both consumers call it - the sidebar's search box and the palette's `useSettingsItems` source - rather than each assembling the four inputs inline, which is the "one branch defines it, the other re-derives it" wiring defect this repo keeps finding. One index, one ranking, two UIs. The sidebar's query text lives in `settings-store` (`searchQuery`) for the same reason the index is shared: the palette's escape row hands its query over, so the drawer opens already filtered.
 
 **Index the settings, not the screens.** The first version held panel titles and engine entries only, and a user searching "theme", "color" or "font" got nothing - the panel that holds all three is called "Appearance" and describes itself as "the look and feel of the application". `app-settings.ts` is the app-side catalogue that fixes it: one `AppSettingDescriptor` per setting (`anchor`, `panel`, `label`, `searchText`, optional `keywords` for the words a user types that the copy never uses - "dark mode", "accent", "zoom"). A new app setting needs an entry here, or it is unfindable.
 
@@ -527,11 +529,14 @@ run any command by name. Mounted once by `Shell`, alongside `ImportModal`.
 - **`CommandPalette.tsx`** - the dialog, the chord, focus restoration, the open flag
   (`useLayoutStore.paletteOpen` / `setPaletteOpen`, deliberately not persisted), and the host
   for the dialogs its commands open (see `useCommandSurfaces.ts` below).
-- **`sources/`** - one hook per family, each returning `PaletteItem[]`: `useTabItems` (open
+- **`sources/`** - one hook per family, each returning `PaletteItem[]`. Two shapes of source:
+  the **shallow** ones return everything they know and let cmdk filter it - `useTabItems` (open
   tabs), `useEntityItems` (requests + collections), `useViewItems` (drawer views and singleton
-  tabs). `commandItems.ts` is the fourth and is a plain function, not a hook: it owns no data,
-  it maps the [command registry](#command-registry-libcommands) onto the same shape. Adding
-  environments or runs later is a new source and nothing else.
+  tabs) - while the **deep** ones take the query, because their corpus is too large to render:
+  `useSettingsItems` (every app setting and engine entry, through the shared settings index),
+  `useVariableItems` (environment names and variable keys across every scope) and `useRunItems`
+  (server-backed, `GET /runs?q=`). `commandItems.ts` is a plain function, not a hook: it owns no
+  data, it maps the [command registry](#command-registry-libcommands) onto the same shape.
 - **`useCommandSurfaces.ts`** - the collection picker, the run dialog and the theme hook, which
   three commands need and no store can hold. Their original hosts are not always on screen (the
   welcome screen's picker only on the welcome tab, the tree's run dialog only while the drawer
@@ -559,9 +564,34 @@ Three things about it are load-bearing:
 Ranking: cmdk's own match score once anything is typed; on the empty query, `rankForEmptyQuery`
 puts the most recent first - focus time for tabs (`tabFocusedAt` in `tabs-store`, session-scoped),
 last-run time for requests (from the run history already in cache). Groups render in a fixed
-order (Tabs, Requests, Collections, Views, Commands, Settings) so the list does not reshuffle as
-you type. Settings is its own group rather than more Commands: twelve sections would bury the
-handful of things the palette can actually *do*.
+order (Tabs, Requests, Collections, Views, Commands, Settings, Variables, Runs) so the list does
+not reshuffle as you type. Settings is its own group rather than more Commands: twelve sections
+would bury the handful of things the palette can actually *do*.
+
+Four rules govern the deep sources, and each exists because of a way the naive version fails:
+
+- **They contribute nothing to the empty query.** The palette's empty state answers "what was I
+  just doing"; ~65 settings entries and every variable key in the app are not that, and a
+  server-backed group must not fetch for a palette nobody typed into.
+- **Each caps itself at `DEEP_GROUP_LIMIT` rows and offers an escape row** - `Search settings
+  for "x"…`, `Search runs for "x"…` - that opens the surface built for browsing the rest, with
+  the query carried over (the settings sidebar's `searchQuery`, the History drawer's, whose
+  other filters the escape resets so a stale one cannot hide what was just promised). The row
+  appears only when there *is* more. Variables has none: no surface browses variables across
+  scopes, so it would have nowhere to go.
+- **An escape row renders in a group of its own**, below the results. cmdk re-sorts a group's
+  items by score, and an escape row has to carry the query verbatim to survive that filter -
+  which would score it above every result it is an escape from. A separate group has its own
+  item container, so nothing sorts across the boundary.
+- **A deep row carries what matched in its `keywords`**, because cmdk filters the rendered list
+  a second time and would otherwise drop rows the source already matched - decisively so for
+  runs, where the engine matched against stored snapshot text that no row prints.
+
+Two invariants are tested rather than commented. **A variable's value is never indexed**, secret
+or not (`secret` is a masking hint, so trusting it would leak every token nobody flagged) - held
+in `sources/useVariableItems.test.ts` against the source's output, because cmdk's second filter
+would hide an indexed value from any DOM assertion. And **an engine that is down hides the Runs
+group silently**: typing is idle input, and idle input must never raise a toast.
 
 **Entry points:** the chord, and the `Search` tile on the welcome Launcher. The title bar's
 search bar (#529) is the third and becomes the primary one - it flips the same store flag.


### PR DESCRIPTION
## Description

Phase 3 of the command palette: the "everything" half. Three new sources - settings entries, variables, and past runs - plus the grouping, caps and escape rows that keep them from swamping the list.

**The plan.** Root cause: the palette could reach things that *have* a place in a tree - tabs, requests, collections, views - and the registry gave it actions. Everything else was still findable only by knowing which screen owned it: a setting by guessing one of twelve categories, a variable key by clicking through every scope in the Variables tab, a run by scrolling History. The approach is a second *shape* of source rather than three more of the same. A shallow source returns everything it knows and lets cmdk filter it; a **deep** source takes the query, because its corpus is too large to render - it ranks and caps itself at `DEEP_GROUP_LIMIT`, and offers an escape row into the surface built for browsing the rest, with the query carried over. The alternative I rejected was giving each deep source its own matcher and its own settings corpus: `useSettingsIndex` extracts the four-catalogue assembly the sidebar was doing inline, so the palette and the sidebar rank settings identically - a palette that disagreed with the settings sidebar about what "cache" matches is two answers to one question, and an inline second copy is exactly the "one branch defines it, the other re-derives it" defect `CLAUDE.md` names.

**The three sources.**

- **Settings** (`useSettingsItems`) - every app setting and engine entry, through #523's index. Enter selects the owning category and leaves the entry's anchor for `useRevealedSetting` to scroll to and outline - the same two calls, in the same order, as the sidebar's own result rows. **Panels are deliberately excluded**: the command registry already generates one command per settings section from the same registries, so indexing the index's `panel` kind would list every settings screen twice under two rows that do the same thing.
- **Variables** (`useVariableItems`) - environment names and variable keys across globals, collections and environments; Enter opens the Variables tab scoped to the owner. **Values are never indexed, secret or not** - `secret` is only a masking hint (see `VariableValue`), so a rule that trusted it would leak every token nobody remembered to flag.
- **Runs** (`useRunItems`) - server-backed through a new `useRunSearchQuery`: one small page, no poll, no retry, its own key family (a plain `RunListResponse` must not sit under `lists()`, which the delete patch walks as `InfiniteData` - the same reason the four sibling families exist). Debounced 300ms, matching the History sidebar's own search box. An engine that is down **hides the group silently**; typing is idle input and idle input must never raise a toast.

**Two things about the rendering are load-bearing.**

- **An escape row renders in a group of its own**, below the results. cmdk re-sorts a group's items by match score, and an escape row has to carry the query verbatim to survive that same filter - which would score it *above* every result it is an escape from. A separate `CommandGroup` has its own item container, so nothing sorts across the boundary.
- **A deep row carries what matched in its `keywords`**, because cmdk filters the rendered list a second time and would otherwise drop rows the source already matched. Decisive for runs, where the engine matched against stored snapshot text that no row prints.

### Deliberate deviations from the issue spec

- **The deep sources contribute nothing to the empty query.** The issue does not say either way; the palette's empty state answers "what was I just doing", and ~65 settings entries plus every variable key in the app is not that. It also means a palette nobody typed into asks the engine for nothing.
- **Variables gets no escape row.** The issue specs escapes for Settings and Runs and names no variables surface, correctly: the Variables tab edits one scope at a time, so there is nothing that browses variables across scopes for the row to open. Capped, and that is all.
- **`GET /runs?q=` is fetched by a new hook rather than `useRunsQuery(q)`.** Reusing the infinite list would install a 5s poll per query a user types through and put palette results in the caches the delete patch walks. Modelled on the four existing purpose-specific run queries (`useLastDesignRunQuery` and siblings), not invented.
- **The settings sidebar's search text moves into `settings-store`.** Required by the escape row (it has to hand the query over); the visible consequence is that the box keeps its text across a drawer close, which reads as an improvement rather than a regression.
- **`RUN_KIND_LABEL` moved** from `RunItem.tsx` to `modules/history/types.ts`. The palette names run types too, and a run must not be a "collection" run in the sidebar and a "scenario" run in the palette - the hand-rolled-copy rule applied to a one-line map rather than a component.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **App suite: 417 files, 4232 tests passed** (190s). No pre-existing failures.
- `pnpm type-check`, `pnpm lint` (zero warnings) and `pnpm format:check` clean.
- Engine untouched (`Engine: none. MCP: none.` per the issue), so no engine build or ctest run - nothing there could change colour.
- `mkdocs build --strict` clean for the `docs/` change.

New tests:

- `modules/palette/deep-sources.test.tsx` (15 tests) - the three sources through the palette, because what they promise is a *landing*, not a list. Settings: an engine entry found by its key reveals it in its category **with the anchor set** (that field is what `useRevealedSetting` reads), an app setting found by a keyword its panel never prints, and no panel listed twice. Variables: a key lands scoped, a globals key names its scope, an environment is found by its own name. Runs: the debounce (fake timers - the engine is asked nothing mid-word), a run row opening its tab, a collection run named by its collection, and the engine-down case. Plus the cap and both escape rows landing their destinations pre-filtered, and the empty query contributing nothing.
- `modules/palette/sources/useVariableItems.test.ts` (6 tests) - **the secrets invariant, held against the source's output rather than the DOM.** A rendered assertion cannot hold it: cmdk filters the list a second time, so a source that indexed values would show nothing for a value query and still carry the value in its items. Mutation-checked both ways - appending values to `keywords` fails two of these, and making the matcher read values fails "cannot be searched by a value".

Mutation checks run on the other guards too: putting escape rows back in the results group fails the cap test; dropping the `isError` branch fails "hides the group when the engine is down" (the fixture leaves a page in hand, as TanStack does after a failed refetch, so the group can only disappear because of that branch).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

`docs/app/COMPONENTS.md` in the same commit: the palette's source list split into shallow and deep, the four deep-source rules with the failure each prevents, the two tested invariants, the widened group order, and - in the Settings section - `useSettingsIndex` as the one place the catalogues are named, plus why the sidebar's query text now lives in the store.

## Related Issues
Closes #527

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfaPjjnu9q7CDsgDSnTwfv)_