### PR TITLE
fix(engine/build): compile response_capture_test.cpp, and fail the build on any unregistered test file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,13 @@ ctest --test-dir engine/build -V
 
 #### Writing Tests
 
+A new `engine/tests/*_test.cpp` must be added to the `add_executable(vayu_tests ...)`
+source list in `engine/CMakeLists.txt`. The list is explicit, not a glob, so an
+unregistered file is simply never compiled and its tests never run - which is
+silent, because a file that is not built produces no output. A configure-time
+guard fails the build naming any test file missing from the list, so you find
+out on your next build rather than never.
+
 ```cpp
 #include <gtest/gtest.h>
 #include "vayu/http/client.hpp"

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -268,6 +268,22 @@ ctest -V
 ./vayu_tests
 ```
 
+### Test files are registered, and the build checks it
+
+The `vayu_tests` sources are listed one by one in `engine/CMakeLists.txt`
+rather than globbed, so the set of files that gets built is visible in the
+diff. The cost of that is a file which is added to `engine/tests/` and never
+listed: it compiles into nothing, runs nothing, and says nothing about it -
+`response_capture_test.cpp` sat unbuilt for ~140 commits that way, and one of
+its assertions had been wrong since the day it was written (issue #668).
+
+A guard beside the source list globs `tests/*_test.cpp` and fails configure
+naming any file the list is missing. The glob is only the check - it never
+becomes the source list - and it is declared `CONFIGURE_DEPENDS`, so adding a
+file re-runs the check on the next `ninja` rather than waiting for someone to
+reconfigure. The guard also fails if the glob matches nothing at all, since a
+check that scans an empty set passes for the wrong reason.
+
 ## Development Tips
 
 ### Faster Rebuilds

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -23,6 +23,11 @@ engine/
 - Install the git pre-commit hook: `bash scripts/install-git-hooks.sh`
 - vcpkg manages all C++ dependencies - do not add one without updating
   `engine/vcpkg.json`
+- A new `tests/*_test.cpp` must be listed in `add_executable(vayu_tests ...)`
+  in `engine/CMakeLists.txt` - the source list is explicit, never a glob. A
+  guard beside it fails configure naming any unregistered file, because an
+  unbuilt test file reports nothing at all (#668: a 16-test suite sat unbuilt
+  for ~140 commits).
 - A fixture that opens a scratch `Database` cleans up with
   `vayu::tests::remove_database_files` (`engine/tests/temp_database.hpp`) - never
   a hand-written suffix list. An opened database writes six files, not the four

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -481,6 +481,7 @@ if(VAYU_BUILD_TESTS)
         tests/refill_deficit_test.cpp
         tests/reservoir_test.cpp
         tests/sample_capture_test.cpp
+        tests/response_capture_test.cpp
         tests/load_pacing_test.cpp
         tests/threshold_eval_test.cpp
         tests/capacity_controller_test.cpp
@@ -551,7 +552,48 @@ if(VAYU_BUILD_TESTS)
         src/http/routes/health.cpp
         src/http/server.cpp
     )
