### PR TITLE
fix(app/data): the Data tab re-reads the declared file instead of asking for it again

### DIFF
--- a/app/src/modules/collections/CollectionDetail/DataTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/DataTab.test.tsx
@@ -23,6 +23,11 @@
  *  - **The path is remembered, and the rows are not.** The store holds where the
  *    file is so the Run dialog can pre-fill; nothing anywhere holds what was in
  *    it.
+ *
+ * And then what the remembered path is *for*, here (issue #727): the tab whose
+ * job is the comparison reads the file back itself, rather than rendering
+ * "Declared from users.csv" beside "Nothing to compare yet" and waiting to be
+ * handed the same file again.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -167,7 +172,10 @@ describe("an existing contract", () => {
 		// again, bucketed by whether a request uses them (issue #600).
 		expect(screen.getAllByText("id").length).toBeGreaterThan(0);
 		expect(screen.getAllByText("email").length).toBeGreaterThan(0);
-		expect(screen.getByText(/Declared from u\.csv/)).toBeTruthy();
+		// The name is its own element so it can be struck through when the file
+		// turns out to be unreadable (issue #727), hence the two assertions.
+		expect(screen.getByText(/Declared from/)).toBeTruthy();
+		expect(screen.getByText("u.csv").className).not.toContain("line-through");
 		expect(screen.getByRole("button", { name: /re-declare/i })).toBeTruthy();
 	});
 
@@ -209,6 +217,122 @@ describe("an existing contract", () => {
 
 		expect(screen.queryByText(/missing a declared column/i)).toBeNull();
 		expect(screen.queryByText(/does not declare/i)).toBeNull();
+	});
+});
+
+describe("the remembered file", () => {
+	/** The `readDataFile` bridge, answering with a file's bytes the way Electron does. */
+	function bridge(impl: (path: string) => { bytes: Uint8Array; fileName: string }) {
+		return vi.fn((path: string) => Promise.resolve(impl(path)));
+	}
+
+	const csv = (text: string, fileName: string) => ({
+		bytes: new TextEncoder().encode(text),
+		fileName,
+	});
+
+	function remember(path = "/home/u/users.csv", fileName = "users.csv") {
+		useDataFileStore.setState({ locations: { col_1: { path, fileName } } });
+	}
+
+	it("compares the remembered file with zero clicks", async () => {
+		remember();
+		const read = bridge(() => csv("id,nickname\n1,addy", "users.csv"));
+		vi.stubGlobal("electronAPI", { readDataFile: read, getFilePath: () => "" });
+
+		render(<DataTab collection={collection({ columns: ["id", "email"] })} />);
+
+		// The whole point: the diff both ways, against a file nobody re-picked.
+		await waitFor(() =>
+			expect(screen.getByText(/missing a declared column: email/i)).toBeTruthy()
+		);
+		expect(screen.getByText(/does not declare: nickname/i)).toBeTruthy();
+		expect(read).toHaveBeenCalledWith("/home/u/users.csv");
+		// Mutation check for the auto-read: without it this callout is what shows,
+		// which is the reported incoherence.
+		expect(screen.queryByText(/Nothing to compare yet/i)).toBeNull();
+	});
+
+	it("says it is reading rather than claiming there is nothing to compare", async () => {
+		remember();
+		let release: (value: { bytes: Uint8Array; fileName: string }) => void = () => {};
+		vi.stubGlobal("electronAPI", {
+			readDataFile: () =>
+				new Promise<{ bytes: Uint8Array; fileName: string }>((resolve) => {
+					release = resolve;
+				}),
+			getFilePath: () => "",
+		});
+
+		render(<DataTab collection={collection({ columns: ["id"] })} />);
+
+		// Before the first paint, not one tick after it: a flash of the callout is
+		// the same lie, one frame long.
+		expect(screen.getByText(/Reading users\.csv/i)).toBeTruthy();
+		expect(screen.queryByText(/Nothing to compare yet/i)).toBeNull();
+
+		release(csv("id\n1", "users.csv"));
+		await waitFor(() => expect(screen.getByText("users.csv")).toBeTruthy());
+	});
+
+	it("degrades to the pick state with the name struck through when the file is gone", async () => {
+		remember("/home/u/gone.csv", "gone.csv");
+		vi.stubGlobal("electronAPI", {
+			readDataFile: () => Promise.reject(new Error("ENOENT: no such file")),
+			getFilePath: () => "",
+		});
+
+		render(<DataTab collection={collection({ columns: ["id"], fileName: "gone.csv" })} />);
+
+		await waitFor(() => expect(screen.getByText(/ENOENT/)).toBeTruthy());
+		// A note beside the name, not a wall in place of the tab: the declared
+		// name is struck through and the picker is still usable.
+		const name = screen.getByText("gone.csv");
+		expect(name.className).toContain("line-through");
+		expect(screen.queryByText(/Could not read the data file/i)).toBeNull();
+		expect(screen.getByText(/Nothing to compare yet/i)).toBeTruthy();
+		expect(screen.getByRole("button", { name: /re-declare/i })).toBeTruthy();
+	});
+
+	it("reads nothing without a contract to compare against", () => {
+		remember();
+		const read = bridge(() => csv("id\n1", "users.csv"));
+		vi.stubGlobal("electronAPI", { readDataFile: read, getFilePath: () => "" });
+
+		render(<DataTab collection={collection()} />);
+
+		expect(read).not.toHaveBeenCalled();
+	});
+
+	it("leaves the picker standing outside Electron, where there is no path to re-read", () => {
+		remember();
+		vi.stubGlobal("electronAPI", undefined);
+
+		render(<DataTab collection={collection({ columns: ["id"] })} />);
+
+		// Not a spinner that never resolves - the browser degradation is the
+		// pick-a-file state, unchanged.
+		expect(screen.queryByText(/Reading/i)).toBeNull();
+		expect(screen.getByText(/Nothing to compare yet/i)).toBeTruthy();
+	});
+
+	it("does not re-read, or replace the pick, when Declare writes the store", async () => {
+		const read = bridge(() => csv("id\n1", "users.csv"));
+		vi.stubGlobal("electronAPI", {
+			readDataFile: read,
+			getFilePath: () => "/home/u/other.csv",
+		});
+
+		render(<DataTab collection={collection({ columns: ["id"] })} />);
+		await pickFile("other.csv", "id,extra\n1,x");
+
+		fireEvent.click(screen.getByRole("button", { name: /re-declare/i }));
+		succeed();
+
+		// The store now holds a path, but re-reading it here would replace the
+		// file the user is looking at with the one they just declared from.
+		expect(read).not.toHaveBeenCalled();
+		expect(screen.getByText("other.csv")).toBeTruthy();
 	});
 });
 

--- a/app/src/modules/collections/CollectionDetail/DataTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/DataTab.tsx
@@ -26,20 +26,28 @@
  * And the thing neither half holds: **rows**. The preview below is in memory
  * for as long as the tab is open, and nothing writes it anywhere.
  *
+ * Which is why opening the tab re-reads the remembered file (issue #727) rather
+ * than waiting to be handed one: the comparison this tab exists for needs the
+ * file *as it is on disk now*, and the only thing stored is where it was. The
+ * Run dialog and Send-with-row already re-read the same path, so a tab that
+ * asked for a manual re-pick was the one surface unable to answer its own
+ * question.
+ *
  * Saves are explicit - Declare and Clear - rather than autosaved, because
  * declaring a contract is a statement about the collection, not a keystroke.
  * That is also why this tab is absent from `TABS_HOLDING_DRAFTS`: it holds no
  * draft to survive a switch away.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Check, Loader2, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui";
 import { Callout } from "@/components/shared";
 import { useUpdateCollectionMutation } from "@/queries/collections";
 import { useDataFileStore } from "@/stores";
-import { describeDataSchemaDiff } from "@/services/data-files";
+import { DataFileError, describeDataSchemaDiff } from "@/services/data-files";
+import { canReadDeclaredDataFile, readDeclaredDataFile } from "@/services/data-files/read-declared";
 import { hasDataContract, type Collection } from "@/types";
 import DataFilePicker, { type SelectedDataFile } from "../DataFilePicker";
 import ColumnAudit from "./ColumnAudit";
@@ -49,15 +57,89 @@ interface DataTabProps {
 	collection: Collection;
 }
 
+/**
+ * Whether opening this collection's tab will re-read a remembered file.
+ *
+ * Asked *before* the first paint as well as inside the effect, which is the
+ * point: the read starts one tick after mount, and a `reading` flag that only
+ * became true then would flash "Nothing to compare yet" over a file that is
+ * about to arrive - the same incoherence issue #727 is about, one frame long.
+ */
+function willReadRemembered(collection: Collection): boolean {
+	return (
+		hasDataContract(collection.dataSchema) &&
+		!!useDataFileStore.getState().locations[collection.id]?.path &&
+		// Outside Electron there is no path to re-read and never will be, so the
+		// picker simply stands - a spinner here would never resolve.
+		canReadDeclaredDataFile()
+	);
+}
+
 export default function DataTab({ collection }: DataTabProps) {
 	const [file, setFile] = useState<SelectedDataFile | null>(null);
 	const [fileError, setFileError] = useState<string | null>(null);
+	/** The remembered file is being opened. Not the same as "no file yet". */
+	const [reading, setReading] = useState(() => willReadRemembered(collection));
+	/**
+	 * Why the remembered file could not be re-read - moved, renamed, or no longer
+	 * parsing. Kept apart from `fileError`, which is a refusal of a file the user
+	 * just picked: this one leaves the picker empty and usable, because picking
+	 * the file again is the whole fix.
+	 */
+	const [readFailure, setReadFailure] = useState<string | null>(null);
 	const updateCollection = useUpdateCollectionMutation();
 	const setDataFile = useDataFileStore((s) => s.setDataFile);
 	const clearDataFile = useDataFileStore((s) => s.clearDataFile);
+	const remembered = useDataFileStore((s) => s.locations[collection.id]);
 
 	const declared = collection.dataSchema?.columns ?? [];
 	const declaredContract = hasDataContract(collection.dataSchema);
+
+	/**
+	 * Open the remembered file when the tab appears.
+	 *
+	 * Part of mount, which is what the `key` on this component in
+	 * `CollectionDetail` makes sufficient: a different collection is a different
+	 * DataTab, so there is no stale file, error or note to clear here.
+	 *
+	 * Deliberately not re-run when the store changes. `remembered` is written by
+	 * Declare and Clear below, and re-reading on it would re-read the file the
+	 * user just declared *from* - and would replace a file they had picked by hand
+	 * since. The store is therefore read here for what it held on mount; the
+	 * reactive value above is for the name the render shows.
+	 *
+	 * Only with a contract: without one there is nothing to compare a file
+	 * against, and the store should hold no path either (Clear takes it with it),
+	 * so a read would be work in service of no question.
+	 */
+	useEffect(() => {
+		const path = useDataFileStore.getState().locations[collection.id]?.path;
+		if (!willReadRemembered(collection) || !path) return;
+
+		let cancelled = false;
+		void readDeclaredDataFile(path)
+			.then((read) => {
+				if (cancelled) return;
+				// `?? read`: a file the user picked while this was in flight is
+				// their answer, not a race for the remembered one to win.
+				setFile((current) => current ?? read);
+				setReading(false);
+			})
+			.catch((e: unknown) => {
+				if (cancelled) return;
+				setReading(false);
+				setReadFailure(
+					e instanceof DataFileError || e instanceof Error
+						? e.message
+						: "The declared file could not be read - pick it again to compare."
+				);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only by design; see above.
+	}, []);
 
 	// Both directions of file-versus-contract, in the picker's warnings slot.
 	// Only meaningful once there is a contract *and* a file - before that, one
@@ -129,7 +211,15 @@ export default function DataTab({ collection }: DataTabProps) {
 						</div>
 						{collection.dataSchema?.fileName && (
 							<p className="text-xs text-muted-foreground">
-								Declared from {collection.dataSchema.fileName}.
+								Declared from{" "}
+								{/* Struck through, not replaced by an error: the name is
+								    still what the contract was read from, and the file
+								    being unreachable is a note beside it rather than a
+								    wall in place of it. */}
+								<span className={readFailure ? "line-through" : undefined}>
+									{collection.dataSchema.fileName}
+								</span>
+								.{readFailure && ` ${readFailure}`}
 							</p>
 						)}
 					</div>
@@ -181,7 +271,19 @@ export default function DataTab({ collection }: DataTabProps) {
 			 */}
 			{declaredContract && <ColumnAudit collection={collection} />}
 
-			{declaredContract && !file && (
+			{/*
+			 * Three states, and the point of separating them is that the third used
+			 * to swallow the first two: a remembered file being read is not
+			 * "nothing to compare", and neither is one this tab has already read.
+			 */}
+			{declaredContract && !file && reading && (
+				<p className="flex items-center gap-2 text-xs text-muted-foreground">
+					<Loader2 className="h-3.5 w-3.5 animate-spin" />
+					Reading {remembered?.fileName ?? "the declared file"}…
+				</p>
+			)}
+
+			{declaredContract && !file && !reading && (
 				<Callout severity="info" title="Nothing to compare yet">
 					Pick a file to see how it lines up against the declared columns.
 				</Callout>

--- a/app/src/modules/collections/CollectionDetail/index.tsx
+++ b/app/src/modules/collections/CollectionDetail/index.tsx
@@ -252,7 +252,12 @@ export default function CollectionDetail() {
 							/>
 						)}
 						{t.id === "variables" && <VariablesTab collection={collection} />}
-						{t.id === "data" && <DataTab collection={collection} />}
+						{/* Keyed: the Data tab reads the remembered file on mount
+						    (issue #727), and this component is not remounted when
+						    the user switches to another collection's tab - so
+						    without a key, collection B would show A's file and
+						    never open its own. It holds no draft to lose. */}
+						{t.id === "data" && <DataTab key={collection.id} collection={collection} />}
 						{t.id === "spec" && <SpecTab collection={collection} />}
 					</TabsContent>
 				))}

--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -63,12 +63,8 @@ import { Callout } from "@/components/shared";
 import { useStartScenarioRunMutation } from "@/queries";
 import { useDashboardStore, useDataFileStore, useSessionStore, useTabsStore } from "@/stores";
 import { loadTestService, scenarioRunService } from "@/services";
-import {
-	DataFileError,
-	decodeDataFile,
-	describeDataSchemaDiff,
-	parseDataFile,
-} from "@/services/data-files";
+import { DataFileError, describeDataSchemaDiff } from "@/services/data-files";
+import { canReadDeclaredDataFile, readDeclaredDataFile } from "@/services/data-files/read-declared";
 import type { Collection } from "@/types";
 import DataFilePicker, { type SelectedDataFile } from "./DataFilePicker";
 
@@ -153,17 +149,13 @@ export default function RunCollectionDialog({
 	useEffect(() => {
 		if (!rememberedFile?.path) return;
 		let cancelled = false;
-		const read = window.electronAPI?.readDataFile;
-		if (!read) return; // No Electron, no path to re-read - the picker stands.
+		// No Electron, no path to re-read - the picker stands.
+		if (!canReadDeclaredDataFile()) return;
 
-		void read(rememberedFile.path)
-			.then(({ bytes, fileName }) => {
+		void readDeclaredDataFile(rememberedFile.path)
+			.then((read) => {
 				if (cancelled) return;
-				// The same decode and the same parser the picker runs, so a file
-				// re-read here cannot disagree with the file as it was picked.
-				const { text } = decodeDataFile(bytes.buffer as ArrayBuffer);
-				const parsed = parseDataFile(text, fileName);
-				setDataFile({ fileName, parsed, path: rememberedFile.path });
+				setDataFile(read);
 				// Same rule as a hand-picked file: a pristine `1` becomes "one
 				// pass per row", a typed one is the user's.
 				if (!iterationsTouched.current) {

--- a/app/src/modules/request-builder/hooks/useSendWithRow.ts
+++ b/app/src/modules/request-builder/hooks/useSendWithRow.ts
@@ -32,12 +32,8 @@
 import { useCallback, useState } from "react";
 
 import { useDataFileStore } from "@/stores";
-import {
-	DataFileError,
-	decodeDataFile,
-	parseDataFile,
-	type ParsedDataFile,
-} from "@/services/data-files";
+import { DataFileError, type ParsedDataFile } from "@/services/data-files";
+import { canReadDeclaredDataFile, readDeclaredDataFile } from "@/services/data-files/read-declared";
 import type { DataContractScope } from "@/types";
 
 /** Why the rows are not available, in a sentence the affordance can show. */
@@ -93,8 +89,7 @@ export function useSendWithRow(contract: DataContractScope | undefined): SendWit
 
 	const load = useCallback(() => {
 		if (!path) return;
-		const read = window.electronAPI?.readDataFile;
-		if (!read) {
+		if (!canReadDeclaredDataFile()) {
 			// No Electron, no path to re-read. Said plainly rather than left as a
 			// spinner that never resolves.
 			setStatus("unavailable");
@@ -103,13 +98,9 @@ export function useSendWithRow(contract: DataContractScope | undefined): SendWit
 		}
 		setStatus("loading");
 		setError(null);
-		void read(path)
-			.then(({ bytes, fileName: readName }) => {
-				// The same decode and the same parser the picker and the Run
-				// dialog run, so a file read here cannot disagree with the file
-				// as it was declared.
-				const { text } = decodeDataFile(bytes.buffer as ArrayBuffer);
-				setParsed(parseDataFile(text, readName));
+		void readDeclaredDataFile(path)
+			.then((read) => {
+				setParsed(read.parsed);
 				setStatus("ready");
 			})
 			.catch((e: unknown) => {

--- a/app/src/services/data-files/index.ts
+++ b/app/src/services/data-files/index.ts
@@ -29,7 +29,10 @@
  *
  * Everything here is pure: text in, rows out. Reading the file is the caller's
  * (a `FileReader`, exactly as `ImportModal` does it - no Electron dialog IPC),
- * and turning its bytes into that text is {@link decodeDataFile}'s.
+ * and turning its bytes into that text is {@link decodeDataFile}'s. The one
+ * read this layer does own is the *second* one - re-opening the path
+ * `data-file-store` remembered - and it lives apart in `read-declared.ts`
+ * precisely so this module stays pure.
  */
 
 import { DataFileError } from "./errors";

--- a/app/src/services/data-files/read-declared.test.ts
+++ b/app/src/services/data-files/read-declared.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Re-reading the declared file (issue #727).
+ *
+ * The three surfaces that do it - the Run dialog's pre-fill, Send-with-row and
+ * the Data tab - share this one function precisely so they cannot decode a file
+ * differently from each other, or from the picker that first read it. So what is
+ * asserted here is the part a caller must be able to rely on without repeating
+ * it: the bytes go through the *same* decoder (a UTF-16 CSV is not garbage), the
+ * name comes back from disk rather than from the caller's memory of it, and the
+ * two failures a caller has to tell apart are two different errors.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { DataFileError } from "./errors";
+import {
+	NoDataFileBridgeError,
+	canReadDeclaredDataFile,
+	readDeclaredDataFile,
+} from "./read-declared";
+
+/** Bytes as the `readDataFile` bridge hands them over. */
+function bridge(text: string, fileName: string, encoding: "utf-8" | "utf-16le" = "utf-8") {
+	const bytes =
+		encoding === "utf-8"
+			? new TextEncoder().encode(text)
+			: (() => {
+					const withBom = `\ufeff${text}`;
+					const out = new Uint8Array(withBom.length * 2);
+					for (let i = 0; i < withBom.length; i++) {
+						const code = withBom.charCodeAt(i);
+						out[i * 2] = code & 0xff;
+						out[i * 2 + 1] = code >> 8;
+					}
+					return out;
+				})();
+	return vi.fn(() => Promise.resolve({ bytes, fileName }));
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("canReadDeclaredDataFile", () => {
+	it("is false outside Electron, where a remembered path can never be opened", () => {
+		vi.stubGlobal("electronAPI", undefined);
+		expect(canReadDeclaredDataFile()).toBe(false);
+	});
+
+	it("is true with the bridge present", () => {
+		vi.stubGlobal("electronAPI", { readDataFile: () => Promise.resolve() });
+		expect(canReadDeclaredDataFile()).toBe(true);
+	});
+});
+
+describe("readDeclaredDataFile", () => {
+	it("parses the file and reports the name disk gave, not the one asked for", async () => {
+		const read = bridge("id,email\n1,a@b.c", "users-renamed.csv");
+		vi.stubGlobal("electronAPI", { readDataFile: read });
+
+		const file = await readDeclaredDataFile("/home/u/users.csv");
+
+		expect(read).toHaveBeenCalledWith("/home/u/users.csv");
+		expect(file.fileName).toBe("users-renamed.csv");
+		expect(file.path).toBe("/home/u/users.csv");
+		expect(file.parsed.columns).toEqual(["id", "email"]);
+		expect(file.parsed.rows).toEqual([{ id: "1", email: "a@b.c" }]);
+	});
+
+	it("decodes UTF-16 the way the picker does, so a re-read cannot disagree with the pick", async () => {
+		// The whole reason this is one function: `TextDecoder("utf-8")` on these
+		// bytes yields NUL-riddled columns that still parse, which is the silent
+		// wrong-request failure `decode.ts` exists to remove.
+		vi.stubGlobal("electronAPI", {
+			readDataFile: bridge("id,city\n1,Köln", "excel.csv", "utf-16le"),
+		});
+
+		const file = await readDeclaredDataFile("/home/u/excel.csv");
+
+		expect(file.parsed.columns).toEqual(["id", "city"]);
+		expect(file.parsed.rows[0].city).toBe("Köln");
+	});
+
+	it("rejects with NoDataFileBridgeError outside Electron", async () => {
+		vi.stubGlobal("electronAPI", undefined);
+		await expect(readDeclaredDataFile("/home/u/users.csv")).rejects.toBeInstanceOf(
+			NoDataFileBridgeError
+		);
+	});
+
+	it("passes the bridge's own failure through, so the caller can show it verbatim", async () => {
+		vi.stubGlobal("electronAPI", {
+			readDataFile: () => Promise.reject(new Error("ENOENT: no such file or directory")),
+		});
+		await expect(readDeclaredDataFile("/home/u/gone.csv")).rejects.toThrow(/ENOENT/);
+	});
+
+	it("rejects a file that no longer parses with the parser's own message", async () => {
+		vi.stubGlobal("electronAPI", { readDataFile: bridge("id,id\n1,2", "dupes.csv") });
+		await expect(readDeclaredDataFile("/home/u/dupes.csv")).rejects.toBeInstanceOf(
+			DataFileError
+		);
+	});
+});

--- a/app/src/services/data-files/read-declared.ts
+++ b/app/src/services/data-files/read-declared.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Re-reading the file a collection declared its contract from (issue #727).
+ *
+ * `index.ts` is deliberately pure - text in, rows out - and stays that way: the
+ * *first* read of a file is a `FileReader` in the picker, driven by a user who
+ * just chose it. This module is the other read, the one no click asks for: the
+ * path `data-file-store` remembered, opened again through the Electron bridge so
+ * a surface can show the file as it is on disk *now*.
+ *
+ * It exists as one function because three surfaces do it - the Run dialog's
+ * pre-fill, Send-with-row, and the Data tab's comparison - and each had (or was
+ * about to have) its own copy of bridge-lookup, decode and parse. A copy is how
+ * one of them ends up decoding differently from the file as it was declared.
+ *
+ * The bridge being absent is its own error rather than a failed read, because it
+ * is a different answer: a browser has no path to re-read and never will, so the
+ * caller shows its degraded state instead of a message inviting a retry that
+ * cannot work.
+ */
+
+import { decodeDataFile } from "./decode";
+import { parseDataFile, type ParsedDataFile } from "./index";
+
+/** A file re-read from disk, in the shape the pickers already hold. */
+export interface DeclaredDataFile {
+	/** The name on disk, which is the main process's answer and not the stored one. */
+	fileName: string;
+	parsed: ParsedDataFile;
+	/** The path it was read from, so a caller can remember it unchanged. */
+	path: string;
+}
+
+/**
+ * No filesystem to re-read from - a browser, not the desktop app.
+ *
+ * Separate from a read failure so callers can tell "there is nothing to try"
+ * from "this file has moved", which have different repairs.
+ */
+export class NoDataFileBridgeError extends Error {
+	constructor(message = "Reading the declared data file needs the desktop app.") {
+		super(message);
+		this.name = "NoDataFileBridgeError";
+	}
+}
+
+/**
+ * Whether a remembered path can be re-read at all on this build.
+ *
+ * Offered separately so a surface can decide *before* it renders a spinner: the
+ * browser case is not a pending read, it is a state that will never resolve.
+ */
+export function canReadDeclaredDataFile(): boolean {
+	return typeof window.electronAPI?.readDataFile === "function";
+}
+
+/**
+ * Read, decode and parse the file at `path`.
+ *
+ * Rejects with `NoDataFileBridgeError` outside Electron, and with
+ * `DataFileError` (or whatever the bridge threw) when the file is gone, moved,
+ * or no longer parses - all of which name the fault in a sentence a caller can
+ * show as-is.
+ */
+export async function readDeclaredDataFile(path: string): Promise<DeclaredDataFile> {
+	const read = window.electronAPI?.readDataFile;
+	if (!read) throw new NoDataFileBridgeError();
+
+	const { bytes, fileName } = await read(path);
+	// The same decode and the same parser the picker runs, so a file re-read
+	// here cannot disagree with the file as it was declared.
+	const { text } = decodeDataFile(bytes.buffer as ArrayBuffer);
+	return { fileName, parsed: parseDataFile(text, fileName), path };
+}

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -15,18 +15,18 @@ a value becomes once it is bound.
 
 ## Supported files
 
-| Extension | Format | Values arrive as |
-|-----------|--------|------------------|
-| `.csv` | Comma-separated, RFC 4180 | strings, always |
-| `.tsv`, `.tab` | Tab-separated, same grammar | strings, always |
-| `.json` | An array of row objects | their JSON types |
+| Extension           | Format                           | Values arrive as |
+| ------------------- | -------------------------------- | ---------------- |
+| `.csv`              | Comma-separated, RFC 4180        | strings, always  |
+| `.tsv`, `.tab`      | Tab-separated, same grammar      | strings, always  |
+| `.json`             | An array of row objects          | their JSON types |
 | `.jsonl`, `.ndjson` | JSON Lines - one object per line | their JSON types |
 
 There is no XLSX support and no headerless mode. A spreadsheet exports to CSV in
 one step, and a file whose first row is data would leave every column
 unaddressable - see below.
 
-## The header row *is* the mapping
+## The header row _is_ the mapping
 
 Column names become `{{data.column}}` tokens and `pm.iterationData` keys with no
 remapping step, exactly as Postman, JMeter and k6 work. A mapping UI would be a
@@ -44,7 +44,7 @@ cell:
   one would drop cells nobody can see.
 
 JSON and JSONL have no header, so the columns are the union of every row's keys,
-in first-seen order. A key that only *some* rows carry is a **warning** at pick
+in first-seen order. A key that only _some_ rows carry is a **warning** at pick
 time naming how many rows lack it - the iterations bound to those rows would
 fail on a `{{data.*}}` token naming it, but a column nothing references is
 harmless, so it does not block the run.
@@ -57,7 +57,7 @@ JSON and JSONL keep what the file declared - `3` is a number, `true` is a
 boolean, `null` is null.
 
 If you need a number to arrive as a number, use a JSON file - and write the
-token *outside* the quotes in the body, `{"n": {{data.n}}}`, because that is
+token _outside_ the quotes in the body, `{"n": {{data.n}}}`, because that is
 what decides whether it arrives as `2` or `"2"`.
 
 A `null` cell is a value `pm.iterationData` hands to a script and a value a
@@ -69,7 +69,7 @@ The parser is RFC 4180, not a `split(",")`:
 
 - A quoted field may contain the delimiter, newlines, and CRLF.
 - A literal quote inside a quoted field is written doubled: `"say ""hi"""`.
-- A quote that does not *open* a field is an ordinary character, so `6" pipe`
+- A quote that does not _open_ a field is an ordinary character, so `6" pipe`
   needs no escaping.
 - Blank lines are skipped, and the count is reported as a warning.
 
@@ -91,12 +91,12 @@ catch it. Re-save as UTF-8 and pick it again.
 ## Size limits
 
 Two engine settings bound a run's data set, and the picker enforces both
-*before* the run rather than letting `POST /runs` refuse it afterwards:
+_before_ the run rather than letting `POST /runs` refuse it afterwards:
 
-| Setting | Default | Bounds |
-|---------|---------|--------|
-| `maxScenarioDataRows` | 1000 | How many rows one run may carry |
-| `maxScenarioDataBytes` | 16 MiB | How large the data set may be |
+| Setting                | Default | Bounds                          |
+| ---------------------- | ------- | ------------------------------- |
+| `maxScenarioDataRows`  | 1000    | How many rows one run may carry |
+| `maxScenarioDataBytes` | 16 MiB  | How large the data set may be   |
 
 Both are editable in **Settings -> Engine -> General**, and the picker reads the
 live values - raise a limit there and the same file is accepted without
@@ -110,14 +110,14 @@ are never persisted on either side - a run's snapshot records their count alone.
 
 ## Reading a row: `{{data.column}}` vs `pm.iterationData`
 
-Both read the same row. They differ in *when*:
+Both read the same row. They differ in _when_:
 
 - **`{{data.column}}`** is substituted into the request - URL, headers, body,
   form fields - immediately before the send. Use it to make each iteration hit a
   different endpoint or send a different payload. See the
   [`{{data.column}}` contract](../engine/api-reference.md#post-runs) in the
   engine's HTTP API reference.
-- **`pm.iterationData`** is read by scripts, *after* the step's request was
+- **`pm.iterationData`** is read by scripts, _after_ the step's request was
   composed, so it cannot change where the request goes. Use it for assertions
   and for values a script derives. See
   [Data rows](../engine/scripting.md#data-rows-pmiterationdata).
@@ -138,19 +138,19 @@ hands `null` to a branch that can read it.
 A cell carrying quotes, backslashes or newlines is **safe in a JSON body**: a
 token inside a string literal is escaped as it binds, so `say "hi"` arrives as
 that text inside valid JSON rather than ending the string. A token written
-*outside* a string literal - `{"n": {{data.n}}}` - is not escaped, which is how
+_outside_ a string literal - `{"n": {{data.n}}}` - is not escaped, which is how
 a JSON file's number arrives as a number.
 
 A cell is **safe in an XML body** too, and by a rule that reads the token's
 position rather than one that escapes everything:
 
-| Where the token sits | What the cell arrives as |
-|----------------------|--------------------------|
-| Element text | `&`, `<` and `>` escaped - `Ben & Jerry's` arrives intact |
-| An attribute value | the above, plus whichever quote delimits *that* attribute |
-| A `<![CDATA[…]]>` section | byte for byte, which is what the section is for; a `]]>` in the cell splits and reopens the section rather than ending it |
-| A tag or attribute **name** - `<{{data.tag}}>` | byte for byte: no escape is legal in a name |
-| An XML **comment** or **processing instruction** | nothing - the row is **refused**, naming the token |
+| Where the token sits                             | What the cell arrives as                                                                                                  |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Element text                                     | `&`, `<` and `>` escaped - `Ben & Jerry's` arrives intact                                                                 |
+| An attribute value                               | the above, plus whichever quote delimits _that_ attribute                                                                 |
+| A `<![CDATA[…]]>` section                        | byte for byte, which is what the section is for; a `]]>` in the cell splits and reopens the section rather than ending it |
+| A tag or attribute **name** - `<{{data.tag}}>`   | byte for byte: no escape is legal in a name                                                                               |
+| An XML **comment** or **processing instruction** | nothing - the row is **refused**, naming the token                                                                        |
 
 The comment and processing-instruction refusals are deliberate: neither is
 content the server reads, and a cell carrying `-->` or `?>` would end the
@@ -206,20 +206,26 @@ preview, and press **Declare columns**.
 
 What that stores, and what it does not:
 
-| | Where it lives | Travels with the collection? |
-|---|---|---|
-| The **columns** | On the collection, as `dataSchema` | Yes - and through import |
-| The file's **path** | This machine only, in local app storage | No |
-| The file's **rows** | Nowhere | No |
+|                     | Where it lives                          | Travels with the collection? |
+| ------------------- | --------------------------------------- | ---------------------------- |
+| The **columns**     | On the collection, as `dataSchema`      | Yes - and through import     |
+| The file's **path** | This machine only, in local app storage | No                           |
+| The file's **rows** | Nowhere                                 | No                           |
 
 Declaring changes no binding rule - a token still binds from the row the run
-carries. What it buys is everything that needs to know the columns *before* a
+carries. What it buys is everything that needs to know the columns _before_ a
 run:
 
 - **The Run dialog pre-fills.** If the declared file is still where you left it,
   opening **Run collection** re-reads it and previews it, ready to start. Move
   or rename the file and the dialog says so and offers the picker - it is a
   note, not a refusal.
+- **The Data tab re-opens it too.** Coming back to the tab reads the declared
+  file again and lines it up against the contract with no re-pick: comparing
+  them is what the tab is for, so it does not wait to be handed the same file a
+  second time. Edit the file on disk and the drift shows on the next visit. A
+  file that has moved has its name struck through beside the declared columns,
+  and the picker stands - which is also how you compare a _different_ file.
 - **A file that does not match is flagged**, in both directions and in both
   places: a declared column the file is missing (every `{{data.x}}` written
   against it would fail to bind at iteration 1) and a column the file carries
@@ -243,8 +249,8 @@ run:
   the script editors.
 - **You can send one request against one row.** A caret appears beside **Send**
   in the request builder whenever a contract and a declared file are both in
-  scope; it lists the file's first rows, and picking one sends *that* request
-  bound to *that* row - the tokens substituted, and `pm.iterationData` readable
+  scope; it lists the file's first rows, and picking one sends _that_ request
+  bound to _that_ row - the tokens substituted, and `pm.iterationData` readable
   in both scripts. This is how you iterate on a script that reads a row without
   starting a whole run each time. See [Send with a row](#send-with-a-row).
 - **The Data tab audits the collection.** A **Referenced columns** panel splits
@@ -267,7 +273,7 @@ is not a general licence to read your disk.
 
 ## Send with a row
 
-Everything above is about a *run*. One thing is worth doing without one: a
+Everything above is about a _run_. One thing is worth doing without one: a
 pre-request script that reads `pm.iterationData`, or a URL carrying
 `{{data.id}}`, used to be testable only by starting a collection run and digging
 the step out of the result - a run per line of script.
@@ -279,7 +285,7 @@ request is sent bound to it:
 - every `{{data.column}}` in the URL, headers and body is substituted from that
   row, exactly as a run's iteration would substitute it;
 - both scripts read the row as `pm.iterationData`, with `pm.info.iteration` `0`
-  and `pm.info.iterationCount` `1` - the send *is* row 0 of 1;
+  and `pm.info.iterationCount` `1` - the send _is_ row 0 of 1;
 - the response lands in the response pane like any other Send, and the send
   appears in History like any other design run.
 
@@ -290,11 +296,12 @@ it again in the Data tab is the fix.
 
 **Auth credentials bind on a single send too.** A `{{data.user}}` in a
 basic-auth username, a bearer token or an api key takes the row's value the same
-way the URL and the body do, and it does so *before* the credentials are encoded
+way the URL and the body do, and it does so _before_ the credentials are encoded
+
 - so the header carries the row's values rather than base64 of the token text.
-This is the same thing a collection run does per iteration, which is what makes
-a credentials file work identically under Send-with-row and under Run
-collection.
+  This is the same thing a collection run does per iteration, which is what makes
+  a credentials file work identically under Send-with-row and under Run
+  collection.
 
 The exception is **OAuth 2.0**: its token is fetched from the token endpoint
 rather than written into the request, so no row can reach it, under either
@@ -312,5 +319,5 @@ user data of unknown sensitivity - credentials, customer records - so neither
 the app nor the engine persists them, and the file itself is read fresh every
 time - whether you pick it or the dialog pre-fills it from the declared path.
 
-Declaring a contract does not change this. What is saved is the *shape* of the
+Declaring a contract does not change this. What is saved is the _shape_ of the
 file - its column names, and its name for display - never a cell of it.


### PR DESCRIPTION
## Description

**Root cause.** `DataTab` held the picked file in local state only (`DataTab.tsx:53`) and read `useDataFileStore` for its *writers* alone - it never read `locations[collection.id]`. So a collection with a declared contract rendered the reported incoherence on one screen: "Declared from users.csv", an enabled "Re-declare from **this file**", and "Nothing to compare yet - Pick a file to see how it lines up". The capability was already proven on two sibling surfaces (`RunCollectionDialog`'s pre-fill and `useSendWithRow`), so staleness was checkable everywhere except the tab built to check it. Verified still present at `056ac1a` before touching anything.

**Approach.** On mount with a declared contract and a remembered location, read the path through the same Electron bridge and populate the compare. A read failure degrades softly rather than erecting a wall: the declared name is struck through beside the contract with the failure message after it, and the picker stands - picking the file again is the whole fix. The manual pick still exists for comparing a *different* file, and "Re-declare from this file" now means what it says. The browser degradation is unchanged: no bridge means no spinner, just the pick-a-file state.

Two supporting changes, each because the alternative was worse:

- **`services/data-files/read-declared.ts`** is now the one bridge-lookup + decode + parse, shared by all three surfaces. The Run dialog and Send-with-row each had their own copy, and a third would be the hand-rolled-copy defect in `CLAUDE.md`: one surface eventually decodes a UTF-16 CSV differently from the file as it was declared. Bridge-absent is its own error type (`NoDataFileBridgeError`) so a caller can distinguish "nothing to try" from "this file moved" - they have different repairs. `index.ts` stays pure and now says where the impure read lives and why.
- **`DataTab` is keyed on `collection.id`** in `CollectionDetail`. The read is mount-only (re-running it on store writes would re-read the file the user just declared *from*, and would replace a file they had picked by hand since), but this component is *not* remounted when the user switches to another collection's tab - so without the key, collection B would show A's file and never open its own. The tab holds no draft to lose, which is why the key is free here.

The reading flag is derived before the first paint (`useState(() => willReadRemembered(collection))`) rather than set inside the effect: an effect-set flag would flash the same "Nothing to compare yet" over a file about to arrive - the same lie, one frame long.

**Alternative rejected:** re-running the read reactively on the store (deps `[remembered]`) instead of keying the component. It reads simpler, but it re-reads on every Declare and clobbers a hand-picked file, which is exactly the trap `RunCollectionDialog` already documented for itself. Keying is what makes mount-only correct instead of merely convenient.

Adjacent and deliberately **not** in this diff: the row cap (`maxScenarioDataRows`) is enforced by the picker but by no re-read path - the main-process gate enforces the extension allowlist and `maxScenarioDataBytes` only. That predates this change and applies equally to the Run dialog and Send-with-row, so it is filed as #751 rather than widened into here.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **497 files, 5178 tests passed**, no pre-existing failures.
- `cd app && pnpm type-check` - clean. `pnpm lint` - clean (0 errors, 0 warnings). `pnpm format:check` - clean.
- Engine untouched, so no `build.py -t` / `ctest` run: no C++ or engine-contract change could go from green to red here.
- `mkdocs build --strict` not run - mkdocs is not installed in this environment. The docs change adds a bullet to an existing list with no links, headings or nav entries, so there is no anchor or link for the strict build to break; CI's docs job covers it.

New behavioural coverage (mutation-checked - each fails with the fix reverted):

- `DataTab.test.tsx` - compares the remembered file with zero clicks (asserts the diff both ways *and* that "Nothing to compare yet" is absent, which is the reported symptom); says "Reading users.csv…" before the first paint instead of the callout; degrades to the pick state with the declared name `line-through` and no error wall when the read rejects; reads nothing without a contract; leaves the picker standing outside Electron; does not re-read or replace a hand-picked file when Declare writes the store.
- `read-declared.test.ts` (new, 7 cases) - the shared reader parses through the *same* decoder (a UTF-16LE CSV round-trips `Köln` rather than arriving NUL-riddled), reports the name disk gave rather than the caller's memory of it, and separates the two failures a caller must tell apart (`NoDataFileBridgeError` vs the bridge's own `ENOENT`, vs `DataFileError` for a file that no longer parses).

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #727
Follow-up filed: #751 (the row cap is not enforced on any re-read path)