### PR TITLE
feat(engine/app/mock): serve a collection's saved examples on a local listener

### DIFF
--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -160,6 +160,15 @@ export const API_ENDPOINTS = {
 	MOCK_ISSUER_BY_ID: (issuerId: string) => `/mock-issuer/${issuerId}`,
 	MOCK_ISSUER_STOP: (issuerId: string) => `/mock-issuer/${issuerId}/stop`,
 
+	// Collection mock server (issue #481 phase 2). Engine-process state like the
+	// two above, so the same verb-path shape. There is no DELETE and no PUT: a
+	// mock's route table is a start-time snapshot of the collection, so changing
+	// what it serves means starting another one, and stopping is what ends it.
+	MOCK_SERVER: `/mock`,
+	MOCK_SERVER_START: `/mock/start`,
+	MOCK_SERVER_STOP: (mockId: string) => `/mock/${mockId}/stop`,
+	MOCK_SERVER_ROUTES: (mockId: string) => `/mock/${mockId}/routes`,
+
 	// OAuth 2.0
 	OAUTH2_TOKEN: `/oauth2/token`,
 	OAUTH2_AUTHORIZE_START: `/oauth2/authorize/start`,

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.error.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.error.test.tsx
@@ -58,6 +58,9 @@ vi.mock("./AuthTab", () => ({ default: () => null }));
 vi.mock("./InfoTab", () => ({ default: () => null }));
 vi.mock("./ScriptTab", () => ({ default: () => null }));
 vi.mock("./VariablesTab", () => ({ default: () => null }));
+// The header's mock-server control reaches the engine and the toast store;
+// this file is about the tab shell, and its own suite covers the control.
+vi.mock("./MockServerControl", () => ({ default: () => null }));
 
 beforeEach(() => {
 	refetch.mockReset();

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.loading.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.loading.test.tsx
@@ -47,6 +47,9 @@ vi.mock("./AuthTab", () => ({ default: () => null }));
 vi.mock("./InfoTab", () => ({ default: () => null }));
 vi.mock("./ScriptTab", () => ({ default: () => null }));
 vi.mock("./VariablesTab", () => ({ default: () => null }));
+// The header's mock-server control reaches the engine and the toast store;
+// this file is about the tab shell, and its own suite covers the control.
+vi.mock("./MockServerControl", () => ({ default: () => null }));
 
 beforeEach(() => {
 	state.collections = { data: [], isLoading: false };

--- a/app/src/modules/collections/CollectionDetail/MockServerControl.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/MockServerControl.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The collection header's mock-server control (issue #481 phase 2).
+ *
+ * This is the only surface that can *start* a mock, because it is the only one
+ * that has a collection. What it has to get right is which mock it is talking
+ * about: the engine's list is every mock in the process, and a header showing a
+ * different collection's URL - or offering "Run mock server" beside one that is
+ * already running - is worse than showing nothing.
+ *
+ * The transport is mocked and the real query hooks run, so starting and
+ * stopping go through the same mutations and cache invalidation the app uses.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useToastStore } from "@/stores";
+import type { MockServer } from "@/types";
+import MockServerControl from "./MockServerControl";
+import { mockForCollection } from "./mock-server-selection";
+
+const listMockServers = vi.fn();
+const startMockServer = vi.fn();
+const stopMockServer = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listMockServers: () => listMockServers(),
+			startMockServer: (...a: unknown[]) => startMockServer(...a),
+			stopMockServer: (...a: unknown[]) => stopMockServer(...a),
+		},
+	};
+});
+
+const writeText = vi.fn();
+
+function mock(overrides: Partial<MockServer> = {}): MockServer {
+	return {
+		mockId: "mock_a",
+		collectionId: "col_1",
+		collectionName: "Pet Store",
+		url: "http://127.0.0.1:43100",
+		port: 43100,
+		latencyMs: 0,
+		errorRatePct: 0,
+		routeCount: 3,
+		routesWithoutExample: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
+function renderControl(collectionId = "col_1") {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<MockServerControl collectionId={collectionId} />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	cleanup();
+	listMockServers.mockReset().mockResolvedValue([]);
+	startMockServer.mockReset().mockResolvedValue(mock());
+	stopMockServer.mockReset().mockResolvedValue({ mockId: "mock_a", stopped: true });
+	writeText.mockReset().mockResolvedValue(undefined);
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+	useToastStore.setState({ toasts: [] });
+});
+
+describe("picking the mock this header is about", () => {
+	it("ignores mocks of other collections", () => {
+		const mine = mock({ mockId: "mock_mine", collectionId: "col_1" });
+		const theirs = mock({ mockId: "mock_theirs", collectionId: "col_2", port: 43000 });
+		expect(mockForCollection([theirs, mine], "col_1")?.mockId).toBe("mock_mine");
+		expect(mockForCollection([theirs], "col_1")).toBeNull();
+		expect(mockForCollection([], "col_1")).toBeNull();
+	});
+
+	it("picks the lowest port when one collection has several", () => {
+		// Nothing stops a user starting two mocks of one collection - different
+		// latency, different error rate - and the engine lists them in map
+		// order, which is not stable across polls.
+		const high = mock({ mockId: "mock_high", port: 43900 });
+		const low = mock({ mockId: "mock_low", port: 43100 });
+		expect(mockForCollection([high, low], "col_1")?.mockId).toBe("mock_low");
+		expect(mockForCollection([low, high], "col_1")?.mockId).toBe("mock_low");
+	});
+});
+
+describe("the collection header's mock-server control", () => {
+	it("offers to start one, and starts it for this collection", async () => {
+		renderControl();
+
+		fireEvent.click(await screen.findByRole("button", { name: /run mock server/i }));
+		await waitFor(() =>
+			expect(startMockServer).toHaveBeenCalledWith({ collectionId: "col_1" })
+		);
+		// The toast names what was started - the route count is the number that
+		// says whether the mock is worth pointing anything at.
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]?.message).toMatch(/port 43100 - 3 routes/i)
+		);
+	});
+
+	it("surfaces the engine's reason rather than a generic failure", async () => {
+		startMockServer.mockRejectedValue(
+			new Error("Collection 'Pet Store' (and everything under it) has no requests to serve")
+		);
+		renderControl();
+
+		fireEvent.click(await screen.findByRole("button", { name: /run mock server/i }));
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]?.message).toMatch(/no requests to serve/i)
+		);
+	});
+
+	it("shows the URL and the controls once one is running, not the start button", async () => {
+		listMockServers.mockResolvedValue([mock({ routesWithoutExample: 1 })]);
+		renderControl();
+
+		expect(await screen.findByText("http://127.0.0.1:43100")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /run mock server/i })).not.toBeInTheDocument();
+		// The count that explains a mock answering 501: reported, not left to be
+		// discovered one request at a time.
+		expect(screen.getByText(/3 routes, 1 without an example/i)).toBeInTheDocument();
+	});
+
+	it("keeps showing the start button when only another collection has a mock", async () => {
+		listMockServers.mockResolvedValue([mock({ collectionId: "col_2" })]);
+		renderControl("col_1");
+
+		expect(await screen.findByRole("button", { name: /run mock server/i })).toBeInTheDocument();
+		expect(screen.queryByText("http://127.0.0.1:43100")).not.toBeInTheDocument();
+	});
+
+	it("copies the base URL and stops the mock", async () => {
+		listMockServers.mockResolvedValueOnce([mock()]).mockResolvedValue([]);
+		renderControl();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy mock server URL" }));
+		await waitFor(() => expect(writeText).toHaveBeenCalledWith("http://127.0.0.1:43100"));
+
+		fireEvent.click(screen.getByRole("button", { name: /stop mock server on port 43100/i }));
+		await waitFor(() => expect(stopMockServer).toHaveBeenCalledWith("mock_a"));
+		// The record dies with the listener, so the header goes back to offering
+		// a start rather than a stopped chip.
+		expect(await screen.findByRole("button", { name: /run mock server/i })).toBeInTheDocument();
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/MockServerControl.tsx
+++ b/app/src/modules/collections/CollectionDetail/MockServerControl.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Start and stop a mock server for the collection on screen (issue #481 phase 2).
+ *
+ * This is the *contextual* starter: a mock needs a collection, and this header
+ * is the one surface that already has one. The Services drawer owns the list of
+ * everything running and can stop any of them, but it has no collection to
+ * start one from - which is why the group there has no "New mock" affordance
+ * and this control exists instead.
+ *
+ * A mock's route table is a snapshot taken at start, so there is nothing to
+ * "restart" - stopping and starting again is the only way to pick up an edit,
+ * and saying so in the tooltip is cheaper than a restart button that hides it.
+ */
+
+import { Copy, Play, ServerCog, Square } from "lucide-react";
+import { Button, TooltipIconButton } from "@/components/ui";
+import { TruncatedText } from "@/components/shared";
+import {
+	useMockServersQuery,
+	useStartMockServerMutation,
+	useStopMockServerMutation,
+} from "@/queries";
+import { useToastStore } from "@/stores";
+import { useCopy } from "@/hooks";
+import { mockForCollection } from "./mock-server-selection";
+
+export default function MockServerControl({ collectionId }: { collectionId: string }) {
+	const showToast = useToastStore((s) => s.showToast);
+	const copy = useCopy();
+	const mocksQuery = useMockServersQuery();
+	const startMock = useStartMockServerMutation();
+	const stopMock = useStopMockServerMutation();
+
+	const running = mockForCollection(mocksQuery.data ?? [], collectionId);
+
+	const start = () =>
+		startMock.mutate(
+			{ collectionId },
+			{
+				onSuccess: (mock) =>
+					showToast(
+						`Mock server on port ${mock.port} - ${mock.routeCount} route${
+							mock.routeCount === 1 ? "" : "s"
+						}`,
+						"success"
+					),
+				// The engine refuses a collection with no requests and one whose
+				// requests it cannot fit, and both messages name the reason. A
+				// generic fallback would turn "nothing to serve" into "could not
+				// start", which is the half that is not actionable.
+				onError: (error) =>
+					showToast(
+						error instanceof Error ? error.message : "Could not start the mock server",
+						"error"
+					),
+			}
+		);
+
+	if (!running) {
+		return (
+			<Button variant="outline" size="sm" onClick={start} disabled={startMock.isPending}>
+				<Play className="h-3.5 w-3.5" aria-hidden="true" />
+				Run mock server
+			</Button>
+		);
+	}
+
+	return (
+		<div className="flex min-w-0 items-center gap-1">
+			{/* A chip, not a button: the URL is the value you copy, and the two
+			    controls beside it are the actions. `surface-sunken` declares the
+			    `--rule` the border reads - a bare border token is invisible on
+			    the panel this header sits on. */}
+			<span className="surface-sunken flex min-w-0 items-center gap-1.5 rounded-md border border-rule px-2 py-1">
+				<ServerCog className="h-3.5 w-3.5 shrink-0 text-success-text" aria-hidden="true" />
+				<TruncatedText className="font-mono text-xs">{running.url}</TruncatedText>
+				<span className="shrink-0 text-xs text-muted-foreground">
+					{running.routeCount} route{running.routeCount === 1 ? "" : "s"}
+					{running.routesWithoutExample > 0 &&
+						`, ${running.routesWithoutExample} without an example`}
+				</span>
+			</span>
+			<TooltipIconButton
+				label="Copy mock server URL"
+				tooltipHint={running.url}
+				icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+				onClick={() => void copy(running.url, "Mock server URL")}
+			/>
+			<TooltipIconButton
+				label={`Stop mock server on port ${running.port}`}
+				tooltipHint="A mock serves the collection as it was when it started - stop and start it again to pick up an edit"
+				icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
+				disabled={stopMock.isPending}
+				onClick={() =>
+					stopMock.mutate(running.mockId, {
+						onError: (error) =>
+							showToast(
+								error instanceof Error
+									? error.message
+									: "Could not stop the mock server",
+								"error"
+							),
+					})
+				}
+			/>
+		</div>
+	);
+}

--- a/app/src/modules/collections/CollectionDetail/draft-survival.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/draft-survival.test.tsx
@@ -77,6 +77,9 @@ vi.mock("@/stores", () => ({
 // drag in a great deal of setup.
 vi.mock("./ScriptTab", () => ({ default: () => null }));
 vi.mock("./VariablesTab", () => ({ default: () => null }));
+// The header's mock-server control reaches the engine and the toast store;
+// this file is about the tab shell, and its own suite covers the control.
+vi.mock("./MockServerControl", () => ({ default: () => null }));
 
 function Screen() {
 	return (

--- a/app/src/modules/collections/CollectionDetail/index.tsx
+++ b/app/src/modules/collections/CollectionDetail/index.tsx
@@ -20,6 +20,7 @@ import { useCollectionsQuery, useRequestsQuery } from "@/queries/collections";
 import { useTabsStore, useSessionStore } from "@/stores";
 import AuthTab from "./AuthTab";
 import InfoTab from "./InfoTab";
+import MockServerControl from "./MockServerControl";
 import ScriptTab from "./ScriptTab";
 import VariablesTab from "./VariablesTab";
 
@@ -128,6 +129,13 @@ export default function CollectionDetail() {
 				<span className="text-xs text-muted-foreground">
 					- {requests.length} request{requests.length !== 1 ? "s" : ""}
 				</span>
+				{/* Right-aligned, because it is an action on the collection rather
+				    than part of its identity. It knows nothing about the tabs
+				    below: a mock serves the whole subtree, which is a property of
+				    the collection, not of whichever tab is open. */}
+				<div className="ml-auto flex min-w-0 items-center">
+					<MockServerControl collectionId={collection.id} />
+				</div>
 			</div>
 
 			{/* Tab bar */}

--- a/app/src/modules/collections/CollectionDetail/mock-server-selection.ts
+++ b/app/src/modules/collections/CollectionDetail/mock-server-selection.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which running mock this collection's header is about (issue #481 phase 2).
+ *
+ * Its own file, like `format.ts` beside it, so `MockServerControl.tsx` exports
+ * nothing but a component and fast refresh keeps working.
+ */
+
+import type { MockServer } from "@/types";
+
+/**
+ * The running mock for @p collectionId, or null.
+ *
+ * By port when there are several: nothing stops a user starting two mocks of
+ * one collection (different latency, different error rate), and the engine
+ * lists them in map order. The lowest port is stable across polls, which is
+ * what keeps the header from flipping between two rows that both apply.
+ */
+export function mockForCollection(mocks: MockServer[], collectionId: string): MockServer | null {
+	const matching = mocks
+		.filter((mock) => mock.collectionId === collectionId)
+		.sort((a, b) => a.port - b.port);
+	return matching[0] ?? null;
+}

--- a/app/src/modules/collections/ImportModal.environments.test.tsx
+++ b/app/src/modules/collections/ImportModal.environments.test.tsx
@@ -75,7 +75,9 @@ describe("ImportModal with a Postman environment export", () => {
 		expect(screen.getByText("Postman Environment")).toBeVisible();
 		expect(screen.getByText("Sample Staging")).toBeVisible();
 		expect(screen.getByText("5 variables")).toBeVisible();
-		expect(screen.getByText(/0 requests · 0 folders · 1 environments/)).toBeVisible();
+		expect(
+			screen.getByText(/0 requests · 0 folders · 0 examples · 1 environments/)
+		).toBeVisible();
 	});
 
 	it("keeps Import enabled - an environment-only import is a real import", async () => {

--- a/app/src/modules/collections/ImportModal.example-count.test.tsx
+++ b/app/src/modules/collections/ImportModal.example-count.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The import preview names how many saved examples it found (issue #481).
+ *
+ * All three parsers computed `ImportMeta.exampleCount` from the day examples
+ * landed, the type declared it, and its own doc comment said it was "shown in
+ * the import preview" - and no surface rendered it. That is the repo's most
+ * repeated defect, and it is the last unmet half of this issue's first
+ * acceptance criterion, because an example has no row of its own in the preview
+ * tree: it lands *inside* a request, so the count is the only place a user
+ * learns their saved responses survived the import.
+ *
+ * Mutation check: delete `{meta.exampleCount} examples` from `PreviewView` and
+ * the first case fails.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ImportModal } from "./ImportModal";
+import { useImportModalStore } from "@/stores";
+
+function renderModal() {
+	const qc = new QueryClient();
+	return render(
+		<QueryClientProvider client={qc}>
+			<ImportModal />
+		</QueryClientProvider>
+	);
+}
+
+/**
+ * Radix TabsTrigger activates on mousedown, not on a bare synthetic click.
+ */
+function selectTab(name: RegExp) {
+	const tab = screen.getByRole("tab", { name });
+	fireEvent.mouseDown(tab);
+	fireEvent.click(tab);
+}
+
+async function preview(source: unknown) {
+	renderModal();
+	selectTab(/Paste JSON/i);
+	fireEvent.change(screen.getByPlaceholderText(/Paste/i), {
+		target: { value: JSON.stringify(source) },
+	});
+	fireEvent.click(screen.getByRole("button", { name: /Detect & Preview/i }));
+}
+
+/** A Postman collection whose one request carries @p responses. */
+function postmanWith(responses: unknown[]) {
+	return {
+		info: {
+			name: "Pets",
+			schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		},
+		item: [
+			{
+				name: "List pets",
+				request: { method: "GET", url: "https://x/pets" },
+				response: responses,
+			},
+		],
+	};
+}
+
+describe("the import preview's example count", () => {
+	beforeEach(() => useImportModalStore.setState({ isOpen: true }));
+
+	it("counts the saved responses an import found", async () => {
+		await preview(
+			postmanWith([
+				{ name: "OK", code: 200, body: '{"id":1}' },
+				{ name: "Missing", code: 404, body: '{"error":"nope"}' },
+			])
+		);
+
+		// Beside the other counts, in the one line that summarises the import.
+		await waitFor(() => expect(screen.getByText(/2 examples/i)).toBeInTheDocument());
+		expect(screen.getByText(/1 requests/i)).toBeInTheDocument();
+	});
+
+	it("says zero rather than going silent for a file that carried none", async () => {
+		// A parser that forgot to look and a file with nothing to find are
+		// different answers, and only a rendered 0 can say the second.
+		await preview(postmanWith([]));
+		await waitFor(() => expect(screen.getByText(/0 examples/i)).toBeInTheDocument());
+	});
+});

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -498,9 +498,16 @@ function PreviewView({
 					</div>
 				)}
 			</div>
+			{/* `exampleCount` is here rather than only in the tree because a saved
+			    example is the one thing in an import with no row of its own to
+			    look at - it lands inside a request, and until this line the count
+			    every parser computed was rendered nowhere at all (issue #481,
+			    acceptance criterion 1). Unconditional like the other four: "0
+			    examples" is the answer for a file that carried none, which is
+			    different from a preview that does not mention them. */}
 			<p className="text-[11px] text-muted-foreground">
-				{meta.requestCount} requests · {meta.folderCount} folders · {meta.environmentCount}{" "}
-				environments · {meta.globalCount} globals
+				{meta.requestCount} requests · {meta.folderCount} folders · {meta.exampleCount}{" "}
+				examples · {meta.environmentCount} environments · {meta.globalCount} globals
 			</p>
 			{collections.length === 0 && environments.length === 0 && globalCount === 0 && (
 				<p className="flex items-center gap-1.5 text-[11px] text-destructive-text">

--- a/app/src/modules/services/ServicesPanel.mock-servers.test.tsx
+++ b/app/src/modules/services/ServicesPanel.mock-servers.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Services drawer's mock-servers group (issue #481 phase 2).
+ *
+ * The group's job is not "list a URL" - the collection header already shows
+ * that for the collection you are looking at. It is the one place a mock
+ * started anywhere (another collection, an MCP tool, curl) can be found,
+ * inspected and stopped, which is what these cases assert.
+ *
+ * The transport is mocked and the real query hooks run, so stopping a mock goes
+ * through the same mutation and cache invalidation the app uses; only the HTTP
+ * call is faked.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui";
+import { useTabsStore, useToastStore } from "@/stores";
+import type { MockServer, MockServerRoute } from "@/types";
+import ServicesPanel from "./ServicesPanel";
+
+const listMockServers = vi.fn();
+const stopMockServer = vi.fn();
+const listMockServerRoutes = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => Promise.resolve([]),
+			listMockIssuers: () => Promise.resolve([]),
+			listMockServers: () => listMockServers(),
+			stopMockServer: (...a: unknown[]) => stopMockServer(...a),
+			listMockServerRoutes: (...a: unknown[]) => listMockServerRoutes(...a),
+		},
+	};
+});
+
+const writeText = vi.fn();
+
+function mock(overrides: Partial<MockServer> = {}): MockServer {
+	return {
+		mockId: "mock_a",
+		collectionId: "col_1",
+		collectionName: "Pet Store",
+		url: "http://127.0.0.1:43100",
+		port: 43100,
+		latencyMs: 0,
+		errorRatePct: 0,
+		routeCount: 3,
+		routesWithoutExample: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
+function route(overrides: Partial<MockServerRoute> = {}): MockServerRoute {
+	return {
+		requestId: "req_1",
+		requestName: "List pets",
+		method: "GET",
+		path: "/pets",
+		hasExample: true,
+		status: 200,
+		...overrides,
+	};
+}
+
+function renderPanel() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<TooltipProvider>
+				<ServicesPanel />
+			</TooltipProvider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	cleanup();
+	listMockServers.mockReset().mockResolvedValue([]);
+	stopMockServer.mockReset().mockResolvedValue({ mockId: "mock_a", stopped: true });
+	listMockServerRoutes.mockReset().mockResolvedValue([]);
+	writeText.mockReset().mockResolvedValue(undefined);
+	vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+	useTabsStore.setState({ openTabs: [], activeTabId: null });
+	useToastStore.setState({ toasts: [] });
+});
+
+describe("the mock servers group", () => {
+	it("says where a mock comes from, since the group cannot start one", async () => {
+		renderPanel();
+		expect(await screen.findByText("Mock servers")).toBeInTheDocument();
+		expect(screen.getByText(/Open a collection and start one/i)).toBeInTheDocument();
+		// No create affordance here on purpose: a mock needs a collection, and
+		// this drawer has none selected.
+		expect(screen.queryByRole("button", { name: /new mock/i })).not.toBeInTheDocument();
+	});
+
+	it("leads with the collection, because two mocks of one differ only by port", async () => {
+		listMockServers.mockResolvedValue([
+			mock({ mockId: "mock_b", port: 43200 }),
+			mock({ mockId: "mock_a", port: 43100 }),
+		]);
+		renderPanel();
+
+		await screen.findAllByText("Pet Store");
+		expect(screen.getByText("Port 43100")).toBeInTheDocument();
+		expect(screen.getByText("Port 43200")).toBeInTheDocument();
+
+		// By port, not by engine map order: the list must not reshuffle on a poll.
+		const ports = screen.getAllByText(/^Port 43\d00$/).map((node) => node.textContent);
+		expect(ports).toEqual(["Port 43100", "Port 43200"]);
+	});
+
+	/*
+	 * The route table is the answer to the only question this surface gets
+	 * asked - "why did the mock 404 that?" - and it is why `GET /mock/:id/routes`
+	 * exists. Without a reader it would be the repo's most repeated defect over
+	 * again: a field written and never displayed.
+	 */
+	it("shows the table the mock is serving when a row is expanded", async () => {
+		listMockServers.mockResolvedValue([mock({ routeCount: 2, routesWithoutExample: 1 })]);
+		listMockServerRoutes.mockResolvedValue([
+			route(),
+			route({
+				requestId: "req_2",
+				requestName: "Get pet",
+				path: "/pets/{{petId}}",
+				hasExample: false,
+				status: 0,
+			}),
+		]);
+		renderPanel();
+
+		// Not fetched until the row is opened - the table is a start-time
+		// snapshot, so there is nothing to load for a row nobody is reading.
+		await screen.findByText("Pet Store");
+		expect(listMockServerRoutes).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: /expand mock server on port 43100/i }));
+
+		expect(await screen.findByText("/pets")).toBeInTheDocument();
+		expect(screen.getByText("/pets/{{petId}}")).toBeInTheDocument();
+		expect(listMockServerRoutes).toHaveBeenCalledWith("mock_a");
+		// A route with no example answers 501, so it is marked rather than
+		// listed as though it served.
+		expect(screen.getByText("no example")).toBeInTheDocument();
+		expect(screen.getByText(/1 of 2 routes have no example/i)).toBeInTheDocument();
+	});
+
+	it("copies the base URL rather than making it read off the row", async () => {
+		listMockServers.mockResolvedValue([mock()]);
+		renderPanel();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Copy mock server URL" }));
+		await waitFor(() => expect(writeText).toHaveBeenCalledWith("http://127.0.0.1:43100"));
+	});
+
+	it("stops a mock and drops it from the list", async () => {
+		// The engine drops the record with the listener, so every list after
+		// the stop is empty - which is what the invalidation has to pick up.
+		listMockServers.mockResolvedValueOnce([mock()]).mockResolvedValue([]);
+		renderPanel();
+
+		fireEvent.click(
+			await screen.findByRole("button", { name: /stop mock server on port 43100/i })
+		);
+		await waitFor(() => expect(stopMockServer).toHaveBeenCalledWith("mock_a"));
+		await waitFor(() =>
+			expect(screen.getByText(/Open a collection and start one/i)).toBeInTheDocument()
+		);
+	});
+
+	it("reports a failed stop instead of leaving the row looking stopped", async () => {
+		listMockServers.mockResolvedValue([mock()]);
+		stopMockServer.mockRejectedValue(new Error("Mock server not found"));
+		renderPanel();
+
+		fireEvent.click(
+			await screen.findByRole("button", { name: /stop mock server on port 43100/i })
+		);
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]?.message).toBe("Mock server not found")
+		);
+	});
+
+	it("keeps a failed route fetch inside the row it belongs to", async () => {
+		listMockServers.mockResolvedValue([mock()]);
+		listMockServerRoutes.mockRejectedValue(new Error("nope"));
+		renderPanel();
+
+		fireEvent.click(
+			await screen.findByRole("button", { name: /expand mock server on port 43100/i })
+		);
+		expect(await screen.findByText(/Couldn't load the routes/i)).toBeInTheDocument();
+		// The row itself is still there and still stoppable.
+		expect(
+			screen.getByRole("button", { name: /stop mock server on port 43100/i })
+		).toBeInTheDocument();
+	});
+
+	it("names the accessible row content rather than replacing it", async () => {
+		listMockServers.mockResolvedValue([mock()]);
+		renderPanel();
+
+		// The same rule the inbox and issuer rows follow: the verb is prefixed
+		// sr-only text, so a screen reader still hears the collection and port.
+		const activator = await screen.findByRole("button", {
+			name: /expand mock server on port 43100/i,
+		});
+		expect(within(activator).getByText("Pet Store")).toBeInTheDocument();
+		expect(within(activator).getByText("Port 43100")).toBeInTheDocument();
+	});
+});

--- a/app/src/modules/services/ServicesPanel.test.tsx
+++ b/app/src/modules/services/ServicesPanel.test.tsx
@@ -38,6 +38,7 @@ const deleteInbox = vi.fn();
 const startMockIssuer = vi.fn();
 const stopMockIssuer = vi.fn();
 const updateMockIssuer = vi.fn();
+const listMockServers = vi.fn();
 
 vi.mock("@/services/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/services/api")>();
@@ -53,6 +54,7 @@ vi.mock("@/services/api", async (importOriginal) => {
 			startMockIssuer: (...a: unknown[]) => startMockIssuer(...a),
 			stopMockIssuer: (...a: unknown[]) => stopMockIssuer(...a),
 			updateMockIssuer: (...a: unknown[]) => updateMockIssuer(...a),
+			listMockServers: () => listMockServers(),
 		},
 	};
 });
@@ -106,6 +108,7 @@ beforeEach(() => {
 	cleanup();
 	listInboxes.mockReset().mockResolvedValue([]);
 	listMockIssuers.mockReset().mockResolvedValue([]);
+	listMockServers.mockReset().mockResolvedValue([]);
 	startInbox.mockReset().mockResolvedValue(inbox());
 	stopInbox.mockReset().mockResolvedValue(inbox({ running: false }));
 	deleteInbox.mockReset().mockResolvedValue({ inboxId: "inbox_a", capturesDeleted: 0 });

--- a/app/src/modules/services/ServicesPanel.tsx
+++ b/app/src/modules/services/ServicesPanel.tsx
@@ -21,9 +21,12 @@
  * width); an issuer has no detail surface, so its whole management fits a row
  * that expands plus one dialog, and no new TabType.
  *
- * Mock servers (#481) get a group here when they exist. There is deliberately
- * no placeholder for them: a group that lists nothing and can start nothing
- * teaches a reader less than its absence does.
+ * Mock servers (#481 phase 2) are the third group. Unlike the other two it has
+ * no create affordance, and that is not an omission: a mock needs a collection
+ * to serve, and this drawer has none selected. The collection header owns the
+ * start (`CollectionDetail/MockServerControl`); this owns the list, so a mock
+ * started from any collection - or from curl - can be found and stopped in the
+ * one place every other running listener is.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -48,16 +51,19 @@ import {
 import {
 	useInboxesQuery,
 	useMockIssuersQuery,
+	useMockServerRoutesQuery,
+	useMockServersQuery,
 	useStartInboxMutation,
 	useStopInboxMutation,
 	useStopMockIssuerMutation,
+	useStopMockServerMutation,
 	useUpdateMockIssuerMutation,
 } from "@/queries";
 import { useTabsStore, useToastStore } from "@/stores";
 import { useCopy } from "@/hooks";
 import { TIMING } from "@/config/timing";
 import { cn } from "@/lib/utils";
-import type { Inbox, MockIssuer, MockIssuerFailureMode } from "@/types";
+import type { Inbox, MockIssuer, MockIssuerFailureMode, MockServer } from "@/types";
 import { DeleteInboxDialog } from "@/modules/inbox/DeleteInboxDialog";
 import { useInboxDeletion } from "@/modules/inbox/useInboxDeletion";
 import { FAILURE_MODE_LABELS, MAX_SLOW_MS, failureModeSummary } from "./failure-modes";
@@ -509,6 +515,137 @@ function IssuerDelayControl({
 }
 
 /**
+ * One running mock server, expanding to the table it is serving.
+ *
+ * The route table is the answer to the only question this surface gets asked -
+ * "why did the mock 404 that?" - and it is a start-time snapshot, so it is
+ * fetched once when the row is opened rather than polled. A row that carried
+ * only a URL would leave the user sending requests to find out what the mock
+ * knows about.
+ */
+function MockServerRow({
+	mock,
+	expanded,
+	onToggle,
+}: {
+	mock: MockServer;
+	expanded: boolean;
+	onToggle: () => void;
+}) {
+	const showToast = useToastStore((s) => s.showToast);
+	const copy = useCopy();
+	const stopMock = useStopMockServerMutation();
+	const routesQuery = useMockServerRoutesQuery(expanded ? mock.mockId : null);
+	const routes = routesQuery.data ?? [];
+
+	return (
+		<>
+			<ServiceRow
+				// Every listed mock is running: stopping one drops it from the
+				// engine's list rather than leaving a stopped record, since a mock
+				// holds nothing that outlives its listener. Same as an issuer,
+				// unlike an inbox and its captures.
+				running
+				onActivate={onToggle}
+				actionLabel={`${expanded ? "Collapse" : "Expand"} mock server on port ${mock.port}`}
+				leading={
+					expanded ? (
+						<ChevronDown
+							className="h-3 w-3 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+					) : (
+						<ChevronRight
+							className="h-3 w-3 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+					)
+				}
+				actions={
+					<>
+						<TooltipIconButton
+							label="Copy mock server URL"
+							tooltipHint={mock.url}
+							icon={<Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+							onClick={() => void copy(mock.url, "Mock server URL")}
+						/>
+						<TooltipIconButton
+							label={`Stop mock server on port ${mock.port}`}
+							icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
+							disabled={stopMock.isPending}
+							onClick={() =>
+								stopMock.mutate(mock.mockId, {
+									onError: (error) =>
+										showToast(
+											error instanceof Error
+												? error.message
+												: "Could not stop the mock server",
+											"error"
+										),
+								})
+							}
+						/>
+					</>
+				}
+			>
+				{/* The collection is what distinguishes one mock from another -
+				    two mocks of one collection differ only by port, and a column
+				    of near-identical loopback URLs is what the inbox rows learned
+				    not to lead with. */}
+				<TruncatedText className="text-xs">{mock.collectionName}</TruncatedText>
+				<span className="shrink-0 text-xs text-muted-foreground">Port {mock.port}</span>
+			</ServiceRow>
+
+			{expanded && (
+				<div className="surface-sunken rounded-md border-l-2 border-rule pl-2 ml-4 mr-1 mb-2">
+					<IssuerDetailRow
+						label="Base URL"
+						value={mock.url}
+						copyLabel="Copy mock server URL"
+						onCopy={() => void copy(mock.url, "Mock server URL")}
+					/>
+					<p className="py-1 text-xs text-muted-foreground">
+						{mock.latencyMs > 0 ? `${mock.latencyMs}ms latency` : "No added latency"}
+						{mock.errorRatePct > 0 && `, ${mock.errorRatePct}% of answers fail`}
+						{mock.routesWithoutExample > 0 &&
+							`, ${mock.routesWithoutExample} of ${mock.routeCount} routes have no example`}
+					</p>
+					{routesQuery.isError ? (
+						<ErrorState
+							variant="inline"
+							title="Couldn't load the routes"
+							className={cn("justify-start", GROUP_NOTE_CLASS)}
+							onRetry={() => void routesQuery.refetch()}
+						/>
+					) : (
+						<ul className="max-h-48 overflow-y-auto py-1">
+							{routes.map((route) => (
+								<li
+									key={`${route.method} ${route.path} ${route.requestId}`}
+									className="flex items-center gap-1.5 py-0.5"
+								>
+									<span className="w-12 shrink-0 font-mono text-[11px] text-muted-foreground">
+										{route.method}
+									</span>
+									<TruncatedText className="min-w-0 flex-1 font-mono text-xs">
+										{route.path}
+									</TruncatedText>
+									{/* A route with no example answers 501, so it is
+									    marked rather than listed as if it served. */}
+									<span className="shrink-0 text-[11px] text-muted-foreground">
+										{route.hasExample ? route.status : "no example"}
+									</span>
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+			)}
+		</>
+	);
+}
+
+/**
  * Which row was just created, for as long as it takes to notice it.
  *
  * Creating an inbox reported nothing at all: the mutation carried an `onError`
@@ -536,13 +673,16 @@ export default function ServicesPanel() {
 	const showToast = useToastStore((s) => s.showToast);
 	const inboxesQuery = useInboxesQuery();
 	const issuersQuery = useMockIssuersQuery();
+	const mocksQuery = useMockServersQuery();
 	const startInbox = useStartInboxMutation();
 	const [expandedIssuerId, setExpandedIssuerId] = useState<string | null>(null);
+	const [expandedMockId, setExpandedMockId] = useState<string | null>(null);
 	const [newIssuerOpen, setNewIssuerOpen] = useState(false);
 	const { flashedId: flashedInboxId, flash: flashInbox } = useRowFlash();
 
 	const inboxes = inboxesQuery.data ?? [];
 	const issuers = issuersQuery.data ?? [];
+	const mocks = mocksQuery.data ?? [];
 
 	/*
 	 * Per group, and only while that group has nothing to show. Each list is its
@@ -553,6 +693,7 @@ export default function ServicesPanel() {
 	 */
 	const showInboxError = inboxesQuery.isError && inboxes.length === 0;
 	const showIssuerError = issuersQuery.isError && issuers.length === 0;
+	const showMockError = mocksQuery.isError && mocks.length === 0;
 
 	/*
 	 * By port. The engine lists inboxes in map order, which is not stable across
@@ -563,6 +704,9 @@ export default function ServicesPanel() {
 	 * so the two lists cannot disagree about what order inboxes are in.
 	 */
 	const orderedInboxes = [...inboxes].sort((a, b) => a.port - b.port);
+	// Same rule, same reason: the engine lists mocks in map order too, and
+	// `createdAt` would reorder the list every time one is restarted.
+	const orderedMocks = [...mocks].sort((a, b) => a.port - b.port);
 
 	const start = () =>
 		startInbox.mutate(
@@ -657,6 +801,39 @@ export default function ServicesPanel() {
 								onToggle={() =>
 									setExpandedIssuerId((current) =>
 										current === issuer.issuerId ? null : issuer.issuerId
+									)
+								}
+							/>
+						))
+					)}
+				</ServiceGroup>
+
+				{/* No create affordance: a mock needs a collection to serve, and
+				    this drawer has none selected. The collection header starts
+				    one; this is where every running mock can be found. */}
+				<ServiceGroup title="Mock servers">
+					{showMockError ? (
+						<ErrorState
+							variant="inline"
+							title="Couldn't load the mock servers"
+							className={cn("justify-start", GROUP_NOTE_CLASS)}
+							onRetry={() => void mocksQuery.refetch()}
+						/>
+					) : mocks.length === 0 ? (
+						<EmptyState
+							variant="inline"
+							className={GROUP_NOTE_CLASS}
+							title="No mock running. Open a collection and start one to serve its saved example responses on a local URL - a free upstream to build or load-test against."
+						/>
+					) : (
+						orderedMocks.map((mock) => (
+							<MockServerRow
+								key={mock.mockId}
+								mock={mock}
+								expanded={expandedMockId === mock.mockId}
+								onToggle={() =>
+									setExpandedMockId((current) =>
+										current === mock.mockId ? null : mock.mockId
 									)
 								}
 							/>

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -98,6 +98,14 @@ export {
 	useStopMockIssuerMutation,
 } from "./mock-issuer";
 
+// Collection mock server (issue #481 phase 2)
+export {
+	useMockServersQuery,
+	useMockServerRoutesQuery,
+	useStartMockServerMutation,
+	useStopMockServerMutation,
+} from "./mock-server";
+
 // Health & Config
 export { useHealthQuery } from "./health";
 export { useConfigQuery, useUpdateConfigMutation } from "./config";

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -116,6 +116,16 @@ export const queryKeys = {
 		list: () => [...queryKeys.mockIssuer.all, "list"] as const,
 	},
 
+	// Collection mock servers (issue #481 phase 2). `list` is every running
+	// mock; `routes` is one mock's table, kept apart because the table is a
+	// start-time snapshot that never changes under a running mock - so it is
+	// fetched once per mock rather than riding on the list's poll.
+	mockServer: {
+		all: ["mockServer"] as const,
+		list: () => [...queryKeys.mockServer.all, "list"] as const,
+		routes: (mockId: string) => [...queryKeys.mockServer.all, "routes", mockId] as const,
+	},
+
 	// Warm-cache pass over every collection's requests (see
 	// usePrefetchCollectionsAndRequests). Keyed here rather than inline so it
 	// can be invalidated when the set of collections changes - it succeeds once

--- a/app/src/queries/mock-server.ts
+++ b/app/src/queries/mock-server.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Collection Mock Server Queries (issue #481 phase 2)
+ *
+ * A mock is a listener the engine holds until it is stopped or the process
+ * ends, so - as with an inbox or an issuer - none of this is stored state the
+ * app could rebuild: every hook here reads the engine back.
+ *
+ * The list is polled (`TIMING.SERVICES_POLL_INTERVAL_MS`) because this window
+ * is not the only client with the lifecycle: the routes answer curl, and the
+ * Services drawer and the collection header both promise to show a running mock
+ * wherever it was started from.
+ *
+ * The route table is *not* polled. It is a snapshot taken when the mock started
+ * and it cannot change under a running mock - editing the collection means
+ * restarting - so a poll would re-fetch a constant every few seconds.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiService } from "@/services/api";
+import { TIMING } from "@/config/timing";
+import type { StartMockServerRequest } from "@/types";
+import { queryKeys } from "./keys";
+
+/** Every mock this engine is running. A stopped one is gone, not listed. */
+export function useMockServersQuery() {
+	return useQuery({
+		queryKey: queryKeys.mockServer.list(),
+		queryFn: () => apiService.listMockServers(),
+		refetchInterval: TIMING.SERVICES_POLL_INTERVAL_MS,
+	});
+}
+
+/**
+ * One mock's route table.
+ *
+ * Disabled without a mock id so a surface can call it unconditionally before
+ * anything is started.
+ */
+export function useMockServerRoutesQuery(mockId: string | null) {
+	return useQuery({
+		queryKey: queryKeys.mockServer.routes(mockId ?? ""),
+		queryFn: () => apiService.listMockServerRoutes(mockId as string),
+		enabled: mockId !== null,
+		staleTime: Infinity,
+	});
+}
+
+export function useStartMockServerMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (request: StartMockServerRequest) => apiService.startMockServer(request),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: queryKeys.mockServer.list() });
+		},
+	});
+}
+
+export function useStopMockServerMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (mockId: string) => apiService.stopMockServer(mockId),
+		onSuccess: (_result, mockId) => {
+			// Nothing is left to read once a mock is stopped - its record goes
+			// with its listener - so the table cache is dropped rather than
+			// invalidated, which would refetch an id the engine now 404s.
+			queryClient.removeQueries({ queryKey: queryKeys.mockServer.routes(mockId) });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.mockServer.list() });
+		},
+	});
+}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -78,6 +78,12 @@ import type {
 	StartMockIssuerResponse,
 	UpdateMockIssuerRequest,
 	StopMockIssuerResponse,
+	MockServer,
+	MockServerRoute,
+	ListMockServersResponse,
+	ListMockServerRoutesResponse,
+	StartMockServerRequest,
+	StopMockServerResponse,
 } from "@/types";
 import type { MonitorSeriesResponse, TimeSeriesResponse } from "@/modules/history/types";
 import { queryClient } from "@/lib/query-client";
@@ -374,6 +380,35 @@ export const apiService = {
 			API_ENDPOINTS.MOCK_ISSUER_STOP(issuerId),
 			{}
 		);
+	},
+
+	// Collection mock server (issue #481 phase 2)
+	async listMockServers(): Promise<MockServer[]> {
+		const response = await httpClient.get<ListMockServersResponse>(API_ENDPOINTS.MOCK_SERVER);
+		return response.data;
+	},
+
+	async startMockServer(request: StartMockServerRequest): Promise<MockServer> {
+		return await httpClient.post<MockServer>(API_ENDPOINTS.MOCK_SERVER_START, request);
+	},
+
+	async stopMockServer(mockId: string): Promise<StopMockServerResponse> {
+		return await httpClient.post<StopMockServerResponse>(
+			API_ENDPOINTS.MOCK_SERVER_STOP(mockId),
+			{}
+		);
+	},
+
+	/**
+	 * The table a mock is serving - method, path template, and whether the
+	 * request behind it has an example. This is how "the mock answers 404" gets
+	 * diagnosed without sending a request per guess.
+	 */
+	async listMockServerRoutes(mockId: string): Promise<MockServerRoute[]> {
+		const response = await httpClient.get<ListMockServerRoutesResponse>(
+			API_ENDPOINTS.MOCK_SERVER_ROUTES(mockId)
+		);
+		return response.data;
 	},
 
 	// Execution

--- a/app/src/services/importers/path-template.conformance.test.ts
+++ b/app/src/services/importers/path-template.conformance.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Cross-language conformance: path templates (issue #481 phase 2).
+ *
+ * The app *writes* the URLs the engine's mock server has to read back. An
+ * OpenAPI import stores `{{baseUrl}}/pets/{{petId}}` because `normalizeVars`
+ * rewrote `{petId}`; the mock turns that same URL back into the route it
+ * serves. A rule the two sides answer differently is an imported request the
+ * mock silently cannot route - invisible until a 404 nobody can explain.
+ *
+ * `templateCases` is the shared half, asserted here and in
+ * `engine/tests/mock_server_routes_test.cpp`. `urlCases` is the engine's own
+ * half - stripping scheme, host, query and fragment, and the `:param` spelling
+ * that Postman writes and this parser never produces - so only the engine
+ * asserts those. This suite still requires them to exist, so emptying the
+ * fixture fails on both sides rather than passing vacuously on one.
+ *
+ * Read from the engine tree on purpose (same pattern as
+ * `variable-resolution.conformance.test.ts`): one file, two readers, no copy to
+ * drift.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { normalizeVars } from "./var-normalize";
+
+interface TemplateCase {
+	name: string;
+	input: string;
+	expected: string;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(
+	here,
+	"..",
+	"..",
+	"..",
+	"..",
+	"engine",
+	"tests",
+	"fixtures",
+	"path-template-conformance.json"
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+	templateCases: TemplateCase[];
+	urlCases: TemplateCase[];
+};
+
+describe("path-template conformance with the engine's mock server", () => {
+	// A fixture that read as an empty list would pass every case below while
+	// checking nothing - the failure mode a source-scanning guard in this repo
+	// shipped with for weeks.
+	it("reads a fixture with cases in both sections", () => {
+		expect(fixture.templateCases.length).toBeGreaterThanOrEqual(5);
+		expect(fixture.urlCases.length).toBeGreaterThanOrEqual(5);
+	});
+
+	it.each(fixture.templateCases)("$name", ({ input, expected }) => {
+		expect(normalizeVars(input, { pathTemplates: true })).toBe(expected);
+	});
+});

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -735,6 +735,68 @@ export interface StopMockIssuerResponse {
 	stopped: boolean;
 }
 
+// Collection mock server API (issue #481 phase 2). Engine-process state like an
+// inbox or an issuer: the engine holds each mock on its own loopback listener,
+// serving the collection's saved examples, and a restart forgets every one.
+
+/** One running mock server, as `POST /mock/start` and `GET /mock` describe it. */
+export interface MockServer {
+	mockId: string;
+	collectionId: string;
+	/** Named at start time - the collection may since have been renamed. */
+	collectionName: string;
+	/** `http://127.0.0.1:<port>`, with no trailing slash: a base to point at. */
+	url: string;
+	port: number;
+	latencyMs: number;
+	errorRatePct: number;
+	/** Requests in the collection subtree the mock is serving. */
+	routeCount: number;
+	/**
+	 * How many of those have no saved example and so answer 501.
+	 *
+	 * The number that explains an otherwise empty-looking mock, which is why it
+	 * is reported rather than left to be discovered one 501 at a time.
+	 */
+	routesWithoutExample: number;
+	createdAt: number;
+}
+
+export interface StartMockServerRequest {
+	collectionId: string;
+	/** 0 (the default) binds an ephemeral port. */
+	port?: number;
+	/** Artificial delay before every answer, 0-30000. */
+	latencyMs?: number;
+	/** Share of answers replaced by a synthesized 500, 0-100. */
+	errorRatePct?: number;
+}
+
+export interface ListMockServersResponse {
+	data: MockServer[];
+}
+
+export interface StopMockServerResponse {
+	mockId: string;
+	stopped: boolean;
+}
+
+/** One entry of a mock's route table, as `GET /mock/:id/routes` reports it. */
+export interface MockServerRoute {
+	requestId: string;
+	requestName: string;
+	method: string;
+	/** The normalized template, e.g. `/pets/{{petId}}`. */
+	path: string;
+	hasExample: boolean;
+	/** The example's status, or 0 when there is no example to serve. */
+	status: number;
+}
+
+export interface ListMockServerRoutesResponse {
+	data: MockServerRoute[];
+}
+
 // Health & Config API
 export type GetHealthResponse = EngineHealth;
 

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -116,7 +116,7 @@ Resizable sidebar (220–480px default, per view). The single left navigation fo
 | **`collections`** | `CollectionTree` (hierarchical collections + requests) | add collection, add request, import |
 | **`history`** | `HistoryList` (past runs, filtered/sorted) | run count |
 | **`variables`** | `VariablesCategoryTree` (globals, collections, environments) | - |
-| **`services`** | `ServicesPanel` (webhook inboxes, OAuth issuers) | new inbox, new issuer |
+| **`services`** | `ServicesPanel` (webhook inboxes, OAuth issuers, mock servers) | new inbox, new issuer |
 | **`settings`** | `SettingsCategoryTree` (app + engine setting categories) | - |
 
 Both `variables` and `settings` follow the same nav/content split: the tree lives here in the Drawer, the editor is the corresponding tab (`VariablesMain` / `SettingsMain`), and selecting a category sets the shared store selection **and** opens/focuses that tab.
@@ -324,7 +324,7 @@ Shared, Monaco-independent modules that power the GraphQL body mode.
 
 ### `CollectionDetail/` (screen `"collection-detail"`)
 
-Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows name + request count; five tabs:
+Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows name + request count, and - right-aligned - the mock-server control; five tabs:
 
 | Tab | Component | Notes |
 |---|---|---|
@@ -333,6 +333,15 @@ Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows n
 | Pre-request | `ScriptTab.tsx` (`kind="pre"`) | Collection pre-request script. **Autosaves** on editor blur - no Save |
 | Post-request | `ScriptTab.tsx` (`kind="post"`) | Collection post-request script. **Autosaves** on editor blur - no Save |
 | Variables | `VariablesTab.tsx` | Collection-scoped variables (count badge) |
+
+`MockServerControl.tsx` is the header's right-hand control and the only surface that can **start** a
+mock server (issue #481 phase 2), because it is the only one holding a collection. With none running
+for this collection it is a **Run mock server** button; with one running it is a chip carrying the
+base URL, the route count and how many of those routes have no example, plus copy and stop. It picks
+its mock by `collectionId` and, when several match, by the **lowest port** - nothing stops a user
+starting two mocks of one collection, and the engine's list order is not stable across polls. There
+is deliberately no restart: a mock's route table is a start-time snapshot, so stop-and-start is the
+only way to pick up an edit, and the stop tooltip says so.
 
 `InheritanceChain.tsx` and `shared.tsx` are helpers used by these tabs (e.g. visualizing the auth/variable inheritance chain); `format.ts` holds the relative-timestamp helper, kept out of `shared.tsx` so a file of components exports nothing else (fast refresh).
 
@@ -602,17 +611,28 @@ One home for the app's **local services** - the things that keep listening after
 (issue #502). Rendered as the `services` drawer view; the Dock's indicator and the welcome tile
 both activate it.
 
-- `ServicesPanel.tsx` - the view. Two groups today, **Webhook inboxes** and **OAuth issuers**, each
-  with its own start affordance in the group header and a one-sentence empty state saying what the
-  service would give you - this drawer is also the features' discoverability. An inbox row opens the
+- `ServicesPanel.tsx` - the view. Three groups: **Webhook inboxes**, **OAuth issuers** and **Mock
+  servers**, each with a one-sentence empty state saying what the service would give you - this
+  drawer is also the features' discoverability. The first two carry their own start affordance in
+  the group header; the third deliberately does not (see below). An inbox row opens the
   inbox *tab* (the drawer lists, the tab shows the captures) and carries copy, stop (running rows
   only) and **delete** (every row); an issuer row expands in place to its token and authorize URLs,
   a copy for the HS256 signing key, its configuration in one line, a live `failureMode` switch, and
   - in `slow` only - the delay that mode answers after, committed on blur rather than per keystroke.
   The inbox group's affordance is **New inbox** (Plus), matching **New issuer**: it always mints a
   new listener, and as a Play labelled "Start inbox" beside a stopped row it read as "restart that
-  one", which nothing here does (issue #553). Mock servers (#481) get a third group when they exist - deliberately no
-  placeholder until then.
+  one", which nothing here does (issue #553).
+
+  **Mock servers (#481 phase 2) have no start affordance here, and that is not an omission**: a
+  mock needs a collection to serve, and this drawer has none selected. The collection header owns
+  the start (`CollectionDetail/MockServerControl`); this group owns the list, so a mock started from
+  any collection - or from an MCP tool, or curl - can be found and stopped where every other running
+  listener is. A mock row leads with the **collection name** (two mocks of one collection differ
+  only by port) and expands in place to its base URL, its latency/error-rate line, and the **route
+  table** from `GET /mock/:id/routes` - the answer to the only question this surface gets asked,
+  "why did the mock 404 that?". The table is fetched when the row is opened and never polled: it is
+  a start-time snapshot that cannot change under a running mock. Stopping a mock removes it from the
+  list, like an issuer and unlike an inbox, because a mock holds nothing that outlives its listener.
 
   Row semantics, all from issue #555. An inbox row **leads with `Port NNNN`** and demotes the URL
   behind it: the port is the part that varies and the part a user names an inbox by, while three

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -215,6 +215,33 @@ issuer leaves the list altogether, unlike an inbox, which stays listed with
 bound listener and the engine refuses one with a `400` rather than half-applying
 it.
 
+#### Collection mock server
+
+```typescript
+apiService.listMockServers(): Promise<MockServer[]>
+apiService.startMockServer(request: StartMockServerRequest): Promise<MockServer>
+apiService.stopMockServer(mockId): Promise<StopMockServerResponse>
+apiService.listMockServerRoutes(mockId): Promise<MockServerRoute[]>
+```
+
+A loopback listener answering a collection's saved example responses on the
+paths its requests describe (issue #481 phase 2). `collectionId` is the only
+required field; `latencyMs` and `errorRatePct` are the injection knobs, and an
+out-of-range value is a `400` rather than a clamp.
+
+Two surfaces, deliberately split. `CollectionDetail/MockServerControl` is the
+only one that can **start** one, because a mock needs a collection and the
+Services drawer has none selected; the drawer's Mock servers group lists and
+stops whatever is running, wherever it came from. Both read the same polled
+list, so a mock started in one is visible in the other within a poll.
+
+`listMockServerRoutes` is **not** polled: the route table is a snapshot taken
+when the mock started and a running mock does not reload the collection, so it is
+fetched once per expanded row (`staleTime: Infinity`). Stopping drops the record
+engine-side - unlike an inbox, which stays listed with `running: false` - so the
+mutation *removes* the routes cache entry instead of invalidating it, which would
+refetch an id the engine now answers `404` for.
+
 #### Create vs update
 
 For collections, requests and environments the engine splits the write verbs:
@@ -589,6 +616,15 @@ export const API_ENDPOINTS = {
     `/inbox/${inboxId}/requests?limit=${limit}&offset=${offset}`,
   INBOX_CAPTURES_CLEAR: (inboxId: string) => `/inbox/${inboxId}/requests`,
   INBOX_LIVE: (inboxId: string) => `/inbox/${inboxId}/live`,
+
+  // Collection mock server - a loopback listener answering the collection's
+  // saved examples. Verb paths for the same reason the inbox uses them. No PUT
+  // and no DELETE: the route table is a start-time snapshot, so changing what a
+  // mock serves means starting another one, and stopping is what ends it.
+  MOCK_SERVER: "/mock",
+  MOCK_SERVER_START: "/mock/start",
+  MOCK_SERVER_STOP: (mockId: string) => `/mock/${mockId}/stop`,
+  MOCK_SERVER_ROUTES: (mockId: string) => `/mock/${mockId}/routes`,
 
   // Real-time stats (SSE)
   METRICS_LIVE: (runId: string) => `/runs/${runId}/live`,

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1601,6 +1601,155 @@ goes to the newcomer; the evicted stream ends on its next write. Every live
 stream writes at least a keep-alive each interval, so a genuinely live watcher is
 never evicted and a second concurrent one is still refused.
 
+## Mock Server
+
+A **mock server** is a listener that answers a collection's [saved
+examples](#request-examples) on the paths its requests describe. It is what
+examples are *for*: import a spec, and the responses it documented become a
+running upstream you can build a frontend against, or point a Vayu load run at,
+without a cloud plan or a second machine.
+
+**Lifetime is the engine process**, exactly as for an inbox and an issuer - a
+verb path starts it, ids are not restorable across restarts, and stopping one
+**drops its record**. There is no stopped state to read: a mock holds nothing
+that outlives its listener, unlike an inbox and its captures.
+
+**Load-testing against a mock is a supported workflow**, and it is the one this
+listener exists for as much as frontend development: a mock is a
+known-latency, zero-cost upstream on the same machine, so a run against it
+measures the *generator* rather than someone else's service, and costs nobody a
+bill. Start the mock, then point a run at one of its paths:
+
+```bash
+curl -s localhost:9876/mock/start -d '{"collectionId":"col_abc123","latencyMs":5}'
+# -> {"mockId":"mock_5f2a","url":"http://127.0.0.1:43117", ...}
+
+curl -s localhost:9876/runs -d '{
+  "mode":"constant_rps","targetRps":500,"duration":"30s",
+  "url":"http://127.0.0.1:43117/pets","method":"GET"
+}'
+```
+
+`latencyMs` is what makes the baseline realistic rather than degenerate, and
+`errorRatePct` is how a run's error handling and [threshold
+verdict](#post-runs) get exercised without breaking a real service.
+
+**Loopback only.** There is no `bind` field. Unlike an inbox - which serves
+capture-and-echo and nothing else, so a LAN-visible one is defensible - a mock
+re-serves stored response bodies verbatim, and a recorded response can carry
+whatever the real one did. See [architecture.md](architecture.md#listeners).
+
+**The route table is a start-time snapshot.** It is built once, from the
+collection and every collection under it (an OpenAPI import files its requests
+in a folder per tag, so the subtree is the only useful unit), and a running mock
+does not reload edits: stop it and start it again.
+
+**How a request is matched.**
+
+- The stored URL is reduced to a path: scheme and host - or the `{{baseUrl}}`
+  variable standing in for them - the query and the fragment are all dropped.
+- All three template spellings are one wildcard segment: `{{petId}}` (Vayu and
+  Postman), `{petId}` (OpenAPI) and `:petId` (Postman's other form). A wildcard
+  matches exactly one non-empty segment. The normalization is pinned to the
+  importers' own by `engine/tests/fixtures/path-template-conformance.json`,
+  which both suites read - the app writes these URLs and the mock reads them
+  back.
+- **Specificity wins, not registration order**: `/pets/mine` answers
+  `GET /pets/mine` even when `/pets/{{petId}}` was stored first.
+- A trailing slash and a repeated `/` are the same route.
+
+**What a miss says.** The message is most of the debugging value, so the three
+outcomes are distinct rather than one blanket 404:
+
+| Case | Status | `code` | Message names |
+|------|--------|--------|---------------|
+| No request has that path | 404 | `mock_no_route` | The method and path, and how many routes are served |
+| The path matches, the method does not | 404 | `mock_method_mismatch` | The matching path template and the methods it *is* served for |
+| A route matched but its request has no saved example | 501 | `mock_no_example` | The request's name, and that an example must be saved or imported |
+
+**Bounds** (rails, not settings): at most **8** mock servers at once (a listener
+thread each), at most **2000** routes in one table, and `latencyMs` capped at
+**30000** - it holds a listener thread for its whole duration and a stop waits
+on that join.
+
+### POST /mock/start
+
+**Request:**
+```json
+{
+  "collectionId": "col_abc123",
+  "port": 0,
+  "latencyMs": 0,
+  "errorRatePct": 0
+}
+```
+
+`collectionId` is required. `port` 0 (the default) binds a free one.
+`latencyMs` (0 - 30000) delays every answer; `errorRatePct` (0 - 100) replaces
+that share of answers with a synthesized `500` carrying `mock_injected_error`.
+Every out-of-range value is a `400` rather than a clamp.
+
+**Response:**
+```json
+{
+  "mockId": "mock_5f2a",
+  "collectionId": "col_abc123",
+  "collectionName": "Pet Store",
+  "url": "http://127.0.0.1:43117",
+  "port": 43117,
+  "latencyMs": 0,
+  "errorRatePct": 0,
+  "routeCount": 12,
+  "routesWithoutExample": 3,
+  "createdAt": 1735689600000
+}
+```
+
+`url` has **no trailing slash** - it is a base to concatenate a path onto.
+`routesWithoutExample` is the number that explains an otherwise empty-looking
+mock, which is why it is reported rather than left to be discovered one `501` at
+a time.
+
+**Errors:** `404` for a collection that does not exist; `400`
+`mock_no_requests` when the collection and its subtree hold none (a listener
+that 404s everything is never what the caller meant); `400`
+`mock_too_many_routes` past the table bound; `409` `mock_limit_reached` at the
+server budget; `409` `mock_bind_failed` when the requested port is taken,
+naming the holder when this engine is the one holding it.
+
+### GET /mock
+
+`{"data": [...]}` - every running mock, in the shape above.
+
+### GET /mock/:mockId/routes
+
+The table the mock is serving. This is how "the mock 404s that path" gets
+diagnosed without sending a request per guess.
+
+```json
+{
+  "data": [
+    {
+      "requestId": "req_1",
+      "requestName": "Get pet",
+      "method": "GET",
+      "path": "/pets/{{petId}}",
+      "hasExample": true,
+      "status": 200
+    }
+  ]
+}
+```
+
+`status` is `0` when `hasExample` is false - there is no example whose status it
+could be. `404` for an unknown mock.
+
+### POST /mock/:mockId/stop
+
+Stops the listener and drops the record: `{"mockId": "...", "stopped": true}`,
+or `404`. In-flight answers - including one inside its configured `latencyMs` -
+are joined before this returns.
+
 ## Authentication
 
 The engine **resolves auth server-side**. Every request's `auth` object (on

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -62,7 +62,7 @@ The HTTP server handles all API requests from the Electron UI. It runs on `127.0
 ### Listeners
 
 This is the engine's whole listener inventory. The management API is the only long-lived one;
-three more are opened on demand, and the rule that separates them is where each may bind.
+four more are opened on demand, and the rule that separates them is where each may bind.
 
 | Listener | Bind | Opened by | Serves |
 |----------|------|-----------|--------|
@@ -70,6 +70,7 @@ three more are opened on demand, and the rule that separates them is where each 
 | OAuth 2.0 loopback callback | `127.0.0.1`, ephemeral port | `POST /oauth2/authorize/start` in loopback mode | One `/callback` path, for the length of one authorization attempt (5-minute TTL) |
 | [Mock OAuth 2.0 issuer](api-reference.md#local-mock-issuer) | `127.0.0.1`, ephemeral port | `POST /mock-issuer/start` (at most 8) | `/token` and `/authorize`, until stopped |
 | [Webhook inbox](api-reference.md#webhook-inbox) | `127.0.0.1` by default; wider only on explicit confirmation | `POST /inbox/start` | Records any method on any path, answers a canned response |
+| [Collection mock server](api-reference.md#mock-server) | `127.0.0.1`, ephemeral port unless one is named | `POST /mock/start` (at most 8) | A collection's saved example responses, on the paths its requests describe, until stopped |
 
 **The inbox is the only one that may bind beyond loopback**, and the two reasons the others may not
 are different reasons:
@@ -83,6 +84,10 @@ are different reasons:
   configured - so exposing it to a LAN exposes capture-and-echo and nothing more. A webhook source
   on another host is a real case; a management API on another host is not one worth the blast
   radius.
+- A **mock server** re-serves stored response bodies verbatim, and a recorded response carries
+  whatever the real one carried - a session cookie, a token, a customer record. That is closer to
+  publishing the request store than to publishing an echo, so it has no `bind` field at all rather
+  than a confirmation gate.
 
 Even so, wide is never the default: `bind` outside 127.0.0.0/8 and `::1` is refused unless the
 caller sends `"confirmNonLoopback": true`, and the inbox then reports `loopback: false` on every
@@ -93,11 +98,13 @@ Each on-demand listener is owned by a manager that is a **member of `Server`, de
 `server_`** (`engine/include/vayu/http/server.hpp`). Members are destroyed in reverse order, so the
 route lambdas holding references to a manager are gone before its destructor stops and joins the
 listener threads - and the `Database` those threads write to, being external to `Server`, is still
-alive at that point. All three managers run that lifecycle - bind, wait for the accept loop, stop,
+alive at that point. All four managers run that lifecycle - bind, wait for the accept loop, stop,
 join, release - through one shared `ManagedListener`
 (`engine/include/vayu/http/managed_listener.hpp`), so a fix to it reaches every listener rather than
-one of three copies; what stays per-manager is the route registration, the error each bind failure
-answers with, and the OAuth attempt TTL sweep.
+one of four copies; what stays per-manager is the route registration, the error each bind failure
+answers with, and the OAuth attempt TTL sweep. The mock server is the one built on the helper rather
+than ported to it: #505 extracted it before this listener existed, which was the whole point of
+extracting it when the third one landed.
 
 That shared listener is also what keeps two of them off one port. Every live listener claims its
 address:port there, and an **explicitly requested** port a live listener already holds is refused

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -403,6 +403,7 @@ if(VAYU_BUILD_ENGINE)
         src/http/routes/cookies.cpp
         src/http/routes/mock_issuer.cpp
         src/http/routes/inbox.cpp
+        src/http/routes/mock_server.cpp
     )
 
     target_link_libraries(vayu-engine PRIVATE
@@ -490,6 +491,7 @@ if(VAYU_BUILD_TESTS)
         tests/oauth_authorize_test.cpp
         tests/mock_issuer_test.cpp
         tests/inbox_test.cpp
+        tests/mock_server_routes_test.cpp
         tests/id_test.cpp
         tests/curl_utils_test.cpp
         tests/curl_transfer_test.cpp
@@ -522,6 +524,7 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/cookies.cpp
         src/http/routes/mock_issuer.cpp
         src/http/routes/inbox.cpp
+        src/http/routes/mock_server.cpp
         src/http/managed_listener.cpp
     )
     

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -595,6 +595,31 @@ constexpr size_t MAX_PER_REQUEST = 100;
 } // namespace request_example
 
 /**
+ * @brief Local mock server bounds (issue #481 phase 2)
+ *
+ * Rails rather than preferences, the same split the inbox and the issuer draw:
+ * every value here bounds a resource the *caller* of the mock does not pay for
+ * - listener threads, and the route table one collection can make the engine
+ * hold. What a user actually tunes per mock (latency, error rate) is request
+ * payload, not config.
+ */
+namespace mock_server {
+/// Concurrently running mocks. Each owns a listener thread plus cpp-httplib's
+/// own accept loop, so this is a thread budget - the same one the issuer's
+/// MAX_ISSUERS is.
+constexpr size_t MAX_SERVERS = 8;
+/// Routes one mock may hold. A collection tree is walked whole at start, so
+/// this bounds what a single `POST /mock/start` materialises; past it the start
+/// is refused rather than the tail silently dropped.
+constexpr size_t MAX_ROUTES = 2000;
+/// Ceiling on the injected per-response delay. It holds a cpp-httplib pool
+/// thread for its whole duration - and the teardown join waits for it - so it
+/// is bounded well below any client timeout, exactly as the inbox's canned
+/// delay is.
+constexpr int MAX_LATENCY_MS = 30000;
+} // namespace mock_server
+
+/**
  * @brief Database optimization configuration
  */
 namespace database {

--- a/engine/include/vayu/http/mock_server.hpp
+++ b/engine/include/vayu/http/mock_server.hpp
@@ -1,0 +1,261 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "vayu/db/database.hpp"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace vayu::http {
+
+/**
+ * One segment of a request path, as the route table matches it.
+ *
+ * A templated segment matches any single non-empty segment; `literal` then
+ * holds the template's own name purely so a 404 can say which route nearly
+ * matched. Matching is per segment rather than by regex over the whole path,
+ * because a template is only ever a *whole* segment in every format Vayu
+ * imports - `/pets/{petId}` - and a substring matcher would have `/petsfoo`
+ * answering a route for `/pets`.
+ */
+struct MockPathSegment {
+    std::string literal;
+    bool templated = false;
+};
+
+/** The response one route answers with - a request's first saved example. */
+struct MockResponse {
+    int status = 200;
+    /// In stored order, duplicates intact: an example holds a KeyValueEntry
+    /// array precisely so a repeated `Set-Cookie` survives being re-served.
+    std::vector<std::pair<std::string, std::string>> headers;
+    std::string body;
+    std::string content_type;
+};
+
+/**
+ * One entry of a mock's route table: a stored request, its path template, and
+ * the example it answers with.
+ *
+ * Built once when the mock starts and const thereafter. A running mock does not
+ * hot-reload edits to the collection - restart it - which is what makes the
+ * table safe to read from a listener thread without a lock.
+ */
+struct MockRoute {
+    std::string request_id;
+    std::string request_name;
+    /// Upper-cased, as the wire carries it.
+    std::string method;
+    /// The normalized template, e.g. `/pets/{{petId}}` - what a 404 prints and
+    /// what `GET /mock` lists, so a user can see what the mock will answer.
+    std::string path_template;
+    std::vector<MockPathSegment> segments;
+    /// False when the request has no saved example. The route is kept anyway:
+    /// "this request matched but has nothing to serve" is a far better answer
+    /// than "no such route", and it is the one an import that dropped its
+    /// examples produces.
+    bool has_response = false;
+    MockResponse response;
+};
+
+/** Why a request did not match, so the 404 body can say which near-miss it was. */
+enum class MockMissKind {
+    /// Nothing in the table has this path shape at all.
+    NoPath,
+    /// The path matches a route, but none of them is registered for this method.
+    MethodMismatch,
+    /// A route matched, and it has no saved example to answer with.
+    NoExample,
+};
+
+/** The outcome of resolving one inbound `method + path` against a route table. */
+struct MockMatch {
+    /// Index into the table, set only when a route matched *and* can answer.
+    std::optional<size_t> route_index;
+    MockMissKind miss = MockMissKind::NoPath;
+    /// For `MethodMismatch`: the methods this path *is* registered for, sorted
+    /// and de-duplicated. For `NoExample`: empty - `route_index` is unset but
+    /// `matched_route` names the request that has nothing to serve.
+    std::vector<std::string> allowed_methods;
+    /// The route that matched the path, for the two miss kinds that had one.
+    std::optional<size_t> matched_route;
+};
+
+/** A started mock server, as `GET /mock` and the start route report it. */
+struct MockServerInfo {
+    std::string mock_id;
+    std::string collection_id;
+    std::string collection_name;
+    /// `http://127.0.0.1:<port>` - the base a client points at. No trailing
+    /// slash: it is concatenated with a path that always has a leading one.
+    std::string url;
+    int port = 0;
+    int latency_ms      = 0;
+    int error_rate_pct  = 0;
+    /// How many routes the table holds, and how many of those have no example
+    /// to serve. The second number is the one that explains an empty-looking
+    /// mock, so it is reported rather than left to be discovered per-404.
+    int route_count            = 0;
+    int routes_without_example = 0;
+    int64_t created_at         = 0;
+};
+
+/** A validated `POST /mock/start` payload. */
+struct MockStartRequest {
+    std::string collection_id;
+    int port           = 0; // 0 = pick an ephemeral port
+    int latency_ms     = 0;
+    int error_rate_pct = 0;
+};
+
+/**
+ * The outcome of validating a payload - the same plain-field shape
+ * `InboxParseError` uses, so the parsing cores stay free of the route helpers
+ * and testable on their own.
+ */
+struct MockParseError {
+    int http_status = 400;
+    std::string code;
+    std::string message;
+};
+
+/**
+ * Validate a `POST /mock/start` payload.
+ *
+ * `collectionId` is the one required field; every other rejection is loud
+ * rather than a fallback to the default, for the reason `parse_inbox_start`
+ * gives - a mock quietly serving with no latency when 50000ms was asked for is
+ * a listener doing something other than what its caller asked for.
+ *
+ * There is no `bind`: a mock is loopback-only in v1. Unlike an inbox there is
+ * no case for exposing it - it answers with stored example bodies, which can
+ * carry whatever a recorded response carried, and the engine has no route auth.
+ */
+std::optional<MockParseError>
+parse_mock_start (const nlohmann::json& json, MockStartRequest& out);
+
+/**
+ * Reduce a stored request URL to the path template the mock matches on.
+ *
+ * A stored URL is whatever the user or an importer wrote: `{{baseUrl}}/pets/1`,
+ * `https://api.example.com/pets/{petId}`, `/pets/:petId`. Everything before the
+ * path - scheme and host, or a leading `{{var}}` standing in for both - is
+ * dropped, since the mock *is* the host; the query and fragment go with it.
+ *
+ * The three template spellings collapse to one: `{{petId}}`, `{petId}` and
+ * `:petId` all normalize to `{{petId}}`. The `{x}` -> `{{x}}` half mirrors the
+ * app's `normalizeVars(path, {pathTemplates: true})` exactly, and the two are
+ * pinned together by `tests/fixtures/path-template-conformance.json` - the app
+ * writes the URLs this function has to read back, so a rule answered two ways
+ * is an imported request the mock cannot route.
+ */
+std::string normalize_mock_path (const std::string& url);
+
+/** Split a normalized path into the segments `resolve_mock_route` matches. */
+std::vector<MockPathSegment> mock_path_segments (const std::string& path);
+
+/**
+ * Build a mock's route table from a collection and every collection under it.
+ *
+ * The whole subtree, not one level: an OpenAPI import puts its requests in a
+ * folder per tag, so a mock of the root collection that only read direct
+ * children would serve nothing at all.
+ *
+ * Ordered by collection walk then by the request's own `order`, and the first
+ * matching route wins ties - so the table is reproducible across restarts
+ * rather than dependent on map iteration.
+ */
+std::vector<MockRoute> build_mock_routes (vayu::db::Database& db, const std::string& collection_id);
+
+/**
+ * Resolve one inbound `method + path` against @p routes.
+ *
+ * Specificity, not registration order, decides between two matching routes:
+ * fewer templated segments wins, so `/pets/mine` beats `/pets/{{petId}}` for
+ * `/pets/mine`. Without it the answer would depend on which request an import
+ * happened to write first, and a literal route could be permanently shadowed.
+ */
+MockMatch resolve_mock_route (const std::vector<MockRoute>& routes,
+const std::string& method,
+const std::string& path);
+
+/** The 404 body a miss answers with - the near-miss is the debugging value. */
+nlohmann::json
+mock_miss_body (const std::vector<MockRoute>& routes, const MockMatch& match, const std::string& method, const std::string& path);
+
+/** The wire shape of a mock, shared by start and list. */
+nlohmann::json mock_server_info_json (const MockServerInfo& info);
+
+/** The wire shape of one route, for `GET /mock/:id/routes`. */
+nlohmann::json mock_route_json (const MockRoute& route);
+
+/**
+ * Owns the engine's collection mock servers (issue #481 phase 2).
+ *
+ * Each mock is an independent `httplib::Server` on its own thread that answers
+ * a collection's saved example responses on the paths its requests describe.
+ * The route table is built once at start and never reloaded, so a mock serves a
+ * consistent snapshot for its whole life - edit the collection and restart it.
+ *
+ * Thread-safe. The destructor stops and joins every listener; the handlers read
+ * only the immutable route table and the manager's own lock is never taken from
+ * one, so a teardown holding it can always join.
+ */
+class MockServerManager {
+    public:
+    // Out-of-line because the map holds unique_ptr<MockServer> and MockServer
+    // is incomplete here (same reason as InboxManager).
+    MockServerManager ();
+    ~MockServerManager ();
+
+    MockServerManager (const MockServerManager&)            = delete;
+    MockServerManager& operator= (const MockServerManager&) = delete;
+
+    struct StartResult {
+        bool ok         = true;
+        int http_status = 500;
+        std::string error_code;
+        std::string error_message;
+        MockServerInfo info;
+    };
+
+    StartResult start (vayu::db::Database& db, const MockStartRequest& request);
+
+    /**
+     * Stop the listener and drop the record.
+     *
+     * A stop *is* a delete here, unlike an inbox: a mock holds no captured
+     * state that would outlive its listener, so a stopped record would list
+     * something that answers nothing and can never answer again (the table is
+     * a start-time snapshot). Same shape a mock issuer's stop takes.
+     *
+     * False when no such mock exists.
+     */
+    bool stop (const std::string& mock_id);
+
+    std::optional<MockServerInfo> get (const std::string& mock_id);
+    std::vector<MockServerInfo> list ();
+
+    /// The route table @p mock_id is serving, or nullopt when it does not
+    /// exist. Const since start(), so this is a copy of an immutable snapshot.
+    std::optional<std::vector<MockRoute>> routes (const std::string& mock_id);
+
+    private:
+    struct MockServer;
+    std::mutex mutex_;
+    std::map<std::string, std::unique_ptr<MockServer>> servers_;
+};
+
+} // namespace vayu::http

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -38,6 +38,9 @@ class MockIssuerManager;
 // the same reason as the two managers above - a route TU that never touches an
 // inbox does not pull in the listener machinery.
 class InboxManager;
+// Owns the collection mock servers; defined in mock_server.hpp. Forward-
+// declared for the same reason as the three managers above.
+class MockServerManager;
 } // namespace vayu::http
 
 namespace vayu::http::routes {
@@ -550,6 +553,9 @@ struct RouteContext {
     vayu::http::MockIssuerManager& mock_issuer_manager;
     /// The webhook inboxes (issue #480). Owned by Server; read by `/inbox`.
     vayu::http::InboxManager& inbox_manager;
+    /// The collection mock servers (issue #481 phase 2). Owned by Server; read
+    /// by `/mock`.
+    vayu::http::MockServerManager& mock_server_manager;
 };
 
 // Route registration functions (implemented in separate files)
@@ -571,6 +577,7 @@ void register_oauth_routes (RouteContext& ctx);
 void register_cookie_routes (RouteContext& ctx);
 void register_mock_issuer_routes (RouteContext& ctx);
 void register_inbox_routes (RouteContext& ctx);
+void register_mock_server_routes (RouteContext& ctx);
 
 /**
  * @brief Generate the TypeScript declarations for the `pm.*` script surface.

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -17,6 +17,7 @@
 #include "vayu/db/database.hpp"
 #include "vayu/http/inbox.hpp"
 #include "vayu/http/mock_issuer.hpp"
+#include "vayu/http/mock_server.hpp"
 #include "vayu/http/oauth_authorize.hpp"
 #include "vayu/http/routes.hpp"
 
@@ -50,17 +51,18 @@ class Server {
     // reference these members are gone with server_, and db_ - external, so
     // outliving all of this - is still alive when their destructors run.
     //
-    // That matters most for the three listener-owning managers: each holds one
-    // ManagedListener per attempt / issuer / inbox, and each destructor stops
-    // and joins those listener threads while a handler may still be writing to
-    // db_. The one rule they all run on lives on the helper - see
-    // managed_listener.hpp. The cookie jar is here for the first half of the
-    // reason alone: an in-flight /execute holds a reference to it, and it is
+    // That matters most for the four listener-owning managers: each holds one
+    // ManagedListener per attempt / issuer / inbox / mock server, and each
+    // destructor stops and joins those listener threads while a handler may
+    // still be writing to db_. The one rule they all run on lives on the helper
+    // - see managed_listener.hpp. The cookie jar is here for the first half of
+    // the reason alone: an in-flight /execute holds a reference to it, and it is
     // process-lifetime by design (see cookie_jar.hpp).
     OAuth2AuthorizeManager oauth_authorize_manager_;
     CookieJar cookie_jar_;
     MockIssuerManager mock_issuer_manager_;
     InboxManager inbox_manager_;
+    MockServerManager mock_server_manager_;
     httplib::Server server_;
     std::thread server_thread_;
     std::atomic<bool> is_running_{ false };

--- a/engine/src/http/routes/mock_server.cpp
+++ b/engine/src/http/routes/mock_server.cpp
@@ -1,0 +1,865 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/routes/mock_server.cpp
+ * @brief The collection mock server: an engine-hosted listener that answers a
+ *        collection's saved example responses (issue #481 phase 2), plus the
+ *        routes that drive it. Lives with the routes for the same reason
+ *        inbox.cpp does - the listener needs httplib, which is linked into the
+ *        engine and the tests.
+ *
+ * Phase 1 gave examples somewhere to live; this is what they are *for*. The
+ * route table is a start-time snapshot of the collection tree, so the listener
+ * thread reads immutable state and the manager's lock never has to be taken
+ * from a handler.
+ */
+
+#include "vayu/http/mock_server.hpp"
+
+#include "vayu/core/constants.hpp"
+#include "vayu/http/managed_listener.hpp"
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/id.hpp"
+#include "vayu/utils/logger.hpp"
+
+#include <httplib.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <set>
+#include <string_view>
+#include <thread>
+#include <unordered_set>
+
+namespace vayu::http {
+
+namespace constants = vayu::core::constants;
+
+namespace {
+
+/// The characters the app's `SIMPLE_VAR` accepts inside `{{ }}` (`[\w.$-]`).
+bool is_simple_var_char (char ch) {
+    const auto c = static_cast<unsigned char> (ch);
+    return std::isalnum (c) != 0 || ch == '_' || ch == '.' || ch == '$' || ch == '-';
+}
+
+/// The characters the app's `PATH_TEMPLATE` accepts inside `{ }` (`[\w$-]`) -
+/// no dot, deliberately: `{a.b}` is not a path parameter in OpenAPI.
+bool is_path_template_char (char ch) {
+    const auto c = static_cast<unsigned char> (ch);
+    return std::isalnum (c) != 0 || ch == '_' || ch == '$' || ch == '-';
+}
+
+std::string trimmed (std::string_view value) {
+    const auto begin = value.find_first_not_of (" \t");
+    if (begin == std::string_view::npos) {
+        return {};
+    }
+    const auto end = value.find_last_not_of (" \t");
+    return std::string (value.substr (begin, end - begin + 1));
+}
+
+/**
+ * Rewrite every template spelling in @p path to `{{name}}`.
+ *
+ * Mirrors `normalizeVars(path, {pathTemplates: true})` in
+ * `app/src/services/importers/var-normalize.ts`: `{{ x }}` and `{{ _.x }}`
+ * tighten to `{{x}}`, a single-brace `{x}` becomes `{{x}}`, and anything that
+ * does not fit either shape (a Nunjucks filter, `{a|b}`) is left verbatim
+ * rather than guessed at. Pinned to the app's copy by
+ * `tests/fixtures/path-template-conformance.json`.
+ */
+std::string normalize_templates (const std::string& path) {
+    std::string out;
+    out.reserve (path.size ());
+    for (std::size_t i = 0; i < path.size ();) {
+        if (path.compare (i, 2, "{{") == 0) {
+            const auto close = path.find ("}}", i + 2);
+            if (close != std::string::npos) {
+                const std::string name = trimmed (std::string_view (path).substr (i + 2, close - i - 2));
+                const bool ok = !name.empty () &&
+                std::all_of (name.begin (), name.end (), is_simple_var_char);
+                if (ok) {
+                    // `_.x` is Insomnia's spelling of the same variable.
+                    const std::string bare = name.rfind ("_.", 0) == 0 ? name.substr (2) : name;
+                    out += "{{" + bare + "}}";
+                    i = close + 2;
+                    continue;
+                }
+            }
+            out += path.substr (i, 2);
+            i += 2;
+            continue;
+        }
+        if (path[i] == '{') {
+            const auto close = path.find ('}', i + 1);
+            const bool doubled = close != std::string::npos && close + 1 < path.size () &&
+            path[close + 1] == '}';
+            if (close != std::string::npos && close > i + 1 && !doubled) {
+                const std::string_view name (path.data () + i + 1, close - i - 1);
+                if (std::all_of (name.begin (), name.end (), is_path_template_char)) {
+                    out += "{{" + std::string (name) + "}}";
+                    i = close + 1;
+                    continue;
+                }
+            }
+        }
+        out += path[i];
+        ++i;
+    }
+    return out;
+}
+
+/// True when @p authority looks like a host rather than the first segment of a
+/// relative path: it carries a dot, a port colon, or is `localhost` itself.
+/// A stored request URL needs a host to be executable, so this errs towards
+/// treating a leading token as one - but `pets` alone stays a path segment.
+bool looks_like_authority (std::string_view authority) {
+    return authority == "localhost" ||
+    authority.find_first_of (".:") != std::string_view::npos;
+}
+
+/// `:param` -> `{{param}}`, applied to a whole segment only. Never reached by a
+/// scheme (`http://`) or a port (`localhost:3000`) - both live in the authority
+/// this runs after.
+std::string normalize_colon_segment (const std::string& segment) {
+    if (segment.size () < 2 || segment[0] != ':') {
+        return segment;
+    }
+    const std::string_view name (segment.data () + 1, segment.size () - 1);
+    if (!std::all_of (name.begin (), name.end (), is_path_template_char)) {
+        return segment;
+    }
+    return "{{" + std::string (name) + "}}";
+}
+
+} // namespace
+
+std::string normalize_mock_path (const std::string& url) {
+    std::string work = trimmed (url);
+
+    // The query and the fragment are not matched on - a mock answers a route,
+    // not a query shape.
+    if (const auto cut = work.find_first_of ("?#"); cut != std::string::npos) {
+        work = work.substr (0, cut);
+    }
+
+    // Scheme and host, or the variable standing in for both, name where the
+    // real service lives. The mock *is* the host, so they go.
+    if (const auto scheme = work.find ("://"); scheme != std::string::npos) {
+        const auto slash = work.find ('/', scheme + 3);
+        work = slash == std::string::npos ? std::string () : work.substr (slash);
+    } else if (work.rfind ("{{", 0) == 0) {
+        const auto close = work.find ("}}");
+        work = close == std::string::npos ? std::string () : work.substr (close + 2);
+    } else if (!work.empty () && work[0] != '/') {
+        const auto slash = work.find ('/');
+        const std::string_view authority (work.data (), slash == std::string::npos ? work.size () : slash);
+        if (looks_like_authority (authority)) {
+            work = slash == std::string::npos ? std::string () : work.substr (slash);
+        }
+    }
+
+    work = normalize_templates (work);
+
+    // Rebuild from segments: that applies the `:param` rule per whole segment,
+    // collapses `//`, drops a trailing slash, and guarantees a leading one.
+    std::string out;
+    std::size_t start = 0;
+    while (start <= work.size ()) {
+        const auto slash = work.find ('/', start);
+        const std::string segment =
+        work.substr (start, slash == std::string::npos ? std::string::npos : slash - start);
+        if (!segment.empty ()) {
+            out += '/';
+            out += normalize_colon_segment (segment);
+        }
+        if (slash == std::string::npos) {
+            break;
+        }
+        start = slash + 1;
+    }
+    return out.empty () ? "/" : out;
+}
+
+std::vector<MockPathSegment> mock_path_segments (const std::string& path) {
+    std::vector<MockPathSegment> segments;
+    std::size_t start = 0;
+    while (start <= path.size ()) {
+        const auto slash = path.find ('/', start);
+        const std::string piece =
+        path.substr (start, slash == std::string::npos ? std::string::npos : slash - start);
+        if (!piece.empty ()) {
+            MockPathSegment segment;
+            const bool templated = piece.size () > 4 && piece.rfind ("{{", 0) == 0 &&
+            piece.compare (piece.size () - 2, 2, "}}") == 0;
+            segment.templated = templated;
+            segment.literal = templated ? piece.substr (2, piece.size () - 4) : piece;
+            segments.push_back (std::move (segment));
+        }
+        if (slash == std::string::npos) {
+            break;
+        }
+        start = slash + 1;
+    }
+    return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Payload validation (pure - unit-tested without a listener)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Read a bounded integer field, or say why it was refused. Absent and `null`
+/// both keep @p out, which the caller seeded with the default.
+std::optional<MockParseError> read_bounded_int (const nlohmann::json& json,
+const char* key,
+int low,
+int high,
+int& out) {
+    const auto it = json.find (key);
+    if (it == json.end () || it->is_null ()) {
+        return std::nullopt;
+    }
+    if (!it->is_number_integer () || it->get<int> () < low || it->get<int> () > high) {
+        return MockParseError{ 400, "bad_request",
+            std::string ("Invalid '") + key + "': must be an integer between " +
+            std::to_string (low) + " and " + std::to_string (high) };
+    }
+    out = it->get<int> ();
+    return std::nullopt;
+}
+
+} // namespace
+
+std::optional<MockParseError>
+parse_mock_start (const nlohmann::json& json, MockStartRequest& out) {
+    out = MockStartRequest{};
+    if (!json.is_object ()) {
+        return MockParseError{ 400, "bad_request", "Request body must be a JSON object" };
+    }
+
+    const auto collection = json.find ("collectionId");
+    if (collection == json.end () || !collection->is_string () ||
+    collection->get<std::string> ().empty ()) {
+        return MockParseError{ 400, "bad_request",
+            "'collectionId' is required and must be a non-empty string" };
+    }
+    out.collection_id = collection->get<std::string> ();
+
+    if (auto err = read_bounded_int (json, "port", 0, 65535, out.port)) {
+        return err;
+    }
+    if (auto err = read_bounded_int (json, "latencyMs", 0,
+        constants::mock_server::MAX_LATENCY_MS, out.latency_ms)) {
+        return err;
+    }
+    if (auto err = read_bounded_int (json, "errorRatePct", 0, 100, out.error_rate_pct)) {
+        return err;
+    }
+    return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+// The route table
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// The enabled header rows of a stored example, in order and with duplicates
+/// intact - the reason an example stores an array rather than an object.
+std::vector<std::pair<std::string, std::string>> example_headers (const std::string& blob) {
+    std::vector<std::pair<std::string, std::string>> out;
+    if (blob.empty ()) {
+        return out;
+    }
+    const auto rows = nlohmann::json::parse (blob, nullptr, /*allow_exceptions=*/false);
+    if (!rows.is_array ()) {
+        return out;
+    }
+    for (const auto& row : rows) {
+        if (!row.is_object ()) {
+            continue;
+        }
+        const auto key = row.find ("key");
+        if (key == row.end () || !key->is_string () || key->get<std::string> ().empty ()) {
+            continue;
+        }
+        if (const auto enabled = row.find ("enabled");
+            enabled != row.end () && enabled->is_boolean () && !enabled->get<bool> ()) {
+            continue;
+        }
+        const auto value = row.find ("value");
+        out.emplace_back (key->get<std::string> (),
+        (value != row.end () && value->is_string ()) ? value->get<std::string> () : "");
+    }
+    return out;
+}
+
+bool header_is (const std::string& name, const char* wanted) {
+    if (name.size () != std::strlen (wanted)) {
+        return false;
+    }
+    return std::equal (name.begin (), name.end (), wanted, [] (char a, char b) {
+        return std::tolower (static_cast<unsigned char> (a)) ==
+        std::tolower (static_cast<unsigned char> (b));
+    });
+}
+
+/// The content type an example is served under: its denormalized column, then
+/// its own `Content-Type` header, then plain text - never a guess at the body.
+std::string
+example_content_type (const vayu::db::RequestExample& example,
+const std::vector<std::pair<std::string, std::string>>& headers) {
+    if (!example.content_type.empty ()) {
+        return example.content_type;
+    }
+    for (const auto& [name, value] : headers) {
+        if (header_is (name, "content-type")) {
+            return value;
+        }
+    }
+    return "text/plain";
+}
+
+} // namespace
+
+std::vector<MockRoute>
+build_mock_routes (vayu::db::Database& db, const std::string& collection_id) {
+    // The whole subtree: an OpenAPI import files its requests under a folder
+    // per tag, so a mock reading only direct children would serve nothing.
+    std::vector<vayu::db::Collection> all = db.get_collections ();
+    std::sort (all.begin (), all.end (), [] (const auto& a, const auto& b) {
+        return a.order != b.order ? a.order < b.order : a.id < b.id;
+    });
+
+    std::vector<std::string> walk;
+    std::deque<std::string> pending{ collection_id };
+    std::unordered_set<std::string> seen{ collection_id };
+    while (!pending.empty ()) {
+        const std::string current = pending.front ();
+        pending.pop_front ();
+        walk.push_back (current);
+        for (const auto& candidate : all) {
+            if (candidate.parent_id && *candidate.parent_id == current &&
+            seen.insert (candidate.id).second) {
+                pending.push_back (candidate.id);
+            }
+        }
+    }
+
+    std::vector<MockRoute> routes;
+    for (const auto& id : walk) {
+        for (const auto& request : db.get_requests_in_collection (id)) {
+            if (routes.size () > constants::mock_server::MAX_ROUTES) {
+                return routes; // The caller refuses a table this size; see start().
+            }
+            MockRoute route;
+            route.request_id    = request.id;
+            route.request_name  = request.name;
+            route.method        = to_string (request.method);
+            route.path_template = normalize_mock_path (request.url);
+            route.segments      = mock_path_segments (route.path_template);
+
+            const auto examples = db.get_request_examples (request.id);
+            if (!examples.empty ()) {
+                // The first one, in the order phase 1 made a contract.
+                const auto& example      = examples.front ();
+                route.has_response       = true;
+                route.response.status    = example.status;
+                route.response.headers   = example_headers (example.headers);
+                route.response.body      = example.body;
+                route.response.content_type =
+                example_content_type (example, route.response.headers);
+            }
+            routes.push_back (std::move (route));
+        }
+    }
+    return routes;
+}
+
+MockMatch resolve_mock_route (const std::vector<MockRoute>& routes,
+const std::string& method,
+const std::string& path) {
+    const auto wanted = mock_path_segments (path);
+
+    MockMatch match;
+    std::vector<std::size_t> path_matches;
+    for (std::size_t i = 0; i < routes.size (); ++i) {
+        const auto& segments = routes[i].segments;
+        if (segments.size () != wanted.size ()) {
+            continue;
+        }
+        bool ok = true;
+        for (std::size_t s = 0; s < segments.size () && ok; ++s) {
+            ok = segments[s].templated || segments[s].literal == wanted[s].literal;
+        }
+        if (ok) {
+            path_matches.push_back (i);
+        }
+    }
+
+    if (path_matches.empty ()) {
+        match.miss = MockMissKind::NoPath;
+        return match;
+    }
+
+    // Specificity decides, not registration order: `/pets/mine` must beat
+    // `/pets/{{petId}}`, otherwise which one answers depends on the order an
+    // import happened to write the two requests in.
+    std::optional<std::size_t> best;
+    std::size_t best_wildcards = 0;
+    for (const auto index : path_matches) {
+        if (routes[index].method != method) {
+            continue;
+        }
+        const auto wildcards = static_cast<std::size_t> (
+        std::count_if (routes[index].segments.begin (), routes[index].segments.end (),
+        [] (const MockPathSegment& segment) { return segment.templated; }));
+        if (!best || wildcards < best_wildcards) {
+            best           = index;
+            best_wildcards = wildcards;
+        }
+    }
+
+    if (!best) {
+        match.miss          = MockMissKind::MethodMismatch;
+        match.matched_route = path_matches.front ();
+        std::set<std::string> methods;
+        for (const auto index : path_matches) {
+            methods.insert (routes[index].method);
+        }
+        match.allowed_methods.assign (methods.begin (), methods.end ());
+        return match;
+    }
+
+    if (!routes[*best].has_response) {
+        match.miss          = MockMissKind::NoExample;
+        match.matched_route = *best;
+        return match;
+    }
+
+    match.route_index  = *best;
+    match.matched_route = *best;
+    return match;
+}
+
+nlohmann::json mock_miss_body (const std::vector<MockRoute>& routes,
+const MockMatch& match,
+const std::string& method,
+const std::string& path) {
+    const std::string target = method + " " + path;
+    switch (match.miss) {
+    case MockMissKind::MethodMismatch: {
+        const auto& matched = routes[*match.matched_route];
+        std::string methods;
+        for (const auto& allowed : match.allowed_methods) {
+            methods += (methods.empty () ? "" : ", ") + allowed;
+        }
+        return routes::error_body (404,
+        target + " - no request matches that method; '" + matched.path_template +
+        "' is served for " + methods,
+        "mock_method_mismatch");
+    }
+    case MockMissKind::NoExample: {
+        const auto& matched = routes[*match.matched_route];
+        return routes::error_body (501,
+        target + " matches request '" + matched.request_name +
+        "', but it has no saved example to serve - import or save one, then restart the mock",
+        "mock_no_example");
+    }
+    case MockMissKind::NoPath:
+    default:
+        return routes::error_body (404,
+        target + " - no request in this collection has that path (" +
+        std::to_string (routes.size ()) + " served)",
+        "mock_no_route");
+    }
+}
+
+nlohmann::json mock_server_info_json (const MockServerInfo& info) {
+    nlohmann::json out;
+    out["mockId"]               = info.mock_id;
+    out["collectionId"]         = info.collection_id;
+    out["collectionName"]       = info.collection_name;
+    out["url"]                  = info.url;
+    out["port"]                 = info.port;
+    out["latencyMs"]            = info.latency_ms;
+    out["errorRatePct"]         = info.error_rate_pct;
+    out["routeCount"]           = info.route_count;
+    out["routesWithoutExample"] = info.routes_without_example;
+    out["createdAt"]            = info.created_at;
+    return out;
+}
+
+nlohmann::json mock_route_json (const MockRoute& route) {
+    nlohmann::json out;
+    out["requestId"]   = route.request_id;
+    out["requestName"] = route.request_name;
+    out["method"]      = route.method;
+    out["path"]        = route.path_template;
+    out["hasExample"]  = route.has_response;
+    out["status"]      = route.has_response ? route.response.status : 0;
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// The listener
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Whether this completion should be turned into a synthesized 500.
+///
+/// 0 and 100 are exact by construction rather than by probability, which is
+/// what makes them the only rates worth a test. In between, the roll is a
+/// splitmix64 of a per-mock counter: decorrelated enough that a run does not
+/// see runs of failures, and deterministic enough to have no global RNG state.
+bool should_inject_error (int rate_pct, std::atomic<std::uint64_t>& counter) {
+    if (rate_pct <= 0) {
+        return false;
+    }
+    if (rate_pct >= 100) {
+        return true;
+    }
+    std::uint64_t x = counter.fetch_add (0x9E3779B97F4A7C15ULL) + 0x9E3779B97F4A7C15ULL;
+    x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+    x ^= x >> 31;
+    return static_cast<int> (x % 100) < rate_pct;
+}
+
+} // namespace
+
+struct MockServerManager::MockServer {
+    std::string id;
+    std::string collection_id;
+    std::string collection_name;
+    int port           = 0;
+    int latency_ms     = 0;
+    int error_rate_pct = 0;
+    int64_t created_at = 0;
+    /// Built once at start and never written again, so the handler reads it
+    /// with no lock at all. A running mock does not hot-reload the collection -
+    /// restart it, which is documented and is what keeps this true.
+    std::vector<MockRoute> routes;
+    int routes_without_example = 0;
+    /// Feeds the error-injection roll. Atomic because every pool thread bumps
+    /// it; nothing else about a served response is mutable.
+    std::atomic<std::uint64_t> served{ 0 };
+
+    /// Declared last so it is destroyed first: the handler reads everything
+    /// above it while the accept loop is alive.
+    ManagedListener listener;
+
+    MockServerInfo info () const {
+        MockServerInfo out;
+        out.mock_id                = id;
+        out.collection_id          = collection_id;
+        out.collection_name        = collection_name;
+        out.port                   = port;
+        out.url                    = "http://127.0.0.1:" + std::to_string (port);
+        out.latency_ms             = latency_ms;
+        out.error_rate_pct         = error_rate_pct;
+        out.route_count            = static_cast<int> (routes.size ());
+        out.routes_without_example = routes_without_example;
+        out.created_at             = created_at;
+        return out;
+    }
+};
+
+MockServerManager::MockServerManager () = default;
+
+MockServerManager::~MockServerManager () {
+    std::lock_guard<std::mutex> lock (mutex_);
+    for (auto& [id, server] : servers_) {
+        // A response inside its configured latency is still holding a listener
+        // thread, so the join inside stop() waits up to MAX_LATENCY_MS - which
+        // is why that bound exists.
+        server->listener.stop ();
+    }
+    servers_.clear ();
+}
+
+MockServerManager::StartResult
+MockServerManager::start (vayu::db::Database& db, const MockStartRequest& request) {
+    StartResult out;
+
+    const auto collection = db.get_collection (request.collection_id);
+    if (!collection) {
+        out.ok            = false;
+        out.http_status   = 404;
+        out.error_code    = "not_found";
+        out.error_message = "Collection '" + request.collection_id + "' not found";
+        return out;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock (mutex_);
+        if (servers_.size () >= constants::mock_server::MAX_SERVERS) {
+            out.ok          = false;
+            out.http_status = 409;
+            out.error_code  = "mock_limit_reached";
+            out.error_message = "Already running the maximum of " +
+            std::to_string (constants::mock_server::MAX_SERVERS) +
+            " mock servers; stop one first";
+            return out;
+        }
+    }
+
+    auto server             = std::make_unique<MockServer> ();
+    server->id              = vayu::utils::generate_id ("mock_");
+    server->collection_id   = request.collection_id;
+    server->collection_name = collection->name;
+    server->latency_ms      = request.latency_ms;
+    server->error_rate_pct  = request.error_rate_pct;
+    server->created_at      = routes::now_ms ();
+    server->routes          = build_mock_routes (db, request.collection_id);
+
+    if (server->routes.size () > constants::mock_server::MAX_ROUTES) {
+        out.ok          = false;
+        out.http_status = 400;
+        out.error_code  = "mock_too_many_routes";
+        out.error_message = "Collection '" + collection->name + "' has more than " +
+        std::to_string (constants::mock_server::MAX_ROUTES) +
+        " requests, past what one mock server holds";
+        return out;
+    }
+    if (server->routes.empty ()) {
+        // Loud rather than a listener that 404s everything: a mock of a
+        // collection with no requests is never what the caller meant.
+        out.ok            = false;
+        out.http_status   = 400;
+        out.error_code    = "mock_no_requests";
+        out.error_message = "Collection '" + collection->name +
+        "' (and everything under it) has no requests to serve";
+        return out;
+    }
+    server->routes_without_example = static_cast<int> (
+    std::count_if (server->routes.begin (), server->routes.end (),
+    [] (const MockRoute& route) { return !route.has_response; }));
+
+    MockServer* raw                   = server.get ();
+    httplib::Server::Handler responder = [raw] (const httplib::Request& req,
+                                          httplib::Response& res) {
+        if (raw->latency_ms > 0) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (raw->latency_ms));
+        }
+        if (should_inject_error (raw->error_rate_pct, raw->served)) {
+            res.status = 500;
+            res.set_content (routes::error_body (500,
+                             "Injected failure (errorRatePct=" +
+                             std::to_string (raw->error_rate_pct) + ")", "mock_injected_error")
+                             .dump (),
+            "application/json");
+            return;
+        }
+
+        const auto match = resolve_mock_route (raw->routes, req.method, req.path);
+        if (!match.route_index) {
+            const auto body = mock_miss_body (raw->routes, match, req.method, req.path);
+            res.status = match.miss == MockMissKind::NoExample ? 501 : 404;
+            res.set_content (body.dump (), "application/json");
+            return;
+        }
+
+        const MockRoute& route = raw->routes[*match.route_index];
+        res.status             = route.response.status;
+        for (const auto& [name, value] : route.response.headers) {
+            if (!header_is (name, "content-type")) {
+                // Appended rather than set: a repeated `Set-Cookie` is exactly
+                // why an example stores its headers as an ordered array.
+                res.headers.emplace (name, value);
+            }
+        }
+        if (!route.response.body.empty ()) {
+            res.set_content (route.response.body, route.response.content_type);
+        } else {
+            res.set_header ("Content-Type", route.response.content_type);
+        }
+    };
+
+    httplib::Server& svr = server->listener.server ();
+    // Every method cpp-httplib routes, on every path: the route table decides
+    // what answers, not httplib's own matcher.
+    svr.Get (".*", responder); // also serves HEAD
+    svr.Post (".*", responder);
+    svr.Put (".*", responder);
+    svr.Patch (".*", responder);
+    svr.Delete (".*", responder);
+    svr.Options (".*", responder);
+
+    const auto started =
+    server->listener.start ("127.0.0.1", request.port, "mock server " + server->id);
+    if (started.port <= 0) {
+        const std::string where = "127.0.0.1:" +
+        (request.port > 0 ? std::to_string (request.port) : std::string ("(any)"));
+        out.ok            = false;
+        out.http_status   = 409;
+        out.error_code    = "mock_bind_failed";
+        out.error_message = started.held_by.empty () ?
+        "Could not bind " + where + " - the address may be in use or unavailable" :
+        "Could not bind " + where + " - " + started.held_by + " is already listening there";
+        return out;
+    }
+    server->port = started.port;
+
+    {
+        std::lock_guard<std::mutex> lock (mutex_);
+        out.info             = server->info ();
+        servers_[server->id] = std::move (server);
+    }
+    out.ok          = true;
+    out.http_status = 200;
+    vayu::utils::log_info ("Mock server started: " + out.info.mock_id + " on " +
+    out.info.url + " (" + std::to_string (out.info.route_count) + " routes)");
+    return out;
+}
+
+bool MockServerManager::stop (const std::string& mock_id) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    auto it = servers_.find (mock_id);
+    if (it == servers_.end ()) {
+        return false;
+    }
+    // Stop joins every in-flight handler before returning, so once this is done
+    // nothing is still reading the record being erased.
+    it->second->listener.stop ();
+    servers_.erase (it);
+    vayu::utils::log_info ("Mock server stopped: " + mock_id);
+    return true;
+}
+
+std::optional<MockServerInfo> MockServerManager::get (const std::string& mock_id) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    auto it = servers_.find (mock_id);
+    if (it == servers_.end ()) {
+        return std::nullopt;
+    }
+    return it->second->info ();
+}
+
+std::vector<MockServerInfo> MockServerManager::list () {
+    std::lock_guard<std::mutex> lock (mutex_);
+    std::vector<MockServerInfo> out;
+    out.reserve (servers_.size ());
+    for (const auto& [id, server] : servers_) {
+        out.push_back (server->info ());
+    }
+    return out;
+}
+
+std::optional<std::vector<MockRoute>> MockServerManager::routes (const std::string& mock_id) {
+    std::lock_guard<std::mutex> lock (mutex_);
+    auto it = servers_.find (mock_id);
+    if (it == servers_.end ()) {
+        return std::nullopt;
+    }
+    return it->second->routes;
+}
+
+} // namespace vayu::http
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+namespace vayu::http::routes {
+
+void register_mock_server_routes (RouteContext& ctx) {
+    /**
+     * POST /mock/start
+     * Body: {collectionId (required), port, latencyMs, errorRatePct}.
+     * Starts a loopback listener answering the collection tree's saved
+     * examples. Returns the started mock: {mockId, collectionId,
+     * collectionName, url, port, latencyMs, errorRatePct, routeCount,
+     * routesWithoutExample, createdAt}.
+     */
+    ctx.server.Post ("/mock/start", [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        nlohmann::json body;
+        try {
+            body = req.body.empty () ? nlohmann::json::object () : nlohmann::json::parse (req.body);
+        } catch (const std::exception& e) {
+            send_error (res, 400, std::string ("Invalid JSON body: ") + e.what ());
+            return;
+        }
+        MockStartRequest start;
+        if (auto error = parse_mock_start (body, start); error) {
+            vayu::utils::log_warning ("POST /mock/start - " + error->message);
+            send_error (res, error->http_status, error->message, error->code);
+            return;
+        }
+        try {
+            auto result = ctx.mock_server_manager.start (ctx.db, start);
+            if (!result.ok) {
+                vayu::utils::log_warning ("POST /mock/start - " + result.error_message);
+                send_error (res, result.http_status, result.error_message, result.error_code);
+                return;
+            }
+            send_json (res, mock_server_info_json (result.info));
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("POST /mock/start - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+
+    /**
+     * POST /mock/:id/stop
+     * Stops the listener and drops the record - a mock holds nothing that
+     * outlives its listener, so there is no stopped state to read (unlike an
+     * inbox, whose captures are the reason its record survives a stop).
+     */
+    ctx.server.Post (R"(/mock/([^/]+)/stop)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string mock_id = req.matches[1];
+        if (!ctx.mock_server_manager.stop (mock_id)) {
+            send_error (res, 404, "Mock server not found");
+            return;
+        }
+        send_json (res, nlohmann::json{ { "mockId", mock_id }, { "stopped", true } });
+    });
+
+    /** GET /mock - every running mock server. */
+    ctx.server.Get ("/mock", [&ctx] (const httplib::Request&, httplib::Response& res) {
+        nlohmann::json data = nlohmann::json::array ();
+        for (const auto& info : ctx.mock_server_manager.list ()) {
+            data.push_back (mock_server_info_json (info));
+        }
+        send_json (res, nlohmann::json{ { "data", std::move (data) } });
+    });
+
+    /**
+     * GET /mock/:id/routes
+     * The table the mock is serving - method, path template, and whether the
+     * request behind it has an example. This is how "the mock answers 404" gets
+     * diagnosed without sending a request per guess.
+     */
+    ctx.server.Get (R"(/mock/([^/]+)/routes)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string mock_id = req.matches[1];
+        const auto routes         = ctx.mock_server_manager.routes (mock_id);
+        if (!routes) {
+            send_error (res, 404, "Mock server not found");
+            return;
+        }
+        nlohmann::json data = nlohmann::json::array ();
+        for (const auto& route : *routes) {
+            data.push_back (mock_route_json (route));
+        }
+        send_json (res, nlohmann::json{ { "data", std::move (data) } });
+    });
+}
+
+} // namespace vayu::http::routes

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -116,7 +116,8 @@ void Server::setup_routes () {
     // Note: route_ctx_ is a class member, ensuring it outlives the lambdas
     route_ctx_ = std::make_unique<routes::RouteContext> (
     routes::RouteContext{ server_, db_, run_manager_, verbose_, shutdown_callback_,
-    oauth_authorize_manager_, cookie_jar_, mock_issuer_manager_, inbox_manager_ });
+    oauth_authorize_manager_, cookie_jar_, mock_issuer_manager_, inbox_manager_,
+    mock_server_manager_ });
 
     routes::register_health_routes (*route_ctx_);
     routes::register_config_routes (*route_ctx_);
@@ -136,6 +137,7 @@ void Server::setup_routes () {
     routes::register_cookie_routes (*route_ctx_);
     routes::register_mock_issuer_routes (*route_ctx_);
     routes::register_inbox_routes (*route_ctx_);
+    routes::register_mock_server_routes (*route_ctx_);
 }
 
 } // namespace vayu::http

--- a/engine/tests/fixtures/path-template-conformance.json
+++ b/engine/tests/fixtures/path-template-conformance.json
@@ -1,0 +1,117 @@
+{
+  "$comment": "Cross-language conformance fixture for mock-server path templates (issue #481 phase 2). Read by BOTH the engine gtest suite (mock_server_routes_test.cpp, via VAYU_ENGINE_SOURCE_DIR) and the app's vitest suite (app/src/services/importers/path-template.conformance.test.ts). The app WRITES the URLs the engine has to read back: an OpenAPI import stores '{{baseUrl}}/pets/{{petId}}' because normalizeVars(path, {pathTemplates: true}) rewrote '{petId}', and the mock server turns that same URL back into the route it serves. A rule answered two ways is an imported request the mock silently cannot route, which is invisible until a 404 nobody can explain. templateCases are the shared half - both sides must produce 'expected' from 'input'. urlCases are the engine's own half: reducing a whole stored request URL (scheme, host, or the variable standing in for both, plus query and fragment) to the path, which the app has no equivalent of.",
+  "templateCases": [
+    {
+      "name": "an OpenAPI path parameter becomes a Vayu variable",
+      "input": "/pets/{petId}",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": "an already-Vayu template is left alone",
+      "input": "/pets/{{petId}}",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": "padding inside the braces is trimmed",
+      "input": "/pets/{{ petId }}",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": "Insomnia's `_.` prefix is dropped",
+      "input": "/pets/{{_.petId}}",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": "every parameter in a multi-level path is rewritten",
+      "input": "/users/{userId}/pets/{petId}",
+      "expected": "/users/{{userId}}/pets/{{petId}}"
+    },
+    {
+      "name": "a hyphen is part of a parameter name",
+      "input": "/v1/{version-id}",
+      "expected": "/v1/{{version-id}}"
+    },
+    {
+      "name": "a path with no template is unchanged",
+      "input": "/pets",
+      "expected": "/pets"
+    },
+    {
+      "name": "a dotted name is not an OpenAPI path parameter, so it stays literal",
+      "input": "/report/{a.b}",
+      "expected": "/report/{a.b}"
+    },
+    {
+      "name": "a filtered expression has no Vayu equivalent and is left verbatim",
+      "input": "/search/{{a|upper}}",
+      "expected": "/search/{{a|upper}}"
+    },
+    {
+      "name": "empty braces name nothing and stay literal",
+      "input": "/pets/{}",
+      "expected": "/pets/{}"
+    }
+  ],
+  "urlCases": [
+    {
+      "name": "the variable standing in for scheme and host is dropped",
+      "input": "{{baseUrl}}/pets/{petId}",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": "a variable base with no separator still yields an absolute path",
+      "input": "{{host}}pets",
+      "expected": "/pets"
+    },
+    {
+      "name": "scheme, host and query are dropped",
+      "input": "https://api.example.com/v1/pets?limit=10",
+      "expected": "/v1/pets"
+    },
+    {
+      "name": "a fragment is dropped too",
+      "input": "https://api.example.com/pets#recent",
+      "expected": "/pets"
+    },
+    {
+      "name": "a Postman-style :param is the third spelling of one wildcard",
+      "input": "http://localhost:3000/pets/:petId",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": ":param on a host-less URL is rewritten the same way",
+      "input": "/pets/:petId",
+      "expected": "/pets/{{petId}}"
+    },
+    {
+      "name": "a bare authority with no scheme is still an authority",
+      "input": "api.example.com/pets",
+      "expected": "/pets"
+    },
+    {
+      "name": "a host with no path is the root",
+      "input": "https://api.example.com",
+      "expected": "/"
+    },
+    {
+      "name": "a base variable with no path is the root",
+      "input": "{{baseUrl}}",
+      "expected": "/"
+    },
+    {
+      "name": "a trailing slash is not part of the route",
+      "input": "{{baseUrl}}/pets/",
+      "expected": "/pets"
+    },
+    {
+      "name": "an empty segment is collapsed",
+      "input": "{{baseUrl}}/pets//list",
+      "expected": "/pets/list"
+    },
+    {
+      "name": "surrounding whitespace is not part of the URL",
+      "input": "  {{baseUrl}}/pets  ",
+      "expected": "/pets"
+    }
+  ]
+}

--- a/engine/tests/mock_server_routes_test.cpp
+++ b/engine/tests/mock_server_routes_test.cpp
@@ -1,0 +1,631 @@
+/**
+ * @file tests/mock_server_routes_test.cpp
+ * @brief Tests for the collection mock server (issue #481 phase 2): payload
+ *        validation, the path-template conformance fixture the app shares,
+ *        route-table construction over a collection tree, match resolution and
+ *        its two near-miss answers, a live listener serving real examples with
+ *        latency and error injection, teardown while running, and one load run
+ *        pointed at a mock end to end.
+ *
+ * The pure halves (normalize, segment, resolve, the miss body) are driven
+ * directly rather than through a socket, matching the suite's other route-core
+ * tests; only the behaviours that need a bound port open one.
+ */
+
+#include <gtest/gtest.h>
+#include <httplib.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+#include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/mock_server.hpp"
+
+using nlohmann::json;
+using vayu::http::MockMissKind;
+using vayu::http::MockServerManager;
+using vayu::http::MockStartRequest;
+
+namespace {
+
+namespace mock_constants = vayu::core::constants::mock_server;
+
+int64_t now_ms () {
+    return std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+    .count ();
+}
+
+// ---------------------------------------------------------------------------
+// Payload validation - no listener, no database
+// ---------------------------------------------------------------------------
+
+TEST (MockParseStart, RequiresACollectionAndDefaultsTheRest) {
+    MockStartRequest out;
+    ASSERT_FALSE (vayu::http::parse_mock_start (json{ { "collectionId", "col_1" } }, out).has_value ());
+    EXPECT_EQ (out.collection_id, "col_1");
+    EXPECT_EQ (out.port, 0);
+    EXPECT_EQ (out.latency_ms, 0);
+    EXPECT_EQ (out.error_rate_pct, 0);
+
+    // A mock with no collection has nothing to serve, so absence is a 400
+    // rather than a listener that 404s everything.
+    EXPECT_TRUE (vayu::http::parse_mock_start (json::object (), out).has_value ());
+    EXPECT_TRUE (vayu::http::parse_mock_start (json{ { "collectionId", "" } }, out).has_value ());
+    EXPECT_TRUE (vayu::http::parse_mock_start (json{ { "collectionId", 7 } }, out).has_value ());
+    EXPECT_TRUE (vayu::http::parse_mock_start (json ("not an object"), out).has_value ());
+}
+
+TEST (MockParseStart, ReadsAndBoundsEveryTuningField) {
+    MockStartRequest out;
+    ASSERT_FALSE (vayu::http::parse_mock_start (json{ { "collectionId", "col_1" },
+                  { "port", 41234 }, { "latencyMs", 25 }, { "errorRatePct", 10 } },
+                  out)
+                  .has_value ());
+    EXPECT_EQ (out.port, 41234);
+    EXPECT_EQ (out.latency_ms, 25);
+    EXPECT_EQ (out.error_rate_pct, 10);
+
+    // Out of range is refused rather than clamped: a mock silently answering
+    // with no delay when one was asked for is a mock doing something other than
+    // what its caller configured.
+    const json base = { { "collectionId", "col_1" } };
+    for (const json& bad :
+    { json{ { "port", -1 } }, json{ { "port", 70000 } }, json{ { "latencyMs", -1 } },
+    json{ { "latencyMs", mock_constants::MAX_LATENCY_MS + 1 } },
+    json{ { "errorRatePct", -1 } }, json{ { "errorRatePct", 101 } },
+    json{ { "latencyMs", "fast" } } }) {
+        json body = base;
+        body.update (bad);
+        EXPECT_TRUE (vayu::http::parse_mock_start (body, out).has_value ()) << body.dump ();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path templates - the half the app shares
+// ---------------------------------------------------------------------------
+
+json load_conformance_fixture () {
+    const std::filesystem::path path = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
+    "tests" / "fixtures" / "path-template-conformance.json";
+    std::ifstream file (path);
+    EXPECT_TRUE (file.is_open ()) << "cannot open " << path;
+    json fixture;
+    file >> fixture;
+    return fixture;
+}
+
+TEST (MockPathTemplate, MatchesTheSharedConformanceFixture) {
+    const json fixture = load_conformance_fixture ();
+
+    // A fixture that read as an empty list would pass every assertion below
+    // while checking nothing - the failure mode a source-scanning guard in this
+    // repo shipped with for weeks.
+    ASSERT_TRUE (fixture.contains ("templateCases"));
+    ASSERT_GE (fixture["templateCases"].size (), 5u);
+    ASSERT_GE (fixture["urlCases"].size (), 5u);
+
+    for (const auto& section : { "templateCases", "urlCases" }) {
+        for (const auto& item : fixture[section]) {
+            const auto input    = item["input"].get<std::string> ();
+            const auto expected = item["expected"].get<std::string> ();
+            EXPECT_EQ (vayu::http::normalize_mock_path (input), expected)
+            << section << ": " << item["name"].get<std::string> ();
+        }
+    }
+}
+
+TEST (MockPathTemplate, SegmentsMarkTemplatesAsWildcards) {
+    const auto segments = vayu::http::mock_path_segments ("/users/{{userId}}/pets");
+    ASSERT_EQ (segments.size (), 3u);
+    EXPECT_FALSE (segments[0].templated);
+    EXPECT_EQ (segments[0].literal, "users");
+    EXPECT_TRUE (segments[1].templated);
+    EXPECT_EQ (segments[1].literal, "userId");
+    EXPECT_FALSE (segments[2].templated);
+    EXPECT_TRUE (vayu::http::mock_path_segments ("/").empty ());
+}
+
+// ---------------------------------------------------------------------------
+// The route table and match resolution
+// ---------------------------------------------------------------------------
+
+class MockServerTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_mock_server.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+        seed_collection ("col_root", std::nullopt, "Pet Store");
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    void seed_collection (const std::string& id,
+    const std::optional<std::string>& parent,
+    const std::string& name) {
+        vayu::db::Collection col;
+        col.id         = id;
+        col.parent_id  = parent;
+        col.name       = name;
+        col.order      = 0;
+        col.created_at = 1;
+        col.updated_at = 1;
+        db_->create_collection (col);
+    }
+
+    void seed_request (const std::string& id,
+    const std::string& collection_id,
+    vayu::HttpMethod method,
+    const std::string& url,
+    const std::string& name = {},
+    int order               = 0) {
+        vayu::db::Request r;
+        r.id            = id;
+        r.collection_id = collection_id;
+        r.name          = name.empty () ? id : name;
+        r.method        = method;
+        r.url           = url;
+        r.order         = order;
+        r.created_at    = 1;
+        r.updated_at    = 1;
+        db_->save_request (r);
+    }
+
+    void seed_example (const std::string& id,
+    const std::string& request_id,
+    int status,
+    const std::string& body,
+    const std::string& content_type = "application/json",
+    const json& headers             = json::array (),
+    int order                       = 0) {
+        vayu::db::RequestExample x;
+        x.id           = id;
+        x.request_id   = request_id;
+        x.name         = id;
+        x.status       = status;
+        x.headers      = headers.dump ();
+        x.body         = body;
+        x.content_type = content_type;
+        x.order        = order;
+        x.created_at   = 1;
+        x.updated_at   = 1;
+        db_->save_request_example (x);
+    }
+
+    /// The canonical fixture: one request with an example, one templated, one
+    /// method-sharing sibling, all under a sub-collection so the walk matters.
+    void seed_pet_store () {
+        seed_collection ("col_pets", "col_root", "Pets");
+        seed_request ("req_list", "col_pets", vayu::HttpMethod::GET,
+        "{{baseUrl}}/pets", "List pets");
+        seed_example ("exa_list", "req_list", 200, R"([{"id":1}])");
+        seed_request ("req_one", "col_pets", vayu::HttpMethod::GET,
+        "{{baseUrl}}/pets/{petId}", "Get pet");
+        seed_example ("exa_one", "req_one", 200, R"({"id":7})");
+        seed_request ("req_create", "col_pets", vayu::HttpMethod::POST,
+        "{{baseUrl}}/pets", "Create pet");
+        seed_example ("exa_create", "req_create", 201, R"({"id":8})");
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+TEST_F (MockServerTest, TheTableCoversTheWholeCollectionSubtree) {
+    seed_pet_store ();
+    // A request directly on the root, and one two levels down - an OpenAPI
+    // import files everything under a folder per tag, so a table built from
+    // direct children alone would serve nothing at all.
+    seed_request ("req_root", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/health");
+    seed_example ("exa_root", "req_root", 200, "ok", "text/plain");
+    seed_collection ("col_deep", "col_pets", "Toys");
+    seed_request ("req_deep", "col_deep", vayu::HttpMethod::GET, "{{baseUrl}}/toys");
+    seed_example ("exa_deep", "req_deep", 200, "[]");
+
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    ASSERT_EQ (routes.size (), 5u);
+
+    std::vector<std::string> served;
+    for (const auto& route : routes) {
+        served.push_back (route.method + " " + route.path_template);
+        EXPECT_TRUE (route.has_response) << route.request_id;
+    }
+    EXPECT_NE (std::find (served.begin (), served.end (), "GET /health"), served.end ());
+    EXPECT_NE (std::find (served.begin (), served.end (), "GET /pets/{{petId}}"), served.end ());
+    EXPECT_NE (std::find (served.begin (), served.end (), "POST /pets"), served.end ());
+    EXPECT_NE (std::find (served.begin (), served.end (), "GET /toys"), served.end ());
+
+    // A mock of the sub-collection is exactly its own subtree.
+    EXPECT_EQ (vayu::http::build_mock_routes (*db_, "col_pets").size (), 4u);
+}
+
+TEST_F (MockServerTest, TheFirstExampleInStoredOrderIsTheOneServed) {
+    seed_request ("req_list", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/pets");
+    // Written newest-first on purpose: the ordering phase 1 made a contract is
+    // `order`, not insertion, and this is the read that depends on it.
+    seed_example ("exa_b", "req_list", 500, "boom", "text/plain", json::array (), 1);
+    seed_example ("exa_a", "req_list", 200, "[]", "application/json", json::array (), 0);
+
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    ASSERT_EQ (routes.size (), 1u);
+    EXPECT_EQ (routes[0].response.status, 200);
+    EXPECT_EQ (routes[0].response.body, "[]");
+}
+
+TEST_F (MockServerTest, ARequestWithNoExampleStaysInTheTableAsUnservable) {
+    seed_request ("req_list", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/pets");
+
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    ASSERT_EQ (routes.size (), 1u);
+    EXPECT_FALSE (routes[0].has_response);
+
+    // "matched, but nothing to serve" is a different answer from "no route",
+    // and it is the one an import that dropped its examples produces.
+    const auto match = vayu::http::resolve_mock_route (routes, "GET", "/pets");
+    EXPECT_FALSE (match.route_index.has_value ());
+    EXPECT_EQ (match.miss, MockMissKind::NoExample);
+    const auto body = vayu::http::mock_miss_body (routes, match, "GET", "/pets");
+    EXPECT_EQ (body["error"]["code"], "mock_no_example");
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find ("req_list"), std::string::npos);
+}
+
+TEST_F (MockServerTest, DisabledExampleHeadersAreNotServedAndDuplicatesSurvive) {
+    seed_request ("req_list", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/pets");
+    seed_example ("exa_list", "req_list", 200, "[]", "application/json",
+    json::array ({ json{ { "key", "Set-Cookie" }, { "value", "a=1" }, { "enabled", true } },
+    json{ { "key", "Set-Cookie" }, { "value", "b=2" }, { "enabled", true } },
+    json{ { "key", "X-Dropped" }, { "value", "no" }, { "enabled", false } } }));
+
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    ASSERT_EQ (routes.size (), 1u);
+    const auto& headers = routes[0].response.headers;
+    ASSERT_EQ (headers.size (), 2u);
+    EXPECT_EQ (headers[0].first, "Set-Cookie");
+    EXPECT_EQ (headers[0].second, "a=1");
+    EXPECT_EQ (headers[1].second, "b=2");
+}
+
+TEST_F (MockServerTest, AnExampleWithNoContentTypeColumnFallsBackToItsHeader) {
+    seed_request ("req_list", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/pets");
+    seed_example ("exa_list", "req_list", 200, "[]", /*content_type=*/"",
+    json::array ({ json{ { "key", "content-type" }, { "value", "application/hal+json" },
+    { "enabled", true } } }));
+
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    ASSERT_EQ (routes.size (), 1u);
+    EXPECT_EQ (routes[0].response.content_type, "application/hal+json");
+}
+
+TEST_F (MockServerTest, ALiteralRouteBeatsATemplatedOneWhateverOrderTheyWereWritten) {
+    // `/pets/mine` sits *after* `/pets/{petId}` in the table (the collection's
+    // own `order` decides), so taking the first match rather than the most
+    // specific one would give the wildcard both paths and shadow the literal
+    // permanently.
+    seed_request ("req_one", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/pets/{petId}",
+    "Get pet", /*order=*/0);
+    seed_example ("exa_one", "req_one", 200, "wildcard", "text/plain");
+    seed_request ("req_mine", "col_root", vayu::HttpMethod::GET, "{{baseUrl}}/pets/mine",
+    "My pets", /*order=*/1);
+    seed_example ("exa_mine", "req_mine", 200, "literal", "text/plain");
+
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    ASSERT_EQ (routes.size (), 2u);
+    ASSERT_EQ (routes[0].path_template, "/pets/{{petId}}") << "the wildcard must come first";
+    const auto mine   = vayu::http::resolve_mock_route (routes, "GET", "/pets/mine");
+    ASSERT_TRUE (mine.route_index.has_value ());
+    EXPECT_EQ (routes[*mine.route_index].response.body, "literal");
+
+    const auto other = vayu::http::resolve_mock_route (routes, "GET", "/pets/42");
+    ASSERT_TRUE (other.route_index.has_value ());
+    EXPECT_EQ (routes[*other.route_index].response.body, "wildcard");
+}
+
+TEST_F (MockServerTest, AMethodMismatchIsNamedRatherThanReportedAsAMissingPath) {
+    seed_pet_store ();
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+
+    const auto match = vayu::http::resolve_mock_route (routes, "DELETE", "/pets");
+    EXPECT_FALSE (match.route_index.has_value ());
+    EXPECT_EQ (match.miss, MockMissKind::MethodMismatch);
+    ASSERT_EQ (match.allowed_methods.size (), 2u);
+    EXPECT_EQ (match.allowed_methods[0], "GET");
+    EXPECT_EQ (match.allowed_methods[1], "POST");
+
+    const auto body    = vayu::http::mock_miss_body (routes, match, "DELETE", "/pets");
+    const auto message = body["error"]["message"].get<std::string> ();
+    EXPECT_EQ (body["error"]["code"], "mock_method_mismatch");
+    EXPECT_NE (message.find ("GET, POST"), std::string::npos) << message;
+    EXPECT_NE (message.find ("/pets"), std::string::npos) << message;
+}
+
+TEST_F (MockServerTest, AnUnknownPathSaysSoAndCountsWhatIsServed) {
+    seed_pet_store ();
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+
+    const auto match = vayu::http::resolve_mock_route (routes, "GET", "/orders/1");
+    EXPECT_EQ (match.miss, MockMissKind::NoPath);
+    EXPECT_FALSE (match.matched_route.has_value ());
+
+    const auto message =
+    vayu::http::mock_miss_body (routes, match, "GET", "/orders/1")["error"]["message"]
+    .get<std::string> ();
+    EXPECT_NE (message.find ("/orders/1"), std::string::npos) << message;
+    EXPECT_NE (message.find ("3 served"), std::string::npos) << message;
+}
+
+TEST_F (MockServerTest, ATrailingSlashIsTheSameRoute) {
+    seed_pet_store ();
+    const auto routes = vayu::http::build_mock_routes (*db_, "col_root");
+    EXPECT_TRUE (vayu::http::resolve_mock_route (routes, "GET", "/pets/").route_index.has_value ());
+}
+
+// ---------------------------------------------------------------------------
+// The manager and a live listener
+// ---------------------------------------------------------------------------
+
+TEST_F (MockServerTest, StartRefusesACollectionThatCannotBeServed) {
+    MockServerManager manager;
+
+    MockStartRequest missing;
+    missing.collection_id = "col_gone";
+    const auto not_found  = manager.start (*db_, missing);
+    EXPECT_FALSE (not_found.ok);
+    EXPECT_EQ (not_found.http_status, 404);
+
+    // A collection with no requests would bind a port and 404 everything, which
+    // is never what the caller meant.
+    MockStartRequest empty;
+    empty.collection_id = "col_root";
+    const auto no_routes = manager.start (*db_, empty);
+    EXPECT_FALSE (no_routes.ok);
+    EXPECT_EQ (no_routes.http_status, 400);
+    EXPECT_EQ (no_routes.error_code, "mock_no_requests");
+    EXPECT_TRUE (manager.list ().empty ());
+}
+
+TEST_F (MockServerTest, AStartedMockServesItsExamplesAndReportsItsTable) {
+    seed_pet_store ();
+    // One request with no example, so the report's second number is not 0.
+    seed_request ("req_bare", "col_pets", vayu::HttpMethod::GET, "{{baseUrl}}/bare");
+
+    MockServerManager manager;
+    MockStartRequest request;
+    request.collection_id = "col_root";
+    const auto started    = manager.start (*db_, request);
+    ASSERT_TRUE (started.ok) << started.error_message;
+    EXPECT_EQ (started.info.collection_name, "Pet Store");
+    EXPECT_EQ (started.info.route_count, 4);
+    EXPECT_EQ (started.info.routes_without_example, 1);
+    EXPECT_EQ (started.info.url, "http://127.0.0.1:" + std::to_string (started.info.port));
+
+    httplib::Client client ("127.0.0.1", started.info.port);
+    client.set_connection_timeout (2);
+    client.set_read_timeout (5);
+
+    const auto listed = client.Get ("/pets");
+    ASSERT_TRUE (listed) << "no response from the mock";
+    EXPECT_EQ (listed->status, 200);
+    EXPECT_EQ (listed->body, R"([{"id":1}])");
+    EXPECT_EQ (listed->get_header_value ("Content-Type"), "application/json");
+
+    // A templated segment matches any single value, and the query is not part
+    // of the route.
+    const auto one = client.Get ("/pets/42?expand=owner");
+    ASSERT_TRUE (one);
+    EXPECT_EQ (one->status, 200);
+    EXPECT_EQ (one->body, R"({"id":7})");
+
+    const auto created = client.Post ("/pets", "{}", "application/json");
+    ASSERT_TRUE (created);
+    EXPECT_EQ (created->status, 201);
+
+    // The two near-misses, over the wire.
+    const auto wrong_method = client.Delete ("/pets");
+    ASSERT_TRUE (wrong_method);
+    EXPECT_EQ (wrong_method->status, 404);
+    EXPECT_EQ (json::parse (wrong_method->body)["error"]["code"], "mock_method_mismatch");
+
+    const auto unknown = client.Get ("/orders");
+    ASSERT_TRUE (unknown);
+    EXPECT_EQ (unknown->status, 404);
+    EXPECT_EQ (json::parse (unknown->body)["error"]["code"], "mock_no_route");
+
+    // A route with no example is a 501 naming the request, not a 404 that sends
+    // the user looking for a path they can see in the list.
+    const auto bare = client.Get ("/bare");
+    ASSERT_TRUE (bare);
+    EXPECT_EQ (bare->status, 501);
+    EXPECT_EQ (json::parse (bare->body)["error"]["code"], "mock_no_example");
+
+    const auto table = manager.routes (started.info.mock_id);
+    ASSERT_TRUE (table.has_value ());
+    EXPECT_EQ (table->size (), 4u);
+    EXPECT_FALSE (manager.routes ("mock_nope").has_value ());
+}
+
+TEST_F (MockServerTest, LatencyAndTheTwoExactErrorRates) {
+    seed_pet_store ();
+    MockServerManager manager;
+
+    MockStartRequest slow;
+    slow.collection_id = "col_root";
+    slow.latency_ms    = 120;
+    const auto delayed = manager.start (*db_, slow);
+    ASSERT_TRUE (delayed.ok) << delayed.error_message;
+
+    httplib::Client slow_client ("127.0.0.1", delayed.info.port);
+    slow_client.set_read_timeout (5);
+    const auto before   = std::chrono::steady_clock::now ();
+    const auto answered = slow_client.Get ("/pets");
+    const auto elapsed  = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::steady_clock::now () - before)
+    .count ();
+    ASSERT_TRUE (answered);
+    EXPECT_EQ (answered->status, 200);
+    // A bound assert, not an equality: the sleep is a floor and the scheduler
+    // owns the ceiling.
+    EXPECT_GE (elapsed, 100);
+
+    // 0 and 100 are exact by construction; nothing in between is tested,
+    // because a probability is not an assertion.
+    MockStartRequest broken;
+    broken.collection_id  = "col_root";
+    broken.error_rate_pct = 100;
+    const auto failing    = manager.start (*db_, broken);
+    ASSERT_TRUE (failing.ok) << failing.error_message;
+    httplib::Client failing_client ("127.0.0.1", failing.info.port);
+    failing_client.set_read_timeout (5);
+    for (int i = 0; i < 5; ++i) {
+        const auto response = failing_client.Get ("/pets");
+        ASSERT_TRUE (response);
+        EXPECT_EQ (response->status, 500);
+        EXPECT_EQ (json::parse (response->body)["error"]["code"], "mock_injected_error");
+    }
+
+    // The default rate never fires, however many completions it sees.
+    httplib::Client healthy ("127.0.0.1", delayed.info.port);
+    healthy.set_read_timeout (5);
+    for (int i = 0; i < 5; ++i) {
+        const auto response = healthy.Get ("/pets");
+        ASSERT_TRUE (response);
+        EXPECT_EQ (response->status, 200);
+    }
+}
+
+TEST_F (MockServerTest, StopEndsTheListenerAndDropsTheRecord) {
+    seed_pet_store ();
+    MockServerManager manager;
+    MockStartRequest request;
+    request.collection_id = "col_root";
+    const auto started    = manager.start (*db_, request);
+    ASSERT_TRUE (started.ok) << started.error_message;
+    const int port = started.info.port;
+
+    ASSERT_EQ (manager.list ().size (), 1u);
+    ASSERT_TRUE (manager.get (started.info.mock_id).has_value ());
+
+    EXPECT_TRUE (manager.stop (started.info.mock_id));
+    // A stop is a delete: a mock holds nothing that outlives its listener, so
+    // there is no stopped record left to read.
+    EXPECT_TRUE (manager.list ().empty ());
+    EXPECT_FALSE (manager.get (started.info.mock_id).has_value ());
+    EXPECT_FALSE (manager.stop (started.info.mock_id));
+
+    httplib::Client client ("127.0.0.1", port);
+    client.set_connection_timeout (1);
+    EXPECT_FALSE (client.Get ("/pets")) << "the listener is still accepting after stop";
+}
+
+TEST_F (MockServerTest, TeardownWhileALatentResponseIsInFlightStillJoins) {
+    seed_pet_store ();
+    int port = 0;
+    {
+        MockServerManager manager;
+        MockStartRequest request;
+        request.collection_id = "col_root";
+        request.latency_ms    = 300;
+        const auto started    = manager.start (*db_, request);
+        ASSERT_TRUE (started.ok) << started.error_message;
+        port = started.info.port;
+
+        std::thread caller ([port] () {
+            httplib::Client client ("127.0.0.1", port);
+            client.set_read_timeout (5);
+            client.Get ("/pets");
+        });
+        // Long enough for the request to be inside the handler's sleep.
+        std::this_thread::sleep_for (std::chrono::milliseconds (80));
+        // The destructor runs here, joining a thread that is mid-response.
+        caller.detach ();
+    }
+    // Reaching this line at all is the assertion: a teardown that did not join
+    // would have hung or torn state out from under the handler.
+    httplib::Client client ("127.0.0.1", port);
+    client.set_connection_timeout (1);
+    EXPECT_FALSE (client.Get ("/pets"));
+}
+
+TEST_F (MockServerTest, TheServerBudgetIsEnforced) {
+    seed_pet_store ();
+    MockServerManager manager;
+    MockStartRequest request;
+    request.collection_id = "col_root";
+    for (std::size_t i = 0; i < mock_constants::MAX_SERVERS; ++i) {
+        ASSERT_TRUE (manager.start (*db_, request).ok) << "start " << i;
+    }
+    const auto refused = manager.start (*db_, request);
+    EXPECT_FALSE (refused.ok);
+    EXPECT_EQ (refused.http_status, 409);
+    EXPECT_EQ (refused.error_code, "mock_limit_reached");
+}
+
+// ---------------------------------------------------------------------------
+// The workflow this feature exists for: a load run against the mock
+// ---------------------------------------------------------------------------
+
+TEST_F (MockServerTest, ALoadRunCanTargetAMockEndToEnd) {
+    seed_pet_store ();
+    MockServerManager manager;
+    MockStartRequest request;
+    request.collection_id = "col_root";
+    const auto started    = manager.start (*db_, request);
+    ASSERT_TRUE (started.ok) << started.error_message;
+
+    vayu::db::Run row;
+    row.id              = "run_mock";
+    row.type            = vayu::RunType::Load;
+    row.status          = vayu::RunStatus::Pending;
+    row.config_snapshot = "{}";
+    row.start_time      = now_ms ();
+    row.end_time        = 0;
+    db_->create_run (row);
+
+    const json config = { { "mode", "constant_rps" }, { "duration", "2s" },
+        { "targetRps", 20.0 }, { "url", started.info.url + "/pets" }, { "method", "GET" },
+        { "timeout", 5000 }, { "workers", 1 } };
+
+    vayu::core::RunManager run_manager;
+    ASSERT_TRUE (run_manager.start_run (row.id, config, *db_, false));
+
+    const auto deadline = std::chrono::steady_clock::now () + std::chrono::seconds (30);
+    while (std::chrono::steady_clock::now () < deadline) {
+        const auto stored = db_->get_run (row.id);
+        if (stored && stored->status != vayu::RunStatus::Running &&
+        stored->status != vayu::RunStatus::Pending) {
+            break;
+        }
+        std::this_thread::sleep_for (std::chrono::milliseconds (50));
+    }
+    run_manager.shutdown (std::chrono::milliseconds (15000));
+
+    const auto stored = db_->get_run (row.id);
+    ASSERT_TRUE (stored.has_value ());
+    ASSERT_FALSE (stored->summary.empty ()) << "the run produced no summary";
+    const json summary = json::parse (stored->summary);
+    // The point of the workflow: a realistic, zero-cost upstream that actually
+    // answers, rather than a run whose every request failed to connect. The
+    // status histogram is the assertion - a run against a dead port still
+    // records total_requests, but it records no 200s.
+    ASSERT_TRUE (summary.contains ("status_codes")) << summary.dump ();
+    EXPECT_GT (summary["status_codes"].value ("200", 0), 0)
+    << "no request to the mock was answered 200: " << summary.dump ();
+    EXPECT_GT (summary.value ("total_requests", 0), 0) << summary.dump ();
+}
+
+} // namespace


### PR DESCRIPTION
## Description

**Plan.** Phase 1 gave examples somewhere to live; nothing read them back, which is the root cause this closes - an imported spec's documented responses sat in `request_examples` and no code path could turn them into a running service. The approach is a fourth on-demand listener whose **route table is a start-time snapshot** of the collection subtree: built once from `build_mock_routes`, const thereafter, so the listener thread reads immutable state and the manager's lock is never taken from a handler. The alternative I rejected was a mock that watches the collection and hot-reloads - it makes every read of the table need a lock on the request-serving hot path, and it makes "which version of my collection is this answering?" unanswerable mid-run, which is exactly the question a load run against the mock has to be able to answer. Restart-to-reload is documented instead.

The second decision worth stating: **path matching is per whole segment, not a regex over the path.** A template is only ever a whole segment in every format Vayu imports, and a substring matcher would have `/petsfoo` answering a route for `/pets`.

### What lands

**Engine** - `mock_server.hpp` / `routes/mock_server.cpp`, `MockServerManager` beside the other three:

- `POST /mock/start` (`collectionId` required; `port`, `latencyMs`, `errorRatePct`), `POST /mock/:id/stop`, `GET /mock`, `GET /mock/:id/routes`.
- The table walks the collection **and every collection under it** - an OpenAPI import files its requests in a folder per tag, so a table built from direct children would serve nothing at all.
- All three template spellings collapse to one wildcard segment: `{{petId}}` (Vayu/Postman), `{petId}` (OpenAPI), `:petId` (Postman's other form). The `{x}` half mirrors `normalizeVars(path, {pathTemplates: true})` and is pinned to it by `engine/tests/fixtures/path-template-conformance.json`, read by both suites - the app writes these URLs and the mock reads them back.
- **Specificity decides, not registration order**: `/pets/mine` beats `/pets/{{petId}}`. Without it, which route answers depends on which request an import happened to write first, and a literal route can be permanently shadowed.
- Loopback only, no `bind` field. Built on the `ManagedListener` #505 extracted - the first listener built on the helper rather than ported to it, which was the point of extracting it when the third one landed.

**App** - `CollectionDetail/MockServerControl` (the only surface holding a collection, so the only one that can start a mock) and a **Mock servers** group in the Services drawer that lists, expands to the route table, and stops. Plus the phase-1 leftover: `ImportMeta.exampleCount` was computed by all three parsers, declared by the type, documented as "shown in the import preview", and rendered nowhere - now the fifth count on the preview's summary line.

### Three deliberate deviations from the issue spec, each with its reason

1. **A matched route with no saved example answers `501 mock_no_example`, not a 404.** The issue names two near-misses (method mismatch, path miss); this is a third the code makes reachable, and it is the one an import that dropped its examples produces. `404` would send the user hunting for a path they can see in `GET /mock/:id/routes`; the 501 names the request instead.
2. **A stop drops the record**, matching a mock issuer rather than an inbox. An inbox's record survives a stop because its captures do; a mock holds nothing that outlives its listener, and its table is a start-time snapshot, so a stopped record would list something that answers nothing and never can again. This also sidesteps the #553 class of problem (a stopped row nothing can remove) rather than inheriting it.
3. **The Services drawer group has no create affordance.** The issue asked for "a per-collection chip as the contextual starter" plus a drawer group; a start button in the drawer would need a collection the drawer does not have. The collection header starts, the drawer lists - stated in both files and in COMPONENTS.md.

Not attempted, and filed rather than left implicit: no app surface sets `latencyMs` / `errorRatePct` yet (the engine accepts and the drawer displays both). Follow-up issue #570.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`; `cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- Engine suite: **1488 / 1488 passed** (253s), 20 of them new.
- App suite: **431 files / 4392 tests passed** (226s).
- `python3 -m mkdocs build --strict -f .github/mkdocs.yml` - built clean (docs change).
- No pre-existing failures on this base (`c626455`).

New engine coverage in `mock_server_routes_test.cpp`: payload validation and every bound; the shared conformance fixture; subtree walk; first-example-in-stored-order; a request with no example staying in the table as unservable; disabled example headers dropped and repeated `Set-Cookie` surviving; content-type fallback; specificity; both near-miss bodies; trailing-slash equivalence; a live listener serving real examples over a socket; latency as a bound assert; error rates **0 and 100 only** (a probability is not an assertion); stop; teardown while a latent response is in flight; the server budget; and **a real load run against a started mock**, asserting the run's status histogram carries 200s.

Mutation-checked by actually reverting each change and confirming the failure:

| Change reverted | Test that went red |
|---|---|
| Specificity in `resolve_mock_route` (first match instead of fewest wildcards) | `ALiteralRouteBeatsATemplatedOneWhateverOrderTheyWereWritten` |
| The subtree walk in `build_mock_routes` (direct children only) | `TheTableCoversTheWholeCollectionSubtree` |
| The `:param` rule in `normalize_mock_path` | `MatchesTheSharedConformanceFixture` |
| `{meta.exampleCount} examples` in `PreviewView` | both cases in `ImportModal.example-count.test.tsx` |

The first of those is the case worth noting: the specificity test passed under mutation on the first attempt, because both fixture requests had `order` 0 and the id tiebreak happened to put the literal first. The test now pins the table order it depends on (`ASSERT_EQ(routes[0].path_template, "/pets/{{petId}}")`) before asserting the match, so it fails for the right reason.

Both conformance-fixture readers assert the fixture is non-empty before iterating it - vacuously-passing table tests are a defect this repo has shipped before.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #481.

Docs updated same-commit: `docs/engine/api-reference.md` (the Mock Server section, including the load-run-against-a-mock workflow the issue asked to state as supported), `docs/engine/architecture.md` (listener inventory is four now, plus why this is the one listener with no wide-bind gate at all), `docs/app/COMPONENTS.md` and `docs/app/api-integration.md`. `db-schema.md` is untouched - phase 2 adds no table.