### PR TITLE
feat(app/openapi): resolve external $refs before parse, and share one resolver

### DIFF
--- a/app/electron/constants.ts
+++ b/app/electron/constants.ts
@@ -82,6 +82,15 @@ export const ENGINE_PORT_RELEASE_DELAY_MS = 500;
  * port is: the main process cannot import renderer modules.
  */
 export const DATA_FILE_MAX_BYTES_SEED = 16 * 1024 * 1024;
+/**
+ * Seed for the engine's `maxSpecDocumentBytes`, used by the spec sibling-read
+ * channel only while the engine cannot answer `GET /config` (see spec-file.ts).
+ *
+ * Same posture as the data-file seed above: not the rule, and mirroring
+ * `SPEC_DOCUMENT_MAX_BYTES` in src/constants/spec-documents.ts because the main
+ * process cannot import renderer modules.
+ */
+export const SPEC_DOCUMENT_MAX_BYTES_SEED = 10 * 1024 * 1024;
 
 // Window
 export const WINDOW_DEFAULT_WIDTH = 1400;

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "url";
 import { EngineSidecar } from "./sidecar.js";
 import { resolveAppPaths } from "./app-paths.js";
 import { readDataFile } from "./data-file.js";
+import { readSpecFile } from "./spec-file.js";
 import { setupOAuthIpcHandlers } from "./oauth.js";
 import { loadWindowState, trackWindowState } from "./window-state.js";
 import { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } from "./updater.js";
@@ -814,6 +815,14 @@ function setupIpcHandlers() {
 	// alternative that was rejected, are in data-file.ts.
 	ipcMain.handle("dataFile:read", async (_event, filePath: unknown) => {
 		return await readDataFile(String(filePath ?? ""));
+	});
+
+	// Read a file an imported OpenAPI document references (issue #649). The
+	// renderer passes the picked document's path and the ref's own text; this
+	// process resolves one against the other, so the web layer still names no
+	// directory of its own. Gates and the rejected alternative are in spec-file.ts.
+	ipcMain.handle("specFile:read", async (_event, specPath: unknown, refPath: unknown) => {
+		return await readSpecFile(String(specPath ?? ""), String(refPath ?? ""));
 	});
 }
 

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -199,6 +199,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	readDataFile: (path: string): Promise<{ bytes: Uint8Array; fileName: string }> =>
 		ipcRenderer.invoke("dataFile:read", path),
 
