### PR TITLE
fix(app/import): group untagged operations by path, and rank a `default` response as information

### DIFF
--- a/app/src/modules/collections/ImportModal.notices.test.tsx
+++ b/app/src/modules/collections/ImportModal.notices.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The preview separates what an import lost from what it merely did (issue #710).
+ *
+ * Importing Stripe's spec put "568 example responses with no numeric status" in
+ * destructive red beside "1 file part needs a file" - one line naming a
+ * conformant construct on every operation, the other naming the single thing the
+ * user had to act on, in the same colour and the same sentence. The disclosure
+ * discipline stays (nothing is dropped silently); the ranking is what changes.
+ *
+ * Mutation check: move `default_response` out of `INFORMATIONAL_KINDS` and the
+ * first case fails - the count reappears in the destructive line.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ImportModal } from "./ImportModal";
+import { useImportModalStore } from "@/stores";
+
+function renderModal() {
+	const qc = new QueryClient();
+	return render(
+		<QueryClientProvider client={qc}>
+			<ImportModal />
+		</QueryClientProvider>
+	);
+}
+
+/** Radix TabsTrigger activates on mousedown, not on a bare synthetic click. */
+function selectTab(name: RegExp) {
+	const tab = screen.getByRole("tab", { name });
+	fireEvent.mouseDown(tab);
+	fireEvent.click(tab);
+}
+
+function preview(source: unknown) {
+	renderModal();
+	selectTab(/Paste JSON/i);
+	fireEvent.change(screen.getByPlaceholderText(/Paste/i), {
+		target: { value: JSON.stringify(source) },
+	});
+	fireEvent.click(screen.getByRole("button", { name: /Detect & Preview/i }));
+}
+
+/** A vendor-shaped spec: `default` on every operation, and one real anomaly. */
+const vendorSpec = {
+	openapi: "3.0.0",
+	info: { title: "Payments" },
+	paths: {
+		"/v1/charges": {
+			get: {
+				summary: "List charges",
+				responses: { "200": { description: "ok" }, default: { description: "error" } },
+			},
+		},
+		"/v1/refunds": {
+			get: {
+				summary: "List refunds",
+				responses: { "2XX": { description: "ok" }, default: { description: "error" } },
+			},
+		},
+	},
+};
+
+/** The line a `<p>`/`<span>` with @p text carries its severity on. */
+function severityOf(text: RegExp): string {
+	return screen.getByText(text).className;
+}
+
+describe("the import preview's notices", () => {
+	beforeEach(() => useImportModalStore.setState({ isOpen: true }));
+
+	it("names `default` responses in muted type, apart from the losses", async () => {
+		preview(vendorSpec);
+
+		await waitFor(() =>
+			expect(screen.getByText(/2 `default` \(catch-all\) responses/i)).toBeInTheDocument()
+		);
+		expect(severityOf(/2 `default` \(catch-all\) responses/i)).toContain(
+			"text-muted-foreground"
+		);
+		// The wildcard key is a loss and keeps the destructive treatment, on a line
+		// of its own - the whole point is that the two do not read alike.
+		expect(severityOf(/1 example response with no numeric status/i)).toContain(
+			"text-destructive-text"
+		);
+	});
+
+	it("says where the folders came from when the spec declared no operation tags", async () => {
+		preview(vendorSpec);
+
+		await waitFor(() => expect(screen.getByText(/2 folders/i)).toBeInTheDocument());
+		// Path-derived folders are Vayu's doing, not the document's, so the preview
+		// says so before the user accepts the tree.
+		expect(screen.getByText(/Folders from paths/i)).toBeInTheDocument();
+	});
+
+	it("says nothing about grouping when the folders are the document's own tags", async () => {
+		preview({
+			openapi: "3.0.0",
+			info: { title: "Tagged" },
+			paths: { "/pets": { get: { summary: "List pets", tags: ["pets"] } } },
+		});
+
+		await waitFor(() => expect(screen.getByText(/1 folders/i)).toBeInTheDocument());
+		expect(screen.queryByText(/Folders from/i)).not.toBeInTheDocument();
+	});
+});

--- a/app/src/modules/collections/ImportModal.tsx
+++ b/app/src/modules/collections/ImportModal.tsx
@@ -17,6 +17,7 @@ import {
 	AlertTriangle,
 	FileWarning,
 	Link2,
+	Info,
 } from "lucide-react";
 import {
 	Button,
@@ -839,9 +840,27 @@ function PreviewView({
 					{lossSummary(meta)}
 				</p>
 			)}
+			{noticeSummary(meta) && (
+				<p className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+					<Info className="h-3.5 w-3.5 shrink-0" />
+					{noticeSummary(meta)}
+				</p>
+			)}
 		</div>
 	);
 }
+
+/**
+ * Skip kinds that describe what a conformant document *is*, not what the import
+ * lost (issue #710).
+ *
+ * `default` is the only one so far: every major vendor spec declares a catch-all
+ * response on every operation, so counting it as damage put "568 example
+ * responses with no numeric status" in destructive red beside the single warning
+ * the user could act on ("1 file part needs a file"). It is still counted and
+ * still named - nothing is dropped silently - but at the severity it deserves.
+ */
+const INFORMATIONAL_KINDS: ReadonlySet<SkippedItem["kind"]> = new Set(["default_response"]);
 
 /**
  * What this file lost, in words - or `""` when it lost nothing.
@@ -853,7 +872,9 @@ function PreviewView({
  */
 function lossSummary(meta: ImportResult["meta"]): string {
 	return [
-		...meta.skipped.map((s) => `${s.count} ${skippedLabel(s.kind, s.count)}`),
+		...meta.skipped
+			.filter((s) => !INFORMATIONAL_KINDS.has(s.kind))
+			.map((s) => `${s.count} ${skippedLabel(s.kind, s.count)}`),
 		...(meta.nonExecutableAuth > 0 ? [`${meta.nonExecutableAuth} auth not executed`] : []),
 		// An OpenAPI upload imports as a file row with nothing attached - the user
 		// has to pick the file before the request can be sent, so the preview says
@@ -868,6 +889,40 @@ function lossSummary(meta: ImportResult["meta"]): string {
 			: []),
 	].join(" · ");
 }
