### PR TITLE
fix(ci): make release builds reuse the vcpkg cache, and stop winget pruning

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -6,8 +6,11 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
 # Releasing Vayu
 
 1. `python build.py --bump-version patch` - updates VERSION, CMakeLists.txt,
-   vcpkg.json, package.json. (`patch` | `minor` | `major` | `x.y.z`; add
-   `--dry-run` to preview.)
+   version.hpp, package.json. (`patch` | `minor` | `major` | `x.y.z`; add
+   `--dry-run` to preview.) It deliberately does **not** touch
+   `engine/vcpkg.json`, and refuses to run if that file has grown a `version`
+   field back: CI keys the vcpkg binary cache on the manifest's hash, so a
+   version there made every release rebuild every C++ dependency from source.
 2. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a
    Changelog format, see below).
 3. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,262 @@
+name: Warm build cache
+
+# Populates the vcpkg binary cache in the **default-branch cache scope**, which
+# is the only scope a tagged release build can read.
+#
+# GitHub Actions caches are ref-scoped, and the rules are unforgiving:
+#
+#   - a run can restore caches from its own ref and from the default branch;
+#   - a run **cannot** restore a cache created for a *different tag*;
+#   - a `pull_request` run's cache is written to `refs/pull/N/merge` and can
+#     only be restored by re-runs of that same pull request - not by the base
+#     branch, not by other pull requests.
+#
+# See https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching
+# ("Restrictions for accessing a cache").
+#
+# So `pr-tests.yml`, which runs only on `pull_request`, writes caches that
+# nothing else can ever read, and `release.yml`, which runs on a tag push, can
+# read only its own (empty, first-run) tag scope plus `refs/heads/master`. Until
+# this workflow existed the *only* thing writing to the master scope was
+# `codeql.yml` - Linux-only, and deliberately sccache-less. That is why the
+# macOS and Windows release legs had never once seen a warm dependency cache,
+# and why v0.17.0 built curl, openssl and libsodium from source on all three
+# platforms. `restore-keys` does not help: it is a key-prefix fallback *within*
+# the scopes a run can already read, not a way out of the scope boundary.
+#
+# Deliberately **not** here: an engine compile to warm sccache. It would not
+# help a release. `engine/include/vayu/core/constants.hpp` builds
+# `DEFAULT_USER_AGENT` from `VAYU_VERSION_STRING`, and 46 files include that
+# header (transitively, near enough all 68 translation units), so the version
+# bump in a release commit changes the preprocessed text of essentially every
+# object file. sccache is content-addressed on exactly that text, so a release
+# commit misses by construction no matter how warm master is. The one time it
+# ever hit - 98.42% on the v0.16.0 retry - the *same tag* had already compiled
+# the *same commit* in a failed attempt an hour earlier. Until that include is
+# narrowed (move `DEFAULT_USER_AGENT` out of `constants.hpp` so a version bump
+# touches ~5 translation units instead of ~68), warming sccache here would burn
+# ~25 minutes of runner time per merge to speed up nothing.
+#
+# vcpkg, by contrast, is pure win: its ABI hash covers the ports, the triplet
+# and the compiler, and *not* the top-level manifest, so the dependency
+# archives stay valid across every release forever.
+
+on:
+  # The cache key changes only when the dependency set or the vcpkg baseline
+  # changes, so that is exactly when the archives need rebuilding.
+  push:
+    branches: [master]
+    paths:
+      - 'engine/vcpkg.json'
+      - '.github/workflows/cache-warm.yml'
+  # The guard below is cheap and catches the regressions that would quietly
+  # switch this workflow off, so it runs before they can merge.
+  pull_request:
+    branches: [master]
+    paths:
+      - 'engine/vcpkg.json'
+      - '.github/workflows/*.yml'
+      - 'build.py'
+  # Weekly, because GitHub evicts cache entries that have not been *accessed*
+  # in 7 days. Reads from pull requests normally keep the entry alive, so this
+  # is a backstop for quiet weeks rather than the main path - and a hit makes
+  # the job a ~1 minute no-op.
+  schedule:
+    - cron: '0 6 * * 1'
+  # Lets the first seeding happen on demand rather than waiting for the next
+  # dependency change.
+  workflow_dispatch:
+
+# NOT `cancel-in-progress: true`. A cancelled run saves nothing, and this
+# workflow exists solely for its save step - cancelling it is indistinguishable
+# from never running it. `codeql.yml` cancels, which is why a burst of merges
+# leaves the master scope unrefreshed; that is correct for an analysis job and
+# wrong for this one.
+concurrency:
+  group: cache-warm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # A warming job whose cache key does not match the key of the job it is
+  # warming is dead weight that still costs runner minutes, and nothing would
+  # report it - the release build would simply go on missing. So the key is
+  # asserted identical across every workflow that caches vcpkg, rather than
+  # trusted to stay in step by hand.
+  guard:
+    name: Cache key agreement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Assert every workflow shares one vcpkg cache key
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Matched as a whole `key:` line, anchored. Two traps this avoids:
+          # a token pattern like `vcpkg-[^ ]*` stops at the first space, so it
+          # would compare only `vcpkg-${{ runner.os }}-${{` and pass happily
+          # while the rest of the key diverged; and an unanchored pattern
+          # matches this step's own text in this very file, so the guard would
+          # end up grading its own source instead of the workflow.
+          #
+          # codeql.yml hardcodes `Linux` where the others interpolate
+          # `runner.os`; it only ever runs on ubuntu, so those are the same
+          # string. Normalise that one difference, require exact equality for
+          # everything else.
+          files=(release.yml pr-tests.yml codeql.yml cache-warm.yml)
+          keys=() commits=()
+          for f in "${files[@]}"; do
+            p=".github/workflows/$f"
+            key=$(grep -oE '^[[:space:]]*key: vcpkg-.*$' "$p" | head -1 \
+                  | sed -E 's/^[[:space:]]*key: //; s/vcpkg-Linux-/vcpkg-\$\{\{ runner.os \}\}-/')
+            commit=$(grep -oE "VCPKG_COMMIT: '[0-9a-f]{40}'" "$p" | head -1)
+            # A guard that matched nothing would pass forever. Fail instead.
+            if [ -z "$key" ] || [ -z "$commit" ]; then
+              echo "::error::$p has no vcpkg cache key line or no VCPKG_COMMIT - this guard just stopped guarding it." >&2
+              exit 1
+            fi
+            keys+=("$key"); commits+=("$commit")
+            echo "  $f"
+            echo "      $key"
+            echo "      $commit"
+          done
+          for i in "${!files[@]}"; do
+            if [ "${keys[$i]}" != "${keys[0]}" ] || [ "${commits[$i]}" != "${commits[0]}" ]; then
+              echo "::error::${files[$i]} disagrees with ${files[0]} on the vcpkg cache key or baseline. They must match exactly, or the warmed cache is unreachable from the build that needs it." >&2
+              exit 1
+            fi
+          done
+          echo "All ${#files[@]} workflows agree."
+
+      - name: Assert engine/vcpkg.json carries no version field
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `version` is optional for a top-level (consuming) manifest and
+          # nothing reads it - the engine's version lives in VERSION,
+          # CMakeLists.txt and version.hpp. It is excluded from vcpkg's ABI
+          # hash, so it never invalidated a real dependency; it only ever
+          # invalidated the *cache key*, which hashes the file whole. Bumping
+          # it on every release is what guaranteed a cold cache at exactly the
+          # moment a warm one mattered most. build.py enforces the same rule at
+          # bump time; this catches a hand edit.
+          if python3 -c "import json,sys; sys.exit(0 if 'version' in json.load(open('engine/vcpkg.json')) else 1)"; then
+            echo "::error file=engine/vcpkg.json::Remove the 'version' field - it is hashed into the CI vcpkg cache key, so bumping it makes every release rebuild every dependency from source." >&2
+            exit 1
+          fi
+          echo "engine/vcpkg.json has no version field."
+
+  warm:
+    name: Warm vcpkg cache on ${{ matrix.os }}
+    # Guard first: if the keys disagree, warming the wrong key helps nobody.
+    needs: guard
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            preset: linux-prod
+          - os: windows-latest
+            preset: windows-prod
+          # macOS is the one platform where the release matrix is not the same
+          # shape as the pull-request matrix: release.yml builds arm64 and x64
+          # separately and lipos them together, so both triplets' dependencies
+          # have to be in the archive for a release to be warm. Handled by the
+          # second configure step below.
+          - os: macos-latest
+            preset: macos-prod-arm64
+    timeout-minutes: 90
+    env:
+      # Keep these three byte-identical to release.yml and pr-tests.yml. The
+      # `guard` job above fails the build if they drift.
+      VCPKG_COMMIT: 'cea592f4772491abdb7c483387a59ea89889f4be'
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ninja-build \
+            build-essential \
+            pkg-config \
+            ca-certificates \
+            autoconf \
+            autoconf-archive \
+            automake \
+            libtool
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        # Same set release.yml installs: vcpkg builds libsodium from source
+        # through its autotools path and runs autoreconf first.
+        run: |
+          command -v ninja || brew install ninja
+          for pkg in autoconf autoconf-archive automake libtool; do
+            brew list --formula "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+          done
+
+      - name: Cache vcpkg compiled packages
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.vcpkg-archives
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('engine/vcpkg.json') }}-${{ env.VCPKG_COMMIT }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ hashFiles('engine/vcpkg.json') }}-
+            vcpkg-${{ runner.os }}-
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+          vcpkgGitCommitId: '${{ env.VCPKG_COMMIT }}'
+          vcpkgJsonGlob: 'engine/vcpkg.json'
+
+      # Configure only - no `buildPreset`. Configuring runs vcpkg in manifest
+      # mode, which is what populates `.vcpkg-archives`; compiling the engine
+      # afterwards would add nothing this cache can carry (see the note at the
+      # top about sccache and the version header).
+      #
+      # No sccache here either, on purpose: nothing in this job compiles engine
+      # sources, and vcpkg's own dependency builds are already cached by the
+      # archives themselves.
+      - name: Resolve dependencies
+        uses: lukka/run-cmake@v10
+        with:
+          cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
+          configurePreset: ${{ matrix.preset }}
+          configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
+
+      # The second macOS triplet. release.yml builds x64 through Rosetta and
+      # lipos it with arm64; without this the x64 half of every release still
+      # compiles its dependencies from source and macOS stays the long pole.
+      - name: Resolve dependencies (macOS x64)
+        if: runner.os == 'macOS'
+        uses: lukka/run-cmake@v10
+        with:
+          cmakeListsTxtPath: '${{ github.workspace }}/engine/CMakeLists.txt'
+          configurePreset: macos-prod-x64
+          configurePresetAdditionalArgs: "['-DVAYU_BUILD_TESTS=ON']"
+
+      - name: Report what the cache now holds
+        shell: bash
+        run: |
+          count=$(find .vcpkg-archives -type f -name '*.zip' 2>/dev/null | wc -l | tr -d ' ')
+          size=$(du -sh .vcpkg-archives 2>/dev/null | cut -f1)
+          echo "### Warmed \`${{ runner.os }}\` vcpkg cache" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Packages archived: \`${count:-0}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Archive size: \`${size:-unknown}\`" >> "$GITHUB_STEP_SUMMARY"
+          # An empty archive directory means the configure step never ran vcpkg
+          # and this workflow saved nothing useful - which would otherwise look
+          # exactly like success.
+          if [ "${count:-0}" -eq 0 ]; then
+            echo "::error::No vcpkg archives were produced - nothing was warmed." >&2
+            exit 1
+          fi

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -92,12 +92,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Matched as a whole `key:` line, anchored. Two traps this avoids:
-          # a token pattern like `vcpkg-[^ ]*` stops at the first space, so it
-          # would compare only `vcpkg-${{ runner.os }}-${{` and pass happily
-          # while the rest of the key diverged; and an unanchored pattern
-          # matches this step's own text in this very file, so the guard would
-          # end up grading its own source instead of the workflow.
+          # Matched as a whole `key:` line, anchored. Two traps this avoids: a
+          # token pattern such as "vcpkg-" followed by a non-space class stops
+          # at the first space, so it would compare only the runner-os prefix
+          # and pass happily while the rest of the key diverged; and an
+          # unanchored pattern matches this step's own text in this very file,
+          # so the guard would end up grading its own source instead of the
+          # workflows.
+          #
+          # Note also that nothing in this script may spell an opening GitHub
+          # expression delimiter in prose. This is a `run:` block, so Actions
+          # scans it for expressions and rejects the whole *file* if one is
+          # left unclosed - which is exactly how the first version of this
+          # comment took the workflow down before any job could start.
           #
           # codeql.yml hardcodes `Linux` where the others interpolate
           # `runner.os`; it only ever runs on ubuntu, so those are the same

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,12 +524,25 @@ jobs:
           # one item. Sorting one item is a no-op: `-Descending` never applies
           # and the list stays in komac's own ascending order, so slicing the
           # tail takes the newest. Upstream knows - issue #323 - and fixed it in
-          # 19e706d on 2025-05-29 by re-enumerating with `$(...)`. That fix has
-          # never been released: `v2` is the repository's only tag, it is a
-          # lightweight tag last moved 2024-11-27, and it therefore still points
-          # six months behind the fix. Anyone pinning `@v2` with a non-zero cap
-          # is silently deleting their own newest releases; at the time of
-          # writing two other packages in winget-pkgs are doing it too.
+          # 19e706d on 2025-05-29 by re-enumerating with `$(...)`; the author's
+          # own comment there describes exactly this ("versions weren't getting
+          # sorted properly due to which it was picking up most recent versions
+          # instead of the oldest versions").
+          #
+          # **Do not read that issue as "resolved, safe to re-enable."** It is
+          # closed as completed, which is the trap: the fix landed on `main` and
+          # was never released. `v2` is the repository's only tag, it is
+          # lightweight, and it still points at 4ffc788 ("docs(funding): remove
+          # ko-fi", 2024-11-27) - six months *older* than the fix. Verified, not
+          # assumed:
+          #
+          #   git merge-base --is-ancestor 19e706d v2   # non-zero: not in v2
+          #
+          # So anyone pinning `@v2` with a non-zero cap is silently deleting
+          # their own newest releases, 14 months after the bug was "fixed"; at
+          # the time of writing two other packages in winget-pkgs are doing it
+          # too. That command, against whatever ref this job pins, is the check
+          # to run before trusting the cap again.
           #
           # Options considered: pin the action to the fixed commit and keep the
           # cap, or turn the cap off. Turning it off wins for now - pinning

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,14 +492,56 @@ jobs:
           installers-regex: 'Vayu-x64\.exe$'
           release-tag: ${{ github.ref_name }}
           token: ${{ env.WINGET_TOKEN }}
-          # Keep the five newest versions in winget-pkgs and drop older ones as
-          # part of each submission. Unbounded, every version Vayu has ever
-          # released stays installable forever at an explicit `--version`, which
-          # matters here because the two oldest are not merely stale: 0.10.0
-          # ships an engine that cannot start without the Visual C++
-          # redistributable. Five keeps a real rollback window - well past the
-          # release cadence that put three versions on winget in three days -
-          # without leaving known-broken builds on offer indefinitely. The
-          # GitHub Releases page is unaffected; this prunes the winget index
-          # only.
-          max-versions-to-keep: 5
+          # `max-versions-to-keep` is deliberately UNSET (the action's default
+          # is 0 = keep everything, and its cleanup step is guarded by
+          # `if: fromJSON(inputs.max-versions-to-keep) > 0`, so unset means the
+          # pruning code never runs at all).
+          #
+          # It used to be 5, to keep a rollback window without leaving known
+          # broken builds on offer - 0.10.0 ships an engine that cannot start
+          # without the Visual C++ redistributable. That intent was fine. The
+          # implementation is not: **the action deletes the NEWEST versions
+          # instead of the oldest.**
+          #
+          # The v0.17.0 release proved it, and the damage was real rather than
+          # theoretical. With 0.10.0, 0.12.0, 0.13.0, 0.14.0, 0.15.0 and 0.16.0
+          # live, the cleanup step logged "Versions to delete: 0.15.0, 0.16.0"
+          # and filed microsoft/winget-pkgs#417718 and #417719 to remove the two
+          # most recent releases, while leaving the broken 0.10.0 exactly where
+          # it was - the precise opposite of why the cap was set. #417718 was
+          # approved and merged, so 0.15.0 is gone from winget. #417719 was
+          # stopped only because a moderator noticed it was deleting the highest
+          # version in the index and asked why.
+          #
+          # The cause is upstream and is not ours to patch. The step does:
+          #
+          #   $Versions = komac list-versions ... | ConvertFrom-Json -NoEnumerate |
+          #               Sort-Object $ToNatural -Descending
+          #   $VersionsToDelete = $Versions[(5 - 1)..($Versions.Count - 1)]
+          #
+          # `-NoEnumerate` (added in a3ac67b for issue #307) writes the array to
+          # the pipeline as a single object, so `Sort-Object` receives exactly
+          # one item. Sorting one item is a no-op: `-Descending` never applies
+          # and the list stays in komac's own ascending order, so slicing the
+          # tail takes the newest. Upstream knows - issue #323 - and fixed it in
+          # 19e706d on 2025-05-29 by re-enumerating with `$(...)`. That fix has
+          # never been released: `v2` is the repository's only tag, it is a
+          # lightweight tag last moved 2024-11-27, and it therefore still points
+          # six months behind the fix. Anyone pinning `@v2` with a non-zero cap
+          # is silently deleting their own newest releases; at the time of
+          # writing two other packages in winget-pkgs are doing it too.
+          #
+          # Options considered: pin the action to the fixed commit and keep the
+          # cap, or turn the cap off. Turning it off wins for now - pinning
+          # would put unreleased upstream `main` on the release path to buy a
+          # convenience, and a stale extra version on winget costs nothing next
+          # to a run that removes the version users are meant to install.
+          #
+          # Consequence, stated plainly rather than left to be discovered: the
+          # winget index now grows without bound, and 0.10.0 and 0.12.0 stay
+          # published until someone files a removal by hand - which is what the
+          # manual workflow in winget-publish.yml is for. Do not restore this
+          # input until upstream cuts a release containing 19e706d, or moves the
+          # `v2` tag onto it. Re-pointing this `uses:` at a newer commit is the
+          # other way, and it needs the same evidence: check that the cleanup
+          # step re-enumerates before `Sort-Object` again.

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -105,14 +105,17 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Submitting athrvk.Vayu $version from tag $tag"
 
-      # `max-versions-to-keep` is deliberately NOT set here, unlike the
-      # automatic job in release.yml which prunes to the five newest. This
-      # workflow exists partly to publish an older tag on purpose, and pruning
-      # keeps the newest N - so it could delete the very version being
-      # submitted, in the same run, and report success. Leaving it unbounded
-      # means a manual submission always does what was asked. The cap is not
-      # lost: the next tagged release prunes back to five, so the invariant is
-      # restored automatically rather than fought here.
+      # `max-versions-to-keep` is deliberately NOT set here. This workflow
+      # exists partly to publish an older tag on purpose, and pruning keeps the
+      # newest N - so it could delete the very version being submitted, in the
+      # same run, and report success.
+      #
+      # It is not set in release.yml either, as of v0.17.0: the action's
+      # pruning deletes the *newest* versions rather than the oldest, because
+      # `ConvertFrom-Json -NoEnumerate` reduces its sort to a no-op. The full
+      # account, and the condition for turning it back on, is in release.yml
+      # beside the input it applies to - so neither path prunes now, and this
+      # workflow is no longer the exception to a rule.
       - name: Submit manifest to winget-pkgs
         uses: vedantmgoyal9/winget-releaser@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,12 +399,19 @@ python build.py --bump-version 0.1.2
 python build.py --bump-version patch --dry-run
 ```
 
-This updates: `VERSION`, `engine/CMakeLists.txt`, `engine/include/vayu/version.hpp`, `engine/vcpkg.json`, `app/package.json`
+This updates: `VERSION`, `engine/CMakeLists.txt`, `engine/include/vayu/version.hpp`, `app/package.json`
+
+`engine/vcpkg.json` is deliberately **not** in that list and must not carry a
+`version` field. It is optional for a top-level manifest, nothing reads it, and
+vcpkg leaves it out of the ABI hash that names cached binary packages - but CI
+keys its vcpkg cache on `hashFiles('engine/vcpkg.json')`, so bumping it minted a
+fresh cache key on every release and made each one rebuild curl, OpenSSL and
+libsodium from source. `build.py` refuses to bump if the field reappears.
 
 2. Commit the version bump:
 
 ```bash
-git add VERSION engine/include/vayu/version.hpp engine/CMakeLists.txt engine/vcpkg.json app/package.json
+git add VERSION engine/include/vayu/version.hpp engine/CMakeLists.txt app/package.json
 git commit -m "chore(release): 0.1.2"
 ```
 

--- a/build.py
+++ b/build.py
@@ -1424,6 +1424,18 @@ def bump_version(bump_type: str, project_root: Path, dry_run: bool = False):
     print(f'  {Style.CYAN}{current_version}{Style.RESET} {Style.ARROW} {Style.GREEN}{new_version}{Style.RESET}')
     print()
 
+    # Checked before the dry-run return, not after: `--dry-run` is what a
+    # release is previewed with, so it is the run that has to report this.
+    # If someone re-adds a `version` to the manifest, every release silently
+    # goes back to a cold vcpkg cache - a ~10-minute regression per platform
+    # that nothing else in CI would report as a failure.
+    if 'version' in json.loads(engine_vcpkg_json.read_text()):
+        print_error(
+            "engine/vcpkg.json has a 'version' field. Remove it: it is optional for a\n"
+            "  top-level manifest, nothing reads it, and it is hashed into the CI vcpkg\n"
+            "  cache key - so bumping it makes every release rebuild every dependency."
+        )
+
     if dry_run:
         print(f'  {Style.YELLOW}{Style.INFO} Dry run - no changes will be made{Style.RESET}')
         print()
@@ -1440,9 +1452,15 @@ def bump_version(bump_type: str, project_root: Path, dry_run: bool = False):
     hpp_content = re.sub(r'#define VAYU_VERSION_PATCH \d+', f'#define VAYU_VERSION_PATCH {new_patch}', hpp_content)
     hpp_content = re.sub(r'#define VAYU_VERSION_STRING ".*"', f'#define VAYU_VERSION_STRING "{new_version}"', hpp_content)
 
-    vcpkg_data = json.loads(engine_vcpkg_json.read_text())
-    vcpkg_data['version'] = new_version
-
+    # engine/vcpkg.json is deliberately NOT bumped, and must not grow a
+    # `version` field again. It is optional for a top-level (consuming)
+    # manifest, nothing reads it - the engine's version comes from VERSION,
+    # CMakeLists.txt and version.hpp - and vcpkg excludes it from the ABI hash
+    # that names every cached binary package. Its only effect was on CI:
+    # release.yml, pr-tests.yml and codeql.yml all key their vcpkg binary cache
+    # on `hashFiles('engine/vcpkg.json')`, so bumping it here minted a brand-new
+    # cache key on every single release and made every release build compile
+    # curl, openssl, libsodium and the rest from source. See cache-warm.yml.
     package_data = json.loads(app_package_json.read_text())
     package_data['version'] = new_version
 
@@ -1452,7 +1470,6 @@ def bump_version(bump_type: str, project_root: Path, dry_run: bool = False):
          re.sub(r'VERSION \d+\.\d+\.\d+', f'VERSION {new_version}', engine_cmake.read_text()),
          'engine/CMakeLists.txt'),
         (engine_version_hpp, hpp_content, 'engine/include/vayu/version.hpp'),
-        (engine_vcpkg_json, json.dumps(vcpkg_data, indent=2) + '\n', 'engine/vcpkg.json'),
         (app_package_json, json.dumps(package_data, indent='\t') + '\n', 'app/package.json'),
     ]
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -325,7 +325,31 @@ The project uses GitHub Actions for automated builds:
   - Builds and publishes installers for all platforms
   - Uses CMakePresets and lukka actions for optimal caching
 
