### PR TITLE
fix(engine/app): name every row-binding surface, and say which tests failed on a smoke row

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -1194,6 +1194,107 @@ describe("run_collection_smoke", () => {
 	});
 
 	/**
+	 * The schema verdict above explains itself on the row; a test failure did
+	 * not (issue #733) - `ok:false` beside a 200 named no reason, and an agent
+	 * had no way to reach the detail the tool had already been handed. Passing
+	 * assertions ride the row too: "2 tests, none failed" is the evidence that
+	 * a request judged `ok` was judged against something.
+	 */
+	test("a request that failed on its tests says which tests failed", async () => {
+		const client = fakeClient({
+			listRequests: vi.fn().mockResolvedValue([
+				{ id: "r1", name: "asserts and passes" },
+				{ id: "r2", name: "asserts and fails" },
+				{ id: "r3", name: "asserts nothing" },
+			]),
+			composeRequest: vi
+				.fn()
+				.mockResolvedValue({ method: "GET", url: "https://api.example.com/ok" }),
+			executeRequest: vi
+				.fn()
+				.mockResolvedValueOnce({
+					status: 200,
+					testResults: [
+						{ name: "status is 200", passed: true },
+						{ name: "body has id", passed: true },
+					],
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					testResults: [
+						{ name: "status is 200", passed: true },
+						{
+							name: "body has id",
+							passed: false,
+							error: "expected undefined to be a number",
+						},
+					],
+				})
+				.mockResolvedValueOnce({ status: 200, testResults: [] }),
+		});
+		const res = await dispatchTool(
+			"run_collection_smoke",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		const summary = res.structuredContent as {
+			passed: number;
+			failed: number;
+			results: Array<{
+				ok: boolean;
+				tests?: { total: number; failed: number; failures?: string[] };
+			}>;
+		};
+		expect(summary).toMatchObject({ passed: 2, failed: 1 });
+		expect(summary.results[0]).toMatchObject({ ok: true, tests: { total: 2, failed: 0 } });
+		expect(summary.results[0].tests?.failures).toBeUndefined();
+		// The row a `ok:false` with a 200 status would otherwise leave unexplained.
+		expect(summary.results[1].ok).toBe(false);
+		expect(summary.results[1].tests).toMatchObject({ total: 2, failed: 1 });
+		expect(summary.results[1].tests?.failures).toEqual([
+			"body has id: expected undefined to be a number",
+		]);
+		// No assertions ran at all is not "everything passed", so the node is
+		// absent rather than a zero the agent would read as a verdict.
+		expect(summary.results[2]).toMatchObject({ ok: true });
+		expect(summary.results[2].tests).toBeUndefined();
+	});
+
+	/**
+	 * Nothing caps `testResults` upstream, so a script writing hundreds of
+	 * failing assertions would otherwise put all of them on one row of a matrix
+	 * that already carries a row per request. `failed` stays the true count, so
+	 * a cut list is visible as one.
+	 */
+	test("a row's failed-test list is capped, and the count still reports the total", async () => {
+		const testResults = Array.from({ length: 25 }, (_, i) => ({
+			name: `check ${i}`,
+			passed: false,
+			error: "nope",
+		}));
+		const client = fakeClient({
+			listRequests: vi.fn().mockResolvedValue([{ id: "r1", name: "noisy" }]),
+			composeRequest: vi
+				.fn()
+				.mockResolvedValue({ method: "GET", url: "https://api.example.com/ok" }),
+			executeRequest: vi.fn().mockResolvedValue({ status: 200, testResults }),
+		});
+		const res = await dispatchTool(
+			"run_collection_smoke",
+			{ collectionId: "c1" },
+			ctxWith(client, { allowlist: ["api.example.com"] })
+		);
+		const row = (
+			res.structuredContent as {
+				results: Array<{ tests?: { total: number; failed: number; failures?: string[] } }>;
+			}
+		).results[0];
+		expect(row.tests).toMatchObject({ total: 25, failed: 25 });
+		expect(row.tests?.failures).toHaveLength(10);
+		expect(row.tests?.failures?.[0]).toBe("check 0: nope");
+	});
+
+	/**
 	 * The gate, made switchable (issue #720). Both directions in one test on the
 	 * same fixture, because the pair is the claim: the argument has to change
 	 * the verdict *and* leave the row's evidence alone. Absent is the on state -

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1544,9 +1544,62 @@ const smokeResultSchema = z.object({
 					failures: z.array(z.string()).optional(),
 				})
 				.optional(),
+			/*
+			 * What this request's own post-request script asserted (issue #733).
+			 * A schema verdict explains itself on the row; a test failure did
+			 * not - `ok:false` beside `statusCode: 200` named no reason at all,
+			 * while the detail sat in the `/execute` body this tool had just
+			 * read. Absent when the response carried no test results, which is
+			 * not the same as every assertion passing.
+			 */
+			tests: z
+				.object({
+					total: z.number(),
+					failed: z.number(),
+					failures: z.array(z.string()).optional(),
+				})
+				.optional(),
 		})
 	),
 });
