### PR TITLE
fix(app/history): a load run's test outcomes are readable after the run (#726)

### DIFF
--- a/app/src/components/shared/TestValidationSummary.test.tsx
+++ b/app/src/components/shared/TestValidationSummary.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The shared test-validation block (issue #726).
+ *
+ * Three things are worth pinning and none of them are layout: that the four
+ * numbers reach the screen, that absent-not-zeros holds both ways, and that a
+ * failure list shorter than its count says so rather than reading as the whole
+ * set of problems.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TestValidationSummary } from "./TestValidationSummary";
+
+const TALLIES = {
+	samplesTested: 100,
+	testsPassed: 87,
+	testsFailed: 13,
+	successRate: 87,
+};
+
+describe("TestValidationSummary", () => {
+	it("shows the four tallies a run's assertions produced", () => {
+		render(<TestValidationSummary testValidation={TALLIES} sampling={undefined} />);
+
+		expect(screen.getByText("Test Validation")).toBeTruthy();
+		expect(screen.getByText("100")).toBeTruthy();
+		expect(screen.getByText("87")).toBeTruthy();
+		expect(screen.getByText("13")).toBeTruthy();
+		expect(screen.getByText("87.0%")).toBeTruthy();
+	});
+
+	it("renders nothing for a run that asserted nothing", () => {
+		// Absent, never a row of zeros: "this run had no tests" and "every
+		// assertion failed" must not look the same.
+		const { container } = render(
+			<TestValidationSummary testValidation={undefined} sampling={undefined} />
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("names each failure when given them", () => {
+		render(
+			<TestValidationSummary
+				testValidation={TALLIES}
+				sampling={undefined}
+				failures={[
+					"status is 200: expected 404 to equal 200",
+					"body has token: expected undefined to exist",
+				]}
+				failuresTotal={2}
+			/>
+		);
+
+		expect(screen.getByText("status is 200: expected 404 to equal 200")).toBeTruthy();
+		expect(screen.getByText("body has token: expected undefined to exist")).toBeTruthy();
+	});
+
+	it("says a shorter list is a slice of a larger count", () => {
+		render(
+			<TestValidationSummary
+				testValidation={TALLIES}
+				sampling={undefined}
+				failures={["status is 200: expected 404 to equal 200"]}
+				failuresTotal={13}
+			/>
+		);
+
+		expect(screen.getByText("Showing 1 of 13.")).toBeTruthy();
+	});
+
+	it("does not claim a slice when the list is the whole count", () => {
+		render(
+			<TestValidationSummary
+				testValidation={TALLIES}
+				sampling={undefined}
+				failures={["only one"]}
+				failuresTotal={1}
+			/>
+		);
+
+		expect(screen.queryByText(/Showing/)).toBeNull();
+	});
+
+	it("still names failures for a report too old to carry the tallies", () => {
+		// The failure row and the summary block are written by different engine
+		// paths; a report with one and not the other must not swallow what it has.
+		render(
+			<TestValidationSummary
+				testValidation={undefined}
+				sampling={undefined}
+				failures={["status is 200: expected 500 to equal 200"]}
+				failuresTotal={1}
+			/>
+		);
+
+		expect(screen.getByText("status is 200: expected 500 to equal 200")).toBeTruthy();
+		expect(screen.queryByText("Samples Tested")).toBeNull();
+	});
+
+	it("discloses what the tested-response store displaced", () => {
+		render(
+			<TestValidationSummary
+				testValidation={TALLIES}
+				sampling={{
+					errorsDropped: 0,
+					successTracesDropped: 0,
+					slowTracesDropped: 0,
+					responseSamplesDropped: 2_900,
+				}}
+			/>
+		);
+
+		expect(screen.getByText(/2,900 further responses were displaced/)).toBeTruthy();
+	});
+});

--- a/app/src/components/shared/TestValidationSummary.tsx
+++ b/app/src/components/shared/TestValidationSummary.tsx
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A load run's aggregate test-validation outcome - how many sampled responses
+ * were asserted against, and how many of those assertions passed (issue #726).
+ *
+ * The engine writes `testValidation` (`run_manager.cpp` -> `runs.cpp`) into
+ * every load-run report whose plan carried a post-request script, and stores
+ * the named per-test failures on a synthetic result row. Before #726 the only
+ * reader of either was the live dashboard's `RequestResponseView`, mounted only
+ * while a run was being watched - so a run reopened from History showed
+ * thresholds, status codes and schema validation but never said whether its
+ * assertions ran at all. This is the one block, rendered by both surfaces.
+ *
+ * **`failures` is the History half only.** The live dashboard lists each named
+ * failure beside the sample it came from, so it passes the aggregate alone; the
+ * History Overview has no per-sample failure surface (its failure row is
+ * filtered out of the Samples tab, see `test-validation.ts`), so it passes the
+ * failures here. The stats card renders on the same `testValidation` both draw
+ * from, so the two cannot disagree on the numbers.
+ */
+
+import { XCircle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import { SampleRetentionNote } from "./SampleRetentionNote";
+import type { RunReport } from "@/types/domain";
+
+export interface TestValidationSummaryProps {
+	testValidation: RunReport["testValidation"];
+	sampling: RunReport["sampling"];
+	/**
+	 * The named per-test failures the run recorded, from the synthetic
+	 * failure-detail result row (`run_manager.cpp` stores it with `status 0`).
+	 * The list is bounded engine-side, so {@link failuresTotal} is the true
+	 * count and a shorter list says so out loud rather than reading as the whole
+	 * set. Omitted by surfaces that already list failures per sample.
+	 */
+	failures?: string[];
+	failuresTotal?: number;
+	className?: string;
+}
+
+export function TestValidationSummary({
+	testValidation,
+	sampling,
+	failures,
+	failuresTotal,
+	className,
+}: TestValidationSummaryProps) {
+	const hasFailures = failures !== undefined && failures.length > 0;
+
+	// A run that asserted nothing has no `testValidation` at all - absent, never
+	// a row of zeros - and with no failures to name there is nothing to show. A
+	// report old enough to omit the block reads the same as a run without tests.
+	if (!testValidation && !hasFailures) return null;
+
+	return (
+		<Card className={className}>
+			<CardHeader>
+				<CardTitle className="text-lg">Test Validation</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{testValidation && (
+					<>
+						<div className="grid grid-cols-[repeat(auto-fit,minmax(130px,1fr))] gap-3">
+							<div>
+								<p className="text-sm text-muted-foreground">Samples Tested</p>
+								<p className="font-bold">{testValidation.samplesTested}</p>
+							</div>
+							<div>
+								<p className="text-sm text-muted-foreground">Passed</p>
+								<p className="font-bold text-status-success-text">
+									{testValidation.testsPassed}
+								</p>
+							</div>
+							<div>
+								<p className="text-sm text-muted-foreground">Failed</p>
+								<p className="font-bold text-destructive-text">
+									{testValidation.testsFailed}
+								</p>
+							</div>
+							<div>
+								<p className="text-sm text-muted-foreground">Success Rate</p>
+								<p className="font-bold">
+									{testValidation.successRate.toFixed(1)}%
+								</p>
+							</div>
+						</div>
+						<SampleRetentionNote
+							sampling={sampling}
+							shown={testValidation.samplesTested}
+							budget="responses"
+							className="mt-3"
+						/>
+					</>
+				)}
+
+				{/*
+				 * The named failures, so a run that failed 13 of 100 assertions is
+				 * not indistinguishable from one that asserted nothing. Modelled on
+				 * the request-builder Tests tab and the live dashboard's per-sample
+				 * list, so the same failure reads the same wherever it is shown.
+				 */}
+				{hasFailures && (
+					<div className={cn("space-y-1", testValidation && "mt-4")}>
+						<p className="text-xs font-medium text-muted-foreground">
+							Failed Tests
+							{failuresTotal !== undefined && (
+								<span className="ml-1">({failuresTotal})</span>
+							)}
+						</p>
+						<div className="space-y-1.5">
+							{failures.map((failure, i) => (
+								<div
+									key={i}
+									className="flex items-start gap-2 bg-status-error/10 border border-status-error/20 rounded-md p-2"
+								>
+									<XCircle className="w-4 h-4 text-status-error-text mt-0.5 shrink-0" />
+									<pre className="text-xs text-status-error-text font-mono whitespace-pre-wrap break-words flex-1 min-w-0">
+										{failure}
+									</pre>
+								</div>
+							))}
+						</div>
+						{/*
+						 * Said out loud when the stored list is shorter than the count:
+						 * a list of ten under a count of forty reads as the whole set of
+						 * problems unless it says otherwise (the SampledSchemaValidation
+						 * precedent beside it).
+						 */}
+						{failuresTotal !== undefined && failuresTotal > failures.length && (
+							<p className="mt-2 text-xs text-muted-foreground tabular-nums">
+								Showing {failures.length} of {failuresTotal}.
+							</p>
+						)}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/src/components/shared/index.ts
+++ b/app/src/components/shared/index.ts
@@ -35,6 +35,9 @@ export * from "./ContractCoverage";
 // "30 of 36 sampled responses matched their schema" - beside the coverage block
 export * from "./SampledSchemaValidation";
 
+// "982 of 1,000 assertions passed" - a load run's test outcome, live and stored
+export * from "./TestValidationSummary";
+
 // "These responses were stored verbatim" - wherever captured samples are shown
 export * from "./CapturedDataWarning";
 

--- a/app/src/modules/dashboard/components/RequestResponseView.tsx
+++ b/app/src/modules/dashboard/components/RequestResponseView.tsx
@@ -28,7 +28,12 @@ import {
 	phasesFromAverages,
 	phasesFromTrace,
 } from "@/components/shared/response-viewer";
-import { SampleRetentionNote, CapturedDataWarning, ThresholdVerdict } from "@/components/shared";
+import {
+	SampleRetentionNote,
+	CapturedDataWarning,
+	ThresholdVerdict,
+	TestValidationSummary,
+} from "@/components/shared";
 import { useRunSamplesQuery } from "@/queries/runs";
 import { httpStatusClass, statusCodeLabel, STATUS_CLASS_STYLE } from "@/constants/http-status";
 
@@ -226,46 +231,13 @@ export default function RequestResponseView({ report }: RequestResponseViewProps
 			    every assertion and still miss the budget it was run to check. */}
 			<ThresholdVerdict verdict={report.thresholdValidation} />
 
-			{/* Test Validation Results */}
-			{report.testValidation && (
-				<Card>
-					<CardHeader>
-						<CardTitle className="text-lg">Test Validation</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<div className="grid grid-cols-[repeat(auto-fit,minmax(130px,1fr))] gap-3">
-							<div>
-								<p className="text-sm text-muted-foreground">Samples Tested</p>
-								<p className="font-bold">{report.testValidation.samplesTested}</p>
-							</div>
-							<div>
-								<p className="text-sm text-muted-foreground">Passed</p>
-								<p className="font-bold text-status-success-text">
-									{report.testValidation.testsPassed}
-								</p>
-							</div>
-							<div>
-								<p className="text-sm text-muted-foreground">Failed</p>
-								<p className="font-bold text-destructive-text">
-									{report.testValidation.testsFailed}
-								</p>
-							</div>
-							<div>
-								<p className="text-sm text-muted-foreground">Success Rate</p>
-								<p className="font-bold">
-									{report.testValidation.successRate.toFixed(1)}%
-								</p>
-							</div>
-						</div>
-						<SampleRetentionNote
-							sampling={report.sampling}
-							shown={report.testValidation.samplesTested}
-							budget="responses"
-							className="mt-3"
-						/>
-					</CardContent>
-				</Card>
-			)}
+			{/* Test Validation Results - the aggregate card, shared with History's
+			    Overview so the numbers cannot drift. This view names each failure
+			    beside its own sample below, so it passes no failure list here. */}
+			<TestValidationSummary
+				testValidation={report.testValidation}
+				sampling={report.sampling}
+			/>
 
 			{/* Sampled Request/Response Results */}
 			{report.results && report.results.length > 0 && (

--- a/app/src/modules/history/main/ScenarioRunView.test.tsx
+++ b/app/src/modules/history/main/ScenarioRunView.test.tsx
@@ -232,6 +232,58 @@ describe("outcomes", () => {
 		}
 	});
 
+	/**
+	 * Issue #726. Thinning drops passing rows only, so tallying the rows makes
+	 * the `passed` chip mean something different per run size - and disagree
+	 * with the step total in the same header strip.
+	 */
+	it("counts the whole run on a thinned run, not the rows that survived", () => {
+		reportQuery.data = report({
+			// One row kept out of 6,000 executed - the failure, as thinning
+			// guarantees.
+			results: [storedStep(0, 0, "failed", { name: "Kept" })],
+			scenario: {
+				iterations: 1,
+				iterationsCompleted: 1,
+				stepsExecuted: 6_000,
+				passed: 5_990,
+				failed: 10,
+				skipped: 0,
+				errored: 0,
+				stepsStored: 1,
+				stepsDropped: 5_999,
+			},
+		});
+
+		render(<ScenarioRunView run={RUN} />);
+
+		// Tally the rows and this reads "0 passed" beside a header claiming
+		// 6,000 steps.
+		expect(outcomeCount("passed")).toContain("5990");
+		expect(outcomeCount("failed")).toContain("10");
+	});
+
+	it("falls back to the streaming rows while the run has no report yet", () => {
+		render(<ScenarioRunView run={{ ...RUN, status: "running" }} />);
+
+		act(() => {
+			const store = useScenarioRunStore.getState();
+			store.startRun("run-1");
+			store.addStep({
+				iteration: 0,
+				stepIndex: 0,
+				name: "Log in",
+				outcome: "passed",
+				statusCode: 200,
+				latencyMs: 40,
+			});
+		});
+
+		// The report's totals are the truth once it exists; until then the only
+		// evidence is what has streamed, and four zeros would be wrong.
+		expect(outcomeCount("passed")).toContain("1");
+	});
+
 	it("gives a skipped step a different row treatment than a passed one", () => {
 		reportQuery.data = report({
 			results: [

--- a/app/src/modules/history/main/ScenarioRunView.tsx
+++ b/app/src/modules/history/main/ScenarioRunView.tsx
@@ -45,6 +45,7 @@ import { cn } from "@/lib/utils";
 import ScenarioStepCard from "./components/ScenarioStepCard";
 import {
 	countOutcomes,
+	outcomeCountsFromReport,
 	stepKey,
 	stepRowsFromReport,
 	thinningDisclosure,
@@ -90,7 +91,15 @@ export default function ScenarioRunView({ run }: ScenarioRunViewProps) {
 	const storedSteps = useMemo(() => stepRowsFromReport(report), [report]);
 	const steps = storedSteps.length > 0 ? storedSteps : liveSteps;
 
-	const counts = useMemo(() => countOutcomes(steps), [steps]);
+	// The report's exact whole-run totals when it can give them, the stored rows
+	// only as a fallback. A thinned run keeps every non-passing row but drops
+	// passes, so counting rows would undercount `passed` against the header's own
+	// step total - the report is the one source that agrees with it (issue #726).
+	// A live run has no report yet and reads its streaming rows until one lands.
+	const counts = useMemo(
+		() => outcomeCountsFromReport(report) ?? countOutcomes(steps),
+		[report, steps]
+	);
 	const thinned = thinningDisclosure(report);
 	const scenario = report?.scenario;
 

--- a/app/src/modules/history/main/components/OverviewTab.tsx
+++ b/app/src/modules/history/main/components/OverviewTab.tsx
@@ -19,15 +19,22 @@ import {
 	CapacitySummary,
 	ContractCoverage,
 	SampledSchemaValidation,
+	TestValidationSummary,
 	ThresholdVerdict,
 } from "@/components/shared";
 import { HeroRow } from "@/modules/dashboard/components/hero/HeroRow";
 import { ModeStatsRow } from "@/modules/dashboard/components/stats/ModeStatsRow";
 import { RunEvents } from "./RunEvents";
+import { extractTestFailures } from "../test-validation";
 import type { TabProps } from "../../types";
 import { httpStatusClass, statusCodeLabel, STATUS_CLASS_STYLE } from "@/constants/http-status";
 
 export default function OverviewTab({ report, derived, anomalies }: TabProps) {
+	// The named failures live on a synthetic result row, not on `testValidation`;
+	// lifted here so the Overview says which assertions failed while the Samples
+	// tab drops the row rather than drawing it as a request that never ran.
+	const testFailures = extractTestFailures(report.results);
+
 	return (
 		<>
 			{/* Mode-adaptive summary - same hero cards + stat row the live dashboard shows.
@@ -60,6 +67,18 @@ export default function OverviewTab({ report, derived, anomalies }: TabProps) {
 			    same document - what was exercised, and what it returned. Absent
 			    for a run that checked nothing. */}
 			<SampledSchemaValidation validation={report.schemaValidation} />
+
+			{/* Whether the run's own assertions passed, and which failed. The
+			    schema block above judges the response against a contract; this
+			    judges it against the run's pm.test scripts - the same distinction
+			    the live dashboard draws. Absent for a run that asserted nothing,
+			    so a run without tests reads exactly as it did before this block. */}
+			<TestValidationSummary
+				testValidation={report.testValidation}
+				sampling={report.sampling}
+				failures={testFailures?.messages}
+				failuresTotal={testFailures?.total}
+			/>
 
 			{/* When the run went wrong, in words. Above the status/error totals
 			    because those are cumulative and this is the thing they hide: a

--- a/app/src/modules/history/main/components/SamplesTab.tsx
+++ b/app/src/modules/history/main/components/SamplesTab.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle, Badge } from "@/components/ui
 import { EmptyState, SampleRetentionNote, CapturedDataWarning } from "@/components/shared";
 import { useRunSamplesQuery } from "@/queries/runs";
 import SampleRequestCard from "./SampleRequestCard";
+import { sampleResultsWithoutValidationRow } from "../test-validation";
 import type { TabProps, SampleResult } from "../../types";
 
 export default function SamplesTab({ report }: TabProps) {
@@ -29,7 +30,12 @@ export default function SamplesTab({ report }: TabProps) {
 		expandedIndex !== null
 	);
 
-	if (!report.results || report.results.length === 0) {
+	// The synthetic test-validation row is not a captured request - it carries no
+	// response, so this tab would draw it as a status-0 card with nothing behind
+	// it. Its failures are named in the Overview instead (issue #726).
+	const samples = sampleResultsWithoutValidationRow(report.results);
+
+	if (samples.length === 0) {
 		return (
 			<Card>
 				{/* The card supplies the frame; EmptyState brings its own padding, so
@@ -51,18 +57,18 @@ export default function SamplesTab({ report }: TabProps) {
 				<div className="flex items-center justify-between">
 					<CardTitle className="text-base">Sampled Request Details</CardTitle>
 					<Badge variant="secondary" className="text-xs">
-						{report.results.length} samples shown
+						{samples.length} samples shown
 					</Badge>
 				</div>
 			</CardHeader>
 			<CardContent className="space-y-2">
 				<SampleRetentionNote
 					sampling={report.sampling}
-					shown={report.results.length}
+					shown={samples.length}
 					budget="traces"
 				/>
 				<CapturedDataWarning sampling={report.sampling} />
-				{report.results.map((sample: SampleResult, idx: number) => (
+				{samples.map((sample: SampleResult, idx: number) => (
 					<SampleRequestCard
 						key={idx}
 						sample={sample}

--- a/app/src/modules/history/main/components/history-test-results.test.tsx
+++ b/app/src/modules/history/main/components/history-test-results.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A load run's test outcomes, read from History (issue #726).
+ *
+ * The engine writes `testValidation` into every load-run report and stores the
+ * named failures on a synthetic result row - and until this issue exactly one
+ * surface read either: the live dashboard's `RequestResponseView`, mounted only
+ * while the run is being watched. Reopened later, a run that failed 13 of 100
+ * sampled test executions was indistinguishable from one that asserted nothing,
+ * precisely where someone audits results. This is the pair of wiring guards for
+ * the two tabs that answer it, which is where the defect lived - not in the
+ * components, which rendered fine.
+ *
+ * Mutation checks: drop `<TestValidationSummary>` from `OverviewTab` and the
+ * first three tests fail; drop the `sampleResultsWithoutValidationRow` call from
+ * `SamplesTab` and the last two do.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import OverviewTab from "./OverviewTab";
+import SamplesTab from "./SamplesTab";
+import { TooltipProvider } from "@/components/ui";
+import { withQueryClient } from "@/test/query-wrapper";
+import { reportToDerived } from "@/modules/dashboard/utils/reportToDerived";
+import type { RunReport } from "@/types";
+
+// Neither tab expands a row here, so this only keeps the lazy captured-samples
+// query away from a real client.
+vi.mock("@/services/api", () => ({
+	apiService: { getRunSamples: vi.fn() },
+}));
+
+/** The synthetic failure row `run_manager.cpp` appends beside the real samples. */
+const VALIDATION_ROW = {
+	timestamp: 1_700_000_000_002,
+	statusCode: 0,
+	latencyMs: 0,
+	error: "Script validation failures",
+	trace: {
+		failures: [
+			"status is 200: expected 404 to equal 200",
+			"body has token: expected undefined to exist",
+		],
+		totalFailed: 13,
+		totalPassed: 87,
+	},
+};
+
+const CAPTURED_SAMPLE = {
+	timestamp: 1_700_000_000_000,
+	statusCode: 200,
+	statusText: "OK",
+	latencyMs: 2,
+};
+
+function makeReport(partial: Partial<RunReport> = {}): RunReport {
+	return {
+		metadata: {
+			runId: "r1",
+			runType: "load",
+			status: "completed",
+			startTime: 0,
+			endTime: 60_000,
+			configuration: { mode: "constant_rps", duration: "60s", targetRps: 1_000 },
+		},
+		summary: {
+			totalRequests: 60_000,
+			successfulRequests: 60_000,
+			failedRequests: 0,
+			errorRate: 0,
+			totalDurationSeconds: 60,
+			avgRps: 1_000,
+		},
+		latency: { min: 1, max: 9, avg: 2, p50: 2, p90: 3, p95: 4, p99: 5 },
+		statusCodes: {},
+		errors: { total: 0, withDetails: 0, types: {} },
+		...partial,
+	};
+}
+
+// `HeroRow` inside the Overview carries tooltips, which need the provider the
+// app shell supplies.
+const renderOverview = (report: RunReport) =>
+	render(
+		withQueryClient(
+			<TooltipProvider>
+				<OverviewTab report={report} derived={reportToDerived(report)} />
+			</TooltipProvider>
+		)
+	);
+
+const renderSamples = (report: RunReport) =>
+	render(withQueryClient(<SamplesTab report={report} derived={reportToDerived(report)} />));
+
+describe("History Overview - a load run's test outcomes", () => {
+	it("shows the run's test tallies", () => {
+		renderOverview(
+			makeReport({
+				testValidation: {
+					samplesTested: 100,
+					testsPassed: 87,
+					testsFailed: 13,
+					successRate: 87,
+				},
+			})
+		);
+
+		expect(screen.getByText("Test Validation")).toBeInTheDocument();
+		expect(screen.getByText("Samples Tested")).toBeInTheDocument();
+		expect(screen.getByText("100")).toBeInTheDocument();
+		expect(screen.getByText("13")).toBeInTheDocument();
+	});
+
+	it("names the failing assertions from the run's stored failure row", () => {
+		renderOverview(
+			makeReport({
+				testValidation: {
+					samplesTested: 100,
+					testsPassed: 87,
+					testsFailed: 13,
+					successRate: 87,
+				},
+				results: [CAPTURED_SAMPLE, VALIDATION_ROW],
+			})
+		);
+
+		expect(screen.getByText("status is 200: expected 404 to equal 200")).toBeInTheDocument();
+		// Thirteen failed, two are stored - said out loud rather than reading as
+		// the whole set of problems.
+		expect(screen.getByText("Showing 2 of 13.")).toBeInTheDocument();
+	});
+
+	it("says nothing about tests for a run that asserted nothing", () => {
+		// Absent, never zeros: a run without scripts must read exactly as it did
+		// before this block existed.
+		renderOverview(makeReport({ results: [CAPTURED_SAMPLE] }));
+
+		expect(screen.queryByText("Test Validation")).not.toBeInTheDocument();
+	});
+});
+
+describe("History Samples - the synthetic failure row", () => {
+	it("does not list the failure row as a sampled request", () => {
+		renderSamples(makeReport({ results: [CAPTURED_SAMPLE, VALIDATION_ROW] }));
+
+		// One captured sample, not two - the failure row has no request behind it
+		// and rendered as a junk status-0 card.
+		expect(screen.getByText("1 samples shown")).toBeInTheDocument();
+		expect(screen.queryByText(/Script validation failures/)).not.toBeInTheDocument();
+	});
+
+	it("says a run whose only row was the failure row captured no samples", () => {
+		renderSamples(makeReport({ results: [VALIDATION_ROW] }));
+
+		expect(screen.getByText("No sampled requests")).toBeInTheDocument();
+	});
+});

--- a/app/src/modules/history/main/scenario-steps.test.ts
+++ b/app/src/modules/history/main/scenario-steps.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect } from "vitest";
 import {
 	appendStepEvent,
 	countOutcomes,
+	outcomeCountsFromReport,
 	stepKey,
 	stepRowsFromReport,
 	thinningDisclosure,
@@ -188,6 +189,61 @@ describe("countOutcomes", () => {
 
 	it("is all zeros for an empty list", () => {
 		expect(countOutcomes([])).toEqual({ passed: 0, failed: 0, skipped: 0, errored: 0 });
+	});
+});
+
+/**
+ * Issue #726. Counting the stored rows undercounts `passed` on any run that
+ * filled `maxScenarioStoredSteps`, because thinning drops passes alone - so the
+ * chips read the engine's exact whole-run totals instead, and fall back to the
+ * rows only when the report cannot say.
+ */
+describe("outcomeCountsFromReport", () => {
+	it("reads the engine's whole-run totals, not the surviving rows", () => {
+		const counts = outcomeCountsFromReport(
+			report({
+				scenario: {
+					iterations: 1,
+					iterationsCompleted: 1,
+					stepsExecuted: 6_000,
+					passed: 5_990,
+					failed: 10,
+					skipped: 0,
+					errored: 0,
+					stepsStored: 5_000,
+					stepsDropped: 1_000,
+				},
+			})
+		);
+
+		// 5,990, not the 4,990 the 5,000 kept rows would tally.
+		expect(counts).toEqual({ passed: 5_990, failed: 10, skipped: 0, errored: 0 });
+	});
+
+	it("is null for a report that carries no scenario summary", () => {
+		// A live run before its report lands, and a load run's report. Both must
+		// leave the caller on the row tally rather than on four zeros.
+		expect(outcomeCountsFromReport(report({}))).toBeNull();
+		expect(outcomeCountsFromReport(undefined)).toBeNull();
+	});
+
+	it("is null when the summary is missing any of the four", () => {
+		// An older sidecar's summary types as complete and is not. A partial read
+		// would report a real count beside a fabricated zero.
+		const partial = report({
+			scenario: {
+				iterations: 1,
+				iterationsCompleted: 1,
+				stepsExecuted: 2,
+				passed: 2,
+				failed: 0,
+				skipped: 0,
+				stepsStored: 2,
+				stepsDropped: 0,
+			} as never,
+		});
+
+		expect(outcomeCountsFromReport(partial)).toBeNull();
 	});
 });
 

--- a/app/src/modules/history/main/scenario-steps.ts
+++ b/app/src/modules/history/main/scenario-steps.ts
@@ -183,6 +183,38 @@ export function countOutcomes(steps: readonly ScenarioStepRow[]): OutcomeCounts 
 }
 
 /**
+ * The run's four outcome totals as the engine counted them, or `null` when the
+ * report cannot say (a live run before its report arrives, or a sidecar older
+ * than these fields).
+ *
+ * These are the **whole-run** counts - `report.scenario.passed/failed/...`,
+ * written from every step the runner executed - not a tally of the stored rows.
+ * The rows are thinned by `maxScenarioStoredSteps` and thinning drops only
+ * passes, so `countOutcomes(steps)` undercounts `passed` on any run that filled
+ * its store: a 6,000-step run keeping 5,000 rows would read "4,990 passed"
+ * beside a header claiming 6,000 steps. The stored-row count stays the list's
+ * own disclosure line (`thinningDisclosure`); the chips read the truth here.
+ *
+ * All four are read defensively: an older report typed as carrying them may
+ * omit one at runtime, and a partial read is worse than falling back to the
+ * rows wholesale.
+ */
+export function outcomeCountsFromReport(report: RunReport | undefined): OutcomeCounts | null {
+	const scenario = report?.scenario;
+	if (!scenario) return null;
+	const { passed, failed, skipped, errored } = scenario;
+	if (
+		typeof passed !== "number" ||
+		typeof failed !== "number" ||
+		typeof skipped !== "number" ||
+		typeof errored !== "number"
+	) {
+		return null;
+	}
+	return { passed, failed, skipped, errored };
+}
+
+/**
  * What the report says the run's own store thinned away, or `null` when it
  * dropped nothing (or is too old to say).
  *

--- a/app/src/modules/history/main/test-validation.test.ts
+++ b/app/src/modules/history/main/test-validation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * Splitting a load run's synthetic test-validation row out of its real samples
+ * (issue #726).
+ *
+ * The two halves are one decision seen twice: whatever `extractTestFailures`
+ * lifts for the Overview to name is exactly what `sampleResultsWithoutValidationRow`
+ * must keep out of the Samples tab, or the row is either shown twice or lost.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+	extractTestFailures,
+	isTestValidationRow,
+	sampleResultsWithoutValidationRow,
+} from "./test-validation";
+import type { SampleResult } from "../types";
+
+const CAPTURED: SampleResult = {
+	timestamp: 1_700_000_000_000,
+	statusCode: 200,
+	statusText: "OK",
+	latencyMs: 12,
+	trace: { request: { method: "GET", url: "https://example.test/" } },
+};
+
+/** A real transport failure: status 0 and an error, but no `failures` list. */
+const CONNECTION_FAILURE: SampleResult = {
+	timestamp: 1_700_000_000_001,
+	statusCode: 0,
+	latencyMs: 0,
+	error: "connection refused",
+	trace: { error_type: "ConnectionError" },
+};
+
+const VALIDATION_ROW: SampleResult = {
+	timestamp: 1_700_000_000_002,
+	statusCode: 0,
+	latencyMs: 0,
+	error: "Script validation failures",
+	trace: {
+		failures: ["status is 200: expected 404 to equal 200"],
+		totalFailed: 13,
+		totalPassed: 87,
+	},
+};
+
+describe("isTestValidationRow", () => {
+	it("identifies the synthetic row by its failures, not by its status code", () => {
+		expect(isTestValidationRow(VALIDATION_ROW)).toBe(true);
+		// Both are status 0 with an error string. Keying on the status would
+		// swallow every connection failure the run recorded.
+		expect(isTestValidationRow(CONNECTION_FAILURE)).toBe(false);
+		expect(isTestValidationRow(CAPTURED)).toBe(false);
+	});
+});
+
+describe("extractTestFailures", () => {
+	it("lifts the failures and the engine's own totals", () => {
+		const failures = extractTestFailures([CAPTURED, VALIDATION_ROW]);
+
+		expect(failures).toEqual({
+			messages: ["status is 200: expected 404 to equal 200"],
+			total: 13,
+			passed: 87,
+		});
+	});
+
+	it("returns null for a run that recorded no failures", () => {
+		expect(extractTestFailures([CAPTURED, CONNECTION_FAILURE])).toBeNull();
+		expect(extractTestFailures([])).toBeNull();
+		expect(extractTestFailures(undefined)).toBeNull();
+	});
+
+	it("falls back to the list length rather than zero when the count is missing", () => {
+		// A row written before the counts existed. Reporting `total: 0` beside a
+		// non-empty list would claim the run failed nothing while showing failures.
+		const row: SampleResult = {
+			...VALIDATION_ROW,
+			trace: { failures: ["a: expected 1 to equal 2", "b: expected 3 to equal 4"] },
+		};
+
+		expect(extractTestFailures([row])).toEqual({
+			messages: ["a: expected 1 to equal 2", "b: expected 3 to equal 4"],
+			total: 2,
+			passed: 0,
+		});
+	});
+});
+
+describe("sampleResultsWithoutValidationRow", () => {
+	it("drops the synthetic row and keeps every captured sample", () => {
+		const kept = sampleResultsWithoutValidationRow([
+			CAPTURED,
+			VALIDATION_ROW,
+			CONNECTION_FAILURE,
+		]);
+
+		expect(kept).toEqual([CAPTURED, CONNECTION_FAILURE]);
+	});
+
+	it("leaves a run without one untouched", () => {
+		expect(sampleResultsWithoutValidationRow([CAPTURED])).toEqual([CAPTURED]);
+		expect(sampleResultsWithoutValidationRow(undefined)).toEqual([]);
+	});
+});

--- a/app/src/modules/history/main/test-validation.ts
+++ b/app/src/modules/history/main/test-validation.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * A load run's per-test failures, as data (issue #726).
+ *
+ * The engine records them on a **synthetic result row** rather than a captured
+ * request: `run_manager.cpp` appends one `Result` whose `trace_data` is
+ * `{failures[], totalFailed, totalPassed}`, with `statusCode 0` and the error
+ * "Script validation failures". It rides in `report.results` beside the real
+ * samples, and `trace.failures` is the only field that tells the two apart - no
+ * captured request ever carries it.
+ *
+ * The live dashboard reads that row inline, per sample. History does not: its
+ * Samples tab would render the row as a status-0 card with no request behind it
+ * (a "junk sample"), so this module lifts the failures out for the Overview to
+ * name and lets the Samples tab drop the row. Pure, so the split and the
+ * extraction are pinned without a DOM.
+ */
+
+import type { SampleResult } from "../types";
+
+/** The named per-test failures a run recorded, lifted off the synthetic row. */
+export interface TestFailures {
+	/** The failure lines, bounded engine-side; {@link total} is the real count. */
+	messages: string[];
+	total: number;
+	passed: number;
+}
+
+/**
+ * Whether this result is the synthetic test-validation row rather than a
+ * captured request. `trace.failures` is present on that row alone, so its
+ * presence - not the status-0 code, which a real connection failure also uses -
+ * is what identifies it.
+ */
+export function isTestValidationRow(result: SampleResult): boolean {
+	return result.trace?.failures !== undefined;
+}
+
+/**
+ * The run's named failures, or `null` when it recorded none (every assertion
+ * passed, or the run asserted nothing). `total` falls back to the list length
+ * for a row that predates the count, never to zero, so a truncated list is not
+ * quietly reported as complete.
+ */
+export function extractTestFailures(results: SampleResult[] | undefined): TestFailures | null {
+	const row = results?.find(isTestValidationRow);
+	const messages = row?.trace?.failures;
+	if (!messages || messages.length === 0) return null;
+	return {
+		messages,
+		total: row?.trace?.totalFailed ?? messages.length,
+		passed: row?.trace?.totalPassed ?? 0,
+	};
+}
+
+/**
+ * The captured samples only - the synthetic failure row removed, so the Samples
+ * tab never renders it as a request that was never sent.
+ */
+export function sampleResultsWithoutValidationRow(
+	results: SampleResult[] | undefined
+): SampleResult[] {
+	if (!results) return [];
+	return results.filter((r) => !isTestValidationRow(r));
+}

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -430,6 +430,7 @@ Three rules the list holds, each pinned by a mutation-checked test:
 - **Rows key on `(iteration, stepIndex)`, never arrival order.** The SSE ring replays from `Last-Event-ID` on reconnect, so a client that resumed mid-run receives events it has already rendered; appending would double every row it re-saw. A malformed `step` payload is dropped by `parseStepEvent` rather than defaulted, because a defaulted `0:0` would *collide* with the real first step.
 - **`skipped` is never `passed`.** It has its own count and its own row treatment (`SampledExchange`'s `state` prop, below). Nothing produces `skipped` until flow control lands, so it is built to render correctly before it can occur.
 - **Thinned results say so.** A run that filled `maxScenarioStoredSteps` reports fewer rows than it ran, with every non-passing step among the ones kept - so a non-zero `stepsDropped` means *successes* are missing. `ScenarioRunView` discloses the three numbers rather than letting `results[]` read as the whole run.
+- **The four chips count the run, not the rows** (issue #726). `outcomeCountsFromReport` reads `report.scenario.passed/failed/skipped/errored` - the engine's exact whole-run totals - and `countOutcomes(steps)` is only the fallback for a live run whose report has not landed yet. Counting rows would undercount `passed` on any thinned run, since thinning drops passes alone: a 6,000-step run keeping 5,000 rows read "4,990 passed" beside a header claiming 6,000 steps, so the chip silently changed meaning with run size. The stored-row count stays the list's own disclosure line above.
 
 A live run can be **stopped** from this tab (`StopRunButton`, below), which matters most for a data-driven run of hundreds of iterations. The control is shown while `isStreaming || run.status is running|pending` - two signals rather than one, because a tab reopened onto a run that is still executing (after a relaunch, or from History) has no stream at all, and is exactly the case where waiting the run out hurts most. It calls `POST /runs/:id/stop`, which needs nothing new engine-side: the scenario runner already checks `should_stop` per *step*, settles the run to `Stopped` and closes the SSE topic, so the streaming tab flips to the stored rows through the same `complete` a normal finish takes. The handler also invalidates the run and its report itself, because a tab that is not the streaming one never receives that event.
 
@@ -481,10 +482,10 @@ The picker is told **which run it is for** (`loadTest`), because a row means som
 
 | Component | Role |
 |---|---|
-| `OverviewTab.tsx` | Summary - renders the dashboard's mode-adaptive `HeroRow` + `ModeStatsRow`; the Rate-Control card is gated to `constant_rps` |
+| `OverviewTab.tsx` | Summary - renders the dashboard's mode-adaptive `HeroRow` + `ModeStatsRow`; the Rate-Control card is gated to `constant_rps`; also the shared `ThresholdVerdict`, `ContractCoverage`, `SampledSchemaValidation` and `TestValidationSummary` (the last carrying the run's named `pm.test` failures) |
 | `RunEvents.tsx` | The run's detected anomaly windows in words (`detectAnomalies`); silent for a clean run |
 | `PerformanceTab.tsx` | Latency/throughput detail |
-| `SamplesTab.tsx`, `SampleRequestCard.tsx` | Sampled request/response pairs |
+| `SamplesTab.tsx`, `SampleRequestCard.tsx` | Sampled request/response pairs; the synthetic test-validation row (`test-validation.ts`) is dropped here so it is never drawn as a request with no response |
 | `ScenarioStepsTab.tsx` | Per-step latency and counts for a **scenario load run** - see below |
 | `TimingBreakdown.tsx` | DNS/connect/TLS/first-byte/download breakdown |
 | `LatencyMetric.tsx`, `HistoricalChartsSection.tsx` | Metric cards + historical charts |
@@ -931,9 +932,11 @@ retry is the reason for saying anything.
 
 One sentence, wherever a sampled set is displayed: how many records the run's
 bounded stores displaced, and that what is on screen is drawn uniformly from
-the whole run rather than its opening. Three surfaces show such a set - the
-dashboard's Sampled Requests and Test Validation cards, and the history Samples
-tab - so the wording lives here once instead of being written out three times.
+the whole run rather than its opening. Several surfaces show such a set - the
+dashboard's Sampled Requests card, the history Samples tab, and the shared
+`TestValidationSummary` (itself rendered in both the dashboard and the history
+Overview) - so the wording lives here once instead of being written out per
+surface and drifting.
 
 Renders nothing when the run displaced nothing, and nothing when the run
 reported no counts at all (an older summary): "nothing was dropped" and "we
@@ -1055,6 +1058,41 @@ failure; a run that checked nothing stays neutral rather than borrowing the
 vocabulary of a failed budget.
 
 The file keeps the name it was given for the load-mode block it was written for.
+
+## Test Validation Summary (`components/shared/TestValidationSummary.tsx`)
+
+Whether a load run's own `pm.test` assertions passed (`RunReport.testValidation`,
+issue #726): samples tested, assertions passed and failed, the success rate, and
+- for the surfaces that have nowhere else to put them - the named failures.
+
+It is the **assertion** counterpart of `SampledSchemaValidation` above it: that
+one judges a response against the contract the run was planned with, this one
+judges it against the scripts the run carries. `ThresholdVerdict` is the third
+reading of the same run and the aggregate of both, since a script sees one
+response at a time and cannot assert a p99.
+
+Two surfaces render it - the live dashboard's `RequestResponseView` and the
+history detail's Overview - and until #726 only the first did. The dashboard is
+mounted **only while a run is being watched**, so a run reopened from History
+showed thresholds, status codes and schema verdicts and never said whether its
+assertions had run at all: a run that failed 13 of 100 sampled test executions
+read exactly like one that asserted nothing, precisely where someone audits
+results.
+
+**The named failures are the History half only.** The engine records them on a
+*synthetic* result row - `run_manager.cpp` appends one `Result` whose
+`trace_data` is `{failures[], totalFailed, totalPassed}`, with `statusCode 0` and
+the error "Script validation failures" - which rides in `report.results` beside
+the real samples. The dashboard lists each failure inline beside that row, so it
+passes the aggregate alone. History cannot: its Samples tab would draw the row as
+a status-0 card with no request behind it, so `main/test-validation.ts` lifts the
+failures out for the Overview to name and filters the row out of the samples
+list. `trace.failures` is what identifies the row - no captured request carries
+it, and the status-0 code alone would also match a real connection failure.
+
+Absent-vs-zero, as everywhere in this family: a run that asserted nothing has no
+`testValidation` at all and renders **nothing**. A shorter failure list than
+`totalFailed` says "Showing N of M" rather than reading as the whole set.
 
 ## Captured Data Warning (`components/shared/CapturedDataWarning.tsx`)
 


### PR DESCRIPTION
## Description

**Plan.** Root cause, both halves: data the engine already writes that no History surface reads. `testValidation` (`runs.cpp`) and the named failures (`run_manager.cpp:400-415`) had exactly one reader - the live dashboard's `RequestResponseView`, mounted only while a run is being watched - and `report.scenario.passed/failed/skipped/errored` had none at all. Approach: extract the Test Validation card to a shared component and render it in History's Overview beside the schema block it is the assertion counterpart of, add a pure module owning the split of the synthetic failure row from the real samples, and point the run-view chips at the report's exact totals with the row tally kept as the live-run fallback. The alternative I rejected for the failure row was rendering it as a sample with a nicer label: it is not a request - it has no method, URL or response - so anything the Samples tab draws for it is a card the reader cannot open, and the failures belong beside the tallies they are the detail of.

Verified against `6fdde30`: the problem still exists exactly as described. `RequestResponseView.tsx:230` is the only `report.testValidation` read in `src/`, `ScenarioRunView.tsx:93` still derives its chips from `countOutcomes(steps)`, and nothing reads the `scenario` outcome totals.

### 1. Load-run test outcomes unreachable after the run

- **`components/shared/TestValidationSummary.tsx`** - the four tallies plus the `SampleRetentionNote`, lifted verbatim out of `RequestResponseView` (which now renders the shared component, so the two surfaces cannot drift), with an optional named-failure list.
- **`main/test-validation.ts`** - pure. The engine records failures on a *synthetic* result row that rides in `report.results` beside the real samples. `extractTestFailures` lifts them for the Overview; `sampleResultsWithoutValidationRow` keeps the row out of the Samples tab, where it drew as a status-0 card with nothing behind it. The row is identified by **`trace.failures`**, deliberately not by its status code - a real connection failure is status 0 with an error string too, and keying on that would have swallowed every one of them.
- `failures` is passed only by History. The dashboard already lists each failure inline beside its own sample, so it passes the aggregate alone; both draw the numbers from the same `testValidation`.
- Absent-not-zeros holds both ways: a run that asserted nothing renders nothing, and a failure list shorter than `totalFailed` says "Showing N of M" (the `SampledSchemaValidation` precedent). `total` falls back to the list length, never to zero, for a row predating the counts.

### 2. Run-view chips undercount every thinned run

`outcomeCountsFromReport` reads the engine's exact whole-run totals; `countOutcomes(steps)` stays the fallback for a live run whose report has not landed yet. Thinning drops passing rows alone, so a 6,000-step run keeping 5,000 read "4,990 passed" beside a header claiming 6,000 steps - the `passed` chip silently changed meaning with run size. It returns `null` unless all four fields are present, because a partial read would print a real count beside a fabricated zero. The stored-row count stays the list's own disclosure line.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- `cd app && pnpm test` - **513 files, 5,616 tests passed** (up from 5,597: +7 `TestValidationSummary.test.tsx`, +7 `test-validation.test.ts`, +5 `history-test-results.test.tsx`, +3 `scenario-steps.test.ts`, +2 `ScenarioRunView.test.tsx`; 3 new files).
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean.
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (the two new headings break no link).
- No engine files changed, so no build or ctest run per `CLAUDE.md`'s "scale the verification" rule - no C++ test could change colour.

Mutation checks, all three run and confirmed, then restored:

1. Remove `<TestValidationSummary>` from `OverviewTab` → 2 of 5 in `history-test-results.test.tsx` fail (the absence test correctly stays green).
2. Replace `sampleResultsWithoutValidationRow(report.results)` with `report.results ?? []` in `SamplesTab` → both Samples tests fail.
3. Revert the chips to `countOutcomes(steps)` → "counts the whole run on a thinned run" fails; the live-run fallback test stays green, which is what makes the pair meaningful.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/app/COMPONENTS.md` - a section for the new shared component, the `OverviewTab` / `SamplesTab` roles in the `LoadTestDetail` table, the chip rule added to `ScenarioRunView`'s pinned-rules list, and the retention note's surface list corrected now that it renders through a shared component in two places.

Only files this change touched were formatted, per the never-format-repo-wide rule.

## Related Issues

Closes #726

Unblocks #730, whose Sequencing says its run-view work lands together with or after this issue - the chips it turns into filter buttons are the same lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NghhHMbSfU67AAVfjFCv31)_