### PR TITLE
feat(settings): categories pass 3 - a full per-entry audit, a Limits shelf, and five more Advanced entries

### DIFF
--- a/app/src/modules/settings/engine-categories.test.ts
+++ b/app/src/modules/settings/engine-categories.test.ts
@@ -14,6 +14,9 @@
  * casing are the two things about it a reader cannot check by reading one file.
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { ENGINE_SETTINGS_CATEGORIES, getEngineCategory } from "./engine-categories";
 import { ENGINE_SETTINGS_EDITED_IN_APP } from "./engine-settings-edited-in-app";
@@ -26,12 +29,17 @@ describe("the engine category registry", () => {
 		// most users never open it. This used to run Core, Database
 		// Performance, Network, Scripting, Observability - the least-visited
 		// category second, and the one users arrive with questions about last.
+		//
+		// Limits joined second-to-last in #703 by the same rule: its entries
+		// are reached from a rejection message that names the setting, never
+		// by browsing, so it ranks below the shelves people open.
 		expect(ENGINE_SETTINGS_CATEGORIES.map((c) => c.id)).toEqual([
 			"general_engine",
 			"network_performance",
 			"services",
 			"observability",
 			"data_retention",
+			"limits",
 			"scripting_sandbox",
 		]);
 	});
@@ -75,6 +83,78 @@ describe("the engine category registry", () => {
 		expect(getEngineCategory("services")?.label).toBe("Services");
 		expect(getEngineCategory("dashboard")).toBeUndefined();
 		expect(getEngineCategory(null)).toBeUndefined();
+	});
+});
+
+/**
+ * The other half of the contract, checked across the language boundary.
+ *
+ * `ConfigRouteTest.EverySeededEntrySitsInADeclaredCategory` pins the same rule
+ * engine-side, but against a `std::set` hand-copied from this file - so a
+ * category added to the seed and to that set, and forgotten here, passes there
+ * and takes the entry off the screen. This side reads the seed itself, which is
+ * the only copy neither test can restate wrongly.
+ */
+describe("the seed and the registry agree on the shelves", () => {
+	const seed = readFileSync(
+		join(
+			dirname(fileURLToPath(import.meta.url)),
+			"..",
+			"..",
+			"..",
+			"..",
+			"engine",
+			"src",
+			"db",
+			"database.cpp"
+		),
+		"utf8"
+	);
+
+	const registered = new Set<string>(ENGINE_SETTINGS_CATEGORIES.map((c) => c.id));
+
+	/**
+	 * One record per seeded entry: its key, and the registered category id
+	 * found inside its `ConfigEntry{...}` literal.
+	 *
+	 * The category is matched *against the registry*, so a typo (or an id this
+	 * file does not carry) yields `undefined` and fails below naming the key -
+	 * which is the drift the alarm exists for. Every entry ends at `now }`, the
+	 * last field of the struct.
+	 */
+	const seeded = [...seed.matchAll(/ConfigEntry\{\s*"([A-Za-z0-9_]+)"/g)].map((match) => {
+		const body = seed.slice(match.index, seed.indexOf("now }", match.index));
+		const found = [...body.matchAll(/"([a-z][a-z_]*)"/g)]
+			.map((m) => m[1])
+			.filter((literal) => registered.has(literal));
+		return { key: match[1], category: found[0], matches: found.length };
+	});
+
+	it("read a non-empty seed carrying every entry", () => {
+		// The failure CLAUDE.md documents: a source scan that reads "" (or the
+		// wrong path) satisfies every assertion below for the wrong reason.
+		expect(seed.length).toBeGreaterThan(0);
+		expect(seeded.length).toBeGreaterThan(40);
+	});
+
+	it("puts every seeded entry on a shelf this registry draws", () => {
+		// An entry in a category the renderer does not know is not a cosmetic
+		// mismatch: SettingsMain filters on it and buildSettingsIndex drops it,
+		// so the setting is on no screen and in no search result.
+		const orphaned = seeded.filter((entry) => entry.category === undefined).map((e) => e.key);
+		expect(orphaned).toEqual([]);
+
+		// Exactly one, so a description that happens to quote another id is not
+		// silently taken for the entry's own category.
+		const ambiguous = seeded.filter((entry) => entry.matches !== 1).map((e) => e.key);
+		expect(ambiguous).toEqual([]);
+	});
+
+	it("draws no shelf the seed leaves empty", () => {
+		// The other direction: a sidebar row with nothing under it. "Database
+		// Performance" was retired for holding three entries; zero is worse.
+		const held = new Set(seeded.map((entry) => entry.category));
+		expect([...registered].filter((id) => !held.has(id))).toEqual([]);
 	});
 });
 

--- a/app/src/modules/settings/engine-categories.ts
+++ b/app/src/modules/settings/engine-categories.ts
@@ -8,7 +8,7 @@
 /**
  * Engine settings category registry
  *
- * The six engine categories, declared once and in sidebar order - mirroring
+ * The seven engine categories, declared once and in sidebar order - mirroring
  * `app-panels.ts` on the client side.
  *
  * This replaces two hand-maintained maps: `ENGINE_CATEGORY_META` in the sidebar
@@ -28,7 +28,7 @@
  */
 
 import type { LucideIcon } from "lucide-react";
-import { Server, Code, Network, Activity, Database, Radio } from "lucide-react";
+import { Server, Code, Network, Activity, Database, Radio, Gauge } from "lucide-react";
 import type { EngineSettingsCategory } from "@/types";
 
 export interface EngineSettingsCategoryMeta {
@@ -53,7 +53,11 @@ export const ENGINE_SETTINGS_CATEGORIES: readonly EngineSettingsCategoryMeta[] =
 	{
 		id: "network_performance",
 		label: "Network & connectivity",
-		description: "Low-level networking tuning for throughput, DNS, and connection persistence",
+		// Widened by #703, which moved the request transport defaults in and
+		// the OAuth renewal watchdog out: the shelf is the wire itself, not
+		// only the throughput knobs it used to hold.
+		description:
+			"The wire itself: what a new request starts with, how many transfers a worker keeps open, and how long a name resolution is reused",
 		icon: Network,
 	},
 	{
@@ -68,7 +72,8 @@ export const ENGINE_SETTINGS_CATEGORIES: readonly EngineSettingsCategoryMeta[] =
 	{
 		id: "observability",
 		label: "Observability",
-		description: "Server monitoring and the live metrics that feed the dashboard's charts",
+		description:
+			"Server monitoring, per-phase latency measurement, and the live metrics that feed the dashboard's charts",
 		icon: Activity,
 	},
 	{
@@ -77,6 +82,16 @@ export const ENGINE_SETTINGS_CATEGORIES: readonly EngineSettingsCategoryMeta[] =
 		description:
 			"What a run stores and for how long: capture and truncation budgets, and the run retention limits",
 		icon: Database,
+	},
+	{
+		id: "limits",
+		label: "Limits",
+		// Late in the order on purpose (#586's rule is likelihood of visit):
+		// nobody browses here. Every entry is arrived at from a rejection
+		// message that names the setting, so search is the way in.
+		description:
+			"The sizes and counts a run or a collection may not exceed - the ceilings that reject an oversized input rather than truncate it",
+		icon: Gauge,
 	},
 	{
 		id: "scripting_sandbox",

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2099,6 +2099,7 @@ export type EngineSettingsCategory =
 	| "services"
 	| "observability"
 	| "data_retention"
+	| "limits"
 	| "scripting_sandbox";
 
 export type SettingsCategory = ClientSettingsCategory | EngineSettingsCategory;

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -484,7 +484,7 @@ min/max/options):
       "type": "enum",
       "label": "Default HTTP Version",
       "description": "Protocol a newly created request starts with...",
-      "category": "general_engine",
+      "category": "network_performance",
       "default": "auto",
       "options": [
         { "value": "auto", "label": "Auto" },
@@ -533,10 +533,13 @@ hand-maintained value-to-label map. `value` and `default` are always strings;
   suffix drifted out of step with the mechanism and misinformed the settings
   screen and the MCP `update_config` result at the same time.
 - **`advanced`** - an internal with no everyday user story (`dbBusyTimeout`, the
-  three `oauth2Refresh*` watchdog knobs, `inboxLivePollIntervalMs`,
-  `sseIdleTimeoutMs`). Still
+  four `oauth2Refresh*` watchdog knobs, `inboxLivePollIntervalMs`,
+  `sseIdleTimeoutMs`, `maxStepsPerIteration`, `monitorScrapeTimeoutMs`,
+  `liveMaxRetainedTicks`, `scriptStackSize` - eleven entries). Still
   live and still settable; the app renders these collapsed under an "Advanced"
-  section at the bottom of their category.
+  section at the bottom of their category. The membership rule is citable: if
+  an entry's own description has to say "only if" or "only for", the entry has
+  declared itself advanced.
 
 `keywords` is an array of strings, **always present** and empty for the entries
 that declare none - a client never has to tell "declares none" from "this
@@ -575,10 +578,11 @@ Full) are an enumeration rather than a range; it is stored as an `enum` so the
 panel draws a picker instead of an integer box the description has to explain.
 
 The Settings panel renders entries dynamically, so new keys appear without app
-changes. The entries below span two categories: the `data_retention` keys govern
-how much a run keeps - most of them on disk, one in memory - and the three
-`monitor*` keys are `observability`, governing how a run scrapes the endpoint it
-watches rather than what it stores:
+changes. The entries below span three categories: the `data_retention` keys
+govern how much of a run is kept on disk; `maxResponseBodyBytes` is `limits`,
+because it fails an oversized read in flight and stores nothing; and
+`phaseHistograms` joins the three `monitor*` keys in `observability`, which
+governs what a run measures rather than what it keeps:
 
 | Key                 | Default   | Range        | Effect |
 |---------------------|-----------|--------------|--------|
@@ -3163,8 +3167,10 @@ as a smaller one:
 A cycle in the `collections.parent_id` tree terminates the recursive walk rather
 than hanging it, exactly as the cascade delete in `DELETE /collections/:id` does.
 
-**Five settings bound a scenario** (all in the `general_engine` category, see
-[GET /config](#get-config)):
+**Five settings bound a scenario** (see [GET /config](#get-config)). Four are in
+the `limits` category, which is where a ceiling that rejects an oversized input
+lives; `maxScenarioStoredSteps` is `data_retention`, because it bounds what a
+finished run keeps rather than what one may ask for:
 
 | Key                   | Default | Range      | Effect |
 |-----------------------|---------|------------|--------|

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -800,7 +800,7 @@ than assuming all eight are there and flat:
 | Load run, error (`load_strategy.cpp`) | an error envelope (`error_type`, `message`, `request_number`) with the eight keys **nested under `timing`**, present whenever `totalMs > 0`, plus **`dataRowIndex`** for a scenario load run given `scenario.data`. A `data_binding_failed` error is written for a request that was never sent at all - a `{{data.column}}` naming a column its row does not carry - so it has no timing. |
 | Design mode (`store_result` in `execution.cpp`) | all eight keys flat, unconditionally - the same set the live `/execute` response carries, so a restored response shows exactly what the live one did (a skipped phase is stored as `0`). Written on **every** single request, alongside a nested `request` object plus either `response` (success) or `error_type` / `error_message` (failure). The `response` node carries `headers`, `body`, `httpVersion` - the negotiated protocol, `""` when nothing was negotiated, same convention as the live `/execute` response (see [POST /execute](api-reference.md#post-execute)) - and `httpVersionDowngraded`, true when the request asked for HTTP/2 and got something older; a row written before either field existed simply has no such key, so `restore-response.ts` must default both. Rows written by older engines omitted zero-valued phases and all of `totalMs`/`wireMs`/`queueWaitMs`, so readers must default missing keys (perceived total also lives in the `latency_ms` column). |
 
-| Scenario run, one row per step execution (`core/scenario_runner.cpp`) | the design-mode writer's trace exactly - it *is* `build_result_trace` - plus five keys naming the step: `iteration` (0-based), `stepIndex`, `stepName`, `requestId` and `outcome` (`passed` / `failed` / `skipped` / `errored`), and a sixth, **`dataRowIndex`**, present only for a run given `scenario.data` - the row that iteration bound, which is the only record of *which* row a wrapped pass re-used. The rows themselves are never stored; the snapshot keeps `dataRowCount` alone. A `skipped` row - a pre-request script called `pm.execution.skipRequest()` - carries the `request` node and **no `response`**, because nothing was sent; `restore-response.ts` already answers `null` for that shape rather than building a hollow 0-byte response. Bodies are capped the same way. The row count is bounded by **`maxScenarioStoredSteps`** (config, `general_engine`, default 5000; `0` = unlimited), biased so that every step that did not pass is kept and successes fill the remainder - what was thinned is reported in `runs.summary`, never silently. |
+| Scenario run, one row per step execution (`core/scenario_runner.cpp`) | the design-mode writer's trace exactly - it *is* `build_result_trace` - plus five keys naming the step: `iteration` (0-based), `stepIndex`, `stepName`, `requestId` and `outcome` (`passed` / `failed` / `skipped` / `errored`), and a sixth, **`dataRowIndex`**, present only for a run given `scenario.data` - the row that iteration bound, which is the only record of *which* row a wrapped pass re-used. The rows themselves are never stored; the snapshot keeps `dataRowCount` alone. A `skipped` row - a pre-request script called `pm.execution.skipRequest()` - carries the `request` node and **no `response`**, because nothing was sent; `restore-response.ts` already answers `null` for that shape rather than building a hollow 0-byte response. Bodies are capped the same way. The row count is bounded by **`maxScenarioStoredSteps`** (config, `data_retention`, default 5000; `0` = unlimited), biased so that every step that did not pass is kept and successes fill the remainder - what was thinned is reported in `runs.summary`, never silently. |
 
 A **streaming** design run (`POST /execute` with `"stream": true`, issue #573)
 adds one node the others never carry: **`events`**, holding `items` (the first
@@ -1020,7 +1020,7 @@ written by `POST /config`. Struct is `db::ConfigEntry`.
 | `type`          | TEXT    | `"integer"` / `"string"` / `"boolean"` / `"number"` / `"enum"` |
 | `label`         | TEXT    | Display label                                          |
 | `description`   | TEXT    | Help text                                              |
-| `category`      | TEXT    | Which sidebar row it renders under; one of `general_engine`, `network_performance`, `services`, `observability`, `data_retention`, `scripting_sandbox` |
+| `category`      | TEXT    | Which sidebar row it renders under; one of `general_engine`, `network_performance`, `services`, `observability`, `data_retention`, `limits`, `scripting_sandbox` |
 | `default_value` | TEXT    | Default as string                                      |
 | `min_value`     | TEXT    | Optional minimum (numbers)                             |
 | `max_value`     | TEXT    | Optional maximum (numbers)                             |
@@ -1035,9 +1035,12 @@ written by `POST /config`. Struct is `db::ConfigEntry`.
 draws one sidebar row per category it declares
 (`app/src/modules/settings/engine-categories.ts`) and drops an entry whose
 category it does not know, so a value outside the list above is a setting with
-no screen. `seed_default_config` is the only writer, and
-`ConfigRouteTest.EverySeededEntrySitsInADeclaredCategory` pins the two lists
-against each other. Reseeding rewrites an existing row's metadata while keeping
+no screen. `seed_default_config` is the only writer, and two guards pin the two
+lists against each other from opposite sides:
+`ConfigRouteTest.EverySeededEntrySitsInADeclaredCategory` reads the seeded rows
+against a set copied into the C++ test, and `engine-categories.test.ts` reads
+`database.cpp` itself against the renderer's registry - so a category added to
+the seed and to the C++ set but forgotten in the app still fails. Reseeding rewrites an existing row's metadata while keeping
 its value, which is how a retired category (`database_performance`, folded into
 `general_engine` in #586) carries an upgraded database across with nothing to
 migrate by hand.

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -960,7 +960,7 @@ the iteration with the step marked `errored` and the reason in its row:
 ### The cycle bound
 
 `setNextRequest` makes an infinite loop a two-line script, so an iteration has a
-ceiling: **`maxStepsPerIteration`** (config, `general_engine`). Its default of
+ceiling: **`maxStepsPerIteration`** (config, `limits`). Its default of
 `0` derives the bound from the collection - ten times its request count, and
 never fewer than 100 - so a straight-through iteration can never trip it, and a
 legitimate retry loop in a short collection has room. Exceeding it fails that

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -2039,8 +2039,12 @@ void Database::seed_default_config () {
     };
 
     // =========================================================================
-    // GENERAL & ENGINE CONFIGURATION
-    // Core settings defining the application's base capacity and threading model
+    // CORE (general_engine)
+    // The engine's own machinery: how much work it runs in parallel, and how
+    // SQLite is tuned underneath it. Everything a *request* or a *run* is
+    // measured or bounded by lives in one of the categories below - #703 moved
+    // the request defaults to Network & connectivity and the ceilings to
+    // Limits, leaving the four settings that describe the engine itself.
     // =========================================================================
 
     upsert_config (restart_required (keywords ({ "cores", "parallelism" }) (
@@ -2051,96 +2055,6 @@ void Database::seed_default_config () {
     "Default equals CPU core count.",
     "general_engine", std::to_string (std::thread::hardware_concurrency ()),
     "1", "128", std::nullopt, now })));
-
-    upsert_config (unit ("ms") (keywords ({ "deadline", "give up", "hang" }) (
-    ConfigEntry{ "defaultTimeout",
-    std::to_string (vayu::core::constants::server::DEFAULT_TIMEOUT_MS), "integer", "Default Request Timeout",
-    "How long an HTTP request may run before it is abandoned, "
-    "when the request does not set a timeout of its own. Raise it for slow "
-    "endpoints; lower it to fail faster.",
-    "general_engine", std::to_string (vayu::core::constants::server::DEFAULT_TIMEOUT_MS),
-    "1000",   // min: 1 second
-    "300000", // max: 5 minutes
-    std::nullopt, now })));
-
-    upsert_config (keywords ({ "h2", "alpn" }) (ConfigEntry{ "defaultHttpVersion",
-    vayu::to_string (vayu::DEFAULT_HTTP_VERSION), "enum", "Default HTTP Version",
-    "Protocol a newly created request starts with. Auto lets the server and "
-    "client negotiate (HTTP/2 where available, falling back to HTTP/1.1). "
-    "Changing this does not alter requests that already exist.",
-    "general_engine", vayu::to_string (vayu::DEFAULT_HTTP_VERSION),
-    std::nullopt, std::nullopt, http_version_options_json (), now }));
-
-    upsert_config (ConfigEntry{ "maxScenarioSteps",
-    std::to_string (vayu::core::constants::scenario::MAX_STEPS), "integer",
-    "Max Scenario Steps",
-    "Largest number of requests one collection run may resolve to. The whole "
-    "sequence is composed before the first send and held in memory for the "
-    "run, and a load-mode scenario allocates a latency histogram per step, so "
-    "this bounds memory rather than expressing a preference. A collection that "
-    "resolves to more steps is rejected outright, never silently truncated.",
-    "general_engine", std::to_string (vayu::core::constants::scenario::MAX_STEPS),
-    "1", "10000", std::nullopt, now });
-
-    upsert_config (ConfigEntry{ "maxScenarioDataRows",
-    std::to_string (vayu::core::constants::scenario::MAX_DATA_ROWS), "integer",
-    "Max Scenario Data Rows",
-    "Largest data set one collection run may carry. The app parses the CSV or "
-    "JSON file and sends the rows on the run payload - the engine never reads "
-    "a file from disk - so this bounds how big that payload may get. A larger "
-    "data set is rejected rather than truncated.",
-    "general_engine", std::to_string (vayu::core::constants::scenario::MAX_DATA_ROWS),
-    "1", "1000000", std::nullopt, now });
-
-    upsert_config (unit ("bytes") (ConfigEntry{ "maxScenarioDataBytes",
-    std::to_string (vayu::core::constants::scenario::MAX_DATA_BYTES), "integer",
-    "Max Scenario Data Size",
-    "Largest data set one collection run may carry, measured over its JSON. "
-    "The row limit alone does not bound the payload - one row is free to hold a "
-    "megabyte in a single cell - and the HTTP body cap above this would drop "
-    "the connection instead of explaining itself. A larger data set is rejected "
-    "with a message naming this setting.",
-    "general_engine", std::to_string (vayu::core::constants::scenario::MAX_DATA_BYTES),
-    "1024", "104857600", std::nullopt, now }));
-
-    upsert_config (unit ("bytes") (keywords ({ "swagger" }) (
-    ConfigEntry{ "maxSpecDocumentBytes",
-    std::to_string (vayu::core::constants::spec_document::MAX_BYTES), "integer",
-    "Max OpenAPI Document Size",
-    "Largest OpenAPI document one collection may bind. The document is stored "
-    "verbatim and parsed back by every feature that reads it, so this bounds "
-    "both the row and that parse. A larger document is rejected with a message "
-    "naming this setting, never stored truncated.",
-    "general_engine", std::to_string (vayu::core::constants::spec_document::MAX_BYTES),
-    "1024", "104857600", std::nullopt, now })));
-
-    upsert_config (ConfigEntry{ "maxScenarioStoredSteps",
-    std::to_string (vayu::core::constants::scenario::MAX_STORED_STEPS), "integer",
-    "Max Stored Scenario Steps",
-    "How many per-step results one collection run keeps, which bounds what a "
-    "long run costs the dashboard to load. Steps that failed, errored or were "
-    "skipped are kept first and successes fill the rest, so raising this buys "
-    "more successful steps to look at and never a failure that was hidden - "
-    "what was thinned is reported in the run summary. 0 stores every step.",
-    "general_engine", std::to_string (vayu::core::constants::scenario::MAX_STORED_STEPS),
-    "0", "1000000", std::nullopt, now });
-
-    upsert_config (keywords ({ "infinite loop" }) (
-    ConfigEntry{ "maxStepsPerIteration", "0", "integer", "Max Steps Per Iteration",
-    "How many requests one iteration of a collection run may send before it is "
-    "stopped. It exists because a script can redirect the sequence with "
-    "pm.execution.setNextRequest, and two steps pointing at each other would "
-    "otherwise run forever. 0 derives the limit from the collection - ten "
-    "times its request count, never fewer than 100.",
-    "general_engine", "0", "0", "1000000", std::nullopt, now }));
-
-    // =========================================================================
-    // STORAGE INTERNALS - part of Core (general_engine)
-    // SQLite optimization settings for high-throughput load testing. These had
-    // a sidebar row of their own ("Database Performance") for three entries,
-    // two of them restart-required internals; #586 folded them into Core, where
-    // the rest of the engine's infrastructure knobs already live.
-    // =========================================================================
 
     upsert_config (restart_required (unit ("bytes") (
     keywords ({ "ram" }) (ConfigEntry{ "dbCacheSize",
@@ -2182,9 +2096,32 @@ void Database::seed_default_config () {
     std::nullopt, std::nullopt, db_synchronous_options_json (), now })));
 
     // =========================================================================
-    // NETWORK & CONNECTIVITY CONFIGURATION
-    // Low-level networking tuning for throughput, DNS, and connection persistence
+    // NETWORK & CONNECTIVITY (network_performance)
+    // The wire itself: what a new request starts with, how many transfers a
+    // worker keeps open, and how long a name resolution is reused. The OAuth
+    // renewal knobs that used to sit here were five of its eight entries and
+    // moved to Services (#703) - a user tuning token renewal does not arrive
+    // at "network tuning".
     // =========================================================================
+
+    upsert_config (unit ("ms") (keywords ({ "deadline", "give up", "hang" }) (
+    ConfigEntry{ "defaultTimeout",
+    std::to_string (vayu::core::constants::server::DEFAULT_TIMEOUT_MS), "integer", "Default Request Timeout",
+    "How long an HTTP request may run before it is abandoned, "
+    "when the request does not set a timeout of its own. Raise it for slow "
+    "endpoints; lower it to fail faster.",
+    "network_performance", std::to_string (vayu::core::constants::server::DEFAULT_TIMEOUT_MS),
+    "1000",   // min: 1 second
+    "300000", // max: 5 minutes
+    std::nullopt, now })));
+
+    upsert_config (keywords ({ "h2", "alpn" }) (ConfigEntry{ "defaultHttpVersion",
+    vayu::to_string (vayu::DEFAULT_HTTP_VERSION), "enum", "Default HTTP Version",
+    "Protocol a newly created request starts with. Auto lets the server and "
+    "client negotiate (HTTP/2 where available, falling back to HTTP/1.1). "
+    "Changing this does not alter requests that already exist.",
+    "network_performance", vayu::to_string (vayu::DEFAULT_HTTP_VERSION),
+    std::nullopt, std::nullopt, http_version_options_json (), now }));
 
     upsert_config (keywords ({ "concurrency", "parallel" }) (
     ConfigEntry{ "eventLoopMaxConcurrent",
@@ -2218,346 +2155,20 @@ void Database::seed_default_config () {
     "3600", // 1 hour
     std::nullopt, now })));
 
-    // Mid-run OAuth 2.0 refresh. A load run renews a header-placed access token
-    // before it expires, so a run longer than its token does not turn into a
-    // 401 storm. All four are read once when the run arms its watchdog, so a
-    // change applies to the next run started - no restart.
-    upsert_config (unit ("ms") (ConfigEntry{ "oauth2RefreshLeadMs",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS), "integer",
-    "OAuth 2.0 Refresh Lead Time",
-    "How far ahead of an access token's expiry a running load "
-    "test renews it. Wider than the 45-second skew the token cache already "
-    "applies, so the new credential is published while the old one is still "
-    "accepted and no request falls in the gap. Raise it for a provider that is "
-    "slow to issue tokens.",
-    "network_performance",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS),
-    "1000",    // 1 second
-    "3600000", // 1 hour
-    std::nullopt, now }));
-
-    upsert_config (unit ("ms") (ConfigEntry{ "oauth2RefreshMinIntervalMs",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS), "integer",
-    "Min OAuth 2.0 Refresh Interval",
-    "Floor on the wait between two mid-run renewals. A token "
-    "whose whole lifetime is shorter than the lead time above is always inside "
-    "its refresh window, so without this floor a run would re-acquire in a tight "
-    "loop and hammer the token endpoint. Lower it only for a provider that "
-    "issues very short-lived tokens.",
-    "network_performance",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS),
-    "100",     // 0.1 second - a floor, never 0: that is the tight loop
-    "3600000", // 1 hour
-    std::nullopt, now }));
-
-    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshRetryMs",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS), "integer",
-    "OAuth 2.0 Refresh Retry Delay",
-    "First wait after a mid-run renewal is refused, doubled "
-    "per consecutive failure up to the ceiling below. The run keeps sending the "
-    "credential it already has - a failed renewal is reported in the run's "
-    "report, never fatal - so this is about recovering from a token endpoint "
-    "that blipped.",
-    "network_performance",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS),
-    "250", "600000", std::nullopt, now })));
-
-    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshRetryMaxMs",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS), "integer",
-    "Max OAuth 2.0 Refresh Retry Delay",
-    "Ceiling on that backoff, so a token endpoint that is "
-    "down for an hour costs the run a bounded number of attempts rather than "
-    "one every few seconds.",
-    "network_performance",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS),
-    "1000", "3600000", std::nullopt, now })));
-
-    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshPollIntervalMs",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
-    "integer", "OAuth 2.0 Refresh Poll Interval",
-    "How often the renewal watchdog wakes while it waits, to "
-    "notice that the run has ended. A finished run joins that thread before it "
-    "writes its report, so this bounds how long the run's last moments take. "
-    "Lower costs a few more wakeups per second on one sleeping thread and "
-    "nothing on the request path.",
-    "network_performance",
-    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
-    "10",   // 10ms - below this the wakeups outweigh what they save
-    "5000", // 5s - past this a finished run visibly waits on the join
-    std::nullopt, now })));
-
-    // Server-vitals monitor. All three are read per run - a change applies to
-    // the next run started, no restart. The interval *bounds* (250-60000ms) are
-    // deliberately not settings: they exist to stop a cadence that measures the
-    // scraper rather than the target.
-    upsert_config (unit ("ms") (keywords ({ "prometheus" }) (
-    ConfigEntry{ "monitorIntervalMs",
-    std::to_string (vayu::core::constants::monitor::DEFAULT_INTERVAL_MS), "integer",
-    "Server Monitoring Scrape Interval",
-    "How often a load test scrapes the metrics endpoint it "
-    "was pointed at, when the run does not set its own interval. Each scrape is "
-    "one request on the run's monitor thread, so it never delays the run's own "
-    "metrics - but a cadence faster than the target's own collection interval "
-    "only re-reads the same numbers. Raise it for an endpoint that is expensive "
-    "to render.",
-    "observability",
-    std::to_string (vayu::core::constants::monitor::DEFAULT_INTERVAL_MS),
-    std::to_string (vayu::core::constants::monitor::MIN_INTERVAL_MS),
-    std::to_string (vayu::core::constants::monitor::MAX_INTERVAL_MS), std::nullopt, now })));
-
-    upsert_config (keywords ({ "prometheus" }) (ConfigEntry{ "monitorMaxSeries",
-    std::to_string (vayu::core::constants::monitor::MAX_SERIES), "integer",
-    "Server Monitoring Metric Limit",
-    "How many metric names one run may chart from its monitored endpoint. Each "
-    "is a line on a single overlay and a name matched against every line of the "
-    "exposition body, so the ceiling is about a readable chart rather than a "
-    "hard cost. The chart has four distinct colours and repeats them past that.",
-    "observability", std::to_string (vayu::core::constants::monitor::MAX_SERIES),
-    "1", "64", std::nullopt, now }));
-
-    upsert_config (unit ("ms") (keywords ({ "prometheus" }) (
-    ConfigEntry{ "monitorScrapeTimeoutMs",
-    std::to_string (vayu::core::constants::monitor::DEFAULT_SCRAPE_TIMEOUT_MS),
-    "integer", "Server Monitoring Scrape Timeout",
-    "How long one scrape of the metrics endpoint may take "
-    "before it counts as a gap in the series. 0 derives the budget from the "
-    "scrape interval - three quarters of it - which is what most endpoints "
-    "want; set it explicitly for an exposition slow enough to fail every scrape "
-    "at that budget, where the only other way out is a slower cadence that also "
-    "thins the data. A value longer than the interval a run scrapes at is "
-    "shortened to it, because a scrape that outlives its own cadence puts the "
-    "loop behind itself.",
-    "observability", std::to_string (vayu::core::constants::monitor::DEFAULT_SCRAPE_TIMEOUT_MS),
-    "0", std::to_string (vayu::core::constants::monitor::MAX_INTERVAL_MS),
-    std::nullopt, now })));
-
     // =========================================================================
