### PR TITLE
fix(engine): bind a deferred replay's real variable scopes

### DIFF
--- a/docs/engine/scripting.md
+++ b/docs/engine/scripting.md
@@ -1460,6 +1460,24 @@ The **language** is current; what is missing is the **host environment**:
   [Script Parts](#script-parts) below) - a collection-level assertion is now
   checked under load, not only in design mode
 
+**All three variable scopes are readable, and none of them is written back.** A
+deferred replay reads the run's own environment (the `environmentId` the run was
+started with), the globals, and the collection chain - the leaf plus its
+ancestors, exactly as a Send does, so an inherited name answers the same in both
+modes. A scenario load run's collection scope is the collection being *run*; a
+single-request run's is the collection of its linked request. Earlier engines
+bound an empty environment and no other scope at all, so
+`pm.environment.get('region')` read `undefined` under load and the same test
+gave opposite verdicts on Send and under load.
+
+Writes are the deliberate exception. A `set()`, `unset()` or `clear()` in a
+deferred script is visible to the samples replayed after it - one set of scopes
+serves the whole pass - but **nothing is persisted**: only design mode writes
+variables back. A sampled response is not an iteration, so there is no ordering
+under which "whichever replay ran last wins" would be a defensible thing to
+store. If a load run's scripts must leave a value behind, write it in design
+mode instead.
+
 **A scenario load run validates per step instead.** It has no run-level `tests`
 field: each plan step carries its own post-request script, and after the run
 drains each is replayed against the responses *that step* produced. The tallies

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -474,6 +474,7 @@ if(VAYU_BUILD_TESTS)
         tests/error_shape_route_test.cpp
         tests/globals_route_test.cpp
         tests/script_variables_test.cpp
+        tests/load_script_scopes_test.cpp
         tests/script_info_test.cpp
         tests/script_send_request_test.cpp
         tests/script_sent_headers_test.cpp

