### PR TITLE
feat(app/mcp): mock servers over MCP, and live-editing a running mock issuer

### DIFF
--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -57,6 +57,16 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		deleteInbox: vi.fn().mockResolvedValue({ inboxId: "inbox_1", capturesDeleted: 2 }),
 		clearInboxCaptures: vi.fn().mockResolvedValue({ inboxId: "inbox_1", cleared: 2 }),
 		updateInboxResponse: vi.fn().mockResolvedValue({ inboxId: "inbox_1" }),
+		startMockServer: vi.fn().mockResolvedValue({
+			mockId: "mock_1",
+			url: "http://127.0.0.1:45010",
+			routeCount: 3,
+			routesWithoutExample: 0,
+		}),
+		stopMockServer: vi.fn().mockResolvedValue({ mockId: "mock_1", stopped: true }),
+		startMockIssuer: vi.fn().mockResolvedValue({ issuerId: "issuer_1" }),
+		stopMockIssuer: vi.fn().mockResolvedValue({ stopped: true }),
+		updateMockIssuer: vi.fn().mockResolvedValue({ issuerId: "issuer_1", failureMode: "slow" }),
 		composeRequest: vi
 			.fn()
 			.mockImplementation((body: { request?: object }) =>
@@ -127,6 +137,14 @@ describe("the registry declares its effects", () => {
 			delete_webhook_inbox: ["service"],
 			clear_inbox_captures: ["service"],
 			update_inbox_response: ["service"],
+			// Mock servers and issuers (#757): the same drawer and the same count,
+			// so the same family. The issuer tools shipped with `invalidates: []`
+			// and a note saying #757 would take it - this is that.
+			start_mock_server: ["service"],
+			stop_mock_server: ["service"],
+			start_mock_issuer: ["service"],
+			stop_mock_issuer: ["service"],
+			update_mock_issuer: ["service"],
 		};
 		for (const [name, entities] of Object.entries(expected)) {
 			const tool = TOOLS.find((t) => t.name === name);
@@ -367,6 +385,47 @@ describe("dispatch emits mcp:data-changed", () => {
 		// The engine assigns the id, so there is none in the arguments - and a new
 		// inbox has no capture cache to drop anyway.
 		expect(onDataChanged).toHaveBeenCalledWith({ entity: "service" });
+	});
+
+	test("stopping a mock names it, so its route-table cache can be dropped", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
+		const res = await dispatchTool("stop_mock_server", { mockId: "mock_1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		// The hint is what makes a stop correct renderer-side: the route table is
+		// held at `staleTime: Infinity`, so an invalidation would not refetch it,
+		// and the id it belongs to no longer exists to refetch from.
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "service", mockId: "mock_1" });
+	});
+
+	test("starting a mock reports the family with no id to narrow by", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
+		const res = await dispatchTool("start_mock_server", { collectionId: "col_1" }, ctx);
+		expect(res.isError).toBeFalsy();
+		// The engine assigns the mock id, so the arguments carry only the
+		// collection - and a mock that just started has no cached table to drop.
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "service", collectionId: "col_1" });
+	});
+
+	test("a live issuer edit reports the services family", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
+		const res = await dispatchTool(
+			"update_mock_issuer",
+			{ issuerId: "issuer_1", failureMode: "slow" },
+			ctx
+		);
+		expect(res.isError).toBeFalsy();
+		// `issuerId` is not a scope hint: the drawer lists issuers together and
+		// has no per-issuer cache to narrow to, so the family alone is the event.
+		expect(onDataChanged).toHaveBeenCalledWith({ entity: "service" });
+	});
+
+	test("an issuer edit that named no field emits nothing - it never reached the engine", async () => {
+		const client = fakeClient();
+		const { ctx, onDataChanged } = ctxWithNotifier(client);
+		const res = await dispatchTool("update_mock_issuer", { issuerId: "issuer_1" }, ctx);
+		expect(res.isError).toBe(true);
+		expect(client.updateMockIssuer).not.toHaveBeenCalled();
+		expect(onDataChanged).not.toHaveBeenCalled();
 	});
 
 	test("an unconfirmed inbox delete emits nothing - nothing changed", async () => {

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -742,6 +742,58 @@ export class EngineClient {
 		);
 	}
 
+	/**
+	 * Merge-patch a running issuer: `PUT /mock-issuer/:id`. The engine refuses
+	 * `port`, `clients`, `claims` and `issueRefreshTokens` outright on a bound
+	 * listener (`apply_mock_issuer_patch`) - the settings a live issuer can
+	 * change are the timing ones. Answers the updated description; an unknown id
+	 * is a 404, an out-of-range value a `400 mock_issuer_invalid_config`.
+	 */
+	updateMockIssuer(issuerId: string, patch: unknown, signal?: AbortSignal): Promise<unknown> {
+		return this.request("PUT", `/mock-issuer/${encodeURIComponent(issuerId)}`, patch, signal);
+	}
+
+	// --- Local services: the collection mock server --------------------------
+	//
+	// A mock binds `127.0.0.1` with no host to configure
+	// (`mock_server.cpp`: `listener.start ("127.0.0.1", ...)`), so - as with the
+	// issuer - nothing here reaches off the machine and the tools over it carry
+	// no allowlist check.
+
+	/**
+	 * Start a mock: `POST /mock/start`. `collectionId` is required; the engine
+	 * assigns the id and, for `port: 0`, the port. The reply is the mock record
+	 * (`mockId`, `collectionId`, `collectionName`, `url`, `port`, `latencyMs`,
+	 * `errorRatePct`, `routeCount`, `routesWithoutExample`, `createdAt`).
+	 */
+	startMockServer(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		return this.request("POST", "/mock/start", payload, signal);
+	}
+
+	/** Every mock running right now: `GET /mock` → `{data: [...]}`. A stopped one is gone, not listed. */
+	listMockServers(signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", "/mock", undefined, signal);
+	}
+
+	/**
+	 * One mock's route table: `GET /mock/:id/routes` → `{data: [...]}`, each row
+	 * `{requestId, requestName, method, path, hasExample, status}`. Taken when
+	 * the mock started and constant under it, so a second read answers the same.
+	 */
+	getMockServerRoutes(mockId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", `/mock/${encodeURIComponent(mockId)}/routes`, undefined, signal);
+	}
+
+	/**
+	 * Stop one: `POST /mock/:id/stop`. The record goes with the listener - a mock
+	 * holds nothing that outlives it - so there is no stopped state to read
+	 * afterwards. An unknown id is a 404, surfaced rather than swallowed for the
+	 * reason {@link stopMockIssuer} records.
+	 */
+	stopMockServer(mockId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request("POST", `/mock/${encodeURIComponent(mockId)}/stop`, undefined, signal);
+	}
+
 	// --- Local services: the webhook inbox -----------------------------------
 	//
 	// The inbox routes take a `bind` and a `confirmNonLoopback` flag; nothing

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -134,6 +134,37 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		}),
 		listMockIssuers: vi.fn().mockResolvedValue({ issuers: [] }),
 		stopMockIssuer: vi.fn().mockResolvedValue({ stopped: true }),
