### PR TITLE
feat(app/services): one home for local services - a Services drawer and a running-state indicator

### DIFF
--- a/app/src/components/layout/Dock.context-toggle.test.tsx
+++ b/app/src/components/layout/Dock.context-toggle.test.tsx
@@ -22,6 +22,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Dock } from "./Dock";
 import { TooltipProvider } from "@/components/ui";
 import { useLayoutStore, useTabsStore, type TabType } from "@/stores";
@@ -29,11 +30,21 @@ import { useLayoutStore, useTabsStore, type TabType } from "@/stores";
 // Injected by vite's `define` in the real build; the Dock renders it.
 vi.stubGlobal("__VAYU_VERSION__", "0.0.0-test");
 
+/*
+ * The Dock reads the two local-service lists for its running-services indicator
+ * (issue #502), so it needs a client - as it has in the app, where every
+ * renderer sits under the root provider. Nothing is mocked: the queries fail
+ * against no engine, the count is 0, and the indicator renders nothing, which
+ * is the state these cases want.
+ */
 function renderDock() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(
-		<TooltipProvider>
-			<Dock />
-		</TooltipProvider>
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<Dock />
+			</TooltipProvider>
+		</QueryClientProvider>
 	);
 }
 

--- a/app/src/components/layout/Dock.engine-status.test.tsx
+++ b/app/src/components/layout/Dock.engine-status.test.tsx
@@ -24,6 +24,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
 import { Dock } from "./Dock";
 import { useEngineStore } from "@/stores";
@@ -32,12 +33,23 @@ import { useEngineStore } from "@/stores";
 // does not, so without this the component throws before it renders anything.
 vi.stubGlobal("__VAYU_VERSION__", "0.0.0-test");
 
