### PR TITLE
fix(app/mcp): an MCP delete or baseline pin now clears the caches the app's own mutations clear

### DIFF
--- a/app/electron/mcp/data-changed.conformance.test.ts
+++ b/app/electron/mcp/data-changed.conformance.test.ts
@@ -21,8 +21,8 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { MCP_DATA_ENTITIES } from "./tools.js";
-import type { McpDataEntity } from "@/types/domain";
+import { MCP_DATA_ENTITIES, type McpDataChangedEvent as MainEvent } from "./tools.js";
+import type { McpDataEntity, McpDataChangedEvent as RendererEvent } from "@/types/domain";
 
 /*
  * Exhaustive by construction: TypeScript rejects this literal if the renderer's
@@ -48,5 +48,29 @@ describe("McpDataEntity mirror", () => {
 		// A comparison of two empty lists passes while proving nothing - the
 		// failure mode CLAUDE.md records for source-scanning guards.
 		expect(MCP_DATA_ENTITIES.length).toBeGreaterThan(0);
+	});
+});
+
+/*
+ * The entity union is not the only thing written twice: the event carrying it
+ * is too, scope hints and all. A hint added on the emitting side and forgotten
+ * on the reading side is the same silent failure - the main process would send
+ * a narrowing the renderer's invalidator never reads.
+ *
+ * Mutual assignability alone would not see it (an extra optional property is
+ * still assignable both ways), so the property *names* are compared as well.
+ * The check is the compiler's - `pnpm type-check` is where it fails; the
+ * assertions below exist so the constants are read rather than left as dead
+ * declarations lint would strip.
+ */
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+const EVENT_TYPES_MATCH: Exact<MainEvent, RendererEvent> = true;
+const EVENT_KEYS_MATCH: Exact<keyof MainEvent, keyof RendererEvent> = true;
+
+describe("McpDataChangedEvent mirror", () => {
+	test("both sides describe the same event, with the same scope hints", () => {
+		expect(EVENT_TYPES_MATCH).toBe(true);
+		expect(EVENT_KEYS_MATCH).toBe(true);
 	});
 });

--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -292,6 +292,30 @@ describe("dispatch emits mcp:data-changed", () => {
 		expect(onDataChanged.mock.calls.map(([e]) => e.entity)).toEqual(["run", "run"]);
 	});
 
