### PR TITLE
feat(openapi): phase 3c - validate a load run's sampled responses at run end

### DIFF
--- a/app/src/components/shared/SampledSchemaValidation.test.tsx
+++ b/app/src/components/shared/SampledSchemaValidation.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * This block sits directly beside a coverage block whose every number is exact,
+ * so the ways it could mislead are all versions of one mistake: letting a reader
+ * take a sampled figure for a whole-run one. Showing a block for a run that
+ * checked nothing, printing a matched count without the denominator it came
+ * from, or reporting a body no schema could describe as a failure would each do
+ * it, and each has a case here.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { SampledSchemaValidation } from "./SampledSchemaValidation";
+import { UNCHECKED_REASONS } from "./response-viewer/validation-reasons";
+import type { RunSchemaValidation } from "@/types/domain";
+
+afterEach(cleanup);
+
+const validation = (over: Partial<RunSchemaValidation> = {}): RunSchemaValidation => ({
+	sampled: 40,
+	checked: 36,
+	valid: 30,
+	failed: 6,
+	unevaluated: 0,
+	uncheckedReasons: { body_not_json: 4 },
+	failures: [{ step: "get pet", status: 200, path: "/id", message: "expected integer" }],
+	failuresTotal: 6,
+	...over,
+});
+
+describe("SampledSchemaValidation", () => {
+	it("renders nothing for a run that checked nothing", () => {
+		// Absent and "walked no samples" both mean not checked. Neither may
+		// render a block, because a block saying nothing failed is a claim about
+		// a contract this run was never judged against.
+		//
+		// Mutation-check: drop the `sampled <= 0` half of the guard and the
+		// second render below produces a card reading "0 / 0 matched".
+		const { container: absent } = render(<SampledSchemaValidation validation={undefined} />);
+		expect(absent.innerHTML).toBe("");
+
+		cleanup();
+		const { container: empty } = render(
+			<SampledSchemaValidation
+				validation={validation({
+					sampled: 0,
+					checked: 0,
+					valid: 0,
+					failed: 0,
+					uncheckedReasons: {},
+					failures: [],
+					failuresTotal: 0,
+				})}
+			/>
+		);
+		expect(empty.innerHTML).toBe("");
+	});
+
+	it("shows the sampled denominator beside the tallies", () => {
+		render(<SampledSchemaValidation validation={validation()} />);
+
+		expect(screen.getByText("30 / 36 matched")).toBeTruthy();
+		// The denominator is the whole point: without "of 40 sampled" a reader
+		// takes 36 for the number of responses the run made.
+		expect(screen.getByText(/36 of 40 sampled responses checked/)).toBeTruthy();
+		expect(screen.getByText(/6 did not match their declared schema/)).toBeTruthy();
+	});
+
+	it("says the numbers describe the sample, beside a coverage block that is exact", () => {
+		render(<SampledSchemaValidation validation={validation()} />);
+
+		// Stated in the block rather than left to the docs, for the same reason
+		// the coverage block states the opposite: the two sit together and a
+		// reader has no other way to tell which kind each is.
+		expect(screen.getByText(/Coverage beside this is exact/)).toBeTruthy();
+		expect(screen.getByText(/over the responses it kept/)).toBeTruthy();
+	});
+
+	it("accounts for unchecked samples by reason, in the wording the response viewer uses", () => {
+		render(<SampledSchemaValidation validation={validation()} />);
+
+		// One list of sentences, shared with the single-response pane. A second
+		// copy here would drift from what a user reads on their own response.
+		const row = screen.getByText(new RegExp(UNCHECKED_REASONS.body_not_json));
+		expect(row.textContent).toContain("4");
+		expect(row.textContent).toContain("not checked");
+	});
+
+	it("names the keywords that went unevaluated rather than only counting them", () => {
+		render(
+			<SampledSchemaValidation
+				validation={validation({
+					unevaluated: 3,
+					unevaluatedKeywords: [
+						{ keyword: "unevaluatedProperties", count: 3 },
+						{ keyword: "prefixItems", count: 1 },
+					],
+				})}
+			/>
+		);
+
+		// A green count beside a schema half of which went unread is the failure
+		// mode the disclosure exists for, so the keywords are named.
+		expect(screen.getByText(/unevaluatedProperties \(3\), prefixItems/)).toBeTruthy();
+		expect(screen.getByText(/neither checked nor failed/)).toBeTruthy();
+	});
+
+	it("discloses that the failure list is shorter than the count", () => {
+		render(
+			<SampledSchemaValidation validation={validation({ failuresTotal: 90, failed: 40 })} />
+		);
+
+		// A list shorter than the count reads as the whole set of problems
+		// unless it says otherwise.
+		expect(screen.getByText("Showing 1 of 90.")).toBeTruthy();
+	});
+
+	it("stays neutral when nothing failed rather than borrowing the failure vocabulary", () => {
+		render(
+			<SampledSchemaValidation
+				validation={validation({
+					valid: 36,
+					failed: 0,
+					failures: [],
+					failuresTotal: 0,
+				})}
+			/>
+		);
+
+		const chip = screen.getByText("36 / 36 matched");
+		expect(chip.className).toContain("text-status-success-text");
+		// A run with nothing wrong must not print a failure sentence.
+		expect(screen.queryByText(/did not match/)).toBeNull();
+	});
+});

