### PR TITLE
chore: close the wave-16 polish batch - two sync tests, three doc truths, two decisions

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -19,6 +19,14 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
 5. CI builds installers and publishes the GitHub Release, using
    `.github/release-notes/<tag>.md` as the release body automatically (no manual
    paste).
+6. Read the sccache hit rate in the release run's log and expect **more than
+   zero engine hits** (issue #659 item 5). A version bump used to edit a header
+   every translation unit preprocessed, so every release compiled the engine
+   cold on all three platforms at a 0% hit rate by construction;
+   `core/user_agent.hpp` exists to keep the version behind a declaration. Zero
+   hits again means something has pulled `vayu/version.hpp` back into a widely
+   included header, and `version_isolation_test.cpp` is the guard that should
+   have caught it.
 
 A release commit needs no test run - every edit is a version string or Markdown.
 The version stamp is worth one cheap check (`./build/vayu-engine --help` prints

--- a/.github/overrides/main.html
+++ b/.github/overrides/main.html
@@ -126,7 +126,7 @@
         "REST and GraphQL request builder",
         "Native C++ load testing with live metrics over SSE",
         "Built-in MCP server for Claude Code, Cursor, VS Code, Codex and Zed",
-        "Import Postman, Insomnia, OpenAPI 3.0 and Swagger 2.0 collections",
+        "Import Postman, Insomnia, OpenAPI 3.1/3.0 and Swagger 2.0 collections",
         "Postman-compatible pm.* test scripts",
         "OAuth 2.0, Bearer, Basic and API key auth",
         "Fully offline - no account, no telemetry, no cloud sync"

--- a/app/src/services/openapi/spec-apply.test.ts
+++ b/app/src/services/openapi/spec-apply.test.ts
@@ -36,6 +36,7 @@ import {
 	type SpecApplySelection,
 } from "./spec-apply";
 import { readSpecOperations, type SpecRequestDraft } from "./spec-operations";
+import { buildUrlWithParams } from "@/modules/request-builder/utils/url";
 import type { Collection, Request } from "@/types";
 
 interface OperationSpec {
@@ -356,5 +357,122 @@ describe("buildSyncPayload", () => {
 		expect(
 			payload(fetched, boundCollection(), (base) => ({ ...base, added: new Set() })).create
 		).toEqual([]);
+	});
+});
+
+/**
+ * A stub parameter the user ticked on, through a whole sync (issue #677 item 1).
+ *
+ * Issues #622/#658 import an optional, value-less parameter **disabled** - the
+ * row is what the endpoint accepts, not what this request should send. Their
+ * re-application clause is the half no test reached: a person who ticked the row
+ * on has stated the intent the import declined to guess, and a sync must not tick
+ * it back off.
+ *
+ * Three separate things have to hold for that, and each has its own way of
+ * failing silently:
+ *
+ *  - the `[off]` marker in `spec-diff`'s row rendering, without which the flip is
+ *    invisible to the comparison and the field reads as matching the document;
+ *  - the three-way flag, which is what calls the flip the user's rather than the
+ *    document's;
+ *  - `defaultSelection`, which leaves a user-touched field out of the ticks.
+ *
+ * The requests here are built from the document's own drafts and then edited the
+ * way the Params table edits them - the row flipped *and* the URL rewritten from
+ * the rows, since since #590 the URL is what actually goes on the wire.
+ */
+describe("a stub parameter enabled by hand", () => {
+	const STUB = doc({
+		"/pets": {
+			get: {
+				operationId: "listPets",
+				summary: "List pets",
+				tags: ["pets"],
+				parameters: [{ name: "verbose", in: "query" }],
+			},
+		},
+	});
+
+	const stubDrafts = () => readSpecOperations(STUB).requests;
+
+	/** The imported request with `verbose` ticked on, as the Params table leaves it. */
+	function verboseEnabled(): Request {
+		const [entry] = stubDrafts();
+		const params = entry.draft.params.map((row) => ({ ...row, enabled: true }));
+		return requestFrom("req_0", entry, {
+			params,
+			url: buildUrlWithParams(entry.draft.url, params),
+		});
+	}
+
+	function syncPayload(fetchedRaw: string, requests: Request[]) {
+		const diff = diffSpec({
+			bound: stubDrafts(),
+			fetched: readSpecOperations(fetchedRaw).requests,
+			requests,
+		});
+		return {
+			diff,
+			body: buildSyncPayload({
+				collectionId: "col_root",
+				diff,
+				selection: defaultSelection(diff),
+				content: fetchedRaw,
+				sourceUrl: null,
+				collections: collections("pets"),
+			}),
+		};
+	}
+
+	it("imports disabled, which is what leaves anything to survive", () => {
+		const [entry] = stubDrafts();
+		expect(entry.draft.params).toEqual([{ key: "verbose", value: "", enabled: false }]);
+		// And off the URL, so the row is listed without being sent.
+		expect(entry.draft.url).not.toContain("verbose");
+	});
+
+	it("survives a sync against a document that did not move", () => {
+		const { diff, body } = syncPayload(STUB, [verboseEnabled()]);
+
+		// Both halves of the flip are seen, and both are the user's - the document
+		// is byte-identical, so there is nothing else they could be. Remove the
+		// `[off]` marker and `params` drops out of this list.
+		expect(diff.changed[0].fields.map((f) => f.field).sort()).toEqual(["params", "url"]);
+		expect(diff.changed[0].fields.every((f) => f.userTouched)).toBe(true);
+		expect(isEmptySelection(defaultSelection(diff))).toBe(true);
+		expect(body.update).toEqual([]);
+	});
+
+	it("survives a sync that does move the parameter list", () => {
+		// The case the marker is actually load-bearing for. The document adds a
+		// second parameter, so `params` differs from it either way and is reported
+		// either way - what the marker decides is whether the flip is *also* a
+		// difference from the bound document, and therefore the user's. Without it
+		// the field reads as untouched, gets ticked by default, and the sync writes
+		// the document's list over the row somebody enabled.
+		const moved = doc({
+			"/pets": {
+				get: {
+					operationId: "listPets",
+					summary: "List pets",
+					tags: ["pets"],
+					parameters: [
+						{ name: "verbose", in: "query" },
+						{ name: "limit", in: "query", required: true, example: "10" },
+					],
+				},
+			},
+		});
+		const { diff, body } = syncPayload(moved, [verboseEnabled()]);
+
+		const params = diff.changed[0].fields.find((f) => f.field === "params");
+		expect(params?.userTouched).toBe(true);
+		// Nothing here is safe to take, so the request is not offered at all and
+		// the payload writes no row. Remove the `[off]` marker and `params` reads
+		// as untouched, gets ticked, and this update arrives carrying the
+		// document's parameter list.
+		expect(defaultSelection(diff).changed.has("req_0")).toBe(false);
+		expect(body.update).toEqual([]);
 	});
 });

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -568,6 +568,19 @@ Two surfaces consume it - the dashboard's Sampled Requests
 credential-shaped). Both notices live in `components/shared`, so the wording
 exists once rather than twice.
 