+
+/**
+ * How many failed-test names one smoke row carries.
+ *
+ * Ten, the number the engine caps a schema verdict's `failures` at
+ * (`constants::schema_validation::MAX_FAILURES`), because the two lists ride
+ * the same row and are read the same way. Nothing caps `testResults` upstream -
+ * a script may write as many assertions as it likes - so the cap has to be
+ * here, and `failed` stays the true total so a cut list is visible as one.
+ */
+const MAX_TEST_FAILURES_PER_ROW = 10;
+
+/**
+ * The post-request script's assertions, flattened for a tool result (#733).
+ *
+ * Rendered `name: message` for the reason the schema failures are: an agent
+ * reads this as text. `undefined` means the response carried no test results at
+ * all - the one state that must not become `{total: 0, failed: 0}`, which would
+ * say the script asserted nothing and everything held, when no script ran.
+ */
+function readTestVerdict(
+	resp: Record<string, unknown>
+): { total: number; failed: number; failures?: string[] } | undefined {
+	if (!Array.isArray(resp.testResults)) return undefined;
+	const tests = resp.testResults as Array<{ name?: unknown; passed?: unknown; error?: unknown }>;
+	if (tests.length === 0) return undefined;
+	const failed = tests.filter((t) => t.passed === false);
+	const failures = failed.slice(0, MAX_TEST_FAILURES_PER_ROW).map((t) => {
+		const name = typeof t.name === "string" && t.name ? t.name : "(unnamed test)";
+		const message = typeof t.error === "string" ? t.error.trim() : "";
+		return message ? `${name}: ${message}` : name;
+	});
+	return {
+		total: tests.length,
+		failed: failed.length,
+		...(failures.length > 0 ? { failures } : {}),
+	};
+}
 
 /**
  * The schema verdict a `POST /execute` body carries, flattened for a tool
@@ -3141,7 +3194,7 @@ export const TOOLS: McpTool[] = [
 		category: "execute",
 		invalidates: ["run", "cookie"],
 		description:
-			"Execute a collection's own saved requests once each and return a pass/fail matrix (a request passes on a 2xx/3xx status with all its tests passing and, when the collection is bound to an OpenAPI document, a response matching the schema that document declares - a response the document declares no schema for is reported as unchecked and never fails the request; pass failOnSchemaError: false to keep that verdict on every row without letting it decide pass/fail). Scope is the collection's DIRECT requests: nested sub-collections are not run, and the result discloses how many were left out - call this tool on each of them to cover them. Requests run one at a time, so a large collection takes as long as its requests do added together. Each request is composed exactly as the app would send it: {{variables}} resolved (environment > collection chain > globals), the request's stored auth applied (inheriting from the collection chain, incl. OAuth2), and its collection-chain + own pre/post scripts run. Each request's resolved host must be on the allowlist; requests whose host still cannot be verified (e.g. a variable did not resolve and allow-all is off) are skipped. Sends real traffic but does not modify Vayu data.",
+			"Execute a collection's own saved requests once each and return a pass/fail matrix (a request passes on a 2xx/3xx status with all its tests passing and, when the collection is bound to an OpenAPI document, a response matching the schema that document declares - a response the document declares no schema for is reported as unchecked and never fails the request; pass failOnSchemaError: false to keep that verdict on every row without letting it decide pass/fail). A row whose request ran assertions carries `tests` - `total`, `failed`, and the failing `name: message` lines (at most 10; `failed` is the true count) - so a request that failed on its tests says which, not just ok:false. Scope is the collection's DIRECT requests: nested sub-collections are not run, and the result discloses how many were left out - call this tool on each of them to cover them. Requests run one at a time, so a large collection takes as long as its requests do added together. Each request is composed exactly as the app would send it: {{variables}} resolved (environment > collection chain > globals), the request's stored auth applied (inheriting from the collection chain, incl. OAuth2), and its collection-chain + own pre/post scripts run. Each request's resolved host must be on the allowlist; requests whose host still cannot be verified (e.g. a variable did not resolve and allow-all is off) are skipped. Sends real traffic but does not modify Vayu data.",
 		annotations: {
 			title: "Run collection smoke test",
 			readOnlyHint: false,
@@ -3239,11 +3292,12 @@ export const TOOLS: McpTool[] = [
 							: typeof resp.statusCode === "number"
 								? resp.statusCode
 								: 0;
-					const testsOk = Array.isArray(resp.testResults)
-						? (resp.testResults as Array<{ passed?: boolean }>).every(
-								(t) => t.passed !== false
-							)
-						: true;
+					// One reading of the assertions decides `ok` *and* rides the
+					// row (issue #733): a row that fails on tests has to be able
+					// to say which, and a second walk here could disagree with
+					// the list the agent is shown.
+					const tests = readTestVerdict(resp);
+					const testsOk = !tests || tests.failed === 0;
 					// The contract's own verdict, folded in the way `testResults`
 					// folds (issue #681): a response the document declares a
 					// schema for and that does not match it is a failed request.
@@ -3265,6 +3319,7 @@ export const TOOLS: McpTool[] = [
 						ok,
 						statusCode: code,
 						...(schema ? { schema } : {}),
+						...(tests ? { tests } : {}),
 					});
 					if (ok) passed++;
 					else failed++;

--- a/docs/app/pm-api-compatibility.md
+++ b/docs/app/pm-api-compatibility.md
@@ -38,7 +38,7 @@ intent is that the most common Postman scripts paste in and run unchanged.
 | Crypto              | `pm.crypto.sha256(data, encoding?)`, `.hmacSha256(key, data, encoding?)` - synchronous, see below |
 | Send from script    | `pm.sendRequest(urlOrOptions, callback)` - synchronous, callback only, refused for agent-started runs, see below |
 | Flow control        | `pm.execution.setNextRequest(name \| null)`, `.skipRequest()` - collection runs only, see below |
-| Data rows           | `pm.iterationData.get(name)`, `.has(name)`, `.toObject()` - read-only, a data-driven collection run or a send-with-row, see below |
+| Data rows           | `pm.iterationData.get(name)`, `.has(name)`, `.toObject()` - read-only, a data-driven collection run, a send-with-row, or a scenario load run's deferred per-step script, see below |
 | Base64              | `btoa(binaryString)`, `atob(base64)` - globals, standard web semantics           |
 | Console             | `console.log/info/warn/error`                                                    |
 
@@ -475,6 +475,12 @@ A **single send** can bind one row as well: the request builder's Send-with-row
 caret and MCP's `run_request` both take one row on `POST /execute`, which is
 what makes a script that reads `pm.iterationData` testable without starting a
 run. `pm.info.iteration` is then `0` of `1` - the send is row 0 of 1.
+
+A **scenario load run's deferred per-step script** reads one too: the sampled
+response carries the row its iteration was bound to. Those three - a
+data-driven collection run, a send-with-row, and that deferred script - are
+every surface that binds a row, and they are what a stashed
+`pm.iterationData` names when it refuses a later call.
 
 Divergences from Postman:
 

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -351,6 +351,12 @@ Notes:
 - **`run_collection_smoke`** runs each saved request once and returns a structured
   pass/fail matrix (2xx–3xx status + all tests passing = pass). Each request is
   composed exactly as the app's **Send** would (see *Request composition* below).
+  A request whose scripts asserted anything carries a `tests` node - `total`,
+  `failed`, and the failing `name: message` lines (issue #733) - so a row that
+  fails on its tests says which, rather than leaving an agent with `ok: false`
+  beside a `200`. The list is cut at ten, the number the engine caps a schema
+  verdict's failures at, while `failed` stays the true count. A response that
+  ran no assertions carries no `tests` node: none ran is not all passed.
   For a collection **bound to an OpenAPI document** each row also carries a
   `schema` verdict (issue #681) and folds it into `ok` the way `testResults`
   folds: a response the document declares a schema for and that does not match

--- a/engine/src/runtime/script_engine.cpp
+++ b/engine/src/runtime/script_engine.cpp
@@ -4943,13 +4943,20 @@ JSValue js_from_json (JSContext* ctx, const nlohmann::json& value, const char* l
 // `pm.iterationData` and a later script running in the same context can call
 // what it stashed. That call reads the *current* execution's row - none - and
 // must say so rather than answering about a run that has finished.
+//
+// The message names every surface that binds a row, not just the collection run
+// #356 shipped with: #402 made a send-with-row one and #599 made a scenario load
+// run's deferred per-step script another, so a message naming only collection
+// runs steers a user who stashed the object during either of those to look for a
+// mistake that is not there.
 ContextData* iteration_data_context (JSContext* ctx, const char* member) {
     auto* data = get_context_data (ctx);
     if (!data || !data->iteration_data) {
         JS_ThrowTypeError (ctx,
-        "pm.iterationData.%s is not available here: this script is not running "
-        "an iteration of a collection run with a data set. See "
-        "docs/engine/scripting.md.",
+        "pm.iterationData.%s is not available here: this script has no data row "
+        "bound. A row is bound by an iteration of a collection run with a data "
+        "set, by a send-with-row, and by a scenario load run's deferred "
+        "per-step script. See docs/engine/scripting.md.",
         member);
         return nullptr;
     }

--- a/engine/tests/script_engine_test.cpp
+++ b/engine/tests/script_engine_test.cpp
@@ -3991,6 +3991,27 @@ TEST_F (ScriptEngineTest, AStashedIterationDataRefusesOnceTheRowIsGone) {
     << second_result.error_message;
 }
 
+// A row is bound by three surfaces, and the refusal has to name all three
+// (issue #733). It named only "a collection run with a data set", stale since
+// #402 made send-with-row and #599 made a scenario load run's deferred per-step
+// script first-class row binders - so a user who stashed the object during
+// either of those was told to look for a data set that was never the point.
+TEST_F (ScriptEngineTest, AStashedIterationDataNamesEverySurfaceThatBindsARow) {
+    const nlohmann::json row{ { "username", "ada" } };
+    auto first        = data_test (request, response, env, row);
+    auto first_result = engine.execute ("globalThis.stashed = pm.iterationData;", first);
+    ASSERT_TRUE (first_result.success) << first_result.error_message;
+
+    auto second_result = engine.execute_test (
+    "globalThis.stashed.toObject();", request, response, env);
+
+    ASSERT_FALSE (second_result.success);
+    for (const char* surface : { "collection run", "send-with-row", "load run" }) {
+        EXPECT_NE (second_result.error_message.find (surface), std::string::npos)
+        << "message does not name " << surface << ": " << second_result.error_message;
+    }
+}
+
 // ============================================================================
 // pm.response.events - a streamed run's buffered event list (issue #575)
 // ============================================================================


### PR DESCRIPTION
## Description

The two live items of #733 (item 1 was already superseded by #732/#738 and is marked as such on the issue). Both are the same defect in two places: a result that knows more than it says.

**Plan.** Root cause of item 2: `iteration_data_context` (`engine/src/runtime/script_engine.cpp`) was written when a data-driven collection run was the only surface that bound a row (#356), and the message never moved when #402 made send-with-row and #599 made a scenario load run's deferred per-step script first-class binders - verified live at `51ab338`: rows reach a script from `scenario_runner.cpp:539`, `execution.cpp:1082,1228` and `run_manager.cpp:132`. Root cause of item 3: `run_collection_smoke` walked `testResults` only to compute a boolean, so an agent got `{ok:false, statusCode:200}` with no reason while the detail sat in the `/execute` body the tool had just read. The approach follows the `schema` verdict beside it - a self-explaining node on the row, one read deciding both `ok` and the list. The alternative I rejected for item 3 was returning the raw `testResults` array per row: it re-nests a shape the tool result does not otherwise use, has no cap (a matrix already carries a row per request), and would let a second walk for `ok` disagree with what the agent is shown.

Engine:
- The stashed-scope refusal now names all three surfaces instead of only collection runs.

App (MCP):
- `run_collection_smoke` rows carry a `tests` node: `total`, `failed`, and the failing `name: message` lines. Cut at ten - the number the engine caps a schema verdict's `failures` at (`constants::schema_validation::MAX_FAILURES`) - with `failed` kept as the true count, so a cut list is visible as one. Nothing caps `testResults` upstream, which is why the cap has to be here.
- A response that ran no assertions carries **no** node: none ran is not all passed.
- `testsOk` is derived from that same read, so the verdict and the list cannot drift.
- The node is declared in `smokeResultSchema` (an undeclared field is dropped by the SDK before an agent sees it) and rides the text content through `structuredResult`, so it has a reader on both channels.

Docs updated in the same commit: `docs/engine/mcp.md` (the smoke tool's result shape), `docs/app/pm-api-compatibility.md` (the `pm.iterationData` scoping row and section named two of the three binding surfaces; `docs/engine/scripting.md` already had all three and needed no change).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
python build.py -e -t
cd engine && ctest --preset linux-dev --output-on-failure   # 1999/1999 passed
cd app && pnpm test                                          # 505 files, 5403 passed
cd app && pnpm type-check                                    # clean
cd app && pnpm lint                                          # clean
```

New tests:
- `ScriptEngineTest.AStashedIterationDataNamesEverySurfaceThatBindsARow` - asserts the refusal names collection run, send-with-row and load run.
- `run_collection_smoke` "a request that failed on its tests says which tests failed" - three rows in one fixture: passing assertions carried, a failure named, no assertions leaving the node absent. Mutation-checked: dropping the row attach fails it (`expected { ok: true } to match { tests: { total: 2, failed: 0 } }`).
- `run_collection_smoke` "a row's failed-test list is capped, and the count still reports the total" - 25 failures render 10 lines with `failed: 25`.

Notes:
- `mkdocs build --strict` was not run - mkdocs is not installed in this environment. The docs edits add no links, headings or nav entries (prose inside existing sections plus one table cell), so there is nothing for the strict build to break; CI covers it.
- `docs/engine/mcp.md` and `docs/app/pm-api-compatibility.md` are not prettier-clean on `master` either, so per CLAUDE.md they were left unformatted rather than reflowed.
- The vcpkg `403` on GitHub source archives reproduced on this environment; cured with `vcpkg-fix-port` as CLAUDE.md documents. Not a code issue.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #733

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjz12vYGPfAbcVZQmnmrGg)_