--- a/app/src/components/shared/SampledSchemaValidation.tsx
+++ b/app/src/components/shared/SampledSchemaValidation.tsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Whether the responses a load run kept matched the schemas its contract
+ * declares (issue #682).
+ *
+ * The other half of the answer `ContractCoverage` beside it starts: coverage
+ * says which of the contract the run touched, this says whether what came back
+ * honoured it. Both are computed against the document the run was *planned*
+ * with, and both are absent when the run was not measured against one - a run
+ * whose responses were never checked did not pass a contract.
+ *
+ * **The one thing this component must never let a reader assume is that these
+ * numbers describe the run.** They describe the bounded reservoir of responses
+ * the run stored: the engine defers validation to run end because the load loop
+ * refills concurrency per completion. So the sampled denominator is rendered
+ * beside every tally rather than left to a tooltip, and `Coverage is exact,
+ * this is sampled` is the sentence the block carries - the same distinction
+ * `docs/app/openapi.md`'s exact-vs-sampled table draws.
+ *
+ * Reasons come from `uncheckedReasonText`, the wording the response viewer
+ * already shows for a single response. One copy: a second list of sentences
+ * here would drift from the one a user reads on their own response.
+ */
+
+import { AlertTriangle } from "lucide-react";
+import { Badge, Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import { uncheckedReasonText } from "./response-viewer/validation-reasons";
+import type { RunSchemaValidation, ValidationUncheckedReason } from "@/types/domain";
+
+export interface SampledSchemaValidationProps {
+	validation: RunSchemaValidation | undefined;
+	className?: string;
+}
+
+export function SampledSchemaValidation({ validation, className }: SampledSchemaValidationProps) {
+	if (!validation || validation.sampled <= 0) return null;
+
+	const unchecked = Object.entries(validation.uncheckedReasons ?? {}) as [
+		ValidationUncheckedReason,
+		number,
+	][];
+	const unevaluated = validation.unevaluatedKeywords ?? [];
+	const failures = validation.failures ?? [];
+
+	return (
+		<Card className={className}>
+			<CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+				<CardTitle className="text-base">Schema validation</CardTitle>
+				{/*
+				 * `Badge variant="chip"` for the reason `ContractCoverage` states at
+				 * its own: it is the variant that lets a caller own the background
+				 * without inheriting a `hover:bg-*` tailwind-merge will not replace.
+				 * Text on a tint, never the bare `--status-*` fill as a foreground.
+				 *
+				 * Red only for a real schema failure. A run that checked nothing is
+				 * not a run that broke its contract, so it stays neutral rather than
+				 * borrowing the vocabulary of a failed budget.
+				 */}
+				<Badge
+					variant="chip"
+					className={cn(
+						"font-medium",
+						validation.failed > 0
+							? "bg-status-error/10 text-status-error-text"
+							: validation.checked > 0
+								? "bg-status-success/10 text-status-success-text"
+								: "bg-muted text-muted-foreground"
+					)}
+				>
+					{validation.valid} / {validation.checked} matched
+				</Badge>
+			</CardHeader>
+			<CardContent>
+				<p className="mb-3 text-xs text-muted-foreground tabular-nums">
+					{validation.checked} of {validation.sampled} sampled{" "}
+					{validation.sampled === 1 ? "response" : "responses"} checked against the spec.
+					{validation.failed > 0 &&
+						` ${validation.failed} did not match ${
+							validation.failed === 1 ? "its" : "their"
+						} declared schema.`}
+				</p>
+				{/*
+				 * The counterpart of the coverage block's "counted on every send",
+				 * and the reason both sentences exist: the two blocks sit together
+				 * and are computed on different evidence, so neither can leave the
+				 * reader to work out which kind its numbers are.
+				 */}
+				<p className="mb-3 text-[11px] text-muted-foreground">
+					Checked at the end of the run, over the responses it kept. Coverage beside this
+					is exact; these numbers describe the sample.
+				</p>
+
+				{unchecked.length > 0 && (
+					<ul className="mb-3 space-y-1">
+						{unchecked.map(([reason, count]) => (
+							<li key={reason} className="text-xs text-muted-foreground tabular-nums">
+								<span className="font-medium">{count}</span>{" "}
+								{count === 1 ? "response" : "responses"} not checked:{" "}
+								{uncheckedReasonText(reason)}
+							</li>
+						))}
+					</ul>
+				)}
+
+				{failures.length > 0 && (
+					<ul className="space-y-1">
+						{failures.map((failure, i) => (
+							<li key={i} className="text-xs">
+								{failure.step && (
+									<span className="text-muted-foreground">{failure.step}: </span>
+								)}
+								<code className="text-foreground">{failure.path || "(body)"}</code>
+								<span className="text-muted-foreground"> - {failure.message}</span>
+							</li>
+						))}
+					</ul>
+				)}
+
+				{/*
+				 * Said out loud, never elided: a list shorter than the count reads as
+				 * the whole set of problems unless it says otherwise.
+				 */}
+				{validation.failuresTotal > failures.length && (
+					<p className="mt-2 text-xs text-muted-foreground tabular-nums">
+						Showing {failures.length} of {validation.failuresTotal}.
+					</p>
+				)}
+
+				{/*
+				 * The dialect gap, in aggregate. Responses whose schema was half read
+				 * passed every check that *ran*, which is a narrower claim than the
+				 * matched count above makes on its own.
+				 */}
+				{unevaluated.length > 0 && (
+					<div className="mt-3 flex items-start gap-1.5 text-xs text-muted-foreground">
+						<AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+						<span className="tabular-nums">
+							{validation.unevaluated} checked{" "}
+							{validation.unevaluated === 1 ? "response" : "responses"} met schema
+							keywords the validator cannot evaluate:{" "}
+							{unevaluated
+								.map(({ keyword, count }) =>
+									count > 1 ? `${keyword} (${count})` : keyword
+								)
+								.join(", ")}
+							. What those keywords describe was neither checked nor failed.
+						</span>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -32,6 +32,9 @@ export * from "./ThresholdVerdict";
 export * from "./CapacitySummary";
 export * from "./ContractCoverage";
 
+// "30 of 36 sampled responses matched their schema" - beside the coverage block
+export * from "./SampledSchemaValidation";
+
 // "These responses were stored verbatim" - wherever captured samples are shown
 export * from "./CapturedDataWarning";
 

--- a/app/src/modules/history/main/components/OverviewTab.tsx
+++ b/app/src/modules/history/main/components/OverviewTab.tsx
@@ -15,7 +15,12 @@ import { AlertCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/utils";
-import { CapacitySummary, ContractCoverage, ThresholdVerdict } from "@/components/shared";
+import {
+	CapacitySummary,
+	ContractCoverage,
+	SampledSchemaValidation,
+	ThresholdVerdict,
+} from "@/components/shared";
 import { HeroRow } from "@/modules/dashboard/components/hero/HeroRow";
 import { ModeStatsRow } from "@/modules/dashboard/components/stats/ModeStatsRow";
 import { RunEvents } from "./RunEvents";
@@ -46,6 +51,12 @@ export default function OverviewTab({ report, derived, anomalies }: TabProps) {
 			    reason: a run can meet every budget while never calling four of
 			    eighteen operations. Absent for a run of an unbound collection. */}
 			<ContractCoverage coverage={report.coverage} />
+
+			{/* And whether what came back honoured that contract. Directly under
+			    coverage because the two answer halves of one question against the
+			    same document - what was exercised, and what it returned. Absent
+			    for a run that checked nothing. */}
+			<SampledSchemaValidation validation={report.schemaValidation} />
 
 			{/* When the run went wrong, in words. Above the status/error totals
 			    because those are cumulative and this is the thing they hide: a

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -356,6 +356,38 @@ export interface RunCoverage {
 }
 
 /**
+ * What checking a load run's **sampled** responses against its bound contract
+ * found (issue #682). See {@link RunReport.schemaValidation} for when it is
+ * present.
+ *
+ * The sibling of {@link RunCoverage}, and the opposite of it in the one way that
+ * matters to a reader: coverage counts every send, this checks the bounded
+ * reservoir the run stored. `sampled` is therefore not decoration - it is the
+ * denominator that stops `failed: 0` being read as "no response failed" when it
+ * means "no sampled response failed".
+ *
+ * `checked` is what a schema could speak about; `uncheckedReasons` accounts for
+ * the rest by engine reason code, so `sampled - checked` is never an unexplained
+ * gap. `unevaluated` counts checked responses whose schema carried a keyword the
+ * draft-07 validator could not evaluate - they passed every check that *ran*,
+ * which is a narrower claim than valid.
+ */
+export interface RunSchemaValidation {
+	sampled: number;
+	checked: number;
+	valid: number;
+	failed: number;
+	unevaluated: number;
+	/** Engine reason code -> how many samples it accounts for. */
+	uncheckedReasons?: Partial<Record<ValidationUncheckedReason, number>>;
+	unevaluatedKeywords?: { keyword: string; count: number }[];
+	/** Bounded examples, capped engine-side across the whole run. */
+	failures: { step?: string; status: number; path: string; message: string }[];
+	/** Every failure found, the cap included - so "3 of 90" stays readable. */
+	failuresTotal: number;
+}
+
+/**
  * Which operation of a collection's bound spec a request *is* (issue #637).
  *
  * `path` is the **templated** path as the document writes it (`/pets/{petId}`),
@@ -1720,6 +1752,21 @@ export interface RunReport {
 	 * `results[]` sample a load run stores.
 	 */
 	coverage?: RunCoverage;
+	/**
+	 * Whether the responses this run kept matched the schemas its bound document
+	 * declares (issue #682).
+	 *
+	 * **Absent, never zeros**, for every run that checked nothing - an unbound
+	 * collection, a single-request run, a document carrying no response schemas.
+	 * A run whose responses were never checked did not pass a contract.
+	 *
+	 * Beside {@link RunReport.coverage} and computed against the same document,
+	 * but on different evidence: coverage is exact, this is **sampled**. The
+	 * engine defers it to run end over the bounded reservoirs, because the load
+	 * loop refills concurrency per completion and a schema walk there would cost
+	 * the run throughput. Anything rendering these numbers has to say so.
+	 */
+	schemaValidation?: RunSchemaValidation;
 	/**
 	 * Whether the run's OAuth 2.0 credential was renewed while it ran.
 	 *

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1010,6 +1010,32 @@ also states that its numbers are counted on every send rather than drawn from th
 stored sample - it sits among figures that *are* sampled, and a reader has no
 other way to tell them apart.
 
+## Sampled Schema Validation (`components/shared/SampledSchemaValidation.tsx`)
+
+Whether the responses a **load** run kept matched the schemas its bound contract
+declares (`RunReport.schemaValidation`, issue #682). Shown in the history
+detail's Overview directly under `ContractCoverage`, which it answers the second
+half of: coverage says what the run exercised, this says whether what came back
+honoured it.
+
+**Its numbers are sampled and the block is built to say so.** The engine defers
+validation to run end over the bounded reservoir of responses the run stored,
+because a load run refills concurrency on every completion. So the card renders
+the `sampled` denominator beside every tally and states outright that the
+coverage block above it is exact while this one is not - the two sit together and
+a reader has no other way to tell which kind each is.
+
+Same absent-vs-zero discipline as `ContractCoverage`: an absent block, or one
+that walked no samples, renders **nothing**. A run whose responses were never
+checked did not pass a contract.
+
+Reasons for a response that could not be checked come from
+`uncheckedReasonText`, the wording the response viewer already shows for a single
+response - one copy, so an aggregate row and a user's own response cannot come to
+describe the same code differently. The chip is red only for a real schema
+failure; a run that checked nothing stays neutral rather than borrowing the
+vocabulary of a failed budget.
+
 ## Captured Data Warning (`components/shared/CapturedDataWarning.tsx`)
 
 Wherever a run's captured response exchanges are on screen: the run stored those

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -379,6 +379,14 @@ and their bodies are a bounded reservoir. Coverage computed from those rows woul
 report an operation as uncovered whenever the store happened to thin the only
 request that touched it.
 
+The two contract blocks a run report carries are therefore **not the same kind of
+number**, and they sit next to each other:
+
+| Block | Counted over | Why |
+|---|---|---|
+| Contract coverage | Every request sent and every response received | One atomic increment per completion is cheap enough for the hot path |
+| [Schema validation](#schema-validation-under-load) | The bounded reservoir of responses the run stored | Validating a body is not, so it is deferred to run end over what was kept |
+
 ### Which document a run is measured against
 
 The document the run was **planned** with, pinned by the `specId` and `specHash`
@@ -462,7 +470,67 @@ part of its schema that would have rejected it was never looked at, and saying s
 is the only honest way to show a green verdict beside a schema that was half
 read.
 
+## Schema validation under load
+
+A **load run** of a bound collection reports whether the responses it kept
+matched the schemas the document declares, in a block on the run's **Overview**
+beside [contract coverage](#contract-coverage).
+
+It is checked **at the end of the run, over the responses the run stored** -
+never as each response arrives. A load run refills concurrency on every
+completion, so a schema walk on that path would cost the run throughput for as
+long as it lasted, and it would do so as a slightly lower RPS nobody would trace
+back to validation. Deferring it is what keeps the numbers the run reports about
+itself honest.
+
+### These numbers are sampled, and the block says so
+
+| Number | What it counts |
+|---|---|
+| Sampled | Responses the run kept and this pass walked - the denominator for everything else |
+| Checked | Of those, the ones a declared schema could speak about |
+| Matched | Checked responses that satisfied their schema |
+| Did not match | Checked responses that did not - the finding |
+| Not checked | Accounted for by reason, one line each, in the same words a single response shows |
+
+So **"0 did not match" means no *sampled* response failed**, not that no response
+failed. A run whose reservoir held 40 of 30,000 responses checked 40 of them.
+That is the difference from the coverage block sitting directly above it, whose
+every number is exact - and it is why the two carry a sentence each saying which
+kind they are.
+
+A response whose body is not JSON, or whose status the document declares nothing
+for, is **not checked** rather than failed. It did not break its contract; no
+schema spoke about it.
+
+### Which responses a run keeps
+
+A load run stores a bounded reservoir per step, drawn uniformly across the whole
+run. A step is kept when something will read it: it carries a **Tests** script,
+or it is bound to an operation and the document carries schemas. The run's whole
+sample budget is split evenly across those steps, so a bound collection that also
+asserts gives each step fewer samples than it would have had for scripts alone.
+What was displaced is reported as the run's dropped-sample count, next to the
+figures it explains.
+
+### When there is no schema-validation block
+
+Absent, never zeros, in each of these cases:
+
+- The collection is not bound to a document.
+- The run was a single request rather than a collection run.
+- The bound document carries **no response schemas** - it was stored before this
+  existed, or declares none. Re-bind or sync the collection.
+- Nothing survived sampling.
+
+A run whose responses were never checked did not pass a contract, and the report
+spells the two differently.
+
+Keywords the validator could not evaluate are disclosed here exactly as they are
+for a single response: **named and counted**, because a matched count computed
+against a schema half of which went unread is narrower than it looks.
+
 ### What is not here yet
 
-Per-step verdicts in a collection run, and validation of the sampled responses of
-a load run. Both are their own change; this page grows with them.
+Per-step verdicts in a collection run, and the opt-in that lets a schema failure
+fail a run. Both are their own change; this page grows with them.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4337,7 +4337,9 @@ sections appear only when relevant (e.g. `rateControl` only for `constant_rps`, 
 only when a test script ran, `thresholdValidation` only when the run declared
 [budgets](#the-thresholds-block-passfail-budgets), `capacity` only for a
 `capacity` run, `auth` only when the run's OAuth 2.0 credential could be
-refreshed mid-run, `coverage` only for a run measured against a bound spec).
+refreshed mid-run, `coverage` only for a run measured against a bound spec,
+`schemaValidation` only for a load run that checked some of its samples against
+one).
 
 The whole-run aggregates come from the run's stored `summary` (written once when the run reaches
 a terminal status - see [db-schema.md](db-schema.md#runs)), combined with the sampled `results`
@@ -4386,6 +4388,43 @@ run; a binding that has since synced to a newer spec cannot rewrite it.
 deliberately plain numbers, shaped like `thresholdValidation`'s counts, so a
 headless CI gate can threshold on them without the block being reshaped. Nothing
 thresholds on them today.
+
+**`schemaValidation`** says whether the responses a **load** run kept matched the
+schemas that same document declares (issue #682). It sits beside `coverage` and
+is computed against the same document, but on different evidence, and the
+difference is the block's most important field: coverage counts every send,
+while this walks the **bounded reservoir of responses the run stored**.
+
+| Field | Meaning |
+|---|---|
+| `sampled` | Responses this pass walked - the denominator for everything else |
+| `checked` | Of those, the ones a declared schema could speak about |
+| `valid` / `failed` | The partition of `checked`. `valid + failed == checked`, always |
+| `unevaluated` | Checked responses whose schema carried a keyword the draft-07 validator could not evaluate |
+| `uncheckedReasons` | Reason code -> count, accounting for every one of `sampled - checked` |
+| `unevaluatedKeywords[]` | `{keyword, count}`, so what went unread is named and not only counted |
+| `failures[]` | Bounded examples: `{step?, status, path, message}` |
+| `failuresTotal` | Every failure found, the cap included - so "3 shown of 90" stays readable |
+
+The reason codes are the ones [`POST /execute`'s validation
+node](#post-execute) uses, unchanged.
+
+**These numbers are sampled, and nothing here pretends otherwise.** Validation is
+deferred to run end because a load run refills concurrency on every completion,
+so a schema walk on that path would cost throughput for the whole run - and would
+do so invisibly. `failed: 0` therefore means "no *sampled* response failed".
+`sampled` is written so a reader always has the denominator; the app renders it
+beside the tallies for the same reason.
+
+A step's responses are kept when a deferred pass will read them - it carries a
+script, or it is bound to an operation and the document carries schemas - and the
+run's sample budget is split evenly across those steps. What was displaced is
+reported as `sampling.response_samples_dropped`.
+
+**Absent, never zeros**, for every run that checked nothing: an unbound
+collection, a single-request run, a document carrying no response schemas, and a
+run whose reservoirs held nothing. A run whose responses were never checked did
+not pass a contract.
 
 **Response:**
 ```json
@@ -4482,6 +4521,12 @@ thresholds on them today.
         "sent": 0, "statusesSeen": [], "declaredHit": [], "declaredMissed": ["204"],
         "undeclaredSeen": [] }
     ]
+  },
+  "schemaValidation": {
+    "sampled": 40, "checked": 36, "valid": 30, "failed": 6, "unevaluated": 0,
+    "uncheckedReasons": { "body_not_json": 4 },
+    "failures": [ { "step": "get pet", "status": 200, "path": "/id", "message": "Value type not permitted by 'type' constraint." } ],
+    "failuresTotal": 6
   },
   "results": [ { "id": 41, "...": "sampled request/response outcomes" } ]
 }

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -516,6 +516,12 @@ default, so `sync_schema()` can
   "thresholds": {
     "checks": [ { "metric": "latencyP99Ms", "limit": 50, "actual": 30.0, "passed": true } ],
     "passed": 1, "failed": 0
+  },
+  "schemaValidation": {
+    "sampled": 40, "checked": 36, "valid": 30, "failed": 6, "unevaluated": 0,
+    "uncheckedReasons": { "body_not_json": 4 },
+    "failures": [ { "step": "get pet", "status": 200, "path": "/id", "message": "..." } ],
+    "failuresTotal": 6
   }
 }
 ```
@@ -532,7 +538,13 @@ from "this run did not measure it". A zero *inside* a present section is meaning
 run over reused connections genuinely has a TLS p50 of 0.
 
 `tests` is **omitted** when deferred script validation did not run, which is what keeps the
-report's `testValidation` section absent rather than reporting zero tests. `thresholds` follows
+report's `testValidation` section absent rather than reporting zero tests. `schemaValidation`
+follows the same rule (issue #682): omitted when the deferred pass over the run's sampled
+responses walked nothing, so an unbound collection's report carries no block rather than one
+saying its contract held. Written in camelCase because the report passes it through verbatim,
+the `phases` rule. Its `sampled` count is stored rather than derived because it is the
+denominator that says these tallies describe the run's bounded reservoir and not the run -
+unlike `coverage` beside it, which is exact. `thresholds` follows
 the same rule and for the same reason: absent when the run declared no
 [budgets](api-reference.md#the-thresholds-block-passfail-budgets), so the report's
 `thresholdValidation` section is left out rather than claiming a run passed nothing. Its `metric`

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -195,6 +195,17 @@ Three things worth knowing before you design around them:
   restored panes cannot disagree. The status-pattern matcher is shared with
   coverage (`match_status_pattern`), so one status cannot be "covered" by one
   rule and "no schema for this status" by another.
+  **Under load the same check is deferred to run end** (#682):
+  `validate_sampled_responses` walks the per-step sample reservoirs once the run
+  has drained and stores `schemaValidation` on `runs.summary`, because the load
+  loop refills concurrency per completion and a schema walk there would cost
+  throughput invisibly - a source-scan test fails if validation reaches
+  `load_strategy.cpp` / `scenario_load.cpp`. That makes the tallies **sampled
+  where `coverage` beside them is exact**, so the block stores its own `sampled`
+  denominator and every reader prints it. A step's responses are now kept for
+  either of two reasons - a script to replay, or a contract to check - which is
+  what `configure_step_samples` is told; one budget covers both, so a bound
+  collection that also asserts thins each step's share.
 - **`followRedirects` / `maxRedirects` are per-request and stored** (request
   builder → **Settings** tab, `requests.follow_redirects` / `max_redirects`).
   Both clients send them on *every* execute and load test rather than eliding

--- a/engine/include/vayu/core/metrics_collector.hpp
+++ b/engine/include/vayu/core/metrics_collector.hpp
@@ -355,25 +355,31 @@ class MetricsCollector {
     /**
      * @brief Size the per-step sample stores for a scenario load run (#450).
      *
-     * @param scripted One entry per plan step, true where that step carries a
-     *        deferred script. A step with none is given no store at all: it is
-     *        never sampled and never counted as a drop, because nothing was
-     *        ever a candidate for a reservoir that does not exist.
+     * @param sampled One entry per plan step, true where a deferred pass will
+     *        read that step's responses - it carries a script to replay, or a
+     *        contract to check against (issue #682). A step no pass will read
+     *        is given no store at all: it is never sampled and never counted as
+     *        a drop, because nothing was ever a candidate for a reservoir that
+     *        does not exist.
      *
      * The run's whole `max_response_samples` budget is split evenly across the
-     * **scripted** steps rather than across every step, so a forty-step plan
-     * with two assertions gives those two the budget instead of thinning it
-     * forty ways down to noise. The split has a floor of one sample per
-     * scripted step: a plan with more scripted steps than the budget has slots
-     * still validates every one of them, which is the property "the last step
-     * of a long plan is sampled" actually needs. That floor is the only case
-     * where the retained total can exceed the configured budget, and it is
-     * bounded by `maxScenarioSteps`.
+     * **read** steps rather than across every step, so a forty-step plan with
+     * two assertions gives those two the budget instead of thinning it forty
+     * ways down to noise. The split has a floor of one sample per read step: a
+     * plan with more of them than the budget has slots still validates every
+     * one, which is the property "the last step of a long plan is sampled"
+     * actually needs. That floor is the only case where the retained total can
+     * exceed the configured budget, and it is bounded by `maxScenarioSteps`.
+     *
+     * One budget, shared by both readers: a bound collection whose steps also
+     * assert gives each step fewer samples than it would have had for scripts
+     * alone. That is the honest cost of checking more of the run, and what was
+     * thinned is disclosed as `response_samples_dropped` either way.
      *
      * Called once, before the first submission. Calling it twice, or after a
      * completion has landed, would resize a store a worker may be inside.
      */
-    void configure_step_samples (const std::vector<bool>& scripted);
+    void configure_step_samples (const std::vector<bool>& sampled);
 
     /**
      * @brief Record a response sample against the plan step that produced it.

--- a/engine/include/vayu/core/run_manager.hpp
+++ b/engine/include/vayu/core/run_manager.hpp
@@ -27,6 +27,7 @@
 #include "vayu/core/metrics_collector.hpp"
 #include "vayu/core/monitor.hpp"
 #include "vayu/core/scenario_plan.hpp"
+#include "vayu/core/schema_validation.hpp"
 #include "vayu/core/threshold_eval.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/event_loop.hpp"
@@ -536,6 +537,32 @@ vayu::db::Database& db,
 bool verbose);
 
 /**
+ * @brief Check a drained load run's sampled responses against the contract it
+ *        was planned against (issue #682, phase 3c of #625).
+ *
+ * **Deferred, and that is the whole design.** The load loop refills concurrency
+ * per completion, so anything on that path costs throughput for the rest of the
+ * run - the reason the script replay is deferred too. Validation therefore
+ * happens once, here, over the reservoirs that survived, and the numbers it
+ * produces describe *those samples* rather than the run. `SampledValidationTotals`
+ * carries its own denominator so a report can say so.
+ *
+ * Scenario load runs only, and only bound ones: a single-request load run
+ * resolves no collection and therefore no binding, exactly as contract coverage
+ * does. Returns totals with `sampled == 0` - which the caller stores as no
+ * section at all - for a run with no schema index, no bound step, or no
+ * surviving sample.
+ *
+ * Declared here rather than kept file-local so the pass can be driven against a
+ * hand-seeded collector in tests; the production caller is `execute_load_test`,
+ * beside `validate_scripts`.
+ *
+ * @param verbose Log the tallies, as the run's own logging does.
+ */
+[[nodiscard]] SampledValidationTotals validate_sampled_responses (
+const std::shared_ptr<RunContext>& context, bool verbose);
+
+/**
  * @brief Hang each step's deferred-validation tallies off its entry in a
  *        scenario summary's `steps` array.
  *
@@ -632,6 +659,13 @@ struct RunSummaryInputs {
     // which is what keeps the report's coverage section out entirely rather
     // than reporting an unbound collection zero of zero operations covered.
     std::optional<nlohmann::json> coverage;
+    // What checking this run's *sampled* responses against the bound contract
+    // found, under the summary's `schemaValidation` key (issue #682). Absent -
+    // and an empty object is treated as absent - for a run that validated
+    // nothing, which keeps the report's section out rather than reporting an
+    // unbound collection a contract nothing failed. Its sibling `coverage` is
+    // exact where this is sampled; see `SampledValidationTotals`.
+    std::optional<nlohmann::json> schema_validation;
     // What the server-vitals scrape recorded, under the summary's `monitor`
     // key. Absent for a run that configured no monitor - the report then omits
     // the section entirely rather than showing a run that scraped nothing.

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -149,6 +149,22 @@ struct SpecBinding {
      * measured", which leaves the coverage block out entirely.
      */
     std::vector<DeclaredOperation> declared_operations;
+    /**
+     * The bound document's stored `response_schemas`, verbatim (issue #682).
+     *
+     * Carried as **text**, not as a parsed `ResponseSchemaIndex`: parsing a
+     * document's whole schema index is the expensive half and nothing during
+     * the run needs it, so the run pays for it once at the end, in the deferred
+     * pass, or not at all. That is the same bargain
+     * `core/schema_validation.hpp` states for why the schemas are a column of
+     * their own rather than folded into `operations`.
+     *
+     * Read here, at resolution, under the same hash check the operations are -
+     * a run is judged against the document it was *planned* against, and a sync
+     * landing mid-run moves the binding to a document this run never saw. Empty
+     * for every case that leaves the schema-validation block out entirely.
+     */
+    std::string response_schemas;
     [[nodiscard]] bool bound () const {
         return !spec_id.empty ();
     }

--- a/engine/include/vayu/core/schema_validation.hpp
+++ b/engine/include/vayu/core/schema_validation.hpp
@@ -72,6 +72,7 @@
  */
 
 #include <cstddef>
+#include <map>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
@@ -235,6 +236,93 @@ class ResponseSchemaIndex {
     std::unordered_map<std::string, size_t> by_operation_id_;
     std::unordered_map<std::string, size_t> by_method_path_;
 };
+
+/**
+ * @brief What a deferred pass over a load run's sampled responses found
+ *        (issue #682, phase 3c of #625).
+ *
+ * **Every number here describes the samples, not the run.** A load run stores a
+ * bounded reservoir of responses per step, and this pass validates that
+ * reservoir at run end - never on the completion path, which refills
+ * concurrency and would pay for a schema walk per response. So `failed: 0`
+ * means "no *sampled* response failed", and the report has to say so beside it;
+ * that is why `sampled` is carried rather than only the four tallies #682 named
+ * - a reader who cannot see the denominator cannot tell a clean run from a
+ * thinly sampled one.
+ *
+ * Contrast `CoverageTally`, whose every number is exact: coverage counts on
+ * each send, through an atomic increment cheap enough for the hot path.
+ * Validation cannot be, and `docs/app/openapi.md`'s exact-vs-sampled table
+ * records which is which.
+ */
+struct SampledValidationTotals {
+    /// Responses this pass walked - the denominator for everything below.
+    size_t sampled = 0;
+    /// Of those, the ones a schema could speak about. `sampled - checked` is
+    /// explained by `unchecked_reasons` rather than left as a gap.
+    size_t checked = 0;
+    /// `valid + failed == checked`, always.
+    size_t valid  = 0;
+    size_t failed = 0;
+    /**
+     * Checked responses whose schema carried a keyword the draft-07 validator
+     * could not evaluate. Counted separately from `valid`/`failed` rather than
+     * subtracted from either: such a response really did pass every check that
+     * ran, and what is being disclosed is that some of its contract went
+     * unread. The dialect-honesty rule of the file comment, in aggregate.
+     */
+    size_t unevaluated = 0;
+    /// Reason code (`to_string(UncheckedReason)`) -> how many samples it
+    /// accounts for. Ordered by the map, so two runs print it the same way.
+    std::map<std::string, size_t> unchecked_reasons;
+    /// Every unevaluatable keyword this run's checked schemas carried, by name,
+    /// with how many responses met it. Named, never just counted - a bare
+    /// "3 unevaluated" tells a reader nothing they can act on.
+    std::map<std::string, size_t> unevaluated_keywords;
+    /**
+     * Bounded examples of what failed, so the block says *what* was wrong and
+     * not only how often. Capped at `constants::schema_validation::MAX_FAILURES`
+     * across the whole run - the same cap one response's verdict is held to,
+     * because a run-wide list is read for the same reason and a forty-step plan
+     * must not multiply it by forty.
+     */
+    struct FailureExample {
+        /// The plan step whose response failed, by name. Empty for a
+        /// single-request shape, which has no step to name.
+        std::string step;
+        int status = 0;
+        /// JSON Pointer into the body, `""` for the body itself.
+        std::string path;
+        std::string message;
+    };
+    std::vector<FailureExample> failure_examples;
+    /// Failures found across every sampled response, including the ones past
+    /// the cap - so `failure_examples.size()` can be read as "3 shown of 90".
+    size_t failures_total = 0;
+
+    /**
+     * @brief Fold one response's verdict in.
+     *
+     * @param step The plan step's name, for a failure example that may be read
+     *        far from the per-step breakdown.
+     * @param status The response's status code, for the same reason.
+     */
+    void record (const ValidationVerdict& verdict, const std::string& step, int status);
+};
+
+/**
+ * @brief The `schemaValidation` object a load run stores in `runs.summary`.
+ *
+ * camelCase, passed through verbatim by the report route - the `coverage` and
+ * `stream` rule, for their reason: one description of the shape rather than a
+ * writer and a translator that can drift.
+ *
+ * Returns an **empty object** when the pass walked no samples at all, which the
+ * caller leaves out of the summary entirely. A run whose reservoirs were empty
+ * validated nothing, and reporting it zeros would read as a contract nothing
+ * failed - the absent-not-zeros rule every conditional section here follows.
+ */
+[[nodiscard]] nlohmann::json build_sampled_validation_payload (const SampledValidationTotals& totals);
 
 /**
  * @brief Validate one JSON body against one schema.

--- a/engine/src/core/load_strategy.cpp
+++ b/engine/src/core/load_strategy.cpp
@@ -209,11 +209,11 @@ const ResultAnnotations& annotations) {
         context->metrics_collector->record_bytes (
         response.timing.bytes_up, response.timing.bytes_down);
 
-        // Sample the response for the deferred validation pass. A scenario
-        // step's script is keyed to the step, not to the run, so its sample
-        // goes to that step's own reservoir - the collector refuses the ones
-        // whose step carries no script. A single-request run keeps the one
-        // run-level store it always had.
+        // Sample the response for the deferred validation passes. What reads a
+        // scenario sample - a step's script, a step's contract - is keyed to
+        // the step, not to the run, so it goes to that step's own reservoir;
+        // the collector refuses the steps nothing will read. A single-request
+        // run keeps the one run-level store it always had.
         if (annotations.step_index) {
             context->metrics_collector->record_step_response_sample (response,
             *annotations.step_index, annotations.iteration.value_or (0),

--- a/engine/src/core/metrics_collector.cpp
+++ b/engine/src/core/metrics_collector.cpp
@@ -450,27 +450,27 @@ void MetricsCollector::record_response_sample (const Response& response) {
 
 const std::vector<ResponseSample> MetricsCollector::NO_SAMPLES;
 
-void MetricsCollector::configure_step_samples (const std::vector<bool>& scripted) {
+void MetricsCollector::configure_step_samples (const std::vector<bool>& sampled) {
     step_samples_.clear ();
-    if (scripted.empty ()) {
+    if (sampled.empty ()) {
         return;
     }
 
-    const size_t scripted_steps =
-    static_cast<size_t> (std::count (scripted.begin (), scripted.end (), true));
+    const size_t read_steps =
+    static_cast<size_t> (std::count (sampled.begin (), sampled.end (), true));
 
-    // The whole run budget across the steps that will actually be validated,
-    // floored at one so a plan with more scripted steps than slots still
-    // samples every one of them. See the header for why the floor is the
-    // deliberate over-run and not an oversight.
-    const size_t per_step = scripted_steps == 0 ?
+    // The whole run budget across the steps a deferred pass will actually read,
+    // floored at one so a plan with more of them than slots still samples every
+    // one. See the header for why the floor is the deliberate over-run and not
+    // an oversight.
+    const size_t per_step = read_steps == 0 ?
     0 :
-    std::max<size_t> (1, config_.max_response_samples / scripted_steps);
+    std::max<size_t> (1, config_.max_response_samples / read_steps);
 
-    step_samples_.reserve (scripted.size ());
-    for (bool has_script : scripted) {
+    step_samples_.reserve (sampled.size ());
+    for (bool is_read : sampled) {
         auto store      = std::make_unique<StepSampleStore> ();
-        store->capacity = has_script ? per_step : 0;
+        store->capacity = is_read ? per_step : 0;
         store->samples.reserve (store->capacity);
         step_samples_.push_back (std::move (store));
     }
@@ -484,7 +484,7 @@ std::optional<size_t> data_row_index) {
         return;
     }
     StepSampleStore& store = *step_samples_[step_index];
-    // A step no script will ever read. Refused before the rate counter, so an
+    // A step no deferred pass will read. Refused before the rate counter, so an
     // unsampled step costs one load and one compare per completion.
     if (store.capacity == 0) {
         return;

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -369,6 +369,76 @@ bool verbose) {
     return validation;
 }
 
+SampledValidationTotals validate_sampled_responses (
+const std::shared_ptr<RunContext>& context, bool verbose) {
+    SampledValidationTotals totals;
+
+    // Scenario load runs only. A single-request load run resolves no collection
+    // and so no binding - the same reason it reports no coverage - and the
+    // per-step stores are what a scenario run is recognised by, exactly as the
+    // script pass recognises it.
+    if (context->scenario == nullptr ||
+    context->metrics_collector->step_sample_step_count () == 0) {
+        return totals;
+    }
+
+    const auto& spec = context->scenario->spec;
+    if (spec.response_schemas.empty ()) {
+        return totals;
+    }
+
+    // The one parse of the document's schema index this run ever pays for, and
+    // it happens after the last completion has landed. An index that will not
+    // parse is "not measured", the reading every other reader of a stored index
+    // gives it - never an empty contract that would pass every body.
+    const auto index = ResponseSchemaIndex::parse (spec.response_schemas);
+    if (!index) {
+        return totals;
+    }
+
+    const auto& plan   = context->scenario->plan;
+    const size_t steps = std::min (plan.steps.size (),
+    context->metrics_collector->step_sample_step_count ());
+
+    for (size_t i = 0; i < steps; ++i) {
+        const auto& step = plan.steps[i];
+        // A step bound to no operation is not a step this contract speaks
+        // about. Skipped rather than counted as unchecked: it would fill the
+        // block with `no_operation` for every unbound step of a mixed
+        // collection, which says nothing about the contract.
+        if (step.spec_operation.empty ()) {
+            continue;
+        }
+
+        const auto& samples = context->metrics_collector->step_response_samples (i);
+        for (const auto& sample : samples) {
+            const auto content_type = sample.headers.find ("Content-Type");
+            try {
+                totals.record (index->check (step.spec_operation, sample.status_code,
+                               content_type != sample.headers.end () ?
+                               content_type->second :
+                               std::string (),
+                               sample.body),
+                step.name, sample.status_code);
+            } catch (const std::exception& e) {
+                // A validator that threw is not a response that failed, and it
+                // must not cost the run the rest of its samples. Same rule the
+                // design-mode hook applies to the same call.
+                vayu::utils::log_warning (
+                "Schema validation of a sample failed: " + std::string (e.what ()));
+            }
+        }
+    }
+
+    if (verbose && totals.sampled > 0) {
+        vayu::utils::log_info ("  Schema validation: " + std::to_string (totals.checked) +
+        " of " + std::to_string (totals.sampled) + " samples checked, " +
+        std::to_string (totals.valid) + " valid, " + std::to_string (totals.failed) +
+        " failed");
+    }
+    return totals;
+}
+
 void attach_step_test_totals (nlohmann::json& scenario,
 const std::vector<std::optional<ScriptValidationTotals>>& per_step) {
     auto steps = scenario.find ("steps");
@@ -1048,6 +1118,18 @@ RunManager& manager) {
             "Script validation failed: " + std::string (e.what ()));
         }
 
+        // The other deferred pass over the same reservoirs (issue #682): what
+        // the bound contract says about the responses that survived sampling.
+        // Here, beside the script replay, for its reason - the completion path
+        // refills concurrency, and neither pass may be on it.
+        SampledValidationTotals schema_totals;
+        try {
+            schema_totals = validate_sampled_responses (context, verbose);
+        } catch (const std::exception& e) {
+            vayu::utils::log_error (
+            "Schema validation failed: " + std::string (e.what ()));
+        }
+
         // Store the whole-run summary: everything the report used to rebuild by
         // scanning the run's metric rows, written once, here.
         try {
@@ -1098,6 +1180,11 @@ RunManager& manager) {
                 // the payload builder treats as absent.
                 inputs.coverage = build_scenario_load_coverage (*scenario_state);
             }
+            // Beside coverage, and deliberately not inside the `scenario_state`
+            // block above: this pass reads the sample reservoirs, which are the
+            // collector's, so it is available whether or not the executor left
+            // a state behind. An empty object is treated as absent.
+            inputs.schema_validation = build_sampled_validation_payload (schema_totals);
 
             // Judged last, off the filled inputs rather than off the collector:
             // the verdict has to be computed from the same numbers the summary
@@ -1342,6 +1429,15 @@ nlohmann::json build_run_summary_payload (const RunSummaryInputs& inputs) {
     // section reads as "not measured" rather than as a contract nothing covered.
     if (inputs.coverage.has_value () && !inputs.coverage->empty ()) {
         summary["coverage"] = *inputs.coverage;
+    }
+    // What the deferred pass over this run's *sampled* responses found against
+    // the bound contract (issue #682). Omitted, on the same empty-is-absent
+    // terms as `coverage`, for every run that validated nothing - so an absent
+    // section reads as "not checked" rather than as a contract nothing broke.
+    // Unlike `coverage` beside it, these numbers describe the samples: the
+    // block carries its own `sampled` denominator and the report says so.
+    if (inputs.schema_validation.has_value () && !inputs.schema_validation->empty ()) {
+        summary["schemaValidation"] = *inputs.schema_validation;
     }
     // What the server-vitals scrape recorded. Omitted for a run that configured
     // no monitor, so the report's section is absent rather than showing a run

--- a/engine/src/core/scenario_load.cpp
+++ b/engine/src/core/scenario_load.cpp
@@ -264,16 +264,25 @@ const ScenarioExecution& execution) {
         context->requests_expected = max_iterations * step_count;
     }
 
-    // Which steps the deferred pass will have a script for. Sized here, before
+    // Which steps the deferred pass will read a sample of. Sized here, before
     // the first submission, because the completion path only ever reads it.
-    // A plan whose steps assert nothing gets no stores at all, so it samples
-    // nothing and the report omits the section rather than showing zeros.
+    // A plan no deferred pass will look at gets no stores at all, so it samples
+    // nothing and the report omits the sections rather than showing zeros.
+    //
+    // Two reasons to keep a step's responses, not one (issue #682): a script to
+    // replay against them, or a contract to check them against. A step bound to
+    // an operation is a candidate whenever the run carries a schema index -
+    // whether the index actually *declares* that operation is a question only
+    // the deferred pass can answer, and answering it here would mean parsing
+    // the whole index on the setup path to save a reservoir.
     {
-        std::vector<bool> scripted (step_count, false);
+        const bool validating = !execution.spec.response_schemas.empty ();
+        std::vector<bool> sampled (step_count, false);
         for (size_t i = 0; i < step_count; ++i) {
-            scripted[i] = !plan.steps[i].post_script.empty ();
+            sampled[i] = !plan.steps[i].post_script.empty () ||
+            (validating && !plan.steps[i].spec_operation.empty ());
         }
-        context->metrics_collector->configure_step_samples (scripted);
+        context->metrics_collector->configure_step_samples (sampled);
     }
 
     vayu::utils::log_info ("Starting Scenario Load Test (" + mode + ")");

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -317,12 +317,18 @@ const ScenarioResolveOptions& options) {
     // a contract from. Any disagreement - no such document, no index on it, a
     // hash that does not match - leaves the operations empty, which is the
     // engine's one spelling of "not measured against a contract".
+    //
+    // The response schemas ride the same read and the same hash check (issue
+    // #682): the deferred pass at run end validates against them, and looking
+    // them up then instead would be the one thing this read exists to prevent.
+    // They are taken as text and parsed only if that pass runs.
     if (resolution.spec.bound ()) {
         if (const auto document = db.get_spec_document (resolution.spec.spec_id);
             document && document->hash == resolution.spec.spec_hash) {
             if (auto declared = parse_declared_operations (document->operations)) {
                 resolution.spec.declared_operations = std::move (*declared);
             }
+            resolution.spec.response_schemas = document->response_schemas;
         }
     }
 

--- a/engine/src/core/schema_validation.cpp
+++ b/engine/src/core/schema_validation.cpp
@@ -248,6 +248,92 @@ nlohmann::json build_validation_payload (const ValidationVerdict& verdict) {
     return node;
 }
 
+void SampledValidationTotals::record (const ValidationVerdict& verdict,
+const std::string& step,
+int status) {
+    ++sampled;
+
+    if (!verdict.checked) {
+        // Counted by reason rather than as a failure. A body a JSON Schema
+        // cannot speak about is not a body that broke its contract, and folding
+        // the two would make every HTML error page look like a schema failure.
+        ++unchecked_reasons[to_string (verdict.reason.value_or (UncheckedReason::NoIndex))];
+        return;
+    }
+
+    ++checked;
+    if (verdict.valid) {
+        ++valid;
+    } else {
+        ++failed;
+    }
+
+    if (!verdict.unevaluated_keywords.empty ()) {
+        ++unevaluated;
+        for (const auto& [keyword, count] : verdict.unevaluated_keywords) {
+            unevaluated_keywords[keyword] += count;
+        }
+    }
+
+    // The run-wide total counts every failure the verdicts found, including the
+    // ones each verdict's own cap already hid - so the "shown of found" figure
+    // is honest about both caps rather than only this one.
+    failures_total += verdict.failures_total;
+    for (const auto& failure : verdict.failures) {
+        if (failure_examples.size () >= limits::MAX_FAILURES) {
+            break;
+        }
+        failure_examples.push_back (
+        FailureExample{ step, status, failure.path, failure.message });
+    }
+}
+
+nlohmann::json build_sampled_validation_payload (const SampledValidationTotals& totals) {
+    if (totals.sampled == 0) {
+        return nlohmann::json::object ();
+    }
+
+    nlohmann::json node;
+    // `sampled` first and always: it is the denominator that makes the rest
+    // readable, and the one number that says these figures describe a sample.
+    node["sampled"]     = totals.sampled;
+    node["checked"]     = totals.checked;
+    node["valid"]       = totals.valid;
+    node["failed"]      = totals.failed;
+    node["unevaluated"] = totals.unevaluated;
+
+    if (!totals.unchecked_reasons.empty ()) {
+        nlohmann::json reasons = nlohmann::json::object ();
+        for (const auto& [reason, count] : totals.unchecked_reasons) {
+            reasons[reason] = count;
+        }
+        node["uncheckedReasons"] = reasons;
+    }
+
+    if (!totals.unevaluated_keywords.empty ()) {
+        nlohmann::json keywords = nlohmann::json::array ();
+        for (const auto& [keyword, count] : totals.unevaluated_keywords) {
+            keywords.push_back ({ { "keyword", keyword }, { "count", count } });
+        }
+        node["unevaluatedKeywords"] = keywords;
+    }
+
+    nlohmann::json failures = nlohmann::json::array ();
+    for (const auto& example : totals.failure_examples) {
+        nlohmann::json entry = { { "status", example.status },
+            { "path", example.path }, { "message", example.message } };
+        if (!example.step.empty ()) {
+            entry["step"] = example.step;
+        }
+        failures.push_back (std::move (entry));
+    }
+    node["failures"] = failures;
+    // Always present, like the per-response verdict's own: a reader comparing
+    // the list's length against it needs the number to be there to compare.
+    node["failuresTotal"] = totals.failures_total;
+    return node;
+}
+
 std::vector<std::pair<std::string, size_t>>
 collect_unevaluated_keywords (const nlohmann::json& schema, const nlohmann::json& ref_roots) {
     const nlohmann::json root = validation_root (schema, ref_roots);

--- a/engine/src/http/routes/runs.cpp
+++ b/engine/src/http/routes/runs.cpp
@@ -231,6 +231,13 @@ struct ReportExtras {
     // stored before the operation index existed - and leaves the section out,
     // because a run that was never judged against a contract did not fail one.
     nlohmann::json coverage = nlohmann::json::object ();
+    // What checking the run's *sampled* responses against that same contract
+    // found (issue #682), passed through verbatim on the `coverage` terms.
+    // Empty is every run that validated nothing - an unbound collection, a
+    // single-request run, a document carrying no response schemas - and leaves
+    // the section out, because a run whose responses were never checked did not
+    // pass a contract. Sampled where `coverage` is exact; the block says so.
+    nlohmann::json schema_validation = nlohmann::json::object ();
 };
 
 // Read a number out of a JSON object, leaving @p out untouched when the key is
@@ -465,6 +472,16 @@ ReportExtras& extras) {
     summary["coverage"]["operations"].is_array () &&
     !summary["coverage"]["operations"].empty ()) {
         extras.coverage = summary["coverage"];
+    }
+
+    // Same again for sampled schema validation (issue #682). A block with no
+    // `sampled` count says nothing a reader can act on - and cannot be labelled
+    // honestly as a sample - so it is treated as absent.
+    if (summary.contains ("schemaValidation") && summary["schemaValidation"].is_object () &&
+    summary["schemaValidation"].contains ("sampled") &&
+    summary["schemaValidation"]["sampled"].is_number () &&
+    summary["schemaValidation"]["sampled"].get<size_t> () > 0) {
+        extras.schema_validation = summary["schemaValidation"];
     }
 
     if (summary.contains ("thresholds") && summary["thresholds"].is_object ()) {
@@ -1070,6 +1087,17 @@ const std::string& run_id) {
     // that was not measured against a contract; see ReportExtras::coverage.
     if (!extras.coverage.empty ()) {
         json_report["coverage"] = extras.coverage;
+    }
+
+    // Whether the responses this run kept matched the schemas that same
+    // document declares (issue #682). Beside `coverage` because they answer
+    // halves of one question - which of the contract was exercised, and whether
+    // what came back honoured it - but on different evidence: coverage counts
+    // every send, this checks the bounded reservoir the run stored. The
+    // `sampled` count rides along so a reader cannot mistake one for the other.
+    // Absent for every run that checked nothing; see ReportExtras.
+    if (!extras.schema_validation.empty ()) {
+        json_report["schemaValidation"] = extras.schema_validation;
     }
 
     // The aggregate verdict, beside the per-response one. `verdict` is derived

--- a/engine/tests/runs_route_test.cpp
+++ b/engine/tests/runs_route_test.cpp
@@ -910,6 +910,82 @@ TEST_F (RunsRouteTest, ReportOmitsCoverageForARunNotMeasuredAgainstAContract) {
     EXPECT_FALSE (empty_body.contains ("coverage")) << empty_body.dump ();
 }
 
+// ---------------------------------------------------------------------------
+// Sampled schema validation (issue #682)
+// ---------------------------------------------------------------------------
+
+// The same whole path, for the block beside coverage: the deferred pass tallies
+// what the reservoirs held, the summary stores it, and the report hands it back
+// unchanged. Nothing translates a name here either.
+TEST_F (RunsRouteTest, ReportCarriesTheSchemaValidationBlockTheRunComputed) {
+    seed ({ .id = "run_schema", .start_time = 1000 });
+
+    vayu::core::ValidationVerdict passed;
+    passed.checked = true;
+    passed.valid   = true;
+    vayu::core::ValidationVerdict broke;
+    broke.checked        = true;
+    broke.valid          = false;
+    broke.failures       = { vayu::core::SchemaFailure{ "/id", "expected integer" } };
+    broke.failures_total = 1;
+    vayu::core::ValidationVerdict skipped;
+    skipped.reason = vayu::core::UncheckedReason::BodyNotJson;
+
+    vayu::core::SampledValidationTotals totals;
+    totals.record (passed, "list pets", 200);
+    totals.record (broke, "get pet", 200);
+    totals.record (skipped, "get pet", 500);
+
+    auto inputs             = summary_inputs ();
+    inputs.schema_validation = vayu::core::build_sampled_validation_payload (totals);
+    db_->update_run_summary (
+    "run_schema", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_schema");
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body.contains ("schemaValidation")) << body.dump ();
+    const auto& validation = body["schemaValidation"];
+    // The denominator rides through: without it a reader cannot tell these
+    // figures describe the reservoir rather than the run.
+    EXPECT_EQ (validation["sampled"].get<size_t> (), 3u);
+    EXPECT_EQ (validation["checked"].get<size_t> (), 2u);
+    EXPECT_EQ (validation["valid"].get<size_t> (), 1u);
+    EXPECT_EQ (validation["failed"].get<size_t> (), 1u);
+    EXPECT_EQ (validation["uncheckedReasons"]["body_not_json"].get<size_t> (), 1u);
+    ASSERT_EQ (validation["failures"].size (), 1u);
+    EXPECT_EQ (validation["failures"][0]["step"].get<std::string> (), "get pet");
+}
+
+// The absent-not-zeros gate, in both shapes it arrives in: a run whose summary
+// carries no block, and one carrying an object that checked nothing. Neither
+// reports a contract nothing failed.
+//
+// Mutation-check: drop the `sampled > 0` condition in the route's reader and
+// the second half reddens - the report gains a block claiming a clean run.
+TEST_F (RunsRouteTest, ReportOmitsSchemaValidationForARunThatCheckedNothing) {
+    seed ({ .id = "run_no_schema", .start_time = 1000 });
+    auto inputs              = summary_inputs ();
+    inputs.schema_validation = std::nullopt;
+    db_->update_run_summary (
+    "run_no_schema", vayu::core::build_run_summary_payload (inputs).dump ());
+
+    auto [status, body] = vayu::http::routes::run_report_response (*db_, "run_no_schema");
+    ASSERT_EQ (status, 200);
+    EXPECT_FALSE (body.contains ("schemaValidation")) << body.dump ();
+
+    seed ({ .id = "run_empty_schema", .start_time = 1000 });
+    auto empty              = summary_inputs ();
+    empty.schema_validation = nlohmann::json{ { "sampled", 0 }, { "checked", 0 },
+        { "valid", 0 }, { "failed", 0 } };
+    db_->update_run_summary (
+    "run_empty_schema", vayu::core::build_run_summary_payload (empty).dump ());
+
+    auto [empty_status, empty_body] =
+    vayu::http::routes::run_report_response (*db_, "run_empty_schema");
+    ASSERT_EQ (empty_status, 200);
+    EXPECT_FALSE (empty_body.contains ("schemaValidation")) << empty_body.dump ();
+}
+
 // The anchor coverage is read against, asserted at the route for the first time
 // (noted on #629 when phase 1 closed): the report echoes the *snapshot's*
 // binding, so a reader can say which document a coverage block was computed

--- a/engine/tests/scenario_load_test.cpp
+++ b/engine/tests/scenario_load_test.cpp
@@ -1149,3 +1149,198 @@ TEST_F (ScenarioLoadTest, ConcurrencyIsTheVirtualUserCountAndBoundsInFlight) {
        "once";
     EXPECT_GT (state->steps_executed.load (), 0u);
 }
+
+// ============================================================================
+// Deferred schema validation over the sampled responses (issue #682)
+// ============================================================================
+
+namespace {
+
+/// The stored `response_schemas` text for a plan whose steps are bound to
+/// `step<i>` operations, each declaring one 200 response.
+///
+/// Built through the wire shape rather than a hand-made index so a change to
+/// what the app stores fails here rather than passing against a private fixture.
+std::string schema_index_for (const std::vector<json>& schemas) {
+    json operations = json::array ();
+    for (size_t i = 0; i < schemas.size (); ++i) {
+        operations.push_back (json{ { "operationId", "step" + std::to_string (i) },
+            { "method", "GET" }, { "path", "/s" + std::to_string (i) },
+            { "responses", json::array ({ json{ { "status", "200" },
+                              { "contentType", "application/json" },
+                              { "schema", schemas[i] } } }) } });
+    }
+    return json{ { "refRoots", json::object () }, { "operations", operations } }.dump ();
+}
+
+/// Bind every step of @p execution to the operation of the same index, and give
+/// the run the index those operations are declared in.
+void bind_to_schemas (vayu::core::ScenarioExecution& execution,
+const std::vector<json>& schemas) {
+    execution.spec.spec_id   = "spec_1";
+    execution.spec.spec_hash = "hash_1";
+    execution.spec.response_schemas = schema_index_for (schemas);
+    for (size_t i = 0; i < execution.plan.steps.size (); ++i) {
+        execution.plan.steps[i].spec_operation =
+        json{ { "operationId", "step" + std::to_string (i) }, { "method", "GET" },
+            { "path", "/s" + std::to_string (i) } }
+        .dump ();
+    }
+}
+
+/// The mock answers every step with `{}`, so this passes and `strict_schema`
+/// does not - which is what lets one run produce both verdicts.
+json open_schema () {
+    return json{ { "type", "object" } };
+}
+
+json strict_schema () {
+    return json{ { "type", "object" }, { "required", json::array ({ "id" }) } };
+}
+
+} // namespace
+
+// A step bound to an operation is sampled even when it carries no script - the
+// contract is the second reason to keep a response, and without it a bound
+// collection that asserts nothing would validate nothing at all.
+//
+// Mutation-check: restore the scripted-only condition in `execute_scenario_load`
+// and both stores are empty, so every assertion below reddens.
+TEST_F (ScenarioLoadTest, ABoundStepIsSampledWithNoScriptOfItsOwn) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0"), server.url ("/s1") });
+    bind_to_schemas (execution, { open_schema (), open_schema () });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto& mc = *context_->metrics_collector;
+    EXPECT_GT (mc.step_response_samples (0).size (), 0u)
+    << "a step bound to an operation was never sampled, so its contract can "
+       "never be checked";
+    EXPECT_GT (mc.step_response_samples (1).size (), 0u);
+}
+
+// The run's own binding decides it: a plan whose steps name no operation is
+// sampled exactly as it was before this existed, so an unbound collection pays
+// nothing for a feature it cannot use.
+TEST_F (ScenarioLoadTest, AnUnboundPlanStillSamplesOnlyItsScriptedSteps) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0"), server.url ("/s1") });
+    execution.plan.steps[0].post_script = "pm.test('t', function () { });";
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto& mc = *context_->metrics_collector;
+    EXPECT_GT (mc.step_response_samples (0).size (), 0u);
+    EXPECT_EQ (mc.step_response_samples (1).size (), 0u)
+    << "an unbound step with no script was sampled - a body-sized copy nothing "
+       "will read";
+}
+
+TEST_F (ScenarioLoadTest, ABoundRunReportsTalliesOverItsSampledResponses) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0"), server.url ("/s1") });
+    // One operation the mock's `{}` satisfies and one it does not, so a single
+    // run produces both verdicts and the partition is observable.
+    bind_to_schemas (execution, { open_schema (), strict_schema () });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 3 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto totals = vayu::core::validate_sampled_responses (context_, false);
+
+    EXPECT_EQ (totals.sampled, 6u);
+    EXPECT_EQ (totals.checked, 6u);
+    EXPECT_EQ (totals.valid, 3u);
+    EXPECT_EQ (totals.failed, 3u);
+    ASSERT_FALSE (totals.failure_examples.empty ());
+    EXPECT_EQ (totals.failure_examples.front ().step, "step1")
+    << "the failing step must be named, or a reader cannot act on the example";
+    EXPECT_EQ (totals.failure_examples.front ().status, 200);
+}
+
+// The gate the whole block turns on: a run of an unbound collection is not a
+// run that passed its contract.
+//
+// Mutation-check: drop the `response_schemas.empty()` guard in
+// `validate_sampled_responses` and this reports a block of zeros instead.
+TEST_F (ScenarioLoadTest, AnUnboundRunValidatesNothingAtAll) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0"), server.url ("/s1") });
+    execution.plan.steps[0].post_script = "pm.test('t', function () { });";
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto totals = vayu::core::validate_sampled_responses (context_, false);
+    EXPECT_EQ (totals.sampled, 0u);
+    EXPECT_TRUE (vayu::core::build_sampled_validation_payload (totals).empty ())
+    << "an unbound run must carry no block at all, never one saying nothing "
+       "failed";
+}
+
+// A binding whose document carries no schema index is "not measured" too - the
+// same spelling coverage gives a document stored before its index existed.
+TEST_F (ScenarioLoadTest, ABindingWithNoSchemaIndexValidatesNothing) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0") });
+    bind_to_schemas (execution, { open_schema () });
+    execution.spec.response_schemas.clear ();
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    EXPECT_EQ (vayu::core::validate_sampled_responses (context_, false).sampled, 0u);
+}
+
+// A step the document does not declare is checked and named, rather than
+// silently dropped: a collection drifting off its contract is exactly what the
+// block is read for.
+TEST_F (ScenarioLoadTest, AStepTheDocumentDoesNotDeclareIsCountedByReason) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0"), server.url ("/s1") });
+    bind_to_schemas (execution, { open_schema (), open_schema () });
+    // The second step's identity moved off the contract.
+    execution.plan.steps[1].spec_operation =
+    json{ { "method", "GET" }, { "path", "/ghosts" } }.dump ();
+
+    const json config = { { "mode", "iterations" }, { "iterations", 2 },
+        { "concurrency", 1 }, { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto totals = vayu::core::validate_sampled_responses (context_, false);
+    EXPECT_EQ (totals.checked, 2u);
+    EXPECT_EQ (totals.failed, 0u)
+    << "an undeclared operation is not a response that broke its contract";
+    EXPECT_EQ (totals.unchecked_reasons.at ("operation_not_declared"), 2u);
+}
+
+// The thinning is disclosed rather than hidden: a run whose reservoirs dropped
+// candidates reports tallies over what it kept, and the retention counter says
+// what it did not.
+TEST_F (ScenarioLoadTest, ARunWhoseSamplesWereThinnedStillReportsHonestly) {
+    ScenarioMockServer server;
+    auto execution = plan_over ({ server.url ("/s0"), server.url ("/s1") });
+    bind_to_schemas (execution, { open_schema (), open_schema () });
+
+    const json config = { { "mode", "iterations" }, { "iterations", 8 },
+        { "concurrency", 1 }, { "max_response_samples", 4 },
+        { "response_sample_rate", 1 } };
+    run (config, execution);
+
+    const auto totals = vayu::core::validate_sampled_responses (context_, false);
+    EXPECT_GT (totals.sampled, 0u);
+    EXPECT_LE (totals.sampled, 4u)
+    << "the pass validated more than the reservoirs could hold";
+    EXPECT_LT (totals.sampled, 16u)
+    << "16 completions into a 4-sample budget must have been thinned";
+    EXPECT_GT (context_->metrics_collector->response_samples_dropped (), 0u)
+    << "what was thinned must be reported, or the tallies read as the whole run";
+}

--- a/engine/tests/schema_validation_test.cpp
+++ b/engine/tests/schema_validation_test.cpp
@@ -22,6 +22,13 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
 using nlohmann::json;
 using namespace vayu::core;
 
@@ -451,4 +458,227 @@ TEST (SchemaValidationBoundsTest, ASchemaTheValidatorRefusesIsUncheckedNotInvali
     EXPECT_FALSE (verdict.checked);
     ASSERT_TRUE (verdict.reason.has_value ());
     EXPECT_EQ (*verdict.reason, UncheckedReason::NoIndex);
+}
+
+// ─── Sampled tallies, for a load run (issue #682) ───────────────────────────
+
+namespace {
+
+/// A verdict as one sampled response would produce it.
+ValidationVerdict checked_verdict (bool valid) {
+    ValidationVerdict verdict;
+    verdict.checked = true;
+    verdict.valid   = valid;
+    if (!valid) {
+        verdict.failures      = { SchemaFailure{ "/id", "expected integer" } };
+        verdict.failures_total = 1;
+    }
+    return verdict;
+}
+
+ValidationVerdict unchecked_verdict (UncheckedReason reason) {
+    ValidationVerdict verdict;
+    verdict.reason = reason;
+    return verdict;
+}
+
+} // namespace
+
+TEST (SampledValidationTest, AllValidSamplesReportNoFailures) {
+    SampledValidationTotals totals;
+    for (int i = 0; i < 4; ++i) {
+        totals.record (checked_verdict (true), "step0", 200);
+    }
+
+    EXPECT_EQ (totals.sampled, 4u);
+    EXPECT_EQ (totals.checked, 4u);
+    EXPECT_EQ (totals.valid, 4u);
+    EXPECT_EQ (totals.failed, 0u);
+    EXPECT_EQ (totals.failures_total, 0u);
+}
+
+TEST (SampledValidationTest, AllInvalidSamplesAreCountedAndExemplified) {
+    SampledValidationTotals totals;
+    for (int i = 0; i < 3; ++i) {
+        totals.record (checked_verdict (false), "step0", 500);
+    }
+
+    EXPECT_EQ (totals.checked, 3u);
+    EXPECT_EQ (totals.valid, 0u);
+    EXPECT_EQ (totals.failed, 3u);
+    EXPECT_EQ (totals.failures_total, 3u);
+    ASSERT_FALSE (totals.failure_examples.empty ());
+    // The example names where and which step, so it reads far from the row it
+    // came from.
+    EXPECT_EQ (totals.failure_examples.front ().step, "step0");
+    EXPECT_EQ (totals.failure_examples.front ().status, 500);
+    EXPECT_EQ (totals.failure_examples.front ().path, "/id");
+}
+
+TEST (SampledValidationTest, AMixedRunPartitionsCheckedIntoValidAndFailed) {
+    SampledValidationTotals totals;
+    totals.record (checked_verdict (true), "step0", 200);
+    totals.record (checked_verdict (false), "step0", 200);
+    totals.record (checked_verdict (true), "step1", 201);
+
+    EXPECT_EQ (totals.sampled, 3u);
+    EXPECT_EQ (totals.checked, 3u);
+    EXPECT_EQ (totals.valid + totals.failed, totals.checked);
+    EXPECT_EQ (totals.valid, 2u);
+    EXPECT_EQ (totals.failed, 1u);
+}
+
+// The distinction the whole verdict shape exists for, in aggregate: a body no
+// JSON Schema can speak about did not break its contract.
+//
+// Mutation-check: fold the unchecked branch into `failed` and this reddens on
+// both counts at once.
+TEST (SampledValidationTest, AnUncheckedSampleIsCountedByReasonNotAsAFailure) {
+    SampledValidationTotals totals;
+    totals.record (checked_verdict (true), "step0", 200);
+    totals.record (unchecked_verdict (UncheckedReason::BodyNotJson), "step0", 200);
+    totals.record (unchecked_verdict (UncheckedReason::BodyNotJson), "step0", 500);
+    totals.record (unchecked_verdict (UncheckedReason::NoSchemaForStatus), "step1", 404);
+
+    EXPECT_EQ (totals.sampled, 4u);
+    EXPECT_EQ (totals.checked, 1u);
+    EXPECT_EQ (totals.failed, 0u)
+    << "a body a schema cannot describe was reported as a contract failure";
+    EXPECT_EQ (totals.unchecked_reasons.at ("body_not_json"), 2u);
+    EXPECT_EQ (totals.unchecked_reasons.at ("no_schema_for_status"), 1u);
+    // The gap between the two is fully explained, never a silent remainder.
+    size_t unchecked = 0;
+    for (const auto& [reason, count] : totals.unchecked_reasons) {
+        (void)reason;
+        unchecked += count;
+    }
+    EXPECT_EQ (totals.checked + unchecked, totals.sampled);
+}
+
+// The dialect disclosure, aggregated: a run whose schemas were half-read says
+// so by name, and the responses stay counted as the valid ones they were.
+TEST (SampledValidationTest, UnevaluatedKeywordsAreDisclosedByNameAcrossSamples) {
+    ValidationVerdict verdict = checked_verdict (true);
+    verdict.unevaluated_keywords = { { "unevaluatedProperties", 1 }, { "prefixItems", 2 } };
+
+    SampledValidationTotals totals;
+    totals.record (verdict, "step0", 200);
+    totals.record (verdict, "step0", 200);
+    totals.record (checked_verdict (true), "step1", 200);
+
+    EXPECT_EQ (totals.valid, 3u) << "an unevaluated keyword must not unmake a "
+                                    "response that passed every check that ran";
+    EXPECT_EQ (totals.unevaluated, 2u);
+    EXPECT_EQ (totals.unevaluated_keywords.at ("unevaluatedProperties"), 2u);
+    EXPECT_EQ (totals.unevaluated_keywords.at ("prefixItems"), 4u);
+}
+
+TEST (SampledValidationTest, FailureExamplesAreCappedAndTheTotalStaysHonest) {
+    SampledValidationTotals totals;
+    for (size_t i = 0; i < constants::schema_validation::MAX_FAILURES * 3; ++i) {
+        totals.record (checked_verdict (false), "step0", 500);
+    }
+
+    EXPECT_EQ (totals.failure_examples.size (), constants::schema_validation::MAX_FAILURES);
+    // Bounded list, unbounded count - so "10 shown of 30" stays readable.
+    EXPECT_EQ (totals.failures_total, constants::schema_validation::MAX_FAILURES * 3);
+}
+
+TEST (SampledValidationPayloadTest, APassThatWalkedNothingIsAnEmptyObject) {
+    // Empty rather than zeros: the caller drops an empty object from the
+    // summary, which is what keeps an unbound run's report free of a block
+    // saying nothing failed.
+    EXPECT_TRUE (build_sampled_validation_payload (SampledValidationTotals{}).empty ());
+}
+
+TEST (SampledValidationPayloadTest, TheDenominatorAndTheTalliesAreAllWritten) {
+    SampledValidationTotals totals;
+    totals.record (checked_verdict (true), "step0", 200);
+    totals.record (checked_verdict (false), "step1", 200);
+    totals.record (unchecked_verdict (UncheckedReason::BodyNotJson), "step1", 200);
+
+    const auto node = build_sampled_validation_payload (totals);
+    // `sampled` is what tells a reader these figures describe the reservoir and
+    // not the run - the one number that must never be inferable-only.
+    EXPECT_EQ (node["sampled"].get<size_t> (), 3u);
+    EXPECT_EQ (node["checked"].get<size_t> (), 2u);
+    EXPECT_EQ (node["valid"].get<size_t> (), 1u);
+    EXPECT_EQ (node["failed"].get<size_t> (), 1u);
+    EXPECT_EQ (node["unevaluated"].get<size_t> (), 0u);
+    EXPECT_EQ (node["uncheckedReasons"]["body_not_json"].get<size_t> (), 1u);
+    ASSERT_TRUE (node["failures"].is_array ());
+    ASSERT_EQ (node["failures"].size (), 1u);
+    EXPECT_EQ (node["failures"][0]["step"].get<std::string> (), "step1");
+    EXPECT_EQ (node["failures"][0]["status"].get<int> (), 200);
+    EXPECT_EQ (node["failuresTotal"].get<size_t> (), 1u);
+    // Absent rather than an empty array: nothing went unread here.
+    EXPECT_FALSE (node.contains ("unevaluatedKeywords"));
+}
+
+// ─── The hot path stays clear (issue #682) ──────────────────────────────────
+
+/**
+ * Validation must never be reachable from a load run's completion path.
+ *
+ * The load loop refills concurrency per completion, so a schema walk there
+ * costs throughput for the whole rest of the run - and it would do so
+ * *silently*, as a slightly lower RPS nobody would trace back. That is why the
+ * pass is deferred to run end, and why the property is asserted structurally
+ * rather than by timing: a shared CI runner cannot measure the difference, so
+ * a timing test would either be flaky or prove nothing.
+ *
+ * The scan asserts it read something first - a guard reading an empty string
+ * passes forever.
+ */
+TEST (SchemaValidationHotPathTest, NoValidationIsReachableFromTheCompletionPath) {
+    const std::filesystem::path root = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) / "src";
+    ASSERT_TRUE (std::filesystem::exists (root));
+
+    // The files a completion runs through: the strategy's per-completion
+    // callback and the scenario executor's virtual-user loop.
+    const std::vector<std::string> hot_path = { "load_strategy.cpp",
+        "scenario_load.cpp", "scenario_runner.cpp", "metrics_collector.cpp" };
+
+    size_t files_scanned = 0;
+    size_t total_bytes   = 0;
+    std::vector<std::string> validators;
+    std::vector<std::string> offenders;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator (root)) {
+        if (!entry.is_regular_file () || entry.path ().extension () != ".cpp") {
+            continue;
+        }
+        std::ifstream file (entry.path ());
+        std::stringstream buffer;
+        buffer << file.rdbuf ();
+        const std::string source = buffer.str ();
+        ++files_scanned;
+        total_bytes += source.size ();
+
+        const std::string name = entry.path ().filename ().string ();
+        // The implementation itself is not a call site.
+        if (name == "schema_validation.cpp") {
+            continue;
+        }
+        if (source.find ("ResponseSchemaIndex") == std::string::npos) {
+            continue;
+        }
+        validators.push_back (name);
+        for (const auto& hot : hot_path) {
+            if (name == hot) {
+                offenders.push_back (name);
+            }
+        }
+    }
+
+    ASSERT_GT (files_scanned, 10u) << "the scan found no sources to read";
+    ASSERT_GT (total_bytes, 1000u) << "the scan read empty files";
+    EXPECT_TRUE (offenders.empty ())
+    << "response validation reached a file the completion path runs through; "
+       "it belongs in the deferred pass at run end";
+    // Exactly the two hooks that exist: design mode resolves an index per
+    // execution, and the load pass parses one at run end. A third caller is not
+    // wrong on its face - it just has to be looked at, and this is what makes
+    // that happen rather than a reviewer noticing.
+    std::sort (validators.begin (), validators.end ());
+    EXPECT_EQ (validators, (std::vector<std::string>{ "run_manager.cpp", "specs.cpp" }));
 }


### PR DESCRIPTION
## Description

Phase 3c of #625 - the third of #628's three hooks, after design mode landed with 3a (#683). A load run of a bound collection now reports whether the responses it kept matched the schemas its document declares, in a block beside contract coverage.

**The plan.** The root cause this phase exists for is that a load run produces thousands of responses nobody looks at: coverage says an operation was exercised, and nothing says whether what came back honoured its contract. The approach is a second deferred pass beside the existing script replay - `validate_sampled_responses` walks the per-step sample reservoirs once the run has drained, parses the document's schema index exactly once, and tallies into `runs.summary.schemaValidation`. The alternative I rejected was validating on the completion path, where the verdict would be per-response and exact: the load loop refills concurrency on every completion, so a schema walk there costs throughput for the rest of the run, and it does so invisibly as a slightly lower RPS. The cost of deferring is that the numbers are **sampled**, and the whole design is shaped around saying so rather than hiding it.

**Two things worth a reviewer's eye:**

1. **Sampling now has two reasons, not one.** `configure_step_samples` was told which steps carried a *script*; a bound collection that asserts nothing would therefore have kept no responses and validated nothing. It is now told which steps a deferred pass will *read* - a script, or a contract. One budget covers both, so a bound collection that also asserts gives each step a smaller share; that is disclosed as `response_samples_dropped` exactly as before. An unbound plan samples precisely as it did (test).

2. **The schema index rides the binding from plan resolution.** `SpecBinding` gains `response_schemas`, read in `resolve_scenario` under the same hash check `operations` already passes, so a sync landing mid-run cannot move a run onto a contract it never saw. It travels as **text** and is parsed once at run end, or not at all - the parse is the expensive half and nothing during the run needs it. I considered re-reading the document by id at run end instead (documents are immutable, there is no `PUT /specs`), which would hold nothing for the run's life; I rejected it because the pin would then rest on an invariant asserted elsewhere rather than on the run carrying what it was planned against, and #681 reads the same column in the same place for the collection-run hook.

Verified against live code before writing: the anchors in the issue still hold. `core/schema_validation.{hpp,cpp}` is unchanged in shape (this calls it, it does not reshape it), and the report/summary sections follow the `coverage` precedent line for line.

### What landed

**Engine**
- `SampledValidationTotals` + `build_sampled_validation_payload` (`core/schema_validation`): `sampled` / `checked` / `valid` / `failed` / `unevaluated`, `uncheckedReasons` accounting for every one of `sampled - checked`, `unevaluatedKeywords` named and counted, and capped `failures[]` with an honest `failuresTotal`.
- `validate_sampled_responses` (`core/run_manager`), beside `validate_scripts` on the drained run.
- `runs.summary.schemaValidation`, passed through verbatim by `GET /runs/:runId/report`.
- `SpecBinding::response_schemas`, read in `resolve_scenario`.

**App**
- `RunSchemaValidation` on `RunReport.schemaValidation`.
- `SampledSchemaValidation`, rendered in `OverviewTab` directly under `ContractCoverage`. Reasons come from `uncheckedReasonText` - the wording the response viewer already shows for a single response, one copy, so an aggregate row and a user's own response cannot drift.

**Docs, same commit**: `docs/app/openapi.md` (new section + the exact-vs-sampled row #682 asked for, as a table naming both blocks), `docs/engine/api-reference.md` (report block + field table), `docs/engine/db-schema.md` (summary key), `docs/app/COMPONENTS.md`, `engine/CLAUDE.md`.

### Deliberate deviations

- **No benchmark**, as the issue specifies: #197 and #287 own the measurements needing a quiet host. The hot-path property is argued **structurally** instead - a source-scanning test fails if `ResponseSchemaIndex` appears in `load_strategy.cpp`, `scenario_load.cpp`, `scenario_runner.cpp` or `metrics_collector.cpp`, and pins the caller set to exactly `{run_manager.cpp, specs.cpp}` so a third caller has to be looked at rather than noticed. The scan asserts it read non-empty sources first.
- **A step bound to no operation is skipped, not counted `no_operation`.** Counting it would fill the block with one reason per unbound step of a mixed collection, which says nothing about the contract.
- **`SchemaFailure` carries no `keyword`**, following 3a's recorded decision - valijson does not expose one.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

`python build.py -e -t` → clean. `ctest --preset linux-dev --output-on-failure` → **1887/1887 passed, 0 failed**. `cd app && pnpm test` → **5083 passed in 488 files**; `pnpm type-check` and `pnpm lint` clean. `mkdocs build --strict` clean. No pre-existing failures observed on this base.

**18 new engine tests**, **7 new app tests**:
- Tallies from seeded verdicts: all-valid, all-invalid, mixed; a body that is not JSON is counted **by reason, never as a failure** (mutation-check: fold the branches and it reddens on both counts); unevaluated keywords aggregated by name while the responses stay counted valid; the failure cap with an honest total.
- End-to-end over a real mock: a bound run's tallies over its reservoirs, with the failing step named; a bound step sampled **with no script of its own**; an unbound plan sampling exactly as before; an undeclared operation counted by reason; a thinned run reporting `sampled` under its budget with `response_samples_dropped` non-zero.
- Summary/report round-trip, and the absent-when-unbound gate in both shapes it arrives in.
- App: the block renders nothing for a run that checked nothing, prints the sampled denominator, states that coverage beside it is exact, and stays neutral when nothing failed.

**Mutation-checked for real, not just described:**
- Reverted the sampling-reason change and rebuilt: `ABoundStepIsSampledWithNoScriptOfItsOwn` and `ABoundRunReportsTalliesOverItsSampledResponses` both fail. Restored, both pass.
- Dropped the `sampled <= 0` half of the app guard: `renders nothing for a run that checked nothing` fails. Restored, passes.

Note for the environment: `valijson` needs `vcpkg-fix-port valijson` before a cold build here, per `engine/CLAUDE.md`.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

## Related Issues

Closes #682. Part of #625; extracted from #628. Independent of #681 (the collection-run hook), which is in flight - the two share `core/schema_validation` and touch `OverviewTab` and the same doc sections, so whichever lands second is a rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMjP6kbM6jZir6VjLrgwx)_