### PR TITLE
fix(engine): refuse a data cell that would forge a header line

### DIFF
--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -161,6 +161,18 @@ Nothing else is escaped: a URL, a header, a form field and a plain-text body
 take the cell byte for byte - including a `text` body that happens to hold XML,
 because the mode you picked is what decides the rule.
 
+A **header** is the one of those with a limit. A header line ends at a line
+break, so a cell holding `ok` followed by a newline and `X-Admin: true` would
+not put that text in the header - it would end the header and send the rest as a
+header of its own, which is a request your file never described. There is no
+escape for a line break in a header, so the row is **refused**, naming the token
+and the row. It applies to a header name, a header value, and a credential that
+goes into a header line - a bearer token, or an api key sent in a header. Basic
+auth's username and password are base64-encoded and an api key sent in the query
+is percent-encoded, so a line break in either is harmless and binds as written.
+A JSON or JSONL file is where this turns up: those keep the cell as the string
+it is, while the CSV grammar has no way to carry a raw newline into one.
+
 ## How many iterations, and which row
 
 **One iteration per row** by default: leave Iterations empty and the row count

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -3360,6 +3360,19 @@ columns the row does have. Substituting an empty string would send a request
 quietly pointing somewhere else, which is the failure this namespace exists to
 remove.
 
