### PR TITLE
fix(app/importers): join imported query params back into the request URL

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ParamsPanel.tsx
@@ -15,37 +15,14 @@
  */
 
 import { useCallback } from "react";
-import { containsVariableToken } from "@/constants/variables";
 import { useRequestBuilderContext } from "../../../context";
 import KeyValueEditor from "@/components/shared/KeyValueEditor";
 import { BulkEditor } from "../../../shared/BulkEditor";
 import { useVariableSupport } from "../../../hooks/useVariableSupport";
 import type { KeyValueItem } from "@/types";
 import { formatParamsToText, parseParamsFromText } from "../../../utils/params-format";
+import { buildUrlWithParams } from "../../../utils/url";
 import { EmptyTableHint } from "./EmptyTableHint";
-
-// Build URL from base and params
-// Note: We don't URL-encode values containing {{variables}} - they get resolved and encoded at request time
-function buildUrlWithParams(baseUrl: string, params: KeyValueItem[]): string {
-	const queryStart = baseUrl.indexOf("?");
-	const base = queryStart === -1 ? baseUrl : baseUrl.slice(0, queryStart);
-
-	const enabledParams = params.filter((p) => p.enabled && p.key.trim());
-	if (enabledParams.length === 0) return base;
-
-	const queryString = enabledParams
-		.map((p) => {
-			// Don't encode if contains variable placeholder - will be resolved later
-			const hasVarInKey = containsVariableToken(p.key);
-			const hasVarInValue = containsVariableToken(p.value);
-			const key = hasVarInKey ? p.key : encodeURIComponent(p.key);
-			const value = hasVarInValue ? p.value : encodeURIComponent(p.value);
-			return p.value ? `${key}=${value}` : key;
-		})
-		.join("&");
-
-	return `${base}?${queryString}`;
-}
 
 export default function ParamsPanel() {
 	const { request, updateField, resolveString } = useRequestBuilderContext();

--- a/app/src/modules/request-builder/utils/url.test.ts
+++ b/app/src/modules/request-builder/utils/url.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The two join rules and the parser that reads them back.
+ *
+ * `buildUrlWithParams` (the Params table: the rows *are* the query) and
+ * `appendParamsToUrl` (import: the rows are *additional* to the query the URL
+ * already carries) differ in exactly one case - a URL that arrives with a query
+ * of its own - and that case is what issue #590 turns on, so it is pinned on
+ * both sides rather than assumed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { appendParamsToUrl, buildUrlWithParams, parseQueryParams } from "./url";
+import type { KeyValueEntry } from "@/types";
+
+const kv = (key: string, value: string, enabled = true): KeyValueEntry => ({
+	key,
+	value,
+	enabled,
+});
+
+describe("buildUrlWithParams", () => {
+	it("replaces the URL's existing query with the rows", () => {
+		expect(buildUrlWithParams("https://x/y?stale=1", [kv("page", "1")])).toBe(
+			"https://x/y?page=1"
+		);
+	});
+
+	it("clears the query when no row is enabled - the table is the whole truth", () => {
+		expect(buildUrlWithParams("https://x/y?page=1", [kv("page", "1", false)])).toBe(
+			"https://x/y"
+		);
+		expect(buildUrlWithParams("https://x/y?page=1", [])).toBe("https://x/y");
+	});
+
+	it("drops rows with no key, and writes a valueless row as a bare key", () => {
+		expect(buildUrlWithParams("https://x/y", [kv("  ", "1"), kv("page", "")])).toBe(
+			"https://x/y?page"
+		);
+	});
+
+	it("encodes keys and values, but leaves {{variables}} alone", () => {
+		expect(buildUrlWithParams("https://x/y", [kv("q", "a b&c"), kv("id", "{{userId}}")])).toBe(
+			"https://x/y?q=a%20b%26c&id={{userId}}"
+		);
+	});
+});
+
+describe("appendParamsToUrl", () => {
+	it("keeps the URL's own query and appends the rows after it", () => {
+		expect(appendParamsToUrl("https://x/y?a=1", [kv("b", "2")])).toBe("https://x/y?a=1&b=2");
+	});
+
+	it("starts a query when the URL has none", () => {
+		expect(appendParamsToUrl("{{baseUrl}}/users", [kv("page", "1")])).toBe(
+			"{{baseUrl}}/users?page=1"
+		);
+	});
+
+	it("leaves a URL with nothing to append exactly as it was", () => {
+		// The disabled-row trap: an import must keep the row in the table and out
+		// of the wire, and must not strip a query the source put in the URL.
+		expect(appendParamsToUrl("https://x/y?a=1", [kv("b", "2", false)])).toBe("https://x/y?a=1");
+		expect(appendParamsToUrl("https://x/y", [])).toBe("https://x/y");
+	});
+
+	it("does not double the separator on a URL that already ends in one", () => {
+		expect(appendParamsToUrl("https://x/y?", [kv("a", "1")])).toBe("https://x/y?a=1");
+		expect(appendParamsToUrl("https://x/y?a=1&", [kv("b", "2")])).toBe("https://x/y?a=1&b=2");
+	});
+
+	it("round-trips through parseQueryParams", () => {
+		const joined = appendParamsToUrl("https://x/y", [kv("q", "a b"), kv("id", "{{userId}}")]);
+		expect(parseQueryParams(joined).map(({ key, value }) => ({ key, value }))).toEqual([
+			{ key: "q", value: "a b" },
+			{ key: "id", value: "{{userId}}" },
+		]);
+	});
+});

--- a/app/src/modules/request-builder/utils/url.ts
+++ b/app/src/modules/request-builder/utils/url.ts
@@ -9,8 +9,61 @@
  * URL utilities for the request builder.
  */
 
-import type { KeyValueItem } from "@/types";
+import type { KeyValueEntry, KeyValueItem } from "@/types";
 import { generateId } from "@/lib/id";
+import { containsVariableToken } from "@/constants/variables";
+
+/**
+ * Render the enabled, keyed rows as a query string, without a leading `?`.
+ *
+ * A row with no value writes as a bare key (`?page`, not `?page=`) - legal, and
+ * the same shape `formatParamsToText` shows the user for that row.
+ *
+ * A segment holding a `{{variable}}` is left unencoded: it is resolved at
+ * request time, and percent-encoding the braces here would send them literally.
+ */
+function toQueryString(params: readonly KeyValueEntry[]): string {
+	return params
+		.filter((p) => p.enabled && p.key.trim())
+		.map((p) => {
+			const key = containsVariableToken(p.key) ? p.key : encodeURIComponent(p.key);
+			const value = containsVariableToken(p.value) ? p.value : encodeURIComponent(p.value);
+			return p.value ? `${key}=${value}` : key;
+		})
+		.join("&");
+}
+
+/**
+ * The URL that expresses exactly these params: the rows *replace* whatever
+ * query the URL carried.
+ *
+ * This is the Params table's rule, and only the table's - there the rows are
+ * the whole truth of the query, so deleting the last one has to clear it. An
+ * importer must not use this: a source URL can carry a query the source did not
+ * also list as a param, and replacing would drop it. See `appendParamsToUrl`.
+ */
+export function buildUrlWithParams(baseUrl: string, params: readonly KeyValueEntry[]): string {
+	const queryStart = baseUrl.indexOf("?");
+	const base = queryStart === -1 ? baseUrl : baseUrl.slice(0, queryStart);
+	const query = toQueryString(params);
+	return query ? `${base}?${query}` : base;
+}
+
+/**
+ * Append these params to whatever query the URL already carries.
+ *
+ * The import rule, where `url` and `params[]` are two independent statements by
+ * the source: Postman splits its query out of the URL (leaving the URL with
+ * none), while Insomnia keeps the URL verbatim beside a separate `parameters[]`
+ * - and appending the two is exactly what Insomnia itself does on send.
+ */
+export function appendParamsToUrl(url: string, params: readonly KeyValueEntry[]): string {
+	const query = toQueryString(params);
+	if (!query) return url;
+	if (!url.includes("?")) return `${url}?${query}`;
+	// A URL ending in `?` or `&` is already sitting on its separator.
+	return /[?&]$/.test(url) ? `${url}${query}` : `${url}&${query}`;
+}
 
 /**
  * Parse the query string of a URL into key/value items.

--- a/app/src/services/importers/factory.test.ts
+++ b/app/src/services/importers/factory.test.ts
@@ -75,3 +75,81 @@ describe("parseImport", () => {
 		expect(() => parseImport("42", opts)).toThrow(UnrecognisedFormatError);
 	});
 });
+
+/**
+ * Issue #590. Each parser states the query its own way - Postman splits it out
+ * of the URL, Insomnia keeps a `parameters[]` beside the URL, OpenAPI invents
+ * params for a URL that never had a query - and every execution path sends
+ * `url` verbatim. So the URL a parser hands on has to already carry the enabled
+ * params, or they never reach the wire.
+ *
+ * Asserted through `parseImport`, not the parsers: the parsers' own split is
+ * still their contract (their suites pin it), and this join is the one rule
+ * applied above all of them.
+ */
+describe("parseImport joins enabled params into the request URL", () => {
+	it("Postman: the split query comes back, minus the disabled row", () => {
+		const req = parseImport(fx("postman-v21.json"), opts).collections[0].children[0]
+			.requests[0];
+		expect(req.url).toBe("{{baseUrl}}/users?page=1");
+		// The table keeps both rows: `params[]` is what the source declared, and
+		// the disabled one has to stay visible to be re-enabled.
+		expect(req.params).toEqual([
+			{ key: "page", value: "1", enabled: true },
+			{ key: "trace", value: "1", enabled: false },
+		]);
+	});
+
+	it("Postman: a request with no query is untouched", () => {
+		const req = parseImport(fx("postman-v21.json"), opts).collections[0].requests[0];
+		expect(req.url).toBe("{{baseUrl}}/users");
+	});
+
+	it("Insomnia: `parameters[]` joins the URL, disabled row excluded", () => {
+		const root = parseImport(fx("insomnia-v4.json"), opts).collections[0];
+		const all = [...root.requests, ...root.children.flatMap((c) => c.requests)];
+		const req = all.find((r) => r.params.length > 0);
+		expect(req?.url).toBe("{{baseUrl}}/users?page=1");
+		expect(req?.params.map((p) => [p.key, p.enabled])).toEqual([
+			["page", true],
+			["trace", false],
+		]);
+	});
+
+	it("Insomnia: a query written inline in the URL survives the join", () => {
+		/*
+		 * The append-vs-replace trap. Insomnia's `url` is taken verbatim and its
+		 * `parameters[]` is a separate list, so both can carry query state - and
+		 * appending them is what Insomnia itself does on send. Rebuilding the URL
+		 * from `params[]` alone (the Params table's rule) would delete the `a=1`
+		 * the source put in the URL, silently.
+		 */
+		const doc = JSON.stringify({
+			_type: "export",
+			__export_format: 4,
+			resources: [
+				{ _id: "w", _type: "workspace", name: "W" },
+				{
+					_id: "r",
+					_type: "request",
+					parentId: "w",
+					name: "R",
+					method: "get",
+					url: "https://x/y?a=1",
+					parameters: [{ name: "b", value: "2" }],
+				},
+			],
+		});
+		expect(parseImport(doc, opts).collections[0].requests[0].url).toBe("https://x/y?a=1&b=2");
+	});
+
+	it("OpenAPI: a declared query parameter reaches the URL as a valueless key", () => {
+		// The stub parsers carry no values (`docs/app/import-collections/openapi-v3.md`),
+		// so a declared parameter joins as a bare key - the same thing the Params
+		// table writes for a keyed row the user has not filled in yet.
+		const root = parseImport(fx("openapi-v3.json"), opts).collections[0];
+		const all = [...root.requests, ...root.children.flatMap((c) => c.requests)];
+		const pets = all.find((r) => r.url.includes("/pets/{{petId}}"));
+		expect(pets?.url).toBe("{{baseUrl}}/pets/{{petId}}?verbose");
+	});
+});

--- a/app/src/services/importers/factory.ts
+++ b/app/src/services/importers/factory.ts
@@ -6,8 +6,9 @@
  */
 
 import yaml from "js-yaml";
-import type { ImportOptions, ImportParser, ImportResult } from "./types";
+import type { CollectionDraft, ImportOptions, ImportParser, ImportResult } from "./types";
 import { UnrecognisedFormatError } from "./types";
+import { appendParamsToUrl } from "@/modules/request-builder/utils/url";
 import { PostmanV21Parser, PostmanV20Parser } from "./postman";
 import { PostmanEnvironmentParser } from "./postman-environment";
 import { InsomniaV4Parser } from "./insomnia-v4";
@@ -36,6 +37,32 @@ function parseRaw(raw: string): unknown {
 }
 
 /**
+ * Restore the app's url/params invariant on every request a parser produced.
+ *
+ * A request built in the app carries its enabled query **inside `url`**: the
+ * Params table rewrites the URL on every edit, and every execution path - design
+ * Send, scenario run, load run - sends `url` verbatim while `params[]` stays
+ * editor state no engine path ever reads. The parsers write the other shape:
+ * Postman splits the query out of the URL into `params[]`, OpenAPI synthesises
+ * params for a URL that never had one, Insomnia carries a `parameters[]` beside
+ * the URL. An imported request therefore went on the wire with its query
+ * missing, silently, until the user happened to edit the table once - which
+ * repaired the URL and hid the bug (issue #590).
+ *
+ * One pass here rather than a call in each parser: it is one rule for every
+ * format including the next one, and it leaves each parser's own mapping honest
+ * - `params[]` still mirrors exactly what the source declared, disabled rows
+ * included, and only the enabled rows reach `url`.
+ */
+function joinParamsIntoUrls(result: ImportResult): void {
+	const walk = (c: CollectionDraft): void => {
+		for (const r of c.requests) r.url = appendParamsToUrl(r.url, r.params);
+		for (const child of c.children) walk(child);
+	};
+	for (const c of result.collections) walk(c);
+}
+
+/**
  * Parse a raw import string. Parses once (JSON then YAML fallback), then runs detectors in order.
  * @throws UnrecognisedFormatError if no parser claims the input.
  */
@@ -45,6 +72,7 @@ export function parseImport(raw: string, opts: ImportOptions, fileName?: string)
 		if (parser.detect(parsed, raw)) {
 			const result = parser.parse(parsed, raw, opts);
 			if (fileName) result.meta.fileName = fileName;
+			joinParamsIntoUrls(result);
 			return result;
 		}
 	}

