### PR TITLE
fix(engine/app/inbox): give a stopped inbox a way off the list - DELETE /inbox/:id, delete in both surfaces, and an affordance that stops implying restart

### DIFF
--- a/app/src/components/layout/Dock.services.test.tsx
+++ b/app/src/components/layout/Dock.services.test.tsx
@@ -62,6 +62,7 @@ function inbox(overrides: Partial<Inbox> = {}): Inbox {
 		port: 41234,
 		running: true,
 		loopback: true,
+		captureCount: 0,
 		response: { status: 200, body: "", headers: {}, delayMs: 0 },
 		...overrides,
 	};

--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -143,6 +143,8 @@ export const API_ENDPOINTS = {
 	INBOX: `/inbox`,
 	INBOX_START: `/inbox/start`,
 	INBOX_STOP: (inboxId: string) => `/inbox/${inboxId}/stop`,
+	// PUT patches the canned response; DELETE removes the inbox and cascades its
+	// captures - the only way one leaves the list before the process does.
 	INBOX_BY_ID: (inboxId: string) => `/inbox/${inboxId}`,
 	INBOX_CAPTURES: (inboxId: string, limit: number, offset: number) =>
 		`/inbox/${inboxId}/requests?limit=${limit}&offset=${offset}`,

--- a/app/src/modules/inbox/DeleteInboxDialog.tsx
+++ b/app/src/modules/inbox/DeleteInboxDialog.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { DeleteConfirmDialog } from "@/components/ui";
+import type { InboxDeletion } from "./useInboxDeletion";
+
+/**
+ * The confirmation both delete affordances raise (issue #553).
+ *
+ * It names the count because that is the whole of what is at stake: the
+ * listener is replaceable in one click, the recorded requests are not. Renders
+ * nothing until the deletion asks for it - an inbox holding nothing is deleted
+ * outright, so this dialog only ever appears over something worth losing.
+ */
+export function DeleteInboxDialog({ deletion }: { deletion: InboxDeletion }) {
+	const { inbox, captureCount } = deletion;
+	return (
+		<DeleteConfirmDialog
+			open={deletion.confirmOpen}
+			onOpenChange={deletion.closeConfirm}
+			title={`Delete the inbox on port ${inbox.port}?`}
+			description={`Its ${captureCount} recorded ${
+				captureCount === 1 ? "request" : "requests"
+			} will be deleted with it. This cannot be undone.`}
+			onConfirm={deletion.confirmDelete}
+			isDeleting={deletion.isDeleting}
+		/>
+	);
+}

--- a/app/src/modules/inbox/InboxView.addressing.test.tsx
+++ b/app/src/modules/inbox/InboxView.addressing.test.tsx
@@ -62,6 +62,7 @@ function inbox(overrides: Partial<Inbox> = {}): Inbox {
 		port: 41234,
 		running: true,
 		loopback: true,
+		captureCount: 0,
 		response: { status: 200, body: "", headers: {}, delayMs: 0 },
 		...overrides,
 	};

--- a/app/src/modules/inbox/InboxView.delete.test.tsx
+++ b/app/src/modules/inbox/InboxView.delete.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Deleting an inbox from the tab (issue #553).
+ *
+ * Stopping an inbox was terminal and one-way: the record and its captures stay
+ * readable for the life of the engine process, so before delete existed a
+ * stopped inbox was a row nothing could remove. These cases are about the two
+ * halves of doing it safely - the recorded requests are what is actually lost,
+ * so the confirmation is worded from their count, and an inbox holding none is
+ * deleted outright rather than made to argue for itself.
+ *
+ * The transport is mocked and the real query hooks run, so the delete goes
+ * through the same mutation and cache invalidation the app uses.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useTabsStore } from "@/stores";
+import type { Inbox, InboxCapture } from "@/types";
+import type { InboxLiveState } from "./useInboxLive";
+import { capturesAtRisk } from "./useInboxDeletion";
+
+const listInboxes = vi.fn();
+const listInboxCaptures = vi.fn();
+const deleteInbox = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => listInboxes(),
+			listInboxCaptures: (...a: unknown[]) => listInboxCaptures(...a),
+			deleteInbox: (...a: unknown[]) => deleteInbox(...a),
+		},
+	};
+});
+
+const live: InboxLiveState = { watching: true, stopped: false, resume: vi.fn() };
+vi.mock("./useInboxLive", () => ({ useInboxLive: () => live }));
+
+const { default: InboxView } = await import("./index");
+
+function inbox(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:41234/",
+		bind: "127.0.0.1",
+		port: 41234,
+		running: true,
+		loopback: true,
+		captureCount: 0,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
+
+function capture(id: number): InboxCapture {
+	return {
+		id,
+		inboxId: "inbox_a",
+		receivedAt: 1700000000000,
+		method: "POST",
+		path: "/hook",
+		query: "",
+		headers: {},
+		body: "{}",
+		bodyBytes: 2,
+		bodyTruncated: false,
+		remoteAddr: "127.0.0.1",
+	};
+}
+
+function capturePage(captures: InboxCapture[]) {
+	return {
+		data: captures,
+		pagination: {
+			total: captures.length,
+			limit: 50,
+			offset: 0,
+			returned: captures.length,
+			hasMore: false,
+		},
+	};
+}
+
+function renderTab() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<InboxView />
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	cleanup();
+	listInboxes.mockReset().mockResolvedValue([inbox()]);
+	listInboxCaptures.mockReset().mockResolvedValue(capturePage([]));
+	deleteInbox.mockReset().mockResolvedValue({ inboxId: "inbox_a", capturesDeleted: 0 });
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText: vi.fn() } });
+	Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("deleting the inbox the tab shows", () => {
+	it("asks first when captures would go with it, and names how many", async () => {
+		listInboxes.mockResolvedValue([inbox({ captureCount: 2, running: false })]);
+		listInboxCaptures.mockResolvedValue(capturePage([capture(1), capture(2)]));
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+		// The listener is one click to replace; the recorded requests are not,
+		// so the count is what the dialog argues from.
+		expect(await screen.findByText(/2 recorded requests/i)).toBeInTheDocument();
+		expect(deleteInbox).not.toHaveBeenCalled();
+
+		fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(deleteInbox).toHaveBeenCalledWith("inbox_a"));
+	});
+
+	it("deletes an inbox holding nothing without asking", async () => {
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(deleteInbox).toHaveBeenCalledWith("inbox_a"));
+		expect(screen.queryByText(/cannot be undone/i)).not.toBeInTheDocument();
+	});
+
+	/*
+	 * The record's count is polled every 10s while the capture list is fed by
+	 * the live stream, so a webhook that has just landed is in the list and not
+	 * yet in the count. Trusting the count alone would destroy it silently.
+	 */
+	it("still asks when only the capture list has seen the arrival", async () => {
+		listInboxes.mockResolvedValue([inbox({ captureCount: 0 })]);
+		listInboxCaptures.mockResolvedValue(capturePage([capture(1)]));
+		renderTab();
+		// The arrival has to be on screen for this to be about the two counts
+		// disagreeing rather than about the list not having loaded yet.
+		await screen.findByText("/hook");
+
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		expect(await screen.findByText(/1 recorded request /i)).toBeInTheDocument();
+		expect(deleteInbox).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the inbox that is left, without the tab being retargeted", async () => {
+		const survivor = inbox({ inboxId: "inbox_b", port: 41235, url: "http://127.0.0.1:41235/" });
+		listInboxes.mockResolvedValue([inbox(), survivor]);
+		useTabsStore.getState().openTab({ type: "inbox", entityId: "inbox_a" });
+		renderTab();
+
+		expect(await screen.findByText("http://127.0.0.1:41234/")).toBeInTheDocument();
+
+		listInboxes.mockResolvedValue([survivor]);
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+		// The tab still names the deleted inbox - selection is derived, not
+		// synced (issue #554) - so the surface has to resolve that itself.
+		expect(await screen.findByText("http://127.0.0.1:41235/")).toBeInTheDocument();
+		expect(useTabsStore.getState().openTabs.filter((t) => t.type === "inbox")).toHaveLength(1);
+	});
+});
+
+describe("what a delete would cost", () => {
+	it("takes whichever source has seen the newest capture", () => {
+		// The drawer passes no list at all, so the record is all it has.
+		expect(capturesAtRisk(inbox({ captureCount: 3 }))).toBe(3);
+		// A stale record beside a live list: the list wins.
+		expect(capturesAtRisk(inbox({ captureCount: 0 }), 1)).toBe(1);
+		// And a list trimmed to a page never talks the count *down*.
+		expect(capturesAtRisk(inbox({ captureCount: 120 }), 50)).toBe(120);
+	});
+});

