### PR TITLE
build(engine): bump the vcpkg baseline, and give it an owner

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -11,15 +11,26 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
    `engine/vcpkg.json`, and refuses to run if that file has grown a `version`
    field back: CI keys the vcpkg binary cache on the manifest's hash, so a
    version there made every release rebuild every C++ dependency from source.
-2. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a
+2. Check the vcpkg baseline for staleness - `cd engine && vcpkg
+   x-update-baseline --dry-run`. **The release window is the cadence**: nothing
+   else owns baseline freshness, and #679 found cpp-httplib five minors behind
+   with curl, openssl and sqlite3 each missing point releases, purely because
+   the pin had gone unexamined since June. A bump is `builtin-baseline` in
+   `engine/vcpkg.json` **and** `VCPKG_COMMIT` in `release.yml`, `pr-tests.yml`,
+   `codeql.yml` and `cache-warm.yml` - one SHA in five places, and the `guard`
+   job in `cache-warm.yml` fails the build if any of them drift. Land a bump as
+   **its own PR before the release commit**, never inside it: a dependency
+   change and a version bump that break one platform together cannot be told
+   apart.
+3. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a
    Changelog format, see below).
-3. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes
+4. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes
    file together).
-4. Tag: `git tag v$(cat VERSION) && git push origin --tags`
-5. CI builds installers and publishes the GitHub Release, using
+5. Tag: `git tag v$(cat VERSION) && git push origin --tags`
+6. CI builds installers and publishes the GitHub Release, using
    `.github/release-notes/<tag>.md` as the release body automatically (no manual
    paste).
