### PR TITLE
fix(app/updater): retry a failed check once, name the error, answer a window-less menu check

### DIFF
--- a/app/electron/updater.test.ts
+++ b/app/electron/updater.test.ts
@@ -33,6 +33,7 @@ const ipcHandlers = new Map<string, (event: unknown, ...args: unknown[]) => unkn
 const showMessageBox = vi.fn().mockResolvedValue({ response: 0 });
 const checkForUpdates = vi.fn().mockResolvedValue(null);
 const quit = vi.fn();
+const openExternal = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("electron", () => ({
 	app: { getVersion: () => "0.9.0", quit: (...args: unknown[]) => quit(...args) },
@@ -44,7 +45,7 @@ vi.mock("electron", () => ({
 			ipcHandlers.set(channel, fn);
 		},
 	},
-	shell: { openExternal: vi.fn() },
+	shell: { openExternal: (...args: unknown[]) => openExternal(...args) },
 }));
 
 vi.mock("electron-updater", () => ({
@@ -99,11 +100,25 @@ async function loadUpdater(platform: NodeJS.Platform = "win32") {
 const realPlatform = process.platform;
 
 beforeEach(() => {
-	showMessageBox.mockClear();
+	showMessageBox.mockClear().mockResolvedValue({ response: 0 });
 	checkForUpdates.mockClear().mockResolvedValue(null);
+	openExternal.mockClear();
 	currentWindow = makeWindow();
 	vi.stubEnv("NODE_ENV", "production");
 });
+
+/**
+ * Fail the attempt in flight the way electron-updater does: the `error` event
+ * and the `checkForUpdates()` rejection both report the same failure.
+ */
+function failAttempt(err: Error): void {
+	listeners.get("error")?.(err);
+}
+
+/** Let the retry's delay elapse so the second attempt runs. */
+async function letRetryRun(): Promise<void> {
+	await vi.advanceTimersByTimeAsync(2_000);
+}
 
 afterEach(() => {
 	vi.unstubAllEnvs();
@@ -133,10 +148,13 @@ describe("checkForUpdatesNow", () => {
 	});
 
 	it("resolves with the error rather than hanging", async () => {
+		vi.useFakeTimers();
 		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
 		initAutoUpdater(getWindow);
 		const pending = checkForUpdatesNow("renderer");
-		listeners.get("error")?.(new Error("ENOTFOUND"));
+		failAttempt(new Error("ENOTFOUND"));
+		await letRetryRun();
+		failAttempt(new Error("ENOTFOUND"));
 		await expect(pending).resolves.toEqual({ status: "error", message: "ENOTFOUND" });
 	});
 
@@ -202,6 +220,150 @@ describe("checkForUpdatesNow", () => {
 		);
 		await expect(ipcHandlers.get("update:check")?.(null)).resolves.toMatchObject({
 			status: "unavailable",
+		});
+	});
+});
+
+describe("one transient is not the answer", () => {
+	// A mac check is three sequential HTTPS requests through Chromium's net
+	// stack, and the first one of the session runs on the coldest possible
+	// stack. Treating that attempt's failure as final is what made "check for
+	// updates fails, click again and it works" reproducible.
+
+	it("retries once, and answers with the retry's outcome", async () => {
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		const pending = checkForUpdatesNow("renderer");
+
+		failAttempt(new Error("ERR_NETWORK_CHANGED"));
+		await letRetryRun();
+		listeners.get("update-not-available")?.({});
+
+		// Not "ERR_NETWORK_CHANGED": the user never sees a failure the second
+		// round trip disproved.
+		await expect(pending).resolves.toEqual({ status: "up-to-date", version: "0.9.0" });
+	});
+
+	it("reports one error, and one dialog, when the retry fails too", async () => {
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		const pending = checkForUpdatesNow("menu");
+
+		failAttempt(new Error("ENOTFOUND"));
+		await letRetryRun();
+		failAttempt(new Error("ENOTFOUND"));
+
+		await expect(pending).resolves.toMatchObject({ status: "error" });
+		expect(showMessageBox).toHaveBeenCalledTimes(1);
+	});
+
+	it("spends one attempt on a failure reported twice", async () => {
+		// electron-updater emits `error` *and* rejects `checkForUpdates()` for
+		// the same failure. Counting signals rather than attempts would burn
+		// the whole budget on a single failed round trip, leaving no retry.
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		checkForUpdates.mockClear().mockRejectedValue(new Error("ENOTFOUND"));
+
+		const pending = checkForUpdatesNow("renderer");
+		await vi.advanceTimersByTimeAsync(0); // the rejection lands
+		failAttempt(new Error("ENOTFOUND")); // ...and the event for the same failure
+		await letRetryRun();
+		await vi.advanceTimersByTimeAsync(0); // the retry's rejection lands
+
+		await expect(pending).resolves.toMatchObject({ status: "error" });
+		expect(checkForUpdates).toHaveBeenCalledTimes(2);
+	});
+
+	it("retries the check a manual click joined", async () => {
+		// The join is the amplifier: a click that lands while the startup check
+		// is in flight inherits its fate. It has to inherit the retry too.
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow); // starts the startup check
+		const first = checkForUpdatesNow("renderer");
+		const joined = checkForUpdatesNow("renderer");
+
+		failAttempt(new Error("ERR_NETWORK_CHANGED"));
+		await letRetryRun();
+		listeners.get("update-available")?.({ version: "1.0.0" });
+
+		await expect(first).resolves.toMatchObject({ status: "available", version: "1.0.0" });
+		await expect(joined).resolves.toEqual(await first);
+	});
+
+	it("keeps one timeout budget across the retry", async () => {
+		// The user clicked once, so the wait they can see stays bounded by one
+		// number - the retry runs inside it, not after it.
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		const pending = checkForUpdatesNow("renderer");
+
+		failAttempt(new Error("ERR_NETWORK_CHANGED"));
+		await vi.advanceTimersByTimeAsync(30_000); // the retry ran, and never answered
+
+		await expect(pending).resolves.toEqual({
+			status: "error",
+			message: "The update check timed out.",
+		});
+	});
+
+	it("retries the periodic check without surfacing anything", async () => {
+		vi.useFakeTimers();
+		const { initAutoUpdater } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		checkForUpdates.mockClear();
+
+		// Nobody is waiting on the startup check - it still gets its retry.
+		failAttempt(new Error("ERR_NETWORK_CHANGED"));
+		await letRetryRun();
+
+		expect(checkForUpdates).toHaveBeenCalledTimes(1);
+		expect(showMessageBox).not.toHaveBeenCalled();
+	});
+
+	it("names the error code so the next report arrives diagnosable", async () => {
+		// electron-updater raises coded errors; the code says who is at fault in
+		// a way the message alone does not. It has to reach the panel, which
+		// prints `message` and nothing else.
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		const coded = Object.assign(new Error("Cannot find latest-mac.yml"), {
+			code: "ERR_UPDATER_LATEST_VERSION_NOT_FOUND",
+		});
+
+		const pending = checkForUpdatesNow("renderer");
+		failAttempt(coded);
+		await letRetryRun();
+		failAttempt(coded);
+
+		await expect(pending).resolves.toEqual({
+			status: "error",
+			message: "Cannot find latest-mac.yml (ERR_UPDATER_LATEST_VERSION_NOT_FOUND)",
+		});
+	});
+
+	it("does not repeat a code the message already carries", async () => {
+		vi.useFakeTimers();
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater();
+		initAutoUpdater(getWindow);
+		const err = Object.assign(new Error("net::ERR_NETWORK_CHANGED"), {
+			code: "net::ERR_NETWORK_CHANGED",
+		});
+
+		const pending = checkForUpdatesNow("renderer");
+		failAttempt(err);
+		await letRetryRun();
+		failAttempt(err);
+
+		await expect(pending).resolves.toEqual({
+			status: "error",
+			message: "net::ERR_NETWORK_CHANGED",
 		});
 	});
 });
@@ -303,13 +465,62 @@ describe("where the result is delivered", () => {
 		);
 	});
 
+	it("leaves an available update to the banner while a window is live", async () => {
+		// The banner is already saying it; a modal on top would be the same news
+		// twice.
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		const pending = checkForUpdatesNow("menu");
+		listeners.get("update-available")?.({ version: "1.0.0" });
+		await pending;
+		expect(showMessageBox).not.toHaveBeenCalled();
+	});
+
+	it("tells the menu about an available update when there is no window", async () => {
+		// The banner is a `webContents.send`, so with no window it goes nowhere -
+		// and on macOS a window-less app is the ordinary state, with the menu
+		// still there to click. Without a dialog the click finds an update and
+		// reports nothing at all.
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		currentWindow = null;
+
+		const pending = checkForUpdatesNow("menu");
+		listeners.get("update-available")?.({ version: "1.0.0" });
+		await pending;
+
+		expect(showMessageBox).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "Vayu 1.0.0 is available" })
+		);
+	});
+
+	it("opens the release notes when that dialog's button is chosen", async () => {
+		// The notify path updates out-of-band, so the release page is the only
+		// action the dialog can offer.
+		showMessageBox.mockResolvedValue({ response: 1 });
+		const { initAutoUpdater, checkForUpdatesNow } = await loadUpdater("darwin");
+		initAutoUpdater(getWindow);
+		currentWindow = null;
+
+		const pending = checkForUpdatesNow("menu");
+		listeners.get("update-available")?.({ version: "1.0.0" });
+		await pending;
+		await vi.waitFor(() => expect(openExternal).toHaveBeenCalledTimes(1));
+
+		expect(openExternal).toHaveBeenCalledWith(expect.stringContaining("v1.0.0"));
+	});
+
 	it("stays silent for the periodic check, which nobody is waiting on", async () => {
+		// Fake timers so the silent retry this schedules cannot fire into a
+		// later test - `afterEach` discards them.
+		vi.useFakeTimers();
 		const { initAutoUpdater } = await loadUpdater();
 		initAutoUpdater(getWindow);
 		// No manual check in flight - the interval's events must not pop a
 		// dialog over whatever the user is doing.
 		listeners.get("update-not-available")?.({});
 		listeners.get("error")?.(new Error("offline"));
+		await letRetryRun();
 		expect(showMessageBox).not.toHaveBeenCalled();
 	});
 

