### PR TITLE
fix(app/history): give `lastDesign` a prefix family so a deleted run stops being restored into an open tab

### DIFF
--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -91,8 +91,13 @@ export type McpDataEntity = (typeof MCP_DATA_ENTITIES)[number];
  * The three scope hints are read from the call's own arguments and narrow the
  * invalidation to the caches that can have gone stale; each is absent when the
  * call did not name it. They are hints, not identity: `requestId` on a
- * `run` event is the saved request a design run was linked to (the key
- * `runs.lastDesign` uses), not the run's own id - `runId` is that.
+ * `run` event is the saved request a design run was linked to, not the run's
+ * own id - `runId` is that. The renderer narrows on `collectionId` (the
+ * `request` family's list key) and on `runId` (the per-run caches it removes);
+ * a run event's `requestId` is emitted because every hint is read off the same
+ * arguments, and the run families it could narrow are invalidated at their
+ * prefixes instead - a `delete_run` names no request, so a per-request key
+ * could not reach the caches a delete moves (see `lib/mcp-invalidation.ts`).
  */
 export interface McpDataChangedEvent {
 	entity: McpDataEntity;

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -102,9 +102,38 @@ describe("invalidateForMcpEvent", () => {
 		expect(keys).toContainEqual(queryKeys.runs.lastCollectionRuns());
 	});
 
-	test("a run linked to a saved request also invalidates its last design run", () => {
+	test("a run invalidates the last-design family whether or not it named a request", () => {
+		// The tools that take a run away - `delete_run`, `set_run_baseline` -
+		// name a `runId` and no request, so the per-request key could never
+		// reach the tab whose run went. Every open request tab mounts
+		// `useLastDesignRunQuery`, which is what would otherwise go on
+		// restoring a deleted run's response.
+		expect(keysFor({ entity: "run", runId: "run_1" }).keys).toContainEqual(
+			queryKeys.runs.lastDesigns()
+		);
+		expect(keysFor({ entity: "run", requestId: "req_7" }).keys).toContainEqual(
+			queryKeys.runs.lastDesigns()
+		);
+	});
+
+	test("the last-design prefix is taken instead of the narrower per-request key", () => {
+		// Not both: the prefix already covers the row, and a duplicate narrower
+		// invalidation is the kind of near-copy that drifts from the prefix.
 		const { keys } = keysFor({ entity: "run", requestId: "req_7" });
-		expect(keys).toContainEqual(queryKeys.runs.lastDesign("req_7"));
+		expect(keys).not.toContainEqual(queryKeys.runs.lastDesign("req_7"));
+	});
+
+	test("a run really does clear an open tab's last-design cache, not just the named request's", () => {
+		// Against a real client: the prefix has to match a cache keyed by a
+		// request the event never mentioned, which is the whole point of it.
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(queryKeys.runs.lastDesign("req_other"), { data: [{ id: "r1" }] });
+
+		invalidateForMcpEvent(queryClient, { entity: "run", runId: "run_1" });
+
+		expect(
+			queryClient.getQueryState(queryKeys.runs.lastDesign("req_other"))?.isInvalidated
+		).toBe(true);
 	});
 
 	test("a run that named no id leaves every per-run cache alone", () => {

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -105,9 +105,13 @@ const INVALIDATORS: Record<
 	 * `useDeleteRunMutation` makes for the same reason: a run id gives no way
 	 * back to the request or collection it belonged to.
 	 *
-	 * `lastDesign` has no prefix family of its own, so it stays per request and
-	 * is reached only when the call named one. Issue #776 tracks that gap, which
-	 * `useDeleteRunMutation` shares.
+	 * `lastDesigns()` is a prefix for that same reason and takes the same trade
+	 * knowingly: `delete_run` and `set_run_baseline` name a `runId` and no
+	 * request, so a per-request key could never reach the tab whose run went
+	 * away, while a `run_request` now invalidates every open tab's last-design
+	 * query rather than the one it ran. Each is a single filtered row, only
+	 * mounted tabs refetch, and the alternative is carrying a run-to-request map
+	 * purely to patch it.
 	 *
 	 * Per-run *report* and series keys are still not invalidated wholesale, and
 	 * that exclusion is the point: a `run_request` creates a run and cannot have
@@ -120,11 +124,7 @@ const INVALIDATORS: Record<
 		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.baselines() });
 		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.recentDesigns() });
 		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lastCollectionRuns() });
