### PR TITLE
ci(release): run release ctest from a shell step with the same stdin as PR tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -313,10 +313,18 @@ jobs:
           python -m pip install --quiet pefile
           python .github/check-windows-deps.py engine/build-release/vayu-engine.exe
 
+      # `< /dev/null` is what a shell step already gives ctest here, written
+      # down so it stays true: release.yml pins the same redirect on its own
+      # ctest steps, and the pair is the contract that the suite sees one stdin
+      # in both places. Without it the release path ran ctest under
+      # `lukka/run-cmake`, whose child gets an unwritten pipe - which is how the
+      # v0.16.0 stdin failure passed every pull request and failed on the tag.
+      # See #589; drop the redirect on one side and that class is reachable
+      # again.
       - name: Run engine tests
         working-directory: engine
         shell: bash
-        run: ctest --preset ${{ matrix.preset }} --output-on-failure --output-junit "$GITHUB_WORKSPACE/engine/test-results.xml"
+        run: ctest --preset ${{ matrix.preset }} --output-on-failure --output-junit "$GITHUB_WORKSPACE/engine/test-results.xml" < /dev/null
 
       # `always()` so a suite that ran and failed is still reported - but on its
       # own that also reports a *pass* for a job that never got as far as

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,17 +116,36 @@ jobs:
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
 
-      - name: Build and run engine tests (arm64)
+      # ctest deliberately does NOT run through `lukka/run-cmake`'s `testPreset`
+      # here, and every engine-test step in this file is split build-then-ctest
+      # for the same reason. The action spawns ctest with an unwritten pipe as
+      # stdin, while pr-tests.yml runs it from a plain shell step - so a test
+      # that reads or probes stdin behaves differently in the two places and
+      # fails *only* at release time, on a tag, with the release half-published.
+      # v0.16.0 shipped exactly that failure (fixed engine-side in #582: a
+      # bodyless POST now declares CURLOPT_POSTFIELDSIZE 0 rather than letting
+      # curl read a body from stdin). The engine is correct under any stdin now,
+      # but the environment divergence that hid it until release is what these
+      # split steps close: `< /dev/null` on both sides of CI, so the suite sees
+      # one stdin everywhere and the next stdin-touching path fails in the pull
+      # request that introduces it. See #589. Do not fold these back into the
+      # action's testPreset.
+      - name: Build engine (arm64)
         if: runner.os == 'macOS'
         uses: lukka/run-cmake@v10
         with:
           cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
           configurePreset: macos-prod-arm64
           buildPreset: macos-prod-arm64
-          testPreset: macos-prod-arm64
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
 
-      - name: Build and run engine tests (x64)
+      - name: Run engine tests (arm64)
+        if: runner.os == 'macOS'
+        working-directory: engine
+        shell: bash
+        run: ctest --preset macos-prod-arm64 --output-on-failure < /dev/null
+
+      - name: Build engine (x64)
         # Both architectures run ctest now that RateLimiterTest hits an
         # in-process mock instead of httpbin.org (issue #30). x64 still goes
         # through Rosetta on M-series runners, but the remaining tests don't
@@ -137,8 +156,13 @@ jobs:
           cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
           configurePreset: macos-prod-x64
           buildPreset: macos-prod-x64
-          testPreset: macos-prod-x64
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
+
+      - name: Run engine tests (x64)
+        if: runner.os == 'macOS'
+        working-directory: engine
+        shell: bash
+        run: ctest --preset macos-prod-x64 --output-on-failure < /dev/null
 
       - name: Create universal binary (macOS)
         if: runner.os == 'macOS'
@@ -153,15 +177,23 @@ jobs:
           lipo -info engine/build-universal/vayu-engine
           chmod +x engine/build-universal/vayu-engine
 
-      - name: Build and run engine tests (Non-macOS)
+      - name: Build engine (Non-macOS)
         if: runner.os != 'macOS'
         uses: lukka/run-cmake@v10
         with:
           cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
           configurePreset: ${{ matrix.preset }}
           buildPreset: ${{ matrix.preset }}
-          testPreset: ${{ matrix.preset }}
           configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
+
+      # `shell: bash` on Windows too, matching pr-tests.yml - the redirect has
+      # to be the same shell's, or the two paths differ again by the thing this
+      # split exists to make identical.
+      - name: Run engine tests (Non-macOS)
+        if: runner.os != 'macOS'
+        working-directory: engine
+        shell: bash
+        run: ctest --preset ${{ matrix.preset }} --output-on-failure < /dev/null
 
       - name: Install frontend dependencies
         working-directory: app


