### PR TITLE
fix(app/services): count mock servers in the Dock's running-services indicator

### DIFF
--- a/app/src/components/layout/Dock.services.test.tsx
+++ b/app/src/components/layout/Dock.services.test.tsx
@@ -25,7 +25,8 @@
  *
  * The transport is mocked and the real queries and hooks run, so the count is
  * computed the way the app computes it - including the asymmetry between the
- * two lists (an inbox stays listed once stopped, an issuer does not).
+ * three lists (an inbox stays listed once stopped, an issuer or a mock server
+ * does not).
  *
  * Two later claims from issue #555, both about the indicator telling the truth:
  * a dead engine is running nothing whatever the query cache still holds, and an
@@ -37,11 +38,12 @@ import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/re
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui";
 import { useEngineStore, useLayoutStore } from "@/stores";
-import type { Inbox, MockIssuer } from "@/types";
+import type { Inbox, MockIssuer, MockServer } from "@/types";
 import { Dock } from "./Dock";
 
 const listInboxes = vi.fn();
 const listMockIssuers = vi.fn();
+const listMockServers = vi.fn();
 
 vi.mock("@/services/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/services/api")>();
@@ -51,6 +53,7 @@ vi.mock("@/services/api", async (importOriginal) => {
 			...actual.apiService,
 			listInboxes: () => listInboxes(),
 			listMockIssuers: () => listMockIssuers(),
+			listMockServers: () => listMockServers(),
 		},
 	};
 });
@@ -90,6 +93,22 @@ function issuer(overrides: Partial<MockIssuer> = {}): MockIssuer {
 	};
 }
 
