### PR TITLE
fix(app/services): stop the drawer telling the user things that are not so

### DIFF
--- a/app/src/components/layout/Dock.services.test.tsx
+++ b/app/src/components/layout/Dock.services.test.tsx
@@ -26,13 +26,17 @@
  * The transport is mocked and the real queries and hooks run, so the count is
  * computed the way the app computes it - including the asymmetry between the
  * two lists (an inbox stays listed once stopped, an issuer does not).
+ *
+ * Two later claims from issue #555, both about the indicator telling the truth:
+ * a dead engine is running nothing whatever the query cache still holds, and an
+ * ambient chip that points at a surface must never be the thing that hides it.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
-import { useLayoutStore } from "@/stores";
+import { useEngineStore, useLayoutStore } from "@/stores";
 import type { Inbox, MockIssuer } from "@/types";
 import { Dock } from "./Dock";
 
@@ -102,6 +106,9 @@ beforeEach(() => {
 	listInboxes.mockReset().mockResolvedValue([]);
 	listMockIssuers.mockReset().mockResolvedValue([]);
 	useLayoutStore.setState({ drawerOpen: true, drawerView: "collections" });
+	// The count is gated on this, and the store's own default is `false` - a
+	// list that answered at all came from an engine that was up.
+	useEngineStore.setState({ isEngineConnected: true, engineError: null });
 });
 
 describe("the services drawer switcher", () => {
@@ -155,5 +162,40 @@ describe("the running-services indicator", () => {
 		fireEvent.click(await screen.findByText("1 service"));
 		expect(useLayoutStore.getState().drawerView).toBe("services");
 		expect(useLayoutStore.getState().drawerOpen).toBe(true);
+	});
+
+	/*
+	 * The switchers to its left toggle, which is right for a button pressed
+	 * twice. This is not one of them: it is an ambient chip *pointing at* the
+	 * drawer, so on `activateDrawerView` it closed the one surface that can stop
+	 * or copy the services it had just announced. Mutation-check: swap
+	 * `revealDrawerView` back for `activateDrawerView` and this fails.
+	 */
+	it("only ever reveals the drawer, even when it is already on services", async () => {
+		useLayoutStore.setState({ drawerOpen: true, drawerView: "services" });
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderDock();
+		fireEvent.click(await screen.findByText("1 service"));
+		expect(useLayoutStore.getState().drawerOpen).toBe(true);
+		expect(useLayoutStore.getState().drawerView).toBe("services");
+	});
+
+	/*
+	 * Services are engine-*process* state, so a disconnected engine is running
+	 * none of them - but TanStack holds the last good list through failed
+	 * refetches, so the Dock rendered "1 service" in green beside its own
+	 * "Disconnected" light. Mutation-check: drop the gate in
+	 * `useRunningServiceCount` and this fails.
+	 */
+	it("says nothing while the engine is down, whatever the cache still holds", async () => {
+		listInboxes.mockResolvedValue([inbox()]);
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderDock();
+		// The cache is warm first, so this proves the gate and not a slow query.
+		expect(await screen.findByText("2 services")).toBeInTheDocument();
+
+		useEngineStore.setState({ isEngineConnected: false });
+		await waitFor(() => expect(screen.queryByText(/service/i)).not.toBeInTheDocument());
+		expect(screen.getByText("Disconnected")).toBeInTheDocument();
 	});
 });

--- a/app/src/components/layout/Dock.tsx
+++ b/app/src/components/layout/Dock.tsx
@@ -253,12 +253,17 @@ function PendingRestart() {
  * light because that is this strip's ambient-status region, and because these
  * are the same kind of fact: what the engine is doing on the user's behalf.
  *
- * **Nothing renders when nothing runs.** The Dock's middle is ambient, and a
+ * **Nothing renders when nothing runs** - and a disconnected engine is running
+ * nothing, which `useRunningServiceCount` is what decides (it holds the gate,
+ * so no reader has to remember the caveat). The Dock's middle is ambient, and a
  * standing "0 services" would spend a permanent line on the ordinary case.
  * Guarded by `Dock.services.test.tsx` - rendering it unconditionally fails.
  */
 function RunningServices() {
-	const activateDrawerView = useLayoutStore((s) => s.activateDrawerView);
+	// Reveal, never toggle: an ambient chip that says something is listening is
+	// pointing *at* the drawer, so clicking it with the drawer already on
+	// Services used to close the one surface that can act on them.
+	const revealDrawerView = useLayoutStore((s) => s.revealDrawerView);
 	const count = useRunningServiceCount();
 
 	if (count === 0) return null;
@@ -273,7 +278,7 @@ function RunningServices() {
 				 * pair the connection light above uses for the same 12px dot.
 				 */}
 				<button
-					onClick={() => activateDrawerView("services")}
+					onClick={() => revealDrawerView("services")}
 					className="flex items-center gap-1 text-xs text-success-text rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
 				>
 					<span className="w-1.5 h-1.5 rounded-full bg-current" />

--- a/app/src/config/timing.ts
+++ b/app/src/config/timing.ts
@@ -43,6 +43,18 @@ export const TIMING = {
 	STATUS_RESET_MS: 2000,
 
 	/**
+	 * How long a just-created row stays highlighted so the eye can find it.
+	 *
+	 * The Services drawer orders inboxes by port, so a new one lands wherever
+	 * its ephemeral port sorts - not at the end. Without the highlight the only
+	 * evidence a click did anything was a row count nobody was counting. Same
+	 * order as `STATUS_RESET_MS`: long enough to be seen after the toast pulls
+	 * the eye elsewhere, short enough that it is over before it reads as a
+	 * selection the user has to clear.
+	 */
+	ROW_FLASH_MS: 2500,
+
+	/**
 	 * How long the collection tree's typeahead buffer survives between
 	 * keystrokes before the next letter starts a fresh search.
 	 *

--- a/app/src/modules/inbox/InboxView.errors.test.tsx
+++ b/app/src/modules/inbox/InboxView.errors.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * One error discipline across the inbox lifecycle (issue #555, item 7).
+ *
+ * Every other mutation on an inbox already toasted its failure - start and
+ * update here, delete in the shared deletion hook, stop from the Services
+ * drawer row. This tab's own Stop and Clear passed no `onError` at all, so a
+ * refused call left a button that had visibly done nothing and put the reason
+ * nowhere but devtools. Two surfaces acting on one lifecycle cannot report
+ * failure two different ways, and "not at all" is the worse of the two.
+ *
+ * Mutation-check: drop the `onError` from either `mutate` call in
+ * `modules/inbox/index.tsx` and the matching case here fails.
+ *
+ * The transport is mocked and the real query hooks run, so a refusal travels
+ * the same mutation path the app uses.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useTabsStore, useToastStore } from "@/stores";
+import type { Inbox, InboxCapture } from "@/types";
+import type { InboxLiveState } from "./useInboxLive";
+
+const listInboxes = vi.fn();
+const listInboxCaptures = vi.fn();
+const stopInbox = vi.fn();
+const clearInboxCaptures = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => listInboxes(),
+			listInboxCaptures: (...a: unknown[]) => listInboxCaptures(...a),
+			stopInbox: (...a: unknown[]) => stopInbox(...a),
+			clearInboxCaptures: (...a: unknown[]) => clearInboxCaptures(...a),
+		},
+	};
+});
+
+const live: InboxLiveState = { watching: true, stopped: false, resume: vi.fn() };
+vi.mock("./useInboxLive", () => ({ useInboxLive: () => live }));
+
+const { default: InboxView } = await import("./index");
+
+function inbox(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:41234/",
+		bind: "127.0.0.1",
+		port: 41234,
+		running: true,
+		loopback: true,
+		captureCount: 1,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
+
+function capture(): InboxCapture {
+	return {
+		id: 1,
+		inboxId: "inbox_a",
+		receivedAt: 1700000000000,
+		method: "POST",
+		path: "/hook",
+		query: "",
+		headers: {},
+		body: "{}",
+		bodyBytes: 2,
+		bodyTruncated: false,
+		remoteAddr: "127.0.0.1",
+	};
+}
+
+function renderTab() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<InboxView />
+		</QueryClientProvider>
+	);
+}
+
+const firstToast = () => useToastStore.getState().toasts[0];
+
+beforeEach(() => {
+	cleanup();
+	listInboxes.mockReset().mockResolvedValue([inbox()]);
+	listInboxCaptures.mockReset().mockResolvedValue({
+		data: [capture()],
+		pagination: { total: 1, limit: 50, offset: 0, returned: 1, hasMore: false },
+	});
+	stopInbox.mockReset().mockResolvedValue(inbox({ running: false }));
+	clearInboxCaptures.mockReset().mockResolvedValue({ inboxId: "inbox_a", cleared: 1 });
+	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
+	useToastStore.setState({ toasts: [] });
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText: vi.fn() } });
+});
+
+describe("a refused mutation in the inbox tab", () => {
+	it("says why the stop did not happen", async () => {
+		stopInbox.mockRejectedValue(new Error("inbox is already stopped"));
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: /stop/i }));
+		await waitFor(() =>
+			expect(firstToast()).toMatchObject({
+				variant: "error",
+				message: "inbox is already stopped",
+			})
+		);
+	});
+
+	it("says why the captures were not cleared", async () => {
+		clearInboxCaptures.mockRejectedValue(new Error("database is locked"));
+		renderTab();
+
+		// Clear is disabled until the list has something in it, so the click
+		// would otherwise land on a dead button and prove nothing.
+		await screen.findByText("/hook");
+		fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+		await waitFor(() =>
+			expect(firstToast()).toMatchObject({ variant: "error", message: "database is locked" })
+		);
+	});
+
+	/*
+	 * A transport that rejects with something other than an Error - a bare
+	 * string from a failed parse - still has to reach the user as words, not as
+	 * silence or "[object Object]".
+	 */
+	it("falls back to a named reason when the failure is not an Error", async () => {
+		stopInbox.mockRejectedValue("boom");
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: /stop/i }));
+		await waitFor(() =>
+			expect(firstToast()).toMatchObject({
+				variant: "error",
+				message: "Could not stop the inbox",
+			})
+		);
+	});
+
+	it("stays quiet when the call succeeds", async () => {
+		renderTab();
+		fireEvent.click(await screen.findByRole("button", { name: /stop/i }));
+		await waitFor(() => expect(stopInbox).toHaveBeenCalledWith("inbox_a"));
+		expect(useToastStore.getState().toasts).toHaveLength(0);
+	});
+});

