### PR TITLE
fix(app/mcp): bound get_run_report's traces as a set, not only one at a time

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -11,6 +11,7 @@ import {
 	dispatchTool,
 	MAX_IN_FLIGHT_BOUND,
 	MAX_INLINE_BODY_BYTES,
+	MAX_REPORT_TRACE_BYTES,
 	toolCatalog,
 	TOOLS,
 	type ToolContext,
@@ -2093,6 +2094,154 @@ describe("inline body bounds", () => {
 			expect(description).toContain(String(MAX_INLINE_BODY_BYTES));
 			expect(description).toMatch(/bodyTruncated/);
 		}
+	});
+
+	/**
+	 * The total bound (issue #769).
+	 *
+	 * The per-node bound does not bound the result: `results[]` holds up to 100
+	 * rows and each keeps up to `MAX_INLINE_BODY_BYTES` per node, so a 100-step
+	 * scenario measured 3.3M characters with every node correctly flagged as
+	 * truncated - 2.5x the 1.3M that failed in #767. At that row count even an
+	 * 8KB body, never touched by the per-node cut, totalled 845K.
+	 */
+	describe("total trace budget", () => {
+		/** A scenario row in the shape `stamp_step_identity` writes. */
+		function step(index: number, outcome: string, body: string) {
+			return {
+				id: index + 1,
+				statusCode: outcome === "passed" ? 200 : 500,
+				latencyMs: 4,
+				trace: {
+					iteration: 0,
+					stepIndex: index,
+					stepName: `step-${index}`,
+					outcome,
+					response: { body },
+				},
+			};
+		}
+
+		function scenarioReport(rows: unknown[]) {
+			return { summary: {}, scenario: { stepsStored: rows.length }, results: rows };
+		}
+
+		test("a 100-step report of oversized bodies comes back inside the budget", async () => {
+			const out = await runReport(
+				reported(
+					scenarioReport(Array.from({ length: 100 }, (_, i) => step(i, "passed", huge)))
+				)
+			);
+
+			const rows = out.results as Array<Record<string, unknown>>;
+			expect(rows).toHaveLength(100);
+			const embedded = rows.filter((row) => row.trace !== undefined);
+			const carried = embedded.reduce(
+				(sum, row) => sum + Buffer.byteLength(JSON.stringify(row.trace), "utf8"),
+				0
+			);
+			expect(carried).toBeLessThanOrEqual(MAX_REPORT_TRACE_BYTES);
+			// The whole result, which is what actually reaches the agent: the
+			// pre-fix measurement for this exact fixture was 3,328,454 characters.
+			expect(JSON.stringify(out).length).toBeLessThan(200_000);
+		});
+
+		test("what was dropped is disclosed on the row and on the report", async () => {
+			const out = await runReport(
+				reported(
+					scenarioReport(Array.from({ length: 100 }, (_, i) => step(i, "passed", huge)))
+				)
+			);
+
+			const rows = out.results as Array<Record<string, unknown>>;
+			const dropped = rows.filter((row) => row.traceOmitted === true);
+			expect(dropped.length).toBeGreaterThan(0);
+			expect(out.tracesOmitted).toBe(dropped.length);
+			expect(out.traceBudgetBytes).toBe(MAX_REPORT_TRACE_BYTES);
+			// A dropped row keeps everything that is not the trace - the run's
+			// shape is the answer even when the payloads cannot come along.
+			expect(dropped[0]).toMatchObject({ statusCode: 200, latencyMs: 4 });
+			expect(dropped[0]).not.toHaveProperty("trace");
+		});
+
+		test("non-passing steps keep their traces first", async () => {
+			// Failures last in run order, so a first-come budget would drop
+			// exactly them - which is the engine's rule for `stepsStored`
+			// (`ScenarioStepStore::add`) read backwards.
+			const rows = [
+				...Array.from({ length: 40 }, (_, i) => step(i, "passed", huge)),
+				step(40, "failed", huge),
+				step(41, "errored", huge),
+			];
+			const out = await runReport(reported(scenarioReport(rows)));
+
+			const results = out.results as Array<Record<string, unknown>>;
+			expect(results).toHaveLength(42);
+			// Row order is the run's, not the budget's.
+			expect((results[40].trace as Record<string, unknown>).outcome).toBe("failed");
+			expect((results[41].trace as Record<string, unknown>).outcome).toBe("errored");
+			expect(results[40]).not.toHaveProperty("traceOmitted");
+			expect(results[41]).not.toHaveProperty("traceOmitted");
+			expect(out.tracesOmitted).toBeGreaterThan(0);
+		});
+
+		test("a single oversized row keeps its trace whatever it costs", async () => {
+			// The #767 case itself: a design report is one row, and a budget that
+			// dropped it would answer nothing at all.
+			const out = await runReport(
+				reported({
+					summary: {},
+					results: [
+						{
+							id: 1,
+							trace: {
+								request: {
+									body: huge,
+									rawRequest: `POST /x HTTP/2\r\n\r\n${huge}`,
+								},
+								response: { body: huge },
+							},
+						},
+					],
+				})
+			);
+
+			const row = (out.results as Row[])[0];
+			expect(Buffer.byteLength(row.trace!.response!.body as string, "utf8")).toBe(
+				MAX_INLINE_BODY_BYTES
+			);
+			expect(out).not.toHaveProperty("tracesOmitted");
+		});
+
+		test("a report inside the budget is byte-for-byte unchanged", async () => {
+			// Under the per-node bound and under the total: nothing added, no
+			// disclosure invented, exactly the object the engine returned.
+			const report = scenarioReport(
+				Array.from({ length: 30 }, (_, i) => step(i, "passed", '{"ok":true}'))
+			);
+			expect(await runReport(reported(report))).toEqual(report);
+		});
+
+		test("rows carrying no trace are never counted or flagged", async () => {
+			// A load report has no traces at all, so there is nothing to omit -
+			// the budget must not invent a disclosure for rows it cannot spend on.
+			const report = {
+				summary: { totalRequests: 5_000 },
+				results: Array.from({ length: 100 }, (_, i) => ({
+					id: i,
+					statusCode: 200,
+					latencyMs: 4,
+				})),
+			};
+			expect(await runReport(reported(report))).toEqual(report);
+		});
+
+		test("the tool description states the total bound and its disclosure", () => {
+			const description = TOOLS.find((t) => t.name === "get_run_report")!.description;
+			expect(description).toContain(String(MAX_REPORT_TRACE_BYTES));
+			expect(description).toMatch(/traceOmitted/);
+			expect(description).toMatch(/tracesOmitted/);
+		});
 	});
 });
 

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -317,32 +317,137 @@ function boundTraceNode(node: unknown): unknown {
 }
 
 /**
+ * How many bytes of stored trace one run report carries in total (issue #769).
+ *
+ * The per-node bound above does not bound the *result*: the report route caps
+ * `results[]` at 100 rows and each row may keep up to `MAX_INLINE_BODY_BYTES`
+ * on each of three nodes, so a 100-step scenario measured at 3.3M characters
+ * with every node honestly flagged as truncated - 2.5x the 1.3M that made #767
+ * fail in the first place. Truncation stops being the binding constraint at
+ * that row count: 100 steps of an 8KB body, well under the per-node bound and
+ * so never touched, still totalled 845K characters.
+ *
+ * 96KB is `MAX_INLINE_BODY_BYTES * 3`: the largest single row the per-node
+ * bound can produce (a request body, a response body and a `rawRequest`, each
+ * at the cap), derived from the existing bound rather than invented beside it.
+ * That is the number with a reason - a budget below it would drop rows for
+ * being merely as big as one row is allowed to be - and it leaves the whole
+ * result an order of magnitude under the 1.3M characters that failed in #767,
+ * or dozens of rows when the bodies are ordinary.
+ *
+ * It bounds the traces, not the report: the row scalars (id, status, latency,
+ * step identity) are ~200 bytes a row, so 100 of them are noise beside one
+ * body, and they are never dropped - the run's shape is the answer even when
+ * the payloads cannot come along, which is why no second row cap is needed.
+ */
+export const MAX_REPORT_TRACE_BYTES = MAX_INLINE_BODY_BYTES * 3;
+
+/**
+ * Whether a row's trace is one to keep first when the budget cannot hold them
+ * all, mirroring the engine's own thinning rule for `stepsStored`
+ * (`ScenarioStepStore::add`, called with `outcome != Passed`) so the two do not
+ * disagree about which steps matter.
+ *
+ * A row the engine stamped no outcome on is a design-mode row, where the engine
+ * has no rule to disagree with; its transport error is the only failure signal
+ * it carries.
+ */
+function isPriorityTraceRow(row: Record<string, unknown>): boolean {
+	const trace = row.trace;
+	if (isRecord(trace) && typeof trace.outcome === "string") return trace.outcome !== "passed";
+	return typeof row.error === "string" && row.error !== "";
+}
+
+/** One report row, with its trace bounded per node and measured. */
+interface MeasuredRow {
+	row: unknown;
+	/** Set only for a row that carries a trace; the per-node-bounded copy. */
+	traced?: { record: Record<string, unknown>; trace: Record<string, unknown>; priority: boolean };
+	/** True when bounding changed the trace, so the row must be rebuilt. */
+	rebuilt: boolean;
+	bytes: number;
+}
+
+/**
  * Bound the stored traces in a run report - what `get_run_report` hands back.
+ *
+ * Two bounds, because one does not imply the other: every trace node is cut to
+ * `MAX_INLINE_BODY_BYTES` (issue #767), and the traces together are cut to
+ * `MAX_REPORT_TRACE_BYTES` (issue #769). Rows past the total budget keep every
+ * scalar and lose only their trace, flagged `traceOmitted` on the row with
+ * `tracesOmitted` and `traceBudgetBytes` on the report - the same disclose-in-
+ * band shape `list_runs` uses for its 100-row page, so an agent that reads a
+ * short report never mistakes it for the whole run.
  *
  * Design and scenario rows only: a load run's results never go through
  * `build_result_trace` (it is called from `record_design_result` and the
  * scenario runner, never the load hot path), so they carry no `trace` node and
  * the walk leaves them untouched. Rebuilt rather than mutated so a report with
- * nothing over the bound comes back as the object the engine returned.
+ * nothing over either bound comes back as the object the engine returned.
  */
 function boundRunReport(value: unknown): unknown {
 	if (!isRecord(value) || !Array.isArray(value.results)) return value;
-	let changed = false;
-	const results = value.results.map((row) => {
-		if (!isRecord(row) || !isRecord(row.trace)) return row;
+
+	let nodeBounded = false;
+	const measured: MeasuredRow[] = value.results.map((row) => {
+		if (!isRecord(row) || !isRecord(row.trace)) return { row, rebuilt: false, bytes: 0 };
 		const trace = row.trace;
 		const next: Record<string, unknown> = { ...trace };
-		let rowChanged = false;
+		let rebuilt = false;
 		for (const key of ["request", "response"] as const) {
 			if (!(key in trace)) continue;
 			next[key] = boundTraceNode(trace[key]);
-			if (next[key] !== trace[key]) rowChanged = true;
+			if (next[key] !== trace[key]) rebuilt = true;
 		}
-		if (!rowChanged) return row;
-		changed = true;
-		return { ...row, trace: next };
+		if (rebuilt) nodeBounded = true;
+		const bounded = rebuilt ? next : trace;
+		// The compact size of what this row would embed. Measured after the
+		// per-node cut, since that is what the result would actually carry.
+		return {
+			row,
+			traced: { record: row, trace: bounded, priority: isPriorityTraceRow(row) },
+			rebuilt,
+			bytes: Buffer.byteLength(JSON.stringify(bounded), "utf8"),
+		};
 	});
-	return changed ? { ...value, results } : value;
+
+	// Spend the budget on the rows that matter first, then in run order. The
+	// first trace is always embedded, whatever it costs: a design run's report
+	// is one row, and a report that dropped it would answer nothing at all.
+	const spendOrder = [
+		...measured.filter((m) => m.traced?.priority),
+		...measured.filter((m) => m.traced && !m.traced.priority),
+	];
+	const keep = new Set<MeasuredRow>();
+	let spent = 0;
+	for (const entry of spendOrder) {
+		if (keep.size > 0 && spent + entry.bytes > MAX_REPORT_TRACE_BYTES) break;
+		keep.add(entry);
+		spent += entry.bytes;
+	}
+
+	const omitted = spendOrder.length - keep.size;
+	if (!nodeBounded && omitted === 0) return value;
+
+	const results = measured.map((entry) => {
+		if (!entry.traced) return entry.row;
+		if (keep.has(entry)) {
+			return entry.rebuilt
+				? { ...entry.traced.record, trace: entry.traced.trace }
+				: entry.row;
+		}
+		const withoutTrace = { ...entry.traced.record };
+		delete withoutTrace.trace;
+		return { ...withoutTrace, traceOmitted: true };
+	});
+
+	if (omitted === 0) return { ...value, results };
+	return {
+		...value,
+		results,
+		tracesOmitted: omitted,
+		traceBudgetBytes: MAX_REPORT_TRACE_BYTES,
+	};
 }
 
 /** Result that carries both a text rendering and structured content. */
@@ -1922,7 +2027,8 @@ export const TOOLS: McpTool[] = [
 		description:
 			"Get the full report for a completed run: summary, latency percentiles (p50/p95/p99), status codes, errors, and timing breakdown. Ideal input for analyzing performance. " +
 			"A run of a collection bound to an OpenAPI document also carries `coverage`: which of the contract's operations the run exercised, which of their declared responses it saw, and any statuses the document never declared. Absent - never zeros - for a run that was not measured against a contract. " +
-			`Stored bodies on each row's trace (request and response) are capped at ${MAX_INLINE_BODY_BYTES} bytes for this result: a capped one carries \`bodyTruncated: true\` beside \`bodyBytes\`, the full size, and a capped \`rawRequest\` carries \`rawRequestTruncated\`. A body in full is still available in the Vayu app's own run history.`,
+			`Stored bodies on each row's trace (request and response) are capped at ${MAX_INLINE_BODY_BYTES} bytes for this result: a capped one carries \`bodyTruncated: true\` beside \`bodyBytes\`, the full size, and a capped \`rawRequest\` carries \`rawRequestTruncated\`. A body in full is still available in the Vayu app's own run history. ` +
+			`The traces together are capped at ${MAX_REPORT_TRACE_BYTES} bytes, since a multi-step run's rows add up past any per-body cap: rows beyond the budget keep every scalar (status, latency, step identity) and carry \`traceOmitted: true\` instead of their trace, with \`tracesOmitted\` and \`traceBudgetBytes\` on the report saying how many. Non-passing steps keep their traces first, matching the engine's own rule for \`stepsStored\`, so a failure is the last thing dropped. An omitted row's trace is still in the Vayu app's own run history.`,
 		annotations: {
 			title: "Get run report",
 			readOnlyHint: true,

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -152,7 +152,7 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `list_requests`        | read     | `GET /requests?collectionId=`                | -                          |
 | `list_environments`    | read     | `GET /environments`                          | -                          |
 | `list_runs`            | read     | `GET /runs?limit=100`                        | First page (100) of the `{data, pagination}` envelope; rows carry a compact summary |
-| `get_run_report`       | read     | `GET /runs/:id/report`                       | Stored trace bodies capped at 32 KB per node |
+| `get_run_report`       | read     | `GET /runs/:id/report`                       | Stored trace bodies capped at 32 KB per node, and 96 KB across the report |
 | `get_engine_config`    | read     | `GET /config`                                | -                          |
 | `get_live_metrics`     | read     | SSE snapshot of last N ticks                 | `limit` must be a whole number ≥ 1 |
 | `compare_runs`         | read     | 2× `GET /runs/:id/report` → diff (structured)| `baseRunId` optional - omitted, it resolves the target's pinned baseline |
@@ -214,6 +214,28 @@ Notes:
   load run's results never go through `build_result_trace`, so they carry no
   trace node at all, and its captured bodies live behind
   `GET /runs/:id/samples`, which has always truncated and disclosed this way.
+- **The traces are bounded as a set, not only one at a time** (issue #769).
+  Capping each node does not cap the report: `/runs/:id/report` returns up to
+  100 rows and each may keep 32 KB on each of three nodes, so a 100-step
+  scenario measured **3.3 M characters** with every node honestly flagged as
+  truncated - 2.5x the size that failed in #767. At that row count truncation is
+  no longer the binding constraint: 100 steps of an 8 KB body, under the
+  per-node cap and so never touched, still totalled 845 K. So `get_run_report`
+  also holds the traces to **96 KB in total** - `MAX_INLINE_BODY_BYTES * 3`, the
+  largest single row the per-node bound can produce, rather than a new number
+  beside it. Rows past the budget keep every scalar (id, status, latency, step
+  identity) and carry `traceOmitted: true` in place of their trace, with
+  `tracesOmitted` and `traceBudgetBytes` on the report. **Non-passing steps
+  spend the budget first**, matching `ScenarioStepStore::add`'s own rule for
+  `stepsStored`, so the two do not disagree about which steps matter - and the
+  rows come back in run order regardless, since the budget decides what a row
+  carries, never where it sits. The first trace is always embedded whatever it
+  costs, so a design run's single-row report never comes back empty. The rows
+  themselves are not capped further: at ~200 bytes of scalars each they are
+  noise beside one body, and the run's shape is the answer even when the
+  payloads cannot come along. Bounded sizes for the fixtures above: 33 K
+  characters for the single 1 MB row, 76 K for 100 steps x 1 MB, 120 K for
+  200 rows with all three nodes populated (24.7 M unbounded).
 - **`start_load_run`'s `stream` flag** consumes each response as a
   `text/event-stream` (issue #576), with `maxStreamDurationMs` and
   `maxStreamEvents` bounding one stream. Both caps are forwarded verbatim on the
@@ -541,7 +563,9 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
     bodies inline, under `trace` (`build_result_trace`, the same node a
     single design-mode send stores) - not behind `GET /runs/:id/samples`, which
     is the load-run capture route - so a long plan against large responses
-    makes for a large report.
+    makes for a large report. That is what the 96 KB total trace budget above
+    bounds: past it a step row keeps its scalars and carries `traceOmitted`
+    instead of its bodies, non-passing steps last to lose them.
   - `start_load_run` takes the same block as an optional `scenario` argument
     and posts it **with** a mode, which hands the plan to the load executor:
     `concurrency` is the number of virtual users, each walking the whole plan


### PR DESCRIPTION
## Description

**Root cause.** #768 bounds a *node*; nothing bounds the *result*. `/runs/:id/report` returns up to 100 rows and each row may keep `MAX_INLINE_BODY_BYTES` on each of three body-carrying nodes, so the ceiling is `rows x nodes x 32 KB` and no code was checking it. Verified against the live code before writing anything: `runs.cpp:1126` still caps `results` at 100, `boundRunReport` still walks per node only, and the scenario runner still writes one `build_result_trace` trace per step into `trace_data` - the shape the issue describes is the shape that is there.

**Approach.** A second bound at the same seam: the traces together are held to **96 KB**, rows past the budget keep every scalar and carry `traceOmitted: true` instead of their trace, and the report says `tracesOmitted` / `traceBudgetBytes`. Non-passing steps spend the budget first, mirroring `ScenarioStepStore::add`'s own rule for `stepsStored` (`outcome != Passed`) so the tool and the engine cannot disagree about which steps matter; rows come back in run order regardless, since the budget decides what a row carries, never where it sits. The first trace is always embedded whatever it costs - a design run's report is one row, and a budget that dropped it would answer nothing at all.

96 KB is `MAX_INLINE_BODY_BYTES * 3`: the largest single row the per-node bound can produce, so it is derived from the existing bound rather than invented beside it, and a row is never dropped for being merely as big as one row is allowed to be.

**The alternative I rejected.** The issue offers `includeTraces: false` / `stepLimit` as an explicit argument. It puts the choice with the agent, but it is a knob that has to be *known about* to help - and the failure mode here is an agent that asked for a report and got a token-limit error instead, which is exactly the case where it would not have passed the argument. The budget-with-disclosure needs no argument and cannot be got wrong. I also **did not** add the second `results` row cap the issue says to consider: row scalars are ~200 bytes each, so 100 of them are noise beside one body, and dropping them would cost the run's shape - the part still worth reading once the payloads cannot come along.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test` - **5260 tests, 499 files, all passing** (7 new tests; the suite was 5250/499 before). `pnpm type-check`, `pnpm lint` and `pnpm format:check` clean. No engine change, so no C++ build or ctest run - the diff is TypeScript and Markdown.

**Measurements re-run, not assumed** (acceptance criterion 3). Fixtures driven through `dispatchTool("get_run_report")` with the fake client, sizes are the tool result's own text:

| Report | Unbounded | Bounded result |
|---|---|---|
| 1 step x 1 MB body (the #767 single-row case) | 1,048,874 | **33,131** |
| 100 steps x 40 KB body | 4,122,310 | **76,360** |
| 100 steps x 1 MB body | 104,883,910 | **76,364** |
| 100 steps x 8 KB body (under the per-node bound) | 845,510 | **102,234** |
| 200 rows x all three nodes populated | 24,657,310 | **119,588** |

The 8 KB row is the case worth reading twice: every body is under the per-node bound, so #768 never touches it, and it was still 845 K on its own - the total budget is what brings it down. The 8 KB case lands *higher* than the 40 KB one because small traces fit more rows inside the same budget, which is the budget working rather than a cap leaking.

**Mutation-checked, both halves.** Removing the budget line reddens three tests by name (`expected 3289980 to be less than or equal to 98304`, matching the issue's 3.3M measurement); collapsing the priority ordering back to run order reddens exactly the non-passing test. Two tests pin what must *not* change: a report inside both bounds comes back byte-for-byte equal, and a load report (no traces at all) is never given an invented disclosure. #768's own per-node tests are untouched and still green.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #769

`docs/engine/mcp.md` in the same commit: the bounded-bodies section gains the total budget beside the per-node one with the measurements, the tool table row states both caps, and `run_collection`'s bullet about step rows carrying bodies inline now points at what bounds them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KorRQUifig7RTufrLS7P5C)_