--- a/app/electron/updater.ts
+++ b/app/electron/updater.ts
@@ -74,14 +74,46 @@ interface PendingCheck {
  * How long to wait for an answer before giving up. Without this a check that
  * never gets a reply - a hung connection, a feed that stalls after the TCP
  * handshake - leaves the settings button spinning with no way back.
+ *
+ * This is one budget for the whole check, retry included: the user clicked once
+ * and the wait they can see must stay bounded by one number. A retry that runs
+ * out of budget reports the timeout rather than the first error - the first
+ * error is logged either way.
  */
 const CHECK_TIMEOUT_MS = 30_000;
+
+/**
+ * A check gets one automatic retry, because on a cold network stack the first
+ * answer is often not the truth.
+ *
+ * A mac check is three sequential HTTPS requests through Chromium's net stack,
+ * and a transient there (`ERR_NETWORK_CHANGED` while Wi-Fi settles after launch
+ * or wake is the textbook one) used to become the final answer. The join rule
+ * below amplifies it: a click that lands while the startup check is in flight
+ * inherits that check's fate, so the coldest possible attempt answered a click
+ * made minutes later. Retrying once absorbs that without giving up the join.
+ */
+const MAX_CHECK_ATTEMPTS = 2;
+
+/** Long enough for a settling network stack, short enough to still feel like one click. */
+const RETRY_DELAY_MS = 2_000;
 
 let intervalTimer: NodeJS.Timeout | null = null;
 /** True once initAutoUpdater has configured the updater (not in dev). */
 let updaterReady = false;
 let pendingCheck: PendingCheck | null = null;
 let resolveWindow: WindowAccessor | null = null;
+
+/**
+ * Attempts started for the check cycle in flight, 0 when none is.
+ *
+ * Module state rather than a field on `PendingCheck` because the periodic and
+ * startup checks retry too, and nobody is waiting on those.
+ */
+let attempt = 0;
+/** The attempt whose failure has already been acted on - see `handleCheckFailure`. */
+let failedAttempt = 0;
+let retryTimer: NodeJS.Timeout | null = null;
 
 /**
  * How the updater finds the window to talk to, asked fresh every time.
@@ -98,6 +130,100 @@ export type WindowAccessor = () => BrowserWindow | null;
 function liveWindow(): BrowserWindow | null {
 	const win = resolveWindow?.() ?? null;
 	return win && !win.isDestroyed() ? win : null;
+}
+
+/**
+ * The fullest description of a failed check we can give the user.
+ *
+ * electron-updater raises coded errors (`newError(message, code)`), and the
+ * code is the part worth reporting: "Cannot find latest-mac.yml" and
+ * `ERR_UPDATER_LATEST_VERSION_NOT_FOUND` say different things about who is at
+ * fault. The message is what the settings panel and the menu dialog print, so
+ * the code has to travel inside it - there is no second field for a reader to
+ * miss.
+ */
+function describeError(err: unknown): string {
+	if (!(err instanceof Error)) return String(err);
+	const parts = [err.message];
+	const code: unknown = (err as { code?: unknown }).code;
+	if (typeof code === "string" && code && !err.message.includes(code)) {
+		parts.push(`(${code})`);
+	}
+	// Some codes already embed their cause in the message; only add one that is
+	// not already there. Read off the object rather than `err.cause`: the
+	// electron tsconfig's lib predates it, and a failure description is not a
+	// reason to move the whole target.
+	const cause: unknown = (err as { cause?: unknown }).cause;
+	const causeText =
+		cause instanceof Error ? cause.message : typeof cause === "string" ? cause : "";
+	if (causeText && !err.message.includes(causeText)) parts.push(`- ${causeText}`);
+	return parts.join(" ");
+}
+
+/** Drop a scheduled retry - the cycle ended, or a newer one replaced it. */
+function clearRetry(): void {
+	if (retryTimer) {
+		clearTimeout(retryTimer);
+		retryTimer = null;
+	}
+}
+
+/** Ask electron-updater for the feed. Failures land in `handleCheckFailure`. */
+function runCheckAttempt(): void {
+	autoUpdater.checkForUpdates().catch((err: unknown) => {
+		// The `error` event fires for the same failure, so this and the handler
+		// both report it; `handleCheckFailure` acts on an attempt once.
+		handleCheckFailure(err);
+	});
+}
+
+/** Start a check with a full retry budget. Every check path goes through here. */
+function startCheckCycle(): void {
+	clearRetry();
+	attempt = 1;
+	failedAttempt = 0;
+	runCheckAttempt();
+}
+
+/** The cycle is over: an answer arrived, the budget is spent, or we are quitting. */
+function endCheckCycle(): void {
+	clearRetry();
+	attempt = 0;
+	failedAttempt = 0;
+}
+
+/**
+ * Retry once, then report.
+ *
+ * A single failure is not an answer - it is one round trip that did not work.
+ * The first one is logged at `error` level on the way past, because the retry
+ * would otherwise hide a *deterministic* failure behind a working second
+ * attempt, and then the only trace of the real mechanism is gone.
+ */
+function handleCheckFailure(err: unknown): void {
+	const message = describeError(err);
+
+	// One failure reaches here twice (the event and the promise rejection).
+	// Answering the attempt rather than the signal keeps that from spending the
+	// whole budget on a single failed round trip.
+	if (attempt > 0 && failedAttempt === attempt) return;
+	failedAttempt = attempt;
+
+	if (attempt > 0 && attempt < MAX_CHECK_ATTEMPTS) {
+		console.error(`[Updater] first check failed, retrying once: ${message}`);
+		retryTimer = setTimeout(() => {
+			retryTimer = null;
+			attempt += 1;
+			runCheckAttempt();
+		}, RETRY_DELAY_MS);
+		// Node keeps the process alive for a pending timer; a retry must not
+		// hold up quit.
+		retryTimer.unref?.();
+		return;
+	}
+
+	endCheckCycle();
+	settleCheck({ status: "error", message });
 }
 
 /**
@@ -173,6 +299,7 @@ export function initAutoUpdater(getWindow: WindowAccessor): void {
 					: undefined,
 		};
 		send("update:available", payload);
+		endCheckCycle();
 		settleCheck({ status: "available", ...payload });
 	});
 
@@ -182,21 +309,23 @@ export function initAutoUpdater(getWindow: WindowAccessor): void {
 
 	// Only surfaced for user-initiated checks; the periodic check stays silent.
 	autoUpdater.on("update-not-available", () => {
+		endCheckCycle();
 		settleCheck({ status: "up-to-date", version: app.getVersion() });
 	});
 
 	autoUpdater.on("error", (err) => {
 		console.error("[Updater] error:", err);
-		settleCheck({ status: "error", message: err.message });
+		handleCheckFailure(err);
 	});
 
 	updaterReady = true;
 
-	const check = () =>
-		autoUpdater.checkForUpdates().catch((err) => console.error("[Updater] check failed:", err));
-
-	void check();
-	intervalTimer = setInterval(() => void check(), CHECK_INTERVAL_MS);
+	// The startup and periodic checks retry on the same budget. They stay
+	// silent - `settleCheck` answers nobody when no one is waiting - but the
+	// startup one runs on the coldest network stack of the session, so it is
+	// the attempt that most needs a second try.
+	startCheckCycle();
+	intervalTimer = setInterval(() => startCheckCycle(), CHECK_INTERVAL_MS);
 }
 
 /**
@@ -207,9 +336,29 @@ export function initAutoUpdater(getWindow: WindowAccessor): void {
  * dialog is shown unparented rather than not at all, which is the macOS
  * all-windows-closed case for the menu's "Check for Updates…".
  */
-function showUpdateDialog(options: Electron.MessageBoxOptions): void {
+function showUpdateDialog(
+	options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
 	const win = liveWindow();
-	void (win ? dialog.showMessageBox(win, options) : dialog.showMessageBox(options));
+	return win ? dialog.showMessageBox(win, options) : dialog.showMessageBox(options);
+}
+
+/**
+ * Announce an available release to a menu check that has no window to show the
+ * banner in. The release-notes button is the only action the notify path has -
+ * the update itself happens out-of-band there.
+ */
+function showAvailableDialog(version: string, url: string): void {
+	void showUpdateDialog({
+		type: "info",
+		message: `Vayu ${version} is available`,
+		detail: `You're on ${app.getVersion()}.`,
+		buttons: ["OK", "Release notes"],
+		defaultId: 0,
+		cancelId: 0,
+	}).then(({ response }) => {
+		if (response === 1) void shell.openExternal(url);
+	});
 }
 
 /**
@@ -236,21 +385,28 @@ function settleCheck(result: UpdateCheckResult): void {
 	// on top of it would be redundant.
 	if (pending.source === "menu") {
 		if (result.status === "up-to-date") {
-			showUpdateDialog({
+			void showUpdateDialog({
 				type: "info",
 				message: "You're up to date",
 				detail: `Vayu ${result.version} is the latest version.`,
 				buttons: ["OK"],
 			});
 		} else if (result.status === "error") {
-			showUpdateDialog({
+			void showUpdateDialog({
 				type: "error",
 				message: "Couldn't check for updates",
 				detail: result.message,
 				buttons: ["OK"],
 			});
+		} else if (result.status === "available" && !liveWindow()) {
+			// "available" normally needs no dialog - the banner is already
+			// showing it. But the banner is a `webContents.send`, and with no
+			// window there is nothing to send it to: the menu click would
+			// otherwise find an update and say nothing at all. On macOS a
+			// window-less app is the ordinary state, and the menu is still
+			// there to click.
+			showAvailableDialog(result.version, result.releaseUrl);
 		}
-		// "available" needs no dialog - the update banner is already showing it.
 	}
 
 	pending.settle(result);
@@ -268,7 +424,7 @@ export function checkForUpdatesNow(source: CheckSource = "menu"): Promise<Update
 			detail: "Update checks only run in packaged builds of Vayu.",
 		};
 		if (source === "menu") {
-			showUpdateDialog({
+			void showUpdateDialog({
 				type: "info",
 				message: "Updates unavailable",
 				detail: result.detail,
@@ -287,6 +443,9 @@ export function checkForUpdatesNow(source: CheckSource = "menu"): Promise<Update
 		settle = resolve;
 	});
 	const timer = setTimeout(() => {
+		// The budget covers the retry too, so a timeout ends the cycle - a
+		// retry still in flight has nobody left to answer.
+		endCheckCycle();
 		settleCheck({ status: "error", message: "The update check timed out." });
 	}, CHECK_TIMEOUT_MS);
 	// Node keeps the process alive for a pending timer; this one must not hold
@@ -294,12 +453,7 @@ export function checkForUpdatesNow(source: CheckSource = "menu"): Promise<Update
 	timer.unref?.();
 	pendingCheck = { source, settle, promise, timer };
 
-	autoUpdater.checkForUpdates().catch((err) => {
-		// The `error` event usually fires too, but not for every rejection -
-		// settling here as well is safe because settleCheck is idempotent.
-		console.error("[Updater] manual check failed:", err);
-		settleCheck({ status: "error", message: err instanceof Error ? err.message : String(err) });
-	});
+	startCheckCycle();
 
 	return promise;
 }
@@ -316,6 +470,7 @@ export function disposeAutoUpdater(): void {
 		clearInterval(intervalTimer);
 		intervalTimer = null;
 	}
+	endCheckCycle();
 	takePendingCheck()?.settle({ status: "error", message: "The update check was cancelled." });
 	resolveWindow = null;
 }


### PR DESCRIPTION
## Description

**Plan.** Root cause: a check's first failure was the final answer everywhere - `checkForUpdatesNow` surfaced the first rejection or `error` event, and the periodic path only logged. The join rule turns that from bad luck into a reproducible "first click always fails": a manual check joins an in-flight one, so a click that lands shortly after launch inherits the fate of the startup check that ran on the coldest possible network stack. The approach is the issue's decided fix - route **every** check path (manual, startup, periodic) through one cycle driver that retries once after ~2s before anything is surfaced, log the first error loudly on the way past, and carry electron-updater's error code into the message the UI already prints. The alternative I rejected was dropping the join so each click starts its own check: that trades one flaky answer for two competing checks with interleaving events and two dialogs, and it would not help the startup or periodic paths at all - the retry absorbs the join's only downside while keeping its one-dialog benefit.

Verified against live code first: `updater.ts` is exactly as the issue describes at `5ae7ec1` (zero-retry posture at `:188-191, :195-199, :297-302`, the join at `:281-283`, the `liveWindow()` guard on the banner send).

Notes on the two judgement calls the issue left open:

- **Timeout budget: one budget for the whole check, retry included** (the alternative was one per attempt). The user clicked once, so the wait they can see stays bounded by one number - a retry that outlives the budget reports the timeout, and the first error is in the log either way. Doubling the worst-case spinner to 62s to name an error better would be paying the majority case for the rare one.
- **Attempts, not signals.** electron-updater reports one failure twice - it emits `error` *and* rejects `checkForUpdates()` (`AppUpdater.js:271`). Counting signals would spend the whole budget on a single failed round trip and leave no retry at all, so `handleCheckFailure` acts on a given attempt once. That is the subtlest thing in the diff and it has its own test.

Where the state lives: attempt counters are module-level rather than fields on `PendingCheck`, because the startup and periodic checks retry too and nobody is waiting on those - `settleCheck` answering nobody is what keeps them silent.

**Error naming** goes inside `message`, not into a new field: `message` is what `UpdatesCard` renders (`UpdatesCard.tsx:100`) and what the menu dialog prints, so a separate `errorCode` field would be written and never read - the defect CLAUDE.md names as this codebase's most repeated. A code already contained in the message is not repeated.

**Rider (issue item 3)** is included: a menu check that finds an update with no live window now shows a dialog with the version and a Release notes button. `"available"` deliberately raises no dialog because the banner covers it - but the banner is a `webContents.send` and there was no window to send it to, so on macOS's ordinary window-less state the click found an update and said nothing. `showUpdateDialog` now returns its promise so the new dialog can act on the chosen button; the existing callers `void` it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`cd app && pnpm test` - **4541/4541 passed** (442 files), no pre-existing failures. `pnpm type-check` and `pnpm lint` clean; `prettier --write` on the two touched files only (both were clean before).

Engine untouched, so no engine build or ctest run - nothing in `engine/` could change colour (CLAUDE.md's scale-the-verification rule).

11 tests added, 1 rewritten (`electron/updater.test.ts`, 30 in the file now):

- Retry: first attempt fails and the retry succeeds -> the user gets the retry's outcome, not the failure it disproved; both attempts fail -> one error result and exactly one dialog on the menu path; the periodic check retries with nothing surfaced; a manual check that joined a failing check still gets the retry.
- One failure reported twice (event + rejection) spends one attempt - asserted as exactly two underlying `checkForUpdates()` calls.
- Timeout: one budget across the retry (still answers at 30s from the click).
- Error naming: the code is appended; a code the message already carries is not repeated.
- Rider: menu + available + no window -> dialog naming the version; with a live window -> still no dialog (the banner's contract, newly pinned); choosing Release notes opens the release page.
- Rewritten: "resolves with the error rather than hanging" now fails both attempts, since one failure is no longer an answer.

Mutation-checked for real, each restored afterwards: `MAX_CHECK_ATTEMPTS = 1` reddens 5 tests; dropping the error code from `describeError` reddens 1; removing the no-window dialog reddens 2; removing the per-attempt dedupe reddens the double-signal test. Full suite green after restoring.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

No doc updates: as the issue states, no published doc describes the check flow, and `docs/app/COMPONENTS.md`'s UpdatesCard line does not describe the outcome text, so nothing there goes stale. The rationale that would otherwise need a doc lives in the code comments.

## Related Issues
Closes #607

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnaKBJY2CsgU6XqHLGnnAF)_