### PR TITLE
ci(winget): sync the fork before publishing, and probe the real mutation

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -180,20 +180,49 @@ missing, because a manual run that published nothing while reporting success
 would be worse than an error. `WINGET_TOKEN` must be a **classic** PAT with
 `public_repo` scope; fine-grained PATs are not supported by the action.
 
-**Every winget credential problem arrives as one opaque line.** komac reports an
-expired token, a fine-grained token, a missing fork, an archived fork and a fork
-owned by another account all as
-`<user> does not have the correct permissions to execute CreateRef` - and only
-after downloading the installer and rendering all three manifests, so the log
-looks like a success until its final line. v0.16.0 failed twice this way. The
-manual workflow therefore preflights the token before doing any work, checking in
-order: it authenticates, it is classic (`x-oauth-scopes` is non-empty and carries
-`public_repo`), and `<token owner>/winget-pkgs` exists, is writable, is not
-archived and is a real fork of `microsoft/winget-pkgs`. Each failure names
-itself. To check the same things by hand, `curl -sI -H "Authorization: token
-$PAT" https://api.github.com/user | grep -i x-oauth-scopes`.
+### When winget publishing fails, suspect the fork before the token
 
-Note the fork is checked against the *token's* owner, not the repository's: a PAT
-belonging to a different account authenticates perfectly and is then denied at
-`CreateRef`. The action's `fork-user` defaults to the repository owner, so the
-two must be the same account unless it is set explicitly.
+**Every winget problem arrives as one opaque line.** An expired token, a
+fine-grained token, a missing fork, an archived fork, a fork owned by another
+account and a fork merely *out of date* all reach the log as
+`<user> does not have the correct permissions to execute CreateRef` - and only
+after komac has downloaded the installer and rendered all three manifests, so
+the run reads as a success until its final line.
+
+**The usual cause is the stale fork, and the message points at the token.**
+v0.16.0 was spent minting tokens for that reason. komac branches at
+*upstream's* head commit, so a fork that does not contain that commit cannot
+have the ref created at it, and GitHub phrases the refusal as permissions.
+Syncing the fork published immediately, with the token that had just "failed".
+[komac#1142](https://github.com/russellbanks/Komac/issues/1142) reports the same
+symptom and the same fix. Note also that REST write access is *not* evidence:
+`POST /repos/<fork>/git/refs` returned 201 throughout, because it creates a ref
+at a commit the fork already has, while komac's GraphQL `createRef` at
+upstream's head was refused.
+
+`.github/actions/winget-preflight` runs before komac in both publishing
+workflows and covers all of it: the token authenticates, is classic
+(`x-oauth-scopes` non-empty and carrying `public_repo`), owns a
+`<token owner>/winget-pkgs` that is writable, unarchived and a real fork of
+`microsoft/winget-pkgs`; then it **syncs that fork** via `merge-upstream`; then
+it creates and deletes a throwaway branch through the same GraphQL mutation
+komac uses. Each failure names itself, and the sync means the common one stops
+happening rather than being diagnosed faster.
+
+It is an action rather than a step in each workflow because both the
+tag-triggered job and the manual one need it, and the copy not being debugged is
+the copy that drifts.
+
+Two things it deliberately does *not* do. It cannot repair a fork that has
+**diverged** from upstream (`merge-upstream` answers 409): resetting the branch
+would discard whatever was committed on top of it, so it stops and says so. And
+it resolves the fork from the **token's** owner, not the repository's - a PAT
+belonging to another account authenticates perfectly and is denied only at the
+branch. `fork-user` defaults to the repository owner, so the two must be the
+same account unless it is set explicitly.
+
+To check a token by hand:
+`curl -sI -H "Authorization: token $PAT" https://api.github.com/user | grep -i
+x-oauth-scopes`. To check the fork, compare
+`git ls-remote https://github.com/<you>/winget-pkgs master` against the same for
+`microsoft/winget-pkgs`.

--- a/.github/actions/winget-preflight/action.yml
+++ b/.github/actions/winget-preflight/action.yml
@@ -1,0 +1,215 @@
+name: Winget publish preflight
+description: >
+  Verify WINGET_TOKEN can publish, bring the winget-pkgs fork up to date, and
+  prove the branch komac needs can actually be created - before komac runs.
+
+# Every winget credential and fork problem reaches the log as one opaque line,
+# "<user> does not have the correct permissions to execute `CreateRef`", emitted
+# only after komac has downloaded the installer and rendered all three
+# manifests. The line names neither which prerequisite failed nor which
+# repository the write was refused on, so an expired token, a fine-grained
+# token, a missing fork and a *stale* fork are indistinguishable from the log.
+#
+# v0.16.0 was lost to exactly that, twice. The token was replaced first because
+# the message says "permissions"; the real cause was a fork 11 days behind
+# microsoft/winget-pkgs, and syncing it published immediately with the same
+# token that had just "failed" (komac issue #1142 reports the identical
+# symptom and the identical fix).
+#
+# So the fork sync below is the fix, not a precaution: komac branches at
+# *upstream's* head commit, and a fork that does not contain that commit cannot
+# have a ref created at it. The fork falls behind between every release, so
+# without this the failure returns on a schedule.
+#
+# Both workflows that publish use this, which is why it is an action rather
+# than a step: the tag-triggered job in release.yml and the manual
+# winget-publish.yml would otherwise carry two copies of it, and the copy that
+# is not being debugged is the one that drifts.
+
+inputs:
+  token:
+    description: >
+      Classic PAT with the public_repo scope, belonging to the account that owns
+      the winget-pkgs fork. Fine-grained PATs are not supported by komac.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify WINGET_TOKEN
+      id: token
+      shell: bash
+      env:
+        WINGET_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${WINGET_TOKEN:-}" ]; then
+          echo "::error::WINGET_TOKEN is not set. Create a *classic* PAT with the" \
+               "public_repo scope (fine-grained PATs are not supported by" \
+               "winget-releaser) and add it as a repository secret."
+          exit 1
+        fi
+
+        status=$(curl -sS -o user.json -D user.headers -w '%{http_code}' \
+                 -H "Authorization: token $WINGET_TOKEN" https://api.github.com/user)
+        if [ "$status" != "200" ]; then
+          echo "::error::WINGET_TOKEN did not authenticate (HTTP $status) - it has" \
+               "most likely expired. Mint a new classic PAT with public_repo scope" \
+               "and update the repository secret."
+          exit 1
+        fi
+
+        # A classic PAT reports its scopes in x-oauth-scopes. A fine-grained PAT
+        # omits the header entirely, so an empty value here is itself the
+        # diagnosis rather than a missing scope.
+        login=$(jq -r .login user.json)
+        scopes=$(grep -i '^x-oauth-scopes:' user.headers | cut -d: -f2- | tr -d '\r' | xargs || true)
+        echo "Authenticates as: $login"
+        echo "Scopes: ${scopes:-<none - this is a fine-grained PAT>}"
+
+        case ",${scopes// /}," in
+          *,public_repo,* | *,repo,*) ;;
+          *)
+            echo "::error::WINGET_TOKEN lacks the public_repo scope (scopes:" \
+                 "${scopes:-none}). komac needs a *classic* PAT with public_repo;" \
+                 "a fine-grained PAT reports no scopes at all."
+            exit 1
+            ;;
+        esac
+
+        # komac branches in the fork named by KOMAC_FORK_OWNER, which
+        # winget-releaser defaults to the repository owner. The token must own
+        # that fork: a token for a different account authenticates perfectly and
+        # is denied only at the branch, which is why this resolves the fork from
+        # $login rather than from the repository owner.
+        fork="$login/winget-pkgs"
+        status=$(curl -sS -o fork.json -w '%{http_code}' \
+                 -H "Authorization: token $WINGET_TOKEN" "https://api.github.com/repos/$fork")
+        if [ "$status" != "200" ]; then
+          echo "::error::$fork is not reachable with this token (HTTP $status)." \
+               "Fork microsoft/winget-pkgs to $login - komac creates its branch" \
+               "there, and without the fork the attempt lands on" \
+               "microsoft/winget-pkgs itself and is refused."
+          exit 1
+        fi
+
+        push=$(jq -r '.permissions.push' fork.json)
+        archived=$(jq -r '.archived' fork.json)
+        parent=$(jq -r '.parent.full_name // "<not a fork>"' fork.json)
+        branch=$(jq -r '.default_branch' fork.json)
+        echo "$fork: push=$push archived=$archived parent=$parent default=$branch"
+
+        if [ "$push" != "true" ] || [ "$archived" != "false" ]; then
+          echo "::error::WINGET_TOKEN cannot write to $fork (push=$push," \
+               "archived=$archived). An archived fork reports push=true and still" \
+               "rejects every write, so unarchive it rather than re-minting the token."
+          exit 1
+        fi
+
+        if [ "$parent" != "microsoft/winget-pkgs" ]; then
+          echo "::error::$fork is not a fork of microsoft/winget-pkgs (parent:" \
+               "$parent). A plain copy of the repository is not detected as the" \
+               "fork; delete it and fork microsoft/winget-pkgs afresh."
+          exit 1
+        fi
+
+        {
+          echo "fork=$fork"
+          echo "branch=$branch"
+        } >> "$GITHUB_OUTPUT"
+
+    # The one that actually keeps releases working. komac creates its branch at
+    # upstream's current head, so a fork missing that commit fails - reported as
+    # a permissions error, which sends everyone to the token instead.
+    - name: Sync the fork with upstream
+      shell: bash
+      env:
+        WINGET_TOKEN: ${{ inputs.token }}
+        FORK: ${{ steps.token.outputs.fork }}
+        BRANCH: ${{ steps.token.outputs.branch }}
+      run: |
+        set -euo pipefail
+
+        status=$(curl -sS -o merge.json -w '%{http_code}' -X POST \
+                 -H "Authorization: token $WINGET_TOKEN" \
+                 -H 'Accept: application/vnd.github+json' \
+                 "https://api.github.com/repos/$FORK/merge-upstream" \
+                 -d "{\"branch\":\"$BRANCH\"}")
+
+        if [ "$status" = "200" ]; then
+          # merge_type is fast-forward, merge, or none (already current).
+          echo "$FORK@$BRANCH: $(jq -r '.merge_type // "unknown"' merge.json)" \
+               "- $(jq -r '.message // ""' merge.json)"
+          exit 0
+        fi
+
+        # 409 means the fork has diverged from upstream and cannot fast-forward,
+        # which breaks komac exactly the way being behind does. It needs a human:
+        # resetting the branch discards whatever was committed on top of it.
+        if [ "$status" = "409" ]; then
+          echo "::error::$FORK@$BRANCH has diverged from microsoft/winget-pkgs and" \
+               "cannot be fast-forwarded. Reset the fork's $BRANCH to upstream (or" \
+               "delete and re-fork); komac cannot branch from it as it stands."
+          exit 1
+        fi
+
+        echo "::error::Could not sync $FORK@$BRANCH with upstream (HTTP $status):" \
+             "$(jq -r '.message // "no message"' merge.json)"
+        exit 1
+
+    # The REST reachability check above passes on a token that still cannot
+    # publish: komac creates its branch through the GraphQL createRef mutation,
+    # and REST write access was demonstrably green while that mutation was being
+    # refused. So exercise the real mutation, on the real fork, at the same
+    # commit komac will branch from - now that the sync has made the fork's head
+    # upstream's head - and delete the branch again.
+    - name: Verify branch creation via GraphQL
+      shell: bash
+      env:
+        WINGET_TOKEN: ${{ inputs.token }}
+        FORK: ${{ steps.token.outputs.fork }}
+        BRANCH: ${{ steps.token.outputs.branch }}
+      run: |
+        set -euo pipefail
+
+        owner=${FORK%/*}
+        name=${FORK#*/}
+        probe="komac-preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+        query='query($o:String!,$n:String!){repository(owner:$o,name:$n){id defaultBranchRef{target{oid}}}}'
+        payload=$(jq -n --arg q "$query" --arg o "$owner" --arg n "$name" \
+                  '{query:$q,variables:{o:$o,n:$n}}')
+        resp=$(curl -sS -H "Authorization: bearer $WINGET_TOKEN" \
+               -X POST -d "$payload" https://api.github.com/graphql)
+
+        repo_id=$(jq -r '.data.repository.id // empty' <<< "$resp")
+        oid=$(jq -r '.data.repository.defaultBranchRef.target.oid // empty' <<< "$resp")
+        if [ -z "$repo_id" ] || [ -z "$oid" ]; then
+          echo "::error::GraphQL could not read $FORK: $(jq -c '.errors // .' <<< "$resp")"
+          exit 1
+        fi
+
+        mutation='mutation($r:ID!,$n:String!,$o:GitObjectID!){createRef(input:{repositoryId:$r,name:$n,oid:$o}){ref{name}}}'
+        payload=$(jq -n --arg q "$mutation" --arg r "$repo_id" \
+                  --arg n "refs/heads/$probe" --arg o "$oid" \
+                  '{query:$q,variables:{r:$r,n:$n,o:$o}}')
+        resp=$(curl -sS -H "Authorization: bearer $WINGET_TOKEN" \
+               -X POST -d "$payload" https://api.github.com/graphql)
+
+        # GraphQL answers 200 with an errors array rather than an HTTP status,
+        # so the body is the only place the refusal appears.
+        if [ "$(jq -r 'has("errors")' <<< "$resp")" = "true" ]; then
+          echo "::error::WINGET_TOKEN cannot create a branch in $FORK, which is" \
+               "what komac does first:" \
+               "$(jq -r '[.errors[].message] | join("; ")' <<< "$resp")"
+          exit 1
+        fi
+
+        echo "Created and will remove $FORK@$probe at $oid"
+
+        # Best-effort: a leftover probe branch is harmless, and failing the job
+        # over the cleanup would fail a publish that is demonstrably fine.
+        curl -sS -o /dev/null -w 'probe branch deleted: %{http_code}\n' -X DELETE \
+          -H "Authorization: token $WINGET_TOKEN" \
+          "https://api.github.com/repos/$FORK/git/refs/heads/$probe" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,6 +420,28 @@ jobs:
     env:
       WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
     steps:
+      # The preflight verifies the token and, critically, syncs the fork with
+      # microsoft/winget-pkgs. komac branches at upstream's head, so a fork that
+      # has fallen behind since the last release cannot have that ref created -
+      # and GitHub reports it as a permissions error, which is why v0.16.0 was
+      # spent replacing a token that was never the problem. The fork drifts
+      # between every release, so this belongs on the automatic path above all.
+      #
+      # Both steps keep the `env.WINGET_TOKEN != ''` guard the submit step has:
+      # this job is a green no-op until the secret exists, so that landing it
+      # can never fail a release tag.
+      - name: Checkout
+        if: env.WINGET_TOKEN != ''
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Preflight and sync the fork
+        if: env.WINGET_TOKEN != ''
+        uses: ./.github/actions/winget-preflight
+        with:
+          token: ${{ env.WINGET_TOKEN }}
+
       - name: Submit manifest to winget-pkgs
         if: env.WINGET_TOKEN != ''
         uses: vedantmgoyal9/winget-releaser@v2

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -48,94 +48,17 @@ jobs:
       # operator explicitly asked for a submission, and a green tick that
       # published nothing would be worse than an error.
       #
-      # This checks the token can actually publish, not merely that it exists.
-      # Every prerequisite below surfaces from komac as the same opaque line -
-      # "<user> does not have the correct permissions to execute `CreateRef`" -
-      # after it has already downloaded the installer and rendered all three
-      # manifests, naming neither which prerequisite failed nor which repository
-      # it was denied on. v0.16.0 was lost to exactly that: an expired token
-      # reported as a permissions error, indistinguishable from a missing fork.
-      # Each check below names its own failure, before any work is done.
-      - name: Verify WINGET_TOKEN can publish
-        env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${WINGET_TOKEN:-}" ]; then
-            echo "::error::WINGET_TOKEN is not set. Create a *classic* PAT with the" \
-                 "public_repo scope (fine-grained PATs are not supported by" \
-                 "winget-releaser) and add it as a repository secret."
-            exit 1
-          fi
-
-          status=$(curl -sS -o user.json -D user.headers -w '%{http_code}' \
-                   -H "Authorization: token $WINGET_TOKEN" https://api.github.com/user)
-          if [ "$status" != "200" ]; then
-            echo "::error::WINGET_TOKEN did not authenticate (HTTP $status) - it has" \
-                 "most likely expired. Mint a new classic PAT with public_repo scope" \
-                 "and update the repository secret."
-            exit 1
-          fi
-
-          # A classic PAT reports its scopes in x-oauth-scopes. A fine-grained PAT
-          # omits the header entirely, so an empty value here is itself the
-          # diagnosis rather than a missing scope.
-          login=$(jq -r .login user.json)
-          scopes=$(grep -i '^x-oauth-scopes:' user.headers | cut -d: -f2- | tr -d '\r' | xargs || true)
-          echo "Authenticates as: $login"
-          echo "Scopes: ${scopes:-<none - this is a fine-grained PAT>}"
-
-          case ",${scopes// /}," in
-            *,public_repo,* | *,repo,*) ;;
-            *)
-              echo "::error::WINGET_TOKEN lacks the public_repo scope (scopes:" \
-                   "${scopes:-none}). winget-releaser needs a *classic* PAT with" \
-                   "public_repo; a fine-grained PAT reports no scopes at all and" \
-                   "cannot create the submission branch."
-              exit 1
-              ;;
-          esac
-
-          # komac branches in the fork named by KOMAC_FORK_OWNER, which the action
-          # defaults to this repository's owner. The token must own that fork: a
-          # token for a different account authenticates perfectly and is then
-          # denied here, which is why the check is against $login rather than
-          # against the repository owner.
-          fork="$login/winget-pkgs"
-          status=$(curl -sS -o fork.json -w '%{http_code}' \
-                   -H "Authorization: token $WINGET_TOKEN" "https://api.github.com/repos/$fork")
-          if [ "$status" != "200" ]; then
-            echo "::error::$fork is not reachable with this token (HTTP $status)." \
-                 "Fork microsoft/winget-pkgs to $login - komac creates its branch" \
-                 "there, and without the fork the attempt lands on" \
-                 "microsoft/winget-pkgs itself and is refused."
-            exit 1
-          fi
-
-          push=$(jq -r '.permissions.push' fork.json)
-          archived=$(jq -r '.archived' fork.json)
-          parent=$(jq -r '.parent.full_name // "<not a fork>"' fork.json)
-          echo "$fork: push=$push archived=$archived parent=$parent"
-
-          if [ "$push" != "true" ] || [ "$archived" != "false" ]; then
-            echo "::error::WINGET_TOKEN cannot write to $fork (push=$push," \
-                 "archived=$archived). An archived fork reports push=true and still" \
-                 "rejects every write, so unarchive it rather than re-minting the token."
-            exit 1
-          fi
-
-          if [ "$parent" != "microsoft/winget-pkgs" ]; then
-            echo "::error::$fork is not a fork of microsoft/winget-pkgs (parent:" \
-                 "$parent). A plain copy of the repository is not detected as the" \
-                 "fork; delete it and fork microsoft/winget-pkgs afresh."
-            exit 1
-          fi
-
+      # The preflight has to come after the checkout, because the action it uses
+      # lives in this repository.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      - name: Preflight and sync the fork
+        uses: ./.github/actions/winget-preflight
+        with:
+          token: ${{ secrets.WINGET_TOKEN }}
 
       # Resolve and validate before submitting, so a typo produces a clear
       # message here instead of a confusing failure inside the action - or,


### PR DESCRIPTION
## Description

v0.16.0 failed to publish to winget three times, and the token was never the cause.

komac creates its submission branch at **upstream's** head commit, so a fork that does not contain that commit cannot have the ref created at it. GitHub phrases that refusal as `<user> does not have the correct permissions to execute CreateRef`, which sends everyone to the credential. Syncing the fork published immediately, with the token that had just "failed". [komac#1142](https://github.com/russellbanks/Komac/issues/1142) reports the same symptom and the same fix.

The fork falls behind between every release, so this recurs on a schedule unless something syncs it.

This adds `.github/actions/winget-preflight`, which runs before komac on both publishing paths and does three things:

1. **Token checks** - authenticates, is classic (`x-oauth-scopes` non-empty and carrying `public_repo`), and owns a `<token owner>/winget-pkgs` that is writable, unarchived and a real fork of `microsoft/winget-pkgs`. Each failure names itself instead of arriving as one opaque line after the manifests have already rendered.
2. **`merge-upstream` sync** - the fix, not a precaution. A diverged fork (409) stops the run with an explanation rather than resetting the branch, since that would discard whatever was committed on top of it.
3. **GraphQL `createRef` probe** - creates and deletes a throwaway branch through the same mutation komac uses, after the sync, at the commit komac will branch from.

Point 3 exists because the check landed in #596 was unsound, and the failing run proved it: it verified write access with `POST /repos/<fork>/git/refs`, which creates a ref at a commit the fork *already has*. It passed green while komac's `createRef` at upstream's head was being refused. A check that can be green while publishing is broken is worse than no check.

Both publishing workflows need all of this, so it is a composite action rather than two inline copies - the copy not being debugged is the copy that drifts. The tag-triggered job in `release.yml` keeps its `env.WINGET_TOKEN != ''` guard on every added step, so it remains a green no-op if the secret is ever absent.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

No suites - this is CI configuration and a doc, and no test could change colour.

- All three YAML files parse (`yaml.safe_load`).
- All three embedded shell scripts pass `bash -n`.
- The jq payload construction for both the GraphQL query and the `createRef` mutation was run locally and produces well-formed request bodies.
- The error-detection branch was exercised against a real refusal body (`{"errors":[{"message":"... CreateRef"}]}` → detected) and a success body (→ not detected), since GraphQL answers 200 with an errors array rather than an HTTP status.
- The scope matcher was checked against `public_repo`, `repo, workflow`, `repo:status`, `gist` and empty.

The action has not executed in CI yet; it runs on the next publish. Re-running **Publish to winget (manual)** from this branch exercises all three preflight steps in full (komac will then find 0.16.0 already submitted).

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Follow-up to #596, which addressed the symptom. Upstream context: [komac#1142](https://github.com/russellbanks/Komac/issues/1142).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8WBjckdnFWkzCqhrceoZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8WBjckdnFWkzCqhrceoZb)_