### PR TITLE
fix(app/openapi): give the sync a document-level tier, and stop reverting a user's method edit

### DIFF
--- a/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
@@ -300,9 +300,12 @@ describe("SpecSync", () => {
 
 		check();
 		await screen.findByText(/the document has changed/i);
-		expect(
-			screen.getByRole("button", { name: /apply selected/i }).hasAttribute("disabled")
-		).toBe(true);
+		// Nothing is ticked, so the apply on offer is the document-level one and
+		// says so - it is no longer a disabled button, because a document that
+		// moved must always be applyable (#717); what it must not do is carry the
+		// user's field. Both halves are asserted below.
+		expect(screen.queryByRole("button", { name: /apply selected/i })).toBeNull();
+		expect(screen.getByRole("button", { name: /update the stored document/i })).toBeTruthy();
 
 		fireEvent.click(screen.getByRole("checkbox", { name: /apply changes to my pets call/i }));
 		apply();
@@ -357,6 +360,147 @@ describe("SpecSync", () => {
 
 		await waitFor(() => expect(syncSpec).toHaveBeenCalledTimes(2));
 		expect((syncSpec.mock.calls[1][0] as SpecSyncRequest).delete).toEqual(["req_1"]);
+	});
+
+	/**
+	 * The document-level tier (issue #717).
+	 *
+	 * `spec-diff` compares request-shaped fields, so a document that tightens a
+	 * response schema or documents a new status produces three empty buckets -
+	 * and Apply used to be disabled on exactly those, permanently, while the
+	 * summary truthfully said the document had changed. The stored document, the
+	 * response-schema index and the coverage index then stayed stale forever.
+	 * These pin the tier that replaces the dead end.
+	 */
+	describe("a change no request row can carry", () => {
+		const withResponses = (
+			properties: Record<string, unknown>,
+			extraStatuses: Record<string, unknown> = {}
+		): string =>
+			doc("List pets", {
+				responses: {
+					"200": {
+						description: "OK",
+						content: {
+							"application/json": { schema: { type: "object", properties } },
+						},
+					},
+					...extraStatuses,
+				},
+			});
+
+		/** The contract as bound, and the same contract with a tighter 200 and a new 429. */
+		const BOUND_SCHEMA = withResponses({ id: { type: "string" } });
+		const TIGHTENED = withResponses(
+			{ id: { type: "string" }, name: { type: "string" } },
+			{ "429": { description: "Too many requests" } }
+		);
+
+		it("says the change is document-level instead of dead-ending on three zeros", async () => {
+			importFetch.mockResolvedValue({ content: TIGHTENED });
+			renderSync({ spec: spec(BOUND_SCHEMA) });
+
+			check();
+
+			expect(await screen.findByText(/the document has changed/i)).toBeTruthy();
+			// The counts are still stated in full, and now they are explained.
+			expect(
+				screen.getByText(
+					/0 new operations · 0 requests whose operation is gone · 0 changed · 1 unchanged/i
+				)
+			).toBeTruthy();
+			expect(screen.getByText(/document-level changes only/i)).toBeTruthy();
+		});
+
+		it("applies it - the new bytes and both indexes, with no request row touched", async () => {
+			// Mutation check: restore `isEmptySelection(...)` to the Apply button's
+			// `disabled` and this reddens at the click - `syncSpec` is never called,
+			// which is the dead end this issue is.
+			importFetch.mockResolvedValue({ content: TIGHTENED });
+			syncSpec.mockResolvedValue({
+				idMap: {},
+				specId: "spec_2",
+				specHash: "def456",
+				syncedAt: 1_700_000_100_000,
+				created: 0,
+				updated: 0,
+				deleted: 0,
+			});
+			renderSync({ spec: spec(BOUND_SCHEMA) });
+
+			check();
+			await screen.findByText(/the document has changed/i);
+
+			fireEvent.click(screen.getByRole("button", { name: /update the stored document/i }));
+
+			await waitFor(() => expect(syncSpec).toHaveBeenCalledTimes(1));
+			const payload = syncSpec.mock.calls[0][0] as SpecSyncRequest;
+			// The document moves, so the binding the engine writes moves with it.
+			expect(payload.spec.content).toBe(TIGHTENED);
+			// Not one request row is named - the whole point of the tier.
+			expect(payload.create).toEqual([]);
+			expect(payload.update).toEqual([]);
+			expect(payload.delete).toEqual([]);
+			expect(payload.collections).toEqual([]);
+			// The indexes ride along, which is what makes validation and coverage
+			// read the *new* contract rather than the one they were stale against.
+			expect(JSON.stringify(payload.spec.responseSchemas)).toContain("name");
+			expect(payload.spec.operations?.length).toBeGreaterThan(0);
+			expect(
+				await screen.findByText(/no request changed.*now bound to the document/i)
+			).toBeTruthy();
+		});
+
+		it("stays applyable when every offered row is unticked", async () => {
+			// The same dead end one step over: a diff that *does* have rows, all of
+			// which the user declines, must still let them onto the new document.
+			importFetch.mockResolvedValue({ content: doc("List all the pets") });
+			renderSync({ spec: spec(BOUND), requests: [request({ name: "My pets call" })] });
+
+			check();
+			await screen.findByText(/the document has changed/i);
+			// Nothing is ticked (the one changed field is the user's own name).
+			expect(
+				screen.getByRole("button", { name: /update the stored document/i })
+			).toBeTruthy();
+			expect(screen.getByText(/no request rows change/i)).toBeTruthy();
+		});
+	});
+
+	it("never takes back a method the user edited, and offers it as its own row", async () => {
+		// Issue #717's problem B, end to end: the document only rewords a summary,
+		// but the apply used to write `method` unconditionally - reverting a HEAD
+		// to GET with no row, no flag and nothing ticked. Mutation check: restore
+		// `patch.method = draft.method` in `updateItem` and the first assertion
+		// reddens; drop "method" from `SpecField` and the second does.
+		importFetch.mockResolvedValue({ content: doc("List all the pets") });
+		renderSync({ spec: spec(BOUND), requests: [request({ method: "HEAD" })] });
+
+		check();
+		await screen.findByText(/the document has changed/i);
+		apply();
+
+		await waitFor(() => expect(syncSpec).toHaveBeenCalledTimes(1));
+		const patch = (syncSpec.mock.calls[0][0] as SpecSyncRequest).update[0];
+		expect(patch.method).toBeUndefined();
+		// The identity still travels, and still records what the operation is.
+		expect(patch.specOperation).toEqual({
+			operationId: "listPets",
+			method: "GET",
+			path: "/pets",
+		});
+
+		// It is a row the user can see and take, flagged as theirs - the treatment
+		// `url` always had and `method` never did.
+		check();
+		await screen.findByText(/the document has changed/i);
+		expect(screen.getByText("method")).toBeTruthy();
+		expect(screen.getAllByText(/edited here/i)).toHaveLength(1);
+		fireEvent.click(screen.getByRole("checkbox", { name: /apply method to list pets/i }));
+		apply();
+
+		await waitFor(() => expect(syncSpec).toHaveBeenCalledTimes(2));
+		expect((syncSpec.mock.calls[1][0] as SpecSyncRequest).update[0].method).toBe("GET");
 	});
 
 	it("surfaces a failed apply and keeps the selection", async () => {

--- a/app/src/modules/collections/CollectionDetail/SpecSync.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.tsx
@@ -22,6 +22,17 @@
  * document its requests do not reflect, which is the state binding exists to
  * make impossible.
  *
+ * **Every apply stores the document; the ticks decide which rows ride along**
+ * (issue #717). That one rule is what makes the dead end structurally
+ * impossible: `spec-diff` compares request-shaped fields, so a document that
+ * only moved a response schema, a status, or its `servers` block produces three
+ * empty buckets - and gating Apply on those buckets left the commonest contract
+ * change of all permanently unapplyable, with the stored document, the
+ * response-schema index and the coverage index stale forever while the UI
+ * truthfully said the document had changed. The apply is labelled for which of
+ * the two it is about to be, because an unlabelled one would be a write nobody
+ * asked for.
+ *
  * The counts are stated in full, zeros included, for the reason `MatchSummary`
  * states its three: "4 changed" alone reads as the whole answer, while "4
  * changed, 0 added, 0 removed, 12 unchanged" is the answer.
@@ -189,6 +200,8 @@ export default function SpecSync({
 	};
 
 	const pendingDeletes = state.phase === "diff" ? state.selection.removed.size : 0;
+	/** No rows ticked - the apply is the document-level one, and says so. */
+	const documentOnly = state.phase === "diff" && isEmptySelection(state.selection);
 
 	return (
 		<div>
@@ -235,9 +248,19 @@ export default function SpecSync({
 				{state.phase === "applied" && (
 					<p className="flex items-center gap-2 text-xs text-status-success-text">
 						<Check className="h-3.5 w-3.5 shrink-0" />
-						Applied - {state.created} request{state.created === 1 ? "" : "s"} created,{" "}
-						{state.updated} updated, {state.deleted} deleted. This collection is now
-						bound to the document you just synced.
+						{state.created + state.updated + state.deleted === 0 ? (
+							<>
+								Applied - the stored document, its response schemas and its coverage
+								index are updated, and no request changed. This collection is now
+								bound to the document you just synced.
+							</>
+						) : (
+							<>
+								Applied - {state.created} request{state.created === 1 ? "" : "s"}{" "}
+								created, {state.updated} updated, {state.deleted} deleted. This
+								collection is now bound to the document you just synced.
+							</>
+						)}
 					</p>
 				)}
 
@@ -254,14 +277,14 @@ export default function SpecSync({
 								onClick={() =>
 									pendingDeletes > 0 ? setConfirmingDeletes(true) : handleApply()
 								}
-								disabled={isEmptySelection(state.selection) || syncSpec.isPending}
+								disabled={syncSpec.isPending}
 							>
 								{syncSpec.isPending ? (
 									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
 								) : (
 									<Upload className="mr-2 h-4 w-4" />
 								)}
-								Apply selected
+								{documentOnly ? "Update the stored document" : "Apply selected"}
 							</Button>
 							<span className="text-[11px] text-muted-foreground">
 								{applySummary(state.selection)}
@@ -313,13 +336,31 @@ function boundDrafts(content: string): SpecRequestDraft[] | null {
 	}
 }
 
-/** "3 to create, 1 to update, 0 to delete" - what the button is about to do. */
+/**
+ * "3 to create, 1 to update, 0 to delete" - what the button is about to do.
+ *
+ * The document is named on both branches because it is written on both: with
+ * nothing ticked it is the whole of the change, and with rows ticked it still
+ * rides along, which is what makes the collection bound to what it just synced.
+ */
 function applySummary(selection: SpecApplySelection): string {
-	if (isEmptySelection(selection)) return "Nothing selected.";
+	if (isEmptySelection(selection))
+		return "Stores the new document, response schemas and coverage index - no request rows change.";
 	return (
 		`${selection.added.size} to create · ${selection.changed.size} to update · ` +
-		`${selection.removed.size} to delete`
+		`${selection.removed.size} to delete, and the new document`
 	);
+}
+
+/**
+ * The document moved, but nothing it says about *this collection's* operations
+ * did - the shape `spec-diff` renders as three empty buckets.
+ *
+ * Named rather than inferred from the summary, because "0 · 0 · 0 · N" is the
+ * one reading a user cannot act on without being told what it means (#717).
+ */
+function documentLevelOnly(diff: SpecDiff): boolean {
+	return diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0;
 }
 
 interface SelectionProps {
@@ -363,6 +404,14 @@ function DiffReport({
 					{diff.removed.length} request{diff.removed.length === 1 ? "" : "s"} whose
 					operation is gone · {diff.changed.length} changed · {diff.unchanged} unchanged
 				</p>
+				{documentLevelOnly(diff) && (
+					<p className="text-[11px] text-muted-foreground">
+						Document-level changes only - no operation this collection maps has moved.
+						Response schemas, statuses and <code>servers</code> live on the document
+						rather than on a request, so applying stores the new document and rebuilds
+						the response-schema and coverage indexes.
+					</p>
+				)}
 				{diff.unmapped > 0 && (
 					<p className="text-[11px] text-muted-foreground">
 						{diff.unmapped} request{diff.unmapped === 1 ? "" : "s"} carry no operation

--- a/app/src/services/openapi/spec-apply.test.ts
+++ b/app/src/services/openapi/spec-apply.test.ts
@@ -175,11 +175,14 @@ describe("a duplicated operationId is not corruption a default apply can commit 
 		});
 
 		const b = body.update.find((u) => u.id === "req_b");
-		expect(b?.method).toBe("POST");
 		expect(b?.specOperation).toEqual({ method: "POST", path: "/b" });
 		// Nothing the document produces for this request differs, so no field of
 		// it is written at all - the update exists only to drop the id the other
-		// operation kept, which is the ambiguity being repaired.
+		// operation kept, which is the ambiguity being repaired. `method` is one of
+		// those fields since #717, so it is absent rather than re-asserted as
+		// "POST" - a stronger form of the same claim, because the first operation's
+		// `GET` cannot reach this request through a key that is not there.
+		expect(b?.method).toBeUndefined();
 		expect(b?.name).toBeUndefined();
 		expect(b?.url).toBeUndefined();
 		// The tweak lands where it belongs, on the request that operation is.
@@ -331,7 +334,9 @@ describe("buildSyncPayload", () => {
 			method: "GET",
 			path: "/pets",
 		});
-		expect(patch.method).toBe("GET");
+		// `request.method` does not, since #717: it is a ticked field like `url`,
+		// and this selection ticked only `name`.
+		expect(patch.method).toBeUndefined();
 		expect(patch.examples).toEqual([]);
 	});
 

--- a/app/src/services/openapi/spec-apply.ts
+++ b/app/src/services/openapi/spec-apply.ts
@@ -28,11 +28,21 @@
  * or sync wrote, and an example saved from a live response is never touched -
  * the engine keeps that promise by `origin`, not this payload.
  *
- * **The identity travels with the request, always.** An applied change writes
- * `specOperation` and `method` even when neither is a ticked field: an
- * operation *is* its method and path template, so a request that recorded the
- * old identity after a rename would be diffed against the wrong operation next
- * time - the exact failure `operation-match.ts` warns about.
+ * **The identity travels with the request, always - and it is `specOperation`,
+ * not `method`.** An applied change writes `specOperation` whether or not
+ * anything was ticked: an operation *is* its method and path template, so a
+ * request that recorded the old identity after a rename would be diffed against
+ * the wrong operation next time - the exact failure `operation-match.ts` warns
+ * about. `request.method` used to ride along on that reasoning and does not
+ * anymore (issue #717): it is what the request *sends*, protects no lookup, and
+ * writing it unconditionally silently reverted a user's `GET` -> `HEAD` edit on
+ * any applied change. It is now a compared, flaggable, tickable `SpecField`
+ * like `url`, which is what an import-written field is owed.
+ *
+ * A method left unticked therefore leaves `request.method` disagreeing with the
+ * `specOperation.method` beside it. That is a state the user chose and it stays
+ * visible: the next check compares the two again and offers the field again,
+ * where writing it for them would be the silent revert this fixes.
  */
 
 import type {
@@ -99,7 +109,15 @@ export function defaultSelection(diff: SpecDiff): SpecApplySelection {
 	};
 }
 
-/** Whether a selection would write anything at all. */
+/**
+ * Whether a selection would write any request *rows*.
+ *
+ * Not "would write anything at all" (issue #717): every apply stores the
+ * re-fetched document and moves the binding to it, so an empty selection is a
+ * document-level update rather than a no-op. This answers which of the two an
+ * apply would be - what the button says it is about to do - and never whether
+ * one is worth making.
+ */
 export function isEmptySelection(selection: SpecApplySelection): boolean {
 	return (
 		selection.added.size === 0 && selection.removed.size === 0 && selection.changed.size === 0
@@ -205,6 +223,7 @@ function updateItem(item: ChangedRequest, fields: ReadonlySet<SpecField>): SpecS
 	const patch: SpecSyncUpdate = { id: item.request.id };
 	if (fields.has("name")) patch.name = draft.name;
 	if (fields.has("description")) patch.description = draft.description;
+	if (fields.has("method")) patch.method = draft.method;
 	if (fields.has("url")) patch.url = draft.url;
 	if (fields.has("params")) patch.params = draft.params;
 	if (fields.has("headers")) patch.headers = draft.headers;
@@ -212,10 +231,9 @@ function updateItem(item: ChangedRequest, fields: ReadonlySet<SpecField>): SpecS
 		patch.body = draft.body;
 		patch.bodyType = draft.body.mode; // the engine never derives this
 	}
-	// Both halves of the identity, whether or not anything else was ticked - see
-	// the file comment for why the method rides with it rather than as a field.
+	// The recorded identity, whether or not anything else was ticked - see the
+	// file comment for why this rides along and `request.method` no longer does.
 	patch.specOperation = item.operation;
-	patch.method = draft.method;
 	// Present, `[]` included: an operation whose documented responses were
 	// removed must lose the examples the last import wrote for them, and an
 	// absent key means "leave every example alone".

--- a/app/src/services/openapi/spec-diff.test.ts
+++ b/app/src/services/openapi/spec-diff.test.ts
@@ -465,4 +465,84 @@ describe("diffSpec", () => {
 			expect(diff.changed[0].renamed).toBe(false);
 		});
 	});
+
+	/**
+	 * `method` is a compared field (issue #717).
+	 *
+	 * It was the one field an import writes that the comparison did not read,
+	 * while `spec-apply` wrote it on every update anyway - so a user's edit was
+	 * reverted by a change to any other field, with no row, no flag and no tick
+	 * to show it happening. Everything here is the ordinary treatment `url` has
+	 * always had, asserted for `method` because the asymmetry was the bug.
+	 */
+	describe("method", () => {
+		it("reports the user's edit as theirs, so an apply cannot take it back silently", () => {
+			// Mutation check: drop "method" from `SpecField`/`FIELDS` and the field
+			// list is `["description"]` - the exact blindness that let the apply
+			// revert a HEAD back to GET.
+			const editedToHead = requestFrom("req_0", draftOf(BOUND, "listPets"), {
+				method: "HEAD",
+			});
+
+			const diff = diffAgainst(
+				doc({
+					"/pets": {
+						get: {
+							operationId: "listPets",
+							summary: "List pets",
+							description: "Paged.",
+						},
+						post: {
+							operationId: "createPet",
+							summary: "Create a pet",
+							requestBody: jsonBody({ name: { type: "string" } }),
+						},
+					},
+					"/pets/{petId}": { get: { operationId: "getPet", summary: "Get a pet" } },
+				}),
+				[editedToHead]
+			);
+
+			const fields = diff.changed[0].fields;
+			expect(fieldNames(fields)).toEqual(["description", "method"]);
+			const method = fields.find((field) => field.field === "method");
+			expect(method?.userTouched).toBe(true);
+			expect(method?.current).toBe("HEAD");
+			expect(method?.next).toBe("GET");
+			// The document's own change is not confused with the user's.
+			expect(fields.find((field) => field.field === "description")?.userTouched).toBe(false);
+		});
+
+		it("reports a method the document itself moved as the document's", () => {
+			// Same operationId, different verb: the request is still followed (the
+			// id leads), and the verb it should now send is offered like any other
+			// field the document moved.
+			const moved = doc({
+				"/pets": {
+					post: {
+						operationId: "listPets",
+						summary: "List pets",
+					},
+				},
+			});
+
+			const diff = diffAgainst(moved, [requestFrom("req_0", draftOf(BOUND, "listPets"))]);
+
+			expect(diff.changed).toHaveLength(1);
+			expect(diff.changed[0].matchedBy).toBe("operationId");
+			const method = diff.changed[0].fields.find((field) => field.field === "method");
+			expect(method?.userTouched).toBe(false);
+			expect(method?.current).toBe("GET");
+			expect(method?.next).toBe("POST");
+		});
+
+		it("leaves a request alone when the document agrees with the verb it holds", () => {
+			// The other direction of the same field: adding `method` to the compared
+			// set must not make every unchanged request report one.
+			const diff = diffAgainst(BOUND, [requestFrom("req_0", draftOf(BOUND, "listPets"))]);
+
+			expect(diff.changed).toHaveLength(0);
+			expect(diff.unchanged).toBe(1);
+		});
+	});
 });

--- a/app/src/services/openapi/spec-diff.ts
+++ b/app/src/services/openapi/spec-diff.ts
@@ -61,11 +61,25 @@ import { operationShapeKey, specPathShape } from "./operation-match";
  * any claim on. `auth` and the scripts are absent on purpose: an import sets
  * auth to `inherit` and the scripts to empty for every operation, so a
  * difference there is always the user's and never the document's.
+ *
+ * **`method` is one of them** (issue #717). It was left out while `spec-apply`
+ * wrote it on every update regardless, so a user who changed an imported `GET`
+ * to `HEAD` had that edit reverted by any applied change - invisibly, because a
+ * field nobody compares is a field nobody can flag or tick. It belongs here by
+ * this list's own definition: an import writes it.
  */
-export type SpecField = "name" | "description" | "url" | "params" | "headers" | "body";
+export type SpecField = "name" | "description" | "method" | "url" | "params" | "headers" | "body";
 
 /** Field order for display - the request builder's own top-to-bottom order. */
-const FIELDS: readonly SpecField[] = ["name", "description", "url", "params", "headers", "body"];
+const FIELDS: readonly SpecField[] = [
+	"name",
+	"description",
+	"method",
+	"url",
+	"params",
+	"headers",
+	"body",
+];
 
 /** One field of one request that no longer matches the document. */
 export interface SpecFieldDiff {
@@ -347,6 +361,7 @@ interface FieldValue {
 interface SpecShaped {
 	name: string;
 	description: string;
+	method: string;
 	url: string;
 	params: KeyValueEntry[];
 	headers: KeyValueEntry[];
@@ -357,6 +372,13 @@ function fieldValues(source: SpecShaped): Record<SpecField, FieldValue> {
 	return {
 		name: text(source.name),
 		description: text(source.description),
+		// Compared as written, unlike `sameOperation`'s uppercasing of the
+		// identity: both sides here are an `HttpMethod`, and the engine parses
+		// that field case-sensitively (`parse_method` 400s on `get`) and
+		// serialises it from an enum - so a stored lowercase verb is a state no
+		// write can reach, and normalising for it would be a guard against
+		// nothing.
+		method: text(source.method),
 		url: text(source.url),
 		params: rows(source.params),
 		headers: rows(source.headers),

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -191,12 +191,32 @@ bound:
   still claims them. Those requests are not going anywhere; they are simply no
   longer described by the contract.
 - **Changed** - the request is still that operation, and one or more of the
-  fields an import writes (name, description, URL, params, headers, body) is no
-  longer what the document produces.
+  fields an import writes (name, description, method, URL, params, headers,
+  body) is no longer what the document produces.
 
 Everything else is counted as unchanged, and requests carrying no operation at
 all are counted separately: the contract never described them, so the comparison
 leaves them out and says how many it left out.
+
+### The fourth kind: a change no request row can carry
+
+The three buckets describe operations, and plenty of contract changes are not
+about an operation's request shape at all - a tightened response schema, a newly
+documented `429`, an edited `servers` block. Those move the document without
+moving a single request, so all three buckets come back empty and the summary
+reads `0 new · 0 gone · 0 changed · N unchanged`.
+
+That is a real change, and it is applyable. The section names it
+**document-level changes only** and offers **Update the stored document**, which
+stores the new document, moves the binding to it, and rebuilds the
+response-schema and coverage indexes - without touching one request row. It is
+the same single transaction as any other apply, with an empty set of rows.
+
+This is also what you get when a diff *does* offer rows and you untick them all:
+the apply is always available while the bytes differ, and it always says which of
+the two it is about to be. Response validation and coverage read the document
+they were stored against, so a collection that can never take the new document is
+a collection judging every run against a contract that has moved on.
 
 ### Renames, and what is never guessed
 
@@ -259,6 +279,18 @@ stored, the collection's binding moves to it, and every created, updated and
 deleted request lands with it - or none of it does and the collection stays
 bound to the document it was bound to before. There is no half-applied sync to
 find and repair.
+
+**Every apply stores the document; the ticks decide which requests ride along.**
+That is why an apply is offered whenever the bytes differ, and why the button
+names which of the two it is - *Apply selected*, or *Update the stored document*
+when no request row is ticked.
+
+**Your method edit is a tickable field like any other.** The HTTP method is one
+of the fields an import writes, so a document that moves an operation's verb
+offers it as a row you can take, and a verb *you* changed is marked **edited
+here** and left for you to decide. Leaving it unticked means the request keeps
+sending what you set while its recorded identity says what the document declares
+- a difference the next check shows you again rather than silently resolving.
 
 Deleting is behind a confirmation that names the count, and the deletions ride
 in the same apply as everything else you ticked.


### PR DESCRIPTION
## Description

Both findings in #717 have one root cause: `SpecField` (`spec-diff.ts:65`) compared six request-shaped fields, and everything downstream trusted that list to be complete.

**Plan.** Root cause: the diff answers "which request rows moved", and Apply was gated on that answer - so a document that changes only a response schema, a status, or its `servers` block produces three empty buckets and dead-ends with Apply permanently disabled, leaving the stored document, the response-schema index and the coverage index stale forever while the UI truthfully said the document had changed. Approach: make the rule one line - **every apply stores the document; the ticks decide which request rows ride along** - and name the case in the UI. The alternative rejected was offering the document-level apply *only* when all three buckets are empty: that is the same dead end one step over, since a user who unticks every offered row is in exactly the state Problem A describes, and #717's acceptance criterion ("Apply is never permanently disabled while bytes differ") rules it out.

**The engine needed no change, and the contract was already pinned.** #717 asked to "verify the engine route accepts an empty batch or add that capability". It accepts: `spec_sync_response` builds `batch.spec` and `batch.binding` unconditionally and `Database::spec_sync_apply` runs `storage.replace(batch.spec)` / `update(batch.binding)` regardless of whether create/update/delete are empty (`spec_sync.cpp:400-404,652-668`; `database.cpp:1166-1170`), with the item cap an upper bound only. `SpecSyncRouteTest.AnEmptySelectionStillMovesTheBindingAndNothingElse` (`spec_sync_route_test.cpp:209`) already asserts the 200, the untouched rows and the moved binding. So this PR is app-only and nothing under `engine/` is touched.

**Problem B was the same blindness pointing the other way.** `method` is a field an OpenAPI import writes, so it belongs in `SpecField` by that type's own definition - but it was absent from the comparison while `updateItem` wrote `patch.method = draft.method` unconditionally. A user who changed an imported `GET` to `HEAD` kept it until the document reworded a *description*, at which point the apply wrote the method back: no row, no `edited here` flag, nothing ticked. Meanwhile a user-edited `url` got the warning and started unticked. It is now an ordinary compared, flaggable, tickable field. The recorded identity still travels with every update - `specOperation` is what `lookup` follows and what a rename would otherwise strand - but `request.method` does not, because it protects no lookup; the stated rationale at `spec-apply.ts:31-35` covered `specOperation` and was quietly doing duty for both.

A method left unticked leaves `request.method` disagreeing with the `specOperation.method` beside it. That is deliberate and self-healing rather than a new hole: the next check compares the two again and offers the field again, where writing it for them is the silent revert being fixed.

**Verified at `682cc9a`** (the issue's anchors were written at `ac27b97`): `SpecField` still listed the six fields, `spec-apply.ts:218` still wrote `method` unconditionally, and `SpecSync.tsx` still gated Apply on `isEmptySelection`. All three sequencing gates the issue names are met on master - #715, #714 and #709 have landed - and the residual coordination it records with #722 over `spec_sync.cpp` does not arise, since no engine file is touched.

### Deliberate deviations, with reasons

- **One removal that is a deviation from my own first draft, not from the spec.** I initially normalised the method to uppercase before comparing, mirroring `sameOperation`. It is unreachable: `Request.method` and `RequestDraft.method` are both `HttpMethod`, and the engine parses that field case-sensitively (`parse_method` in `types.hpp:74` returns `nullopt` for `get`, so the write is a 400) and serialises it back from an enum. A stored lowercase verb is a state no write can reach, so the guard was against nothing and came out; the reasoning is recorded at the call site so it is not re-added.
- **The `applied` message branches** on a zero-row result rather than printing "0 requests created, 0 updated, 0 deleted", which reads as though nothing happened when the document, the schema index and the coverage index all moved.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, full: **502 files, 5317 tests, all passing** (7 new: 44 → 51 across the three touched test files). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `mkdocs build --strict` clean. `prettier --check` clean on every touched source file - all six were clean at the base commit and were formatted; `docs/app/openapi.md` was **not** prettier-clean at `682cc9a` and is left as it is, per the repo rule about formatting only files that were clean before. No engine or C++ change - nothing under `engine/` is touched and no engine test could change colour - so no `build.py -t` / `ctest` run. No pre-existing failures observed on the base commit.

Each guard mutation-checked (mutation applied, confirmed red, reverted):

| Guard | Mutation that turns it red |
|---|---|
| a schema-only change is applyable - the new bytes, both indexes, and not one request row named | restore `isEmptySelection(...)` to the Apply button's `disabled` (1 red: `syncSpec` is never called, which is the dead end) |
| a user's `HEAD` survives an apply of a description-only change | restore `patch.method = draft.method` in `updateItem` (3 red across `spec-apply.test.ts` and `SpecSync.test.tsx`) |
| the user's method edit is reported, flagged as theirs, and the document's own change is not confused with it | drop `"method"` from `SpecField` / `FIELDS` (2 red) |
| a method the document itself moved is offered as the document's | same mutation (covered above) |

Also covered: the summary states "document-level changes only" beside the unchanged full counts; the button names which apply it is about to be, and the empty-selection case is reached both by a diff with no rows at all *and* by a diff whose only row is the user's own edit (the dead end one step over); adding `method` to the compared set does not make an agreeing request report a change; and the duplicated-`operationId` payload test from #715 now asserts `method` is **absent** rather than re-asserted as `"POST"` - a stronger form of the same claim, since the other operation's `GET` cannot reach the request through a key that is not there.

Not asserted here, deliberately: that the binding hash moves and the indexes are rebuilt. Those are the engine's half, already covered by `spec_sync_route_test.cpp`; what the renderer owns is that the new bytes and both indexes are *sent*, which is what the new test asserts.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/openapi.md` gains a **"The fourth kind: a change no request row can carry"** section beside the three buckets (what produces it, what the apply does, and that it also covers unticking every offered row), the apply section gains the one-rule statement and the method rule, and `method` joins the field list in the Changed bucket. The `spec-apply.ts:31-35` rationale comment that claimed the method rides with the identity now says what actually happens, and `isEmptySelection`'s doc comment no longer claims to answer "would this write anything at all".

## Related Issues
Closes #717

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss5HubXjS4u9rj6r34he3s)_