### PR TITLE
feat(app/mock): set a mock server's latency and error rate when starting it

### DIFF
--- a/app/src/modules/collections/CollectionDetail/MockServerControl.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/MockServerControl.test.tsx
@@ -22,7 +22,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
 import { useToastStore } from "@/stores";
@@ -164,5 +164,120 @@ describe("the collection header's mock-server control", () => {
 		// The record dies with the listener, so the header goes back to offering
 		// a start rather than a stopped chip.
 		expect(await screen.findByRole("button", { name: /run mock server/i })).toBeInTheDocument();
+	});
+});
+
+/*
+ * The options dialog (issue #570). The engine has taken `latencyMs` and
+ * `errorRatePct` since #481 phase 2 and the drawer has displayed both, so the
+ * defect this closes is a UI naming a setting it offered no way to change.
+ *
+ * The dialog is exercised through the control rather than on its own, because
+ * the wiring is the part that was missing: a dialog collecting two numbers that
+ * never reach `startMockServer` would satisfy any test of the form alone.
+ */
+describe("the mock server options dialog", () => {
+	const openDialog = async () => {
+		renderControl();
+		fireEvent.click(await screen.findByRole("button", { name: "Mock server options" }));
+		return within(await screen.findByRole("dialog"));
+	};
+
+	it("sends the latency and error rate that were typed", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByRole("spinbutton", { name: /latency/i }), {
+			target: { value: "250" },
+		});
+		fireEvent.change(dialog.getByRole("spinbutton", { name: /error rate/i }), {
+			target: { value: "5" },
+		});
+		fireEvent.click(dialog.getByRole("button", { name: /start mock server/i }));
+
+		await waitFor(() =>
+			expect(startMockServer).toHaveBeenCalledWith({
+				collectionId: "col_1",
+				latencyMs: 250,
+				errorRatePct: 5,
+			})
+		);
+		// A started mock leaves nothing to configure, so the form goes.
+		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+	});
+
+	it("sends both knobs off when the dialog is opened and submitted untouched", async () => {
+		const dialog = await openDialog();
+		fireEvent.click(dialog.getByRole("button", { name: /start mock server/i }));
+		await waitFor(() =>
+			expect(startMockServer).toHaveBeenCalledWith({
+				collectionId: "col_1",
+				latencyMs: 0,
+				errorRatePct: 0,
+			})
+		);
+	});
+
+	/*
+	 * The engine answers a `400 bad_request` naming the field and not the bound,
+	 * so the form has to carry the range itself - and say it in words, since a
+	 * reddened field beside a greyed-out Start states that something is wrong
+	 * and never which field or why.
+	 */
+	it.each([
+		["latency", /latency/i, "30001", /0 to 30000/],
+		["error rate", /error rate/i, "101", /0 to 100/],
+	])(
+		"refuses an out-of-range %s by name, and sends nothing",
+		async (_name, label, value, bound) => {
+			const dialog = await openDialog();
+			fireEvent.change(dialog.getByRole("spinbutton", { name: label }), {
+				target: { value },
+			});
+
+			expect(dialog.getByText(bound)).toBeInTheDocument();
+			const start = dialog.getByRole("button", { name: /start mock server/i });
+			expect(start).toBeDisabled();
+			fireEvent.click(start);
+			expect(startMockServer).not.toHaveBeenCalled();
+		}
+	);
+
+	it("refuses an emptied field rather than reading it as zero", async () => {
+		// `Number("")` is 0 and a whole number, so every other check passes it -
+		// this is the one case where the form would send what was not typed.
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByRole("spinbutton", { name: /latency/i }), {
+			target: { value: "" },
+		});
+		expect(dialog.getByRole("button", { name: /start mock server/i })).toBeDisabled();
+		expect(startMockServer).not.toHaveBeenCalled();
+	});
+
+	it("shows the engine's refusal in the form, and does not also toast it", async () => {
+		startMockServer.mockRejectedValue(
+			new Error("Collection 'Pet Store' (and everything under it) has no requests to serve")
+		);
+		const dialog = await openDialog();
+		fireEvent.click(dialog.getByRole("button", { name: /start mock server/i }));
+
+		expect(await dialog.findByText(/no requests to serve/i)).toBeInTheDocument();
+		// The dialog stays open on a failure, so a toast behind it would report
+		// the same message twice and lose it once.
+		expect(useToastStore.getState().toasts).toHaveLength(0);
+	});
+
+	it("does not greet the next open with the last failure", async () => {
+		// The mutation lives in the control and outlives the dialog, so an
+		// unreset error would be a Callout about a start the user has moved on
+		// from.
+		startMockServer.mockRejectedValue(new Error("has no requests to serve"));
+		renderControl();
+		fireEvent.click(await screen.findByRole("button", { name: /run mock server/i }));
+		await waitFor(() =>
+			expect(useToastStore.getState().toasts[0]?.message).toMatch(/no requests to serve/i)
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Mock server options" }));
+		const dialog = within(await screen.findByRole("dialog"));
+		expect(dialog.queryByText(/no requests to serve/i)).not.toBeInTheDocument();
 	});
 });

