### PR TITLE
docs: add Google Search Console verification meta tag

### DIFF
--- a/.github/overrides/main.html
+++ b/.github/overrides/main.html
@@ -41,6 +41,22 @@
 {% endblock %}
 
 {% block extrahead %}
+  {#
+    Google Search Console ownership proof for the https://athrvk.github.io/vayu/
+    URL-prefix property. It has to sit in <head> - the same tag written into a
+    page's Markdown lands in <body> and Google will not see it - and it has to be
+    on the property root, which this block covers by emitting it site-wide.
+
+    Not a secret, and checked in on purpose: the token is a public identifier
+    served in the source of every page, and it verifies nothing for anyone else.
+    Google only accepts a token that matches the one it issued to the requesting
+    account, so a fork serving this copy gains no access to the property. That is
+    why it is a literal here rather than an `!ENV` like the analytics ID, which is
+    kept out of the tree for a different reason - stopping forks from writing into
+    the real GA property.
+  #}
+  <meta name="google-site-verification" content="9oxsHaOL-f7J6VoYf2jD82plcMxsDyjxsq6Sjfy-LK8">
+
   {% set title = page_title %}
   {% set description = page.meta.description if page.meta and page.meta.description else config.site_description %}
   {#


### PR DESCRIPTION
## Description
Adds the Google Search Console ownership proof for the `https://athrvk.github.io/vayu/` URL-prefix property.

The tag goes at the top of `{% block extrahead %}` in `.github/overrides/main.html`, alongside the other hand-written head tags (Open Graph, Twitter, JSON-LD), for two reasons:

- **It has to be in `<head>`.** The same tag written into a page's Markdown renders into `<body>`, where Google will not see it - verification would just fail, and it would look like a Google problem rather than a placement one.
- **It has to be on the property root.** Emitting it from `extrahead` puts it on every page, which covers the root URL Google fetches.

The token is a public identifier, not a credential: it is served in the source of every page, and Google only accepts a token matching the one it issued to the requesting account, so a fork serving this copy cannot verify the property for itself. That is why it is a checked-in literal rather than an `!ENV` like the analytics measurement ID - that one is kept out of the tree for a different reason, to stop forks writing into the real GA property.

`.github/overrides/**` is already in the `paths:` filter of `docs.yml`, so the deploy triggers on merge with nothing under `docs/` changed.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
`mkdocs build --strict -f .github/mkdocs.yml` - builds clean. Confirmed the rendered tag lands inside `<head>` on `site/index.html` (the property root) and on nested pages such as `site/engine/cli/index.html`.

No suites run: the change is a single static `<meta>` line in a Jinja template, and a template syntax error is a *build* failure, which the strict build covers.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGgGs5zFNPC6khhSB5amFi)_