+A cell carrying a **CR or LF bound into a header** errors the same way. A
+header line ends at CRLF, so a cell holding `ok\r\nX-Admin: true` does not put
+that text in the header - it ends the header and makes the remainder a header of
+its own, forged by the data file. There is no escape for a line break in a
+header the way there is for a quote in a JSON body, so the row is refused rather
+than encoded around, naming the token and the row. The rule covers a header
+name, a header value, and a credential written into a header line (a bearer
+token, an api key sent in a header); basic auth's pair and an api key sent in
+the query are base64- and percent-encoded before they reach the wire, so they
+bind unchanged. JSON and JSONL rows keep native strings - there is no CSV
+grammar to have stripped the newline - so this is an ordinary cell, not an
+exotic one.
+
 **Two headers that bind to one name** error the same way. `X-{{data.h}}`
 resolving to `authorization` beside a literal `Authorization`, or two templated
 names resolving alike, would leave the request carrying one of the two - so the

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1045,6 +1045,12 @@ scope - it cannot be read or written through `pm.variables` - and it is
 documented under
 [Scenario runs](api-reference.md#scenario-runs).
 
+The substitution is written for the place it lands in: a token inside a JSON or
+XML body is escaped for that document, and a cell carrying a line break bound
+into a **header** - a header name, a header value, or a credential written into
+a header line - is refused rather than allowed to end the header line and forge
+one of its own.
+
 ### It is read-only
 
 `set`, `unset` and `clear` are bound and **throw**. The rows are an input to the

--- a/engine/include/vayu/core/scenario_data.hpp
+++ b/engine/include/vayu/core/scenario_data.hpp
@@ -49,6 +49,17 @@
  * that produce it - a file whose row 3 collides sends two good requests and
  * then one quietly missing its auth.
  *
+ * A cell carrying a **CR or LF bound into a header** is the same failure once
+ * more, on the same field (issue #732). A header line ends at CRLF, so a cell
+ * holding `ok\r\nX-Admin: true` does not put that text in the header - it ends
+ * the header and makes the remainder a header of its own, which is a request
+ * the file's author never wrote. There is no escape for a line break in a
+ * header, so unlike a quote in a JSON body this cannot be encoded around: the
+ * bind errors. It covers a header name, a header value, and a credential
+ * `apply_auth` writes into a header line (a bearer token, an api key sent in a
+ * header) - not basic auth's pair or an api key sent in the query, whose bytes
+ * are base64- and percent-encoded before they reach the wire.
+ *
  * ## A value is written for the document it lands in
  *
  * Substitution is textual, so a value carrying a `"` used to end the JSON
@@ -211,7 +222,8 @@ struct StepDataTemplate {
  * from the plan step @p request was copied from), because a field is addressed
  * by its position in the walk.
  *
- * Fails for a column @p row does not carry, a column whose cell is `null`, two
+ * Fails for a column @p row does not carry, a column whose cell is `null`, a
+ * cell whose value would end the header line it is bound into, two
  * header names that bound to one name, and a token placed where an `xml` body
  * has no encoding that would keep the document meaning what it says - inside a
  * comment or a processing instruction. That last one fails for every row alike,
@@ -240,6 +252,12 @@ size_t row_index);
  * (base64 for basic auth, percent-encoding for an api key in the query) is
  * `apply_auth`'s to add *after* the bind - which is the whole point of binding
  * before the auth is applied.
+ *
+ * Verbatim is not unchecked: a credential `apply_auth` writes into a header
+ * line takes the header rule above, so a cell holding a CR or LF is refused
+ * there too. `walk_auth_credentials` says which credential that is, per
+ * `http::CredentialDestination`, because the destination is a property of the
+ * auth mode rather than of the string.
  *
  * Empty for the ordinary step, whose credentials carry no token and whose auth
  * is therefore resolved into the plan once, as it always was.

--- a/engine/include/vayu/http/auth_resolver.hpp
+++ b/engine/include/vayu/http/auth_resolver.hpp
@@ -10,6 +10,7 @@
 #include "vayu/db/database.hpp"
 #include "vayu/types.hpp"
 
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
@@ -58,6 +59,25 @@ UnsupportedAuth>;
 Auth parse_auth (const nlohmann::json& auth);
 
 /**
+ * @brief Where a credential ends up once `apply_auth` has written it.
+ *
+ * A bind rule can depend on this - a value written into a header line must not
+ * carry the CR or LF that would end the line (issue #732) - and this walk is
+ * the only place that knows which credential is which, because the destination
+ * is a property of the *mode* rather than of the string. Saying it here is what
+ * stops each caller from re-deriving it from the variant and drifting.
+ */
+enum class CredentialDestination : std::uint8_t {
+    /// Written into a header line as it stands: a bearer token, and both halves
+    /// of an api key sent in a header.
+    HeaderLine,
+    /// Encoded before it reaches the wire, so no byte of it can end a line or a
+    /// field: basic auth's pair (base64) and an api key sent as a query
+    /// parameter (percent-encoded).
+    Encoded,
+};
+
+/**
  * @brief Visit every credential string a parsed auth carries, in a fixed order.
  *
  * The fields a user types a secret into, and so the fields a `{{data.column}}`
@@ -67,6 +87,8 @@ Auth parse_auth (const nlohmann::json& auth);
  * here as well, through the same static_assert.
  *
  * `@p auth` may be `const`; the visitor then receives `const std::string&`.
+ * Each credential is visited with the @ref CredentialDestination it is headed
+ * for, so a caller whose rule depends on that reads it rather than deducing it.
  *
  * **OAuth 2.0 is deliberately absent.** Its config is not a credential the
  * request carries but the input to a token acquisition that happens once, when
@@ -81,13 +103,18 @@ void walk_auth_credentials (AuthRef& auth, Visit&& visit) {
         using T = std::decay_t<decltype (a)>;
 
         if constexpr (std::is_same_v<T, BearerAuth>) {
-            visit (a.token);
+            visit (a.token, CredentialDestination::HeaderLine);
         } else if constexpr (std::is_same_v<T, BasicAuth>) {
-            visit (a.username);
-            visit (a.password);
+            // Collapsed into one base64 `Authorization` value by `apply_auth`.
+            visit (a.username, CredentialDestination::Encoded);
+            visit (a.password, CredentialDestination::Encoded);
         } else if constexpr (std::is_same_v<T, ApiKeyAuth>) {
-            visit (a.key);
-            visit (a.value);
+            // Both halves go the same way: a header line, or a percent-encoded
+            // query parameter.
+            const CredentialDestination destination =
+            a.in_query ? CredentialDestination::Encoded : CredentialDestination::HeaderLine;
+            visit (a.key, destination);
+            visit (a.value, destination);
         } else if constexpr (std::is_same_v<T, NoAuth> || std::is_same_v<T, OAuth2Auth>) {
             // Nothing to bind: no credential at all, and an oauth2 config is
             // handled where it is refused rather than here.

--- a/engine/src/core/scenario_data.cpp
+++ b/engine/src/core/scenario_data.cpp
@@ -40,10 +40,15 @@ std::string token_for (const std::string& column) {
     return "{{" + std::string (vayu::http::DATA_NAMESPACE_PREFIX) + column + "}}";
 }
 
-/// What kind of text a visited field is, for the one rule that depends on it.
+/// What kind of text a visited field is, for the rules that depend on it.
 enum class FieldContext : std::uint8_t {
-    /// A URL, a header, a form field, a text body: no quoting rule of its own.
+    /// A URL, a form field, a text body: no quoting rule of its own.
     Plain,
+    /// A header name or value, or a credential `apply_auth` writes into a
+    /// header line. Plain text like @ref Plain - a header has no quoting rule -
+    /// except that a CR or LF in a bound value ends the line rather than
+    /// sitting in it, so the join refuses one (issue #732).
+    Header,
     /// A body whose text is a JSON document, so a token may land inside a
     /// string literal and has to be escaped when it does.
     JsonDocument,
@@ -124,8 +129,8 @@ std::optional<HeaderCollision> walk_bindable_fields (vayu::Request& request, Vis
         for (const auto& [name, value] : request.headers) {
             std::string bound_name  = name;
             std::string bound_value = value;
-            visit (bound_name, FieldContext::Plain);
-            visit (bound_value, FieldContext::Plain);
+            visit (bound_name, FieldContext::Header);
+            visit (bound_value, FieldContext::Header);
             // A plain `emplace` is first-wins and silent, and a dropped header
             // is exactly the quiet wrong request this namespace exists to
             // remove - worse than most, because the collision belongs to the
@@ -169,6 +174,41 @@ std::string describe_header_collision (const HeaderCollision& collision, size_t 
     "\", which another header of this request already resolves to - one of the "
     "two would be dropped, so the row is refused rather than sent with a "
     "header missing";
+}
+
+/// Which `FieldContext` a credential headed for @p destination binds under.
+FieldContext credential_context (vayu::http::CredentialDestination destination) {
+    return destination == vayu::http::CredentialDestination::HeaderLine ?
+    FieldContext::Header :
+    FieldContext::Plain;
+}
+
+/**
+ * The refusal a value that would end the header line it is bound into reads as.
+ *
+ * A header line is `Key: value` terminated by CRLF, so a cell carrying either
+ * byte does not sit in the header - it ends it, and whatever follows is read as
+ * a header of its own. JSON and JSONL rows reach the binder as native strings,
+ * with no CSV grammar to have stripped a newline on the way in, so this is an
+ * ordinary cell rather than an exotic one.
+ *
+ * A refusal rather than an encoding, for the reason an XML comment is one: a
+ * header value has no escape for a line break, so every candidate encoding
+ * either changes the value or leaves the line ended. Stripping the bytes would
+ * be the quiet wrong request this namespace exists to remove - the header would
+ * arrive holding something the file does not say.
+ */
+std::string describe_header_line_break (const std::string& column, size_t row_index) {
+    return token_for (column) + " is bound into a header, and data row " +
+    std::to_string (row_index) +
+    " has a line break in that column - a CR or LF ends the header line rather "
+    "than sitting in it, so the rest of the value would be read as headers of "
+    "its own; the row is refused rather than sent forging a header";
+}
+
+/// Whether @p value carries a byte that ends the header line it is written into.
+bool ends_a_header_line (std::string_view value) {
+    return value.find_first_of ("\r\n") != std::string_view::npos;
 }
 
 /**
@@ -595,7 +635,7 @@ class TemplateJoiner {
     : template_ (tmpl), row_ (row), row_index_ (row_index) {
     }
 
-    void operator() (std::string& field, FieldContext /*context*/) {
+    void operator() (std::string& field, FieldContext context) {
         const size_t position = next_field_++;
         // The templates are in ascending walk order, so one cursor finds them
         // all without searching - every field between two of them is untouched.
@@ -640,7 +680,18 @@ class TemplateJoiner {
                 std::to_string (row_index_) + " - a data token substitutes a value, and this row has none for it";
                 return;
             }
-            out += encode_data_value (*cell, entry.encodings[i]);
+            std::string encoded = encode_data_value (*cell, entry.encodings[i]);
+            // Checked on the encoded text rather than the cell, because that is
+            // what the field ends up holding - and only in a header, where a
+            // line break is a line terminator. Everywhere else the same bytes
+            // are ordinary content: a JSON body escapes them, and a URL, a form
+            // field or a text body carries them as the cell wrote them.
+            if (context == FieldContext::Header && ends_a_header_line (encoded)) {
+                result_.ok = false;
+                result_.error = describe_header_line_break (entry.columns[i], row_index_);
+                return;
+            }
+            out += encoded;
             out += entry.literals[i + 1];
         }
         field = std::move (out);
@@ -696,8 +747,9 @@ StepDataTemplate tokenize_data_fields (const vayu::Request& request) {
 
 StepDataTemplate tokenize_auth_fields (const vayu::http::Auth& auth) {
     FieldSplitter splitter;
-    vayu::http::walk_auth_credentials (auth, [&splitter] (const std::string& field) {
-        splitter (field, FieldContext::Plain);
+    vayu::http::walk_auth_credentials (auth,
+    [&splitter] (const std::string& field, vayu::http::CredentialDestination destination) {
+        splitter (field, credential_context (destination));
     });
     return splitter.take ();
 }
@@ -710,8 +762,14 @@ size_t row_index) {
         return DataBindResult{ true, {} };
     }
     TemplateJoiner joiner (tmpl, row, row_index);
+    // A bearer token and an api key sent in a header are header text, so a line
+    // break in the cell behind one forges a header exactly as it would in
+    // `request.headers` - the walk says which credential is which so this does
+    // not have to re-read the mode (issue #732).
     vayu::http::walk_auth_credentials (auth,
-    [&joiner] (std::string& field) { joiner (field, FieldContext::Plain); });
+    [&joiner] (std::string& field, vayu::http::CredentialDestination destination) {
+        joiner (field, credential_context (destination));
+    });
     return joiner.result ();
 }
 

--- a/engine/tests/scenario_data_test.cpp
+++ b/engine/tests/scenario_data_test.cpp
@@ -21,9 +21,11 @@
 #include <string>
 
 #include "vayu/core/scenario_data.hpp"
+#include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/jsonrpc_body.hpp"
 #include "vayu/http/request_composer.hpp"
 #include "vayu/types.hpp"
+#include "vayu/utils/encoding.hpp"
 
 using nlohmann::json;
 using vayu::core::bind_data_row;
@@ -209,6 +211,89 @@ TEST (ScenarioDataHeaderCollisionTest, HeadersThatStayDistinctStillBind) {
     EXPECT_EQ (request.headers.size (), 2u);
     EXPECT_EQ (request.headers.at ("X-Tenant"), "acme");
     EXPECT_EQ (request.headers.at ("X-Region"), "bound");
+}
+
+// ---------------------------------------------------------------------------
+// A cell that would end the header line it is bound into (issue #732)
+// ---------------------------------------------------------------------------
+
+TEST (ScenarioDataHeaderLineBreakTest, ACrlfCellBoundIntoAHeaderValueRefusesTheRow) {
+    // The failure the refusal exists for: a header line ends at CRLF, so this
+    // cell does not put its text in `X-Note` - it ends `X-Note` and makes
+    // `X-Admin: true` a header of its own, forged by a data file. Revert the
+    // Header-context check in the joiner and this reads `ok`, with
+    // `X-Note` holding the line break for libcurl to do as it likes with.
+    // JSONL rows keep native strings, so the cell is an ordinary one.
+    auto request              = request_with_url ("https://api.test/");
+    request.headers["X-Note"] = "{{data.note}}";
+
+    const auto result =
+    bind_data_row (request, json::parse (R"({"note":"ok\r\nX-Admin: true"})"), 4);
+
+    EXPECT_FALSE (result.ok);
+    // Enough to fix the file without guessing which column: the token, and the
+    // row it came from.
+    EXPECT_NE (result.error.find ("{{data.note}}"), std::string::npos) << result.error;
+    EXPECT_NE (result.error.find ("row 4"), std::string::npos) << result.error;
+}
+
+TEST (ScenarioDataHeaderLineBreakTest, ABareLineFeedIsRefusedToo) {
+    // Neither byte is the terminator on its own, and neither is safe: a lone LF
+    // ends the line for a lenient parser and a lone CR for another. The check
+    // is on both rather than on the CRLF pair.
+    auto request              = request_with_url ("https://api.test/");
+    request.headers["X-Note"] = "prefix {{data.note}}";
+    const auto lf = bind_data_row (request, json::parse (R"({"note":"a\nb"})"), 0);
+    EXPECT_FALSE (lf.ok) << lf.error;
+
+    auto with_cr              = request_with_url ("https://api.test/");
+    with_cr.headers["X-Note"] = "{{data.note}}";
+    const auto cr = bind_data_row (with_cr, json::parse (R"({"note":"a\rb"})"), 0);
+    EXPECT_FALSE (cr.ok) << cr.error;
+}
+
+TEST (ScenarioDataHeaderLineBreakTest, AHeaderNameIsCheckedAsWellAsItsValue) {
+    // Composition resolves header names too, so a name is as forgeable as a
+    // value - `X-a: x\r\nX-Admin: true` is one bound name away from the same
+    // request.
+    auto request                     = request_with_url ("https://api.test/");
+    request.headers["X-{{data.hn}}"] = "plain";
+
+    const auto result =
+    bind_data_row (request, json::parse (R"({"hn":"a: x\r\nX-Admin"})"), 0);
+
+    EXPECT_FALSE (result.ok);
+    EXPECT_NE (result.error.find ("{{data.hn}}"), std::string::npos) << result.error;
+}
+
+TEST (ScenarioDataHeaderLineBreakTest, TheSameCellIsFineEverywhereElse) {
+    // The refusal is a header rule, not a rule about the cell: the same bytes
+    // are ordinary content in a body and in a form field's value, where a JSON
+    // document escapes them and a text one carries them as written. Widen the
+    // check past the header context and this fails.
+    auto request         = request_with_url ("https://api.test/");
+    request.body.mode    = vayu::BodyMode::Json;
+    request.body.content = R"({"note":"{{data.note}}"})";
+    request.body.fields  = { { "note", "{{data.note}}", true } };
+
+    const auto result = bind_data_row (request, json::parse (R"({"note":"a\r\nb"})"), 0);
+
+    ASSERT_TRUE (result.ok) << result.error;
+    EXPECT_EQ (request.body.content, R"({"note":"a\r\nb"})");
+    ASSERT_EQ (request.body.fields.size (), 1u);
+    EXPECT_EQ (request.body.fields[0].value, "a\r\nb");
+}
+
+TEST (ScenarioDataHeaderLineBreakTest, AnOrdinaryHeaderCellStillBinds) {
+    // The refusal must not fire on a value that merely carries whitespace - a
+    // tab and a space are legal in a header value and always were.
+    auto request              = request_with_url ("https://api.test/");
+    request.headers["X-Note"] = "{{data.note}}";
+
+    const auto result = bind_data_row (request, json::parse (R"({"note":"a b\tc"})"), 0);
+
+    ASSERT_TRUE (result.ok) << result.error;
+    EXPECT_EQ (request.headers.at ("X-Note"), "a b\tc");
 }
 
 TEST (ScenarioDataBindTest, TheRawBodyAndEveryFormFieldBind) {
@@ -802,6 +887,81 @@ TEST (ScenarioDataTemplateTest, AnAbsentColumnFailsTheJoinAndNamesTheRow) {
     << bound.error;
     EXPECT_NE (bound.error.find ("row 7"), std::string::npos) << bound.error;
     EXPECT_NE (bound.error.find ("id"), std::string::npos) << bound.error;
+}
+
+// ---------------------------------------------------------------------------
+// The same header rule reaches the credentials `apply_auth` writes into a
+// header line (issue #732)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Bind @p row into @p auth's credentials and apply the result, as a step or a
+/// send-with-row does - the sequence `bind_auth_row` exists to own.
+vayu::core::DataBindResult
+bind_auth (vayu::Request& request, const json& auth, const json& row, size_t row_index) {
+    const auto parsed = vayu::http::parse_auth (auth);
+    return vayu::core::bind_auth_row (
+    request, parsed, vayu::core::tokenize_auth_fields (parsed), row, row_index);
+}
+
+} // namespace
+
+TEST (ScenarioDataAuthLineBreakTest, ABearerTokenCarryingALineBreakIsRefused) {
+    // `Authorization: Bearer <token>` is a header line like any other, so a
+    // credential is as forgeable as `request.headers` - and it is the field a
+    // credentials file most often binds. Revert the credential destinations to
+    // a flat `FieldContext::Plain` and this reads `ok`, with the forged header
+    // sitting inside Authorization.
+    auto request = request_with_url ("https://api.test/");
+
+    const auto result = bind_auth (request,
+    json::parse (R"({"mode":"bearer","token":"{{data.token}}"})"),
+    json::parse (R"({"token":"t\r\nX-Admin: true"})"), 2);
+
+    EXPECT_FALSE (result.ok);
+    EXPECT_NE (result.error.find ("{{data.token}}"), std::string::npos)
+    << result.error;
+    EXPECT_NE (result.error.find ("row 2"), std::string::npos) << result.error;
+    EXPECT_EQ (request.headers.count ("Authorization"), 0u)
+    << "a refused bind must not have applied the auth";
+}
+
+TEST (ScenarioDataAuthLineBreakTest, AnApiKeySentInAHeaderIsRefusedOnEitherHalf) {
+    for (const char* field : { "key", "value" }) {
+        auto request = request_with_url ("https://api.test/");
+        json auth = json::parse (R"({"mode":"apikey","key":"X-Key","value":"v"})");
+        auth[field] = "{{data.cell}}";
+
+        const auto result = bind_auth (
+        request, auth, json::parse (R"({"cell":"a\r\nX-Admin: true"})"), 0);
+
+        EXPECT_FALSE (result.ok) << "api key " << field << ": " << result.error;
+    }
+}
+
+TEST (ScenarioDataAuthLineBreakTest, BasicCredentialsAndAQueryApiKeyStillBind) {
+    // The refusal follows the destination, not the mode's name: basic's pair is
+    // base64-encoded and a query api key percent-encoded before either reaches
+    // the wire, so no byte of the cell can end a line and refusing one would be
+    // a row rejected for a request it could not have forged.
+    auto basic              = request_with_url ("https://api.test/");
+    const auto basic_result = bind_auth (basic,
+    json::parse (R"({"mode":"basic","username":"u","password":"{{data.pw}}"})"),
+    json::parse (R"({"pw":"p\r\nq"})"), 0);
+
+    ASSERT_TRUE (basic_result.ok) << basic_result.error;
+    EXPECT_EQ (basic.headers.at ("Authorization"),
+    "Basic " + vayu::utils::base64_encode (std::string ("u:p\r\nq")));
+
+    auto query              = request_with_url ("https://api.test/");
+    const auto query_result = bind_auth (query,
+    json::parse (R"({"mode":"apikey","in":"query","key":"k","value":"{{data.v}}"})"),
+    json::parse (R"({"v":"a\r\nb"})"), 0);
+
+    ASSERT_TRUE (query_result.ok) << query_result.error;
+    EXPECT_EQ (query.url, "https://api.test/?k=a%0D%0Ab");
+    EXPECT_TRUE (query.headers.empty ());
 }
 
 TEST (ScenarioDataScanTest, ThePrefixAloneIsNotSomethingToRefuse) {


### PR DESCRIPTION
## Description

**Plan.** Root cause is that a header is bound as plain text with no rule of its own: `walk_bindable_fields` visited header names and values with `FieldContext::Plain` → `Verbatim`, and the only bind-time refusal on that path was the two-names-collapse-to-one collision (#595). A JSON or JSONL cell holding `ok\r\nX-Admin: true` therefore did not sit in the header - it ended the header line and made the remainder a header of its own, with `header_value_reaches_wire` (`curl_utils.cpp:316-341`) filtering all-whitespace values only and everything else delegated to whatever the linked libcurl does with an embedded CRLF. The approach gives a header its own `FieldContext` and refuses a bound value carrying CR or LF, naming the column and the row - a refusal rather than an encoding for the same reason an XML comment is one: a header has no escape for a line break, so every candidate encoding either changes the value or leaves the line ended. The alternative I rejected was stripping the bytes (the issue offers it as an option): a header would then arrive holding something the file does not say, which is the quiet wrong request this namespace exists to remove, and it would diverge from the refusal shape #595 and #593/#618 established next to it.

Verified the problem still exists at `825cb60` before touching anything - `scenario_data.cpp:120-159` and the wire gate are as the issue describes.

**Blast radius.** Tracing who else turns a data cell into header text found one more path the issue does not name and the acceptance criterion does cover: `bind_auth_row` binds credentials *before* `apply_auth` encodes them, and `apply_auth` writes a bearer token into `Authorization: Bearer <token>` and a header-mode api key into `req.headers[key]` as they stand - so `{{data.token}}` forges a header exactly as `request.headers` would. Basic auth's pair (base64) and a query api key (percent-encoded) cannot, so refusing those would reject a row for a request it could not have sent.

Which credential is which is a property of the auth **mode**, not of the string, and `walk_auth_credentials` is the only place that knows it. Rather than have the binder re-derive it from the variant (a parallel array that a future mode would silently outgrow), the walk now visits each credential with the `http::CredentialDestination` it is headed for - `HeaderLine` or `Encoded` - and the binder maps that to its context. A new mode has to answer the question at the walk, where the existing `static_assert` already forces every mode to be handled.

**Deliberate scope note.** This closes the data-cell path the issue is about. The same forgery through a *composed* `{{variable}}` (an environment value carrying CRLF reaching a header) is a different origin with a different fix site - `build_request_header_list`, which today has no error channel and would have to drop rather than refuse - and a multipart form-field **name** reaches `curl_mime_name` under the same absence of a check. Both are filed as #738 rather than widened into this diff.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **1917 tests, 100% passing**, 251s. No pre-existing failures observed. (The cold build needed `vcpkg-fix-port` first, per CLAUDE.md's 403 note.)

No TypeScript changed, so the app suite could not change colour and was not run. `python3 -m mkdocs build --strict -f .github/mkdocs.yml` succeeds on the three touched docs.

Eight new tests, all mutation-checked by actually reverting the fix, rebuilding and re-running:

| Mutation | What fails |
|---|---|
| The joiner's `FieldContext::Header` check disabled | all 5 refusal tests (3 header, 2 credential); the 3 "still binds" guards keep passing |
| `credential_context` flattened to `Plain` | exactly the 2 credential tests; the header tests keep passing |

| Test | Asserts |
|---|---|
| `ACrlfCellBoundIntoAHeaderValueRefusesTheRow` | the issue's exact cell, refused, naming the token and row 4 |
| `ABareLineFeedIsRefusedToo` | a lone LF and a lone CR, not just the CRLF pair |
| `AHeaderNameIsCheckedAsWellAsItsValue` | a bound header *name* is as forgeable as a value |
| `TheSameCellIsFineEverywhereElse` | the same bytes still bind in a JSON body and a form field's value - the check is not widened |
| `AnOrdinaryHeaderCellStillBinds` | a space and a tab are still legal header text |
| `ABearerTokenCarryingALineBreakIsRefused` | the credential path, and that a refused bind applied no auth at all |
| `AnApiKeySentInAHeaderIsRefusedOnEitherHalf` | both halves of a header api key |
| `BasicCredentialsAndAQueryApiKeyStillBind` | base64 and percent-encoded destinations bind unchanged, byte for byte |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the refusal beside the collision rule it mirrors, in the scenario-run data section), `docs/app/data-driven-runs.md` (the header limit on the "nothing else is escaped" rule, including which credentials it covers and why JSON/JSONL is where it turns up), and `docs/engine/scripting.md` (one line where `{{data.column}}` is contrasted with `pm.iterationData`). The module header and `walk_auth_credentials`'s contract carry the rationale in `engine/`.

## Related Issues
Closes #732

Also covers item 1 of #733, which batches the same finding - that item can be struck there rather than implemented twice. Follow-up filed as #738 (the same forgery from a composed variable or a multipart field name).