### PR TITLE
docs(dashboard): give the five code-quality gates a real home

### DIFF
--- a/app/src/modules/dashboard/README.md
+++ b/app/src/modules/dashboard/README.md
@@ -8,6 +8,8 @@ This module displays real-time load test metrics and results.
 
 - `index.tsx` - Main LoadTestDashboard component (entry point)
 - `components/` - Sub-components (DashboardHeader, MetricsView, etc.)
+- `hooks/` - Dashboard-scoped hooks (`useMode`)
+- `utils/` - Pure derivation and geometry helpers
 - `types.ts` - Type definitions
 
 ## Usage
@@ -15,3 +17,33 @@ This module displays real-time load test metrics and results.
 ```tsx
 import LoadTestDashboard from "@/modules/dashboard";
 ```
+
+## Code-quality gates
+
+Five rules this module holds to. Each names the file that owns it - that file is
+the authority, so a change belongs there rather than in the component that
+consumes it.
+
+- **Tooltip copy lives in one file.** `components/tooltips.tsx` is the single
+  source of every InfoChip string. Components import by key
+  (`<InfoChip tip={TOOLTIPS.rateFidelity} />`) and never write tooltip copy
+  inline. Nothing outside the file locks the wording - no test pins a string and
+  no document restates it - so `tooltips.tsx` is where wording is decided, and
+  editing an entry there updates every card that shows it.
+- **No chart geometry constants in component files.** `utils/chartGeometry.ts`
+  owns `TIME_SERIES_DIMS` and `HDR_DIMS`. The full-width time-series charts must
+  stay dimensionally identical or the dashboard rows stop lining up, and the HDR
+  plot must match its own skeleton or the card shifts height when the final
+  report arrives.
+- **The mode mapping lives in exactly one place.** `hooks/useMode.ts` is the only
+  interpreter of the freeform engine `mode` string. Mode-adaptive components take
+  the discriminator from it instead of re-parsing the raw value, and the mode
+  vocabulary is derived from `LOAD_TEST_MODES` rather than hand-listed.
+- **No card re-derives from raw metrics.** `components/MetricsView.tsx` computes
+  one memoized `DashboardDerived` bundle (shape in `types.ts`) and passes it to
+  `HeroRow` and `ModeStatsRow`, which stay pure presentational components that
+  read what they need.
+- **The per-mode stat-card table lives with its router.**
+  `components/stats/ModeStatsRow.tsx` decides which four cards each mode shows,
+  and its file comment tabulates them. Add a mode there, next to the branch that
+  renders it.

--- a/app/src/modules/dashboard/components/stats/ModeStatsRow.tsx
+++ b/app/src/modules/dashboard/components/stats/ModeStatsRow.tsx
@@ -8,7 +8,8 @@
 /**
  * ModeStatsRow - the mode-adaptive Row 4 router. Four stat cards swap on d.mode.
  * For three of the four modes the 4th card is the universal p99 latency stat;
- * the first three switch per mode (Plan 4 §62–69):
+ * the first three switch per mode. This table is the authority for which cards
+ * a mode shows - add a mode here, beside the branch that renders it:
  *
  *   constant_rps         Duration · Total requests · Peak concurrency · p99
  *   constant_concurrency Duration · Total requests · Throughput / VU   · p99
@@ -20,7 +21,7 @@
  * that branch renders all four cards itself. Shared cards (Duration / Total /
  * Peak) and the universal p99 card live here; the mode-only cards live in
  * ModeStatCards.tsx. Consumes {@link DashboardDerived}; never re-derives from
- * raw metrics (gate #9). All InfoChip copy via TOOLTIPS.
+ * raw metrics. All InfoChip copy via TOOLTIPS.
  */
 
 import { cn } from "@/lib/utils";

--- a/app/src/modules/dashboard/components/tooltips.tsx
+++ b/app/src/modules/dashboard/components/tooltips.tsx
@@ -7,9 +7,9 @@
 
 /**
  * tooltips - centralized InfoChip wording for every dashboard metric card and
- * chart (Plan 4 code-quality gate #2: components import strings by key, they
- * do not write tooltip copy inline). Wording is locked in
- * docs/plans/4-dashboard-redesign.md §"Tooltip wording".
+ * chart: components import strings by key, they do not write tooltip copy
+ * inline. This file is the authority for the wording itself - nothing outside
+ * it pins a string - so an edit here is the whole change.
  *
  * Most entries are plain strings; a few carry inline markup and are therefore
  * ReactNode. Consume as: <InfoChip tip={TOOLTIPS.rateFidelity} />.

--- a/app/src/modules/dashboard/hooks/useMode.ts
+++ b/app/src/modules/dashboard/hooks/useMode.ts
@@ -11,7 +11,7 @@
  * The engine/run-config `mode` string is freeform (and historically defaulted
  * to the constant_rps model). Every mode-adaptive component MUST derive its
  * behaviour from this discriminator rather than re-parsing the raw string, so
- * the mapping lives in exactly one place (Plan 4 code-quality gate #5).
+ * the mapping lives in exactly one place - this file.
  */
 
 import { LOAD_TEST_MODES } from "@/constants/load-test-modes";

