### PR TITLE
fix(runs): resolve a run's spec binding through the collection chain

### DIFF
--- a/app/src/components/shared/ContractCoverage.test.tsx
+++ b/app/src/components/shared/ContractCoverage.test.tsx
@@ -110,6 +110,21 @@ describe("ContractCoverage", () => {
 		).toBeTruthy();
 	});
 
+	it("says whose contract it is when the binding came from a parent collection", () => {
+		// A tag sub-collection of an imported spec is measured against the whole
+		// document, so most of it is honestly uncovered - without this line the
+		// same numbers read as a catastrophe (issue #716).
+		render(<ContractCoverage coverage={coverage()} inheritedBinding />);
+		expect(screen.getByText(/contract is bound on a parent collection/)).toBeTruthy();
+	});
+
+	it("stays silent about the binding when the collection that ran carries it", () => {
+		// Absent is the engine's spelling of "nothing to disclose", and a line
+		// about parent collections on a whole-collection run would be noise.
+		render(<ContractCoverage coverage={coverage()} />);
+		expect(screen.queryByText(/parent collection/)).toBeNull();
+	});
+
 	it("reads as complete only when nothing is uncovered and nothing undeclared", () => {
 		render(
 			<ContractCoverage

--- a/app/src/components/shared/ContractCoverage.tsx
+++ b/app/src/components/shared/ContractCoverage.tsx
@@ -36,6 +36,17 @@ import type { RunCoverage, RunCoverageOperation } from "@/types/domain";
 
 export interface ContractCoverageProps {
 	coverage: RunCoverage | undefined;
+	/**
+	 * `metadata.openapi.inherited` - the contract belongs to an ancestor of the
+	 * collection that ran (issue #716).
+	 *
+	 * The numbers are unchanged by it; what changes is how they read. Running one
+	 * tag sub-collection of an imported spec is measured against the whole
+	 * document, so "4 / 618 operations" is the honest answer for a scoped run and
+	 * a catastrophe for a whole-collection one, and nothing else on this card
+	 * tells them apart.
+	 */
+	inheritedBinding?: boolean;
 	className?: string;
 }
 
@@ -45,7 +56,7 @@ function formatPct(value: number): string {
 	return `${Number.isInteger(value) ? value : value.toFixed(1)}%`;
 }
 
-export function ContractCoverage({ coverage, className }: ContractCoverageProps) {
+export function ContractCoverage({ coverage, inheritedBinding, className }: ContractCoverageProps) {
 	if (!coverage || coverage.operations.length === 0) return null;
 
 	const uncovered = coverage.operationsTotal - coverage.operationsCovered;
@@ -102,6 +113,15 @@ export function ContractCoverage({ coverage, className }: ContractCoverageProps)
 				 */}
 				<p className="mb-3 text-[11px] text-muted-foreground">
 					Counted on every send, not from the stored sample.
+					{/*
+					 * Beside "what these numbers are" rather than raised as a
+					 * warning: running one tag folder of an imported spec is an
+					 * ordinary thing to do, and the operations it leaves uncovered
+					 * are the truth about the contract rather than a fault to flag
+					 * (issue #716).
+					 */}
+					{inheritedBinding &&
+						" The contract is bound on a parent collection, so its operations outside this one count as uncovered."}
 				</p>
 				<ul className="space-y-1.5">
 					{coverage.operations.map((operation) => (

--- a/app/src/modules/history/main/ScenarioRunView.tsx
+++ b/app/src/modules/history/main/ScenarioRunView.tsx
@@ -221,7 +221,10 @@ export default function ScenarioRunView({ run }: ScenarioRunViewProps) {
 				    did this run exercise" is a whole-run answer, and a reader
 				    who has to scroll past forty step cards to reach it will not.
 				    Absent for a run of a collection bound to nothing. */}
-				<ContractCoverage coverage={report?.coverage} />
+				<ContractCoverage
+					coverage={report?.coverage}
+					inheritedBinding={report?.metadata?.openapi?.inherited}
+				/>
 
 				{/* And whether what came back honoured it - the same whole-run
 				    answer, so it sits under coverage here exactly as it does in

--- a/app/src/modules/history/main/components/OverviewTab.tsx
+++ b/app/src/modules/history/main/components/OverviewTab.tsx
@@ -50,7 +50,10 @@ export default function OverviewTab({ report, derived, anomalies }: TabProps) {
 			    Beside the verdict rather than below the charts, and for the same
 			    reason: a run can meet every budget while never calling four of
 			    eighteen operations. Absent for a run of an unbound collection. */}
-			<ContractCoverage coverage={report.coverage} />
+			<ContractCoverage
+				coverage={report.coverage}
+				inheritedBinding={report.metadata?.openapi?.inherited}
+			/>
 
 			{/* And whether what came back honoured that contract. Directly under
 			    coverage because the two answer halves of one question against the

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1577,6 +1577,30 @@ export interface RunReport {
 			/** Sent by the engine since 0.11.0; not rendered anywhere yet. */
 			maxRedirects?: number;
 		};
+		/**
+		 * The document this run was measured against (issue #637), echoed from
+		 * the snapshot its plan stamped - not what the collection binds today.
+		 *
+		 * Absent for a run of an unbound collection, and for a single-request
+		 * run: a run nobody measured against a contract is not a run measured
+		 * against nothing.
+		 */
+		openapi?: {
+			specId: string;
+			specHash: string;
+			/**
+			 * Whether the binding came from an **ancestor** of the collection
+			 * this run named (issue #716).
+			 *
+			 * An OpenAPI import binds the root and files every request under tag
+			 * sub-collections, so running one tag folder is measured against the
+			 * whole document - most of its operations honestly uncovered. Absent
+			 * means the run's own collection carries the binding and there is
+			 * nothing to disclose; {@link RunReport.coverage}'s block is the
+			 * reader, and prints one line when it is set.
+			 */
+			inherited?: boolean;
+		};
 	};
 	summary: {
 		totalRequests: number;

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -430,11 +430,24 @@ stamped on the run - not whatever the collection is bound to now. Sync the
 binding to a newer spec and an older run's report still says what that run
 actually covered.
 
+**Which collection's binding that is** follows the same rule a single Send does:
+the nearest bound collection walking from the one that ran up to the root. An
+import binds the root and files every request under its tag sub-collections, so
+running the `pets` folder is measured against the whole document - it is not an
+unbound run, and it was never meant to be one.
+
+That makes a scoped run's coverage **partial on purpose**: the run enumerates one
+folder, the contract is the whole API, and the operations under every other tag
+are honestly uncovered. The block says so in a line of its own when the contract
+came from a parent collection, so `4 / 618 operations` reads as the scope of the
+run rather than an API nobody is calling.
+
 ### When there is no coverage block
 
 Absent, never zeros, in each of these cases:
 
-- The collection is not bound to a document.
+- The collection is not bound to a document, and neither is any collection
+  above it.
 - The run was a single request rather than a collection run.
 - The bound document has **no operation index** - it was stored before this
   existed. Re-bind or sync the collection and its next run reports coverage.
@@ -568,7 +581,8 @@ figures it explains.
 
 Absent, never zeros, in each of these cases:
 
-- The collection is not bound to a document.
+- The collection is not bound to a document, and neither is any collection
+  above it.
 - The run was a single request rather than a collection run.
 - The bound document carries **no response schemas** - it was stored before this
   existed, or declares none. Re-bind or sync the collection.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4406,6 +4406,18 @@ has to say what the run was measured against, and the binding is free to have
 moved since. An unbound run carries **no `openapi` key at all** - absent rather
 than an empty object, so "not measured against a spec" has one spelling.
 
+The binding is resolved by walking from the run's collection up to the root and
+taking the **nearest bound ancestor**, the same walk a single request's
+design-mode validation uses (issue #716). An import binds the root and files
+every request under tag sub-collections, so running one tag folder is measured
+against the document its root binds. When the binding came from an ancestor
+rather than from the collection the run named, the node carries
+`"inherited": true` - absent otherwise, like every other finding here. The run
+still enumerates only its own subtree, so the coverage below is **partial by
+construction**: most of the contract's operations are honestly uncovered, and
+that flag is what lets a reader tell scoped-run truth from a collection that has
+stopped calling its API.
+
 **`coverage`** says which of that spec's operations the run exercised and which
 of their declared responses it saw (issue #629). It is present only for a
 scenario run - design or load - of a collection bound to a document that carries

--- a/engine/include/vayu/core/scenario_plan.hpp
+++ b/engine/include/vayu/core/scenario_plan.hpp
@@ -140,6 +140,22 @@ struct SpecBinding {
     std::string spec_id;
     std::string spec_hash;
     /**
+     * Whether the binding came from an **ancestor** of the collection this run
+     * names, rather than from that collection itself (issue #716).
+     *
+     * Stamped into the manifest, and through it into `metadata.openapi`, because
+     * it changes what the coverage numbers beside it mean. An import binds the
+     * root and files requests under tag sub-collections, so running one tag
+     * folder is measured against the *whole* document: most of its operations
+     * are honestly uncovered, and "4 of 618 covered" reads as a catastrophe
+     * unless the report says the contract is the ancestor's. The reader is the
+     * app's coverage block, which prints one line when this is set.
+     *
+     * False for an unbound run as well as for a collection carrying its own
+     * binding - neither has anything to disclose.
+     */
+    bool inherited = false;
+    /**
      * The bound document's declared operations, read once here (issue #629).
      *
      * Read at resolution rather than at run end for the reason the whole plan

--- a/engine/include/vayu/core/spec_binding.hpp
+++ b/engine/include/vayu/core/spec_binding.hpp
@@ -11,6 +11,8 @@
 #include <optional>
 #include <string>
 
+#include "vayu/db/database.hpp"
+
 /**
  * @file spec_binding.hpp
  * @brief Completing a collection's `openapi` binding (issue #709).
@@ -69,5 +71,46 @@ struct SpecStamp {
  */
 [[nodiscard]] std::optional<std::string> stamp_spec_binding (const std::string& openapi,
 const std::function<std::optional<SpecStamp> (const std::string& spec_id)>& stamp_of);
+
+/** Which collection answers for a request's contract, and what it binds. */
+struct BoundSpec {
+    /**
+     * The collection the binding was found on - the run's own collection, or an
+     * ancestor of it.
+     *
+     * Carried rather than dropped because it is the difference between "this
+     * collection covers 4 of 618 operations" and the same sentence read as a
+     * catastrophe: a run of one tag sub-collection is measured against the
+     * whole document its root binds, and the reader has to be told that is what
+     * happened (issue #716).
+     */
+    std::string collection_id;
+    std::string spec_id;
+    /// `""` for a binding that names no version - see `stamp_spec_binding`.
+    std::string spec_hash;
+};
+
+/**
+ * The binding that answers for @p collection_id: the nearest bound collection
+ * walking from it up to the root, or `std::nullopt` when nothing in its
+ * ancestry binds a document.
+ *
+ * **One walk, because the two callers must agree.** An OpenAPI import binds the
+ * ROOT and files every request under tag sub-collections, so a request's own
+ * collection almost never carries the binding. Design-mode validation resolved
+ * that by walking the chain while scenario resolution read only the named
+ * collection's own column, and the two disagreed about what "bound" means -
+ * running the `pets` tag folder measured no coverage and validated nothing,
+ * silently (issue #716). Nearest ancestor wins, so a sub-collection that binds a
+ * document of its own answers for its own requests rather than the root's
+ * document answering for everything.
+ *
+ * An unparseable or non-object `openapi` column binds nothing and the walk
+ * continues past it, the reading every other reader of that column gives it. The
+ * chain is cycle-guarded by `collection_chain`, so corrupted `parent_id` data
+ * terminates instead of looping under the DB mutex.
+ */
+[[nodiscard]] std::optional<BoundSpec>
+nearest_spec_binding (vayu::db::Database& db, const std::string& collection_id);
 
 } // namespace vayu::core

--- a/engine/src/core/scenario_plan.cpp
+++ b/engine/src/core/scenario_plan.cpp
@@ -16,6 +16,7 @@
 #include <variant>
 
 #include "vayu/core/scenario_data.hpp"
+#include "vayu/core/spec_binding.hpp"
 #include "vayu/http/auth_resolver.hpp"
 #include "vayu/http/request_builder.hpp"
 #include "vayu/http/request_composer.hpp"
@@ -295,19 +296,19 @@ const ScenarioResolveOptions& options) {
 
     // The spec this run is measured against, read once here and stamped into the
     // snapshot by `build_scenario_manifest` (issue #637). Read from the
-    // collection rather than looked up in `spec_documents`: the hash *stored on
+    // collection chain rather than looked up in `spec_documents`: the hash *on
     // the binding* is what the collection was last synced to, and that - not
     // whatever the document says today - is what the run was planned against.
-    // An unparseable blob binds nothing, the same reading every other reader of
-    // this column gives it.
-    try {
-        const auto binding = nlohmann::json::parse (collection->openapi);
-        if (binding.is_object ()) {
-            resolution.spec.spec_id   = binding.value ("specId", std::string ());
-            resolution.spec.spec_hash = binding.value ("specHash", std::string ());
-        }
-    } catch (const std::exception&) {
-        // Leaves the binding unbound; a malformed column must not fail a run.
+    //
+    // Resolved through `nearest_spec_binding`, the same walk design-mode
+    // validation uses, because an import binds the root and files every request
+    // under tag sub-collections: reading only the named collection's own column
+    // left the natural "run this tag folder" measuring nothing at all, silently
+    // (issue #716).
+    if (const auto bound = nearest_spec_binding (db, request.collection_id)) {
+        resolution.spec.spec_id   = bound->spec_id;
+        resolution.spec.spec_hash = bound->spec_hash;
+        resolution.spec.inherited = bound->collection_id != request.collection_id;
     }
 
     // The document's declared operations, read once here so contract coverage
@@ -518,6 +519,11 @@ const SpecBinding& spec) {
     if (spec.bound ()) {
         manifest["openapi"] =
         nlohmann::json{ { "specId", spec.spec_id }, { "specHash", spec.spec_hash } };
+        // Carried only when it happened, like every other finding in the report:
+        // absent means the run's own collection binds the document (issue #716).
+        if (spec.inherited) {
+            manifest["openapi"]["inherited"] = true;
+        }
     }
     return manifest;
 }

--- a/engine/src/core/spec_binding.cpp
+++ b/engine/src/core/spec_binding.cpp
@@ -9,6 +9,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "vayu/http/request_composer.hpp"
+
 namespace vayu::core {
 
 std::optional<std::string> stamp_spec_binding (const std::string& openapi,
@@ -47,6 +49,39 @@ const std::function<std::optional<SpecStamp> (const std::string& spec_id)>& stam
         binding["syncedAt"] = stamp->synced_at;
     }
     return binding.dump ();
+}
+
+namespace {
+
+/// A binding field, or `""` for one that is absent or not a string. Typed
+/// rather than `value()`d because a column edited from outside the engine can
+/// hold anything, and `value()` throws on a type it did not expect.
+std::string string_field (const nlohmann::json& binding, const char* key) {
+    const auto field = binding.find (key);
+    return field != binding.end () && field->is_string () ?
+    field->get<std::string> () :
+    std::string ();
+}
+
+} // namespace
+
+std::optional<BoundSpec>
+nearest_spec_binding (vayu::db::Database& db, const std::string& collection_id) {
+    const auto chain = vayu::http::collection_chain (db, collection_id);
+    // Root-first, so walking backwards finds the *nearest* bound ancestor.
+    for (auto it = chain.rbegin (); it != chain.rend (); ++it) {
+        const nlohmann::json binding =
+        nlohmann::json::parse (it->openapi, nullptr, /*allow_exceptions=*/false);
+        if (!binding.is_object ()) {
+            continue; // an unparseable column binds nothing, as everywhere else
+        }
+        auto spec_id = string_field (binding, "specId");
+        if (spec_id.empty ()) {
+            continue;
+        }
+        return BoundSpec{ it->id, std::move (spec_id), string_field (binding, "specHash") };
+    }
+    return std::nullopt;
 }
 
 } // namespace vayu::core

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -25,7 +25,6 @@
 #include "vayu/core/constants.hpp"
 #include "vayu/core/schema_validation.hpp"
 #include "vayu/core/spec_binding.hpp"
-#include "vayu/http/request_composer.hpp"
 #include "vayu/core/spec_coverage.hpp"
 #include "vayu/http/routes.hpp"
 #include "vayu/utils/encoding.hpp"
@@ -115,8 +114,9 @@ read_spec_indexes (const nlohmann::json& item, vayu::db::SpecDocument& spec, siz
  *
  * The binding lives on the collection an import created, and requests live in
  * its *tag sub-collections*, so this walks the ancestry and takes the nearest
- * bound collection - the same chain `POST /compose` walks for inherited auth,
- * through the same helper, cycle guard included. A request whose ancestry binds
+ * bound collection - `core::nearest_spec_binding`, over the same chain
+ * `POST /compose` walks for inherited auth, cycle guard included, and the same
+ * function a scenario run resolves through. A request whose ancestry binds
  * nothing is not part of a contract: `bound` stays false and the caller writes
  * **no verdict at all**, which is the distinction the whole node rests on - a
  * response that was never judged against a contract did not fail one.
@@ -138,31 +138,16 @@ const std::optional<std::string>& request_id) {
     }
     resolved.spec_operation = request->spec_operation.value_or (std::string ());
 
-    std::string spec_id;
-    std::string spec_hash;
-    const auto chain = vayu::http::collection_chain (db, request->collection_id);
-    // Root-first, so walking backwards finds the *nearest* bound ancestor: a
-    // sub-collection that binds a document of its own answers for its own
-    // requests rather than the root's document answering for everything.
-    for (auto it = chain.rbegin (); it != chain.rend (); ++it) {
-        try {
-            const auto binding = nlohmann::json::parse (it->openapi);
-            if (!binding.is_object ()) {
-                continue;
-            }
-            const auto id = binding.value ("specId", std::string ());
-            if (!id.empty ()) {
-                spec_id   = id;
-                spec_hash = binding.value ("specHash", std::string ());
-                break;
-            }
-        } catch (const std::exception&) {
-            continue; // an unparseable column binds nothing, as everywhere else
-        }
-    }
-    if (spec_id.empty ()) {
+    // The same walk `resolve_scenario` uses, through the same function: the two
+    // paths disagreeing about what "bound" means is what left a tag
+    // sub-collection's run measuring nothing while a Send of the same request
+    // was checked (issue #716).
+    const auto bound = vayu::core::nearest_spec_binding (db, request->collection_id);
+    if (!bound) {
         return resolved;
     }
+    const std::string& spec_id   = bound->spec_id;
+    const std::string& spec_hash = bound->spec_hash;
 
     resolved.bound = true;
     const auto document = db.get_spec_document (spec_id);

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -36,6 +36,9 @@
 #include "vayu/core/scenario_plan.hpp"
 #include "vayu/core/schema_validation.hpp"
 #include "vayu/db/database.hpp"
+// For `resolve_design_schema_index` - the design path this file now pins
+// against the scenario path (issue #716).
+#include "vayu/http/routes.hpp"
 #include "vayu/utils/json.hpp"
 
 using nlohmann::json;
@@ -847,6 +850,157 @@ TEST_F (SpecsRouteTest, ABindingWhoseHashHasMovedIsNotMeasuredRatherThanMismeasu
     execution.plan = resolved.plan;
     execution.spec = resolved.spec;
     EXPECT_FALSE (vayu::core::make_coverage_tally (execution).active ());
+}
+
+// ---------------------------------------------------------------------------
+// The ancestor walk (issue #716) - one answer for both paths
+// ---------------------------------------------------------------------------
+
+/**
+ * The shape an OpenAPI import actually produces: the ROOT binds the document and
+ * every request lives under a tag sub-collection that binds nothing. Returns the
+ * tag sub-collection's id, the one a user right-clicks to run.
+ */
+std::string bind_root_with_tag_child (vayu::db::Database& db,
+const std::string& spec_id,
+const std::string& hash,
+std::string* root_out = nullptr) {
+    auto [root_status, root] = routes::create_collection_response (db,
+    json{ { "name", "Pets API" },
+    { "openapi", { { "specId", spec_id }, { "specHash", hash } } } });
+    EXPECT_EQ (root_status, 200) << root.dump ();
+    const std::string root_id = root.value ("id", std::string{});
+    if (root_out != nullptr) {
+        *root_out = root_id;
+    }
+    auto [tag_status, tag] = routes::create_collection_response (db,
+    json{ { "name", "pets" }, { "parentId", root_id } });
+    EXPECT_EQ (tag_status, 200) << tag.dump ();
+    return tag.value ("id", std::string{});
+}
+
+TEST_F (SpecsRouteTest, ATagSubCollectionRunIsMeasuredAgainstTheRootsContract) {
+    // The whole of the reported bug: the binding is on the root an import
+    // created, the requests are one level down, and running that tag folder used
+    // to resolve `{}` - no coverage, no schema validation, and an absent block
+    // is indistinguishable from "never bound".
+    const json operations =
+    json::array ({ json{ { "operationId", "listPets" }, { "method", "GET" },
+    { "path", "/pets" }, { "responses", json::array ({ "200" }) } } });
+    const json response_schemas = { { "refRoots", json::object () },
+        { "operations",
+        json::array ({ json{ { "method", "GET" }, { "path", "/pets" },
+        { "responses",
+        json::array ({ json{ { "status", "200" }, { "contentType", "application/json" },
+        { "schema", json{ { "type", "array" } } } } }) } } }) } };
+    auto [status, stored] = routes::create_spec_document_response (*db_,
+    json{ { "content", PETSTORE }, { "operations", operations },
+    { "responseSchemas", response_schemas } });
+    ASSERT_EQ (status, 200) << stored.dump ();
+    const std::string spec_id = stored.value ("id", std::string{});
+    const std::string hash    = routes::spec_content_hash (PETSTORE);
+
+    const std::string tag_id = bind_root_with_tag_child (*db_, spec_id, hash);
+    create_request (tag_id,
+    json{ { "specOperation",
+    { { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" } } } });
+
+    auto resolved = resolve (tag_id);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    ASSERT_TRUE (resolved.spec.bound ()) << "the root's binding answers for its subtree";
+    EXPECT_EQ (resolved.spec.spec_id, spec_id);
+    EXPECT_EQ (resolved.spec.spec_hash, hash);
+    EXPECT_FALSE (resolved.spec.schema_reason.has_value ())
+    << "measurable, not a binding to explain away";
+    EXPECT_EQ (resolved.spec.declared_operations.size (), 1u)
+    << "no declared operations means no coverage block on this run";
+    EXPECT_FALSE (resolved.spec.response_schemas.empty ())
+    << "no schema index means no response of this run was ever validated";
+
+    vayu::core::ScenarioExecution execution;
+    execution.plan = resolved.plan;
+    execution.spec = resolved.spec;
+    EXPECT_TRUE (vayu::core::make_coverage_tally (execution).active ())
+    << "an inactive tally is how the coverage section goes missing";
+
+    // And the run says whose contract it was measured against, because most of
+    // those 618 operations being uncovered is scoped-run truth, not catastrophe.
+    const json manifest = vayu::core::build_scenario_manifest (resolved.request,
+    resolved.plan, resolved.spec);
+    ASSERT_TRUE (manifest.contains ("openapi")) << manifest.dump ();
+    EXPECT_EQ (manifest["openapi"]["specId"].get<std::string> (), spec_id);
+    EXPECT_TRUE (manifest["openapi"].value ("inherited", false)) << manifest.dump ();
+}
+
+TEST_F (SpecsRouteTest, ACollectionCarryingItsOwnBindingDisclosesNothingToDisclose) {
+    const std::string spec_id = store_spec ();
+    const std::string col_id  = create_collection (json{ { "name", "Pets" },
+    { "openapi", { { "specId", spec_id },
+    { "specHash", routes::spec_content_hash (PETSTORE) } } } });
+    create_request (col_id);
+
+    auto resolved = resolve (col_id);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_FALSE (resolved.spec.inherited);
+    const json manifest = vayu::core::build_scenario_manifest (resolved.request,
+    resolved.plan, resolved.spec);
+    // Absent rather than `false`, the rule every other finding in the report
+    // follows: carried only where it happened.
+    EXPECT_FALSE (manifest["openapi"].contains ("inherited")) << manifest.dump ();
+}
+
+TEST_F (SpecsRouteTest, TheDesignPathAndTheScenarioPathResolveOneBinding) {
+    // Both walks must answer "the nearest bound ancestor", so a fixture where
+    // the nearest and the root disagree tells them apart. The nearer binding is
+    // deliberately stale: picking the root instead would resolve *cleanly*, so
+    // an agreeing pair of "unmeasurable" verdicts can only come from both paths
+    // having chosen the same - nearer - binding.
+    const json operations =
+    json::array ({ json{ { "operationId", "listPets" }, { "method", "GET" },
+    { "path", "/pets" }, { "responses", json::array ({ "200" }) } } });
+    auto [status, stored] = routes::create_spec_document_response (*db_,
+    json{ { "content", PETSTORE }, { "operations", operations } });
+    ASSERT_EQ (status, 200) << stored.dump ();
+    const std::string root_spec = stored.value ("id", std::string{});
+
+    constexpr const char* OTHER =
+    R"({"openapi":"3.1.0","info":{"title":"Store","version":"1.0.0"},"paths":{}})";
+    const std::string nearer_spec = store_spec (OTHER);
+
+    std::string root_id;
+    const std::string tag_id = bind_root_with_tag_child (
+    *db_, root_spec, routes::spec_content_hash (PETSTORE), &root_id);
+    auto [bind_status, bound] = routes::update_collection_response (*db_, tag_id,
+    json{ { "openapi",
+    { { "specId", nearer_spec }, { "specHash", "a-hash-this-document-never-had" } } } });
+    ASSERT_EQ (bind_status, 200) << bound.dump ();
+    // One level deeper again, so neither path is answering from the collection
+    // the binding sits on.
+    auto [leaf_status, leaf] = routes::create_collection_response (*db_,
+    json{ { "name", "pets/{petId}" }, { "parentId", tag_id } });
+    ASSERT_EQ (leaf_status, 200) << leaf.dump ();
+    const std::string leaf_id = leaf.value ("id", std::string{});
+    const std::string req_id  = create_request (leaf_id,
+    json{ { "specOperation",
+    { { "operationId", "listPets" }, { "method", "GET" }, { "path", "/pets" } } } });
+
+    auto resolved = resolve (leaf_id);
+    ASSERT_TRUE (resolved.ok) << resolved.error;
+    EXPECT_EQ (resolved.spec.spec_id, nearer_spec)
+    << "nearest bound ancestor wins";
+    ASSERT_TRUE (resolved.spec.schema_reason.has_value ());
+    EXPECT_EQ (*resolved.spec.schema_reason, vayu::core::UncheckedReason::HashMismatch);
+    EXPECT_TRUE (resolved.spec.declared_operations.empty ())
+    << "the root's operations would mean the scenario walk took the wrong "
+       "binding";
+
+    const auto design = routes::resolve_design_schema_index (*db_, req_id);
+    EXPECT_TRUE (design.bound);
+    ASSERT_TRUE (design.reason.has_value ())
+    << "a clean index here means the design walk took the root's binding";
+    EXPECT_EQ (*design.reason, *resolved.spec.schema_reason)
+    << "the two paths must resolve one binding, or a Send and a run of the same "
+       "request disagree about what it is measured against";
 }
 
 TEST_F (SpecsRouteTest, ADocumentStoredWithoutAnIndexReportsNoCoverageRatherThanZero) {


### PR DESCRIPTION
## Description

**Plan.** Root cause is two copies of one question. `resolve_scenario` read the `openapi` column of only the collection the run named (`scenario_plan.cpp:303-311`), while design-mode validation of the same request walked the ancestry to the nearest bound collection (`specs.cpp:141-162`, via `collection_chain`) - and an OpenAPI import binds the ROOT and files every request under tag sub-collections, so right-clicking the `pets` folder and running it resolved `{}`: no `metadata.openapi`, no coverage block, no `schemaValidation`, silently, while a single Send of the very same request **was** checked. The approach deletes the duplication rather than keeping the two walks in step: both paths now resolve through one function, `core::nearest_spec_binding`, over the chain `POST /compose` already walks for inherited auth, cycle guard included. The alternative I rejected was fixing `resolve_scenario` with a walk of its own - it repairs this report and leaves the same two-copies shape that produced it, which the next field added to a binding would break again in exactly this way.

Verified the problem still exists at `825cb60` before touching anything - both anchors are as the issue describes.

**Blast radius.** `nearest_spec_binding`'s callers are the two above; nothing else parses `collections.openapi` to answer "what is this run measured against" (`db/database.cpp` and the write cores read it for other reasons and are untouched). Downstream of `resolve_scenario`, everything flows from `resolution.spec` - `make_coverage_tally`, the deferred load-mode validation pass, the collection runner's per-step verdicts - so all three engage on the fixed path with no change of their own. The manifest node reaches the report through `runs.cpp:929`'s verbatim echo, so no route change either.

**The disclosure decision (acceptance criterion 3).** A scoped run is now measured against the whole document while enumerating one subtree - partial coverage *by construction*, which is what running one tag folder means. So `SpecBinding` carries `inherited`, the manifest stamps `"inherited": true` on the `openapi` node when the binding came from an ancestor, `metadata.openapi` echoes it, and the app's coverage block prints one line from it. Carried only when it happened, like every other finding in the report. It has a reader on purpose: a field with none is this repo's most repeated defect, and without the line `4 / 618 operations` reads as an API nobody is calling rather than as the scope of the run.

Robustness note: the shared walk reads binding fields **typed** rather than through `json::value()`, which throws on a type it did not expect - a column edited from outside the engine can hold `{"specHash": 7}`, and the old design-path copy survived that only by catching the exception.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **1912 tests, 100% passing**, 349s (was 1909; 3 new). `cd app && pnpm test` - **492 files, 5138 tests, all passing** (2 new). `pnpm type-check` and `pnpm lint` clean; `prettier --check` clean on every touched app file (each was clean before, and only those two were formatted). `python3 -m mkdocs build --strict -f .github/mkdocs.yml` succeeds. No pre-existing failures observed.

Five new tests, each mutation-checked by reverting the fix, rebuilding and re-running:

| Mutation | What fails |
|---|---|
| `resolve_scenario` accepts the binding only when it sits on the run's own collection (the pre-fix read) | `ATagSubCollectionRunIsMeasuredAgainstTheRootsContract`, `TheDesignPathAndTheScenarioPathResolveOneBinding`; the own-binding guard keeps passing |
| The `inherited` stamp dropped from the manifest | exactly `ATagSubCollectionRunIsMeasuredAgainstTheRootsContract`'s disclosure assertion |
| `inheritedBinding` never rendered (app) | exactly `says whose contract it is when the binding came from a parent collection` |

| Test | Asserts |
|---|---|
| `specs_route_test` - `ATagSubCollectionRunIsMeasuredAgainstTheRootsContract` | the reported bug: root binds, request one level down, run the child - `specId`/`specHash` are the root's, `declared_operations` and `response_schemas` are present, the coverage tally is **active**, and the manifest discloses `inherited` |
| `specs_route_test` - `TheDesignPathAndTheScenarioPathResolveOneBinding` | parity on one fixture: a *stale* nearer binding under a clean root, request two levels down - picking the root would resolve cleanly, so both paths agreeing on `HashMismatch` can only mean they chose the same nearest binding |
| `specs_route_test` - `ACollectionCarryingItsOwnBindingDisclosesNothingToDisclose` | `inherited` absent, not `false`, for an ordinary whole-collection run |
| `ContractCoverage.test.tsx` x2 | the line renders when the contract came from a parent, and is silent otherwise |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (`metadata.openapi` gains the nearest-bound-ancestor rule, the `inherited` key, and why the coverage below it is partial by construction) and `docs/app/openapi.md` ("Which document a run is measured against" gains which *collection's* binding that is and what a scoped run's numbers mean; both "when there is no block" lists now say "and neither is any collection above it", which was the silently wrong half).

## Related Issues
Closes #716

---
_Generated by [Claude Code](https://claude.ai/code/session_0187kSczLjrrfdQDdRdpw3Jg)_