### PR TITLE
feat(app/palette): start a load test from the palette, against the live draft

### DIFF
--- a/app/src/lib/commands/index.ts
+++ b/app/src/lib/commands/index.ts
@@ -7,5 +7,6 @@
 
 export { COMMANDS, availableCommands, commandById } from "./registry";
 export { baseCommandContext } from "./context";
+export { useLiveCommandSurfaceStore, useRegisterLoadTestSurface } from "./live-surfaces";
 export { commandTitle } from "./types";
 export type { Command, CommandContext, CommandGroup, CommandSurfaces } from "./types";

--- a/app/src/lib/commands/live-surfaces.ts
+++ b/app/src/lib/commands/live-surfaces.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The channel a *mounted feature* contributes a command surface through.
+ *
+ * `CommandSurfaces` was originally the palette host's own set: three dialogs it
+ * mounts itself, so it can always offer them. One action does not fit that
+ * shape. Starting a load test needs the request builder's **live editor draft**
+ * - the URL, headers, body and auth as currently typed, before autosave has run
+ * - and that draft exists only inside `RequestBuilderProvider`, which the
+ * palette is a sibling of. A command reaching for the saved request instead
+ * would run the *old* URL after an edit and report it as the run the user asked
+ * for: a near-miss that reads as a bug, which is why #526 shipped the registry
+ * without this command rather than approximating it.
+ *
+ * So the mounted feature hands its own handler out, and the palette merges what
+ * is registered into the surfaces it offers. The alternative - reading the draft
+ * out of the provider from outside it, or recomposing the payload in the command
+ * - would be a second copy of `buildExecBody` and the single-active-run policy,
+ * exactly the "hand-rolled copy of a primitive" defect the registry exists to
+ * remove. Nothing about the load test moves; only its *reachability* changes.
+ *
+ * **One slot, one contributor.** A registry of arbitrary named surfaces would be
+ * a framework built for a second caller that does not exist yet. When one
+ * arrives - a "Send request" command has the same live-draft problem - it joins
+ * this file as a second slot, rather than inventing a second channel.
+ *
+ * **The clear is identity-checked.** Unmount effects run before the next mount's
+ * effects, so switching request tabs clears then registers in the right order -
+ * but a remount that ever lands the other way round would otherwise leave the
+ * slot empty with a builder on screen. Comparing identity makes the clear a
+ * no-op for anyone but the current holder.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { create } from "zustand";
+
+interface LiveCommandSurfaceState {
+	/** The mounted request builder's start-load-test handler, or null. */
+	startLoadTest: (() => void) | null;
+	registerStartLoadTest: (handler: () => void) => void;
+	/** Drops `handler` if it is still the registered one. */
+	clearStartLoadTest: (handler: () => void) => void;
+}
+
+export const useLiveCommandSurfaceStore = create<LiveCommandSurfaceState>((set) => ({
+	startLoadTest: null,
+	registerStartLoadTest: (handler) => set({ startLoadTest: handler }),
+	clearStartLoadTest: (handler) =>
+		set((state) => (state.startLoadTest === handler ? { startLoadTest: null } : state)),
+}));
+
+/**
+ * Publish `handler` as the live start-load-test surface for as long as the
+ * caller is mounted.
+ *
+ * The registered function is a **stable** wrapper over a ref rather than
+ * `handler` itself. The builder's own `startLoadTest` closes over the draft, so
+ * its identity changes on every keystroke; registering that directly would write
+ * to this store - and re-render the palette - once per character typed. The
+ * wrapper is written once and reads the current handler when it is called.
+ */
+export function useRegisterLoadTestSurface(handler: () => void): void {
+	const latest = useRef(handler);
+	useEffect(() => {
+		latest.current = handler;
+	}, [handler]);
+
+	const stable = useCallback(() => latest.current(), []);
+
+	useEffect(() => {
+		const { registerStartLoadTest, clearStartLoadTest } = useLiveCommandSurfaceStore.getState();
+		registerStartLoadTest(stable);
+		return () => clearStartLoadTest(stable);
+	}, [stable]);
+}

