### PR TITLE
feat(app/mcp): start_mock_issuer and siblings - let an agent mint its own tokens

### DIFF
--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -446,6 +446,41 @@ export class EngineClient {
 		}
 		return ticks.slice(-limit);
 	}
+
+	// --- Local services: the OAuth 2.0 mock issuer ---------------------------
+	//
+	// Every issuer binds `127.0.0.1` and the engine takes no host for it
+	// (`mock_issuer.cpp`: "127.0.0.1 only, never configurable"), so none of these
+	// three reaches anything off the machine - which is why the tools over them
+	// carry no allowlist check.
+
+	/**
+	 * Start a mock issuer: `POST /mock-issuer/start`. The engine assigns the id
+	 * and, for `port: 0`, the port; the reply carries `issuerId`, `issuerUrl`,
+	 * `tokenUrl`, `authorizeUrl` and the per-issuer `signingKey`.
+	 */
+	startMockIssuer(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		return this.request("POST", "/mock-issuer/start", payload, signal);
+	}
+
+	/** The running mock issuers: `GET /mock-issuer` → `{issuers: [...]}`. */
+	listMockIssuers(signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", "/mock-issuer", undefined, signal);
+	}
+
+	/**
+	 * Stop one: `POST /mock-issuer/:id/stop`. An unknown id is a 404, which
+	 * arrives as an {@link EngineRequestError} rather than a silent success -
+	 * "the issuer you meant is gone" and "it stopped" are different answers.
+	 */
+	stopMockIssuer(issuerId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request(
+			"POST",
+			`/mock-issuer/${encodeURIComponent(issuerId)}/stop`,
+			undefined,
+			signal
+		);
+	}
 }
 
 /** True for the rejection a fetch produces when its signal aborts. */

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -76,6 +76,15 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 			variables: { baseUrl: { value: "x", enabled: true } },
 		}),
 		updateEnvironment: vi.fn().mockResolvedValue({ id: "env_1", name: "Dev" }),
+		startMockIssuer: vi.fn().mockResolvedValue({
+			issuerId: "issuer_1",
+			issuerUrl: "http://127.0.0.1:41234",
+			tokenUrl: "http://127.0.0.1:41234/token",
+			authorizeUrl: "http://127.0.0.1:41234/authorize",
+			signingKey: "k3y",
+		}),
+		listMockIssuers: vi.fn().mockResolvedValue({ issuers: [] }),
+		stopMockIssuer: vi.fn().mockResolvedValue({ stopped: true }),
 		...overrides,
 	} as unknown as EngineClient;
 }
