### PR TITLE
fix(engine/data): bind {{data.*}} credentials before auth encodes them

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2598,7 +2598,8 @@ as a smaller one:
 | `data` not an array, or a row that is not an object | |
 | More `data` rows than `maxScenarioDataRows` | The message carries the count and the cap. |
 | A `data` array larger than `maxScenarioDataBytes` | The row count cannot catch a few very large rows, and the transport's own body cap would drop the connection instead of explaining itself. |
-| A step carrying a `{{data.*}}` token in a run sent without `data` | Nothing would bind it, so the literal token would be sent. The message names the step and the token. |
+| A step carrying a `{{data.*}}` token in a run sent without `data` | Nothing would bind it, so the literal token would be sent. The message names the step and the token. The step's credential fields are scanned as well as its request. |
+| A step with a `{{data.*}}` token in its `oauth2` config | The token is acquired once, when the plan is resolved, so no iteration exists for a row to reach it. Refused with or without a data set. |
 
 A cycle in the `collections.parent_id` tree terminates the recursive walk rather
 than hanging it, exactly as the cascade delete in `DELETE /collections/:id` does.
@@ -2681,10 +2682,24 @@ the ordinary unknown-name rule instead.
 **Where a token participates.** Exhaustively: the **URL** (path and query
 string alike, so a token in a stored request's params reaches it once they are
 joined into the URL), every **header name** and **header value**, the **raw
-body**, and **both halves of every form field** (`x-www-form-urlencoded` and
-`form-data`). Nothing else - in particular a `{{data.*}}` written into an
-**auth** field is not bound today, and script text is never interpolated at all
-(a script reads its row through `pm.iterationData`).
+body**, **both halves of every form field** (`x-www-form-urlencoded` and
+`form-data`), and the **credential fields** of the request's auth - the bearer
+**token**, basic auth's **username** and **password**, and an api key's **name**
+and **value**. Script text is never interpolated at all (a script reads its row
+through `pm.iterationData`).
+
+> **Credentials bind before they are encoded.** A credentials file behind basic
+> auth is the canonical data-driven run, so a step whose credentials carry a
+> `{{data.*}}` keeps them unresolved in the plan and applies its auth *per
+> iteration* instead: the row is bound first, and only then does the username
+> and password become one base64 `Authorization`, or an api key become a
+> percent-encoded query parameter. Every other step still resolves its auth once,
+> when the plan is composed.
+>
+> **OAuth 2.0 is the exception, and it is refused rather than ignored.** Its
+> token is acquired once, when the run is planned, so no iteration exists for a
+> row to reach - a `{{data.*}}` anywhere in an `oauth2` config is a `400` at
+> `POST /runs` naming the token, with or without a data set.
 
 **What a cell renders as.** The CSV/TSV path produces only strings, so the first
 row is the ordinary case; a JSON or JSONL file may carry any type:

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -350,7 +350,12 @@ applied to the outgoing request rather than being left to the UI. This lives in
 - **`auth_resolver`** (`apply_auth` / `preflight_auth` / `plan_auth_refresh`) - a
   typed `Auth` variant with an exhaustive per-mode handler: bearer/basic/api-key
   are injected inline; `oauth2` delegates to the token client. A user-supplied