-const renderDock = () =>
-	render(
-		<TooltipProvider>
-			<Dock />
-		</TooltipProvider>
+/*
+ * The Dock reads the two local-service lists for its running-services indicator
+ * (issue #502), so it needs a client - as it has in the app, where every
+ * renderer sits under the root provider. Nothing is mocked: the queries fail
+ * against no engine, the count is 0, and the indicator renders nothing, which
+ * is the state these cases want.
+ */
+const renderDock = () => {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<Dock />
+			</TooltipProvider>
+		</QueryClientProvider>
 	);
+};
 
 beforeEach(() => {
 	cleanup();

--- a/app/src/components/layout/Dock.services.test.tsx
+++ b/app/src/components/layout/Dock.services.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A running local service has to be visible from anywhere (issue #502).
+ *
+ * A webhook inbox kept recording with its tab closed and an OAuth issuer had no
+ * app surface at all, so the app could not answer "is something still
+ * listening?" anywhere. The Dock's middle region already carries that class of
+ * fact (the connection light), so the aggregate indicator lives there.
+ *
+ * Two claims, and the second is the one a source scan could not make:
+ *
+ * 1. The fifth Dock button exists and activates the services drawer view.
+ * 2. **Nothing renders when nothing runs.** Mutation-check: make
+ *    `RunningServices` render unconditionally and the first case below fails,
+ *    because "0 services" appears in a Dock with an empty engine.
+ *
+ * The transport is mocked and the real queries and hooks run, so the count is
+ * computed the way the app computes it - including the asymmetry between the
+ * two lists (an inbox stays listed once stopped, an issuer does not).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useLayoutStore } from "@/stores";
+import type { Inbox, MockIssuer } from "@/types";
+import { Dock } from "./Dock";
+
+const listInboxes = vi.fn();
+const listMockIssuers = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => listInboxes(),
+			listMockIssuers: () => listMockIssuers(),
+		},
+	};
+});
+
+// The Dock prints the app version, which Vite `define`s at build time.
+vi.stubGlobal("__VAYU_VERSION__", "0.0.0-test");
+
+function inbox(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:41234/",
+		bind: "127.0.0.1",
+		port: 41234,
+		running: true,
+		loopback: true,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
+
+function issuer(overrides: Partial<MockIssuer> = {}): MockIssuer {
+	return {
+		issuerId: "iss_a",
+		issuerUrl: "http://127.0.0.1:42000",
+		tokenUrl: "http://127.0.0.1:42000/token",
+		authorizeUrl: "http://127.0.0.1:42000/authorize",
+		signingKey: "k".repeat(32),
+		port: 42000,
+		expiresInSeconds: 3600,
+		failureMode: "none",
+		slowMs: 0,
+		issueRefreshTokens: true,
+		clientCount: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
+const renderDock = () => {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<Dock />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+};
+
+beforeEach(() => {
+	cleanup();
+	listInboxes.mockReset().mockResolvedValue([]);
+	listMockIssuers.mockReset().mockResolvedValue([]);
+	useLayoutStore.setState({ drawerOpen: true, drawerView: "collections" });
+});
+
+describe("the services drawer switcher", () => {
+	it("is in the Dock's sidebar navigation, with its chord in the tooltip", () => {
+		renderDock();
+		const button = screen.getByRole("button", { name: "Services" });
+		expect(button).toBeInTheDocument();
+		expect(button.getAttribute("aria-pressed")).toBe("false");
+	});
+
+	it("activates the services view", () => {
+		renderDock();
+		fireEvent.click(screen.getByRole("button", { name: "Services" }));
+		expect(useLayoutStore.getState().drawerView).toBe("services");
+		expect(useLayoutStore.getState().drawerOpen).toBe(true);
+	});
+});
+
+describe("the running-services indicator", () => {
+	it("renders nothing while nothing is running", async () => {
+		renderDock();
+		// The lists have to have arrived - asserting on the empty first render
+		// would pass before either query resolved and prove nothing.
+		await waitFor(() => expect(listMockIssuers).toHaveBeenCalled());
+		expect(screen.queryByText(/service/i)).not.toBeInTheDocument();
+	});
+
+	it("does not count an inbox the engine has stopped", async () => {
+		listInboxes.mockResolvedValue([inbox({ running: false })]);
+		renderDock();
+		await waitFor(() => expect(listInboxes).toHaveBeenCalled());
+		expect(screen.queryByText(/service/i)).not.toBeInTheDocument();
+	});
+
+	it("counts a running inbox", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		renderDock();
+		expect(await screen.findByText("1 service")).toBeInTheDocument();
+	});
+
+	it("counts inboxes and issuers together, and pluralises", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		listMockIssuers.mockResolvedValue([issuer(), issuer({ issuerId: "iss_b" })]);
+		renderDock();
+		expect(await screen.findByText("3 services")).toBeInTheDocument();
+	});
+
+	it("opens the services drawer when clicked", async () => {
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderDock();
+		fireEvent.click(await screen.findByText("1 service"));
+		expect(useLayoutStore.getState().drawerView).toBe("services");
+		expect(useLayoutStore.getState().drawerOpen).toBe(true);
+	});
+});

--- a/app/src/components/layout/Dock.tsx
+++ b/app/src/components/layout/Dock.tsx
@@ -5,7 +5,16 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import { FolderOpen, Clock, Braces, Info, PanelRight, RefreshCw, Settings } from "lucide-react";
+import {
+	FolderOpen,
+	Clock,
+	Braces,
+	Info,
+	PanelRight,
+	Radio,
+	RefreshCw,
+	Settings,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatChord } from "@/lib/platform";
 import {
@@ -17,6 +26,7 @@ import {
 } from "@/stores";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 import { contextBarHasContent } from "./context-bar-content";
+import { useRunningServiceCount } from "@/modules/services";
 import { useEngineRestart } from "@/hooks/useEngineRestart";
 
 interface DrawerButton {
@@ -72,6 +82,25 @@ const DRAWER_BUTTONS: DrawerButton[] = [
 		icon: <Braces className="w-4 h-4" />,
 		label: "Variables",
 		shortcut: formatChord({ mod: true, shift: true, key: "U" }),
+	},
+	{
+		view: "services",
+		/*
+		 * `Radio`: the group is inboxes, OAuth issuers and (with #481) mock
+		 * servers - things that sit there *listening*, which is what the
+		 * broadcast arcs say and what none of the alternatives do. `Server`
+		 * reads as a remote host, which is the thing these stand in for rather
+		 * than what they are; `Play` is the load-test run mark; `Plug` reads as
+		 * a connection to something else, and the point of a local service is
+		 * that there is nothing else.
+		 *
+		 * Distinct in the strip: it is the only glyph made of concentric arcs -
+		 * Collections a solid trapezoid, History a filled circle, Variables two
+		 * open curves, Settings a round cog.
+		 */
+		icon: <Radio className="w-4 h-4" />,
+		label: "Services",
+		shortcut: formatChord({ mod: true, shift: true, key: "S" }),
 	},
 	{
 		view: "settings",
@@ -214,6 +243,50 @@ function PendingRestart() {
 	return pendingRestart ? <PendingRestartButton /> : null;
 }
 
+/**
+ * A local service is listening somewhere - the one thing that was invisible
+ * outside the surface that started it (issue #502).
+ *
+ * A webhook inbox recorded a request whether or not its tab was open, and an
+ * OAuth issuer had no app surface at all, so "is something still running?" was
+ * a question the app could not answer anywhere. It sits beside the connection
+ * light because that is this strip's ambient-status region, and because these
+ * are the same kind of fact: what the engine is doing on the user's behalf.
+ *
+ * **Nothing renders when nothing runs.** The Dock's middle is ambient, and a
+ * standing "0 services" would spend a permanent line on the ordinary case.
+ * Guarded by `Dock.services.test.tsx` - rendering it unconditionally fails.
+ */
+function RunningServices() {
+	const activateDrawerView = useLayoutStore((s) => s.activateDrawerView);
+	const count = useRunningServiceCount();
+
+	if (count === 0) return null;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				{/*
+				 * A button, not a chip: knowing a listener is up is only half the
+				 * need - the other half is getting to it, and the drawer is where
+				 * it can be stopped or copied. `success-text` is the accessible
+				 * pair the connection light above uses for the same 12px dot.
+				 */}
+				<button
+					onClick={() => activateDrawerView("services")}
+					className="flex items-center gap-1 text-xs text-success-text rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+				>
+					<span className="w-1.5 h-1.5 rounded-full bg-current" />
+					{count === 1 ? "1 service" : `${count} services`}
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="top">
+				<p>Local services are running. Open the Services sidebar.</p>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 function PendingRestartButton() {
 	const { restart, isRestarting } = useEngineRestart();
 
@@ -273,7 +346,7 @@ export function Dock() {
 			 */}
 			<div className="flex items-center h-[var(--dock-height)] px-2 gap-2 border-t border-border bg-panel shrink-0">
 				{/* Left - drawer switchers.
-				    <nav>: these four choose what the sidebar shows, which is the
+				    <nav>: these five choose what the sidebar shows, which is the
 				    app's primary navigation. Not role="toolbar" - that promises
 				    arrow-key traversal between the buttons, which this does not
 				    implement, and claiming it would mislead a keyboard user. */}
@@ -294,6 +367,8 @@ export function Dock() {
 				{/* Middle - ambient status */}
 				<div className="flex-1 flex items-center justify-center gap-4">
 					<EngineStatus />
+
+					<RunningServices />
 
 					<PendingRestart />
 

--- a/app/src/components/layout/Drawer.tsx
+++ b/app/src/components/layout/Drawer.tsx
@@ -12,6 +12,7 @@ import CollectionTree from "@/modules/collections/CollectionTree";
 import HistoryList from "@/modules/history/sidebar/HistoryList";
 import VariablesCategoryTree from "@/modules/variables/sidebar/VariablesCategoryTree";
 import { SettingsCategoryTree } from "@/modules/settings";
+import { ServicesPanel } from "@/modules/services";
 
 export function Drawer() {
 	const { drawerOpen, drawerView, drawerWidth, setDrawerWidth } = useLayoutStore();
@@ -23,7 +24,7 @@ export function Drawer() {
 	return (
 		/* <aside>, so the sidebar is a landmark a screen reader can jump to
 		   instead of an anonymous div. Labelled by the active view because the
-		   drawer hosts four different panels - "Complementary" alone would not
+		   drawer hosts five different panels - "Complementary" alone would not
 		   say which one is showing. */
 		<aside
 			className="relative flex shrink-0 bg-panel"
@@ -42,6 +43,7 @@ export function Drawer() {
 				{drawerView === "collections" && <CollectionTree />}
 				{drawerView === "history" && <HistoryList />}
 				{drawerView === "variables" && <VariablesCategoryTree />}
+				{drawerView === "services" && <ServicesPanel />}
 				{drawerView === "settings" && <SettingsCategoryTree />}
 			</div>
 

--- a/app/src/components/layout/Shell.tsx
+++ b/app/src/components/layout/Shell.tsx
@@ -115,12 +115,16 @@ export default function Shell() {
 			if (!(e.metaKey || e.ctrlKey)) return;
 			const key = e.key.toLowerCase();
 
-			// ⇧⌘E / ⇧⌘H / ⇧⌘U - drawer view switchers (match Dock tooltips)
+			// ⇧⌘E / ⇧⌘H / ⇧⌘U / ⇧⌘S - drawer view switchers (match Dock tooltips)
 			if (e.shiftKey) {
 				const views: Record<string, DrawerView> = {
 					e: "collections",
 					h: "history",
 					u: "variables",
+					// ⌘S is save, so the services view takes the shifted pair - free
+					// in both maps: the renderer binds no other ⇧⌘ chord and the
+					// native menu's only one is ⇧⌘W (close window).
+					s: "services",
 				};
 				const view = views[key];
 				if (view) {

--- a/app/src/components/layout/variables-icon.test.tsx
+++ b/app/src/components/layout/variables-icon.test.tsx
@@ -54,6 +54,10 @@ vi.mock("@/queries", () => ({
 		enabled: false,
 	}),
 	runDetailOptions: () => ({ queryKey: ["run"], queryFn: async () => undefined, enabled: false }),
+	// The Dock's running-services indicator reads both service lists; with none
+	// running it renders nothing, which is the state this file wants anyway.
+	useInboxesQuery: () => ({ data: [] }),
+	useMockIssuersQuery: () => ({ data: [] }),
 }));
 
 vi.mock("@/modules/variables/variables-store", () => ({
@@ -104,13 +108,14 @@ describe("the variables icon", () => {
 		const nav = screen.getByRole("navigation", { name: "Sidebar views" });
 		const buttons = Array.from(nav.querySelectorAll("button"));
 
-		expect(buttons).toHaveLength(4);
+		// Five since Services joined the strip (issue #502).
+		expect(buttons).toHaveLength(5);
 		const perButton = buttons.map((b) => iconNames(b).join("+"));
 		expect(new Set(perButton).size).toBe(perButton.length);
 	});
 
 	it("keeps the bolt out of the drawer switchers entirely", () => {
-		// `Zap` means "load test" in this app. Any of the four wearing it would
+		// `Zap` means "load test" in this app. Any of the five wearing it would
 		// re-introduce the same misreading in a different slot.
 		renderDock();
 		const nav = screen.getByRole("navigation", { name: "Sidebar views" });
@@ -148,7 +153,7 @@ describe("the variables icon", () => {
 				onSearch={() => {}}
 				onHistory={() => {}}
 				onVariables={() => {}}
-				onInbox={() => {}}
+				onServices={() => {}}
 			/>
 		);
 		const tile = screen.getByRole("button", { name: /Variables/ });

--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -141,6 +141,15 @@ export const API_ENDPOINTS = {
 	INBOX_CAPTURES_CLEAR: (inboxId: string) => `/inbox/${inboxId}/requests`,
 	INBOX_LIVE: (inboxId: string) => `/inbox/${inboxId}/live`,
 
+	// OAuth 2.0 mock issuer (issue #479). Engine-process state like an inbox, so
+	// the same verb-path shape: START creates one, the id paths update and stop
+	// it. There is no DELETE - stopping is what ends an issuer, and the record
+	// goes with it (unlike an inbox, which stays readable once stopped).
+	MOCK_ISSUER: `/mock-issuer`,
+	MOCK_ISSUER_START: `/mock-issuer/start`,
+	MOCK_ISSUER_BY_ID: (issuerId: string) => `/mock-issuer/${issuerId}`,
+	MOCK_ISSUER_STOP: (issuerId: string) => `/mock-issuer/${issuerId}/stop`,
+
 	// OAuth 2.0
 	OAUTH2_TOKEN: `/oauth2/token`,
 	OAUTH2_AUTHORIZE_START: `/oauth2/authorize/start`,

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -81,6 +81,23 @@ export const TIMING = {
 	/** Engine health poll interval while the app is open. */
 	HEALTH_CHECK_INTERVAL_MS: 30_000,
 
+	/**
+	 * How often the two local-service lists (webhook inboxes, OAuth issuers) are
+	 * re-read.
+	 *
+	 * They are polled at all because this app is not the only client that can
+	 * start one: the MCP server exposes the same lifecycle to an agent, and curl
+	 * reaches the engine directly. Without a poll the Dock's running-services
+	 * indicator would only ever report what this window itself started, which is
+	 * the opposite of what it promises.
+	 *
+	 * 10s rather than the health check's 30s because a service the user just
+	 * started elsewhere should show up while they are still looking, and rather
+	 * than the runs list's 5s because neither list changes on its own - only
+	 * when somebody acts.
+	 */
+	SERVICES_POLL_INTERVAL_MS: 10_000,
+
 	/** Wait after asking electron to restart the engine before refetching. */
 	ENGINE_RESTART_WAIT_MS: 1500,
 

--- a/app/src/modules/README.md
+++ b/app/src/modules/README.md
@@ -54,6 +54,19 @@ Some modules have components displayed in both the sidebar and main content area
     import CollectionTree from "@/modules/collections/CollectionTree";
     ```
 
+#### `services/`
+
+- **Location:** Sidebar only - the `services` drawer view (issue #502)
+- **Components:** `ServicesPanel.tsx` - the local services (webhook inboxes, OAuth issuers):
+  status, copy-URL, start/stop, and the issuer's start dialog
+- **Also exports** `useRunningServiceCount()`, which the Dock's ambient indicator reads - one
+  count, because the two lists disagree on their own terms (a stopped inbox stays listed, a
+  stopped issuer does not)
+- **Usage:**
+    ```tsx
+    import { ServicesPanel, useRunningServiceCount } from "@/modules/services";
+    ```
+
 ### Main-Only Modules
 
 #### `request-builder/`

--- a/app/src/modules/palette/sources/useViewItems.ts
+++ b/app/src/modules/palette/sources/useViewItems.ts
@@ -9,7 +9,7 @@
  * The app's own surfaces - drawer views and the tabs that are one of a kind.
  *
  * Two mechanisms behind one group, because the user is not asked to know the
- * difference: Collections/History/Variables/Settings switch the drawer
+ * difference: Collections/History/Variables/Services/Settings switch the drawer
  * (`activateDrawerView`, the same call the Dock's buttons make), while
  * Variables/Settings/Inbox are singleton *tabs*. Variables and Settings are
  * both - the drawer holds the tree, the tab holds the editor - so their entry
@@ -22,7 +22,7 @@
  * here set the view explicitly instead.
  */
 
-import { Braces, Clock, Folder, Inbox, Settings } from "lucide-react";
+import { Braces, Clock, Folder, Inbox, Radio, Settings } from "lucide-react";
 import { useLayoutStore, useTabsStore, type DrawerView, type TabType } from "@/stores";
 import type { PaletteItem } from "../types";
 
@@ -56,14 +56,21 @@ const VIEWS: ViewEntry[] = [
 		tabType: "variables",
 	},
 	{
+		title: "Services",
+		keywords: ["inbox", "webhook", "oauth", "issuer", "mock", "listener"],
+		icon: Radio,
+		drawerView: "services",
+	},
+	{
 		title: "Settings",
 		keywords: ["preferences", "options", "config"],
 		icon: Settings,
 		drawerView: "settings",
 		tabType: "settings",
 	},
-	// No drawer view of its own: an inbox is engine state, not a stored record,
-	// so the tab is the whole surface (see the Launcher tile's note).
+	// Kept beside Services, which lists inboxes and is where one is started:
+	// this entry is the *tab*, the detail surface with the capture list, and
+	// searching "inbox" should reach both.
 	{ title: "Inbox", keywords: ["webhook", "receive", "callback"], icon: Inbox, tabType: "inbox" },
 ];
 

--- a/app/src/modules/services/NewIssuerDialog.tsx
+++ b/app/src/modules/services/NewIssuerDialog.tsx
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * NewIssuerDialog (issue #502)
+ *
+ * The start form for a mock OAuth 2.0 issuer. Everything here is optional
+ * engine-side, so the dialog opens ready to submit: a bare start is the common
+ * "I just need a token" case, and the three fields are the ones that change
+ * what the tokens *are* - how long they live, what they claim, and how the
+ * issuer misbehaves.
+ *
+ * The port is not offered. An issuer binds an ephemeral loopback port by
+ * default, an explicit one that another listener holds is a `500`, and nothing
+ * about a mock issuer wants a memorable port - its URLs are copied, not typed.
+ * Clients are not offered either: with none configured any client id is
+ * accepted, which is what a test needs; a real client list is a fixture the MCP
+ * tools and the API can still supply.
+ *
+ * Every value is validated here before it is sent, because the engine refuses a
+ * bad one with a `400 mock_issuer_invalid_config` rather than falling back to a
+ * default - and an issuer running with an expiry other than the one asked for
+ * would defeat the point of asking. The claims box is the one that needs it
+ * most: a JSON typo is invisible until a token comes back without the claim.
+ */
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Label,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Textarea,
+} from "@/components/ui";
+import { Callout } from "@/components/shared";
+import { useStartMockIssuerMutation } from "@/queries";
+import { useToastStore } from "@/stores";
+import type { MockIssuerFailureMode } from "@/types";
+import {
+	DEFAULT_EXPIRES_IN_SECONDS,
+	DEFAULT_SLOW_MS,
+	FAILURE_MODE_LABELS,
+	MAX_EXPIRES_IN_SECONDS,
+	MAX_SLOW_MS,
+} from "./failure-modes";
+
+export interface NewIssuerDialogProps {
+	/**
+	 * Mounted only while open, like `RunCollectionDialog`: the mount *is* the
+	 * reset, so the fields and any engine error start clean every time rather
+	 * than carrying the last attempt over or needing an effect to clear it.
+	 */
+	onOpenChange: (open: boolean) => void;
+	/** Called with the new issuer's id, so the drawer can expand its row. */
+	onStarted?: (issuerId: string) => void;
+}
+
+/**
+ * Claims are a JSON *object* or nothing at all. An array or a bare scalar
+ * parses cleanly and is still not a claim set, so both are named here rather
+ * than sent onward to come back as an engine error the user cannot place.
+ */
+function parseClaims(text: string): { claims?: Record<string, unknown>; error?: string } {
+	const trimmed = text.trim();
+	if (trimmed === "") return {};
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch (error) {
+		return { error: error instanceof Error ? error.message : "Claims must be valid JSON" };
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { error: 'Claims must be a JSON object, e.g. {"sub": "alice"}' };
+	}
+	return { claims: parsed as Record<string, unknown> };
+}
+
+export function NewIssuerDialog({ onOpenChange, onStarted }: NewIssuerDialogProps) {
+	const showToast = useToastStore((s) => s.showToast);
+	const startIssuer = useStartMockIssuerMutation();
+
+	const [expiresIn, setExpiresIn] = useState(String(DEFAULT_EXPIRES_IN_SECONDS));
+	const [failureMode, setFailureMode] = useState<MockIssuerFailureMode>("none");
+	const [slowMs, setSlowMs] = useState(String(DEFAULT_SLOW_MS));
+	const [claimsText, setClaimsText] = useState("");
+
+	const expiresInValue = Number(expiresIn);
+	const expiresInValid =
+		Number.isInteger(expiresInValue) &&
+		expiresInValue >= 1 &&
+		expiresInValue <= MAX_EXPIRES_IN_SECONDS;
+
+	const slowMsValue = Number(slowMs);
+	const slowMsValid =
+		failureMode !== "slow" ||
+		(Number.isInteger(slowMsValue) && slowMsValue >= 0 && slowMsValue <= MAX_SLOW_MS);
+
+	const claims = parseClaims(claimsText);
+	const canStart = expiresInValid && slowMsValid && !claims.error && !startIssuer.isPending;
+
+	const start = () => {
+		if (!canStart) return;
+		startIssuer.mutate(
+			{
+				expiresInSeconds: expiresInValue,
+				failureMode,
+				// Only when it means something: `slowMs` outside `slow` mode is a
+				// value the issuer never reads, and sending it would put a number
+				// in the row summary that nothing acts on.
+				...(failureMode === "slow" ? { slowMs: slowMsValue } : {}),
+				...(claims.claims ? { claims: claims.claims } : {}),
+			},
+			{
+				onSuccess: (issuer) => {
+					onStarted?.(issuer.issuerId);
+					showToast("Mock issuer started", "success");
+					onOpenChange(false);
+				},
+			}
+		);
+	};
+
+	const engineError = startIssuer.error;
+
+	return (
+		<Dialog open onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>New OAuth issuer</DialogTitle>
+					<DialogDescription>
+						A local issuer that mints signed tokens on demand - point a request&apos;s
+						OAuth 2.0 config at its token URL and no external identity provider is
+						involved.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 py-2">
+					<div className="flex items-center justify-between gap-4">
+						<Label htmlFor="new-issuer-expiry" className="leading-snug">
+							Token lifetime
+							<span className="block text-xs font-normal text-muted-foreground">
+								Seconds. What `exp` is stamped with, and what `expires_in` reports.
+							</span>
+						</Label>
+						<Input
+							id="new-issuer-expiry"
+							type="number"
+							min={1}
+							max={MAX_EXPIRES_IN_SECONDS}
+							step={1}
+							value={expiresIn}
+							onChange={(e) => setExpiresIn(e.target.value)}
+							className="w-28 shrink-0"
+							aria-invalid={!expiresInValid}
+						/>
+					</div>
+
+					<div className="flex items-center justify-between gap-4">
+						<Label htmlFor="new-issuer-failure-mode" className="leading-snug">
+							Failure mode
+							<span className="block text-xs font-normal text-muted-foreground">
+								How `/token` answers. Changeable while the issuer runs.
+							</span>
+						</Label>
+						<Select
+							value={failureMode}
+							onValueChange={(value) =>
+								setFailureMode(value as MockIssuerFailureMode)
+							}
+						>
+							<SelectTrigger id="new-issuer-failure-mode" className="w-40 shrink-0">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.entries(FAILURE_MODE_LABELS).map(([mode, label]) => (
+									<SelectItem key={mode} value={mode}>
+										{label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					{failureMode === "slow" && (
+						<div className="flex items-center justify-between gap-4">
+							<Label htmlFor="new-issuer-slow" className="leading-snug">
+								Delay
+								<span className="block text-xs font-normal text-muted-foreground">
+									Milliseconds to wait before answering normally.
+								</span>
+							</Label>
+							<Input
+								id="new-issuer-slow"
+								type="number"
+								min={0}
+								max={MAX_SLOW_MS}
+								step={100}
+								value={slowMs}
+								onChange={(e) => setSlowMs(e.target.value)}
+								className="w-28 shrink-0"
+								aria-invalid={!slowMsValid}
+							/>
+						</div>
+					)}
+
+					<div className="space-y-1">
+						<Label htmlFor="new-issuer-claims" className="leading-snug">
+							Claims
+							<span className="block text-xs font-normal text-muted-foreground">
+								JSON merged into every token. `iss`, `iat`, `exp` and `jti` are the
+								issuer&apos;s own and always win.
+							</span>
+						</Label>
+						<Textarea
+							id="new-issuer-claims"
+							rows={4}
+							spellCheck={false}
+							placeholder={'{ "sub": "alice", "roles": ["admin"] }'}
+							value={claimsText}
+							onChange={(e) => setClaimsText(e.target.value)}
+							className="font-mono text-xs"
+							aria-invalid={!!claims.error}
+							aria-describedby={claims.error ? "new-issuer-claims-error" : undefined}
+						/>
+						{claims.error && (
+							<p
+								id="new-issuer-claims-error"
+								className="text-xs text-destructive-text"
+							>
+								{claims.error}
+							</p>
+						)}
+					</div>
+
+					{/* The engine's own refusal, shown where the field that caused it
+					    is - a toast would take the message away from the form the
+					    user has to correct. */}
+					{engineError && (
+						<Callout severity="blocking" title="Could not start the issuer">
+							{engineError instanceof Error ? engineError.message : "Unknown error"}
+						</Callout>
+					)}
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button onClick={start} disabled={!canStart}>
+						{startIssuer.isPending && (
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+						)}
+						Start issuer
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/src/modules/services/ServicesPanel.test.tsx
+++ b/app/src/modules/services/ServicesPanel.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Services drawer (issue #502).
+ *
+ * The OAuth issuer had no app surface at all before this - the engine's four
+ * routes were reachable only from curl or the MCP tools - so these cases are
+ * the first proof that a user can start, read and stop one. The inbox half is
+ * about the second entry point: the drawer lists it and opens its tab, without
+ * taking the tab's job.
+ *
+ * The transport is mocked and the real query hooks run, so a row acting on a
+ * service goes through the same mutation and cache invalidation the app uses;
+ * only the HTTP call is faked.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabsStore, useToastStore } from "@/stores";
+import type { Inbox, MockIssuer } from "@/types";
+import ServicesPanel from "./ServicesPanel";
+
+const listInboxes = vi.fn();
+const listMockIssuers = vi.fn();
+const startInbox = vi.fn();
+const stopInbox = vi.fn();
+const startMockIssuer = vi.fn();
+const stopMockIssuer = vi.fn();
+const updateMockIssuer = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => listInboxes(),
+			listMockIssuers: () => listMockIssuers(),
+			startInbox: (...a: unknown[]) => startInbox(...a),
+			stopInbox: (...a: unknown[]) => stopInbox(...a),
+			startMockIssuer: (...a: unknown[]) => startMockIssuer(...a),
+			stopMockIssuer: (...a: unknown[]) => stopMockIssuer(...a),
+			updateMockIssuer: (...a: unknown[]) => updateMockIssuer(...a),
+		},
+	};
+});
+
+const writeText = vi.fn();
+
+function inbox(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:41234/",
+		bind: "127.0.0.1",
+		port: 41234,
+		running: true,
+		loopback: true,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
+
+function issuer(overrides: Partial<MockIssuer> = {}): MockIssuer {
+	return {
+		issuerId: "iss_a",
+		issuerUrl: "http://127.0.0.1:42000",
+		tokenUrl: "http://127.0.0.1:42000/token",
+		authorizeUrl: "http://127.0.0.1:42000/authorize",
+		signingKey: "k".repeat(32),
+		port: 42000,
+		expiresInSeconds: 3600,
+		failureMode: "none",
+		slowMs: 0,
+		issueRefreshTokens: false,
+		clientCount: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
+function renderPanel() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<ServicesPanel />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	cleanup();
+	listInboxes.mockReset().mockResolvedValue([]);
+	listMockIssuers.mockReset().mockResolvedValue([]);
+	startInbox.mockReset().mockResolvedValue(inbox());
+	stopInbox.mockReset().mockResolvedValue(inbox({ running: false }));
+	startMockIssuer.mockReset().mockResolvedValue({
+		issuerId: "iss_new",
+		issuerUrl: "http://127.0.0.1:42001",
+		tokenUrl: "http://127.0.0.1:42001/token",
+		authorizeUrl: "http://127.0.0.1:42001/authorize",
+		signingKey: "s".repeat(32),
+	});
+	stopMockIssuer.mockReset().mockResolvedValue({ stopped: true });
+	updateMockIssuer.mockReset().mockResolvedValue(issuer({ failureMode: "server_error" }));
+	writeText.mockReset();
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+	useToastStore.setState({ toasts: [] });
+});
+
+describe("the services drawer", () => {
+	it("names both service kinds, so the drawer teaches what a service is", async () => {
+		renderPanel();
+		expect(await screen.findByText("Webhook inboxes")).toBeInTheDocument();
+		expect(screen.getByText("OAuth issuers")).toBeInTheDocument();
+	});
+
+	it("says what each empty group would give you, not just that it is empty", async () => {
+		renderPanel();
+		expect(await screen.findByText(/records every request sent to it/i)).toBeInTheDocument();
+		expect(screen.getByText(/mint your own OAuth 2.0 tokens locally/i)).toBeInTheDocument();
+	});
+
+	it("starts an inbox from the group's own affordance", async () => {
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: "Start inbox" }));
+		await waitFor(() => expect(startInbox).toHaveBeenCalled());
+	});
+});
+
+describe("an inbox row", () => {
+	it("opens the inbox tab - the drawer lists, the tab shows the captures", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: /open inbox on port 41234/i }));
+		expect(useTabsStore.getState().openTabs.map((t) => t.type)).toContain("inbox");
+	});
+
+	it("copies the URL a webhook source is pointed at", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		expect(writeText).toHaveBeenCalledWith("http://127.0.0.1:41234/");
+	});
+
+	it("stops a running inbox", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: /stop inbox on port 41234/i }));
+		await waitFor(() => expect(stopInbox).toHaveBeenCalledWith("inbox_a"));
+	});
+
+	/*
+	 * A stopped inbox stays listed - the engine keeps its record and its
+	 * captures readable - so the row has to say which it is and drop the action
+	 * that no longer applies. This is the half an issuer row does not have: a
+	 * stopped issuer is gone from the engine's list entirely.
+	 */
+	it("marks a stopped inbox and offers no stop for it", async () => {
+		listInboxes.mockResolvedValue([inbox({ running: false })]);
+		renderPanel();
+		expect(await screen.findByText("Stopped")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /stop inbox/i })).not.toBeInTheDocument();
+	});
+});
+
+describe("an issuer row", () => {
+	it("hands over the two URLs and the signing key only once expanded", async () => {
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderPanel();
+		// Collapsed: the row is the issuer's base URL and nothing else, so a
+		// drawer of eight issuers stays readable.
+		expect(screen.queryByText("http://127.0.0.1:42000/token")).not.toBeInTheDocument();
+
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+
+		expect(screen.getByText("http://127.0.0.1:42000/token")).toBeInTheDocument();
+		expect(screen.getByText("http://127.0.0.1:42000/authorize")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Copy signing key" }));
+		expect(writeText).toHaveBeenCalledWith("k".repeat(32));
+	});
+
+	it("summarises what the issuer will do, in its own numbers", async () => {
+		listMockIssuers.mockResolvedValue([
+			issuer({ expiresInSeconds: 120, failureMode: "slow", slowMs: 2000, clientCount: 2 }),
+		]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+		expect(
+			screen.getByText(
+				/Tokens expire in 120s · answers after 2000ms · 2 clients configured\./
+			)
+		).toBeInTheDocument();
+	});
+
+	it("flips a running issuer into a failure mode without restarting it", async () => {
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+		fireEvent.click(screen.getByRole("combobox"));
+		fireEvent.click(screen.getByRole("option", { name: "Server error" }));
+		await waitFor(() =>
+			expect(updateMockIssuer).toHaveBeenCalledWith("iss_a", { failureMode: "server_error" })
+		);
+	});
+
+	it("stops the issuer it names", async () => {
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: /stop issuer on port 42000/i }));
+		await waitFor(() => expect(stopMockIssuer).toHaveBeenCalledWith("iss_a"));
+	});
+});
+
+describe("starting an issuer", () => {
+	const openDialog = async () => {
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: "New issuer" }));
+		return within(await screen.findByRole("dialog"));
+	};
+
+	it("sends the defaults when nothing is changed - a bare start is the common case", async () => {
+		const dialog = await openDialog();
+		fireEvent.click(dialog.getByRole("button", { name: /start issuer/i }));
+		await waitFor(() =>
+			expect(startMockIssuer).toHaveBeenCalledWith({
+				expiresInSeconds: 3600,
+				failureMode: "none",
+			})
+		);
+	});
+
+	it("sends the claims the user typed", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByLabelText(/claims/i), {
+			target: { value: '{"sub":"alice"}' },
+		});
+		fireEvent.click(dialog.getByRole("button", { name: /start issuer/i }));
+		await waitFor(() =>
+			expect(startMockIssuer).toHaveBeenCalledWith({
+				expiresInSeconds: 3600,
+				failureMode: "none",
+				claims: { sub: "alice" },
+			})
+		);
+	});
+
+	/*
+	 * The engine refuses a bad config rather than falling back to a default, and
+	 * a claims typo is otherwise invisible until a token comes back without the
+	 * claim. So both are refused here, with the reason on the field.
+	 */
+	it("refuses malformed claims by name, and sends nothing", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByLabelText(/claims/i), { target: { value: "{sub:" } });
+		expect(dialog.getByRole("button", { name: /start issuer/i })).toBeDisabled();
+		fireEvent.click(dialog.getByRole("button", { name: /start issuer/i }));
+		expect(startMockIssuer).not.toHaveBeenCalled();
+	});
+
+	it("refuses a claims value that is valid JSON but not a claim set", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByLabelText(/claims/i), { target: { value: '["admin"]' } });
+		expect(dialog.getByText(/must be a JSON object/i)).toBeInTheDocument();
+		expect(dialog.getByRole("button", { name: /start issuer/i })).toBeDisabled();
+	});
+
+	it("refuses an out-of-range lifetime", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByLabelText(/token lifetime/i), { target: { value: "0" } });
+		expect(dialog.getByRole("button", { name: /start issuer/i })).toBeDisabled();
+	});
+});

--- a/app/src/modules/services/ServicesPanel.tsx
+++ b/app/src/modules/services/ServicesPanel.tsx
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Services drawer view (issue #502)
+ *
+ * Vayu runs *services* - listeners that keep going after you switch tabs - and
+ * until this view each one arrived with its own ad-hoc entry point: the webhook
+ * inbox through a single welcome tile, the OAuth mock issuer through curl and
+ * nothing else. This is the one place that lists them, starts them, and hands
+ * over the URLs they exist to give you.
+ *
+ * It is a drawer view rather than a tab because that is what the shell already
+ * says navigation is - the Dock's left group switches drawer views, and a
+ * service is a thing you consult while working in a request, not a document you
+ * open. The inbox keeps its tab as the detail surface (a capture list needs the
+ * width); an issuer has no detail surface, so its whole management fits a row
+ * that expands plus one dialog, and no new TabType.
+ *
+ * Mock servers (#481) get a group here when they exist. There is deliberately
+ * no placeholder for them: a group that lists nothing and can start nothing
+ * teaches a reader less than its absence does.
+ */
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Copy, KeyRound, Play, Plus, Square } from "lucide-react";
+import { DrawerPanel, EmptyState, ErrorState, TruncatedText } from "@/components/shared";
+import {
+	Badge,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	TooltipIconButton,
+} from "@/components/ui";
+import {
+	useInboxesQuery,
+	useMockIssuersQuery,
+	useStartInboxMutation,
+	useStopInboxMutation,
+	useStopMockIssuerMutation,
+	useUpdateMockIssuerMutation,
+} from "@/queries";
+import { useTabsStore, useToastStore } from "@/stores";
+import { cn } from "@/lib/utils";
+import type { Inbox, MockIssuer, MockIssuerFailureMode } from "@/types";
+import { FAILURE_MODE_LABELS, failureModeSummary } from "./failure-modes";
+import { NewIssuerDialog } from "./NewIssuerDialog";
+
+/**
+ * The running light, in the vocabulary the inbox header already uses.
+ *
+ * `success-text` rather than the bare status token for the same reason the
+ * Dock's connection light uses it: as 12px text the indicator token misses AA,
+ * and the dot inherits the accessible pair through `bg-current`.
+ */
+function StatusDot({ running }: { running: boolean }) {
+	return (
+		<span
+			className={cn(
+				"h-1.5 w-1.5 shrink-0 rounded-full bg-current",
+				running ? "text-success-text" : "text-muted-foreground"
+			)}
+			aria-hidden="true"
+		/>
+	);
+}
+
+interface ServiceRowProps {
+	/** What the row does when the row itself - or its activator - is clicked. */
+	onActivate: () => void;
+	/** Names the activator. Icon-only trailing controls carry their own. */
+	activateLabel: string;
+	running: boolean;
+	children: React.ReactNode;
+	/** Trailing controls: copy, stop. */
+	actions?: React.ReactNode;
+	leading?: React.ReactNode;
+}
+
+/**
+ * One service, as a drawer row.
+ *
+ * The row paints the hover fill and the activator stretches into it
+ * (`self-stretch`), and the row delegates clicks that land on its own box -
+ * both halves of the hit-area rule in `app/CLAUDE.md`. A row carrying trailing
+ * buttons cannot be one big button, so without the pair the responsive area is
+ * the label's own bounding box and the padding around it is dead.
+ */
+function ServiceRow({
+	onActivate,
+	activateLabel,
+	running,
+	children,
+	actions,
+	leading,
+}: ServiceRowProps) {
+	return (
+		<div
+			className="flex h-8 cursor-pointer items-center gap-1 px-3 hover:bg-muted/50"
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onActivate();
+			}}
+		>
+			{leading}
+			<button
+				type="button"
+				onClick={onActivate}
+				aria-label={activateLabel}
+				className="flex min-w-0 flex-1 items-center gap-2 self-stretch text-left text-sm"
+			>
+				<StatusDot running={running} />
+				{children}
+			</button>
+			{actions && <div className="flex shrink-0 items-center gap-0.5">{actions}</div>}
+		</div>
+	);
+}
+
+interface ServiceGroupProps {
+	title: string;
+	/** The group's own start affordance - "Start inbox", "New issuer…". */
+	action?: React.ReactNode;
+	children: React.ReactNode;
+}
+
+function ServiceGroup({ title, action, children }: ServiceGroupProps) {
+	return (
+		<section className="mb-4">
+			<div className="flex items-center justify-between gap-1 px-3 py-1.5">
+				<h3 className="text-xs tracking-wider text-muted-foreground">{title}</h3>
+				{action}
+			</div>
+			{children}
+		</section>
+	);
+}
+
+/** `px-3 py-2 text-left`: a drawer group's line, not a centred pane. */
+const GROUP_NOTE_CLASS = "px-3 py-2 text-left text-xs";
+
+function useCopy() {
+	const showToast = useToastStore((s) => s.showToast);
+	return (value: string, what: string) => {
+		void navigator.clipboard.writeText(value);
+		showToast(`${what} copied`, "success");
+	};
+}
+
+function InboxRow({ inbox }: { inbox: Inbox }) {
+	const openTab = useTabsStore((s) => s.openTab);
+	const showToast = useToastStore((s) => s.showToast);
+	const copy = useCopy();
+	const stopInbox = useStopInboxMutation();
+
+	return (
+		<ServiceRow
+			running={inbox.running}
+			onActivate={() => openTab({ type: "inbox", entityId: null })}
+			activateLabel={`Open inbox on port ${inbox.port}`}
+			actions={
+				<>
+					<TooltipIconButton
+						label="Copy inbox URL"
+						icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+						onClick={() => copy(inbox.url, "Inbox URL")}
+					/>
+					{inbox.running && (
+						<TooltipIconButton
+							label={`Stop inbox on port ${inbox.port}`}
+							icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
+							disabled={stopInbox.isPending}
+							onClick={() =>
+								stopInbox.mutate(inbox.inboxId, {
+									onError: (error) =>
+										showToast(
+											error instanceof Error
+												? error.message
+												: "Could not stop the inbox",
+											"error"
+										),
+								})
+							}
+						/>
+					)}
+				</>
+			}
+		>
+			<TruncatedText className="font-mono text-xs">{inbox.url}</TruncatedText>
+			{/* An inbox reachable beyond this machine is badged wherever it is
+			    named - the standing reminder that the engine's non-loopback
+			    confirmation was given. */}
+			{!inbox.loopback && (
+				<Badge variant="chip" className="bg-status-warning-fill text-primary-foreground">
+					{inbox.bind}
+				</Badge>
+			)}
+			{!inbox.running && <span className="text-xs text-muted-foreground">Stopped</span>}
+		</ServiceRow>
+	);
+}
+
+/** One labelled URL inside an expanded issuer, with its copy control. */
+function IssuerDetailRow({
+	label,
+	value,
+	copyLabel,
+	onCopy,
+}: {
+	label: string;
+	value: string;
+	copyLabel: string;
+	onCopy: () => void;
+}) {
+	return (
+		<div className="flex items-center gap-1 py-0.5">
+			<span className="w-16 shrink-0 text-xs text-muted-foreground">{label}</span>
+			<TruncatedText className="min-w-0 flex-1 font-mono text-xs">{value}</TruncatedText>
+			<TooltipIconButton
+				label={copyLabel}
+				icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+				onClick={onCopy}
+			/>
+		</div>
+	);
+}
+
+function IssuerRow({
+	issuer,
+	expanded,
+	onToggle,
+}: {
+	issuer: MockIssuer;
+	expanded: boolean;
+	onToggle: () => void;
+}) {
+	const showToast = useToastStore((s) => s.showToast);
+	const copy = useCopy();
+	const stopIssuer = useStopMockIssuerMutation();
+	const updateIssuer = useUpdateMockIssuerMutation();
+
+	const setFailureMode = (failureMode: MockIssuerFailureMode) => {
+		updateIssuer.mutate(
+			{ issuerId: issuer.issuerId, update: { failureMode } },
+			{
+				onError: (error) =>
+					showToast(
+						error instanceof Error ? error.message : "Could not update the issuer",
+						"error"
+					),
+			}
+		);
+	};
+
+	return (
+		<>
+			<ServiceRow
+				// Every listed issuer is running: stopping one drops it from the
+				// engine's list rather than leaving a stopped record behind, which
+				// is where this differs from an inbox.
+				running
+				onActivate={onToggle}
+				activateLabel={`${expanded ? "Collapse" : "Expand"} issuer on port ${issuer.port}`}
+				leading={
+					expanded ? (
+						<ChevronDown
+							className="h-3 w-3 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+					) : (
+						<ChevronRight
+							className="h-3 w-3 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+					)
+				}
+				actions={
+					<TooltipIconButton
+						label={`Stop issuer on port ${issuer.port}`}
+						icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
+						disabled={stopIssuer.isPending}
+						onClick={() =>
+							stopIssuer.mutate(issuer.issuerId, {
+								onError: (error) =>
+									showToast(
+										error instanceof Error
+											? error.message
+											: "Could not stop the issuer",
+										"error"
+									),
+							})
+						}
+					/>
+				}
+			>
+				<TruncatedText className="font-mono text-xs">{issuer.issuerUrl}</TruncatedText>
+				{issuer.failureMode !== "none" && (
+					<Badge variant="outline">{FAILURE_MODE_LABELS[issuer.failureMode]}</Badge>
+				)}
+			</ServiceRow>
+
+			{expanded && (
+				<div className="border-l-2 border-rule pl-2 ml-4 mr-1 mb-2">
+					<IssuerDetailRow
+						label="Token"
+						value={issuer.tokenUrl}
+						copyLabel="Copy token URL"
+						onCopy={() => copy(issuer.tokenUrl, "Token URL")}
+					/>
+					<IssuerDetailRow
+						label="Authorize"
+						value={issuer.authorizeUrl}
+						copyLabel="Copy authorize URL"
+						onCopy={() => copy(issuer.authorizeUrl, "Authorize URL")}
+					/>
+					{/* The signing key is the whole point of the issuer being a mock:
+					    it is the HS256 secret the service under test verifies the
+					    minted tokens with. Copied, never displayed - a 32-character
+					    secret in a 260px drawer is noise, and this one is offered as
+					    a value to paste, not to read. */}
+					<div className="flex items-center gap-1 py-0.5">
+						<span className="w-16 shrink-0 text-xs text-muted-foreground">Key</span>
+						<span className="min-w-0 flex-1 text-xs text-muted-foreground">
+							HS256 shared secret
+						</span>
+						<TooltipIconButton
+							label="Copy signing key"
+							icon={<KeyRound className="h-3.5 w-3.5" aria-hidden="true" />}
+							onClick={() => copy(issuer.signingKey, "Signing key")}
+						/>
+					</div>
+
+					<p className="py-1 text-xs text-muted-foreground">
+						{failureModeSummary(issuer)}
+					</p>
+
+					{/* The one setting worth changing without a restart: flipping an
+					    issuer into an error mode is how retry handling gets tested,
+					    and the engine accepts it on a running listener. Expiry and
+					    slowMs are also mutable but are configuration you decide when
+					    you start one; this is the switch you throw mid-test. */}
+					<label className="flex items-center gap-2 py-1">
+						<span className="text-xs text-muted-foreground">Failure mode</span>
+						<Select
+							value={issuer.failureMode}
+							onValueChange={(value) =>
+								setFailureMode(value as MockIssuerFailureMode)
+							}
+							disabled={updateIssuer.isPending}
+						>
+							<SelectTrigger className="h-7 flex-1 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.entries(FAILURE_MODE_LABELS).map(([mode, label]) => (
+									<SelectItem key={mode} value={mode}>
+										{label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</label>
+				</div>
+			)}
+		</>
+	);
+}
+
+export default function ServicesPanel() {
+	const showToast = useToastStore((s) => s.showToast);
+	const inboxesQuery = useInboxesQuery();
+	const issuersQuery = useMockIssuersQuery();
+	const startInbox = useStartInboxMutation();
+	const [expandedIssuerId, setExpandedIssuerId] = useState<string | null>(null);
+	const [newIssuerOpen, setNewIssuerOpen] = useState(false);
+
+	const inboxes = inboxesQuery.data ?? [];
+	const issuers = issuersQuery.data ?? [];
+
+	/*
+	 * Per group, and only while that group has nothing to show. Each list is its
+	 * own query against its own engine routes, so one failing says nothing about
+	 * the other - and TanStack keeps the last good data through a failed
+	 * background refetch, which is worth more than an error replacing a list the
+	 * user can still act on. Same rule the variables tree follows.
+	 */
+	const showInboxError = inboxesQuery.isError && inboxes.length === 0;
+	const showIssuerError = issuersQuery.isError && issuers.length === 0;
+
+	const start = () =>
+		startInbox.mutate(
+			{},
+			{
+				onError: (error) =>
+					showToast(
+						error instanceof Error ? error.message : "Could not start the inbox",
+						"error"
+					),
+			}
+		);
+
+	return (
+		<DrawerPanel title="Services">
+			<div className="flex w-full flex-col py-2">
+				<ServiceGroup
+					title="Webhook inboxes"
+					action={
+						<TooltipIconButton
+							label="Start inbox"
+							icon={<Play className="h-3.5 w-3.5" aria-hidden="true" />}
+							disabled={startInbox.isPending}
+							onClick={start}
+						/>
+					}
+				>
+					{showInboxError ? (
+						<ErrorState
+							variant="inline"
+							title="Couldn't load the inboxes"
+							className={cn("justify-start", GROUP_NOTE_CLASS)}
+							onRetry={() => void inboxesQuery.refetch()}
+						/>
+					) : inboxes.length === 0 ? (
+						<EmptyState
+							variant="inline"
+							className={GROUP_NOTE_CLASS}
+							title="No inbox yet. Start one for a local URL that records every request sent to it - no tunnel, no third party."
+						/>
+					) : (
+						inboxes.map((inbox) => <InboxRow key={inbox.inboxId} inbox={inbox} />)
+					)}
+				</ServiceGroup>
+
+				<ServiceGroup
+					title="OAuth issuers"
+					action={
+						<TooltipIconButton
+							label="New issuer"
+							icon={<Plus className="h-3.5 w-3.5" aria-hidden="true" />}
+							onClick={() => setNewIssuerOpen(true)}
+						/>
+					}
+				>
+					{showIssuerError ? (
+						<ErrorState
+							variant="inline"
+							title="Couldn't load the issuers"
+							className={cn("justify-start", GROUP_NOTE_CLASS)}
+							onRetry={() => void issuersQuery.refetch()}
+						/>
+					) : issuers.length === 0 ? (
+						<EmptyState
+							variant="inline"
+							className={GROUP_NOTE_CLASS}
+							title="No issuer running. Start one to mint your own OAuth 2.0 tokens locally, with the claims and failures you choose."
+						/>
+					) : (
+						issuers.map((issuer) => (
+							<IssuerRow
+								key={issuer.issuerId}
+								issuer={issuer}
+								expanded={expandedIssuerId === issuer.issuerId}
+								onToggle={() =>
+									setExpandedIssuerId((current) =>
+										current === issuer.issuerId ? null : issuer.issuerId
+									)
+								}
+							/>
+						))
+					)}
+				</ServiceGroup>
+			</div>
+
+			{newIssuerOpen && (
+				<NewIssuerDialog onOpenChange={setNewIssuerOpen} onStarted={setExpandedIssuerId} />
+			)}
+		</DrawerPanel>
+	);
+}

--- a/app/src/modules/services/failure-modes.ts
+++ b/app/src/modules/services/failure-modes.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What a mock issuer's `failureMode` means, in one place.
+ *
+ * The row badge, the row's live switch and the start dialog all name these four
+ * modes; three copies of the mapping would be three chances for the UI to call
+ * `server_error` something the next surface calls something else.
+ *
+ * Bounds mirror the engine's own (`core/constants.hpp`, `mi::`): asking for a
+ * value outside them is a `400 mock_issuer_invalid_config`, so the dialog
+ * refuses it up front rather than turning a typo into a failed request.
+ */
+
+import type { MockIssuer, MockIssuerFailureMode } from "@/types";
+
+export const FAILURE_MODE_LABELS: Record<MockIssuerFailureMode, string> = {
+	none: "None",
+	slow: "Slow",
+	server_error: "Server error",
+	invalid_client: "Invalid client",
+};
+
+/** `mi::MAX_EXPIRES_IN_SECONDS` - 31 days. */
+export const MAX_EXPIRES_IN_SECONDS = 31 * 86400;
+/** `mi::MAX_SLOW_MS`. */
+export const MAX_SLOW_MS = 60_000;
+export const DEFAULT_EXPIRES_IN_SECONDS = 3600;
+export const DEFAULT_SLOW_MS = 2000;
+
+/** The issuer's configuration as one line, for the expanded row. */
+export function failureModeSummary(issuer: MockIssuer): string {
+	const parts = [`Tokens expire in ${issuer.expiresInSeconds}s`];
+	if (issuer.failureMode === "slow") {
+		parts.push(`answers after ${issuer.slowMs}ms`);
+	} else if (issuer.failureMode !== "none") {
+		parts.push(`answers ${FAILURE_MODE_LABELS[issuer.failureMode].toLowerCase()}`);
+	}
+	parts.push(
+		issuer.clientCount === 0
+			? "any client id accepted"
+			: `${issuer.clientCount} client${issuer.clientCount === 1 ? "" : "s"} configured`
+	);
+	if (issuer.issueRefreshTokens) parts.push("refresh tokens issued");
+	return `${parts.join(" · ")}.`;
+}

--- a/app/src/modules/services/index.ts
+++ b/app/src/modules/services/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+export { default as ServicesPanel } from "./ServicesPanel";
+export { useRunningServiceCount } from "./useRunningServices";

--- a/app/src/modules/services/useRunningServices.ts
+++ b/app/src/modules/services/useRunningServices.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * How many local services are running, for the Dock's ambient indicator.
+ *
+ * One hook rather than each surface counting for itself: the drawer and the
+ * indicator have to agree about what "running" means, and they disagree on the
+ * two lists' own terms. An inbox keeps its record after it is stopped (`running`
+ * is the flag that says so); a stopped issuer is *gone* from the engine's list,
+ * so every issuer listed is a running one.
+ *
+ * Both reads go through the same query keys the drawer uses, so mounting this
+ * in the Dock costs one shared poll, not a second set of requests.
+ */
+
+import { useInboxesQuery, useMockIssuersQuery } from "@/queries";
+
+export function useRunningServiceCount(): number {
+	const { data: inboxes = [] } = useInboxesQuery();
+	const { data: issuers = [] } = useMockIssuersQuery();
+
+	return inboxes.filter((inbox) => inbox.running).length + issuers.length;
+}

--- a/app/src/modules/welcome/Launcher.tsx
+++ b/app/src/modules/welcome/Launcher.tsx
@@ -16,7 +16,7 @@
 // `Braces` is the app-wide mark for variables - see the note in
 // `components/layout/Dock.tsx`. It was `Database` here, which reads as stored
 // records rather than `{{name}}` substitutions.
-import { Download, Plus, Braces, History, Inbox, Search } from "lucide-react";
+import { Download, Plus, Braces, History, Radio, Search } from "lucide-react";
 import { Eyebrow } from "@/components/ui";
 import type { Run } from "@/types";
 import { ActionTile } from "./components/ActionTile";
@@ -31,7 +31,7 @@ interface LauncherProps {
 	onSearch: () => void;
 	onHistory: () => void;
 	onVariables: () => void;
-	onInbox: () => void;
+	onServices: () => void;
 }
 
 function plural(n: number, word: string) {
@@ -46,7 +46,7 @@ export function Launcher({
 	onSearch,
 	onHistory,
 	onVariables,
-	onInbox,
+	onServices,
 }: LauncherProps) {
 	return (
 		<div className="flex flex-col gap-8">
@@ -67,10 +67,13 @@ export function Launcher({
 					<ActionTile icon={Download} label="Import" onClick={onImport} />
 					<ActionTile icon={History} label="History" onClick={onHistory} />
 					<ActionTile icon={Braces} label="Variables" onClick={onVariables} />
-					{/* The receiving half of the app. It has no drawer view to
-					    switch to - an inbox is engine state, not a stored record
-					    - so this tile is how it is reached. */}
-					<ActionTile icon={Inbox} label="Inbox" onClick={onInbox} />
+					{/* The local services - the webhook inbox, the OAuth mock
+					    issuer. Like History, this tile activates a drawer view
+					    rather than opening a tab: the inbox used to be reachable
+					    from here and nowhere else, and a tile that teaches where
+					    a whole family of features lives outlives one that opens
+					    a single tab (issue #502). */}
+					<ActionTile icon={Radio} label="Services" onClick={onServices} />
 				</div>
 			</section>
 

--- a/app/src/modules/welcome/WelcomeScreen.tsx
+++ b/app/src/modules/welcome/WelcomeScreen.tsx
@@ -101,7 +101,7 @@ export default function WelcomeScreen() {
 						onSearch={() => setPaletteOpen(true)}
 						onHistory={() => activateDrawerView("history")}
 						onVariables={() => openTab({ type: "variables", entityId: null })}
-						onInbox={() => openTab({ type: "inbox", entityId: null })}
+						onServices={() => activateDrawerView("services")}
 					/>
 				)}
 			</div>

--- a/app/src/queries/inbox.ts
+++ b/app/src/queries/inbox.ts
@@ -17,14 +17,25 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiService } from "@/services/api";
+import { TIMING } from "@/config/timing";
 import type { InboxCannedResponse, StartInboxRequest } from "@/types";
 import { queryKeys } from "./keys";
 
-/** Every inbox this engine has started, running or stopped. */
+/**
+ * Every inbox this engine has started, running or stopped.
+ *
+ * Polled - unlike the captures below, which the stream owns. The list changes
+ * when *somebody* starts or stops an inbox, and this window is not the only one
+ * who can: the MCP tools and a bare curl reach the same routes. The Services
+ * drawer and the Dock's running-services indicator both promise to show a
+ * running listener wherever it came from, which a list only this app's own
+ * mutations refreshed could not do.
+ */
 export function useInboxesQuery() {
 	return useQuery({
 		queryKey: queryKeys.inbox.list(),
 		queryFn: () => apiService.listInboxes(),
+		refetchInterval: TIMING.SERVICES_POLL_INTERVAL_MS,
 	});
 }
 

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -83,6 +83,14 @@ export {
 	useClearInboxCapturesMutation,
 } from "./inbox";
 
+// OAuth 2.0 mock issuer
+export {
+	useMockIssuersQuery,
+	useStartMockIssuerMutation,
+	useUpdateMockIssuerMutation,
+	useStopMockIssuerMutation,
+} from "./mock-issuer";
+
 // Health & Config
 export { useHealthQuery } from "./health";
 export { useConfigQuery, useUpdateConfigMutation } from "./config";

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -104,6 +104,14 @@ export const queryKeys = {
 		captures: (inboxId: string) => [...queryKeys.inbox.all, "captures", inboxId] as const,
 	},
 
+	// OAuth 2.0 mock issuers (issue #479). One key: the engine reports every
+	// running issuer in one call and there is no per-issuer read - stopping one
+	// removes it from the same list.
+	mockIssuer: {
+		all: ["mockIssuer"] as const,
+		list: () => [...queryKeys.mockIssuer.all, "list"] as const,
+	},
+
 	// Warm-cache pass over every collection's requests (see
 	// usePrefetchCollectionsAndRequests). Keyed here rather than inline so it
 	// can be invalidated when the set of collections changes - it succeeds once

--- a/app/src/queries/mock-issuer.ts
+++ b/app/src/queries/mock-issuer.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * OAuth 2.0 Mock Issuer Queries (issue #479)
+ *
+ * An issuer is a listener the engine holds until it is stopped or the process
+ * ends, so - as with an inbox - none of this is stored state the app could
+ * rebuild: every hook here reads the engine back.
+ *
+ * The list is polled (`TIMING.SERVICES_POLL_INTERVAL_MS`) because this window
+ * is not the only client with the lifecycle: the MCP tools hand it to an agent
+ * and the routes answer curl. A mutation invalidating the list covers what this
+ * app did; the poll covers everything else.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiService } from "@/services/api";
+import { TIMING } from "@/config/timing";
+import type { StartMockIssuerRequest, UpdateMockIssuerRequest } from "@/types";
+import { queryKeys } from "./keys";
+
+/** Every issuer this engine is running. A stopped one is gone, not listed. */
+export function useMockIssuersQuery() {
+	return useQuery({
+		queryKey: queryKeys.mockIssuer.list(),
+		queryFn: () => apiService.listMockIssuers(),
+		refetchInterval: TIMING.SERVICES_POLL_INTERVAL_MS,
+	});
+}
+
+export function useStartMockIssuerMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (request: StartMockIssuerRequest = {}) => apiService.startMockIssuer(request),
+		// The start reply carries the URLs and the signing key but none of the
+		// settings, so it cannot be written into the list cache as a row - the
+		// list is refetched for the full record instead.
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: queryKeys.mockIssuer.list() });
+		},
+	});
+}
+
+export function useUpdateMockIssuerMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ issuerId, update }: { issuerId: string; update: UpdateMockIssuerRequest }) =>
+			apiService.updateMockIssuer(issuerId, update),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: queryKeys.mockIssuer.list() });
+		},
+	});
+}
+
+export function useStopMockIssuerMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (issuerId: string) => apiService.stopMockIssuer(issuerId),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: queryKeys.mockIssuer.list() });
+		},
+	});
+}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -70,6 +70,12 @@ import type {
 	ListInboxesResponse,
 	StartInboxRequest,
 	ClearInboxCapturesResponse,
+	MockIssuer,
+	ListMockIssuersResponse,
+	StartMockIssuerRequest,
+	StartMockIssuerResponse,
+	UpdateMockIssuerRequest,
+	StopMockIssuerResponse,
 } from "@/types";
 import type { MonitorSeriesResponse, TimeSeriesResponse } from "@/modules/history/types";
 import { queryClient } from "@/lib/query-client";
@@ -312,6 +318,35 @@ export const apiService = {
 	async clearInboxCaptures(inboxId: string): Promise<ClearInboxCapturesResponse> {
 		return await httpClient.delete<ClearInboxCapturesResponse>(
 			API_ENDPOINTS.INBOX_CAPTURES_CLEAR(inboxId)
+		);
+	},
+
+	// OAuth 2.0 mock issuer (issue #479)
+	async listMockIssuers(): Promise<MockIssuer[]> {
+		const response = await httpClient.get<ListMockIssuersResponse>(API_ENDPOINTS.MOCK_ISSUER);
+		return response.issuers;
+	},
+
+	async startMockIssuer(request: StartMockIssuerRequest = {}): Promise<StartMockIssuerResponse> {
+		return await httpClient.post<StartMockIssuerResponse>(
+			API_ENDPOINTS.MOCK_ISSUER_START,
+			request
+		);
+	},
+
+	/**
+	 * Change what a *running* issuer does. Only the three mutable settings are
+	 * accepted - a port, client list or claim set cannot move under a bound
+	 * listener, and the engine refuses one rather than half-applying it.
+	 */
+	async updateMockIssuer(issuerId: string, update: UpdateMockIssuerRequest): Promise<MockIssuer> {
+		return await httpClient.put<MockIssuer>(API_ENDPOINTS.MOCK_ISSUER_BY_ID(issuerId), update);
+	},
+
+	async stopMockIssuer(issuerId: string): Promise<StopMockIssuerResponse> {
+		return await httpClient.post<StopMockIssuerResponse>(
+			API_ENDPOINTS.MOCK_ISSUER_STOP(issuerId),
+			{}
 		);
 	},
 

--- a/app/src/stores/layout-store.ts
+++ b/app/src/stores/layout-store.ts
@@ -18,7 +18,7 @@ import {
 	PANEL_MAX_WIDTH,
 } from "@/constants/layout";
 
-export type DrawerView = "collections" | "history" | "variables" | "settings";
+export type DrawerView = "collections" | "history" | "variables" | "services" | "settings";
 
 interface LayoutState {
 	// Drawer

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -651,6 +651,77 @@ export interface ClearInboxCapturesResponse {
 	cleared: number;
 }
 
+// OAuth 2.0 mock issuer API (issue #479). Engine-process state like an inbox:
+// the engine holds each issuer on its own loopback listener and a restart
+// forgets every one of them, so nothing here is stored client-side either.
+
+/** What `/token` answers with, so retry and error handling are testable. */
+export type MockIssuerFailureMode = "none" | "slow" | "server_error" | "invalid_client";
+
+/** One running issuer, as `GET /mock-issuer` and the `PUT` reply describe it. */
+export interface MockIssuer {
+	issuerId: string;
+	/** Base URL - the OAuth `iss` of every token it mints. */
+	issuerUrl: string;
+	tokenUrl: string;
+	authorizeUrl: string;
+	/** HS256 secret the service under test verifies this issuer's tokens with. */
+	signingKey: string;
+	port: number;
+	expiresInSeconds: number;
+	failureMode: MockIssuerFailureMode;
+	/** How long `slow` mode waits before answering; ignored in every other mode. */
+	slowMs: number;
+	issueRefreshTokens: boolean;
+	/** 0 accepts any client id; otherwise the id must be one of the configured ones. */
+	clientCount: number;
+	createdAt: number;
+}
+
+export interface MockIssuerClient {
+	clientId: string;
+	clientSecret?: string;
+}
+
+export interface StartMockIssuerRequest {
+	/** 0 (the default) binds an ephemeral port. */
+	port?: number;
+	expiresInSeconds?: number;
+	claims?: Record<string, unknown>;
+	clients?: MockIssuerClient[];
+	failureMode?: MockIssuerFailureMode;
+	slowMs?: number;
+	issueRefreshTokens?: boolean;
+}
+
+/**
+ * The start call answers with the URLs and the key only - not the full record.
+ * The list is what carries the settings back, which is why starting one
+ * invalidates it rather than writing the reply into the cache.
+ */
+export interface StartMockIssuerResponse {
+	issuerId: string;
+	issuerUrl: string;
+	tokenUrl: string;
+	authorizeUrl: string;
+	signingKey: string;
+}
+
+export interface ListMockIssuersResponse {
+	issuers: MockIssuer[];
+}
+
+/** Only these three can change under a bound listener; the rest are a 400. */
+export interface UpdateMockIssuerRequest {
+	expiresInSeconds?: number;
+	failureMode?: MockIssuerFailureMode;
+	slowMs?: number;
+}
+
+export interface StopMockIssuerResponse {
+	stopped: boolean;
+}
+
 // Health & Config API
 export type GetHealthResponse = EngineHealth;
 

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -25,6 +25,7 @@ State lives outside components: **Zustand** stores (`stores/`) for UI/navigation
     │   ├── <CollectionTree />           //   collections view (default)
     │   ├── <HistoryList />              //   history view
     │   ├── <VariablesCategoryTree />    //   variables view
+    │   ├── <ServicesPanel />            //   services view - modules/services/
     │   └── <SettingsCategoryTree />     //   settings view
     ├── <TabStrip />                     // Open tabs + "+" button - over main+context, left edge = drawer edge
     ├── main content (switched on active tab type)
@@ -98,7 +99,7 @@ Main layout: tab-centric with resizable drawer, split/overlay context bar, and d
 
 - **One uniform layout for every tab** - `Drawer` (left) + a content column holding `TabStrip` over main + `ContextBar`. No tab type takes over the row. This is deliberate: the Dock's drawer switchers always have a Drawer to act on, so they can never be dead. (Settings used to full-take-over and suppress the Drawer, which left those buttons doing nothing while Settings was open.)
 - **Left navigation is always the Drawer.** Every main view that needs a category/entity list uses the shared Drawer for it - never its own left rail. `SettingsMain` and `VariablesMain` are pure content panes; their category trees live in the Drawer (`settings` / `variables` views). Follow this pattern for any new view - do not add a second sidebar inside the main area.
-- **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab). ⌘K (command palette) is **not** in this map - it is owned by `CommandPalette`, on the capture phase, because Monaco swallows the key on the bubble.
+- **Keyboard handlers:** ⌘S (save), ⌘W (close tab), ⌘B (toggle drawer), ⇧⌘E/H/U/S (drawer views), ⌘I (toggle context bar), ⌘, (open settings tab). ⌘K (command palette) is **not** in this map - it is owned by `CommandPalette`, on the capture phase, because Monaco swallows the key on the bubble.
 - **Drawer:** toggles visibility via `toggleDrawer()` (state in `useLayoutStore`); always resizable 220–480px.
 - **Content routing:** switches main area based on `activeTab.type` (welcome | request | collection | dashboard | run | variables | settings). Default is `WelcomeScreen`.
 - **Drawer-view sync:** an effect points the Drawer at the view matching the active tab - `variables`→variables, `settings`→settings, `request`/`collection`→collections - and opens it.
@@ -108,13 +109,14 @@ Main layout: tab-centric with resizable drawer, split/overlay context bar, and d
 
 ### `Drawer` (`components/layout/Drawer.tsx`)
 
-Resizable sidebar (220–480px default, per view). The single left navigation for the whole app - one of four views per `useLayoutStore.drawerView`. Every view is titled: its `DrawerPanel` header is the drawer's half of the second chrome row, sharing `--tabstrip-height` and its bottom rule with the tab strip across the resize handle, with an optional tools slot beside the title.
+Resizable sidebar (220–480px default, per view). The single left navigation for the whole app - one of five views per `useLayoutStore.drawerView`. Every view is titled: its `DrawerPanel` header is the drawer's half of the second chrome row, sharing `--tabstrip-height` and its bottom rule with the tab strip across the resize handle, with an optional tools slot beside the title.
 
 | View | Component | Band tools today |
 |------|-----------|------------------|
 | **`collections`** | `CollectionTree` (hierarchical collections + requests) | add collection, add request, import |
 | **`history`** | `HistoryList` (past runs, filtered/sorted) | run count |
 | **`variables`** | `VariablesCategoryTree` (globals, collections, environments) | - |
+| **`services`** | `ServicesPanel` (webhook inboxes, OAuth issuers) | start inbox, new issuer |
 | **`settings`** | `SettingsCategoryTree` (app + engine setting categories) | - |
 
 Both `variables` and `settings` follow the same nav/content split: the tree lives here in the Drawer, the editor is the corresponding tab (`VariablesMain` / `SettingsMain`), and selecting a category sets the shared store selection **and** opens/focuses that tab.
@@ -215,8 +217,9 @@ HTTPie takes headers as bare `Name:value` words and a body as `--raw`, so the co
 
 Footer bar (h-8, shrink-0). Horizontal layout:
 
-- **Left - drawer switchers:** buttons for Collections (⇧⌘E), History (⇧⌘H), Variables (⇧⌘U), Settings (⌘,). Each activates its Drawer view; active state highlights when the drawer is open on that view. Settings sits here too because it is now a Drawer view like the rest.
+- **Left - drawer switchers:** buttons for Collections (⇧⌘E), History (⇧⌘H), Variables (⇧⌘U), Services (⇧⌘S), Settings (⌘,). Each activates its Drawer view; active state highlights when the drawer is open on that view. Settings sits here too because it is now a Drawer view like the rest.
 - **Middle - ambient status:** engine connection status (green dot + text if connected), save status (Saving… / Saved), app version. When the engine is *down* the indicator becomes a focusable tooltip carrying `engineError` - the health poll's reason, which was previously recorded and rendered nowhere, so a refused connection, a timeout and a TLS failure all read as one word. A save *failure* is not shown here - it is reported as a toast, like every other failure in the app.
+- **Middle - running services:** a dot plus "2 services" whenever at least one local service (a running webhook inbox, an OAuth issuer) is up, and **nothing at all when none is** - the Dock's middle is ambient, and a standing "0 services" would spend a permanent line on the ordinary case. Clicking it activates the Services drawer, which is where a service can be read, copied or stopped. Before it, a running inbox was invisible outside its own tab and an issuer was invisible everywhere. → `Dock.services.test.tsx` (mutation-checked: rendered unconditionally, the absent-case tests fail).
 - **Middle - pending restart:** once a setting the engine marks `requiresRestart` has been saved, a "Restart pending" button appears beside the connection status and restarts the engine in place (`useEngineRestart`, shared with the Settings banner so the two cannot diverge). It tracks saves made since this renderer connected - not a comparison against the engine's running values, which it does not report - so it says *saved*, not *in effect*, and does not survive a renderer reload. A failed restart leaves the signal standing and reports the reason as a toast.
 - **Right - toggles:** Context bar toggle (⌘I). Pressed when the bar is open *and* the active tab is one it has content for, so the highlight always matches what is on screen.
 
@@ -499,8 +502,44 @@ never dirty - both stated explicitly in `tabs-store`, since a *missing* answer r
 "clean" and is what once made a dirty Settings tab LRU-evictable
 (`components/layout/tab-type-coverage.test.ts` guards all three switches).
 
-**Entry point:** the `Inbox` tile on the welcome Launcher. It has no Drawer view to switch to -
-an inbox is not a stored record - so there is nothing for a Dock button to act on.
+**Entry points:** the **Services** drawer view, which lists every inbox and opens this tab (issue
+#502), and the palette's `Inbox` entry. The welcome Launcher's tile is now `Services` rather than
+`Inbox` - it teaches where the whole family of local services lives instead of opening one tab -
+and the Dock's running-services indicator activates the same view. Until #502 the Launcher tile was
+the *only* way in, and a running inbox was invisible once its tab was closed.
+
+## Services (`modules/services/`)
+
+One home for the app's **local services** - the things that keep listening after you switch tabs
+(issue #502). Rendered as the `services` drawer view; the Dock's indicator and the welcome tile
+both activate it.
+
+- `ServicesPanel.tsx` - the view. Two groups today, **Webhook inboxes** and **OAuth issuers**, each
+  with its own start affordance in the group header and a one-sentence empty state saying what the
+  service would give you - this drawer is also the features' discoverability. An inbox row opens the
+  inbox *tab* (the drawer lists, the tab shows the captures); an issuer row expands in place to its
+  token and authorize URLs, a copy for the HS256 signing key, its configuration in one line, and a
+  live `failureMode` switch. Mock servers (#481) get a third group when they exist - deliberately no
+  placeholder until then.
+- `NewIssuerDialog.tsx` - the start form: token lifetime, failure mode (plus its delay), and a JSON
+  claims box. Everything is validated before it is sent, because the engine refuses a bad config
+  with a `400` rather than falling back to a default, and a claims typo is otherwise invisible until
+  a token comes back without the claim. Mounted only while open, so the mount is the reset.
+- `useRunningServices.ts` - `useRunningServiceCount()`, shared by the drawer and the Dock. One place
+  because the two lists disagree on their own terms: a stopped inbox stays listed with
+  `running: false`, while a stopped issuer is gone from the engine's list entirely.
+- `failure-modes.ts` - the four `failureMode` labels, the engine's bounds, and the row's
+  one-line summary. Shared so the badge, the live switch and the dialog cannot name a mode
+  differently.
+
+**No new tab type.** An issuer's whole management surface fits a row plus a dialog, and a `TabType`
+costs three switch statements and the coverage guard. The inbox keeps its tab because a capture
+list needs the width.
+
+**Data:** `queries/inbox.ts` and `queries/mock-issuer.ts`, both polled at
+`TIMING.SERVICES_POLL_INTERVAL_MS`. They are polled rather than driven by this app's own mutations
+alone because the MCP tools and a bare curl reach the same engine routes - an indicator that only
+knew what this window started would contradict its own promise.
 
 ## Welcome (`modules/welcome/`)
 
@@ -512,7 +551,8 @@ It is **not** a resume screen: `openTabs`/`activeTabId` are persisted and restor
 - `EmptyState.tsx` - fresh workspace. Import leads (people arrive carrying Postman/Insomnia/OpenAPI collections). The only state with branding.
 - `Launcher.tsx` - populated. Action row, recent runs, workspace counts. No branding; the logo is in the title bar.
 - `components/` - `ActionTile`, `RecentRuns`, `FooterLinks`. The action row is six tiles: New
-  request, Search, Import, History, Variables, Inbox. Search opens the command palette - the
+  request, Search, Import, History, Variables, Services. Services and History both activate a
+  drawer view rather than opening a tab. Search opens the command palette - the
   chord alone is undiscoverable, and this grid is where the app teaches its own surfaces.
 - `LauncherSkeleton.tsx` - one skeleton tile per real tile. It has drifted a tile behind the
   Launcher before; `WelcomeScreen.test.tsx` now asserts both grids against one constant.

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -162,6 +162,26 @@ clears only the jar used when no environment is selected, and an id clears that
 environment's. It reaches `DELETE /cookies` with the parameter absent, present
 and empty, or present with the id, respectively.
 
+#### OAuth 2.0 mock issuer
+
+```typescript
+apiService.listMockIssuers(): Promise<MockIssuer[]>
+apiService.startMockIssuer(request?: StartMockIssuerRequest): Promise<StartMockIssuerResponse>
+apiService.updateMockIssuer(issuerId, update: UpdateMockIssuerRequest): Promise<MockIssuer>
+apiService.stopMockIssuer(issuerId): Promise<StopMockIssuerResponse>
+```
+
+A local issuer that mints HS256 tokens on demand (issue #479); the Services
+drawer (`modules/services/`) is the surface, added in #502 - before it these
+routes had no client but curl and the MCP tools. Two asymmetries the surface has
+to respect: `startMockIssuer` answers with the URLs and the signing key **only**,
+not the full record, so the list is refetched rather than patched; and a stopped
+issuer leaves the list altogether, unlike an inbox, which stays listed with
+`running: false`. `updateMockIssuer` accepts only `expiresInSeconds`,
+`failureMode` and `slowMs` - a port, client list or claim set cannot move under a
+bound listener and the engine refuses one with a `400` rather than half-applying
+it.
+
 #### Create vs update
 
 For collections, requests and environments the engine splits the write verbs:

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -97,7 +97,7 @@ Manages the left drawer (collections/history/variables/settings), the right cont
 ```typescript
 {
   drawerOpen: boolean                    // Is the left drawer visible?
-  drawerView: DrawerView                 // "collections" | "history" | "variables" | "settings"
+  drawerView: DrawerView                 // "collections" | "history" | "variables" | "services" | "settings"
   drawerWidth: number                    // One width for every view
   contextBarOpen: boolean                // Is the right context bar visible?
   contextBarWidth: number


### PR DESCRIPTION
## Description

**Plan.** Root cause: Vayu grew *services* - listeners that keep running after you switch tabs - without the shell growing a concept for them, so each arrived with its own ad-hoc entry. Verified at `f88adfb`, the issue's premises still hold: `WelcomeScreen.tsx:104` was the sole non-test `openTab({type:"inbox"})` call site, `rg -i issuer app/src` found nothing outside the MCP settings blurb, and `Dock.tsx` had no reference to either. Approach: take the shell at its word - the Dock's left group *is* drawer-view switching - and add a fifth view plus one ambient indicator in the Dock's status region, with the issuer's whole management as a row that expands plus one dialog. **Rejected: a new `TabType` for the issuer.** It costs three switch statements and the `tab-type-coverage` guard, and buys width an issuer has no use for (two URLs, a key and three settings); the inbox keeps its tab precisely because a capture list *does* need the width.

- **A fifth drawer view, `services`** (`DrawerView` union, `Drawer.tsx` switch, a `Radio` Dock button on ⇧⌘S - free in both the renderer's chord map and the native menu, whose only ⇧⌘ binding is ⇧⌘W). Groups for **Webhook inboxes** and **OAuth issuers**, each with status dot, copy-URL, start/stop, and a one-sentence empty state saying what the service gives you.
- **The issuer is manageable from the UI for the first time**: create with lifetime / failure mode / claims, list, expand for the token and authorize URLs and the HS256 signing key, flip `failureMode` on a running issuer, stop.
- **Running-state visibility in the chrome**: a dot plus "2 services" beside the connection light, activating the drawer - and rendering **nothing** when nothing runs, since the Dock's middle is ambient.
- **Entry-point consolidation**: the Launcher's `Inbox` tile becomes `Services` and activates the drawer, exactly as the History tile already does (tile count unchanged at six); the command palette's view list gains the same entry so it does not disagree with the Dock about what the app is made of.
- **Data layer**: `MOCK_ISSUER*` endpoints, types, four `apiService` methods, `queryKeys.mockIssuer`, `queries/mock-issuer.ts`. Both service lists poll at `TIMING.SERVICES_POLL_INTERVAL_MS` (10s), because the MCP tools and a bare curl reach the same routes - an indicator that only knew what this window started would contradict what it promises. That is the one addition beyond the issue's text, and the reason is in the constant's comment.

Deliberate deviations, both offered as the implementer's call in the issue: **no "Mock servers" placeholder group** (a group that lists nothing and starts nothing teaches less than its absence; #481 adds it), and **the welcome tile activates the drawer rather than keeping a direct-to-inbox path** - one further click, but it teaches where the family lives, which is the gap the issue was filed about.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

All green on this branch, from a clean `master` base:

- `cd app && pnpm test` - **4275 passed, 420 files** (up from 4252: 7 new in `Dock.services.test.tsx`, 16 in `ServicesPanel.test.tsx`).
- `cd app && pnpm type-check` - clean.
- `cd app && pnpm lint` - clean (zero warnings).
- `cd app && pnpm format:check` - clean. Only files I touched were formatted; each was prettier-clean at `HEAD` first.

No engine change, so no C++ build or ctest run - nothing in the engine could change colour.

Mutation-checked, both confirmed by reverting and re-running:

- Remove `if (count === 0) return null` from `RunningServices` → the two absent-case tests fail ("renders nothing while nothing is running", "does not count an inbox the engine has stopped").
- Drop the claims check from the dialog's `canStart` → both malformed-claims tests fail.

Three existing Dock test files needed updating, and the reason is a real consequence rather than test churn: the Dock now reads server state, so it needs a `QueryClientProvider` - as it always has in the app, where every renderer sits under the root provider (`TitleBar` already had the same note). `variables-icon.test.tsx`'s icon-uniqueness guard asserted four switcher buttons and now asserts five.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs in the same commit: `docs/app/COMPONENTS.md` (drawer-views table and the shell tree, the Dock's indicator, a new Services module section, the inbox's entry points, the Launcher tile row), `docs/app/api-integration.md` (the four issuer methods and the two asymmetries a client must respect - the start reply is not the record, and a stopped issuer leaves the list while a stopped inbox does not), `docs/app/state-management.md` (the `DrawerView` union), `app/src/modules/README.md` (the new module). `docs/engine/mcp.md` untouched.

## Related Issues
Closes #502


---
_Generated by [Claude Code](https://claude.ai/code/session_01R6tuBjEFAxSDYXsHztL1xJ)_