### PR TITLE
fix(app/variables): make a runtime token's tooltip reachable, and stop the script chips painting data columns red

### DIFF
--- a/app/src/components/shared/VariableInput/RuntimeToken.tsx
+++ b/app/src/components/shared/VariableInput/RuntimeToken.tsx
@@ -33,6 +33,7 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { DataTokenTone } from "@/lib/data-contract";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
 
 export interface RuntimeTokenProps {
 	/** Name as written inside the braces, e.g. `"$guid"` or `"data.email"`. */
@@ -51,12 +52,6 @@ export interface RuntimeTokenProps {
 	tone?: DataTokenTone;
 }
 
-/** The one place a tone becomes a colour, so the two states cannot drift apart. */
-const TONE_CLASS: Record<DataTokenTone, string> = {
-	muted: "text-muted-foreground",
-	warning: "text-warning-text",
-};
-
 export default function RuntimeToken({
 	name,
 	description,
@@ -67,7 +62,7 @@ export default function RuntimeToken({
 		<Tooltip>
 			<TooltipTrigger asChild>
 				<span
-					className={cn("inline rounded-md font-[inherit]", TONE_CLASS[tone])}
+					className={cn("inline rounded-md font-[inherit]", DATA_TOKEN_TONE_CLASS[tone])}
 					contentEditable={false}
 					suppressContentEditableWarning
 				>

--- a/app/src/components/shared/VariableInput/index.tsx
+++ b/app/src/components/shared/VariableInput/index.tsx
@@ -326,10 +326,51 @@ export default function VariableInput({
 		variables?.updateVariable(name, newValue, scope);
 	};
 
+	/**
+	 * Put the caret at the near edge of a token that took the click.
+	 *
+	 * A run-time token has to receive pointer events for its tooltip to open at
+	 * all (issue #604), which means the click no longer reaches the transparent
+	 * input underneath and the browser cannot place the caret from it. The token
+	 * carries the offsets of its own text in `value`, so the near edge is
+	 * recoverable: the half of the token that was clicked decides which side of
+	 * it the caret lands on.
+	 *
+	 * The edges rather than an offset *within* the token, because there is no
+	 * position inside `{{data.email}}` that means anything - it is one atom to
+	 * everything that reads it, and dropping the caret between its braces is how
+	 * a keystroke corrupts the name.
+	 */
+	const placeCaretAtTokenEdge = (token: HTMLElement, clientX: number) => {
+		const input = inputRef.current;
+		const start = Number(token.dataset.tokenStart);
+		const end = Number(token.dataset.tokenEnd);
+		if (!input || !Number.isFinite(start) || !Number.isFinite(end)) return;
+
+		const rect = token.getBoundingClientRect();
+		const caret = clientX < rect.left + rect.width / 2 ? start : end;
+		input.focus();
+		input.setSelectionRange(caret, caret);
+		setCursorPosition(caret);
+	};
+
 	// Focus the hidden input when clicking on the container (but not on variable tokens)
 	const handleContainerClick = (e: React.MouseEvent) => {
-		// Don't focus if clicking on a variable token (it has its own click handling)
 		const target = e.target as HTMLElement;
+		/*
+		 * A run-time token has no popover - a tooltip is the whole of it - so it
+		 * must not swallow the click the way an editable token does. Before
+		 * issue #604 it did neither: the overlay's `pointer-events: none` meant
+		 * the token never saw a pointer event, so the tooltip could not open,
+		 * and the early return below meant that once events were enabled the
+		 * click would land nowhere. The fix is the pair.
+		 */
+		const runtime = target.closest<HTMLElement>("[data-runtime-token]");
+		if (runtime) {
+			placeCaretAtTokenEdge(runtime, e.clientX);
+			return;
+		}
+		// Don't focus if clicking on a variable token (it has its own click handling)
 		if (target.closest("[data-variable-token]")) {
 			return;
 		}
@@ -340,7 +381,19 @@ export default function VariableInput({
 	const renderOverlayContent = () => {
 		if (!value) return null;
 
+		/*
+		 * Where each segment's text starts in `value`. The segments tile the
+		 * whole string (matches plus the slices between them), so a running
+		 * count is exact - and it is what lets a click on a run-time token put
+		 * the caret back on the right side of it, see `placeCaretAtTokenEdge`.
+		 */
+		let offset = 0;
+
 		return segments.map((seg, i) => {
+			const start = offset;
+			offset += seg.content.length;
+			const tokenBounds = { "data-token-start": start, "data-token-end": offset };
+
 			if (seg.type === "variable" && seg.varName) {
 				/*
 				 * The reserved namespace is read *before* the scopes, exactly as
@@ -358,7 +411,16 @@ export default function VariableInput({
 					 */
 					const data = describeDataToken(seg.varName, variables?.dataColumns);
 					return (
-						<span key={`${i}-${seg.varName}`} data-variable-token>
+						<span
+							key={`${i}-${seg.varName}`}
+							data-variable-token
+							data-runtime-token
+							{...tokenBounds}
+							// The tooltip is this token's entire content, and a
+							// tooltip opens on a pointer event the overlay's
+							// `pointer-events: none` never delivered (issue #604).
+							style={{ pointerEvents: "auto" }}
+						>
 							<RuntimeToken
 								name={seg.varName}
 								description={data.description}
@@ -375,7 +437,13 @@ export default function VariableInput({
 				const dynamic = varInfo ? undefined : DYNAMIC_BY_NAME.get(seg.varName);
 				if (dynamic) {
 					return (
-						<span key={`${i}-${seg.varName}`} data-variable-token>
+						<span
+							key={`${i}-${seg.varName}`}
+							data-variable-token
+							data-runtime-token
+							{...tokenBounds}
+							style={{ pointerEvents: "auto" }} // See the data.* token above.
+						>
 							<RuntimeToken
 								name={dynamic.name}
 								description={dynamic.description}

--- a/app/src/components/shared/VariableInput/runtime-token-interaction.test.tsx
+++ b/app/src/components/shared/VariableInput/runtime-token-interaction.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A run-time token's tooltip has to be reachable, and the caret it used to let
+ * through has to survive that (issue #604).
+ *
+ * The overlay paints with `pointer-events: none` so clicks fall through to the
+ * transparent input underneath and place the caret. `EditableVariable`'s wrapper
+ * re-enables them because it has a popover to open; `RuntimeToken`'s did not -
+ * so neither `{{$guid}}` nor `{{data.email}}` ever received a pointer event, and
+ * the Radix tooltip that is the token's *entire* content could never open. It
+ * had been in that state since the generator token was added.
+ *
+ * **Why the pointer-events assertion is spelled out rather than implied by the
+ * hover.** `userEvent` refuses to hover through an inherited
+ * `pointer-events: none` and would fail on the unfixed component by itself, but
+ * it is not a dependency of this app and adding one is not this fix's call.
+ * `fireEvent` dispatches whatever it is told to, CSS notwithstanding - so a
+ * hover test alone would pass on the broken component and prove nothing. The
+ * pair restores the mutation check: drop the inline style and the first test
+ * here fails; break the wiring and the rest do.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui";
+import { variableSupportStub } from "@/test/variable-support";
+import VariableInput from "./index";
+
+function renderInput(value: string, columns?: string[]) {
+	const scope = variableSupportStub(
+		{ merchantId: { value: "m_1", scope: "global" } },
+		columns ? { dataColumns: { collectionName: "Orders", columns } } : {}
+	);
+	const utils = render(
+		<TooltipProvider delayDuration={0}>
+			<VariableInput value={value} onChange={() => {}} aria-label="URL" variables={scope} />
+		</TooltipProvider>
+	);
+	const input = screen.getByLabelText("URL") as HTMLInputElement;
+	return { ...utils, input };
+}
+
+/** The wrapper that owns the pointer events, for the nth run-time token. */
+function runtimeToken(container: HTMLElement, index = 0): HTMLElement {
+	const tokens = container.querySelectorAll<HTMLElement>("[data-runtime-token]");
+	expect(tokens.length).toBeGreaterThan(index);
+	return tokens[index];
+}
+
+/** The hover Radix actually listens for on a tooltip trigger. */
+function hover(token: HTMLElement) {
+	const trigger = token.firstElementChild ?? token;
+	fireEvent.pointerMove(trigger, { pointerType: "mouse" });
+}
+
+/**
+ * jsdom has no layout, so every rect is zero and "which half was clicked" has
+ * no answer of its own. Give the token a box, then click a point inside it.
+ */
+function stubBox(token: HTMLElement, left: number, width: number) {
+	token.getBoundingClientRect = () =>
+		({
+			left,
+			width,
+			right: left + width,
+			top: 0,
+			bottom: 0,
+			height: 0,
+			x: left,
+			y: 0,
+		}) as DOMRect;
+}
+
+describe("a run-time token", () => {
+	it("receives pointer events, which is what makes its tooltip reachable at all", () => {
+		const { container } = renderInput("https://x/y?id={{$guid}}");
+
+		// The overlay stays transparent to the pointer; only the token opts back in.
+		const overlay = container.querySelector<HTMLElement>('[aria-hidden="true"]');
+		expect(overlay?.style.pointerEvents).toBe("none");
+		expect(runtimeToken(container).style.pointerEvents).toBe("auto");
+	});
+});
+
+describe("a run-time token's tooltip", () => {
+	it("opens on hover for a generator", async () => {
+		const { container } = renderInput("https://x/y?id={{$guid}}");
+
+		hover(runtimeToken(container));
+
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("generated per use");
+	});
+
+	it("opens on hover for a data column, carrying the declared contract", async () => {
+		const { container } = renderInput("https://x/{{data.email}}", ["email"]);
+
+		hover(runtimeToken(container));
+
+		const tooltip = await screen.findByRole("tooltip");
+		expect(tooltip).toHaveTextContent("Data column - bound per iteration");
+		expect(tooltip).toHaveTextContent("declared in Orders");
+	});
+
+	it("names what is declared when the column is not in the contract", async () => {
+		const { container } = renderInput("https://x/{{data.emial}}", ["email"]);
+
+		hover(runtimeToken(container));
+
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("declared: email");
+	});
+});
+
+describe("clicking a run-time token", () => {
+	it("puts the caret before it when the left half is clicked", () => {
+		const { container, input } = renderInput("ab{{$guid}}cd");
+		const token = runtimeToken(container);
+		stubBox(token, 100, 40);
+
+		fireEvent.click(token, { clientX: 105 });
+
+		// "ab" is two characters, so the token starts at 2.
+		expect(input.selectionStart).toBe(2);
+		expect(document.activeElement).toBe(input);
+	});
+
+	it("puts the caret after it when the right half is clicked", () => {
+		const { container, input } = renderInput("ab{{$guid}}cd");
+		const token = runtimeToken(container);
+		stubBox(token, 100, 40);
+
+		fireEvent.click(token, { clientX: 135 });
+
+		// `{{$guid}}` is nine characters: 2 + 9.
+		expect(input.selectionStart).toBe(11);
+	});
+
+	it("counts from the token's own place in the value, not from the first one", () => {
+		const { container, input } = renderInput("{{$guid}}-{{$timestamp}}");
+		const second = runtimeToken(container, 1);
+		stubBox(second, 200, 40);
+
+		fireEvent.click(second, { clientX: 205 });
+
+		// `{{$guid}}-` is ten characters.
+		expect(input.selectionStart).toBe(10);
+	});
+});
+
+describe("an editable token", () => {
+	it("is not treated as a run-time one - its popover still owns the click", () => {
+		const { container, input } = renderInput("{{merchantId}}");
+		expect(container.querySelector("[data-runtime-token]")).toBeNull();
+
+		const token = container.querySelector<HTMLElement>("[data-variable-token]");
+		expect(token).toBeTruthy();
+		fireEvent.click(token!);
+
+		// The container's click handler must not pull focus into the input
+		// behind a token that opened something of its own.
+		expect(document.activeElement).not.toBe(input);
+	});
+});

--- a/app/src/lib/data-token-tone.ts
+++ b/app/src/lib/data-token-tone.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The one place a `DataTokenTone` becomes a colour.
+ *
+ * It lived inside `RuntimeToken` while the overlay was the only surface that
+ * painted a `{{data.*}}` name. The script panel's "Referenced" chips paint the
+ * same names (issue #604) and were reaching for `destructive` instead, so the
+ * table moved out here rather than being copied - a hand-rolled copy of a
+ * primitive does not receive the primitive's fixes, and "which colour is this
+ * state" is exactly the fact the two surfaces must not disagree on.
+ *
+ * Its own module, not an export from `RuntimeToken.tsx`: a file that exports
+ * both a component and a value cannot be hot-reloaded
+ * (`react-refresh/only-export-components`) - the same reason `badgeVariants`
+ * sits beside `badge.tsx` rather than in it. Not in `data-contract.ts` either,
+ * which is deliberately pure logic shared with the completion providers and the
+ * audit, none of which render anything.
+ */
+
+import type { DataTokenTone } from "./data-contract";
+
+/**
+ * Foreground per tone. `warning` is amber rather than destructive red on
+ * purpose: an undeclared column still binds if the run's file carries it, so
+ * the state reads "check this", never "nothing can ever answer this".
+ */
+export const DATA_TOKEN_TONE_CLASS: Record<DataTokenTone, string> = {
+	muted: "text-muted-foreground",
+	warning: "text-warning-text",
+};

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script-data-chip.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The "Referenced:" chips must not call a data column broken (issue #604).
+ *
+ * The row chips each name the script mentions and paints it
+ * `allVariables[name] ? "secondary" : "destructive"`. A `{{data.email}}` can
+ * never be in `allVariables` - the namespace is disjoint from the scopes by
+ * design - so every data column in a script was painted the destructive red
+ * that #592 removed from the builder, in the one row that claims to say whether
+ * a name resolves.
+ *
+ * The chip reads `describeDataToken`, the same function the token in the URL bar
+ * reads, so the two surfaces cannot come to disagree about which columns a
+ * contract declares. These tests pin the three states through the panel rather
+ * than the helper: the helper was already right, and the defect was that this
+ * surface never asked it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import ScriptPanel from "./script/ScriptPanel";
+
+/** Monaco does not run under jsdom; nothing here tests the editor. */
+vi.mock("@/components/ui", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/components/ui")>()),
+	CodeEditor: () => <div data-testid="code-editor" />,
+}));
+
+/** One data column and one ordinary name nothing defines, in one script. */
+const SCRIPT = `const to = "{{data.email}}"; const k = "{{missing_key}}";`;
+
+const contract: { value: { collectionName: string; columns: string[] } | undefined } = {
+	value: undefined,
+};
+
+vi.mock("../../../context", () => ({
+	useRequestBuilderContext: () => ({
+		// `collectionId: null` keeps the inherited-scripts notice out of the tree,
+		// which would otherwise want a QueryClient. The contract this panel paints
+		// against arrives as `dataColumns`, already resolved by the provider, so
+		// the chain walk is not what these cases are about.
+		request: { preRequestScript: SCRIPT, testScript: SCRIPT, collectionId: null },
+		updateField: () => {},
+		getAllVariables: () => ({}),
+		get dataColumns() {
+			return contract.value;
+		},
+		inheritedPreScripts: [],
+		inheritedPostScripts: [],
+		legacyPreScript: "",
+		legacyPostScript: "",
+	}),
+}));
+
+/**
+ * `collectionId: null` leaves InheritedScriptsNotice nothing to inherit, but it
+ * still calls `useCollectionAncestors`, which wants a QueryClient this test does
+ * not stand up. Mocked here, not tested here - the same reason
+ * `script-panels.test.tsx` mocks it.
+ */
+vi.mock("@/queries/collections", () => ({
+	useCollectionAncestors: () => [],
+}));
+
+/** The chip carrying `name`, by its text. */
+function chipFor(container: HTMLElement, name: string): HTMLElement {
+	const chip = [...container.querySelectorAll<HTMLElement>('[data-slot="badge"]')].find(
+		(el) => el.textContent === name
+	);
+	expect(chip, `no chip for ${name}`).toBeTruthy();
+	return chip!;
+}
+
+beforeEach(() => {
+	contract.value = undefined;
+});
+
+describe("a {{data.*}} name in the referenced row", () => {
+	it("is never painted destructive, with no contract in scope", () => {
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		const chip = chipFor(container, "data.email");
+		expect(chip.className).not.toContain("bg-destructive");
+		expect(chip.className).toContain("text-muted-foreground");
+	});
+
+	it("stays informational when the contract declares the column", () => {
+		contract.value = { collectionName: "Orders", columns: ["email"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		const chip = chipFor(container, "data.email");
+		expect(chip.className).toContain("text-muted-foreground");
+		expect(chip.getAttribute("title")).toContain("declared in Orders");
+	});
+
+	it("warns - amber, not red - when no contract in scope declares it", () => {
+		contract.value = { collectionName: "Orders", columns: ["name"] };
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		const chip = chipFor(container, "data.email");
+		expect(chip.className).toContain("text-warning-text");
+		expect(chip.className).not.toContain("bg-destructive");
+		// The fix is nearly always a typo, so the chip carries the declared list.
+		expect(chip.getAttribute("title")).toContain("declared: name");
+	});
+});
+
+describe("an ordinary name nothing defines", () => {
+	it("keeps the destructive chip - that reading is still true for it", () => {
+		const { container } = render(<ScriptPanel variant="pre" />);
+
+		// Guards the scan as much as the behaviour: if no chip were rendered at
+		// all, every "not destructive" assertion above would pass vacuously.
+		expect(chipFor(container, "missing_key").className).toContain("bg-destructive");
+	});
+});

--- a/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/script/ScriptPanel.tsx
@@ -26,6 +26,10 @@ import InheritedScriptsNotice from "../InheritedScriptsNotice";
 import LegacyScriptNotice from "../LegacyScriptNotice";
 import { SCRIPT_VARIANTS, type ScriptVariant } from "./script-variants";
 import { referencedVariables } from "@/lib/referenced-variables";
+import { describeDataToken } from "@/lib/data-contract";
+import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
+import { isDataVariableName } from "@/lib/variable-resolution";
+import { cn } from "@/lib/utils";
 
 /** How many referenced names get a chip before the rest become a count. */
 const CHIP_LIMIT = 5;
@@ -81,15 +85,46 @@ export default function ScriptPanel({ variant }: ScriptPanelProps) {
 			{hasReferencedVars && (
 				<div className="flex flex-wrap items-center gap-2">
 					<span className="text-xs text-muted-foreground">Referenced:</span>
-					{usedVars.slice(0, CHIP_LIMIT).map((varName) => (
-						<Badge
-							key={varName}
-							variant={allVariables[varName] ? "secondary" : "destructive"}
-							className="font-mono text-xs"
-						>
-							{varName}
-						</Badge>
-					))}
+					{usedVars.slice(0, CHIP_LIMIT).map((varName) => {
+						/*
+						 * A `data.*` name is not a variable and never becomes one
+						 * (issue #604): the namespace is disjoint from the scopes,
+						 * so `allVariables` cannot hold it and the red chip below
+						 * was reporting "not defined" about a name for which that
+						 * is not a defect - the same paint #592 removed from the
+						 * builder, left behind here.
+						 *
+						 * It reads the contract in scope through `describeDataToken`
+						 * rather than inventing a fourth state, so a column this
+						 * chip calls declared is the one the token in the URL bar
+						 * calls declared. Muted or amber, never destructive.
+						 */
+						if (isDataVariableName(varName)) {
+							const data = describeDataToken(varName, context.dataColumns);
+							return (
+								<Badge
+									key={varName}
+									variant="chip"
+									className={cn(
+										"font-mono text-xs bg-muted",
+										DATA_TOKEN_TONE_CLASS[data.tone]
+									)}
+									title={`${data.description} - ${data.note}`}
+								>
+									{varName}
+								</Badge>
+							);
+						}
+						return (
+							<Badge
+								key={varName}
+								variant={allVariables[varName] ? "secondary" : "destructive"}
+								className="font-mono text-xs"
+							>
+								{varName}
+							</Badge>
+						);
+					})}
 					{usedVars.length > CHIP_LIMIT && (
 						<span className="text-xs text-muted-foreground">
 							+{usedVars.length - CHIP_LIMIT} more

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1170,6 +1170,26 @@ column still binds if the run's file carries it, so this is "check this", not
 The `{{` autocomplete offers declared columns as a **Data columns** group beside
 Variables and Dynamic.
 
+The same three states paint the **"Referenced:" chips** in the script panel
+(issue #604), through the same `describeDataToken` call. A `data.*` name can
+never be in `allVariables` - the namespace is disjoint from the scopes - so the
+chip row's `resolves ? secondary : destructive` rule read every data column as
+undefined, which is the paint #592 removed from the builder. `DATA_TOKEN_TONE_CLASS`
+(`lib/data-token-tone.ts`) is the one table both surfaces read, so a column the
+chip calls declared is the one the token calls declared.
+
+**A run-time token receives pointer events; the overlay does not.** The overlay
+is `pointer-events: none` so clicks reach the transparent input underneath and
+place the caret, and each token wrapper opts back in for itself -
+`EditableVariable` because it opens a popover, `RuntimeToken` because a tooltip
+*is* its whole content and cannot open without a pointer event (issue #604: it
+never had this, so neither `{{$guid}}` nor `{{data.email}}` could be hovered).
+Opting in costs the caret, so the token carries the offsets of its own text and
+a click puts the caret at the **near edge** - before the token when its left
+half was clicked, after it when its right half was. The edges, not a position
+inside: `{{data.email}}` is one atom to everything that reads it, and a caret
+between its braces is how a keystroke corrupts the name.
+
 `EditableVariable` takes the scope as a **required** prop, because a token only
 renders where there is one. `RuntimeToken` serves both run-time cases - a value
 produced when the request is sent rather than stored anywhere - and is one

--- a/docs/app/variable-resolution.md
+++ b/docs/app/variable-resolution.md
@@ -104,6 +104,11 @@ run with a mismatched file is still the user's to start. Declared columns are
 also completed: `{{data.` offers them in the request fields and the body editors,
 and `pm.iterationData.get("` offers them in the script editors (see below).
 
+The script panel's **"Referenced:" chips** read the same three states (issue
+#604). They used to paint a name red whenever no scope defined it, which for a
+`data.*` name is always - the reading that made a working column look broken in
+a row whose whole job is to say whether a name resolves.
+
 The **audit** in the Data tab is the same comparison in the other direction -
 the declared columns against the tokens the collection's requests actually
 carry. See


### PR DESCRIPTION
## Description

Both findings from #604, adjacent to #592/#603 and deliberately left out of that diff.

**Item 1 - `RuntimeToken`'s tooltip was unreachable.** `VariableInput` paints its overlay with `pointerEvents: "none"` so clicks fall through to the transparent input underneath and place the caret. `EditableVariable`'s wrapper re-enables them explicitly, because it has a popover to open. `RuntimeToken`'s did not - so neither `{{$guid}}` nor `{{data.email}}` ever received a pointer event, and the Radix tooltip that is the token's **entire** content could never open. This predates #603: the generator token has been in that state since it was added, and the data token inherited it.

**Item 2 - the script panel's "Referenced:" chips called a data column broken.** The row paints each name `allVariables[name] ? "secondary" : "destructive"`. A `data.*` name can never be in `allVariables` - the namespace is disjoint from the scopes by design - so every data column in a script got the destructive red that #592 removed from the builder, in the one row whose job is to say whether a name resolves.

**Plan (root cause, approach, rejected alternative).** The root cause of item 1 is that `pointer-events` was decided per *overlay* while the need for it is per *token*: the overlay is right to be transparent, and a token whose whole content is a tooltip cannot be. So each token wrapper opts in for itself. The approach is the pair the issue called for, because re-enabling events alone costs the caret the click used to place: the wrapper carries `data-token-start` / `data-token-end` - the offsets of its own text in `value`, from the same running count that renders the segments - and `handleContainerClick` puts the caret at the token's **near edge**, before it when the left half was clicked and after it when the right half was. The alternative I rejected is `pointerEvents: "auto"` on its own, which is the one-line version and the reason this was called "awkward rather than a one-line fix" in the issue: `handleContainerClick` early-returns on anything inside `[data-variable-token]`, so the tooltip would work and clicking the token would do nothing at all. I also rejected placing the caret at an offset *within* the token - there is no position inside `{{data.email}}` that means anything, it is one atom to everything that reads it, and a caret between its braces is how a keystroke corrupts the name.

For item 2 the root cause is a second reading of the same fact: the chip asks "does a scope define this name" of a name for which that question is not the defect. It now asks `describeDataToken` - the same call the overlay token makes, against the same `dataColumns` contract - so the chip's three states are #613's vocabulary rather than a fourth of its own. The alternative I rejected is a local `isData ? "secondary" : ...` in the panel: it fixes the colour and re-opens the drift the shared helper exists to close, since "declared" would then be decided in two places.

**The decision, recorded** (acceptance criterion 3, also written up on the issue): a `data.*` chip is **muted** when the column is declared or when no contract is in scope, **amber** when a contract in scope does not declare it, and **never destructive**. Its `title` carries the tooltip's text, so the declared list is one hover away when the column is a typo. `DATA_TOKEN_TONE_CLASS` moved out of `RuntimeToken.tsx` into `lib/data-token-tone.ts` so both surfaces read one table - its own module rather than an export from the component file, for the `react-refresh/only-export-components` reason `badgeVariants` sits beside `badge.tsx`.

**Blast radius.** `data-runtime-token` is written by `VariableInput` and read only by its own click handler; `data-token-start` / `-end` likewise. `DATA_TOKEN_TONE_CLASS` has two readers on this commit and no third copy remains (`rg TONE_CLASS` is clean). `describeDataToken` gains a caller and is otherwise untouched. `EditableVariable`'s wrapper, the overlay's own `pointer-events: none`, and every non-`data.*` chip are unchanged - the control cases below assert exactly that.

**Two corrections to the issue body, reality winning over the snapshot:**

- **The collection `ScriptTab` did not have item 2's defect.** The issue says both panels chip each name with `variant={allVariables[varName] ? "secondary" : "destructive"}`. `ScriptTab` renders every reference as `variant="chip"` with a fixed `bg-primary/10 text-variable` and consults no variable map at all, so it never painted anything red. Left alone.
- **The wider point in the issue is left open on purpose.** "The engine does not interpolate `{{}}` inside a script at all, so arguably *every* template chip in that row overstates what will happen" is true, applies equally to `{{base_url}}`, and is a change to what the row *means* rather than to a colour. Folding it in would have made this a redesign of the affordance rather than the bug fix the issue asks for. Happy to file it as its own issue with that reading written up.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `pnpm test` - **4756 tests across 459 files, all passing**, on the committed tree. No pre-existing failures.
- `pnpm type-check`, `pnpm lint` (zero warnings) and `prettier --check` on the six touched files - all clean. Only files this PR touches were formatted.
- **12 new tests in two files**, both behavioural rather than source scans, because the defect was invisible in the markup - the tooltip was right there in the tree, correctly wired, and unreachable:
  - `runtime-token-interaction.test.tsx` (8): the token receives pointer events while the overlay does not; the tooltip opens on hover for a generator and for a data column, carrying the declaring collection and, for an undeclared one, the declared list; the caret lands before the token on a left-half click and after it on a right-half click; the offsets count from the token's own place in the value rather than the first token's; and an editable token is still not treated as a run-time one.
  - `script-data-chip.test.tsx` (4): the three data-column states, plus a control asserting an ordinary undefined name **keeps** its destructive chip - which also guards the scan, since with no chips rendered every "not destructive" assertion above would pass vacuously.
- **Mutation-checked, at two grains.** Removing only the `pointerEvents: "auto"` style fails exactly 1 of the 8 (the pointer-events guard) and leaves the caret cases green. Restoring the whole bug - dropping the marker attribute too - fails **7 of 8**; the one that still passes is the editable-token control, which is correct. Making the chip branch unreachable (`if (false)`) fails **3 of 4**, the survivor again being the control.
- **Why the hover test is not a `userEvent.hover`.** The issue asks for one, and `userEvent` refuses to hover through an inherited `pointer-events: none`, which would be a clean mutation check on its own. It is not a dependency of this app (zero usages), and adding one is not a bug fix's call - so the test dispatches the `pointerMove` Radix actually listens for and the pointer-events guard is spelled out as its own assertion instead. `fireEvent` ignores CSS, so a hover test alone would have passed on the broken component and proved nothing; the pair restores the check. Say the word if you would rather take the dependency and I will swap it.

Engine suite not run: nothing under `engine/` is touched and no engine code reads any of this.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs land in the same commit: `docs/app/COMPONENTS.md` gains the pointer-events/near-edge rule and the note that the script chips read the same three states, and `docs/app/variable-resolution.md` gains the chip sentence beside the token states it already documented.

## Related Issues

Closes #604.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVRX5ZtN73kgLGDiu1MWnT)_