+**A sample carries the response side only, so its request headers are the
+composed ones.** `GET /runs/:id/samples` returns response headers and body; what
+a sample viewer shows for the request comes from the run's composed request, not
+from a sent record, because the load transport keeps none. So a sampled capture
+can differ from the wire in the two ways the design-mode `sentHeaders` record
+exists to state (issue #664): an enabled header whose value is empty is listed
+although libcurl dropped it, and the two the engine derives at send time - the
+body-implied `Content-Type` and the default `User-Agent` - do not appear. For
+load samples this is **recorded as permanent** (issue #677 item 7): which
+completions are sampled is decided when they finish, so a record for the few
+that are kept would have to be built for every transfer. Design-mode traces
+store `sentHeaders` and do not diverge.
+
 A sample whose transfer was a **stream** also carries `response.events` (issue
 #657) - `{items, totalEvents, eventsTruncated}`, parsed engine-side out of the
 stored `text/event-stream` body. Both surfaces render it through the shared

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -575,8 +575,10 @@ Full) are an enumeration rather than a range; it is stored as an `enum` so the
 panel draws a picker instead of an integer box the description has to explain.
 
 The Settings panel renders entries dynamically, so new keys appear without app
-changes. These `data_retention` keys govern how much a run keeps - most of them
-on disk, one in memory:
+changes. The entries below span two categories: the `data_retention` keys govern
+how much a run keeps - most of them on disk, one in memory - and the three
+`monitor*` keys are `observability`, governing how a run scrapes the endpoint it
+watches rather than what it stores:
 
 | Key                 | Default   | Range        | Effect |
 |---------------------|-----------|--------------|--------|
@@ -2698,9 +2700,17 @@ questions: the composed one is what a *pre-request* script saw and what reseeds
 a request tab from a run. The key is **absent** on a step that sent nothing and
 on every row written before the field, so a reader falls back to
 `request.headers` - `restore-response.ts`'s `sentSide` is that reader. A load
-run's sampled capture records no sent headers at all and is unaffected: its
-deferred replay keeps reading the composed map, as
-[scripting.md](scripting.md#request-object-pmrequest) documents.
+run's sampled capture records no sent headers at all: its deferred replay and
+the Samples viewer both keep reading the composed map, as
+[scripting.md](scripting.md#request-object-pmrequest) documents. That map can
+differ from the wire in exactly the two ways this record exists to state - a
+value-less enabled header is listed although it never went out, and the derived
+`User-Agent` and body-implied `Content-Type` are absent - and for load samples
+that divergence is **recorded as permanent** rather than treated as a gap to
+close (issue #677 item 7). Which completions become samples is decided when they
+finish, so a sent record for the few that are kept would have to be built for
+every transfer, and a load run exists not to charge the hot path for what it
+throws away.
 
 Values in `rawRequest` are not redacted:
 this field exists to say exactly what went out. On a followed redirect it is the

--- a/docs/index.md
+++ b/docs/index.md
@@ -203,7 +203,7 @@ the tree, variables, auth and scripts.
 
 === "OpenAPI & Swagger"
 
-    **OpenAPI 3.0 and Swagger 2.0**, JSON or YAML. A spec describes endpoints
+    **OpenAPI 3.1/3.0 and Swagger 2.0**, JSON or YAML. A spec describes endpoints
     rather than recording requests, so Vayu generates **stubs**: one collection
     per tag, a `{{baseUrl}}` variable from the server definition, parameters with
     empty values, and a request body sampled from the schema. Auth schemes map
@@ -345,7 +345,7 @@ persists.
     and pre/post-request scripts. Postman environments are a separate export;
     import that file too and it becomes a Vayu environment, and a globals export
     merges into Vayu's globals scope. Insomnia v4,
-    OpenAPI 3.0 and Swagger 2.0 import too; see
+    OpenAPI 3.1/3.0 and Swagger 2.0 import too; see
     [what carries over](#bring-your-existing-collections).
 
 ??? question "Will my Postman test scripts still run?"

--- a/engine/tests/spec_sync_route_test.cpp
+++ b/engine/tests/spec_sync_route_test.cpp
@@ -33,6 +33,9 @@
 
 #include "temp_database.hpp"
 #include "vayu/core/constants.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/core/scenario_plan.hpp"
+#include "vayu/core/spec_coverage.hpp"
 #include "vayu/db/database.hpp"
 
 using nlohmann::json;
@@ -51,6 +54,10 @@ const std::string& id,
 const nlohmann::json& json);
 std::pair<int, nlohmann::json>
 create_request_response (vayu::db::Database& db, const nlohmann::json& json);
+// Defined in runs.cpp - the reader that must not resolve coverage from the
+// collection's binding as it stands now.
+std::pair<int, nlohmann::json>
+run_report_response (vayu::db::Database& db, const std::string& run_id);
 } // namespace vayu::http::routes
 
 namespace {
@@ -445,6 +452,115 @@ TEST_F (SpecSyncRouteTest, AnEmptyDocumentIsNotASpec) {
     json{ { "collectionId", root_ }, { "spec", json{ { "content", "" } } } });
     EXPECT_EQ (status, 400) << response.dump ();
     EXPECT_EQ (binding ()["specId"].get<std::string> (), bound_spec_);
+}
+
+// ---------------------------------------------------------------------------
+// What a sync does *not* touch: an older run's coverage (issue #629, #677 item 3)
+// ---------------------------------------------------------------------------
+
+// Coverage is pinned to the document the run was **planned** against, which
+// docs/app/openapi.md states as a promise to the reader: "sync the binding to a
+// newer spec and an older run's report still says what that run actually
+// covered". The pieces of that were each pinned on their own - the plan-time
+// hash check, and the summary round trip - but nothing ran the sentence end to
+// end, which is the only way to catch a later re-read that resolves coverage
+// from the collection's *current* binding instead of from the stored block.
+TEST_F (SpecSyncRouteTest, ASyncLeavesAnOlderRunsStoredCoverageAlone) {
+    // A document that declares one operation, bound with the hash the engine
+    // computed for it - the agreement the plan requires before it will read an
+    // index at all.
+    const json v1_index =
+    json::array ({ { { "operationId", "listPets" }, { "method", "GET" },
+    { "path", "/pets" }, { "responses", json::array ({ "200", "404" }) } } });
+    auto [stored_status, stored] = routes::create_spec_document_response (
+    *db_, json{ { "content", BOUND_DOC }, { "operations", v1_index } });
+    ASSERT_EQ (stored_status, 200) << stored.dump ();
+    const std::string v1_id   = stored.value ("id", std::string{});
+    const std::string v1_hash = stored.value ("hash", std::string{});
+    {
+        auto [status, body] = routes::update_collection_response (*db_, root_,
+        json{ { "openapi",
+        json{ { "specId", v1_id }, { "specHash", v1_hash }, { "syncedAt", 1 } } } });
+        ASSERT_EQ (status, 200) << body.dump ();
+    }
+    create_request (root_,
+    json{ { "specOperation",
+    json{ { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" } } } });
+
+    // Plan the run the way a real one is planned, so the tally counts against
+    // the index this collection was bound to when it ran.
+    auto plan_now = [&] {
+        vayu::core::ScenarioResolveOptions options;
+        options.timeout_ms            = 1000;
+        options.limits.max_steps      = 10;
+        options.limits.max_data_rows  = 10;
+        options.limits.max_data_bytes = 4096;
+        return vayu::core::resolve_scenario (*db_,
+        json{ { "source", "collection" }, { "collectionId", root_ } }, options);
+    };
+    auto resolved = plan_now ();
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_EQ (resolved.spec.declared_operations.size (), 1u);
+
+    vayu::core::ScenarioExecution execution;
+    execution.plan = resolved.plan;
+    execution.spec = resolved.spec;
+    auto tally     = vayu::core::make_coverage_tally (execution);
+    ASSERT_TRUE (tally.active ());
+    tally.record (0, 200);
+
+    vayu::db::Run run;
+    run.id              = "run_before_sync";
+    run.type            = vayu::RunType::Scenario;
+    run.status          = vayu::RunStatus::Completed;
+    run.config_snapshot = json{
+        { "url", "https://example.test/pets" },
+        { "scenario",
+        json{ { "collectionId", root_ },
+        { "openapi", json{ { "specId", v1_id }, { "specHash", v1_hash } } } } }
+    }.dump ();
+    run.start_time = 1000;
+    run.end_time   = 1001;
+    db_->create_run (run);
+
+    vayu::core::RunSummaryInputs inputs;
+    inputs.coverage = tally.build ();
+    db_->update_run_summary (
+    run.id, vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [before_status, before] = routes::run_report_response (*db_, run.id);
+    ASSERT_EQ (before_status, 200) << before.dump ();
+    ASSERT_TRUE (before.contains ("coverage")) << before.dump ();
+    const json coverage_before = before["coverage"];
+
+    // The contract moves: a second operation, a second document, a new binding.
+    const json v2_index = json::array (
+    { { { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" },
+      { "responses", json::array ({ "200", "404" }) } },
+    { { "operationId", "listOwners" }, { "method", "GET" },
+    { "path", "/owners" }, { "responses", json::array ({ "200" }) } } });
+    auto [sync_status, synced] = routes::spec_sync_response (*db_,
+    json{ { "collectionId", root_ },
+    { "spec", json{ { "content", FETCHED_DOC }, { "operations", v2_index } } } });
+    ASSERT_EQ (sync_status, 200) << synced.dump ();
+    ASSERT_NE (binding ()["specId"].get<std::string> (), v1_id)
+    << "the sync has to have actually moved the binding, or this proves "
+       "nothing";
+    // And the collection now measures against a contract of two operations, so
+    // "1" below is a discrimination rather than a number that could not move.
+    auto replanned = plan_now ();
+    ASSERT_TRUE (replanned.ok) << replanned.error;
+    ASSERT_EQ (replanned.spec.declared_operations.size (), 2u);
+
+    // Re-read the *same* run. Every number, and the stamp naming which document
+    // they were computed against, is what it was before the sync.
+    auto [after_status, after] = routes::run_report_response (*db_, run.id);
+    ASSERT_EQ (after_status, 200) << after.dump ();
+    EXPECT_EQ (after["coverage"], coverage_before);
+    EXPECT_EQ (after["coverage"]["operationsTotal"].get<size_t> (), 1u)
+    << "the newer document declares two - reading it here would say so";
+    EXPECT_EQ (after["metadata"]["openapi"]["specId"].get<std::string> (), v1_id);
+    EXPECT_EQ (after["metadata"]["openapi"]["specHash"].get<std::string> (), v1_hash);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

All seven items of #677, the untracked batch from the wave-16 closure verification.

**Plan.** The root cause across the batch is the same one CLAUDE.md names as this codebase's standing defect, in two shapes: a mechanism that exists with no reader (items 1 and 3 are behaviours nothing exercises end to end) and a document that has drifted from the code it describes (items 4-6). So the approach is to reach each item's anchor in the source first and verify the problem is still live, then fix it at the layer that owns it - a test where the behaviour is, a sentence where the reader is. The alternative I rejected was landing items 1-6 and leaving 2 and 7 as "still open": the issue is explicit that silence was the only wrong state for those two, and a batch that closes the cheap five and defers the two that need a judgement is exactly the deferral that produced this issue in the first place. Both are decided below, with the code checked rather than the issue's framing taken at face value - which changed the answer for item 7.

### Items 1 and 3 - tests, mutation-checked

**Item 1** (`app/src/services/openapi/spec-apply.test.ts`). #622/#658 import an optional, value-less parameter **disabled**; the clause with no test was re-application - a user who ticks the row on has stated the intent the import declined to guess, and a sync must not tick it back off. The protection is three layers deep and one test now covers all of them: the `[off]` marker in `spec-diff`'s row rendering, the three-way `userTouched` flag, and `defaultSelection` leaving a user-touched field out of the ticks.

Two cases, not one. The issue asks for the unchanged-document case, and that is the first test. The second is the one where the marker is actually load-bearing: when the document *also* moves the parameter list, `params` differs from the new document either way, and what the marker decides is whether it also differs from the **bound** one - so without it the field reads as untouched, gets ticked by default, and the sync writes the document's list over the row somebody enabled. That is the data loss; the unchanged-document case alone cannot reach it.

Requests are edited the way the Params table edits them - the row flipped **and** the URL rebuilt from the rows via `buildUrlWithParams` - because since #590 the URL is what actually goes on the wire, so a hand-flipped `params` array with a stale URL would be a state the app never produces.

**Item 3** (`engine/tests/spec_sync_route_test.cpp`). `docs/app/openapi.md` promises a reader that syncing the binding to a newer spec leaves an older run's report saying what that run covered. The plan-time hash check and the summary round trip were each pinned on their own; the sentence was not. The new test plans against a one-operation document, stores the run's coverage, syncs the binding to a two-operation document through `POST /specs/sync`, and re-reads the *same* run - coverage identical, `metadata.openapi` still naming v1.

It also re-plans after the sync and asserts the live binding now declares **two** operations, so the stored `operationsTotal` of 1 is a discrimination rather than a number that could not have moved. That is what would catch a later reader resolving coverage from the collection's current binding instead of the stored block.

### Items 4-6 - doc truths

- `docs/index.md:206` and `:348` said "OpenAPI 3.0 and Swagger 2.0"; 3.1 is real and the README says so. The structured-data `featureList` in `.github/overrides/main.html` repeated the claim, so it is aligned too. Phrasing matched to the README's `OpenAPI 3.1/3.0`.
- The api-reference config-table intro called all ten rows `data_retention`. Three (`monitorIntervalMs`, `monitorMaxSeries`, `monitorScrapeTimeoutMs`) have been `observability` since #586, verified against `database.cpp`'s catalogue. The intro now names both categories and what each governs; the table is left whole, since splitting a ten-row table to move three rows costs a reader more than the sentence does.
- The sccache measurement pointer from #659 item 5 now lives in the `releasing` skill's checklist, at step 6 where the release actually happens, with the reason a reader needs to act on a zero.

### Items 2 and 7 - decisions, recorded on the issue

Both are written up in full on #677 with the evidence; the short form:

**Item 7: (b), document the divergence, permanent.** The issue framed (a) as "only the sampling branch pays" - the code says otherwise. `MetricsCollector::capture_exchange` takes only the `Response`, and which completions become samples is settled by the reservoir *after* the transfer finishes, so a sent record for the few kept would have to be built for every transfer, which is precisely the allocation `build_request_header_list (…, nullptr)` exists to avoid. It also needs a new column: `GET /runs/:id/samples` carries the response side only. Against that, the divergence is exactly the two cases #662/#664 already enumerate, so it is now stated where a reader meets a sampled capture - `docs/engine/api-reference.md` (which previously said "records no sent headers at all and is unaffected" without naming what that costs) and `docs/app/api-integration.md`.

**Item 2: (a), detect the re-import and offer Sync.** Recording the current behaviour as permanent would document a foot-gun rather than remove one, and detection needs no new machinery (`source_url` and the content hash are both stored). But it is a detection pass, a dialog, routing into the Spec tab and three outcomes' worth of tests - not a line of copy - so it is filed as **#680** rather than smuggled into this batch. This item is closed by the decision; #680 carries the implementation.

## Type of Change

- [x] Documentation update
- [x] Tests (no production behaviour changes)

## Testing

Full local suites on this branch, all green:

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **1843/1843 passed, 0 failed** (1842 before this branch; the new `SpecSyncRouteTest.ASyncLeavesAnOlderRunsStoredCoverageAlone` is the addition).
- `cd app && pnpm test` - **5042 passed across 484 files** (5039 before; three new cases in `spec-apply.test.ts`).
- `cd app && pnpm type-check` - clean.
- `cd app && pnpm lint` - clean, zero warnings.
- `mkdocs build --strict` - clean, for the four touched `docs/` and `.github/` files.

**Mutation checks.** Replacing `` return entry.enabled ? typed : `${typed} [off]`; `` with `return typed;` in `spec-diff.ts` reddens **both** new item-1 tests (`params` drops out of the reported fields in the first, `userTouched` goes false in the second); the marker was restored and the suite re-run green. Item 3's discrimination is asserted inside the test itself - the re-plan proves the live binding says two where the stored block says one.

No pre-existing failures were encountered on either suite.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Two style notes worth stating rather than leaving to a reviewer to spot. `engine/tests/spec_sync_route_test.cpp` was not clang-format-clean before this change (65 pre-existing violations), so per the repo's "format only files you touched that were clean before" rule I formatted **only the added block** - the diff is 116 insertions and no modified lines, and the file's violation count is unchanged at 65. `app/src/services/openapi/spec-apply.test.ts` was prettier-clean and still is.

## Related Issues

Closes #677

Files #680 for item 2's implementation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nxf3jYqi7S9ZzVUhZ5PXPg)_