### PR TITLE
test(engine/reorder): state the tie the root-normalization test asserts

### DIFF
--- a/engine/tests/reorder_route_test.cpp
+++ b/engine/tests/reorder_route_test.cpp
@@ -80,6 +80,11 @@ class ReorderRouteTest : public ::testing::Test {
     protected:
     static constexpr const char* DB_PATH = "test_reorder_route.db";
 
+    // One millisecond apart, which is the entire margin `now_ms()` fails to
+    // guarantee between two rows written inside the same tick.
+    static constexpr int64_t EARLIER = 1700000000000;
+    static constexpr int64_t LATER   = EARLIER + 1;
+
     void SetUp () override {
         cleanup ();
         db_ = std::make_unique<vayu::db::Database> (DB_PATH);
@@ -112,6 +117,26 @@ class ReorderRouteTest : public ::testing::Test {
         { "method", "GET" }, { "url", "https://example.com" } });
         EXPECT_EQ (status, 200) << response.dump ();
         return response["id"].get<std::string> ();
+    }
+
+    /**
+     * Forces a collection's stored `order` and `created_at`, bypassing the
+     * routes.
+     *
+     * The create core stamps `created_at` with `now_ms()`, so two collections
+     * created inside one millisecond carry the same stamp. Once `order` is tied
+     * as well, the display order falls through to `id`, which is a random UUID.
+     * A scope built by two bare `make_collection` calls therefore has no stated
+     * order at all, and asserting which row normalization renumbers first is
+     * asserting a coin flip (issue #559). Every test that cares which row wins
+     * states both keys through this.
+     */
+    void set_collection_position (const std::string& id, int order, int64_t created_at) {
+        auto row = db_->get_collection (id);
+        ASSERT_TRUE (row.has_value ());
+        row->order      = order;
+        row->created_at = created_at;
+        db_->create_collection (*row);
     }
 
     /** Forces a row to a stored `order`, bypassing the routes - the legacy shape. */
