### PR TITLE
fix(app/importers): import optional value-less OpenAPI header params disabled

### DIFF
--- a/app/src/services/importers/__fixtures__/openapi-v3.json
+++ b/app/src/services/importers/__fixtures__/openapi-v3.json
@@ -26,7 +26,12 @@
 						"required": true,
 						"schema": { "type": "string" }
 					},
-					{ "name": "verbose", "in": "query", "schema": { "type": "boolean" } }
+					{ "name": "verbose", "in": "query", "schema": { "type": "boolean" } },
+					{
+						"name": "X-Request-Id",
+						"in": "header",
+						"schema": { "type": "string" }
+					}
 				]
 			}
 		},

--- a/app/src/services/importers/__fixtures__/swagger-v2.json
+++ b/app/src/services/importers/__fixtures__/swagger-v2.json
@@ -33,7 +33,8 @@
 						"type": "array",
 						"collectionFormat": "multi",
 						"items": { "type": "string" }
-					}
+					},
+					{ "name": "X-Request-Id", "in": "header", "type": "string" }
 				]
 			}
 		}

--- a/app/src/services/importers/openapi-shared.ts
+++ b/app/src/services/importers/openapi-shared.ts
@@ -210,8 +210,8 @@ export function exampleBodyText(value: unknown): string {
 }
 
 /**
- * A value a spec declares for a query parameter, as the text a Params row holds -
- * or `undefined` when there is nothing Vayu can put on the wire.
+ * A value a spec declares for a query or header parameter, as the text its row
+ * holds - or `undefined` when there is nothing Vayu can put on the wire.
  *
  * Only scalars convert. An array or object value is serialized by the parameter's
  * `style`/`explode` (v3) or `collectionFormat` (v2), neither of which this importer
@@ -227,24 +227,26 @@ export function paramValueText(declared: unknown): string | undefined {
 }
 
 /**
- * One `in: "query"` parameter as a Params row (issue #622).
+ * One declared `in: "query"` or `in: "header"` parameter as a table row
+ * (issues #622, #658).
  *
  * A spec's parameter list declares what the endpoint *accepts*, not what every
  * request should *send*. An optional parameter with no declared value has nothing
- * to send, so it imports **disabled**: the row stays in the Params table, one click
- * from use, while the `url` - which since #590 carries every enabled row - does not
- * gain a bare `?verbose` nobody chose. Some APIs read that bare key as `verbose=true`,
- * so importing it enabled changed the wire for imported collections.
+ * to send, so it imports **disabled**: the row stays in its table, one click from
+ * use, and off the wire. Enabled it was a choice nobody made - for a query row the
+ * `url`, which since #590 carries every enabled row, gained a bare `?verbose` that
+ * some APIs read as `verbose=true`; for a header row the request claimed to send
+ * `X-Request-Id` with an empty value, which is not a header any spec asked for.
  *
  * Two things override that, and only these two:
  *
  * - `required: true` - a spec saying the parameter must be sent is an instruction,
- *   not documentation. The row imports enabled even with no value, and the bare key
- *   is the user's cue to fill it in.
+ *   not documentation. The row imports enabled even with no value, and the empty
+ *   value is the user's cue to fill it in.
  * - a declared value - a row carrying `?status=available` sends what the spec said,
  *   which is the case enabling was ever right for.
  */
