### PR TITLE
docs(engine): name curl 8.21's redirect-cookie rule, and assert the unbound step frame

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1750,6 +1750,10 @@ the next. **One jar per environment**, plus one for requests sent with no
 environment selected; in memory only, for the life of the engine process, and
 never written to disk. Load runs neither read nor write it.
 
+Cookies set *during* a redirect chain follow curl's cross-origin rule rather
+than the jar's - see [POST /execute](#post-execute) for what a redirect that
+changes origin does to them.
+
 ### GET /cookies
 
 Every jar that holds anything, one entry per scope.
@@ -2637,6 +2641,20 @@ clients send these explicitly for exactly that reason (see
 [api-integration](../app/api-integration.md)). `POST /runs` accepts the same
 three fields with the same defaults, so a load test can be run under the policy
 the request was configured with.
+
+**A redirect that crosses origins drops the cookies the hop set.** Since
+**curl 8.21.0** (`http: don't pass on set cookies to new origins`, which the
+engine picked up with the vcpkg baseline bump of #679), a `Set-Cookie` returned
+by one origin is not applied to the follow-up request when the `Location`
+points at a different one; a same-origin hop is unchanged. This is upstream
+security hardening, inherited deliberately, and it is not configurable - the
+engine sets `CURLOPT_FOLLOWLOCATION` per request wherever `followRedirects` is
+true, so it holds on `POST /execute`, on load runs and on streaming requests
+alike. A flow that depended on a cookie surviving a cross-origin hop (a login
+that bounces through an identity provider is the usual shape) now sends the
+follow-up request without it. Nothing about the [cookie jar](#cookies) itself
+changed: it is domain-scoped as before, so a cookie is still stored under the
+origin that set it and still sent on a later request back to that origin.
 
 **Protocol.** `httpVersion` selects which HTTP version curl attempts:
 `"auto"` lets ALPN negotiate (curl's own default), `"http1.1"` forces

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -1126,7 +1126,9 @@ TEST_F (ScenarioRunnerTest, ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere) {
     // nothing rather than `operation_not_declared`.
     stamp_spec_operation ("req_ok", json{ { "method", "GET" }, { "path", "/pet" } });
 
-    const auto run_id = start (/*iterations=*/1);
+    const auto run_id  = start (/*iterations=*/1);
+    const auto context = manager_.get_run (run_id);
+    ASSERT_TRUE (context != nullptr);
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 
     const auto rows = db_->get_results (run_id);
@@ -1136,6 +1138,18 @@ TEST_F (ScenarioRunnerTest, ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere) {
     // Absent from the summary too, and absent rather than a block of zeros: a
     // run nothing judged did not match none of a contract.
     EXPECT_FALSE (summary_of (run_id).contains ("schemaValidation"));
+
+    // And absent from the wire, which is the surface a live view reads. The
+    // stored row above proves the trace; this proves the `step` frame, which is
+    // built on a separate path - a key added there unconditionally (even as a
+    // null) would leave the watcher showing a verdict the report never writes.
+    const auto batch = context->ticks_since (0);
+    ASSERT_EQ (batch.payloads.size (), 1u);
+    const auto& payload = batch.payloads[0];
+    const auto data_at  = payload.find ("data: ");
+    ASSERT_NE (data_at, std::string::npos) << payload;
+    EXPECT_FALSE (json::parse (payload.substr (data_at + 6)).contains ("validation"))
+    << payload;
 }
 
 TEST_F (ScenarioRunnerTest, ABoundDocumentWithNoSchemaIndexIsSaidSoRatherThanSilent) {


### PR DESCRIPTION
## Description

Items 1 and 2 of the wave-17 micro batch in #690. Item 3 is a tracking record with no action due, so this PR deliberately does **not** close the issue - see "Deviation" below.

**Plan.** Root cause of item 1: the vcpkg baseline bump (#679) inherited curl 8.21.0's `http: don't pass on set cookies to new origins`, which changes what a redirect-following request sends - and the engine enables `CURLOPT_FOLLOWLOCATION` per request, so the change is user-visible on every transfer path while no doc named it. The approach is one paragraph where redirect policy is already documented (`POST /execute`'s "Redirect policy" block), plus a one-line pointer from the Cookies section, because that is where a reader chasing cookie behaviour lands first. I rejected putting it in `docs/engine/architecture.md#cookie-jar` instead: the jar's own semantics did not change, only what curl carries across a redirect hop, so filing it under the jar would misattribute the rule.

Root cause of item 2: #681's absent-vs-present discipline ("never judged" is not "judged and passed") was pinned on the stored trace and the summary, and on the SSE frame only through `build_step_payload` with a hand-built `StepRecord`. That proves the *builder*; it does not prove the *wiring* - that a real unbound run produces records with no verdict to begin with. Those are two distinct code paths (`scenario_runner.cpp:182` for the trace, `:313` for the frame). The approach extends `ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere` to read the run's own ticks, which is what its name already claimed, rather than adding a fourth near-duplicate run test. I rejected asserting this from a new synthetic test: a synthetic `StepRecord` cannot fail in the direction that matters here, which is the runner stamping a verdict on a run that binds no document.

Blast radius traced: the `validation` key on a step frame has exactly one producer (`build_step_payload`) and the renderer's live collection-run view as its consumer; no engine code reads it back. The docs change touches no code.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Test coverage

## Testing

- `python build.py -e -t` - green (needed `vcpkg-fix-port` first for the documented cloud-egress 403 on GitHub source archives; no manifest change committed, the overlay is local).
- `ctest --preset linux-dev --output-on-failure` - **1899/1899 passed, 0 failed**, 289.5s. No pre-existing failures on this base (`566077a`).
- `mkdocs build --strict -f .github/mkdocs.yml` - clean, including the new `#cookies` and `#post-execute` intra-page anchors.
- **Mutation check on the new assertion**: changing `build_step_payload` to emit `data["validation"]` unconditionally (null when absent) reddens `ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere` with the offending frame in the failure message (`..."stepIndex":0,"validation":null}`), and reddens the existing synthetic test too. Restored and re-verified green.

No app suite run: the diff is one Markdown file and one C++ test file, with no app-side surface touched. `docs/` is outside the `app/`-rooted prettier glob, so `format:check` is unaffected.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Refs #690 (items 1 and 2).

**Deviation from the usual "Closes #N":** #690's third acceptance criterion is that item 3 - the JSON Schema 2020-12 evaluation gap - "stays open as the record until a demand-driven decision closes it with (a) or (b)". Closing the issue on this PR would delete exactly the tracker record item 3 exists to be. The issue should stay open with items 1 and 2 checked off.

---
_Generated by [Claude Code](https://claude.ai/code/session_011r8Euyr1xGY1h2JfKE8amh)_