-6. Read the sccache hit rate in the release run's log and expect **more than
+7. Read the sccache hit rate in the release run's log and expect **more than
    zero engine hits** (issue #659 item 5). A version bump used to edit a header
    every translation unit preprocessed, so every release compiled the engine
    cold on all three platforms at a 0% hit rate by construction;

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -136,6 +136,22 @@ jobs:
           done
           echo "All ${#files[@]} workflows agree."
 
+          # The four workflows agreeing with each other is only half of it.
+          # The commit they check vcpkg out at must also be the commit
+          # `engine/vcpkg.json` resolves dependency versions against - they are
+          # the same number written in two places, and nothing compared them
+          # until now. Diverged, CI resolves versions from the manifest's
+          # baseline while building against a different clone's port files, and
+          # the mismatch surfaces as an unexplained platform failure rather
+          # than as the config error it is.
+          baseline=$(python3 -c "import json; print(json.load(open('engine/vcpkg.json'))['builtin-baseline'])")
+          pinned=$(printf '%s' "${commits[0]}" | grep -oE '[0-9a-f]{40}')
+          if [ "$baseline" != "$pinned" ]; then
+            echo "::error file=engine/vcpkg.json::builtin-baseline ($baseline) and the workflows' VCPKG_COMMIT ($pinned) disagree. Bump them together." >&2
+            exit 1
+          fi
+          echo "engine/vcpkg.json builtin-baseline agrees: $baseline"
+
       - name: Assert every workflow resolves the same pnpm store key
         shell: bash
         run: |
@@ -212,7 +228,7 @@ jobs:
     env:
       # Keep these three byte-identical to release.yml and pr-tests.yml. The
       # `guard` job above fails the build if they drift.
-      VCPKG_COMMIT: 'cea592f4772491abdb7c483387a59ea89889f4be'
+      VCPKG_COMMIT: '94a541197763a4f449a1b91478df48c0584a6256'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,7 +90,7 @@ jobs:
       contents: read
       actions: read
     env:
-      VCPKG_COMMIT: 'cea592f4772491abdb7c483387a59ea89889f4be'
+      VCPKG_COMMIT: '94a541197763a4f449a1b91478df48c0584a6256'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -219,7 +219,7 @@ jobs:
             preset: macos-prod
     timeout-minutes: 60
     env:
-      VCPKG_COMMIT: 'cea592f4772491abdb7c483387a59ea89889f4be'
+      VCPKG_COMMIT: '94a541197763a4f449a1b91478df48c0584a6256'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             preset: macos-prod-arm64
     timeout-minutes: 120
     env:
-      VCPKG_COMMIT: 'cea592f4772491abdb7c483387a59ea89889f4be'
+      VCPKG_COMMIT: '94a541197763a4f449a1b91478df48c0584a6256'
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/.vcpkg-archives,readwrite'
       SCCACHE_GHA_ENABLED: 'true'
       # v0.17.1's Windows leg reported 18 sccache "Cache errors" where v0.17.0

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -138,6 +138,7 @@ Dependencies are managed via vcpkg and specified in `engine/vcpkg.json`:
 | curl | HTTP client library |
 | libsodium | SHA-256, HMAC-SHA256, base64 and hex (PKCE, Basic/OAuth credentials, `pm.crypto`) |
 | nlohmann-json | JSON parsing/serialization |
+| valijson | JSON Schema validation of responses against a bound OpenAPI document |
 | cpp-httplib | HTTP server library |
 | sqlite3 | Embedded database |
 | sqlite-orm | C++ ORM for SQLite |
@@ -357,7 +358,7 @@ Set `VCPKG_ROOT` environment variable or install vcpkg in a standard location.
 
 ### Linker Errors
 
-- Ensure all vcpkg dependencies are installed: `vcpkg install curl[http2] libsodium nlohmann-json cpp-httplib sqlite3 sqlite-orm gtest`
+- Ensure all vcpkg dependencies are installed: `vcpkg install curl[http2] libsodium nlohmann-json valijson cpp-httplib sqlite3 sqlite-orm gtest`
   (the `http2` feature is required - without it libcurl is built without nghttp2 and the HTTP/2 support test fails)
 - On Windows, ensure Visual Studio C++ tools are installed
 

--- a/engine/include/vayu/core/schema_validation.hpp
+++ b/engine/include/vayu/core/schema_validation.hpp
@@ -48,7 +48,9 @@
  *
  * ### Which validator, and why not the one the issue named
  *
- * `valijson` (v1.1.0, BSD-2), not `json-schema-validator` (pboettch) which
+ * `valijson` (BSD-2; the version is `engine/vcpkg.json`'s baseline to pin, not
+ * this comment's - it named v1.1.0 and went stale the first time the baseline
+ * moved), not `json-schema-validator` (pboettch) which
  * #625/#628 named first and #628 recorded valijson as the fallback for. The
  * fallback was taken, and the reason is not taste: pboettch's `set_root_schema`
  * **segfaults on a recursive schema** - a `Node` whose `child` is a `Node`,

--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -23,5 +23,5 @@
     },
     "sqlite-orm"
   ],
-  "builtin-baseline": "cea592f4772491abdb7c483387a59ea89889f4be"
+  "builtin-baseline": "94a541197763a4f449a1b91478df48c0584a6256"
 }


### PR DESCRIPTION
## Description

Bumps the vcpkg `builtin-baseline` from `cea592f4` (2026-06-04) to `94a54119` (2026-08-15), the matching `VCPKG_COMMIT` in all four workflows, and records a cadence so the pin stops drifting unexamined.

**Plan.** The root cause is not the pin's age but that nothing owned it: it was set once and never re-checked, so the four actively-released dependencies drifted while the header-only ones stayed current by coincidence. The approach is the one-SHA-in-five-places bump plus an owner for the next check - a bump without a cadence just resets the same clock. I rejected the alternative of `version>=` overrides on the four lagging ports: it fixes today's list, leaves the baseline stale for everything added later, and hides the next drift behind a green build - the stopgap-to-be-replaced-later that CLAUDE.md's core principle rules out.

### What actually moved

Resolved from the vcpkg registry at both commits, not from the issue's snapshot:

| Dependency | Old baseline | New baseline |
|---|---|---|
| cpp-httplib | 0.46.1 | **0.53.0** |
| curl | 8.20.0 | 8.21.0 |
| openssl | 3.6.2 | 3.6.3 |
| sqlite3 | 3.53.1 | 3.53.4 |
| gtest | 1.17.0 | **1.18.0** |
| nghttp2 | 1.69.0 | 1.70.0 |
| valijson | 1.1.0 | 1.1.3 |
| nlohmann-json, libsodium, sqlite-orm, zlib, brotli | \- | unchanged |