--- a/app/src/modules/inbox/index.tsx
+++ b/app/src/modules/inbox/index.tsx
@@ -166,18 +166,24 @@ export default function InboxView() {
 		);
 	}
 
+	/**
+	 * One error discipline for the whole inbox lifecycle (issue #555, item 7).
+	 *
+	 * Start, update, delete and the drawer's own stop all toasted their failure;
+	 * this tab's Stop and Clear passed no `onError` at all, so a refused stop
+	 * left a button that had visibly done nothing and no reason anywhere. Taken
+	 * here rather than in #556's tab pass, which both issues name as the shared
+	 * brush - whichever landed second was to skip it.
+	 */
+	const reportFailure = (fallback: string) => (mutationError: unknown) =>
+		showToast(mutationError instanceof Error ? mutationError.message : fallback, "error");
+
 	const start = () => {
 		startInbox.mutate(
 			{},
 			{
 				onSuccess: (started) => show(started.inboxId),
-				onError: (mutationError) =>
-					showToast(
-						mutationError instanceof Error
-							? mutationError.message
-							: "Could not start the inbox",
-						"error"
-					),
+				onError: reportFailure("Could not start the inbox"),
 			}
 		);
 	};
@@ -186,15 +192,7 @@ export default function InboxView() {
 		if (!inbox) return;
 		updateResponse.mutate(
 			{ inboxId: inbox.inboxId, response },
-			{
-				onError: (mutationError) =>
-					showToast(
-						mutationError instanceof Error
-							? mutationError.message
-							: "Could not update the response",
-						"error"
-					),
-			}
+			{ onError: reportFailure("Could not update the response") }
 		);
 	};
 