-		if (event.requestId) {
-			void queryClient.invalidateQueries({
-				queryKey: queryKeys.runs.lastDesign(event.requestId),
-			});
-		}
+		void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lastDesigns() });
 		/*
 		 * A named run is one that already existed and was rewritten or removed
 		 * (`delete_run`, `stop_run`, `set_run_baseline` - the only tools that take

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -49,9 +49,14 @@ export const queryKeys = {
 		// plain `RunListResponse`, so it must NOT sit under `lists()`: the
 		// delete-run patch walks every cache under that prefix as `InfiniteData`
 		// and threw on this shape (`old.pages` undefined) for any open request
-		// tab. Its own family keeps the two apart at the root.
-		lastDesign: (requestId: string) =>
-			[...queryKeys.runs.all, "lastDesign", requestId] as const,
+		// tab. Its own family keeps the two apart at the root. `lastDesigns()`
+		// is the prefix to invalidate when the run set changes without a known
+		// request (a delete, a history clear): a run id gives no way back to the
+		// request the run belonged to, and `RequestBuilderProvider` mounts this
+		// query for every open request tab, so without the prefix a deleted run
+		// goes on being restored into one.
+		lastDesigns: () => [...queryKeys.runs.all, "lastDesign"] as const,
+		lastDesign: (requestId: string) => [...queryKeys.runs.lastDesigns(), requestId] as const,
 		// The last N design runs of one request, for the context bar's Recent
 		// sends section. Its own family for the same reason `lastDesign` has
 		// one: it caches a plain `RunListResponse`, and the delete-run patch

--- a/app/src/queries/runs.query.test.tsx
+++ b/app/src/queries/runs.query.test.tsx
@@ -38,6 +38,7 @@ import {
 	runsPollInterval,
 	runDetailOptions,
 	useDeleteRunMutation,
+	useInvalidateRuns,
 	RunNotFoundError,
 	isRunNotFound,
 } from "./runs";
@@ -356,6 +357,29 @@ describe("useDeleteRunMutation with a foreign cache shape under the runs prefix"
 		const lastDesign = queryKeys.runs.lastDesign("req_1") as readonly unknown[];
 		// Not a prefix match: `setQueriesData({queryKey: lists()})` must not reach it.
 		expect(lastDesign.slice(0, lists.length)).not.toEqual([...lists]);
+		// ...but inside its own family, so a delete or a history clear reaches
+		// it. The prefix is load-bearing only while this holds: a `lastDesign`
+		// built at the root again would silently stop being invalidated.
+		const family = queryKeys.runs.lastDesigns() as readonly unknown[];
+		expect(lastDesign.slice(0, family.length)).toEqual([...family]);
+	});
+
+	it("invalidates the last-design family, so an open tab stops restoring the deleted run", async () => {
+		// A run id gives no way back to the request the run belonged to, so the
+		// prefix is the only reach a delete has - and every open request tab
+		// mounts `useLastDesignRunQuery` on the row that just went away.
+		const client = seededClient();
+		client.setQueryData(queryKeys.runs.lastDesign("req_1"), page([runRow("r1")]));
+		deleteRun.mockResolvedValue(undefined);
+
+		const { result } = renderHook(() => useDeleteRunMutation(), { wrapper: wrapper(client) });
+		await result.current.mutateAsync("r1");
+
+		await waitFor(() =>
+			expect(client.getQueryState(queryKeys.runs.lastDesign("req_1"))?.isInvalidated).toBe(
+				true
+			)
+		);
 	});
 
 	it("deletes cleanly with a last-design-run cache present, and patches every cache", async () => {
@@ -404,6 +428,34 @@ describe("useDeleteRunMutation with a foreign cache shape under the runs prefix"
 		await expect(result.current.mutateAsync("r1")).resolves.toBeUndefined();
 		// Untouched - the updater does not know this shape and says so by refusing it.
 		expect(client.getQueryData(strayKey)).toEqual(page([runRow("r1")]));
+	});
+});
+
+/**
+ * Clearing the history removes every run at once, so each family keyed outside
+ * `runs.lists()` has to be named here or it survives the clear - which is the
+ * same hole a delete leaves, one scale up.
+ */
+describe("useInvalidateRuns", () => {
+	it("names every run family that lives outside the list prefix", () => {
+		const client = makeClient();
+		const spy = vi.spyOn(client, "invalidateQueries").mockReturnValue(Promise.resolve());
+
+		const { result } = renderHook(() => useInvalidateRuns(), { wrapper: wrapper(client) });
+		result.current();
+
+		const keys = spy.mock.calls.map(([filters]) => filters?.queryKey);
+		for (const key of [
+			queryKeys.runs.lists(),
+			queryKeys.runs.allRuns(),
+			queryKeys.runs.recentDesigns(),
+			queryKeys.runs.lastCollectionRuns(),
+			queryKeys.runs.baselines(),
+			queryKeys.runs.lastDesigns(),
+		]) {
+			expect(keys).toContainEqual(key);
+		}
+		spy.mockRestore();
 	});
 });
 