@@ -2369,5 +2378,246 @@ describe("engine transport failures are told apart", () => {
 		);
 		expect(res.isError).toBe(true);
 		expect(firstText(res)).toMatch(/Make sure the Vayu app is running/);
+	});
+});
+
+/*
+ * The local OAuth 2.0 mock issuer (#509). The engine has served
+ * `/mock-issuer/*` since #479; these three tools are what let an agent asked to
+ * "test this auth flow" mint its own tokens instead of having a human curl the
+ * engine first.
+ */
+describe("mock issuer tools", () => {
+	const byName = () => new Map(TOOLS.map((t) => [t.name, t]));
+
+	test("start and stop are execute, list is read, and none of them opens the world", () => {
+		const tools = byName();
+		expect(tools.get("start_mock_issuer")?.category).toBe("execute");
+		expect(tools.get("stop_mock_issuer")?.category).toBe("execute");
+		expect(tools.get("list_mock_issuers")?.category).toBe("read");
+		for (const name of ["start_mock_issuer", "stop_mock_issuer", "list_mock_issuers"]) {
+			// Loopback-only by engine contract, so an agent's client must not be
+			// told these reach an open world - that hint is what a cautious client
+			// asks about before calling.
+			expect(tools.get(name)?.annotations.openWorldHint, name).toBe(false);
+			expect(tools.get(name)?.annotations.destructiveHint, name).toBeFalsy();
+		}
+	});
+
+	test("they invalidate nothing, because no renderer surface reads issuers yet", () => {
+		// The #502 coordination, locked so it is a decision rather than an
+		// oversight: declaring an entity here before the Services drawer reads it
+		// is precisely the written-never-read defect. When #502 lands, this
+		// expectation changes with it.
+		for (const name of ["start_mock_issuer", "stop_mock_issuer", "list_mock_issuers"]) {
+			expect(byName().get(name)?.invalidates, name).toEqual([]);
+		}
+	});
+
+	test("start sends only the fields the caller named and returns the issuer's urls", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_mock_issuer",
+			{
+				expiresInSeconds: 60,
+				claims: { sub: "alice", roles: ["admin"] },
+				issueRefreshTokens: true,
+			},
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.startMockIssuer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		// An absent field must stay absent: the engine reads a present one with a
+		// bad value as a 400 rather than falling back to its default, and
+		// `undefined` would serialize to `null`.
+		expect(payload).toEqual({
+			expiresInSeconds: 60,
+			claims: { sub: "alice", roles: ["admin"] },
+			issueRefreshTokens: true,
+		});
+		expect(Object.keys(payload as object)).not.toContain("port");
+		expect(Object.keys(payload as object)).not.toContain("failureMode");
+		const body = JSON.parse(firstText(res)) as Record<string, unknown>;
+		expect(body.issuerId).toBe("issuer_1");
+		expect(body.tokenUrl).toBe("http://127.0.0.1:41234/token");
+		expect(body.authorizeUrl).toBe("http://127.0.0.1:41234/authorize");
+		expect(body.signingKey).toBe("k3y");
+	});
+
+	test("start forwards every configurable field, none renamed on the way", async () => {
+		const client = fakeClient();
+		const args = {
+			port: 41234,
+			expiresInSeconds: 3600,
+			claims: { sub: "alice" },
+			clients: [{ clientId: "cid", clientSecret: "s3cret" }],
+			failureMode: "slow",
+			slowMs: 2000,
+			issueRefreshTokens: false,
+		};
+		const res = await dispatchTool("start_mock_issuer", args, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		// Keyed exactly as `parse_mock_issuer_settings` reads them - a rename here
+		// is a field the engine silently ignores.
+		expect((client.startMockIssuer as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual(args);
+	});
+
+	test("list round-trips the engine's envelope", async () => {
+		const running = {
+			issuers: [
+				{ issuerId: "issuer_1", tokenUrl: "http://127.0.0.1:41234/token", port: 41234 },
+			],
+		};
+		const client = fakeClient({ listMockIssuers: vi.fn().mockResolvedValue(running) });
+		const res = await dispatchTool("list_mock_issuers", {}, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		expect(JSON.parse(firstText(res))).toEqual(running);
+	});
+
+	test("stop names the issuer, and an unknown id is an error rather than a shrug", async () => {
+		const client = fakeClient();
+		const ok = await dispatchTool(
+			"stop_mock_issuer",
+			{ issuerId: "issuer_1" },
+			ctxWith(client)
+		);
+		expect(ok.isError).toBeFalsy();
+		expect(client.stopMockIssuer).toHaveBeenCalledWith("issuer_1", undefined);
+
+		const gone = fakeClient({
+			stopMockIssuer: vi
+				.fn()
+				.mockRejectedValue(
+					new EngineRequestError("Engine responded 404", 404, "Mock issuer not found")
+				),
+		});
+		const res = await dispatchTool("stop_mock_issuer", { issuerId: "issuer_9" }, ctxWith(gone));
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/404/);
+	});
+
+	test("stop refuses an empty id before the engine is called", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool("stop_mock_issuer", { issuerId: "" }, ctxWith(client));
+		expect(res.isError).toBe(true);
+		expect(client.stopMockIssuer).not.toHaveBeenCalled();
+	});
+
+	/*
+	 * The gating matrix. The issuer is loopback-only by engine contract, so
+	 * neither of the two gates that govern the other effectful tools applies: the
+	 * allowlist exists to stop an agent generating traffic against third parties,
+	 * and the write toggle gates saved data. What does govern them is the per-tool
+	 * switch - and an agent that could already reach `POST /mock-issuer/start`
+	 * through `run_request` with `localhost` allowlisted gains no capability here.
+	 */
+	test("neither the empty allowlist nor the write toggle gates them", async () => {
+		const client = fakeClient();
+		const locked = ctxWith(client, { allowlist: [], allowAll: false, allowWrites: false });
+		for (const [tool, args] of [
+			["start_mock_issuer", {}],
+			["list_mock_issuers", {}],
+			["stop_mock_issuer", { issuerId: "issuer_1" }],
+		] as const) {
+			const res = await dispatchTool(tool, args, locked);
+			expect(res.isError, tool).toBeFalsy();
+		}
+		expect(client.startMockIssuer).toHaveBeenCalled();
+		expect(client.stopMockIssuer).toHaveBeenCalled();
+	});
+
+	test("the per-tool switch is what turns them off", async () => {
+		const client = fakeClient();
+		const off = ctxWith(client, {
+			disabledTools: ["start_mock_issuer", "list_mock_issuers", "stop_mock_issuer"],
+		});
+		for (const [tool, args] of [
+			["start_mock_issuer", {}],
+			["list_mock_issuers", {}],
+			["stop_mock_issuer", { issuerId: "issuer_1" }],
+		] as const) {
+			const res = await dispatchTool(tool, args, off);
+			expect(res.isError, tool).toBe(true);
+			expect(firstText(res), tool).toMatch(/disabled in Vayu Settings/);
+		}
+		expect(client.startMockIssuer).not.toHaveBeenCalled();
+		expect(client.listMockIssuers).not.toHaveBeenCalled();
+		expect(client.stopMockIssuer).not.toHaveBeenCalled();
+	});
+
+	test("the schema refuses a malformed config before the engine sees it", () => {
+		const shape = TOOLS.find((t) => t.name === "start_mock_issuer")!.inputSchema as Record<
+			string,
+			z.ZodTypeAny
+		>;
+		// A failure mode outside the closed set would start an issuer that behaves
+		// nothing like the one the agent asked for.
+		expect(shape.failureMode.safeParse("explode").success).toBe(false);
+		expect(shape.failureMode.safeParse("invalid_client").success).toBe(true);
+		expect(shape.claims.safeParse("sub=alice").success).toBe(false);
+		expect(shape.claims.safeParse({ sub: "alice" }).success).toBe(true);
+		expect(shape.port.safeParse(70000).success).toBe(false);
+		expect(shape.port.safeParse(1.5).success).toBe(false);
+		expect(shape.port.safeParse(0).success).toBe(true);
+		expect(shape.expiresInSeconds.safeParse(0).success).toBe(false);
+		expect(shape.slowMs.safeParse(-1).success).toBe(false);
+		expect(shape.clients.safeParse([{ clientSecret: "s" }]).success).toBe(false);
+		expect(shape.clients.safeParse([{ clientId: "cid" }]).success).toBe(true);
+		// Every field is optional: an issuer with no config at all is the common
+		// "I just need a token" case.
+		expect(z.object(shape).safeParse({}).success).toBe(true);
+	});
+
+	test("an agent mints a token against its own issuer, end to end", async () => {
+		// The owner scenario from #509, through the MCP layer: stand up an issuer,
+		// point a request at the token URL it returned, get a token back.
+		const client = fakeClient({
+			executeRequest: vi.fn().mockImplementation((payload: Record<string, unknown>) =>
+				Promise.resolve(
+					String(payload.url ?? "").endsWith("/token")
+						? {
+								statusCode: 200,
+								body: JSON.stringify({
+									access_token: "header.payload.signature",
+									token_type: "Bearer",
+									expires_in: 3600,
+								}),
+							}
+						: { statusCode: 404 }
+				)
+			),
+		});
+		const ctx = ctxWith(client, { allowlist: ["127.0.0.1"] });
+
+		const started = await dispatchTool(
+			"start_mock_issuer",
+			{ clients: [{ clientId: "cid", clientSecret: "s3cret" }] },
+			ctx
+		);
+		expect(started.isError).toBeFalsy();
+		const { tokenUrl } = JSON.parse(firstText(started)) as { tokenUrl: string };
+
+		const token = await dispatchTool(
+			"run_request",
+			{
+				method: "POST",
+				url: tokenUrl,
+				bodyType: "x-www-form-urlencoded",
+				body: "grant_type=client_credentials&client_id=cid&client_secret=s3cret",
+			},
+			ctx
+		);
+		expect(token.isError).toBeFalsy();
+		const sent = (client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(sent.url).toBe(tokenUrl);
+		expect(firstText(token)).toContain("header.payload.signature");
+
+		const stopped = await dispatchTool(
+			"stop_mock_issuer",
+			{ issuerId: (JSON.parse(firstText(started)) as { issuerId: string }).issuerId },
+			ctx
+		);
+		expect(stopped.isError).toBeFalsy();
+		expect(client.stopMockIssuer).toHaveBeenCalledWith("issuer_1", undefined);
 	});
 });

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -123,9 +123,11 @@ export interface ToolResult {
 
 /**
  * Capability class surfaced in Settings for per-tool control; each maps to a
- * distinct gate profile: `read` (inspection, ungated), `execute` (sends a
- * request to a target host - allowlist), `write` (mutates saved data/config -
- * write toggle), `load` (starts/stops load tests - allowlist + caps + confirm).
+ * gate profile: `read` (inspection, ungated), `execute` (has an effect outside
+ * this process without touching saved data - allowlist when it sends to a
+ * target host, none when the effect is a loopback service the engine hosts, as
+ * for the mock issuer), `write` (mutates saved data/config - write toggle),
+ * `load` (starts/stops load tests - allowlist + caps + confirm).
  */
 export type ToolCategory = "read" | "execute" | "write" | "load";
 
@@ -986,6 +988,49 @@ function describeCascade(scope: CascadeScope): string {
 		`Deleting "${scope.name}" also destroys ${scope.descendants} sub-collection(s) and ` +
 		`${scope.requests} saved request(s) inside it. This cannot be undone.`
 	);
+}
+
+// --- Mock issuer -------------------------------------------------------------
+
+/**
+ * The fields `POST /mock-issuer/start` accepts, in the engine's spelling
+ * (`parse_mock_issuer_settings`, engine/src/http/routes/mock_issuer.cpp). One
+ * list rather than a hand-written object literal per field, so the payload
+ * builder and the tool's input schema cannot drift apart.
+ */
+const MOCK_ISSUER_START_KEYS = [
+	"port",
+	"expiresInSeconds",
+	"claims",
+	"clients",
+	"failureMode",
+	"slowMs",
+	"issueRefreshTokens",
+] as const;
+
+/** The failure modes the issuer's `/token` endpoint can be put into. */
+const MOCK_ISSUER_FAILURE_MODES = ["none", "slow", "server_error", "invalid_client"] as const;
+
+/**
+ * The start body, carrying only the fields the caller actually named - an
+ * absent one must stay absent, because the engine reads a present field with a
+ * bad type or an out-of-range value as an error rather than falling back to the
+ * default, and `undefined` would serialize to `null`.
+ *
+ * The engine's *limits* (the 31-day expiry ceiling, the 60s slow ceiling, 32
+ * clients, 8 concurrent issuers) are deliberately not restated in the schema:
+ * they live in `core/constants.hpp`, an out-of-range value comes back as a
+ * `400 mock_issuer_invalid_config` naming the bound, and a second copy here
+ * would be a second thing to keep in step - one that refuses values the engine
+ * accepts the moment either side moves. What the schema does own is the shape:
+ * a claims object, an integer port, a failure mode from the closed set above.
+ */
+function mockIssuerStartPayload(args: Record<string, unknown>): Record<string, unknown> {
+	const payload: Record<string, unknown> = {};
+	for (const key of MOCK_ISSUER_START_KEYS) {
+		if (args[key] !== undefined) payload[key] = args[key];
+	}
+	return payload;
 }
 
 // --- Tool definitions --------------------------------------------------------
@@ -2154,6 +2199,119 @@ export const TOOLS: McpTool[] = [
 				return engineErrorResult(err);
 			}
 		},
+	},
+	{
+		name: "start_mock_issuer",
+		category: "execute",
+		// Nothing in the renderer reads issuers today (`rg -i issuer app/src` is
+		// empty), so there is no entity to invalidate: an `McpDataEntity` with no
+		// reader is the written-never-read defect that field exists to prevent.
+		// #502 adds the Services drawer that lists them - when it lands, an
+		// "issuer" entity belongs here and on its query.
+		invalidates: [],
+		description:
+			"Start a local OAuth 2.0 mock issuer and return its id, token URL, authorize URL and signing key. Use it to test an auth flow offline: start an issuer, point a request's oauth2 auth at the returned tokenUrl, run it with run_request, and assert on what the target received - no real identity provider, so no 2FA prompts, provider rate limits or account lockouts in the loop. It needs no allowlist entry: the engine binds every issuer to 127.0.0.1 and takes no host for it, so it is unreachable off this machine. The access token is an HS256 JWT signed with the returned signingKey - hand that key to the service under test and it can verify the mock's tokens. Set a short expiresInSeconds (with issueRefreshTokens) to exercise the 401-then-refresh path, and failureMode to exercise retry handling. At most 8 issuers run at once; stop yours with stop_mock_issuer when you are done.",
+		annotations: {
+			title: "Start mock OAuth issuer",
+			readOnlyHint: false,
+			// It binds a loopback listener and mints tokens for it: it destroys no
+			// saved data and reaches nothing off the machine.
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			port: z
+				.number()
+				.int()
+				.min(0)
+				.max(65535)
+				.optional()
+				.describe("Port to bind on 127.0.0.1. Default 0 - the engine picks a free one."),
+			expiresInSeconds: z
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe(
+					"Lifetime of a minted access token, in seconds (default 3600). Set it low to make a token expire mid-test."
+				),
+			claims: z
+				.record(z.unknown())
+				.optional()
+				.describe(
+					'Extra JWT claims, e.g. {"sub": "alice", "roles": ["admin"]}. iss, iat, exp and jti are always the issuer\'s own; sub, client_id and scope are filled in only when you do not set them.'
+				),
+			clients: z
+				.array(
+					z.object({
+						clientId: z.string().min(1).describe("Client id this issuer accepts."),
+						clientSecret: z
+							.string()
+							.optional()
+							.describe("Secret that client must then present."),
+					})
+				)
+				.optional()
+				.describe(
+					"Clients the issuer accepts. Omit (the default) to accept any client id."
+				),
+			failureMode: z
+				.enum(MOCK_ISSUER_FAILURE_MODES)
+				.optional()
+				.describe(
+					'How /token misbehaves: "none" (default), "slow" (answers after slowMs), "server_error" (500), "invalid_client" (401).'
+				),
+			slowMs: z
+				.number()
+				.int()
+				.nonnegative()
+				.optional()
+				.describe('Delay before /token answers, in milliseconds. Only "slow" reads it.'),
+			issueRefreshTokens: z
+				.boolean()
+				.optional()
+				.describe(
+					"Return a refresh_token alongside the access token, so a refresh grant can be tested. A refresh rotates its token - the presented one is spent."
+				),
+		},
+		handler: (args, ctx, signal) =>
+			callEngine(() => ctx.client.startMockIssuer(mockIssuerStartPayload(args), signal)),
+	},
+	{
+		name: "list_mock_issuers",
+		category: "read",
+		invalidates: [],
+		description:
+			"List the OAuth 2.0 mock issuers running right now, each with its id, urls, signing key, port, token expiry, failure mode and configured client count. Use it to find an issuer started earlier in the session, or to confirm one was stopped.",
+		annotations: {
+			title: "List mock OAuth issuers",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {},
+		handler: (_args, ctx, signal) => callEngine(() => ctx.client.listMockIssuers(signal)),
+	},
+	{
+		name: "stop_mock_issuer",
+		category: "execute",
+		// See start_mock_issuer - no renderer reader yet, #502 adds one.
+		invalidates: [],
+		description:
+			"Stop a running OAuth 2.0 mock issuer and free its port. Tokens it already minted stay valid until they expire - nothing verifies them against the issuer once it is gone. An unknown id is an error, not a silent success.",
+		annotations: {
+			title: "Stop mock OAuth issuer",
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			issuerId: z.string().describe("Issuer ID to stop (from start_mock_issuer)."),
+		},
+		handler: (args, ctx, signal) =>
+			callEngine(() => ctx.client.stopMockIssuer(requireStr(args, "issuerId"), signal)),
 	},
 ];
 

