### PR TITLE
refactor(engine/inbox): delegate the live-claim slot to LiveClaimSlot

### DIFF
--- a/engine/include/vayu/http/inbox.hpp
+++ b/engine/include/vayu/http/inbox.hpp
@@ -236,25 +236,14 @@ class InboxManager {
     /**
      * Claim the single live-stream slot for an inbox.
      *
-     * Each SSE stream occupies one cpp-httplib pool thread for as long as it is
-     * open (the server uses the default task queue), so an unbounded number of
-     * watchers on one inbox is an unbounded number of parked threads.
-     *
-     * A claim held by a **provably dead** stream is taken over rather than
-     * refused (issue #506): the holder only notices its socket died when the
-     * next write fails, up to one poll interval later, so a client reconnecting
-     * inside that window used to meet a 409 - which `EventSource` treats as
-     * fatal, killing the stream for good. A holder that has not written
-     * successfully for `LIVE_CLAIM_STALE_INTERVALS` poll intervals is not
-     * writing, so its slot is given to the newcomer. Every live holder writes
-     * at least a keep-alive each interval, so a genuinely live stream is never
-     * evicted and a second concurrent watcher is still refused.
+     * The rule itself - one holder, takeover of a provably dead one, a token
+     * an evicted holder cannot act on - belongs to `LiveClaimSlot`, which each
+     * inbox owns one of; these three methods add only the inbox lookup and the
+     * window. That window is `LIVE_CLAIM_STALE_INTERVALS` of *this* inbox's
+     * poll interval, so a slower cadence widens it with no second decision.
      *
      * Returns the claim, or nullopt when the inbox does not exist or is watched
-     * by a live stream. The claim identifies *which* claim the caller holds:
-     * an evicted holder passing its own token to `note_live_write` /
-     * `release_live` is a no-op there, so it can neither keep its successor's
-     * clock alive nor release its successor's slot.
+     * by a live stream.
      */
     std::optional<LiveClaim> try_claim_live (const std::string& inbox_id);
 
@@ -264,20 +253,19 @@ class InboxManager {
      *
      * False means the claim was taken over while this stream was not writing -
      * the caller must end its stream without releasing, since the slot now
-     * belongs to someone else.
+     * belongs to someone else. A deleted inbox reports false for the same
+     * reason: there is no slot left to hold.
      */
     bool note_live_write (const std::string& inbox_id, LiveClaim claim);
 
-    /// Release @p claim's slot. A no-op when @p claim is no longer the holder.
+    /// Release @p claim's slot. A no-op when @p claim is no longer the holder,
+    /// or when the inbox is gone.
     void release_live (const std::string& inbox_id, LiveClaim claim);
 
     private:
     struct Inbox;
     std::mutex mutex_;
     std::map<std::string, std::unique_ptr<Inbox>> inboxes_;
-    /// Source of claim tokens; monotonic so a token is never reused, and
-    /// therefore never mistaken for a later claim on the same inbox.
-    LiveClaim next_live_claim_ = 1;
 
     void teardown_locked (Inbox& inbox);
 };

--- a/engine/include/vayu/http/live_claim.hpp
+++ b/engine/include/vayu/http/live_claim.hpp
@@ -45,9 +45,9 @@ using LiveClaim = std::uint64_t;
  *
  * **Not** internally synchronized: every method must be called under the lock
  * that guards the owning record, which is also the lock its other fields are
- * read under. That is why `InboxManager` (which predates this type and still
- * carries the equivalent fields inline) can adopt it without changing its
- * locking - see issue #583.
+ * read under. That is what lets an owner adopt it without changing its locking
+ * - `InboxManager` holds one per inbox under its own `mutex_`,
+ * `SseStreamContext` one under a mutex of its own.
  */
 class LiveClaimSlot {
     public:

--- a/engine/src/http/routes/inbox.cpp
+++ b/engine/src/http/routes/inbox.cpp
@@ -368,15 +368,10 @@ struct InboxManager::Inbox {
     /// Resolved once at start and const thereafter, so every capture in one
     /// inbox was truncated and retained by the same rules.
     InboxLimits limits;
-    /// One live SSE stream per inbox; see InboxManager::try_claim_live. Both
-    /// fields are guarded by InboxManager::mutex_ - every accessor locks it -
-    /// and `live_claim == 0` means unclaimed.
-    LiveClaim live_claim = 0;
-    /// When the holder last wrote to its socket successfully. A holder writes
-    /// at least a keep-alive every poll interval, so a long gap here is the
-    /// only evidence available that its socket is gone: cpp-httplib reports
-    /// that only through the next failing write.
-    std::chrono::steady_clock::time_point live_last_write{};
+    /// One live SSE stream per inbox; see InboxManager::try_claim_live. Guarded
+    /// by InboxManager::mutex_ - every accessor locks it - which is the
+    /// externally-locked-by-its-owner contract LiveClaimSlot is written to.
+    LiveClaimSlot live_claim;
 
     /// Guards `response` only. The capture handler takes this and never the
     /// manager's lock, so a teardown holding the manager lock can always join.
@@ -621,34 +616,22 @@ std::optional<LiveClaim> InboxManager::try_claim_live (const std::string& inbox_
         return std::nullopt;
     }
     Inbox& inbox = *it->second;
-    if (inbox.live_claim != 0) {
-        const auto since = std::chrono::steady_clock::now () - inbox.live_last_write;
-        if (since < live_claim_stale_after (inbox.limits)) {
-            return std::nullopt;
-        }
-        // Held by a stream that is not writing. Take it over rather than refuse:
-        // the refusal is what strands a reconnecting client (issue #506).
-    }
-    inbox.live_claim      = next_live_claim_++;
-    inbox.live_last_write = std::chrono::steady_clock::now ();
-    return inbox.live_claim;
+    return inbox.live_claim.try_claim (live_claim_stale_after (inbox.limits));
 }
 
 bool InboxManager::note_live_write (const std::string& inbox_id, LiveClaim claim) {
     std::lock_guard<std::mutex> lock (mutex_);
     auto it = inboxes_.find (inbox_id);
-    if (it == inboxes_.end () || it->second->live_claim != claim) {
+    if (it == inboxes_.end ()) {
         return false;
     }
-    it->second->live_last_write = std::chrono::steady_clock::now ();
-    return true;
+    return it->second->live_claim.note_write (claim);
 }
 
 void InboxManager::release_live (const std::string& inbox_id, LiveClaim claim) {
     std::lock_guard<std::mutex> lock (mutex_);
-    if (auto it = inboxes_.find (inbox_id);
-        it != inboxes_.end () && it->second->live_claim == claim) {
-        it->second->live_claim = 0;
+    if (auto it = inboxes_.find (inbox_id); it != inboxes_.end ()) {
+        it->second->live_claim.release (claim);
     }
 }
 


### PR DESCRIPTION
## Description

**Root cause.** The one-watcher-per-stream rule (#506 - claim the slot, take it over when the holder has provably stopped writing, never let an evicted holder release its successor's slot) existed in two implementations: inline on `InboxManager::Inbox` as `live_claim` / `live_last_write` plus the three methods over them, and in `LiveClaimSlot`, the primitive #573 extracted for `SseStreamContext`. Verified still the case at `7c2dda0` - the problem is exactly as the issue describes. CLAUDE.md's own rule is the cost: a hand-rolled copy of a primitive does not receive the primitive's fixes, so the next correction to the stale-takeover window or the never-reuse-a-token invariant lands in one of the two.

**Approach.** `Inbox` holds one `LiveClaimSlot` and the three `InboxManager` methods reduce to an inbox lookup plus a delegation under the manager's existing `mutex_`. `LiveClaimSlot` is deliberately not internally synchronized precisely for this - it is called under the lock that already guards the owning record - so the locking does not change and no second mutex appears. `live_claim_stale_after (inbox.limits)` becomes the `stale_after` argument, keeping the window derived from each inbox's own poll interval rather than fixing it at the slot.

**Alternative rejected:** giving `LiveClaimSlot` its own mutex so the delegation needs no discipline from the caller. That would take two locks per claim on the inbox path and, worse, invert the rule the type is documented around - the slot is read alongside the other fields of its owning record, and a lock of its own would make "guarded by the owner's lock" false for one field of `Inbox` and true for the rest.

**Token numbering changes, deliberately.** `next_live_claim_` was a manager-wide counter; `LiveClaimSlot`'s is per-slot, so two inboxes now both start at claim 1. Every accessor takes the inbox id first and compares the claim only within that inbox's slot, so cross-inbox uniqueness was never load-bearing. The invariant that is - never reused *within* a slot - is what `LiveClaimSlot` guarantees, and `OneLiveStreamPerInbox` still pins it.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Neither a feature nor a fix - a refactor with no behaviour change. The doc box is ticked for the three comment blocks that moved with the logic.

## Testing

- **Engine** - `python build.py -e -t && cd engine && ctest --preset linux-dev --output-on-failure`: **1613 tests, 100% passed, 0 failed**. No pre-existing failures.
- **App** - not built or run, and deliberately: no app file is touched and the issue's "App changes" section is `None - no wire shape changes`, so vitest could not change colour (CLAUDE.md's scale-the-verification rule).
- `clang-format --dry-run --Werror` clean on all three touched files.

**Mutation-checked** as the issue asks - against the existing suite rather than by adding parallel coverage, each mutation reverted and re-verified green:

1. Dropping the holder guard from `LiveClaimSlot::release` (release unconditionally) reddens `InboxListenerTest.AReconnectTakesOverAClaimThatStoppedWriting` - specifically its "the evicted holder released a slot that was no longer its own" assertion. This is the check that matters most here: the inbox's behaviour now demonstrably flows through the primitive, so a fix to the primitive reaches the inbox.
2. Replacing `live_claim_stale_after (inbox.limits)` with a fixed `0ms` reddens three - `OneLiveStreamPerInbox`, `AWritingStreamKeepsItsClaimPastTheStaleWindow` and `AReconnectTakesOverAClaimThatStoppedWriting` - so the per-inbox window is still plumbed through the delegation and not silently constant.

`DeleteLeavesAnAttachedLiveStreamNothingToStrand` covers the deleted-inbox path, which is the one branch the delegation keeps at the manager level (a missing inbox is `false` / a no-op before the slot is reached).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - none added by design; the issue asks for a mutation check against the existing suite instead
- [x] I have updated documentation

## Docs

No published doc describes the claim mechanics, so none needed updating. Three comment blocks did, all in the same commit:

- `live_claim.hpp`'s class comment drops its note that `InboxManager` predates the type and still carries the fields inline (the issue's stated docs item) and names both owners instead.
- `inbox.hpp`'s `try_claim_live` comment no longer restates the #506 rule - restating it one layer up is the same duplication in prose - and now says what these three methods add over the slot: the inbox lookup and the window. `note_live_write` / `release_live` gained the deleted-inbox case they always had and never stated.
- `Inbox`'s member comment records the locking contract the slot depends on.

`constants.hpp`'s `LIVE_CLAIM_STALE_INTERVALS` still points at `InboxManager::try_claim_live`, which is still the method that consumes it.

## Notes on scope

- No behaviour, no wire shape, no app surface changes. `sse_stream.cpp`'s use of the primitive is untouched.
- Nothing adjacent was refactored: the SSE handler in `inbox.cpp` still calls the same three methods with the same signatures.

## Related Issues

Closes #583

---
_Generated by [Claude Code](https://claude.ai/code/session_0189DJpa9oC9XLzBx8VoZHNu)_