### PR TITLE
fix(app/titlebar): drag the window by the row's slack right of the search bar

### DIFF
--- a/app/src/components/layout/TitleBar.search-bar.test.tsx
+++ b/app/src/components/layout/TitleBar.search-bar.test.tsx
@@ -180,4 +180,34 @@ describe("title-row drag regions", () => {
 			).toBe("no-drag");
 		}
 	});
+
+	/**
+	 * The test above passes against the defect it is paired with: it reads
+	 * `effectiveRegion`, which a *cluster* opting out satisfies, so a wrapper
+	 * marked `no-drag` in its entirety looks identical to a control that opted
+	 * out on itself. The difference is everything the wrapper covers and the
+	 * control does not - here the whole third `1fr` column, i.e. the row's slack
+	 * right of the search bar, which is what the window is dragged by.
+	 *
+	 * So this asserts the wrapper's own inherited value instead, and the button's
+	 * own declaration rather than an inherited one.
+	 */
+	it("keeps the slack around the env switcher draggable, opting out only the control", async () => {
+		// Every platform: the right column holds the switcher alone on Windows and
+		// macOS and the HTML window buttons too on Linux, and the slack has to
+		// drag on all three.
+		for (const platform of ["win32", "darwin", "linux"]) {
+			await renderFor(platform);
+			const envButton = screen.getByRole("button", { name: /switch environment/i });
+			// `DropdownMenuTrigger asChild` renders the button in place, so its DOM
+			// parent is the row's right-hand wrapper, not a Radix-inserted node.
+			const wrapper = envButton.parentElement;
+			expect(wrapper, `no right-hand wrapper on ${platform}`).not.toBeNull();
+			expect(effectiveRegion(wrapper), `right column is dead on ${platform}`).toBe("drag");
+			expect(appRegion(envButton), `env switcher not clickable on ${platform}`).toBe(
+				"no-drag"
+			);
+			cleanup();
+		}
+	});
 });

--- a/app/src/components/layout/TitleBar.tsx
+++ b/app/src/components/layout/TitleBar.tsx
@@ -235,6 +235,11 @@ function EnvSwitcher() {
 								"bg-primary/10 text-primary-text border-primary/30 hover:bg-primary/20"
 							: "border-transparent text-muted-foreground hover:bg-accent hover:text-foreground"
 					)}
+					// Per-control opt-out, the pattern AppIcon and CommandSearchBar's
+					// trigger follow. `DropdownMenuTrigger asChild` renders this button
+					// in place with no wrapper node, so the declaration lands on the
+					// real element.
+					style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
 					aria-label="Switch environment"
 				>
 					<Cloud className="w-3 h-3 shrink-0" />
@@ -299,15 +304,22 @@ export default function TitleBar() {
 			    remaining area stays draggable. */}
 			<CommandSearchBar className="w-[min(44vw,28rem)]" />
 