--- a/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
+++ b/app/src/modules/settings/main/panels/McpSettingsPanel.tsx
@@ -141,7 +141,8 @@ const TOOL_CATEGORIES: { id: McpToolCategory; label: string; description: string
 	{
 		id: "execute",
 		label: "Execute",
-		description: "Send real requests to a target (single request or a collection smoke test).",
+		description:
+			"Send real requests to a target (single request or a collection smoke test), and run the local mock OAuth issuer.",
 	},
 	{
 		id: "write",

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -134,8 +134,10 @@ validated by the SDK). A few declare an `outputSchema` and return validated
 `structuredContent` alongside the text rendering.
 
 The four categories partition tools by what they can do - and thus which gate
-applies: **read** (inspection, always safe), **execute** (sends real traffic to
-a target - allowlist), **write** (mutates saved data or engine config - write
+applies: **read** (inspection, always safe), **execute** (has an effect outside
+this process without touching saved data - allowlist when it sends real traffic
+to a target, none when the effect is a loopback service the engine hosts, as for
+the mock issuer), **write** (mutates saved data or engine config - write
 toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 
 | Tool                   | Category | Maps to                                      | Gate                       |
@@ -161,6 +163,9 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
 | `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm; optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity` |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
+| `start_mock_issuer`    | execute  | `POST /mock-issuer/start`                    | - (loopback-only listener, so no allowlist entry applies); limits are the engine's - 31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent issuers |
+| `list_mock_issuers`    | read     | `GET /mock-issuer`                           | -                          |
+| `stop_mock_issuer`     | execute  | `POST /mock-issuer/:id/stop`                 | - (unknown id is a `404`, surfaced as a tool error) |
 
 Notes:
 
@@ -248,6 +253,27 @@ Notes:
   could not be read), because a matrix whose `total` silently excludes nested
   folders reads as a whole-collection pass. Requests run serially, so a large
   collection takes as long as its requests do added together.
+- **The mock-issuer tools** let an agent asked to "test this auth flow" mint its
+  own tokens: `start_mock_issuer` stands up a
+  [local OAuth 2.0 issuer](api-reference.md#local-mock-issuer) and returns its
+  `issuerId`, `tokenUrl`, `authorizeUrl` and `signingKey`, so the agent can
+  point a request's `oauth2` auth at the token URL, `run_request` it, and assert
+  on what the target received - offline, with no real provider's 2FA prompts or
+  rate limits in the loop. `expiresInSeconds` plus `issueRefreshTokens` is how
+  the 401-then-refresh path is exercised, and `failureMode` is how retry
+  handling is. **No allowlist entry is needed and none is checked**: the engine
+  binds every issuer to `127.0.0.1` and takes no host for it, so an issuer is
+  unreachable off the machine; the per-tool switch is what turns these off. The
+  start body is forwarded verbatim under the engine's own key names, and the
+  engine's limits (31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent
+  issuers) stay engine-side rather than being restated in the tool schema, for
+  the same reason `monitor`'s ranges are - a second copy would refuse values the
+  engine accepts the moment either side moves. The schema owns the *shape*: a
+  claims object, an integer port, a `failureMode` from the closed set. Stopping
+  an issuer frees its port; tokens it already minted stay valid until they
+  expire, since nothing verifies them against a live issuer. These tools emit no
+  `mcp:data-changed` event because no renderer surface reads issuers yet -
+  #502's Services drawer is what adds one.
 - **Cancellation:** the `AbortSignal` the SDK fires on `notifications/cancelled`
   is threaded into the engine `fetch` for every tool call, resource read,
   template list and prompt, so a client cancelling an in-flight call actually
@@ -611,6 +637,16 @@ configurable in **Settings → MCP** and persisted.
   the toggle **and** confirmation: the toggle is a single session-wide switch a
   user flips once to let an agent save a request, which is not consent to
   destroy a subtree.
+- **Loopback services carry no gate of their own** - `start_mock_issuer` and
+  `stop_mock_issuer` are `execute` tools that neither the allowlist nor the
+  write toggle governs. The allowlist exists to stop an agent generating traffic
+  against third parties it was never pointed at, and a mock issuer is bound to
+  `127.0.0.1` by the engine with no host to configure; the write toggle gates
+  saved data, which an ephemeral listener is not. Nor would a gate here withhold
+  anything: an agent with `localhost` allowlisted can already reach
+  `POST /mock-issuer/start` through `run_request`, for the same reason the
+  endpoint needs no auth token. The bounds that do apply are the engine's own -
+  at most 8 issuers at once - and the per-tool switch below.
 - **Per-tool control** - any tool or whole read/execute/write/load category can be
   switched off; a disabled tool is omitted from `tools/list` **and** rejected by
   `tools/call`. This and the write toggle are **independent**, and a write tool
@@ -809,10 +845,6 @@ builds on the mechanism the spec is deprecating and the payoff is client-depende
 
 - **MCP-originated run tagging** - tag runs started via MCP so History shows
   provenance.
-- **`start_mock_issuer`** - a tool over the engine's local OAuth 2.0 mock issuer
-  ([API reference](./api-reference.md#local-mock-issuer)), so an agent asked to
-  "test this auth flow" can mint its own tokens. Deliberately out of scope of
-  the engine-side feature (#479); the routes are reachable today.
 - **`vayu mcp` bin** - package the stdio CLI as a first-class command (backlog M1).
 - **Live push over HTTP** - stateful sessions (see Design notes).
 - **Hosted MCP for Vayu Cloud** - OAuth-gated, remote.


### PR DESCRIPTION
## Description

Three MCP tools over the engine's local OAuth 2.0 mock issuer, retiring the `mcp.md` Deferred entry.

**The plan.** Root cause: the issuer has been fully operational engine-side since #479 (`POST /mock-issuer/start`, `GET /mock-issuer`, `POST /mock-issuer/:id/stop`, `PUT /mock-issuer/:id` - verified still at `engine/src/http/routes/mock_issuer.cpp:764-830`), but `rg -i issuer app/electron/mcp` returned nothing, so an agent asked to "test this auth flow" needed a human to curl the engine first. Approach: three thin tools (`start_mock_issuer` / `list_mock_issuers` / `stop_mock_issuer`) plus three passthrough `EngineClient` methods, forwarding the start body under the engine's own key names. The alternative I rejected was re-stating the engine's limits (31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent issuers) in the Zod schema: they live in `core/constants.hpp`, an out-of-range value already comes back as a `400 mock_issuer_invalid_config` naming the bound, and a second copy would refuse values the engine accepts the moment either side moves - the same reasoning `monitor`'s ranges already follow. The schema owns the *shape* instead (claims object, integer port, `failureMode` from the closed set).

**Deliberate deviations from the issue spec, both stated in the code and docs:**

1. **No `allowWrites` gate on the two `execute` tools.** The issue's Tests section suggested the write-gating refusal matrix should cover them. Nothing in the repo supports that: `config.ts` documents `allowWrites` as gating *the write category*, the Settings card says in so many words that "every tool in the Write group above refuses", and the issue's own body says to follow `run_request`'s discipline (which is the allowlist) while also saying the allowlist does not apply here. Rather than invent a gate that contradicts the on-screen copy, the gating matrix locks the *decision*: with an empty allowlist and writes off, all three succeed; the per-tool switch is what turns them off. The reasoning - loopback-only bind, no saved data touched, and an agent with `localhost` allowlisted can already reach the route through `run_request` - is recorded as a new **Loopback services carry no gate of their own** bullet under Safety model. Both directions are mutation-checked (adding a `writesDisabled(ctx)` guard fails the matrix test).
2. **No `PUT` update tool.** The issue marked it optional ("include it only if free"); start/list/stop covers the agent loop, and `failureMode` / `expiresInSeconds` are both settable at start.

`invalidates` is `[]` on all three, per the issue's #502 coordination rule: `rg -i issuer app/src` is still empty, so declaring an `McpDataEntity` now would be exactly the written-never-read defect. The comment and a test name #502 as the change that adds the reader.

One small adjacent fix the docs-in-step rule required: the `execute` category is no longer only "sends real requests to a target", so its copy is updated in three places - `mcp.md`, the `ToolCategory` doc comment, and the Settings MCP panel's category table.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- **App suite: 4252 tests across 418 files, all passing.** MCP subset: 381 tests across 12 files.
- 11 new tests in `tools.test.ts`: categories/annotations; the `invalidates: []` decision; start sends only the fields named (absent stays absent - the engine 400s a present-but-bad field rather than defaulting); start forwards all seven fields unrenamed; list round-trip; stop passes the id and surfaces a 404 as an error; stop refuses an empty id before the engine is called; the gating matrix in both directions; schema rejection of a bad `failureMode`, non-object `claims`, out-of-range/fractional port, zero expiry, negative `slowMs` and a client with no `clientId`; and the owner scenario end to end - start an issuer, `run_request` a client-credentials grant at the returned `tokenUrl`, get a token back, stop it.
- Mutation-checked: dropping `claims` from the forwarded key list fails 2 tests; adding a `writesDisabled(ctx)` guard to `start_mock_issuer` fails 4.
- `mkdocs build --strict -f .github/mkdocs.yml` passes.
- No engine changes, so no engine build/suite run - nothing in `engine/` could change colour.
- `docs/engine/mcp.md` was not prettier-clean on `master` and is outside `app/`'s `format:check` glob, so it is left unformatted per CLAUDE.md; the two TS files it touches were clean before and are formatted.

No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #509

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMaACrqFiE1Pjv9hqFjXmt)_