+		updateMockIssuer: vi.fn().mockResolvedValue({
+			issuerId: "issuer_1",
+			failureMode: "server_error",
+			slowMs: 0,
+		}),
+		startMockServer: vi.fn().mockResolvedValue({
+			mockId: "mock_1",
+			collectionId: "col_1",
+			collectionName: "API",
+			url: "http://127.0.0.1:45010",
+			port: 45010,
+			latencyMs: 0,
+			errorRatePct: 0,
+			routeCount: 4,
+			routesWithoutExample: 0,
+			createdAt: "2026-08-18T09:00:00Z",
+		}),
+		listMockServers: vi.fn().mockResolvedValue({ data: [] }),
+		getMockServerRoutes: vi.fn().mockResolvedValue({
+			data: [
+				{
+					requestId: "req_1",
+					requestName: "Get users",
+					method: "GET",
+					path: "/users",
+					hasExample: true,
+					status: 200,
+				},
+			],
+		}),
+		stopMockServer: vi.fn().mockResolvedValue({ mockId: "mock_1", stopped: true }),
 		startInbox: vi.fn().mockResolvedValue({
 			inboxId: "inbox_1",
 			url: "http://127.0.0.1:45001",
@@ -4040,12 +4071,18 @@ describe("engine transport failures are told apart", () => {
 describe("mock issuer tools", () => {
 	const byName = () => new Map(TOOLS.map((t) => [t.name, t]));
 
-	test("start and stop are execute, list is read, and none of them opens the world", () => {
+	test("start, stop and update are execute, list is read, and none of them opens the world", () => {
 		const tools = byName();
 		expect(tools.get("start_mock_issuer")?.category).toBe("execute");
 		expect(tools.get("stop_mock_issuer")?.category).toBe("execute");
+		expect(tools.get("update_mock_issuer")?.category).toBe("execute");
 		expect(tools.get("list_mock_issuers")?.category).toBe("read");
-		for (const name of ["start_mock_issuer", "stop_mock_issuer", "list_mock_issuers"]) {
+		for (const name of [
+			"start_mock_issuer",
+			"stop_mock_issuer",
+			"update_mock_issuer",
+			"list_mock_issuers",
+		]) {
 			// Loopback-only by engine contract, so an agent's client must not be
 			// told these reach an open world - that hint is what a cautious client
 			// asks about before calling.
@@ -4054,14 +4091,14 @@ describe("mock issuer tools", () => {
 		}
 	});
 
-	test("they invalidate nothing, because no renderer surface reads issuers yet", () => {
-		// The #502 coordination, locked so it is a decision rather than an
-		// oversight: declaring an entity here before the Services drawer reads it
-		// is precisely the written-never-read defect. When #502 lands, this
-		// expectation changes with it.
-		for (const name of ["start_mock_issuer", "stop_mock_issuer", "list_mock_issuers"]) {
-			expect(byName().get(name)?.invalidates, name).toEqual([]);
+	test("the mutating ones invalidate the services family, the read stays silent", () => {
+		// The other half of the #502 coordination: the drawer reads issuers, so
+		// the tools that change what it would show declare the entity that
+		// refreshes it (#757). A read declaring one would be the inverse defect.
+		for (const name of ["start_mock_issuer", "stop_mock_issuer", "update_mock_issuer"]) {
+			expect(byName().get(name)?.invalidates, name).toEqual(["service"]);
 		}
+		expect(byName().get("list_mock_issuers")?.invalidates).toEqual([]);
 	});
 
 	test("start sends only the fields the caller named and returns the issuer's urls", async () => {
@@ -4153,6 +4190,87 @@ describe("mock issuer tools", () => {
 		expect(client.stopMockIssuer).not.toHaveBeenCalled();
 	});
 
+	test("update sends only the fields it was asked to change", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"update_mock_issuer",
+			{ issuerId: "issuer_1", failureMode: "server_error" },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		// A merge-patch: `slowMs` absent means "leave it", and spelling it as
+		// null or 0 would mean something else entirely.
+		expect(client.updateMockIssuer).toHaveBeenCalledWith(
+			"issuer_1",
+			{ failureMode: "server_error" },
+			undefined
+		);
+	});
+
+	test("update forwards both mutable settings under the engine's own names", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"update_mock_issuer",
+			{ issuerId: "issuer_1", failureMode: "slow", slowMs: 2500 },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		// Keyed as `read_mutable_settings` reads them - a rename here is a field
+		// the engine silently ignores while the tool reports success.
+		expect(client.updateMockIssuer).toHaveBeenCalledWith(
+			"issuer_1",
+			{ failureMode: "slow", slowMs: 2500 },
+			undefined
+		);
+	});
+
+	test("update refuses an empty patch rather than reporting a no-op as done", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"update_mock_issuer",
+			{ issuerId: "issuer_1" },
+			ctxWith(client)
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/failureMode/);
+		// The engine accepts `{}` and answers 200, so without this the agent is
+		// told its change landed when nothing changed.
+		expect(client.updateMockIssuer).not.toHaveBeenCalled();
+	});
+
+	test("update refuses a start-only setting through the schema, not the engine", () => {
+		const shape = TOOLS.find((t) => t.name === "update_mock_issuer")!.inputSchema as Record<
+			string,
+			z.ZodTypeAny
+		>;
+		// Port, clients, claims and issueRefreshTokens cannot change under a bound
+		// listener - the engine answers "stop it and start a new one" - so they
+		// are not offered here at all.
+		for (const key of ["port", "clients", "claims", "issueRefreshTokens", "expiresInSeconds"]) {
+			expect(shape[key], key).toBeUndefined();
+		}
+		expect(shape.failureMode.safeParse("explode").success).toBe(false);
+		expect(shape.failureMode.safeParse("none").success).toBe(true);
+		expect(shape.slowMs.safeParse(-1).success).toBe(false);
+	});
+
+	test("update surfaces an unknown id as an error", async () => {
+		const gone = fakeClient({
+			updateMockIssuer: vi
+				.fn()
+				.mockRejectedValue(
+					new EngineRequestError("Engine responded 404", 404, "Mock issuer not found")
+				),
+		});
+		const res = await dispatchTool(
+			"update_mock_issuer",
+			{ issuerId: "issuer_9", failureMode: "none" },
+			ctxWith(gone)
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/404/);
+	});
+
 	/*
 	 * The gating matrix. The issuer is loopback-only by engine contract, so
 	 * neither of the two gates that govern the other effectful tools applies: the
@@ -4167,23 +4285,31 @@ describe("mock issuer tools", () => {
 		for (const [tool, args] of [
 			["start_mock_issuer", {}],
 			["list_mock_issuers", {}],
+			["update_mock_issuer", { issuerId: "issuer_1", failureMode: "none" }],
 			["stop_mock_issuer", { issuerId: "issuer_1" }],
 		] as const) {
 			const res = await dispatchTool(tool, args, locked);
 			expect(res.isError, tool).toBeFalsy();
 		}
 		expect(client.startMockIssuer).toHaveBeenCalled();
+		expect(client.updateMockIssuer).toHaveBeenCalled();
 		expect(client.stopMockIssuer).toHaveBeenCalled();
 	});
 
 	test("the per-tool switch is what turns them off", async () => {
 		const client = fakeClient();
 		const off = ctxWith(client, {
-			disabledTools: ["start_mock_issuer", "list_mock_issuers", "stop_mock_issuer"],
+			disabledTools: [
+				"start_mock_issuer",
+				"list_mock_issuers",
+				"update_mock_issuer",
+				"stop_mock_issuer",
+			],
 		});
 		for (const [tool, args] of [
 			["start_mock_issuer", {}],
 			["list_mock_issuers", {}],
+			["update_mock_issuer", { issuerId: "issuer_1", failureMode: "none" }],
 			["stop_mock_issuer", { issuerId: "issuer_1" }],
 		] as const) {
 			const res = await dispatchTool(tool, args, off);
@@ -4192,6 +4318,7 @@ describe("mock issuer tools", () => {
 		}
 		expect(client.startMockIssuer).not.toHaveBeenCalled();
 		expect(client.listMockIssuers).not.toHaveBeenCalled();
+		expect(client.updateMockIssuer).not.toHaveBeenCalled();
 		expect(client.stopMockIssuer).not.toHaveBeenCalled();
 	});
 
@@ -4269,6 +4396,281 @@ describe("mock issuer tools", () => {
 		);
 		expect(stopped.isError).toBeFalsy();
 		expect(client.stopMockIssuer).toHaveBeenCalledWith("issuer_1", undefined);
+	});
+});
+
+/*
+ * The collection mock server (#757). The engine has served `/mock/*` since #481
+ * and the UI has driven it since 0.16.0; these four tools are what let an agent
+ * asked to "stand up the API this client expects" do it from the collection's
+ * own saved examples rather than writing a stub server.
+ */
+describe("mock server tools", () => {
+	const byName = () => new Map(TOOLS.map((t) => [t.name, t]));
+
+	test("start and stop are execute, the two reads are read, and none opens the world", () => {
+		const tools = byName();
+		expect(tools.get("start_mock_server")?.category).toBe("execute");
+		expect(tools.get("stop_mock_server")?.category).toBe("execute");
+		expect(tools.get("list_mock_servers")?.category).toBe("read");
+		expect(tools.get("get_mock_routes")?.category).toBe("read");
+		for (const name of [
+			"start_mock_server",
+			"stop_mock_server",
+			"list_mock_servers",
+			"get_mock_routes",
+		]) {
+			// Loopback-only by engine contract (`listener.start ("127.0.0.1", …)`),
+			// so a cautious client must not be told these reach an open world.
+			expect(tools.get(name)?.annotations.openWorldHint, name).toBe(false);
+			// A mock serves stored examples and records nothing, so a stop loses
+			// nothing that was not recreatable by starting it again.
+			expect(tools.get(name)?.annotations.destructiveHint, name).toBeFalsy();
+		}
+	});
+
+	test("the mutating ones invalidate the services family, the reads stay silent", () => {
+		expect(byName().get("start_mock_server")?.invalidates).toEqual(["service"]);
+		expect(byName().get("stop_mock_server")?.invalidates).toEqual(["service"]);
+		expect(byName().get("list_mock_servers")?.invalidates).toEqual([]);
+		expect(byName().get("get_mock_routes")?.invalidates).toEqual([]);
+	});
+
+	test("start sends the collection plus only the knobs the caller named", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_mock_server",
+			{ collectionId: "col_1", latencyMs: 250 },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		const payload = (client.startMockServer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		// An absent knob stays absent: the engine reads a present one with a bad
+		// value as a 400 rather than falling back to its default.
+		expect(payload).toEqual({ collectionId: "col_1", latencyMs: 250 });
+		expect(Object.keys(payload as object)).not.toContain("port");
+		expect(Object.keys(payload as object)).not.toContain("errorRatePct");
+		const body = JSON.parse(firstText(res)) as Record<string, unknown>;
+		expect(body.mockId).toBe("mock_1");
+		expect(body.url).toBe("http://127.0.0.1:45010");
+		expect(body.routeCount).toBe(4);
+	});
+
+	test("start forwards every knob under the engine's own names", async () => {
+		const client = fakeClient();
+		const args = { collectionId: "col_1", port: 45010, latencyMs: 100, errorRatePct: 25 };
+		const res = await dispatchTool("start_mock_server", args, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		// Keyed exactly as `parse_mock_start` reads them - a rename here is a knob
+		// the engine silently ignores while the tool reports it applied.
+		expect((client.startMockServer as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual(args);
+	});
+
+	test("start refuses a missing collection before the engine is called", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool("start_mock_server", {}, ctxWith(client));
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/collectionId/);
+		expect(client.startMockServer).not.toHaveBeenCalled();
+	});
+
+	test("a mock whose routes have no examples says so, instead of leaving it in the JSON", async () => {
+		const client = fakeClient({
+			startMockServer: vi.fn().mockResolvedValue({
+				mockId: "mock_2",
+				url: "http://127.0.0.1:45011",
+				routeCount: 5,
+				routesWithoutExample: 3,
+			}),
+		});
+		const res = await dispatchTool(
+			"start_mock_server",
+			{ collectionId: "col_1" },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		// "It started" and "it can answer" are different answers, and only the
+		// second is what was asked for - three of five routes answer 501 here.
+		const caveat = res.content.map((c) => c.text).join("\n");
+		expect(caveat).toMatch(/3 of 5 route\(s\) have no saved example/);
+		expect(caveat).toMatch(/501/);
+	});
+
+	test("a mock with no routes at all gets the sharper caveat", async () => {
+		const client = fakeClient({
+			startMockServer: vi.fn().mockResolvedValue({
+				mockId: "mock_3",
+				url: "http://127.0.0.1:45012",
+				routeCount: 0,
+				routesWithoutExample: 0,
+			}),
+		});
+		const res = await dispatchTool(
+			"start_mock_server",
+			{ collectionId: "col_empty" },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		const text = res.content.map((c) => c.text).join("\n");
+		expect(text).toMatch(/serves no routes/);
+		expect(text).toMatch(/404/);
+	});
+
+	test("a fully-exampled mock gets no caveat at all", async () => {
+		// The mutation check for the two above: with nothing to warn about, the
+		// result is the engine's record and nothing else.
+		const res = await dispatchTool(
+			"start_mock_server",
+			{ collectionId: "col_1" },
+			ctxWith(fakeClient())
+		);
+		expect(res.isError).toBeFalsy();
+		expect(res.content).toHaveLength(1);
+	});
+
+	test("list and routes round-trip the engine's envelopes", async () => {
+		const running = {
+			data: [
+				{
+					mockId: "mock_1",
+					collectionId: "col_1",
+					collectionName: "API",
+					url: "http://127.0.0.1:45010",
+					port: 45010,
+					routeCount: 4,
+				},
+			],
+		};
+		const client = fakeClient({ listMockServers: vi.fn().mockResolvedValue(running) });
+		const listed = await dispatchTool("list_mock_servers", {}, ctxWith(client));
+		expect(listed.isError).toBeFalsy();
+		expect(JSON.parse(firstText(listed))).toEqual(running);
+
+		const routes = await dispatchTool("get_mock_routes", { mockId: "mock_1" }, ctxWith(client));
+		expect(routes.isError).toBeFalsy();
+		expect(client.getMockServerRoutes).toHaveBeenCalledWith("mock_1", undefined);
+		// The has-example flag is the whole point of the table - it is what says
+		// which routes answer 501 rather than a body.
+		const table = JSON.parse(firstText(routes)) as { data: Array<Record<string, unknown>> };
+		expect(table.data[0].hasExample).toBe(true);
+		expect(table.data[0].path).toBe("/users");
+	});
+
+	test("routes refuses an empty id before the engine is called", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool("get_mock_routes", { mockId: "" }, ctxWith(client));
+		expect(res.isError).toBe(true);
+		expect(client.getMockServerRoutes).not.toHaveBeenCalled();
+	});
+
+	test("stop names the mock, and an unknown id is an error rather than a shrug", async () => {
+		const client = fakeClient();
+		const ok = await dispatchTool("stop_mock_server", { mockId: "mock_1" }, ctxWith(client));
+		expect(ok.isError).toBeFalsy();
+		expect(client.stopMockServer).toHaveBeenCalledWith("mock_1", undefined);
+
+		const gone = fakeClient({
+			stopMockServer: vi
+				.fn()
+				.mockRejectedValue(
+					new EngineRequestError("Engine responded 404", 404, "Mock server not found")
+				),
+		});
+		const res = await dispatchTool("stop_mock_server", { mockId: "mock_9" }, ctxWith(gone));
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/404/);
+	});
+
+	test("the schema refuses a malformed knob before the engine sees it", () => {
+		const shape = TOOLS.find((t) => t.name === "start_mock_server")!.inputSchema as Record<
+			string,
+			z.ZodTypeAny
+		>;
+		expect(shape.port.safeParse(70000).success).toBe(false);
+		expect(shape.port.safeParse(0).success).toBe(true);
+		// A percentage is 0-100 by definition rather than by an engine constant,
+		// which is why this bound lives here and `latencyMs`'s ceiling does not.
+		expect(shape.errorRatePct.safeParse(101).success).toBe(false);
+		expect(shape.errorRatePct.safeParse(100).success).toBe(true);
+		expect(shape.latencyMs.safeParse(-1).success).toBe(false);
+		// The collection is the one thing a mock cannot be started without.
+		expect(z.object(shape).safeParse({}).success).toBe(false);
+		expect(z.object(shape).safeParse({ collectionId: "col_1" }).success).toBe(true);
+	});
+
+	/*
+	 * The gating matrix, for the same reason the issuer block carries one: a mock
+	 * is loopback-only by engine contract, so neither the allowlist (which exists
+	 * to stop an agent generating traffic against third parties) nor the write
+	 * toggle (which gates saved data - a mock only reads it) applies.
+	 */
+	test("neither the empty allowlist nor the write toggle gates them", async () => {
+		const client = fakeClient();
+		const locked = ctxWith(client, { allowlist: [], allowAll: false, allowWrites: false });
+		for (const [tool, args] of [
+			["start_mock_server", { collectionId: "col_1" }],
+			["list_mock_servers", {}],
+			["get_mock_routes", { mockId: "mock_1" }],
+			["stop_mock_server", { mockId: "mock_1" }],
+		] as const) {
+			const res = await dispatchTool(tool, args, locked);
+			expect(res.isError, tool).toBeFalsy();
+		}
+		expect(client.startMockServer).toHaveBeenCalled();
+		expect(client.stopMockServer).toHaveBeenCalled();
+	});
+
+	test("the per-tool switch is what turns them off", async () => {
+		const client = fakeClient();
+		const off = ctxWith(client, {
+			disabledTools: [
+				"start_mock_server",
+				"list_mock_servers",
+				"get_mock_routes",
+				"stop_mock_server",
+			],
+		});
+		for (const [tool, args] of [
+			["start_mock_server", { collectionId: "col_1" }],
+			["list_mock_servers", {}],
+			["get_mock_routes", { mockId: "mock_1" }],
+			["stop_mock_server", { mockId: "mock_1" }],
+		] as const) {
+			const res = await dispatchTool(tool, args, off);
+			expect(res.isError, tool).toBe(true);
+			expect(firstText(res), tool).toMatch(/disabled in Vayu Settings/);
+		}
+		expect(client.startMockServer).not.toHaveBeenCalled();
+		expect(client.stopMockServer).not.toHaveBeenCalled();
+	});
+
+	test("an agent stands up a mock, reads its table and points a request at it", async () => {
+		// The owner scenario from #481, through the MCP layer: start a mock for a
+		// collection, confirm what it serves, send to it, stop it.
+		const client = fakeClient();
+		const ctx = ctxWith(client, { allowlist: ["127.0.0.1"] });
+
+		const started = await dispatchTool("start_mock_server", { collectionId: "col_1" }, ctx);
+		expect(started.isError).toBeFalsy();
+		const { mockId, url } = JSON.parse(firstText(started)) as { mockId: string; url: string };
+
+		const routes = await dispatchTool("get_mock_routes", { mockId }, ctx);
+		expect(routes.isError).toBeFalsy();
+		const { data } = JSON.parse(firstText(routes)) as { data: Array<{ path: string }> };
+
+		const sent = await dispatchTool(
+			"run_request",
+			{ method: "GET", url: `${url}${data[0].path}` },
+			ctx
+		);
+		expect(sent.isError).toBeFalsy();
+		expect((client.executeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0].url).toBe(
+			"http://127.0.0.1:45010/users"
+		);
+
+		const stopped = await dispatchTool("stop_mock_server", { mockId }, ctx);
+		expect(stopped.isError).toBeFalsy();
+		expect(client.stopMockServer).toHaveBeenCalledWith("mock_1", undefined);
 	});
 });
 

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -94,13 +94,14 @@ export type McpDataEntity = (typeof MCP_DATA_ENTITIES)[number];
  * One thing changed. Invalidation only - no data rides across, the renderer
  * refetches through its normal query layer.
  *
- * The four scope hints are read from the call's own arguments and narrow the
+ * The five scope hints are read from the call's own arguments and narrow the
  * invalidation to the caches that can have gone stale; each is absent when the
  * call did not name it. They are hints, not identity: `requestId` on a
  * `run` event is the saved request a design run was linked to, not the run's
  * own id - `runId` is that. The renderer narrows on `collectionId` (the
- * `request` family's list key), on `runId` (the per-run caches it removes) and
- * on `inboxId` (the capture list it removes); a run event's `requestId` is
+ * `request` family's list key), on `runId` (the per-run caches it removes), on
+ * `inboxId` (the capture list it removes) and on `mockId` (the route table it
+ * removes); a run event's `requestId` is
  * emitted because every hint is read off the same
  * arguments, and the run families it could narrow are invalidated at their
  * prefixes instead - a `delete_run` names no request, so a per-request key
@@ -130,6 +131,18 @@ export interface McpDataChangedEvent {
 	 * rather than refetched into (see `lib/mcp-invalidation.ts`).
 	 */
 	inboxId?: string;
+	/**
+	 * The collection mock server the call named, when it named one. Among the
+	 * tools that emit at all that is only `stop_mock_server`;
+	 * `start_mock_server` has no id to name until the engine has answered.
+	 *
+	 * Read for the same reason `inboxId` is - a cache that has to be *dropped*
+	 * rather than refetched - though the reason it cannot be refetched is the
+	 * mirror one: a stopped mock's record dies with its listener, so refetching
+	 * its route table would 404 and leave an error state describing a table that
+	 * no longer exists. `useStopMockServerMutation` already drops it app-side.
+	 */
+	mockId?: string;
 }
 
 export interface ToolContext {
@@ -2229,6 +2242,93 @@ function mockIssuerStartPayload(args: Record<string, unknown>): Record<string, u
 	return payload;
 }
 
+/**
+ * The settings `PUT /mock-issuer/:id` will change under a bound listener.
+ *
+ * Deliberately a subset of the start keys rather than the same list: the engine
+ * refuses `port`, `clients`, `claims` and `issueRefreshTokens` on a running
+ * issuer with "stop it and start a new one" (`apply_mock_issuer_patch`), so
+ * offering them here would be offering a call that always fails. It is also a
+ * subset of what the PUT accepts - `expiresInSeconds` is mutable engine-side
+ * and is not offered, because a token's lifetime is fixed when it is minted, so
+ * changing it mid-session changes nothing about the tokens already in the
+ * agent's hands and only the *next* mint. #757 scoped this tool to the two
+ * knobs the UI's own live edit exposes; widening it belongs to whoever finds a
+ * use for it.
+ */
+const MOCK_ISSUER_PATCH_KEYS = ["failureMode", "slowMs"] as const;
+
+/**
+ * The merge-patch body for `update_mock_issuer`, carrying only what the caller
+ * named - an omitted field keeps its current value engine-side, which is the
+ * whole point of patching a live issuer rather than restarting it.
+ */
+function mockIssuerPatchPayload(args: Record<string, unknown>): Record<string, unknown> {
+	const patch: Record<string, unknown> = {};
+	for (const key of MOCK_ISSUER_PATCH_KEYS) {
+		if (args[key] !== undefined) patch[key] = args[key];
+	}
+	return patch;
+}
+
+// --- Collection mock server --------------------------------------------------
+
+/**
+ * The fields `POST /mock/start` accepts (`parse_mock_start`,
+ * engine/src/http/routes/mock_server.cpp). `collectionId` is required and is
+ * validated by {@link requireStr} before the body is built; the other three are
+ * optional knobs.
+ */
+const MOCK_SERVER_START_KEYS = ["port", "latencyMs", "errorRatePct"] as const;
+
+/**
+ * The start body. `collectionId` always travels; a knob the caller did not name
+ * stays absent, for the reason {@link mockIssuerStartPayload} records - the
+ * engine reads a present field with a bad value as a 400 rather than falling
+ * back to its default.
+ *
+ * The engine's `latencyMs` ceiling is not restated in the schema (the same
+ * division of labour the issuer tools document): it lives in
+ * `core/constants.hpp`, an out-of-range value comes back as a 400 naming the
+ * bound, and a copy here would refuse values the engine accepts the moment
+ * either side moves. `port` and `errorRatePct` are bounded in the schema
+ * because their bounds are the *shape* - a port is 0-65535 everywhere and a
+ * percentage is 0-100 by definition, not by an engine constant.
+ */
+function mockServerStartPayload(args: Record<string, unknown>): Record<string, unknown> {
+	const payload: Record<string, unknown> = { collectionId: requireStr(args, "collectionId") };
+	for (const key of MOCK_SERVER_START_KEYS) {
+		if (args[key] !== undefined) payload[key] = args[key];
+	}
+	return payload;
+}
+
+/**
+ * What a started mock could not serve, or "" when every route has an example.
+ *
+ * A mock with routes but no examples answers `501` to each of them, which reads
+ * as a broken mock rather than as an empty collection - so the count the engine
+ * already reports (`routesWithoutExample`) is turned into a sentence instead of
+ * being left for an agent to notice in the JSON. `routeCount: 0` is the sharper
+ * case and gets its own line: there is nothing to point a client at.
+ */
+function mockServerCaveat(started: unknown): string {
+	if (!isRecord(started)) return "";
+	const routes = Number(started.routeCount);
+	const without = Number(started.routesWithoutExample);
+	if (Number.isFinite(routes) && routes === 0) {
+		return (
+			"\nThis mock serves no routes: the collection has no requests the mock could map. " +
+			"Every path answers 404."
+		);
+	}
+	if (!Number.isFinite(without) || without <= 0) return "";
+	return (
+		`\n${without} of ${routes} route(s) have no saved example, and answer 501 rather than a body. ` +
+		"Save an example on those requests (or check get_mock_routes for which they are) before pointing a client at them."
+	);
+}
+
 // --- Webhook inbox -----------------------------------------------------------
 
 /**
@@ -4001,11 +4101,10 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "start_mock_issuer",
 		category: "execute",
-		// #502's Services drawer now reads the issuer list, and #756 added the
-		// `service` entity these belong on - but wiring the issuer tools to it,
-		// and to the mock-server tools beside them, is #757's half of the epic.
-		// Until then the drawer's poll is what shows an MCP-started issuer.
-		invalidates: [],
+		// #502's Services drawer reads the issuer list and #756 added the
+		// `service` entity; #757 is where the issuer tools take it, so an
+		// MCP-started issuer appears without waiting out the drawer's poll.
+		invalidates: ["service"],
 		description:
 			"Start a local OAuth 2.0 mock issuer and return its id, token URL, authorize URL and signing key. Use it to test an auth flow offline: start an issuer, point a request's oauth2 auth at the returned tokenUrl, run it with run_request, and assert on what the target received - no real identity provider, so no 2FA prompts, provider rate limits or account lockouts in the loop. It needs no allowlist entry: the engine binds every issuer to 127.0.0.1 and takes no host for it, so it is unreachable off this machine. The access token is an HS256 JWT signed with the returned signingKey - hand that key to the service under test and it can verify the mock's tokens. Set a short expiresInSeconds (with issueRefreshTokens) to exercise the 401-then-refresh path, and failureMode to exercise retry handling. At most 8 issuers run at once; stop yours with stop_mock_issuer when you are done.",
 		annotations: {
@@ -4093,8 +4192,7 @@ export const TOOLS: McpTool[] = [
 	{
 		name: "stop_mock_issuer",
 		category: "execute",
-		// See start_mock_issuer - the `service` entity is #757's to take here.
-		invalidates: [],
+		invalidates: ["service"],
 		description:
 			"Stop a running OAuth 2.0 mock issuer and free its port. Tokens it already minted stay valid until they expire - nothing verifies them against the issuer once it is gone. An unknown id is an error, not a silent success.",
 		annotations: {
@@ -4109,6 +4207,166 @@ export const TOOLS: McpTool[] = [
 		},
 		handler: (args, ctx, signal) =>
 			callEngine(() => ctx.client.stopMockIssuer(requireStr(args, "issuerId"), signal)),
+	},
+	{
+		name: "update_mock_issuer",
+		category: "execute",
+		invalidates: ["service"],
+		description:
+			"Change how a running OAuth 2.0 mock issuer's /token endpoint behaves, live: its failure mode and its slow-mode delay. Use it to walk a client through a sequence - mint a token against a healthy issuer, flip it to server_error to see the retry, flip it back - without stopping the issuer, which would invalidate the token URL the request under test is already pointed at and change the signing key. This is a merge-patch: a field you omit keeps its current value. Only these two settings can change under a running issuer; the port, client list, claims and refresh-token setting are fixed when it starts, and asking to change one is an error telling you to start a new issuer.",
+		annotations: {
+			title: "Update mock OAuth issuer",
+			readOnlyHint: false,
+			// It rewrites two settings of a loopback listener; nothing recorded is
+			// lost and the same patch applied twice is the same issuer.
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			issuerId: z.string().describe("Issuer ID to update (from start_mock_issuer)."),
+			failureMode: z
+				.enum(MOCK_ISSUER_FAILURE_MODES)
+				.optional()
+				.describe(
+					'How /token should misbehave from now on: "none" (healthy), "slow" (answers after slowMs), "server_error" (500), "invalid_client" (401). Omit to leave it unchanged.'
+				),
+			slowMs: z
+				.number()
+				.int()
+				.nonnegative()
+				.optional()
+				.describe(
+					'New delay before /token answers, in milliseconds (engine cap 60000). Only "slow" reads it. Omit to leave it unchanged.'
+				),
+		},
+		handler: (args, ctx, signal) => {
+			const issuerId = requireStr(args, "issuerId");
+			const patch = mockIssuerPatchPayload(args);
+			if (Object.keys(patch).length === 0) {
+				// The engine accepts an empty patch and changes nothing, so a
+				// success here would report a call that did not do what it was
+				// asked - the `update_inbox_response` precedent.
+				throw new ToolArgError('Name at least one of "failureMode" or "slowMs" to change.');
+			}
+			return callEngine(() => ctx.client.updateMockIssuer(issuerId, patch, signal));
+		},
+	},
+	{
+		name: "start_mock_server",
+		category: "execute",
+		invalidates: ["service"],
+		description:
+			"Start a local mock server that answers a collection's saved examples, and return its id and base URL. Use it to stand up the API a client under test expects without that API existing: point the client at the returned url and every request whose method and path match a saved request in the collection gets that request's example back - status, headers and body. A route whose request has no saved example answers 501, and a path that matches nothing answers 404, so the returned routeCount and routesWithoutExample are what say whether the mock is usable; get_mock_routes lists them. latencyMs and errorRatePct are how a client's timeout and retry handling get exercised - errorRatePct injects synthesized 500s at that rate. It needs no allowlist entry: the engine binds every mock to 127.0.0.1 and takes no host for it, so it is unreachable off this machine. Stop it with stop_mock_server when you are done; a mock keeps its port until then.",
+		annotations: {
+			title: "Start mock server",
+			readOnlyHint: false,
+			// A loopback listener over data it only reads: it destroys nothing and
+			// reaches nothing off the machine.
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			collectionId: z
+				.string()
+				.describe(
+					"Collection whose saved examples the mock serves (from list_collections). Its sub-collections are included."
+				),
+			port: z
+				.number()
+				.int()
+				.min(0)
+				.max(65535)
+				.optional()
+				.describe("Port to bind on 127.0.0.1. Default 0 - the engine picks a free one."),
+			latencyMs: z
+				.number()
+				.int()
+				.nonnegative()
+				.optional()
+				.describe(
+					"Artificial delay before every answer, in milliseconds (default 0). Use it to make a client's timeout handling fire."
+				),
+			errorRatePct: z
+				.number()
+				.int()
+				.min(0)
+				.max(100)
+				.optional()
+				.describe(
+					"Percentage of answers replaced with a synthesized 500 (default 0). 0 and 100 are exact; in between it is a per-request roll."
+				),
+		},
+		handler: async (args, ctx, signal) => {
+			const payload = mockServerStartPayload(args);
+			let started: unknown;
+			try {
+				started = await ctx.client.startMockServer(payload, signal);
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			// The caveat rides on the result rather than being left in the JSON:
+			// "the mock started" and "the mock can answer" are different answers,
+			// and only the second one is what the agent asked for. Read off the
+			// engine's reply, which is why this is `pagedRead`'s shape rather
+			// than a plain `callEngine`.
+			return withCaveat(jsonResult(started), mockServerCaveat(started));
+		},
+	},
+	{
+		name: "list_mock_servers",
+		category: "read",
+		invalidates: [],
+		description:
+			"List the mock servers running right now, each with its id, the collection it serves and that collection's name, its base URL and port, its latency and error-rate knobs, and how many routes it has. A stopped mock is gone rather than listed - its record dies with its listener - so this is also how to confirm one stopped.",
+		annotations: {
+			title: "List mock servers",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {},
+		handler: (_args, ctx, signal) => callEngine(() => ctx.client.listMockServers(signal)),
+	},
+	{
+		name: "get_mock_routes",
+		category: "read",
+		invalidates: [],
+		description:
+			"List the routes one mock server is serving: method, path template, the saved request behind each, and whether that request has an example (hasExample false means the route answers 501). This is how 'the mock answers 404' gets diagnosed without sending a request per guess. The table is a snapshot taken when the mock started and cannot change under it - editing the collection means restarting the mock - so a second read answers the same thing.",
+		annotations: {
+			title: "Get mock server routes",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			mockId: z.string().describe("Mock server ID (from start_mock_server)."),
+		},
+		handler: (args, ctx, signal) =>
+			callEngine(() => ctx.client.getMockServerRoutes(requireStr(args, "mockId"), signal)),
+	},
+	{
+		name: "stop_mock_server",
+		category: "execute",
+		invalidates: ["service"],
+		description:
+			"Stop a running mock server and free its port. Unlike a webhook inbox there is nothing left to read afterwards - a mock records nothing, so its record goes with its listener and it disappears from list_mock_servers. Requests sent to the URL after this are refused by the machine. An unknown id is an error, not a silent success.",
+		annotations: {
+			title: "Stop mock server",
+			readOnlyHint: false,
+			// Nothing recorded is lost: a mock serves stored examples and keeps no
+			// state of its own.
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			mockId: z.string().describe("Mock server ID to stop (from start_mock_server)."),
+		},
+		handler: (args, ctx, signal) =>
+			callEngine(() => ctx.client.stopMockServer(requireStr(args, "mockId"), signal)),
 	},
 	{
 		name: "start_webhook_inbox",
@@ -4453,6 +4711,7 @@ function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: To
 	const requestId = str(args, "requestId");
 	const runId = str(args, "runId");
 	const inboxId = str(args, "inboxId");
+	const mockId = str(args, "mockId");
 	for (const entity of tool.invalidates) {
 		try {
 			ctx.onDataChanged({
@@ -4461,6 +4720,7 @@ function notifyDataChanged(tool: McpTool, args: Record<string, unknown>, ctx: To
 				...(requestId !== undefined ? { requestId } : {}),
 				...(runId !== undefined ? { runId } : {}),
 				...(inboxId !== undefined ? { inboxId } : {}),
+				...(mockId !== undefined ? { mockId } : {}),
 			});
 		} catch (err) {
 			console.error(`[MCP] Failed to notify "${entity}" change from ${tool.name}:`, err);

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			requestId?: string;
 			runId?: string;
 			inboxId?: string;
+			mockId?: string;
 		}) => void
 	) => {
 		const handler = (_event: unknown, change: unknown) =>

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -195,22 +195,36 @@ describe("invalidateForMcpEvent", () => {
 		expect(keys).toEqual([queryKeys.config.all]);
 	});
 
-	test("a service change invalidates the inbox list", () => {
+	test("a service change invalidates every service list", () => {
+		// One family, three lists: the Services drawer and the Dock count ask
+		// "what is listening", not "which kind", so a `service` event has to
+		// reach the mock and issuer lists as well as the inbox one (#757).
 		const { handled, keys } = keysFor({ entity: "service" });
 		expect(handled).toBe(true);
-		expect(keys).toEqual([queryKeys.inbox.list()]);
+		expect(keys).toEqual([
+			queryKeys.inbox.list(),
+			queryKeys.mockServer.list(),
+			queryKeys.mockIssuer.list(),
+		]);
 	});
 
 	test("a named inbox has its captures removed, not merely invalidated", () => {
 		// `useInboxCapturesQuery` merges a fetched page into what the cache holds,
 		// so an invalidation after a clear or a delete would union the destroyed
 		// rows straight back. Removal is what makes the refetch start from empty.
-		const { keys, removed } = keysFor({ entity: "service", inboxId: "inbox_1" });
-		expect(keys).toEqual([queryKeys.inbox.list()]);
+		const { removed } = keysFor({ entity: "service", inboxId: "inbox_1" });
 		expect(removed).toEqual([queryKeys.inbox.captures("inbox_1")]);
 	});
 
-	test("a service event that named no inbox leaves every capture list alone", () => {
+	test("a named mock has its route table removed, not merely invalidated", () => {
+		// The table is held at `staleTime: Infinity` (it is a start-time snapshot),
+		// so an invalidation would not refetch it - and after a stop the mock's id
+		// 404s, so a refetch would leave an error state describing a dead table.
+		const { removed } = keysFor({ entity: "service", mockId: "mock_1" });
+		expect(removed).toEqual([queryKeys.mockServer.routes("mock_1")]);
+	});
+
+	test("a service event that named neither leaves both per-id caches alone", () => {
 		const { removed } = keysFor({ entity: "service" });
 		expect(removed).toEqual([]);
 	});
@@ -227,6 +241,21 @@ describe("invalidateForMcpEvent", () => {
 		expect(queryClient.getQueryData(queryKeys.inbox.captures("inbox_1"))).toBeUndefined();
 		expect(queryClient.getQueryData(queryKeys.inbox.captures("inbox_2"))).toEqual({
 			data: [{ id: 2 }],
+		});
+	});
+
+	test("a stopped mock's route table really is gone from a live cache", () => {
+		// Same shape as the capture check above, and for the mirror reason: the
+		// stopped mock's table must go, another running mock's must survive.
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(queryKeys.mockServer.routes("mock_1"), { data: [{ path: "/a" }] });
+		queryClient.setQueryData(queryKeys.mockServer.routes("mock_2"), { data: [{ path: "/b" }] });
+
+		invalidateForMcpEvent(queryClient, { entity: "service", mockId: "mock_1" });
+
+		expect(queryClient.getQueryData(queryKeys.mockServer.routes("mock_1"))).toBeUndefined();
+		expect(queryClient.getQueryData(queryKeys.mockServer.routes("mock_2"))).toEqual({
+			data: [{ path: "/b" }],
 		});
 	});
 

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -171,10 +171,17 @@ const INVALIDATORS: Record<
 	},
 
 	/*
-	 * The engine's local services (issue #756). The inbox list is polled, so this
-	 * is about immediacy in the Services drawer and the Dock's running-services
-	 * count - an agent that starts an inbox and reports its URL should not be
-	 * describing a listener the window will not show for another poll interval.
+	 * The engine's local services (issues #756, #757). Every list here is polled,
+	 * so this is about immediacy in the Services drawer and the Dock's
+	 * running-services count - an agent that starts an inbox or a mock and
+	 * reports its URL should not be describing a listener the window will not
+	 * show for another poll interval.
+	 *
+	 * All three lists are invalidated on every `service` event rather than one
+	 * per kind, because the entity is deliberately one family: the drawer and
+	 * the Dock count ask "what is listening", not "which kind" (see
+	 * `MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`). Three refetches of a
+	 * short list is the price of not carrying a discriminator no reader wants.
 	 *
 	 * The captures are the half that cannot be handled by invalidation.
 	 * `useInboxCapturesQuery` *merges* its fetched page into whatever the cache
@@ -193,11 +200,24 @@ const INVALIDATORS: Record<
 	 * already had (and any "load more" pages beyond the first). That is the
 	 * `run` family's trade taken again and for the same reason: a stale answer
 	 * is a lie, a refetch is a wait.
+	 *
+	 * A mock's route table needs the same drop for the other half of that
+	 * reason. `useMockServerRoutesQuery` holds it at `staleTime: Infinity`
+	 * because it is a start-time snapshot, so an invalidation would not refetch
+	 * it - and after a `stop_mock_server` there is nothing to refetch anyway:
+	 * the record dies with the listener and the id now 404s. Dropping the entry
+	 * is what `useStopMockServerMutation` already does app-side, for the same
+	 * reason `useDeleteInboxMutation` removes rather than invalidates.
 	 */
 	service: (queryClient, event) => {
 		void queryClient.invalidateQueries({ queryKey: queryKeys.inbox.list() });
+		void queryClient.invalidateQueries({ queryKey: queryKeys.mockServer.list() });
+		void queryClient.invalidateQueries({ queryKey: queryKeys.mockIssuer.list() });
 		if (event.inboxId) {
 			queryClient.removeQueries({ queryKey: queryKeys.inbox.captures(event.inboxId) });
+		}
+		if (event.mockId) {
+			queryClient.removeQueries({ queryKey: queryKeys.mockServer.routes(event.mockId) });
 		}
 	},
 };

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2233,7 +2233,7 @@ export type McpDataEntity =
 	| "run"
 	| "cookie"
 	| "config"
-	/** Engine-hosted local services: webhook inboxes today, more as #757 lands. */
+	/** Engine-hosted local services: webhook inboxes, mock servers and mock issuers. */
 	| "service";
 
 /**
@@ -2259,6 +2259,12 @@ export interface McpDataChangedEvent {
 	 * `delete_webhook_inbox`, `clear_inbox_captures`, `update_inbox_response`).
 	 */
 	inboxId?: string;
+	/**
+	 * The collection mock server the call named, when it named one - only
+	 * `stop_mock_server` among the mutating tools, since `start_mock_server` has
+	 * no id until the engine answers.
+	 */
+	mockId?: string;
 }
 
 export interface ScriptCompletion {

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1309,7 +1309,7 @@ to keys through `lib/mcp-invalidation.ts`:
 | `run` | `runs.lists()`, `runs.allRuns()`, `runs.baselines()`, `runs.recentDesigns()`, `runs.lastCollectionRuns()`, `runs.lastDesigns()` - and a **removal** of `runs.detail/report/samples/timeSeries/monitorSeries` for a named `runId` | The history list polls, but Settings' count, the vs-baseline strip, Recent sends, Last run and every open tab's last design run do not. The four prefixes rather than per-row keys because a run id gives no way back to the request or collection it belonged to - the same trade `useDeleteRunMutation` makes |
 | `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
 | `config` | `config.all` | |
-| `service` | `inbox.list()`, plus a **removal** of `inbox.captures(inboxId)` for a named inbox | The drawer and the Dock's count poll, so the list is about immediacy; the captures cannot be invalidated, because `useInboxCapturesQuery` merges its fetched page into the cache and would union back the rows a `clear_inbox_captures` just destroyed |
+| `service` | `inbox.list()`, `mockServer.list()`, `mockIssuer.list()`, plus a **removal** of `inbox.captures(inboxId)` for a named inbox and of `mockServer.routes(mockId)` for a named mock | The drawer and the Dock's count poll, so the lists are about immediacy; the captures cannot be invalidated, because `useInboxCapturesQuery` merges its fetched page into the cache and would union back the rows a `clear_inbox_captures` just destroyed, and a stopped mock's route table has no id left to refetch from |
 
 The event carries no engine data, only which family went stale, so a row still
 reaches the UI by exactly one path: the query layer. Per-run reports and time
@@ -1328,15 +1328,22 @@ a lie and a refetch is a wait. `runs.lastDesigns()` is taken at its prefix and
 never per request (#776): `delete_run` and `set_run_baseline` name a `runId` and
 no request, so the narrow key could not reach the tab whose run went away, and
 the cost of the prefix is that a `run_request` refetches one filtered row per
-*mounted* tab instead of one. The `service` family (issue #756) takes the same
-shape one level down: `inboxId` is its scope hint, and a named inbox has its
-capture list *removed* rather than invalidated for a reason the run family does
-not have - three writers share that one cache entry (the fetch, the load-more
-pages and the live SSE stream), so every write to it is a union by capture id,
-and a refetch into a cache still holding cleared rows puts them straight back.
-The app's own clear mutation writes an empty page first for exactly this; from
-the main process the equivalent is to drop the entry. Only inboxes are wired
-today - mock servers and the OAuth issuers join the family in #757.
+*mounted* tab instead of one. The `service` family (issues #756, #757) takes the
+same shape one level down, with two scope hints instead of one. `inboxId`: a
+named inbox has its capture list *removed* rather than invalidated for a reason
+the run family does not have - three writers share that one cache entry (the
+fetch, the load-more pages and the live SSE stream), so every write to it is a
+union by capture id, and a refetch into a cache still holding cleared rows puts
+them straight back. The app's own clear mutation writes an empty page first for
+exactly this; from the main process the equivalent is to drop the entry.
+`mockId`: a named mock has its route table removed for the mirror reason - the
+table is a start-time snapshot held at `staleTime: Infinity`, so an invalidation
+would not refetch it, and after a `stop_mock_server` there is nothing to refetch
+from, since a mock's record dies with its listener. Both are what
+`useDeleteInboxMutation` and `useStopMockServerMutation` already do app-side.
+All three lists are invalidated on every `service` event rather than one per
+kind, because the entity is deliberately one family: the drawer and the Dock's
+count ask "what is listening", not "which kind".
 The entity list is duplicated across the process boundary
 (`MCP_DATA_ENTITIES` in `electron/mcp/tools.ts`, `McpDataEntity` in
 `types/domain.ts`) because production code under `electron/` cannot import from

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -177,6 +177,11 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `start_mock_issuer`    | execute  | `POST /mock-issuer/start`                    | - (loopback-only listener, so no allowlist entry applies); limits are the engine's - 31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent issuers |
 | `list_mock_issuers`    | read     | `GET /mock-issuer`                           | -                          |
 | `stop_mock_issuer`     | execute  | `POST /mock-issuer/:id/stop`                 | - (unknown id is a `404`, surfaced as a tool error) |
+| `update_mock_issuer`   | execute  | `PUT /mock-issuer/:id` (merge-patch)         | - (live edit of `failureMode` / `slowMs`; an empty patch is refused before the engine sees it) |
+| `start_mock_server`    | execute  | `POST /mock/start`                           | - (loopback-only listener, so no allowlist entry applies); the `latencyMs` ceiling is the engine's |
+| `list_mock_servers`    | read     | `GET /mock`                                  | - (running mocks only - a stopped one has no record) |
+| `get_mock_routes`      | read     | `GET /mock/:id/routes`                       | - (a start-time snapshot, constant under a running mock) |
+| `stop_mock_server`     | execute  | `POST /mock/:id/stop`                        | - (unknown id is a `404`, surfaced as a tool error) |
 | `start_webhook_inbox`  | execute  | `POST /inbox/start`                          | - (loopback-only listener; `bind` / `confirmNonLoopback` are never sent) |
 | `list_webhook_inboxes` | read     | `GET /inbox`                                 | -                          |
 | `stop_webhook_inbox`   | execute  | `POST /inbox/:id/stop`                       | - (frees the port, keeps the record and its captures) |
@@ -400,11 +405,40 @@ Notes:
   engine accepts the moment either side moves. The schema owns the *shape*: a
   claims object, an integer port, a `failureMode` from the closed set. Stopping
   an issuer frees its port; tokens it already minted stay valid until they
-  expire, since nothing verifies them against a live issuer. These tools emit no
-  `mcp:data-changed` event yet: #502's Services drawer does read issuers now, and
-  wiring them to the `service` entity the inbox tools introduced is #757's half
-  of epic #753 - until then the drawer's own poll is what shows an MCP-started
-  issuer.
+  expire, since nothing verifies them against a live issuer. **A running issuer
+  is edited, not recreated**: `update_mock_issuer` merge-patches `failureMode`
+  and `slowMs` live (issue #757), so an agent can mint a token against a healthy
+  issuer, flip it to `server_error` to watch the client retry, and flip it back
+  without the token URL under test moving or the signing key changing. Those two
+  are the only settings a bound listener will take - the engine refuses `port`,
+  `clients`, `claims` and `issueRefreshTokens` with "stop it and start a new
+  one", so the tool does not offer them at all rather than offering a call that
+  always fails. `expiresInSeconds` is mutable engine-side and is also left out:
+  a token's lifetime is fixed when it is minted, so changing it says nothing
+  about the tokens an agent already holds. An empty patch is refused here rather
+  than forwarded, because the engine accepts one and answers `200` - which would
+  report a change that did not happen (the `update_inbox_response` precedent).
+- **The mock-server tools** are how an agent stands up the API a client under
+  test expects, out of the collection's own saved examples (issue #757, over the
+  engine's [mock server](api-reference.md#mock-server) from #481):
+  `start_mock_server` binds a listener that answers each request's example -
+  status, headers, body - and returns its `mockId` and base URL,
+  `get_mock_routes` lists what it will serve, and `stop_mock_server` frees the
+  port. `latencyMs` and `errorRatePct` are how a client's timeout and retry
+  handling get exercised; `0` and `100` percent are exact by construction, in
+  between it is a per-request roll. **A started mock is not necessarily a usable
+  one**, which is why the result carries a caveat rather than leaving the counts
+  in the JSON: a route whose request has no saved example answers `501`, a path
+  matching nothing answers `404`, and a collection with no mappable requests
+  serves nothing at all. **Loopback-only** for the same engine-side reason as an
+  issuer - `mock_server.cpp` starts every listener on `127.0.0.1` with no host
+  to configure - so no allowlist entry is needed or checked. **A stop is a
+  delete here**, unlike an inbox: a mock records nothing, so its record dies
+  with its listener and it simply leaves `list_mock_servers`. The route table is
+  a snapshot taken at start and cannot change under a running mock (editing the
+  collection means restarting), which is why the renderer holds it at
+  `staleTime: Infinity` and a `stop_mock_server` event carries the `mockId` so
+  that cache entry is *dropped* rather than refetched into a `404`.
 - **The webhook-inbox tools** are the assertion half an agent testing a webhook
   needs (issue #756): `start_webhook_inbox` stands up a
   [local inbox](api-reference.md#webhook-inbox) and returns its URL,
@@ -905,15 +939,18 @@ configurable in **Settings → MCP** and persisted.
   save a request, which is not consent to destroy a subtree or a run's stored
   history.
 - **Loopback services carry no gate of their own** - `start_mock_issuer`,
-  `stop_mock_issuer`, `start_webhook_inbox`, `stop_webhook_inbox` and
+  `stop_mock_issuer`, `update_mock_issuer`, `start_mock_server`,
+  `stop_mock_server`, `start_webhook_inbox`, `stop_webhook_inbox` and
   `update_inbox_response` are `execute` tools that neither the allowlist nor the
   write toggle governs. (The two that destroy recorded data,
   `delete_webhook_inbox` and `clear_inbox_captures`, are `write` tools and do
   take the toggle - what they end is not the listener but the captures.) The allowlist exists to stop an agent generating traffic
   against third parties it was never pointed at, and a mock issuer is bound to
-  `127.0.0.1` by the engine with no host to configure - as is an inbox, whose
+  `127.0.0.1` by the engine with no host to configure - as is a mock server, and
+  as is an inbox, whose
   `bind` these tools never send; the write toggle gates saved data, which an
-  ephemeral listener is not. Nor would a gate here withhold
+  ephemeral listener is not (a mock server only *reads* the examples it serves).
+  Nor would a gate here withhold
   anything: an agent with `localhost` allowlisted can already reach
   `POST /mock-issuer/start` through `run_request`, for the same reason the
   endpoint needs no auth token. The bounds that do apply are the engine's own -
@@ -1022,18 +1059,24 @@ Each tool declares the data families it changes (`invalidates` in `tools.ts`)
 and `dispatchTool` - the single dispatch path - sends one `mcp:data-changed` per
 family after a call that did **not** return an error. The event names a family
 (`collection`, `request`, `environment`, `run`, `cookie`, `config`, `service`)
-plus the `collectionId` / `requestId` / `runId` / `inboxId` the call itself
-named; it carries no engine data, so the
-renderer still reads every row through its query layer. The four hints are read
+plus the `collectionId` / `requestId` / `runId` / `inboxId` / `mockId` the call
+itself named; it carries no engine data, so the
+renderer still reads every row through its query layer. The five hints are read
 off the call's own arguments at the dispatch chokepoint, which is what keeps a
 new write tool from having to remember an emit of its own - every tool in the
 registry spells them the same way. They are hints, not identity: `requestId` on
 a `run` event is the saved request a design run was linked to, while `runId` is
 the run itself, and only the tools that rewrite or remove an **existing** run
 (`stop_run`, `set_run_baseline`, `delete_run`) name one - a runner's new run has
-no per-run cache to drop yet. `inboxId` is the same shape for the `service`
-family: the inbox tools that act on an existing listener name it, and
-`start_webhook_inbox` cannot, since the engine assigns the id. The renderer side, including
+no per-run cache to drop yet. `inboxId` and `mockId` are the same shape for the
+`service` family: the tools that act on an existing listener name one, and
+`start_webhook_inbox` / `start_mock_server` cannot, since the engine assigns the
+id. Both exist because their per-id cache has to be **dropped** rather than
+refetched - a cleared capture list would union its destroyed rows straight back,
+and a stopped mock's route table has no live id left to refetch from. `service`
+is deliberately one family covering inboxes, mock servers and issuers, because
+the surfaces that read them - the Services drawer and the Dock's
+running-services count - ask "what is listening" rather than "which kind". The renderer side, including
 which query keys each family maps to, is in
 [`docs/app/state-management.md`](../app/state-management.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -265,7 +265,7 @@ second process to manage, and nothing leaves the machine.
     url = "http://127.0.0.1:9877/mcp"
     ```
 
-**24 tools, 5 resources, 4 prompts.** Inspection (`list_collections`,
+**42 tools, 5 resources, 4 prompts.** Inspection (`list_collections`,
 `get_run_report`, `compare_runs`), execution (`run_request`,
 `run_collection_smoke`), load (`start_load_run`, `stop_run`), and writes
 (full CRUD over collections and saved requests, plus `update_environment`) -
@@ -357,7 +357,7 @@ persists.
 ??? question "Can my coding agent use it?"
 
     Yes - Vayu hosts an MCP server on `127.0.0.1:9877` and one command registers
-    it with Claude Code, Cursor, VS Code, Codex or Zed. The agent gets 24 tools
+    it with Claude Code, Cursor, VS Code, Codex or Zed. The agent gets 42 tools
     across inspection, execution, load runs and writes, behind a host allowlist,
     load caps, and a write toggle that ships off. See the
     [MCP reference](engine/mcp.md).


### PR DESCRIPTION
## Description

S4 of epic #753. Two gaps, one diff.

The examples-driven mock server (#481, shipped 0.16.0) had zero MCP coverage: an agent could read about a collection's examples but could not stand up the API a client under test expects. And the issuer tools lagged the UI's own live edit (`ServicesPanel.tsx` IssuerDelayControl → `PUT /mock-issuer/:id`), so an agent testing retry behaviour had to destroy and recreate an issuer to flip its failure mode - which moves the token URL the request under test is pointed at and changes the signing key.

**Plan (root cause, approach, rejected alternative).** The root cause is not a missing endpoint but a missing *registry entry*: `/mock/*` and the issuer PUT have been served since #481/#479 and the renderer has driven both for two releases, so this is purely the MCP side catching up. The approach is therefore four tools plus one extension on the existing registry pattern, each a thin forward to a new `engine-client` method, with the gating posture copied verbatim from the issuer tools (loopback-bound engine-side, so no allowlist and no write toggle; the per-tool switch is what turns them off). Two places refuse to be a passthrough, and both are the "written but never read" rule pointing at the caller: a started mock whose routes have no examples answers `501` to every one of them, so the counts the engine already reports become a sentence on the result rather than a number in the JSON; and an empty issuer patch is refused here, because the engine accepts one and answers `200`, which would report a change that did not happen (the `update_inbox_response` precedent at `tools.ts`).

**The alternative I rejected** was declaring `invalidates: ["service"]` on the new tools and stopping there, which is what the issue's "reuse S3's invalidation entity" sentence reads like at first. Tracing the reader showed it would have been exactly the defect CLAUDE.md names: the renderer's `service` invalidator (`lib/mcp-invalidation.ts`) invalidated **only** `inbox.list()`, so an MCP-started mock would have declared an entity that refreshed the wrong list and the drawer would still have waited out its poll - the write landing nowhere a reader could see it. The invalidator now takes all three service lists, which also retires the `invalidates: []` note the issuer tools shipped with (`// the 'service' entity is #757's to take here`). A second entity per service kind was considered and rejected for the reason `MCP_DATA_ENTITIES` already records: the Services drawer and the Dock's count ask "what is listening", not "which kind".

**What the code verification changed.** The issue's problem statement holds at `d47bb49` - the route line numbers, the `501`-on-no-example behaviour and the `127.0.0.1` bind are all still as described. One thing the issue did not mention and the code required: a stopped mock's route table needs a *new* scope hint. `useMockServerRoutesQuery` holds it at `staleTime: Infinity` (it is a start-time snapshot), so an invalidation would not refetch it, and after a stop the id `404`s, so a refetch would leave an error state describing a table that no longer exists - `useStopMockServerMutation` already drops it app-side for exactly this. So `mockId` joins the event, mirrored across all three copies of the shape (`tools.ts`, `types/domain.ts`, `preload.ts`), which `data-changed.conformance.test.ts` enforces at compile time.

### Tools added

| Tool | Category | Maps to |
|---|---|---|
| `start_mock_server` | execute | `POST /mock/start` |
| `list_mock_servers` | read | `GET /mock` |
| `get_mock_routes` | read | `GET /mock/:id/routes` |
| `stop_mock_server` | execute | `POST /mock/:id/stop` |
| `update_mock_issuer` | execute | `PUT /mock-issuer/:id` (merge-patch) |

### Deliberate deviations from the issue spec

- **`update_mock_issuer` omits `expiresInSeconds`**, which the engine's `read_mutable_settings` does accept on a live issuer. The issue named `failureMode` and `slowMs` (the two the UI exposes) and I kept to that: a token's lifetime is fixed when it is minted, so changing it mid-session says nothing about the tokens an agent already holds. The reason is recorded next to `MOCK_ISSUER_PATCH_KEYS` rather than left for the next reader to rediscover. The four settings the engine *refuses* on a bound listener (`port`, `clients`, `claims`, `issueRefreshTokens`) are not offered either, and a test asserts their absence - offering them would be offering a call that always fails.
- **`latencyMs` carries no schema ceiling** while `port` and `errorRatePct` do. The ceiling is an engine constant (`core/constants.hpp`) and restating it would refuse values the engine accepts the moment either side moves - the `tools.ts:1216` posture the issue cites. A port range and a percentage are the *shape*, not a constant, so those stay.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Testing

All green on `7f8da38`, with no pre-existing failures on the base commit.

```
cd app && pnpm test          → 507 files, 5446 tests passed
cd app && pnpm type-check    → clean (tsc ×3)
cd app && pnpm lint          → clean (0 errors, 0 warnings)
cd app && pnpm format:check  → clean
mkdocs build --strict        → clean
```

No engine build or `ctest` run: the diff is TypeScript, tests and Markdown, and nothing in it can change the colour of a C++ test.

**Mutation-checked**, per CLAUDE.md - each fix reverted, the failure confirmed, then restored:

- Dropping the `mockId` route-table removal → 2 failures in `mcp-invalidation.test.ts`.
- Dropping the empty-patch refusal on `update_mock_issuer` → 2 failures (`tools.test.ts`, `data-changed.test.ts`).
- Dropping the no-example caveat → 2 failures in `tools.test.ts`.

New coverage: payload shaping (an absent knob stays absent, since the engine reads a present-but-bad field as a `400` rather than defaulting), every field forwarded under the engine's own key names, `404` on an unknown id surfaced rather than shrugged off, empty-id refusals before the engine is called, the schema bounds, the gating matrix (neither the allowlist nor the write toggle applies; the per-tool switch does), the invalidation declarations, and two end-to-end walks - stand up a mock → read its table → send to it → stop it, and the issuer's mint-and-stop.

The declaration map in `data-changed.test.ts` is exhaustive over `TOOLS`, so the five new tools had to be added there or the guard fails - which is what keeps a new tool from shipping invisible to the UI.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/mcp.md` (five tool-table rows, the mock-server narrative, the extended mock-issuer section rather than a duplicated rationale, the loopback-gating bullet, and the `mcp:data-changed` hint list now naming five hints), `docs/app/state-management.md` (the `service` row and its rationale paragraph), and `docs/index.md`, whose "24 tools" count was already stale at 37 and is now 42.

## Related Issues

Closes #757

Filed while here, out of scope and not in this diff: #792 - the Dock's running-services count reads inboxes and issuers but not mock servers, so a running mock is uncounted whatever surface started it.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ueBxLnjy4gWuo9GgJ2f8y)_