### PR TITLE
docs(claude): name the vcpkg 403 workaround at the repo root, not only in engine/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,17 @@ and `libtool` - vcpkg builds libsodium from source there and runs `autoreconf`
 first. `python build.py --setup` installs them; without them the *dependency*
 install fails, which does not look like a missing build tool.
 
+**A `403` from vcpkg on a GitHub source archive is not a dependency you cannot
+have.** In the cloud dev environment the egress policy refuses those archives
+while allowing git-over-https, so a port fetched by `vcpkg_from_github` dies on
+a cold cache with `curl operation failed with response code 403` - which reads
+like a wall and is one command: `vcpkg-fix-port <port>` (no arguments re-does
+the whole manifest), then build again. It is repeated here rather than left in
+`engine/CLAUDE.md` alone because the message appears while running `build.py`
+from the repo root, and a session that has not opened a file under `engine/`
+never loads that file - one did, read the 403 as policy, and abandoned a phase
+of #625 over it. Full note there.
+
 **On Windows, do not hand-configure cmake or set `VCPKG_ROOT` - just run
 `build.py`.** It imports the MSVC environment via `vcvars` and finds cmake,
 ninja and vcpkg inside the Visual Studio Build Tools install


### PR DESCRIPTION
## Description

**Plan.** Root cause: `engine/CLAUDE.md` gained a note in #683 saying that the cloud dev environment's egress policy answers GitHub *source archives* with `403` while allowing git-over-https, and that `vcpkg-fix-port <port>` is the one-command fix. That note is in the right place for depth and the wrong place for timing - a nested guide loads once a session opens a file in that tree, and this `403` appears while running `python build.py` from the **repo root**, before any engine file has been touched. Approach: eleven lines in the root Build section, next to the Windows `VCPKG_ROOT` paragraph that exists for the same shape of reason, pointing at the full note. **Rejected alternative:** leaving it in `engine/` alone and relying on the "Where the rest lives" table - that table tells a reader the guide exists, but a reader who has just been told by their tooling that a host is blocked does not go looking for a C++ conventions file.

This is not hypothetical. A session hit exactly this: it read `curl operation failed with response code 403` as an egress policy nothing could route around, reported #628 as blocked on its dependency, and released the claim. The dependency installed fine one command later. The whole cost was that the message and the fix lived in different files.

Duplication earns its keep precisely here - the root Build section is where the reader already is when the message appears - and the detail (what the fixer does, why overlay ports are pinned to the manifest baseline) stays in `engine/CLAUDE.md` rather than being restated.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`CLAUDE.md`-only, one section, no code path and no published docs page - so nothing here can change a test's colour, and per this repo's own scaling rule that means no suite run. What was checked instead:

| Check | Result |
|---|---|
| Em-dash sweep over the added lines | none (repo rule: ` - `) |
| `vcpkg-fix-port` named in both files, consistently | root 1, `engine/CLAUDE.md` 1 |
| Diff scope | `CLAUDE.md`, +11 lines, nothing else |

Not run, deliberately: `mkdocs build --strict` (`CLAUDE.md` is not under `docs/` and is not a published page) and `pnpm format:check` (its prettier glob runs inside `app/`, so the root file is outside it - unlike `app/CLAUDE.md`, which is why that one needed formatting in #683).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, prose only
- [x] I have updated documentation

## Related Issues

Follow-up to #683, which added the `engine/CLAUDE.md` note this points at. No issue - it is a gap that only became visible from having walked into it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsqLQm59zf8Fc3STDCP4iR)_