### PR TITLE
fix(app/mcp): bound the response bodies run_request and get_run_report return

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -1574,6 +1574,68 @@ describe("inline body bounds", () => {
 		expect(await runReport(reported(report))).toEqual(report);
 	});
 
+	/**
+	 * The scenario shape, pinned ahead of `run_collection` (#754 / PR #765).
+	 *
+	 * A scenario step is written through the same pair a single `/execute` uses
+	 * - `build_result_trace` then `cap_trace_bodies`
+	 * (`scenario_runner.cpp:678-689`) - into the same `results.trace_data`
+	 * column (`scenario_runner.cpp:715`) that `/runs/:id/report` parses back
+	 * into `results[].trace`. So one scenario report carries one such trace per
+	 * step, up to the report route's 100-row cap, instead of the single trace
+	 * reproduced in #767. This fixture is that shape: step identity stamped on
+	 * the trace beside the nodes, and a skipped step whose `response` the
+	 * runner erased.
+	 */
+	test("a scenario report is bounded per step, skipped steps included", async () => {
+		const out = await runReport(
+			reported({
+				summary: {},
+				scenario: { iterations: 1, steps: [{ index: 0, name: "login", executed: 1 }] },
+				results: [
+					{
+						id: 1,
+						trace: {
+							iteration: 0,
+							stepIndex: 0,
+							stepName: "login",
+							outcome: "passed",
+							request: { url: "u" },
+							response: { body: huge },
+						},
+					},
+					{
+						id: 2,
+						trace: {
+							iteration: 0,
+							stepIndex: 1,
+							stepName: "checkout",
+							outcome: "skipped",
+							// No `response` node at all: the runner erases it for a
+							// step that never sent.
+							request: { body: huge },
+						},
+					},
+				],
+			})
+		);
+
+		const rows = out.results as Array<Row & { trace: Record<string, unknown> }>;
+		expect(Buffer.byteLength(rows[0].trace.response!.body as string, "utf8")).toBe(
+			MAX_INLINE_BODY_BYTES
+		);
+		expect(rows[0].trace.response!.bodyBytes).toBe(huge.length);
+		// Identity survives the rebuild - the step list reads these.
+		expect(rows[0].trace.stepName).toBe("login");
+		// The skipped step's request is bounded, and no empty `response` is
+		// invented for it: an erased node must stay erased, or the step's
+		// expanded view reads as a server that answered with nothing.
+		expect(Buffer.byteLength(rows[1].trace.request!.body as string, "utf8")).toBe(
+			MAX_INLINE_BODY_BYTES
+		);
+		expect(rows[1].trace).not.toHaveProperty("response");
+	});
+
 	test("both tool descriptions state the bound", () => {
 		for (const name of ["run_request", "get_run_report"]) {
 			const description = TOOLS.find((t) => t.name === name)!.description;

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import {
 	dispatchTool,
 	MAX_IN_FLIGHT_BOUND,
+	MAX_INLINE_BODY_BYTES,
 	toolCatalog,
 	TOOLS,
 	type ToolContext,
@@ -1361,6 +1362,227 @@ describe("get_live_metrics limit", () => {
  * schema being broken - hiding the body. So every 200 the engine can answer
  * with must produce a result the schema accepts.
  */
+/**
+ * Inline body bounds (issue #767).
+ *
+ * `run_request` and `get_run_report` were raw passthroughs, and an ordinary
+ * page fetch came back as 1.3M characters - over the tool-result token limit,
+ * so the agent got an error instead of a response. The bound lives here rather
+ * than in the engine: full fidelity is right for a person clicking Send, and
+ * what is being violated is specific to a result feeding a context window.
+ */
+describe("inline body bounds", () => {
+	const allow = { allowlist: ["api.example.com"] };
+	const huge = "x".repeat(MAX_INLINE_BODY_BYTES + 5_000);
+
+	/** A `/execute` answer in the shape `serialize(Response)` emits. */
+	function executeAnswer(over: Record<string, unknown>) {
+		return {
+			status: 200,
+			statusText: "OK",
+			headers: { "content-type": "application/json" },
+			requestHeaders: {},
+			bodySize: 128,
+			httpVersion: "2",
+			httpVersionDowngraded: false,
+			body: null,
+			bodyRaw: "",
+			timing: { totalMs: 12 },
+			...over,
+		};
+	}
+
+	function executed(answer: Record<string, unknown>) {
+		return fakeClient({ executeRequest: vi.fn().mockResolvedValue(answer) });
+	}
+
+	async function runRequest(client: EngineClient) {
+		const res = await dispatchTool(
+			"run_request",
+			{ url: "https://api.example.com/x" },
+			ctxWith(client, allow)
+		);
+		expect(res.isError).toBeFalsy();
+		return JSON.parse(firstText(res)) as Record<string, unknown>;
+	}
+
+	test("run_request cuts an oversized body and states its real size", async () => {
+		const answer = executeAnswer({ bodyRaw: huge, bodySize: huge.length });
+		const out = await runRequest(executed(answer));
+
+		expect(Buffer.byteLength(out.bodyRaw as string, "utf8")).toBe(MAX_INLINE_BODY_BYTES);
+		expect(out.bodyTruncated).toBe(true);
+		// The engine's own count, not the size of the slice we kept - the whole
+		// point of the flag is to say how much was not sent.
+		expect(out.bodySize).toBe(huge.length);
+	});
+
+	test("run_request leaves a body under the bound byte-for-byte", async () => {
+		const small = JSON.stringify({ userId: 1, id: 5, completed: false });
+		const answer = executeAnswer({
+			body: { userId: 1, id: 5, completed: false },
+			bodyRaw: small,
+			bodySize: small.length,
+		});
+		const out = await runRequest(executed(answer));
+
+		// Exact equality, not a subset: over-truncating an ordinary small
+		// response would be its own regression, and so would a stray flag.
+		expect(out).toEqual(answer);
+		expect(out).not.toHaveProperty("bodyTruncated");
+	});
+
+	test("run_request nulls the parsed body once bodyRaw has been cut", async () => {
+		const payload = {
+			items: Array.from({ length: 4_000 }, (_, i) => ({ i, pad: "xxxxxxxx" })),
+		};
+		const raw = JSON.stringify(payload);
+		expect(raw.length).toBeGreaterThan(MAX_INLINE_BODY_BYTES);
+		const out = await runRequest(
+			executed(executeAnswer({ body: payload, bodyRaw: raw, bodySize: raw.length }))
+		);
+
+		// The doubling case: `body` and `bodyRaw` carry the same payload, so a
+		// cut bodyRaw beside an intact parsed body would hand back in full the
+		// bytes it just claimed to have dropped.
+		expect(out.body).toBeNull();
+		expect(out.bodyTruncated).toBe(true);
+	});
+
+	test("run_request cuts a large rawRequest but keeps its headers whole", async () => {
+		const head = "POST /x HTTP/2\r\nHost: api.example.com\r\nCookie: session=abc\r\n\r\n";
+		const out = await runRequest(executed(executeAnswer({ rawRequest: head + huge })));
+
+		const raw = out.rawRequest as string;
+		expect(raw.startsWith(head)).toBe(true);
+		expect(raw).toContain("Cookie: session=abc");
+		expect(Buffer.byteLength(raw, "utf8")).toBe(head.length + MAX_INLINE_BODY_BYTES);
+		expect(out.rawRequestTruncated).toBe(true);
+		expect(out.rawRequestBytes).toBe(head.length + huge.length);
+	});
+
+	test("run_request does not touch a headers-only rawRequest", async () => {
+		const answer = executeAnswer({ rawRequest: "GET /x HTTP/2\r\nHost: api.example.com\r\n" });
+		expect(await runRequest(executed(answer))).toEqual(answer);
+	});
+
+	test("the cut never splits a multi-byte character", async () => {
+		// Two-byte characters against a bound that is not a multiple of two:
+		// a naive byte slice would end mid-character and decode to U+FFFD.
+		const out = await runRequest(
+			executed(executeAnswer({ bodyRaw: "é".repeat(MAX_INLINE_BODY_BYTES) }))
+		);
+		expect(out.bodyRaw as string).not.toContain("�");
+		expect(Buffer.byteLength(out.bodyRaw as string, "utf8")).toBeLessThanOrEqual(
+			MAX_INLINE_BODY_BYTES
+		);
+	});
+
+	function reported(report: Record<string, unknown>) {
+		return fakeClient({ getRunReport: vi.fn().mockResolvedValue(report) });
+	}
+
+	async function runReport(client: EngineClient) {
+		const res = await dispatchTool("get_run_report", { runId: "run_1" }, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		return JSON.parse(firstText(res)) as Record<string, unknown>;
+	}
+
+	type Row = {
+		trace?: { request?: Record<string, unknown>; response?: Record<string, unknown> };
+	};
+
+	test("get_run_report cuts a stored trace body on every row", async () => {
+		const out = await runReport(
+			reported({
+				summary: {},
+				results: [
+					{ id: 1, trace: { request: { url: "u" }, response: { body: huge } } },
+					{ id: 2, trace: { request: { url: "u" }, response: { body: huge } } },
+				],
+			})
+		);
+
+		// Per row, not just the first: a scenario run carries one trace per step
+		// (up to 100 in a report), which is what multiplies this defect.
+		for (const row of out.results as Row[]) {
+			const response = row.trace!.response!;
+			expect(Buffer.byteLength(response.body as string, "utf8")).toBe(MAX_INLINE_BODY_BYTES);
+			expect(response.bodyTruncated).toBe(true);
+			expect(response.bodyBytes).toBe(huge.length);
+		}
+	});
+
+	test("get_run_report keeps the engine's own bodyBytes when it already truncated", async () => {
+		const out = await runReport(
+			reported({
+				results: [
+					{
+						id: 1,
+						trace: {
+							// What a trace the engine cut at maxTraceBodyBytes looks
+							// like: a 5MB slice that records the true original size.
+							response: { body: huge, bodyTruncated: true, bodyBytes: 40_000_000 },
+						},
+					},
+				],
+			})
+		);
+
+		const response = (out.results as Row[])[0].trace!.response!;
+		expect(response.bodyBytes).toBe(40_000_000);
+	});
+
+	test("get_run_report bounds the request side too", async () => {
+		const head = "POST /x HTTP/2\r\nHost: api.example.com\r\n\r\n";
+		const out = await runReport(
+			reported({
+				results: [{ id: 1, trace: { request: { body: huge, rawRequest: head + huge } } }],
+			})
+		);
+
+		const request = (out.results as Row[])[0].trace!.request!;
+		expect(Buffer.byteLength(request.body as string, "utf8")).toBe(MAX_INLINE_BODY_BYTES);
+		expect(request.bodyTruncated).toBe(true);
+		expect(Buffer.byteLength(request.rawRequest as string, "utf8")).toBe(
+			head.length + MAX_INLINE_BODY_BYTES
+		);
+		expect(request.rawRequestTruncated).toBe(true);
+	});
+
+	test("a load-mode report passes through untouched", async () => {
+		// A load run's results never go through build_result_trace, so they
+		// carry no trace node - exact equality proves the walk added nothing.
+		const report = {
+			summary: { totalRequests: 5_000 },
+			latency: { p95: 12 },
+			results: [
+				{ id: 1, statusCode: 200, latencyMs: 4 },
+				{ id: 2, statusCode: 500, latencyMs: 9, error: "timeout" },
+			],
+		};
+		expect(await runReport(reported(report))).toEqual(report);
+	});
+
+	test("a design report under the bound passes through untouched", async () => {
+		const report = {
+			summary: {},
+			results: [
+				{ id: 1, trace: { request: { url: "u" }, response: { body: '{"ok":true}' } } },
+			],
+		};
+		expect(await runReport(reported(report))).toEqual(report);
+	});
+
+	test("both tool descriptions state the bound", () => {
+		for (const name of ["run_request", "get_run_report"]) {
+			const description = TOOLS.find((t) => t.name === name)!.description;
+			expect(description).toContain(String(MAX_INLINE_BODY_BYTES));
+			expect(description).toMatch(/bodyTruncated/);
+		}
+	});
+});
+
 describe("get_engine_health output always satisfies its own schema", () => {
 	const healthSchema = () => TOOLS.find((t) => t.name === "get_engine_health")!.outputSchema!;
 

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -176,6 +176,175 @@ function jsonResult(value: unknown): ToolResult {
 	return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
 }
 
+// --- Inline body bounds ------------------------------------------------------
+
+/**
+ * How much of a body a tool result carries inline (issue #767).
+ *
+ * A tool-result budget, not an engine one. Neither engine cap fits: the config
+ * entry that bounds a single response, `maxResponseBodyBytes`, documents itself
+ * as load-only ("Design-mode sends are not affected"), and `maxTraceBodyBytes`
+ * (5MB) is a storage bound sized for a human opening one full trace in the UI.
+ * Between them a design send returns every byte it read - an ordinary page
+ * fetch came back as 1.3M characters and exceeded the tool-result token limit
+ * outright, with nothing in between the engine's answer and the agent.
+ *
+ * 32KB is not a new number: it is `maxSampleBodyBytes`
+ * (`DEFAULT_MAX_SAMPLE_BODY_BYTES`, engine `constants.hpp`), this codebase's own
+ * answer to "how much of a body does an automated reader get" for load-run
+ * captures. Fixed rather than read from live config: `run_request` has just
+ * sent a real request and should not pay a second round trip for a number that
+ * only has to be reasonable, and a constant is what the tests can pin.
+ */
+export const MAX_INLINE_BODY_BYTES = 32_768;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Cut a string to at most `maxBytes` UTF-8 bytes, reporting its true size.
+ *
+ * The cut steps back off a continuation byte rather than landing mid-character:
+ * a split code point comes back as a replacement glyph, which an agent reads as
+ * content the response never carried.
+ */
+function boundText(
+	text: string,
+	maxBytes = MAX_INLINE_BODY_BYTES
+): { text: string; truncated: boolean; bytes: number } {
+	const buf = Buffer.from(text, "utf8");
+	if (buf.byteLength <= maxBytes) return { text, truncated: false, bytes: buf.byteLength };
+	let end = maxBytes;
+	while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+	return { text: buf.subarray(0, end).toString("utf8"), truncated: true, bytes: buf.byteLength };
+}
+
+const HEADER_BODY_SEPARATOR = "\r\n\r\n";
+
+/**
+ * Bound a node's `rawRequest` wire message, cutting the body half only.
+ *
+ * The engine's rule for this field, kept rather than re-decided
+ * (`cap_node_raw_request`, `engine/src/utils/json.cpp`): the header block is the
+ * reason the field exists - it carries the `Cookie` line libcurl attached, which
+ * appears nowhere else - so a cut that ate the headers would take exactly what
+ * the reader opened it for. A message with no blank line has no body to cut.
+ *
+ * Unlike the engine, this records the cut explicitly. The engine can lean on the
+ * `bodyTruncated` pair beside it because both are capped at one limit at write
+ * time; a tool result has to say so on its own, since the field an agent reads
+ * here sits beside the *response*'s size fields, not the request body's.
+ *
+ * Returns the node unchanged (same reference) when nothing was cut, so callers
+ * can tell "bounded" from "untouched" without re-comparing content.
+ */
+function boundWireMessage(node: Record<string, unknown>): Record<string, unknown> {
+	const raw = node.rawRequest;
+	if (typeof raw !== "string") return node;
+	const separator = raw.indexOf(HEADER_BODY_SEPARATOR);
+	if (separator === -1) return node;
+	const bodyStart = separator + HEADER_BODY_SEPARATOR.length;
+	const bounded = boundText(raw.slice(bodyStart));
+	if (!bounded.truncated) return node;
+	return {
+		...node,
+		rawRequest: raw.slice(0, bodyStart) + bounded.text,
+		rawRequestTruncated: true,
+		rawRequestBytes: Buffer.byteLength(raw, "utf8"),
+	};
+}
+
+/**
+ * Bound one `POST /execute` response - what `run_request` hands back.
+ *
+ * `bodySize` is the engine's own byte count for this body and is exactly what a
+ * truncation flag refers to, so it is used rather than recomputed; it is only
+ * filled in when the engine sent no usable one.
+ */
+function boundExecuteResponse(value: unknown): unknown {
+	if (!isRecord(value)) return value;
+	let out = value;
+	const bodyRaw = value.bodyRaw;
+	if (typeof bodyRaw === "string") {
+		const bounded = boundText(bodyRaw);
+		if (bounded.truncated) {
+			out = {
+				...out,
+				bodyRaw: bounded.text,
+				// The parsed body holds the same payload verbatim, so leaving it
+				// would hand back in full the very bytes `bodyRaw` now says were
+				// cut - the JSON-doubling case. Null rather than deleted:
+				// `serialize(Response)` always emits this key, and null is already
+				// its "nothing parsed here" value, so a truncated response keeps
+				// the shape every reader of this tool already parses.
+				body: null,
+				bodyTruncated: true,
+				...(typeof value.bodySize === "number" ? {} : { bodySize: bounded.bytes }),
+			};
+		}
+	}
+	return boundWireMessage(out);
+}
+
+/**
+ * Bound one stored-trace node (`trace.request` or `trace.response`).
+ *
+ * Mirrors the engine's own disclosure pair for a cut body
+ * (`cap_node_body`): `bodyTruncated` plus `bodyBytes` holding the *original*
+ * size, so an agent that has read one convention recognises the other.
+ */
+function boundTraceNode(node: unknown): unknown {
+	if (!isRecord(node)) return node;
+	let out = node;
+	const body = node.body;
+	if (typeof body === "string") {
+		const bounded = boundText(body);
+		if (bounded.truncated) {
+			out = {
+				...out,
+				body: bounded.text,
+				bodyTruncated: true,
+				// Only when the engine recorded none. A trace it already cut at
+				// `maxTraceBodyBytes` carries the true original size here, and
+				// overwriting that with the size of the 5MB slice we re-cut would
+				// replace a real number with a smaller one that looks just as real.
+				...(typeof node.bodyBytes === "number" ? {} : { bodyBytes: bounded.bytes }),
+			};
+		}
+	}
+	return boundWireMessage(out);
+}
+
+/**
+ * Bound the stored traces in a run report - what `get_run_report` hands back.
+ *
+ * Design and scenario rows only: a load run's results never go through
+ * `build_result_trace` (it is called from `record_design_result` and the
+ * scenario runner, never the load hot path), so they carry no `trace` node and
+ * the walk leaves them untouched. Rebuilt rather than mutated so a report with
+ * nothing over the bound comes back as the object the engine returned.
+ */
+function boundRunReport(value: unknown): unknown {
+	if (!isRecord(value) || !Array.isArray(value.results)) return value;
+	let changed = false;
+	const results = value.results.map((row) => {
+		if (!isRecord(row) || !isRecord(row.trace)) return row;
+		const trace = row.trace;
+		const next: Record<string, unknown> = { ...trace };
+		let rowChanged = false;
+		for (const key of ["request", "response"] as const) {
+			if (!(key in trace)) continue;
+			next[key] = boundTraceNode(trace[key]);
+			if (next[key] !== trace[key]) rowChanged = true;
+		}
+		if (!rowChanged) return row;
+		changed = true;
+		return { ...row, trace: next };
+	});
+	return changed ? { ...value, results } : value;
+}
+
 /** Result that carries both a text rendering and structured content. */
 function structuredResult(value: Record<string, unknown>): ToolResult {
 	return {
@@ -235,10 +404,19 @@ function engineErrorResult(err: unknown): ToolResult {
 	return errorResult(`Unexpected error: ${msg}`);
 }
 
-/** Wrap an engine call so transport errors surface as tool errors, not crashes. */
-async function callEngine(fn: () => Promise<unknown>): Promise<ToolResult> {
+/**
+ * Wrap an engine call so transport errors surface as tool errors, not crashes.
+ *
+ * `shape` runs on the engine's answer before it becomes a result - the one seam
+ * where a passthrough tool can bound what it hands an agent (issue #767).
+ */
+async function callEngine(
+	fn: () => Promise<unknown>,
+	shape?: (value: unknown) => unknown
+): Promise<ToolResult> {
 	try {
-		return jsonResult(await fn());
+		const answer = await fn();
+		return jsonResult(shape ? shape(answer) : answer);
 	} catch (err) {
 		return engineErrorResult(err);
 	}
@@ -1352,7 +1530,8 @@ export const TOOLS: McpTool[] = [
 		invalidates: [],
 		description:
 			"Get the full report for a completed run: summary, latency percentiles (p50/p95/p99), status codes, errors, and timing breakdown. Ideal input for analyzing performance. " +
-			"A run of a collection bound to an OpenAPI document also carries `coverage`: which of the contract's operations the run exercised, which of their declared responses it saw, and any statuses the document never declared. Absent - never zeros - for a run that was not measured against a contract.",
+			"A run of a collection bound to an OpenAPI document also carries `coverage`: which of the contract's operations the run exercised, which of their declared responses it saw, and any statuses the document never declared. Absent - never zeros - for a run that was not measured against a contract. " +
+			`Stored bodies on each row's trace (request and response) are capped at ${MAX_INLINE_BODY_BYTES} bytes for this result: a capped one carries \`bodyTruncated: true\` beside \`bodyBytes\`, the full size, and a capped \`rawRequest\` carries \`rawRequestTruncated\`. A body in full is still available in the Vayu app's own run history.`,
 		annotations: {
 			title: "Get run report",
 			readOnlyHint: true,
@@ -1361,7 +1540,10 @@ export const TOOLS: McpTool[] = [
 		},
 		inputSchema: { runId: z.string().describe("Run ID to fetch.") },
 		handler: (args, ctx, signal) =>
-			callEngine(() => ctx.client.getRunReport(requireStr(args, "runId"), signal)),
+			callEngine(
+				() => ctx.client.getRunReport(requireStr(args, "runId"), signal),
+				boundRunReport
+			),
 	},
 	{
 		name: "get_engine_config",
@@ -1383,7 +1565,8 @@ export const TOOLS: McpTool[] = [
 		category: "execute",
 		invalidates: ["run", "cookie"],
 		description:
-			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app (environment > collection chain > globals). Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.)",
+			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app (environment > collection chain > globals). Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.) " +
+			`The response body is capped at ${MAX_INLINE_BODY_BYTES} bytes in this result: over that, \`bodyRaw\` holds the first ${MAX_INLINE_BODY_BYTES} bytes, \`bodyTruncated\` is true, \`bodySize\` is the real size, and the parsed \`body\` is null rather than a full copy of what was cut. A large \`rawRequest\` is capped the same way (headers kept whole) and flagged with \`rawRequestTruncated\`.`,
 		annotations: {
 			title: "Send a request",
 			readOnlyHint: false,
@@ -1479,7 +1662,10 @@ export const TOOLS: McpTool[] = [
 			const streaming = args.stream === true;
 			payload.stream = streaming;
 			if (!streaming) {
-				return callEngine(() => ctx.client.executeRequest(payload, signal));
+				return callEngine(
+					() => ctx.client.executeRequest(payload, signal),
+					boundExecuteResponse
+				);
 			}
 			return runStreamingRequest(args, payload, ctx, signal);
 		},

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -152,11 +152,11 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `list_requests`        | read     | `GET /requests?collectionId=`                | -                          |
 | `list_environments`    | read     | `GET /environments`                          | -                          |
 | `list_runs`            | read     | `GET /runs?limit=100`                        | First page (100) of the `{data, pagination}` envelope; rows carry a compact summary |
-| `get_run_report`       | read     | `GET /runs/:id/report`                       | -                          |
+| `get_run_report`       | read     | `GET /runs/:id/report`                       | Stored trace bodies capped at 32 KB per node |
 | `get_engine_config`    | read     | `GET /config`                                | -                          |
 | `get_live_metrics`     | read     | SSE snapshot of last N ticks                 | `limit` must be a whole number ≥ 1 |
 | `compare_runs`         | read     | 2× `GET /runs/:id/report` → diff (structured)| `baseRunId` optional - omitted, it resolves the target's pinned baseline |
-| `run_request`          | execute  | `POST /compose` + `POST /execute` (+ `GET /runs/:id/events` when streaming) | allowlist                  |
+| `run_request`          | execute  | `POST /compose` + `POST /execute` (+ `GET /runs/:id/events` when streaming) | allowlist; response body capped at 32 KB |
 | `run_collection_smoke` | execute  | `GET /requests?…` + `POST /compose` + `POST /execute` (×N) | allowlist per host |
 | `create_collection`    | write    | `POST /collections`                          | write toggle               |
 | `update_collection`    | write    | `PUT /collections/:id` (merge-patch)         | write toggle               |
@@ -192,6 +192,27 @@ Notes:
   adds nothing. Absent, never zeros, for a run that was not measured against a
   contract, so an agent must branch on the key's presence rather than reading a
   zero as full non-coverage.
+- **Bodies are bounded before they reach an agent** (issue #767). `run_request`
+  and `get_run_report` were raw passthroughs, and neither engine cap covers this
+  case: `maxResponseBodyBytes` bounds load runs only ("Design-mode sends are not
+  affected") and `maxTraceBodyBytes` is 5 MB, sized for the database and a human
+  reading one full trace. So a single ordinary page fetch answered with 1.3 M
+  characters and blew the tool-result token limit outright. Both tools now cap a
+  body at **32 KB** - `maxSampleBodyBytes`, the engine's own answer to how much
+  of a body an automated reader gets, rather than a new number. What a cut looks
+  like, in the engine's existing vocabulary (`cap_node_body`,
+  `run_samples_response`): `bodyTruncated: true` beside the full size, in
+  `bodySize` on a `run_request` response and `bodyBytes` on a stored trace node,
+  and `rawRequestTruncated` / `rawRequestBytes` for a cut wire message - whose
+  headers are always kept whole, since the `Cookie` line libcurl attached
+  appears nowhere else. A cut `bodyRaw` comes back with its parsed `body` as
+  `null`, because the two carry the same payload and an intact `body` would
+  return in full exactly what was just dropped. A trace the engine had already
+  truncated keeps the original size the engine recorded. Under the bound,
+  nothing is added and nothing is changed. Load-run reports are unaffected: a
+  load run's results never go through `build_result_trace`, so they carry no
+  trace node at all, and its captured bodies live behind
+  `GET /runs/:id/samples`, which has always truncated and disclosed this way.
 - **`start_load_run`'s `stream` flag** consumes each response as a
   `text/event-stream` (issue #576), with `maxStreamDurationMs` and
   `maxStreamEvents` bounding one stream. Both caps are forwarded verbatim on the


### PR DESCRIPTION
## Description

**Plan.** Root cause: both tools are raw passthroughs (`callEngine` was `jsonResult(await fn())`, nothing between the engine's answer and the agent), and *neither* engine cap covers a tool result - `maxResponseBodyBytes` documents itself as load-only ("Design-mode sends are not affected") and `maxTraceBodyBytes` is 5MB, a storage bound sized for a human opening one full trace in the UI. Between them a design send returns every byte it read, which is how an ordinary page fetch became 1.3M characters and exceeded the token limit outright. The approach is one shaping seam at the MCP layer: `callEngine` takes an optional `shape` callback, and the two handlers pass a bounding function. The alternative I rejected was capping engine-side - the engine's full-fidelity capture is correct for its actual purpose (a person clicks Send and expects to see everything), and the constraint being violated is specific to an MCP result feeding a context window, which is how every other bounded MCP read (`get_live_metrics`, `list_runs`) already treats it. I also rejected reading `maxSampleBodyBytes` from live config per call: `run_request` has just sent a real HTTP request and should not pay a second round trip for a number that only has to be reasonable, and a constant is what the tests can pin.

Verified against master (`21e5eb1`) before writing: both handlers are still the passthroughs the issue anchors to, `serialize(const Response&)` still emits `bodyRaw` unconditionally with no cap, and `/runs/:id/report` still parses `result.trace_data` into `results[].trace` for up to 100 rows.

**The bound is 32KB** - `DEFAULT_MAX_SAMPLE_BODY_BYTES`, this codebase's own answer to "how much of a body does an automated reader get", not a new number. **The disclosure is the engine's existing vocabulary**, so an agent that has read one convention recognises the other:

- `bodyTruncated: true` beside the full size - `bodySize` on a `run_request` response (already present and already correct, so it is used rather than recomputed) and `bodyBytes` on a stored trace node, the pair `cap_node_body` and `run_samples_response` use.
- **A cut `bodyRaw` nulls the parsed `body`** rather than leaving it holding in full the bytes `bodyRaw` now says were dropped - the JSON-doubling case. Null rather than deleted: `serialize(Response)` always emits that key and `null` is already its "nothing parsed here" value, so a truncated response keeps the shape every reader already parses. (The issue asked for this choice to be stated.)
- **A cut wire message keeps its header block whole**, the engine's own rule for that field (`cap_node_raw_request` - the `Cookie` line libcurl attached appears nowhere else, so a cut that ate the headers would take exactly what the reader opened it for), and is flagged `rawRequestTruncated` / `rawRequestBytes`. Unlike the engine it carries its own marker, because in an `/execute` answer `rawRequest` sits beside the *response*'s size fields, not the request body's.
- **A trace the engine already truncated keeps the size the engine recorded.** Overwriting `bodyBytes` with the length of the 5MB slice re-cut here would replace a true number with a smaller one that looks just as real.
- **Under the bound nothing is added and nothing changes** - the report is rebuilt only when a row was actually cut, so an unaffected answer comes back as the object the engine returned.

Load-run reports are unaffected by routing, not by luck: their results never go through `build_result_trace` (called only from `record_design_result` and the scenario runner, never the load hot path), so they carry no `trace` node and the walk is a no-op. Their captured bodies live behind `GET /runs/:id/samples`, which has always truncated and disclosed correctly.

**One deliberate extension beyond the issue's spec.** Step 3 names `trace.response.body` and `trace.request.rawRequest`; this also bounds `trace.request.body`. It is the same node, the same defect and the same helper, and bounding a large POST body in the wire copy while leaving it whole in the field beside it would leave the context blowout open through the one field still uncapped.

**Not touched, as the issue asks:** `run_collection_smoke` (reads only status/testResults off each response), `compare_runs` (returns a derived delta, never raw bodies), and `run_request`'s streaming path (returns events under #575's bounds, not an exchange).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only change (`app/electron/mcp/` plus one doc), so the verification is the app half of the issue's stated commands:

- `pnpm test` - **5210 passed, 498 files**, of which `electron/mcp/tools.test.ts` is **172 (13 new)**. New coverage: an oversized body cut to exactly the bound with the engine's real `bodySize` preserved; a small response byte-for-byte identical to the fixture by exact equality (over-truncating an ordinary response would be its own regression); the JSON-doubling case nulling the parsed body; a large `rawRequest` cut with its `Cookie` header intact and both flags set; a headers-only `rawRequest` untouched; a multi-byte body cut without producing a replacement glyph; every row of a multi-row report bounded, not just the first (the scenario multiplier); the engine's original `bodyBytes` preserved; the request side (`body` and `rawRequest`) bounded; a load-mode report and an under-bound design report passing through by exact equality; both descriptions stating the bound.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean. Only the two TS files were formatted; `docs/engine/mcp.md` was already not prettier-clean on master and was deliberately left alone per the repo's "format only files you touched that were clean before" rule.
- **Mutation-checked** the two subtlest guards: deleting `body: null` reddens the JSON-doubling test, and replacing the `bodyBytes`-preservation guard with an unconditional overwrite reddens the already-truncated-trace test. Both restored and re-run green (172/172).
- Engine untouched, so no engine build or `ctest` run - no C++ source, test or CMake file is in the diff.
- `mkdocs build --strict` not run: mkdocs is not installed in this environment. The docs change adds no page, link or heading anchor - two table cells and one bullet inside an existing section.
- No pre-existing failures observed on this base.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

`docs/engine/mcp.md` in the same commit: the `run_request` and `get_run_report` tool-table rows now state their bound in the Gate column, beside `list_runs`' 100-row cap and `get_live_metrics`' tick bound, and a note records the bound, the flag names, what a cut looks like on each shape, and why this belongs at the MCP layer rather than the engine.

## Related Issues
Closes #767

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZokMjGaCAJxsbVHreLpxy)_