### PR TITLE
feat(app/engine/tls): transport policy phase 2 - custom CA certificates, and verifySSL end to end

### DIFF
--- a/app/src/components/layout/context-bar/templated-request.ts
+++ b/app/src/components/layout/context-bar/templated-request.ts
@@ -47,5 +47,6 @@ export function templatedRequest(
 		// `CodeSection` for why the resolved mode cannot read it from the
 		// composed payload.
 		stream: request.stream,
+		verifySSL: request.verifySSL,
 	};
 }

--- a/app/src/constants/request.ts
+++ b/app/src/constants/request.ts
@@ -22,6 +22,14 @@ export const DEFAULT_REQUEST_NAME = "New Request";
 export const DEFAULT_FOLLOW_REDIRECTS = true;
 export const DEFAULT_MAX_REDIRECTS = 10;
 
+/**
+ * TLS verification default (issue #706). Mirrors `vayu::Request::verify_ssl`
+ * and the `requests.verify_ssl` column default. `true` is the only safe seed:
+ * a request that reached the app without the field must verify, never trust
+ * whatever answers.
+ */
+export const DEFAULT_VERIFY_SSL = true;
+
 /** Bounds offered by the Settings tab; the engine clamps to the same range. */
 export const MIN_MAX_REDIRECTS = 0;
 export const MAX_MAX_REDIRECTS = 100;