-    // SCRIPTING ENVIRONMENT CONFIGURATION
-    // Configuration for the QuickJS sandbox execution, limits, and debugging
+    // SERVICES (services)
+    // The long-lived surfaces: streaming requests, the webhook inboxes and mock
+    // servers the Dock calls Services, and the OAuth issuers behind them.
+    // Before #586 these were filed under Observability, which is the drawer's
+    // word for none of them - a user managing a service found no matching word
+    // in the tree.
     // =========================================================================
 
-    upsert_config (unit ("ms") (keywords ({ "runaway" }) (ConfigEntry{ "scriptTimeout",
-    std::to_string (vayu::core::constants::script_engine::TIMEOUT_MS), "integer", "Script Execution Timeout",
-    "How long a pre- or post-request script may run. A script "
-    "that exceeds this is aborted and reported as an error, so an infinite loop "
-    "cannot hang the engine. 0 disables the limit, which is not recommended.",
-    "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::TIMEOUT_MS),
-    "0", "60000", std::nullopt, now })));
-
-    upsert_config (keywords ({ "debug", "print" }) (ConfigEntry{ "scriptEnableConsole",
-    vayu::core::constants::script_engine::ENABLE_CONSOLE ? "true" : "false",
-    "boolean", "Enable Script Console",
-    "Makes console.log() available inside scripts, with its output shown in the "
-    "response viewer. Turn it off during a load test, where the writes cost "
-    "throughput for output nobody reads.",
-    "scripting_sandbox", vayu::core::constants::script_engine::ENABLE_CONSOLE ? "true" : "false",
-    std::nullopt, std::nullopt, std::nullopt, now }));
-
-    upsert_config (unit ("bytes") (keywords ({ "ram", "oom" }) (
-    ConfigEntry{ "scriptMemoryLimit",
-    std::to_string (vayu::core::constants::script_engine::MEMORY_LIMIT), "integer", "Script Memory Limit",
-    "Largest heap one script execution may allocate before it is aborted. Raise "
-    "it only for a script that processes very large data structures.",
-    "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::MEMORY_LIMIT),
-    "1048576",   // 1MB
-    "268435456", // 256MB
-    std::nullopt, now })));
-
-    upsert_config (unit ("bytes") (keywords ({ "recursion" }) (
-    ConfigEntry{ "scriptStackSize",
-    std::to_string (vayu::core::constants::script_engine::STACK_SIZE), "integer", "Script Stack Size",
-    "Depth of the call stack one script execution may use. Raise it only for a "
-    "script that recurses deeply enough to overflow.",
-    "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::STACK_SIZE),
-    "65536",   // 64KB
-    "1048576", // 1MB
-    std::nullopt, now })));
-
-    // =========================================================================
-    // OBSERVABILITY CONFIGURATION
-    // Monitoring and live metrics: what a run watches, and how the dashboard's
-    // live charts are fed. What a run *stores* is `data_retention` below - the
-    // two were one category holding 24 of 48 entries until #586, and "how much
-    // of a response body is kept" was never an observability question.
-    // =========================================================================
-
-    upsert_config (unit ("ms") (keywords ({ "refresh rate", "sse" }) (
-    ConfigEntry{ "liveTickIntervalMs",
-    std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
-    "integer", "Live Metrics Tick Interval",
-    "How often the engine emits a live-metrics tick into the "
-    "in-memory replay topic during a run. A lower value gives smoother live "
-    "charts for slightly more CPU; the 1-second ceiling exists because slower "
-    "ticks defeat live smoothness. The historical 1 Hz database sampling is "
-    "unaffected.",
-    "observability", std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
-    "10", "1000", std::nullopt, now })));
-
-    upsert_config (unit ("ms") (keywords ({ "time range" }) (
-    ConfigEntry{ "liveReplayWindowMs",
-    std::to_string (vayu::core::constants::server::DEFAULT_LIVE_REPLAY_WINDOW_MS),
-    "integer", "Live Chart Window",
-    "How much recent live-metrics history to keep: the span the dashboard's live "
-    "charts show, and the span the engine holds in memory per run so the "
-    "dashboard can rebuild those charts when it attaches - or re-attaches - "
-    "mid-run. One setting drives both, so they cannot disagree. Its editor is "
-    "Settings > Dashboard > Chart window, which is where the effect is "
-    "visible; this list deliberately does not offer a second one. Expressed "
-    "as elapsed time "
-    "rather than a tick count, so it survives a change to the tick interval. 0 "
-    "means the full run (no time limit). Live Metrics Tick Ceiling is the "
-    "memory backstop "
-    "either way, so a fast tick interval reaches that ceiling before a long "
-    "window does.",
-    "observability",
-    std::to_string (vayu::core::constants::server::DEFAULT_LIVE_REPLAY_WINDOW_MS),
-    "0", "3600000", std::nullopt, now })));
-
-    upsert_config (ConfigEntry{ "liveMaxRetainedTicks",
-    std::to_string (vayu::core::constants::server::DEFAULT_MAX_LIVE_TICKS),
-    "integer", "Live Metrics Tick Ceiling",
-    "Hard ceiling on live-metrics data points held in memory per run, on both "
-    "sides - the engine's replay ring and the dashboard's chart history. It is "
-    "a memory bound rather than a rendering one, since the charts bucket points "
-    "before plotting, and it binds only when the chart window divided by the "
-    "tick interval exceeds it - a long window at a fast tick interval, which "
-    "stock settings never reach. Raise it if a long window is being cut short; "
-    "each point costs roughly 1 KB.",
-    "observability",
-    std::to_string (vayu::core::constants::server::DEFAULT_MAX_LIVE_TICKS),
-    "1000", "500000", std::nullopt, now });
-
-    upsert_config (unit ("ms") (ConfigEntry{ "liveRetentionMs",
-    "60000",
-    "integer", "Live Metrics Retention",
-    "How long a finished run's in-memory live-metrics topic "
-    "is kept so the dashboard can still attach and replay it. After this window "
-    "the run is evicted and the dashboard falls back to the stored report. 0 "
-    "disables retention, so that fallback is immediate.",
-    "observability", "60000",
-    "0", "600000", std::nullopt, now }));
-
-    // =========================================================================
-    // DATA & RETENTION CONFIGURATION
-    // What a run stores and for how long: capture and truncation budgets, and
-    // the two retention limits. The words a user arrives with here are "why is
-    // my response body cut off" and "keep fewer runs", neither of which reads
-    // as observability - which is why these left it (#586). The app's General >
-    // Data management block, which shows and clears stored runs, points here.
-    // =========================================================================
-
-    upsert_config (ConfigEntry{ "maxStoredErrors",
-    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS),
-    "integer", "Stored Error Records Per Run",
-    "How many individual error records a run keeps for its report. The error "
-    "total, the failed-request count, the error rate and the status-code "
-    "breakdown are always exact - this bounds only the per-error detail behind "
-    "the report's 'By Error Type' breakdown, which on a run with more errors "
-    "than this covers the first N and will not sum to the total beside it. 0 "
-    "means unlimited, which against a fully refusing target grows for the life "
-    "of the run.",
-    "data_retention",
-    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS),
-    "0", "10000000", std::nullopt, now });
-
-    upsert_config (unit ("bytes") (ConfigEntry{ "maxTraceBodyBytes",
-    std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES), "integer",
-    "Max Stored Trace Body Size",
-    "Largest request or response body kept in a design run's stored "
-    "trace. A larger body is truncated in the database - the response viewer "
-    "says so, and re-sending fetches the full body - so one huge response does "
-    "not bloat storage forever.",
-    "data_retention", std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES),
-    "1024",       // 1KB
-    "104857600",  // 100MB
-    std::nullopt, now }));
-
-    upsert_config (unit ("bytes") (ConfigEntry{ "maxSampleBodyBytes",
-    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES),
-    "integer", "Max Captured Sample Body",
-    "Largest response body kept for a single captured load-run "
-    "sample. Deliberately far smaller than the design-run trace limit, because "
-    "a load run captures tens of exchanges nobody asked for individually. A "
-    "larger body is stored truncated and marked as such.",
-    "data_retention",
-    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES),
-    "0",         // 0 disables body capture while keeping headers and metadata
-    "104857600", // 100MB
-    std::nullopt, now }));
-
-    upsert_config (unit ("bytes") (ConfigEntry{ "maxSampleBytes",
-    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES),
-    "integer", "Load-Run Capture Budget",
-    "How much captured response-body data one load run may store. Once spent, "
-    "samples keep their headers and metadata and only their bodies are "
-    "dropped, and the report says how many. Captured data is stored verbatim, "
-    "can contain credentials, and is deleted with the run.",
-    "data_retention",
-    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES),
-    "0",          // 0 disables body capture while keeping headers and metadata
-    "1073741824", // 1GB
-    std::nullopt, now }));
-
-    upsert_config (keywords ({ "ttfb", "timings" }) (ConfigEntry{ "phaseHistograms",
-    vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",
-    "boolean", "Per-Phase Latency Histograms",
-    "Records DNS, connect, TLS, first-byte and download times for every "
-    "load-test completion, so the report gives each phase real percentiles "
-    "instead of an average over the few exchanges it stores traces for. This is "
-    "what answers whether a slow p99 came from the server or from connection "
-    "setup. It costs five histogram writes per completion; turn it off only if "
-    "a run at your throughput ceiling measurably suffers.",
-    "data_retention",
-    vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",
-    std::nullopt, std::nullopt, std::nullopt, now }));
-
-    upsert_config (unit ("bytes") (ConfigEntry{ "maxResponseBodyBytes",
-    std::to_string (vayu::core::constants::event_loop::MAX_RESPONSE_BODY_BYTES),
-    "integer", "Max Load-Test Response Body",
-    "Largest response body a single load-test request will read into "
-    "memory. A larger response fails that request with an error instead of "
-    "being buffered, so load testing a big download or a streaming endpoint "
-    "cannot exhaust memory - every in-flight request holds its own body. "
-    "Design-mode sends are not affected.",
-    "data_retention", std::to_string (vayu::core::constants::event_loop::MAX_RESPONSE_BODY_BYTES),
-    "1024",       // 1KB
-    "1073741824", // 1GB
-    std::nullopt, now }));
-
-    upsert_config (keywords ({ "cleanup" }) (ConfigEntry{ "maxRunsRetained",
-    std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED), "integer",
-    "Max Runs Retained",
-    "Keep at most this many most-recent runs; older runs, with their metrics "
-    "and results, are pruned at startup and after each run finishes. A higher "
-    "value - or 0 for unlimited - keeps more history but grows the database "
-    "file on disk and slows down loading the run history. In-progress runs are "
-    "never pruned.",
-    "data_retention", std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED),
-    "0", "100000", std::nullopt, now }));
-
-    upsert_config (unit ("days") (keywords ({ "cleanup" }) (
-    ConfigEntry{ "runRetentionDays",
-    std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS), "integer",
-    "Run Retention",
-    "Delete runs older than this age, with their metrics and results, at "
-    "startup and after each run finishes. A higher value - or 0 to keep runs "
-    "forever - retains more history at the cost of a larger database file on "
-    "disk. In-progress runs are never pruned.",
-    "data_retention", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
-    "0", "3650", std::nullopt, now })));
-
-    // =========================================================================
-    // SERVICES CONFIGURATION
-    // The long-lived surfaces: streaming requests, and the webhook inboxes,
-    // mock servers and OAuth issuers the Dock calls Services. Before #586 these
-    // were filed under Observability, which is the drawer's word for none of
-    // them - a user managing a service found no matching word in the tree.
-    // =========================================================================
-
-    // SSE requests (issue #573). All six are read once when a stream starts, so
-    // a change applies to the next stream - no restart - and one run's events
-    // are all bounded by a single rule rather than by whatever the setting
-    // happened to be at each arrival.
+    // SSE requests (issue #573). All six - these five and `sseMaxStoredEvents`,
+    // which #703 moved to Data & retention as the per-run storage budget it is -
+    // are read once when a stream starts, so a change applies to the next
+    // stream - no restart - and one run's events are all bounded by a single
+    // rule rather than by whatever the setting happened to be at each arrival.
     upsert_config (keywords ({ "eventsource", "server-sent", "event stream" }) (
     ConfigEntry{ "sseMaxRetainedEvents",
     std::to_string (vayu::core::constants::sse::MAX_RETAINED_EVENTS), "integer",
@@ -2585,18 +2196,6 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::sse::MIN_EVENT_BYTES),
     std::to_string (vayu::core::constants::sse::EVENT_BYTES_CEILING),
     std::nullopt, now })));
