### PR TITLE
feat(app/mcp): document CRUD parity - saved-request auth and settings, example CRUD, collection state and move_item

### DIFF
--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -123,6 +123,18 @@ describe("the registry declares its effects", () => {
 			create_request: ["request"],
 			update_request: ["request"],
 			delete_request: ["request"],
+			// Document CRUD (#759). The example tools take the `request` family
+			// because that is where their rows live: the examples query key is
+			// nested under `requests.detail(id)`, so invalidating the request the
+			// call named reaches the open Examples panel too.
+			create_request_example: ["request"],
+			update_request_example: ["request"],
+			delete_request_example: ["request"],
+			// A move changes both trees at once - the row leaves one parent's
+			// list and joins another's - and a moved collection takes its
+			// requests with it, which is why it declares the pair rather than
+			// the family of the thing moved.
+			move_item: ["collection", "request"],
 			update_environment: ["environment"],
 			// State CRUD (#758). The globals writer takes the `environment` family
 			// rather than one of its own: same resolution order, same blob shape,

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -252,6 +252,19 @@ export class EngineClient {
 		return this.request("GET", "/collections", undefined, signal);
 	}
 
+	/**
+	 * Fetch a single collection by id. There is no `GET /collections/:id` route
+	 * either (see {@link getEnvironment}), and the list already answers each
+	 * collection in full - its variables, auth and scripts included, which is
+	 * what a merge-patch write has to read first. Returns `null` when no
+	 * collection matches.
+	 */
+	async getCollection(id: string, signal?: AbortSignal): Promise<unknown> {
+		const list = await this.request<unknown>("GET", "/collections", undefined, signal);
+		const arr = Array.isArray(list) ? (list as Array<Record<string, unknown>>) : [];
+		return arr.find((c) => c && typeof c === "object" && c.id === id) ?? null;
+	}
+
 	listRequests(collectionId: string, signal?: AbortSignal): Promise<unknown> {
 		return this.request(
 			"GET",
@@ -480,6 +493,86 @@ export class EngineClient {
 	/** Delete a saved request: `DELETE /requests/:id`. */
 	deleteRequest(id: string, signal?: AbortSignal): Promise<unknown> {
 		return this.request("DELETE", `/requests/${encodeURIComponent(id)}`, undefined, signal);
+	}
+
+	/*
+	 * Saved example responses. Every path is nested under the owning request
+	 * (issue #481) because one request owns them: the engine checks the owner
+	 * before the example, so an example reached through the wrong request is a
+	 * 404 rather than a cross-request write. That ownership is why these take a
+	 * `requestId` rather than an example id alone.
+	 */
+
+	/** A request's saved examples, in stored order: `GET /requests/:id/examples`. */
+	listRequestExamples(requestId: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request(
+			"GET",
+			`/requests/${encodeURIComponent(requestId)}/examples`,
+			undefined,
+			signal
+		);
+	}
+
+	/**
+	 * Create one saved example: `POST /requests/:id/examples` (the engine assigns
+	 * the id). A request already holding the per-request maximum answers `409`.
+	 */
+	createRequestExample(
+		requestId: string,
+		payload: unknown,
+		signal?: AbortSignal
+	): Promise<unknown> {
+		return this.request(
+			"POST",
+			`/requests/${encodeURIComponent(requestId)}/examples`,
+			payload,
+			signal
+		);
+	}
+
+	/**
+	 * Update one saved example: `PUT /requests/:id/examples/:exampleId`,
+	 * merge-patch like every other update here - a missing example is a `404`,
+	 * never a silent create.
+	 */
+	updateRequestExample(
+		requestId: string,
+		exampleId: string,
+		payload: unknown,
+		signal?: AbortSignal
+	): Promise<unknown> {
+		return this.request(
+			"PUT",
+			`/requests/${encodeURIComponent(requestId)}/examples/${encodeURIComponent(exampleId)}`,
+			payload,
+			signal
+		);
+	}
+
+	/** Delete one saved example: `DELETE /requests/:id/examples/:exampleId`. */
+	deleteRequestExample(
+		requestId: string,
+		exampleId: string,
+		signal?: AbortSignal
+	): Promise<unknown> {
+		return this.request(
+			"DELETE",
+			`/requests/${encodeURIComponent(requestId)}/examples/${encodeURIComponent(exampleId)}`,
+			undefined,
+			signal
+		);
+	}
+
+	/**
+	 * Reposition collections and requests in one atomic batch: `POST /reorder`
+	 * (issue #365). The whole batch validates and commits under one acquisition
+	 * of the engine's DB mutex, which is why a move goes through here rather than
+	 * through `PUT /collections/:id`'s own `parentId`: two concurrent reparents
+	 * cannot both pass an acyclicity check neither one's commit was visible to.
+	 * A rejected batch writes nothing at all.
+	 */
+	reorder(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		return this.request("POST", "/reorder", payload, signal);
 	}
 
 	/**

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -12,6 +12,7 @@ import {
 	DEFAULT_RUN_SAMPLE_LIMIT,
 	DEFAULT_RUN_SERIES_LIMIT,
 	dispatchTool,
+	MAX_EXAMPLES_BODY_BYTES,
 	MAX_INBOX_CAPTURE_LIMIT,
 	MAX_IN_FLIGHT_BOUND,
 	MAX_INLINE_BODY_BYTES,
@@ -119,6 +120,25 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		createCollection: vi.fn().mockResolvedValue({ id: "col_1", name: "API" }),
 		updateCollection: vi.fn().mockResolvedValue({ id: "col_1", name: "Renamed" }),
 		deleteCollection: vi.fn().mockResolvedValue({ message: "Collection deleted successfully" }),
+		getCollection: vi.fn().mockResolvedValue({
+			id: "col_1",
+			name: "API",
+			variables: { baseUrl: { value: "https://api.example.com", enabled: true } },
+			auth: { mode: "none" },
+			preRequestScript: "",
+			postRequestScript: "",
+		}),
+		listRequestExamples: vi.fn().mockResolvedValue([]),
+		createRequestExample: vi
+			.fn()
+			.mockResolvedValue({ id: "exa_1", requestId: "req_1", name: "200 OK" }),
+		updateRequestExample: vi
+			.fn()
+			.mockResolvedValue({ id: "exa_1", requestId: "req_1", name: "200 OK" }),
+		deleteRequestExample: vi
+			.fn()
+			.mockResolvedValue({ message: "Example deleted successfully", id: "exa_1" }),
+		reorder: vi.fn().mockResolvedValue({ collections: [], requests: [] }),
 		getEnvironment: vi.fn().mockResolvedValue({
 			id: "env_1",
 			name: "Dev",
@@ -1388,6 +1408,622 @@ describe("an agent can round-trip its own work", () => {
 		);
 		expect(removedCollection.isError).toBeFalsy();
 		expect(client.deleteCollection).toHaveBeenCalledWith(collectionId, undefined);
+	});
+});
+
+/*
+ * Document CRUD parity (#759). What an agent could *write* onto a saved
+ * document used to be a fraction of what the app stores: no auth, none of the
+ * Settings tab, no examples at all, and a collection's variables, auth and
+ * scripts unreachable. These cover the four things that closes, and the two
+ * rules that keep it safe to hand an agent - a patch carries only what the
+ * caller named, and where a row came from is never the caller's to claim.
+ */
+describe("document CRUD parity", () => {
+	/** The arguments one engine-client fake was called with. */
+	function callArgs(fn: unknown, index = 0): unknown[] {
+		return (fn as ReturnType<typeof vi.fn>).mock.calls[index];
+	}
+
+	/** The zod schema one tool declares for `field`. */
+	function schemaOf(tool: string, field: string) {
+		const found = TOOLS.find((t) => t.name === tool);
+		expect(found, tool).toBeDefined();
+		return found!.inputSchema[field] as z.ZodTypeAny;
+	}
+
+	describe("saved-request auth and settings", () => {
+		const auth = { mode: "bearer", token: "{{apiToken}}" };
+
+		test("create_request stores auth and the four Settings fields", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"create_request",
+				{
+					collectionId: "col_1",
+					name: "Get users",
+					url: "https://api.example.com/users",
+					auth,
+					followRedirects: false,
+					maxRedirects: 3,
+					httpVersion: "http2",
+					stream: true,
+				},
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(callArgs(client.createRequest)[0]).toMatchObject({
+				auth,
+				followRedirects: false,
+				maxRedirects: 3,
+				httpVersion: "http2",
+				stream: true,
+			});
+		});
+
+		test("a create that names none of them sends none of them", async () => {
+			// The engine's own defaults are the answer for a caller that said
+			// nothing; a filler here would store a policy nobody chose.
+			const client = fakeClient();
+			await dispatchTool(
+				"create_request",
+				{ collectionId: "col_1", name: "Get users", url: "https://api.example.com/users" },
+				ctxWith(client, { allowWrites: true })
+			);
+			const payload = callArgs(client.createRequest)[0] as Record<string, unknown>;
+			for (const key of [
+				"auth",
+				"followRedirects",
+				"maxRedirects",
+				"httpVersion",
+				"stream",
+			]) {
+				expect(Object.keys(payload), key).not.toContain(key);
+			}
+		});
+
+		test("update_request patches only the settings it names", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"update_request",
+				{ requestId: "req_1", maxRedirects: 0 },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			// Exactly one key: `PUT /requests/:id` merge-patches, so a defaulted
+			// `followRedirects: true` beside it would silently rewrite a policy
+			// the user set in the app.
+			expect(callArgs(client.updateRequest)[1]).toEqual({ maxRedirects: 0 });
+		});
+
+		test("update_request replaces the auth block whole", async () => {
+			const client = fakeClient();
+			await dispatchTool(
+				"update_request",
+				{ requestId: "req_1", auth: { mode: "none" } },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(callArgs(client.updateRequest)[1]).toEqual({ auth: { mode: "none" } });
+		});
+
+		test("the stored auth input is the run tools' schema, refusals included", () => {
+			const run = schemaOf("run_request", "auth");
+			const created = schemaOf("create_request", "auth");
+			const updated = schemaOf("update_request", "auth");
+			const collection = schemaOf("update_collection", "auth");
+			const cases: unknown[] = [
+				undefined,
+				{ mode: "bearer", token: "t" },
+				{ mode: "oauth2", clientId: "id", clientSecret: "s" },
+				// The refusals: a block with no mode, a bare string, a number, an
+				// array. One shared schema means one answer to each.
+				{ token: "t" },
+				"bearer",
+				7,
+				[],
+			];
+			for (const value of cases) {
+				const expected = run.safeParse(value).success;
+				expect(created.safeParse(value).success, JSON.stringify(value)).toBe(expected);
+				expect(updated.safeParse(value).success, JSON.stringify(value)).toBe(expected);
+				expect(collection.safeParse(value).success, JSON.stringify(value)).toBe(expected);
+			}
+			// The four differ only in wording, which is what makes them one schema
+			// with four descriptions rather than four schemas.
+			expect(run.safeParse({ token: "t" }).success).toBe(false);
+			expect(run.safeParse({ mode: "bearer", token: "t" }).success).toBe(true);
+		});
+	});
+
+	describe("saved examples", () => {
+		test("create_request_example marks the row as user-written, whatever the caller claims", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"create_request_example",
+				{
+					requestId: "req_1",
+					name: "200 OK",
+					status: 201,
+					headers: { "content-type": "application/json" },
+					body: '{"ok":true}',
+					contentType: "application/json",
+					// The engine accepts this field; the tool must not forward it.
+					origin: "import",
+				},
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			const [requestId, payload] = callArgs(client.createRequestExample) as [
+				string,
+				Record<string, unknown>,
+			];
+			expect(requestId).toBe("req_1");
+			expect(payload).toEqual({
+				name: "200 OK",
+				status: 201,
+				contentType: "application/json",
+				headers: [{ key: "content-type", value: "application/json", enabled: true }],
+				body: '{"ok":true}',
+				// Forwarding the caller's "import" would hand an agent's row to the
+				// next OpenAPI sync to overwrite - the omission is the point.
+				origin: "user",
+			});
+		});
+
+		test("update_request_example patches only what it names, and never the origin", async () => {
+			const client = fakeClient();
+			await dispatchTool(
+				"update_request_example",
+				{ requestId: "req_1", exampleId: "exa_1", status: 500, origin: "user" },
+				ctxWith(client, { allowWrites: true })
+			);
+			const [requestId, exampleId, payload] = callArgs(client.updateRequestExample) as [
+				string,
+				string,
+				Record<string, unknown>,
+			];
+			expect(requestId).toBe("req_1");
+			expect(exampleId).toBe("exa_1");
+			expect(payload).toEqual({ status: 500 });
+		});
+
+		test("an update naming no field is refused rather than sent", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"update_request_example",
+				{ requestId: "req_1", exampleId: "exa_1" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBe(true);
+			expect(client.updateRequestExample).not.toHaveBeenCalled();
+		});
+
+		test("list_request_examples clips one oversized body and says so", async () => {
+			const body = "x".repeat(MAX_INLINE_BODY_BYTES + 500);
+			const client = fakeClient({
+				listRequestExamples: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "exa_1", name: "big", status: 200, body, bodyTruncated: false },
+					]),
+			});
+			const res = await dispatchTool(
+				"list_request_examples",
+				{ requestId: "req_1" },
+				ctxWith(client)
+			);
+			expect(res.isError).toBeFalsy();
+			const parsed = JSON.parse(firstText(res)) as {
+				examples: Array<Record<string, unknown>>;
+				bodiesOmitted: number;
+			};
+			expect(parsed.examples[0]).toMatchObject({
+				name: "big",
+				bodyClipped: true,
+				bodyBytes: body.length,
+				// The engine's own flag is a different fact and is left as it was.
+				bodyTruncated: false,
+			});
+			expect((parsed.examples[0].body as string).length).toBe(MAX_INLINE_BODY_BYTES);
+			expect(parsed.bodiesOmitted).toBe(0);
+		});
+
+		test("the list has a budget: bodies past it are dropped, their rows kept", async () => {
+			const body = "x".repeat(MAX_INLINE_BODY_BYTES);
+			const rows = [1, 2, 3, 4].map((n) => ({
+				id: `exa_${n}`,
+				name: `example ${n}`,
+				status: 200,
+				body,
+			}));
+			const client = fakeClient({
+				listRequestExamples: vi.fn().mockResolvedValue(rows),
+			});
+			const res = await dispatchTool(
+				"list_request_examples",
+				{ requestId: "req_1" },
+				ctxWith(client)
+			);
+			const parsed = JSON.parse(firstText(res)) as {
+				examples: Array<Record<string, unknown>>;
+				bodiesOmitted: number;
+				bodyBudgetBytes: number;
+			};
+			expect(parsed.bodyBudgetBytes).toBe(MAX_EXAMPLES_BODY_BYTES);
+			expect(parsed.bodiesOmitted).toBe(1);
+			// The scalars survive: a row an agent cannot read the body of is
+			// still a row it has to know exists.
+			expect(parsed.examples[3]).toMatchObject({
+				id: "exa_4",
+				name: "example 4",
+				status: 200,
+				bodyOmitted: true,
+				bodyBytes: body.length,
+			});
+			expect(parsed.examples[3].body).toBe("");
+			expect(parsed.examples[0].bodyOmitted).toBeUndefined();
+		});
+
+		test("a small body is passed through untouched", async () => {
+			const client = fakeClient({
+				listRequestExamples: vi
+					.fn()
+					.mockResolvedValue([{ id: "exa_1", name: "ok", status: 200, body: "{}" }]),
+			});
+			const res = await dispatchTool(
+				"list_request_examples",
+				{ requestId: "req_1" },
+				ctxWith(client)
+			);
+			const parsed = JSON.parse(firstText(res)) as {
+				examples: Array<Record<string, unknown>>;
+			};
+			expect(parsed.examples[0]).toEqual({
+				id: "exa_1",
+				name: "ok",
+				status: 200,
+				body: "{}",
+			});
+		});
+
+		test("delete_request_example previews the example and its mock consequence", async () => {
+			const client = fakeClient({
+				listRequestExamples: vi
+					.fn()
+					.mockResolvedValue([{ id: "exa_1", name: "200 OK", status: 200 }]),
+			});
+			const res = await dispatchTool(
+				"delete_request_example",
+				{ requestId: "req_1", exampleId: "exa_1" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(firstText(res)).toMatch(/awaiting confirmation/i);
+			expect(firstText(res)).toContain("200 OK");
+			expect(firstText(res)).toMatch(/mock server/i);
+			expect(client.deleteRequestExample).not.toHaveBeenCalled();
+		});
+
+		test("confirmed, it deletes; unknown, it says so and deletes nothing", async () => {
+			const client = fakeClient({
+				listRequestExamples: vi
+					.fn()
+					.mockResolvedValue([{ id: "exa_1", name: "200 OK", status: 200 }]),
+			});
+			const ctx = ctxWith(client, { allowWrites: true });
+			const done = await dispatchTool(
+				"delete_request_example",
+				{ requestId: "req_1", exampleId: "exa_1", confirmed: true },
+				ctx
+			);
+			expect(done.isError).toBeFalsy();
+			expect(client.deleteRequestExample).toHaveBeenCalledWith("req_1", "exa_1", undefined);
+
+			const missing = await dispatchTool(
+				"delete_request_example",
+				{ requestId: "req_1", exampleId: "exa_gone", confirmed: true },
+				ctx
+			);
+			expect(missing.isError).toBe(true);
+			expect(firstText(missing)).toContain("exa_gone");
+			expect(client.deleteRequestExample).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("collection-level state", () => {
+		test("create_collection stores variables, auth and both scripts", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"create_collection",
+				{
+					name: "API",
+					variables: {
+						baseUrl: "https://api.example.com",
+						token: { value: "t", secret: true },
+					},
+					auth: { mode: "apikey", key: "X-Key", value: "{{token}}" },
+					preRequestScript: "pm.request.headers.add('x-run', '1')",
+					postRequestScript: "pm.test('ok', () => {})",
+				},
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(callArgs(client.createCollection)[0]).toEqual({
+				name: "API",
+				auth: { mode: "apikey", key: "X-Key", value: "{{token}}" },
+				preRequestScript: "pm.request.headers.add('x-run', '1')",
+				postRequestScript: "pm.test('ok', () => {})",
+				variables: {
+					baseUrl: { enabled: true, value: "https://api.example.com" },
+					token: { enabled: true, value: "t", secret: true },
+				},
+			});
+		});
+
+		test("update_collection merges variables against the stored blob", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"update_collection",
+				{ collectionId: "col_1", variables: { token: "t" } },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			// The read is what makes it a merge: `PUT /collections/:id` replaces
+			// the whole blob, so without it setting `token` would drop `baseUrl`.
+			expect(client.getCollection).toHaveBeenCalledWith("col_1", undefined);
+			expect(callArgs(client.updateCollection)[1]).toEqual({
+				variables: {
+					baseUrl: { value: "https://api.example.com", enabled: true },
+					token: { enabled: true, value: "t" },
+				},
+			});
+		});
+
+		test("removeVariables deletes a name, and an absent one is reported", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"update_collection",
+				{ collectionId: "col_1", removeVariables: ["baseUrl", "nope"] },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(callArgs(client.updateCollection)[1]).toEqual({ variables: {} });
+			// A name that was not there is a caveat beside the result, not an
+			// error - the same disclosure update_environment makes.
+			expect(res.content.map((c) => c.text).join("\n")).toContain("nope");
+		});
+
+		test("a rename still needs no read, and an empty patch is refused", async () => {
+			const client = fakeClient();
+			const renamed = await dispatchTool(
+				"update_collection",
+				{ collectionId: "col_1", name: "Renamed", preRequestScript: "" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(renamed.isError).toBeFalsy();
+			expect(client.getCollection).not.toHaveBeenCalled();
+			// An empty string is a value: it is how a collection script is cleared.
+			expect(callArgs(client.updateCollection)[1]).toEqual({
+				name: "Renamed",
+				preRequestScript: "",
+			});
+
+			const nothing = await dispatchTool(
+				"update_collection",
+				{ collectionId: "col_1" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(nothing.isError).toBe(true);
+			expect(client.updateCollection).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("move_item", () => {
+		/** Two collections at the root, one nested, and a request list per collection. */
+		const TREE = [
+			{ id: "col_1", name: "API", parentId: "", order: 0 },
+			{ id: "col_2", name: "Internal", parentId: "", order: 1 },
+			{ id: "col_1a", name: "v1", parentId: "col_1", order: 0 },
+		];
+
+		function moveClient(requests: Record<string, unknown[]> = {}) {
+			return fakeClient({
+				listCollections: vi.fn().mockResolvedValue(TREE),
+				listRequests: vi
+					.fn()
+					.mockImplementation((id: string) => Promise.resolve(requests[id] ?? [])),
+			});
+		}
+
+		test("a request lands after the collection's current requests", async () => {
+			const client = moveClient({
+				col_2: [
+					{ id: "r1", order: 0 },
+					{ id: "r2", order: 1 },
+				],
+			});
+			const res = await dispatchTool(
+				"move_item",
+				{ type: "request", id: "req_1", collectionId: "col_2" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			// A dense destination needs no sibling rewritten - only the row that
+			// moved, carrying its new owner.
+			expect(callArgs(client.reorder)[0]).toEqual({
+				moves: [{ type: "request", id: "req_1", order: 2, collectionId: "col_2" }],
+			});
+		});
+
+		test("position 'first' shifts exactly the siblings whose slot changes", async () => {
+			const client = moveClient({
+				col_2: [
+					{ id: "r1", order: 0 },
+					{ id: "r2", order: 2 },
+				],
+			});
+			await dispatchTool(
+				"move_item",
+				{ type: "request", id: "req_1", collectionId: "col_2", position: "first" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(callArgs(client.reorder)[0]).toEqual({
+				moves: [
+					{ type: "request", id: "req_1", order: 0, collectionId: "col_2" },
+					{ type: "request", id: "r1", order: 1 },
+					// r2 already sits at 2, which is where it belongs after the
+					// insert - a batch that rewrote it would be writing nothing.
+				],
+			});
+		});
+
+		test("repositioning inside the same collection does not leave the row tied", async () => {
+			// The bug this shape exists to prevent: state the whole arrangement,
+			// and the moved row cannot land level with the sibling it displaced.
+			const client = moveClient({
+				col_2: [
+					{ id: "r1", order: 0 },
+					{ id: "req_1", order: 1 },
+					{ id: "r2", order: 2 },
+				],
+			});
+			await dispatchTool(
+				"move_item",
+				{ type: "request", id: "req_1", collectionId: "col_2" },
+				ctxWith(client, { allowWrites: true })
+			);
+			const batch = callArgs(client.reorder)[0] as { moves: Array<Record<string, unknown>> };
+			expect(batch.moves).toEqual([
+				{ type: "request", id: "req_1", order: 2, collectionId: "col_2" },
+				{ type: "request", id: "r2", order: 1 },
+			]);
+			const orders = batch.moves.map((m) => m.order);
+			expect(new Set(orders).size).toBe(orders.length);
+		});
+
+		test("a legacy collection whose rows all sit at 0 gets real positions", async () => {
+			const client = moveClient({
+				col_2: [
+					{ id: "r1", order: 0 },
+					{ id: "r2", order: 0 },
+				],
+			});
+			await dispatchTool(
+				"move_item",
+				{ type: "request", id: "req_1", collectionId: "col_2" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(callArgs(client.reorder)[0]).toEqual({
+				moves: [
+					{ type: "request", id: "req_1", order: 2, collectionId: "col_2" },
+					{ type: "request", id: "r2", order: 1 },
+				],
+			});
+		});
+
+		test("a collection moves to the top level, and among its new siblings", async () => {
+			const client = moveClient();
+			await dispatchTool(
+				"move_item",
+				{ type: "collection", id: "col_1a", parentId: null },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(callArgs(client.reorder)[0]).toEqual({
+				moves: [{ type: "collection", id: "col_1a", order: 2, parentId: null }],
+			});
+		});
+
+		test("a collection cannot move into itself or its own subtree", async () => {
+			const client = moveClient();
+			const ctx = ctxWith(client, { allowWrites: true });
+			const intoSelf = await dispatchTool(
+				"move_item",
+				{ type: "collection", id: "col_1", parentId: "col_1" },
+				ctx
+			);
+			expect(intoSelf.isError).toBe(true);
+			expect(firstText(intoSelf)).toMatch(/itself/i);
+
+			const intoChild = await dispatchTool(
+				"move_item",
+				{ type: "collection", id: "col_1", parentId: "col_1a" },
+				ctx
+			);
+			expect(intoChild.isError).toBe(true);
+			expect(firstText(intoChild)).toContain("col_1a");
+			// The engine would refuse the same batch under its lock; refusing here
+			// is about naming the problem, so nothing may reach it.
+			expect(client.reorder).not.toHaveBeenCalled();
+		});
+
+		test("a collection move states its destination or is refused", async () => {
+			const client = moveClient();
+			const res = await dispatchTool(
+				"move_item",
+				{ type: "collection", id: "col_1a" },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toContain("parentId");
+			expect(client.reorder).not.toHaveBeenCalled();
+		});
+
+		test("an unknown collection is named rather than sent", async () => {
+			const client = moveClient();
+			const res = await dispatchTool(
+				"move_item",
+				{ type: "collection", id: "col_gone", parentId: null },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toContain("col_gone");
+			expect(client.reorder).not.toHaveBeenCalled();
+		});
+	});
+
+	test("every new write verb refuses before touching the engine when writes are off", async () => {
+		const client = fakeClient();
+		const calls: Array<[string, Record<string, unknown>, keyof EngineClient]> = [
+			[
+				"create_request_example",
+				{ requestId: "req_1", name: "200 OK" },
+				"createRequestExample",
+			],
+			[
+				"update_request_example",
+				{ requestId: "req_1", exampleId: "exa_1", status: 500 },
+				"updateRequestExample",
+			],
+			[
+				"delete_request_example",
+				{ requestId: "req_1", exampleId: "exa_1", confirmed: true },
+				"deleteRequestExample",
+			],
+			["move_item", { type: "request", id: "req_1", collectionId: "col_2" }, "reorder"],
+		];
+		for (const [tool, args, method] of calls) {
+			const res = await dispatchTool(tool, args, ctxWith(client, { allowWrites: false }));
+			expect(res.isError, tool).toBe(true);
+			expect(client[method], tool).not.toHaveBeenCalled();
+		}
+		// Nor may one read what it would change while writes are off.
+		expect(client.listRequestExamples).not.toHaveBeenCalled();
+		expect(client.listRequests).not.toHaveBeenCalled();
+	});
+
+	test("the new tools carry the categories and hints their gates imply", () => {
+		const byName = new Map(TOOLS.map((t) => [t.name, t]));
+		expect(byName.get("list_request_examples")?.category).toBe("read");
+		for (const name of [
+			"create_request_example",
+			"update_request_example",
+			"delete_request_example",
+			"move_item",
+		]) {
+			expect(byName.get(name)?.category, name).toBe("write");
+		}
+		expect(byName.get("delete_request_example")?.annotations.destructiveHint).toBe(true);
+		expect(byName.get("list_request_examples")?.annotations.readOnlyHint).toBe(true);
 	});
 });
 

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1030,6 +1030,26 @@ function removeVariablesInput(subject: string) {
 		);
 }
 
+/**
+ * Read the `variables` argument as a patch, refusing anything that is not a
+ * name -> value map.
+ *
+ * The throwing form of the check `create_environment` / `update_environment`
+ * make inline (`dispatchTool` turns a `ToolArgError` into the same tool error
+ * their `errorResult` produces, with the same message). It is a function here
+ * because the collection tools take the argument at two more call sites, and a
+ * fourth hand-written copy of "is this an object" is how the four start
+ * disagreeing about what a malformed one does.
+ */
+function readVariablesPatch(args: Record<string, unknown>): Record<string, unknown> | undefined {
+	const value = args.variables;
+	if (value === undefined || value === null) return undefined;
+	if (!isRecord(value)) {
+		throw new ToolArgError('"variables" must be an object mapping names to values.');
+	}
+	return value;
+}
+
 /** Read and validate `removeVariables` off raw arguments. */
 function removalNames(args: Record<string, unknown>): string[] {
 	const value = args.removeVariables;
@@ -1656,6 +1676,30 @@ function storedScriptInput(which: "pre" | "post", clearable: boolean) {
 }
 
 /**
+ * A collection's stored scripts - the ones that run around *every* request in
+ * it, not around one (issue #759).
+ *
+ * A separate fragment from `storedScriptInput` rather than a parameter on it,
+ * because what an agent has to know here is the scope: a script written onto a
+ * collection runs for every request below it, including the ones in its
+ * sub-collections, so the blast radius of a wrong one is a whole tree rather
+ * than a row. Both take the same clearing rule the request scripts do on an
+ * update - the engine merge-patches strings, so an empty string is a value.
+ */
+function collectionScriptInput(which: "pre" | "post") {
+	const when =
+		which === "pre"
+			? "before each request in this collection is sent, ahead of that request's own pre-request script"
+			: "after each response in this collection arrives, ahead of that request's own test script";
+	return z
+		.string()
+		.optional()
+		.describe(
+			`JavaScript stored on the collection and run ${when} - the app's collection-level scripts. It runs for every request in the collection and in its sub-collections, so scope it accordingly. Read the \`vayu://scripting/completions\` resource for the sandbox's surface. Leave it out to keep the stored script; pass an empty string to clear it.`
+		);
+}
+
+/**
  * Optional auth block. Callers can copy a saved request's `auth` object verbatim
  * (read via list_requests). The engine applies it - bearer/basic/apikey and
  * oauth2 (using its token cache) - after `{{variables}}` inside it are resolved;
@@ -1668,6 +1712,90 @@ const authInput = z
 	.describe(
 		"Optional auth block (e.g. { mode: 'bearer', token: '{{apiToken}}' }); the engine resolves and applies it."
 	);
+
+/**
+ * The auth block as it is *stored* on a document, described for the resource
+ * holding it (issue #759).
+ *
+ * The same schema `run_request` and `start_load_run` take - one definition, not
+ * a copy - because a saved request's auth and an ad-hoc one are the same object
+ * in the same shape, and an agent that read a request's `auth` over
+ * `list_requests` must be able to write it back verbatim. What differs per
+ * subject is only which modes are meaningful: a request may `inherit` (its
+ * default), while a collection is the root of the chain and never does.
+ */
+function storedAuthInput(subject: string, extra: string) {
+	return authInput.describe(
+		`Auth block stored on ${subject}, in the same shape run_request takes - e.g. { mode: 'bearer', token: '{{apiToken}}' }. It is stored as written and resolved when the request is sent, so {{variables}} inside it are fine. ${extra}`
+	);
+}
+
+/**
+ * The **Settings** tab's four per-request fields, as the engine stores them on
+ * the row (issue #759).
+ *
+ * One definition spread into both `create_request` and `update_request`: the
+ * fields mean the same thing on either verb, and the merge-patch difference is
+ * carried by the surrounding tool description rather than by two copies of four
+ * schemas. Ranges are the engine's own (`apply_request_fields`) rather than new
+ * numbers - `maxRedirects` is clamped to 0-100 there, and an unrecognized
+ * `httpVersion` is a 400 rather than a coercion, which is why the enum is
+ * closed here too.
+ *
+ * `verifySSL` is deliberately **not** among them: it is stored beside these
+ * (issue #706) and belongs to the transport epic's own CRUD pass - see #795.
+ */
+function requestSettingsInput() {
+	return {
+		followRedirects: z
+			.boolean()
+			.optional()
+			.describe(
+				"Follow 3xx redirects when this request is sent (default true). The request builder's Settings tab."
+			),
+		maxRedirects: z
+			.number()
+			.int()
+			.min(0)
+			.max(100)
+			.optional()
+			.describe("How many redirects to follow before giving up (default 10, 0-100)."),
+		httpVersion: z
+			.enum(HTTP_VERSIONS)
+			.optional()
+			.describe(
+				'Protocol to negotiate when this request is sent: "auto" | "http1.1" | "http2" (default "auto").'
+			),
+		stream: z
+			.boolean()
+			.optional()
+			.describe(
+				"Consume the response as a text/event-stream rather than buffering it (default false). Stored on the request, so a later send - from the app or from run_request - streams without being told to."
+			),
+	};
+}
+
+/** The stored settings a call named, forwarded verbatim; an unnamed one is absent. */
+const REQUEST_SETTINGS_KEYS = ["followRedirects", "maxRedirects", "httpVersion", "stream"] as const;
+
+/**
+ * Lay the caller's stored-settings fields onto a request payload.
+ *
+ * Values pass through unvalidated on purpose: the schema above owns the shapes,
+ * and the engine owns the ranges - re-deriving either here would be a second
+ * copy that refuses what the engine accepts the moment one side moves. What
+ * this owns is the *absent* rule, which is the merge-patch contract: a field the
+ * caller did not name is never written, so an update cannot silently reset the
+ * redirect policy a user set in the app.
+ */
+function applyRequestSettings(
+	args: Record<string, unknown>,
+	payload: Record<string, unknown>
+): void {
+	for (const key of REQUEST_SETTINGS_KEYS) {
+		if (args[key] !== undefined) payload[key] = args[key];
+	}
+}
 
 // --- Structured output schemas ----------------------------------------------
 
@@ -2283,11 +2411,29 @@ function toKeyValueEntries(
 
 // --- Cascade accounting for delete_collection --------------------------------
 
-/** A `GET /collections` row, narrowed to the fields the cascade walk reads. */
+/**
+ * A `GET /collections` row, narrowed to the fields the cascade walk reads - plus
+ * the `order` a move reads, since both work from the same one list read.
+ */
 interface CollectionRow {
 	id: string;
 	name?: string;
 	parentId?: string | null;
+	order?: number;
+}
+
+/**
+ * The collection a row sits under, or `null` for a root one.
+ *
+ * Two spellings reach here for "no parent": the engine serializes a root
+ * collection's `parentId` as `null`, while a row that has been through a client
+ * whose type calls it optional can arrive without the key at all. An empty
+ * string is the third - what the cascade walk has always treated as a root.
+ * Comparing raw values would file a root collection under a parent named "",
+ * which is a destination that does not exist.
+ */
+function collectionParent(row: CollectionRow): string | null {
+	return typeof row.parentId === "string" && row.parentId !== "" ? row.parentId : null;
 }
 
 /** The collections list, dropping anything without a usable id. */
@@ -2577,6 +2723,187 @@ export const MAX_INBOX_CAPTURE_LIMIT = 100;
 function boundInboxCaptures(value: unknown): unknown {
 	if (!isRecord(value) || !Array.isArray(value.data)) return value;
 	return { ...value, data: value.data.map(boundTraceNode) };
+}
+
+// --- Saved example responses -------------------------------------------------
+
+/**
+ * How much of a stored example body one result carries, and how much a whole
+ * list may spend (issue #759, on the #767 / #769 precedent).
+ *
+ * An example body is capped engine-side at 1 MB and a request may hold 100 of
+ * them, so an unbounded list is a 100 MB tool result - the same shape that made
+ * `get_run_report` blow the token limit before #769 bounded its traces. The two
+ * numbers are that fix's, not new ones: `MAX_INLINE_BODY_BYTES` per body, and
+ * three times it across the list, which is the largest single row the per-body
+ * bound can produce.
+ */
+export const MAX_EXAMPLES_BODY_BYTES = MAX_INLINE_BODY_BYTES * 3;
+
+/** A list of examples with its bodies bounded, and what that cost. */
+interface BoundedExamples {
+	examples: unknown[];
+	/** Rows whose body did not fit the list budget at all. */
+	bodiesOmitted: number;
+	bodyBudgetBytes: number;
+}
+
+/**
+ * Bound the bodies of one request's examples, disclosing every cut.
+ *
+ * The flags are deliberately **not** the engine's `bodyTruncated`: that field
+ * already means something else on this row - the client that captured the
+ * response stored only a prefix of it - and reusing the name would leave an
+ * agent unable to tell a short capture from a short *read*. So a body cut to fit
+ * this result is `bodyClipped` with the stored size in `bodyBytes`, and one that
+ * did not fit at all is `bodyOmitted` with the same size, keeping every scalar
+ * (id, name, status, headers, order, origin) that says what the row is.
+ */
+function boundExampleBodies(value: unknown): BoundedExamples {
+	const rows = Array.isArray(value) ? value : [];
+	let spent = 0;
+	let bodiesOmitted = 0;
+	const examples = rows.map((row) => {
+		if (!isRecord(row) || typeof row.body !== "string" || row.body === "") return row;
+		const stored = Buffer.byteLength(row.body, "utf8");
+		const remaining = MAX_EXAMPLES_BODY_BYTES - spent;
+		if (remaining <= 0) {
+			bodiesOmitted++;
+			return { ...row, body: "", bodyOmitted: true, bodyBytes: stored };
+		}
+		const bounded = boundText(row.body, Math.min(MAX_INLINE_BODY_BYTES, remaining));
+		spent += Buffer.byteLength(bounded.text, "utf8");
+		if (!bounded.truncated) return row;
+		return { ...row, body: bounded.text, bodyClipped: true, bodyBytes: bounded.bytes };
+	});
+	return { examples, bodiesOmitted, bodyBudgetBytes: MAX_EXAMPLES_BODY_BYTES };
+}
+
+/**
+ * The fields an example write may state, in the engine's spelling
+ * (`apply_request_example_fields`).
+ *
+ * **`origin` is not among them, and that is the point.** The column says who
+ * wrote the row - `import` for an importer or a spec sync, `user` for what the
+ * app saved from a live response - and the OpenAPI sync replaces the first kind
+ * without touching the second (#588, #722). An agent that could claim `import`
+ * could hand its own example to the next sync to overwrite; one that could claim
+ * `user` could pin a stale imported row against the document it came from.
+ * Neither is the agent's call, so the field is refused by omission: the SDK
+ * strips what the schema does not declare, and the payload builder copies only
+ * the keys below.
+ */
+const EXAMPLE_WRITE_KEYS = ["name", "status", "contentType"] as const;
+
+/**
+ * The body of an example write - the named fields only, so an update leaves
+ * what it did not mention alone (the engine merge-patches on `PUT`).
+ *
+ * `headers` follows the request tools' rule: a string map in, the engine's
+ * `{key, value, enabled}` rows out, replacing the stored list wholesale.
+ */
+function exampleWritePayload(args: Record<string, unknown>): Record<string, unknown> {
+	const payload: Record<string, unknown> = {};
+	for (const key of EXAMPLE_WRITE_KEYS) {
+		if (args[key] !== undefined) payload[key] = args[key];
+	}
+	if (args.headers !== undefined) {
+		if (!isRecord(args.headers)) {
+			throw new ToolArgError('"headers" must be an object mapping header names to values.');
+		}
+		payload.headers = toKeyValueEntries(args.headers);
+	}
+	const body = str(args, "body");
+	if (body !== undefined) payload.body = body;
+	return payload;
+}
+
+/** One stored example named in words, for the prompt that asks to delete it. */
+function describeExample(exampleId: string, example: Record<string, unknown>): string {
+	const name = typeof example.name === "string" && example.name !== "" ? example.name : exampleId;
+	const status = typeof example.status === "number" ? ` (status ${example.status})` : "";
+	return `"${name}"${status}`;
+}
+
+// --- Moving an item to another parent ----------------------------------------
+
+/**
+ * Where a moved row lands among its new siblings.
+ *
+ * Two positions, not an index: `POST /reorder` writes dense positions and a
+ * drag computes them from a pointer, which an agent has none of. Naming a slot
+ * in the middle would mean an agent maintaining the app's ordering arithmetic
+ * (`modules/collections/reorder-math.ts`) from the outside, and getting it wrong
+ * is a folder that visibly reshuffles. First and last are the two an agent can
+ * mean unambiguously; anything finer stays a UI gesture.
+ */
+const MOVE_POSITIONS = ["first", "last"] as const;
+
+/**
+ * The reorder batch that lands `movedId` at either end of its destination.
+ *
+ * `siblings` is the destination block **as the engine lists it** - already
+ * sorted by `order`, then `createdAt`, then `id` - with the moved row itself
+ * removed, so the arrangement this produces is simply that array with the row
+ * put on one end. Every position in the block is then stated outright rather
+ * than left to the engine's `normalize` pass, because the two would have to
+ * agree about a block the moved row is still inside while it runs: normalizing
+ * `[A, B, C]` and then writing `A` at `2` puts it level with `C`, and the tie
+ * goes to whichever row was created first. Stating the whole arrangement cannot
+ * tie.
+ *
+ * Only rows whose stored `order` actually changes get an entry - the rule
+ * `reorder-math.ts` follows for a drag, and what keeps a move inside a large
+ * collection from rewriting every row in it. The moved row is always written:
+ * it is the one carrying the destination owner, which is the move.
+ *
+ * The scope it *left* keeps a gap where it was (the rows after it are not
+ * renumbered). That is invisible - display order reads the column's relative
+ * values, never its density - and closing it would double the batch for
+ * nothing.
+ */
+function moveBatch(params: {
+	type: "collection" | "request";
+	movedId: string;
+	position: "first" | "last";
+	/** The destination's own key: `parentId` (null = the top level) or `collectionId`. */
+	owner: Record<string, unknown>;
+	siblings: readonly OrderedSibling[];
+}): Record<string, unknown> {
+	const { type, movedId, position, owner, siblings } = params;
+	const offset = position === "first" ? 1 : 0;
+	const moves: Record<string, unknown>[] = [
+		{
+			type,
+			id: movedId,
+			order: position === "first" ? 0 : siblings.length,
+			...owner,
+		},
+	];
+	siblings.forEach((row, index) => {
+		if (row.order === index + offset) return;
+		moves.push({ type, id: row.id, order: index + offset });
+	});
+	return { moves };
+}
+
+/** A destination row, narrowed to what a move has to know about it. */
+interface OrderedSibling {
+	id: string;
+	order?: number;
+}
+
+/**
+ * The rows of a `GET /requests?collectionId=` answer, in the order it lists
+ * them - which is the order the tree displays, since the engine sorts every
+ * list read by the same three keys the renderer's comparator uses.
+ */
+function readOrderedSiblings(value: unknown): OrderedSibling[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter(
+		(row): row is OrderedSibling =>
+			!!row && typeof row === "object" && typeof (row as OrderedSibling).id === "string"
+	);
 }
 
 // --- Tool definitions --------------------------------------------------------
@@ -3082,7 +3409,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["collection"],
 		description:
-			"Create a collection (the folder saved requests live in). GUARDED: requires write access to be enabled in Vayu Settings. Pass `parentId` to nest it inside an existing collection; omit it for a top-level one. Returns the created collection - its `id` is what create_request takes as `collectionId`.",
+			"Create a collection (the folder saved requests live in), with the variables, auth and pre/post-request scripts every request inside it composes against. GUARDED: requires write access to be enabled in Vayu Settings. Pass `parentId` to nest it inside an existing collection; omit it for a top-level one. Returns the created collection - its `id` is what create_request takes as `collectionId`.",
 		annotations: {
 			title: "Create collection",
 			readOnlyHint: false,
@@ -3096,6 +3423,13 @@ export const TOOLS: McpTool[] = [
 				.optional()
 				.describe("Optional parent collection ID; omit for a top-level collection."),
 			description: z.string().optional(),
+			variables: variablesInput("the new collection"),
+			auth: storedAuthInput(
+				"this collection",
+				'A collection is the root of an auth chain and never inherits, so "inherit" is refused by the engine; requests below it that store { mode: "inherit" } resolve to this block.'
+			),
+			preRequestScript: collectionScriptInput("pre"),
+			postRequestScript: collectionScriptInput("post"),
 		},
 		handler: async (args, ctx, signal) => {
 			const refused = writesDisabled(ctx);
@@ -3103,8 +3437,17 @@ export const TOOLS: McpTool[] = [
 			const payload: Record<string, unknown> = { name: requireStr(args, "name") };
 			const parentId = str(args, "parentId");
 			if (parentId !== undefined) payload.parentId = parentId;
-			const description = str(args, "description");
-			if (description !== undefined) payload.description = description;
+			for (const field of ["description", "preRequestScript", "postRequestScript"] as const) {
+				const value = str(args, field);
+				if (value !== undefined) payload[field] = value;
+			}
+			const auth = readAuthArg(args);
+			if (auth) payload.auth = auth;
+			const patch = readVariablesPatch(args);
+			// Merged against nothing, the way create_environment does it: on a
+			// create every variable is new, which is what turns the string form
+			// into a stored entry and enforces "a new variable carries a value".
+			if (patch !== undefined) payload.variables = mergeVariables({}, patch, []).variables;
 			return callEngine(() => ctx.client.createCollection(payload, signal));
 		},
 	},
@@ -3113,7 +3456,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["collection"],
 		description:
-			"Rename or re-describe a collection. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - everything else the collection holds (its variables, auth, scripts, and the requests inside it) is left alone. This is not a move: re-parenting a collection is a reorder operation and is not exposed here.",
+			"Change a collection: its name, description, variables, auth or pre/post-request scripts - the state every request inside it composes against. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change, and the requests inside it are never touched. Variables merge: one you do not name is left alone, and a named one keeps every flag you do not state; removeVariables deletes names outright. Auth replaces the stored block whole. This is not a move - to re-parent a collection, use move_item.",
 		annotations: {
 			title: "Update collection",
 			readOnlyHint: false,
@@ -3125,6 +3468,14 @@ export const TOOLS: McpTool[] = [
 			collectionId: z.string().describe("Collection ID to update."),
 			name: z.string().optional().describe("New display name."),
 			description: z.string().optional().describe("New description."),
+			variables: variablesInput("this collection"),
+			removeVariables: removeVariablesInput("this collection"),
+			auth: storedAuthInput(
+				"this collection",
+				'A collection never inherits - it is the root of the chain - so the engine refuses "inherit" here; { mode: "none" } is how a collection stops being an auth source.'
+			),
+			preRequestScript: collectionScriptInput("pre"),
+			postRequestScript: collectionScriptInput("post"),
 		},
 		handler: async (args, ctx, signal) => {
 			const refused = writesDisabled(ctx);
@@ -3133,14 +3484,49 @@ export const TOOLS: McpTool[] = [
 			// The engine merge-patches, so a body naming nothing would be a write
 			// that changes nothing while reporting success. Say so instead.
 			const payload: Record<string, unknown> = {};
-			for (const field of ["name", "description"] as const) {
+			for (const field of [
+				"name",
+				"description",
+				// An empty string is a value here, not an omission - the same rule
+				// update_request's scripts follow, and how one gets cleared.
+				"preRequestScript",
+				"postRequestScript",
+			] as const) {
 				const value = str(args, field);
 				if (value !== undefined) payload[field] = value;
 			}
-			if (Object.keys(payload).length === 0) {
-				return errorResult('Pass at least one of "name" or "description" to change.');
+			const auth = readAuthArg(args);
+			if (auth) payload.auth = auth;
+			const patch = readVariablesPatch(args);
+			const removals = removalNames(args);
+			if (Object.keys(payload).length === 0 && patch === undefined && removals.length === 0) {
+				return errorResult(
+					'Pass at least one field to change ("name", "description", "variables", "removeVariables", "auth", "preRequestScript" or "postRequestScript").'
+				);
 			}
-			return callEngine(() => ctx.client.updateCollection(collectionId, payload, signal));
+			let absentRemovals: string[] = [];
+			if (patch !== undefined || removals.length > 0) {
+				// `PUT /collections/:id` replaces the whole variables blob, exactly
+				// as the environment PUT does, so "change one variable" is a
+				// read-merge-write here too - without the read, an agent setting one
+				// variable would drop every other one the collection holds.
+				let existing: Record<string, unknown>;
+				try {
+					existing = ((await ctx.client.getCollection(collectionId, signal)) ??
+						{}) as Record<string, unknown>;
+				} catch (err) {
+					return engineErrorResult(err);
+				}
+				const merged = mergeVariables(existing.variables, patch, removals);
+				payload.variables = merged.variables;
+				absentRemovals = merged.absentRemovals;
+			}
+			const result = await callEngine(() =>
+				ctx.client.updateCollection(collectionId, payload, signal)
+			);
+			return result.isError
+				? result
+				: withCaveat(result, absentRemovalCaveat(absentRemovals));
 		},
 	},
 	{
@@ -3203,7 +3589,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			"Create a saved request inside a collection (stores it; does not send it), optionally with its pre-request and test scripts. GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed, and a stored script runs only when the request is later sent.",
+			'Create a saved request inside a collection (stores it; does not send it), with its auth, redirect policy, protocol and stream flag, and its pre-request and test scripts - everything the app\'s builder stores except file body parts. GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed, and a stored script runs only when the request is later sent. Auth is stored as written and resolved at send time, so {{variables}} inside it are fine; leaving `auth` out stores the default "inherit", which resolves against the collection chain.',
 		annotations: {
 			title: "Create saved request",
 			readOnlyHint: false,
@@ -3224,6 +3610,11 @@ export const TOOLS: McpTool[] = [
 					'Body type: json, text, graphql, jsonrpc, xml, form-data, x-www-form-urlencoded (default text). For the two form types, write `body` as `key=value&key=value`; it is split into form fields. A jsonrpc `body` may be the bare call object - the engine adds `"jsonrpc":"2.0"` and `"id":1` when it names no id, and sends a frame that already declares a string `"jsonrpc"` unchanged. File parts are not supported here - a multipart file part names a path on the user\'s machine, which an agent cannot choose for them; author it in the app. An xml `body` is stored and sent verbatim as application/xml.'
 				),
 			description: z.string().optional(),
+			auth: storedAuthInput(
+				"this request",
+				'Omit it for the stored default, "inherit", which resolves against the collection chain when the request is sent.'
+			),
+			...requestSettingsInput(),
 			preRequestScript: storedScriptInput("pre", false),
 			postRequestScript: storedScriptInput("post", false),
 		},
@@ -3236,6 +3627,9 @@ export const TOOLS: McpTool[] = [
 				url: requireStr(args, "url"),
 				method: str(args, "method") ?? "GET",
 			};
+			const auth = readAuthArg(args);
+			if (auth) payload.auth = auth;
+			applyRequestSettings(args, payload);
 			if (args.headers && typeof args.headers === "object") {
 				payload.headers = toKeyValueEntries(args.headers);
 			}
@@ -3262,7 +3656,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			"Correct a saved request: its name, URL, method, headers, body, description or pre/post-request scripts. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - anything you leave out keeps its stored value, including the request's auth. Passing `headers` replaces the whole header list, so send every header the request should end up with; passing a script replaces that script, and an empty string clears it.",
+			"Correct a saved request: its name, URL, method, headers, body, auth, redirect policy, protocol, stream flag, description or pre/post-request scripts. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - anything you leave out keeps its stored value. Passing `headers` replaces the whole header list, so send every header the request should end up with; passing `auth` replaces the whole auth block, so send the mode and its credentials together ({ mode: 'none' } clears it, { mode: 'inherit' } hands it back to the collection chain); passing a script replaces that script, and an empty string clears it.",
 		annotations: {
 			title: "Update saved request",
 			readOnlyHint: false,
@@ -3287,6 +3681,11 @@ export const TOOLS: McpTool[] = [
 					"Body type for `body`: json, text, graphql, jsonrpc, xml, form-data, x-www-form-urlencoded. Only meaningful alongside `body`. A jsonrpc `body` is enveloped engine-side exactly as `create_request` describes; an xml `body` is stored and sent verbatim as application/xml. File parts are not supported here; a stored one is left alone unless `body` replaces the whole body."
 				),
 			description: z.string().optional().describe("New description."),
+			auth: storedAuthInput(
+				"this request",
+				"Replaces the stored block whole - send the mode and its credentials together. Leave it out to keep what is stored."
+			),
+			...requestSettingsInput(),
 			preRequestScript: storedScriptInput("pre", true),
 			postRequestScript: storedScriptInput("post", true),
 		},
@@ -3317,6 +3716,13 @@ export const TOOLS: McpTool[] = [
 			if (args.headers && typeof args.headers === "object" && !Array.isArray(args.headers)) {
 				payload.headers = toKeyValueEntries(args.headers);
 			}
+			// Auth and the four Settings fields ride the same rule as the strings
+			// above: stated is written, absent is left alone. The block replaces
+			// the stored one wholesale because the engine stores it as one JSON
+			// column - there is no per-credential patch to offer.
+			const auth = readAuthArg(args);
+			if (auth) payload.auth = auth;
+			applyRequestSettings(args, payload);
 			const body = str(args, "body");
 			const bodyType = str(args, "bodyType");
 			if (body !== undefined) {
@@ -3333,7 +3739,7 @@ export const TOOLS: McpTool[] = [
 			}
 			if (Object.keys(payload).length === 0) {
 				return errorResult(
-					"Pass at least one field to change (name, url, method, headers, body, description, preRequestScript or postRequestScript)."
+					"Pass at least one field to change (name, url, method, headers, body, auth, followRedirects, maxRedirects, httpVersion, stream, description, preRequestScript or postRequestScript)."
 				);
 			}
 			return callEngine(() => ctx.client.updateRequest(requestId, payload, signal));
@@ -3391,6 +3797,299 @@ export const TOOLS: McpTool[] = [
 			});
 			if (unconfirmed) return unconfirmed;
 			return callEngine(() => ctx.client.deleteRequest(requestId, signal));
+		},
+	},
+	{
+		name: "list_request_examples",
+		category: "read",
+		invalidates: [],
+		description:
+			"List a request's saved example responses - the responses stored beside it, in the order a mock server would serve them (the first match answers). Every row carries its name, status, headers, content type, `order` and `origin` (`import` for what an importer or an OpenAPI sync wrote, `user` for what was saved from a live response). " +
+			`Bodies are bounded: one over ${MAX_INLINE_BODY_BYTES} bytes comes back cut with \`bodyClipped: true\` and its stored size in \`bodyBytes\`, and once the list has spent ${MAX_EXAMPLES_BODY_BYTES} bytes the remaining bodies are dropped with \`bodyOmitted: true\` (the row's scalars are always kept). \`bodiesOmitted\` counts them. The engine's own \`bodyTruncated\` is a different fact - it says the response was already cut when it was captured.`,
+		annotations: {
+			title: "List saved examples",
+			readOnlyHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			requestId: z.string().describe("Saved request whose examples to list."),
+		},
+		handler: async (args, ctx, signal) => {
+			const requestId = requireStr(args, "requestId");
+			return callEngine(
+				() => ctx.client.listRequestExamples(requestId, signal),
+				boundExampleBodies
+			);
+		},
+	},
+	{
+		name: "create_request_example",
+		category: "write",
+		invalidates: ["request"],
+		description:
+			"Save an example response on a request - what a mock server for its collection answers with, and what the Examples tab shows. GUARDED: requires write access to be enabled in Vayu Settings. Vayu assigns the id and appends the example after the request's current ones; a request already holding the maximum (100) is refused by the engine. The example is marked as written by hand: an agent cannot claim an example came from an import, because an OpenAPI sync replaces imported examples and leaves the others alone.",
+		annotations: {
+			title: "Create saved example",
+			readOnlyHint: false,
+			destructiveHint: false,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			requestId: z.string().describe("Saved request to attach the example to."),
+			name: z.string().describe("Display name for the example (e.g. '200 OK')."),
+			status: z
+				.number()
+				.int()
+				.min(100)
+				.max(599)
+				.optional()
+				.describe("HTTP status the example answers with (default 200)."),
+			headers: z.record(z.string()).optional().describe("Response headers as a string map."),
+			body: z.string().optional().describe("Response body, stored verbatim."),
+			contentType: z
+				.string()
+				.optional()
+				.describe(
+					"Content type of `body` (e.g. application/json). Stored beside the headers; a mock server sends it."
+				),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const requestId = requireStr(args, "requestId");
+			const payload = exampleWritePayload(args);
+			payload.name = requireStr(args, "name");
+			// Stated rather than left to the engine's default, which is `import`:
+			// this row was written by an agent, and the sync that replaces
+			// imported rows must not be handed one it did not write (#588, #722).
+			payload.origin = "user";
+			return callEngine(() => ctx.client.createRequestExample(requestId, payload, signal));
+		},
+	},
+	{
+		name: "update_request_example",
+		category: "write",
+		invalidates: ["request"],
+		description:
+			"Correct a saved example: its name, status, headers, body or content type. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change; passing `headers` replaces the whole header list. Where the example came from is not editable - an imported example stays imported, which is what lets an OpenAPI sync tell the two apart.",
+		annotations: {
+			title: "Update saved example",
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			requestId: z.string().describe("Request that owns the example."),
+			exampleId: z.string().describe("Example ID to update."),
+			name: z.string().optional().describe("New display name."),
+			status: z.number().int().min(100).max(599).optional().describe("New HTTP status."),
+			headers: z
+				.record(z.string())
+				.optional()
+				.describe(
+					"Replacement response headers as a string map (replaces the stored list)."
+				),
+			body: z.string().optional().describe("New response body."),
+			contentType: z.string().optional().describe("New content type for `body`."),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const requestId = requireStr(args, "requestId");
+			const exampleId = requireStr(args, "exampleId");
+			const payload = exampleWritePayload(args);
+			if (Object.keys(payload).length === 0) {
+				return errorResult(
+					'Pass at least one field to change ("name", "status", "headers", "body" or "contentType").'
+				);
+			}
+			return callEngine(() =>
+				ctx.client.updateRequestExample(requestId, exampleId, payload, signal)
+			);
+		},
+	},
+	{
+		name: "delete_request_example",
+		category: "write",
+		invalidates: ["request"],
+		description:
+			"Delete one saved example from a request. GUARDED: requires write access to be enabled in Vayu Settings, and confirmation: if the client supports elicitation the user is prompted with the example's name and what a mock server loses; otherwise call once for a preview, then again with `confirmed: true`. There is no undo, and a mock server for this collection stops answering with it once it is restarted.",
+		annotations: {
+			title: "Delete saved example",
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			requestId: z.string().describe("Request that owns the example."),
+			exampleId: z.string().describe("Example ID to delete."),
+			confirmed: confirmedInput("actually delete the example"),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const requestId = requireStr(args, "requestId");
+			const exampleId = requireStr(args, "exampleId");
+			// Read the list first so the prompt names the example rather than an
+			// id - the same rule delete_request follows. There is no by-id read
+			// for one example, and the owner check the engine makes on every
+			// nested path is exactly this scan: an id stored under another
+			// request is "no such example" here too.
+			let stored: Record<string, unknown> | undefined;
+			try {
+				const rows = await ctx.client.listRequestExamples(requestId, signal);
+				stored = (Array.isArray(rows) ? rows : []).find(
+					(row) => isRecord(row) && row.id === exampleId
+				) as Record<string, unknown> | undefined;
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			if (!stored) {
+				return errorResult(`No example with id "${exampleId}" on request "${requestId}".`);
+			}
+			const subject = describeExample(exampleId, stored);
+			const consequence =
+				"A mock server for this collection stops answering with it once it is restarted. This cannot be undone.";
+			const unconfirmed = await confirmDestructive(args, ctx, {
+				message: `Delete the saved example ${subject}?\n\n${consequence}`,
+				acceptTitle: "Delete the example",
+				acceptDescription: "Confirm to delete this saved example.",
+				declined: "Example not deleted - the user declined.",
+				preview:
+					"AWAITING CONFIRMATION - nothing was deleted.\n\n" +
+					`This would delete the saved example ${subject}. ${consequence}\n\n` +
+					"This is a preview. To delete it, call delete_request_example again with confirmed: true and the same arguments.",
+			});
+			if (unconfirmed) return unconfirmed;
+			return callEngine(() => ctx.client.deleteRequestExample(requestId, exampleId, signal));
+		},
+	},
+	{
+		name: "move_item",
+		category: "write",
+		/*
+		 * Both families, and the pair is load-bearing rather than cautious. The
+		 * `request` event narrows on the `collectionId` the call named, which for
+		 * a move is the *destination* - the list the row left would stay stale on
+		 * its own. `collection` is the coarse one (`collections.all` +
+		 * `requests.all`), so it covers the source list, the two parents' orders,
+		 * and the subtree a moved collection took with it.
+		 */
+		invalidates: ["collection", "request"],
+		description:
+			"Move a collection or a saved request into another collection - the row menu's 'Move to...', over MCP. GUARDED: requires write access to be enabled in Vayu Settings. It lands at the end of its new parent by default, or at the front with `position: 'first'`; positions in between stay a UI gesture, because naming one means doing the app's ordering arithmetic from the outside. A collection may move to the top level (`parentId: null`); a request always belongs to a collection. Refused, with nothing written, when a collection would move into itself or into its own subtree.",
+		annotations: {
+			title: "Move an item",
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			type: z
+				.enum(["collection", "request"])
+				.describe("What is being moved: a collection (folder) or a saved request."),
+			id: z.string().describe("ID of the collection or request to move."),
+			parentId: z
+				.string()
+				.nullable()
+				.optional()
+				.describe(
+					"Destination for a collection: another collection's id, or null for the top level. Required when `type` is 'collection'."
+				),
+			collectionId: z
+				.string()
+				.optional()
+				.describe(
+					"Destination collection for a request. Required when `type` is 'request'."
+				),
+			position: z
+				.enum(MOVE_POSITIONS)
+				.optional()
+				.describe("Where it lands among its new siblings: 'last' (default) or 'first'."),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const type = requireStr(args, "type");
+			if (type !== "collection" && type !== "request") {
+				return errorResult('"type" must be "collection" or "request".');
+			}
+			const id = requireStr(args, "id");
+			// Read off the raw value rather than through `str`, which answers
+			// `undefined` for a non-string: a `position: 0` would then default to
+			// "last" and land the row at the opposite end of the one it named.
+			const position = args.position === undefined ? "last" : args.position;
+			if (position !== "first" && position !== "last") {
+				return errorResult('"position" must be "first" or "last".');
+			}
+
+			let batch: Record<string, unknown>;
+			try {
+				if (type === "collection") {
+					// Stated, not inferred: `parentId` absent would have to mean
+					// either "the top level" or "leave it where it is", and a move
+					// that guessed wrong is a folder somewhere nobody asked for.
+					if (!("parentId" in args)) {
+						return errorResult(
+							'Moving a collection needs "parentId" - another collection\'s id, or null for the top level.'
+						);
+					}
+					const parentId = args.parentId === null ? null : str(args, "parentId");
+					if (parentId === undefined) {
+						return errorResult('"parentId" must be a collection id or null.');
+					}
+					const rows = readCollectionRows(await ctx.client.listCollections(signal));
+					const subtree = collectionSubtree(rows, id);
+					if (subtree === null) return errorResult(`No collection with id "${id}".`);
+					// The UI's own refusal set, walked here so the answer names the
+					// problem. The engine rejects the same batch under its lock -
+					// that check is the one that is race-free and stays the
+					// authority; this one exists so an agent is told "into its own
+					// subtree" rather than handed a 400 about a move entry.
+					if (parentId !== null && subtree.includes(parentId)) {
+						return errorResult(
+							parentId === id
+								? `A collection cannot be moved into itself ("${id}").`
+								: `"${id}" cannot be moved into "${parentId}" - that collection is inside it.`
+						);
+					}
+					if (parentId !== null && !rows.some((row) => row.id === parentId)) {
+						return errorResult(`No collection with id "${parentId}".`);
+					}
+					batch = moveBatch({
+						type,
+						movedId: id,
+						position,
+						owner: { parentId },
+						siblings: rows.filter(
+							(row) => collectionParent(row) === parentId && row.id !== id
+						),
+					});
+				} else {
+					const collectionId = str(args, "collectionId");
+					if (collectionId === undefined) {
+						return errorResult(
+							'Moving a request needs "collectionId" - the collection it should end up in.'
+						);
+					}
+					const siblings = readOrderedSiblings(
+						await ctx.client.listRequests(collectionId, signal)
+					).filter((row) => row.id !== id);
+					batch = moveBatch({
+						type,
+						movedId: id,
+						position,
+						owner: { collectionId },
+						siblings,
+					});
+				}
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			return callEngine(() => ctx.client.reorder(batch, signal));
 		},
 	},
 	{

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -56,6 +56,28 @@ describe("invalidateForMcpEvent", () => {
 		expect(keys).toContainEqual(queryKeys.requests.detail("req_3"));
 	});
 
+	test("a named request reaches its examples, which have no key of their own", () => {
+		/*
+		 * The MCP example tools (#759) declare the `request` family and name the
+		 * request they wrote to. `queryKeys.requests.examples(id)` is nested under
+		 * `requests.detail(id)`, so invalidating the detail key covers the open
+		 * Examples panel by prefix - no second entity, and no key here that only
+		 * these three tools would use. Asserted because the coverage is a
+		 * *consequence* of how the key is built: flatten `examples` out from under
+		 * `detail` and an example an agent created would never appear in a panel
+		 * that was already open.
+		 */
+		const { keys } = keysFor({ entity: "request", requestId: "req_3" });
+		const examples = queryKeys.requests.examples("req_3");
+		const detail = keys.find(
+			(key) =>
+				Array.isArray(key) &&
+				key.length <= examples.length &&
+				key.every((part, index) => part === examples[index])
+		);
+		expect(detail).toEqual(queryKeys.requests.detail("req_3"));
+	});
+
 	test("a created request touches no detail cache", () => {
 		// A create names no request id, and the row it made has no detail entry to
 		// invalidate - the narrowing exists for the tools that name one row.

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -162,12 +162,17 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `run_request`          | execute  | `POST /compose` + `POST /execute` (+ `GET /runs/:id/events` when streaming) | allowlist; response body capped at 32 KB |
 | `run_collection_smoke` | execute  | `GET /requests?…` + `POST /compose` + `POST /execute` (×N) | allowlist per host |
 | `run_collection`       | execute  | `GET /requests?…` (+ `GET /collections` when recursive) + `POST /compose` (×N) + `POST /runs` | allowlist on **every** step - one step off it refuses the whole run |
-| `create_collection`    | write    | `POST /collections`                          | write toggle               |
-| `update_collection`    | write    | `PUT /collections/:id` (merge-patch)         | write toggle               |
+| `create_collection`    | write    | `POST /collections`                          | write toggle; takes `variables`, `auth` and both collection scripts |
+| `update_collection`    | write    | `GET /collections` (scan, only when variables change) + `PUT /collections/:id` (merge-patch) | write toggle; `variables` merges like `update_environment`'s, `removeVariables` deletes names |
 | `delete_collection`    | write    | `GET /collections` + `GET /requests?…` (×N) + `DELETE /collections/:id` | write toggle + confirm |
-| `create_request`       | write    | `POST /requests`                             | write toggle               |
-| `update_request`       | write    | `PUT /requests/:id` (merge-patch)            | write toggle               |
+| `create_request`       | write    | `POST /requests`                             | write toggle; takes the builder's whole surface - auth, `followRedirects` / `maxRedirects` / `httpVersion` / `stream`, both scripts - minus file body parts |
+| `update_request`       | write    | `PUT /requests/:id` (merge-patch)            | write toggle; same fields, and only the ones named are written |
 | `delete_request`       | write    | `GET /requests/:id` + `DELETE /requests/:id` | write toggle + confirm     |
+| `list_request_examples`| read     | `GET /requests/:id/examples`                 | - (bodies capped at 32 KB each, 96 KB across the list) |
+| `create_request_example`| write   | `POST /requests/:id/examples`                | write toggle; always stored as `origin: "user"` - an agent cannot claim an import |
+| `update_request_example`| write   | `PUT /requests/:id/examples/:exampleId` (merge-patch) | write toggle; `origin` is not writable |
+| `delete_request_example`| write   | `GET /requests/:id/examples` + `DELETE /requests/:id/examples/:exampleId` | write toggle + confirm (the prompt names the example and the mock consequence) |
+| `move_item`            | write    | `GET /collections` or `GET /requests?…` + `POST /reorder` | write toggle; `first` / `last` only, and a collection into its own subtree is refused before the engine sees it |
 | `create_environment`   | write    | `POST /environments`                         | write toggle (the engine assigns the id; created inactive) |
 | `update_environment`   | write    | `GET /environments` (scan) + `PUT /environments/:id` (fetch-merge) | write toggle; `variables` takes a string or `{value, secret, type, enabled}`, `removeVariables` deletes names |
 | `activate_environment` | write    | `PUT /environments/:id` (`isActive`), + `GET /environments` for `"none"` | write toggle; one PUT - the engine deactivates the previous row in the same transaction |
@@ -340,8 +345,10 @@ Notes:
   script. A patch naming nothing is refused rather than sent as a write that
   changes nothing, and `bodyType` without `body` is refused too (the blob and
   its denormalized column move together or the two disagree about what the
-  request sends). `update_collection` renames and re-describes only: reparenting
-  is `POST /reorder`'s job and is not exposed here.
+  request sends). `update_collection` carries a collection's own state - name,
+  description, variables, auth, both scripts - and never its position:
+  re-parenting is `move_item`'s job (below), because `POST /reorder` is the only
+  write path that is atomic against a concurrent one.
 - **`delete_collection` cascades**, so it reads the subtree first: `GET
   /collections` gives it every descendant through `parentId`, one `GET
   /requests?collectionId=` per collection in that subtree gives the request
@@ -349,6 +356,70 @@ Notes:
   subtree - or an id no collection has - is a refusal, never a prompt carrying
   a number nobody verified. `delete_request` reads the row the same way, so the
   prompt names the request and its URL rather than an opaque id.
+- **A saved request an agent writes is the one the builder writes** (issue
+  #759). `create_request` / `update_request` carry the request's `auth` block and
+  the four **Settings** tab fields (`followRedirects`, `maxRedirects`,
+  `httpVersion`, `stream`) as well as its url, headers, body and both scripts, so
+  an agent that can send an authenticated request can now save one. The `auth`
+  input is the *same schema* `run_request` takes rather than a copy of it - one
+  definition, four descriptions - which is what lets an agent read a request's
+  `auth` over `list_requests` and write it back verbatim. Both the auth block and
+  each setting follow the merge-patch rule the strings already did: named is
+  written, absent is left alone, so an update that mentions only `maxRedirects`
+  cannot hand a stored `followRedirects: false` back to the engine's default. The
+  two exclusions are deliberate: **file body parts**, which name a path on the
+  user's machine an agent cannot choose for them, and **`verifySSL`** (issue
+  #706), which belongs to the transport epic's own CRUD pass - see #795.
+- **Examples are writable, and where one came from is not** (issue #759).
+  `list_request_examples` reads what a request has saved beside it - what a mock
+  server for its collection answers with - and the three write tools author it,
+  so an agent that can start a mock (`start_mock_server`) can now author what it
+  serves. The `origin` column is the one field no tool accepts: it says whether a
+  row came from an importer (`import`) or from a person (`user`), and an OpenAPI
+  sync replaces the first kind while leaving the second alone (#588, #655). An
+  agent that could claim `import` would hand its own example to the next sync to
+  overwrite, and one that could claim `user` could pin a stale imported row
+  against the document it came from - neither is the agent's call, so
+  `create_request_example` always stores `user` and the update tool cannot
+  restate it. Bodies are bounded on the way out for the reason
+  `get_run_report`'s traces are (#767, #769): an example body is capped
+  engine-side at 1 MB and a request may hold 100 of them. One over 32 KB comes
+  back cut, flagged `bodyClipped` with its stored size in `bodyBytes`; once the
+  list has spent 96 KB the remaining bodies are dropped with `bodyOmitted` and
+  counted in `bodiesOmitted`, every row's scalars kept. `bodyClipped` is not the
+  engine's `bodyTruncated`, which says the response was already cut when it was
+  *captured* - two different facts, so two different names.
+- **Collection-level state is writable, and merges the way an environment's
+  does** (issue #759). `create_collection` / `update_collection` take the
+  `variables`, `auth` and pre/post-request scripts that shape every request
+  below them - the same three the composer walks (`compose_script_parts` runs the
+  chain's scripts before the request's own). `variables` uses
+  `update_environment`'s input and its rules unchanged, including
+  `removeVariables` and the "a new variable carries a value" refusal, because it
+  is the same blob shape and a second dialect would be a second thing to learn.
+  The read that makes it a merge is only done when variables are actually
+  changing: a rename sends one `PUT` and nothing else. A collection is the root
+  of an auth chain and never inherits, which the engine enforces - `{mode:
+  "none"}` is how a collection stops being an auth source.
+- **`move_item` is a bounded move, not a reorder** (issue #759). It maps to
+  `POST /reorder`, whose batch validates and commits under one acquisition of the
+  engine's DB mutex (#386) - which is why re-parenting goes here rather than
+  through `PUT /collections/:id`'s own `parentId`, where two concurrent moves can
+  each pass an acyclicity check neither one's commit was visible to. What the
+  tool offers is the row menu's "Move to...": a destination, and `first` or
+  `last` among its new siblings. Positions in between stay a UI gesture on
+  purpose - naming one means reproducing the app's ordering arithmetic
+  (`modules/collections/reorder-math.ts`) from outside it, and getting it wrong
+  is a folder that visibly reshuffles. The batch states the destination block's
+  whole arrangement rather than leaning on the engine's `normalize` pass, because
+  normalization runs *before* the moves and would leave a row moved to the end of
+  a block it is already in tied with the sibling it displaced; only the rows whose
+  stored `order` actually changes get an entry. A collection may move to the top
+  level (`parentId: null`) and a request always belongs to a collection. Moving a
+  collection into itself or into its own subtree is refused here, walking the
+  same tree the app's "Move to..." dialog walks, so the answer names the problem -
+  the engine refuses the same batch under its lock, and that check stays the
+  authority.
 - **`update_environment`** fetches the environment and merges the supplied
   variables (`PUT /environments/:id` replaces the whole variables blob), so
   partial updates preserve untouched variables and the name. Overwriting an
@@ -691,7 +762,10 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   an agent could already run arbitrary scripts through `run_request`, and a
   stored one runs only when the request is later sent. Both tools already
   declare `invalidates: ["request"]`, so the renderer refetches the row and
-  picks the scripts up without a further entity.
+  picks the scripts up without a further entity. A collection's own scripts -
+  the ones that run around *every* request below it - are
+  `create_collection` / `update_collection`'s fields of the same two names
+  (issue #759), and carry the same clearing rule.
 - **Load-testing a saved request** - `start_load_run` with a `requestId`
   composes it by id, exactly as `run_collection_smoke` and the app do:
   variables resolved, stored auth applied through the collection chain, and the
@@ -973,20 +1047,22 @@ configurable in **Settings → MCP** and persisted.
 - **Confirmation** - anti-accident, not anti-adversary: it stops a stray tool
   call from starting load or destroying saved work, but on HTTP it is agent-side
   (the caps/allowlist are the enforcement). Elicitation upgrades it to a human
-  prompt where supported. Six tools carry it - `start_load_run`,
-  `delete_collection`, `delete_request`, `delete_run`, `delete_environment` and
-  `delete_webhook_inbox` - through one implementation, so the elicitation path
-  cannot drift between them. A preview is a *successful* result
+  prompt where supported. Seven tools carry it - `start_load_run`,
+  `delete_collection`, `delete_request`, `delete_request_example`,
+  `delete_run`, `delete_environment` and `delete_webhook_inbox` - through one
+  implementation, so the elicitation path cannot drift between them. A preview is a *successful* result
   that deliberately did nothing, so it emits no `mcp:data-changed` event either.
 - **Write toggle** (`allowWrites`, default off) - gates every tool in the
   **write** category: `create_collection`, `update_collection`,
   `delete_collection`, `create_request`, `update_request`, `delete_request`,
+  `create_request_example`, `update_request_example`,
+  `delete_request_example`, `move_item`,
   `create_environment`, `update_environment`, `activate_environment`,
   `delete_environment`, `update_globals`, `clear_cookies`,
   `update_engine_config`, `set_run_baseline`,
   `delete_run`, `delete_webhook_inbox`, `clear_inbox_captures`. Does not gate
   `run_request` / `run_collection_smoke` / load runs
-  (allowlist + caps). The five deletes need the toggle **and** confirmation:
+  (allowlist + caps). The six deletes need the toggle **and** confirmation:
   the toggle is a single session-wide switch a user flips once to let an agent
   save a request, which is not consent to destroy a subtree or a run's stored
   history. `clear_cookies` takes the toggle without a confirmation, because


### PR DESCRIPTION
## Description

Document CRUD parity for the MCP surface (#759, S5b of epic #753). What an agent could *write* onto a saved document was a fraction of what the app stores; this closes the four gaps the issue names.

**Plan.** The root cause is not a missing endpoint - the engine has had all of this since #481 / #365 - it is that `tools.ts` grew its write surface one field at a time and never caught up with the row. So the fix is additive at the tool layer only: extend the four CRUD tools with the fields the engine already applies through `apply_request_fields` / `apply_collection_fields`, add the four example tools over `/requests/:id/examples`, and map a move onto `POST /reorder`. The alternative I rejected for `move_item` was `PUT /collections/:id`'s own `parentId`, which is one call instead of a batch - but it validates acyclicity under a different lock than the write, which is exactly the race `POST /reorder` was built to close (#386). For the same reason the move states the destination block's whole arrangement rather than leaning on the engine's `normalize` pass: normalization runs *before* the moves, so a row moved to the end of a block it is already in would land level with the sibling it displaced and the tie would go to `createdAt`.

**What changed**

- **Request auth and settings.** `create_request` / `update_request` take `auth` and the four Settings-tab fields (`followRedirects`, `maxRedirects`, `httpVersion`, `stream`). The `auth` input is `run_request`'s own schema re-described (`storedAuthInput`), not a copy - one definition, four descriptions - so an agent can write back verbatim what `list_requests` handed it. Every field follows the merge-patch rule the strings already did.
- **Examples.** `list_request_examples` (read) plus create / update / delete. `origin` is the one field no tool accepts: a created example is always `user`, because an OpenAPI sync replaces `import` rows and leaves the others alone (#588, #655), so a claimable origin would let an agent hand its own example to the next sync to overwrite - or pin a stale imported row against its document. Read bodies are bounded on the #767 / #769 precedent (32 KB per body → `bodyClipped`; 96 KB across the list → `bodyOmitted`, counted in `bodiesOmitted`), since an example body is capped engine-side at 1 MB and a request may hold 100 of them. The flags are deliberately not the engine's `bodyTruncated`, which says the response was already cut when it was *captured*.
- **Collection-level state.** `create_collection` / `update_collection` take `variables` (the `update_environment` input and merge rules unchanged, `removeVariables` included), `auth` and both collection scripts. The read that makes variables a merge happens only when variables are actually changing - a rename is still one `PUT`.
- **`move_item`.** Re-parents a collection (`parentId`, `null` = top level) or a request (`collectionId`), `first` / `last` only. Refuses a collection into itself or its own subtree by walking the same tree the app's "Move to..." dialog walks, so the answer names the problem; the engine refuses the same batch under its lock and stays the authority. Only rows whose stored `order` actually changes get an entry.

**App changes (required by the issue) - verified, no wiring needed.** `queryKeys.requests.examples(id)` is nested under `queryKeys.requests.detail(id)`, and the `request` invalidator already invalidates the detail key when the event names a `requestId` - which the three example tools do. So an example created over MCP reaches an open Examples panel by key prefix. That coverage is a *consequence* of how the key is built rather than an intention, so it is now asserted in `mcp-invalidation.test.ts`. `move_item` declares `["collection", "request"]`: the `request` event narrows on the destination collection, and the coarse `collection` event is what covers the list the row left.

**Deliberate deviation.** `verifySSL` is stored on the request beside the four settings (#706) and is still unwritable over MCP. The issue's Sequencing section says it belongs to the transport epic's own PR, not this one; #706 merged without extending the CRUD inputs, so rather than fold it in silently I left it out, said why in the tool comment and in `mcp.md`, and filed the gap as **#795**.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Local, on this branch:

- `cd app && pnpm test` - **507 files, 5502 tests passed** (up from 5445; 57 new assertions across `tools.test.ts`, `data-changed.test.ts` and `mcp-invalidation.test.ts`).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-test projects).
- `cd app && pnpm lint` - clean, zero warnings.
- `npx prettier --check` on every file touched. `docs/engine/mcp.md` was already not prettier-clean at `a48d08d` and was left unformatted per the repo rule.
- No engine build or ctest run: the diff is TypeScript and Markdown only, so no C++ test could change colour.

New coverage worth naming, each written so reverting the fix fails it:

- The stored `auth` input accepts and refuses exactly what `run_request`'s does, across seven values including `{token}` with no mode, a bare string, a number and an array - the assertion is equality with the run tool's verdict, so the two cannot drift apart.
- `create_request_example` called with `origin: "import"` sends `origin: "user"`; forwarding the caller's value fails the test.
- Body bounding: one oversized body clipped with its stored size, a four-row list where the fourth body is dropped and its scalars kept, and a small body passed through byte-identical.
- Collection variables merge against the stored blob (drop the read and `baseUrl` disappears), `removeVariables` reports an absent name as a caveat, and a rename makes no read at all.
- `move_item`: dense destination writes one row, `first` shifts only the siblings whose slot changes, a same-collection reposition produces no two rows at the same `order`, a legacy all-zero block gets real positions, self- and descendant-moves are refused with nothing reaching the engine, and every new write tool refuses before touching the engine when writes are off.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #759

Filed while implementing: #795 (the `verifySSL` CRUD gap #706 left behind).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZdRySDjRe3kzMpRvTP5gf)_