### PR TITLE
refactor(app/key-value): the key/value table takes its variable scope as a prop, so it can leave the request builder

### DIFF
--- a/app/src/modules/inbox/CannedResponseControls.test.tsx
+++ b/app/src/modules/inbox/CannedResponseControls.test.tsx
@@ -30,6 +30,15 @@ function response(overrides: Partial<InboxCannedResponse> = {}): InboxCannedResp
 	return { status: 200, body: "", headers: {}, delayMs: 0, ...overrides };
 }
 
+/*
+ * The reply headers are `KeyValueEditor` rows now, not hand-rolled `Input`
+ * pairs (#564) - so they are labelled by the table's placeholders and the table
+ * always keeps one trailing blank row to type into, in place of the panel's own
+ * "Add header" button.
+ */
+const headerName = (row: number) => screen.getAllByLabelText("Name")[row];
+const headerValue = (row: number) => screen.getAllByLabelText("Value")[row];
+
 /** The message the panel just refused with. */
 function lastToastMessage(): string | undefined {
 	const { toasts } = useToastStore.getState();
@@ -56,20 +65,16 @@ describe("every field the engine serves", () => {
 		);
 
 		expect(screen.getByLabelText("Reply body")).toHaveValue('{"ok":true}');
-		expect(screen.getByLabelText("Reply header 1 name")).toHaveValue("X-Trace");
-		expect(screen.getByLabelText("Reply header 1 value")).toHaveValue("abc");
+		expect(headerName(0)).toHaveValue("X-Trace");
+		expect(headerValue(0)).toHaveValue("abc");
 
 		fireEvent.change(screen.getByLabelText("Reply status"), { target: { value: "503" } });
 		fireEvent.change(screen.getByLabelText("Reply delay (ms)"), { target: { value: "250" } });
 		fireEvent.change(screen.getByLabelText("Reply body"), { target: { value: "retry later" } });
-		fireEvent.change(screen.getByLabelText("Reply header 1 value"), {
-			target: { value: "def" },
-		});
-		fireEvent.click(screen.getByRole("button", { name: "Add header" }));
-		fireEvent.change(screen.getByLabelText("Reply header 2 name"), {
-			target: { value: "Retry-After" },
-		});
-		fireEvent.change(screen.getByLabelText("Reply header 2 value"), { target: { value: "5" } });
+		fireEvent.change(headerValue(0), { target: { value: "def" } });
+		// The trailing blank row is where a new header is typed - no add button.
+		fireEvent.change(headerName(1), { target: { value: "Retry-After" } });
+		fireEvent.change(headerValue(1), { target: { value: "5" } });
 		fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
 		// Whole, not a diff: the route is a merge-patch, so a field left out of
@@ -93,7 +98,7 @@ describe("every field the engine serves", () => {
 			/>
 		);
 
-		fireEvent.click(screen.getByRole("button", { name: "Remove reply header 1" }));
+		fireEvent.click(screen.getAllByLabelText("Remove row")[0]);
 		fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 		// An omitted `headers` is what the engine reads as "keep what you have",
 		// which is how a deleted header comes back on the next apply.
@@ -139,7 +144,7 @@ describe("input the engine would refuse", () => {
 			/>
 		);
 
-		fireEvent.change(screen.getByLabelText("Reply header 1 value"), { target: { value: "v" } });
+		fireEvent.change(headerValue(0), { target: { value: "v" } });
 		fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 		expect(onApply).not.toHaveBeenCalled();
 		expect(lastToastMessage()).toMatch(/needs a name/);
@@ -156,11 +161,8 @@ describe("input the engine would refuse", () => {
 			/>
 		);
 
-		fireEvent.click(screen.getByRole("button", { name: "Add header" }));
-		fireEvent.change(screen.getByLabelText("Reply header 2 name"), {
-			target: { value: "X-Trace" },
-		});
-		fireEvent.change(screen.getByLabelText("Reply header 2 value"), { target: { value: "b" } });
+		fireEvent.change(headerName(1), { target: { value: "X-Trace" } });
+		fireEvent.change(headerValue(1), { target: { value: "b" } });
 		fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
 		expect(onApply).not.toHaveBeenCalled();
@@ -188,7 +190,9 @@ describe("a stopped inbox", () => {
 		expect(screen.getByLabelText("Reply delay (ms)")).toBeDisabled();
 		expect(screen.getByLabelText("Reply body")).toBeDisabled();
 		expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
-		expect(screen.getByRole("button", { name: "Add header" })).toBeDisabled();
+		expect(headerName(0)).toBeDisabled();
+		expect(headerValue(0)).toBeDisabled();
+		expect(screen.getAllByLabelText("Remove row")[0]).toBeDisabled();
 		expect(screen.getByText(/stopped, so nothing is being served/)).toBeInTheDocument();
 	});
 
@@ -206,6 +210,43 @@ describe("a stopped inbox", () => {
 
 		expect(screen.getByLabelText("Reply status")).toHaveValue("503");
 		expect(screen.getByLabelText("Reply body")).toHaveValue("gone");
-		expect(screen.getByLabelText("Reply header 1 name")).toHaveValue("X-Trace");
+		expect(headerName(0)).toHaveValue("X-Trace");
+	});
+});
+
+describe("the key/value table it borrows", () => {
+	/*
+	 * The point of #564. These rows were plain `Input` pairs because
+	 * `KeyValueRow` called `useRequestBuilderContext()` in its body and that
+	 * hook throws with no provider above it - so the app's key/value primitive,
+	 * and every fix that lands in it, could not reach this panel. Restore the
+	 * hook and this whole file fails to render.
+	 */
+	it("mounts with no RequestBuilderProvider anywhere above it", () => {
+		render(
+			<CannedResponseControls
+				response={response({ headers: { "X-Trace": "abc" } })}
+				pending={false}
+				stopped={false}
+				onApply={vi.fn()}
+			/>
+		);
+		expect(headerName(0)).toHaveValue("X-Trace");
+	});
+
+	it("offers no variable affordances, because a canned reply has no scope", () => {
+		// `{{trace}}` is sent verbatim by the engine. A token here would colour
+		// it "not defined" and open an editor with nowhere to write.
+		const { container } = render(
+			<CannedResponseControls
+				response={response({ headers: { "X-Trace": "{{trace}}" } })}
+				pending={false}
+				stopped={false}
+				onApply={vi.fn()}
+			/>
+		);
+		expect(headerValue(0)).toHaveValue("{{trace}}");
+		expect(container.querySelector("[data-variable-token]")).toBeNull();
+		expect(container.querySelector('[aria-label^="Resolved value of"]')).toBeNull();
 	});
 });

--- a/app/src/modules/inbox/CannedResponseControls.tsx
+++ b/app/src/modules/inbox/CannedResponseControls.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useState } from "react";
-import { ChevronDown, Plus, Trash2 } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import {
 	Button,
 	Collapsible,
@@ -30,6 +30,9 @@ import {
 	Label,
 	Textarea,
 } from "@/components/ui";
+import KeyValueEditor from "@/modules/request-builder/shared/KeyValueEditor";
+import { toKeyValueItems } from "@/modules/request-builder/utils/key-value";
+import type { KeyValueItem } from "@/modules/request-builder/types";
 import { useToastStore } from "@/stores";
 import { cn } from "@/lib/utils";
 import type { InboxCannedResponse } from "@/types";
@@ -44,15 +47,20 @@ import type { InboxCannedResponse } from "@/types";
  */
 const MAX_RESPONSE_DELAY_MS = 30000;
 
-/** One header draft. `id` keys the row across edits; the name may still be blank. */
-interface HeaderDraft {
-	id: number;
-	name: string;
-	value: string;
-}
-
-function toDrafts(headers: Record<string, string>): HeaderDraft[] {
-	return Object.entries(headers).map(([name, value], index) => ({ id: index, name, value }));
+/**
+ * The served header set as editor rows, with the trailing blank row the table
+ * always keeps.
+ *
+ * `KeyValueEditor` is the app's key/value table and these rows used to be a
+ * hand-rolled pair of `Input`s, because `KeyValueRow` threw outside
+ * `RequestBuilderProvider` (#564). No `variables` is passed: a canned reply has
+ * no variable scope, so nothing resolves and no `{{` autocomplete opens - which
+ * is what a header set the engine echoes verbatim actually is.
+ */
+function toHeaderRows(headers: Record<string, string>): KeyValueItem[] {
+	return toKeyValueItems(
+		Object.entries(headers).map(([key, value]) => ({ key, value, enabled: true }))
+	);
 }
 
 interface CannedResponseControlsProps {
@@ -77,8 +85,8 @@ export function CannedResponseControls({
 	const [statusDraft, setStatusDraft] = useState(String(response.status));
 	const [delayDraft, setDelayDraft] = useState(String(response.delayMs));
 	const [bodyDraft, setBodyDraft] = useState(response.body);
-	const [headerDrafts, setHeaderDrafts] = useState<HeaderDraft[]>(() =>
-		toDrafts(response.headers)
+	const [headerRows, setHeaderRows] = useState<KeyValueItem[]>(() =>
+		toHeaderRows(response.headers)
 	);
 	// Open when there is something to see: a configured body or header set is
 	// part of what the inbox answers with, and a reader who has to go looking
@@ -88,24 +96,6 @@ export function CannedResponseControls({
 	);
 
 	const disabled = stopped || pending;
-
-	const updateHeader = (id: number, field: "name" | "value", next: string) =>
-		setHeaderDrafts((drafts) =>
-			drafts.map((draft) => (draft.id === id ? { ...draft, [field]: next } : draft))
-		);
-
-	const addHeader = () =>
-		setHeaderDrafts((drafts) => [
-			...drafts,
-			{
-				id: drafts.reduce((max, draft) => Math.max(max, draft.id), -1) + 1,
-				name: "",
-				value: "",
-			},
-		]);
-
-	const removeHeader = (id: number) =>
-		setHeaderDrafts((drafts) => drafts.filter((draft) => draft.id !== id));
 
 	/**
 	 * Read the four drafts back, or say which one is wrong.
@@ -132,12 +122,12 @@ export function CannedResponseControls({
 		// A Map, not an object literal, so a header literally named `__proto__`
 		// is a header rather than an assignment nobody meant.
 		const headers = new Map<string, string>();
-		for (const draft of headerDrafts) {
-			const name = draft.name.trim();
-			// A wholly blank row is a row the user added and did not fill; a value
-			// with no name is an edit that would silently go nowhere, since the
-			// engine keys headers by name.
-			if (name === "" && draft.value === "") continue;
+		for (const row of headerRows) {
+			const name = row.key.trim();
+			// A wholly blank row is the table's trailing spare, or one the user
+			// added and did not fill; a value with no name is an edit that would
+			// silently go nowhere, since the engine keys headers by name.
+			if (name === "" && row.value === "") continue;
 			if (name === "") {
 				showToast("A reply header needs a name", "error");
 				return null;
@@ -146,7 +136,7 @@ export function CannedResponseControls({
 				showToast(`Reply header "${name}" is set twice`, "error");
 				return null;
 			}
-			headers.set(name, draft.value);
+			headers.set(name, row.value);
 		}
 
 		// Sent whole, not as a diff. The route is a merge-patch, so an omitted
@@ -160,7 +150,7 @@ export function CannedResponseControls({
 		if (next) onApply(next);
 	};
 
-	const headerCount = headerDrafts.filter((draft) => draft.name.trim() !== "").length;
+	const headerCount = headerRows.filter((row) => row.key.trim() !== "").length;
 
 	return (
 		<Collapsible
@@ -241,48 +231,20 @@ export function CannedResponseControls({
 
 					<div className="flex flex-col gap-1">
 						<span className="text-xs font-medium">Reply headers</span>
-						{headerDrafts.map((draft) => (
-							<div key={draft.id} className="flex items-center gap-2">
-								<Input
-									className="h-7 flex-1 font-mono text-xs"
-									value={draft.name}
-									disabled={disabled}
-									placeholder="Name"
-									aria-label={`Reply header ${draft.id + 1} name`}
-									onChange={(e) => updateHeader(draft.id, "name", e.target.value)}
-								/>
-								<Input
-									className="h-7 flex-1 font-mono text-xs"
-									value={draft.value}
-									disabled={disabled}
-									placeholder="Value"
-									aria-label={`Reply header ${draft.id + 1} value`}
-									onChange={(e) =>
-										updateHeader(draft.id, "value", e.target.value)
-									}
-								/>
-								<Button
-									variant="ghost"
-									size="sm"
-									className="h-7 px-2"
-									disabled={disabled}
-									aria-label={`Remove reply header ${draft.id + 1}`}
-									onClick={() => removeHeader(draft.id)}
-								>
-									<Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-								</Button>
-							</div>
-						))}
-						<Button
-							variant="ghost"
-							size="sm"
-							className="h-7 self-start"
-							disabled={disabled}
-							onClick={addHeader}
-						>
-							<Plus className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
-							Add header
-						</Button>
+						{/*
+						 * No `allowDisable`: a canned header is either in the set the
+						 * engine serves or it is not, and a third "present but off"
+						 * state would be a row the panel keeps and the reply never
+						 * carries. Removing the row is the whole vocabulary.
+						 */}
+						<KeyValueEditor
+							items={headerRows}
+							onChange={setHeaderRows}
+							keyPlaceholder="Name"
+							valuePlaceholder="Value"
+							allowDisable={false}
+							readOnly={disabled}
+						/>
 					</div>
 				</div>
 			</CollapsibleContent>

--- a/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/AuthPanel.tsx
@@ -31,6 +31,7 @@ import { AUTH_MODE_LABELS, EDITABLE_AUTH_MODES, uneditableAuthLabel } from "@/co
 import type { RequestAuth } from "@/types";
 import { useRequestBuilderContext } from "../../../context";
 import VariableInput from "../../../shared/VariableInput";
+import { useVariableSupport } from "../../../hooks/useVariableSupport";
 import AuthInheritBanner from "./AuthInheritBanner";
 
 /** `inherit` first - a request, unlike a collection, may defer to its parent. */
@@ -52,12 +53,22 @@ const AUTH_MODE_ICONS: Record<PickerMode, typeof Key> = {
 // field). Secret fields (client secret / password) instead use the masked
 // SecretInput with a reveal toggle - masking and {{variable}} token highlighting
 // can't coexist, and hiding the secret at rest wins for those fields.
-const VariableTextInput: AuthTextInput = ({ value, onChange, placeholder, type }) =>
-	type === "password" ? (
+// Always mounted inside `RequestBuilderProvider`, so it reads the scope here
+// rather than threading it through every auth field - `VariableInput` itself no
+// longer knows the context exists (#564).
+const VariableTextInput: AuthTextInput = ({ value, onChange, placeholder, type }) => {
+	const variables = useVariableSupport();
+	return type === "password" ? (
 		<SecretInput value={value} onChange={onChange} placeholder={placeholder} />
 	) : (
-		<VariableInput value={value} onChange={onChange} placeholder={placeholder} />
+		<VariableInput
+			value={value}
+			onChange={onChange}
+			placeholder={placeholder}
+			variables={variables}
+		/>
 	);
+};
 
 /** Empty config for a freshly picked mode. */
 function defaultsFor(mode: PickerMode): RequestAuth {

--- a/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.test.tsx
@@ -152,4 +152,20 @@ describe("form-data and urlencoded", () => {
 		const { container } = renderPanel({ bodyMode: mode });
 		expect(container.querySelector('input[type="checkbox"]')).not.toBeNull();
 	});
+
+	/*
+	 * The table takes its variable scope as a prop now, because the hook it used
+	 * to call throws outside `RequestBuilderProvider` and made the primitive
+	 * unusable anywhere else (#564). The thread from context to prop is a wiring
+	 * bug waiting to happen - the row's own tests hand it a scope directly and
+	 * would stay green with `variables={variables}` deleted from this panel.
+	 * Mutation check: delete it and the marker disappears.
+	 */
+	it("hands the table this request's variable scope", () => {
+		const { container } = renderPanel({
+			bodyMode: "form-data",
+			formData: [{ id: "fd1", key: "region", value: "{{zone}}", enabled: true }],
+		});
+		expect(container.querySelector('[aria-label="Resolved value of region"]')).not.toBeNull();
+	});
 });

--- a/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/BodyPanel.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui";
 import { useRequestBuilderContext } from "../../../context";
 import KeyValueEditor from "../../../shared/KeyValueEditor";
+import { useVariableSupport } from "../../../hooks/useVariableSupport";
 import type { BodyMode, KeyValueItem } from "../../../types";
 import { createEmptyKeyValue, toFlatHeaders } from "../../../utils/key-value";
 import { containsVariableToken } from "@/constants/variables";
@@ -162,6 +163,7 @@ export default function BodyPanel() {
 		setAutoContentType,
 		resolvedAuth,
 	} = useRequestBuilderContext();
+	const variables = useVariableSupport();
 	// The environment scoping GraphQL introspection's compose call - the same id
 	// the builder's Send path passes.
 	const activeEnvironmentId = useSessionStore((s) => s.activeEnvironmentId);
@@ -453,6 +455,7 @@ export default function BodyPanel() {
 					// Only multipart can carry a file: urlencoded's wire body is a
 					// string of pairs, and the engine refuses a file part there.
 					allowFiles={request.bodyMode === "form-data"}
+					variables={variables}
 				/>
 			)}
 		</div>

--- a/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/HeadersPanel.tsx
@@ -20,11 +20,13 @@ import { useRequestBuilderContext } from "../../../context";
 import KeyValueEditor, { BulkEditor } from "../../../shared/KeyValueEditor";
 import type { KeyValueItem } from "../../../types";
 import { useHeadersManager } from "../../../hooks/useHeadersManager";
+import { useVariableSupport } from "../../../hooks/useVariableSupport";
 import { STANDARD_HEADERS } from "@/constants/http";
 import { EmptyTableHint } from "./EmptyTableHint";
 
 export default function HeadersPanel() {
 	const { request, updateField } = useRequestBuilderContext();
+	const variables = useVariableSupport();
 
 	const {
 		displayHeaders,
@@ -71,6 +73,7 @@ export default function HeadersPanel() {
 				showResolved={true}
 				allowDisable={true}
 				keySuggestions={STANDARD_HEADERS}
+				variables={variables}
 				canEdit={canEdit}
 				canRemove={canRemove}
 				canDisable={canDisable}

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
@@ -18,6 +18,7 @@ import { useCallback } from "react";
 import { containsVariableToken } from "@/constants/variables";
 import { useRequestBuilderContext } from "../../../context";
 import KeyValueEditor, { BulkEditor } from "../../../shared/KeyValueEditor";
+import { useVariableSupport } from "../../../hooks/useVariableSupport";
 import type { KeyValueItem } from "../../../types";
 import { formatParamsToText, parseParamsFromText } from "../../../utils/params-format";
 import { EmptyTableHint } from "./EmptyTableHint";
@@ -47,6 +48,7 @@ function buildUrlWithParams(baseUrl: string, params: KeyValueItem[]): string {
 
 export default function ParamsPanel() {
 	const { request, updateField, resolveString } = useRequestBuilderContext();
+	const variables = useVariableSupport();
 
 	// Handle params change and sync to URL
 	const handleParamsChange = useCallback(
@@ -101,6 +103,7 @@ export default function ParamsPanel() {
 					valuePlaceholder="Value"
 					showResolved={true}
 					allowDisable={true}
+					variables={variables}
 				/>
 
 				{/*

--- a/app/src/modules/request-builder/components/UrlBar/UrlInput.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/UrlInput.tsx
@@ -16,6 +16,7 @@ import { useCallback } from "react";
 import { detectCommand, parseCommand } from "@/services/curl/parseCurl";
 import { useRequestBuilderContext } from "../../context";
 import VariableInput from "../../shared/VariableInput";
+import { useVariableSupport } from "../../hooks/useVariableSupport";
 import { parseQueryParams } from "../../utils/url";
 
 interface UrlInputProps {
@@ -24,6 +25,7 @@ interface UrlInputProps {
 
 export default function UrlInput({ className }: UrlInputProps) {
 	const { request, updateField, setRequest } = useRequestBuilderContext();
+	const variables = useVariableSupport();
 
 	// Sync params from URL when URL changes directly
 	const handleUrlChange = useCallback(
@@ -69,6 +71,7 @@ export default function UrlInput({ className }: UrlInputProps) {
 			// make a poor spoken name, and it is withheld entirely once the URL
 			// contains a variable.
 			aria-label="Request URL"
+			variables={variables}
 			className={className ?? "w-full"}
 		/>
 	);

--- a/app/src/modules/request-builder/hooks/useVariableSupport.ts
+++ b/app/src/modules/request-builder/hooks/useVariableSupport.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The request builder's own variable scope, in the shape the variable-aware
+ * inputs take as a prop.
+ *
+ * `VariableInput` and `KeyValueEditor` used to reach for
+ * `useRequestBuilderContext()` themselves, which is what made them unusable
+ * outside this module - the hook throws with no provider above it (#564). They
+ * take a `VariableSupport` now, and this is the one adapter from the context to
+ * that shape, rather than a `useMemo` copied into each of the five call sites
+ * inside the builder.
+ *
+ * Memoised on the three members: the object is a prop on a `memo`-wrapped row,
+ * so a fresh identity each render would re-render every row of the densest
+ * table in the app on every keystroke.
+ */
+
+import { useMemo } from "react";
+import type { VariableSupport } from "@/types";
+import { useRequestBuilderContext } from "../context/RequestBuilderContext";
+
+export function useVariableSupport(): VariableSupport {
+	const { resolveString, getAllVariables, getVariableOrigins, updateVariable, writableScopes } =
+		useRequestBuilderContext();
+	return useMemo(
+		() => ({
+			resolveString,
+			getAllVariables,
+			getVariableOrigins,
+			updateVariable,
+			writableScopes,
+		}),
+		[resolveString, getAllVariables, getVariableOrigins, updateVariable, writableScopes]
+	);
+}

--- a/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.test.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.test.tsx
@@ -32,21 +32,19 @@
  * appears, and the row's height.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui";
-import { VARIABLE_PATTERN } from "@/constants/variables";
+import { variableSupportStub } from "@/test/variable-support";
 import KeyValueRow from "./KeyValueRow";
 
-vi.mock("../../context/RequestBuilderContext", () => ({
-	useRequestBuilderContext: () => ({
-		resolveString: (s: string) => s.replace(VARIABLE_PATTERN, (_m, n) => `resolved-${n}`),
-		getAllVariables: () => ({}),
-		getVariableOrigins: () => [],
-		writableScopes: [],
-		updateVariable: () => {},
-	}),
-}));
+/*
+ * The scope arrives as a prop. This file used to `vi.mock` the request-builder
+ * context, which is precisely why nobody noticed the row could not render
+ * without one (#564) - the mock stood in for a provider that every real caller
+ * outside the builder was missing.
+ */
+const scope = variableSupportStub();
 
 function row(overrides: Partial<Parameters<typeof KeyValueRow>[0]> = {}) {
 	const { container } = render(
@@ -60,6 +58,7 @@ function row(overrides: Partial<Parameters<typeof KeyValueRow>[0]> = {}) {
 				showResolved={true}
 				allowDisable={true}
 				readOnly={false}
+				variables={scope}
 				onUpdate={() => {}}
 				onPickFile={() => {}}
 				onToggleKind={() => {}}
@@ -140,6 +139,51 @@ describe("the resolved value", () => {
 	it("is withheld entirely when the caller turns resolution off", () => {
 		const container = row({ showResolved: false });
 		expect(peek(container)).toBeNull();
+	});
+
+	/*
+	 * The mutation check for the prop thread (#564). Drop `variables` at any
+	 * mount site and this row goes from "resolves `{{format}}`" to "shows the
+	 * literal" - which is correct for a surface with no variable scope and
+	 * wrong for the request builder, so the two cases have to be told apart.
+	 */
+	it("resolves through the scope it was handed, not one it reaches for", () => {
+		const marker = peek(row());
+		expect(marker!.getAttribute("aria-label")).toBe("Resolved value of Accept");
+		// The tooltip content only mounts on hover; what proves the thread is
+		// that the marker appeared at all, which needs `resolveString` to have
+		// changed the text.
+		expect(marker).not.toBeNull();
+	});
+
+	it("stays away entirely on a surface with no variable scope", () => {
+		// Not a degraded request builder - an inbox's canned reply headers have
+		// no variables to resolve, so a marker would point at nothing.
+		expect(peek(row({ variables: undefined }))).toBeNull();
+	});
+});
+
+describe("a row with no variable scope at all", () => {
+	/*
+	 * The whole of #564: `KeyValueRow` called `useRequestBuilderContext()` in
+	 * its body and that hook *throws* with no `RequestBuilderProvider` above it,
+	 * so the app's densest table was structurally unavailable to every surface
+	 * that is not the request builder. Restore the hook and this test throws.
+	 */
+	it("renders outside RequestBuilderProvider", () => {
+		const container = row({ variables: undefined });
+		const fields = container.querySelectorAll<HTMLInputElement>('input[type="text"]');
+		expect(fields).toHaveLength(2);
+		expect(fields[0].value).toBe("Accept");
+	});
+
+	it("shows the literal text rather than painting an undefined-variable token", () => {
+		// A `{{format}}` token here would colour as "not defined" and open an
+		// editor with nowhere to write. There is no scope; it is just text.
+		const container = row({ variables: undefined });
+		expect(container.querySelector("[data-variable-token]")).toBeNull();
+		const value = container.querySelectorAll<HTMLInputElement>('input[type="text"]')[1];
+		expect(value.value).toBe("{{format}}");
 	});
 });
 

--- a/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/KeyValueRow.tsx
@@ -14,14 +14,17 @@
  * The resolved value moved out of a column and into `ResolvedPeek` - see the
  * note there for why, and for how it stays out of the way of the variable
  * token's own popover.
+ *
+ * Resolution comes from the optional `variables` prop. With none the row is
+ * still a row: plain fields, no marker, no tokens. See `VariableSupport`.
  */
 
 import { memo } from "react";
 import { Trash2, Sigma, Paperclip, Type } from "lucide-react";
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import type { VariableSupport } from "@/types";
 import type { KeyValueItem } from "../../types";
-import { useRequestBuilderContext } from "../../context/RequestBuilderContext";
 import VariableInput from "../VariableInput";
 import FilePartCell, { type PickedFile } from "./FilePartCell";
 
@@ -35,6 +38,8 @@ interface KeyValueRowProps {
 	keySuggestions?: string[];
 	/** `form-data` only: rows may be switched between a text value and a file. */
 	allowFiles?: boolean;
+	/** The variable scope this row edits inside, or none. See `VariableSupport`. */
+	variables?: VariableSupport;
 	onUpdate: (id: string, field: keyof KeyValueItem, value: string | boolean) => void;
 	/** Sets the file members of one row together - a pick is one edit, not four. */
 	onPickFile: (id: string, file: PickedFile) => void;
@@ -93,6 +98,7 @@ function KeyValueRow({
 	readOnly,
 	keySuggestions,
 	allowFiles = false,
+	variables,
 	onUpdate,
 	onPickFile,
 	onToggleKind,
@@ -102,14 +108,14 @@ function KeyValueRow({
 	canEditValue = true,
 	canDisable = true,
 }: KeyValueRowProps) {
-	const { resolveString } = useRequestBuilderContext();
-
-	const resolvedKey = resolveString(item.key);
-	const resolvedValue = resolveString(item.value);
+	const resolveString = variables?.resolveString;
+	const resolvedKey = resolveString ? resolveString(item.key) : item.key;
+	const resolvedValue = resolveString ? resolveString(item.value) : item.value;
 	/*
 	 * "Contains a variable" is exactly "resolving changed something". A row whose
 	 * text is already literal has nothing to peek at, which is the condition the
-	 * marker keys off.
+	 * marker keys off - and with no scope nothing resolves, so a table outside
+	 * the request builder shows no marker at all rather than an empty one.
 	 */
 	const hasVariables = item.key !== resolvedKey || item.value !== resolvedValue;
 
@@ -162,6 +168,7 @@ function KeyValueRow({
 				placeholder={keyPlaceholder}
 				disabled={keyReadOnly || !item.enabled}
 				suggestions={keySuggestions}
+				variables={variables}
 				className="h-8"
 			/>
 
@@ -179,6 +186,7 @@ function KeyValueRow({
 					onChange={(v) => onUpdate(item.id, "value", v)}
 					placeholder={valuePlaceholder}
 					disabled={valueReadOnly || !item.enabled}
+					variables={variables}
 					className="h-8"
 				/>
 			)}

--- a/app/src/modules/request-builder/shared/KeyValueEditor/file-part-row.test.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/file-part-row.test.tsx
@@ -26,16 +26,6 @@ import { TooltipProvider } from "@/components/ui";
 import KeyValueEditor from "./index";
 import type { KeyValueItem } from "../../types";
 
-vi.mock("../../context/RequestBuilderContext", () => ({
-	useRequestBuilderContext: () => ({
-		resolveString: (s: string) => s,
-		getAllVariables: () => ({}),
-		getVariableOrigins: () => [],
-		writableScopes: [],
-		updateVariable: () => {},
-	}),
-}));
-
 afterEach(() => {
 	vi.unstubAllGlobals();
 });

--- a/app/src/modules/request-builder/shared/KeyValueEditor/index.tsx
+++ b/app/src/modules/request-builder/shared/KeyValueEditor/index.tsx
@@ -27,6 +27,14 @@
  *
  * **The trailing blank row** comes from one `withTrailingBlank` rather than two
  * copies that had drifted.
+ *
+ * **Its variable scope arrives as a prop** (`variables`), not from
+ * `useRequestBuilderContext()`. That hook throws with no provider above it, so
+ * reading it in the row's body made the app's key/value primitive structurally
+ * unmountable anywhere else, and the inbox and the variables module each grew
+ * their own copy (#564). Omit the prop and the table resolves nothing and
+ * offers no autocomplete, which is what a surface with no variables should
+ * show.
  */
 
 import { useCallback } from "react";
@@ -49,6 +57,7 @@ export default function KeyValueEditor({
 	readOnly = false,
 	keySuggestions,
 	allowFiles = false,
+	variables,
 	canEdit = () => true, // Default: allow editing all items
 	canRemove = () => true, // Default: allow removing all items
 	canDisable = () => true, // Default: allow disabling all items
@@ -180,6 +189,7 @@ export default function KeyValueEditor({
 						readOnly={readOnly}
 						keySuggestions={keySuggestions}
 						allowFiles={allowFiles}
+						variables={variables}
 						onUpdate={handleUpdate}
 						onPickFile={handlePickFile}
 						onToggleKind={handleToggleKind}

--- a/app/src/modules/request-builder/shared/VariableInput/EditableVariable.test.tsx
+++ b/app/src/modules/request-builder/shared/VariableInput/EditableVariable.test.tsx
@@ -34,14 +34,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui";
-
-vi.mock("../../context/RequestBuilderContext", () => ({
-	useRequestBuilderContext: () => ({
-		getVariableOrigins: () => [],
-		writableScopes: [],
-		updateVariable: () => {},
-	}),
-}));
+import { variableSupportStub } from "@/test/variable-support";
 
 // Radix only mounts tooltip content while open, and jsdom synthesises no hover.
 // Forcing `open` is the narrowest way to reach the content this file is about.
@@ -66,6 +59,7 @@ function renderToken(props: Partial<React.ComponentProps<typeof EditableVariable
 				scope="environment"
 				resolved
 				sourceName="Staging"
+				variables={variableSupportStub()}
 				{...props}
 			/>
 		</TooltipProvider>

--- a/app/src/modules/request-builder/shared/VariableInput/EditableVariable.tsx
+++ b/app/src/modules/request-builder/shared/VariableInput/EditableVariable.tsx
@@ -24,7 +24,7 @@ import type { VariableScope } from "@/components/ui";
 import { cn } from "@/lib/utils";
 // The specific module, not the `../../context` barrel - matching the sibling
 // `VariableInput/index.tsx`, whose tests mock this exact path.
-import { useRequestBuilderContext } from "../../context/RequestBuilderContext";
+import type { VariableSupport } from "@/types";
 import type { VariableScope as RequestBuilderVariableScope } from "../../types";
 
 export interface EditableVariableProps {
@@ -44,6 +44,12 @@ export interface EditableVariableProps {
 	secret?: boolean;
 	/** The environment or collection it came from. Absent for globals. */
 	sourceName?: string;
+	/**
+	 * The scope this token belongs to. Required, not optional as it is further
+	 * up: a token only renders where there *is* a scope, so the popover always
+	 * has origins to list and writable targets to offer (#564).
+	 */
+	variables: VariableSupport;
 }
 
 export default function EditableVariable({
@@ -55,8 +61,9 @@ export default function EditableVariable({
 	disabled = false,
 	secret = false,
 	sourceName,
+	variables,
 }: EditableVariableProps) {
-	const { getVariableOrigins, writableScopes } = useRequestBuilderContext();
+	const { getVariableOrigins, writableScopes } = variables;
 
 	const varInfo = resolved ? { value, scope: scope as VariableScope, secret, sourceName } : null;
 

--- a/app/src/modules/request-builder/shared/VariableInput/dynamic-variable-token.test.tsx
+++ b/app/src/modules/request-builder/shared/VariableInput/dynamic-variable-token.test.tsx
@@ -23,28 +23,26 @@
  * editable one, not the generator.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui";
-
-const variables: Record<string, { value: string; scope: string }> = {};
-
-vi.mock("../../context/RequestBuilderContext", () => ({
-	useRequestBuilderContext: () => ({
-		getAllVariables: () => variables,
-		getVariableOrigins: () => [],
-		writableScopes: [],
-		updateVariable: () => {},
-		resolveString: (s: string) => s,
-	}),
-}));
-
+import { variableSupportStub } from "@/test/variable-support";
+import type { ResolvedVariable } from "@/types";
 import VariableInput from "./index";
+
+const variables: Record<string, ResolvedVariable> = {};
+
+/*
+ * The scope is a prop now, not a mocked module. This file used to `vi.mock` the
+ * request-builder context because the component reached for it in its body -
+ * the coupling that made the key/value table unmountable anywhere else (#564).
+ */
+const scope = variableSupportStub(variables);
 
 function overlayOf(value: string) {
 	const { container } = render(
 		<TooltipProvider>
-			<VariableInput value={value} onChange={() => {}} placeholder="URL" />
+			<VariableInput value={value} onChange={() => {}} placeholder="URL" variables={scope} />
 		</TooltipProvider>
 	);
 	const overlay = container.querySelector('[aria-hidden="true"]');

--- a/app/src/modules/request-builder/shared/VariableInput/index.tsx
+++ b/app/src/modules/request-builder/shared/VariableInput/index.tsx
@@ -26,7 +26,7 @@ import {
 } from "react";
 import { VariableAutocomplete, SuggestionList } from "@/components/ui";
 import { cn } from "@/lib/utils";
-import { useRequestBuilderContext } from "../../context/RequestBuilderContext";
+import type { ResolvedVariable, VariableSupport } from "@/types";
 import type { VariableScope } from "../../types";
 import EditableVariable from "./EditableVariable";
 import DynamicVariableToken from "./DynamicVariableToken";
@@ -49,7 +49,16 @@ interface VariableInputProps {
 	 * silently left the field anonymous to a screen reader.
 	 */
 	"aria-label"?: string;
+	/**
+	 * The variable scope this field edits inside. Omitted where there is none,
+	 * which makes this a plain text field: no tokens, no `{{` autocomplete, no
+	 * edit popover. See `VariableSupport`.
+	 */
+	variables?: VariableSupport;
 }
+
+/** Stable identity for the no-scope case, so the memos below do not re-run. */
+const NO_VARIABLES: Record<string, ResolvedVariable> = {};
 
 /** The generator table by name, for the overlay's token lookup. */
 const DYNAMIC_BY_NAME = new Map(DYNAMIC_VARIABLES.map((v) => [v.name, v]));
@@ -96,9 +105,8 @@ export default function VariableInput({
 	suggestions = [],
 	onPaste,
 	"aria-label": ariaLabel,
+	variables,
 }: VariableInputProps) {
-	const { getAllVariables, updateVariable } = useRequestBuilderContext();
-
 	const [showSuggestions, setShowSuggestions] = useState(false);
 	const [showPlainSuggestions, setShowPlainSuggestions] = useState(false);
 	const [cursorPosition, setCursorPosition] = useState(0);
@@ -107,9 +115,14 @@ export default function VariableInput({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const isNavigatingRef = useRef(false);
 
-	const allVariables = getAllVariables();
+	const allVariables = variables ? variables.getAllVariables() : NO_VARIABLES;
 	const segments = useMemo(() => parseSegments(value), [value]);
-	const hasVariables = segments.some((s) => s.type === "variable");
+	/*
+	 * With no scope, `{{name}}` is just text: the overlay would paint a token
+	 * claiming the name is undefined, and clicking it would open an editor with
+	 * nowhere to write. The literal the user typed is the honest thing to show.
+	 */
+	const hasVariables = Boolean(variables) && segments.some((s) => s.type === "variable");
 
 	/*
 	 * Check if we should show autocomplete.
@@ -119,16 +132,22 @@ export default function VariableInput({
 	 * file, once for this check and once in `handleSelectVariable` below - which
 	 * is a pair that drifts the moment either is touched.
 	 */
-	const checkForSuggestions = useCallback((inputValue: string, cursorPos: number) => {
-		const context = variableCompletionContext(inputValue.slice(0, cursorPos));
-		if (!context) {
-			setShowSuggestions(false);
-			return;
-		}
-		setSearchQuery(context.query);
-		setShowSuggestions(true);
-		setShowPlainSuggestions(false);
-	}, []);
+	const checkForSuggestions = useCallback(
+		(inputValue: string, cursorPos: number) => {
+			// Nothing to complete from without a scope.
+			const context = variables
+				? variableCompletionContext(inputValue.slice(0, cursorPos))
+				: null;
+			if (!context) {
+				setShowSuggestions(false);
+				return;
+			}
+			setSearchQuery(context.query);
+			setShowSuggestions(true);
+			setShowPlainSuggestions(false);
+		},
+		[variables]
+	);
 
 	const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
 		const newValue = e.target.value;
@@ -297,7 +316,8 @@ export default function VariableInput({
 
 	// Handle variable value change from token popover
 	const handleVariableChange = (name: string, newValue: string, scope: VariableScope) => {
-		updateVariable(name, newValue, scope);
+		// Only reachable from a token, and a token only renders with a scope.
+		variables?.updateVariable(name, newValue, scope);
 	};
 
 	// Focus the hidden input when clicking on the container (but not on variable tokens)
@@ -350,6 +370,9 @@ export default function VariableInput({
 							sourceName={varInfo?.sourceName}
 							onValueChange={handleVariableChange}
 							disabled={disabled}
+							// Non-null by construction: a token only renders under
+							// `hasVariables`, which is false without a scope.
+							variables={variables!}
 						/>
 					</span>
 				);

--- a/app/src/modules/request-builder/shared/VariableInput/variable-token-font.test.tsx
+++ b/app/src/modules/request-builder/shared/VariableInput/variable-token-font.test.tsx
@@ -30,30 +30,27 @@
  * inline style was the only thing that could override the inherited font.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui";
+import { variableSupportStub } from "@/test/variable-support";
 import VariableInput from "./index";
 
-vi.mock("../../context/RequestBuilderContext", () => ({
-	useRequestBuilderContext: () => ({
-		getAllVariables: () => ({
-			base_url: { value: "https://api.example.com", scope: "global" },
-		}),
-		// The token now hovers to a tooltip and its popover lists every other
-		// definition, so the stub owes both of these.
-		getVariableOrigins: () => [],
-		writableScopes: [],
-		updateVariable: () => {},
-		resolveString: (s: string) => s,
-	}),
-}));
+/* Handed in rather than mocked - see the note in dynamic-variable-token.test. */
+const scope = variableSupportStub({
+	base_url: { value: "https://api.example.com", scope: "global" },
+});
 
 /** The input rendered with a variable in it, which is what builds the overlay. */
 function withVariable() {
 	const { container } = render(
 		<TooltipProvider>
-			<VariableInput value="{{base_url}}/users" onChange={() => {}} placeholder="URL" />
+			<VariableInput
+				value="{{base_url}}/users"
+				onChange={() => {}}
+				placeholder="URL"
+				variables={scope}
+			/>
 		</TooltipProvider>
 	);
 	return container;

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -28,6 +28,7 @@ import type {
 	ScriptPart,
 	VariableOrigin,
 	VariableScope,
+	VariableSupport,
 } from "@/types";
 
 // ============================================================================
@@ -398,6 +399,18 @@ export interface KeyValueEditorProps {
 	 * something that cannot be sent.
 	 */
 	allowFiles?: boolean;
+	/**
+	 * The variable scope the table edits inside, handed in by whoever mounts it.
+	 *
+	 * Omitted where there is none - the inbox's canned reply headers, say - and
+	 * the table then resolves nothing, shows no `ResolvedPeek` and offers no
+	 * `{{` autocomplete. That is the correct reading of a surface with no
+	 * variables, not a degraded one. It is a prop rather than a context read
+	 * because the hook that used to supply it *throws* outside
+	 * `RequestBuilderProvider`, which made this table structurally unusable
+	 * anywhere else (#564).
+	 */
+	variables?: VariableSupport;
 	canEdit?: (item: KeyValueItem, field: keyof KeyValueItem) => boolean;
 	canRemove?: (item: KeyValueItem) => boolean;
 	canDisable?: (item: KeyValueItem) => boolean;

--- a/app/src/test/variable-support.ts
+++ b/app/src/test/variable-support.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A variable scope for tests, in the shape the variable-aware inputs take.
+ *
+ * These used to be `vi.mock("../../context/RequestBuilderContext", ...)` blocks
+ * copied into four files - which is why nobody noticed that `VariableInput` and
+ * `KeyValueRow` could not render without a `RequestBuilderProvider` at all
+ * (#564): every test stood one in.
+ *
+ * Resolution is deliberately visible - `{{name}}` becomes `resolved-name` - so
+ * a test can tell "the scope was used" from "the literal was passed through",
+ * which is the whole distinction the prop thread has to keep.
+ */
+
+import { VARIABLE_PATTERN } from "@/constants/variables";
+import type { ResolvedVariable, VariableSupport } from "@/types";
+
+export function variableSupportStub(
+	variables: Record<string, ResolvedVariable> = {},
+	overrides: Partial<VariableSupport> = {}
+): VariableSupport {
+	return {
+		resolveString: (s) => s.replace(VARIABLE_PATTERN, (_m, name) => `resolved-${name}`),
+		getAllVariables: () => variables,
+		getVariableOrigins: () => [],
+		updateVariable: () => {},
+		writableScopes: [],
+		...overrides,
+	};
+}

--- a/app/src/types/ui.ts
+++ b/app/src/types/ui.ts
@@ -10,6 +10,8 @@
 // preload contract. View/navigation state now lives with its owning store
 // (DrawerView in layout-store, TabType in tabs-store).
 
+import type { ResolvedVariable, VariableOrigin, VariableScope } from "./domain";
+
 /** App theme preference. `system` follows the OS via Electron's nativeTheme. */
 export type ThemeSource = "system" | "light" | "dark";
 
@@ -18,3 +20,39 @@ export type ThemeSource = "system" | "light" | "dark";
  * Re-exported from the single source of truth in `@/constants/color-schemes`.
  */
 export type { ColorScheme } from "@/constants/color-schemes";
+
+/**
+ * The variable scope a variable-aware input is editing inside, handed in rather
+ * than reached for.
+ *
+ * `VariableInput` and the key/value table used to call
+ * `useRequestBuilderContext()` in their bodies, and that hook *throws* with no
+ * `RequestBuilderProvider` above it - so the app's densest table could not
+ * render anywhere but the request builder, and every other surface that wanted
+ * key/value rows hand-rolled its own (issue #564). A hand-rolled copy never
+ * receives the primitive's fixes.
+ *
+ * Optional at every consumer, and its absence is a real state rather than a
+ * degraded one: a surface with no variable scope - an inbox's canned reply
+ * headers, say - has nothing to resolve, nothing to autocomplete and no
+ * definition to edit, so the field is a plain text field. The members travel
+ * together because they are one concept - the variable scope - and each is
+ * meaningless without the rest: without `getAllVariables` there are no tokens
+ * to render, and a token with no `updateVariable` offers an edit that goes
+ * nowhere.
+ */
+export interface VariableSupport {
+	/** `{{name}}` substituted, for a preview of what will actually be sent. */
+	resolveString: (input: string) => string;
+	/** Every name in scope, for token rendering and the `{{` autocomplete. */
+	getAllVariables: () => Record<string, ResolvedVariable>;
+	/** Every definition of a name, winner and losers alike. Display-only. */
+	getVariableOrigins: (name: string) => VariableOrigin[];
+	/** Write a new value for a name, from a token's edit popover. */
+	updateVariable: (name: string, value: string, scope: VariableScope) => void;
+	/**
+	 * The scopes `updateVariable` can actually write to right now, so the
+	 * popover's scope picker cannot offer a target that does not exist.
+	 */
+	writableScopes: VariableScope[];
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -247,9 +247,29 @@ The request editor. Entry: `modules/request-builder/index.tsx`.
 | `components/ResponseViewer/` | `index`, `ResponseCookies`, `ResponseTimingTab`, `TestResults`, `ConsoleOutput`, `RawRequestResponse`, `ClientErrorView` (status bar, actions and the Headers tab now come from `shared/response-viewer/`). The Console tab renders whenever the response carries console logs **or** a `preScriptError`/`postScriptError`, so a script that throws before logging still shows its error rather than a silent 200 |
 | `components/LoadTestConfigDialog/` | Load-test configuration dialog (mode, duration, RPS, concurrency, …). Renders `OAuth2LoadTestGuard` when the request's effective auth is OAuth 2.0. A second disclosure, **Pass/fail budgets**, declares the run's latency / error-rate / throughput limits; the field table and its rules are `budgets.ts`, and the p99 field is seeded from the `sloThresholdMs` client setting so that setting becomes the default budget rather than a parallel notion of "too slow". A budget out of the engine's range blocks Start with a named message instead of being dropped from the payload |
 | `components/OAuth2LoadTestGuard.tsx`, `components/oauth2-load-test-coverage.ts` | Warns when a duration-based load test would outlive its access token (the engine acquires a token once per run, no mid-run refresh): offers **Refresh** when a fresh token would cover the run, or **blocks Start** (with a "Start anyway" override) when even a fresh token can't. The pure coverage decision lives in `oauth2-load-test-coverage.ts` |
-| `shared/KeyValueEditor/` | `index`, `KeyValueRow`, `FilePartCell` - reusable key/value table (params, headers, form fields). `allowFiles` (form-data only) turns each row into a text/file switch; `FilePartCell` is the value cell of a file part - it picks a file, shows the path, and marks one an import brought in and this app never chose. `lib/file-path.ts` holds the basename rule it shares with the importers |
-| `shared/VariableInput/` | `index`, `EditableVariable`, `DynamicVariableToken` - input with `{{variable}}` highlighting + autocomplete. `EditableVariable` is the stored-variable token (hover to read, click to edit, red when nothing defines the name); `DynamicVariableToken` is the `{{$guid}}` one, which has no stored value to show or edit and must not be painted as undefined |
-| `hooks/`, `utils/` | Module hooks; `utils/key-value` (flat↔entry conversions), `utils/id` |
+| `shared/KeyValueEditor/` | `index`, `KeyValueRow`, `FilePartCell` - reusable key/value table (params, headers, form fields). **Resolution is an input, not an ambient dependency:** the optional `variables` prop carries the [`VariableSupport`](#variable-scope-as-a-prop-variablesupport) scope, and with it omitted the table resolves nothing, shows no `ResolvedPeek` and offers no `{{` autocomplete - the correct reading of a surface with no variables. That is what lets it mount outside `RequestBuilderProvider`; before it, `KeyValueRow` called the context hook in its body and that hook *throws* with no provider, so every other surface hand-rolled its own rows (issue #564). `allowFiles` (form-data only) turns each row into a text/file switch and stays on this table rather than the caller, since only the request builder has a wire format that can carry a file; `FilePartCell` is the value cell of a file part - it picks a file, shows the path, and marks one an import brought in and this app never chose. `lib/file-path.ts` holds the basename rule it shares with the importers |
+| `shared/VariableInput/` | `index`, `EditableVariable`, `DynamicVariableToken` - input with `{{variable}}` highlighting + autocomplete. Takes the same optional `variables` scope; without one it is a plain text field, since a token would paint a name "not defined" and open an editor with nowhere to write. `EditableVariable` is the stored-variable token (hover to read, click to edit, red when nothing defines the name) and takes the scope as a **required** prop, because a token only renders where there is one; `DynamicVariableToken` is the `{{$guid}}` one, which has no stored value to show or edit and must not be painted as undefined |
+| `hooks/`, `utils/` | Module hooks - `useHeadersManager`, and `useVariableSupport`, the one adapter from the request-builder context to the `VariableSupport` prop shape (memoised: it is a prop on a `memo`-wrapped row); `utils/key-value` (flat↔entry conversions), `utils/id` |
+
+### Variable scope as a prop (`VariableSupport`)
+
+`VariableSupport` (in `types/ui.ts`) is the variable slice of the request-builder
+context - `resolveString`, `getAllVariables`, `getVariableOrigins`,
+`updateVariable`, `writableScopes` - as a plain object a caller hands in.
+
+It exists because reaching for the context instead made two primitives
+unmountable anywhere but the request builder: `useRequestBuilderContext()`
+throws with no provider above it, so `KeyValueEditor`, `VariableInput` and
+`EditableVariable` could not render at all elsewhere, and the surfaces that
+wanted key/value rows wrote their own instead (issue #564). A hand-rolled copy
+of a primitive never receives the primitive's fixes.
+
+The prop is **optional** on `KeyValueEditor` and `VariableInput`, and its
+absence is a real state rather than a degraded one: a canned webhook reply has
+no variable scope, so nothing resolves, no token paints and no autocomplete
+opens. Inside the request builder every mount site passes
+`useVariableSupport()`; `AuthPanel`'s `VariableTextInput` calls that hook itself,
+since it is always under the provider.
 
 > **cURL / wget import:** pasting a `curl` or `wget` command into the URL field auto-populates the whole request (method, URL, params, headers, body, auth). Auth maps `-u`/`--user` (and wget `--http-user`/`--http-password`) to Basic, and curl `--oauth2-bearer` to Bearer; an `Authorization` header is left as a raw header (to preserve `{{variables}}`). Form-shaped `-d`/`--data` without an explicit `Content-Type` maps to `x-www-form-urlencoded` rows (curl's on-the-wire default), while a raw JSON/text blob stays a text body. Detection + parsing live in `services/curl/` (`tokenize.ts` shell tokenizer + `parseCurl.ts`), kept separate from the collection `importers/` pipeline since this targets the active request. The paste is a request-shape replacement - identity (`id`, `name`, `collectionId`) and scripts are preserved; file references (`-d @file`, `-F field=@file`, `--post-file`) are skipped since they can't be read from pasted text. Non-command pastes fall through to normal input.
 
@@ -496,7 +516,12 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   `setState` inside an effect. Apply sends the whole response, not a diff: `PUT /inbox/:id` is a
   merge-patch, so an omitted `headers` is how a header the user deleted comes back. On a **stopped**
   inbox every control is disabled and says why - the route still merge-patches a stopped record, so
-  a live-looking panel there is an edit accepted for a reply nothing will ever send.
+  a live-looking panel there is an edit accepted for a reply nothing will ever send. The reply
+  headers are
+  [`KeyValueEditor`](#request-builder-modulesrequest-builder) rows, with no `variables` scope
+  passed - a canned reply is echoed verbatim, so there is nothing to resolve. They were local
+  `Input` pairs until #564 made the primitive mountable outside `RequestBuilderProvider`; the
+  table's trailing blank row replaced the panel's own "Add header" button.
 - `CaptureDetail.tsx` - one capture, rendered through `UnifiedResponseViewer` and `buildRawRequest`.
   A capture is an exchange with no response, which that viewer already handles; a request you
   received should read like one you sent.


### PR DESCRIPTION
## Description

**Plan.** The root cause is that resolution was an *ambient* dependency: `KeyValueRow` called `useRequestBuilderContext()` in its body, and that hook `throw`s with no `RequestBuilderProvider` above it. So the app's key/value primitive - the surface carrying the `h-8` pitch, the trailing-blank row, the `ResolvedPeek` marker and the per-field `canEdit`/`canRemove`/`canDisable` policy - could not render anywhere else at all, and every other surface wrote its own. The approach is to make the scope an **input**: one optional `variables` prop threaded from whoever mounts the table, whose absence is a real state (nothing resolves, no token paints, no autocomplete opens) rather than a degraded one. The alternative I rejected was a second, non-throwing "variables context" that the primitives read and degrade from - it keeps the dependency ambient, so the next component to be extracted hits the same wall, and it makes "does this surface have variables" invisible at the call site instead of stated there.

### One deviation from the issue spec, verified against the code

**The coupling was three components deep, not one.** The issue says the row uses the context "for exactly one thing - `resolveString`". That is true of `KeyValueRow` itself, but every row renders a `VariableInput`, which calls the same hook for `getAllVariables`/`updateVariable` (`VariableInput/index.tsx:100`), and every variable token renders an `EditableVariable`, which calls it for `getVariableOrigins`/`writableScopes` (`EditableVariable.tsx:59`). Threading only `resolveString` would have left the table throwing exactly as before - the drift is why nothing caught it: four test files `vi.mock`ed the context module, so every test stood in the provider that no real caller outside the builder had.

So `VariableSupport` (in `types/ui.ts`) bundles all five members. They are one concept - the variable scope - and each is meaningless alone: without `getAllVariables` there are no tokens to render, and a token with no `updateVariable` offers an edit that goes nowhere. It is optional on `KeyValueEditor` and `VariableInput`, and **required** on `EditableVariable`, since a token only renders where a scope exists.

### The other decisions the issue asked for

- **`allowFiles` stays on the shared table**, not behind a request-builder wrapper. It is already gated correctly (`form-data` only, because the engine refuses a file part anywhere else) and the file cell is the row's *value* cell, not a sibling - hoisting it into a wrapper would mean the wrapper reimplementing the row's grid. A caller with no file-capable wire format simply omits it, exactly as it omits `variables`.
- **Moving the directory to `components/shared/` is deferred** (the issue allows it as a second commit). It now drags `VariableInput` and `EditableVariable` along, and `KeyValueItem` is referenced in 27 files - mechanical churn that is not what unblocks reuse. Filed as a follow-up; the inbox imports from `@/modules/request-builder/shared/KeyValueEditor` until then.
- **`VariableTableEditor` is untouched**, as the issue directs.

### Adoption

The inbox's reply headers are `KeyValueEditor` rows with no scope passed - a canned reply is echoed verbatim by the engine, so there is nothing to resolve. The table's trailing blank row replaces the panel's own "Add header" button. No hand-rolled key/value rows remain in `modules/inbox/`.

Inside the builder, the five mount sites (`ParamsPanel`, `HeadersPanel`, `BodyPanel`, `UrlInput`, `AuthPanel`) pass `useVariableSupport()` - one memoised adapter rather than a `useMemo` copied five times. Memoised deliberately: the object is a prop on a `memo`-wrapped row, so a fresh identity per render would re-render every row of the densest table in the app on every keystroke.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- Full app suite: **427 files / 4361 tests passed** (243s).
- `python3 -m mkdocs build --strict -f .github/mkdocs.yml` - built clean (docs change).
- Engine untouched, so no engine build or `ctest` run - nothing there could change colour.

New tests, mutation-checked by actually reverting each change and confirming the failure:

| Change reverted | Tests that went red |
|---|---|
| `useRequestBuilderContext()` restored in `KeyValueRow` | **23** across `CannedResponseControls.test.tsx` and `KeyValueRow.test.tsx`, all `useRequestBuilderContext must be used within RequestBuilderProvider` |
| `variables={variables}` deleted from `BodyPanel` | `hands the table this request's variable scope` |

The second one is the point of adding a panel-level test at all: the row's own tests hand it a scope directly, so they stay green with the thread deleted - the "written but never read" wiring class `CLAUDE.md` warns about.

Also new: the row renders outside a provider with two working text fields; a `{{format}}` value with no scope shows the literal rather than an undefined-variable token; the row's `ResolvedPeek` still appears with a scope and stays away without one; the inbox panel mounts with no provider anywhere above it and offers no variable affordances.

Four test files (`KeyValueRow`, `dynamic-variable-token`, `variable-token-font`, `EditableVariable`) dropped their `vi.mock` of the context and share `test/variable-support.ts`. `file-part-row.test.tsx`'s mock was dead and is gone.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #564

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQ4WvQjqkwMT884PjudWof)_