-Both workflows use the same CMakePresets as local development for consistency.
+- **Warm build cache**: `.github/workflows/cache-warm.yml`
+  - Runs on `master` when `engine/vcpkg.json` changes, weekly, or on demand
+  - Resolves the vcpkg dependencies for all three platforms so the archives
+    exist in the **default-branch cache scope**
+
+These workflows use the same CMakePresets as local development for consistency.
+
+### Why a separate cache-warming workflow
+
+GitHub Actions caches are scoped to the ref that created them. A run can
+restore caches from its own ref and from the default branch, but never from a
+different tag, and never from a pull request - a `pull_request` run writes to
+`refs/pull/N/merge`, which only re-runs of that same pull request can read.
+
+So the caches `pr-tests.yml` writes are unreachable from anywhere else, and a
+tagged release build can only inherit from `master`. Nothing was building on
+`master` except CodeQL, which is Linux-only, so the macOS and Windows release
+legs had never had a warm dependency cache at all. `cache-warm.yml` exists to
+put the vcpkg archives in that scope for every platform.
+
+All four caching workflows must key the cache identically or the warmed entry
+is unreachable from the build that needs it; `cache-warm.yml` has a guard job
+that fails if they drift. For the same reason `engine/vcpkg.json` carries no
+`version` field - the key hashes that file, so bumping it per release minted a
+new key every time and guaranteed a cold cache exactly at release.
 
 ## Resources
 