+function mockServer(overrides: Partial<MockServer> = {}): MockServer {
+	return {
+		mockId: "mock_a",
+		collectionId: "col_1",
+		collectionName: "Pet Store",
+		url: "http://127.0.0.1:43100",
+		port: 43100,
+		latencyMs: 0,
+		errorRatePct: 0,
+		routeCount: 3,
+		routesWithoutExample: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
 const renderDock = () => {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(
@@ -105,6 +124,7 @@ beforeEach(() => {
 	cleanup();
 	listInboxes.mockReset().mockResolvedValue([]);
 	listMockIssuers.mockReset().mockResolvedValue([]);
+	listMockServers.mockReset().mockResolvedValue([]);
 	useLayoutStore.setState({ drawerOpen: true, drawerView: "collections" });
 	// The count is gated on this, and the store's own default is `false` - a
 	// list that answered at all came from an engine that was up.
@@ -152,6 +172,24 @@ describe("the running-services indicator", () => {
 	it("counts inboxes and issuers together, and pluralises", async () => {
 		listInboxes.mockResolvedValue([inbox()]);
 		listMockIssuers.mockResolvedValue([issuer(), issuer({ issuerId: "iss_b" })]);
+		renderDock();
+		expect(await screen.findByText("3 services")).toBeInTheDocument();
+	});
+
+	/*
+	 * A mock server is the third listener the engine holds, and the count read
+	 * past it entirely (issue #792): a mock started from the collection header,
+	 * the drawer or an MCP tool held a port while the Dock said nothing was
+	 * running, disagreeing with the drawer it opens.
+	 */
+	it("counts a running mock server, alone and alongside the other two", async () => {
+		listMockServers.mockResolvedValue([mockServer()]);
+		renderDock();
+		expect(await screen.findByText("1 service")).toBeInTheDocument();
+
+		cleanup();
+		listInboxes.mockResolvedValue([inbox()]);
+		listMockIssuers.mockResolvedValue([issuer()]);
 		renderDock();
 		expect(await screen.findByText("3 services")).toBeInTheDocument();
 	});

--- a/app/src/components/layout/variables-icon.test.tsx
+++ b/app/src/components/layout/variables-icon.test.tsx
@@ -54,10 +54,11 @@ vi.mock("@/queries", () => ({
 		enabled: false,
 	}),
 	runDetailOptions: () => ({ queryKey: ["run"], queryFn: async () => undefined, enabled: false }),
-	// The Dock's running-services indicator reads both service lists; with none
-	// running it renders nothing, which is the state this file wants anyway.
+	// The Dock's running-services indicator reads all three service lists; with
+	// none running it renders nothing, which is the state this file wants anyway.
 	useInboxesQuery: () => ({ data: [] }),
 	useMockIssuersQuery: () => ({ data: [] }),
+	useMockServersQuery: () => ({ data: [] }),
 }));
 
 vi.mock("@/modules/variables/variables-store", () => ({

--- a/app/src/modules/README.md
+++ b/app/src/modules/README.md
@@ -60,8 +60,8 @@ Some modules have components displayed in both the sidebar and main content area
 - **Components:** `ServicesPanel.tsx` - the local services (webhook inboxes, OAuth issuers):
   status, copy-URL, start/stop, and the issuer's start dialog
 - **Also exports** `useRunningServiceCount()`, which the Dock's ambient indicator reads - one
-  count, because the two lists disagree on their own terms (a stopped inbox stays listed, a
-  stopped issuer does not)
+  count over all three lists, because they disagree on their own terms (a stopped inbox stays
+  listed, a stopped issuer or mock server does not)
 - **Usage:**
     ```tsx
     import { ServicesPanel, useRunningServiceCount } from "@/modules/services";

--- a/app/src/modules/services/useRunningServices.test.tsx
+++ b/app/src/modules/services/useRunningServices.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The count has to name every local service the engine holds (issue #792).
+ *
+ * The hook counted inboxes and issuers and not mock servers, so a running mock -
+ * a bound loopback listener holding a port, which is exactly what the indicator
+ * exists to surface - contributed zero, and the Dock disagreed with the drawer
+ * it opens. Mutation-check: drop the `mocks.length` term and the first case
+ * below reads 2 instead of 3.
+ *
+ * The transport is mocked and the real query hooks run, so the three lists are
+ * combined the way the app combines them - including their asymmetry: an inbox
+ * stays listed once stopped and carries `running`, while a stopped issuer or
+ * mock is gone from the engine's list entirely.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useEngineStore } from "@/stores";
+import type { Inbox, MockIssuer, MockServer } from "@/types";
+import { useRunningServiceCount } from "./useRunningServices";
+
+const listInboxes = vi.fn();
+const listMockIssuers = vi.fn();
+const listMockServers = vi.fn();
+
+vi.mock("@/services/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/services/api")>();
+	return {
+		...actual,
+		apiService: {
+			...actual.apiService,
+			listInboxes: () => listInboxes(),
+			listMockIssuers: () => listMockIssuers(),
+			listMockServers: () => listMockServers(),
+		},
+	};
+});
+
+function inbox(overrides: Partial<Inbox> = {}): Inbox {
+	return {
+		inboxId: "inbox_a",
+		url: "http://127.0.0.1:41234/",
+		bind: "127.0.0.1",
+		port: 41234,
+		running: true,
+		loopback: true,
+		captureCount: 0,
+		response: { status: 200, body: "", headers: {}, delayMs: 0 },
+		...overrides,
+	};
+}
+
+function issuer(overrides: Partial<MockIssuer> = {}): MockIssuer {
+	return {
+		issuerId: "iss_a",
+		issuerUrl: "http://127.0.0.1:42000",
+		tokenUrl: "http://127.0.0.1:42000/token",
+		authorizeUrl: "http://127.0.0.1:42000/authorize",
+		signingKey: "k".repeat(32),
+		port: 42000,
+		expiresInSeconds: 3600,
+		failureMode: "none",
+		slowMs: 0,
+		issueRefreshTokens: true,
+		clientCount: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
+function mockServer(overrides: Partial<MockServer> = {}): MockServer {
+	return {
+		mockId: "mock_a",
+		collectionId: "col_1",
+		collectionName: "Pet Store",
+		url: "http://127.0.0.1:43100",
+		port: 43100,
+		latencyMs: 0,
+		errorRatePct: 0,
+		routeCount: 3,
+		routesWithoutExample: 0,
+		createdAt: 1700000000000,
+		...overrides,
+	};
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+function countHook() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return { client, ...renderHook(() => useRunningServiceCount(), { wrapper: wrapper(client) }) };
+}
+
+beforeEach(() => {
+	listInboxes.mockReset().mockResolvedValue([]);
+	listMockIssuers.mockReset().mockResolvedValue([]);
+	listMockServers.mockReset().mockResolvedValue([]);
+	// The count is gated on this, and the store's own default is `false` - a
+	// list that answered at all came from an engine that was up.
+	useEngineStore.setState({ isEngineConnected: true, engineError: null });
+});
+
+describe("useRunningServiceCount", () => {
+	it("counts a mock server beside the inboxes and issuers, and not a stopped inbox", async () => {
+		listInboxes.mockResolvedValue([inbox(), inbox({ inboxId: "inbox_b", running: false })]);
+		listMockIssuers.mockResolvedValue([issuer()]);
+		listMockServers.mockResolvedValue([mockServer()]);
+
+		const { result } = countHook();
+
+		await waitFor(() => expect(result.current).toBe(3));
+	});
+
+	it("counts a mock server on its own - the case the Dock reported as nothing running", async () => {
+		listMockServers.mockResolvedValue([mockServer()]);
+
+		const { result } = countHook();
+
+		await waitFor(() => expect(result.current).toBe(1));
+	});
+
+	/*
+	 * A stopped mock is *gone* from `GET /mock` rather than flagged - its record
+	 * dies with its listener - so the count falls out of the shorter list, with
+	 * no `running` filter to apply.
+	 */
+	it("drops the mock again once it is stopped", async () => {
+		listMockServers.mockResolvedValue([mockServer(), mockServer({ mockId: "mock_b" })]);
+
+		const { client, result } = countHook();
+		await waitFor(() => expect(result.current).toBe(2));
+
+		listMockServers.mockResolvedValue([mockServer()]);
+		await client.invalidateQueries();
+
+		await waitFor(() => expect(result.current).toBe(1));
+	});
+
+	/*
+	 * Services are engine-*process* state, so a disconnected engine is running
+	 * none of them - but TanStack holds the last good list through failed
+	 * refetches. Nothing covered the gate at this level before.
+	 */
+	it("reports nothing while the engine is down, whatever the cache still holds", async () => {
+		listMockServers.mockResolvedValue([mockServer()]);
+
+		const { result } = countHook();
+		// The cache is warm first, so this proves the gate and not a slow query.
+		await waitFor(() => expect(result.current).toBe(1));
+
+		useEngineStore.setState({ isEngineConnected: false });
+
+		await waitFor(() => expect(result.current).toBe(0));
+	});
+});

--- a/app/src/modules/services/useRunningServices.ts
+++ b/app/src/modules/services/useRunningServices.ts
@@ -9,16 +9,16 @@
  * How many local services are running, for the Dock's ambient indicator.
  *
  * One hook rather than each surface counting for itself: the drawer and the
- * indicator have to agree about what "running" means, and they disagree on the
- * two lists' own terms. An inbox keeps its record after it is stopped (`running`
- * is the flag that says so); a stopped issuer is *gone* from the engine's list,
- * so every issuer listed is a running one.
+ * indicator have to agree about what "running" means, and the three lists
+ * disagree on their own terms. An inbox keeps its record after it is stopped
+ * (`running` is the flag that says so); a stopped issuer or mock server is
+ * *gone* from the engine's list, so every one of those listed is a running one.
  *
- * Both reads go through the same query keys the drawer uses, so mounting this
- * in the Dock costs one shared poll, not a second set of requests.
+ * All three reads go through the same query keys the drawer uses, so mounting
+ * this in the Dock costs one shared poll, not a second set of requests.
  *
- * **A dead engine is running nothing, whatever the cache still holds.** Both
- * lists are engine-*process* state, so when the engine goes down every service
+ * **A dead engine is running nothing, whatever the cache still holds.** All
+ * three lists are engine-*process* state, so when the engine goes down every service
  * it was holding went down with it - but TanStack keeps the last good data
  * through failed refetches, which is right for a list the user can still read
  * and wrong for a count that claims something is listening. The Dock said "2
@@ -27,14 +27,15 @@
  * later reader inherits the answer instead of re-deriving the caveat.
  */
 
-import { useInboxesQuery, useMockIssuersQuery } from "@/queries";
+import { useInboxesQuery, useMockIssuersQuery, useMockServersQuery } from "@/queries";
 import { useEngineStore } from "@/stores";
 
 export function useRunningServiceCount(): number {
 	const isEngineConnected = useEngineStore((s) => s.isEngineConnected);
 	const { data: inboxes = [] } = useInboxesQuery();
 	const { data: issuers = [] } = useMockIssuersQuery();
+	const { data: mocks = [] } = useMockServersQuery();
 
 	if (!isEngineConnected) return 0;
-	return inboxes.filter((inbox) => inbox.running).length + issuers.length;
+	return inboxes.filter((inbox) => inbox.running).length + issuers.length + mocks.length;
 }

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -720,10 +720,11 @@ both activate it.
   beside a greyed-out Start says something is wrong and never which field or why, and `aria-invalid`
   alone announces "invalid" with no correction. Mounted only while open, so the mount is the reset.
 - `useRunningServices.ts` - `useRunningServiceCount()`, shared by the drawer and the Dock. One place
-  because the two lists disagree on their own terms: a stopped inbox stays listed with
-  `running: false`, while a stopped issuer is gone from the engine's list entirely - and because a
-  **disconnected engine is running none of them**, which is the gate this hook holds so that no
-  caller renders a green count off a stale cache (issue #555).
+  because the three lists disagree on their own terms: a stopped inbox stays listed with
+  `running: false`, while a stopped issuer or mock server is gone from the engine's list entirely -
+  and because a **disconnected engine is running none of them**, which is the gate this hook holds
+  so that no caller renders a green count off a stale cache (issue #555). The mock-server list was
+  missing from the sum until issue #792, so a mock holding a port counted as nothing.
 - `failure-modes.ts` - the four `failureMode` labels, the engine's bounds, and the row's
   one-line summary. Shared so the badge, the live switch and the dialog cannot name a mode
   differently.


### PR DESCRIPTION
## Description

`useRunningServiceCount` counted two of the three local services the engine hosts, so a running collection mock server contributed zero to the Dock's ambient indicator.

**Plan.** The root cause is a hook that was written against the two services that existed when it was written (#502) and never revisited when mock servers arrived (#481 phase 2) - `ServicesPanel.tsx:676` reads `useMockServersQuery()` and lists mocks beside inboxes and issuers, while the hook the same module exports does not, so the Dock's count disagreed with the drawer it opens. That is precisely the split the hook's own doc comment says it exists to prevent ("the drawer and the indicator have to agree about what 'running' means"), and the gap is not MCP-specific: a mock started from the collection header, the drawer or curl was uncounted the same way. The approach is the one the hook already uses for issuers - add the query and take its length. A stopped mock is *gone* from `GET /mock` rather than flagged (`mock_server.cpp` keeps no stopped state, and `MockServer` carries no `running` field), so there is nothing to filter; the alternative I rejected was a `running`-style filter mirroring the inbox term, which would have implied a stopped-mock record the engine never serves. The existing disconnected-engine gate (#555) covers the new term unchanged, since a mock is engine-*process* state like the other two, and the query shares `queryKeys.mockServer.list()` with the drawer, so mounting it in the Dock costs no extra poll.

**Blast radius.** `useRunningServiceCount` has exactly one caller, `RunningServices` in `Dock.tsx:267`, which renders nothing at 0 and pluralises above 1 - both unchanged. Two existing test files mount the Dock through a stub that had to learn about the third list: `Dock.services.test.tsx` mocks the transport (`listMockServers` added, defaulted to `[]` in `beforeEach`, so every existing case still describes the state it named), and `variables-icon.test.tsx` mocks `@/queries` wholesale with a factory, where a missing export is a crash rather than an empty list. The three other Dock test files mock neither and are unaffected.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Local, on this branch:

- `cd app && pnpm test` - **508 files, 5479 tests passed** (up from 507 / 5470 at `a48d08d`; +9 across the new hook file and `Dock.services.test.tsx`).
- `cd app && pnpm type-check` - clean (renderer, electron, electron-test projects).
- `cd app && pnpm lint` - clean, zero warnings.
- `npx prettier --check` on every file touched. `docs/app/COMPONENTS.md` was already not prettier-clean at `a48d08d` and was left unformatted per the repo rule.
- No engine build or ctest run: the diff is TypeScript and Markdown only, so no C++ test could change colour.
- `mkdocs build --strict` could not run here - `pip install mkdocs-material mkdocs-minify-plugin` fails building the `jsmin` / `csscompressor` wheels in this environment. The docs edit is prose inside an existing bullet with no new link, heading or nav entry, so there is no new way for the strict build to fail; CI's docs job covers it.

New coverage, mutation-checked - dropping the `mocks.length` term fails 5 of these:

- `useRunningServices.test.tsx` (new; the hook had no test file at all): one running mock, one running inbox, one stopped inbox and one issuer sum to **3**; a mock on its own reads **1** (the case the Dock reported as nothing running); stopping one of two mocks - the shorter list, no flag - drops the count to 1; and a disconnected engine reports 0 with a warm cache, which nothing covered at this level before.
- `Dock.services.test.tsx`: a running mock raises the indicator on its own and alongside the other two, so the assertion is on the rendered chip rather than the hook's return.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #792

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH9BAPBFNpGQN9i7JgrLb3)_