@@ -277,7 +275,11 @@ export default function InboxView() {
 					<Button
 						variant="outline"
 						size="sm"
-						onClick={() => clearCaptures.mutate(inbox.inboxId)}
+						onClick={() =>
+							clearCaptures.mutate(inbox.inboxId, {
+								onError: reportFailure("Could not clear the captures"),
+							})
+						}
 						disabled={clearCaptures.isPending || captures.length === 0}
 					>
 						<Eraser className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
@@ -287,7 +289,11 @@ export default function InboxView() {
 						<Button
 							variant="outline"
 							size="sm"
-							onClick={() => stopInbox.mutate(inbox.inboxId)}
+							onClick={() =>
+								stopInbox.mutate(inbox.inboxId, {
+									onError: reportFailure("Could not stop the inbox"),
+								})
+							}
 							disabled={stopInbox.isPending}
 						>
 							<Square className="mr-2 h-3.5 w-3.5" aria-hidden="true" />

--- a/app/src/modules/palette/sources/useViewItems.ts
+++ b/app/src/modules/palette/sources/useViewItems.ts
@@ -19,7 +19,7 @@
  * `activateDrawerView` *toggles* when the drawer is already on that view, which
  * is right for a button pressed twice and wrong for a search result: picking
  * "History" from the palette must show History, never hide it. So the entries
- * here set the view explicitly instead.
+ * here reveal it instead (`revealDrawerView`, the store's non-toggling half).
  */
 
 import { Braces, Clock, Folder, Inbox, Radio, Settings } from "lucide-react";
@@ -76,8 +76,7 @@ const VIEWS: ViewEntry[] = [
 
 export function useViewItems(): PaletteItem[] {
 	const openTab = useTabsStore((s) => s.openTab);
-	const setDrawerOpen = useLayoutStore((s) => s.setDrawerOpen);
-	const setDrawerView = useLayoutStore((s) => s.setDrawerView);
+	const revealDrawerView = useLayoutStore((s) => s.revealDrawerView);
 
 	return VIEWS.map((view) => ({
 		id: `view:${view.title.toLowerCase()}`,
@@ -86,10 +85,7 @@ export function useViewItems(): PaletteItem[] {
 		keywords: view.keywords,
 		icon: view.icon,
 		perform: () => {
-			if (view.drawerView) {
-				setDrawerOpen(true);
-				setDrawerView(view.drawerView);
-			}
+			if (view.drawerView) revealDrawerView(view.drawerView);
 			if (view.tabType) openTab({ type: view.tabType, entityId: null });
 		},
 	}));

--- a/app/src/modules/services/NewIssuerDialog.tsx
+++ b/app/src/modules/services/NewIssuerDialog.tsx
@@ -150,24 +150,44 @@ export function NewIssuerDialog({ onOpenChange, onStarted }: NewIssuerDialogProp
 				</DialogHeader>
 
 				<div className="space-y-4 py-2">
-					<div className="flex items-center justify-between gap-4">
-						<Label htmlFor="new-issuer-expiry" className="leading-snug">
-							Token lifetime
-							<span className="block text-xs font-normal text-muted-foreground">
-								Seconds. What `exp` is stamped with, and what `expires_in` reports.
-							</span>
-						</Label>
-						<Input
-							id="new-issuer-expiry"
-							type="number"
-							min={1}
-							max={MAX_EXPIRES_IN_SECONDS}
-							step={1}
-							value={expiresIn}
-							onChange={(e) => setExpiresIn(e.target.value)}
-							className="w-28 shrink-0"
-							aria-invalid={!expiresInValid}
-						/>
+					{/* The bound in words, not only in `aria-invalid` and a disabled
+					    button. A field that reddens while Start greys out states
+					    that something is wrong and never which field or why - and
+					    `aria-invalid` alone announces "invalid" with no correction.
+					    The claims box below already did this; the two numbers did
+					    not. */}
+					<div className="space-y-1">
+						<div className="flex items-center justify-between gap-4">
+							<Label htmlFor="new-issuer-expiry" className="leading-snug">
+								Token lifetime
+								<span className="block text-xs font-normal text-muted-foreground">
+									Seconds. What `exp` is stamped with, and what `expires_in`
+									reports.
+								</span>
+							</Label>
+							<Input
+								id="new-issuer-expiry"
+								type="number"
+								min={1}
+								max={MAX_EXPIRES_IN_SECONDS}
+								step={1}
+								value={expiresIn}
+								onChange={(e) => setExpiresIn(e.target.value)}
+								className="w-28 shrink-0"
+								aria-invalid={!expiresInValid}
+								aria-describedby={
+									expiresInValid ? undefined : "new-issuer-expiry-error"
+								}
+							/>
+						</div>
+						{!expiresInValid && (
+							<p
+								id="new-issuer-expiry-error"
+								className="text-xs text-destructive-text"
+							>
+								{`A whole number of seconds, 1 to ${MAX_EXPIRES_IN_SECONDS}.`}
+							</p>
+						)}
 					</div>
 
 					<div className="flex items-center justify-between gap-4">
@@ -197,24 +217,37 @@ export function NewIssuerDialog({ onOpenChange, onStarted }: NewIssuerDialogProp
 					</div>
 
 					{failureMode === "slow" && (
-						<div className="flex items-center justify-between gap-4">
-							<Label htmlFor="new-issuer-slow" className="leading-snug">
-								Delay
-								<span className="block text-xs font-normal text-muted-foreground">
-									Milliseconds to wait before answering normally.
-								</span>
-							</Label>
-							<Input
-								id="new-issuer-slow"
-								type="number"
-								min={0}
-								max={MAX_SLOW_MS}
-								step={100}
-								value={slowMs}
-								onChange={(e) => setSlowMs(e.target.value)}
-								className="w-28 shrink-0"
-								aria-invalid={!slowMsValid}
-							/>
+						<div className="space-y-1">
+							<div className="flex items-center justify-between gap-4">
+								<Label htmlFor="new-issuer-slow" className="leading-snug">
+									Delay
+									<span className="block text-xs font-normal text-muted-foreground">
+										Milliseconds to wait before answering normally.
+									</span>
+								</Label>
+								<Input
+									id="new-issuer-slow"
+									type="number"
+									min={0}
+									max={MAX_SLOW_MS}
+									step={100}
+									value={slowMs}
+									onChange={(e) => setSlowMs(e.target.value)}
+									className="w-28 shrink-0"
+									aria-invalid={!slowMsValid}
+									aria-describedby={
+										slowMsValid ? undefined : "new-issuer-slow-error"
+									}
+								/>
+							</div>
+							{!slowMsValid && (
+								<p
+									id="new-issuer-slow-error"
+									className="text-xs text-destructive-text"
+								>
+									{`A whole number of milliseconds, 0 to ${MAX_SLOW_MS}.`}
+								</p>
+							)}
 						</div>
 					)}
 

--- a/app/src/modules/services/ServicesPanel.test.tsx
+++ b/app/src/modules/services/ServicesPanel.test.tsx
@@ -149,13 +149,68 @@ describe("the services drawer", () => {
 		await waitFor(() => expect(startInbox).toHaveBeenCalled());
 		expect(screen.queryByRole("button", { name: /^start inbox$/i })).not.toBeInTheDocument();
 	});
+
+	/*
+	 * The start mutation carried an `onError` and no `onSuccess`, so a
+	 * successful create reported nothing at all - and since rows sort by port,
+	 * the new one lands wherever its ephemeral port falls rather than at the
+	 * end. Mutation-check: drop the `onSuccess` and this fails.
+	 */
+	it("says a new inbox started, and names the port it got", async () => {
+		startInbox.mockResolvedValue(inbox({ inboxId: "inbox_new", port: 41240 }));
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: "New inbox" }));
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]).toMatchObject({
+				variant: "success",
+				message: "Inbox started on port 41240",
+			})
+		);
+	});
+
+	it("highlights the row it just created, so the eye can find it in port order", async () => {
+		const created = inbox({
+			inboxId: "inbox_new",
+			port: 41230,
+			url: "http://127.0.0.1:41230/",
+		});
+		startInbox.mockResolvedValue(created);
+		listInboxes.mockResolvedValue([inbox(), created]);
+		renderPanel();
+
+		await screen.findByText("Port 41234");
+		fireEvent.click(screen.getByRole("button", { name: "New inbox" }));
+
+		const flashedRow = await waitFor(() => {
+			const row = screen.getByText("Port 41230").closest("div.flex.h-8");
+			expect(row?.className).toContain("bg-primary/10");
+			return row;
+		});
+		// And only that row - the highlight names one inbox, not the group.
+		expect(screen.getByText("Port 41234").closest("div.flex.h-8")).not.toBe(flashedRow);
+		expect(screen.getByText("Port 41234").closest("div.flex.h-8")?.className).not.toContain(
+			"bg-primary/10"
+		);
+	});
+
+	it("still reports a refused start, and highlights nothing", async () => {
+		startInbox.mockRejectedValue(new Error("address already in use"));
+		renderPanel();
+		fireEvent.click(await screen.findByRole("button", { name: "New inbox" }));
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]).toMatchObject({
+				variant: "error",
+				message: "address already in use",
+			})
+		);
+	});
 });
 
 describe("an inbox row", () => {
 	it("opens the inbox tab - the drawer lists, the tab shows the captures", async () => {
 		listInboxes.mockResolvedValue([inbox()]);
 		renderPanel();
-		fireEvent.click(await screen.findByRole("button", { name: /open inbox on port 41234/i }));
+		fireEvent.click(await screen.findByRole("button", { name: /open inbox.*port 41234/i }));
 		expect(useTabsStore.getState().openTabs.map((t) => t.type)).toContain("inbox");
 	});
 
@@ -172,14 +227,14 @@ describe("an inbox row", () => {
 		]);
 		renderPanel();
 
-		fireEvent.click(await screen.findByRole("button", { name: /open inbox on port 41235/i }));
+		fireEvent.click(await screen.findByRole("button", { name: /open inbox.*port 41235/i }));
 		expect(useTabsStore.getState().openTabs).toContainEqual(
 			expect.objectContaining({ type: "inbox", entityId: "inbox_b" })
 		);
 
 		// And the second row retargets the one open tab rather than opening a
 		// second inbox tab.
-		fireEvent.click(screen.getByRole("button", { name: /open inbox on port 41234/i }));
+		fireEvent.click(screen.getByRole("button", { name: /open inbox.*port 41234/i }));
 		const inboxTabs = useTabsStore.getState().openTabs.filter((t) => t.type === "inbox");
 		expect(inboxTabs).toHaveLength(1);
 		expect(inboxTabs[0].entityId).toBe("inbox_a");
@@ -244,6 +299,111 @@ describe("an inbox row", () => {
 		await waitFor(() => expect(deleteInbox).toHaveBeenCalledWith("inbox_a"));
 		expect(stopInbox).not.toHaveBeenCalled();
 	});
+
+	/*
+	 * The row's `aria-label` *replaced* its content in the accessible name, so
+	 * everything the row says about this particular inbox - which one it is,
+	 * whether it is still listening, whether it is reachable beyond this machine
+	 * - was inaudible, and a stopped row and a running one read identically.
+	 * Mutation-check: put the label back as an `aria-label` on the activator and
+	 * this fails on every assertion after the first.
+	 */
+	it("reads out what the row says, not a label that replaces it", async () => {
+		listInboxes.mockResolvedValue([
+			inbox({ running: false, loopback: false, bind: "0.0.0.0" }),
+		]);
+		renderPanel();
+
+		const name = (await screen.findByRole("button", { name: /open inbox/i })).textContent ?? "";
+		expect(name).toContain("Open inbox");
+		expect(name).toContain("Port 41234");
+		expect(name).toContain("http://127.0.0.1:41234/");
+		expect(name).toContain("Stopped");
+		expect(name).toContain("0.0.0.0");
+	});
+
+	/*
+	 * Three inboxes were three near-identical monospace URLs differing in one
+	 * digit. The port is the part that varies and the part a user names an inbox
+	 * by, so it leads and the URL - the value you copy, not the one you scan a
+	 * list by - is demoted behind it.
+	 */
+	it("leads with the port, so a list of inboxes is not one string repeated", async () => {
+		listInboxes.mockResolvedValue([
+			inbox(),
+			inbox({ inboxId: "inbox_b", port: 41235, url: "http://127.0.0.1:41235/" }),
+		]);
+		renderPanel();
+		expect(await screen.findByText("Port 41234")).toBeInTheDocument();
+		expect(screen.getByText("Port 41235")).toBeInTheDocument();
+	});
+
+	/*
+	 * The engine lists inboxes in map order, which is not stable across polls -
+	 * so a row could move under the pointer, and a newly created one arrived
+	 * anywhere. Port is the stable key the record carries (it carries no
+	 * creation stamp; see the module doc). Mutation-check: render `inboxes`
+	 * instead of `orderedInboxes` and this fails.
+	 */
+	it("orders rows by port, whatever order the engine listed them in", async () => {
+		listInboxes.mockResolvedValue([
+			inbox({ inboxId: "inbox_c", port: 41236, url: "http://127.0.0.1:41236/" }),
+			inbox(),
+			inbox({ inboxId: "inbox_b", port: 41235, url: "http://127.0.0.1:41235/" }),
+		]);
+		renderPanel();
+		await screen.findByText("Port 41234");
+		expect(screen.getAllByText(/^Port 4123\d$/).map((el) => el.textContent)).toEqual([
+			"Port 41234",
+			"Port 41235",
+			"Port 41236",
+		]);
+	});
+
+	/*
+	 * `writeText` rejects - a denied permission, an unfocused document - and
+	 * this fired it with `void` and toasted "copied" regardless, so the user
+	 * pasted whatever was on the clipboard before. Mutation-check: drop the
+	 * await and the catch, and this reports a success.
+	 */
+	it("does not claim a copy that the clipboard refused", async () => {
+		writeText.mockRejectedValue(new Error("Clipboard write denied"));
+		listInboxes.mockResolvedValue([inbox()]);
+		renderPanel();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]).toMatchObject({ variant: "error" })
+		);
+		expect(useToastStore.getState().toasts[0].message).toMatch(/Clipboard write denied/);
+	});
+
+	/*
+	 * A stopped inbox's URL copies perfectly well and then refuses connections,
+	 * a long way from the cause - so the affordance says which it is where the
+	 * URL itself is offered.
+	 */
+	it("warns that a stopped inbox's URL has nothing listening behind it", async () => {
+		listInboxes.mockResolvedValue([inbox({ running: false })]);
+		renderPanel();
+		fireEvent.focus(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		// Radix renders the content twice - the visible tip and its aria copy.
+		expect((await screen.findAllByText(/stopped, not listening/i)).length).toBeGreaterThan(0);
+	});
+
+	it("says so when the copy worked", async () => {
+		writeText.mockResolvedValue(undefined);
+		listInboxes.mockResolvedValue([inbox()]);
+		renderPanel();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]).toMatchObject({
+				variant: "success",
+				message: "Inbox URL copied",
+			})
+		);
+	});
 });
 
 describe("an issuer row", () => {
@@ -290,6 +450,101 @@ describe("an issuer row", () => {
 		await waitFor(() =>
 			expect(updateMockIssuer).toHaveBeenCalledWith("iss_a", { failureMode: "server_error" })
 		);
+	});
+
+	/*
+	 * Slow is the one mode with a parameter, and the switch offered no way to
+	 * see or set it: the issuer answered after whatever `slowMs` it was
+	 * *started* with, the summary line beside the switch reported that number,
+	 * and `PUT /mock-issuer/:id` had accepted a new one all along. Mutation-
+	 * check: render the control unconditionally and the first assertion fails;
+	 * drop it entirely and the rest do.
+	 */
+	it("does not offer a delay in a mode that never reads one", async () => {
+		listMockIssuers.mockResolvedValue([issuer({ failureMode: "none" })]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+		expect(screen.queryByLabelText(/delay/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the delay a slow issuer is running with, and sends the new one", async () => {
+		listMockIssuers.mockResolvedValue([issuer({ failureMode: "slow", slowMs: 2000 })]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+
+		const delay = screen.getByLabelText(/delay/i);
+		expect(delay).toHaveValue(2000);
+		fireEvent.change(delay, { target: { value: "5000" } });
+		fireEvent.blur(delay);
+		await waitFor(() =>
+			expect(updateMockIssuer).toHaveBeenCalledWith("iss_a", { slowMs: 5000 })
+		);
+	});
+
+	/*
+	 * Every character of "5000" is a valid number, so a field committing per
+	 * keystroke would send 5, 50, 500 - three PUTs reconfiguring a running
+	 * listener on the way to the one the user meant.
+	 */
+	it("commits the delay once, not once per keystroke", async () => {
+		listMockIssuers.mockResolvedValue([issuer({ failureMode: "slow", slowMs: 2000 })]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+
+		const delay = screen.getByLabelText(/delay/i);
+		fireEvent.change(delay, { target: { value: "5" } });
+		fireEvent.change(delay, { target: { value: "50" } });
+		fireEvent.change(delay, { target: { value: "500" } });
+		expect(updateMockIssuer).not.toHaveBeenCalled();
+
+		fireEvent.blur(delay);
+		await waitFor(() => expect(updateMockIssuer).toHaveBeenCalledTimes(1));
+		expect(updateMockIssuer).toHaveBeenCalledWith("iss_a", { slowMs: 500 });
+	});
+
+	/*
+	 * The engine answers an out-of-range value with a `400
+	 * mock_issuer_invalid_config` that names no field, so the bound is stated
+	 * here and nothing is sent.
+	 */
+	it("refuses an out-of-range delay by name, and sends nothing", async () => {
+		listMockIssuers.mockResolvedValue([issuer({ failureMode: "slow", slowMs: 2000 })]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+
+		const delay = screen.getByLabelText(/delay/i);
+		fireEvent.change(delay, { target: { value: "999999" } });
+		expect(screen.getByText(/whole number of milliseconds, 0 to 60000/i)).toBeInTheDocument();
+		fireEvent.blur(delay);
+		expect(updateMockIssuer).not.toHaveBeenCalled();
+	});
+
+	/*
+	 * `border-rule` inherits the `--rule` its enclosing surface declares, and no
+	 * drawer surface declares one - so a rule here fell back to the canvas
+	 * default, which against `--panel` in dark measures 1.07 and is simply not
+	 * visible. Asserting `border-rule` is present would prove nothing (it always
+	 * was); what has to hold is the *declaration*, per `app/CLAUDE.md`.
+	 * Mutation-check: drop `surface-sunken` and this fails.
+	 */
+	it("declares the surface its expanded detail's rule reads on", async () => {
+		listMockIssuers.mockResolvedValue([issuer()]);
+		renderPanel();
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand issuer on port 42000/i })
+		);
+
+		const detail = screen.getByText("HS256 shared secret").closest("div.border-l-2");
+		expect(detail?.className).toContain("border-rule");
+		expect(detail?.className).toContain("surface-sunken");
 	});
 
 	it("stops the issuer it names", async () => {
@@ -353,9 +608,27 @@ describe("starting an issuer", () => {
 		expect(dialog.getByRole("button", { name: /start issuer/i })).toBeDisabled();
 	});
 
-	it("refuses an out-of-range lifetime", async () => {
+	/*
+	 * A reddened field beside a greyed-out Start says that something is wrong
+	 * and never which field or why, and `aria-invalid` alone announces
+	 * "invalid" with no correction. The claims box already stated its rule; the
+	 * two numeric fields did not. Mutation-check: delete the error paragraphs
+	 * and the two text assertions here fail while the disabled ones still pass,
+	 * which is the whole point.
+	 */
+	it("refuses an out-of-range lifetime, and says what would be in range", async () => {
 		const dialog = await openDialog();
 		fireEvent.change(dialog.getByLabelText(/token lifetime/i), { target: { value: "0" } });
+		expect(dialog.getByRole("button", { name: /start issuer/i })).toBeDisabled();
+		expect(dialog.getByText(/whole number of seconds, 1 to 2678400/i)).toBeInTheDocument();
+	});
+
+	it("refuses an out-of-range delay, and says what would be in range", async () => {
+		const dialog = await openDialog();
+		fireEvent.click(dialog.getByRole("combobox"));
+		fireEvent.click(await screen.findByRole("option", { name: "Slow" }));
+		fireEvent.change(dialog.getByLabelText(/delay/i), { target: { value: "-1" } });
+		expect(dialog.getByText(/whole number of milliseconds, 0 to 60000/i)).toBeInTheDocument();
 		expect(dialog.getByRole("button", { name: /start issuer/i })).toBeDisabled();
 	});
 });

--- a/app/src/modules/services/ServicesPanel.tsx
+++ b/app/src/modules/services/ServicesPanel.tsx
@@ -26,11 +26,12 @@
  * teaches a reader less than its absence does.
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, Copy, KeyRound, Plus, Square, Trash2 } from "lucide-react";
 import { DrawerPanel, EmptyState, ErrorState, TruncatedText } from "@/components/shared";
 import {
 	Badge,
+	Input,
 	Select,
 	SelectContent,
 	SelectItem,
@@ -47,11 +48,12 @@ import {
 	useUpdateMockIssuerMutation,
 } from "@/queries";
 import { useTabsStore, useToastStore } from "@/stores";
+import { TIMING } from "@/config/timing";
 import { cn } from "@/lib/utils";
 import type { Inbox, MockIssuer, MockIssuerFailureMode } from "@/types";
 import { DeleteInboxDialog } from "@/modules/inbox/DeleteInboxDialog";
 import { useInboxDeletion } from "@/modules/inbox/useInboxDeletion";
-import { FAILURE_MODE_LABELS, failureModeSummary } from "./failure-modes";
+import { FAILURE_MODE_LABELS, MAX_SLOW_MS, failureModeSummary } from "./failure-modes";
 import { NewIssuerDialog } from "./NewIssuerDialog";
 
 /**
@@ -76,13 +78,15 @@ function StatusDot({ running }: { running: boolean }) {
 interface ServiceRowProps {
 	/** What the row does when the row itself - or its activator - is clicked. */
 	onActivate: () => void;
-	/** Names the activator. Icon-only trailing controls carry their own. */
-	activateLabel: string;
+	/** The verb, prefixed to the row's own content to name the activator. */
+	actionLabel: string;
 	running: boolean;
 	children: React.ReactNode;
 	/** Trailing controls: copy, stop, delete. */
 	actions?: React.ReactNode;
 	leading?: React.ReactNode;
+	/** Highlights the row - a just-created service, so the eye can find it. */
+	flashed?: boolean;
 }
 
 /**
@@ -93,18 +97,32 @@ interface ServiceRowProps {
  * both halves of the hit-area rule in `app/CLAUDE.md`. A row carrying trailing
  * buttons cannot be one big button, so without the pair the responsive area is
  * the label's own bounding box and the padding around it is dead.
+ *
+ * **The verb is `sr-only` text, not an `aria-label`.** A label *replaces* the
+ * element's content when the accessible name is computed, so "Open inbox on
+ * port 41234" silenced everything the row actually says - the URL, "Stopped",
+ * the reachable-beyond-this-machine badge, an issuer's failure mode. A screen
+ * reader heard a row that could not be stopped and a row that could as the same
+ * row. Prefixing instead composes the two: the verb, then the content, in the
+ * order they are read on screen.
  */
 function ServiceRow({
 	onActivate,
-	activateLabel,
+	actionLabel,
 	running,
 	children,
 	actions,
 	leading,
+	flashed,
 }: ServiceRowProps) {
 	return (
 		<div
-			className="flex h-8 cursor-pointer items-center gap-1 px-3 hover:bg-muted/50"
+			className={cn(
+				"flex h-8 cursor-pointer items-center gap-1 px-3 hover:bg-muted/50",
+				// Not a selection - the drawer has none - so a background tint
+				// rather than the accent fill a selected row would carry.
+				flashed && "bg-primary/10"
+			)}
 			onClick={(e) => {
 				if (e.target === e.currentTarget) onActivate();
 			}}
@@ -113,9 +131,9 @@ function ServiceRow({
 			<button
 				type="button"
 				onClick={onActivate}
-				aria-label={activateLabel}
 				className="flex min-w-0 flex-1 items-center gap-2 self-stretch text-left text-sm"
 			>
+				<span className="sr-only">{actionLabel}</span>
 				<StatusDot running={running} />
 				{children}
 			</button>
@@ -146,15 +164,32 @@ function ServiceGroup({ title, action, children }: ServiceGroupProps) {
 /** `px-3 py-2 text-left`: a drawer group's line, not a centred pane. */
 const GROUP_NOTE_CLASS = "px-3 py-2 text-left text-xs";
 
+/**
+ * Copy, and say so only once it worked.
+ *
+ * `writeText` returns a promise that *rejects* - a denied permission, a
+ * document that is not focused, a platform with no clipboard behind the API -
+ * and this fired it with `void` and toasted "copied" unconditionally, so a
+ * failed copy was reported as a success and the user pasted whatever was on the
+ * clipboard before. Every other copy site in the app already awaits; this is
+ * the one that did not.
+ */
 function useCopy() {
 	const showToast = useToastStore((s) => s.showToast);
-	return (value: string, what: string) => {
-		void navigator.clipboard.writeText(value);
-		showToast(`${what} copied`, "success");
+	return async (value: string, what: string) => {
+		try {
+			await navigator.clipboard.writeText(value);
+			showToast(`${what} copied`, "success");
+		} catch (error) {
+			showToast(
+				error instanceof Error ? `Could not copy: ${error.message}` : "Could not copy",
+				"error"
+			);
+		}
 	};
 }
 
-function InboxRow({ inbox }: { inbox: Inbox }) {
+function InboxRow({ inbox, flashed }: { inbox: Inbox; flashed: boolean }) {
 	const openTab = useTabsStore((s) => s.openTab);
 	const showToast = useToastStore((s) => s.showToast);
 	const copy = useCopy();
@@ -166,17 +201,26 @@ function InboxRow({ inbox }: { inbox: Inbox }) {
 		<>
 			<ServiceRow
 				running={inbox.running}
+				flashed={flashed}
 				// The tab is a singleton pointed at one inbox, so the row hands it the
 				// id it names - without it the tab showed whichever inbox it had last
 				// (in practice the first), and the row's label was a lie (issue #554).
 				onActivate={() => openTab({ type: "inbox", entityId: inbox.inboxId })}
-				activateLabel={`Open inbox on port ${inbox.port}`}
+				actionLabel="Open inbox"
 				actions={
 					<>
+						{/* The URL rides the tooltip rather than the name: the name is
+						    what a screen reader reads on every row, and three inboxes
+						    would be three near-identical 30-character strings. A
+						    stopped inbox says so here too - the URL copies fine and
+						    then refuses connections, a long way from the cause. */}
 						<TooltipIconButton
 							label="Copy inbox URL"
+							tooltipHint={
+								inbox.running ? inbox.url : `${inbox.url} - stopped, not listening`
+							}
 							icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
-							onClick={() => copy(inbox.url, "Inbox URL")}
+							onClick={() => void copy(inbox.url, "Inbox URL")}
 						/>
 						{inbox.running && (
 							<TooltipIconButton
@@ -209,7 +253,15 @@ function InboxRow({ inbox }: { inbox: Inbox }) {
 					</>
 				}
 			>
-				<TruncatedText className="font-mono text-xs">{inbox.url}</TruncatedText>
+				{/* The port is what distinguishes one inbox from another and the
+				    only part of the URL that varies, so it leads. The URL stays
+				    visible but demoted - it is the value you copy, not the one you
+				    read a list by, and a column of `http://127.0.0.1:4123x/` in
+				    mono was three rows that looked identical. */}
+				<span className="shrink-0 text-xs">Port {inbox.port}</span>
+				<TruncatedText className="font-mono text-xs text-muted-foreground">
+					{inbox.url}
+				</TruncatedText>
 				{/* An inbox reachable beyond this machine is badged wherever it is
 				    named - the standing reminder that the engine's non-loopback
 				    confirmation was given. */}
@@ -267,9 +319,9 @@ function IssuerRow({
 	const stopIssuer = useStopMockIssuerMutation();
 	const updateIssuer = useUpdateMockIssuerMutation();
 
-	const setFailureMode = (failureMode: MockIssuerFailureMode) => {
+	const update = (patch: { failureMode?: MockIssuerFailureMode; slowMs?: number }) => {
 		updateIssuer.mutate(
-			{ issuerId: issuer.issuerId, update: { failureMode } },
+			{ issuerId: issuer.issuerId, update: patch },
 			{
 				onError: (error) =>
 					showToast(
@@ -280,6 +332,8 @@ function IssuerRow({
 		);
 	};
 
+	const setFailureMode = (failureMode: MockIssuerFailureMode) => update({ failureMode });
+
 	return (
 		<>
 			<ServiceRow
@@ -288,7 +342,7 @@ function IssuerRow({
 				// is where this differs from an inbox.
 				running
 				onActivate={onToggle}
-				activateLabel={`${expanded ? "Collapse" : "Expand"} issuer on port ${issuer.port}`}
+				actionLabel={`${expanded ? "Collapse" : "Expand"} issuer on port ${issuer.port}`}
 				leading={
 					expanded ? (
 						<ChevronDown
@@ -327,19 +381,25 @@ function IssuerRow({
 				)}
 			</ServiceRow>
 
+			{/* `surface-sunken`, not a bare `border-rule`: a rule inherits the
+			    `--rule` its enclosing surface declares, and no drawer surface
+			    declares one - so this fell back to the canvas default, which on
+			    `--panel` in dark measures 1.07 and is simply not there. Sunken is
+			    also what this is: the nested detail slab of the row above, the
+			    same treatment the settings cookie rows and the console panes use. */}
 			{expanded && (
-				<div className="border-l-2 border-rule pl-2 ml-4 mr-1 mb-2">
+				<div className="surface-sunken rounded-md border-l-2 border-rule pl-2 ml-4 mr-1 mb-2">
 					<IssuerDetailRow
 						label="Token"
 						value={issuer.tokenUrl}
 						copyLabel="Copy token URL"
-						onCopy={() => copy(issuer.tokenUrl, "Token URL")}
+						onCopy={() => void copy(issuer.tokenUrl, "Token URL")}
 					/>
 					<IssuerDetailRow
 						label="Authorize"
 						value={issuer.authorizeUrl}
 						copyLabel="Copy authorize URL"
-						onCopy={() => copy(issuer.authorizeUrl, "Authorize URL")}
+						onCopy={() => void copy(issuer.authorizeUrl, "Authorize URL")}
 					/>
 					{/* The signing key is the whole point of the issuer being a mock:
 					    it is the HS256 secret the service under test verifies the
@@ -354,7 +414,7 @@ function IssuerRow({
 						<TooltipIconButton
 							label="Copy signing key"
 							icon={<KeyRound className="h-3.5 w-3.5" aria-hidden="true" />}
-							onClick={() => copy(issuer.signingKey, "Signing key")}
+							onClick={() => void copy(issuer.signingKey, "Signing key")}
 						/>
 					</div>
 
@@ -388,10 +448,116 @@ function IssuerRow({
 							</SelectContent>
 						</Select>
 					</label>
+
+					{/* Slow is the one mode with a parameter, and the switch above
+					    offered no way to see or set it: the issuer answered after
+					    whatever `slowMs` it was *started* with, the summary line
+					    reported that number, and the engine's `PUT` had accepted a
+					    new one all along. Shown only in the mode that reads it -
+					    outside `slow` the value is one the issuer never consults. */}
+					{issuer.failureMode === "slow" && (
+						<IssuerDelayControl
+							// Keyed on what the engine is serving, so a value changed
+							// elsewhere (an MCP tool, a curl) re-seeds the draft by
+							// remount rather than by an effect - the same way
+							// `CannedResponseControls` is keyed in the inbox tab.
+							key={issuer.slowMs}
+							issuerId={issuer.issuerId}
+							slowMs={issuer.slowMs}
+							pending={updateIssuer.isPending}
+							onApply={(slowMs) => update({ slowMs })}
+						/>
+					)}
 				</div>
 			)}
 		</>
 	);
+}
+
+/**
+ * The delay `slow` mode answers after.
+ *
+ * Committed on blur and on Enter rather than per keystroke: every character of
+ * "2000" is a valid number, so a live-committing field would send 2, then 20,
+ * then 200 - three `PUT`s reconfiguring a running listener on the way to the
+ * one the user meant. An out-of-range value is refused here with the bound
+ * named, because the engine answers it with a `400 mock_issuer_invalid_config`
+ * that says nothing about which field.
+ */
+function IssuerDelayControl({
+	issuerId,
+	slowMs,
+	pending,
+	onApply,
+}: {
+	issuerId: string;
+	slowMs: number;
+	pending: boolean;
+	onApply: (slowMs: number) => void;
+}) {
+	const [draft, setDraft] = useState(String(slowMs));
+	const value = Number(draft);
+	const valid = Number.isInteger(value) && value >= 0 && value <= MAX_SLOW_MS;
+	const errorId = `issuer-${issuerId}-slow-error`;
+
+	const commit = () => {
+		if (!valid || value === slowMs) return;
+		onApply(value);
+	};
+
+	return (
+		<div className="py-1">
+			<label className="flex items-center gap-2">
+				<span className="text-xs text-muted-foreground">Delay</span>
+				<Input
+					type="number"
+					min={0}
+					max={MAX_SLOW_MS}
+					step={100}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
+					onBlur={commit}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") commit();
+					}}
+					disabled={pending}
+					aria-invalid={!valid}
+					aria-describedby={valid ? undefined : errorId}
+					className="h-7 flex-1 text-xs"
+				/>
+				<span className="text-xs text-muted-foreground">ms</span>
+			</label>
+			{!valid && (
+				<p id={errorId} className="pt-1 text-xs text-destructive-text">
+					{`A whole number of milliseconds, 0 to ${MAX_SLOW_MS}.`}
+				</p>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Which row was just created, for as long as it takes to notice it.
+ *
+ * Creating an inbox reported nothing at all: the mutation carried an `onError`
+ * and no `onSuccess`, and the new row landed wherever its ephemeral port sorted
+ * rather than at the end, so the only evidence a click had done anything was a
+ * row count nobody was counting. The timer is cleared on unmount and restarted
+ * per flash, so switching drawer views mid-flash leaves nothing running.
+ */
+function useRowFlash() {
+	const [flashedId, setFlashedId] = useState<string | null>(null);
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => () => clearTimeout(timer.current ?? undefined), []);
+
+	const flash = (id: string) => {
+		clearTimeout(timer.current ?? undefined);
+		setFlashedId(id);
+		timer.current = setTimeout(() => setFlashedId(null), TIMING.ROW_FLASH_MS);
+	};
+
+	return { flashedId, flash };
 }
 
 export default function ServicesPanel() {
@@ -401,6 +567,7 @@ export default function ServicesPanel() {
 	const startInbox = useStartInboxMutation();
 	const [expandedIssuerId, setExpandedIssuerId] = useState<string | null>(null);
 	const [newIssuerOpen, setNewIssuerOpen] = useState(false);
+	const { flashedId: flashedInboxId, flash: flashInbox } = useRowFlash();
 
 	const inboxes = inboxesQuery.data ?? [];
 	const issuers = issuersQuery.data ?? [];
@@ -415,10 +582,24 @@ export default function ServicesPanel() {
 	const showInboxError = inboxesQuery.isError && inboxes.length === 0;
 	const showIssuerError = issuersQuery.isError && issuers.length === 0;
 
+	/*
+	 * By port. The engine lists inboxes in map order, which is not stable across
+	 * polls, so a row could move while being read and a new one arrived
+	 * anywhere. The record carries no creation stamp - checked, and #555's
+	 * decision is that it does not gain one (see the module doc) - and port is
+	 * the stable key it does have. Same ordering the inbox tab's switcher uses,
+	 * so the two lists cannot disagree about what order inboxes are in.
+	 */
+	const orderedInboxes = [...inboxes].sort((a, b) => a.port - b.port);
+
 	const start = () =>
 		startInbox.mutate(
 			{},
 			{
+				onSuccess: (started) => {
+					showToast(`Inbox started on port ${started.port}`, "success");
+					flashInbox(started.inboxId);
+				},
 				onError: (error) =>
 					showToast(
 						error instanceof Error ? error.message : "Could not start the inbox",
@@ -462,7 +643,13 @@ export default function ServicesPanel() {
 							title="No inbox yet. Start one for a local URL that records every request sent to it - no tunnel, no third party."
 						/>
 					) : (
-						inboxes.map((inbox) => <InboxRow key={inbox.inboxId} inbox={inbox} />)
+						orderedInboxes.map((inbox) => (
+							<InboxRow
+								key={inbox.inboxId}
+								inbox={inbox}
+								flashed={inbox.inboxId === flashedInboxId}
+							/>
+						))
 					)}
 				</ServiceGroup>
 

--- a/app/src/modules/services/useRunningServices.ts
+++ b/app/src/modules/services/useRunningServices.ts
@@ -16,13 +16,25 @@
  *
  * Both reads go through the same query keys the drawer uses, so mounting this
  * in the Dock costs one shared poll, not a second set of requests.
+ *
+ * **A dead engine is running nothing, whatever the cache still holds.** Both
+ * lists are engine-*process* state, so when the engine goes down every service
+ * it was holding went down with it - but TanStack keeps the last good data
+ * through failed refetches, which is right for a list the user can still read
+ * and wrong for a count that claims something is listening. The Dock said "2
+ * services" in green beside its own "Disconnected" light. The gate lives here
+ * rather than at the one call site because the count is what is untrue: any
+ * later reader inherits the answer instead of re-deriving the caveat.
  */
 
 import { useInboxesQuery, useMockIssuersQuery } from "@/queries";
+import { useEngineStore } from "@/stores";
 
 export function useRunningServiceCount(): number {
+	const isEngineConnected = useEngineStore((s) => s.isEngineConnected);
 	const { data: inboxes = [] } = useInboxesQuery();
 	const { data: issuers = [] } = useMockIssuersQuery();
 
+	if (!isEngineConnected) return 0;
 	return inboxes.filter((inbox) => inbox.running).length + issuers.length;
 }

--- a/app/src/stores/layout-store.ts
+++ b/app/src/stores/layout-store.ts
@@ -75,6 +75,18 @@ interface LayoutState {
 	setDrawerView: (view: DrawerView) => void;
 	/** Open the drawer to a specific view, or toggle it closed if already on that view */
 	activateDrawerView: (view: DrawerView) => void;
+	/**
+	 * Show a view, never hide it - the non-toggling half of the pair above.
+	 *
+	 * `activateDrawerView` toggles when the drawer is already on that view,
+	 * which is right for a switcher pressed twice and wrong for anything that
+	 * *points at* a view: a palette result, or an ambient status chip that says
+	 * something is running. Both of those had hand-rolled the pair
+	 * (`setDrawerOpen(true)` then `setDrawerView`), and the Dock's
+	 * running-services indicator had not - so clicking it with the drawer
+	 * already on Services closed the one surface that could act on them.
+	 */
+	revealDrawerView: (view: DrawerView) => void;
 	setDrawerWidth: (width: number) => void;
 
 	setContextBarOpen: (open: boolean) => void;
@@ -112,6 +124,7 @@ export const useLayoutStore = create<LayoutState>()(
 					drawerView: view,
 					drawerOpen: s.drawerView === view ? !s.drawerOpen : true,
 				})),
+			revealDrawerView: (view) => set({ drawerView: view, drawerOpen: true }),
 			setDrawerWidth: (width) =>
 				set({ drawerWidth: Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, width)) }),
 

--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -81,6 +81,18 @@ if (hasDom && typeof Element.prototype.setPointerCapture !== "function") {
 	};
 }
 
+/*
+ * jsdom has no layout, so it implements no scrolling either and
+ * `scrollIntoView` is absent from `Element.prototype`. Radix's Select calls it
+ * on the option it is about to highlight when a listbox opens, so without this
+ * the *whole* open throws - the value never changes and the failure surfaces
+ * later as "cannot find the field that mode reveals", nowhere near the cause.
+ * A no-op is the honest stub: there is nothing to scroll.
+ */
+if (hasDom && typeof Element.prototype.scrollIntoView !== "function") {
+	Element.prototype.scrollIntoView = function scrollIntoView() {};
+}
+
 if (typeof globalThis.ResizeObserver === "undefined") {
 	globalThis.ResizeObserver = class {
 		observe() {}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -219,7 +219,7 @@ Footer bar (h-8, shrink-0). Horizontal layout:
 
 - **Left - drawer switchers:** buttons for Collections (⇧⌘E), History (⇧⌘H), Variables (⇧⌘U), Services (⇧⌘S), Settings (⌘,). Each activates its Drawer view; active state highlights when the drawer is open on that view. Settings sits here too because it is now a Drawer view like the rest.
 - **Middle - ambient status:** engine connection status (green dot + text if connected), save status (Saving… / Saved), app version. When the engine is *down* the indicator becomes a focusable tooltip carrying `engineError` - the health poll's reason, which was previously recorded and rendered nowhere, so a refused connection, a timeout and a TLS failure all read as one word. A save *failure* is not shown here - it is reported as a toast, like every other failure in the app.
-- **Middle - running services:** a dot plus "2 services" whenever at least one local service (a running webhook inbox, an OAuth issuer) is up, and **nothing at all when none is** - the Dock's middle is ambient, and a standing "0 services" would spend a permanent line on the ordinary case. Clicking it activates the Services drawer, which is where a service can be read, copied or stopped. Before it, a running inbox was invisible outside its own tab and an issuer was invisible everywhere. → `Dock.services.test.tsx` (mutation-checked: rendered unconditionally, the absent-case tests fail).
+- **Middle - running services:** a dot plus "2 services" whenever at least one local service (a running webhook inbox, an OAuth issuer) is up, and **nothing at all when none is** - the Dock's middle is ambient, and a standing "0 services" would spend a permanent line on the ordinary case. A **disconnected engine counts as none**, whatever the query cache still holds: services are engine-*process* state, so they died with it, and the gate lives in `useRunningServiceCount` rather than here so no later reader has to re-derive the caveat. Clicking it **reveals** the Services drawer (`revealDrawerView`, never `activateDrawerView`) - an ambient chip pointing at a surface must not be the thing that hides it, and on the toggling call it closed the drawer whenever it was already on Services. Before it, a running inbox was invisible outside its own tab and an issuer was invisible everywhere. → `Dock.services.test.tsx` (mutation-checked: rendered unconditionally, the absent-case tests fail; on `activateDrawerView`, the reveal case fails).
 - **Middle - pending restart:** once a setting the engine marks `requiresRestart` has been saved, a "Restart pending" button appears beside the connection status and restarts the engine in place (`useEngineRestart`, shared with the Settings banner so the two cannot diverge). It tracks saves made since this renderer connected - not a comparison against the engine's running values, which it does not report - so it says *saved*, not *in effect*, and does not survive a renderer reload. A failed restart leaves the signal standing and reports the reason as a toast.
 - **Right - toggles:** Context bar toggle (⌘I). Pressed when the bar is open *and* the active tab is one it has content for, so the highlight always matches what is on screen.
 
@@ -482,7 +482,11 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   `Select` in the header, shown only when more than one inbox exists (with one, it could pick only
   what is already on screen) and ordered by port - the engine lists in map order, which is not
   stable across polls, and a switcher whose entries move under the pointer is worse than none. An
-  inbox record carries no creation stamp; whether it should is #555's decision.
+  inbox record carries no creation stamp and does not gain one - #555 answered that, and the
+  Services drawer orders by port for the same reason. Every mutation this tab owns reports its
+  failure as a toast (`reportFailure`), which is the one discipline the whole inbox lifecycle
+  follows; Stop and Clear used to pass no `onError` at all (#555, item 7 - taken here rather than in
+  #556's tab pass, which both issues named as the shared brush).
 - `CannedResponseControls.tsx` - reply status and delay. Its own component so the two fields can be
   drafts (typing `50` on the way to `500` must not push a 50 at the next caller) and so re-seeding
   them from the engine is a remount - `InboxView` keys it on the served values - rather than a
@@ -546,18 +550,42 @@ both activate it.
   service would give you - this drawer is also the features' discoverability. An inbox row opens the
   inbox *tab* (the drawer lists, the tab shows the captures) and carries copy, stop (running rows
   only) and **delete** (every row); an issuer row expands in place to its token and authorize URLs,
-  a copy for the HS256 signing key, its configuration in one line, and a live `failureMode` switch.
+  a copy for the HS256 signing key, its configuration in one line, a live `failureMode` switch, and
+  - in `slow` only - the delay that mode answers after, committed on blur rather than per keystroke.
   The inbox group's affordance is **New inbox** (Plus), matching **New issuer**: it always mints a
   new listener, and as a Play labelled "Start inbox" beside a stopped row it read as "restart that
   one", which nothing here does (issue #553). Mock servers (#481) get a third group when they exist - deliberately no
   placeholder until then.
+
+  Row semantics, all from issue #555. An inbox row **leads with `Port NNNN`** and demotes the URL
+  behind it: the port is the part that varies and the part a user names an inbox by, while three
+  full URLs are three near-identical monospace strings differing in one digit. The URL is still on
+  the row and also rides the copy control's tooltip, which says so when the inbox is **stopped** -
+  a stopped inbox's URL copies perfectly well and then refuses connections, a long way from the
+  cause. Rows are ordered **by port**, because the engine lists them in map order (not stable across
+  polls) and the record carries no creation stamp; the inbox tab's switcher orders the same way.
+  Creating one **toasts and flashes** the new row for `TIMING.ROW_FLASH_MS` - it lands wherever its
+  ephemeral port sorts, not at the end. The activator's verb is `sr-only` text **prefixed to** the
+  row's content, never an `aria-label`: a label *replaces* the content in the accessible name, so
+  the URL, `Stopped`, and the reachable-beyond-this-machine badge were all inaudible and a stopped
+  row read identically to a running one.
+
+  **No user-editable inbox name** (#555's stated decision point, answered *no*). A name would be an
+  engine field - `InboxInfo` carries none, so it would need storage, a `PUT /inbox/:id` key and a
+  wire-shape change - to label something whose whole identity is already the port it holds. `Port
+  NNNN` ships instead and needs nothing from the engine. Revisit only if inboxes ever outlive the
+  engine process, where a port is no longer a stable name.
 - `NewIssuerDialog.tsx` - the start form: token lifetime, failure mode (plus its delay), and a JSON
   claims box. Everything is validated before it is sent, because the engine refuses a bad config
   with a `400` rather than falling back to a default, and a claims typo is otherwise invisible until
-  a token comes back without the claim. Mounted only while open, so the mount is the reset.
+  a token comes back without the claim. Every refusal **names its bound in words**: a reddened field
+  beside a greyed-out Start says something is wrong and never which field or why, and `aria-invalid`
+  alone announces "invalid" with no correction. Mounted only while open, so the mount is the reset.
 - `useRunningServices.ts` - `useRunningServiceCount()`, shared by the drawer and the Dock. One place
   because the two lists disagree on their own terms: a stopped inbox stays listed with
-  `running: false`, while a stopped issuer is gone from the engine's list entirely.
+  `running: false`, while a stopped issuer is gone from the engine's list entirely - and because a
+  **disconnected engine is running none of them**, which is the gate this hook holds so that no
+  caller renders a green count off a stale cache (issue #555).
 - `failure-modes.ts` - the four `failureMode` labels, the engine's bounds, and the row's
   one-line summary. Shared so the badge, the live switch and the dialog cannot name a mode
   differently.


### PR DESCRIPTION
## Description

The seven verified defects from the 2026-08-13 services-drawer review, batched (#555), plus the three small items the issue listed as also in scope.

**Plan.** The root cause under most of these is one shape: a surface that reports state it has not actually checked. The indicator counted a warm cache instead of a live engine; the create path reported nothing and then let the new row sort anywhere; the copy hook reported success before the write resolved; `aria-label` reported a row's identity while silencing everything the row said. So each fix moves the claim to where the truth is - the count gate lives in `useRunningServiceCount` (the count is what is untrue, so no later reader has to re-derive the caveat), the copy toast lives behind the `await`, the accessible name is composed from the content rather than replacing it. The alternative I rejected for the indicator was gating in the Dock, where the issue suggested it: it fixes the one caller and leaves the hook still willing to answer "2 services" for a dead engine.

Item-by-item against the issue:

1. **Dock indicator lied on a dead engine** - `useRunningServiceCount` returns 0 when `isEngineConnected` is false. Services are engine-*process* state, so they died with it; TanStack's last-good data is right for a list you can still read and wrong for a count claiming something is listening.
2. **Indicator click closed the drawer** - the store gains `revealDrawerView`, the non-toggling half of `activateDrawerView`. The palette had hand-rolled that pair inline (`setDrawerOpen(true)` + `setDrawerView`) and now shares the primitive, so there are not three implementations of "reveal" with a fourth on the way.
3. **Silent create, arbitrary position** - the start mutation gains an `onSuccess` that toasts with the port and flashes the new row (`TIMING.ROW_FLASH_MS`). Rows order by port.
4. **Anonymous rows** - rows lead with `Port NNNN` and demote the URL behind it; the copy control's tooltip carries the URL too.
5. **`aria-label` hid the row** - the verb is now `sr-only` text *prefixed* to the content, so the name reads "Open inbox Port 41234 http://… Stopped" instead of replacing all of it.
6. **Copy reported unconditionally** - `useCopy` awaits and toasts the failure. A stopped inbox's copy control says its listener is gone.
7. **Two error disciplines** - the inbox tab's Stop and Clear gain `onError` toasts via a local `reportFailure`. **Taken here**, not in #556's tab pass; both issues named this as the shared brush for whichever landed second.

Also in scope, as the issue listed: the New issuer dialog's two numeric fields state their bound in words (`aria-invalid` alone announces "invalid" with no correction); the expanded issuer gains the `slowMs` control the engine's `PUT` has always accepted, shown only in `slow` and committed on blur/Enter so "5000" is not sent as 5, 50, 500; and that expanded block declares `surface-sunken`.

### Deliberate deviations, both stated with reasons

- **The name-field decision point is answered *no*.** `InboxInfo` carries no name and no creation stamp (verified in `engine/include/vayu/http/inbox.hpp` and the `inbox_info_json` writer). A name would mean engine storage, a `PUT /inbox/:id` key and a wire-shape change, to label something whose whole identity already *is* the port it holds. `Port NNNN` ships and needs nothing from the engine. Recorded in `docs/app/COMPONENTS.md` with the condition to revisit under: if inboxes ever outlive the engine process, a port stops being a stable name. This also settles the open question `modules/inbox/index.tsx` left pointing at #555.
- **The `border-rule` item was verified rather than taken on trust,** and the diagnosis shifted. `:root` *does* declare a default `--rule` documented as reading on the canvas and on `--panel`, so this was not an undeclared fallback - but the measurement behind that claim was taken against `--background`. Against `--panel` in dark (L 7% under a rule at L 10%) it computes to **1.07**, against the design system's ~1.29 target. Rather than invent a `.surface-panel` class and re-tune a token every drawer view inherits, I used the app's existing idiom for a nested detail slab (`surface-sunken`, as `CookiesCard`, `ClientErrorView` and `ScriptSection` all do) - which declares its own rule at 1.343 dark and is what this block *is*.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all four green.

- **App suite: 4338 passed, 425 files.** No pre-existing failures on this base.
- `ServicesPanel.test.tsx` 20 → 35 cases; `Dock.services.test.tsx` 6 → 9; new `InboxView.errors.test.tsx` (4).
- Format check was run per-file: all eleven files I touched were prettier-clean at `HEAD` before I formatted them, so nothing else in the tree was reflowed.

Every fix is **mutation-checked** - the fix reverted, the suite run, the fix restored:

| Reverted | Result |
|---|---|
| the `isEngineConnected` gate | 1 failed |
| `revealDrawerView` → `activateDrawerView` | 2 failed |
| `sr-only` verb → `aria-label` | 3 failed |
| `orderedInboxes` → `inboxes` | 1 failed |
| the copy `await`/`catch` | 1 failed |
| the start `onSuccess` | 2 failed |
| the tab's two `onError`s | 3 failed |

One test-infrastructure note: `scrollIntoView` joins the jsdom shims in `src/test/setup.ts`. Radix's Select calls it on the option it highlights when a listbox opens, so without it the *entire* open throws and the failure surfaces later as "cannot find the field that mode reveals" - a long way from the cause.

No engine changes, so no engine build or ctest run: the diff is renderer TypeScript and one Markdown file.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit (`docs/app/COMPONENTS.md`): the Dock's running-services paragraph (the connectivity gate and reveal-not-toggle), the Services section (row labelling, ordering, flash, the `sr-only` name rule, the delay control, the recorded name decision), the `useRunningServices` and `NewIssuerDialog` entries, and the inbox tab's entry - whose "whether it should is #555's decision" line is now answered rather than left dangling.

## Related Issues

Closes #555

---
_Generated by [Claude Code](https://claude.ai/code/session_016CKZWGPt5CsJKAeM9CX94c)_