### PR TITLE
fix(engine/http): stop reporting a value-less header as sent

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2550,6 +2550,11 @@ and an h2 request rendered in HTTP/1 form - none of which appear in
 issued them. It carries the two the engine derives at send time - the
 body-implied `Content-Type` and the default `User-Agent` - and drops a
 `form-data` `Content-Type`, which libcurl writes itself with the boundary. It
+also drops **an enabled header whose value is empty or only whitespace**: a
+header line with nothing after the colon is libcurl's spelling for *remove this
+header*, so such a row never reaches the wire on any transport and is not
+reported as sent either. To send a header that is present with an empty value,
+give it a value - the engine does not emit libcurl's `Key;` form. It
 does not carry libcurl's own additions or the jar's `Cookie` line; those are
 `rawRequest`'s alone. A test script's `pm.request.headers` reads this same set
 (see [scripting.md](scripting.md#request-object-pmrequest)), so an assertion

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -396,7 +396,9 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   composed is not the request that was sent, and asserting on the composed one
   is how a correct request gets reported as wrong. `requestHeaders` in the
   result is the sent record - composed plus those first two, minus a
-  `form-data` `Content-Type` libcurl writes itself - and `rawRequest` is the
+  `form-data` `Content-Type` libcurl writes itself and minus any header whose
+  value is empty, which libcurl reads as a removal rather than sending - and
+  `rawRequest` is the
   full wire frame including the `Cookie` line and libcurl's own `Accept` /
   `Content-Length`. Both are passed through verbatim; read them rather than the
   request the call sent. A `postRequestScript` reads the same set as

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -395,7 +395,7 @@ means the ones the engine derives at send time are there too - the body-implied
 asserting on the Content-Type a GraphQL request sent reads the header the engine
 supplied, rather than the `undefined` it read before (#483).
 
-Three consequences worth knowing:
+Four consequences worth knowing:
 
 - **An authored header is never overridden.** The engine only derives a
   Content-Type the request does not declare, so what a script reads back is what
@@ -404,6 +404,11 @@ Three consequences worth knowing:
   itself, boundary and all, so the engine suppresses an authored one and does
   not report as sent what it did not send. The script's view matches the
   response pane's Headers tab exactly.
+- **A header with an empty value is absent too.** A header line with nothing
+  after the colon is libcurl's spelling for *remove this header*, so an enabled
+  row whose value is empty (or only whitespace) never goes on the wire - and
+  the sent record does not claim it did. A pre-request script that sets a
+  header to `''` has removed it, not blanked it; give it a value to send one.
 - **`Cookie` is not here.** It is wire-only by design; `pm.cookies` is the
   cookie surface, and the response's raw view is the full wire frame (which also
   carries libcurl's own `Accept`, `Host` and `Content-Length`).

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -466,6 +466,7 @@ if(VAYU_BUILD_TESTS)
         tests/script_info_test.cpp
         tests/script_send_request_test.cpp
         tests/script_sent_headers_test.cpp
+        tests/sent_headers_wire_test.cpp
         tests/set_cookie_test.cpp
         tests/cookie_jar_test.cpp
         tests/form_body_test.cpp

--- a/engine/include/vayu/http/event_loop/curl_utils.hpp
+++ b/engine/include/vayu/http/event_loop/curl_utils.hpp
@@ -113,13 +113,14 @@ Response error_response (const Error& error);
 [[nodiscard]] curl_mime* apply_method_and_body (CURL* curl, const Request& request);
 
 /**
- * @brief The "Content-Type: ..." header line the body implies, or empty.
+ * @brief The Content-Type value the body implies, or empty.
  *
  * Empty when the request already declares a Content-Type (a header the user
- * typed always wins) and empty for every mode that implies none. Both clients
- * call this after their own header loop so the two cannot drift.
+ * typed always wins) and empty for every mode that implies none. Read only by
+ * `build_request_header_list`, which is where every driver gets its headers,
+ * so the rule cannot drift between them.
  */
-[[nodiscard]] std::string body_content_type_header (const Request& request);
+[[nodiscard]] std::string body_content_type_value (const Request& request);
 
 /**
  * @brief True when this request header must not be forwarded as written.
@@ -128,6 +129,49 @@ Response error_response (const Error& error);
  * `vayu::http::content_type_is_engine_owned`.
  */
 [[nodiscard]] bool suppresses_request_header (const Request& request, const std::string& key);
+
+/**
+ * @brief True when libcurl sends this header value rather than reading the
+ *        line as an instruction to remove the header.
+ *
+ * `CURLOPT_HTTPHEADER` overloads one string with two meanings: `Key: value`
+ * adds a header, and `Key:` with nothing after the colon *removes* one, which
+ * is how libcurl lets a caller drop a header it would otherwise add itself.
+ * The engine spells every header `key + ": " + value`, so an enabled request
+ * row with an empty value lands on the removal side and never reaches the wire
+ * - sending it deliberately would need the `Key;` spelling, which the engine
+ * does not emit (issue #662). libcurl skips the whitespace after the colon
+ * before deciding, so a value of spaces alone is dropped too.
+ */
+[[nodiscard]] bool header_value_reaches_wire (std::string_view value);
+
+/**
+ * @brief Build the `CURLOPT_HTTPHEADER` list for a request, and record what it
+ *        puts on the wire.
+ *
+ * The one place a driver's outbound header set is decided: the request's own
+ * headers minus the suppressed and the value-less, plus the two the engine
+ * derives (the body-implied Content-Type and a default User-Agent when the
+ * request names none). All three drivers - the single-request client, the load
+ * event loop and the SSE stream consumer - call this, so none of them can
+ * disagree about what goes out.
+ *
+ * @param sent When non-null, cleared and filled with exactly the headers
+ *        appended to the returned list. That is `Response::request_headers`,
+ *        the "sent record" the response pane's Headers tab and a test script's
+ *        `pm.request.headers` read - built from the same appends as the list
+ *        rather than snapshotted beside it, because a snapshot taken
+ *        separately reported headers libcurl had dropped. The load driver
+ *        passes nullptr: it records no sent headers, and building the map per
+ *        transfer would cost the hot path an allocation for nobody.
+ *
+ * @return The header list, which the caller **must** free with
+ *         `curl_slist_free_all` once the transfer has finished, or nullptr
+ *         when the request sends no headers at all.
+ */
+[[nodiscard]] curl_slist* build_request_header_list (const Request& request,
+const std::string& user_agent,
+Headers* sent);
 
 /**
  * @brief Record one "Key: Value" response header line into `headers`.

--- a/engine/include/vayu/http/form_body.hpp
+++ b/engine/include/vayu/http/form_body.hpp
@@ -132,7 +132,7 @@ namespace vayu::http {
  * user who typed it.
  *
  * Only ever a *default*: a Content-Type the caller set wins in both cases
- * (`body_content_type_header`), which is how an explicit
+ * (`body_content_type_value`), which is how an explicit
  * `application/graphql` still reaches the server.
  */
 [[nodiscard]] std::string implied_content_type (const Body& body);

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -361,8 +361,9 @@ Result<Response> Client::send (const Request& request) {
     Response response;
     std::string response_body;
 
-    // Store request headers for response
-    response.request_headers = request.headers;
+    // `request_headers` is the *sent* record and is filled by
+    // build_request_header_list below, from the very appends that build the
+    // slist - see its contract for why it is not snapshotted here.
 
     // Set error buffer
     curl_easy_setopt (curl, CURLOPT_ERRORBUFFER, impl_->error_buffer);
@@ -374,35 +375,9 @@ Result<Response> Client::send (const Request& request) {
     // disagree about what goes on the wire - see apply_method_and_body)
     curl_mime* mime = detail::apply_method_and_body (curl, request);
 
-    // Set headers
-    struct curl_slist* headers_list = nullptr;
-    for (const auto& [key, value] : request.headers) {
-        if (detail::suppresses_request_header (request, key)) {
-            // Not sent, so not reported as sent either - libcurl writes the
-            // multipart Content-Type, boundary and all.
-            response.request_headers.erase (key);
-            continue;
-        }
-        std::string header = key + ": " + value;
-        headers_list       = curl_slist_append (headers_list, header.c_str ());
-    }
-
-    // The Content-Type the body mode implies, when the request declares none.
-    if (std::string content_type = detail::body_content_type_header (request);
-        !content_type.empty ()) {
-        headers_list = curl_slist_append (headers_list, content_type.c_str ());
-        response.request_headers["Content-Type"] =
-        vayu::http::implied_content_type (request.body);
-    }
-
-    // Add User-Agent if not set
-    bool has_user_agent = request.headers.contains ("User-Agent") ||
-    request.headers.contains ("user-agent");
-    if (!has_user_agent) {
-        std::string ua = "User-Agent: " + impl_->config.user_agent;
-        headers_list   = curl_slist_append (headers_list, ua.c_str ());
-        response.request_headers["User-Agent"] = impl_->config.user_agent;
-    }
+    // Set headers, and record the same set as what was sent.
+    struct curl_slist* headers_list = detail::build_request_header_list (
+    request, impl_->config.user_agent, &response.request_headers);
 
     if (headers_list) {
         curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers_list);

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -295,7 +295,7 @@ curl_mime* apply_method_and_body (CURL* curl, const Request& request) {
     return mime;
 }
 
-std::string body_content_type_header (const Request& request) {
+std::string body_content_type_value (const Request& request) {
     const std::string implied = vayu::http::implied_content_type (request.body);
     if (implied.empty ()) {
         return {};
@@ -305,12 +305,60 @@ std::string body_content_type_header (const Request& request) {
     if (request.headers.contains ("Content-Type")) {
         return {};
     }
-    return "Content-Type: " + implied;
+    return implied;
 }
 
 bool suppresses_request_header (const Request& request, const std::string& key) {
     return vayu::http::content_type_is_engine_owned (request.body) &&
     CaseInsensitiveLess::equal (key, "Content-Type");
+}
+
+bool header_value_reaches_wire (std::string_view value) {
+    return std::any_of (value.begin (), value.end (),
+    [] (char c) { return std::isspace (static_cast<unsigned char> (c)) == 0; });
+}
+
+curl_slist* build_request_header_list (const Request& request,
+const std::string& user_agent,
+Headers* sent) {
+    curl_slist* list = nullptr;
+    if (sent != nullptr) {
+        sent->clear ();
+    }
+
+    // Every header goes out through here, so the wire and the sent record are
+    // the same decision made once. A value libcurl would read as a removal is
+    // neither appended nor reported.
+    const auto append = [&] (const std::string& key, const std::string& value) {
+        if (!header_value_reaches_wire (value)) {
+            return;
+        }
+        const std::string line = key + ": " + value;
+        list                   = curl_slist_append (list, line.c_str ());
+        if (sent != nullptr) {
+            (*sent)[key] = value;
+        }
+    };
+
+    for (const auto& [key, value] : request.headers) {
+        if (suppresses_request_header (request, key)) {
+            // Not sent, so not reported as sent either - libcurl writes the
+            // multipart Content-Type, boundary and all.
+            continue;
+        }
+        append (key, value);
+    }
+
+    // The Content-Type the body mode implies, when the request declares none.
+    // Empty when neither holds - which `append` drops, as it drops any
+    // value-less header.
+    append ("Content-Type", body_content_type_value (request));
+
+    if (!request.headers.contains ("User-Agent")) {
+        append ("User-Agent", user_agent);
+    }
+
+    return list;
 }
 
 void ingest_header_line (std::string_view line, Headers& headers) {
@@ -473,29 +521,10 @@ CURL* setup_easy_handle (CURL* curl, TransferData* data, const EventLoopConfig& 
         data->submitted_at + std::chrono::milliseconds (request.stream_bounds->max_duration_ms);
     }
 
-    // Set headers
-    for (const auto& [key, value] : request.headers) {
-        if (suppresses_request_header (request, key)) {
-            continue;
-        }
-        std::string header = key + ": " + value;
-        data->headers_list = curl_slist_append (data->headers_list, header.c_str ());
-    }
-
-    // The Content-Type the body mode implies, when the request declares none.
-    if (std::string content_type = body_content_type_header (request);
-        !content_type.empty ()) {
-        data->headers_list =
-        curl_slist_append (data->headers_list, content_type.c_str ());
-    }
-
-    // Add User-Agent if not set
-    bool has_user_agent = request.headers.contains ("User-Agent") ||
-    request.headers.contains ("user-agent");
-    if (!has_user_agent) {
-        std::string ua = "User-Agent: " + config.user_agent;
-        data->headers_list = curl_slist_append (data->headers_list, ua.c_str ());
-    }
+    // Set headers. No sent record is kept on this path - a load run's captures
+    // record none, and `script_request_header_view` reads the composed map
+    // instead - so the map is not built per transfer.
+    data->headers_list = build_request_header_list (request, config.user_agent, nullptr);
 
     if (data->headers_list) {
         curl_easy_setopt (curl, CURLOPT_HTTPHEADER, data->headers_list);

--- a/engine/src/http/sse_stream.cpp
+++ b/engine/src/http/sse_stream.cpp
@@ -349,7 +349,6 @@ long idle_timeout_seconds (int64_t idle_timeout_ms) {
 
 vayu::Response consume_sse_stream (const SseStreamRequest& request, SseStreamContext& context) {
     vayu::Response response;
-    response.request_headers = request.request.headers;
 
     // The same gate both other drivers apply: a request curl cannot send as
     // written is refused as a status-0 response rather than sent as something
@@ -387,27 +386,8 @@ vayu::Response consume_sse_stream (const SseStreamRequest& request, SseStreamCon
     curl_easy_setopt (curl, CURLOPT_URL, request.request.url.c_str ());
     curl_mime* mime = detail::apply_method_and_body (curl, request.request);
 
-    struct curl_slist* headers_list = nullptr;
-    for (const auto& [key, value] : request.request.headers) {
-        if (detail::suppresses_request_header (request.request, key)) {
-            response.request_headers.erase (key);
-            continue;
-        }
-        const std::string header = key + ": " + value;
-        headers_list = curl_slist_append (headers_list, header.c_str ());
-    }
-    if (std::string content_type = detail::body_content_type_header (request.request);
-        !content_type.empty ()) {
-        headers_list = curl_slist_append (headers_list, content_type.c_str ());
-        response.request_headers["Content-Type"] =
-        vayu::http::implied_content_type (request.request.body);
-    }
-    if (!request.request.headers.contains ("User-Agent") &&
-    !request.request.headers.contains ("user-agent")) {
-        const std::string ua = "User-Agent: " + request.user_agent;
-        headers_list         = curl_slist_append (headers_list, ua.c_str ());
-        response.request_headers["User-Agent"] = request.user_agent;
-    }
+    struct curl_slist* headers_list = detail::build_request_header_list (
+    request.request, request.user_agent, &response.request_headers);
     if (headers_list) {
         curl_easy_setopt (curl, CURLOPT_HTTPHEADER, headers_list);
     }

--- a/engine/tests/echo_server.hpp
+++ b/engine/tests/echo_server.hpp
@@ -115,6 +115,15 @@ class EchoServer {
         return found == headers_.end () ? std::string () : found->second;
     }
 
+    /// Whether the header arrived at all. The distinction {@link header}
+    /// cannot make: an empty-valued header and an absent one both read as
+    /// `""` there, and telling them apart is the whole question when what is
+    /// under test is which headers reached the wire (issue #662).
+    bool has_header (const std::string& name) const {
+        std::lock_guard<std::mutex> lock (mutex_);
+        return headers_.find (name) != headers_.end ();
+    }
+
     /// The request target as received - {@link path} plus the query string,
     /// still percent-encoded. What a test asserts against when the encoding
     /// itself is the point (an api key placed in the query).

--- a/engine/tests/sent_headers_wire_test.cpp
+++ b/engine/tests/sent_headers_wire_test.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @file sent_headers_wire_test.cpp
+ * @brief `Response::request_headers` against the wire it claims to describe
+ *        (issue #662).
+ *
+ * The sent record exists to be trusted about what went out, and it was not:
+ * every driver spells a header `key + ": " + value`, which libcurl reads as an
+ * instruction to *remove* the header when the value is empty - so an enabled
+ * request row with a blank value never reached the wire while the response
+ * pane's Headers tab listed it as sent.
+ *
+ * So the assertions here are paired: what the server received, and what the
+ * record says it received. A record built by any means other than the appends
+ * that build the header list can pass the second half and fail the first.
+ * `has_header` is what makes the first half decidable - a header sent empty
+ * and a header never sent both read as `""`.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "echo_server.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/http/event_loop.hpp"
+#include "vayu/http/sse_stream.hpp"
+
+namespace vayu::http {
+namespace {
+
+using vayu::tests::EchoServer;
+
+Request get_request (const std::string& url) {
+    Request request;
+    request.method     = HttpMethod::GET;
+    request.url        = url;
+    request.timeout_ms = 5000;
+    return request;
+}
+
+class SentHeadersWireTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        server_ = std::make_unique<EchoServer> ();
+        client_ = std::make_unique<Client> ();
+    }
+
+    void TearDown () override {
+        client_.reset ();
+        server_.reset ();
+    }
+
+    std::unique_ptr<EchoServer> server_;
+    std::unique_ptr<Client> client_;
+};
+
+// ---------------------------------------------------------------------------
+// The single-request client - the driver behind POST /execute, and the one
+// whose record the response pane renders.
+// ---------------------------------------------------------------------------
+
+// The premise, stated as a test rather than assumed from libcurl's docs: a
+// value-less header does not reach the server. If libcurl ever started sending
+// it, the filter below would be the wrong fix and this reddens first.
+TEST_F (SentHeadersWireTest, ValuelessHeaderNeverReachesTheWire) {
+    Request request              = get_request (server_->url ());
+    request.headers["X-Blank"]   = "";
+    request.headers["X-Present"] = "kept";
+
+    ASSERT_TRUE (client_->send (request).is_ok ());
+
+    EXPECT_FALSE (server_->has_header ("X-Blank"));
+    EXPECT_EQ (server_->header ("X-Present"), "kept");
+}
+
+// The bug itself. Mutation check: drop the `header_value_reaches_wire` gate in
+// `build_request_header_list` and `X-Blank` is reported as sent again while the
+// assertion above still passes - which is exactly the state this fixes.
+TEST_F (SentHeadersWireTest, ValuelessHeaderIsNotReportedAsSent) {
+    Request request              = get_request (server_->url ());
+    request.headers["X-Blank"]   = "";
+    request.headers["X-Present"] = "kept";
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    const auto& sent = result.value ().request_headers;
+    EXPECT_FALSE (sent.contains ("X-Blank"))
+    << "reported a header libcurl dropped as sent";
+    EXPECT_EQ (sent.at ("X-Present"), "kept");
+}
+
+// libcurl skips the whitespace after the colon before deciding, so a value of
+// spaces alone is a removal too - and a record that only checked for `empty()`
+// would report it as sent.
+TEST_F (SentHeadersWireTest, WhitespaceOnlyValueIsDroppedAndUnreported) {
+    Request request              = get_request (server_->url ());
+    request.headers["X-Spaces"]  = "  \t ";
+    request.headers["X-Present"] = "kept";
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    EXPECT_FALSE (server_->has_header ("X-Spaces"));
+    EXPECT_FALSE (result.value ().request_headers.contains ("X-Spaces"));
+    EXPECT_EQ (server_->header ("X-Present"), "kept");
+}
+
+// The two headers the engine derives at send time stay in the record - the
+// filter drops what libcurl drops, not what the engine adds. `User-Agent` is
+// the one every request gets; a value-bearing header is unaffected.
+TEST_F (SentHeadersWireTest, DerivedAndValueBearingHeadersAreStillReported) {
+    Request request            = get_request (server_->url ());
+    request.headers["X-Trace"] = "abc";
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    const auto& sent = result.value ().request_headers;
+    ASSERT_TRUE (sent.contains ("User-Agent"));
+    EXPECT_EQ (sent.at ("User-Agent"), server_->header ("User-Agent"));
+    EXPECT_EQ (sent.at ("X-Trace"), "abc");
+}
+
+// A request that declares its own User-Agent keeps it - the derived one is a
+// default, not an override, and the record must not gain a second spelling of
+// a header the wire carries once.
+TEST_F (SentHeadersWireTest, ADeclaredUserAgentWinsOverTheDefault) {
+    Request request               = get_request (server_->url ());
+    request.headers["User-Agent"] = "test-agent/1.0";
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    EXPECT_EQ (server_->header ("User-Agent"), "test-agent/1.0");
+    EXPECT_EQ (result.value ().request_headers.at ("User-Agent"), "test-agent/1.0");
+}
+
+// The multipart Content-Type rule is untouched by the filter: it is suppressed
+// because libcurl writes it with the boundary, not because it is value-less,
+// and both reasons run through the same builder now.
+TEST_F (SentHeadersWireTest, MultipartContentTypeIsStillSuppressed) {
+    Request request                 = get_request (server_->url ());
+    request.method                  = HttpMethod::POST;
+    request.body.mode               = BodyMode::FormData;
+    request.body.fields             = { { "a", "1", true } };
+    request.headers["Content-Type"] = "multipart/form-data";
+
+    auto result = client_->send (request);
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+
+    EXPECT_TRUE (
+    server_->content_type ().starts_with ("multipart/form-data; boundary="))
+    << server_->content_type ();
+    EXPECT_FALSE (result.value ().request_headers.contains ("Content-Type"));
+}
+
+// ---------------------------------------------------------------------------
+// The other two drivers. All three build their header list through
+// `build_request_header_list`, and these prove the sharing is real: a driver
+// that kept its own loop would still send the value-less header here.
+// ---------------------------------------------------------------------------
+
+TEST_F (SentHeadersWireTest, LoadDriverDropsTheSameHeader) {
+    EventLoop loop;
+    loop.start ();
+
+    Request request              = get_request (server_->url ());
+    request.headers["X-Blank"]   = "";
+    request.headers["X-Present"] = "kept";
+    auto result                  = loop.submit_async (request).future.get ();
+    loop.stop ();
+
+    ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+    EXPECT_FALSE (server_->has_header ("X-Blank"));
+    EXPECT_EQ (server_->header ("X-Present"), "kept");
+}
+
+TEST_F (SentHeadersWireTest, StreamConsumerDropsTheSameHeaderAndReportsTheTruth) {
+    SseStreamRequest stream_request;
+    stream_request.run_id                       = "run-sent-headers";
+    stream_request.request                      = get_request (server_->url ());
+    stream_request.request.headers["X-Blank"]   = "";
+    stream_request.request.headers["X-Present"] = "kept";
+    // The echo endpoint answers JSON and closes, which is a stream of zero
+    // events - all this test needs, since the headers go out before the first
+    // byte comes back.
+    SseStreamContext context (stream_request.run_id, stream_request.limits);
+
+    const vayu::Response response = consume_sse_stream (stream_request, context);
+
+    EXPECT_FALSE (server_->has_header ("X-Blank"));
+    EXPECT_EQ (server_->header ("X-Present"), "kept");
+    EXPECT_FALSE (response.request_headers.contains ("X-Blank"))
+    << "the stream consumer reported a header libcurl dropped as sent";
+    EXPECT_EQ (response.request_headers.at ("X-Present"), "kept");
+}
+
+} // namespace
+} // namespace vayu::http

--- a/engine/tests/xml_body_test.cpp
+++ b/engine/tests/xml_body_test.cpp
@@ -10,7 +10,7 @@
  * on "it parses", because a re-serialization that normalized the declaration or
  * collapsed the whitespace would still parse and would still be wrong; the
  * derived header is asserted at the socket, because the rule that skips it when
- * the caller set one lives two functions away (`body_content_type_header`).
+ * the caller set one lives two functions away (`body_content_type_value`).
  *
  * Both drivers are exercised - the design-run `Client::send` and the load-run
  * `EventLoop` - for the reason the sibling modes are: they share


### PR DESCRIPTION
## Description

**Decision recorded for the issue: option 1, report the truth.** The sent-headers record is corrected to match the wire; the wire is not changed to match the record. Most APIs do not distinguish `X-Foo:` (empty) from absent, the Params-table model already writes a bare key for an empty value, and emitting libcurl's `X-Foo;` spelling would be a wire-behaviour change nobody asked for.

**Plan.** Root cause: each of the three drivers built its `CURLOPT_HTTPHEADER` list and *separately* snapshotted `Response::request_headers` beside it (`client.cpp` copied `request.headers` before the loop and erased only the multipart `Content-Type`; `sse_stream.cpp` did the same). Two records of one decision, so they could disagree - and they did, because libcurl reads `Key:` with nothing after the colon as *remove this header*, and the engine spells every header `key + ": " + value`. Approach: one shared `build_request_header_list` that both appends to the slist and fills the sent record from those same appends, so a header libcurl drops is neither sent nor reported. Rejected alternative: post-filtering each transport's existing snapshot by the same rule - it works, but leaves three copies of the decision in place, which is what produced the bug; the issue's own fix pathway calls for the shared helper.

Verified the problem still exists as described before touching anything - the anchors in the issue were all accurate at `53e124f`.

### What changed

- **`detail::header_value_reaches_wire(value)`** - the libcurl rule, stated once: a value that is empty *or only whitespace* is a removal, because libcurl skips the whitespace after the colon before deciding.
- **`detail::build_request_header_list(request, user_agent, sent)`** - the one place a driver's outbound header set is decided: the request's headers minus the suppressed and the value-less, plus the body-implied `Content-Type` and the default `User-Agent`. All three drivers call it. `sent` is nullable; the load event loop passes `nullptr` because it records no sent headers, so the hot path builds no map per transfer.
- `body_content_type_header` -> **`body_content_type_value`** (the builder composes the line now), which also removes the `implied_content_type` re-derivation that was copy-pasted at each snapshot site.
- The redundant lower-case `user-agent` lookups are gone - `Headers` is `std::map<..., CaseInsensitiveLess>` and has been throughout.

### Blast radius, traced

`Response::request_headers` has three consumers, all now consistent with the wire: the response pane's Headers tab (`HeadersViewer`, via `execute-mapping.ts`), a test script's `pm.request.headers` (`script_request_header_view`), and `requestHeaders` in the MCP execute result. No app change was needed - the renderer renders whatever the engine reports, and nothing in Vayu was filtering these rows (confirmed at `key-value.ts:26` and `request_composer.cpp:442`).

**Deliberate non-change, worth stating:** the event-loop transport keeps no sent record *at all* (`script_request_header_view` documents why its fallback to the composed map is load-bearing). There is therefore nothing false for it to report, and seeding one would change that documented fallback - out of scope here. The shared builder still makes its wire behaviour provably identical, which `LoadDriverDropsTheSameHeader` pins.

**Adjacent, deliberately not in this diff** (filed as a follow-up): a *restored* response rebuilds its "sent" headers from `trace.request.headers`, which `build_result_trace` stores as the **composed** map by design - so the restored panel has a related-but-different divergence.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev` - **1753/1753 passed**, no pre-existing failures on this base.

New file `engine/tests/sent_headers_wire_test.cpp` (8 tests, all passing) asserts the wire and the record *in pairs*, since a record built any other way can satisfy one and not the other. `EchoServer` gains `has_header` - `header()` returns `""` for both "sent empty" and "never sent", and telling those apart is the entire question.

**Mutation check**, run for real rather than reasoned about: replacing `header_value_reaches_wire` with `return true` turns 4 of the 8 red -

```
837 - ValuelessHeaderIsNotReportedAsSent            (Failed)
838 - WhitespaceOnlyValueIsDroppedAndUnreported     (Failed)
841 - MultipartContentTypeIsStillSuppressed         (Failed)
843 - StreamConsumerDropsTheSameHeaderAndReportsTheTruth (Failed)
```

while `ValuelessHeaderNeverReachesTheWire` and `LoadDriverDropsTheSameHeader` stay green - correct, those pin the premise (libcurl really does drop it) rather than the fix, and they are what reddens first if libcurl's behaviour ever changes.

No app files changed, so the app suite could not change colour and was not run. `mkdocs` is not installed in this environment, so `mkdocs build --strict` was not run; the docs edits add prose to existing paragraphs and introduce no new links, anchors or nav entries.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`clang-format` was applied to the new test file and to the new lines only - `client.cpp` and `curl_utils.cpp` were already not clang-format-clean on `master`, and CLAUDE.md forbids reformatting them wholesale.

Docs updated in the same commit: `docs/engine/api-reference.md` (the `requestHeaders` sent-record contract), `docs/engine/scripting.md` (a fourth consequence for `pm.request.headers` - setting a header to `''` in a pre-request script removes it rather than blanking it), `docs/engine/mcp.md`, plus the two comments that named `body_content_type_header`.

## Related Issues
Closes #662

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWErpQnhJ9GzXSqC5K3nx8)_