-export function queryParamRow(
+export function declaredParamRow(
 	name: string,
 	declared: unknown,
 	required: unknown,

--- a/app/src/services/importers/openapi-v2.test.ts
+++ b/app/src/services/importers/openapi-v2.test.ts
@@ -40,6 +40,8 @@ describe("OpenApiV2Parser", () => {
 		// Optional with no `default` - one disabled row, and `collectionFormat` still
 		// unread (#622 does not change that; an array `default` is not sendable either).
 		expect(get.params).toEqual([{ key: "status", value: "", enabled: false }]);
+		// The declared header follows the same rule (#658) - listed, not sent.
+		expect(get.headers).toEqual([{ key: "X-Request-Id", value: "", enabled: false }]);
 	});
 
 	it("maps basic and oauth2 schemes via swaggerSchemeToAuth", () => {
@@ -332,6 +334,64 @@ describe("OpenApiV2Parser", () => {
 					},
 				])
 			).toEqual([{ key: "status", value: "", enabled: false }]);
+		});
+	});
+
+	/**
+	 * Issue #658, the header half. Same rule and the same `default`, so a Swagger
+	 * operation no longer imports a declared header as an enabled empty value.
+	 */
+	describe("header parameter enabled state", () => {
+		const headersOf = (parameters: unknown[]) => {
+			const spec = {
+				swagger: "2.0",
+				info: { title: "Header API" },
+				paths: { "/items": { get: { summary: "List items", parameters } } },
+			};
+			return p.parse(spec, JSON.stringify(spec), opts).collections[0].requests[0].headers;
+		};
+
+		it("imports an optional value-less header disabled and a required one enabled", () => {
+			expect(
+				headersOf([
+					{ name: "X-Request-Id", in: "header", type: "string" },
+					{ name: "X-Tenant", in: "header", type: "string", required: true },
+				])
+			).toEqual([
+				{ key: "X-Request-Id", value: "", enabled: false },
+				{ key: "X-Tenant", value: "", enabled: true },
+			]);
+		});
+
+		it("carries a scalar default as the row's value, enabled", () => {
+			expect(
+				headersOf([
+					{ name: "X-Api-Version", in: "header", type: "string", default: "2026-08-01" },
+				])
+			).toEqual([{ key: "X-Api-Version", value: "2026-08-01", enabled: true }]);
+		});
+
+		it("carries no description, since the Headers table has no column for one", () => {
+			expect(
+				headersOf([
+					{
+						name: "X-Request-Id",
+						in: "header",
+						type: "string",
+						description: "Correlation id",
+					},
+				])
+			).toEqual([{ key: "X-Request-Id", value: "", enabled: false }]);
+		});
+
+		it("still drops the headers Vayu manages, required or not", () => {
+			expect(
+				headersOf([
+					{ name: "Authorization", in: "header", type: "string", required: true },
+					{ name: "content-type", in: "header", type: "string", default: "text/plain" },
+					{ name: "X-Keep", in: "header", type: "string", required: true },
+				])
+			).toEqual([{ key: "X-Keep", value: "", enabled: true }]);
 		});
 	});
 });

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -20,9 +20,9 @@ import { normalizeVars } from "./var-normalize";
 import { mapSwaggerOAuth2 } from "./oauth2-import";
 import {
 	createRefResolver,
+	declaredParamRow,
 	deref,
 	exampleBodyText,
-	queryParamRow,
 	resolvePathItem,
 	responseExample,
 	SkipTally,
@@ -202,12 +202,15 @@ function buildSwaggerOp(
 			case "query":
 				// Swagger 2.0 states a non-body parameter's value inline as `default`;
 				// it has no `example` keyword (that arrived with v3's Example Object).
-				params.push(queryParamRow(name, param.default, param.required, description));
+				params.push(declaredParamRow(name, param.default, param.required, description));
 				break;
 			case "header": {
 				const lower = name.toLowerCase();
+				// Same value/enabled rule as a query row (#658). No description: the
+				// Headers table has no column for one, so carrying it would be a field
+				// nothing reads.
 				if (lower !== "authorization" && lower !== "content-type")
-					headers.push({ key: name, value: "", enabled: true });
+					headers.push(declaredParamRow(name, param.default, param.required));
 				break;
 			}
 			case "body": {

--- a/app/src/services/importers/openapi-v3.test.ts
+++ b/app/src/services/importers/openapi-v3.test.ts
@@ -30,6 +30,9 @@ describe("OpenApiV3Parser", () => {
 		// Optional, and the spec declares no value for it - documentation, not intent
 		// (#622), so the row imports disabled and stays off the URL.
 		expect(get.params).toEqual([{ key: "verbose", value: "", enabled: false }]);
+		// Same rule for the declared header (#658): optional and value-less, so the
+		// row is listed but off the wire rather than sent with an empty value.
+		expect(get.headers).toEqual([{ key: "X-Request-Id", value: "", enabled: false }]);
 		expect(get.auth).toEqual({ mode: "inherit" });
 	});
 
@@ -442,6 +445,86 @@ describe("OpenApiV3Parser", () => {
 			).toEqual([
 				{ key: "verbose", value: "", enabled: false, description: "Expand the payload" },
 			]);
+		});
+	});
+
+	/**
+	 * Issue #658, the header half of the same rule. An enabled header row with an
+	 * empty value is a header nobody chose: the request claims to send
+	 * `X-Request-Id` with nothing in it, which is more likely to trip server
+	 * validation than an absent query key is.
+	 */
+	describe("header parameter enabled state", () => {
+		const headersOf = (parameters: unknown[]) => {
+			const spec = {
+				openapi: "3.0.0",
+				info: { title: "Header API" },
+				components: { schemas: { Tenant: { type: "string", default: "acme" } } },
+				paths: { "/items": { get: { summary: "List items", parameters } } },
+			};
+			return p.parse(spec, JSON.stringify(spec), opts).collections[0].requests[0].headers;
+		};
+
+		it("imports an optional value-less header disabled and a required one enabled", () => {
+			expect(
+				headersOf([
+					{ name: "X-Request-Id", in: "header", schema: { type: "string" } },
+					{
+						name: "X-Tenant",
+						in: "header",
+						required: true,
+						schema: { type: "string" },
+					},
+				])
+			).toEqual([
+				{ key: "X-Request-Id", value: "", enabled: false },
+				{ key: "X-Tenant", value: "", enabled: true },
+			]);
+		});
+
+		it("carries a declared value, by the same precedence a query row uses", () => {
+			expect(
+				headersOf([
+					{
+						name: "X-Api-Version",
+						in: "header",
+						example: "2026-08-01",
+						schema: { type: "string", default: "2024-01-01" },
+					},
+					{
+						name: "X-Tenant",
+						in: "header",
+						schema: { $ref: "#/components/schemas/Tenant" },
+					},
+				])
+			).toEqual([
+				{ key: "X-Api-Version", value: "2026-08-01", enabled: true },
+				{ key: "X-Tenant", value: "acme", enabled: true },
+			]);
+		});
+
+		it("leaves a non-scalar declared value value-less and disabled", () => {
+			expect(
+				headersOf([
+					{ name: "X-Tags", in: "header", schema: { type: "array", default: ["a"] } },
+				])
+			).toEqual([{ key: "X-Tags", value: "", enabled: false }]);
+		});
+
+		it("carries no description, since the Headers table has no column for one", () => {
+			expect(
+				headersOf([{ name: "X-Request-Id", in: "header", description: "Correlation id" }])
+			).toEqual([{ key: "X-Request-Id", value: "", enabled: false }]);
+		});
+
+		it("still drops the headers Vayu manages, required or not", () => {
+			expect(
+				headersOf([
+					{ name: "Authorization", in: "header", required: true },
+					{ name: "content-type", in: "header", example: "application/json" },
+					{ name: "X-Keep", in: "header", required: true },
+				])
+			).toEqual([{ key: "X-Keep", value: "", enabled: true }]);
 		});
 	});
 });

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -20,11 +20,11 @@ import { normalizeVars } from "./var-normalize";
 import { mapOpenApiV3OAuth2 } from "./oauth2-import";
 import {
 	createRefResolver,
+	declaredParamRow,
 	deref,
 	exampleBodyText,
 	findJsonMediaType,
 	firstNamedExample,
-	queryParamRow,
 	resolvePathItem,
 	responseExample,
 	SkipTally,
@@ -187,7 +187,7 @@ function buildOperation(
 		const description = asStr(resolved.description);
 		if (resolved.in === "query") {
 			params.push(
-				queryParamRow(
+				declaredParamRow(
 					name,
 					declaredParamValue(resolved, resolveRef),
 					resolved.required,
@@ -197,7 +197,12 @@ function buildOperation(
 		} else if (resolved.in === "header") {
 			const lower = name.toLowerCase();
 			if (lower === "authorization" || lower === "content-type") continue;
-			headers.push({ key: name, value: "", enabled: true });
+			// Same value/enabled rule as a query row (#658). No description: the
+			// Headers table has no column for one, so carrying it would be a field
+			// nothing reads.
+			headers.push(
+				declaredParamRow(name, declaredParamValue(resolved, resolveRef), resolved.required)
+			);
 		}
 	}
 	const examples = buildExamples(op.responses, resolveRef, tally);

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -77,8 +77,9 @@ Two consequences worth expecting:
   what the Params table writes for the same row. The OpenAPI parsers import an
   optional value-less parameter **disabled** so this does not happen for a
   parameter the spec merely documents - only a `required` one, or one carrying a
-  declared value, reaches the URL (see
-  [Query parameter values & enabled state](./openapi-v3.md#query-parameter-values--enabled-state)).
+  declared value, reaches the URL. Declared **header** parameters follow the same
+  rule (see
+  [Parameter values & enabled state](./openapi-v3.md#parameter-values--enabled-state)).
 
 ### 2. Assign temp IDs - `assign-ids.ts`
 

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -1,6 +1,6 @@
 # OpenAPI 2.0 (Swagger)
 
-Parses a Swagger 2.0 specification into the Vayu draft model. Swagger 2.0, like OpenAPI 3.0, is a **specification document, not a request log** - it describes endpoints, parameters, and schemas but carries no concrete values. The parser therefore emits **synthetic request stubs**: a `{{baseUrl}}` built from `schemes`/`host`/`basePath`, header params with empty values, query params carrying a declared `default` when there is one (see [Query parameter values & enabled state](#query-parameter-values--enabled-state)), and a body sampled from the `in: "body"` parameter schema. Users fill in real values after import.
+Parses a Swagger 2.0 specification into the Vayu draft model. Swagger 2.0, like OpenAPI 3.0, is a **specification document, not a request log** - it describes endpoints, parameters, and schemas but carries no concrete values. The parser therefore emits **synthetic request stubs**: a `{{baseUrl}}` built from `schemes`/`host`/`basePath`, query and header params carrying a declared `default` when there is one (and importing disabled when there is not - see [Parameter values & enabled state](#parameter-values--enabled-state)), and a body sampled from the `in: "body"` parameter schema. Users fill in real values after import.
 
 The document is not thrown away once it has been read. The collection it
 produces is **bound** to it: the spec is stored verbatim (with the URL it was
@@ -91,8 +91,8 @@ Built by `buildSwaggerOp(method, path, op, spec, resolveRef, pathParams)`.
 | `op.description` | `description` | fallback `""` |
 | HTTP method | `method` | `method.toUpperCase()` (e.g. `get` → `GET`), cast to `HttpMethod` |
 | `path` | `url` | `` `{{baseUrl}}${normalizeVars(path, { pathTemplates: true })}` `` - always prefixed with `{{baseUrl}}`, even if no `host` was defined (see [URL](#url--path-parameters)) |
-| parameter `in: "query"` | `params` | `{ key: name, value, enabled, description? }` via `queryParamRow` - `description` included only when present; `value` and `enabled` follow [Query parameter values & enabled state](#query-parameter-values--enabled-state). Only the enabled rows are joined onto the `url` by `parseImport` - see [The url/params invariant](./README.md#the-urlparams-invariant) |
-| parameter `in: "header"` | `headers` | `{ key: name, value: "", enabled: true }` - **no description carried**; `authorization` and `content-type` headers are dropped (case-insensitive) since Vayu manages those |
+| parameter `in: "query"` | `params` | `{ key: name, value, enabled, description? }` via `declaredParamRow` - `description` included only when present; `value` and `enabled` follow [Parameter values & enabled state](#parameter-values--enabled-state). Only the enabled rows are joined onto the `url` by `parseImport` - see [The url/params invariant](./README.md#the-urlparams-invariant) |
+| parameter `in: "header"` | `headers` | `{ key: name, value, enabled }` via the same `declaredParamRow` - **no description carried** (the Headers table has no column for one); `authorization` and `content-type` headers are dropped (case-insensitive) since Vayu manages those |
 | parameter `in: "body"` | `body` | sampled via `sampleSchema`; JSON vs text decided by `consumes` (see [Parameters & body](#parameters--body)) |
 | parameter `in: "formData"` | `body` | collected into form fields; the encoding (`x-www-form-urlencoded` vs `form-data`) comes from `consumes` (see [`consumes` → body mode](#consumes--body-mode)) |
 | parameter `in: "path"` | - | not emitted as params/headers; path params are represented in the URL via `normalizeVars` |
@@ -155,27 +155,27 @@ Swagger 2.0 has **no `requestBody` object** (unlike v3). Request bodies are expr
 
 | `param.in` | Effect | Detail |
 |------------|--------|--------|
-| `query` | push to `params` | `queryParamRow(name, param.default, param.required, description)`; `description` only when present (see [Query parameter values & enabled state](#query-parameter-values--enabled-state)) |
-| `header` | push to `headers` | `{ key, value: "", enabled: true }`; skipped when `name.toLowerCase()` is `authorization` or `content-type` |
+| `query` | push to `params` | `declaredParamRow(name, param.default, param.required, description)`; `description` only when present (see [Parameter values & enabled state](#parameter-values--enabled-state)) |
+| `header` | push to `headers` | `declaredParamRow(name, param.default, param.required)` - same rule, no `description`; skipped when `name.toLowerCase()` is `authorization` or `content-type` |
 | `body` | set `body` | `sample = param.schema ? sampleSchema(param.schema, resolveRef) : {}`; serialized with `JSON.stringify(sample, null, 2)`. Mode is JSON or text per `consumes` (below). |
 | `formData` | collect into `formFields` | `{ key: name, value: "", enabled: true }` per field; a `type: file` parameter becomes a **file part** instead (see [`type: file` fields](#type-file-fields)) |
 | (anything else) | ignored | no `default` case action |
 
 After the loop, **form data wins**: if any `formData` fields were collected, `body` is unconditionally replaced with `{ mode: formMode, fields: formFields }` - overriding any body set by an `in: "body"` parameter. (A spec mixing both would be unusual, but the code resolves it in favor of the form.) `formMode` comes from `consumes`, below.
 
-### Query parameter values & enabled state
+### Parameter values & enabled state
 
-A spec's `parameters` list declares what an operation **accepts**, not what every request should **send** - and since the [url/params join](./README.md#the-urlparams-invariant) every enabled row reaches the wire. `queryParamRow` (`openapi-shared.ts`, shared with the [OpenAPI 3 parser](./openapi-v3.md#query-parameter-values--enabled-state)) decides both fields from the parameter alone:
+A spec's `parameters` list declares what an operation **accepts**, not what every request should **send** - and an enabled row reaches the wire either way: a query row through the [url/params join](./README.md#the-urlparams-invariant), a header row as a header the request claims to send. `declaredParamRow` (`openapi-shared.ts`, shared with the [OpenAPI 3 parser](./openapi-v3.md#parameter-values--enabled-state) and applied to `in: "query"` and `in: "header"` alike) decides both fields from the parameter alone:
 
 | Parameter declares | `value` | `enabled` |
 |--------------------|---------|-----------|
 | a scalar `default` | that value as text (`25`, `false`) | `true` |
-| `required: true`, no `default` | `""` | `true` - joins as a bare key (`?tenant`), the cue to fill it in |
+| `required: true`, no `default` | `""` | `true` - a query row joins as a bare key (`?tenant`), a header row is listed with an empty value; either is the cue to fill it in |
 | nothing, and not required | `""` | **`false`** |
 
 `default` is the only value keyword read: Swagger 2.0 has no `example` for a non-body parameter (the Example Object arrived with v3), and `enum` lists what is allowed rather than what to send. Only scalars become a value - an array or object `default` is serialized by `collectionFormat`, which this parser does not read (below), so such a parameter imports value-less. A declared `""` is value-less too: an empty-value row writes as a bare key, so `?q=` is not a shape the Params table can hold.
 
-Why optional value-less parameters import **disabled** (issue #622): the row is documentation ("this endpoint accepts `verbose`"), not intent ("send `verbose` always"). Enabled, it joined the stored URL as `?verbose`, which some APIs read as `verbose=true` - a wire change nobody chose. Disabled, the row is still listed in the Params table one click from use.
+Why optional value-less parameters import **disabled** (issues #622, #658): the row is documentation ("this endpoint accepts `verbose`"), not intent ("send `verbose` always"). Enabled, a query row joined the stored URL as `?verbose`, which some APIs read as `verbose=true`, and a header row claimed an `X-Request-Id:` with nothing in it - both a wire change nobody chose. Disabled, the row is still listed in its table one click from use.
 
 ### `consumes` → body mode
 
@@ -250,7 +250,7 @@ Body schemas are turned into stub values by `sampleSchema(schema, resolveRef)` (
 **Not implemented.** Swagger 2.0's `collectionFormat` (`csv` / `ssv` / `tsv` / `pipes` / `multi`) on array parameters is **not consulted anywhere** in the parser. A `query` parameter - array or scalar - produces exactly **one** `KeyValueEntry`:
 
 ```ts
-params.push(queryParamRow(name, param.default, param.required, description));
+params.push(declaredParamRow(name, param.default, param.required, description));
 ```
 
 There is no per-value expansion, no separator joining, and no `multi` handling. The parameter's `type` and `items` are ignored entirely, and an **array `default` is not carried as a value** for the same reason: without `collectionFormat` there is no separator to join it with, and joining on a guess would send what the spec did not declare. `multi` does **not** emit one entry per value - it emits the same single entry as any other query param.
@@ -283,14 +283,14 @@ const primaryScheme = (reqName && defs[reqName]) || Object.values(defs)[0];
 
 ## Options & lossy behavior
 
-This parser is **stub-only**: it materializes the shape of each request, and the only values it carries are the ones the spec states outright - a query parameter's `default` ([above](#query-parameter-values--enabled-state)) and a response example. The `ImportOptions` argument (`importEnvironments`, `importScripts`) is **ignored** - the parameter is `_opts` and is never read (identical to v3).
+This parser is **stub-only**: it materializes the shape of each request, and the only values it carries are the ones the spec states outright - a query or header parameter's `default` ([above](#parameter-values--enabled-state)) and a response example. The `ImportOptions` argument (`importEnvironments`, `importScripts`) is **ignored** - the parameter is `_opts` and is never read (identical to v3).
 
 Dropped / not represented:
 
 - **Scripts:** all `preRequestScript` / `postRequestScript` are `""` (Swagger has no scripts; `importScripts` has no effect here).
 - **Environments:** none produced (`environments: []`, `meta.environmentCount: 0`). Swagger has no environment concept; the `scheme`/`host`/`basePath` triple becomes a single `baseUrl` collection variable.
 - **Additional schemes:** only `schemes[0]` is used; other schemes are dropped.
-- **`collectionFormat`, parameter `type` / `items`, `required`, `default`, `enum` on params:** not consumed - query/header/form params are always empty-value stubs.
+- **`collectionFormat`, parameter `type` / `items`, `enum` on params:** not consumed. `required` and a scalar `default` **are** read, for query and header params alike - see [Parameter values & enabled state](#parameter-values--enabled-state); form params are still always empty-value stubs.
 - **Response headers** (`responses[code].headers`): not imported. Response schemas and examples *are*, since issue #481 - see [Documented responses](#documented-responses).
 - **`authorization` / `content-type` header parameters:** dropped (Vayu manages them).
 - **Path parameters as params:** not emitted (path params live in the URL only).
@@ -329,7 +329,7 @@ Shared between both: tree-by-first-tag, `{{baseUrl}}`-prefixed URLs, `normalizeV
 | `createRefResolver`, `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve an in-document `$ref` and a `$ref`'d path item; guard `parameters` and tally what was dropped |
 | `bundleExternalRefs` | `ref-bundler.ts` | resolve references to *other files* before parse, and count what it could not reach |
 | `responseExample`, `exampleBodyText`, `deref` | `openapi-shared.ts` | map one `responses` entry to an example draft - the half shared with the v3 parser |
-| `queryParamRow`, `paramValueText` | `openapi-shared.ts` | one `in: "query"` parameter as a Params row - the value/enabled rule both OpenAPI parsers apply |
+| `declaredParamRow`, `paramValueText` | `openapi-shared.ts` | one `in: "query"` or `in: "header"` parameter as a table row - the value/enabled rule both OpenAPI parsers apply |
 | `countExamples` | `shared.ts` | total the examples across the finished drafts, for `meta.exampleCount` |
 
 Beyond `countExamples`, this parser does **not** use the Postman/Insomnia helpers in `shared.ts` (`asString`, `toVarRecord`, `mapKeyValues`, `mapPostmanAuth`, `rawBody`, `joinExec`); it builds drafts directly. See the [index](./README.md#shared-helpers) for the full shared-helper reference.

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -1,6 +1,6 @@
 # OpenAPI 3.0
 
-Parses an OpenAPI 3.0.x specification into the Vayu draft model. OpenAPI is a **specification document, not a request log** - it describes endpoints, parameters, and schemas but carries no concrete values. The parser therefore emits **synthetic request stubs**: a `{{baseUrl}}` from the first server, header params with empty values, query params carrying whatever value the spec declares for them (usually none - see [Query parameter values & enabled state](#query-parameter-values--enabled-state)), and a body sampled from the request schema. Users fill in real values after import.
+Parses an OpenAPI 3.0.x specification into the Vayu draft model. OpenAPI is a **specification document, not a request log** - it describes endpoints, parameters, and schemas but carries no concrete values. The parser therefore emits **synthetic request stubs**: a `{{baseUrl}}` from the first server, query and header params carrying whatever value the spec declares for them (usually none, in which case the row imports disabled - see [Parameter values & enabled state](#parameter-values--enabled-state)), and a body sampled from the request schema. Users fill in real values after import.
 
 The document is not thrown away once it has been read. The collection it
 produces is **bound** to it: the spec is stored verbatim (with the URL it was
@@ -122,28 +122,28 @@ Built by `buildOperation(method, path, op, resolveRef, pathParams)`.
 | `op.description` | `description` | fallback `""` |
 | HTTP method | `method` | `method.toUpperCase()` (e.g. `get` → `GET`), cast to `HttpMethod` |
 | `path` | `url` | `` `{{baseUrl}}${normalizeVars(path, { pathTemplates: true })}` `` - always prefixed with `{{baseUrl}}`, even if no server was defined (see [URL](#url--path-parameters)) |
-| parameters with `in: "query"` | `params` | `{ key: name, value, enabled, description? }` via `queryParamRow` - `description` included only when present; `value` and `enabled` follow [Query parameter values & enabled state](#query-parameter-values--enabled-state). Only the enabled rows are joined onto the `url` by `parseImport` - see [The url/params invariant](./README.md#the-urlparams-invariant) |
-| parameters with `in: "header"` | `headers` | `{ key: name, value: "", enabled: true }` - **no description carried**; `authorization` and `content-type` headers are dropped (case-insensitive) since Vayu manages those |
+| parameters with `in: "query"` | `params` | `{ key: name, value, enabled, description? }` via `declaredParamRow` - `description` included only when present; `value` and `enabled` follow [Parameter values & enabled state](#parameter-values--enabled-state). Only the enabled rows are joined onto the `url` by `parseImport` - see [The url/params invariant](./README.md#the-urlparams-invariant) |
+| parameters with `in: "header"` | `headers` | `{ key: name, value, enabled }` via the same `declaredParamRow` - **no description carried** (the Headers table has no column for one); `authorization` and `content-type` headers are dropped (case-insensitive) since Vayu manages those |
 | parameters with `in: "path"` / `in: "cookie"` | - | not emitted as params/headers; path params are represented in the URL via `normalizeVars`. Cookie params are dropped. |
 | `op.requestBody` | `body` | via `buildBody` (see [Request body](#request-body-generation)) |
 | (none) | `auth` | always `{ mode: "inherit" }` - auth is configured once at the collection level |
 | (none) | `preRequestScript` / `postRequestScript` | always `""` |
 
-### Query parameter values & enabled state
+### Parameter values & enabled state
 
-A spec's `parameters` list declares what an operation **accepts**, not what every request should **send** - and since the [url/params join](./README.md#the-urlparams-invariant) every enabled row reaches the wire. `queryParamRow` (`openapi-shared.ts`, shared with the [Swagger parser](./openapi-v2.md)) decides both fields from the parameter alone:
+A spec's `parameters` list declares what an operation **accepts**, not what every request should **send** - and an enabled row reaches the wire either way: a query row through the [url/params join](./README.md#the-urlparams-invariant), a header row as a header the request claims to send. `declaredParamRow` (`openapi-shared.ts`, shared with the [Swagger parser](./openapi-v2.md) and applied to `in: "query"` and `in: "header"` alike) decides both fields from the parameter alone:
 
 | Parameter declares | `value` | `enabled` |
 |--------------------|---------|-----------|
 | a scalar `example` / `examples` / `schema.example` / `schema.default` | that value as text | `true` |
-| `required: true`, no value | `""` | `true` - joins as a bare key (`?tenant`), the cue to fill it in |
+| `required: true`, no value | `""` | `true` - a query row joins as a bare key (`?tenant`), a header row is listed with an empty value; either is the cue to fill it in |
 | nothing, and not required | `""` | **`false`** |
 
 Value precedence is the parameter's own `example`, then the first entry of its `examples` map (unwrapped by `firstNamedExample`), then the schema's `example`, then the schema's `default` - the same "concrete example beats generated stub" order [`buildBody`](#request-body-generation) uses, and a `default` only describes what the server assumes when the parameter is **absent**, so it ranks last. The `schema` is followed one `$ref` hop (`deref`).
 
 Only scalars become a value. An array or object is serialized by the parameter's `style`/`explode`, which this parser does not read, and one row holds one string - so such a parameter imports value-less, like one declaring nothing. A declared `""` is value-less too: an empty-value row writes as a bare key, so `?q=` is not a shape the Params table can hold.
 
-Why optional value-less parameters import **disabled** (issue #622): the row is documentation ("this endpoint accepts `verbose`"), not intent ("send `verbose` always"). Enabled, it joined the stored URL as `?verbose`, which some APIs read as `verbose=true` - a wire change nobody chose. Disabled, the row is still listed in the Params table one click from use.
+Why optional value-less parameters import **disabled** (issues #622, #658): the row is documentation ("this endpoint accepts `verbose`"), not intent ("send `verbose` always"). Enabled, a query row joined the stored URL as `?verbose`, which some APIs read as `verbose=true`, and a header row claimed an `X-Request-Id:` with nothing in it - both a wire change nobody chose. Disabled, the row is still listed in its table one click from use.
 
 ## URL & path parameters
 
@@ -228,7 +228,7 @@ Auth is applied **only at the root collection**; every request is `{ mode: "inhe
 
 ## Options & lossy behavior
 
-This parser is **stub-only**: it materializes the shape of each request, and the only values it carries are the ones the spec states outright - a query parameter's `example`/`default` ([above](#query-parameter-values--enabled-state)) and a response example. The `ImportOptions` argument (`importEnvironments`, `importScripts`) is **ignored** - the parameter is `_opts` and is never read.
+This parser is **stub-only**: it materializes the shape of each request, and the only values it carries are the ones the spec states outright - a query or header parameter's `example`/`default` ([above](#parameter-values--enabled-state)) and a response example. The `ImportOptions` argument (`importEnvironments`, `importScripts`) is **ignored** - the parameter is `_opts` and is never read.
 
 Dropped / not represented:
 
@@ -265,7 +265,7 @@ An import with nothing to report still yields `skipped: []` - only non-zero kind
 | `importedFilePart`, `unattachedFileParts` | `shared.ts` | build a file form row; count the rows that still need a file, for `meta` |
 | `createRefResolver`, `resolvePathItem`, `SkipTally` | `openapi-shared.ts` | resolve an in-document `$ref` and a `$ref`'d path item; guard `parameters` and tally what was dropped |
 | `bundleExternalRefs` | `ref-bundler.ts` | resolve references to *other files* before parse, and count what it could not reach |
-| `queryParamRow`, `paramValueText` | `openapi-shared.ts` | one `in: "query"` parameter as a Params row - the value/enabled rule both OpenAPI parsers apply |
+| `declaredParamRow`, `paramValueText` | `openapi-shared.ts` | one `in: "query"` or `in: "header"` parameter as a table row - the value/enabled rule both OpenAPI parsers apply |
 | `responseExample`, `findJsonMediaType`, `firstNamedExample`, `exampleBodyText`, `deref` | `openapi-shared.ts` | map one `responses` entry to an example draft; the halves the two OpenAPI parsers share |
 | `countExamples` | `shared.ts` | total the examples across the finished drafts, for `meta.exampleCount` |
 


### PR DESCRIPTION
## Description

**The plan.** The root cause is a scope boundary that outlived its reason: #633 fixed the value/enabled rule for query parameters and explicitly excluded headers because #622 did not name them, so both parsers still pushed `{ key: name, value: "", enabled: true }` for every declared header. Verified against the code before writing - `openapi-v3.ts:197` and `openapi-v2.ts:207` at `24aa26d` both did exactly that. The approach is to apply #633's rule verbatim to headers through the *same* helper rather than a second copy of it: `queryParamRow` is renamed `declaredParamRow` and both parsers call it for `in: "query"` and `in: "header"` alike, so the next fix to the rule reaches both kinds. The alternative I rejected was a `headerParamRow` sibling with its own copy of the required/declared-value logic - it reads cleaner at the call site and is precisely the hand-rolled-copy failure CLAUDE.md warns about, since the two would drift the first time the precedence changes.

**One correction to the issue's premise, traced rather than assumed.** The issue says the empty row "sends `X-Request-Id:` (empty value) on every request". End to end nothing in Vayu filters it - `key-value.ts:26` drops only disabled rows and blank keys, `request_composer.cpp:442` coerces a missing value to `""`, and all three transports append `key + ": " + value` unconditionally (`client.cpp:386`, `curl_utils.cpp:481`, `sse_stream.cpp:396`) - but libcurl itself omits a custom header whose value is empty, so the header does not reach the wire. The defect is therefore not a stray header on the wire; it is that the imported request *claims* to send one. `client.cpp:365` snapshots `request.headers` before the slist is built, so the response viewer's "request headers sent" panel lists `X-Request-Id` with an empty value for a header libcurl dropped. That is a lie about the request, and the row is still a choice nobody made - so the fix and its shape are unchanged, and the acceptance criterion ("present, disabled, and off the wire") is met by the enabled filter at `key-value.ts:26`. The reporting gap belongs to the engine, not to this rule; filed separately rather than widened into this diff.

**Blast radius.** Both parsers write `headers: KeyValueEntry[]` into a `RequestDraft`; the readers are the import orchestrator (`orchestrator.fixture-parity.test.ts` compares the whole tree field by field, and passes unchanged), the request store, and the Headers table. No description is carried for a header row - `HeadersPanel` renders no description column, so passing one would be a field nothing reads, which is the repeat defect CLAUDE.md names. That asymmetry with query rows is deliberate and is now stated in the code comment, in both mapping docs, and locked by a test in each parser.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **473 files, 4944 tests passed, 0 failed** (9 new: 5 in `openapi-v3.test.ts`, 4 in `openapi-v2.test.ts`, plus two fixture assertions extended).
- `cd app && pnpm type-check` clean; `pnpm lint` clean (0 errors, 0 warnings); `prettier --check` clean on every file touched.
- `mkdocs build --strict -f .github/mkdocs.yml` - **built clean**, which is what gates the heading rename below.
- Engine untouched (no C++ in this diff), so per CLAUDE.md's "if no test could possibly go from green to red, do not run tests" the engine build and ctest suite were not run.

**Mutation-checked, run rather than reasoned about:** reverting both parsers' header branches to `{ key: name, value: "", enabled: true }` and re-running reddens **9 tests across 2 files**; restoring returns all 309 importer tests to green. The fixture assertions are part of that count, so the rule is proven on a real spec and not only on inline ones.

What the tests lock, per parser: the optional/required split in one assertion (the mutation's target), a declared value carried enabled - v3 through the full `example` → `$ref`'d `schema.default` precedence, v2 off `default` - a non-scalar declared value staying value-less and disabled, no `description` on a header row even when the spec declares one, and `authorization` / `content-type` still dropped whether required or carrying a value (a guard the refactor did not previously have).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #658. Applies the rule #633 established for #622.

**Deliberate deviation from the issue spec, with reason:** the issue asks for the header lines in the two mapping docs. The rule is now shared, so leaving a section titled "Query parameter values & enabled state" as the place the header rule is documented would be stale on arrival. The section is retitled **"Parameter values & enabled state"** in both docs and the four in-repo links to the old anchor are updated (`README.md`, and the self- and cross-links in each page); `mkdocs build --strict` passes, which is the check a broken anchor would fail. Per #658's sequencing note this lands before #655, so import and sync see one rule for headers as well as queries.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TtdvkM5g7kwF3qAmgpd2t)_