### PR TITLE
fix(app/data): enforce maxScenarioDataRows on every re-read of a declared file

### DIFF
--- a/app/src/modules/collections/CollectionDetail/DataTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/DataTab.test.tsx
@@ -46,10 +46,16 @@ vi.mock("@/queries/collections", () => ({
 	useUpdateCollectionMutation: () => mutation,
 }));
 
+/**
+ * The engine data caps, as `useDataFileLimits` reads them. Empty leaves the
+ * seeds standing, which is every case but the row-cap one below.
+ */
+const configEntries: { key: string; value: string }[] = [];
+
 vi.mock("@/queries", () => ({
-	// The picker reads the two engine caps through `useDataFileLimits`; empty
-	// entries leave it on the seeds, which no case here goes near.
-	useConfigQuery: () => ({ data: { entries: [] } }),
+	// The picker and the tab's own re-read both read the caps through
+	// `useDataFileLimits`.
+	useConfigQuery: () => ({ data: { entries: configEntries } }),
 	// The referenced-columns panel (issue #600) reads both of these. It has its
 	// own suite - `ColumnAudit.test.tsx` - so here it only has to render: no
 	// collections means no subtree to audit, and no requests means every
@@ -93,6 +99,7 @@ function succeed() {
 }
 
 beforeEach(() => {
+	configEntries.length = 0;
 	mutation.mutate.mockClear();
 	mutation.isPending = false;
 	mutation.isError = false;
@@ -292,6 +299,44 @@ describe("the remembered file", () => {
 		expect(screen.queryByText(/Could not read the data file/i)).toBeNull();
 		expect(screen.getByText(/Nothing to compare yet/i)).toBeTruthy();
 		expect(screen.getByRole("button", { name: /re-declare/i })).toBeTruthy();
+	});
+
+	/*
+	 * The row cap on the tab's own re-read (issue #751). The picker refuses a
+	 * hand-picked file over `maxScenarioDataRows` naming the setting; a file
+	 * declared under a higher cap and re-read under a lower one has to meet the
+	 * same refusal, rather than being compared against the contract and then
+	 * refused by `POST /runs` at the next run.
+	 */
+	it("refuses a remembered file over the row cap, naming the setting", async () => {
+		remember("/home/u/grown.csv", "grown.csv");
+		vi.stubGlobal("electronAPI", {
+			readDataFile: bridge(() => csv("id\n1\n2\n3", "grown.csv")),
+			getFilePath: () => "",
+		});
+		configEntries.push({ key: "maxScenarioDataRows", value: "2" });
+
+		render(<DataTab collection={collection({ columns: ["id"], fileName: "grown.csv" })} />);
+
+		await waitFor(() =>
+			expect(screen.getByText(/3 rows, over the 2[\s\S]*maxScenarioDataRows/)).toBeTruthy()
+		);
+		// Refused, not compared: no preview of a file no run can use.
+		expect(screen.getByText(/Nothing to compare yet/i)).toBeTruthy();
+	});
+
+	it("compares that same file once the setting is raised", async () => {
+		remember("/home/u/grown.csv", "grown.csv");
+		vi.stubGlobal("electronAPI", {
+			readDataFile: bridge(() => csv("id\n1\n2\n3", "grown.csv")),
+			getFilePath: () => "",
+		});
+		configEntries.push({ key: "maxScenarioDataRows", value: "3" });
+
+		render(<DataTab collection={collection({ columns: ["id"], fileName: "grown.csv" })} />);
+
+		await waitFor(() => expect(screen.getByText("grown.csv")).toBeTruthy());
+		expect(screen.queryByText(/maxScenarioDataRows/)).toBeNull();
 	});
 
 	it("reads nothing without a contract to compare against", () => {

--- a/app/src/modules/collections/CollectionDetail/DataTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/DataTab.tsx
@@ -48,6 +48,7 @@ import { useUpdateCollectionMutation } from "@/queries/collections";
 import { useDataFileStore } from "@/stores";
 import { DataFileError, describeDataSchemaDiff } from "@/services/data-files";
 import { canReadDeclaredDataFile, readDeclaredDataFile } from "@/services/data-files/read-declared";
+import { useDataFileLimits } from "@/hooks/useDataFileLimits";
 import { hasDataContract, type Collection } from "@/types";
 import DataFilePicker, { type SelectedDataFile } from "../DataFilePicker";
 import ColumnAudit from "./ColumnAudit";
@@ -87,6 +88,12 @@ export default function DataTab({ collection }: DataTabProps) {
 	 * the file again is the whole fix.
 	 */
 	const [readFailure, setReadFailure] = useState<string | null>(null);
+	/*
+	 * The row cap the re-read is measured against, same as a hand-picked file
+	 * (issue #751). A file that has grown past the setting is refused here rather
+	 * than compared against the contract and then refused at Run.
+	 */
+	const { maxRows } = useDataFileLimits();
 	const updateCollection = useUpdateCollectionMutation();
 	const setDataFile = useDataFileStore((s) => s.setDataFile);
 	const clearDataFile = useDataFileStore((s) => s.clearDataFile);
@@ -117,7 +124,7 @@ export default function DataTab({ collection }: DataTabProps) {
 		if (!willReadRemembered(collection) || !path) return;
 
 		let cancelled = false;
-		void readDeclaredDataFile(path)
+		void readDeclaredDataFile(path, { maxRows })
 			.then((read) => {
 				if (cancelled) return;
 				// `?? read`: a file the user picked while this was in flight is

--- a/app/src/modules/collections/DataFilePicker.tsx
+++ b/app/src/modules/collections/DataFilePicker.tsx
@@ -49,6 +49,7 @@ import {
 	DATA_FILE_ACCEPT,
 	DataFileError,
 	decodeDataFile,
+	describeRowCapRefusal,
 	parseDataFile,
 	resolveIterationCount,
 	type ParsedDataFile,
@@ -171,10 +172,12 @@ export default function DataFilePicker({
 			try {
 				const { text } = decodeDataFile(reader.result as ArrayBuffer);
 				const parsed = parseDataFile(text, file.name);
-				if (parsed.rows.length > maxRows) {
-					refuse(
-						`The file has ${parsed.rows.length} rows, over the ${maxRows} a run may carry. Raise the maxScenarioDataRows engine setting, or split the file.`
-					);
+				// The same sentence a re-read of a remembered path refuses with
+				// (`read-declared.ts`), from one place - the two used to be one
+				// refusal and one silent acceptance.
+				const overRowCap = describeRowCapRefusal(parsed.rows.length, maxRows);
+				if (overRowCap) {
+					refuse(overRowCap);
 					return;
 				}
 				// The path is Electron's to give (`webUtils`, inside the preload)

--- a/app/src/modules/collections/RunCollectionDialog.test.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.test.tsx
@@ -31,11 +31,18 @@ const startRunState = {
 	error: null as Error | null,
 };
 
+/**
+ * The two engine data caps, as `useDataFileLimits` reads them. Empty by default,
+ * which leaves the seeds standing - only the row-cap cases below set one, and
+ * they set it to a number the engine does not seed so a hardcoded copy could not
+ * pass for the fetched value.
+ */
+const configEntries: { key: string; value: string }[] = [];
+
 vi.mock("@/queries", () => ({
 	useStartScenarioRunMutation: () => startRunState,
-	// The picker reads the two engine data caps through `useDataFileLimits`.
-	// Empty entries leave it on the seeds, which no case here goes near.
-	useConfigQuery: () => ({ data: { entries: [] } }),
+	// The picker and the pre-fill both read the caps through `useDataFileLimits`.
+	useConfigQuery: () => ({ data: { entries: configEntries } }),
 }));
 
 const startMonitoring = vi.fn();
@@ -59,6 +66,7 @@ function succeedWith(runId: string) {
 }
 
 beforeEach(() => {
+	configEntries.length = 0;
 	mutate.mockClear();
 	startMonitoring.mockClear();
 	startLoadMonitoring.mockClear();
@@ -539,6 +547,53 @@ describe("pre-filling from the declared data file", () => {
 		// Not a blocking refusal: a run without a file is a legal run.
 		expect(screen.getByRole("button", { name: /^run$/i })).toHaveProperty("disabled", false);
 		expect(screen.getByText(/choose file/i)).toBeTruthy();
+	});
+
+	/*
+	 * The row cap on the pre-fill path (issue #751).
+	 *
+	 * A hand-picked file over `maxScenarioDataRows` is refused by the picker
+	 * naming the setting; the remembered path was accepted, previewed, and
+	 * refused by `POST /runs` at Start - the late failure the preview exists to
+	 * move earlier. Lowering the setting reaches the same file, which is why the
+	 * cap is read live rather than captured when the file was declared.
+	 */
+	it("refuses a remembered file that is now over the row cap, naming the setting", async () => {
+		configEntries.push({ key: "maxScenarioDataRows", value: "2" });
+		remember("/home/u/users.csv", "users.csv");
+		stubReadDataFile(async () => ({
+			bytes: bytesOf("user\nada\ngrace\nalan"),
+			fileName: "users.csv",
+		}));
+
+		render(<RunCollectionDialog collection={COLLECTION} onOpenChange={vi.fn()} />);
+
+		await waitFor(() =>
+			expect(screen.getByText(/3 rows, over the 2[\s\S]*maxScenarioDataRows/)).toBeTruthy()
+		);
+		// Nothing pre-filled: the rows the engine would refuse never reach a Run
+		// the user can start.
+		expect(screen.queryByText("ada")).toBeNull();
+		expect(screen.getByText(/choose file/i)).toBeTruthy();
+		// A note, not a blocker - a run without a file is still a legal run.
+		expect(screen.getByRole("button", { name: /^run$/i })).toHaveProperty("disabled", false);
+
+		fireEvent.click(screen.getByRole("button", { name: /^run$/i }));
+		expect(mutate.mock.calls[0][0].scenario).not.toHaveProperty("data");
+	});
+
+	it("pre-fills the same file once the setting is raised, with no restart", async () => {
+		configEntries.push({ key: "maxScenarioDataRows", value: "3" });
+		remember("/home/u/users.csv", "users.csv");
+		stubReadDataFile(async () => ({
+			bytes: bytesOf("user\nada\ngrace\nalan"),
+			fileName: "users.csv",
+		}));
+
+		render(<RunCollectionDialog collection={COLLECTION} onOpenChange={vi.fn()} />);
+
+		await waitFor(() => expect(screen.getByText("ada")).toBeTruthy());
+		expect(screen.queryByText(/maxScenarioDataRows/)).toBeNull();
 	});
 
 	it("does nothing when the collection has no remembered file", async () => {

--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -65,6 +65,7 @@ import { useDashboardStore, useDataFileStore, useSessionStore, useTabsStore } fr
 import { loadTestService, scenarioRunService } from "@/services";
 import { DataFileError, describeDataSchemaDiff } from "@/services/data-files";
 import { canReadDeclaredDataFile, readDeclaredDataFile } from "@/services/data-files/read-declared";
+import { useDataFileLimits } from "@/hooks/useDataFileLimits";
 import type { Collection } from "@/types";
 import DataFilePicker, { type SelectedDataFile } from "./DataFilePicker";
 
@@ -133,6 +134,14 @@ export default function RunCollectionDialog({
 	const [prefillNote, setPrefillNote] = useState<string | null>(null);
 
 	const rememberedFile = useDataFileStore((s) => s.locations[collection.id]);
+	/*
+	 * The row cap the pre-filled file has to fit inside, same as a hand-picked
+	 * one (issue #751). Read here as well as in the picker below because the
+	 * re-read happens before any picker holds the file - a file that grew past
+	 * the setting would otherwise pre-fill, preview, and be refused by the
+	 * engine at Run.
+	 */
+	const { maxRows } = useDataFileLimits();
 
 	/**
 	 * Pre-fill from the file this collection was last run with (issue #599).
@@ -152,7 +161,7 @@ export default function RunCollectionDialog({
 		// No Electron, no path to re-read - the picker stands.
 		if (!canReadDeclaredDataFile()) return;
 
-		void readDeclaredDataFile(rememberedFile.path)
+		void readDeclaredDataFile(rememberedFile.path, { maxRows })
 			.then((read) => {
 				if (cancelled) return;
 				setDataFile(read);

--- a/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/UrlBar.test.tsx
@@ -77,6 +77,11 @@ function ctx(canStartLoadTest: boolean, overrides: CtxOverrides = {}): RequestBu
 		getVariableOrigins: () => [],
 		updateVariable: vi.fn(),
 		writableScopes: [],
+		// Send-with-row's row cap. The bar reads it off the context rather than
+		// the config query precisely so this file can render without a
+		// `QueryClientProvider`; no case here declares a contract, so nothing
+		// measures anything against it.
+		dataFileMaxRows: 1000,
 		executeRequest: vi.fn(async () => {}),
 		saveRequest: vi.fn(async () => {}),
 		startLoadTest: vi.fn(),

--- a/app/src/modules/request-builder/components/UrlBar/index.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/index.tsx
@@ -102,6 +102,7 @@ export default function UrlBar() {
 		startLoadTest,
 		canStartLoadTest,
 		dataColumns,
+		dataFileMaxRows,
 	} = useRequestBuilderContext();
 	const isLoadTestRunning = useDashboardStore((s) => s.isStreaming);
 	const openTab = useTabsStore((s) => s.openTab);
@@ -125,7 +126,7 @@ export default function UrlBar() {
 	 * request" always meant; it is still session-lived, and still thrown away
 	 * with the builder.
 	 */
-	const rows = useSendWithRow(dataColumns);
+	const rows = useSendWithRow(dataColumns, dataFileMaxRows);
 	const [rowIndexByRequest, setRowIndexByRequest] = useState<Record<string, number>>({});
 	/*
 	 * An unsaved request has no id and cannot be switched away from and back to

--- a/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
+++ b/app/src/modules/request-builder/components/UrlBar/send-with-row.test.tsx
@@ -56,7 +56,8 @@ function csvBytes(text = CSV): { bytes: Uint8Array; fileName: string } {
 function ctx(
 	executeRequest: RequestBuilderContextValue["executeRequest"],
 	dataColumns?: DataContractScope,
-	requestId: string | null = null
+	requestId: string | null = null,
+	dataFileMaxRows = 1000
 ): RequestBuilderContextValue {
 	return {
 		request: {
@@ -94,6 +95,7 @@ function ctx(
 		updateVariable: vi.fn(),
 		writableScopes: [],
 		dataColumns,
+		dataFileMaxRows,
 		executeRequest,
 		saveRequest: vi.fn(async () => {}),
 		startLoadTest: vi.fn(),
@@ -104,11 +106,14 @@ function ctx(
 function renderBar(
 	executeRequest: RequestBuilderContextValue["executeRequest"],
 	dataColumns?: DataContractScope,
-	requestId: string | null = null
+	requestId: string | null = null,
+	dataFileMaxRows?: number
 ) {
 	return render(
 		<TooltipProvider>
-			<RequestBuilderContext.Provider value={ctx(executeRequest, dataColumns, requestId)}>
+			<RequestBuilderContext.Provider
+				value={ctx(executeRequest, dataColumns, requestId, dataFileMaxRows)}
+			>
 				<UrlBar />
 			</RequestBuilderContext.Provider>
 		</TooltipProvider>
@@ -266,6 +271,27 @@ describe("picking a row", () => {
 		// been: picking the file again in the Data tab is the whole fix, and a
 		// toast that scrolled away would not say what to do.
 		expect(await screen.findByText(/no such file or directory/i)).toBeTruthy();
+	});
+
+	it("offers no rows out of a file over the run's row cap, naming the setting", async () => {
+		// Two data rows against a cap of one (issue #751). The file is the
+		// collection's data set, so one the picker would refuse - and `POST /runs`
+		// after it - is not a set to bind a Send from.
+		rememberFile();
+		stubReadDataFile(async () => csvBytes());
+		renderBar(
+			vi.fn(async () => {}),
+			CONTRACT,
+			null,
+			1
+		);
+
+		openPicker();
+
+		expect(
+			await screen.findByText(/2 rows, over the 1[\s\S]*maxScenarioDataRows/)
+		).toBeTruthy();
+		expect(screen.queryByText(/ada@example\.test/)).toBeNull();
 	});
 });
 

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.graphql-reveal.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.graphql-reveal.test.tsx
@@ -48,6 +48,9 @@ vi.mock("@/queries", () => ({
 	useEnvironmentsQuery: () => ({ data: [] }),
 	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
 	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 }));
 
 /** The tab the provider currently has on screen. */

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.name-sync.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.name-sync.test.tsx
@@ -60,6 +60,9 @@ vi.mock("@/queries", () => ({
 	useEnvironmentsQuery: () => ({ data: [] }),
 	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
 	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 }));
 
 /** Shows what the builder holds, and offers the two writes the Info tab makes. */

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.tsx
@@ -21,6 +21,7 @@ import { RequestBuilderContext } from "./RequestBuilderContext";
 import { emptyDrafts, type BodyDrafts, type VariablesDraft } from "../utils/body-drafts";
 import { useVariableResolver, useSaveManager } from "@/hooks";
 import { resolveDataContract } from "@/lib/data-contract";
+import { useDataFileLimits } from "@/hooks/useDataFileLimits";
 import {
 	useCollectionAncestors,
 	useGlobalsQuery,
@@ -610,6 +611,13 @@ export default function RequestBuilderProvider({
 		[collectionId, collections]
 	);
 
+	/*
+	 * The row cap Send-with-row measures the declared file against (issue #751),
+	 * read here for the same reason the contract is resolved here: the config
+	 * query is the provider's to hold, not the URL bar's.
+	 */
+	const { maxRows: dataFileMaxRows } = useDataFileLimits();
+
 	const writableScopes = useMemo((): VariableScope[] => {
 		const scopes: VariableScope[] = [];
 		if (globalsData?.variables) scopes.push("global");
@@ -846,6 +854,7 @@ export default function RequestBuilderProvider({
 			updateVariable,
 			writableScopes,
 			dataColumns,
+			dataFileMaxRows,
 			executeRequest,
 			saveRequest,
 			startLoadTest,
@@ -885,6 +894,7 @@ export default function RequestBuilderProvider({
 			updateVariable,
 			writableScopes,
 			dataColumns,
+			dataFileMaxRows,
 			executeRequest,
 			saveRequest,
 			startLoadTest,

--- a/app/src/modules/request-builder/context/RequestBuilderProvider.variables.test.tsx
+++ b/app/src/modules/request-builder/context/RequestBuilderProvider.variables.test.tsx
@@ -52,6 +52,9 @@ vi.mock("@/queries", () => ({
 	useUpdateCollectionMutation: () => ({ mutate: mutateCollection }),
 	useUpdateEnvironmentMutation: () => ({ mutate: mutateEnvironment }),
 	useLastDesignRunQuery: () => ({ run: null, report: null, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 }));
 vi.mock("@/stores", async (importOriginal) => ({
 	// The real event-stream store, which the provider reads to know whether a

--- a/app/src/modules/request-builder/context/body-drafts-lifetime.test.tsx
+++ b/app/src/modules/request-builder/context/body-drafts-lifetime.test.tsx
@@ -65,6 +65,9 @@ vi.mock("@/queries", () => ({
 	useEnvironmentsQuery: () => ({ data: [] }),
 	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
 	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 }));
 
 const JSON_BODY = '{"merchant":"mrc_8813"}';

--- a/app/src/modules/request-builder/context/execute-request-switch.test.tsx
+++ b/app/src/modules/request-builder/context/execute-request-switch.test.tsx
@@ -55,6 +55,9 @@ vi.mock("@/queries", () => ({
 	useEnvironmentsQuery: () => ({ data: [] }),
 	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
 	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 }));
 
 function makeResponse(tag: string): ResponseState {

--- a/app/src/modules/request-builder/context/execute-stream-branch.test.tsx
+++ b/app/src/modules/request-builder/context/execute-stream-branch.test.tsx
@@ -63,6 +63,9 @@ vi.mock("@/queries", () => ({
 	useEnvironmentsQuery: () => ({ data: [] }),
 	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
 	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 	queryKeys: {
 		runs: { lists: () => ["runs"], recentDesign: (id: string) => ["runs", "recent", id] },
 	},

--- a/app/src/modules/request-builder/hooks/useSendWithRow.test.ts
+++ b/app/src/modules/request-builder/hooks/useSendWithRow.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Send-with-row reading the declared file (issues #601, #751).
+ *
+ * The hook's job is "which rows can this request bind", and the answer has to
+ * come from the file the *declaring* collection remembers - which is why the
+ * store is keyed by `contract.collectionId` here rather than by the request's
+ * own parent.
+ *
+ * The row cap is the other half. A file over `maxScenarioDataRows` is one the
+ * picker refuses and one `POST /runs` refuses, so offering its rows here would
+ * mean a request that sends fine beside a collection that cannot run at all.
+ * The cap arrives as an argument for the same reason the contract does - the
+ * config query belongs to the provider, not to a hook the URL bar calls - so
+ * what is pinned here is that the hook honours the number it is handed rather
+ * than any copy of its own.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+import { useDataFileStore } from "@/stores";
+import type { DataContractScope } from "@/types";
+
+import { useSendWithRow } from "./useSendWithRow";
+
+/** A cap no case is testing, so the read turns on the file alone. */
+const NO_CAP_IN_PLAY = 1000;
+
+const CONTRACT: DataContractScope = {
+	collectionName: "Checkout flow",
+	collectionId: "col_1",
+	columns: ["user"],
+};
+
+/** The bridge answering with a CSV of `count` rows, as Electron hands it over. */
+function stubBridge(count: number, fileName = "users.csv") {
+	const text = `user\n${Array.from({ length: count }, (_, i) => `user-${i}`).join("\n")}`;
+	const read = vi.fn(() => Promise.resolve({ bytes: new TextEncoder().encode(text), fileName }));
+	vi.stubGlobal("electronAPI", { readDataFile: read });
+	return read;
+}
+
+beforeEach(() => {
+	vi.unstubAllGlobals();
+	useDataFileStore.setState({
+		locations: { col_1: { path: "/home/u/users.csv", fileName: "users.csv" } },
+	});
+});
+
+describe("loading the declared file", () => {
+	it("reads the file the declaring collection remembers", async () => {
+		const read = stubBridge(2);
+
+		const { result } = renderHook(() => useSendWithRow(CONTRACT, NO_CAP_IN_PLAY));
+		expect(result.current.available).toBe(true);
+		act(() => result.current.load());
+
+		await waitFor(() => expect(result.current.status).toBe("ready"));
+		expect(read).toHaveBeenCalledWith("/home/u/users.csv");
+		expect(result.current.parsed?.rows).toHaveLength(2);
+		expect(result.current.error).toBeNull();
+	});
+
+	it("touches the filesystem only when the picker asks", () => {
+		const read = stubBridge(2);
+
+		renderHook(() => useSendWithRow(CONTRACT, NO_CAP_IN_PLAY));
+
+		// Mounting a request tab must not open a file for a Send nobody asked for.
+		expect(read).not.toHaveBeenCalled();
+	});
+});
+
+describe("the row cap", () => {
+	it("refuses a file over it, naming the setting, with no rows to bind", async () => {
+		stubBridge(3);
+
+		const { result } = renderHook(() => useSendWithRow(CONTRACT, 2));
+		act(() => result.current.load());
+
+		await waitFor(() => expect(result.current.status).toBe("unavailable"));
+		expect(result.current.error).toMatch(/3 rows, over the 2[\s\S]*maxScenarioDataRows/);
+		expect(result.current.parsed).toBeNull();
+	});
+
+	it("reads the cap it is handed, so raising it offers the same file's rows", async () => {
+		stubBridge(3);
+
+		const { result } = renderHook(() => useSendWithRow(CONTRACT, 3));
+		act(() => result.current.load());
+
+		await waitFor(() => expect(result.current.status).toBe("ready"));
+		expect(result.current.parsed?.rows).toHaveLength(3);
+	});
+});

--- a/app/src/modules/request-builder/hooks/useSendWithRow.ts
+++ b/app/src/modules/request-builder/hooks/useSendWithRow.ts
@@ -71,8 +71,18 @@ export interface SendWithRowState {
  *        needed a `QueryClientProvider` to render is the coupling issue #564
  *        removed from the variable slice and #600 kept out of the token
  *        painter. The provider already holds this answer.
+ * @param maxRows The live `maxScenarioDataRows` (issue #751), from the builder
+ *        context's `dataFileMaxRows` - and for the same reason as the contract,
+ *        since it is the config query that knows it. The cap bounds a *run* and
+ *        a Send binds one row, but the file is the collection's data set: one
+ *        the picker would refuse is not a set to offer rows out of, and letting
+ *        it through here would mean a request sending happily beside a
+ *        collection that cannot run at all.
  */
-export function useSendWithRow(contract: DataContractScope | undefined): SendWithRowState {
+export function useSendWithRow(
+	contract: DataContractScope | undefined,
+	maxRows: number
+): SendWithRowState {
 	// Keyed by the collection that *declared* the contract, not by the request's
 	// own parent: under the chain rule a sub-collection inherits an ancestor's
 	// contract, and the file was picked in that ancestor's Data tab.
@@ -98,7 +108,7 @@ export function useSendWithRow(contract: DataContractScope | undefined): SendWit
 		}
 		setStatus("loading");
 		setError(null);
-		void readDeclaredDataFile(path)
+		void readDeclaredDataFile(path, { maxRows })
 			.then((read) => {
 				setParsed(read.parsed);
 				setStatus("ready");
@@ -112,7 +122,7 @@ export function useSendWithRow(contract: DataContractScope | undefined): SendWit
 						: `The declared file is no longer at ${fileName ?? "its recorded path"} - pick it again in the Data tab.`
 				);
 			});
-	}, [path, fileName]);
+	}, [path, fileName, maxRows]);
 
 	return {
 		available: !!contract && !!path,

--- a/app/src/modules/request-builder/load-test-command-surface.test.tsx
+++ b/app/src/modules/request-builder/load-test-command-surface.test.tsx
@@ -50,6 +50,9 @@ vi.mock("@/queries", () => ({
 	useEnvironmentsQuery: () => ({ data: [] }),
 	useUpdateEnvironmentMutation: () => ({ mutate: vi.fn() }),
 	useLastDesignRunQuery: () => ({ run: undefined, report: undefined, isLoading: false }),
+	// The provider reads the engine data caps for Send-with-row's row cap
+	// (`useDataFileLimits`); empty entries leave it on the seeds.
+	useConfigQuery: () => ({ data: { entries: [] } }),
 }));
 
 /** Edits the draft the way the URL bar does. */

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -449,6 +449,16 @@ export interface RequestBuilderContextValue {
 	 * removed for the variable slice (#564).
 	 */
 	dataColumns?: DataContractScope;
+	/**
+	 * The live `maxScenarioDataRows` a declared data file has to fit inside
+	 * (issue #751), for Send-with-row's re-read of it.
+	 *
+	 * On the context for the same reason `dataColumns` is: it is the config
+	 * query's answer, and the UrlBar reading that query itself would make the
+	 * bar unrenderable without a `QueryClientProvider`. Never a constant -
+	 * raising the setting has to reach the next read without a restart.
+	 */
+	dataFileMaxRows: number;
 
 	// Actions
 	/**

--- a/app/src/services/data-files/index.ts
+++ b/app/src/services/data-files/index.ts
@@ -350,5 +350,6 @@ export function resolveIterationCount(
 export { parseDelimited } from "./tabular";
 export { DataFileError } from "./errors";
 export { decodeDataFile, type DecodedDataFile } from "./decode";
+export { describeRowCapRefusal } from "./row-cap";
 export { diffDataSchema, describeDataSchemaDiff, type DataSchemaDiff } from "./schema-diff";
 export { auditDataColumns, type AuditableRequest, type ColumnAudit } from "./column-audit";

--- a/app/src/services/data-files/read-declared.test.ts
+++ b/app/src/services/data-files/read-declared.test.ts
@@ -18,6 +18,11 @@
  * it: the bytes go through the *same* decoder (a UTF-16 CSV is not garbage), the
  * name comes back from disk rather than from the caller's memory of it, and the
  * two failures a caller has to tell apart are two different errors.
+ *
+ * And the refusal the re-read used to skip (issue #751): the picker turns down a
+ * hand-picked file over `maxScenarioDataRows`, so a remembered path that has
+ * grown past it must be turned down here rather than previewed and refused by
+ * `POST /runs` afterwards.
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
@@ -46,6 +51,14 @@ function bridge(text: string, fileName: string, encoding: "utf-8" | "utf-16le" =
 	return vi.fn(() => Promise.resolve({ bytes, fileName }));
 }
 
+/** A cap no case below is testing, so the read turns on the file alone. */
+const LIMITS = { maxRows: 1000 };
+
+/** A CSV with `count` data rows under a single `user` column. */
+function csvOfRows(count: number): string {
+	return `user\n${Array.from({ length: count }, (_, i) => `user-${i}`).join("\n")}`;
+}
+
 afterEach(() => {
 	vi.unstubAllGlobals();
 });
@@ -67,7 +80,7 @@ describe("readDeclaredDataFile", () => {
 		const read = bridge("id,email\n1,a@b.c", "users-renamed.csv");
 		vi.stubGlobal("electronAPI", { readDataFile: read });
 
-		const file = await readDeclaredDataFile("/home/u/users.csv");
+		const file = await readDeclaredDataFile("/home/u/users.csv", LIMITS);
 
 		expect(read).toHaveBeenCalledWith("/home/u/users.csv");
 		expect(file.fileName).toBe("users-renamed.csv");
@@ -84,7 +97,7 @@ describe("readDeclaredDataFile", () => {
 			readDataFile: bridge("id,city\n1,Köln", "excel.csv", "utf-16le"),
 		});
 
-		const file = await readDeclaredDataFile("/home/u/excel.csv");
+		const file = await readDeclaredDataFile("/home/u/excel.csv", LIMITS);
 
 		expect(file.parsed.columns).toEqual(["id", "city"]);
 		expect(file.parsed.rows[0].city).toBe("Köln");
@@ -92,7 +105,7 @@ describe("readDeclaredDataFile", () => {
 
 	it("rejects with NoDataFileBridgeError outside Electron", async () => {
 		vi.stubGlobal("electronAPI", undefined);
-		await expect(readDeclaredDataFile("/home/u/users.csv")).rejects.toBeInstanceOf(
+		await expect(readDeclaredDataFile("/home/u/users.csv", LIMITS)).rejects.toBeInstanceOf(
 			NoDataFileBridgeError
 		);
 	});
@@ -101,13 +114,41 @@ describe("readDeclaredDataFile", () => {
 		vi.stubGlobal("electronAPI", {
 			readDataFile: () => Promise.reject(new Error("ENOENT: no such file or directory")),
 		});
-		await expect(readDeclaredDataFile("/home/u/gone.csv")).rejects.toThrow(/ENOENT/);
+		await expect(readDeclaredDataFile("/home/u/gone.csv", LIMITS)).rejects.toThrow(/ENOENT/);
 	});
 
 	it("rejects a file that no longer parses with the parser's own message", async () => {
 		vi.stubGlobal("electronAPI", { readDataFile: bridge("id,id\n1,2", "dupes.csv") });
-		await expect(readDeclaredDataFile("/home/u/dupes.csv")).rejects.toBeInstanceOf(
+		await expect(readDeclaredDataFile("/home/u/dupes.csv", LIMITS)).rejects.toBeInstanceOf(
 			DataFileError
 		);
+	});
+});
+
+describe("the row cap on a re-read", () => {
+	it("refuses a remembered file over it, naming the count and the setting", async () => {
+		vi.stubGlobal("electronAPI", { readDataFile: bridge(csvOfRows(4), "grown.csv") });
+
+		// The picker's sentence, not a second one: a user who has read
+		// "raise maxScenarioDataRows" once should not meet a paraphrase of it.
+		await expect(readDeclaredDataFile("/home/u/grown.csv", { maxRows: 3 })).rejects.toThrow(
+			/4 rows, over the 3[\s\S]*maxScenarioDataRows/
+		);
+		// A `DataFileError`, which is what every caller's catch already shows
+		// verbatim beside a picker that is still usable.
+		await expect(
+			readDeclaredDataFile("/home/u/grown.csv", { maxRows: 3 })
+		).rejects.toBeInstanceOf(DataFileError);
+	});
+
+	it("reads the cap it was handed, so raising the setting accepts the same file", async () => {
+		// The file the case above refused, under a setting the user has raised.
+		// The cap cannot be a seed captured anywhere: this is the whole reason it
+		// travels in as an argument.
+		vi.stubGlobal("electronAPI", { readDataFile: bridge(csvOfRows(4), "grown.csv") });
+
+		const file = await readDeclaredDataFile("/home/u/grown.csv", { maxRows: 4 });
+
+		expect(file.parsed.rows).toHaveLength(4);
 	});
 });

--- a/app/src/services/data-files/read-declared.ts
+++ b/app/src/services/data-files/read-declared.ts
@@ -23,9 +23,19 @@
  * is a different answer: a browser has no path to re-read and never will, so the
  * caller shows its degraded state instead of a message inviting a retry that
  * cannot work.
+ *
+ * The row cap is enforced **here**, against the live setting the caller passes
+ * in (issue #751). The main-process gate this reads through already refuses the
+ * byte cap on the way out (`electron/data-file.ts`), but it deliberately does
+ * not parse - the app owns parsing - so it cannot count rows, and without this
+ * the remembered path was the one way past a refusal the picker makes on every
+ * hand-picked file. `maxRows` is required rather than optional so a fourth
+ * surface cannot re-open the hole by omitting it.
  */
 
 import { decodeDataFile } from "./decode";
+import { DataFileError } from "./errors";
+import { describeRowCapRefusal } from "./row-cap";
 import { parseDataFile, type ParsedDataFile } from "./index";
 
 /** A file re-read from disk, in the shape the pickers already hold. */
@@ -60,15 +70,28 @@ export function canReadDeclaredDataFile(): boolean {
 	return typeof window.electronAPI?.readDataFile === "function";
 }
 
+/** What a re-read has to be measured against, beyond parsing. */
+export interface DeclaredDataFileLimits {
+	/**
+	 * The live `maxScenarioDataRows`, from {@link useDataFileLimits}. Never a
+	 * constant: a user who raises the setting must get the file on the next
+	 * re-read, without restarting anything.
+	 */
+	maxRows: number;
+}
+
 /**
- * Read, decode and parse the file at `path`.
+ * Read, decode and parse the file at `path`, refusing a set over `maxRows`.
  *
  * Rejects with `NoDataFileBridgeError` outside Electron, and with
  * `DataFileError` (or whatever the bridge threw) when the file is gone, moved,
- * or no longer parses - all of which name the fault in a sentence a caller can
- * show as-is.
+ * no longer parses, or now carries more rows than a run may - all of which name
+ * the fault in a sentence a caller can show as-is.
  */
-export async function readDeclaredDataFile(path: string): Promise<DeclaredDataFile> {
+export async function readDeclaredDataFile(
+	path: string,
+	{ maxRows }: DeclaredDataFileLimits
+): Promise<DeclaredDataFile> {
 	const read = window.electronAPI?.readDataFile;
 	if (!read) throw new NoDataFileBridgeError();
 
@@ -76,5 +99,14 @@ export async function readDeclaredDataFile(path: string): Promise<DeclaredDataFi
 	// The same decode and the same parser the picker runs, so a file re-read
 	// here cannot disagree with the file as it was declared.
 	const { text } = decodeDataFile(bytes.buffer as ArrayBuffer);
-	return { fileName, parsed: parseDataFile(text, fileName), path };
+	const parsed = parseDataFile(text, fileName);
+
+	// The picker's own refusal, thrown rather than returned: every caller here
+	// already shows a failed re-read as a note beside a usable picker, which is
+	// the right shape for this too - picking the file again, or raising the
+	// setting, is the fix.
+	const refusal = describeRowCapRefusal(parsed.rows.length, maxRows);
+	if (refusal) throw new DataFileError(refusal);
+
+	return { fileName, parsed, path };
 }

--- a/app/src/services/data-files/row-cap.ts
+++ b/app/src/services/data-files/row-cap.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * `maxScenarioDataRows`, as every surface that reads a data file states it
+ * (issue #751).
+ *
+ * The comparison and the sentence live together because they were about to live
+ * apart: the picker refused a hand-picked file over the cap, and the three
+ * surfaces that re-read a *remembered* path refused nothing at all, so a file
+ * that grew past the setting previewed cleanly and died at `POST /runs` with the
+ * `400` the picker exists to move earlier. A second copy of the message is how
+ * the two drift, and a second copy of the `>` is how one of them ends up
+ * off-by-one, so neither is copied.
+ *
+ * The number itself is **never** hardcoded by a caller: it is the engine setting
+ * a user can raise, fetched through `useDataFileLimits`. See
+ * `constants/data-files.ts` for why the seed there is not the rule.
+ *
+ * The byte cap has no equivalent here because its two checks read different
+ * things - the picker stats the `File` before reading it, the main process stats
+ * the path before opening it (`electron/data-file.ts`) - and neither has a
+ * parsed file in hand.
+ */
+
+/**
+ * The refusal for a data set over `maxRows`, or `null` when it fits.
+ *
+ * Returning the message rather than throwing keeps it usable by the picker,
+ * which has an `onError` slot and no catch to fall into.
+ */
+export function describeRowCapRefusal(rowCount: number, maxRows: number): string | null {
+	if (rowCount <= maxRows) return null;
+	return `The file has ${rowCount} rows, over the ${maxRows} a run may carry. Raise the maxScenarioDataRows engine setting, or split the file.`;
+}

--- a/docs/app/data-driven-runs.md
+++ b/docs/app/data-driven-runs.md
@@ -90,18 +90,28 @@ catch it. Re-save as UTF-8 and pick it again.
 
 ## Size limits
 
-Two engine settings bound a run's data set, and the picker enforces both
-_before_ the run rather than letting `POST /runs` refuse it afterwards:
+Two engine settings bound a run's data set, and the app enforces both _before_
+the run rather than letting `POST /runs` refuse it afterwards:
 
 | Setting                | Default | Bounds                          |
 | ---------------------- | ------- | ------------------------------- |
 | `maxScenarioDataRows`  | 1000    | How many rows one run may carry |
 | `maxScenarioDataBytes` | 16 MiB  | How large the data set may be   |
 
-Both are editable in **Settings -> Engine -> General**, and the picker reads the
+Both are editable in **Settings -> Engine -> General**, and the app reads the
 live values - raise a limit there and the same file is accepted without
 restarting anything. The row limit alone does not bound the payload, since one
 row is free to hold a megabyte in a single cell, which is why there are two.
+
+The caps apply to a file **re-read from a remembered path** exactly as they do
+to one picked by hand, and both refusals name the setting. That matters because
+neither side of the comparison holds still: a declared file grows rows after it
+was declared, and the setting itself can be lowered under a file that has not
+changed at all. So the Run dialog's pre-fill, Send-with-row and the Data tab
+each refuse a file over the cap instead of previewing it - the byte cap when the
+file is opened (the app's main process stats it before reading), the row cap
+once it is parsed, since counting rows means parsing and the engine never opens
+a file.
 
 The engine never opens a file. The app parses it and sends the rows inline on
 the run payload, because the script sandbox has no filesystem access by design
@@ -269,7 +279,9 @@ same way a variable defined on a parent collection is in scope below it.
 
 Vayu only ever re-opens a file whose extension is one of the formats above, and
 only up to the same `maxScenarioDataBytes` a run may carry - the remembered path
-is not a general licence to read your disk.
+is not a general licence to read your disk. A re-opened file over
+`maxScenarioDataRows` is refused too, once it has been parsed, so a file that
+outgrew the cap says so here rather than at the next run.
 
 ## Send with a row
 
@@ -292,7 +304,9 @@ request is sent bound to it:
 The caret is **absent**, not greyed out, when there is nothing to bind - no
 contract in the collection chain, or no remembered file for the collection that
 declared it. A file that has moved says so when you open the list, and picking
-it again in the Data tab is the fix.
+it again in the Data tab is the fix. So does a file over `maxScenarioDataRows`:
+a single send binds one row, but the file is the collection's data set, and one
+no run can use is not a set to pick a row out of.
 
 **Auth credentials bind on a single send too.** A `{{data.user}}` in a
 basic-auth username, a bearer token or an api key takes the row's value the same


### PR DESCRIPTION
## Description

**Root cause.** `DataFilePicker.handleFile` refuses a hand-picked file over both engine caps before the run, but a file re-read from the remembered path met only one of them: the main-process gate enforces the extension allowlist and `maxScenarioDataBytes` (`electron/data-file.ts`), and nothing counted rows on the way back. So all three re-read surfaces - the Run dialog's pre-fill, Send-with-row, and the Data tab's comparison - accepted a set the picker would have refused, leaving `POST /runs` to return the `400` the preview exists to move earlier. Verified still present at `0d3359b`, exactly as #751 describes it.

**Approach.** The comparison and its sentence now live together in `services/data-files/row-cap.ts` (`describeRowCapRefusal`), used by the picker and by `readDeclaredDataFile`, whose new **required** `maxRows` argument carries the live setting from `useDataFileLimits`.

**Alternative rejected.** The issue's preferred shape was a check at each of the three callers with the picker's message extracted. That keeps one message but leaves three copies of the check, and a fourth caller re-opens the hole silently. Enforcing inside the shared reader keeps one message *and* one comparison, and a required argument means a new caller cannot omit the cap. It is still the renderer-side option: the value is the config query's, passed in by the caller, and the main process (which deliberately does not parse, so it cannot count rows) is untouched - that was the option the issue rejected outright.

One deliberate deviation in the wiring: `useSendWithRow` takes `maxRows` as an argument rather than calling `useDataFileLimits` itself, sourced from a new `dataFileMaxRows` on the request-builder context. Reading the config query inside the hook makes `UrlBar` unrenderable without a `QueryClientProvider` - the coupling #564 removed from the variable slice and #600 kept out of the token painter, and the reason `dataColumns` already travels this exact route. The provider tests gained the `useConfigQuery` line their mocks now need.

Note: this also subsumes item 3 of #729 (the pre-fill path bypassing the row-cap refusal). #729's other two findings are untouched.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only diff (TypeScript/renderer); no engine source touched, so no engine build or ctest run - per CLAUDE.md, verification is scaled to what could change colour.

- `pnpm test` - **498 files, 5189 tests, all passing** (up from 5183: 5 new cap cases plus the existing suite).
- `pnpm type-check`, `pnpm lint`, `pnpm prettier --check` on every touched file - clean.
- **Mutation check**: disabling the cap throw in `readDeclaredDataFile` fails exactly 5 tests, one per assertion site - `read-declared.test.ts`, `RunCollectionDialog.test.tsx`, `DataTab.test.tsx`, `useSendWithRow.test.ts`, `send-with-row.test.tsx`. Restored and re-run green.
- Each surface has both directions: a file over the cap refused with the setting named, and the *same* file accepted once the setting is raised, so the check reads the live value rather than a seed.
- `mkdocs build --strict` was not run - mkdocs is not installed in this environment. The docs edit is prose inside existing sections with no new links, anchors or nav entries, so there is no link-resolution surface; CI's docs job gates it.

No pre-existing failures on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #751

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9US5SYN91eBkH8GN7xr6V)_