-
-    upsert_config (keywords ({ "eventsource", "server-sent", "event stream" }) (
-    ConfigEntry{ "sseMaxStoredEvents",
-    std::to_string (vayu::core::constants::sse::MAX_STORED_EVENTS), "integer",
-    "Stream Events Stored Per Run",
-    "How many events a finished streaming run keeps on disk, so reopening it "
-    "from History shows the timeline again. A run that received more says so - "
-    "the stored list is marked truncated and carries the true total. 0 keeps "
-    "the count and no events.",
-    "services", std::to_string (vayu::core::constants::sse::MAX_STORED_EVENTS),
-    "0", std::to_string (vayu::core::constants::sse::STORED_EVENTS_CEILING),
-    std::nullopt, now }));
 
     upsert_config (unit ("ms") (
     keywords ({ "eventsource", "server-sent", "event stream" }) (
@@ -2679,6 +2278,421 @@ void Database::seed_default_config () {
     std::to_string (vayu::core::constants::inbox::MIN_LIVE_POLL_INTERVAL_MS),
     std::to_string (vayu::core::constants::inbox::MAX_LIVE_POLL_INTERVAL_MS), std::nullopt, now })));
 
+    // Mid-run OAuth 2.0 refresh. A load run renews a header-placed access token
+    // before it expires, so a run longer than its token does not turn into a
+    // 401 storm. All five are read once when the run arms its watchdog, so a
+    // change applies to the next run started - no restart. They sat in Network
+    // & connectivity until #703, where they were five of its eight entries; a
+    // user tuning token renewal arrives at Services, which is where the Dock
+    // files the OAuth issuer itself.
+    upsert_config (unit ("ms") (ConfigEntry{ "oauth2RefreshLeadMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS), "integer",
+    "OAuth 2.0 Refresh Lead Time",
+    "How far ahead of an access token's expiry a running load "
+    "test renews it. Wider than the 45-second skew the token cache already "
+    "applies, so the new credential is published while the old one is still "
+    "accepted and no request falls in the gap. Raise it for a provider that is "
+    "slow to issue tokens.",
+    "services",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_LEAD_MS),
+    "1000",    // 1 second
+    "3600000", // 1 hour
+    std::nullopt, now }));
+
+    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshMinIntervalMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS), "integer",
+    "Min OAuth 2.0 Refresh Interval",
+    "Floor on the wait between two mid-run renewals. A token "
+    "whose whole lifetime is shorter than the lead time above is always inside "
+    "its refresh window, so without this floor a run would re-acquire in a tight "
+    "loop and hammer the token endpoint. Lower it only for a provider that "
+    "issues very short-lived tokens.",
+    "services",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_MIN_INTERVAL_MS),
+    "100",     // 0.1 second - a floor, never 0: that is the tight loop
+    "3600000", // 1 hour
+    std::nullopt, now })));
+
+    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshRetryMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS), "integer",
+    "OAuth 2.0 Refresh Retry Delay",
+    "First wait after a mid-run renewal is refused, doubled "
+    "per consecutive failure up to the ceiling below. The run keeps sending the "
+    "credential it already has - a failed renewal is reported in the run's "
+    "report, never fatal - so this is about recovering from a token endpoint "
+    "that blipped.",
+    "services",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MS),
+    "250", "600000", std::nullopt, now })));
+
+    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshRetryMaxMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS), "integer",
+    "Max OAuth 2.0 Refresh Retry Delay",
+    "Ceiling on that backoff, so a token endpoint that is "
+    "down for an hour costs the run a bounded number of attempts rather than "
+    "one every few seconds.",
+    "services",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_RETRY_MAX_MS),
+    "1000", "3600000", std::nullopt, now })));
+
+    upsert_config (advanced (unit ("ms") (ConfigEntry{ "oauth2RefreshPollIntervalMs",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
+    "integer", "OAuth 2.0 Refresh Poll Interval",
+    "How often the renewal watchdog wakes while it waits, to "
+    "notice that the run has ended. A finished run joins that thread before it "
+    "writes its report, so this bounds how long the run's last moments take. "
+    "Lower costs a few more wakeups per second on one sleeping thread and "
+    "nothing on the request path.",
+    "services",
+    std::to_string (vayu::core::constants::server::OAUTH2_REFRESH_POLL_INTERVAL_MS),
+    "10",   // 10ms - below this the wakeups outweigh what they save
+    "5000", // 5s - past this a finished run visibly waits on the join
+    std::nullopt, now })));
+
+    // =========================================================================
+    // OBSERVABILITY (observability)
+    // What a run measures and what the dashboard's live charts are fed: the
+    // server-vitals monitor, the live-metrics topic, and the per-phase timing
+    // histograms. What a run *stores* is Data & retention below - the two were
+    // one category holding 24 of 48 entries until #586.
+    // =========================================================================
+
+    // Server-vitals monitor. All three are read per run - a change applies to
+    // the next run started, no restart. The interval *bounds* (250-60000ms) are
+    // deliberately not settings: they exist to stop a cadence that measures the
+    // scraper rather than the target.
+    upsert_config (unit ("ms") (keywords ({ "prometheus" }) (
+    ConfigEntry{ "monitorIntervalMs",
+    std::to_string (vayu::core::constants::monitor::DEFAULT_INTERVAL_MS), "integer",
+    "Server Monitoring Scrape Interval",
+    "How often a load test scrapes the metrics endpoint it "
+    "was pointed at, when the run does not set its own interval. Each scrape is "
+    "one request on the run's monitor thread, so it never delays the run's own "
+    "metrics - but a cadence faster than the target's own collection interval "
+    "only re-reads the same numbers. Raise it for an endpoint that is expensive "
+    "to render.",
+    "observability",
+    std::to_string (vayu::core::constants::monitor::DEFAULT_INTERVAL_MS),
+    std::to_string (vayu::core::constants::monitor::MIN_INTERVAL_MS),
+    std::to_string (vayu::core::constants::monitor::MAX_INTERVAL_MS), std::nullopt, now })));
+
+    upsert_config (keywords ({ "prometheus" }) (ConfigEntry{ "monitorMaxSeries",
+    std::to_string (vayu::core::constants::monitor::MAX_SERIES), "integer",
+    "Server Monitoring Metric Limit",
+    "How many metric names one run may chart from its monitored endpoint. Each "
+    "is a line on a single overlay and a name matched against every line of the "
+    "exposition body, so the ceiling is about a readable chart rather than a "
+    "hard cost. The chart has four distinct colours and repeats them past that.",
+    "observability", std::to_string (vayu::core::constants::monitor::MAX_SERIES),
+    "1", "64", std::nullopt, now }));
+
+    upsert_config (advanced (unit ("ms") (keywords ({ "prometheus" }) (
+    ConfigEntry{ "monitorScrapeTimeoutMs",
+    std::to_string (vayu::core::constants::monitor::DEFAULT_SCRAPE_TIMEOUT_MS),
+    "integer", "Server Monitoring Scrape Timeout",
+    "How long one scrape of the metrics endpoint may take "
+    "before it counts as a gap in the series. 0 derives the budget from the "
+    "scrape interval - three quarters of it - which is what most endpoints "
+    "want; set it explicitly for an exposition slow enough to fail every scrape "
+    "at that budget, where the only other way out is a slower cadence that also "
+    "thins the data. A value longer than the interval a run scrapes at is "
+    "shortened to it, because a scrape that outlives its own cadence puts the "
+    "loop behind itself.",
+    "observability", std::to_string (vayu::core::constants::monitor::DEFAULT_SCRAPE_TIMEOUT_MS),
+    "0", std::to_string (vayu::core::constants::monitor::MAX_INTERVAL_MS),
+    std::nullopt, now }))));
+
+    upsert_config (unit ("ms") (keywords ({ "refresh rate", "sse" }) (
+    ConfigEntry{ "liveTickIntervalMs",
+    std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
+    "integer", "Live Metrics Tick Interval",
+    "How often the engine emits a live-metrics tick into the "
+    "in-memory replay topic during a run. A lower value gives smoother live "
+    "charts for slightly more CPU; the 1-second ceiling exists because slower "
+    "ticks defeat live smoothness. The historical 1 Hz database sampling is "
+    "unaffected.",
+    "observability", std::to_string (vayu::core::constants::server::STATS_INTERVAL_MS),
+    "10", "1000", std::nullopt, now })));
+
+    upsert_config (unit ("ms") (keywords ({ "time range" }) (
+    ConfigEntry{ "liveReplayWindowMs",
+    std::to_string (vayu::core::constants::server::DEFAULT_LIVE_REPLAY_WINDOW_MS),
+    "integer", "Live Chart Window",
+    "How much recent live-metrics history to keep: the span the dashboard's live "
+    "charts show, and the span the engine holds in memory per run so the "
+    "dashboard can rebuild those charts when it attaches - or re-attaches - "
+    "mid-run. One setting drives both, so they cannot disagree. Its editor is "
+    "Settings > Dashboard > Chart window, which is where the effect is "
+    "visible; this list deliberately does not offer a second one. Expressed "
+    "as elapsed time "
+    "rather than a tick count, so it survives a change to the tick interval. 0 "
+    "means the full run (no time limit). Live Metrics Tick Ceiling is the "
+    "memory backstop "
+    "either way, so a fast tick interval reaches that ceiling before a long "
+    "window does.",
+    "observability",
+    std::to_string (vayu::core::constants::server::DEFAULT_LIVE_REPLAY_WINDOW_MS),
+    "0", "3600000", std::nullopt, now })));
+
+    upsert_config (advanced (ConfigEntry{ "liveMaxRetainedTicks",
+    std::to_string (vayu::core::constants::server::DEFAULT_MAX_LIVE_TICKS),
+    "integer", "Live Metrics Tick Ceiling",
+    "Hard ceiling on live-metrics data points held in memory per run, on both "
+    "sides - the engine's replay ring and the dashboard's chart history. It is "
+    "a memory bound rather than a rendering one, since the charts bucket points "
+    "before plotting, and it binds only when the chart window divided by the "
+    "tick interval exceeds it - a long window at a fast tick interval, which "
+    "stock settings never reach. Raise it if a long window is being cut short; "
+    "each point costs roughly 1 KB.",
+    "observability",
+    std::to_string (vayu::core::constants::server::DEFAULT_MAX_LIVE_TICKS),
+    "1000", "500000", std::nullopt, now }));
+
+    upsert_config (unit ("ms") (ConfigEntry{ "liveRetentionMs",
+    "60000",
+    "integer", "Live Metrics Retention",
+    "How long a finished run's in-memory live-metrics topic "
+    "is kept so the dashboard can still attach and replay it. After this window "
+    "the run is evicted and the dashboard falls back to the stored report. 0 "
+    "disables retention, so that fallback is immediate.",
+    "observability", "60000",
+    "0", "600000", std::nullopt, now }));
+
+    upsert_config (keywords ({ "ttfb", "timings" }) (ConfigEntry{ "phaseHistograms",
+    vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",
+    "boolean", "Per-Phase Latency Histograms",
+    "Records DNS, connect, TLS, first-byte and download times for every "
+    "load-test completion, so the report gives each phase real percentiles "
+    "instead of an average over the few exchanges it stores traces for. This is "
+    "what answers whether a slow p99 came from the server or from connection "
+    "setup. It costs five histogram writes per completion; turn it off only if "
+    "a run at your throughput ceiling measurably suffers.",
+    "observability",
+    vayu::core::constants::metrics_collector::DEFAULT_PHASE_HISTOGRAMS ? "true" : "false",
+    std::nullopt, std::nullopt, std::nullopt, now }));
+
+    // =========================================================================
+    // DATA & RETENTION (data_retention)
+    // Every per-run storage budget, in one place: how much of a body is kept,
+    // how many records are kept, and how long a finished run survives. The
+    // words a user arrives with here are "why is my response body cut off" and
+    // "keep fewer runs". #703 completed the shelf - the per-step and the
+    // per-stream retention budgets were filed under Core and Services.
+    // =========================================================================
+
+    upsert_config (ConfigEntry{ "maxStoredErrors",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS),
+    "integer", "Stored Error Records Per Run",
+    "How many individual error records a run keeps for its report. The error "
+    "total, the failed-request count, the error rate and the status-code "
+    "breakdown are always exact - this bounds only the per-error detail behind "
+    "the report's 'By Error Type' breakdown, which on a run with more errors "
+    "than this covers the first N and will not sum to the total beside it. 0 "
+    "means unlimited, which against a fully refusing target grows for the life "
+    "of the run.",
+    "data_retention",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_ERRORS),
+    "0", "10000000", std::nullopt, now });
+
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxTraceBodyBytes",
+    std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES), "integer",
+    "Max Stored Trace Body Size",
+    "Largest request or response body kept in a design run's stored "
+    "trace. A larger body is truncated in the database - the response viewer "
+    "says so, and re-sending fetches the full body - so one huge response does "
+    "not bloat storage forever.",
+    "data_retention", std::to_string (vayu::core::constants::json::MAX_TRACE_BODY_BYTES),
+    "1024",       // 1KB
+    "104857600",  // 100MB
+    std::nullopt, now }));
+
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxSampleBodyBytes",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES),
+    "integer", "Max Captured Sample Body",
+    "Largest response body kept for a single captured load-run "
+    "sample. Deliberately far smaller than the design-run trace limit, because "
+    "a load run captures tens of exchanges nobody asked for individually. A "
+    "larger body is stored truncated and marked as such.",
+    "data_retention",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BODY_BYTES),
+    "0",         // 0 disables body capture while keeping headers and metadata
+    "104857600", // 100MB
+    std::nullopt, now }));
+
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxSampleBytes",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES),
+    "integer", "Load-Run Capture Budget",
+    "How much captured response-body data one load run may store. Once spent, "
+    "samples keep their headers and metadata and only their bodies are "
+    "dropped, and the report says how many. Captured data is stored verbatim, "
+    "can contain credentials, and is deleted with the run.",
+    "data_retention",
+    std::to_string (vayu::core::constants::metrics_collector::DEFAULT_MAX_SAMPLE_BYTES),
+    "0",          // 0 disables body capture while keeping headers and metadata
+    "1073741824", // 1GB
+    std::nullopt, now }));
+
+    upsert_config (ConfigEntry{ "maxScenarioStoredSteps",
+    std::to_string (vayu::core::constants::scenario::MAX_STORED_STEPS), "integer",
+    "Max Stored Scenario Steps",
+    "How many per-step results one collection run keeps, which bounds what a "
+    "long run costs the dashboard to load. Steps that failed, errored or were "
+    "skipped are kept first and successes fill the rest, so raising this buys "
+    "more successful steps to look at and never a failure that was hidden - "
+    "what was thinned is reported in the run summary. 0 stores every step.",
+    "data_retention", std::to_string (vayu::core::constants::scenario::MAX_STORED_STEPS),
+    "0", "1000000", std::nullopt, now });
+
+    upsert_config (keywords ({ "eventsource", "server-sent", "event stream" }) (
+    ConfigEntry{ "sseMaxStoredEvents",
+    std::to_string (vayu::core::constants::sse::MAX_STORED_EVENTS), "integer",
+    "Stream Events Stored Per Run",
+    "How many events a finished streaming run keeps on disk, so reopening it "
+    "from History shows the timeline again. A run that received more says so - "
+    "the stored list is marked truncated and carries the true total. 0 keeps "
+    "the count and no events.",
+    "data_retention", std::to_string (vayu::core::constants::sse::MAX_STORED_EVENTS),
+    "0", std::to_string (vayu::core::constants::sse::STORED_EVENTS_CEILING),
+    std::nullopt, now }));
+
+    upsert_config (keywords ({ "cleanup" }) (ConfigEntry{ "maxRunsRetained",
+    std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED), "integer",
+    "Max Runs Retained",
+    "Keep at most this many most-recent runs; older runs, with their metrics "
+    "and results, are pruned at startup and after each run finishes. A higher "
+    "value - or 0 for unlimited - keeps more history but grows the database "
+    "file on disk and slows down loading the run history. In-progress runs are "
+    "never pruned.",
+    "data_retention", std::to_string (vayu::core::constants::database::MAX_RUNS_RETAINED),
+    "0", "100000", std::nullopt, now }));
+
+    upsert_config (unit ("days") (keywords ({ "cleanup" }) (
+    ConfigEntry{ "runRetentionDays",
+    std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS), "integer",
+    "Run Retention",
+    "Delete runs older than this age, with their metrics and results, at "
+    "startup and after each run finishes. A higher value - or 0 to keep runs "
+    "forever - retains more history at the cost of a larger database file on "
+    "disk. In-progress runs are never pruned.",
+    "data_retention", std::to_string (vayu::core::constants::database::RUN_RETENTION_DAYS),
+    "0", "3650", std::nullopt, now })));
+
+    // =========================================================================
+    // LIMITS (limits) - added by #703
+    // The sizes and counts a run or a collection may not exceed. Every entry
+    // here is arrived at from a rejection message that names the setting, which
+    // is why they deserve one shelf instead of hiding among infrastructure -
+    // and why none of them truncates: each refuses the oversized input and says
+    // which knob refused it.
+    // =========================================================================
+
+    upsert_config (ConfigEntry{ "maxScenarioSteps",
+    std::to_string (vayu::core::constants::scenario::MAX_STEPS), "integer",
+    "Max Scenario Steps",
+    "Largest number of requests one collection run may resolve to. The whole "
+    "sequence is composed before the first send and held in memory for the "
+    "run, and a load-mode scenario allocates a latency histogram per step, so "
+    "this bounds memory rather than expressing a preference. A collection that "
+    "resolves to more steps is rejected outright, never silently truncated.",
+    "limits", std::to_string (vayu::core::constants::scenario::MAX_STEPS),
+    "1", "10000", std::nullopt, now });
+
+    upsert_config (ConfigEntry{ "maxScenarioDataRows",
+    std::to_string (vayu::core::constants::scenario::MAX_DATA_ROWS), "integer",
+    "Max Scenario Data Rows",
+    "Largest data set one collection run may carry. The app parses the CSV or "
+    "JSON file and sends the rows on the run payload - the engine never reads "
+    "a file from disk - so this bounds how big that payload may get. A larger "
+    "data set is rejected rather than truncated.",
+    "limits", std::to_string (vayu::core::constants::scenario::MAX_DATA_ROWS),
+    "1", "1000000", std::nullopt, now });
+
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxScenarioDataBytes",
+    std::to_string (vayu::core::constants::scenario::MAX_DATA_BYTES), "integer",
+    "Max Scenario Data Size",
+    "Largest data set one collection run may carry, measured over its JSON. "
+    "The row limit alone does not bound the payload - one row is free to hold a "
+    "megabyte in a single cell - and the HTTP body cap above this would drop "
+    "the connection instead of explaining itself. A larger data set is rejected "
+    "with a message naming this setting.",
+    "limits", std::to_string (vayu::core::constants::scenario::MAX_DATA_BYTES),
+    "1024", "104857600", std::nullopt, now }));
+
+    upsert_config (unit ("bytes") (keywords ({ "swagger" }) (
+    ConfigEntry{ "maxSpecDocumentBytes",
+    std::to_string (vayu::core::constants::spec_document::MAX_BYTES), "integer",
+    "Max OpenAPI Document Size",
+    "Largest OpenAPI document one collection may bind. The document is stored "
+    "verbatim and parsed back by every feature that reads it, so this bounds "
+    "both the row and that parse. A larger document is rejected with a message "
+    "naming this setting, never stored truncated.",
+    "limits", std::to_string (vayu::core::constants::spec_document::MAX_BYTES),
+    "1024", "104857600", std::nullopt, now })));
+
+    upsert_config (unit ("bytes") (ConfigEntry{ "maxResponseBodyBytes",
+    std::to_string (vayu::core::constants::event_loop::MAX_RESPONSE_BODY_BYTES),
+    "integer", "Max Load-Test Response Body",
+    "Largest response body a single load-test request will read into "
+    "memory. A larger response fails that request with an error instead of "
+    "being buffered, so load testing a big download or a streaming endpoint "
+    "cannot exhaust memory - every in-flight request holds its own body. "
+    "Design-mode sends are not affected.",
+    "limits", std::to_string (vayu::core::constants::event_loop::MAX_RESPONSE_BODY_BYTES),
+    "1024",       // 1KB
+    "1073741824", // 1GB
+    std::nullopt, now }));
+
+    upsert_config (advanced (keywords ({ "infinite loop" }) (
+    ConfigEntry{ "maxStepsPerIteration", "0", "integer", "Max Steps Per Iteration",
+    "How many requests one iteration of a collection run may send before it is "
+    "stopped. It exists because a script can redirect the sequence with "
+    "pm.execution.setNextRequest, and two steps pointing at each other would "
+    "otherwise run forever. 0 derives the limit from the collection - ten "
+    "times its request count, never fewer than 100.",
+    "limits", "0", "0", "1000000", std::nullopt, now })));
+
+    // =========================================================================
+    // SCRIPTING ENVIRONMENT (scripting_sandbox)
+    // The QuickJS sandbox a pre- or post-request script runs in: its deadline,
+    // its memory and stack, and whether console output is collected.
+    // =========================================================================
+
+    upsert_config (unit ("ms") (keywords ({ "runaway" }) (ConfigEntry{ "scriptTimeout",
+    std::to_string (vayu::core::constants::script_engine::TIMEOUT_MS), "integer", "Script Execution Timeout",
+    "How long a pre- or post-request script may run. A script "
+    "that exceeds this is aborted and reported as an error, so an infinite loop "
+    "cannot hang the engine. 0 disables the limit, which is not recommended.",
+    "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::TIMEOUT_MS),
+    "0", "60000", std::nullopt, now })));
+
+    upsert_config (keywords ({ "debug", "print" }) (ConfigEntry{ "scriptEnableConsole",
+    vayu::core::constants::script_engine::ENABLE_CONSOLE ? "true" : "false",
+    "boolean", "Enable Script Console",
+    "Makes console.log() available inside scripts, with its output shown in the "
+    "response viewer. Turn it off during a load test, where the writes cost "
+    "throughput for output nobody reads.",
+    "scripting_sandbox", vayu::core::constants::script_engine::ENABLE_CONSOLE ? "true" : "false",
+    std::nullopt, std::nullopt, std::nullopt, now }));
+
+    upsert_config (unit ("bytes") (keywords ({ "ram", "oom" }) (
+    ConfigEntry{ "scriptMemoryLimit",
+    std::to_string (vayu::core::constants::script_engine::MEMORY_LIMIT), "integer", "Script Memory Limit",
+    "Largest heap one script execution may allocate before it is aborted. Raise "
+    "it only for a script that processes very large data structures.",
+    "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::MEMORY_LIMIT),
+    "1048576",   // 1MB
+    "268435456", // 256MB
+    std::nullopt, now })));
+
+    upsert_config (advanced (unit ("bytes") (keywords ({ "recursion" }) (
+    ConfigEntry{ "scriptStackSize",
+    std::to_string (vayu::core::constants::script_engine::STACK_SIZE), "integer", "Script Stack Size",
+    "Depth of the call stack one script execution may use. Raise it only for a "
+    "script that recurses deeply enough to overflow.",
+    "scripting_sandbox", std::to_string (vayu::core::constants::script_engine::STACK_SIZE),
+    "65536",   // 64KB
+    "1048576", // 1MB
+    std::nullopt, now }))));
     if (existing.empty ()) {
         vayu::utils::log_info ("Seeded default configuration values");
     } else {

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -15,6 +15,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -338,10 +339,14 @@ TEST_F (ConfigRouteTest, NoSeededLabelSpellsOutMaxMinOrCarriesAUnit) {
 // than by count - an entry added to or dropped from the group has to say so
 // here.
 TEST_F (ConfigRouteTest, AdvancedFlagsExactlyTheRecordedInternals) {
+    // #703 added the five below the original six, by a heuristic that is
+    // citable in review: if an entry's own description has to say "only if" or
+    // "only for", the entry has declared itself advanced.
     const std::set<std::string> expected = { "dbBusyTimeout",
         "oauth2RefreshRetryMs", "oauth2RefreshRetryMaxMs",
         "oauth2RefreshPollIntervalMs", "inboxLivePollIntervalMs",
-        "sseIdleTimeoutMs" };
+        "sseIdleTimeoutMs", "oauth2RefreshMinIntervalMs", "maxStepsPerIteration",
+        "monitorScrapeTimeoutMs", "liveMaxRetainedTicks", "scriptStackSize" };
 
     auto entries = db_->get_all_config_entries ();
     ASSERT_FALSE (entries.empty ()) << "catalogue empty - nothing was scanned";
@@ -583,7 +588,8 @@ TEST_F (ConfigRouteTest, EverySeededEntrySitsInADeclaredCategory) {
     // Kept in step with app/src/types/domain.ts (EngineSettingsCategory) and
     // app/src/modules/settings/engine-categories.ts.
     const std::set<std::string> declared = { "general_engine", "network_performance",
-        "services", "observability", "data_retention", "scripting_sandbox" };
+        "services", "observability", "data_retention", "limits",
+        "scripting_sandbox" };
 
     auto entries = db_->get_all_config_entries ();
     ASSERT_GT (entries.size (), 20u)
@@ -619,6 +625,99 @@ TEST_F (ConfigRouteTest, TheRetiredDatabaseCategoryIsGoneAndItsEntriesAreInCore)
         auto entry = db_->get_config_entry (key);
         ASSERT_TRUE (entry.has_value ()) << key;
         EXPECT_EQ (entry->category, "general_engine") << key;
+    }
+}
+
+// The #703 audit read all 48 entries against #586's own rule - *which words
+// does a user arrive with* - and moved sixteen. Pinned by key, like the
+// advanced set above, because a move is a recorded decision: an entry that
+// drifts back to the shelf it left has to say so here.
+TEST_F (ConfigRouteTest, TheAuditedEntriesSitOnTheShelfThatCoversThem) {
+    const std::map<std::string, std::string> placed = {
+        // Core kept only the engine's own machinery; a request deadline and a
+        // protocol default are transport, not engine capacity.
+        { "defaultTimeout", "network_performance" },
+        { "defaultHttpVersion", "network_performance" },
+        // Every ceiling a rejection message names, on one shelf.
+        { "maxScenarioSteps", "limits" }, { "maxScenarioDataRows", "limits" },
+        { "maxScenarioDataBytes", "limits" }, { "maxSpecDocumentBytes", "limits" },
+        { "maxStepsPerIteration", "limits" },
+        // Not retention: it fails an oversized load-run read in flight and
+        // stores nothing.
+        { "maxResponseBodyBytes", "limits" },
+        // Per-run storage budgets, which is what Data & retention is for.
+        { "maxScenarioStoredSteps", "data_retention" },
+        { "sseMaxStoredEvents", "data_retention" },
+        // A measurement toggle, whatever it costs to store.
+        { "phaseHistograms", "observability" },
+        // Five of Network & connectivity's eight entries were OAuth; the Dock
+        // files an OAuth issuer under Services and so does this.
+        { "oauth2RefreshLeadMs", "services" },
+        { "oauth2RefreshMinIntervalMs", "services" },
+        { "oauth2RefreshRetryMs", "services" },
+        { "oauth2RefreshRetryMaxMs", "services" },
+        { "oauth2RefreshPollIntervalMs", "services" } };
+
+    for (const auto& [key, category] : placed) {
+        auto entry = db_->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key;
+        EXPECT_EQ (entry->category, category) << key;
+    }
+}
+
+// A move changes one of the five fields settings search matches on: the
+// category label. The other four travel with the entry, so an entry is only
+// still reachable after a move if the words a user types for it live in its
+// key, label, description or keywords - which is what this asserts, over the
+// same corpus `matchRank` reads before it reaches the category
+// (app/src/lib/settings-index.ts). The terms below are the ones #703 committed
+// to when it moved them.
+TEST_F (ConfigRouteTest, MovedEntriesStayFindableByTheWordsTheyAreSoughtWith) {
+    const std::vector<std::pair<std::string, std::vector<std::string>>> sought = {
+        { "defaultTimeout", { "timeout", "deadline" } },
+        { "defaultHttpVersion", { "http", "protocol" } },
+        { "maxScenarioSteps", { "scenario", "steps" } },
+        { "maxScenarioDataRows", { "rows", "data" } },
+        { "maxScenarioDataBytes", { "data", "bytes" } },
+        { "maxSpecDocumentBytes", { "openapi", "swagger" } },
+        { "maxStepsPerIteration", { "iteration", "infinite loop" } },
+        { "maxResponseBodyBytes", { "response body", "load-test" } },
+        { "maxScenarioStoredSteps", { "stored", "scenario" } },
+        // The one the audit called out: it leaves Services, and "sse" and
+        // "stream" have to keep finding it from the key and the label.
+        { "sseMaxStoredEvents", { "sse", "stream" } },
+        { "phaseHistograms", { "latency", "ttfb", "timings" } },
+        // "network" is deliberately not required of these - nobody types it
+        // looking for token renewal. "oauth" is.
+        { "oauth2RefreshLeadMs", { "oauth", "token" } },
+        { "oauth2RefreshMinIntervalMs", { "oauth", "token" } },
+        { "oauth2RefreshRetryMs", { "oauth", "token" } },
+        { "oauth2RefreshRetryMaxMs", { "oauth", "token" } },
+        { "oauth2RefreshPollIntervalMs", { "oauth", "refresh" } } };
+
+    auto lowered = [] (std::string text) {
+        for (auto& c : text) {
+            c = static_cast<char> (std::tolower (static_cast<unsigned char> (c)));
+        }
+        return text;
+    };
+
+    for (const auto& [key, terms] : sought) {
+        auto entry = db_->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key;
+
+        std::string haystack =
+        lowered (entry->key + " " + entry->label + " " + entry->description);
+        for (const auto& term : json::parse (entry->keywords)) {
+            haystack += " " + lowered (term.get<std::string> ());
+        }
+
+        for (const auto& term : terms) {
+            EXPECT_NE (haystack.find (term), std::string::npos)
+            << "entry '" << key << "' is no longer findable under '" << term
+            << "' - it moved category, so the category label no longer carries "
+            << "the search for it";
+        }
     }
 }
 

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -298,6 +298,35 @@ TEST_F (DatabaseTest, SeedMovesAnEntryOutOfARetiredCategory) {
     << "a category move must not reset the value the user stored";
 }
 
