### PR TITLE
fix(engine/http): a bodyless POST declares a zero-length body

### DIFF
--- a/.github/release-notes/v0.16.0.md
+++ b/.github/release-notes/v0.16.0.md
@@ -51,6 +51,7 @@ The **local services and load-test judgement release**. Vayu could send in every
 - **One UI-font default.** The constant said Inter while the stylesheet, the picker's caption and the design-system doc said Space Grotesk, so a fresh install painted Space Grotesk and swapped the moment the appearance store mounted. "Reset app settings" also named three preference groups while clearing six.
 - Threshold and capacity status chips go through the Badge primitive rather than a hand-rolled span with no radius class, which pinned them square for anyone who chose the Rounded setting.
 - A Windows engine build failure (`std::getenv` is deprecated under `/W4 /WX`), a CI check that published a green `C++ Tests ()` for a job that never ran a test, and a reorder test that asserted the outcome of a random UUID comparison and reddened roughly half the time on a fast runner.
+- **A POST with no body says it has none.** Asking libcurl for a POST does not describe an empty body - it describes one whose length the caller has not stated, which libcurl then reads from its default source, the engine process's own standard input. So a bodyless POST - a trigger endpoint, a logout - went out chunked and length-less, which a server is entitled to refuse with a 411, and where that input was not already at end-of-file the request blocked where the timeout could not reach it.
 
 ### Internal
 

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -253,6 +253,27 @@ curl_mime* apply_method_and_body (CURL* curl, const Request& request) {
         // is both unnecessary and destructive here.
         if (!mime) {
             curl_easy_setopt (curl, CURLOPT_POST, 1L);
+            // CURLOPT_POST alone does not say "no body" - it says "a body, of a
+            // length I have not told you", and libcurl then reads that body
+            // from its default read callback, which is `stdin`. Declaring the
+            // length as zero is what makes a bodyless POST a bodyless POST.
+            //
+            // Without it the request goes out chunked and length-less, which
+            // the servers that answer a trigger or a logout POST are entitled
+            // to refuse with a 411 - and which no other client sends. Worse
+            // where stdin is not already at EOF: the read happens inside
+            // libcurl's callback on the transfer thread, so CURLOPT_TIMEOUT_MS
+            // never fires and the transfer blocks until stdin closes. The app
+            // spawns the daemon with stdin ignored and a shell redirects it
+            // from /dev/null, so both EOF at once and hid this; an engine
+            // started by hand on a terminal, or under a parent that pipes stdin
+            // and never writes to it, hangs outright.
+            //
+            // The body-bearing branch above sets POSTFIELDSIZE for the same
+            // reason; this is the case with no body to set it for.
+            if (!has_body) {
+                curl_easy_setopt (curl, CURLOPT_POSTFIELDSIZE, 0L);
+            }
         }
         break;
     case HttpMethod::PUT:

--- a/engine/tests/curl_transfer_test.cpp
+++ b/engine/tests/curl_transfer_test.cpp
@@ -35,6 +35,14 @@ class MethodEchoServer {
         svr.Post ("/echo", [] (const httplib::Request& req, httplib::Response& res) {
             res.set_content ("POST:" + req.body, "text/plain");
         });
+        // How the request framed its body, which is the only place the
+        // difference between "an empty body" and "a body of unknown length"
+        // shows up. See BodylessPostDeclaresAZeroLengthBody.
+        svr.Post ("/framing", [] (const httplib::Request& req, httplib::Response& res) {
+            res.set_content ("len=" + req.get_header_value ("Content-Length") +
+            ";te=" + req.get_header_value ("Transfer-Encoding"),
+            "text/plain");
+        });
         svr.Get ("/big", [] (const httplib::Request&, httplib::Response& res) {
             res.set_content (std::string (kBigBodyBytes, 'x'), "text/plain");
         });
@@ -158,6 +166,42 @@ TEST_F (CurlTransferTest, BodylessGetAndPostAreUnchanged) {
     auto post_result  = run_once (post);
     ASSERT_TRUE (post_result.is_ok ());
     EXPECT_EQ (post_result.value ().body, "POST:payload");
+}
+
+// A POST with no body is an ordinary request (a trigger endpoint, a logout),
+// and CURLOPT_POST on its own does not describe one: with no POSTFIELDS and no
+// POSTFIELDSIZE, libcurl treats the length as unknown and pulls the body from
+// its *default read callback*, which reads `stdin`. The engine sets no read
+// callback, so such a request took whatever the process's stdin happened to be.
+//
+// The framing asserted here is what every stdin gets wrong: the request goes
+// out chunked and length-less, which a server answering a trigger or logout
+// POST may refuse with a 411. The hang is the half that depends on stdin - the
+// read sits inside libcurl's callback on the transfer thread, out of
+// CURLOPT_TIMEOUT_MS's reach, so it blocks until stdin closes. A shell's
+// /dev/null EOFs at once and hides it; lukka/run-cmake spawns ctest with a pipe
+// it never writes to, which is where this surfaced, 60 seconds at a time.
+//
+// So this asserts the declared length rather than the hang: red in a
+// millisecond under any stdin, rather than red only under some and only after
+// a ctest timeout.
+//
+// Mutation-check: drop the POSTFIELDSIZE line from apply_method_and_body and
+// both cases below report an unset length.
+TEST_F (CurlTransferTest, BodylessPostDeclaresAZeroLengthBody) {
+    vayu::Request post;
+    post.method = vayu::HttpMethod::POST;
+    post.url    = server->url ("/framing");
+
+    auto loop_result = run_once (post);
+    ASSERT_TRUE (loop_result.is_ok ());
+    EXPECT_EQ (loop_result.value ().body, "len=0;te=")
+    << "a bodyless POST must declare Content-Length: 0, not an unknown length";
+
+    vayu::http::Client client;
+    auto client_result = client.send (post);
+    ASSERT_TRUE (client_result.is_ok ());
+    EXPECT_EQ (client_result.value ().body, "len=0;te=");
 }
 
 // HEAD with a body cannot be honoured (NOBODY resets the method and drops the


### PR DESCRIPTION
## Description

The v0.16.0 release build ([run 31794419774](https://github.com/athrvk/vayu/actions/runs/31794419774)) failed on all three platforms with one test, `SentRequestHeadersTest.DefaultUserAgentReachesTheTestScript (Timeout)` - the only test in the suite that sends a **POST with no body**. That turned out to be a real engine defect rather than a flaky test.

`CURLOPT_POST` does not mean "no body". It means "a body whose length I have not told you", and with no `POSTFIELDS` and no `POSTFIELDSIZE` libcurl reads that body from its **default read callback, which is `stdin`**. The engine sets no read callback, so every bodyless POST framed itself `Transfer-Encoding: chunked` and took its content from whatever the process's standard input happened to be.

Two consequences:

- **On the wire, always.** A trigger or logout POST goes out with no `Content-Length`, which a server is entitled to refuse with a 411 and which no other client sends.
- **A hang, where stdin is not already at EOF.** The read happens inside libcurl's callback on the transfer thread, where `CURLOPT_TIMEOUT_MS` cannot reach it - so the transfer neither completes nor times out. This is why ctest reported `Timeout` rather than a failure.

**Why only the release build caught it.** `pr-tests.yml` runs `ctest` from a bash step, so stdin is `/dev/null` and EOFs immediately - green on every PR. `release.yml` runs it through `lukka/run-cmake`'s `testPreset`, a Node action whose child stdin is a pipe nobody writes to. The test was four days old (ba2dd52) and this was the first release since.

The app itself is not affected by the hang: `sidecar.ts` spawns the daemon with `stdio: ["ignore", ...]`. For app users the defect is the framing.

The fix is one option in `apply_method_and_body`, which both curl paths share.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- New `CurlTransferTest.BodylessPostDeclaresAZeroLengthBody`, covering both the event-loop and `Client` paths. Mutation-checked: red before the fix (`len=;te=chunked`), green after.
- The original failure reproduced locally against the same binary - 4ms pass with `/dev/null` stdin, hangs indefinitely with an open stdin pipe. After the fix it passes in 36ms under the open pipe.
- Full engine suite: 1496/1496 passing (`ctest --preset linux-dev`).

The regression test asserts the framing rather than the hang deliberately, so it is red in a millisecond under any stdin instead of red only under some and only after a 60-second ctest timeout.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs: added a `### Fixed` entry to `.github/release-notes/v0.16.0.md`, since that release published no artifacts.

## Related Issues

No issue - this is the v0.16.0 release build failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAFa68iNsq7dVxWrtmuBrx)_