-  `Authorization` header always wins. `plan_auth_refresh` decides afterwards
+  `Authorization` header always wins. A scenario step whose credentials carry a
+  `{{data.*}}` token is the one case auth is *not* resolved into the plan: the
+  row has to be bound before the credential is encoded, so the step keeps its
+  typed `Auth` and applies it per iteration
+  (`bind_step_auth`, see [Scenario runs](api-reference.md#scenario-runs)).
+  `plan_auth_refresh` decides afterwards
   whether the credential a *load* run just resolved can be kept current past its
   expiry - see the run lifecycle below.
 - **`oauth_client`** (`acquire_token`) - grant handling (client_credentials,

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -922,10 +922,11 @@ script throws rather than answering with the finished run's row.
 **To put the row into the request itself, use `{{data.column}}` instead.** A
 script reads `pm.iterationData` *after* its step's request was composed, so it
 cannot change where the request goes without editing `pm.request` by hand. The
-reserved `data.*` namespace does that directly: a URL, header or body carrying
-`{{data.email}}` has it substituted with the iteration's row immediately before
-the send. It is a namespace, not a variable scope - it cannot be read or
-written through `pm.variables` - and it is documented under
+reserved `data.*` namespace does that directly: a URL, header, body, form field
+or **credential** carrying `{{data.email}}` has it substituted with the
+iteration's row immediately before the send. It is a namespace, not a variable
+scope - it cannot be read or written through `pm.variables` - and it is
+documented under
 [Scenario runs](api-reference.md#scenario-runs).
 
 ### It is read-only

--- a/engine/include/vayu/core/scenario_data.hpp
+++ b/engine/include/vayu/core/scenario_data.hpp
@@ -61,6 +61,17 @@
  * binds a row per iteration per virtual user (issue #449). Both modes drive the
  * same template rather than one keeping a scanner of its own, so a step binds
  * identically however it is executed.
+ *
+ * ## Credentials are bound before they are encoded
+ *
+ * A credentials file driving basic auth is the canonical data-driven run, and
+ * the fields above cannot serve it: `apply_auth` collapses a username and a
+ * password into one base64 `Authorization` value, so a `{{data.user}}` resolved
+ * into the plan is already unreadable by the time anything scans the built
+ * request - it went out as base64 of the literal token text, silently (issue
+ * #591). `tokenize_auth_fields` therefore splits the *typed* credentials
+ * instead, and a step that carries one binds them and applies its auth per
+ * iteration rather than at plan time.
  */
 
 #include <cstddef>
@@ -70,6 +81,7 @@
 #include <string>
 #include <vector>
 
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/types.hpp"
 
 namespace vayu::core {
@@ -168,6 +180,48 @@ struct StepDataTemplate {
 const StepDataTemplate& tmpl,
 const nlohmann::json& row,
 size_t row_index);
+
+/**
+ * Split @p auth's credential strings around their `{{data.column}}` tokens.
+ *
+ * The same splitter the request walk drives, over `walk_auth_credentials`
+ * instead of `walk_bindable_fields` - one field list per walk, and the join
+ * below drives the identical walk, so neither can address a credential the
+ * other does not.
+ *
+ * Every credential binds **verbatim**: a token, a username and an api key are
+ * plain text, not a document with a quoting rule, and what escaping they need
+ * (base64 for basic auth, percent-encoding for an api key in the query) is
+ * `apply_auth`'s to add *after* the bind - which is the whole point of binding
+ * before the auth is applied.
+ *
+ * Empty for the ordinary step, whose credentials carry no token and whose auth
+ * is therefore resolved into the plan once, as it always was.
+ */
+[[nodiscard]] StepDataTemplate tokenize_auth_fields (const vayu::http::Auth& auth);
+
+/**
+ * Join @p tmpl's credentials against @p row, in place on @p auth.
+ *
+ * @p auth must be the parsed auth @p tmpl was split from, for the same reason
+ * `apply_data_template` needs the request it was split from: a credential is
+ * addressed by its position in the walk.
+ */
+[[nodiscard]] DataBindResult apply_auth_data_template (vayu::http::Auth& auth,
+const StepDataTemplate& tmpl,
+const nlohmann::json& row,
+size_t row_index);
+
+/**
+ * The first `{{data.column}}` in any string of @p value, recursively, written
+ * back with its braces - or `nullopt` when it carries none.
+ *
+ * For a block that has no bind to offer at all and must therefore refuse rather
+ * than defer: an OAuth 2.0 config, whose token is acquired once when the plan
+ * is resolved. Object *keys* are not scanned - a column name where a config key
+ * belongs is not a placement anyone means.
+ */
+[[nodiscard]] std::optional<std::string> first_data_token_in (const nlohmann::json& value);
 
 /**
  * Render one row value as the text a `{{data.column}}` token substitutes.

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -43,6 +43,7 @@
 
 #include "vayu/core/scenario_data.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/types.hpp"
 
 namespace vayu::core {
@@ -69,6 +70,18 @@ struct ScenarioStep {
     /// to re-scan the step per iteration. Empty for a step that carries none,
     /// which is what both executors test before doing any join work at all.
     StepDataTemplate data_template;
+    /// The step's parsed auth, kept **only** when its credentials carry a
+    /// `{{data.column}}`. `NoAuth` for every other step, whose auth is already
+    /// resolved into `request` above.
+    vayu::http::Auth auth;
+    /// `auth`'s tokens, split once here like `data_template`.
+    ///
+    /// **Non-empty means this step's auth was deferred**: `request` carries no
+    /// credential yet, and an executor must call `bind_step_auth` before
+    /// sending or the request goes out unauthenticated. Deferral only ever
+    /// happens in a run that has rows - a data token with no data set is
+    /// refused when the plan resolves - so an executor always has a row for it.
+    StepDataTemplate auth_template;
 };
 
 /** An ordered, immutable sequence of composed steps. */
@@ -181,11 +194,34 @@ struct ScenarioResolution {
  * `limits.max_data_rows` or `limits.max_data_bytes`, and any `source` other
  * than `"collection"`. A step carrying a `{{data.*}}` token in a run sent
  * *without* `data` joins that list (issue #415): nothing would bind it, so it
- * would be sent as the literal token.
+ * would be sent as the literal token - and a step's *credentials* are scanned
+ * for one as well as its request, because a data token in a basic-auth field is
+ * exactly as unbindable and used to be base64-encoded where nothing could see
+ * it (issue #591). A `{{data.*}}` in an **OAuth 2.0** config is refused
+ * outright, with or without a data set: that token is acquired here, once, so
+ * there is no iteration for a row to reach.
  */
 ScenarioResolution resolve_scenario (vayu::db::Database& db,
 const nlohmann::json& scenario,
 const ScenarioResolveOptions& options);
+
+/**
+ * Bind @p row into @p step's deferred credentials and apply them to @p request.
+ *
+ * A no-op returning success for the ordinary step, whose auth was resolved into
+ * the plan and whose `auth_template` is therefore empty - both executors call
+ * it beside `apply_data_template` rather than testing first, because the two
+ * halves of one iteration's bind belong together and one binder for both modes
+ * is what keeps a step from binding differently depending on which one ran it.
+ *
+ * Call it **after** the request's own data pass and before the send: the
+ * credentials must be bound before `apply_auth` encodes them, which is the
+ * ordering the deferral exists to fix.
+ */
+[[nodiscard]] DataBindResult bind_step_auth (vayu::Request& request,
+const ScenarioStep& step,
+const nlohmann::json& row,
+size_t row_index);
 
 /**
  * The `scenario` object a scenario run stores in `runs.config_snapshot`: the

--- a/engine/include/vayu/http/auth_resolver.hpp
+++ b/engine/include/vayu/http/auth_resolver.hpp
@@ -13,6 +13,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <variant>
 
 namespace vayu::http {
@@ -55,6 +56,49 @@ UnsupportedAuth>;
  * expected to be resolved app-side; if it reaches here it is treated as no-op.
  */
 Auth parse_auth (const nlohmann::json& auth);
+
+/**
+ * @brief Visit every credential string a parsed auth carries, in a fixed order.
+ *
+ * The fields a user types a secret into, and so the fields a `{{data.column}}`
+ * token may legitimately sit in: the bearer token, both halves of basic auth,
+ * and an api key's name and value. Driving the same variant `apply_auth`
+ * consumes is what keeps the two from drifting - a new mode is a compile error
+ * here as well, through the same static_assert.
+ *
+ * `@p auth` may be `const`; the visitor then receives `const std::string&`.
+ *
+ * **OAuth 2.0 is deliberately absent.** Its config is not a credential the
+ * request carries but the input to a token acquisition that happens once, when
+ * a plan is resolved; there is no per-iteration acquisition for a row to reach,
+ * so a data token in it is refused rather than walked
+ * (`core::resolve_scenario`, issue #591).
+ */
+template <typename AuthRef, typename Visit>
+void walk_auth_credentials (AuthRef& auth, Visit&& visit) {
+    std::visit (
+    [&visit] (auto& a) {
+        using T = std::decay_t<decltype (a)>;
+
+        if constexpr (std::is_same_v<T, BearerAuth>) {
+            visit (a.token);
+        } else if constexpr (std::is_same_v<T, BasicAuth>) {
+            visit (a.username);
+            visit (a.password);
+        } else if constexpr (std::is_same_v<T, ApiKeyAuth>) {
+            visit (a.key);
+            visit (a.value);
+        } else if constexpr (std::is_same_v<T, NoAuth> || std::is_same_v<T, OAuth2Auth>) {
+            // Nothing to bind: no credential at all, and an oauth2 config is
+            // handled where it is refused rather than here.
+        } else {
+            static_assert (std::is_same_v<T, UnsupportedAuth>, "unhandled Auth variant");
+            // digest / aws / ntlm are stored but never executed, so a token in
+            // one binds nothing and reaches no wire.
+        }
+    },
+    auth);
+}
 
 /**
  * @brief Outcome of resolving auth onto a request.

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -147,7 +147,9 @@ bool advance_json_string_state (std::string_view literal, bool in_string) {
  */
 class FieldSplitter {
     public:
-    void operator() (std::string& field, FieldContext context) {
+    /// Takes its field by const reference: a split rewrites nothing, and the
+    /// credential walk visits strings it has no copy of.
+    void operator() (const std::string& field, FieldContext context) {
         const size_t position = next_field_++;
         if (field.empty ()) {
             return;
@@ -320,10 +322,50 @@ StepDataTemplate tokenize_data_fields (const vayu::Request& request) {
     // trade.
     vayu::Request scratch = request;
     FieldSplitter splitter;
-    walk_bindable_fields (scratch, [&splitter] (std::string& field, FieldContext context) {
+    walk_bindable_fields (scratch, [&splitter] (const std::string& field, FieldContext context) {
         splitter (field, context);
     });
     return splitter.take ();
+}
+
+StepDataTemplate tokenize_auth_fields (const vayu::http::Auth& auth) {
+    FieldSplitter splitter;
+    vayu::http::walk_auth_credentials (auth, [&splitter] (const std::string& field) {
+        splitter (field, FieldContext::Plain);
+    });
+    return splitter.take ();
+}
+
+DataBindResult apply_auth_data_template (vayu::http::Auth& auth,
+const StepDataTemplate& tmpl,
+const nlohmann::json& row,
+size_t row_index) {
+    if (tmpl.empty ()) {
+        return DataBindResult{ true, {} };
+    }
+    TemplateJoiner joiner (tmpl, row, row_index);
+    vayu::http::walk_auth_credentials (auth,
+    [&joiner] (std::string& field) { joiner (field, FieldContext::Plain); });
+    return joiner.result ();
+}
+
+std::optional<std::string> first_data_token_in (const nlohmann::json& value) {
+    if (value.is_string ()) {
+        const auto split = vayu::http::split_tokens (
+        value.get<std::string> (), vayu::http::is_data_variable_name);
+        if (split.names.empty ()) {
+            return std::nullopt;
+        }
+        return "{{" + split.names.front () + "}}";
+    }
+    if (value.is_object () || value.is_array ()) {
+        for (const auto& child : value) {
+            if (auto found = first_data_token_in (child)) {
+                return found;
+            }
+        }
+    }
+    return std::nullopt;
 }
 
 DataBindResult apply_data_template (vayu::Request& request,

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -396,11 +396,17 @@ const ScenarioExecution& execution) {
         request.cookie_lines            = vu->cookies;
 
         // The data pass, per iteration and before the send. A step carrying no
-        // `{{data.*}}` token has an empty template and is not walked at all,
+        // `{{data.*}}` token has empty templates and is not walked at all,
         // which is what makes a token-free plan free per iteration.
-        if (!step.data_template.empty () && row) {
+        if (row && !(step.data_template.empty () && step.auth_template.empty ())) {
             auto bound = apply_data_template (
             request, step.data_template, execution.data_rows[*row], *row);
+            if (bound.ok) {
+                // Then the credentials, which is why the plan left them typed:
+                // they have to carry the row's values *before* `apply_auth`
+                // base64-encodes them onto the request (issue #591).
+                bound = bind_step_auth (request, step, execution.data_rows[*row], *row);
+            }
             if (!bound.ok) {
                 // Nothing goes on the wire, so nothing will ever complete for
                 // this step: this path owns the whole accounting a completion

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -13,8 +13,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 
 #include "vayu/core/scenario_data.hpp"
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/request_builder.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/script_parts.hpp"
@@ -285,7 +287,40 @@ const ScenarioResolveOptions& options) {
         }
 
         // Auth is resolved into headers/url here, which is what makes the plan
-        // credential-grade and the snapshot manifest necessary.
+        // credential-grade and the snapshot manifest necessary - unless the
+        // credentials themselves come from the data file. `apply_auth`
+        // collapses basic auth into one base64 `Authorization` value, so a
+        // `{{data.user}}` resolved into the plan is unreadable by the time
+        // anything scans the built request: it used to go out as base64 of the
+        // literal token text, silently, and the refusal below could not see it
+        // either (issue #591). Such a step keeps its credentials typed and
+        // unbound and applies its auth per iteration instead - one base64 per
+        // iteration, and only for the steps that need it.
+        const vayu::http::Auth parsed_auth =
+        vayu::http::parse_auth (payload.value ("auth", nlohmann::json ()));
+        StepDataTemplate auth_template = tokenize_auth_fields (parsed_auth);
+
+        // OAuth 2.0 is the one mode deferral cannot serve: its token is
+        // acquired right here, once, against the token endpoint, so there is no
+        // per-iteration acquisition for a row to reach - and adding one would
+        // mean a network round trip per virtual user per iteration. Refused by
+        // name in both directions, with or without a data set, rather than sent
+        // to the token endpoint as the literal token text.
+        if (const auto* oauth2 = std::get_if<vayu::http::OAuth2Auth> (&parsed_auth)) {
+            if (auto token = first_data_token_in (oauth2->config)) {
+                return invalid (describe_step (index, row) + " carries " + *token +
+                " in its OAuth 2.0 configuration. That token is acquired once, "
+                "when the run is planned, so a data column can never reach it "
+                "- "
+                "use a static credential there, or move the data token into "
+                "the "
+                "request itself.");
+            }
+        }
+
+        if (!auth_template.empty ()) {
+            payload.erase ("auth");
+        }
         auto built = vayu::http::build_request (payload, &db, options.timeout_ms);
         if (!built.ok || built.parse_failed) {
             return invalid ("Cannot compose " + describe_step (index, row) +
@@ -306,7 +341,15 @@ const ScenarioResolveOptions& options) {
         // exists, rather than rediscovered per step per iteration once it has
         // started (issue #415).
         if (!has_data) {
-            if (auto token = data_template.first_token ()) {
+            auto token = data_template.first_token ();
+            if (!token) {
+                // The credentials are scanned too, and for the same reason: a
+                // data token in a basic-auth field is exactly as unbindable as
+                // one in the URL, and until it was kept out of the base64 above
+                // this refusal could not see it at all.
+                token = auth_template.first_token ();
+            }
+            if (token) {
                 return invalid (describe_step (index, row) + " carries " + *token +
                 ", but this run has no 'scenario.data' set. A data token has "
                 "no row to bind to and would reach the wire written as it "
@@ -324,11 +367,43 @@ const ScenarioResolveOptions& options) {
         step.post_script   = vayu::http::read_post_request_script (payload);
         step.stored_url    = row.url;
         step.data_template = std::move (data_template);
+        // Only ever reached with rows behind it: the refusal above returns for
+        // a credential token in a run that has no data set, so a deferred step
+        // cannot arrive at an executor with no row to bind.
+        if (!auth_template.empty ()) {
+            step.auth          = parsed_auth;
+            step.auth_template = std::move (auth_template);
+        }
         resolution.plan.steps.push_back (std::move (step));
     }
 
     resolution.ok = true;
     return resolution;
+}
+
+DataBindResult bind_step_auth (vayu::Request& request,
+const ScenarioStep& step,
+const nlohmann::json& row,
+size_t row_index) {
+    if (step.auth_template.empty ()) {
+        return DataBindResult{ true, {} };
+    }
+
+    // Copied because the plan is immutable and shared by every virtual user of
+    // the run, and the join rewrites the credentials in place.
+    vayu::http::Auth auth = step.auth;
+    if (auto bound = apply_auth_data_template (auth, step.auth_template, row, row_index);
+        !bound.ok) {
+        return bound;
+    }
+
+    // No database handle: oauth2 is the only mode `apply_auth` needs one for,
+    // and an oauth2 config carrying a data token is refused when the plan
+    // resolves - deferral never reaches here with one.
+    if (auto applied = vayu::http::apply_auth (request, auth, nullptr); !applied.ok) {
+        return DataBindResult{ false, applied.message };
+    }
+    return DataBindResult{ true, {} };
 }
 
 nlohmann::json build_scenario_manifest (const ScenarioRequest& request,

--- a/engine/src/core/scenario_runner.cpp
+++ b/engine/src/core/scenario_runner.cpp
@@ -414,6 +414,15 @@ RunManager& manager) {
                     // it.
                     auto bound = apply_data_template (inputs.request,
                     step.data_template, data_rows[*data_row_index], *data_row_index);
+                    if (bound.ok) {
+                        // Then the credentials, for a step whose auth the plan
+                        // deliberately left unresolved: they have to carry the
+                        // row's values *before* `apply_auth` base64-encodes
+                        // them onto the request (issue #591). A no-op for every
+                        // other step.
+                        bound = bind_step_auth (inputs.request, step,
+                        data_rows[*data_row_index], *data_row_index);
+                    }
                     if (!bound.ok) {
                         data_bind_error = std::move (bound.error);
                     }

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -30,8 +30,10 @@
 #include "vayu/core/run_manager.hpp"
 #include "vayu/core/scenario_data.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/event_loop.hpp"
+#include "vayu/utils/encoding.hpp"
 
 namespace {
 
@@ -51,6 +53,10 @@ class ScenarioMockServer {
         std::string path;
         std::string cookie; // The `Cookie` header as received; "" when absent.
         std::string body;   // The request body as received; "" for a GET.
+        // The `Authorization` as received; "" when absent. Read off the wire
+        // because a credential bound from a data row is only correct once it is
+        // encoded, and the encoding is what used to hide the bug (issue #591).
+        std::string authorization;
     };
 
     explicit ScenarioMockServer (size_t login_rendezvous = 0)
@@ -133,7 +139,8 @@ class ScenarioMockServer {
     private:
     void record (const httplib::Request& req, const std::string& path) {
         std::lock_guard<std::mutex> lock (hits_mtx_);
-        hits_.push_back ({ path, req.get_header_value ("Cookie"), req.body });
+        hits_.push_back ({ path, req.get_header_value ("Cookie"), req.body,
+        req.get_header_value ("Authorization") });
     }
 
     httplib::Server svr;
@@ -233,6 +240,17 @@ class ScenarioLoadTest : public ::testing::Test {
             step.data_template = vayu::core::tokenize_data_fields (step.request);
         }
         execution.data_rows = rows;
+    }
+
+    /// Give every step the deferred auth `resolve_scenario` leaves behind for
+    /// credentials carrying a `{{data.*}}` token - through the resolver's own
+    /// two calls, for the same reason `with_data` uses the real splitter.
+    static void with_deferred_auth (vayu::core::ScenarioExecution& execution,
+    const json& auth) {
+        for (auto& step : execution.plan.steps) {
+            step.auth          = vayu::http::parse_auth (auth);
+            step.auth_template = vayu::core::tokenize_auth_fields (step.auth);
+        }
     }
 
     std::unique_ptr<vayu::db::Database> db_;
@@ -834,6 +852,60 @@ TEST_F (ScenarioLoadTest, AStepWithoutADataTokenCarriesNoTemplate) {
 
     EXPECT_EQ (server.hits_for ("/s0").size (), 1u)
     << "the untemplated step was still sent unchanged";
+}
+
+// A credentials file, end to end and read off the wire: every virtual user
+// sends its *own* row's credentials, base64-encoded after the bind rather than
+// around it. Before this, the header on every one of these was
+// base64("{{data.user}}:{{data.pass}}") - a literal token nobody ever saw,
+// because the encoding hid it (issue #591).
+TEST_F (ScenarioLoadTest, ACredentialsFileBindsPerIterationOnTheWire) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/echo") });
+    with_data (execution,
+    { json{ { "user", "alice" }, { "pass", "pw0" } },
+    json{ { "user", "bob" }, { "pass", "pw1" } } });
+    with_deferred_auth (execution,
+    json{ { "mode", "basic" }, { "username", "{{data.user}}" },
+    { "password", "{{data.pass}}" } });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 } };
+    run (config, execution);
+
+    std::vector<std::string> sent;
+    for (const auto& hit : server.hits_for ("/echo")) {
+        sent.push_back (hit.authorization);
+    }
+    EXPECT_EQ (sent,
+    (std::vector<std::string>{ "Basic " + vayu::utils::base64_encode ("alice:pw0"),
+    "Basic " + vayu::utils::base64_encode ("bob:pw1") }));
+}
+
+// The credential half of the failure path: a column the row does not carry ends
+// the step before the send, exactly as one in the URL does - never a request
+// with a blank password.
+TEST_F (ScenarioLoadTest, AnAbsentColumnInACredentialErrorsTheStepInsteadOfSendingIt) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/echo") });
+    with_data (execution, { json{ { "user", "alice" } } });
+    with_deferred_auth (execution,
+    json{ { "mode", "basic" }, { "username", "{{data.user}}" },
+    { "password", "{{data.missing}}" } });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 1 },
+        { "concurrency", 1 } };
+    auto state        = run (config, execution);
+
+    EXPECT_EQ (server.hits_for ("/echo").size (), 0u)
+    << "a request whose credentials could not bind reached the wire";
+    EXPECT_EQ (state->steps_errored.load (), 1u);
+    EXPECT_EQ (context_->in_flight (), 0u);
+
+    const auto& errors = context_->metrics_collector->errors ();
+    ASSERT_FALSE (errors.empty ());
+    EXPECT_NE (errors[0].error_message.find ("{{data.missing}}"), std::string::npos)
+    << errors[0].error_message;
 }
 
 // A token naming a column the bound row does not carry fails the step loudly:

--- a/engine/tests/scenario_plan_test.cpp
+++ b/engine/tests/scenario_plan_test.cpp
@@ -44,6 +44,7 @@
 #include "vayu/db/database.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/http/script_parts.hpp"
+#include "vayu/utils/encoding.hpp"
 
 using nlohmann::json;
 
@@ -715,6 +716,244 @@ TEST_F (ScenarioPlanTest, ThePrefixAloneDoesNotBlockARunWithoutData) {
 
     ASSERT_TRUE (resolved.ok) << resolved.error;
     EXPECT_EQ (resolved.plan.steps[0].request.url, "https://example.test/u/");
+}
+
+// --- Data tokens in the credentials (issue #591) ------------------------------
+
+namespace {
+
+/// The `Authorization` a step is carrying, or "" when it carries none.
+std::string authorization_of (const vayu::Request& request) {
+    const auto header = request.headers.find ("Authorization");
+    return header == request.headers.end () ? std::string{} : header->second;
+}
+
+} // namespace
+
+TEST_F (ScenarioPlanTest, BasicAuthCredentialsBindPerIterationRatherThanEncodingTheToken) {
+    // The canonical data-driven run: a credentials file behind basic auth. Bind
+    // the credentials after `apply_auth` and every iteration sends
+    // `base64("{{data.user}}:{{data.pass}}")` - the literal token text - as an
+    // ordinary-looking 401. Nothing in the plan can see it once it is encoded,
+    // which is why the plan must not encode it.
+    seed_collection ("col", "");
+    seed_request ("login", "col", /*order=*/0, "https://example.test/login",
+    R"({"mode":"basic","username":"{{data.user}}","password":"{{data.pass}}"})");
+
+    json scenario = block ("col");
+    scenario["data"] =
+    json::array ({ json{ { "user", "alice" }, { "pass", "s3cret" } } });
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_EQ (resolved.plan.steps.size (), 1u);
+    const auto& step = resolved.plan.steps[0];
+
+    // Deferred: the plan carries no credential at all for this step, so there
+    // is nothing on it for the token text to have been baked into.
+    EXPECT_FALSE (step.auth_template.empty ())
+    << "the step's credentials carry a data token, so its auth must be "
+       "deferred";
+    EXPECT_EQ (authorization_of (step.request), "")
+    << "auth was applied at plan time, which is what hid the token";
+
+    vayu::Request request = step.request;
+    const auto bound      = vayu::core::bind_step_auth (
+    request, step, resolved.data_rows[0], /*row_index=*/0);
+    ASSERT_TRUE (bound.ok) << bound.error;
+    EXPECT_EQ (authorization_of (request),
+    "Basic " + vayu::utils::base64_encode ("alice:s3cret"));
+}
+
+TEST_F (ScenarioPlanTest, EachRowGetsItsOwnCredentialsFromTheSamePlan) {
+    // The plan is resolved once and shared by every iteration and virtual user,
+    // so a bind that leaked into it would give every row the first row's
+    // credentials. Two rows through one step is what shows it does not.
+    seed_collection ("col", "");
+    seed_request ("login", "col", /*order=*/0, "https://example.test/login",
+    R"({"mode":"basic","username":"{{data.user}}","password":"pw"})");
+
+    json scenario = block ("col");
+    scenario["data"] =
+    json::array ({ json{ { "user", "alice" } }, json{ { "user", "bob" } } });
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    const auto& step = resolved.plan.steps[0];
+
+    std::vector<std::string> sent;
+    for (size_t row = 0; row < resolved.data_rows.size (); ++row) {
+        vayu::Request request = step.request;
+        const auto bound =
+        vayu::core::bind_step_auth (request, step, resolved.data_rows[row], row);
+        ASSERT_TRUE (bound.ok) << bound.error;
+        sent.push_back (authorization_of (request));
+    }
+
+    EXPECT_EQ (sent[0], "Basic " + vayu::utils::base64_encode ("alice:pw"));
+    EXPECT_EQ (sent[1], "Basic " + vayu::utils::base64_encode ("bob:pw"));
+}
+
+TEST_F (ScenarioPlanTest, BearerAndApiKeyCredentialsBindByContract) {
+    // These two passed before this existed, but only by accident: their values
+    // land verbatim in header text, so the request-side binder happened to walk
+    // them. An api key in the *query* did not even manage that - `apply_auth`
+    // percent-encoded the token's braces before the binder ever saw it. Pinned
+    // so the accident cannot regress and the query placement stays fixed.
+    const auto bound_request = [&] (const std::string& auth,
+                               const std::string& url, const json& row) {
+        reset_database ();
+        seed_collection ("col", "");
+        seed_request ("req", "col", /*order=*/0, url, auth);
+
+        json scenario    = block ("col");
+        scenario["data"] = json::array ({ row });
+
+        const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+        EXPECT_TRUE (resolved.ok) << resolved.error;
+        vayu::Request request = resolved.plan.steps[0].request;
+        const auto result     = vayu::core::bind_step_auth (
+        request, resolved.plan.steps[0], resolved.data_rows[0], /*row_index=*/0);
+        EXPECT_TRUE (result.ok) << result.error;
+        return request;
+    };
+
+    EXPECT_EQ (authorization_of (bound_request (R"({"mode":"bearer","token":"{{data.token}}"})",
+               "https://example.test/x", json{ { "token", "t0ken" } })),
+    "Bearer t0ken");
+
+    const auto api_key_header =
+    bound_request (R"({"mode":"apikey","key":"X-Key","value":"{{data.key}}"})",
+    "https://example.test/x", json{ { "key", "k3y" } });
+    ASSERT_EQ (api_key_header.headers.count ("X-Key"), 1u);
+    EXPECT_EQ (api_key_header.headers.at ("X-Key"), "k3y");
+
+    // The value is percent-encoded *after* the bind, so a cell with a space is
+    // one query parameter rather than two.
+    const auto api_key_query = bound_request (
+    R"({"mode":"apikey","key":"token","value":"{{data.key}}","in":"query"})",
+    "https://example.test/x", json{ { "key", "k 3y" } });
+    EXPECT_EQ (api_key_query.url, "https://example.test/x?token=k%203y");
+}
+
+TEST_F (ScenarioPlanTest, AMissingColumnInACredentialEndsTheStepByName) {
+    // The failure path: a credential naming a column the row does not carry is
+    // the same loud error as one in the URL, not a request sent with a blank
+    // password.
+    seed_collection ("col", "");
+    seed_request ("login", "col", /*order=*/0, "https://example.test/login",
+    R"({"mode":"basic","username":"{{data.user}}","password":"{{data.missing}}"})");
+
+    json scenario    = block ("col");
+    scenario["data"] = json::array ({ json{ { "user", "alice" } } });
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+
+    vayu::Request request = resolved.plan.steps[0].request;
+    const auto bound      = vayu::core::bind_step_auth (
+    request, resolved.plan.steps[0], resolved.data_rows[0], /*row_index=*/0);
+    EXPECT_FALSE (bound.ok);
+    EXPECT_NE (bound.error.find ("{{data.missing}}"), std::string::npos)
+    << bound.error;
+    EXPECT_EQ (authorization_of (request), "")
+    << "a failed credential bind must send nothing, not a half-built header";
+}
+
+TEST_F (ScenarioPlanTest, ADataTokenInTheCredentialsWithNoDataSetIsRefused) {
+    // The #415 guard, reached through the auth block. Before the credentials
+    // were kept out of the base64 this run started and sent
+    // `base64("{{data.user}}:")` on every request.
+    seed_collection ("col", "");
+    seed_request ("login", "col", /*order=*/0, "https://example.test/login",
+    R"({"mode":"basic","username":"{{data.user}}","password":"pw"})");
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, block ("col"), options ());
+
+    EXPECT_FALSE (resolved.ok);
+    EXPECT_NE (resolved.error.find ("{{data.user}}"), std::string::npos)
+    << resolved.error;
+    EXPECT_NE (resolved.error.find ("scenario.data"), std::string::npos)
+    << resolved.error;
+    EXPECT_TRUE (resolved.plan.steps.empty ());
+}
+
+TEST_F (ScenarioPlanTest, ADataTokenInAnOAuth2ConfigIsRefusedWithOrWithoutData) {
+    // The one mode deferral cannot serve: the token is acquired here, once, so
+    // no iteration exists for a row to reach. Refused by name rather than sent
+    // to the token endpoint as the literal text.
+    const auto refused = [&] (const json& scenario) {
+        const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+        EXPECT_FALSE (resolved.ok);
+        EXPECT_NE (resolved.error.find ("{{data.secret}}"), std::string::npos)
+        << resolved.error;
+        EXPECT_NE (resolved.error.find ("OAuth 2.0"), std::string::npos)
+        << resolved.error;
+        EXPECT_NE (resolved.error.find ("Request oauth_req"), std::string::npos)
+        << resolved.error;
+    };
+
+    seed_collection ("col", "");
+    seed_request ("oauth_req", "col", /*order=*/0, "https://example.test/x",
+    R"({"mode":"oauth2","config":{"tokenUrl":"https://auth.test/token",
+        "clientId":"c","clientSecret":"{{data.secret}}"}})");
+
+    refused (block ("col"));
+
+    json with_rows    = block ("col");
+    with_rows["data"] = json::array ({ json{ { "secret", "s" } } });
+    refused (with_rows);
+}
+
+TEST_F (ScenarioPlanTest, CredentialsWithoutADataTokenAreStillResolvedIntoThePlan) {
+    // Deferral must not widen: the ordinary step still pays its auth once, at
+    // plan time, and carries an executable credential without any per-iteration
+    // work. Drop the `auth_template.empty()` test in `resolve_scenario` and
+    // this step arrives at the wire with no `Authorization` at all.
+    seed_collection ("col", "");
+    seed_request ("static_req", "col", /*order=*/0, "https://example.test/x",
+    R"({"mode":"basic","username":"alice","password":"s3cret"})");
+
+    json scenario    = block ("col");
+    scenario["data"] = json::array ({ json{ { "user", "unused" } } });
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    const auto& step = resolved.plan.steps[0];
+
+    EXPECT_TRUE (step.auth_template.empty ());
+    EXPECT_EQ (authorization_of (step.request),
+    "Basic " + vayu::utils::base64_encode ("alice:s3cret"));
+
+    // And `bind_step_auth` is the no-op the executors call unconditionally.
+    vayu::Request request = step.request;
+    const auto bound      = vayu::core::bind_step_auth (
+    request, step, resolved.data_rows[0], /*row_index=*/0);
+    EXPECT_TRUE (bound.ok) << bound.error;
+    EXPECT_EQ (authorization_of (request), authorization_of (step.request));
+}
+
+TEST_F (ScenarioPlanTest, AUserSuppliedAuthorizationHeaderStillWinsOverBoundCredentials) {
+    // `apply_auth`'s precedence rule is the deferred path's too, because it is
+    // the same `apply_auth` - a header the user wrote is never overwritten,
+    // whichever iteration the credentials came from.
+    seed_collection ("col", "");
+    seed_request ("req", "col", /*order=*/0, "https://example.test/x",
+    R"({"mode":"basic","username":"{{data.user}}","password":"pw"})",
+    /*post_script=*/"", /*created_at=*/1,
+    R"([{"key":"Authorization","value":"Bearer mine","enabled":true}])");
+
+    json scenario    = block ("col");
+    scenario["data"] = json::array ({ json{ { "user", "alice" } } });
+
+    const auto resolved = vayu::core::resolve_scenario (*db_, scenario, options ());
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+
+    vayu::Request request = resolved.plan.steps[0].request;
+    const auto bound      = vayu::core::bind_step_auth (
+    request, resolved.plan.steps[0], resolved.data_rows[0], /*row_index=*/0);
+    ASSERT_TRUE (bound.ok) << bound.error;
+    EXPECT_EQ (authorization_of (request), "Bearer mine");
 }
 
 TEST_F (ScenarioPlanTest, AnUnknownSourceDoesNotFallThroughToTheCollectionPath) {

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -41,6 +41,7 @@
 #include "vayu/core/scenario_runner.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/cookie_jar.hpp"
+#include "vayu/utils/encoding.hpp"
 #include "vayu/utils/json.hpp"
 
 using nlohmann::json;
@@ -58,6 +59,10 @@ struct SeenRequest {
     std::string cookie;
     std::string marker; // the X-Marker header, which the tests' scripts set
     std::string body;   // the request body as received; "" for a GET
+    /// The `Authorization` as received; "" when absent. Credentials bound from
+    /// a data row are only correct once encoded, and the encoding is what used
+    /// to hide the bug (issue #591), so they are asserted off the wire.
+    std::string authorization;
 };
 
 /**
@@ -72,8 +77,9 @@ class ScenarioMockServer {
 
         const auto record = [this] (const httplib::Request& req) {
             std::lock_guard<std::mutex> lock (mtx);
-            seen.push_back ({ req.path, req.target, req.get_header_value ("Cookie"),
-            req.get_header_value ("X-Marker"), req.body });
+            seen.push_back ({ req.path, req.target,
+            req.get_header_value ("Cookie"), req.get_header_value ("X-Marker"),
+            req.body, req.get_header_value ("Authorization") });
         };
 
         svr.Get ("/ok", [record] (const httplib::Request& req, httplib::Response& res) {
@@ -197,10 +203,12 @@ class ScenarioRunnerTest : public ::testing::Test {
     const std::string& absolute_url = "",
     const std::string& name         = "",
     const std::string& headers      = "",
-    const std::string& body         = "") {
+    const std::string& body         = "",
+    const std::string& auth         = "") {
         vayu::db::Request r;
         r.id            = id;
         r.collection_id = "col_1";
+        r.auth          = auth;
         r.name          = name.empty () ? "Step " + id : name;
         // A body is what a POST is for, so the two travel together rather than
         // leaving a caller to remember the method.
@@ -1107,6 +1115,27 @@ TEST_F (ScenarioRunnerTest, ATokenNamingAnAbsentColumnErrorsTheStepWithoutSendin
     EXPECT_FALSE (trace.contains ("response"));
     EXPECT_NE (
     trace["request"]["url"].get<std::string> ().find ("{{data.absent}}"), std::string::npos);
+}
+
+// A credentials file behind basic auth, end to end. The plan deliberately does
+// not resolve this step's auth: `apply_auth` would base64 the *token text* into
+// one `Authorization` value, which is unreadable by the time anything scans the
+// built request - so every iteration used to send the same wrong credential and
+// report it as an ordinary 401 (issue #591).
+TEST_F (ScenarioRunnerTest, ACredentialsFileBindsPerIterationOnTheWire) {
+    seed_collection ("col_1");
+    seed_request ("req_a", 0, "/ok", "", "", "", "", "", "",
+    R"({"mode":"basic","username":"{{data.user}}","password":"{{data.pass}}"})");
+
+    const auto run_id =
+    start_with_data (json::array ({ { { "user", "ada" }, { "pass", "pw0" } },
+    { { "user", "grace" }, { "pass", "pw1" } } }));
+    ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
+
+    auto seen = server_->requests ();
+    ASSERT_EQ (seen.size (), 2u);
+    EXPECT_EQ (seen[0].authorization, "Basic " + vayu::utils::base64_encode ("ada:pw0"));
+    EXPECT_EQ (seen[1].authorization, "Basic " + vayu::utils::base64_encode ("grace:pw1"));
 }
 
 // A cell carrying a quote used to end the JSON string it was dropped into and


### PR DESCRIPTION
## Description

A credentials file driving basic auth silently sent garbage: `{{data.user}}` / `{{data.pass}}` in a request's basic-auth fields went out as `Authorization: Basic base64("{{data.user}}:{{data.pass}}")` on every iteration - the literal token text - and came back as ordinary 401s the user would blame on the target.

**Root cause**, verified still present at `a420c35`: plan resolution applied auth before it scanned for data tokens. `build_request` -> `apply_auth` collapses `username:password` into one base64 `Authorization` value (`auth_resolver.cpp:226-231`), and only then did `tokenize_data_fields` walk the built request (`scenario_plan.cpp:289` vs `:298`). Once encoded the token is invisible, so the binder never saw it *and* the #415 no-data refusal could not see it either - a run whose only data token lived in the credentials sailed straight through the guard that exists for exactly that case.

**Approach - option (a) from the issue, with one refusal where (a) is architecturally impossible.** A step whose parsed credentials carry a `{{data.*}}` withholds its `auth` from `build_request`, keeps the typed `Auth` plus a split template on the step, and applies auth *per iteration*: bind the row into the credentials, then `apply_auth`. Bearer and apikey then work by contract rather than by accident. OAuth 2.0 is refused by name instead: its token is acquired once, at plan resolution, so there is no per-iteration acquisition for a row to reach, and inventing one would mean a network round trip per virtual user per iteration. Every step without a credential token still resolves its auth once at plan time, unchanged - deferral costs nothing where it is not needed.

**Alternative rejected:** option (b), refusing any `{{data.*}}` in an auth field. Honest and cheap, but it walls off the credentials-file use case that is the whole point of a data-driven load test, and the header workaround makes the user hand-assemble base64. Also rejected: a second field list for credentials. `walk_auth_credentials` drives the same `Auth` variant `apply_auth` consumes, with the same exhaustive `static_assert`, so a new auth mode is a compile error in both places rather than a silent hole in one.

**Two corrections to the issue's reading of the current state**, both now pinned:

- apikey **in header** did work by accident (its value lands verbatim in header text). apikey **in query** did not: `apply_auth` percent-encodes the value, so `{{data.k}}` reached the URL as `%7B%7Bdata.k%7D%7D` and the binder never matched it. Binding before `apply_auth` fixes that placement too - a cell with a space is now one correctly-encoded parameter rather than two.
- The #415 guard now scans the credentials as well as the request, so an auth-only data token in a no-data run is refused by name.

The decision is recorded on the issue as the acceptance criteria ask.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure` - **1607 tests, 100% passed, 0 failed** (1596 before this change; 11 new). No pre-existing failures.

**Engine, `scenario_plan_test.cpp` (8 new):** basic auth binds per iteration and the plan carries no `Authorization` for that step; two rows through one shared plan get their own credentials (a bind leaking into the plan would give both the first row's); bearer, apikey-in-header and apikey-in-query bind by contract, the query one asserted through its percent-encoding; a credential naming an absent column ends the step by name and leaves no half-built header; an auth-only data token with no data set is refused by the #415 guard; an `oauth2` config carrying one is refused with *and* without a data set; a credential with no data token is still resolved into the plan and `bind_step_auth` is a no-op for it; a user-supplied `Authorization` header still wins over bound credentials.

**Engine, end-to-end off the wire** - the shape the issue asks for, both modes. `scenario_runner_test.cpp` (design) and `scenario_load_test.cpp` (load) each drive a two-row credentials file through the real mock and read the `Authorization` header the server received: `Basic base64("ada:pw0")` then `Basic base64("grace:pw1")`. The load suite also pins the credential failure path - an absent column errors the step, sends nothing, and the message reaches the run's error store.

**Mutation-checked:** removing the `payload.erase("auth")` (i.e. reordering the scan back behind `apply_auth`) reddens the plan tests that assert the deferred step carries no credential, and the design-mode end-to-end test, which then sees base64 of the literal token text - 4 tests red, restored all green. Dropping the `auth_template.empty()` test on the other side reddens `CredentialsWithoutADataTokenAreStillResolvedIntoThePlan`, which is what stops the fix from widening into steps that never needed it.

No app file is touched (the issue scopes the builder's painting to #592, which landed as #603), so the app suite could not change colour and was not run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Notes on scope

- **`docs/engine/api-reference.md`** now enumerates the participating fields exhaustively including the credential fields, replacing the line that said auth "is not bound today", and the scenario refusal table gains the oauth2 row. `docs/engine/scripting.md` and `docs/engine/architecture.md` are updated in the same commit for the same claim. `mkdocs build --strict` could not be run here - mkdocs is not installed in this environment - so the docs job on this PR is the check for it; only existing anchors are linked (`api-reference.md#scenario-runs`, already linked from `scripting.md`).
- **Left for #595 item 4, deliberately:** a `{{data.*}}` on a single-request `POST /execute` or a non-scenario load run still sends literal braces with no warning. That is the same silence one layer over, but it is that issue's scope and its decision to record.
- `FieldSplitter::operator()` now takes its field by `const&`. It never wrote through the reference; the change is what lets the credential walk feed it strings it holds no copy of, rather than adding a scratch copy per credential.

## Related Issues

Closes #591

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT3pqUkuJtAyjf14HuZMmU)_