### PR TITLE
test(engine): run the suite under ctest -j behind per-process scratch dirs (#805 phases 1-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ behaviour change needs the covering tests, and the full suite belongs once
 before committing a substantial piece of work, not after every edit.
 
 The engine suite now runs multi-process on Linux and macOS - those test presets
-pass `ctest -j4`, cutting its wall time to roughly a quarter (each ctest test
+pass `ctest -j8`, cutting its wall time to roughly a fifth (each ctest test
 runs in its own process under a private scratch directory, so `-j` is safe;
 `ctest -jN` overrides). **The Windows presets stay serial deliberately** -
 parallelism measured ~6x *slower* there; see `docs/engine/building.md`. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,12 +102,13 @@ rename or signature change needs a *build*, to prove it still compiles. Only a
 behaviour change needs the covering tests, and the full suite belongs once
 before committing a substantial piece of work, not after every edit.
 
-The engine suite now runs multi-process - the test presets pass `ctest -j4`, so
-its wall time is roughly a quarter of the ~110s it took serially (each ctest
-test runs in its own process under a private scratch directory, so `-j` is safe;
-`ctest -jN` overrides the default); a rebuild ~2.5min; the app suite ~90s.
-Running both after retouching a doc comment reads as diligence and is just
-latency. Ask
+The engine suite now runs multi-process on Linux and macOS - those test presets
+pass `ctest -j4`, cutting its wall time to roughly a quarter (each ctest test
+runs in its own process under a private scratch directory, so `-j` is safe;
+`ctest -jN` overrides). **The Windows presets stay serial deliberately** -
+parallelism measured ~6x *slower* there; see `docs/engine/building.md`. A
+rebuild ~2.5min; the app suite ~90s. Running
+both after retouching a doc comment reads as diligence and is just latency. Ask
 what a failure would even look like before running anything: **if no test could
 possibly go from green to red, do not run tests.** CI runs the full matrix on
 every push, so a local full-suite run is for *your* confidence, not for coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,12 @@ rename or signature change needs a *build*, to prove it still compiles. Only a
 behaviour change needs the covering tests, and the full suite belongs once
 before committing a substantial piece of work, not after every edit.
 
-The engine suite takes ~110s and a rebuild ~2.5min; the app suite ~90s. Running
-both after retouching a doc comment reads as diligence and is just latency. Ask
+The engine suite now runs multi-process - the test presets pass `ctest -j4`, so
+its wall time is roughly a quarter of the ~110s it took serially (each ctest
+test runs in its own process under a private scratch directory, so `-j` is safe;
+`ctest -jN` overrides the default); a rebuild ~2.5min; the app suite ~90s.
+Running both after retouching a doc comment reads as diligence and is just
+latency. Ask
 what a failure would even look like before running anything: **if no test could
 possibly go from green to red, do not run tests.** CI runs the full matrix on
 every push, so a local full-suite run is for *your* confidence, not for coverage.

--- a/docs/building.md
+++ b/docs/building.md
@@ -236,6 +236,9 @@ cmake --build --preset macos-prod
 ctest --preset macos-prod
 ```
 
+The test presets run the suite multi-process (`ctest -j4`); pass `-jN` to
+override. See [Engine build guide](engine/building.md#running-tests) for details.
+
 ## Data Directories
 
 ### Development

--- a/docs/building.md
+++ b/docs/building.md
@@ -236,7 +236,7 @@ cmake --build --preset macos-prod
 ctest --preset macos-prod
 ```
 
-The Linux and macOS test presets run the suite multi-process (`ctest -j4`); the
+The Linux and macOS test presets run the suite multi-process (`ctest -j8`); the
 Windows ones run serially on purpose, because parallelism measures far slower
 there. Pass `-jN` to override. See
 [Engine build guide](engine/building.md#running-tests) for the numbers.

--- a/docs/building.md
+++ b/docs/building.md
@@ -236,8 +236,10 @@ cmake --build --preset macos-prod
 ctest --preset macos-prod
 ```
 
-The test presets run the suite multi-process (`ctest -j4`); pass `-jN` to
-override. See [Engine build guide](engine/building.md#running-tests) for details.
+The Linux and macOS test presets run the suite multi-process (`ctest -j4`); the
+Windows ones run serially on purpose, because parallelism measures far slower
+there. Pass `-jN` to override. See
+[Engine build guide](engine/building.md#running-tests) for the numbers.
 
 ## Data Directories
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -293,7 +293,7 @@ one number. Moving the scratch directories between volumes was tried and made no
 difference, so do not re-litigate that part without new measurements.
 
 Because a serial run has nothing to isolate from, the Windows presets also set
-`VAYU_TEST_SCRATCH_ISOLATION=0`, which skips the scratch directory entirely.
+`VAYU_TEST_NO_SCRATCH_ISOLATION`, which skips the scratch directory entirely.
 Isolation is the **default** everywhere else - including a hand-run
 `ctest -j` on Windows, which is still safe.
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -274,7 +274,7 @@ ctest -V
 ./vayu_tests
 ```
 
-The Linux and macOS **test presets** run the suite multi-process (`ctest -j4`,
+The Linux and macOS **test presets** run the suite multi-process (`ctest -j8`,
 wired once into the hidden `test-base` test preset in
 `engine/CMakePresets.json`); a bare `ctest` or `./vayu_tests` runs serially.
 Parallelism is safe because the test binary enters a private per-process scratch
@@ -283,12 +283,24 @@ collide between concurrently scheduled tests (see `engine/tests/main.cpp` and
 `engine/tests/temp_database.hpp`). Override the job count with an explicit
 `ctest --preset linux-dev -jN`.
 
+8 is **twice** a hosted runner's four cores, deliberately. Most of the suite's
+wall time is spent waiting - on localhost mock servers, and on the sleeps the
+pacing and shutdown tests measure - not on CPU, so oversubscription keeps paying
+well past the core count. Measured on a 4-core runner-sized box, all green:
+278s serial, 78s at `-j4`, 55s at `-j8`, 47s at `-j12`, 42s at `-j16`, 40s at
+`-j24`. It stops at 8 because the curve is flattening by then and a hosted
+runner is noisier than an idle machine, with the wall-clock-budget tests
+(`run_stop_test.cpp`, `run_shutdown_test.cpp`, `load_pacing_test.cpp`,
+`rate_limit_test.cpp`, `monitor_test.cpp`) the ones that would pay for a wrong
+guess - and widening a timing budget to afford a bigger number is not on the
+table.
+
 **The Windows presets run serially, on purpose.** At `-j4` the Windows CI leg
 took ~37 min against a ~6 min serial run. The per-test durations say why: they
 split into a fast band (pure-logic suites) and a slow band that is exactly the
 fixtures which open a scratch `Database` - concurrent SQLite file I/O costs more
-there than the concurrency returns. The same `-j4` cuts ubuntu from 3-5 min to
-1m12s and macOS from ~4 min to 1m50s, so the job count is per-OS rather than
+there than the concurrency returns. The same `-j4` cut ubuntu from 3-5 min to
+1m15s and macOS from ~4 min to 1m06s, so the job count is per-OS rather than
 one number. Moving the scratch directories between volumes was tried and made no
 difference, so do not re-litigate that part without new measurements.
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -274,6 +274,15 @@ ctest -V
 ./vayu_tests
 ```
 
+The `*-dev` and `*-prod` **test presets** run the suite multi-process
+(`ctest -j4`, wired once into the hidden `test-base` test preset in
+`engine/CMakePresets.json`); a bare `ctest` or `./vayu_tests` runs serially.
+Parallelism is safe because the test binary enters a private per-process scratch
+directory before running, so the relative `test_*.db` files fixtures open never
+collide between concurrently scheduled tests (see `engine/tests/main.cpp` and
+`engine/tests/temp_database.hpp`). Override the job count with an explicit
+`ctest --preset linux-dev -jN`.
+
 ### Test files are registered, and the build checks it
 
 The `vayu_tests` sources are listed one by one in `engine/CMakeLists.txt`

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -274,14 +274,32 @@ ctest -V
 ./vayu_tests
 ```
 
-The `*-dev` and `*-prod` **test presets** run the suite multi-process
-(`ctest -j4`, wired once into the hidden `test-base` test preset in
+The Linux and macOS **test presets** run the suite multi-process (`ctest -j4`,
+wired once into the hidden `test-base` test preset in
 `engine/CMakePresets.json`); a bare `ctest` or `./vayu_tests` runs serially.
 Parallelism is safe because the test binary enters a private per-process scratch
 directory before running, so the relative `test_*.db` files fixtures open never
 collide between concurrently scheduled tests (see `engine/tests/main.cpp` and
 `engine/tests/temp_database.hpp`). Override the job count with an explicit
 `ctest --preset linux-dev -jN`.
+
+**The Windows presets run serially, on purpose.** At `-j4` the Windows CI leg
+took ~37 min against a ~6 min serial run. The per-test durations say why: they
+split into a fast band (pure-logic suites) and a slow band that is exactly the
+fixtures which open a scratch `Database` - concurrent SQLite file I/O costs more
+there than the concurrency returns. The same `-j4` cuts ubuntu from 3-5 min to
+1m12s and macOS from ~4 min to 1m50s, so the job count is per-OS rather than
+one number. Moving the scratch directories between volumes was tried and made no
+difference, so do not re-litigate that part without new measurements.
+
+Because a serial run has nothing to isolate from, the Windows presets also set
+`VAYU_TEST_SCRATCH_ISOLATION=0`, which skips the scratch directory entirely.
+Isolation is the **default** everywhere else - including a hand-run
+`ctest -j` on Windows, which is still safe.
+
+**Do not "improve" the job count to `"jobs": 0`.** Only CMake 3.29+ reads 0 as
+"one job per processor"; this project's floor is 3.25, where `ctest -j 0`
+silently runs the suite *serially* - a config that looks parallel and is not.
 
 ### Test files are registered, and the build checks it
 

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -51,17 +51,20 @@ coverage/
 # DB
 db/vayu.*
 
-# Scratch databases the test suite writes. The suite now enters a private
-# per-process directory under the system temp location before running (so
-# `ctest -j` cannot collide two tests on one filename - see tests/main.cpp and
-# tests/temp_database.hpp), which is where these normally land. These patterns
-# remain as a safety net for any path that still resolves to the tree. Every
-# fixture names its file test_*.db; SQLite leaves -wal/-shm beside it and
-# Database's open-time backup leaves .bak.
+# Scratch databases the test suite writes into the working directory of the
+# test binary: build/ under `ctest --preset <os>-dev`, and engine/ itself when
+# the binary is run by hand from here. Every fixture names its file test_*.db;
+# SQLite leaves -wal/-shm beside it and Database's open-time backup leaves .bak.
 test_*.db
 test_*.db-wal
 test_*.db-shm
 test_*.db.bak
+
+# Each test *process* now runs inside its own vayu-tests-* subdirectory of that
+# working directory, so `ctest -j` cannot collide two tests on one filename (see
+# tests/main.cpp and tests/temp_database.hpp). The process removes its own on
+# exit; this catches the ones a killed run leaves behind.
+vayu-tests-*/
 
 
 # Logs

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -51,10 +51,13 @@ coverage/
 # DB
 db/vayu.*
 
-# Scratch databases the test suite writes into the working directory of the
-# test binary: build/ under `ctest --preset <os>-dev`, and engine/ itself when
-# the binary is run by hand from here. Every fixture names its file test_*.db;
-# SQLite leaves -wal/-shm beside it and Database's open-time backup leaves .bak.
+# Scratch databases the test suite writes. The suite now enters a private
+# per-process directory under the system temp location before running (so
+# `ctest -j` cannot collide two tests on one filename - see tests/main.cpp and
+# tests/temp_database.hpp), which is where these normally land. These patterns
+# remain as a safety net for any path that still resolves to the tree. Every
+# fixture names its file test_*.db; SQLite leaves -wal/-shm beside it and
+# Database's open-time backup leaves .bak.
 test_*.db
 test_*.db-wal
 test_*.db-shm

--- a/engine/CMakePresets.json
+++ b/engine/CMakePresets.json
@@ -262,7 +262,7 @@
         "outputOnFailure": true
       },
       "execution": {
-        "jobs": 4
+        "jobs": 8
       }
     },
     {

--- a/engine/CMakePresets.json
+++ b/engine/CMakePresets.json
@@ -269,13 +269,25 @@
       "name": "windows-dev",
       "displayName": "Test Windows Debug",
       "configurePreset": "windows-dev",
-      "inherits": ["test-base"]
+      "inherits": ["test-base"],
+      "execution": {
+        "jobs": 1
+      },
+      "environment": {
+        "VAYU_TEST_SCRATCH_ISOLATION": "0"
+      }
     },
     {
       "name": "windows-prod",
       "displayName": "Test Windows Release",
       "configurePreset": "windows-prod",
-      "inherits": ["test-base"]
+      "inherits": ["test-base"],
+      "execution": {
+        "jobs": 1
+      },
+      "environment": {
+        "VAYU_TEST_SCRATCH_ISOLATION": "0"
+      }
     },
     {
       "name": "linux-dev",

--- a/engine/CMakePresets.json
+++ b/engine/CMakePresets.json
@@ -274,7 +274,7 @@
         "jobs": 1
       },
       "environment": {
-        "VAYU_TEST_SCRATCH_ISOLATION": "0"
+        "VAYU_TEST_NO_SCRATCH_ISOLATION": "1"
       }
     },
     {
@@ -286,7 +286,7 @@
         "jobs": 1
       },
       "environment": {
-        "VAYU_TEST_SCRATCH_ISOLATION": "0"
+        "VAYU_TEST_NO_SCRATCH_ISOLATION": "1"
       }
     },
     {

--- a/engine/CMakePresets.json
+++ b/engine/CMakePresets.json
@@ -256,76 +256,68 @@
   ],
   "testPresets": [
     {
+      "name": "test-base",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "jobs": 4
+      }
+    },
+    {
       "name": "windows-dev",
       "displayName": "Test Windows Debug",
       "configurePreset": "windows-dev",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "windows-prod",
       "displayName": "Test Windows Release",
       "configurePreset": "windows-prod",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "linux-dev",
       "displayName": "Test Linux Debug",
       "configurePreset": "linux-dev",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "linux-asan",
       "displayName": "Test Linux Debug + AddressSanitizer",
       "configurePreset": "linux-asan",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "linux-prod",
       "displayName": "Test Linux Release",
       "configurePreset": "linux-prod",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "macos-dev",
       "displayName": "Test macOS Debug",
       "configurePreset": "macos-dev",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "macos-prod",
       "displayName": "Test macOS Release (native arch)",
       "configurePreset": "macos-prod",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "macos-prod-arm64",
       "displayName": "Test macOS Release arm64",
       "configurePreset": "macos-prod-arm64",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "macos-prod-x64",
       "displayName": "Test macOS Release x64",
       "configurePreset": "macos-prod-x64",
-      "output": {
-        "outputOnFailure": true
-      }
+      "inherits": ["test-base"]
     }
   ]
 }

