### PR TITLE
fix(app/engine): the inbox tab's copy button no longer claims a refused copy

### DIFF
--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -17,6 +17,7 @@ export { useElectronTheme } from "./useElectronTheme";
 export { useResizable } from "./useResizable";
 export { useOverflowTitle } from "./useOverflowTitle";
 export { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+export { useCopy } from "./useCopy";
 
 // Note: useCollections, useRuns, useHealthCheck have been replaced by TanStack Query hooks
 // Import from @/queries instead

--- a/app/src/hooks/useCopy.ts
+++ b/app/src/hooks/useCopy.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Copy, and say so only once it worked.
+ *
+ * `writeText` returns a promise that *rejects* - a denied permission, a
+ * document that is not focused, a platform with no clipboard behind the API.
+ * A call site that fires it with `void` and toasts "copied" unconditionally
+ * reports a failed copy as a success, so the user pastes whatever was on the
+ * clipboard before, and the rejection goes unhandled.
+ *
+ * It lives here rather than beside one of its callers because two surfaces
+ * offer the same inbox URL - the Services drawer's row and the inbox tab's
+ * header - and the tab's button kept the exact defect the drawer's fix removed
+ * (issue #555 item 6, then #565 item 1). A hand-rolled copy does not receive
+ * the primitive's fixes.
+ *
+ * `what` names the value in both toasts, so a surface with several copy
+ * controls says which one it is talking about.
+ */
+
+import { useToastStore } from "@/stores";
+
+export function useCopy(): (value: string, what: string) => Promise<void> {
+	const showToast = useToastStore((s) => s.showToast);
+	return async (value: string, what: string) => {
+		try {
+			await navigator.clipboard.writeText(value);
+			showToast(`${what} copied`, "success");
+		} catch (error) {
+			showToast(
+				error instanceof Error ? `Could not copy: ${error.message}` : "Could not copy",
+				"error"
+			);
+		}
+	};
+}

--- a/app/src/modules/inbox/InboxView.errors.test.tsx
+++ b/app/src/modules/inbox/InboxView.errors.test.tsx
@@ -22,6 +22,10 @@
  * Mutation-check: drop the `onError` from either `mutate` call in
  * `modules/inbox/index.tsx` and the matching case here fails.
  *
+ * The header's copy control answers to the same discipline and is pinned at the
+ * bottom of this file (issue #565, item 1) - it is not a mutation, but it is
+ * the other thing on this tab that can fail and used to say it had not.
+ *
  * The transport is mocked and the real query hooks run, so a refusal travels
  * the same mutation path the app uses.
  */
@@ -37,6 +41,7 @@ const listInboxes = vi.fn();
 const listInboxCaptures = vi.fn();
 const stopInbox = vi.fn();
 const clearInboxCaptures = vi.fn();
+const writeText = vi.fn();
 
 vi.mock("@/services/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/services/api")>();
@@ -109,7 +114,8 @@ beforeEach(() => {
 	clearInboxCaptures.mockReset().mockResolvedValue({ inboxId: "inbox_a", cleared: 1 });
 	useTabsStore.setState({ openTabs: [], activeTabId: null, tabFocusedAt: {} });
 	useToastStore.setState({ toasts: [] });
-	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText: vi.fn() } });
+	writeText.mockReset().mockResolvedValue(undefined);
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
 });
 
 describe("a refused mutation in the inbox tab", () => {
@@ -162,5 +168,50 @@ describe("a refused mutation in the inbox tab", () => {
 		fireEvent.click(await screen.findByRole("button", { name: /stop/i }));
 		await waitFor(() => expect(stopInbox).toHaveBeenCalledWith("inbox_a"));
 		expect(useToastStore.getState().toasts).toHaveLength(0);
+	});
+});
+
+/*
+ * The same discipline for the copy control (issue #565, item 1). The drawer's
+ * row got the awaiting path in #555 item 6; this header button kept the defect
+ * that fix removed - `void writeText(...)` and an unconditional "copied", so a
+ * refusal read as a success and the rejection went unhandled. Both surfaces now
+ * take the same `useCopy`.
+ *
+ * Mutation-check: point the button back at a bare `void
+ * navigator.clipboard.writeText` with an unconditional success toast and the
+ * refusal case here fails.
+ */
+describe("the inbox tab's copy control", () => {
+	it("does not claim a copy that the clipboard refused", async () => {
+		writeText.mockRejectedValue(new Error("Clipboard write denied"));
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		await waitFor(() => expect(firstToast()).toMatchObject({ variant: "error" }));
+		expect(firstToast().message).toMatch(/Clipboard write denied/);
+	});
+
+	it("names the failure even when the rejection is not an Error", async () => {
+		writeText.mockRejectedValue("denied");
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		await waitFor(() =>
+			expect(firstToast()).toMatchObject({ variant: "error", message: "Could not copy" })
+		);
+	});
+
+	it("says so when the copy worked", async () => {
+		renderTab();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy inbox URL" }));
+		await waitFor(() =>
+			expect(firstToast()).toMatchObject({
+				variant: "success",
+				message: "Inbox URL copied",
+			})
+		);
+		expect(writeText).toHaveBeenCalledWith("http://127.0.0.1:41234/");
 	});
 });

