### PR TITLE
feat(engine/data): bind {{data.*}} in auth credentials on a single send

### DIFF
--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -809,12 +809,17 @@ const MAX_STREAM_BUDGET_MS = 60_000;
  * a column the row does not carry is a `400` naming the token and the row's
  * columns, and *nothing is sent* - so an agent reading the error can fix the
  * request rather than wondering what went out.
+ *
+ * Credentials bind too (issue #642), and the description says which mode does
+ * not: an agent that is told "auth cannot bind" writes the token somewhere else
+ * for no reason, and one told nothing writes it into an oauth2 config and gets
+ * a 400 it cannot explain.
  */
 const dataRowInput = z
 	.record(z.unknown())
 	.optional()
 	.describe(
-		'One data row to bind, as an object of name/value pairs (e.g. {"id": "7", "email": "a@b.c"}). Every {{data.column}} in the URL, headers and body is substituted against it, and pre-request and post-response scripts read it as pm.iterationData (pm.info.iteration is 0). A column the row does not carry is an error naming the token and the row\'s columns, and nothing is sent. Auth credentials cannot carry a {{data.*}} token on a single send - they are applied before the row is read - so move such a token into the URL, a header or the body. Omit this to send without a row, which leaves {{data.*}} tokens written as they stand.'
+		'One data row to bind, as an object of name/value pairs (e.g. {"id": "7", "email": "a@b.c"}). Every {{data.column}} in the URL, headers, body and auth credentials is substituted against it, and pre-request and post-response scripts read it as pm.iterationData (pm.info.iteration is 0). A column the row does not carry is an error naming the token and the row\'s columns, and nothing is sent. A credential binds before it is encoded, so basic auth base64s the row\'s values; the exception is OAuth 2.0, whose token comes from the token endpoint rather than the request, so a {{data.*}} in an oauth2 config is refused by name. Omit this to send without a row, which leaves {{data.*}} tokens written as they stand.'
 	);
 
 const streamInput = z

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -338,20 +338,23 @@ export interface ExecuteRequestRequest {
 	 * One data row to bind before the request goes out (issue #601).
 	 *
 	 * The single-send half of `scenario.data`: `{{data.column}}` tokens in the
-	 * URL, headers, body and form fields are substituted against it, and both
-	 * scripts read it as `pm.iterationData` (`pm.info.iteration` is 0 - the send
-	 * *is* row 0 of 1). Absent is the ordinary send, where those tokens go out
-	 * written as they stand and `pm.iterationData` is `undefined`.
+	 * URL, headers, body, form fields and auth credentials are substituted
+	 * against it, and both scripts read it as `pm.iterationData`
+	 * (`pm.info.iteration` is 0 - the send *is* row 0 of 1). Absent is the
+	 * ordinary send, where those tokens go out written as they stand and
+	 * `pm.iterationData` is `undefined`.
 	 *
 	 * An object of name/value pairs, never the array a run sends: one row. A
 	 * column the row does not carry is a `400` naming the token and the row's
 	 * own columns, and nothing is sent - the same refusal a run makes per
 	 * iteration, moved to before the run row exists.
 	 *
-	 * Credentials are the one place a token cannot bind here: auth is applied
-	 * when the request is built, before the row is read, so an `auth` block
-	 * carrying `{{data.*}}` is a `400` rather than a silent base64 of the token
-	 * text. A collection run binds those per iteration (issue #591).
+	 * Credentials bind **before** they are encoded (issue #642), so basic auth
+	 * base64s the row's values rather than the token text - the same deferral a
+	 * collection run performs per iteration (issue #591). OAuth 2.0 is the one
+	 * mode no row can reach, because its token is acquired against the token
+	 * endpoint instead of being written into the request; a `{{data.*}}` in an
+	 * oauth2 config is a `400` naming the token.
 	 */
 	data?: Record<string, unknown>;
 }

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -264,12 +264,19 @@ contract in the collection chain, or no remembered file for the collection that
 declared it. A file that has moved says so when you open the list, and picking
 it again in the Data tab is the fix.
 
-One thing a single send cannot bind is **auth credentials**. Auth is applied
-when the request is built, before the row is read, so a `{{data.user}}` in a
-username would go out as part of an already-encoded header. Vayu refuses that by
-name rather than sending it wrong: move the token into the URL, a header or the
-body, or run the collection with the data file, which binds credentials per
-iteration.
+**Auth credentials bind on a single send too.** A `{{data.user}}` in a
+basic-auth username, a bearer token or an api key takes the row's value the same
+way the URL and the body do, and it does so *before* the credentials are encoded
+- so the header carries the row's values rather than base64 of the token text.
+This is the same thing a collection run does per iteration, which is what makes
+a credentials file work identically under Send-with-row and under Run
+collection.
+
+The exception is **OAuth 2.0**: its token is fetched from the token endpoint
+rather than written into the request, so no row can reach it, under either
+Send-with-row or a collection run. A `{{data.*}}` in an OAuth 2.0 config is
+refused by name rather than sent wrong - use a static credential there, or move
+the token into the request itself.
 
 The rows read for the picker are held for that send and nothing more - the same
 rule the rest of this page describes.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2379,16 +2379,22 @@ Refused with a **400**, before any run row exists and with nothing sent:
 | over the byte cap | `'data' is N bytes, over the limit of M (raise the 'maxScenarioDataBytes' setting to allow more)` |
 | a token names a column the row lacks | the binder's own sentence, naming the token, the row and the row's columns |
 | a `null` cell, a header collision, an unwritable XML placement | the binder's own sentence - identical to a run's, see [Scenario runs](#scenario-runs) |
-| `auth` carries a `{{data.*}}` token | `Auth credentials carry {{data.user}}, and a single send cannot bind them: ...` |
+| an OAuth 2.0 config carries a `{{data.*}}` token | `Auth credentials carry {{data.client}} in an OAuth 2.0 configuration, and no row can reach it: ...` |
 
-That last one is the one asymmetry with a collection run, and it is a refusal
-rather than a silent wrong send. Auth is applied when the request is built -
-basic credentials are already collapsed into one base64 `Authorization` value -
-so a credential token would go out as base64 of the literal token text. A run
-resolves its plan once and can afford to keep the credentials typed and bind
-them per iteration (issue #591); a single send has no plan to hang that off, so
-it names the token and points at the alternatives (move it into the URL, a
-header or the body, or run the collection with a data file).
+**Credentials bind here too** (issue #642). A `{{data.user}}` in a basic-auth
+username, a bearer token or an api key is substituted from the row like any
+other field, and it is bound **before** the credentials are encoded - so basic
+auth base64s the row's values, and an api key in the query is percent-encoded
+after the substitution rather than before. This is the same deferral a
+collection run performs per iteration (issue #591): the credentials are parsed
+and kept typed, the request is built without resolving them, and the auth is
+applied once the row has reached it.
+
+**OAuth 2.0 is the one mode a row cannot reach**, and it is refused by name
+rather than sent wrong. Its token is acquired against the token endpoint instead
+of being written into the request, so there is no moment at which a bind could
+happen - exactly the reason a scenario run refuses the same config. Use a static
+credential there, or move the data token into the request itself.
 
 **`requestName` is script identity, not an HTTP field** - it never reaches the
 wire. The scripts read it as `pm.info.requestName` (with `requestId` as

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -410,10 +410,11 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   It rides *beside* the composed payload rather than through `/compose`, because
   `{{data.*}}` survives composition by design - that is what leaves the tokens
   for the engine to bind. A column the row does not carry is an error naming the
-  token and the row's columns, and **nothing is sent**. Auth credentials are the
-  one place a token cannot bind on a single send (they are applied before the
-  row is read) and are refused by name rather than sent as base64 of the token
-  text. The allowlist gate reads the composed URL as always - a `{{data.*}}` in
+  token and the row's columns, and **nothing is sent**. Auth credentials bind as
+  well (issue #642) - before they are encoded, so basic auth base64s the row's
+  values - with OAuth 2.0 the one mode no row can reach, refused by name because
+  its token comes from the token endpoint rather than from the request. The
+  allowlist gate reads the composed URL as always - a `{{data.*}}` in
   the *path* leaves the host knowable and is judged on that host, while a
   template in the authority is still "unknown host" and denied.
   `run_collection_smoke` stays out of it: it has no scenario path at all, so

--- a/engine/include/vayu/core/scenario_data.hpp
+++ b/engine/include/vayu/core/scenario_data.hpp
@@ -259,6 +259,36 @@ const nlohmann::json& row,
 size_t row_index);
 
 /**
+ * Bind @p auth's credentials against @p row and apply the result to @p request.
+ *
+ * The whole deferred-credential sequence in one place - join, then apply - for
+ * every caller that built its request with `http::AuthResolution::Defer`. Both
+ * of them drive this: a scenario step binds it per iteration through
+ * `bind_step_auth`, and a single send binds it once
+ * (`POST /execute` with a `data` row, issue #642). A second copy of the order
+ * would be a copy that stops receiving this one's fixes, and the order is the
+ * entire point - the row has to reach the credentials before `apply_auth`
+ * base64-encodes them.
+ *
+ * @p auth is taken **by value**: the join rewrites credentials in place, and a
+ * plan's step auth is shared, immutable and re-bound by every virtual user.
+ *
+ * A no-op returning success for an empty @p tmpl, so a caller may call it
+ * unconditionally. Note that this makes an empty template mean "these
+ * credentials carry no row values" and *not* "apply this auth" - a caller that
+ * deferred a build must only have done so for a non-empty template.
+ *
+ * No database handle reaches `apply_auth`: oauth2 is the only mode that needs
+ * one, and an oauth2 config carrying a data token is refused before any build
+ * is deferred (@ref first_oauth2_data_token).
+ */
+[[nodiscard]] DataBindResult bind_auth_row (vayu::Request& request,
+vayu::http::Auth auth,
+const StepDataTemplate& tmpl,
+const nlohmann::json& row,
+size_t row_index);
+
+/**
  * The first `{{data.column}}` in any string of @p value, recursively, written
  * back with its braces - or `nullopt` when it carries none.
  *
@@ -268,6 +298,24 @@ size_t row_index);
  * belongs is not a placement anyone means.
  */
 [[nodiscard]] std::optional<std::string> first_data_token_in (const nlohmann::json& value);
+
+/**
+ * The first `{{data.column}}` in @p auth's OAuth 2.0 configuration, or
+ * `nullopt` - for any other mode as well as for an oauth2 config carrying none.
+ *
+ * **OAuth 2.0 is the one mode deferral cannot serve**, and this is the check
+ * that says so, for both callers that defer. Its token is acquired against the
+ * token endpoint once - when a plan is resolved, or before a single send leaves
+ * - so there is no later moment at which a row could reach the acquisition, the
+ * way binding a credential before `apply_auth` encodes it reaches every other
+ * mode. Refused by name rather than sent to the token endpoint as the literal
+ * token text.
+ *
+ * Every other mode's credentials are walked by `walk_auth_credentials` and
+ * bound; an oauth2 config is deliberately absent from that walk, which is why
+ * it needs this second, config-shaped scan.
+ */
+[[nodiscard]] std::optional<std::string> first_oauth2_data_token (const vayu::http::Auth& auth);
 
 /**
  * Render one row value as the text a `{{data.column}}` token substitutes.

--- a/engine/include/vayu/http/request_builder.hpp
+++ b/engine/include/vayu/http/request_builder.hpp
@@ -10,10 +10,30 @@
 #include "vayu/db/database.hpp"
 #include "vayu/types.hpp"
 
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <string>
 
 namespace vayu::http {
+
+/**
+ * @brief Whether `build_request` resolves the config's `auth`, or leaves it.
+ *
+ * `Apply` is what every ordinary caller wants and is the default: the
+ * credentials become an `Authorization` header (or a query parameter) as part
+ * of building the request.
+ *
+ * `Defer` exists for the one caller shape that must touch the credentials
+ * *before* they are encoded: a `{{data.column}}` token inside a credential has
+ * to carry its row's value before `apply_auth` base64-encodes a username and
+ * password into one header, because after that it is unreadable and would go
+ * out as base64 of the literal token text (issue #591). Such a caller parses
+ * the auth itself, joins it against the row and applies it afterwards -
+ * `vayu::core::bind_auth_row` is that step, and it is the only correct way to
+ * finish a deferred build. A `Defer` whose auth is never applied sends an
+ * unauthenticated request.
+ */
+enum class AuthResolution : std::uint8_t { Apply, Defer };
 
 /**
  * @brief Result of constructing a Request from a run config.
@@ -41,8 +61,10 @@ struct RequestBuild {
  * @param config     The run config JSON (HTTP fields at the root, plus `auth`).
  * @param db         Database handle for token lookup (reserved for oauth2; may be null).
  * @param timeout_ms The already-resolved request timeout to apply.
+ * @param auth       Whether to resolve `auth` here (default) or leave it to the
+ *                   caller - see @ref AuthResolution.
  */
 RequestBuild build_request (const nlohmann::json& config, vayu::db::Database* db,
-int timeout_ms);
+int timeout_ms, AuthResolution auth = AuthResolution::Apply);
 
 } // namespace vayu::http

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -19,8 +19,11 @@
 #include <vector>
 
 #include "vayu/core/run_manager.hpp"
+#include "vayu/core/scenario_data.hpp"
 #include "vayu/db/database.hpp"
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/cookie_jar.hpp"
+#include "vayu/http/request_builder.hpp"
 // The `POST /execute` core - `ScriptVariableScopes`, the exchange itself - now
 // shared with the scenario runner and therefore declared where `vayu_core` can
 // see it. Included here so route TUs keep naming it through routes.hpp.
@@ -636,25 +639,47 @@ struct DataRow {
 DataRow read_data_row (const nlohmann::json& json, size_t max_bytes);
 
 /**
- * The first `{{data.column}}` token in @p json's `auth` block, or `nullopt`.
+ * How a send-with-row's credentials are resolved (issue #642).
  *
- * A send-with-row binds what composition left written - the URL, header names
- * and values, the body, both halves of every form field - and `build_request`
- * has already collapsed the credentials into an `Authorization` header by the
- * time the row is in hand. A `{{data.user}}` there would go out as base64 of the
- * literal token text, silently, which is exactly the defect issue #591 removed
- * from the load path (there by binding the *typed* credentials before
- * `apply_auth` sees them, which a plan can afford because it is resolved once).
+ * `resolution` is what `build_request` must be told, and it is `Defer` exactly
+ * when `credentials` is non-empty: a `{{data.column}}` inside a credential has
+ * to carry the row's value *before* `apply_auth` collapses a username and a
+ * password into one base64 `Authorization` value, since after that the token is
+ * unreadable and goes out as base64 of its own literal text (issue #591). The
+ * ordinary send - every credential static - keeps resolving auth inside the
+ * build, byte for byte as it did before this existed.
  *
- * A single send has no plan to hang a credential template off, so this endpoint
- * refuses by name instead - the same shape the scenario planner uses for an
- * OAuth 2.0 config, whose token is likewise acquired before any row exists.
- * Refusing is the half that matters: nothing wrong reaches the wire, and the
- * message names the token and the alternative. Binding them here is issue #642.
- * Only consulted when the payload carries a row - without one, a `data.*` token anywhere is today's
- * goes-out-literal behaviour and is not this endpoint's to reopen.
+ * `ok == false` carries the 400 the route answers with. There is one: an
+ * OAuth 2.0 config carrying a data token, which no deferral can serve.
  */
-std::optional<std::string> first_auth_data_token (const nlohmann::json& json);
+struct SendRowAuth {
+    bool ok = true;
+    std::string error;
+    /// The parsed, still-unbound auth - `bind_auth_row`'s input, not the
+    /// payload's, because the join addresses a credential by its position in
+    /// the walk over *this* value.
+    vayu::http::Auth auth;
+    /// The credentials split around their tokens; empty when none carries one.
+    vayu::core::StepDataTemplate credentials;
+    vayu::http::AuthResolution resolution = vayu::http::AuthResolution::Apply;
+};
+
+/**
+ * Decide how `POST /execute` resolves the credentials of a send carrying a row.
+ *
+ * The half of the sequence that must happen **before** the request is built;
+ * `vayu::core::bind_auth_row` is the half that happens after, and the two are
+ * split exactly there because `build_request` sits between them.
+ *
+ * @p has_row is false for an ordinary send, which returns `Apply` with an empty
+ * template and no refusal: without a row there is nothing to bind a token
+ * against, so a `{{data.*}}` in a credential keeps today's goes-out-literal
+ * behaviour rather than becoming a new refusal this endpoint never had.
+ *
+ * Extracted from the handler (execution.cpp) so send_with_row_test.cpp can
+ * drive it directly, matching the suite's other route-core tests.
+ */
+SendRowAuth plan_send_row_auth (const nlohmann::json& json, bool has_row);
 
 /**
  * What a design execution's two scripts produced, as the four keys every

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 #include "vayu/http/graphql_body.hpp"
 #include "vayu/http/request_composer.hpp"
@@ -714,6 +715,27 @@ size_t row_index) {
     return joiner.result ();
 }
 
+DataBindResult bind_auth_row (vayu::Request& request,
+vayu::http::Auth auth,
+const StepDataTemplate& tmpl,
+const nlohmann::json& row,
+size_t row_index) {
+    if (tmpl.empty ()) {
+        return DataBindResult{ true, {} };
+    }
+
+    if (auto bound = apply_auth_data_template (auth, tmpl, row, row_index); !bound.ok) {
+        return bound;
+    }
+
+    // No database handle: see the header - the one mode that would need it is
+    // refused before a build is ever deferred.
+    if (auto applied = vayu::http::apply_auth (request, auth, nullptr); !applied.ok) {
+        return DataBindResult{ false, applied.message };
+    }
+    return DataBindResult{ true, {} };
+}
+
 std::optional<std::string> first_data_token_in (const nlohmann::json& value) {
     if (value.is_string ()) {
         const auto split = vayu::http::split_tokens (
@@ -731,6 +753,14 @@ std::optional<std::string> first_data_token_in (const nlohmann::json& value) {
         }
     }
     return std::nullopt;
+}
+
+std::optional<std::string> first_oauth2_data_token (const vayu::http::Auth& auth) {
+    const auto* oauth2 = std::get_if<vayu::http::OAuth2Auth> (&auth);
+    if (oauth2 == nullptr) {
+        return std::nullopt;
+    }
+    return first_data_token_in (oauth2->config);
 }
 
 DataBindResult apply_data_template (vayu::Request& request,

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -362,22 +362,22 @@ const ScenarioResolveOptions& options) {
         // mean a network round trip per virtual user per iteration. Refused by
         // name in both directions, with or without a data set, rather than sent
         // to the token endpoint as the literal token text.
-        if (const auto* oauth2 = std::get_if<vayu::http::OAuth2Auth> (&parsed_auth)) {
-            if (auto token = first_data_token_in (oauth2->config)) {
-                return invalid (describe_step (index, row) + " carries " + *token +
-                " in its OAuth 2.0 configuration. That token is acquired once, "
-                "when the run is planned, so a data column can never reach it "
-                "- "
-                "use a static credential there, or move the data token into "
-                "the "
-                "request itself.");
-            }
+        if (auto token = first_oauth2_data_token (parsed_auth)) {
+            return invalid (describe_step (index, row) + " carries " + *token +
+            " in its OAuth 2.0 configuration. That token is acquired once, "
+            "when the run is planned, so a data column can never reach it - "
+            "use a static credential there, or move the data token into the "
+            "request itself.");
         }
 
-        if (!auth_template.empty ()) {
-            payload.erase ("auth");
-        }
-        auto built = vayu::http::build_request (payload, &db, options.timeout_ms);
+        // Deferred through the builder's own option rather than by hiding the
+        // `auth` key from it: one mechanism, named at the call site, shared
+        // with the single send that defers for the same reason (issue #642).
+        const auto auth_resolution = auth_template.empty () ?
+        vayu::http::AuthResolution::Apply :
+        vayu::http::AuthResolution::Defer;
+        auto built =
+        vayu::http::build_request (payload, &db, options.timeout_ms, auth_resolution);
         if (!built.ok || built.parse_failed) {
             return invalid ("Cannot compose " + describe_step (index, row) +
             ": " + built.error_message);
@@ -442,25 +442,11 @@ DataBindResult bind_step_auth (vayu::Request& request,
 const ScenarioStep& step,
 const nlohmann::json& row,
 size_t row_index) {
-    if (step.auth_template.empty ()) {
-        return DataBindResult{ true, {} };
-    }
-
-    // Copied because the plan is immutable and shared by every virtual user of
-    // the run, and the join rewrites the credentials in place.
-    vayu::http::Auth auth = step.auth;
-    if (auto bound = apply_auth_data_template (auth, step.auth_template, row, row_index);
-        !bound.ok) {
-        return bound;
-    }
-
-    // No database handle: oauth2 is the only mode `apply_auth` needs one for,
-    // and an oauth2 config carrying a data token is refused when the plan
-    // resolves - deferral never reaches here with one.
-    if (auto applied = vayu::http::apply_auth (request, auth, nullptr); !applied.ok) {
-        return DataBindResult{ false, applied.message };
-    }
-    return DataBindResult{ true, {} };
+    // The join-then-apply order lives in one place, shared with the single
+    // send that binds credentials once (issue #642); this is the per-iteration
+    // caller of it. The step's auth is copied by the callee, which is what a
+    // plan shared by every virtual user of the run requires.
+    return bind_auth_row (request, step.auth, step.auth_template, row, row_index);
 }
 
 nlohmann::json build_scenario_manifest (const ScenarioRequest& request,

--- a/engine/src/http/request_builder.cpp
+++ b/engine/src/http/request_builder.cpp
@@ -13,7 +13,7 @@
 namespace vayu::http {
 
 RequestBuild build_request (const nlohmann::json& config, vayu::db::Database* db,
-int timeout_ms) {
+int timeout_ms, AuthResolution auth_resolution) {
     RequestBuild out;
 
     auto parsed = vayu::json::deserialize_request (config);
@@ -26,6 +26,15 @@ int timeout_ms) {
 
     out.request            = parsed.value ();
     out.request.timeout_ms = timeout_ms;
+
+    // Deferred: the caller holds credentials that must bind a data row before
+    // they are encoded, and applies the auth itself once they have. Left
+    // untouched here rather than applied-then-rewritten, because `apply_auth`
+    // is not reversible - a base64 `Authorization` value cannot be un-collapsed
+    // back into the username and password a row was meant to fill.
+    if (auth_resolution == AuthResolution::Defer) {
+        return out;
+    }
 
     auto auth = apply_auth (
     out.request, config.value ("auth", nlohmann::json ()), db);

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -373,18 +373,38 @@ DataRow read_data_row (const nlohmann::json& json, size_t max_bytes) {
 }
 
 /**
- * @brief The first `{{data.column}}` in a `POST /execute` payload's `auth`
- *        block (issue #601).
+ * @brief How a send-with-row resolves its credentials (issue #642).
  *
- * Non-static: send_with_row_test.cpp drives it directly. See routes.hpp for why
- * the endpoint refuses rather than binds.
+ * Non-static: send_with_row_test.cpp drives it directly. See routes.hpp for the
+ * contract and for why the ordinary send is untouched.
  */
-std::optional<std::string> first_auth_data_token (const nlohmann::json& json) {
-    const auto auth = json.find ("auth");
-    if (auth == json.end () || auth->is_null ()) {
-        return std::nullopt;
+SendRowAuth plan_send_row_auth (const nlohmann::json& json, bool has_row) {
+    SendRowAuth out;
+    if (!has_row) {
+        // Not merely the same answer as an unbindable payload's - deliberately
+        // not parsing at all. `parse_auth` warns on an unresolved `inherit`,
+        // and on this path the build is about to parse the very same block; a
+        // second parse would double every such warning on the ordinary send.
+        return out;
     }
-    return vayu::core::first_data_token_in (*auth);
+    out.auth = vayu::http::parse_auth (json.value ("auth", nlohmann::json ()));
+
+    if (auto token = vayu::core::first_oauth2_data_token (out.auth)) {
+        out.ok    = false;
+        out.error = "Auth credentials carry " + *token +
+        " in an OAuth 2.0 configuration, and no row can reach it: the token is "
+        "acquired against the token endpoint before the request is sent, not "
+        "written into the request the way every other credential is. Use a "
+        "static credential there, or move the data token into the request "
+        "itself.";
+        return out;
+    }
+
+    out.credentials = vayu::core::tokenize_auth_fields (out.auth);
+    if (!out.credentials.empty ()) {
+        out.resolution = vayu::http::AuthResolution::Defer;
+    }
+    return out;
 }
 
 namespace {
@@ -823,13 +843,28 @@ void register_execution_routes (RouteContext& ctx) {
             return;
         }
 
+        // How the credentials resolve, decided before the build because it is
+        // the build that would otherwise encode them out of reach (issue #642).
+        // The refusal it can carry - an oauth2 config with a data token - is a
+        // 400 here, beside the row's own, and for the same reason: nothing has
+        // been recorded or sent yet.
+        const auto row_auth = plan_send_row_auth (json, data_row.value.has_value ());
+        if (!row_auth.ok) {
+            vayu::utils::log_warning ("POST /execute - " + row_auth.error);
+            send_error (res, 400, row_auth.error);
+            return;
+        }
+
         // Build the request once: deserialize + timeout + auth. A malformed
         // payload fails here (before any run record is created); an auth
-        // failure is surfaced after the run exists (below).
+        // failure is surfaced after the run exists (below). Credentials
+        // carrying a `{{data.*}}` are the one case the build leaves alone - the
+        // bind below applies them once the row has reached them.
         const int request_timeout_ms = resolve_request_timeout_ms (
         json, ctx.db.get_config_int (
         "defaultTimeout", vayu::core::constants::server::DEFAULT_TIMEOUT_MS));
-        auto built = vayu::http::build_request (json, &ctx.db, request_timeout_ms);
+        auto built = vayu::http::build_request (
+        json, &ctx.db, request_timeout_ms, row_auth.resolution);
         if (built.parse_failed) {
             vayu::utils::log_warning ("POST /execute - Invalid request format");
             send_error (res, 400, built.error_message);
@@ -844,20 +879,16 @@ void register_execution_routes (RouteContext& ctx) {
         // (scenario_data.hpp). Nothing runs, so nothing is recorded: the
         // refusal precedes the run row exactly as the flag checks above do.
         if (data_row.value) {
-            if (auto token = first_auth_data_token (json)) {
-                const std::string error = "Auth credentials carry " + *token +
-                ", and a single send cannot bind them: the credentials are "
-                "applied when the request is built, before the row is read. "
-                "Move the token into the URL, a header or the body, or run the "
-                "collection with a data file - a collection run binds "
-                "credentials per iteration (issue #591).";
-                vayu::utils::log_warning ("POST /execute - " + error);
-                send_error (res, 400, error);
-                return;
+            auto bound = vayu::core::bind_data_row (built.request, *data_row.value, 0);
+            if (bound.ok) {
+                // Then the credentials the build deferred, in the order the
+                // scenario executors bind theirs: the row reaches them before
+                // `apply_auth` encodes them onto the request. A no-op for the
+                // ordinary send, whose auth the build already applied.
+                bound = vayu::core::bind_auth_row (
+                built.request, row_auth.auth, row_auth.credentials, *data_row.value, 0);
             }
-            if (auto bound =
-                vayu::core::bind_data_row (built.request, *data_row.value, 0);
-                !bound.ok) {
+            if (!bound.ok) {
                 vayu::utils::log_warning ("POST /execute - " + bound.error);
                 send_error (res, 400, bound.error);
                 return;
@@ -929,7 +960,8 @@ void register_execution_routes (RouteContext& ctx) {
         }
 
         // Take the request built above. Auth is already resolved into its
-        // headers/url, so pm.request reflects the real outgoing set - and
+        // headers/url - by the build, or by the bind above for credentials that
+        // carried the row - so pm.request reflects the real outgoing set - and
         // because the pre-request script runs after that and writes back into
         // this same object, a script-set Authorization header wins over the
         // engine-applied one.

--- a/engine/tests/echo_server.hpp
+++ b/engine/tests/echo_server.hpp
@@ -53,6 +53,7 @@ class EchoServer {
             {
                 std::lock_guard<std::mutex> lock (mutex_);
                 path_         = req.path;
+                target_       = req.target;
                 headers_      = req.headers;
                 body_         = req.body;
                 content_type_ = req.get_header_value ("Content-Type");
@@ -114,6 +115,14 @@ class EchoServer {
         return found == headers_.end () ? std::string () : found->second;
     }
 
+    /// The request target as received - {@link path} plus the query string,
+    /// still percent-encoded. What a test asserts against when the encoding
+    /// itself is the point (an api key placed in the query).
+    std::string target () const {
+        std::lock_guard<std::mutex> lock (mutex_);
+        return target_;
+    }
+
     std::string content_type () const {
         std::lock_guard<std::mutex> lock (mutex_);
         return content_type_;
@@ -131,6 +140,7 @@ class EchoServer {
     int port_ = 0;
     mutable std::mutex mutex_;
     std::string path_;
+    std::string target_;
     httplib::Headers headers_;
     std::string body_;
     std::string content_type_;

--- a/engine/tests/send_with_row_test.cpp
+++ b/engine/tests/send_with_row_test.cpp
@@ -16,7 +16,7 @@
  * that: one row, bound into the request the same binder a run uses, and read by
  * both scripts as `pm.iterationData`.
  *
- * Three things are pinned here, and they are the three the route composes:
+ * Four things are pinned here, and they are the four the route composes:
  *
  * 1. `read_data_row` - the payload says what the row is, and says so in a way
  *    that fails loudly when it is malformed. A row the engine could not read
@@ -28,6 +28,12 @@
  * 3. `iteration_data` on the exchange's contexts, so `pm.iterationData.get`
  *    answers in a pre-request script and in a test script - and is `undefined`
  *    on a send that named no row, which is the fact a script branches on.
+ * 4. The **credentials** binding too (issue #642). This endpoint used to refuse
+ *    a `{{data.*}}` in an auth field, because `build_request` had already
+ *    collapsed basic credentials into one base64 header by the time the row was
+ *    in hand. `plan_send_row_auth` decides that before the build instead, the
+ *    build defers, and `bind_auth_row` - the same join-then-apply a scenario
+ *    step drives per iteration - applies them once the row has reached them.
  *
  * What is NOT covered here: that the route rejects before `create_run`. The
  * suite has no in-process HTTP route harness (see run_route_test.cpp), so that
@@ -48,16 +54,19 @@
 #include "vayu/core/scenario_data.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/cookie_jar.hpp"
+#include "vayu/http/request_builder.hpp"
 #include "vayu/http/request_exchange.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/runtime/script_engine.hpp"
 #include "vayu/types.hpp"
+#include "vayu/utils/encoding.hpp"
 
 namespace {
 
 using nlohmann::json;
+using vayu::core::bind_auth_row;
 using vayu::core::bind_data_row;
-using vayu::http::routes::first_auth_data_token;
+using vayu::http::routes::plan_send_row_auth;
 using vayu::http::routes::read_data_row;
 using vayu::http::routes::read_stream_flag;
 using vayu::http::routes::read_transient_flag;
@@ -143,36 +152,103 @@ TEST (ReadDataRow, ComposesWithTransientAndStream) {
     EXPECT_TRUE (read_data_row (stream_payload, kDataBytes).value.has_value ());
 }
 
-// --- the auth refusal --------------------------------------------------------
+// --- how the credentials resolve (issue #642) --------------------------------
 
-TEST (SendWithRowAuth, PlainCredentialsCarryNoToken) {
+/// Every credential static: the build resolves auth exactly as it always did,
+/// and nothing is deferred. This is the ordinary authenticated send, and it is
+/// the case that must not change shape now that another one exists.
+TEST (SendWithRowAuth, StaticCredentialsResolveInTheBuild) {
     const json payload{ { "auth",
-    { { "mode", "basic" }, { "basic", { { "username", "ada" }, { "password", "s3cret" } } } } } };
-    EXPECT_FALSE (first_auth_data_token (payload).has_value ());
+    { { "mode", "basic" }, { "username", "ada" }, { "password", "s3cret" } } } };
+
+    const auto plan = plan_send_row_auth (payload, true);
+    EXPECT_TRUE (plan.ok);
+    EXPECT_TRUE (plan.credentials.empty ());
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
 }
 
-TEST (SendWithRowAuth, AbsentAuthCarriesNoToken) {
-    EXPECT_FALSE (first_auth_data_token (json{ { "url", "http://x/" } }).has_value ());
-    EXPECT_FALSE (first_auth_data_token (json{ { "auth", nullptr } }).has_value ());
+TEST (SendWithRowAuth, AbsentAuthResolvesInTheBuild) {
+    for (const auto& payload :
+    { json{ { "url", "http://x/" } }, json{ { "auth", nullptr } } }) {
+        const auto plan = plan_send_row_auth (payload, true);
+        EXPECT_TRUE (plan.ok);
+        EXPECT_TRUE (plan.credentials.empty ());
+        EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
+    }
 }
 
-/// The token is named back, because "your auth has a data token in it" without
-/// saying which one is unactionable in a block with four credential fields.
-TEST (SendWithRowAuth, CredentialTokenIsNamed) {
+/// A credential carrying a row value defers, which is the whole feature: the
+/// build leaves the credentials alone so the row can reach them before
+/// `apply_auth` collapses them into one base64 header.
+TEST (SendWithRowAuth, CredentialTokenDefersTheAuth) {
     const json payload{ { "auth",
-    { { "mode", "basic" },
-    { "basic", { { "username", "{{data.user}}" }, { "password", "s3cret" } } } } } };
-    const auto token = first_auth_data_token (payload);
-    ASSERT_TRUE (token.has_value ());
-    EXPECT_EQ (*token, "{{data.user}}");
+    { { "mode", "basic" }, { "username", "{{data.user}}" }, { "password", "s3cret" } } } };
+
+    const auto plan = plan_send_row_auth (payload, true);
+    ASSERT_TRUE (plan.ok);
+    EXPECT_FALSE (plan.credentials.empty ());
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Defer);
+    EXPECT_EQ (plan.credentials.first_token ().value_or (""), "{{data.user}}");
+}
+
+/// Without a row there is nothing to bind against, so the token keeps the
+/// behaviour it has always had here rather than becoming a refusal or a
+/// deferral that never applies - a deferred build whose auth is never applied
+/// would send the request unauthenticated.
+TEST (SendWithRowAuth, NoRowNeverDefers) {
+    const json payload{ { "auth",
+    { { "mode", "basic" }, { "username", "{{data.user}}" }, { "password", "s3cret" } } } };
+
+    const auto plan = plan_send_row_auth (payload, false);
+    EXPECT_TRUE (plan.ok);
+    EXPECT_TRUE (plan.credentials.empty ());
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
 }
 
 /// An ordinary `{{user}}` is not a data token - it is a variable composition
-/// already resolved, and refusing it would refuse every authenticated send.
+/// already resolved, and deferring it would defer every authenticated send.
 TEST (SendWithRowAuth, OrdinaryVariableIsNotADataToken) {
+    const json payload{ { "auth", { { "mode", "bearer" }, { "token", "{{apiToken}}" } } } };
+
+    const auto plan = plan_send_row_auth (payload, true);
+    EXPECT_TRUE (plan.ok);
+    EXPECT_TRUE (plan.credentials.empty ());
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
+}
+
+/// OAuth 2.0 is the one mode no deferral can serve, and it stays refused by
+/// name: the token is acquired against the token endpoint, not written into the
+/// request, so there is no later moment at which a row could reach it.
+TEST (SendWithRowAuth, Oauth2DataTokenIsRefusedByName) {
     const json payload{ { "auth",
-    { { "mode", "bearer" }, { "bearer", { { "token", "{{apiToken}}" } } } } } };
-    EXPECT_FALSE (first_auth_data_token (payload).has_value ());
+    { { "mode", "oauth2" },
+    { "config",
+    { { "grantType", "client_credentials" },
+    { "clientId", "{{data.client}}" },
+    { "tokenUrl", "https://issuer.example/token" } } } } } };
+
+    const auto plan = plan_send_row_auth (payload, true);
+    ASSERT_FALSE (plan.ok);
+    EXPECT_NE (plan.error.find ("{{data.client}}"), std::string::npos);
+    EXPECT_NE (plan.error.find ("OAuth 2.0"), std::string::npos);
+    // The message has to say *why* no row can serve it, or "not supported" is
+    // the only thing a reader takes from it.
+    EXPECT_NE (plan.error.find ("token endpoint"), std::string::npos);
+}
+
+/// The refusal is scoped to the mode, not to the endpoint: an oauth2 config
+/// with no data token in it is an ordinary send that happens to carry a row.
+TEST (SendWithRowAuth, Oauth2WithoutADataTokenIsNotRefused) {
+    const json payload{ { "auth",
+    { { "mode", "oauth2" },
+    { "config",
+    { { "grantType", "client_credentials" },
+    { "clientId", "static-client" },
+    { "tokenUrl", "https://issuer.example/token" } } } } } };
+
+    const auto plan = plan_send_row_auth (payload, true);
+    EXPECT_TRUE (plan.ok);
+    EXPECT_EQ (plan.resolution, vayu::http::AuthResolution::Apply);
 }
 
 // --- the bind, end to end ----------------------------------------------------
@@ -206,6 +282,43 @@ class SendWithRowTest : public ::testing::Test {
             inputs.iteration_count = 1;
         }
         return execute_exchange (engine, jar, "", scopes, std::move (inputs), false);
+    }
+
+    /// What the route's pre-send sequence produced for a payload carrying a
+    /// row: either the request it would send, or the message it would answer
+    /// `400` with.
+    struct RowSend {
+        bool ok = true;
+        std::string error;
+        vayu::Request request;
+    };
+
+    /// The route's sequence over a payload that carries a row - plan the
+    /// credentials, build, bind the request, bind the credentials - in the
+    /// order execution.cpp runs it. Driven here rather than hand-ordered per
+    /// test because the *order* is what these tests are about: a credential
+    /// bound after `apply_auth` is a credential bound too late.
+    static RowSend build_with_row (const json& payload, const json& row) {
+        RowSend out;
+
+        const auto plan = plan_send_row_auth (payload, true);
+        if (!plan.ok) {
+            return RowSend{ false, plan.error, {} };
+        }
+
+        auto built = vayu::http::build_request (payload, nullptr, 10000, plan.resolution);
+        if (built.parse_failed || !built.ok) {
+            return RowSend{ false, built.error_message, {} };
+        }
+        out.request = std::move (built.request);
+
+        auto bound = bind_data_row (out.request, row, 0);
+        if (bound.ok) {
+            bound = bind_auth_row (out.request, plan.auth, plan.credentials, row, 0);
+        }
+        out.ok    = bound.ok;
+        out.error = bound.error;
+        return out;
     }
 
     /// `pm.test` around one assertion, so a failed assertion reports its own
@@ -256,6 +369,132 @@ TEST_F (SendWithRowTest, MissingColumnFailsTheBindByName) {
     EXPECT_FALSE (bound.ok);
     EXPECT_NE (bound.error.find ("data.id"), std::string::npos);
     EXPECT_NE (bound.error.find ("email"), std::string::npos);
+}
+
+// --- credentials on the wire (issue #642) ------------------------------------
+//
+// Every one of these asserts against what the echo server *received*. A bind
+// that reached the `Auth` struct but not the transfer is the exact defect this
+// endpoint used to refuse rather than risk, so asserting the struct would
+// assert the wrong half. Mutation check: move the `apply_auth` back into the
+// build (`AuthResolution::Apply` in `plan_send_row_auth`) and the three binding
+// tests go red together - the header arrives as base64 of `{{data.user}}:...`.
+
+/// Basic auth, the canonical credentials-file case: both halves come from the
+/// row, and the header the server receives decodes to the row's values rather
+/// than to the tokens' text.
+TEST_F (SendWithRowTest, BasicCredentialsBindBeforeTheyAreEncoded) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () },
+        { "auth", { { "mode", "basic" }, { "username", "{{data.user}}" },
+        { "password", "{{data.pass}}" } } } };
+    const json row{ { "user", "ada" }, { "pass", "s3cr3t:7" } };
+
+    auto prepared = build_with_row (payload, row);
+    ASSERT_TRUE (prepared.ok) << prepared.error;
+
+    auto outcome = send (std::move (prepared.request), &row, "", "");
+    ASSERT_EQ (outcome.response.status_code, 200);
+
+    const std::string header = server_->header ("Authorization");
+    ASSERT_EQ (header.rfind ("Basic ", 0), 0u) << header;
+    const auto decoded = vayu::utils::base64_decode (header.substr (6));
+    ASSERT_TRUE (decoded.has_value ()) << header;
+    // A colon in the password is why this decodes rather than string-matches:
+    // the base64 is of `user:pass` joined, and the row is allowed to contain
+    // the separator.
+    EXPECT_EQ (*decoded, "ada:s3cr3t:7");
+}
+
+TEST_F (SendWithRowTest, BearerCredentialBindsToTheRow) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () },
+        { "auth", { { "mode", "bearer" }, { "token", "{{data.token}}" } } } };
+    const json row{ { "token", "t-7" } };
+
+    auto prepared = build_with_row (payload, row);
+    ASSERT_TRUE (prepared.ok) << prepared.error;
+
+    auto outcome = send (std::move (prepared.request), &row, "", "");
+    ASSERT_EQ (outcome.response.status_code, 200);
+    EXPECT_EQ (server_->header ("Authorization"), "Bearer t-7");
+}
+
+TEST_F (SendWithRowTest, ApiKeyHeaderBindsBothHalves) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () },
+        { "auth", { { "mode", "apikey" }, { "key", "X-{{data.header}}" },
+        { "value", "{{data.key}}" } } } };
+    const json row{ { "header", "Tenant-Key" }, { "key", "k-7" } };
+
+    auto prepared = build_with_row (payload, row);
+    ASSERT_TRUE (prepared.ok) << prepared.error;
+
+    auto outcome = send (std::move (prepared.request), &row, "", "");
+    ASSERT_EQ (outcome.response.status_code, 200);
+    EXPECT_EQ (server_->header ("X-Tenant-Key"), "k-7");
+}
+
+/// An api key in the query is the case that proves the *ordering* rather than
+/// just the substitution: percent-encoding is `apply_auth`'s to add after the
+/// bind, so a row value containing a reserved character arrives encoded - which
+/// binding after the auth had been applied could not produce.
+TEST_F (SendWithRowTest, ApiKeyInQueryIsEncodedAfterTheBind) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () },
+        { "auth", { { "mode", "apikey" }, { "key", "token" },
+        { "value", "{{data.key}}" }, { "in", "query" } } } };
+    const json row{ { "key", "a b&c" } };
+
+    auto prepared = build_with_row (payload, row);
+    ASSERT_TRUE (prepared.ok) << prepared.error;
+
+    auto outcome = send (std::move (prepared.request), &row, "", "");
+    ASSERT_EQ (outcome.response.status_code, 200);
+    EXPECT_NE (server_->target ().find ("token=a%20b%26c"), std::string::npos)
+    << server_->target ();
+}
+
+/// A credential naming a column the row lacks fails the same way a URL token
+/// does, and the route turns it into the same 400 - nothing is sent.
+TEST_F (SendWithRowTest, MissingCredentialColumnFailsTheBind) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () },
+        { "auth", { { "mode", "basic" }, { "username", "{{data.user}}" },
+        { "password", "static" } } } };
+
+    const auto prepared = build_with_row (payload, json{ { "tenant", "acme" } });
+    EXPECT_FALSE (prepared.ok);
+    EXPECT_NE (prepared.error.find ("data.user"), std::string::npos);
+    EXPECT_NE (prepared.error.find ("tenant"), std::string::npos);
+    // Nothing reached the server: the failure is decided before any transfer.
+    EXPECT_TRUE (server_->path ().empty ());
+}
+
+/// The request's own tokens and its credentials bind from one row, in one send.
+TEST_F (SendWithRowTest, RequestAndCredentialsBindFromTheSameRow) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () + "/users/{{data.id}}" },
+        { "auth", { { "mode", "bearer" }, { "token", "{{data.token}}" } } } };
+    const json row{ { "id", "7" }, { "token", "t-7" } };
+
+    auto prepared = build_with_row (payload, row);
+    ASSERT_TRUE (prepared.ok) << prepared.error;
+
+    auto outcome = send (std::move (prepared.request), &row, "", "");
+    ASSERT_EQ (outcome.response.status_code, 200);
+    EXPECT_EQ (server_->path (), "/echo/users/7");
+    EXPECT_EQ (server_->header ("Authorization"), "Bearer t-7");
+}
+
+/// A static credential still resolves inside the build on a send that carries a
+/// row - the deferral is per-payload, not per-endpoint.
+TEST_F (SendWithRowTest, StaticCredentialsStillResolveInTheBuild) {
+    const json payload{ { "method", "GET" }, { "url", server_->url () + "/users/{{data.id}}" },
+        { "auth", { { "mode", "bearer" }, { "token", "static-token" } } } };
+    const json row{ { "id", "7" } };
+
+    auto prepared = build_with_row (payload, row);
+    ASSERT_TRUE (prepared.ok) << prepared.error;
+
+    auto outcome = send (std::move (prepared.request), &row, "", "");
+    ASSERT_EQ (outcome.response.status_code, 200);
+    EXPECT_EQ (server_->path (), "/echo/users/7");
+    EXPECT_EQ (server_->header ("Authorization"), "Bearer static-token");
 }
 
 /// The motivating gap, closed: a pre-request script reads the row on a single


### PR DESCRIPTION
## Description

`POST /execute` with a `data` row now binds `{{data.*}}` in basic, bearer and
apikey credentials instead of refusing them.

**The plan (root cause → approach → rejected alternative).** Root cause is
ordering, not principle: `build_request` called `apply_auth` while
deserializing, so by the time the route held the row the credentials were
already collapsed into one base64 `Authorization` value - a `{{data.user}}`
inside it would have gone out as base64 of the literal token text, which is the
defect #591 removed from the load path. The route therefore refused. The
approach is the one the issue names: give the single send the same deferral
`resolve_scenario` has. `build_request` takes an `AuthResolution`, so a caller
that must reach the credentials first says so rather than hiding the `auth` key
from the builder; `plan_send_row_auth` makes that decision before the build, and
`bind_auth_row` - the join-then-apply lifted out of `bind_step_auth`, now shared
by both callers - applies the auth once the row has reached it. **The
alternative I rejected is a second `apply_auth` call site in the execute route
that re-derives the sequence.** The order *is* the contract here (bind, then
encode), and a copy of it is a copy that stops receiving this one's fixes -
which is exactly how the load path's version came to need #591 in the first
place. Extracting cost one function and removed a divergence rather than adding
one.

**Verified against the code first**, per the issue's ask: `build_request`
(`request_builder.cpp:15-38`), `resolve_scenario`'s deferral
(`scenario_plan.cpp:329-435`) and `bind_step_auth` (`:441-464`) are all still as
the issue describes them, so the fix is the one it specifies.

### What landed

**`http::AuthResolution` on `build_request`** - `Apply` (the default) or
`Defer`. Every existing caller passes nothing and is byte-identical; the load
path is untouched. `Defer` returns the deserialized request with its
credentials unresolved, and the header says plainly that a `Defer` whose auth is
never applied sends an unauthenticated request.

**`resolve_scenario` moved onto the same option**, dropping its
`payload.erase("auth")`. That erase was a second spelling of "skip the auth" -
correct only because `deserialize_request` happens not to read the key. One
mechanism, named at the call site, is what keeps the two deferring callers from
drifting.

**`core::bind_auth_row`** - join the credentials against the row, then
`apply_auth`. `bind_step_auth` is now a two-line caller of it (per iteration,
per virtual user) and the execute route is the other (once). Auth is taken **by
value**, because a plan's step auth is shared and immutable while the join
rewrites in place.

**`core::first_oauth2_data_token`** - the one refusal, now shared. Both the
planner and the route asked the same `get_if<OAuth2Auth>` + `first_data_token_in`
question; it is one function.

**The refusal narrowed to the mode that needs it.** `first_auth_data_token` -
the blanket "any data token in `auth`" scan - is gone, replaced by
`plan_send_row_auth`. OAuth 2.0 stays refused, by name, because its token is
acquired against the token endpoint rather than written into the request, so no
row can reach it. The message says that rather than "not supported", and a test
asserts it names both the token and the reason.

**Ordering is the feature.** The row reaches the credentials *before*
`apply_auth` encodes them, so basic auth base64s the row's values and an api key
in the query is percent-encoded after the substitution. `ApiKeyInQueryIsEncodedAfterTheBind`
is the test that can only pass in that order.

**No row still means no deferral.** Without a row there is nothing to bind
against, so a `{{data.*}}` in a credential keeps the goes-out-literal behaviour
this endpoint already had - and `plan_send_row_auth` returns before parsing at
all on that path, so the ordinary send does not gain a second `parse_auth` (and
a doubled `inherit` warning) for a decision it cannot use.

### Deliberate deviations from the issue spec

None. One addition worth naming: the issue's test list did not include the
api-key-in-header case, and it is covered too - both halves of an api key are
bindable, so a header *name* coming from the row is a shape a test should hold.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` -
  **1709/1709 passed**, including **13 new tests** in
  `engine/tests/send_with_row_test.cpp` (base was 1699).
- `cd app && pnpm type-check`, `pnpm lint` clean; `npx prettier --check` clean on
  the two app files touched; `pnpm vitest run electron/mcp` - **407/407**.
- `mkdocs build --strict -f .github/mkdocs.yml` builds clean.

The app suite was not run in full and no app behaviour is touched - the two
changes there are a TSDoc block and one Zod `describe()` string, and no test
asserts either (grepped). Per the repo's "scale the verification to what the
change could actually break" rule, no vitest case could change colour.

New coverage:

- **`plan_send_row_auth`** (7): static credentials and absent auth resolve in
  the build; a credential token defers and names its token; **no row never
  defers**; an ordinary `{{var}}` is not a data token; an oauth2 config with a
  data token is refused naming the token *and* the reason; an oauth2 config
  without one is not refused.
- **On the wire** (6, through the echo server): basic credentials decode to the
  row's values; bearer; an api key binding both halves into a header; an api key
  in the query percent-encoded *after* the bind; a missing credential column
  failing the bind with nothing sent; request tokens and credentials binding
  from one row; and a static credential still resolving in the build on a send
  that carries a row.

Every wire assertion reads what the **server received**, never the `Request`
struct - a bind that reached the struct and not the transfer is precisely the
failure this endpoint used to refuse rather than risk.

**Mutation-checked** (broken, confirmed red, restored): flipping
`plan_send_row_auth`'s `Defer` back to `Apply` reddens
`CredentialTokenDefersTheAuth` and `BasicCredentialsBindBeforeTheyAreEncoded`
together, and nothing else - the `Authorization` header then arrives as base64
of `{{data.user}}:...`, which is the exact defect.

`EchoServer` gained a `target()` accessor (path **plus** query string, still
encoded), because `path()` drops the query and the api-key-in-query case is
about the encoding.

### One pre-existing flake observed

`StreamExecuteTest` (`sse_stream_test.cpp`) segfaulted twice during this
session's full-suite runs, in two *different* tests of that fixture. It passed
5/5 in isolation and the last three full-suite runs are clean at 1709/1709. Not
fixed or hidden here, and I do not believe it is this diff: those tests send no
`data` row, so `plan_send_row_auth` returns before parsing anything and
`build_request` receives the default `Apply` - the instructions they execute are
the same as on `master`. The fixture starts two servers, a paced streaming
origin and a thread per test, which is the shape a teardown race takes. Filed
separately rather than folded into this PR.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs land in the same commit per the repo rule: `docs/engine/api-reference.md`
(the `POST /execute` `data` 400 table drops the credentials row and gains the
oauth2 one, with the binding rule stated), `docs/app/data-driven-runs.md` (the
"one thing a single send cannot bind" paragraph is now false and is rewritten),
`docs/engine/mcp.md` and the Zod `describe()` in `app/electron/mcp/tools.ts`
(`run_request`'s `data` restriction narrowed to oauth2), and the `data` TSDoc in
`app/src/types/api.ts`. `docs/engine/scripting.md` already said a **credential**
carrying `{{data.email}}` is substituted and needed no change - that sentence
became universally true rather than run-only.

## Related Issues

Closes #642. Follow-up to #601 (PR #641), whose refusal and tests this replaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_015n88aQVD9ndxVEoCJmVL5f)_