+	test("a housekeeping write carries the run id as its scope hint", async () => {
+		// The renderer needs it to drop that one run's report and series caches
+		// (issue #774): they are `staleTime: Infinity` and keyed per run, so
+		// without the hint a deleted run keeps rendering under an open tab.
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
+		await dispatchTool("delete_run", { runId: "run_1", confirmed: true }, ctx);
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run", runId: "run_1" });
+	});
+
+	test("a runner names no run id - the run it made has no per-run cache yet", async () => {
+		// The hint means "this existing run changed"; attaching it to a create
+		// would drop caches for a run nothing has fetched.
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), {
+			allowlist: ["api.example.com"],
+		});
+		await dispatchTool(
+			"run_request",
+			{ url: "https://api.example.com/users", requestId: "req_7" },
+			ctx
+		);
+		const event = onDataChanged.mock.calls[0][0];
+		expect("runId" in event).toBe(false);
+	});
+
 	test("a delete_run preview changed nothing, so it notifies nothing", async () => {
 		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
 		const res = await dispatchTool("delete_run", { runId: "run_1" }, ctx);
@@ -303,7 +327,9 @@ describe("dispatch emits mcp:data-changed", () => {
 		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
 		const res = await dispatchTool("stop_run", { runId: "run_1" }, ctx);
 		expect(res.isError).toBeFalsy();
-		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run" });
+		// With the hint, because a stopped run's own report and series are what
+		// changed - it went terminal.
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run", runId: "run_1" });
 	});
 
 	test("a context without a notifier dispatches normally", async () => {

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -88,11 +88,11 @@ export type McpDataEntity = (typeof MCP_DATA_ENTITIES)[number];
  * One thing changed. Invalidation only - no data rides across, the renderer
  * refetches through its normal query layer.
  *
- * The two scope hints are read from the call's own arguments and narrow the
- * invalidation to the caches that can have gone stale; both are absent when the
- * call named neither. They are hints, not identity: `requestId` on a
+ * The three scope hints are read from the call's own arguments and narrow the
+ * invalidation to the caches that can have gone stale; each is absent when the
+ * call did not name it. They are hints, not identity: `requestId` on a
  * `run` event is the saved request a design run was linked to (the key
- * `runs.lastDesign` uses), not the run's own id.
+ * `runs.lastDesign` uses), not the run's own id - `runId` is that.
  */
 export interface McpDataChangedEvent {
 	entity: McpDataEntity;
@@ -100,6 +100,13 @@ export interface McpDataChangedEvent {
 	collectionId?: string;
 	/** The saved request the call named, when it named one. */
 	requestId?: string;
+	/**
+	 * The history run the call named, when it named one. Only the tools that
+	 * rewrite or remove an *existing* run spell this (`stop_run`,
+	 * `set_run_baseline`, `delete_run`); a runner names the request or
+	 * collection it ran, and the run it created has no per-run cache yet.
+	 */
+	runId?: string;
 }
 
 export interface ToolContext {
@@ -3921,12 +3928,14 @@ function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: To
 	if (!ctx.onDataChanged || tool.invalidates.length === 0) return;
 	const collectionId = str(args, "collectionId");
 	const requestId = str(args, "requestId");
+	const runId = str(args, "runId");
 	for (const entity of tool.invalidates) {
 		try {
 			ctx.onDataChanged({
 				entity,
 				...(collectionId !== undefined ? { collectionId } : {}),
 				...(requestId !== undefined ? { requestId } : {}),
+				...(runId !== undefined ? { runId } : {}),
 			});
 		} catch (err) {
 			console.error(`[MCP] Failed to notify "${entity}" change from ${tool.name}:`, err);

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -11,12 +11,24 @@ import { invalidateForMcpEvent } from "./mcp-invalidation";
 import { queryKeys } from "@/queries/keys";
 import type { McpDataChangedEvent } from "@/types/domain";
 
-/** Apply one event against a spied client and return the keys it invalidated. */
+/**
+ * Apply one event against a spied client and return what it did.
+ *
+ * `removed` is kept apart from `keys` because the two are not
+ * interchangeable: invalidation leaves the cached answer in place until a
+ * refetch replaces it, removal drops it. A run that no longer exists needs the
+ * second, and a test that read them as one list could not tell.
+ */
 function keysFor(event: McpDataChangedEvent) {
 	const queryClient = new QueryClient();
 	const spy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+	const removeSpy = vi.spyOn(queryClient, "removeQueries").mockImplementation(() => {});
 	const handled = invalidateForMcpEvent(queryClient, event);
-	return { handled, keys: spy.mock.calls.map(([filters]) => filters?.queryKey) };
+	return {
+		handled,
+		keys: spy.mock.calls.map(([filters]) => filters?.queryKey),
+		removed: removeSpy.mock.calls.map(([filters]) => filters?.queryKey),
+	};
 }
 
 afterEach(() => {
@@ -75,7 +87,19 @@ describe("invalidateForMcpEvent", () => {
 
 	test("a run invalidates both list families", () => {
 		const { keys } = keysFor({ entity: "run" });
-		expect(keys).toEqual([queryKeys.runs.lists(), queryKeys.runs.allRuns()]);
+		expect(keys).toContainEqual(queryKeys.runs.lists());
+		expect(keys).toContainEqual(queryKeys.runs.allRuns());
+	});
+
+	test("a run invalidates the baseline, Recent sends and Last run families", () => {
+		// None of the three is polled, and each answers something a run write can
+		// move - the pin, the newest send, the collection's last run. Their
+		// prefixes because a run id gives no way back to the request or
+		// collection, exactly as `useDeleteRunMutation` argues.
+		const { keys } = keysFor({ entity: "run" });
+		expect(keys).toContainEqual(queryKeys.runs.baselines());
+		expect(keys).toContainEqual(queryKeys.runs.recentDesigns());
+		expect(keys).toContainEqual(queryKeys.runs.lastCollectionRuns());
 	});
 
 	test("a run linked to a saved request also invalidates its last design run", () => {
@@ -83,12 +107,53 @@ describe("invalidateForMcpEvent", () => {
 		expect(keys).toContainEqual(queryKeys.runs.lastDesign("req_7"));
 	});
 
-	test("a run leaves per-run reports alone", () => {
+	test("a run that named no id leaves every per-run cache alone", () => {
 		// A new run cannot have changed an existing run's report, and those are
 		// the expensive fetches in this family.
-		const { keys } = keysFor({ entity: "run", requestId: "req_7" });
+		const { keys, removed } = keysFor({ entity: "run", requestId: "req_7" });
 		expect(keys).not.toContainEqual(queryKeys.runs.report("req_7"));
 		expect(keys).not.toContainEqual(queryKeys.runs.all);
+		expect(removed).toEqual([]);
+	});
+
+	test("a named run has its report, samples, both series and detail removed", () => {
+		// Removed rather than invalidated: samples and both series are
+		// `staleTime: Infinity`, so a deleted run would go on feeding an open
+		// History tab until the entry was garbage collected.
+		const { removed } = keysFor({ entity: "run", runId: "run_1" });
+		expect(removed).toEqual([
+			queryKeys.runs.detail("run_1"),
+			queryKeys.runs.report("run_1"),
+			queryKeys.runs.samples("run_1"),
+			queryKeys.runs.timeSeries("run_1"),
+			queryKeys.runs.monitorSeries("run_1"),
+		]);
+	});
+
+	test("a named run leaves another run's per-run caches untouched", () => {
+		// The removal is keyed, not a prefix sweep over `runs.all` - which would
+		// take every other run's report with it.
+		const { removed } = keysFor({ entity: "run", runId: "run_1" });
+		for (const key of removed) {
+			expect(key).not.toEqual(queryKeys.runs.all);
+			expect(key).toContain("run_1");
+		}
+		expect(removed).not.toContainEqual(queryKeys.runs.report("run_2"));
+	});
+
+	test("a deleted run really is gone from a live cache, not just marked stale", () => {
+		// The spied version above proves which keys were named; this proves the
+		// call has the effect claimed, against a real QueryClient.
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(queryKeys.runs.report("run_1"), { id: "run_1" });
+		queryClient.setQueryData(queryKeys.runs.samples("run_1"), { id: "run_1" });
+		queryClient.setQueryData(queryKeys.runs.report("run_2"), { id: "run_2" });
+
+		invalidateForMcpEvent(queryClient, { entity: "run", runId: "run_1" });
+
+		expect(queryClient.getQueryData(queryKeys.runs.report("run_1"))).toBeUndefined();
+		expect(queryClient.getQueryData(queryKeys.runs.samples("run_1"))).toBeUndefined();
+		expect(queryClient.getQueryData(queryKeys.runs.report("run_2"))).toEqual({ id: "run_2" });
 	});
 
 	test("a cookie change invalidates the single jar key", () => {

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -95,31 +95,66 @@ const INVALIDATORS: Record<
 
 	/*
 	 * The history list polls on its own, so this is about immediacy there - but
-	 * `allRuns` (Settings' count), `lastDesign` (a request tab's restored
-	 * response) and `recentDesign` (its Recent sends section) are not polled at
-	 * all, and an MCP-run request left them stale indefinitely. Reports and time
-	 * series are keyed per run and describe runs that already existed, so they
-	 * are deliberately not touched.
+	 * `allRuns` (Settings' count) and the four small per-request/per-collection
+	 * families are not polled at all, and an MCP write left them stale
+	 * indefinitely. They are covered at their prefixes rather than per row: a
+	 * run write can change what any of them answers (a delete may have taken the
+	 * pin, or the newest send) and the event names at most one request, so the
+	 * narrow key would leave whichever list actually moved behind. Each is five
+	 * rows, and only the mounted ones refetch - the same trade
+	 * `useDeleteRunMutation` makes for the same reason: a run id gives no way
+	 * back to the request or collection it belonged to.
 	 *
-	 * That last sentence stopped being the whole story with `delete_run` and
-	 * `set_run_baseline` (issue #755): a run can now be removed or re-pinned from
-	 * MCP, and what this leaves stale is what `useDeleteRunMutation` /
-	 * `useSetRunBaselineMutation` clear for the same writes made in the UI - the
-	 * baseline family, the per-run report and series entries (`staleTime:
-	 * Infinity`), Recent sends and Last run. Tracked in issue #774 rather than
-	 * widened here, because dropping one run's caches needs a run-id scope hint
-	 * the event does not carry yet.
+	 * `lastDesign` has no prefix family of its own, so it stays per request and
+	 * is reached only when the call named one. Issue #776 tracks that gap, which
+	 * `useDeleteRunMutation` shares.
+	 *
+	 * Per-run *report* and series keys are still not invalidated wholesale, and
+	 * that exclusion is the point: a `run_request` creates a run and cannot have
+	 * changed an existing one's report, which is the expensive fetch in this
+	 * family. They are dropped only for the one run a call named - see below.
 	 */
 	run: (queryClient, event) => {
 		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lists() });
 		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.allRuns() });
+		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.baselines() });
+		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.recentDesigns() });
+		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lastCollectionRuns() });
 		if (event.requestId) {
 			void queryClient.invalidateQueries({
 				queryKey: queryKeys.runs.lastDesign(event.requestId),
 			});
-			void queryClient.invalidateQueries({
-				queryKey: queryKeys.runs.recentDesign(event.requestId),
-			});
+		}
+		/*
+		 * A named run is one that already existed and was rewritten or removed
+		 * (`delete_run`, `stop_run`, `set_run_baseline` - the only tools that take
+		 * a `runId`). Its per-run caches are `staleTime: Infinity` for the series
+		 * and the samples, so invalidation alone would leave a deleted run's
+		 * report rendering under an open History tab until it was garbage
+		 * collected: they are removed, not marked stale.
+		 *
+		 * `detail` goes with them deliberately. It is what makes the deleted case
+		 * *correct* rather than merely fresh - dropping it lets `runDetailOptions`
+		 * refetch, take its 404 and hand `HistoryDetail` the `RunNotFoundError` it
+		 * already renders as "This run no longer exists", instead of a pane that
+		 * keeps describing a run the sidebar no longer lists.
+		 *
+		 * The hint says which run changed, not how, so this cannot tell a delete
+		 * from a re-pin. That is the accepted cost: after `stop_run` the report
+		 * and series genuinely did change (the run went terminal), and after
+		 * `set_run_baseline` an open detail pane pays one refetch of data it
+		 * already had. A stale answer is a lie; a refetch is a wait.
+		 */
+		if (event.runId) {
+			for (const key of [
+				queryKeys.runs.detail(event.runId),
+				queryKeys.runs.report(event.runId),
+				queryKeys.runs.samples(event.runId),
+				queryKeys.runs.timeSeries(event.runId),
+				queryKeys.runs.monitorSeries(event.runId),
+			]) {
+				queryClient.removeQueries({ queryKey: key });
+			}
 		}
 	},
 

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2230,6 +2230,12 @@ export interface McpDataChangedEvent {
 	collectionId?: string;
 	/** The saved request the call named, when it named one. */
 	requestId?: string;
+	/**
+	 * The history run the call named, when it named one. Only the tools that
+	 * rewrite or remove an *existing* run spell this (`stop_run`,
+	 * `set_run_baseline`, `delete_run`).
+	 */
+	runId?: string;
 }
 
 export interface ScriptCompletion {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1300,14 +1300,26 @@ to keys through `lib/mcp-invalidation.ts`:
 | `collection` | `collections.all`, `requests.all` | A `delete_collection` cascades through descendants and their requests, and which rows those were is engine-side knowledge - the same reason `useDeleteCollectionMutation` invalidates coarsely |
 | `request` | `requests.listByCollection(collectionId)`, or `requests.lists()` when the call named no collection, plus `requests.detail(requestId)` when the call named one row | The same narrowing `useUpdateRequestMutation` does; without a named owner the owner is unknowable here. The detail key is for `update_request` / `delete_request`: it is `staleTime: Infinity`, so a restored tab would otherwise keep serving the copy it read on open |
 | `environment` | `environments.all`, `compose.all` | Variables are read through the detail cache as well as the list; `POST /compose` substitutes those same variables, and nothing refetches a composition on its own |
-| `run` | `runs.lists()`, `runs.allRuns()`, plus `runs.lastDesign(requestId)` and `runs.recentDesign(requestId)` when the call named one | The history list polls, but Settings' count, a request tab's restored response and its Recent sends list do not |
+| `run` | `runs.lists()`, `runs.allRuns()`, `runs.baselines()`, `runs.recentDesigns()`, `runs.lastCollectionRuns()`, plus `runs.lastDesign(requestId)` when the call named one - and a **removal** of `runs.detail/report/samples/timeSeries/monitorSeries` for a named `runId` | The history list polls, but Settings' count, the vs-baseline strip, Recent sends and Last run do not. The three prefixes rather than per-row keys because a run id gives no way back to the request or collection it belonged to - the same trade `useDeleteRunMutation` makes |
 | `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
 | `config` | `config.all` | |
 
 The event carries no engine data, only which family went stale, so a row still
 reaches the UI by exactly one path: the query layer. Per-run reports and time
-series are deliberately left alone - a new run cannot have changed an existing
-run's report. The entity list is duplicated across the process boundary
+series are still never invalidated *wholesale* - a new run cannot have changed
+an existing run's report, and those are the expensive fetches in the family.
+They are dropped only for the one run a call named: `stop_run`,
+`set_run_baseline` and `delete_run` each take a `runId`, and the event carries
+it as a third scope hint. Removal rather than invalidation, because `samples`
+and both series are `staleTime: Infinity` - a deleted run would otherwise go on
+rendering under an open History tab until its entry was garbage collected.
+`runs.detail` goes with them so the pane refetches, takes its 404 and shows
+`HistoryDetail`'s "This run no longer exists" state instead of a run the sidebar
+no longer lists. The hint says *which* run changed, not *how*, so a `set_run_baseline`
+costs an open detail pane one refetch of data it already had; a stale answer is
+a lie and a refetch is a wait. `runs.lastDesign` has no prefix family, so a
+deleted design run can still leave one stale - issue #776, shared with
+`useDeleteRunMutation`. The entity list is duplicated across the process boundary
 (`MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`, `McpDataEntity` in
 `types/domain.ts`) because production code under `electron/` cannot import from
 `app/src`; `data-changed.conformance.test.ts` is what keeps the copies equal,

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -958,8 +958,15 @@ Each tool declares the data families it changes (`invalidates` in `tools.ts`)
 and `dispatchTool` - the single dispatch path - sends one `mcp:data-changed` per
 family after a call that did **not** return an error. The event names a family
 (`request`, `environment`, `run`, `cookie`, `config`) plus the `collectionId` /
-`requestId` the call itself named; it carries no engine data, so the renderer
-still reads every row through its query layer. The renderer side, including
+`requestId` / `runId` the call itself named; it carries no engine data, so the
+renderer still reads every row through its query layer. The three hints are read
+off the call's own arguments at the dispatch chokepoint, which is what keeps a
+new write tool from having to remember an emit of its own - every tool in the
+registry spells them the same way. They are hints, not identity: `requestId` on
+a `run` event is the saved request a design run was linked to, while `runId` is
+the run itself, and only the tools that rewrite or remove an **existing** run
+(`stop_run`, `set_run_baseline`, `delete_run`) name one - a runner's new run has
+no per-run cache to drop yet. The renderer side, including
 which query keys each family maps to, is in
 [`docs/app/state-management.md`](../app/state-management.md).
 


### PR DESCRIPTION
## Description

**Root cause.** `INVALIDATORS.run` (`app/src/lib/mcp-invalidation.ts`) was written while every run-invalidating tool only *created* runs, so it took `runs.lists()` and `runs.allRuns()` and deliberately left everything per-run alone. #755 added `delete_run` and `set_run_baseline`, which change or remove an *existing* run and carry a `runId` rather than a `requestId` - so the families `useDeleteRunMutation` and `useSetRunBaselineMutation` clear for the identical write made in the UI were exactly the ones MCP did not.

**Approach.** Two halves, matching the two shapes of staleness:

1. The three prefix families the renderer's own mutations invalidate - `runs.baselines()`, `runs.recentDesigns()`, `runs.lastCollectionRuns()` - now go on every `run` event, for the reason those mutations give: a run id offers no way back to the request or collection it belonged to, and each is a five-row list where only mounted observers refetch. The per-request `recentDesign(requestId)` call is dropped as redundant under its own prefix; `lastDesign(requestId)` stays, having no prefix to be covered by.
2. The event gains a third scope hint, `runId`, read off the call's arguments at the same chokepoint as the other two - so no tool needs an emit of its own. When present, that run's `detail` / `report` / `samples` / `timeSeries` / `monitorSeries` entries are **removed**, not invalidated: `samples` and both series are `staleTime: Infinity`, so a deleted run went on rendering under an open History tab until its entry was garbage collected. Dropping `detail` is what makes the deleted case *correct* rather than merely fresh - it lets `runDetailOptions` refetch, take its 404, and hand `HistoryDetail` the `RunNotFoundError` it already renders as "This run no longer exists" (verified present at `HistoryDetail.tsx:100`, which answers the issue's "check whether the History view handles the selected run vanishing" - it does, it just was never given the chance).

**Alternative rejected.** Giving the event delete-vs-update semantics (a `deleted: true` flag, or a per-tool emit) so the removal fires only for `delete_run`. Rejected because it breaks the generic hint mechanism - `notifyDataChanged` reads hints straight off the call's arguments, which is what keeps a new write tool from having to remember an emit - and the imprecision costs little in practice: after `stop_run` the report and series genuinely did change (the run went terminal), and after `set_run_baseline` an open detail pane pays one localhost refetch of data it already had. A stale answer is a lie; a refetch is a wait.

**Deviations from the issue spec.** Two, both additive:
- `runs.detail` is removed alongside the four families the issue names. Without it the acceptance criterion "no surface still reads the deleted run from cache" cannot hold - the detail pane's header is such a surface.
- The conformance test now mirrors the *event shape*, not just the entity union, as the issue's Tests section asked. Mutual assignability alone cannot see an extra optional property, so the property names are compared too; the check is the compiler's, and `pnpm type-check` is where it fails.

One correction to the issue's Problem section: `runs.report` is `staleTime: RUNS_STALE_TIME_MS`, not `Infinity` - only `samples`, `timeSeries` and `monitorSeries` are `Infinity`. It does not change the fix, since the report was still never invalidated by an MCP write at all.

**Deferred.** `runs.lastDesign` is the one family with no plural prefix to widen to (`keys.ts:53`), so a deleted design run can still leave an open request tab restoring a response that no longer exists. `useDeleteRunMutation` has the identical hole, so this is not an MCP bug and closing it means a `keys.ts` change plus both readers - filed as **#776** and referenced from the code comment and the doc rather than left as a "later".

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only change (renderer + Electron main); no C++ touched, so no engine rebuild or `ctest` run - per `CLAUDE.md`, no engine test could change colour.

- `pnpm test` - **502 files, 5310 tests, all passing** (230s)
- `pnpm type-check` - clean (all three projects, including the new compile-time event mirror)
- `pnpm lint` - clean (zero errors, zero warnings)
- `pnpm prettier --check` on the six touched source files - clean
- No em-dashes; no repo-wide formatting

**Mutation check** (per `CLAUDE.md`): with the three prefix invalidations removed and `removeQueries` stubbed out, three guards fail and the other fourteen pass -

```
× a run invalidates the baseline, Recent sends and Last run families
× a named run has its report, samples, both series and detail removed
× a deleted run really is gone from a live cache, not just marked stale
  Tests  3 failed | 14 passed (17)
```

New coverage:
- `mcp-invalidation.test.ts` - the three prefixes; the five removed keys in order; that removal is keyed rather than a `runs.all` sweep (another run's report survives); an event with no `runId` removes nothing; and one test against a **real** `QueryClient` proving the entries are gone from the cache rather than merely named in a spy.
- `data-changed.test.ts` - `delete_run` emits `{entity: "run", runId: "run_1"}`; a runner emits no `runId` at all (the hint means "this existing run changed", and attaching it to a create would drop caches for a run nothing has fetched). `stop_run`'s existing assertion was updated to the new shape.
- `data-changed.conformance.test.ts` - the event-shape mirror described above.

`mkdocs build --strict` was not run - mkdocs is not installed in this environment, and the docs edits are prose plus one table cell with no new links, headings or nav entries.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/state-management.md` (the `run` row of the `mcp:data-changed` table, plus the paragraph explaining why per-run reports are still not invalidated wholesale - kept and rewritten rather than deleted, per the third acceptance criterion) and `docs/engine/mcp.md` (the emitting side: the third hint, where the hints come from, and which tools name one).

## Related Issues
Closes #774

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkD5Vv8ZT556J8NiqNFatR)_