### PR TITLE
fix(openapi): extract response schemas through a response-level $ref

### DIFF
--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -122,7 +122,10 @@ export class OpenApiV2Parser implements ImportParser {
 						...identity,
 						responses: declaredResponsesOf(op.responses),
 					});
-					schemaOperations.push({ identity, responses: responseSchemasV2(op, spec) });
+					schemaOperations.push({
+						identity,
+						responses: responseSchemasV2(op, spec, resolveRef),
+					});
 				}
 				const req = buildSwaggerOp(method, path, op, spec, resolveRef, pathParams, tally);
 				const tag = asStr(asArray(op.tags)[0]);

--- a/app/src/services/importers/openapi-v3.test.ts
+++ b/app/src/services/importers/openapi-v3.test.ts
@@ -314,6 +314,98 @@ describe("OpenApiV3Parser", () => {
 		expect(result.meta.skipped).toEqual([{ kind: "malformed_spec", count: 2 }]);
 	});
 
+	describe("a spec whose responses live in components (issue #714)", () => {
+		// GitHub's shape. Both indexes stored beside the document are built in
+		// this one walk, so this is where they can be held to the same answer.
+		const spec = {
+			openapi: "3.0.0",
+			paths: {
+				"/repos/{owner}/{repo}": {
+					get: {
+						operationId: "repos/get",
+						summary: "Get a repository",
+						responses: {
+							"200": {
+								description: "ok",
+								content: {
+									"application/json": {
+										schema: { $ref: "#/components/schemas/repo" },
+									},
+								},
+							},
+							"404": { $ref: "#/components/responses/not_found" },
+						},
+					},
+				},
+			},
+			components: {
+				responses: {
+					not_found: {
+						description: "Resource not found",
+						content: {
+							"application/json": {
+								schema: { $ref: "#/components/schemas/basic_error" },
+							},
+						},
+					},
+				},
+				schemas: { repo: { type: "object" }, basic_error: { type: "object" } },
+			},
+		};
+
+		it("agrees with coverage about which statuses are declared", () => {
+			// Coverage reads the status *keys* and so always saw the 404;
+			// extraction read the `$ref` node's absent `content` and saw nothing,
+			// so the two contradicted each other about one document on one run.
+			// Revert the deref and the 404 vanishes from the schema index while
+			// staying in the operation index.
+			const root = p.parse(spec, JSON.stringify(spec), opts).collections[0];
+			const declared = root.spec!.operations!.find(
+				(o) => o.path === "/repos/{owner}/{repo}"
+			)!;
+			expect(declared.responses).toEqual(["200", "404"]);
+
+			const indexed = root.spec!.responseSchemas!.operations.find(
+				(o) => o.path === "/repos/{owner}/{repo}"
+			)!;
+			expect(indexed.responses.map((r) => r.status)).toEqual(["200", "404"]);
+			expect(indexed.responses.find((r) => r.status === "404")).toEqual({
+				status: "404",
+				contentType: "application/json",
+				schema: { $ref: "#/components/schemas/basic_error" },
+			});
+			// The schema the `$ref`'d response points at has to be reachable, or
+			// the entry validates nothing - `refRoots` is where the engine looks.
+			expect(root.spec!.responseSchemas!.refRoots).toEqual({
+				components: {
+					schemas: { repo: { type: "object" }, basic_error: { type: "object" } },
+				},
+			});
+		});
+
+		it("counts a response `$ref` that resolves to nothing exactly once", () => {
+			// Two readers deref this entry - examples and schema extraction - and
+			// only the examples walk tallies. Counting in both would report one
+			// broken ref as two lost items in the import preview.
+			const broken = {
+				...spec,
+				paths: {
+					"/repos/{owner}/{repo}": {
+						get: {
+							operationId: "repos/get",
+							summary: "Get a repository",
+							responses: { "404": { $ref: "#/components/responses/gone_missing" } },
+						},
+					},
+				},
+			};
+			const result = p.parse(broken, JSON.stringify(broken), opts);
+			expect(result.meta.skipped).toEqual([{ kind: "malformed_spec", count: 1 }]);
+			// And nothing half-extracted lands in the index.
+			expect(result.collections[0].spec!.responseSchemas).toBeUndefined();
+		});
+	});
+
 	it("resolves requestBody.$ref to a referenced request body", () => {
 		const spec = {
 			openapi: "3.0.0",

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -122,7 +122,10 @@ export class OpenApiV3Parser implements ImportParser {
 						...identity,
 						responses: declaredResponsesOf(op.responses),
 					});
-					schemaOperations.push({ identity, responses: responseSchemasV3(op) });
+					schemaOperations.push({
+						identity,
+						responses: responseSchemasV3(op, resolveRef),
+					});
 				}
 				const req = buildOperation(method, path, op, resolveRef, pathParams, tally);
 				const tag = asStr(asArray(op.tags)[0]);

--- a/app/src/services/importers/response-schemas.test.ts
+++ b/app/src/services/importers/response-schemas.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { createRefResolver } from "./openapi-shared";
 import {
 	buildResponseSchemaIndex,
 	refRootsOf,
@@ -23,6 +24,9 @@ import {
 	responseSchemasV3,
 	toJsonSchema,
 } from "./response-schemas";
+
+/** A document that declares nothing to resolve, for the ref-free cases. */
+const noRefs = createRefResolver({});
 
 describe("toJsonSchema", () => {
 	it("turns `nullable` into a union with null", () => {
@@ -129,7 +133,7 @@ describe("responseSchemasV3", () => {
 	};
 
 	it("keeps every media type, translated, with the status pattern verbatim", () => {
-		expect(responseSchemasV3(operation)).toEqual([
+		expect(responseSchemasV3(operation, noRefs)).toEqual([
 			{
 				status: "200",
 				contentType: "application/json",
@@ -144,12 +148,120 @@ describe("responseSchemasV3", () => {
 		// An absent schema is not an empty one: `{}` would validate everything
 		// and report a body as matching a contract that never described it.
 		expect(
-			responseSchemasV3({ responses: { "200": { content: { "text/plain": {} } } } })
+			responseSchemasV3({ responses: { "200": { content: { "text/plain": {} } } } }, noRefs)
 		).toEqual([]);
 	});
 
 	it("is empty for an operation with no responses", () => {
-		expect(responseSchemasV3({})).toEqual([]);
+		expect(responseSchemasV3({}, noRefs)).toEqual([]);
+	});
+
+	describe("a response that is itself a `$ref` (issue #714)", () => {
+		// GitHub's public spec declares nearly every response this way. Read
+		// unresolved, the `$ref` node has no `content`, so nothing is extracted
+		// and the engine reports "the spec declares no response for this status"
+		// about a status the document declares plainly.
+		const components = {
+			responses: {
+				not_found: {
+					description: "Resource not found",
+					content: {
+						"application/json": {
+							schema: { $ref: "#/components/schemas/basic_error" },
+						},
+					},
+				},
+				validation_failed: {
+					description: "Validation failed",
+					content: { "application/json": { schema: { type: "object", nullable: true } } },
+				},
+			},
+			schemas: { basic_error: { type: "object" } },
+		};
+		const resolveRef = createRefResolver({ components });
+
+		it("extracts exactly what the inline-equivalent document would", () => {
+			// The pair, side by side: same document, one written through
+			// components, one written out. Revert the deref and the first side
+			// goes empty while the second stays full.
+			const viaRef = responseSchemasV3(
+				{
+					responses: {
+						"404": { $ref: "#/components/responses/not_found" },
+						"422": { $ref: "#/components/responses/validation_failed" },
+					},
+				},
+				resolveRef
+			);
+			const inline = responseSchemasV3(
+				{
+					responses: {
+						"404": components.responses.not_found,
+						"422": components.responses.validation_failed,
+					},
+				},
+				resolveRef
+			);
+			expect(viaRef).toEqual(inline);
+			expect(viaRef).toEqual([
+				{
+					status: "404",
+					contentType: "application/json",
+					// A schema `$ref` inside the resolved response is still kept as
+					// written - `refRoots` carries `components.schemas`, which is
+					// what it points into.
+					schema: { $ref: "#/components/schemas/basic_error" },
+				},
+				{
+					status: "422",
+					contentType: "application/json",
+					schema: { type: ["object", "null"] },
+				},
+			]);
+		});
+
+		it("extracts both halves of an operation mixing inline and `$ref` responses", () => {
+			expect(
+				responseSchemasV3(
+					{
+						responses: {
+							"200": {
+								content: { "application/json": { schema: { type: "array" } } },
+							},
+							"404": { $ref: "#/components/responses/not_found" },
+						},
+					},
+					resolveRef
+				)
+			).toEqual([
+				{ status: "200", contentType: "application/json", schema: { type: "array" } },
+				{
+					status: "404",
+					contentType: "application/json",
+					schema: { $ref: "#/components/schemas/basic_error" },
+				},
+			]);
+		});
+
+		it("steps over a `$ref` to a component that does not exist", () => {
+			// Nothing to extract and nothing to throw: the entry is simply not in
+			// the index, which reads as "not checked" rather than as a pass.
+			expect(
+				responseSchemasV3(
+					{
+						responses: {
+							"404": { $ref: "#/components/responses/gone_missing" },
+							"200": {
+								content: { "application/json": { schema: { type: "array" } } },
+							},
+						},
+					},
+					resolveRef
+				)
+			).toEqual([
+				{ status: "200", contentType: "application/json", schema: { type: "array" } },
+			]);
+		});
 	});
 });
 
@@ -160,7 +272,8 @@ describe("responseSchemasV2", () => {
 				produces: ["application/json", "application/xml"],
 				responses: { "200": { schema: { type: "object" } } },
 			},
-			{}
+			{},
+			noRefs
 		);
 		expect(declared).toEqual([
 			{ status: "200", contentType: "application/json", schema: { type: "object" } },
@@ -174,14 +287,50 @@ describe("responseSchemasV2", () => {
 				{ responses: { "200": { schema: { type: "object" } } } },
 				{
 					produces: ["application/hal+json"],
-				}
+				},
+				noRefs
 			)
 		).toEqual([
 			{ status: "200", contentType: "application/hal+json", schema: { type: "object" } },
 		]);
 		expect(
-			responseSchemasV2({ responses: { "200": { schema: { type: "object" } } } }, {})
+			responseSchemasV2({ responses: { "200": { schema: { type: "object" } } } }, {}, noRefs)
 		).toEqual([{ status: "200", contentType: "application/json", schema: { type: "object" } }]);
+	});
+
+	it("follows a 2.0 response `$ref` into the document's `responses` container", () => {
+		// 2.0 spells the same shape one level shallower: `#/responses/X`, not
+		// `#/components/responses/X`. Revert the deref and this goes empty.
+		const spec = {
+			responses: {
+				NotFound: { description: "gone", schema: { $ref: "#/definitions/Error" } },
+			},
+			definitions: { Error: { type: "object" } },
+		};
+		expect(
+			responseSchemasV2(
+				{ responses: { "404": { $ref: "#/responses/NotFound" } } },
+				spec,
+				createRefResolver(spec)
+			)
+		).toEqual([
+			{
+				status: "404",
+				contentType: "application/json",
+				schema: { $ref: "#/definitions/Error" },
+			},
+		]);
+	});
+
+	it("steps over a 2.0 `$ref` to a response that does not exist", () => {
+		const spec = { responses: {} };
+		expect(
+			responseSchemasV2(
+				{ responses: { "404": { $ref: "#/responses/NotFound" } } },
+				spec,
+				createRefResolver(spec)
+			)
+		).toEqual([]);
 	});
 });
 

--- a/app/src/services/importers/response-schemas.ts
+++ b/app/src/services/importers/response-schemas.ts
@@ -38,8 +38,10 @@
  */
 
 import type { DeclaredResponseSchema, ResponseSchemaIndex, SpecOperation } from "@/types";
+import type { RefResolver } from "./openapi-shared";
 
 import { asArray, asRecord, asStr } from "@/lib/json-node";
+import { deref } from "./openapi-shared";
 
 /** Where #649's bundler inlines the external files a document referenced. */
 const BUNDLED_KEY = "x-vayu-bundled";
@@ -212,6 +214,38 @@ function mapSchemas(map: Record<string, unknown>): Record<string, unknown> {
 }
 
 /**
+ * Why both extractors below `deref` each `responses` entry before reading it
+ * (issue #714).
+ *
+ * A response may be `{"$ref": "#/components/responses/not_found"}` in 3.x, or
+ * `{"$ref": "#/responses/NotFound"}` in 2.0 - the shape GitHub's public spec
+ * uses for nearly every response it declares. The `$ref` node carries no
+ * `content` and no `schema` of its own, so reading it unresolved emits no
+ * schema, and the engine then reports `no_schema_for_status` - "the spec
+ * declares no response for this status" - about a status the document declares
+ * plainly, while coverage (which reads the status *keys*, and so never needed
+ * the ref) counts the very same status as declared. The examples half of this
+ * same parse already follows the ref (`deref` in `buildExamples` /
+ * `buildSwaggerExamples`); extraction was the one reader that did not.
+ *
+ * Single-hop, like every other ref these parsers follow: a ref to a ref is not
+ * a shape generators emit, and chasing one needs a cycle guard.
+ *
+ * **A ref that resolves to nothing is skipped and not counted here**, though
+ * the issue's pathway suggested counting it. The examples walk derefs the same
+ * entry of the same operation and already tallies `malformed_spec` for it, over
+ * a superset of what extraction sees - it runs for every operation, extraction
+ * only for those with a usable `specOperation` identity. A second count would
+ * report one broken ref as two lost items in the import preview.
+ * `openapi-v3.test.ts` holds the count at one, so the double cannot be added
+ * back without a red test.
+ *
+ * Schemas *inside* the resolved response keep their own `$ref`s as written, the
+ * same as an inline response's - `refRootsOf` carries `components.schemas` and
+ * `definitions`, which is what those point into.
+ */
+
+/**
  * An OpenAPI 3.x operation's declared response schemas.
  *
  * Every media type is kept, not just the JSON one: what can be validated is
@@ -221,13 +255,16 @@ function mapSchemas(map: Record<string, unknown>): Record<string, unknown> {
  * is nothing to check against, and an empty schema would claim everything is
  * valid.
  */
-export function responseSchemasV3(operation: Record<string, unknown>): DeclaredResponseSchema[] {
+export function responseSchemasV3(
+	operation: Record<string, unknown>,
+	resolveRef: RefResolver
+): DeclaredResponseSchema[] {
 	const responses = asRecord(operation.responses);
 	if (!responses) return [];
 
 	const declared: DeclaredResponseSchema[] = [];
 	for (const [status, response] of Object.entries(responses)) {
-		const node = asRecord(response);
+		const node = asRecord(deref(response, resolveRef));
 		if (!node || !status) continue;
 		const content = asRecord(node.content);
 		if (!content) continue;
@@ -254,7 +291,8 @@ export function responseSchemasV3(operation: Record<string, unknown>): DeclaredR
  */
 export function responseSchemasV2(
 	operation: Record<string, unknown>,
-	spec: Record<string, unknown>
+	spec: Record<string, unknown>,
+	resolveRef: RefResolver
 ): DeclaredResponseSchema[] {
 	const responses = asRecord(operation.responses);
 	if (!responses) return [];
@@ -268,7 +306,7 @@ export function responseSchemasV2(
 
 	const declared: DeclaredResponseSchema[] = [];
 	for (const [status, response] of Object.entries(responses)) {
-		const node = asRecord(response);
+		const node = asRecord(deref(response, resolveRef));
 		if (!node || !status || node.schema === undefined) continue;
 		const schema = toJsonSchema(node.schema);
 		for (const contentType of mediaTypes) {

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -481,6 +481,20 @@ Not a failure, and it says which of these it was:
 | The body is not JSON | A JSON Schema cannot describe HTML |
 | There was no response | The request never reached a server |
 
+A response the document writes as a reference -
+`"404": {"$ref": "#/components/responses/not_found"}`, the shape GitHub's public
+spec uses for nearly every response - is read through to the component it names,
+so it is checked like any other.
+
+**A collection bound before that was true keeps the index it was stored with**,
+and reports *the spec declares no response for this status* against every
+`$ref`-ed response in it. The index is rebuilt when the document is stored
+again, so the remedy is to **re-bind** the collection from the
+[Spec tab](#binding-a-collection-you-already-have) - or to sync it, if the
+document upstream has genuinely changed. A **Check for changes** against a
+document whose bytes are identical reports *unchanged* and stops there, by
+design: it compares bytes, and these bytes did not move.
+
 ### Where OpenAPI stops being JSON Schema
 
 Schemas are translated when the document is stored, because a validator reads


### PR DESCRIPTION
## Description

`responseSchemasV3` read `operation.responses[status].content` directly and never resolved a response written as `{"$ref": "#/components/responses/not_found"}` - the shape GitHub's public spec uses for nearly every response it declares. The `$ref` node carries no `content` key, so the loop `continue`d and emitted no schema; `responseSchemasV2` skipped `#/responses/X` identically. On one run of such a document, response validation reported `no_schema_for_status` - rendered as *"The spec declares no response for this status"* - about a status the document declares plainly, while contract coverage, whose walk reads the status **keys** and so never needed the ref, counted that very same status as declared. Two features contradicting each other about one document.

**Plan.** *Root cause:* extraction is the one reader in this parse that hands the **raw** operation to the responses walk. The examples half of the same walk already resolves exactly these refs (`deref(rawResponse, resolveRef)` at `openapi-v3.ts:307`, `openapi-v2.ts:323`); `responseSchemasV3`/`V2` were simply called with no resolver in hand. *Approach:* give them the parser's `resolveRef` and `deref` each `responses` entry before reading it - single hop, matching every other ref these parsers follow - after which the resolved entry flows through the existing content/media-type logic unchanged. *The alternative I rejected* was carrying `components.responses` into the stored `refRoots` and letting the engine resolve the ref at validation time. It moves OpenAPI knowledge into the engine, which the #625 division deliberately keeps out of it; it inflates the index against the byte cap it shares with the document; and it would falsify the standing comment in `refRootsOf` that a schema `$ref` can only resolve to a schema. Resolving at extraction time keeps the stored index byte-identical to what an inline-equivalent document produces - which is the property the new test asserts, and the reason no engine change is needed.

### What changed

**App**
- `services/importers/response-schemas.ts` - `responseSchemasV3(operation, resolveRef)` and `responseSchemasV2(operation, spec, resolveRef)` `deref` each `responses` entry. Required parameters rather than optional, so each caller states its answer.
- `services/importers/openapi-v3.ts`, `openapi-v2.ts` - pass the `resolveRef` already in scope.

Nothing else needed wiring: the bind path (`SpecTab`) and the sync path (`SpecSync`) both read the index off `readSpecOperations`, which goes through these same parsers, so both heal automatically.

**Docs (same commit)**
- `docs/app/openapi.md` - `$ref`-ed responses are checked like any other, and the repair path for collections bound before this: a **re-bind**. A byte-identical *Check for changes* reports *unchanged* and stops, so "sync it" would have been advice that could not work.

### Deliberate deviation from the issue

The issue's fix pathway says "tally on failure" for a `$ref` that resolves to nothing. **It is stepped over and not tallied here.** The examples walk derefs the same entry of the same operation and already counts it as `malformed_spec`, over a superset of what extraction sees - it runs for every operation, extraction only for those with a usable `specOperation` identity. A second count would report one broken ref as two lost items in the import preview. The parser-level test holds the count at exactly one, so the double cannot be added back without a red test.

No engine test was added either. The engine cannot distinguish a `$ref`-sourced index entry from an inline one - there is no difference in the stored index - and `schema_validation_test.cpp` already covers "given an index entry for this status, `checked: true`". The app-side test that closes the loop is the equality assertion: the `$ref` document and its inline equivalent extract to the same array, `refRoots` included.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test`: **5136 tests in 492 files, all passing** (196s). `pnpm type-check`, `pnpm lint` (zero warnings) and `prettier --check` on the five touched app files: clean. Both test files were prettier-clean before the change and were formatted after it; nothing else was touched.
- `python3 -m mkdocs build --strict -f .github/mkdocs.yml`: clean, for the `docs/` edit.
- No engine code changed, so no engine build or ctest run - per `CLAUDE.md`, no C++ test could go from green to red here.
- No pre-existing failures observed on this base (`dcc34e4`).

Seven new tests, mutation-checked by reverting the `deref` on both extractors and confirming they go red (**4 failed / 52 passed**; restored, 56/56):

- **The pair, side by side** - the same document written through `components.responses` and written out inline extract to an identical array, including the `$ref` a resolved response's schema keeps. *Reverted: the `$ref` side goes empty while the inline side stays full.*
- An operation mixing inline and `$ref`-ed responses extracts both halves.
- A `$ref` to a component that does not exist is stepped over: the other statuses still extract, nothing throws.
- The 2.0 spelling one level shallower (`#/responses/NotFound` into `definitions`), and its missing-component case.
- **Coverage and validation agree on one parse** (`openapi-v3.test.ts`) - a GitHub-shaped spec's operation index declares `["200", "404"]` and its schema index now indexes both, with `refRoots` carrying the schema the `$ref`-ed response points into. *Reverted: the 404 vanishes from the schema index while staying in the operation index - the contradiction, asserted.*
- A response `$ref` that resolves to nothing counts exactly once in `meta.skipped`, and nothing half-extracted lands in the index.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #714

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgbiu3HvBWyQoduUDzNSUu)_