Three rows the issue did not predict, because it snapshotted the Aug-4 registry and this lands on Aug-15 HEAD: **gtest 1.17.0 -> 1.18.0** (the issue listed gtest as having no gap), **cpp-httplib 0.53.0** rather than the 0.51.0 it expected, and **valijson**, which did not exist in the manifest when the issue was written.

### cpp-httplib 0.46.1 -> 0.53.0, reviewed rather than trusted

115 non-merge commits across seven minors, read from the upstream git history. What the engine's surface actually touches:

**Fixes that land directly on code we run:**

- **`c7ba963` ignore ranges for unknown-length streams.** `write_content_with_provider` now clears `req.ranges` when a content provider has no known length. Every SSE endpoint we serve is exactly that shape - `res.set_content_provider("text/event-stream", ...)` in `routes/events.cpp:107` and `routes/metrics.cpp:327,434` - so before this, a client sending `Range:` on a live metrics or events subscription could have its stream sliced. Paired with `23fef15`, which applies a Range only to a 206.
- **`a691e53` close the listening socket in `stop()` even when not serving.** `ManagedListener::stop()` calls `Server::stop()` unconditionally, including on the path where a bind succeeded but the accept loop had not come up. That is the port-claim leak this fix removes.
- **`8e702d3` drain the socket gracefully before close** in `process_and_close_socket` - teardown ordering, the other half of the `ManagedListener` canary.
- **`85ec396` listen backlog 5 -> 128.** We never set `CPPHTTPLIB_LISTEN_BACKLOG`, so we take the new default.

**Stricter parsing, all inbound-request-side:** CR/LF in the request target is now rejected (`255c075`), out-of-range `Content-Length` is flagged (`982235c`), the final transfer coding is matched order-independently (`75938f0`, `486c81b`), multipart parts have a header-line cap (`877a52f`), and `write_headers` skips invalid field pairs rather than emitting them (`695961f`, a response-splitting fix). All of these tighten what a malformed client can do to the daemon; none of them changes a well-formed request.

**Ordering now preserved** for duplicate header fields (`d860c84`), query parameters (`7963c38`) and multipart parts (`23f67f2`). Behaviour change, in the safe direction - previously the order was whatever the multimap gave back.

**Verified inapplicable rather than assumed:** the mount-point segment-boundary fix (`2b8658f`) and file-request handling - we serve no static files; the `X-Forwarded-For` changes (`fd0c18b`, `6c4cbd4`) - the inbox reads `req.remote_addr` directly and never calls `get_client_ip`; every WebSocket and client-side change including `0c1cc8c` (strip cookies on cross-origin redirect) - we use cpp-httplib as a server only, and libcurl for all outbound traffic. `SO_REUSEPORT` is still set the same way, so `docs/engine/architecture.md:131` stays accurate.

**Nothing surprising found.** No API we call changed signature, and no default we depend on was reversed.

### curl 8.20.0 -> 8.21.0

The advisory check the issue asked for: <https://curl.se/docs/vuln-8.20.0.html> lists **18 vulnerabilities whose last-affected version is 8.20.0** - i.e. our current pin is the last release carrying them, and 8.21.0 is the fix. <https://curl.se/docs/vuln-8.21.0.html> lists none. Among them are several that touch how this engine uses libcurl: HTTP/2 stream-dependency-tree use-after-free (we build curl with the `http2` feature), a trailing-dot-domain super-cookie bug (we drive cookies through `CURLOPT_COOKIELIST`, `http/cookie_jar.hpp`), and connection-reuse flaws for mismatched services.

One behaviour change worth naming: 8.21.0 **stops passing set-cookies on to a new origin across a redirect**. We enable `CURLOPT_FOLLOWLOCATION` per request (`client.cpp:400`, `curl_utils.cpp:585`, `sse_stream.cpp:453`), so a request that today picks up a `Set-Cookie` from a redirect hop and carries it to a different-origin target will stop doing so. That is a hardening change, not a regression, but it is a user-visible difference for anyone whose flow depended on it.

