### PR TITLE
feat(engine/app/import): bound POST /import/fetch by a caller-stated maxBytes, behind a transport ceiling

### DIFF
--- a/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
@@ -40,7 +40,7 @@ const syncSpec = vi.fn();
 
 vi.mock("@/services/api", () => ({
 	apiService: {
-		importFetch: (url: string) => importFetch(url),
+		importFetch: (url: string, maxBytes?: number) => importFetch(url, maxBytes),
 		updateRequest,
 		updateCollection,
 		createRequest,
@@ -166,6 +166,10 @@ describe("SpecSync", () => {
 
 		expect(await screen.findByText(/up to date/i)).toBeTruthy();
 		expect(screen.queryByText(/the document has changed/i)).toBeNull();
+		// The re-fetch is spec-only, so it states the document's own live cap as
+		// the fetch's byte bound (issue #784) rather than leaving the engine to
+		// buffer whatever the URL now serves.
+		expect(importFetch).toHaveBeenCalledWith(expect.any(String), 10 * 1024 * 1024);
 	});
 
 	it("states every count, zeros included, when the document has changed", async () => {

--- a/app/src/modules/collections/CollectionDetail/SpecSync.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.tsx
@@ -126,7 +126,9 @@ export default function SpecSync({
 				},
 				{
 					maxBytes,
-					fetchUrl: async (url) => (await apiService.importFetch(url)).content,
+					// Spec-only path, so the fetch carries the document's own
+					// live cap (issue #784).
+					fetchUrl: async (url) => (await apiService.importFetch(url, maxBytes)).content,
 					...(window.electronAPI?.readSpecFile
 						? { readSpecFile: window.electronAPI.readSpecFile }
 						: {}),

--- a/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
@@ -89,7 +89,7 @@ vi.mock("@/queries/runs", () => ({
 
 const importFetch = vi.fn();
 vi.mock("@/services/api", () => ({
-	apiService: { importFetch: (url: string) => importFetch(url) },
+	apiService: { importFetch: (url: string, maxBytes?: number) => importFetch(url, maxBytes) },
 }));
 
 // The bound half of the tab renders the Sync section (issue #654), which reads
@@ -233,6 +233,27 @@ describe("binding a collection that already has requests", () => {
 			path: "/home/u/petstore.json",
 			fileName: "petstore.json",
 		});
+	});
+
+	// Issue #784. This tab only ever fetches a document it is about to bind, so
+	// the fetch carries the cap the engine will store it under - the refusal
+	// then happens while the bytes arrive, rather than after a document the
+	// engine was never going to accept has been buffered whole.
+	it("fetches under the engine's live document cap", async () => {
+		importFetch.mockResolvedValue({ content: OPENAPI });
+		render(<SpecTab collection={collection()} />);
+
+		fireEvent.change(screen.getByPlaceholderText(/openapi.json/i), {
+			target: { value: "https://api.example.com/openapi.json" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
+
+		await waitFor(() =>
+			expect(importFetch).toHaveBeenCalledWith(
+				"https://api.example.com/openapi.json",
+				10 * 1024 * 1024
+			)
+		);
 	});
 
 	it("sends the fetched URL as the document's origin, and remembers no path", async () => {

--- a/app/src/modules/collections/CollectionDetail/SpecTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.tsx
@@ -50,6 +50,7 @@ import {
 	useUpdateCollectionMutation,
 } from "@/queries/collections";
 import { useBindSpecMutation, useSpecQuery } from "@/queries/specs";
+import { useSpecDocumentLimit } from "@/hooks/useSpecDocumentLimit";
 import { useSpecFileStore } from "@/stores";
 import { matchOperations } from "@/services/openapi/operation-match";
 import { readSpecOperations } from "@/services/openapi/spec-operations";
@@ -113,6 +114,10 @@ export default function SpecTab({ collection }: SpecTabProps) {
 	const [url, setUrl] = useState("");
 	const [exporting, setExporting] = useState(false);
 	const [fetching, setFetching] = useState(false);
+	// The bound the fetch below carries: this tab only ever fetches a document
+	// it is about to bind, so it is the same cap the engine will store it under
+	// (issue #784).
+	const { maxBytes: specMaxBytes } = useSpecDocumentLimit();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	// Parsed on every render of a picked document rather than stored in state:
@@ -178,7 +183,7 @@ export default function SpecTab({ collection }: SpecTabProps) {
 		setFetching(true);
 		setPickError(null);
 		try {
-			const { content } = await apiService.importFetch(url);
+			const { content } = await apiService.importFetch(url, specMaxBytes);
 			setPicked({ content, sourceUrl: url });
 		} catch (e) {
 			setPickError((e as Error).message);

--- a/app/src/modules/collections/ImportModal.options.test.tsx
+++ b/app/src/modules/collections/ImportModal.options.test.tsx
@@ -29,7 +29,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const importFetch = vi.fn();
-vi.mock("@/services/api", () => ({ apiService: { importFetch: (u: string) => importFetch(u) } }));
+vi.mock("@/services/api", () => ({
+	apiService: {
+		importFetch: (u: string, maxBytes?: number) => importFetch(u, maxBytes),
+	},
+}));
 
 import { ImportModal } from "./ImportModal";
 import { useImportModalStore } from "@/stores";
@@ -124,5 +128,24 @@ describe("ImportModal URL fetch while in flight", () => {
 
 		release({ content: postman });
 		await waitFor(() => expect(screen.getByText(/Postman Collection v2\.1/i)).toBeVisible());
+	});
+
+	// Issue #784. This box takes any format, and the document it just fetched is
+	// a Postman export - which is never stored as a spec document, so bounding
+	// the fetch by `maxSpecDocumentBytes` would refuse an export that imports
+	// today, naming a setting that does not apply to it. The engine's transport
+	// ceiling is what stands behind this one.
+	it("states no spec bound on a fetch that may be any format", async () => {
+		importFetch.mockResolvedValue({ content: postman });
+
+		renderModal();
+		selectTab(/URL/i);
+		fireEvent.change(screen.getByPlaceholderText(/petstore/i), {
+			target: { value: "https://example.com/collection.json" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /^Fetch$/i }));
+
+		await waitFor(() => expect(screen.getByText(/Postman Collection v2\.1/i)).toBeVisible());
+		expect(importFetch).toHaveBeenCalledWith("https://example.com/collection.json", undefined);
 	});
 });

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -145,7 +145,13 @@ export function ImportModal() {
 			{ importEnvironments, importScripts },
 			{
 				maxBytes: specMaxBytes,
-				fetchUrl: async (target) => (await apiService.importFetch(target)).content,
+				// A `$ref` target is part of the document being bundled, so the
+				// bound is the same one the bundle has to fit - and stating it
+				// moves the refusal to where the bytes arrive, instead of after
+				// a file the engine was never going to store has been buffered
+				// whole (issue #784).
+				fetchUrl: async (target) =>
+					(await apiService.importFetch(target, specMaxBytes)).content,
 				...(readSpecFile
 					? {
 							readSibling: async (specPath, refPath) => {
@@ -252,6 +258,13 @@ export function ImportModal() {
 		if (isFetching) return;
 		setPhase("detecting");
 		try {
+			// No `maxBytes`: this box takes any format, and a Postman or
+			// Insomnia export is never stored as a spec document, so bounding it
+			// by `maxSpecDocumentBytes` would refuse an export that imports
+			// today with a message naming a setting that does not apply to it.
+			// The engine's transport ceiling stands behind the fetch instead
+			// (issue #784), and the bundler's own check still refuses an
+			// over-cap OpenAPI document once the format is known.
 			const { content } = await apiService.importFetch(url);
 			await runBatch([{ text: content, sourceUrl: url }]);
 		} catch (e) {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -702,10 +702,22 @@ export const apiService = {
 	},
 
 	// Import
-	async importFetch(url: string): Promise<ImportFetchResponse> {
+	/**
+	 * Fetch a URL through the engine, past the renderer's CORS.
+	 *
+	 * @param maxBytes the largest response this fetch may read (issue #784).
+	 * The route is one proxy for every import format, so the engine has no
+	 * format to derive a bound from: a caller that knows it is fetching an
+	 * OpenAPI document passes the live `maxSpecDocumentBytes`
+	 * ({@link useSpecDocumentLimit}), and a format-agnostic caller passes
+	 * nothing and gets the engine's transport ceiling - a number no import may
+	 * exceed, deliberately not restated here so the two cannot drift. Over the
+	 * bound is a `413` whose message names it.
+	 */
+	async importFetch(url: string, maxBytes?: number): Promise<ImportFetchResponse> {
 		return await httpClient.post<ImportFetchResponse>(
 			API_ENDPOINTS.IMPORT_FETCH,
-			{ url },
+			maxBytes === undefined ? { url } : { url, maxBytes },
 			{ timeout: proxiedRequestTimeoutMs() }
 		);
 	},

--- a/app/src/services/importers/api-fetch.test.ts
+++ b/app/src/services/importers/api-fetch.test.ts
@@ -24,4 +24,27 @@ describe("apiService.importFetch", () => {
 		);
 		expect(res).toEqual({ content: "{}", contentType: "application/json" });
 	});
+
+	// The bound is the caller's to state (issue #784): the route proxies every
+	// import format, so the engine has none to derive. A caller that knows it is
+	// fetching a spec sends the live `maxSpecDocumentBytes`; one that does not
+	// sends no key at all and gets the engine's transport ceiling - which is why
+	// the field has to be *absent*, not a zero or a null the engine would have
+	// to interpret.
+	it("sends the caller's byte bound when it states one", async () => {
+		vi.mocked(httpClient.post).mockResolvedValue({ content: "{}", contentType: "" });
+		await apiService.importFetch("https://x/spec.json", 10 * 1024 * 1024);
+		expect(httpClient.post).toHaveBeenCalledWith(
+			"/import/fetch",
+			{ url: "https://x/spec.json", maxBytes: 10 * 1024 * 1024 },
+			{ timeout: expect.any(Number) }
+		);
+	});
+
+	it("sends no maxBytes key at all when the caller states no bound", async () => {
+		vi.mocked(httpClient.post).mockResolvedValue({ content: "{}", contentType: "" });
+		await apiService.importFetch("https://x/collection.json");
+		const body = vi.mocked(httpClient.post).mock.calls[0][1];
+		expect(body).not.toHaveProperty("maxBytes");
+	});
 });

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -419,9 +419,18 @@ apiService.updateGlobals(variables): Promise<GlobalVariables>
 #### Import
 
 ```typescript
-apiService.importFetch(url): Promise<ImportFetchResponse>          // POST /import/fetch
+apiService.importFetch(url, maxBytes?): Promise<ImportFetchResponse> // POST /import/fetch
 apiService.applyImport(payload): Promise<ImportApplyResponse>      // POST /import/apply
 ```
+
+`importFetch`'s `maxBytes` is the largest response that fetch may read. The
+engine has no format to derive one from - the route proxies Postman and Insomnia
+exports as well as OpenAPI documents - so the caller states it: the spec paths
+(`$ref` bundling, spec re-fetch, the Spec tab's URL box) pass the live
+`maxSpecDocumentBytes` from `useSpecDocumentLimit`, and the format-agnostic
+import URL box passes nothing, leaving the engine's transport ceiling. Over the
+bound is a `413` whose message names it, raised while the body is arriving
+rather than after it has been buffered whole.
 
 `applyImport` sends a whole parsed import - collections, requests, environments
 and **spec documents** - in one atomic call. Items reference each other by

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1557,10 +1557,30 @@ via libcurl and returns the raw body and content type.
 
 **Request:**
 ```json
-{ "url": "https://example.com/collection.json" }
+{ "url": "https://example.com/collection.json", "maxBytes": 10485760 }
 ```
 
 The `url` must be a string starting with `http://` or `https://`.
+
+**`maxBytes` is the caller's bound on the response, and the caller states it**
+because this route is one proxy for *every* import format - a Postman or
+Insomnia export rides it exactly as an OpenAPI document does. Bounding it by
+`maxSpecDocumentBytes` would refuse a collection that imports today with a
+message naming a setting that governs nothing about it, so the callers that
+*are* fetching a spec (`$ref` bundling and spec re-fetch) pass that live cap
+themselves and the rest pass nothing.
+
+- Absent or `null` means the engine's **transport ceiling**, 256 MiB. So does a
+  larger value: a bound over the ceiling is clamped to it rather than refused,
+  because `maxSpecDocumentBytes` can be raised to 100 MiB and an import the
+  setting allows must not be turned into a `400`.
+- Anything that is not a positive integer - `0`, a negative, a string, a
+  fraction - is a `400`. It is not rounded into a bound the caller did not ask
+  for.
+- The bound is on what is **read**, not on what is returned: the transfer is cut
+  off as soon as the body grows past it, whether the server declared a length or
+  not, so nothing buffers the whole document first. A declared length is what the
+  refusal names as the size.
 
 **Response:** `200`
 ```json
@@ -1579,6 +1599,10 @@ never turn into a `500`.
 - `400` `Invalid JSON body` - the request body did not parse.
 - `400` `Invalid URL` - `url` is missing, not a string, or does
   not start with `http://` / `https://`.
+- `400` `Invalid 'maxBytes': must be a positive integer`.
+- `413` `Refused to fetch: <detail>` - the response was over the bound in force.
+  The detail names the bound that was applied (the clamped one, not the one
+  asked for) and the size when the upstream declared one.
 - `502` `Failed to fetch: <detail>` - the upstream request failed
   (connection error, transport failure).
 

--- a/engine/include/vayu/core/constants.hpp
+++ b/engine/include/vayu/core/constants.hpp
@@ -721,6 +721,29 @@ constexpr size_t MAX_STATUSES_PER_OPERATION = 50;
 } // namespace spec_document
 
 /**
+ * @brief The URL-import proxy's bounds (issue #784).
+ */
+namespace import_fetch {
+/// Bytes `POST /import/fetch` will read from a remote URL when the caller
+/// states no `maxBytes` of its own - and the ceiling a stated one is clamped to.
+///
+/// A transport ceiling, deliberately not the document cap. The route is one
+/// shared proxy for *every* URL import - Postman and Insomnia exports ride it
+/// as well as OpenAPI documents - and a Postman collection is never stored as a
+/// `spec_documents` row, so `maxSpecDocumentBytes` governs nothing about it;
+/// capping the fetch there would refuse a collection that imports today with a
+/// message naming a setting that has nothing to do with it. So the *caller*
+/// states the bound it knows (the spec paths pass the live
+/// `maxSpecDocumentBytes`), and this stands behind it, because a bound the
+/// caller chooses is not a bound against a hostile URL.
+///
+/// Set above the largest `maxSpecDocumentBytes` a user can configure (100 MiB,
+/// the config entry's own maximum) so that raising that setting to its limit
+/// can never be silently narrowed by this one.
+constexpr size_t MAX_BYTES = 256ULL * 1024 * 1024;
+} // namespace import_fetch
+
+/**
  * @brief Response schema validation bounds (issue #628).
  *
  * Every value here bounds what one *response* can make the engine do or store,

--- a/engine/include/vayu/http/client.hpp
+++ b/engine/include/vayu/http/client.hpp
@@ -69,6 +69,24 @@ struct ClientConfig {
      * directly. Read only when `cookie_jar` is set.
      */
     std::vector<CookieWrite> cookie_writes;
+
+    /**
+     * @brief Largest response body this client will buffer, 0 = unbounded
+     *        (issue #784).
+     *
+     * Zero, and therefore unbounded, for every caller that does not set it -
+     * which is what "Design-mode sends are not affected" by
+     * `maxResponseBodyBytes` has always meant, and this must not change it. The
+     * `/import/fetch` proxy sets it, because that route buffers a response from
+     * a URL a user typed with nothing behind it at all.
+     *
+     * Enforced by the write callback, which cuts the transfer short as soon as
+     * the body grows past the bound - whether the server declared a length or
+     * not - and fails it with `ErrorCode::ResponseTooLarge` rather than
+     * buffering to the end. The declared length, when there is one, is what the
+     * error message names as the count.
+     */
+    size_t max_response_bytes = 0;
 };
 
 /**

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -344,7 +344,19 @@ enum class ErrorCode {
     /// because reporting these as `ConnectionFailed` or `InternalError` sent
     /// users debugging an endpoint that was never reached (issue #705).
     /// Appended for the same reason `DataBindingFailed` was.
-    ProxyError
+    ProxyError,
+    /// The response was refused because it was larger than the bound the caller
+    /// set for this transfer (`ClientConfig::max_response_bytes`, issue #784) -
+    /// either the advertised `Content-Length` was already over it, or the body
+    /// grew past it mid-transfer and the write was cut short. Distinct because
+    /// the caller has to answer it differently from a network failure: the
+    /// `/import/fetch` proxy turns this into a `413` naming the bound, where a
+    /// `ConnectionFailed` is a `502`. Appended for the same reason `ProxyError`
+    /// was. The load path's `maxResponseBodyBytes` overrun keeps reporting
+    /// `InternalError`: that number is an engine memory guard rather than a
+    /// bound a client asked for, and it is what every stored load trace already
+    /// carries.
+    ResponseTooLarge
 };
 
 /**
@@ -365,6 +377,7 @@ inline const char* to_string (ErrorCode code) {
     case ErrorCode::InternalError: return "INTERNAL_ERROR";
     case ErrorCode::DataBindingFailed: return "DATA_BINDING_FAILED";
     case ErrorCode::ProxyError: return "PROXY_ERROR";
+    case ErrorCode::ResponseTooLarge: return "RESPONSE_TOO_LARGE";
     }
     return "UNKNOWN";
 }

--- a/engine/src/http/client.cpp
+++ b/engine/src/http/client.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -101,13 +102,99 @@ int debug_callback (CURL* handle, curl_infotype type, char* data, size_t size, v
 }
 
 /**
- * @brief Callback for writing response body
+ * @brief What one transfer buffers, and the bound it may not pass (issue #784).
+ */
+struct BodySink {
+    std::string body;
+    /// Largest body this transfer may buffer, 0 = unbounded - copied from
+    /// `ClientConfig::max_response_bytes`.
+    size_t max_bytes = 0;
+    /// Set by write_callback when it refused to buffer more, so the completion
+    /// can name the bound instead of reporting curl's generic write failure.
+    bool limit_exceeded = false;
+};
+
+/**
+ * @brief Callback for writing response body, bounded by the sink's cap.
+ *
+ * The same short-count refusal the load loop's callback uses
+ * (`curl_callbacks.cpp`): keep the prefix that fits, then hand curl fewer bytes
+ * than it offered, which fails the transfer. That is what makes the bound a
+ * bound on what is *read* rather than a check run after a whole hostile
+ * response has already been buffered.
+ *
+ * Deliberately the only enforcement, rather than a belt to `CURLOPT_MAXFILESIZE`:
+ * curl 8.21 refuses an over-bound `Content-Length` at header time *and* aborts a
+ * length-less transfer that grows past the value, so setting both left whichever
+ * fired first deciding how the failure was reported - and one of the two branches
+ * dead in every case. This one is version-independent and is the idiom the engine
+ * already enforces a body cap with.
  */
 size_t write_callback (char* ptr, size_t size, size_t nmemb, void* userdata) {
-    auto* response_body = static_cast<std::string*> (userdata);
-    size_t total_size   = size * nmemb;
-    response_body->append (ptr, total_size);
+    auto* sink        = static_cast<BodySink*> (userdata);
+    size_t total_size = size * nmemb;
+
+    if (sink->max_bytes > 0) {
+        const size_t remaining =
+        sink->max_bytes - std::min (sink->max_bytes, sink->body.size ());
+        if (total_size > remaining) {
+            sink->body.append (ptr, remaining);
+            sink->limit_exceeded = true;
+            return remaining; // Short count: abort with CURLE_WRITE_ERROR.
+        }
+    }
+
+    sink->body.append (ptr, total_size);
     return total_size;
+}
+
+/**
+ * @brief The size the server declared for this response, if it declared one.
+ *
+ * Read off the headers the header callback already collected rather than from
+ * `CURLINFO_CONTENT_LENGTH_DOWNLOAD_T`: a transfer aborted at the bound never
+ * finished, and libcurl's progress info for one that did not run is `-1`
+ * whether the server declared a length or not. The header block is there
+ * either way, because headers arrive before the first byte of body.
+ */
+std::optional<unsigned long long> declared_content_length (const Headers& headers) {
+    for (const auto& [key, value] : headers) {
+        std::string lower = key;
+        std::transform (lower.begin (), lower.end (), lower.begin (),
+        [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+        if (lower != "content-length") {
+            continue;
+        }
+        try {
+            size_t consumed                   = 0;
+            const unsigned long long declared = std::stoull (value, &consumed);
+            // A trailing-garbage or empty value is no declaration at all; the
+            // caller says so rather than reporting a number the server did not.
+            return consumed == value.size () ? std::optional{ declared } : std::nullopt;
+        } catch (const std::exception&) {
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief Why a bounded transfer was refused, in the terms the caller set it.
+ *
+ * Names the count when there is an honest one to name - the length the server
+ * declared - and says so plainly when there is not, because a body cut off at
+ * the bound is only known to be *at least* that large and reporting the bound
+ * as the size would be a measurement the engine never made.
+ */
+std::string too_large_message (const Headers& headers, size_t max_bytes) {
+    const std::string bound = std::to_string (max_bytes) + " byte limit";
+    const auto declared     = declared_content_length (headers);
+    if (declared && *declared > max_bytes) {
+        return "Response is " + std::to_string (*declared) + " bytes, over the " + bound;
+    }
+    // No claim about the header here: this branch also covers a server whose
+    // declared length was under the bound and whose body was not.
+    return "Response grew past the " + bound + " and the transfer was cut off there";
 }
 
 /**
@@ -331,7 +418,8 @@ Result<Response> Client::send (const Request& request) {
 
     // Response data
     Response response;
-    std::string response_body;
+    BodySink sink;
+    sink.max_bytes = impl_->config.max_response_bytes;
 
     // `request_headers` is the *sent* record and is filled by
     // build_request_header_list below, from the very appends that build the
@@ -360,7 +448,7 @@ Result<Response> Client::send (const Request& request) {
 
     // Set callbacks
     curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, write_callback);
-    curl_easy_setopt (curl, CURLOPT_WRITEDATA, &response_body);
+    curl_easy_setopt (curl, CURLOPT_WRITEDATA, &sink);
     curl_easy_setopt (curl, CURLOPT_HEADERFUNCTION, header_callback);
     curl_easy_setopt (curl, CURLOPT_HEADERDATA, &response);
 
@@ -479,8 +567,15 @@ Result<Response> Client::send (const Request& request) {
 
     // Check for errors
     if (res != CURLE_OK) {
-        // Convert curl error to ErrorCode and message
-        Error error = detail::curl_to_error (curl, res, impl_->error_buffer);
+        // A refused body is not a network failure, and curl's own word for it
+        // says nothing a caller can act on: the write callback's short count
+        // surfaces as a generic CURLE_WRITE_ERROR. So it is recognized here and
+        // reported as the condition it is, which `/import/fetch` answers with a
+        // 413 rather than a 502.
+        Error error = sink.limit_exceeded ?
+        Error{ ErrorCode::ResponseTooLarge,
+            too_large_message (response.headers, sink.max_bytes) } :
+        detail::curl_to_error (curl, res, impl_->error_buffer);
 
         // Return Response object with error details (Postman-compatible approach)
         response.status_code = 0; // 0 indicates client-side error (no server response)
@@ -507,7 +602,7 @@ Result<Response> Client::send (const Request& request) {
     response.error_code = ErrorCode::None; // Explicitly set to None for successful requests
 
     // Set body
-    response.body      = std::move (response_body);
+    response.body      = std::move (sink.body);
     response.body_size = response.body.size ();
 
     return response;

--- a/engine/src/http/routes/import.cpp
+++ b/engine/src/http/routes/import.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -31,7 +32,18 @@
 namespace vayu::http::routes {
 
 /**
- * Fetch the URL in `request_body` ({"url": "..."}) via libcurl.
+ * Fetch the URL in `request_body` ({"url": "...", "maxBytes": 12345}) via libcurl.
+ *
+ * The caller states the bound (issue #784). This route is one shared proxy for
+ * every URL import - a Postman or Insomnia export comes through it exactly as an
+ * OpenAPI document does - so it has no format to derive a cap from, and
+ * `maxSpecDocumentBytes` governs nothing about an export that is never stored as
+ * a `spec_documents` row. The callers that *are* fetching a spec pass that live
+ * cap themselves; a stated bound over
+ * `constants::import_fetch::MAX_BYTES` is clamped to it, and an absent one is
+ * that ceiling, because a bound the caller chooses is not a bound against a
+ * hostile URL. An over-bound response is a `413` naming what was refused,
+ * without the whole body ever being buffered - see `ClientConfig::max_response_bytes`.
  *
  * @param transport How to reach the network. Passed in rather than resolved
  *                  here because this function is deliberately `Database`-free
@@ -59,8 +71,24 @@ const vayu::http::TransportPolicy& transport) {
         return { 400, error_body (400, "Invalid URL") };
     }
 
+    // The caller's bound, clamped to the transport ceiling. Absent or null is
+    // the ceiling; anything that is not a positive integer is refused rather
+    // than rounded into one, because a client that sent `0` or `-1` meant
+    // something, and guessing which would be the silent bound this whole change
+    // exists to remove.
+    size_t max_bytes = vayu::core::constants::import_fetch::MAX_BYTES;
+    if (req.contains ("maxBytes") && !req["maxBytes"].is_null ()) {
+        const auto& stated = req["maxBytes"];
+        if (!stated.is_number_unsigned () || stated.get<uint64_t> () == 0) {
+            return { 400, error_body (400, "Invalid 'maxBytes': must be a positive integer") };
+        }
+        max_bytes = static_cast<size_t> (
+        std::min (stated.get<uint64_t> (), static_cast<uint64_t> (max_bytes)));
+    }
+
     vayu::http::ClientConfig client_config;
-    client_config.transport = transport;
+    client_config.transport          = transport;
+    client_config.max_response_bytes = max_bytes;
     vayu::http::Client client (client_config);
     auto result = client.get (url);
     if (!result.is_ok ()) {
@@ -68,6 +96,13 @@ const vayu::http::TransportPolicy& transport) {
     }
 
     const auto& resp = result.value ();
+    if (resp.error_code == ErrorCode::ResponseTooLarge) {
+        // Not a 502: the upstream answered fine, this engine refused what it
+        // was answering with. The message carries the bound that was applied -
+        // the clamped one, not the one the caller asked for - so a client whose
+        // request was narrowed reads the number that actually stopped it.
+        return { 413, error_body (413, "Refused to fetch: " + resp.error_message) };
+    }
     if (resp.has_error ()) {
         const std::string detail =
         resp.error_message.empty () ? "connection error" : resp.error_message;
@@ -759,6 +794,16 @@ import_apply_response (vayu::db::Database& db, const nlohmann::json& body) {
 }
 
 void register_import_routes (RouteContext& ctx) {
+    /**
+     * POST /import/fetch
+     * Fetches a remote collection or spec past the renderer's CORS, for every
+     * import format alike.
+     * Body params: url (required, http/https), maxBytes (optional - the largest
+     * response this fetch may read, clamped to the engine's transport ceiling;
+     * absent means that ceiling).
+     * Returns: 200 `{"content", "contentType"}`, 400 on a bad url or maxBytes,
+     * 413 when the response is over the bound, 502 when the fetch itself failed.
+     */
     ctx.server.Post ("/import/fetch",
     [&ctx] (const httplib::Request& req, httplib::Response& res) {
         vayu::utils::log_info ("POST /import/fetch");

--- a/engine/tests/import_route_test.cpp
+++ b/engine/tests/import_route_test.cpp
@@ -6,13 +6,16 @@
 #include <gtest/gtest.h>
 #include <httplib.h>
 
+#include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <string>
 #include <thread>
 #include <utility>
 
 #include <nlohmann/json.hpp>
 
+#include "vayu/core/constants.hpp"
 #include "vayu/http/transport_policy.hpp"
 
 namespace vayu::http::routes {
@@ -23,15 +26,43 @@ const vayu::http::TransportPolicy& transport);
 
 namespace {
 
+/// One chunk of the chunked endpoint, and how many of them it has to hand out.
+/// Large enough that a transfer cut off at a 1 KiB bound cannot have been asked
+/// for anything close to all of them - which is how `served()` proves the
+/// refusal happened while the bytes were arriving.
+constexpr size_t CHUNK_BYTES         = 1024;
+constexpr size_t CHUNKED_TOTAL_BYTES = 4 * 1024 * 1024;
+
 class MockSpecServer {
     public:
-    MockSpecServer () {
+    /// @param large_bytes size of the `/large` body, which is served with a
+    ///        `Content-Length` - the header-time half of the bound.
+    explicit MockSpecServer (size_t large_bytes = 64 * 1024) {
         svr_.Get ("/spec.json", [] (const httplib::Request&, httplib::Response& res) {
             res.set_content (R"({"openapi":"3.0.0"})", "application/json");
         });
         svr_.Get ("/missing", [] (const httplib::Request&, httplib::Response& res) {
             res.status = 404;
             res.set_content (R"({"error":"not found"})", "application/json");
+        });
+        svr_.Get ("/large", [large_bytes] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (std::string (large_bytes, 'x'), "application/octet-stream");
+        });
+        // No Content-Length at all, so only the write callback can stop it.
+        svr_.Get ("/chunked", [this] (const httplib::Request&, httplib::Response& res) {
+            res.set_chunked_content_provider ("application/octet-stream",
+            [this] (size_t offset, httplib::DataSink& sink) {
+                if (offset >= CHUNKED_TOTAL_BYTES) {
+                    sink.done ();
+                    return true;
+                }
+                const std::string chunk (CHUNK_BYTES, 'y');
+                if (!sink.write (chunk.data (), chunk.size ())) {
+                    return false;
+                }
+                served_.store (offset + chunk.size ());
+                return true;
+            });
         });
         port_   = svr_.bind_to_any_port ("127.0.0.1");
         thread_ = std::thread ([this] { svr_.listen_after_bind (); });
@@ -46,12 +77,28 @@ class MockSpecServer {
     int port () const {
         return port_;
     }
+    /// Bytes the chunked endpoint got as far as handing to the socket.
+    size_t served () const {
+        return served_.load ();
+    }
+    std::string url (const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string (port_) + path;
+    }
 
     private:
     httplib::Server svr_;
     int port_ = 0;
     std::thread thread_;
+    std::atomic<size_t> served_{ 0 };
 };
+
+/// The request body for one fetch, with or without a stated bound.
+std::string fetch_body (const std::string& url) {
+    return nlohmann::json{ { "url", url } }.dump ();
+}
+std::string fetch_body (const std::string& url, uint64_t max_bytes) {
+    return nlohmann::json{ { "url", url }, { "maxBytes", max_bytes } }.dump ();
+}
 
 TEST (ImportFetch, RejectsInvalidJson) {
     auto [status, body] = vayu::http::routes::import_fetch (
@@ -91,6 +138,107 @@ TEST (ImportFetch, ProxiesNon2xxRemoteResponse) {
     vayu::http::routes::import_fetch (body, vayu::http::TransportPolicy{});
     EXPECT_EQ (status, 200); // transport OK → proxied through, not 502
     EXPECT_EQ (json["content"].get<std::string> (), R"({"error":"not found"})");
+}
+
+// ---------------------------------------------------------------------------
+// The caller-stated byte bound (issue #784)
+// ---------------------------------------------------------------------------
+
+TEST (ImportFetchBound, RefusesAnAdvertisedLengthOverTheStatedBound) {
+    MockSpecServer mock;
+    const auto [status, body] = vayu::http::routes::import_fetch (
+    fetch_body (mock.url ("/large"), 1024), vayu::http::TransportPolicy{});
+
+    // 413, not 502: the upstream answered, this engine refused the answer.
+    EXPECT_EQ (status, 413);
+    const std::string message = body["error"]["message"].get<std::string> ();
+    // Both numbers, because either alone leaves the reader guessing what to do:
+    // the count says how far over it is, the bound says what to raise.
+    EXPECT_NE (message.find (std::to_string (64 * 1024)), std::string::npos) << message;
+    EXPECT_NE (message.find ("1024"), std::string::npos) << message;
+}
+
+TEST (ImportFetchBound, CutsOffAChunkedResponseThatGrowsPastTheBound) {
+    // No Content-Length, so nothing can be refused at header time - the body
+    // has to be stopped while it arrives. That is the half of the fix that
+    // makes the bound a bound on what is *read*, so the assertion is not only
+    // the status: the server must never have been asked for the whole 4 MiB.
+    MockSpecServer mock;
+    const auto [status, body] = vayu::http::routes::import_fetch (
+    fetch_body (mock.url ("/chunked"), CHUNK_BYTES), vayu::http::TransportPolicy{});
+
+    EXPECT_EQ (status, 413);
+    EXPECT_NE (body["error"]["message"].get<std::string> ().find (std::to_string (CHUNK_BYTES)),
+    std::string::npos);
+    EXPECT_LT (mock.served (), CHUNKED_TOTAL_BYTES / 2);
+}
+
+TEST (ImportFetchBound, AcceptsAResponseExactlyAtTheBound) {
+    // The bound is inclusive on both halves of the check - a document of
+    // exactly `maxSpecDocumentBytes` is one the engine will store, so refusing
+    // to fetch it would be the renderer and the engine disagreeing by one byte.
+    MockSpecServer mock (4096);
+    const auto [status, json] = vayu::http::routes::import_fetch (
+    fetch_body (mock.url ("/large"), 4096), vayu::http::TransportPolicy{});
+
+    EXPECT_EQ (status, 200);
+    EXPECT_EQ (json["content"].get<std::string> ().size (), 4096u);
+}
+
+TEST (ImportFetchBound, FetchesAnExportLargerThanTheSpecCapWhenNoBoundIsStated) {
+    // The regression this shape exists to avoid: `/import/fetch` is one proxy
+    // for every format, and a Postman or Insomnia export is never stored as a
+    // spec document - so the default bound must not be `maxSpecDocumentBytes`.
+    const size_t over_spec_cap = vayu::core::constants::spec_document::MAX_BYTES + 1;
+    MockSpecServer mock (over_spec_cap);
+    const auto [status, json] = vayu::http::routes::import_fetch (
+    fetch_body (mock.url ("/large")), vayu::http::TransportPolicy{});
+
+    EXPECT_EQ (status, 200);
+    EXPECT_EQ (json["content"].get<std::string> ().size (), over_spec_cap);
+}
+
+TEST (ImportFetchBound, RejectsAMaxBytesThatIsNotAPositiveInteger) {
+    MockSpecServer mock;
+    for (const auto& stated : { nlohmann::json (0), nlohmann::json (-1),
+         nlohmann::json ("1024"), nlohmann::json (1024.5) }) {
+        nlohmann::json body = { { "url", mock.url ("/spec.json") }, { "maxBytes", stated } };
+        const auto [status, response] = vayu::http::routes::import_fetch (
+        body.dump (), vayu::http::TransportPolicy{});
+        EXPECT_EQ (status, 400) << stated.dump ();
+        EXPECT_NE (
+        response["error"]["message"].get<std::string> ().find ("maxBytes"),
+        std::string::npos);
+    }
+}
+
+TEST (ImportFetchBound, AbsentAndNullMaxBytesBothMeanTheCeiling) {
+    MockSpecServer mock;
+    nlohmann::json with_null = { { "url", mock.url ("/spec.json") }, { "maxBytes", nullptr } };
+    const auto [status, json] = vayu::http::routes::import_fetch (
+    with_null.dump (), vayu::http::TransportPolicy{});
+
+    EXPECT_EQ (status, 200);
+    EXPECT_EQ (json["content"].get<std::string> (), R"({"openapi":"3.0.0"})");
+}
+
+TEST (ImportFetchBound, AStatedBoundOverTheCeilingIsClampedRatherThanRefused) {
+    // A user may raise `maxSpecDocumentBytes` to its own maximum, and the spec
+    // paths pass that number straight through. Asking for more than the engine
+    // allows is answered by the ceiling, not by a 400 that would break an
+    // import the setting explicitly permits.
+    static_assert (vayu::core::constants::import_fetch::MAX_BYTES > 100 * 1024 * 1024,
+    "the transport ceiling must sit above the largest configurable "
+    "maxSpecDocumentBytes");
+
+    MockSpecServer mock;
+    const auto [status, json] = vayu::http::routes::import_fetch (
+    fetch_body (mock.url ("/spec.json"),
+    static_cast<uint64_t> (vayu::core::constants::import_fetch::MAX_BYTES) + 1),
+    vayu::http::TransportPolicy{});
+
+    EXPECT_EQ (status, 200);
+    EXPECT_EQ (json["content"].get<std::string> (), R"({"openapi":"3.0.0"})");
 }
 
 } // namespace


### PR DESCRIPTION
## Description

`POST /import/fetch` fetched a URL and returned `resp.body` whole, with no size bound anywhere on the path, so a URL serving gigabytes was buffered in full before anything looked at it.

**Plan.** Root cause: `import_fetch` (`engine/src/http/routes/import.cpp`) has no cap value to read - it is deliberately `Database`-free - and the obvious belt, `spec_size_cap(db)`, is wrong for it: the route is **one shared proxy for every URL import**, Postman and Insomnia exports included, and an export is never stored as a `spec_documents` row, so `maxSpecDocumentBytes` governs nothing about it. Approach: the caller states the bound it knows (`maxBytes`), the engine enforces it on what is *read*, and a transport ceiling stands behind it - because a bound the caller chooses is not a bound against a hostile URL. The alternative the issue names, a second byte knob in `config`, is what `spec_size_cap`'s own "one cap rather than a second knob" note argues against; a settable ceiling would be a third limit to drift, and no user has a reason to tune it.

Verified against the live code at `7cabbf1`: the route still returns the body unbounded, `spec_size_cap` is still `maxSpecDocumentBytes`, `ImportModal.handleFetchUrl` still sends every format through this route, and `import_fetch` is still declared locally in `import_route_test.cpp` and `transport_policy_test.cpp` - the signature is unchanged here (the bound rides in the body), so neither declaration had to move.

### Engine

- **`maxBytes` on the request.** Absent or `null` means the transport ceiling, `constants::import_fetch::MAX_BYTES` (256 MiB, chosen above the largest `maxSpecDocumentBytes` a user can configure - the config entry's own maximum is 100 MiB). A **larger** value is clamped to the ceiling rather than refused, so raising that setting to its limit can never turn into a `400`; the refusal message names the bound that was actually applied. Anything that is not a positive integer (`0`, negative, string, fraction) is a `400` - not rounded into a bound the caller did not ask for.
- **`ClientConfig::max_response_bytes`** bounds what one synchronous transfer buffers, `0` = unbounded, which is every existing caller - design sends keep being unaffected by any byte cap, as `maxResponseBodyBytes`' own documentation says. Enforced by the write callback's short-count refusal, the idiom `curl_callbacks.cpp` already enforces the load cap with, so the transfer is **cut off while the body arrives** rather than checked after it has been buffered whole.
- **One enforcement, not two.** `CURLOPT_MAXFILESIZE_LARGE` was implemented first as the header-time half. Mutation-checking showed curl 8.21 covers *both* halves on its own - removing either one left every test green - which means keeping both leaves whichever fires first deciding how the failure is reported, and one branch dead in every case. The write callback is the one kept: version-independent, and the pattern the engine already uses.
- **`ErrorCode::ResponseTooLarge`**, appended (so no stored numeric code moves), answered by the route with a `413` naming the bound and, when the server declared one, the size. The load path's `maxResponseBodyBytes` overrun deliberately keeps reporting `InternalError` - that number is an engine memory guard rather than a bound a client asked for, and it is what every stored load trace already carries.

### App changes (required, same PR)

`apiService.importFetch(url, maxBytes?)`, and each call site passes what it actually knows:

- `$ref` bundling (`ImportModal`), spec re-fetch (`SpecSync`) and the Spec tab's URL box (`SpecTab`) pass the live `maxSpecDocumentBytes` from `useSpecDocumentLimit`. For the bundler this also moves the per-file refusal to where the bytes arrive, instead of after a file the engine was never going to store has been buffered.
- The **import URL box** passes nothing: it takes any format, and bounding it by the spec cap would refuse an export that imports today with a message naming a setting that does not apply to it. It gets the engine's ceiling. The number is deliberately *not* restated app-side, for the reason `useSpecDocumentLimit` reads its cap from the engine rather than hard-coding it.

Where a refusal surfaces: the import URL box and the Spec tab render the engine's `413` message directly; a `$ref` that is refused stays a counted **unresolved ref**, which is the bundler's existing documented behaviour ("unreachable, refused by a gate, or over the engine's own cap") and is deliberately unchanged - making one ref fatal would be a different decision from the one that module already records.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Engine, full suite: `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` - **2003 tests, all passing** (7 new). App suite, full: **505 files, 5403 tests, all passing** (5 new). `pnpm type-check` clean, `pnpm lint` clean (zero warnings), `prettier --check` clean on every touched file, `git clang-format` clean on the changed C++ lines. No pre-existing failures on the base commit. clang-tidy could not run locally (the environment has 18.1.3; `engine/.clang-tidy` needs >= 19) - CI lints it.

Mutation-checked (fix reverted, confirmed red, restored):

| Guard | Mutation that turns it red |
|---|---|
| `RefusesAnAdvertisedLengthOverTheStatedBound`, `CutsOffAChunkedResponseThatGrowsPastTheBound` | drop the write-callback bound, or stop setting `max_response_bytes` on the route's client |
| `FetchesAnExportLargerThanTheSpecCapWhenNoBoundIsStated` | make the default bound `spec_document::MAX_BYTES` - the exact regression this shape exists to avoid |
| `fetches under the engine's live document cap` (SpecTab), `reports up to date …` (SpecSync) | drop the `maxBytes` argument at that call site |
| `states no spec bound on a fetch that may be any format` (ImportModal) | pass the spec cap on the format-agnostic path |
| `sends no maxBytes key at all when the caller states no bound` | always send the key |

The chunked test asserts more than the status: the mock server records how far it got, and the assertion is that it was never asked for half of its 4 MiB - which is what proves the refusal happened while the bytes were arriving, not after. Also covered: a body exactly at the bound is accepted (the bound is inclusive, so the fetch and `POST /specs` cannot disagree by one byte), `null` means the ceiling, and an over-ceiling ask is clamped rather than refused.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/engine/api-reference.md` (`maxBytes`, the clamp, the `400` and the `413` on `POST /import/fetch`) and `docs/app/api-integration.md` (the new signature and which call sites state a bound). `mkdocs build --strict` was not run - mkdocs is not installed here and neither edit adds a link, anchor or nav entry.

## Related Issues
Closes #784

---
_Generated by [Claude Code](https://claude.ai/code/session_019sZ4uq6vxyop88euPMCWbQ)_