-			{/* Right controls */}
+			{/* Right controls.
+			    No `no-drag` here: this wrapper is the whole third 1fr column, so
+			    opting it out would take the row's slack right of the search bar with
+			    it - the largest drag surface on this side. Each control opts out on
+			    itself instead (EnvSwitcher's trigger, WindowControls' own root), the
+			    way AppIcon and CommandSearchBar already do. */}
 			<div
 				className="flex min-w-0 items-center justify-end gap-2 px-3 h-full"
 				style={
 					{
-						WebkitAppRegion: "no-drag",
 						// Windows paints native min/max/close as an overlay on top of the
 						// web content in the top-right corner. Reserve its width (exposed by
 						// the Window Controls Overlay API) so the env switcher isn't covered.
+						// The strip stays a drag region: the overlay rectangle is hit-tested
+						// by the OS before the DOM sees it, so what the page declares under
+						// it does not apply there.
 						...(isWindows && {
 							paddingRight: "calc(100vw - env(titlebar-area-width, 100vw) + 0.5rem)",
 						}),


### PR DESCRIPTION
## Description

**Plan.** Root cause: the right-hand cluster opts out of the drag region on its **wrapper** (`TitleBar.tsx:303-315`) rather than on the control inside it, and that wrapper is the entire third `1fr` grid column (`grid-cols-[1fr_auto_1fr]`, laid out `justify-end`). Everything between the centred search bar and the right-aligned pill - the row's slack on that side, which looks like plain title-bar chrome - is therefore `no-drag` and cannot move the window. The approach is the per-control pattern the same file already uses three times over (`AppIcon:136`, `WindowControls:58`, `CommandSearchBar.tsx:43`): drop the wrapper's declaration so it inherits `drag` from the `<header>` the way column 1 does, and put `no-drag` on `EnvSwitcher`'s trigger button. The alternative I rejected was keeping the wrapper `no-drag` and adding a sibling drag spacer to fill the slack - that reintroduces the same dead strip whenever the column's contents change width (a long environment name, the Linux button cluster), and it hand-rolls what inheritance already gives correctly.

Verified against master (`a8690df`) before writing: the wrapper still carries `WebkitAppRegion: "no-drag"` exactly as the issue anchors it, `rg AppRegion app/src` still returns only `TitleBar.tsx` and `CommandSearchBar.tsx` as producers, and no engine, MCP or import path reads the property - this is self-contained to the renderer.

**The Windows overlay padding stays as-is.** The reserved `paddingRight` (sized from `env(titlebar-area-width)`) is where Electron's Window Controls Overlay draws native controls above the web content; that rectangle is hit-tested by the OS before it reaches the DOM, so whatever the page declares underneath it is moot there. The reasoning is now a comment beside the padding rather than an unstated assumption. Per the issue this is the one claim a jsdom test cannot settle - see the deviation note below.

**`docs/app/COMPONENTS.md:81` is deliberately untouched.** It already states the target invariant ("opting out per control or per cluster is fine; opting out a wrapper that spans the row's slack is not, because that slack is what the window is dragged by"). The doc was right and the code had drifted from it, so the fix is the code catching up - the issue calls this out explicitly so the docs step is not skipped as forgotten.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

App-only renderer change (two files, no engine source), so the verification is the app half of the repo's gate:

- `pnpm vitest run src/components/layout/TitleBar.search-bar.test.tsx` - **7 passed (1 new)**.
- `pnpm test` - **5222 passed, 499 files**. Nothing else moved; the two other tests that read `-webkit-app-region` (`app-icon-system-menu.test.tsx`, `TabStrip.overflow.test.tsx`) are unaffected.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean. Both touched files were already prettier-clean, so formatting them changed nothing else.
- **Mutation-checked**, as the issue asks: putting `no-drag` back on the wrapper reddens the new case (`right column is dead on win32: expected "no-drag" to be "drag"`) while the other six stay green - including the pre-existing "drags by the row and not by its controls", which is precisely why it never caught this. Restored and re-run green (7/7).
- Engine untouched, so no engine build or `ctest` run - no C++, CMake or test file is in the diff.
- No pre-existing failures observed on this base.

The new test asserts what the old one structurally could not. The existing case reads `effectiveRegion` (own-or-inherited) on the *controls*, which a blanket wrapper satisfies exactly as well as a per-control opt-out; the new one asserts the **wrapper** inherits `drag` and that the button carries its **own** `no-drag`, looped over `win32`/`darwin`/`linux` rather than pinned to the host platform.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation (n/a - the doc already states the invariant; see above)

## Deviation from the issue spec

One acceptance criterion asks for a manual check on a packaged (or `pnpm electron:dev`) **Windows** build, confirming the native min/max/close overlay still behaves with the reserved padding strip now inheriting `drag`. **This run could not perform it** - the environment is headless Linux with no Windows build and no real hit-testing (jsdom has none, which is why the issue asked for a manual check rather than an assertion). The code change matches the issue's stated pathway exactly and the WCO reasoning is documented at the site; the Windows overlay check and the three-platform drag-by-the-slack check remain for you at review time. Everything else in the acceptance criteria is done and verified above.

Also noted while in the file, deliberately **not** touched (adjacent, not this diff): `docs/app/COMPONENTS.md` names the right-hand control `EnvPill` while the component is `EnvSwitcher` - a naming drift in the same paragraph, worth a one-word fix in whatever next edits that file.

## Related Issues
Closes #764

---
_Generated by [Claude Code](https://claude.ai/code/session_011BpCNjz5vErxBpMs5bxZqB)_