### PR TITLE
feat(app/mcp): webhook inboxes over MCP - full lifecycle, captures, and the live canned response

### DIFF
--- a/app/electron/mcp/data-changed.conformance.test.ts
+++ b/app/electron/mcp/data-changed.conformance.test.ts
@@ -37,6 +37,7 @@ const RENDERER_ENTITIES: Record<McpDataEntity, true> = {
 	run: true,
 	cookie: true,
 	config: true,
+	service: true,
 };
 
 describe("McpDataEntity mirror", () => {

--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -47,6 +47,16 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		getRun: vi.fn().mockResolvedValue({ id: "run_1", type: "load", status: "completed" }),
 		deleteRun: vi.fn().mockResolvedValue({ message: "Run deleted successfully" }),
 		setRunBaseline: vi.fn().mockResolvedValue({ id: "run_1", baseline: true }),
+		startInbox: vi
+			.fn()
+			.mockResolvedValue({ inboxId: "inbox_1", url: "http://127.0.0.1:45001" }),
+		listInboxes: vi.fn().mockResolvedValue({
+			data: [{ inboxId: "inbox_1", url: "http://127.0.0.1:45001", captureCount: 2 }],
+		}),
+		stopInbox: vi.fn().mockResolvedValue({ inboxId: "inbox_1", running: false }),
+		deleteInbox: vi.fn().mockResolvedValue({ inboxId: "inbox_1", capturesDeleted: 2 }),
+		clearInboxCaptures: vi.fn().mockResolvedValue({ inboxId: "inbox_1", cleared: 2 }),
+		updateInboxResponse: vi.fn().mockResolvedValue({ inboxId: "inbox_1" }),
 		composeRequest: vi
 			.fn()
 			.mockImplementation((body: { request?: object }) =>
@@ -109,6 +119,14 @@ describe("the registry declares its effects", () => {
 			// lists, so both invalidate `run` exactly as the runners do.
 			set_run_baseline: ["run"],
 			delete_run: ["run"],
+			// Webhook inboxes (#756): every one of these changes what the Services
+			// drawer and the Dock's running-services count answer, and the two
+			// that touch captures change what an open inbox tab is showing.
+			start_webhook_inbox: ["service"],
+			stop_webhook_inbox: ["service"],
+			delete_webhook_inbox: ["service"],
+			clear_inbox_captures: ["service"],
+			update_inbox_response: ["service"],
 		};
 		for (const [name, entities] of Object.entries(expected)) {
 			const tool = TOOLS.find((t) => t.name === name);
@@ -330,6 +348,32 @@ describe("dispatch emits mcp:data-changed", () => {
 		// With the hint, because a stopped run's own report and series are what
 		// changed - it went terminal.
 		expect(onDataChanged).toHaveBeenCalledWith({ entity: "run", runId: "run_1" });
+	});
+
+	test("an inbox call names the inbox it acted on, so the captures cache can be dropped", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
+		const res = await dispatchTool("clear_inbox_captures", { inboxId: "inbox_1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		// The hint is what makes a clear correct renderer-side: an invalidation
+		// alone refetches into a cache that still holds the cleared rows and
+		// unions them straight back (see `lib/mcp-invalidation.ts`).
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "service", inboxId: "inbox_1" });
+	});
+
+	test("starting an inbox reports the family with no id to narrow by", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
+		const res = await dispatchTool("start_webhook_inbox", { port: 0 }, ctx);
+		expect(res.isError).toBeFalsy();
+		// The engine assigns the id, so there is none in the arguments - and a new
+		// inbox has no capture cache to drop anyway.
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "service" });
+	});
+
+	test("an unconfirmed inbox delete emits nothing - nothing changed", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
+		const res = await dispatchTool("delete_webhook_inbox", { inboxId: "inbox_1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		expect(onDataChanged).not.toHaveBeenCalled();
 	});
 
 	test("a context without a notifier dispatches normally", async () => {

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -741,6 +741,100 @@ export class EngineClient {
 			signal
 		);
 	}
+
+	// --- Local services: the webhook inbox -----------------------------------
+	//
+	// The inbox routes take a `bind` and a `confirmNonLoopback` flag; nothing
+	// here sends either, so every inbox an MCP call starts listens on the
+	// engine's loopback default. That is a stated non-goal of epic #753 rather
+	// than an omission, and it is enforced by the payload builder in `tools.ts`
+	// (`inboxStartPayload`) - this client takes the payload it is given.
+
+	/**
+	 * Start an inbox: `POST /inbox/start`. Every field of the body is optional;
+	 * the engine assigns the id and, for `port: 0` or no port at all, the port.
+	 * The reply is the inbox record (`inboxId`, `url`, `bind`, `port`,
+	 * `running`, `loopback`, `captureCount`, `response`).
+	 */
+	startInbox(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		return this.request("POST", "/inbox/start", payload, signal);
+	}
+
+	/** Every inbox this engine process has started, running or stopped: `GET /inbox`. */
+	listInboxes(signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", "/inbox", undefined, signal);
+	}
+
+	/**
+	 * Free the listener, keep the record and its captures:
+	 * `POST /inbox/:id/stop`. Answers the stopped record; an unknown id is a 404.
+	 */
+	stopInbox(inboxId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request(
+			"POST",
+			`/inbox/${encodeURIComponent(inboxId)}/stop`,
+			undefined,
+			signal
+		);
+	}
+
+	/**
+	 * Stop the listener, drop the record and its captures: `DELETE /inbox/:id`.
+	 * Answers `{inboxId, capturesDeleted}` - the count is what makes a delete
+	 * confirmable in terms of what is actually lost.
+	 */
+	deleteInbox(inboxId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request("DELETE", `/inbox/${encodeURIComponent(inboxId)}`, undefined, signal);
+	}
+
+	/**
+	 * One inbox's captures, newest first: `GET /inbox/:id/requests?limit=&offset=`
+	 * in the `{data, pagination}` envelope. The rows are the whole captures -
+	 * the engine has no per-capture detail route, so a list read is a full read.
+	 *
+	 * The engine clamps `limit` to the inbox's own retention silently; the tool
+	 * over this refuses above its bound instead, for the #319 reason.
+	 */
+	getInboxCaptures(
+		inboxId: string,
+		limit: number,
+		offset: number,
+		signal?: AbortSignal
+	): Promise<unknown> {
+		const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+		return this.request(
+			"GET",
+			`/inbox/${encodeURIComponent(inboxId)}/requests?${params.toString()}`,
+			undefined,
+			signal
+		);
+	}
+
+	/**
+	 * Drop the captures, keep the listener: `DELETE /inbox/:id/requests`.
+	 * Answers `{inboxId, cleared}`.
+	 */
+	clearInboxCaptures(inboxId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request(
+			"DELETE",
+			`/inbox/${encodeURIComponent(inboxId)}/requests`,
+			undefined,
+			signal
+		);
+	}
+
+	/**
+	 * Merge-patch the canned response, live: `PUT /inbox/:id`. Absent fields
+	 * keep their current value engine-side, so a caller changing the status does
+	 * not have to restate the body and headers. Answers the updated record.
+	 */
+	updateInboxResponse(
+		inboxId: string,
+		response: unknown,
+		signal?: AbortSignal
+	): Promise<unknown> {
+		return this.request("PUT", `/inbox/${encodeURIComponent(inboxId)}`, response, signal);
+	}
 }
 
 /** True for the rejection a fetch produces when its signal aborts. */

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -8,9 +8,11 @@
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import {
+	DEFAULT_INBOX_CAPTURE_LIMIT,
 	DEFAULT_RUN_SAMPLE_LIMIT,
 	DEFAULT_RUN_SERIES_LIMIT,
 	dispatchTool,
+	MAX_INBOX_CAPTURE_LIMIT,
 	MAX_IN_FLIGHT_BOUND,
 	MAX_INLINE_BODY_BYTES,
 	MAX_REPORT_TRACE_BYTES,
@@ -132,6 +134,36 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		}),
 		listMockIssuers: vi.fn().mockResolvedValue({ issuers: [] }),
 		stopMockIssuer: vi.fn().mockResolvedValue({ stopped: true }),
+		startInbox: vi.fn().mockResolvedValue({
+			inboxId: "inbox_1",
+			url: "http://127.0.0.1:45001",
+			bind: "127.0.0.1",
+			port: 45001,
+			running: true,
+			loopback: true,
+			captureCount: 0,
+			response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		}),
+		listInboxes: vi.fn().mockResolvedValue({
+			data: [
+				{
+					inboxId: "inbox_1",
+					url: "http://127.0.0.1:45001",
+					port: 45001,
+					running: true,
+					loopback: true,
+					captureCount: 3,
+					response: { status: 200, body: "", headers: {}, delayMs: 0 },
+				},
+			],
+		}),
+		stopInbox: vi.fn().mockResolvedValue({ inboxId: "inbox_1", running: false }),
+		deleteInbox: vi.fn().mockResolvedValue({ inboxId: "inbox_1", capturesDeleted: 3 }),
+		getInboxCaptures: vi.fn().mockResolvedValue(emptyPage()),
+		clearInboxCaptures: vi.fn().mockResolvedValue({ inboxId: "inbox_1", cleared: 3 }),
+		updateInboxResponse: vi
+			.fn()
+			.mockResolvedValue({ inboxId: "inbox_1", response: { status: 503 } }),
 		...overrides,
 	} as unknown as EngineClient;
 }
@@ -4409,6 +4441,348 @@ describe("run housekeeping tools", () => {
 			expect(res.isError).toBe(true);
 			expect(firstText(res)).toMatch(/NOT deleted/);
 			expect(firstText(res)).toMatch(/again/i);
+		});
+	});
+});
+
+describe("webhook inbox tools", () => {
+	const byName = () => new Map(TOOLS.map((t) => [t.name, t]));
+	const forwarded = (client: EngineClient, method: keyof EngineClient) =>
+		(client[method] as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+	const allText = (r: { content: Array<{ text: string }> }) =>
+		r.content.map((c) => c.text).join("\n");
+
+	describe("the loopback guarantee", () => {
+		test("no inbox payload can carry a bind or a non-loopback confirmation", async () => {
+			// The mutation check for epic #753's stated non-goal: an inbox MCP
+			// started must not be reachable off this machine. Asserted as the
+			// *absence* of both fields, whatever the caller sent - the engine only
+			// leaves loopback when it is asked to, so never asking is the guard.
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"start_webhook_inbox",
+				{ port: 45001, bind: "0.0.0.0", confirmNonLoopback: true },
+				ctxWith(client)
+			);
+			expect(res.isError).toBeFalsy();
+			const payload = forwarded(client, "startInbox")[0] as Record<string, unknown>;
+			expect(payload).not.toHaveProperty("bind");
+			expect(payload).not.toHaveProperty("confirmNonLoopback");
+			expect(payload).toEqual({ port: 45001 });
+		});
+
+		test("the schema does not offer a bind at all", () => {
+			const schema = byName().get("start_webhook_inbox")?.inputSchema ?? {};
+			expect(Object.keys(schema).sort()).toEqual(["port", "response"]);
+		});
+	});
+
+	describe("start_webhook_inbox", () => {
+		test("forwards only the canned-response fields the caller named", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"start_webhook_inbox",
+				{ response: { status: 202, body: "queued", delayMs: 250 } },
+				ctxWith(client)
+			);
+			expect(res.isError).toBeFalsy();
+			// An absent field must stay absent: `PUT /inbox/:id` is a merge-patch
+			// and a spelled-out null is "reset this", not "unspecified".
+			expect(forwarded(client, "startInbox")[0]).toEqual({
+				response: { status: 202, body: "queued", delayMs: 250 },
+			});
+		});
+
+		test("needs no write toggle - it saves nothing", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"start_webhook_inbox",
+				{},
+				ctxWith(client, { allowWrites: false })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(client.startInbox).toHaveBeenCalled();
+		});
+	});
+
+	describe("get_inbox_captures", () => {
+		test("stated pagination is forwarded", async () => {
+			const client = fakeClient();
+			await dispatchTool(
+				"get_inbox_captures",
+				{ inboxId: "inbox_1", limit: 50, offset: 100 },
+				ctxWith(client)
+			);
+			expect(forwarded(client, "getInboxCaptures")).toEqual(["inbox_1", 50, 100, undefined]);
+		});
+
+		test("with no pagination it asks for the documented default page", async () => {
+			const client = fakeClient();
+			await dispatchTool("get_inbox_captures", { inboxId: "inbox_1" }, ctxWith(client));
+			expect(forwarded(client, "getInboxCaptures")).toEqual([
+				"inbox_1",
+				DEFAULT_INBOX_CAPTURE_LIMIT,
+				0,
+				undefined,
+			]);
+		});
+
+		test("a page beyond the tool's cap is refused, not clamped", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"get_inbox_captures",
+				{ inboxId: "inbox_1", limit: MAX_INBOX_CAPTURE_LIMIT + 1 },
+				ctxWith(client)
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toContain(String(MAX_INBOX_CAPTURE_LIMIT));
+			expect(client.getInboxCaptures).not.toHaveBeenCalled();
+		});
+
+		test("non-positive pagination is refused", async () => {
+			const client = fakeClient();
+			for (const args of [
+				{ inboxId: "inbox_1", limit: 0 },
+				{ inboxId: "inbox_1", offset: -1 },
+			]) {
+				const res = await dispatchTool("get_inbox_captures", args, ctxWith(client));
+				expect(res.isError).toBe(true);
+			}
+			expect(client.getInboxCaptures).not.toHaveBeenCalled();
+		});
+
+		test("a truncated page discloses what it left behind", async () => {
+			const client = fakeClient({
+				getInboxCaptures: vi
+					.fn()
+					.mockResolvedValue(page([{ id: 9, method: "POST" }], 400, 25)),
+			});
+			const res = await dispatchTool(
+				"get_inbox_captures",
+				{ inboxId: "inbox_1", offset: 25 },
+				ctxWith(client)
+			);
+			expect(allText(res)).toMatch(/1 of 400 captures/);
+			expect(allText(res)).toMatch(/offset: 26/);
+		});
+
+		test("a capture body past the inline bound is cut and says so", async () => {
+			// A webhook can post megabytes; the engine stores up to
+			// `inboxMaxBodyBytes` of it, which is configurable well past what a
+			// tool result can carry (issue #767's case, arriving by another route).
+			const body = "x".repeat(MAX_INLINE_BODY_BYTES + 500);
+			const client = fakeClient({
+				getInboxCaptures: vi.fn().mockResolvedValue(
+					page([
+						{ id: 1, method: "POST", body, bodyBytes: body.length },
+						{ id: 2, method: "POST", body: "small", bodyBytes: 5 },
+					])
+				),
+			});
+			const res = await dispatchTool(
+				"get_inbox_captures",
+				{ inboxId: "inbox_1" },
+				ctxWith(client)
+			);
+			const captures = (JSON.parse(firstText(res)) as { data: Record<string, unknown>[] })
+				.data;
+			expect((captures[0].body as string).length).toBeLessThanOrEqual(MAX_INLINE_BODY_BYTES);
+			expect(captures[0].bodyTruncated).toBe(true);
+			// The engine's own count of the original size survives the cut - a
+			// smaller number here would look just as real and be wrong.
+			expect(captures[0].bodyBytes).toBe(body.length);
+			// Under the bound nothing is touched, flag included.
+			expect(captures[1]).toEqual({ id: 2, method: "POST", body: "small", bodyBytes: 5 });
+		});
+
+		test("an unknown inbox is an engine error, not an empty page", async () => {
+			const client = fakeClient({
+				getInboxCaptures: vi
+					.fn()
+					.mockRejectedValue(
+						new EngineRequestError("Engine responded 404", 404, "Inbox not found")
+					),
+			});
+			const res = await dispatchTool(
+				"get_inbox_captures",
+				{ inboxId: "gone" },
+				ctxWith(client)
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toMatch(/404/);
+		});
+	});
+
+	describe("stop_webhook_inbox", () => {
+		test("stops without the write toggle, and keeps the captures", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"stop_webhook_inbox",
+				{ inboxId: "inbox_1" },
+				ctxWith(client, { allowWrites: false })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(client.stopInbox).toHaveBeenCalledWith("inbox_1", undefined);
+			expect(client.deleteInbox).not.toHaveBeenCalled();
+			// The distinction an agent has to be able to read off the tool list.
+			expect(byName().get("stop_webhook_inbox")?.description).toMatch(/NOT a delete/);
+		});
+	});
+
+	describe("delete_webhook_inbox", () => {
+		test("is refused while writes are off, without even reading the inbox", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"delete_webhook_inbox",
+				{ inboxId: "inbox_1", confirmed: true },
+				ctxWith(client, { allowWrites: false })
+			);
+			expect(res.isError).toBe(true);
+			expect(client.listInboxes).not.toHaveBeenCalled();
+			expect(client.deleteInbox).not.toHaveBeenCalled();
+		});
+
+		test("the preview names the real capture count and deletes nothing", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"delete_webhook_inbox",
+				{ inboxId: "inbox_1" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(firstText(res)).toMatch(/awaiting confirmation/i);
+			expect(firstText(res)).toContain("3 captured requests");
+			expect(firstText(res)).toContain("http://127.0.0.1:45001");
+			expect(client.deleteInbox).not.toHaveBeenCalled();
+		});
+
+		test("an empty inbox says so rather than leaving the count unstated", async () => {
+			const client = fakeClient({
+				listInboxes: vi.fn().mockResolvedValue({
+					data: [{ inboxId: "inbox_1", url: "http://127.0.0.1:45001", running: false }],
+				}),
+			});
+			const res = await dispatchTool(
+				"delete_webhook_inbox",
+				{ inboxId: "inbox_1" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(firstText(res)).toContain("0 captured requests");
+			expect(firstText(res)).toContain("stopped");
+		});
+
+		test("deletes once confirmed", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"delete_webhook_inbox",
+				{ inboxId: "inbox_1", confirmed: true },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(client.deleteInbox).toHaveBeenCalledWith("inbox_1", undefined);
+		});
+
+		test("an id the engine does not list is an argument error, not a delete", async () => {
+			const client = fakeClient({ listInboxes: vi.fn().mockResolvedValue({ data: [] }) });
+			const res = await dispatchTool(
+				"delete_webhook_inbox",
+				{ inboxId: "inbox_gone", confirmed: true },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toContain("inbox_gone");
+			expect(client.deleteInbox).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("clear_inbox_captures", () => {
+		test("is refused while writes are off", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"clear_inbox_captures",
+				{ inboxId: "inbox_1" },
+				ctxWith(client, { allowWrites: false })
+			);
+			expect(res.isError).toBe(true);
+			expect(client.clearInboxCaptures).not.toHaveBeenCalled();
+		});
+
+		test("clears with the toggle on, and needs no confirmation", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"clear_inbox_captures",
+				{ inboxId: "inbox_1" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(client.clearInboxCaptures).toHaveBeenCalledWith("inbox_1", undefined);
+		});
+	});
+
+	describe("update_inbox_response", () => {
+		test("sends only the named fields, so the rest keep their live values", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"update_inbox_response",
+				{ inboxId: "inbox_1", status: 503, delayMs: 0 },
+				ctxWith(client)
+			);
+			expect(res.isError).toBeFalsy();
+			expect(forwarded(client, "updateInboxResponse")).toEqual([
+				"inbox_1",
+				{ status: 503, delayMs: 0 },
+				undefined,
+			]);
+		});
+
+		test("a patch naming no field is refused instead of reported as applied", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"update_inbox_response",
+				{ inboxId: "inbox_1" },
+				ctxWith(client)
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toMatch(/status/);
+			expect(client.updateInboxResponse).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("categories and hints", () => {
+		test("the reads are reads, the listeners execute, and the two deletes write", () => {
+			const tools = byName();
+			expect(tools.get("list_webhook_inboxes")?.category).toBe("read");
+			expect(tools.get("get_inbox_captures")?.category).toBe("read");
+			expect(tools.get("start_webhook_inbox")?.category).toBe("execute");
+			expect(tools.get("stop_webhook_inbox")?.category).toBe("execute");
+			expect(tools.get("update_inbox_response")?.category).toBe("execute");
+			// Both destroy recorded data, so both sit behind the write toggle.
+			expect(tools.get("delete_webhook_inbox")?.category).toBe("write");
+			expect(tools.get("clear_inbox_captures")?.category).toBe("write");
+			expect(tools.get("delete_webhook_inbox")?.annotations.destructiveHint).toBe(true);
+			expect(tools.get("clear_inbox_captures")?.annotations.destructiveHint).toBe(true);
+			// A stop loses nothing, and neither reaches off the machine.
+			expect(tools.get("stop_webhook_inbox")?.annotations.destructiveHint).toBe(false);
+			for (const name of [
+				"start_webhook_inbox",
+				"list_webhook_inboxes",
+				"stop_webhook_inbox",
+				"delete_webhook_inbox",
+				"get_inbox_captures",
+				"clear_inbox_captures",
+				"update_inbox_response",
+			]) {
+				expect(tools.get(name)?.annotations.openWorldHint, name).toBe(false);
+			}
+		});
+
+		test("no tool offers the live SSE stream - polling the captures is the shape", () => {
+			// Single-watcher engine-side (a second is a 409), and the app's own
+			// inbox tab may hold it. Locked as a decision rather than an omission.
+			expect(
+				TOOLS.map((t) => t.name).filter((n) => /inbox.*live|live.*inbox/.test(n))
+			).toEqual([]);
+			expect(byName().get("get_inbox_captures")?.description).toMatch(/no live stream/i);
 		});
 	});
 });

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -80,6 +80,12 @@ export const MCP_DATA_ENTITIES = [
 	"run",
 	"cookie",
 	"config",
+	// The local services the engine hosts for as long as its process lives -
+	// webhook inboxes today, mock servers and issuers as #757 reaches them. One
+	// family rather than one per service: the renderer reads them through the
+	// Services drawer and the Dock's running-services count, which ask "what is
+	// listening" and not "which kind".
+	"service",
 ] as const;
 
 export type McpDataEntity = (typeof MCP_DATA_ENTITIES)[number];
@@ -107,6 +113,17 @@ export interface McpDataChangedEvent {
 	 * collection it ran, and the run it created has no per-run cache yet.
 	 */
 	runId?: string;
+	/**
+	 * The webhook inbox the call named, when it named one. Only the tools that
+	 * act on an *existing* inbox spell it (`stop_webhook_inbox`,
+	 * `delete_webhook_inbox`, `clear_inbox_captures`, `update_inbox_response`);
+	 * `start_webhook_inbox` has no id to name until the engine has answered.
+	 *
+	 * The renderer needs it because a capture list is not merely stale after a
+	 * clear or a delete - it is *wrong*, and its cache entry has to be dropped
+	 * rather than refetched into (see `lib/mcp-invalidation.ts`).
+	 */
+	inboxId?: string;
 }
 
 export interface ToolContext {
@@ -549,6 +566,24 @@ function describeRun(runId: string, run: Record<string, unknown>): string {
 }
 
 /**
+ * A webhook inbox named in words, for the prompt that asks a human to delete it.
+ *
+ * The capture count is the part that has to be there: a stopped inbox holding
+ * 40 recorded webhooks and one holding none are the same call with very
+ * different consequences, and only this sentence tells them apart. It is stated
+ * even at zero, because "captures 0 requests" is the reassurance that makes the
+ * prompt answerable - an absent count reads as unknown, not as none.
+ */
+function describeInbox(inboxId: string, inbox: Record<string, unknown>): string {
+	const parts: string[] = [];
+	if (typeof inbox.url === "string" && inbox.url !== "") parts.push(inbox.url);
+	parts.push(inbox.running === true ? "running" : "stopped");
+	const captures = typeof inbox.captureCount === "number" ? inbox.captureCount : 0;
+	parts.push(`${captures} captured request${captures === 1 ? "" : "s"}`);
+	return `the webhook inbox ${inboxId} (${parts.join(", ")})`;
+}
+
+/**
  * The `GET /runs` query a `list_runs` call describes.
  *
  * Only the filters the caller actually stated travel. An omitted one must not
@@ -574,15 +609,25 @@ function runListQuery(args: Record<string, unknown>): RunListQuery {
  * A paginated engine read whose result says what it left behind.
  * {@link callEngine} with a `shape` cannot do this: the caveat is text beside
  * the JSON, not a rewrite of it.
+ *
+ * `shape` is the same seam {@link callEngine} offers, and it runs before the
+ * caveat is computed - a page whose rows carry bodies is bounded here, and the
+ * caveat still describes the page the engine answered rather than the cut one
+ * (it reads `pagination`, which a body bound does not touch).
  */
-async function pagedRead(fn: () => Promise<unknown>, noun: string): Promise<ToolResult> {
+async function pagedRead(
+	fn: () => Promise<unknown>,
+	noun: string,
+	shape?: (value: unknown) => unknown
+): Promise<ToolResult> {
 	let answer: unknown;
 	try {
 		answer = await fn();
 	} catch (err) {
 		return engineErrorResult(err);
 	}
-	return withCaveat(jsonResult(answer), pageCaveat(answer, noun));
+	const caveat = pageCaveat(answer, noun);
+	return withCaveat(jsonResult(shape ? shape(answer) : answer), caveat);
 }
 
 /** Result that carries both a text rendering and structured content. */
@@ -2087,6 +2132,80 @@ function mockIssuerStartPayload(args: Record<string, unknown>): Record<string, u
 		if (args[key] !== undefined) payload[key] = args[key];
 	}
 	return payload;
+}
+
+// --- Webhook inbox -----------------------------------------------------------
+
+/**
+ * The canned-response fields `POST /inbox/start` and `PUT /inbox/:id` read
+ * (`apply_response_fields`, engine/src/http/routes/inbox.cpp). Both routes take
+ * the same block - start applies it to the defaults, the PUT merge-patches the
+ * live one - so one list serves both payload builders.
+ */
+const INBOX_RESPONSE_KEYS = ["status", "body", "headers", "delayMs"] as const;
+
+/**
+ * The canned response a call described, carrying only the fields it named.
+ *
+ * An omitted field must stay omitted rather than travel as `null`: the PUT is a
+ * merge-patch, so a spelled-out `null` would be the caller saying "reset this"
+ * where they said nothing at all. Bounds (a 100-599 status, a delay under 30s)
+ * are the engine's and come back as a `400` naming them - the schema owns the
+ * shape, the same division `mockIssuerStartPayload` documents.
+ */
+function inboxResponsePayload(response: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const key of INBOX_RESPONSE_KEYS) {
+		if (response[key] !== undefined) out[key] = response[key];
+	}
+	return out;
+}
+
+/**
+ * The `POST /inbox/start` body for a `start_webhook_inbox` call.
+ *
+ * **`bind` and `confirmNonLoopback` are never emitted**, whatever the arguments
+ * carry. Binding a listener to a routable interface exposes it beyond this
+ * machine, which epic #753 records as a non-goal for every MCP-hosted service -
+ * so the guarantee lives here, in the one function that builds the body, rather
+ * than in a schema an agent could be tempted to route around. With no `bind`
+ * the engine uses its loopback default, and its non-loopback refusal never
+ * comes into play.
+ */
+function inboxStartPayload(args: Record<string, unknown>): Record<string, unknown> {
+	const payload: Record<string, unknown> = {};
+	if (typeof args.port === "number") payload.port = args.port;
+	if (isRecord(args.response)) payload.response = inboxResponsePayload(args.response);
+	return payload;
+}
+
+/**
+ * Default page for `get_inbox_captures` - the same 25 `get_run_samples` uses
+ * and for the same reason: a capture is a whole recorded request, body
+ * included, so a page is measured in bodies rather than rows.
+ *
+ * The ceiling is this side's, not the engine's. `GET /inbox/:id/requests`
+ * clamps to the inbox's retention (500 by default, up to 10000 with
+ * `inboxMaxCaptures` raised), and a capture body is bounded by
+ * `inboxMaxBodyBytes` - 64 KB by default and configurable to 8 MB - so the
+ * engine's own bound says nothing about what a tool result can carry. 100 rows
+ * of bounded body is the largest page worth handing an agent; more is `offset`.
+ */
+export const DEFAULT_INBOX_CAPTURE_LIMIT = 25;
+export const MAX_INBOX_CAPTURE_LIMIT = 100;
+
+/**
+ * Bound the bodies in one capture page.
+ *
+ * A capture carries the engine's own `body` / `bodyTruncated` / `bodyBytes`
+ * disclosure trio - the shape {@link boundTraceNode} already speaks - so the
+ * page is bounded by the same function rather than by a copy of it: a webhook
+ * posting a 6 MB payload is exactly the #767 case, and the cut has to leave
+ * `bodyBytes` alone where the engine already recorded the true original size.
+ */
+function boundInboxCaptures(value: unknown): unknown {
+	if (!isRecord(value) || !Array.isArray(value.data)) return value;
+	return { ...value, data: value.data.map(boundTraceNode) };
 }
 
 // --- Tool definitions --------------------------------------------------------
@@ -3748,11 +3867,10 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "start_mock_issuer",
 		category: "execute",
-		// Nothing in the renderer reads issuers today (`rg -i issuer app/src` is
-		// empty), so there is no entity to invalidate: an `McpDataEntity` with no
-		// reader is the written-never-read defect that field exists to prevent.
-		// #502 adds the Services drawer that lists them - when it lands, an
-		// "issuer" entity belongs here and on its query.
+		// #502's Services drawer now reads the issuer list, and #756 added the
+		// `service` entity these belong on - but wiring the issuer tools to it,
+		// and to the mock-server tools beside them, is #757's half of the epic.
+		// Until then the drawer's poll is what shows an MCP-started issuer.
 		invalidates: [],
 		description:
 			"Start a local OAuth 2.0 mock issuer and return its id, token URL, authorize URL and signing key. Use it to test an auth flow offline: start an issuer, point a request's oauth2 auth at the returned tokenUrl, run it with run_request, and assert on what the target received - no real identity provider, so no 2FA prompts, provider rate limits or account lockouts in the loop. It needs no allowlist entry: the engine binds every issuer to 127.0.0.1 and takes no host for it, so it is unreachable off this machine. The access token is an HS256 JWT signed with the returned signingKey - hand that key to the service under test and it can verify the mock's tokens. Set a short expiresInSeconds (with issueRefreshTokens) to exercise the 401-then-refresh path, and failureMode to exercise retry handling. At most 8 issuers run at once; stop yours with stop_mock_issuer when you are done.",
@@ -3841,7 +3959,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "stop_mock_issuer",
 		category: "execute",
-		// See start_mock_issuer - no renderer reader yet, #502 adds one.
+		// See start_mock_issuer - the `service` entity is #757's to take here.
 		invalidates: [],
 		description:
 			"Stop a running OAuth 2.0 mock issuer and free its port. Tokens it already minted stay valid until they expire - nothing verifies them against the issuer once it is gone. An unknown id is an error, not a silent success.",
@@ -3857,6 +3975,277 @@ export const TOOLS: McpTool[] = [
 		},
 		handler: (args, ctx, signal) =>
 			callEngine(() => ctx.client.stopMockIssuer(requireStr(args, "issuerId"), signal)),
+	},
+	{
+		name: "start_webhook_inbox",
+		category: "execute",
+		invalidates: ["service"],
+		description:
+			"Start a local webhook inbox and return its id and URL. It records every request sent to it - method, path, query, headers, body, caller address - so an agent can point a webhook at the URL, trigger it, and then assert on what actually arrived with get_inbox_captures. It needs no allowlist entry: the inbox listens on this machine's loopback interface only, which MCP does not let you change, so it is unreachable from off the machine. Give it a canned `response` to make the sender see a specific status, body, headers or delay - the reply every captured request gets, changeable later with update_inbox_response. Stop it with stop_webhook_inbox when you are done (the captures survive a stop), or delete_webhook_inbox to remove it and them.",
+		annotations: {
+			title: "Start webhook inbox",
+			readOnlyHint: false,
+			// It binds a loopback listener and records what arrives: it destroys
+			// no saved data and reaches nothing off the machine.
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			port: z
+				.number()
+				.int()
+				.min(0)
+				.max(65535)
+				.optional()
+				.describe(
+					"Port to listen on, on this machine's loopback interface. Default 0 - the engine picks a free one. The interface itself is not configurable over MCP."
+				),
+			response: z
+				.object({
+					status: z
+						.number()
+						.int()
+						.min(100)
+						.max(599)
+						.optional()
+						.describe("Status code the inbox answers with (default 200)."),
+					body: z.string().optional().describe("Response body the inbox answers with."),
+					headers: z
+						.record(z.string())
+						.optional()
+						.describe(
+							'Response headers, e.g. {"Content-Type": "application/json"}. Replaces the current set rather than merging into it.'
+						),
+					delayMs: z
+						.number()
+						.int()
+						.nonnegative()
+						.optional()
+						.describe(
+							"Milliseconds to wait before answering, for testing a sender's timeout handling. The engine caps this at 30000."
+						),
+				})
+				.optional()
+				.describe(
+					"The canned reply every request to this inbox receives. Omit for the engine's default (200, empty body)."
+				),
+		},
+		handler: (args, ctx, signal) =>
+			callEngine(() => ctx.client.startInbox(inboxStartPayload(args), signal)),
+	},
+	{
+		name: "list_webhook_inboxes",
+		category: "read",
+		invalidates: [],
+		description:
+			"List the webhook inboxes this engine has started, running and stopped alike, each with its id, URL, port, whether it is still listening, how many requests it has captured, and its canned response. A stopped inbox stays listed with its captures readable until it is deleted, so this is also how to find an inbox started earlier in the session.",
+		annotations: {
+			title: "List webhook inboxes",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {},
+		handler: (_args, ctx, signal) => callEngine(() => ctx.client.listInboxes(signal)),
+	},
+	{
+		name: "stop_webhook_inbox",
+		category: "execute",
+		invalidates: ["service"],
+		description:
+			"Stop a webhook inbox's listener and free its port. This is NOT a delete: the inbox stays listed and everything it captured stays readable with get_inbox_captures - use delete_webhook_inbox to remove the record and its captures. Requests sent to the URL after this are refused by the machine, not recorded. An unknown id is an error, not a silent success.",
+		annotations: {
+			title: "Stop webhook inbox",
+			readOnlyHint: false,
+			// Nothing recorded is lost - the captures outlive the listener.
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			inboxId: z.string().describe("Inbox ID to stop (from start_webhook_inbox)."),
+		},
+		handler: (args, ctx, signal) =>
+			callEngine(() => ctx.client.stopInbox(requireStr(args, "inboxId"), signal)),
+	},
+	{
+		name: "delete_webhook_inbox",
+		category: "write",
+		invalidates: ["service"],
+		description:
+			"Delete a webhook inbox: stop its listener if it is still running, drop the record, and destroy every request it captured. GUARDED: requires write access to be enabled in Vayu Settings, and confirmation - if the client supports elicitation the user is prompted with how many captures go with it, otherwise call once for a preview and again with `confirmed: true`. There is no undo, and the captures are the part that cannot be recreated. To keep them, use stop_webhook_inbox instead.",
+		annotations: {
+			title: "Delete webhook inbox",
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			inboxId: z.string().describe("Inbox ID to delete."),
+			confirmed: confirmedInput("actually delete the inbox and its captures"),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const inboxId = requireStr(args, "inboxId");
+			// Read the list first so the prompt states the real capture count and
+			// the URL, not an id - the same read-before-prompt `delete_collection`
+			// and `delete_run` do. `GET /inbox` is the only read that answers for
+			// a single inbox: the engine has no `GET /inbox/:id`.
+			let inbox: Record<string, unknown>;
+			try {
+				const listed = await ctx.client.listInboxes(signal);
+				const rows = isRecord(listed) && Array.isArray(listed.data) ? listed.data : [];
+				const found = rows.find((row) => isRecord(row) && row.inboxId === inboxId);
+				if (!isRecord(found)) return errorResult(`No webhook inbox with id "${inboxId}".`);
+				inbox = found;
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			const subject = describeInbox(inboxId, inbox);
+			const unconfirmed = await confirmDestructive(args, ctx, {
+				message: `Delete ${subject}?\n\nEverything it captured is destroyed with it. This cannot be undone.`,
+				acceptTitle: "Delete the inbox",
+				acceptDescription: "Confirm to delete this inbox and every request it captured.",
+				declined: "Inbox not deleted - the user declined.",
+				preview:
+					"AWAITING CONFIRMATION - nothing was deleted.\n\n" +
+					`This would delete ${subject}, along with every request it captured. This cannot be undone; stop_webhook_inbox frees the port and keeps them.\n\n` +
+					"This is a preview. To delete it, call delete_webhook_inbox again with confirmed: true and the same arguments.",
+			});
+			if (unconfirmed) return unconfirmed;
+			return callEngine(() => ctx.client.deleteInbox(inboxId, signal));
+		},
+	},
+	{
+		name: "get_inbox_captures",
+		category: "read",
+		invalidates: [],
+		description:
+			"Read what a webhook inbox recorded, newest first. Each row is the whole captured request - method, path, query string, headers, body and the caller's address - so this is the assertion half of a webhook test: start an inbox, trigger the sender, read the captures. An inbox that has received nothing returns an empty page, not an error. " +
+			`A body the engine cut at its capture cap carries \`bodyTruncated\` beside \`bodyBytes\`, the true original size. BOUNDED: ${DEFAULT_INBOX_CAPTURE_LIMIT} captures per call by default, ${MAX_INBOX_CAPTURE_LIMIT} at most - a larger \`limit\` is refused, not clamped - and each body is cut to ${MAX_INLINE_BODY_BYTES / 1024} KB for this result. \`pagination\` says how many exist; read the rest with \`offset\`. There is no live stream over MCP: poll this after triggering the sender.`,
+		annotations: {
+			title: "Get inbox captures",
+			readOnlyHint: true,
+			// The newest-first page moves as captures arrive, exactly as
+			// `get_live_metrics` does - the same reason that one is not idempotent.
+			idempotentHint: false,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			inboxId: z.string().describe("Inbox ID whose captures to read."),
+			limit: z
+				.number()
+				.int()
+				.positive()
+				.max(MAX_INBOX_CAPTURE_LIMIT)
+				.optional()
+				.describe(
+					`How many captures to return (default ${DEFAULT_INBOX_CAPTURE_LIMIT}, max ${MAX_INBOX_CAPTURE_LIMIT}).`
+				),
+			offset: z
+				.number()
+				.int()
+				.nonnegative()
+				.optional()
+				.describe("How many captures to skip, for paging (default 0)."),
+		},
+		handler: (args, ctx, signal) => {
+			const inboxId = requireStr(args, "inboxId");
+			const limit = optionalPageLimit(
+				args,
+				"limit",
+				DEFAULT_INBOX_CAPTURE_LIMIT,
+				MAX_INBOX_CAPTURE_LIMIT
+			);
+			const offset = optionalOffset(args, "offset");
+			return pagedRead(
+				() => ctx.client.getInboxCaptures(inboxId, limit, offset, signal),
+				"captures",
+				boundInboxCaptures
+			);
+		},
+	},
+	{
+		name: "clear_inbox_captures",
+		category: "write",
+		invalidates: ["service"],
+		description:
+			"Delete every request a webhook inbox has captured, keeping the listener running on the same URL. Use it to start a fresh assertion window between triggers. GUARDED: requires write access to be enabled in Vayu Settings; unlike delete_webhook_inbox it needs no confirmation, because the inbox survives and the next trigger records again. The captures themselves do not come back.",
+		annotations: {
+			title: "Clear inbox captures",
+			readOnlyHint: false,
+			// It destroys recorded data, which is what this hint is for - the
+			// listener surviving does not make the captures recoverable.
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			inboxId: z.string().describe("Inbox ID whose captures to clear."),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const inboxId = requireStr(args, "inboxId");
+			return callEngine(() => ctx.client.clearInboxCaptures(inboxId, signal));
+		},
+	},
+	{
+		name: "update_inbox_response",
+		category: "execute",
+		invalidates: ["service"],
+		description:
+			"Change what a running webhook inbox answers, live: status, body, headers or delay. The next request to arrive gets the new reply - nothing restarts and no captures are lost - so one inbox can answer 200 for the first trigger and 500 for the next, which is how a sender's retry or error handling gets exercised. This is a merge-patch: fields you omit keep their current value, and `headers` replaces the whole header set rather than merging into it.",
+		annotations: {
+			title: "Update inbox response",
+			readOnlyHint: false,
+			// It rewrites the canned reply of a listener and destroys nothing;
+			// calling it again with the same block is a no-op.
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			inboxId: z.string().describe("Inbox ID whose canned response to change."),
+			status: z
+				.number()
+				.int()
+				.min(100)
+				.max(599)
+				.optional()
+				.describe("New status code. Omit to leave it unchanged."),
+			body: z.string().optional().describe("New response body. Omit to leave it unchanged."),
+			headers: z
+				.record(z.string())
+				.optional()
+				.describe(
+					"New response header set, replacing the current one entirely. Omit to leave it unchanged."
+				),
+			delayMs: z
+				.number()
+				.int()
+				.nonnegative()
+				.optional()
+				.describe(
+					"New delay before answering, in milliseconds (engine cap 30000). Omit to leave it unchanged."
+				),
+		},
+		handler: (args, ctx, signal) => {
+			const inboxId = requireStr(args, "inboxId");
+			const response = inboxResponsePayload(args);
+			if (Object.keys(response).length === 0) {
+				// An empty merge-patch is accepted by the engine and changes
+				// nothing, which would report success for a call that did not do
+				// what it was asked. Say which fields exist instead.
+				throw new ToolArgError(
+					'Name at least one of "status", "body", "headers" or "delayMs" to change.'
+				);
+			}
+			return callEngine(() => ctx.client.updateInboxResponse(inboxId, response, signal));
+		},
 	},
 ];
 
@@ -3929,6 +4318,7 @@ function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: To
 	const collectionId = str(args, "collectionId");
 	const requestId = str(args, "requestId");
 	const runId = str(args, "runId");
+	const inboxId = str(args, "inboxId");
 	for (const entity of tool.invalidates) {
 		try {
 			ctx.onDataChanged({
@@ -3936,6 +4326,7 @@ function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: To
 				...(collectionId !== undefined ? { collectionId } : {}),
 				...(requestId !== undefined ? { requestId } : {}),
 				...(runId !== undefined ? { runId } : {}),
+				...(inboxId !== undefined ? { inboxId } : {}),
 			});
 		} catch (err) {
 			console.error(`[MCP] Failed to notify "${entity}" change from ${tool.name}:`, err);

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -35,9 +35,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	// this file is a CommonJS script and must not grow imports.
 	onMcpDataChanged: (
 		callback: (event: {
-			entity: "request" | "environment" | "run" | "cookie" | "config";
+			entity:
+				| "collection"
+				| "request"
+				| "environment"
+				| "run"
+				| "cookie"
+				| "config"
+				| "service";
 			collectionId?: string;
 			requestId?: string;
+			runId?: string;
+			inboxId?: string;
 		}) => void
 	) => {
 		const handler = (_event: unknown, change: unknown) =>

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -166,6 +166,41 @@ describe("invalidateForMcpEvent", () => {
 		expect(keys).toEqual([queryKeys.config.all]);
 	});
 
+	test("a service change invalidates the inbox list", () => {
+		const { handled, keys } = keysFor({ entity: "service" });
+		expect(handled).toBe(true);
+		expect(keys).toEqual([queryKeys.inbox.list()]);
+	});
+
+	test("a named inbox has its captures removed, not merely invalidated", () => {
+		// `useInboxCapturesQuery` merges a fetched page into what the cache holds,
+		// so an invalidation after a clear or a delete would union the destroyed
+		// rows straight back. Removal is what makes the refetch start from empty.
+		const { keys, removed } = keysFor({ entity: "service", inboxId: "inbox_1" });
+		expect(keys).toEqual([queryKeys.inbox.list()]);
+		expect(removed).toEqual([queryKeys.inbox.captures("inbox_1")]);
+	});
+
+	test("a service event that named no inbox leaves every capture list alone", () => {
+		const { removed } = keysFor({ entity: "service" });
+		expect(removed).toEqual([]);
+	});
+
+	test("cleared captures really are gone from a live cache", () => {
+		// Against a real QueryClient, since the point is the effect: another
+		// inbox's captures must survive, and the named one's must not.
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(queryKeys.inbox.captures("inbox_1"), { data: [{ id: 1 }] });
+		queryClient.setQueryData(queryKeys.inbox.captures("inbox_2"), { data: [{ id: 2 }] });
+
+		invalidateForMcpEvent(queryClient, { entity: "service", inboxId: "inbox_1" });
+
+		expect(queryClient.getQueryData(queryKeys.inbox.captures("inbox_1"))).toBeUndefined();
+		expect(queryClient.getQueryData(queryKeys.inbox.captures("inbox_2"))).toEqual({
+			data: [{ id: 2 }],
+		});
+	});
+
 	test("an unknown entity is reported, not thrown", () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const { handled, keys } = keysFor({

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -169,6 +169,37 @@ const INVALIDATORS: Record<
 	config: (queryClient) => {
 		void queryClient.invalidateQueries({ queryKey: queryKeys.config.all });
 	},
+
+	/*
+	 * The engine's local services (issue #756). The inbox list is polled, so this
+	 * is about immediacy in the Services drawer and the Dock's running-services
+	 * count - an agent that starts an inbox and reports its URL should not be
+	 * describing a listener the window will not show for another poll interval.
+	 *
+	 * The captures are the half that cannot be handled by invalidation.
+	 * `useInboxCapturesQuery` *merges* its fetched page into whatever the cache
+	 * holds - three writers feed one entry, so union-by-id is what keeps the SSE
+	 * stream and the fetch from overwriting each other - and a union with the
+	 * rows a `clear_inbox_captures` just destroyed puts every one of them back.
+	 * The app's own clear mutation writes an empty page before refetching for
+	 * exactly this reason; from here the equivalent is to drop the entry, so the
+	 * merge starts from nothing. A delete needs the same drop for a different
+	 * reason: `useDeleteInboxMutation` removes rather than invalidates, because
+	 * refetching an id the engine now 404s leaves an error state describing a
+	 * list that no longer exists.
+	 *
+	 * The hint says which inbox a call named, not what it did to it, so a
+	 * `update_inbox_response` costs its open tab one refetch of captures it
+	 * already had (and any "load more" pages beyond the first). That is the
+	 * `run` family's trade taken again and for the same reason: a stale answer
+	 * is a lie, a refetch is a wait.
+	 */
+	service: (queryClient, event) => {
+		void queryClient.invalidateQueries({ queryKey: queryKeys.inbox.list() });
+		if (event.inboxId) {
+			queryClient.removeQueries({ queryKey: queryKeys.inbox.captures(event.inboxId) });
+		}
+	},
 };
 
 /**

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2217,7 +2217,15 @@ export interface McpConnectResult {
  * there cannot import from here (see `tsconfig.node.json`), so the duplication
  * is deliberate and pinned by `electron/mcp/data-changed.conformance.test.ts`.
  */
-export type McpDataEntity = "collection" | "request" | "environment" | "run" | "cookie" | "config";
+export type McpDataEntity =
+	| "collection"
+	| "request"
+	| "environment"
+	| "run"
+	| "cookie"
+	| "config"
+	/** Engine-hosted local services: webhook inboxes today, more as #757 lands. */
+	| "service";
 
 /**
  * What the main process sends over `mcp:data-changed`. Invalidation only - the
@@ -2236,6 +2244,12 @@ export interface McpDataChangedEvent {
 	 * `set_run_baseline`, `delete_run`).
 	 */
 	runId?: string;
+	/**
+	 * The webhook inbox the call named, when it named one. Only the tools that
+	 * act on an existing inbox spell it (`stop_webhook_inbox`,
+	 * `delete_webhook_inbox`, `clear_inbox_captures`, `update_inbox_response`).
+	 */
+	inboxId?: string;
 }
 
 export interface ScriptCompletion {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1303,6 +1303,7 @@ to keys through `lib/mcp-invalidation.ts`:
 | `run` | `runs.lists()`, `runs.allRuns()`, `runs.baselines()`, `runs.recentDesigns()`, `runs.lastCollectionRuns()`, plus `runs.lastDesign(requestId)` when the call named one - and a **removal** of `runs.detail/report/samples/timeSeries/monitorSeries` for a named `runId` | The history list polls, but Settings' count, the vs-baseline strip, Recent sends and Last run do not. The three prefixes rather than per-row keys because a run id gives no way back to the request or collection it belonged to - the same trade `useDeleteRunMutation` makes |
 | `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
 | `config` | `config.all` | |
+| `service` | `inbox.list()`, plus a **removal** of `inbox.captures(inboxId)` for a named inbox | The drawer and the Dock's count poll, so the list is about immediacy; the captures cannot be invalidated, because `useInboxCapturesQuery` merges its fetched page into the cache and would union back the rows a `clear_inbox_captures` just destroyed |
 
 The event carries no engine data, only which family went stale, so a row still
 reaches the UI by exactly one path: the query layer. Per-run reports and time
@@ -1319,7 +1320,15 @@ no longer lists. The hint says *which* run changed, not *how*, so a `set_run_bas
 costs an open detail pane one refetch of data it already had; a stale answer is
 a lie and a refetch is a wait. `runs.lastDesign` has no prefix family, so a
 deleted design run can still leave one stale - issue #776, shared with
-`useDeleteRunMutation`. The entity list is duplicated across the process boundary
+`useDeleteRunMutation`. The `service` family (issue #756) takes the same shape
+one level down: `inboxId` is its scope hint, and a named inbox has its capture
+list *removed* rather than invalidated for a reason the run family does not
+have - three writers share that one cache entry (the fetch, the load-more pages
+and the live SSE stream), so every write to it is a union by capture id, and a
+refetch into a cache still holding cleared rows puts them straight back. The
+app's own clear mutation writes an empty page first for exactly this; from the
+main process the equivalent is to drop the entry. Only inboxes are wired today -
+mock servers and the OAuth issuers join the family in #757. The entity list is duplicated across the process boundary
 (`MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`, `McpDataEntity` in
 `types/domain.ts`) because production code under `electron/` cannot import from
 `app/src`; `data-changed.conformance.test.ts` is what keeps the copies equal,

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -177,6 +177,13 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `start_mock_issuer`    | execute  | `POST /mock-issuer/start`                    | - (loopback-only listener, so no allowlist entry applies); limits are the engine's - 31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent issuers |
 | `list_mock_issuers`    | read     | `GET /mock-issuer`                           | -                          |
 | `stop_mock_issuer`     | execute  | `POST /mock-issuer/:id/stop`                 | - (unknown id is a `404`, surfaced as a tool error) |
+| `start_webhook_inbox`  | execute  | `POST /inbox/start`                          | - (loopback-only listener; `bind` / `confirmNonLoopback` are never sent) |
+| `list_webhook_inboxes` | read     | `GET /inbox`                                 | -                          |
+| `stop_webhook_inbox`   | execute  | `POST /inbox/:id/stop`                       | - (frees the port, keeps the record and its captures) |
+| `delete_webhook_inbox` | write    | `GET /inbox` + `DELETE /inbox/:id`           | write toggle + confirm (the prompt names the capture count) |
+| `get_inbox_captures`   | read     | `GET /inbox/:id/requests?limit=&offset=`     | 25 captures per call by default, 100 max; each body capped at 32 KB |
+| `clear_inbox_captures` | write    | `DELETE /inbox/:id/requests`                 | write toggle               |
+| `update_inbox_response`| execute  | `PUT /inbox/:id` (merge-patch)               | - (live edit of the canned reply) |
 
 Notes:
 
@@ -385,8 +392,34 @@ Notes:
   claims object, an integer port, a `failureMode` from the closed set. Stopping
   an issuer frees its port; tokens it already minted stay valid until they
   expire, since nothing verifies them against a live issuer. These tools emit no
-  `mcp:data-changed` event because no renderer surface reads issuers yet -
-  #502's Services drawer is what adds one.
+  `mcp:data-changed` event yet: #502's Services drawer does read issuers now, and
+  wiring them to the `service` entity the inbox tools introduced is #757's half
+  of epic #753 - until then the drawer's own poll is what shows an MCP-started
+  issuer.
+- **The webhook-inbox tools** are the assertion half an agent testing a webhook
+  needs (issue #756): `start_webhook_inbox` stands up a
+  [local inbox](api-reference.md#webhook-inbox) and returns its URL,
+  `get_inbox_captures` reads back what arrived - method, path, query, headers,
+  body, caller address - and `update_inbox_response` changes what the sender
+  sees, live, so one inbox can answer `200` for the first trigger and `503` for
+  the next. **Loopback-only, and not by policy alone**: the engine's
+  `bind` / `confirmNonLoopback` pair is never emitted by
+  `inboxStartPayload`, whatever arguments a call carries, so an inbox MCP
+  started cannot be reached off this machine - a stated non-goal of epic #753,
+  guarded in the one function that builds the body and mutation-checked in
+  `tools.test.ts`. **A stop is not a delete**: `stop_webhook_inbox` frees the
+  port and leaves every capture readable, while `delete_webhook_inbox` destroys
+  them and therefore takes the write toggle *and* a confirmation whose prompt
+  names how many captures go with it (read from `GET /inbox` first, the way
+  `delete_run` reads the run). `clear_inbox_captures` is the middle case -
+  recorded data destroyed, listener kept - so it takes the toggle without the
+  confirmation. **No live stream**: `GET /inbox/:id/live` is single-watcher
+  (a second is a `409`) and the app's own inbox tab may hold it, so MCP polls
+  `get_inbox_captures` instead - the same bounded-snapshot posture
+  `get_live_metrics` takes. Capture bodies are cut to 32 KB for the result with
+  the engine's own `bodyTruncated` / `bodyBytes` disclosure kept intact, since
+  `inboxMaxBodyBytes` reaches 8 MB and a webhook payload is whatever the sender
+  sent.
 - **Cancellation:** the `AbortSignal` the SDK fires on `notifications/cancelled`
   is threaded into the engine `fetch` for every tool call, resource read,
   template list and prompt, so a client cancelling an in-flight call actually
@@ -831,25 +864,31 @@ configurable in **Settings → MCP** and persisted.
 - **Confirmation** - anti-accident, not anti-adversary: it stops a stray tool
   call from starting load or destroying saved work, but on HTTP it is agent-side
   (the caps/allowlist are the enforcement). Elicitation upgrades it to a human
-  prompt where supported. Four tools carry it - `start_load_run`,
-  `delete_collection`, `delete_request` and `delete_run` - through one
-  implementation, so the elicitation path cannot drift between them. A preview is a *successful* result
+  prompt where supported. Five tools carry it - `start_load_run`,
+  `delete_collection`, `delete_request`, `delete_run` and
+  `delete_webhook_inbox` - through one implementation, so the elicitation path
+  cannot drift between them. A preview is a *successful* result
   that deliberately did nothing, so it emits no `mcp:data-changed` event either.
 - **Write toggle** (`allowWrites`, default off) - gates every tool in the
   **write** category: `create_collection`, `update_collection`,
   `delete_collection`, `create_request`, `update_request`, `delete_request`,
   `update_environment`, `update_engine_config`, `set_run_baseline`,
-  `delete_run`. Does not gate `run_request` / `run_collection_smoke` / load runs
-  (allowlist + caps). The three deletes need the toggle **and** confirmation:
+  `delete_run`, `delete_webhook_inbox`, `clear_inbox_captures`. Does not gate
+  `run_request` / `run_collection_smoke` / load runs
+  (allowlist + caps). The four deletes need the toggle **and** confirmation:
   the toggle is a single session-wide switch a user flips once to let an agent
   save a request, which is not consent to destroy a subtree or a run's stored
   history.
-- **Loopback services carry no gate of their own** - `start_mock_issuer` and
-  `stop_mock_issuer` are `execute` tools that neither the allowlist nor the
-  write toggle governs. The allowlist exists to stop an agent generating traffic
+- **Loopback services carry no gate of their own** - `start_mock_issuer`,
+  `stop_mock_issuer`, `start_webhook_inbox`, `stop_webhook_inbox` and
+  `update_inbox_response` are `execute` tools that neither the allowlist nor the
+  write toggle governs. (The two that destroy recorded data,
+  `delete_webhook_inbox` and `clear_inbox_captures`, are `write` tools and do
+  take the toggle - what they end is not the listener but the captures.) The allowlist exists to stop an agent generating traffic
   against third parties it was never pointed at, and a mock issuer is bound to
-  `127.0.0.1` by the engine with no host to configure; the write toggle gates
-  saved data, which an ephemeral listener is not. Nor would a gate here withhold
+  `127.0.0.1` by the engine with no host to configure - as is an inbox, whose
+  `bind` these tools never send; the write toggle gates saved data, which an
+  ephemeral listener is not. Nor would a gate here withhold
   anything: an agent with `localhost` allowlisted can already reach
   `POST /mock-issuer/start` through `run_request`, for the same reason the
   endpoint needs no auth token. The bounds that do apply are the engine's own -
@@ -957,16 +996,19 @@ collection tree until some unrelated mutation happened to refetch the lists.
 Each tool declares the data families it changes (`invalidates` in `tools.ts`)
 and `dispatchTool` - the single dispatch path - sends one `mcp:data-changed` per
 family after a call that did **not** return an error. The event names a family
-(`request`, `environment`, `run`, `cookie`, `config`) plus the `collectionId` /
-`requestId` / `runId` the call itself named; it carries no engine data, so the
-renderer still reads every row through its query layer. The three hints are read
+(`collection`, `request`, `environment`, `run`, `cookie`, `config`, `service`)
+plus the `collectionId` / `requestId` / `runId` / `inboxId` the call itself
+named; it carries no engine data, so the
+renderer still reads every row through its query layer. The four hints are read
 off the call's own arguments at the dispatch chokepoint, which is what keeps a
 new write tool from having to remember an emit of its own - every tool in the
 registry spells them the same way. They are hints, not identity: `requestId` on
 a `run` event is the saved request a design run was linked to, while `runId` is
 the run itself, and only the tools that rewrite or remove an **existing** run
 (`stop_run`, `set_run_baseline`, `delete_run`) name one - a runner's new run has
-no per-run cache to drop yet. The renderer side, including
+no per-run cache to drop yet. `inboxId` is the same shape for the `service`
+family: the inbox tools that act on an existing listener name it, and
+`start_webhook_inbox` cannot, since the engine assigns the id. The renderer side, including
 which query keys each family maps to, is in
 [`docs/app/state-management.md`](../app/state-management.md).
 


### PR DESCRIPTION
## Description

The webhook inbox (#480, shipped 0.16.0) had **zero** MCP coverage, so the loop it exists for - start an inbox, trigger the sender, assert on what arrived - was unreachable from an agent; MCP covered only the OAuth-issuer third of the Services drawer.

**Plan.** Root cause: the inbox routes are a complete engine surface (`POST /inbox/start`, `GET /inbox`, `POST /inbox/:id/stop`, `DELETE /inbox/:id`, `GET|DELETE /inbox/:id/requests`, `PUT /inbox/:id`) that the tool registry never followed, and the renderer's `mcp:data-changed` union had no family for engine-hosted services at all - so even a wired-up tool would have been invisible in an open Services drawer until the next poll. Approach: seven tools over those routes in the registry pattern, plus a new `service` entity in **both** copies of the union and an `inboxId` scope hint. The alternative rejected was giving inboxes their own entity name (`inbox`): epic #753 has #757 reusing this family for mock servers and the issuers, and the renderer surfaces that read it (the drawer, the Dock's running-services count) ask "what is listening", not "which kind" - one family with a scope hint is what those readers actually want.

Verified at `682cc9a`: the routes, the field names and the bounds in the issue all still match `engine/src/http/routes/inbox.cpp`, and the two renderer readers it names (`useRunningServiceCount`, the drawer/tab queries under `app/src/queries/inbox.ts`) exist as described.

**Tools** (`app/electron/mcp/tools.ts`, client methods in `engine-client.ts`):

| Tool | Category | Notes |
|---|---|---|
| `start_webhook_inbox` | execute | canned `response` {status, headers, body, delayMs}; loopback-only |
| `list_webhook_inboxes` | read | running and stopped, URL, port, capture count |
| `stop_webhook_inbox` | execute | frees the port, **keeps** the captures - the description says so |
| `delete_webhook_inbox` | write | + confirm; reads `GET /inbox` first so the prompt names the real capture count |
| `get_inbox_captures` | read | 25/call default, 100 max (refused, not clamped), bodies cut to 32 KB |
| `clear_inbox_captures` | write | destroys recorded data, so the toggle; listener survives, so no confirm |
| `update_inbox_response` | execute | live merge-patch; refuses a patch that names no field |

**The loopback guarantee is a guard, not a note.** `inboxStartPayload` never emits `bind` or `confirmNonLoopback`, whatever a call carries, and the schema offers neither - so the non-goal epic #753 records lives in the one function that builds the body, mutation-checked by a test that sends both fields and asserts their absence.

**No live SSE stream**, deliberately: `GET /inbox/:id/live` is single-watcher (a second is a `409`) and the app's own inbox tab may hold it, so polling `get_inbox_captures` is the MCP shape - the `get_live_metrics` bounded-snapshot precedent. A registry-level test locks that as a decision rather than an omission.

**Capture bodies are bounded** through the existing `boundTraceNode` helper rather than a copy of it: a capture carries the same `body` / `bodyTruncated` / `bodyBytes` trio a stored trace node does, `inboxMaxBodyBytes` reaches 8 MB, and a webhook payload is whatever the sender sent - this is #767's case arriving by another route. The engine's original-size count survives the cut.

## App changes (required, same PR)

- New `service` entity in `MCP_DATA_ENTITIES` (main) and `McpDataEntity` (renderer), plus the conformance test and the preload payload type.
- New `inboxId` scope hint, read at the dispatch chokepoint like the other three.
- `INVALIDATORS.service` invalidates `inbox.list()` and **removes** `inbox.captures(inboxId)` for a named inbox. The removal is load-bearing, not a nicety: `useInboxCapturesQuery` *merges* its fetched page into the cache (three writers share that entry - fetch, load-more, the SSE stream - so every write is a union by capture id), so invalidating after a `clear_inbox_captures` unions the destroyed rows straight back. The app's own clear mutation writes an empty page first for exactly this reason; from the main process, dropping the entry is the equivalent. A delete needs the same drop for the reason `useDeleteInboxMutation` already removes rather than invalidates - refetching an id the engine now 404s leaves an error state describing a list that no longer exists.

**Deliberate deviation from the issue spec:** the entity is named `service`, not `inbox`, for the reason above (the issue offered either). Also, the issuer tools' `invalidates: []` comments claimed "no renderer surface reads issuers" - #502's drawer landed and does, so the comments now point at the `service` entity and at #757, which owns the wiring. Comment-only; the issuer tools' behaviour is unchanged and stays #757's.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, full: **502 files, 5340 tests, all passing** (26 new). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on every touched file, `mkdocs build --strict` clean. No engine or C++ change - nothing under `engine/` is touched and no engine test could change colour - so no `build.py -t` / `ctest` run. No pre-existing failures observed on the base commit.

Mutation-checked (fix reverted, confirmed red, restored):

| Guard | Mutation that turns it red |
|---|---|
| no inbox payload carries `bind` / `confirmNonLoopback` | forward `bind` in `inboxStartPayload` |
| a capture body past 32 KB is cut, with the engine's `bodyBytes` intact | drop the `boundInboxCaptures` shape |
| an inbox event names the inbox it acted on | drop `inboxId` from `notifyDataChanged` |
| a named inbox has its captures **removed**, not invalidated (spied, and again against a real `QueryClient`) | swap `removeQueries` for `invalidateQueries` |

Also covered: pagination forwarded and refused above the cap / below 1, the bounded-page caveat, the delete preview naming the real capture count (and `0 captured requests` for an empty one), an id the engine does not list refusing without deleting, both write-toggle refusals, the empty merge-patch refusal, categories and destructive hints, and that no tool exposes the live stream.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/mcp.md` (seven tool-table rows, a webhook-inbox notes bullet, the loopback-services and write-toggle/confirmation lists in the safety model, the `mcp:data-changed` families and hints) and `docs/app/state-management.md` (the `service` row and the removal rationale).

## Related Issues
Closes #756

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxPU9xBjgPzXPofErVPkJJ)_