### PR TITLE
feat(engine/openapi): phase 1a - spec_documents storage, the collection binding, per-request operation identity, and the run stamp

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -654,7 +654,8 @@ the null-vs-absent rule.
   "parentId": null,         // Optional, null for root
   "order": 0,               // Optional, appended after siblings if omitted - see Ordering
   "variables": {},          // Optional, collection-scoped variables
-  "dataSchema": {}          // Optional, the declared data contract - see below
+  "dataSchema": {},         // Optional, the declared data contract - see below
+  "openapi": {}             // Optional, the bound spec document - see below
 }
 ```
 
@@ -677,7 +678,8 @@ its value, an explicit `null` resets it to the default.
   "parentId": null,         // Optional, null moves it to the root
   "order": 3,               // Optional; a move with no order appends - see Ordering
   "variables": null,        // Optional, null resets to {}
-  "dataSchema": null        // Optional, null clears the declared contract
+  "dataSchema": null,       // Optional, null clears the declared contract
+  "openapi": null           // Optional, null unbinds the spec document
 }
 ```
 
@@ -721,6 +723,28 @@ that writes nothing.
 The schema is stored; the file's **rows are not**, anywhere, and neither is its
 path - it is machine-local and stays app-side. See
 [Data-driven runs](../app/data-driven-runs.md).
+
+**`openapi` (both verbs, and `POST /import/apply`):** the OpenAPI document this
+collection is bound to (issue #637).
+
+```json
+{"specId":"spec_3f2b1c9a-...","specHash":"<hex sha256>","syncedAt":1700000000000}
+```
+
+`{}` means bound to nothing, and is what an absent field on create and an
+explicit `null` on update both resolve to - so **unbinding is
+`{"openapi": null}`** rather than a verb of its own. A present value must be an
+object (`400` otherwise, like `variables` and `dataSchema`). A *non-empty* one is
+a binding and is validated further: `specId` must be a non-empty string that
+resolves to a stored [spec document](#specs) (`400` naming the id otherwise),
+`specHash` a string, `syncedAt` a number.
+
+`specHash` records which *version* of the document the collection was last synced
+to; a scenario run of a bound collection stamps both values into its snapshot and
+report (see [GET /runs/:runId/report](#get-runsrunidreport)).
+
+Deleting the document is refused while a collection binds it - the binding is
+never cascaded away, see [DELETE /specs/:id](#delete-specsid).
 
 ### DELETE /collections/:id
 
@@ -853,8 +877,9 @@ the null-vs-absent rule.
   "maxRedirects": 10,                // Optional, hops while following, clamped to 0..100. Default 10
   "httpVersion": "auto",             // Optional: "auto" | "http1.1" | "http2". Absent/null seeds
                                       // from the "defaultHttpVersion" config entry
-  "stream": false                    // Optional, consume the response as an event stream.
+  "stream": false,                   // Optional, consume the response as an event stream.
                                       // Default false - see below
+  "specOperation": null              // Optional, which spec operation this request is - see below
 }
 ```
 
@@ -873,6 +898,23 @@ toggle persists here and a bulk import carries it. The engine never acts on the
 stored value by itself: `POST /execute` reads the flag off the payload it is
 given, and the by-id compose path deliberately does not add it, so an existing
 caller that composes by id keeps getting a buffered send.
+
+**`specOperation` names which operation of the collection's
+[bound spec](#post-collections) this request is** (issue #637):
+
+```json
+{"operationId": "listPets", "method": "GET", "path": "/pets/{petId}"}
+```
+
+`method` and `path` are required inside the object and `operationId` is optional,
+because an OpenAPI operation may declare none. `path` is the **templated** path
+from the document, never a concrete URL - it is the identity a re-fetched spec is
+diffed against - so a `path` that does not start with `/` is a `400`, as is a
+missing or empty `method` / `path`, a non-object value, or a non-string
+`operationId`. `null` (or absent on create) means the request declares no
+operation, and both request serializers emit `specOperation: null` for it - the
+key is always present, so a client never has to tell "no operation" from "not
+serialized". Two requests may name the same operation.
 
 **Response:** The created request object, carrying the engine-generated `id`.
 
@@ -903,8 +945,8 @@ must resolve to a stored collection (`400` otherwise), and a move that states no
 states no `collectionId` is not checked against the request's stored one, so a
 row stranded before this validation existed stays editable, and repairable by a
 `PUT` that moves it somewhere real. Omitting `followRedirects` / `maxRedirects` /
-`stream` leaves the stored values untouched; sending `null` resets them to
-`true` / `10` / `false`. A non-boolean
+`stream` / `specOperation` leaves the stored values untouched; sending `null`
+resets them to `true` / `10` / `false` / "no operation". A non-boolean
 `followRedirects` or `stream`, or a non-integer `maxRedirects`, is ignored rather
 than rejected. `maxRedirects` is clamped to `0..100` on the way in.
 
@@ -922,8 +964,8 @@ request re-seeds it.
 **Errors:** `404` if the request does not exist; `400` on a `null`
 `collectionId` / `name` / `method` / `url`, a `collectionId` naming a collection
 that does not exist, an unrecognized `method`, a
-malformed `params` / `headers` entry, or an `httpVersion` that is not
-`"auto"` / `"http1.1"` / `"http2"`.
+malformed `params` / `headers` entry, a malformed `specOperation`, or an
+`httpVersion` that is not `"auto"` / `"http1.1"` / `"http2"`.
 
 ### DELETE /requests/:id
 
@@ -1031,6 +1073,96 @@ is a `400`).
   "id": "exa_1234567890"
 }
 ```
+
+## Specs
+
+OpenAPI documents, stored once and bound to collections by
+[`collections.openapi`](#post-collections) (issue #637). A spec is not owned by a
+collection: several may bind the same document, and unbinding one must leave it
+there for the others - so it is a top-level resource with no cascade reaching it,
+and the rule that keeps that safe is the delete refusal below.
+
+The document is stored **verbatim** and its `hash` is computed engine-side on
+every write, never taken from the caller. A scenario run of a bound collection
+stamps `specId` + `specHash` into its snapshot and report, and that stamp only
+means anything because both sides of a later comparison were computed by the same
+code on the same bytes.
+
+There is deliberately **no `PUT /specs/:id`**: a document that changed is a
+different document, and rewriting one in place would invalidate the hash every
+run of every bound collection was stamped with. A re-fetch stores a new document
+and moves the binding.
+
+### POST /specs
+
+Store one OpenAPI document. **Create only**, and the engine owns the id - see
+[Resource writes](#resource-writes-create-vs-update).
+
+**Request:**
+```json
+{
+  "content": "{\"openapi\":\"3.1.0\", ...}",  // Required, non-empty, at most maxSpecDocumentBytes
+  "sourceUrl": "https://api.example.com/openapi.json"  // Optional; null when pasted or uploaded
+}
+```
+
+**Response:**
+```json
+{
+  "id": "spec_3f2b1c9a-...",
+  "content": "{\"openapi\":\"3.1.0\", ...}",
+  "sourceUrl": "https://api.example.com/openapi.json",
+  "fetchedAt": 1730000000000,
+  "hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+}
+```
+
+`sourceUrl` is `null` rather than `""` when the document did not come from a URL,
+so a client can offer a re-fetch for exactly the documents that have somewhere to
+re-fetch from.
+
+**Errors:** `400` if the body carries `id`, `hash` or `fetchedAt` (all
+engine-computed), if `content` is missing, `null` or empty, if `sourceUrl` is
+present and not a string or `null`, or if the document is larger than the live
+`maxSpecDocumentBytes` [config entry](#get-config) - default **10 MiB**, aligned
+with the engine's JSON field cap. The size rejection names the byte count, the
+cap and the setting, and is checked on `POST /import/apply` too, through the same
+helper; the document is never stored truncated.
+
+### GET /specs/:id
+
+**Response:** the whole stored document, `content` included - rendering and
+validating it is what every reader wants it for. `404` (message `Spec not found`)
+when it does not exist.
+
+### DELETE /specs/:id
+
+Delete a stored document.
+
+**Response:**
+```json
+{
+  "message": "Spec deleted successfully",
+  "id": "spec_3f2b1c9a-..."
+}
+```
+
+**Errors:** `404` when it does not exist. `409` while any collection still binds
+it, with a message naming the first binder (and a count of the rest) so the
+caller knows what to unbind without a second round trip:
+
+```json
+{
+  "error": {
+    "code": "conflict",
+    "message": "Spec 'spec_3f2b...' is bound by collection 'Pets API' (col_9a1f...); unbind it before deleting the document"
+  }
+}
+```
+
+The refusal is deliberate rather than a cascade to unbound: the caller asked to
+delete a document, not to edit collections it never mentioned. Unbind with
+`PUT /collections/:id` and `{"openapi": null}`, then delete.
 
 ## Reorder
 
@@ -1159,8 +1291,8 @@ never turn into a `500`.
 
 ### POST /import/apply
 
-Persist an entire parsed import - collections, their requests, and environments -
-in **one atomic call**. Items reference each other by opaque **temp ids** the
+Persist an entire parsed import - collections, their requests, environments, and
+the OpenAPI documents they bind - in **one atomic call**. Items reference each other by opaque **temp ids** the
 client invents; the engine generates every real id via `generate_id` and returns
 the translation in `idMap`.
 
@@ -1172,9 +1304,14 @@ accepted a client-supplied `id` - which they no longer do (see
 **Request:**
 ```json
 {
+  "specs": [
+    { "tempId": "s1", "content": "{\"openapi\":\"3.1.0\", ...}",
+      "sourceUrl": "https://api.example.com/openapi.json" }
+  ],
   "collections": [
     { "tempId": "c1", "parentTempId": null, "name": "My API", "order": 0,
       "variables": {}, "auth": {"mode":"none"},
+      "openapi": {"specTempId": "s1"},
       "preRequestScript": "", "postRequestScript": "" },
     { "tempId": "c2", "parentTempId": "c1", "name": "Users", "order": 0 }
   ],
@@ -1194,10 +1331,10 @@ accepted a client-supplied `id` - which they no longer do (see
 }
 ```
 
-- All three sections are optional; absent or `null` means "none of that kind"
+- All four sections are optional; absent or `null` means "none of that kind"
   (the [null-vs-absent rule](#the-null-vs-absent-rule)). An empty payload is a
   `200` with an empty `idMap`.
-- Every item needs a non-empty string `tempId`, **unique across all three
+- Every item needs a non-empty string `tempId`, **unique across all four
   sections** (they share one namespace, because `idMap` is one flat map). Temp ids
   are never stored.
 - A collection's `parentTempId` and a request's `collectionTempId` must name a
@@ -1226,12 +1363,23 @@ accepted a client-supplied `id` - which they no longer do (see
   and an entry that fails validation is a per-item `400` naming the *request's*
   `tempId`. An entry with no `order` takes its payload position, so the stored
   order is the order the source file listed the responses in.
-- Up to **10,000 items** per call (collections + requests + environments +
-  nested examples - they are rows this call allocates and writes, so they count).
+- A **`specs`** item carries `content` (required, non-empty) and an optional
+  `sourceUrl`; its `hash` and `fetchedAt` are engine-computed and a per-item
+  `400` if sent, and the size cap is the same live `maxSpecDocumentBytes` that
+  [`POST /specs`](#post-specs) enforces, through the same helper. Spec rows are
+  written **before** the collections that bind them, in the same transaction.
+- A collection binds a spec through **`openapi.specTempId`** (a spec in this
+  payload, resolved through the temp-id map exactly as `collectionTempId` is) or
+  **`openapi.specId`** (one already stored). Sending both is a per-item `400`,
+  and so is either one that resolves to nothing. The resolved value is stored as
+  `openapi.specId`; `specTempId` is never persisted.
+- Up to **10,000 items** per call (collections + requests + environments + specs
+  + nested examples - they are rows this call allocates and writes, so they
+  count).
 
 **Response:** `200`
 ```json
-{ "idMap": { "c1": "col_<uuid>", "c2": "col_<uuid>", "r1": "req_<uuid>", "e1": "env_<uuid>" } }
+{ "idMap": { "c1": "col_<uuid>", "c2": "col_<uuid>", "r1": "req_<uuid>", "e1": "env_<uuid>", "s1": "spec_<uuid>" } }
 ```
 
 Every `tempId` sent appears in `idMap`. Nested examples do not - they carry no
@@ -1253,13 +1401,16 @@ Messages, by case:
 - `400` `Invalid JSON body` - the body did not parse.
 - `400` `Body must be a JSON object`.
 - `400` `Invalid 'collections': must be an array` - a section was
-  present but not an array (same for `requests` / `environments`).
+  present but not an array (same for `requests` / `environments` / `specs`).
 - `400` `Invalid collection at index 2: 'tempId' must be a non-empty string`.
 - `400` `Invalid collection at index 0: 'id' is not accepted - the engine assigns ids; reference items by 'tempId'`.
 - `400` `Duplicate tempId 'c1'`, with `item: "c1"`.
 - `400` `Unknown parentTempId 'c9'`, with `item: "c2"`, and the same for
   `collectionTempId` - including a `collectionTempId` that names an environment
   rather than a collection.
+- `400` `Unknown openapi.specTempId 's9'`, with `item: "c1"`, and
+  `400` `Spec 'spec_...' does not exist` for an `openapi.specId` that resolves to
+  no stored document.
 - `400` `Cycle in parentTempId references at 'c1'`, with `item: "c2"` -
   a cycle (including a self-parent) in the payload's own parent graph. The
   stored-tree walk that guards `POST /collections` cannot see this one, because
@@ -3840,6 +3991,13 @@ rows for the timing breakdown and the `results[]` array. A run with no summary n
 terminal status - the engine died mid-run - and its report is built from those sampled `results`
 alone rather than erroring. **The response shape is the same either way.**
 
+**`metadata.openapi`** appears only for a run whose collection was
+[bound to a spec](#post-collections) when the run was planned (issue #637). It is
+echoed from the run's snapshot rather than re-read from the collection: a report
+has to say what the run was measured against, and the binding is free to have
+moved since. An unbound run carries **no `openapi` key at all** - absent rather
+than an empty object, so "not measured against a spec" has one spelling.
+
 **Response:**
 ```json
 {
@@ -3858,6 +4016,10 @@ alone rather than erroring. **The response shape is the same either way.**
       "followRedirects": true,
       "maxRedirects": 10,
       "httpVersion": "auto"
+    },
+    "openapi": {
+      "specId": "spec_3f2b1c9a-...",
+      "specHash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
     }
   },
   "summary": {

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -40,6 +40,7 @@ Stores folder/group hierarchy for requests.
 | `pre_request_script` | TEXT    | Default `""`                                 |
 | `post_request_script`| TEXT    | Default `""`                                 |
 | `data_schema`        | TEXT    | JSON: the declared data contract; default `"{}"` |
+| `openapi`            | TEXT    | JSON: the bound spec document; default `"{}"` |
 | `order`              | INTEGER | Sort order within parent; default 0          |
 | `created_at`         | INTEGER | Unix ms                                      |
 | `updated_at`         | INTEGER | Unix ms                                      |
@@ -66,6 +67,26 @@ user data of unknown sensitivity and are persisted nowhere - not here, not in a
 run snapshot (which records `dataRowCount` only). The file's path is likewise
 not stored engine-side: it is true of one machine, so the app keeps it in a
 local store. See [Data-driven runs](../app/data-driven-runs.md).
+
+**openapi** - the OpenAPI document this collection is bound to (issue #637):
+
+```json
+{"specId":"spec_3f2b1c9a-...","specHash":"<hex sha256>","syncedAt":1700000000000}
+```
+
+`{}` - the default, and what an explicit `null` on `PUT` resets to - means the
+collection is bound to nothing, so unbinding needs no verb of its own. A
+non-empty object is a binding and must carry a `specId` that resolves to a row in
+[`spec_documents`](#spec_documents); `specHash` records which *version* of the
+document the collection was last synced to, and `syncedAt` when. Shape validation
+lives in `apply_collection_fields` so all three write paths enforce it, and the
+resolvability check sits in the route cores beside `reject_missing_collection` -
+`POST /import/apply` binds specs it is about to write in the same transaction.
+
+The **edge** is stored here; the **document** is not. Several collections may
+bind the same spec, so nothing here owns it: no cascade reaches `spec_documents`,
+and `DELETE /specs/:id` is refused while any collection names the row. NOT NULL
+with a `default_value`, the same migration shape as `data_schema` above.
 
 **auth** is a JSON discriminated union: `{"mode":"none"}` | `{"mode":"bearer","token":"..."}` |
 `{"mode":"basic","username":"...","password":"..."}` | `{"mode":"apikey","key":"...","value":"...","in":"header"|"query"}` |
@@ -114,6 +135,7 @@ Stores individual HTTP request definitions.
 | `max_redirects`       | INTEGER | Hops allowed while following; default 10             |
 | `http_version`        | TEXT    | `'auto'` \| `'http1.1'` \| `'http2'`; default `'auto'` |
 | `stream`              | INTEGER | Boolean; consume the response as SSE; default 0      |
+| `spec_operation`      | TEXT    | JSON: which spec operation this is; NULL when none   |
 | `created_at`          | INTEGER | Unix ms                                              |
 | `updated_at`          | INTEGER | Unix ms                                              |
 
@@ -174,6 +196,28 @@ i.e. the behaviour they already had (a row predating `http_version` could only
 ever have run HTTP/1.1, since nghttp2 was not yet linked). `max_redirects` is
 clamped to `0..100` on write.
 
+**spec_operation** - which operation of the collection's bound
+[`openapi`](#collections) document this request *is* (issue #637):
+
+```json
+{"operationId":"listPets","method":"GET","path":"/pets/{petId}"}
+```
+
+`method` and `path` are required and `operationId` is optional, because an
+OpenAPI operation may declare none. `path` is the **templated** path from the
+document, never a concrete URL - it is the identity a re-fetched spec is diffed
+against and the key coverage counts by, and a substituted URL would match nothing
+in the document it came from, so a `path` that does not start with `/` is a
+`400`. Two requests may name the same operation.
+
+Nullable rather than `NOT NULL` with a `"{}"` default, unlike the four columns
+above: a request that answers to no operation declares nothing, and `NULL` is
+that - `{}` would be a second spelling of the same absence for every reader to
+handle. A nullable column is `ALTER TABLE ADD COLUMN`-friendly without a default.
+Both request serializers emit it as `specOperation`, `null` when the column is,
+and `apply_request_fields` applies it, so `POST`, `PUT` and `POST /import/apply`
+all carry it.
+
 **http_version** stores `Request::http_version` (the *requested* protocol, an
 enum member spelled as text) - a different value and a different value space
 from `Response::http_version`, the *negotiated* protocol string
@@ -229,6 +273,52 @@ rather than merely stale.
 a truncation - a half-body served as if whole is worse than a refused write - and
 a request holds at most `MAX_PER_REQUEST` (100) examples. Both constants live in
 `engine/include/vayu/core/constants.hpp`.
+
+---
+
+### `spec_documents`
+
+Stores OpenAPI documents, bound to collections by
+[`collections.openapi`](#collections) (issue #637).
+
+| Column       | Type    | Notes                                              |
+|--------------|---------|----------------------------------------------------|
+| `id`         | TEXT PK | `spec_` + UUID                                     |
+| `content`    | TEXT    | The document, verbatim; capped (see below)         |
+| `source_url` | TEXT    | Where it was fetched from; NULL when pasted/uploaded |
+| `fetched_at` | INTEGER | Unix ms                                            |
+| `hash`       | TEXT    | Hex `sha256(content)`, computed engine-side        |
+
+**content** is stored as text rather than a parsed model, because every feature
+stacked behind this needs the *document*: the Spec tab renders it, sync
+re-fetches and diffs against it, response validation resolves `$ref`s through it,
+and export writes a new one beside it. A parse here would be re-done by each of
+them anyway and would lose whatever the author wrote that the parser did not
+model.
+
+**hash** is the content+hash pair [`body_blobs`](#body_blobs) uses, and is
+**never taken from the caller** - `POST /specs` and `POST /import/apply` both
+compute it through `spec_content_hash`, and a body carrying `hash` or `fetchedAt`
+is a `400`. A scenario run of a bound collection stamps `specId` + `specHash`
+into its [`runs.config_snapshot`](#runs) under `scenario.openapi`, and that stamp
+only means anything because both sides of a later comparison were computed by the
+same code on the same bytes.
+
+**Ownership, and why there is no cascade.** A spec is bound *by* collections
+rather than owned by one: several may bind the same row, and unbinding one must
+leave it there for the others. So nothing deletes a document implicitly -
+`DELETE /specs/:id` is refused with a `409` naming the binder while any
+collection still names it. There is likewise no `PUT /specs/:id`: a document that
+changed is a different document, and rewriting one in place would invalidate the
+hash every run of every bound collection was stamped with.
+
+**Cap.** A document over the live `maxSpecDocumentBytes`
+[`config_entries`](#config_entries) value (default 10 MiB, aligned with
+`json::MAX_FIELD_SIZE`) is a `400` naming the size and the cap, on both write
+paths - never a truncation, and never cpp-httplib's own body cap dropping the
+connection without explaining itself.
+
+A new table, so `sync_schema()` creates it outright and there is no migration.
 
 ---
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -44,6 +44,7 @@ The daemon listens on `http://127.0.0.1:9876`. Key endpoints:
 | GET | `/health` | Health check |
 | POST | `/import/apply` | Persist a whole parsed import atomically; returns a temp-id -> real-id map |
 | GET | `/requests/:id/examples` | A request's saved example responses (issue #481), in stored order |
+| POST | `/specs` | Store an OpenAPI document (issue #637); `GET`/`DELETE /specs/:id` read and remove it |
 | POST | `/collections`, `/requests`, `/environments`, `/requests/:id/examples` | **Create only** - 409 on an existing id |
 | PUT | `/collections/:id`, `/requests/:id`, `/environments/:id`, `/requests/:id/examples/:exampleId` | **Update only** (merge-patch) - 404 on a missing id |
 
@@ -110,6 +111,19 @@ Three things worth knowing before you design around them:
   transfer, the post-request one after the stream ends, reading the bounded list
   as `pm.response.events`; because the route already answered `202`, their
   output is stored on the trace's `scripts` node rather than returned.
+- **An OpenAPI document is stored once and *bound* by collections, never owned
+  by one** (#637). `spec_documents` holds the text verbatim plus an
+  engine-computed `hash`; `collections.openapi`
+  (`{specId, specHash, syncedAt}`, `{}` = unbound) is the edge, and
+  `requests.spec_operation` (`{operationId?, method, path}`, NULL = none) says
+  which operation a request *is*. Several collections may bind one document, so
+  nothing cascades to it: `DELETE /specs/:id` is a **409 naming the binder**
+  while any collection holds it, and there is no `PUT /specs/:id` - a changed
+  document is a new one, because rewriting in place would invalidate the hash
+  every run of every bound collection was stamped with. A scenario run of a
+  bound collection stamps `specId` + `specHash` into `config_snapshot` and
+  `GET /runs/:id/report` echoes it under `metadata.openapi`; an unbound run
+  carries no key at all.
 - **`followRedirects` / `maxRedirects` are per-request and stored** (request
   builder → **Settings** tab, `requests.follow_redirects` / `max_redirects`).
   Both clients send them on *every* execute and load test rather than eliding

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -391,6 +391,7 @@ if(VAYU_BUILD_ENGINE)
         src/http/routes/collections.cpp
         src/http/routes/requests.cpp
         src/http/routes/examples.cpp
+        src/http/routes/specs.cpp
         src/http/routes/reorder.cpp
         src/http/routes/environments.cpp
         src/http/routes/globals.cpp
@@ -453,6 +454,7 @@ if(VAYU_BUILD_TESTS)
         tests/sse_stream_test.cpp
         tests/requests_route_test.cpp
         tests/examples_route_test.cpp
+        tests/specs_route_test.cpp
         tests/runs_route_test.cpp
         tests/collections_route_test.cpp
         tests/resource_write_route_test.cpp
@@ -518,6 +520,7 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/config.cpp
         src/http/routes/requests.cpp
         src/http/routes/examples.cpp
+        src/http/routes/specs.cpp
         src/http/routes/reorder.cpp
         src/http/routes/runs.cpp
         src/http/routes/collections.cpp

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -651,6 +651,19 @@ constexpr size_t MAX_PER_REQUEST = 100;
 } // namespace request_example
 
 /**
+ * @brief OpenAPI document bounds (issue #637).
+ */
+namespace spec_document {
+/// Bytes one stored OpenAPI document may hold (config key
+/// `maxSpecDocumentBytes`). Aligned with `json::MAX_FIELD_SIZE`, because every
+/// later phase parses the stored text back as JSON and that is the ceiling the
+/// parse path already carries. Engine-authored so an oversized document is
+/// refused with a message naming the count and the cap, the way `MAX_DATA_BYTES`
+/// is - cpp-httplib's own body cap would drop the connection instead.
+constexpr size_t MAX_BYTES = 10 * 1024 * 1024;
+} // namespace spec_document
+
+/**
  * @brief Local mock server bounds (issue #481 phase 2)
  *
  * Rails rather than preferences, the same split the inbox and the issuer draw:

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -114,6 +114,29 @@ struct ScenarioRequest {
 };
 
 /**
+ * The OpenAPI document a run's collection was bound to when the run was planned
+ * (issue #637).
+ *
+ * Both halves or neither: the id says *which* document and the hash says *which
+ * version of it*, and a report that carried only the id would claim a run was
+ * measured against a spec that may have been replaced since. `bound()` is false
+ * for a collection that binds nothing, and a run of one stamps no `openapi`
+ * object at all - absent, rather than an empty one that reads as "bound to
+ * nothing in particular".
+ *
+ * Captured at resolution rather than read back at report time for the same
+ * reason the whole plan is: a run is a record of what ran, and the binding is
+ * free to move afterwards.
+ */
+struct SpecBinding {
+    std::string spec_id;
+    std::string spec_hash;
+    [[nodiscard]] bool bound () const {
+        return !spec_id.empty ();
+    }
+};
+
+/**
  * A resolved scenario, ready to execute: what was asked for and what it
  * resolved to.
  *
@@ -176,6 +199,10 @@ struct ScenarioResolution {
     ScenarioPlan plan;
     /// The validated `data` rows, for `ScenarioExecution::data_rows`.
     std::vector<nlohmann::json> data_rows;
+    /// The collection's spec binding as of resolution; unbound for most runs.
+    /// Read straight into `build_scenario_manifest`, which is the only thing
+    /// that needs it - nothing about *executing* the plan depends on it.
+    SpecBinding spec;
 };
 
 /**
@@ -235,8 +262,15 @@ size_t row_index);
  * `sanitize_config_snapshot` (`utils/json.cpp`) exists to keep exactly that out
  * of the run store, and persisting a composed plan would route around its
  * allowlist. The full plan lives in memory for the run's life and nowhere else.
+ *
+ * A spec-bound collection also stamps `openapi: {specId, specHash}` here
+ * (issue #637), which `GET /runs/:id/report` echoes under `metadata` and #629's
+ * coverage report reads as its anchor. @p spec unbound stamps **nothing** - the
+ * key is absent rather than null, so "this run was not measured against a spec"
+ * is one answer with one spelling.
  */
 nlohmann::json build_scenario_manifest (const ScenarioRequest& request,
-const ScenarioPlan& plan);
+const ScenarioPlan& plan,
+const SpecBinding& spec = {});
 
 } // namespace vayu::core

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -110,6 +110,26 @@ class Database {
     int64_t count_request_examples (const std::string& request_id);
     void delete_request_example (const std::string& id);
 
+    // OpenAPI documents (issue #637). Bound by collections rather than owned by
+    // one, so nothing here cascades: `delete_spec_document` is only ever reached
+    // once the route has proven no collection still names the id.
+
+    void save_spec_document (const SpecDocument& s);
+    std::optional<SpecDocument> get_spec_document (const std::string& id);
+    /**
+     * @brief The collections whose `openapi` binding names @p spec_id.
+     *
+     * A scan rather than an index: the binding lives inside a JSON blob, so
+     * there is no column to index, and the collections table is the small,
+     * sidebar-sized one. Its callers are the delete refusal and nothing on a
+     * request's hot path.
+     *
+     * Empty means the spec is bound by nobody, which is the only state
+     * `delete_spec_document` may be called in.
+     */
+    std::vector<Collection> get_collections_bound_to_spec (const std::string& spec_id);
+    void delete_spec_document (const std::string& id);
+
     /**
      * @brief Persist a whole import in one transaction (issue #96).
      *
@@ -125,7 +145,8 @@ class Database {
     void import_apply (const std::vector<Collection>& collections,
     const std::vector<Request>& requests,
     const std::vector<Environment>& environments,
-    const std::vector<RequestExample>& examples = {});
+    const std::vector<RequestExample>& examples = {},
+    const std::vector<SpecDocument>& specs = {});
 
     /**
      * @brief Persist a whole batch reorder in one transaction (issue #365).

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -486,6 +487,35 @@ std::optional<std::pair<int, nlohmann::json>>
 apply_request_example_fields (vayu::db::RequestExample& x, const nlohmann::json& json, bool is_create);
 
 /**
+ * Hex-encoded SHA-256 of an OpenAPI document's text (issue #637) - what
+ * `spec_documents.hash` stores and what a run's snapshot is stamped with.
+ * Defined in specs.cpp.
+ */
+std::string spec_content_hash (const std::string& content);
+
+/**
+ * The live `maxSpecDocumentBytes` cap, read fresh per write. Shared by
+ * `POST /specs` and `POST /import/apply` so the two cannot enforce different
+ * limits. Defined in specs.cpp.
+ */
+size_t spec_size_cap (vayu::db::Database& db);
+
+/**
+ * Rejects a collection write whose `openapi` binding names a spec that will not
+ * exist once the write lands (issue #637).
+ *
+ * Outside `apply_collection_fields` for the same reason `reject_missing_collection`
+ * is outside `apply_request_fields`: `POST /import/apply` runs the applier over
+ * rows whose spec section is still unwritten, so an existence check inside it
+ * would refuse a legal bulk import. @p pending names what the caller is about to
+ * write in the same transaction; every path but import passes an empty set.
+ * Defined in specs.cpp.
+ */
+std::optional<std::pair<int, nlohmann::json>> reject_unbindable_spec (vayu::db::Database& db,
+const std::string& openapi,
+const std::unordered_set<std::string>& pending);
+
+/**
  * The outcome of resolving `pm.info.requestName` for a `POST /execute` payload.
  *
  * `name` absent is a normal answer, not a failure: an ad-hoc request has no
@@ -675,6 +705,7 @@ void register_config_routes (RouteContext& ctx);
 void register_collection_routes (RouteContext& ctx);
 void register_request_routes (RouteContext& ctx);
 void register_request_example_routes (RouteContext& ctx);
+void register_spec_routes (RouteContext& ctx);
 void register_reorder_routes (RouteContext& ctx);
 void register_environment_routes (RouteContext& ctx);
 void register_globals_routes (RouteContext& ctx);

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -819,6 +819,13 @@ struct Collection {
     // no contract. The *schema* lives here, never the rows - a data file's rows
     // are user data of unknown sensitivity and are persisted nowhere.
     std::string data_schema{ "{}" };
+    // JSON - the OpenAPI document this collection is bound to (issue #637):
+    // {"specId": "spec_...", "specHash": "<hex>", "syncedAt": ms}. `{}` means
+    // unbound, which is what every collection written before the binding
+    // existed backfills to. The *document* lives in `spec_documents`; this is
+    // only the edge, so two collections may bind the same spec and unbinding
+    // one leaves the document alone.
+    std::string openapi{ "{}" };
     int order;
     int64_t created_at;
     int64_t updated_at;
@@ -854,6 +861,17 @@ struct Request {
     // flag off the payload (`read_stream_flag`), and the by-id compose path
     // deliberately does not send it - see `payload_from_stored`.
     bool stream = false; // INTEGER NOT NULL DEFAULT 0
+    // Which operation of the bound OpenAPI document this request *is*
+    // (issue #637): {"operationId"?: "listPets", "method": "GET",
+    // "path": "/pets"}. Nullable rather than NOT NULL-with-a-default, on the
+    // `config_entries.unit` precedent: a request that answers to no operation
+    // declares nothing, and NULL is that - `{}` would be a second spelling of
+    // the same absence for every reader to handle.
+    //
+    // `path` is the *template* (`/pets/{petId}`), never a concrete URL, because
+    // it is the identity a re-fetched spec is diffed against (#627) and the key
+    // coverage counts by (#629). Two requests may name the same operation.
+    std::optional<std::string> spec_operation;
     int64_t created_at;
     int64_t updated_at;
 };
@@ -892,6 +910,40 @@ struct RequestExample {
     int order = 0;
     int64_t created_at;
     int64_t updated_at;
+};
+
+/**
+ * @brief An OpenAPI document, stored once and bound to collections (issue #637).
+ *
+ * The text is kept verbatim - not a parsed model - because everything the epic
+ * stacked behind this needs the *document*: the Spec tab renders it (#638), sync
+ * re-fetches and diffs against it (#627), response validation resolves `$ref`s
+ * through it (#628), and export writes a new one beside it (#630). A parse here
+ * would have to be re-done by each of them anyway, and would lose whatever the
+ * author wrote that the parser did not model.
+ *
+ * Owned by nobody: a spec is bound *by* collections (`Collection::openapi`)
+ * rather than owned by one, so no cascade reaches it and `DELETE /specs/:id` is
+ * refused while any collection names it.
+ */
+struct SpecDocument {
+    std::string id; // "spec_"-prefixed, engine-minted like every other id
+    std::string content;
+    /// Where it was fetched from, when it came from a URL rather than a file.
+    /// Nullable: "pasted or uploaded" is an answer, and `""` would be a second
+    /// spelling of it. Phase 2 (#627) re-fetches through this.
+    std::optional<std::string> source_url;
+    int64_t fetched_at = 0;
+    /**
+     * Hex-encoded `sha256(content)`, computed engine-side on every write.
+     *
+     * Never taken from the caller, and stored beside the content rather than
+     * derived per read: a run stamps the hash it planned against
+     * (`runs.config_snapshot`), and that stamp is only worth anything if the
+     * value it was compared to was computed by the same code on the same bytes.
+     * The `body_blobs` content+hash pair is the shape this follows.
+     */
+    std::string hash;
 };
 
 struct Environment {

--- a/engine/include/vayu/utils/json.hpp
+++ b/engine/include/vayu/utils/json.hpp
@@ -52,6 +52,11 @@ using Json = nlohmann::json;
 [[nodiscard]] Json serialize (const vayu::db::RequestExample& example);
 
 /**
+ * @brief Serialize a stored OpenAPI document to JSON (issue #637)
+ */
+[[nodiscard]] Json serialize (const vayu::db::SpecDocument& spec);
+
+/**
  * @brief Serialize an Environment to JSON
  */
 [[nodiscard]] Json serialize (const vayu::db::Environment& environment);

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -293,6 +293,23 @@ const ScenarioResolveOptions& options) {
         return invalid ("No collection with id '" + request.collection_id + "'");
     }
 
+    // The spec this run is measured against, read once here and stamped into the
+    // snapshot by `build_scenario_manifest` (issue #637). Read from the
+    // collection rather than looked up in `spec_documents`: the hash *stored on
+    // the binding* is what the collection was last synced to, and that - not
+    // whatever the document says today - is what the run was planned against.
+    // An unparseable blob binds nothing, the same reading every other reader of
+    // this column gives it.
+    try {
+        const auto binding = nlohmann::json::parse (collection->openapi);
+        if (binding.is_object ()) {
+            resolution.spec.spec_id   = binding.value ("specId", std::string ());
+            resolution.spec.spec_hash = binding.value ("specHash", std::string ());
+        }
+    } catch (const std::exception&) {
+        // Leaves the binding unbound; a malformed column must not fail a run.
+    }
+
     const auto rows = collect_requests (db, request.collection_id, request.recursive);
     if (rows.empty ()) {
         return invalid ("Collection '" + request.collection_id + "' has no requests" +
@@ -447,7 +464,8 @@ size_t row_index) {
 }
 
 nlohmann::json build_scenario_manifest (const ScenarioRequest& request,
-const ScenarioPlan& plan) {
+const ScenarioPlan& plan,
+const SpecBinding& spec) {
     nlohmann::json steps = nlohmann::json::array ();
     for (const auto& step : plan.steps) {
         steps.push_back ({ { "index", step.index }, { "requestId", step.request_id },
@@ -455,10 +473,16 @@ const ScenarioPlan& plan) {
         { "url", step.stored_url } });
     }
 
-    return nlohmann::json{ { "source", request.source },
+    nlohmann::json manifest{ { "source", request.source },
         { "collectionId", request.collection_id },
         { "recursive", request.recursive }, { "iterations", request.iterations },
         { "dataRowCount", request.data_row_count }, { "steps", std::move (steps) } };
+    // Absent for an unbound collection, never `null` or `{}` - see the header.
+    if (spec.bound ()) {
+        manifest["openapi"] =
+        nlohmann::json{ { "specId", spec.spec_id }, { "specHash", spec.spec_hash } };
+    }
+    return manifest;
 }
 
 } // namespace vayu::core

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -209,6 +209,11 @@ inline auto make_storage (const std::string& path) {
     // backfills to `{}`, which is what "declares no contract" is spelled as.
     make_column ("data_schema", &Collection::data_schema,
     default_value (std::string ("{}"))),
+    // The OpenAPI binding (issue #637). Same NOT NULL + default_value shape as
+    // `data_schema` directly above, and for the same reason: sync_schema ALTERs
+    // it onto an existing, non-empty collections table and every pre-existing
+    // row backfills to `{}`, which is how "bound to no spec" is spelled.
+    make_column ("openapi", &Collection::openapi, default_value (std::string ("{}"))),
     make_column ("order", &Collection::order),
     make_column ("created_at", &Collection::created_at),
     make_column ("updated_at", &Collection::updated_at)),
@@ -242,6 +247,11 @@ inline auto make_storage (const std::string& path) {
     // existing requests table and every pre-existing row backfills to "not a
     // stream", which is what they all were.
     make_column ("stream", &Request::stream, default_value (false)),
+    // Which operation of the bound spec this request is (issue #637). Nullable
+    // rather than NOT NULL with a default, on the `config_entries.unit`
+    // precedent below: a nullable column is ALTER-friendly without one, and
+    // NULL is the only spelling of "declares no operation".
+    make_column ("spec_operation", &Request::spec_operation),
     make_column ("created_at", &Request::created_at),
     make_column ("updated_at", &Request::updated_at)),
 
@@ -259,6 +269,15 @@ inline auto make_storage (const std::string& path) {
     make_column ("order", &RequestExample::order),
     make_column ("created_at", &RequestExample::created_at),
     make_column ("updated_at", &RequestExample::updated_at)),
+
+    // Spec documents: OpenAPI documents, stored once and bound to collections
+    // (issue #637). A new table, so sync_schema() creates it outright and there
+    // is no migration - the `request_examples` precedent above.
+    make_table ("spec_documents", make_column ("id", &SpecDocument::id, primary_key ()),
+    make_column ("content", &SpecDocument::content),
+    make_column ("source_url", &SpecDocument::source_url), // NULL = not fetched from a URL
+    make_column ("fetched_at", &SpecDocument::fetched_at),
+    make_column ("hash", &SpecDocument::hash)), // hex sha256 of `content`
 
     // Environments: Named variable sets (dev, staging, prod)
     make_table ("environments", make_column ("id", &Environment::id, primary_key ()),
@@ -868,6 +887,52 @@ void Database::delete_request_example (const std::string& id) {
 }
 
 // ============================================================================
+// Spec documents (issue #637)
+// ============================================================================
+
+void Database::save_spec_document (const SpecDocument& s) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    vayu::utils::log_debug ("Saving spec document: id=" + s.id + ", hash=" + s.hash);
+    impl_->storage.replace (s);
+}
+
+std::optional<SpecDocument> Database::get_spec_document (const std::string& id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    auto rows = impl_->storage.get_all<SpecDocument> (where (c (&SpecDocument::id) == id));
+    if (rows.empty ())
+        return std::nullopt;
+    return rows.front ();
+}
+
+std::vector<Collection> Database::get_collections_bound_to_spec (const std::string& spec_id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    std::vector<Collection> bound;
+    if (spec_id.empty ()) {
+        return bound;
+    }
+    // The binding is a JSON blob, so the match is made here rather than in SQL.
+    // An unparseable blob binds nothing - the same reading every serializer
+    // gives it - and must not make the spec undeletable.
+    for (auto& col : impl_->storage.get_all<Collection> ()) {
+        try {
+            const auto parsed = nlohmann::json::parse (col.openapi);
+            if (parsed.is_object () && parsed.value ("specId", std::string ()) == spec_id) {
+                bound.push_back (std::move (col));
+            }
+        } catch (const std::exception&) {
+            continue;
+        }
+    }
+    return bound;
+}
+
+void Database::delete_spec_document (const std::string& id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    vayu::utils::log_debug ("Deleting spec document: id=" + id);
+    impl_->storage.remove_all<SpecDocument> (where (c (&SpecDocument::id) == id));
+}
+
+// ============================================================================
 // Bulk import - collections + requests + environments in one transaction
 // ============================================================================
 
@@ -877,19 +942,26 @@ void Database::delete_request_example (const std::string& id) {
 void Database::import_apply (const std::vector<Collection>& collections,
 const std::vector<Request>& requests,
 const std::vector<Environment>& environments,
-const std::vector<RequestExample>& examples) {
+const std::vector<RequestExample>& examples,
+const std::vector<SpecDocument>& specs) {
     if (collections.empty () && requests.empty () && environments.empty () &&
-    examples.empty ()) {
+    examples.empty () && specs.empty ()) {
         return;
     }
 
     vayu::utils::log_debug ("Applying import: " + std::to_string (collections.size ()) +
     " collections, " + std::to_string (requests.size ()) + " requests, " +
     std::to_string (environments.size ()) + " environments, " +
-    std::to_string (examples.size ()) + " examples");
+    std::to_string (examples.size ()) + " examples, " +
+    std::to_string (specs.size ()) + " specs");
 
     retry_on_busy ("apply import", 5, std::chrono::milliseconds (100), [&] {
         impl_->storage.transaction ([&] {
+            // Ahead of the collections, which may bind them - the same
+            // owner-before-referrer order the rest of this transaction keeps.
+            for (const auto& s : specs) {
+                impl_->storage.replace (s);
+            }
             for (const auto& c : collections) {
                 impl_->storage.replace (c);
             }
@@ -1939,6 +2011,17 @@ void Database::seed_default_config () {
     "with a message naming this setting.",
     "general_engine", std::to_string (vayu::core::constants::scenario::MAX_DATA_BYTES),
     "1024", "104857600", std::nullopt, now }));
+
+    upsert_config (unit ("bytes") (keywords ({ "swagger" }) (
+    ConfigEntry{ "maxSpecDocumentBytes",
+    std::to_string (vayu::core::constants::spec_document::MAX_BYTES), "integer",
+    "Max OpenAPI Document Size",
+    "Largest OpenAPI document one collection may bind. The document is stored "
+    "verbatim and parsed back by every feature that reads it, so this bounds "
+    "both the row and that parse. A larger document is rejected with a message "
+    "naming this setting, never stored truncated.",
+    "general_engine", std::to_string (vayu::core::constants::spec_document::MAX_BYTES),
+    "1024", "104857600", std::nullopt, now })));
 
     upsert_config (ConfigEntry{ "maxScenarioStoredSteps",
     std::to_string (vayu::core::constants::scenario::MAX_STORED_STEPS), "integer",

--- a/engine/src/http/routes/collections.cpp
+++ b/engine/src/http/routes/collections.cpp
@@ -168,6 +168,46 @@ validate_data_schema (const nlohmann::json& schema) {
 }
 
 /**
+ * Contents-validation for the `openapi` binding (issue #637), run after
+ * `apply_json_field` has settled the shape - the same split `validate_data_schema`
+ * above draws, and for the same reason.
+ *
+ * An empty object is the *unbound* state and is always legal. A non-empty one is
+ * a binding, and a binding without a `specId` names nothing: it would serialize
+ * as a collection that claims a spec and read back as one nobody can fetch, so
+ * it is a 400 rather than a stored half-edge.
+ *
+ * Whether that `specId` resolves is deliberately **not** checked here. This
+ * applier also runs under `POST /import/apply`, against a payload whose spec
+ * rows are not written yet - the same reason `reject_missing_collection` sits in
+ * the request route cores rather than in `apply_request_fields`. Resolution is
+ * `reject_unbindable_spec`'s, called by each write path with whatever it knows
+ * is about to exist.
+ */
+static std::optional<std::pair<int, nlohmann::json>>
+validate_openapi_binding (const nlohmann::json& binding) {
+    if (binding.empty ()) {
+        return std::nullopt; // Unbound; nothing to check.
+    }
+    if (!binding.contains ("specId") || !binding["specId"].is_string () ||
+    binding["specId"].get<std::string> ().empty ()) {
+        return std::make_pair (400,
+        error_body (400,
+        "Invalid 'openapi.specId': a binding must name a stored spec "
+        "(send openapi: {} or null to unbind)"));
+    }
+    if (binding.contains ("specHash") && !binding["specHash"].is_string ()) {
+        return std::make_pair (
+        400, error_body (400, "Invalid 'openapi.specHash': must be a string"));
+    }
+    if (binding.contains ("syncedAt") && !binding["syncedAt"].is_number ()) {
+        return std::make_pair (
+        400, error_body (400, "Invalid 'openapi.syncedAt': must be a number"));
+    }
+    return std::nullopt;
+}
+
+/**
  * Applies the request body onto `c` under the one null-vs-absent rule (see the
  * helpers in routes.hpp). Shared by the create and update cores so the two
  * verbs cannot drift apart on what a field means - the only thing that differs
@@ -238,6 +278,18 @@ bool is_create) {
         }
     }
 
+    // The OpenAPI binding (issue #637). `{}` is "bound to nothing", which both
+    // an absent field on create and an explicit null on update mean - so
+    // unbinding is `{"openapi": null}` and needs no verb of its own.
+    if (auto err = apply_json_field (json, "openapi", c.openapi, "{}", is_create)) {
+        return err;
+    }
+    if (json.contains ("openapi") && json["openapi"].is_object ()) {
+        if (auto err = validate_openapi_binding (json["openapi"])) {
+            return err;
+        }
+    }
+
     // Reject writes that would put a cycle in the collection tree (self-parent,
     // or reparent into a descendant) before they reach the DB - a cycle makes
     // cascade delete loop forever under the global mutex. Cycle/self checks
@@ -285,8 +337,24 @@ create_collection_response (vayu::db::Database& db, const nlohmann::json& json) 
         return *err;
     }
 
-    db.create_collection (c);
-    return { 200, vayu::json::serialize (c) };
+    // The spec check and the write are one composite, so they are one lock
+    // scope (issue #386's rule): the check proves a spec exists, and between
+    // that read and this write a concurrent `DELETE /specs/:id` would otherwise
+    // see no binder, delete the document, and leave this collection bound to
+    // nothing - the one state the check exists to prevent. The delete side
+    // holds the lock across its own check-and-remove for the same reason.
+    // `reject_unbindable_spec` is here rather than in the shared applier because
+    // bulk import binds specs it is about to write - see its declaration.
+    std::pair<int, nlohmann::json> result;
+    db.with_lock ([&] {
+        if (auto err = reject_unbindable_spec (db, c.openapi, {})) {
+            result = *err;
+            return;
+        }
+        db.create_collection (c);
+        result = { 200, vayu::json::serialize (c) };
+    });
+    return result;
 }
 
 /**
@@ -316,8 +384,24 @@ const nlohmann::json& json) {
     }
     c.updated_at = now_ms ();
 
-    db.create_collection (c);
-    return { 200, vayu::json::serialize (c) };
+    // One lock scope over check-then-write, exactly as the create core does -
+    // see there for why the two cannot be separate acquisitions. The check runs
+    // only when the write states a binding: a collection bound to a spec that
+    // has since been deleted out of band must stay editable by a PUT that says
+    // nothing about `openapi`, rather than becoming unwritable - the same
+    // reading `reject_missing_collection` gets on a request move.
+    std::pair<int, nlohmann::json> result;
+    db.with_lock ([&] {
+        if (json.contains ("openapi")) {
+            if (auto err = reject_unbindable_spec (db, c.openapi, {})) {
+                result = *err;
+                return;
+            }
+        }
+        db.create_collection (c);
+        result = { 200, vayu::json::serialize (c) };
+    });
+    return result;
 }
 
 void register_collection_routes (RouteContext& ctx) {

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -1185,8 +1185,8 @@ void register_execution_routes (RouteContext& ctx) {
                 return;
             }
 
-            scenario_manifest =
-            vayu::core::build_scenario_manifest (resolved.request, resolved.plan);
+            scenario_manifest = vayu::core::build_scenario_manifest (
+            resolved.request, resolved.plan, resolved.spec);
 
             auto execution     = std::make_shared<vayu::core::ScenarioExecution> ();
             execution->request = std::move (resolved.request);

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -170,7 +170,13 @@ struct TempIds {
     std::vector<std::string> collections;              // in payload order
     std::vector<std::string> requests;
     std::vector<std::string> environments;
+    std::vector<std::string> specs;
     std::unordered_set<std::string> is_collection;
+    std::unordered_set<std::string> is_spec;
+    /// The engine ids the payload's own spec section claimed. A collection may
+    /// bind one of these even though no row exists yet, which is exactly what
+    /// `reject_unbindable_spec`'s `pending` argument is for.
+    std::unordered_set<std::string> pending_spec_ids;
     std::unordered_map<std::string, std::string> parent_of; // collection -> its parent
 };
 
@@ -191,10 +197,11 @@ std::vector<std::string>& claimed) {
     return std::nullopt;
 }
 
-/** Pass 1 - claim every tempId across the three sections, then note the collections. */
+/** Pass 1 - claim every tempId across the four sections, then note the owners. */
 std::optional<std::pair<int, nlohmann::json>> claim_all (const nlohmann::json& collections,
 const nlohmann::json& requests,
 const nlohmann::json& environments,
+const nlohmann::json& specs,
 TempIds& temps) {
     if (auto err = claim_section (collections, "collection", "col_", temps.real, temps.collections)) {
         return err;
@@ -205,8 +212,15 @@ TempIds& temps) {
     if (auto err = claim_section (environments, "environment", "env_", temps.real, temps.environments)) {
         return err;
     }
+    if (auto err = claim_section (specs, "spec", "spec_", temps.real, temps.specs)) {
+        return err;
+    }
     for (const auto& temp : temps.collections) {
         temps.is_collection.insert (temp);
+    }
+    for (const auto& temp : temps.specs) {
+        temps.is_spec.insert (temp);
+        temps.pending_spec_ids.insert (temps.real.at (temp));
     }
     return std::nullopt;
 }
@@ -291,6 +305,48 @@ apply_item_fields (Apply apply, const char* kind, const std::string& temp_id) {
     return std::nullopt;
 }
 
+/**
+ * Resolves one collection item's `openapi` binding into the shape the shared
+ * applier stores.
+ *
+ * A payload-local spec is named by `openapi.specTempId`, exactly as a request
+ * names its owner with `collectionTempId`, and is rewritten here into the
+ * `specId` the applier and every reader expect. `specId` is also accepted
+ * directly, for a collection binding a document that is *already* stored - an
+ * incremental import into an existing spec - and that id is checked against the
+ * store by `reject_unbindable_spec` alongside the payload's own.
+ *
+ * Both at once is a 400: they are two answers to one question, and picking one
+ * would leave the caller believing the other was honoured.
+ */
+std::optional<std::pair<int, nlohmann::json>>
+resolve_spec_binding (nlohmann::json& fields, const TempIds& temps, const std::string& temp) {
+    auto binding = fields.find ("openapi");
+    if (binding == fields.end () || binding->is_null () || !binding->is_object ()) {
+        return std::nullopt; // Unbound, or a shape the applier will reject.
+    }
+    auto spec_temp = binding->find ("specTempId");
+    if (spec_temp == binding->end () || spec_temp->is_null ()) {
+        return std::nullopt;
+    }
+    if (!spec_temp->is_string ()) {
+        return item_error ("Invalid 'openapi.specTempId': must be a string", temp);
+    }
+    if (binding->contains ("specId")) {
+        return item_error (
+        "Invalid 'openapi': send either 'specTempId' (a spec in this payload) or "
+        "'specId' (one already stored), not both",
+        temp);
+    }
+    const std::string named = spec_temp->get<std::string> ();
+    if (!temps.is_spec.contains (named)) {
+        return item_error ("Unknown openapi.specTempId '" + named + "'", temp);
+    }
+    binding->erase ("specTempId");
+    (*binding)["specId"] = temps.real.at (named);
+    return std::nullopt;
+}
+
 /** Pass 3a - collection rows, through the same applier POST /collections uses. */
 std::optional<std::pair<int, nlohmann::json>> build_collection_rows (vayu::db::Database& db,
 const nlohmann::json& collections,
@@ -310,6 +366,10 @@ std::vector<vayu::db::Collection>& out) {
         fields["parentId"]    = parent == temps.parent_of.end () ?
         nlohmann::json (nullptr) :
         nlohmann::json (temps.real.at (parent->second));
+
+        if (auto err = resolve_spec_binding (fields, temps, temp)) {
+            return err;
+        }
 
         vayu::db::Collection c;
         c.id         = temps.real.at (temp);
@@ -446,7 +506,67 @@ std::vector<vayu::db::RequestExample>& examples_out) {
     return std::nullopt;
 }
 
-/** Pass 3c - environment rows; nothing to resolve, they reference nobody. */
+/**
+ * Pass 3c - spec rows (issue #637). They reference nobody; collections reference
+ * *them*, which is why they are claimed in pass 1 like everything else.
+ *
+ * Deliberately not through a shared applier, because there is no field applier
+ * to share: `POST /specs` is create-only with two settable fields, and the two
+ * decisions that matter - the hash is computed here, never taken from the
+ * caller, and the size cap is the live `maxSpecDocumentBytes` - are made by the
+ * same two helpers the route core uses, so the paths cannot drift on either.
+ */
+std::optional<std::pair<int, nlohmann::json>> build_spec_rows (vayu::db::Database& db,
+const nlohmann::json& specs,
+const TempIds& temps,
+int64_t now,
+std::vector<vayu::db::SpecDocument>& out) {
+    out.reserve (specs.size ());
+    const size_t cap = spec_size_cap (db);
+
+    for (size_t i = 0; i < specs.size (); ++i) {
+        const auto& item        = specs[i];
+        const std::string& temp = temps.specs[i];
+
+        if (!item.contains ("content") || !item["content"].is_string () ||
+        item["content"].get<std::string> ().empty ()) {
+            return item_error ("Invalid 'content': must be a non-empty string", temp);
+        }
+        for (const char* derived : { "hash", "fetchedAt" }) {
+            if (item.contains (derived)) {
+                return item_error (std::string ("Invalid '") + derived +
+                "': computed by the engine; omit it",
+                temp);
+            }
+        }
+
+        vayu::db::SpecDocument s;
+        s.id      = temps.real.at (temp);
+        s.content = item["content"].get<std::string> ();
+        if (s.content.size () > cap) {
+            return item_error ("Spec document is " + std::to_string (s.content.size ()) +
+            " bytes, over the limit of " + std::to_string (cap) +
+            " (raise the 'maxSpecDocumentBytes' setting to allow more)",
+            temp);
+        }
+        s.hash       = spec_content_hash (s.content);
+        s.fetched_at = now;
+
+        if (item.contains ("sourceUrl") && !item["sourceUrl"].is_null ()) {
+            if (!item["sourceUrl"].is_string ()) {
+                return item_error ("Invalid 'sourceUrl': must be a string or null", temp);
+            }
+            const auto url = item["sourceUrl"].get<std::string> ();
+            if (!url.empty ()) {
+                s.source_url = url;
+            }
+        }
+        out.push_back (std::move (s));
+    }
+    return std::nullopt;
+}
+
+/** Pass 3d - environment rows; nothing to resolve, they reference nobody. */
 std::optional<std::pair<int, nlohmann::json>>
 build_environment_rows (const nlohmann::json& environments,
 const TempIds& temps,
@@ -505,6 +625,7 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
     const nlohmann::json* collections   = nullptr;
     const nlohmann::json* requests      = nullptr;
     const nlohmann::json* environments  = nullptr;
+    const nlohmann::json* specs         = nullptr;
     if (auto err = read_items (body, "collections", collections)) {
         return *err;
     }
@@ -512,6 +633,9 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
         return *err;
     }
     if (auto err = read_items (body, "environments", environments)) {
+        return *err;
+    }
+    if (auto err = read_items (body, "specs", specs)) {
         return *err;
     }
 
@@ -525,15 +649,15 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
             nested_examples += item["examples"].size ();
         }
     }
-    const size_t total =
-    collections->size () + requests->size () + environments->size () + nested_examples;
+    const size_t total = collections->size () + requests->size () +
+    environments->size () + nested_examples + specs->size ();
     if (total > MAX_IMPORT_ITEMS) {
         return body_error ("Import too large: " + std::to_string (total) +
         " items exceeds the limit of " + std::to_string (MAX_IMPORT_ITEMS) + " per call");
     }
 
     TempIds temps;
-    if (auto err = claim_all (*collections, *requests, *environments, temps)) {
+    if (auto err = claim_all (*collections, *requests, *environments, *specs, temps)) {
         return *err;
     }
     if (auto err = resolve_parents (*collections, temps)) {
@@ -548,6 +672,12 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
     std::vector<vayu::db::Request> request_rows;
     std::vector<vayu::db::Environment> environment_rows;
     std::vector<vayu::db::RequestExample> example_rows;
+    std::vector<vayu::db::SpecDocument> spec_rows;
+    // Ahead of the collections that may bind them, so a binding is validated
+    // against rows that have already been built.
+    if (auto err = build_spec_rows (db, *specs, temps, now, spec_rows)) {
+        return *err;
+    }
     if (auto err = build_collection_rows (db, *collections, temps, now, collection_rows)) {
         return *err;
     }
@@ -558,8 +688,30 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
         return *err;
     }
 
-    db.import_apply (collection_rows, request_rows, environment_rows, example_rows);
-    return { 200, nlohmann::json{ { "idMap", temps.real } } };
+    // The one existence check the shared applier cannot make - a binding may
+    // name a spec this payload is about to write, or one already stored, and
+    // nothing else - and the last thing before the write, under the same lock
+    // as the write. A binding validated outside the lock could be committed
+    // just after a concurrent `DELETE /specs/:id` removed the document it
+    // named, which is the dangling state the check exists to prevent. Bounded:
+    // one JSON parse per collection row, then the transaction `import_apply`
+    // was going to take the lock for anyway.
+    std::pair<int, nlohmann::json> result{ 200, nlohmann::json{ { "idMap", temps.real } } };
+    db.with_lock ([&] {
+        for (size_t i = 0; i < collection_rows.size (); ++i) {
+            if (auto err = apply_item_fields (
+                [&] {
+                    return reject_unbindable_spec (db, collection_rows[i].openapi,
+                    temps.pending_spec_ids);
+                },
+                "collection", temps.collections[i])) {
+                result = *err;
+                return;
+            }
+        }
+        db.import_apply (collection_rows, request_rows, environment_rows, example_rows, spec_rows);
+    });
+    return result;
 }
 
 void register_import_routes (RouteContext& ctx) {
@@ -578,13 +730,16 @@ void register_import_routes (RouteContext& ctx) {
      * Persists an entire parsed import atomically: collections, their requests
      * and environments in one transaction, with every real id generated
      * engine-side and returned in an `idMap` keyed by the client's temp ids.
-     * Body params: collections / requests / environments (arrays; absent or null
-     * means none). Each item carries a `tempId`; a collection may carry
-     * `parentTempId`, a request must carry `collectionTempId`, and a request
-     * may carry `examples` (an array of saved example responses, written with
-     * engine-generated ids and absent from the `idMap` - nothing references
-     * them). All other fields are the ones the matching POST /<resource>
-     * accepts, minus `id`.
+     * Body params: collections / requests / environments / specs (arrays; absent
+     * or null means none). Each item carries a `tempId`; a collection may carry
+     * `parentTempId` and may bind a spec with `openapi.specTempId` (a spec in
+     * this payload) or `openapi.specId` (one already stored), a request must
+     * carry `collectionTempId`, and a request may carry `examples` (an array of
+     * saved example responses, written with engine-generated ids and absent from
+     * the `idMap` - nothing references them). A spec item carries `content` and
+     * an optional `sourceUrl`; its `hash` and `fetchedAt` are engine-computed
+     * and rejected if sent. All other fields are the ones the matching
+     * POST /<resource> accepts, minus `id`.
      * Returns: 200 `{"idMap": {...}}`, or 400 with `error.item` naming the
      * item that failed - in which case nothing at all was written.
      */

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -110,6 +110,65 @@ static std::string http_version_seed (vayu::db::Database& db) {
 }
 
 /**
+ * Applies `specOperation` - which operation of the bound spec this request is
+ * (issue #637) - under the same null-vs-absent rule as every other field, with
+ * `null`/absent-on-create meaning "declares no operation" (a NULL column).
+ *
+ * Its own helper rather than `apply_json_field`, because the column is nullable:
+ * `apply_json_field` resets to a *text* default, and `"{}"` there would be a
+ * second spelling of "no operation" that every reader - the serializers, the
+ * diff in #627, the coverage count in #629 - would have to learn.
+ *
+ * Contents are validated, not merely shaped. `method` and `path` are what make
+ * the identity an identity: an operation with neither is not one, and a
+ * `spec_operation` holding half of one would fail much later, as a request that
+ * silently matches nothing in the spec it is supposedly bound to. `path` is the
+ * templated path, so it is required to start with `/` - a concrete URL stored
+ * here would never match the document it came from.
+ */
+static std::optional<std::pair<int, nlohmann::json>>
+apply_spec_operation_field (const nlohmann::json& json, std::optional<std::string>& out, bool is_create) {
+    if (!json.contains ("specOperation")) {
+        if (is_create) {
+            out = std::nullopt;
+        }
+        return std::nullopt;
+    }
+    const auto& value = json["specOperation"];
+    if (value.is_null ()) {
+        out = std::nullopt;
+        return std::nullopt;
+    }
+    if (!value.is_object ()) {
+        return std::make_pair (400,
+        error_body (400, "Invalid 'specOperation': must be a JSON object or null"));
+    }
+
+    for (const char* key : { "method", "path" }) {
+        if (!value.contains (key) || !value[key].is_string () ||
+        value[key].get<std::string> ().empty ()) {
+            return std::make_pair (400,
+            error_body (400, std::string ("Invalid 'specOperation.") + key +
+            "': must be a non-empty string"));
+        }
+    }
+    if (value["path"].get<std::string> ().front () != '/') {
+        return std::make_pair (400,
+        error_body (400,
+        "Invalid 'specOperation.path': must be the templated path from the "
+        "document and start with '/' (e.g. '/pets/{petId}')"));
+    }
+    if (value.contains ("operationId") && !value["operationId"].is_null () &&
+    !value["operationId"].is_string ()) {
+        return std::make_pair (400,
+        error_body (400, "Invalid 'specOperation.operationId': must be a string"));
+    }
+
+    out = value.dump ();
+    return std::nullopt;
+}
+
+/**
  * Applies the request body onto `r` under the one null-vs-absent rule (see the
  * helpers in routes.hpp). Shared by the create and update cores so the two
  * verbs cannot drift apart on what a field means.
@@ -188,6 +247,14 @@ bool is_create) {
     // applier rather than the by-id route alone, so `POST /import/apply` -
     // which runs this same function over a bulk payload - carries it too.
     apply_bool_field (json, "stream", r.stream, false, is_create);
+
+    // Operation identity (issue #637). Here rather than in the by-id route, for
+    // the same reason `stream` is: `POST /import/apply` runs this same applier,
+    // and an importer that recovered the operation a request came from must be
+    // able to store it in the one call that writes the tree.
+    if (auto err = apply_spec_operation_field (json, r.spec_operation, is_create)) {
+        return err;
+    }
 
     return std::nullopt;
 }
@@ -383,9 +450,10 @@ void register_request_routes (RouteContext& ctx) {
      * Body params: collectionId, name, method, url (all required), description,
      * params/headers (arrays of KeyValueEntry), body, bodyType, auth,
      * preRequestScript, postRequestScript, order, followRedirects,
-     * maxRedirects, stream, httpVersion (absent/null seeds from the
-     * "defaultHttpVersion" config entry; an unrecognized value is a 400, never
-     * silently coerced).
+     * maxRedirects, stream, specOperation ({operationId?, method, path} naming
+     * the operation of the collection's bound spec this request is, or null for
+     * none), httpVersion (absent/null seeds from the "defaultHttpVersion"
+     * config entry; an unrecognized value is a 400, never silently coerced).
      * Returns: The created request object, or 400 (body `id`, missing required
      * field, bad field shape).
      */

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -856,6 +856,20 @@ const std::string& run_id) {
         if (!config_obj.empty ()) {
             metadata["configuration"] = config_obj;
         }
+
+        // The spec this run was planned against (issue #637), echoed from the
+        // snapshot the scenario manifest stamped it into. Echoed rather than
+        // re-read from the collection: the binding is free to have moved since,
+        // and a report has to say what the run was measured against, not what
+        // the collection points at today. Absent for an unbound run, which is
+        // how the manifest stores it - #629's coverage block reads this.
+        if (auto scenario = config.find ("scenario");
+            scenario != config.end () && scenario->is_object ()) {
+            if (auto openapi = scenario->find ("openapi");
+                openapi != scenario->end () && openapi->is_object ()) {
+                metadata["openapi"] = *openapi;
+            }
+        }
     } catch (...) {
     }
 

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file http/routes/specs.cpp
+ * @brief OpenAPI documents - stored once, bound by collections (issue #637).
+ *
+ * A spec is not owned by a collection: several may bind the same document, and
+ * unbinding one must leave it there for the others. So it is a top-level
+ * resource with no cascade reaching it, and the one rule that keeps that safe
+ * lives here - `DELETE /specs/:id` refuses while any collection still names it,
+ * saying which. The alternative, cascading the bindings to unbound, would
+ * silently detach collections the caller never mentioned.
+ *
+ * The document is stored **verbatim** and its hash is computed here on every
+ * write, never taken from the caller: a run stamps the hash it planned against,
+ * and that stamp only means something if both sides were computed by this code
+ * on these bytes.
+ */
+
+#include "vayu/core/constants.hpp"
+#include "vayu/http/routes.hpp"
+#include "vayu/utils/encoding.hpp"
+#include "vayu/utils/id.hpp"
+#include "vayu/utils/json.hpp"
+#include "vayu/utils/logger.hpp"
+#include "vayu/utils/sha256.hpp"
+
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace vayu::http::routes {
+
+/**
+ * The live cap on a stored document, in bytes.
+ *
+ * Read fresh on every write from the `maxSpecDocumentBytes` config entry rather
+ * than cached, exactly as `http_version_seed` reads its default: a user who
+ * raises the limit must be able to import the document that was refused, without
+ * restarting the engine. A non-positive stored value falls back to the compiled
+ * default rather than disabling the cap - a tampered or zeroed row must not be
+ * able to turn the bound off.
+ *
+ * Shared with `POST /import/apply`, which writes spec rows of its own; declared
+ * in routes.hpp so the two paths cannot come to enforce different limits.
+ */
+size_t spec_size_cap (vayu::db::Database& db) {
+    const int configured = db.get_config_int ("maxSpecDocumentBytes",
+    static_cast<int> (vayu::core::constants::spec_document::MAX_BYTES));
+    if (configured <= 0) {
+        return vayu::core::constants::spec_document::MAX_BYTES;
+    }
+    return static_cast<size_t> (configured);
+}
+
+/**
+ * Hex-encoded SHA-256 of a document's text - the value stored in
+ * `spec_documents.hash` and stamped onto a run's snapshot.
+ *
+ * Non-static so specs_route_test.cpp can assert the two agree on the same bytes;
+ * declared in routes.hpp for the same reason.
+ */
+std::string spec_content_hash (const std::string& content) {
+    const auto digest = vayu::utils::sha256 (content);
+    return vayu::utils::hex_encode (std::string_view (
+    reinterpret_cast<const char*> (digest.data ()), digest.size ()));
+}
+
+/**
+ * Refuses a collection write whose `openapi` binding names a spec that will not
+ * exist when the write lands.
+ *
+ * A binding that resolves to nothing is the worst of the states this table can
+ * be in: the collection reads back as spec-bound, its runs stamp a `specId`
+ * nobody can fetch, and #627's sync has nothing to re-fetch *from*. So it is
+ * refused at the write rather than discovered by a later reader.
+ *
+ * @p pending is what the caller is about to write in the same transaction and
+ * cannot look up yet - `POST /import/apply`'s own spec section. Every other
+ * write path passes an empty set, because everything it may bind is already
+ * stored.
+ */
+std::optional<std::pair<int, nlohmann::json>> reject_unbindable_spec (vayu::db::Database& db,
+const std::string& openapi,
+const std::unordered_set<std::string>& pending) {
+    std::string spec_id;
+    try {
+        const auto parsed = nlohmann::json::parse (openapi);
+        if (!parsed.is_object ()) {
+            return std::nullopt;
+        }
+        spec_id = parsed.value ("specId", std::string ());
+    } catch (const std::exception&) {
+        return std::nullopt; // Not a binding; the applier already had its say.
+    }
+    if (spec_id.empty () || pending.contains (spec_id) ||
+    db.get_spec_document (spec_id).has_value ()) {
+        return std::nullopt;
+    }
+    return std::make_pair (400,
+    error_body (400, "Spec '" + spec_id + "' does not exist"));
+}
+
+/**
+ * Testable core of POST /specs - store one OpenAPI document, returning
+ * {http_status, json_body}.
+ *
+ * Create only, like every other resource here: the engine mints the id (#97), so
+ * a body `id` is a 400. There is deliberately no `PUT /specs/:id` - a document
+ * that changed is a *different* document, and rewriting one in place would
+ * invalidate the hash every run of every collection bound to it was stamped
+ * with. Phase 2 (#627) re-fetches by storing a new one and moving the binding.
+ *
+ * `hash` and `fetchedAt` are engine-computed and rejected in the body for the
+ * same reason `id` is: a caller-supplied hash would be a claim about bytes
+ * nobody verified.
+ */
+std::pair<int, nlohmann::json>
+create_spec_document_response (vayu::db::Database& db, const nlohmann::json& json) {
+    if (auto err = reject_client_supplied_id (json)) {
+        return *err;
+    }
+    for (const char* derived : { "hash", "fetchedAt" }) {
+        if (json.contains (derived)) {
+            return { 400,
+                error_body (400, std::string ("'") + derived +
+                "' is computed by the engine; omit it") };
+        }
+    }
+
+    std::string content;
+    if (auto err = apply_required_string_field (json, "content", content, /*is_create=*/true)) {
+        return *err;
+    }
+    if (content.empty ()) {
+        return { 400,
+            error_body (400,
+            "Invalid 'content': an empty document is not a spec") };
+    }
+    const size_t cap = spec_size_cap (db);
+    if (content.size () > cap) {
+        return { 400,
+            error_body (400, "Spec document is " + std::to_string (content.size ()) +
+            " bytes, over the limit of " + std::to_string (cap) +
+            " (raise the 'maxSpecDocumentBytes' setting to allow more)") };
+    }
+
+    vayu::db::SpecDocument spec;
+    spec.id      = vayu::utils::generate_id ("spec_");
+    spec.content = std::move (content);
+    spec.hash    = spec_content_hash (spec.content);
+    // When it was taken, not when the row was written - they are the same
+    // instant here, and #627 will re-stamp it on every re-fetch.
+    spec.fetched_at = now_ms ();
+
+    if (json.contains ("sourceUrl") && !json["sourceUrl"].is_null ()) {
+        if (!json["sourceUrl"].is_string ()) {
+            return { 400,
+                error_body (400, "Invalid 'sourceUrl': must be a string or null") };
+        }
+        const auto url = json["sourceUrl"].get<std::string> ();
+        if (!url.empty ()) {
+            spec.source_url = url;
+        }
+    }
+
+    if (db.get_spec_document (spec.id).has_value ()) {
+        return { 409,
+            error_body (409, "Spec '" + spec.id + "' already exists") };
+    }
+
+    db.save_spec_document (spec);
+    return { 200, vayu::json::serialize (spec) };
+}
+
+/** Testable core of GET /specs/:id - the whole document, or a 404. */
+std::pair<int, nlohmann::json>
+get_spec_document_response (vayu::db::Database& db, const std::string& id) {
+    auto spec = db.get_spec_document (id);
+    if (!spec) {
+        return { 404, error_body (404, "Spec not found") };
+    }
+    return { 200, vayu::json::serialize (*spec) };
+}
+
+/**
+ * Testable core of DELETE /specs/:id.
+ *
+ * A spec still bound by a collection is a **409 naming the collection**, never a
+ * cascade that quietly unbinds it: the caller asked to delete a document, not to
+ * edit collections it did not mention, and the message has to be actionable
+ * without a second round trip. Only the first binder is named, with a count when
+ * there are more, so the answer stays one line whatever the fan-out.
+ */
+std::pair<int, nlohmann::json>
+delete_spec_document_response (vayu::db::Database& db, const std::string& id) {
+    // Read-decide-write, so the whole of it is one lock scope (issue #386's
+    // rule): between "nobody binds this" and the delete, a concurrent collection
+    // write could bind it and be left pointing at a document that is gone. The
+    // collection write cores hold the lock across their own check-and-write, so
+    // the two composites serialize against each other rather than interleaving.
+    std::pair<int, nlohmann::json> result;
+    db.with_lock ([&] {
+        if (!db.get_spec_document (id).has_value ()) {
+            result = { 404, error_body (404, "Spec not found") };
+            return;
+        }
+        const auto bound = db.get_collections_bound_to_spec (id);
+        if (!bound.empty ()) {
+            std::string message = "Spec '" + id + "' is bound by collection '" +
+            bound.front ().name + "' (" + bound.front ().id + ")";
+            if (bound.size () > 1) {
+                message += " and " + std::to_string (bound.size () - 1) + " other" +
+                std::string (bound.size () == 2 ? "" : "s");
+            }
+            message += "; unbind it before deleting the document";
+            result = { 409, error_body (409, message) };
+            return;
+        }
+
+        db.delete_spec_document (id);
+        result = { 200,
+            nlohmann::json{ { "message", "Spec deleted successfully" }, { "id", id } } };
+    });
+    return result;
+}
+
+void register_spec_routes (RouteContext& ctx) {
+    /**
+     * POST /specs
+     * Stores one OpenAPI document verbatim and returns it with the id, hash and
+     * fetch time the engine assigned. Create only - there is no PUT, because a
+     * changed document is a new one (see the core above).
+     * Body params: content (required, non-empty, at most `maxSpecDocumentBytes`),
+     * sourceUrl (optional; null or absent means it did not come from a URL).
+     * `id`, `hash` and `fetchedAt` are engine-owned and a 400 if sent.
+     * Returns: the stored document, or 400.
+     */
+    ctx.server.Post ("/specs", [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto json           = nlohmann::json::parse (req.body);
+            auto [status, body] = create_spec_document_response (ctx.db, json);
+            if (status != 200) {
+                vayu::utils::log_warning ("POST /specs - " + std::to_string (status) +
+                ": " + error_message_of (body));
+            } else {
+                vayu::utils::log_info ("POST /specs - Stored spec: id=" +
+                body["id"].get<std::string> () +
+                ", hash=" + body["hash"].get<std::string> ());
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("POST /specs - Error: " + std::string (e.what ()));
+            send_error (res, 400, e.what ());
+        }
+    });
+
+    /**
+     * GET /specs/:id
+     * Returns the whole stored document - content included, since rendering and
+     * validating it is what every reader wants it for.
+     * Returns: the document, or 404.
+     */
+    ctx.server.Get (R"(/specs/([^/]+))",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string spec_id = req.matches[1];
+        try {
+            auto [status, body] = get_spec_document_response (ctx.db, spec_id);
+            if (status != 200) {
+                vayu::utils::log_warning ("GET /specs/:id - Spec not found: " + spec_id);
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("GET /specs/:id - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+
+    /**
+     * DELETE /specs/:id
+     * Deletes a stored document. Refused with 409 while any collection binds it,
+     * naming the binder - never a cascade that unbinds collections the caller
+     * did not mention.
+     * Returns: a message and the id, 404, or 409.
+     */
+    ctx.server.Delete (R"(/specs/([^/]+))",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string spec_id = req.matches[1];
+        try {
+            auto [status, body] = delete_spec_document_response (ctx.db, spec_id);
+            if (status != 200) {
+                vayu::utils::log_warning ("DELETE /specs/:id - " + std::to_string (status) +
+                " for id=" + spec_id + ": " + error_message_of (body));
+            } else {
+                vayu::utils::log_info ("DELETE /specs/:id - Deleted spec: id=" + spec_id);
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("DELETE /specs/:id - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
+        }
+    });
+}
+
+} // namespace vayu::http::routes

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -124,6 +124,7 @@ void Server::setup_routes () {
     routes::register_collection_routes (*route_ctx_);
     routes::register_request_routes (*route_ctx_);
     routes::register_request_example_routes (*route_ctx_);
+    routes::register_spec_routes (*route_ctx_);
     routes::register_reorder_routes (*route_ctx_);
     routes::register_environment_routes (*route_ctx_);
     routes::register_globals_routes (*route_ctx_);

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -270,6 +270,52 @@ void cap_trace_bodies (nlohmann::json& trace, size_t max_body_bytes) {
     }
 }
 
+namespace {
+
+/**
+ * The `specOperation` value both request serializers emit (issue #637).
+ *
+ * Shared rather than written twice on purpose: `serialize` backs
+ * `GET /requests/:id` and `serialize_to_stream` backs `GET /requests`, and a
+ * field added to one and forgotten in the other is this file's standing trap -
+ * the two views of the same row would disagree about whether a request names an
+ * operation at all. One reading, called from both.
+ *
+ * `null` for a column that is NULL and for a blob that no longer parses: the
+ * two are the same answer to "which operation is this", and every block around
+ * here degrades the same way rather than failing the read it sits in.
+ */
+Json spec_operation_node (const std::optional<std::string>& stored) {
+    if (!stored.has_value () || stored->empty ()) {
+        return nullptr;
+    }
+    try {
+        auto parsed = Json::parse (*stored);
+        return parsed.is_object () ? parsed : Json (nullptr);
+    } catch (const std::exception&) {
+        return nullptr;
+    }
+}
+
+} // namespace
+
+Json serialize (const vayu::db::SpecDocument& s) {
+    Json json;
+    json["id"] = s.id;
+    // Verbatim, and the whole of it: the Spec tab renders this text, a re-fetch
+    // diffs against it, and a validator resolves `$ref`s through it. A cap here
+    // would be a truncation nothing downstream could detect - the write path is
+    // where the size is refused.
+    json["content"] = s.content;
+    // Null rather than "" when the document did not come from a URL, so a client
+    // can offer "re-fetch" for exactly the documents that have somewhere to
+    // re-fetch from.
+    json["sourceUrl"] = s.source_url.has_value () ? Json (*s.source_url) : Json (nullptr);
+    json["fetchedAt"] = s.fetched_at;
+    json["hash"]      = s.hash;
+    return json;
+}
+
 Json serialize (const vayu::db::Collection& c) {
     Json json;
     json["id"] = c.id;
@@ -316,6 +362,20 @@ Json serialize (const vayu::db::Collection& c) {
             json["dataSchema"] = Json::parse (c.data_schema);
         } catch (const std::exception&) {
             json["dataSchema"] = Json::object ();
+        }
+    }
+
+    // The OpenAPI binding (issue #637). Same try-parse-with-default block, and
+    // `{}` for the same two cases: a row written before the column existed, and
+    // a blob that no longer parses. Both mean "bound to nothing", which is what
+    // an empty object says.
+    if (c.openapi.empty ()) {
+        json["openapi"] = Json::object ();
+    } else {
+        try {
+            json["openapi"] = Json::parse (c.openapi);
+        } catch (const std::exception&) {
+            json["openapi"] = Json::object ();
         }
     }
 
@@ -383,6 +443,12 @@ Json serialize (const vayu::db::Request& r) {
     json["maxRedirects"]      = r.max_redirects;
     json["httpVersion"]       = r.http_version;
     json["stream"]            = r.stream;
+    // Operation identity (issue #637). Always present as a key, `null` when the
+    // request declares none - the column is nullable, and a client that has to
+    // tell "no operation" from "key not serialized yet" would be guessing. An
+    // unparseable blob reads as null for the same reason the blocks above
+    // degrade to their defaults.
+    json["specOperation"] = spec_operation_node (r.spec_operation);
     json["updatedAt"]         = r.updated_at;
     json["createdAt"]         = r.created_at;
     return json;
@@ -1011,6 +1077,9 @@ void serialize_to_stream (const vayu::db::Request& r, std::ostream& out) {
     out << "\"maxRedirects\":" << r.max_redirects << ",";
     out << "\"httpVersion\":" << Json (r.http_version).dump () << ",";
     out << "\"stream\":" << (r.stream ? "true" : "false") << ",";
+    // Through the same `spec_operation_node` the object serializer uses, so the
+    // list route and the single route cannot come to disagree about it.
+    out << "\"specOperation\":" << spec_operation_node (r.spec_operation).dump () << ",";
     out << "\"updatedAt\":" << r.updated_at << ",";
     out << "\"createdAt\":" << r.created_at;
     out << "}";

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -1,0 +1,550 @@
+/**
+ * @file tests/specs_route_test.cpp
+ * @brief The OpenAPI storage foundation (issue #637): the `/specs` routes, the
+ *        collection binding, per-request operation identity, the fourth
+ *        `/import/apply` section, and the run stamp.
+ *
+ * Focus: this is a *contract* four later phases build on, so what is pinned here
+ * is the shape they will read - not merely that a write succeeds.
+ *
+ *  - A spec is stored once with an engine-computed hash, and a bound one cannot
+ *    be deleted out from under its collection.
+ *  - A binding that names nothing is refused at the write, on every path, so no
+ *    collection can read back as bound to a spec nobody can fetch.
+ *  - `specOperation` reads back identically through **both** request serializers.
+ *    They are separate code (`serialize` and `serialize_to_stream`) and a field
+ *    added to one and forgotten in the other is this repo's standing trap.
+ *  - A bound collection's run stamps `specId`/`specHash`; an unbound one stamps
+ *    nothing at all, absent rather than empty.
+ *
+ * Covers the routes' extracted cores in isolation, matching the suite's other
+ * route tests (no in-process HTTP server).
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "temp_database.hpp"
+#include "vayu/core/constants.hpp"
+#include "vayu/core/scenario_plan.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/utils/json.hpp"
+
+using nlohmann::json;
+
+namespace vayu::http::routes {
+// Defined in specs.cpp; each returns {http_status, json_body}.
+std::pair<int, nlohmann::json>
+create_spec_document_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+get_spec_document_response (vayu::db::Database& db, const std::string& id);
+std::pair<int, nlohmann::json>
+delete_spec_document_response (vayu::db::Database& db, const std::string& id);
+std::string spec_content_hash (const std::string& content);
+// Defined in collections.cpp / requests.cpp / import.cpp.
+std::pair<int, nlohmann::json>
+create_collection_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_collection_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+create_request_response (vayu::db::Database& db, const nlohmann::json& json);
+std::pair<int, nlohmann::json> update_request_response (vayu::db::Database& db,
+const std::string& id,
+const nlohmann::json& json);
+std::pair<int, nlohmann::json>
+get_request_response (vayu::db::Database& db, const std::string& id);
+std::string list_requests_body (vayu::db::Database& db, const std::string& collection_id);
+std::pair<int, nlohmann::json>
+import_apply_response (vayu::db::Database& db, const nlohmann::json& body);
+} // namespace vayu::http::routes
+
+namespace {
+
+namespace routes = vayu::http::routes;
+
+/** A minimal but real OpenAPI 3.1 document - the text is stored verbatim. */
+constexpr const char* PETSTORE =
+R"({"openapi":"3.1.0","info":{"title":"Pets","version":"1.0.0"},)"
+R"("paths":{"/pets":{"get":{"operationId":"listPets"}}}})";
+
+class SpecsRouteTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_specs_route.db";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+    }
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    /** Stores one document through the route core and returns its id. */
+    std::string store_spec (const char* content = PETSTORE) {
+        auto [status, body] =
+        routes::create_spec_document_response (*db_, json{ { "content", content } });
+        EXPECT_EQ (status, 200) << body.dump ();
+        return body.value ("id", std::string{});
+    }
+
+    /** Creates a collection through the route core and returns its id. */
+    std::string create_collection (const json& body) {
+        auto [status, response] = routes::create_collection_response (*db_, body);
+        EXPECT_EQ (status, 200) << response.dump ();
+        return response.value ("id", std::string{});
+    }
+
+    /** Creates a request under @p collection_id and returns its id. */
+    std::string create_request (const std::string& collection_id,
+    const json& extra = json::object ()) {
+        json body = { { "collectionId", collection_id }, { "name", "list pets" },
+            { "method", "GET" }, { "url", "https://example.test/pets" } };
+        body.update (extra);
+        auto [status, response] = routes::create_request_response (*db_, body);
+        EXPECT_EQ (status, 200) << response.dump ();
+        return response.value ("id", std::string{});
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+// POST /specs - stored once, hashed here
+// ---------------------------------------------------------------------------
+
+TEST_F (SpecsRouteTest, StoresTheDocumentVerbatimWithAnEngineComputedHash) {
+    auto [status, body] = routes::create_spec_document_response (*db_,
+    json{ { "content", PETSTORE }, { "sourceUrl", "https://example.test/openapi.json" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    EXPECT_EQ (body["content"].get<std::string> (), PETSTORE)
+    << "the document must round-trip byte for byte - every later phase parses "
+       "this text";
+    EXPECT_EQ (body["sourceUrl"].get<std::string> (), "https://example.test/openapi.json");
+    EXPECT_TRUE (body["id"].get<std::string> ().starts_with ("spec_"));
+    EXPECT_GT (body["fetchedAt"].get<int64_t> (), 0);
+    // The value, not merely "a string": the run stamp is only worth anything if
+    // both sides of a comparison were computed by this function on these bytes.
+    EXPECT_EQ (body["hash"].get<std::string> (), routes::spec_content_hash (PETSTORE));
+    EXPECT_EQ (body["hash"].get<std::string> ().size (), 64u) << "hex sha256";
+}
+
+TEST_F (SpecsRouteTest, SourceUrlIsNullWhenTheDocumentDidNotComeFromOne) {
+    auto [status, body] =
+    routes::create_spec_document_response (*db_, json{ { "content", PETSTORE } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    // Null rather than "": a client offers "re-fetch" for exactly the documents
+    // that have somewhere to re-fetch from, and "" would look like one.
+    EXPECT_TRUE (body["sourceUrl"].is_null ());
+}
+
+TEST_F (SpecsRouteTest, RejectsAnEmptyOrMissingDocument) {
+    auto [missing, missing_body] =
+    routes::create_spec_document_response (*db_, json::object ());
+    EXPECT_EQ (missing, 400) << missing_body.dump ();
+
+    auto [empty, empty_body] =
+    routes::create_spec_document_response (*db_, json{ { "content", "" } });
+    EXPECT_EQ (empty, 400) << empty_body.dump ();
+}
+
+TEST_F (SpecsRouteTest, RejectsAnEngineOwnedFieldInTheBody) {
+    for (const char* field : { "id", "hash", "fetchedAt" }) {
+        json body = { { "content", PETSTORE } };
+        body[field] = field == std::string ("fetchedAt") ? json (1) : json ("spoofed");
+        auto [status, response] = routes::create_spec_document_response (*db_, body);
+        EXPECT_EQ (status, 400) << field << ": " << response.dump ();
+    }
+}
+
+TEST_F (SpecsRouteTest, RefusesADocumentOverTheConfiguredCapNamingBothNumbers) {
+    // Below the compiled default, so this proves the *live* config entry is what
+    // the write reads - not the constant.
+    auto entry = db_->get_config_entry ("maxSpecDocumentBytes");
+    ASSERT_TRUE (entry.has_value ()) << "the cap must be a seeded, user-visible knob";
+    entry->value = "64";
+    db_->save_config_entry (*entry);
+    const std::string oversized (128, 'x');
+
+    auto [status, body] =
+    routes::create_spec_document_response (*db_, json{ { "content", oversized } });
+    ASSERT_EQ (status, 400) << body.dump ();
+    const std::string message = body["error"]["message"].get<std::string> ();
+    EXPECT_NE (message.find ("128"), std::string::npos) << message;
+    EXPECT_NE (message.find ("64"), std::string::npos) << message;
+    EXPECT_NE (message.find ("maxSpecDocumentBytes"), std::string::npos) << message;
+}
+
+// ---------------------------------------------------------------------------
+// GET / DELETE /specs/:id
+// ---------------------------------------------------------------------------
+
+TEST_F (SpecsRouteTest, ReadsBackTheStoredDocumentAndAnswers404ForAMissingOne) {
+    const std::string id = store_spec ();
+
+    auto [found, found_body] = routes::get_spec_document_response (*db_, id);
+    ASSERT_EQ (found, 200) << found_body.dump ();
+    EXPECT_EQ (found_body["content"].get<std::string> (), PETSTORE);
+
+    auto [missing, missing_body] = routes::get_spec_document_response (*db_, "spec_nope");
+    EXPECT_EQ (missing, 404) << missing_body.dump ();
+}
+
+TEST_F (SpecsRouteTest, DeletesAnUnboundDocument) {
+    const std::string id = store_spec ();
+
+    auto [status, body] = routes::delete_spec_document_response (*db_, id);
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_FALSE (db_->get_spec_document (id).has_value ());
+}
+
+TEST_F (SpecsRouteTest, RefusesToDeleteADocumentACollectionStillBindsAndNamesIt) {
+    const std::string spec_id = store_spec ();
+    create_collection (json{ { "name", "Pets API" },
+    { "openapi",
+    { { "specId", spec_id }, { "specHash", routes::spec_content_hash (PETSTORE) } } } });
+
+    auto [status, body] = routes::delete_spec_document_response (*db_, spec_id);
+    ASSERT_EQ (status, 409) << body.dump ();
+    const std::string message = body["error"]["message"].get<std::string> ();
+    // Actionable without a second round trip - the caller has to know *which*
+    // collection to unbind.
+    EXPECT_NE (message.find ("Pets API"), std::string::npos) << message;
+    EXPECT_TRUE (db_->get_spec_document (spec_id).has_value ())
+    << "a refused delete must leave the document alone";
+}
+
+TEST_F (SpecsRouteTest, DeleteSucceedsOnceTheCollectionUnbinds) {
+    const std::string spec_id = store_spec ();
+    const std::string col_id  = create_collection (
+    json{ { "name", "Pets API" }, { "openapi", { { "specId", spec_id } } } });
+
+    // Unbinding is the one null-vs-absent rule, not a verb of its own.
+    auto [unbound, unbound_body] =
+    routes::update_collection_response (*db_, col_id, json{ { "openapi", nullptr } });
+    ASSERT_EQ (unbound, 200) << unbound_body.dump ();
+    EXPECT_TRUE (unbound_body["openapi"].is_object ());
+    EXPECT_TRUE (unbound_body["openapi"].empty ()) << "`{}` is how unbound is spelled";
+
+    auto [status, body] = routes::delete_spec_document_response (*db_, spec_id);
+    EXPECT_EQ (status, 200) << body.dump ();
+}
+
+// ---------------------------------------------------------------------------
+// The collection binding
+// ---------------------------------------------------------------------------
+
+TEST_F (SpecsRouteTest, AnUnboundCollectionSerializesAnEmptyBinding) {
+    const std::string col_id = create_collection (json{ { "name", "Plain" } });
+    auto stored              = db_->get_collection (col_id);
+    ASSERT_TRUE (stored.has_value ());
+    const auto serialized = vayu::json::serialize (*stored);
+    ASSERT_TRUE (serialized.contains ("openapi"));
+    EXPECT_TRUE (serialized["openapi"].is_object ());
+    EXPECT_TRUE (serialized["openapi"].empty ());
+}
+
+TEST_F (SpecsRouteTest, RejectsABindingThatNamesNoSpec) {
+    const std::string spec_id = store_spec ();
+    // An object that is not empty is a binding, and a binding without a specId
+    // names nothing - it would read back as a bound collection nobody can
+    // resolve.
+    auto [status, body] = routes::create_collection_response (*db_,
+    json{ { "name", "Pets" }, { "openapi", { { "syncedAt", 5 } } } });
+    EXPECT_EQ (status, 400) << body.dump ();
+
+    for (const auto& bad :
+    { json{ { "specId", spec_id }, { "specHash", 7 } },
+    json{ { "specId", spec_id }, { "syncedAt", "yesterday" } } }) {
+        auto [bad_status, bad_body] = routes::create_collection_response (*db_,
+        json{ { "name", "Pets" }, { "openapi", bad } });
+        EXPECT_EQ (bad_status, 400) << bad_body.dump ();
+    }
+}
+
+TEST_F (SpecsRouteTest, RejectsABindingToASpecThatDoesNotExist) {
+    auto [created, created_body] = routes::create_collection_response (*db_,
+    json{ { "name", "Pets" }, { "openapi", { { "specId", "spec_ghost" } } } });
+    ASSERT_EQ (created, 400) << created_body.dump ();
+    EXPECT_NE (created_body["error"]["message"].get<std::string> ().find ("spec_ghost"),
+    std::string::npos);
+
+    // And on update, which is the path a bind-from-here flow actually uses.
+    const std::string col_id = create_collection (json{ { "name", "Pets" } });
+    auto [updated, updated_body] = routes::update_collection_response (*db_, col_id,
+    json{ { "openapi", { { "specId", "spec_ghost" } } } });
+    EXPECT_EQ (updated, 400) << updated_body.dump ();
+}
+
+TEST_F (SpecsRouteTest, AnUpdateThatSaysNothingAboutTheBindingKeepsIt) {
+    const std::string spec_id = store_spec ();
+    const std::string col_id  = create_collection (
+    json{ { "name", "Pets" }, { "openapi", { { "specId", spec_id }, { "syncedAt", 42 } } } });
+
+    auto [status, body] =
+    routes::update_collection_response (*db_, col_id, json{ { "name", "Pets v2" } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (body["openapi"]["specId"].get<std::string> (), spec_id);
+    EXPECT_EQ (body["openapi"]["syncedAt"].get<int> (), 42);
+}
+
+// ---------------------------------------------------------------------------
+// Per-request operation identity - through both serializers
+// ---------------------------------------------------------------------------
+
+TEST_F (SpecsRouteTest, OperationIdentityReadsBackIdenticallyThroughBothSerializers) {
+    const std::string col_id = create_collection (json{ { "name", "Pets" } });
+    const json operation     = { { "operationId", "listPets" }, { "method", "GET" },
+        { "path", "/pets/{petId}" } };
+    const std::string req_id = create_request (col_id, json{ { "specOperation", operation } });
+
+    // The single-request route (`serialize`).
+    auto [status, single] = routes::get_request_response (*db_, req_id);
+    ASSERT_EQ (status, 200) << single.dump ();
+    ASSERT_TRUE (single.contains ("specOperation"));
+    EXPECT_EQ (single["specOperation"], operation);
+
+    // The list route (`serialize_to_stream`) - separate code, and the half this
+    // repo has forgotten before. Parsed back so the comparison is structural
+    // rather than a key-order coincidence.
+    const json listed = json::parse (routes::list_requests_body (*db_, col_id));
+    ASSERT_EQ (listed.size (), 1u);
+    ASSERT_TRUE (listed[0].contains ("specOperation"));
+    EXPECT_EQ (listed[0]["specOperation"], single["specOperation"])
+    << "the list route and the single route disagree about specOperation";
+}
+
+TEST_F (SpecsRouteTest, ARequestThatNamesNoOperationSerializesNullOnBothPaths) {
+    const std::string col_id = create_collection (json{ { "name", "Pets" } });
+    const std::string req_id = create_request (col_id);
+
+    auto [status, single] = routes::get_request_response (*db_, req_id);
+    ASSERT_EQ (status, 200) << single.dump ();
+    ASSERT_TRUE (single.contains ("specOperation"))
+    << "the key must always be present - absent would read as 'not serialized "
+       "yet' rather than 'declares no operation'";
+    EXPECT_TRUE (single["specOperation"].is_null ());
+
+    const json listed = json::parse (routes::list_requests_body (*db_, col_id));
+    ASSERT_EQ (listed.size (), 1u);
+    // `contains` before the read: a stream serializer that dropped the key would
+    // otherwise abort the whole binary on nlohmann's debug assertion instead of
+    // failing this one test.
+    ASSERT_TRUE (listed[0].contains ("specOperation"));
+    EXPECT_TRUE (listed[0]["specOperation"].is_null ());
+}
+
+TEST_F (SpecsRouteTest, OperationIdentityIsUnsetByAnExplicitNullOnUpdate) {
+    const std::string col_id = create_collection (json{ { "name", "Pets" } });
+    const std::string req_id = create_request (col_id,
+    json{ { "specOperation", { { "method", "GET" }, { "path", "/pets" } } } });
+
+    auto [kept, kept_body] =
+    routes::update_request_response (*db_, req_id, json{ { "name", "renamed" } });
+    ASSERT_EQ (kept, 200) << kept_body.dump ();
+    EXPECT_FALSE (kept_body["specOperation"].is_null ()) << "absent means keep";
+
+    auto [reset, reset_body] =
+    routes::update_request_response (*db_, req_id, json{ { "specOperation", nullptr } });
+    ASSERT_EQ (reset, 200) << reset_body.dump ();
+    EXPECT_TRUE (reset_body["specOperation"].is_null ());
+    EXPECT_FALSE (db_->get_request (req_id)->spec_operation.has_value ())
+    << "the column must be NULL, not the string \"{}\"";
+}
+
+TEST_F (SpecsRouteTest, RejectsAnOperationIdentityThatIsNotOne) {
+    const std::string col_id = create_collection (json{ { "name", "Pets" } });
+    const json bad[] = {
+        json ("GET /pets"),                                     // not an object
+        json{ { "operationId", "listPets" } },                  // no method/path
+        json{ { "method", "GET" } },                            // no path
+        json{ { "path", "/pets" } },                            // no method
+        json{ { "method", "" }, { "path", "/pets" } },          // empty method
+        json{ { "method", "GET" }, { "path", "pets" } },        // not a template path
+        json{ { "method", "GET" }, { "path", "https://x/p" } }, // a concrete URL
+        json{ { "method", "GET" }, { "path", "/pets" }, { "operationId", 7 } },
+    };
+    for (const auto& operation : bad) {
+        json body = { { "collectionId", col_id }, { "name", "r" }, { "method", "GET" },
+            { "url", "https://example.test/pets" }, { "specOperation", operation } };
+        auto [status, response] = routes::create_request_response (*db_, body);
+        EXPECT_EQ (status, 400) << operation.dump () << " -> " << response.dump ();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// POST /import/apply - the fourth section
+// ---------------------------------------------------------------------------
+
+TEST_F (SpecsRouteTest, ImportWritesSpecsAndResolvesABindingThroughTheTempIdMap) {
+    json payload = { { "specs", { { { "tempId", "s1" }, { "content", PETSTORE },
+                                   { "sourceUrl", "https://example.test/openapi.json" } } } },
+        { "collections", { { { "tempId", "c1" }, { "name", "Pets" },
+                             { "openapi", { { "specTempId", "s1" }, { "syncedAt", 9 } } } } } },
+        { "requests",
+            { { { "tempId", "r1" }, { "collectionTempId", "c1" }, { "name", "list" },
+                { "method", "GET" }, { "url", "https://example.test/pets" },
+                { "specOperation", { { "operationId", "listPets" },
+                                       { "method", "GET" }, { "path", "/pets" } } } } } } };
+
+    auto [status, body] = routes::import_apply_response (*db_, payload);
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    const auto spec_id = body["idMap"]["s1"].get<std::string> ();
+    EXPECT_TRUE (spec_id.starts_with ("spec_"));
+    auto stored_spec = db_->get_spec_document (spec_id);
+    ASSERT_TRUE (stored_spec.has_value ());
+    EXPECT_EQ (stored_spec->content, PETSTORE);
+    // Computed on the import path too, never carried on the payload.
+    EXPECT_EQ (stored_spec->hash, routes::spec_content_hash (PETSTORE));
+    EXPECT_EQ (stored_spec->source_url.value_or (""), "https://example.test/openapi.json");
+
+    auto stored_col = db_->get_collection (body["idMap"]["c1"].get<std::string> ());
+    ASSERT_TRUE (stored_col.has_value ());
+    const json binding = json::parse (stored_col->openapi);
+    EXPECT_EQ (binding["specId"].get<std::string> (), spec_id)
+    << "the temp id must have been rewritten to the engine's real id";
+    EXPECT_FALSE (binding.contains ("specTempId"));
+    EXPECT_EQ (binding["syncedAt"].get<int> (), 9);
+
+    // Operation identity rides the shared applier, so it arrives free.
+    auto stored_req = db_->get_request (body["idMap"]["r1"].get<std::string> ());
+    ASSERT_TRUE (stored_req.has_value ());
+    ASSERT_TRUE (stored_req->spec_operation.has_value ());
+    EXPECT_EQ (json::parse (*stored_req->spec_operation)["operationId"].get<std::string> (),
+    "listPets");
+}
+
+TEST_F (SpecsRouteTest, ImportMayBindASpecThatIsAlreadyStored) {
+    const std::string spec_id = store_spec ();
+    json payload = { { "collections", { { { "tempId", "c1" }, { "name", "Pets" },
+                                          { "openapi", { { "specId", spec_id } } } } } } };
+
+    auto [status, body] = routes::import_apply_response (*db_, payload);
+    ASSERT_EQ (status, 200) << body.dump ();
+    auto stored = db_->get_collection (body["idMap"]["c1"].get<std::string> ());
+    ASSERT_TRUE (stored.has_value ());
+    EXPECT_EQ (json::parse (stored->openapi)["specId"].get<std::string> (), spec_id);
+}
+
+TEST_F (SpecsRouteTest, ImportRefusesAnUnresolvableBindingAndWritesNothing) {
+    for (const auto& binding : { json{ { "specTempId", "nobody" } },
+         json{ { "specId", "spec_ghost" } } }) {
+        json payload = { { "collections",
+            { { { "tempId", "c1" }, { "name", "Pets" }, { "openapi", binding } } } } };
+        auto [status, body] = routes::import_apply_response (*db_, payload);
+        EXPECT_EQ (status, 400) << binding.dump () << " -> " << body.dump ();
+        EXPECT_TRUE (db_->get_collections ().empty ())
+        << "a rejected payload must persist nothing";
+    }
+}
+
+TEST_F (SpecsRouteTest, ImportRefusesABindingThatNamesTheSpecTwoWays) {
+    json payload = { { "specs", { { { "tempId", "s1" }, { "content", PETSTORE } } } },
+        { "collections",
+            { { { "tempId", "c1" }, { "name", "Pets" },
+                { "openapi", { { "specTempId", "s1" }, { "specId", "spec_other" } } } } } } };
+    auto [status, body] = routes::import_apply_response (*db_, payload);
+    EXPECT_EQ (status, 400) << body.dump ();
+    EXPECT_TRUE (db_->get_spec_document (std::string ()).has_value () == false);
+    EXPECT_TRUE (db_->get_collections ().empty ());
+}
+
+TEST_F (SpecsRouteTest, ImportRefusesAnEngineComputedFieldOnASpecItem) {
+    for (const char* field : { "hash", "fetchedAt" }) {
+        json item = { { "tempId", "s1" }, { "content", PETSTORE } };
+        item[field] = field == std::string ("fetchedAt") ? json (1) : json ("spoofed");
+        auto [status, body] = routes::import_apply_response (*db_, json{ { "specs", { item } } });
+        EXPECT_EQ (status, 400) << field << ": " << body.dump ();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The run stamp - the reader that makes the binding worth storing
+// ---------------------------------------------------------------------------
+
+TEST_F (SpecsRouteTest, ABoundCollectionsRunStampsTheSpecIdAndHash) {
+    const std::string spec_id = store_spec ();
+    const std::string hash    = routes::spec_content_hash (PETSTORE);
+    const std::string col_id  = create_collection (json{ { "name", "Pets" },
+    { "openapi", { { "specId", spec_id }, { "specHash", hash } } } });
+    create_request (col_id);
+
+    vayu::core::ScenarioResolveOptions options;
+    options.timeout_ms            = 1000;
+    options.limits.max_steps      = 10;
+    options.limits.max_data_rows  = 10;
+    options.limits.max_data_bytes = 4096;
+    auto resolved = vayu::core::resolve_scenario (*db_,
+    json{ { "source", "collection" }, { "collectionId", col_id } }, options);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_TRUE (resolved.spec.bound ());
+
+    const json manifest = vayu::core::build_scenario_manifest (resolved.request,
+    resolved.plan, resolved.spec);
+    ASSERT_TRUE (manifest.contains ("openapi")) << manifest.dump ();
+    EXPECT_EQ (manifest["openapi"]["specId"].get<std::string> (), spec_id);
+    EXPECT_EQ (manifest["openapi"]["specHash"].get<std::string> (), hash);
+}
+
+TEST_F (SpecsRouteTest, AnUnboundCollectionsRunStampsNothingAtAll) {
+    const std::string col_id = create_collection (json{ { "name", "Plain" } });
+    create_request (col_id);
+
+    vayu::core::ScenarioResolveOptions options;
+    options.timeout_ms            = 1000;
+    options.limits.max_steps      = 10;
+    options.limits.max_data_rows  = 10;
+    options.limits.max_data_bytes = 4096;
+    auto resolved = vayu::core::resolve_scenario (*db_,
+    json{ { "source", "collection" }, { "collectionId", col_id } }, options);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_FALSE (resolved.spec.bound ());
+
+    const json manifest = vayu::core::build_scenario_manifest (resolved.request,
+    resolved.plan, resolved.spec);
+    // Absent, not null and not `{}` - one answer with one spelling, which is
+    // what #629's coverage block branches on.
+    EXPECT_FALSE (manifest.contains ("openapi")) << manifest.dump ();
+}
+
+TEST_F (SpecsRouteTest, TheStampRecordsWhatTheRunWasPlannedAgainstNotTheLatestBinding) {
+    const std::string spec_id = store_spec ();
+    const std::string hash    = routes::spec_content_hash (PETSTORE);
+    const std::string col_id  = create_collection (json{ { "name", "Pets" },
+    { "openapi", { { "specId", spec_id }, { "specHash", hash } } } });
+    create_request (col_id);
+
+    vayu::core::ScenarioResolveOptions options;
+    options.timeout_ms            = 1000;
+    options.limits.max_steps      = 10;
+    options.limits.max_data_rows  = 10;
+    options.limits.max_data_bytes = 4096;
+    auto resolved = vayu::core::resolve_scenario (*db_,
+    json{ { "source", "collection" }, { "collectionId", col_id } }, options);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    const json manifest = vayu::core::build_scenario_manifest (resolved.request,
+    resolved.plan, resolved.spec);
+
+    // Unbind afterwards: a run is a record of what ran, so the manifest already
+    // built must not change under it.
+    auto [status, body] =
+    routes::update_collection_response (*db_, col_id, json{ { "openapi", nullptr } });
+    ASSERT_EQ (status, 200) << body.dump ();
+    EXPECT_EQ (manifest["openapi"]["specHash"].get<std::string> (), hash);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

The engine half of #626 - the storage foundation #627-#630 all stack on.

**The plan (root cause → approach → rejected alternative).** The epic needs one
place a spec document lives and one place a collection says which document it
speaks for, and every phase behind it (#627 sync, #628 validation, #629
coverage, #630 export) reads that contract rather than re-deriving it. The
approach is a new `spec_documents` table holding the text **verbatim** plus an
engine-computed hex sha256, and a `collections.openapi` blob
(`{specId, specHash, syncedAt}`, `{}` = unbound) as the *edge* - so several
collections may bind one document, nothing cascades to it, and a spec still
bound is a `409` naming the binder rather than a silent unbind of collections
the caller never mentioned. **The alternative I rejected is storing a parsed
model instead of the text.** Every phase behind this needs the document itself -
the Spec tab renders it, sync diffs against it, the validator resolves `$ref`s
through it, export writes a new one beside it - so a parse here would be redone
by each of them and would drop whatever the author wrote that the parser did not
model. I also rejected a `PUT /specs/:id`: a changed document is a *different*
document, and rewriting one in place would invalidate the hash every run of
every bound collection was already stamped with.

Everything below is #626's decision restated, not re-opened - including the two
it left open (delete-while-bound is refuse-with-name; bind-from-here stays in
phase 1 on the app side).

**What landed**

- **`spec_documents`** - `id` (`spec_` prefix), `content`, nullable `source_url`,
  `fetched_at`, `hash`. New table, so `sync_schema` creates it outright; the
  content+hash pair follows `body_blobs`. The hash is **never taken from the
  caller** on either write path - a caller-supplied one would be a claim about
  bytes nobody verified, and the run stamp is only worth something because both
  sides were computed by the same code on the same bytes.
- **Routes** - `POST /specs`, `GET /specs/:id`, `DELETE /specs/:id`. The size cap
  is the live `maxSpecDocumentBytes` config entry (default 10 MB, aligned with
  `json::MAX_FIELD_SIZE`), read fresh per write and shared with import through
  one helper, refusing with the count *and* the cap per the `MAX_DATA_BYTES`
  rationale rather than letting the transport reset.
- **Collection binding** - `openapi` column (NOT NULL, `default_value "{}"`, so
  `sync_schema` ALTERs it on), applied in `apply_collection_fields` via
  `apply_json_field` + a contents check, and serialized with the same
  try-parse-with-default block `dataSchema` uses. Unbinding is the existing
  null rule (`{"openapi": null}`), not a verb of its own.
- **Per-request operation identity** - one nullable `spec_operation` column
  (`{operationId?, method, path}`), applied in `apply_request_fields` and emitted
  by **both** serializers through a single shared `spec_operation_node`, so the
  list route and the single route cannot drift. Roster comment updated. `path`
  must be the templated path (`/pets/{petId}`) and is rejected if it is not -
  it is the identity #627 diffs against and #629 counts by, and a concrete URL
  would match nothing in the document it came from.
- **`/import/apply`** - a fourth `specs` section claimed in pass 1 with its own
  prefix; a collection binds either `openapi.specTempId` (resolved through the
  temp-id map exactly as `collectionTempId` is) or `openapi.specId` (one already
  stored), both at once being a `400`. Spec rows are written ahead of the
  collections that bind them, in the same transaction. The item cap counts them.
- **The reader, same change** - `resolve_scenario` captures the binding off the
  collection it already fetches, `build_scenario_manifest` stamps
  `openapi: {specId, specHash}` into `runs.config_snapshot`, and
  `GET /runs/:id/report` echoes it under `metadata`. An unbound run stamps
  **nothing** (absent, not empty), so #629 has one thing to branch on.

**Deliberate deviations from the issue spec**, both additive:

1. The issue says import resolves the binding "like `collectionTempId`". I also
   accept a plain `openapi.specId` naming an **already stored** document, since
   an incremental import into an existing spec is a real case and refusing it
   would have made #627 add the path back. Sending both spellings is a `400`.
2. The issue does not mention locking. Each check-then-write here is a
   read-decide-write composite, so all three (`POST`/`PUT /collections`,
   `POST /import/apply`) and the delete refusal hold the DB mutex for the whole
   of it via `Database::with_lock` - otherwise a concurrent `DELETE /specs/:id`
   could land between "this spec exists" and the write and strand a binding,
   which is the one state the check exists to prevent. This is `with_lock`'s
   documented purpose (#386); the import check moved to the locked section so
   there is one check site rather than two. No threaded test was added - these
   are three call sites of an existing primitive, not a new concurrency
   protocol.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev` - **1681/1681 passed**,
including **25 new tests** in `engine/tests/specs_route_test.cpp`. No app code
was touched, so the app suite was not in scope for this change.

The new tests pin the contract the four phases behind this will read, not merely
that a write succeeds: spec CRUD with the value of the hash asserted (not just
"a string"), the cap proven to read the *live* config entry rather than the
constant, delete-while-bound naming the binder and leaving the row alone,
binding shapes and unresolvable `specId` on create **and** update, `specOperation`
through **both** serializers compared against each other, the null/absent/reset
rule on the nullable column, the import round-trip with temp-id resolution, and
the run stamp present when bound / **absent** when not.

**Mutation-checked** (reverted, confirmed red, restored):

- Dropping `specOperation` from `serialize_to_stream` only →
  `OperationIdentityReadsBackIdenticallyThroughBothSerializers` fails
  (`listed[0].contains("specOperation")` false) while the single-route
  assertions still pass - i.e. the test catches exactly the two-serializer trap.
- Removing the snapshot stamp from `build_scenario_manifest` →
  `ABoundCollectionsRunStampsTheSpecIdAndHash` fails.

`mkdocs build --strict -f .github/mkdocs.yml` builds clean with the docs changes.

**Pre-existing, not introduced here:** `HttpClientTest.UnnegotiatedConnectionReportsEmptyHttpVersion`
timed out once on a first run in this sandbox and passed on every subsequent
run - a network-dependent flake, untouched by this change.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs land in the same commit per the repo rule: `docs/engine/db-schema.md` (the
two new columns and the new table, each with the reasoning for its migration
shape) and `docs/engine/api-reference.md` (a new `## Specs` section, the
`openapi` and `specOperation` field contracts on both verbs, the `specs` import
section and its new error messages, and `metadata.openapi` on the report).
`engine/CLAUDE.md` gains the endpoint row and the design note.

## Related Issues

Closes #637. Part of #625; the engine half of #626. Unblocks #627, #628, #629,
#630 and the app half #638.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwR2hqEy71AGfBbLZgn6HM)_