### PR TITLE
fix(engine/app/history): a restored trace shows the cookies that were sent

### DIFF
--- a/app/src/modules/request-builder/utils/restore-response.test.ts
+++ b/app/src/modules/request-builder/utils/restore-response.test.ts
@@ -110,6 +110,98 @@ describe("responseFromRunResult", () => {
 		);
 	});
 
+	/**
+	 * The gap issue #348 closed. `trace.request.headers` is the *composed* map
+	 * and libcurl attaches the jar's cookies itself, so a view rebuilt from it
+	 * can never show a `Cookie` line - the same request showed one right after
+	 * a send and none after a reload. The engine now stores the wire message it
+	 * already had; this asserts the restored view reads it rather than
+	 * rebuilding around it.
+	 *
+	 * Mutation-check: drop the `request.rawRequest ||` preference in `sentSide`
+	 * and this fails on the missing `Cookie` line.
+	 */
+	it("prefers the stored wire message, cookies and all, over rebuilding one", () => {
+		const wire =
+			"GET /users HTTP/1.1\r\n" +
+			"Host: api.example.test\r\n" +
+			"Accept: application/json\r\n" +
+			"Cookie: session=abc123\r\n" +
+			"\r\n";
+
+		const restored = responseFromRunResult(
+			sample({
+				trace: {
+					request: {
+						method: "GET",
+						url: "https://api.example.test/users",
+						headers: { Accept: "application/json" },
+						rawRequest: wire,
+					},
+					response: { headers: {}, body: "{}" },
+				},
+			})
+		);
+
+		expect(restored?.rawRequest).toBe(wire);
+		// The composed map is still what the Headers tab shows - it is the
+		// engine's own sent record, and the two panes are not the same view.
+		expect(restored?.requestHeaders).toEqual({ Accept: "application/json" });
+	});
+
+	/**
+	 * A row written before #348 has no `rawRequest`, and a restored run from
+	 * last week has to keep rendering. Same fallback shape as
+	 * `trace.response?.httpVersion`.
+	 */
+	it("falls back to rebuilding when the row predates the stored wire message", () => {
+		const restored = responseFromRunResult(
+			sample({
+				trace: {
+					request: {
+						method: "GET",
+						url: "https://api.example.test/users",
+						headers: { Accept: "application/json" },
+					},
+					response: { headers: {}, body: "{}" },
+				},
+			})
+		);
+
+		expect(restored?.rawRequest).toBe(
+			"GET /users HTTP/1.1\r\n" +
+				"Host: api.example.test\r\n" +
+				"Accept: application/json\r\n" +
+				"\r\n"
+		);
+	});
+
+	/**
+	 * A failed transfer stores the engine's synthesized message rather than
+	 * nothing, so the preference has to hold on the error path too - that path
+	 * builds its `ResponseState` through a different branch of
+	 * `responseFromRunResult`, and only `sentSide` is shared.
+	 */
+	it("prefers the stored wire message on a run that never reached a server", () => {
+		const restored = responseFromRunResult(
+			sample({
+				statusCode: 0,
+				trace: {
+					request: {
+						method: "GET",
+						url: "https://nope.example.test/",
+						headers: {},
+						rawRequest: "GET / HTTP/2\r\nHost: nope.example.test\r\n\r\n",
+					},
+					error_type: "CONNECTION_FAILED",
+					error_message: "Could not connect to host",
+				},
+			})
+		);
+
+		expect(restored?.rawRequest).toBe("GET / HTTP/2\r\nHost: nope.example.test\r\n\r\n");
+	});
+
 	it("returns null when the run result carries neither an exchange nor an error", () => {
 		expect(responseFromRunResult(undefined)).toBeNull();
 		expect(responseFromRunResult(sample({ trace: { dnsMs: 4.2 } }))).toBeNull();

--- a/app/src/modules/request-builder/utils/restore-response.ts
+++ b/app/src/modules/request-builder/utils/restore-response.ts
@@ -73,6 +73,18 @@ function detectBodyType(body: string): ResponseState["bodyType"] {
  * The parts of a restored response that are the same whether the run succeeded
  * or failed: what was sent.
  *
+ * `trace.request.rawRequest` is the engine's own wire message, stored since
+ * issue #348. Preferred whenever it is there, because it is the only version
+ * that carries what libcurl added on our behalf - the `Cookie` line the jar
+ * matched above all, which the composed `headers` map has never held. Without
+ * it the same exchange showed a `Cookie` header right after a send and none
+ * after a reload.
+ *
+ * `buildRawRequest` stays as the fallback rather than being replaced: every row
+ * written before that change has no such field, and a restored run from last
+ * week must still render. Same shape as the `trace.response?.httpVersion`
+ * fallback below it.
+ *
  * `trace.response?.httpVersion` is only present when a response was actually
  * received (`build_result_trace` omits the whole `response` node on an error
  * path, see execution.cpp) - so a run that never reached a server has nothing
@@ -81,17 +93,19 @@ function detectBodyType(body: string): ResponseState["bodyType"] {
  */
 function sentSide(trace: NonNullable<RunResultSample["trace"]>) {
 	const request = trace.request;
+	if (!request) return { requestHeaders: {}, rawRequest: undefined };
+
 	return {
-		requestHeaders: request?.headers || {},
-		rawRequest: request
-			? buildRawRequest(
-					request.method || "GET",
-					request.url || "",
-					request.headers || {},
-					request.body,
-					trace.response?.httpVersion
-				)
-			: undefined,
+		requestHeaders: request.headers || {},
+		rawRequest:
+			request.rawRequest ||
+			buildRawRequest(
+				request.method || "GET",
+				request.url || "",
+				request.headers || {},
+				request.body,
+				trace.response?.httpVersion
+			),
 	};
 }
 

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -500,6 +500,20 @@ export interface RunResultTrace {
 		bodyTruncated?: boolean;
 		/** The request body's original byte length, present only when truncated. */
 		bodyBytes?: number;
+		/**
+		 * The wire message the transfer actually sent - `build_result_trace`'s
+		 * copy of the live response's `rawRequest` (issue #348), stored so a
+		 * restored raw view shows the `Cookie` line the jar attached instead of
+		 * rebuilding a session-less request from `headers`. Absent on rows
+		 * written before that change and on a step that sent nothing, which is
+		 * why `restore-response.ts`'s `sentSide` keeps `buildRawRequest` as its
+		 * fallback. Values are **not redacted** - same contract as the live
+		 * field (see `docs/engine/api-reference.md`).
+		 *
+		 * Its body half is capped at `maxTraceBodyBytes` like `body` is; the
+		 * header block is never cut.
+		 */
+		rawRequest?: string;
 	};
 	response?: {
 		headers?: Record<string, string>;

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2049,6 +2049,16 @@ final hop, matching the response beside it. A transfer that failed before
 sending anything (DNS failure, connection refused) has no frame to read, and
 falls back to a request synthesized from what was composed.
 
+**The stored trace keeps the same string**, as `trace_data.request.rawRequest`
+on the design run this execute created (and on each step row of a scenario run)
+- so reopening a run shows the raw request the live view showed, cookies
+included, rather than one rebuilt from `headers` that never had them. Its body
+half is capped at `maxTraceBodyBytes` like `body` is, and the key is absent both
+on a step that sent nothing and on rows written before the field existed; see
+[db-schema](db-schema.md#results). The redaction posture is the live field's,
+for the reason [Security](architecture.md#security) records: a trace is the
+record of what was sent.
+
 **`consoleLogs` entries carry their own source and level.** `source` is which of
 the request's two scripts wrote the line (`"pre"` for the pre-request script,
 `"test"` for the post-request one) and `level` is the `console.*` method that was

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -292,6 +292,16 @@ makes a session survive from one design-mode request to the next.
   log gets exported and shared, the raw view is read on the machine whose
   Settings already display the same value. A script-written cookie is on that
   frame too, since it goes out on the same transfer.
+- **History keeps that frame too, cookies included.** The jar itself is never
+  persisted, but a design or scenario run stores the message its transfer sent
+  as `trace_data.request.rawRequest` (`build_result_trace`), so reopening the
+  run shows the same `Cookie` line the live view did instead of a session-less
+  request rebuilt from the composed headers (issue #348). That is a deliberate
+  write of credential-grade material, into the node that already stores the
+  resolved `Authorization` header beside it - see [Security](#security) for
+  where the line between this and `runs.config_snapshot` falls. It is bounded
+  by run retention, not by the process: `DELETE /cookies` empties the jar and
+  does not touch stored runs.
 - **Script writes are staged, not applied in place** (`pm.cookies.jar()`, issue
   #337). `capture_jar_cookies` *replaces* a scope's contents with what the
   finishing handle held, so a write dropped into the map beside an in-flight
@@ -860,6 +870,19 @@ data/
   values of sensitive headers (`Authorization`, cookies, etc.). Token request
   bodies/responses are never logged. On-disk encryption (`safeStorage`) and
   mid-run token refresh are deferred.
+- **Where the redaction line falls, and why it is not one line.** Two columns of
+  a run row answer two different questions, and the split is deliberate:
+  `runs.config_snapshot` records the request **as authored**, so
+  `sanitize_config_snapshot` keeps `auth` down to `{mode}` and a scenario run
+  stores the uncomposed URL - a composed plan carries resolved `Authorization`
+  headers and an `apikey` in the query string, and persisting one would route
+  around that allowlist. `results.trace_data` records what was **sent**, which
+  is the only thing it is for: it stores the resolved request headers, and since
+  issue #348 the wire message itself (`request.rawRequest`, the `Cookie` line
+  included). Both are credential-grade, both are plaintext under the v1 posture
+  above, and a trace that hid what went out would have no reason to exist. What
+  bounds their lifetime is run retention (`maxRuns` / the prune pass), not the
+  process - so clearing the cookie jar does not clear the runs that recorded it.
 
 ## Dependencies
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -586,9 +586,23 @@ than assuming all eight are there and flat:
 
 | Scenario run, one row per step execution (`core/scenario_runner.cpp`) | the design-mode writer's trace exactly - it *is* `build_result_trace` - plus five keys naming the step: `iteration` (0-based), `stepIndex`, `stepName`, `requestId` and `outcome` (`passed` / `failed` / `skipped` / `errored`), and a sixth, **`dataRowIndex`**, present only for a run given `scenario.data` - the row that iteration bound, which is the only record of *which* row a wrapped pass re-used. The rows themselves are never stored; the snapshot keeps `dataRowCount` alone. A `skipped` row - a pre-request script called `pm.execution.skipRequest()` - carries the `request` node and **no `response`**, because nothing was sent; `restore-response.ts` already answers `null` for that shape rather than building a hollow 0-byte response. Bodies are capped the same way. The row count is bounded by **`maxScenarioStoredSteps`** (config, `general_engine`, default 5000; `0` = unlimited), biased so that every step that did not pass is kept and successes fill the remainder - what was thinned is reported in `runs.summary`, never silently. |
 
+The `request` node also carries **`rawRequest`** - the message the transfer actually put on the
+wire, the same string the live [`POST /execute`](api-reference.md#post-execute) response returns
+(issue #348). It is what a restored raw-request view reads, because it is the only copy that
+carries what libcurl added on our own behalf: the [cookie jar](architecture.md#cookie-jar)'s
+`Cookie` line, `Accept`, the real `Content-Length`. Values in it are **not redacted**, matching
+the live field's contract - it lands in the same node that already stores the resolved
+`Authorization` header among `request.headers` (see [Security](architecture.md#security) for why
+this column and `runs.config_snapshot` answer differently). The key is **absent** on a step that
+sent nothing (a `pm.execution.skipRequest()`) and on every row written before #348, so a reader
+falls back to rebuilding the view from `method`/`url`/`headers`/`body` -
+`restore-response.ts`'s `sentSide` is that reader.
+
 The design-mode `request.body` and `response.body` are **capped at `maxTraceBodyBytes`**
 (config, `observability`, default 5 MiB) before storage, so downloading one 50 MB response does
-not live in SQLite forever. When a body is cut, its node gains two keys:
+not live in SQLite forever. `request.rawRequest` ends with that same body and is capped to the
+same limit, **body half only** - its header block is never cut, being the reason the field is
+stored at all. When a body is cut, its node gains two keys:
 
 | Key on `request` / `response` | Type | Meaning |
 |-------------------------------|------|---------|

--- a/engine/include/vayu/utils/json.hpp
+++ b/engine/include/vayu/utils/json.hpp
@@ -109,8 +109,12 @@ const std::vector<vayu::db::Result>& results);
  * gains `bodyTruncated: true` and `bodyBytes` (the original byte length) so a
  * reader can tell a stored slice from the whole body. The cut is on a raw byte
  * boundary - the body is an opaque string - so the caller must dump with
- * `error_handler_t::replace` in case the slice splits a UTF-8 sequence. See
- * docs/engine/db-schema.md (results.trace_data).
+ * `error_handler_t::replace` in case the slice splits a UTF-8 sequence.
+ *
+ * The request node's `rawRequest` ends with that same body, so it is capped to
+ * the same limit - body half only, header block kept whole, since the headers
+ * are what the field is stored for. See docs/engine/db-schema.md
+ * (results.trace_data).
  */
 void cap_trace_bodies (nlohmann::json& trace, size_t max_body_bytes);
 

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -47,6 +47,31 @@ const vayu::Response& response) {
         trace["request"]["body"] = request.body.content;
     }
 
+    // What the wire carried, so a restored raw-request view says the same thing
+    // the live one did (issue #348). `headers` above is the *composed* map and
+    // has no `Cookie` line - libcurl attaches those itself from the jar - so
+    // rebuilding the view from it client-side showed a session-less request
+    // after a reload and the real one immediately after a send.
+    //
+    // Omitted rather than stored empty when there was no transfer at all (a
+    // `pm.execution.skipRequest()` step hands this a default `Response`): the
+    // reader's fallback synthesis is the right answer there, and "" would
+    // suppress it. A transfer that failed before sending still has a value -
+    // `Client::send` synthesizes one from the composed request - and storing
+    // that is what keeps an unreachable host showing the request it attempted.
+    //
+    // This is credential-grade material and deliberately not redacted, matching
+    // the live field's documented contract: the `Cookie` line lands in the same
+    // node that already stores the resolved `Authorization` header beside it.
+    // The redaction that does apply to run rows is `sanitize_config_snapshot`,
+    // which guards `runs.config_snapshot` - a record of the request as
+    // *authored*. A trace is the record of what was *sent*, and one that hid
+    // what was sent would have no reason to exist. See
+    // docs/engine/architecture.md (Security).
+    if (!response.raw_request.empty ()) {
+        trace["request"]["rawRequest"] = response.raw_request;
+    }
+
     if (!response.has_error ()) {
         // "" when nothing was negotiated, not omitted - same convention as
         // serialize(Response) in json.cpp, so restore-response.ts can't

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -14,6 +14,7 @@
 
 #include <ostream>
 #include <sstream>
+#include <string_view>
 
 #include "vayu/core/constants.hpp"
 #include "vayu/http/form_body.hpp"
@@ -205,11 +206,48 @@ void cap_node_body (nlohmann::json& node, size_t max_body_bytes) {
     }
 }
 
+// Cap the body half of a request node's `rawRequest`, leaving the header block
+// whole.
+//
+// The stored wire message ends with the same body the `body` field beside it
+// carries, so the cap has to reach it too - otherwise a 50 MB POST lands in
+// `trace_data` in full through the field that was added last, which is the
+// bloat `cap_node_body` exists to bound.
+//
+// The cut is body-side only, and deliberately so: the header block is the whole
+// reason the field is stored (it carries the `Cookie` line libcurl attached),
+// and a `maxTraceBodyBytes` smaller than the headers would eat exactly what a
+// reader opened the tab for. A message with no blank line has no body to cap
+// and is left alone.
+//
+// No separate truncation marker: the cut lands at the same limit `cap_node_body`
+// applies to the node's own `body`, so the `bodyTruncated`/`bodyBytes` pair it
+// records already tells a reader this trace's request body is a stored slice.
+void cap_node_raw_request (nlohmann::json& node, size_t max_body_bytes) {
+    if (!node.is_object () || !node.contains ("rawRequest") ||
+    !node["rawRequest"].is_string ()) {
+        return;
+    }
+    const std::string raw = node["rawRequest"].get<std::string> ();
+
+    static constexpr std::string_view HEADER_BODY_SEPARATOR = "\r\n\r\n";
+    const size_t separator = raw.find (HEADER_BODY_SEPARATOR);
+    if (separator == std::string::npos) {
+        return;
+    }
+
+    const size_t body_start = separator + HEADER_BODY_SEPARATOR.size ();
+    if (raw.size () - body_start > max_body_bytes) {
+        node["rawRequest"] = raw.substr (0, body_start + max_body_bytes);
+    }
+}
+
 } // namespace
 
 void cap_trace_bodies (nlohmann::json& trace, size_t max_body_bytes) {
     if (trace.contains ("request")) {
         cap_node_body (trace["request"], max_body_bytes);
+        cap_node_raw_request (trace["request"], max_body_bytes);
     }
     if (trace.contains ("response")) {
         cap_node_body (trace["response"], max_body_bytes);

--- a/engine/tests/execution_trace_test.cpp
+++ b/engine/tests/execution_trace_test.cpp
@@ -136,6 +136,82 @@ TEST (ExecutionTrace, StoredHttpVersionMatchesTheLiveWireKey) {
     EXPECT_EQ (trace["response"]["httpVersion"], live["httpVersion"]);
 }
 
+// ============================================================================
+// rawRequest - the wire message, stored (issue #348)
+//
+// The live raw-request view reads the transfer's own outbound frame; the
+// restored one used to rebuild the string from the composed header map. Those
+// two disagree the moment the cookie jar attaches anything, because libcurl
+// adds `Cookie` itself and the composed map never sees it - so the same
+// exchange showed a session right after a send and none after a reload.
+// ============================================================================
+
+// A response as `Client::send` leaves it: the wire frame carries the jar's
+// cookie and libcurl's own `Accept`, neither of which is in `request.headers`.
+vayu::Response make_response_with_wire_request () {
+    auto response        = make_response ();
+    response.raw_request = "GET /health HTTP/1.1\r\n"
+                           "Host: 127.0.0.1\r\n"
+                           "accept: application/json\r\n"
+                           "Cookie: session=abc123\r\n"
+                           "\r\n";
+    return response;
+}
+
+TEST (ExecutionTrace, StoresTheWireRequestBesideTheComposedHeaders) {
+    auto trace =
+    build_result_trace (make_request (), make_response_with_wire_request ());
+
+    ASSERT_TRUE (trace["request"].contains ("rawRequest"));
+    EXPECT_NE (trace["request"]["rawRequest"].get<std::string> ().find (
+               "Cookie: session=abc123"),
+    std::string::npos);
+
+    // The composed map is unchanged - it is the *sent record*, not the wire,
+    // and the two are deliberately different views (api-reference.md).
+    EXPECT_FALSE (trace["request"]["headers"].contains ("Cookie"));
+}
+
+// The same invariant style as the timing and httpVersion tests above: what
+// serialize(Response) puts on the live /execute wire is what the stored trace
+// carries, so the live and restored raw views cannot drift apart again.
+TEST (ExecutionTrace, StoredRawRequestMatchesTheLiveWireKey) {
+    auto response = make_response_with_wire_request ();
+
+    auto trace = build_result_trace (make_request (), response);
+    auto live  = vayu::json::serialize (response);
+
+    EXPECT_EQ (trace["request"]["rawRequest"], live["rawRequest"]);
+}
+
+// A step that sent nothing (`pm.execution.skipRequest()`) hands this a default
+// Response. Omitted, not stored empty: the reader prefers this key when it is
+// present, so "" would suppress the fallback synthesis that is the right answer
+// there - and it is what every row written before #348 relies on.
+TEST (ExecutionTrace, OmitsRawRequestWhenNothingWasSent) {
+    auto trace = build_result_trace (make_request (), make_response ());
+
+    EXPECT_FALSE (trace["request"].contains ("rawRequest"));
+}
+
+// A transfer that failed before sending has no frame to read, but `Client::send`
+// synthesizes one from the composed request - so an unreachable host still
+// stores the request it attempted, on the branch that writes no response node.
+TEST (ExecutionTrace, FailedTransferStillStoresItsSynthesizedRequest) {
+    auto response          = make_response_with_wire_request ();
+    response.status_code   = 0;
+    response.error_code    = vayu::ErrorCode::ConnectionFailed;
+    response.error_message = "connection refused";
+
+    auto trace = build_result_trace (make_request (), response);
+
+    ASSERT_FALSE (trace.contains ("response"));
+    ASSERT_TRUE (trace["request"].contains ("rawRequest"));
+    EXPECT_NE (
+    trace["request"]["rawRequest"].get<std::string> ().find ("GET /health"),
+    std::string::npos);
+}
+
 TEST (ExecutionTrace, FailureStoresErrorInsteadOfResponse) {
     auto response          = make_response ();
     response.status_code   = 0;

--- a/engine/tests/json_test.cpp
+++ b/engine/tests/json_test.cpp
@@ -345,6 +345,68 @@ TEST (CapTraceBodies, InvalidUtf8SliceDumpsWithReplacement) {
     (void)trace.dump (-1, ' ', false, nlohmann::json::error_handler_t::replace));
 }
 
+// ============================================================================
+// cap_trace_bodies - rawRequest (issue #348)
+//
+// The stored wire message ends with the same body the node's `body` field
+// carries, so without a cap of its own the field added last would carry a whole
+// oversized POST into trace_data and route around the guard entirely.
+// ============================================================================
+
+namespace {
+
+// A wire message as `raw_request_from_wire` builds it: header block, blank
+// line, body.
+std::string make_raw_request (const std::string& body) {
+    return "POST / HTTP/1.1\r\nHost: example.test\r\nCookie: "
+           "session=abc\r\n\r\n" +
+    body;
+}
+
+} // namespace
+
+TEST (CapTraceBodies, CapsTheRawRequestBodyAndKeepsTheHeaderBlockWhole) {
+    // A cap far smaller than the header block: the headers are the reason the
+    // field is stored, so the cut is body-side only. Cutting from the front
+    // would take the Cookie line - exactly what a reader opened the tab for.
+    const size_t cap               = 4;
+    auto trace                     = make_trace ("REQUESTBODY", "RESPONSEBODY");
+    trace["request"]["rawRequest"] = make_raw_request ("REQUESTBODY");
+
+    cap_trace_bodies (trace, cap);
+
+    const auto raw = trace["request"]["rawRequest"].get<std::string> ();
+    EXPECT_EQ (raw, make_raw_request ("REQU"));
+    EXPECT_NE (raw.find ("Cookie: session=abc"), std::string::npos);
+    // The node's own body is capped by the same limit, and its metadata is what
+    // tells a reader this request's body is a stored slice.
+    EXPECT_TRUE (trace["request"]["bodyTruncated"].get<bool> ());
+}
+
+TEST (CapTraceBodies, LeavesAnUnderCapRawRequestVerbatim) {
+    auto trace = make_trace ("small-request", "small-response");
+    trace["request"]["rawRequest"] = make_raw_request ("small-request");
+
+    cap_trace_bodies (trace, 1024);
+
+    EXPECT_EQ (trace["request"]["rawRequest"], make_raw_request ("small-request"));
+}
+
+// A GET's wire message is a header block and an empty body; a synthesized one
+// for a transfer that never connected may carry no blank line at all. Neither
+// has a body to cap, and neither may lose a byte.
+TEST (CapTraceBodies, LeavesABodylessRawRequestAlone) {
+    auto trace                     = make_trace ("", "");
+    trace["request"]["rawRequest"] = make_raw_request ("");
+
+    cap_trace_bodies (trace, 1);
+    EXPECT_EQ (trace["request"]["rawRequest"], make_raw_request (""));
+
+    trace["request"]["rawRequest"] = "GET / HTTP/1.1\r\nHost: example.test";
+    cap_trace_bodies (trace, 1);
+    EXPECT_EQ (trace["request"]["rawRequest"], "GET / HTTP/1.1\r\nHost: example.test");
+}
+
 TEST (CapTraceBodies, IgnoresAnErrorTraceWithNoResponseBody) {
     // An error trace carries error_type/error_message and no response node - the
     // cap must leave it untouched rather than fabricate a body.


### PR DESCRIPTION
## Description

Two code paths produced a "raw request" string and they disagreed. The **live** view has read the transfer's own `CURLINFO_HEADER_OUT` frame since #339, so it shows the `Cookie` line the jar attached. The **restored** view did not move with it - it rebuilt the string client-side from `trace.request.headers`, the *composed* map, which never sees a cookie because libcurl attaches those itself. The same exchange showed a session right after a send and none after a reload, with nothing to tell the user which was the truth.

Implements **direction A** from the decision recorded on the issue: *store it, treated as credential-grade.*

**Plan (root cause, approach, rejected alternative).** The root cause is that the restored view was rebuilding information the engine already had and threw away: `Response::raw_request` exists on every send and was returned live but never persisted. So the fix is to store it rather than to improve the client-side rebuild - `build_result_trace` writes `trace_data.request.rawRequest`, and `restore-response.ts` prefers it with `buildRawRequest` kept as the fallback for rows written before this change. The alternative I rejected was storing only the wire *header block* and letting the app join it to the stored `body`, which would have avoided duplicating the body in the row. It is wrong on fidelity: `wire_body_bytes` is not `body.content` for a form-data or graphql body, so the joined view would show the composed body rather than the sent one - reintroducing exactly the class of live-vs-restored divergence this issue closes. The duplication is instead bounded by capping (below).

**What "credential-grade" means for a run row** - the open question option A carried. The redaction that applies to run rows is `sanitize_config_snapshot`, and it guards `runs.config_snapshot`, which is the record of the request *as authored* (hence the allowlist down to `{mode}`, and the scenario manifest's uncomposed URL). `results.trace_data` is the record of what was *sent*, and it already stores the resolved `Authorization` header among `request.headers` - auth is resolved into the request before `build_result_trace` ever sees it. The `Cookie` line therefore lands in the same node, at the same grade, under the same documented v1 plaintext-at-rest posture, and adds no new persistence path. A trace that hid what went out would have no reason to exist. What bounds its lifetime is run retention, not the process: `DELETE /cookies` empties the jar and does not touch stored runs. That distinction is now written down in `architecture.md` rather than left to be re-derived.

**Storage.** The stored message ends with the same body the node's `body` field carries, so `cap_trace_bodies` caps it at `maxTraceBodyBytes` too - **body half only, header block kept whole**, since the headers are the entire reason the field is stored and a cap smaller than them would eat the `Cookie` line a reader opened the tab for. Without this a 50 MB POST would reach `trace_data` in full through the field added last, routing around the guard.

**Blast radius traced.** `build_result_trace` is shared by the design-run writer and the scenario runner, so scenario step rows get the same fidelity from one writer rather than two. `design-run-seed.ts` reads `trace.request` to seed the *editor* and correctly keeps using `headers`/`body` - a wire message is not an editable request. The key is omitted (not stored `""`) when there was no transfer, so a `pm.execution.skipRequest()` step and every pre-existing row both take the fallback.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally, on a 4-core Linux container.

| Command | Result |
|---|---|
| `python build.py -e -t` | Build complete |
| `cd engine && ctest --preset linux-dev --output-on-failure` | **1475 passed, 0 failed** |
| `cd app && pnpm test` | **4367 passed** across 427 files |
| `cd app && pnpm type-check` | clean |
| `cd app && pnpm lint` | clean (zero warnings) |
| `pnpm prettier --check` (touched files) | clean |
| `mkdocs build --strict` | built, no broken links or anchors |

No pre-existing failures observed on the base commit.

**Engine** (7 new tests). `ExecutionTrace` gains: the wire request is stored beside the composed headers and the composed map still has no `Cookie`; the stored string equals `serialize(Response)["rawRequest"]` - the same live-vs-stored invariant the timing and `httpVersion` tests already use, which is what stops the two views drifting again; the key is omitted when nothing was sent; and a failed transfer still stores its synthesized request on the branch that writes no `response` node. `CapTraceBodies` gains: the body half is cut while the header block (and its `Cookie` line) survives a cap of 4 bytes, an under-cap message is verbatim, and a bodyless or separator-less message is untouched.

**App** (3 new tests). The stored message is preferred verbatim and `requestHeaders` still shows the composed map; a row without the field falls back to `buildRawRequest` unchanged; and the preference also holds on the error path, which builds its `ResponseState` through a different branch with only `sentSide` shared.

**Mutation-checked both sides**, per `CLAUDE.md`. Removing the `request.rawRequest ||` preference fails both app preference tests while the fallback test stays green. Removing the engine write and the cap call fails 4 engine tests - `StoresTheWireRequestBesideTheComposedHeaders`, `StoredRawRequestMatchesTheLiveWireKey`, `FailedTransferStillStoresItsSynthesizedRequest` and `CapsTheRawRequestBodyAndKeepsTheHeaderBlockWhole` - while `OmitsRawRequestWhenNothingWasSent` correctly still passes, since it asserts an absence.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`clang-format` state is byte-identical to master: the two files that carried pre-existing violations (`json.cpp`, `json_test.cpp`) still carry exactly those five each, and nothing else was reformatted. The repo `scripts/pre-commit` clang-tidy hook exits 0.

Docs updated in the same commit: the Cookie Jar **Lifetime**/**Shown as sent** bullets in `architecture.md`, a new **Security** note drawing the `config_snapshot` vs `trace_data` line, the `results.trace_data` field description and cap paragraph in `db-schema.md`, and the `rawRequest` contract in `api-reference.md`.

**No deliberate deviation from the issue spec.** The field name, the reader's fallback and the required app change are as specified; the cap is an addition the spec did not name, and the reason is above.

## Related Issues
Closes #348

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDUnjRH8dLiRb6JbAYkxiT)_