### PR TITLE
feat(app/mcp): load-run recording knobs, OAuth2 token tools, scripting types resource

### DIFF
--- a/app/electron/mcp/data-changed.conformance.test.ts
+++ b/app/electron/mcp/data-changed.conformance.test.ts
@@ -38,6 +38,7 @@ const RENDERER_ENTITIES: Record<McpDataEntity, true> = {
 	cookie: true,
 	config: true,
 	service: true,
+	oauth: true,
 };
 
 describe("McpDataEntity mirror", () => {

--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -74,6 +74,11 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		startMockIssuer: vi.fn().mockResolvedValue({ issuerId: "issuer_1" }),
 		stopMockIssuer: vi.fn().mockResolvedValue({ stopped: true }),
 		updateMockIssuer: vi.fn().mockResolvedValue({ issuerId: "issuer_1", failureMode: "slow" }),
+		fetchOAuth2Token: vi
+			.fn()
+			.mockResolvedValue({ cacheKey: "key_1", accessToken: "bearer", expiresIn: 3600 }),
+		getOAuth2TokenStatus: vi.fn().mockResolvedValue({ found: true, expired: false }),
+		clearOAuth2Token: vi.fn().mockResolvedValue({ deleted: true }),
 		composeRequest: vi
 			.fn()
 			.mockImplementation((body: { request?: object }) =>
@@ -162,6 +167,11 @@ describe("the registry declares its effects", () => {
 			start_mock_issuer: ["service"],
 			stop_mock_issuer: ["service"],
 			update_mock_issuer: ["service"],
+			// The OAuth 2.0 token cache (#760): both change what the auth tab's
+			// token-status row reports, and it polls at 30s - long enough to keep
+			// showing an entry an agent has already cleared.
+			fetch_oauth2_token: ["oauth"],
+			clear_oauth2_token: ["oauth"],
 		};
 		for (const [name, entities] of Object.entries(expected)) {
 			const tool = TOOLS.find((t) => t.name === name);
@@ -456,6 +466,37 @@ describe("dispatch emits mcp:data-changed", () => {
 		const res = await dispatchTool("update_mock_issuer", { issuerId: "issuer_1" }, ctx);
 		expect(res.isError).toBe(true);
 		expect(client.updateMockIssuer).not.toHaveBeenCalled();
+		expect(onDataChanged).not.toHaveBeenCalled();
+	});
+
+	test("a token fetch and a token clear report the oauth family", async () => {
+		const acquired = ctxWithNotifier(fakeClient(), { allowlist: ["id.example.com"] });
+		const fetched = await dispatchTool(
+			"fetch_oauth2_token",
+			{
+				config: {
+					grantType: "client_credentials",
+					accessTokenUrl: "https://id.example.com/token",
+					clientId: "client_a",
+				},
+			},
+			acquired.ctx
+		);
+		expect(fetched.isError).toBeFalsy();
+		// No scope hint: the key a fetch writes under is derived engine-side and
+		// appears only in the answer, so the family is invalidated at its prefix.
+		expect(acquired.onDataChanged).toHaveBeenCalledWith({ entity: "oauth" });
+
+		const cleared = ctxWithNotifier(fakeClient(), WRITES_ENABLED);
+		const res = await dispatchTool("clear_oauth2_token", { cacheKey: "key_1" }, cleared.ctx);
+		expect(res.isError).toBeFalsy();
+		expect(cleared.onDataChanged).toHaveBeenCalledWith({ entity: "oauth" });
+	});
+
+	test("reading a token's status emits nothing", async () => {
+		const { ctx, onDataChanged } = ctxWithNotifier(fakeClient());
+		const res = await dispatchTool("get_oauth2_token_status", { cacheKey: "key_1" }, ctx);
+		expect(res.isError).toBeFalsy();
 		expect(onDataChanged).not.toHaveBeenCalled();
 	});
 

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -430,6 +430,18 @@ export class EngineClient {
 		return this.request("GET", "/scripting/completions", undefined, signal);
 	}
 
+	/**
+	 * The same surface as TypeScript declarations: `GET /scripting/types` answers
+	 * `{version, engine, libUri, typeDefinitions}`, the `.d.ts` text generated
+	 * from the completion table by `script_types.cpp`. The app feeds it to
+	 * Monaco's TypeScript worker; MCP serves it as a resource, because a
+	 * signature an agent can read is what turns a name into a call it gets right
+	 * the first time.
+	 */
+	getScriptTypeDefinitions(signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", "/scripting/types", undefined, signal);
+	}
+
 	updateConfig(payload: unknown, signal?: AbortSignal): Promise<unknown> {
 		return this.request("POST", "/config", payload, signal);
 	}
@@ -769,6 +781,57 @@ export class EngineClient {
 			clearTimeout(timer);
 		}
 		return out;
+	}
+
+	// --- OAuth 2.0 token cache -----------------------------------------------
+	//
+	// The three routes the app's auth tab drives (`engine/src/http/routes/
+	// oauth.cpp`). The engine owns the cache key - `cache_key(config)` over
+	// accessTokenUrl / clientId / credentialsId / username - so callers name a
+	// config to acquire and the returned `cacheKey` to inspect or clear. The
+	// interactive `authorization_code` exchange (`/oauth2/authorize/*`) is
+	// deliberately absent: it needs a browser and a loopback listener the app
+	// owns, and agent-driven browser auth is a non-goal of epic #753.
+
+	/**
+	 * Acquire or return a cached token: `POST /oauth2/token` `{config, force?}`.
+	 *
+	 * This is the one call here that waits on a third-party server, so it takes
+	 * the derived budget for the reason {@link executeRequest} does - a token
+	 * endpoint is as slow as any other host. A `409 oauth2_interactive_required`
+	 * is the engine's answer for a config whose grant needs a browser.
+	 */
+	async fetchOAuth2Token(payload: unknown, signal?: AbortSignal): Promise<unknown> {
+		const timeoutMs = await this.proxiedTimeoutMs(payload, signal);
+		return this.request("POST", "/oauth2/token", payload, signal, timeoutMs);
+	}
+
+	/**
+	 * Cache status for one key: `GET /oauth2/token?key=`. Always `200` - presence
+	 * and expiry are in the body (`{found, expired?, token?}`), so a missing
+	 * entry is an answer rather than an error.
+	 */
+	getOAuth2TokenStatus(cacheKey: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request(
+			"GET",
+			`/oauth2/token?key=${encodeURIComponent(cacheKey)}`,
+			undefined,
+			signal
+		);
+	}
+
+	/**
+	 * Drop one cached token: `DELETE /oauth2/token?key=`. Idempotent, and the
+	 * body's `deleted` reports whether a row existed - which is what lets a tool
+	 * tell "cleared it" from "there was nothing there".
+	 */
+	clearOAuth2Token(cacheKey: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request(
+			"DELETE",
+			`/oauth2/token?key=${encodeURIComponent(cacheKey)}`,
+			undefined,
+			signal
+		);
 	}
 
 	// --- Local services: the OAuth 2.0 mock issuer ---------------------------

--- a/app/electron/mcp/prompts.test.ts
+++ b/app/electron/mcp/prompts.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * @file prompts.test.ts
+ * @brief What the server-provided prompts say, and where they get their data.
+ *
+ * A prompt is the one surface that talks *about* the tools rather than calling
+ * them, so it drifts silently: `suggest_load_profile` listed four modes for as
+ * long as `start_load_run` supported five, steering agents away from a mode the
+ * tool had (issue #760). These tests pin the two claims that can go stale - the
+ * mode list, and which arguments a prompt genuinely needs.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { PROMPTS } from "./prompts.js";
+import { resolveSafetyConfig } from "./config.js";
+import { KNOWN_LOAD_MODES } from "./safety.js";
+import type { ToolContext } from "./tools.js";
+import type { EngineClient } from "./engine-client.js";
+
+const REPORT = { latency: { p99: 120 }, summary: { avgRps: 500 }, statusCodes: { "200": 10 } };
+
+function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}) {
+	return {
+		getRunReport: vi.fn().mockResolvedValue(REPORT),
+		getRun: vi.fn().mockResolvedValue({ id: "run_target", requestId: "req_1" }),
+		listBaselineRuns: vi.fn().mockResolvedValue({ data: [{ id: "run_pinned" }] }),
+		...overrides,
+	} as unknown as EngineClient;
+}
+
+function ctxWith(client: EngineClient): ToolContext {
+	return { client, config: resolveSafetyConfig() };
+}
+
+function prompt(name: string) {
+	const found = PROMPTS.find((p) => p.name === name);
+	if (!found) throw new Error(`prompt "${name}" is not registered`);
+	return found;
+}
+
+const textOf = (result: { messages: Array<{ content: { text: string } }> }) =>
+	result.messages.map((m) => m.content.text).join("\n");
+
+describe("suggest_load_profile", () => {
+	test("names every mode start_load_run accepts", async () => {
+		const text = textOf(
+			await prompt("suggest_load_profile").build(
+				{ url: "https://api.example.com" },
+				ctxWith(fakeClient())
+			)
+		);
+
+		// The set `safety.ts` knows as `KNOWN_LOAD_MODES` - the guard that
+		// decides which cap applies, so it is the one list that cannot fall
+		// behind the engine. A mode the tool gains and the prompt does not is
+		// exactly the drift this test exists to catch.
+		expect(KNOWN_LOAD_MODES.size).toBeGreaterThan(0);
+		for (const mode of KNOWN_LOAD_MODES) {
+			expect(text, mode).toContain(mode);
+		}
+	});
+
+	test("says when capacity is the mode to reach for, not merely that it exists", async () => {
+		// A bare name in a list is not guidance: the whole reason the omission
+		// mattered is that an agent picks a mode from what the prompt explains.
+		const text = textOf(
+			await prompt("suggest_load_profile").build(
+				{ url: "https://api.example.com" },
+				ctxWith(fakeClient())
+			)
+		);
+		expect(text).toMatch(/capacity[^.]*sloMs|sloMs[^.]*capacity/s);
+	});
+
+	test("needs no engine data", async () => {
+		const client = fakeClient();
+		await prompt("suggest_load_profile").build({ url: "https://x.example" }, ctxWith(client));
+		expect(client.getRunReport).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * The prompt asked for both run ids while the `compare_runs` *tool* has
+ * resolved the pinned baseline since it shipped - the same question reaching a
+ * user two ways, one of them demanding an id Vayu already knew.
+ */
+describe("compare_runs", () => {
+	test("resolves the target's pinned baseline when none is given", async () => {
+		const client = fakeClient();
+		const text = textOf(
+			await prompt("compare_runs").build({ targetRunId: "run_target" }, ctxWith(client))
+		);
+
+		expect(client.listBaselineRuns).toHaveBeenCalledWith("req_1", undefined);
+		expect(client.getRunReport).toHaveBeenCalledWith("run_pinned", undefined);
+		expect(text).toContain("run_pinned -> run_target");
+	});
+
+	test("an explicitly named base is used as-is, with nothing resolved", async () => {
+		const client = fakeClient();
+		const text = textOf(
+			await prompt("compare_runs").build(
+				{ baseRunId: "run_main", targetRunId: "run_target" },
+				ctxWith(client)
+			)
+		);
+
+		expect(client.listBaselineRuns).not.toHaveBeenCalled();
+		expect(text).toContain("run_main -> run_target");
+	});
+
+	test("a target with no pinned baseline fails with the fix named", async () => {
+		const client = fakeClient({ listBaselineRuns: vi.fn().mockResolvedValue({ data: [] }) });
+
+		// Loudly, rather than comparing against some other run: a regression
+		// verdict about the wrong pair is a wrong answer presented as a right one.
+		await expect(
+			prompt("compare_runs").build({ targetRunId: "run_target" }, ctxWith(client))
+		).rejects.toThrow(/baseline/i);
+	});
+});

--- a/app/electron/mcp/prompts.ts
+++ b/app/electron/mcp/prompts.ts
@@ -15,6 +15,7 @@
 
 import { z } from "zod";
 import type { ToolContext } from "./tools.js";
+import { resolveBaseline } from "./tools.js";
 import { compareReports } from "./compare.js";
 
 export interface PromptMessage {
@@ -72,12 +73,26 @@ export const PROMPTS: McpPromptDef[] = [
 		title: "Compare two runs",
 		description: "Compare two runs and assess whether performance regressed.",
 		argsSchema: {
-			baseRunId: z.string().describe("Baseline run ID (e.g. main)."),
+			// Optional, matching the `compare_runs` *tool*: it has resolved the
+			// target's pinned baseline since it shipped, and a prompt that
+			// demanded both ids described a capability narrower than the one
+			// behind it - the user was asked for a run id Vayu already knew.
+			baseRunId: z
+				.string()
+				.optional()
+				.describe(
+					"Baseline run ID (e.g. main). Leave it out to compare against the run pinned as baseline for whatever saved request the target ran."
+				),
 			targetRunId: z.string().describe("Comparison run ID (e.g. the change)."),
 		},
 		build: async (args, ctx, signal) => {
-			const baseRunId = arg(args, "baseRunId");
 			const targetRunId = arg(args, "targetRunId");
+			// Resolution failures throw with the fix named ("pin one, or pass
+			// baseRunId"), which is the answer the user needs - a prompt built
+			// against some other run would read as a regression report about a
+			// comparison nobody asked for.
+			const baseRunId =
+				arg(args, "baseRunId") || (await resolveBaseline(targetRunId, ctx, signal));
 			const [base, target] = await Promise.all([
 				ctx.client.getRunReport(baseRunId, signal),
 				ctx.client.getRunReport(targetRunId, signal),
@@ -136,7 +151,10 @@ export const PROMPTS: McpPromptDef[] = [
 				messages: [
 					userText(
 						`Design a load test with Vayu's start_load_run tool for ${url}. Goal: ${goal}.\n\n` +
-							"Recommend a mode (constant_rps, constant_concurrency, ramp_up, or iterations), a " +
+							"Recommend a mode - constant_rps, constant_concurrency, ramp_up, iterations, or " +
+							"capacity, which searches for the highest concurrency that still holds a p99 " +
+							"budget (`sloMs`) and is the mode to reach for when the goal is a number for " +
+							"'how much can it take' rather than a verdict at one load level. Then a " +
 							"starting RPS/concurrency, a duration, and how to iterate (e.g. ramp until p99 " +
 							"exceeds an SLO). Explain the reasoning, then propose the exact start_load_run " +
 							"arguments. Respect Vayu's configured caps and the host allowlist."

--- a/app/electron/mcp/protocol.integration.test.ts
+++ b/app/electron/mcp/protocol.integration.test.ts
@@ -63,6 +63,15 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 				},
 			],
 		}),
+		// The same surface as declarations (issue #760), in the envelope
+		// `GET /scripting/types` answers with.
+		getScriptTypeDefinitions: async () => ({
+			version: "1.0.0",
+			engine: "quickjs",
+			libUri: "ts:vayu/pm.d.ts",
+			typeDefinitions:
+				"declare namespace pm {\n  function test(name: string, fn: () => void): void;\n}\n",
+		}),
 		// Identity composition: the request echoed back, as the engine's
 		// POST /compose returns for an inline request with nothing to resolve.
 		composeRequest: async (body: { request?: object; environmentId?: string }) => ({
@@ -230,6 +239,7 @@ describe("resources", () => {
 		expect(uris).toContain("vayu://environments");
 		expect(uris).toContain("vayu://config");
 		expect(uris).toContain("vayu://scripting/completions");
+		expect(uris).toContain("vayu://scripting/types");
 		await server.close();
 	});
 
@@ -243,6 +253,17 @@ describe("resources", () => {
 		expect(text).toContain("Synchronous");
 		expect(text).not.toContain("insertText");
 		expect(text).not.toContain("sortText");
+		await server.close();
+	});
+
+	// The other half of the same surface (issue #760): the names come from the
+	// completions resource, the signatures from the engine's own declarations.
+	it("serves the sandbox's type declarations from the engine", async () => {
+		const { client, server } = await connectClient();
+		const res = await client.readResource({ uri: "vayu://scripting/types" });
+		const text = String((res.contents[0] as { text?: string }).text);
+		expect(text).toContain("declare namespace pm");
+		expect(text).toContain("ts:vayu/pm.d.ts");
 		await server.close();
 	});
 

--- a/app/electron/mcp/resources.test.ts
+++ b/app/electron/mcp/resources.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, test, vi } from "vitest";
-import { STATIC_RESOURCES, projectScriptingSurface } from "./resources.js";
+import { STATIC_RESOURCES, projectScriptingSurface, projectScriptingTypes } from "./resources.js";
 import type { ToolContext } from "./tools.js";
 import type { EngineClient } from "./engine-client.js";
 
@@ -172,6 +172,84 @@ describe("vayu://scripting/completions resource", () => {
 		} as ToolContext;
 
 		await expect(scriptingResource().read(ctx)).rejects.toThrow("engine is down");
+	});
+});
+
+/**
+ * The declarations half of the same surface (issue #760). The completions
+ * resource answers "what is there"; this one answers "what does it take", and
+ * the same anti-drift rule applies - the text must be the engine's, not a copy
+ * kept here.
+ */
+describe("vayu://scripting/types resource", () => {
+	const typesResource = () => {
+		const r = STATIC_RESOURCES.find((s) => s.uri === "vayu://scripting/types");
+		if (!r) throw new Error("scripting types resource is not registered");
+		return r;
+	};
+
+	function typesContext(payload: unknown, getScriptTypeDefinitions = vi.fn()) {
+		getScriptTypeDefinitions.mockResolvedValue(payload);
+		return {
+			ctx: {
+				client: { getScriptTypeDefinitions } as unknown as EngineClient,
+			} as ToolContext,
+			getScriptTypeDefinitions,
+		};
+	}
+
+	test("serves the declarations the engine generated, with its version stamps", async () => {
+		// A declaration the app has never heard of: only a resource that reads
+		// the engine can produce it, so a hardcoded .d.ts here fails.
+		const { ctx, getScriptTypeDefinitions } = typesContext({
+			version: "1.0.0",
+			engine: "quickjs",
+			libUri: "ts:vayu/pm.d.ts",
+			typeDefinitions: "declare function somethingTheAppHasNeverHeardOf(): void;",
+		});
+
+		const types = await typesResource().read(ctx);
+
+		expect(getScriptTypeDefinitions).toHaveBeenCalledTimes(1);
+		expect(types).toEqual({
+			version: "1.0.0",
+			engine: "quickjs",
+			libUri: "ts:vayu/pm.d.ts",
+			typeDefinitions: "declare function somethingTheAppHasNeverHeardOf(): void;",
+		});
+	});
+
+	test("forwards the cancellation signal to the engine client", async () => {
+		const { ctx, getScriptTypeDefinitions } = typesContext({
+			typeDefinitions: "declare var pm;",
+		});
+		const controller = new AbortController();
+
+		await typesResource().read(ctx, controller.signal);
+
+		expect(getScriptTypeDefinitions).toHaveBeenCalledWith(controller.signal);
+	});
+
+	// Same rule as the completions resource: an agent reading a missing
+	// declaration concludes the sandbox has no such call.
+	test.each([
+		["a payload that is not an object", "declare var pm;"],
+		["a payload with no typeDefinitions key", { version: "1.0.0" }],
+		["typeDefinitions that is not a string", { typeDefinitions: { pm: true } }],
+		["an empty declaration text", { typeDefinitions: "" }],
+		["null", null],
+	])("throws loudly on %s", (_label, payload) => {
+		expect(() => projectScriptingTypes(payload)).toThrow(/scripting\/types/);
+	});
+
+	test("propagates an engine failure rather than serving an empty surface", async () => {
+		const ctx = {
+			client: {
+				getScriptTypeDefinitions: vi.fn().mockRejectedValue(new Error("engine is down")),
+			} as unknown as EngineClient,
+		} as ToolContext;
+
+		await expect(typesResource().read(ctx)).rejects.toThrow("engine is down");
 	});
 });
 

--- a/app/electron/mcp/resources.ts
+++ b/app/electron/mcp/resources.ts
@@ -14,7 +14,9 @@
  *        callback (enumerate recent runs) and a completion callback (autocomplete
  *        run IDs). `vayu://scripting/completions` re-serves the engine's own
  *        script-sandbox surface so an agent discovers it the way the editor does,
- *        instead of from a prose copy that drifts (issue #233).
+ *        instead of from a prose copy that drifts (issue #233), and
+ *        `vayu://scripting/types` serves that same surface's TypeScript
+ *        declarations - the signatures the names alone do not carry.
  *        All read-only; no allowlist/caps apply. See docs/engine/mcp.md.
  */
 
@@ -86,6 +88,25 @@ export const STATIC_RESOURCES: StaticResourceDef[] = [
 		read: async (ctx, signal) =>
 			projectScriptingSurface(await ctx.client.getScriptCompletions(signal)),
 	},
+	{
+		name: "scripting-types",
+		uri: "vayu://scripting/types",
+		title: "Script sandbox type declarations",
+		// Beside the completion list rather than instead of it: the completions
+		// answer "what is there", these answer "what does it take and what does
+		// it return". An agent writing `pm.expect(...)` chains or reading
+		// `pm.response.to.have` needs the signature, and the alternative to
+		// serving the engine's own `.d.ts` is prose that drifts - the drift
+		// issue #233 recorded for the completion list.
+		description:
+			"The engine's TypeScript declarations (.d.ts) for the pre-request / test script " +
+			"sandbox - the same text the app's editor feeds to its TypeScript worker, so every " +
+			"pm.* signature, parameter and return type is the running engine's. Read this " +
+			"beside vayu://scripting/completions when you need the shape of a call rather " +
+			"than its name.",
+		read: async (ctx, signal) =>
+			projectScriptingTypes(await ctx.client.getScriptTypeDefinitions(signal)),
+	},
 ];
 
 /** One sandbox name as an agent sees it - the engine's own keys, minus Monaco's. */
@@ -134,6 +155,46 @@ export function projectScriptingSurface(payload: unknown): ScriptingSurface {
 		});
 	}
 	return { version: root.version, engine: root.engine, completions };
+}
+
+/** The sandbox's type declarations as an agent sees them. */
+export interface ScriptingTypes {
+	version?: unknown;
+	engine?: unknown;
+	/** Monaco's library URI for the declarations - kept so the two halves of the
+	 *  surface are recognisably the same document the editor loads. */
+	libUri?: unknown;
+	typeDefinitions: string;
+}
+
+/**
+ * Reduce `GET /scripting/types` to the declarations and the version stamps
+ * around them.
+ *
+ * Throws on anything but a non-empty `typeDefinitions` string, for the reason
+ * {@link projectScriptingSurface} throws: half a type surface is worse than
+ * none, because an agent reads a missing declaration as "the sandbox has no
+ * such call" and writes around a capability that is there. An empty string is
+ * one of those failures rather than an empty sandbox - the engine generates
+ * these from the same table the completions come from, so it never legitimately
+ * produces nothing.
+ */
+export function projectScriptingTypes(payload: unknown): ScriptingTypes {
+	const root =
+		payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
+	const declarations =
+		root && typeof root.typeDefinitions === "string" ? root.typeDefinitions : "";
+	if (!declarations) {
+		throw new Error(
+			"GET /scripting/types returned no `typeDefinitions` text - cannot describe the script sandbox"
+		);
+	}
+	return {
+		version: root!.version,
+		engine: root!.engine,
+		libUri: root!.libUri,
+		typeDefinitions: declarations,
+	};
 }
 
 /** Templated per-run report resource. */

--- a/app/electron/mcp/safety.ts
+++ b/app/electron/mcp/safety.ts
@@ -266,8 +266,14 @@ export interface LoadRunParams {
  * Modes the engine recognises (`parse_load_test_type`, `vayu/types.hpp`).
  * Anything else falls through `LoadStrategy::create`, so the guard mirrors that
  * fallback rather than trusting the string it was given.
+ *
+ * Exported for the prompt test rather than for production use: this is the one
+ * list in the MCP layer that has to track the engine's modes (a mode missing
+ * here reaches the wrong cap), which makes it the thing to measure the
+ * `suggest_load_profile` prompt's enumeration against - that prompt named four
+ * of five for as long as `capacity` had existed.
  */
-const KNOWN_LOAD_MODES = new Set([
+export const KNOWN_LOAD_MODES = new Set([
 	"constant_rps",
 	"constant_concurrency",
 	"ramp_up",

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -15,8 +15,11 @@ import {
 	MAX_INBOX_CAPTURE_LIMIT,
 	MAX_IN_FLIGHT_BOUND,
 	MAX_INLINE_BODY_BYTES,
+	MAX_REDIRECTS_BOUND,
 	MAX_REPORT_TRACE_BYTES,
 	MAX_RUN_SERIES_LIMIT,
+	MAX_SLOW_THRESHOLD_MS,
+	MAX_SUCCESS_SAMPLE_PERIOD,
 	toolCatalog,
 	TOOLS,
 	type ToolContext,
@@ -70,6 +73,23 @@ function page(data: unknown[], total = data.length, offset = 0) {
 }
 
 const emptyPage = () => page([]);
+
+/**
+ * `serialize_token`'s shape (`engine/src/http/oauth_client.cpp`), bearer bytes
+ * included - the fakes serve what the engine serves, so the tools' redaction
+ * has something real to remove.
+ */
+const OAUTH2_TOKEN_RECORD = {
+	// Unit-separated, as `cache_key(config)` builds it engine-side.
+	cacheKey: "https://id.example.com/oauth/token\u001fclient_a\u001fdefault\u001f",
+	accessToken: "eyJhbGciOiJIUzI1NiJ9.thebearer.sig",
+	tokenType: "Bearer",
+	scope: "orders:read",
+	expiresIn: 3600,
+	createdAt: 1_755_000_000_000,
+	expiresAt: 1_755_003_600_000,
+	hasRefreshToken: true,
+};
 
 /** Build a fake EngineClient with vi.fn()s for the methods under test. */
 function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}) {
@@ -137,6 +157,11 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 		saveGlobals: vi.fn().mockResolvedValue({ id: "globals", updatedAt: 2, variables: {} }),
 		getCookies: vi.fn().mockResolvedValue({ scopes: [] }),
 		clearCookies: vi.fn().mockResolvedValue({ cleared: 4 }),
+		fetchOAuth2Token: vi.fn().mockResolvedValue(OAUTH2_TOKEN_RECORD),
+		getOAuth2TokenStatus: vi
+			.fn()
+			.mockResolvedValue({ found: true, expired: false, token: OAUTH2_TOKEN_RECORD }),
+		clearOAuth2Token: vi.fn().mockResolvedValue({ deleted: true }),
 		startMockIssuer: vi.fn().mockResolvedValue({
 			issuerId: "issuer_1",
 			issuerUrl: "http://127.0.0.1:41234",
@@ -5783,5 +5808,330 @@ describe("webhook inbox tools", () => {
 			).toEqual([]);
 			expect(byName().get("get_inbox_captures")?.description).toMatch(/no live stream/i);
 		});
+	});
+});
+
+/**
+ * The run-recording knobs the app's load dialog has always sent, reachable over
+ * MCP for the first time (issue #760).
+ *
+ * The load-bearing assertions are the payload *keys*: these three are the only
+ * snake_case fields on `POST /runs`, and a camelCase spelling reaches the engine
+ * as an unread key rather than an error - a knob an agent believes it set and no
+ * run ever reads.
+ */
+describe("start_load_run recording knobs", () => {
+	const allow = { allowlist: ["api.example.com"] };
+	const started = (client: EngineClient) =>
+		(client.startRun as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+
+	async function start(args: Record<string, unknown>, client = fakeClient()) {
+		const res = await dispatchTool(
+			"start_load_run",
+			{ url: "https://api.example.com/users", confirmed: true, ...args },
+			ctxWith(client, allow)
+		);
+		return { res, client };
+	}
+
+	test("each knob travels under the engine's own key", async () => {
+		const { res, client } = await start({
+			successSamplePeriod: 5,
+			slowRequestThresholdMs: 750,
+			saveTimingBreakdown: true,
+			comment: "nightly baseline",
+		});
+
+		expect(res.isError).toBeFalsy();
+		expect(started(client)).toMatchObject({
+			success_sample_rate: 5,
+			slow_threshold_ms: 750,
+			save_timing_breakdown: true,
+			comment: "nightly baseline",
+		});
+		// The camelCase argument names must not also reach the engine: it reads
+		// the snake_case ones and would ignore these in silence.
+		for (const camel of [
+			"successSamplePeriod",
+			"slowRequestThresholdMs",
+			"saveTimingBreakdown",
+		]) {
+			expect(started(client)).not.toHaveProperty(camel);
+		}
+	});
+
+	test("a knob the caller did not name is absent, not defaulted", async () => {
+		const { client } = await start({ comment: "just a note" });
+		const payload = started(client);
+
+		// Each has an engine-side default a stated value would overwrite; a
+		// defaulted `save_timing_breakdown: false` here would switch off tracing
+		// for a caller that never mentioned it.
+		for (const key of ["success_sample_rate", "slow_threshold_ms", "save_timing_breakdown"]) {
+			expect(payload).not.toHaveProperty(key);
+		}
+	});
+
+	test("a sampling period of 0 is refused at the schema, not sent as a divide by zero", () => {
+		const schema = z.object(
+			TOOLS.find((t) => t.name === "start_load_run")!.inputSchema as z.ZodRawShape
+		);
+		expect(schema.safeParse({ successSamplePeriod: 0 }).success).toBe(false);
+		expect(schema.safeParse({ successSamplePeriod: 1 }).success).toBe(true);
+		expect(
+			schema.safeParse({ successSamplePeriod: MAX_SUCCESS_SAMPLE_PERIOD + 1 }).success
+		).toBe(false);
+		// 0 disables outlier capture and is legal; a negative would mark every
+		// completion an outlier.
+		expect(schema.safeParse({ slowRequestThresholdMs: 0 }).success).toBe(true);
+		expect(schema.safeParse({ slowRequestThresholdMs: -1 }).success).toBe(false);
+		expect(
+			schema.safeParse({ slowRequestThresholdMs: MAX_SLOW_THRESHOLD_MS + 1 }).success
+		).toBe(false);
+	});
+
+	/**
+	 * `POST /runs` has no guard on `maxRedirects` - it reaches
+	 * `CURLOPT_MAXREDIRS`, where a negative means *unlimited* - so this schema is
+	 * the only thing between `-1` and a run that follows chains forever.
+	 */
+	test("the redirect policy reaches composition, and a negative ceiling is refused", async () => {
+		const { client } = await start({ followRedirects: false, maxRedirects: 3 });
+		const composed = (client.composeRequest as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			request: Record<string, unknown>;
+		};
+
+		expect(composed.request).toMatchObject({ followRedirects: false, maxRedirects: 3 });
+
+		const schema = z.object(
+			TOOLS.find((t) => t.name === "start_load_run")!.inputSchema as z.ZodRawShape
+		);
+		expect(schema.safeParse({ maxRedirects: -1 }).success).toBe(false);
+		expect(schema.safeParse({ maxRedirects: 0 }).success).toBe(true);
+		expect(schema.safeParse({ maxRedirects: MAX_REDIRECTS_BOUND + 1 }).success).toBe(false);
+	});
+
+	/**
+	 * Both executors read them off the same `RunContext`, so forwarding on one
+	 * path only would be a knob that silently does nothing on the other.
+	 */
+	test("a scenario load run carries the same knobs", async () => {
+		const client = fakeClient({
+			listRequests: vi.fn().mockResolvedValue([{ id: "req_1", name: "Step", order: 0 }]),
+			composeRequest: vi
+				.fn()
+				.mockResolvedValue({ method: "GET", url: "https://api.example.com/step" }),
+		});
+		const res = await dispatchTool(
+			"start_load_run",
+			{
+				scenario: { collectionId: "col_1" },
+				confirmed: true,
+				successSamplePeriod: 2,
+				slowRequestThresholdMs: 900,
+				saveTimingBreakdown: true,
+				comment: "scenario soak",
+			},
+			ctxWith(client, allow)
+		);
+
+		expect(res.isError).toBeFalsy();
+		expect(started(client)).toMatchObject({
+			success_sample_rate: 2,
+			slow_threshold_ms: 900,
+			save_timing_breakdown: true,
+			comment: "scenario soak",
+		});
+	});
+
+	test("a scenario run refuses the redirect policy by name - each step keeps its own", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"start_load_run",
+			{ scenario: { collectionId: "col_1" }, confirmed: true, followRedirects: true },
+			ctxWith(client, allow)
+		);
+
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/followRedirects/);
+		expect(firstText(res)).toMatch(/stored redirect policy/i);
+		expect(client.startRun).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * The OAuth 2.0 token-cache tools (issue #760).
+ *
+ * Two rules carry the weight here and both are security-shaped: the interactive
+ * grant is refused *before* the engine is called, and no tool ever returns the
+ * access token's bytes.
+ */
+describe("OAuth 2.0 token tools", () => {
+	const config = {
+		grantType: "client_credentials",
+		accessTokenUrl: "https://id.example.com/oauth/token",
+		clientId: "client_a",
+		clientSecret: "s3cret",
+	};
+	const allow = { allowlist: ["id.example.com"] };
+
+	test("the three tools sit in the categories their effects call for", () => {
+		const tools = new Map(TOOLS.map((t) => [t.name, t]));
+		// It contacts a third party; it does not mutate saved documents.
+		expect(tools.get("fetch_oauth2_token")?.category).toBe("execute");
+		expect(tools.get("fetch_oauth2_token")?.annotations.openWorldHint).toBe(true);
+		expect(tools.get("get_oauth2_token_status")?.category).toBe("read");
+		// It destroys a stored credential, so it sits behind the write toggle -
+		// the same place `clear_cookies` sits for the same reason.
+		expect(tools.get("clear_oauth2_token")?.category).toBe("write");
+	});
+
+	test("fetch acquires the token and never hands back the bearer", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool("fetch_oauth2_token", { config }, ctxWith(client, allow));
+
+		expect(res.isError).toBeFalsy();
+		expect(client.fetchOAuth2Token).toHaveBeenCalledTimes(1);
+		expect((client.fetchOAuth2Token as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual({
+			config,
+		});
+		const text = firstText(res);
+		expect(text).not.toContain(OAUTH2_TOKEN_RECORD.accessToken);
+		// What an agent legitimately needs from the cache is its shape - the key
+		// it can inspect and clear by, and when it expires.
+		expect(JSON.parse(text)).toEqual({
+			cacheKey: OAUTH2_TOKEN_RECORD.cacheKey,
+			tokenType: "Bearer",
+			scope: "orders:read",
+			expiresIn: 3600,
+			createdAt: OAUTH2_TOKEN_RECORD.createdAt,
+			expiresAt: OAUTH2_TOKEN_RECORD.expiresAt,
+			hasRefreshToken: true,
+			// Stated rather than silently omitted: an agent that finds no token
+			// and is not told why concludes the acquisition half-failed.
+			accessTokenWithheld: true,
+		});
+	});
+
+	test("force is forwarded only when asked for", async () => {
+		const forced = fakeClient();
+		await dispatchTool("fetch_oauth2_token", { config, force: true }, ctxWith(forced, allow));
+		expect(
+			(forced.fetchOAuth2Token as ReturnType<typeof vi.fn>).mock.calls[0][0]
+		).toMatchObject({ force: true });
+
+		const plain = fakeClient();
+		await dispatchTool("fetch_oauth2_token", { config, force: false }, ctxWith(plain, allow));
+		// A stated `false` is the engine's own default, and sending it would make
+		// "the caller said no" indistinguishable from "the caller said nothing".
+		expect(
+			(plain.fetchOAuth2Token as ReturnType<typeof vi.fn>).mock.calls[0][0]
+		).not.toHaveProperty("force");
+	});
+
+	/**
+	 * The refusal is not merely "it cannot work". `acquire_token` answers a cache
+	 * hit *before* it looks at the grant, so a call naming a config that matches
+	 * an entry the user authorized in a browser would otherwise reach into it.
+	 */
+	test("the authorization_code grant is refused before the engine is called", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"fetch_oauth2_token",
+			{ config: { ...config, grantType: "authorization_code" } },
+			ctxWith(client, allow)
+		);
+
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/authorization_code/);
+		// The refusal names where the user can do it instead.
+		expect(firstText(res)).toMatch(/Auth tab|in Vayu/i);
+		expect(client.fetchOAuth2Token).not.toHaveBeenCalled();
+	});
+
+	test("the token endpoint is gated by the allowlist, and so is a different refresh host", async () => {
+		const blocked = fakeClient();
+		const off = await dispatchTool("fetch_oauth2_token", { config }, ctxWith(blocked));
+		expect(off.isError).toBe(true);
+		expect(firstText(off)).toMatch(/accessTokenUrl/);
+		expect(blocked.fetchOAuth2Token).not.toHaveBeenCalled();
+
+		// A config whose refresh URL points somewhere else must not walk around
+		// the gate the token URL passed.
+		const sneaky = fakeClient();
+		const res = await dispatchTool(
+			"fetch_oauth2_token",
+			{ config: { ...config, refreshTokenUrl: "https://elsewhere.example.net/refresh" } },
+			ctxWith(sneaky, allow)
+		);
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toMatch(/refreshTokenUrl/);
+		expect(sneaky.fetchOAuth2Token).not.toHaveBeenCalled();
+	});
+
+	test("status reports presence and expiry without the bearer", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"get_oauth2_token_status",
+			{ cacheKey: OAUTH2_TOKEN_RECORD.cacheKey },
+			ctxWith(client)
+		);
+
+		expect(res.isError).toBeFalsy();
+		expect(client.getOAuth2TokenStatus).toHaveBeenCalledWith(
+			OAUTH2_TOKEN_RECORD.cacheKey,
+			undefined
+		);
+		const text = firstText(res);
+		expect(text).toContain('"found": true');
+		expect(text).toContain('"expired": false');
+		expect(text).not.toContain(OAUTH2_TOKEN_RECORD.accessToken);
+	});
+
+	test("an absent entry is an answer, not an error", async () => {
+		const client = fakeClient({
+			getOAuth2TokenStatus: vi.fn().mockResolvedValue({ found: false }),
+		});
+		const res = await dispatchTool(
+			"get_oauth2_token_status",
+			{ cacheKey: "nothing-here" },
+			ctxWith(client)
+		);
+
+		expect(res.isError).toBeFalsy();
+		expect(firstText(res)).toContain('"found": false');
+	});
+
+	test("clearing is refused while writes are off, and reports what it removed when on", async () => {
+		const gated = fakeClient();
+		const refused = await dispatchTool(
+			"clear_oauth2_token",
+			{ cacheKey: OAUTH2_TOKEN_RECORD.cacheKey },
+			ctxWith(gated)
+		);
+		expect(refused.isError).toBe(true);
+		expect(firstText(refused)).toMatch(/writes are disabled/i);
+		expect(gated.clearOAuth2Token).not.toHaveBeenCalled();
+
+		const client = fakeClient();
+		const res = await dispatchTool(
+			"clear_oauth2_token",
+			{ cacheKey: OAUTH2_TOKEN_RECORD.cacheKey },
+			ctxWith(client, { allowWrites: true })
+		);
+		expect(res.isError).toBeFalsy();
+		expect(client.clearOAuth2Token).toHaveBeenCalledWith(
+			OAUTH2_TOKEN_RECORD.cacheKey,
+			undefined
+		);
+		expect(firstText(res)).toContain('"deleted": true');
+	});
+
+	test("the cache families the renderer must refetch are declared", () => {
+		const tools = new Map(TOOLS.map((t) => [t.name, t]));
+		// Both change what the auth tab's status row shows; a read changes nothing.
+		expect(tools.get("fetch_oauth2_token")?.invalidates).toEqual(["oauth"]);
+		expect(tools.get("clear_oauth2_token")?.invalidates).toEqual(["oauth"]);
+		expect(tools.get("get_oauth2_token_status")?.invalidates).toEqual([]);
 	});
 });

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -86,6 +86,12 @@ export const MCP_DATA_ENTITIES = [
 	// Services drawer and the Dock's running-services count, which ask "what is
 	// listening" and not "which kind".
 	"service",
+	// The engine's OAuth 2.0 token cache (issue #760). Its own family rather
+	// than a fold into `config`: it has one reader of its own
+	// (`queryKeys.oauth`), and the auth tab's token-status row polls at 30s -
+	// long enough for an agent to clear a token, say so, and leave the window
+	// showing the entry it just destroyed.
+	"oauth",
 ] as const;
 
 export type McpDataEntity = (typeof MCP_DATA_ENTITIES)[number];
@@ -757,7 +763,11 @@ function writesDisabled(ctx: ToolContext): ToolResult | null {
 
 /**
  * The run pinned as baseline for whatever saved request @p targetRunId ran -
- * `compare_runs`'s answer when the caller named no base.
+ * `compare_runs`'s answer when the caller named no base, tool and prompt alike:
+ * the prompt asked for both ids while the tool resolved one, so the same
+ * question reached the agent two ways (issue #760). Exported for the prompt
+ * rather than copied into it, since a second resolution rule would be a second
+ * definition of "the baseline".
  *
  * Resolution is the engine's, not a scan here: `GET /runs?baseline=true&
  * requestId=...` is ordered newest-first, so "the baseline" is its first row.
@@ -770,7 +780,7 @@ function writesDisabled(ctx: ToolContext): ToolResult | null {
  * (an ad-hoc load run) has nothing to resolve *through*, which is a different
  * problem from a request with no pin, and says so.
  */
-async function resolveBaseline(
+export async function resolveBaseline(
 	targetRunId: string,
 	ctx: ToolContext,
 	signal?: AbortSignal
@@ -1193,6 +1203,15 @@ function readRequestOverrides(args: Record<string, unknown>): Record<string, unk
 	// `start_load_run` Zod schemas restrict the value to a known protocol.
 	const httpVersion = str(args, "httpVersion");
 	if (httpVersion !== undefined) out.httpVersion = httpVersion;
+	// Redirect policy is part of the request half, not the load shape: the app
+	// sends both fields through `POST /compose` beside the method and the body
+	// (`request-builder/index.tsx`), and the engine emits them on every composed
+	// payload under the never-elided rule. Only `start_load_run` declares them -
+	// `run_request` has no such argument, so nothing can arrive here from it -
+	// because an ad-hoc load target has no saved request whose stored policy the
+	// run could inherit.
+	if (typeof args.followRedirects === "boolean") out.followRedirects = args.followRedirects;
+	if (typeof args.maxRedirects === "number") out.maxRedirects = args.maxRedirects;
 	return out;
 }
 
@@ -1434,6 +1453,74 @@ const DEFAULT_LOAD_MODE = "constant_concurrency";
  */
 export const MAX_IN_FLIGHT_BOUND = 1_000_000;
 
+/**
+ * The engine's guards on the two numeric recording knobs
+ * (`validate_run_config`, `engine/src/http/routes/execution.cpp`), mirrored for
+ * the reason {@link MAX_IN_FLIGHT_BOUND} is: the schema refuses an
+ * out-of-range value by name instead of surfacing a `400`.
+ *
+ * Deliberately *not* the load dialog's own ceilings - `LOAD_TEST_LIMITS`
+ * narrows the slow threshold to a minute because that is a sensible thing to
+ * put on a slider, not because the engine refuses more. A tool that copied the
+ * slider's bound would refuse runs the engine accepts and the app cannot
+ * compose.
+ */
+export const MAX_SUCCESS_SAMPLE_PERIOD = 100_000;
+export const MAX_SLOW_THRESHOLD_MS = 86_400_000;
+
+/**
+ * The redirect ceiling `apply_request_fields` clamps a stored request to
+ * (`std::clamp (r.max_redirects, 0, 100)`). `POST /runs` has no guard of its
+ * own - the field reaches `CURLOPT_MAXREDIRS` as an `int`, where a negative
+ * means *unlimited* - so this schema is the only thing between an agent's
+ * `maxRedirects: -1` and a run that follows redirect chains forever. Refused
+ * rather than clamped, like every other bound here: a value silently changed is
+ * a run measuring something the agent did not ask for.
+ */
+export const MAX_REDIRECTS_BOUND = 100;
+
+/**
+ * The recording knobs the app's load dialog sends, as `{tool argument: run
+ * config key}`. Two spellings because the engine's are snake_case here and only
+ * here - `success_sample_rate` is not a rate but a *period* (keep 1 in N), and
+ * the app's own `StartLoadTestRequest` carries a comment saying so. The
+ * argument is named for what the value means; the payload key stays the
+ * engine's, so `get_run_report`'s echo of the config snapshot matches what a
+ * run was started with.
+ */
+const LOAD_RECORDING_FIELDS: ReadonlyArray<[argument: string, configKey: string]> = [
+	["successSamplePeriod", "success_sample_rate"],
+	["slowRequestThresholdMs", "slow_threshold_ms"],
+	["saveTimingBreakdown", "save_timing_breakdown"],
+];
+
+/**
+ * Copy the recording knobs and the run comment onto a `POST /runs` payload.
+ *
+ * Shared by both load paths because both read them: a scenario load run is
+ * driven by the same `RunContext`, whose constructor is the one place
+ * `success_sample_rate` / `save_timing_breakdown` / `slow_threshold_ms` are
+ * read (`core/run_manager.cpp`), and `comment` is lifted into the run summary
+ * and the report's `metadata.configuration` by `routes/runs.cpp` whichever
+ * executor produced the run. Forwarding them on one path only would have been a
+ * knob that silently did nothing on the other.
+ *
+ * Absent stays absent - never defaulted - because each of these has an engine
+ * default a stated value would overwrite, and "the caller said nothing" and
+ * "the caller asked for the default" are the same run only by accident.
+ */
+function applyRecordingKnobs(
+	args: Record<string, unknown>,
+	payload: Record<string, unknown>
+): void {
+	for (const [argument, configKey] of LOAD_RECORDING_FIELDS) {
+		const value = args[argument];
+		if (typeof value === "number" || typeof value === "boolean") payload[configKey] = value;
+	}
+	const comment = str(args, "comment");
+	if (comment !== undefined) payload.comment = comment;
+}
+
 // --- Shared input schema fragments ------------------------------------------
 
 /** Optional resolution scope shared by the ad-hoc execute/load tools. */
@@ -1668,6 +1755,86 @@ const authInput = z
 	.describe(
 		"Optional auth block (e.g. { mode: 'bearer', token: '{{apiToken}}' }); the engine resolves and applies it."
 	);
+
+// --- OAuth 2.0 token cache ---------------------------------------------------
+
+/**
+ * The `oauth2` config block, shaped as the engine reads it (`oauth_client.cpp`)
+ * and as a saved request's `auth` already carries it - so an agent can lift the
+ * block out of `list_requests` and hand it to `fetch_oauth2_token` unchanged.
+ *
+ * `passthrough` rather than an enumerated object for the same reason
+ * {@link authInput} is: the engine owns which fields a grant needs, and a
+ * closed schema here would refuse a config the engine accepts the day a field
+ * is added. What is enumerated is the one field this layer decides on -
+ * `grantType`, because the interactive grant is refused before the call.
+ */
+const oauth2ConfigInput = z
+	.object({
+		grantType: z
+			.string()
+			.describe(
+				"client_credentials | password. `authorization_code` is refused here - it needs a browser, so authorize it in the app."
+			),
+		accessTokenUrl: z.string().describe("The provider's token endpoint (http(s))."),
+		clientId: z.string().describe("OAuth 2.0 client id."),
+	})
+	.passthrough()
+	.describe(
+		"The OAuth 2.0 config to acquire a token for - the same block a saved request's `auth` carries, so it can be copied from list_requests verbatim. Beyond the three required fields the engine reads clientSecret, username/password (password grant), scope, audience, resource, refreshTokenUrl, autoRefreshToken, clientAuthentication and credentialsId. The cache key is derived from accessTokenUrl + clientId + credentialsId + username: configs differing only in scope share one cached token, so set a distinct `credentialsId` to keep them apart."
+	);
+
+/** The engine-derived key one cache entry lives under. */
+const oauth2CacheKeyInput = z
+	.string()
+	.describe(
+		"The cache key, as returned in `cacheKey` by fetch_oauth2_token (or shown by the app's auth tab). Derived engine-side from the config; there is no way to compose one here that would be guaranteed to match."
+	);
+
+/**
+ * Why the interactive grant is refused rather than attempted.
+ *
+ * Two reasons, and the second is the load-bearing one. It cannot work: the
+ * exchange needs a browser and the loopback listener `oauth_authorize.cpp`
+ * binds, which the app drives and MCP has no place in. And it must not be
+ * *attempted*, because `acquire_token` answers a cache hit before it ever looks
+ * at the grant - so a call naming a config whose accessTokenUrl / clientId /
+ * credentialsId happen to match an entry the user authorized interactively
+ * would return that entry without proving anything. Refusing on `grantType`
+ * closes the shape of that call rather than trusting the redaction below to
+ * make it harmless.
+ */
+const OAUTH2_INTERACTIVE_REFUSAL =
+	'The `authorization_code` grant is not available over MCP: it redirects through a browser to a loopback listener the app owns, and an agent cannot complete that exchange. Authorize it once in Vayu (the request\'s Auth tab -> "Get New Access Token"); the token lands in the same engine cache these tools read, so get_oauth2_token_status and clear_oauth2_token work on it afterwards. For a machine-to-machine flow use `client_credentials`.';
+
+/**
+ * The engine's token record with the bearer removed.
+ *
+ * **The decision, stated rather than implied:** no MCP tool returns access
+ * token bytes. The engine is what applies a token to a request - an agent names
+ * a config and the run authenticates - so the bytes buy an agent nothing it can
+ * use through Vayu, while handing them over turns a token the *user* acquired
+ * (including through a browser flow no agent could complete) into something an
+ * agent can carry off this machine. Everything an agent legitimately needs from
+ * the cache is its shape: which key, what type, which scopes, when it expires,
+ * whether a refresh token came with it.
+ *
+ * `accessTokenWithheld` is stated rather than left as a silent omission,
+ * because an agent that finds no `accessToken` and is not told why concludes
+ * the acquisition half-failed and retries with `force`.
+ */
+export function projectOAuth2Token(token: unknown): unknown {
+	if (!isRecord(token)) return token;
+	const { accessToken: _withheld, ...rest } = token;
+	return { ...rest, accessTokenWithheld: true };
+}
+
+/** `GET /oauth2/token`'s answer, with the nested token record projected. */
+export function projectOAuth2Status(status: unknown): unknown {
+	if (!isRecord(status)) return status;
+	if (!isRecord(status.token)) return status;
+	return { ...status, token: projectOAuth2Token(status.token) };
+}
 
 // --- Structured output schemas ----------------------------------------------
 
@@ -2083,6 +2250,14 @@ const SINGLE_TARGET_LOAD_FIELDS: ReadonlyArray<[string, string]> = [
 	["bodyType", "each step keeps its own stored body"],
 	["auth", "each step's auth is resolved from the request and its collection chain"],
 	["httpVersion", "each step keeps its own stored protocol"],
+	[
+		"followRedirects",
+		"each step keeps its own stored redirect policy - set it on the saved request",
+	],
+	[
+		"maxRedirects",
+		"each step keeps its own stored redirect policy - set it on the saved request",
+	],
 	["postRequestScript", "each step runs the scripts stored on it and its collection chain"],
 	["tests", "each step runs the scripts stored on it and its collection chain"],
 	[
@@ -2223,6 +2398,10 @@ async function startScenarioLoadRun(
 	if (args.thresholds && typeof args.thresholds === "object")
 		payload.thresholds = args.thresholds;
 	if (monitor && typeof monitor === "object") payload.monitor = monitor;
+	// And for the same reason again: the recording knobs are read by the
+	// `RunContext` both executors share, so a scenario run keeps traces on the
+	// terms an agent stated exactly as a single-target run does.
+	applyRecordingKnobs(args, payload);
 	const cappedDuration = defaultDurationUnderCap(loadParams, ctx.config);
 	if (cappedDuration !== null) payload.duration = cappedDuration;
 
@@ -3980,7 +4159,7 @@ export const TOOLS: McpTool[] = [
 		category: "load",
 		invalidates: ["run"],
 		description:
-			"Start a load test against a URL, or against a saved request via `requestId` - which composes it exactly as the app does, including the collection chain's and its own test scripts, so a load run checks the same assertions a Send does. GUARDED: the host must be on the allowlist, and RPS/concurrency/duration must be within Vayu's caps. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given; pass an `auth` block to authenticate the load (bearer/basic/apikey/oauth2, applied engine-side). Pass a `postRequestScript` - the same assertions you would give run_request - to validate responses under load; it runs against sampled responses. A pre-request script is not offered here for a single target: the engine runs one on a single request only, never on a load run. Pass `scenario` INSTEAD of url/requestId to load-test a collection's ordered sequence: `concurrency` then means virtual users, each walking the plan with its own cookies and running every step's stored scripts, and only constant_concurrency, ramp_up and iterations can drive it. Confirmation is required: if the client supports elicitation the user is prompted directly; otherwise call once for a preview, then again with `confirmed: true`.",
+			"Start a load test against a URL, or against a saved request via `requestId` - which composes it exactly as the app does, including the collection chain's and its own test scripts, so a load run checks the same assertions a Send does. GUARDED: the host must be on the allowlist, and RPS/concurrency/duration must be within Vayu's caps. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given; pass an `auth` block to authenticate the load (bearer/basic/apikey/oauth2, applied engine-side). Pass a `postRequestScript` - the same assertions you would give run_request - to validate responses under load; it runs against sampled responses. A pre-request script is not offered here for a single target: the engine runs one on a single request only, never on a load run. Pass `scenario` INSTEAD of url/requestId to load-test a collection's ordered sequence: `concurrency` then means virtual users, each walking the plan with its own cookies and running every step's stored scripts, and only constant_concurrency, ramp_up and iterations can drive it. What the run *keeps* is yours to set too - `successSamplePeriod`, `slowRequestThresholdMs` and `saveTimingBreakdown` decide which responses are traced, and `comment` stamps the run with why it exists; all four apply to a scenario run as well. There is no per-request timeout on a run: the engine's `defaultTimeout` setting governs every transfer (change it with update_engine_config), so a slow target is a config change and not an argument here. Confirmation is required: if the client supports elicitation the user is prompted directly; otherwise call once for a preview, then again with `confirmed: true`.",
 		annotations: {
 			title: "Start load test",
 			readOnlyHint: false,
@@ -4172,6 +4351,59 @@ export const TOOLS: McpTool[] = [
 				.describe(
 					"Scrape the target's own metrics endpoint for the life of the run, so its CPU or memory can be read on the same timeline as p99 and throughput. The report comes back with a `monitor` section: per-series min/max/avg plus the sample and failed-scrape counts. Omit for a run that measures only the client side."
 				),
+			// The redirect policy of the request being load-tested. A saved
+			// request carries its own (composed in, never elided), so these are
+			// the override; an ad-hoc target has none, so they are the only way to
+			// state one at all. Load-shape arguments they are not - which is why a
+			// scenario run refuses them by name rather than ignoring them.
+			followRedirects: z
+				.boolean()
+				.optional()
+				.describe(
+					"Whether a 3xx is followed (engine default: true). With `requestId`, overrides the policy stored on that request; on an ad-hoc target this is how the policy is stated at all. A load test that follows redirects measures the whole chain, so its latency is the chain's, not the first hop's."
+				),
+			maxRedirects: z
+				.number()
+				.int()
+				.min(0)
+				.max(MAX_REDIRECTS_BOUND)
+				.optional()
+				.describe(
+					`How many redirects may be followed, 0-${MAX_REDIRECTS_BOUND} (engine default: 10; 0 means a 3xx is returned as the response). Requires \`followRedirects\` to be on to have any effect.`
+				),
+			// The recording knobs the app's load dialog sets. None of them changes
+			// what the run *sends* - they decide what it keeps - so none takes a
+			// gate of its own beyond the ones the run already passed.
+			comment: z
+				.string()
+				.optional()
+				.describe(
+					"A note stamped on the run, shown beside it in History and in the report's `metadata.configuration`. Use it to say what the run was for - the reason a report is worth keeping is rarely recoverable from its numbers."
+				),
+			successSamplePeriod: z
+				.number()
+				.int()
+				.min(1)
+				.max(MAX_SUCCESS_SAMPLE_PERIOD)
+				.optional()
+				.describe(
+					`Keep 1 in N successful responses (the engine's \`success_sample_rate\`, which is a period and not a percentage): 1 keeps every one, 100 keeps 1%. Default 100. Only sampled responses carry a timing breakdown, and only if \`saveTimingBreakdown\` is on. Range 1-${MAX_SUCCESS_SAMPLE_PERIOD}; 0 is a division by zero engine-side and is refused here.`
+				),
+			slowRequestThresholdMs: z
+				.number()
+				.int()
+				.min(0)
+				.max(MAX_SLOW_THRESHOLD_MS)
+				.optional()
+				.describe(
+					'Capture any completion at or above this many milliseconds as an outlier, whatever the sampling period keeps. 0 disables outlier capture. This is the knob that answers "what did the slow 1% look like" - the sampled subset is uniform and will not contain them.'
+				),
+			saveTimingBreakdown: z
+				.boolean()
+				.optional()
+				.describe(
+					"Store the per-phase timing (DNS, connect, TLS, TTFB) of each sampled success, which is what fills the report's timing-breakdown section. Off by default - a breakdown is stored per retained record, so it is the knob that decides whether the run keeps traces at all."
+				),
 			requestId: z
 				.string()
 				.optional()
@@ -4308,6 +4540,7 @@ export const TOOLS: McpTool[] = [
 			if (monitor && typeof monitor === "object") {
 				payload.monitor = monitor;
 			}
+			applyRecordingKnobs(args, payload);
 			// An omitted duration is 60s engine-side, not "unbounded" and not
 			// "capped" - so a cap under 60s has to be sent as an explicit field
 			// or it never reaches the run.
@@ -4524,6 +4757,95 @@ export const TOOLS: McpTool[] = [
 				if (err instanceof ToolArgError) return errorResult(err.message);
 				return engineErrorResult(err);
 			}
+		},
+	},
+	{
+		name: "fetch_oauth2_token",
+		category: "execute",
+		invalidates: ["oauth"],
+		description:
+			"Acquire an OAuth 2.0 token for a client_credentials or password config and cache it engine-side, so the next run_request / start_load_run carrying the same config authenticates without a round trip - and so a token problem surfaces here, named, instead of as a wall of 401s inside a run. Pass `force: true` to refresh a token that is cached but stale. The interactive authorization_code grant is refused: it needs a browser and a loopback redirect the app owns, so authorize it there once and the cache this tool reads is the same one. GUARDED: the token endpoint's host must be on Vayu's MCP allowlist. The access token itself is never returned - what comes back is the cache entry's shape (key, type, scope, expiry, whether a refresh token came with it), because the engine applies the token to requests and nothing an agent does with the bearer needs its bytes.",
+		annotations: {
+			title: "Fetch OAuth 2.0 token",
+			readOnlyHint: false,
+			// It contacts a third party and writes a credential into the engine's
+			// cache, replacing whatever was there for that key.
+			destructiveHint: true,
+			openWorldHint: true,
+		},
+		inputSchema: {
+			config: oauth2ConfigInput,
+			force: z
+				.boolean()
+				.optional()
+				.describe(
+					"Refresh even when a valid token is cached. The engine uses the stored refresh token when the config allows it and falls back to a fresh grant. Default false - a cached, unexpired token is returned as-is."
+				),
+		},
+		handler: async (args, ctx, signal) => {
+			const config = isRecord(args.config) ? args.config : undefined;
+			if (!config) return errorResult('"config" must be an OAuth 2.0 config object.');
+			const grantType = str(config, "grantType");
+			if (grantType === "authorization_code") {
+				return errorResult(OAUTH2_INTERACTIVE_REFUSAL);
+			}
+			// Both URLs the engine may post to. The refresh URL defaults to the
+			// token URL engine-side, so it is only checked when it names a
+			// different host - a gate that read one of the two would be a gate a
+			// config can walk around.
+			for (const key of ["accessTokenUrl", "refreshTokenUrl"]) {
+				const url = str(config, key);
+				if (url === undefined || url === "") continue;
+				const gate = checkAllowlist(url, ctx.config);
+				if (!gate.ok) return errorResult(`${key}: ${gate.error!}`);
+			}
+			const payload: Record<string, unknown> = { config };
+			if (args.force === true) payload.force = true;
+			return callEngine(
+				() => ctx.client.fetchOAuth2Token(payload, signal),
+				(answer) => projectOAuth2Token(answer)
+			);
+		},
+	},
+	{
+		name: "get_oauth2_token_status",
+		category: "read",
+		invalidates: [],
+		description:
+			"Ask whether a token is cached for a cache key, and whether it has expired - the read behind 'is this flow failing because the token went stale?'. The cache key is the `cacheKey` fetch_oauth2_token returned; the engine derives it from the token URL, client id, credentials id and (for password grants) the username, so configs differing only in scope share one entry. An absent entry is an answer (`found: false`), not an error. The access token is never returned, only the shape of the entry - see fetch_oauth2_token.",
+		annotations: {
+			title: "OAuth 2.0 token status",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: { cacheKey: oauth2CacheKeyInput },
+		handler: (args, ctx, signal) =>
+			callEngine(
+				() => ctx.client.getOAuth2TokenStatus(requireStr(args, "cacheKey"), signal),
+				(answer) => projectOAuth2Status(answer)
+			),
+	},
+	{
+		name: "clear_oauth2_token",
+		category: "write",
+		invalidates: ["oauth"],
+		description:
+			"Drop the cached token for a cache key, so the next request that uses that config acquires a fresh one - the tool equivalent of the auth tab's Clear button. Use it when a provider has revoked or rotated credentials and the cache is still serving the old token. Idempotent: clearing a key nothing is cached under reports `deleted: false` rather than failing. No confirmation - nothing saved is lost, only a credential a re-fetch restores. GUARDED: requires write access to be enabled in Vayu Settings.",
+		annotations: {
+			title: "Clear OAuth 2.0 token",
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: { cacheKey: oauth2CacheKeyInput },
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			return callEngine(() =>
+				ctx.client.clearOAuth2Token(requireStr(args, "cacheKey"), signal)
+			);
 		},
 	},
 	{

--- a/app/src/lib/mcp-invalidation.test.ts
+++ b/app/src/lib/mcp-invalidation.test.ts
@@ -269,6 +269,33 @@ describe("invalidateForMcpEvent", () => {
 		});
 	});
 
+	test("an oauth change invalidates the token-status family", () => {
+		const { handled, keys } = keysFor({ entity: "oauth" });
+		expect(handled).toBe(true);
+		expect(keys).toEqual([queryKeys.oauth.all]);
+	});
+
+	test("the prefix reaches a status query cached under any key", () => {
+		// The event carries no cache key - a fetch's key is derived engine-side
+		// and appears only in the answer - so the prefix has to cover an entry
+		// stored under a key this side never saw.
+		const queryClient = new QueryClient();
+		const spy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+		queryClient.setQueryData(queryKeys.oauth.token("some-engine-derived-key"), {
+			found: true,
+		});
+
+		invalidateForMcpEvent(queryClient, { entity: "oauth" });
+
+		const [filters] = spy.mock.calls[0];
+		expect(
+			queryClient
+				.getQueryCache()
+				.findAll(filters)
+				.map((q) => q.queryKey)
+		).toContainEqual(queryKeys.oauth.token("some-engine-derived-key"));
+	});
+
 	test("an unknown entity is reported, not thrown", () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const { handled, keys } = keysFor({

--- a/app/src/lib/mcp-invalidation.ts
+++ b/app/src/lib/mcp-invalidation.ts
@@ -232,6 +232,25 @@ const INVALIDATORS: Record<
 			queryClient.removeQueries({ queryKey: queryKeys.mockServer.routes(event.mockId) });
 		}
 	},
+
+	/*
+	 * The engine's OAuth 2.0 token cache (issue #760). Invalidated at
+	 * `oauth.all` rather than at the one key the call named, because the event
+	 * carries no cache key: the key an agent clears is an argument, but the key
+	 * a `fetch_oauth2_token` writes is derived engine-side and only appears in
+	 * the answer, so a per-key hint would be present for one tool and absent for
+	 * the other - the shape that leaves a stale row exactly when it matters.
+	 * The prefix costs a refetch of every mounted status query, and only an open
+	 * Auth tab mounts one.
+	 *
+	 * The query polls at 30s on its own (`useOAuth2TokenStatusQuery`), so this
+	 * is about immediacy in the same way the `service` family is: an agent that
+	 * clears a token and says so must not leave the row that shows it valid
+	 * standing for another half minute.
+	 */
+	oauth: (queryClient) => {
+		void queryClient.invalidateQueries({ queryKey: queryKeys.oauth.all });
+	},
 };
 
 /**

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -2234,7 +2234,9 @@ export type McpDataEntity =
 	| "cookie"
 	| "config"
 	/** Engine-hosted local services: webhook inboxes, mock servers and mock issuers. */
-	| "service";
+	| "service"
+	/** The engine's OAuth 2.0 token cache - fetched, refreshed or cleared. */
+	| "oauth";
 
 /**
  * What the main process sends over `mcp:data-changed`. Invalidation only - the

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1317,6 +1317,7 @@ to keys through `lib/mcp-invalidation.ts`:
 | `cookie` | `cookies.all` | One key for every jar - the engine reports them together |
 | `config` | `config.all` | |
 | `service` | `inbox.list()`, `mockServer.list()`, `mockIssuer.list()`, plus a **removal** of `inbox.captures(inboxId)` for a named inbox and of `mockServer.routes(mockId)` for a named mock | The drawer and the Dock's count poll, so the lists are about immediacy; the captures cannot be invalidated, because `useInboxCapturesQuery` merges its fetched page into the cache and would union back the rows a `clear_inbox_captures` just destroyed, and a stopped mock's route table has no id left to refetch from |
+| `oauth` | `oauth.all` | The whole prefix, not the one key: `useOAuth2TokenStatusQuery` is keyed per cache key, and the key a `fetch_oauth2_token` writes under is derived engine-side and appears only in the answer, so the event carries no hint to narrow by. The query polls at 30s on its own, so this is immediacy - an agent that clears a token must not leave the row saying it is valid |
 
 The event carries no engine data, only which family went stale, so a row still
 reaches the UI by exactly one path: the query layer. Per-run reports and time

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -179,8 +179,11 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `set_run_baseline`     | write    | `PUT /runs/:id/baseline`                     | write toggle               |
 | `delete_run`           | write    | `GET /runs/:id` + `DELETE /runs/:id`         | write toggle + confirm     |
 | `update_engine_config` | write    | `POST /config`                               | write toggle               |
-| `start_load_run`       | load     | `POST /compose` + `POST /runs`, or (with `scenario`) `GET /requests?…` + `POST /compose` (×N) + `POST /runs` | allowlist + caps + confirm; optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity`, narrowed to the middle three for a scenario |
+| `start_load_run`       | load     | `POST /compose` + `POST /runs`, or (with `scenario`) `GET /requests?…` + `POST /compose` (×N) + `POST /runs` | allowlist + caps + confirm; optional `thresholds` budgets and `monitor` server-vitals block; `mode` accepts `constant_rps` \| `constant_concurrency` \| `ramp_up` \| `iterations` \| `capacity`, narrowed to the middle three for a scenario; the recording knobs and `comment` below apply to both shapes, the redirect policy to a single target only |
 | `stop_run`             | load     | `POST /runs/:id/stop`                        | -                          |
+| `fetch_oauth2_token`   | execute  | `POST /oauth2/token`                         | allowlist, on `accessTokenUrl` **and** `refreshTokenUrl`; `authorization_code` refused before the call; the access token is never returned |
+| `get_oauth2_token_status` | read  | `GET /oauth2/token?key=`                     | - (an absent entry is `found: false`, not a 404); the access token is never returned |
+| `clear_oauth2_token`   | write    | `DELETE /oauth2/token?key=`                  | write toggle; idempotent - `deleted: false` when nothing was cached |
 | `start_mock_issuer`    | execute  | `POST /mock-issuer/start`                    | - (loopback-only listener, so no allowlist entry applies); limits are the engine's - 31-day expiry, 60s `slowMs`, 32 clients, 8 concurrent issuers |
 | `list_mock_issuers`    | read     | `GET /mock-issuer`                           | -                          |
 | `stop_mock_issuer`     | execute  | `POST /mock-issuer/:id/stop`                 | - (unknown id is a `404`, surfaced as a tool error) |
@@ -210,6 +213,29 @@ Notes:
   the 60s other modes fall back to), so a cap between those two values still
   injects an explicit `duration` when the agent omits one. `get_live_metrics` is a **bounded snapshot** (SSE
   read with a time budget), not a stream - `tools/call` stays request/response.
+- **What a load run *keeps* is settable too** (issue #760), which is what the
+  MCP surface was missing rather than any part of the load shape:
+  `successSamplePeriod` (the engine's `success_sample_rate` - a **period**, keep
+  1 in N, not a percentage; the argument is named for what the value means and
+  the payload key stays the engine's), `slowRequestThresholdMs`,
+  `saveTimingBreakdown` and `comment`. All four reach a **scenario** run too:
+  both executors read them off the one `RunContext`, and `comment` is lifted
+  into the run summary and the report's `metadata.configuration` whichever
+  produced the run. Bounds mirror `validate_run_config`, so a value the schema
+  accepts is one `POST /runs` accepts, and an absent knob stays absent - each has
+  an engine default a stated value would overwrite.
+  The **redirect policy** (`followRedirects` / `maxRedirects`) belongs to the
+  request half instead: it rides through `POST /compose` beside the method and
+  the body, overriding a saved request's stored policy or supplying the only one
+  an ad-hoc target has. A scenario run refuses both by name, as it does every
+  other single-target field - each step keeps the policy stored on it.
+  `maxRedirects` is bounded 0-100 here because `POST /runs` has no guard of its
+  own and the value reaches `CURLOPT_MAXREDIRS`, where a negative means
+  *unlimited*.
+  **There is no per-run timeout, and that is not an omission**: the engine has
+  no such field - every transfer is bounded by the `defaultTimeout` setting
+  (`resolve_request_timeout_ms`), which `update_engine_config` changes. Recorded
+  here so it is not re-derived as a gap each time the schema is read.
 - **`get_run_report` carries contract coverage** for a run of a collection bound
   to an OpenAPI document (issue #629): which of the contract's operations the run
   exercised, which of their declared responses it saw, and any statuses the
@@ -435,6 +461,33 @@ Notes:
   could not be read), because a matrix whose `total` silently excludes nested
   folders reads as a whole-collection pass. Requests run serially, so a large
   collection takes as long as its requests do added together.
+- **The OAuth 2.0 token tools** (issue #760) are how an agent gets a token
+  problem named instead of discovering it as a wall of 401s inside a run:
+  `fetch_oauth2_token` acquires (or force-refreshes) a token for a config and
+  caches it engine-side, `get_oauth2_token_status` says whether an entry exists
+  and whether it has expired, and `clear_oauth2_token` drops one. The config is
+  the same block a saved request's `auth` carries, so it can be copied out of
+  `list_requests` verbatim; the **cache key is the engine's**
+  (`accessTokenUrl` + `clientId` + `credentialsId` + username), so configs
+  differing only in scope share an entry and a distinct `credentialsId` is what
+  separates them.
+  Two rules here are security decisions rather than plumbing, and both are
+  stated in the tool descriptions so an agent reads them before it reads a
+  refusal. **No tool returns access-token bytes.** The engine is what applies a
+  token to a request, so the bytes buy an agent nothing it can use through Vayu,
+  while handing them over would turn a credential the *user* acquired into
+  something an agent can carry off the machine; what comes back is the entry's
+  shape - key, type, scope, expiry, whether a refresh token came with it - plus
+  an explicit `accessTokenWithheld`, because an agent that finds no token and is
+  not told why concludes the acquisition half-failed. And **the
+  `authorization_code` grant is refused before the engine is called**, not
+  merely because the browser exchange is one MCP cannot drive: `acquire_token`
+  answers a cache hit *before* it looks at the grant, so a call naming a config
+  that happened to match an entry the user authorized interactively would
+  otherwise reach into it. The refusal names the app's Auth tab as the place to
+  authorize, and the entry that lands there is the one these tools then read.
+  The allowlist gate covers `refreshTokenUrl` as well as `accessTokenUrl` - a
+  gate that read one of two URLs is a gate a config can walk around.
 - **The mock-issuer tools** let an agent asked to "test this auth flow" mint its
   own tokens: `start_mock_issuer` stands up a
   [local OAuth 2.0 issuer](api-reference.md#local-mock-issuer) and returns its
@@ -629,6 +682,15 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   request the call sent. A `postRequestScript` reads the same set as
   `pm.request.headers` (see
   [scripting.md](scripting.md#request-object-pmrequest)).
+- **Transport fields** - `httpVersion` rides the inline overlay for both tools,
+  and `start_load_run` adds `followRedirects` / `maxRedirects` (issue #760).
+  They belong here rather than beside the load shape because they describe the
+  *request*: `POST /compose` emits all three on a stored request under the
+  never-elided rule, so an agent's value has to be laid over the composed
+  payload the same way a URL override is. A URL-only run has no stored row
+  behind it, which makes this the only way its redirect policy gets stated at
+  all. `verifySSL` is the one transport field neither tool writes yet -
+  [#795](https://github.com/athrvk/vayu/issues/795).
 - **Streaming** - `run_request` takes `stream: true` for a `text/event-stream`
   endpoint (issue #575). `tools/call` is request/response, so the tool does not
   stream to the agent: it starts the run, reads the relay for at most
@@ -822,6 +884,7 @@ Read-only Vayu data an agent can attach as context (`resources.ts`):
 | `vayu://environments`       | All environments.                |
 | `vayu://config`             | Engine configuration entries.    |
 | `vayu://scripting/completions` | The script sandbox's full API surface (see below). |
+| `vayu://scripting/types`    | The same surface as TypeScript declarations - the `.d.ts` the app's editor loads, so a call's parameters and return type are the running engine's. |
 | `vayu://run/{runId}/report` | A run's full report (templated). |
 
 The templated report resource has a **list** callback (enumerates recent runs so
@@ -838,6 +901,16 @@ anything else a script in the app can. What an agent lacked was any way to
 sentences in those fields' descriptions, so `pm.expect` chains,
 `pm.response.to.*`, the variable scopes and `pm.crypto` were invisible and
 simply never attempted.
+
+Two resources, because a name and a signature are different questions.
+`vayu://scripting/completions` re-serves `GET /scripting/completions` (Monaco's
+own fields projected away) and answers *what exists*;
+`vayu://scripting/types` re-serves `GET /scripting/types`, the `.d.ts` the
+engine generates from the same table, and answers *what it takes and returns*
+(issue #760). Both throw rather than serve a partial surface - an agent reading
+a truncated API list concludes the sandbox cannot do what it can - and neither
+holds a copy of the surface here, which is the whole point: the app's own
+quick-reference panel had gone stale before #233 and this is what replaced it.
 
 #### `pm.sendRequest` is refused for MCP-started runs
 
@@ -904,7 +977,7 @@ Server-provided starting points a user picks in their client (`prompts.ts`):
 | Prompt                 | Arguments                | Produces                                                    |
 | ---------------------- | ------------------------ | ----------------------------------------------------------- |
 | `summarize_run`        | `runId`                  | The run report + a "summarize p50/p95/p99, errors, health". |
-| `compare_runs`         | `baseRunId, targetRunId` | The computed delta + "did this regress?".                   |
+| `compare_runs`         | `baseRunId?, targetRunId` | The computed delta + "did this regress?". An omitted `baseRunId` resolves the target's pinned baseline through the same `resolveBaseline` the tool uses - the prompt demanded an id Vayu already knew (#760). |
 | `diagnose_errors`      | `runId`                  | The report + an error-focused diagnosis prompt.             |
 | `suggest_load_profile` | `url, goal?`             | Guidance to design a `start_load_run` (no engine data).     |
 
@@ -1111,7 +1184,8 @@ collection tree until some unrelated mutation happened to refetch the lists.
 Each tool declares the data families it changes (`invalidates` in `tools.ts`)
 and `dispatchTool` - the single dispatch path - sends one `mcp:data-changed` per
 family after a call that did **not** return an error. The event names a family
-(`collection`, `request`, `environment`, `run`, `cookie`, `config`, `service`)
+(`collection`, `request`, `environment`, `run`, `cookie`, `config`, `service`,
+`oauth`)
 plus the `collectionId` / `requestId` / `runId` / `inboxId` / `mockId` the call
 itself named; it carries no engine data, so the
 renderer still reads every row through its query layer. The five hints are read
@@ -1129,7 +1203,13 @@ refetched - a cleared capture list would union its destroyed rows straight back,
 and a stopped mock's route table has no live id left to refetch from. `service`
 is deliberately one family covering inboxes, mock servers and issuers, because
 the surfaces that read them - the Services drawer and the Dock's
-running-services count - ask "what is listening" rather than "which kind". The renderer side, including
+running-services count - ask "what is listening" rather than "which kind".
+`oauth` (issue #760) carries **no** hint of its own even though a cache key
+exists: an agent names the key it clears, but the key a `fetch_oauth2_token`
+writes under is derived engine-side and appears only in the answer, so a hint
+would be present for one tool and absent for the other - the shape that leaves
+a stale row exactly when it matters. The family is invalidated at its prefix
+instead. The renderer side, including
 which query keys each family maps to, is in
 [`docs/app/state-management.md`](../app/state-management.md).
 


### PR DESCRIPTION
## Description

The S6 batch of epic #753: four smaller parity items sharing `start_load_run`'s region and the read surface.

**Plan.** The root cause is not one omission but three of a kind - the load dialog has always sent knobs that decide what a run *keeps* (rather than what it sends), the app has always driven the engine's OAuth 2.0 token cache, and the engine has always served the sandbox's `.d.ts`; the MCP layer followed none of them, so an agent could shape a run but not ask it to capture the slow tail, could pass an oauth2 block but not find out why it was 401ing, and could read the sandbox's names but never a signature. The approach is additive at the tool/resource layer over endpoints that already exist: extend `start_load_run`'s schema and map the four knobs onto the engine's own config keys, add three tools over `/oauth2/token`, and add one resource over `GET /scripting/types`. The alternative I rejected for the token tools was returning the access token the engine hands back - it is what `POST /oauth2/token` answers with, and passing it through would have been the smaller diff - but the engine is what applies a token to a request, so the bytes buy an agent nothing it can use through Vayu, while `acquire_token` answers a **cache hit before it looks at the grant**, which would have made `fetch_oauth2_token` a way to read back a credential the user acquired in a browser flow no agent could complete. Redaction plus an up-front `authorization_code` refusal closes that shape instead.

**What changed**

- **Recording knobs.** `successSamplePeriod`, `slowRequestThresholdMs`, `saveTimingBreakdown` and `comment`, forwarded as `success_sample_rate` / `slow_threshold_ms` / `save_timing_breakdown` / `comment`. The argument is named for what the value means and the payload key stays the engine's: `success_sample_rate` is a **period** (keep 1 in N), not the percentage its name suggests - the app's own `StartLoadTestRequest` carries a comment saying so, and `LoadTestConfigDialog` converts from the slider's percentage before sending. Bounds mirror `validate_run_config` (1-100000, 0-86400000), not the dialog's narrower sliders, so a value the schema accepts is one `POST /runs` accepts. All four apply to a **scenario** run as well - both executors read them off the one `RunContext`, and `comment` is lifted into the run summary and `metadata.configuration` whichever produced the run - so forwarding on one path only would have been a knob that silently did nothing on the other.
- **Redirect policy.** `followRedirects` / `maxRedirects` on `start_load_run`, through `readRequestOverrides` and so through `POST /compose`, beside `httpVersion`: they describe the *request*, the engine emits them on every composed payload under the never-elided rule, and a URL-only run has no stored row whose policy it could inherit. A scenario run refuses both by name, as it does every other single-target field. `maxRedirects` is bounded 0-100 because `POST /runs` has **no** guard of its own and the value reaches `CURLOPT_MAXREDIRS`, where a negative means unlimited.
- **OAuth 2.0 token tools.** `fetch_oauth2_token` (execute; allowlist checked on `accessTokenUrl` **and** `refreshTokenUrl` - a gate that read one of two URLs is a gate a config can walk around), `get_oauth2_token_status` (read; an absent entry is `found: false`, not an error), `clear_oauth2_token` (write toggle, idempotent, no confirmation - the same posture `clear_cookies` takes for the same reason). Neither returns access-token bytes; the projection keeps the entry's shape and states `accessTokenWithheld`, because an agent that finds no token and is not told why concludes the acquisition half-failed. The interactive grant is refused with the app's Auth tab named as where to do it.
- **`vayu://scripting/types`.** The `.d.ts` the app's editor feeds to its TypeScript worker, on the completions resource's non-truncation posture (throw rather than serve a partial surface, `resources.ts` precedent). Two resources because a name and a signature are different questions.
- **Prompts.** `suggest_load_profile` now names all five modes - it omitted `capacity` for as long as the tool has had it - and says when to reach for it rather than only listing it; the test measures the enumeration against `safety.ts`'s `KNOWN_LOAD_MODES`, the one list that cannot fall behind the engine. `compare_runs`' `baseRunId` is optional and resolves the target's pinned baseline through the **same** `resolveBaseline` the tool uses (now exported rather than copied), so the prompt stops demanding an id Vayu already knew.

**App changes (required by the issue).** The issue said "none - verify the token-status card polls or listens". It does both: `useOAuth2TokenStatusQuery` is keyed at `queryKeys.oauth.token(cacheKey)` and polls at 30s. That is long enough for an agent to clear a token, report it, and leave the row saying the entry is valid, so the two writing tools declare a new **`oauth`** data family and the renderer invalidates `queryKeys.oauth.all` on it. Invalidating `config` (the issue's fallback suggestion) would have been an unrelated cache. The prefix rather than the one key, because the event carries no cache key: an agent names the key it clears, but the key a fetch writes under is derived engine-side and appears only in the answer - a hint present for one tool and absent for the other is the shape that leaves a stale row exactly when it matters.

**Deliberate deviations from the issue spec**

- The issue named the argument `successSampleRate` with a range of 1-100. The stored field is a period with an engine range of 1-100000, and the app converts a percentage into it before sending; a 1-100 "rate" would have refused legal values and invited an agent to pass 50 meaning half. Named `successSamplePeriod` and described as the period it is.
- The issue offered "align the `compare_runs` prompt to accept an omitted base, or state why not". Aligned.
- No new safety-config entry. The issue anticipated one only for a per-call `verifySSL` on `run_request`, which belongs to #795 (and to #706's transport epic), not here.

**Rebased onto #796.** Document CRUD parity landed while this was open and both branches added a block after `authInput` in `tools.ts` - kept both, in master's order then this branch's. One de-duplication the merge made necessary: `requestSettingsInput`'s `maxRedirects` bound and this branch's `MAX_REDIRECTS_BOUND` were the same engine clamp written twice in one file, so the schema now reads the constant.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Local, on the merged tree (base `f79fd6b`):

- `cd app && pnpm test` - **508 files, 5536 tests passed**. Per-file test counts were checked against both merge parents to prove the merge dropped nothing: every changed test file equals `master + this branch - base`.
- `cd app && pnpm type-check` - clean. `data-changed.conformance.test.ts` failed to compile until the renderer's union named `oauth`, which is the guard doing its job.
- `cd app && pnpm lint` and `pnpm format:check` - clean, zero warnings. `docs/engine/mcp.md` and `docs/app/state-management.md` were already not prettier-clean before this branch and were left unformatted per the repo rule.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean, before and after the merge.
- No engine build or ctest run: the diff is TypeScript and Markdown only, so no C++ test could change colour.

New coverage worth naming, each written so reverting the fix fails it:

- The three recording knobs arrive under the engine's snake_case keys **and** the camelCase argument names do not also reach the engine; a knob the caller did not name stays absent rather than being defaulted.
- `successSamplePeriod: 0` is refused at the schema (it is a modulo divisor engine-side), `slowRequestThresholdMs: 0` is accepted and `-1` refused, `maxRedirects: -1` refused.
- A scenario load run carries all four knobs, and refuses `followRedirects` with the reason naming the saved request.
- `fetch_oauth2_token` never returns the bearer: the result is asserted whole, so a passthrough fails it. `force: false` is not forwarded; an `authorization_code` config is refused with nothing reaching the engine; a `refreshTokenUrl` on an off-list host is refused after the token URL passed.
- `clear_oauth2_token` is refused while writes are off with nothing reaching the engine.
- `vayu://scripting/types` serves a declaration the app has never heard of, and throws on an empty or missing `typeDefinitions` rather than serving a partial surface.
- The `oauth` invalidator reaches a status query cached under a key this side never saw.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #760