### PR TITLE
fix(app/engine/openapi): clear stamps a re-bind orphans, and reclaim documents nothing can reach

### DIFF
--- a/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
@@ -42,7 +42,7 @@ const bindSpec = {
 	isPending: false,
 	isError: false,
 	error: null as Error | null,
-	data: undefined as { failedStamps: string[] } | undefined,
+	data: undefined as { failedStamps: string[]; failedClears: string[] } | undefined,
 };
 
 const syncSpec = {
@@ -169,7 +169,7 @@ async function pickFile(name: string, text: string) {
 /** Resolve the bind the way TanStack would, running the caller's onSuccess. */
 function bindSucceeds() {
 	const [, options] = bindSpec.mutate.mock.calls[bindSpec.mutate.mock.calls.length - 1];
-	options?.onSuccess?.({ stamped: 0, failedStamps: [] });
+	options?.onSuccess?.({ stamped: 0, failedStamps: [], failedClears: [] });
 }
 
 beforeEach(() => {
@@ -256,6 +256,67 @@ describe("binding a collection that already has requests", () => {
 		expect(useSpecFileStore.getState().locations.col_1).toBeUndefined();
 	});
 
+	/*
+	 * Re-binding to a different document (issue #718). Nothing writes null to a
+	 * request's `specOperation` anywhere else in the app, so a stamp the new
+	 * document does not account for would otherwise be permanent - and coverage
+	 * resolves stamps by `operationId` first, so it would claim whichever
+	 * operation of the new document shares the id rather than simply going
+	 * unread.
+	 */
+	it("clears identity recorded against a document this one is not", async () => {
+		requests = [
+			request("r1", "{{baseUrl}}/pets"),
+			// Matched the *old* document, matches nothing here: its URL is not a
+			// path this spec declares.
+			request("r2", "{{baseUrl}}/v1/legacy", {
+				operationId: "legacyPing",
+				method: "GET",
+				path: "/v1/legacy",
+			}),
+			// No stamp to clear - an unmatched request that never had identity is
+			// left exactly as it was.
+			request("r3", "{{baseUrl}}/health"),
+		];
+		render(<SpecTab collection={collection()} />);
+		await pickFile("petstore.json", OPENAPI);
+
+		fireEvent.click(screen.getByRole("button", { name: /bind this spec/i }));
+
+		const [payload] = bindSpec.mutate.mock.calls[0];
+		expect(payload.clearStamps).toEqual(["r2"]);
+		// The matched request is stamped, not cleared - the two lists are disjoint,
+		// which is what lets the mutation write both at once.
+		expect(payload.stamps.map((s: { requestId: string }) => s.requestId)).toEqual(["r1"]);
+	});
+
+	it("discloses the clearing before it happens, and stays silent when there is none", async () => {
+		requests = [
+			request("r1", "{{baseUrl}}/pets"),
+			request("r2", "{{baseUrl}}/v1/legacy", {
+				operationId: "legacyPing",
+				method: "GET",
+				path: "/v1/legacy",
+			}),
+		];
+		const { unmount } = render(<SpecTab collection={collection()} />);
+		await pickFile("petstore.json", OPENAPI);
+
+		// The one line on this screen that describes a write to something already
+		// there, so the user reads it before pressing Bind.
+		expect(
+			screen.getByText(/1 request records an operation this document does not have/i)
+		).toBeTruthy();
+		unmount();
+
+		// A collection with nothing stale says nothing - a zero here would read as
+		// a warning about a bind that rewrites nothing.
+		requests = [request("r1", "{{baseUrl}}/pets"), request("r3", "{{baseUrl}}/health")];
+		render(<SpecTab collection={collection()} />);
+		await pickFile("petstore.json", OPENAPI);
+		expect(screen.queryByText(/does not have/i)).toBeNull();
+	});
+
 	it("refuses a document that is not a spec, by name, and offers no bind", async () => {
 		render(<SpecTab collection={collection()} />);
 
@@ -325,8 +386,18 @@ describe("a bound collection", () => {
 	});
 
 	it("says which requests kept no identity when some stamps failed", async () => {
-		bindSpec.data = { failedStamps: ["req_9"] };
+		bindSpec.data = { failedStamps: ["req_9"], failedClears: [] };
 		render(<SpecTab collection={bound()} />);
 		expect(screen.getByText(/1 request kept no operation identity/i)).toBeTruthy();
+	});
+
+	// The other half of the same report, and the worse state of the two: a stamp
+	// that survived still reads as identity, in a document nothing is bound to.
+	it("says which requests still record another document's operation", async () => {
+		bindSpec.data = { failedStamps: [], failedClears: ["req_9"] };
+		render(<SpecTab collection={bound()} />);
+		expect(
+			screen.getByText(/1 request still records an operation of another document/i)
+		).toBeTruthy();
 	});
 });

--- a/app/src/modules/collections/CollectionDetail/SpecTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.tsx
@@ -24,12 +24,18 @@
  *   `spec-file-store` and never reaches the engine. A URL-sourced spec keeps its
  *   origin portably instead, in `spec_documents.source_url`.
  *
- * **Binding** deliberately creates, deletes and edits nothing: it matches what
- * is already there and stamps identity on the matches - the operations with no
+ * **Binding** deliberately creates and deletes nothing: it matches what is
+ * already there and stamps identity on the matches - the operations with no
  * request, and the requests with no operation, are *reported* and left alone.
- * The one place this tab writes requests is the Sync section, and only for the
- * items the user ticks: it re-reads the document and says what moved (#654),
- * and applies the selection in one engine transaction (#655).
+ * The one field it does rewrite is a request's own `specOperation`, and only to
+ * clear one recorded against a **different** document (#718): after a bind, a
+ * request's identity is the operation it matched here, or nothing. Unbinding
+ * still leaves stamps exactly as they are, so unbind-then-bind-the-same-document
+ * costs nothing - it is re-binding to a different one that would otherwise leave
+ * a request claiming an operation of a document nothing is bound to.
+ * The one place this tab writes *other* request fields is the Sync section, and
+ * only for the items the user ticks: it re-reads the document and says what
+ * moved (#654), and applies the selection in one engine transaction (#655).
  */
 
 import { useMemo, useRef, useState } from "react";
@@ -135,6 +141,22 @@ export default function SpecTab({ collection }: SpecTabProps) {
 
 	const mappedCount = requests.filter((r) => r.specOperation).length;
 
+	/*
+	 * Requests carrying identity the document about to be bound does not account
+	 * for (issue #718). Binding is the only moment the app can tell: unbinding
+	 * deliberately leaves stamps alone - so unbind-then-bind-the-same-document is
+	 * lossless - and it is re-binding to a *different* one that would otherwise
+	 * leave a request stamped as an operation of a document this collection is
+	 * no longer bound to. Coverage resolves stamps by `operationId` first, so
+	 * such a stamp does not merely go unread; it claims whatever operation of the
+	 * new document happens to share the id.
+	 */
+	const staleStamps = useMemo(
+		() =>
+			match ? match.unmatchedRequests.filter((r) => r.specOperation).map((r) => r.id) : [],
+		[match]
+	);
+
 	const handleFile = (file: File) => {
 		const reader = new FileReader();
 		reader.onload = () => {
@@ -176,6 +198,7 @@ export default function SpecTab({ collection }: SpecTabProps) {
 					requestId: request.id,
 					specOperation: operation,
 				})),
+				clearStamps: staleStamps,
 				// Stored with the document so a run of this collection can report
 				// its contract coverage (issue #629).
 				operations: parsed?.declaredOperations ?? [],
@@ -243,7 +266,8 @@ export default function SpecTab({ collection }: SpecTabProps) {
 					<p className="text-xs text-muted-foreground">
 						Pick a document below. Vayu matches its operations to the requests already
 						here by method and path, and records the identity of the ones that match -
-						nothing is created, deleted or rewritten.
+						nothing is created or deleted. The only thing rewritten is identity recorded
+						against a different document, which is cleared.
 					</p>
 				</div>
 			)}
@@ -318,6 +342,7 @@ export default function SpecTab({ collection }: SpecTabProps) {
 							matched={match.matched.length}
 							unmatchedRequests={match.unmatchedRequests.length}
 							unmatchedOperations={match.unmatchedOperations.length}
+							staleStamps={staleStamps.length}
 						/>
 					)}
 
@@ -349,13 +374,31 @@ export default function SpecTab({ collection }: SpecTabProps) {
 			<SaveFailed mutation={bindSpec} what="the spec binding" />
 			<SaveFailed mutation={updateCollection} what="the spec binding" />
 
-			{bindSpec.data && bindSpec.data.failedStamps.length > 0 && (
-				<Callout severity="warning" title="Bound, but some requests were not stamped">
-					{bindSpec.data.failedStamps.length} request
-					{bindSpec.data.failedStamps.length === 1 ? "" : "s"} kept no operation identity.
-					Bind again to retry those.
-				</Callout>
-			)}
+			{bindSpec.data &&
+				(bindSpec.data.failedStamps.length > 0 ||
+					bindSpec.data.failedClears.length > 0) && (
+					<Callout severity="warning" title="Bound, but some identities did not land">
+						{bindSpec.data.failedStamps.length > 0 && (
+							<>
+								{bindSpec.data.failedStamps.length} request
+								{bindSpec.data.failedStamps.length === 1 ? "" : "s"} kept no
+								operation identity.{" "}
+							</>
+						)}
+						{/* Named apart from the line above because it is the worse state:
+						    a stamp that survived still *reads* as identity, and it is
+						    identity in a document this collection is not bound to. */}
+						{bindSpec.data.failedClears.length > 0 && (
+							<>
+								{bindSpec.data.failedClears.length} request
+								{bindSpec.data.failedClears.length === 1 ? "" : "s"} still record
+								{bindSpec.data.failedClears.length === 1 ? "s" : ""} an operation of
+								another document.{" "}
+							</>
+						)}
+						Bind again to retry those.
+					</Callout>
+				)}
 
 			{bound && (
 				<div>
@@ -484,6 +527,7 @@ function MatchSummary({
 	matched,
 	unmatchedRequests,
 	unmatchedOperations,
+	staleStamps,
 }: {
 	title: string;
 	format: string;
@@ -491,6 +535,7 @@ function MatchSummary({
 	matched: number;
 	unmatchedRequests: number;
 	unmatchedOperations: number;
+	staleStamps: number;
 }) {
 	return (
 		<div className="rounded-md border border-rule surface-sunken p-3 space-y-1">
@@ -511,6 +556,19 @@ function MatchSummary({
 				operation
 				{unmatchedOperations === 1 ? "" : "s"} with no request
 			</p>
+			{/*
+			 * The one line here that describes a *write* to something that already
+			 * exists, so it is stated separately and only when it applies. Nothing
+			 * else about a bind touches a request that did not match; this does,
+			 * and the user is agreeing to it (issue #718).
+			 */}
+			{staleStamps > 0 && (
+				<p className="text-[11px] text-muted-foreground">
+					{staleStamps} request{staleStamps === 1 ? "" : "s"} record
+					{staleStamps === 1 ? "s" : ""} an operation this document does not have - that
+					identity is cleared, because it names another document.
+				</p>
+			)}
 		</div>
 	);
 }

--- a/app/src/queries/spec-bind-stamps.test.tsx
+++ b/app/src/queries/spec-bind-stamps.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A bind writes identity in both directions (issue #718).
+ *
+ * `useBindSpecMutation` used to write only the matches, which is indistinguishable
+ * from correct while a collection is bound once and never again. Re-binding to a
+ * *different* document stamps whatever matches it and says nothing about the
+ * rest, so a request that matched the old document kept the old document's
+ * operation - and coverage resolves a stamp by `operationId` first, so such a
+ * stamp does not go unread, it claims whichever operation of the new document
+ * happens to share the id.
+ *
+ * The invariant these tests hold: after a bind, a request's `specOperation` is
+ * the operation it matched in the bound document, or nothing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useBindSpecMutation, type BindSpecInput } from "./specs";
+
+const createSpec = vi.fn();
+const updateCollection = vi.fn();
+const updateRequest = vi.fn();
+
+vi.mock("@/services/api", () => ({
+	apiService: {
+		createSpec: (...a: unknown[]) => createSpec(...a),
+		updateCollection: (...a: unknown[]) => updateCollection(...a),
+		updateRequest: (...a: unknown[]) => updateRequest(...a),
+	},
+}));
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+function bind() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return renderHook(() => useBindSpecMutation(), { wrapper: wrapper(client) });
+}
+
+const input = (over: Partial<BindSpecInput> = {}): BindSpecInput => ({
+	collectionId: "col_1",
+	content: "{}",
+	sourceUrl: null,
+	stamps: [],
+	clearStamps: [],
+	...over,
+});
+
+/** Every `updateRequest` call, as `[id, specOperation]` pairs. */
+function requestWrites(): [string, unknown][] {
+	return updateRequest.mock.calls.map(([patch]) => [
+		(patch as { id: string }).id,
+		(patch as { specOperation: unknown }).specOperation,
+	]);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	createSpec.mockResolvedValue({ id: "spec_2", hash: "h2" });
+	updateCollection.mockResolvedValue({});
+	updateRequest.mockResolvedValue({});
+});
+
+describe("useBindSpecMutation", () => {
+	it("clears the identity of a request the new document does not account for", async () => {
+		const { result } = bind();
+
+		await result.current.mutateAsync(
+			input({
+				stamps: [
+					{
+						requestId: "req_matched",
+						specOperation: { operationId: "listPets", method: "GET", path: "/pets" },
+					},
+				],
+				clearStamps: ["req_stale"],
+			})
+		);
+
+		// `null`, never an absent key: the engine reads absent as "keep", so a
+		// patch that merely omits the field is a no-op that looks like a clear.
+		expect(requestWrites()).toContainEqual(["req_stale", null]);
+		expect(requestWrites()).toContainEqual([
+			"req_matched",
+			{ operationId: "listPets", method: "GET", path: "/pets" },
+		]);
+		expect(updateRequest).toHaveBeenCalledTimes(2);
+	});
+
+	it("writes nothing for a request named by neither list", async () => {
+		const { result } = bind();
+
+		await result.current.mutateAsync(input());
+
+		// A collection whose requests all matched, or none did and none carried a
+		// stamp: the bind is two writes and no third.
+		expect(updateRequest).not.toHaveBeenCalled();
+	});
+
+	it("reports a failed clear apart from a failed stamp", async () => {
+		updateRequest.mockImplementation(({ id }: { id: string }) =>
+			id === "req_stale" ? Promise.reject(new Error("boom")) : Promise.resolve({})
+		);
+		const { result } = bind();
+
+		const outcome = await result.current.mutateAsync(
+			input({
+				stamps: [
+					{
+						requestId: "req_matched",
+						specOperation: { operationId: "listPets", method: "GET", path: "/pets" },
+					},
+				],
+				clearStamps: ["req_stale"],
+			})
+		);
+
+		// The two failures leave different states and are named separately: an
+		// unstamped request has no identity, a request whose clear failed still
+		// claims one, and it is one of another document's.
+		expect(outcome.failedClears).toEqual(["req_stale"]);
+		expect(outcome.failedStamps).toEqual([]);
+		expect(outcome.stamped).toBe(1);
+	});
+
+	it("keeps the binding when a clear fails, rather than rolling it back", async () => {
+		updateRequest.mockRejectedValue(new Error("boom"));
+		const { result } = bind();
+
+		const outcome = await result.current.mutateAsync(input({ clearStamps: ["req_stale"] }));
+
+		// Same rule the stamps have always followed: there is no transaction
+		// spanning three routes, and the collection *is* bound.
+		expect(updateCollection).toHaveBeenCalledWith({
+			id: "col_1",
+			openapi: expect.objectContaining({ specId: "spec_2", specHash: "h2" }),
+		});
+		expect(outcome.spec.id).toBe("spec_2");
+		expect(outcome.failedClears).toEqual(["req_stale"]);
+	});
+});

--- a/app/src/queries/specs.ts
+++ b/app/src/queries/specs.ts
@@ -116,6 +116,17 @@ export interface BindSpecInput {
 	/** Identity to stamp on the requests that matched. May be empty. */
 	stamps: SpecOperationStamp[];
 	/**
+	 * Requests whose recorded identity must be *cleared*, by id (issue #718).
+	 *
+	 * The other half of stamping, and required rather than optional because a
+	 * caller that forgets it leaves the bug this exists for: nothing else in the
+	 * app ever writes `null` here, so a request stamped against a document this
+	 * collection is no longer bound to keeps that stamp forever - and coverage
+	 * resolves a stamp by `operationId` first, so one whose id happens to exist
+	 * in the new document claims the wrong operation rather than none.
+	 */
+	clearStamps: string[];
+	/**
 	 * What the document declares, stored beside it so a run of this collection
 	 * can report its contract coverage (issue #629). Absent for a document the
 	 * parsers produced no index for, which is stored as "no index".
@@ -139,10 +150,18 @@ export interface BindSpecResult {
 	 * routes and an unstamped request is a request the next bind can stamp.
 	 */
 	failedStamps: string[];
+	/**
+	 * Requests whose *clear* failed, by id - reported for the same reason and
+	 * separately, because the state it leaves is the worse of the two: a stamp
+	 * naming an operation of a document this collection is not bound to, which
+	 * reads as identity rather than as a gap.
+	 */
+	failedClears: string[];
 }
 
 /**
- * Store a document, bind the collection to it, and stamp the matched requests.
+ * Store a document, bind the collection to it, and make every request's
+ * recorded identity agree with what it matched.
  *
  * Three writes in a fixed order, because each depends on the one before: the
  * document has no id until it is stored, the binding is what makes the identity
@@ -150,6 +169,14 @@ export interface BindSpecResult {
  * bind did not happen. A stamp failing does not: the collection *is* bound, and
  * saying so while naming what did not land is more useful than reporting a
  * failure for a binding the user can see worked.
+ *
+ * **The third write goes both ways** (issue #718). A bind used to write only
+ * the matches, which held while a collection was bound once and never again -
+ * but re-binding to a *different* document stamps the requests that match it
+ * and says nothing about the rest, so every non-matcher kept identity from the
+ * old document. The invariant now is one sentence: after a bind, a request's
+ * `specOperation` is the operation it matched in the bound document, or
+ * nothing. That the two sets are disjoint is what lets both batches go at once.
  *
  * A spec stored by a bind that then failed is left where it is. Documents are
  * not owned by collections (several may bind one), so there is nothing to
@@ -165,6 +192,7 @@ export function useBindSpecMutation() {
 			content,
 			sourceUrl,
 			stamps,
+			clearStamps,
 			operations,
 			responseSchemas,
 		}: BindSpecInput): Promise<BindSpecResult> => {
@@ -180,19 +208,39 @@ export function useBindSpecMutation() {
 				openapi: { specId: spec.id, specHash: spec.hash, syncedAt: Date.now() },
 			});
 
+			// `null`, not an absent key: the engine reads absent as "keep" and
+			// null as "reset to the default", and the default is no operation.
+			// The same rule an unbind follows for the collection binding, which
+			// is why stamping and un-stamping are one verb rather than two.
+			const writes = [
+				...stamps.map((stamp) => ({
+					requestId: stamp.requestId,
+					specOperation: stamp.specOperation as SpecOperation | null,
+				})),
+				...clearStamps.map((requestId) => ({ requestId, specOperation: null })),
+			];
 			const results = await Promise.allSettled(
-				stamps.map((stamp) =>
+				writes.map((write) =>
 					apiService.updateRequest({
-						id: stamp.requestId,
-						specOperation: stamp.specOperation,
+						id: write.requestId,
+						specOperation: write.specOperation,
 					})
 				)
 			);
+			const rejected = new Set(
+				writes.filter((_, i) => results[i].status === "rejected").map((w) => w.requestId)
+			);
 			const failedStamps = stamps
-				.filter((_, i) => results[i].status === "rejected")
-				.map((stamp) => stamp.requestId);
+				.map((stamp) => stamp.requestId)
+				.filter((id) => rejected.has(id));
+			const failedClears = clearStamps.filter((id) => rejected.has(id));
 
-			return { spec, stamped: stamps.length - failedStamps.length, failedStamps };
+			return {
+				spec,
+				stamped: stamps.length - failedStamps.length,
+				failedStamps,
+				failedClears,
+			};
 		},
 		// Settled, not success: a stamp that landed before a later one failed is
 		// already on the engine, and the counts the tab shows are read from the

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -38,6 +38,16 @@ Several collections may bind the same document. It is not owned by any of them,
 which is why unbinding one leaves it in place, and why the engine refuses to
 delete a document while a collection still binds it.
 
+Because nothing owns a document, nothing deletes one on your behalf either -
+until it can no longer be reached at all. **A stored document lives while a
+collection binds it, or while a run you still have names it**; once neither is
+true, the engine reclaims it during its ordinary housekeeping (on startup, after
+a run, after a sync, after a collection is deleted). That is what keeps a year of
+weekly syncs of a 12 MB document from leaving a year of 12 MB rows behind: a run
+pins the document it was measured against for exactly as long as the run itself
+is retained, so its [coverage](#contract-coverage) always has a source, and the
+superseded copies go.
+
 ## Binding on import
 
 Import an OpenAPI 3.x or Swagger 2.0 document the usual way -
@@ -158,8 +168,27 @@ already there:
 
 The result is stated before anything is written - how many matched, how many
 requests carry no operation, how many operations have no request - and only the
-matches are stamped. **Nothing is created, deleted or rewritten**: acting on the
-difference is what applying a sync will do.
+matches are stamped. **Nothing is created or deleted**: acting on the difference
+is what applying a sync will do.
+
+### Identity from another document is cleared
+
+One thing a bind does rewrite, and it says so before it does: a request that
+records an operation the document being bound does not account for has that
+identity **cleared**. The rule after any bind is one sentence - *a request's
+operation is the one it matched in the bound document, or nothing.*
+
+This is the re-bind case, and only that case. Unbinding leaves every recorded
+operation exactly as it is, so unbind and bind the same document again and
+nothing is lost. Bind a *different* one, though, and without this the requests
+that do not match it would keep identity from the old document - which is worse
+than no identity, because [coverage](#contract-coverage) resolves a stamp by its
+`operationId` first, so a stale stamp claims whichever operation of the new
+document happens to share that id.
+
+The summary counts them before you press Bind, and if a clear fails to land the
+tab names how many requests still record another document's operation - binding
+again retries them.
 
 ## Checking a bound spec for changes
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1217,7 +1217,8 @@ OpenAPI documents, stored once and bound to collections by
 [`collections.openapi`](#post-collections) (issue #637). A spec is not owned by a
 collection: several may bind the same document, and unbinding one must leave it
 there for the others - so it is a top-level resource with no cascade reaching it,
-and the rule that keeps that safe is the delete refusal below.
+and the rule that keeps that safe is the delete refusal below. What it is *not*
+is immortal: see the reclamation rule further down.
 
 The document is stored **verbatim** and its `hash` is computed engine-side on
 every write, never taken from the caller. A scenario run of a bound collection
@@ -1229,6 +1230,25 @@ There is deliberately **no `PUT /specs/:id`**: a document that changed is a
 different document, and rewriting one in place would invalidate the hash every
 run of every bound collection was stamped with. A re-fetch stores a new document
 and moves the binding.
+
+**A document nothing can reach is reclaimed** (issue #718). Having no owner is
+what let these rows accumulate with no way to die - every sync mints one and
+moves the binding off the last, and `DELETE /specs/:id` needs an id no route
+hands out for an unbound document. So the engine sweeps on one rule:
+
+> A document lives while a collection binds it, **or** while a retained run names
+> it in its snapshot under `scenario.openapi.specId`.
+
+Run-referenced documents live exactly as long as the runs do, so a report's
+coverage never describes a contract whose source is gone. The sweep runs as part
+of ordinary housekeeping - at startup, after each run's retention pass, after a
+`POST /specs/sync`, and after a `DELETE /collections/:id` - and **spares any
+document written in the last 10 minutes**, because storing a document is the
+first of the three writes that bind one and a caller may not have sent the
+`PUT /collections/:id` yet. A client that stores a document it does not intend to
+bind should therefore expect it to go: `GET /specs/:id` will answer `404` once it
+is unreachable by that rule. Nothing here changes what `DELETE /specs/:id`
+refuses, and no cascade was added - a bound document is untouched.
 
 ### POST /specs
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -355,11 +355,36 @@ same code on the same bytes.
 
 **Ownership, and why there is no cascade.** A spec is bound *by* collections
 rather than owned by one: several may bind the same row, and unbinding one must
-leave it there for the others. So nothing deletes a document implicitly -
+leave it there for the others. So no cascade deletes a document -
 `DELETE /specs/:id` is refused with a `409` naming the binder while any
 collection still names it. There is likewise no `PUT /specs/:id`: a document that
 changed is a different document, and rewriting one in place would invalidate the
 hash every run of every bound collection was stamped with.
+
+**Lifetime, and the sweep that enforces it** (issue #718). Having no owner left
+these rows with no way to die: every `POST /specs/sync` mints a new document and
+moves the binding off the old one, unbinding leaves it, re-binding mints another,
+and deleting a bound collection takes its requests and not the document - while
+`DELETE /specs/:id` needs an id and there is no list route to get an unreachable
+one from. Weekly syncs of a 12 MB document therefore stranded ~600 MB a year that
+nothing could read or reclaim. The rule now, and the only one:
+
+> A document lives while a collection binds it, **or** while a retained run names
+> it in [`runs.config_snapshot`](#runs) under `scenario.openapi.specId`.
+
+`Database::sweep_orphaned_spec_documents()` applies it and returns how many rows
+went. Run-referenced documents live as long as the runs do, deliberately: a
+scenario run stamps the `specId` it was planned against and its report describes
+that contract, so the source has to outlive the binding by exactly the retention
+window - which is why the sweep is the tail of `prune_runs_configured()`, the
+pass that *releases* those references, and thereby runs on startup and at the end
+of every run. It also runs after `spec_sync_apply` (the accretion source) and
+after `delete_collection` (the last binder going away). Two rules keep it honest:
+a document written within `SPEC_DOCUMENT_SWEEP_GRACE_MS` (10 min) is always
+spared, because binding stores the document *before* the `PUT /collections/:id`
+that names it and a document in that window is a bind in flight, not an orphan;
+and the pass never throws or reads `content`, so no caller can fail over
+housekeeping and no 10 MiB blob is loaded to decide its fate.
 
 **Cap.** A document over the live `maxSpecDocumentBytes`
 [`config_entries`](#config_entries) value (default 10 MiB, aligned with

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -790,6 +790,18 @@ constexpr int SYNCHRONOUS = 0;
 constexpr int MAX_RUNS_RETAINED = 200;
 /// Run retention: delete runs older than N days (0 = unlimited).
 constexpr int RUN_RETENTION_DAYS = 30;
+/**
+ * How recently a stored OpenAPI document must have arrived to be spared by the
+ * orphan sweep, whatever else says nothing references it (issue #718).
+ *
+ * Binding a collection is three writes over three requests, and the *document*
+ * is the first of them: between `POST /specs` and the `PUT /collections/:id`
+ * that names it, a document is bound by nobody and pinned by no run - exactly
+ * the shape of an orphan. Ten minutes is far longer than that window and far
+ * shorter than the interval between the passes that sweep, so a document this
+ * spares is reclaimed by the next one rather than kept.
+ */
+constexpr int64_t SPEC_DOCUMENT_SWEEP_GRACE_MS = 600'000;
 } // namespace database
 } // namespace vayu::core::constants
 

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -176,6 +176,47 @@ class Database {
     void delete_spec_document (const std::string& id);
 
     /**
+     * @brief Reclaim documents nothing can reach any more, returning how many
+     *        went (issue #718).
+     *
+     * Nothing owns a `spec_documents` row, which is what leaves it with no
+     * cascade to die by: every sync mints a new document and moves the binding
+     * off the old one, unbinding leaves it, re-binding mints another, and
+     * deleting the bound collection takes its requests and not the document. A
+     * year of weekly syncs of a 12 MB document therefore strands ~600 MB of
+     * rows no route can even enumerate, since `DELETE /specs/:id` needs an id
+     * and there is no list route to get one from.
+     *
+     * **The lifetime rule this implements**, and the only one: a document lives
+     * while a collection binds it, or while a *retained run* names it in
+     * `runs.config_snapshot`. The second half is what makes the sweep safe to
+     * run beside retention rather than instead of it - a scenario run stamps
+     * the `specId` it planned against, and its report's coverage describes a
+     * contract the reader may still want to see the source of. So a document
+     * outlives the binding that made it by exactly as long as the runs that
+     * used it, and goes with the last of them. That is also why the first of
+     * the three callers is `prune_runs_configured`: the pass that *releases*
+     * run references is the one that should look for what they were holding,
+     * and hanging the sweep there puts it on a startup and on the end of every
+     * run without a schedule of its own. The other two are `spec_sync_apply`
+     * (the accretion source) and `delete_collection` (a binder going away).
+     *
+     * A document written within `SPEC_DOCUMENT_SWEEP_GRACE_MS` is spared
+     * whatever else it looks like - see that constant for the bind-in-flight
+     * window it exists for.
+     *
+     * **Never throws.** All three callers reach it as the tail of an operation
+     * whose success does not depend on it (a startup, a sync, a collection
+     * delete), so a failure here is logged and swallowed rather than turned
+     * into a failed sync. Cheap when there is nothing to do, which is what
+     * riding on every run completion requires: it asks the three questions
+     * cheapest-first and stops at the first that leaves nothing at stake, so
+     * the ordinary case never reads the runs table - and no path reads
+     * `content`.
+     */
+    size_t sweep_orphaned_spec_documents ();
+
+    /**
      * @brief Repair bindings stored without the document version they name
      *        (issue #709), returning how many were stamped.
      *

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -862,6 +862,15 @@ void Database::delete_collection (const std::string& id) {
         }
         return true; // Commit
     });
+
+    // 3. The cascade above is still deliberately not a cascade *to* the document
+    //    a deleted collection was bound to - several collections may bind one,
+    //    so the binding going away is not the document going away. It is the
+    //    moment to ask whether anything still holds it, though, and that is what
+    //    the sweep answers (issue #718). Outside the transaction: the subtree is
+    //    gone either way, and this must not be able to roll it back. Never
+    //    throws; see the declaration.
+    sweep_orphaned_spec_documents ();
 }
 
 // ============================================================================
@@ -991,6 +1000,127 @@ void Database::delete_spec_document (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     vayu::utils::log_debug ("Deleting spec document: id=" + id);
     impl_->storage.remove_all<SpecDocument> (where (c (&SpecDocument::id) == id));
+}
+
+namespace {
+
+/**
+ * The `specId` a JSON blob names at @p path, or "" when it names none.
+ *
+ * One reader for both halves of the sweep's reference set, because the two
+ * blobs disagree about where the id sits and about nothing else: a collection
+ * writes `{specId, specHash, syncedAt}` at the root, a run's snapshot writes
+ * the same identity under `scenario.openapi`. Unparseable text references
+ * nothing - the reading every other reader of these two columns gives it, and
+ * the one that cannot make a corrupt row pin a document forever.
+ */
+std::string spec_id_at (const std::string& blob, std::initializer_list<const char*> path) {
+    try {
+        auto node = nlohmann::json::parse (blob);
+        for (const char* key : path) {
+            if (!node.is_object ()) {
+                return {};
+            }
+            const auto it = node.find (key);
+            if (it == node.end ()) {
+                return {};
+            }
+            node = *it;
+        }
+        if (!node.is_object ()) {
+            return {};
+        }
+        return node.value ("specId", std::string ());
+    } catch (const std::exception&) {
+        return {};
+    }
+}
+
+} // namespace
+
+size_t Database::sweep_orphaned_spec_documents () {
+    try {
+        std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+        // Cheapest question first, and each of the three below is asked only
+        // when the one before it left something at stake. This pass rides on
+        // every run completion, so what it costs when there is nothing to
+        // reclaim - the ordinary case - is what it costs.
+        //
+        // 1. Which documents are even old enough to consider? Two columns and
+        //    never `content`: that is the one column here that reaches
+        //    `maxSpecDocumentBytes` (10 MiB by default), and this pass reads no
+        //    byte of a document whose fate it is only deciding.
+        const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+        std::chrono::system_clock::now ().time_since_epoch ())
+                            .count ();
+        const int64_t cutoff = now - vayu::core::constants::database::SPEC_DOCUMENT_SWEEP_GRACE_MS;
+
+        std::vector<std::string> candidates;
+        for (const auto& [id, fetched_at] : impl_->storage.select (
+             columns (&SpecDocument::id, &SpecDocument::fetched_at))) {
+            // A bind stores the document before the binding that names it, so a
+            // document inside the window is a bind in flight - see the grace
+            // constant.
+            if (fetched_at <= cutoff) {
+                candidates.push_back (id);
+            }
+        }
+        if (candidates.empty ()) {
+            return 0;
+        }
+
+        // 2. Which of those does a collection still bind? The same parse
+        //    `get_collections_bound_to_spec` makes, once over the sidebar-sized
+        //    table rather than once per candidate.
+        std::unordered_set<std::string> referenced;
+        for (const auto& binding : impl_->storage.select (&Collection::openapi)) {
+            auto spec_id = spec_id_at (binding, {});
+            if (!spec_id.empty ()) {
+                referenced.insert (std::move (spec_id));
+            }
+        }
+        std::erase_if (candidates,
+        [&] (const std::string& id) { return referenced.count (id) > 0; });
+        if (candidates.empty ()) {
+            return 0;
+        }
+
+        // 3. And which does a retained run still name? Last, because it is the
+        //    expensive read: `config_snapshot` is wide and there are up to
+        //    `maxRunsRetained` of them.
+        std::unordered_set<std::string> pinned;
+        for (const auto& snapshot : impl_->storage.select (&Run::config_snapshot)) {
+            auto spec_id = spec_id_at (snapshot, { "scenario", "openapi" });
+            if (!spec_id.empty ()) {
+                pinned.insert (std::move (spec_id));
+            }
+        }
+        std::erase_if (candidates,
+        [&] (const std::string& id) { return pinned.count (id) > 0; });
+        if (candidates.empty ()) {
+            return 0;
+        }
+
+        // What survived all three questions is unreachable by definition.
+        impl_->storage.transaction ([&] {
+            for (const auto& id : candidates) {
+                impl_->storage.remove_all<SpecDocument> (
+                where (c (&SpecDocument::id) == id));
+            }
+            return true; // Commit
+        });
+
+        vayu::utils::log_info ("Swept " + std::to_string (candidates.size ()) +
+        " OpenAPI document(s) no collection binds and no retained run names");
+        return candidates.size ();
+    } catch (const std::exception& e) {
+        // Best-effort by contract - see the header for why a caller must not
+        // fail over this.
+        vayu::utils::log_warning (
+        "OpenAPI document sweep failed: " + std::string (e.what ()));
+        return 0;
+    }
 }
 
 int64_t Database::stamp_hashless_spec_bindings () {
@@ -1180,6 +1310,14 @@ void Database::spec_sync_apply (const SpecSyncBatch& batch) {
             return true; // Commit
         });
     });
+
+    // The binding moved off whatever it named before, and a sync is the one
+    // operation that does that on a schedule - weekly, for a document that may
+    // be 12 MB (issue #718). Reclaimed here rather than left to the next
+    // startup, and outside the retried transaction because the sync has already
+    // succeeded and must not be undone by housekeeping. Never throws; see the
+    // declaration.
+    sweep_orphaned_spec_documents ();
 }
 
 // The one place a caller can scope the DB mutex around more than a single call.
@@ -1570,6 +1708,12 @@ void Database::prune_runs_configured () {
     const int max_age_days =
     get_config_int ("runRetentionDays", vayu::core::constants::database::RUN_RETENTION_DAYS);
     prune_runs (max_runs, max_age_days);
+    // A run that has just been pruned may have been the last thing naming an
+    // OpenAPI document (issue #718). Retention is where that reference is
+    // released, so it is where the release is noticed - and this is what puts
+    // the sweep on both a startup and the end of every run without a schedule
+    // of its own. Never throws; see the declaration.
+    sweep_orphaned_spec_documents ();
 }
 
 // ============================================================================

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 #include <sqlite3.h>
 
 #include <chrono>
@@ -996,6 +997,189 @@ TEST_F (DatabaseTest, PruneRunsByAgeSparesABaselineRun) {
     auto ids = run_ids (db);
     EXPECT_TRUE (ids.count ("pinned_stale"));
     EXPECT_FALSE (ids.count ("stale"));
+}
+
+// ============================================================================
+// OpenAPI document reclamation (sweep_orphaned_spec_documents, issue #718)
+// ============================================================================
+
+namespace {
+
+/** Long enough ago to be outside the grace window, whatever the clock says. */
+int64_t long_ago () {
+    const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                        .count ();
+    return now - vayu::core::constants::database::SPEC_DOCUMENT_SWEEP_GRACE_MS - 1000;
+}
+
+/** A stored document old enough for the sweep to consider it. */
+void seed_spec (Database& db, const std::string& id, int64_t fetched_at) {
+    SpecDocument spec;
+    spec.id         = id;
+    spec.content    = R"({"openapi":"3.0.0"})";
+    spec.hash       = "hash_" + id;
+    spec.fetched_at = fetched_at;
+    db.save_spec_document (spec);
+}
+
+/** A collection bound to @p spec_id, or to nothing when it is empty. */
+void seed_bound_collection (Database& db, const std::string& id, const std::string& spec_id) {
+    Collection col;
+    col.id      = id;
+    col.name    = id;
+    col.openapi = spec_id.empty () ?
+    "{}" :
+    nlohmann::json{ { "specId", spec_id }, { "specHash", "hash_" + spec_id },
+        { "syncedAt", 1 } }
+    .dump ();
+    db.create_collection (col);
+}
+
+/** A terminal scenario run whose snapshot pins @p spec_id, as a real one does. */
+void seed_run_pinning_spec (Database& db, const std::string& id, const std::string& spec_id) {
+    vayu::db::Run run;
+    run.id         = id;
+    run.type       = vayu::RunType::Scenario;
+    run.status     = vayu::RunStatus::Completed;
+    run.start_time = 1000;
+    // The shape `build_scenario_manifest` writes into `config_snapshot`: the
+    // identity sits under `scenario.openapi`, not at the root.
+    run.config_snapshot = nlohmann::json{
+        { "scenario",
+        nlohmann::json{ { "collectionId", "col_x" },
+        { "openapi", nlohmann::json{ { "specId", spec_id }, { "specHash", "hash_" + spec_id } } } } }
+    }.dump ();
+    db.create_run (run);
+}
+
+} // namespace
+
+// The accretion the sweep exists for: every sync mints a document and moves the
+// binding off the last one, and nothing owned the one left behind.
+TEST_F (DatabaseTest, SweepsADocumentNoCollectionBindsAndNoRunNames) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    seed_spec (db, "spec_old", long_ago ());
+    seed_spec (db, "spec_live", long_ago ());
+    seed_bound_collection (db, "col_1", "spec_live");
+
+    EXPECT_EQ (db.sweep_orphaned_spec_documents (), 1u);
+    EXPECT_FALSE (db.get_spec_document ("spec_old").has_value ());
+    EXPECT_TRUE (db.get_spec_document ("spec_live").has_value ())
+    << "the sweep took the document a collection is bound to";
+}
+
+// The other half of the lifetime rule: a run's report describes a contract, and
+// the document that contract came from outlives the binding by exactly as long
+// as the run that used it.
+TEST_F (DatabaseTest, SweepKeepsADocumentARetainedRunNames) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    seed_spec (db, "spec_old", long_ago ());
+    seed_run_pinning_spec (db, "run_1", "spec_old");
+
+    EXPECT_EQ (db.sweep_orphaned_spec_documents (), 0u);
+    EXPECT_TRUE (db.get_spec_document ("spec_old").has_value ());
+
+    // ...and goes with the last run that named it. Retention is what releases
+    // the reference, which is why the sweep rides along with it.
+    db.delete_run ("run_1");
+    EXPECT_EQ (db.sweep_orphaned_spec_documents (), 1u);
+    EXPECT_FALSE (db.get_spec_document ("spec_old").has_value ());
+}
+
+// A run that names a *different* document must not shield this one - the pin is
+// read by id, not by "some run mentions a spec".
+TEST_F (DatabaseTest, SweepReadsTheRunsOwnSpecIdRatherThanAnyRunAtAll) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    seed_spec (db, "spec_orphan", long_ago ());
+    seed_spec (db, "spec_pinned", long_ago ());
+    seed_run_pinning_spec (db, "run_1", "spec_pinned");
+
+    EXPECT_EQ (db.sweep_orphaned_spec_documents (), 1u);
+    EXPECT_FALSE (db.get_spec_document ("spec_orphan").has_value ());
+    EXPECT_TRUE (db.get_spec_document ("spec_pinned").has_value ());
+}
+
+// Binding is three writes over three requests and the document is the first of
+// them, so a document seconds old that nothing names is a bind in flight.
+TEST_F (DatabaseTest, SweepSparesADocumentInsideTheGraceWindow) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    const int64_t now = std::chrono::duration_cast<std::chrono::milliseconds> (
+    std::chrono::system_clock::now ().time_since_epoch ())
+                        .count ();
+    seed_spec (db, "spec_just_stored", now);
+
+    EXPECT_EQ (db.sweep_orphaned_spec_documents (), 0u);
+    EXPECT_TRUE (db.get_spec_document ("spec_just_stored").has_value ())
+    << "a document stored between POST /specs and the binding that names it "
+       "was swept";
+}
+
+// Retention is the pass that releases run references, so it is the pass that
+// notices what they were holding - and that is what puts the sweep on a startup
+// and on the end of every run without a schedule of its own.
+TEST_F (DatabaseTest, PruningRunsReclaimsTheDocumentTheLastPrunedRunHeld) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    seed_spec (db, "spec_old", long_ago ());
+    seed_run_pinning_spec (db, "run_1", "spec_old");
+
+    // Age cap disabled, count cap of zero would disable both - so drop the run
+    // by age, the way a month-old run goes.
+    db.prune_runs (0, 30);
+    ASSERT_TRUE (db.get_all_runs ().empty ());
+    // Still there: prune_runs is the primitive, prune_runs_configured is the
+    // pass. Only the pass sweeps.
+    EXPECT_TRUE (db.get_spec_document ("spec_old").has_value ());
+
+    db.prune_runs_configured ();
+    EXPECT_FALSE (db.get_spec_document ("spec_old").has_value ());
+}
+
+// Deleting a bound collection still does not cascade to the document - several
+// collections may bind one - but it is the moment to ask whether anything else
+// still does.
+TEST_F (DatabaseTest, DeletingTheLastBinderReclaimsTheDocument) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    seed_spec (db, "spec_1", long_ago ());
+    seed_bound_collection (db, "col_1", "spec_1");
+    seed_bound_collection (db, "col_2", "spec_1");
+
+    db.delete_collection ("col_1");
+    EXPECT_TRUE (db.get_spec_document ("spec_1").has_value ())
+    << "a document a second collection still binds was swept";
+
+    db.delete_collection ("col_2");
+    EXPECT_FALSE (db.get_spec_document ("spec_1").has_value ());
+}
+
+// A binding that is not JSON references nothing - the reading every other
+// reader of this column gives it, and the one that cannot make a corrupt row
+// pin a document forever.
+TEST_F (DatabaseTest, SweepTreatsAnUnparseableBindingAsBindingNothing) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    seed_spec (db, "spec_1", long_ago ());
+    Collection col;
+    col.id      = "col_1";
+    col.name    = "Broken";
+    col.openapi = "not json at all";
+    db.create_collection (col);
+
+    EXPECT_EQ (db.sweep_orphaned_spec_documents (), 1u);
+    EXPECT_FALSE (db.get_spec_document ("spec_1").has_value ());
 }
 
 TEST_F (DatabaseTest, SetRunBaselineTogglesAndPersists) {

--- a/engine/tests/spec_sync_route_test.cpp
+++ b/engine/tests/spec_sync_route_test.cpp
@@ -217,6 +217,55 @@ TEST_F (SpecSyncRouteTest, AnEmptySelectionStillMovesTheBindingAndNothingElse) {
     EXPECT_NE (binding ()["specId"].get<std::string> (), bound_spec_);
 }
 
+// A sync moves the binding off the document it named, and nothing owns what is
+// left - which is how a weekly sync of a 12 MB document stranded a 12 MB row a
+// week, unreachable by any route (issue #718).
+TEST_F (SpecSyncRouteTest, SyncingReclaimsTheDocumentTheBindingLeftBehind) {
+    // Age the seeded document past the sweep's grace window: it was stored a
+    // moment ago, and a document that new is treated as a bind in flight.
+    auto seeded = db_->get_spec_document (bound_spec_);
+    ASSERT_TRUE (seeded.has_value ());
+    seeded->fetched_at -= vayu::core::constants::database::SPEC_DOCUMENT_SWEEP_GRACE_MS + 1000;
+    db_->save_spec_document (*seeded);
+
+    auto [status, response] = routes::spec_sync_response (*db_, body ());
+    ASSERT_EQ (status, 200) << response.dump ();
+
+    EXPECT_FALSE (db_->get_spec_document (bound_spec_).has_value ())
+    << "the superseded document outlived the sync that moved the binding off it";
+    // What the binding names now is untouched, which is the half that would make
+    // a too-eager sweep catastrophic rather than merely wasteful.
+    auto live = db_->get_spec_document (response["specId"].get<std::string> ());
+    EXPECT_TRUE (live.has_value ());
+}
+
+// The same sync, with a run still naming the document it supersedes: coverage
+// on that run's report describes a contract, so its source outlives the binding
+// by exactly the run's own retention.
+TEST_F (SpecSyncRouteTest, SyncingKeepsASupersededDocumentARunStillNames) {
+    auto seeded = db_->get_spec_document (bound_spec_);
+    ASSERT_TRUE (seeded.has_value ());
+    seeded->fetched_at -= vayu::core::constants::database::SPEC_DOCUMENT_SWEEP_GRACE_MS + 1000;
+    db_->save_spec_document (*seeded);
+
+    // The shape a scenario run's manifest stamps into its snapshot.
+    vayu::db::Run run;
+    run.id              = "run_pins_it";
+    run.type            = vayu::RunType::Scenario;
+    run.status          = vayu::RunStatus::Completed;
+    run.start_time      = 1000;
+    run.config_snapshot = json{ { "scenario",
+    json{ { "collectionId", root_ }, { "openapi", json{ { "specId", bound_spec_ } } } } } }
+                          .dump ();
+    db_->create_run (run);
+
+    auto [status, response] = routes::spec_sync_response (*db_, body ());
+    ASSERT_EQ (status, 200) << response.dump ();
+
+    EXPECT_TRUE (db_->get_spec_document (bound_spec_).has_value ())
+    << "a sync reclaimed the document a retained run was measured against";
+}
+
 TEST_F (SpecSyncRouteTest, CreatedRequestsAppendAfterTheCollectionsExistingOnes) {
     create_request (root_); // order 0
 


### PR DESCRIPTION
## Description

Two lifecycle holes in the OpenAPI binding state machine, filed together because they share the bind / sync / delete paths.

**Plan.** Root cause, both halves: **nothing in the codebase ever un-references a document.** No writer anywhere sets a request's `specOperation` back to null, and no code path deletes a `spec_documents` row that stopped being reachable - so identity and storage both accumulate against documents the collection has moved off. Approach: give each a single statable rule and put it in one place. **A** - after a bind, a request's `specOperation` is the operation it matched *in the bound document*, or nothing; the bind mutation now writes `null` for the non-matchers, and the tab discloses the count before the user agrees. **B** - a `spec_documents` row lives while a collection binds it *or* a retained run names it, enforced by one sweep hung off the pass that releases run references.

The alternative rejected for **B** was reference-counting documents, or cascading a delete from unbind. Counting needs a column every one of four write paths must maintain correctly forever and is wrong the first time one forgets; cascading from unbind is simply incorrect, since several collections may bind one document and a *run* may still need it. A sweep asking "can anything still reach this?" cannot drift out of step with the writers, because it reads the same two columns they write.

The alternative rejected for **A** was clearing only a stamp the new document does not *declare* (rather than every non-matcher). It sounds gentler and is the actual bug: coverage resolves stamps `operationId`-first, so a v1 stamp surviving because v2 happens to declare the same id is exactly the wrong-operation claim #718 describes.

**Verified at `682cc9a`** (the issue's anchors were written at `ac27b97`): `handleUnbind` still cleared only the collection binding (`SpecTab.tsx:208-217`), `useBindSpecMutation` still wrote stamps and nothing else (`specs.ts:183-195`), `spec_sync_apply` still never deleted the superseded row (`database.cpp`), and `DELETE /specs/:id` still had no caller. Both sequencing gates the issue records are met: #709 shipped in 0.18.1, so the bind path is the shipped one and the backfill-before-sweep ordering is already satisfied on master.

### A - stale stamps after a re-bind

`useBindSpecMutation` gains a required `clearStamps: string[]`, and writes `specOperation: null` for each - the engine's existing null-vs-absent rule, so no engine change was needed. `SpecTab` computes it as *the unmatched requests that carry a stamp*, and:

- the match summary states the count **before** Bind is pressed ("N requests record an operation this document does not have - that identity is cleared"), because this is the one thing a bind rewrites;
- the "nothing is created, deleted or rewritten" copy - now false - says what is actually true;
- a clear that fails is reported **apart from** a stamp that failed, because the state it leaves is the worse of the two: a surviving stamp still reads as identity, and it is identity in a document nothing is bound to.

Unbind is untouched, deliberately, per the issue: it still leaves stamps exactly as they are, so unbind-then-bind-the-same-document is lossless.

### B - unreachable `spec_documents` rows

New `Database::sweep_orphaned_spec_documents()`, returning how many rows went, implementing one rule:

> A document lives while a collection binds it, **or** while a retained run names it in `runs.config_snapshot` under `scenario.openapi.specId`.

Called from three places, each with its own reason: `prune_runs_configured()` (the pass that *releases* run references - which is what puts the sweep on a startup and the end of every run with no schedule of its own), `spec_sync_apply()` (the accretion source), and `delete_collection()` (the last binder going away).

Three properties are load-bearing rather than incidental:

- **A 10-minute grace window** (`SPEC_DOCUMENT_SWEEP_GRACE_MS`). Binding is three writes over three requests and the *document is the first of them*, so between `POST /specs` and the `PUT /collections/:id` that names it a document is bound by nobody and pinned by no run - indistinguishable from an orphan. Without this, a run finishing in that window deletes the document a bind is midway through storing.
- **Cheapest question first, stopping at the first that leaves nothing at stake.** It rides on every run completion, so what it costs when there is nothing to reclaim is what it costs: age, then bindings, then - only if a candidate survives both - the runs table, which is the wide read. It never reads `content` on any path, which is the one column that reaches the 10 MiB cap.
- **It never throws.** All three callers reach it as the tail of an operation whose success does not depend on it; a failed sweep must not turn into a failed sync.

Blast radius traced before writing: every reader of a stored document reaches it through a *binding* (`useSpecQuery(binding?.specId)`, `useBoundSpecReader`, `scenario_plan.cpp` at plan time, the specs routes). Nothing reads a document by a run's stamped `specId`, and a run's coverage is computed at plan time and stored on the run - so a swept document breaks no reader. The scenario manifest is stamped into `config_snapshot` at run *creation*, so a run pins its document from the moment its row exists, with no window where an in-flight run is unprotected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

**Engine:** `python build.py -e -t` clean, `ctest --preset linux-dev` **1996 tests, all passing** (9 new). **App:** **503 files, 5317 tests, all passing** (7 new; 502/5310 at the base commit). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `mkdocs build --strict` clean.

`prettier --check` clean on every touched source file - all four were clean at `682cc9a` and were formatted. The three Markdown files under `docs/` were **not** prettier-clean at the base commit and are left as they are, per the repo rule about formatting only files that were clean before. C++ formatted with `git clang-format` against the base, so only the lines this PR adds moved.

No pre-existing failures observed on the base commit.

Each guard below was mutation-checked (mutation applied, whole suite run, confirmed red, reverted) - and in the engine's case the mutations were run in two batches so each failing set names the line it belongs to, rather than one build failing everything at once:

| Guard | Mutation that turns it red | Result |
|---|---|---|
| a bind clears identity the new document does not account for, and stamps only the matches | `clearStamps: staleStamps` -> `[]` in `SpecTab` | 1 red |
| the clear is written as `null`, not an omitted key | send the patch without `specOperation` | 1 red |
| a failed clear is reported apart from a failed stamp | fold `failedClears` into `failedStamps` | 2 red |
| pruning runs reclaims what the last pruned run held; deleting the last binder reclaims the document; a sync reclaims what it superseded | drop all three `sweep_orphaned_spec_documents()` call sites | exactly 3 red, one per call site (`PruningRunsReclaims...`, `DeletingTheLastBinder...`, `SyncingReclaims...`) |
| a document a retained run names survives (and a run naming a *different* document does not shield it) | drop the run-pin filter | 3 red |
| a document inside the grace window is spared | drop the `fetched_at` gate | 1 red |

Also covered, behaviourally rather than by mutation: the sweep takes an unreachable document and leaves a bound one; a document goes with the *last* run that named it (asserted by deleting that run and sweeping again); deleting one of two binders reclaims nothing and deleting the second reclaims it; a corrupt (unparseable) `collections.openapi` binds nothing rather than pinning a document forever; the disclosure line is absent when nothing is stale; a request with no stamp is left alone rather than written to; and the binding still holds when a clear fails, rather than being rolled back.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/db-schema.md` gains the **lifetime rule** beside the "no cascade" section (the rule, the three callers, the grace window, and why run-referenced documents live as long as the runs); `docs/engine/api-reference.md` states it as API-visible behaviour under **Specs**, since a client that stores a document and never binds it will eventually see a `404`; `docs/app/openapi.md` gains **"Identity from another document is cleared"** beside the binding section and the document-lifetime paragraph beside the ownership one. The `SpecTab` header comment and the tab's own copy both carried the now-false "rewrites nothing" claim and say what happens instead.

## Related Issues

Closes #718

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ljj1KuTAstpT4S9Rz39qg)_