### PR TITLE
fix(app/import): resolve server URLs, disclose cookie and body drops, and cap the document before preview

### DIFF
--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -1018,6 +1018,22 @@ const SKIPPED_LABELS: Record<SkippedItem["kind"], [singular: string, plural: str
 		"operation whose operationId was already used (identified by path instead)",
 		"operations whose operationId was already used (identified by path instead)",
 	],
+	// The three below name what the *request* lost rather than the spec construct
+	// that was skipped (issue #719): a reader of this line is deciding what to
+	// finish by hand after the import, and "cookie parameter" alone does not say
+	// that nothing carries it.
+	cookie_param: [
+		"cookie parameter (not imported - use the cookie jar)",
+		"cookie parameters (not imported - use the cookie jar)",
+	],
+	unmapped_body: [
+		"request body in a format Vayu cannot fill in (binary, XML, image)",
+		"request bodies in a format Vayu cannot fill in (binary, XML, image)",
+	],
+	unresolved_base_url: [
+		"server URL that could not be resolved to a real address",
+		"server URLs that could not be resolved to a real address",
+	],
 };
 
 function skippedLabel(kind: SkippedItem["kind"], count: number): string {

--- a/app/src/services/importers/batch.test.ts
+++ b/app/src/services/importers/batch.test.ts
@@ -248,6 +248,46 @@ describe("reparseBatch", () => {
 	});
 });
 
+describe("detectBatch - a document the engine could not store", () => {
+	/**
+	 * Issue #719: the refusal has to land here, on the entry, because that is what
+	 * keeps it out of `applicableEntries` - and so out of `POST /import/apply`,
+	 * where it used to arrive as a 400 that rolled back a transaction the user had
+	 * already confirmed from a healthy-looking preview.
+	 */
+	it("refuses an over-cap spec as a row with no result, so nothing is applied", async () => {
+		const oversized = fixture("openapi-v3.json").padEnd(4096);
+		const entries = await detectBatch(
+			[{ fileName: "big.json", relativePath: "big.json", text: oversized }],
+			OPTS,
+			intake({ maxBytes: 2048 })
+		);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0].result).toBeNull();
+		expect(entries[0].error).toMatch(/over the 2048.*maxSpecDocumentBytes/s);
+		expect(applicableEntries(entries)).toEqual([]);
+	});
+
+	it("leaves a smaller spec in the same batch importable", async () => {
+		const entries = await detectBatch(
+			[
+				{ fileName: "big.json", relativePath: "big.json", text: postman.padEnd(4096) },
+				{ fileName: "ok.json", relativePath: "ok.json", text: fixture("openapi-v3.json") },
+			],
+			OPTS,
+			intake({ maxBytes: 2048 })
+		);
+
+		// The Postman file is over the same number and imports anyway: the cap is
+		// the spec-document cap, and a collection is not stored as one.
+		expect(entries.map((e) => e.result?.meta.format)).toEqual([
+			"Postman Collection v2.1",
+			"OpenAPI 3.0",
+		]);
+	});
+});
+
 describe("isImportableFileName", () => {
 	it("takes the spec extensions and nothing else", () => {
 		expect(["a.json", "b.yaml", "c.yml", "D.JSON"].every(isImportableFileName)).toBe(true);

--- a/app/src/services/importers/factory.test.ts
+++ b/app/src/services/importers/factory.test.ts
@@ -184,4 +184,31 @@ describe("parseImport joins enabled params into the request URL", () => {
 		const req = parseImport(spec, opts).collections[0].requests[0];
 		expect(req.url).toBe("{{baseUrl}}/items?tenant&limit=25");
 	});
+
+	/**
+	 * Issue #719. The two halves of the fix that only exist once the whole
+	 * pipeline runs: the factory knows where the bytes came from, and the raw
+	 * text is parsed as YAML before any detector sees it.
+	 */
+	it("hands the source URL to the parser, so a relative server URL resolves", () => {
+		const spec = JSON.stringify({
+			openapi: "3.0.0",
+			info: { title: "Relative API" },
+			servers: [{ url: "/api/v3" }],
+			paths: { "/items": { get: { summary: "List" } } },
+		});
+		const result = parseImport(spec, opts, {
+			sourceUrl: "https://acme.dev/specs/openapi.json",
+		});
+		expect(result.collections[0].variables.baseUrl.value).toBe("https://acme.dev/api/v3");
+		expect(result.meta.skipped).toEqual([]);
+		// And the source URL still reaches the stored document, which is what a
+		// re-fetch follows (#638) - the two uses are independent.
+		expect(result.collections[0].spec?.sourceUrl).toBe("https://acme.dev/specs/openapi.json");
+	});
+
+	it("routes unquoted YAML `swagger: 2.0`, which loads as a number", () => {
+		const yaml = ["swagger: 2.0", "info:", "  title: Store API", "paths: {}"].join("\n");
+		expect(parseImport(yaml, opts).meta.format).toBe("OpenAPI 2.0 (Swagger)");
+	});
 });

--- a/app/src/services/importers/factory.ts
+++ b/app/src/services/importers/factory.ts
@@ -5,7 +5,13 @@
  * LICENSE file in the "app" directory of this source tree.
  */
 
-import type { CollectionDraft, ImportOptions, ImportParser, ImportResult } from "./types";
+import type {
+	CollectionDraft,
+	ImportOptions,
+	ImportParser,
+	ImportResult,
+	ImportSource,
+} from "./types";
 import { UnrecognisedFormatError } from "./types";
 import { parseRaw } from "./parse-raw";
 import { appendParamsToUrl } from "@/modules/request-builder/utils/url";
@@ -54,24 +60,11 @@ function joinParamsIntoUrls(result: ImportResult): void {
 }
 
 /**
- * Where the raw text came from, for the two facts a parser cannot know.
- *
- * `fileName` is display only (the preview names the file). `sourceUrl` is
- * persisted: it becomes `spec_documents.source_url`, which is what makes a
- * re-fetch possible at all - before this it lived in the import dialog's local
- * state and was discarded when the dialog closed (issue #638).
+ * Where the raw text came from. Declared beside `ImportParser` in `./types`,
+ * since `parse` now takes it, and re-exported here because this is where every
+ * caller already reaches for it.
  */
-export interface ImportSource {
-	fileName?: string;
-	sourceUrl?: string;
-	/**
-	 * External `$ref`s the bundling pass could not reach (issue #649). Stamped
-	 * into `meta.skipped` here for the same reason the two above are stamped
-	 * here: bundling happens before parse, so no parser can know the count, and a
-	 * loss the preview never names is the defect bundling exists to fix.
-	 */
-	unresolvedRefs?: number;
-}
+export type { ImportSource };
 
 /**
  * Parse a raw import string. Parses once (JSON then YAML fallback), then runs detectors in order.
@@ -85,12 +78,16 @@ export function parseImport(
 	const parsed = parseRaw(raw);
 	for (const parser of PARSERS) {
 		if (parser.detect(parsed, raw)) {
-			const result = parser.parse(parsed, raw, opts);
+			// `source` reaches `parse` because a relative `servers[0].url` is
+			// relative to where the document was fetched from, and only the parser
+			// knows it has one (issue #719).
+			const result = parser.parse(parsed, raw, opts, source);
 			if (source.fileName) result.meta.fileName = source.fileName;
-			// Stamped here rather than passed into `parse`, for the same reason
-			// `fileName` is: where the bytes came from is the caller's knowledge,
-			// and only a format that produced a spec document has anywhere to put
-			// it. A non-OpenAPI import carries no `spec`, so this is a no-op.
+			// Stamped here rather than read inside `parse`, for the same reason
+			// `fileName` is: what a spec document records about its own origin is
+			// the caller's knowledge, and only a format that produced one has
+			// anywhere to put it. A non-OpenAPI import carries no `spec`, so this is
+			// a no-op.
 			if (source.sourceUrl) {
 				for (const collection of result.collections) {
 					if (collection.spec) collection.spec.sourceUrl = source.sourceUrl;

--- a/app/src/services/importers/openapi-v2.test.ts
+++ b/app/src/services/importers/openapi-v2.test.ts
@@ -42,6 +42,18 @@ describe("OpenApiV2Parser", () => {
 		expect(p.detect({ openapi: "3.0.0" }, "")).toBe(false);
 	});
 
+	/**
+	 * Issue #719. `swagger: 2.0` written without quotes is loaded by js-yaml as
+	 * the number 2 - a shape JSON cannot produce and hand-written YAML routinely
+	 * does - and the file was reported as "Unrecognised format".
+	 */
+	it("detects an unquoted YAML version claim, which loads as a number", () => {
+		expect(p.detect({ swagger: 2 }, "")).toBe(true);
+		expect(p.detect({ swagger: 3 }, "")).toBe(false);
+		expect(p.detect({ swagger: "3.0" }, "")).toBe(false);
+		expect(p.detect({}, "")).toBe(false);
+	});
+
 	it("constructs baseUrl from scheme+host+basePath and maps apiKey scheme", () => {
 		const root = p.parse(parsed, raw, opts).collections[0];
 		expect(root.variables.baseUrl.value).toBe("https://api.store.com/v2");

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -73,8 +73,25 @@ export class OpenApiV2Parser implements ImportParser {
 	readonly formatName = "OpenAPI 2.0 (Swagger)";
 	readonly formatKey = "openapi-v2";
 
+	/**
+	 * The version claim, as either of the two shapes a real file writes it in
+	 * (issue #719).
+	 *
+	 * `swagger: "2.0"` is what the specification says and what every JSON export
+	 * produces - JSON has no other option, since the key is quoted or it is not
+	 * valid. Hand-written YAML routinely leaves it unquoted, and YAML then loads
+	 * `2.0` as the **number** 2, so a string comparison alone rejected a perfectly
+	 * ordinary Swagger file as "Unrecognised format". The v3 side never had this
+	 * problem for a reason that does not generalise: `3.0.3` has two dots, so it
+	 * is a string whatever the quoting.
+	 *
+	 * Only detection needs this. Nothing in `parse` reads the field, and the
+	 * document is stored as the bytes it arrived as - so there is no normalized
+	 * copy to keep, and nothing downstream that could disagree about the version.
+	 */
 	detect(parsed: unknown, _raw: string): boolean {
-		return prop(parsed, "swagger") === "2.0";
+		const claimed = prop(parsed, "swagger");
+		return claimed === "2.0" || claimed === 2;
 	}
 
 	parse(parsed: unknown, raw: string, _opts: ImportOptions): ImportResult {

--- a/app/src/services/importers/openapi-v3.test.ts
+++ b/app/src/services/importers/openapi-v3.test.ts
@@ -673,5 +673,179 @@ describe("OpenApiV3Parser", () => {
 				])
 			).toEqual([{ key: "X-Keep", value: "", enabled: true }]);
 		});
+
+		/**
+		 * Issue #719. A cookie parameter has no row to import into - Vayu's cookies
+		 * come from the jar - so the only question is whether the drop is named.
+		 */
+		it("drops a cookie parameter and counts it, leaving path parameters uncounted", () => {
+			const spec = {
+				openapi: "3.0.0",
+				info: { title: "Cookie API" },
+				paths: {
+					"/items/{id}": {
+						get: {
+							summary: "Get item",
+							parameters: [
+								{ name: "session", in: "cookie", schema: { type: "string" } },
+								{ name: "csrf", in: "cookie", schema: { type: "string" } },
+								{ name: "id", in: "path", required: true },
+								{ name: "q", in: "query" },
+							],
+						},
+					},
+				},
+			};
+			const result = p.parse(spec, JSON.stringify(spec), opts);
+			const request = result.collections[0].requests[0];
+			expect(request.headers).toEqual([]);
+			expect(request.params).toEqual([{ key: "q", value: "", enabled: false }]);
+			// The path parameter is carried, as the URL template - so it is a drop
+			// that never happened and must not be counted as one.
+			expect(request.url).toBe("{{baseUrl}}/items/{{id}}");
+			expect(result.meta.skipped).toEqual([{ kind: "cookie_param", count: 2 }]);
+		});
+	});
+
+	/**
+	 * Issue #719: a `requestBody` declaring only media types with no Vayu mode
+	 * returned `{mode: "none"}` on the same path as *no body at all*, so a binary
+	 * upload imported as a bodyless POST reporting nothing skipped.
+	 */
+	describe("request bodies with no Vayu mode", () => {
+		const parseWithBody = (requestBody: unknown) => {
+			const spec = {
+				openapi: "3.0.0",
+				info: { title: "Body API" },
+				paths: { "/upload": { post: { summary: "Upload", requestBody } } },
+			};
+			return p.parse(spec, JSON.stringify(spec), opts);
+		};
+
+		it("counts a binary body, and still imports the operation", () => {
+			const result = parseWithBody({
+				content: {
+					"application/octet-stream": { schema: { type: "string", format: "binary" } },
+				},
+			});
+			expect(result.collections[0].requests[0].body).toEqual({ mode: "none" });
+			expect(result.meta.requestCount).toBe(1);
+			expect(result.meta.skipped).toEqual([{ kind: "unmapped_body", count: 1 }]);
+		});
+
+		it("counts an XML body once, however many unmapped media types declared it", () => {
+			const result = parseWithBody({
+				content: { "application/xml": {}, "image/png": {} },
+			});
+			expect(result.meta.skipped).toEqual([{ kind: "unmapped_body", count: 1 }]);
+		});
+
+		it("counts nothing for an operation that declared no body at all", () => {
+			expect(parseWithBody(undefined).meta.skipped).toEqual([]);
+		});
+
+		it("counts nothing when a mode was found", () => {
+			const json = parseWithBody({
+				content: { "application/json": { schema: { type: "object" } } },
+			});
+			expect(json.meta.skipped).toEqual([]);
+			const text = parseWithBody({ content: { "text/plain": {} } });
+			expect(text.collections[0].requests[0].body).toEqual({ mode: "text", content: "" });
+			expect(text.meta.skipped).toEqual([]);
+		});
+	});
+
+	/**
+	 * Issue #719: `servers[0].url` was taken verbatim, so a templated or relative
+	 * server URL produced a `{{baseUrl}}` no request could ever reach - with
+	 * nothing in the preview to say so.
+	 */
+	describe("server URL resolution", () => {
+		const baseUrlOf = (servers: unknown, sourceUrl?: string) => {
+			const spec = {
+				openapi: "3.0.0",
+				info: { title: "Server API" },
+				servers,
+				paths: { "/items": { get: { summary: "List" } } },
+			};
+			const result = p.parse(
+				spec,
+				JSON.stringify(spec),
+				opts,
+				sourceUrl ? { sourceUrl } : {}
+			);
+			return {
+				baseUrl: result.collections[0].variables.baseUrl?.value,
+				skipped: result.meta.skipped,
+			};
+		};
+
+		it("substitutes the declared defaults of every server variable", () => {
+			expect(
+				baseUrlOf([
+					{
+						url: "{protocol}://{hostname}/api/v3",
+						variables: {
+							protocol: { default: "https", enum: ["http", "https"] },
+							hostname: { default: "api.acme.dev" },
+						},
+					},
+				])
+			).toEqual({ baseUrl: "https://api.acme.dev/api/v3", skipped: [] });
+		});
+
+		it("substitutes a numeric default, which hand-written YAML produces", () => {
+			expect(
+				baseUrlOf([
+					{
+						url: "https://api.acme.dev:{port}/v1",
+						variables: { port: { default: 8443 } },
+					},
+				])
+			).toEqual({ baseUrl: "https://api.acme.dev:8443/v1", skipped: [] });
+		});
+
+		it("resolves a relative server URL against the URL the document came from", () => {
+			expect(baseUrlOf([{ url: "/api/v3" }], "https://acme.dev/specs/openapi.yaml")).toEqual({
+				baseUrl: "https://acme.dev/api/v3",
+				skipped: [],
+			});
+			expect(baseUrlOf([{ url: "v3" }], "https://acme.dev/specs/openapi.yaml")).toEqual({
+				baseUrl: "https://acme.dev/specs/v3",
+				skipped: [],
+			});
+		});
+
+		it("counts a relative URL that has nothing to resolve against, keeping it verbatim", () => {
+			expect(baseUrlOf([{ url: "/api/v3" }])).toEqual({
+				baseUrl: "/api/v3",
+				skipped: [{ kind: "unresolved_base_url", count: 1 }],
+			});
+		});
+
+		it("counts a variable the document declares no default for, keeping it verbatim", () => {
+			expect(
+				baseUrlOf(
+					[{ url: "https://{tenant}.acme.dev", variables: { tenant: { enum: ["a"] } } }],
+					"https://acme.dev/openapi.yaml"
+				)
+			).toEqual({
+				baseUrl: "https://{tenant}.acme.dev",
+				skipped: [{ kind: "unresolved_base_url", count: 1 }],
+			});
+		});
+
+		it("leaves an absolute URL exactly as written, and counts nothing", () => {
+			expect(
+				baseUrlOf([{ url: "https://api.acme.dev/v1" }], "https://acme.dev/spec.json")
+			).toEqual({ baseUrl: "https://api.acme.dev/v1", skipped: [] });
+		});
+
+		it("adds no baseUrl variable, and counts nothing, when the document declares no server", () => {
+			expect(baseUrlOf(undefined, "https://acme.dev/spec.json")).toEqual({
+				baseUrl: undefined,
+				skipped: [],
+			});
+		});
 	});
 });

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -20,6 +20,7 @@ import type {
 	ImportOptions,
 	ImportParser,
 	ImportResult,
+	ImportSource,
 	RequestDraft,
 } from "./types";
 import { asArray, asRecord, asStr, prop, type JsonRecord } from "@/lib/json-node";