+// The same guarantee for a category move that is *live* rather than historical.
+// #703 re-shelved sixteen entries, and every install that has ever started the
+// engine carries the old category on the row; the value beside it may be one
+// the user chose deliberately (a provider slow to issue tokens is exactly why
+// this knob is settable). `upsert_config` preserves the value and rewrites the
+// metadata around it, so the migration is the next startup and nothing else -
+// but only a test says so before an upgrade does.
+TEST_F (DatabaseTest, SeedRehomesAnAuditedEntryWithoutResettingItsValue) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    auto seeded = db.get_config_entry ("oauth2RefreshLeadMs");
+    ASSERT_TRUE (seeded.has_value ());
+    ASSERT_EQ (seeded->category, "services");
+
+    ConfigEntry stale = *seeded;
+    stale.category    = "network_performance"; // where it sat before #703
+    stale.value       = "120000";
+    db.save_config_entry (stale);
+
+    db.seed_default_config ();
+
+    auto migrated = db.get_config_entry ("oauth2RefreshLeadMs");
+    ASSERT_TRUE (migrated.has_value ());
+    EXPECT_EQ (migrated->category, "services");
+    EXPECT_EQ (migrated->value, "120000")
+    << "a category move must not reset the value the user stored";
+}
+
 TEST_F (DatabaseTest, SeedRemovesTheSweepRetiredEntries) {
     const std::vector<std::string> retired = { "maxConnections", "tcpKeepAliveIdle",
         "tcpKeepAliveInterval", "statsInterval", "maxJsonFieldSize",


### PR DESCRIPTION
## Description

Pass 2 (#586) fixed the shelves; this pass audits every entry on them. Sixteen rows move, one category (`limits`) is added, and Advanced grows 6 -> 11.

**Plan (root cause, approach, rejected alternative).** The root cause is that #586 split the categories but never re-read the entries against its own rule - *which words does a user arrive with* - so Core accumulated twelve entries under a description covering four of them, Network & connectivity was five-eighths OAuth, and the per-run storage budgets were scattered across three shelves. The approach is pure seed metadata: category strings and `advanced (...)` wraps in `seed_default_config`, plus the new id in the renderer registry and the `EngineSettingsCategory` union. `upsert_config` already preserves a user's value while refreshing the metadata around it, so an existing install migrates on next start with values intact - no migration code, no schema change. **The alternative I rejected** was rewriting the three stale banner comments in place while leaving the entries where they were: that would have left each banner sitting above entries belonging to three different categories, which is a worse lie than the one being fixed. The entries are physically regrouped instead, so each banner describes what follows it.

**Verified against reality first.** The counts in the issue reproduce exactly on `master` (Core 12, N&C 8, Services 9, Observability 7, Data & retention 8, Scripting 4 = 48), and the six `advanced` entries it lists are the six that carry the flag. No drift; the fix is the one the issue describes.

### Final layout

| Category | Before | After | Notes |
|---|---|---|---|
| Core | 12 | 4 | `workers`, `dbCacheSize`, `dbSynchronous`, `dbBusyTimeout` |
| Network & connectivity | 8 | 5 | gains `defaultTimeout`, `defaultHttpVersion`; loses the five `oauth2Refresh*` |
| Services | 9 | 13 | gains the `oauth2Refresh*` family; loses `sseMaxStoredEvents` |
| Observability | 7 | 8 | gains `phaseHistograms` |
| Data & retention | 8 | 8 | gains `maxScenarioStoredSteps`, `sseMaxStoredEvents`; loses `maxResponseBodyBytes`, `phaseHistograms` |
| **Limits** (new) | - | 6 | the ceilings a rejection message names |
| Scripting environment | 4 | 4 | unchanged |

Advanced gains `maxStepsPerIteration`, `oauth2RefreshMinIntervalMs`, `monitorScrapeTimeoutMs`, `liveMaxRetainedTicks`, `scriptStackSize` - by the rule the issue names, and it is worth keeping citable: **if the description has to say "only if" or "only for", the entry has declared itself advanced.**

### Two deliberate deviations from the issue spec

1. **`sseMaxStoredEvents` does not gain `"sse"` / `"stream"` keywords.** The issue asks for them so the entry stays findable from the Services side. Adding them would fail the existing seed guard (`SeededKeywordsNeverRepeatWordsTheEntryAlreadyCarries`), because "sse" is in the key and "Stream" is in the label - and that guard is right: the matcher reaches key and label *before* keywords and ranks them higher, so the terms would only push the entry above better matches. The outcome the issue wants already holds through those two fields, and a new test now pins it rather than leaving it to be assumed.
2. **`SettingsMain.advanced-section.test.tsx` is unchanged.** The issue asks it to cover the categories that newly have an advanced tail. That component is payload-driven and category-agnostic by construction - it filters on `entry.advanced` and never reads a category id - so a per-category copy would assert the same mechanism three more times. The file's own header already says membership is pinned in `config_route_test.cpp`; that is where the five new keys are recorded.

The count invariant the issue asks for ("all 48 land in a registered category, none orphaned") already existed as `EverySeededEntrySitsInADeclaredCategory`. What it was *missing* is the other direction: its declared set is a `std::set` hand-copied from the TypeScript, so a category added to the seed and to that set but forgotten in the app passes there and takes the entry off the screen. `engine-categories.test.ts` now reads `database.cpp` itself against the registry and closes that gap.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All commands from the issue, on this branch:

- `python build.py -e -t` - green.
- `cd engine && ctest --preset linux-dev --output-on-failure` - **1902 passed, 0 failed**.
- `cd app && pnpm test` - **5129 passed across 492 files**.
- `cd app && pnpm type-check` - clean. `pnpm lint` - clean (0 warnings). `prettier --check` on the three touched app files - clean.

No pre-existing failures on the base commit.

**Mutation checks**, each run against a rebuilt engine and reverted after:

| Guard | Mutation | Result |
|---|---|---|
| `TheAuditedEntriesSitOnTheShelfThatCoversThem` | put `phaseHistograms` back in `data_retention` | fails, naming the key and both categories |
| `MovedEntriesStayFindableByTheWordsTheyAreSoughtWith` | drop `keywords ({ "swagger" })` from `maxSpecDocumentBytes` (the only field carrying that term) | fails: `entry 'maxSpecDocumentBytes' is no longer findable under 'swagger'` |
| `engine-categories.test.ts` drift alarm | remove `limits` from `ENGINE_SETTINGS_CATEGORIES` | fails twice - the id-order assertion, and the orphan check naming all six stranded keys |

The drift alarm also asserts it scanned a non-empty seed carrying >40 entries, per the repo's non-empty-scan rule.

**Not run:** `mkdocs build --strict` - mkdocs is not installed in this environment. The docs edits change only inline prose and table cells; no page, heading or relative link is added, moved or renamed, so there is nothing for the strict build to newly reject.

**Not verified in the running app:** the sidebar renders `ENGINE_SETTINGS_CATEGORIES` and `SettingsMain` filters on `entry.category`, both fully data-driven, so `limits` needs no component change - but the new row has not been looked at on screen.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/db-schema.md` (the closed category set, `maxScenarioStoredSteps`'s category, both drift guards named), `docs/engine/api-reference.md` (the `defaultHttpVersion` example, the `advanced` list and its rule, the retention table's category spread, the scenario-bounds section), `docs/engine/scripting.md` (`maxStepsPerIteration`'s category).

Note for the reviewer: `engine/src/db/database.cpp` shows a large diff because the seed's `upsert_config` calls are physically regrouped to match the final shelves. Every entry's text is byte-identical apart from its category string and the `advanced (...)` wraps - the diff is a move. Ordering has no runtime effect: `SettingsMain` sorts by label.

Two things this unblocks and one it does not: #705 (transport policy phase 1) said to land after this pass so its proxy rows arrive on a Network & connectivity that means what it says - that shelf is now clear. Services sits at 13 against the `NoCategoryBecomesADumpingGround` bound of 15, which is fine today and worth remembering before the next long-lived surface arrives.

## Related Issues
Closes #703

---
_Generated by [Claude Code](https://claude.ai/code/session_013HfX92W5yFn2JfBGWCnv1i)_