### PR TITLE
fix(app/inbox): give the inbox tab an address, so a drawer row opens the inbox it names

### DIFF
--- a/app/src/modules/inbox/InboxView.addressing.test.tsx
+++ b/app/src/modules/inbox/InboxView.addressing.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which inbox the tab is showing (issue #554).
+ *
+ * The tab is a singleton and used to have no address at all: it rendered
+ * whichever inbox its own start mutation had last named, falling back to the
+ * first the engine listed. So a drawer row labelled "Open inbox on port 41235"
+ * opened a tab showing port 41234, and nothing in the tab could switch. The
+ * address now lives in the tab's `entityId`, written by the drawer row and by
+ * the switcher in this header, and read back here.
+ *
+ * The transport is mocked and the real query hooks run, so the surface reaches
+ * its inbox the way the app does.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useTabsStore } from "@/stores";
+import type { Inbox } from "@/types";
+import type { InboxLiveState } from "./useInboxLive";
+
+const listInboxes = vi.fn();
+const listInboxCaptures = vi.fn();
+const startInbox = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => listInboxes(),
+			listInboxCaptures: (...a: unknown[]) => listInboxCaptures(...a),
+			startInbox: (...a: unknown[]) => startInbox(...a),
+		},
+	};
+});
+
+// The stream itself is #506's subject and needs an EventSource; this file is
+// about which inbox the surface is pointed at.
+const live: InboxLiveState = { watching: true, stopped: false, resume: vi.fn() };
+vi.mock("./useInboxLive", () => ({ useInboxLive: () => live }));
+
+const { default: InboxView } = await import("./index");
+
+function inbox(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:41234/",
+		bind: "127.0.0.1",
+		port: 41234,
+		running: true,
+		loopback: true,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
+
+const second = inbox({ inboxId: "inbox_b", port: 41235, url: "http://127.0.0.1:41235/" });
+
+/** Open the tab at @p entityId, the way the drawer row or a restore would. */
+function openInboxTab(entityId: string | null) {
+	useTabsStore.getState().openTab({ type: "inbox", entityId });
+}
+
+function renderTab() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<InboxView />
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	cleanup();
+	listInboxes.mockReset().mockResolvedValue([inbox(), second]);
+	listInboxCaptures.mockReset().mockResolvedValue({
+		data: [],
+		pagination: { total: 0, limit: 50, offset: 0, returned: 0, hasMore: false },
+	});
+	startInbox.mockReset().mockResolvedValue(second);
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText: vi.fn() } });
+	// jsdom has no layout, so the scroll the Select does to its checked item on
+	// open is absent rather than a no-op (same stub as `CodeSection.test.tsx`).
+	Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("the inbox the tab shows", () => {
+	it("is the one the tab was opened for, not the first the engine listed", async () => {
+		openInboxTab("inbox_b");
+		renderTab();
+
+		expect(await screen.findByText("http://127.0.0.1:41235/")).toBeInTheDocument();
+		expect(screen.queryByText("http://127.0.0.1:41234/")).not.toBeInTheDocument();
+		// The captures it asks for belong to that inbox too - a header naming one
+		// inbox over another's list is the same lie one layer down.
+		await waitFor(() => expect(listInboxCaptures).toHaveBeenCalledWith("inbox_b"));
+	});
+
+	it("falls back to a stable choice when the tab names no inbox", async () => {
+		// The engine lists in map order, which is not stable across polls, so the
+		// fallback orders by port rather than taking whatever came back first.
+		listInboxes.mockResolvedValue([second, inbox()]);
+		openInboxTab(null);
+		renderTab();
+
+		expect(await screen.findByText("http://127.0.0.1:41234/")).toBeInTheDocument();
+	});
+
+	it("falls back when the tab names an inbox this engine no longer has", async () => {
+		// Tabs are persisted and an inbox is engine-process state, so a restored
+		// tab routinely addresses an id from a previous run.
+		openInboxTab("inbox_from_a_previous_engine");
+		renderTab();
+
+		expect(await screen.findByText("http://127.0.0.1:41234/")).toBeInTheDocument();
+	});
+});
+
+describe("the header's inbox switcher", () => {
+	it("moves the tab to the inbox picked, without going back through the drawer", async () => {
+		openInboxTab("inbox_a");
+		renderTab();
+		await screen.findByText("http://127.0.0.1:41234/");
+
+		fireEvent.click(screen.getByRole("combobox", { name: "Inbox" }));
+		fireEvent.click(await screen.findByRole("option", { name: /Port 41235/ }));
+
+		expect(await screen.findByText("http://127.0.0.1:41235/")).toBeInTheDocument();
+		// Written to the tab, not to a second copy of the selection beside it:
+		// one address is what keeps the drawer and this switcher agreeing.
+		const tab = useTabsStore.getState().openTabs.find((t) => t.type === "inbox");
+		expect(tab?.entityId).toBe("inbox_b");
+	});
+
+	it("names each inbox by port and says which are stopped", async () => {
+		listInboxes.mockResolvedValue([inbox(), { ...second, running: false }]);
+		openInboxTab("inbox_a");
+		renderTab();
+		await screen.findByText("http://127.0.0.1:41234/");
+
+		fireEvent.click(screen.getByRole("combobox", { name: "Inbox" }));
+
+		expect(await screen.findByRole("option", { name: "Port 41234" })).toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Port 41235 (stopped)" })).toBeInTheDocument();
+	});
+
+	it("is absent for a single inbox, where it could only pick what is shown", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		openInboxTab("inbox_a");
+		renderTab();
+		await screen.findByText("http://127.0.0.1:41234/");
+
+		expect(screen.queryByRole("combobox", { name: "Inbox" })).not.toBeInTheDocument();
+	});
+});
+
+describe("starting an inbox from the tab", () => {
+	it("points the tab at what it started", async () => {
+		listInboxes.mockResolvedValue([]);
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: /start inbox/i }));
+
+		await waitFor(() =>
+			expect(useTabsStore.getState().openTabs.find((t) => t.type === "inbox")?.entityId).toBe(
+				"inbox_b"
+			)
+		);
+	});
+});