--- a/app/src/modules/collections/CollectionDetail/MockServerControl.tsx
+++ b/app/src/modules/collections/CollectionDetail/MockServerControl.tsx
@@ -17,9 +17,18 @@
  * A mock's route table is a snapshot taken at start, so there is nothing to
  * "restart" - stopping and starting again is the only way to pick up an edit,
  * and saying so in the tooltip is cheaper than a restart button that hides it.
+ *
+ * The button starts directly and the options dialog sits beside it (issue
+ * #570). A dialog on the way in would make the common case - serve this
+ * collection with nothing set - two clicks to serve the uncommon one, which is
+ * the wrong trade and the one the acceptance criteria pin: latency and error
+ * rate are for the load run you point at the mock, not for poking a route by
+ * hand. `NewIssuerDialog` has no equivalent split because an issuer has no
+ * defaults-only case worth one click.
  */
 
-import { Copy, Play, ServerCog, Square } from "lucide-react";
+import { Copy, Play, ServerCog, SlidersHorizontal, Square } from "lucide-react";
+import { useState } from "react";
 import { Button, TooltipIconButton } from "@/components/ui";
 import { TruncatedText } from "@/components/shared";
 import {
@@ -30,6 +39,8 @@ import {
 import { useToastStore } from "@/stores";
 import { useCopy } from "@/hooks";
 import { mockForCollection } from "./mock-server-selection";
+import { StartMockServerDialog } from "./StartMockServerDialog";
+import type { MockServerOptions } from "./mock-server-options";
 
 export default function MockServerControl({ collectionId }: { collectionId: string }) {
 	const showToast = useToastStore((s) => s.showToast);
@@ -37,38 +48,79 @@ export default function MockServerControl({ collectionId }: { collectionId: stri
 	const mocksQuery = useMockServersQuery();
 	const startMock = useStartMockServerMutation();
 	const stopMock = useStopMockServerMutation();
+	const [optionsOpen, setOptionsOpen] = useState(false);
 
 	const running = mockForCollection(mocksQuery.data ?? [], collectionId);
 
-	const start = () =>
+	/**
+	 * Without @p options the payload is `{ collectionId }` alone, exactly as it
+	 * was before the dialog existed - the engine's own defaults rather than this
+	 * surface restating them.
+	 */
+	const start = (options?: MockServerOptions) =>
 		startMock.mutate(
-			{ collectionId },
+			{ collectionId, ...options },
 			{
-				onSuccess: (mock) =>
+				onSuccess: (mock) => {
+					setOptionsOpen(false);
 					showToast(
 						`Mock server on port ${mock.port} - ${mock.routeCount} route${
 							mock.routeCount === 1 ? "" : "s"
 						}`,
 						"success"
-					),
+					);
+				},
 				// The engine refuses a collection with no requests and one whose
 				// requests it cannot fit, and both messages name the reason. A
 				// generic fallback would turn "nothing to serve" into "could not
 				// start", which is the half that is not actionable.
-				onError: (error) =>
+				//
+				// From the dialog the same message is a Callout in the form, so
+				// there is no toast: the dialog stays open on a failure, and a
+				// toast behind it would report it twice and lose it once.
+				onError: (error) => {
+					if (options) return;
 					showToast(
 						error instanceof Error ? error.message : "Could not start the mock server",
 						"error"
-					),
+					);
+				},
 			}
 		);
 
 	if (!running) {
 		return (
-			<Button variant="outline" size="sm" onClick={start} disabled={startMock.isPending}>
-				<Play className="h-3.5 w-3.5" aria-hidden="true" />
-				Run mock server
-			</Button>
+			<div className="flex items-center gap-1">
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={() => start()}
+					disabled={startMock.isPending}
+				>
+					<Play className="h-3.5 w-3.5" aria-hidden="true" />
+					Run mock server
+				</Button>
+				<TooltipIconButton
+					label="Mock server options"
+					tooltipHint="Latency and error rate"
+					icon={<SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />}
+					disabled={startMock.isPending}
+					// The mutation outlives the dialog, so a failed direct start
+					// would greet the next open with a Callout about it.
+					onClick={() => {
+						startMock.reset();
+						setOptionsOpen(true);
+					}}
+				/>
+				{optionsOpen && (
+					<StartMockServerDialog
+						onOpenChange={setOptionsOpen}
+						onStart={start}
+						pending={startMock.isPending}
+						error={startMock.error}
+					/>
+				)}
+			</div>
 		);
 	}
 
@@ -95,7 +147,7 @@ export default function MockServerControl({ collectionId }: { collectionId: stri
 			/>
 			<TooltipIconButton
 				label={`Stop mock server on port ${running.port}`}
-				tooltipHint="A mock serves the collection as it was when it started - stop and start it again to pick up an edit"
+				tooltipHint="A mock keeps the collection, latency and error rate it started with - stop and start it again to change any of them"
 				icon={<Square className="h-3.5 w-3.5" aria-hidden="true" />}
 				disabled={stopMock.isPending}
 				onClick={() =>

--- a/app/src/modules/collections/CollectionDetail/StartMockServerDialog.tsx
+++ b/app/src/modules/collections/CollectionDetail/StartMockServerDialog.tsx
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ *
+ * The start form for a mock server's two injection knobs (issue #570), on the
+ * shape of `services/NewIssuerDialog` - the precedent for "a service with
+ * options, started from a form".
+ *
+ * It is the *secondary* affordance, not the way in: the common case is "serve
+ * this collection with nothing set", and the header's button still does that in
+ * one click. Latency and error rate matter to the run you point at the mock -
+ * one is what makes a load-run baseline realistic rather than degenerate, the
+ * other is how a run's error handling and threshold verdict get exercised
+ * without breaking a real service - and neither is what you want on the way to
+ * poking a route by hand.
+ *
+ * Both are start-time only. The engine has no `PUT /mock/:id`, and this did not
+ * add one: they are read per response, so they *could* be live, but a run
+ * against a mock has to be able to say which configuration produced its
+ * numbers, which is the same reason the route table is a start-time snapshot.
+ * Stop and start to change one - and the stop tooltip says so.
+ *
+ * The mutation lives in `MockServerControl`, not here: it owns the success
+ * toast and the started/running switch either way, and a second copy of the
+ * start call is a second place for the two to drift.
+ */
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Label,
+} from "@/components/ui";
+import { Callout } from "@/components/shared";
+import {
+	DEFAULT_MOCK_OPTIONS,
+	MAX_MOCK_ERROR_RATE_PCT,
+	MAX_MOCK_LATENCY_MS,
+	outOfRange,
+	type MockServerOptions,
+} from "./mock-server-options";
+
+export interface StartMockServerDialogProps {
+	/**
+	 * Mounted only while open, like `NewIssuerDialog`: the mount *is* the reset,
+	 * so the fields start at the defaults every time rather than carrying the
+	 * last attempt over.
+	 */
+	onOpenChange: (open: boolean) => void;
+	/** Start with these. The caller closes the dialog once the engine answers. */
+	onStart: (options: MockServerOptions) => void;
+	/** The caller's start mutation, so the footer can say it is in flight. */
+	pending: boolean;
+	/** The engine's refusal, shown here rather than behind the dialog. */
+	error: Error | null;
+}
+
+export function StartMockServerDialog({
+	onOpenChange,
+	onStart,
+	pending,
+	error,
+}: StartMockServerDialogProps) {
+	const [latency, setLatency] = useState(String(DEFAULT_MOCK_OPTIONS.latencyMs));
+	const [errorRate, setErrorRate] = useState(String(DEFAULT_MOCK_OPTIONS.errorRatePct));
+
+	const latencyError = outOfRange(latency, MAX_MOCK_LATENCY_MS, "milliseconds");
+	const errorRateError = outOfRange(errorRate, MAX_MOCK_ERROR_RATE_PCT, "percent");
+	const canStart = !latencyError && !errorRateError && !pending;
+
+	const start = () => {
+		if (!canStart) return;
+		onStart({ latencyMs: Number(latency), errorRatePct: Number(errorRate) });
+	};
+
+	return (
+		<Dialog open onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Mock server options</DialogTitle>
+					<DialogDescription>
+						What the mock does on its way to answering. Both are fixed for the life of
+						the mock - stop and start it to change either.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 py-2">
+					{/* The bound in words, not only in `aria-invalid` and a disabled
+					    button: a field that reddens while Start greys out states that
+					    something is wrong and never which field or why. */}
+					<div className="space-y-1">
+						<div className="flex items-center justify-between gap-4">
+							<Label htmlFor="mock-latency" className="leading-snug">
+								Latency
+								<span className="block text-xs font-normal text-muted-foreground">
+									Milliseconds to wait before every answer. A baseline with no
+									latency at all is not one a real service can be read against.
+								</span>
+							</Label>
+							<Input
+								id="mock-latency"
+								type="number"
+								min={0}
+								max={MAX_MOCK_LATENCY_MS}
+								step={50}
+								value={latency}
+								onChange={(e) => setLatency(e.target.value)}
+								className="w-28 shrink-0"
+								aria-invalid={!!latencyError}
+								aria-describedby={latencyError ? "mock-latency-error" : undefined}
+							/>
+						</div>
+						{latencyError && (
+							<p id="mock-latency-error" className="text-xs text-destructive-text">
+								{latencyError}
+							</p>
+						)}
+					</div>
+
+					<div className="space-y-1">
+						<div className="flex items-center justify-between gap-4">
+							<Label htmlFor="mock-error-rate" className="leading-snug">
+								Error rate
+								<span className="block text-xs font-normal text-muted-foreground">
+									Percent of answers replaced by a 500, so a run&apos;s error
+									handling and threshold verdict get exercised without breaking a
+									real service.
+								</span>
+							</Label>
+							<Input
+								id="mock-error-rate"
+								type="number"
+								min={0}
+								max={MAX_MOCK_ERROR_RATE_PCT}
+								step={1}
+								value={errorRate}
+								onChange={(e) => setErrorRate(e.target.value)}
+								className="w-28 shrink-0"
+								aria-invalid={!!errorRateError}
+								aria-describedby={
+									errorRateError ? "mock-error-rate-error" : undefined
+								}
+							/>
+						</div>
+						{errorRateError && (
+							<p id="mock-error-rate-error" className="text-xs text-destructive-text">
+								{errorRateError}
+							</p>
+						)}
+					</div>
+
+					{/* The engine's own refusal - a collection with nothing to serve,
+					    or the server budget - shown where the form is rather than as a
+					    toast behind an open dialog. */}
+					{error && (
+						<Callout severity="blocking" title="Could not start the mock server">
+							{error.message}
+						</Callout>
+					)}
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button onClick={start} disabled={!canStart}>
+						{pending && (
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+						)}
+						Start mock server
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/src/modules/collections/CollectionDetail/mock-server-options.ts
+++ b/app/src/modules/collections/CollectionDetail/mock-server-options.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The two knobs `POST /mock/start` takes beyond the collection (issue #570).
+ *
+ * Its own file, like `mock-server-selection.ts` beside it, so the dialog
+ * exports nothing but a component and fast refresh keeps working - and so the
+ * bounds live somewhere a test can read them without rendering.
+ *
+ * Bounds mirror the engine's own (`core/constants.hpp`, `mock_server::`, plus
+ * the literal 0-100 `parse_mock_start` applies to the rate). Out of range is a
+ * `400 bad_request` that names the field and not the bound, which is a poor
+ * place to learn the range from - so the form refuses the value with the bound
+ * spelled out instead.
+ */
+
+/** `constants::mock_server::MAX_LATENCY_MS`. */
+export const MAX_MOCK_LATENCY_MS = 30_000;
+/** A share of answers, so the bound is the percentage itself. */
+export const MAX_MOCK_ERROR_RATE_PCT = 100;
+
+/** What the start dialog collects, in the shape `POST /mock/start` takes. */
+export interface MockServerOptions {
+	latencyMs: number;
+	errorRatePct: number;
+}
+
+/** Both knobs off - a mock that answers its examples as fast as it can. */
+export const DEFAULT_MOCK_OPTIONS: MockServerOptions = { latencyMs: 0, errorRatePct: 0 };
+
+/**
+ * The refusal for @p text as a field bounded `0..max`, or null when it is
+ * sendable.
+ *
+ * An empty box is refused rather than read as 0: `Number("")` is 0 and a whole
+ * number, so every other check here passes it, and a silently-zeroed field is
+ * the one case where the form would send something the user did not type.
+ */
+export function outOfRange(text: string, max: number, noun: string): string | null {
+	const bound = `A whole number of ${noun}, 0 to ${max}.`;
+	if (text.trim() === "") return bound;
+	const value = Number(text);
+	if (!Number.isInteger(value) || value < 0 || value > max) return bound;
+	return null;
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -322,6 +322,22 @@ starting two mocks of one collection, and the engine's list order is not stable 
 is deliberately no restart: a mock's route table is a start-time snapshot, so stop-and-start is the
 only way to pick up an edit, and the stop tooltip says so.
 
+Beside the button, not in front of it, is a **Mock server options** control opening
+`StartMockServerDialog.tsx` - the start form for `latencyMs` and `errorRatePct` (issue #570). The
+split is the point: the common case is "serve this collection with nothing set" and stays one click,
+while the two knobs matter to the load run you point at a mock rather than to poking a route by
+hand. A dialog on the way in would charge the common case for the uncommon one;
+[`NewIssuerDialog`](#services-modulesservices) has no equivalent split because an issuer has no
+defaults-only case worth one click. The bounds (`0-30000ms`, `0-100%`) live in
+`mock-server-options.ts` mirroring `constants::mock_server::`, and the form refuses an out-of-range
+or emptied value **with the range in words** - the engine's `400` names the field and not the bound.
+The mutation stays in `MockServerControl` and the dialog reports its failure as a `Callout` instead
+of a toast behind an open form; opening the dialog resets it, so a failed one-click start does not
+greet the next open. Neither knob is mutable on a running mock: they are read per response and so
+*could* be, but a run against a mock has to be able to say which configuration produced its numbers
+- the same reason the route table is frozen - so there is no `PUT /mock/:id` and the stop tooltip
+names all three as start-time.
+
 `InheritanceChain.tsx` and `shared.tsx` are helpers used by these tabs (e.g. visualizing the auth/variable inheritance chain); `format.ts` holds the relative-timestamp helper, kept out of `shared.tsx` so a file of components exports nothing else (fast refresh).
 
 All five tabs hold their edits in a draft; four of them commit it without being asked. Info commits on blur (name) and on `onCommit` (description); both Script tabs commit when focus leaves the editor; Variables autosaves through `VariableTableEditor`. Info and the Script tabs take the draft, the resync and the mutation reset from [`useEntityDraft()`](./state-management.md#useentitydraft---manual-draftsave-model) and render no Save button at all - the hook owns the mutation reset on a collection switch, which had been hand-rolled per tab with one tab omitting it.
@@ -609,7 +625,11 @@ both activate it.
   listener is. A mock row leads with the **collection name** (two mocks of one collection differ
   only by port) and expands in place to its base URL, its latency/error-rate line, and the **route
   table** from `GET /mock/:id/routes` - the answer to the only question this surface gets asked,
-  "why did the mock 404 that?". The table is fetched when the row is opened and never polled: it is
+  "why did the mock 404 that?". The latency/error-rate line **reports**, and correctly offers no
+  control: both are set when the mock starts (the collection header's options dialog, issue #570)
+  and are start-time for the same reason the route table is, so a live switch here - the shape the
+  issuer row's `failureMode` takes - would need a `PUT /mock/:id` the engine deliberately does not
+  have. The table is fetched when the row is opened and never polled: it is
   a start-time snapshot that cannot change under a running mock. Stopping a mock removes it from the
   list, like an issuer and unlike an inbox, because a mock holds nothing that outlives its listener.
 

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -235,6 +235,14 @@ Services drawer has none selected; the drawer's Mock servers group lists and
 stops whatever is running, wherever it came from. Both read the same polled
 list, so a mock started in one is visible in the other within a poll.
 
+The knobs are sent from that control's options dialog and nowhere else
+(`StartMockServerDialog`, issue #570), bounds-checked against
+`mock-server-options.ts` before the request leaves - the engine's `400` names
+the field but not the range. There is no update verb: `latencyMs` and
+`errorRatePct` are read per response and so *could* change under a running
+mock, but a run pointed at one has to be able to say which configuration
+produced its numbers, so they are frozen at start like the route table.
+
 `listMockServerRoutes` is **not** polled: the route table is a snapshot taken
 when the mock started and a running mock does not reload the collection, so it is
 fetched once per expanded row (`staleTime: Infinity`). Stopping drops the record


### PR DESCRIPTION
## Description

**Plan.** The root cause is a UI that names a setting it offers no way to change: `POST /mock/start` has taken `latencyMs` and `errorRatePct` since #481 phase 2, `StartMockServerRequest` declares both, `apiService.startMockServer` forwards whatever it is given, and the Services drawer's expanded mock row *displays* both - while the only caller, `MockServerControl`, sent `{ collectionId }` and nothing else. Confirmed still true at `12cfe27`; the anchors had not drifted. The approach is a start form on the shape of `services/NewIssuerDialog` (the precedent for "a service with options, started from a form"), reached from a **second** control beside the existing button rather than by turning the button into a dialog opener. The alternative I rejected is exactly that - dialog on the way in - because the common case is "serve this collection with nothing set" and charging it a second click to serve the uncommon one is the wrong trade, and the issue's own acceptance criteria pin it ("starting a mock with no options set is no harder than it is today"). The one-click path still sends `{ collectionId }` alone, so the engine's defaults stay the engine's rather than being restated here.

### The mutable-on-a-running-mock question: answered **no**, and no `PUT /mock/:id` is added

They *could* be live - unlike the route table they are read per response, not baked into a snapshot - and the issuer row's `failureMode` switch is the precedent for wanting it. The reason not to is the workflow the two knobs exist for: a load run pointed at a mock has to be able to say which configuration produced its numbers, and a rate that can move mid-run makes the run's status histogram unattributable. That is the same argument that froze the route table in #569, so answering yes here would leave the mock half-frozen for no principle. It is stated in three places a future session will hit: the dialog's header comment, `COMPONENTS.md` (including *why* the drawer row correctly shows these values with no control beside them), and the stop tooltip the user actually reads - now "A mock keeps the collection, latency and error rate it started with - stop and start it again to change any of them". Engine and MCP are untouched, as the issue's default said they should be.

### What lands

- **`StartMockServerDialog.tsx`** beside `MockServerControl` - two fields, the engine error as a `Callout` in the form rather than a toast behind an open dialog.
- **`mock-server-options.ts`** - the bounds (`MAX_MOCK_LATENCY_MS` mirroring `constants::mock_server::MAX_LATENCY_MS`, `MAX_MOCK_ERROR_RATE_PCT`) and the one `outOfRange` refusal both fields share. Its own file for the reason `mock-server-selection.ts` beside it has one: the dialog exports a component and nothing else, so fast refresh keeps working - and a bound a test can read without rendering.
- **`MockServerControl.tsx`** keeps the mutation, so there is one start call, one success toast and one started/running switch. `start(options?)` spreads nothing when called from the button. Two smaller things the split made necessary rather than optional: the dialog path suppresses the toast (the form already shows the message, and a toast behind an open dialog reports it twice and loses it once), and opening the dialog calls `startMock.reset()` (the mutation outlives the dialog, so a failed one-click start would otherwise greet the next open with a stale `Callout`).

Validation is the shape `IssuerDelayControl` set: refused in the form with the bound in words, because the engine's `400 bad_request` names the field and not the range. An **emptied** field is refused too, rather than read as zero - `Number("")` is `0` and a whole number, so every other check passes it, and it is the one case where the form would send something the user did not type.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint && pnpm format:check` - all green.

- App suite: **432 files / 4407 tests passed** (205s), 6 of them new.
- `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1495 / 1495 passed** (203s). No engine change; run because the diff was verified end to end, not because anything here could move it.
- `python3 -m mkdocs build --strict -f .github/mkdocs.yml` - built clean (docs change).
- No pre-existing failures on this base (`12cfe27`).

New coverage in `MockServerControl.test.tsx`, driven through the control rather than the dialog alone - the wiring is the part that was missing, and a form collecting two numbers that never reach `startMockServer` would satisfy any test of the form by itself. Mutation-checked by reverting each change and confirming the failure:

| Change reverted | Test that went red |
|---|---|
| `latencyMs` dropped from the dialog's payload | `sends the latency and error rate that were typed` |
| The empty-string refusal in `outOfRange` | `refuses an emptied field rather than reading it as zero` |
| The dialog-path toast suppression (`if (options) return`) | `shows the engine's refusal in the form, and does not also toast it` |
| `startMock.reset()` on opening the dialog | `does not greet the next open with the last failure` |
| The bound spelled out (the error paragraphs) | `refuses an out-of-range latency by name, and sends nothing` |

The last one is the case worth stating: with the paragraph gone the *disabled-button* half still passes, which is exactly the failure mode the issuer dialog's numeric fields were fixed for - a field that reddens while Start greys out says something is wrong and never which field or why.

The defaults path is guarded by the test that was already there: `offers to start one, and starts it for this collection` asserts `toHaveBeenCalledWith({ collectionId: "col_1" })` exactly, so it fails the moment this surface starts restating the engine's defaults.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #570.

Docs updated same-commit per the repo's doc table: `docs/app/COMPONENTS.md` (the `MockServerControl` paragraph, and the Services drawer's mock row - which reports latency and error rate and correctly offers no control) and `docs/app/api-integration.md` (which surface sends the knobs, and why there is no update verb).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6K5vSwj2Jndf7CFKzskfy)_