### PR TITLE
build(env): self-heal a vcpkg clone that predates the pinned baseline

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,4 +8,8 @@ fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 
+# --setup carries the stale-vcpkg-baseline self-heal (issue #692): a container
+# image whose vcpkg clone predates the pinned baseline is brought forward before
+# dependencies are installed. Do not re-probe for it here - one implementation,
+# and it is the one every other entry point uses too.
 python3 "$PROJECT_DIR/build.py" --setup

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -21,7 +21,18 @@ description: Cut a Vayu release - version bump, curated release notes, tagging, 
    job in `cache-warm.yml` fails the build if any of them drift. Land a bump as
    **its own PR before the release commit**, never inside it: a dependency
    change and a version bump that break one platform together cannot be told
-   apart.
+   apart. Before merging a bump, run it against a **deliberately stale clone**
+   (issue #692) - every environment that has not updated since the last bump is
+   about to be one, and the self-heal in `build.py` is what stands between them
+   and an error that reads like a corrupt registry:
+
+   ```bash
+   git clone --depth=1 https://github.com/microsoft/vcpkg.git /tmp/stale-vcpkg
+   git -C /tmp/stale-vcpkg fetch --depth=1 origin <a-sha-from-before-the-bump>
+   git -C /tmp/stale-vcpkg reset --hard FETCH_HEAD
+   /tmp/stale-vcpkg/bootstrap-vcpkg.sh -disableMetrics
+   VCPKG_ROOT=/tmp/stale-vcpkg python build.py -e     # must self-heal, then build
+   ```
 3. Write the curated release notes to `.github/release-notes/vX.Y.Z.md` (Keep a
    Changelog format, see below).
 4. Commit both: `git commit -m "chore(release): x.y.z"` (version bump + notes

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,8 +9,9 @@ name: PR CI - run tests
 # work jobs are skipped when nothing they own was touched, and `ci-gate` still
 # reports. That is the case its "or skipped" branch was always written for.
 #
-# The work is split by tree - `app`, `engine`, `installer` - rather than run as
-# one job per OS, because the two trees have wildly different costs and are
+# The work is split by tree - `app`, `engine`, `installer`, `build-script` -
+# rather than run as one job per OS, because the trees have wildly different
+# costs and are
 # rarely touched together. Measured over the last 28 runs (median 14.0 min, p90
 # 16.6 min), with warm vcpkg and sccache caches:
 #
@@ -48,6 +49,7 @@ jobs:
       app: ${{ steps.area.outputs.app }}
       engine: ${{ steps.area.outputs.engine }}
       installer: ${{ steps.area.outputs.installer }}
+      build_script: ${{ steps.area.outputs.build_script }}
     steps:
       # Two invocations, because `predicate-quantifier` applies to the whole
       # action and the two kinds of filter need opposite ones. This one answers
@@ -126,6 +128,10 @@ jobs:
               - 'build.py'
               - 'VERSION'
               - '.github/check-windows-deps.py'
+              - '.github/workflows/pr-tests.yml'
+            build_script:
+              - 'build.py'
+              - 'scripts/test/vcpkg_baseline_test.py'
               - '.github/workflows/pr-tests.yml'
             installer:
               - 'install.sh'
@@ -440,6 +446,28 @@ jobs:
           /bin/bash scripts/test/install_test.sh
           /bin/bash scripts/test/install_e2e.sh
 
+  # build.py's plumbing, on its own job because it needs neither a C++ toolchain
+  # nor Node: throwaway git repositories and python3. Linux only - the code under
+  # test shells out to git, which behaves the same on every runner, and the
+  # engine job already covers build.py's real use on all three.
+  build-script:
+    name: Build script
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.build_script == 'true'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Test the stale-vcpkg-baseline self-heal
+        run: python3 scripts/test/vcpkg_baseline_test.py
+
   ci-gate:
     name: CI gate
     runs-on: ubuntu-latest
@@ -447,7 +475,7 @@ jobs:
     # filter cannot be read as "nothing to test". Without it, a broken `changes`
     # job skips everything, and "skipped" would pass this gate on a change
     # nobody ran.
-    needs: [changes, app, engine, installer]
+    needs: [changes, app, engine, installer, build-script]
     if: always()
     steps:
       - name: Pass if every job succeeded or was skipped
@@ -474,6 +502,7 @@ jobs:
           check app       "${{ needs.app.result }}"
           check engine    "${{ needs.engine.result }}"
           check installer "${{ needs.installer.result }}"
+          check build-script "${{ needs['build-script'].result }}"
 
           if [[ $status -ne 0 ]]; then
             echo "CI failed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,20 @@ from the repo root, and a session that has not opened a file under `engine/`
 never loads that file - one did, read the 403 as policy, and abandoned a phase
 of #625 over it. Full note there.
 
+**A vcpkg clone older than the pinned baseline is not a corrupt registry.** It
+fails once per dependency with `path 'versions/baseline.json' exists on disk,
+but not in '<sha>'`, and - once someone runs the `git fetch` that error
+suggests - with `no version database entry for <port> at <version>`. Both mean
+the clone predates `builtin-baseline` in `engine/vcpkg.json`; the second is the
+half-cured state, because vcpkg reads the baseline map out of that commit but
+the version database out of the *worktree*. `build.py` now updates the clone
+itself before configuring, so re-running the build is normally the whole answer;
+where it cannot (modified checkout, no network) it names the manual cure,
+`git -C "$VCPKG_ROOT" pull --ff-only origin master`. Baseline bumps are routine
+by design - the releasing cadence examines the pin every release - so this is on
+the path of every environment that has sat still, which is why it is written
+down next to the 403 rather than left to be rediscovered.
+
 **On Windows, do not hand-configure cmake or set `VCPKG_ROOT` - just run
 `build.py`.** It imports the MSVC environment via `vcvars` and finds cmake,
 ninja and vcpkg inside the Visual Studio Build Tools install

--- a/build.py
+++ b/build.py
@@ -630,6 +630,174 @@ def check_vcpkg() -> Optional[str]:
 
     return None
 
+# How vcpkg words a registry clone that predates the pinned `builtin-baseline`.
+# There are two distinct failures behind these, and they arrive in sequence:
+#
+#   1. the clone lacks the baseline *commit* - "path 'versions/baseline.json'
+#      exists on disk, but not in <sha>" (older tool builds pass git's own
+#      message through, which reads like a corrupt tree; newer ones wrap it as
+#      "while checking out baseline");
+#   2. the commit is fetched but the *worktree* is still old - "no version
+#      database entry for <port> at <version>", because vcpkg reads the version
+#      database from the checked-out tree, not from the baseline commit.
+#
+# Fetching cures the first and exposes the second, so the heal below does both.
+VCPKG_STALE_BASELINE_SIGNATURES = (
+    "exists on disk, but not in",
+    "while checking out baseline",
+    "no version database entry for",
+)
+
+def read_vcpkg_baseline(engine_dir: Path) -> Optional[str]:
+    """The commit engine/vcpkg.json pins as `builtin-baseline`, or None."""
+    try:
+        manifest = json.loads((engine_dir / "vcpkg.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    baseline = manifest.get("builtin-baseline")
+    return baseline if isinstance(baseline, str) and baseline else None
+
+def stale_baseline_hint(vcpkg_root: str) -> str:
+    """The manual cure, phrased the same way everywhere it is printed.
+
+    `pull`, not `fetch`: fetching alone makes the baseline commit reachable and
+    then fails on the next line, because the version database vcpkg reads comes
+    from the worktree.
+    """
+    return (f'Your vcpkg clone predates the pinned baseline in engine/vcpkg.json.\n'
+            f'  Fix it with:  git -C "{vcpkg_root}" pull --ff-only origin master')
+
+def git_output(args: List[str], timeout: int = 30) -> Optional[str]:
+    """Run a git command, returning its stdout, or None if it failed at all.
+
+    Every git call here is a probe on someone else's checkout, so a missing
+    git, a non-repository or a non-zero exit are all the same answer: cannot
+    tell, carry on without healing.
+    """
+    try:
+        result = subprocess.run(["git"] + args, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+def heal_stale_vcpkg_baseline(vcpkg_root: str, engine_dir: Path) -> bool:
+    """Bring a vcpkg registry clone forward to the pinned baseline.
+
+    A clone that predates the pin fails once per dependency with wording that
+    reads as corruption and is only staleness. Baseline bumps are routine by
+    design - the releasing cadence examines the pin every release - so every
+    environment that has not been updated since the last bump hits this on its
+    next build.
+
+    Fetching is half of it: vcpkg reads `versions/baseline.json` out of the
+    baseline *commit*, but the per-port version database out of the **worktree**,
+    so a fetched-but-unmoved clone trades one error for "no version database
+    entry for <port> at <version>". The condition that satisfies both is the
+    same one: the baseline has to be an ancestor of what is checked out.
+
+    Returns True when the clone can resolve the baseline afterwards. False means
+    the caller should expect vcpkg to fail, having already printed the manual
+    cure - this never leaves a wall without its one-command answer.
+    """
+    baseline = read_vcpkg_baseline(engine_dir)
+    if not baseline:
+        return True
+
+    root = Path(vcpkg_root)
+    # Not every vcpkg root is a git checkout - the copy bundled with Visual
+    # Studio Build Tools resolves differently - and one that is not cannot be
+    # healed or diagnosed here. Probe, do not assume.
+    if git_output(["-C", str(root), "rev-parse", "--git-dir"]) is None:
+        return True
+
+    def carries_baseline() -> bool:
+        """Is the pinned commit in the checked-out history? Both halves at once:
+        a missing commit and a behind worktree both answer no."""
+        return git_output(["-C", str(root), "merge-base", "--is-ancestor", baseline, "HEAD"]) is not None
+
+    if carries_baseline():
+        if VERBOSE:
+            log_dim(f'vcpkg baseline {baseline[:10]} present')
+        return True
+
+    log(f'{Style.CYAN}{Style.ARROW}{Style.RESET} vcpkg clone predates baseline {baseline[:10]} - updating...')
+
+    remotes = (git_output(["-C", str(root), "remote"]) or "").split()
+    if not remotes:
+        log(f'{Style.YELLOW}{Style.WARN}{Style.RESET} vcpkg checkout has no git remote to update from')
+        log_dim(stale_baseline_hint(vcpkg_root))
+        return False
+    remote = "origin" if "origin" in remotes else remotes[0]
+
+    # Moving someone's worktree is only safe when there is nothing there to
+    # lose. Ignore untracked files: a bootstrapped root is full of them
+    # (the vcpkg binary, buildtrees/, installed/) and none are ours to keep.
+    if git_output(["-C", str(root), "status", "--porcelain", "--untracked-files=no"]):
+        log(f'{Style.YELLOW}{Style.WARN}{Style.RESET} vcpkg checkout has local modifications - not touching it')
+        log_dim(stale_baseline_hint(vcpkg_root))
+        return False
+
+    # A plain fetch, not a fetch of the baseline sha: it reaches the pin from a
+    # shallow `--setup` clone as well as a full one, and asking for a bare sha
+    # needs server-side support only some hosts enable. 10 minutes because a
+    # cold registry fetch is minutes of transfer, and a hung network should end
+    # the build, not own it.
+    if git_output(["-C", str(root), "fetch", "--quiet", remote], timeout=600) is None:
+        log(f'{Style.YELLOW}{Style.WARN}{Style.RESET} could not fetch the vcpkg registry from {remote}')
+        log_dim(stale_baseline_hint(vcpkg_root))
+        return False
+
+    # A shallow clone is what `--setup` bootstraps, and it is cut at the
+    # registry *tip* - so a pin that is merely older than the clone sits behind
+    # the shallow boundary, present in no fetch of new commits. Deepening is the
+    # only way back to it, and it is the difference between a fresh bootstrap
+    # that can build the engine and one that cannot.
+    if (git_output(["-C", str(root), "cat-file", "-e", f"{baseline}^{{commit}}"]) is None
+            and git_output(["-C", str(root), "rev-parse", "--is-shallow-repository"]) == "true"):
+        git_output(["-C", str(root), "fetch", "--quiet", "--unshallow", remote], timeout=600)
+
+    branch = git_output(["-C", str(root), "symbolic-ref", "--short", "-q", "HEAD"])
+    if branch:
+        # The attached case, and the one nearly everyone is in: fast-forward the
+        # checked-out branch. --ff-only so a clone carrying its own commits is
+        # refused rather than merged into.
+        git_output(["-C", str(root), "merge", "--ff-only", "--quiet", f"{remote}/{branch}"], timeout=120)
+
+    if not carries_baseline():
+        # Detached, on a branch with no counterpart upstream, or one that cannot
+        # fast-forward. Land exactly on the pinned commit: it is the version
+        # database this build needs, and it cannot overshoot into a newer
+        # registry the pin was never tested against.
+        git_output(["-C", str(root), "checkout", "--quiet", "--detach", baseline], timeout=300)
+
+    if carries_baseline():
+        # Re-read the attachment: a refused fast-forward falls through to the
+        # detach above, so the branch we started on is not what we ended on.
+        now_on = git_output(["-C", str(root), "symbolic-ref", "--short", "-q", "HEAD"])
+        where = f'on branch {now_on}' if now_on else f'detached at {baseline[:10]}'
+        log(f'{Style.GREEN}{Style.CHECK}{Style.RESET} vcpkg registry updated to baseline {baseline[:10]} ({where})')
+        return True
+
+    log(f'{Style.YELLOW}{Style.WARN}{Style.RESET} vcpkg registry update did not reach baseline {baseline[:10]}')
+    log_dim(stale_baseline_hint(vcpkg_root))
+    return False
+
+def explain_vcpkg_failure(output: str, vcpkg_root: Optional[str]) -> None:
+    """Translate vcpkg's stale-baseline wording, if that is what just failed.
+
+    The self-heal above covers the case where a fetch is possible. This is the
+    case where it was not - no remote, no network, a vcpkg root that is not a
+    checkout - and the point is that the error names its own cure instead of
+    reading as a corrupt tree.
+    """
+    if not output or not any(sig in output for sig in VCPKG_STALE_BASELINE_SIGNATURES):
+        return
+    print()
+    print(f'  {Style.YELLOW}{Style.INFO} {stale_baseline_hint(vcpkg_root or "$VCPKG_ROOT")}{Style.RESET}')
+    print()
+
 def check_prerequisites(skip_app: bool):
     """Check all prerequisites with clean table output."""
     tools = [
@@ -853,9 +1021,14 @@ def setup_environment(project_root: Path):
     print()
 
     # ── vcpkg engine dependencies ─────────────────────────────────────────────
+    engine_dir = project_root / "engine"
+    # Before installing anything: a clone older than the pinned baseline fails
+    # every dependency with an error that reads like corruption. This is also
+    # the whole of the session-start hook's coverage - it runs `--setup`.
+    heal_stale_vcpkg_baseline(vcpkg_root, engine_dir)
+
     log(f'{Style.CYAN}{Style.ARROW}{Style.RESET} Pre-installing vcpkg engine dependencies...')
     vcpkg_bin = Path(vcpkg_root) / "vcpkg"
-    engine_dir = project_root / "engine"
     triplet = "x64-osx" if system_name == "macOS" else "x64-linux"
     # engine/ has a vcpkg.json manifest, so vcpkg runs in manifest mode and
     # installs the declared dependencies. Manifest mode rejects individual
@@ -993,6 +1166,13 @@ def build_engine(preset: str, clean: bool, run_tests: bool, project_root: Path) 
             spinner.stop()
             print()
 
+    # cmake configures vcpkg in manifest mode, so a registry clone older than
+    # the pinned baseline fails here rather than at install time. Heal it first;
+    # local developers get the same self-heal `--setup` gives a fresh container.
+    vcpkg_root = check_vcpkg()
+    if vcpkg_root:
+        heal_stale_vcpkg_baseline(vcpkg_root, engine_dir)
+
     # Configure
     spinner = Spinner("Configuring CMake")
     spinner.start()
@@ -1007,6 +1187,7 @@ def build_engine(preset: str, clean: bool, run_tests: bool, project_root: Path) 
         spinner.stop()
     else:
         spinner.stop(Style.CROSS, Style.RED)
+        explain_vcpkg_failure(output, vcpkg_root)
         return None
 
     print()

--- a/docs/building.md
+++ b/docs/building.md
@@ -269,6 +269,39 @@ export PATH=$VCPKG_ROOT:$PATH
 - Or set `VCPKG_ROOT` environment variable
 - Script auto-detects Visual Studio bundled CMake and vcpkg
 
+### vcpkg Cannot Find the Pinned Baseline
+
+**Problem:** every dependency fails during configure with one of
+
+```
+fatal: path 'versions/baseline.json' exists on disk, but not in '94a5411977...'
+  while checking out baseline 94a5411977...
+```
+
+```
+error: no version database entry for cpp-httplib at 0.53.0.
+Available versions: 0.52.0, 0.51.0, ...
+```
+
+The first reads like a corrupt registry and the second like a deleted release.
+Both mean the same thing: your `$VCPKG_ROOT` clone is older than the
+`builtin-baseline` commit pinned in `engine/vcpkg.json`. Baseline bumps happen
+every release cycle, so any clone that has not been updated recently hits this.
+
+vcpkg reads the baseline map out of the pinned *commit* but the per-port version
+database out of the *worktree*, which is why a bare `git fetch` cures the first
+error and lands you on the second.
+
+**Solution:** `build.py` detects this and updates the clone itself, so the usual
+answer is to re-run the build. Where it cannot - a modified checkout, no
+network, or a vcpkg that is not a git clone - it prints the manual cure:
+
+```bash
+git -C "$VCPKG_ROOT" pull --ff-only origin master
+```
+
+CI is unaffected: the workflows check out the exact `VCPKG_COMMIT`.
+
 ### Engine Fails to Start
 
 **Problem:** "Failed to Start Engine" error

--- a/scripts/test/vcpkg_baseline_test.py
+++ b/scripts/test/vcpkg_baseline_test.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+build.py's stale-vcpkg-baseline self-heal (issue #692).
+
+A vcpkg registry clone that predates the `builtin-baseline` in
+engine/vcpkg.json fails dependency resolution with vcpkg's most misleading
+error - "path 'versions/baseline.json' exists on disk, but not in <sha>" - once
+per dependency. It reads as a corrupt tree and is only a clone that has not
+been updated since the pin moved. Baseline bumps are routine by design, so this
+is on the path of every environment that has sat still.
+
+Fetching is only half the cure, and the half that produces a second confusing
+error ("no version database entry for <port> at <version>"): vcpkg reads the
+baseline map out of the pinned commit and the version database out of the
+worktree. The fixtures below model both files so a heal cannot pass by curing
+one of them.
+
+Everything here drives the real functions in build.py against throwaway git
+repositories: an "upstream" that advances past a clone, exactly as vcpkg's
+registry advances past a container image. No network, no vcpkg install.
+
+Run: python3 scripts/test/vcpkg_baseline_test.py
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PASSED = 0
+FAILED = 0
+
+
+def load_build_module():
+    """Import build.py by path - it is a script, not an installed module."""
+    spec = importlib.util.spec_from_file_location("vayu_build", REPO_ROOT / "build.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def pass_(name: str) -> None:
+    global PASSED
+    print(f"  ok - {name}")
+    PASSED += 1
+
+
+def fail(name: str, detail: str) -> None:
+    global FAILED
+    print(f"  FAIL - {name}")
+    print(f"         {detail}")
+    FAILED += 1
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    pass_(name) if condition else fail(name, detail)
+
+
+def git(repo: Path, *args: str) -> str:
+    """Run git in repo with an identity, so commits work on a bare CI box."""
+    result = subprocess.run(
+        ["git", "-C", str(repo),
+         "-c", "user.name=vayu-test", "-c", "user.email=test@vayu.invalid",
+         "-c", "commit.gpgsign=false", *args],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+# The two files vcpkg reads, and it reads them from different places: the
+# baseline map out of the pinned commit, the per-port version database out of
+# the worktree. The fixtures model both, because healing only one is the bug.
+BASELINE_MAP = Path("versions") / "baseline.json"
+VERSION_DB = Path("versions") / "c-" / "curl.json"
+
+
+def make_registry(root: Path) -> Path:
+    """A stand-in vcpkg registry with one commit, ready to be cloned."""
+    registry = root / "registry"
+    (registry / VERSION_DB.parent).mkdir(parents=True)
+    (registry / BASELINE_MAP).write_text(json.dumps({"default": {"curl": {"baseline": "8.0.0"}}}))
+    (registry / VERSION_DB).write_text(json.dumps({"versions": ["8.0.0"]}))
+    git(registry.parent, "init", "--quiet", str(registry))
+    git(registry, "add", "-A")
+    git(registry, "commit", "--quiet", "-m", "initial")
+    return registry
+
+
+def advance_registry(registry: Path, version: str) -> str:
+    """Publish a new curl version upstream; return the sha to pin as baseline."""
+    known = json.loads((registry / VERSION_DB).read_text())["versions"]
+    (registry / VERSION_DB).write_text(json.dumps({"versions": [version] + known}))
+    (registry / BASELINE_MAP).write_text(json.dumps({"default": {"curl": {"baseline": version}}}))
+    git(registry, "add", "-A")
+    git(registry, "commit", "--quiet", "-m", f"curl {version}")
+    return git(registry, "rev-parse", "HEAD")
+
+
+def worktree_knows(clone: Path, version: str) -> bool:
+    """Does the *checked-out* version database carry this version?
+
+    This is the assertion that separates a real heal from a fetch: after a
+    fetch alone the commit is reachable and this file is still the old one,
+    which is the "no version database entry for curl at <version>" failure.
+    """
+    try:
+        return version in json.loads((clone / VERSION_DB).read_text())["versions"]
+    except (OSError, ValueError, KeyError):
+        return False
+
+
+def make_engine_dir(root: Path, baseline) -> Path:
+    """An engine/ whose vcpkg.json pins `baseline` (omitted when None)."""
+    engine = root / "engine"
+    engine.mkdir(parents=True, exist_ok=True)
+    manifest = {"name": "vayu-engine", "dependencies": ["curl"]}
+    if baseline is not None:
+        manifest["builtin-baseline"] = baseline
+    (engine / "vcpkg.json").write_text(json.dumps(manifest))
+    return engine
+
+
+def heal(build, vcpkg_root, engine_dir):
+    """Call the self-heal, returning (result, printed output)."""
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        result = build.heal_stale_vcpkg_baseline(str(vcpkg_root), engine_dir)
+    return result, buffer.getvalue()
+
+
+def test_stale_clone_heals(build, root: Path) -> None:
+    """The observed case: a clone made before the pin moved."""
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    baseline = advance_registry(registry, "8.21.0")
+    engine = make_engine_dir(root, baseline)
+
+    check("a clone predating the pin cannot resolve the pinned version",
+          not worktree_knows(clone, "8.21.0"), "fixture is not actually stale")
+
+    result, output = heal(build, clone, engine)
+    check("a stale clone is brought forward to the baseline",
+          result and worktree_knows(clone, "8.21.0"),
+          f"returned {result}; output: {output.strip()}")
+
+
+def test_fetched_but_unmoved_clone_heals(build, root: Path) -> None:
+    """The correction on issue #692: fetching is only half the cure.
+
+    Here the baseline commit is already in the object store - someone ran the
+    `git fetch` the first error suggested - and the worktree is still old. A
+    heal that probes only for the commit calls this healthy, and vcpkg then
+    fails with "no version database entry for curl at 8.21.0".
+    """
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    baseline = advance_registry(registry, "8.21.0")
+    git(clone, "fetch", "--quiet", "origin")
+    engine = make_engine_dir(root, baseline)
+
+    check("the fetched clone has the baseline commit but not the version db",
+          git(clone, "cat-file", "-t", baseline) == "commit" and not worktree_knows(clone, "8.21.0"),
+          "fixture does not model the fetched-but-unmoved state")
+
+    result, output = heal(build, clone, engine)
+    check("a fetched-but-unmoved worktree is still moved forward",
+          result and worktree_knows(clone, "8.21.0"),
+          f"returned {result}; output: {output.strip()}")
+
+
+def test_shallow_clone_heals(build, root: Path) -> None:
+    """`--setup` bootstraps vcpkg with --depth=1, so shallow is a real shape.
+
+    The pin here is *behind* the upstream tip, which is the shape a real bump
+    has by the time anyone builds against it: the heal has to reach a commit
+    that is neither the tip nor inside the clone's shallow boundary.
+    """
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--depth=1", f"file://{registry}", str(clone)],
+        check=True,
+    )
+    baseline = advance_registry(registry, "8.21.0")
+    advance_registry(registry, "8.22.0")
+    engine = make_engine_dir(root, baseline)
+
+    result, output = heal(build, clone, engine)
+    check("a shallow clone is healed too", result and worktree_knows(clone, "8.21.0"),
+          f"returned {result}; output: {output.strip()}")
+
+
+def test_shallow_clone_at_the_tip_heals(build, root: Path) -> None:
+    """A fresh `--setup` bootstrap: `git clone --depth=1`, cut at the tip.
+
+    Its worktree already contains the pinned version - the pin is older than
+    the tip - but the baseline *commit* is behind the shallow boundary, so
+    vcpkg cannot read the baseline map out of it and no fetch of new commits
+    will ever bring it in. Only deepening does.
+    """
+    registry = make_registry(root)
+    baseline = advance_registry(registry, "8.21.0")
+    advance_registry(registry, "8.22.0")
+    clone = root / "vcpkg"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--depth=1", f"file://{registry}", str(clone)],
+        check=True,
+    )
+    engine = make_engine_dir(root, baseline)
+
+    check("the bootstrap clone is missing the pinned commit",
+          subprocess.run(["git", "-C", str(clone), "cat-file", "-e", baseline],
+                         capture_output=True).returncode != 0,
+          "fixture does not model a shallow boundary")
+
+    result, output = heal(build, clone, engine)
+    check("a shallow clone cut at the tip is deepened to reach the pin",
+          result and git(clone, "cat-file", "-t", baseline) == "commit",
+          f"returned {result}; output: {output.strip()}")
+
+
+def test_detached_clone_lands_on_the_pin(build, root: Path) -> None:
+    """A detached checkout has no branch to fast-forward - land on the pin."""
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    git(clone, "checkout", "--quiet", "--detach", "HEAD")
+    baseline = advance_registry(registry, "8.21.0")
+    advance_registry(registry, "8.22.0")
+    engine = make_engine_dir(root, baseline)
+
+    result, output = heal(build, clone, engine)
+    check("a detached clone is checked out at the pinned commit",
+          result and git(clone, "rev-parse", "HEAD") == baseline,
+          f"returned {result}; HEAD {git(clone, 'rev-parse', 'HEAD')}; output: {output.strip()}")
+    check("landing on the pin does not overshoot into a newer registry",
+          worktree_knows(clone, "8.21.0") and not worktree_knows(clone, "8.22.0"),
+          "the worktree moved past the pinned commit")
+
+
+def test_current_clone_is_left_alone(build, root: Path) -> None:
+    """A clone that already carries the pin must not pay for an update.
+
+    Asserted by deleting the remote's directory first: any fetch would fail, so
+    a clean pass proves the probe short-circuited.
+    """
+    registry = make_registry(root)
+    baseline = advance_registry(registry, "8.21.0")
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    engine = make_engine_dir(root, baseline)
+    shutil.rmtree(registry)
+
+    result, output = heal(build, clone, engine)
+    check("a current clone passes without touching the network",
+          result and output.strip() == "", f"returned {result}; output: {output.strip()}")
+
+
+def test_dirty_clone_is_not_touched(build, root: Path) -> None:
+    """Someone's edited registry is theirs. Refuse, say why, and name the cure.
+
+    git would refuse to clobber the edit on its own; what it would not do is
+    say which of the several things that can go wrong here went wrong. The
+    named reason is the whole contribution of the guard, so it is asserted.
+    """
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    baseline = advance_registry(registry, "8.21.0")
+    engine = make_engine_dir(root, baseline)
+    (clone / BASELINE_MAP).write_text('{"default":{"curl":{"baseline":"local-edit"}}}')
+
+    result, output = heal(build, clone, engine)
+    check("a dirty checkout reports failure rather than moving", result is False,
+          f"returned {result}")
+    check("the local modification survives",
+          "local-edit" in (clone / BASELINE_MAP).read_text(), "the edit was overwritten")
+    check("the refusal says the checkout is modified, not just that it failed",
+          "local modifications" in output, f"output: {output.strip()}")
+    check("the refusal names the manual cure",
+          f'git -C "{clone}" pull --ff-only origin master' in output, f"output: {output.strip()}")
+
+
+def test_unhealable_clone_names_the_cure(build, root: Path) -> None:
+    """No remote to update from: fail loudly, naming the command."""
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    git(clone, "remote", "remove", "origin")
+    baseline = advance_registry(registry, "8.21.0")
+    engine = make_engine_dir(root, baseline)
+
+    result, output = heal(build, clone, engine)
+    check("an unhealable clone reports failure", result is False, f"returned {result}")
+    check("the failure names `git -C <root> pull`",
+          f'git -C "{clone}" pull --ff-only origin master' in output, f"output: {output.strip()}")
+
+
+def test_non_git_vcpkg_root_is_skipped(build, root: Path) -> None:
+    """The vcpkg bundled with VS Build Tools is not something to fetch."""
+    plain = root / "vcpkg-not-a-checkout"
+    plain.mkdir()
+    engine = make_engine_dir(root, "0" * 40)
+
+    result, output = heal(build, plain, engine)
+    check("a vcpkg root that is not a git checkout is skipped silently",
+          result and output.strip() == "", f"returned {result}; output: {output.strip()}")
+
+
+def test_manifest_without_baseline_is_skipped(build, root: Path) -> None:
+    """Nothing to probe against - and nothing to complain about."""
+    registry = make_registry(root)
+    clone = root / "vcpkg"
+    subprocess.run(["git", "clone", "--quiet", str(registry), str(clone)], check=True)
+    engine = make_engine_dir(root, None)
+
+    result, output = heal(build, clone, engine)
+    check("a manifest with no builtin-baseline is skipped silently",
+          result and output.strip() == "", f"returned {result}; output: {output.strip()}")
+
+
+def test_error_translation(build) -> None:
+    """The path where healing was impossible: the error must name its cure.
+
+    Both wordings are verbatim from a real stale clone - the first from the
+    tool version in issue #692, the second from the one in the cloud container
+    that reproduced it. A signature matching only one of them would leave half
+    the installed tool versions untranslated.
+    """
+    wordings = {
+        "the git-level wording": (
+            "error: fatal: path 'versions/baseline.json' exists on disk, but not in "
+            "'94a541197763a4f449a1b91478df48c0584a6256'\n"
+            "  while loading baseline version for curl\n"
+        ),
+        "the wrapped wording": (
+            "error: while checking out baseline from commit "
+            "'94a541197763a4f449a1b91478df48c0584a6256', failed to `git show` "
+            "versions/baseline.json. This may be fixed by fetching commits with `git fetch`.\n"
+            "while loading baseline version for curl\n"
+        ),
+        # The second failure, reached only after a fetch: commit present,
+        # worktree behind. Without this signature the half-healed clone - the
+        # state the first error's own advice leaves you in - goes untranslated.
+        "the stale-worktree wording": (
+            "error: no version database entry for cpp-httplib at 0.53.0.\n"
+            "Available versions:\n  0.52.0\n  0.51.0\n"
+        ),
+    }
+    for label, vcpkg_error in wordings.items():
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            build.explain_vcpkg_failure(vcpkg_error, "/opt/vcpkg")
+        translated = buffer.getvalue()
+        check(f"{label} is translated",
+              'git -C "/opt/vcpkg" pull --ff-only origin master' in translated,
+              f"output: {translated.strip()}")
+
+    vcpkg_error = wordings["the git-level wording"]
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        build.explain_vcpkg_failure("ninja: build stopped: subcommand failed.\n", "/opt/vcpkg")
+    check("an unrelated failure is not translated", buffer.getvalue().strip() == "",
+          f"output: {buffer.getvalue().strip()}")
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        build.explain_vcpkg_failure(vcpkg_error, None)
+    check("an unresolved vcpkg root still names the variable",
+          "$VCPKG_ROOT" in buffer.getvalue(), f"output: {buffer.getvalue().strip()}")
+
+
+def main() -> int:
+    if shutil.which("git") is None:
+        print("git is required to run this suite")
+        return 1
+
+    build = load_build_module()
+    print("build.py stale-vcpkg-baseline self-heal")
+    print()
+
+    # Each case gets its own temporary tree: they all create a registry and a
+    # clone at fixed names, and a leaked one would make the next case lie.
+    per_tree = [
+        test_stale_clone_heals,
+        test_fetched_but_unmoved_clone_heals,
+        test_shallow_clone_heals,
+        test_shallow_clone_at_the_tip_heals,
+        test_detached_clone_lands_on_the_pin,
+        test_current_clone_is_left_alone,
+        test_dirty_clone_is_not_touched,
+        test_unhealable_clone_names_the_cure,
+        test_non_git_vcpkg_root_is_skipped,
+        test_manifest_without_baseline_is_skipped,
+    ]
+    for case in per_tree:
+        with tempfile.TemporaryDirectory() as tmp:
+            case(build, Path(tmp))
+
+    test_error_translation(build)
+
+    print()
+    print(f"  {PASSED} passed, {FAILED} failed")
+    if PASSED == 0:
+        print("  no assertions ran - the suite proved nothing")
+        return 1
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

**Plan.** Root cause: a `$VCPKG_ROOT` clone older than `builtin-baseline` cannot resolve the pin, and vcpkg words that as a corrupt tree. Your correction on the issue is the load-bearing half - fetching only makes the baseline *commit* reachable, and vcpkg reads the per-port version database out of the **worktree**, so a fetched-but-unmoved clone trades `exists on disk, but not in '<sha>'` for `no version database entry for <port> at <version>`. I reproduced both signatures against a real clone 40 commits behind the pin before writing anything, and confirmed a bare `git fetch` lands exactly on the second error. The approach is therefore one predicate - *is the pinned commit an ancestor of HEAD* - which is false in both broken states and true only when the clone can actually build, plus an update path that fetches, deepens a shallow bootstrap clone, fast-forwards the checked-out branch, and otherwise lands detached on the pin. Rejected alternative: probing only for the commit's presence (`git cat-file`) with a bare `git fetch` as the cure - it is what the error text suggests, it passes a naive test suite, and it leaves the build failing on the next line; the `test_fetched_but_unmoved_clone_heals` case exists to keep it rejected.

Layer by layer, as the issue asked:

- **Session-start hook** - `.claude/hooks/session-start.sh` runs `build.py --setup` and nothing else, so the heal was placed in `--setup` ahead of its vcpkg install rather than duplicated as a shell probe (a hand-rolled copy of a primitive never receives the primitive's fixes). The hook carries a comment saying so, so nobody adds the second copy later.
- **`build.py`** - the same heal runs before cmake configure, so local developers self-heal too; guarded on `$VCPKG_ROOT` actually being a git checkout, since the Windows BuildTools-bundled vcpkg is not one. When configure fails anyway, the output is matched against all three wordings and translated into the one-command cure.
- **Docs, same commit** - `docs/building.md` gains a troubleshooting entry with both failure signatures and the corrected recipe; root `CLAUDE.md` gains the same one-paragraph treatment the 403 note has; the `releasing` skill's baseline-bump step (#679) gains the deliberately-stale-clone verification that acceptance criterion 3 asks for.

Behaviour on the paths that cannot heal is the point, not an afterthought: no remote, no network, a modified checkout, or a vcpkg root that is not a clone each print `git -C "$VCPKG_ROOT" pull --ff-only origin master` rather than leaving the wall standing. A modified checkout is refused outright - moving someone's edited registry is not this script's call.

Two deviations from the issue text, both driven by evidence gathered while implementing:

1. The cure is `pull --ff-only`, not `fetch` - per your correction, and independently reproduced here.
2. A shallow clone cut at the registry *tip* (what `--setup`'s own `git clone --depth=1` produces) has the older pin behind its shallow boundary, where no fetch of new commits can reach it. That needed a deepen step, which the issue did not anticipate; without it a fresh bootstrap cannot build the engine at all between baseline bumps.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

**New suite** - `scripts/test/vcpkg_baseline_test.py`, **23 assertions, 0 failed**. It drives the real functions in `build.py` against throwaway git registries that model both files vcpkg reads (baseline map and version database), so a heal cannot pass by curing one of them. Cases: stale clone, fetched-but-unmoved worktree, shallow clone behind the tip, shallow clone cut *at* the tip, detached HEAD, already-current clone (asserted by deleting the remote first, so any network call would fail), dirty checkout, remote-less checkout, non-git root, manifest without a baseline, and all three error wordings plus a negative.

Mutation-checked, five ways - each reverted in turn, suite re-run, fix restored:

| Mutation | Result |
|---|---|
| heal removed entirely | 9 failed |
| probe only the commit's presence (the pre-correction fix) | 3 failed |
| dirty-worktree guard removed | 1 failed |
| detach fallback removed | 2 failed |
| shallow deepen removed | 1 failed |

It runs in CI as a new `build-script` job (python3 + git only, Linux, ~5s), wired into the `changes` filter on `build.py` and into the `CI gate`'s checklist so a skip cannot be read as a pass.

**End-to-end, real vcpkg** - a clone pinned 40 commits behind `94a5411977`, on `master`, with the bootstrapped binary:

```
BEFORE  vcpkg install --dry-run  ->  exit 1
        fatal: path 'versions/baseline.json' exists on disk, but not in '94a5411977...'
HEAL    -> vcpkg clone predates baseline 94a5411977 - updating...
        v vcpkg registry updated to baseline 94a5411977 (on branch master)
AFTER   vcpkg install --dry-run  ->  exit 0
```

**Repo suites** - `python build.py -e -t` green (18m 32s, cold vcpkg cache), `ctest --preset linux-dev`: **1899/1899 passed, 0 failed**. `mkdocs build --strict` clean. The app tree is untouched, so its suite was not run.

No pre-existing failures were observed on the base commit.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #692

---
_Generated by [Claude Code](https://claude.ai/code/session_0113CymBRkQaKhXPR92JdWJv)_