--- a/app/src/modules/inbox/index.tsx
+++ b/app/src/modules/inbox/index.tsx
@@ -17,11 +17,25 @@
  * restoring into a tab, and the engine allows a single live stream per inbox
  * (each holds a pool thread), so a surface that watched several at once would
  * be spending threads on lists nobody is reading.
+ *
+ * One tab still has to be able to name *which* inbox it shows (issue #554).
+ * That address is the tab's own `entityId`, written by whoever opens the tab -
+ * a drawer row, or the switcher in this header - and never mirrored into local
+ * state: two records of one selection is how the drawer came to open a tab
+ * showing a different inbox than the row it was clicked on.
  */
 
 import { useState } from "react";
 import { Copy, Inbox as InboxIcon, Play, RotateCw, Square, Trash2 } from "lucide-react";
-import { Badge, Button } from "@/components/ui";
+import {
+	Badge,
+	Button,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui";
 import { Callout, EmptyState, ErrorState } from "@/components/shared";
 import {
 	useClearInboxCapturesMutation,
@@ -31,7 +45,7 @@ import {
 	useStopInboxMutation,
 	useUpdateInboxResponseMutation,
 } from "@/queries";
-import { useToastStore } from "@/stores";
+import { useTabsStore, useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
 import type { Inbox, InboxCannedResponse, InboxCapture } from "@/types";
 import { CannedResponseControls } from "./CannedResponseControls";
@@ -75,26 +89,43 @@ function CaptureRow({ capture, selected, onSelect }: CaptureRowProps) {
 
 export default function InboxView() {
 	const showToast = useToastStore((s) => s.showToast);
+	const { openTabs, activeTabId, openTab } = useTabsStore();
 	const { data: inboxes = [], isError, error, refetch } = useInboxesQuery();
-	const [selectedInboxId, setSelectedInboxId] = useState<string | null>(null);
-	const [selectedCaptureId, setSelectedCaptureId] = useState<number | null>(null);
+	// Which capture, and of which inbox: ids are per-inbox, so a bare number
+	// carried across a switch can select a row in the inbox switched *to*.
+	const [selection, setSelection] = useState<{ inboxId: string; captureId: number } | null>(null);
 
 	const startInbox = useStartInboxMutation();
 	const stopInbox = useStopInboxMutation();
 	const updateResponse = useUpdateInboxResponseMutation();
 	const clearCaptures = useClearInboxCapturesMutation();
 
-	// Derived, not synced into state: the engine is the list of inboxes, and a
-	// selection it no longer has falls back to the first one it does. An effect
-	// writing the fallback back into `selectedInboxId` would say the same thing
-	// one render later, and be wrong for that render.
+	// The tab is the address (see the file comment): this reads it, and `show`
+	// below is the only writer, so the drawer and the switcher change the same
+	// thing.
+	const activeTab = openTabs.find((t) => t.id === activeTabId);
+	const addressedInboxId = activeTab?.type === "inbox" ? activeTab.entityId : null;
+	const show = (inboxId: string) => openTab({ type: "inbox", entityId: inboxId });
+
+	// The engine lists inboxes in map order, which is not stable across polls -
+	// so both the switcher's entries and the fallback below order by port. An
+	// inbox record carries no creation stamp; whether it should is #555's
+	// decision, and port is the stable key the record has today.
+	const ordered = [...inboxes].sort((a, b) => a.port - b.port);
+
+	// Derived, not synced into state: the engine is the list of inboxes, and an
+	// address it no longer has falls back to the first one it does. An effect
+	// writing that fallback back into the tab would say the same thing one
+	// render later, and be wrong for that render.
 	const inbox: Inbox | null =
-		inboxes.find((i) => i.inboxId === selectedInboxId) ?? inboxes[0] ?? null;
+		inboxes.find((i) => i.inboxId === addressedInboxId) ?? ordered[0] ?? null;
 
 	const capturesQuery = useInboxCapturesQuery(inbox?.inboxId ?? null);
 	const captures = capturesQuery.data?.data ?? [];
 	const live = useInboxLive(inbox?.inboxId ?? null, inbox?.running === true);
 
+	const selectedCaptureId =
+		selection !== null && selection.inboxId === inbox?.inboxId ? selection.captureId : null;
 	const selectedCapture = captures.find((c) => c.id === selectedCaptureId) ?? captures[0] ?? null;
 
 	if (isError) {
@@ -111,7 +142,7 @@ export default function InboxView() {
 		startInbox.mutate(
 			{},
 			{
-				onSuccess: (started) => setSelectedInboxId(started.inboxId),
+				onSuccess: (started) => show(started.inboxId),
 				onError: (mutationError) =>
 					showToast(
 						mutationError instanceof Error
@@ -189,6 +220,26 @@ export default function InboxView() {
 				<Badge variant="outline">
 					{inbox.running ? (live.watching ? "Live" : "Running") : "Stopped"}
 				</Badge>
+
+				{/* The tab's multi-inbox story, which it never had: with several
+				    listeners running, this is the only way to reach one of them
+				    without going back through the drawer. Absent for a single
+				    inbox, where a switcher with one entry is just a control that
+				    does nothing. */}
+				{inboxes.length > 1 && (
+					<Select value={inbox.inboxId} onValueChange={show}>
+						<SelectTrigger className="h-7 w-auto gap-1 text-xs" aria-label="Inbox">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{ordered.map((option) => (
+								<SelectItem key={option.inboxId} value={option.inboxId}>
+									{`Port ${option.port}${option.running ? "" : " (stopped)"}`}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				)}
 
 				<div className="ml-auto flex items-center gap-2">
 					<Button
@@ -270,7 +321,12 @@ export default function InboxView() {
 									key={capture.id}
 									capture={capture}
 									selected={selectedCapture?.id === capture.id}
-									onSelect={() => setSelectedCaptureId(capture.id)}
+									onSelect={() =>
+										setSelection({
+											inboxId: inbox.inboxId,
+											captureId: capture.id,
+										})
+									}
 								/>
 							))
 						)}

--- a/app/src/modules/inbox/useInboxLive.test.tsx
+++ b/app/src/modules/inbox/useInboxLive.test.tsx
@@ -24,8 +24,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { queryKeys } from "@/queries";
-import type { InboxCapturesResponse } from "@/types";
+import { queryKeys, useInboxesQuery } from "@/queries";
+import type { Inbox, InboxCapturesResponse } from "@/types";
 import {
 	INBOX_LIVE_MAX_RETRIES,
 	INBOX_LIVE_RETRY_BASE_MS,
@@ -33,6 +33,29 @@ import {
 	inboxLiveRetryDelayMs,
 	useInboxLive,
 } from "./useInboxLive";
+
+const listInboxes = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: { ...actual.apiService, listInboxes: () => listInboxes() },
+	};
+});
+
+function record(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:4100/",
+		bind: "127.0.0.1",
+		port: 4100,
+		running: true,
+		loopback: true,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
 
 /** Every source the hook opened, in order, with its callbacks reachable. */
 class MockEventSource {
@@ -71,14 +94,21 @@ function wrapper(client: QueryClient) {
 	);
 }
 
-/** Fail the open stream and let its scheduled retry fire. */
-function dropAndWait() {
-	act(() => latest().onerror?.());
-	act(() => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 2));
+/**
+ * Fail the open stream and let its scheduled retry fire.
+ *
+ * Async because the reconnect is: before spending a retry the hook asks the
+ * engine whether the listener is still there (issue #554), so the timer is
+ * scheduled a microtask after the error rather than inside it.
+ */
+async function dropAndWait() {
+	await act(async () => void latest().onerror?.());
+	await act(async () => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 2));
 }
 
 beforeEach(() => {
 	MockEventSource.instances = [];
+	listInboxes.mockReset().mockResolvedValue([record()]);
 	vi.stubGlobal("EventSource", MockEventSource);
 	vi.useFakeTimers();
 });
@@ -148,14 +178,14 @@ describe("useInboxLive", () => {
 		expect(cached?.data.map((c) => c.id)).toEqual([7]);
 	});
 
-	it("reconnects after a drop and comes back to Live", () => {
+	it("reconnects after a drop and comes back to Live", async () => {
 		const { result } = renderHook(() => useInboxLive("inbox_a", true), {
 			wrapper: wrapper(makeClient()),
 		});
 		act(() => latest().onopen?.());
 
 		const dropped = latest();
-		dropAndWait();
+		await dropAndWait();
 
 		// The dead source is closed rather than left to a browser retry that a
 		// 409 has already made fatal, and a fresh one takes its place.
@@ -167,7 +197,7 @@ describe("useInboxLive", () => {
 		expect(result.current.watching).toBe(true);
 	});
 
-	it("resumes from the last capture it saw, so the gap is not lost", () => {
+	it("resumes from the last capture it saw, so the gap is not lost", async () => {
 		renderHook(() => useInboxLive("inbox_a", true), { wrapper: wrapper(makeClient()) });
 		act(() => latest().onopen?.());
 		expect(latest().url).not.toContain("lastEventId");
@@ -185,21 +215,21 @@ describe("useInboxLive", () => {
 				})
 			)
 		);
-		dropAndWait();
+		await dropAndWait();
 
 		// A header is not settable on a fresh EventSource, so the resume point
 		// travels as the query parameter the engine reads on the same terms.
 		expect(latest().url).toContain("lastEventId=12");
 	});
 
-	it("gives up after a bounded number of refusals and offers a resume", () => {
+	it("gives up after a bounded number of refusals and offers a resume", async () => {
 		const { result } = renderHook(() => useInboxLive("inbox_a", true), {
 			wrapper: wrapper(makeClient()),
 		});
 
 		// A persistent 409 never opens, so every attempt fails the same way.
 		for (let attempt = 0; attempt <= INBOX_LIVE_MAX_RETRIES; attempt++) {
-			dropAndWait();
+			await dropAndWait();
 		}
 
 		expect(sources()).toHaveLength(INBOX_LIVE_MAX_RETRIES + 1);
@@ -217,12 +247,12 @@ describe("useInboxLive", () => {
 		expect(result.current.watching).toBe(true);
 	});
 
-	it("cancels a scheduled retry on unmount", () => {
+	it("cancels a scheduled retry on unmount", async () => {
 		const { unmount } = renderHook(() => useInboxLive("inbox_a", true), {
 			wrapper: wrapper(makeClient()),
 		});
 		act(() => latest().onopen?.());
-		act(() => latest().onerror?.());
+		await act(async () => void latest().onerror?.());
 
 		const openedBeforeUnmount = sources().length;
 		unmount();
@@ -231,7 +261,7 @@ describe("useInboxLive", () => {
 		expect(sources()).toHaveLength(openedBeforeUnmount);
 	});
 
-	it("cancels a scheduled retry when the inbox changes, and starts the new one clean", () => {
+	it("cancels a scheduled retry when the inbox changes, and starts the new one clean", async () => {
 		const { result, rerender } = renderHook(
 			({ id }: { id: string }) => useInboxLive(id, true),
 			{ wrapper: wrapper(makeClient()), initialProps: { id: "inbox_a" } }
@@ -250,7 +280,7 @@ describe("useInboxLive", () => {
 				})
 			)
 		);
-		act(() => latest().onerror?.());
+		await act(async () => void latest().onerror?.());
 		const openedForA = sources().length;
 
 		rerender({ id: "inbox_b" });
@@ -272,5 +302,58 @@ describe("useInboxLive", () => {
 		expect(sources()).toHaveLength(0);
 		expect(result.current.watching).toBe(false);
 		expect(result.current.stopped).toBe(false);
+	});
+});
+
+/**
+ * What the tab does: the engine's record decides whether a stream is wanted, so
+ * a stop issued anywhere reaches the stream through the list (issue #554).
+ */
+function useWatchedInbox(inboxId: string) {
+	const { data: inboxes = [] } = useInboxesQuery();
+	const inbox = inboxes.find((i) => i.inboxId === inboxId);
+	const live = useInboxLive(inboxId, inbox?.running !== false);
+	return { live, running: inbox?.running };
+}
+
+describe("a stop issued outside this tab", () => {
+	it("reaches the surface within the close, not on the next poll", async () => {
+		const { result } = renderHook(() => useWatchedInbox("inbox_a"), {
+			wrapper: wrapper(makeClient()),
+		});
+		await act(async () => {});
+		act(() => latest().onopen?.());
+		expect(result.current.live.watching).toBe(true);
+
+		// Stopped from the drawer, an MCP tool or curl: the listener goes and
+		// the stream ends exactly the way a dropped connection does.
+		listInboxes.mockResolvedValue([record({ running: false })]);
+		await act(async () => void latest().onerror?.());
+
+		// No timer has advanced, so this cannot have come from the poll.
+		expect(result.current.running).toBe(false);
+
+		await act(async () => void vi.advanceTimersByTime(INBOX_LIVE_RETRY_MAX_MS * 2));
+
+		// And the retry budget is untouched: no reconnect was attempted against
+		// a listener that is gone on purpose, and the surface does not offer the
+		// Resume that belongs to a stream which gave up.
+		expect(sources()).toHaveLength(1);
+		expect(result.current.live.watching).toBe(false);
+		expect(result.current.live.stopped).toBe(false);
+	});
+
+	it("is told apart from a genuine drop, which still reconnects", async () => {
+		const { result } = renderHook(() => useWatchedInbox("inbox_a"), {
+			wrapper: wrapper(makeClient()),
+		});
+		await act(async () => {});
+		act(() => latest().onopen?.());
+
+		// Same close, but the engine still lists the listener as running.
+		await dropAndWait();
+
+		expect(sources()).toHaveLength(2);
+		expect(result.current.running).toBe(true);
 	});
 });

--- a/app/src/modules/inbox/useInboxLive.ts
+++ b/app/src/modules/inbox/useInboxLive.ts
@@ -21,10 +21,10 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { API_ENDPOINTS } from "@/config/api-endpoints";
 import { queryKeys } from "@/queries";
-import type { InboxCapture, InboxCapturesResponse } from "@/types";
+import type { Inbox, InboxCapture, InboxCapturesResponse } from "@/types";
 
 /** Narrow one SSE payload to a capture, or reject it. */
 export function parseCaptureEvent(raw: unknown): InboxCapture | null {
@@ -104,6 +104,31 @@ export function inboxLiveRetryDelayMs(attempt: number, random: () => number = Ma
 		INBOX_LIVE_RETRY_MAX_MS
 	);
 	return Math.round(step + random() * step * 0.5);
+}
+
+/**
+ * Ask the engine, now, whether @p inboxId still has a listener (issue #554).
+ *
+ * A stream ends the same way whether the connection dropped or somebody stopped
+ * the inbox - from the drawer, an MCP tool or a bare curl - and only the engine
+ * knows which. The list is polled at `SERVICES_POLL_INTERVAL_MS`, so left to the
+ * poll a deliberate stop spends up to ten seconds looking like a live inbox
+ * whose stream is flapping. Reading it here answers both halves: the surface
+ * reflects the stop within the close, and the reconnect budget is kept for the
+ * drops it was added for.
+ *
+ * Only a definite answer counts. A refetch that failed leaves the last good
+ * list in the cache, which still says `running` - so a stream lost to a blip
+ * retries, as it must.
+ */
+async function listenerIsGone(client: QueryClient, inboxId: string): Promise<boolean> {
+	// `refetchType: "all"`, not the default "active": whether some other surface
+	// happens to be observing the list is not what should decide whether this
+	// answer is fresh.
+	await client.invalidateQueries({ queryKey: queryKeys.inbox.list(), refetchType: "all" });
+	const inboxes = client.getQueryData<Inbox[]>(queryKeys.inbox.list());
+	if (inboxes === undefined) return false;
+	return inboxes.find((i) => i.inboxId === inboxId)?.running !== true;
 }
 
 /** One subscription's stream state, stamped with the subscription it belongs to. */
@@ -227,7 +252,15 @@ export function useInboxLive(inboxId: string | null, enabled: boolean): InboxLiv
 				source = null;
 				if (cancelled || exhausted) return;
 				attempts += 1;
-				retryTimer = setTimeout(connect, inboxLiveRetryDelayMs(attempts));
+				const attempt = attempts;
+				void (async () => {
+					// The reconnect waits on this answer rather than racing it: a
+					// retry fired first is a request to re-attach to a listener the
+					// user has just stopped.
+					if (await listenerIsGone(queryClient, inboxId)) return;
+					if (cancelled) return;
+					retryTimer = setTimeout(connect, inboxLiveRetryDelayMs(attempt));
+				})();
 			};
 		};
 

--- a/app/src/modules/services/ServicesPanel.test.tsx
+++ b/app/src/modules/services/ServicesPanel.test.tsx
@@ -148,6 +148,32 @@ describe("an inbox row", () => {
 		expect(useTabsStore.getState().openTabs.map((t) => t.type)).toContain("inbox");
 	});
 
+	/*
+	 * The row's label names one inbox, so the tab has to receive that one. It
+	 * used to open the tab with no address at all, which the tab resolved to the
+	 * first inbox in the engine's list - clicking the second row showed the
+	 * first (issue #554).
+	 */
+	it("hands the tab the inbox the row names, not just the tab type", async () => {
+		listInboxes.mockResolvedValue([
+			inbox(),
+			inbox({ inboxId: "inbox_b", port: 41235, url: "http://127.0.0.1:41235/" }),
+		]);
+		renderPanel();
+
+		fireEvent.click(await screen.findByRole("button", { name: /open inbox on port 41235/i }));
+		expect(useTabsStore.getState().openTabs).toContainEqual(
+			expect.objectContaining({ type: "inbox", entityId: "inbox_b" })
+		);
+
+		// And the second row retargets the one open tab rather than opening a
+		// second inbox tab.
+		fireEvent.click(screen.getByRole("button", { name: /open inbox on port 41234/i }));
+		const inboxTabs = useTabsStore.getState().openTabs.filter((t) => t.type === "inbox");
+		expect(inboxTabs).toHaveLength(1);
+		expect(inboxTabs[0].entityId).toBe("inbox_a");
+	});
+
 	it("copies the URL a webhook source is pointed at", async () => {
 		listInboxes.mockResolvedValue([inbox()]);
 		renderPanel();

--- a/app/src/modules/services/ServicesPanel.tsx
+++ b/app/src/modules/services/ServicesPanel.tsx
@@ -161,7 +161,10 @@ function InboxRow({ inbox }: { inbox: Inbox }) {
 	return (
 		<ServiceRow
 			running={inbox.running}
-			onActivate={() => openTab({ type: "inbox", entityId: null })}
+			// The tab is a singleton pointed at one inbox, so the row hands it the
+			// id it names - without it the tab showed whichever inbox it had last
+			// (in practice the first), and the row's label was a lie (issue #554).
+			onActivate={() => openTab({ type: "inbox", entityId: inbox.inboxId })}
 			activateLabel={`Open inbox on port ${inbox.port}`}
 			actions={
 				<>

--- a/app/src/stores/tabs-store.test.ts
+++ b/app/src/stores/tabs-store.test.ts
@@ -394,3 +394,51 @@ describe("tabFocusedAt", () => {
 		expect(useTabsStore.getState().tabFocusedAt).toBe(before);
 	});
 });
+
+/**
+ * A singleton is one tab, not one address (issue #554).
+ *
+ * The inbox tab is the case that needs it: the Services drawer lists every
+ * inbox and each row opens *this* tab pointed at its own. Deduping on type
+ * alone made the row's promise unkeepable - the tab focused, still showing
+ * whichever inbox it had.
+ */
+describe("opening a singleton that is already open", () => {
+	const inboxTab = () => useTabsStore.getState().openTabs.find((t) => t.type === "inbox");
+
+	it("retargets it at the entity asked for instead of focusing the old one", () => {
+		const store = useTabsStore.getState();
+		store.openTab({ type: "inbox", entityId: "inbox_a" });
+		const opened = inboxTab()!;
+
+		useTabsStore.getState().openTab({ type: "inbox", entityId: "inbox_b" });
+
+		const { openTabs, activeTabId } = useTabsStore.getState();
+		expect(openTabs.filter((t) => t.type === "inbox")).toHaveLength(1);
+		// The same tab, moved - not a second one, and not a new id, which would
+		// discard the strip position and the focus stamp.
+		expect(inboxTab()!.id).toBe(opened.id);
+		expect(inboxTab()!.entityId).toBe("inbox_b");
+		expect(activeTabId).toBe(opened.id);
+	});
+
+	it("leaves a singleton opened with the same address untouched", () => {
+		useTabsStore.getState().openTab({ type: "inbox", entityId: "inbox_a" });
+		const before = useTabsStore.getState().openTabs;
+
+		useTabsStore.getState().openTab({ type: "inbox", entityId: "inbox_a" });
+
+		// Same array identity: nothing re-rendered on a repeat open.
+		expect(useTabsStore.getState().openTabs).toBe(before);
+	});
+
+	it("still dedupes the addressless singletons, which retargeting cannot move", () => {
+		const store = useTabsStore.getState();
+		store.openTab({ type: "settings", entityId: null });
+		store.openTab({ type: "settings", entityId: null });
+
+		const { openTabs } = useTabsStore.getState();
+		expect(openTabs.filter((t) => t.type === "settings")).toHaveLength(1);
+		expect(openTabs[0].entityId).toBeNull();
+	});
+});

--- a/app/src/stores/tabs-store.ts
+++ b/app/src/stores/tabs-store.ts
@@ -29,7 +29,16 @@ export interface Tab {
 
 const MAX_OPEN_TABS = 12;
 
-// Singletons: only one tab of this type can exist at a time
+/**
+ * Singletons: only one tab of this type can exist at a time.
+ *
+ * One tab, not one address. Opening a singleton that is already open with a
+ * *different* `entityId` retargets the open tab rather than focusing whatever
+ * it was showing - the inbox tab is one surface pointed at one inbox, and the
+ * drawer row that names inbox B has to be able to show B in it (issue #554).
+ * The others are always opened with a null `entityId`, for which retargeting is
+ * a no-op.
+ */
 const SINGLETON_TYPES: TabType[] = ["welcome", "variables", "settings", "inbox"];
 
 // These tab types are exempt from LRU auto-close
@@ -209,9 +218,18 @@ export const useTabsStore = create<TabsState>()(
 						: t.type === tabDef.type && t.entityId === tabDef.entityId
 				);
 				if (existing) {
+					// Only a singleton can reach this branch with a different
+					// entityId - the entity-keyed lookup above matched on it.
+					const tabs =
+						existing.entityId === tabDef.entityId
+							? openTabs
+							: openTabs.map((t) =>
+									t.id === existing.id ? { ...t, entityId: tabDef.entityId } : t
+								);
 					set({
+						openTabs: tabs,
 						activeTabId: existing.id,
-						tabFocusedAt: stampFocus(tabFocusedAt, openTabs, existing.id),
+						tabFocusedAt: stampFocus(tabFocusedAt, tabs, existing.id),
 					});
 					return;
 				}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -476,7 +476,11 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
 `docs/engine/api-reference.md` (Webhook Inbox).
 
 - `index.tsx` (`InboxView`, screen `"inbox"`) - start/stop, the URL with a copy control, the
-  running/live badge, the capture list and the detail pane.
+  running/live badge, the inbox switcher, the capture list and the detail pane. The switcher is a
+  `Select` in the header, shown only when more than one inbox exists (with one, it could pick only
+  what is already on screen) and ordered by port - the engine lists in map order, which is not
+  stable across polls, and a switcher whose entries move under the pointer is worse than none. An
+  inbox record carries no creation stamp; whether it should is #555's decision.
 - `CannedResponseControls.tsx` - reply status and delay. Its own component so the two fields can be
   drafts (typing `50` on the way to `500` must not push a 50 at the next caller) and so re-seeding
   them from the engine is a remount - `InboxView` keys it on the served values - rather than a
@@ -493,6 +497,12 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   resumes from the last capture id it saw (`?lastEventId=`, since no API sets a header on a
   fresh connection), and once the retries are spent reports `stopped` so the surface can say
   so and offer a Resume rather than leave the badge reading `Running`.
+  A stream also ends because somebody *stopped* the inbox - from the drawer, an MCP tool or curl -
+  and that close is indistinguishable from a drop. So before spending a retry the hook refetches
+  the inbox list and reads the record: gone or `running: false` means no reconnect, and the tab
+  reflects the stop inside the close instead of on the next `SERVICES_POLL_INTERVAL_MS` poll. A
+  refetch that failed leaves the last good list, which still says running - a blip must still
+  retry.
 - `utils.ts` - `captureUrl`, which rebuilds the absolute URL from the stored path and raw query.
 
 **One tab, not one per inbox.** An inbox is engine-process state with no id worth restoring into a
@@ -501,6 +511,15 @@ watching several at once would spend threads on lists nobody reads. The tab is a
 never dirty - both stated explicitly in `tabs-store`, since a *missing* answer reads the same as
 "clean" and is what once made a dirty Settings tab LRU-evictable
 (`components/layout/tab-type-coverage.test.ts` guards all three switches).
+
+**One tab, but a retargetable one.** The tab's own `entityId` is the address of the inbox it shows,
+and `openTab` on an already-open singleton with a different `entityId` moves that tab rather than
+just focusing it (`tabs-store`). Both writers go through it - a drawer row and the header's
+switcher - so there is exactly one record of which inbox is on screen. Before this the tab had no
+address at all: it showed whichever inbox its own start mutation had last named, falling back to
+the first the engine listed, so a row labelled "Open inbox on port B" opened a tab showing A
+(issue #554). An address the engine no longer lists (a tab restored across an engine restart)
+falls back to the lowest-numbered port.
 
 **Entry points:** the **Services** drawer view, which lists every inbox and opens this tab (issue
 #502), and the palette's `Inbox` entry. The welcome Launcher's tile is now `Services` rather than

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -55,7 +55,11 @@ Manages all open tabs (welcome, request, collection, dashboard, run, variables, 
 ```
 
 **Key Features:**
-- Deduplication: Singleton types (welcome, variables, settings) only allow one tab at a time
+- Deduplication: Singleton types (welcome, variables, settings, inbox) only allow one tab at a
+  time. Opening one that is already open with a *different* `entityId` **retargets** it - same tab
+  id, new address - rather than focusing whatever it was showing. The inbox tab is the case that
+  needs it: every Services drawer row opens that one tab pointed at its own inbox (issue #554).
+  The other three are always opened with a null `entityId`, for which this is a no-op
 - LRU eviction: Oldest non-active, non-exempt, clean tabs are closed when over limit
 - Integration with save-store: dirty tabs are never selected for eviction. The
   guard resolves each tab's save-context key by tab *type* (`isTabDirty`),


### PR DESCRIPTION
## Description

**Plan.** Root cause, verified at master `c76f874`: the issue's three premises still hold exactly as filed. `InboxRow` called `openTab({type:"inbox", entityId:null})` (`ServicesPanel.tsx:164`) while its own label named a port; `SINGLETON_TYPES` dedupes on `type` alone, so `entityId` was ignored on an already-open singleton; and `InboxView` resolved its inbox from `selectedInboxId`, which only its own start mutation ever wrote, falling back to `inboxes[0]`. With inboxes A and B, clicking B's row showed A, and the tab had no switcher. Approach: make the tab's own `entityId` the address, retarget the singleton on `openTab`, and read it back in the tab - so the drawer row and the new header switcher write **one** record of which inbox is on screen.

**Rejected: the issue's three-level preference** (tab `entityId`, then the tab's own last selection, then `inboxes[0]`). Two records of one selection is the bug being fixed, one layer up: with a local selection also in play, a user who had picked A in the switcher would click B's drawer row and see nothing happen, because "last selection" and "the address" disagree and only ordering decides. So the switcher and the start mutation retarget the tab instead, and there is no second copy to go stale. The fallback for an address the engine no longer lists is the **lowest-numbered port**, not `inboxes[0]` - the engine lists in map order, which is not stable across polls, and a tab that reshuffles under a poll is the same defect in slow motion.

### App

- **`tabs-store`**: opening a singleton that is already open with a *different* `entityId` retargets that tab - same tab id (the strip position and focus stamp survive), new address - instead of just focusing it. The other three singletons are always opened with `entityId: null`, for which this is a no-op; a repeat open with the same address returns the identical `openTabs` array, so nothing re-renders.
- **`ServicesPanel`**: the inbox row hands the tab the id it names.
- **`InboxView`**: reads the address off the active tab, and a `Select` in the header switches between inboxes (shown only when there is more than one - with one it could pick only what is already on screen; ordered by port, labelled `Port NNNN` with a `(stopped)` suffix). An inbox record carries **no creation stamp**, so "ordered by creation" is not available; whether the engine should carry one is #555's decision point and port is the stable key the record has today.
- **Capture selection is keyed by inbox as well as id.** Capture ids are per-inbox, so a bare number carried across a switch can select a row in the inbox switched *to*. Unreachable before this PR, reachable now.
- **`useInboxLive`**: a stream ends the same way whether the socket dropped or somebody stopped the listener (drawer, MCP tool, curl), and only the engine knows which. Before spending a retry the hook refetches the inbox list and reads the record: absent or `running: false` means no reconnect, and the tab reads `Stopped` inside the close instead of up to `SERVICES_POLL_INTERVAL_MS` later. It **waits** on that answer rather than racing it - a retry fired first is a request to re-attach to a listener the user has just stopped. A refetch that failed leaves the last good list, which still says running, so a genuine blip still retries; `refetchType: "all"` so the answer's freshness does not depend on which other surface happens to be observing the list.

Out of scope by the issue's own sequencing: the stopped inbox's honest verbs (delete in #553, disabled controls in #556).

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

All green on this branch, from master `c76f874`:

- `cd app && pnpm test` - **4288 passed, 421 files** (up from 4275: 13 new).
- `cd app && npx tsc --noEmit`, `pnpm lint` (zero warnings), `pnpm format:check` - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean.

Engine untouched (the issue verified there is no engine half), so no engine build or ctest run: no C++ test could change colour.

New cases: 7 in `InboxView.addressing.test.tsx`, 3 in `tabs-store.test.ts`, 2 in `useInboxLive.test.tsx`, 1 in `ServicesPanel.test.tsx`.

Mutation-checked, each reverted and re-run:

- Row back to `entityId: null` → "hands the tab the inbox the row names" fails.
- Retarget removed from `openTab` → the tab-store retarget case and the switcher case fail.
- `InboxView` back to `inboxes[0]` → 3 addressing cases fail.
- Fallback back to `inboxes[0]` (engine order) → "falls back to a stable choice" fails.
- The `listenerIsGone` gate removed → "reaches the surface within the close" fails, on the reconnect it should not have made.

The retry path is now scheduled a microtask after the error, so `useInboxLive.test.tsx`'s existing drop helper awaits; its assertions are unchanged.

No pre-existing failures encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs in the same commit: `docs/app/COMPONENTS.md` (the switcher, the retargetable-singleton note, and the live hook's stop-vs-drop rule) and `docs/app/state-management.md` (the singleton list, which was also missing `inbox`, plus the retarget semantics).

## Related Issues

Closes #554

---
_Generated by [Claude Code](https://claude.ai/code/session_016S43hQCD7xp2uiv1KDXbKB)_