@@ -389,9 +414,10 @@ TEST_F (ReorderRouteTest, NormalizesTheRootCollectionsWhenParentIdIsNull) {
     const std::string b     = make_collection ("B");
     const std::string child = make_collection ("child", a);
 
-    auto root_row   = db_->get_collection (b);
-    root_row->order = 0; // Tie the two roots, the pre-#360 shape.
-    db_->create_collection (*root_row);
+    // Tie the two roots at the pre-#360 shape, and state the key that breaks
+    // the tie rather than inheriting whatever the clock happened to give them.
+    set_collection_position (a, 0, EARLIER);
+    set_collection_position (b, 0, LATER);
 
     auto [status, response] = reorder_response (*db_,
     json{ { "normalize",
@@ -402,6 +428,33 @@ TEST_F (ReorderRouteTest, NormalizesTheRootCollectionsWhenParentIdIsNull) {
     EXPECT_EQ (db_->get_collection (b)->order, 1);
     // A nested collection is in a different scope and must be left alone.
     EXPECT_EQ (db_->get_collection (child)->order, 0);
+}
+
+/**
+ * The same tied scope with the stamps swapped, so the renumber must come out
+ * the other way round.
+ *
+ * Without this the test above passes just as well against a normalization that
+ * read no `created_at` at all and simply kept whatever order the rows were
+ * created in - two rows and one direction cannot separate "renumbered in stored
+ * order" from "renumbered in creation order".
+ */
+TEST_F (ReorderRouteTest, NormalizesTiedRootsInStoredOrderNotCreationOrder) {
+    const std::string a = make_collection ("A");
+    const std::string b = make_collection ("B");
+
+    // `b` was created second and is stamped first, so stored order and creation
+    // order disagree; stored order is the one normalization owes the client.
+    set_collection_position (a, 0, LATER);
+    set_collection_position (b, 0, EARLIER);
+
+    auto [status, response] = reorder_response (*db_,
+    json{ { "normalize",
+    json::array ({ json{ { "type", "collection" }, { "parentId", nullptr } } }) } });
+
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_EQ (db_->get_collection (b)->order, 0);
+    EXPECT_EQ (db_->get_collection (a)->order, 1);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

**Plan.** Root cause, verified at master `c76f874`: the issue's premises hold exactly as filed. `normalize_scope` (`engine/src/http/routes/reorder.cpp:294-309`) walks `get_collections()`, which orders by `order`, then `created_at`, then `id` (`engine/src/db/database.cpp:688-689`). `NormalizesTheRootCollectionsWhenParentIdIsNull` tied the two roots at `order = 0` by construction to reproduce the pre-#360 shape, so the only separator left was `created_at` - stamped by `now_ms()` (`routes.hpp:48`), i.e. milliseconds. Two collections created inside one tick carry the same stamp, the decision falls to `id`, and `generate_id` is a random 128-bit draw (`engine/src/utils/id.cpp:60`). The test asserted the outcome of a UUID comparison.

That deduction is what makes this airtight rather than a guess: the three-key sort is a **total order**, `order` is tied deliberately, and `id` is random - so the assertion can only fail when `created_at` ties too. A failure *proves* a same-millisecond collision. **Approach:** state `created_at` explicitly on both roots, so the test pins "normalization renumbers a tied scope in stored order", which is what it means to check.

**Rejected: option B, asserting the property (`{0, 1}` in some order) instead of the identity.** It would go green without ever pinning which row wins - and "renumber a tied scope in the pinned display order" is precisely the behaviour this test exists to cover, so weakening it to a set membership would keep CI quiet while covering less than before. Option C (giving the roots distinct `order`s) was dismissed in the issue for losing the legacy all-zeros shape, and I agree.

**One addition beyond a minimal fix: a companion test stamping the scope the other way.** With a single direction, the fixed test passes just as well against a normalization that read no `created_at` at all and simply kept creation order - the two agree whenever rows are created in stamp order. `NormalizesTiedRootsInStoredOrderNotCreationOrder` makes stored order and creation order disagree, so only a normalization that actually reads the stored key survives both. This is the issue's "force the tie both ways" criterion expressed as a permanent test rather than a one-off manual check.

### Engine (tests only)

- **`set_collection_position (id, order, created_at)`** on the fixture, mirroring the existing `set_request_order` - forces both keys through the same `db_->create_collection` upsert the test already used, so no new machinery. Its comment records *why* a bare pair of `make_collection` calls has no stated order, which is the constraint the code cannot show.
- **`NormalizesTheRootCollectionsWhenParentIdIsNull`** stamps both roots (`EARLIER` / `LATER`, one millisecond apart - the exact margin `now_ms()` fails to guarantee). Its nested-child assertion is unchanged.
- **`NormalizesTiedRootsInStoredOrderNotCreationOrder`** - the reverse direction.

**Sibling tests checked for the same latent tie (acceptance criterion 2); none has it:**

| Test | Why it is tie-safe |
|---|---|
| `NormalizationMaterializesTheDisplayedOrderOfALegacyScope` | Reads `displayed` out of the DB and compares the post-normalize order against *it*, not a hard-coded sequence |
| `NormalizationIsIdempotent` | Asserts a write count (2) and a dense `{0,1,2}` - true under any tiebreak |
| `NormalizationRunsBeforeTheMovesAndTheMovesWin` | States an explicit move for all three rows, overriding the renumber entirely |

Deliberately **not** taken here, per the issue's own split: whether `created_at`-then-`id` is the right total order for rows written in one transaction. That is a contract question, not a test question.

## Type of Change
- [x] Bug fix

## Testing

All green on this branch, from master `c76f874`:

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1464 passed, 0 failed** (up from 1463: 1 new test).
- `ReorderRouteTest.*` (22 tests) repeated **30x** - 0 failures. The two root-normalization tests alone repeated **200x** - 0 failures.
- `clang-format --dry-run --Werror` clean on the touched file, which was clean before the change.

**Mutation-checked.** Swapping the stamps in the primary test (`a` to `LATER`, `b` to `EARLIER`) reddens it exactly as the CI failure did:

```
reorder_route_test.cpp:427: Failure   Which is: 1   (a->order, expected 0)
reorder_route_test.cpp:428: Failure   Which is: 0   (b->order, expected 1)
```

restored and re-verified green. That is the proof the assertion reads `created_at` rather than passing by construction.

Note the original flake did **not** reproduce locally - 600 runs of the unfixed test on this container, 0 failures. That is the expected shape of the defect on a host slow enough to separate the two creates by a millisecond (each test takes ~190ms here), not evidence against it. The confirmation came from CI itself: the identical commit on PR #557 went red on `Engine on ubuntu-latest` and green on re-run with no code change, while the same suite passed on macos-latest in the same run.

No pre-existing failures encountered.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs: none. The issue expects none, and `docs/engine/api-reference.md`'s Ordering section already states the three-key rule correctly - this change fixes a test that failed to state its inputs, not the documented contract.

## Related Issues

Closes #559

---
_Generated by [Claude Code](https://claude.ai/code/session_012TWqzjfoRA2QQbaviEtEgW)_