--- a/engine/include/vayu/http/request_exchange.hpp
+++ b/engine/include/vayu/http/request_exchange.hpp
@@ -124,6 +124,20 @@ vayu::runtime::ScriptContext& ctx,
 const std::string& script_type);
 
 /**
+ * Point @p ctx's four variable scopes at @p scopes, and nothing else.
+ *
+ * The leaf collection scope is handed over writable while its ancestors are
+ * read-only (issue #234); that rule is the reason this is a function rather
+ * than four assignments at each call site.
+ *
+ * Separate from `bind_script_scopes` because a **deferred** replay - a load
+ * run's `tests` script, a scenario load run's per-step script - has scopes to
+ * read but no transfer and therefore no cookie jar to bind (issue #728). It
+ * must not be the call site that re-derives which scope is writable.
+ */
+void bind_variable_scopes (vayu::runtime::ScriptContext& ctx, ScriptVariableScopes& scopes);
+
+/**
  * Point @p ctx's variable scopes and cookie surfaces at this run's.
  *
  * The rules here are not obvious and each one is load-bearing: the leaf

--- a/engine/src/core/run_manager.cpp
+++ b/engine/src/core/run_manager.cpp
@@ -17,6 +17,7 @@
 #include "vayu/core/scenario_runner.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/request_builder.hpp"
+#include "vayu/http/request_exchange.hpp"
 #include "vayu/http/script_parts.hpp"
 #include "vayu/http/sse_stream.hpp"
 #include "vayu/runtime/script_engine.hpp"
@@ -78,11 +79,14 @@ struct ScriptReplay {
 /**
  * @brief Replay one script against one set of samples, tallying the results.
  *
+ * @param scopes The run's stored variable scopes, shared by every replay of the
+ *        pass and mutated in place by any `set()` a script performs - see
+ *        `validate_scripts` for why those writes are never persisted.
  * @param failure_messages Appended to, bounded by MAX_FAILURE_MESSAGES across
  *        the whole run - a forty-step plan must not multiply the cap by forty.
  */
 ScriptValidationTotals run_replay (vayu::runtime::ScriptEngine& engine,
-vayu::Environment& env,
+vayu::http::routes::ScriptVariableScopes& scopes,
 const ScriptReplay& replay,
 std::vector<std::string>& failure_messages) {
     ScriptValidationTotals totals;
@@ -107,7 +111,11 @@ std::vector<std::string>& failure_messages) {
         try {
             auto script_ctx =
             vayu::runtime::ScriptContext::for_test (*replay.request, response);
-            script_ctx.environment  = &env;
+            // All four scopes, through the one function that knows which of
+            // them a script may write (issue #728). Binding only `environment`
+            // here - and an empty one at that - is what made the same test
+            // script pass on Send and fail on every replay.
+            vayu::http::routes::bind_variable_scopes (script_ctx, scopes);
             script_ctx.request_id   = replay.request_id;
             script_ctx.request_name = replay.request_name;
             // The iteration this response was actually sent in, for a scenario
@@ -218,7 +226,6 @@ bool verbose) {
     vayu::http::read_allow_script_requests (context->config);
 
     vayu::runtime::ScriptEngine engine (script_config);
-    vayu::Environment env;
     // One read for the whole pass, shared by every replay it drives.
     const vayu::http::SseLimits sse_limits = vayu::http::read_sse_limits (db);
 
@@ -228,6 +235,7 @@ bool verbose) {
     vayu::Request dummy_request;
     std::optional<std::string> script_request_id;
     std::optional<std::string> script_request_name;
+    std::optional<vayu::db::Request> linked_request;
     if (!per_step) {
         // Build a dummy request for script context (HTTP request fields are at root level)
         auto request_result = vayu::json::deserialize_request (context->config);
@@ -243,23 +251,67 @@ bool verbose) {
             id->is_string () && !id->get<std::string> ().empty ()) {
             script_request_id = id->get<std::string> ();
         }
+        // The linked request row, read once for the two readers below: the
+        // `pm.info.requestName` fallback, and the collection scope its scripts
+        // read (issue #728). The lookup used to be wrapped in a catch, on the
+        // grounds that it cost the script only a name - it now also decides
+        // which collection scope the replay binds, and empty scopes are the
+        // silently wrong verdicts this pass exists to avoid, so a failure is
+        // left to propagate (see the scopes note below).
+        if (script_request_id) {
+            linked_request = db.get_request (*script_request_id);
+        }
+
         if (auto name = context->config.find ("requestName");
             name != context->config.end () && name->is_string () &&
             !name->get<std::string> ().empty ()) {
             script_request_name = name->get<std::string> ();
-        } else if (script_request_id) {
-            try {
-                if (auto stored = db.get_request (*script_request_id);
-                    stored && !stored->name.empty ()) {
-                    script_request_name = stored->name;
-                }
-            } catch (const std::exception& e) {
-                // A lookup failure costs the script a name, never the validation.
-                vayu::utils::log_warning (
-                "pm.info.requestName lookup failed: " + std::string (e.what ()));
-            }
+        } else if (linked_request && !linked_request->name.empty ()) {
+            script_request_name = linked_request->name;
         }
     }
+
+    // The scopes the replayed scripts read (issue #728). A load run's `tests`
+    // script is the same script a Send runs, so `pm.environment.get('region')`
+    // must answer the same here as it does there - before this, every replay
+    // read an empty environment and no globals or collection scope at all, so a
+    // test comparing a response against a variable failed on every sample and
+    // reported the target as broken.
+    //
+    // Which collection scope is the run's is the same question the two
+    // sequential paths answer: a scenario run's is the collection being run
+    // (`scenario_runner.cpp`), a single-request run's is the collection of the
+    // request it links (`load_script_variable_scopes(db, run)`). Read off the
+    // payload, which is what the run row itself was populated from, and where
+    // this function already reads `requestId` from.
+    //
+    // A database failure here is deliberately not caught: it propagates to
+    // `execute_load_test`, which logs it and stores no `testValidation`
+    // section. Tallies computed against scopes that failed to load would be
+    // the silently wrong verdicts this issue is about, and "never judged" must
+    // not be reported as "judged and passed".
+    std::optional<std::string> environment_id;
+    if (auto it = context->config.find ("environmentId");
+        it != context->config.end () && it->is_string () &&
+        !it->get<std::string> ().empty ()) {
+        environment_id = it->get<std::string> ();
+    }
+
+    std::string collection_id;
+    if (per_step) {
+        collection_id = context->scenario->request.collection_id;
+    } else if (linked_request) {
+        collection_id = linked_request->collection_id;
+    }
+
+    // Loaded once and shared by every replay of the pass, so a `set()` is
+    // readable by the samples replayed after it - the same within-a-run
+    // visibility a sequential run gives. Never persisted:
+    // `persist_script_variables` is design-mode only, and a reservoir sample is
+    // not an iteration, so writing back whichever replay ran last would store a
+    // value no ordering justifies.
+    auto scopes = vayu::http::routes::load_script_variable_scopes (db,
+    environment_id, collection_id);
 
     size_t passed = 0;
     size_t failed = 0;
@@ -309,7 +361,8 @@ bool verbose) {
             step.name + ": ";
             replay.sse_limits = sse_limits;
 
-            const auto totals = run_replay (engine, env, replay, failure_messages);
+            const auto totals =
+            run_replay (engine, scopes, replay, failure_messages);
             validation.steps[i] = totals;
             sampled += totals.sampled;
             passed += totals.passed;
@@ -335,7 +388,8 @@ bool verbose) {
         replay.request_name = script_request_name;
         replay.sse_limits   = sse_limits;
 
-        const auto totals = run_replay (engine, env, replay, failure_messages);
+        const auto totals =
+        run_replay (engine, scopes, replay, failure_messages);
         sampled           = totals.sampled;
         passed            = totals.passed;
         failed            = totals.failed;

--- a/engine/src/http/request_exchange.cpp
+++ b/engine/src/http/request_exchange.cpp
@@ -278,18 +278,22 @@ const std::string& script_type) {
     return result;
 }
 
