### PR TITLE
feat(app/data): phase 2 - schema-aware {{data.*}}, column completions, and a referenced-columns audit

### DIFF
--- a/app/src/components/shared/VariableInput/RuntimeToken.tsx
+++ b/app/src/components/shared/VariableInput/RuntimeToken.tsx
@@ -31,6 +31,8 @@
  */
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import type { DataTokenTone } from "@/lib/data-contract";
 
 export interface RuntimeTokenProps {
 	/** Name as written inside the braces, e.g. `"$guid"` or `"data.email"`. */
@@ -39,14 +41,33 @@ export interface RuntimeTokenProps {
 	description: string;
 	/** When it is produced, e.g. "generated per use". */
 	note: string;
+	/**
+	 * `warning` for a token that will read correctly only if the run's file
+	 * disagrees with the contract - a `{{data.x}}` naming a column no contract
+	 * in scope declares (issue #600). Never `destructive`: that paint means "no
+	 * value can ever answer this name", and an undeclared column can still bind
+	 * from a file the contract has drifted from.
+	 */
+	tone?: DataTokenTone;
 }
 
-export default function RuntimeToken({ name, description, note }: RuntimeTokenProps) {
+/** The one place a tone becomes a colour, so the two states cannot drift apart. */
+const TONE_CLASS: Record<DataTokenTone, string> = {
+	muted: "text-muted-foreground",
+	warning: "text-warning-text",
+};
+
+export default function RuntimeToken({
+	name,
+	description,
+	note,
+	tone = "muted",
+}: RuntimeTokenProps) {
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
 				<span
-					className="inline rounded-md font-[inherit] text-muted-foreground"
+					className={cn("inline rounded-md font-[inherit]", TONE_CLASS[tone])}
 					contentEditable={false}
 					suppressContentEditableWarning
 				>

--- a/app/src/components/shared/VariableInput/data-column-paint.test.tsx
+++ b/app/src/components/shared/VariableInput/data-column-paint.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `{{data.*}}` painted against the declared contract (issue #600).
+ *
+ * Phase 1 (#603) stopped painting these tokens red and left every one of them
+ * neutral, because nothing in the app knew which columns existed. Now that a
+ * collection declares them, the token can say which of three states it is in -
+ * and the middle one is the whole point: `{{data.emial}}` binds nothing, and
+ * without this the first anyone hears of it is a run that sent the braces.
+ *
+ * The three states are asserted through the rendered overlay rather than off
+ * `describeDataToken` (which has its own suite): the wiring from
+ * `VariableSupport.dataColumns` to a class on a span is what a screenshot would
+ * show, and it is what would silently go missing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
+import { variableSupportStub } from "@/test/variable-support";
+import type { DataContractScope } from "@/types";
+import VariableInput from "./index";
+
+const contract: DataContractScope = {
+	collectionName: "Checkout flow",
+	columns: ["id", "email"],
+};
+
+function overlayOf(value: string, dataColumns?: DataContractScope) {
+	const { container } = render(
+		<TooltipProvider>
+			<VariableInput
+				value={value}
+				onChange={() => {}}
+				placeholder="URL"
+				variables={variableSupportStub({}, { dataColumns })}
+			/>
+		</TooltipProvider>
+	);
+	const overlay = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+	expect(overlay).toBeTruthy();
+	return overlay;
+}
+
+function tokenOf(value: string, dataColumns?: DataContractScope) {
+	const token = overlayOf(value, dataColumns).querySelector("[data-variable-token] span");
+	expect(token).toBeTruthy();
+	return token as HTMLElement;
+}
+
+describe("a token naming a declared column", () => {
+	it("is informational, never a warning", () => {
+		const token = tokenOf("https://x/{{data.id}}", contract);
+		expect(token.className).toContain("text-muted-foreground");
+		expect(token.className).not.toContain("text-warning-text");
+	});
+});
+
+describe("a token naming a column the contract does not declare", () => {
+	it("is painted as a warning - not muted, and not the destructive red of an unknown variable", () => {
+		const token = tokenOf("https://x/{{data.emial}}", contract);
+		expect(token.className).toContain("text-warning-text");
+		expect(token.className).not.toContain("text-muted-foreground");
+		// A file the contract has drifted from can still carry the column, so
+		// this is never the "nothing can ever bind this" tier.
+		expect(token.className).not.toContain("text-destructive-text");
+	});
+
+	it("still offers nothing to create - the namespace is disjoint whatever the paint", () => {
+		const overlay = overlayOf("{{data.emial}}", contract);
+		expect(overlay.querySelector('[role="button"]')).toBeNull();
+	});
+
+	it("paints only the undeclared one when both kinds sit in the same field", () => {
+		const overlay = overlayOf("{{data.id}}/{{data.emial}}", contract);
+		const tokens = [...overlay.querySelectorAll("[data-variable-token] span")];
+		expect(tokens).toHaveLength(2);
+		expect(tokens[0].className).toContain("text-muted-foreground");
+		expect(tokens[1].className).toContain("text-warning-text");
+	});
+});
+
+describe("with no contract anywhere in the chain", () => {
+	it("keeps phase 1's neutral token", () => {
+		// Nothing was declared, so nothing can be validated. A token painted
+		// amber for lacking a contract nobody wrote would be noise, and it would
+		// be noise in every workspace that has never opened the Data tab.
+		const token = tokenOf("https://x/{{data.emial}}");
+		expect(token.className).toContain("text-muted-foreground");
+		expect(token.className).not.toContain("text-warning-text");
+	});
+});

--- a/app/src/components/shared/VariableInput/index.tsx
+++ b/app/src/components/shared/VariableInput/index.tsx
@@ -38,6 +38,7 @@ import { VARIABLE_PATTERN } from "@/constants/variables";
 import { variableCompletionContext } from "@/lib/variable-completion";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 import { isDataVariableName } from "@/lib/variable-resolution";
+import { describeDataToken } from "@/lib/data-contract";
 
 interface VariableInputProps {
 	value: string;
@@ -349,12 +350,20 @@ export default function VariableInput({
 				 * it had. Only a collection run's iteration binds one.
 				 */
 				if (isDataVariableName(seg.varName)) {
+					/*
+					 * Three states now rather than one (issue #600): a declared
+					 * column, a column no contract in scope declares, and - when
+					 * nothing in the chain declares anything - phase 1's neutral
+					 * token, unchanged. `describeDataToken` owns which is which.
+					 */
+					const data = describeDataToken(seg.varName, variables?.dataColumns);
 					return (
 						<span key={`${i}-${seg.varName}`} data-variable-token>
 							<RuntimeToken
 								name={seg.varName}
-								description="Bound by the run's data file"
-								note="per iteration"
+								description={data.description}
+								note={data.note}
+								tone={data.tone}
 							/>
 						</span>
 					);
@@ -470,6 +479,7 @@ export default function VariableInput({
 						variables={variablesForAutocomplete}
 						searchQuery={searchQuery}
 						onSelect={handleSelectVariable}
+						dataColumns={variables?.dataColumns}
 					/>
 				</div>
 			)}

--- a/app/src/components/ui/variable-autocomplete.data-columns.test.tsx
+++ b/app/src/components/ui/variable-autocomplete.data-columns.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Declared columns in the plain-field `{{` list (issue #600).
+ *
+ * The Monaco provider covers the body editors; this list is the URL bar, header
+ * values and every key/value cell - which is where most `{{data.*}}` tokens are
+ * actually written. Offered as full `data.<column>` names rather than bare ones
+ * because that is the string the token carries, and `onSelect` inserts exactly
+ * what it is handed.
+ */
+
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VariableAutocomplete } from "./variable-autocomplete";
+import type { DataContractScope } from "@/types";
+
+// cmdk scrolls its selected item into view on mount; jsdom has no layout.
+beforeAll(() => {
+	Element.prototype.scrollIntoView = vi.fn();
+});
+
+const contract: DataContractScope = {
+	collectionName: "Checkout flow",
+	columns: ["id", "email"],
+};
+
+describe("data columns in the plain-field list", () => {
+	it("shows them under their own heading, naming the collection that declared them", () => {
+		render(<VariableAutocomplete variables={{}} onSelect={vi.fn()} dataColumns={contract} />);
+		expect(screen.getByText("Data columns")).toBeInTheDocument();
+		expect(screen.getByText("data.email")).toBeInTheDocument();
+		expect(screen.getAllByText("Checkout flow").length).toBeGreaterThan(0);
+	});
+
+	it("filters on the whole token name, which is what has been typed", () => {
+		// The query at the moment this list matters is `data.`, not `email`.
+		render(
+			<VariableAutocomplete
+				variables={{}}
+				searchQuery="data."
+				onSelect={vi.fn()}
+				dataColumns={contract}
+			/>
+		);
+		expect(screen.getByText("data.id")).toBeInTheDocument();
+		expect(screen.queryByText("$guid")).toBeNull();
+	});
+
+	it("shows no heading at all when the chain declares no contract", () => {
+		render(<VariableAutocomplete variables={{}} onSelect={vi.fn()} />);
+		expect(screen.queryByText("Data columns")).toBeNull();
+	});
+});

--- a/app/src/components/ui/variable-autocomplete.tsx
+++ b/app/src/components/ui/variable-autocomplete.tsx
@@ -19,7 +19,8 @@ import { useMemo } from "react";
 import { Command, CommandList, CommandEmpty, CommandGroup, CommandItem } from "./command";
 import { VariableScopeBadge } from "./variable-scope-badge";
 import { cn } from "@/lib/utils";
-import type { ResolvedVariable } from "@/types";
+import type { DataContractScope, ResolvedVariable } from "@/types";
+import { DATA_NAMESPACE_PREFIX } from "@/lib/variable-resolution";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 
 // Re-export ResolvedVariable as VariableInfo for backward compatibility
@@ -34,6 +35,12 @@ export interface VariableAutocompleteProps {
 	onSelect: (variableName: string) => void;
 	/** Optional className for the container */
 	className?: string;
+	/**
+	 * The data contract in scope, when the collection chain declares one
+	 * (issue #600). Its columns are offered as `data.<column>` names, which is
+	 * how a request field addresses them - the same string the token carries.
+	 */
+	dataColumns?: DataContractScope;
 }
 
 export function VariableAutocomplete({
@@ -41,6 +48,7 @@ export function VariableAutocomplete({
 	searchQuery = "",
 	onSelect,
 	className,
+	dataColumns,
 }: VariableAutocompleteProps) {
 	// Filter variables based on search query
 	const filteredVariables = useMemo(() => {
@@ -64,7 +72,26 @@ export function VariableAutocomplete({
 		);
 	}, [variables, searchQuery]);
 
-	if (filteredVariables.length === 0 && filteredDynamic.length === 0) {
+	/*
+	 * Columns are their own group for the same reason generators are: they are
+	 * not variables, and interleaving them would put a name no scope defines
+	 * among the ones the user created. They are offered from the contract rather
+	 * than from `variables` because the namespace is disjoint from the scopes -
+	 * a stored variable named `data.email` cannot shadow the column, so there is
+	 * no shadowing check to make here.
+	 */
+	const filteredColumns = useMemo(() => {
+		const lowerQuery = searchQuery.toLowerCase();
+		return (dataColumns?.columns ?? [])
+			.map((column) => `${DATA_NAMESPACE_PREFIX}${column}`)
+			.filter((name) => name.toLowerCase().includes(lowerQuery));
+	}, [dataColumns, searchQuery]);
+
+	if (
+		filteredVariables.length === 0 &&
+		filteredDynamic.length === 0 &&
+		filteredColumns.length === 0
+	) {
 		return null;
 	}
 
@@ -84,6 +111,23 @@ export function VariableAutocomplete({
 								>
 									<span className="font-mono text-sm">{name}</span>
 									<VariableScopeBadge scope={varInfo.scope} variant="compact" />
+								</CommandItem>
+							))}
+						</CommandGroup>
+					)}
+					{filteredColumns.length > 0 && (
+						<CommandGroup heading="Data columns">
+							{filteredColumns.map((name) => (
+								<CommandItem
+									key={name}
+									value={name}
+									onSelect={() => onSelect(name)}
+									className="flex items-center justify-between cursor-pointer"
+								>
+									<span className="font-mono text-sm">{name}</span>
+									<span className="ml-2 truncate text-[11px] text-muted-foreground">
+										{dataColumns?.collectionName}
+									</span>
 								</CommandItem>
 							))}
 						</CommandGroup>

--- a/app/src/hooks/data-column-completion.test.tsx
+++ b/app/src/hooks/data-column-completion.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Declared columns in the two Monaco lists (issue #600).
+ *
+ * A contract nobody can complete from is a contract nobody uses: the columns
+ * live on the collection, and the places you spell them are a body editor
+ * (`{{data.email}}`) and a script (`pm.iterationData.get("email")`). Both
+ * providers are registered once per language in `App`, so this drives them the
+ * way Monaco does - build the provider, call `provideCompletionItems` against a
+ * line - rather than scanning source.
+ *
+ * What each case is really guarding is the *scoping*: a list that offered
+ * columns everywhere would offer names that bind nothing in every workspace
+ * that declares no contract.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { DataContractScope } from "@/types";
+
+interface Suggestion {
+	label: string;
+	insertText: string;
+	detail?: string;
+	filterText?: string;
+}
+
+interface ProviderLike {
+	provideCompletionItems: (
+		model: { getLineContent: () => string },
+		position: { lineNumber: number; column: number }
+	) => { suggestions: Suggestion[] };
+}
+
+const registered: Array<{ language: string; provider: ProviderLike }> = [];
+
+vi.mock("@monaco-editor/react", () => ({
+	useMonaco: () => ({
+		languages: {
+			CompletionItemKind: { Variable: 4, Function: 1, Field: 3 },
+			registerCompletionItemProvider: (language: string, provider: ProviderLike) => {
+				registered.push({ language, provider });
+				return { dispose: () => {} };
+			},
+		},
+	}),
+}));
+
+/** No variables at all, so every suggestion below can only be a column. */
+vi.mock("./useVariableResolver", () => ({
+	useVariableResolver: () => ({ getAllVariables: () => ({}) }),
+}));
+
+vi.mock("./useActiveCollectionId", () => ({ useActiveCollectionId: () => "col_1" }));
+
+const contract = {
+	current: undefined as DataContractScope | undefined,
+};
+vi.mock("./useDataContract", () => ({ useDataContract: () => contract.current }));
+
+const { useVariableCompletionProvider } = await import("./useVariableCompletionProvider");
+const { useScriptVariableCompletionProvider } =
+	await import("./useScriptVariableCompletionProvider");
+
+const declared: DataContractScope = {
+	collectionName: "Checkout flow",
+	columns: ["id", "email"],
+};
+
+/** Completions the first provider registered for `language` offers for `line`. */
+function suggestionsFor(hook: () => void, line: string, language: string): Suggestion[] {
+	registered.length = 0;
+	renderHook(hook);
+	const entry = registered.find((r) => r.language === language);
+	expect(entry).toBeTruthy();
+	return entry!.provider.provideCompletionItems(
+		{ getLineContent: () => line },
+		{ lineNumber: 1, column: line.length + 1 }
+	).suggestions;
+}
+
+const inBody = (line: string) => suggestionsFor(useVariableCompletionProvider, line, "json");
+/**
+ * Just the column entries. The body list also carries every generator
+ * (`{{$guid}}` and friends), which is a different feature and has its own suite
+ * - filtering here keeps a new generator from reddening these cases.
+ */
+const columnsInBody = (line: string) => inBody(line).filter((s) => s.label.startsWith("data."));
+const inScript = (line: string) =>
+	suggestionsFor(useScriptVariableCompletionProvider, line, "javascript");
+
+describe("`{{data.` in a request body", () => {
+	it("offers the declared columns, ready to insert as tokens", () => {
+		contract.current = declared;
+		const suggestions = columnsInBody('{"email": "{{data.');
+		expect(suggestions.map((s) => s.label)).toEqual(["data.id", "data.email"]);
+		expect(suggestions[1].insertText).toBe("{{data.email}}");
+		// The list has to say where the columns came from: in a sub-collection
+		// they are an ancestor's, and its Data tab is where they change.
+		expect(suggestions[1].detail).toContain("Checkout flow");
+	});
+
+	it("filters on the whole `{{data.` prefix, which is how Monaco narrows it", () => {
+		contract.current = declared;
+		// Monaco matches `filterText` against what has been typed since the
+		// replace range started, and the range starts at the braces - a bare
+		// `email` there would never match a caret sitting after `{{data.`.
+		expect(columnsInBody("{{data.").map((s) => s.filterText)).toEqual([
+			"{{data.id",
+			"{{data.email",
+		]);
+	});
+
+	it("offers nothing when the chain declares no contract", () => {
+		contract.current = undefined;
+		expect(columnsInBody("{{")).toEqual([]);
+		// The rest of the list is untouched - this adds a source, it does not
+		// replace one.
+		expect(inBody("{{").length).toBeGreaterThan(0);
+	});
+
+	it("offers nothing when the caret is not inside an open `{{`", () => {
+		contract.current = declared;
+		expect(inBody('{"email": "someone@example.com"')).toEqual([]);
+	});
+});
+
+describe('`pm.iterationData.get("` in a script', () => {
+	it("offers the declared columns as bare names - the argument is not a template", () => {
+		contract.current = declared;
+		const suggestions = inScript('const user = pm.iterationData.get("');
+		expect(suggestions.map((s) => s.label)).toEqual(["id", "email"]);
+		expect(suggestions[0].insertText).toBe("id");
+		expect(suggestions[0].detail).toContain("Checkout flow");
+	});
+
+	it("offers them to a guarded call too", () => {
+		contract.current = declared;
+		expect(inScript("pm.iterationData?.has('").map((s) => s.label)).toEqual(["id", "email"]);
+	});
+
+	it("offers nothing when the chain declares no contract", () => {
+		contract.current = undefined;
+		expect(inScript('pm.iterationData.get("')).toEqual([]);
+	});
+
+	it("does not bleed into a variable accessor, whose names are a different set", () => {
+		contract.current = declared;
+		// `pm.environment.get("email")` reads the environment; a column offered
+		// there is a name that returns `undefined` at run time.
+		expect(inScript('pm.environment.get("')).toEqual([]);
+		// `replaceIn` interpolates variables, and the data pass is a different
+		// pass over the composed request - a column is not one of its names.
+		expect(inScript('pm.variables.replaceIn("{{').map((s) => s.label)).not.toContain("email");
+	});
+});

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -13,6 +13,7 @@ export { useDraftSaveContext } from "./useDraftSaveContext";
 export { useVariableResolver } from "./useVariableResolver";
 export { useActiveEnvironmentGuard } from "./useActiveEnvironmentGuard";
 export { useVariableCompletionProvider } from "./useVariableCompletionProvider";
+export { useDataContract } from "./useDataContract";
 export { useElectronTheme } from "./useElectronTheme";
 export { useResizable } from "./useResizable";
 export { useOverflowTitle } from "./useOverflowTitle";

--- a/app/src/hooks/script-completion-split.test.tsx
+++ b/app/src/hooks/script-completion-split.test.tsx
@@ -61,6 +61,13 @@ vi.mock("./useVariableResolver", () => ({
 /** The providers scope themselves to the active tab; scoping is covered by `variable-completion-scope.test.tsx`. */
 vi.mock("./useActiveCollectionId", () => ({ useActiveCollectionId: () => undefined }));
 
+/**
+ * Declared data columns are a second source in this list (issue #600) and have
+ * their own suite - `data-column-completion.test.tsx`. Stubbed to "no contract"
+ * here, which is the state these cases were written in.
+ */
+vi.mock("./useDataContract", () => ({ useDataContract: () => undefined }));
+
 /** One `pm.*` entry is enough to tell "the list appeared" from "it yielded". */
 vi.mock("@/queries", () => ({
 	useScriptCompletionsQuery: () => ({

--- a/app/src/hooks/useDataContract.ts
+++ b/app/src/hooks/useDataContract.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The data contract in scope for a collection - the chain answer, from the
+ * cache (issue #600).
+ *
+ * The walk itself is `resolveDataContract`, which is pure and tested on its
+ * own; this is the one adapter from the collections query to it, so the token
+ * painter, the two completion providers and the Data tab's audit all read the
+ * same object rather than each walking `parentId` themselves.
+ *
+ * Memoised on the query result and the id: the return value is a prop on
+ * `VariableSupport`, which is itself a prop on a `memo`-wrapped key/value row -
+ * a fresh object each render would re-render the densest table in the app on
+ * every keystroke, which is the reason `useVariableSupport` memoises at all.
+ */
+
+import { useMemo } from "react";
+import { useCollectionsQuery } from "@/queries";
+import { resolveDataContract } from "@/lib/data-contract";
+import type { DataContractScope } from "@/types";
+
+export function useDataContract(
+	collectionId: string | null | undefined
+): DataContractScope | undefined {
+	const { data: collections = [] } = useCollectionsQuery();
+	return useMemo(
+		() => resolveDataContract(collectionId, collections) ?? undefined,
+		[collectionId, collections]
+	);
+}

--- a/app/src/hooks/useScriptVariableCompletionProvider.ts
+++ b/app/src/hooks/useScriptVariableCompletionProvider.ts
@@ -34,6 +34,12 @@
  * the two move together, or one of them offers names the other cannot read.
  * See docs/app/variable-resolution.md.
  *
+ * **`pm.iterationData` completes columns, not variables** (issue #600). The row
+ * it reads is bound from the collection's data file, so the names are the
+ * declared columns of the contract in scope - the same list the `{{data.*}}`
+ * tokens are validated against, so what an editor offers and what the builder
+ * paints green cannot disagree.
+ *
  * Call once (in App). A completion provider is global per language, so a single
  * registration covers every script editor instance. The same shape as
  * `useScriptCompletionProvider` and `useVariableCompletionProvider` beside it.
@@ -44,6 +50,7 @@ import { useMonaco } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import { useVariableResolver } from "./useVariableResolver";
 import { useActiveCollectionId } from "./useActiveCollectionId";
+import { useDataContract } from "./useDataContract";
 import { scriptVariableCompletionContext } from "@/lib/script-variable-completion";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
 
@@ -68,6 +75,12 @@ export function useScriptVariableCompletionProvider() {
 	 */
 	const collectionId = useActiveCollectionId();
 	const { getAllVariables } = useVariableResolver({ collectionId });
+	/*
+	 * `pm.iterationData.get("` completes columns, not variables (issue #600) -
+	 * the row is bound from the collection's data file, so the names come from
+	 * the contract in scope and from nowhere else.
+	 */
+	const dataColumns = useDataContract(collectionId);
 
 	useEffect(() => {
 		if (!monaco) return;
@@ -90,6 +103,27 @@ export function useScriptVariableCompletionProvider() {
 					startColumn: context.startIndex + 1,
 					endColumn: position.column,
 				};
+
+				/*
+				 * A column list and a variable list share no rules: no scope filter
+				 * applies, generators do not exist there, and the declaring
+				 * collection is the useful detail rather than a resolved value. So
+				 * it answers here rather than threading a third case through the
+				 * mapping below.
+				 */
+				if (context.scope === "data") {
+					return {
+						suggestions: (dataColumns?.columns ?? []).map((column) => ({
+							label: column,
+							kind: monaco.languages.CompletionItemKind.Field,
+							insertText: column,
+							detail: `Data column - ${dataColumns?.collectionName}`,
+							documentation: "Bound per iteration by a collection run's data file",
+							filterText: column,
+							range,
+						})),
+					};
+				}
 
 				const template = context.mode === "template";
 
@@ -145,5 +179,5 @@ export function useScriptVariableCompletionProvider() {
 		});
 
 		return () => disposable.dispose();
-	}, [monaco, getAllVariables, collectionId]);
+	}, [monaco, getAllVariables, collectionId, dataColumns]);
 }

--- a/app/src/hooks/useVariableCompletionProvider.dynamic.test.tsx
+++ b/app/src/hooks/useVariableCompletionProvider.dynamic.test.tsx
@@ -57,6 +57,13 @@ vi.mock("./useVariableResolver", () => ({
 /** The providers scope themselves to the active tab; scoping is covered by `variable-completion-scope.test.tsx`. */
 vi.mock("./useActiveCollectionId", () => ({ useActiveCollectionId: () => undefined }));
 
+/**
+ * Declared data columns are a second source in both lists (issue #600) and have
+ * their own suite - `data-column-completion.test.tsx`. Stubbed to "no contract"
+ * here, which is the state these cases were written in.
+ */
+vi.mock("./useDataContract", () => ({ useDataContract: () => undefined }));
+
 import { useVariableCompletionProvider } from "./useVariableCompletionProvider";
 
 /** Completions offered for a line whose caret sits inside an open `{{`. */

--- a/app/src/hooks/useVariableCompletionProvider.ts
+++ b/app/src/hooks/useVariableCompletionProvider.ts
@@ -29,6 +29,12 @@
  * list is globals + the whole ancestor chain + the active environment, which is
  * exactly the set `{{name}}` resolves against at compose time.
  *
+ * **Declared data columns are offered too** (issue #600). `{{data.email}}` is
+ * not a variable - the namespace is disjoint from the scopes - so the columns
+ * come from the contract the collection chain declares rather than from the
+ * resolver's map, and they are a group of their own between the variables and
+ * the generators.
+ *
  * Called once, in App - a completion provider is global per language, so one
  * registration covers every editor instance. The same shape as
  * `useScriptCompletionProvider` beside it.
@@ -39,8 +45,10 @@ import { useMonaco } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
 import { useVariableResolver } from "./useVariableResolver";
 import { useActiveCollectionId } from "./useActiveCollectionId";
+import { useDataContract } from "./useDataContract";
 import { variableCompletionContext } from "@/lib/variable-completion";
 import { DYNAMIC_VARIABLES } from "@/lib/dynamic-variables";
+import { DATA_NAMESPACE_PREFIX } from "@/lib/variable-resolution";
 
 const CLOSE_BRACES = "}}";
 
@@ -57,12 +65,27 @@ export const BODY_LANGUAGES = ["json", "plaintext", "graphql"];
 /** The resolver's own precedence, so the winning definition sorts first. */
 const SCOPE_ORDER: Record<string, number> = { environment: 0, collection: 1, global: 2 };
 
+/**
+ * Between the scopes and the generators: a declared column is workspace data
+ * like a variable, so it outranks the table that exists everywhere, but it is
+ * not a variable and must not push one down the list.
+ */
+const DATA_SORT_GROUP = 7;
+
 /** Sorts after every scope above, so a generator never outranks a real variable. */
 const DYNAMIC_SORT_GROUP = 8;
 
 export function useVariableCompletionProvider() {
 	const monaco = useMonaco();
-	const { getAllVariables } = useVariableResolver({ collectionId: useActiveCollectionId() });
+	const collectionId = useActiveCollectionId();
+	const { getAllVariables } = useVariableResolver({ collectionId });
+	/*
+	 * The declared columns of whichever collection in the chain declares them
+	 * (issue #600). Offered from the contract rather than from the variable map
+	 * because the namespace is disjoint from the scopes - `{{data.email}}` is
+	 * never a variable, so nothing in `getAllVariables` can carry it.
+	 */
+	const dataColumns = useDataContract(collectionId);
 
 	useEffect(() => {
 		if (!monaco) return;
@@ -136,6 +159,28 @@ export function useVariableCompletionProvider() {
 					});
 				}
 
+				/*
+				 * Declared columns, from the contract in scope (issue #600). They
+				 * come from the contract rather than from `variables` because the
+				 * namespace is disjoint from the scopes - no variable can carry one.
+				 */
+				for (const column of dataColumns?.columns ?? []) {
+					const name = `${DATA_NAMESPACE_PREFIX}${column}`;
+					suggestions.push({
+						label: name,
+						// `Field`, not `Variable`: the icon is the only thing in the
+						// list saying this is a column of a run's row rather than a
+						// name some scope defines.
+						kind: monaco.languages.CompletionItemKind.Field,
+						insertText: `{{${name}${closing}`,
+						detail: `Data column - ${dataColumns?.collectionName}`,
+						documentation: "Bound per iteration by a collection run's data file",
+						sortText: `${DATA_SORT_GROUP}${name}`,
+						filterText: `{{${name}`,
+						range,
+					});
+				}
+
 				return { suggestions };
 			},
 		};
@@ -144,5 +189,5 @@ export function useVariableCompletionProvider() {
 			monaco.languages.registerCompletionItemProvider(language, provider)
 		);
 		return () => disposables.forEach((d) => d.dispose());
-	}, [monaco, getAllVariables]);
+	}, [monaco, getAllVariables, dataColumns]);
 }

--- a/app/src/hooks/variable-completion-scope.test.tsx
+++ b/app/src/hooks/variable-completion-scope.test.tsx
@@ -82,6 +82,13 @@ vi.mock("./useActiveCollectionId", () => ({
 	useActiveCollectionId: () => activeCollectionId.current,
 }));
 
+/**
+ * Declared data columns are a second source in both lists (issue #600) and have
+ * their own suite - `data-column-completion.test.tsx`. Stubbed to "no contract"
+ * here, which is the state these cases were written in.
+ */
+vi.mock("./useDataContract", () => ({ useDataContract: () => undefined }));
+
 import { useVariableCompletionProvider } from "./useVariableCompletionProvider";
 import { useScriptVariableCompletionProvider } from "./useScriptVariableCompletionProvider";
 

--- a/app/src/lib/data-contract.test.ts
+++ b/app/src/lib/data-contract.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The chain rule and the three token states (issue #600).
+ *
+ * The chain rule is the part that is easy to get subtly wrong and impossible to
+ * see in a screenshot: a request in a sub-collection binds the *parent's* data
+ * when the sub-collection declares none, so the contract that validates its
+ * tokens has to be the parent's too. A painter that read only the leaf's row
+ * would paint every token in a sub-collection amber.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+	collectionsUnderContract,
+	describeDataToken,
+	resolveDataContract,
+	type ContractNode,
+} from "./data-contract";
+
+function collection(
+	id: string,
+	parentId?: string,
+	columns?: string[],
+	name = `collection-${id}`
+): ContractNode {
+	return { id, parentId, name, dataSchema: columns ? { columns } : {} };
+}
+
+describe("resolveDataContract", () => {
+	it("finds the leaf's own contract", () => {
+		const contract = resolveDataContract("leaf", [collection("leaf", undefined, ["id"])]);
+		expect(contract).toEqual({ collectionName: "collection-leaf", columns: ["id"] });
+	});
+
+	it("walks up to the nearest declaring ancestor when the leaf declares none", () => {
+		const contract = resolveDataContract("leaf", [
+			collection("root", undefined, ["id", "email"]),
+			collection("mid", "root"),
+			collection("leaf", "mid"),
+		]);
+		expect(contract?.collectionName).toBe("collection-root");
+		expect(contract?.columns).toEqual(["id", "email"]);
+	});
+
+	it("stops at the nearest one - leaf beats root", () => {
+		// The variable chain's own rule (leaf over root). A parent contract
+		// winning here would let an ancestor's stale columns invalidate a
+		// sub-collection that has since declared its own.
+		const contract = resolveDataContract("leaf", [
+			collection("root", undefined, ["id"]),
+			collection("leaf", "root", ["plan"]),
+		]);
+		expect(contract?.collectionName).toBe("collection-leaf");
+		expect(contract?.columns).toEqual(["plan"]);
+	});
+
+	it("treats a declared-then-cleared collection as transparent, not as a contract of none", () => {
+		// Clearing stores `{}`, which is how "no contract" is spelled. Reading it
+		// as an override would let it shadow a working contract above.
+		const contract = resolveDataContract("leaf", [
+			collection("root", undefined, ["id"]),
+			{ id: "leaf", parentId: "root", name: "leaf", dataSchema: { columns: [] } },
+		]);
+		expect(contract?.collectionName).toBe("collection-root");
+	});
+
+	it("is null when nothing in the chain declares one, and for no collection at all", () => {
+		expect(resolveDataContract("leaf", [collection("leaf")])).toBeNull();
+		expect(resolveDataContract(undefined, [collection("leaf", undefined, ["id"])])).toBeNull();
+	});
+
+	it("terminates on a parentId cycle", () => {
+		// The engine tolerates cycles in stored data, so an unguarded walk here
+		// is a hung window rather than a wrong answer.
+		const nodes = [collection("a", "b"), collection("b", "a", ["id"])];
+		expect(resolveDataContract("a", nodes)?.columns).toEqual(["id"]);
+	});
+});
+
+describe("collectionsUnderContract", () => {
+	const tree = [
+		collection("root", undefined, ["id"]),
+		collection("child", "root"),
+		collection("grandchild", "child"),
+		collection("owner", "root", ["other"]),
+		collection("under-owner", "owner"),
+		collection("elsewhere", undefined, ["id"]),
+	];
+
+	it("covers the whole subtree the contract binds", () => {
+		expect(collectionsUnderContract("root", tree)).toEqual(["root", "child", "grandchild"]);
+	});
+
+	it("stops at a sub-collection that declares its own, and its subtree with it", () => {
+		// `owner` answers for itself and for `under-owner` (the chain rule), so
+		// neither belongs in the root contract's audit.
+		const ids = collectionsUnderContract("root", tree);
+		expect(ids).not.toContain("owner");
+		expect(ids).not.toContain("under-owner");
+	});
+});
+
+describe("describeDataToken", () => {
+	const contract = {
+		collectionName: "Users",
+		columns: ["id", "email", "plan"],
+	};
+
+	it("says nothing new when no contract is in scope - phase 1's state, unchanged", () => {
+		const described = describeDataToken("data.email", null);
+		expect(described.tone).toBe("muted");
+		expect(described.description).toBe("Bound by the run's data file");
+	});
+
+	it("names the declaring collection for a declared column", () => {
+		const described = describeDataToken("data.email", contract);
+		expect(described.tone).toBe("muted");
+		expect(described.description).toBe("Data column - bound per iteration");
+		expect(described.note).toContain("Users");
+	});
+
+	it("warns, and prints the declared list, for a column the contract does not carry", () => {
+		const described = describeDataToken("data.emial", contract);
+		expect(described.tone).toBe("warning");
+		expect(described.description).toContain("Users");
+		expect(described.note).toBe("declared: id, email, plan");
+	});
+
+	it("leaves a name outside the namespace in the neutral state", () => {
+		// `{{data.}}` addresses no column, so it is not the namespace's business -
+		// the boundary `isDataVariableName` draws.
+		expect(describeDataToken("data.", contract).tone).toBe("muted");
+	});
+});

--- a/app/src/lib/data-contract.ts
+++ b/app/src/lib/data-contract.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Which data contract answers for a request, and what a `{{data.*}}` token
+ * should say about itself (issue #600, phase 2 of #598).
+ *
+ * Phase 1 put the columns on a collection. This is the rule that decides which
+ * collection's columns a given request is checked against: **the nearest
+ * declared ancestor, leaf to root** - the same shape as the variable chain
+ * (`useVariableResolver`: environment > collection chain leaf->root > global),
+ * so a sub-collection run recursively under a parent binds the parent's data
+ * and finds the parent's contract when it declares none of its own. The rule is
+ * documented for users in `docs/app/variable-resolution.md`.
+ *
+ * Nearest *declared*, not nearest declaring-or-not: a sub-collection that
+ * declares nothing is transparent rather than a contract of zero columns.
+ * Declaring `{}` is how a collection says "no contract" (see
+ * `hasDataContract`), and treating that as an override would make an empty
+ * declaration silently shadow a working one above it.
+ *
+ * Pure, and separate from the hook that feeds it, because three surfaces read
+ * the same answer - the token painter, the completion providers and the Data
+ * tab's audit - and a second copy of the walk is the defect this repo keeps
+ * finding.
+ */
+
+import { collectSubtreeIds, walkAncestors, type TreeNode } from "@/modules/collections/tree-utils";
+import { hasDataContract, type CollectionDataSchema, type DataContractScope } from "@/types/domain";
+import { dataColumnName } from "./variable-resolution";
+
+/** The minimum a contract walk needs from a collection row. */
+export interface ContractNode extends TreeNode {
+	name: string;
+	dataSchema?: CollectionDataSchema;
+}
+
+/**
+ * The contract in scope for `collectionId`, or null when no collection in its
+ * chain declares one.
+ *
+ * `walkAncestors` returns the chain root-first and carries the cycle guard, so
+ * this reads it backwards to get leaf-first without walking `parentId` itself.
+ */
+export function resolveDataContract(
+	collectionId: string | null | undefined,
+	collections: readonly ContractNode[]
+): DataContractScope | null {
+	if (!collectionId) return null;
+	const chain = walkAncestors(collectionId, collections);
+	for (let i = chain.length - 1; i >= 0; i--) {
+		const collection = chain[i];
+		if (!hasDataContract(collection.dataSchema)) continue;
+		return {
+			collectionName: collection.name,
+			columns: collection.dataSchema?.columns ?? [],
+		};
+	}
+	return null;
+}
+
+/**
+ * The collections whose requests `rootId`'s contract answers for: itself, plus
+ * every descendant down to - but not including - one that declares a contract
+ * of its own.
+ *
+ * The audit needs this rather than the collection's own requests, because the
+ * chain rule is what makes a `{{data.email}}` in a sub-collection *this*
+ * contract's business. Auditing the leaf alone would report a column as
+ * unreferenced while a request one level down references it, which is the
+ * reading that gets a working column deleted.
+ */
+export function collectionsUnderContract(
+	rootId: string,
+	collections: readonly ContractNode[]
+): string[] {
+	return collectSubtreeIds(
+		rootId,
+		collections,
+		(collection) => !hasDataContract(collection.dataSchema)
+	);
+}
+
+/**
+ * The three states a `{{data.*}}` token can be in, which is the whole of what
+ * phase 2 adds to the painting phase 1 left neutral.
+ *
+ * `muted` for both readable states and `warning` for the one that needs
+ * attention - never `destructive`, which is reserved for a name nothing can
+ * ever bind. An undeclared column is not broken: the contract may simply be out
+ * of date, and the run is still the user's to start.
+ */
+export type DataTokenTone = "muted" | "warning";
+
+export interface DataTokenDescription {
+	tone: DataTokenTone;
+	/** The tooltip's first line - what the token stands for. */
+	description: string;
+	/** The tooltip's trailing note - when, or against what, it is decided. */
+	note: string;
+}
+
+/** `a, b, c` - the declared list as a tooltip prints it. */
+function columnList(columns: string[]): string {
+	return columns.join(", ");
+}
+
+/**
+ * What the token says about itself, given the contract in scope.
+ *
+ * Three states, and the middle one is the reason the phase exists:
+ *
+ * - **No contract anywhere in the chain** - phase 1's neutral wording, kept
+ *   exactly: nothing has been declared, so nothing can be validated, and a
+ *   token painted amber for lacking a contract nobody wrote would be noise.
+ * - **A declared column** - informational, and the tooltip names the declaring
+ *   collection so the reader knows which Data tab owns it.
+ * - **A column no contract in scope declares** - warning. The run will send the
+ *   braces literally unless the file happens to carry the column anyway, and
+ *   the declared list is printed because the fix is nearly always a typo.
+ */
+export function describeDataToken(
+	name: string,
+	contract: DataContractScope | null | undefined
+): DataTokenDescription {
+	const column = dataColumnName(name);
+	if (!contract || !column) {
+		return {
+			tone: "muted",
+			description: "Bound by the run's data file",
+			note: "per iteration",
+		};
+	}
+	if (contract.columns.includes(column)) {
+		return {
+			tone: "muted",
+			description: "Data column - bound per iteration",
+			note: `declared in ${contract.collectionName}`,
+		};
+	}
+	return {
+		tone: "warning",
+		description: `Not a declared column of ${contract.collectionName}`,
+		note: `declared: ${columnList(contract.columns)}`,
+	};
+}

--- a/app/src/lib/script-variable-completion.test.ts
+++ b/app/src/lib/script-variable-completion.test.ts
@@ -55,6 +55,31 @@ describe("scriptVariableCompletionContext", () => {
 		}
 	});
 
+	it("reads pm.iterationData as the column source it is, not as a variable scope", () => {
+		// The row is bound from the collection's data file, so the names that
+		// belong in this argument are declared columns (issue #600). Both
+		// spellings, because a script that guards - which the surface's own docs
+		// tell it to do, since `pm.iterationData` is undefined outside a
+		// data-driven run - is the common one, and a list that vanished the
+		// moment the user guarded would teach the opposite.
+		expect(scriptVariableCompletionContext('pm.iterationData.get("')?.scope).toBe("data");
+		expect(scriptVariableCompletionContext("pm.iterationData.has('")?.scope).toBe("data");
+		expect(scriptVariableCompletionContext('pm.iterationData?.get("')?.scope).toBe("data");
+		expect(scriptVariableCompletionContext('pm.iterationData?.get("em')).toMatchObject({
+			scope: "data",
+			mode: "name",
+			query: "em",
+		});
+	});
+
+	it("offers nothing for the row's argument-less and refusing members", () => {
+		// `toObject()` takes no argument, and `set`/`unset` throw on a read-only
+		// row - a name offered inside a call that always throws teaches the wrong
+		// thing, which is the same rule `pm.variables.set` follows.
+		expect(scriptVariableCompletionContext('pm.iterationData.toObject("')).toBeNull();
+		expect(scriptVariableCompletionContext('pm.iterationData.set("')).toBeNull();
+	});
+
 	it("reports what has been typed, and where replacing it starts", () => {
 		const context = scriptVariableCompletionContext('pm.environment.get("ba');
 		expect(context).toMatchObject({ scope: "environment", mode: "name", query: "ba" });

--- a/app/src/lib/script-variable-completion.ts
+++ b/app/src/lib/script-variable-completion.ts
@@ -27,8 +27,16 @@
 
 import { variableCompletionContext } from "./variable-completion";
 
-/** Which names belong in the list. `all` is the merged read - `pm.variables`. */
-export type ScriptVariableScope = "environment" | "collection" | "global" | "all";
+/**
+ * Which names belong in the list. `all` is the merged read - `pm.variables`.
+ *
+ * `data` is the odd one and deliberately named for what it selects rather than
+ * for a scope: `pm.iterationData` reads the run's data row, so the list is the
+ * *declared columns* of the collection's contract (issue #600), not variables
+ * at all. A caller that treats it as a variable scope finds no names, because
+ * no variable ever carries one - the namespace is disjoint from the tiers.
+ */
+export type ScriptVariableScope = "environment" | "collection" | "global" | "all" | "data";
 
 export interface ScriptVariableCompletionContext {
 	scope: ScriptVariableScope;
@@ -91,6 +99,7 @@ const SCOPE_BY_ACCESSOR: Record<string, ScriptVariableScope> = {
 	globals: "global",
 	collectionVariables: "collection",
 	variables: "all",
+	iterationData: "data",
 };
 
 /**
@@ -106,14 +115,23 @@ const NAME_METHODS: Record<string, readonly string[]> = {
 	globals: ["get", "set", "has", "unset"],
 	collectionVariables: ["get", "set", "has", "unset"],
 	variables: ["get", "has"],
+	// The row is read-only - set, unset and clear throw - and `toObject` takes
+	// no argument, so `get` and `has` are the whole of it.
+	iterationData: ["get", "has"],
 };
 
 /**
  * `pm.<accessor>.<method>(` immediately before the caret's string, allowing the
  * whitespace a formatter might leave. Anchored to the end so only the *first*
  * argument matches - `set`'s second argument is a value, not a name.
+ *
+ * Optional chaining counts as the dot it is. `pm.iterationData` is `undefined`
+ * outside a data-driven run and its own documentation says to guard before
+ * calling, so `pm.iterationData?.get("` is how the call is actually written -
+ * and a completion list that vanished when the user guarded would be teaching
+ * the opposite of what the surface asks for.
  */
-const ACCESSOR_CALL = /pm\s*\.\s*(\w+)\s*\.\s*(\w+)\s*\(\s*$/;
+const ACCESSOR_CALL = /pm\s*\??\.\s*(\w+)\s*\??\.\s*(\w+)\s*\(\s*$/;
 
 /**
  * Returns null when the caret is not inside a `pm.*` variable name argument.

--- a/app/src/lib/variable-resolution.ts
+++ b/app/src/lib/variable-resolution.ts
@@ -108,6 +108,18 @@ export function isDataVariableName(name: string): boolean {
 }
 
 /**
+ * The column a `data.*` name addresses, or null for a name outside the
+ * namespace.
+ *
+ * One place strips the prefix, rather than a `slice(5)` in the painter, another
+ * in the audit and a third in the completion providers - each of which would
+ * have to re-derive the boundary `isDataVariableName` already draws.
+ */
+export function dataColumnName(name: string): string | null {
+	return isDataVariableName(name) ? name.slice(DATA_NAMESPACE_PREFIX.length) : null;
+}
+
+/**
  * Substitute `{{name}}` occurrences in one pass: the reserved `data.*`
  * namespace first (kept verbatim), then scopes, then the dynamic-variable
  * table. A defined name (even one spelled `$guid`) wins over a generator; an

--- a/app/src/modules/collections/CollectionDetail/ColumnAudit.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ColumnAudit.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The Data tab's referenced-columns panel (issue #600).
+ *
+ * `auditDataColumns` has its own suite for the bucketing; what is pinned here
+ * is the part only the component knows - **which requests are audited**. The
+ * chain rule says a contract binds every request beneath it, so a column
+ * referenced one level down is referenced, and a sub-collection that declares
+ * its own contract answers for itself. Getting that wrong prints "declared but
+ * not referenced" beside a column a run binds on every iteration, which is the
+ * reading that gets a working column deleted.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Collection, Request } from "@/types";
+
+const collections: Collection[] = [];
+const requestsByCollection = new Map<string, Request[]>();
+
+vi.mock("@/queries", () => ({
+	useCollectionsQuery: () => ({ data: collections }),
+	useMultipleCollectionRequests: (ids: string[]) => ({
+		// Mirrors the real hook: one entry per requested id, empty where the
+		// collection holds nothing.
+		requestsByCollection: new Map(ids.map((id) => [id, requestsByCollection.get(id) ?? []])),
+		isLoading: false,
+	}),
+}));
+
+const { default: ColumnAudit } = await import("./ColumnAudit");
+
+function collection(id: string, parentId?: string, columns?: string[]): Collection {
+	return {
+		id,
+		name: `Collection ${id}`,
+		description: "",
+		parentId,
+		order: 0,
+		variables: {},
+		auth: { mode: "none" },
+		preRequestScript: "",
+		postRequestScript: "",
+		dataSchema: columns ? { columns } : {},
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+	} as Collection;
+}
+
+function request(url: string): Request {
+	return {
+		id: `req_${url}`,
+		collectionId: "",
+		name: "req",
+		description: "",
+		method: "GET",
+		url,
+		params: [],
+		headers: [],
+		body: { mode: "none" },
+		bodyType: "none",
+		auth: { mode: "inherit" },
+		preRequestScript: "",
+		postRequestScript: "",
+		followRedirects: true,
+		maxRedirects: 10,
+		httpVersion: "auto",
+		stream: false,
+		order: 0,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+	} as Request;
+}
+
+function setTree(rows: Collection[], requests: Record<string, Request[]>) {
+	collections.length = 0;
+	collections.push(...rows);
+	requestsByCollection.clear();
+	for (const [id, list] of Object.entries(requests)) requestsByCollection.set(id, list);
+}
+
+/** The chips under a bucket heading, in order. */
+function bucket(label: string): string[] {
+	const heading = screen.queryByText(label);
+	if (!heading) return [];
+	const chips = heading.parentElement?.querySelectorAll("code") ?? [];
+	return [...chips].map((chip) => chip.textContent ?? "");
+}
+
+describe("which requests the audit reads", () => {
+	it("counts a reference from a sub-collection that declares nothing of its own", () => {
+		setTree([collection("root", undefined, ["id", "email"]), collection("child", "root")], {
+			root: [request("https://x/{{data.id}}")],
+			child: [request("https://x/{{data.email}}")],
+		});
+
+		render(<ColumnAudit collection={collection("root", undefined, ["id", "email"])} />);
+
+		expect(bucket("Declared and referenced")).toEqual(["id", "email"]);
+		expect(bucket("Declared but not referenced")).toEqual([]);
+	});
+
+	it("stops at a sub-collection that declares its own contract", () => {
+		// `owner` answers for its own requests now, so a token in one of them is
+		// not evidence about the root's contract.
+		setTree(
+			[
+				collection("root", undefined, ["id", "email"]),
+				collection("owner", "root", ["email"]),
+			],
+			{
+				root: [request("https://x/{{data.id}}")],
+				owner: [request("https://x/{{data.email}}")],
+			}
+		);
+
+		render(<ColumnAudit collection={collection("root", undefined, ["id", "email"])} />);
+
+		expect(bucket("Declared and referenced")).toEqual(["id"]);
+		expect(bucket("Declared but not referenced")).toEqual(["email"]);
+	});
+});
+
+describe("what the panel says", () => {
+	it("warns about a column the requests reference and the contract does not declare", () => {
+		setTree([collection("root", undefined, ["email"])], {
+			root: [request("https://x/{{data.emial}}")],
+		});
+
+		render(<ColumnAudit collection={collection("root", undefined, ["email"])} />);
+
+		expect(bucket("Referenced but not declared")).toEqual(["emial"]);
+		expect(screen.getByText(/Nothing will bind these/)).toBeTruthy();
+	});
+
+	it("labels the script scan as best-effort, always", () => {
+		// The claim the panel must never make is that it knows what a script
+		// reads: `pm.iterationData.get(key)` is unanswerable at authoring time.
+		setTree([collection("root", undefined, ["email"])], { root: [] });
+
+		render(<ColumnAudit collection={collection("root", undefined, ["email"])} />);
+
+		expect(screen.getByText(/best-effort/)).toBeTruthy();
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/ColumnAudit.tsx
+++ b/app/src/modules/collections/CollectionDetail/ColumnAudit.tsx
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * "Which declared columns do the requests actually use?" - the Data tab's
+ * referenced-columns panel (issue #600).
+ *
+ * The contract and the requests drift apart in both directions and neither is
+ * visible until a run: a renamed column leaves `{{data.emial}}` behind, and a
+ * column nobody references makes a file wider than it needs to be. The diff
+ * beside this one compares the contract to a *file*; this compares it to the
+ * requests, which needs no file at all.
+ *
+ * **Which requests.** Everything the contract answers for - this collection and
+ * every descendant down to one that declares its own - because that is the set
+ * the chain rule binds (`collectionsUnderContract`). Auditing the leaf alone
+ * would call a column unreferenced while a request one level down references
+ * it.
+ *
+ * **Scripts are labeled, never claimed.** `pm.iterationData.get(key)` computes
+ * its name at run time, so the scan finds literals only and says so.
+ */
+
+import { useMemo } from "react";
+
+import { Callout } from "@/components/shared";
+import { useCollectionsQuery, useMultipleCollectionRequests } from "@/queries";
+import { auditDataColumns } from "@/services/data-files";
+import { collectionsUnderContract } from "@/lib/data-contract";
+import type { Collection } from "@/types";
+import { SectionLabel } from "./shared";
+
+interface ColumnAuditProps {
+	/** The collection whose contract is audited. Rendered only when it has one. */
+	collection: Collection;
+}
+
+/** One column chip, in the tone its bucket carries. */
+function ColumnChip({ column, tone }: { column: string; tone: "neutral" | "warning" }) {
+	return (
+		<code
+			className={
+				tone === "warning"
+					? "rounded-sm bg-warning/10 px-1.5 py-0.5 font-mono text-[11px] text-warning-text"
+					: "rounded-sm bg-accent px-1.5 py-0.5 font-mono text-[11px]"
+			}
+		>
+			{column}
+		</code>
+	);
+}
+
+function Bucket({
+	label,
+	columns,
+	tone = "neutral",
+}: {
+	label: string;
+	columns: string[];
+	tone?: "neutral" | "warning";
+}) {
+	if (columns.length === 0) return null;
+	return (
+		<div className="space-y-1.5">
+			<p className="text-xs text-muted-foreground">{label}</p>
+			<div className="flex flex-wrap gap-1.5">
+				{columns.map((column) => (
+					<ColumnChip key={column} column={column} tone={tone} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+export default function ColumnAudit({ collection }: ColumnAuditProps) {
+	// Read from the collection rather than taken as a prop: the caller renders
+	// its own list of the same columns just above, and two sources for one list
+	// is one list that can disagree with itself.
+	const declared = useMemo(() => collection.dataSchema?.columns ?? [], [collection.dataSchema]);
+	const { data: collections = [] } = useCollectionsQuery();
+	const auditedCollectionIds = useMemo(
+		() => collectionsUnderContract(collection.id, collections),
+		[collection.id, collections]
+	);
+	const { requestsByCollection, isLoading } = useMultipleCollectionRequests(auditedCollectionIds);
+
+	const audit = useMemo(() => {
+		const requests = auditedCollectionIds.flatMap((id) => requestsByCollection.get(id) ?? []);
+		return auditDataColumns(declared, requests);
+	}, [auditedCollectionIds, requestsByCollection, declared]);
+
+	return (
+		<div>
+			<SectionLabel>Referenced columns</SectionLabel>
+			<div className="rounded-md border border-rule bg-card surface-card p-3 space-y-3">
+				{isLoading ? (
+					<p className="text-xs text-muted-foreground">Reading the requests…</p>
+				) : (
+					<>
+						<Bucket label="Declared and referenced" columns={audit.referenced} />
+						<Bucket
+							label="Referenced but not declared"
+							columns={audit.undeclared}
+							tone="warning"
+						/>
+						<Bucket label="Declared but not referenced" columns={audit.unreferenced} />
+						{audit.undeclared.length > 0 && (
+							<Callout severity="warning" title="Nothing will bind these">
+								A run leaves a token naming an undeclared column written as it
+								stands unless the file happens to carry the column anyway.
+								Re-declare from the file, or fix the token.
+							</Callout>
+						)}
+						<p className="text-[11px] text-muted-foreground">
+							{audit.inScripts.length > 0
+								? `Scripts also name ${audit.inScripts.join(", ")}. Only literal pm.iterationData.get() arguments are scanned - script usage is dynamic, so this list is best-effort.`
+								: "Only literal pm.iterationData.get() arguments are scanned - script usage is dynamic, so this list is best-effort."}
+						</p>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/src/modules/collections/CollectionDetail/DataTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/DataTab.test.tsx
@@ -45,6 +45,15 @@ vi.mock("@/queries", () => ({
 	// The picker reads the two engine caps through `useDataFileLimits`; empty
 	// entries leave it on the seeds, which no case here goes near.
 	useConfigQuery: () => ({ data: { entries: [] } }),
+	// The referenced-columns panel (issue #600) reads both of these. It has its
+	// own suite - `ColumnAudit.test.tsx` - so here it only has to render: no
+	// collections means no subtree to audit, and no requests means every
+	// declared column reports as unreferenced.
+	useCollectionsQuery: () => ({ data: [] }),
+	useMultipleCollectionRequests: () => ({
+		requestsByCollection: new Map(),
+		isLoading: false,
+	}),
 }));
 
 const { default: DataTab } = await import("./DataTab");
@@ -154,8 +163,10 @@ describe("an existing contract", () => {
 			<DataTab collection={collection({ columns: ["id", "email"], fileName: "u.csv" })} />
 		);
 
-		expect(screen.getByText("id")).toBeTruthy();
-		expect(screen.getByText("email")).toBeTruthy();
+		// `getAllByText`: the referenced-columns panel below lists the same names
+		// again, bucketed by whether a request uses them (issue #600).
+		expect(screen.getAllByText("id").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("email").length).toBeGreaterThan(0);
 		expect(screen.getByText(/Declared from u\.csv/)).toBeTruthy();
 		expect(screen.getByRole("button", { name: /re-declare/i })).toBeTruthy();
 	});

--- a/app/src/modules/collections/CollectionDetail/DataTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/DataTab.tsx
@@ -42,6 +42,7 @@ import { useDataFileStore } from "@/stores";
 import { describeDataSchemaDiff } from "@/services/data-files";
 import { hasDataContract, type Collection } from "@/types";
 import DataFilePicker, { type SelectedDataFile } from "../DataFilePicker";
+import ColumnAudit from "./ColumnAudit";
 import { InfoBanner, SaveFailed, SectionLabel } from "./shared";
 
 interface DataTabProps {
@@ -172,6 +173,13 @@ export default function DataTab({ collection }: DataTabProps) {
 					</Button>
 				)}
 			</div>
+
+			{/*
+			 * The audit needs no file - it compares the contract to the requests -
+			 * so it sits below the picker rather than inside it, and only once
+			 * there is a contract to compare against.
+			 */}
+			{declaredContract && <ColumnAudit collection={collection} />}
 
 			{declaredContract && !file && (
 				<Callout severity="info" title="Nothing to compare yet">

--- a/app/src/modules/collections/tree-utils.ts
+++ b/app/src/modules/collections/tree-utils.ts
@@ -69,6 +69,48 @@ export function isDescendant(
 }
 
 /**
+ * Every id in `rootId`'s subtree, the root first and included.
+ *
+ * `descend` is asked about each *child* before it is taken: a false answer
+ * drops that child and everything under it, which is what "this subtree answers
+ * for itself now" looks like from above (a sub-collection declaring its own
+ * data contract - see `lib/data-contract.ts`). The root is never asked; it is
+ * the subtree being described.
+ *
+ * Guarded like every walk in this module: a `parentId` cycle is reachable in
+ * stored data, and an unguarded descent is a hung window rather than a wrong
+ * answer.
+ */
+export function collectSubtreeIds<T extends TreeNode>(
+	rootId: string,
+	nodes: readonly T[],
+	descend: (node: T) => boolean = () => true
+): string[] {
+	const childrenOf = new Map<string, T[]>();
+	for (const node of nodes) {
+		if (!node.parentId) continue;
+		const siblings = childrenOf.get(node.parentId);
+		if (siblings) siblings.push(node);
+		else childrenOf.set(node.parentId, [node]);
+	}
+
+	const ids: string[] = [rootId];
+	const visited = new Set<string>([rootId]);
+	const queue = [rootId];
+	while (queue.length > 0) {
+		const current = queue.shift()!;
+		for (const child of childrenOf.get(current) ?? []) {
+			if (visited.has(child.id)) continue;
+			visited.add(child.id);
+			if (!descend(child)) continue;
+			ids.push(child.id);
+			queue.push(child.id);
+		}
+	}
+	return ids;
+}
+
+/**
  * Every entity id a cascade delete of `rootId` reaches: the collection itself,
  * its descendant folders, and the requests all of them hold.
  *

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -20,6 +20,7 @@ import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } fro
 import { RequestBuilderContext } from "./RequestBuilderContext";
 import { emptyDrafts, type BodyDrafts, type VariablesDraft } from "../utils/body-drafts";
 import { useVariableResolver, useSaveManager } from "@/hooks";
+import { resolveDataContract } from "@/lib/data-contract";
 import {
 	useCollectionAncestors,
 	useGlobalsQuery,
@@ -582,6 +583,20 @@ export default function RequestBuilderProvider({
 	 * guard changes above, this list is the next thing in the file to change.
 	 * A caller that offers a scope not in here gets a silent no-op.
 	 */
+	/**
+	 * The data contract in scope (issue #600) - the nearest declared ancestor of
+	 * this request's collection, from the collections already loaded above.
+	 *
+	 * Resolved once here and carried on the context, so `VariableInput` and the
+	 * key/value rows can paint a `{{data.*}}` token against it without reaching
+	 * for the query cache themselves. Undefined is the ordinary state: most
+	 * collections declare nothing.
+	 */
+	const dataColumns = useMemo(
+		() => resolveDataContract(collectionId, collections) ?? undefined,
+		[collectionId, collections]
+	);
+
 	const writableScopes = useMemo((): VariableScope[] => {
 		const scopes: VariableScope[] = [];
 		if (globalsData?.variables) scopes.push("global");
@@ -806,6 +821,7 @@ export default function RequestBuilderProvider({
 			getVariableOrigins,
 			updateVariable,
 			writableScopes,
+			dataColumns,
 			executeRequest,
 			saveRequest,
 			startLoadTest,
@@ -844,6 +860,7 @@ export default function RequestBuilderProvider({
 			getVariableOrigins,
 			updateVariable,
 			writableScopes,
+			dataColumns,
 			executeRequest,
 			saveRequest,
 			startLoadTest,

--- a/app/src/modules/request-builder/hooks/useVariableSupport.test.tsx
+++ b/app/src/modules/request-builder/hooks/useVariableSupport.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The builder's inputs only paint a `{{data.*}}` token against the contract if
+ * the contract actually reaches them (issue #600).
+ *
+ * This is the wiring half of the feature, and it is the half this codebase
+ * keeps losing: `VariableInput` reads `variables.dataColumns`, and every test
+ * of the painting hands it a stub, so a `useVariableSupport` that never filled
+ * the member would leave every token neutral in the running app with a green
+ * suite.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { DataContractScope } from "@/types";
+
+const contract: DataContractScope = {
+	collectionName: "Checkout flow",
+	columns: ["id", "email"],
+};
+
+/*
+ * Stable member identities, as the provider's own `useCallback`s give: the
+ * memo below can only be measured against a context that does not hand out
+ * fresh functions every render.
+ */
+const contextValue = {
+	request: { collectionId: "col_leaf" },
+	resolveString: (s: string) => s,
+	getAllVariables: () => ({}),
+	getVariableOrigins: () => [],
+	updateVariable: () => {},
+	writableScopes: [],
+	dataColumns: contract,
+};
+
+vi.mock("../context/RequestBuilderContext", () => ({
+	useRequestBuilderContext: () => contextValue,
+}));
+
+const { useVariableSupport } = await import("./useVariableSupport");
+
+describe("useVariableSupport", () => {
+	it("carries the contract in scope, so the tokens can be painted against it", () => {
+		const { result } = renderHook(() => useVariableSupport());
+		expect(result.current.dataColumns).toBe(contract);
+	});
+
+	it("keeps its identity across renders, since it is a prop on a memoised row", () => {
+		const { result, rerender } = renderHook(() => useVariableSupport());
+		const first = result.current;
+		rerender();
+		expect(result.current).toBe(first);
+	});
+});

--- a/app/src/modules/request-builder/hooks/useVariableSupport.ts
+++ b/app/src/modules/request-builder/hooks/useVariableSupport.ts
@@ -16,9 +16,15 @@
  * that shape, rather than a `useMemo` copied into each of the five call sites
  * inside the builder.
  *
- * Memoised on the three members: the object is a prop on a `memo`-wrapped row,
- * so a fresh identity each render would re-render every row of the densest
- * table in the app on every keystroke.
+ * Memoised on its members: the object is a prop on a `memo`-wrapped row, so a
+ * fresh identity each render would re-render every row of the densest table in
+ * the app on every keystroke.
+ *
+ * Every member is read straight off the context, `dataColumns` (the declared
+ * data contract, issue #600) included. The provider resolves that one from the
+ * collections it already holds rather than this hook querying for it: a token
+ * painter that reached for the query cache would need a `QueryClientProvider`
+ * above every mount of `VariableInput`, which is the coupling the prop removed.
  */
 
 import { useMemo } from "react";
@@ -26,8 +32,14 @@ import type { VariableSupport } from "@/types";
 import { useRequestBuilderContext } from "../context/RequestBuilderContext";
 
 export function useVariableSupport(): VariableSupport {
-	const { resolveString, getAllVariables, getVariableOrigins, updateVariable, writableScopes } =
-		useRequestBuilderContext();
+	const {
+		resolveString,
+		getAllVariables,
+		getVariableOrigins,
+		updateVariable,
+		writableScopes,
+		dataColumns,
+	} = useRequestBuilderContext();
 	return useMemo(
 		() => ({
 			resolveString,
@@ -35,7 +47,15 @@ export function useVariableSupport(): VariableSupport {
 			getVariableOrigins,
 			updateVariable,
 			writableScopes,
+			dataColumns,
 		}),
-		[resolveString, getAllVariables, getVariableOrigins, updateVariable, writableScopes]
+		[
+			resolveString,
+			getAllVariables,
+			getVariableOrigins,
+			updateVariable,
+			writableScopes,
+			dataColumns,
+		]
 	);
 }

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -23,6 +23,7 @@ import type { BodyDrafts, VariablesDraft } from "./utils/body-drafts";
 import type {
 	BodyMode,
 	ConsoleLogEntry,
+	DataContractScope,
 	HttpMethod,
 	HttpVersion,
 	KeyValueItem,
@@ -422,6 +423,17 @@ export interface RequestBuilderContextValue {
 	 * hand the user a Create button that does nothing.
 	 */
 	writableScopes: VariableScope[];
+	/**
+	 * The data contract in scope for this request's collection, or undefined
+	 * when nothing in its chain declares one (issue #600).
+	 *
+	 * Resolved here rather than by the inputs that paint against it: the
+	 * provider already holds the collections, and a token painter reaching for
+	 * the query cache itself would make `VariableInput` unrenderable without a
+	 * `QueryClientProvider` - the same coupling the `VariableSupport` prop
+	 * removed for the variable slice (#564).
+	 */
+	dataColumns?: DataContractScope;
 
 	// Actions
 	executeRequest: () => Promise<void>;

--- a/app/src/services/data-files/column-audit.test.ts
+++ b/app/src/services/data-files/column-audit.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import { describe, it, expect } from "vitest";
+import { auditDataColumns, type AuditableRequest } from "./column-audit";
+
+function request(overrides: Partial<AuditableRequest> = {}): AuditableRequest {
+	return {
+		url: "https://api.example.com/users",
+		params: [],
+		headers: [],
+		body: { mode: "none" },
+		preRequestScript: "",
+		postRequestScript: "",
+		...overrides,
+	};
+}
+
+describe("auditDataColumns", () => {
+	it("splits declared columns into referenced and unreferenced", () => {
+		const audit = auditDataColumns(
+			["id", "email", "plan"],
+			[request({ url: "https://api.example.com/users/{{data.id}}" })]
+		);
+		expect(audit.referenced).toEqual(["id"]);
+		expect(audit.unreferenced).toEqual(["email", "plan"]);
+		expect(audit.undeclared).toEqual([]);
+	});
+
+	it("reports a referenced column no contract declares", () => {
+		// The typo case, and the reason the panel exists: nothing says so until a
+		// run reaches the request and sends the braces literally.
+		const audit = auditDataColumns(["email"], [request({ url: "https://x/{{data.emial}}" })]);
+		expect(audit.undeclared).toEqual(["emial"]);
+		expect(audit.referenced).toEqual([]);
+	});
+
+	it("walks every field the engine's binder walks", () => {
+		// URL, params (folded into the URL by composition), header names and
+		// values, body text and form field names and values. A field missing here
+		// is a column reported unreferenced while a run binds it.
+		const declared = ["inUrl", "inParamKey", "inParamValue", "inHeaderKey", "inHeaderValue"];
+		const audit = auditDataColumns(declared, [
+			request({
+				url: "https://x/{{data.inUrl}}",
+				params: [
+					{ key: "{{data.inParamKey}}", value: "v", enabled: true },
+					{ key: "k", value: "{{data.inParamValue}}", enabled: true },
+				],
+				headers: [
+					{ key: "X-{{data.inHeaderKey}}", value: "v", enabled: true },
+					{ key: "Authorization", value: "Bearer {{data.inHeaderValue}}", enabled: true },
+				],
+			}),
+		]);
+		expect(audit.referenced).toEqual(declared);
+		expect(audit.unreferenced).toEqual([]);
+	});
+
+	it("reads a text body and both halves of a form field", () => {
+		const audit = auditDataColumns(
+			["body", "fieldKey", "fieldValue"],
+			[
+				request({ body: { mode: "json", content: '{"e":"{{data.body}}"}' } }),
+				request({
+					body: {
+						mode: "form-data",
+						fields: [
+							{ key: "{{data.fieldKey}}", value: "v", enabled: true },
+							{ key: "k", value: "{{data.fieldValue}}", enabled: true },
+						],
+					},
+				}),
+			]
+		);
+		expect(audit.unreferenced).toEqual([]);
+	});
+
+	it("deduplicates across requests and keeps the contract's order", () => {
+		const audit = auditDataColumns(
+			["id", "email"],
+			[
+				request({ url: "https://x/{{data.email}}/{{data.email}}" }),
+				request({ url: "https://x/{{data.id}}" }),
+			]
+		);
+		expect(audit.referenced).toEqual(["id", "email"]);
+	});
+
+	it("finds a literal column in a script and does not call it unreferenced", () => {
+		// The conservative direction: telling someone a column is unused when a
+		// script reads it is what gets a working column deleted.
+		const audit = auditDataColumns(
+			["plan"],
+			[request({ postRequestScript: 'const p = pm.iterationData.get("plan");' })]
+		);
+		expect(audit.inScripts).toEqual(["plan"]);
+		expect(audit.unreferenced).toEqual([]);
+		// Still not "referenced": that bucket is the verified one.
+		expect(audit.referenced).toEqual([]);
+	});
+
+	it("reads the guarded and the has() spellings a script actually uses", () => {
+		const audit = auditDataColumns(
+			["a", "b"],
+			[
+				request({
+					preRequestScript: 'pm.iterationData?.get("a");',
+					postRequestScript: "if (pm.iterationData.has('b')) {}",
+				}),
+			]
+		);
+		expect(audit.inScripts).toEqual(["a", "b"]);
+	});
+
+	it("finds nothing in a computed argument, which is what best-effort means", () => {
+		const audit = auditDataColumns(
+			["plan"],
+			[request({ postRequestScript: "const k = 'plan'; pm.iterationData.get(k);" })]
+		);
+		expect(audit.inScripts).toEqual([]);
+		expect(audit.unreferenced).toEqual(["plan"]);
+	});
+
+	it("ignores a name outside the namespace", () => {
+		const audit = auditDataColumns(
+			["id"],
+			[request({ url: "https://x/{{baseUrl}}/{{data.}}/{{data.id}}" })]
+		);
+		expect(audit.undeclared).toEqual([]);
+		expect(audit.referenced).toEqual(["id"]);
+	});
+});

--- a/app/src/services/data-files/column-audit.ts
+++ b/app/src/services/data-files/column-audit.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Referenced columns versus declared ones (issue #600).
+ *
+ * `schema-diff` beside this answers "does this *file* match the contract";
+ * this answers "do the *requests* match it", which is the question the Data tab
+ * can ask without a file at all. A `{{data.emial}}` typo is invisible until a
+ * run reaches that request, binds nothing and sends the braces literally.
+ *
+ * **Request fields are authoritative, scripts are not.** The fields walked here
+ * are exactly the ones the engine's binder walks (`scenario_data.cpp`
+ * `walk_bindable_fields`: URL, header names and values, body text, form field
+ * names and values) plus query params, which composition folds into the URL
+ * before the binder sees them. A script, by contrast, computes its column names
+ * at run time - `pm.iterationData.get(key)` is unanswerable here - so the
+ * script scan finds string literals only and is labeled as best-effort
+ * everywhere it is shown. The engine remains the run-time authority; this is
+ * authoring-time advice.
+ *
+ * The one direction the best-effort scan is allowed to move a verdict is the
+ * conservative one: a column a script literal names is not reported as
+ * unreferenced. Telling someone a column is unused when a script reads it is
+ * the worse error, and it is the one that gets a working column deleted.
+ */
+
+import { VARIABLE_PATTERN } from "@/constants/variables";
+import { dataColumnName } from "@/lib/variable-resolution";
+import type { KeyValueEntry, Request, RequestBody } from "@/types";
+
+/** What the audit needs from a request - `Request` satisfies it structurally. */
+export type AuditableRequest = Pick<
+	Request,
+	"url" | "params" | "headers" | "body" | "preRequestScript" | "postRequestScript"
+>;
+
+export interface ColumnAudit {
+	/** Declared columns a request field references. */
+	referenced: string[];
+	/** Referenced by a request field, declared by nothing - the warning bucket. */
+	undeclared: string[];
+	/** Declared, and nothing found referencing it - informational. */
+	unreferenced: string[];
+	/**
+	 * Columns named by a literal `pm.iterationData.get("x")` / `.has("x")`.
+	 * Best-effort by construction - see the module comment.
+	 */
+	inScripts: string[];
+}
+
+/**
+ * `pm.iterationData.get("column")`, and the `has` spelling, with a literal
+ * argument. Optional chaining is allowed because the surface is `undefined`
+ * outside a data-driven run and its own docs tell scripts to guard.
+ *
+ * A computed argument (`get(key)`) matches nothing here on purpose: a name this
+ * cannot see is exactly why the result is labeled rather than claimed.
+ */
+const SCRIPT_COLUMN_PATTERN = /iterationData\s*\??\.\s*(?:get|has)\s*\(\s*(['"`])([^'"`\\]*)\1/g;
+
+/** Every string a data row can bind in one request, in the binder's own order. */
+function bindableStrings(request: AuditableRequest): string[] {
+	const strings: string[] = [request.url];
+	const entries = (rows: readonly KeyValueEntry[] | undefined) => {
+		for (const row of rows ?? []) {
+			strings.push(row.key, row.value);
+		}
+	};
+	// Params are folded into the URL by composition, before the binder runs, so
+	// a token in one binds exactly as a token in the URL does.
+	entries(request.params);
+	entries(request.headers);
+	const body: RequestBody | undefined = request.body;
+	if (body && "content" in body) strings.push(body.content);
+	if (body && "fields" in body) entries(body.fields);
+	return strings;
+}
+
+/** The `data.*` columns a string references, in the order they appear. */
+function columnsIn(text: string): string[] {
+	if (!text) return [];
+	const found: string[] = [];
+	for (const match of text.matchAll(VARIABLE_PATTERN)) {
+		const column = dataColumnName(match[1].trim());
+		if (column) found.push(column);
+	}
+	return found;
+}
+
+/** The columns a script names with a literal argument. */
+function scriptColumnsIn(script: string): string[] {
+	if (!script) return [];
+	return [...script.matchAll(SCRIPT_COLUMN_PATTERN)]
+		.map((match) => match[2])
+		.filter((column) => column.length > 0);
+}
+
+/**
+ * Audit `requests` against `declared`.
+ *
+ * Column order follows the contract for the declared buckets and first
+ * appearance for the undeclared one, so the panel reads the way the Data tab
+ * above it does. Every list is deduplicated: a column referenced by nine
+ * requests is one column.
+ */
+export function auditDataColumns(
+	declared: readonly string[],
+	requests: readonly AuditableRequest[]
+): ColumnAudit {
+	const declaredSet = new Set(declared);
+	const referencedSet = new Set<string>();
+	const undeclared: string[] = [];
+	const scriptSet = new Set<string>();
+
+	for (const request of requests) {
+		for (const text of bindableStrings(request)) {
+			for (const column of columnsIn(text)) {
+				if (declaredSet.has(column)) referencedSet.add(column);
+				else if (!undeclared.includes(column)) undeclared.push(column);
+			}
+		}
+		for (const script of [request.preRequestScript, request.postRequestScript]) {
+			for (const column of scriptColumnsIn(script)) scriptSet.add(column);
+		}
+	}
+
+	return {
+		referenced: declared.filter((column) => referencedSet.has(column)),
+		undeclared,
+		unreferenced: declared.filter(
+			(column) => !referencedSet.has(column) && !scriptSet.has(column)
+		),
+		inScripts: [...scriptSet],
+	};
+}

--- a/app/src/services/data-files/index.ts
+++ b/app/src/services/data-files/index.ts
@@ -348,3 +348,4 @@ export { parseDelimited } from "./tabular";
 export { DataFileError } from "./errors";
 export { decodeDataFile, type DecodedDataFile } from "./decode";
 export { diffDataSchema, describeDataSchemaDiff, type DataSchemaDiff } from "./schema-diff";
+export { auditDataColumns, type AuditableRequest, type ColumnAudit } from "./column-audit";

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -210,6 +210,32 @@ export function hasDataContract(schema: CollectionDataSchema | undefined): boole
 	return !!schema?.columns && schema.columns.length > 0;
 }
 
+/**
+ * The contract that answers for a request, and which collection declared it
+ * (issue #600).
+ *
+ * A contract is declared on one collection but binds every request beneath it,
+ * so "which columns are in scope here" is a *chain* answer, not a row read -
+ * see `lib/data-contract.ts` for the walk and `docs/app/variable-resolution.md`
+ * for the rule. The declaring collection travels with the columns because every
+ * surface that shows them has to say where they came from: a token painted
+ * amber in a sub-collection is only actionable if the tooltip names the
+ * collection whose Data tab would fix it.
+ */
+export interface DataContractScope {
+	/**
+	 * The name of the collection that declared it - an ancestor, or the leaf.
+	 *
+	 * The name and not the id, because every consumer *shows* this: the token
+	 * tooltip, the two completion lists. An id nothing navigates by would be a
+	 * field written and never read, which is this codebase's most repeated
+	 * defect - add it back the day something links to that collection's Data tab.
+	 */
+	collectionName: string;
+	/** Declared column names, in the order the contract lists them. */
+	columns: string[];
+}
+
 /** A row the sidebar places in a tree - a {@link Collection} or a {@link Request}. */
 export interface OrderedTreeRow {
 	order?: number;

--- a/app/src/types/ui.ts
+++ b/app/src/types/ui.ts
@@ -10,7 +10,13 @@
 // preload contract. View/navigation state now lives with its owning store
 // (DrawerView in layout-store, TabType in tabs-store).
 
-import type { FormFieldEntry, ResolvedVariable, VariableOrigin, VariableScope } from "./domain";
+import type {
+	DataContractScope,
+	FormFieldEntry,
+	ResolvedVariable,
+	VariableOrigin,
+	VariableScope,
+} from "./domain";
 
 /** App theme preference. `system` follows the OS via Electron's nativeTheme. */
 export type ThemeSource = "system" | "light" | "dark";
@@ -55,6 +61,21 @@ export interface VariableSupport {
 	 * popover's scope picker cannot offer a target that does not exist.
 	 */
 	writableScopes: VariableScope[];
+	/**
+	 * The data contract in scope, when the chain declares one (issue #600).
+	 *
+	 * Optional, and unlike the members above it is optional *within* a scope
+	 * rather than with it: most collections declare no contract, and a field in
+	 * one is still fully variable-aware. Absent therefore means "nothing
+	 * declared", which is the state phase 1 left every `{{data.*}}` token in -
+	 * so a consumer that never sets it behaves exactly as it did (the #564
+	 * prop-thread contract holds).
+	 *
+	 * It sits here rather than being looked up per token because the lookup is a
+	 * chain walk against the collections cache, and the tokens are rendered
+	 * inside a `memo`-wrapped row that must not re-run one per keystroke.
+	 */
+	dataColumns?: DataContractScope;
 }
 
 /**

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -314,7 +314,7 @@ Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows n
 | Pre-request | `ScriptTab.tsx` (`kind="pre"`) | Collection pre-request script. **Autosaves** on editor blur - no Save |
 | Post-request | `ScriptTab.tsx` (`kind="post"`) | Collection post-request script. **Autosaves** on editor blur - no Save |
 | Variables | `VariablesTab.tsx` | Collection-scoped variables (count badge) |
-| Data | `DataTab.tsx` | The declared **data contract** (issue #599): pick a file, preview it, **Declare** its columns onto `collection.dataSchema`, **Clear** to reset. Declared-column count badge. Saves explicitly per action, so it holds no draft and is absent from `TABS_HOLDING_DRAFTS` |
+| Data | `DataTab.tsx` | The declared **data contract** (issue #599): pick a file, preview it, **Declare** its columns onto `collection.dataSchema`, **Clear** to reset, plus the **referenced-columns audit** (`ColumnAudit.tsx`, issue #600). Declared-column count badge. Saves explicitly per action, so it holds no draft and is absent from `TABS_HOLDING_DRAFTS` |
 
 `MockServerControl.tsx` is the header's right-hand control and the only surface that can **start** a
 mock server (issue #481 phase 2), because it is the only one holding a collection. With none running
@@ -429,6 +429,20 @@ The entry point is `modules/collections/RunCollectionDialog.tsx`, opened from a 
 `modules/collections/DataFilePicker.tsx` is the data-file half (issue #402). It reads a CSV/TSV/JSON/JSONL file through a hidden `<input type="file">` + `FileReader` - the `ImportModal` precedent, deliberately no Electron dialog IPC - decodes its **bytes** (`decodeDataFile`, so a non-UTF-8 export is named rather than parsed into question marks), parses it with `services/data-files/`, and previews the first ten rows in the `ui/table.tsx` grid. Two things it exists to say **before** the run rather than after: everything the engine would reject (a ragged row, a duplicated column, a non-object, a line that will not parse, a set over `maxScenarioDataRows` or `maxScenarioDataBytes`) is refused here with the row, line or setting named - the two caps read live through `useDataFileLimits` rather than restated, so raising one engine-side is enough, and the **resolved iteration count** is stated, because an explicit `iterations` wins over the row count - a 500-row file with Iterations left at 1 runs once. Picking a file blanks a **pristine** `1` so the field shows what will happen - pristine and not merely equal to `1`, because a deliberately typed `1` reads the same and clearing it would turn one pass into a full pass per row, and `iterations` is then omitted from the payload entirely: the engine owns "absent means one pass per row", and a client computing the row count itself would be a second copy of that rule. The previewed rows and the sent rows are one array; the parent holds the single `ParsedDataFile`. Rows are held for the run request and no longer - nothing persists them, here or engine-side. The user-facing file contract lives in [Data-Driven Runs](data-driven-runs.md).
 
 `CollectionDetail/DataTab.tsx` is the authoring-time half of the same file (issue #599, phase 1 of #598). It reuses the picker in `mode="declare"` - same parser, same refusals, no iteration arithmetic - and turns the previewed file's columns into `collection.dataSchema` through `useUpdateCollectionMutation`. **Clear** sends `dataSchema: null`, not `{}`: the engine reads absent as "keep", so a cleared contract is only expressible as a null that survives to the wire. What is stored splits by what it is true of: the **columns** are the same on every machine and ride the engine row; the file's **path** is true of one filesystem and lives in `stores/data-file-store.ts`; the **rows** are true of nobody and are stored nowhere at all. When both a contract and a file are in hand, `services/data-files/schema-diff.ts` renders the mismatch in both directions into the picker's warnings slot - shared with the run dialog, so the tab and the runner cannot describe the same file differently.
+
+`CollectionDetail/ColumnAudit.tsx` is phase 2's half of the tab (issue #600):
+the contract against the **requests** rather than against a file, so it needs no
+file at all. It buckets the declared columns into referenced, referenced-but-
+undeclared (amber, and the typo case this exists to catch) and
+declared-but-unreferenced, scanning the fields the engine's binder walks - URL,
+params, header names and values, body text, form field names and values
+(`services/data-files/column-audit.ts`). **Which requests**: everything the
+contract binds - this collection and every descendant down to one that declares
+its own (`collectionsUnderContract`) - because auditing the leaf alone would
+call a column unreferenced while a request one level down references it.
+Scripts are scanned for literal `pm.iterationData.get("column")` arguments only
+and the line says so: a computed argument is unanswerable at authoring time, and
+the engine remains the run-time authority.
 
 `RunCollectionDialog` **pre-fills from that declaration** as part of mount, which is what keeps the dialog's mount-is-reset contract intact: if `data-file-store` holds a path for this collection it re-reads it over the `dataFile:read` IPC (`electron/data-file.ts` - extension allowlist plus the engine's fetched `maxScenarioDataBytes`, the one channel on which the renderer names a path), decodes and parses it with the same modules the picker uses, and diffs it against the declared columns. A file that has moved leaves the picker empty and a sentence saying so - a warning, never a blocker, because a run without a file is a legal run and re-picking is the whole remedy.
 
@@ -1130,9 +1144,25 @@ generator table:
 
 | Token | Painted by | Looks like |
 |-------|-----------|------------|
-| `{{data.email}}` - the reserved `data.*` namespace (issue #402) | `RuntimeToken` | muted, "Bound by the run's data file / per iteration", no popover |
+| `{{data.email}}` - the reserved `data.*` namespace (issue #402) | `RuntimeToken` | muted or amber, depending on the declared contract - see below |
 | `{{merchantId}}` - a stored variable, or a name nothing defines | `EditableVariable` | accent when it resolves, **red** when it does not; hover reads, click edits or creates |
 | `{{$guid}}` - a generator | `RuntimeToken` | muted, "generated per use", no popover |
+
+**A `data.*` token has three states of its own** (issue #600), decided by
+`describeDataToken` against `VariableSupport.dataColumns` - the contract the
+collection chain declares, resolved leaf-to-root by `resolveDataContract`:
+
+| In scope | Paint | Tooltip |
+|----------|-------|---------|
+| the column is declared | muted | "Data column - bound per iteration", naming the declaring collection |
+| a contract exists, the column is not in it | **amber** (`text-warning-text`) | "Not a declared column of X", listing what is declared |
+| no contract anywhere in the chain | muted | "Bound by the run's data file / per iteration" |
+
+Amber rather than the destructive red an unknown variable gets: an undeclared
+column still binds if the run's file carries it, so this is "check this", not
+"nothing can ever answer this". None of the three offers to create a variable.
+The `{{` autocomplete offers declared columns as a **Data columns** group beside
+Variables and Dynamic.
 
 `EditableVariable` takes the scope as a **required** prop, because a token only
 renders where there is one. `RuntimeToken` serves both run-time cases - a value
@@ -1155,7 +1185,11 @@ module for its cell input is the same inversion one level down (issue #567).
 
 `VariableSupport` (in `types/ui.ts`) is the variable slice of the request-builder
 context - `resolveString`, `getAllVariables`, `getVariableOrigins`,
-`updateVariable`, `writableScopes` - as a plain object a caller hands in.
+`updateVariable`, `writableScopes` - as a plain object a caller hands in, plus
+the optional `dataColumns` (the declared data contract in scope, issue #600).
+`dataColumns` is optional *within* a scope rather than with it: absent means the
+chain declares no contract, which is every workspace that has not opened the
+Data tab.
 
 It exists because reaching for the context instead made two primitives
 unmountable anywhere but the request builder: `useRequestBuilderContext()`

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -187,6 +187,26 @@ run:
   expects, so it says which file to run with rather than only that one is
   missing.
 
+- **The builder checks your tokens.** With a contract in scope, a
+  `{{data.email}}` that names a declared column reads as one, and a
+  `{{data.emial}}` that names nothing declared is painted amber with the
+  declared list in its tooltip - so a typo shows while you are typing it rather
+  than at iteration 1. It is advice, not a refusal: an undeclared column still
+  binds if the file you run with carries it.
+- **The columns are offered while you type.** `{{data.` completes them in the
+  URL, params, headers and body, and `pm.iterationData.get("` completes them in
+  the script editors.
+- **The Data tab audits the collection.** A **Referenced columns** panel splits
+  the declared columns into the ones your requests use, the ones your requests
+  name but the contract does not declare, and the ones nothing references -
+  across this collection and every sub-collection that does not declare a
+  contract of its own. Scripts are scanned for literal
+  `pm.iterationData.get("column")` arguments only, and the panel says so: a
+  column name a script computes at run time cannot be seen from here.
+
+A sub-collection with no contract of its own uses the nearest ancestor's, the
+same way a variable defined on a parent collection is in scope below it.
+
 **Re-declare from this file** replaces the columns when your file changes shape;
 **Clear** removes the contract and forgets the remembered path.
 

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -79,6 +79,38 @@ drift on them. See
 [api-reference.md](../engine/api-reference.md#scenario-runs) for what the
 engine does with the token once a row exists.
 
+### Which contract answers for a request: nearest declared ancestor
+
+A collection can **declare** the columns its data files carry (the Data tab,
+issue #599). Which declaration applies to a given request is a chain answer, and
+the rule is the variable chain's own read backwards: **the nearest declared
+ancestor, leaf to root** (`resolveDataContract` in `lib/data-contract.ts`). A
+request in a sub-collection run recursively under a parent binds the parent's
+data, so when the sub-collection declares nothing the walk finds the parent's
+contract - and when it declares its own, its own wins, exactly as a leaf
+variable shadows an ancestor's.
+
+A collection that declared a contract and then cleared it holds `{}`, which is
+how "no contract" is spelled, so the walk treats it as transparent rather than
+as a contract of zero columns - an empty declaration cannot shadow a working one
+above it.
+
+This is what makes the token states possible: with a contract in scope,
+`{{data.email}}` is *checkable*. A declared column paints informationally, a
+column no contract in scope declares paints **amber** with the declared list in
+its tooltip, and a chain that declares nothing keeps the neutral token above. It
+is authoring-time advice in every case - the run's file is the authority, and a
+run with a mismatched file is still the user's to start. Declared columns are
+also completed: `{{data.` offers them in the request fields and the body editors,
+and `pm.iterationData.get("` offers them in the script editors (see below).
+
+The **audit** in the Data tab is the same comparison in the other direction -
+the declared columns against the tokens the collection's requests actually
+carry. See
+[COMPONENTS.md](COMPONENTS.md#shared-variable-input-componentssharedvariableinput)
+for the paint and
+[Data-Driven Runs](data-driven-runs.md) for the file itself.
+
 ---
 
 ## Layers
@@ -409,6 +441,15 @@ Three rules make the offered set match what the call can actually read:
   name the call can read. This list narrowed to the immediate collection while
   the engine did; the rule underneath is unchanged, which is that the list
   offers exactly what the call resolves.
+- **`pm.iterationData` completes columns, not variables.** The row it reads is
+  bound from the collection's data file, so the names offered inside
+  `pm.iterationData.get("…")` and `.has("…")` are the declared columns of the
+  contract in scope (issue #600) - the same list the `{{data.*}}` tokens are
+  painted against, so an editor and the builder cannot disagree. Optional
+  chaining counts as the dot it is (`pm.iterationData?.get("`), because the
+  surface is `undefined` outside a data-driven run and its own documentation
+  tells scripts to guard before calling. Nothing is offered when the chain
+  declares no contract.
 - **Generators belong to `replaceIn` alone.** `pm.variables.replaceIn` takes a
   template and interpolates it, so it gets brace-style completion including
   `{{$guid}}`; `pm.variables.get("$guid")` is not a lookup that resolves, so no


### PR DESCRIPTION
## Description

Phase 2 of #598, app-side only, against phase 1's `dataSchema` (verified still on the collection at `7c2dda0`).

**Root cause.** Phase 1 gave a collection a place to declare its columns and gave nothing a reason to read them. `isDataVariableName` had exactly one behavioural consumer (the painter that made every `{{data.*}}` token neutral), so at authoring time the app still could not tell `{{data.email}}` from `{{data.emial}}` - the first anyone hears of the typo is a run that bound nothing and sent the braces.

**Approach.** Answer "which contract applies here" once, and let three surfaces read the same answer. The rule is the variable chain's own read backwards - **the nearest declared ancestor, leaf to root** (`lib/data-contract.ts`), matching the fact that a sub-collection run recursively under a parent binds the parent's data. A collection that declared and then cleared holds `{}`, which stays *transparent* rather than shadowing a working contract above it - reading an empty declaration as an override is the subtle way this rule goes wrong. The resolved contract travels as an optional `dataColumns` member on `VariableSupport`, so a consumer that passes no scope is unchanged (the #564 contract holds).

**Alternative rejected:** having the token painter look the contract up itself, through `useDataContract` in `useVariableSupport`. It reads as the smaller wiring and it re-couples a shared primitive to the query cache - `VariableInput` would need a `QueryClientProvider` above every mount, which is exactly what the `VariableSupport` prop removed. The provider already holds `collections`, so it resolves the contract once and carries it on the context; the standalone hook stays for the two Monaco providers, which have no builder context. Also rejected: putting columns in the engine's completions table - a column is per-collection data, not part of the pm surface, and editing that table would trip the `script-typedefs.d.ts` byte-pin for a list that changes per collection.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## What landed

- **Paint, three states** (`describeDataToken`, `RuntimeToken` gains a tone): a declared column reads informationally and names the declaring collection; a column no contract in scope declares paints **amber** (`text-warning-text`) with the declared list in its tooltip; a chain that declares nothing keeps phase 1's neutral token. Never the destructive red of an unknown variable - an undeclared column still binds if the run's file carries it - and no state offers to create a variable.
- **Completions**: `{{data.` offers `data.<column>` in the plain fields (a **Data columns** group in `VariableAutocomplete`) and in the body editors; `pm.iterationData.get("` / `.has("` offers bare column names in both script editors. Optional chaining counts as the dot it is, because the surface is `undefined` outside a data-driven run and its own documentation tells scripts to guard - a list that vanished when the user guarded would teach the opposite.
- **The audit** (`ColumnAudit.tsx` + `services/data-files/column-audit.ts`): declared columns split into referenced, referenced-but-undeclared (warning) and unreferenced, over the fields the engine's binder walks. **Which requests** is the part the chain rule decides: this collection and every descendant down to one that declares its own (`collectionsUnderContract`), because auditing the leaf alone would call a column unreferenced while a request one level down references it. Scripts are scanned for literal `pm.iterationData.get("column")` arguments only and the line says so; the one direction that best-effort scan may move a verdict is the conservative one (a column a script literal names is not reported as unreferenced).

## Testing

- **App** - `pnpm test`: **454 files, 4630 tests, all passing** (447 files before; 7 new test files). `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean.
- **Docs** - `mkdocs build --strict -f .github/mkdocs.yml` clean.
- **Engine** - not built or run, and deliberately: no engine file is touched, so `ctest` could not change colour (CLAUDE.md's scale-the-verification rule). The typedef byte-pin the issue asks about is app-side (`script-typedefs.docs-compile.test.ts`) and is green in the run above.

**Mutation-checked**, each reverted and confirmed red, then restored:
- dropping `tone={data.tone}` from the token reddens 2 of the paint cases;
- making `collectionsUnderContract` an unfiltered subtree walk reddens 3 cases across the audit panel and the chain suite;
- disabling the `context.scope === "data"` branch in the script provider reddens both column-completion cases.

Coverage by surface: the chain rule (leaf beats root, parent found when leaf silent, cleared-is-transparent, `parentId` cycle terminates); the three token states through the rendered overlay, including two tokens of different kinds in one field; the audit's buckets over every binder field, dedup, the literal script scan and the computed argument it cannot see; both completion lists, their scoping to a declaring chain, and that neither bleeds into a variable accessor; and `useVariableSupport` threading the member at all - the wiring half, since every painting test hands in a stub and would stay green if the real hook never filled it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Deviations from the issue spec, each with its reason

1. **The contract is resolved in `RequestBuilderProvider`, not in `useVariableSupport`.** The issue names `useVariableSupport` as the populator, and doing the *lookup* there coupled `VariableInput` to the query cache: 37 tests across four files broke on a missing `QueryClientProvider`, which is the same defect #564 fixed. The member arrives exactly as specified; only where it is computed differs.
2. **`DataContractScope` carries the declaring collection's name, not its id.** An id would have had no reader - the tooltip and both completion lists show the name - and a written-but-never-read field is this codebase's most repeated defect. Worth adding back the day a surface links to that collection's Data tab.
3. **The audit reads the subtree, not "the collection's requests".** The issue says the latter; the chain rule makes the former the honest set, and the difference is a false "declared but not referenced" beside a column a run binds every iteration. `collectSubtreeIds` was added to `tree-utils` rather than hand-rolled, so it carries the cycle guard every walk in that module carries.
4. **`ACCESSOR_CALL` now accepts optional chaining**, which widens every `pm.*` accessor, not only `pm.iterationData`. `pm.iterationData` is `undefined` outside a data-driven run and its own docs tell scripts to guard, so `pm.iterationData?.get("` is the spelling people write; the same widening is correct for `pm.environment?.get("` and costs nothing.
5. **`docs/app/data-driven-runs.md` is updated too**, though the issue lists only `variable-resolution.md` and `COMPONENTS.md`. That page is the user-facing contract for this feature and phase 1 created it; leaving it describing a contract that only pre-fills the runner would have made it stale in the same commit that changed what declaring buys.

## Notes on scope

- No renderer state, store or query key is added. The audit reads the requests through the existing `useMultipleCollectionRequests`.
- `dataColumnName` is one exported helper in `variable-resolution.ts` rather than a `slice(5)` in the painter, the audit and both providers.
- Two existing suites gained a `useDataContract` stub and `DataTab.test.tsx` gained the two queries the panel reads; no assertion was weakened, and one `getByText` became `getAllByText` because the audit lists the same column names below the declared ones.

## Related Issues

Closes #600. Part of #598 - this unblocks #601 (phase 3).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1Na4VYNS14eSiRrJJLJGy)_