### PR TITLE
fix(app/ui): a tooltip hint has to read on the tooltip

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -101,6 +101,14 @@ white-on-`--primary` never occurs because fills use `--primary-fill`).
   between them. → `drawer-row-hit-area.test.tsx`. Assert the height as a
   `className`, not `offsetHeight`: jsdom has no layout and reports 0 for
   everything, so an `offsetHeight` guard passes while measuring nothing.
+- **Inside a tooltip, every colour is a tint of `--primary-foreground`.**
+  `TooltipContent` paints `bg-primary-fill`, where the canvas-tuned
+  `--muted-foreground` measures 1.04–2.27:1 - a disappearance, not a
+  de-emphasis, and it hid a URL the tooltip existed to show. Secondary lines use
+  the `TooltipHint` primitive, which holds the one tint.
+  → `tooltip-hint-contrast.test.ts` (ratios per scheme, plus a scan of every
+  tooltip block in `src`), `tooltip-icon-button.test.tsx` (the rendered class,
+  which the scan cannot see)
 - **Adding an accent scheme:** `constants/color-schemes.ts` + `index.css`, both
   themes, nothing else. → `color-schemes.test.ts`
 - **A `Badge` that paints its own `bg-` must be `variant="chip"`.** Every other

--- a/app/src/components/shared/VariableInput/EditableVariable.tsx
+++ b/app/src/components/shared/VariableInput/EditableVariable.tsx
@@ -19,7 +19,13 @@
  * written to - happen here.
  */
 