+void bind_variable_scopes (vayu::runtime::ScriptContext& ctx, ScriptVariableScopes& scopes) {
+    ctx.environment         = &scopes.environment;
+    ctx.globals             = &scopes.globals;
+    ctx.collectionVariables = &scopes.collection;
+    ctx.collectionAncestors = &scopes.collection_ancestors;
+}
+
 void bind_script_scopes (vayu::runtime::ScriptContext& ctx,
 ScriptVariableScopes& scopes,
 vayu::http::CookieJar& jar,
 const std::string& cookie_scope,
 std::vector<vayu::http::CookieWrite>* writes) {
-    ctx.cookie_jar          = &jar;
-    ctx.cookie_scope        = cookie_scope;
-    ctx.cookie_writes       = writes;
-    ctx.environment         = &scopes.environment;
-    ctx.globals             = &scopes.globals;
-    ctx.collectionVariables = &scopes.collection;
-    ctx.collectionAncestors = &scopes.collection_ancestors;
+    bind_variable_scopes (ctx, scopes);
+    ctx.cookie_jar    = &jar;
+    ctx.cookie_scope  = cookie_scope;
+    ctx.cookie_writes = writes;
 }
 
 ExchangeOutcome execute_exchange (vayu::runtime::ScriptEngine& engine,

--- a/engine/tests/load_script_scopes_test.cpp
+++ b/engine/tests/load_script_scopes_test.cpp
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the AGPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The variable scopes a *deferred* replay reads (issue #728).
+ *
+ * A load run's `tests` script is the same script a Send runs, so the two must
+ * not disagree about what `pm.environment.get('region')` answers. Before the
+ * fix, `validate_scripts` bound one freshly constructed empty `Environment` and
+ * nothing else: every scope read `undefined` under load, so a test comparing a
+ * response against a variable failed on every sampled replay and reported the
+ * target as broken.
+ *
+ * These tests drive `validate_scripts` against a real database, because the
+ * wiring between the loader and the replay is the thing under test - a test
+ * calling `run_replay` with scopes it built itself would stay green with the
+ * production path still binding nothing.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "temp_database.hpp"
+#include "vayu/core/run_manager.hpp"
+#include "vayu/core/scenario_plan.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/types.hpp"
+
+using json = nlohmann::json;
+
+namespace {
+
+/// A 200 whose body names the region the environment also names, so a script
+/// can compare the two the way the issue's example does.
+vayu::Response response_with (const std::string& body) {
+    vayu::Response response;
+    response.status_code             = 200;
+    response.status_text             = "OK";
+    response.body                    = body;
+    response.timing.total_ms         = 1.0;
+    response.headers["Content-Type"] = "application/json";
+    return response;
+}
+
+class LoadScriptScopesTest : public ::testing::Test {
+    protected:
+    static constexpr const char* DB_PATH = "test_load_script_scopes.db";
+    static constexpr const char* GLOBALS_BLOB = R"({"build":{"value":"1.2.3","enabled":true}})";
+    static constexpr const char* LEAF_BLOB = R"({"page_size":{"value":"25","enabled":true}})";
+
+    void SetUp () override {
+        cleanup ();
+        db_ = std::make_unique<vayu::db::Database> (DB_PATH);
+        db_->init ();
+
+        // Tenants (root, defines `tenant`) -> Users (leaf, defines
+        // `page_size`), so an inherited name is covered as well as a leaf one.
+        add_collection ("col_root", "Tenants", std::nullopt,
+        R"({"tenant":{"value":"acme","enabled":true}})");
+        add_collection ("col_leaf", "Users", "col_root", LEAF_BLOB);
+
+        add_request ("req_1", "col_leaf");
+
+        vayu::db::Environment environment;
+        environment.id         = "env_eu";
+        environment.name       = "EU";
+        environment.variables  = R"({"region":{"value":"EU","enabled":true}})";
+        environment.created_at = 1;
+        environment.updated_at = 1;
+        db_->save_environment (environment);
+
+        vayu::db::Globals globals;
+        globals.id         = "globals";
+        globals.variables  = GLOBALS_BLOB;
+        globals.updated_at = 1;
+        db_->save_globals (globals);
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        cleanup ();
+    }
+
+    static void cleanup () {
+        vayu::tests::remove_database_files (DB_PATH);
+    }
+
+    void add_collection (const std::string& id,
+    const std::string& name,
+    std::optional<std::string> parent,
+    const std::string& variables) {
+        vayu::db::Collection collection;
+        collection.id         = id;
+        collection.name       = name;
+        collection.parent_id  = std::move (parent);
+        collection.variables  = variables;
+        collection.auth       = "{}";
+        collection.order      = 0;
+        collection.created_at = 1;
+        collection.updated_at = 1;
+        db_->create_collection (collection);
+    }
+
+    void add_request (const std::string& id, const std::string& collection_id) {
+        vayu::db::Request request;
+        request.id            = id;
+        request.collection_id = collection_id;
+        request.name          = "List users";
+        request.method        = vayu::HttpMethod::GET;
+        request.url           = "https://api.example.com/users";
+        request.params        = "[]";
+        request.headers       = "[]";
+        request.body          = R"({"mode":"none"})";
+        request.body_type     = "none";
+        request.auth          = R"({"mode":"none"})";
+        request.order         = 0;
+        request.created_at    = 1;
+        request.updated_at    = 1;
+        db_->save_request (request);
+    }
+
+    /**
+     * A single-request load run as `POST /runs` records one: the payload
+     * carries the environment and the linked request, and the reservoir keeps
+     * every sample offered so the test decides what is replayed.
+     */
+    static std::shared_ptr<vayu::core::RunContext>
+    single_request_run (const std::string& script, bool with_environment = true) {
+        json cfg = { { "response_sample_rate", 1 },
+            { "max_response_samples", 100 }, { "requestId", "req_1" } };
+        if (with_environment) {
+            cfg["environmentId"] = "env_eu";
+        }
+        auto context = std::make_shared<vayu::core::RunContext> ("run-scopes", cfg);
+        context->test_script = script;
+        return context;
+    }
+
+    /// A scenario load run of `col_leaf` with one scripted step, its store
+    /// seeded directly - the executor is not what is under test here.
+    static std::shared_ptr<vayu::core::RunContext> scenario_run (const std::string& step_script) {
+        const json cfg = { { "response_sample_rate", 1 },
+            { "max_response_samples", 100 }, { "environmentId", "env_eu" } };
+        auto context =
+        std::make_shared<vayu::core::RunContext> ("run-scenario-scopes", cfg);
+
+        auto execution = std::make_shared<vayu::core::ScenarioExecution> ();
+        execution->request.source        = "collection";
+        execution->request.collection_id = "col_leaf";
+        execution->request.iterations    = 1;
+
+        vayu::core::ScenarioStep step;
+        step.index          = 0;
+        step.request_id     = "req_1";
+        step.name           = "List users";
+        step.post_script    = step_script;
+        step.request.method = vayu::HttpMethod::GET;
+        step.request.url    = "https://api.example.com/users";
+        execution->plan.steps.push_back (step);
+
+        context->scenario = execution;
+        context->metrics_collector->configure_step_samples ({ true });
+        return context;
+    }
+
+    std::string stored_environment_variables () {
+        auto environment = db_->get_environment ("env_eu");
+        EXPECT_TRUE (environment.has_value ());
+        return environment ? environment->variables : std::string ();
+    }
+
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// The issue itself: the same assertion that passes on Send with environment E
+// must pass under a load run recorded with E. Mutation-check - restore the
+// `vayu::Environment env;` the replay used to bind and this fails, because
+// `pm.environment.get` answers `undefined` and the comparison against the
+// response body fails on every sample.
+TEST_F (LoadScriptScopesTest, ATestPassingOnSendPassesUnderLoad) {
+    auto context = single_request_run (R"(
+        pm.test('region matches the environment', function () {
+            const body = pm.response.json();
+            pm.expect(body.region).to.eql(pm.environment.get('region'));
+        });
+    )");
+    context->metrics_collector->record_response_sample (response_with (R"({"region":"EU"})"));
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_TRUE (validation.run.has_value ());
+    EXPECT_EQ (validation.run->sampled, 1u);
+    EXPECT_EQ (validation.run->passed, 1u);
+    EXPECT_EQ (validation.run->failed, 0u)
+    << "the replay read an empty environment, so a test that passes on Send "
+       "reports the target as broken";
+}
+
+// Globals and the collection chain, which the pre-fix path did not bind at all
+// - not even an empty one. The ancestor's `tenant` is the D2 asymmetry's own
+// case (issue #234): an inherited name must answer in a script exactly as it
+// does in a URL.
+TEST_F (LoadScriptScopesTest, GlobalsAndTheWholeCollectionChainAreBoundToo) {
+    auto context = single_request_run (R"(
+        pm.test('globals', function () {
+            pm.expect(pm.globals.get('build')).to.eql('1.2.3');
+        });
+        pm.test('leaf collection scope', function () {
+            pm.expect(pm.collectionVariables.get('page_size')).to.eql('25');
+        });
+        pm.test('inherited collection scope', function () {
+            pm.expect(pm.collectionVariables.get('tenant')).to.eql('acme');
+        });
+    )");
+    context->metrics_collector->record_response_sample (response_with ("{}"));
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_TRUE (validation.run.has_value ());
+    EXPECT_EQ (validation.run->passed, 3u);
+    EXPECT_EQ (validation.run->failed, 0u);
+}
+
+// A scenario load run's collection scope is the collection being *run*, not the
+// collection of some request the run row happens to link - the same rule the
+// design-mode runner applies. Mutation-check: resolve the scope from
+// `script_request_id` in both shapes and this fails, since a scenario run has
+// no run-level request id and the scope comes back empty.
+TEST_F (LoadScriptScopesTest, AScenarioStepReplayReadsTheRunningCollectionsScope) {
+    auto context = scenario_run (R"(
+        pm.test('step scopes', function () {
+            pm.expect(pm.environment.get('region')).to.eql('EU');
+            pm.expect(pm.collectionVariables.get('page_size')).to.eql('25');
+            pm.expect(pm.collectionVariables.get('tenant')).to.eql('acme');
+        });
+    )");
+    context->metrics_collector->record_step_response_sample (
+    response_with ("{}"), 0, 0, std::nullopt);
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_EQ (validation.steps.size (), 1u);
+    ASSERT_TRUE (validation.steps[0].has_value ());
+    EXPECT_EQ (validation.steps[0]->passed, 1u);
+    EXPECT_EQ (validation.steps[0]->failed, 0u);
+}
+
+// The write rule, half one: a replay's `set()` is never persisted. A reservoir
+// sample is not an iteration, so there is no ordering that would justify
+// storing whichever replay wrote last.
+TEST_F (LoadScriptScopesTest, AReplayWriteIsNeverPersisted) {
+    const std::string before = stored_environment_variables ();
+
+    auto context = single_request_run (R"(
+        pm.environment.set('region', 'US');
+        pm.globals.set('build', 'tampered');
+        pm.collectionVariables.set('page_size', '999');
+        pm.test('wrote', function () {
+            pm.expect(pm.environment.get('region')).to.eql('US');
+        });
+    )");
+    context->metrics_collector->record_response_sample (response_with ("{}"));
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+    ASSERT_TRUE (validation.run.has_value ());
+    EXPECT_EQ (validation.run->passed, 1u)
+    << "the write was not even visible in-memory";
+
+    EXPECT_EQ (stored_environment_variables (), before)
+    << "a deferred replay persisted a variable; only design mode may write "
+       "back";
+    auto globals = db_->get_globals ();
+    ASSERT_TRUE (globals.has_value ());
+    EXPECT_EQ (globals->variables, GLOBALS_BLOB);
+    auto leaf = db_->get_collection ("col_leaf");
+    ASSERT_TRUE (leaf.has_value ());
+    EXPECT_EQ (leaf->variables, LEAF_BLOB);
+}
+
+// The write rule, half two: one set of scopes for the whole pass, so a write is
+// readable by the samples replayed after it. The first sample finds nothing and
+// fails, the second finds the first one's write and passes - which pins the
+// sharing precisely, where "both passed" would also be true of per-sample
+// scopes that were merely non-empty.
+TEST_F (LoadScriptScopesTest, AWriteIsVisibleToTheSamplesReplayedAfterIt) {
+    auto context = single_request_run (R"(
+        const prior = pm.globals.get('seen');
+        pm.globals.set('seen', 'yes');
+        pm.test('sees the earlier replay write', function () {
+            pm.expect(prior).to.eql('yes');
+        });
+    )");
+    context->metrics_collector->record_response_sample (response_with ("{}"));
+    context->metrics_collector->record_response_sample (response_with ("{}"));
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_TRUE (validation.run.has_value ());
+    EXPECT_EQ (validation.run->sampled, 2u);
+    EXPECT_EQ (validation.run->passed, 1u);
+    EXPECT_EQ (validation.run->failed, 1u);
+}
+
+// A run recorded without an environment keeps the documented empty-scope
+// behaviour - `get` is `undefined`, not an error - while still binding the
+// scopes that do exist. Absent is not the same as unbound.
+TEST_F (LoadScriptScopesTest, ARunWithNoEnvironmentStillBindsTheOtherScopes) {
+    auto context = single_request_run (R"(
+        pm.test('no environment', function () {
+            pm.expect(pm.environment.get('region')).to.eql(undefined);
+        });
+        pm.test('globals still bound', function () {
+            pm.expect(pm.globals.get('build')).to.eql('1.2.3');
+        });
+    )",
+    /*with_environment=*/false);
+    context->metrics_collector->record_response_sample (response_with ("{}"));
+
+    const auto validation = vayu::core::validate_scripts (context, *db_, false);
+
+    ASSERT_TRUE (validation.run.has_value ());
+    EXPECT_EQ (validation.run->passed, 2u);
+    EXPECT_EQ (validation.run->failed, 0u);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

**Plan.** Root cause is that the deferred pass owned a scope it had no business inventing: `validate_scripts` constructed a bare `vayu::Environment` (`run_manager.cpp:221`) and `run_replay` bound that one field (`:110`), so every replayed script read an empty environment and *no* globals or collection scope at all - while the run row already records `environment_id` and `load_script_variable_scopes` already exists for exactly this question, used by `POST /execute` and by the design scenario runner. A test like `pm.expect(json.region).to.eql(pm.environment.get('region'))` therefore passed on Send with the EU environment and failed on every sampled replay, and `testValidation` reported a failure rate that said the API broke when only the harness had. The approach resolves the run's scopes through that one existing loader and binds all four through a `bind_variable_scopes` extracted out of `bind_script_scopes`, so the replay is not a second call site deciding which scope is writable. The alternative I rejected was binding the four fields inline in `run_replay`: it is four lines today and a hand-rolled copy of the leaf-writable/ancestors-read-only rule (#234) forever after - the copy that stops receiving the primitive's fixes.

Verified the problem still exists at `825cb60` before touching anything - both anchors are as the issue describes.

**Which collection scope is the run's.** The same question the two sequential paths already answer, and they answer it differently for good reason: a scenario run's scope is the collection being *run* (`scenario_runner.cpp:440`, which has no single request row to derive one from), a single-request run's is the collection of its linked request (`load_script_variable_scopes(db, run)`). Both are reproduced here rather than collapsed into one, because collapsing them is what would break a scenario run - it carries no run-level `requestId`. Read off `context->config`, which is the payload the run row itself was populated from and where this function already reads `requestId`.

**Blast radius.** `bind_script_scopes`'s five call sites are unchanged in behaviour (it now delegates its first four assignments). `run_replay` is file-local with two call sites, both updated. Nothing downstream of `validate_scripts` reads a scope - the tallies are the only output - so the report shape, the SSE frames and the app are untouched; this PR adds no field and no wire key, and needs no app change (the issue names none).

**Two deliberate decisions, both recorded beside the code.**

- *Write semantics* (the issue asks for a ruling): one set of scopes serves the whole pass, so a `set()` is readable by the samples replayed after it, and **nothing is persisted**. `persist_script_variables` stays design-mode only - a reservoir sample is not an iteration, so there is no ordering under which "whichever replay ran last wins" would be a defensible thing to store.
- *A failed scope load is not caught.* The linked-request lookup used to sit in a `try` whose comment reasoned that a failure "costs the script a name, never the validation"; that row now also decides the collection scope, so the trade changed. A database failure propagates to `execute_load_test`, which logs it and stores no `testValidation` section - tallies computed against scopes that failed to load are exactly the silently wrong verdicts this issue is about, and "never judged" must not be reported as "judged and passed".

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `cd engine && ctest --preset linux-dev --output-on-failure` - **1915 tests, 100% passing**, 290s (1909 before; 6 new). No pre-existing failures observed. (The cold build needed `vcpkg-fix-port` first, per CLAUDE.md's 403 note.)

No TypeScript changed, so the app suite could not change colour and was not run. `mkdocs build --strict` could not be run - mkdocs is not installed here and the egress policy blocks installing it - but the docs edit adds no page, heading, anchor or link, only prose inside an existing section, so there is nothing new for the link check to resolve; CI's docs job is the real gate.

Six new tests in `engine/tests/load_script_scopes_test.cpp`, driven through `validate_scripts` against a real database, because the wiring between the loader and the replay is the thing under test - a test calling `run_replay` with scopes it built itself would stay green with the production path still binding nothing. All three mutations were applied for real (rebuild + re-run), not reasoned about:

| Mutation | What fails |
|---|---|
| Restore the pre-fix binding (one empty `Environment`, nothing else) | 5 of 6 - every scope test, single-request and per-step alike; the persistence guard correctly keeps passing, since the old code stored nothing either |
| Resolve the collection scope from the run-level `requestId` in both shapes | exactly `AScenarioStepReplayReadsTheRunningCollectionsScope` - a scenario run has no run-level request id, so its scope comes back empty |
| Call `persist_script_variables` after the pass | exactly `AReplayWriteIsNeverPersisted`, which proves that guard is not vacuous |

| Test | Asserts |
|---|---|
| `ATestPassingOnSendPassesUnderLoad` | the reported bug: the issue's own comparison of a response field against `pm.environment.get` passes under a run recorded with that environment |
| `GlobalsAndTheWholeCollectionChainAreBoundToo` | globals, the leaf collection scope, and an **inherited** ancestor variable - the D2 asymmetry's own case (#234), which the old path did not bind even empty |
| `AScenarioStepReplayReadsTheRunningCollectionsScope` | a scenario load run's per-step replay reads the running collection's scope, not a request-derived one |
| `AReplayWriteIsNeverPersisted` | environment, globals and collection blobs are byte-identical on disk after a pass whose script wrote to all three |
| `AWriteIsVisibleToTheSamplesReplayedAfterIt` | one set of scopes for the pass, pinned precisely: sample 1 fails (nothing written yet), sample 2 passes (reads sample 1's write) |
| `ARunWithNoEnvironmentStillBindsTheOtherScopes` | absent is not unbound - no environment still means `undefined` rather than an error, and globals stay bound |

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/scripting.md`'s load-mode section now states which scopes a deferred replay reads (and which collection's, for each run shape) and the write rule, which it previously described with no load-mode exception at all. `run_manager.cpp` and the new `bind_variable_scopes` carry the rationale beside the code. The new test file is registered in `engine/CMakeLists.txt`, per the engine guide's rule against an unbuilt suite.

## Related Issues

Closes #728

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChcD9Q4WQLdyGFeG4GskN6)_