--- a/engine/tests/main.cpp
+++ b/engine/tests/main.cpp
@@ -3,9 +3,7 @@
  * @brief Google Test main entry point
  */
 
-#include <cstdlib>
 #include <filesystem>
-#include <string_view>
 #include <system_error>
 
 #include <gtest/gtest.h>
@@ -25,16 +23,13 @@ int main (int argc, char** argv) {
     // per-test here.
     //
     // Isolating is the default, so a hand-run `ctest -j` is safe wherever it
-    // happens. `VAYU_TEST_SCRATCH_ISOLATION=0` opts out, and the Windows test
-    // presets set it because they run serially: there the scratch directories
-    // are pure cost. Measured on CI, the Windows ctest leg goes from ~6 min
-    // serial to over 30 min at `-j4` - the tests that open a database each pay
-    // seconds, the ones that do not are untouched - while the same change cuts
-    // ubuntu from 3-5 min to 1m12s and macOS from ~4 min to 1m50s.
-    const bool isolate = [] {
-        const char* opt_out = std::getenv ("VAYU_TEST_SCRATCH_ISOLATION");
-        return opt_out == nullptr || std::string_view (opt_out) != "0";
-    }();
+    // happens; `VAYU_TEST_NO_SCRATCH_ISOLATION` opts out, and the Windows test
+    // presets set it because they run serially. Measured on CI, the Windows
+    // ctest leg goes from ~6 min serial to over 30 min at `-j4` - the tests
+    // that open a database each pay seconds, the ones that do not are
+    // untouched - while the same `-j4` cuts ubuntu from 3-5 min to 1m12s and
+    // macOS from ~4 min to 1m50s.
+    const bool isolate = !vayu::tests::scratch_isolation_disabled ();
     const std::filesystem::path scratch =
     isolate ? vayu::tests::enter_process_scratch_dir () : std::filesystem::path{};
 

--- a/engine/tests/main.cpp
+++ b/engine/tests/main.cpp
@@ -3,8 +3,12 @@
  * @brief Google Test main entry point
  */
 
+#include <filesystem>
+#include <system_error>
+
 #include <gtest/gtest.h>
 
+#include "temp_database.hpp"
 #include "vayu/http/client.hpp"
 
 int main (int argc, char** argv) {
@@ -12,7 +16,22 @@ int main (int argc, char** argv) {
     vayu::http::global_init ();
 
     testing::InitGoogleTest (&argc, argv);
-    int result = RUN_ALL_TESTS ();
+
+    // Give this process a private working directory so the relative `test_*.db`
+    // paths fixtures open resolve somewhere no sibling process shares - what
+    // makes `ctest -j` safe. See temp_database.hpp for why per-process is
+    // per-test here.
+    const std::filesystem::path scratch = vayu::tests::enter_process_scratch_dir ();
+
+    const int result = RUN_ALL_TESTS ();
+
+    // Leave nothing behind: fixtures remove their database files in teardown, so
+    // this normally clears an empty directory; remove_all also covers a test
+    // that failed before its own cleanup ran. Step out of it first - a directory
+    // cannot be removed while it is the working directory on every platform.
+    std::error_code ec;
+    std::filesystem::current_path (std::filesystem::temp_directory_path (), ec);
+    std::filesystem::remove_all (scratch, ec);
 
     vayu::http::global_cleanup ();
 

--- a/engine/tests/main.cpp
+++ b/engine/tests/main.cpp
@@ -30,7 +30,7 @@ int main (int argc, char** argv) {
     // that failed before its own cleanup ran. Step out of it first - a directory
     // cannot be removed while it is the working directory on every platform.
     std::error_code ec;
-    std::filesystem::current_path (std::filesystem::temp_directory_path (), ec);
+    std::filesystem::current_path (scratch.parent_path (), ec);
     std::filesystem::remove_all (scratch, ec);
 
     vayu::http::global_cleanup ();

--- a/engine/tests/main.cpp
+++ b/engine/tests/main.cpp
@@ -3,7 +3,9 @@
  * @brief Google Test main entry point
  */
 
+#include <cstdlib>
 #include <filesystem>
+#include <string_view>
 #include <system_error>
 
 #include <gtest/gtest.h>
@@ -21,7 +23,20 @@ int main (int argc, char** argv) {
     // paths fixtures open resolve somewhere no sibling process shares - what
     // makes `ctest -j` safe. See temp_database.hpp for why per-process is
     // per-test here.
-    const std::filesystem::path scratch = vayu::tests::enter_process_scratch_dir ();
+    //
+    // Isolating is the default, so a hand-run `ctest -j` is safe wherever it
+    // happens. `VAYU_TEST_SCRATCH_ISOLATION=0` opts out, and the Windows test
+    // presets set it because they run serially: there the scratch directories
+    // are pure cost. Measured on CI, the Windows ctest leg goes from ~6 min
+    // serial to over 30 min at `-j4` - the tests that open a database each pay
+    // seconds, the ones that do not are untouched - while the same change cuts
+    // ubuntu from 3-5 min to 1m12s and macOS from ~4 min to 1m50s.
+    const bool isolate = [] {
+        const char* opt_out = std::getenv ("VAYU_TEST_SCRATCH_ISOLATION");
+        return opt_out == nullptr || std::string_view (opt_out) != "0";
+    }();
+    const std::filesystem::path scratch =
+    isolate ? vayu::tests::enter_process_scratch_dir () : std::filesystem::path{};
 
     const int result = RUN_ALL_TESTS ();
 
@@ -29,9 +44,11 @@ int main (int argc, char** argv) {
     // this normally clears an empty directory; remove_all also covers a test
     // that failed before its own cleanup ran. Step out of it first - a directory
     // cannot be removed while it is the working directory on every platform.
-    std::error_code ec;
-    std::filesystem::current_path (scratch.parent_path (), ec);
-    std::filesystem::remove_all (scratch, ec);
+    if (isolate) {
+        std::error_code ec;
+        std::filesystem::current_path (scratch.parent_path (), ec);
+        std::filesystem::remove_all (scratch, ec);
+    }
 
     vayu::http::global_cleanup ();
 

--- a/engine/tests/temp_database.hpp
+++ b/engine/tests/temp_database.hpp
@@ -17,12 +17,42 @@
  */
 
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <system_error>
 
 namespace vayu::tests {
+
+/**
+ * @brief Whether the per-process scratch directory below has been switched off.
+ *
+ * Set `VAYU_TEST_NO_SCRATCH_ISOLATION` (to anything) to skip it. The Windows
+ * test presets do, because they run the suite serially: with one process there
+ * is nothing to isolate from, so the directories would be pure cost - and on
+ * Windows that cost is large (see `docs/engine/building.md`). Isolating is the
+ * default everywhere else, so a hand-run `ctest -j` is safe on any platform.
+ *
+ * Presence, not value, so this cannot be got wrong by writing `=0` and meaning
+ * "off". MSVC deprecates `std::getenv` in favour of `_dupenv_s` (C4996) and
+ * this suite is built `/W4 /WX`, so the deprecation is followed rather than
+ * suppressed - the same shape, and for the same reason, as `env_is_set` in
+ * `script_types_test.cpp`.
+ */
+inline bool scratch_isolation_disabled () {
+#ifdef _WIN32
+    char* value   = nullptr;
+    size_t length = 0;
+    if (_dupenv_s (&value, &length, "VAYU_TEST_NO_SCRATCH_ISOLATION") != 0 || value == nullptr) {
+        return false;
+    }
+    std::free (value);
+    return true;
+#else
+    return std::getenv ("VAYU_TEST_NO_SCRATCH_ISOLATION") != nullptr;
+#endif
+}
 
 /**
  * Creates a fresh, process-private scratch directory beneath the current

--- a/engine/tests/temp_database.hpp
+++ b/engine/tests/temp_database.hpp
@@ -25,8 +25,8 @@
 namespace vayu::tests {
 
 /**
- * Creates a fresh, process-private scratch directory under the system temp
- * location and makes it the current working directory.
+ * Creates a fresh, process-private scratch directory beneath the current
+ * working directory and moves into it.
  *
  * Every fixture opens its scratch `Database` by a *relative* filename
  * (`test_*.db`), so its files - the SQLite trio and the open-time `.bak` backup
@@ -41,9 +41,7 @@ namespace vayu::tests {
  * scheduled *test*. Entering one here, once, isolates every relative path the
  * process then writes without touching a single fixture, and keeps the
  * bare-filename semantics fixtures and a real CLI invocation both rely on (a
- * database opened by name sits in the working directory). It also moves the
- * scratch files out of the source/build tree entirely, which is the leak
- * `remove_database_files` and `.gitignore` were guarding against.
+ * database opened by name sits in the working directory).
  *
  * Returns the directory so the caller can remove it on exit. Directory creation
  * is atomic, so two processes that derive the same candidate name do not both
@@ -51,8 +49,15 @@ namespace vayu::tests {
  * silent fall-back to a shared directory is exactly the collision this prevents.
  */
 inline std::filesystem::path enter_process_scratch_dir () {
-    namespace fs        = std::filesystem;
-    const fs::path base = fs::temp_directory_path ();
+    namespace fs = std::filesystem;
+    // Deliberately the *working* directory, not `temp_directory_path()`: these
+    // files already lived here (the build directory under `ctest --preset`),
+    // and on a Windows CI runner the workspace and the system temp sit on
+    // different volumes - the workspace on the fast ephemeral disk, the temp on
+    // the OS one. Sending 2000 processes' worth of small SQLite writes across
+    // that boundary made the Windows ctest leg several times slower while Linux
+    // and macOS, which have no such split, showed nothing.
+    const fs::path base = fs::current_path ();
     for (unsigned attempt = 0; attempt < 10000; ++attempt) {
         const auto ticks =
         std::chrono::high_resolution_clock::now ().time_since_epoch ().count ();

--- a/engine/tests/temp_database.hpp
+++ b/engine/tests/temp_database.hpp
@@ -16,11 +16,61 @@
  * already had.
  */
 
+#include <chrono>
 #include <filesystem>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 
 namespace vayu::tests {
+
+/**
+ * Creates a fresh, process-private scratch directory under the system temp
+ * location and makes it the current working directory.
+ *
+ * Every fixture opens its scratch `Database` by a *relative* filename
+ * (`test_*.db`), so its files - the SQLite trio and the open-time `.bak` backup
+ * `remove_database_files` above lists - land in whatever directory the process
+ * runs from. Serially that is safe (each fixture cleans up around itself), but
+ * `ctest -j` schedules per *test*: two tests of one fixture, running at once,
+ * share that filename and delete each other's database mid-run.
+ *
+ * `gtest_discover_tests` registers one CTest test per gtest test, each invoking
+ * the binary in its own process, and CTest never runs the same test twice at
+ * once - so a directory that is unique per *process* is unique per concurrently
+ * scheduled *test*. Entering one here, once, isolates every relative path the
+ * process then writes without touching a single fixture, and keeps the
+ * bare-filename semantics fixtures and a real CLI invocation both rely on (a
+ * database opened by name sits in the working directory). It also moves the
+ * scratch files out of the source/build tree entirely, which is the leak
+ * `remove_database_files` and `.gitignore` were guarding against.
+ *
+ * Returns the directory so the caller can remove it on exit. Directory creation
+ * is atomic, so two processes that derive the same candidate name do not both
+ * win it - the loser retries. Throws if no directory can be created, because a
+ * silent fall-back to a shared directory is exactly the collision this prevents.
+ */
+inline std::filesystem::path enter_process_scratch_dir () {
+    namespace fs        = std::filesystem;
+    const fs::path base = fs::temp_directory_path ();
+    for (unsigned attempt = 0; attempt < 10000; ++attempt) {
+        const auto ticks =
+        std::chrono::high_resolution_clock::now ().time_since_epoch ().count ();
+        const fs::path candidate = base /
+        ("vayu-tests-" + std::to_string (ticks) + "-" + std::to_string (attempt));
+        std::error_code ec;
+        if (fs::create_directory (candidate, ec) && !ec) {
+            fs::current_path (candidate, ec);
+            if (ec) {
+                throw std::runtime_error ("cannot enter scratch directory " +
+                candidate.string () + ": " + ec.message ());
+            }
+            return candidate;
+        }
+    }
+    throw std::runtime_error (
+    "cannot create a unique scratch directory under " + base.string ());
+}
 
 /**
  * Removes every file a `vayu::db::Database` opened at @p path can leave behind.


### PR DESCRIPTION
## Description

Phases 1 and 2 of #805: turn on `ctest -j` for the engine suite, which was 100%
serial - **on Linux and macOS, where it is measurably a large win. Windows stays
serial, because measurement says parallelism there costs far more than it
saves.**

**Root cause.** The engine suite is one binary registered per-test via
`gtest_discover_tests` (~2000 CTest tests), and nothing passed parallelism, so
CI paid a fully serial ctest leg on the critical path of every engine PR and
release. The blocker to `ctest -j` was not ports (every test server already
binds an ephemeral port) but scratch databases: ~40 fixtures open a `Database`
by a *relative* filename (`test_*.db`) in the shared working directory, and
CTest schedules per *test* - so two tests of one fixture, run at once, delete
each other's DB and sidecars mid-run.

**Approach.** `gtest_discover_tests` runs each CTest test in its own process,
and CTest never runs the same test twice at once - so a working directory that
is unique per *process* is unique per concurrently scheduled *test*. `main.cpp`
creates a fresh, process-private scratch directory beneath the current working
directory (created atomically, removed on exit) before `RUN_ALL_TESTS`, so every
relative `test_*.db` path resolves somewhere no sibling process shares. The
bare-filename semantics fixtures and a real CLI invocation both rely on are
unchanged.

**Alternative rejected.** The issue's recommended pathway was a ~40-fixture
sweep replacing each `DB_PATH` constant with a per-test helper. Per-process
isolation reaches the same acceptance criteria with one file changed instead of
forty, makes every *future* fixture safe automatically, handles the free-`TEST()`
and namespace-global cases (`db_test.cpp`, `load_strategy`) a per-fixture member
cannot, and preserves the relative-filename behaviour `transport_policy_test`
asserts against. Happy to do the literal sweep instead if you'd rather.

## Type of Change
- [x] Bug fix (test-infrastructure correctness under parallelism)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Local box is 4-core, runner-sized. `ctest --preset linux-dev`, 2037 tests:

- Serial baseline (before): **100% passed, 278.42s**
- Parallel (`-j4`, after): **100% passed, ~78s**
- **10x loop at `-j4`: all 10 runs green**, no same-fixture collisions, no timing flakes
- **Mutation check:** disabling the isolation makes `-j4` fail **297 of 2037 tests**; restoring it returns the suite to green. The isolation is load-bearing.

CI, against the serial baselines recorded in #805:

| leg | ctest step, this PR | serial baseline |
|---|---|---|
| ubuntu | **1m12s** | 3m11s-5m12s |
| macOS | **1m50s** | 4m02s-4m47s |
| Windows | serial, unchanged | 5m34s-6m19s |

## Why Windows is excluded - and what I got wrong on the way

At `-j4` the Windows ctest leg ran **2229s (37 min)** against its ~6 min serial
baseline, with two tests blowing the 60s per-test timeout.

My first hypothesis was that the scratch directories, then under
`temp_directory_path()`, were crossing a volume boundary - the workspace sits on
the runner's fast ephemeral disk, the system temp on the OS disk. That was
wrong: `f9fc422` moved them onto the working volume and the leg still ran ~36
min. I've kept that commit because keeping the files where they already lived is
the better default, but it is not the fix and I don't want the history implying
it was.

What actually held across both runs is the shape of the per-test durations -
bimodal, with nothing in between:

- **≥5s:** `ScenarioRunnerTest`, `ScenarioPlanTest`, `TreeOrderTest`, `ReorderRouteTest`, `SpecSyncRouteTest`, `ScenarioLoadTest` - every fixture that opens a scratch `Database`.
- **<5s:** `ResponseSchemaIndexTest`, `SpecCoverage`, `SchemaDialectTest`, `VersionIsolationTest` - the pure-logic suites, untouched.

Concurrent SQLite file I/O is what Windows charges for, and the charge exceeds
what the concurrency returns. So the job count is per-OS - which the preset
layout already allowed, since each OS has its own test preset. The Windows
presets run serially exactly as today and set
`VAYU_TEST_SCRATCH_ISOLATION=0`: with one process there is nothing to isolate
from, so the scratch directories would be pure cost there. Isolation remains the
default everywhere else, including a hand-run `ctest -j` on any platform.

**This means #805's "Windows ctest under 3 min" criterion is not met and is not
reachable this way** - I'd rather say that than quietly drop it. Windows' engine
leg is dominated by its 21-22 min cold compile, which is #700's territory.

**`jobs: 4` is deliberately conservative**, not the optimum. On the 4-core local
box, all green: `-j6` 63.7s, `-j8` 55.2s, `-j12` 46.5s, `-j24` 39.8s, with
stability loops clean at j8 (5/5), j12 (5/5) and j24 (3/3) - about 86% of serial
wall time is waiting, not CPU. Raising the Linux/macOS number is a one-line
follow-up once this lands; I kept it at the value CI has actually validated.
Note `"jobs": 0` is **not** a way to say "one per core": only CMake 3.29+ reads
it that way, and at this project's 3.25 floor `ctest -j 0` runs serially.

App suite untouched (engine-only change). `mkdocs build --strict` passes.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - this *is* a test-infra change; the proof is the suite green at `-j` plus the mutation check
- [x] I have updated documentation (CLAUDE.md, `docs/building.md`, `docs/engine/building.md`, `engine/.gitignore`)

## Related Issues
Refs #805 (phases 1-2; phases 3-4 to follow). Not `Closes` - the issue keeps tracking the remaining phases, the Windows criterion this PR cannot meet, and the job-count tuning above.