--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -1,6 +1,5 @@
 {
   "name": "vayu-engine",
-  "version": "0.17.0",
   "description": "High-performance API execution engine",
   "homepage": "https://github.com/vayu/vayu",
   "license": "MIT",


### PR DESCRIPTION
## Description

Release builds have compiled every C++ dependency from source on every platform, every time. v0.17.0 was fully cold: 0% sccache on all three legs, and a full vcpkg rebuild. Two independent causes, neither of them vcpkg's fault. Plus a third, unrelated finding in the same run: the winget step has been deleting our newest releases.

### 1. The vcpkg cache key churned at exactly the wrong moment

`build.py --bump-version` rewrote `"version"` in `engine/vcpkg.json`, and `release.yml`, `pr-tests.yml` and `codeql.yml` all key their vcpkg cache on `hashFiles('engine/vcpkg.json')`. Every release therefore minted a key nothing had ever written — `f0373199…`, `a279b515…`, `18ad63ec…`, `21d77951…`, `d5cfaa89…`, one per release.

The field was doing no work. It is optional for a top-level (consuming) manifest, nothing reads it (`VERSION`, `CMakeLists.txt` and `version.hpp` own the version), and vcpkg excludes it from the ABI hash that names cached binary packages. Removed, and `build.py` now refuses to bump if it reappears.

### 2. Nothing warmed the cache scope a release can read

Actions caches are ref-scoped: a run restores from its own ref plus the default branch — never a different tag, never a pull request's `refs/pull/N/merge`. So:

- `pr-tests.yml` runs only on `pull_request`, so everything it caches is unreachable from anywhere else, permanently.
- The only writer to the `master` scope was `codeql.yml`, which is Linux-only and deliberately sccache-less.
- **macOS and Windows release legs had therefore never had a warm dependency cache at all.**

This explains the observed history exactly. v0.16.0's retry hit `vcpkg-Linux-21d779…` because CodeQL's master run had saved it ~2 h earlier. v0.17.0 missed because CodeQL for that commit started at `03:49:13` and the tag build started at `03:49:37` — 24 seconds later, ~15 minutes before the save.

New `.github/workflows/cache-warm.yml` resolves dependencies for all three platforms on `master` (both macOS triplets, since release lipos arm64+x64), on `engine/vcpkg.json` changes, weekly, or on demand. It configures only — it does not build the engine.

It also carries a **guard job**: a warm cache under a key the release build doesn't use is dead weight that still costs runner minutes, and nothing else would report it. The guard asserts all four caching workflows share one cache key and one `VCPKG_COMMIT`, and that `engine/vcpkg.json` has no `version` field.

### 3. sccache is deliberately *not* warmed

`engine/include/vayu/core/constants.hpp` builds `DEFAULT_USER_AGENT` from `VAYU_VERSION_STRING`, and 46 files include that header — transitively near enough all 68 translation units. sccache is content-addressed on preprocessed text, so a release commit's version bump changes essentially every object file and misses by construction, however warm `master` is. The 98.42% hit on the v0.16.0 retry was the *same tag* recompiling the *same commit* after a failed first attempt, not cross-commit reuse.

Warming it would burn ~25 min of runner time per merge to speed up nothing. The cure (move `DEFAULT_USER_AGENT` out of `constants.hpp` so a bump touches ~5 TUs instead of ~68) is written down in the workflow comment for whoever picks it up.

### 4. winget: pruning disabled, because it deletes the newest versions

`vedantmgoyal9/winget-releaser@v2`'s cleanup step does:

```powershell
$Versions = komac list-versions ... | ConvertFrom-Json -NoEnumerate | Sort-Object $ToNatural -Descending
$VersionsToDelete = $Versions[(5 - 1)..($Versions.Count - 1)]
```

`-NoEnumerate` writes the array to the pipeline as a single object, so `Sort-Object` receives exactly one item. Sorting one item is a no-op: `-Descending` never applies, the list stays in komac's ascending order, and slicing the tail takes the **newest**.

v0.17.0's run logged `Versions to delete: 0.15.0, 0.16.0` and filed microsoft/winget-pkgs#417718 and #417719 against our two most recent releases, while leaving 0.10.0 — which cannot start without the Visual C++ redistributable, and was the reason the cap existed — untouched. #417718 merged, so **0.15.0 is gone from winget**. #417719 was stopped only because a moderator noticed it was removing the highest version in the index.

Upstream knows (vedantmgoyal9/winget-releaser#323) and fixed it in `19e706d` on 2025-05-29, but has never released it: `v2` is the repository's only tag, is lightweight, and last moved 2024-11-27 — six months behind the fix.

`max-versions-to-keep` is now unset. The action's default is `0`, and its cleanup step is gated on `fromJSON(inputs.max-versions-to-keep) > 0`, so the pruning code never runs. Pinning to the fixed commit was considered and rejected: it would put unreleased upstream `main` on the release path to buy a convenience.

**Stated consequence:** the winget index now grows unbounded, and 0.10.0 / 0.12.0 stay published until someone files a removal by hand (that is what `winget-publish.yml` is for).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Scaled to what the change can break — no C++ or TypeScript changed, so neither suite could go from green to red.

- **vcpkg manifest still resolves** without the `version` field: `vcpkg install --dry-run` against `engine/` produces the same 15-package plan.
- **The `version` field genuinely does not affect binary reuse** — verified rather than assumed. Dumped vcpkg's per-package ABI entries for the same manifest at `0.17.0`, at `0.18.0`, and with the field removed: **all 332 entries byte-identical in all three**. Every cached binary was always reusable; only the cache key threw them away.
- **`build.py --bump-version` mutation-checked**: bumps cleanly and no longer writes `engine/vcpkg.json` (diff touches `VERSION`, `CMakeLists.txt`, `version.hpp`, `package.json` only); re-adding the field makes it exit 1 with the explanation; removing it again restores the pass. The check sits *before* the `--dry-run` return, since `--dry-run` is how a release is previewed.
- **Guard job mutation-checked** against a scratch copy of the workflows — baseline passes, and all four mutations fail as intended: changed key in `pr-tests.yml`, changed `VCPKG_COMMIT` in `release.yml`, deleted key line in `codeql.yml` (the empty-scan case, so the guard cannot silently pass while scanning nothing), and a re-added `version` field. Baseline re-verified passing afterwards. Two real bugs were found and fixed this way: the first pattern truncated at the first space and compared only a key prefix, and it matched its own source text in `cache-warm.yml`.
- **YAML parses** for all five workflows; the guard script was extracted from the shipped YAML and executed verbatim rather than retyped.
- **`mkdocs build --strict`** passes (docs-touching change).

Not run: engine and app suites. No behaviour they cover is reachable from this diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) — guard job with mutation checks, plus the `build.py` bump guard
- [x] I have updated documentation

## Related Issues

None — surfaced while investigating why the v0.16.0 and v0.17.0 release runs had no cache hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018h1T2NJqJ9prijDCStwoL5)_