### PR TITLE
fix(openapi): refuse a duplicated operationId as an identity

### DIFF
--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -1007,6 +1007,12 @@ const SKIPPED_LABELS: Record<SkippedItem["kind"], [singular: string, plural: str
 		"reference to a file Vayu could not read",
 		"references to files Vayu could not read",
 	],
+	// The operation imports; what it loses is the repeated id, so the wording
+	// says which half went (issue #715) rather than implying a dropped request.
+	duplicate_operation_id: [
+		"operation whose operationId was already used (identified by path instead)",
+		"operations whose operationId was already used (identified by path instead)",
+	],
 };
 
 function skippedLabel(kind: SkippedItem["kind"], count: number): string {

--- a/app/src/services/importers/openapi-shared.ts
+++ b/app/src/services/importers/openapi-shared.ts
@@ -55,8 +55,13 @@ export function createRefResolver(document: unknown): RefResolver {
  * bad key must not turn the whole import into a rejected payload. The request
  * still imports; it simply names no operation, which is exactly the state of a
  * request the spec never described.
+ *
+ * Deliberately not exported: a parser reaching for this one operation at a time
+ * cannot see that another operation already claimed the same `operationId`, and
+ * stamping that id twice is what {@link createOperationIdentifier} exists to
+ * prevent (issue #715). Parsers take the identifier; this is what it is built on.
  */
-export function specOperationOf(
+function specOperationOf(
 	method: string,
 	path: string,
 	operationId: unknown
@@ -144,6 +149,48 @@ export class SkipTally {
 	items(): SkippedItem[] {
 		return [...this.counts].map(([kind, count]) => ({ kind, count }));
 	}
+}
+
+/**
+ * {@link specOperationOf} for a whole document, with a **duplicated
+ * `operationId` kept on its first declaration only** (issue #715).
+ *
+ * A document declaring one id on two operations is invalid OpenAPI and common
+ * in generated specs, and stamping it verbatim on both requests is what turns
+ * that upstream sloppiness into local corruption: the sync diff follows an id
+ * before a path, so the second declaration's request resolves to the *first*
+ * declaration's operation, reads as renamed toward an operation it never was,
+ * and a default-ticked apply then rewrites its method, URL and identity. The
+ * same ambiguity reaches the engine's coverage index, which resolves by id
+ * first as well.
+ *
+ * So a repeated id is dropped rather than repeated: the later operation imports
+ * with the identity it can still state unambiguously - its method and templated
+ * path - which is what `spec-diff` then follows it by. First declaration wins
+ * because document order is stable across re-fetches of the same file, so two
+ * syncs of an unchanged document agree about which request holds the id. The
+ * drop is counted, because a request quietly missing the identity the document
+ * appeared to give it is the kind of loss the import preview exists to name.
+ *
+ * One call per operation: the count is per duplicate declaration, and calling
+ * it twice for the same operation would report a duplicate the document does
+ * not contain.
+ */
+export function createOperationIdentifier(
+	tally: SkipTally
+): (method: string, path: string, operationId: unknown) => SpecOperation | undefined {
+	const claimed = new Set<string>();
+	return (method, path, operationId) => {
+		const identity = specOperationOf(method, path, operationId);
+		const id = identity?.operationId;
+		if (!identity || !id) return identity;
+		if (!claimed.has(id)) {
+			claimed.add(id);
+			return identity;
+		}
+		tally.add("duplicate_operation_id");
+		return { method: identity.method, path: identity.path };
+	};
 }
 
 /**

--- a/app/src/services/importers/openapi-v2.test.ts
+++ b/app/src/services/importers/openapi-v2.test.ts
@@ -10,6 +10,33 @@ const opts = { importEnvironments: true, importScripts: true };
 describe("OpenApiV2Parser", () => {
 	const p = new OpenApiV2Parser();
 
+	it("keeps a duplicated operationId on its first declaration only (issue #715)", () => {
+		// The same rule as the v3 parser, through the same shared identifier: two
+		// requests carrying one id is what lets a later sync pair the second with
+		// the first one's operation.
+		const spec = {
+			swagger: "2.0",
+			info: { title: "Generated API" },
+			paths: {
+				"/a": { get: { operationId: "list", summary: "List A" } },
+				"/b": { post: { operationId: "list", summary: "Create B" } },
+			},
+		};
+		const result = p.parse(spec, JSON.stringify(spec), opts);
+		const requests = result.collections[0].requests;
+
+		expect(requests.find((r) => r.name === "List A")!.specOperation).toEqual({
+			operationId: "list",
+			method: "GET",
+			path: "/a",
+		});
+		expect(requests.find((r) => r.name === "Create B")!.specOperation).toEqual({
+			method: "POST",
+			path: "/b",
+		});
+		expect(result.meta.skipped).toEqual([{ kind: "duplicate_operation_id", count: 1 }]);
+	});
+
 	it("detects by swagger 2.0", () => {
 		expect(p.detect(parsed, raw)).toBe(true);
 		expect(p.detect({ openapi: "3.0.0" }, "")).toBe(false);

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -36,7 +36,7 @@ import {
 	resolvePathItem,
 	responseExample,
 	SkipTally,
-	specOperationOf,
+	createOperationIdentifier,
 } from "./openapi-shared";
 import { countExamples, importedFilePart, unattachedFileParts } from "./shared";
 import { buildResponseSchemaIndex, responseSchemasV2 } from "./response-schemas";
@@ -95,6 +95,10 @@ export class OpenApiV2Parser implements ImportParser {
 		const tagCollections = new Map<string, CollectionDraft>();
 		const rootRequests: RequestDraft[] = [];
 		const tally = new SkipTally();
+		// One identifier for the whole document: it is what keeps a repeated
+		// `operationId` off the second request that would otherwise claim it
+		// (issue #715), which needs the memory of every id already stamped.
+		const identify = createOperationIdentifier(tally);
 		let requestCount = 0;
 		// The declared-operation index (issue #629) - see the v3 parser for why
 		// it is built in this walk rather than by a second pass over `paths`.
@@ -116,7 +120,7 @@ export class OpenApiV2Parser implements ImportParser {
 				const op = asRecord(pathItem[method]);
 				if (!op) continue;
 				requestCount += 1;
-				const identity = specOperationOf(method, path, op.operationId);
+				const identity = identify(method, path, op.operationId);
 				if (identity) {
 					declaredOperations.push({
 						...identity,
@@ -127,7 +131,16 @@ export class OpenApiV2Parser implements ImportParser {
 						responses: responseSchemasV2(op, spec, resolveRef),
 					});
 				}
-				const req = buildSwaggerOp(method, path, op, spec, resolveRef, pathParams, tally);
+				const req = buildSwaggerOp(
+					method,
+					path,
+					op,
+					spec,
+					resolveRef,
+					pathParams,
+					tally,
+					identity
+				);
 				const tag = asStr(asArray(op.tags)[0]);
 				if (tag) {
 					if (!tagCollections.has(tag)) {
@@ -198,7 +211,9 @@ function buildSwaggerOp(
 	spec: JsonRecord,
 	resolveRef: (r: string) => unknown,
 	pathParams: unknown[],
-	tally: SkipTally
+	tally: SkipTally,
+	/** The identity `parse` claimed for this operation - see the v3 parser. */
+	specOperation: SpecOperation | undefined
 ): RequestDraft {
 	const params: KeyValueEntry[] = [];
 	const headers: KeyValueEntry[] = [];
@@ -276,7 +291,6 @@ function buildSwaggerOp(
 	}
 
 	const examples = buildSwaggerExamples(op, spec, resolveRef, tally);
-	const specOperation = specOperationOf(method, path, op.operationId);
 	return {
 		name: asStr(op.summary) ?? asStr(op.operationId) ?? `${method.toUpperCase()} ${path}`,
 		description: asStr(op.description) ?? "",

--- a/app/src/services/importers/openapi-v3.test.ts
+++ b/app/src/services/importers/openapi-v3.test.ts
@@ -314,6 +314,61 @@ describe("OpenApiV3Parser", () => {
 		expect(result.meta.skipped).toEqual([{ kind: "malformed_spec", count: 2 }]);
 	});
 
+	describe("a document that declares one operationId twice (issue #715)", () => {
+		// Invalid OpenAPI, and common in generated specs. Stamping the id on both
+		// requests is what let a sync pair the second one with the first one's
+		// operation and rewrite its identity on an all-defaults apply.
+		const spec = {
+			openapi: "3.0.0",
+			info: { title: "Generated API" },
+			paths: {
+				"/a": {
+					get: {
+						operationId: "list",
+						summary: "List A",
+						responses: { "200": { description: "ok" } },
+					},
+				},
+				"/b": {
+					post: {
+						operationId: "list",
+						summary: "Create B",
+						responses: { "201": { description: "made" } },
+					},
+				},
+			},
+		};
+		const parse = () => p.parse(spec, JSON.stringify(spec), opts);
+
+		it("keeps the id on the first declaration and identifies the second by its path alone", () => {
+			const requests = parse().collections[0].requests;
+			expect(requests.find((r) => r.name === "List A")!.specOperation).toEqual({
+				operationId: "list",
+				method: "GET",
+				path: "/a",
+			});
+			expect(requests.find((r) => r.name === "Create B")!.specOperation).toEqual({
+				method: "POST",
+				path: "/b",
+			});
+		});
+
+		it("indexes the declared operations by those same identities", () => {
+			// The engine resolves coverage by operationId first, so an index that
+			// disagreed with the requests would reintroduce the ambiguity there.
+			expect(parse().collections[0].spec!.operations).toEqual([
+				{ operationId: "list", method: "GET", path: "/a", responses: ["200"] },
+				{ method: "POST", path: "/b", responses: ["201"] },
+			]);
+		});
+
+		it("names the dropped id in the preview rather than losing it silently", () => {
+			expect(parse().meta.skipped).toEqual([{ kind: "duplicate_operation_id", count: 1 }]);
+			// The operation itself imported whole - only the repeated id went.
+			expect(parse().meta.requestCount).toBe(2);
+		});
+	});
+
 	describe("a spec whose responses live in components (issue #714)", () => {
 		// GitHub's shape. Both indexes stored beside the document are built in
 		// this one walk, so this is where they can be held to the same answer.

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -37,7 +37,7 @@ import {
 	resolvePathItem,
 	responseExample,
 	SkipTally,
-	specOperationOf,
+	createOperationIdentifier,
 } from "./openapi-shared";
 import { countExamples, importedFilePart, unattachedFileParts } from "./shared";
 import { buildResponseSchemaIndex, responseSchemasV3 } from "./response-schemas";
@@ -89,6 +89,10 @@ export class OpenApiV3Parser implements ImportParser {
 		const tagCollections = new Map<string, CollectionDraft>();
 		const rootRequests: RequestDraft[] = [];
 		const tally = new SkipTally();
+		// One identifier for the whole document: it is what keeps a repeated
+		// `operationId` off the second request that would otherwise claim it
+		// (issue #715), which needs the memory of every id already stamped.
+		const identify = createOperationIdentifier(tally);
 		let requestCount = 0;
 		// The declared-operation index stored beside the document (issue #629).
 		// Built in this same walk rather than by a second pass over `paths`: a
@@ -116,7 +120,7 @@ export class OpenApiV3Parser implements ImportParser {
 				const op = asRecord(pathItem[method]);
 				if (!op) continue;
 				requestCount += 1;
-				const identity = specOperationOf(method, path, op.operationId);
+				const identity = identify(method, path, op.operationId);
 				if (identity) {
 					declaredOperations.push({
 						...identity,
@@ -127,7 +131,15 @@ export class OpenApiV3Parser implements ImportParser {
 						responses: responseSchemasV3(op, resolveRef),
 					});
 				}
-				const req = buildOperation(method, path, op, resolveRef, pathParams, tally);
+				const req = buildOperation(
+					method,
+					path,
+					op,
+					resolveRef,
+					pathParams,
+					tally,
+					identity
+				);
 				const tag = asStr(asArray(op.tags)[0]);
 				if (tag) {
 					if (!tagCollections.has(tag))
@@ -216,7 +228,12 @@ function buildOperation(
 	op: JsonRecord,
 	resolveRef: (r: string) => unknown,
 	pathParams: unknown[],
-	tally: SkipTally
+	tally: SkipTally,
+	/** The identity `parse` claimed for this operation - passed rather than
+	 * re-derived, so the request and the declared-operation index can never
+	 * disagree about which of two operations kept a repeated `operationId`
+	 * (issue #715). */
+	specOperation: SpecOperation | undefined
 ): RequestDraft {
 	const params: KeyValueEntry[] = [];
 	const headers: KeyValueEntry[] = [];
@@ -251,7 +268,6 @@ function buildOperation(
 		}
 	}
 	const examples = buildExamples(op.responses, resolveRef, tally);
-	const specOperation = specOperationOf(method, path, op.operationId);
 	return {
 		name: asStr(op.summary) ?? asStr(op.operationId) ?? `${method.toUpperCase()} ${path}`,
 		description: asStr(op.description) ?? "",

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -56,7 +56,16 @@ export interface SkippedItem {
 		 * the factory, which is also why it is the one kind that says nothing about
 		 * Vayu's own representability.
 		 */
-		| "external_ref";
+		| "external_ref"
+		/**
+		 * An operation whose `operationId` another operation already declared
+		 * (issue #715). The operation itself imports whole - only the repeated id
+		 * is dropped from its recorded identity, which then rests on its method
+		 * and path alone. Counted because a sync follows the identity a request
+		 * records, so which request kept the id is not a detail the user should
+		 * have to discover from a diff.
+		 */
+		| "duplicate_operation_id";
 	count: number;
 }
 

--- a/app/src/services/openapi/spec-apply.test.ts
+++ b/app/src/services/openapi/spec-apply.test.ts
@@ -131,6 +131,61 @@ function payload(
 	});
 }
 
+describe("a duplicated operationId is not corruption a default apply can commit (issue #715)", () => {
+	/*
+	 * The end-to-end shape of the failure: a generated document declares one id
+	 * on two operations, an import before the fix stamped it on both requests,
+	 * and upstream then tweaks the first operation. The user clicks Check for
+	 * changes and Apply with everything ticked as it came.
+	 *
+	 * What must not be in that payload is a write that moves the second request
+	 * onto the first one's operation - its method, its URL and its identity.
+	 */
+	const DUP = doc({
+		"/a": { get: { operationId: "list", summary: "List A" } },
+		"/b": { post: { operationId: "list", summary: "Create B" } },
+	});
+	const TWEAKED = doc({
+		"/a": { get: { operationId: "list", summary: "List A, now documented" } },
+		"/b": { post: { operationId: "list", summary: "Create B" } },
+	});
+
+	it("writes nothing of the first operation onto the second request", () => {
+		const entries = readSpecOperations(DUP).requests;
+		const requests = [
+			requestFrom("req_a", entries[0]),
+			// The stamp an import before the fix left on the second declaration.
+			requestFrom("req_b", entries[1], {
+				specOperation: { operationId: "list", method: "POST", path: "/b" },
+			}),
+		];
+		const diff = diffSpec({
+			bound: entries,
+			fetched: readSpecOperations(TWEAKED).requests,
+			requests,
+		});
+		const body = buildSyncPayload({
+			collectionId: "col_root",
+			diff,
+			selection: defaultSelection(diff),
+			content: TWEAKED,
+			sourceUrl: null,
+			collections: collections(),
+		});
+
+		const b = body.update.find((u) => u.id === "req_b");
+		expect(b?.method).toBe("POST");
+		expect(b?.specOperation).toEqual({ method: "POST", path: "/b" });
+		// Nothing the document produces for this request differs, so no field of
+		// it is written at all - the update exists only to drop the id the other
+		// operation kept, which is the ambiguity being repaired.
+		expect(b?.name).toBeUndefined();
+		expect(b?.url).toBeUndefined();
+		// The tweak lands where it belongs, on the request that operation is.
+		expect(body.update.find((u) => u.id === "req_a")?.name).toBe("List A, now documented");
+	});
+});
+
 describe("defaultSelection", () => {
 	it("ticks every added operation and no removal", () => {
 		const fetched = doc({

--- a/app/src/services/openapi/spec-diff.test.ts
+++ b/app/src/services/openapi/spec-diff.test.ts
@@ -34,6 +34,7 @@ import type { Request } from "@/types";
 interface OperationSpec {
 	operationId?: string;
 	summary?: string;
+	description?: string;
 	parameters?: unknown[];
 	requestBody?: unknown;
 }
@@ -118,6 +119,95 @@ function diffAgainst(fetchedRaw: string, requests: Request[]) {
 }
 
 const fieldNames = (fields: { field: string }[]): string[] => fields.map((f) => f.field).sort();
+
+describe("a document that declares one operationId twice (issue #715)", () => {
+	/*
+	 * Invalid OpenAPI and ordinary in generated specs. Import now keeps a
+	 * repeated id on its first declaration only, so what the diff has to survive
+	 * is the shape an import *before* that fix left behind: two requests
+	 * claiming one id, plus a document whose id names an operation that
+	 * contradicts what the second request says it is.
+	 */
+	const DUP = doc({
+		"/a": { get: { operationId: "list", summary: "List A" } },
+		"/b": { post: { operationId: "list", summary: "Create B" } },
+	});
+	/** What an import before the fix stamped on the second declaration. */
+	const staleStamp = { operationId: "list", method: "POST", path: "/b" } as const;
+
+	const entries = () => readSpecOperations(DUP).requests;
+
+	/** Both requests, the second still carrying the id the first also claims. */
+	function collection(): Request[] {
+		const [a, b] = entries();
+		return [
+			requestFrom("req_a", a),
+			requestFrom("req_b", b, { specOperation: { ...staleStamp } }),
+		];
+	}
+
+	const diffDup = (fetchedRaw: string, requests: Request[]) =>
+		diffSpec({
+			bound: entries(),
+			fetched: readSpecOperations(fetchedRaw).requests,
+			requests,
+		});
+
+	it("leaves the second request on its own operation when the first one changes", () => {
+		const tweaked = doc({
+			"/a": {
+				get: { operationId: "list", summary: "List A", description: "Now documented" },
+			},
+			"/b": { post: { operationId: "list", summary: "Create B" } },
+		});
+
+		const diff = diffDup(tweaked, collection());
+
+		// The id two requests claim identifies neither, so each is followed by its
+		// own endpoint. Following the id instead pairs `req_b` with `GET /a` and
+		// reports its name, url and body as changed.
+		const b = diff.changed.find((c) => c.request.id === "req_b");
+		expect(b?.matchedBy).toBe("path");
+		expect(b?.operation).toEqual({ method: "POST", path: "/b" });
+		expect(b?.fields).toEqual([]);
+		const a = diff.changed.find((c) => c.request.id === "req_a");
+		expect(fieldNames(a?.fields ?? [])).toEqual(["description"]);
+		expect(diff.added).toEqual([]);
+		expect(diff.removed).toEqual([]);
+	});
+
+	it("prefers the request's own endpoint over an id naming a different one", () => {
+		// One claimant, so the id is not ambiguous among the requests - what
+		// refuses it here is the entry it names having a different method and
+		// path from the stamp, while the document still declares the stamp's own.
+		const orphaned = [requestFrom("req_b", entries()[1], { specOperation: { ...staleStamp } })];
+
+		const diff = diffDup(DUP, orphaned);
+
+		const b = diff.changed.find((c) => c.request.id === "req_b");
+		expect(b?.matchedBy).toBe("path");
+		expect(b?.operation).toEqual({ method: "POST", path: "/b" });
+		expect(b?.fields).toEqual([]);
+		expect(diff.removed).toEqual([]);
+		// Nothing claims `GET /a` now, which is an addition to offer and not a
+		// request to overwrite.
+		expect(diff.added.map((entry) => entry.operation.path)).toEqual(["/a"]);
+	});
+
+	it("reports a moved endpoint as gone rather than following the shared id to the other operation", () => {
+		const moved = doc({
+			"/a": { get: { operationId: "list", summary: "List A" } },
+			"/b2": { post: { operationId: "list", summary: "Create B" } },
+		});
+
+		const diff = diffDup(moved, collection());
+
+		expect(diff.removed.map((r) => r.id)).toEqual(["req_b"]);
+		expect(diff.added.map((entry) => entry.operation.path)).toEqual(["/b2"]);
+		expect(diff.changed).toEqual([]);
+		expect(diff.unchanged).toBe(1);
+	});
+});
 
 describe("diffSpec", () => {
 	it("reports nothing changed when the document is the same", () => {

--- a/app/src/services/openapi/spec-diff.ts
+++ b/app/src/services/openapi/spec-diff.ts
@@ -30,6 +30,9 @@
  * overwrites the wrong request. The path side is compared through
  * `specPathShape`, the same flattening `matchOperations` binds with, so a
  * renamed *path parameter* (`{petId}` -> `{id}`) is the same endpoint here too.
+ * An id is only followed while it means one thing, though - see {@link lookup}
+ * for the two ways a duplicated `operationId` stops it from meaning anything
+ * (issue #715).
  *
  * **Changed is measured against what an import would produce**, not against a
  * hand-written idea of the mapping: the drafts come from the same parsers the
@@ -144,6 +147,7 @@ export interface SpecDiffInput {
 export function diffSpec({ bound, fetched, requests }: SpecDiffInput): SpecDiff {
 	const fetchedIndex = index(fetched);
 	const boundIndex = bound ? index(bound) : null;
+	const ambiguousIds = idsMoreThanOneRequestClaims(requests);
 
 	const added: SpecRequestDraft[] = [];
 	const removed: Request[] = [];
@@ -160,14 +164,16 @@ export function diffSpec({ bound, fetched, requests }: SpecDiffInput): SpecDiff 
 			continue;
 		}
 
-		const found = lookup(fetchedIndex, boundOperation);
+		const found = lookup(fetchedIndex, boundOperation, ambiguousIds);
 		if (!found) {
 			removed.push(request);
 			continue;
 		}
 		claimed.add(found.entry);
 
-		const previous = boundIndex ? lookup(boundIndex, boundOperation)?.entry : undefined;
+		const previous = boundIndex
+			? lookup(boundIndex, boundOperation, ambiguousIds)?.entry
+			: undefined;
 		const fields = diffFields(request, found.entry.draft, previous?.draft);
 		const renamed = !sameOperation(boundOperation, found.entry.operation);
 		if (fields.length === 0 && !renamed) {
@@ -204,7 +210,9 @@ interface OperationIndex {
  * First rather than last because a document that declares one `operationId`
  * twice is already invalid, and the duplicate then falls out as an `added`
  * operation - visible, rather than silently displacing the one a request is
- * bound to.
+ * bound to. The drafts arrive from the import parsers, which drop a repeated id
+ * rather than stamping it twice (issue #715), so the second declaration reaches
+ * this with a method-and-path identity and is indexed by path alone.
  */
 function index(entries: readonly SpecRequestDraft[]): OperationIndex {
 	const byOperationId = new Map<string, SpecRequestDraft>();
@@ -218,15 +226,54 @@ function index(entries: readonly SpecRequestDraft[]): OperationIndex {
 	return { byOperationId, byPath };
 }
 
+/**
+ * The `operationId`s more than one request in this collection records - the
+ * shape a document that declared one id twice left behind (issue #715).
+ *
+ * Import no longer stamps a repeated id at all, but a collection imported
+ * before that fix still holds two requests claiming one id, and an id two
+ * requests claim identifies neither of them. They are followed by path here,
+ * which is the same refusal-to-guess `operation-match.ts` binds by.
+ */
+function idsMoreThanOneRequestClaims(requests: readonly Request[]): ReadonlySet<string> {
+	const seen = new Set<string>();
+	const repeated = new Set<string>();
+	for (const request of requests) {
+		const id = request.specOperation?.operationId;
+		if (!id) continue;
+		if (seen.has(id)) repeated.add(id);
+		else seen.add(id);
+	}
+	return repeated;
+}
+
+/**
+ * The document's entry for one recorded identity, and how it was found.
+ *
+ * The `operationId` leads - that is what follows an operation whose path moved
+ * - with two limits, both of them cases where following it would pair a request
+ * with an operation that contradicts what the request says it is (issue #715):
+ *
+ * - an id **two requests claim** identifies neither, so it is skipped entirely;
+ * - an id whose entry has a different method + path shape loses to an **exact
+ *   match on the request's own** method + path, because a document still
+ *   declaring the endpoint the request records is a stronger statement about
+ *   which operation this is than an id pointing somewhere else. With no exact
+ *   match the id is still followed: that is the ordinary rename, where the
+ *   document moved the path and the id is all there is left to follow.
+ */
 function lookup(
 	spec: OperationIndex,
-	operation: SpecOperation
+	operation: SpecOperation,
+	ambiguousIds: ReadonlySet<string>
 ): { entry: SpecRequestDraft; matchedBy: IdentityMatch } | undefined {
-	if (operation.operationId) {
-		const byId = spec.byOperationId.get(operation.operationId);
-		if (byId) return { entry: byId, matchedBy: "operationId" };
-	}
 	const byPath = spec.byPath.get(pathKey(operation));
+	const { operationId } = operation;
+	if (operationId && !ambiguousIds.has(operationId)) {
+		const byId = spec.byOperationId.get(operationId);
+		if (byId && (!byPath || pathKey(byId.operation) === pathKey(operation)))
+			return { entry: byId, matchedBy: "operationId" };
+	}
 	return byPath ? { entry: byPath, matchedBy: "path" } : undefined;
 }
 

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -283,7 +283,7 @@ than tallying while building them, so the number and the rows cannot disagree.
 
 **`SkippedItem`** - `{ kind: "websocket" | "grpc" | "api_spec" | "unit_test" | "file_body" |
 "malformed_item" | "unsupported_method" | "malformed_spec" | "example_no_status" |
-"external_ref", count }`.
+"external_ref" | "duplicate_operation_id", count }`.
 Surfaces work Vayu can't represent so the Preview can warn instead of silently dropping.
 Three of the kinds are not about representability: `unsupported_method` is an operation whose
 HTTP method has no `HttpMethod` (OpenAPI 3's `trace`), and `malformed_item` / `malformed_spec`
@@ -298,7 +298,12 @@ pick, so it is counted rather than guessed at. `external_ref` is the fifth, and 
 kind no parser produces: a `$ref` naming another file that the bundling pass could not
 read (`ref-bundler.ts`, issue #649) is counted **before** parse and stamped into
 `meta.skipped` by `parseImport`, one per reference - because each one is an operation that
-imported without the schema it declared.
+imported without the schema it declared. `duplicate_operation_id` is the sixth, and the only
+one where nothing is dropped from the request itself: an `operationId` a document declares
+twice is kept on the first operation and left off the second, whose recorded identity then
+rests on its method and templated path alone (issue #715). Counted per repeated declaration,
+because a sync follows the identity a request records, and which of the two kept the id is
+not something the user should have to work out from a diff.
 
 Supporting value types:
 - `KeyValueEntry`: `{ key, value, enabled, description? }` - duplicates and `enabled:false`

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -88,7 +88,7 @@ Built inline when a tag is first encountered.
 
 ### Request (per operation)
 
-Built by `buildSwaggerOp(method, path, op, spec, resolveRef, pathParams)`.
+Built by `buildSwaggerOp(method, path, op, spec, resolveRef, pathParams, tally, specOperation)`.
 
 | Swagger | Vayu `RequestDraft` | Notes |
 |---------|---------------------|-------|
@@ -104,6 +104,7 @@ Built by `buildSwaggerOp(method, path, op, spec, resolveRef, pathParams)`.
 | (none) | `auth` | always `{ mode: "inherit" }` - auth is configured once at the collection level |
 | (none) | `preRequestScript` / `postRequestScript` | always `""` |
 | `op.responses` | `examples` | via `buildSwaggerExamples` (see [Documented responses](#documented-responses)); **absent** when nothing was representable |
+| `op.operationId`, method, `path` | `specOperation` | the operation this request is, recorded for [sync](../openapi.md#checking-a-bound-spec-for-changes). Claimed through the shared `createOperationIdentifier`, so an `operationId` this document declares twice is kept on the first operation only and the second is identified by method and path - the rule and its reason are written out in [OpenAPI 3.0](./openapi-v3.md#operation-identity) |
 
 **Parameter resolution & merge.** `buildSwaggerOp` concatenates path-item-level `parameters` (passed in as `pathParams`) with operation-level `op.parameters`, resolving any `$ref` entries via `resolveRef`. Each parameter is keyed by `` `${in}:${name}` `` in a `Map` (`byKey`), so an operation-level parameter **overrides** a path-level one with the same `in`+`name` (later writes win). Entries missing `in` or `name` after resolution are skipped.
 
@@ -302,7 +303,7 @@ Dropped / not represented:
 - **Multi-tag grouping:** only the first tag groups an operation.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
 
-`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec` and `example_no_status` are the only kinds this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). Nothing to report still yields `[]`.
+`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec`, `example_no_status` and `duplicate_operation_id` are the only kinds this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). Nothing to report still yields `[]`.
 
 ## Differences from OpenAPI 3.0
 

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -119,7 +119,7 @@ Built by `makeTagCollection(spec, tag)`.
 
 ### Request (per operation)
 
-Built by `buildOperation(method, path, op, resolveRef, pathParams)`.
+Built by `buildOperation(method, path, op, resolveRef, pathParams, tally, specOperation)`. The identity is passed in rather than derived here - see [Operation identity](#operation-identity).
 
 | OpenAPI | Vayu `RequestDraft` | Notes |
 |---------|---------------------|-------|
@@ -133,6 +133,13 @@ Built by `buildOperation(method, path, op, resolveRef, pathParams)`.
 | `op.requestBody` | `body` | via `buildBody` (see [Request body](#request-body-generation)) |
 | (none) | `auth` | always `{ mode: "inherit" }` - auth is configured once at the collection level |
 | (none) | `preRequestScript` / `postRequestScript` | always `""` |
+| `op.operationId`, method, `path` | `specOperation` | the operation this request is, recorded for [sync](../openapi.md#checking-a-bound-spec-for-changes) - see [Operation identity](#operation-identity). Absent for a `paths` key that does not start with `/` |
+
+### Operation identity
+
+Every request records which operation it is - `{ operationId?, method, path }`, the templated path exactly as the document writes it (`/pets/{petId}`), never the `{{petId}}` rewrite that goes into the URL. `parse` claims one identity per operation through `createOperationIdentifier(tally)` (`openapi-shared.ts`) and hands that same value to both the request draft and the declared-operation index stored beside the document, so the requests and the coverage index cannot disagree about which operation is which.
+
+**A duplicated `operationId` is kept on its first declaration only** (issue #715). Declaring one id on two operations is invalid OpenAPI and common in generated specs, and stamping it on both requests is what let a later sync resolve the second request to the *first* operation - reporting it as renamed toward an operation it never was, and rewriting its method, URL and identity on an all-defaults apply. The second operation therefore imports identified by its method and path alone, which is what sync then follows it by, and each repeated declaration is counted as a `duplicate_operation_id` [`SkippedItem`](./README.md#draft-model-the-parser-output-contract) so the preview names the drop. First declaration wins because document order is stable across re-fetches of the same file. Nothing else is lost: the operation itself imports whole, and `op.operationId` still supplies the request name when there is no `summary`. A `paths` key that does not start with `/` records no identity at all - the engine refuses one.
 
 ### Parameter values & enabled state
 
@@ -257,6 +264,7 @@ Dropped / not represented:
 | `unsupported_method` | a path item carries a `trace` operation |
 | `malformed_spec` | a path item is not an object / its `$ref` does not resolve; or a `parameters` value is present but not an array |
 | `example_no_status` | a response key is not a three-digit status - `default`, or a `2XX` wildcard |
+| `duplicate_operation_id` | an `operationId` another operation in this document already declared (see [Operation identity](#operation-identity)) |
 
 An import with nothing to report still yields `skipped: []` - only non-zero kinds are emitted.
 

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -210,6 +210,17 @@ addition:
 - **Both changed at once** is reported as one operation gone and one arrived,
   because there is nothing left to follow, and a wrong identity is what would
   make a later apply rewrite the wrong request.
+- An **`operationId` that means two things is not followed at all**. Generated
+  documents sometimes declare one id on two operations, which is invalid
+  OpenAPI; those requests are followed by their method and path, and a request
+  whose endpoint the document no longer declares is reported as gone rather than
+  attached to the other operation that shares its id. An import keeps a repeated
+  id on the first operation only and says so in the preview, so a freshly
+  imported collection carries no ambiguous identity at all - one imported before
+  that rule has its identity repaired the first time a sync is applied.
+- A **path that still exists wins over an id that points elsewhere**: if the
+  document declares the request's own method and path, that is the operation it
+  is, whatever some other operation's `operationId` claims.
 
 ### What you edited is marked as yours
 


### PR DESCRIPTION
## Description

**Plan.** Root cause is that an `operationId` is treated as an identity even when it names two operations: `specOperationOf` stamped it verbatim on both requests at import, and `spec-diff`'s `lookup` returned the `byOperationId` hit unconditionally, never cross-checking the entry's method+path against the request's own stamp - so the request bound to the *second* declaration resolved to the *first* declaration's draft, reported as "renamed, followed by its operationId", and `renamed=true` carried it past the empty-fields skip in `defaultSelection`, letting an all-defaults apply rewrite its method, url and `specOperation`. The approach closes both halves: import claims one identity per operation through a new `createOperationIdentifier`, which keeps a repeated id on its first declaration and identifies later ones by method and path alone (disclosed as a skip count), and the diff stops following an id that means two things. The alternative I rejected was fixing the diff alone: it repairs the sync but leaves an ambiguous id in stored stamps and in the declared-operation index the engine resolves coverage by id-first, so the same ambiguity would keep arriving from every fresh import.

Verified the problem still exists at `825cb60` before touching anything - `spec-diff.ts:225-227` and the `specOperationOf` call sites are as the issue describes.

**Import (`openapi-shared.ts`, both parsers).** `createOperationIdentifier(tally)` wraps `specOperationOf` with the memory of every id already claimed in this document. First declaration keeps the id (document order is stable across re-fetches, so two syncs of an unchanged document agree about which request holds it); a later one imports with `{ method, path }` and each repeat is counted as a new `duplicate_operation_id` `SkippedItem`, which the import preview names. The operation itself still imports whole, and `op.operationId` still supplies the request name when there is no `summary`.

The claimed identity is now **passed into** `buildOperation` / `buildSwaggerOp` rather than derived a second time inside them - the two calls per operation were a hand-rolled second opinion that would have disagreed about which of two operations kept the id. `specOperationOf` is no longer exported, so a future parser cannot bypass the dedupe by reaching for it directly.

**Diff (`spec-diff.ts`).** `lookup` follows the id with two limits, both cases where following it pairs a request with an operation that contradicts what the request says it is:

- an id **more than one request in the collection claims** - the stamp an import before this fix left behind - identifies neither, so it is skipped entirely and both are followed by path;
- an id whose entry has a **different method + path shape** loses to an exact match on the request's own method + path. With no exact match the id is still followed: that is the ordinary rename the id-first rule exists for, and its test still passes unchanged.

**Deliberate deviation from the issue spec.** The issue asks the regression to assert request B's "method/url/**stamp** untouched". Its method and url are untouched; its stamp is *repaired* - the apply drops the ambiguous id and writes `{ method: "POST", path: "/b" }`, the identity the document now supports. That is the point of the import half rather than a gap: an old collection heals on the first applied sync instead of carrying an ambiguous id forever. The test asserts the repaired stamp explicitly.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **492 files, 5144 tests, all passing** (was 5137 before; 7 new). `pnpm type-check` and `pnpm lint` clean; `prettier --check` clean on every touched file (each was clean before). `python3 -m mkdocs build --strict -f .github/mkdocs.yml` succeeds with the new anchors and links.

No engine or other C++ code changed, so the engine build and ctest suite could not change colour and were not run. No pre-existing failures observed.

New tests, each mutation-checked (fix reverted, failure confirmed, restored):

| Test | Reverting what makes it fail |
|---|---|
| `spec-diff.test.ts` - "leaves the second request on its own operation when the first one changes" | either half of `lookup` |
| `spec-diff.test.ts` - "prefers the request's own endpoint over an id naming a different one" | the shape cross-check |
| `spec-diff.test.ts` - "reports a moved endpoint as gone rather than following the shared id" | the two-claimants refusal |
| `spec-apply.test.ts` - "writes nothing of the first operation onto the second request" | the pre-fix `lookup`; the payload's `method` flips to `GET` - the issue's exact corruption |
| `openapi-v3.test.ts` x3 - identity, declared-operation index, skip tally | the id drop in `createOperationIdentifier` |
| `openapi-v2.test.ts` - the same rule through the shared identifier | the same |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/openapi.md` (the sync's never-guessed rules gain the duplicate-id and exact-path-wins entries), `docs/app/import-collections/openapi-v3.md` (a new **Operation identity** section carrying the rule and its reason, the identity row in the request mapping table, the skip-kind table, the corrected `buildOperation` signature), `docs/app/import-collections/openapi-v2.md` (identity row pointing at that section, corrected signature, corrected "only kinds this parser can emit"), and `docs/app/import-collections/README.md` (the `SkippedItem` union and the sixth kind's rationale).

## Related Issues
Closes #715

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6DbztCqcvDvxoYXkZsGB5)_