### PR TITLE
feat(app/mcp): run a collection from MCP, in design mode and under load

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,10 +29,10 @@ ships with safe-by-default guardrails. See `docs/engine/mcp.md` for the design.
   `enableDnsRebindingProtection` + `allowedHosts`), so a malicious web page
   cannot drive the endpoint through a forged `Host`.
 - **Target allowlist (empty by default).** The traffic-sending tools
-  (`run_request`, `run_collection_smoke`, `start_load_run`) refuse any host that
-  is not explicitly allowlisted. The check runs against the **resolved** host
-  (after `{{variable}}` substitution), so a variable-built URL cannot slip past
-  it. A fresh install cannot be used to send traffic anywhere until the user opts
+  (`run_request`, `run_collection_smoke`, `run_collection`, `start_load_run`)
+  refuse any host that is not explicitly allowlisted. The check runs against the
+  **resolved** host (after `{{variable}}` substitution), so a variable-built URL
+  cannot slip past it. A fresh install cannot be used to send traffic anywhere until the user opts
   in per host.
 - **Hard load caps (enforcement).** `start_load_run` rejects requests whose RPS,
   concurrency, or duration exceed configured ceilings. Together with the
@@ -46,8 +46,8 @@ ships with safe-by-default guardrails. See `docs/engine/mcp.md` for the design.
 - **Data writes off by default.** The data-mutating tools (`create_request`,
   `update_environment`, `update_engine_config`) are refused unless the user
   enables write access in Settings. Traffic-sending tools (`run_request`,
-  `run_collection_smoke`) and load runs are not affected by this toggle - they
-  are governed by the allowlist and caps.
+  `run_collection_smoke`, `run_collection`) and load runs are not affected by
+  this toggle - they are governed by the allowlist and caps.
 - **Per-tool control.** Any tool (or a whole read/execute/write/load category) can
   be switched off; a disabled tool is removed from `tools/list` and rejected by
   `tools/call`.

--- a/app/electron/mcp/config.ts
+++ b/app/electron/mcp/config.ts
@@ -51,10 +51,10 @@ export interface McpSafetyConfig {
 	 * Gates every tool in the `write` category - the collection and saved-request
 	 * CRUD verbs, `update_environment` and `update_engine_config`. When false
 	 * (default), those tools refuse; the two deletes additionally require
-	 * confirmation even with it on. It does
-	 * **not** gate traffic-sending tools (`run_request`, `run_collection_smoke`)
-	 * or load runs - those are governed by the allowlist, the hard caps, and the
-	 * load-run confirmation gate independently.
+	 * confirmation even with it on. It does **not** gate traffic-sending tools
+	 * (`run_request`, `run_collection_smoke`, `run_collection`) or load runs -
+	 * those are governed by the allowlist, the hard caps, and the load-run
+	 * confirmation gate independently.
 	 */
 	allowWrites: boolean;
 	/**

--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -97,6 +97,9 @@ describe("the registry declares its effects", () => {
 			update_engine_config: ["config"],
 			run_request: ["run", "cookie"],
 			run_collection_smoke: ["run", "cookie"],
+			// The design-mode runner is the one executor handed the cookie jar
+			// (`start_scenario_run`), so its steps refill it the way a Send does.
+			run_collection: ["run", "cookie"],
 			start_load_run: ["run"],
 			stop_run: ["run"],
 		};

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -1304,6 +1304,452 @@ describe("run_collection_smoke", () => {
 	});
 });
 
+/**
+ * Scenario runs from MCP (issue #754), reversing #454's deferral. Two surfaces
+ * over one engine route: `run_collection` posts a `scenario` block with no
+ * `mode` (design-mode runner), `start_load_run` posts the same block *with* one
+ * (virtual users). What these tests own is the same thing every other tool test
+ * owns - what reaches `POST /runs`, and that no traffic is arranged before the
+ * gates have run. The plan resolution itself is engine-side.
+ */
+describe("run_collection", () => {
+	/** A client whose collection `c1` holds two allowlisted requests. */
+	function scenarioClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}) {
+		return fakeClient({
+			listRequests: vi.fn().mockResolvedValue([
+				{ id: "r1", name: "login" },
+				{ id: "r2", name: "checkout" },
+			]),
+			composeRequest: vi
+				.fn()
+				.mockImplementation(({ requestId }: { requestId: string }) =>
+					Promise.resolve({ method: "GET", url: `https://api.example.com/${requestId}` })
+				),
+			...overrides,
+		});
+	}
+
+	test("is an execute tool that invalidates runs and the cookie jar", () => {
+		const tool = TOOLS.find((t) => t.name === "run_collection");
+		expect(tool?.category).toBe("execute");
+		// Steps share the environment's jar, the way a Send does.
+		expect(tool?.invalidates).toEqual(["run", "cookie"]);
+	});
+
+	test("posts the scenario block with rows, recursion and iterations intact", async () => {
+		const client = scenarioClient();
+		const rows = [{ id: "1" }, { id: "2" }];
+		const res = await dispatchTool(
+			"run_collection",
+			{
+				collectionId: "c1",
+				environmentId: "env_1",
+				recursive: false,
+				iterations: 3,
+				data: rows,
+			},
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		expect(res.isError).toBeFalsy();
+		expect(client.startRun).toHaveBeenCalledTimes(1);
+		const payload = (client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(payload).toEqual({
+			scenario: {
+				source: "collection",
+				collectionId: "c1",
+				recursive: false,
+				iterations: 3,
+				data: rows,
+			},
+			environmentId: "env_1",
+		});
+		// The absence of `mode` is what makes this a design-mode run: a mode
+		// beside the block would hand the same plan to the load executor.
+		expect(payload).not.toHaveProperty("mode");
+	});
+
+	test("omits iterations and data when the caller named neither", async () => {
+		const client = scenarioClient();
+		await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		const payload = (client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			scenario: Record<string, unknown>;
+		};
+		// The engine owns both defaults (1 pass, or the row count with data), so
+		// a computed copy here would be a second place for that rule to live.
+		expect(payload.scenario).not.toHaveProperty("iterations");
+		expect(payload.scenario).not.toHaveProperty("data");
+		expect(payload.scenario.recursive).toBe(false);
+	});
+
+	test("refuses the whole run on the first un-allowlisted step, starting nothing", async () => {
+		const client = scenarioClient({
+			listRequests: vi.fn().mockResolvedValue([
+				{ id: "r1", name: "login" },
+				{ id: "r2", name: "offsite" },
+				{ id: "r3", name: "checkout" },
+			]),
+			composeRequest: vi.fn().mockImplementation(({ requestId }: { requestId: string }) =>
+				Promise.resolve({
+					method: "GET",
+					url:
+						requestId === "r2"
+							? "https://evil.test/x"
+							: `https://api.example.com/${requestId}`,
+				})
+			),
+		});
+		const res = await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		expect(res.isError).toBe(true);
+		// Named the way the engine names a step, so the row is findable.
+		expect(firstText(res)).toMatch(/step 1 \(request 'offsite', id 'r2'\)/);
+		expect(firstText(res)).toMatch(/evil\.test/);
+		expect(firstText(res)).toMatch(/Nothing was started/);
+		expect(client.startRun).not.toHaveBeenCalled();
+		// The walk stops at the refusal rather than composing the rest.
+		expect(client.composeRequest).toHaveBeenCalledTimes(2);
+	});
+
+	test("a step that cannot compose refuses the run rather than starting a plan the engine would reject", async () => {
+		const client = scenarioClient({
+			composeRequest: vi
+				.fn()
+				.mockRejectedValue(new EngineRequestError("Engine responded 500", 500, "boom")),
+		});
+		const res = await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/Cannot compose step 0 \(request 'login', id 'r1'\)/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * The engine emits each sub-collection's whole subtree before the folder's
+	 * own requests (`collect_requests`, the sidebar's order). The pre-flight walk
+	 * has to agree, or its "first bad step" names a step the run reaches later.
+	 */
+	test("walks sub-collections in the engine's order when recursive", async () => {
+		const requestsByCollection: Record<string, Array<{ id: string; name: string }>> = {
+			c1: [{ id: "root_a", name: "root a" }],
+			c2: [{ id: "child_a", name: "child a" }],
+			c3: [{ id: "grand_a", name: "grand a" }],
+		};
+		const client = scenarioClient({
+			listCollections: vi.fn().mockResolvedValue([
+				{ id: "c1", name: "API" },
+				{ id: "c2", name: "Billing", parentId: "c1" },
+				{ id: "c3", name: "Invoices", parentId: "c2" },
+				{ id: "c9", name: "Elsewhere" },
+			]),
+			listRequests: vi
+				.fn()
+				.mockImplementation((id: string) =>
+					Promise.resolve(requestsByCollection[id] ?? [])
+				),
+		});
+		const res = await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1", recursive: true },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		expect(res.isError).toBeFalsy();
+		const composedIds = (client.composeRequest as ReturnType<typeof vi.fn>).mock.calls.map(
+			(call) => (call[0] as { requestId: string }).requestId
+		);
+		expect(composedIds).toEqual(["grand_a", "child_a", "root_a"]);
+		expect(res.structuredContent).toMatchObject({ plannedSteps: 3 });
+		// A collection outside the subtree is not walked.
+		expect(client.listRequests).not.toHaveBeenCalledWith("c9", undefined);
+	});
+
+	test("a parent cycle terminates instead of walking forever", async () => {
+		const client = scenarioClient({
+			listCollections: vi.fn().mockResolvedValue([
+				{ id: "c1", name: "A", parentId: "c2" },
+				{ id: "c2", name: "B", parentId: "c1" },
+			]),
+			listRequests: vi.fn().mockResolvedValue([]),
+		});
+		const res = await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1", recursive: true },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		// An empty plan is the engine's refusal to make, not this walk's - what
+		// matters here is that the walk returned at all.
+		expect(res.isError).toBeFalsy();
+		expect(client.startRun).toHaveBeenCalledTimes(1);
+	});
+
+	test("returns the run id with the plan size and how to follow it", async () => {
+		const client = scenarioClient({
+			startRun: vi.fn().mockResolvedValue({
+				runId: "run_7",
+				status: "pending",
+				message: "Collection run started",
+			}),
+		});
+		const res = await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		expect(res.structuredContent).toMatchObject({
+			runId: "run_7",
+			status: "pending",
+			plannedSteps: 2,
+		});
+		// The report's own bound, stated where the agent reads the run id -
+		// a 200-step plan does not come back as 200 rows.
+		expect(firstText(res)).toMatch(/at most 100 step rows/);
+		expect(firstText(res)).toMatch(/get_run_report/);
+	});
+
+	test("surfaces the engine's own refusal verbatim", async () => {
+		const client = scenarioClient({
+			startRun: vi
+				.fn()
+				.mockRejectedValue(
+					new EngineRequestError(
+						"Engine responded 400",
+						400,
+						"'scenario.data' has 2000 rows, over the limit of 1000"
+					)
+				),
+		});
+		const res = await dispatchTool(
+			"run_collection",
+			{ collectionId: "c1", data: [{ id: "1" }] },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/over the limit of 1000/);
+	});
+});
+
+describe("start_load_run scenario runs", () => {
+	function scenarioLoadClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}) {
+		return fakeClient({
+			listRequests: vi.fn().mockResolvedValue([{ id: "r1", name: "login" }]),
+			composeRequest: vi
+				.fn()
+				.mockResolvedValue({ method: "GET", url: "https://api.example.com/login" }),
+			...overrides,
+		});
+	}
+
+	const allowed = { allowlist: ["api.example.com"] };
+
+	test("posts the scenario block beside the load shape", async () => {
+		const client = scenarioLoadClient();
+		const rows = [{ id: "1" }];
+		const res = await dispatchTool(
+			"start_load_run",
+			{
+				scenario: { collectionId: "c1", recursive: true, data: rows },
+				mode: "constant_concurrency",
+				concurrency: 5,
+				duration: "30s",
+				environmentId: "env_1",
+				confirmed: true,
+			},
+			ctxWith(client, allowed)
+		);
+		expect(res.isError).toBeFalsy();
+		expect((client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual({
+			mode: "constant_concurrency",
+			scenario: { source: "collection", collectionId: "c1", recursive: true, data: rows },
+			environmentId: "env_1",
+			concurrency: 5,
+			duration: "30s",
+		});
+	});
+
+	test("refuses the single-target arguments by name instead of ignoring them", async () => {
+		const client = scenarioLoadClient();
+		for (const [key, value] of [
+			["url", "https://api.example.com/x"],
+			["requestId", "req_1"],
+			["method", "POST"],
+			["auth", { mode: "bearer", token: "t" }],
+			["postRequestScript", "pm.test('ok', () => {})"],
+			["collectionId", "c1"],
+			["maxInFlight", 10],
+			["stream", true],
+			["sloMs", 500],
+		] as Array<[string, unknown]>) {
+			const res = await dispatchTool(
+				"start_load_run",
+				{ scenario: { collectionId: "c1" }, [key]: value, confirmed: true },
+				ctxWith(client, allowed)
+			);
+			expect(res.isError, key).toBe(true);
+			expect(firstText(res), key).toContain(`"${key}"`);
+			expect(firstText(res), key).toMatch(/do not apply to a scenario load run/);
+		}
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("refuses the two modes the engine cannot drive, with its reasoning", async () => {
+		const client = scenarioLoadClient();
+		const capacity = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, mode: "capacity", confirmed: true },
+			ctxWith(client, allowed)
+		);
+		expect(capacity.isError).toBe(true);
+		expect(firstText(capacity)).toMatch(/one windowed p99/);
+		expect(firstText(capacity)).toMatch(/constant_concurrency, ramp_up, iterations/);
+
+		const rps = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, mode: "constant_rps", confirmed: true },
+			ctxWith(client, allowed)
+		);
+		expect(rps.isError).toBe(true);
+		expect(firstText(rps)).toMatch(/arrival-rate executor/);
+
+		// The rate itself is what selects that path, whatever mode is declared.
+		const rate = await dispatchTool(
+			"start_load_run",
+			{
+				scenario: { collectionId: "c1" },
+				mode: "constant_concurrency",
+				targetRps: 50,
+				confirmed: true,
+			},
+			ctxWith(client, allowed)
+		);
+		expect(rate.isError).toBe(true);
+		expect(firstText(rate)).toMatch(/closed-loop by design/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("applies the load caps to virtual users, duration and iterations", async () => {
+		const client = scenarioLoadClient();
+		const vus = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, concurrency: 5000, confirmed: true },
+			ctxWith(client, { ...allowed, maxConcurrency: 50 })
+		);
+		expect(vus.isError).toBe(true);
+		expect(firstText(vus)).toMatch(/concurrency 5000 exceeds the MCP cap of 50/);
+
+		const duration = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, duration: "2h", confirmed: true },
+			ctxWith(client, { ...allowed, maxDurationSeconds: 300 })
+		);
+		expect(duration.isError).toBe(true);
+		expect(firstText(duration)).toMatch(/exceeds the MCP cap of 300s/);
+
+		const iterations = await dispatchTool(
+			"start_load_run",
+			{
+				scenario: { collectionId: "c1" },
+				mode: "iterations",
+				iterations: 999_999,
+				confirmed: true,
+			},
+			ctxWith(client, { ...allowed, maxIterations: 1000 })
+		);
+		expect(iterations.isError).toBe(true);
+		expect(firstText(iterations)).toMatch(/exceeds the MCP cap of 1000/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("injects the capped duration when the caller omitted one", async () => {
+		const client = scenarioLoadClient();
+		await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, confirmed: true },
+			ctxWith(client, { ...allowed, maxDurationSeconds: 20 })
+		);
+		// The engine's own default is 60s, so a 20s cap only binds if it is sent.
+		expect((client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+			duration: "20s",
+		});
+	});
+
+	test("gates every step on the allowlist before anything is started", async () => {
+		const client = scenarioLoadClient({
+			listRequests: vi.fn().mockResolvedValue([
+				{ id: "r1", name: "login" },
+				{ id: "r2", name: "offsite" },
+			]),
+			composeRequest: vi.fn().mockImplementation(({ requestId }: { requestId: string }) =>
+				Promise.resolve({
+					method: "GET",
+					url:
+						requestId === "r2"
+							? "https://evil.test/x"
+							: "https://api.example.com/login",
+				})
+			),
+		});
+		const res = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, confirmed: true },
+			ctxWith(client, allowed)
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/step 1 \(request 'offsite', id 'r2'\)/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("previews the planned run and starts nothing until confirmed", async () => {
+		const client = scenarioLoadClient();
+		const preview = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, concurrency: 4 },
+			ctxWith(client, allowed)
+		);
+		expect(preview.isError).toBeFalsy();
+		expect(firstText(preview)).toMatch(/AWAITING CONFIRMATION/);
+		expect(firstText(preview)).toMatch(/1 step\(s\) per iteration/);
+		expect(client.startRun).not.toHaveBeenCalled();
+
+		const started = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "c1" }, concurrency: 4, confirmed: true },
+			ctxWith(client, allowed)
+		);
+		expect(started.isError).toBeFalsy();
+		expect(client.startRun).toHaveBeenCalledTimes(1);
+	});
+
+	test("a declined elicitation starts nothing", async () => {
+		const client = scenarioLoadClient();
+		const ctx: ToolContext = {
+			...ctxWith(client, allowed),
+			elicit: vi.fn().mockResolvedValue({ action: "decline" }),
+		};
+		const res = await dispatchTool("start_load_run", { scenario: { collectionId: "c1" } }, ctx);
+		expect(firstText(res)).toMatch(/declined/);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+
+	test("the scenario block offers no iterations of its own", () => {
+		// A load run reads the top-level `iterations`; `scenario.iterations` is the
+		// design runner's pass count and the load executor never looks at it, so
+		// offering it here would be an argument written and never read.
+		const tool = TOOLS.find((t) => t.name === "start_load_run");
+		const shape = (tool!.inputSchema.scenario as z.ZodOptional<z.ZodObject<z.ZodRawShape>>)._def
+			.innerType.shape;
+		expect(Object.keys(shape).sort()).toEqual(["collectionId", "data", "recursive"]);
+	});
+});
+
 describe("get_live_metrics limit", () => {
 	function metricsClient() {
 		return fakeClient({ getLiveMetricsSnapshot: vi.fn().mockResolvedValue([]) });
@@ -1832,14 +2278,15 @@ describe("dispatchTool", () => {
 		expect(Object.keys(loadRun!.inputSchema)).toContain("tests");
 	});
 
-	test("start_load_run states that scenario runs are out of its scope", () => {
-		// The tool loads one target. Collection/scenario load runs exist and are
-		// app-dialog-only (`RunCollectionDialog.tsx`), and an agent reading the
-		// tool list has no other place to learn that - so silence here reads as
-		// "scenarios are not a thing", not as "not here".
+	test("start_load_run offers scenario runs rather than deferring them", () => {
+		// #454 scoped them out and said so in the description; #754 reversed that.
+		// The description is where an agent learns a collection can be the target
+		// at all, so it has to name the argument and what `concurrency` becomes.
 		const loadRun = TOOLS.find((t) => t.name === "start_load_run");
 		expect(loadRun?.description).toMatch(/scenario/i);
-		expect(loadRun?.description).toMatch(/Run Collection dialog/);
+		expect(loadRun?.description).toMatch(/virtual users/);
+		expect(loadRun?.description).not.toMatch(/cannot be started from here/);
+		expect(Object.keys(loadRun!.inputSchema)).toContain("scenario");
 	});
 
 	test("both execute-shaped tools name the validation script the same way", () => {

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -1513,6 +1513,11 @@ describe("run_collection", () => {
 		// a 200-step plan does not come back as 200 rows.
 		expect(firstText(res)).toMatch(/at most 100 step rows/);
 		expect(firstText(res)).toMatch(/get_run_report/);
+		// And that the rows carry bodies inline. A design-mode step trace embeds
+		// the request and response bodies (`build_result_trace`), unlike a load
+		// run's captures, which live behind GET /runs/:id/samples - so an agent
+		// told the opposite would size a 100-step report as if it were metadata.
+		expect(firstText(res)).toMatch(/bodies inline/);
 	});
 
 	test("surfaces the engine's own refusal verbatim", async () => {

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -2554,8 +2554,10 @@ export const TOOLS: McpTool[] = [
 					`The run executes engine-side. Read it with get_run_report(runId): the ` +
 					`\`scenario\` section carries the iteration and pass/fail/skip totals plus ` +
 					`\`stepsStored\`/\`stepsDropped\`, and \`results\` returns at most 100 step rows ` +
-					`(non-passing steps are kept first). Response bodies are not on the report - ` +
-					`GET /runs/:id/samples has them. stop_run ends the run early.`,
+					`(non-passing steps are kept first). Each row's \`trace\` carries that step's ` +
+					`request and response bodies inline, so a long plan against large responses ` +
+					`makes for a large report - read the totals first and the rows when you need ` +
+					`them. stop_run ends the run early.`,
 			});
 		},
 	},

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -841,6 +841,40 @@ const failOnSchemaErrorInput = z
 		"Whether a response that does not match the schema the collection's bound OpenAPI document declares fails its request (default true). Set false to report the schema verdict on each row without letting it decide pass/fail - useful against a document known to lag its API. Only a checked verdict is ever folded in: a status or content type the document declares no schema for is reported unchecked and never fails a request, with or without this."
 	);
 
+/**
+ * The two fields a scenario block carries besides its collection id, declared
+ * here because both scenario surfaces take them and they must mean the same
+ * thing on each (issue #754): `run_collection` runs the plan once through the
+ * design runner, `start_load_run` drives the same plan with virtual users.
+ *
+ * `iterations` is deliberately not among them - see the scenario block on
+ * `start_load_run` for why a load run reads the top-level one instead.
+ *
+ * Whether to descend into sub-collections, and in which order that happens.
+ */
+const scenarioRecursiveInput = z
+	.boolean()
+	.optional()
+	.describe(
+		"Descend into sub-collections (default false). The order is the sidebar's: at every level each sub-collection's whole subtree runs before that level's own requests."
+	);
+
+/**
+ * The inline data set, in the shape `POST /runs` reads it.
+ *
+ * Inline because the engine never opens a file - the app parses CSV/TSV/JSON and
+ * sends rows, and a path an agent chose would be a trust boundary neither side
+ * wants. The engine's own `maxScenarioDataRows` / `maxScenarioDataBytes` bound
+ * the array and its 400 is surfaced verbatim rather than re-derived here, which
+ * would be a second copy of a limit the user can raise in Settings.
+ */
+const scenarioDataInput = z
+	.array(z.record(z.unknown()))
+	.optional()
+	.describe(
+		'Data rows, one flat object per row (e.g. [{"id":"1"},{"id":"2"}]). Every {{data.column}} in a step\'s URL, headers, body and auth credentials is bound per iteration, and both scripts read the row as pm.iterationData. A step carrying a {{data.*}} token with no data set is refused by the engine before anything is sent, as is a present-but-empty array. Rows are never persisted - only their count is recorded on the run.'
+	);
+
 const streamInput = z
 	.boolean()
 	.optional()
@@ -1098,6 +1132,363 @@ function smokeScopeCaveat(children: string[] | null): string {
 		`collection's direct requests only, and the counts above exclude every request nested ` +
 		`inside: ${children.join(", ")}. Call run_collection_smoke on each to cover them.`
 	);
+}
+
+// --- Scenario runs (a collection as the unit of work) ------------------------
+
+/** A step of a scenario plan, as much of it as the pre-flight walk needs. */
+interface ScenarioStepRow {
+	id: string;
+	name: string;
+}
+
+/**
+ * The saved requests a scenario run will execute, in the order the engine will
+ * execute them (issue #754).
+ *
+ * Mirrors `collect_requests` (`engine/src/core/scenario_plan.cpp`): without
+ * `recursive` a collection's direct requests are the whole plan; with it, every
+ * sub-collection's subtree is emitted **before** that level's own requests, which
+ * is the order the sidebar renders. The order matters here for one reason - the
+ * pre-flight refusal names the first step that fails - so a walk in some other
+ * order would name a different step than the run would have reached first.
+ *
+ * The `visited` set is the same guard the engine's walk carries: a corrupted
+ * `parentId` (a self-parent, an A -> B -> A loop) must terminate rather than
+ * enumerate forever.
+ */
+async function scenarioStepRows(
+	client: EngineClient,
+	collectionId: string,
+	recursive: boolean,
+	signal?: AbortSignal
+): Promise<ScenarioStepRow[]> {
+	const requestsIn = async (id: string): Promise<ScenarioStepRow[]> => {
+		const rows = await client.listRequests(id, signal);
+		return (Array.isArray(rows) ? rows : []).map((row) => {
+			const rec = (row ?? {}) as { id?: unknown; name?: unknown };
+			return {
+				id: typeof rec.id === "string" ? rec.id : "",
+				name: String(rec.name ?? rec.id ?? "request"),
+			};
+		});
+	};
+	if (!recursive) return requestsIn(collectionId);
+
+	const all = await client.listCollections(signal);
+	// One read, grouped by parent - `GET /collections` is ordered by `order`, so
+	// each parent's children keep that order without a sort here.
+	const childrenOf = new Map<string, string[]>();
+	for (const item of Array.isArray(all) ? all : []) {
+		if (!item || typeof item !== "object") continue;
+		const rec = item as { id?: unknown; parentId?: unknown };
+		if (typeof rec.id !== "string" || typeof rec.parentId !== "string" || !rec.parentId) {
+			continue;
+		}
+		childrenOf.set(rec.parentId, [...(childrenOf.get(rec.parentId) ?? []), rec.id]);
+	}
+
+	const ordered: ScenarioStepRow[] = [];
+	const visited = new Set<string>();
+	// Two entry kinds on one stack, exactly as the engine walks it: `emit` is
+	// pushed *under* the children, so a folder's own requests come last.
+	const stack: Array<{ step: "descend" | "emit"; id: string }> = [
+		{ step: "descend", id: collectionId },
+	];
+	while (stack.length > 0) {
+		const entry = stack.pop() as { step: "descend" | "emit"; id: string };
+		if (entry.step === "emit") {
+			ordered.push(...(await requestsIn(entry.id)));
+			continue;
+		}
+		if (visited.has(entry.id)) continue;
+		visited.add(entry.id);
+		stack.push({ step: "emit", id: entry.id });
+		const children = childrenOf.get(entry.id) ?? [];
+		for (let i = children.length - 1; i >= 0; i--) {
+			stack.push({ step: "descend", id: children[i] });
+		}
+	}
+	return ordered;
+}
+
+/**
+ * How a step is named in a refusal: the engine's own `describe_step` wording
+ * (`scenario_plan.cpp`), including its zero-based index, so a pre-flight refusal
+ * and the engine's own refusal for the same step read identically.
+ */
+function describeScenarioStep(index: number, row: ScenarioStepRow): string {
+	return `step ${index} (request '${row.name}', id '${row.id}')`;
+}
+
+/**
+ * Gate every step of a scenario against the allowlist *before* the run exists,
+ * and return how many steps the plan has.
+ *
+ * A scenario is one run: there is no per-step skip the way `run_collection_smoke`
+ * has one, because the engine starts the whole sequence or none of it. So a
+ * single un-allowlisted step refuses the run and **nothing is started** - the
+ * alternative would be an agent generating traffic against a host it was never
+ * pointed at, in the middle of a sequence it cannot stop selectively.
+ *
+ * Composition is the engine's, by id, with the caller's environment - the same
+ * call `resolve_scenario` makes for each step, which is what makes the URL this
+ * gate reads the URL the run would send to. A step that will not compose refuses
+ * here too: the engine resolves the identical plan before it creates the run row
+ * and would refuse it for the same reason, so failing early costs nothing and
+ * says so in the same words.
+ *
+ * Throws {@link ToolArgError} for a refusal; engine transport failures propagate
+ * to the caller's `engineErrorResult`.
+ */
+async function preflightScenarioSteps(
+	target: { collectionId: string; recursive: boolean; environmentId?: string },
+	ctx: ToolContext,
+	signal?: AbortSignal
+): Promise<number> {
+	const rows = await scenarioStepRows(ctx.client, target.collectionId, target.recursive, signal);
+	for (let index = 0; index < rows.length; index++) {
+		const row = rows[index];
+		const step = describeScenarioStep(index, row);
+		let composed: Record<string, unknown>;
+		try {
+			composed = await composeViaEngine(
+				ctx.client,
+				{ requestId: row.id, environmentId: target.environmentId },
+				signal
+			);
+		} catch (err) {
+			throw new ToolArgError(
+				`Cannot compose ${step}: ${err instanceof Error ? err.message : String(err)}. ` +
+					`Nothing was started - the engine resolves this same plan before it creates the ` +
+					`run, and would refuse it for this reason too.`
+			);
+		}
+		const url = String(composed.url ?? "");
+		const gate = checkAllowlist(url, ctx.config);
+		if (!gate.ok) {
+			throw new ToolArgError(
+				`Refusing to run this collection: ${step} sends to ${url}. ${gate.error} ` +
+					`Nothing was started - a scenario runs as one sequence, so a single step the ` +
+					`allowlist does not cover refuses all ${rows.length} of them.`
+			);
+		}
+	}
+	return rows.length;
+}
+
+/** The scenario block an agent passed to `start_load_run`, if it passed one. */
+function readScenarioArg(
+	args: Record<string, unknown>
+): { collectionId: string; recursive?: boolean; data?: unknown[] } | undefined {
+	const block = args.scenario;
+	if (!block || typeof block !== "object" || Array.isArray(block)) return undefined;
+	return block as { collectionId: string; recursive?: boolean; data?: unknown[] };
+}
+
+/**
+ * `start_load_run`'s arguments that describe a *single* target, which a scenario
+ * replaces wholesale, mapped to what an agent should do instead.
+ *
+ * Refused rather than ignored: each of these would otherwise be an argument an
+ * agent believes shaped the run and that nothing on the scenario path ever reads
+ * - the codebase's most-repeated defect, arriving through the front door. The
+ * steps are saved requests, so their method, body, auth, protocol and scripts
+ * are the stored ones, composed per step.
+ */
+const SINGLE_TARGET_LOAD_FIELDS: ReadonlyArray<[string, string]> = [
+	["url", "a scenario's targets are the collection's saved requests"],
+	["requestId", "a scenario runs a collection, not one saved request"],
+	["method", "each step keeps its own stored method"],
+	["headers", "each step keeps its own stored headers"],
+	["body", "each step keeps its own stored body"],
+	["bodyType", "each step keeps its own stored body"],
+	["auth", "each step's auth is resolved from the request and its collection chain"],
+	["httpVersion", "each step keeps its own stored protocol"],
+	["postRequestScript", "each step runs the scripts stored on it and its collection chain"],
+	["tests", "each step runs the scripts stored on it and its collection chain"],
+	[
+		"collectionId",
+		"the collection to run is `scenario.collectionId`; this argument only scopes variable resolution for a single ad-hoc target",
+	],
+	["maxInFlight", "in-flight requests are bounded by the virtual-user count (`concurrency`)"],
+	["sloMs", "that is `capacity` mode's field, and a scenario cannot run in capacity mode"],
+	["stepDuration", "that is `capacity` mode's field, and a scenario cannot run in capacity mode"],
+	["stream", "run-level stream bounds are applied to a single-target run's request only"],
+	[
+		"maxStreamDurationMs",
+		"run-level stream bounds are applied to a single-target run's request only",
+	],
+	[
+		"maxStreamEvents",
+		"run-level stream bounds are applied to a single-target run's request only",
+	],
+];
+
+/** The modes the engine will drive a scenario with (`validate_scenario_load_config`). */
+const SCENARIO_LOAD_MODES = ["constant_concurrency", "ramp_up", "iterations"] as const;
+
+/**
+ * Why the engine refuses the other two modes, in its own reasoning rather than a
+ * bare "unsupported": an agent told *why* `constant_rps` cannot drive a sequence
+ * picks `constant_concurrency`, and one told only "no" tries again.
+ */
+function scenarioModeRefusal(mode: string): string | null {
+	if ((SCENARIO_LOAD_MODES as readonly string[]).includes(mode)) return null;
+	const shared = `Scenario load runs accept ${SCENARIO_LOAD_MODES.join(", ")}.`;
+	if (mode === "capacity") {
+		return (
+			`"capacity" is not available for scenario runs: the search judges one windowed p99, ` +
+			`and a sequence has one per step - which of them is "the" latency the knee is measured ` +
+			`against is a question the mode does not answer. ${shared}`
+		);
+	}
+	if (mode === "constant_rps") {
+		return (
+			`"constant_rps" is not available for scenario runs: an open-loop arrival rate over a ` +
+			`multi-step sequence is an arrival-rate executor, which Vayu does not implement. ` +
+			`${shared} For a scenario, "concurrency" is the number of virtual users.`
+		);
+	}
+	return `Unknown load mode "${mode}" for a scenario run. ${shared}`;
+}
+
+/**
+ * Start a scenario **load** run: the collection's plan driven by virtual users
+ * (issue #754, reversing #454's deferral).
+ *
+ * Split from `start_load_run`'s single-target path rather than folded into it,
+ * because the two share only their gates: there is no request to compose here
+ * (every step composes engine-side at plan time), no url to check (the
+ * pre-flight walk checks every step's), and a different set of load fields
+ * applies. What they do share - the allowlist, `checkLoadCaps`, the duration
+ * default under the cap, and the confirmation - runs through the same helpers,
+ * so a cap raised in Settings binds both paths identically.
+ */
+async function startScenarioLoadRun(
+	args: Record<string, unknown>,
+	scenario: { collectionId: string; recursive?: boolean; data?: unknown[] },
+	ctx: ToolContext,
+	signal?: AbortSignal
+): Promise<ToolResult> {
+	const inapplicable = SINGLE_TARGET_LOAD_FIELDS.filter(([key]) => args[key] !== undefined);
+	if (inapplicable.length > 0) {
+		return errorResult(
+			`These arguments do not apply to a scenario load run: ` +
+				inapplicable.map(([key, why]) => `"${key}" (${why})`).join("; ") +
+				`. Nothing was started - each of them would have been read as shaping this run ` +
+				`while the scenario executor never looks at it. Remove them and retry.`
+		);
+	}
+
+	const mode = str(args, "mode") ?? DEFAULT_LOAD_MODE;
+	const modeRefusal = scenarioModeRefusal(mode);
+	if (modeRefusal) return errorResult(modeRefusal);
+	// The engine refuses a rate on either spelling, because either one selects
+	// the open-loop path regardless of the declared mode.
+	if (typeof args.targetRps === "number" && args.targetRps > 0) {
+		return errorResult(
+			`"targetRps" is not available for scenario runs: it selects an open-loop arrival rate, ` +
+				`and a scenario run is closed-loop by design. Set "concurrency" - the number of ` +
+				`virtual users - instead.`
+		);
+	}
+
+	const monitor = args.monitor as { url?: unknown } | undefined;
+	if (monitor && typeof monitor === "object") {
+		const monitorGate = checkMonitorHost(String(monitor.url ?? ""), ctx.config);
+		if (!monitorGate.ok) return errorResult(monitorGate.error!);
+	}
+
+	const loadParams: LoadRunParams = {
+		mode,
+		concurrency: typeof args.concurrency === "number" ? args.concurrency : undefined,
+		startConcurrency:
+			typeof args.startConcurrency === "number" ? args.startConcurrency : undefined,
+		iterations: typeof args.iterations === "number" ? args.iterations : undefined,
+		duration: (args.duration as string | number | undefined) ?? undefined,
+		rampUpDuration: (args.rampUpDuration as string | number | undefined) ?? undefined,
+	};
+	const caps = checkLoadCaps(loadParams, ctx.config);
+	if (!caps.ok) return errorResult(caps.error!);
+
+	const environmentId = str(args, "environmentId");
+	const recursive = scenario.recursive === true;
+	let plannedSteps: number;
+	try {
+		plannedSteps = await preflightScenarioSteps(
+			{ collectionId: scenario.collectionId, recursive, environmentId },
+			ctx,
+			signal
+		);
+	} catch (err) {
+		if (err instanceof ToolArgError) return errorResult(err.message);
+		return engineErrorResult(err);
+	}
+
+	const payload: Record<string, unknown> = {
+		mode,
+		scenario: scenarioBlock(scenario, recursive),
+		...(environmentId !== undefined ? { environmentId } : {}),
+	};
+	for (const key of ["concurrency", "startConcurrency", "iterations"]) {
+		if (typeof args[key] === "number") payload[key] = args[key];
+	}
+	for (const key of ["duration", "rampUpDuration"]) {
+		const v = str(args, key);
+		if (v !== undefined) payload[key] = v;
+	}
+	// Both travel verbatim for the same reason they do on the single-target
+	// path: the keys are the engine's own and it is what judges the values.
+	// Neither is executor-specific - a scenario load run is a load run, with the
+	// same metrics thread, monitor scrape and end-of-run threshold evaluation.
+	if (args.thresholds && typeof args.thresholds === "object")
+		payload.thresholds = args.thresholds;
+	if (monitor && typeof monitor === "object") payload.monitor = monitor;
+	const cappedDuration = defaultDurationUnderCap(loadParams, ctx.config);
+	if (cappedDuration !== null) payload.duration = cappedDuration;
+
+	const unconfirmed = await confirmDestructive(args, ctx, {
+		message:
+			`Start a scenario load test over collection ${scenario.collectionId} ` +
+			`(${plannedSteps} step(s) per iteration, mode: ${mode})?\n\n` +
+			`This generates real traffic within Vayu's caps.`,
+		acceptTitle: "Start the load test",
+		acceptDescription: "Confirm to generate load now.",
+		declined: "Load run not started - the user declined.",
+		preview:
+			"AWAITING CONFIRMATION - no run was started.\n\n" +
+			"This is a preview. To start the load test, call start_load_run again with " +
+			"confirmed: true and the same arguments.\n\n" +
+			`Planned run (${plannedSteps} step(s) per iteration):\n${JSON.stringify(payload, null, 2)}`,
+	});
+	if (unconfirmed) return unconfirmed;
+
+	return withCaveat(
+		await callEngine(() => ctx.client.startRun(payload, signal)),
+		`\n\nThe plan is ${plannedSteps} step(s) per iteration. Follow the run with ` +
+			`get_run_report: its \`scenario\` section carries the virtual-user, iteration and ` +
+			`per-step breakdown. Pre-request scripts DO run on a scenario load run - each virtual ` +
+			`user walks the plan the way the design runner does.`
+	);
+}
+
+/** The `scenario` block `POST /runs` reads, from the arguments an agent gave. */
+function scenarioBlock(
+	scenario: { collectionId: string; data?: unknown[] },
+	recursive: boolean,
+	iterations?: number
+): Record<string, unknown> {
+	return {
+		source: "collection",
+		collectionId: scenario.collectionId,
+		recursive,
+		// Omitted rather than defaulted: with `data` present and this absent the
+		// engine sets the pass count to the row count, and a client computing
+		// its own would be a second copy of a rule only one side enforces.
+		...(iterations !== undefined ? { iterations } : {}),
+		...(scenario.data !== undefined ? { data: scenario.data } : {}),
+	};
 }
 
 /** Convert a `{key: value}` header map to the engine's KeyValueEntry[] shape. */
@@ -2088,11 +2479,92 @@ export const TOOLS: McpTool[] = [
 		},
 	},
 	{
+		name: "run_collection",
+		category: "execute",
+		invalidates: ["run", "cookie"],
+		description:
+			"Run a collection as the product means collections to be run: its saved requests executed as an ordered sequence, one step at a time, by the engine's design-mode runner. Unlike run_collection_smoke this is ONE run with a run id - steps share a cookie jar, `pm.execution` flow control (setNextRequest, skipRequest) works, pre-request scripts run, and passing `data` repeats the sequence once per row with {{data.column}} bound and pm.iterationData set. Pass recursive: true to include sub-collections, in the sidebar's order. The collection tree IS the sequence: there is no step list to give. Every step's resolved host must be on the allowlist - unlike the smoke matrix, which skips an off-allowlist request and runs the rest, a scenario is one run, so a single step the allowlist does not cover refuses the whole run and nothing is sent. Returns the run id immediately; the run continues engine-side and get_run_report reads its outcome. Sends real traffic but does not modify Vayu data. For a load test over the same sequence, use start_load_run's `scenario` argument.",
+		annotations: {
+			title: "Run collection",
+			readOnlyHint: false,
+			destructiveHint: true,
+			openWorldHint: true,
+		},
+		inputSchema: {
+			collectionId: z.string().describe("Collection whose requests make up the sequence."),
+			environmentId: z
+				.string()
+				.optional()
+				.describe(
+					"Environment whose variables resolve {{templates}} in every step, and whose cookie jar the run uses."
+				),
+			recursive: scenarioRecursiveInput,
+			// Positive: the engine reads the count as a pass total, so a zero is a
+			// run with nothing to do and a negative is not a count at all. Named
+			// rather than clamped, like every other count in this registry.
+			iterations: z
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe(
+					"How many passes over the sequence (default 1, or the row count when `data` is given). With more passes than rows the row index wraps."
+				),
+			data: scenarioDataInput,
+		},
+		handler: async (args, ctx, signal) => {
+			const collectionId = requireStr(args, "collectionId");
+			const environmentId = str(args, "environmentId");
+			const recursive = args.recursive === true;
+			const iterations = typeof args.iterations === "number" ? args.iterations : undefined;
+			const data = Array.isArray(args.data) ? (args.data as unknown[]) : undefined;
+
+			let plannedSteps: number;
+			try {
+				plannedSteps = await preflightScenarioSteps(
+					{ collectionId, recursive, environmentId },
+					ctx,
+					signal
+				);
+			} catch (err) {
+				if (err instanceof ToolArgError) return errorResult(err.message);
+				return engineErrorResult(err);
+			}
+
+			const payload: Record<string, unknown> = {
+				scenario: scenarioBlock({ collectionId, data }, recursive, iterations),
+				...(environmentId !== undefined ? { environmentId } : {}),
+			};
+
+			let started: unknown;
+			try {
+				started = await ctx.client.startRun(payload, signal);
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			// The engine's 202 body is the answer; anything else is handed back as
+			// it came rather than dressed up as a started run.
+			if (!started || typeof started !== "object" || Array.isArray(started)) {
+				return jsonResult(started);
+			}
+			return structuredResult({
+				...(started as Record<string, unknown>),
+				plannedSteps,
+				nextStep:
+					`The run executes engine-side. Read it with get_run_report(runId): the ` +
+					`\`scenario\` section carries the iteration and pass/fail/skip totals plus ` +
+					`\`stepsStored\`/\`stepsDropped\`, and \`results\` returns at most 100 step rows ` +
+					`(non-passing steps are kept first). Response bodies are not on the report - ` +
+					`GET /runs/:id/samples has them. stop_run ends the run early.`,
+			});
+		},
+	},
+	{
 		name: "start_load_run",
 		category: "load",
 		invalidates: ["run"],
 		description:
-			"Start a load test against a URL, or against a saved request via `requestId` - which composes it exactly as the app does, including the collection chain's and its own test scripts, so a load run checks the same assertions a Send does. GUARDED: the host must be on the allowlist, and RPS/concurrency/duration must be within Vayu's caps. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given; pass an `auth` block to authenticate the load (bearer/basic/apikey/oauth2, applied engine-side). Pass a `postRequestScript` - the same assertions you would give run_request - to validate responses under load; it runs against sampled responses. A pre-request script is not offered here: the engine runs one on a single request only, never on a load run. This tool loads a single target - a scenario (collection) load run, which drives a sequence of saved requests, is started from the app's Run Collection dialog and cannot be started from here. Confirmation is required: if the client supports elicitation the user is prompted directly; otherwise call once for a preview, then again with `confirmed: true`.",
+			"Start a load test against a URL, or against a saved request via `requestId` - which composes it exactly as the app does, including the collection chain's and its own test scripts, so a load run checks the same assertions a Send does. GUARDED: the host must be on the allowlist, and RPS/concurrency/duration must be within Vayu's caps. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given; pass an `auth` block to authenticate the load (bearer/basic/apikey/oauth2, applied engine-side). Pass a `postRequestScript` - the same assertions you would give run_request - to validate responses under load; it runs against sampled responses. A pre-request script is not offered here for a single target: the engine runs one on a single request only, never on a load run. Pass `scenario` INSTEAD of url/requestId to load-test a collection's ordered sequence: `concurrency` then means virtual users, each walking the plan with its own cookies and running every step's stored scripts, and only constant_concurrency, ramp_up and iterations can drive it. Confirmation is required: if the client supports elicitation the user is prompted directly; otherwise call once for a preview, then again with `confirmed: true`.",
 		annotations: {
 			title: "Start load test",
 			readOnlyHint: false,
@@ -2294,9 +2766,36 @@ export const TOOLS: McpTool[] = [
 			collectionId: collectionIdInput,
 			postRequestScript: validationScriptInput,
 			tests: validationScriptAliasInput,
+			// The other shape POST /runs accepts (issue #754). Mutually exclusive
+			// with every single-target argument, which the handler refuses by name
+			// rather than ignoring - see SINGLE_TARGET_LOAD_FIELDS.
+			//
+			// No `iterations` inside the block, unlike the design-mode runner's:
+			// a load run reads the *top-level* `iterations` (`scenario_load.cpp`
+			// takes it from the run config), and `scenario.iterations` is the
+			// design runner's per-run pass count, which this executor never looks
+			// at. Offering it here would be an argument written and never read.
+			scenario: z
+				.object({
+					collectionId: z
+						.string()
+						.describe("Collection whose saved requests are the sequence."),
+					recursive: scenarioRecursiveInput,
+					data: scenarioDataInput,
+				})
+				.optional()
+				.describe(
+					"Load-test a collection's ordered sequence instead of one target. Cannot be combined with url/requestId or any single-target field. `concurrency` is the number of virtual users, each walking the whole plan with its own cookies; `iterations` (top level) is the total passes across all of them in iterations mode. Modes: constant_concurrency (default), ramp_up, iterations - constant_rps and capacity are refused, with the engine's reasoning."
+				),
 			confirmed: confirmedInput("actually start the run"),
 		},
 		handler: async (args, ctx, signal) => {
+			// A scenario replaces the single target wholesale - there is nothing to
+			// compose here, so the branch comes before composition rather than
+			// inside it.
+			const scenario = readScenarioArg(args);
+			if (scenario) return startScenarioLoadRun(args, scenario, ctx, signal);
+
 			let composed;
 			try {
 				composed = await composeLoadRunRequest(args, ctx, signal);

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -516,7 +516,11 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
     `{{data.column}}` bound and `pm.iterationData` set. It returns the run id
     immediately - the run continues engine-side - along with the plan's step
     count and the note that `get_run_report`'s `results` carries **at most 100**
-    step rows.
+    step rows. Each of those rows carries that step's request and response
+    bodies inline, under `trace` (`build_result_trace`, the same node a
+    single design-mode send stores) - not behind `GET /runs/:id/samples`, which
+    is the load-run capture route - so a long plan against large responses
+    makes for a large report.
   - `start_load_run` takes the same block as an optional `scenario` argument
     and posts it **with** a mode, which hands the plan to the load executor:
     `concurrency` is the number of virtual users, each walking the whole plan

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -158,6 +158,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `compare_runs`         | read     | 2× `GET /runs/:id/report` → diff (structured)| `baseRunId` optional - omitted, it resolves the target's pinned baseline |
 | `run_request`          | execute  | `POST /compose` + `POST /execute` (+ `GET /runs/:id/events` when streaming) | allowlist                  |
 | `run_collection_smoke` | execute  | `GET /requests?…` + `POST /compose` + `POST /execute` (×N) | allowlist per host |
+| `run_collection`       | execute  | `GET /requests?…` (+ `GET /collections` when recursive) + `POST /compose` (×N) + `POST /runs` | allowlist on **every** step - one step off it refuses the whole run |
 | `create_collection`    | write    | `POST /collections`                          | write toggle               |
 | `update_collection`    | write    | `PUT /collections/:id` (merge-patch)         | write toggle               |
 | `delete_collection`    | write    | `GET /collections` + `GET /requests?…` (×N) + `DELETE /collections/:id` | write toggle + confirm |
@@ -166,7 +167,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `delete_request`       | write    | `GET /requests/:id` + `DELETE /requests/:id` | write toggle + confirm     |
 | `update_environment`   | write    | `GET /environments` (scan) + `PUT /environments/:id` (fetch-merge) | write toggle |
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
-| `start_load_run`       | load     | `POST /compose` + `POST /runs`               | allowlist + caps + confirm; optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity` |
+| `start_load_run`       | load     | `POST /compose` + `POST /runs`, or (with `scenario`) `GET /requests?…` + `POST /compose` (×N) + `POST /runs` | allowlist + caps + confirm; optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity`, narrowed to the middle three for a scenario |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
 | `start_mock_issuer`    | execute  | `POST /mock-issuer/start`                    | - (loopback-only listener, so no allowlist entry applies); limits are the engine's - 31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent issuers |
 | `list_mock_issuers`    | read     | `GET /mock-issuer`                           | -                          |
@@ -456,8 +457,10 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   allowlist gate reads the composed URL as always - a `{{data.*}}` in
   the *path* leaves the host knowable and is judged on that host, while a
   template in the authority is still "unknown host" and denied.
-  `run_collection_smoke` stays out of it: it has no scenario path at all, so
-  there is no row for it to bind.
+  `run_collection_smoke` stays out of it: it runs each request on its own, with
+  no sequence to iterate, so there is no row for it to bind. A whole *data set*
+  - many rows, one pass each - is the scenario tools' argument instead
+  (`run_collection` and `start_load_run`'s `scenario.data`, below).
 - **Protocol** - `run_request` and `start_load_run` both take an optional
   `httpVersion` Zod-enum arg (`"auto" | "http1.1" | "http2"`, default `"auto"`),
   mirroring the request builder's Settings-tab picker. `run_collection_smoke`
@@ -502,13 +505,51 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   has no such hook - so the composed `preRequestScripts` are stripped from the
   payload and the count of dropped scripts is reported in the tool's result
   rather than passing silently.
-- **Scenario runs are out of scope** - `start_load_run` loads a *single* target
-  (a URL, or one saved request). A scenario load run - a collection's ordered
-  sequence of requests, driven as one run - is started from the app's **Run
-  Collection** dialog only; no MCP tool starts one, and `collectionId` here
-  scopes variable resolution rather than naming a sequence to run. The tool's
-  own description says so, because a tool list that is silent about scenarios
-  reads as "scenarios do not exist" rather than "not from here".
+- **Scenario runs - a collection as the unit of work** (issue #754, reversing
+  #454's deferral). A collection's ordered sequence of requests can be run from
+  MCP in both of the engine's modes, over the one `POST /runs` route that takes
+  a `scenario` block:
+  - `run_collection` posts the block with **no** `mode`, which is what selects
+    the design-mode runner: steps execute one at a time, share the environment's
+    cookie jar, honour `pm.execution` flow control, run their stored
+    **pre-request** scripts, and repeat once per `data` row with
+    `{{data.column}}` bound and `pm.iterationData` set. It returns the run id
+    immediately - the run continues engine-side - along with the plan's step
+    count and the note that `get_run_report`'s `results` carries **at most 100**
+    step rows.
+  - `start_load_run` takes the same block as an optional `scenario` argument
+    and posts it **with** a mode, which hands the plan to the load executor:
+    `concurrency` is the number of virtual users, each walking the whole plan
+    with its own cookies. Only `constant_concurrency` (the default), `ramp_up`
+    and `iterations` can drive a sequence - `capacity` and `constant_rps` are
+    refused with the engine's own reasoning (a knee measured against which
+    step's p99? an arrival-rate executor Vayu does not implement), as is any
+    non-zero `targetRps`, which selects that path whatever the declared mode.
+  - The collection tree **is** the sequence: there is no step list to send, and
+    `recursive: true` walks sub-collections in the sidebar's order (each
+    subtree before that level's own requests, mirroring `collect_requests`).
+  - **Rows are inline** - the engine never opens a file - and its
+    `maxScenarioDataRows` / `maxScenarioDataBytes` refusals are surfaced
+    verbatim rather than re-derived in the schema.
+  - `scenario.iterations` is offered on `run_collection` only. A load run reads
+    the **top-level** `iterations` (total passes across all virtual users); the
+    in-block count is the design runner's and the load executor never reads it,
+    so offering it there would be an argument written and never read.
+  - **The allowlist gate is all-or-nothing here**, unlike the smoke matrix's
+    per-request skip: every step is composed by id and gated before the run is
+    created, and one step the allowlist does not cover refuses the whole run
+    with nothing sent, naming the step the way the engine names it
+    (`step 1 (request 'checkout', id 'r2')`). A step that will not compose
+    refuses it too - the engine resolves the same plan before creating the run
+    row and would refuse it for the same reason.
+  - Every argument that describes a *single* target (`url`, `requestId`,
+    `method`, `headers`, `body`, `auth`, `httpVersion`, `postRequestScript`,
+    `collectionId`) is **refused by name** beside a `scenario`, as are
+    `maxInFlight` (in-flight is bounded by the virtual-user count),
+    `sloMs`/`stepDuration` (capacity's own fields) and `stream` and its two caps
+    (run-level stream bounds are attached to a single-target run's request
+    only). Each would otherwise be an argument an agent believes shaped the run
+    that nothing on this path reads.
 - **Request mutation** - a pre-request script's `pm.request` edits (url, method,
   headers, body) are applied to the request that is sent, so an agent can sign a
   request or override the engine-applied auth from `run_request`, and a saved
@@ -534,8 +575,11 @@ MCP a jar of its own would make the same saved request behave differently for
 an agent than in the UI - a surprise in the harder direction to debug. The
 state stays visible and resettable: Settings → General → Cookies lists every
 jar and clears it, and `GET /cookies` reports the same. An agent that must not
-inherit a session should run in an environment of its own. `start_load_run` is
-unaffected - load runs never touch the jar.
+inherit a session should run in an environment of its own. `run_collection`
+shares the jar too - the design-mode runner is the one executor handed it, which
+is what lets a login step authenticate the steps after it. `start_load_run` is
+unaffected either way: a single-target load run never touches the jar, and a
+scenario load run gives each virtual user cookies of its own.
 
 > **History.** Until issue #226 MCP carried `resolve.ts` - a full main-process
 > port of the renderer's composition pipeline - because the engine composed


### PR DESCRIPTION
## Description

**Plan.** Root cause: the engine has taken a `scenario` block on `POST /runs` since #357 and the Run Collection dialog uses it daily, but the MCP layer stopped at `run_collection_smoke` - #454 scoped scenario runs out with a sentence in the tool description. Nothing engine-side is missing, so the fix is entirely MCP-layer plumbing: a new `run_collection` tool posting the block with **no** `mode` (which is what selects the design-mode runner) and an optional `scenario` argument on `start_load_run` posting it **with** one (virtual users). The alternative I rejected was a single tool with a `loadTest` flag: the two shapes accept disjoint argument sets - a design run reads `scenario.iterations` and no load fields, a load run reads `concurrency`/`duration` and never reads `scenario.iterations` - so one schema would have had to accept every field and refuse most of them per branch, which is exactly the "argument written and never read" shape the repo keeps finding. Verified against master before writing: the engine files the issue anchors to are unchanged, and `POST /compose` by id is the same call `resolve_scenario` makes per step, which is what makes the pre-flight gate read the URL the run would actually send to.

Both tools carry the pre-flight walk the issue specifies: list the collection's requests (recursive when asked), compose each by id, gate the resolved URL. Unlike the smoke matrix, which skips one request and runs the rest, a scenario is one run - so a single un-allowlisted step refuses the whole run with nothing sent, naming the step the way the engine names it (`step 1 (request 'checkout', id 'r2')`). The recursive walk mirrors `collect_requests` - each subtree before that level's own requests, same cycle guard - so the step it names is the step the run would have reached first.

Every argument that describes a *single* target (`url`, `requestId`, `method`, `headers`, `body`, `auth`, `httpVersion`, `postRequestScript`, `collectionId`) is refused **by name** beside a `scenario`, as are `maxInFlight`, `sloMs`/`stepDuration` and `stream` with its two caps. Each was traced to the engine first: `maxInFlight` is warned about and ignored in `scenario_load.cpp`, `sloMs`/`stepDuration` belong to `capacity` (which a scenario cannot use), and `request.stream_bounds` is attached inside `if (!context->scenario)` in `run_manager.cpp`. Silently forwarding them would be the codebase's most-repeated defect arriving through the front door.

**One deliberate deviation from the issue spec.** The issue lists `iterations` inside `start_load_run`'s scenario block; it is not there. A scenario *load* run reads the **top-level** `iterations` (`scenario_load.cpp:251`, `config.value("iterations", 1000)`), while `scenario.iterations` is the design runner's per-run pass count that the load executor never reads - so offering it there would be an argument an agent believes bounds the run that nothing looks at. `run_collection` offers it, the top-level one is unchanged for iterations mode, and both are documented.

**Deferred, filed rather than dropped:** `failOnSchemaError` (the contract-as-gate flag the Run Collection dialog exposes for design-mode runs) is outside this issue's stated input list, so `run_collection` does not take it and the engine's default (off) applies. Filed as #766 with its sequencing.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only change (no engine source touched), so the verification is the app half of the issue's stated commands:

- `pnpm test` - **5216 passed, 498 files**, of which `electron/mcp/tools.test.ts` is 178 (23 new). New coverage: scenario payload forwarded intact (rows, recursion, iterations); design mode sends no `mode`; iterations/data omitted so the engine keeps its own defaults; first un-allowlisted step refuses the run with nothing started and the walk stopping there; a step that will not compose refuses it; recursive order matches the engine; a `parentId` cycle terminates; run id returned with plan size and the 100-row report bound; the engine's own 400 surfaced verbatim; mutual-exclusion refusals across nine single-target fields; capacity/constant_rps/targetRps refusals carrying the engine's reasoning; caps applied to VUs, duration and iterations; capped duration injected when omitted; preview-then-confirm and declined elicitation both starting nothing; the scenario block offering no `iterations` of its own.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean (only files touched here were formatted).
- Mutation-checked the two subtlest guards: reversing the walk's emit order fails the ordering test (`['root_a','child_a','grand_a']` vs expected), and stubbing the allowlist gate to always-pass fails the refusal test. Both restored.
- `data-changed.test.ts`'s registry guard needed `run_collection: ["run", "cookie"]` added - that is the guard working as designed (the design-mode runner is the one executor handed the cookie jar).
- `mkdocs build --strict` not run: mkdocs is not installed in this environment. The docs change adds no page, link or heading - one table row and prose inside existing sections.
- No pre-existing failures observed on this base.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/mcp.md` (tool table row, `start_load_run`'s route/mode cell, the scenario section that said this could not be started from MCP, the data-rows note, the cookie-jar paragraph - `run_collection` shares the jar, a scenario load run gives each VU its own), plus the traffic-sending tool enumerations in `SECURITY.md` and `config.ts`'s `allowWrites` comment.

## Related Issues
Closes #754 · part of epic #753 (S1, landing before #760, which also edits `start_load_run`'s schema) · defers #766