### PR TITLE
fix(app/dialog): cap the panel's height and give it a scrolling body band

### DIFF
--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -51,7 +51,13 @@ const CommandDialog = ({
 	return (
 		<Dialog {...props}>
 			{/* No corner close button: it would land on top of the search field,
-			    and Escape or a click outside is how a palette is dismissed. */}
+			    and Escape or a click outside is how a palette is dismissed.
+
+			    No `DialogBody` either (issue #773): a palette is its input plus
+			    `CommandList`, which caps and scrolls itself, so the band that
+			    would claim the leftover height already exists one level in. The
+			    panel's cap still applies, and `overflow-hidden` keeps the list's
+			    own scroll the only one. */}
 			<DialogContent showClose={false} className={cn("overflow-hidden p-0", className)}>
 				<DialogTitle className="sr-only">{title}</DialogTitle>
 				<DialogDescription className="sr-only">{description}</DialogDescription>

--- a/app/src/components/ui/dialog-height-band.test.tsx
+++ b/app/src/components/ui/dialog-height-band.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A dialog taller than the viewport scrolls its body, not its panel (issue #773).
+ *
+ * `DialogContent` is `fixed` and centred by a translate, and it declared no
+ * height cap - so a panel taller than the viewport was centred on a box it did
+ * not fit and clipped at *both* ends, with nothing to scroll because a fixed
+ * box does not scroll the page. Measured in Chromium at a 613px viewport, an
+ * eighteen-row settings dialog put its Run button 198px below the screen:
+ * reachable by Tab, unreachable by pointer, which is how it survived.
+ *
+ * The fix has two halves and this file guards both, because either alone is
+ * still broken:
+ *
+ * 1. the panel caps its height, and
+ * 2. a `DialogBody` band takes the scroll - so the header and footer stay put
+ *    and the corner close button, positioned against the *panel*, does not
+ *    scroll away with the content. Putting the scroll on the panel instead is
+ *    the tempting one-liner, and it is what loses the close button.
+ *
+ * jsdom reports 0 for every measurement, so what is asserted is the declaration
+ * on the element that carries it, per the rule in app/CLAUDE.md. The behaviour
+ * itself was measured in Chromium: with the band, the footer sits at 542px of a
+ * 613px viewport and the close button stays at y=63 however far the body is
+ * scrolled; without it, the footer is at 1001px.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogBody,
+	DialogFooter,
+	DialogTitle,
+	DialogDescription,
+} from "./dialog";
+
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function renderTallDialog() {
+	render(
+		<Dialog open>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Run a load test</DialogTitle>
+					<DialogDescription>Pick a profile, then start the run.</DialogDescription>
+				</DialogHeader>
+				<DialogBody>
+					{Array.from({ length: 18 }, (_, i) => (
+						<p key={i}>Row {i}</p>
+					))}
+				</DialogBody>
+				<DialogFooter>
+					<button>Run</button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+	const panel = document.querySelector('[data-slot="dialog-content"]');
+	const body = document.querySelector('[data-slot="dialog-body"]');
+	expect(panel).toBeTruthy();
+	expect(body).toBeTruthy();
+	return { panel: panel as HTMLElement, body: body as HTMLElement };
+}
+
+describe("the dialog height cap", () => {
+	it("caps the panel, so it can never be centred on a box it does not fit", () => {
+		const { panel } = renderTallDialog();
+		expect(panel.className).toContain("max-h-[85vh]");
+	});
+
+	it("puts the scroll on the body band and not on the panel", () => {
+		const { body } = renderTallDialog();
+
+		// The panel keeps an `overflow-y-auto` of its own as the fallback for a
+		// dialog with no band, but the band is what scrolls when there is one -
+		// and only the band can, because only the band gives up height.
+		expect(body.className).toContain("overflow-y-auto");
+		// `flex-auto` (basis auto), not `flex-1` (basis 0%): a short dialog must
+		// not stretch its one band over the whole cap.
+		expect(body.className).toContain("flex-auto");
+		// The vertical `min-w-0`: a flex item's automatic minimum on the main
+		// axis is its content, so without this the band refuses to shrink and
+		// the overflow moves straight back out to the panel.
+		expect(body.className).toContain("min-h-0");
+	});
+
+	it("keeps the close button out of the band that scrolls", () => {
+		const { panel, body } = renderTallDialog();
+
+		// The whole reason the scroll is not simply on the panel: the close
+		// button is `absolute` inside it, so a scrolling panel takes the visible
+		// way out with it exactly when the dialog is long enough to need one.
+		const close = screen.getByRole("button", { name: /close/i });
+		expect(panel.contains(close)).toBe(true);
+		expect(body.contains(close)).toBe(false);
+	});
+
+	it("keeps the header and footer fixed bands", () => {
+		renderTallDialog();
+		// Without `shrink-0` the two bands are what give up height first, which
+		// squashes the title rather than scrolling the content.
+		expect(document.querySelector('[data-slot="dialog-header"]')?.className).toContain(
+			"shrink-0"
+		);
+		expect(document.querySelector('[data-slot="dialog-footer"]')?.className).toContain(
+			"shrink-0"
+		);
+	});
+});
+
+/**
+ * The rendered half above proves the primitive is right; this proves the
+ * dialogs use it. A source scan is the weaker kind of guard, so it is scoped to
+ * what only a scan can see - every call site at once - and it asserts it read
+ * something, per the rule in the repo CLAUDE.md.
+ */
+describe("the dialogs that can grow", () => {
+	/** Call sites that own their height deliberately, with the reason. */
+	const OPT_OUTS = new Map([
+		// Bands of its own (header, tab strip, body, footer), each with a
+		// divider, and the scroll already on the one that needs it.
+		["modules/collections/ImportModal.tsx", "manages its own bands"],
+		// A palette is its input plus `CommandList`, which caps and scrolls
+		// itself one level in.
+		["components/ui/command.tsx", "cmdk owns the list scroll"],
+		// Header and footer only - there is no middle to scroll.
+		["components/ui/delete-confirm-dialog.tsx", "no body"],
+	]);
+
+	function tsxFiles(dir: string): string[] {
+		return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) return tsxFiles(full);
+			return entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+				? [full]
+				: [];
+		});
+	}
+
+	const files = tsxFiles(srcRoot).filter((f) =>
+		readFileSync(f, "utf8").includes("<DialogContent")
+	);
+
+	it("read a real set of call sites", () => {
+		// The failure this exists to prevent: a scan whose match stopped working
+		// passes forever while reading nothing. Thirteen call sites today.
+		expect(files.length).toBeGreaterThanOrEqual(8);
+	});
+
+	it("gives every dialog a scrolling band, or an opt-out with a reason", () => {
+		const offenders: string[] = [];
+		for (const file of files) {
+			const relative = file
+				.slice(srcRoot.length + 1)
+				.split("\\")
+				.join("/");
+			if (OPT_OUTS.has(relative)) continue;
+			if (!readFileSync(file, "utf8").includes("<DialogBody")) offenders.push(relative);
+		}
+		// A new dialog with no band is not a style slip: it is the #773 bug
+		// arriving again, silently, on whichever laptop is not maximised.
+		expect(offenders).toEqual([]);
+	});
+
+	it("does not leave an ad-hoc panel height cap behind", () => {
+		// Two call sites carried their own `max-h-[…]` on the panel, at two
+		// different numbers, because the primitive had none. Only a dialog that
+		// declares itself an opt-out above may keep one.
+		const offenders: string[] = [];
+		for (const file of files) {
+			const relative = file
+				.slice(srcRoot.length + 1)
+				.split("\\")
+				.join("/");
+			if (OPT_OUTS.has(relative)) continue;
+			for (const tag of readFileSync(file, "utf8").matchAll(/<DialogContent\b[\s\S]*?>/g)) {
+				// Comments inside the opening tag first: prose naming a class is
+				// not a class.
+				if (/max-h-\[/.test(tag[0].replace(/\/\/[^\n]*/g, ""))) offenders.push(relative);
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/app/src/components/ui/dialog.tsx
+++ b/app/src/components/ui/dialog.tsx
@@ -60,23 +60,42 @@ function DialogContent({ className, children, showClose = true, ...props }: Dial
 					// property, which the scale-only keyframes compose with
 					// rather than fight.
 					//
-					// `grid-cols-1` is load-bearing, not tidiness (issue #701).
-					// It is `repeat(1, minmax(0, 1fr))`, and the `0` is the
-					// point: an implicit track is `auto`, whose minimum is its
-					// items' min-content, so one wide descendant - a data-file
-					// preview table, a long unbroken URL - grows the track past
-					// this panel's own `max-w`, which cannot follow it. The panel
-					// stays the painted width while every row inside lays out at
-					// the track's, so right-aligned controls and the footer end
-					// up over the backdrop. Making the descendant a scroller does
-					// not help: `overflow-auto` bounds the box, not the
-					// min-content width it contributes upward. Clamping the track
-					// is what lets those scrollers scroll.
+					// `flex flex-col` carries two jobs, and both are
+					// load-bearing.
 					//
-					// Written as the stock utility rather than the arbitrary
-					// `grid-cols-[minmax(0,1fr)]` that says it more directly:
-					// Tailwind emits no rule for that one, so it would have been
-					// a class that reads correctly and styles nothing.
+					// **Width** (issue #701). This was `grid grid-cols-1` -
+					// `repeat(1, minmax(0, 1fr))` - because an implicit grid
+					// track is `auto`, whose minimum is its items' min-content,
+					// so one wide descendant - a data-file preview table, a long
+					// unbroken URL - grew the track past this panel's own
+					// `max-w`, which cannot follow it. The panel stayed the
+					// painted width while every row inside laid out at the
+					// track's, so right-aligned controls and the footer ended up
+					// over the backdrop. A column flex container refuses the same
+					// thing for a different reason: `min-width: auto` does not
+					// apply on the cross axis, so an item stretches to the line -
+					// this panel's own content width - and a wide descendant
+					// overflows *inside* it rather than widening it. Measured in
+					// Chromium against the seven-column shape from #701: an
+					// `auto` track put the footer 580px past the painted edge,
+					// and `grid-cols-1` and this flex column both put it 25px
+					// inside it, to the pixel.
+					//
+					// **Height** (issue #773). `max-h-[85vh]` plus a
+					// `DialogBody`, which is the band that scrolls. Without the
+					// cap a panel taller than the viewport is centred on a box it
+					// does not fit and clipped at *both* ends, with nothing to
+					// scroll because it is `fixed` - an eighteen-row dialog at a
+					// 613px viewport left its Run button 198px below the screen,
+					// reachable by Tab and not by pointer.
+					//
+					// `overflow-y-auto` here is the fallback for a dialog with no
+					// `DialogBody`: nothing claims the leftover height, so the
+					// panel scrolls itself and the footer stays reachable. It
+					// takes the corner close button with it, which is exactly why
+					// a dialog that can grow should take the band instead - with
+					// one present the panel never scrolls at all and the button
+					// stays pinned.
 					//
 					// Two widths, not eleven. A dialog is either a form or a
 					// decision, which is `sm:max-w-lg` (512px), or it holds
@@ -88,7 +107,7 @@ function DialogContent({ className, children, showClose = true, ...props }: Dial
 					// See docs/design-system.md; go wider only with content that
 					// earns it, since a dialog is a focus device before it is a
 					// container.
-					"dialog-panel fixed left-[50%] top-[50%] z-50 grid w-full max-w-xl grid-cols-1 translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg",
+					"dialog-panel fixed left-[50%] top-[50%] z-50 flex max-h-[85vh] w-full max-w-xl translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg",
 					className
 				)}
 				{...props}
@@ -108,7 +127,37 @@ function DialogContent({ className, children, showClose = true, ...props }: Dial
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		data-slot="dialog-header"
-		className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+		className={cn("flex shrink-0 flex-col space-y-1.5 text-center sm:text-left", className)}
+		{...props}
+	/>
+);
+
+/**
+ * The band that scrolls (issue #773).
+ *
+ * A dialog that can grow past the viewport puts everything between its header
+ * and its footer in here: `flex-auto` claims the height the two fixed bands
+ * leave, and once that is less than the content asks for, this box scrolls -
+ * so the title stays readable, the primary action stays on screen, and the
+ * corner close button, which is positioned against the panel rather than
+ * against this box, does not scroll away with the content.
+ *
+ * `min-h-0` is what allows the shrink at all: a flex item's automatic minimum
+ * size on the main axis is its content, so without it this band refuses to be
+ * shorter than its content and the overflow moves back out to the panel. It is
+ * the vertical case of the `min-w-0` rule in docs/design-system.md.
+ *
+ * `flex-auto` and not `flex-1`: `flex-1` bases the item at `0%`, which asks a
+ * short dialog to stretch its one band over the whole cap. Basis `auto` grows
+ * only into height that is actually free and shrinks only when there is none.
+ *
+ * A short dialog does not need one - a confirm, a rename, a three-field form.
+ * The panel keeps its own `overflow-y-auto` for those.
+ */
+const DialogBody = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+	<div
+		data-slot="dialog-body"
+		className={cn("min-h-0 min-w-0 flex-auto overflow-y-auto", className)}
 		{...props}
 	/>
 );
@@ -116,7 +165,10 @@ const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		data-slot="dialog-footer"
-		className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+		className={cn(
+			"flex shrink-0 flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+			className
+		)}
 		{...props}
 	/>
 );
@@ -152,6 +204,7 @@ export {
 	DialogClose,
 	DialogContent,
 	DialogHeader,
+	DialogBody,
 	DialogFooter,
 	DialogTitle,
 	DialogDescription,

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -36,6 +36,7 @@ export {
 	DialogClose,
 	DialogContent,
 	DialogHeader,
+	DialogBody,
 	DialogFooter,
 	DialogTitle,
 	DialogDescription,

--- a/app/src/modules/collections/CollectionDetail/StartMockServerDialog.tsx
+++ b/app/src/modules/collections/CollectionDetail/StartMockServerDialog.tsx
@@ -33,6 +33,7 @@ import {
 	Button,
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -93,7 +94,7 @@ export function StartMockServerDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4 py-2">
+				<DialogBody className="space-y-4 py-2">
 					{/* The bound in words, not only in `aria-invalid` and a disabled
 					    button: a field that reddens while Start greys out states that
 					    something is wrong and never which field or why. */}
@@ -166,7 +167,7 @@ export function StartMockServerDialog({
 							{error.message}
 						</Callout>
 					)}
-				</div>
+				</DialogBody>
 
 				<DialogFooter>
 					<Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/app/src/modules/collections/ExportSpecDialog.tsx
+++ b/app/src/modules/collections/ExportSpecDialog.tsx
@@ -32,6 +32,7 @@ import {
 	Button,
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -126,7 +127,7 @@ export default function ExportSpecDialog({ collection, onOpenChange }: ExportSpe
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-3">
+				<DialogBody className="space-y-3">
 					<div className="flex items-center gap-3">
 						<span className="text-xs text-muted-foreground">Format</span>
 						<ToggleGroup
@@ -164,7 +165,7 @@ export default function ExportSpecDialog({ collection, onOpenChange }: ExportSpe
 					)}
 
 					{result?.value && <ExportSummary notes={result.value.notes} />}
-				</div>
+				</DialogBody>
 
 				<DialogFooter>
 					<Button variant="ghost" onClick={() => onOpenChange(false)}>

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -576,6 +576,14 @@ export function ImportModal() {
 				// `w-[560px]` this carried: a fixed width is one the panel keeps
 				// on a viewport narrower than it, and the primitive's `w-full`
 				// under a cap gives the same stable band without that edge.
+				//
+				// The height guard stays this dialog's own (issue #773): the
+				// primitive's `max-h-[85vh]` + `DialogBody` is for a panel with
+				// one scrolling middle, and this one has bands of its own - a
+				// tab strip, a body, a footer, each with a divider - with the
+				// scroll already on the band that needs it. `overflow-hidden`
+				// keeps that scroll where the bands put it, and 82vh leaves the
+				// divider lines clear of the viewport edge.
 				className="flex max-w-xl max-h-[82vh] flex-col gap-0 overflow-hidden border-border-strong bg-card surface-card p-0"
 				// No prose description; without this Radix logs a missing
 				// aria-describedby warning.

--- a/app/src/modules/collections/MoveToDialog.tsx
+++ b/app/src/modules/collections/MoveToDialog.tsx
@@ -22,6 +22,7 @@ import { Folder, FolderTree } from "lucide-react";
 import {
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogHeader,
 	DialogTitle,
 	DialogDescription,
@@ -93,7 +94,7 @@ export function MoveToDialog({ entity, collections, onClose, onMove }: MoveToDia
 						Currently in {ownerName}. Choose where it should go - it lands at the end.
 					</DialogDescription>
 				</DialogHeader>
-				<div className="max-h-72 overflow-y-auto -mx-1 px-1">
+				<DialogBody className="max-h-72 -mx-1 px-1">
 					{offersTopLevel && (
 						<Button
 							variant="ghost"
@@ -121,7 +122,7 @@ export function MoveToDialog({ entity, collections, onClose, onMove }: MoveToDia
 							There is nowhere else to move this.
 						</p>
 					)}
-				</div>
+				</DialogBody>
 			</DialogContent>
 		</Dialog>
 	);

--- a/app/src/modules/collections/RunCollectionDialog.layout.test.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.layout.test.tsx
@@ -16,7 +16,7 @@
  * toggles, the Iterations field, the data file's Remove button and the
  * Cancel/Run footer all rendered outside the panel, over the dimmed backdrop.
  *
- * The mechanism is the grid: `DialogContent` is a grid whose single track is
+ * The mechanism was the grid: `DialogContent` was a grid whose single track is
  * `auto`, and an auto track's minimum is its items' min-content - so the
  * preview table's min-content grew the track past the panel's `max-w`, which
  * cannot follow it. Every row in that grid then lays out at the track's width,
@@ -24,10 +24,18 @@
  * table's wrapper `overflow-auto` does not prevent this: it bounds the box, not
  * the min-content width the box contributes upward.
  *
+ * The panel is a **column flex container** since issue #773, which needed the
+ * height cap a grid cannot honour, and it refuses the same widening for a
+ * different reason: `min-width: auto` does not apply on the cross axis, so an
+ * item stretches to the line - the panel's own content width - and a wide
+ * descendant overflows inside it instead of widening it. So this file still
+ * guards #701; only the declaration that buys it changed.
+ *
  * jsdom reports 0 for every measurement, so what is asserted here is the
  * declaration that fixes it, on the element that carries it - measured
- * separately in a real engine, where seven columns spilled the footer 428px
- * past the painted edge before the clamp and 0px after it.
+ * separately in a real browser, where seven columns spilled the footer 428px
+ * past the painted edge before the clamp, 580px under a bare `auto` track, and
+ * 0px under either `grid-cols-1` or this flex column.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -57,19 +65,20 @@ beforeEach(() => {
 });
 
 describe("the run dialog's panel", () => {
-	it("clamps its grid track so no descendant can widen it past the painted panel", () => {
+	it("lays its rows out in a column no descendant can widen past the painted panel", () => {
 		render(<RunCollectionDialog collection={COLLECTION} onOpenChange={vi.fn()} />);
 
 		const panel = document.querySelector('[data-slot="dialog-content"]');
 		expect(panel).toBeTruthy();
 
-		// `grid-cols-1` is `repeat(1, minmax(0, 1fr))`, and the 0 is the whole
-		// fix: it lets the track be smaller than its content's min-content, which
-		// is what hands the scrollers inside it something to scroll within. The
-		// arbitrary `grid-cols-[minmax(0,1fr)]` would say it more plainly and
-		// compiles to nothing, so this asserts the utility that has a rule.
-		expect(panel?.className).toContain("grid-cols-1");
-		expect(panel?.className).toContain("grid");
+		// A column flex line has a definite cross size - this panel's content
+		// width - and a stretched item takes it, because `min-width: auto` is a
+		// main-axis rule. That is what hands the scrollers inside it something
+		// to scroll within. An `auto` grid track, which is what this was before
+		// `grid-cols-1`, is the shape that spills.
+		expect(panel?.className).toContain("flex-col");
+		expect(panel?.className).toContain("flex");
+		expect(panel?.className).not.toContain("grid");
 	});
 
 	it("still caps the panel's own width - the clamp is not a licence to grow", () => {

--- a/app/src/modules/collections/RunCollectionDialog.tsx
+++ b/app/src/modules/collections/RunCollectionDialog.tsx
@@ -57,6 +57,7 @@ import { Loader2, Play } from "lucide-react";
 import {
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogHeader,
 	DialogFooter,
 	DialogTitle,
@@ -353,7 +354,7 @@ export default function RunCollectionDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4 py-2">
+				<DialogBody className="space-y-4 py-2">
 					<div className="flex items-center justify-between gap-4">
 						<Label htmlFor="run-collection-recursive" className="leading-snug">
 							Include sub-folders
@@ -531,7 +532,7 @@ export default function RunCollectionDialog({
 							{error instanceof Error ? error.message : "The engine refused it."}
 						</Callout>
 					)}
-				</div>
+				</DialogBody>
 
 				<DialogFooter>
 					<Button

--- a/app/src/modules/collections/SpecReimportDialog.tsx
+++ b/app/src/modules/collections/SpecReimportDialog.tsx
@@ -27,6 +27,7 @@ import {
 	Button,
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -80,37 +81,42 @@ export default function SpecReimportDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<ul className="space-y-2">
-					{matches.map((match) => (
-						<li
-							key={match.entryId}
-							className="flex items-center gap-3 rounded-md border border-rule surface-sunken p-2"
-						>
-							<span className="min-w-0 flex-1">
-								<span className="flex items-baseline gap-1.5">
-									<FileJson className="h-3.5 w-3.5 shrink-0 text-primary" />
-									<span className="truncate text-xs font-medium">
-										{match.label}
+				<DialogBody>
+					<ul className="space-y-2">
+						{matches.map((match) => (
+							<li
+								key={match.entryId}
+								className="flex items-center gap-3 rounded-md border border-rule surface-sunken p-2"
+							>
+								<span className="min-w-0 flex-1">
+									<span className="flex items-baseline gap-1.5">
+										<FileJson className="h-3.5 w-3.5 shrink-0 text-primary" />
+										<span className="truncate text-xs font-medium">
+											{match.label}
+										</span>
+									</span>
+									<span className="block text-[11px] text-muted-foreground">
+										Bound to{" "}
+										<span className="font-medium text-foreground">
+											{match.collectionName}
+										</span>{" "}
+										-{" "}
+										{match.matchedBy === "sourceUrl"
+											? "the same URL that collection was bound from, so this may be a newer version of it"
+											: "byte for byte the document that collection is bound to"}
 									</span>
 								</span>
-								<span className="block text-[11px] text-muted-foreground">
-									Bound to{" "}
-									<span className="font-medium text-foreground">
-										{match.collectionName}
-									</span>{" "}
-									-{" "}
-									{match.matchedBy === "sourceUrl"
-										? "the same URL that collection was bound from, so this may be a newer version of it"
-										: "byte for byte the document that collection is bound to"}
-								</span>
-							</span>
-							<Button variant="outline" onClick={() => onSync(match.collectionId)}>
-								<RefreshCw className="mr-2 h-4 w-4" />
-								Sync instead
-							</Button>
-						</li>
-					))}
-				</ul>
+								<Button
+									variant="outline"
+									onClick={() => onSync(match.collectionId)}
+								>
+									<RefreshCw className="mr-2 h-4 w-4" />
+									Sync instead
+								</Button>
+							</li>
+						))}
+					</ul>
+				</DialogBody>
 
 				<DialogFooter className="gap-2 sm:gap-0">
 					<Button ref={cancelRef} variant="secondary" onClick={onCancel}>

--- a/app/src/modules/history/main/SaveRunToRequestDialog.tsx
+++ b/app/src/modules/history/main/SaveRunToRequestDialog.tsx
@@ -29,6 +29,7 @@ import { Loader2, ArrowRight, ChevronRight } from "lucide-react";
 import {
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogHeader,
 	DialogFooter,
 	DialogTitle,
@@ -262,28 +263,30 @@ export default function SaveRunToRequestDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				{tally.length > 0 && (
-					<div className="flex flex-wrap gap-3 font-mono text-[11px] tabular-nums">
-						{tally.map((t) => (
-							<span key={t.state} className="text-muted-foreground">
-								<span className={cn("font-bold", t.text)}>{t.glyph}</span> {t.n}{" "}
-								{t.state}
-							</span>
+				<DialogBody className="space-y-4">
+					{tally.length > 0 && (
+						<div className="flex flex-wrap gap-3 font-mono text-[11px] tabular-nums">
+							{tally.map((t) => (
+								<span key={t.state} className="text-muted-foreground">
+									<span className={cn("font-bold", t.text)}>{t.glyph}</span> {t.n}{" "}
+									{t.state}
+								</span>
+							))}
+						</div>
+					)}
+
+					<div className="max-h-[24rem] overflow-y-auto surface-sunken rounded-md">
+						{writable.length === 0 && (
+							<p className="px-4 py-3 text-xs text-muted-foreground">
+								The request already matches this run. Only fields the run cannot
+								write are shown below.
+							</p>
+						)}
+						{items.map((item) => (
+							<ChangeRow key={item.field} item={item} />
 						))}
 					</div>
-				)}
-
-				<div className="max-h-[24rem] overflow-y-auto surface-sunken rounded-md">
-					{writable.length === 0 && (
-						<p className="px-4 py-3 text-xs text-muted-foreground">
-							The request already matches this run. Only fields the run cannot write
-							are shown below.
-						</p>
-					)}
-					{items.map((item) => (
-						<ChangeRow key={item.field} item={item} />
-					))}
-				</div>
+				</DialogBody>
 
 				<DialogFooter className="items-center gap-2 sm:gap-0">
 					<span className="mr-auto text-[11px] text-muted-foreground">

--- a/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
+++ b/app/src/modules/request-builder/components/LoadTestConfigDialog/index.tsx
@@ -56,6 +56,7 @@ import {
 	CollapsibleTrigger,
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogHeader,
 	DialogTitle,
 	DialogDescription,
@@ -568,7 +569,7 @@ export default function LoadTestConfigDialog({
 
 	return (
 		<Dialog open onOpenChange={(open) => !open && onClose()}>
-			<DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+			<DialogContent className="max-w-xl">
 				<DialogHeader>
 					<DialogTitle>Run a load test</DialogTitle>
 					<DialogDescription>
@@ -576,7 +577,7 @@ export default function LoadTestConfigDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4">
+				<DialogBody className="space-y-4">
 					{notices.map((n) => (
 						<div key={n.key}>{n.node}</div>
 					))}
@@ -1050,7 +1051,7 @@ export default function LoadTestConfigDialog({
 							onGateChange={setOauthGated}
 						/>
 					)}
-				</div>
+				</DialogBody>
 
 				<DialogFooter>
 					<Button variant="outline" onClick={onClose} disabled={isStarting}>

--- a/app/src/modules/request-builder/components/ResponseViewer/SaveAsExampleDialog.tsx
+++ b/app/src/modules/request-builder/components/ResponseViewer/SaveAsExampleDialog.tsx
@@ -26,6 +26,7 @@ import {
 	Button,
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -80,7 +81,7 @@ export function SaveAsExampleDialog({ requestId, response, onClose }: SaveAsExam
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4 py-2">
+				<DialogBody className="space-y-4 py-2">
 					<div className="space-y-1">
 						<Label htmlFor="example-name" className="leading-snug">
 							Name
@@ -133,7 +134,7 @@ export function SaveAsExampleDialog({ requestId, response, onClose }: SaveAsExam
 							{save.error.message}
 						</Callout>
 					)}
-				</div>
+				</DialogBody>
 
 				<DialogFooter>
 					<Button variant="outline" onClick={onClose}>

--- a/app/src/modules/services/NewIssuerDialog.tsx
+++ b/app/src/modules/services/NewIssuerDialog.tsx
@@ -34,6 +34,7 @@ import {
 	Button,
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -149,7 +150,7 @@ export function NewIssuerDialog({ onOpenChange, onStarted }: NewIssuerDialogProp
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4 py-2">
+				<DialogBody className="space-y-4 py-2">
 					{/* The bound in words, not only in `aria-invalid` and a disabled
 					    button. A field that reddens while Start greys out states
 					    that something is wrong and never which field or why - and
@@ -288,7 +289,7 @@ export function NewIssuerDialog({ onOpenChange, onStarted }: NewIssuerDialogProp
 							{engineError instanceof Error ? engineError.message : "Unknown error"}
 						</Callout>
 					)}
-				</div>
+				</DialogBody>
 
 				<DialogFooter>
 					<Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/app/src/modules/welcome/components/CollectionPicker.tsx
+++ b/app/src/modules/welcome/components/CollectionPicker.tsx
@@ -17,6 +17,7 @@ import { Folder } from "lucide-react";
 import {
 	Dialog,
 	DialogContent,
+	DialogBody,
 	DialogHeader,
 	DialogTitle,
 	DialogDescription,
@@ -44,7 +45,7 @@ export function CollectionPicker({
 					<DialogTitle>Add request to</DialogTitle>
 					<DialogDescription>Pick the collection for the new request.</DialogDescription>
 				</DialogHeader>
-				<div className="flex max-h-72 flex-col gap-1 overflow-auto">
+				<DialogBody className="flex max-h-72 flex-col gap-1">
 					{collections.map((collection) => (
 						<button
 							key={collection.id}
@@ -56,7 +57,7 @@ export function CollectionPicker({
 							<TruncatedText>{collection.name}</TruncatedText>
 						</button>
 					))}
-				</div>
+				</DialogBody>
 			</DialogContent>
 		</Dialog>
 	);

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1338,6 +1338,19 @@ Primitives built on Radix UI + cmdk:
 
 `badge`, `button`, `card`, `collapsible`, `command`, `delete-confirm-dialog`, `dialog`, `dropdown-menu`, `info-chip`, `input`, `secret-input` (masked field with a reveal toggle - client secret / passwords, and the variables table's secret rows, which is where the pattern was extracted from), `kbd`, `label`, `popover`, `resizable`, `scroll-area`, `select`, `separator`, `skeleton`, `suggestion-list`, `switch`, `tabs`, `textarea`, `tooltip`, plus variable-aware inputs: `variable-autocomplete`, `variable-popover`, `variable-scope-badge`, and markdown: `markdown-view`, `markdown-editor`.
 
+### `dialog`
+
+`DialogContent` is a column flex panel with two caps: `max-w-xl` (the width
+scale, issue #701) and `max-h-[85vh]` (issue #773). Anything between the header
+and the footer that can grow goes in **`DialogBody`**, which is the band that
+scrolls - so the title and the primary action stay on screen and the corner
+close button, positioned against the panel, does not scroll away with the
+content. `ImportModal` and `CommandDialog` opt out because each already has a
+self-scrolling band of its own, and `DeleteConfirmDialog` has no middle at all;
+every other call site takes the band, which `dialog-height-band.test.tsx`
+enforces. The rules and the measurements are in
+[design-system.md](../design-system.md).
+
 The `cva` definitions for `badge`, `button` and `toast` live in sibling
 `*-variants.ts` modules and are re-exported from `components/ui/index.ts`. A
 module that exports both a component and a value cannot be hot-reloaded, which

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1436,12 +1436,21 @@ the backdrop. Issue #701 found this in the Run Collection dialog, where a
 seven-column data-file preview put the footer buttons 428px outside the painted
 panel.
 
-`DialogContent` therefore declares `grid-cols-1` - `repeat(1, minmax(0, 1fr))` -
-and that is the fix for any width-capped grid surface: the `0` lets the track be
-narrower than its content's min-content, which is what gives the scrollers
-inside it room to scroll. Prefer it on the surface over `min-w-0` sprinkled on
-the items - the items are written by every caller, and the cap is the surface's
-own promise.
+`grid-cols-1` - `repeat(1, minmax(0, 1fr))` - is the fix for any width-capped
+grid surface: the `0` lets the track be narrower than its content's min-content,
+which is what gives the scrollers inside it room to scroll. Prefer it on the
+surface over `min-w-0` sprinkled on the items - the items are written by every
+caller, and the cap is the surface's own promise.
+
+`DialogContent` itself is a **column flex container** rather than that grid
+since issue #773, which needed a height cap a grid will not honour (see below),
+and it refuses the same widening for a different reason: `min-width: auto` is a
+main-axis rule, so on the cross axis an item stretches to the line - the panel's
+own content width - and a wide descendant overflows inside it instead of
+widening it. Measured in Chromium on the seven-column shape from #701, the
+footer landed 580px past the painted edge under a bare `auto` track and 25px
+*inside* it under either spelling of the clamp. The grid version is still the
+right one for a surface that is genuinely a grid.
 
 Write it as the stock utility, not as the arbitrary value that says it more
 directly. **Tailwind emits no rule for `grid-cols-[minmax(0,1fr)]`** (verified
@@ -1466,6 +1475,49 @@ keeps on a viewport narrower than it, where `w-full` under a cap gives the same
 stable band and still fits. And widening is never the fix for content escaping
 the panel - a wider panel with an `auto` track spills exactly the same way, just
 further along. Clamp the track; widen only for the reading.
+
+### Dialog height: one cap, and the band that scrolls
+
+A dialog panel is `fixed` and centred by a translate, so a panel taller than the
+viewport is centred on a box it does not fit: clipped at the **top and the
+bottom** at once, with nothing to scroll, because a fixed box does not scroll the
+page. The footer is the half that goes, which makes the dialog's primary action
+unreachable by pointer - and only *by pointer*, since Tab still reaches it, which
+is how this survived fourteen call sites (issue #773). Measured in Chromium at a
+613px viewport, an eighteen-row dialog put its Run button 227px below the screen.
+
+The panel therefore declares `max-h-[85vh]`, and the band between the header and
+the footer is a **`DialogBody`**:
+
+```tsx
+<DialogContent className="sm:max-w-xl">
+  <DialogHeader>…</DialogHeader>
+  <DialogBody className="space-y-4 py-2">…</DialogBody>   {/* the only scroller */}
+  <DialogFooter>…</DialogFooter>
+</DialogContent>
+```
+
+Three rules hold it together:
+
+- **The body scrolls, never the panel.** `overflow-y-auto` on the panel is the
+  tempting one-liner and it is the wrong one: the corner close button is
+  `absolute` *inside* the panel, so it scrolls away exactly when the dialog is
+  long enough to need a visible way out. The panel keeps one anyway as a
+  fallback for a dialog with no band; with a band present the panel never
+  scrolls and the button stays pinned.
+- **`min-h-0` on the band is load-bearing**, for the same reason `min-w-0` is
+  one section up: a flex item's automatic minimum on the main axis is its
+  content, so without it the band refuses to shrink and the overflow moves
+  straight back out to the panel.
+- **`flex-auto`, not `flex-1`.** Basis `0%` asks a short dialog to stretch its
+  one band over the whole cap; basis `auto` grows only into height that is free.
+
+Header and footer are `shrink-0` so they stay bands rather than being the first
+thing squashed. A dialog with no middle to scroll - a confirm, a rename - needs
+no body. A dialog that manages bands of its own (`ImportModal`) or whose content
+is already a self-scrolling list (`CommandDialog`) opts out at the call site with
+the reason written there; `dialog-height-band.test.tsx` holds that list closed,
+so a new dialog cannot skip the band silently.
 
 ---
 


### PR DESCRIPTION
## Description

A dialog taller than the viewport was centred on a box it did not fit - clipped at the top *and* the bottom, with nothing to scroll, because `DialogContent` is `fixed` and a fixed box does not scroll the page. The footer is the half that goes, so the primary action became unreachable **by pointer** (Tab still reaches it, which is how this survived thirteen call sites, only two of which guarded against it, at two different numbers).

**Plan.** Root cause: the panel declares no height cap and no band to scroll, so the overflow has nowhere to go. Approach: cap the panel at `max-h-[85vh]` and add a `DialogBody` that claims the height the header and footer leave and scrolls when that is less than its content. The alternative rejected is the obvious one-liner, `max-h-[85vh] overflow-y-auto` on the panel: the corner close button is `absolute` **inside** the panel, so it scrolls away exactly when the dialog grows long enough to need a visible way out. The panel keeps an `overflow-y-auto` anyway, but only as the fallback for a dialog with no band - with one present the panel never scrolls at all.

Verified at `682cc9a`: `dialog.tsx:91` still had the uncapped `fixed`/translate panel the issue anchors to, and the two ad-hoc guards were still at `LoadTestConfigDialog/index.tsx:571` and `ImportModal.tsx:579`.

**The panel becomes a column flex container, and that part was measured rather than assumed.** The issue's fix pathway calls for it; I first tried to keep the documented `grid-cols-1` and merely add the cap, because `docs/design-system.md` reasons at length about why the grid track clamp lives on the surface. Chromium says that does not work: under `max-height`, an auto grid row simply refuses to shrink, so the body stayed 832px and the footer stayed 388px below the screen. A flex column shrinks it to 373px and puts the footer at 542px of a 613px viewport.

**The #701 width clamp survives**, for a different reason than `grid-cols-1` gave it: `min-width: auto` is a main-axis rule, so on the cross axis an item stretches to the flex line - the panel's own content width - and a wide descendant overflows *inside* it rather than widening it. On the seven-column shape from #701, the footer lands **580px past** the painted edge under a bare `auto` track and **25px inside** it under either `grid-cols-1` or this flex column, to the pixel. `RunCollectionDialog.layout.test.tsx` still guards #701; only the declaration it names changed, and its doc comment now carries both numbers.

**Adoption.** Every call site takes the band except three, each saying why at the call site (and the list is held closed by a test, so a new dialog cannot skip it silently):

| Opt-out | Reason |
|---|---|
| `ImportModal` | manages its own header/tabs/body/footer bands, each with a divider, with the scroll already on the one that needs it - keeps its `82vh` and `overflow-hidden` |
| `CommandDialog` | a palette is its input plus `CommandList`, which caps and scrolls itself one level in |
| `DeleteConfirmDialog` | header and footer only - there is no middle to scroll |

`LoadTestConfigDialog`'s ad-hoc `max-h-[90vh] overflow-y-auto` is folded into the primitive (it was the "panel scrolls, close button goes with it" behaviour this replaces). `MoveToDialog` and `CollectionPicker` keep their `max-h-72` list caps *on the band itself*, so a short list stays short and a short viewport still shrinks it.

Two details the issue asked to check rather than assume: `Select` and `Popover` both portal their content (`select.tsx:79`, `popover.tsx:28`), so neither is clipped by the new scrollport; and the bands that carry `py-2` keep that padding inside the scrollport, so a focus ring at either end has clearance at rest.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, full: **503 files, 5317 tests, all passing** (7 new). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on every touched file, `mkdocs build --strict` clean. No engine or C++ change - nothing under `engine/` is touched and no engine test could change colour - so no `build.py -t` / `ctest` run. No pre-existing failures observed on the base commit.

**Measured in Chromium** (headless, 1200x613 viewport) against the *real* markup: the dialog was rendered through the actual primitives, its DOM dumped, and loaded with the app's own Tailwind build.

| | Before | After |
|---|---|---|
| Panel box | top **-251**, bottom **864** - cut off at both ends | top 54, bottom 559 - inside the viewport |
| Run button | **227px below the screen** | bottom at 535, reachable |
| What scrolls | nothing (page not scrollable, panel `fixed`) | the body band (629px of scroll); the panel does not |
| Close button | - | y=70 at rest **and** with the body fully scrolled |
| Footer vs painted panel edge | - | 24px inside it (the #701 clamp holds) |

Guards, each mutation-checked (mutation applied, confirmed red, reverted):

| Guard | Mutation that turns it red |
|---|---|
| the panel declares a height cap | drop `max-h-[85vh]` |
| the scroll lives on the body band (`overflow-y-auto` + `min-h-0`) | drop `overflow-y-auto` from `DialogBody` |
| the band is `flex-auto`, so a short dialog does not stretch over the cap | swap it for `flex-1` |
| header and footer stay fixed bands | drop `shrink-0` |
| every non-opt-out call site has a band | revert one dialog's `DialogBody` to a `div` |
| no ad-hoc panel `max-h-[…]` comes back | re-add `max-h-[90vh]` to `LoadTestConfigDialog` |

The close-button guard asserts the structural relationship (inside the panel, outside the band) rather than a class, since that is the thing the tempting one-liner breaks; it is non-vacuous because the same element is asserted present in the panel. The source scan asserts it read a real set of call sites first, per the repo rule about scans that pass while reading nothing.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/design-system.md` gains a **"Dialog height: one cap, and the band that scrolls"** section beside the width scale (the cap, which band scrolls, why the close button stays out of the scrollport, and the `min-h-0` / `flex-auto` rules), and its grid-track section is corrected to say the panel is no longer that grid and why. `docs/app/COMPONENTS.md` gains a `dialog` entry naming `DialogBody` and the three opt-outs.

## Related Issues
Closes #773

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXVjb9NBqLi323vo5SoHXm)_