+
+/**
+ * What this file is worth knowing about but did not lose - or `""` when there is
+ * nothing to say (issue #710).
+ *
+ * The counterpart to {@link lossSummary}, rendered in muted type rather than
+ * destructive, and shared by the same two callers for the same reason. Two things
+ * land here: a spec-conformant construct that has no place in Vayu's model
+ * (`default` responses), and a grouping decision the import made that the
+ * document did not spell out.
+ */
+function noticeSummary(meta: ImportResult["meta"]): string {
+	return [
+		...meta.skipped
+			.filter((s) => INFORMATIONAL_KINDS.has(s.kind))
+			.map((s) => `${s.count} ${skippedLabel(s.kind, s.count)}`),
+		...(meta.folderStrategy && meta.folderStrategy !== "tags"
+			? [FOLDER_STRATEGY_NOTES[meta.folderStrategy]]
+			: []),
+	].join(" · ");
+}
+
+/**
+ * How a folder tree the user is about to accept came to exist (issue #710).
+ *
+ * Only the two path-involving strategies say anything: folders from an
+ * operation's own `tags` are the document's own structure and need no
+ * explanation, while folders derived from paths are Vayu's doing and would
+ * otherwise read as something the spec contained.
+ */
+const FOLDER_STRATEGY_NOTES: Record<"paths" | "mixed", string> = {
+	paths: "Folders from paths - this spec declares no operation tags",
+	mixed: "Folders from tags, and from paths where an operation declared none",
+};
 
 /**
  * The batch ledger: one row per picked file (issue #666).
@@ -933,6 +988,7 @@ function BatchRow({
 	// wherever it is named.
 	const name = entryLabel(entry);
 	const loss = result ? lossSummary(result.meta) : "";
+	const notices = result ? noticeSummary(result.meta) : "";
 	return (
 		<label className="flex items-start gap-2 py-1 pl-1 text-xs">
 			<input
@@ -980,6 +1036,12 @@ function BatchRow({
 						{loss}
 					</span>
 				)}
+				{notices && (
+					<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+						<Info className="h-3 w-3 shrink-0" />
+						{notices}
+					</span>
+				)}
 				{outcome && (
 					<span
 						className={`flex items-center gap-1.5 text-[11px] ${
@@ -1025,6 +1087,14 @@ const SKIPPED_LABELS: Record<SkippedItem["kind"], [singular: string, plural: str
 	example_no_status: [
 		"example response with no numeric status",
 		"example responses with no numeric status",
+	],
+	// Named as the construct rather than as a loss (issue #710): `default` is
+	// valid OpenAPI on every operation of most vendor specs, so the line has to
+	// read as "here is what happened to them", not as a tally of damage. The
+	// severity comes from INFORMATIONAL_KINDS; the wording has to match it.
+	default_response: [
+		"`default` (catch-all) response - no status to serve under, not imported as an example",
+		"`default` (catch-all) responses - no status to serve under, not imported as examples",
 	],
 	// Not "external ref": the count is what the user lost, and what they lost is
 	// a schema the spec pointed at in another file (issue #649). The wording says

--- a/app/src/services/importers/examples-import.test.ts
+++ b/app/src/services/importers/examples-import.test.ts
@@ -28,6 +28,7 @@ import { ImportOrchestrator, type ImportApi } from "./orchestrator";
 import { assignTempIds } from "./assign-ids";
 import type { ImportApplyRequest } from "@/types";
 import type { ImportResult, RequestDraft } from "./types";
+import { requestsOf } from "@/test/import-drafts";
 
 const opts = { importEnvironments: true, importScripts: true };
 
@@ -46,7 +47,7 @@ function postmanWith(responses: unknown[]): Record<string, unknown> {
 }
 
 function firstRequest(result: ImportResult): RequestDraft {
-	return result.collections[0].requests[0];
+	return requestsOf(result)[0];
 }
 
 describe("Postman saved responses", () => {
@@ -217,7 +218,7 @@ describe("OpenAPI 3 documented responses", () => {
 		]);
 	});
 
-	it("counts a `default` or wildcard response rather than guessing a status", () => {
+	it("counts a `default` or wildcard response rather than guessing a status, each on its own counter", () => {
 		const result = new OpenApiV3Parser().parse(
 			openApiWith({
 				"200": { description: "ok" },
@@ -228,7 +229,11 @@ describe("OpenAPI 3 documented responses", () => {
 			opts
 		);
 		expect(firstRequest(result).examples).toHaveLength(1);
-		expect(result.meta.skipped).toContainEqual({ kind: "example_no_status", count: 2 });
+		// Both are skipped for the same reason and reported apart (#710): `default`
+		// is conformant and on nearly every operation of a vendor spec, while a
+		// `4XX` wildcard is a key the preview should keep flagging as a loss.
+		expect(result.meta.skipped).toContainEqual({ kind: "default_response", count: 1 });
+		expect(result.meta.skipped).toContainEqual({ kind: "example_no_status", count: 1 });
 	});
 
 	it("follows a $ref'd response object", () => {

--- a/app/src/services/importers/factory.test.ts
+++ b/app/src/services/importers/factory.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseImport } from "./factory";
 import { UnrecognisedFormatError } from "./types";
+import { requestsOf } from "@/test/import-drafts";
 
 const opts = { importEnvironments: true, importScripts: true };
 const fx = (name: string) => readFileSync(join(__dirname, "__fixtures__", name), "utf8");
@@ -101,7 +102,7 @@ describe("parseImport joins enabled params into the request URL", () => {
 	});
 
 	it("Postman: a request with no query is untouched", () => {
-		const req = parseImport(fx("postman-v21.json"), opts).collections[0].requests[0];
+		const req = requestsOf(parseImport(fx("postman-v21.json"), opts))[0];
 		expect(req.url).toBe("{{baseUrl}}/users");
 	});
 
@@ -140,7 +141,7 @@ describe("parseImport joins enabled params into the request URL", () => {
 				},
 			],
 		});
-		expect(parseImport(doc, opts).collections[0].requests[0].url).toBe("https://x/y?a=1&b=2");
+		expect(requestsOf(parseImport(doc, opts))[0].url).toBe("https://x/y?a=1&b=2");
 	});
 
 	it("OpenAPI: an optional value-less parameter stays off the URL", () => {
@@ -181,7 +182,7 @@ describe("parseImport joins enabled params into the request URL", () => {
 				},
 			},
 		});
-		const req = parseImport(spec, opts).collections[0].requests[0];
+		const req = requestsOf(parseImport(spec, opts))[0];
 		expect(req.url).toBe("{{baseUrl}}/items?tenant&limit=25");
 	});
 

--- a/app/src/services/importers/openapi-folders.test.ts
+++ b/app/src/services/importers/openapi-folders.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * How an OpenAPI import decides what goes in which folder (issue #710).
+ *
+ * Grouping by an operation's first tag is right up until a document declares no
+ * operation tags at all - Stripe's official spec is 568 operations with root
+ * `tags:` that **no operation references**, so tag grouping alone dropped the
+ * whole API into one flat list of 568 requests. The fallback groups by the first
+ * meaningful path segment, which is what the vendor's own docs are organized by.
+ *
+ * Both parsers are driven here rather than once each: the routing lives in
+ * `OperationFolders` precisely so there is one rule, and a test per parser is
+ * how the second copy would have gone unnoticed.
+ *
+ * Mutation check: make `place()` push every untagged request onto the root and
+ * the three tagging shapes below fail; drop the version-prefix skip and the
+ * Stripe-shaped case files everything under `v1`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { OpenApiV3Parser } from "./openapi-v3";
+import { OpenApiV2Parser } from "./openapi-v2";
+import { pathFolderName } from "./openapi-shared";
+import type { CollectionDraft, ImportResult } from "./types";
+
+const opts = { importEnvironments: true, importScripts: true };
+
+/** An OpenAPI 3 document whose operations are @p operations, keyed by path. */
+function v3(
+	paths: Record<string, Record<string, unknown>>,
+	tags?: unknown[]
+): Record<string, unknown> {
+	return {
+		openapi: "3.0.0",
+		info: { title: "API" },
+		...(tags ? { tags } : {}),
+		paths: Object.fromEntries(
+			Object.entries(paths).map(([path, op]) => [path, { get: { summary: path, ...op } }])
+		),
+	};
+}
+
+/** The same document as a Swagger 2.0 one, so both parsers answer the same question. */
+function v2(
+	paths: Record<string, Record<string, unknown>>,
+	tags?: unknown[]
+): Record<string, unknown> {
+	return { ...v3(paths, tags), swagger: "2.0", openapi: undefined };
+}
+
+function parseV3(document: Record<string, unknown>): ImportResult {
+	return new OpenApiV3Parser().parse(document, JSON.stringify(document), opts);
+}
+
+function parseV2(document: Record<string, unknown>): ImportResult {
+	return new OpenApiV2Parser().parse(document, JSON.stringify(document), opts);
+}
+
+/** Folder name → the requests it holds, for one parsed import. */
+function foldered(result: ImportResult): Record<string, string[]> {
+	const root: CollectionDraft = result.collections[0];
+	return Object.fromEntries(root.children.map((c) => [c.name, c.requests.map((r) => r.name)]));
+}
+
+describe("folders for an untagged spec", () => {
+	// (a) no tags anywhere - the shape a hand-written or generated spec often has.
+	const untagged = {
+		"/v1/account_links": {},
+		"/v1/checkout/sessions": {},
+		"/v1/checkout/sessions/{session}": {},
+	};
+
+	it("groups by the first meaningful path segment, in both parsers", () => {
+		for (const result of [parseV3(v3(untagged)), parseV2(v2(untagged))]) {
+			expect(foldered(result)).toEqual({
+				account_links: ["/v1/account_links"],
+				checkout: ["/v1/checkout/sessions", "/v1/checkout/sessions/{session}"],
+			});
+			// Nothing left flat, and the preview's count is what the tree holds.
+			expect(result.collections[0].requests).toEqual([]);
+			expect(result.meta.folderCount).toBe(2);
+		}
+	});
+
+	it("says the folders came from paths, so the tree is not a surprise", () => {
+		expect(parseV3(v3(untagged)).meta.folderStrategy).toBe("paths");
+		expect(parseV2(v2(untagged)).meta.folderStrategy).toBe("paths");
+	});
+
+	// (b) the Stripe shape: root tags declared, referenced by no operation.
+	it("ignores root tags no operation references", () => {
+		const document = v3(untagged, [
+			{ name: "billing", description: "Billing APIs", "x-kind": "api-group" },
+			{ name: "core", "x-kind": "api-group" },
+		]);
+		// Matching those group names onto paths is guesswork the importer refuses
+		// (a recorded non-goal), so they contribute no folder at all.
+		expect(Object.keys(foldered(parseV3(document)))).toEqual(["account_links", "checkout"]);
+	});
+});
+
+describe("folders for a tagged spec", () => {
+	const tagged = {
+		"/pets": { tags: ["pets"] },
+		"/pets/{id}": { tags: ["pets", "admin"] },
+	};
+
+	it("keeps tag grouping untouched, with the declared description", () => {
+		const result = parseV3(v3(tagged, [{ name: "pets", description: "Pet ops" }]));
+		expect(foldered(result)).toEqual({ pets: ["/pets", "/pets/{id}"] });
+		expect(result.collections[0].children[0].description).toBe("Pet ops");
+		// Only the first tag groups an operation - `admin` is not a folder.
+		expect(result.meta.folderStrategy).toBe("tags");
+	});
+
+	// (c) mixed: a partially tagged document gets both rules, per operation.
+	it("falls back per operation, so a partly tagged spec gets both", () => {
+		const result = parseV3(v3({ "/pets": { tags: ["pets"] }, "/v2/orders/{id}": {} }));
+		expect(foldered(result)).toEqual({ pets: ["/pets"], orders: ["/v2/orders/{id}"] });
+		expect(result.meta.folderStrategy).toBe("mixed");
+	});
+
+	it("merges a path folder and a tag of the same name, keeping the description", () => {
+		// The path fallback can land on a name a tag also uses. One folder holds
+		// both rather than two folders sharing a name, and the tag's description
+		// still describes what is in it.
+		const result = parseV3(
+			v3({ "/orders": {}, "/legacy": { tags: ["orders"] } }, [
+				{ name: "orders", description: "Order ops" },
+			])
+		);
+		expect(foldered(result)).toEqual({ orders: ["/orders", "/legacy"] });
+		expect(result.collections[0].children[0].description).toBe("Order ops");
+	});
+});
+
+describe("a path that names no resource", () => {
+	it("leaves the request on the root rather than inventing a folder", () => {
+		const result = parseV3(v3({ "/": {}, "/v1": {}, "/api/{id}": {} }));
+		expect(result.collections[0].children).toEqual([]);
+		expect(result.collections[0].requests.map((r) => r.name)).toEqual([
+			"/",
+			"/v1",
+			"/api/{id}",
+		]);
+		// No folders means no rule to explain, so the preview says nothing.
+		expect(result.meta.folderStrategy).toBeUndefined();
+		expect(result.meta.folderCount).toBe(0);
+	});
+});
+
+describe("pathFolderName", () => {
+	it("steps over version, api and template segments to the first resource", () => {
+		expect(pathFolderName("/v1/account_links")).toBe("account_links");
+		expect(pathFolderName("/api/v2/{tenant}/orders")).toBe("orders");
+		expect(pathFolderName("/V1.1/users")).toBe("users");
+		// Only leading segments are stepped over - a resource named `api` deeper in
+		// the path is still what the operation is about.
+		expect(pathFolderName("/users/{id}/api")).toBe("users");
+	});
+
+	it("returns undefined when the path names nothing to group by", () => {
+		expect(pathFolderName("/")).toBeUndefined();
+		expect(pathFolderName("/v1")).toBeUndefined();
+		expect(pathFolderName("/api/{id}")).toBeUndefined();
+	});
+});

--- a/app/src/services/importers/openapi-shared.ts
+++ b/app/src/services/importers/openapi-shared.ts
@@ -6,8 +6,14 @@
  */
 
 import type { KeyValueEntry, SpecOperation } from "@/types";
-import type { ExampleDraft, SkippedItem } from "./types";
-import { asRecord, asStr, prop } from "@/lib/json-node";
+import type {
+	CollectionDraft,
+	ExampleDraft,
+	FolderStrategy,
+	RequestDraft,
+	SkippedItem,
+} from "./types";
+import { asArray, asRecord, asStr, prop } from "@/lib/json-node";
 
 export type RefResolver = (ref: string) => unknown;
 
@@ -151,6 +157,130 @@ export class SkipTally {
 	}
 }
 
+/** A path segment that names the API's version rather than a resource. */
+const VERSION_SEGMENT = /^v\d+(\.\d+)*$/i;
+
+/** A path segment that is entirely a `{template}`, which names a value, not a resource. */
+const TEMPLATE_SEGMENT = /^\{.*\}$/;
+
+/**
+ * The folder an untagged operation belongs in, read off its path (issue #710) -
+ * or `undefined` when the path names no resource to group by.
+ *
+ * A document whose operations carry no `tags` is not a broken document: Stripe's
+ * official spec declares root-level tags that **no operation references**, so
+ * every one of its 568 operations grouped by tag alone lands in one flat list.
+ * The first meaningful path segment is what the vendor's own documentation is
+ * organized by (`/v1/checkout/sessions` is "checkout"), so it is the grouping the
+ * reader already expects.
+ *
+ * Leading segments that name no resource are stepped over: a version (`v1`,
+ * `v2.1`), the ubiquitous `api` mount point, and a `{template}` segment, which
+ * holds a value rather than naming anything. `/api/v2/{tenant}/orders` is
+ * therefore "orders". A path with nothing left after that - `/`, `/v1`, `/{id}` -
+ * yields `undefined`, and its request stays on the root rather than getting a
+ * folder named after a placeholder.
+ *
+ * The segment is taken exactly as written (`account_links`, not "Account links"):
+ * a prettified name is one the document never contained, and it is the name a
+ * user matches against the vendor's docs.
+ */
+export function pathFolderName(path: string): string | undefined {
+	for (const segment of path.split("/")) {
+		if (!segment) continue;
+		if (TEMPLATE_SEGMENT.test(segment)) continue;
+		if (VERSION_SEGMENT.test(segment) || segment.toLowerCase() === "api") continue;
+		return segment;
+	}
+	return undefined;
+}
+
+/**
+ * Where each operation's request goes: a folder named by the operation's first
+ * tag, a folder named by its path (issue #710), or the root collection.
+ *
+ * Shared rather than written per parser because it is one decision the two make
+ * identically - both used to keep their own `Map<string, CollectionDraft>` plus
+ * the same tag-description lookup, and the path fallback would have been the
+ * third copy of the same routing to drift.
+ *
+ * **Only the first tag groups an operation**, unchanged from before: an operation
+ * tagged `["a", "b"]` lands in `a` alone, because a request duplicated into two
+ * folders is two requests to edit.
+ */
+export class OperationFolders {
+	private readonly folders = new Map<string, CollectionDraft>();
+	private readonly root: RequestDraft[] = [];
+	private tagged = false;
+	private pathed = false;
+
+	/** @param declaredTags the document's top-level `tags[]`, for folder descriptions. */
+	constructor(private readonly declaredTags: unknown) {}
+
+	place(request: RequestDraft, path: string, tags: unknown): void {
+		const tag = asStr(asArray(tags)[0]);
+		const name = tag ?? pathFolderName(path);
+		if (!name) {
+			this.root.push(request);
+			return;
+		}
+		if (tag) this.tagged = true;
+		else this.pathed = true;
+		let folder = this.folders.get(name);
+		if (!folder) {
+			folder = {
+				name,
+				description: tag ? this.describe(tag) : "",
+				variables: {},
+				auth: { mode: "none" },
+				preRequestScript: "",
+				postRequestScript: "",
+				children: [],
+				requests: [],
+			};
+			this.folders.set(name, folder);
+		} else if (tag && !folder.description) {
+			// A path segment can be spelled exactly like a tag, in which case the
+			// folder already exists with no description. The tag's description still
+			// describes what is in it, so it is filled in rather than dropped.
+			folder.description = this.describe(tag);
+		}
+		folder.requests.push(request);
+	}
+
+	/** The folders, in first-encounter order. */
+	children(): CollectionDraft[] {
+		return [...this.folders.values()];
+	}
+
+	/** Requests whose operation had neither a tag nor a groupable path. */
+	rootRequests(): RequestDraft[] {
+		return this.root;
+	}
+
+	count(): number {
+		return this.folders.size;
+	}
+
+	/**
+	 * Which rule produced the folders, so the preview can say so - a spec that
+	 * declares no operation tags gets a folder tree the document never spelled
+	 * out, and that must not be a surprise. `undefined` when there are no folders
+	 * to explain.
+	 */
+	strategy(): FolderStrategy | undefined {
+		if (this.tagged && this.pathed) return "mixed";
+		if (this.tagged) return "tags";
+		if (this.pathed) return "paths";
+		return undefined;
+	}
+
+	private describe(tag: string): string {
+		const def = asArray(this.declaredTags).find((t) => prop(t, "name") === tag);
+		return asStr(prop(def, "description")) ?? "";
+	}
+}
+
 /**
  * {@link specOperationOf} for a whole document, with a **duplicated
  * `operationId` kept on its first declaration only** (issue #715).
@@ -206,7 +336,13 @@ export function createOperationIdentifier(
  *
  * A key that is not a numeric status (`default`, `2XX`) has no status line to
  * be served under, so it is skipped and tallied rather than guessed at - the
- * caller passes the tally, and the preview names the loss.
+ * caller passes the tally, and the preview names it.
+ *
+ * `default` gets a counter of its own (issue #710). It is the spec-conformant
+ * catch-all every major vendor declares on every operation - Stripe on all 568,
+ * GitHub likewise - so counting it beside malformed keys reported a fully valid
+ * document as one defect per operation, in the same red as the one warning that
+ * needed action. Same behaviour, told apart so the preview can rank them.
  */
 export function responseExample(
 	code: string,
@@ -222,6 +358,10 @@ export function responseExample(
 		return undefined;
 	}
 	const status = Number(code);
+	if (code === "default") {
+		tally.add("default_response");
+		return undefined;
+	}
 	if (!/^\d{3}$/.test(code) || status < 100 || status > 599) {
 		tally.add("example_no_status");
 		return undefined;

--- a/app/src/services/importers/openapi-v2.test.ts
+++ b/app/src/services/importers/openapi-v2.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { OpenApiV2Parser, swaggerSchemeToAuth } from "./openapi-v2";
+import { requestsOf } from "@/test/import-drafts";
 
 const raw = readFileSync(join(__dirname, "__fixtures__/swagger-v2.json"), "utf8");
 const parsed = JSON.parse(raw);
@@ -23,7 +24,7 @@ describe("OpenApiV2Parser", () => {
 			},
 		};
 		const result = p.parse(spec, JSON.stringify(spec), opts);
-		const requests = result.collections[0].requests;
+		const requests = requestsOf(result);
 
 		expect(requests.find((r) => r.name === "List A")!.specOperation).toEqual({
 			operationId: "list",
@@ -119,9 +120,9 @@ describe("OpenApiV2Parser", () => {
 				},
 			},
 		};
-		const get = p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "List items")!;
+		const get = requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "List items"
+		)!;
 		expect(get.params).toContainEqual({ key: "status", value: "", enabled: false });
 	});
 
@@ -139,9 +140,9 @@ describe("OpenApiV2Parser", () => {
 				},
 			},
 		};
-		const get = p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "List items")!;
+		const get = requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "List items"
+		)!;
 		expect(get.params).toEqual([
 			{ key: "q", value: "", enabled: false, description: "op-level" },
 		]);