--- a/app/src/modules/inbox/InboxView.test.tsx
+++ b/app/src/modules/inbox/InboxView.test.tsx
@@ -30,6 +30,7 @@ const inbox: Inbox = {
 	port: 4100,
 	running: true,
 	loopback: true,
+	captureCount: 0,
 	response: { status: 200, body: "", delayMs: 0, headers: {} },
 };
 
@@ -45,6 +46,7 @@ vi.mock("@/queries", () => ({
 	}),
 	useStartInboxMutation: () => noop,
 	useStopInboxMutation: () => noop,
+	useDeleteInboxMutation: () => noop,
 	useUpdateInboxResponseMutation: () => noop,
 	useClearInboxCapturesMutation: () => noop,
 }));

--- a/app/src/modules/inbox/index.tsx
+++ b/app/src/modules/inbox/index.tsx
@@ -26,7 +26,7 @@
  */
 
 import { useState } from "react";
-import { Copy, Inbox as InboxIcon, Play, RotateCw, Square, Trash2 } from "lucide-react";
+import { Copy, Eraser, Inbox as InboxIcon, Play, RotateCw, Square, Trash2 } from "lucide-react";
 import {
 	Badge,
 	Button,
@@ -50,6 +50,8 @@ import { cn } from "@/lib/utils";
 import type { Inbox, InboxCannedResponse, InboxCapture } from "@/types";
 import { CannedResponseControls } from "./CannedResponseControls";
 import { CaptureDetail } from "./CaptureDetail";
+import { DeleteInboxDialog } from "./DeleteInboxDialog";
+import { useInboxDeletion } from "./useInboxDeletion";
 import { useInboxLive } from "./useInboxLive";
 
 function formatTime(ms: number): string {
@@ -84,6 +86,32 @@ function CaptureRow({ capture, selected, onSelect }: CaptureRowProps) {
 				{capture.bodyBytes} bytes{capture.query ? ` · ?${capture.query}` : ""}
 			</span>
 		</button>
+	);
+}
+
+/**
+ * The tab's half of inbox deletion (issue #553).
+ *
+ * Its own component so the hook is never called for an inbox that does not
+ * exist - `InboxView` returns its empty state before there is one to delete.
+ * It passes the capture total it already has, which the record's polled count
+ * can lag behind by up to a services poll.
+ */
+function DeleteInboxButton({ inbox, listedTotal }: { inbox: Inbox; listedTotal: number }) {
+	const deletion = useInboxDeletion(inbox, listedTotal);
+	return (
+		<>
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={deletion.requestDelete}
+				disabled={deletion.isDeleting}
+			>
+				<Trash2 className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+				Delete
+			</Button>
+			<DeleteInboxDialog deletion={deletion} />
+		</>
 	);
 }
 
@@ -242,13 +270,17 @@ export default function InboxView() {
 				)}
 
 				<div className="ml-auto flex items-center gap-2">
+					{/* Eraser, not the bin: Delete sits beside it and takes the
+					    whole inbox, and two adjacent destructive controls sharing one
+					    icon is how a listener gets deleted by someone meaning to empty
+					    the list. */}
 					<Button
 						variant="outline"
 						size="sm"
 						onClick={() => clearCaptures.mutate(inbox.inboxId)}
 						disabled={clearCaptures.isPending || captures.length === 0}
 					>