--- a/app/src/drawer-row-hit-area.test.tsx
+++ b/app/src/drawer-row-hit-area.test.tsx
@@ -68,6 +68,7 @@ const REQUEST: Request = {
 	postRequestScript: "",
 	followRedirects: true,
 	maxRedirects: 10,
+	verifySSL: true,
 	httpVersion: "auto",
 	stream: false,
 	order: 0,

--- a/app/src/modules/collections/CollectionDetail/ColumnAudit.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/ColumnAudit.test.tsx
@@ -73,6 +73,7 @@ function request(url: string): Request {
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		order: 0,

--- a/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
@@ -96,6 +96,7 @@ const request = (overrides: Partial<Request> = {}): Request =>
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		specOperation: { operationId: "listPets", method: "GET", path: "/pets" },

--- a/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
@@ -149,6 +149,7 @@ const request = (id: string, url: string, specOperation?: Request["specOperation
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		specOperation,

--- a/app/src/modules/collections/CollectionTreeContext.test.tsx
+++ b/app/src/modules/collections/CollectionTreeContext.test.tsx
@@ -58,6 +58,7 @@ const REQUEST: Request = {
 	postRequestScript: "",
 	followRedirects: true,
 	maxRedirects: 10,
+	verifySSL: true,
 	httpVersion: "auto",
 	stream: false,
 	order: 0,

--- a/app/src/modules/collections/ExportSpecDialog.test.tsx
+++ b/app/src/modules/collections/ExportSpecDialog.test.tsx
@@ -93,6 +93,7 @@ function request(overrides: Partial<Request> = {}): Request {
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		order: 0,

--- a/app/src/modules/collections/RequestItem.test.tsx
+++ b/app/src/modules/collections/RequestItem.test.tsx
@@ -42,6 +42,7 @@ const REQUEST: Request = {
 	postRequestScript: "",
 	followRedirects: true,
 	maxRedirects: 10,
+	verifySSL: true,
 	httpVersion: "auto",
 	stream: false,
 	order: 0,

--- a/app/src/modules/history/main/DesignRunView.test.tsx
+++ b/app/src/modules/history/main/DesignRunView.test.tsx
@@ -124,6 +124,7 @@ function designRun(overrides: Partial<Run> = {}): Run {
 			],
 			followRedirects: false,
 			maxRedirects: 3,
+			verifySSL: true,
 			httpVersion: "http2",
 			requestId: "req_1",
 		},

--- a/app/src/modules/history/main/DesignRunView.tsx
+++ b/app/src/modules/history/main/DesignRunView.tsx
@@ -207,6 +207,10 @@ export default function DesignRunView({ run }: DesignRunViewProps) {
 						// actually used (seeded by design-run-seed.ts), not
 						// whatever the engine would default to.
 						httpVersion: request.httpVersion,
+						// And the TLS verification the run was recorded with -
+						// a resend that verified where the run did not would
+						// fail against the host the run was aimed at.
+						verifySSL: request.verifySSL,
 						// Identity for the script sandbox (pm.info), not an HTTP
 						// field. A replay copy is detached, so its name is the
 						// only one the engine can be told about.

--- a/app/src/modules/history/main/design-run-seed.ts
+++ b/app/src/modules/history/main/design-run-seed.ts
@@ -28,6 +28,7 @@ import {
 	DEFAULT_FOLLOW_REDIRECTS,
 	DEFAULT_HTTP_VERSION,
 	DEFAULT_MAX_REDIRECTS,
+	DEFAULT_VERIFY_SSL,
 	isHttpVersion,
 } from "@/constants/request";
 
@@ -45,6 +46,7 @@ interface DesignSnapshot {
 	followRedirects?: boolean;
 	maxRedirects?: number;
 	httpVersion?: string;
+	verifySSL?: boolean;
 }
 
 export interface DesignRunSeed {
@@ -145,6 +147,10 @@ export function seedFromRun(run: Run, liveRequest?: Request | null): DesignRunSe
 			httpVersion: isHttpVersion(snapshot.httpVersion)
 				? snapshot.httpVersion
 				: DEFAULT_HTTP_VERSION,
+			// A run recorded before the field was sent has no key, and reads as
+			// verifying - the same direction every other default here takes,
+			// and the only safe one for this field.
+			verifySSL: snapshot.verifySSL ?? DEFAULT_VERIFY_SSL,
 		},
 		collectionPreScripts: collectionParts(snapshot.preRequestScripts),
 		collectionPostScripts: collectionParts(snapshot.postRequestScripts),

--- a/app/src/modules/history/main/save-run-to-request.test.ts
+++ b/app/src/modules/history/main/save-run-to-request.test.ts
@@ -53,6 +53,7 @@ function run(overrides: Partial<Run> = {}): Run {
 			],
 			followRedirects: false,
 			maxRedirects: 3,
+			verifySSL: true,
 			httpVersion: "http2",
 			requestId: "req_1",
 		},
@@ -417,6 +418,9 @@ describe("buildChangeset", () => {
 			followRedirects: false,
 			maxRedirects: 3,
 			httpVersion: "http2",
+			// The run's snapshot predates `verifySSL`, so the seed reads it as
+			// verifying - the live request has to match to stay "kept".
+			verifySSL: true,
 			auth: { mode: "bearer", token: "x" },
 		} as Partial<Request>);
 

--- a/app/src/modules/history/main/save-run-to-request.ts
+++ b/app/src/modules/history/main/save-run-to-request.ts
@@ -369,6 +369,11 @@ export function buildChangeset(seed: DesignRunSeed, live: Request): ChangesetIte
 		String(patch.maxRedirects ?? live.maxRedirects)
 	);
 	scalar("Protocol", live.httpVersion, patch.httpVersion ?? live.httpVersion);
+	scalar(
+		"Verify TLS certificate",
+		String(live.verifySSL),
+		String(patch.verifySSL ?? live.verifySSL)
+	);
 
 	items.push(authItem(seed, live));
 
@@ -395,6 +400,7 @@ export function applyRunToRequest(seed: DesignRunSeed, live: Request): UpdateReq
 		followRedirects: request.followRedirects ?? live.followRedirects,
 		maxRedirects: request.maxRedirects ?? live.maxRedirects,
 		httpVersion: request.httpVersion ?? live.httpVersion,
+		verifySSL: request.verifySSL ?? live.verifySSL,
 	};
 
 	// The body is only written when the run's stored request body was not

--- a/app/src/modules/request-builder/components/RequestTabs/panels/SettingsPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/SettingsPanel.tsx
@@ -22,8 +22,14 @@
  * POST - and what it changes is how the response is *delivered*, which is
  * exactly what this tab is for.
  *
- * `verifySSL` is deliberately not exposed here - it weakens transport security
- * and was deferred; issue #706 is the record and the place it will land.
+ * **Verification off is loud, not hidden** (issue #706). The row was withheld
+ * for years on the grounds that exposing it weakens transport security; what
+ * that produced was an unreachable knob and users with no way to reach an
+ * internal host at all. The answer to a dangerous state is to make it say so -
+ * the warning line below the toggle, and the Settings tab's own badge - not to
+ * remove the control and leave the trust store as the only way out. The row
+ * says which of the two the reader probably wants: trusting the authority in
+ * Settings > Network & connectivity keeps verification on everywhere.
  *
  * **The rows are the app-settings rows** (issue #702). This tab used to
  * hand-roll a toggle arrangement, a number field and a labelled dropdown that
@@ -34,6 +40,8 @@
  * now (11px, uppercase, muted), and a section holding one row *is* that row,
  * which is why Protocol and Streaming carry no heading of their own.
  */
+
+import { AlertTriangle } from "lucide-react";
 
 import { Eyebrow } from "@/components/ui";
 import {
@@ -57,6 +65,7 @@ const FOLLOW_LABEL = "Follow redirects";
 const MAX_LABEL = "Maximum redirects";
 const PROTOCOL_LABEL = "Protocol";
 const STREAM_LABEL = "Event stream";
+const VERIFY_LABEL = "Verify TLS certificate";
 
 export default function SettingsPanel() {
 	const { request, setRequest, updateField, getAutoAccept, setAutoAccept } =
@@ -164,6 +173,40 @@ export default function SettingsPanel() {
 							: "Only applies while Follow redirects is on."
 					}
 				/>
+			</div>
+
+			<div className="space-y-4">
+				<Eyebrow>Security</Eyebrow>
+
+				<ToggleRow
+					label={VERIFY_LABEL}
+					checked={request.verifySSL}
+					onChange={(checked) => updateField("verifySSL", checked)}
+					description={
+						<>
+							Off skips the certificate check entirely - hostname included - so an
+							internal or self-signed host answers instead of failing. To keep
+							verification on, add the authority under Settings &gt; Network &amp;
+							connectivity instead.
+						</>
+					}
+				/>
+
+				{/*
+				 * Text, not a Badge: it paints no background, which is the rule
+				 * `badge-hover.test.tsx` exists for - and the same treatment the
+				 * response bar gives its protocol-downgrade line, so the two
+				 * warnings in the request builder read as one thing.
+				 */}
+				{!request.verifySSL && (
+					<div className="flex items-start gap-1.5 text-xs text-status-warning-text">
+						<AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+						<span>
+							This request accepts any certificate. A machine in the middle can read
+							and rewrite it - Send, load tests and streams alike.
+						</span>
+					</div>
+				)}
 			</div>
 
 			<ToggleRow

--- a/app/src/modules/request-builder/components/RequestTabs/panels/settings-hierarchy.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/settings-hierarchy.test.tsx
@@ -144,6 +144,7 @@ describe("the Settings tab's hierarchy", () => {
 			"Protocol",
 			"Follow redirects",
 			"Maximum redirects",
+			"Verify TLS certificate",
 			"Event stream",
 		]);
 	});

--- a/app/src/modules/request-builder/components/RequestTabs/settings-tab.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/settings-tab.test.tsx
@@ -52,6 +52,7 @@ const settingsTab = () => screen.getByRole("tab", { name: /settings/i });
 const followToggle = () => screen.getByRole("switch", { name: /follow redirects/i });
 const hopLimit = () => screen.getByLabelText(/maximum redirects/i);
 const protocolPicker = () => screen.getByRole("combobox", { name: /protocol/i });
+const verifyToggle = () => screen.getByRole("switch", { name: /verify tls certificate/i });
 
 describe("Settings tab", () => {
 	it("is a member of the tab strip, so it joins arrow-key navigation", () => {
@@ -85,6 +86,14 @@ describe("Settings tab", () => {
 		expect(settingsTab().textContent).toContain("1");
 	});
 
+	it("badges when TLS verification is off, even with everything else default", () => {
+		// Issue #706: the state this badge matters most for. A request that
+		// accepts any certificate is indistinguishable from one that does not
+		// until a surface says so, and the tab strip is the first one visible.
+		renderTabs({ verifySSL: false });
+		expect(settingsTab().textContent).toContain("1");
+	});
+
 	it("badges when the protocol differs from the default, even with default redirects", () => {
 		// The badge predicate used to only look at followRedirects/maxRedirects
 		// (isRedirectPolicyNonDefault). Changing only the protocol must still
@@ -106,6 +115,34 @@ describe("Settings panel controls", () => {
 		const updateField = renderTabs({ followRedirects: false });
 		fireEvent.click(followToggle());
 		expect(updateField).toHaveBeenCalledWith("followRedirects", true);
+	});
+
+	it("writes the verify toggle through to the request", () => {
+		const updateField = renderTabs();
+		fireEvent.click(verifyToggle());
+		expect(updateField).toHaveBeenCalledWith("verifySSL", false);
+	});
+
+	it("turns verification back on from the off state", () => {
+		const updateField = renderTabs({ verifySSL: false });
+		fireEvent.click(verifyToggle());
+		expect(updateField).toHaveBeenCalledWith("verifySSL", true);
+	});
+
+	it("says nothing about certificates while verification is on", () => {
+		renderTabs();
+		expect(screen.queryByText(/accepts any certificate/i)).toBeNull();
+	});
+
+	it("warns, in the warning colour, once verification is off", () => {
+		// The whole answer to the #706 deferral ("exposing it weakens transport
+		// security") is that the off state is loud. Asserted by class rather
+		// than by looks: jsdom has no layout, and the token is the thing that
+		// makes this line read as a warning rather than as more description.
+		renderTabs({ verifySSL: false });
+		const warning = screen.getByText(/accepts any certificate/i);
+		const line = warning.closest("div");
+		expect(line?.className).toContain("text-status-warning-text");
 	});
 
 	it("keeps both controls in the keyboard tab order", () => {

--- a/app/src/modules/request-builder/index.tsx
+++ b/app/src/modules/request-builder/index.tsx
@@ -176,6 +176,7 @@ export default function RequestBuilder() {
 			followRedirects: fetchedRequest.followRedirects,
 			maxRedirects: fetchedRequest.maxRedirects,
 			httpVersion: fetchedRequest.httpVersion,
+			verifySSL: fetchedRequest.verifySSL,
 			stream: fetchedRequest.stream,
 			collectionId: fetchedRequest.collectionId,
 		};
@@ -247,6 +248,11 @@ export default function RequestBuilder() {
 					// engine's own default win silently, which is not a
 					// decision this client should hand over.
 					httpVersion: request.httpVersion,
+					// And the one where the silent default is a security
+					// decision: `verify_ssl` defaults to true engine-side, so an
+					// omitted `false` verifies the certificate the user turned
+					// verification off for (issue #706).
+					verifySSL: request.verifySSL,
 					// Identity for the script sandbox (pm.info), not an HTTP
 					// field - it rides through composition to /execute.
 					...execIdentity(request),
@@ -492,6 +498,7 @@ export default function RequestBuilder() {
 				followRedirects: request.followRedirects,
 				maxRedirects: request.maxRedirects,
 				httpVersion: request.httpVersion,
+				verifySSL: request.verifySSL,
 				stream: request.stream,
 			});
 		},
@@ -562,6 +569,10 @@ export default function RequestBuilder() {
 						// One control in the Settings tab governs both modes; the
 						// load dialog decides load shape, not request semantics.
 						httpVersion: pendingLoadTestRequest.httpVersion,
+						// And its TLS verification, for the same reason: a load
+						// test that verified where Send did not would fail on
+						// every request against the host the user opted out for.
+						verifySSL: pendingLoadTestRequest.verifySSL,
 						// The collection chain's test scripts too. Load runs only ever
 						// validated the request's own, so a collection-level assertion
 						// passed in design mode and was never checked under load.

--- a/app/src/modules/request-builder/request-settings-plumbing.test.ts
+++ b/app/src/modules/request-builder/request-settings-plumbing.test.ts
@@ -34,7 +34,13 @@
  * `isRedirectPolicyNonDefault` was renamed to `isRequestSettingsNonDefault`: a
  * name that only mentions redirects is how the next field misses this file.
  *
- * All three fields have the same shape at every hop, deliberately. A revision
+ * `verifySSL` joined them in issue #706, with the same four hops and one extra
+ * reason to send it at the default: the engine's default is to *verify*, so a
+ * dropped `false` does not merely pick the engine's preference - it verifies
+ * the certificate the user turned verification off for, and the request fails
+ * against the host the setting exists for.
+ *
+ * All four fields have the same shape at every hop, deliberately. A revision
  * of this branch gave `httpVersion` a per-run picker in the load test dialog,
  * so the load-test hop read the confirmed `LoadTestConfig` instead of the
  * request. That was reversed: one control in the request builder's Settings
@@ -68,7 +74,7 @@ describe("redirect policy and protocol reach every payload the renderer builds",
 		expect(source).toContain("engineExecuteRequest");
 	});
 
-	for (const field of ["followRedirects", "maxRedirects", "httpVersion"] as const) {
+	for (const field of ["followRedirects", "maxRedirects", "httpVersion", "verifySSL"] as const) {
 		it(`loads ${field} from the saved request into the editor state`, () => {
 			expect(hops(source ?? "", "fetchedRequest", field)).toBe(1);
 		});
@@ -79,7 +85,7 @@ describe("redirect policy and protocol reach every payload the renderer builds",
 		});
 	}
 
-	for (const field of ["followRedirects", "maxRedirects", "httpVersion"] as const) {
+	for (const field of ["followRedirects", "maxRedirects", "httpVersion", "verifySSL"] as const) {
 		it(`sends ${field} with the load test`, () => {
 			expect(hops(source ?? "", "pendingLoadTestRequest", field)).toBe(1);
 		});

--- a/app/src/modules/request-builder/types.ts
+++ b/app/src/modules/request-builder/types.ts
@@ -154,6 +154,8 @@ export interface RequestState {
 	maxRedirects: number;
 	/** Protocol to negotiate. See `Request.httpVersion` for the full rationale. */
 	httpVersion: HttpVersion;
+	/** Verify the TLS certificate. See `Request.verifySSL` for the rationale. */
+	verifySSL: boolean;
 	/**
 	 * Consume this endpoint's response as a `text/event-stream` (issue #574).
 	 *

--- a/app/src/modules/request-builder/utils/request-state.test.ts
+++ b/app/src/modules/request-builder/utils/request-state.test.ts
@@ -38,6 +38,7 @@ describe("isRequestSettingsNonDefault", () => {
 		followRedirects: true,
 		maxRedirects: 10,
 		httpVersion: DEFAULT_HTTP_VERSION,
+		verifySSL: true,
 		stream: false,
 	} as const;
 
@@ -57,6 +58,13 @@ describe("isRequestSettingsNonDefault", () => {
 		// This is the case the rename exists for: a request that only changes
 		// its protocol must still badge the Settings tab.
 		expect(isRequestSettingsNonDefault({ ...defaults, httpVersion: "http2" })).toBe(true);
+	});
+
+	it("is true when TLS verification is off and nothing else differs", () => {
+		// The field whose non-default state is the one worth badging most:
+		// a request that accepts any certificate looks exactly like one that
+		// does not until this tab says so (issue #706).
+		expect(isRequestSettingsNonDefault({ ...defaults, verifySSL: false })).toBe(true);
 	});
 
 	it("is true when the event-stream flag is on and nothing else differs", () => {

--- a/app/src/modules/request-builder/utils/request-state.ts
+++ b/app/src/modules/request-builder/utils/request-state.ts
@@ -17,6 +17,7 @@ import {
 	DEFAULT_HTTP_VERSION,
 	DEFAULT_MAX_REDIRECTS,
 	DEFAULT_STREAM,
+	DEFAULT_VERIFY_SSL,
 	type HttpVersion,
 } from "@/constants/request";
 import { createEmptyKeyValue } from "@/components/shared/KeyValueEditor/key-value";
@@ -56,6 +57,7 @@ export const createDefaultRequestState = (
 		followRedirects: DEFAULT_FOLLOW_REDIRECTS,
 		maxRedirects: DEFAULT_MAX_REDIRECTS,
 		httpVersion,
+		verifySSL: DEFAULT_VERIFY_SSL,
 		stream: DEFAULT_STREAM,
 	};
 };
@@ -75,12 +77,16 @@ export const createDefaultRequestState = (
  * component (`react-refresh/only-export-components`).
  */
 export function isRequestSettingsNonDefault(
-	state: Pick<RequestState, "followRedirects" | "maxRedirects" | "httpVersion" | "stream">
+	state: Pick<
+		RequestState,
+		"followRedirects" | "maxRedirects" | "httpVersion" | "verifySSL" | "stream"
+	>
 ): boolean {
 	return (
 		state.followRedirects !== DEFAULT_FOLLOW_REDIRECTS ||
 		state.maxRedirects !== DEFAULT_MAX_REDIRECTS ||
 		state.httpVersion !== DEFAULT_HTTP_VERSION ||
+		state.verifySSL !== DEFAULT_VERIFY_SSL ||
 		state.stream !== DEFAULT_STREAM
 	);
 }

--- a/app/src/modules/settings/main/SettingsMain.text-row.test.tsx
+++ b/app/src/modules/settings/main/SettingsMain.text-row.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The engine `text` card renders a textarea (issue #706).
+ *
+ * `text` is the multi-line string the CA bundle arrives as: several PEM blocks
+ * whose line breaks are the format. Rendered through the `string` branch it
+ * would be a single-line `Input` showing one line of a certificate with the
+ * rest scrolled out of view - which is how the setting would look broken while
+ * holding exactly what the user pasted.
+ *
+ * Asserted on the element rather than by the value it holds: the failure this
+ * guards is the *control type*, and a value round-trips identically through
+ * either one.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SettingsMain from "./SettingsMain";
+import type { ConfigEntry } from "@/types";
+
+const textEntry: ConfigEntry = {
+	key: "customCaCertificates",
+	label: "Custom CA Certificates",
+	description: "Certificate authorities to trust in addition to the platform's own.",
+	type: "text",
+	value: "",
+	default: "",
+	category: "network_performance",
+	requiresRestart: false,
+	advanced: false,
+	keywords: [],
+	updatedAt: 0,
+};
+
+vi.mock("@/queries", () => ({
+	useConfigQuery: () => ({
+		data: { entries: [textEntry] },
+		isLoading: false,
+		error: null,
+	}),
+	useUpdateConfigMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/modules/settings/settings-store", () => ({
+	useSettingsStore: () => ({
+		selectedCategory: "network_performance",
+		restartRequiredKeys: [],
+	}),
+}));
+
+vi.mock("@/stores", () => ({
+	useEngineStore: () => ({
+		isEngineConnected: true,
+		pendingRestart: false,
+		restartRequiredKeys: [],
+		addRestartRequiredKey: vi.fn(),
+		clearRestartRequired: vi.fn(),
+	}),
+	useToastStore: (selector: (s: { showToast: () => void }) => unknown) =>
+		selector({ showToast: vi.fn() }),
+}));
+
+vi.mock("@/stores/save-store", () => ({
+	// SettingsMain destructures nine members; a partial mock throws on the first
+	// one it calls, which is easy to mistake for a defect in the component.
+	useSaveStore: () => ({
+		startSaving: vi.fn(),
+		completeSaveThenIdle: vi.fn(),
+		failSave: vi.fn(),
+		setStatus: vi.fn(),
+		markPendingSave: vi.fn(),
+		registerContext: vi.fn(),
+		unregisterContext: vi.fn(),
+		setActiveContext: vi.fn(),
+		updateContext: vi.fn(),
+	}),
+}));
+
+function renderSettings() {
+	// SettingsMain calls useQueryClient directly (for invalidation), so the
+	// provider is required even with the query hooks mocked.
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<SettingsMain />
+		</QueryClientProvider>
+	);
+}
+
+const control = () => screen.getByLabelText("Custom CA Certificates");
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("the engine text card", () => {
+	it("renders a textarea, not the single-line input", () => {
+		renderSettings();
+		expect(control().tagName).toBe("TEXTAREA");
+	});
+
+	it("keeps the pasted line breaks intact", () => {
+		// A `<input type="text">` drops them silently, which is the shape of the
+		// bug: the certificate is stored as one line and stops being a PEM.
+		renderSettings();
+		const pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n";
+		fireEvent.change(control(), { target: { value: pem } });
+		expect((control() as HTMLTextAreaElement).value).toBe(pem);
+	});
+
+	it("shows the content as monospace, since its line structure is the format", () => {
+		renderSettings();
+		expect(control().className).toContain("font-mono");
+	});
+});

--- a/app/src/modules/settings/main/SettingsMain.tsx
+++ b/app/src/modules/settings/main/SettingsMain.tsx
@@ -40,6 +40,7 @@ import {
 	CardHeader,
 	CardTitle,
 	Skeleton,
+	Textarea,
 } from "@/components/ui";
 import { EmptyState } from "@/components/shared";
 import { cn } from "@/lib/utils";
@@ -725,6 +726,25 @@ export default function SettingsMain() {
 							defaultValue={entry.default}
 							defaultDisplay={defaultDisplay}
 							onResetToDefault={() => handleResetToDefault(entry)}
+						/>
+					) : entry.type === "text" ? (
+						/*
+						 * The multi-line string: what goes in it is pasted rather
+						 * than typed (a PEM bundle, today), and a single-line
+						 * input shows one line of it with the rest scrolled out
+						 * of sight. Monospace because the content is delimited
+						 * text whose line breaks are load-bearing - a wrapped
+						 * -----BEGIN CERTIFICATE----- is not the same string.
+						 */
+						<Textarea
+							value={currentValue}
+							onChange={(e) => handleValueChange(entry, e.target.value)}
+							rows={8}
+							spellCheck={false}
+							className="font-mono text-xs"
+							// Same as the Switch above: the name is in the
+							// CardTitle, which nothing links to this control.
+							aria-label={entry.label}
 						/>
 					) : (
 						<Input

--- a/app/src/services/codegen/codegen.test.ts
+++ b/app/src/services/codegen/codegen.test.ts
@@ -831,6 +831,38 @@ describe("the target registry", () => {
 });
 
 /**
+ * A request that skips certificate verification (issue #706). curl has the
+ * flag and emits it; the round trip through `parseCommand` is what keeps the
+ * paste and the snippet describing one request.
+ */
+describe("a request with TLS verification off", () => {
+	const INSECURE: SnippetRequest = {
+		method: "GET",
+		url: "https://internal.example.com/health",
+		verifySSL: false,
+	};
+
+	it("curl emits -k, and parseCurl reads it back as the same setting", () => {
+		const { code } = generateCurl(INSECURE);
+		expect(code).toContain(" -k");
+		const reparsed = parseCommand(code.split("\\\n").join(" "));
+		expect(reparsed?.verifySSL).toBe(false);
+	});
+
+	it("says nothing when the request verifies, which is curl's own default", () => {
+		const { code } = generateCurl({ ...INSECURE, verifySSL: true });
+		expect(code).not.toContain(" -k");
+	});
+
+	it("treats an unstated verifySSL as verifying", () => {
+		// Every caller that predates the field, and the codegen preview's own
+		// fixtures: absent must not read as "do not verify".
+		const { code } = generateCurl({ method: "GET", url: "https://api.example.com/" });
+		expect(code).not.toContain(" -k");
+	});
+});
+
+/**
  * A stream-flagged request (issue #575). Two targets have a first-class
  * unbuffered mode and emit it; the three whose stock idiom buffers the whole
  * body say so, because a snippet that looked like the request would hang on an

--- a/app/src/services/codegen/curl.ts
+++ b/app/src/services/codegen/curl.ts
@@ -61,6 +61,14 @@ export function generateCurl(
 		if (accept) args.push(`-H ${shellQuote(`${ACCEPT_HEADER}: ${accept}`)}`);
 	}
 
+	if (!prepared.verifySSL) {
+		// Emitted only when verification is off, and `parseCurl` reads it back
+		// as the same setting - the round trip issue #706 asks for. The verifying
+		// default needs no flag: `curl` verifies unless told otherwise, so
+		// emitting nothing is emitting the request.
+		args.push("-k");
+	}
+
 	if (prepared.basicAuth) {
 		args.push(
 			`-u ${shellQuote(`${prepared.basicAuth.username}:${prepared.basicAuth.password}`)}`

--- a/app/src/services/codegen/prepare.ts
+++ b/app/src/services/codegen/prepare.ts
@@ -54,6 +54,8 @@ export interface PreparedRequest {
 	body: PreparedBody | undefined;
 	/** Whether the response is a stream - see `SnippetRequest.stream`. */
 	stream: boolean;
+	/** Whether TLS verification is on - see `SnippetRequest.verifySSL`. */
+	verifySSL: boolean;
 	notes: string[];
 	masked: boolean;
 }
@@ -268,6 +270,9 @@ export function prepareRequest(
 		basicAuth: maskedBasic,
 		body: body ? maskedBody(body, masker.apply) : undefined,
 		stream: request.stream === true,
+		// Absent means verifying: the engine's default, and the safe reading of
+		// a caller that never set it.
+		verifySSL: request.verifySSL !== false,
 		notes,
 		masked: masker.wasUsed(),
 	};

--- a/app/src/services/codegen/types.ts
+++ b/app/src/services/codegen/types.ts
@@ -52,6 +52,15 @@ export interface SnippetRequest {
 	 * command that would hang on an endless stream.
 	 */
 	stream?: boolean;
+	/**
+	 * Verify the TLS certificate (issue #706). Default `true`, and the snippet
+	 * only says anything when it is off - `curl -k` is the flag `parseCurl`
+	 * reads back, so a request pasted from a command that turned verification
+	 * off regenerates the command it came from. Targets with no first-class
+	 * spelling for it carry a note instead of silently emitting a verifying
+	 * request, the same split `stream` above takes.
+	 */
+	verifySSL?: boolean;
 }
 
 export interface CodegenOptions {

--- a/app/src/services/curl/parseCurl.test.ts
+++ b/app/src/services/curl/parseCurl.test.ts
@@ -364,6 +364,42 @@ describe("parseCommand - failure modes", () => {
 });
 
 /**
+ * `-k` / `--insecure` says the host's certificate does not verify, which is a
+ * property of the request rather than an output nicety - so it maps onto the
+ * stored `verifySSL` instead of being skipped (issue #706). A command that
+ * turned verification off, imported as a verifying request, fails on its first
+ * send for the reason the command already named. `codegen.test.ts` holds the
+ * other half of the round trip.
+ */
+describe("parseCommand - curl -k is the verifySSL setting", () => {
+	test.each([["-k"], ["--insecure"]])("%s turns verification off", (flag) => {
+		const parsed = parseCommand(`curl ${flag} https://internal.example.com/health`);
+		expect(parsed?.verifySSL).toBe(false);
+	});
+
+	test("a command without it verifies, which is curl's own default", () => {
+		const parsed = parseCommand("curl https://api.example.com/health");
+		expect(parsed?.verifySSL).toBe(true);
+	});
+
+	test("wget's spelling of the same intent is honoured too", () => {
+		const parsed = parseCommand(
+			"wget --no-check-certificate https://internal.example.com/health"
+		);
+		expect(parsed?.verifySSL).toBe(false);
+	});
+
+	test("the flag is not mistaken for a value-taking one", () => {
+		// `-k` used to sit in the no-argument skip set; a mapping that consumed
+		// the next token instead would eat the URL and the parse would return
+		// null.
+		const parsed = parseCommand("curl -k -X POST https://internal.example.com/orders");
+		expect(parsed?.url).toBe("https://internal.example.com/orders");
+		expect(parsed?.method).toBe("POST");
+	});
+});
+
+/**
  * `-N` / `--no-buffer` is how a stream is consumed from a terminal, so it maps
  * onto the request's Event stream setting rather than being skipped as an
  * output nicety (issue #575). The generator emits it back, and

--- a/app/src/services/curl/parseCurl.ts
+++ b/app/src/services/curl/parseCurl.ts
@@ -46,6 +46,7 @@ export type ParsedRequest = Pick<
 	| "urlEncoded"
 	| "auth"
 	| "stream"
+	| "verifySSL"
 >;
 
 type CommandKind = "curl" | "wget";
@@ -97,6 +98,7 @@ interface Builder {
 	basic: { username: string; password: string } | null;
 	bearer: string | null; // curl --oauth2-bearer
 	stream: boolean; // -N / --no-buffer
+	insecure: boolean; // curl -k / --insecure, wget --no-check-certificate
 }
 
 function newBuilder(): Builder {
@@ -113,6 +115,7 @@ function newBuilder(): Builder {
 		basic: null,
 		bearer: null,
 		stream: false,
+		insecure: false,
 	};
 }
 
@@ -316,6 +319,12 @@ function resolve(b: Builder): ParsedRequest {
 		urlEncoded,
 		auth,
 		stream: b.stream,
+		// `-k` says "do not verify", so the stored field is its inverse. Mapped
+		// rather than skipped (issue #706): a pasted command that turns
+		// verification off described a host whose certificate does not verify,
+		// and importing it as a verifying request means the paste fails on the
+		// first send for a reason the command already named.
+		verifySSL: !b.insecure,
 	};
 }
 
@@ -363,8 +372,6 @@ const CURL_NOARG = new Set([
 	"--verbose",
 	"-L",
 	"--location",
-	"-k",
-	"--insecure",
 	"-f",
 	"--fail",
 	"-S",
@@ -493,6 +500,10 @@ function parseCurl(args: string[]): ParsedRequest {
 				value();
 				b.uploadFile = true;
 				break;
+			case "-k":
+			case "--insecure":
+				b.insecure = true;
+				break;
 			case "-N":
 			case "--no-buffer":
 				// curl's unbuffered flag is how a streaming endpoint is consumed
@@ -528,7 +539,6 @@ function parseCurl(args: string[]): ParsedRequest {
 const WGET_NOARG = new Set([
 	"-q",
 	"--quiet",
-	"--no-check-certificate",
 	"--continue",
 	"-c",
 	"--no-verbose",
@@ -602,6 +612,13 @@ function parseWget(args: string[]): ParsedRequest {
 			// --post-file sends file contents as the body; can't read it → skip.
 			case "--post-file":
 				value();
+				break;
+			// wget's spelling of `-k`, mapped for the same reason and through
+			// the same builder field - the two commands resolve into one
+			// request, so honouring the intent on one path and eating it on the
+			// other is the drift this parser exists to avoid.
+			case "--no-check-certificate":
+				b.insecure = true;
 				break;
 			default:
 				if (WGET_SKIP_WITH_ARG.has(flag)) {

--- a/app/src/services/exporters/openapi.test.ts
+++ b/app/src/services/exporters/openapi.test.ts
@@ -60,6 +60,7 @@ function request(overrides: Partial<Request> = {}): Request {
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		order: 0,

--- a/app/src/services/openapi/operation-match.test.ts
+++ b/app/src/services/openapi/operation-match.test.ts
@@ -35,6 +35,7 @@ function request(id: string, method: string, url: string): Request {
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		order: 0,

--- a/app/src/services/openapi/spec-apply.test.ts
+++ b/app/src/services/openapi/spec-apply.test.ts
@@ -82,6 +82,7 @@ function requestFrom(
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		specOperation: operation,

--- a/app/src/services/openapi/spec-diff.test.ts
+++ b/app/src/services/openapi/spec-diff.test.ts
@@ -95,6 +95,7 @@ function requestFrom(
 		postRequestScript: "",
 		followRedirects: true,
 		maxRedirects: 10,
+		verifySSL: true,
 		httpVersion: "auto",
 		stream: false,
 		specOperation: operation,

--- a/app/src/services/transformers/request-transformer.test.ts
+++ b/app/src/services/transformers/request-transformer.test.ts
@@ -20,6 +20,7 @@ import {
 	DEFAULT_FOLLOW_REDIRECTS,
 	DEFAULT_HTTP_VERSION,
 	DEFAULT_MAX_REDIRECTS,
+	DEFAULT_VERIFY_SSL,
 } from "@/constants/request";
 
 const base = {
@@ -47,6 +48,27 @@ describe("RequestTransformer redirect policy", () => {
 		});
 		expect(req.followRedirects).toBe(false);
 		expect(req.maxRedirects).toBe(2);
+	});
+
+	it("reads a row with no verifySSL as verifying", () => {
+		// The same hop, and the one where the wrong default is a security
+		// decision: every request stored before the column existed comes back
+		// without the key, and must not read as "accept any certificate"
+		// (issue #706).
+		expect(RequestTransformer.toFrontend({ ...base }).verifySSL).toBe(DEFAULT_VERIFY_SSL);
+	});
+
+	it("preserves a stored verifySSL of false", () => {
+		expect(RequestTransformer.toFrontend({ ...base, verifySSL: false }).verifySSL).toBe(false);
+	});
+
+	it("ignores a non-boolean verifySSL rather than coercing it", () => {
+		// `"false"` is truthy, so a coercing read would turn a corrupted row
+		// into a verifying one silently - the reason every field here checks
+		// the type rather than the value.
+		expect(RequestTransformer.toFrontend({ ...base, verifySSL: "false" }).verifySSL).toBe(
+			DEFAULT_VERIFY_SSL
+		);
 	});
 
 	it("keeps a stored maxRedirects of 0 rather than treating it as absent", () => {

--- a/app/src/services/transformers/request-transformer.ts
+++ b/app/src/services/transformers/request-transformer.ts
@@ -25,6 +25,7 @@ import { asRecord, asStr } from "@/lib/json-node";
 import {
 	DEFAULT_FOLLOW_REDIRECTS,
 	DEFAULT_STREAM,
+	DEFAULT_VERIFY_SSL,
 	DEFAULT_HTTP_VERSION,
 	DEFAULT_MAX_REDIRECTS,
 	MAX_MAX_REDIRECTS,
@@ -139,6 +140,9 @@ export class RequestTransformer {
 			// carrying a value this build doesn't recognise, reads as the
 			// engine default rather than as an unselectable value.
 			httpVersion: coerceHttpVersion(raw.httpVersion),
+			// TLS verification: same rule again, and the direction matters -
+			// a row stored before this column existed reads as verifying.
+			verifySSL: typeof raw.verifySSL === "boolean" ? raw.verifySSL : DEFAULT_VERIFY_SSL,
 			// Event stream: same rule as the redirect policy - a row stored
 			// before this column existed reads as `false`, which is what it was.
 			stream: typeof raw.stream === "boolean" ? raw.stream : DEFAULT_STREAM,

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -173,6 +173,8 @@ export interface CreateRequestRequest {
 	followRedirects?: boolean;
 	maxRedirects?: number;
 	httpVersion?: HttpVersion;
+	/** Verify the TLS certificate - see {@link Request.verifySSL}. */
+	verifySSL?: boolean;
 	/** Consume the response as an event stream - see {@link Request.stream}. */
 	stream?: boolean;
 	/** Which spec operation this request is - see {@link Request.specOperation}. */
@@ -202,6 +204,8 @@ export interface UpdateRequestRequest {
 	followRedirects?: boolean;
 	maxRedirects?: number;
 	httpVersion?: HttpVersion;
+	/** Verify the TLS certificate - see {@link Request.verifySSL}. */
+	verifySSL?: boolean;
 	/** Consume the response as an event stream - see {@link Request.stream}. */
 	stream?: boolean;
 	/**
@@ -342,6 +346,14 @@ export interface ExecuteRequestRequest {
 	 * section.
 	 */
 	httpVersion?: HttpVersion;
+	/**
+	 * Verify the TLS certificate. Sent on every execute for the reason above
+	 * and one more: the engine's default is `true`, so an omitted `false`
+	 * verifies the certificate the user turned verification off for - the
+	 * default winning silently is a security decision here, not a surprise
+	 * (issue #706).
+	 */
+	verifySSL?: boolean;
 	requestId?: string;
 	/**
 	 * The request's name, for the script sandbox to read as `pm.info.requestName`
@@ -487,6 +499,9 @@ export interface StartLoadTestRequest {
 
 	/** Protocol to negotiate - same rationale as `followRedirects` above. */
 	httpVersion?: HttpVersion;
+
+	/** TLS verification - same rationale, and see {@link Request.verifySSL}. */
+	verifySSL?: boolean;
 
 	// Load test strategy
 	mode: LoadTestMode;

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -596,6 +596,18 @@ export interface Request {
 	 */
 	httpVersion: HttpVersion;
 	/**
+	 * Verify the TLS certificate this endpoint presents. Engine default is
+	 * `true`, and it is sent on every payload rather than elided at the default
+	 * for exactly that reason: an omitted `false` verifies the certificate the
+	 * user asked the engine not to check (issue #706).
+	 *
+	 * Per-request, not app-wide: it describes the one internal host with the
+	 * self-signed certificate. Trusting an authority everywhere is the other
+	 * control, Settings > Network & connectivity > Custom CA Certificates, and
+	 * it is the one to reach for first.
+	 */
+	verifySSL: boolean;
+	/**
 	 * Consume this endpoint's response as a `text/event-stream` (issue #574).
 	 * Stored on the request because it describes the *endpoint* rather than one
 	 * send, so the builder's Event stream toggle survives a tab switch and a
@@ -2054,7 +2066,12 @@ export interface EngineConfig {
 export interface ConfigEntry {
 	key: string;
 	value: string;
-	type: "integer" | "string" | "boolean" | "number" | "enum";
+	/**
+	 * `text` is a multi-line string (a pasted PEM bundle, issue #706) - the
+	 * same value space as `string`, rendered as a textarea rather than a
+	 * single-line input because the content has line breaks that matter.
+	 */
+	type: "integer" | "string" | "boolean" | "number" | "enum" | "text";
 	label: string;
 	description: string;
 	category: string;

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -877,6 +877,7 @@ await apiService.executeRequest({
   followRedirects: true,
   maxRedirects: 10,
   httpVersion: "auto",
+  verifySSL: true,
   requestId: "req_123",
   environmentId: "env_456"
 });
@@ -891,14 +892,17 @@ untouched - script text is never interpolated; the by-id compose path (used by
 MCP) builds the same list engine-side. The **engine** joins the parts and runs
 the result - see `docs/engine/architecture.md` → *Request composition boundary*.
 
-**Redirect policy and protocol are always sent, never elided.**
-`followRedirects`, `maxRedirects` and `httpVersion` all come from the request's
-**Settings** tab and are included on every execute even when they equal the
-defaults. The engine defaults `follow_redirects` to `true`, so omitting a
+**Redirect policy, protocol and TLS verification are always sent, never
+elided.** `followRedirects`, `maxRedirects`, `httpVersion` and `verifySSL` all
+come from the request's **Settings** tab and are included on every execute even
+when they equal the defaults. The engine defaults `follow_redirects` to `true`, so omitting a
 `false` would follow the 3xx the user asked to inspect - a bug the app shipped
 with for a long time, when nothing in the renderer sent these fields at all.
-The same three fields go out with `startLoadTest()`, so a load test exercises
-the same policy and protocol the request was configured with - there is no
+`verifySSL` carries the same rule for a sharper reason: the engine verifies
+unless told otherwise, so an omitted `false` verifies the certificate the user
+turned verification off for, and the send fails against the one host the
+setting exists for. All four go out with `startLoadTest()`, so a load test
+exercises the same policy, protocol and trust the request was configured with - there is no
 separate, load-test-only protocol control; the Settings tab's picker is the
 only one, and it governs Send and load test alike. `httpVersion` is
 `"auto" | "http1.1" | "http2"`: `"auto"` lets ALPN negotiate, `"http1.1"`
@@ -1005,6 +1009,7 @@ await apiService.startLoadTest({
   followRedirects: true,
   maxRedirects: 10,
   httpVersion: "auto",
+  verifySSL: true,
   mode: "constant_rps",
   duration: "30s",
   targetRps: 100,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,6 +245,16 @@ a refused CONNECT - is reported as its own `PROXY_ERROR`, never as the target's
 `CONNECTION_FAILED`. Cookies are unaffected: libcurl matches them on the origin
 host, never on the proxy.
 
+The same policy carries **who the engine trusts**. `customCaCertificates` holds
+pasted PEM anchors, materialized as a bundle beside the database and added to
+the platform's own trust rather than replacing it, so a TLS-inspecting proxy or
+an internal authority is verifiable on every one of those paths at once. Per
+request, the Settings tab's *Verify TLS certificate* row turns verification off
+for one endpoint - stored, sent on every send and load test, and painted as a
+warning while it is off. See
+[TLS trust settings](engine/api-reference.md#tls-trust-settings) for the
+per-backend behaviour on each platform.
+
 ### Variable Resolution
 
 Variables are resolved with priority: **Environment > Collection > Global**

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -650,6 +650,43 @@ numeric values stored in existing traces are unchanged.
 Cookies are unaffected by any of this: libcurl owns the wire cookies and
 matches them on the **origin** host, never the proxy hop.
 
+#### TLS trust settings
+
+One more `network_performance` entry decides *who* the engine trusts, and it
+reaches the same six outbound paths the proxy settings do.
+
+| Key | Default | Values | Effect |
+|-----|---------|--------|--------|
+| `customCaCertificates` | `""` | PEM text (`text` entry) | Certificate authorities to trust **in addition** to the ones this platform already trusts. Pasted content, not a path: a path breaks when the file moves and cannot be shown back in Settings. `POST /config` refuses text that holds no `-----BEGIN CERTIFICATE-----` block, and names a pasted private key for what it is. |
+
+The engine materializes the bundle as `ca-bundle.pem` beside its database and
+points `CURLOPT_CAINFO` at it, rewriting the file only when the setting's
+content changes. **Native trust is preserved** - the mechanism differs by TLS
+backend, and each is stated rather than assumed:
+
+| Platform | Backend at the pinned vcpkg baseline | What the bundle does |
+|----------|--------------------------------------|----------------------|
+| Linux | OpenSSL (default paths + `CURL_CA_FALLBACK`) | `CURLOPT_CAINFO` **replaces** the default bundle, so the materialized file is the platform's own anchors **concatenated with** the pasted ones. The system bundle is located the way curl locates it: `CURL_CA_BUNDLE` / `SSL_CERT_FILE`, then libcurl's compiled-in `cainfo`, then the standard distribution paths. |
+| macOS | Apple SecTrust (`USE_APPLE_SECTRUST=ON`) | The OS trust store is the backend's own and is not a file to merge, so the bundle holds the pasted certificates alone and the store keeps applying. |
+| Windows | Schannel | Same as macOS: the certificate store stays in force and the bundle extends it. |
+
+Two things make that table checkable rather than a claim. `CURLOPT_CAINFO` is
+the one transport option a backend can refuse outright, so the engine checks
+the return code and logs an error naming the backend if it ever does - and the
+test suite asserts on every CI platform that this build's backend accepts it.
+Where a bundle is in force the engine also sets `CURLSSLOPT_NATIVE_CA`, which
+asks the backends that implement it to keep consulting the OS store; it is a
+no-op on the rest, and on Linux the merge above is what carries the guarantee.
+
+A certificate that still fails to verify fails at handshake time with libcurl's
+own `SSL_ERROR` - the validation on the way in is about the *shape* of the
+paste, deliberately, so a chain curl would accept is never refused by a parser
+of ours.
+
+Per-request, `verifySSL: false` turns verification off for one endpoint
+entirely (see [POST /execute](#post-execute)); trusting the authority here is
+the answer that keeps verification on everywhere else.
+
 In-progress (`running`/`pending`) runs are never pruned, and neither are runs
 pinned as baselines (see
 [PUT /runs/:runId/baseline](#put-runsrunidbaseline)); neither kind counts
@@ -867,6 +904,7 @@ then `id` - the same contract `GET /collections` has for collections. See
     "followRedirects": true,
     "maxRedirects": 10,
     "httpVersion": "auto",
+    "verifySSL": true,
     "stream": false,
     "updatedAt": 1234567890,
     "createdAt": 1234567890
@@ -874,10 +912,11 @@ then `id` - the same contract `GET /collections` has for collections. See
 ]
 ```
 
-`followRedirects` / `maxRedirects` / `httpVersion` / `stream` are the request's
-stored execution options. They are always present in the response: a request
-saved before these columns existed reads back as the engine defaults
-(`true` / `10` / `"auto"` / `false`), which is the behaviour it already had.
+`followRedirects` / `maxRedirects` / `httpVersion` / `verifySSL` / `stream` are
+the request's stored execution options. They are always present in the response:
+a request saved before these columns existed reads back as the engine defaults
+(`true` / `10` / `"auto"` / `true` / `false`), which is the behaviour it already
+had.
 `httpVersion` is `"auto"` | `"http1.1"` | `"http2"` - what was *requested*, not
 what was negotiated; see [POST /execute](#post-execute) for the negotiated
 value on a response.
@@ -912,6 +951,7 @@ entry.
   "followRedirects": true,
   "maxRedirects": 10,
   "httpVersion": "auto",
+  "verifySSL": true,
   "stream": false,
   "createdAt": 1234567890,
   "updatedAt": 1234567890
@@ -948,6 +988,7 @@ the null-vs-absent rule.
   "maxRedirects": 10,                // Optional, hops while following, clamped to 0..100. Default 10
   "httpVersion": "auto",             // Optional: "auto" | "http1.1" | "http2". Absent/null seeds
                                       // from the "defaultHttpVersion" config entry
+  "verifySSL": true,                 // Optional, verify the TLS certificate. Default true
   "stream": false,                   // Optional, consume the response as an event stream.
                                       // Default false - see below
   "specOperation": null              // Optional, which spec operation this request is - see below
@@ -1016,10 +1057,10 @@ must resolve to a stored collection (`400` otherwise), and a move that states no
 states no `collectionId` is not checked against the request's stored one, so a
 row stranded before this validation existed stays editable, and repairable by a
 `PUT` that moves it somewhere real. Omitting `followRedirects` / `maxRedirects` /
-`stream` / `specOperation` leaves the stored values untouched; sending `null`
-resets them to `true` / `10` / `false` / "no operation". A non-boolean
-`followRedirects` or `stream`, or a non-integer `maxRedirects`, is ignored rather
-than rejected. `maxRedirects` is clamped to `0..100` on the way in.
+`verifySSL` / `stream` / `specOperation` leaves the stored values untouched;
+sending `null` resets them to `true` / `10` / `true` / `false` / "no operation".
+A non-boolean `followRedirects`, `verifySSL` or `stream`, or a non-integer
+`maxRedirects`, is ignored rather than rejected. `maxRedirects` is clamped to `0..100` on the way in.
 
 **`httpVersion`** follows the same [null-vs-absent rule](#the-null-vs-absent-rule)
 as the fields above, but validates more strictly: absent keeps the stored
@@ -2445,7 +2486,7 @@ payload that skips composition is sent byte-for-byte as supplied.
   headers (later duplicates win), body, auth (absent auth defaults to
   `inherit`), the ordered script-part lists (collection chain root→leaf, then
   the request's own), the stored execution options (`followRedirects` /
-  `maxRedirects` / `httpVersion`, always emitted) and its `requestName` (the
+  `maxRedirects` / `httpVersion` / `verifySSL`, always emitted) and its `requestName` (the
   script sandbox reads it as `pm.info.requestName`; omitted when the row's name
   is empty). The request's own collection scopes resolution; `collectionId` is
   only a fallback for a request without one. An unknown id is a definitive
@@ -2532,7 +2573,8 @@ If a non-interactive OAuth 2.0 token cannot be obtained, the engine still return
   "allowScriptRequests": false,        // Optional, default false - see below
   "followRedirects": true,             // Optional, default true
   "maxRedirects": 10,                  // Optional, default 10
-  "verifySSL": true,                   // Optional, default true
+  "verifySSL": true,                   // Optional, default true - stored per request and
+                                       // settable in the request builder's Settings tab
   "httpVersion": "auto",               // Optional: "auto" | "http1.1" | "http2", default "auto"
   "transient": false,                  // Optional, default false - see below
   "stream": false,                     // Optional, default false - see below
@@ -2732,6 +2774,17 @@ clients send these explicitly for exactly that reason (see
 [api-integration](../app/api-integration.md)). `POST /runs` accepts the same
 three fields with the same defaults, so a load test can be run under the policy
 the request was configured with.
+
+**TLS verification.** `verifySSL` defaults to **true** and is stored on the
+request (`requests.verify_ssl`, the Settings tab's *Verify TLS certificate*
+row). Both clients send it on every execute and every load test rather than
+eliding the default, for a stronger reason than the redirect policy above: an
+omitted `false` **verifies** the certificate the user turned verification off
+for, so the request fails against the one host the setting exists for. Off
+skips both the chain and the hostname check (`CURLOPT_SSL_VERIFYPEER` and
+`CURLOPT_SSL_VERIFYHOST`), which is why the app paints the state as a warning.
+To keep verification on for a host with an internal authority, add the CA under
+[TLS trust settings](#tls-trust-settings) instead.
 
 **A redirect that crosses origins drops the cookies the hop set.** Since
 **curl 8.21.0** (`http: don't pass on set cookies to new origins`, which the

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -153,6 +153,7 @@ Stores individual HTTP request definitions.
 | `follow_redirects`    | INTEGER | Boolean; default 1 (follow)                          |
 | `max_redirects`       | INTEGER | Hops allowed while following; default 10             |
 | `http_version`        | TEXT    | `'auto'` \| `'http1.1'` \| `'http2'`; default `'auto'` |
+| `verify_ssl`          | INTEGER | Boolean; verify the TLS certificate; default 1       |
 | `stream`              | INTEGER | Boolean; consume the response as SSE; default 0      |
 | `spec_operation`      | TEXT    | JSON: which spec operation this is; NULL when none   |
 | `created_at`          | INTEGER | Unix ms                                              |
@@ -1132,6 +1133,14 @@ the three are read together as one policy at the point of use - see
 [Proxy settings](api-reference.md#proxy-settings) for the values, the
 cross-field rule `POST /config` enforces over `proxyMode` + `proxyUrl`, and why
 `proxyUrl` holds credentials in plaintext exactly as `oauth_tokens` does.
+
+**`customCaCertificates`** is the one `text` entry - a multi-line string, which
+is a rendering distinction rather than a value-space one: the app draws a
+textarea for it because what it holds is pasted PEM whose line breaks are the
+format. The certificates themselves are public, so nothing here is a
+credential; the engine materializes them as `ca-bundle.pem` beside this
+database (see [TLS trust settings](api-reference.md#tls-trust-settings)), which
+is derived state a delete only costs a rewrite.
 
 **`dbSynchronous`** is the exception: SQLite's durability levels (`"0"` Off,
 `"1"` Normal, `"2"` Full) are its enumeration rather than ours, so that one

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -223,7 +223,12 @@ Three things worth knowing before you design around them:
   Both clients send them on *every* execute and load test rather than eliding
   the defaults, because the engine's `follow_redirects` defaults to **true** -
   an omitted `false` would silently follow the 3xx the user asked to see.
-  **`verifySSL` is still engine-only**; it was deliberately not exposed.
+  **`verifySSL` joined them** (#706, `requests.verify_ssl` → **Settings** tab),
+  under the same never-elided rule and for a stronger reason: the engine
+  verifies unless told otherwise, so a dropped `false` verifies the certificate
+  the user opted out for. The old "engine-only, deliberately not exposed" line
+  is gone with the deferral it recorded - the answer to a dangerous state is a
+  loud control, not an unreachable one.
 - **Every outbound transfer leaves through one `TransportPolicy`** (#705,
   `include/vayu/http/transport_policy.hpp`). It is resolved from the
   `proxyMode` / `proxyUrl` / `proxyBypass` settings at the point of use -
@@ -234,7 +239,14 @@ Three things worth knowing before you design around them:
   driver: the three had grown their own SSL blocks and only two ever grew a
   proxy block, so SSE silently ignored `CURLOPT_PROXY` for its whole life.
   Every mode writes `CURLOPT_PROXY` rather than skipping it, because handles
-  are reused. A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
+  are reused - and #706's `ca_bundle_path` writes `CURLOPT_CAINFO` the same
+  way, empty included. That bundle is materialized from the
+  `customCaCertificates` setting beside the database and **extends** the
+  platform's trust rather than replacing it: on an OpenSSL build CAINFO *is*
+  the whole store, so the file is the system anchors plus the user's, while
+  Schannel and Apple SecTrust keep their OS store. The per-backend claim is
+  tested on each CI platform (`TlsBackend.AcceptsACustomCaBundleOnThisPlatform`)
+  rather than reasoned about, because a wrong claim here is a security claim. A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
   the target's `ConnectionFailed` - and `curl_to_error` now takes the handle,
   because a 407 answered to a CONNECT is a plain `CURLE_RECV_ERROR` and only
   `CURLINFO_HTTP_CONNECTCODE` remembers a proxy said no.

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -120,6 +120,16 @@ class Database {
     // Initialize database (create tables, etc.)
     void init ();
 
+    /**
+     * @brief The database file this instance was opened on.
+     *
+     * The engine's data directory, effectively: files derived from settings
+     * are written beside it (the CA bundle `resolve_transport_policy`
+     * materializes, issue #706) so that a caller holding a `Database` needs no
+     * second path parameter threaded through it to find them.
+     */
+    const std::string& path () const;
+
     // Project Management
     void create_collection (const Collection& c);
     std::vector<Collection> get_collections ();

--- a/engine/include/vayu/http/transport_policy.hpp
+++ b/engine/include/vayu/http/transport_policy.hpp
@@ -16,8 +16,9 @@
  * single-request client, the load event loop and the SSE consumer - reads the
  * same struct, which is the whole point: building transport config per-driver
  * is how the SSE path came to have no proxy option at all while the other two
- * did. Phases 2 and 3 of #704 extend this struct with the TLS fields; nothing
- * about the plumbing changes when they do.
+ * did. Phase 2 (#706) added the CA bundle to it and touched no driver, which
+ * is the plumbing working as designed; phase 3's client certificates arrive
+ * the same way.
  */
 
 #include <array>
@@ -106,7 +107,47 @@ struct TransportPolicy {
      * that ships in libcurl is the one the user's other tools already obey.
      */
     std::string proxy_bypass;
+
+    /**
+     * The materialized CA bundle `CURLOPT_CAINFO` points at, empty when the
+     * user has added no certificate of their own (issue #706).
+     *
+     * A *path*, because that is the only shape libcurl takes - but what the
+     * user stores is the PEM *content* (`customCaCertificates`), and this file
+     * is derived from it beside the database. A stored path would break the
+     * moment the file moved and could not be shown back in Settings.
+     *
+     * On an OpenSSL-backed build `CURLOPT_CAINFO` *replaces* the default
+     * bundle, so the file this names is the system anchors and the user's PEMs
+     * concatenated - the additive rule of #704 is kept by construction rather
+     * than by hoping the backend merges for us. See `resolve_transport_policy`.
+     */
+    std::string ca_bundle_path;
 };
+
+/**
+ * @brief Why @p pem cannot be a CA bundle, or nullopt when it can.
+ *
+ * The one copy of the rule, shared by `POST /config` (which rejects a bad
+ * paste outright) and the resolver (which re-checks a row edited around the
+ * route). Deliberately shallow - it asks whether the text is PEM-shaped, not
+ * whether the certificates inside it are valid or unexpired, because a
+ * pasted-in-full chain that curl accepts must not be refused by a parser of
+ * ours, and the certificate that fails to verify says so at handshake time
+ * with libcurl's own error rather than a guess of ours at paste time.
+ */
+std::optional<std::string> ca_pem_rejection (std::string_view pem);
+
+/**
+ * @brief The trust anchors this platform verifies with today, as PEM text.
+ *
+ * Empty when they cannot be read as a file - which is the normal case on
+ * Windows (Schannel) and macOS (Apple SecTrust), where the anchors live in an
+ * OS store rather than a bundle. Exposed for the tests and for the per-platform
+ * disclosure in the docs; production code reaches it through
+ * `resolve_transport_policy`.
+ */
+std::string system_ca_bundle_pem ();
 
 /**
  * @brief Read the policy out of the config table.

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -922,6 +922,12 @@ struct Request {
     bool follow_redirects    = true;   // INTEGER NOT NULL DEFAULT 1
     int max_redirects        = 10;     // INTEGER NOT NULL DEFAULT 10
     std::string http_version = "auto"; // TEXT NOT NULL DEFAULT 'auto'
+    // Whether the TLS certificate is verified (issue #706). Stored beside the
+    // redirect policy for the same reason: it is a property of *this* endpoint
+    // - the internal host with the self-signed certificate - not a mode the
+    // whole app is put into. Defaults to verifying, here and in the column, so
+    // that no row can arrive at "trust anything" by omission.
+    bool verify_ssl = true; // INTEGER NOT NULL DEFAULT 1
     // Consume this request's response as a `text/event-stream` (issue #574).
     // Stored rather than chosen per send, because it changes what Send *is* for
     // this endpoint - the execution model, not one run's options - and a toggle

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -476,10 +476,13 @@ struct Database::Impl {
     /// size in force instead of the size requested.
     std::atomic<int> applied_cache_size_bytes{ 0 };
 
-    /// The file `storage` was opened on, for `Database::path`.
-    std::string db_path;
+    /// The file `storage` was opened on, for `Database::path`. Named for the
+    /// file rather than `db_path`, which the constructor below already uses for
+    /// the parsed `std::filesystem::path` - MSVC builds this /W4 /WX and a
+    /// shadowed member is C4458, an error here.
+    std::string opened_file;
 
-    Impl (const std::string& path) : storage (make_storage (path)), db_path (path) {
+    Impl (const std::string& path) : storage (make_storage (path)), opened_file (path) {
         std::filesystem::path db_path (path);
         if (db_path.has_parent_path ()) {
             std::filesystem::create_directories (db_path.parent_path ());
@@ -664,7 +667,7 @@ Database::Database (const std::string& db_path) {
 Database::~Database () = default;
 
 const std::string& Database::path () const {
-    return impl_->db_path;
+    return impl_->opened_file;
 }
 
 // Initialize database with optimized SQLite settings

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -240,6 +240,10 @@ inline auto make_storage (const std::string& path) {
     // pre-existing rows backfill to the engine defaults (follow, cap at 10).
     make_column ("follow_redirects", &Request::follow_redirects, default_value (true)),
     make_column ("max_redirects", &Request::max_redirects, default_value (10)),
+    // Per-request TLS verification (issue #706). Same NOT NULL + default_value
+    // shape, and the default is the safe one: a row written before this column
+    // existed backfills to verifying, never to trusting whatever answers.
+    make_column ("verify_ssl", &Request::verify_ssl, default_value (true)),
     // Protocol selection. TEXT (not an ordinal) so a stored value survives a
     // reorder of the HttpVersion enum. NOT NULL with a default_value so
     // sync_schema can ALTER TABLE ADD COLUMN onto an existing requests table.
@@ -472,7 +476,10 @@ struct Database::Impl {
     /// size in force instead of the size requested.
     std::atomic<int> applied_cache_size_bytes{ 0 };
 
-    Impl (const std::string& path) : storage (make_storage (path)) {
+    /// The file `storage` was opened on, for `Database::path`.
+    std::string db_path;
+
+    Impl (const std::string& path) : storage (make_storage (path)), db_path (path) {
         std::filesystem::path db_path (path);
         if (db_path.has_parent_path ()) {
             std::filesystem::create_directories (db_path.parent_path ());
@@ -655,6 +662,10 @@ Database::Database (const std::string& db_path) {
 }
 
 Database::~Database () = default;
+
+const std::string& Database::path () const {
+    return impl_->db_path;
+}
 
 // Initialize database with optimized SQLite settings
 void Database::init () {
@@ -2247,6 +2258,24 @@ void Database::seed_default_config () {
     "rule, so an empty one means nothing is exempt and any no_proxy the engine "
     "was started with is ignored. Under From environment it overrides that "
     "variable when set, and defers to it when empty.",
+    "network_performance", "", std::nullopt, std::nullopt, std::nullopt, now }));
+
+    // Custom trust anchors (issue #706). `text` rather than `string` because
+    // what goes in it is a pasted PEM block: the single-line input every other
+    // string entry renders cannot show one, let alone several.
+    //
+    // Content, not a path - a path breaks the moment the file moves and cannot
+    // be shown back in Settings. The engine materializes the bundle beside the
+    // database, extending the platform's own anchors rather than replacing
+    // them; see `resolve_transport_policy`.
+    upsert_config (keywords ({ "firewall", "mitm", "zscaler", "ssl" }) (
+    ConfigEntry{ "customCaCertificates", "", "text", "Custom CA Certificates",
+    "Certificate authorities to trust in addition to the ones this platform "
+    "already trusts, pasted as PEM text (one or more -----BEGIN "
+    "CERTIFICATE----- blocks). This is what makes a corporate TLS-inspecting "
+    "proxy or an internal self-signed authority verifiable everywhere the "
+    "engine sends: requests, load runs, streams, OAuth token fetches and spec "
+    "imports alike. Paste certificates only - never a private key.",
     "network_performance", "", std::nullopt, std::nullopt, std::nullopt, now }));
 
     // =========================================================================

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <charconv>
 #include <chrono>
+#include <mutex>
 #include <optional>
 #include <string_view>
 #include <system_error>
@@ -519,6 +520,42 @@ Error curl_to_error (CURL* curl, CURLcode code, const char* error_buffer) {
 void apply_transport_policy (CURL* curl, const TransportPolicy& policy, bool verify_ssl) {
     curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, verify_ssl ? 1L : 0L);
     curl_easy_setopt (curl, CURLOPT_SSL_VERIFYHOST, verify_ssl ? 2L : 0L);
+
+    // The user's trust anchors (issue #706). Written on every handle, empty
+    // path included, for the reason the proxy options are: handles are reused,
+    // so a bundle left behind by a previous policy would outlive the setting
+    // that asked for it. Null restores the backend's own default.
+    //
+    // The return code is checked because this is the one transport option a
+    // TLS backend can refuse outright - `CURLE_NOT_BUILT_IN` from a backend
+    // with no CAINFO support - and a silently ignored bundle means every
+    // request fails verification with nothing anywhere saying the certificates
+    // were never loaded. Logged once per process: the load path applies a
+    // policy per transfer, and a per-request line would be the log.
+    const CURLcode ca_result = curl_easy_setopt (curl, CURLOPT_CAINFO,
+    policy.ca_bundle_path.empty () ? static_cast<const char*> (nullptr) :
+                                     policy.ca_bundle_path.c_str ());
+    if (ca_result != CURLE_OK && !policy.ca_bundle_path.empty ()) {
+        static std::once_flag warned;
+        std::call_once (warned, [ca_result] {
+            const curl_version_info_data* info = curl_version_info (CURLVERSION_NOW);
+            vayu::utils::log_error ("This build's TLS backend (" +
+            std::string (info != nullptr && info->ssl_version != nullptr ? info->ssl_version : "unknown") +
+            ") refused a custom CA bundle: " + std::string (curl_easy_strerror (ca_result)) +
+            ". Custom CA certificates are not in use on this platform.");
+        });
+    }
+
+    // With a bundle in force, ask the backend to keep consulting the operating
+    // system's own store as well. On an OpenSSL build CAINFO *replaces* the
+    // default bundle, which is why the materialized file already carries the
+    // system anchors; this is the same guarantee said the other way for the
+    // backends that can honour it, and a no-op where they cannot. Written in
+    // both directions - the default `0` when no bundle is set - because a
+    // reused handle would otherwise keep a flag the current policy never asked
+    // for, the rule every option here follows.
+    curl_easy_setopt (curl, CURLOPT_SSL_OPTIONS,
+    policy.ca_bundle_path.empty () ? 0L : static_cast<long> (CURLSSLOPT_NATIVE_CA));
 
     switch (policy.proxy_mode) {
     case ProxyMode::Environment:

--- a/engine/src/http/request_composer.cpp
+++ b/engine/src/http/request_composer.cpp
@@ -560,6 +560,11 @@ const std::vector<vayu::db::Collection>& chain) {
     payload["followRedirects"] = request.follow_redirects;
     payload["maxRedirects"]    = request.max_redirects;
     payload["httpVersion"]     = request.http_version;
+    // Same rule, and the one field where eliding the default would be a
+    // security bug rather than a surprise: `verify_ssl` defaults to *true*
+    // engine-side, so an omitted `false` would verify the certificate the user
+    // explicitly asked the engine not to check (issue #706).
+    payload["verifySSL"]       = request.verify_ssl;
     payload["requestId"]       = request.id;
 
     // Identity for the script sandbox (`pm.info.requestName`), not an HTTP

--- a/engine/src/http/routes/config.cpp
+++ b/engine/src/http/routes/config.cpp
@@ -236,6 +236,18 @@ const std::string& body) {
             }
         }
 
+        // Per-key rule, the way the proxy URL's lives in `proxy_url_rejection`:
+        // the type system says "text" and only this key knows that the text has
+        // to be PEM. Rejected at the boundary rather than at handshake time,
+        // because a pasted key or a truncated block would otherwise be stored,
+        // materialized, and reported as an unrelated verification failure on
+        // every request afterwards (issue #706).
+        if (reason.empty () && key == "customCaCertificates" && !value.empty ()) {
+            if (const auto rejection = vayu::http::ca_pem_rejection (value)) {
+                reason = "'customCaCertificates' is not a usable PEM bundle: " + *rejection;
+            }
+        }
+
         if (!reason.empty ()) {
             errors.push_back (reason);
             continue;

--- a/engine/src/http/routes/requests.cpp
+++ b/engine/src/http/routes/requests.cpp
@@ -229,6 +229,11 @@ bool is_create) {
     apply_int_field (json, "order", r.order, 0, is_create);
     apply_bool_field (json, "followRedirects", r.follow_redirects, true, is_create);
 
+    // TLS verification (issue #706). Through the shared applier like every
+    // other stored field, so `POST /requests`, `PUT /requests/:id` and
+    // `POST /import/apply` all carry it without three copies of the rule.
+    apply_bool_field (json, "verifySSL", r.verify_ssl, true, is_create);
+
     apply_int_field (json, "maxRedirects", r.max_redirects, 10, is_create);
     // Clamp to the range the UI offers; libcurl reads -1 as "unlimited", which
     // is not a policy we want a stray value to select.

--- a/engine/src/http/transport_policy.cpp
+++ b/engine/src/http/transport_policy.cpp
@@ -15,6 +15,14 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <system_error>
+
+#include <curl/curl.h>
 
 #include "vayu/db/database.hpp"
 #include "vayu/utils/logger.hpp"
@@ -32,6 +40,164 @@ constexpr std::array<std::string_view, 7> PROXY_SCHEMES = { "http", "https",
 bool is_blank (std::string_view value) {
     return std::all_of (value.begin (), value.end (),
     [] (unsigned char c) { return std::isspace (c) != 0; });
+}
+
+/// The PEM markers a certificate is wrapped in. Only the certificate label is
+/// accepted: a pasted *private key* is the one mistake worth naming, because
+/// the file it would land in is world-readable and the user would never see it
+/// again.
+constexpr std::string_view CERT_BEGIN     = "-----BEGIN CERTIFICATE-----";
+constexpr std::string_view CERT_END       = "-----END CERTIFICATE-----";
+constexpr std::string_view KEY_MARKER     = "-----BEGIN PRIVATE KEY-----";
+constexpr std::string_view RSA_KEY_MARKER = "-----BEGIN RSA PRIVATE KEY-----";
+
+/// Where a Linux/BSD build keeps its trust store when libcurl was built
+/// without a compiled-in bundle path (`CURL_CA_FALLBACK`, which is how the
+/// pinned vcpkg port is built). Probed in the order curl's own fallback probes
+/// them, so the file we read is the file it would have read.
+constexpr std::array<std::string_view, 6> SYSTEM_CA_BUNDLES = {
+    "/etc/ssl/certs/ca-certificates.crt", // Debian, Ubuntu, Alpine
+    "/etc/pki/tls/certs/ca-bundle.crt",   // Fedora, RHEL
+    "/etc/ssl/ca-bundle.pem",             // openSUSE
+    "/etc/pki/tls/cacert.pem",            // legacy RHEL
+    "/etc/ssl/cert.pem",                  // FreeBSD, some macOS installs
+    "/usr/local/share/certs/ca-root-nss.crt"
+};
+
+std::string read_file (const std::filesystem::path& path) {
+    std::ifstream in (path, std::ios::binary);
+    if (!in) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf ();
+    return buffer.str ();
+}
+
+/// The file libcurl itself would verify against, or an empty path when this
+/// build has none. Environment first, because a user who exports
+/// `CURL_CA_BUNDLE` has already told every curl on the machine where their
+/// anchors are and ours must not be the one tool that ignores it.
+std::filesystem::path system_ca_bundle_path () {
+    for (const char* variable : { "CURL_CA_BUNDLE", "SSL_CERT_FILE" }) {
+        if (const char* value = std::getenv (variable);
+            value != nullptr && value[0] != '\0') {
+            std::error_code ec;
+            if (std::filesystem::is_regular_file (value, ec)) {
+                return { value };
+            }
+        }
+    }
+
+    const curl_version_info_data* info = curl_version_info (CURLVERSION_NOW);
+    if (info != nullptr && info->age >= CURLVERSION_SEVENTH &&
+    info->cainfo != nullptr && info->cainfo[0] != '\0') {
+        std::error_code ec;
+        if (std::filesystem::is_regular_file (info->cainfo, ec)) {
+            return { info->cainfo };
+        }
+    }
+
+    for (const auto& candidate : SYSTEM_CA_BUNDLES) {
+        std::error_code ec;
+        if (std::filesystem::is_regular_file (candidate, ec)) {
+            return { candidate };
+        }
+    }
+    return {};
+}
+
+/**
+ * Write @p content to @p path, through a temporary beside it.
+ *
+ * Renamed into place rather than truncated and rewritten, because the resolver
+ * runs on the request path: a transfer that read the file halfway through a
+ * rewrite would verify against a truncated bundle, and "some of your CAs" is
+ * the failure shape this whole feature exists to remove.
+ */
+bool write_atomically (const std::filesystem::path& path, const std::string& content) {
+    std::filesystem::path temp = path;
+    temp += ".tmp";
+
+    {
+        std::ofstream out (temp, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            return false;
+        }
+        out << content;
+        if (!out) {
+            return false;
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename (temp, path, ec);
+    if (ec) {
+        std::filesystem::remove (temp, ec);
+        return false;
+    }
+    return true;
+}
+
+/**
+ * The bundle path for @p pem, materialized beside the database.
+ *
+ * Cached on the content that produced it: `resolve_transport_policy` runs per
+ * transfer (deliberately - a settings change must reach the next request), and
+ * rewriting a file on every send is a cost the feature has no reason to carry.
+ * The existence check is part of the key, so a bundle deleted underneath the
+ * engine comes back rather than being trusted because we once wrote it.
+ */
+std::string materialize_ca_bundle (const std::string& pem,
+const std::filesystem::path& directory) {
+    static std::mutex cache_mutex;
+    static std::string cached_pem;
+    static std::string cached_path;
+
+    // A database opened by a bare filename ("vayu.db", which the tests and the
+    // CLI both do) has no parent path; the bundle belongs beside it either way.
+    const std::filesystem::path dir =
+    directory.empty () ? std::filesystem::path (".") : directory;
+    const std::filesystem::path bundle = dir / "ca-bundle.pem";
+
+    std::lock_guard<std::mutex> lock (cache_mutex);
+    std::error_code ec;
+    if (cached_pem == pem && cached_path == bundle.string () &&
+    std::filesystem::is_regular_file (bundle, ec)) {
+        return cached_path;
+    }
+
+    // The user's anchors *extend* the platform's rather than replacing them
+    // (decision 4 of #704). On an OpenSSL-backed build `CURLOPT_CAINFO` is the
+    // whole trust store, so the merge has to happen here; where the platform
+    // verifies through an OS store instead (Schannel, Apple SecTrust) there is
+    // no file to read and the bundle holds the user's certificates alone,
+    // with the OS store still consulted by the backend itself.
+    std::string content;
+    const std::filesystem::path system_bundle = system_ca_bundle_path ();
+    if (!system_bundle.empty ()) {
+        content = read_file (system_bundle);
+        if (!content.empty () && content.back () != '\n') {
+            content += '\n';
+        }
+    }
+    content += pem;
+    if (!content.empty () && content.back () != '\n') {
+        content += '\n';
+    }
+
+    std::filesystem::create_directories (dir, ec);
+    if (!write_atomically (bundle, content)) {
+        vayu::utils::log_error ("Could not write the CA bundle to " + bundle.string () +
+        "; the certificates in 'customCaCertificates' are not in use");
+        cached_pem.clear ();
+        cached_path.clear ();
+        return {};
+    }
+
+    cached_pem  = pem;
+    cached_path = bundle.string ();
+    return cached_path;
 }
 
 } // namespace
@@ -115,8 +281,56 @@ std::optional<std::string> proxy_url_rejection (std::string_view url) {
     return std::nullopt;
 }
 
+std::optional<std::string> ca_pem_rejection (std::string_view pem) {
+    if (pem.empty () || is_blank (pem)) {
+        return std::string ("no certificate found");
+    }
+    if (pem.find (KEY_MARKER) != std::string_view::npos ||
+    pem.find (RSA_KEY_MARKER) != std::string_view::npos) {
+        return std::string (
+        "this is a private key, not a certificate - paste only the "
+        "certificate blocks (a key belongs in the client-certificate "
+        "registry, not the trust store)");
+    }
+
+    const auto begin = pem.find (CERT_BEGIN);
+    if (begin == std::string_view::npos) {
+        return "no '" + std::string (CERT_BEGIN) + "' block found";
+    }
+    if (pem.find (CERT_END, begin + CERT_BEGIN.size ()) == std::string_view::npos) {
+        return "a certificate block is not closed by '" + std::string (CERT_END) + "'";
+    }
+    return std::nullopt;
+}
+
+std::string system_ca_bundle_pem () {
+    const std::filesystem::path path = system_ca_bundle_path ();
+    if (path.empty ()) {
+        return {};
+    }
+    return read_file (path);
+}
+
 TransportPolicy resolve_transport_policy (vayu::db::Database& db) {
     TransportPolicy policy;
+
+    // TLS trust first: it is independent of the proxy, and the manual-mode
+    // early return below would otherwise skip it for every direct sender.
+    const std::string ca_pem = db.get_config_string ("customCaCertificates", "");
+    if (!ca_pem.empty () && !is_blank (ca_pem)) {
+        if (const auto rejection = ca_pem_rejection (ca_pem)) {
+            // `POST /config` refuses this shape, so only a hand-edited row
+            // reaches it. Named rather than swallowed: a bundle silently
+            // dropped would leave every request failing verification with no
+            // line anywhere saying the certificates were never loaded.
+            vayu::utils::log_error (
+            "Config 'customCaCertificates' is unusable (" + *rejection +
+            "); no custom CA certificates are in use");
+        } else {
+            policy.ca_bundle_path = materialize_ca_bundle (
+            ca_pem, std::filesystem::path (db.path ()).parent_path ());
+        }
+    }
 
     const std::string mode_value =
     db.get_config_string ("proxyMode", to_string (policy.proxy_mode));

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -472,6 +472,7 @@ Json serialize (const vayu::db::Request& r) {
     json["followRedirects"]   = r.follow_redirects;
     json["maxRedirects"]      = r.max_redirects;
     json["httpVersion"]       = r.http_version;
+    json["verifySSL"]         = r.verify_ssl;
     json["stream"]            = r.stream;
     // Operation identity (issue #637). Always present as a key, `null` when the
     // request declares none - the column is nullable, and a client that has to
@@ -1110,6 +1111,7 @@ void serialize_to_stream (const vayu::db::Request& r, std::ostream& out) {
     out << "\"followRedirects\":" << (r.follow_redirects ? "true" : "false") << ",";
     out << "\"maxRedirects\":" << r.max_redirects << ",";
     out << "\"httpVersion\":" << Json (r.http_version).dump () << ",";
+    out << "\"verifySSL\":" << (r.verify_ssl ? "true" : "false") << ",";
     out << "\"stream\":" << (r.stream ? "true" : "false") << ",";
     // Through the same `spec_operation_node` the object serializer uses, so the
     // list route and the single route cannot come to disagree about it.

--- a/engine/tests/config_route_test.cpp
+++ b/engine/tests/config_route_test.cpp
@@ -807,4 +807,55 @@ TEST_F (ConfigRouteTest, UnknownProxyModeIs400) {
     EXPECT_EQ (status, 400) << body.dump ();
 }
 
+// ---------------------------------------------------------------------------
+// Custom CA certificates (issue #706) - the paste is checked at the boundary,
+// because what a bad one produces is a bundle curl is pointed at that holds no
+// anchor: every HTTPS request fails verification afterwards while Settings
+// shows a trust store that looks configured.
+// ---------------------------------------------------------------------------
+
+TEST_F (ConfigRouteTest, PastedCertificatesAreStored) {
+    const nlohmann::json body = { { "entries",
+    { { "customCaCertificates", "-----BEGIN CERTIFICATE-----\nMIIBkTCB+w==\n-----END CERTIFICATE-----\n" } } } };
+    auto [status, response] =
+    vayu::http::routes::apply_config_update (*db_, body.dump ());
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_NE (db_->get_config_string ("customCaCertificates", "").find ("BEGIN CERTIFICATE"),
+    std::string::npos);
+}
+
+TEST_F (ConfigRouteTest, TextThatHoldsNoCertificateIs400) {
+    const nlohmann::json body = { { "entries",
+    { { "customCaCertificates", "paste your certificate here" } } } };
+    auto [status, response] =
+    vayu::http::routes::apply_config_update (*db_, body.dump ());
+    EXPECT_EQ (status, 400) << response.dump ();
+    EXPECT_TRUE (db_->get_config_string ("customCaCertificates", "").empty ())
+    << "a rejected update must not leave the value behind";
+}
+
+TEST_F (ConfigRouteTest, APastedPrivateKeyIs400AndSaysSo) {
+    const nlohmann::json body = { { "entries",
+    { { "customCaCertificates",
+    "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n" } } } };
+    auto [status, response] =
+    vayu::http::routes::apply_config_update (*db_, body.dump ());
+    ASSERT_EQ (status, 400) << response.dump ();
+    EXPECT_NE (response.dump ().find ("private key"), std::string::npos)
+    << response.dump ();
+}
+
+TEST_F (ConfigRouteTest, ClearingTheCertificatesIsAllowed) {
+    // Empty is how the setting is turned off, so the PEM rule must not make it
+    // impossible to undo a paste.
+    const nlohmann::json set = { { "entries",
+    { { "customCaCertificates", "-----BEGIN CERTIFICATE-----\nMIIBkTCB+w==\n-----END CERTIFICATE-----\n" } } } };
+    ASSERT_EQ (vayu::http::routes::apply_config_update (*db_, set.dump ()).first, 200);
+
+    auto [status, response] = vayu::http::routes::apply_config_update (
+    *db_, R"({"entries":{"customCaCertificates":""}})");
+    EXPECT_EQ (status, 200) << response.dump ();
+    EXPECT_TRUE (db_->get_config_string ("customCaCertificates", "x").empty ());
+}
+
 } // namespace

--- a/engine/tests/request_composer_test.cpp
+++ b/engine/tests/request_composer_test.cpp
@@ -256,6 +256,7 @@ TEST_F (RequestComposerTest, ComposesASavedRequestById) {
     r.follow_redirects    = false;
     r.max_redirects       = 3;
     r.http_version        = "http2";
+    r.verify_ssl          = false;
     db_->save_request (r);
 
     auto [status, payload] = vayu::http::compose_request_core (
@@ -292,6 +293,12 @@ TEST_F (RequestComposerTest, ComposesASavedRequestById) {
     EXPECT_EQ (payload["followRedirects"], false);
     EXPECT_EQ (payload["maxRedirects"], 3);
     EXPECT_EQ (payload["httpVersion"], "http2");
+    // Never elided at the default, and this one for a stronger reason than the
+    // rest: the engine verifies unless told otherwise, so a dropped `false`
+    // would verify the certificate the user turned verification off for
+    // (issue #706).
+    ASSERT_TRUE (payload.contains ("verifySSL"));
+    EXPECT_EQ (payload["verifySSL"], false);
 
     // Ids echoed so the composed payload can be POSTed to /execute unchanged.
     EXPECT_EQ (payload["requestId"], "req_1");

--- a/engine/tests/resource_write_route_test.cpp
+++ b/engine/tests/resource_write_route_test.cpp
@@ -72,6 +72,9 @@ create_environment_response (vayu::db::Database& db, const nlohmann::json& json)
 std::pair<int, nlohmann::json> update_environment_response (vayu::db::Database& db,
 const std::string& id,
 const nlohmann::json& json);
+// Defined in requests.cpp - the list serializer, which is separate code from
+// the single-request one and has been the half a new field missed before.
+std::string list_requests_body (vayu::db::Database& db, const std::string& collection_id);
 // Defined in config.cpp - used here only to flip the "defaultHttpVersion"
 // global mid-test, proving the httpVersion seed is read live rather than
 // baked in at process start.
@@ -661,6 +664,78 @@ TEST_F (ResourceWriteRouteTest, RequestMaxRedirectsIsClamped) {
     update_request_response (*db_, id, json{ { "maxRedirects", 5000 } });
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["maxRedirects"], 100);
+}
+
+// ---------------------------------------------------------------------------
+// Requests - verifySSL (issue #706). Stored like the redirect policy and
+// defaulted like it: absent means verifying on create, `null` resets to
+// verifying on update. The direction is what these pin - a field that read as
+// "accept any certificate" whenever a client left it out would turn every
+// pre-existing request insecure on the first save.
+// ---------------------------------------------------------------------------
+
+TEST_F (ResourceWriteRouteTest, RequestCreateAbsentVerifySSLVerifies) {
+    const std::string collection = make_collection ();
+    auto [status, body]          = create_request_response (*db_,
+             json{ { "collectionId", collection }, { "name", "R" }, { "method", "GET" },
+             { "url", "https://example.com" } });
+    ASSERT_EQ (status, 200);
+    ASSERT_TRUE (body.contains ("verifySSL"));
+    EXPECT_EQ (body["verifySSL"], true);
+    EXPECT_TRUE (db_->get_request (body["id"].get<std::string> ())->verify_ssl);
+}
+
+TEST_F (ResourceWriteRouteTest, RequestCreateStoresVerifySSLFalse) {
+    const std::string collection = make_collection ();
+    auto [status, body]          = create_request_response (*db_,
+             json{ { "collectionId", collection }, { "name", "R" }, { "method", "GET" },
+             { "url", "https://example.com" }, { "verifySSL", false } });
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (body["verifySSL"], false);
+    EXPECT_FALSE (db_->get_request (body["id"].get<std::string> ())->verify_ssl);
+}
+
+TEST_F (ResourceWriteRouteTest, RequestUpdateKeepsVerifySSLWhenAbsent) {
+    const std::string collection = make_collection ();
+    const std::string id         = make_request (collection);
+    ASSERT_EQ (
+    update_request_response (*db_, id, json{ { "verifySSL", false } }).first, 200);
+
+    auto [status, body] =
+    update_request_response (*db_, id, json{ { "name", "Renamed" } });
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (body["verifySSL"], false)
+    << "an untouched field must survive a patch";
+}
+
+TEST_F (ResourceWriteRouteTest, RequestUpdateNullVerifySSLResetsToVerifying) {
+    const std::string collection = make_collection ();
+    const std::string id         = make_request (collection);
+    ASSERT_EQ (
+    update_request_response (*db_, id, json{ { "verifySSL", false } }).first, 200);
+
+    auto [status, body] =
+    update_request_response (*db_, id, json{ { "verifySSL", nullptr } });
+    ASSERT_EQ (status, 200);
+    EXPECT_EQ (body["verifySSL"], true);
+}
+
+TEST_F (ResourceWriteRouteTest, VerifySSLReadsBackThroughBothSerializers) {
+    // The two-serializer rule: `serialize` answers the single-request route and
+    // `serialize_to_stream` the list, and this repo has shipped a field on one
+    // and not the other before.
+    const std::string collection = make_collection ();
+    auto [status, created]       = create_request_response (*db_,
+          json{ { "collectionId", collection }, { "name", "R" }, { "method", "GET" },
+          { "url", "https://internal.example.com" }, { "verifySSL", false } });
+    ASSERT_EQ (status, 200);
+
+    const json listed =
+    json::parse (vayu::http::routes::list_requests_body (*db_, collection));
+    ASSERT_EQ (listed.size (), 1u);
+    ASSERT_TRUE (listed[0].contains ("verifySSL"))
+    << "the list serializer dropped the field the single-request one carries";
+    EXPECT_EQ (listed[0]["verifySSL"], created["verifySSL"]);
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -12,14 +12,18 @@
  * end.
  */
 
+#include <curl/curl.h>
 #include <gtest/gtest.h>
 #include <httplib.h>
 
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <utility>
@@ -178,6 +182,15 @@ Request get_request (const std::string& url) {
     return request;
 }
 
+/// The whole of @p path as a string - the bundle assertions read the file the
+/// resolver wrote rather than the value it returned.
+std::string read_whole_file (const std::string& path) {
+    std::ifstream in (path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << in.rdbuf ();
+    return buffer.str ();
+}
+
 TransportPolicy manual_through (const MockProxy& proxy) {
     TransportPolicy policy;
     policy.proxy_mode = ProxyMode::Manual;
@@ -299,6 +312,138 @@ TEST (ProxyUrlValidation, RejectsTheShapesThatAreAlwaysMistakes) {
     EXPECT_TRUE (proxy_url_rejection ("ftp://proxy.example:8080").has_value ());
     EXPECT_TRUE (proxy_url_rejection ("http://:8080").has_value ());
     EXPECT_TRUE (proxy_url_rejection ("http://").has_value ());
+}
+
+// ---------------------------------------------------------------------------
+// TLS trust - the pasted bundle, and what this platform's backend does with it
+// (issue #706)
+// ---------------------------------------------------------------------------
+
+/// A syntactically complete certificate block. Never parsed as a certificate by
+/// anything under test - the validation here is deliberately about PEM shape,
+/// so a body that is only base64-shaped is exactly the right fixture.
+constexpr const char* SAMPLE_CERT =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBkTCB+wIJAJ2Vayu0TESTMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnZh\n"
+"eXUtY2EwHhcNMjYwMTAxMDAwMDAwWhcNMzYwMTAxMDAwMDAwWjARMQ8wDQYDVQQD\n"
+"-----END CERTIFICATE-----\n";
+
+TEST (CaPemValidation, AcceptsACertificateBlock) {
+    EXPECT_FALSE (ca_pem_rejection (SAMPLE_CERT).has_value ());
+    // Two anchors in one paste is the normal corporate shape (root plus the
+    // issuing intermediate).
+    EXPECT_FALSE (ca_pem_rejection (std::string (SAMPLE_CERT) + SAMPLE_CERT).has_value ());
+}
+
+TEST (CaPemValidation, RejectsWhatIsNotAPemBundle) {
+    EXPECT_TRUE (ca_pem_rejection ("").has_value ());
+    EXPECT_TRUE (ca_pem_rejection ("   \n\t ").has_value ());
+    EXPECT_TRUE (ca_pem_rejection ("not a certificate").has_value ());
+    // Truncated at the paste: the half-copied block, which curl would refuse at
+    // handshake time with an error naming nothing the user recognises.
+    EXPECT_TRUE (
+    ca_pem_rejection ("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJ\n").has_value ());
+}
+
+TEST (CaPemValidation, NamesAPastedPrivateKeyForWhatItIs) {
+    // The mistake worth its own message: the file this would land in is not a
+    // secret store, and "no certificate found" would send the user looking for
+    // a formatting problem instead of telling them what they pasted.
+    const auto rejection = ca_pem_rejection (
+    "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n");
+    ASSERT_TRUE (rejection.has_value ());
+    EXPECT_NE (rejection->find ("private key"), std::string::npos) << *rejection;
+}
+
+TEST_F (TransportPolicyDbTest, NoPastedCertificatesMeansNoBundle) {
+    const auto policy = resolve_transport_policy (*db_);
+    EXPECT_TRUE (policy.ca_bundle_path.empty ())
+    << "with nothing pasted the backend's own trust store must be left alone";
+}
+
+TEST_F (TransportPolicyDbTest, PastedCertificatesAreMaterializedBesideTheDatabase) {
+    set_config ("customCaCertificates", SAMPLE_CERT);
+
+    const auto policy = resolve_transport_policy (*db_);
+    ASSERT_FALSE (policy.ca_bundle_path.empty ());
+    ASSERT_TRUE (std::filesystem::exists (policy.ca_bundle_path));
+    // Beside the database, whatever shape its path has: this fixture opens one
+    // by bare filename (parent path ""), which is the working directory - the
+    // same case a CLI invocation produces.
+    const std::filesystem::path db_dir =
+    std::filesystem::path (db_->path ()).parent_path ();
+    EXPECT_EQ (std::filesystem::absolute (
+               std::filesystem::path (policy.ca_bundle_path).parent_path ()),
+    std::filesystem::absolute (db_dir.empty () ? std::filesystem::path (".") : db_dir));
+
+    const std::string bundle = read_whole_file (policy.ca_bundle_path);
+    EXPECT_NE (bundle.find (SAMPLE_CERT), std::string::npos)
+    << "the pasted certificate is not in the bundle curl is pointed at";
+
+    // The additive rule of #704, asserted where it is actually enforceable:
+    // wherever this platform exposes its anchors as a file (every
+    // OpenSSL-backed build, which is where CAINFO *replaces* the default),
+    // the merged bundle has to still contain them - otherwise adding one
+    // corporate CA would quietly untrust the public web.
+    const std::string system_anchors = system_ca_bundle_pem ();
+    if (!system_anchors.empty ()) {
+        EXPECT_NE (bundle.find (system_anchors), std::string::npos)
+        << "the platform's own anchors were replaced rather than extended";
+        EXPECT_GT (bundle.size (), system_anchors.size ());
+    }
+    std::filesystem::remove (policy.ca_bundle_path);
+}
+
+TEST_F (TransportPolicyDbTest, AChangedPasteReachesTheNextTransfer) {
+    // The bundle is cached on the content that produced it, because the policy
+    // is resolved per transfer. A cache that ignored a settings change would
+    // keep verifying against the old anchors until the engine restarted.
+    set_config ("customCaCertificates", SAMPLE_CERT);
+    const auto first = resolve_transport_policy (*db_);
+    ASSERT_FALSE (first.ca_bundle_path.empty ());
+
+    const std::string second_cert = std::string (SAMPLE_CERT) +
+    "-----BEGIN CERTIFICATE-----\nQkJCQkJC\n-----END CERTIFICATE-----\n";
+    set_config ("customCaCertificates", second_cert);
+    const auto second = resolve_transport_policy (*db_);
+    ASSERT_FALSE (second.ca_bundle_path.empty ());
+
+    const std::string bundle = read_whole_file (second.ca_bundle_path);
+    EXPECT_NE (bundle.find ("QkJCQkJC"), std::string::npos)
+    << "the second paste never reached the file";
+    std::filesystem::remove (second.ca_bundle_path);
+}
+
+TEST_F (TransportPolicyDbTest, AnUnusablePasteIsNotMaterialized) {
+    // Only reachable from a hand-edited row - POST /config refuses this shape.
+    // What must not happen is a file curl is pointed at that holds no
+    // certificate: every HTTPS request would then fail verification, with the
+    // trust store looking configured.
+    set_config ("customCaCertificates", "-----BEGIN PRIVATE KEY-----\nMIIB\n");
+
+    const auto policy = resolve_transport_policy (*db_);
+    EXPECT_TRUE (policy.ca_bundle_path.empty ());
+}
+
+TEST (TlsBackend, AcceptsACustomCaBundleOnThisPlatform) {
+    // The per-platform claim, checked on the platform rather than reasoned
+    // about: `CURLOPT_CAINFO` is the one transport option a TLS backend can
+    // refuse outright (`CURLE_NOT_BUILT_IN`), and the three CI legs build
+    // against three different backends - OpenSSL on Linux, Apple SecTrust on
+    // macOS, Schannel on Windows. A refusal here means the docs' additive-trust
+    // claim is false for this build, which is a security claim, so it fails the
+    // suite rather than being discovered by a user whose requests all stop
+    // verifying.
+    CURL* curl = curl_easy_init ();
+    ASSERT_NE (curl, nullptr);
+    const CURLcode result =
+    curl_easy_setopt (curl, CURLOPT_CAINFO, "/nonexistent/ca-bundle.pem");
+    const curl_version_info_data* info = curl_version_info (CURLVERSION_NOW);
+    EXPECT_EQ (result, CURLE_OK)
+    << "TLS backend '"
+    << (info != nullptr && info->ssl_version != nullptr ? info->ssl_version : "unknown")
+    << "' refuses CURLOPT_CAINFO: " << curl_easy_strerror (result);
+    curl_easy_cleanup (curl);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Phase 2 of #704, on #705's shared applier. Two halves of one trust story, plus the retro-filing of the untracked `964c220a` deferral.

**Plan (root cause, approach, rejected alternative).** The root cause is one absence and one dead end: there has never been a hook for a user-supplied CA (`CURLOPT_CAINFO`/`CAPATH` appear nowhere, so a corporate MITM or an internal self-signed host leaves every HTTPS request failing with no in-app recourse), and `verify_ssl` has been a wire-only knob with no column, no serializer, no compose emission and no writer. The approach follows the phase-1 substrate rather than adding to it: the CA bundle becomes a field on `TransportPolicy`, resolved from settings at the point of use and applied by the single `detail::apply_transport_policy`, so all three drivers and all five `Client` sites inherit it without individual wiring; `verify_ssl` takes the exact hop set `followRedirects` already has, on both sides. The alternative I rejected was storing a *path* to a CA file instead of the certificate content - it is less code and one fewer materialization step, but the path breaks the moment the file moves, cannot be shown back in Settings, and would put a per-machine absolute path in a settings row; storing content and deriving the bundle beside the database keeps the setting portable and the file disposable. I also rejected setting `CURLOPT_CAINFO` and hoping each backend merges: on OpenSSL it *replaces* the default store, so adding one corporate CA would quietly untrust the public web. The materialized bundle is the system anchors concatenated with the user's, which makes the additive rule true by construction on the platform where it could go wrong.

### Custom CAs

- `customCaCertificates` (a new `text` config entry in `network_performance`) holds pasted PEM. `resolve_transport_policy` validates it, merges the platform's own anchors where they are readable as a file, and writes `ca-bundle.pem` beside the database - atomically, and only when the content changed, since the policy is resolved per transfer.
- `POST /config` refuses text that holds no certificate block and names a pasted **private key** for what it is, rather than storing it and letting every later request fail verification for an unrelated-looking reason.
- The applier writes `CURLOPT_CAINFO` on every handle (empty included, the reused-handle rule the proxy options already follow), **checks the return code** - it is the one transport option a backend can refuse outright - and logs the backend by name if it ever does. With a bundle in force it also sets `CURLSSLOPT_NATIVE_CA`.
- Per-platform behaviour is documented as a table and backed by `TlsBackend.AcceptsACustomCaBundleOnThisPlatform`, which runs on all three CI legs.

### verifySSL end to end

Column on `requests` → both stored-request serializers → `apply_request_fields` (so `POST`/`PUT`/`POST /import/apply` all carry it) → `POST /compose` → the renderer's four payload hops (pinned by `request-settings-plumbing.test.ts`) → a toggle in the request builder's **Settings** tab, plus the design-run replay path (seed, resend, save-run-to-request). Never elided at the default: the engine verifies unless told otherwise, so a dropped `false` verifies the certificate the user opted out for. Off is loud - a warning line in `--status-warning-text` under the row, and the tab badges.

`curl -k` / `--insecure` moved out of the no-argument skip set into a mapped flag, and the curl generator emits `-k` back; `parseCurl`/codegen round-trip it through the real parser.

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing

All local, on this branch:

- **Engine**: `python build.py -e -t` then `ctest --preset linux-dev` - **1987 passed, 0 failed** (1983 before this branch; the new C++ tests are 14 across `transport_policy_test.cpp`, `config_route_test.cpp`, `resource_write_route_test.cpp` and `request_composer_test.cpp`).
- **App**: `pnpm test` - **5221 passed, 0 failed** across 499 files; `pnpm type-check`, `pnpm lint` and `pnpm prettier --check` on the touched files are clean.
- **Docs**: `mkdocs build --strict -f .github/mkdocs.yml` builds clean.
- **Mutation-checked**, both directions: deleting `apply_bool_field(..., "verifySSL", ...)` reddens two CRUD tests; swapping the warning line's token to `text-muted-foreground` reddens the Settings-tab warning test. Restored and re-run green.

New behavioural coverage: PEM validation (including the pasted-key message), the bundle materialized beside the database and containing the system anchors *plus* the paste, a changed paste reaching the next transfer, an unusable row never materializing, `POST /config` accept/reject/clear, the CAINFO-acceptance check per platform, verifySSL through both serializers and the create/update null-vs-absent matrix, compose emitting a stored `false`, the `-k` round trip, and the transformer defaulting a pre-column row to *verifying*.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

`docs/engine/api-reference.md` (the new **TLS trust settings** section with the per-backend table, the `verifySSL` payload note, the request CRUD fields), `docs/engine/db-schema.md` (the `verify_ssl` column and the `text` entry), `docs/app/api-integration.md` (the renderer sends it), `docs/architecture.md` (trust beside the proxy) and `engine/CLAUDE.md` - where the stale "`verifySSL` is still engine-only" line is replaced rather than left to mislead.

## Deliberate deviations from the issue spec

1. **The custom-CA test is mechanism-level, not a TLS handshake.** The issue asks for a test where "a host signed by a user-added CA verifies once the setting is set and fails before". There is no HTTPS server fixture in the suite - `cpp-httplib` is built without the `openssl` feature - so a handshake-level test means adding that feature (and OpenSSL as an explicit dependency on macOS and Windows, where curl uses the native backends) plus a certificate-generating fixture. That is a dependency decision with the same weight as #628's and belongs to you, not to this PR, so what landed instead is: the merge asserted against the platform's real anchors, and `CURLOPT_CAINFO` acceptance asserted on each CI backend. I have not filed a follow-up issue for the handshake fixture, since the right shape depends on that dependency call - say the word and I will open one.
2. **wget's `--no-check-certificate` is mapped too.** The issue names only `-k`; both commands resolve through one builder, so honouring the intent on one path and eating it on the other would be a fresh instance of the drift this change is removing. One line each.
3. **The other four codegen targets stay silent.** The issue scopes codegen to curl (where the flag round-trips with `parseCurl`); `verify=False` / `rejectUnauthorized` idioms for python/fetch/httpie/powershell are separate work, not smuggled in here.
4. **No MCP overlay knob.** A stored request's `verifySSL` reaches MCP already, since its tools compose by id - and inline load-run knob parity is #760's scope, so nothing here touches it.
5. **`--cacert` stays unmapped on the paste path**, as the issue says: it is app-global here, and phase 4's disclosure ledger is where it gets named.

## Related Issues
Closes #706

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP69SpJdLnr82oPpQsPeYF)_