-    
+
+    # A *_test.cpp that is on disk but absent from the list above is compiled
+    # into nothing and reports nothing - no output, no failure, just a suite
+    # count that quietly never included it. response_capture_test.cpp sat that
+    # way for ~140 commits and its 16 tests never ran once (#668). This is the
+    # "assert you scanned something non-empty" rule applied to the build: the
+    # glob is a *check* against the explicit list, never a substitute for it,
+    # so nothing about how the target is built becomes order-dependent or
+    # invisible in the diff. CONFIGURE_DEPENDS re-runs the glob when the
+    # directory changes, so the failure lands on whoever adds the file rather
+    # than on whoever notices years later.
+    file(GLOB vayu_test_files_on_disk CONFIGURE_DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/*_test.cpp")
+    if(NOT vayu_test_files_on_disk)
+        message(FATAL_ERROR
+            "Test registration guard found no tests/*_test.cpp under "
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests - the guard is scanning the "
+            "wrong place and would pass no matter what is missing.")
+    endif()
+    get_target_property(vayu_registered_test_sources vayu_tests SOURCES)
+    set(vayu_registered_test_paths "")
+    foreach(source IN LISTS vayu_registered_test_sources)
+        if(NOT IS_ABSOLUTE "${source}")
+            set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
+        endif()
+        list(APPEND vayu_registered_test_paths "${source}")
+    endforeach()
+    set(vayu_unregistered_tests "")
+    foreach(test_file IN LISTS vayu_test_files_on_disk)
+        if(NOT test_file IN_LIST vayu_registered_test_paths)
+            file(RELATIVE_PATH relative_test_file "${CMAKE_CURRENT_SOURCE_DIR}" "${test_file}")
+            list(APPEND vayu_unregistered_tests "${relative_test_file}")
+        endif()
+    endforeach()
+    if(vayu_unregistered_tests)
+        string(REPLACE ";" "\n  " vayu_unregistered_tests "${vayu_unregistered_tests}")
+        message(FATAL_ERROR
+            "These test files exist but are not in add_executable(vayu_tests ...), "
+            "so none of their tests would run:\n  ${vayu_unregistered_tests}\n"
+            "Add them to the source list in engine/CMakeLists.txt.")
+    endif()
+
     # The cross-language conformance fixture lives in the source tree and is
     # read at test runtime by path (the app's vitest suite reads the same file),
     # so the tests need to know where the sources are regardless of the build

--- a/engine/tests/response_capture_test.cpp
+++ b/engine/tests/response_capture_test.cpp
@@ -461,7 +461,12 @@ TEST_F (ResponseCaptureTest, SamplesEndpointPaginatesAndFourOhFours) {
     auto [missing_status, missing] =
     vayu::http::routes::run_samples_response (*db_, "no_such_run", 50, 0);
     EXPECT_EQ (missing_status, 404);
-    EXPECT_EQ (missing["error"]["code"].get<int> (), 404);
+    // The shared error shape (#173) carries a per-status *slug*, not the
+    // numeric status - `error_shape_route_test.cpp` pins the table this route
+    // reads through. The assertion here asked for a number, which threw rather
+    // than failed, and no one saw it because the file was never compiled (#668).
+    EXPECT_EQ (missing["error"]["code"], "not_found");
+    EXPECT_FALSE (missing["error"]["message"].get<std::string> ().empty ());
 }
 
 // A run that captured nothing is an empty page, not an error - the Samples tab


### PR DESCRIPTION
## Description

**Plan.** Root cause, verified against `8a9a494` before touching anything (the anchor held): `engine/tests/response_capture_test.cpp` is on disk, is 470+ lines, and defines **16** tests - and `add_executable(vayu_tests ...)` in `engine/CMakeLists.txt` is an explicit list with no `GLOB`, so the file was never a translation unit. `ctest -N | grep -c ResponseCapture` returned `0`, and nothing anywhere reported it: a source file that is not compiled produces no output, no failure and no count. Approach: register the file, run it, fix what the run turns up, and add a configure-time guard that checks the glob of `tests/*_test.cpp` against the target's own `SOURCES` so the next unregistered file fails the build naming itself. **Rejected alternative:** the one-line fix - just adding the source line. It closes this instance and leaves the class open, which is precisely how this one survived ~140 commits; the issue says the same. **Also rejected:** replacing the explicit list with the glob. That would make the guard unnecessary by making the set of built files invisible in the diff and order-dependent across platforms - the glob stays a *check*, never the source list.

### The registration guard

- Globs `tests/*_test.cpp` with **`CONFIGURE_DEPENDS`**, compares against `get_target_property(... vayu_tests SOURCES)` (normalised to absolute paths, so it does not care how an entry was spelled), and `FATAL_ERROR`s naming every file the list is missing.
- **An empty glob is itself a failure.** This is CLAUDE.md's "a source-scanning guard must assert it scanned something non-empty" rule applied to the build - a guard pointed at the wrong directory would otherwise pass forever, which is the exact shape of the bug it exists to prevent.
- `CONFIGURE_DEPENDS` is what makes it land on the right person: adding a file re-runs the glob on the next `ninja` rather than waiting for someone to reconfigure for unrelated reasons.

### The one aged assertion, corrected rather than deleted

`SamplesEndpointPaginatesAndFourOhFours` asserted `body["error"]["code"].get<int>() == 404`. The shared error shape (#173) carries a per-status **slug** (`"not_found"`), and `git show d2fe130:engine/include/vayu/http/routes.hpp` confirms it already did when this file landed - so the assertion was wrong the day it was written, and threw a `json.exception.type_error.302` instead of failing an expectation. It now asserts the slug and a non-empty message, the same way `error_shape_route_test.cpp` and `examples_route_test.cpp` do. The other 15 tests passed unmodified on the first run - the file had not otherwise drifted.

### Blast radius, traced

`rg`'d rather than assumed: `response_capture_test.cpp` was the **only** `*_test.cpp` on disk missing from the list (`comm` over the two sorted sets), so the guard is green on the tree as it stands. It reads the target property rather than a new variable, which means the source list itself is untouched apart from the one added line - nothing else about how `vayu_tests` is built changed. Nothing outside `engine/CMakeLists.txt` reads that list.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **1788/1788 passed**. The base (`8a9a494`) runs **1772**; the difference is exactly the 16 tests this file defines. No pre-existing failures on this base. No app files were touched, so the vitest suite could not change colour and was not run.

The first run after registering the file was **1787/1788**, the single failure being the aged 404 assertion above; it is green after the correction.

**The guard was verified by running it, not by reading it:**

| Probe | Result |
|---|---|
| copy a test file in unregistered, then `cmake --preset linux-dev` | configure **fails**: `These test files exist but are not in add_executable(vayu_tests ...)` … `tests/guard_probe_test.cpp` |
| copy it in *after* a clean configure, then `ninja vayu_tests` | build **fails** through `--regenerate-during-build` - `CONFIGURE_DEPENDS` re-ran the glob, so no manual reconfigure was needed |
| acceptance criterion | `ctest --preset linux-dev -N \| grep -c ResponseCapture` = **16** (was `0`) |

Mutation check on the registration itself: dropping the `tests/response_capture_test.cpp` line takes the suite back to 1772 and `grep -c ResponseCapture` back to `0` - and now also fails configure, which is the point of the guard.

`clang-format` (18) reports **29 warnings on this test file both before and after** the edit - the tree is formatted by a newer clang-format, so the count staying identical is the check that the edit introduced no new violation. `mkdocs build --strict` was **not** run - mkdocs is not installed in this environment; the docs edits add prose plus one `###` heading to an existing page, with no new page, nav entry or relative link.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/building.md` (a "Test files are registered, and the build checks it" section under Running Tests), `CONTRIBUTING.md` (the registration step in Writing Tests, which was the gap that let this happen), `engine/CLAUDE.md` (the convention bullet, beside the other test-fixture rule).

## Related Issues

Closes #668.

Note on sequencing: the issue suggests landing after #667 to avoid a conflict in the same source list. #667 is still open, so this is based on `master` - the guard reads the target's `SOURCES` property rather than restructuring the list, so the overlap is one added line each and either merge order is a trivial resolution.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmV5pNGjPju3NXfoa4FJKq)_