@@ -79,16 +80,21 @@ export class OpenApiV3Parser implements ImportParser {
 		return !!v && v.startsWith("3.");
 	}
 
-	parse(parsed: unknown, raw: string, _opts: ImportOptions): ImportResult {
+	parse(
+		parsed: unknown,
+		raw: string,
+		_opts: ImportOptions,
+		source: ImportSource = {}
+	): ImportResult {
 		const spec = asRecord(parsed) ?? {};
 		const resolveRef = createRefResolver(spec);
 
-		const baseUrl = asStr(prop(asArray(spec.servers)[0], "url")) ?? "";
 		const primaryScheme = pickPrimaryScheme(spec);
 
 		const tagCollections = new Map<string, CollectionDraft>();
 		const rootRequests: RequestDraft[] = [];
 		const tally = new SkipTally();
+		const baseUrl = resolveServerUrl(asArray(spec.servers)[0], source.sourceUrl, tally);
 		// One identifier for the whole document: it is what keeps a repeated
 		// `operationId` off the second request that would otherwise claim it
 		// (issue #715), which needs the memory of every id already stamped.
@@ -200,6 +206,68 @@ export class OpenApiV3Parser implements ImportParser {
 	}
 }
 
+/** A URL that already names its own scheme - `https:`, and any other. */
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+/** What is left of a `{token}` after substitution, which is what cannot resolve. */
+const SERVER_TEMPLATE = /\{[^{}/]+\}/;
+
+/**
+ * `servers[0]` → the `{{baseUrl}}` every imported request is written against
+ * (issue #719).
+ *
+ * Taken verbatim, that field produces a URL a request can never reach in two
+ * ways, both silently. A Server Object may template its URL -
+ * `{protocol}://{hostname}/api/v3` - and those single braces are **not** Vayu
+ * variables (only the path goes through `normalizeVars`), so the literal
+ * survived into every request line and failed at connect with nothing said. And
+ * a server URL is allowed to be relative, in which case OpenAPI says it is
+ * relative to where the document itself lives - which the parser knows only
+ * because the factory now hands it over.
+ *
+ * So: substitute the defaults the document declares (the spec **requires** a
+ * default on every server variable, so a complete document always resolves),
+ * then resolve what is left against the source URL when it needs one. Anything
+ * still unresolvable is kept exactly as written and counted - a base the user
+ * can see is unfinished beats a host Vayu invented.
+ */
+export function resolveServerUrl(
+	server: unknown,
+	sourceUrl: string | undefined,
+	tally: SkipTally
+): string {
+	const raw = asStr(prop(server, "url")) ?? "";
+	if (!raw) return "";
+
+	const variables = asRecord(prop(server, "variables")) ?? {};
+	const substituted = raw.replace(/\{([^{}/]+)\}/g, (token, name: string) => {
+		const declared = asRecord(variables[name]);
+		if (declared?.default === undefined) return token;
+		// A default is `string` per the spec; a number or boolean is what a
+		// hand-written document produces and reads the same on the wire.
+		const value = declared.default;
+		return typeof value === "object" || value === null ? token : String(value);
+	});
+
+	if (SERVER_TEMPLATE.test(substituted)) {
+		tally.add("unresolved_base_url");
+		return substituted;
+	}
+	if (HAS_SCHEME.test(substituted)) return substituted;
+	if (!sourceUrl) {
+		// A pasted or file-picked document: there is no location to be relative
+		// to, so the URL stays as written rather than being guessed at.
+		tally.add("unresolved_base_url");
+		return substituted;
+	}
+	try {
+		return new URL(substituted, sourceUrl).toString();
+	} catch {
+		tally.add("unresolved_base_url");
+		return substituted;
+	}
+}
+
 function pickPrimaryScheme(spec: JsonRecord): unknown {
 	const required = asRecord(asArray(spec.security)[0]);
 	const reqName = required ? Object.keys(required)[0] : undefined;
@@ -265,7 +333,17 @@ function buildOperation(
 			headers.push(
 				declaredParamRow(name, declaredParamValue(resolved, resolveRef), resolved.required)
 			);
+		} else if (resolved.in === "cookie") {
+			// Vayu has no cookie-parameter row - a request's cookies come from the
+			// jar - so the declaration is dropped. Counted rather than folded into a
+			// `Cookie` header: the header is one joined value and a spec declares
+			// these one at a time, so building it means inventing a merge the
+			// document never wrote. Mapping them is a recorded non-goal (#719), and
+			// the count is what keeps the drop out of the silent category.
+			tally.add("cookie_param");
 		}
+		// `in: "path"` is deliberately not here and not counted: a path parameter is
+		// already carried, as the `{{var}}` `normalizeVars` wrote into the URL.
 	}
 	const examples = buildExamples(op.responses, resolveRef, tally);
 	return {
@@ -275,7 +353,7 @@ function buildOperation(
 		url: `{{baseUrl}}${normalizeVars(path, { pathTemplates: true })}`,
 		params,
 		headers,
-		body: buildBody(op.requestBody, resolveRef),
+		body: buildBody(op.requestBody, resolveRef, tally),
 		auth: { mode: "inherit" },
 		preRequestScript: "",
 		postRequestScript: "",
@@ -350,10 +428,28 @@ function findJsonMedia(content: JsonRecord): JsonRecord | undefined {
 	return key ? asRecord(content[key]) : undefined;
 }
 
-function buildBody(requestBody: unknown, resolveRef: (r: string) => unknown): RequestBody {
+/**
+ * An operation's `requestBody` → the request's body.
+ *
+ * @param tally counts a body the importer has no mode for (issue #719). An
+ * `application/octet-stream`, `application/xml` or `image/*` body used to return
+ * `{mode: "none"}` on the same path as *no body at all*, so GitHub's "Upload a
+ * release asset" imported as a bodyless POST reporting 0 skipped. The two cases
+ * are told apart by whether the document declared any media type: an operation
+ * with no `requestBody` lost nothing and is not counted.
+ */
+function buildBody(
+	requestBody: unknown,
+	resolveRef: (r: string) => unknown,
+	tally: SkipTally
+): RequestBody {
 	const ref = asStr(prop(requestBody, "$ref"));
 	const content = asRecord(prop(ref ? resolveRef(ref) : requestBody, "content"));
 	if (!content) return { mode: "none" };
+	const unmapped = (): RequestBody => {
+		if (Object.keys(content).length > 0) tally.add("unmapped_body");
+		return { mode: "none" };
+	};
 	const jsonMedia = findJsonMedia(content);
 	if (jsonMedia) {
 		const sample =
@@ -377,5 +473,5 @@ function buildBody(requestBody: unknown, resolveRef: (r: string) => unknown): Re
 			return { mode: multipart ? "form-data" : "x-www-form-urlencoded", fields };
 		}
 	}
-	return { mode: "none" };
+	return unmapped();
 }

--- a/app/src/services/importers/ref-bundler.test.ts
+++ b/app/src/services/importers/ref-bundler.test.ts
@@ -271,6 +271,42 @@ describe("bundleExternalRefs - the engine's cap", () => {
 		);
 	});
 
+	/**
+	 * Issue #719. The running total was only ever compared after an external
+	 * document had been loaded, so a spec that references nothing - which is what
+	 * the generated multi-megabyte documents are - passed bundling whatever its
+	 * size and was first refused by the engine at apply, after the user had
+	 * confirmed a preview built from it.
+	 */
+	it("refuses a single over-cap document before it is parsed, naming the setting", async () => {
+		const oversized = singleFileRaw.padEnd(4096);
+		const readSibling = vi.fn(async () => "{}");
+		await expect(
+			bundleExternalRefs(oversized, { maxBytes: 2048, readSibling })
+		).rejects.toThrow(SpecBundleTooLargeError);
+		await expect(
+			bundleExternalRefs(oversized, { maxBytes: 2048, readSibling })
+		).rejects.toThrow(/The spec is 4096 bytes, over the 2048.*maxSpecDocumentBytes/s);
+		// Before parse, and before a single ref is followed: the point of moving
+		// the check is that nothing downstream runs on a document that cannot be
+		// stored.
+		expect(readSibling).not.toHaveBeenCalled();
+	});
+
+	it("leaves a document that is not a spec alone, whatever its size", async () => {
+		// The cap is the *spec document* cap. A Postman collection is stored as
+		// collections and requests, so it has no such limit to be measured against.
+		const collection = JSON.stringify({
+			info: { name: "Big", schema: "https://schema.getpostman.com/json/collection/v2.1.0/" },
+			item: [],
+		}).padEnd(4096);
+		await expect(bundleExternalRefs(collection, { maxBytes: 2048 })).resolves.toEqual({
+			text: collection,
+			bundled: 0,
+			unresolvedRefs: 0,
+		});
+	});
+
 	it("follows the setting rather than a hard-coded copy", async () => {
 		const readSibling = vi.fn(async () =>
 			JSON.stringify({ Pet: { type: "object" } }).padEnd(4000)

--- a/app/src/services/importers/ref-bundler.ts
+++ b/app/src/services/importers/ref-bundler.ts
@@ -88,14 +88,25 @@ export interface BundleResult {
 }
 
 /**
- * A bundle that outgrew the engine's cap. Fatal rather than tallied: the engine
- * would refuse to store the document, so continuing would import a collection
+ * A document that outgrew the engine's cap. Fatal rather than tallied: the
+ * engine would refuse to store it, so continuing would import a collection
  * bound to nothing.
+ *
+ * Thrown for the document **on its own** as well as for a bundle (issue #719).
+ * Only the bundle was checked before, so a single over-cap file - the common
+ * shape, since the specs that reach this size are generated single files - was
+ * fetched, parsed and previewed in full, and first refused by the engine at
+ * apply, 400ing the whole transaction after the user had confirmed a preview
+ * that looked healthy. The wording says which of the two happened, because the
+ * remedy differs: a bundle can be imported pre-bundled, a single file can only
+ * be met by raising the setting.
  */
 export class SpecBundleTooLargeError extends Error {
-	constructor(bytes: number, maxBytes: number) {
+	constructor(bytes: number, maxBytes: number, bundled = true) {
 		super(
-			`The spec and the files it references come to ${bytes} bytes, over the ${maxBytes} one document may hold. Raise the maxSpecDocumentBytes engine setting, or import a bundled spec.`
+			bundled
+				? `The spec and the files it references come to ${bytes} bytes, over the ${maxBytes} one document may hold. Raise the maxSpecDocumentBytes engine setting, or import a bundled spec.`
+				: `The spec is ${bytes} bytes, over the ${maxBytes} one document may hold. Raise the maxSpecDocumentBytes engine setting.`
 		);
 		this.name = "SpecBundleTooLargeError";
 	}
@@ -356,6 +367,12 @@ export async function bundleExternalRefs(
 	/** Targets seen but not yet loaded, with the base that named them. */
 	const pending: { key: string; base: DocumentBase }[] = [];
 	let bytes = byteLength(raw);
+	// The document by itself, before a single ref is followed. The loop below
+	// checks the running total, which never runs for a spec that references
+	// nothing - so an over-cap single file used to reach the engine's own refusal
+	// at apply instead (issue #719). Here it is refused before parse, in front of
+	// the preview, naming the setting that would allow it.
+	if (bytes > intake.maxBytes) throw new SpecBundleTooLargeError(bytes, intake.maxBytes, false);
 
 	const enqueue = (value: unknown, base: DocumentBase): void => {
 		for (const ref of collectRefs(value)) {

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -65,7 +65,34 @@ export interface SkippedItem {
 		 * records, so which request kept the id is not a detail the user should
 		 * have to discover from a diff.
 		 */
-		| "duplicate_operation_id";
+		| "duplicate_operation_id"
+		/**
+		 * A parameter declared `in: "cookie"` (issue #719). Vayu's request model
+		 * has no cookie-parameter row - cookies are the jar's, not a request
+		 * field - so the declaration is dropped. Counted rather than mapped onto a
+		 * `Cookie` header row: a spec declares one cookie per parameter and the
+		 * header is a single joined value, so building it would mean inventing a
+		 * merge the document never wrote. Naming the loss is the honest half.
+		 */
+		| "cookie_param"
+		/**
+		 * A `requestBody` declaring only media types the importer has no mode for -
+		 * `application/octet-stream`, `application/xml`, `image/*` (issue #719).
+		 * The operation imports; what it loses is the body, which without this
+		 * counter left a bodyless request that looked complete. Only a body that
+		 * declared *something* counts: an operation with no `requestBody` at all
+		 * lost nothing.
+		 */
+		| "unmapped_body"
+		/**
+		 * A server URL that cannot be turned into one a request could reach
+		 * (issue #719) - a `{variable}` the document declares no default for, or a
+		 * relative URL in a document that arrived with no URL to resolve it
+		 * against. The URL imports exactly as written, because guessing a host is
+		 * worse than a base the user can see is unfinished, and is counted so the
+		 * preview says which of the two happened.
+		 */
+		| "unresolved_base_url";
 	count: number;
 }
 
@@ -244,13 +271,42 @@ export interface ImportResult {
 	meta: ImportMeta;
 }
 
+/**
+ * Where the raw text came from, for the two facts a parser cannot know.
+ *
+ * `fileName` is display only (the preview names the file). `sourceUrl` is
+ * persisted: it becomes `spec_documents.source_url`, which is what makes a
+ * re-fetch possible at all - before this it lived in the import dialog's local
+ * state and was discarded when the dialog closed (issue #638). It is also what
+ * a relative `servers[0].url` resolves against, which is why it reaches `parse`
+ * rather than only being stamped onto the result afterwards (issue #719).
+ */
+export interface ImportSource {
+	fileName?: string;
+	sourceUrl?: string;
+	/**
+	 * External `$ref`s the bundling pass could not reach (issue #649). Stamped
+	 * into `meta.skipped` by the factory for the same reason the two above are
+	 * stamped there: bundling happens before parse, so no parser can know the
+	 * count, and a loss the preview never names is the defect bundling exists to
+	 * fix.
+	 */
+	unresolvedRefs?: number;
+}
+
 export interface ImportParser {
 	readonly formatName: string; // "Postman Collection v2.1"
 	readonly formatKey: string; // "postman-v21"
 	// Factory parses raw once (JSON, then YAML fallback) and passes the parsed object.
 	// Conscious divergence from the PRD's detect(raw: string).
 	detect(parsed: unknown, raw: string): boolean;
-	parse(parsed: unknown, raw: string, opts: ImportOptions): ImportResult;
+	/**
+	 * @param source where the bytes came from. Optional because only the OpenAPI 3
+	 * parser has anything to do with it - a relative `servers[0].url` is relative
+	 * to the document's own location (issue #719) - and a parser that ignores it
+	 * should not have to name it.
+	 */
+	parse(parsed: unknown, raw: string, opts: ImportOptions, source?: ImportSource): ImportResult;
 }
 
 export class UnrecognisedFormatError extends Error {

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -283,7 +283,8 @@ than tallying while building them, so the number and the rows cannot disagree.
 
 **`SkippedItem`** - `{ kind: "websocket" | "grpc" | "api_spec" | "unit_test" | "file_body" |
 "malformed_item" | "unsupported_method" | "malformed_spec" | "example_no_status" |
-"external_ref" | "duplicate_operation_id", count }`.
+"external_ref" | "duplicate_operation_id" | "cookie_param" | "unmapped_body" |
+"unresolved_base_url", count }`.
 Surfaces work Vayu can't represent so the Preview can warn instead of silently dropping.
 Three of the kinds are not about representability: `unsupported_method` is an operation whose
 HTTP method has no `HttpMethod` (OpenAPI 3's `trace`), and `malformed_item` / `malformed_spec`
@@ -304,6 +305,20 @@ twice is kept on the first operation and left off the second, whose recorded ide
 rests on its method and templated path alone (issue #715). Counted per repeated declaration,
 because a sync follows the identity a request records, and which of the two kept the id is
 not something the user should have to work out from a diff.
+
+The last three are OpenAPI 3 kinds added by issue #719, each closing a drop that had no
+counter at all. `cookie_param` is a parameter declared `in: "cookie"`: Vayu's cookies come
+from the jar, and folding one declaration at a time into a single joined `Cookie` header
+would mean inventing a merge the document never wrote, so mapping them is a recorded
+non-goal and naming the loss is the honest half. `unmapped_body` is a `requestBody`
+declaring only media types with no Vayu mode - `application/octet-stream`,
+`application/xml`, `image/*` - which used to return `{ mode: "none" }` on the same path as
+*no body at all*, so a binary upload imported as a bodyless POST reporting nothing skipped;
+an operation that declared no body is still not counted, because it lost nothing.
+`unresolved_base_url` is a `servers[0].url` that could not be made into an address a request
+could reach - a `{variable}` the document declares no default for, or a relative URL in a
+document that arrived with no URL to resolve it against (see
+[OpenAPI 3.0](./openapi-v3.md#the-base-url)).
 
 Supporting value types:
 - `KeyValueEntry`: `{ key, value, enabled, description? }` - duplicates and `enabled:false`

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -28,11 +28,12 @@ collection's Spec tab does with it.
 
 ```ts
 detect(parsed) {
-  return parsed?.swagger === "2.0";
+  const claimed = parsed?.swagger;
+  return claimed === "2.0" || claimed === 2;
 }
 ```
 
-The top-level `swagger` field must equal the exact string `"2.0"`. OpenAPI 3.x (the `openapi` field, no `swagger`) is handled by a separate parser - see [OpenAPI v3](./openapi-v3.md). The factory (`factory.ts`) parses the raw text once (JSON, then YAML fallback) and runs each parser's `detect` in registration order.
+The top-level `swagger` field must be the string `"2.0"` or the **number** `2` (issue #719). The string is what the specification says and what every JSON export writes - JSON has no other option, since the key is quoted or the file is not valid. Hand-written YAML routinely leaves it unquoted, and js-yaml then loads `2.0` as the number `2`, so a string comparison alone reported an ordinary Swagger file as "Unrecognised format". The v3 side never had this problem for a reason that does not generalise: `3.0.3` has two dots, so it stays a string whatever the quoting. Only detection needs the widening - nothing in `parse` reads the field, and the document is stored as the bytes it arrived as, so there is no normalized copy to keep in step. OpenAPI 3.x (the `openapi` field, no `swagger`) is handled by a separate parser - see [OpenAPI v3](./openapi-v3.md). The factory (`factory.ts`) parses the raw text once (JSON, then YAML fallback) and runs each parser's `detect` in registration order.
 
 ## Tree structure
 
@@ -303,7 +304,7 @@ Dropped / not represented:
 - **Multi-tag grouping:** only the first tag groups an operation.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
 
-`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec`, `example_no_status` and `duplicate_operation_id` are the only kinds this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). Nothing to report still yields `[]`.
+`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec`, `example_no_status` and `duplicate_operation_id` are the only kinds this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). The three kinds issue #719 added are v3-only for the same kind of reason: Swagger 2.0 has no `in: "cookie"` parameter, no Server Object to template or leave relative - `host` is a host - and every declared body maps to one, so `cookie_param`, `unresolved_base_url` and `unmapped_body` have no case here either. Nothing to report still yields `[]`.
 
 ## Differences from OpenAPI 3.0
 
@@ -311,7 +312,7 @@ See [OpenAPI v3](./openapi-v3.md) for the v3 reference. Key contrasts:
 
 | Aspect | v2 (Swagger) | v3 (OpenAPI 3.0) |
 |--------|--------------|------------------|
-| Detection | `swagger === "2.0"` (exact) | `openapi` is a string starting with `"3."` |
+| Detection | `swagger === "2.0"`, or the number `2` from unquoted YAML | `openapi` is a string starting with `"3."` |
 | Base URL | `schemes[0]` + `host` + `basePath` | `servers[0].url` |
 | Request body | `in: "body"` / `in: "formData"` parameters | dedicated `op.requestBody` with `content` map |
 | Body content-type decision | `consumes` (op → spec → JSON default) | media-type keys of `requestBody.content` |

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -76,10 +76,20 @@ Built inline in `parse`.
 |---------|------------------------|-------|
 | `info.title` | `name` | fallback `"Imported API"` |
 | `info.description` | `description` | fallback `""` |
-| `servers[0].url` | `variables.baseUrl` | only added when a base URL exists: `{ baseUrl: { value, enabled: true } }`; otherwise `variables` is `{}`. Additional `servers[]` are ignored. |
+| `servers[0].url` | `variables.baseUrl` | resolved first (see [The base URL](#the-base-url)); only added when a base URL exists: `{ baseUrl: { value, enabled: true } }`; otherwise `variables` is `{}`. Additional `servers[]` are ignored. |
 | `security` / `components.securitySchemes` | `auth` | via `pickPrimaryScheme` + `schemeToAuth` (see [Auth](#auth--security)). Collections never inherit. |
 | (none) | `preRequestScript` / `postRequestScript` | always `""` |
 | `op.responses` | `examples` | via `buildExamples` (see [Documented responses](#documented-responses)); **absent** when nothing was representable |
+
+### The base URL
+
+`servers[0].url` is not always an address (issue #719). A Server Object may **template** its URL, and the URL may be **relative**, so the field is resolved by `resolveServerUrl` before it becomes `{{baseUrl}}`:
+
+1. **Server variables are substituted** from the defaults the document declares - `{protocol}://{hostname}/api/v3` with `variables: { protocol: { default: "https" }, hostname: { default: "api.acme.dev" } }` becomes `https://api.acme.dev/api/v3`. The specification **requires** a default on every server variable, so a complete document always resolves. Single braces are not Vayu variables - only the path goes through [`normalizeVars`](./README.md#normalizevars) - so before this the literal `{protocol}` survived into every request line and failed at connect with nothing said.
+2. **A relative URL is resolved against the URL the document was fetched from**, which is what OpenAPI says it is relative to. `/api/v3` fetched from `https://acme.dev/specs/openapi.yaml` becomes `https://acme.dev/api/v3`. The source URL reaches the parser as the fourth argument to `parse` - the factory has always known it (it is also `spec_documents.source_url`) and now hands it over.
+3. **Anything still unresolvable is kept exactly as written and counted** as an `unresolved_base_url` `SkippedItem`: a variable with no declared default, or a relative URL in a pasted or file-picked document, which has no location to be relative to. A base URL the user can see is unfinished beats a host Vayu invented.
+
+An absolute URL is passed through untouched - not re-serialized through `URL`, so a stored document's own spelling survives.
 
 **Parameter resolution & merge.** `buildOperation` concatenates path-item-level `parameters` with operation-level `op.parameters`, resolving any `$ref` entries via `resolveRef`. Each parameter is keyed by `` `${in}:${name}` `` in a `Map`, so an operation-level parameter **overrides** a path-level one with the same `in`+`name` (later writes win). Entries missing `in` or `name` after resolution are skipped.
 
@@ -255,7 +265,8 @@ Dropped / not represented:
 - **`trace` operations:** dropped - `HttpMethod` has no `"TRACE"`. Counted as `unsupported_method` (see [Tree structure](#tree-structure)), not silently omitted.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
 - **Form-field property schemas:** only field **names** and whether the field is a file (`format: binary`) are imported; `required`, other types, and nested structure are not.
-- **A whole-body binary** (`application/octet-stream` and other non-form, non-JSON, non-text media types): no body is produced (`{ mode: "none" }`) and nothing is counted - unlike a multipart file part, which imports (see [File parts](#file-parts)).
+- **A whole-body binary** (`application/octet-stream` and other non-form, non-JSON, non-text media types): no body is produced (`{ mode: "none" }`) and the operation is counted as `unmapped_body` (issue #719) - unlike a multipart file part, which imports (see [File parts](#file-parts)). An operation that declares no `requestBody` at all is **not** counted: it lost nothing, and the two used to be indistinguishable.
+- **Cookie parameters** (`in: "cookie"`): dropped and counted as `cookie_param` (issue #719). Vayu has no cookie-parameter row - a request's cookies come from the jar - and mapping them onto a `Cookie` header is a recorded non-goal: the header is one joined value while a spec declares these one at a time, so building it would mean inventing a merge the document never wrote. `in: "path"` is neither dropped nor counted; it is already carried, as the `{{param}}` the URL template holds.
 
 `meta` population: `format = "OpenAPI 3.0"`, `requestCount` = total operations built (TRACE excluded), `folderCount` = number of tag collections, `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the `SkipTally`:
 
@@ -265,6 +276,9 @@ Dropped / not represented:
 | `malformed_spec` | a path item is not an object / its `$ref` does not resolve; or a `parameters` value is present but not an array |
 | `example_no_status` | a response key is not a three-digit status - `default`, or a `2XX` wildcard |
 | `duplicate_operation_id` | an `operationId` another operation in this document already declared (see [Operation identity](#operation-identity)) |
+| `cookie_param` | a parameter declared `in: "cookie"` - one per distinct cookie parameter per operation |
+| `unmapped_body` | a `requestBody` declaring only media types with no Vayu mode - one per operation, however many such media types it listed |
+| `unresolved_base_url` | `servers[0].url` still carries a `{variable}` with no declared default, or is relative in a document with no source URL (see [The base URL](#the-base-url)) |
 
 An import with nothing to report still yields `skipped: []` - only non-zero kinds are emitted.
 

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -127,7 +127,14 @@ the same spec always produces the same bytes and the same hash. A single-file
 spec is untouched.
 
 If the whole bundle would exceed `maxSpecDocumentBytes`, the import stops and
-says so rather than storing a truncated contract.
+says so rather than storing a truncated contract. **So does a single document
+over the same limit**, before it is parsed and before the preview is built
+(issue #719) - the check used to run only while following references, so a
+generated single-file spec too large to store was fetched, parsed and previewed
+in full, and refused by the engine only once you pressed Import, which failed
+the whole transaction. The message names the size, the limit and the setting.
+The limit is the *spec document* one: a Postman or Insomnia export is stored as
+collections and requests, so it is not measured against it.
 
 ## The Spec tab
 


### PR DESCRIPTION
## Description

Four confirmed findings in the OpenAPI import path, each one a construct the document declared and the import dropped **with nothing in the preview to say so** - which is this subsystem's own discipline (`SkippedItem` exists precisely for this) violated four times.

**Plan.** Root cause is one habit in four places: a field is read at face value and the case it cannot represent falls through a branch with no `else` and no `tally.add`. So each fix is the same shape - resolve what can be resolved, keep verbatim what cannot, and **count it under a kind the preview names**. The alternative rejected throughout was guessing: substituting a host for an unresolvable `{hostname}`, folding cookie parameters into a joined `Cookie` header the document never wrote, or clamping an over-cap document instead of refusing it. A base URL the user can see is unfinished beats one Vayu invented, and every one of these drops is recoverable by hand once it is named.

**Verified at `682cc9a`** (the issue's anchors were written at `ac27b97`): all four still held as described - `baseUrl` was `servers[0].url` verbatim, `buildOperation` emitted only `query`/`header` rows, `buildBody` returned `{mode: "none"}` with no tally passed in, the bundler's size check ran only after an external document had been loaded, and `detect` required the string `"2.0"`.

### 1. Server variables and relative server URLs

`resolveServerUrl` substitutes the defaults a Server Object declares (the spec **requires** a default, so a complete document always resolves), then resolves a relative URL against the URL the document was fetched from - which is what OpenAPI says it is relative to. `{protocol}://{hostname}/api/v3` becomes `https://api.acme.dev/api/v3`; `/api/v3` fetched from `https://acme.dev/specs/openapi.yaml` becomes `https://acme.dev/api/v3`. Single braces are not Vayu variables (only the path goes through `normalizeVars`), so before this the literal survived into every request line and failed at connect.

The source URL reaches the parser because `parse` now takes an `ImportSource` fourth argument - the factory has always known it (it is also `spec_documents.source_url`) and only stamped it onto the result afterwards. `ImportSource` moved to `types.ts` beside `ImportParser` for that reason and is re-exported from `factory.ts`, so no caller changed. Anything still unresolvable - a variable with no default, a relative URL in a pasted document - is kept **exactly as written** and counted as `unresolved_base_url`. An absolute URL is passed through untouched rather than re-serialized through `URL`, so a document's own spelling survives.

### 2. Cookie parameters and unmapped request bodies

New kinds `cookie_param` and `unmapped_body`, both disclosed in the preview. Mapping cookie parameters onto a `Cookie` header is a **recorded non-goal**: the header is one joined value and a spec declares these one at a time, so building it means inventing a merge. `in: "path"` is deliberately neither dropped nor counted - it is already carried as the `{{param}}` in the URL template.

`unmapped_body` counts only a body that declared *something*: an operation with no `requestBody` lost nothing, and the two used to be indistinguishable, which is why GitHub's "Upload a release asset" imported as a bodyless POST reporting 0 skipped.

### 3. The document-size cap, before the preview instead of at apply

The bundler's running total was only compared against the cap *after* loading an external document, so a spec that references nothing - which is what the generated multi-megabyte documents are - passed bundling at any size and was first refused by the engine at `POST /import/apply`, 400ing the whole transaction after the user had confirmed a preview built from it. The document's own bytes are now checked before a single ref is followed, so the refusal lands on the batch entry, which keeps it out of `applicableEntries` and therefore out of the apply. `SpecBundleTooLargeError` gained a second wording because the remedy differs: a bundle can be imported pre-bundled, a single file can only be met by raising the setting. Both name `maxSpecDocumentBytes`.

The check sits after the bundler's `isOpenApiDocument` gate, so it is the **spec-document** cap: a Postman or Insomnia export is stored as collections and requests and is not measured against it. There is a test for that, because it is the thing this change could plausibly have broken.

### 4. Unquoted `swagger: 2.0`

js-yaml loads it as the number `2` - a shape JSON cannot produce and hand-written YAML routinely does - so an ordinary Swagger file was rejected as "Unrecognised format". Detection now accepts the string or the number. Only detection needs it: nothing in `parse` reads the field and the document is stored as the bytes it arrived as, so there is no normalized copy to keep in step.

### Deliberate deviation from the issue spec

The issue's item 3 offers **"an engine-side byte cap on `/import/fetch` responses is the belt (naming the same setting)"**. Not implemented here, for a reason found while tracing the route rather than to save work: `/import/fetch` is one shared proxy for *every* URL import, not a spec-only route - the import dialog fetches Postman and Insomnia exports through it too. Capping it at `maxSpecDocumentBytes` would refuse a >10 MB Postman collection that imports today and that no spec-document limit governs, and the engine cannot tell from the URL what it is fetching; the alternative, a second byte knob, is the thing `spec_size_cap`'s own doc comment argues against ("the document's own cap rather than a second knob"). The issue is labelled `component:app` only, which agrees. Filed as **#784** so the unbounded buffer stays tracked, with the option that does work - the caller stating its bound - written up there. The app-side refusal in item 3 is implemented in full, and it is the one the acceptance criterion names.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, full: **502 files, 5329 tests, all passing** (19 new). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `mkdocs build --strict` clean. `prettier --check` clean on every touched source file - the two test files that needed formatting were prettier-clean at the base commit and so were formatted; no other file was touched by a formatter. No engine or C++ change - nothing under `engine/` is touched and no engine test could change colour - so no `build.py -t` / `ctest` run. No pre-existing failures observed on the base commit.

Each guard mutation-checked (mutation applied, confirmed red, reverted):

| Guard | Mutation that turns it red |
|---|---|
| server variables substituted, relative URLs resolved, and neither counted when they resolve | return `servers[0].url` verbatim (6 red, across the parser and the factory) |
| a cookie parameter is counted, and a path parameter is not | drop `tally.add("cookie_param")` (1 red) |
| an unmapped body is counted, and an absent one is not | return `{mode: "none"}` instead of `unmapped()` (2 red) |
| a single over-cap document is refused before parse, and the entry carries no result | remove the root check (2 red, bundler and batch) |
| unquoted `swagger: 2.0` detects, through the real YAML path | require the string `"2.0"` (2 red) |
| the factory hands the source over, so a relative URL resolves end to end | call `parse` with three arguments again (1 red) |

The over-cap bundler test also asserts `readSibling` was never called - the point of moving the check is that nothing downstream runs on a document that cannot be stored - and the batch test asserts `applicableEntries` is empty, which is what "never reaches apply" means at that layer. Also covered: a numeric server-variable default (what hand-written YAML produces), a document with no `servers` adding no `baseUrl` and counting nothing, an XML+image body counted once rather than per media type, and a Postman export over the same cap still importing.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/import-collections/openapi-v3.md` gains a **"The base URL"** section and rows for the three new kinds (plus the corrected binary-body and cookie-parameter entries in the not-imported list), `openapi-v2.md` gains the detection rule and states why the three new kinds have no case there, `import-collections/README.md` extends the `SkippedItem` contract, and `docs/app/openapi.md` documents the single-document cap beside the bundle one.

## Related Issues
Closes #719