### PR DESCRIPTION
## Description

**Root cause.** Verified still present at `7c2dda0`, exactly as the issue describes. `release.yml` ran ctest *inside* `lukka/run-cmake` via `testPreset:`, and the action spawns its child with an unwritten pipe as stdin. `pr-tests.yml` runs ctest from a plain `shell: bash` step, where stdin is effectively `/dev/null`. Two environments, one suite. The engine half of the v0.16.0 failure is already fixed (#582: a bodyless POST declares `CURLOPT_POSTFIELDSIZE` 0 rather than letting curl read a body from stdin, regression-tested in `curl_transfer_test.cpp`), so the engine is correct under any stdin today - but the divergence that made that failure *release-only* was untouched and undecided. Any future engine path that reads or probes stdin passes every pull request and fails on a tag, with the release half-published.

**Approach.** Take the issue's first option - normalize on the boring stdin - and make it explicit on both sides rather than inherited on one. The three release-side `Build and run engine tests` steps split into a build-only `run-cmake` step plus a `shell: bash` ctest step, and both workflows now pin `< /dev/null` on the ctest invocation. Writing the redirect on the PR side too is the point: "the same stdin" is then a contract stated in both files, not a property of how a runner happens to wire a shell step, so removing it from either side is a visible edit rather than a silent drift back.

**Alternative rejected:** the issue's inverted option - give the PR path the same pipe-stdin shape as release, so the divergence is caught in PRs. The issue already leans against it and it is the wrong direction: a pipe stdin is the weirder of the two environments, tests should run under the ordinary one, and #582's regression test already pins the pipe case explicitly at the level that can actually assert on it. Also rejected: keeping `testPreset:` and looking for a stdin knob on `lukka/run-cmake` - the action exposes none, which is why the issue names "run ctest as a plain step" as the fallback.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

None of the four. This is CI plumbing: no engine, app or docs file is touched, and no shipped behaviour changes.

## Testing

**No suites run, deliberately.** No C++ or TypeScript file is touched, so neither ctest nor vitest could change colour - CLAUDE.md's scale-the-verification rule, and the issue's own Tests section says "None - this is workflow plumbing. The proof is the next release run."

What was checked instead, since a workflow's failure mode is a workflow mistake:

- Both files parse as YAML, and the resulting step lists were dumped and read back: three build/test pairs on the release side, one on the PR side, each ctest carrying the redirect.
- Every preset named by a new ctest step exists as a **test** preset in `engine/CMakePresets.json` (`macos-prod-arm64`, `macos-prod-x64`, and the `matrix.preset` values `linux-prod` / `windows-prod`).
- The build-only shape - `run-cmake` with `configurePreset` + `buildPreset` and no `testPreset` - is not new: `pr-tests.yml`'s `Build engine` step has run exactly that on all three OSes for months, so the release side is adopting a shape already green in CI rather than an untested one.
- `working-directory: engine` and `shell: bash` (on Windows too) match `pr-tests.yml`'s ctest step, so the two invocations differ only in `--output-junit`, which release does not publish.
- No em-dashes in either file.

The remaining acceptance criterion - the next release's engine-test step passing on a tree where PR tests passed - is observable only at the next tag, as the issue states.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - none; the issue specifies none, and the engine-side regression test from #582 already pins the code behaviour
- [x] I have updated documentation

## Docs

None, and checked rather than assumed. The issue says to touch `docs/building.md` only if it describes CI shape. It does not: its single `ctest --preset macos-prod` line (`:231`) is in a local **Usage** block for building on your own machine, alongside the `cmake --preset` / `cmake --build --preset` pair. The record lives in the workflow comments, as the issue asks.

## Notes on scope

- The comment on the release side sits above the first split pair and covers the file's convention, so the two later pairs do not each restate it; it names #582, #589 and the reason, and ends with "do not fold these back into the action's testPreset" - the specific edit that would undo this.
- Nothing adjacent was changed: the macOS universal-binary step, the Windows import-table check, the junit publishing on the PR side and its `require_tests` decision are all untouched. The macOS x64 step keeps its existing Rosetta comment, which moved with the build half it explains.
- Step renames (`Build and run engine tests (arm64)` becomes `Build engine (arm64)` + `Run engine tests (arm64)`) change check-run names on the release workflow only. Nothing keys off them - release.yml publishes no junit report and has no check-name gate.

## Related Issues

Closes #589

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5QpReaw8rdYLX2orcvGTP)_