-						<Trash2 className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+						<Eraser className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
 						Clear
 					</Button>
 					{inbox.running ? (
@@ -267,6 +299,13 @@ export default function InboxView() {
 							Start new
 						</Button>
 					)}
+					{/* Last, and the only control here that ends the record rather than
+					    the listener. Before it, a stopped inbox could only be left
+					    behind (issue #553). */}
+					<DeleteInboxButton
+						inbox={inbox}
+						listedTotal={capturesQuery.data?.pagination.total ?? 0}
+					/>
 				</div>
 			</header>
 

--- a/app/src/modules/inbox/useInboxDeletion.ts
+++ b/app/src/modules/inbox/useInboxDeletion.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Deleting an inbox (issue #553), for both surfaces that offer it.
+ *
+ * Two surfaces delete an inbox - the drawer row and this tab - and they have to
+ * agree on the two things that matter: when the confirmation appears, and what
+ * it says is about to be lost. Kept here rather than written twice, because two
+ * copies of a destructive rule drift in the direction of the one that forgot to
+ * ask.
+ */
+
+import { useState } from "react";
+import { useDeleteInboxMutation } from "@/queries";
+import { useToastStore } from "@/stores";
+import type { Inbox } from "@/types";
+
+/**
+ * How many captures deleting @p inbox would destroy.
+ *
+ * The record's own count is up to one services poll (10s) old, while a surface
+ * holding the capture list has the live stream's arrivals already merged in -
+ * so the higher of the two is the one that has seen the newest capture. Taking
+ * only the record would let the tab silently destroy a capture it is currently
+ * displaying, which is the exact case the confirmation exists for.
+ */
+export function capturesAtRisk(inbox: Inbox, listedTotal?: number): number {
+	return Math.max(inbox.captureCount, listedTotal ?? 0);
+}
+
+export interface InboxDeletion {
+	/** The inbox being deleted - what the dialog words itself from. */
+	inbox: Inbox;
+	captureCount: number;
+	/** Deletes an empty inbox outright; opens the confirmation when it holds captures. */
+	requestDelete: () => void;
+	confirmOpen: boolean;
+	closeConfirm: () => void;
+	confirmDelete: () => void;
+	isDeleting: boolean;
+}
+
+/**
+ * @param listedTotal the capture total a surface holding the list already
+ *        knows, fresher than the record's own count. Omitted by the drawer,
+ *        which has no list.
+ */
+export function useInboxDeletion(inbox: Inbox, listedTotal?: number): InboxDeletion {
+	const showToast = useToastStore((s) => s.showToast);
+	const deleteInbox = useDeleteInboxMutation();
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const captureCount = capturesAtRisk(inbox, listedTotal);
+
+	const run = () =>
+		deleteInbox.mutate(inbox.inboxId, {
+			onSuccess: () => setConfirmOpen(false),
+			onError: (error) => {
+				// Closed on failure too: the dialog has said all it can, and the
+				// toast carries the reason. Leaving it open invites a retry of
+				// the same call that just refused.
+				setConfirmOpen(false);
+				showToast(
+					error instanceof Error ? error.message : "Could not delete the inbox",
+					"error"
+				);
+			},
+		});
+
+	return {
+		inbox,
+		captureCount,
+		// An empty inbox has nothing to lose, so asking is pure friction - and
+		// an inbox nobody has sent anything to is exactly the one most likely to
+		// be deleted.
+		requestDelete: () => (captureCount > 0 ? setConfirmOpen(true) : run()),
+		confirmOpen,
+		closeConfirm: () => setConfirmOpen(false),
+		confirmDelete: run,
+		isDeleting: deleteInbox.isPending,
+	};
+}

--- a/app/src/modules/inbox/useInboxLive.test.tsx
+++ b/app/src/modules/inbox/useInboxLive.test.tsx
@@ -52,6 +52,7 @@ function record(overrides: Partial<Inbox> = {}): Inbox {
 		port: 4100,
 		running: true,
 		loopback: true,
+		captureCount: 0,
 		response: { status: 200, body: "", headers: {}, delayMs: 0 },
 		...overrides,
 	};

--- a/app/src/modules/services/ServicesPanel.test.tsx
+++ b/app/src/modules/services/ServicesPanel.test.tsx
@@ -34,6 +34,7 @@ const listInboxes = vi.fn();
 const listMockIssuers = vi.fn();
 const startInbox = vi.fn();
 const stopInbox = vi.fn();
+const deleteInbox = vi.fn();
 const startMockIssuer = vi.fn();
 const stopMockIssuer = vi.fn();
 const updateMockIssuer = vi.fn();
@@ -48,6 +49,7 @@ vi.mock("@/services/api", async (importOriginal) => {
 			listMockIssuers: () => listMockIssuers(),
 			startInbox: (...a: unknown[]) => startInbox(...a),
 			stopInbox: (...a: unknown[]) => stopInbox(...a),
+			deleteInbox: (...a: unknown[]) => deleteInbox(...a),
 			startMockIssuer: (...a: unknown[]) => startMockIssuer(...a),
 			stopMockIssuer: (...a: unknown[]) => stopMockIssuer(...a),
 			updateMockIssuer: (...a: unknown[]) => updateMockIssuer(...a),
@@ -65,6 +67,7 @@ function inbox(overrides: Partial<Inbox> = {}): Inbox {
 		port: 41234,
 		running: true,
 		loopback: true,
+		captureCount: 0,
 		response: { status: 200, body: "", headers: {}, delayMs: 0 },
 		...overrides,
 	};
@@ -105,6 +108,7 @@ beforeEach(() => {
 	listMockIssuers.mockReset().mockResolvedValue([]);
 	startInbox.mockReset().mockResolvedValue(inbox());
 	stopInbox.mockReset().mockResolvedValue(inbox({ running: false }));
+	deleteInbox.mockReset().mockResolvedValue({ inboxId: "inbox_a", capturesDeleted: 0 });
 	startMockIssuer.mockReset().mockResolvedValue({
 		issuerId: "iss_new",
 		issuerUrl: "http://127.0.0.1:42001",
@@ -133,10 +137,17 @@ describe("the services drawer", () => {
 		expect(screen.getByText(/mint your own OAuth 2.0 tokens locally/i)).toBeInTheDocument();
 	});
 
-	it("starts an inbox from the group's own affordance", async () => {
+	/*
+	 * "New inbox", not "Start inbox": the affordance always mints a new listener,
+	 * and beside a stopped row the old Play icon and wording read as "restart
+	 * that one" - which it never did (issue #553).
+	 */
+	it("mints a new inbox from the group's own affordance, and says that is what it does", async () => {
+		listInboxes.mockResolvedValue([inbox({ running: false })]);
 		renderPanel();
-		fireEvent.click(await screen.findByRole("button", { name: "Start inbox" }));
+		fireEvent.click(await screen.findByRole("button", { name: "New inbox" }));
 		await waitFor(() => expect(startInbox).toHaveBeenCalled());
+		expect(screen.queryByRole("button", { name: /^start inbox$/i })).not.toBeInTheDocument();
 	});
 });
 
@@ -199,6 +210,39 @@ describe("an inbox row", () => {
 		renderPanel();
 		expect(await screen.findByText("Stopped")).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: /stop inbox/i })).not.toBeInTheDocument();
+	});
+
+	/*
+	 * The row a stopped inbox most needs. Stopping is terminal by design - the
+	 * record and its captures stay readable until the engine exits - so without
+	 * a delete here every stopped inbox was permanent, and the group's own
+	 * affordance minted more (issue #553).
+	 */
+	it("deletes a stopped inbox, which nothing else here can remove", async () => {
+		listInboxes.mockResolvedValue([inbox({ running: false })]);
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: /delete inbox on port 41234/i }));
+		await waitFor(() => expect(deleteInbox).toHaveBeenCalledWith("inbox_a"));
+	});
+
+	it("asks before destroying captures, naming what would be lost", async () => {
+		listInboxes.mockResolvedValue([inbox({ captureCount: 37 })]);
+		renderPanel();
+
+		fireEvent.click(await screen.findByRole("button", { name: /delete inbox on port 41234/i }));
+		expect(await screen.findByText(/37 recorded requests/i)).toBeInTheDocument();
+		expect(deleteInbox).not.toHaveBeenCalled();
+
+		fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(deleteInbox).toHaveBeenCalledWith("inbox_a"));
+	});
+
+	it("deletes a running inbox too - the engine stops it on the way", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: /delete inbox on port 41234/i }));
+		await waitFor(() => expect(deleteInbox).toHaveBeenCalledWith("inbox_a"));
+		expect(stopInbox).not.toHaveBeenCalled();
 	});
 });
 