--- a/app/src/modules/dashboard/types.ts
+++ b/app/src/modules/dashboard/types.ts
@@ -81,7 +81,8 @@ export interface MetricsViewProps {
  * Single derived-metrics bundle the orchestrator computes once (memoized) and
  * passes to the mode-adaptive HeroRow and ModeStatsRow. Centralizing derivation
  * here keeps the hero/stat card variants pure presentational components that
- * read what they need - no card re-derives from raw metrics (Plan 4 gate #9).
+ * read what they need - no card re-derives from raw metrics. `MetricsView` is
+ * the one producer; see "Code-quality gates" in this module's README.
  */
 export interface DashboardDerived {
 	mode: LoadMode;

--- a/app/src/modules/dashboard/utils/chartGeometry.ts
+++ b/app/src/modules/dashboard/utils/chartGeometry.ts
@@ -10,7 +10,7 @@
  * Shared SVG geometry for the full-width time-series charts (Throughput,
  * Latency, Percentiles, and the ramp_up Response-time-vs-concurrency scatter).
  * All of these MUST stay dimensionally identical so the dashboard rows line up
- * (Plan 4 code-quality gate #4: no chart geometry constants in component files).
+ * Chart geometry constants belong here, never in a component file.
  */
 export const TIME_SERIES_DIMS = { VW: 1080, VH: 240, PL: 56, PR: 12, PT: 16, PB: 28 } as const;
 


### PR DESCRIPTION
## Description

Six comments under `app/src/modules/dashboard/` cited a "Plan 4" dashboard-redesign document as the authority for a rule, and that document is not in the repository. Verified again at `4427f21`: `rg -n "Plan 4|docs/plans" app/src` found all six sites the issue lists, unchanged, and no `4-dashboard-redesign` file exists anywhere in the tree or in the delete history - it was never committed. #695 deleted `docs/plans/`, so `tooltips.tsx:12`'s path citation now dangles into a directory that is gone too.

**Plan.** The root cause is a citation pointing at a document that was never in the repo, not a missing rule: each of the five rules is real and the code follows it (strings imported by key, no chart geometry in components, one mode mapping, no card re-deriving from raw metrics, and the per-mode stat-card table). So the fix moves each rule's *authority* to somewhere a reader can actually reach - a **Code-quality gates** section in `app/src/modules/dashboard/README.md`, which already carries the module's why - and repoints or inlines the six comments, dropping the `§` numbering entirely since it refers to a numbering nothing in this repo can resolve. The alternative I rejected was reconstructing the plan document from the comments: it would manufacture a doc nobody wrote, restate rules that are better stated next to the file that enforces them, and re-create the same drift risk the issue is about.

**The tooltip-wording question, answered.** `rg` for `TOOLTIPS` shows fourteen consumers importing by key and no test anywhere pinning a tooltip string; no document restates the copy. So nothing locks the wording today - `components/tooltips.tsx` *is* the authority - and the file comment now says exactly that instead of pointing at a document. The README records the same.

Changes:

- `README.md` - new "Code-quality gates" section: five rules in the repo's own words, each naming the file that owns it (`components/tooltips.tsx`, `utils/chartGeometry.ts`, `hooks/useMode.ts`, `components/MetricsView.tsx` + `types.ts`, `components/stats/ModeStatsRow.tsx`). Structure list gains the `hooks/` and `utils/` lines the gates refer to.
- `tooltips.tsx`, `chartGeometry.ts`, `useMode.ts` - rule stated inline, citation dropped (each is one line and needs no pointer).
- `types.ts` - names `MetricsView` as the one producer and points at the README section.
- `ModeStatsRow.tsx` - the `§62-69` citation becomes a statement that the table below it is the authority; the second, bare `(gate #9)` reference on line 23 is dropped too, since the numbering it used is going away with the rest.

No behaviour changes: comments and Markdown only.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Per the issue and root `CLAUDE.md` (if no test could change colour, do not run tests), the gate is lint and format on the touched files - no test suite could go from green to red on a comment edit, and no test references any of these comments.

- `cd app && pnpm lint` - clean (zero errors, zero warnings; `--max-warnings 0`).
- `prettier --check` on the six touched files - "All matched files use Prettier code style!".
- Acceptance criterion 1 re-verified: `rg -n "Plan 4|docs/plans|gate #" app/src app/electron engine docs *.md` returns nothing.

Nothing under `docs/` changed, so no `mkdocs build --strict` run is implied.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - not applicable, comment/Markdown only
- [x] I have updated documentation - the documentation *is* the change

## Related Issues
Closes #696

---
_Generated by [Claude Code](https://claude.ai/code/session_015CGwAfLe51qXZWnBtuhQxg)_