--- a/app/src/lib/commands/registry.test.ts
+++ b/app/src/lib/commands/registry.test.ts
@@ -109,6 +109,7 @@ describe("availability", () => {
 		expect(ids).not.toContain("new-request");
 		expect(ids).not.toContain("run-collection");
 		expect(ids).not.toContain("toggle-theme");
+		expect(ids).not.toContain("run-load-test");
 		// Nothing is open, so there is no tab to close either.
 		expect(ids).not.toContain("close-tab");
 		// These two need only stores, so the menu bridge can offer them.
@@ -127,10 +128,34 @@ describe("availability", () => {
 		expect(availableCommands(fullContext()).map((c) => c.id)).toContain("run-collection");
 	});
 
+	/*
+	 * The load-test command is the one entry a host cannot satisfy by mounting a
+	 * dialog: it needs the request builder's live draft, contributed while that
+	 * builder is on screen. So a palette host offering everything it *owns* is
+	 * still not enough - which is the mount race, tested here as a state rather
+	 * than as a timing.
+	 */
+	it("hides the load-test command until a mounted builder contributes it", () => {
+		const requestTab: CommandContext = {
+			activeTab: { id: "t1", type: "request", entityId: "r1" },
+			activeTabLabel: "Charge card",
+			activeCollection: null,
+			surfaces: surfaces(),
+		};
+		expect(availableCommands(requestTab).map((c) => c.id)).not.toContain("run-load-test");
+
+		const contributed: CommandContext = {
+			...requestTab,
+			surfaces: { ...surfaces(), startLoadTest: () => {} },
+		};
+		expect(availableCommands(contributed).map((c) => c.id)).toContain("run-load-test");
+	});
+
 	it("names the target of a contextual command, so Enter holds no surprise", () => {
 		const ctx = fullContext();
 		expect(commandTitle(commandById("run-collection"), ctx)).toBe('Run "Payments"');
 		expect(commandTitle(commandById("close-tab"), ctx)).toBe('Close "Payments"');
+		expect(commandTitle(commandById("run-load-test"), ctx)).toBe('Load test "Payments"');
 	});
 
 	it("falls back to a generic close title when nothing knows the label", () => {
@@ -140,6 +165,7 @@ describe("availability", () => {
 			activeCollection: null,
 		};
 		expect(commandTitle(commandById("close-tab"), ctx)).toBe("Close tab");
+		expect(commandTitle(commandById("run-load-test"), ctx)).toBe("Load test this request");
 	});
 });
 
@@ -173,6 +199,16 @@ describe("performing", () => {
 
 		commandById("close-tab").perform(ctx);
 		expect(useTabsStore.getState().openTabs).toHaveLength(0);
+	});
+
+	it("starts a load test through the contributed handler, never a copy of one", () => {
+		let started = 0;
+		const ctx: CommandContext = {
+			...fullContext(),
+			surfaces: { ...surfaces(), startLoadTest: () => started++ },
+		};
+		commandById("run-load-test").perform(ctx);
+		expect(started).toBe(1);
 	});
 
 	it("hands the collection to the host rather than running it itself", () => {

--- a/app/src/lib/commands/registry.ts
+++ b/app/src/lib/commands/registry.ts
@@ -24,7 +24,9 @@
  * added there appears here without an edit, and cannot be named differently.
  */
 
-import { Download, Play, Plus, Settings, SunMoon, X } from "lucide-react";
+// `Zap` is the load-test mark throughout the app - the dashboard tab, a finished
+// load run in the strip (`tab-descriptors.ts`). The palette uses the same bolt.
+import { Download, Play, Plus, Settings, SunMoon, X, Zap } from "lucide-react";
 import { useImportModalStore, useTabsStore } from "@/stores";
 import { useSettingsStore } from "@/modules/settings/settings-store";
 import { APP_SETTINGS_PANELS } from "@/modules/settings/main/app-panels";
@@ -81,6 +83,25 @@ const ACTION_COMMANDS: readonly Command[] = [
 		perform: (ctx) => {
 			if (ctx.activeCollection) ctx.surfaces?.runCollection(ctx.activeCollection);
 		},
+	},
+	{
+		id: "run-load-test",
+		// Named like the other contextual commands. The label is the tab strip's,
+		// so the row and the tab it acts on cannot read differently.
+		title: (ctx) =>
+			ctx.activeTabLabel ? `Load test "${ctx.activeTabLabel}"` : "Load test this request",
+		keywords: ["load", "benchmark", "stress", "performance", "rps", "throughput", "start"],
+		group: "action",
+		icon: Zap,
+		/*
+		 * The one surface no host can mount for itself. Starting a load test needs
+		 * the request builder's live draft, so the mounted builder contributes the
+		 * handler through `live-surfaces.ts` and this command is available exactly
+		 * while that contribution stands - not merely while a request tab is open,
+		 * which is true a frame before the builder has finished loading it.
+		 */
+		available: (ctx) => ctx.surfaces?.startLoadTest !== undefined,
+		perform: (ctx) => ctx.surfaces?.startLoadTest?.(),
 	},
 	{
 		id: "close-tab",

--- a/app/src/lib/commands/types.ts
+++ b/app/src/lib/commands/types.ts
@@ -41,6 +41,13 @@ export type CommandGroup = "action" | "settings";
  * mounted them. A caller that has not (the native menu bridge) simply omits
  * this, and the commands that need it declare themselves unavailable rather
  * than throwing when picked.
+ *
+ * Two kinds of entry live here, and the difference is who supplies them. The
+ * required three are the *host's*: a surface that renders the palette can mount
+ * all three itself, so offering `surfaces` at all means offering those. The
+ * optional ones are contributed by a **mounted feature** through
+ * `live-surfaces.ts` - present only while that feature is on screen, which is
+ * why they are optional even for a host that offers everything it owns.
  */
 export interface CommandSurfaces {
 	/** Create a request, asking which collection when that is ambiguous. */
@@ -49,6 +56,12 @@ export interface CommandSurfaces {
 	runCollection: (collection: Collection) => void;
 	/** Flip the app between light and dark. */
 	toggleThemeMode: () => void;
+	/**
+	 * Start a load test for the request the builder currently holds - the live
+	 * editor draft, not the saved copy. Contributed by the mounted request
+	 * builder; absent whenever none is mounted.
+	 */
+	startLoadTest?: () => void;
 }
 
 /**

--- a/app/src/modules/palette/CommandPalette.test.tsx
+++ b/app/src/modules/palette/CommandPalette.test.tsx
@@ -33,6 +33,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CommandPalette } from "./CommandPalette";
 import { useImportModalStore, useLayoutStore, useTabsStore } from "@/stores";
 import { useSettingsStore } from "@/modules/settings/settings-store";
+import { useLiveCommandSurfaceStore } from "@/lib/commands";
 
 const COLLECTIONS = [
 	{ id: "c1", name: "Payments", parentId: undefined },
@@ -140,6 +141,7 @@ beforeEach(() => {
 	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
 	useImportModalStore.setState({ isOpen: false });
 	useSettingsStore.setState({ selectedCategory: "appearance", highlightedKey: null });
+	useLiveCommandSurfaceStore.setState({ startLoadTest: null });
 });
 afterEach(cleanup);
 
@@ -347,6 +349,38 @@ describe("commands", () => {
 		open();
 		// Named after its target, so Enter holds no surprise.
 		expect(screen.getByText('Run "Payments"')).toBeInTheDocument();
+	});
+
+	/*
+	 * The join the two ends cannot prove on their own: the registry declares the
+	 * command available when a surface exists, the builder publishes one, and this
+	 * hook is what carries the second to the first. Drop the merge in
+	 * `useCommandSurfaces` and the row never appears.
+	 */
+	it("offers the load-test command only while a mounted builder contributes it", () => {
+		useTabsStore.setState({
+			openTabs: [{ id: "t1", type: "request", entityId: "r1" }],
+			activeTabId: "t1",
+			tabFocusedAt: {},
+		});
+		renderPalette();
+		open();
+		// Named after the tab, like the other contextual commands. The request
+		// query is stubbed empty here, so the strip calls this tab "Request".
+		expect(screen.queryByText('Load test "Request"')).not.toBeInTheDocument();
+		cleanup();
+
+		const started = vi.fn();
+		useLiveCommandSurfaceStore.setState({ startLoadTest: started });
+		renderPalette();
+		open();
+		expect(screen.getByText('Load test "Request"')).toBeInTheDocument();
+
+		typeQuery('Load test "Req');
+		pressEnter();
+
+		expect(started).toHaveBeenCalledTimes(1);
+		expect(useLayoutStore.getState().paletteOpen).toBe(false);
 	});
 
 	it("keeps the run dialog on screen after the pick closes the palette", () => {

--- a/app/src/modules/palette/useCommandSurfaces.ts
+++ b/app/src/modules/palette/useCommandSurfaces.ts
@@ -20,12 +20,19 @@
  * and syncs instances through Electron's `theme-changed` event - so a toggle
  * from here reaches the Appearance panel's radio group the same way an OS theme
  * change does.
+ *
+ * A fourth surface is **not** hosted here, and cannot be: starting a load test
+ * needs the request builder's live editor draft, which exists only inside a
+ * provider the palette is a sibling of. The mounted builder contributes it
+ * through `lib/commands/live-surfaces.ts` and this hook merges what is
+ * registered, so the command is offered while a builder is on screen and absent
+ * the rest of the time.
  */
 
 import { useCallback, useMemo, useState } from "react";
 import { useNewRequest } from "@/hooks/useNewRequest";
 import { useElectronTheme } from "@/hooks/useElectronTheme";
-import type { CommandSurfaces } from "@/lib/commands";
+import { useLiveCommandSurfaceStore, type CommandSurfaces } from "@/lib/commands";
 import type { Collection } from "@/types";
 import type { NewRequestPickerProps } from "@/hooks/useNewRequest";
 
@@ -41,6 +48,7 @@ export function useCommandSurfaces(): UseCommandSurfacesReturn {
 	const { newRequest, pickerProps } = useNewRequest();
 	const { isDark, setTheme } = useElectronTheme();
 	const [runTarget, setRunTarget] = useState<Collection | null>(null);
+	const startLoadTest = useLiveCommandSurfaceStore((s) => s.startLoadTest);
 
 	const dismissRunDialog = useCallback(() => setRunTarget(null), []);
 
@@ -52,9 +60,17 @@ export function useCommandSurfaces(): UseCommandSurfacesReturn {
 		[isDark, setTheme]
 	);
 
+	// Spread rather than assigned: the command's availability asks whether the key
+	// is defined, and `startLoadTest: undefined` would answer that correctly today
+	// but only by accident of how the check is spelled.
 	const surfaces = useMemo<CommandSurfaces>(
-		() => ({ newRequest, runCollection: setRunTarget, toggleThemeMode }),
-		[newRequest, toggleThemeMode]
+		() => ({
+			newRequest,
+			runCollection: setRunTarget,
+			toggleThemeMode,
+			...(startLoadTest ? { startLoadTest } : {}),
+		}),
+		[newRequest, toggleThemeMode, startLoadTest]
 	);
 
 	return { surfaces, pickerProps, runTarget, dismissRunDialog };

--- a/app/src/modules/request-builder/components/LoadTestCommandSurface.tsx
+++ b/app/src/modules/request-builder/components/LoadTestCommandSurface.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The request builder's contribution to the command registry: "start a load
+ * test for what is on screen right now".
+ *
+ * A component rather than a hook call in `RequestBuilder`, because the handler
+ * it publishes lives *inside* `RequestBuilderProvider` - `startLoadTest` closes
+ * over the live draft, and the builder's own component sits outside the
+ * provider it renders. Mounting a child that reads the context is how anything
+ * else here reaches the draft too.
+ *
+ * It renders nothing, and it is mounted from `modules/request-builder/index.tsx`
+ * alone. `DesignRunView` also mounts a `RequestBuilderProvider` - a detached
+ * copy of a past run, deliberately without an `onStartLoadTest` handler - and
+ * simply does not render this, so "exactly one contributor" holds by
+ * construction rather than by a runtime guard.
+ */
+
+import { useRegisterLoadTestSurface } from "@/lib/commands";
+import { useRequestBuilderContext } from "../context";
+
+export default function LoadTestCommandSurface(): null {
+	const { startLoadTest } = useRequestBuilderContext();
+	useRegisterLoadTestSurface(startLoadTest);
+	return null;
+}

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -25,6 +25,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { RequestBuilderProvider } from "./context";
 import RequestBuilderLayout from "./components/RequestBuilderLayout";
 import LoadTestConfigDialog from "./components/LoadTestConfigDialog";
+import LoadTestCommandSurface from "./components/LoadTestCommandSurface";
 import { useTabsStore, useSessionStore, useDashboardStore, useToastStore } from "@/stores";
 import {
 	useRequestQuery,
@@ -614,6 +615,10 @@ export default function RequestBuilder() {
 				onStartLoadTest={handleStartLoadTest}
 			>
 				<RequestBuilderLayout />
+				{/* Renders nothing. Publishes this builder's live draft to the
+				    command registry, so the palette's "Load test …" runs the
+				    request as currently edited rather than as last saved. */}
+				<LoadTestCommandSurface />
 			</RequestBuilderProvider>
 
 			{/* Load Test Configuration Dialog */}

--- a/app/src/modules/request-builder/load-test-command-surface.test.tsx
+++ b/app/src/modules/request-builder/load-test-command-surface.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The live-draft channel, end to end: what the palette actually starts.
+ *
+ * The whole reason #526 shipped the command registry without a load-test entry
+ * is that a command reaching the *saved* request would run the old URL after an
+ * edit and report it as the run the user asked for. So the assertion that
+ * matters is not "a handler fired" but "the handler received what is on screen"
+ * - revert the wiring to the stored request and the third test below fails on
+ * the URL it was handed.
+ *
+ * The provider is mocked down to the same seams `RequestBuilderProvider.name-sync`
+ * uses: variable resolution, the save manager and the query hooks have nothing
+ * to do with which draft crosses the channel.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { RequestBuilderProvider, useRequestBuilderContext } from "./context";
+import LoadTestCommandSurface from "./components/LoadTestCommandSurface";
+import { useLiveCommandSurfaceStore } from "@/lib/commands";
+import type { RequestState } from "./types";
+
+vi.mock("@/hooks", () => ({
+	useVariableResolver: () => ({
+		resolveString: (s: string) => s,
+		resolveObject: (o: unknown) => o,
+		getVariable: () => null,
+		getAllVariables: () => ({}),
+		getVariableOrigins: () => [],
+	}),
+	useSaveManager: () => ({ forceSave: vi.fn(), status: "idle", isSaving: false }),
+}));
+
+vi.mock("@/queries", () => ({
+	useGlobalsQuery: () => ({ data: { variables: {} } }),
+	useUpdateGlobalsMutation: () => ({ mutate: vi.fn() }),
+	useCollectionsQuery: () => ({ data: [] }),
+	useCollectionAncestors: () => [],
+	useUpdateCollectionMutation: () => ({ mutate: vi.fn() }),
+	useEnvironmentsQuery: () => ({ data: [] }),
+	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
+	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+}));
+
+/** Edits the draft the way the URL bar does. */
+function UrlEditor() {
+	const { updateField } = useRequestBuilderContext();
+	return <button onClick={() => updateField("url", "https://api.test/edited")}>edit url</button>;
+}
+
+function Harness({ onStartLoadTest }: { onStartLoadTest?: (r: RequestState) => void }) {
+	const initialRequest: Partial<RequestState> = {
+		id: "req_1",
+		name: "Charge card",
+		url: "https://api.test/saved",
+	};
+	return (
+		<RequestBuilderProvider
+			initialRequest={initialRequest}
+			collectionId="col_1"
+			{...(onStartLoadTest ? { onStartLoadTest } : {})}
+		>
+			<UrlEditor />
+			<LoadTestCommandSurface />
+		</RequestBuilderProvider>
+	);
+}
+
+const registered = () => useLiveCommandSurfaceStore.getState().startLoadTest;
+
+beforeEach(() => {
+	useLiveCommandSurfaceStore.setState({ startLoadTest: null });
+});
+
+describe("the request builder contributes its live draft to the command registry", () => {
+	it("registers nothing until a builder is mounted", () => {
+		expect(registered()).toBeNull();
+	});
+
+	it("publishes a handler while mounted", () => {
+		render(<Harness onStartLoadTest={vi.fn()} />);
+		expect(registered()).not.toBeNull();
+	});
+
+	it("hands over the request as edited, not as stored", () => {
+		const started = vi.fn();
+		render(<Harness onStartLoadTest={started} />);
+
+		act(() => screen.getByText("edit url").click());
+		act(() => registered()?.());
+
+		expect(started).toHaveBeenCalledTimes(1);
+		expect(started.mock.calls[0]?.[0]).toMatchObject({ url: "https://api.test/edited" });
+	});
+
+	it("keeps one registration across draft edits, so typing does not churn the store", () => {
+		render(<Harness onStartLoadTest={vi.fn()} />);
+		const first = registered();
+
+		act(() => screen.getByText("edit url").click());
+
+		// The builder's own `startLoadTest` is a new function after every edit;
+		// what crosses the channel is a stable wrapper, or the palette re-renders
+		// once per keystroke.
+		expect(registered()).toBe(first);
+	});
+
+	it("clears the surface on unmount, so a closed tab leaves no dead handler", () => {
+		const { unmount } = render(<Harness onStartLoadTest={vi.fn()} />);
+		expect(registered()).not.toBeNull();
+
+		unmount();
+
+		expect(registered()).toBeNull();
+	});
+
+	it("leaves the clear to the current holder, so a remount out of order still stands", () => {
+		render(<Harness onStartLoadTest={vi.fn()} />);
+		const current = registered();
+
+		// A previous builder's unmount arriving late must not empty the slot the
+		// builder now on screen owns.
+		act(() => useLiveCommandSurfaceStore.getState().clearStartLoadTest(() => {}));
+
+		expect(registered()).toBe(current);
+	});
+});

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -540,7 +540,9 @@ run any command by name. Mounted once by `Shell`, alongside `ImportModal`.
 - **`useCommandSurfaces.ts`** - the collection picker, the run dialog and the theme hook, which
   three commands need and no store can hold. Their original hosts are not always on screen (the
   welcome screen's picker only on the welcome tab, the tree's run dialog only while the drawer
-  is open), so the palette mounts its own - the same components, driven by the same calls.
+  is open), so the palette mounts its own - the same components, driven by the same calls. It
+  also merges the surfaces a *mounted feature* contributes (the request builder's live draft,
+  for "Load test …") - see [Command Registry](#command-registry-libcommands).
 - **`types.ts`** - the `PaletteItem` shape, the fixed group order, and `rankForEmptyQuery`.
 - **`PaletteResults.tsx`** - grouping and rendering. **Mounted only while the palette is open**,
   the same cost rule the context bar applies to a collapsed section: a shut palette holds no
@@ -607,12 +609,14 @@ in step or could enumerate them.
 - **`types.ts`** - `Command` (`id`, `title`, `keywords`, `group`, `icon`, `available?`,
   `perform`) and `CommandContext`. A `title` may be a function of the context, which is how a
   contextual command names its target: `Run "payments"`, not `Run collection`.
-- **`registry.ts`** - the roster. Actions (new request, import, run collection, close tab,
-  toggle theme, open settings) plus one command per settings section, **generated** from
+- **`registry.ts`** - the roster. Actions (new request, import, run collection, load test, close
+  tab, toggle theme, open settings) plus one command per settings section, **generated** from
   `app-panels.ts` and `engine-categories.ts` so a section added there appears here without an
   edit and cannot be named differently.
 - **`context.ts`** - `baseCommandContext()`, the React-free snapshot for a caller that is not a
   render (the native-menu bridge). `hooks/useCommandContext.ts` is the full version.
+- **`live-surfaces.ts`** - the channel a *mounted feature* contributes a surface through. One
+  slot, one contributor: the request builder's start-load-test handler.
 
 Two rules make it work without a dependency-injection tangle:
 
@@ -623,10 +627,41 @@ Two rules make it work without a dependency-injection tangle:
   than throwing when picked. `CommandSurfaces` is optional on the context; the menu bridge omits
   it, so "New request" is simply not among the commands it can run.
 
+### When a surface is a store, and when it is a live contribution
+
+Most of what a `perform` needs is a store, and a store is always the answer when the state
+outlives any one mounted view. `CommandSurfaces` covers the rest, and it has two halves:
+
+- **Host-owned** (`newRequest`, `runCollection`, `toggleThemeMode`) - dialogs and hooks that are
+  React but that *any* rendering caller can mount for itself. The palette does exactly that in
+  `useCommandSurfaces`, so offering `surfaces` at all means offering these three.
+- **Contributed by a mounted feature** (`startLoadTest`) - state that exists only inside one
+  component tree and cannot be lifted without copying it. Starting a load test needs the request
+  builder's **live editor draft**, before autosave has run; the palette is a sibling of
+  `RequestBuilderProvider`, so a command reading a store would find only the last *saved* request
+  and would silently run the old URL after an edit. The builder publishes its own handler through
+  `live-surfaces.ts` (`useRegisterLoadTestSurface`, mounted by
+  `modules/request-builder/components/LoadTestCommandSurface.tsx`), `useCommandSurfaces` merges
+  what is registered, and the command is `available` exactly while that contribution stands - so
+  it is absent rather than inert while no builder is on screen, and closing the tab removes it.
+  Nothing about the load test moves: the single-active-run policy, the ceilings check and
+  `LoadTestConfigDialog` all stay in the builder.
+
+The rejected alternative is worth naming, because it is the tempting one: reading the draft out
+of the provider from outside it, or recomposing the payload inside the command, would be a second
+copy of `buildExecBody` and of the run policy - the "hand-rolled copy of a primitive" defect this
+registry exists to remove.
+
+The channel is deliberately **one slot with one contributor**, not a registry of arbitrary named
+surfaces. A second feature with the same live-draft problem (a "Send request" command has it)
+joins that file as a second slot rather than inventing a second channel - but not before it
+exists.
+
 Consumers: `modules/palette/sources/commandItems.ts` (the Commands and Settings groups) and
 `hooks/useMenuActions.ts` (Preferences… → `open-settings`). `lib/commands/registry.test.ts` walks
 the roster and asserts every entry says something and that the settings roster still covers both
-catalogues.
+catalogues; `modules/request-builder/load-test-command-surface.test.tsx` holds the live channel to
+handing over the request *as edited*, and to clearing itself on unmount.
 
 ## Toaster (`components/shared/Toaster.tsx`)
 


### PR DESCRIPTION
## Description

**Plan.** Root cause: `handleStartLoadTest` takes a `RequestState` - the request builder's *live editor draft*, before autosave has run - and that draft exists only inside `RequestBuilderProvider`, which the palette is a sibling of in `Shell`. Every other roster entry reaches a store or a dialog the palette can host itself; this one cannot, which is why #526 left it out rather than shipping a command that would silently run the last *saved* URL after an edit. The approach is the seam the registry already anticipated: `CommandSurfaces` gains an optional `startLoadTest`, contributed by the *mounted feature* through a new one-slot channel (`lib/commands/live-surfaces.ts`) instead of by the palette host, and `useCommandSurfaces` merges what is registered. The command is `available` exactly while that contribution stands, so it is absent rather than inert. **Rejected alternative:** reading the draft out of `RequestBuilderProvider` from outside it, or recomposing the payload inside the command - either is a second copy of `buildExecBody` and of the single-active-run policy, precisely the "hand-rolled copy of a primitive" defect the registry exists to remove. Nothing about the load test moves; only its reachability changes.

The problem was verified against master `38694c0` before writing anything: `handleStartLoadTest` still lives at `modules/request-builder/index.tsx:379`, still takes `RequestState`, and `rg` confirmed the palette's only path to a request was the query cache.

**What landed**

- `lib/commands/types.ts` - `CommandSurfaces` documents its two halves: the three the host owns and can always mount, and the optional ones a mounted feature contributes.
- `lib/commands/live-surfaces.ts` (new) - the channel. One slot, one contributor. `useRegisterLoadTestSurface` publishes a **stable** wrapper over a ref rather than the builder's own handler, whose identity changes on every keystroke - the direct version would write to the store, and re-render the palette, once per character typed. The unmount clear is identity-checked, so a late clear cannot empty a slot the builder now on screen owns.
- `lib/commands/registry.ts` - the `run-load-test` command. Titled after its target like the other contextual entries (`Load test "Charge card"`, from the tab strip's own descriptor), `Zap` for the icon because that is the load-test mark throughout the app.
- `modules/request-builder/components/LoadTestCommandSurface.tsx` (new) - renders nothing; publishes the draft. A component rather than a hook call in `RequestBuilder`, because `startLoadTest` lives *inside* the provider that component renders. Mounted from `modules/request-builder/index.tsx` alone, so "exactly one contributor" holds by construction - `DesignRunView` mounts a provider too (a detached copy of a past run, deliberately without an `onStartLoadTest`) and simply does not render it, which is why no runtime guard was added.
- `modules/palette/useCommandSurfaces.ts` - merges the registered surface.

Engine: none. MCP: none. No deviation from the issue spec; the only judgement call it left open was where the contributor mounts, and the reason for the extra component file is above.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **App suite: 4241 tests across 418 files passed** (11 of them new/changed here). Type-check, ESLint (zero warnings) and `prettier --check` clean.
- `mkdocs build --strict -f .github/mkdocs.yml` builds clean, for the `docs/` change.
- No pre-existing failures observed on this base.

Each new test was mutation-checked - the fix reverted, the failure confirmed, the fix restored:

| Mutation | Test that caught it |
|---|---|
| Handler ref frozen at mount (i.e. the saved request) | `hands over the request as edited, not as stored` - fails with `https://api.test/saved` |
| Register the unstable handler directly | `keeps one registration across draft edits` |
| Drop the unmount clear | `clears the surface on unmount` |
| Drop the identity check in the clear | `leaves the clear to the current holder` |
| `available: () => true` | `hides the load-test command until a mounted builder contributes it` |
| Drop the merge in `useCommandSurfaces` | `offers the load-test command only while a mounted builder contributes it` |

The availability matrix is covered as state rather than as timing: no request tab, a request tab whose builder has not yet registered (the mount race), and registered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/app/COMPONENTS.md` gains a "When a surface is a store, and when it is a live contribution" subsection under Command Registry - what the channel is for, when it is the right answer instead of a store, the rejected alternative, and why it stays one slot. The file is not covered by the app's `format:check` glob, so the edit was made by hand rather than through prettier, which would have reflowed ~139 unrelated lines.

## Related Issues
Closes #547

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJiieSjLD27ybo3bRqGAxt)_