### PR TITLE
fix(app/engine/trace): a restored response's sent-headers panel shows what was sent

### DIFF
--- a/app/src/modules/request-builder/utils/restore-response.test.ts
+++ b/app/src/modules/request-builder/utils/restore-response.test.ts
@@ -150,8 +150,8 @@ describe("responseFromRunResult", () => {
 		);
 
 		expect(restored?.rawRequest).toBe(wire);
-		// The composed map is still what the Headers tab shows - it is the
-		// engine's own sent record, and the two panes are not the same view.
+		// A row with no `sentHeaders` still falls back to the composed map, so
+		// the raw preference and the header preference are independent.
 		expect(restored?.requestHeaders).toEqual({ Accept: "application/json" });
 	});
 
@@ -180,6 +180,77 @@ describe("responseFromRunResult", () => {
 				"Accept: application/json\r\n" +
 				"\r\n"
 		);
+	});
+
+	/**
+	 * The gap issue #664 closed, one field over from #348. The panel this feeds
+	 * is labelled as what was sent, and `trace.request.headers` is the
+	 * *composed* request: it names an empty-valued header libcurl dropped and a
+	 * `form-data` `Content-Type` libcurl rewrote with its boundary, and it is
+	 * missing the body-implied `Content-Type` and the default `User-Agent` the
+	 * engine derives at send time - which the live panel showed. The engine now
+	 * stores the sent record it already had.
+	 *
+	 * Mutation-check: drop the `request.sentHeaders ||` preference in `sentSide`
+	 * and every assertion in this test fails.
+	 */
+	it("prefers the stored sent record over the composed map for the sent panel", () => {
+		const restored = responseFromRunResult(
+			sample({
+				trace: {
+					request: {
+						method: "POST",
+						url: "https://api.example.test/upload",
+						headers: {
+							"Content-Type": "multipart/form-data",
+							"X-Blank": "",
+							accept: "application/json",
+						},
+						sentHeaders: {
+							accept: "application/json",
+							"Content-Type": "multipart/form-data; boundary=------abc123",
+							"User-Agent": "vayu/0.17.0",
+						},
+					},
+					response: { headers: {}, body: "{}" },
+				},
+			})
+		);
+
+		// Exhaustive, so all three drifts fail here at once: the derived
+		// `User-Agent` the composed map lacks, the boundary libcurl added to the
+		// multipart `Content-Type`, and the value-less `X-Blank` that never
+		// reached the wire.
+		expect(restored?.requestHeaders).toEqual({
+			accept: "application/json",
+			"Content-Type": "multipart/form-data; boundary=------abc123",
+			"User-Agent": "vayu/0.17.0",
+		});
+	});
+
+	/**
+	 * Absent-not-empty, the same contract `rawRequest` has: a run recorded
+	 * before #664 - and a step that sent nothing, whose response carries no sent
+	 * record either - restores exactly as it does today.
+	 */
+	it("falls back to the composed map when the row predates the stored sent record", () => {
+		const restored = responseFromRunResult(
+			sample({
+				trace: {
+					request: {
+						method: "GET",
+						url: "https://api.example.test/users",
+						headers: { Accept: "application/json", "X-Trace": "abc" },
+					},
+					response: { headers: {}, body: "{}" },
+				},
+			})
+		);
+
+		expect(restored?.requestHeaders).toEqual({
+			Accept: "application/json",
+			"X-Trace": "abc",
+		});
 	});
 
 	/**

--- a/app/src/modules/request-builder/utils/restore-response.ts
+++ b/app/src/modules/request-builder/utils/restore-response.ts
@@ -154,13 +154,27 @@ function detectBodyType(body: string): ResponseState["bodyType"] {
  * path, see execution.cpp) - so a run that never reached a server has nothing
  * here, and `buildRawRequest` falls back to its own HTTP/1.1 default, the same
  * as a pre-migration stored row.
+ *
+ * `trace.request.sentHeaders` is the same preference one field over, for the
+ * structured map (issue #664). The panel this fills is labelled as what was
+ * sent, and `headers` is the *composed* request: it names a value-less header
+ * libcurl dropped and a `form-data` `Content-Type` it wrote itself, and it is
+ * missing the body-implied `Content-Type` and default `User-Agent` the engine
+ * derives - so the live and restored panels disagreed about one exchange. The
+ * composed map stays as the fallback for the rows written before the field, and
+ * stays in the trace because `design-run-seed.ts` reseeds a request tab from
+ * it, which is a different question with a different right answer.
+ *
+ * `buildRawRequest` below is still handed `headers`, not the sent record: it
+ * synthesizes a wire message for a row that stored none, and every such row
+ * predates both fields.
  */
 function sentSide(trace: NonNullable<RunResultSample["trace"]>) {
 	const request = trace.request;
 	if (!request) return { requestHeaders: {}, rawRequest: undefined };
 
 	return {
-		requestHeaders: request.headers || {},
+		requestHeaders: request.sentHeaders || request.headers || {},
 		rawRequest:
 			request.rawRequest ||
 			buildRawRequest(

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -766,6 +766,22 @@ export interface RunResultTrace {
 		 * header block is never cut.
 		 */
 		rawRequest?: string;
+		/**
+		 * What the transfer actually issued - `build_result_trace`'s copy of the
+		 * live response's `requestHeaders` (issue #664), which is `headers`
+		 * minus the suppressed and value-less entries plus the two the engine
+		 * derives at send time (the body-implied `Content-Type`, the default
+		 * `User-Agent`).
+		 *
+		 * This is the map the response pane's "sent" disclosure means;
+		 * `headers` beside it is the *composed* request and stays because
+		 * `design-run-seed.ts` reseeds a request tab from it. Absent on rows
+		 * written before the field and on a step that sent nothing, which is
+		 * why `restore-response.ts`'s `sentSide` keeps `headers` as its
+		 * fallback. Values are **not redacted** - same contract as
+		 * `rawRequest`.
+		 */
+		sentHeaders?: Record<string, string>;
 	};
 	response?: {
 		headers?: Record<string, string>;

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2634,6 +2634,19 @@ does not carry libcurl's own additions or the jar's `Cookie` line; those are
 (see [scripting.md](scripting.md#request-object-pmrequest)), so an assertion
 about what went out and the response pane's Headers tab cannot disagree.
 
+**The stored trace keeps this map too**, as `trace_data.request.sentHeaders`
+beside the composed `request.headers` (issue #664) - so a restored response
+pane's sent-headers disclosure shows the set the live one showed, derived
+`User-Agent` and body-implied `Content-Type` included, rather than the composed
+map's different answer. Both maps are stored because they answer different
+questions: the composed one is what a *pre-request* script saw and what reseeds
+a request tab from a run. The key is **absent** on a step that sent nothing and
+on every row written before the field, so a reader falls back to
+`request.headers` - `restore-response.ts`'s `sentSide` is that reader. A load
+run's sampled capture records no sent headers at all and is unaffected: its
+deferred replay keeps reading the composed map, as
+[scripting.md](scripting.md#request-object-pmrequest) documents.
+
 Values in `rawRequest` are not redacted:
 this field exists to say exactly what went out. On a followed redirect it is the
 final hop, matching the response beside it. A transfer that failed before

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -958,9 +958,10 @@ data/
   stores the uncomposed URL - a composed plan carries resolved `Authorization`
   headers and an `apikey` in the query string, and persisting one would route
   around that allowlist. `results.trace_data` records what was **sent**, which
-  is the only thing it is for: it stores the resolved request headers, and since
-  issue #348 the wire message itself (`request.rawRequest`, the `Cookie` line
-  included). Both are credential-grade, both are plaintext under the v1 posture
+  is the only thing it is for: it stores the resolved request headers - both as
+  composed and, since issue #664, as the transfer issued them
+  (`request.sentHeaders`) - and since issue #348 the wire message itself
+  (`request.rawRequest`, the `Cookie` line included). Both are credential-grade, both are plaintext under the v1 posture
   above, and a trace that hid what went out would have no reason to exist. What
   bounds their lifetime is run retention (`maxRuns` / the prune pass), not the
   process - so clearing the cookie jar does not clear the runs that recorded it.

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -751,6 +751,20 @@ sent nothing (a `pm.execution.skipRequest()`) and on every row written before #3
 falls back to rebuilding the view from `method`/`url`/`headers`/`body` -
 `restore-response.ts`'s `sentSide` is that reader.
 
+The `request` node carries a second header map, **`sentHeaders`** - the record of what the
+transfer issued, the same map the live [`POST /execute`](api-reference.md#post-execute) response
+returns as `requestHeaders` (issue #664). It is `headers` minus the entries the transfer
+suppresses (a `form-data` `Content-Type`, which libcurl writes itself with the boundary) and the
+value-less ones libcurl drops, plus the two the engine derives at send time: the body-implied
+`Content-Type` and the default `User-Agent`. Both maps are stored because both are read, and they
+answer different questions - `sentHeaders` is what the response pane's sent-headers disclosure
+means, while `headers` is the request as *composed*, which is what a pre-request script saw and
+what `design-run-seed.ts` reseeds a request tab from. Values are **not redacted**, same contract
+as `rawRequest` beside it. The key is **absent** on a step that sent nothing and on every row
+written before #664, so a reader falls back to `headers`. The load-run writers store no sent
+record at all - the load driver passes `nullptr` for it, to keep an allocation off the hot path -
+so a sampled capture's replay reads the composed map either way.
+
 The design-mode `request.body` and `response.body` are **capped at `maxTraceBodyBytes`**
 (config, `observability`, default 5 MiB) before storage, so downloading one 50 MB response does
 not live in SQLite forever. `request.rawRequest` ends with that same body and is capped to the

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -47,6 +47,33 @@ const vayu::Response& response) {
         trace["request"]["body"] = request.body.content;
     }
 
+    // The *sent* record, beside the composed map (issue #664). `headers` above
+    // is what the request was composed with; `response.request_headers` is what
+    // `build_request_header_list` appended - that set minus the suppressed
+    // (a `form-data` Content-Type libcurl writes itself) and the value-less
+    // (issue #662), plus the two the engine derives at send time, the
+    // body-implied `Content-Type` and the default `User-Agent`. The response
+    // pane's "request headers sent" disclosure means the second, and rebuilding
+    // it from the first named headers the wire never carried and hid the two it
+    // did - so the same exchange read differently live and after a reload.
+    //
+    // Both maps are stored because both are read: `design-run-seed.ts` reseeds
+    // a request tab from the composed one, and reseeding from the sent record
+    // would write the engine's derived headers back into the user's request as
+    // if a person had typed them.
+    //
+    // Omitted rather than stored empty when nothing was recorded, on the same
+    // reasoning as `rawRequest` below: the reader prefers this key when it is
+    // there, so an empty object would suppress the composed-map fallback that
+    // is the right answer for a step that sent nothing and for every row
+    // written before this field. The load path records no sent headers at all -
+    // `build_request_header_list` takes nullptr there, to keep an allocation
+    // off the hot path - so a sampled capture keeps replaying from the composed
+    // map, unchanged by this.
+    if (!response.request_headers.empty ()) {
+        trace["request"]["sentHeaders"] = response.request_headers;
+    }
+
     // What the wire carried, so a restored raw-request view says the same thing
     // the live one did (issue #348). `headers` above is the *composed* map and
     // has no `Cookie` line - libcurl attaches those itself from the jar - so

--- a/engine/tests/execution_trace_test.cpp
+++ b/engine/tests/execution_trace_test.cpp
@@ -167,9 +167,82 @@ TEST (ExecutionTrace, StoresTheWireRequestBesideTheComposedHeaders) {
                "Cookie: session=abc123"),
     std::string::npos);
 
-    // The composed map is unchanged - it is the *sent record*, not the wire,
-    // and the two are deliberately different views (api-reference.md).
+    // The composed map is unchanged - it is neither the wire nor the sent
+    // record, and the three are deliberately different views
+    // (api-reference.md).
     EXPECT_FALSE (trace["request"]["headers"].contains ("Cookie"));
+}
+
+// The sent record, stored beside the composed map (issue #664). Before it, the
+// restored response pane rebuilt its "headers sent" disclosure from the
+// composed map and so disagreed with the live pane about the same exchange:
+// the live one reads `Response::request_headers`, which is what
+// `build_request_header_list` appended.
+vayu::Request make_multipart_request () {
+    vayu::Request request;
+    request.method = vayu::HttpMethod::POST;
+    request.url    = "http://127.0.0.1/upload";
+    // Composed, but not sent: libcurl writes the multipart Content-Type itself
+    // with the boundary, and a value-less header is libcurl's spelling for
+    // "remove this one" (issue #662).
+    request.headers["Content-Type"] = "multipart/form-data";
+    request.headers["X-Blank"]      = "";
+    request.headers["accept"]       = "application/json";
+    return request;
+}
+
+// What build_request_header_list would have recorded for that request: the
+// survivors, plus the two the engine derives at send time.
+vayu::Response make_response_with_sent_headers () {
+    auto response                      = make_response ();
+    response.request_headers["accept"] = "application/json";
+    response.request_headers["Content-Type"] =
+    "multipart/form-data; boundary=------abc123";
+    response.request_headers["User-Agent"] = "vayu/0.17.0";
+    return response;
+}
+
+TEST (ExecutionTrace, StoresTheSentHeadersBesideTheComposedMap) {
+    auto trace = build_result_trace (
+    make_multipart_request (), make_response_with_sent_headers ());
+
+    ASSERT_TRUE (trace["request"].contains ("sentHeaders"));
+    const auto& sent = trace["request"]["sentHeaders"];
+
+    // The two the composed map structurally cannot answer for.
+    EXPECT_EQ (sent["User-Agent"], "vayu/0.17.0");
+    EXPECT_EQ (sent["Content-Type"], "multipart/form-data; boundary=------abc123");
+    // The one the wire dropped is not reported as sent.
+    EXPECT_FALSE (sent.contains ("X-Blank"));
+
+    // And the composed map is still stored, unchanged: design-run-seed.ts
+    // reseeds a request tab from it, and seeding it from the sent record would
+    // write the engine's derived headers back as if a person had typed them.
+    EXPECT_EQ (trace["request"]["headers"]["X-Blank"], "");
+    EXPECT_EQ (trace["request"]["headers"]["Content-Type"], "multipart/form-data");
+}
+
+// Same invariant style as the timing and rawRequest tests above: what
+// serialize(Response) puts on the live /execute wire is what the stored trace
+// carries, so the live and restored Headers tabs cannot drift apart again.
+TEST (ExecutionTrace, StoredSentHeadersMatchTheLiveWireKey) {
+    auto response = make_response_with_sent_headers ();
+
+    auto trace = build_result_trace (make_multipart_request (), response);
+    auto live  = vayu::json::serialize (response);
+
+    EXPECT_EQ (trace["request"]["sentHeaders"], live["requestHeaders"]);
+}
+
+// Omitted, not stored empty - for the reason the rawRequest omission has: the
+// reader prefers this key when present, so an empty object would suppress the
+// composed-map fallback that is the right answer both for a step that sent
+// nothing and for every row written before the field. A load run's deferred
+// replay is the same shape: it records no sent headers at all.
+TEST (ExecutionTrace, OmitsSentHeadersWhenNothingWasRecorded) {
+    auto trace = build_result_trace (make_multipart_request (), make_response ());
+
+    EXPECT_FALSE (trace["request"].contains ("sentHeaders"));
 }
 
 // The same invariant style as the timing and httpVersion tests above: what


### PR DESCRIPTION
## Description

**Decision recorded for the issue: option 1 - store the sent record too.** Option 2 (relabel the restored panel as "composed") is cheaper but leaves two panels under one label meaning different things, and the panel exists precisely to answer "what went out".

**Plan.** Root cause, verified against `8a9a494` before touching anything (the anchors held - `request_exchange.cpp:44` and `restore-response.ts:163`): `build_result_trace` stores `trace["request"]["headers"] = request.headers`, the **composed** map, and `sentSide()` maps it straight into `requestHeaders`, which `ResponseViewer` -> `ResponseHeadersPanel` renders under the "request headers sent" disclosure that the live path fills from `Response::request_headers`. Two different records, one label. Approach: store the sent record beside the composed one as `request.sentHeaders`, written from the `Response::request_headers` that `build_request_header_list` fills **from the very appends that build libcurl's header list** - so there is exactly one definition of "sent" and the live panel, `pm.request.headers` and the restored panel all read it. **Rejected alternative:** replacing `headers` with the sent record rather than adding beside it. That would have been a second bug: `design-run-seed.ts` reseeds a request tab from `trace.request.headers`, and seeding it from the sent record would write the engine's derived `User-Agent` and body-implied `Content-Type` back into the user's request as if a person had typed them.

### Engine

- **`trace.request.sentHeaders`** (`build_result_trace`, `http/request_exchange.cpp`) - `Response::request_headers`, which is the composed set minus the suppressed (a `form-data` `Content-Type` libcurl writes itself with the boundary) and the value-less (#662), plus the two the engine derives at send time.
- **Absent, not empty**, on the same reasoning `rawRequest` beside it already uses: the reader prefers this key when present, so `{}` would suppress the composed-map fallback that is the right answer both for a `pm.execution.skipRequest()` step and for every row written before the field. No migration and no backfill - it is a JSON node inside `results.trace_data`.
- Written **before** the success/error split, so a transfer that failed after `Client::send` recorded its headers still restores the attempt it made - the same posture `rawRequest` has on that path.

### App

- **`sentSide()`** prefers `request.sentHeaders`, falling back to `request.headers` - the identical shape to the `rawRequest || buildRawRequest(...)` fallback one line down, for the identical reason. `buildRawRequest` is still handed the composed map: it synthesizes a wire message only for rows that stored none, and every such row predates both fields.
- **`domain.ts`** gains the field with the contract on it (what it is, why `headers` stays, why it can be absent, that values are not redacted).

### The load path, deliberately unchanged

Stated here rather than left implied, as the issue asks. A load run records **no** sent headers at all - `build_request_header_list` takes `nullptr` on that driver, to keep a per-transfer allocation off the hot path - so a sampled capture's deferred replay keeps reading the composed map through `script_request_header_view`'s documented fallback. Extending the sent record to samples is a separate decision with its own cost (a per-completion map on the hot path, and a column to store it in); nothing in this diff forecloses it.

### Blast radius, traced

`trace.request.headers` has three readers in the app, `rg`'d rather than assumed: `sentSide` (this bug), `design-run-seed.ts:119` (reseeding a request tab - correctly wants the composed map, untouched), and `SampleRequestCard.tsx`, whose comment records that it *stopped* reading it. `build_result_trace` has two callers - `execution.cpp`'s `store_result` and `scenario_runner.cpp`'s per-step record - and both get the field, which is right: a scenario run's step rows restore through the same reader. `cap_trace_bodies` walks the `body` and `rawRequest` nodes only and does not touch this one; nothing caps or redacts headers on either path today.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **1775/1775 passed** (1772 on the base; the three new ones are the difference). `pnpm test` - **4963/4963 passed** (474 files). `pnpm type-check` and `pnpm lint` clean; `prettier --check` clean over the app files I touched, and `clang-format` (18, matching the repo style on this file - it reports no diff on the untouched base) applied to the engine test file. No pre-existing failures on this base.

New: 3 tests in `engine/tests/execution_trace_test.cpp` and 2 in `app/src/modules/request-builder/utils/restore-response.test.ts`.

**Mutation checks, run for real rather than reasoned about:**

| Reverted | What reddened |
|---|---|
| the `sentHeaders` write in `build_result_trace` | `ExecutionTrace.StoresTheSentHeadersBesideTheComposedMap`, `ExecutionTrace.StoredSentHeadersMatchTheLiveWireKey` (2 of 3 - `OmitsSentHeadersWhenNothingWasRecorded` asserts the key is absent and correctly stayed green) |
| the `request.sentHeaders \|\|` preference in `sentSide` | `prefers the stored sent record over the composed map for the sent panel`, alone in a file of 30 |

Both were restored and the suites re-run green.

Worth calling out among the engine tests: `StoredSentHeadersMatchTheLiveWireKey` compares the stored node against `serialize(response)["requestHeaders"]` - the same invariant style the timing and `rawRequest` tests use, so the live Headers tab and the restored one cannot drift apart again without a red test.

`mkdocs build --strict` was **not** run - mkdocs is not installed in this environment. The docs edits add prose to existing pages and introduce no new page, nav entry or heading anchor; the two cross-links used (`scripting.md#request-object-pmrequest`, `api-reference.md#post-execute`) already appear on the pages they were added to.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/api-reference.md` (the stored trace carries the sent map, and which of the two a restored view reads), `docs/engine/db-schema.md` (the `sentHeaders` node, how it differs from `headers`, and why the load writers have none), `docs/engine/architecture.md` (the Security paragraph enumerating what `results.trace_data` stores).

## Related Issues

Closes #664.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwfKKbcrarDZxCfrnsADkU)_