### PR TITLE
feat(app/mcp): saved-request `verifySSL` over MCP, and the per-call answer

### DIFF
--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -12,6 +12,7 @@ import {
 	DEFAULT_RUN_SAMPLE_LIMIT,
 	DEFAULT_RUN_SERIES_LIMIT,
 	dispatchTool,
+	INSECURE_TLS_REFUSAL,
 	MAX_EXAMPLES_BODY_BYTES,
 	MAX_INBOX_CAPTURE_LIMIT,
 	MAX_IN_FLIGHT_BOUND,
@@ -21,6 +22,7 @@ import {
 	MAX_RUN_SERIES_LIMIT,
 	MAX_SLOW_THRESHOLD_MS,
 	MAX_SUCCESS_SAMPLE_PERIOD,
+	REQUEST_SETTINGS_KEYS,
 	toolCatalog,
 	TOOLS,
 	type ToolContext,
@@ -1557,6 +1559,134 @@ describe("document CRUD parity", () => {
 			// with four descriptions rather than four schemas.
 			expect(run.safeParse({ token: "t" }).success).toBe(false);
 			expect(run.safeParse({ mode: "bearer", token: "t" }).success).toBe(true);
+		});
+	});
+
+	/**
+	 * Certificate verification (#795). The stored field was written by the engine
+	 * and the app and by no MCP tool, so an agent could neither save a request
+	 * against a self-signed host nor restate what `list_requests` showed it. What
+	 * these hold is the pair of answers that closes it: the stored field is
+	 * writable under the merge-patch rule, and a *per-call* downgrade is refused.
+	 */
+	describe("certificate verification", () => {
+		const allow = { allowlist: ["api.example.com"] };
+
+		test("create_request stores verification off when the caller asks for it", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"create_request",
+				{
+					collectionId: "col_1",
+					name: "Internal health",
+					url: "https://internal.example.test/health",
+					verifySSL: false,
+				},
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(res.isError).toBeFalsy();
+			expect(callArgs(client.createRequest)[0]).toMatchObject({ verifySSL: false });
+		});
+
+		test("update_request patches verifySSL alone", async () => {
+			const client = fakeClient();
+			await dispatchTool(
+				"update_request",
+				{ requestId: "req_1", verifySSL: false },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(callArgs(client.updateRequest)[1]).toEqual({ verifySSL: false });
+		});
+
+		test("an update that does not name it leaves the stored value alone", async () => {
+			// The one field where the merge-patch rule is a security rule: a
+			// defaulted `true` here would silently re-enable a check the user
+			// turned off, and the request would then fail against the host it was
+			// written for.
+			const client = fakeClient();
+			await dispatchTool(
+				"update_request",
+				{ requestId: "req_1", name: "Internal health", httpVersion: "http2" },
+				ctxWith(client, { allowWrites: true })
+			);
+			const payload = callArgs(client.updateRequest)[1] as Record<string, unknown>;
+			expect(Object.keys(payload)).not.toContain("verifySSL");
+		});
+
+		test("every declared setting is a setting the payload builder reads", () => {
+			// The wiring rule, not a restatement of the list: a field added to
+			// `requestSettingsInput` and not to `REQUEST_SETTINGS_KEYS` parses
+			// happily and reaches the engine never - this repo's most repeated
+			// defect. Driven through both verbs because both spread the schema.
+			for (const key of REQUEST_SETTINGS_KEYS) {
+				expect(schemaOf("create_request", key), key).toBeDefined();
+				expect(schemaOf("update_request", key), key).toBeDefined();
+			}
+		});
+
+		test.each([
+			["followRedirects", false],
+			["maxRedirects", 3],
+			["httpVersion", "http2"],
+			["stream", true],
+			["verifySSL", false],
+		] as const)("update_request forwards %s on its own", async (key, value) => {
+			const client = fakeClient();
+			await dispatchTool(
+				"update_request",
+				{ requestId: "req_1", [key]: value },
+				ctxWith(client, { allowWrites: true })
+			);
+			expect(callArgs(client.updateRequest)[1]).toEqual({ [key]: value });
+		});
+
+		test("run_request refuses a per-call downgrade before anything is sent", async () => {
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"run_request",
+				{ url: "https://api.example.com/x", verifySSL: false },
+				ctxWith(client, allow)
+			);
+			expect(res.isError).toBe(true);
+			expect(firstText(res)).toBe(INSECURE_TLS_REFUSAL);
+			// Refused *before* composition, so nothing was even resolved - a
+			// refusal after the exchange would be a request already sent.
+			expect(client.composeRequest).not.toHaveBeenCalled();
+			expect(client.executeRequest).not.toHaveBeenCalled();
+			// The refusal names both supported routes, which is the whole point of
+			// answering here rather than dropping an unknown argument.
+			expect(firstText(res)).toContain("update_request");
+			expect(firstText(res)).toContain("Network & connectivity");
+		});
+
+		test("run_request accepts the safe default and forwards nothing for it", async () => {
+			// `true` is what the composed payload already carries, so an agent
+			// restating it is not argued with - and not echoed into the request
+			// overlay either, where it would be a second source for one value.
+			const client = fakeClient();
+			const res = await dispatchTool(
+				"run_request",
+				{ url: "https://api.example.com/x", verifySSL: true },
+				ctxWith(client, allow)
+			);
+			expect(res.isError).toBeFalsy();
+			const composed = callArgs(client.composeRequest)[0] as {
+				request: Record<string, unknown>;
+			};
+			expect(Object.keys(composed.request)).not.toContain("verifySSL");
+			const executed = callArgs(client.executeRequest)[0] as Record<string, unknown>;
+			expect(Object.keys(executed)).not.toContain("verifySSL");
+		});
+
+		test("the load and collection runners take no TLS argument at all", () => {
+			// One answer, not three: the stored field is the only way a Vayu run
+			// skips a certificate check, so no execute/load tool may grow an
+			// argument that bypasses the record the app shows.
+			for (const name of ["start_load_run", "run_collection", "run_collection_smoke"]) {
+				const tool = TOOLS.find((t) => t.name === name);
+				expect(tool, name).toBeDefined();
+				expect(Object.keys(tool!.inputSchema), name).not.toContain("verifySSL");
+			}
 		});
 	});
 

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -1562,6 +1562,44 @@ const environmentIdInput = z
 	.describe("Optional environment ID whose variables resolve {{templates}} in this request.");
 
 /**
+ * The refusal an ad-hoc send gets for `verifySSL: false`, and with it the
+ * answer to the per-call TLS question issue #795 posed.
+ *
+ * The stored field is writable (`create_request` / `update_request`) and a
+ * per-call one is not, because the two differ in what survives the call. A
+ * stored `verifySSL: false` is a document: the app's Settings tab shows the box
+ * unticked and prints a warning under it, `list_requests` reads it back, and a
+ * user can undo it. An argument on one send is visible only inside the agent's
+ * own transcript - nothing in Vayu records that a certificate went unchecked,
+ * so nobody can find it afterwards or take it back.
+ *
+ * The alternative considered was the `allowInsecureTls` safety toggle #795
+ * sketched. Rejected: it would be a *global* permission - every allowlisted host
+ * for the rest of the session, granted once for one dev box and then forgotten -
+ * where the stored field is per request, and it would need a Settings control of
+ * its own to be reachable at all, which is a second way to weaken TLS for a case
+ * the first one already covers.
+ *
+ * `true` is accepted rather than refused alongside it: it is what the composed
+ * payload already carries, so an agent restating the safe default should not be
+ * argued with.
+ */
+export const INSECURE_TLS_REFUSAL =
+	"verifySSL: false is not accepted on a one-off send - a skipped certificate check has to leave a record, and an argument on a single call leaves none. Two ways forward: ask the user to add the internal authority under Vayu Settings > Network & connectivity, which keeps verification on for every request; or save the request with create_request/update_request `verifySSL: false` and run it (run_collection_smoke composes a saved request exactly as stored). The app then shows that request as accepting any certificate, and the user can untick it.";
+
+/**
+ * `run_request`'s TLS argument: declared so that asking for the downgrade gets
+ * {@link INSECURE_TLS_REFUSAL} - naming the two supported routes - rather than a
+ * stripped unknown key and a handshake failure the agent has to guess at.
+ */
+const verifySSLSendInput = z
+	.boolean()
+	.optional()
+	.describe(
+		"Verify the server's TLS certificate (default true). Only `true` is accepted here: `false` is refused, because skipping the certificate check for one agent-issued send leaves no trace in Vayu afterwards. Save the request with `verifySSL: false` (create_request / update_request) if the user wants an internal or self-signed host reachable, or have them trust that authority under Vayu Settings > Network & connectivity."
+	);
+
+/**
  * The post-response validation script, declared identically on `run_request` and
  * `start_load_run` so one script an agent writes carries between them - the way
  * the app's single **Tests** tab drives both Send and a load run. See
@@ -1823,19 +1861,25 @@ function storedAuthInput(subject: string, extra: string) {
 }
 
 /**
- * The **Settings** tab's four per-request fields, as the engine stores them on
- * the row (issue #759).
+ * The **Settings** tab's five per-request fields, as the engine stores them on
+ * the row (issues #759, #795).
  *
  * One definition spread into both `create_request` and `update_request`: the
  * fields mean the same thing on either verb, and the merge-patch difference is
- * carried by the surrounding tool description rather than by two copies of four
+ * carried by the surrounding tool description rather than by two copies of five
  * schemas. Ranges are the engine's own (`apply_request_fields`) rather than new
  * numbers - `maxRedirects` is clamped to 0-100 there, and an unrecognized
  * `httpVersion` is a 400 rather than a coercion, which is why the enum is
  * closed here too.
  *
- * `verifySSL` is deliberately **not** among them: it is stored beside these
- * (issue #706) and belongs to the transport epic's own CRUD pass - see #795.
+ * `verifySSL` is the one whose description has to say what the field *means*
+ * rather than what it sets: it is the only setting here whose off position is a
+ * security downgrade, and an agent that reads "certificate verification" as a
+ * strictness knob would turn it off to make a handshake stop failing. The
+ * merge-patch rule matters more for it than for the other four for the same
+ * reason - a defaulted `true` on an unrelated update would silently re-enable
+ * verification a user turned off, and the request would then fail against the
+ * host it was written for.
  */
 function requestSettingsInput() {
 	return {
@@ -1866,11 +1910,29 @@ function requestSettingsInput() {
 			.describe(
 				"Consume the response as a text/event-stream rather than buffering it (default false). Stored on the request, so a later send - from the app or from run_request - streams without being told to."
 			),
+		verifySSL: z
+			.boolean()
+			.optional()
+			.describe(
+				"Verify the server's TLS certificate when this request is sent (default true). Setting it false skips the certificate check entirely, hostname included, so an internal or self-signed host answers instead of failing - and anything on the network path can then read and rewrite the request. It is stored on the request and applies to every later send of it: the app's Send, a load run and a stream alike. Prefer keeping it on and having the user add the internal authority under Vayu Settings > Network & connectivity; turn it off only when they have asked for exactly that, and say so in your reply, because the app shows this request as accepting any certificate from then on."
+			),
 	};
 }
 
-/** The stored settings a call named, forwarded verbatim; an unnamed one is absent. */
-const REQUEST_SETTINGS_KEYS = ["followRedirects", "maxRedirects", "httpVersion", "stream"] as const;
+/**
+ * The stored settings a call named, forwarded verbatim; an unnamed one is absent.
+ *
+ * Every key {@link requestSettingsInput} declares appears here - the schema
+ * declares the shape, this list is what the payload builder actually reads, so a
+ * field added to one and not the other is an argument the engine never sees.
+ */
+export const REQUEST_SETTINGS_KEYS = [
+	"followRedirects",
+	"maxRedirects",
+	"httpVersion",
+	"stream",
+	"verifySSL",
+] as const;
 
 /**
  * Lay the caller's stored-settings fields onto a request payload.
@@ -3422,7 +3484,7 @@ export const TOOLS: McpTool[] = [
 		category: "execute",
 		invalidates: ["run", "cookie"],
 		description:
-			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app (environment > collection chain > globals). Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.) " +
+			"Send a single HTTP request through Vayu (Design mode) and return the response, timing, and any test results. The target host must be on Vayu's MCP allowlist. {{variables}} in the URL, headers, and body are resolved when an environmentId (and/or collectionId) is given, using the same precedence as the app (environment > collection chain > globals). Pass an `auth` block to have the engine apply bearer/basic/apikey/oauth2 auth. Pass a `preRequestScript` to sign or otherwise rewrite the request before it goes out - its pm.request edits are applied to what is actually sent. (To replay a saved request with its stored auth and scripts across a whole collection, use run_collection_smoke.) Certificate verification is always on for a send made this way - `verifySSL: false` is refused here, because a skipped check on a one-off call is recorded nowhere; it belongs on the saved request, where the app shows it. " +
 			`The response body is capped at ${MAX_INLINE_BODY_BYTES} bytes in this result: over that, \`bodyRaw\` holds the first ${MAX_INLINE_BODY_BYTES} bytes, \`bodyTruncated\` is true, \`bodySize\` is the real size, and the parsed \`body\` is null rather than a full copy of what was cut. A large \`rawRequest\` is capped the same way (headers kept whole) and flagged with \`rawRequestTruncated\`.`,
 		annotations: {
 			title: "Send a request",
@@ -3448,6 +3510,7 @@ export const TOOLS: McpTool[] = [
 				.describe(
 					'Protocol to negotiate: "auto" | "http1.1" | "http2" (default "auto"). Mirrors the request builder\'s Settings tab picker.'
 				),
+			verifySSL: verifySSLSendInput,
 			requestId: z.string().optional().describe("Optional saved request ID to link."),
 			environmentId: environmentIdInput,
 			collectionId: collectionIdInput,
@@ -3465,6 +3528,10 @@ export const TOOLS: McpTool[] = [
 			streamBudgetMs: streamBudgetMsInput,
 		},
 		handler: async (args, ctx, signal) => {
+			// Before anything is composed, let alone sent: a refusal that arrived
+			// after the exchange would be a request already made insecurely. `true`
+			// falls through - it restates the composed default (issue #795).
+			if (args.verifySSL === false) return errorResult(INSECURE_TLS_REFUSAL);
 			const request: Record<string, unknown> = {
 				...readRequestOverrides(args),
 				url: requireStr(args, "url"),
@@ -3775,7 +3842,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			'Create a saved request inside a collection (stores it; does not send it), with its auth, redirect policy, protocol and stream flag, and its pre-request and test scripts - everything the app\'s builder stores except file body parts. GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed, and a stored script runs only when the request is later sent. Auth is stored as written and resolved at send time, so {{variables}} inside it are fine; leaving `auth` out stores the default "inherit", which resolves against the collection chain.',
+			'Create a saved request inside a collection (stores it; does not send it), with its auth, redirect policy, protocol, stream flag and certificate-verification setting, and its pre-request and test scripts - everything the app\'s builder stores except file body parts. GUARDED: requires write access to be enabled in Vayu Settings. The URL may contain {{variables}} since it is only saved, not executed, and a stored script runs only when the request is later sent. Auth is stored as written and resolved at send time, so {{variables}} inside it are fine; leaving `auth` out stores the default "inherit", which resolves against the collection chain.',
 		annotations: {
 			title: "Create saved request",
 			readOnlyHint: false,
@@ -3842,7 +3909,7 @@ export const TOOLS: McpTool[] = [
 		category: "write",
 		invalidates: ["request"],
 		description:
-			"Correct a saved request: its name, URL, method, headers, body, auth, redirect policy, protocol, stream flag, description or pre/post-request scripts. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - anything you leave out keeps its stored value. Passing `headers` replaces the whole header list, so send every header the request should end up with; passing `auth` replaces the whole auth block, so send the mode and its credentials together ({ mode: 'none' } clears it, { mode: 'inherit' } hands it back to the collection chain); passing a script replaces that script, and an empty string clears it.",
+			"Correct a saved request: its name, URL, method, headers, body, auth, redirect policy, protocol, stream flag, certificate-verification setting, description or pre/post-request scripts. GUARDED: requires write access to be enabled in Vayu Settings. Only the fields you pass change - anything you leave out keeps its stored value. Passing `headers` replaces the whole header list, so send every header the request should end up with; passing `auth` replaces the whole auth block, so send the mode and its credentials together ({ mode: 'none' } clears it, { mode: 'inherit' } hands it back to the collection chain); passing a script replaces that script, and an empty string clears it.",
 		annotations: {
 			title: "Update saved request",
 			readOnlyHint: false,
@@ -3902,7 +3969,7 @@ export const TOOLS: McpTool[] = [
 			if (args.headers && typeof args.headers === "object" && !Array.isArray(args.headers)) {
 				payload.headers = toKeyValueEntries(args.headers);
 			}
-			// Auth and the four Settings fields ride the same rule as the strings
+			// Auth and the five Settings fields ride the same rule as the strings
 			// above: stated is written, absent is left alone. The block replaces
 			// the stored one wholesale because the engine stores it as one JSON
 			// column - there is no per-credential patch to offer.

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -159,13 +159,13 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `get_engine_config`    | read     | `GET /config`                                | -                          |
 | `get_live_metrics`     | read     | SSE snapshot of last N ticks                 | `limit` must be a whole number ≥ 1 |
 | `compare_runs`         | read     | 2× `GET /runs/:id/report` → diff (structured)| `baseRunId` optional - omitted, it resolves the target's pinned baseline |
-| `run_request`          | execute  | `POST /compose` + `POST /execute` (+ `GET /runs/:id/events` when streaming) | allowlist; response body capped at 32 KB |
+| `run_request`          | execute  | `POST /compose` + `POST /execute` (+ `GET /runs/:id/events` when streaming) | allowlist; response body capped at 32 KB; `verifySSL: false` refused - the downgrade belongs on a saved request |
 | `run_collection_smoke` | execute  | `GET /requests?…` + `POST /compose` + `POST /execute` (×N) | allowlist per host |
 | `run_collection`       | execute  | `GET /requests?…` (+ `GET /collections` when recursive) + `POST /compose` (×N) + `POST /runs` | allowlist on **every** step - one step off it refuses the whole run |
 | `create_collection`    | write    | `POST /collections`                          | write toggle; takes `variables`, `auth` and both collection scripts |
 | `update_collection`    | write    | `GET /collections` (scan, only when variables change) + `PUT /collections/:id` (merge-patch) | write toggle; `variables` merges like `update_environment`'s, `removeVariables` deletes names |
 | `delete_collection`    | write    | `GET /collections` + `GET /requests?…` (×N) + `DELETE /collections/:id` | write toggle + confirm |
-| `create_request`       | write    | `POST /requests`                             | write toggle; takes the builder's whole surface - auth, `followRedirects` / `maxRedirects` / `httpVersion` / `stream`, both scripts - minus file body parts |
+| `create_request`       | write    | `POST /requests`                             | write toggle; takes the builder's whole surface - auth, `followRedirects` / `maxRedirects` / `httpVersion` / `stream` / `verifySSL`, both scripts - minus file body parts |
 | `update_request`       | write    | `PUT /requests/:id` (merge-patch)            | write toggle; same fields, and only the ones named are written |
 | `delete_request`       | write    | `GET /requests/:id` + `DELETE /requests/:id` | write toggle + confirm     |
 | `list_request_examples`| read     | `GET /requests/:id/examples`                 | - (bodies capped at 32 KB each, 96 KB across the list) |
@@ -382,20 +382,37 @@ Notes:
   subtree - or an id no collection has - is a refusal, never a prompt carrying
   a number nobody verified. `delete_request` reads the row the same way, so the
   prompt names the request and its URL rather than an opaque id.
-- **A saved request an agent writes is the one the builder writes** (issue
-  #759). `create_request` / `update_request` carry the request's `auth` block and
-  the four **Settings** tab fields (`followRedirects`, `maxRedirects`,
-  `httpVersion`, `stream`) as well as its url, headers, body and both scripts, so
-  an agent that can send an authenticated request can now save one. The `auth`
-  input is the *same schema* `run_request` takes rather than a copy of it - one
-  definition, four descriptions - which is what lets an agent read a request's
-  `auth` over `list_requests` and write it back verbatim. Both the auth block and
-  each setting follow the merge-patch rule the strings already did: named is
-  written, absent is left alone, so an update that mentions only `maxRedirects`
-  cannot hand a stored `followRedirects: false` back to the engine's default. The
-  two exclusions are deliberate: **file body parts**, which name a path on the
-  user's machine an agent cannot choose for them, and **`verifySSL`** (issue
-  #706), which belongs to the transport epic's own CRUD pass - see #795.
+- **A saved request an agent writes is the one the builder writes** (issues
+  #759, #795). `create_request` / `update_request` carry the request's `auth`
+  block and the five **Settings** tab fields (`followRedirects`, `maxRedirects`,
+  `httpVersion`, `stream`, `verifySSL`) as well as its url, headers, body and
+  both scripts, so an agent that can send an authenticated request can now save
+  one. The `auth` input is the *same schema* `run_request` takes rather than a
+  copy of it - one definition, four descriptions - which is what lets an agent
+  read a request's `auth` over `list_requests` and write it back verbatim. Both
+  the auth block and each setting follow the merge-patch rule the strings already
+  did: named is written, absent is left alone, so an update that mentions only
+  `maxRedirects` cannot hand a stored `followRedirects: false` back to the
+  engine's default. For `verifySSL` that rule is a *security* rule rather than a
+  convenience: a defaulted `true` on an unrelated update would silently re-enable
+  a certificate check the user turned off. The one exclusion left is deliberate:
+  **file body parts**, which name a path on the user's machine an agent cannot
+  choose for them.
+- **A skipped certificate check has to leave a record** (issue #795). The
+  *stored* `verifySSL: false` is writable over MCP; a *per-call* one is not.
+  `run_request` declares `verifySSL` only so that `false` is refused by name -
+  the refusal points at the two supported routes, adding the internal authority
+  under **Vayu Settings > Network & connectivity** (verification stays on) or
+  saving the request with `verifySSL: false` and running that. `start_load_run`,
+  `run_collection` and `run_collection_smoke` take no such argument at all; they
+  compose saved requests, so the stored field is what they honour. The difference
+  is what survives the call: a stored value is a document the app's Settings tab
+  shows unticked with a warning under it, `list_requests` reads back and the user
+  can undo, while an argument on one send is visible only inside the agent's own
+  transcript. The `allowInsecureTls` safety toggle #795 sketched was rejected for
+  the same reason it would have been convenient - it is a global permission,
+  granted once for one dev host and then in force for every allowlisted host,
+  where the stored field is per request.
 - **Examples are writable, and where one came from is not** (issue #759).
   `list_request_examples` reads what a request has saved beside it - what a mock
   server for its collection answers with - and the three write tools author it,
@@ -760,8 +777,11 @@ How each tool uses `POST /compose` (`tools.ts::composeViaEngine`):
   never-elided rule, so an agent's value has to be laid over the composed
   payload the same way a URL override is. A URL-only run has no stored row
   behind it, which makes this the only way its redirect policy gets stated at
-  all. `verifySSL` is the one transport field neither tool writes yet -
-  [#795](https://github.com/athrvk/vayu/issues/795).
+  all. `verifySSL` is the one transport field that deliberately does **not** ride
+  the overlay: `run_request` refuses `verifySSL: false` and `start_load_run`
+  takes no such argument, because a certificate check skipped for one call is
+  recorded nowhere afterwards. It is written onto the saved request instead
+  (issue #795), and every by-id compose then carries it.
 - **Streaming** - `run_request` takes `stream: true` for a `text/event-stream`
   endpoint (issue #575). `tools/call` is request/response, so the tool does not
   stream to the agent: it starts the run, reads the relay for at most


### PR DESCRIPTION
## Description

`verifySSL` is stored on every request (`apply_request_fields`), emitted on every composed payload under the never-elided rule (`request_composer.cpp`), and editable in the request builder's **Settings** tab - and until this PR no MCP tool could write it. Verified still true at `177a750`: #759 was told in its Sequencing section to leave the field to the transport epic's own CRUD pass, #706 merged without extending those inputs, and the deferral comment was still sitting in `requestSettingsInput`.

**Plan.** Root cause is a field that has a writer (the app), a store (the row) and a reader (`list_requests`, every compose) but no MCP write path - the deferral in #759 was never picked up. The fix adds it as the fifth field of the one schema both CRUD verbs already spread (`requestSettingsInput`) and to `REQUEST_SETTINGS_KEYS`, the one list the payload builder reads, so both verbs carry it under the existing merge-patch rule rather than growing a second rule for one field. For `verifySSL` that rule is a *security* rule and not a convenience: a defaulted `true` on an unrelated update would silently re-enable a certificate check the user turned off, and the request would then fail against the host it was written for.

**The per-call question (step 2 of the issue), answered: refused, not gated.** `run_request` declares `verifySSL` so that `false` is refused *by name* - before composition, so nothing is resolved or sent - with the refusal naming the two routes that leave a record: have the user trust the internal authority under **Settings > Network & connectivity** (verification stays on), or store `verifySSL: false` on the request and run that. **The alternative I rejected** is the `allowInsecureTls` safety toggle the issue sketched. It would be a *global* permission - every allowlisted host for the rest of the session, granted once for one dev box and then forgotten - where the stored field is per request, visible in the Settings tab with its warning, readable back over `list_requests` and revocable by unticking a box. It would also need a Settings control of its own to be reachable, i.e. a second way to weaken TLS for a case the first one already covers. `verifySSL: true` is accepted and forwarded nowhere: it restates what the composed payload already carries. `start_load_run` / `run_collection` / `run_collection_smoke` take no such argument at all - they compose saved requests, so the stored field is what they honour.

**Blast radius.** `requestSettingsInput` has exactly two call sites (`create_request`, `update_request`); `REQUEST_SETTINGS_KEYS` exactly one reader (`applyRequestSettings`). `list_requests` passes engine rows through verbatim, so the stored value was already readable - this closes the write half. No engine change: `apply_request_fields` and `PUT /requests/:id`'s merge-patch already accept the field. No renderer change: both verbs already `invalidates: ["request"]`, and the issue names no app-side work.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Local, on this branch (cut from `177a750`):

- `cd app && pnpm test` - **509 files, 5553 tests passed**.
- `cd app && pnpm type-check` - clean. `cd app && pnpm lint` - clean, zero warnings.
- `npx prettier --write` on the two touched TS files; `docs/engine/mcp.md` was **not** prettier-clean at base (checked at `HEAD` before editing), so it was hand-edited only, per the repo rule against formatting files that were already dirty.
- `mkdocs build --strict` - documentation built, no warnings.
- No engine build or `ctest`: the diff is TypeScript and Markdown only, and no C++ was touched. CI runs the full matrix.

Eight new tests in `tools.test.ts`'s document-CRUD block, all mutation-checked (removing `"verifySSL"` from `REQUEST_SETTINGS_KEYS` and deleting the `run_request` guard fails 4 of them):

- `create_request` stores `verifySSL: false`; `update_request` patches it alone.
- An update naming other settings does **not** send `verifySSL` - the merge-patch rule, which for this field is what stops a silent re-enable.
- Every key in `REQUEST_SETTINGS_KEYS` is declared by both verbs, and each forwards on its own (table-driven over all five) - the wiring guard for "declared in the schema, never read by the payload builder", this repo's most repeated defect shape.
- `run_request` refuses `verifySSL: false` with the exported refusal string and calls neither `composeRequest` nor `executeRequest`; accepts `verifySSL: true` without echoing it into the compose overlay or the execute payload.
- The load and collection runners declare no `verifySSL` at all.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Closes #795.

Acceptance criteria: an agent can save a request with verification off and read it back (`list_requests` passes the row through); an update that does not name `verifySSL` leaves it alone (mutation-checked); the `run_request` question is answered - refused, with the reason in the tool description and in `docs/engine/mcp.md` under "A skipped certificate check has to leave a record". #707 (client certificates) should follow this shape: the durable, per-request, app-visible field rather than a per-call argument or a global toggle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtxJE3f9k5i6iJVqattCq2)_