### PR TITLE
fix(engine): store a buffered send's script results on its trace

### DIFF
--- a/app/src/modules/request-builder/utils/restore-response.ts
+++ b/app/src/modules/request-builder/utils/restore-response.ts
@@ -95,13 +95,17 @@ export function eventsFromTrace(
 
 /**
  * The stored `scripts` node, as the response pane's four script fields
- * (issue #575).
+ * (issue #575, extended to every design send by #725).
  *
- * Only a **streaming** design run's trace carries it, and for a reason worth
- * knowing here: that send was answered `202` before its post-request script had
- * run, so the trace is the only route its test results ever take. A buffered
- * send's results arrive in the `/execute` body and are not stored, which is why
- * an ordinary restored run still shows no Tests pane.
+ * Both transports write it. A streaming send has no choice - it was answered
+ * `202` before its post-request script had run, so the trace is the only route
+ * its results ever take - and a buffered send stores the same object it also
+ * returns in the `/execute` body. Until #725 it stored nothing, so a restored
+ * ordinary send showed the Tests pane's empty state whether its assertions had
+ * passed or never run.
+ *
+ * A trace written before that fix carries no node, which is why an absent one
+ * is read as "no results" rather than as a failure.
  *
  * The keys are the engine's own (`build_script_result_node`), identical to the
  * live body's, so nothing is renamed on the way through - a rename here would

--- a/app/src/modules/request-builder/utils/script-funnels.test.ts
+++ b/app/src/modules/request-builder/utils/script-funnels.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache License, Version 2.0
+ * found in the LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Both response funnels carry the script results (issue #725).
+ *
+ * The restore funnel already read the stored `scripts` node, but only a
+ * *streaming* send ever wrote one - so an ordinary send's restored Tests pane
+ * showed its empty state whether the assertions had passed or never run. The
+ * engine now stores the same object it returns on every design send, and these
+ * are the tests that redden if either side stops carrying it: delete the
+ * `scriptsFromTrace` spread from `responseFromRunResult` and the restore and
+ * parity cases fail.
+ *
+ * The sibling of `validation-funnels.test.ts`, for the same reason that file
+ * exists: `execute-mapping.ts` and `restore-response.ts` are the copy pair this
+ * codebase keeps finding drifted.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ConsoleLogEntry, SanityResult, TestResult } from "@/types";
+import { responseFromExecuteResult } from "./execute-mapping";
+import { responseFromRunResult, type RunResultSample } from "./restore-response";
+
+/** One passing and one failing assertion: the pane draws them differently. */
+const TEST_RESULTS: TestResult[] = [
+	{ name: "Status is 200", passed: true },
+	{ name: "Body carries an id", passed: false, error: "expected undefined to equal 1" },
+];
+
+const CONSOLE_LOGS: ConsoleLogEntry[] = [
+	{ source: "pre", level: "log", message: "token refreshed" },
+	{ source: "test", level: "error", message: "unexpected shape" },
+];
+
+/** The four keys as the engine writes them, live body and stored node alike. */
+const SCRIPTS = {
+	testResults: TEST_RESULTS,
+	consoleLogs: CONSOLE_LOGS,
+	postScriptError: "ReferenceError: pmm is not defined",
+};
+
+const executeResult = (scripts?: typeof SCRIPTS): SanityResult =>
+	({
+		status: 200,
+		statusText: "OK",
+		headers: { "content-type": "application/json" },
+		body: { id: "one" },
+		bodyRaw: '{"id":"one"}',
+		bodySize: 12,
+		...(scripts ?? {}),
+	}) as unknown as SanityResult;
+
+const runResult = (scripts?: typeof SCRIPTS): RunResultSample =>
+	({
+		timestamp: 1_700_000_000_000,
+		statusCode: 200,
+		statusText: "OK",
+		latencyMs: 12,
+		trace: {
+			request: { method: "GET", url: "https://api.example.com/pets/1", headers: {} },
+			response: {
+				status: 200,
+				headers: { "content-type": "application/json" },
+				body: '{"id":"one"}',
+			},
+			...(scripts ? { scripts } : {}),
+		},
+	}) as unknown as RunResultSample;
+
+describe("the live funnel", () => {
+	it("carries the four script keys", () => {
+		const live = responseFromExecuteResult(executeResult(SCRIPTS));
+		expect(live.testResults).toEqual(TEST_RESULTS);
+		expect(live.consoleLogs).toEqual(CONSOLE_LOGS);
+		expect(live.postScriptError).toBe(SCRIPTS.postScriptError);
+	});
+});
+
+describe("the restore funnel", () => {
+	it("carries the four script keys from the stored node", () => {
+		const restored = responseFromRunResult(runResult(SCRIPTS));
+		expect(restored?.testResults).toEqual(TEST_RESULTS);
+		expect(restored?.consoleLogs).toEqual(CONSOLE_LOGS);
+		expect(restored?.postScriptError).toBe(SCRIPTS.postScriptError);
+	});
+
+	it("leaves them absent when the trace carries no node", () => {
+		// A trace written before #725, and a send that ran no scripts, are the
+		// same shape - so absent has to read as "no results", never as "none
+		// passed". The empty state is what the pane shows either way.
+		const restored = responseFromRunResult(runResult());
+		expect(restored?.testResults).toBeUndefined();
+		expect(restored?.consoleLogs).toBeUndefined();
+		expect(restored?.postScriptError).toBeUndefined();
+	});
+});
+
+describe("funnel parity", () => {
+	it("shows the same assertions live and restored", () => {
+		// The point of the engine storing the object it returned rather than the
+		// app deriving a second one: a run reopened from History is the run that
+		// was sent, failure messages included.
+		const live = responseFromExecuteResult(executeResult(SCRIPTS));
+		const restored = responseFromRunResult(runResult(SCRIPTS));
+
+		expect(restored?.testResults).toEqual(live.testResults);
+		expect(restored?.consoleLogs).toEqual(live.consoleLogs);
+		expect(restored?.preScriptError).toEqual(live.preScriptError);
+		expect(restored?.postScriptError).toEqual(live.postScriptError);
+	});
+});

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -1032,15 +1032,19 @@ export interface RunResultTrace {
 	 */
 	events?: RunResultStreamEvents;
 	/**
-	 * What a **streaming** run's scripts produced (issue #575), under the same
-	 * four key names the live `/execute` body uses - one engine builder
+	 * What a design run's scripts produced (issue #575), under the same four key
+	 * names the live `/execute` body uses - one engine object
 	 * (`build_script_result_node`) fills both, so a restored Tests pane and a
 	 * live one cannot disagree about what a failed assertion looks like.
 	 *
-	 * Stored rather than returned because there is nobody left to return it to:
-	 * a streaming send is answered `202` before its post-request script has run.
-	 * A buffered send carries these in its response and stores none of them, so
-	 * this node is present on streaming traces only.
+	 * A streaming send has no alternative: it is answered `202` before its
+	 * post-request script has run, so the trace is the only route its results
+	 * take. A buffered send *also* stores the object it returns (issue #725) -
+	 * before that it stored none of them, and a restored ordinary send showed
+	 * the same empty Tests pane whether its assertions had passed or never run.
+	 *
+	 * Absent means the send ran no scripts, or predates #725 - never that
+	 * nothing passed.
 	 */
 	scripts?: RunResultScripts;
 	/**

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2524,11 +2524,12 @@ one the runtime cannot have. See
 [Scripting](scripting.md#pmresponseevents---a-streamed-runs-events).
 
 Because the route has already answered `202`, a streaming run's script output
-has nowhere to be *returned*: it is stored on the run's trace under `scripts`,
-with the same four keys the buffered response body uses (`testResults`,
-`consoleLogs`, `preScriptError`, `postScriptError`). One engine builder fills
-both, so a live pane and a restored one cannot disagree. A run whose scripts
-said nothing stores no node at all.
+has nowhere to be *returned*: the trace's `scripts` node is the only route it
+takes. That node is not a streaming feature - every design send stores it
+(issue #725), with the same four keys the buffered response body carries
+(`testResults`, `consoleLogs`, `preScriptError`, `postScriptError`). One engine
+object fills both, so a live pane and a restored one cannot disagree. A run
+whose scripts said nothing stores no node at all.
 
 Tuning: `sseMaxRetainedEvents`, `sseMaxEventBytes`, `sseMaxStoredEvents`,
 `sseMaxStreamDurationMs`, `sseMaxStreamEvents` and `sseIdleTimeoutMs` (see
@@ -2749,6 +2750,16 @@ The same object is stored on the design run's `trace_data.validation`, so a
 restored response shows the verdict the live one did rather than recomputing it.
 A streaming send carries none - an event stream is not a document a response
 schema describes.
+
+**The four script keys are stored the same way** (issue #725). `testResults`,
+`consoleLogs`, `preScriptError` and `postScriptError` are returned in the body
+above *and* written to the design run's `trace_data.scripts` as one object, so a
+response restored from History carries the assertions the live one showed. This
+used to hold for a streaming send only, which made a restored ordinary send's
+Tests pane empty whether its assertions passed or never ran. A send whose
+scripts said nothing stores no `scripts` node at all - absent means no scripts,
+not no results - and a `transient` execution stores neither, as it stores
+nothing.
 
 | Field | Meaning |
 |---|---|

--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -295,7 +295,9 @@ A streaming send is answered `202` before its script has run, so the results go
 to the run's trace rather than into a response body - the app's Tests and
 Console panes show them when the stream finishes, and
 [`GET /runs/:runId/report`](api-reference.md#get-runsrunidreport) carries them
-under the trace's `scripts` node.
+under the trace's `scripts` node. A buffered send returns them *and* stores the
+same object there (issue #725), so reopening either kind of run from History
+shows the assertions it made.
 
 ### Reading response headers
 

--- a/engine/include/vayu/http/routes.hpp
+++ b/engine/include/vayu/http/routes.hpp
@@ -763,11 +763,14 @@ SendRowAuth plan_send_row_auth (const nlohmann::json& json, bool has_row);
  * client already reads: `testResults`, `consoleLogs`, `preScriptError` and
  * `postScriptError`.
  *
- * One builder for two homes. A buffered send merges it into the `/execute`
- * response body; a streaming send has already answered `202`, so it stores the
- * same object in its trace (`StreamRecord::scripts`) and the app reads it back
- * from there. Building it twice is how the live pane and the restored one would
- * come to disagree about what a failed assertion looks like.
+ * One object, two homes - and every design send now uses both (issue #725). A
+ * buffered send merges it into the `/execute` response body *and* hands the
+ * same object to `record_design_result`; a streaming send has already answered
+ * `202`, so the trace is the only route it takes. Building it twice, or storing
+ * it on one transport only, is how the live pane and the restored one come to
+ * disagree about what a failed assertion looks like - the buffered half
+ * disagreed by omission until #725, and a restored Tests tab could not tell
+ * "passed" from "never ran".
  *
  * Each key is present only when it has something to say, so a request with no
  * scripts contributes an empty object and stores nothing.
@@ -788,17 +791,6 @@ const vayu::ScriptResult& post_script_result);
 struct StreamRecord {
     /// The bounded `events` node, from `stream_trace_node`.
     nlohmann::json events;
-    /**
-     * What the run's scripts produced, from `build_script_result_node`, or null
-     * when the request carried none (issue #575).
-     *
-     * Stored rather than returned, because there is nobody left to return it
-     * to: the route answered `202` the moment the stream started, so a
-     * streaming run's test results reach the app the same way its events do -
-     * through the trace. `restore-response.ts` maps this node onto the response
-     * pane's existing Tests and Console panes.
-     */
-    nlohmann::json scripts;
     /// The run's terminal status. A stream that was stopped is `Stopped`, which
     /// is neither the `Completed` nor the `Failed` the response alone implies.
     vayu::RunStatus status = vayu::RunStatus::Completed;
@@ -819,13 +811,22 @@ struct StreamRecord {
  *        stored verbatim on the trace. `std::nullopt` writes no node, which is
  *        what an unbound collection - and a stream, whose body is an event
  *        stream rather than a document any response schema describes - means.
+ * @param scripts What this send's scripts produced, from
+ *        `build_script_result_node` - the *same* object the buffered path also
+ *        returns in its `/execute` body (issue #725). A property of the
+ *        execution rather than of the transport, which is why it is a parameter
+ *        here and not a `StreamRecord` field: a send whose results were stored
+ *        only when it happened to stream is how a restored Tests tab came to be
+ *        empty for every ordinary send. An empty object writes no node, so a
+ *        request with no scripts stores nothing.
  */
 void record_design_result (vayu::db::Database& db,
 const std::optional<std::string>& run_id,
 const vayu::Request& request,
 const vayu::Response& response,
-const StreamRecord* stream                                        = nullptr,
-const std::optional<vayu::core::ValidationVerdict>& validation = std::nullopt);
+const StreamRecord* stream                                     = nullptr,
+const std::optional<vayu::core::ValidationVerdict>& validation = std::nullopt,
+const nlohmann::json& scripts = nlohmann::json::object ());
 
 /**
  * @brief Callback type for graceful shutdown

--- a/engine/src/http/routes/execution.cpp
+++ b/engine/src/http/routes/execution.cpp
@@ -413,8 +413,7 @@ namespace {
 
 // Build the final response JSON with script results
 nlohmann::json build_response_json (const vayu::Response& response,
-const vayu::ScriptResult& pre_script_result,
-const vayu::ScriptResult& post_script_result,
+const nlohmann::json& scripts,
 const std::optional<vayu::core::ValidationVerdict>& validation) {
     nlohmann::json response_json = vayu::json::serialize (response);
     // The schema verdict (#628), on the same terms as the script keys below:
@@ -426,11 +425,11 @@ const std::optional<vayu::core::ValidationVerdict>& validation) {
         response_json["validation"] = vayu::core::build_validation_payload (*validation);
     }
     // Merged in at the top level, which is where every client has read these
-    // four keys since before there was a second placement for them. The
-    // streaming path stores the same object under the trace's `scripts` node -
-    // one builder, two homes, so a key can never mean one thing live and
-    // another restored.
-    response_json.update (build_script_result_node (pre_script_result, post_script_result));
+    // four keys since before there was a second placement for them. The node
+    // arrives built, because the caller hands the *same* object to
+    // `record_design_result` for the trace's `scripts` key - one object, two
+    // homes, so a key can never mean one thing live and another restored.
+    response_json.update (scripts);
     return response_json;
 }
 
@@ -585,7 +584,8 @@ const std::optional<std::string>& run_id,
 const vayu::Request& request,
 const vayu::Response& response,
 const StreamRecord* stream,
-const std::optional<vayu::core::ValidationVerdict>& validation) {
+const std::optional<vayu::core::ValidationVerdict>& validation,
+const nlohmann::json& scripts) {
     if (!run_id) {
         return;
     }
@@ -622,13 +622,17 @@ const std::optional<vayu::core::ValidationVerdict>& validation) {
             trace["validation"] = vayu::core::build_validation_payload (*validation);
         }
 
+        // Every design send that ran scripts, not only a streaming one (#725):
+        // a buffered send's results used to reach the live body and stop there,
+        // so a restored Tests tab could not tell "passed" from "never ran".
+        // Only when the run had scripts at all - an empty node would put a
+        // Tests pane's worth of nothing on every stored send.
+        if (scripts.is_object () && !scripts.empty ()) {
+            trace["scripts"] = scripts;
+        }
+
         if (stream) {
             trace["events"] = stream->events;
-            // Only when the run had scripts at all: an empty node would put a
-            // Tests pane's worth of nothing on every stored stream.
-            if (stream->scripts.is_object () && !stream->scripts.empty ()) {
-                trace["scripts"] = stream->scripts;
-            }
         }
 
         // A capped body may split a UTF-8 sequence, and the raw response body can
@@ -1103,6 +1107,7 @@ void register_execution_routes (RouteContext& ctx) {
                                const vayu::Response& response,
                                const vayu::http::SseStreamContext& context) mutable {
                 StreamRecord record;
+                nlohmann::json scripts = nlohmann::json::object ();
                 record.events = vayu::http::stream_trace_node (context);
                 record.status =
                 context.end_reason () == vayu::http::SseEndReason::Stopped ?
@@ -1145,7 +1150,7 @@ void register_execution_routes (RouteContext& ctx) {
                             // already captured, exactly as on the buffered path.
                             jar.apply (cookie_scope, post_cookie_writes);
                         }
-                        record.scripts = build_script_result_node (
+                        scripts = build_script_result_node (
                         pre_script_result, post_script_result);
                     } catch (const std::exception& e) {
                         vayu::utils::log_error (
@@ -1157,7 +1162,11 @@ void register_execution_routes (RouteContext& ctx) {
                     scopes.globals, scopes.collection);
                 }
 
-                record_design_result (db, id, sent, response, &record);
+                // No verdict: a stream's body is an event stream, not a
+                // document any response schema describes (see the contract on
+                // the parameter).
+                record_design_result (
+                db, id, sent, response, &record, std::nullopt, scripts);
             };
 
             auto context = ctx.sse_manager.start (std::move (spec));
@@ -1223,11 +1232,18 @@ void register_execution_routes (RouteContext& ctx) {
         const auto validation =
         validate_design_response (ctx.db, run.request_id, exchange.response);
 
+        // Built once, then sent *and* stored (#725). The live body and the
+        // trace's `scripts` node are the same object, so a restored Tests tab
+        // shows the assertions this send actually made rather than the
+        // empty-state that used to make "passed" and "never ran" identical.
+        const nlohmann::json scripts = build_script_result_node (
+        exchange.pre_script_result, exchange.post_script_result);
+
         // Store result to database (non-blocking, errors logged). A transient
         // execution stops here: no trace row, so the post-auth headers this
-        // exchange carries never reach disk.
+        // exchange carries never reach disk - and neither do these results.
         record_design_result (ctx.db, run_id, exchange.request, exchange.response,
-        /*stream=*/nullptr, validation);
+        /*stream=*/nullptr, validation, scripts);
 
         // Persist script-set variables (design mode only; best-effort)
         persist_script_variables (
@@ -1236,9 +1252,8 @@ void register_execution_routes (RouteContext& ctx) {
         // Build and send response
         // Engine returns 200 - the server's status is in the response body
         res.status = 200;
-        res.set_content (build_response_json (exchange.response,
-        exchange.pre_script_result, exchange.post_script_result, validation)
-        .dump (2),
+        res.set_content (
+        build_response_json (exchange.response, scripts, validation).dump (2),
         "application/json");
     };
     ctx.server.Post ("/execute", execute_request);

--- a/engine/tests/sse_stream_test.cpp
+++ b/engine/tests/sse_stream_test.cpp
@@ -995,6 +995,24 @@ class StreamExecuteTest : public ::testing::Test {
         return json::object ();
     }
 
+    /// The stored trace of the most recent design run. A buffered send answers
+    /// with the response rather than a run id, so its row is found by recency -
+    /// safe because each test gets its own database, and unpolled because the
+    /// buffered path stores before it answers.
+    json latest_design_trace () {
+        auto runs = db_->get_runs_paginated (vayu::db::RunFilter{}, 1, 0);
+        if (runs.empty ()) {
+            ADD_FAILURE () << "no run row was created for the buffered send";
+            return json::object ();
+        }
+        auto results = db_->get_results (runs[0].id);
+        if (results.empty ()) {
+            ADD_FAILURE () << "no result row was stored for " << runs[0].id;
+            return json::object ();
+        }
+        return json::parse (results[0].trace_data);
+    }
+
     void set_config (const char* key, const std::string& value) {
         auto entry = db_->get_config_entry (key);
         ASSERT_TRUE (entry.has_value ()) << key;
@@ -1220,6 +1238,67 @@ TEST_F (StreamExecuteTest, MalformedFramesAreDroppedAndTheRunStillCompletes) {
     EXPECT_TRUE (trace["scripts"]["testResults"][0]["passed"].get<bool> ())
     << trace["scripts"]["testResults"][0].value ("error", "");
     EXPECT_EQ (trace["events"]["endReason"], "completed");
+}
+
+// ---------------------------------------------------------------------------
+// Scripts on the buffered send (issue #725)
+//
+// The transport that *has* somewhere to return its results stores them too.
+// Driven through the real `POST /execute` handler for the same reason the
+// streaming cases above are: the wiring is the thing under test, and a test
+// that called `record_design_result` directly would stay green with the route
+// still throwing the node away.
+// ---------------------------------------------------------------------------
+
+TEST_F (StreamExecuteTest, ABufferedSendStoresTheScriptResultsItAlsoReturns) {
+    serve (1);
+    const auto body = send_buffered (json{ { "postRequestScript", R"JS(
+        console.log('asserted');
+        pm.test('the origin answered', function () {
+            pm.expect(pm.response.code).to.equal(200);
+        });
+        pm.test('and this one does not hold', function () {
+            pm.expect(pm.response.code).to.equal(418);
+        });
+    )JS" } });
+    ASSERT_TRUE (body.contains ("testResults")) << body.dump (2);
+
+    const auto trace = latest_design_trace ();
+    ASSERT_TRUE (trace.contains ("scripts")) << trace.dump (2);
+
+    // Key for key against the live body rather than field by field: the two
+    // panes are the pair this codebase keeps finding drifted, and the only
+    // assertion that cannot be satisfied by a subset is the whole object.
+    json returned = json::object ();
+    for (const char* key :
+    { "testResults", "consoleLogs", "preScriptError", "postScriptError" }) {
+        if (body.contains (key)) {
+            returned[key] = body[key];
+        }
+    }
+    EXPECT_EQ (trace["scripts"], returned) << trace["scripts"].dump (2);
+
+    // And that the stored node really carries the distinctions the pane draws -
+    // a restored run must tell passed from failed, and either from never-ran.
+    ASSERT_EQ (trace["scripts"]["testResults"].size (), 2u);
+    EXPECT_TRUE (trace["scripts"]["testResults"][0]["passed"].get<bool> ());
+    EXPECT_FALSE (trace["scripts"]["testResults"][1]["passed"].get<bool> ());
+    EXPECT_FALSE (
+    trace["scripts"]["testResults"][1].value ("error", "").empty ());
+    EXPECT_EQ (trace["scripts"]["consoleLogs"][0]["message"], "asserted");
+}
+
+// The other half of the rule the streaming path holds: absent means the send
+// had no scripts, so an empty node must never be written. Without this,
+// "always store something" would pass the test above.
+TEST_F (StreamExecuteTest, ABufferedSendWithoutScriptsStoresNoScriptNode) {
+    serve (1);
+    const auto body = send_buffered (json::object ());
+    EXPECT_FALSE (body.contains ("testResults")) << body.dump (2);
+
+    const auto trace = latest_design_trace ();
+    EXPECT_FALSE (trace.contains ("scripts")) << trace.dump (2);
+    EXPECT_FALSE (trace.contains ("events")) << trace.dump (2);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

**Plan.** Root cause is that the trace's `scripts` node was owned by the *transport* rather than by the execution: `record_design_result` wrote it only from `StreamRecord::scripts` (`execution.cpp:625-631`), so a buffered `POST /execute` returned `testResults`/`consoleLogs`/`preScriptError`/`postScriptError` in its body and stored none of them. Restoring that run from History showed the Tests pane's empty state, making "5 passed" and "no assertions ever ran" the same picture - and `restore-response.ts:100-104` recorded the asymmetry as fact with no issue number behind it, which root `CLAUDE.md` forbids. The approach moves the node off `StreamRecord` and makes it a parameter of `record_design_result`, so one place decides whether a design run stores it and neither path can be the one that forgets; the buffered handler builds it **once** and hands the same object to the response body and to the trace, which is the discipline the schema verdict (#628) already follows next door. The alternative I rejected was the issue's own smaller suggestion - drop the `stream` condition around the existing `StreamRecord` field and have the buffered call site fill a `StreamRecord` - because a struct named for streams carrying an ordinary send's results is exactly the mislabelling that let this survive, and it leaves two writers of one key.

Verified the problem still exists at `825cb60` before touching anything: the `stream != nullptr` condition and the restore comment are as the issue describes.

**Blast radius.** Traced every reader of the node before changing the writer. The app half is **zero new code**: `scriptsFromTrace` is spread into *both* branches of `responseFromRunResult` (`restore-response.ts:249,291`), so the error path and the ordinary path already render whatever is stored - the reader existed and the writer was missing, the mirror image of this repo's signature defect. `StreamRecord::scripts` had exactly one writer and one reader, both in `execution.cpp`; no test or other route touched it. The scenario runner's step traces are a different builder and out of scope (that is #724).

**Deliberate scope note.** The issue's acceptance criteria are met with no renderer change, so this PR touches app *comments and types* only - `restore-response.ts`'s note and `domain.ts`'s `scripts?` doc, both of which asserted the old behaviour and would otherwise be reference material telling the next session something false.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **1911 tests, 100% passing**, 293s (1909 before; 2 new). `cd app && pnpm test` - **493 files, 5140 tests, all passing** (5136 before; 4 new). `pnpm type-check` clean; ESLint and `prettier --check` clean on every touched app file (each was clean before). No pre-existing failures observed. The cold build needed `vcpkg-fix-port` first, per CLAUDE.md's 403 note.

`mkdocs build --strict` could **not** be run - mkdocs is not installed in this environment and the egress policy blocks installing it. The docs edits add no page, heading, anchor or link, only prose inside existing sections, so there is nothing new for the link check to resolve; CI's docs job is the real gate.

New tests, each mutation-checked (fix reverted, failure confirmed, restored):

| Test | Reverting what makes it fail |
|---|---|
| `sse_stream_test.cpp` - `ABufferedSendStoresTheScriptResultsItAlsoReturns` | re-adding the `stream &&` guard on the store: this test alone reddens, all 8 streaming cases stay green |
| `sse_stream_test.cpp` - `ABufferedSendWithoutScriptsStoresNoScriptNode` | writing the node unconditionally (guards "absent means no scripts", which the test above alone would not) |
| `script-funnels.test.ts` x2 (restore + parity) | deleting the `scriptsFromTrace` spread from `responseFromRunResult` |

The engine pair is driven through the **real `POST /execute` handler** on a real server, reusing the `StreamExecuteTest` harness and its existing `send_buffered` helper, because the wiring is the thing under test - a test calling `record_design_result` directly would stay green with the route still throwing the node away. The first asserts the stored node **key for key** against the live body rather than field by field, since these two funnels are the pair this codebase keeps finding drifted.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/api-reference.md` (the four script keys stored beside the `validation` paragraph that states the same rule, and the streaming section corrected - the node is no longer a streaming feature) and `docs/engine/scripting.md` (one line where the stream's storage is described). The rationale lives beside the code in `routes.hpp` (the parameter's contract says why it is a parameter and not a `StreamRecord` field).

## Related Issues
Closes #725

The `scripts` node is now attached in one place for both design paths, which is the shape #724 needs for a collection run's step traces - that issue's engine half becomes "call the existing builder from the scenario runner", with no second decision about when to store.

---
_Generated by [Claude Code](https://claude.ai/code/session_011isZxmBAJm8SdZ3Y1wSVrU)_