@@ -166,9 +167,9 @@ describe("OpenApiV2Parser", () => {
 
 	const formBody = (consumes?: string[]) => {
 		const spec = formSpec(consumes);
-		return p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "Log in")!.body;
+		return requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "Log in"
+		)!.body;
 	};
 
 	it("maps formData to urlencoded or multipart per consumes", () => {
@@ -199,9 +200,9 @@ describe("OpenApiV2Parser", () => {
 
 	it("falls back to the spec-level consumes for the form encoding", () => {
 		const spec = { ...formSpec(), consumes: ["application/x-www-form-urlencoded"] };
-		const body = p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "Log in")!.body;
+		const body = requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "Log in"
+		)!.body;
 		expect(body.mode).toBe("x-www-form-urlencoded");
 	});
 
@@ -216,7 +217,7 @@ describe("OpenApiV2Parser", () => {
 			"x-pathItems": { UserOps: { get: { summary: "Get user" } } },
 		};
 		const result = p.parse(spec, JSON.stringify(spec), opts);
-		expect(result.collections[0].requests.map((r) => r.name)).toEqual(["Get user", "Health"]);
+		expect(requestsOf(result).map((r) => r.name)).toEqual(["Get user", "Health"]);
 		expect(result.meta.requestCount).toBe(2);
 		expect(result.meta.skipped).toEqual([]);
 	});
@@ -235,10 +236,8 @@ describe("OpenApiV2Parser", () => {
 		};
 		const result = p.parse(spec, JSON.stringify(spec), opts);
 		expect(result.meta.requestCount).toBe(2);
-		expect(result.collections[0].requests.find((r) => r.name === "List items")!.params).toEqual(
-			[]
-		);
-		expect(result.collections[0].requests.find((r) => r.name === "Other")!.params).toEqual([
+		expect(requestsOf(result).find((r) => r.name === "List items")!.params).toEqual([]);
+		expect(requestsOf(result).find((r) => r.name === "Other")!.params).toEqual([
 			{ key: "ok", value: "", enabled: false },
 		]);
 		expect(result.meta.skipped).toEqual([{ kind: "malformed_spec", count: 1 }]);
@@ -272,7 +271,7 @@ describe("OpenApiV2Parser", () => {
 
 	it("imports a `type: file` formData param as a file part, not an empty text row", () => {
 		const result = uploadResult(["multipart/form-data"]);
-		expect(result.collections[0].requests[0].body).toEqual({
+		expect(requestsOf(result)[0].body).toEqual({
 			mode: "form-data",
 			fields: [
 				{ key: "caption", value: "", enabled: true },
@@ -287,7 +286,7 @@ describe("OpenApiV2Parser", () => {
 	it("forces multipart for a file param a urlencoded-only consumes contradicts", () => {
 		// Only multipart has a file form on the wire, so the encoding follows the part.
 		expect(
-			uploadResult(["application/x-www-form-urlencoded"]).collections[0].requests[0].body
+			requestsOf(uploadResult(["application/x-www-form-urlencoded"]))[0].body
 		).toMatchObject({ mode: "form-data" });
 	});
 
@@ -316,9 +315,9 @@ describe("OpenApiV2Parser", () => {
 				},
 			},
 		};
-		const post = p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "Create item")!;
+		const post = requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "Create item"
+		)!;
 		expect(post.body.mode).toBe("json");
 	});
 
@@ -333,7 +332,7 @@ describe("OpenApiV2Parser", () => {
 				info: { title: "Params API" },
 				paths: { "/items": { get: { summary: "List items", parameters } } },
 			};
-			return p.parse(spec, JSON.stringify(spec), opts).collections[0].requests[0].params;
+			return requestsOf(p.parse(spec, JSON.stringify(spec), opts))[0].params;
 		};
 
 		it("imports an optional value-less parameter disabled and a required one enabled", () => {
@@ -387,7 +386,7 @@ describe("OpenApiV2Parser", () => {
 				info: { title: "Header API" },
 				paths: { "/items": { get: { summary: "List items", parameters } } },
 			};
-			return p.parse(spec, JSON.stringify(spec), opts).collections[0].requests[0].headers;
+			return requestsOf(p.parse(spec, JSON.stringify(spec), opts))[0].headers;
 		};
 
 		it("imports an optional value-less header disabled and a required one enabled", () => {

--- a/app/src/services/importers/openapi-v2.ts
+++ b/app/src/services/importers/openapi-v2.ts
@@ -35,6 +35,7 @@ import {
 	exampleBodyText,
 	resolvePathItem,
 	responseExample,
+	OperationFolders,
 	SkipTally,
 	createOperationIdentifier,
 } from "./openapi-shared";
@@ -109,8 +110,7 @@ export class OpenApiV2Parser implements ImportParser {
 		const defs = asRecord(spec.securityDefinitions) ?? {};
 		const primaryScheme = (reqName && defs[reqName]) || Object.values(defs)[0];
 
-		const tagCollections = new Map<string, CollectionDraft>();
-		const rootRequests: RequestDraft[] = [];
+		const folders = new OperationFolders(spec.tags);
 		const tally = new SkipTally();
 		// One identifier for the whole document: it is what keeps a repeated
 		// `operationId` off the second request that would otherwise claim it
@@ -158,25 +158,7 @@ export class OpenApiV2Parser implements ImportParser {
 					tally,
 					identity
 				);
-				const tag = asStr(asArray(op.tags)[0]);
-				if (tag) {
-					if (!tagCollections.has(tag)) {
-						const def = asArray(spec.tags).find((t) => prop(t, "name") === tag);
-						tagCollections.set(tag, {
-							name: tag,
-							description: asStr(prop(def, "description")) ?? "",
-							variables: {},
-							auth: { mode: "none" },
-							preRequestScript: "",
-							postRequestScript: "",
-							children: [],
-							requests: [],
-						});
-					}
-					tagCollections.get(tag)!.requests.push(req);
-				} else {
-					rootRequests.push(req);
-				}
+				folders.place(req, path, op.tags);
 			}
 		}
 
@@ -189,8 +171,8 @@ export class OpenApiV2Parser implements ImportParser {
 			auth: swaggerSchemeToAuth(primaryScheme),
 			preRequestScript: "",
 			postRequestScript: "",
-			children: [...tagCollections.values()],
-			requests: rootRequests,
+			children: folders.children(),
+			requests: folders.rootRequests(),
 			// The document itself, so the import can store it and bind this
 			// collection to it in the same atomic call (issue #637) - see the v3
 			// parser for why it is `raw` rather than a re-serialization, and for
@@ -209,7 +191,8 @@ export class OpenApiV2Parser implements ImportParser {
 			meta: {
 				format: this.formatName,
 				requestCount,
-				folderCount: tagCollections.size,
+				folderCount: folders.count(),
+				...(folders.strategy() ? { folderStrategy: folders.strategy() } : {}),
 				environmentCount: 0,
 				globalCount: 0,
 				exampleCount: countExamples([root]),

--- a/app/src/services/importers/openapi-v3.test.ts
+++ b/app/src/services/importers/openapi-v3.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { OpenApiV3Parser } from "./openapi-v3";
+import { requestNamed, requestsOf } from "@/test/import-drafts";
 
 const raw = readFileSync(join(__dirname, "__fixtures__/openapi-v3.json"), "utf8");
 const parsed = JSON.parse(raw);
@@ -46,9 +47,15 @@ describe("OpenApiV3Parser", () => {
 		});
 	});
 
-	it("places untagged operations directly on the root", () => {
+	it("files an untagged operation under a folder named by its path (#710)", () => {
+		// `/health` carries no `tags`, so it used to land on the root beside the
+		// tag folders. The grouping tests live in `openapi-folders.test.ts`; this
+		// case stays here because the shared fixture is what the rest of this file
+		// reads, and a fixture that quietly regrouped would move every assertion.
 		const root = p.parse(parsed, raw, opts).collections[0];
-		expect(root.requests.find((r) => r.name === "Health")).toBeTruthy();
+		expect(root.requests).toEqual([]);
+		const health = root.children.find((c) => c.name === "health")!;
+		expect(health.requests.map((r) => r.name)).toEqual(["Health"]);
 	});
 
 	it("generates JSON body for charset/+json content types", () => {
@@ -72,8 +79,8 @@ describe("OpenApiV3Parser", () => {
 				},
 			},
 		};
-		const root = p.parse(spec, JSON.stringify(spec), opts).collections[0];
-		const req = root.requests.find((r) => r.name === "Make thing")!;
+		const result = p.parse(spec, JSON.stringify(spec), opts);
+		const req = requestNamed(result, "Make thing");
 		expect(req.body).toEqual({ mode: "json", content: JSON.stringify({ a: "" }, null, 2) });
 	});
 
@@ -87,8 +94,8 @@ describe("OpenApiV3Parser", () => {
 				},
 			},
 		};
-		const root = p.parse(spec, JSON.stringify(spec), opts).collections[0];
-		const req = root.requests.find((r) => r.name === "List items")!;
+		const result = p.parse(spec, JSON.stringify(spec), opts);
+		const req = requestNamed(result, "List items");
 		expect(req.params).toContainEqual({ key: "shared", value: "", enabled: false });
 	});
 
@@ -111,11 +118,11 @@ describe("OpenApiV3Parser", () => {
 			paths: { "/users/{id}": { $ref: "#/components/pathItems/UserOps" } },
 		};
 		const result = p.parse(spec, JSON.stringify(spec), opts);
-		const names = result.collections[0].requests.map((r) => r.name);
+		const names = requestsOf(result).map((r) => r.name);
 		expect(names).toEqual(["Get user", "Delete user"]);
 		expect(result.meta.requestCount).toBe(2);
 		// The referenced item's shared parameters come along with it.
-		const get = result.collections[0].requests[0];
+		const get = requestsOf(result)[0];
 		expect(get.params).toEqual([{ key: "expand", value: "", enabled: false }]);
 		expect(get.url).toBe("{{baseUrl}}/users/{{id}}");
 		expect(result.meta.skipped).toEqual([]);
@@ -164,9 +171,9 @@ describe("OpenApiV3Parser", () => {
 				},
 			},
 		};
-		const req = p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "Get token")!;
+		const req = requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "Get token"
+		)!;
 		expect(req.body).toEqual({
 			mode: "x-www-form-urlencoded",
 			fields: [
@@ -198,9 +205,9 @@ describe("OpenApiV3Parser", () => {
 				},
 			},
 		};
-		const req = p
-			.parse(spec, JSON.stringify(spec), opts)
-			.collections[0].requests.find((r) => r.name === "Upload")!;
+		const req = requestsOf(p.parse(spec, JSON.stringify(spec), opts)).find(
+			(r) => r.name === "Upload"
+		)!;
 		expect(req.body).toEqual({
 			mode: "form-data",
 			fields: [{ key: "file", value: "", enabled: true }],
@@ -234,7 +241,7 @@ describe("OpenApiV3Parser", () => {
 	it("imports a `format: binary` multipart property as a file part, not an empty text row", () => {
 		const spec = uploadSpec("multipart/form-data");
 		const result = p.parse(spec, JSON.stringify(spec), opts);
-		expect(result.collections[0].requests[0].body).toEqual({
+		expect(requestsOf(result)[0].body).toEqual({
 			mode: "form-data",
 			fields: [
 				{ key: "caption", value: "", enabled: true },
@@ -249,7 +256,7 @@ describe("OpenApiV3Parser", () => {
 	it("leaves a binary property under urlencoded as text - that wire form has no file", () => {
 		const spec = uploadSpec("application/x-www-form-urlencoded");
 		const result = p.parse(spec, JSON.stringify(spec), opts);
-		expect(result.collections[0].requests[0].body).toEqual({
+		expect(requestsOf(result)[0].body).toEqual({
 			mode: "x-www-form-urlencoded",
 			fields: [
 				{ key: "caption", value: "", enabled: true },
@@ -283,7 +290,7 @@ describe("OpenApiV3Parser", () => {
 		};
 		const result = p.parse(spec, JSON.stringify(spec), opts);
 		expect(result.meta.requestCount).toBe(1); // TRACE cannot be built; the count stays honest
-		expect(result.collections[0].requests.map((r) => r.name)).toEqual(["Get it"]);
+		expect(requestsOf(result).map((r) => r.name)).toEqual(["Get it"]);
 		expect(result.meta.skipped).toEqual([{ kind: "unsupported_method", count: 1 }]);
 	});
 
@@ -306,10 +313,10 @@ describe("OpenApiV3Parser", () => {
 		};
 		const result = p.parse(spec, JSON.stringify(spec), opts);
 		expect(result.meta.requestCount).toBe(2);
-		const list = result.collections[0].requests.find((r) => r.name === "List items")!;
+		const list = requestsOf(result).find((r) => r.name === "List items")!;
 		expect(list.params).toEqual([]);
 		// Every other path still imports, params and all.
-		const other = result.collections[0].requests.find((r) => r.name === "Other")!;
+		const other = requestsOf(result).find((r) => r.name === "Other")!;
 		expect(other.params).toEqual([{ key: "ok", value: "", enabled: false }]);
 		expect(result.meta.skipped).toEqual([{ kind: "malformed_spec", count: 2 }]);
 	});
@@ -341,7 +348,7 @@ describe("OpenApiV3Parser", () => {
 		const parse = () => p.parse(spec, JSON.stringify(spec), opts);
 
 		it("keeps the id on the first declaration and identifies the second by its path alone", () => {
-			const requests = parse().collections[0].requests;
+			const requests = requestsOf(parse());
 			expect(requests.find((r) => r.name === "List A")!.specOperation).toEqual({
 				operationId: "list",
 				method: "GET",
@@ -488,8 +495,8 @@ describe("OpenApiV3Parser", () => {
 				},
 			},
 		};
-		const root = p.parse(spec, JSON.stringify(spec), opts).collections[0];
-		const req = root.requests.find((r) => r.name === "Create pet")!;
+		const result = p.parse(spec, JSON.stringify(spec), opts);
+		const req = requestNamed(result, "Create pet");
 		expect(req.body).toEqual({
 			mode: "json",
 			content: JSON.stringify({ id: 0, name: "" }, null, 2),
@@ -509,7 +516,7 @@ describe("OpenApiV3Parser", () => {
 				components: { schemas: { Limit: { type: "integer", default: 25 } } },
 				paths: { "/items": { get: { summary: "List items", parameters } } },
 			};
-			return p.parse(spec, JSON.stringify(spec), opts).collections[0].requests[0].params;
+			return requestsOf(p.parse(spec, JSON.stringify(spec), opts))[0].params;
 		};
 
 		it("imports an optional value-less parameter disabled and a required one enabled", () => {
@@ -609,7 +616,7 @@ describe("OpenApiV3Parser", () => {
 				components: { schemas: { Tenant: { type: "string", default: "acme" } } },
 				paths: { "/items": { get: { summary: "List items", parameters } } },
 			};
-			return p.parse(spec, JSON.stringify(spec), opts).collections[0].requests[0].headers;
+			return requestsOf(p.parse(spec, JSON.stringify(spec), opts))[0].headers;
 		};
 
 		it("imports an optional value-less header disabled and a required one enabled", () => {
@@ -697,7 +704,7 @@ describe("OpenApiV3Parser", () => {
 				},
 			};
 			const result = p.parse(spec, JSON.stringify(spec), opts);
-			const request = result.collections[0].requests[0];
+			const request = requestsOf(result)[0];
 			expect(request.headers).toEqual([]);
 			expect(request.params).toEqual([{ key: "q", value: "", enabled: false }]);
 			// The path parameter is carried, as the URL template - so it is a drop
@@ -728,7 +735,7 @@ describe("OpenApiV3Parser", () => {
 					"application/octet-stream": { schema: { type: "string", format: "binary" } },
 				},
 			});
-			expect(result.collections[0].requests[0].body).toEqual({ mode: "none" });
+			expect(requestsOf(result)[0].body).toEqual({ mode: "none" });
 			expect(result.meta.requestCount).toBe(1);
 			expect(result.meta.skipped).toEqual([{ kind: "unmapped_body", count: 1 }]);
 		});
@@ -750,7 +757,7 @@ describe("OpenApiV3Parser", () => {
 			});
 			expect(json.meta.skipped).toEqual([]);
 			const text = parseWithBody({ content: { "text/plain": {} } });
-			expect(text.collections[0].requests[0].body).toEqual({ mode: "text", content: "" });
+			expect(requestsOf(text)[0].body).toEqual({ mode: "text", content: "" });
 			expect(text.meta.skipped).toEqual([]);
 		});
 	});

--- a/app/src/services/importers/openapi-v3.ts
+++ b/app/src/services/importers/openapi-v3.ts
@@ -37,6 +37,7 @@ import {
 	firstNamedExample,
 	resolvePathItem,
 	responseExample,
+	OperationFolders,
 	SkipTally,
 	createOperationIdentifier,
 } from "./openapi-shared";
@@ -91,8 +92,7 @@ export class OpenApiV3Parser implements ImportParser {
 
 		const primaryScheme = pickPrimaryScheme(spec);
 
-		const tagCollections = new Map<string, CollectionDraft>();
-		const rootRequests: RequestDraft[] = [];
+		const folders = new OperationFolders(spec.tags);
 		const tally = new SkipTally();
 		const baseUrl = resolveServerUrl(asArray(spec.servers)[0], source.sourceUrl, tally);
 		// One identifier for the whole document: it is what keeps a repeated
@@ -146,14 +146,7 @@ export class OpenApiV3Parser implements ImportParser {
 					tally,
 					identity
 				);
-				const tag = asStr(asArray(op.tags)[0]);
-				if (tag) {
-					if (!tagCollections.has(tag))
-						tagCollections.set(tag, makeTagCollection(spec, tag));
-					tagCollections.get(tag)!.requests.push(req);
-				} else {
-					rootRequests.push(req);
-				}
+				folders.place(req, path, op.tags);
 			}
 		}
 
@@ -166,8 +159,8 @@ export class OpenApiV3Parser implements ImportParser {
 			auth: schemeToAuth(primaryScheme),
 			preRequestScript: "",
 			postRequestScript: "",
-			children: [...tagCollections.values()],
-			requests: rootRequests,
+			children: folders.children(),
+			requests: folders.rootRequests(),
 			// The document itself, so the import can store it and bind this
 			// collection to it in the same atomic call (issue #637). `raw` and not
 			// a re-serialization: the engine hashes the bytes it stores, and a
@@ -194,7 +187,8 @@ export class OpenApiV3Parser implements ImportParser {
 			meta: {
 				format: this.formatName,
 				requestCount,
-				folderCount: tagCollections.size,
+				folderCount: folders.count(),
+				...(folders.strategy() ? { folderStrategy: folders.strategy() } : {}),
 				environmentCount: 0,
 				globalCount: 0,
 				exampleCount: countExamples([root]),
@@ -274,20 +268,6 @@ function pickPrimaryScheme(spec: JsonRecord): unknown {
 	const schemes = asRecord(prop(spec.components, "securitySchemes")) ?? {};
 	if (reqName && schemes[reqName]) return schemes[reqName];
 	return Object.values(schemes)[0];
-}
-
-function makeTagCollection(spec: JsonRecord, tag: string): CollectionDraft {
-	const def = asArray(spec.tags).find((t) => prop(t, "name") === tag);
-	return {
-		name: tag,
-		description: asStr(prop(def, "description")) ?? "",
-		variables: {},
-		auth: { mode: "none" },
-		preRequestScript: "",
-		postRequestScript: "",
-		children: [],
-		requests: [],
-	};
 }
 
 function buildOperation(

--- a/app/src/services/importers/types.ts
+++ b/app/src/services/importers/types.ts
@@ -41,12 +41,23 @@ export interface SkippedItem {
 		| "unsupported_method"
 		| "malformed_spec"
 		/**
-		 * An OpenAPI response whose key is not a numeric status - `default`, or a
-		 * `2XX` wildcard. It documents a real response, but a saved example is
-		 * served under one status line and there is no honest value to pick, so it
-		 * is dropped and counted rather than guessed at (issue #481).
+		 * An OpenAPI response whose key is not a numeric status and is not
+		 * `default` - a `2XX` wildcard, or junk. It documents a real response, but
+		 * a saved example is served under one status line and there is no honest
+		 * value to pick, so it is dropped and counted rather than guessed at
+		 * (issue #481).
 		 */
 		| "example_no_status"
+		/**
+		 * An OpenAPI response keyed `default` (issue #710). Dropped for exactly the
+		 * reason above - a catch-all has no status line to be served under - but
+		 * counted apart from it, because it is not a defect: `default` is
+		 * spec-conformant and near-universal (all 568 of Stripe's operations
+		 * declare one), so folded in with malformed keys it painted a valid
+		 * document as hundreds of losses and buried the warnings that could be
+		 * acted on. The preview ranks it as information, not damage.
+		 */
+		| "default_response"
 		/**
 		 * A `$ref` naming a file the import could not reach - unfetchable,
 		 * unparseable, or relative in a pasted document that has no directory and
@@ -96,11 +107,30 @@ export interface SkippedItem {
 	count: number;
 }
 
+/**
+ * Which rule an OpenAPI import grouped its folders by (issue #710): the
+ * operations' own `tags`, the first meaningful segment of their paths for
+ * operations that declare none, or both in one document.
+ */
+export type FolderStrategy = "tags" | "paths" | "mixed";
+
 export interface ImportMeta {
 	format: string;
 	fileName?: string;
 	requestCount: number;
 	folderCount: number;
+	/**
+	 * How the folders above came to exist (issue #710), disclosed in the preview.
+	 * Path grouping builds a tree the document never spelled out, so a user
+	 * looking at ~150 folders for a spec with no tags in it has to be able to see
+	 * why they are there.
+	 *
+	 * Optional, and only the two OpenAPI parsers set it: a format that carries its
+	 * own folders (Postman, Insomnia) makes no such choice, and one that says
+	 * nothing must not look like one that said "tags". Absent too when a document
+	 * produced no folders at all - there is no rule to explain.
+	 */
+	folderStrategy?: FolderStrategy;
 	environmentCount: number;
 	/** Variables destined for Vayu's globals scope. Only a Postman globals export produces any. */
 	globalCount: number;

--- a/app/src/services/openapi/spec-apply.test.ts
+++ b/app/src/services/openapi/spec-apply.test.ts
@@ -289,13 +289,31 @@ describe("buildSyncPayload", () => {
 		expect(body.create.every((item) => item.collectionId === undefined)).toBe(true);
 	});
 
-	it("puts an untagged operation on the bound collection itself", () => {
+	it("puts an untagged operation where an import would - its path folder (#710)", () => {
 		const fetched = doc({
 			"/pets": { get: { operationId: "listPets", summary: "List pets", tags: ["pets"] } },
 			"/owners": {
 				get: { operationId: "listOwners", summary: "List owners", tags: ["owners"] },
 			},
 			"/health": { get: { operationId: "health", summary: "Health" } },
+		});
+		const body = payload(fetched, boundCollection());
+
+		// A synced collection has to end up shaped like an imported one, so the
+		// added request follows the import's grouping rather than the rule that
+		// held before the path fallback existed.
+		expect(body.collections).toHaveLength(1);
+		expect(body.collections[0].name).toBe("health");
+		expect(body.create[0].collectionTempId).toBe(body.collections[0].tempId);
+	});
+
+	it("still puts an operation whose path names no resource on the bound collection", () => {
+		const fetched = doc({
+			"/pets": { get: { operationId: "listPets", summary: "List pets", tags: ["pets"] } },
+			"/owners": {
+				get: { operationId: "listOwners", summary: "List owners", tags: ["owners"] },
+			},
+			"/{id}": { get: { operationId: "byId", summary: "By id" } },
 		});
 		const body = payload(fetched, boundCollection());
 

--- a/app/src/services/openapi/spec-apply.ts
+++ b/app/src/services/openapi/spec-apply.ts
@@ -145,7 +145,7 @@ export interface BuildSyncPayloadInput {
 	 * it would silently turn validation off for a collection that had it.
 	 */
 	responseSchemas?: ResponseSchemaIndex;
-	/** Every stored collection, to find the tag folder an added operation lands in. */
+	/** Every stored collection, to find the folder an added operation lands in. */
 	collections: readonly Collection[];
 }
 
@@ -153,9 +153,10 @@ export interface BuildSyncPayloadInput {
  * The `POST /specs/sync` body for one selection.
  *
  * Added operations land where an import would have put them - the sub-collection
- * named after the operation's first tag, created here when the bound collection
- * does not have one yet, and the bound collection itself for an untagged
- * operation. Matching an existing folder by name rather than creating one per
+ * named after the operation's first tag, else the one its path names (issue
+ * #710), created here when the bound collection does not have one yet, and the
+ * bound collection itself for an operation that gets neither. Matching an
+ * existing folder by name rather than creating one per
  * sync is what keeps a collection that has been synced five times shaped like
  * one that was imported once.
  */
@@ -258,7 +259,7 @@ class FolderResolver {
 		collections: readonly Collection[]
 	) {
 		for (const collection of collections) {
-			// Direct children only: an import files its tag folders on the bound
+			// Direct children only: an import files its folders on the bound
 			// collection itself, so a same-named folder two levels down is somebody
 			// else's and matching it would move the operation out of the shape the
 			// document describes.

--- a/app/src/services/openapi/spec-operations.ts
+++ b/app/src/services/openapi/spec-operations.ts
@@ -37,9 +37,9 @@ export interface SpecRequestDraft {
 	operation: SpecOperation;
 	draft: RequestDraft;
 	/**
-	 * The sub-collection an import files this operation under - its first tag -
-	 * and `""` for an operation with no tag, which imports onto the root
-	 * (issue #655).
+	 * The sub-collection an import files this operation under - its first tag,
+	 * else the folder its path names (issue #710) - and `""` for an operation
+	 * that gets neither, which imports onto the root (issue #655).
 	 *
 	 * Kept because applying an *added* operation has to put the request
 	 * somewhere, and "where an import would have put it" is the only answer that

--- a/app/src/test/import-drafts.ts
+++ b/app/src/test/import-drafts.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Reading requests out of a parsed import without depending on where the parser
+ * filed them (issue #710).
+ *
+ * Every OpenAPI test that asserts something about *one* request - its headers,
+ * its body, the value on a query row - used to reach for
+ * `collections[0].requests[0]`, which encoded the grouping rule into ~50
+ * assertions that are not about grouping at all. The moment untagged operations
+ * gained a path-derived folder, all of them read `undefined`.
+ *
+ * So: walk the tree. A test that means "the request this one-operation fixture
+ * produced" now says exactly that, and stays true whichever folder holds it.
+ * Grouping itself is asserted where it belongs, in `openapi-folders.test.ts`.
+ */
+
+import type { CollectionDraft, ImportResult, RequestDraft } from "@/services/importers/types";
+
+/** Every request in a draft tree, root-level first, then each folder's, in order. */
+export function allRequests(collections: CollectionDraft[]): RequestDraft[] {
+	return collections.flatMap((c) => [...c.requests, ...allRequests(c.children)]);
+}
+
+/** Every request a parsed import produced, whichever folder each one landed in. */
+export function requestsOf(result: ImportResult): RequestDraft[] {
+	return allRequests(result.collections);
+}
+
+/**
+ * The single request a one-operation fixture produced, wherever grouping put it.
+ *
+ * Throws rather than picking the first of several: a fixture that grew a second
+ * operation would otherwise silently move the assertion onto a different
+ * request.
+ */
+export function soleRequest(result: ImportResult): RequestDraft {
+	const found = allRequests(result.collections);
+	if (found.length !== 1) {
+		throw new Error(`expected exactly one imported request, found ${found.length}`);
+	}
+	return found[0];
+}
+
+/** The request named @p name, wherever grouping put it. */
+export function requestNamed(result: ImportResult, name: string): RequestDraft {
+	const found = allRequests(result.collections).filter((r) => r.name === name);
+	if (found.length !== 1) {
+		throw new Error(`expected exactly one request named "${name}", found ${found.length}`);
+	}
+	return found[0];
+}

--- a/docs/app/import-collections/README.md
+++ b/docs/app/import-collections/README.md
@@ -267,8 +267,15 @@ stored order - a mock server answers with the first example of a matched request
 **`EnvironmentDraft`** - `name`, `description`, `variables: Record<string, VariableValue>`.
 
 **`ImportMeta`** - `format`, `fileName?`, `requestCount`, `folderCount`,
-`environmentCount`, `globalCount`, `exampleCount`, `skipped: SkippedItem[]`,
-`nonExecutableAuth: number`, `unattachedFileParts: number`.
+`folderStrategy?`, `environmentCount`, `globalCount`, `exampleCount`,
+`skipped: SkippedItem[]`, `nonExecutableAuth: number`, `unattachedFileParts: number`.
+
+`folderStrategy` (`"tags" | "paths" | "mixed"`) says which rule an OpenAPI import grouped its
+folders by, and the Preview states it whenever paths were involved - a folder tree the
+document never spelled out must not read as one it did (issue #710, see
+[openapi-v3.md](./openapi-v3.md#tree-structure)). Only the two OpenAPI parsers set it: a
+format that carries its own folders makes no such choice, and a parser that says nothing must
+not look like one that said `"tags"`.
 
 `exampleCount` totals the saved example responses across the whole tree, from
 `countExamples(collections)` in `shared.ts` - read off the finished drafts for the same
@@ -283,8 +290,8 @@ than tallying while building them, so the number and the rows cannot disagree.
 
 **`SkippedItem`** - `{ kind: "websocket" | "grpc" | "api_spec" | "unit_test" | "file_body" |
 "malformed_item" | "unsupported_method" | "malformed_spec" | "example_no_status" |
-"external_ref" | "duplicate_operation_id" | "cookie_param" | "unmapped_body" |
-"unresolved_base_url", count }`.
+"default_response" | "external_ref" | "duplicate_operation_id" | "cookie_param" |
+"unmapped_body" | "unresolved_base_url", count }`.
 Surfaces work Vayu can't represent so the Preview can warn instead of silently dropping.
 Three of the kinds are not about representability: `unsupported_method` is an operation whose
 HTTP method has no `HttpMethod` (OpenAPI 3's `trace`), and `malformed_item` / `malformed_spec`
@@ -293,9 +300,13 @@ are shapes the source file got wrong - a Postman `item[]` entry that is not an o
 spec allows - stepped over so the rest of the file still imports. The two OpenAPI kinds are
 counted via `SkipTally` in `openapi-shared.ts`, shared by both OpenAPI parsers: they are
 structural clones, and a second copy would drift. `example_no_status` is a fourth
-non-representability case: an OpenAPI response keyed `default` or `2XX` documents a real
-response, but an example is served under one status line and there is no honest value to
-pick, so it is counted rather than guessed at. `external_ref` is the fifth, and the only
+non-representability case: an OpenAPI response keyed `2XX` (or with a junk key) documents a
+real response, but an example is served under one status line and there is no honest value
+to pick, so it is counted rather than guessed at. `default_response` is the same skip for the
+`default` key, on a counter of its own (issue #710) because it is conformant and declared on
+nearly every operation of a vendor spec - the Preview names it as information rather than as
+damage, which is what keeps a 568-count line from burying the one warning that needs acting
+on. `external_ref` is the fifth, and the only
 kind no parser produces: a `$ref` naming another file that the bundling pass could not
 read (`ref-bundler.ts`, issue #649) is counted **before** parse and stamped into
 `meta.skipped` by `parseImport`, one per reference - because each one is an operation that

--- a/docs/app/import-collections/openapi-v2.md
+++ b/docs/app/import-collections/openapi-v2.md
@@ -37,24 +37,27 @@ The top-level `swagger` field must be the string `"2.0"` or the **number** `2` (
 
 ## Tree structure
 
-The spec maps to a single root collection, with operations grouped into child collections by their first tag.
+The spec maps to a single root collection, with operations grouped into child collections by their first tag - or, for an operation that declares no tag, by the first meaningful segment of its path (issue #710).
 
 - **Root collection** ← the whole spec (named from `info.title`). It directly holds:
-  - `requests`: every **untagged** operation (`rootRequests`).
-  - `children`: one child collection per distinct first-tag, in first-encounter order.
-- **Tag child collections** ← created lazily, inline in `parse`, the first time a tag is seen, keyed in a `Map<string, CollectionDraft>` (`tagCollections`). Description comes from the matching entry in the top-level `tags[]` array (if any).
+  - `requests`: every operation that has neither a tag nor a groupable path.
+  - `children`: one child collection per distinct folder name, in first-encounter order.
+- **Child collections** ← created lazily by `OperationFolders` (`openapi-shared.ts`), the first time a name is seen. A tag-named folder takes its description from the matching entry in the top-level `tags[]` array (if any); a path-named folder has none.
 
 Iteration order: `parse` loops over `spec.paths` entries, and for each path item over the fixed `HTTP_METHODS` list (`get, post, put, patch, delete, head, options`). For each present operation it calls `buildSwaggerOp(...)`, then routes by tag:
 
 ```ts
-const tag = op.tags?.[0];   // ONLY the first tag is used
-if (tag) tagCollections.get(tag).requests.push(req);
-else     rootRequests.push(req);
+const tag  = op.tags?.[0];              // ONLY the first tag is used
+const name = tag ?? pathFolderName(path);  // the fallback, per operation
+if (name) folders.get(name).requests.push(req);
+else      rootRequests.push(req);
 ```
 
-**Multi-tag operations:** only `op.tags[0]` is consulted. An operation with `tags: ["a", "b"]` lands solely in the `a` child collection; `b` is ignored (no duplication, no extra folder). An operation with no `tags` (or `tags: []`) becomes a root request.
+**Multi-tag operations:** only `op.tags[0]` is consulted. An operation with `tags: ["a", "b"]` lands solely in the `a` child collection; `b` is ignored (no duplication, no extra folder).
 
-Unlike v3 (which has dedicated `makeTagCollection` / `buildBody` helpers), v2 builds the root and tag collections inline in `parse` and delegates only the per-operation draft to `buildSwaggerOp`. `$ref` resolution comes from `createRefResolver` (`openapi-shared.ts`), the same one the v3 parser uses - both had built it by hand, identically, until issue #649.
+**Untagged operations** take the same path fallback the v3 parser does, from the same `OperationFolders` - the rule, its version/`api`/`{template}` skips and `meta.folderStrategy` are written out once, in [OpenAPI 3.0](./openapi-v3.md#tree-structure).
+
+Unlike v3 (which has a dedicated `buildBody` helper), v2 builds the root collection inline in `parse` and delegates only the per-operation draft to `buildSwaggerOp`. `$ref` resolution comes from `createRefResolver` (`openapi-shared.ts`), the same one the v3 parser uses - both had built it by hand, identically, until issue #649.
 
 References naming **other files** (`./definitions/pet.yaml#/Pet`) are resolved before this parser runs, by `ref-bundler.ts`; what could not be reached is counted as an `external_ref` `SkippedItem`. The rules are the same for both OpenAPI parsers and are written out in [OpenAPI 3.0](./openapi-v3.md#external-refs) and [OpenAPI Collections](../openapi.md#specs-written-across-several-files).
 
@@ -71,12 +74,12 @@ Built inline in `parse`.
 | `schemes` + `host` + `basePath` | `variables.baseUrl` | only added when `host` is present: `{ baseUrl: { value: baseUrl, enabled: true } }`; otherwise `variables` is `{}`. See [Base URL](#base-url-construction). |
 | `security` / `securityDefinitions` | `auth` | via the picked primary scheme + `swaggerSchemeToAuth` (see [Auth](#auth--security)). Collections never inherit. |
 | (none) | `preRequestScript` / `postRequestScript` | always `""` |
-| tag groups | `children` | `[...tagCollections.values()]` |
-| untagged operations | `requests` | |
+| tag and path groups | `children` | `folders.children()` |
+| operations with neither | `requests` | |
 
-### Collection (per tag)
+### Collection (per folder)
 
-Built inline when a tag is first encountered.
+Built by `OperationFolders` (`openapi-shared.ts`), shared with the v3 parser.
 
 | Swagger | Vayu `CollectionDraft` | Notes |
 |---------|------------------------|-------|
@@ -124,7 +127,7 @@ Saved example responses (issue #481), from the half of the spec that says what c
 | `examples[<media type>]` → `sampleSchema(schema)` | `body` | documented example first, generated sample second - the same precedence this file already uses for a request body |
 | `op.produces` → `spec.produces` | `contentType`, and a single `Content-Type` header | a 2.0 response does not name its own media type; the JSON entry wins, and a spec that lists no `produces` at all is treated as `application/json` |
 
-A response that documents no body still imports (`204` is a real answer), and a key that is not a numeric status - `default`, or a wildcard - is skipped and counted as `example_no_status`.
+A response that documents no body still imports (`204` is a real answer), and a key that is not a numeric status is skipped and counted: `default` as `default_response`, a wildcard or junk key as `example_no_status` - counted apart for the reason [OpenAPI 3.0](./openapi-v3.md#documented-responses) gives.
 
 ## Base URL construction
 
@@ -304,7 +307,7 @@ Dropped / not represented:
 - **Multi-tag grouping:** only the first tag groups an operation.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
 
-`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of tag collections (`tagCollections.size`), `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec`, `example_no_status` and `duplicate_operation_id` are the only kinds this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). The three kinds issue #719 added are v3-only for the same kind of reason: Swagger 2.0 has no `in: "cookie"` parameter, no Server Object to template or leave relative - `host` is a host - and every declared body maps to one, so `cookie_param`, `unresolved_base_url` and `unmapped_body` have no case here either. Nothing to report still yields `[]`.
+`meta` population: `format = "OpenAPI 2.0 (Swagger)"`, `requestCount` = total operations built, `folderCount` = number of folders (`folders.count()`), `folderStrategy` = which rule produced them, `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the shared `SkipTally` - `malformed_spec`, `example_no_status`, `default_response` and `duplicate_operation_id` are the only kinds this parser can emit (Swagger 2.0's Path Item Object has no `trace`, so there is no `unsupported_method` case here). The three kinds issue #719 added are v3-only for the same kind of reason: Swagger 2.0 has no `in: "cookie"` parameter, no Server Object to template or leave relative - `host` is a host - and every declared body maps to one, so `cookie_param`, `unresolved_base_url` and `unmapped_body` have no case here either. Nothing to report still yields `[]`.
 
 ## Differences from OpenAPI 3.0
 
@@ -323,9 +326,9 @@ See [OpenAPI v3](./openapi-v3.md) for the v3 reference. Key contrasts:
 | `$ref` namespace | `#/definitions/...` | `#/components/schemas/...` (resolver is generic in both) |
 | Auth schemes | `securityDefinitions` (`basic`, `apiKey`, `oauth2`) | `components.securitySchemes` (`http`/bearer/basic, `apiKey`, `oauth2`) |
 | Auth helper | `swaggerSchemeToAuth` | `schemeToAuth` |
-| Collection build | inline in `parse` | helper `makeTagCollection` |
+| Collection build | root inline in `parse`; folders from the shared `OperationFolders` | root inline in `parse`; folders from the shared `OperationFolders` |
 
-Shared between both: tree-by-first-tag, `{{baseUrl}}`-prefixed URLs, `normalizeVars` path conversion, `sampleSchema`, request `auth: inherit`, `ImportOptions` ignored, and the `openapi-shared.ts` helpers (`resolvePathItem`, `SkipTally`) - so a `$ref`'d path item, a malformed `parameters` list, and `meta.skipped` behave identically in both.
+Shared between both: the folder routing (`OperationFolders` - first tag, else path segment), `{{baseUrl}}`-prefixed URLs, `normalizeVars` path conversion, `sampleSchema`, request `auth: inherit`, `ImportOptions` ignored, and the `openapi-shared.ts` helpers (`resolvePathItem`, `SkipTally`) - so a `$ref`'d path item, a malformed `parameters` list, and `meta.skipped` behave identically in both.
 
 ## Shared helpers used
 

--- a/docs/app/import-collections/openapi-v3.md
+++ b/docs/app/import-collections/openapi-v3.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  What Vayu generates from an OpenAPI 3.0 or 3.1 specification - collections per tag, request stubs, servers, security schemes, and schema-sampled bodies.
+  What Vayu generates from an OpenAPI 3.0 or 3.1 specification - collections per tag (or per path segment for untagged operations), request stubs, servers, security schemes, and schema-sampled bodies.
 ---
 
 # OpenAPI 3.0
@@ -37,26 +37,37 @@ The top-level `openapi` field must be a string beginning with `"3."` (so `3.0.0`
 
 ## Tree structure
 
-The spec maps to a single root collection, with operations grouped into child collections by their first tag.
+The spec maps to a single root collection, with operations grouped into child collections by their first tag - or, for an operation that declares no tag, by the first meaningful segment of its path (issue #710).
 
 - **Root collection** ← the whole spec (named from `info.title`). It directly holds:
-  - `requests`: every **untagged** operation.
-  - `children`: one child collection per distinct first-tag, in first-encounter order.
-- **Tag child collections** ← created lazily by `makeTagCollection(spec, tag)` the first time a tag is seen, keyed in a `Map<string, CollectionDraft>`. Description comes from the matching entry in the top-level `tags[]` array (if any).
+  - `requests`: every operation that has neither a tag nor a groupable path.
+  - `children`: one child collection per distinct folder name, in first-encounter order.
+- **Child collections** ← created lazily by `OperationFolders` (`openapi-shared.ts`) the first time a name is seen, keyed in a `Map<string, CollectionDraft>`. A tag-named folder takes its description from the matching entry in the top-level `tags[]` array (if any); a path-named folder has none, because the document declares none.
 
 Iteration order: `parse` loops over `spec.paths` entries, resolves each path item through `resolvePathItem` (`openapi-shared.ts`) so a `{"$ref": "#/components/pathItems/X"}` item is read from its target instead of contributing nothing, and then loops over the fixed `HTTP_METHODS` list (`get, post, put, patch, delete, head, options`). A path item that is not an object - or whose `$ref` does not resolve to one - is counted as a `malformed_spec` [`SkippedItem`](./README.md#draft-model-the-parser-output-contract) and skipped, so the drop is named in the preview rather than silent. The ref is followed **one hop only**, like the parameter and `requestBody` refs. For each present operation `parse` calls `buildOperation(...)`, then routes by tag:
 
 ```ts
-const tag = op.tags?.[0];   // ONLY the first tag is used
-if (tag) tagCollections.get(tag).requests.push(req);
-else     rootRequests.push(req);
+const tag  = op.tags?.[0];              // ONLY the first tag is used
+const name = tag ?? pathFolderName(path);  // the fallback, per operation
+if (name) folders.get(name).requests.push(req);
+else      rootRequests.push(req);
 ```
 
-**Multi-tag operations:** only `op.tags[0]` is consulted. An operation with `tags: ["a", "b"]` lands solely in the `a` child collection; `b` is ignored (no duplication, no extra folder). An operation with no `tags` (or `tags: []`) becomes a root request.
+**Multi-tag operations:** only `op.tags[0]` is consulted. An operation with `tags: ["a", "b"]` lands solely in the `a` child collection; `b` is ignored (no duplication, no extra folder).
+
+**Untagged operations - the path fallback.** A document whose operations carry no `tags` at all is common and not broken: Stripe's official spec declares root-level `tags:` that **no operation references**, so grouping by tag alone imported all 568 of its operations as one flat list. `pathFolderName` (`openapi-shared.ts`) therefore names a folder from the first path segment that names a resource:
+
+- Leading segments that name no resource are stepped over: a version (`v1`, `v2.1`), the `api` mount point, and a whole-`{template}` segment. `/api/v2/{tenant}/orders` is `orders`.
+- The segment is taken exactly as written (`account_links`), because that is the name the vendor's own documentation uses.
+- A path with nothing left - `/`, `/v1`, `/{id}` - yields no folder, and its request stays on the root rather than being filed under a placeholder.
+
+The fallback applies **per operation**, so a partly tagged document gets both rules. A path-derived name that a tag also uses is one folder holding both, not two folders with one name; the tag's description is kept. Inferring folders from root `tags[]` entries that no operation references (Stripe's `x-kind: api-group` list) is a recorded **non-goal** - matching those names onto paths is vendor-specific guesswork.
+
+Which rule ran is reported as `meta.folderStrategy` (`"tags"`, `"paths"` or `"mixed"`), and the import preview states it whenever paths were involved: a folder tree the document never spelled out must not read as one it did.
 
 **`trace` operations:** OpenAPI 3's Path Item Object also defines `trace`, which is **not** in `HTTP_METHODS` because `HttpMethod` (`types/domain.ts`) has no `"TRACE"` - Vayu cannot execute one. A `trace` operation is therefore not built, is **not** counted in `requestCount`, and is counted as an `unsupported_method` `SkippedItem` so the preview says so. `UNSUPPORTED_METHODS` in `openapi-v3.ts` is the list; `trace` is its only member, since a path item defines exactly the eight methods.
 
-Key internal functions: `buildOperation` (per-operation `RequestDraft`), `makeTagCollection` (per-tag `CollectionDraft`), `buildBody` / `findJsonMedia` (request body), `pickPrimaryScheme` / `schemeToAuth` (collection auth), and `createRefResolver` (`openapi-shared.ts`) for `$ref` resolution - shared with the v2 parser, which built the identical closure by hand until issue #649.
+Key internal functions: `buildOperation` (per-operation `RequestDraft`), `OperationFolders` / `pathFolderName` (`openapi-shared.ts`, folder routing - shared with the v2 parser), `buildBody` / `findJsonMedia` (request body), `pickPrimaryScheme` / `schemeToAuth` (collection auth), and `createRefResolver` (`openapi-shared.ts`) for `$ref` resolution - shared with the v2 parser, which built the identical closure by hand until issue #649.
 
 ## External `$ref`s
 
@@ -110,18 +121,18 @@ A response `$ref` is resolved (single hop, like the parser's other refs). An `ex
 
 A response that documents **no body** still imports: `204 No Content` is a real answer and a mock server has to be able to give it.
 
-A key that is not a numeric status - `default`, or a `2XX` wildcard - is **skipped and counted** as `example_no_status`. It documents a real response, but an example is served under one status line and there is no honest value to pick.
-| tag groups | `children` | `[...tagCollections.values()]` |
-| untagged operations | `requests` | |
+A key that is not a numeric status is **skipped and counted**: `default` as `default_response`, anything else (a `2XX` wildcard, junk) as `example_no_status`. Both document a real response, but an example is served under one status line and there is no honest value to pick. They are counted apart because `default` is conformant and near-universal - every one of Stripe's 568 operations declares one - so the preview names it as information while a malformed key stays a warning (issue #710).
+| tag and path groups | `children` | `folders.children()` |
+| operations with neither | `requests` | |
 
-### Collection (per tag)
+### Collection (per folder)
 
-Built by `makeTagCollection(spec, tag)`.
+Built by `OperationFolders` (`openapi-shared.ts`), shared with the v2 parser.
 
 | OpenAPI | Vayu `CollectionDraft` | Notes |
 |---------|------------------------|-------|
-| `tag` (the string) | `name` | |
-| `tags[].description` where `tags[].name === tag` | `description` | fallback `""` |
+| `tags[0]`, else the first meaningful path segment | `name` | see [Tree structure](#tree-structure) |
+| `tags[].description` where `tags[].name === tag` | `description` | fallback `""`; a path-named folder has none unless a tag of the same name arrives |
 | (none) | `variables` | always `{}` (baseUrl lives only on the root) |
 | (none) | `auth` | always `{ mode: "none" }` - tag collections do not carry security |
 | (none) | `children` | always `[]` (tags are flat; no nesting) |
@@ -262,19 +273,21 @@ Dropped / not represented:
 - **Cookie parameters** and **path parameters as params**: not emitted (path params live in the URL only).
 - **`authorization` / `content-type` header parameters:** dropped (Vayu manages them).
 - **Multi-tag grouping:** only the first tag groups an operation.
+- **Root `tags[]` entries no operation references:** not turned into folders - see the path fallback in [Tree structure](#tree-structure).
 - **`trace` operations:** dropped - `HttpMethod` has no `"TRACE"`. Counted as `unsupported_method` (see [Tree structure](#tree-structure)), not silently omitted.
 - **A path item, or a `parameters` list, whose shape the spec does not allow:** stepped over and counted as `malformed_spec` so the rest of the file still imports.
 - **Form-field property schemas:** only field **names** and whether the field is a file (`format: binary`) are imported; `required`, other types, and nested structure are not.
 - **A whole-body binary** (`application/octet-stream` and other non-form, non-JSON, non-text media types): no body is produced (`{ mode: "none" }`) and the operation is counted as `unmapped_body` (issue #719) - unlike a multipart file part, which imports (see [File parts](#file-parts)). An operation that declares no `requestBody` at all is **not** counted: it lost nothing, and the two used to be indistinguishable.
 - **Cookie parameters** (`in: "cookie"`): dropped and counted as `cookie_param` (issue #719). Vayu has no cookie-parameter row - a request's cookies come from the jar - and mapping them onto a `Cookie` header is a recorded non-goal: the header is one joined value while a spec declares these one at a time, so building it would mean inventing a merge the document never wrote. `in: "path"` is neither dropped nor counted; it is already carried, as the `{{param}}` the URL template holds.
 
-`meta` population: `format = "OpenAPI 3.0"`, `requestCount` = total operations built (TRACE excluded), `folderCount` = number of tag collections, `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the `SkipTally`:
+`meta` population: `format = "OpenAPI 3.0"`, `requestCount` = total operations built (TRACE excluded), `folderCount` = number of folders (`folders.count()`), `folderStrategy` = which rule produced them (`"tags"` / `"paths"` / `"mixed"`, absent when there are no folders), `environmentCount = 0`, `exampleCount` = example responses imported (read off the finished drafts by `countExamples`), `nonExecutableAuth = 0` (oauth2 is now executable), `unattachedFileParts` = file parts imported with no file attached (`unattachedFileParts`, read off the finished drafts), and `skipped` from the `SkipTally`:
 
 | `SkippedItem.kind` | Counted when |
 |--------------------|--------------|
 | `unsupported_method` | a path item carries a `trace` operation |
 | `malformed_spec` | a path item is not an object / its `$ref` does not resolve; or a `parameters` value is present but not an array |
-| `example_no_status` | a response key is not a three-digit status - `default`, or a `2XX` wildcard |
+| `example_no_status` | a response key is neither a three-digit status nor `default` - a `2XX` wildcard, or junk |
+| `default_response` | a response keyed `default` - conformant, and reported as information rather than as a loss |
 | `duplicate_operation_id` | an `operationId` another operation in this document already declared (see [Operation identity](#operation-identity)) |
 | `cookie_param` | a parameter declared `in: "cookie"` - one per distinct cookie parameter per operation |
 | `unmapped_body` | a `requestBody` declaring only media types with no Vayu mode - one per operation, however many such media types it listed |

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -333,10 +333,12 @@ in the same apply as everything else you ticked.
 
 ### Where a new operation lands
 
-In the sub-collection named after its first tag, exactly where an import would
-have filed it - matched by name against the folders the bound collection
-already has, and created once per tag when there is none. An operation with no
-tag lands on the bound collection itself.
+In the sub-collection named after its first tag - or, when the operation
+declares no tag, the one named after the first meaningful segment of its path -
+exactly where an import would have filed it. The folder is matched by name
+against those the bound collection already has, and created once when there is
+none. An operation that gets neither name (a path like `/` or `/{id}`) lands on
+the bound collection itself.
 
 ### What applying does to examples
 


### PR DESCRIPTION
## Description

Both findings of #710, verified live at `8fbe515` and still present as described.

**Plan.** Root cause of item 1: the grouping decision is `op.tags[0]` and nothing else (`openapi-v3.ts:149`, `openapi-v2.ts:161`), so a document that declares root `tags:` its operations never reference - Stripe's shape, and GitHub's - has no grouping key at all and every request falls to `rootRequests`. The fix adds a per-operation fallback to the first meaningful path segment and moves the whole routing into a shared `OperationFolders` (`openapi-shared.ts`), because both parsers already held a hand-rolled copy of the tag map plus the tag-description lookup, and the segment logic would have become the third copy. Root cause of item 2: `responseExample` refuses a non-numeric key correctly, but files `default` on the same counter as `2XX` and junk keys - and `default` is conformant and on nearly every operation of a vendor spec, so the preview's one destructive line read "568 example responses with no numeric status" beside "1 file part needs a file". The behaviour is right; the counter and the severity were not.

The alternative I rejected for item 1 was making the fallback conditional on size (only flatten-rescue a spec above N requests): a threshold is a knob the issue did not ask for, and it would make two specs of the same shape import differently. For item 2 I rejected dropping the `default` count entirely - the disclosure discipline says nothing vanishes silently; what changes is how it is ranked.

Engine: unchanged - this issue is app-only.

App:
- `pathFolderName` names a folder from the first path segment that names a resource, stepping over a version (`v1`, `v2.1`), the `api` mount point and a whole `{template}` segment. `/api/v2/{tenant}/orders` is `orders`; `/`, `/v1` and `/{id}` yield nothing and keep their request on the root rather than filing it under a placeholder. The segment is taken as written (`account_links`), because that is the name the vendor's own docs use.
- `OperationFolders` routes every operation: first tag, else path folder, else root - shared by both parsers, so a tagged spec's tree is byte-identical to before. A path-derived name that a tag also uses is **one** folder holding both, and the tag's description is filled in rather than dropped.
- Root `tags[]` entries no operation references stay a recorded non-goal - matching Stripe's `x-kind: api-group` names onto paths is vendor guesswork.
- `meta.folderStrategy` (`"tags" | "paths" | "mixed"`, absent when there are no folders) is read by the preview, which states "Folders from paths - this spec declares no operation tags" whenever paths were involved. Optional, and only the OpenAPI parsers set it: a format carrying its own folders makes no such choice.
- `default` responses get their own skip kind, `default_response`, and the preview splits its one line in two: `lossSummary` (destructive, unchanged wording) and a new `noticeSummary` (muted, `Info` icon). Both are shared by the single-file preview and every batch-ledger row, the same way `lossSummary` already was - a batch has to say per file what one file says alone.
- Sync needed no change and got the same grouping for free: `spec-apply` derives an added operation's folder from the parse, so a synced collection stays shaped like an imported one. Its comments and one test were updated to the new rule.

Tests that assert something about *one* request stopped reading `collections[0].requests[0]` - that encoded the grouping rule into ~50 assertions that are not about grouping - and now go through `requestsOf` / `requestNamed` / `soleRequest` in `src/test/import-drafts.ts`.

Docs updated in the same commit: `docs/app/import-collections/openapi-v3.md` (tree structure, the fallback rule, the response-key split, `meta` population, skip-kind table), `openapi-v2.md` (same, pointing at v3 for the shared rule), `README.md` (the `ImportMeta` and `SkippedItem` contracts), and `docs/app/openapi.md` (where a new operation lands on sync).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

```
cd app && pnpm test          # 507 files, 5418 passed
cd app && pnpm type-check    # clean
cd app && pnpm lint          # clean
cd app && pnpm format:check  # clean on every file touched (all were clean before)
mkdocs build --strict -f .github/mkdocs.yml   # clean
```

New tests:
- `openapi-folders.test.ts` - the three tagging shapes the issue asks for, driven through **both** parsers: (a) no tags anywhere, (b) the Stripe shape (root tags no operation references), (c) partly tagged. Plus the version/`api`/`{template}` skips, the no-resource path staying on the root, folder counts, and `folderStrategy`. Mutation-checked: routing every untagged request to the root fails 5 of the 9; dropping the version skip fails 6 (the Stripe-shaped case files everything under `v1`).
- `ImportModal.notices.test.tsx` - the `default` line renders `text-muted-foreground` while the `2XX` line keeps `text-destructive-text`, and the folder-strategy disclosure appears for a path-grouped spec and not for a tagged one. Mutation-checked: emptying `INFORMATIONAL_KINDS` fails the first case.
- `examples-import.test.ts` - the tally split (`default_response: 1`, `example_no_status: 1` from one operation declaring both), replacing the old combined `count: 2`.
- `openapi-v3.test.ts` - the shared fixture's untagged `/health` now asserts its path folder rather than root placement.
- `spec-apply.test.ts` - an added untagged operation lands in its path folder, and one whose path names no resource still lands on the bound collection.

Engine was not built or tested: no C++ file is touched by this change, and no app-side behaviour here crosses the HTTP API.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues
Closes #710

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaY2J96CiUED68uLqhmHzn)_