### PR TITLE
fix(app/sse): a streaming Send opts its scripts into pm.sendRequest too

### DIFF
--- a/app/src/services/api.script-requests.test.ts
+++ b/app/src/services/api.script-requests.test.ts
@@ -22,8 +22,13 @@
  * is the only layer that can catch it.
  *
  * Set inside the service rather than at each call site, so this also pins that
- * a caller does not have to know about it: the two callers below pass no such
+ * a caller does not have to know about it: the callers below pass no such
  * field.
+ *
+ * The streaming send is asserted beside the buffered one because the two are
+ * the same button (issue #653). While they disagreed, a `pm.sendRequest` was
+ * allowed with the stream toggle off and refused with it on - and nothing but
+ * the payload can see that, which is what makes them one test file.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -57,6 +62,18 @@ describe("the renderer opts its own executions into pm.sendRequest", () => {
 			url: "https://example.com",
 			allowScriptRequests: true,
 		});
+	});
+
+	it("sends allowScriptRequests on a streaming send too - one Send, one answer", async () => {
+		// The engine reads the flag before it branches on `stream`, so this is
+		// the only layer that decides whether a stream's scripts may send.
+		post.mockResolvedValue({ runId: "run_1", eventsUrl: "/runs/run_1/events" } as never);
+
+		await apiService.executeStreamRequest({ method: "GET", url: "https://example.com" });
+
+		expect(post).toHaveBeenCalledTimes(1);
+		const [, body] = post.mock.calls[0];
+		expect(body).toMatchObject({ stream: true, allowScriptRequests: true });
 	});
 
 	it("sends allowScriptRequests on a load run - one Tests script, one behaviour", async () => {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -512,18 +512,19 @@ export const apiService = {
 	 * (`maxStreamDurationMs`, `maxStreamEvents`, the idle timeout), not by a
 	 * client deadline.
 	 *
-	 * `allowScriptRequests` is not sent here, unlike `executeRequest` above.
-	 * That flag was pointless while the engine refused a stream carrying
-	 * scripts; #612 shipped those scripts, so today it means a `pm.sendRequest`
-	 * is refused on a streaming send and allowed on a buffered one - the same
-	 * button, two answers. Left as it stands rather than swept in with the
-	 * wording fix, because sending it is a behaviour change with its own
-	 * verification: see issue #620's follow-up.
+	 * `allowScriptRequests` is sent here for the same reason `executeRequest`
+	 * sends it, and it is the same reason both times: the asker is a user at
+	 * the request editor pressing Send, and `stream` describes the shape of the
+	 * response, not what that user's scripts may do. The engine reads the flag
+	 * before it branches on `stream` (`execution.cpp`), so it governs a
+	 * streaming send's pre- and post-request scripts exactly as it governs a
+	 * buffered one's (issue #653).
 	 */
 	async executeStreamRequest(data: ExecuteRequestRequest): Promise<ExecuteStreamResponse> {
 		const answer = await httpClient.post<ExecuteStreamResponse>(API_ENDPOINTS.EXECUTE_REQUEST, {
 			...data,
 			stream: true,
+			allowScriptRequests: true,
 		});
 		// Loud rather than a stream that silently never opens: without both
 		// fields there is no run to stop and no URL to tail, and the response

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -784,6 +784,14 @@ come back as a `400` the user has to read, so they are rendered as the response
 streaming send (issue #575), the pre-request half before the transfer and the
 post-request half once the stream has terminated.
 
+**The payload carries `allowScriptRequests` here for the same reason the
+buffered one does** (issue #653): the asker is a user at the request editor
+pressing Send, and the **Event stream** setting describes the shape of the
+answer, not what that user's scripts may do. The engine reads the flag before it
+branches on `stream`, so a `pm.sendRequest` behaves identically with the toggle
+on and off. While only the buffered call sent it, the same button allowed a
+script-issued request one way and refused it the other.
+
 The renderer sends the **inline** compose shape (`{ request, collectionId,
 environmentId }`) rather than compose-by-id, because Send executes the *editor
 state* - possibly unsaved, or a detached History replay copy that has no saved

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2429,7 +2429,9 @@ from inside a script never passes that gate. Denying unless a caller asks means
 a client that forgets gets a script that cannot send rather than unchecked
 egress. The app's Send and load runs send `true`; the MCP server never does.
 `POST /runs` reads the same field for its deferred `tests` validation, so one
-script behaves the same on both. See
+script behaves the same on both. Read **before** the `stream` branch, so a
+streaming send's scripts are governed by it exactly as a buffered send's are -
+the app sends it on both halves of Send (issue #653). See
 [scripting.md](scripting.md#sending-a-request-from-a-script-pmsendrequest).
 
 **Script parts.** `preRequestScript` / `postRequestScript` above are the legacy

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -568,10 +568,12 @@ Three ways to close that were available, and this is which one and why:
   moment anyone flips it for an unrelated reason.
 - **Refuse script-issued requests unless the caller explicitly asks.** Chosen.
   The engine denies `pm.sendRequest` unless the execute/run payload carries
-  `allowScriptRequests: true`. The app's own Send and load runs ask for it, in
-  one place each (`apiService.executeRequest` / `startLoadTest`); this server
-  never does. The allowlist stays exactly where the user configured it, and the
-  engine gains a capability bit rather than a policy copy.
+  `allowScriptRequests: true`. The app's own Send and load runs ask for it, each
+  in the one service method that owns that call (`apiService.executeRequest` and
+  `executeStreamRequest` - Send's two halves - plus `startLoadTest` /
+  `startScenarioRun`); this server never does. The allowlist stays exactly where
+  the user configured it, and the engine gains a capability bit rather than a
+  policy copy.
 
 Denying by **default** is the load-bearing half: a new tool here, or any future
 engine client, gets a script that cannot send rather than unchecked egress.

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -773,6 +773,12 @@ requests unless the caller explicitly asks for them (`allowScriptRequests` on
 server never does. Calling it from an agent-started run throws a message saying
 so. See [MCP](mcp.md#the-script-sandbox-surface).
 
+The flag is a property of **who asked for the execution**, not of the shape its
+answer comes back in: `POST /execute` reads it before it branches on `stream`,
+so a streaming send's pre- and post-request scripts are governed by exactly the
+bit a buffered send's are (issue #653). Pressing Send with the **Event stream**
+setting on and off gives `pm.sendRequest` the same answer.
+
 **No `{{variable}}` resolution.** A script-supplied URL is sent as written.
 Interpolation happens strictly before the pre-request script and a payload is
 resolved exactly once; a second pass here would break that invariant. Use

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -106,6 +106,16 @@ class StreamServer {
             });
         });
 
+        // A plain, non-streaming endpoint, for the one thing a stream's
+        // pre-request script does that the stream itself cannot: send a
+        // request of its own. Counted apart from `note_request`, whose record
+        // belongs to the transfer - an aside must not overwrite the headers a
+        // test reads back off `/scripted`.
+        svr_.Get ("/aside", [this] (const httplib::Request&, httplib::Response& res) {
+            aside_count_.fetch_add (1);
+            res.set_content (R"({"ok":true})", "application/json");
+        });
+
         svr_.Get ("/silent", [this] (const httplib::Request&, httplib::Response& res) {
             res.set_header ("X-Fixture", "silent");
             res.set_chunked_content_provider (
@@ -155,6 +165,12 @@ class StreamServer {
         return received_count_.load ();
     }
 
+    /// Requests a script sent to `/aside` of its own accord. Zero is the only
+    /// proof that a refusal was a refusal rather than a swallowed answer.
+    int aside_requests () const {
+        return aside_count_.load ();
+    }
+
     private:
     void note_request (const httplib::Request& req) {
         std::lock_guard<std::mutex> lock (received_mutex_);
@@ -174,6 +190,7 @@ class StreamServer {
     mutable std::mutex received_mutex_;
     std::map<std::string, std::string, std::less<>> received_headers_;
     std::atomic<int> received_count_{ 0 };
+    std::atomic<int> aside_count_{ 0 };
 };
 
 vayu::Request get_request (const std::string& url) {
@@ -943,6 +960,24 @@ class StreamExecuteTest : public ::testing::Test {
         return json::parse (response->body).value ("runId", std::string ());
     }
 
+    /// Send @p payload as an ordinary buffered execute and return the answer
+    /// body. The same fields the streaming path stores in its trace's `scripts`
+    /// node arrive here inline, which is what lets one test hold both
+    /// transports to the same rule.
+    json send_buffered (json payload) {
+        payload["method"] = "GET";
+        payload["url"]    = origin_->url ("/scripted");
+        httplib::Client client ("127.0.0.1", port_);
+        client.set_read_timeout (20, 0);
+        auto response = client.Post ("/execute", payload.dump (), "application/json");
+        EXPECT_TRUE (response);
+        if (!response) {
+            return json::object ();
+        }
+        EXPECT_EQ (response->status, 200) << response->body;
+        return json::parse (response->body);
+    }
+
     /// The stored trace, once the run has reached a terminal status. Polled off
     /// the row rather than the manager: the trace is written by the worker's
     /// completion callback, and the row's status is what says it has run.
@@ -1059,6 +1094,72 @@ TEST_F (StreamExecuteTest, ThePreRequestScriptsEditReachesTheWire) {
     const auto trace = trace_for (run_id);
     EXPECT_TRUE (trace["scripts"]["testResults"][0]["passed"].get<bool> ());
     EXPECT_EQ (origin_->received_header ("X-From-Script"), "yes");
+}
+
+// ---------------------------------------------------------------------------
+// `pm.sendRequest` on a stream (issue #653)
+//
+// Whether a script may send is a property of who asked for the execution, not
+// of the shape the response comes back in - `allow_send_request` is read from
+// the payload before the route branches on `stream`. Both transports are held
+// to the rule in one test each, because the defect these replace was precisely
+// the two disagreeing while each looked right on its own: the flag reached the
+// engine from a buffered Send and not from a streaming one, so the same button
+// allowed a `pm.sendRequest` with the toggle off and refused it with the toggle
+// on.
+// ---------------------------------------------------------------------------
+
+TEST_F (StreamExecuteTest, AStreamsScriptMaySendWhenTheCallerAskedForIt) {
+    serve (1);
+    // What the callback saw, written onto the request that goes on the wire -
+    // the origin's own record, so this cannot pass on a callback that never
+    // ran. `pm.sendRequest` is blocking, so the header is set before the
+    // transfer starts.
+    const std::string script = "pm.sendRequest('" + origin_->url ("/aside") +
+    "', function (err, res) { "
+    "  var seen = err ? 'error' : String(res.json().ok); "
+    "  pm.request.headers.add({ key: 'X-Aside', value: seen }); "
+    "});";
+    const json payload = { { "preRequestScript", script }, { "allowScriptRequests", true } };
+
+    const auto buffered = send_buffered (payload);
+    EXPECT_FALSE (buffered.contains ("preScriptError")) << buffered.dump (2);
+    EXPECT_EQ (origin_->aside_requests (), 1);
+    EXPECT_EQ (origin_->received_header ("X-Aside"), "true");
+
+    const auto run_id = start (payload);
+    ASSERT_FALSE (run_id.empty ());
+    const auto trace = trace_for (run_id);
+    EXPECT_FALSE (trace.contains ("scripts") && trace["scripts"].contains ("preScriptError"))
+    << trace.dump (2);
+    EXPECT_EQ (origin_->aside_requests (), 2)
+    << "the streaming send's script never reached the network";
+    EXPECT_EQ (origin_->received_header ("X-Aside"), "true");
+}
+
+TEST_F (StreamExecuteTest, AStreamsScriptIsRefusedWhenTheCallerDidNotAsk) {
+    serve (1);
+    const std::string script =
+    "pm.sendRequest('" + origin_->url ("/aside") + "', function () {});";
+    const json payload = { { "preRequestScript", script } };
+
+    const auto buffered = send_buffered (payload);
+    ASSERT_TRUE (buffered.contains ("preScriptError")) << buffered.dump (2);
+    EXPECT_NE (buffered["preScriptError"].get<std::string> ().find (
+               "pm.sendRequest is not available"),
+    std::string::npos)
+    << buffered["preScriptError"];
+
+    const auto run_id = start (payload);
+    ASSERT_FALSE (run_id.empty ());
+    const auto trace = trace_for (run_id);
+    ASSERT_TRUE (trace.contains ("scripts")) << trace.dump (2);
+    ASSERT_TRUE (trace["scripts"].contains ("preScriptError")) << trace.dump (2);
+    // The same message, not merely a refusal: a stream that refused for its own
+    // reason would be the divergence this test exists to forbid.
+    EXPECT_EQ (trace["scripts"]["preScriptError"], buffered["preScriptError"]);
+    EXPECT_EQ (origin_->aside_requests (), 0)
+    << "a denied script still reached the network";
 }
 
 // Absent, not empty. A stream that produced nothing has an empty list; a


### PR DESCRIPTION
## Description

**The plan.** The root cause is an omission that outlived its reason: `allowScriptRequests` was pointless while the engine refused a stream carrying scripts, so `executeStreamRequest` never sent it - and when #612 shipped scripts on a streaming send, the missing field silently became a behaviour. Today the same Send button allows a `pm.sendRequest` with the **Event stream** toggle off and refuses it, pointing the user at a Settings control they did not misconfigure, with the toggle on. Verified against the code before writing: `read_allow_script_requests(json)` is read at `execution.cpp:1012`, **before** the `if (stream.value)` branch, and the `script_config` it fills is captured into the streaming path's pre-request script and into the worker's completion callback - so the engine already governs both halves of a streaming send with that bit and only the renderer's payload was short a field. The approach is therefore the one-line send plus the tests that make the two paths provably agree. The alternative I rejected is the one the issue names as defensible: restricting a stream's scripts on purpose and rewording the refusal to say so. It fails the "who asked" rule the flag is built on (`routes.hpp`, `ExecuteRequestRequest`) - the asker is identical in both cases, a user at the request editor pressing Send - and `stream` describes the shape of the *answer*, not what that user's scripts may do.

Blast radius traced rather than assumed. Every app caller of `POST /execute` is accounted for: `executeRequest` (renderer Send, plus GraphQL introspection and the engine health probe, which reach it through the same service method), `executeStreamRequest` (fixed here), and the MCP server's `engine-client`, which must never ask and still does not - `electron/mcp/tools.test.ts` pins both that it does not set the field and that an agent cannot smuggle it through the tool schema. `startLoadTest` / `startScenarioRun` already send it. The flag stays set inside the service rather than at each call site, so the single-choke-point rule the file states is preserved.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

- `python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **1745 tests passed, 0 failed** (2 new in `sse_stream_test.cpp`).
- `cd app && pnpm test` - **470 files, 4908 tests passed** (1 new in `api.script-requests.test.ts`).
- `cd app && pnpm type-check` clean; `eslint` and `prettier --check` clean on both touched app files; `clang-format` clean on the lines added to `sse_stream_test.cpp` (the file is not clean on `master` - its existing comment reflow was left alone).
- `mkdocs build --strict` not run: mkdocs is not installed in this environment. The docs edits add prose to existing sections and no link, anchor or nav entry changed.

**Mutation-checked, run rather than reasoned about:**

- Engine: setting `script_config.allow_send_request = false` inside the `if (stream.value)` branch and rebuilding reddens `AStreamsScriptMaySendWhenTheCallerAskedForIt` while the buffered half of the same test still passes - so the test really covers the streaming path and not just the shared read. Green again on restore.
- App: dropping `allowScriptRequests` from `executeStreamRequest` reddens the new payload assertion. Nothing else changes shape when this regresses, which is why the assertion is on the captured body.

What the engine tests lock: the same payload is sent **buffered and streaming** in one test each, because the defect was the two disagreeing while each looked right alone. With the flag, the script's own request reaches the origin on both transports and the value its callback saw is read back off a header the origin recorded - so it cannot pass on a callback that never ran. Without it, both report the *identical* refusal message (a stream refusing for its own reason would be the divergence these forbid) and the origin's aside counter stays at zero, which is the only proof a refusal was a refusal rather than a swallowed answer.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #653. Follows #652, which swept the stale "scripts are refused on a stream" claim and left this comment pointing here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnDa7h5BPcP2sRXFao4pPq)_