--- a/app/src/queries/runs.ts
+++ b/app/src/queries/runs.ts
@@ -569,6 +569,11 @@ export function useDeleteRunMutation() {
 			// same reason: the deleted run may have been the pin, and its id
 			// gives no way back to the request it was pinned for.
 			void queryClient.invalidateQueries({ queryKey: queryKeys.runs.baselines() });
+			// And the per-request last-design caches, for the fourth time and
+			// the same reason. This one is the tab-visible case: every open
+			// request tab mounts `useLastDesignRunQuery`, so without it a tab
+			// goes on restoring the response of the run just deleted.
+			void queryClient.invalidateQueries({ queryKey: queryKeys.runs.lastDesigns() });
 		},
 	});
 }
@@ -625,8 +630,9 @@ export function useSetRunBaselineMutation() {
 /**
  * Invalidate every runs list (trigger refetch) - the polled infinite list, the
  * all-runs Settings query, the per-request Recent sends and per-collection
- * Last run lists, and the per-request baseline lookups, which are their own
- * families and would otherwise survive a cleared history.
+ * Last run lists, the per-request baseline lookups and the per-request
+ * last-design lookups, which are their own families and would otherwise survive
+ * a cleared history.
  */
 export function useInvalidateRuns() {
 	const queryClient = useQueryClient();
@@ -637,5 +643,6 @@ export function useInvalidateRuns() {
 		queryClient.invalidateQueries({ queryKey: queryKeys.runs.recentDesigns() });
 		queryClient.invalidateQueries({ queryKey: queryKeys.runs.lastCollectionRuns() });
 		queryClient.invalidateQueries({ queryKey: queryKeys.runs.baselines() });
+		queryClient.invalidateQueries({ queryKey: queryKeys.runs.lastDesigns() });
 	};
 }

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1104,7 +1104,12 @@ sibling lists and a drop index into the minimal set of rows to rewrite.
   **not** sit under `runs.lists()`: `RequestBuilderProvider` mounts it for every
   open request tab, and the delete-run patch walks that prefix as
   `InfiniteData`. Keeping the two shapes apart at the root is the rule - a
-  prefix patch must never meet a cache shape it did not write.
+  prefix patch must never meet a cache shape it did not write. Under the
+  `lastDesigns()` prefix, like the three families below it, so a delete, a
+  cleared history or an MCP `run` event reaches it without knowing which
+  request it belonged to (#776): a run id gives no way back to one, and until
+  the prefix existed a deleted design run went on being restored into the tab
+  that had it open.
 - **`useRecentDesignRunsQuery(requestId)`** - The last `RECENT_DESIGN_RUN_LIMIT`
   (5) design runs of a request, newest first, behind the context bar's **Recent
   sends** section. One filtered call (`?requestId=&type=design&limit=5`) and
@@ -1225,6 +1230,7 @@ runs: {
   all: ["runs"],
   lists: () => ["runs", "list"],
   list: (filters = {}) => ["runs", "list", filters],      // keyed by its server-side filters (q, baseline)
+  lastDesigns: () => ["runs", "lastDesign"],               // prefix: invalidate every request's last run
   lastDesign: (requestId) => ["runs", "lastDesign", requestId],
   recentDesigns: () => ["runs", "recentDesign"],           // prefix: invalidate every request's list
   recentDesign: (requestId) => ["runs", "recentDesign", requestId],
@@ -1300,7 +1306,7 @@ to keys through `lib/mcp-invalidation.ts`:
 | `collection` | `collections.all`, `requests.all` | A `delete_collection` cascades through descendants and their requests, and which rows those were is engine-side knowledge - the same reason `useDeleteCollectionMutation` invalidates coarsely |
 | `request` | `requests.listByCollection(collectionId)`, or `requests.lists()` when the call named no collection, plus `requests.detail(requestId)` when the call named one row | The same narrowing `useUpdateRequestMutation` does; without a named owner the owner is unknowable here. The detail key is for `update_request` / `delete_request`: it is `staleTime: Infinity`, so a restored tab would otherwise keep serving the copy it read on open |
 | `environment` | `environments.all`, `compose.all` | Variables are read through the detail cache as well as the list; `POST /compose` substitutes those same variables, and nothing refetches a composition on its own |
-| `run` | `runs.lists()`, `runs.allRuns()`, `runs.baselines()`, `runs.recentDesigns()`, `runs.lastCollectionRuns()`, plus `runs.lastDesign(requestId)` when the call named one - and a **removal** of `runs.detail/report/samples/timeSeries/monitorSeries` for a named `runId` | The history list polls, but Settings' count, the vs-baseline strip, Recent sends and Last run do not. The three prefixes rather than per-row keys because a run id gives no way back to the request or collection it belonged to - the same trade `useDeleteRunMutation` makes |
+| `run` | `runs.lists()`, `runs.allRuns()`, `runs.baselines()`, `runs.recentDesigns()`, `runs.lastCollectionRuns()`, `runs.lastDesigns()` - and a **removal** of `runs.detail/report/samples/timeSeries/monitorSeries` for a named `runId` | The history list polls, but Settings' count, the vs-baseline strip, Recent sends, Last run and every open tab's last design run do not. The four prefixes rather than per-row keys because a run id gives no way back to the request or collection it belonged to - the same trade `useDeleteRunMutation` makes |
 | `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
 | `config` | `config.all` | |
 
@@ -1317,9 +1323,11 @@ rendering under an open History tab until its entry was garbage collected.
 `HistoryDetail`'s "This run no longer exists" state instead of a run the sidebar
 no longer lists. The hint says *which* run changed, not *how*, so a `set_run_baseline`
 costs an open detail pane one refetch of data it already had; a stale answer is
-a lie and a refetch is a wait. `runs.lastDesign` has no prefix family, so a
-deleted design run can still leave one stale - issue #776, shared with
-`useDeleteRunMutation`. The entity list is duplicated across the process boundary
+a lie and a refetch is a wait. `runs.lastDesigns()` is taken at its prefix and
+never per request (#776): `delete_run` and `set_run_baseline` name a `runId` and
+no request, so the narrow key could not reach the tab whose run went away, and
+the cost of the prefix is that a `run_request` refetches one filtered row per
+*mounted* tab instead of one. The entity list is duplicated across the process boundary
 (`MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`, `McpDataEntity` in
 `types/domain.ts`) because production code under `electron/` cannot import from
 `app/src`; `data-changed.conformance.test.ts` is what keeps the copies equal,


### PR DESCRIPTION
## Description

`runs.lastDesign(requestId)` was the one per-request run family keyed at the root of `runs.all` with no plural prefix, so nothing that changes the run set *without naming a request* could reach it. `RequestBuilderProvider` mounts `useLastDesignRunQuery` for every open request tab, so deleting a request's most recent design run - from History, over MCP, or by clearing the history - left that tab restoring the response of a run the sidebar no longer lists.

**Plan.** Root cause: `lastDesign` earned its own family for a shape reason (it caches a plain `RunListResponse`, and the delete-run patch walks everything under `lists()` as `InfiniteData`) but never got the plural key the other three shape-siblings have, so `useDeleteRunMutation` and `INVALIDATORS.run` had nothing to invalidate - and a run id gives no way back to the request the run belonged to. Approach: add `lastDesigns()` and build `lastDesign(requestId)` from it, so the **cache key is byte-identical** and only the reach changes; then take the prefix in every reader. The alternative rejected is the one #774 rejected for the other three families: carrying a run-to-request map so a delete could patch the exact row. It is real state to keep correct across `delete_run`, `stop_run`, `set_run_baseline` and history retention, purely to avoid refetching a single filtered row per *mounted* tab.

Changes:

- `queries/keys.ts` - `lastDesigns()` prefix, `lastDesign(requestId)` built from it, with the same one-line rationale the other three carry.
- `queries/runs.ts` - `useDeleteRunMutation` invalidates `lastDesigns()` alongside the three prefixes it already took.
- `queries/runs.ts` - `useInvalidateRuns` (Settings' *Clear run history*) does too. **Deviation from the issue, which named two readers:** this is the third invalidator of exactly these families, and its own doc comment claims to cover "their own families [that] would otherwise survive a cleared history". Clearing the history is the same hole one scale up, and leaving it while fixing the delete would have left a known-identical bug in the function directly below. One line, same family, locked by its own test.
- `lib/mcp-invalidation.ts` - `INVALIDATORS.run` invalidates `lastDesigns()` unconditionally; the narrower `if (event.requestId)` branch is **removed** rather than left duplicating a prefix that already covers it. `delete_run` and `set_run_baseline` name a `runId` and no request, so that branch could never reach the tab whose run went away.
- `electron/mcp/tools.ts` - the `McpDataChangedEvent` doc comment named `runs.lastDesign` as the reader of a run event's `requestId`; with the branch gone that was stale, so it now says which hints the renderer actually narrows on and why this one is not among them.

The trade is the one #774 accepted for the other three prefixes and is written down beside the code: a `run_request` now invalidates every *mounted* tab's last-design query rather than the one it ran. Each is a single `limit=1` row and only mounted tabs refetch.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, full: **502 files, 5314 tests, all passing.** `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on every touched file. No engine or C++ change, so no `build.py -t` / `ctest` run - nothing under `engine/` is touched and no engine test could change colour.

Five new/extended assertions, each mutation-checked (fix reverted, confirmed red, restored):

| Guard | Mutation that turns it red |
|---|---|
| `mcp-invalidation.test.ts`: a `run` event invalidates `lastDesigns()` whether it named a request or only a `runId` | drop the line from `INVALIDATORS.run` (2 tests red) |
| `mcp-invalidation.test.ts`: the prefix is taken *instead of* `lastDesign(requestId)` | re-add the narrower branch |
| `mcp-invalidation.test.ts`: against a real `QueryClient`, a `runId`-only event marks a cache keyed by a request it never mentioned as invalidated | drop the line (the point of the prefix) |
| `runs.query.test.tsx`: the delete mutation leaves `lastDesign("req_1")` invalidated | drop the line from `useDeleteRunMutation` (1 red) |
| `runs.query.test.tsx`: `useInvalidateRuns` names all six families | drop the line from `useInvalidateRuns` (1 red) |
| `runs.query.test.tsx`: `lastDesign(id)` is still a child of `lastDesigns()` and still outside `lists()` | key `lastDesign` at the root again (3 red across both files) |

The last one is the load-bearing invariant: the prefix only works while `lastDesign(id)` stays under it, and a future edit that re-roots the key would otherwise silently stop being invalidated again.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit (`docs/app/state-management.md`): the `useLastDesignRunQuery` bullet gains the prefix beside the other three, the key-factory listing gains `lastDesigns()`, and the `mcp:data-changed` table's `run` row drops the "#776" caveat this PR is.

## Related Issues
Closes #776

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3dQEsnAco4FyehHygroDx)_