--- a/app/src/modules/services/ServicesPanel.tsx
+++ b/app/src/modules/services/ServicesPanel.tsx
@@ -27,7 +27,7 @@
  */
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Copy, KeyRound, Play, Plus, Square } from "lucide-react";
+import { ChevronDown, ChevronRight, Copy, KeyRound, Plus, Square, Trash2 } from "lucide-react";
 import { DrawerPanel, EmptyState, ErrorState, TruncatedText } from "@/components/shared";
 import {
 	Badge,
@@ -49,6 +49,8 @@ import {
 import { useTabsStore, useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
 import type { Inbox, MockIssuer, MockIssuerFailureMode } from "@/types";
+import { DeleteInboxDialog } from "@/modules/inbox/DeleteInboxDialog";
+import { useInboxDeletion } from "@/modules/inbox/useInboxDeletion";
 import { FAILURE_MODE_LABELS, failureModeSummary } from "./failure-modes";
 import { NewIssuerDialog } from "./NewIssuerDialog";
 
@@ -78,7 +80,7 @@ interface ServiceRowProps {
 	activateLabel: string;
 	running: boolean;
 	children: React.ReactNode;
-	/** Trailing controls: copy, stop. */
+	/** Trailing controls: copy, stop, delete. */
 	actions?: React.ReactNode;
 	leading?: React.ReactNode;
 }
@@ -124,7 +126,7 @@ function ServiceRow({
 
 interface ServiceGroupProps {
 	title: string;
-	/** The group's own start affordance - "Start inbox", "New issuer…". */
+	/** The group's own create affordance - "New inbox", "New issuer…". */
 	action?: React.ReactNode;
 	children: React.ReactNode;
 }
@@ -157,54 +159,72 @@ function InboxRow({ inbox }: { inbox: Inbox }) {
 	const showToast = useToastStore((s) => s.showToast);
 	const copy = useCopy();
 	const stopInbox = useStopInboxMutation();
+	// No capture list on this surface, so the record's own count is all it knows.
+	const deletion = useInboxDeletion(inbox);
 
 	return (
-		<ServiceRow
-			running={inbox.running}
-			// The tab is a singleton pointed at one inbox, so the row hands it the
-			// id it names - without it the tab showed whichever inbox it had last
-			// (in practice the first), and the row's label was a lie (issue #554).
-			onActivate={() => openTab({ type: "inbox", entityId: inbox.inboxId })}
-			activateLabel={`Open inbox on port ${inbox.port}`}
-			actions={
-				<>
-					<TooltipIconButton
-						label="Copy inbox URL"
-						icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
-						onClick={() => copy(inbox.url, "Inbox URL")}
-					/>
-					{inbox.running && (
+		<>
+			<ServiceRow
+				running={inbox.running}
+				// The tab is a singleton pointed at one inbox, so the row hands it the
+				// id it names - without it the tab showed whichever inbox it had last
+				// (in practice the first), and the row's label was a lie (issue #554).
+				onActivate={() => openTab({ type: "inbox", entityId: inbox.inboxId })}
+				activateLabel={`Open inbox on port ${inbox.port}`}
+				actions={
+					<>
 						<TooltipIconButton
-							label={`Stop inbox on port ${inbox.port}`}
-							icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
-							disabled={stopInbox.isPending}
-							onClick={() =>
-								stopInbox.mutate(inbox.inboxId, {
-									onError: (error) =>
-										showToast(
-											error instanceof Error
-												? error.message
-												: "Could not stop the inbox",
-											"error"
-										),
-								})
-							}
+							label="Copy inbox URL"
+							icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+							onClick={() => copy(inbox.url, "Inbox URL")}
 						/>
-					)}
-				</>
-			}
-		>
-			<TruncatedText className="font-mono text-xs">{inbox.url}</TruncatedText>
-			{/* An inbox reachable beyond this machine is badged wherever it is
-			    named - the standing reminder that the engine's non-loopback
-			    confirmation was given. */}
-			{!inbox.loopback && (
-				<Badge variant="chip" className="bg-status-warning-fill text-primary-foreground">
-					{inbox.bind}
-				</Badge>
-			)}
-			{!inbox.running && <span className="text-xs text-muted-foreground">Stopped</span>}
-		</ServiceRow>
+						{inbox.running && (
+							<TooltipIconButton
+								label={`Stop inbox on port ${inbox.port}`}
+								icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
+								disabled={stopInbox.isPending}
+								onClick={() =>
+									stopInbox.mutate(inbox.inboxId, {
+										onError: (error) =>
+											showToast(
+												error instanceof Error
+													? error.message
+													: "Could not stop the inbox",
+												"error"
+											),
+									})
+								}
+							/>
+						)}
+						{/* On every row, running or not. A stopped inbox had no way off
+						    this list at all before: it stayed until the engine process
+						    exited, while the group's affordance minted more of them
+						    (issue #553). Deleting a running one stops it on the way. */}
+						<TooltipIconButton
+							label={`Delete inbox on port ${inbox.port}`}
+							icon={<Trash2 className="h-3.5 w-3.5" aria-hidden="true" />}
+							disabled={deletion.isDeleting}
+							onClick={deletion.requestDelete}
+						/>
+					</>
+				}
+			>
+				<TruncatedText className="font-mono text-xs">{inbox.url}</TruncatedText>
+				{/* An inbox reachable beyond this machine is badged wherever it is
+				    named - the standing reminder that the engine's non-loopback
+				    confirmation was given. */}
+				{!inbox.loopback && (
+					<Badge
+						variant="chip"
+						className="bg-status-warning-fill text-primary-foreground"
+					>
+						{inbox.bind}
+					</Badge>
+				)}
+				{!inbox.running && <span className="text-xs text-muted-foreground">Stopped</span>}
+			</ServiceRow>
+			<DeleteInboxDialog deletion={deletion} />
+		</>
 	);
 }
 
@@ -413,9 +433,16 @@ export default function ServicesPanel() {
 				<ServiceGroup
 					title="Webhook inboxes"
 					action={
+						/* "New inbox", matching the issuer group's "New issuer", and a
+						   Plus rather than a Play: this always mints a *new* listener,
+						   and beside a stopped row a Play labelled "Start inbox" read
+						   as "restart that one" (issue #553). Restart is deliberately
+						   not a thing an inbox does - delete it and start another,
+						   since the captures are what a restart would have to decide
+						   about and this way the user decides instead. */
 						<TooltipIconButton
-							label="Start inbox"
-							icon={<Play className="h-3.5 w-3.5" aria-hidden="true" />}
+							label="New inbox"
+							icon={<Plus className="h-3.5 w-3.5" aria-hidden="true" />}
 							disabled={startInbox.isPending}
 							onClick={start}
 						/>

--- a/app/src/queries/inbox.ts
+++ b/app/src/queries/inbox.ts
@@ -73,6 +73,25 @@ export function useStopInboxMutation() {
 	});
 }
 
+/**
+ * Delete an inbox and the captures it holds (issue #553).
+ *
+ * Unlike a stop, there is nothing left to read afterwards - so the captures
+ * cache entry is dropped rather than invalidated. An invalidation would refetch
+ * an id the engine now answers `404` for, leaving an error state describing a
+ * list that no longer exists.
+ */
+export function useDeleteInboxMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (inboxId: string) => apiService.deleteInbox(inboxId),
+		onSuccess: (_result, inboxId) => {
+			queryClient.removeQueries({ queryKey: queryKeys.inbox.captures(inboxId) });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.inbox.list() });
+		},
+	});
+}
+
 export function useUpdateInboxResponseMutation() {
 	const queryClient = useQueryClient();
 	return useMutation({

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -82,6 +82,7 @@ export {
 	useInboxCapturesQuery,
 	useStartInboxMutation,
 	useStopInboxMutation,
+	useDeleteInboxMutation,
 	useUpdateInboxResponseMutation,
 	useClearInboxCapturesMutation,
 } from "./inbox";

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -71,6 +71,7 @@ import type {
 	ListInboxesResponse,
 	StartInboxRequest,
 	ClearInboxCapturesResponse,
+	DeleteInboxResponse,
 	MockIssuer,
 	ListMockIssuersResponse,
 	StartMockIssuerRequest,
@@ -304,6 +305,18 @@ export const apiService = {
 
 	async stopInbox(inboxId: string): Promise<Inbox> {
 		return await httpClient.post<Inbox>(API_ENDPOINTS.INBOX_STOP(inboxId), {});
+	},
+
+	/**
+	 * Delete the inbox and the captures it is holding (issue #553).
+	 *
+	 * Stronger than `stopInbox`, which frees the listener and leaves the record
+	 * - and its captures - readable for the life of the engine process. A
+	 * running inbox is stopped by the engine on the way, so this is one call
+	 * whatever state the inbox is in.
+	 */
+	async deleteInbox(inboxId: string): Promise<DeleteInboxResponse> {
+		return await httpClient.delete<DeleteInboxResponse>(API_ENDPOINTS.INBOX_BY_ID(inboxId));
 	},
 
 	/**

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -601,6 +601,13 @@ export interface Inbox {
 	running: boolean;
 	/** False when the inbox is reachable beyond this machine - badge it. */
 	loopback: boolean;
+	/**
+	 * How many captures this inbox is holding - what deleting it would destroy.
+	 *
+	 * Up to one services poll old, so a surface that also holds the capture list
+	 * knows better; see `capturesAtRisk` in `modules/inbox/useInboxDeletion.ts`.
+	 */
+	captureCount: number;
 	response: InboxCannedResponse;
 }
 
@@ -649,6 +656,12 @@ export interface InboxCapturesResponse {
 export interface ClearInboxCapturesResponse {
 	inboxId: string;
 	cleared: number;
+}
+
+/** What `DELETE /inbox/:id` reports it destroyed - record plus captures. */
+export interface DeleteInboxResponse {
+	inboxId: string;
+	capturesDeleted: number;
 }
 
 // OAuth 2.0 mock issuer API (issue #479). Engine-process state like an inbox:

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -116,7 +116,7 @@ Resizable sidebar (220–480px default, per view). The single left navigation fo
 | **`collections`** | `CollectionTree` (hierarchical collections + requests) | add collection, add request, import |
 | **`history`** | `HistoryList` (past runs, filtered/sorted) | run count |
 | **`variables`** | `VariablesCategoryTree` (globals, collections, environments) | - |
-| **`services`** | `ServicesPanel` (webhook inboxes, OAuth issuers) | start inbox, new issuer |
+| **`services`** | `ServicesPanel` (webhook inboxes, OAuth issuers) | new inbox, new issuer |
 | **`settings`** | `SettingsCategoryTree` (app + engine setting categories) | - |
 
 Both `variables` and `settings` follow the same nav/content split: the tree lives here in the Drawer, the editor is the corresponding tab (`VariablesMain` / `SettingsMain`), and selecting a category sets the shared store selection **and** opens/focuses that tab.
@@ -475,8 +475,10 @@ The receiving half of the app (issue #480): an engine-hosted listener that recor
 sent to it, so building a webhook consumer needs no cloud tunnel. Engine contract:
 `docs/engine/api-reference.md` (Webhook Inbox).
 
-- `index.tsx` (`InboxView`, screen `"inbox"`) - start/stop, the URL with a copy control, the
-  running/live badge, the inbox switcher, the capture list and the detail pane. The switcher is a
+- `index.tsx` (`InboxView`, screen `"inbox"`) - start/stop/clear/delete, the URL with a copy
+  control, the running/live badge, the inbox switcher, the capture list and the detail pane. Clear
+  (Eraser) empties the capture list; Delete (bin) ends the inbox itself, so the two adjacent
+  destructive controls do not share an icon. The switcher is a
   `Select` in the header, shown only when more than one inbox exists (with one, it could pick only
   what is already on screen) and ordered by port - the engine lists in map order, which is not
   stable across polls, and a switcher whose entries move under the pointer is worse than none. An
@@ -503,6 +505,12 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   reflects the stop inside the close instead of on the next `SERVICES_POLL_INTERVAL_MS` poll. A
   refetch that failed leaves the last good list, which still says running - a blip must still
   retry.
+- `useInboxDeletion.ts` / `DeleteInboxDialog.tsx` - deleting an inbox (issue #553), shared with the
+  Services drawer so the two surfaces cannot disagree about when the confirmation appears or what it
+  says is at stake. An inbox holding captures confirms and names their count; one holding none is
+  deleted outright. `capturesAtRisk` takes the higher of the record's polled `captureCount` and the
+  capture total a surface already holds - the record lags a services poll behind the live stream, so
+  trusting it alone would let the tab destroy a capture it is displaying.
 - `utils.ts` - `captureUrl`, which rebuilds the absolute URL from the stored path and raw query.
 
 **One tab, not one per inbox.** An inbox is engine-process state with no id worth restoring into a
@@ -536,9 +544,12 @@ both activate it.
 - `ServicesPanel.tsx` - the view. Two groups today, **Webhook inboxes** and **OAuth issuers**, each
   with its own start affordance in the group header and a one-sentence empty state saying what the
   service would give you - this drawer is also the features' discoverability. An inbox row opens the
-  inbox *tab* (the drawer lists, the tab shows the captures); an issuer row expands in place to its
-  token and authorize URLs, a copy for the HS256 signing key, its configuration in one line, and a
-  live `failureMode` switch. Mock servers (#481) get a third group when they exist - deliberately no
+  inbox *tab* (the drawer lists, the tab shows the captures) and carries copy, stop (running rows
+  only) and **delete** (every row); an issuer row expands in place to its token and authorize URLs,
+  a copy for the HS256 signing key, its configuration in one line, and a live `failureMode` switch.
+  The inbox group's affordance is **New inbox** (Plus), matching **New issuer**: it always mints a
+  new listener, and as a Play labelled "Start inbox" beside a stopped row it read as "restart that
+  one", which nothing here does (issue #553). Mock servers (#481) get a third group when they exist - deliberately no
   placeholder until then.
 - `NewIssuerDialog.tsx` - the start form: token lifetime, failure mode (plus its delay), and a JSON
   claims box. Everything is validated before it is sent, because the engine refuses a bad config

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -171,6 +171,7 @@ through this endpoint, so the whole tree still lands in one engine transaction.
 apiService.listInboxes(): Promise<Inbox[]>
 apiService.startInbox(request?: StartInboxRequest): Promise<Inbox>
 apiService.stopInbox(inboxId): Promise<Inbox>
+apiService.deleteInbox(inboxId): Promise<DeleteInboxResponse>
 apiService.updateInboxResponse(inboxId, response: Partial<InboxCannedResponse>): Promise<Inbox>
 apiService.listInboxCaptures(inboxId, limit?, offset?): Promise<InboxCapturesResponse>
 apiService.clearInboxCaptures(inboxId): Promise<ClearInboxCapturesResponse>
@@ -182,6 +183,12 @@ merge-patch - an omitted field keeps what the inbox is serving - and the live
 capture stream (`INBOX_LIVE`) is a plain `EventSource` rather than `SSEClient`,
 which maps load-test metrics specifically. Captures arriving on that stream are
 merged into the `listInboxCaptures` cache, so there is one list.
+`deleteInbox` is the stronger of the two lifecycle calls: `stopInbox` frees the
+listener and leaves the record and its captures readable for the life of the
+engine process, while a delete takes both (issue #553). Its mutation *removes*
+the captures cache entry rather than invalidating it - an invalidation would
+refetch an id the engine now `404`s. `Inbox.captureCount` is what a delete would
+destroy, and is what the confirmation is worded from.
 `clearCookies` distinguishes three cases the way the engine does, and they are
 not interchangeable: **omitted** clears every jar, `{ environmentId: null }`
 clears only the jar used when no environment is selected, and an id clears that
@@ -576,6 +583,7 @@ export const API_ENDPOINTS = {
   INBOX: "/inbox",
   INBOX_START: "/inbox/start",
   INBOX_STOP: (inboxId: string) => `/inbox/${inboxId}/stop`,
+  // PUT patches the canned response; DELETE removes the inbox and its captures.
   INBOX_BY_ID: (inboxId: string) => `/inbox/${inboxId}`,
   INBOX_CAPTURES: (inboxId: string, limit: number, offset: number) =>
     `/inbox/${inboxId}/requests?limit=${limit}&offset=${offset}`,

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1404,7 +1404,7 @@ no create/update split ([POST creates, PUT updates](#resource-writes-create-vs-u
 applies to collections, requests and environments), ids are not restorable
 across restarts, and `POST /inbox/start` is a verb path for that reason. Stopping
 an inbox frees its listener but keeps the record - and therefore its captures -
-readable until the engine exits.
+readable until the engine exits; `DELETE /inbox/:inboxId` is what removes both.
 
 **Binding is a trust decision.** The default is `127.0.0.1`. Any other address
 is refused unless the caller also sends `"confirmNonLoopback": true`, and the
@@ -1482,9 +1482,14 @@ this way, since the kernel does not hand out a port it is already using.
   "port": 41235,
   "running": true,
   "loopback": true,
+  "captureCount": 0,
   "response": { "status": 200, "body": "", "headers": {}, "delayMs": 0 }
 }
 ```
+
+`captureCount` is how many captures the inbox is holding right now - what a
+`DELETE /inbox/:inboxId` would destroy with it. Every route that returns an
+inbox fills it, so a client can word a confirmation without a second round trip.
 
 ### GET /inbox
 
@@ -1501,7 +1506,26 @@ so a client can send back what `start` handed it. `404` for an unknown id.
 ### POST /inbox/:inboxId/stop
 
 Stop the listener. Returns the inbox with `running: false`. Captures survive;
-`404` for an unknown id.
+`404` for an unknown id. A stop is not a delete - `DELETE /inbox/:inboxId` is.
+
+### DELETE /inbox/:inboxId
+
+Stop the listener, drop the record, and delete its captures with it:
+`{"inboxId": "...", "capturesDeleted": 12}`. `404` for an unknown id.
+
+**A running inbox is stopped rather than refused** - one call, because the
+caller's intent is that the inbox be gone. That is safe rather than racy
+because the teardown joins every in-flight handler before returning, so nothing
+can still be capturing when the rows are cleared. The order is stop, then
+clear, then drop the record: a database failure therefore leaves the inbox in
+place - stopped, and deletable again - rather than orphaning captures no inbox
+could list.
+
+The captures dying *with* the record is the point, and is why `stop` keeps them:
+they go by explicit user intent here, instead of the record living to the end of
+the process to protect them. **There is deliberately no restart route**: delete
+and start a new inbox. A restart would have to decide what happens to the
+existing captures, and this way the user decides.
 
 ### GET /inbox/:inboxId/requests
 

--- a/engine/include/vayu/http/inbox.hpp
+++ b/engine/include/vayu/http/inbox.hpp
@@ -45,6 +45,14 @@ struct InboxInfo {
     bool running = true;
     /// False when `bind` is neither 127.0.0.0/8 nor ::1; the UI badges those.
     bool loopback = true;
+    /// How many captures this inbox is holding - what a delete would take with
+    /// it, which is why a client needs it before asking to delete one.
+    ///
+    /// The one field InboxManager cannot answer: captures live in the database,
+    /// not the manager. The routes fill it from there (`inbox_json` in
+    /// inbox.cpp), so a wire shape built without a database reports 0 rather
+    /// than a wrong number.
+    int64_t capture_count = 0;
     InboxCannedResponse response;
 };
 
@@ -196,6 +204,29 @@ class InboxManager {
     /// Stop the listener, keeping the record (and its captures) readable.
     /// False when no such inbox exists; stopping a stopped inbox is a no-op.
     bool stop (const std::string& inbox_id);
+
+    /**
+     * Stop the listener, drop the record, and delete its captures.
+     *
+     * The counterpart `stop()` deliberately is not: a stopped inbox stays
+     * readable, and before this existed that made every stopped inbox a
+     * permanent row (issue #553). The captures die *with* the record here, by
+     * explicit user intent, which is the honest resolution of the objection
+     * that kept delete out of `stop()`.
+     *
+     * A running inbox is stopped rather than refused - one call, because the
+     * caller's intent is "make it gone". That is safe rather than racy because
+     * `ManagedListener::stop()` joins every in-flight handler before returning,
+     * so once the teardown is done no capture can still be landing.
+     *
+     * Ordering is stop, then clear, then erase. A clear that throws therefore
+     * leaves the record in place - stopped, and deletable again - rather than
+     * orphaning rows that no inbox could ever list.
+     *
+     * @return how many captures were deleted, or nullopt when no such inbox
+     *         exists. A database failure propagates as an exception.
+     */
+    std::optional<int64_t> remove (vayu::db::Database& db, const std::string& inbox_id);
 
     std::optional<InboxInfo> get (const std::string& inbox_id);
     std::vector<InboxInfo> list ();

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -301,13 +301,14 @@ nlohmann::json inbox_info_json (const InboxInfo& info) {
     }
 
     nlohmann::json out;
-    out["inboxId"]  = info.inbox_id;
-    out["url"]      = info.url;
-    out["bind"]     = info.bind;
-    out["port"]     = info.port;
-    out["running"]  = info.running;
-    out["loopback"] = info.loopback;
-    out["response"] = std::move (response);
+    out["inboxId"]      = info.inbox_id;
+    out["url"]          = info.url;
+    out["bind"]         = info.bind;
+    out["port"]         = info.port;
+    out["running"]      = info.running;
+    out["loopback"]     = info.loopback;
+    out["captureCount"] = info.capture_count;
+    out["response"]     = std::move (response);
     return out;
 }
 
@@ -539,6 +540,24 @@ bool InboxManager::stop (const std::string& inbox_id) {
     return true;
 }
 
+std::optional<int64_t>
+InboxManager::remove (vayu::db::Database& db, const std::string& inbox_id) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    auto it = inboxes_.find (inbox_id);
+    if (it == inboxes_.end ()) {
+        return std::nullopt;
+    }
+    // Stop first: the join inside it is what makes "no capture can still be
+    // landing" true, so the clear below cannot race a webhook into rows that
+    // outlive the record. See the header for why the order is load-bearing.
+    teardown_locked (*it->second);
+    const int64_t deleted = db.clear_inbox_requests (inbox_id);
+    inboxes_.erase (it);
+    vayu::utils::log_info (
+    "Inbox deleted: " + inbox_id + " (" + std::to_string (deleted) + " captures)");
+    return deleted;
+}
+
 std::optional<InboxInfo> InboxManager::get (const std::string& inbox_id) {
     std::lock_guard<std::mutex> lock (mutex_);
     auto it = inboxes_.find (inbox_id);
@@ -665,6 +684,21 @@ void send_parse_error (httplib::Response& res, const InboxParseError& error) {
 } // namespace
 
 /**
+ * The wire shape of an inbox with its capture count filled in.
+ *
+ * `captureCount` is the one field the manager cannot answer - captures are
+ * database rows - so every route that hands an inbox back fills it through
+ * here. One place rather than four, because the failure mode of the fourth
+ * copy is not a compile error: it is a `0` that reads as "nothing to lose"
+ * beside a delete confirmation. Extracted (like `inbox_captures_response`) so
+ * that wiring is covered without an in-process HTTP server.
+ */
+nlohmann::json inbox_json (vayu::db::Database& db, InboxInfo info) {
+    info.capture_count = db.count_inbox_requests (info.inbox_id);
+    return inbox_info_json (info);
+}
+
+/**
  * Testable core of `GET /inbox/:id/requests`: the capture page in the
  * `{data, pagination}` envelope every list endpoint returns, or a 404 for an
  * inbox the manager does not know. Extracted so the wiring is covered without
@@ -760,7 +794,7 @@ void register_inbox_routes (RouteContext& ctx) {
                 result.error_code);
                 return;
             }
-            send_json (res, inbox_info_json (result.info));
+            send_json (res, inbox_json (ctx.db, result.info));
         } catch (const std::exception& e) {
             vayu::utils::log_error (
             "POST /inbox/start - Error: " + std::string (e.what ()));
@@ -771,7 +805,7 @@ void register_inbox_routes (RouteContext& ctx) {
     /**
      * POST /inbox/:id/stop
      * Frees the listener. The record and its captures stay readable until the
-     * engine exits, so a stop is not a delete.
+     * engine exits - a stop is not a delete, and `DELETE /inbox/:id` is.
      */
     ctx.server.Post (R"(/inbox/([^/]+)/stop)",
     [&ctx] (const httplib::Request& req, httplib::Response& res) {
@@ -785,14 +819,43 @@ void register_inbox_routes (RouteContext& ctx) {
             send_error (res, 404, "Inbox not found");
             return;
         }
-        send_json (res, inbox_info_json (*info));
+        send_json (res, inbox_json (ctx.db, *info));
+    });
+
+    /**
+     * DELETE /inbox/:id
+     * Stop the listener, drop the record, and delete its captures with it -
+     * the only way a stopped inbox leaves the list before the process does.
+     * A running inbox is stopped rather than refused: the caller asked for it
+     * to be gone, and the teardown joins before the captures are cleared.
+     *
+     * `[^/]+` cannot span a `/`, so this pattern never swallows
+     * `/inbox/:id/requests` - the two DELETE routes are disjoint whatever
+     * order they are registered in.
+     */
+    ctx.server.Delete (R"(/inbox/([^/]+))",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string inbox_id = req.matches[1];
+        try {
+            const auto deleted = ctx.inbox_manager.remove (ctx.db, inbox_id);
+            if (!deleted) {
+                send_error (res, 404, "Inbox not found");
+                return;
+            }
+            send_json (res,
+            nlohmann::json{ { "inboxId", inbox_id }, { "capturesDeleted", *deleted } });
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "DELETE /inbox/:id - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
     });
 
     /** GET /inbox - every inbox this process has started, running or stopped. */
     ctx.server.Get ("/inbox", [&ctx] (const httplib::Request&, httplib::Response& res) {
         nlohmann::json data = nlohmann::json::array ();
         for (const auto& info : ctx.inbox_manager.list ()) {
-            data.push_back (inbox_info_json (info));
+            data.push_back (inbox_json (ctx.db, info));
         }
         send_json (res, nlohmann::json{ { "data", std::move (data) } });
     });
@@ -828,7 +891,7 @@ void register_inbox_routes (RouteContext& ctx) {
             send_error (res, 404, "Inbox not found");
             return;
         }
-        send_json (res, inbox_info_json (*info));
+        send_json (res, inbox_json (ctx.db, *info));
     });
 
     /**

--- a/engine/tests/inbox_test.cpp
+++ b/engine/tests/inbox_test.cpp
@@ -32,6 +32,8 @@ InboxManager& manager,
 const std::string& inbox_id,
 int64_t limit,
 int64_t offset);
+// Defined in inbox.cpp; the wire shape every inbox route answers with.
+nlohmann::json inbox_json (vayu::db::Database& db, vayu::http::InboxInfo info);
 } // namespace vayu::http::routes
 
 namespace {
@@ -368,6 +370,76 @@ TEST_F (InboxListenerTest, StopFreesTheListenerAndKeepsTheHistory) {
     << "a stopped inbox must refuse further connections";
 }
 
+/*
+ * Delete is what stop deliberately is not. Before it existed, a stopped inbox
+ * was a row nothing could remove until the engine exited (issue #553).
+ */
+TEST_F (InboxListenerTest, DeleteFreesTheListenerAndTakesTheCapturesWithIt) {
+    auto started = start ();
+    {
+        auto client = client_for (started.info);
+        ASSERT_TRUE (client.Post ("/hook", "{}", "application/json"));
+        ASSERT_TRUE (client.Post ("/hook", "{}", "application/json"));
+    }
+    ASSERT_EQ (db_->count_inbox_requests (started.info.inbox_id), 2);
+
+    // A running inbox is stopped rather than refused: one call, because the
+    // caller's intent is "make it gone".
+    const auto deleted = manager_->remove (*db_, started.info.inbox_id);
+    ASSERT_TRUE (deleted.has_value ());
+    EXPECT_EQ (*deleted, 2);
+
+    EXPECT_FALSE (manager_->get (started.info.inbox_id).has_value ());
+    EXPECT_TRUE (manager_->list ().empty ());
+    // The cascade: dropping it leaves rows no inbox can ever list again.
+    EXPECT_EQ (db_->count_inbox_requests (started.info.inbox_id), 0);
+
+    httplib::Client client ("127.0.0.1", started.info.port);
+    client.set_connection_timeout (0, 300000); // 300ms
+    EXPECT_FALSE (client.Post ("/hook", "{}", "application/json"))
+    << "a deleted inbox must refuse further connections";
+
+    // Gone means gone: a second delete is a 404, not a second success.
+    EXPECT_FALSE (manager_->remove (*db_, started.info.inbox_id).has_value ());
+    EXPECT_FALSE (manager_->remove (*db_, "inbox_nope").has_value ());
+}
+
+TEST_F (InboxListenerTest, DeleteTakesOnlyItsOwnInboxsCaptures) {
+    auto kept   = start ();
+    auto doomed = start ();
+    auto keeper = client_for (kept.info);
+    auto sender = client_for (doomed.info);
+    ASSERT_TRUE (keeper.Post ("/hook", "{}", "application/json"));
+    ASSERT_TRUE (sender.Post ("/hook", "{}", "application/json"));
+
+    ASSERT_EQ (manager_->remove (*db_, doomed.info.inbox_id).value_or (-1), 1);
+
+    EXPECT_EQ (db_->count_inbox_requests (kept.info.inbox_id), 1)
+    << "an unrelated inbox lost its captures";
+    EXPECT_TRUE (manager_->get (kept.info.inbox_id).has_value ());
+}
+
+/*
+ * A live stream holds the deleted inbox's claim slot. It notices at its next
+ * poll, and what it must not do on the way out is release a slot that has
+ * since been handed to somebody else - the same rule an evicted holder follows.
+ */
+TEST_F (InboxListenerTest, DeleteLeavesAnAttachedLiveStreamNothingToStrand) {
+    auto started     = start ();
+    const auto claim = manager_->try_claim_live (started.info.inbox_id);
+    ASSERT_TRUE (claim.has_value ());
+
+    ASSERT_TRUE (manager_->remove (*db_, started.info.inbox_id).has_value ());
+
+    // What the stream's own loop checks: the inbox is gone, so it breaks out.
+    EXPECT_FALSE (manager_->get (started.info.inbox_id).has_value ());
+    EXPECT_FALSE (manager_->note_live_write (started.info.inbox_id, *claim));
+    // And the release on the way out finds nothing to release, rather than
+    // reaching into a record that no longer exists.
+    manager_->release_live (started.info.inbox_id, *claim);
+    SUCCEED ();
+}
+
 TEST_F (InboxListenerTest, ASecondInboxCannotShareARunningInboxsPort) {
     // Without the listener's port guard this second start succeeds on Linux -
     // cpp-httplib binds with SO_REUSEPORT - and the kernel then splits the
@@ -671,6 +743,30 @@ TEST_F (InboxStorageTest, TheCaptureListCoreAnswers404ForAnUnknownInboxAndPages)
     EXPECT_FALSE (page2["pagination"]["hasMore"].get<bool> ());
 }
 
+/*
+ * The count a delete confirmation is worded from. It is the one field the
+ * manager cannot answer, so a route that built the wire shape without it would
+ * report 0 - which reads as "nothing to lose" beside a destructive action.
+ */
+TEST_F (InboxStorageTest, TheWireShapeCarriesWhatTheInboxIsHolding) {
+    InboxManager manager;
+    auto started = manager.start (*db_, InboxStartRequest{});
+    ASSERT_TRUE (started.ok) << started.error_message;
+    const std::string inbox_id = started.info.inbox_id;
+
+    EXPECT_EQ (
+    vayu::http::routes::inbox_json (*db_, started.info)["captureCount"], 0);
+
+    for (int i = 0; i < 3; ++i) {
+        append (inbox_id, "body" + std::to_string (i), 100);
+    }
+    // Read back from the manager, as every route does: the count is filled in
+    // from the database rather than carried on the record.
+    auto info = manager.get (inbox_id);
+    ASSERT_TRUE (info.has_value ());
+    EXPECT_EQ (vayu::http::routes::inbox_json (*db_, *info)["captureCount"], 3);
+}
+
 TEST (InboxWireShape, CaptureAndInfoCarryEveryFieldTheUiReads) {
     vayu::db::InboxRequest capture;
     capture.id             = 12;
@@ -712,6 +808,9 @@ TEST (InboxWireShape, CaptureAndInfoCarryEveryFieldTheUiReads) {
     EXPECT_TRUE (info_wire["running"].get<bool> ());
     EXPECT_EQ (info_wire["response"]["status"], 204);
     EXPECT_TRUE (info_wire["response"]["headers"].is_object ());
+    // Present even on a shape built without a database, so a client never has
+    // to tell "no captures" apart from "the field is missing".
+    EXPECT_EQ (info_wire["captureCount"], 0);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

**Root cause.** The engine has no `DELETE /inbox/:id` - the route set is start, `:id/stop`, list, `PUT :id`, `:id/requests` GET+DELETE, `:id/live`, and the only DELETE is captures-only. `InboxManager::stop` is terminal by design ("a stop is not a delete", PR #499's recorded rationale: dropping the record on stop would strand its captures). So every stopped inbox was an unremovable row until the engine process exited, while the drawer's group affordance - a Play icon labelled "Start inbox" - minted a new one on every click and, beside a stopped row, read as "restart that one".

**Approach.** Add the route the objection was actually asking for. `DELETE /inbox/:id` stops the listener, deletes its captures and drops the record: the captures die *with* the record, by explicit user intent, instead of the record living to the end of the process to protect them. A running inbox is stopped rather than 409-refused, because the caller's intent is "make it gone" and `ManagedListener::stop()` joins every in-flight handler before returning, so nothing can still be capturing when the rows are cleared. Ordering is stop -> clear -> erase, so a database failure leaves the inbox in place (stopped, and deletable again) rather than orphaning rows no inbox could ever list.

**Alternative rejected.** 409-require-stopped, so `DELETE` never has to stop anything. Rejected because the teardown is provably not racy here (the join is what makes it safe) and it would make the drawer's one-click delete a two-call dance for the common case. A **restart** route was also considered and deliberately not added: it would have to decide what happens to the existing captures, and delete-plus-new lets the user decide instead. Both decisions are documented in `api-reference.md`.

**One enabling change beyond the route.** The confirmation has to name what would be lost, and the capture count is not something `InboxManager` can know - captures are database rows. `InboxInfo` gains `capture_count`, emitted as `captureCount`, filled in by a single `inbox_json(db, info)` helper that every inbox-returning route goes through, since the failure mode of a fourth copy is not a compile error but a `0` reading as "nothing to lose" beside a destructive action.

### Engine
- `DELETE /inbox/:id` -> `{"inboxId", "capturesDeleted"}`, `404` for an unknown id, `500` on a database failure with the record intact.
- `InboxManager::remove(db, id)`, with the ordering rationale on the declaration.
- `captureCount` on the wire shape, through one helper; `inbox_json` extracted (like `inbox_captures_response`) so the wiring is testable without an in-process HTTP server.

### App
- Delete on **every** drawer row (running or stopped) and beside Stop/Clear in the tab.
- `useInboxDeletion` + `DeleteInboxDialog` in `modules/inbox/`, shared by both surfaces so they cannot disagree about when the confirmation appears or how it is worded. Captures present -> confirm, naming the count; none -> delete outright.
- `capturesAtRisk` takes the higher of the record's polled `captureCount` and a surface's own capture total: the record is up to one `SERVICES_POLL_INTERVAL_MS` behind while the tab's list is fed by the live stream, so trusting the record alone would let the tab silently destroy a capture it is displaying.
- `useDeleteInboxMutation` **removes** the captures cache entry rather than invalidating it - an invalidation would refetch an id the engine now `404`s.
- The group affordance is now **New inbox** (Plus), matching **New issuer**; nothing implies restart any more.
- A deleted, addressed inbox needs no retargeting: the tab's selection is derived (#554), so it falls back to the remaining inbox on its own - pinned by a test.

### Deliberate deviations from the issue
- The issue's item 3 says to "coordinate with the multi-inbox addressing issue - land that first". #554 has since merged, so the tab delete lands on the stable addressing it asked for.
- The tab's **Clear** moves from `Trash2` to `Eraser`. Not in the issue, but a direct consequence of it: two adjacent destructive controls sharing one icon is how a listener gets deleted by someone meaning to empty the list.
- MCP: none, as the issue states - verified, no inbox tools exist.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All commands from the issue, on this branch:

- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1468/1468 passed** (32 inbox tests, 4 of them new).
- `cd app && pnpm test` - **4317 passed / 424 files** (5 new cases plus the shared-rule unit test).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` on the touched files - clean. `clang-format` clean on the three engine files.

New engine cases (`inbox_test.cpp`):
- `DeleteFreesTheListenerAndTakesTheCapturesWithIt` - the record is gone from `get`/`list`, captures count 0, the port refuses connections, a second delete is a 404.
- `DeleteTakesOnlyItsOwnInboxsCaptures` - the cascade is per-inbox.
- `DeleteLeavesAnAttachedLiveStreamNothingToStrand` - a live-claim holder finds the inbox gone, `note_live_write` returns false so it ends without releasing a slot that may since belong to someone else, and the release is a harmless no-op.
- `TheWireShapeCarriesWhatTheInboxIsHolding` - the count is filled from the database, not carried on the record.

New app cases: drawer delete of a stopped inbox, of a running one (no separate stop call), the count-naming confirmation, the renamed group affordance; tab delete with and without a confirmation, the stale-count case, and the post-delete fallback.

**Mutation-checked** (reverted, confirmed red, restored):
- Dropping `db.clear_inbox_requests` from `remove` -> `DeleteFreesTheListenerAndTakesTheCapturesWithIt` fails on the captures count.
- `capturesAtRisk` reduced to `inbox.captureCount` -> both the stale-count case and the unit test fail.

No pre-existing failures on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #553

Unblocks #555, which the issue sequences after this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZWd1e7euyFpV6LLEQ7p1a)_