--- a/app/src/services/importers/orchestrator.test.ts
+++ b/app/src/services/importers/orchestrator.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { ImportOrchestrator, type ImportApi } from "./orchestrator";
 import { assignTempIds } from "./assign-ids";
+import { parseImport } from "./factory";
 import type { ImportResult } from "./types";
 import type { ImportApplyRequest, VariableValue } from "@/types";
 
@@ -146,6 +149,32 @@ describe("ImportOrchestrator", () => {
 		expect(stated.maxRedirects).toBe(3);
 		expect(Object.keys(unstated)).not.toContain("followRedirects");
 		expect(Object.keys(unstated)).not.toContain("maxRedirects");
+	});
+
+	it("stores an imported request's query inside its url (issue #590)", async () => {
+		/*
+		 * The end of the chain the issue traced: whatever `url` this payload
+		 * carries is what the engine stores, what the builder loads into the URL
+		 * bar, and what every execution path - design Send, scenario run, load
+		 * run - sends verbatim, since no engine path reads `params[]` at all. So
+		 * the query has to be in `url` by the time the import is applied, not
+		 * repaired later by the user's first edit of the Params table.
+		 */
+		const result = assignTempIds(
+			parseImport(
+				readFileSync(join(__dirname, "__fixtures__", "postman-v21.json"), "utf8"),
+				opts
+			)
+		);
+		const { api, calls } = fakeApi();
+		await new ImportOrchestrator(api).run(result, opts);
+
+		const listUsers = calls[0].requests.find((r) => r.name === "List users")!;
+		expect(listUsers.url).toBe("{{baseUrl}}/users?page=1");
+		expect(listUsers.params).toEqual([
+			{ key: "page", value: "1", enabled: true },
+			{ key: "trace", value: "1", enabled: false },
+		]);
 	});
 
 	it("sends the whole tree in exactly one /import/apply call", async () => {

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -42,10 +42,40 @@ raw string ──▶ parseImport() ──▶ assignTempIds() ──▶ ImportOrc
    `PostmanV21 → PostmanV20 → PostmanEnvironment → InsomniaV4 → OpenApiV3 → OpenApiV2`.
    The first parser whose `detect()` returns `true` gets to `parse()`.
 3. No match → throws `UnrecognisedFormatError`.
+4. **Joins each request's enabled params into its `url`** - see
+   [The url/params invariant](#the-urlparams-invariant) below.
 
 The factory parses the raw text **once** and hands every detector the already-parsed
 object (plus the raw string). This is a conscious divergence from the PRD's
 `detect(raw: string)` - detectors receive `(parsed, raw)`.
+
+#### The url/params invariant
+
+A stored request carries its **enabled** query inside `url`; `params[]` mirrors
+it for the editor, disabled rows included (see
+[request-storage-design.md](../../request-storage-design.md)). `url` is what
+every execution path sends verbatim, and no engine path reads `params[]` at all.
+
+Every parser states the query some other way - Postman splits it out of the URL
+into `params[]`, Insomnia keeps a `parameters[]` beside a verbatim URL, the
+OpenAPI parsers synthesize params for a URL that never had a query - so an
+imported request used to go on the wire with its query missing, silently, until
+the user happened to edit the Params table once (issue #590).
+
+`parseImport` closes that with one pass over every request draft,
+`appendParamsToUrl(r.url, r.params)`
+(`modules/request-builder/utils/url.ts`, shared with the Params table rather than
+copied). It **appends**, so a URL that arrived with a query of its own keeps it -
+which is what Insomnia's own send does with its two sources. Each parser's
+mapping stays as documented: `params[]` is still exactly what the source
+declared, and only the enabled rows reach `url`.
+
+Two consequences worth expecting:
+
+- A row disabled in the source stays in the table and out of the URL.
+- A row with a key and no value joins as a **bare key** (`?verbose`), which is
+  what the Params table writes for the same row. The OpenAPI parsers emit
+  value-less stubs, so their URLs now name the declared query parameters.
 
 ### 2. Assign temp IDs - `assign-ids.ts`
 

--- a/docs/app/import-collections/insomnia-v4.md
+++ b/docs/app/import-collections/insomnia-v4.md
@@ -79,8 +79,8 @@ Built by `buildRequest`.
 | `name` | `name` | Falls back to `"Untitled"`. |
 | `description` | `description` | Falls back to `""`. |
 | `method` | `method` | Upper-cased; restricted to `GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS`, otherwise defaults to `GET`. |
-| `url` | `url` | `normalizeVars(asString(url))`. |
-| `parameters[]` (`{name,value,disabled,description}`) | `params` | `mapKeyValues`: `name → key`, `disabled !== true → enabled`. A string `description` is forwarded (any other type is ignored). Rows without a `key` are dropped. |
+| `url` | `url` | `normalizeVars(asString(url))` - taken verbatim, query string and all. `parseImport` then **appends** the enabled `parameters[]` to it (see [The url/params invariant](./README.md#the-urlparams-invariant)), which is what Insomnia itself does with its two query sources on send: a URL written `https://x/y?a=1` beside a `b=2` parameter stores as `https://x/y?a=1&b=2`. |
+| `parameters[]` (`{name,value,disabled,description}`) | `params` | `mapKeyValues`: `name → key`, `disabled !== true → enabled`. A string `description` is forwarded (any other type is ignored). Rows without a `key` are dropped. Enabled rows also join the `url`, per the row above. |
 | `headers[]` (`{name,value,disabled,description}`) | `headers` | Same mapping as params. |
 | `settingFollowRedirects` (`"global" \| "on" \| "off"`) | `followRedirects` | `"off" → false`, `"on" → true`; `"global"` (Insomnia's default, meaning "use the app setting", which follows redirects) and an absent field leave the draft field **absent**, so the engine default (`true`) applies. Insomnia has no per-request redirect limit, so `maxRedirects` is never imported. |
 | `body` | `body` | Via `insomniaBody`. See [Body mapping](#body-mapping). |

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -82,7 +82,7 @@ Built by `buildSwaggerOp(method, path, op, spec, resolveRef, pathParams)`.
 | `op.description` | `description` | fallback `""` |
 | HTTP method | `method` | `method.toUpperCase()` (e.g. `get` → `GET`), cast to `HttpMethod` |
 | `path` | `url` | `` `{{baseUrl}}${normalizeVars(path, { pathTemplates: true })}` `` - always prefixed with `{{baseUrl}}`, even if no `host` was defined (see [URL](#url--path-parameters)) |
-| parameter `in: "query"` | `params` | `{ key: name, value: "", enabled: true, description? }` - `description` included only when present |
+| parameter `in: "query"` | `params` | `{ key: name, value: "", enabled: true, description? }` - `description` included only when present. `parseImport` also joins them onto the `url` as **bare keys** (`?verbose`), since the stub carries no value - see [The url/params invariant](./README.md#the-urlparams-invariant) |
 | parameter `in: "header"` | `headers` | `{ key: name, value: "", enabled: true }` - **no description carried**; `authorization` and `content-type` headers are dropped (case-insensitive) since Vayu manages those |
 | parameter `in: "body"` | `body` | sampled via `sampleSchema`; JSON vs text decided by `consumes` (see [Parameters & body](#parameters--body)) |
 | parameter `in: "formData"` | `body` | collected into form fields; the encoding (`x-www-form-urlencoded` vs `form-data`) comes from `consumes` (see [`consumes` → body mode](#consumes--body-mode)) |

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -107,7 +107,7 @@ Built by `buildOperation(method, path, op, resolveRef, pathParams)`.
 | `op.description` | `description` | fallback `""` |
 | HTTP method | `method` | `method.toUpperCase()` (e.g. `get` → `GET`), cast to `HttpMethod` |
 | `path` | `url` | `` `{{baseUrl}}${normalizeVars(path, { pathTemplates: true })}` `` - always prefixed with `{{baseUrl}}`, even if no server was defined (see [URL](#url--path-parameters)) |
-| parameters with `in: "query"` | `params` | `{ key: name, value: "", enabled: true, description? }` - `description` included only when present |
+| parameters with `in: "query"` | `params` | `{ key: name, value: "", enabled: true, description? }` - `description` included only when present. `parseImport` also joins them onto the `url` as **bare keys** (`?verbose`), since the stub carries no value - see [The url/params invariant](./README.md#the-urlparams-invariant) |
 | parameters with `in: "header"` | `headers` | `{ key: name, value: "", enabled: true }` - **no description carried**; `authorization` and `content-type` headers are dropped (case-insensitive) since Vayu manages those |
 | parameters with `in: "path"` / `in: "cookie"` | - | not emitted as params/headers; path params are represented in the URL via `normalizeVars`. Cookie params are dropped. |
 | `op.requestBody` | `body` | via `buildBody` (see [Request body](#request-body-generation)) |

--- a/docs/app/import-collections/postman.md
+++ b/docs/app/import-collections/postman.md
@@ -127,6 +127,8 @@ Values of the wrong type are ignored rather than coerced (a `"false"` string wou
 
 Postman path-segment variables, host arrays, and port are not separately consumed - only `raw` (base) and `query` matter for the object form.
 
+**The split is `pmUrl`'s output, not the stored shape.** `parseImport` rejoins each request's *enabled* params onto its `url` afterwards, because that is where every execution path reads the query from - see [The url/params invariant](./README.md#the-urlparams-invariant). So `{{baseUrl}}/users?page=1&trace=1` with `trace` disabled parses to base + two params here, and is stored as `{{baseUrl}}/users?page=1` with both params still in the table.
+
 ## Body mapping
 
 `pmBody(body, ctx)` switches on `body.mode`. A missing `body` or missing `body.mode` → `{ mode: "none" }`.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -831,6 +831,14 @@ the null-vs-absent rule.
 }
 ```
 
+**`params` is builder display state, not the query the engine sends.** The
+engine stores it and hands it back verbatim; nothing in the request-composition
+path ever reads it. `url` is the wire truth, so a query parameter that must
+reach the wire belongs **in `url`** - the app's Params table keeps the two in
+step by rewriting `url` on every edit, and stores disabled rows in `params` only.
+A raw API, MCP or import caller that puts the query only in `params` stores a
+request that sends none of it (issue #590).
+
 **`stream` is the saved half of [`POST /execute`'s `stream`](#post-execute)**
 (issue #574). It records that *this endpoint* is a `text/event-stream`, which is
 a property of the endpoint rather than of one send, so the app's Event stream

--- a/docs/request-storage-design.md
+++ b/docs/request-storage-design.md
@@ -29,6 +29,25 @@ Requests are stored **WITH variables** (e.g., `{{baseUrl}}/api/users`) in the da
 }
 ```
 
+#### The `url` / `params` invariant
+
+**Enabled query parameters live inside `url`. `params[]` mirrors them for the
+editor, disabled entries included.**
+
+`url` is the wire truth: every execution path - design Send, collection scenario
+run, load run - sends it verbatim, and no engine path reads `params[]` at all
+(it is builder display state, see
+[engine/api-reference.md](engine/api-reference.md)). The Params table maintains
+the invariant on the app's side by rewriting `url` on every edit, keeping
+disabled rows in `params[]` only.
+
+A writer that stores the query *only* in `params[]` therefore stores a request
+that sends nothing of it. That was issue #590: every importer split the query
+out of the URL, so an imported request dropped its query on every send until the
+user happened to edit the Params table once. Imports now restore the invariant at
+parse time (`parseImport`, see
+[app/import-collections/README.md](app/import-collections/README.md)).
+
 ### 2. Request Execution
 
 **Process**:


### PR DESCRIPTION
## Description

An imported request never sent its query. Import `{{baseUrl}}/users?page=1`, hit Send (or run it in a scenario, or under load) and the wire request is `{{baseUrl}}/users` - and it stays that way until the user happens to edit the Params table once, which silently repairs the URL.

**Plan.** Root cause is a broken invariant, not a broken send path. The app's rule is that a request's *enabled* query lives inside `url`, with `params[]` mirroring it for the editor (disabled rows included); `url` is the wire truth every execution path sends verbatim, and no engine path reads `params[]` at all. Only `ParamsPanel`'s `onChange` handler maintained that rule, so every importer violated it on write - Postman lifts the query out of the URL into `params[]`, Insomnia keeps a `parameters[]` beside a verbatim URL, the OpenAPI parsers synthesize params for a URL that never had a query. The fix restores the invariant at parse time: `parseImport` runs one pass over every request draft joining its enabled params onto its URL, and the join primitive moves out of `ParamsPanel` into `request-builder/utils/url.ts` so it is shared rather than copied. **Rejected alternative:** merging engine-side at compose time - that changes an engine contract (`url` is the wire truth, `params` is display state) to fix an app-side writer, and invites double-append for app-native requests whose URL already carries the query.

Two deliberate calls inside that:

- **Append, not replace.** `buildUrlWithParams` (the panel's rule - the table *is* the query, so clearing the last row clears it) would have deleted the inline query an Insomnia URL is allowed to carry beside its `parameters[]`. `appendParamsToUrl` adds to whatever query the URL already has, which is also exactly what Insomnia itself does with its two sources on send. Both rules are exported, each with one caller and a comment saying which is which; a test pins the Insomnia case that separates them.
- **One pass in `parseImport`, not a call in each parser.** One rule for every format including the next one, `flatten()` stays a pure field copier (so `orchestrator.fixture-parity` keeps comparing against an independent walk), and each parser's own mapping stays honest - `params[]` still mirrors exactly what the source declared.

**Deviation from the issue, on purpose:** the issue suggested flipping the split-pinning assertions in `postman.test.ts` / `insomnia-v4` / OpenAPI. Those suites call each parser directly, and the parsers really do still split - that *is* their contract. The join is asserted one layer up, through `parseImport`, where it actually happens.

**Behaviour worth expecting:** the OpenAPI parsers emit value-less stubs, so an operation declaring a `verbose` query parameter now imports as `{{baseUrl}}/pets/{{petId}}?verbose` - a bare key, which is what the Params table already writes for that same row on the user's first edit. Documented in both OpenAPI mapping docs. If those stub rows should import *disabled* instead, that is a separate call about the importer's `enabled` choice and I have not made it here.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **442 files, 4530 tests, all passing.** `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean. `mkdocs build --strict` clean (docs-touching change). No engine file changed, so the engine build/suite was not run.

New coverage:

- `modules/request-builder/utils/url.test.ts` (9 cases) - both join rules, the case that separates them (a URL arriving with its own query), the disabled-row trap, the bare-key and `{{variable}}`-not-encoded rules, and a `parseQueryParams` round-trip.
- `services/importers/factory.test.ts` (5 cases) - Postman's split query comes back minus the disabled row while both rows stay in the table; a request with no query is untouched; Insomnia's `parameters[]` joins; an inline Insomnia URL query survives; OpenAPI's declared parameter reaches the URL.
- `services/importers/orchestrator.test.ts` (1 case) - the end of the chain: the `/import/apply` payload the engine stores carries `{{baseUrl}}/users?page=1`.

Mutation-checked both ways: commenting out the join reddens all 4 import-level tests (and leaves the no-query case green); swapping `appendParamsToUrl` for `buildUrlWithParams` reddens exactly the inline-Insomnia-query test.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: the invariant is written down in `docs/request-storage-design.md` and `docs/app/import-collections/README.md`, each format's mapping doc points at it (`postman.md`, `insomnia-v4.md`, `openapi-v2.md`, `openapi-v3.md`), and `docs/engine/api-reference.md`'s `POST /requests` now warns raw API/MCP callers that `params` is builder display state the engine never sends.

## Related Issues
Closes #590

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJYyFHwxVj4MYVah4GKG6w)_