openssl 3.6.2 -> 3.6.3 and sqlite3 3.53.1 -> 3.53.4 are patch releases; I did not audit their changelogs line by line and am not claiming to have.

### Cadence (the issue's rider)

Recorded as the issue recommended - a line in the `releasing` skill, now step 2 of the release checklist: check `vcpkg x-update-baseline --dry-run` in the release-prep window, and land any bump as **its own PR before** the release commit, since a dependency change and a version bump that break one platform together cannot be told apart. The release cycle becomes the natural cadence; nothing owned it before.

### One small guard added

`cache-warm.yml`'s `guard` job asserted the four workflows agree with each other, but nothing compared them against `engine/vcpkg.json`'s `builtin-baseline` - the same SHA written in a fifth place. This PR is precisely the change that can leave those two diverged, so the guard now checks it too. Verified live: with the workflows bumped and the manifest not yet, the check fails naming both values; with both bumped, it passes.

## Type of Change

- [x] Bug fix (security-relevant dependency updates)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Both sides of the bump were built and run on this Linux container, so the numbers below are a before/after on the same machine rather than a single green run:

| | baseline | engine build | `ctest --preset linux-dev` |
|---|---|---|---|
| Control (before) | `cea592f4` | ok, 12m49s | **1887/1887 passed**, 250.1s |
| This PR (after) | `94a54119` | ok, 17m36s, **0 errors 0 warnings** | **1887/1887 passed**, 253.8s |

No pre-existing failures to report - the control run was fully green, so anything red after the bump would have been attributable to it. Nothing was. Worth noting that cpp-httplib's seven-minor jump and gtest 1.17 -> 1.18 both compiled without a single new warning, which is the cheapest evidence that no API we call changed under us.

Versions confirmed from the built tree rather than from intent - `vcpkg_installed/vcpkg/status` after the build reads cpp-httplib 0.53.0, curl 8.21.0, openssl 3.6.3, sqlite3 3.53.4, gtest 1.18.0, nghttp2 1.70.0, valijson 1.1.3. The same versions were printed independently when this environment's overlay ports were regenerated against the new baseline, port by port.

### The two manual smokes the issue asked for

Run against a real daemon on the new build, since these exercise the changed cpp-httplib surface hardest:

- **SSE stream.** Started a `constant_concurrency` run and subscribed to `/runs/:id/live`: 50 `data:` frames in 5s, well-formed `event: metrics` payloads. Then re-ran it **with a `Range: bytes=0-10` header** - the case `c7ba963` changed - and got the full 50-frame stream rather than an 11-byte slice. That is the fix landing on our own endpoint, not just in upstream's test suite.
- **Mock server.** Created a collection and request, `POST /mock/start` bound an ephemeral port, the mock matched the route and answered `501` (`MockMissKind::NoExample` - the designed answer for a matched route with no saved example, `mock_server.cpp:673`), and `POST /mock/:id/stop` tore the listener down cleanly. That is the `ManagedListener` bind/serve/teardown path the `a691e53` and `8e702d3` changes touch.

`docs/engine/building.md` also gains the `valijson` row and the `vcpkg install` line it was missing - drift left by the phase-3a commit that added the dependency, in the one table this PR is already editing the subject of. `schema_validation.hpp` likewise stopped pinning "v1.1.0" in prose, since the manifest is the source of truth and that comment went stale the moment the baseline moved.

`mkdocs build --strict` is not run here (mkdocs is not installed in this environment); the docs change adds a table row and edits an inline code span, introducing no link, heading or nav entry, so it cannot fail the strict build. The docs workflow covers it on the PR.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable - the engine suite is the test for a dependency bump; the new guard assertion is verified above)
- [x] I have updated documentation

## Related Issues

Closes #679

---
_Generated by [Claude Code](https://claude.ai/code/session_016wBMEgCCfN4A2D3Cuxcmtv)_