+	// Read a file an imported OpenAPI document references (issue #649). Two
+	// arguments and not a composed path: the renderer holds the picked
+	// document's path and the ref's text, and the main process resolves one
+	// against the other, so this channel reads files a *document* named rather
+	// than paths the web layer built. Gated there (extension allowlist + the
+	// engine's fetched `maxSpecDocumentBytes`); bytes, not text, for the same
+	// reason `readDataFile` returns bytes.
+	readSpecFile: (
+		specPath: string,
+		refPath: string
+	): Promise<{ bytes: Uint8Array; fileName: string }> =>
+		ipcRenderer.invoke("specFile:read", specPath, refPath),
+
 	// Before quit flush handler. ACKs main once the callback settles so quit
 	// can resume immediately instead of waiting out the fallback timeout.
 	onBeforeQuit: (callback: () => void | Promise<void>) => {

--- a/app/electron/spec-file.test.ts
+++ b/app/electron/spec-file.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The gates on the channel that reads the files an imported spec references
+ * (issue #649).
+ *
+ * Same shape as `data-file.test.ts`, because the channel is the same widening of
+ * the same posture: the renderer hands over a document path and a reference, and
+ * what keeps that from being "read any file" is an extension allowlist plus the
+ * engine's fetched cap. Both are driven against an injected filesystem, so a
+ * regression in either shows up here rather than as a file the app should never
+ * have opened.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import path from "path";
+import { readSpecFile, SPEC_FILE_EXTENSIONS, type SpecFileSystem } from "./spec-file";
+
+const system = (overrides: Partial<SpecFileSystem> = {}): SpecFileSystem => ({
+	stat: vi.fn(async () => ({ size: 10, isFile: () => true })),
+	readFile: vi.fn(async () => Buffer.from('{"Pet":{"type":"object"}}')),
+	fetchConfig: vi.fn(async () => ({
+		entries: [{ key: "maxSpecDocumentBytes", value: "1024" }],
+	})),
+	...overrides,
+});
+
+const SPEC = "/home/u/api/spec/openapi.yaml";
+
+describe("readSpecFile - resolving the reference", () => {
+	it("resolves it against the picked document's directory, not the process cwd", async () => {
+		// The renderer passes the ref as the *document* wrote it; the resolution
+		// happens here, which is what keeps the web layer from naming directories.
+		const io = system();
+		await readSpecFile(SPEC, "./schemas/pet.json", io);
+		expect(io.readFile).toHaveBeenCalledWith(path.resolve("/home/u/api/spec/schemas/pet.json"));
+	});
+
+	it("follows a reference that climbs out of that directory", async () => {
+		// `spec/openapi.yaml` -> `../shared/error.yaml` is an ordinary layout, and
+		// the file is named by a document the user chose to import.
+		const io = system();
+		const result = await readSpecFile(SPEC, "../shared/error.yaml", io);
+		expect(io.readFile).toHaveBeenCalledWith(path.resolve("/home/u/api/shared/error.yaml"));
+		expect(result.fileName).toBe("error.yaml");
+	});
+
+	it("refuses an absolute reference, which describes one machine's disk", async () => {
+		const io = system();
+		await expect(readSpecFile(SPEC, "/etc/hosts.json", io)).rejects.toThrow(/absolute path/);
+		expect(io.stat).not.toHaveBeenCalled();
+	});
+
+	it("refuses an empty document path or an empty reference", async () => {
+		const io = system();
+		await expect(readSpecFile("", "./pet.json", io)).rejects.toThrow(/No spec file path/);
+		await expect(readSpecFile(SPEC, "  ", io)).rejects.toThrow(/No referenced file/);
+		expect(io.stat).not.toHaveBeenCalled();
+	});
+});
+
+describe("readSpecFile - the extension allowlist", () => {
+	it("opens the three a spec can be written in", async () => {
+		for (const extension of SPEC_FILE_EXTENSIONS) {
+			const result = await readSpecFile(SPEC, `./defs${extension}`, system());
+			expect(result.fileName).toBe(`defs${extension}`);
+		}
+	});
+
+	it("is case-insensitive, because Windows exports are SCHEMA.JSON", async () => {
+		await expect(readSpecFile(SPEC, "./SCHEMA.JSON", system())).resolves.toBeTruthy();
+	});
+
+	it("refuses anything else without touching the disk", async () => {
+		const io = system();
+		for (const ref of ["../../.ssh/id_rsa", "./vayu.db", "./secrets.env", "./notes"]) {
+			await expect(readSpecFile(SPEC, ref, io)).rejects.toThrow(/only opens spec files/);
+		}
+		expect(io.readFile).not.toHaveBeenCalled();
+		expect(io.stat).not.toHaveBeenCalled();
+	});
+});
+
+describe("readSpecFile - the engine's byte cap", () => {
+	it("follows the fetched setting rather than a hard-coded copy", async () => {
+		const big = system({ stat: vi.fn(async () => ({ size: 5000, isFile: () => true })) });
+		await expect(readSpecFile(SPEC, "./pet.json", big)).rejects.toThrow(/maxSpecDocumentBytes/);
+
+		const raised = system({
+			stat: vi.fn(async () => ({ size: 5000, isFile: () => true })),
+			fetchConfig: vi.fn(async () => ({
+				entries: [{ key: "maxSpecDocumentBytes", value: "1048576" }],
+			})),
+		});
+		await expect(readSpecFile(SPEC, "./pet.json", raised)).resolves.toBeTruthy();
+	});
+
+	it("names the size and the setting, so 'raise it' is actionable", async () => {
+		const io = system({ stat: vi.fn(async () => ({ size: 5000, isFile: () => true })) });
+		await expect(readSpecFile(SPEC, "./pet.json", io)).rejects.toThrow(
+			/pet.json is 5000 bytes, over the 1024/
+		);
+		expect(io.readFile).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the seed when the engine cannot answer", async () => {
+		const io = system({
+			fetchConfig: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+		});
+		await expect(readSpecFile(SPEC, "./pet.json", io)).resolves.toBeTruthy();
+	});
+});
+
+describe("readSpecFile - what it returns", () => {
+	it("hands back bytes, as the data-file channel does", async () => {
+		const io = system({ readFile: vi.fn(async () => Buffer.from([0x7b, 0x7d])) });
+		const { bytes } = await readSpecFile(SPEC, "./pet.json", io);
+		expect(Array.from(bytes)).toEqual([0x7b, 0x7d]);
+	});
+
+	it("reports a reference that is not there by naming both halves", async () => {
+		const io = system({
+			stat: vi.fn(async () => {
+				throw new Error("ENOENT");
+			}),
+		});
+		await expect(readSpecFile(SPEC, "./gone.json", io)).rejects.toThrow(
+			/references \.\/gone\.json, which is not at .*gone\.json/
+		);
+	});
+
+	it("refuses a directory that happens to end in .json", async () => {
+		const io = system({ stat: vi.fn(async () => ({ size: 4096, isFile: () => false })) });
+		await expect(readSpecFile(SPEC, "./schemas.json", io)).rejects.toThrow(/is not at/);
+	});
+});

--- a/app/electron/spec-file.ts
+++ b/app/electron/spec-file.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Reading the files an imported OpenAPI document references (issue #649).
+ *
+ * A multi-file spec names its siblings by relative path - `./schemas/pet.yaml`,
+ * `../shared/error.yaml` - and until those are read, every operation that
+ * depends on one imports short with nothing said about it. The file the user
+ * picked arrives as a `File`; its neighbours never do, so this is the channel
+ * that reads them.
+ *
+ * **The renderer never names a directory here.** It passes the picked
+ * document's path (which it already holds from `getFilePath`) and the ref's own
+ * text, and the resolution happens *in this process*. That is the difference
+ * between "read a file this document asked for" and "read a path the web layer
+ * composed", and it is why the two arguments are not one.
+ *
+ * The gates are `data-file.ts`'s, for the same reasons stated there at length:
+ *
+ *  1. **Extension allowlist** - the three a spec can be written in and nothing
+ *     else, so the channel cannot be pointed at a key, a database or a dotfile.
+ *  2. **The engine's `maxSpecDocumentBytes`, fetched** - never a second copy of
+ *     the rule. The bundle has to fit what `POST /specs` will store, and a user
+ *     who raises the setting can import the bigger spec the same session.
+ *
+ * **A ref that climbs out of the spec's directory is allowed**, and that is a
+ * decision rather than an oversight: `spec/openapi.yaml` referencing
+ * `../shared/error.yaml` is an ordinary layout, and the file is named by a
+ * document the user chose to import. A directory jail would refuse real specs
+ * while adding nothing the extension allowlist does not already give - the same
+ * reasoning that rejected a registry of picked paths for `dataFile:read`.
+ *
+ * Bytes, not text, again matching `dataFile:read`: decoding belongs to one place
+ * on the renderer side, so a sibling read here cannot disagree with the picked
+ * file read through `FileReader`.
+ */
+
+import { promises as fs } from "fs";
+import path from "path";
+
+import { ENGINE_HOST, ENGINE_PORT, SPEC_DOCUMENT_MAX_BYTES_SEED } from "./constants.js";
+
+/** Extensions this channel will open, lower-cased and with the dot. */
+export const SPEC_FILE_EXTENSIONS: readonly string[] = [".json", ".yaml", ".yml"];
+
+/** What the handler resolves to: the file's bytes and the name it has now. */
+export interface SpecFileReadResult {
+	bytes: Uint8Array;
+	fileName: string;
+}
+
+/** The I/O this module performs, injected so the gates are testable without a disk. */
+export interface SpecFileSystem {
+	stat: (filePath: string) => Promise<{ size: number; isFile: () => boolean }>;
+	readFile: (filePath: string) => Promise<Buffer>;
+	fetchConfig: () => Promise<unknown>;
+}
+
+const defaultSystem: SpecFileSystem = {
+	stat: (filePath) => fs.stat(filePath),
+	readFile: (filePath) => fs.readFile(filePath),
+	fetchConfig: async () => {
+		const response = await fetch(`http://${ENGINE_HOST}:${ENGINE_PORT}/config`);
+		if (!response.ok) throw new Error(`config responded ${response.status}`);
+		return await response.json();
+	},
+};
+
+/**
+ * The live `maxSpecDocumentBytes`, or the seed when the engine cannot answer.
+ *
+ * Falling back rather than failing, as the data-file channel does: an
+ * unreachable engine is a state the user is about to hit anyway - the import
+ * cannot be applied either - and refusing to *read* would report it as a problem
+ * with their spec.
+ */
+async function maxSpecFileBytes(system: SpecFileSystem): Promise<number> {
+	try {
+		const config = (await system.fetchConfig()) as {
+			entries?: { key?: string; value?: string }[];
+		};
+		const entry = config?.entries?.find((e) => e.key === "maxSpecDocumentBytes");
+		const value = Number(entry?.value);
+		if (Number.isFinite(value) && value > 0) return value;
+	} catch {
+		// Fall through to the seed.
+	}
+	return SPEC_DOCUMENT_MAX_BYTES_SEED;
+}
+
+/**
+ * Read one file referenced by an imported spec, or throw a message the import
+ * dialog can show as-is.
+ *
+ * @param specPath the document the user picked - only its directory is used.
+ * @param refPath the `$ref` target as the document wrote it, relative to that
+ * directory.
+ */
+export async function readSpecFile(
+	specPath: string,
+	refPath: string,
+	system: SpecFileSystem = defaultSystem
+): Promise<SpecFileReadResult> {
+	if (typeof specPath !== "string" || specPath.trim() === "") {
+		throw new Error("No spec file path was given.");
+	}
+	if (typeof refPath !== "string" || refPath.trim() === "") {
+		throw new Error("No referenced file was named.");
+	}
+	if (path.isAbsolute(refPath)) {
+		// A spec that names an absolute path describes one machine's disk, not a
+		// document. Refusing is honest; resolving it would make an import behave
+		// differently on the author's machine than on anyone else's.
+		throw new Error(`"${refPath}" is an absolute path, and a spec reference must be relative.`);
+	}
+
+	const resolved = path.resolve(path.dirname(specPath), refPath);
+	const extension = path.extname(resolved).toLowerCase();
+	if (!SPEC_FILE_EXTENSIONS.includes(extension)) {
+		throw new Error(
+			`Vayu only opens spec files (${SPEC_FILE_EXTENSIONS.join(", ")}), and this reference is "${extension || "extensionless"}".`
+		);
+	}
+
+	let size: number;
+	try {
+		const stats = await system.stat(resolved);
+		if (!stats.isFile()) throw new Error("not a file");
+		size = stats.size;
+	} catch {
+		throw new Error(`The spec references ${refPath}, which is not at ${resolved}.`);
+	}
+
+	const maxBytes = await maxSpecFileBytes(system);
+	if (size > maxBytes) {
+		throw new Error(
+			`${refPath} is ${size} bytes, over the ${maxBytes} one document may hold. Raise the maxSpecDocumentBytes engine setting, or split the spec.`
+		);
+	}
+
+	const buffer = await system.readFile(resolved);
+	return {
+		bytes: new Uint8Array(buffer),
+		fileName: path.basename(resolved),
+	};
+}

--- a/app/src/constants/spec-documents.ts
+++ b/app/src/constants/spec-documents.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Seed for the engine's cap on one stored OpenAPI document, mirroring
+ * `constants::spec_document::MAX_BYTES` engine-side.
+ *
+ * Not the rule - `maxSpecDocumentBytes` is a setting a user can raise, and the
+ * live value comes from the config query via {@link useSpecDocumentLimit}. This
+ * stands in only until that query resolves, and it is the number the engine
+ * itself seeds, so the gap changes nothing.
+ */
+export const SPEC_DOCUMENT_MAX_BYTES = 10 * 1024 * 1024;

--- a/app/src/hooks/useSpecDocumentLimit.ts
+++ b/app/src/hooks/useSpecDocumentLimit.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * useSpecDocumentLimit
+ *
+ * The engine cap an imported OpenAPI document - and everything bundled into it
+ * (issue #649) - has to fit inside: `maxSpecDocumentBytes`.
+ *
+ * Read from the engine rather than restated, the same rule `useDataFileLimits`
+ * follows: `POST /specs` applies this cap, and a renderer copy could only drift
+ * in the direction that hurts - refusing a spec the user had just raised the
+ * setting to allow, with no way to tell which side said no.
+ *
+ * Read-only: the setting is edited from the engine settings list. Until the
+ * config query resolves the module seed stands, which is the number the engine
+ * itself seeds.
+ */
+
+import { useConfigQuery } from "@/queries";
+import { SPEC_DOCUMENT_MAX_BYTES } from "@/constants/spec-documents";
+
+export function useSpecDocumentLimit(): { maxBytes: number } {
+	const { data: config } = useConfigQuery();
+	// Entry values are strings. An absent key - config still loading, or an
+	// engine older than this setting - leaves the seed rather than parsing
+	// `undefined` to NaN.
+	const raw = Number(config?.entries?.find((e) => e.key === "maxSpecDocumentBytes")?.value);
+	return { maxBytes: Number.isFinite(raw) && raw > 0 ? raw : SPEC_DOCUMENT_MAX_BYTES };
+}

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -31,6 +31,8 @@ import {
 	type SkippedItem,
 } from "@/services/importers/types";
 import { importFailureMessage } from "@/services/importers/failure-message";
+import { bundleExternalRefs } from "@/services/importers/ref-bundler";
+import { useSpecDocumentLimit } from "@/hooks/useSpecDocumentLimit";
 import { MethodBadge } from "@/components/shared";
 
 type Tab = "file" | "url" | "paste";
@@ -66,7 +68,13 @@ export function ImportModal() {
 	// They used to live only long enough to render the preview.
 	const [specFilePath, setSpecFilePath] = useState("");
 	const [sourceUrl, setSourceUrl] = useState("");
+	// External `$ref`s the bundling pass below could not reach (issue #649).
+	// Held in state because a toggle re-parses the already-bundled text, and the
+	// count belongs to the document rather than to the parse - a re-detect that
+	// dropped it would quietly un-report a loss the user was already told about.
+	const [unresolvedRefs, setUnresolvedRefs] = useState(0);
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const { maxBytes: specMaxBytes } = useSpecDocumentLimit();
 
 	const reset = () => {
 		setPhase("idle");
@@ -77,6 +85,7 @@ export function ImportModal() {
 		setUrl("");
 		setSpecFilePath("");
 		setSourceUrl("");
+		setUnresolvedRefs(0);
 	};
 
 	const handleClose = () => {
@@ -104,9 +113,64 @@ export function ImportModal() {
 		}
 	};
 
-	const runDetect = (raw: string, source: ImportSource = {}) => {
+	/**
+	 * Resolve what the document references, then detect it (issue #649).
+	 *
+	 * A multi-file OpenAPI spec is only itself once its `$ref`s are followed:
+	 * before this, every one of them parsed to `undefined` and the operation
+	 * imported without the body or parameters it declared, silently. Bundling is
+	 * async and parsing is not, so it happens here rather than inside
+	 * `parseImport`, and what the parser (and the engine) then sees is one
+	 * self-contained document. A spec with nothing external is passed through
+	 * byte for byte.
+	 *
+	 * Both intakes are handed over, and the bundler uses whichever a given ref
+	 * needs: absolute URLs go through the engine proxy for a file-picked spec
+	 * too, and a relative ref in a pasted document has neither, which is the one
+	 * case that can only be reported.
+	 */
+	const runDetect = async (
+		raw: string,
+		source: ImportSource & { specPath?: string } = {}
+	): Promise<void> => {
 		setPhase("detecting");
-		detect(raw, { importEnvironments, importScripts }, source);
+		const { specPath, ...rest } = source;
+		const readSpecFile = window.electronAPI?.readSpecFile;
+		try {
+			const bundle = await bundleExternalRefs(raw, {
+				maxBytes: specMaxBytes,
+				...(rest.sourceUrl ? { sourceUrl: rest.sourceUrl } : {}),
+				fetchUrl: async (target) => (await apiService.importFetch(target)).content,
+				...(specPath && readSpecFile
+					? {
+							readSibling: async (relativePath) => {
+								const { bytes } = await readSpecFile(specPath, relativePath);
+								// UTF-8, exactly as `FileReader.readAsText` decoded the
+								// document these bytes sit beside. A sibling that is not
+								// UTF-8 fails to parse and is reported as an unresolved
+								// ref, which is what it is.
+								return new TextDecoder("utf-8").decode(bytes);
+							},
+						}
+					: {}),
+			});
+			setUnresolvedRefs(bundle.unresolvedRefs);
+			detect(
+				bundle.text,
+				{ importEnvironments, importScripts },
+				{
+					...rest,
+					...(bundle.unresolvedRefs ? { unresolvedRefs: bundle.unresolvedRefs } : {}),
+				}
+			);
+		} catch (e) {
+			// Only the size cap throws - an unreachable reference is counted, not
+			// fatal. A bundle over the cap is fatal because the engine would refuse
+			// to store it, leaving a collection bound to nothing.
+			setResult(null);
+			setError((e as Error).message);
+			setPhase("error");
+		}
 	};
 
 	// Re-parse the already-loaded source when an option toggle changes in preview.
@@ -118,6 +182,10 @@ export function ImportModal() {
 			detect(lastRaw, next, {
 				fileName: result?.meta.fileName,
 				...(sourceUrl ? { sourceUrl } : {}),
+				// `lastRaw` is the bundled text, so nothing is re-fetched - but the
+				// refs that stayed unresolved are still unresolved, and the count has
+				// to be restated or the preview stops mentioning them.
+				...(unresolvedRefs ? { unresolvedRefs } : {}),
 			});
 		}
 	};
@@ -125,14 +193,17 @@ export function ImportModal() {
 	const handleFile = (file: File) => {
 		const reader = new FileReader();
 		reader.onload = () => {
+			const path = window.electronAPI?.getFilePath(file) ?? "";
 			// The path at pick time, while there is still a `File` to take it
 			// from - `getFilePath` is a preload-local read of the object, not a
 			// channel the renderer can name a path on. Empty outside Electron and
 			// for a drag-and-drop of remote content, which is the state "no
 			// remembered file" already means.
-			setSpecFilePath(window.electronAPI?.getFilePath(file) ?? "");
+			setSpecFilePath(path);
 			setSourceUrl("");
-			runDetect(String(reader.result), { fileName: file.name });
+			// The path is also what a `$ref` to a sibling file is resolved against,
+			// in the main process - see `readSpecFile`.
+			void runDetect(String(reader.result), { fileName: file.name, specPath: path });
 		};
 		reader.onerror = () => {
 			setError("Could not read file");
@@ -155,7 +226,7 @@ export function ImportModal() {
 			const { content } = await apiService.importFetch(url);
 			setSpecFilePath("");
 			setSourceUrl(url);
-			detect(content, { importEnvironments, importScripts }, { sourceUrl: url });
+			await runDetect(content, { sourceUrl: url });
 		} catch (e) {
 			setError((e as Error).message);
 			setPhase("error");
@@ -311,7 +382,7 @@ export function ImportModal() {
 								className="h-40 w-full font-mono text-xs"
 							/>
 							<Button
-								onClick={() => runDetect(pasteText)}
+								onClick={() => void runDetect(pasteText)}
 								disabled={!pasteText.trim()}
 								className="mt-2"
 							>
@@ -609,6 +680,13 @@ const SKIPPED_LABELS: Record<SkippedItem["kind"], [singular: string, plural: str
 	example_no_status: [
 		"example response with no numeric status",
 		"example responses with no numeric status",
+	],
+	// Not "external ref": the count is what the user lost, and what they lost is
+	// a schema the spec pointed at in another file (issue #649). The wording says
+	// which half failed - Vayu found the reference and could not read the file.
+	external_ref: [
+		"reference to a file Vayu could not read",
+		"references to files Vayu could not read",
 	],
 };
 

--- a/app/src/services/importers/__fixtures__/openapi-v3-multifile/shared/error.json
+++ b/app/src/services/importers/__fixtures__/openapi-v3-multifile/shared/error.json
@@ -1,0 +1,10 @@
+{
+	"Error": {
+		"type": "object",
+		"required": ["message"],
+		"properties": {
+			"code": { "type": "integer", "example": 400 },
+			"message": { "type": "string", "example": "pet already exists" }
+		}
+	}
+}

--- a/app/src/services/importers/__fixtures__/openapi-v3-multifile/spec/openapi.json
+++ b/app/src/services/importers/__fixtures__/openapi-v3-multifile/spec/openapi.json
@@ -1,0 +1,39 @@
+{
+	"openapi": "3.0.3",
+	"info": { "title": "Multi-file Pets", "version": "1.0.0" },
+	"servers": [{ "url": "https://api.pets.com/v1" }],
+	"paths": {
+		"/pets": {
+			"post": {
+				"operationId": "createPet",
+				"summary": "Create pet",
+				"tags": ["pets"],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": { "$ref": "./schemas/pet.json#/Pet" }
+						}
+					}
+				},
+				"responses": {
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": { "$ref": "./schemas/pet.json#/Pet" }
+							}
+						}
+					},
+					"400": {
+						"description": "Bad request",
+						"content": {
+							"application/json": {
+								"schema": { "$ref": "../shared/error.json#/Error" }
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/app/src/services/importers/__fixtures__/openapi-v3-multifile/spec/schemas/pet.json
+++ b/app/src/services/importers/__fixtures__/openapi-v3-multifile/spec/schemas/pet.json
@@ -1,0 +1,15 @@
+{
+	"Pet": {
+		"type": "object",
+		"required": ["id", "name"],
+		"properties": {
+			"id": { "type": "integer", "example": 7 },
+			"name": { "type": "string", "example": "Rex" },
+			"tag": { "$ref": "#/Tag" }
+		}
+	},
+	"Tag": {
+		"type": "object",
+		"properties": { "label": { "type": "string", "example": "good-boy" } }
+	}
+}

--- a/app/src/services/importers/factory.ts
+++ b/app/src/services/importers/factory.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import yaml from "js-yaml";
 import type { CollectionDraft, ImportOptions, ImportParser, ImportResult } from "./types";
 import { UnrecognisedFormatError } from "./types";
+import { parseRaw } from "./parse-raw";
 import { appendParamsToUrl } from "@/modules/request-builder/utils/url";
 import { PostmanV21Parser, PostmanV20Parser } from "./postman";
 import { PostmanEnvironmentParser } from "./postman-environment";
@@ -26,15 +26,6 @@ const PARSERS: ImportParser[] = [
 	new OpenApiV3Parser(),
 	new OpenApiV2Parser(),
 ];
-
-function parseRaw(raw: string): unknown {
-	try {
-		return JSON.parse(raw);
-	} catch {
-		// Throws on malformed YAML - let it propagate as a parse error.
-		return yaml.load(raw);
-	}
-}
 
 /**
  * Restore the app's url/params invariant on every request a parser produced.
@@ -73,6 +64,13 @@ function joinParamsIntoUrls(result: ImportResult): void {
 export interface ImportSource {
 	fileName?: string;
 	sourceUrl?: string;
+	/**
+	 * External `$ref`s the bundling pass could not reach (issue #649). Stamped
+	 * into `meta.skipped` here for the same reason the two above are stamped
+	 * here: bundling happens before parse, so no parser can know the count, and a
+	 * loss the preview never names is the defect bundling exists to fix.
+	 */
+	unresolvedRefs?: number;
 }
 
 /**
@@ -97,6 +95,12 @@ export function parseImport(
 				for (const collection of result.collections) {
 					if (collection.spec) collection.spec.sourceUrl = source.sourceUrl;
 				}
+			}
+			if (source.unresolvedRefs && source.unresolvedRefs > 0) {
+				result.meta.skipped.push({
+					kind: "external_ref",
+					count: source.unresolvedRefs,
+				});
 			}
 			joinParamsIntoUrls(result);
 			return result;

--- a/app/src/services/importers/openapi-shared.ts
+++ b/app/src/services/importers/openapi-shared.ts
@@ -12,6 +12,35 @@ import { asRecord, asStr, prop } from "@/lib/json-node";
 export type RefResolver = (ref: string) => unknown;
 
 /**
+ * The in-document `$ref` resolver, once (issue #649).
+ *
+ * Both parsers built this by hand, identically - the repo's hand-rolled-copy
+ * defect, in the one helper every other helper here takes as an argument. The
+ * two escapes are the JSON Pointer ones (`~1` is `/`, `~0` is `~`), and the walk
+ * is `prop()` per segment so a pointer into a non-object yields `undefined`
+ * rather than throwing.
+ *
+ * **In-document only, and that is now a guarantee rather than a gap.** A ref
+ * naming another file (`./pets.yaml#/Pet`) has no `#/` prefix to strip, so every
+ * segment names a key no document has and the walk lands on `undefined` - which
+ * a caller cannot tell from "the spec documented nothing here". External refs
+ * are therefore resolved *before* parse by `ref-bundler.ts`, which inlines what
+ * it can reach and counts what it cannot into the skip tally. Anything still
+ * external by the time this runs is a ref the user has already been told about.
+ */
+export function createRefResolver(document: unknown): RefResolver {
+	return (ref: string): unknown => {
+		const path = ref
+			.replace(/^#\//, "")
+			.split("/")
+			.map((s) => s.replace(/~1/g, "/").replace(/~0/g, "~"));
+		let cur: unknown = document;
+		for (const seg of path) cur = prop(cur, seg);
+		return cur;
+	};
+}
+
+/**
  * The identity of one operation: its method, the **templated** path as the
  * document writes it, and its `operationId` when it declares one (issue #637).
  *

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -19,6 +19,7 @@ import { sampleSchema } from "./schema-sampler";
 import { normalizeVars } from "./var-normalize";
 import { mapSwaggerOAuth2 } from "./oauth2-import";
 import {
+	createRefResolver,
 	deref,
 	exampleBodyText,
 	queryParamRow,
@@ -67,15 +68,7 @@ export class OpenApiV2Parser implements ImportParser {
 
 	parse(parsed: unknown, raw: string, _opts: ImportOptions): ImportResult {
 		const spec = asRecord(parsed) ?? {};
-		const resolveRef = (ref: string): unknown => {
-			const path = ref
-				.replace(/^#\//, "")
-				.split("/")
-				.map((s) => s.replace(/~1/g, "/").replace(/~0/g, "~"));
-			let cur: unknown = spec;
-			for (const seg of path) cur = prop(cur, seg);
-			return cur;
-		};
+		const resolveRef = createRefResolver(spec);
 
 		const scheme = asStr(asArray(spec.schemes)[0]) ?? "https";
 		const basePathValue = asStr(spec.basePath);

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -19,6 +19,7 @@ import { sampleSchema, schemaFormFields } from "./schema-sampler";
 import { normalizeVars } from "./var-normalize";
 import { mapOpenApiV3OAuth2 } from "./oauth2-import";
 import {
+	createRefResolver,
 	deref,
 	exampleBodyText,
 	findJsonMediaType,
@@ -70,15 +71,7 @@ export class OpenApiV3Parser implements ImportParser {
 
 	parse(parsed: unknown, raw: string, _opts: ImportOptions): ImportResult {
 		const spec = asRecord(parsed) ?? {};
-		const resolveRef = (ref: string): unknown => {
-			const path = ref
-				.replace(/^#\//, "")
-				.split("/")
-				.map((s) => s.replace(/~1/g, "/").replace(/~0/g, "~"));
-			let cur: unknown = spec;
-			for (const seg of path) cur = prop(cur, seg);
-			return cur;
-		};
+		const resolveRef = createRefResolver(spec);
 
 		const baseUrl = asStr(prop(asArray(spec.servers)[0], "url")) ?? "";
 		const primaryScheme = pickPrimaryScheme(spec);

--- a/app/src/services/importers/orchestrator.fixture-parity.test.ts
+++ b/app/src/services/importers/orchestrator.fixture-parity.test.ts
@@ -174,7 +174,15 @@ describe("import payload parity with the per-item path", () => {
 	it("checks every fixture in the fixtures directory", () => {
 		// Derived from the directory, not hardcoded: a new format's fixture has to
 		// be added to FIXTURES rather than silently skipping this parity check.
-		const onDisk = readdirSync(join(__dirname, "__fixtures__")).sort();
+		//
+		// Files only. A *multi-file* spec fixture is a directory of documents with
+		// one entry point (issue #649) - there is no single file to hand a parser,
+		// and its parity is exercised by `ref-bundler.test.ts`, which bundles it
+		// first and then parses the result like any other single document.
+		const onDisk = readdirSync(join(__dirname, "__fixtures__"), { withFileTypes: true })
+			.filter((entry) => entry.isFile())
+			.map((entry) => entry.name)
+			.sort();
 		expect(onDisk.length).toBeGreaterThan(0);
 		expect([...FIXTURES].sort()).toEqual(onDisk);
 	});

--- a/app/src/services/importers/parse-raw.ts
+++ b/app/src/services/importers/parse-raw.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+import yaml from "js-yaml";
+
+/**
+ * Parse an import's raw text once: JSON, then YAML.
+ *
+ * Its own module because two callers need the *same* answer - the factory, which
+ * hands the parsed value to the detectors, and the ref bundler (issue #649),
+ * which has to walk the same document before parse to resolve external refs. A
+ * second copy would be a second opinion about what the bytes are.
+ *
+ * @throws on malformed YAML - the caller reports it as a parse error.
+ */
+export function parseRaw(raw: string): unknown {
+	try {
+		return JSON.parse(raw);
+	} catch {
+		// Throws on malformed YAML - let it propagate as a parse error.
+		return yaml.load(raw);
+	}
+}

--- a/app/src/services/importers/ref-bundler.test.ts
+++ b/app/src/services/importers/ref-bundler.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What bundling has to get right (issue #649).
+ *
+ * The defect it closes is invisible by construction - an external `$ref` used to
+ * resolve to `undefined` and the import simply came out smaller - so the
+ * load-bearing assertions here are the ones that go through a *parser*: the
+ * request body stub is only non-empty if the ref actually reached the schema in
+ * the other file. Revert the bundling call and those reds; assertions about the
+ * bundled text alone would not.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import {
+	bundleExternalRefs,
+	BUNDLE_KEY,
+	SpecBundleTooLargeError,
+	type ExternalRefIntake,
+} from "./ref-bundler";
+import { parseImport } from "./factory";
+import { createRefResolver } from "./openapi-shared";
+
+const MULTIFILE = join(__dirname, "__fixtures__/openapi-v3-multifile");
+const ENTRY = join(MULTIFILE, "spec/openapi.json");
+const entryRaw = readFileSync(ENTRY, "utf8");
+const singleFileRaw = readFileSync(join(__dirname, "__fixtures__/openapi-v3.json"), "utf8");
+
+/** A cap no fixture comes near, so a size test has to set its own. */
+const ROOMY = 10 * 1024 * 1024;
+
+/**
+ * The file intake, as Electron's `specFile:read` behaves: the *ref's own path*
+ * arrives, resolved in the main process against the picked document's directory.
+ */
+function fileIntake(overrides: Partial<ExternalRefIntake> = {}): ExternalRefIntake {
+	return {
+		maxBytes: ROOMY,
+		readSibling: vi.fn(async (relativePath: string) =>
+			readFileSync(resolve(dirname(ENTRY), relativePath), "utf8")
+		),
+		...overrides,
+	};
+}
+
+const opts = { importEnvironments: true, importScripts: true };
+
+describe("bundleExternalRefs - a document with nothing external", () => {
+	it("returns the input byte for byte", async () => {
+		// `SpecDraft` promises the engine the document verbatim, and that promise
+		// is kept for every single-file spec - the common case. Re-serializing here
+		// would make every YAML spec drift on its first sync.
+		const result = await bundleExternalRefs(singleFileRaw, fileIntake());
+		expect(result.text).toBe(singleFileRaw);
+		expect(result.bundled).toBe(0);
+		expect(result.unresolvedRefs).toBe(0);
+	});
+
+	it("does not walk a format that has no external refs to walk", async () => {
+		const postman = readFileSync(join(__dirname, "__fixtures__/postman-v21.json"), "utf8");
+		const intake = fileIntake();
+		const result = await bundleExternalRefs(postman, intake);
+		expect(result.text).toBe(postman);
+		expect(intake.readSibling).not.toHaveBeenCalled();
+	});
+
+	it("hands unparseable text back untouched, for the detector to report", async () => {
+		const result = await bundleExternalRefs("{ not: [json", fileIntake());
+		expect(result).toEqual({ text: "{ not: [json", bundled: 0, unresolvedRefs: 0 });
+	});
+});
+
+describe("bundleExternalRefs - sibling files", () => {
+	it("resolves the schema a ref names, so the operation imports what it declared", async () => {
+		const { text, bundled, unresolvedRefs } = await bundleExternalRefs(entryRaw, fileIntake());
+		expect(bundled).toBe(2);
+		expect(unresolvedRefs).toBe(0);
+
+		const request = parseImport(text, opts).collections[0].children[0].requests[0];
+		const body = request.body;
+		expect(body.mode).toBe("json");
+		// Before bundling this stub was `{}`: the ref resolved to `undefined` and
+		// the sampler had nothing to sample.
+		expect(JSON.parse("content" in body ? body.content : "{}")).toEqual({
+			id: 7,
+			name: "Rex",
+			tag: { label: "good-boy" },
+		});
+	});
+
+	it("resolves a ref that climbs out of the spec's own directory", async () => {
+		const { text } = await bundleExternalRefs(entryRaw, fileIntake());
+		const example = parseImport(
+			text,
+			opts
+		).collections[0].children[0].requests[0].examples?.find((e) => e.status === 400);
+		expect(JSON.parse(example!.body)).toEqual({ code: 400, message: "pet already exists" });
+	});
+
+	it("reads each target once however many refs name it", async () => {
+		// `pet.json` is referenced twice (the body and the 201 response).
+		const intake = fileIntake();
+		await bundleExternalRefs(entryRaw, intake);
+		const reads = (intake.readSibling as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+		// Relative to the picked document, `..` and all - resolving it is the main
+		// process's job, and collapsing it here would name a different file.
+		expect(reads.sort()).toEqual(["../shared/error.json", "schemas/pet.json"]);
+	});
+
+	it("rewrites a bundled file's own in-document refs into its subtree", async () => {
+		// `pet.json` says `{"$ref": "#/Tag"}`, which means Tag *in pet.json*. Left
+		// alone it would resolve against the root document, where there is no Tag.
+		const { text } = await bundleExternalRefs(entryRaw, fileIntake());
+		const doc = JSON.parse(text) as Record<string, unknown>;
+		const bundle = doc[BUNDLE_KEY] as Record<string, Record<string, unknown>>;
+		const pet = Object.entries(bundle).find(([slug]) => slug.startsWith("pet.json-"))!;
+		const tagRef = (
+			(pet[1].Pet as Record<string, Record<string, Record<string, string>>>).properties
+				.tag as unknown as { $ref: string }
+		).$ref;
+		expect(tagRef).toBe(`#/${BUNDLE_KEY}/${pet[0]}/Tag`);
+		expect(createRefResolver(doc)(tagRef)).toEqual(bundle[pet[0]].Tag);
+	});
+});
+
+describe("bundleExternalRefs - URLs", () => {
+	const urlSpec = JSON.stringify({
+		openapi: "3.0.0",
+		info: { title: "Remote", version: "1" },
+		paths: {
+			"/pets": {
+				get: {
+					operationId: "listPets",
+					responses: {
+						"200": {
+							description: "ok",
+							content: {
+								"application/json": { schema: { $ref: "./defs/pet.yaml#/Pet" } },
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+
+	it("resolves a relative ref against the URL the document was fetched from", async () => {
+		const fetchUrl = vi.fn(
+			async () => "Pet:\n  type: object\n  properties:\n    id:\n      type: integer\n"
+		);
+		const { bundled, unresolvedRefs } = await bundleExternalRefs(urlSpec, {
+			maxBytes: ROOMY,
+			sourceUrl: "https://acme.dev/specs/openapi.json",
+			fetchUrl,
+		});
+		expect(fetchUrl).toHaveBeenCalledWith("https://acme.dev/specs/defs/pet.yaml");
+		expect(bundled).toBe(1);
+		expect(unresolvedRefs).toBe(0);
+	});
+
+	it("fetches an absolute ref even when the document came off disk", async () => {
+		const absolute = urlSpec.replace("./defs/pet.yaml", "https://acme.dev/common.json");
+		const fetchUrl = vi.fn(async () => JSON.stringify({ Pet: { type: "object" } }));
+		const intake = fileIntake({ fetchUrl });
+		const { bundled } = await bundleExternalRefs(absolute, intake);
+		expect(fetchUrl).toHaveBeenCalledWith("https://acme.dev/common.json");
+		expect(intake.readSibling).not.toHaveBeenCalled();
+		expect(bundled).toBe(1);
+	});
+});
+
+describe("bundleExternalRefs - transitive refs and cycles", () => {
+	const chain: Record<string, string> = {
+		"b.json": JSON.stringify({ B: { $ref: "./c.json#/C" } }),
+		"c.json": JSON.stringify({ C: { type: "string" } }),
+	};
+	const spec = JSON.stringify({
+		openapi: "3.0.0",
+		info: { title: "Chain", version: "1" },
+		components: { schemas: { A: { $ref: "./b.json#/B" } } },
+		paths: {},
+	});
+
+	it("follows a ref through a file that refers to a third", async () => {
+		const readSibling = vi.fn(async (path: string) => chain[path]);
+		const { bundled, unresolvedRefs, text } = await bundleExternalRefs(spec, {
+			maxBytes: ROOMY,
+			readSibling,
+		});
+		expect(bundled).toBe(2);
+		expect(unresolvedRefs).toBe(0);
+		// The chain is walkable end to end in the bundled document, which is the
+		// only thing a parser can do with it.
+		const doc = JSON.parse(text) as Record<string, unknown>;
+		const resolve = createRefResolver(doc);
+		const a = resolve("#/components/schemas/A") as { $ref: string };
+		const b = resolve(a.$ref) as { $ref: string };
+		expect(resolve(b.$ref)).toEqual({ type: "string" });
+	});
+
+	it("terminates on a cycle, reading each file once", async () => {
+		const cyclic: Record<string, string> = {
+			"b.json": JSON.stringify({ B: { $ref: "./c.json#/C" } }),
+			"c.json": JSON.stringify({ C: { $ref: "./b.json#/B" } }),
+		};
+		const readSibling = vi.fn(async (path: string) => cyclic[path]);
+		const { bundled } = await bundleExternalRefs(spec, { maxBytes: ROOMY, readSibling });
+		expect(bundled).toBe(2);
+		expect(readSibling).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("bundleExternalRefs - what it cannot reach is said out loud", () => {
+	it("counts a relative ref in a document with no directory and no URL", async () => {
+		// A pasted spec. Two refs name `pet.json`, and both are operations that
+		// imported short - so both are counted, not the one file.
+		const { text, bundled, unresolvedRefs } = await bundleExternalRefs(entryRaw, {
+			maxBytes: ROOMY,
+		});
+		expect(bundled).toBe(0);
+		expect(unresolvedRefs).toBe(3);
+		expect(text).toBe(entryRaw);
+	});
+
+	it("counts a file that is not there, and leaves the ref as the document wrote it", async () => {
+		const readSibling = vi.fn(async () => {
+			throw new Error("The spec references schemas/pet.json, which is not at /tmp/x");
+		});
+		const { text, unresolvedRefs } = await bundleExternalRefs(entryRaw, {
+			maxBytes: ROOMY,
+			readSibling,
+		});
+		expect(unresolvedRefs).toBe(3);
+		expect(text).toContain("./schemas/pet.json#/Pet");
+	});
+
+	it("counts an unparseable target rather than bundling garbage", async () => {
+		const readSibling = vi.fn(async () => "{ not: [json");
+		const { bundled, unresolvedRefs } = await bundleExternalRefs(entryRaw, {
+			maxBytes: ROOMY,
+			readSibling,
+		});
+		expect(bundled).toBe(0);
+		expect(unresolvedRefs).toBe(3);
+	});
+
+	it("surfaces the count through the import preview's skip tally", async () => {
+		const { text, unresolvedRefs } = await bundleExternalRefs(entryRaw, { maxBytes: ROOMY });
+		const meta = parseImport(text, opts, { unresolvedRefs }).meta;
+		expect(meta.skipped).toContainEqual({ kind: "external_ref", count: 3 });
+	});
+});
+
+describe("bundleExternalRefs - the engine's cap", () => {
+	it("refuses a bundle over it, naming the size and the setting", async () => {
+		const readSibling = vi.fn(async () =>
+			JSON.stringify({ Pet: { type: "object" } }).padEnd(4000)
+		);
+		await expect(bundleExternalRefs(entryRaw, { maxBytes: 2048, readSibling })).rejects.toThrow(
+			SpecBundleTooLargeError
+		);
+		await expect(bundleExternalRefs(entryRaw, { maxBytes: 2048, readSibling })).rejects.toThrow(
+			/over the 2048 one document may hold.*maxSpecDocumentBytes/s
+		);
+	});
+
+	it("follows the setting rather than a hard-coded copy", async () => {
+		const readSibling = vi.fn(async () =>
+			JSON.stringify({ Pet: { type: "object" } }).padEnd(4000)
+		);
+		await expect(
+			bundleExternalRefs(entryRaw, { maxBytes: 1024 * 1024, readSibling })
+		).resolves.toBeTruthy();
+	});
+});
+
+describe("bundleExternalRefs - determinism", () => {
+	it("produces the same bytes for the same inputs", async () => {
+		// Sync decides "unchanged" by hashing this text (#627), so a bundle that
+		// varied by iteration order would report every re-fetch as a change.
+		const first = await bundleExternalRefs(entryRaw, fileIntake());
+		const second = await bundleExternalRefs(entryRaw, fileIntake());
+		expect(first.text).toBe(second.text);
+	});
+
+	it("names a bundled document after the target, not the order it was read", async () => {
+		const swapped = entryRaw
+			.replace("./schemas/pet.json#/Pet", "PET_ONE")
+			.replace("../shared/error.json#/Error", "./schemas/pet.json#/Pet")
+			.replace("PET_ONE", "../shared/error.json#/Error");
+		const original = JSON.parse(
+			(await bundleExternalRefs(entryRaw, fileIntake())).text
+		) as Record<string, Record<string, unknown>>;
+		const reordered = JSON.parse(
+			(await bundleExternalRefs(swapped, fileIntake())).text
+		) as Record<string, Record<string, unknown>>;
+		expect(Object.keys(reordered[BUNDLE_KEY])).toEqual(Object.keys(original[BUNDLE_KEY]));
+	});
+});

--- a/app/src/services/importers/ref-bundler.ts
+++ b/app/src/services/importers/ref-bundler.ts
@@ -1,0 +1,426 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Bundling a multi-file OpenAPI document into one, before it is parsed
+ * (issue #649).
+ *
+ * **The defect this closes.** The parsers resolve `#/`-rooted pointers against
+ * the document they were handed, and nothing else. A `$ref` naming another file
+ * - `"./schemas/pet.yaml#/Pet"`, `"https://acme.dev/common.yaml#/Error"` - keeps
+ * its whole string as the pointer, so the walk lands on `undefined` and the
+ * caller reads that as *the spec documented nothing here*: an empty body stub,
+ * a parameter that vanished, an example that never imported. No error, no count,
+ * nothing the preview could name. Multi-file specs are the norm at the size of
+ * API this feature exists for.
+ *
+ * So this runs first, replaces every external ref it can reach with an
+ * in-document one, and **counts the ones it cannot** so the import preview can
+ * say so. Nothing here guesses: an unreachable ref is left exactly as written
+ * and reported, never quietly deleted.
+ *
+ * **Two intakes, because a spec arrives two ways.** A URL-sourced document
+ * resolves its relative refs against that URL and fetches them through the
+ * engine's existing `POST /import/fetch` - reused as-is, not widened. A
+ * file-picked document reads its siblings through the `specFile:read` IPC, which
+ * is gated in the main process (see `app/electron/spec-file.ts`). An absolute
+ * `http(s)` ref is fetchable either way. A pasted document has neither, so its
+ * relative refs are unresolvable by construction - and are reported as such
+ * rather than silently dropped.
+ *
+ * **Where the resolved documents land.** Each one is inlined whole under a root
+ * `x-vayu-bundled` map and every ref that pointed into it is rewritten to that
+ * location. A root `x-` extension key is legal in Swagger 2.0 and OpenAPI 3.x
+ * alike, so this is one rule for both parsers and does not have to choose
+ * between `definitions` and `components/schemas` - and it survives the schema
+ * validator a later phase brings in. A bundled document's *own* in-document refs
+ * are rewritten too: `#/definitions/Pet` inside `pets.yaml` means Pet in
+ * `pets.yaml`, not Pet in the root document.
+ *
+ * **Determinism is load-bearing**, not tidiness: the bundled text is what gets
+ * stored as the spec document, and sync (#627) decides "unchanged" by comparing
+ * hashes of exactly this output. Targets are therefore bundled in sorted order
+ * with slugs derived only from the target itself.
+ *
+ * **A document that needed no bundling is returned byte for byte.** `SpecDraft`
+ * promises the engine the document verbatim - a re-serialization would make
+ * every YAML spec drift on its first sync - and that promise is kept for every
+ * single-file spec, which is the common case. Only a document that genuinely is
+ * several files is stored as the bundle, because there is no single verbatim
+ * text for one of those to begin with.
+ */
+
+import { asRecord, asStr } from "@/lib/json-node";
+import { parseRaw } from "./parse-raw";
+
+/** Root key the resolved documents are inlined under. */
+export const BUNDLE_KEY = "x-vayu-bundled";
+
+/** How the bundler reaches the files a document names. */
+export interface ExternalRefIntake {
+	/**
+	 * The engine's live `maxSpecDocumentBytes`. The bundle has to fit what the
+	 * engine will store, and the number is fetched rather than restated.
+	 */
+	maxBytes: number;
+	/** The URL the document was fetched from; relative refs resolve against it. */
+	sourceUrl?: string;
+	/** Fetch an absolute URL's text (the engine proxy). Absent = no URL intake. */
+	fetchUrl?: (url: string) => Promise<string>;
+	/**
+	 * Read a file beside the picked document, by the path the ref wrote,
+	 * normalized. Absent = the document was not picked from disk.
+	 */
+	readSibling?: (relativePath: string) => Promise<string>;
+}
+
+export interface BundleResult {
+	/** What to parse, and what to store. Identical to the input when `bundled` is 0. */
+	text: string;
+	/** Distinct external documents inlined. */
+	bundled: number;
+	/** External refs left unresolved - reported to the user, never silent. */
+	unresolvedRefs: number;
+}
+
+/**
+ * A bundle that outgrew the engine's cap. Fatal rather than tallied: the engine
+ * would refuse to store the document, so continuing would import a collection
+ * bound to nothing.
+ */
+export class SpecBundleTooLargeError extends Error {
+	constructor(bytes: number, maxBytes: number) {
+		super(
+			`The spec and the files it references come to ${bytes} bytes, over the ${maxBytes} one document may hold. Raise the maxSpecDocumentBytes engine setting, or import a bundled spec.`
+		);
+		this.name = "SpecBundleTooLargeError";
+	}
+}
+
+/** `$ref` targets that are absolute URLs, which either intake can fetch. */
+const ABSOLUTE_URL = /^https?:\/\//i;
+
+/** One external document, once, however many refs point at it. */
+interface BundledDoc {
+	/** Canonical target - an absolute URL, or a path relative to the picked file. */
+	key: string;
+	/** Where refs *inside* this document resolve from. */
+	base: DocumentBase;
+	slug: string;
+	value: unknown;
+}
+
+/** What a document's own relative refs are relative to. */
+type DocumentBase = { kind: "url"; url: string } | { kind: "file"; dir: string } | { kind: "none" };
+
+/**
+ * Is this a document the bundler should even look at?
+ *
+ * Only the OpenAPI family uses `$ref` to name other files; a Postman or Insomnia
+ * export has no such notion, and walking one to prove it would be work with a
+ * guaranteed answer. This is the same discrimination `detect()` makes, kept
+ * deliberately loose - a version string it does not recognise is still an
+ * OpenAPI document with refs to resolve.
+ */
+function isOpenApiDocument(value: unknown): boolean {
+	const record = asRecord(value);
+	if (!record) return false;
+	return typeof record.openapi === "string" || typeof record.swagger === "string";
+}
+
+/** Split `"./pets.yaml#/components/schemas/Pet"` into its file and its pointer. */
+function splitRef(ref: string): { target: string; pointer: string } {
+	const hash = ref.indexOf("#");
+	if (hash < 0) return { target: ref, pointer: "" };
+	return { target: ref.slice(0, hash), pointer: ref.slice(hash + 1) };
+}
+
+/**
+ * Normalize a relative path against a directory, keeping `..` that cannot be
+ * cancelled.
+ *
+ * A spec laid out as `spec/openapi.yaml` referencing `../shared/error.yaml` is
+ * ordinary, so an escaping segment is preserved and handed to the main process,
+ * which is where the gate lives. Collapsing it here would silently read a
+ * different file than the document named.
+ */
+function joinRelative(dir: string, target: string): string {
+	const out: string[] = [];
+	for (const segment of [...dir.split("/"), ...target.split("/")]) {
+		if (!segment || segment === ".") continue;
+		if (segment === "..") {
+			const last = out[out.length - 1];
+			if (out.length > 0 && last !== "..") out.pop();
+			else out.push("..");
+			continue;
+		}
+		out.push(segment);
+	}
+	return out.join("/");
+}
+
+/** The directory part of a normalized relative path (`""` for a top-level file). */
+function dirOf(relativePath: string): string {
+	const cut = relativePath.lastIndexOf("/");
+	return cut < 0 ? "" : relativePath.slice(0, cut);
+}
+
+/**
+ * The canonical identity of a ref target, or `undefined` when this document has
+ * no way to name it (a relative ref in a pasted spec).
+ */
+function resolveTarget(target: string, base: DocumentBase): BundledDoc["key"] | undefined {
+	if (ABSOLUTE_URL.test(target)) {
+		try {
+			return new URL(target).toString();
+		} catch {
+			return undefined;
+		}
+	}
+	if (base.kind === "url") {
+		try {
+			return new URL(target, base.url).toString();
+		} catch {
+			return undefined;
+		}
+	}
+	if (base.kind === "file") return joinRelative(base.dir, target);
+	return undefined;
+}
+
+/** Where refs inside a document that was loaded from @p key resolve from. */
+function baseOf(key: string): DocumentBase {
+	return ABSOLUTE_URL.test(key) ? { kind: "url", url: key } : { kind: "file", dir: dirOf(key) };
+}
+
+/**
+ * FNV-1a, so two different targets with the same file name get different slugs.
+ * A hash and not a counter: the slug has to depend on the target alone for the
+ * output to be reproducible.
+ */
+function hash32(text: string): string {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < text.length; i++) {
+		h ^= text.charCodeAt(i);
+		h = Math.imul(h, 0x01000193) >>> 0;
+	}
+	return h.toString(16).padStart(8, "0");
+}
+
+/**
+ * A JSON Pointer segment naming one bundled document: readable enough to
+ * recognise in the stored text, and free of `/` and `~` so it needs no escaping.
+ */
+function slugFor(key: string): string {
+	const tail = key.split(/[/\\]/).pop() || key;
+	const readable = tail.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 40);
+	return `${readable}-${hash32(key)}`;
+}
+
+/** Every `$ref` string in a value, in document order. */
+function collectRefs(value: unknown, found: string[] = []): string[] {
+	if (Array.isArray(value)) {
+		for (const item of value) collectRefs(item, found);
+		return found;
+	}
+	const record = asRecord(value);
+	if (!record) return found;
+	const ref = asStr(record.$ref);
+	if (ref) found.push(ref);
+	for (const child of Object.values(record)) collectRefs(child, found);
+	return found;
+}
+
+function byteLength(text: string): number {
+	return new TextEncoder().encode(text).length;
+}
+
+/**
+ * Rewrite one document's refs for its new home.
+ *
+ * @param inBundle where this document now lives (`undefined` for the root), so
+ * its own `#/...` refs follow it.
+ */
+function rewriteRefs(
+	value: unknown,
+	base: DocumentBase,
+	loaded: Map<string, BundledDoc>,
+	inBundle: string | undefined
+): unknown {
+	if (Array.isArray(value)) return value.map((item) => rewriteRefs(item, base, loaded, inBundle));
+	const record = asRecord(value);
+	if (!record) return value;
+
+	const out: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(record)) {
+		if (key === "$ref" && typeof child === "string") {
+			out[key] = rewriteRef(child, base, loaded, inBundle);
+			continue;
+		}
+		out[key] = rewriteRefs(child, base, loaded, inBundle);
+	}
+	return out;
+}
+
+function rewriteRef(
+	ref: string,
+	base: DocumentBase,
+	loaded: Map<string, BundledDoc>,
+	inBundle: string | undefined
+): string {
+	const { target, pointer } = splitRef(ref);
+	if (!target) {
+		// In-document. Inside a bundled file that means *this file*, which now
+		// lives one level down; in the root document it already points at itself.
+		return inBundle ? bundledPointer(inBundle, pointer) : ref;
+	}
+	const key = resolveTarget(target, base);
+	const doc = key ? loaded.get(key) : undefined;
+	// An unresolved ref is left exactly as the document wrote it. It has already
+	// been counted, and rewriting it would invent a location nothing is at.
+	return doc ? bundledPointer(doc.slug, pointer) : ref;
+}
+
+/**
+ * A pointer into one bundled document. Slugs carry no `/` or `~`, so no JSON
+ * Pointer escaping is needed for the segment this adds.
+ */
+function bundledPointer(slug: string, pointer: string): string {
+	const rest =
+		pointer && pointer !== "/" ? (pointer.startsWith("/") ? pointer : `/${pointer}`) : "";
+	return `#/${BUNDLE_KEY}/${slug}${rest}`;
+}
+
+/**
+ * External refs this document names that nothing resolved - counted **per ref**,
+ * because that is what the user lost: two operations pointing at the same
+ * unreachable file are two operations that imported short.
+ */
+function countUnresolved(
+	value: unknown,
+	base: DocumentBase,
+	loaded: Map<string, BundledDoc>
+): number {
+	let count = 0;
+	for (const ref of collectRefs(value)) {
+		const { target } = splitRef(ref);
+		if (!target) continue;
+		const key = resolveTarget(target, base);
+		if (!key || !loaded.has(key)) count += 1;
+	}
+	return count;
+}
+
+/**
+ * Resolve every external `$ref` a document names, transitively.
+ *
+ * Returns the input unchanged - byte for byte - when there was nothing external
+ * to resolve, which is every single-file spec.
+ *
+ * @throws {SpecBundleTooLargeError} when the documents together exceed the
+ * engine's cap. Every other failure (unreachable, unparseable, no intake for
+ * this source) is counted into `unresolvedRefs` and leaves the ref as written.
+ */
+export async function bundleExternalRefs(
+	raw: string,
+	intake: ExternalRefIntake
+): Promise<BundleResult> {
+	let root: unknown;
+	try {
+		root = parseRaw(raw);
+	} catch {
+		// Not parseable at all - the format detector reports that, with a message
+		// about the file rather than about its refs.
+		return { text: raw, bundled: 0, unresolvedRefs: 0 };
+	}
+	if (!isOpenApiDocument(root)) return { text: raw, bundled: 0, unresolvedRefs: 0 };
+
+	const rootBase: DocumentBase = intake.sourceUrl
+		? { kind: "url", url: intake.sourceUrl }
+		: intake.readSibling
+			? { kind: "file", dir: "" }
+			: { kind: "none" };
+
+	const loaded = new Map<string, BundledDoc>();
+	/** Targets already tried and refused, so a second ref does not retry them. */
+	const failed = new Set<string>();
+	/** Targets seen but not yet loaded, with the base that named them. */
+	const pending: { key: string; base: DocumentBase }[] = [];
+	let bytes = byteLength(raw);
+
+	const enqueue = (value: unknown, base: DocumentBase): void => {
+		for (const ref of collectRefs(value)) {
+			const { target } = splitRef(ref);
+			if (!target) continue;
+			// A relative ref with nothing to be relative to - a pasted document -
+			// resolves to no key at all, and is counted in the pass below.
+			const key = resolveTarget(target, base);
+			if (!key || failed.has(key) || loaded.has(key)) continue;
+			if (!pending.some((p) => p.key === key)) pending.push({ key, base });
+		}
+	};
+
+	enqueue(root, rootBase);
+
+	// Breadth-first, one load per target however many refs name it. A document
+	// already loaded is never re-enqueued, which is what terminates a cycle.
+	while (pending.length > 0) {
+		const next = pending.shift()!;
+		const text = await loadTarget(next.key, intake);
+		if (text === undefined) {
+			failed.add(next.key);
+			continue;
+		}
+		bytes += byteLength(text);
+		if (bytes > intake.maxBytes) throw new SpecBundleTooLargeError(bytes, intake.maxBytes);
+
+		let value: unknown;
+		try {
+			value = parseRaw(text);
+		} catch {
+			failed.add(next.key);
+			continue;
+		}
+		const base = baseOf(next.key);
+		loaded.set(next.key, { key: next.key, base, slug: slugFor(next.key), value });
+		enqueue(value, base);
+	}
+
+	// Counted after loading, over every document in the bundle: a ref inside a
+	// resolved file that names a fourth file nobody could reach is the same loss.
+	let unresolvedRefs = countUnresolved(root, rootBase, loaded);
+	for (const doc of loaded.values())
+		unresolvedRefs += countUnresolved(doc.value, doc.base, loaded);
+
+	if (loaded.size === 0) return { text: raw, bundled: 0, unresolvedRefs };
+
+	// Sorted, so the same inputs always serialize to the same bytes - sync
+	// compares hashes of this text.
+	const bundle: Record<string, unknown> = {};
+	for (const doc of [...loaded.values()].sort((a, b) => (a.slug < b.slug ? -1 : 1))) {
+		bundle[doc.slug] = rewriteRefs(doc.value, doc.base, loaded, doc.slug);
+	}
+
+	const rewritten = rewriteRefs(root, rootBase, loaded, undefined) as Record<string, unknown>;
+	const text = JSON.stringify({ ...rewritten, [BUNDLE_KEY]: bundle }, null, 2);
+	if (byteLength(text) > intake.maxBytes) {
+		throw new SpecBundleTooLargeError(byteLength(text), intake.maxBytes);
+	}
+	return { text, bundled: loaded.size, unresolvedRefs };
+}
+
+/** The text at one target, or `undefined` when this import cannot reach it. */
+async function loadTarget(key: string, intake: ExternalRefIntake): Promise<string | undefined> {
+	try {
+		if (ABSOLUTE_URL.test(key)) return await intake.fetchUrl?.(key);
+		return await intake.readSibling?.(key);
+	} catch {
+		// Unreachable, refused by a gate, or over the engine's own cap. The count
+		// is what the user sees; the reason belongs to the channel that refused.
+		return undefined;
+	}
+}

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -44,7 +44,17 @@ export interface SkippedItem {
 		 * served under one status line and there is no honest value to pick, so it
 		 * is dropped and counted rather than guessed at (issue #481).
 		 */
-		| "example_no_status";
+		| "example_no_status"
+		/**
+		 * A `$ref` naming a file the import could not reach - unfetchable,
+		 * unparseable, or relative in a pasted document that has no directory and
+		 * no URL to be relative to (issue #649). Counted per ref, because each one
+		 * is an operation that imported without the schema it declared. Not
+		 * produced by a parser: bundling runs before parse and hands its count to
+		 * the factory, which is also why it is the one kind that says nothing about
+		 * Vayu's own representability.
+		 */
+		| "external_ref";
 	count: number;
 }
 
@@ -150,6 +160,13 @@ export interface RequestDraft {
  * hashes what it stores and a re-fetch is diffed against those bytes, so a
  * round-trip through `JSON.parse` would make every YAML spec drift on its first
  * sync.
+ *
+ * One exception, and only one: a document that referenced other files carries
+ * the **bundle** those were inlined into (issue #649). There is no verbatim text
+ * for a spec that is several files, and storing the entry file alone would store
+ * a document naming files nothing downstream can reach. Bundling is
+ * deterministic, so the hash is still stable across re-fetches; a single-file
+ * spec is untouched.
  */
 export interface SpecDraft {
 	tempId?: string; // assigned by assign-ids pre-pass; opaque, never stored

--- a/app/src/types/electron.d.ts
+++ b/app/src/types/electron.d.ts
@@ -138,6 +138,22 @@ interface ElectronAPI {
 	 */
 	readDataFile: (path: string) => Promise<{ bytes: Uint8Array; fileName: string }>;
 
+	/**
+	 * Read a file an imported OpenAPI document references (issue #649), given the
+	 * picked document's path and the `$ref` target as the document wrote it - the
+	 * main process resolves the second against the first's directory. Rejects
+	 * with a message the import dialog can show as-is when the reference is
+	 * absolute, names an extension Vayu does not open, is not there, or is over
+	 * the engine's `maxSpecDocumentBytes`.
+	 *
+	 * Bytes rather than text, matching `readDataFile`. Absent outside Electron,
+	 * where a multi-file spec simply reports its refs as unresolved.
+	 */
+	readSpecFile: (
+		specPath: string,
+		refPath: string
+	) => Promise<{ bytes: Uint8Array; fileName: string }>;
+
 	// Before quit flush handler
 	onBeforeQuit: (callback: () => void | Promise<void>) => () => void;
 }

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -219,7 +219,8 @@ import complete-but-empty and the user picks the file. Every parser gets it from
 than tallying while building them, so the number and the rows cannot disagree.
 
 **`SkippedItem`** - `{ kind: "websocket" | "grpc" | "api_spec" | "unit_test" | "file_body" |
-"malformed_item" | "unsupported_method" | "malformed_spec" | "example_no_status", count }`.
+"malformed_item" | "unsupported_method" | "malformed_spec" | "example_no_status" |
+"external_ref", count }`.
 Surfaces work Vayu can't represent so the Preview can warn instead of silently dropping.
 Three of the kinds are not about representability: `unsupported_method` is an operation whose
 HTTP method has no `HttpMethod` (OpenAPI 3's `trace`), and `malformed_item` / `malformed_spec`
@@ -230,7 +231,11 @@ counted via `SkipTally` in `openapi-shared.ts`, shared by both OpenAPI parsers: 
 structural clones, and a second copy would drift. `example_no_status` is a fourth
 non-representability case: an OpenAPI response keyed `default` or `2XX` documents a real
 response, but an example is served under one status line and there is no honest value to
-pick, so it is counted rather than guessed at.
+pick, so it is counted rather than guessed at. `external_ref` is the fifth, and the only
+kind no parser produces: a `$ref` naming another file that the bundling pass could not
+read (`ref-bundler.ts`, issue #649) is counted **before** parse and stamped into
+`meta.skipped` by `parseImport`, one per reference - because each one is an operation that
+imported without the schema it declared.
 
 Supporting value types:
 - `KeyValueEntry`: `{ key, value, enabled, description? }` - duplicates and `enabled:false`

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -48,7 +48,9 @@ else     rootRequests.push(req);
 
 **Multi-tag operations:** only `op.tags[0]` is consulted. An operation with `tags: ["a", "b"]` lands solely in the `a` child collection; `b` is ignored (no duplication, no extra folder). An operation with no `tags` (or `tags: []`) becomes a root request.
 
-Unlike v3 (which has dedicated `makeTagCollection` / `buildBody` helpers), v2 builds the root and tag collections inline in `parse` and delegates only the per-operation draft to `buildSwaggerOp`. A closed-over `resolveRef` handles `$ref` resolution.
+Unlike v3 (which has dedicated `makeTagCollection` / `buildBody` helpers), v2 builds the root and tag collections inline in `parse` and delegates only the per-operation draft to `buildSwaggerOp`. `$ref` resolution comes from `createRefResolver` (`openapi-shared.ts`), the same one the v3 parser uses - both had built it by hand, identically, until issue #649.
+
+References naming **other files** (`./definitions/pet.yaml#/Pet`) are resolved before this parser runs, by `ref-bundler.ts`; what could not be reached is counted as an `external_ref` `SkippedItem`. The rules are the same for both OpenAPI parsers and are written out in [OpenAPI 3.0](./openapi-v3.md#external-refs) and [OpenAPI Collections](../openapi.md#specs-written-across-several-files).
 
 ## Field mapping
 
@@ -324,7 +326,8 @@ Shared between both: tree-by-first-tag, `{{baseUrl}}`-prefixed URLs, `normalizeV
 |--------|--------|--------------------|
 | [`normalizeVars`](./README.md#normalizevars) | `var-normalize.ts` | convert Swagger `{param}` path templates → Vayu `{{param}}` in request URLs |
 | `sampleSchema` | `schema-sampler.ts` | generate a sample JSON body from an `in: "body"` parameter `schema` (bounded, ref-resolving) |
-| `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve a `$ref`'d path item; guard `parameters` and tally what was dropped |
+| `createRefResolver`, `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve an in-document `$ref` and a `$ref`'d path item; guard `parameters` and tally what was dropped |
+| `bundleExternalRefs` | `ref-bundler.ts` | resolve references to *other files* before parse, and count what it could not reach |
 | `responseExample`, `exampleBodyText`, `deref` | `openapi-shared.ts` | map one `responses` entry to an example draft - the half shared with the v3 parser |
 | `queryParamRow`, `paramValueText` | `openapi-shared.ts` | one `in: "query"` parameter as a Params row - the value/enabled rule both OpenAPI parsers apply |
 | `countExamples` | `shared.ts` | total the examples across the finished drafts, for `meta.exampleCount` |

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -51,7 +51,15 @@ else     rootRequests.push(req);
 
 **`trace` operations:** OpenAPI 3's Path Item Object also defines `trace`, which is **not** in `HTTP_METHODS` because `HttpMethod` (`types/domain.ts`) has no `"TRACE"` - Vayu cannot execute one. A `trace` operation is therefore not built, is **not** counted in `requestCount`, and is counted as an `unsupported_method` `SkippedItem` so the preview says so. `UNSUPPORTED_METHODS` in `openapi-v3.ts` is the list; `trace` is its only member, since a path item defines exactly the eight methods.
 
-Key internal functions: `buildOperation` (per-operation `RequestDraft`), `makeTagCollection` (per-tag `CollectionDraft`), `buildBody` / `findJsonMedia` (request body), `pickPrimaryScheme` / `schemeToAuth` (collection auth), and a closed-over `resolveRef` for `$ref` resolution.
+Key internal functions: `buildOperation` (per-operation `RequestDraft`), `makeTagCollection` (per-tag `CollectionDraft`), `buildBody` / `findJsonMedia` (request body), `pickPrimaryScheme` / `schemeToAuth` (collection auth), and `createRefResolver` (`openapi-shared.ts`) for `$ref` resolution - shared with the v2 parser, which built the identical closure by hand until issue #649.
+
+## External `$ref`s
+
+The resolver above walks `#/`-rooted pointers **inside the document it was given**, and nothing else. A reference naming another file (`./schemas/pet.yaml#/Pet`, `https://acme.dev/common.yaml#/Error`) is not such a pointer, so it used to resolve to `undefined` - which every caller reads as *the spec documented nothing here*: an empty body stub, a missing parameter, an example that never imported, and no entry in `meta.skipped` to say so.
+
+Those references are now resolved **before** the parser runs, by `ref-bundler.ts` (issue #649): each referenced document is fetched (through the engine's `/import/fetch`) or read from beside the picked file (through the gated `specFile:read` IPC), inlined under a root `x-vayu-bundled` key, and every reference into it rewritten to an in-document pointer. What reaches `parse` is therefore always self-contained, and the parser needs no notion of files.
+
+What could **not** be reached is counted as an `external_ref` `SkippedItem` - one per reference - and its `$ref` is left exactly as the document wrote it. See [OpenAPI Collections](../openapi.md#specs-written-across-several-files) for the user-facing rules, including which intake applies to a fetched, picked or pasted document, and why a multi-file spec is stored as the bundle.
 
 ## Field mapping
 
@@ -255,7 +263,8 @@ An import with nothing to report still yields `skipped: []` - only non-zero kind
 | `sampleSchema` | `schema-sampler.ts` | generate a sample JSON body from a request `schema` (bounded, ref-resolving) |
 | `schemaFormFields` | `schema-sampler.ts` | field names for an urlencoded / multipart body, resolved through the sampler, each flagged text or file |
 | `importedFilePart`, `unattachedFileParts` | `shared.ts` | build a file form row; count the rows that still need a file, for `meta` |
-| `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve a `$ref`'d path item; guard `parameters` and tally what was dropped |
+| `createRefResolver`, `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve an in-document `$ref` and a `$ref`'d path item; guard `parameters` and tally what was dropped |
+| `bundleExternalRefs` | `ref-bundler.ts` | resolve references to *other files* before parse, and count what it could not reach |
 | `queryParamRow`, `paramValueText` | `openapi-shared.ts` | one `in: "query"` parameter as a Params row - the value/enabled rule both OpenAPI parsers apply |
 | `responseExample`, `findJsonMediaType`, `firstNamedExample`, `exampleBodyText`, `deref` | `openapi-shared.ts` | map one `responses` entry to an example draft; the halves the two OpenAPI parsers share |
 | `countExamples` | `shared.ts` | total the examples across the finished drafts, for `meta.exampleCount` |

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -40,7 +40,9 @@ creates is bound automatically:
 
 - The document is stored **verbatim**, exactly the bytes that were read. A
   YAML spec stays YAML; nothing is re-serialized, because the hash is taken of
-  what was stored and a later re-fetch is compared against it.
+  what was stored and a later re-fetch is compared against it. A spec written
+  across several files is the one exception - see
+  [Specs written across several files](#specs-written-across-several-files).
 - A **fetched URL is kept**, so the document knows where it came from.
 - Every request created from an operation records that operation's
   `operationId` (when the document declares one), its method, and its
@@ -48,6 +50,47 @@ creates is bound automatically:
 
 Other formats are unaffected. A Postman or Insomnia import binds nothing and
 records no operation identity: those files describe requests, not a contract.
+
+## Specs written across several files
+
+A large document is usually not one document: schemas live in their own files,
+shared errors in another, and the entry point names them with references like
+`./schemas/pet.yaml#/Pet`. Vayu **follows those references before it parses**,
+inlines what they name, and imports the result as one document.
+
+Where a referenced file is read from depends on where the spec came from:
+
+| The spec was… | A relative reference is read… | An absolute `https://` reference |
+|---|---|---|
+| Fetched from a URL | From that URL's directory | Fetched |
+| Picked as a file | From beside the file, on this machine | Fetched |
+| Pasted as text | Not at all - there is no directory to read from | Fetched |
+
+References are followed through the files they lead to, so a file that refers to
+a third is resolved too, and a cycle stops rather than looping. Each file is read
+once however many references name it.
+
+**What cannot be read is said, never silently dropped.** A file that is missing,
+unreachable, or not valid JSON or YAML leaves its reference exactly as the
+document wrote it, and the import preview counts it - one per reference, because
+each one is an operation that imported without the schema it declared. Before
+this, such a reference simply produced an empty body stub and no message at all.
+
+Reading a file beside a picked spec is the only part of this that touches the
+disk. It goes through the same kind of gate the [data
+contract](data-driven-runs.md) uses for its files: only `.json`, `.yaml` and
+`.yml`, only paths resolved in the desktop process from the document you picked,
+and nothing larger than the engine's `maxSpecDocumentBytes`.
+
+**A multi-file spec is stored as the bundle** - the entry document with the
+others inlined - and not as the entry file alone. There is no single verbatim
+text for a spec that is several files, and storing only the entry would store a
+document naming files nothing else can reach. The bundling is deterministic, so
+the same spec always produces the same bytes and the same hash. A single-file
+spec is untouched.
+
+If the whole bundle would exceed `maxSpecDocumentBytes`, the import stops and
+says so rather than storing a truncated contract.
 
 ## The Spec tab
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -305,7 +305,11 @@ the persisted payload rather than against the store's surface.
 The path is written when an OpenAPI file is imported (`queries/import.ts`, after
 the apply, because the collection has no id until then) or when the Spec tab
 binds a picked file, obtained through the preload's existing `getFilePath`
-bridge, and dropped on unbind. It is normalized through **both** `migrate` and
+bridge, and dropped on unbind. Reading the files a picked document *references*
+needs the gated `specFile:read` IPC (`electron/spec-file.ts`), which takes the
+document's path plus the reference and resolves one against the other in the
+main process - the renderer names no directory of its own, the same posture
+`dataFile:read` holds. It is normalized through **both** `migrate` and
 `merge`, for the reason spelled out for `data-file-store` above.
 
 #### `engine-store.ts` - Engine Connection & Restart State


### PR DESCRIPTION
## Description

A `$ref` naming another file - `./schemas/pet.yaml#/Pet` - is not a `#/` pointer. Both OpenAPI parsers walked it as one anyway (`ref.replace(/^#\//, "").split("/")`), so every segment named a key no document has, the walk landed on `undefined`, and `deref` handed that back to `buildOperation`, which reads it as *the spec documented nothing here*: an empty body stub, a parameter that vanished, an example that never imported. No error, no `meta.skipped` entry, nothing the preview could name. Multi-file specs are the norm at the size of API this feature exists for.

**The plan.** Root cause: the resolver is in-document by construction, and nothing upstream of it ever made the document self-contained. The approach is to resolve external references **before** parse and hand the parsers one document - `parseImport` stays synchronous, the parsers stay unaware that files exist, and the engine stores something that names no file it cannot reach. `ref-bundler.ts` walks the raw document, loads each distinct target once (transitively, cycles terminating), inlines it under a root `x-vayu-bundled` key and rewrites every ref into it - including a bundled file's own `#/...` refs, which mean *that file*, not the root. **The alternative I rejected is teaching `resolveRef` to fetch**: it would make the resolver async and therefore `sampleSchema`, `buildOperation` and `parse` async with it, spread network I/O through five modules whose whole contract is "pure over a parsed value", and re-fetch the same file once per ref - and it would still leave the engine storing an entry document that names files nothing downstream can read.

While in there, the resolver both parsers had built **by hand, identically** (the repo's named hand-rolled-copy defect) is now `createRefResolver` in `openapi-shared.ts`, which already held every helper that takes it as an argument.

### Decisions this forced, recorded

- **A document with nothing external is returned byte for byte.** `SpecDraft` promises the engine the document verbatim - a re-serialization would make every YAML spec drift on its first sync - and that promise is kept for every single-file spec, which is the common case. Only a spec that genuinely *is* several files is stored as the bundle, because there is no single verbatim text for one of those; its doc comment now states the exception.
- **Bundling is deterministic** (targets sorted, slugs derived from the target alone, never from read order), because sync (#627) decides "unchanged" by hashing exactly this output.
- **`x-vayu-bundled` at the root**, not `#/components/schemas`: a root `x-` extension key is legal in Swagger 2.0 and OpenAPI 3.x alike, so it is one rule for both parsers, it collides with nothing the document declares, and it survives the schema validator #628 brings in.
- **Unreachable is disclosed, never guessed.** The ref is left exactly as the document wrote it and counted as a new `external_ref` skip - **per ref**, not per file, because each one is an operation that imported short.
- **Over the cap is fatal**, unlike an unreachable ref: the engine would refuse to store the document, so continuing would import a collection bound to nothing.

### The new IPC, and why it takes two arguments

`specFile:read` is modelled on `dataFile:read`'s landed shape, with its gates and its rationale restated in the module header: extension allowlist (`.json`, `.yaml`, `.yml`), and the engine's **fetched** `maxSpecDocumentBytes` rather than a second copy of the rule. It takes the picked document's path **plus the ref's own text** and resolves one against the other *in the main process* - so this reads files a **document** named, not paths the renderer composed, and the renderer still names no directory of its own. A ref that climbs out of the spec's directory (`../shared/error.yaml`) is allowed and that is a decision: it is an ordinary layout, and a directory jail would refuse real specs while adding nothing the allowlist does not already give - the same reasoning that rejected a path registry for `dataFile:read`.

### Deviation from the issue spec

One: the issue said "inline the resolved subtrees under `#/components` (standard bundling)" - inherited from #627. `components` does not exist in Swagger 2.0 (it is `definitions`), so that rule cannot be one rule for both parsers; `x-vayu-bundled` is, for the reasons above. Everything else is as specified.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

| Suite | Result |
|---|---|
| `pnpm test` (vitest, whole app) | **4884 / 4884 passed**, 468 files (32 new; base 4852) |
| `pnpm type-check` | clean |
| `pnpm lint` | clean |
| `mkdocs build --strict` | clean |

**No engine build or ctest run.** The diff is app-side only - no C++, no engine route, no payload or schema change - so no engine test could go from green to red, which is the repo's stated rule for what to run.

New coverage (32):

- **`ref-bundler.test.ts` (19)** - a single-file spec returned byte for byte; a Postman export not walked at all; sibling refs resolved (including one climbing out of the spec's directory) with the assertion taken **through the parser**, since the body stub is only non-empty if the ref genuinely reached the other file's schema; one read per target however many refs name it; a bundled file's own `#/Tag` rewritten into its subtree and re-resolved through `createRefResolver`; URL-relative resolution against `sourceUrl`; an absolute ref fetched even for a file-picked spec; a transitive chain walked end to end and a cycle terminating on two reads; the four unreachable cases each counted per ref with the `$ref` left as written; the count surfacing through `parseImport` into `meta.skipped`; the cap refusing with size and setting, and following a raised setting; and byte-identical output across runs and across ref order.
- **`spec-file.test.ts` (13)** - `data-file.test.ts`'s shape against an injected filesystem: resolution against the document's directory, the `..` case, an absolute ref refused, the extension allowlist (case-insensitive, and nothing touched on refusal), the fetched cap and its seed fallback, bytes returned, and a moved file or a directory reported as such.

**Mutation-checked** (broken, confirmed red, restored):

- return the raw text instead of the bundle -> **8** tests fail, led by the through-the-parser body assertion;
- stop rewriting a bundled file's own in-document refs -> **2** fail, including that same body assertion, because `#/Tag` then resolves against the root;
- drop the `external_ref` stamping in `parseImport` -> the tally test fails and nothing else.

A multi-file fixture lives in `__fixtures__/openapi-v3-multifile/` as a directory with one entry point, so the fixture-parity guard now lists **files** and says why - there is no single file to hand a parser, and `ref-bundler.test.ts` is what exercises it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs land in the same commit: `docs/app/openapi.md` gains **Specs written across several files** (which intake applies to a fetched, picked or pasted document; what is disclosed; that the stored document is the bundle) and its verbatim-storage bullet now names the exception; `docs/app/import-collections/openapi-v3.md` gains an **External `$ref`s** section and both parser pages now name the shared `createRefResolver` instead of "a closed-over `resolveRef`"; the import README's `SkippedItem` list gains `external_ref` and the paragraph explaining it; `docs/app/state-management.md` records the `specFile:read` channel beside the spec file store.

## Related Issues

Closes #649. Extracted from #627 (phase 2 of #625), which now covers sync only and can assume a self-contained document.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A29FQXDYbHDCpQR4Lpk9jB)_