### PR TITLE
fix(app/openapi): answer "which operations" from the coverage rows, and stop reading "0 requests" for a tree the screen runs

### DIFF
--- a/app/src/components/shared/ContractCoverage.test.tsx
+++ b/app/src/components/shared/ContractCoverage.test.tsx
@@ -19,7 +19,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { ContractCoverage } from "./ContractCoverage";
-import type { RunCoverage } from "@/types/domain";
+import type { RunCoverage, RunCoverageOperation } from "@/types/domain";
 
 afterEach(cleanup);
 
@@ -123,6 +123,75 @@ describe("ContractCoverage", () => {
 		// about parent collections on a whole-collection run would be noise.
 		render(<ContractCoverage coverage={coverage()} />);
 		expect(screen.queryByText(/parent collection/)).toBeNull();
+	});
+
+	/*
+	 * The header can say "2 undeclared statuses observed" while every row paints
+	 * its statuses identically, leaving the reader no way to find *which*
+	 * operations returned them - the array the engine builds to answer that was
+	 * typed and rendered nowhere (issue #723). Class assertions rather than a
+	 * source scan, because the tint arrives through `cn()` on a binding.
+	 */
+	describe("per-row findings", () => {
+		const withStatuses = (over: Partial<RunCoverageOperation> = {}) =>
+			coverage({
+				operations: [
+					{
+						operationId: "listPets",
+						method: "GET",
+						path: "/pets",
+						sent: 6,
+						statusesSeen: [200, 503],
+						declaredHit: ["200"],
+						declaredMissed: [],
+						undeclaredSeen: [503],
+						...over,
+					},
+				],
+			});
+
+		// The undeclared span carries an `sr-only` suffix, so its text content is
+		// "503 undeclared" and an exact match would not find it.
+		const statusSpan = (code: number) => screen.getByText(new RegExp(`^${code}\\b`));
+
+		it("sets an undeclared status apart from a declared one", () => {
+			render(<ContractCoverage coverage={withStatuses()} />);
+			const undeclared = statusSpan(503);
+			const declared = statusSpan(200);
+			// The tint marks it; the status keeps its own text colour, because an
+			// undeclared 503 is still a 503.
+			expect(undeclared.className).toContain("bg-status-warning/10");
+			expect(undeclared.className).toContain("text-status-error-text");
+			expect(declared.className).not.toContain("bg-status-warning");
+		});
+
+		it("says which status is undeclared for a reader who cannot see the tint", () => {
+			// Colour alone is not a difference. Without this the row is
+			// indistinguishable to a screen reader from a fully declared one.
+			render(<ContractCoverage coverage={withStatuses()} />);
+			expect(statusSpan(503).textContent).toMatch(/undeclared/);
+			expect(statusSpan(200).textContent).not.toMatch(/undeclared/);
+		});
+
+		it("discloses statuses the engine's per-row cap dropped", () => {
+			// A list shorter than the count it belongs to, rendered as complete,
+			// is what the truncation-disclosure discipline forbids.
+			render(<ContractCoverage coverage={withStatuses({ statusesTruncated: 7 })} />);
+			expect(screen.getByText("+7 more")).toBeTruthy();
+		});
+
+		it("counts responses whose status no class describes", () => {
+			render(<ContractCoverage coverage={withStatuses({ otherStatusResponses: 3 })} />);
+			expect(screen.getByText("3 off-range")).toBeTruthy();
+		});
+
+		it("stays quiet about both when neither happened", () => {
+			// Absent is the engine's spelling of zero for these two, and a row
+			// reading "+0 more" would be noise on every well-behaved operation.
+			render(<ContractCoverage coverage={withStatuses()} />);
+			expect(screen.queryByText(/more$/)).toBeNull();
+			expect(screen.queryByText(/off-range/)).toBeNull();
+		});
 	});
 
 	it("reads as complete only when nothing is uncovered and nothing undeclared", () => {

--- a/app/src/components/shared/ContractCoverage.tsx
+++ b/app/src/components/shared/ContractCoverage.tsx
@@ -138,6 +138,18 @@ export function ContractCoverage({ coverage, inheritedBinding, className }: Cont
 
 function CoverageRow({ operation }: { operation: RunCoverageOperation }) {
 	const covered = operation.sent > 0;
+	/*
+	 * `undeclaredSeen` repeats the codes from `statusesSeen` that answered to no
+	 * declared pattern, so the row can paint them apart rather than leaving the
+	 * header's "N undeclared statuses observed" unanswerable from the list below
+	 * it (issue #723). A Set because a row carries up to 50 of each.
+	 *
+	 * Both lists are capped independently by the engine, so an undeclared code
+	 * past the cap can be absent from `statusesSeen` and go unpainted here. That
+	 * is what `statusesTruncated` discloses; it is not a case this lookup can
+	 * recover.
+	 */
+	const undeclared = new Set(operation.undeclaredSeen);
 
 	return (
 		<li className="flex items-baseline justify-between gap-3 text-sm">
@@ -152,17 +164,61 @@ function CoverageRow({ operation }: { operation: RunCoverageOperation }) {
 			</span>
 			<span className="flex shrink-0 items-baseline gap-1.5">
 				{!covered && <span className="text-xs text-muted-foreground">never called</span>}
-				{operation.statusesSeen.map((status) => (
+				{operation.statusesSeen.map((status) => {
+					const isUndeclared = undeclared.has(status);
+					return (
+						<span
+							key={status}
+							/*
+							 * The warning *tint* behind the status's own text
+							 * colour, never a fill under it: an undeclared 200
+							 * is still a 200, and repainting the code itself
+							 * would trade one fact for the other. Tint plus
+							 * `--status-*-text` is the pairing the status-token
+							 * rules allow (app/CLAUDE.md); a background makes it
+							 * a box, so it takes a radius token rather than
+							 * pinning square.
+							 */
+							className={cn(
+								"font-mono text-xs",
+								STATUS_CLASS_STYLE[httpStatusClass(status)].text,
+								isUndeclared && "rounded-md bg-status-warning/10 px-1"
+							)}
+							title={
+								isUndeclared
+									? `${status} - this document declares no response for it`
+									: undefined
+							}
+						>
+							{status}
+							{/* The tint is the only visual difference, and colour
+							    alone is not a difference for every reader. */}
+							{isUndeclared && <span className="sr-only"> undeclared</span>}
+						</span>
+					);
+				})}
+				{/*
+				 * Dropped by the engine's per-operation cap on the two status
+				 * lists. A list shorter than the count it belongs to, rendered as
+				 * though complete, is the shape the truncation-disclosure
+				 * discipline exists to forbid.
+				 */}
+				{operation.statusesTruncated !== undefined && (
 					<span
-						key={status}
-						className={cn(
-							"font-mono text-xs",
-							STATUS_CLASS_STYLE[httpStatusClass(status)].text
-						)}
+						className="text-xs text-muted-foreground"
+						title={`${operation.statusesTruncated} more not shown - the per-operation status list is capped`}
 					>
-						{status}
+						+{operation.statusesTruncated} more
 					</span>
-				))}
+				)}
+				{operation.otherStatusResponses !== undefined && (
+					<span
+						className="text-xs text-muted-foreground"
+						title="Responses whose status fell outside 100-599, so no status class describes them"
+					>
+						{operation.otherStatusResponses} off-range
+					</span>
+				)}
 				{operation.transportErrors !== undefined && (
 					<span className="text-xs text-destructive-text">
 						{operation.transportErrors} failed

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.error.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.error.test.tsx
@@ -43,6 +43,9 @@ const state = {
 vi.mock("@/queries/collections", () => ({
 	useCollectionsQuery: () => state.collections,
 	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	// The shell counts the whole subtree for its header (issue #723); an empty
+	// map is "no requests anywhere", which is what these cases are about.
+	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map(), isLoading: false }),
 }));
 
 vi.mock("@/stores", () => ({

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.loading.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.loading.test.tsx
@@ -32,6 +32,9 @@ const state = {
 vi.mock("@/queries/collections", () => ({
 	useCollectionsQuery: () => state.collections,
 	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	// The shell counts the whole subtree for its header (issue #723); an empty
+	// map is "no requests anywhere", which is what these cases are about.
+	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map(), isLoading: false }),
 }));
 
 vi.mock("@/stores", () => ({

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.request-count.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.request-count.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What "N requests" names on the collection screen (issue #723).
+ *
+ * An OpenAPI import files its requests under one sub-collection per tag, so a
+ * spec-bound root owns none directly. The header counted only those, and read
+ * "GitHub v3 REST API - 0 requests" beside a mock toggle serving the whole
+ * subtree, a Run dialog running it, and a Spec tab counting it. One screen, two
+ * meanings for one word, and the smaller one on the line a reader sees first.
+ *
+ * These pin the subtree meaning in both places that state it, so the header and
+ * the Info tab cannot drift apart from each other or from the surfaces around
+ * them. The mutation each guards against is the narrower read coming back: swap
+ * the subtree count for the root's own requests and the first two go red.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import CollectionDetail from "./index";
+
+/** `spec-root` owns nothing directly; its two tag folders hold four requests. */
+const collections = [
+	{ id: "spec-root", name: "GitHub v3 REST API", variables: {} },
+	{ id: "tag-users", name: "users", parentId: "spec-root", variables: {} },
+	{ id: "tag-repos", name: "repos", parentId: "spec-root", variables: {} },
+	{ id: "elsewhere", name: "unrelated", variables: {} },
+];
+
+const requestsByCollection = new Map<string, unknown[]>([
+	["spec-root", []],
+	["tag-users", [{ id: "r1" }, { id: "r2" }]],
+	["tag-repos", [{ id: "r3" }, { id: "r4" }]],
+	// Outside the subtree. Present so a count that ignores the walk and sums
+	// every cached collection is red too, not just one that ignores children.
+	["elsewhere", [{ id: "r5" }, { id: "r6" }, { id: "r7" }]],
+]);
+
+const seenIds: string[][] = [];
+
+vi.mock("@/queries/collections", () => ({
+	useCollectionsQuery: () => ({ data: collections, isLoading: false, isError: false }),
+	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	useMultipleCollectionRequests: (ids: string[]) => {
+		seenIds.push(ids);
+		return {
+			requestsByCollection: new Map(
+				ids.map((id) => [id, requestsByCollection.get(id) ?? []])
+			),
+			isLoading: false,
+		};
+	},
+}));
+
+vi.mock("@/stores", () => ({
+	useTabsStore: () => ({
+		openTabs: [{ id: "t1", type: "collection", entityId: "spec-root" }],
+		activeTabId: "t1",
+	}),
+	useSessionStore: (selector: (s: unknown) => unknown) =>
+		selector({ setLastCollectionId: vi.fn() }),
+}));
+
+// Stubbed to read back the prop the shell hands it: the count is computed once
+// in the shell and passed down, so what this file can prove about the Info tab
+// is that it is given the subtree number. InfoTab's own suite covers the Stat.
+vi.mock("./InfoTab", () => ({
+	default: ({ requestCount }: { requestCount: number }) => (
+		<div data-testid="info-request-count">{requestCount}</div>
+	),
+}));
+
+vi.mock("./AuthTab", () => ({ default: () => null }));
+vi.mock("./ScriptTab", () => ({ default: () => null }));
+vi.mock("./VariablesTab", () => ({ default: () => null }));
+// Reaches the engine and the toast store; its own suite covers it.
+vi.mock("./MockServerControl", () => ({ default: () => null }));
+
+beforeEach(() => {
+	seenIds.length = 0;
+});
+
+describe("the request count on a spec-bound root", () => {
+	it("counts the subtree in the header, not the requests the root owns", () => {
+		render(<CollectionDetail />);
+		expect(screen.getByText(/- 4 requests/)).toBeTruthy();
+		expect(screen.queryByText(/- 0 requests/)).toBeNull();
+	});
+
+	it("hands the Info tab the same number the header states", () => {
+		// Two surfaces, one count, computed once in the shell: the Info tab used
+		// to be handed the root's own requests, so agreeing here is what stops
+		// the screen contradicting itself again.
+		render(<CollectionDetail />);
+		expect(screen.getByTestId("info-request-count").textContent).toBe("4");
+	});
+
+	it("walks the subtree rather than every collection the cache holds", () => {
+		render(<CollectionDetail />);
+		expect([...seenIds[seenIds.length - 1]].sort()).toEqual([
+			"spec-root",
+			"tag-repos",
+			"tag-users",
+		]);
+	});
+});

--- a/app/src/modules/collections/CollectionDetail/CollectionDetail.spec-target.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/CollectionDetail.spec-target.test.tsx
@@ -41,6 +41,9 @@ const collection = {
 vi.mock("@/queries/collections", () => ({
 	useCollectionsQuery: () => ({ data: [collection], isLoading: false }),
 	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	// The shell counts the whole subtree for its header (issue #723); an empty
+	// map is "no requests anywhere", which is what these cases are about.
+	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map(), isLoading: false }),
 }));
 
 vi.mock("./AuthTab", () => ({ default: () => null }));

--- a/app/src/modules/collections/CollectionDetail/InfoTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/InfoTab.tsx
@@ -33,6 +33,11 @@ import { formatRelative } from "./format";
 
 interface InfoTabProps {
 	collection: Collection;
+	/**
+	 * Requests in the collection's whole subtree, not the ones it owns directly
+	 * (issue #723) - the count the shell computes for its header, so the two
+	 * cannot disagree about what "Requests" names. See the rationale there.
+	 */
 	requestCount: number;
 	/** Whether this is the tab on screen - see `useDraftSaveContext`. */
 	active?: boolean;

--- a/app/src/modules/collections/CollectionDetail/draft-survival.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/draft-survival.test.tsx
@@ -60,6 +60,9 @@ const mutation = {
 vi.mock("@/queries/collections", () => ({
 	useCollectionsQuery: () => ({ data: [collection], isLoading: false, isError: false }),
 	useRequestsQuery: () => ({ data: [], isLoading: false }),
+	// The shell counts the whole subtree for its header (issue #723); an empty
+	// map is "no requests anywhere", which is what these cases are about.
+	useMultipleCollectionRequests: () => ({ requestsByCollection: new Map(), isLoading: false }),
 	useUpdateCollectionMutation: () => mutation,
 	useCollectionAncestors: () => [],
 }));

--- a/app/src/modules/collections/CollectionDetail/index.tsx
+++ b/app/src/modules/collections/CollectionDetail/index.tsx
@@ -16,7 +16,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Folder } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger, TabLabel, TabCount } from "@/components/ui";
 import { DetailSkeleton, EmptyState, ErrorState } from "@/components/shared";
-import { useCollectionsQuery, useRequestsQuery } from "@/queries/collections";
+import { useCollectionsQuery, useMultipleCollectionRequests } from "@/queries/collections";
+import { collectSubtreeIds } from "@/modules/collections/tree-utils";
 import { useTabsStore, useSessionStore } from "@/stores";
 import AuthTab from "./AuthTab";
 import DataTab from "./DataTab";
@@ -88,7 +89,30 @@ export default function CollectionDetail() {
 		error: collectionsError,
 		refetch: refetchCollections,
 	} = useCollectionsQuery();
-	const { data: requests = [] } = useRequestsQuery(selectedCollectionId);
+	/*
+	 * The whole subtree, not this collection's own requests (issue #723).
+	 *
+	 * An OpenAPI import files its requests under one sub-collection per tag, so
+	 * a spec-bound root owns none directly - and this header read "GitHub v3
+	 * REST API - 0 requests" above a mock serving a thousand routes. Every other
+	 * surface on this screen already means the subtree when it says "this
+	 * collection": the mock toggle beside the count serves it, the Run dialog
+	 * runs it, the export walks it, and the Spec tab counts it with that
+	 * rationale written out. The count says the same thing they do rather than
+	 * describing a narrower set by the same name.
+	 *
+	 * Free of extra fetches in practice: `CollectionTree` already holds a query
+	 * per collection, so these resolve from the cache the sidebar filled.
+	 */
+	const subtreeIds = useMemo(
+		() => (selectedCollectionId ? collectSubtreeIds(selectedCollectionId, collections) : []),
+		[selectedCollectionId, collections]
+	);
+	const { requestsByCollection } = useMultipleCollectionRequests(subtreeIds);
+	const requestCount = useMemo(
+		() => [...requestsByCollection.values()].reduce((total, r) => total + r.length, 0),
+		[requestsByCollection]
+	);
 
 	const collection = useMemo(
 		() => collections.find((c) => c.id === selectedCollectionId) ?? null,
@@ -165,7 +189,7 @@ export default function CollectionDetail() {
 				<Folder className="w-[15px] h-[15px] text-primary shrink-0" />
 				<span className="text-sm font-semibold text-foreground">{collection.name}</span>
 				<span className="text-xs text-muted-foreground">
-					- {requests.length} request{requests.length !== 1 ? "s" : ""}
+					- {requestCount} request{requestCount !== 1 ? "s" : ""}
 				</span>
 				{/* Right-aligned, because it is an action on the collection rather
 				    than part of its identity. It knows nothing about the tabs
@@ -230,7 +254,7 @@ export default function CollectionDetail() {
 						{t.id === "info" && (
 							<InfoTab
 								collection={collection}
-								requestCount={requests.length}
+								requestCount={requestCount}
 								active={tab === "info"}
 							/>
 						)}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -312,9 +312,16 @@ Shared, Monaco-independent modules that power the GraphQL body mode.
 
 Tab shell reached via `navigationStore.navigateToCollection(id)`. Header shows name + request count, and - right-aligned - the mock-server control; seven tabs:
 
+The **request count is the whole subtree**, not the requests the collection owns
+directly, and the shell computes it once for both the header and the Info tab. A
+spec-bound root usually owns none directly - an OpenAPI import files them under
+one sub-collection per tag - and every other surface on this screen already means
+the subtree: the mock serves it, the Run dialog runs it, the export walks it, the
+Spec tab counts it.
+
 | Tab | Component | Notes |
 |---|---|---|
-| Info | `InfoTab.tsx` | Name, description, request count. **Autosaves** - no Save/Cancel |
+| Info | `InfoTab.tsx` | Name, description, request count (the shell's subtree count, handed down). **Autosaves** - no Save/Cancel |
 | Auth | `AuthTab.tsx` | Collection-level auth (concrete; never `inherit`). Mode picker + hints only - the fields are the shared [`AuthFields`](#shared-auth-fields-componentssharedauthfields). **The one tab with a Save button**, and it says so above the fields |
 | Pre-request | `ScriptTab.tsx` (`kind="pre"`) | Collection pre-request script. **Autosaves** on editor blur - no Save |
 | Post-request | `ScriptTab.tsx` (`kind="post"`) | Collection post-request script. **Autosaves** on editor blur - no Save |

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -411,6 +411,23 @@ Requests whose operation the document does not declare are counted too, as
 collection that has drifted off its contract, which is exactly what the block
 exists to notice.
 
+### Reading a row
+
+Each row lists the statuses that operation answered with. A status the document
+declares **no** response for carries a warning tint behind it and reads as
+`undeclared` to a screen reader - so the header's "N undeclared statuses
+observed" is answerable from the rows below it, not just a total. The status
+keeps its own colour either way: an undeclared 503 is still a server error.
+
+Two further findings appear on a row only when they happened, because they are
+zero on almost every one:
+
+| On the row | What it means |
+|---|---|
+| `+N more` | The per-operation status list is capped, and N entries were dropped |
+| `N off-range` | Responses whose status fell outside 100-599, which no status class describes |
+| `N failed` | Sends that never got a response at all |
+
 ### What is exact and what is sampled
 
 **Every number in a coverage block is exact.** It is counted as each request is


### PR DESCRIPTION
## Description

Two CONFIRMED findings from the `ac27b97` review, batched as #723 named them.

**Plan.** Root cause of item 1: the engine computes `undeclaredSeen`, `otherStatusResponses` and `statusesTruncated` per operation (`spec_coverage.cpp:340-382`) and `domain.ts:325-331` types all three, but `ContractCoverage.tsx` rendered a row from `statusesSeen` / `declaredMissed` / `transportErrors` only - the canonical "written but never read". The header's "3 undeclared statuses observed" was therefore unanswerable from the list directly beneath it. Approach: paint undeclared codes apart **in the existing list** rather than adding a second one, so the row keeps saying "here is what this operation answered with" and gains a second fact about the same codes. The alternative rejected was a separate `undeclared: 500, 503` group on the row - it reads more explicitly, but it prints codes twice and makes the common row (nothing undeclared) pay for the rare one.

Root cause of item 2: `CollectionDetail` counted `useRequestsQuery(collectionId)` - the collection's *direct* requests - while every other surface on that screen means the subtree. The fix takes the subtree count the Spec tab already computes, with the rationale it already records. The alternative rejected is the issue's other spelling, `0 direct · 1220 in tree`: it never loses information, but it invents a second vocabulary on a line every collection renders, and the direct count has nothing on this screen to anchor it - there is no request list here, so it would be a number a reader cannot act on.

Changes:

- `ContractCoverage.tsx` - undeclared statuses carry the warning **tint** behind their own `--status-*-text` colour (an undeclared 503 is still a server error, so the code itself is not repainted), plus an `sr-only` "undeclared" suffix and a `title`, since colour alone is not a difference. `statusesTruncated` renders as `+N more` and `otherStatusResponses` as `N off-range`, beside the `N failed` they match; each is absent when the engine omits it, so a well-behaved row is unchanged.
- `CollectionDetail/index.tsx` - the header and the Info tab take the subtree count, computed **once in the shell** from `collectSubtreeIds` + `useMultipleCollectionRequests` and handed down, so the two cannot disagree. `useRequestsQuery` had no other caller here and is dropped.
- `InfoTab.tsx` - the `requestCount` prop documents what it now names.

**No extra fetches:** `CollectionTree` already holds a request query per collection, so the subtree reads resolve from the cache the sidebar filled.

**Deliberate deviation from the issue spec.** #723 says "apply it to header, Info and sidebar coherently". The sidebar is left alone: `CollectionItem`'s `(N)` is `requests.length + childCollections.length` - the count of direct child *rows*, tied to `aria-setsize` and to what expanding the row reveals. It never claimed a request count, and on a spec root it already reads `(45)` for 45 tag folders rather than `(0)`. Changing it to a subtree request count would break its correspondence with the tree it labels, which is a worse incoherence than the one being fixed.

**Follow-up filed:** #786. Wiring `statusesTruncated` into the row turned up that the engine increments one shared counter across two `capped_statuses` calls over overlapping sets, so the number is "entries dropped across two lists" rather than "statuses hidden". That is why the row says `+N more` with a deliberately vague noun and the code comment says so. Engine-side counting fix, out of scope for an app rendering issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App suite, full: **503 files, 5318 tests, all passing.** `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on all nine touched source files. No engine or C++ change - the engine was read, not modified - so no `build.py -t` / `ctest` run; no engine test could change colour.

`mkdocs build --strict` was not run: mkdocs is not installed in this environment. The docs change adds one heading and one table to an existing page and introduces no link, anchor reference or nav entry, so neither strict-mode failure mode is reachable; CI covers it.

Eight new assertions, every one mutation-checked (fix reverted, confirmed red, restored):

| Guard | Mutation that turns it red |
|---|---|
| An undeclared status carries the tint and keeps its status colour; a declared one carries neither | drop the `isUndeclared &&` tint (1 red) |
| The undeclared status reads as such without the colour | drop the `sr-only` suffix (1 red) |
| A capped row discloses `+7 more` | drop the `statusesTruncated` block (1 red) |
| An off-range count renders | drop the `otherStatusResponses` block (1 red) |
| Neither renders when the engine omitted them | - (pins absent-not-zero) |
| The header counts the subtree, not the root's own requests | count `requestsByCollection.get(rootId)` again (1 red) |
| The Info tab is handed the same number | same mutation (1 red) |
| The walk covers the subtree and stops there | - (a fourth collection outside the subtree holds 3 requests, so summing the whole cache is red too) |

The last one is the load-bearing one for item 2: `collectSubtreeIds` is what makes the count "this tree" rather than "every collection cached", and a future edit that summed the map without the walk would otherwise pass.

No pre-existing failures observed on the base commit (`682cc9a`).

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/openapi.md` gains a "Reading a row" section covering the undeclared treatment and the three conditional row findings; `docs/app/COMPONENTS.md` records that the collection screen's request count is the subtree and is computed once in the shell.

## Related Issues
Closes #723

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGGwmMsZyuhCn9fH4UR46g)_