### PR TITLE
fix(engine/sse): drain stream consumers before the state they write through

### DIFF
--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -844,11 +844,24 @@ row exists - and the executor is the only thing that differs.
   whole run.
 - **Event Loop Threads**: One per CPU core (handles curl_multi I/O)
 
+- **Stream Consumer Threads**: One per live streaming request (`POST /execute`
+  with `"stream": true`), owned by `SseStreamManager`.
+
 Shutdown unwinds that in a fixed order, because every one of these threads
-holds references to state `main` owns: HTTP server stopped → run workers
-signalled and joined (each joins its own metrics and monitor threads and stops
-its event loop first) → `curl_global_cleanup` → `Database` / `RunManager`
-destroyed at scope exit. Nothing is detached.
+holds references to state `main` owns: HTTP server stopped **and its stream
+consumers drained** (`Server::stop()` calls `SseStreamManager::shutdown()`,
+which signals every stream and joins its worker) → run workers signalled and
+joined (each joins its own metrics and monitor threads and stops its event loop
+first) → `curl_global_cleanup` → `Database` / `RunManager` destroyed at scope
+exit. Nothing is detached.
+
+The stream drain belongs to `stop()` rather than to `~Server` because
+`curl_global_cleanup` runs *between* the two: a consumer joined only by the
+member destructor would still be inside a curl transfer while curl's global
+state was torn down, and still writing its run row through a `Database` that is
+about to be destroyed - the #125 defect in the one worker `RunManager` does not
+own (#646). Any other owner of an `SseStreamManager` owes the same order: drain
+before the `Database` and `CookieJar` its workers reach through go away.
 
 ## Performance Characteristics
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -57,7 +57,25 @@ cmake --build --preset linux-prod
 # Debug build
 cmake --preset linux-dev     # or macos-dev, windows-dev
 cmake --build --preset linux-dev
+
+# Debug build with AddressSanitizer, into its own build-asan/ tree
+cmake --preset linux-asan
+cmake --build --preset linux-asan
+ctest --preset linux-asan
 ```
+
+`linux-asan` is a separate tree rather than a flag on `linux-dev`, so an ASan
+run never invalidates the ordinary build's objects. It is the tool for a
+**lifetime** bug - a crash the ordinary suite only produces intermittently and
+without an assertion failure, which is what a use-after-free across threads
+looks like. Two things worth knowing when you reach for it:
+
+- Run the suspect tests **under load**, not alone. Issue #646 was a worker
+  thread writing through a `Database` its fixture had already destroyed; it
+  passed 5/5 in isolation and reproduced on every attempt with four copies of
+  the binary running concurrently (each from its own working directory, since
+  the fixtures write scratch `test_*.db` files into it).
+- `ASAN_OPTIONS=detect_leaks=0` keeps the report to the memory error itself.
 
 ### Traditional CMake
 

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -2,6 +2,7 @@
 build/
 build-test/
 build-release/
+build-asan/
 cmake-build-*/
 out/
 data/

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -115,7 +115,16 @@ Three things worth knowing before you design around them:
   reinterpretation. **Scripts run** (#575): the pre-request one before the
   transfer, the post-request one after the stream ends, reading the bounded list
   as `pm.response.events`; because the route already answered `202`, their
-  output is stored on the trace's `scripts` node rather than returned.
+  output is stored on the trace's `scripts` node rather than returned. **A
+  consumer worker is drained by whoever owns the manager, before the state it
+  writes through goes away** (#646): `Server::stop()` calls
+  `SseStreamManager::shutdown()` - which signals every stream and *joins* its
+  worker - because `daemon.cpp` runs `curl_global_cleanup` between that call and
+  `~Server`. A test fixture holding a manager beside a `Database` it resets owes
+  the same order, and the two SSE fixtures hold it by keeping the manager in a
+  `unique_ptr` reset first. Waiting on `context->closed()` is *not* draining: it
+  flips at the end of the transfer, with the completion callback - which writes
+  the run row - still to run.
 - **An OpenAPI document is stored once and *bound* by collections, never owned
   by one** (#637). `spec_documents` holds the text verbatim plus an
   engine-computed `hash`; `collections.openapi`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -539,6 +539,11 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/events.cpp
         src/http/routes/mock_server.cpp
         src/http/managed_listener.cpp
+        # The daemon's own Server, so its shutdown ordering is testable rather
+        # than only reachable by running the daemon (#646). It registers every
+        # route group, which is why health.cpp joins the list here too.
+        src/http/routes/health.cpp
+        src/http/server.cpp
     )
     
     # The cross-language conformance fixture lives in the source tree and is

--- a/engine/CMakePresets.json
+++ b/engine/CMakePresets.json
@@ -99,6 +99,23 @@
       }
     },
     {
+      "name": "linux-asan",
+      "displayName": "Linux Debug + AddressSanitizer",
+      "description": "Debug build with ASan, for diagnosing lifetime bugs the ordinary suite only shows as an intermittent crash (issue #646)",
+      "inherits": ["base", "base-fallback"],
+      "binaryDir": "${sourceDir}/build-asan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "VAYU_USE_ASAN": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
       "name": "linux-prod",
       "displayName": "Linux Release",
       "description": "Production build for Linux (Release)",
@@ -201,6 +218,12 @@
       "jobs": 0
     },
     {
+      "name": "linux-asan",
+      "displayName": "Build Linux Debug + AddressSanitizer",
+      "configurePreset": "linux-asan",
+      "jobs": 0
+    },
+    {
       "name": "linux-prod",
       "displayName": "Build Linux Release",
       "configurePreset": "linux-prod",
@@ -252,6 +275,14 @@
       "name": "linux-dev",
       "displayName": "Test Linux Debug",
       "configurePreset": "linux-dev",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "linux-asan",
+      "displayName": "Test Linux Debug + AddressSanitizer",
+      "configurePreset": "linux-asan",
       "output": {
         "outputOnFailure": true
       }

--- a/engine/include/vayu/http/server.hpp
+++ b/engine/include/vayu/http/server.hpp
@@ -62,8 +62,13 @@ class Server {
     //
     // SseStreamManager owns curl transfers rather than listeners, and is here
     // for exactly the same reason: its workers write run rows through db_ and
-    // read cookie_jar_, and its destructor stops and joins every one of them.
+    // read cookie_jar_, and its shutdown stops and joins every one of them.
     // Declared after the jar so it is destroyed before it.
+    //
+    // The declaration order is the backstop, not the mechanism: `stop()` drains
+    // it explicitly, because `daemon.cpp` calls `curl_global_cleanup` between
+    // its `server.stop()` and this object's destruction, and a transfer still
+    // running then is the #125 defect (see sse_stream.hpp and #646).
     OAuth2AuthorizeManager oauth_authorize_manager_;
     CookieJar cookie_jar_;
     MockIssuerManager mock_issuer_manager_;

--- a/engine/include/vayu/http/sse_stream.hpp
+++ b/engine/include/vayu/http/sse_stream.hpp
@@ -277,10 +277,18 @@ struct SseStreamRequest {
 /**
  * Owns the engine's streaming consumers - one worker thread per live stream.
  *
- * Thread-safe. The destructor asks every worker to stop and joins it, so the
+ * Thread-safe. `shutdown()` asks every worker to stop and joins it, so the
  * `Database` and `CookieJar` a worker touches must outlive the manager: it is
  * declared before `server_` in server.hpp for that reason, alongside the
  * listener-owning managers.
+ *
+ * **Every owner must drain before the state its workers reach through is torn
+ * down** - which is not the same instant as "the manager is destroyed". A
+ * worker writes its run row through a `Database&` and runs curl to the last
+ * byte, so `Server::stop()` calls `shutdown()` while both are still standing,
+ * the way `RunManager::shutdown()` is called for the load workers (#125). A
+ * fixture that owns a manager beside a `Database` it resets in `TearDown` owes
+ * the same order (#646).
  */
 class SseStreamManager {
     public:
@@ -320,6 +328,18 @@ class SseStreamManager {
     /// How many streams are held, live or retained. For tests and teardown
     /// assertions - production reads `get`.
     [[nodiscard]] std::size_t size () const;
+
+    /**
+     * Stop every live stream and **join** its worker, then refuse to start
+     * another. Terminal and idempotent, exactly like `RunManager::shutdown()`:
+     * a manager that has drained cannot be reopened, because the caller drains
+     * only when the `Database` and `CookieJar` its workers hold are about to
+     * go away, and a stream started after that has nothing left to write to.
+     *
+     * Called by `Server::stop()` and by the destructor. Draining an idle
+     * manager returns immediately.
+     */
+    void shutdown ();
 
     private:
     struct Stream {

--- a/engine/src/http/server.cpp
+++ b/engine/src/http/server.cpp
@@ -84,6 +84,16 @@ void Server::stop () {
         }
         is_running_ = false;
     }
+
+    // Outside the `is_running_` guard and after the listener is down, because
+    // "the server has stopped" must mean no engine work is still in flight
+    // (#646). A stream consumer is a worker like a run worker: it holds `db_`,
+    // reads `cookie_jar_` and is inside a curl transfer. `daemon.cpp` runs
+    // `curl_global_cleanup` between this call and `~Server`, so a stream joined
+    // only by the member destructor would still be transferring while curl's
+    // global state was torn down underneath it - the #125 defect, in the one
+    // worker RunManager does not own. Draining an idle manager is immediate.
+    sse_manager_.shutdown ();
 }
 
 bool Server::is_running () const {

--- a/engine/src/http/sse_stream.cpp
+++ b/engine/src/http/sse_stream.cpp
@@ -526,6 +526,10 @@ vayu::Response consume_sse_stream (const SseStreamRequest& request, SseStreamCon
 SseStreamManager::SseStreamManager () = default;
 
 SseStreamManager::~SseStreamManager () {
+    shutdown ();
+}
+
+void SseStreamManager::shutdown () {
     std::map<std::string, Stream> draining;
     {
         std::lock_guard<std::mutex> lock (mutex_);

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -90,7 +90,8 @@ class StreamServer {
             });
         });
 
-        svr_.Get ("/endless", [this] (const httplib::Request&, httplib::Response& res) {
+        svr_.Get ("/endless", [this] (const httplib::Request& req, httplib::Response& res) {
+            note_request (req);
             res.set_chunked_content_provider (
             "text/event-stream", [this] (size_t, httplib::DataSink& sink) {
                 while (!stopping_.load ()) {
@@ -147,6 +148,13 @@ class StreamServer {
         return found == received_headers_.end () ? std::string () : found->second;
     }
 
+    /// Requests this origin has answered. A test that must interrupt a stream
+    /// *in flight* needs to know the transfer actually started, and the run row
+    /// exists before the worker has connected.
+    int requests_received () const {
+        return received_count_.load ();
+    }
+
     private:
     void note_request (const httplib::Request& req) {
         std::lock_guard<std::mutex> lock (received_mutex_);
@@ -154,6 +162,7 @@ class StreamServer {
         for (const auto& [key, value] : req.headers) {
             received_headers_[key] = value;
         }
+        received_count_.fetch_add (1);
     }
 
     httplib::Server svr_;
@@ -164,6 +173,7 @@ class StreamServer {
     std::atomic<int> pace_ms_{ 0 };
     mutable std::mutex received_mutex_;
     std::map<std::string, std::string, std::less<>> received_headers_;
+    std::atomic<int> received_count_{ 0 };
 };
 
 vayu::Request get_request (const std::string& url) {
@@ -622,6 +632,41 @@ TEST (SseStreamManagerTest, TearsDownWithAStreamStillRunning) {
     SUCCEED ();
 }
 
+// The ordering contract every owner runs on (#646): `shutdown()` does not
+// return until each worker has finished - callback included. `closed()` flips
+// at the end of the transfer, with the completion callback still to run, so a
+// drain that waited on the context rather than joining the thread would return
+// while the worker was still inside `on_complete`, writing through a `Database`
+// its owner is about to destroy. That is the intermittent segfault this test
+// exists to keep fixed.
+TEST (SseStreamManagerTest, ShutdownJoinsEveryWorkerAndIsTerminalAndIdempotent) {
+    StreamServer server;
+    SseStreamManager manager;
+    std::atomic<bool> completed{ false };
+
+    auto spec = spec_for (server.url ("/endless"), brisk_limits ());
+    spec.on_complete = [&completed] (const vayu::Request&, const vayu::Response&,
+                       const SseStreamContext&) { completed.store (true); };
+    auto context = manager.start (std::move (spec));
+    ASSERT_NE (context, nullptr);
+    while (context->total_events () < 1) {
+        std::this_thread::sleep_for (std::chrono::milliseconds (5));
+    }
+
+    manager.shutdown ();
+    EXPECT_TRUE (completed.load ()) << "shutdown returned while the worker was "
+                                       "still in its completion callback";
+    EXPECT_EQ (manager.size (), 0u);
+    EXPECT_EQ (context->end_reason (), SseEndReason::Stopped);
+
+    // Terminal, like RunManager's: a drain happens because the state the
+    // workers write through is going away, so a stream started afterwards
+    // would have nothing to write to.
+    EXPECT_EQ (manager.start (spec_for (server.url ("/endless"), brisk_limits ())), nullptr);
+    manager.shutdown ();
+    EXPECT_EQ (manager.size (), 0u);
+}
+
 TEST (SseStreamManagerTest, SweepsOnlyFinishedStreamsPastTheirRetention) {
     StreamServer server ({ "data: a\n\n" });
     SseStreamManager manager;
@@ -656,10 +701,11 @@ class RelayTest : public ::testing::Test {
         vayu::tests::remove_database_files (DB_PATH);
         db_ = std::make_unique<vayu::db::Database> (DB_PATH);
         db_->init ();
-        ctx_ = std::make_unique<vayu::http::routes::RouteContext> (
+        manager_ = std::make_unique<SseStreamManager> ();
+        ctx_     = std::make_unique<vayu::http::routes::RouteContext> (
         vayu::http::routes::RouteContext{ svr_, *db_, run_manager_, false,
         nullptr, authorize_manager_, cookie_jar_, mock_issuer_manager_,
-        inbox_manager_, mock_server_manager_, manager_ });
+        inbox_manager_, mock_server_manager_, *manager_ });
         vayu::http::routes::register_event_stream_routes (*ctx_);
         svr_.set_write_timeout (60, 0);
         port_   = svr_.bind_to_any_port ("127.0.0.1");
@@ -672,6 +718,13 @@ class RelayTest : public ::testing::Test {
         if (thread_.joinable ()) {
             thread_.join ();
         }
+        // Before `db_`, always (#646). A stream worker outlives the test body -
+        // `closed()` flips at the end of the transfer, with the completion
+        // callback still to run - and it writes through `*db_`, so resetting
+        // the database first is a use-after-free that only shows up as an
+        // intermittent segfault under load. Same order as InboxListenerTest,
+        // and the order `Server::stop()` holds in production.
+        manager_.reset ();
         ctx_.reset ();
         db_.reset ();
         vayu::tests::remove_database_files (DB_PATH);
@@ -686,7 +739,7 @@ class RelayTest : public ::testing::Test {
         }
         origin_ = std::make_unique<StreamServer> (std::move (chunks));
         auto context =
-        manager_.start (spec_for (origin_->url ("/scripted"), brisk_limits ()));
+        manager_->start (spec_for (origin_->url ("/scripted"), brisk_limits ()));
         const auto deadline =
         std::chrono::steady_clock::now () + std::chrono::seconds (10);
         while (context && !context->closed () && std::chrono::steady_clock::now () < deadline) {
@@ -718,7 +771,9 @@ class RelayTest : public ::testing::Test {
     vayu::http::MockIssuerManager mock_issuer_manager_;
     vayu::http::InboxManager inbox_manager_;
     vayu::http::MockServerManager mock_server_manager_;
-    SseStreamManager manager_;
+    /// Held by pointer so `TearDown` can join its workers *before* the
+    /// database they write through goes away - see the note there (#646).
+    std::unique_ptr<SseStreamManager> manager_;
     std::unique_ptr<vayu::http::routes::RouteContext> ctx_;
     std::unique_ptr<StreamServer> origin_;
 };
@@ -807,7 +862,7 @@ TEST_F (RelayTest, AnExpiredStreamIsSweptAndReads404) {
     auto response = client ().Get ("/runs/run_test/events");
     ASSERT_TRUE (response);
     EXPECT_EQ (response->status, 404);
-    EXPECT_EQ (manager_.size (), 0u);
+    EXPECT_EQ (manager_->size (), 0u);
 }
 
 // ---------------------------------------------------------------------------
@@ -831,10 +886,11 @@ class StreamExecuteTest : public ::testing::Test {
         vayu::tests::remove_database_files (DB_PATH);
         db_ = std::make_unique<vayu::db::Database> (DB_PATH);
         db_->init ();
-        ctx_ = std::make_unique<vayu::http::routes::RouteContext> (
+        manager_ = std::make_unique<SseStreamManager> ();
+        ctx_     = std::make_unique<vayu::http::routes::RouteContext> (
         vayu::http::routes::RouteContext{ svr_, *db_, run_manager_, false,
         nullptr, authorize_manager_, cookie_jar_, mock_issuer_manager_,
-        inbox_manager_, mock_server_manager_, manager_ });
+        inbox_manager_, mock_server_manager_, *manager_ });
         vayu::http::routes::register_execution_routes (*ctx_);
         vayu::http::routes::register_event_stream_routes (*ctx_);
         svr_.set_write_timeout (60, 0);
@@ -848,6 +904,12 @@ class StreamExecuteTest : public ::testing::Test {
         if (thread_.joinable ()) {
             thread_.join ();
         }
+        // Before `db_` and before `origin_`, always (#646). `trace_for` returns
+        // as soon as the result row lands, which the worker writes from inside
+        // its completion callback - so the test body finishes with that worker
+        // still on the stack of `*db_`. Joining here is what makes the reset
+        // below safe; it is the order `Server::stop()` holds in production.
+        manager_.reset ();
         ctx_.reset ();
         db_.reset ();
         vayu::tests::remove_database_files (DB_PATH);
@@ -915,7 +977,9 @@ class StreamExecuteTest : public ::testing::Test {
     vayu::http::MockIssuerManager mock_issuer_manager_;
     vayu::http::InboxManager inbox_manager_;
     vayu::http::MockServerManager mock_server_manager_;
-    SseStreamManager manager_;
+    /// Held by pointer so `TearDown` can join its workers *before* the
+    /// database they write through goes away - see the note there (#646).
+    std::unique_ptr<SseStreamManager> manager_;
     std::unique_ptr<vayu::http::routes::RouteContext> ctx_;
     std::unique_ptr<StreamServer> origin_;
 };
@@ -1055,6 +1119,85 @@ TEST_F (StreamExecuteTest, MalformedFramesAreDroppedAndTheRunStillCompletes) {
     EXPECT_TRUE (trace["scripts"]["testResults"][0]["passed"].get<bool> ())
     << trace["scripts"]["testResults"][0].value ("error", "");
     EXPECT_EQ (trace["events"]["endReason"], "completed");
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown ordering (issue #646)
+//
+// The fixtures above hold the rule in their `TearDown`; this holds it where the
+// daemon does. `daemon.cpp` runs `curl_global_cleanup` between its
+// `server.stop()` and the point where `~Server` destroys its members, so a
+// stream joined only by the member destructor is a transfer running through
+// curl's global teardown - the #125 defect, in the one worker `RunManager` does
+// not own.
+// ---------------------------------------------------------------------------
+
+/// A port nothing is listening on. `vayu::http::Server` takes its port up
+/// front, so a test cannot ask it for an ephemeral one the way the fixtures
+/// above do; listening and stopping is what actually releases the socket
+/// (`bind_to_any_port` alone leaves it open until the process exits).
+int free_port () {
+    httplib::Server probe;
+    const int port = probe.bind_to_any_port ("127.0.0.1");
+    std::thread runner ([&probe] () { probe.listen_after_bind (); });
+    probe.wait_until_ready ();
+    probe.stop ();
+    runner.join ();
+    return port;
+}
+
+TEST (SseServerShutdownTest, StoppingTheServerDrainsALiveStream) {
+    static constexpr const char* DB_PATH = "test_sse_server_shutdown.db";
+    vayu::tests::remove_database_files (DB_PATH);
+    auto db = std::make_unique<vayu::db::Database> (DB_PATH);
+    db->init ();
+    vayu::core::RunManager run_manager;
+    StreamServer origin;
+
+    const int port = free_port ();
+    {
+        vayu::http::Server server (*db, run_manager, port, false);
+        server.start ();
+
+        httplib::Client client ("127.0.0.1", port);
+        client.set_read_timeout (20, 0);
+        const auto ready = std::chrono::steady_clock::now () + std::chrono::seconds (10);
+        while (!client.Get ("/health") && std::chrono::steady_clock::now () < ready) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (10));
+        }
+
+        // `/endless` never stops talking, so the only thing that can end this
+        // stream inside the test is the drain itself.
+        const json payload = { { "method", "GET" },
+            { "url", origin.url ("/endless") }, { "stream", true } };
+        auto response = client.Post ("/execute", payload.dump (), "application/json");
+        ASSERT_TRUE (response);
+        ASSERT_EQ (response->status, 202) << response->body;
+        const auto run_id = json::parse (response->body).value ("runId", std::string ());
+        ASSERT_FALSE (run_id.empty ());
+
+        const auto deadline =
+        std::chrono::steady_clock::now () + std::chrono::seconds (10);
+        while (origin.requests_received () == 0 &&
+        std::chrono::steady_clock::now () < deadline) {
+            std::this_thread::sleep_for (std::chrono::milliseconds (5));
+        }
+        ASSERT_GT (origin.requests_received (), 0)
+        << "the stream never reached the origin";
+
+        server.stop ();
+
+        // The result row is written by the worker, from inside its completion
+        // callback. Present the instant `stop()` returns means the worker was
+        // joined rather than left running - and left running is what would put
+        // it inside curl while `curl_global_cleanup` ran, and inside `db`
+        // while the daemon destroyed it.
+        EXPECT_FALSE (db->get_results (run_id).empty ())
+        << "server.stop() returned with the stream's worker still running";
+    }
+
+    db.reset ();
+    vayu::tests::remove_database_files (DB_PATH);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

`StreamExecuteTest`'s intermittent SEGFAULT is a **use-after-free**, and the
answer to the question #646 says must not stay ambiguous is: **both**. The
fixture was tearing down out of order, *and* the daemon's own shutdown path had
the same hole one layer up.

**The plan.** Root cause, named by the sanitizer rather than inferred: an SSE
consumer worker writes its run row through `Database&` from inside
`on_complete`, which runs **after** `context->close()` has already flipped
`closed()` - so "the stream is finished" is true while the worker is still
inside the database. `StreamExecuteTest::trace_for` returns the moment that row
lands, so the test body ends with the worker still unwinding, and `TearDown`
then `db_.reset()`s underneath it. The manager was only joined by its own
destructor, which runs after the whole fixture body, i.e. after the database is
gone. The approach is to make the drain **an explicit step every owner takes
before the state its workers reach through goes away**: `SseStreamManager` gains
`shutdown()` (signal + join, terminal and idempotent - `RunManager::shutdown()`'s
shape), the two SSE fixtures hold the manager in a `unique_ptr` they reset first,
and `Server::stop()` calls it. **The alternative I rejected is reordering the
fixture members and letting the destructors do it** - it fixes these two
fixtures and nothing else, leaves the daemon hole open, and is exactly the
"reorder until the symptom stops" the issue warns against: nothing would fail
if a future edit put the reset back.

**The production defect, stated.** `daemon.cpp` runs `curl_global_cleanup()`
*between* `server.stop()` and the point where `~Server` destroys `sse_manager_`.
A stream still live at shutdown was therefore inside a curl transfer while
curl's global state was torn down - the #125 defect (detached run workers
outliving `db` and curl), in the one worker `RunManager` does not own. That is
why the drain belongs to `stop()` and not to the member destructor. The
declaration order in `server.hpp` stays as the backstop; it is no longer the
mechanism.

### Reproduced under a sanitizer, as the issue asks

New `linux-asan` preset (`-DVAYU_USE_ASAN=ON` already existed; it had no preset).
On `cb50e2e`, unmodified, four copies of the ASan binary running
`--gtest_filter='StreamExecuteTest.*' --gtest_repeat=15` concurrently, each from
its own working directory: **4 of 4 processes aborted**, in four different
tests. In isolation it passed 8/8 repeats, matching the issue's report.

```
ERROR: AddressSanitizer: heap-use-after-free ... WRITE of size 4 at ... thread T57
    #1 sqlite_orm::internal::connection_holder::release()
    #11 vayu::db::Database::get_config_entry(...)          database.cpp:1739
    #13 vayu::db::Database::prune_runs_configured()        database.cpp:1428
    #14 vayu::http::routes::record_design_result(...)      execution.cpp:612
    #15 operator()                                         execution.cpp:1105   <- on_complete
    #20 operator()                                         sse_stream.cpp:583   <- the worker
freed by thread T0 here:
    #8  vayu::db::Database::~Database()                    database.cpp:631
    #12 TearDown                                           sse_stream_test.cpp:852  <- db_.reset()
```

Same load, after the fix: **0 reports in 4 x 15 repeats**, `StreamExecuteTest`
plus `RelayTest` plus `SseStreamManagerTest`, all green.

### What landed

**`SseStreamManager::shutdown()`** - the destructor's body, now callable. Signal
all, then join all (unchanged: teardown costs one stream's stop latency, not the
sum). Terminal like `RunManager::shutdown()` - a drained manager refuses
`start()`, because a caller drains exactly when the `Database` and `CookieJar`
are about to go away and a stream begun after that has nothing to write to.

**`Server::stop()` drains it**, outside the `is_running_` guard and after the
listener is down, so "the server has stopped" means no engine work is still in
flight - the ordering `daemon.cpp` already states for run workers and curl.

**The two SSE fixtures** hold the manager in a `unique_ptr` and reset it before
`db_`, the `InboxListenerTest` precedent, with the constraint named at the reset
rather than left to member order.

**`src/http/server.cpp` (and `routes/health.cpp`, which it registers) join the
test target.** The daemon's `Server` had no test reaching it at all, which is
why this ordering could only be found by running the daemon.

**A `linux-asan` preset** (configure/build/test), into its own `build-asan/` tree
so an ASan run never invalidates the ordinary build's objects. The issue asked me
to consider one and I think it earns its place: this class of bug is invisible
without it, and the next person should not have to hand-roll the cmake line. The
`-DVAYU_USE_ASAN` option it sets is pre-existing.

### Deliberate deviations from the issue spec

1. **No new sanitizer-only test.** The issue offers "a direct test that a
   manager with a live consumer is destroyed without touching freed memory -
   under ASan, so the assertion is the sanitizer's". A test whose only oracle is
   a sanitizer passes silently in the ordinary suite, which is where it would
   run. Both new tests assert in **plain** builds instead
   (`completed.load()` after `shutdown()`; the result row after `stop()`) and
   are ASan-clean on top.
2. **The stress loop is not in the suite**, per the issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

| Suite | Result |
|---|---|
| `python build.py -e -t` + `ctest --preset linux-dev` | **1704 / 1704 passed** (2 new; base 1702) |
| `ctest --repeat until-fail:50 -R StreamExecuteTest` | **clean** (with the two new tests folded in: 12 ctest cases, 50 repeats each) |
| ASan, 4 x 15 repeats of the three SSE suites under concurrency | 0 sanitizer reports |
| `mkdocs build --strict` | clean |

New coverage (2):

- **`SseStreamManagerTest.ShutdownJoinsEveryWorkerAndIsTerminalAndIdempotent`** -
  an endless stream whose `on_complete` sets a flag; after `shutdown()` returns
  the flag is **already set**, which is the difference between joining the
  worker and waiting on `closed()`. Plus terminal (`start()` after a drain is
  `nullptr`) and idempotent.
- **`SseServerShutdownTest.StoppingTheServerDrainsALiveStream`** - the
  production wiring, through a real `vayu::http::Server`: `POST /execute` with
  `stream: true` against an endless origin, then `stop()`, and the run's result
  row is present the instant it returns. The origin can never end that stream,
  so the row exists only if the drain did.

**Mutation-checked** (broken, confirmed red, restored):

- delete `sse_manager_.shutdown()` from `Server::stop()` -> the server test fails
  with "server.stop() returned with the stream's worker still running", and
  nothing else changes;
- make `shutdown()` signal without draining -> the manager test fails on both the
  completion flag and `size()`, and the joinable threads then abort the process,
  which is the same shape as the original crash.

`StreamServer` gained a request counter (`requests_received()`), because the run
row exists before the worker has connected and the server test must interrupt a
transfer that is genuinely in flight; `/endless` now records its request like
`/scripted` did.

No app change: this is engine-side lifetime only, and no endpoint, payload or
status code moved.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs land in the same commit: `docs/engine/architecture.md` (the thread model
gains stream consumers, and the shutdown chain - which listed run workers and
`curl_global_cleanup` but not streams - now says where the drain happens and
why), `docs/engine/building.md` (the `linux-asan` preset, plus the two things
that make a lifetime bug reproducible: run under load, from separate working
directories), and the streaming bullet in `engine/CLAUDE.md`.

## Related Issues

Closes #646. The ordering it restores is #125's, applied to the streaming
worker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R37jbB54wnfbx3qmGZ9yfm)_