-import { VariablePopover, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
+import {
+	VariablePopover,
+	Tooltip,
+	TooltipContent,
+	TooltipHint,
+	TooltipTrigger,
+} from "@/components/ui";
 import type { VariableScope } from "@/components/ui";
 import { cn } from "@/lib/utils";
 // The specific module, not the `../../context` barrel - matching the sibling
@@ -155,9 +161,7 @@ export default function EditableVariable({
 									{secret ? "secret" : value || "empty"}
 								</span>
 								{sourceName && (
-									<span className="shrink-0 text-primary-foreground/70">
-										{sourceName}
-									</span>
+									<TooltipHint className="shrink-0">{sourceName}</TooltipHint>
 								)}
 							</span>
 						)}

--- a/app/src/components/shared/VariableInput/RuntimeToken.tsx
+++ b/app/src/components/shared/VariableInput/RuntimeToken.tsx
@@ -30,7 +30,7 @@
  * tooltip that says where the value will come from.
  */
 
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui";
+import { Tooltip, TooltipContent, TooltipHint, TooltipTrigger } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { DataTokenTone } from "@/lib/data-contract";
 import { DATA_TOKEN_TONE_CLASS } from "@/lib/data-token-tone";
@@ -72,7 +72,7 @@ export default function RuntimeToken({
 			<TooltipContent side="bottom" className="max-w-xs">
 				<span className="flex items-baseline gap-2">
 					<span className="break-all">{description}</span>
-					<span className="shrink-0 text-primary-foreground/70">{note}</span>
+					<TooltipHint className="shrink-0">{note}</TooltipHint>
 				</span>
 			</TooltipContent>
 		</Tooltip>

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -81,7 +81,7 @@ export type { ToastVariantName } from "./toast";
 
 export { ToggleGroup, ToggleGroupItem } from "./toggle-group";
 export type { ToggleGroupProps } from "./toggle-group";
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "./tooltip";
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipHint, TooltipProvider } from "./tooltip";
 export { TooltipIconButton } from "./tooltip-icon-button";
 export type { TooltipIconButtonProps } from "./tooltip-icon-button";
 export { InfoChip } from "./info-chip";

--- a/app/src/components/ui/tooltip-hint-contrast.test.ts
+++ b/app/src/components/ui/tooltip-hint-contrast.test.ts
@@ -20,21 +20,21 @@
  * label's own white, which bottoms out at 3.6:1 on `sunset` and is the fill's
  * own ceiling - a hint cannot beat the text it is secondary to - and far above
  * the canvas token, which fails the bar on every scheme. Both halves are
- * asserted:
- * a test that only checks the new value passes just as happily on a bar so low
- * the old one would have cleared it.
+ * asserted: a test that only checks the new value passes just as happily on a
+ * bar so low the old one would have cleared it.
  *
  * Values are parsed out of `index.css` rather than restated, so a retuned
  * accent is measured rather than assumed.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const uiDir = dirname(fileURLToPath(import.meta.url));
-const css = readFileSync(join(uiDir, "..", "..", "index.css"), "utf8");
+const SRC = join(uiDir, "..", "..");
+const css = readFileSync(join(SRC, "index.css"), "utf8");
 const tooltip = readFileSync(join(uiDir, "tooltip.tsx"), "utf8");
 
 type Hsl = [number, number, number];
@@ -120,4 +120,57 @@ describe("a tooltip hint on the tooltip's own fill", () => {
 			}
 		}
 	);
+});
+
+/*
+ * Fixing three call sites does not fix the app: the next hand-written tooltip
+ * can reach for `text-muted-foreground` exactly as this one did, and every
+ * assertion above would stay green. So the rule is made **enumerable rather
+ * than impossible**, the way the border rules are - the mistake is one shape,
+ * a canvas-tuned foreground inside a `TooltipContent`, and every block in the
+ * app is read.
+ *
+ * A scan cannot see a class that arrives in a variable, which is why the
+ * rendered-class guard in `tooltip-icon-button.test.tsx` exists alongside it.
+ * The two catch different halves and neither is sufficient.
+ */
+function tsxFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name === "dist") continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...tsxFiles(full));
+		else if (entry.name.endsWith(".tsx") && !entry.name.includes(".test.")) out.push(full);
+	}
+	return out;
+}
+
+/** `<TooltipContent …>…</TooltipContent>`, comments stripped so prose about the
+ *  rule does not read as a violation of it. */
+const TOOLTIP_BLOCK = /<TooltipContent\b[^>]*>[\s\S]*?<\/TooltipContent>/g;
+
+/** The foregrounds tuned for the canvas: muted, plain, and the `-text` tier. */
+const CANVAS_FOREGROUND = /\btext-(?:muted-foreground|foreground|[a-z]+-text)\b/;
+
+const blocks = tsxFiles(SRC).flatMap((file) =>
+	[
+		...readFileSync(file, "utf8")
+			.replace(/\/\*[\s\S]*?\*\//g, "")
+			.matchAll(TOOLTIP_BLOCK),
+	].map((m) => ({ file, source: m[0] }))
+);
+
+describe("every tooltip in the app, not only the three this fix touched", () => {
+	it("found the tooltips to scan", () => {
+		// A regex that stopped matching would make the next case vacuous - this
+		// repo has had a guard pass for weeks while reading an empty string.
+		expect(blocks.length).toBeGreaterThan(12);
+	});
+
+	it("paints no canvas-tuned foreground on the tooltip's fill", () => {
+		const offenders = blocks
+			.filter((b) => CANVAS_FOREGROUND.test(b.source))
+			.map((b) => `${b.file}: ${CANVAS_FOREGROUND.exec(b.source)?.[0]}`);
+		expect(offenders).toEqual([]);
+	});
 });

--- a/app/src/components/ui/tooltip-hint-contrast.test.ts
+++ b/app/src/components/ui/tooltip-hint-contrast.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A tooltip's secondary line has to read on the tooltip.
+ *
+ * `TooltipContent` paints `bg-primary-fill`, so a hint's colour sits on a
+ * saturated accent, not on the canvas - and `--muted-foreground` is tuned for
+ * the canvas. On the fills it measures **1.04 to 2.27:1**, which is not a
+ * de-emphasis but a disappearance: `TooltipIconButton` rendered its hint that
+ * way and the mock-server row's tooltip printed `http://127.0.0.1:51056` in
+ * grey-on-blue at 1.04, the URL being the one thing in that tooltip a reader
+ * has to read.
+ *
+ * The bar is 2.5:1 in every accent scheme and both themes. That is below the
+ * label's own white, which bottoms out at 3.6:1 on `sunset` and is the fill's
+ * own ceiling - a hint cannot beat the text it is secondary to - and far above
+ * the canvas token, which fails the bar on every scheme. Both halves are
+ * asserted:
+ * a test that only checks the new value passes just as happily on a bar so low
+ * the old one would have cleared it.
+ *
+ * Values are parsed out of `index.css` rather than restated, so a retuned
+ * accent is measured rather than assumed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const uiDir = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(uiDir, "..", "..", "index.css"), "utf8");
+const tooltip = readFileSync(join(uiDir, "tooltip.tsx"), "utf8");
+
+type Hsl = [number, number, number];
+
+function declarations(name: string): Hsl[] {
+	const re = new RegExp(`--${name}:\\s*([\\d.]+)\\s+([\\d.]+)%\\s+([\\d.]+)%`, "g");
+	return [...css.matchAll(re)].map((m) => [Number(m[1]), Number(m[2]), Number(m[3])]);
+}
+
+function toRgb([h, s, l]: Hsl): [number, number, number] {
+	const H = h / 360,
+		S = s / 100,
+		L = l / 100;
+	const f = (n: number) => {
+		const k = (n + H * 12) % 12;
+		const a = S * Math.min(L, 1 - L);
+		return L - a * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)));
+	};
+	return [f(0), f(8), f(4)];
+}
+
+const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+function luminance([r, g, b]: [number, number, number]): number {
+	return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: [number, number, number], b: [number, number, number]): number {
+	const la = luminance(a),
+		lb = luminance(b);
+	return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** Composite a colour at `alpha` over a background - what `/80` resolves to. */
+function over(fg: Hsl, bg: Hsl, alpha: number): [number, number, number] {
+	const f = toRgb(fg),
+		b = toRgb(bg);
+	return [0, 1, 2].map((i) => f[i] * alpha + b[i] * (1 - alpha)) as [number, number, number];
+}
+
+/** Every `--primary-fill` in the stylesheet: the default plus each accent. */
+const FILLS = declarations("primary-fill");
+const FOREGROUNDS = declarations("primary-foreground");
+const MUTED = declarations("muted-foreground");
+
+/** The hint's own alpha, read off the component so the two cannot drift. */
+const alpha = (() => {
+	const m = tooltip.match(/text-primary-foreground\/(\d+)/);
+	if (!m) throw new Error("TooltipHint no longer tints --primary-foreground");
+	return Number(m[1]) / 100;
+})();
+
+const BAR = 2.5;
+
+describe("the scan itself", () => {
+	it("found the fills, the foregrounds and the hint's alpha", () => {
+		// A stylesheet that stopped matching would make every case below vacuous.
+		expect(FILLS.length).toBeGreaterThan(5);
+		expect(FOREGROUNDS.length).toBeGreaterThan(0);
+		expect(MUTED.length).toBeGreaterThan(0);
+		expect(alpha).toBeGreaterThan(0);
+	});
+});
+
+describe("a tooltip hint on the tooltip's own fill", () => {
+	it.each(FILLS.map((fill) => [fill.join(" "), fill] as const))("clears %s", (_label, fill) => {
+		for (const fg of FOREGROUNDS) {
+			expect(contrast(over(fg, fill, alpha), toRgb(fill))).toBeGreaterThanOrEqual(BAR);
+		}
+	});
+
+	/*
+	 * The half that makes the bar mean something. `--muted-foreground` is the
+	 * colour the hint used to carry, and it fails on every fill - so the bar is
+	 * one the old value could not have passed, and reverting the component to it
+	 * fails the suite rather than sliding under a lenient threshold.
+	 */
+	it.each(FILLS.map((fill) => [fill.join(" "), fill] as const))(
+		"is a bar the canvas-tuned --muted-foreground fails on %s",
+		(_label, fill) => {
+			for (const muted of MUTED) {
+				expect(contrast(toRgb(muted), toRgb(fill))).toBeLessThan(BAR);
+			}
+		}
+	);
+});

--- a/app/src/components/ui/tooltip-icon-button.test.tsx
+++ b/app/src/components/ui/tooltip-icon-button.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { TooltipProvider } from "./tooltip";
 import { TooltipIconButton } from "./tooltip-icon-button";
 
@@ -40,6 +40,39 @@ describe("TooltipIconButton", () => {
 		);
 		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 		expect(onClick).toHaveBeenCalledOnce(); // still once - disabled swallowed it
+	});
+
+	/*
+	 * The hint is secondary text on `bg-primary-fill`, so it has to be a tint of
+	 * the foreground that reads there. It carried `text-muted-foreground` - a
+	 * canvas token, ~1.0-2.3:1 on the accent fills - which made the mock-server
+	 * row's URL unreadable inside its own tooltip. A source scan would not catch
+	 * a regression that arrives through `cn()`, so the class is read off the
+	 * rendered element; the ratios themselves are `tooltip-hint-contrast.test.ts`.
+	 */
+	it("paints the hint as a tint of the tooltip's own foreground", async () => {
+		renderButton(
+			<TooltipIconButton
+				label="Copy mock server URL"
+				tooltipHint="http://127.0.0.1:51056"
+				icon={<svg />}
+			/>
+		);
+
+		// Radix opens on focus, which needs no pointer geometry in jsdom.
+		await act(async () => {
+			fireEvent.focus(screen.getByRole("button", { name: "Copy mock server URL" }));
+		});
+
+		// Radix mirrors the content into a visually-hidden copy for the
+		// `aria-describedby` announcement, so both spans are matched and both
+		// are asserted rather than picking one and hoping it is the visible one.
+		const hints = await screen.findAllByText("http://127.0.0.1:51056");
+		expect(hints.length).toBeGreaterThan(0);
+		for (const hint of hints) {
+			expect(hint.className).toContain("text-primary-foreground/");
+			expect(hint.className).not.toContain("text-muted-foreground");
+		}
 	});
 
 	it("forwards arbitrary button props such as aria-pressed", () => {

--- a/app/src/components/ui/tooltip-icon-button.tsx
+++ b/app/src/components/ui/tooltip-icon-button.tsx
@@ -27,7 +27,7 @@
 
 import * as React from "react";
 import { Button, type ButtonProps } from "./button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+import { Tooltip, TooltipContent, TooltipHint, TooltipTrigger } from "./tooltip";
 
 export interface TooltipIconButtonProps extends Omit<ButtonProps, "aria-label" | "children"> {
 	/** Names the button (aria-label) and fills the tooltip. Required. */
@@ -61,7 +61,7 @@ export function TooltipIconButton({
 				{tooltipHint ? (
 					<span className="flex items-center gap-1.5">
 						{label}
-						<span className="text-muted-foreground">{tooltipHint}</span>
+						<TooltipHint>{tooltipHint}</TooltipHint>
 					</span>
 				) : (
 					label

--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -38,4 +38,20 @@ function TooltipContent({
 	);
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+/**
+ * Secondary text inside a tooltip - a shortcut, a URL, the source of a value.
+ *
+ * **`--muted-foreground` is not a de-emphasis here, it is a disappearance.** A
+ * tooltip is `bg-primary-fill`, and that token is tuned against the canvas: on
+ * the accent fills it measures 1.04-2.27:1, worst on Blue, where the hint is
+ * often a URL the reader is meant to read off the tooltip. De-emphasis on a
+ * *filled* surface has to be an alpha of the foreground that already reads on
+ * it - the same argument `surface-sunken` makes for its `--rule` - which is
+ * what this is, so the one value lives here rather than at each call site.
+ * → `tooltip-hint-contrast.test.ts`
+ */
+function TooltipHint({ className, ...props }: React.ComponentProps<"span">) {
+	return <span className={cn("text-primary-foreground/80", className)} {...props} />;
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipHint, TooltipProvider };

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -783,6 +783,17 @@ Pinning `--primary` to its light value would look like a contrast fix and is in
 fact a regression: accent *text* on the dark card would fall from APCA Lc 44–69
 to Lc 22–37.
 
+**Secondary text on the fill is a tint of `--primary-foreground`, never
+`--muted-foreground`.** The muted token is tuned against the canvas, so on the
+accent fills it measures 1.04–2.27:1 - on `ocean`, the default, it is 1.04,
+which is not a de-emphasis but a disappearance. A tooltip's second line (a
+shortcut, a URL, the source of a value) therefore uses the `TooltipHint`
+primitive, which holds the one tint; the same argument `surface-sunken` makes
+for its `--rule`, on a filled surface instead of a raised one. The hint cannot
+out-read the label it is secondary to - white on `sunset` is the ceiling at
+3.6:1 - so the bar is 2.5:1 on every scheme, checked in
+`tooltip-hint-contrast.test.ts`.
+
 | Scheme | Light (`--primary` = `--primary-fill`) | Dark `--primary` | Dark `--primary-fill` |
 |--------|-----------|----------|----------|
 | `sunset` | `24 90% 46%` | `24 95% 58%` | `24 90% 46%` |


### PR DESCRIPTION
## Description

Reported from the running app: the mock-server row's **Copy mock server URL** tooltip printed `http://127.0.0.1:51056` in grey on the blue fill, unreadable.

**Plan.** `TooltipIconButton` painted its hint `text-muted-foreground`. `TooltipContent` is `bg-primary-fill`, and the muted token is tuned against the canvas, so on the accent fills it measures **1.04-2.27:1** - 1.04 on `ocean`, the default scheme, which is exactly the screenshot. That is not a de-emphasis, it is a disappearance, and it lands on the one line of that tooltip a reader actually has to read. De-emphasis on a *filled* surface has to be an alpha of the foreground that already reads on it - the same argument `surface-sunken` makes for its `--rule`, and the argument the app's two other tooltip-hint sites had already worked out for themselves (`text-primary-foreground/70`, with the reasoning spelled out in a comment in `EditableVariable.tsx`). The primitive never received it, which is the defect shape CLAUDE.md names ("a hand-rolled copy of a primitive does not receive the primitive's fixes") pointing the other way: the *primitive* was the copy. So rather than patch one class, the tint moves into one exported `TooltipHint` and all three sites use it.

The alternative I rejected was giving the hint the tooltip's full `--primary-foreground` and de-emphasising by size or a separator. White is the fill's own ceiling (3.6:1 on `sunset`), so at full strength the hint reads exactly as loud as the label it is subordinate to, and every hint in the app becomes a second headline. `/80` measures 2.8-4.3 across the schemes - visibly secondary, and 2.7x the worst case it replaces.

**One behaviour, app-wide.** Before this there were two: the primitive's muted grey and the two hand-rolled `/70` sites. After it there is one definition (`TooltipHint`), one tint literal (`text-primary-foreground/80`, in `tooltip.tsx`), three consumers, and no remaining hard-coded tint anywhere in `src`. Audited rather than assumed: all **17** `TooltipContent` blocks in the app were read - the three that carry a secondary line now share the primitive, the other fourteen render plain text and inherit the tooltip's own foreground - and no other solid `bg-primary-fill` surface (Button default, Badge default, the Send button, `SendWithRowMenu`, the two appearance swatches) pairs a fill with a canvas-tuned foreground. The only `-text`-token-on-a-background pairings left in the app are `bg-destructive/10` tints over the canvas, which is where that tier belongs.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Local, on this branch (rebased onto `177a750`, master after #798 merged):

- `cd app && pnpm test` - **510 files, 5581 tests passed**.
- `cd app && pnpm type-check` - clean. `cd app && pnpm lint` - clean, zero warnings.
- `npx prettier --check` on every touched file. `docs/design-system.md` is hand-edited only, per the repo rule against formatting it.
- No engine build or ctest run: the diff is TypeScript and Markdown only.

Three guards, each catching what the others cannot:

- `tooltip-icon-button.test.tsx` opens the tooltip and reads the class **off the rendered element** - a regression arriving through a `cn()` binding is invisible to a source scan (CLAUDE.md's badge-hover lesson). Mutation-checked: restoring `text-muted-foreground` fails it.
- `tooltip-hint-contrast.test.ts` measures the **ratio** against every `--primary-fill` in `index.css`, with the alpha parsed out of `tooltip.tsx` so nothing is restated and a retuned accent is measured rather than assumed. The hint must clear **2.5:1** on every fill, **and** `--muted-foreground` must fail that same bar on every fill - the second half is what stops the threshold from later being lowered to something the broken value would have passed.
- The same file scans **every `<TooltipContent>` block in `src`** for a canvas-tuned foreground, so the next hand-written tooltip cannot reintroduce the bug without touching the primitive. It asserts it found blocks first (this repo has had a guard pass for weeks while reading an empty string). Mutation-checked: reverting the primitive puts the offending file in the failure list by name.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

None - reported directly against the running app. The rule is recorded in `docs/design-system.md` (Color Schemes) and in `app/CLAUDE.md` beside the other test-enforced UI rules, so the next hint does not have to rediscover it.