### PR TITLE
fix(engine/app/coverage): count the statuses a coverage row hides, not the entries two capped lists dropped

### DIFF
--- a/app/src/components/shared/ContractCoverage.test.tsx
+++ b/app/src/components/shared/ContractCoverage.test.tsx
@@ -173,11 +173,40 @@ describe("ContractCoverage", () => {
 			expect(statusSpan(200).textContent).not.toMatch(/undeclared/);
 		});
 
+		it("paints an undeclared status that only the second list carries", () => {
+			// The engine caps the two lists separately, so an undeclared code past
+			// the `statusesSeen` cap arrives in `undeclaredSeen` alone. Rendering
+			// `statusesSeen` by itself dropped it from the row while
+			// `statusesTruncated` - which counts the codes *neither* list carries -
+			// did not account for it, so the row showed fewer statuses than it
+			// claimed to be hiding (issue #786).
+			render(
+				<ContractCoverage
+					coverage={withStatuses({
+						statusesSeen: [200, 503],
+						undeclaredSeen: [503, 599],
+					})}
+				/>
+			);
+			expect(statusSpan(599).textContent).toMatch(/undeclared/);
+			// One span per code, in ascending order, however the two lists split.
+			expect(screen.getAllByText(/^503\b/)).toHaveLength(1);
+			expect(screen.getByRole("listitem").textContent).toMatch(/200.*503.*599/);
+		});
+
 		it("discloses statuses the engine's per-row cap dropped", () => {
 			// A list shorter than the count it belongs to, rendered as complete,
-			// is what the truncation-disclosure discipline forbids.
+			// is what the truncation-disclosure discipline forbids. The number is
+			// distinct statuses hidden, and the label has to say so (issue #786).
 			render(<ContractCoverage coverage={withStatuses({ statusesTruncated: 7 })} />);
-			expect(screen.getByText("+7 more")).toBeTruthy();
+			expect(screen.getByText("+7 more").getAttribute("title")).toBe(
+				"7 more statuses observed and not shown - the per-operation status list is capped"
+			);
+		});
+
+		it("counts one hidden status in the singular", () => {
+			render(<ContractCoverage coverage={withStatuses({ statusesTruncated: 1 })} />);
+			expect(screen.getByText("+1 more").getAttribute("title")).toMatch(/1 more status /);
 		});
 
 		it("counts responses whose status no class describes", () => {

--- a/app/src/components/shared/ContractCoverage.tsx
+++ b/app/src/components/shared/ContractCoverage.tsx
@@ -143,13 +143,18 @@ function CoverageRow({ operation }: { operation: RunCoverageOperation }) {
 	 * declared pattern, so the row can paint them apart rather than leaving the
 	 * header's "N undeclared statuses observed" unanswerable from the list below
 	 * it (issue #723). A Set because a row carries up to 50 of each.
-	 *
-	 * Both lists are capped independently by the engine, so an undeclared code
-	 * past the cap can be absent from `statusesSeen` and go unpainted here. That
-	 * is what `statusesTruncated` discloses; it is not a case this lookup can
-	 * recover.
 	 */
 	const undeclared = new Set(operation.undeclaredSeen);
+	/*
+	 * The two lists are capped independently by the engine, so an undeclared code
+	 * past the seen cap can be absent from `statusesSeen` while `undeclaredSeen`
+	 * still carries it. Painting their union rather than `statusesSeen` alone
+	 * shows every code the row discloses, which is what makes `statusesTruncated`
+	 * - the distinct statuses in neither list - the count of what is *not* shown
+	 * beside it (issue #786). Identical to `statusesSeen` on every row under the
+	 * cap, which is every row in practice.
+	 */
+	const statuses = [...new Set([...operation.statusesSeen, ...undeclared])].sort((a, b) => a - b);
 
 	return (
 		<li className="flex items-baseline justify-between gap-3 text-sm">
@@ -164,7 +169,7 @@ function CoverageRow({ operation }: { operation: RunCoverageOperation }) {
 			</span>
 			<span className="flex shrink-0 items-baseline gap-1.5">
 				{!covered && <span className="text-xs text-muted-foreground">never called</span>}
-				{operation.statusesSeen.map((status) => {
+				{statuses.map((status) => {
 					const isUndeclared = undeclared.has(status);
 					return (
 						<span
@@ -198,15 +203,17 @@ function CoverageRow({ operation }: { operation: RunCoverageOperation }) {
 					);
 				})}
 				{/*
-				 * Dropped by the engine's per-operation cap on the two status
-				 * lists. A list shorter than the count it belongs to, rendered as
-				 * though complete, is the shape the truncation-disclosure
-				 * discipline exists to forbid.
+				 * Statuses this operation answered with that the engine's
+				 * per-operation cap left out of both lists. A list shorter than
+				 * the count it belongs to, rendered as though complete, is the
+				 * shape the truncation-disclosure discipline exists to forbid.
 				 */}
 				{operation.statusesTruncated !== undefined && (
 					<span
 						className="text-xs text-muted-foreground"
-						title={`${operation.statusesTruncated} more not shown - the per-operation status list is capped`}
+						title={`${operation.statusesTruncated} more status${
+							operation.statusesTruncated === 1 ? "" : "es"
+						} observed and not shown - the per-operation status list is capped`}
 					>
 						+{operation.statusesTruncated} more
 					</span>

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -328,7 +328,16 @@ export interface RunCoverageOperation {
 	transportErrors?: number;
 	/** Responses whose status fell outside 100-599. Absent when there were none. */
 	otherStatusResponses?: number;
-	/** Codes dropped from the two lists above by the per-row cap. */
+	/**
+	 * Distinct statuses this operation answered with that appear in *neither*
+	 * list above, dropped by the per-row cap. Absent when both lists are
+	 * complete.
+	 *
+	 * Counted across the two lists together rather than per list (issue #786):
+	 * `undeclaredSeen` repeats codes from `statusesSeen`, so a code past both
+	 * caps would otherwise be counted twice, and a code the undeclared list
+	 * still carries is not hidden at all.
+	 */
 	statusesTruncated?: number;
 }
 

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -492,7 +492,7 @@ zero on almost every one:
 
 | On the row | What it means |
 |---|---|
-| `+N more` | The per-operation status list is capped, and N entries were dropped |
+| `+N more` | The per-operation status list is capped, and N distinct statuses this operation answered with are not among the ones shown |
 | `N off-range` | Responses whose status fell outside 100-599, which no status class describes |
 | `N failed` | Sends that never got a response at all |
 

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -4611,6 +4611,7 @@ the index existed all report no block rather than a contract covered zero of.
 | `declaredResponsesTotal` / `declaredResponsesHit` / `declaredResponseCoveragePct` | Declared status patterns, and how many the run produced |
 | `undeclaredStatusesSeen` | Distinct (operation, status) pairs the document declares nothing for |
 | `operations[]` | Per operation: `sent`, `statusesSeen`, `declaredHit`, `declaredMissed`, `undeclaredSeen`, and `transportErrors` / `otherStatusResponses` / `statusesTruncated` when non-zero |
+| `operations[].statusesTruncated` | Distinct statuses the operation answered with that appear in **neither** list - the two are capped at 50 each and `undeclaredSeen` repeats codes from `statusesSeen`, so this is not the entries the two dropped between them |
 | `transportErrors` / `undeclaredOperationRequests` | Whole-run findings, present only when they happened |
 
 Rows come back **uncovered first** - an operation nothing exercised is the

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -716,7 +716,9 @@ constexpr size_t MAX_OPERATIONS = 2000;
 
 /// Status codes one coverage row may list under `statusesSeen`/`undeclaredSeen`.
 /// A misconfigured target can answer one operation with hundreds of distinct
-/// codes; the row stays readable and says how many it dropped.
+/// codes; the row stays readable and says how many distinct codes it hides -
+/// `statusesTruncated` counts what *neither* list carries, since the two are
+/// capped separately and the undeclared one repeats codes from the other.
 constexpr size_t MAX_STATUSES_PER_OPERATION = 50;
 } // namespace spec_document
 

--- a/engine/src/core/spec_coverage.cpp
+++ b/engine/src/core/spec_coverage.cpp
@@ -65,16 +65,21 @@ bool matches_range (const std::string& pattern, int status) {
     return status >= hundreds * 100 && status < (hundreds + 1) * 100;
 }
 
-/// Serialize at most `MAX_STATUSES_PER_OPERATION` codes, ascending. Whatever is
-/// dropped is added to @p dropped and named by the row, never elided.
-nlohmann::json capped_statuses (const std::set<int>& codes, size_t& dropped) {
+/// Serialize at most `MAX_STATUSES_PER_OPERATION` codes, ascending. Every code
+/// it emits joins @p shown, which is what lets the row name the distinct
+/// statuses it hides rather than the entries the two lists dropped between them
+/// (issue #786): `undeclaredSeen` is a subset of `statusesSeen`, so a counter
+/// shared by the two calls counts a code past both caps twice, and a code the
+/// undeclared list still carries is not hidden at all.
+nlohmann::json capped_statuses (const std::set<int>& codes, std::set<int>& shown) {
     nlohmann::json out = nlohmann::json::array ();
     for (const int code : codes) {
+        // Ascending, so nothing after the cap can be emitted either.
         if (out.size () >= limits::MAX_STATUSES_PER_OPERATION) {
-            ++dropped;
-            continue;
+            break;
         }
         out.push_back (code);
+        shown.insert (code);
     }
     return out;
 }
@@ -358,12 +363,14 @@ size_t undeclared_operation_requests) {
             (hit[p] ? declared_hit : declared_missed).push_back (operation.responses[p]);
         }
 
-        size_t statuses_dropped = 0;
+        // Braced initialization evaluates left to right, so both lists have
+        // filled this by the time the row is read below.
+        std::set<int> statuses_shown;
         nlohmann::json row{ { "method", operation.method }, { "path", operation.path },
             { "sent", seen.sent },
-            { "statusesSeen", capped_statuses (statuses_seen, statuses_dropped) },
+            { "statusesSeen", capped_statuses (statuses_seen, statuses_shown) },
             { "declaredHit", declared_hit }, { "declaredMissed", declared_missed },
-            { "undeclaredSeen", capped_statuses (undeclared, statuses_dropped) } };
+            { "undeclaredSeen", capped_statuses (undeclared, statuses_shown) } };
         // Absent rather than "" for an operation the document gives no id - the
         // same absent-not-empty rule the binding itself follows.
         if (!operation.operation_id.empty ()) {
@@ -377,8 +384,11 @@ size_t undeclared_operation_requests) {
         if (seen.other_status_responses > 0) {
             row["otherStatusResponses"] = seen.other_status_responses;
         }
-        if (statuses_dropped > 0) {
-            row["statusesTruncated"] = statuses_dropped;
+        // Every emitted code is drawn from `statuses_seen` - the undeclared set
+        // is a subset of it - so what neither list carries is one subtraction.
+        const size_t statuses_hidden = statuses_seen.size () - statuses_shown.size ();
+        if (statuses_hidden > 0) {
+            row["statusesTruncated"] = statuses_hidden;
         }
 
         const bool covered = seen.sent > 0;

--- a/engine/tests/spec_coverage_test.cpp
+++ b/engine/tests/spec_coverage_test.cpp
@@ -20,7 +20,15 @@
 
 #include "vayu/core/spec_coverage.hpp"
 
+#include "vayu/core/constants.hpp"
+
 #include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+namespace limits = vayu::core::constants::spec_document;
 
 using vayu::core::build_coverage_payload;
 using vayu::core::CoverageTally;
@@ -229,6 +237,58 @@ TEST (SpecCoverage, FindingsThatDidNotHappenAreAbsentRatherThanZero) {
     EXPECT_FALSE (coverage.contains ("undeclaredOperationRequests"));
     EXPECT_FALSE (row_for (coverage, "/pets").contains ("transportErrors"));
     EXPECT_FALSE (row_for (coverage, "/pets").contains ("statusesTruncated"));
+}
+
+TEST (SpecCoverage, TheTruncationCountIsDistinctStatusesHiddenNotEntriesTwoListsDropped) {
+    // The two lists are capped separately and `undeclaredSeen` repeats codes
+    // from `statusesSeen`, so a code past both caps used to be counted twice and
+    // a code the undeclared list still carries counted as hidden (issue #786).
+    const std::vector<DeclaredOperation> declared{ op ("listPets", "GET", "/pets", { "200" }) };
+    OperationObservation seen;
+    seen.statuses[200] = 1;
+    // 60 undeclared codes above the declared one, so both lists overflow the
+    // cap of 50 and their shown halves are different sets.
+    for (int status = 400; status < 460; ++status) {
+        seen.statuses[status] = 1;
+    }
+    seen.sent = seen.statuses.size ();
+
+    const auto row = row_for (build_coverage_payload (declared, { seen }, 0), "/pets");
+    ASSERT_EQ (row["statusesSeen"].size (), limits::MAX_STATUSES_PER_OPERATION);
+    ASSERT_EQ (row["undeclaredSeen"].size (), limits::MAX_STATUSES_PER_OPERATION);
+
+    // What the row shows, counted the way a reader of the payload sees it:
+    // either list carrying a code is that code disclosed.
+    std::set<int> shown;
+    for (const char* list : { "statusesSeen", "undeclaredSeen" }) {
+        for (const auto& status : row[list]) {
+            shown.insert (status.get<int> ());
+        }
+    }
+    ASSERT_EQ (shown.size (), 51u);
+    // 61 observed, 51 named: the shared counter reported 21 for this row, which
+    // is entries dropped across the two lists rather than statuses hidden.
+    const size_t hidden = row["statusesTruncated"].get<size_t> ();
+    EXPECT_EQ (hidden, seen.statuses.size () - shown.size ());
+    EXPECT_EQ (hidden, 10u);
+}
+
+TEST (SpecCoverage, ACodeOverTheCapInOnlyOneListIsStillCountedOnce) {
+    // Every code declared, so `undeclaredSeen` is empty and only the seen list
+    // truncates - the ordinary shape, which the subtraction must not change.
+    std::vector<std::string> responses;
+    responses.reserve (60);
+    OperationObservation seen;
+    for (int status = 400; status < 460; ++status) {
+        responses.push_back (std::to_string (status));
+        seen.statuses[status] = 1;
+    }
+    seen.sent = seen.statuses.size ();
+    const std::vector<DeclaredOperation> declared{ op ("listPets", "GET", "/pets", responses) };
+
+    const auto row = row_for (build_coverage_payload (declared, { seen }, 0), "/pets");
+    EXPECT_EQ (row["undeclaredSeen"], nlohmann::json::array ());
+    EXPECT_EQ (row["statusesTruncated"].get<size_t> (), 10u);
 }
 
 TEST (SpecCoverage, ADocumentThatDeclaresNothingProducesNoBlockAtAll) {


### PR DESCRIPTION
## Description

`statusesTruncated` on a coverage row counted drops across two lists with one shared counter, so it could exceed the number of statuses actually hidden.

**Plan.** Root cause: `build_coverage_payload` (`engine/src/core/spec_coverage.cpp`) passes one `size_t& dropped` to both `capped_statuses` calls, and `undeclaredSeen` is a **subset** of `statusesSeen` - so a code past both caps increments it twice, and a code the undeclared list still carries increments it while the row is showing that code. The number was "entries dropped across the two lists", which is not something a reader can act on. Approach: drop the counter, have `capped_statuses` record what it *emitted* into a set the two calls share, and report `statuses_seen.size() - shown.size()`. Every emitted code is drawn from the seen set, so the distinct hidden count is one subtraction that cannot double-count, and the doc comment the field already carried becomes true. The alternative the issue offered - a second `undeclaredTruncated` field - is only worth a second number if a reader would act differently on *which* list lost codes; none would, and two counts to render is the drift risk `spec_size_cap`'s "one cap rather than a second knob" note argues against elsewhere.

Verified at `e78e2e5`: the shared-counter code, the field name and the cap (`MAX_STATUSES_PER_OPERATION = 50`) are all still as the issue describes, and `statusesTruncated` is engine-produced with `ContractCoverage` as its only reader (`app/src/types/domain.ts` types it, no other consumer - MCP, CLI and the report route pass the block through verbatim).

## App changes (required, same PR)

Making the count "statuses this row is not showing" makes the renderer's `+N more` a claim it has to keep, so the row now paints the **union** of `statusesSeen` and `undeclaredSeen` rather than `statusesSeen` alone. The two lists are capped independently, so an undeclared code past the seen cap arrives in `undeclaredSeen` only - the component's own comment recorded that as a code it "cannot recover", and it is exactly the code the new count says is shown. The union is identical to `statusesSeen` on every row under the cap, which is every row in practice, so nothing changes for an ordinary run.

- `RunCoverageOperation.statusesTruncated`'s doc comment now says what is counted and why it is counted across the two lists together.
- The `+N more` tooltip reads `N more statuses observed and not shown - the per-operation status list is capped` (singular for 1), so the rendered wording and the field agree.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Engine, full: `python build.py -e -t` then `ctest --preset linux-dev` - **1998 tests, all passing** (2 new). App suite, full: **505 files, 5371 tests, all passing** (3 new). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on every touched file. No pre-existing failures on the base commit. `mkdocs build --strict` was not run - mkdocs is not installed in this environment and both docs edits are table-cell prose, with no link, anchor or nav change.

Mutation-checked (fix reverted, confirmed red, restored):

| Guard | Mutation that turns it red |
|---|---|
| `TheTruncationCountIsDistinctStatusesHiddenNotEntriesTwoListsDropped` - 61 observed statuses, both lists over the cap: the row names 51 and reports 10 hidden | restore the per-list drop arithmetic (reports 21) |
| `paints an undeclared status that only the second list carries` | render `operation.statusesSeen` instead of the union |

Also covered: a row whose codes are all declared truncates in one list only and still reports 10 (the ordinary shape, which the subtraction must not change); the existing absent-not-zero guard still holds for a row under the cap; the singular tooltip at N = 1.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/openapi.md` ("Reading a row" - what `+N more` counts) and `docs/engine/api-reference.md` (a `statusesTruncated` row on the coverage table, stating that it is not the entries the two lists dropped between them). `MAX_STATUSES_PER_OPERATION`'s own comment says the same.

## Related Issues
Closes #786

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHa9z6Wnmy6L3BtZv9G7iH)_