--- a/app/src/modules/inbox/index.tsx
+++ b/app/src/modules/inbox/index.tsx
@@ -47,6 +47,7 @@ import {
 	useUpdateInboxResponseMutation,
 } from "@/queries";
 import { useTabsStore, useToastStore } from "@/stores";
+import { useCopy } from "@/hooks";
 import { cn } from "@/lib/utils";
 import type { Inbox, InboxCannedResponse, InboxCapture } from "@/types";
 import { CannedResponseControls } from "./CannedResponseControls";
@@ -124,6 +125,7 @@ function DeleteInboxButton({ inbox, listedTotal }: { inbox: Inbox; listedTotal: 
 
 export default function InboxView() {
 	const showToast = useToastStore((s) => s.showToast);
+	const copy = useCopy();
 	const { openTabs, activeTabId, openTab } = useTabsStore();
 	const { data: inboxes = [], isError, error, refetch } = useInboxesQuery();
 	// Which capture, and of which inbox: ids are per-inbox, so a bare number
@@ -144,8 +146,8 @@ export default function InboxView() {
 
 	// The engine lists inboxes in map order, which is not stable across polls -
 	// so both the switcher's entries and the fallback below order by port. An
-	// inbox record carries no creation stamp; whether it should is #555's
-	// decision, and port is the stable key the record has today.
+	// inbox record carries no creation stamp and does not gain one - #555
+	// answered that - and port is the stable key the record has.
 	const ordered = [...inboxes].sort((a, b) => a.port - b.port);
 
 	// Derived, not synced into state: the engine is the list of inboxes, and an
@@ -242,10 +244,7 @@ export default function InboxView() {
 					variant="ghost"
 					size="sm"
 					aria-label="Copy inbox URL"
-					onClick={() => {
-						void navigator.clipboard.writeText(inbox.url);
-						showToast("Inbox URL copied", "success");
-					}}
+					onClick={() => void copy(inbox.url, "Inbox URL")}
 				>
 					<Copy className="h-3.5 w-3.5" aria-hidden="true" />
 				</Button>

--- a/app/src/modules/services/ServicesPanel.tsx
+++ b/app/src/modules/services/ServicesPanel.tsx
@@ -54,6 +54,7 @@ import {
 	useUpdateMockIssuerMutation,
 } from "@/queries";
 import { useTabsStore, useToastStore } from "@/stores";
+import { useCopy } from "@/hooks";
 import { TIMING } from "@/config/timing";
 import { cn } from "@/lib/utils";
 import type { Inbox, MockIssuer, MockIssuerFailureMode } from "@/types";
@@ -169,31 +170,6 @@ function ServiceGroup({ title, action, children }: ServiceGroupProps) {
 
 /** `px-3 py-2 text-left`: a drawer group's line, not a centred pane. */
 const GROUP_NOTE_CLASS = "px-3 py-2 text-left text-xs";
-
-/**
- * Copy, and say so only once it worked.
- *
- * `writeText` returns a promise that *rejects* - a denied permission, a
- * document that is not focused, a platform with no clipboard behind the API -
- * and this fired it with `void` and toasted "copied" unconditionally, so a
- * failed copy was reported as a success and the user pasted whatever was on the
- * clipboard before. Every other copy site in the app already awaits; this is
- * the one that did not.
- */
-function useCopy() {
-	const showToast = useToastStore((s) => s.showToast);
-	return async (value: string, what: string) => {
-		try {
-			await navigator.clipboard.writeText(value);
-			showToast(`${what} copied`, "success");
-		} catch (error) {
-			showToast(
-				error instanceof Error ? `Could not copy: ${error.message}` : "Could not copy",
-				"error"
-			);
-		}
-	};
-}
 
 function InboxRow({ inbox, flashed }: { inbox: Inbox; flashed: boolean }) {
 	const openTab = useTabsStore((s) => s.openTab);

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -506,7 +506,10 @@ sent to it, so building a webhook consumer needs no cloud tunnel. Engine contrac
   Services drawer orders by port for the same reason. Every mutation this tab owns reports its
   failure as a toast (`reportFailure`), which is the one discipline the whole inbox lifecycle
   follows; Stop and Clear used to pass no `onError` at all (#555, item 7 - taken there rather than in
-  #556's tab pass, which both issues named as the shared brush).
+  #556's tab pass, which both issues named as the shared brush). The header's copy control answers
+  to the same discipline through the shared `useCopy` (see [Services](#services-modulesservices)) -
+  it is not a mutation, but it is the other thing here that can fail, and it claimed success
+  regardless until #565.
 - `CannedResponseControls.tsx` - all four fields the engine serves: reply status and delay inline,
   body and headers behind a disclosure that opens on its own when either is set. It showed status and
   delay only, so a reply body or header set configured by an MCP tool or a bare curl was invisible
@@ -616,7 +619,12 @@ both activate it.
   full URLs are three near-identical monospace strings differing in one digit. The URL is still on
   the row and also rides the copy control's tooltip, which says so when the inbox is **stopped** -
   a stopped inbox's URL copies perfectly well and then refuses connections, a long way from the
-  cause. Rows are ordered **by port**, because the engine lists them in map order (not stable across
+  cause. Every copy control here goes through the shared `useCopy` hook (`hooks/useCopy.ts`), which
+  **awaits** `writeText` and toasts the failure: the promise rejects on a denied permission or an
+  unfocused document, and a `void` call with an unconditional "copied" reports a refusal as a
+  success while the rejection goes unhandled. It is a shared hook rather than a local one because
+  the inbox tab's header offers the same URL and kept that exact defect after the drawer's fix
+  (#555 item 6, then #565 item 1) - a hand-rolled copy does not receive the primitive's fixes. Rows are ordered **by port**, because the engine lists them in map order (not stable across
   polls) and the record carries no creation stamp; the inbox tab's switcher orders the same way.
   Creating one **toasts and flashes** the new row for `TIMING.ROW_FLASH_MS` - it lands wherever its
   ephemeral port sorts, not at the end. The activator's verb is `sr-only` text **prefixed to** the

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -196,6 +196,17 @@ writes rows that cannot see each other yet, so an omitted `order` gives the
 payload's items consecutive slots starting from the append point - see
 [POST /import/apply](#post-importapply).
 
+**Any writer producing several sibling rows at once owes them distinct
+`order`s** - the import applier is the instance of a general rule, not a special
+case. The `createdAt` leg is a millisecond stamp, so rows written inside one
+tick tie on it and fall through to `id`, which compares random UUIDs: stable
+across reads of the same data, but arbitrary with respect to the order the
+caller meant. Single-row creates need nothing extra, because the append scan
+already sees every stored sibling and hands out a fresh slot. The rule is on the
+writer rather than on a finer timestamp: a microsecond stamp would still tie
+under a fast enough writer, and it would make row identity depend on clock
+resolution across the three platforms Vayu builds on.
+
 **Repositioning several rows at once** is [`POST /reorder`](#post-reorder), not a
 run of `PUT`s. Each `PUT` is its own write under its own lock, so a reorder
 expressed as N sibling `PUT`s is last-write-wins between concurrent clients, can

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -700,9 +700,16 @@ std::vector<Collection> Database::get_collections () {
     // a collection among its equal-`order` siblings - and the sidebar, the MCP
     // smoke tool and a scenario plan each saw a different shuffle. `created_at`
     // second matches what the renderer displays; `id` last makes the result a
-    // total order even for rows written in the same millisecond. The renderer's
-    // comparator applies the identical rule, pinned by
-    // tests/fixtures/tree-order-conformance.json.
+    // total order even for rows written in the same millisecond. That last leg
+    // compares random UUIDs, so it is stable across reads but arbitrary with
+    // respect to the order the caller meant - which is why the contract puts
+    // the duty on the writer (issue #565): anything producing several siblings
+    // at once owes them distinct `order`s, as build_collection_rows and the
+    // examples import already do. A finer timestamp was rejected: it still ties
+    // under a fast enough writer, and it would make row identity depend on
+    // clock resolution across three platforms. See the Ordering section of
+    // docs/engine/api-reference.md. The renderer's comparator applies the
+    // identical rule, pinned by tests/fixtures/tree-order-conformance.json.
     return impl_->storage.get_all<Collection> (multi_order_by (order_by (&Collection::order),
     order_by (&Collection::created_at), order_by (&Collection::id)));
 }


### PR DESCRIPTION
## Description

Both of #565's items, plus the rider.

**Plan.** Root cause of item 1 is that `useCopy` - the awaiting copy path #555 item 6 added - was declared module-private inside `ServicesPanel.tsx`, so the inbox tab's header button, which offers the same URL, carried a second hand-rolled copy of the same three lines and kept the exact defect the drawer's fix removed: `void navigator.clipboard.writeText(...)` followed by an unconditional `showToast("Inbox URL copied", "success")`. `writeText` rejects on a denied permission, an unfocused document, or a platform with no clipboard behind the API, so a refusal was reported as a success and the rejection went unhandled. The approach is to lift `useCopy` to `hooks/useCopy.ts` and point both surfaces at it - CLAUDE.md's "a hand-rolled copy of a primitive does not receive the primitive's fixes" is exactly how this survived its own fix. The alternative I rejected was the two-line local fix the issue allowed for (inline the try/catch in `index.tsx`): it closes the bug and leaves the third surface that offers a URL free to reintroduce it, which is the shape that produced #565.

Item 2 is a decision, taken as **the contract stands**. `get_collections` sorts `order`, then `created_at`, then `id`; the `id` leg compares random UUIDs, so it *is* a total order, but arbitrary with respect to the order the caller meant. No production code misbehaves - the flaky consumer #559 fixed was the test, and the bulk writers (`build_collection_rows`, the examples import in `import.cpp`) already hand out consecutive `order`s for exactly this reason, verified against the current code rather than the issue's description. What was missing was the general clause, so the contract now states the duty on the **writer**: anything producing several sibling rows at once owes them distinct `order`s; single-row creates need nothing, since the append scan sees every stored sibling. A finer timestamp was rejected as the alternative - it still ties under a fast enough writer, and it would make row identity depend on clock resolution across the three platforms Vayu builds on. No engine code change beyond the comment at the tie rule, which previously read as though a same-millisecond tie were settled and would now contradict the docs.

Rider: `modules/inbox/index.tsx`'s switcher comment said "whether it should is #555's decision" in pending tense; #555 decided (no creation stamp), so it now matches `docs/app/COMPONENTS.md`.

No deviation from the issue spec.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green: **427 files, 4364 tests passed**, type-check clean, ESLint clean at `--max-warnings 0`, Prettier clean.

Three new cases in `InboxView.errors.test.tsx` pin the tab's copy control, mirroring the drawer's: a refused write toasts the error, a non-`Error` rejection still reaches the user as words, and a successful copy toasts success and writes the URL. **Mutation-check performed, not assumed** - reverting the button to `void navigator.clipboard.writeText(...)` plus the unconditional success toast fails 2 of the 3 (`Tests 2 failed | 5 passed`); restored, 7 pass.

The engine change is comment-only and the docs change is Markdown, so per CLAUDE.md no engine rebuild or ctest run: no test could go from green to red. `mkdocs build --strict` is clean, and the new `#services-modulesservices` cross-link resolves in the built HTML (checked for the `id` in `site/app/COMPONENTS/index.html`).

No pre-existing failures observed.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/COMPONENTS.md` (the shared `useCopy` and why it is shared, under Services; the inbox tab's bullet now names the copy control as part of the same error discipline) and `docs/engine/api-reference.md` (the bulk-writer clause in the Ordering section). Only files that were Prettier-clean before were formatted - both Markdown files were already outside Prettier's coverage and were left as they were.

## Related Issues
Closes #565

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zyg2TNqooRpFTNGwaVkcv)_