### PR TITLE
feat(app/engine/spec): a metadata-only spec read, and a Spec tab that shows a skeleton instead of blanks (#712)

### DIFF
--- a/app/src/config/api-endpoints.ts
+++ b/app/src/config/api-endpoints.ts
@@ -55,6 +55,10 @@ export const API_ENDPOINTS = {
 	// whoever else binds it.
 	SPECS: `/specs`,
 	SPEC_BY_ID: (id: string) => `/specs/${id}`,
+	// The same document without the document (issue #712): what the Spec tab's
+	// card needs, so opening the tab does not transfer a 12 MB spec to paint a
+	// URL and a date. The full read above still backs export, sync and matching.
+	SPEC_META: (id: string) => `/specs/${id}/meta`,
 	// Applying a re-fetched document to the collection bound to it (issue #655):
 	// the new document, the moved binding and the created/updated/deleted
 	// requests in one engine transaction.

--- a/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.test.tsx
@@ -37,6 +37,7 @@ const createRequest = vi.fn();
 const deleteRequest = vi.fn();
 const createSpec = vi.fn();
 const syncSpec = vi.fn();
+const getSpec = vi.fn();
 
 vi.mock("@/services/api", () => ({
 	apiService: {
@@ -47,6 +48,8 @@ vi.mock("@/services/api", () => ({
 		deleteRequest,
 		createSpec,
 		syncSpec: (payload: SpecSyncRequest) => syncSpec(payload),
+		// The stored document is read by the check, not by the tab (issue #712).
+		getSpec: (id: string) => getSpec(id),
 	},
 }));
 
@@ -129,11 +132,14 @@ function renderSync(props: {
 	const wrapper = ({ children }: { children: ReactNode }) => (
 		<QueryClientProvider client={client}>{children}</QueryClientProvider>
 	);
+	// The section is given the binding's id and reads the document itself, so a
+	// test supplies the document by answering that read.
+	if (props.spec) getSpec.mockResolvedValue(props.spec);
 	return render(
 		<SpecSync
 			collection={collection()}
 			collections={props.collections ?? [collection()]}
-			spec={props.spec}
+			specId="spec_1"
 			specFile={undefined}
 			requests={props.requests ?? [request()]}
 		/>,
@@ -260,14 +266,45 @@ describe("SpecSync", () => {
 		}
 	});
 
-	it("cannot be checked until the stored document has loaded", async () => {
-		renderSync({ spec: undefined });
+	/*
+	 * Issue #712. The section used to be gated on a document the tab preloaded -
+	 * so Check was unpressable until a transfer of up to `maxSpecDocumentBytes`
+	 * had finished, for a comparison the user had not asked for yet. It now reads
+	 * the stored bytes when it needs them, which is when Check is pressed.
+	 */
+	it("is pressable before the stored document has been read, and reads it on the click", async () => {
+		let answer: (spec: SpecDocument) => void = () => {};
+		getSpec.mockReturnValue(
+			new Promise<SpecDocument>((resolve) => {
+				answer = resolve;
+			})
+		);
+		importFetch.mockResolvedValue({ content: BOUND });
+		renderSync({});
 
 		const button = screen.getByRole("button", { name: /check for changes/i });
-		expect(button.hasAttribute("disabled")).toBe(true);
-		await waitFor(() => {
-			expect(screen.getByText(/has to load before it can be compared/i)).toBeTruthy();
-		});
+		expect(button.hasAttribute("disabled")).toBe(false);
+		// Nothing is transferred until it is asked for: rendering the section
+		// reads no document at all.
+		expect(getSpec).not.toHaveBeenCalled();
+
+		check();
+
+		await waitFor(() => expect(getSpec).toHaveBeenCalledWith("spec_1"));
+		answer(spec(BOUND));
+		expect(await screen.findByText(/up to date/i)).toBeTruthy();
+	});
+
+	it("says the check failed when the stored document cannot be read", async () => {
+		getSpec.mockRejectedValue(new Error("Spec not found"));
+		renderSync({});
+
+		check();
+
+		expect(await screen.findByText(/couldn't check this document/i)).toBeTruthy();
+		expect(screen.getByText(/spec not found/i)).toBeTruthy();
+		// The comparison never started, so nothing was re-fetched either.
+		expect(importFetch).not.toHaveBeenCalled();
 	});
 	it("applies the whole selection in one call, and stores the bytes it diffed", async () => {
 		const next = doc("List all the pets");

--- a/app/src/modules/collections/CollectionDetail/SpecSync.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecSync.tsx
@@ -33,6 +33,14 @@
  * the two it is about to be, because an unlabelled one would be a write nobody
  * asked for.
  *
+ * **The stored document is read when Check is pressed, not before** (issue
+ * #712). This section is the only reader here that needs the document's *bytes*
+ * - to compare them - and it needs them at the moment a comparison is asked
+ * for. It used to be handed the document the tab had preloaded, which meant
+ * Check stayed disabled until a transfer of up to `maxSpecDocumentBytes` had
+ * finished for a comparison nobody had requested yet; the tab now describes the
+ * document instead of reading it.
+ *
  * The counts are stated in full, zeros included, for the reason `MatchSummary`
  * states its three: "4 changed" alone reads as the whole answer, while "4
  * changed, 0 added, 0 removed, 12 unchanged" is the answer.
@@ -45,7 +53,7 @@ import { Button, DeleteConfirmDialog } from "@/components/ui";
 import { Callout } from "@/components/shared";
 import { apiService } from "@/services/api";
 import { useSpecDocumentLimit } from "@/hooks/useSpecDocumentLimit";
-import { useSyncSpecMutation } from "@/queries/specs";
+import { useSpecContentReader, useSyncSpecMutation } from "@/queries/specs";
 import {
 	diffSpec,
 	type ChangedRequest,
@@ -62,13 +70,7 @@ import {
 import { readSpecOperations, type SpecRequestDraft } from "@/services/openapi/spec-operations";
 import { refetchSpec } from "@/services/openapi/spec-refetch";
 import type { SpecFileLocation } from "@/stores";
-import type {
-	Collection,
-	DeclaredOperation,
-	Request,
-	ResponseSchemaIndex,
-	SpecDocument,
-} from "@/types";
+import type { Collection, DeclaredOperation, Request, ResponseSchemaIndex } from "@/types";
 import { SaveFailed, SectionLabel } from "./shared";
 
 interface SpecSyncProps {
@@ -76,8 +78,15 @@ interface SpecSyncProps {
 	collection: Collection;
 	/** Every stored collection, to find the tag folder an added operation lands in. */
 	collections: readonly Collection[];
-	/** The bound document, or `undefined` while the engine has not answered. */
-	spec: SpecDocument | undefined;
+	/**
+	 * The bound document's id, from the collection's own binding (issue #712).
+	 *
+	 * The id rather than the document: this section is the one reader that needs
+	 * the *bytes*, and it needs them on a click, not on a tab opening. It used to
+	 * take the document the tab had preloaded, which made Check unpressable until
+	 * a 12 MB transfer nobody asked for had finished.
+	 */
+	specId: string;
 	/** Where this machine keeps the picked file, when it was this machine that picked it. */
 	specFile: SpecFileLocation | undefined;
 	/** Every request beneath the bound collection - the same set the counts describe. */
@@ -95,6 +104,15 @@ type CheckState =
 			unresolvedRefs: number;
 			/** The bytes that were diffed, and the ones an apply stores - never a re-fetch. */
 			content: string;
+			/**
+			 * Where the bound document said it came from, read with it (issue #712).
+			 *
+			 * Carried from the check to the apply rather than held beside this state:
+			 * an apply stores a row that records the same origin, and a second piece
+			 * of state for it would go stale the moment a sync moved the binding to a
+			 * new document.
+			 */
+			sourceUrl: string | null;
 			/** The re-fetched document's declared-operation index (issue #629). */
 			operations: DeclaredOperation[];
 			/** And its response schema index (issue #628), carried the same way. */
@@ -106,7 +124,7 @@ type CheckState =
 export default function SpecSync({
 	collection,
 	collections,
-	spec,
+	specId,
 	specFile,
 	requests,
 }: SpecSyncProps) {
@@ -114,14 +132,26 @@ export default function SpecSync({
 	const [state, setState] = useState<CheckState>({ phase: "idle" });
 	const [confirmingDeletes, setConfirmingDeletes] = useState(false);
 	const syncSpec = useSyncSpecMutation();
+	const readSpecContent = useSpecContentReader();
 
 	const handleCheck = async () => {
-		if (!spec || state.phase === "checking") return;
+		if (state.phase === "checking") return;
 		setState({ phase: "checking" });
 		try {
+			/*
+			 * The bound bytes first, and here rather than on mount (issue #712): a
+			 * comparison needs the document this collection is bound to, and this is
+			 * the moment a comparison was asked for. Serial rather than concurrent
+			 * with the re-fetch below, so a stored document that cannot be read says
+			 * *that* instead of racing a network error for which message the user
+			 * gets. Cached by spec id, so a second check - or an export in the same
+			 * session - costs one read, not two.
+			 */
+			const storedDocument = await readSpecContent(specId);
+
 			const { text, unresolvedRefs } = await refetchSpec(
 				{
-					sourceUrl: spec.sourceUrl,
+					sourceUrl: storedDocument.sourceUrl,
 					...(specFile ? { file: specFile } : {}),
 				},
 				{
@@ -139,14 +169,14 @@ export default function SpecSync({
 			// stores (`spec_content_hash`), this holds exactly those bytes, and a
 			// SHA-256 in the renderer would be a copy of that rule with its own
 			// way of being wrong.
-			if (text === spec.content) {
+			if (text === storedDocument.content) {
 				setState({ phase: "unchanged" });
 				return;
 			}
 
 			const read = readSpecOperations(text);
 			const diff = diffSpec({
-				bound: boundDrafts(spec.content),
+				bound: boundDrafts(storedDocument.content),
 				fetched: read.requests,
 				requests,
 			});
@@ -155,6 +185,7 @@ export default function SpecSync({
 				diff,
 				unresolvedRefs,
 				content: text,
+				sourceUrl: storedDocument.sourceUrl,
 				// Carried from the check to the apply so the new document is
 				// stored with its own index (issue #629): the sync writes a new
 				// `spec_documents` row, and one without an index would silently
@@ -174,7 +205,7 @@ export default function SpecSync({
 		);
 
 	const handleApply = () => {
-		if (state.phase !== "diff" || !spec) return;
+		if (state.phase !== "diff") return;
 		const payload = buildSyncPayload({
 			collectionId: collection.id,
 			diff: state.diff,
@@ -185,7 +216,7 @@ export default function SpecSync({
 			// The document is re-fetched from the source the binding recorded, so
 			// the new row records the same one - a file-sourced document keeps
 			// having no URL rather than acquiring one.
-			sourceUrl: spec.sourceUrl,
+			sourceUrl: state.sourceUrl,
 			collections,
 		});
 		syncSpec.mutate(payload, {
@@ -213,7 +244,11 @@ export default function SpecSync({
 					<Button
 						variant="outline"
 						onClick={() => void handleCheck()}
-						disabled={!spec || state.phase === "checking" || syncSpec.isPending}
+						// Pressable as soon as the collection names a document (issue
+						// #712): what it needs is fetched by the click, and the checking
+						// spinner covers that wait honestly. The old gate waited on a
+						// preloaded document the tab no longer transfers.
+						disabled={state.phase === "checking" || syncSpec.isPending}
 					>
 						{state.phase === "checking" ? (
 							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -226,12 +261,6 @@ export default function SpecSync({
 						Re-reads the document and compares it. Nothing is written until you apply.
 					</span>
 				</div>
-
-				{!spec && (
-					<p className="text-[11px] text-muted-foreground">
-						The stored document has to load before it can be compared.
-					</p>
-				)}
 
 				{state.phase === "error" && (
 					<Callout severity="blocking" title="Couldn't check this document">

--- a/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.test.tsx
@@ -52,26 +52,35 @@ const syncSpec = {
 	error: null as Error | null,
 };
 
-const specQuery = {
-	data: undefined as { sourceUrl: string | null; fetchedAt: number } | undefined,
+const specMetaQuery = {
+	data: undefined as
+		| { sourceUrl: string | null; fetchedAt: number; contentBytes: number }
+		| undefined,
 	isLoading: false,
 	isError: false,
 };
 
 let requests: Request[] = [];
+/** Whether the subtree's request lists have answered - the mapped count's input. */
+let requestsLoading = false;
 
 vi.mock("@/queries/collections", () => ({
 	useCollectionsQuery: () => ({ data: [{ id: "col_1", name: "Pets", parentId: undefined }] }),
 	useMultipleCollectionRequests: () => ({
 		requestsByCollection: new Map([["col_1", requests]]),
-		isLoading: false,
+		isLoading: requestsLoading,
 	}),
 	useUpdateCollectionMutation: () => updateCollection,
 }));
 
 vi.mock("@/queries/specs", () => ({
-	useSpecQuery: () => specQuery,
+	// The card describes the document rather than reading it (issue #712).
+	useSpecMetaQuery: () => specMetaQuery,
 	useBindSpecMutation: () => bindSpec,
+	// The Sync section reads the stored bytes when Check is pressed. Stubbed
+	// like the queries above - what a check does with them is asserted in
+	// SpecSync.test.tsx.
+	useSpecContentReader: () => () => new Promise(() => {}),
 	// The Sync section's apply half (issue #655). Stubbed like the two above:
 	// this file renders the tab without a QueryClient, and what a sync writes is
 	// asserted in SpecSync.test.tsx.
@@ -183,8 +192,10 @@ beforeEach(() => {
 	syncSpec.mutate.mockClear();
 	syncSpec.isPending = false;
 	syncSpec.isError = false;
-	specQuery.data = undefined;
-	specQuery.isError = false;
+	specMetaQuery.data = undefined;
+	specMetaQuery.isLoading = false;
+	specMetaQuery.isError = false;
+	requestsLoading = false;
 	importFetch.mockReset();
 	requests = [];
 	useSpecFileStore.setState({ locations: {} });
@@ -357,7 +368,11 @@ describe("a bound collection", () => {
 		collection({ specId: "spec_1", specHash: "9f86d081884c7d659a2feaa0c55ad015", syncedAt: 0 });
 
 	it("shows where the document came from, its hash and how much of the tree it covers", () => {
-		specQuery.data = { sourceUrl: "https://api.example.com/openapi.json", fetchedAt: 0 };
+		specMetaQuery.data = {
+			sourceUrl: "https://api.example.com/openapi.json",
+			fetchedAt: 0,
+			contentBytes: 2048,
+		};
 		requests = [
 			request("r1", "{{baseUrl}}/pets", {
 				operationId: "listPets",
@@ -376,7 +391,7 @@ describe("a bound collection", () => {
 	});
 
 	it("names the picked file when the document has no URL", () => {
-		specQuery.data = { sourceUrl: null, fetchedAt: 0 };
+		specMetaQuery.data = { sourceUrl: null, fetchedAt: 0, contentBytes: 2048 };
 		useSpecFileStore.setState({
 			locations: { col_1: { path: "/home/u/petstore.json", fileName: "petstore.json" } },
 		});
@@ -399,6 +414,56 @@ describe("a bound collection", () => {
 		expect(payload).toEqual({ id: "col_1", openapi: null });
 		options?.onSuccess?.({});
 		expect(useSpecFileStore.getState().locations.col_1).toBeUndefined();
+	});
+
+	/*
+	 * Issue #712. The card used to render blanks while the whole document
+	 * downloaded: the source line printed the "stored with this collection"
+	 * fallback - which is a *claim*, not a blank - and the mapped count flashed
+	 * 0 of 0 before the request lists answered. Both are now skeletons, and the
+	 * mutation check is that the fallback markup is unreachable while pending.
+	 */
+	it("renders a skeleton card while the document is being described, never a fallback source", () => {
+		specMetaQuery.isLoading = true;
+		specMetaQuery.data = undefined;
+		requests = [request("r1", "{{baseUrl}}/pets")];
+
+		render(<SpecTab collection={bound()} />);
+
+		expect(screen.getByTestId("spec-source-skeleton")).toBeTruthy();
+		expect(screen.getByTestId("spec-fetched-skeleton")).toBeTruthy();
+		expect(screen.getByTestId("spec-size-skeleton")).toBeTruthy();
+		// The false statement this replaced: a URL-imported spec claiming to have
+		// come from nowhere in particular, right up until the read landed.
+		expect(screen.queryByText(/a document stored with this collection/i)).toBeNull();
+		// And the pending treatment the card used to have for its one covered
+		// cell, which said nothing about the rest of it.
+		expect(screen.queryByText("…")).toBeNull();
+
+		// The binding's own facts are known before any read - hiding them would be
+		// a second way of describing the document wrongly.
+		expect(screen.getByText("9f86d081884c")).toBeTruthy();
+	});
+
+	it("skeletons the mapped count until the request lists answer, so it cannot flash 0 of 0", () => {
+		requestsLoading = true;
+		requests = [];
+		specMetaQuery.data = { sourceUrl: null, fetchedAt: 0, contentBytes: 2048 };
+
+		render(<SpecTab collection={bound()} />);
+
+		expect(screen.getByTestId("spec-mapped-skeleton")).toBeTruthy();
+		expect(screen.queryByText(/0 of 0 requests/i)).toBeNull();
+	});
+
+	it("shows the document's size once it is described", () => {
+		specMetaQuery.data = { sourceUrl: null, fetchedAt: 0, contentBytes: 12 * 1024 * 1024 };
+
+		render(<SpecTab collection={bound()} />);
+
+		// Through the settings formatter, so the size beside a document and the
+		// limit it is stored under read in the same unit.
+		expect(screen.getByText("12.0 MB")).toBeTruthy();
 	});
 
 	it("offers no picker while a spec is bound - re-binding is sync's job", () => {

--- a/app/src/modules/collections/CollectionDetail/SpecTab.tsx
+++ b/app/src/modules/collections/CollectionDetail/SpecTab.tsx
@@ -41,7 +41,7 @@
 import { useMemo, useRef, useState } from "react";
 import { Download, FileJson, Link2, Loader2, Trash2, Upload } from "lucide-react";
 
-import { Button, Input } from "@/components/ui";
+import { Button, Input, Skeleton } from "@/components/ui";
 import { Callout } from "@/components/shared";
 import { apiService } from "@/services/api";
 import {
@@ -49,13 +49,14 @@ import {
 	useMultipleCollectionRequests,
 	useUpdateCollectionMutation,
 } from "@/queries/collections";
-import { useBindSpecMutation, useSpecQuery } from "@/queries/specs";
+import { useBindSpecMutation, useSpecMetaQuery } from "@/queries/specs";
 import { useSpecDocumentLimit } from "@/hooks/useSpecDocumentLimit";
 import { useSpecFileStore } from "@/stores";
 import { matchOperations } from "@/services/openapi/operation-match";
 import { readSpecOperations } from "@/services/openapi/spec-operations";
 import SpecCoverageLine from "./SpecCoverageLine";
 import { collectSubtreeIds } from "@/modules/collections/tree-utils";
+import { formatBytes } from "@/modules/settings/utils/format-size";
 import ExportSpecDialog from "@/modules/collections/ExportSpecDialog";
 import { hasSpecBinding, type Collection } from "@/types";
 import { formatRelative } from "./format";
@@ -79,6 +80,10 @@ interface PickedSpec {
 export default function SpecTab({ collection }: SpecTabProps) {
 	const binding = collection.openapi;
 	const bound = hasSpecBinding(binding);
+	// The same condition as `bound`, in the form the Sync section needs: it reads
+	// the document by id, and `hasSpecBinding` answers a question rather than
+	// narrowing the field it asked about.
+	const boundSpecId = binding?.specId;
 
 	const { data: collections = [] } = useCollectionsQuery();
 	/*
@@ -91,17 +96,25 @@ export default function SpecTab({ collection }: SpecTabProps) {
 		() => collectSubtreeIds(collection.id, collections),
 		[collection.id, collections]
 	);
-	const { requestsByCollection } = useMultipleCollectionRequests(subtreeIds);
+	const { requestsByCollection, isLoading: requestsLoading } =
+		useMultipleCollectionRequests(subtreeIds);
 	const requests = useMemo(
 		() => [...requestsByCollection.values()].flat(),
 		[requestsByCollection]
 	);
 
+	/*
+	 * The card describes the document; it does not read it (issue #712). A first
+	 * open used to transfer the whole stored spec - 12 MB for Stripe's - to paint
+	 * a source line and a date, because both live on the document rather than on
+	 * the collection's binding. The readers that genuinely need the text (export,
+	 * and the Sync section's comparison) fetch it on the action that needs it.
+	 */
 	const {
-		data: spec,
+		data: specMeta,
 		isLoading: specLoading,
 		isError: specFailed,
-	} = useSpecQuery(binding?.specId);
+	} = useSpecMetaQuery(binding?.specId);
 	const specFile = useSpecFileStore((s) => s.locations[collection.id]);
 	const clearSpecFile = useSpecFileStore((s) => s.clearSpecFile);
 	const setSpecFile = useSpecFileStore((s) => s.setSpecFile);
@@ -255,12 +268,14 @@ export default function SpecTab({ collection }: SpecTabProps) {
 
 			{bound ? (
 				<BoundSpec
-					sourceUrl={spec?.sourceUrl ?? null}
+					sourceUrl={specMeta?.sourceUrl ?? null}
 					fileName={specFile?.fileName}
 					specHash={binding?.specHash}
-					fetchedAt={spec?.fetchedAt}
+					fetchedAt={specMeta?.fetchedAt}
+					contentBytes={specMeta?.contentBytes}
 					syncedAt={binding?.syncedAt}
 					loading={specLoading}
+					requestsLoading={requestsLoading}
 					failed={specFailed}
 					mappedCount={mappedCount}
 					requestCount={requests.length}
@@ -366,11 +381,13 @@ export default function SpecTab({ collection }: SpecTabProps) {
 
 			{bound && <SpecCoverageLine collectionId={collection.id} />}
 
-			{bound && (
+			{boundSpecId && (
 				<SpecSync
 					collection={collection}
 					collections={collections}
-					spec={spec}
+					// The binding's id, not the document: the section reads the stored
+					// bytes itself, when Check is pressed (issue #712).
+					specId={boundSpecId}
 					specFile={specFile}
 					requests={requests}
 				/>
@@ -455,8 +472,10 @@ function BoundSpec({
 	fileName,
 	specHash,
 	fetchedAt,
+	contentBytes,
 	syncedAt,
 	loading,
+	requestsLoading,
 	failed,
 	mappedCount,
 	requestCount,
@@ -465,8 +484,12 @@ function BoundSpec({
 	fileName: string | undefined;
 	specHash: string | undefined;
 	fetchedAt: number | undefined;
+	contentBytes: number | undefined;
 	syncedAt: number | undefined;
+	/** The document's own description is still in flight. */
 	loading: boolean;
+	/** The subtree's request lists are still in flight - the mapped count's input. */
+	requestsLoading: boolean;
 	failed: boolean;
 	mappedCount: number;
 	requestCount: number;
@@ -477,6 +500,12 @@ function BoundSpec({
 	 * only known if this machine is the one that picked it. Neither means the
 	 * document was pasted - so the third line says where it came from as
 	 * precisely as it can rather than inventing a filename.
+	 *
+	 * It is the *settled* answer, and only that (issue #712). While the document
+	 * is being described, all three are unknown, and rendering the fallback then
+	 * is not a blank - it is a false statement: a URL-imported spec would claim
+	 * to have come from nowhere in particular right up until the read lands. So
+	 * a pending card renders a skeleton here, never this string.
 	 */
 	const source = sourceUrl ?? fileName ?? "a document stored with this collection";
 
@@ -485,13 +514,28 @@ function BoundSpec({
 			<SectionLabel>Bound spec</SectionLabel>
 			<div className="rounded-md border border-rule bg-card surface-card p-3 space-y-2">
 				<div className="flex items-center gap-2 text-xs">
-					{sourceUrl ? (
-						<Link2 className="h-3.5 w-3.5 text-primary shrink-0" />
+					{/* The icon is part of the claim - a link icon beside a skeleton would
+					    already be saying the document came from a URL. */}
+					{loading ? (
+						<Skeleton data-testid="spec-source-skeleton" className="h-4 w-64" />
 					) : (
-						<FileJson className="h-3.5 w-3.5 text-primary shrink-0" />
+						<>
+							{sourceUrl ? (
+								<Link2 className="h-3.5 w-3.5 text-primary shrink-0" />
+							) : (
+								<FileJson className="h-3.5 w-3.5 text-primary shrink-0" />
+							)}
+							<span className="font-mono break-all">{source}</span>
+						</>
 					)}
-					<span className="font-mono break-all">{source}</span>
 				</div>
+				{/*
+				 * A cell is a skeleton while *its own* input is unknown, rather than the
+				 * grid going blank as a block: Hash and Bound are read off the
+				 * collection's binding, which this tab has before it renders, and
+				 * hiding a value that is already known would be a second way of
+				 * describing the document wrongly.
+				 */}
 				<dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
 					<div className="flex gap-1.5">
 						<dt>Hash</dt>
@@ -500,18 +544,42 @@ function BoundSpec({
 					<div className="flex gap-1.5">
 						<dt>Operations mapped</dt>
 						<dd className="text-foreground">
-							{mappedCount} of {requestCount} request{requestCount === 1 ? "" : "s"}
+							{requestsLoading ? (
+								<Skeleton data-testid="spec-mapped-skeleton" className="h-3 w-28" />
+							) : (
+								<>
+									{mappedCount} of {requestCount} request
+									{requestCount === 1 ? "" : "s"}
+								</>
+							)}
 						</dd>
 					</div>
 					<div className="flex gap-1.5">
 						<dt>Fetched</dt>
 						<dd className="text-foreground">
-							{loading ? "…" : formatRelative(epochToIso(fetchedAt))}
+							{loading ? (
+								<Skeleton
+									data-testid="spec-fetched-skeleton"
+									className="h-3 w-20"
+								/>
+							) : (
+								formatRelative(epochToIso(fetchedAt))
+							)}
 						</dd>
 					</div>
 					<div className="flex gap-1.5">
 						<dt>Bound</dt>
 						<dd className="text-foreground">{formatRelative(epochToIso(syncedAt))}</dd>
+					</div>
+					<div className="flex gap-1.5">
+						<dt>Size</dt>
+						<dd className="text-foreground">
+							{loading ? (
+								<Skeleton data-testid="spec-size-skeleton" className="h-3 w-16" />
+							) : (
+								formatDocumentSize(contentBytes)
+							)}
+						</dd>
 					</div>
 				</dl>
 				{failed && (
@@ -576,6 +644,18 @@ function MatchSummary({
 			)}
 		</div>
 	);
+}
+
+/**
+ * The document's size, or `-` for a card whose description could not be read.
+ *
+ * Through the settings formatter rather than a second rounding of the same
+ * number: the size shown here and the `maxSpecDocumentBytes` limit shown in
+ * Settings are the same quantity, and two spellings of "1.5 MB" would be one
+ * more thing to keep in step.
+ */
+function formatDocumentSize(bytes: number | undefined): string {
+	return bytes === undefined ? "-" : formatBytes(bytes);
 }
 
 /** The first 12 hex characters - enough to compare two by eye, and it fits. */

--- a/app/src/queries/index.ts
+++ b/app/src/queries/index.ts
@@ -44,6 +44,8 @@ export {
 // Bound OpenAPI documents (issues #637, #638)
 export {
 	useSpecQuery,
+	useSpecMetaQuery,
+	useSpecContentReader,
 	useBindSpecMutation,
 	type BindSpecInput,
 	type BindSpecResult,

--- a/app/src/queries/keys.ts
+++ b/app/src/queries/keys.ts
@@ -145,6 +145,12 @@ export const queryKeys = {
 	specs: {
 		all: ["specs"] as const,
 		detail: (id: string) => [...queryKeys.specs.all, "detail", id] as const,
+		// The same document described rather than transferred (issue #712), under
+		// its own key because it is a different shape of answer: a cached `meta`
+		// must never satisfy a reader that needs `content`, and one document in
+		// two caches is safe precisely because both are immutable - a changed
+		// document is a new id.
+		meta: (id: string) => [...queryKeys.specs.all, "meta", id] as const,
 	},
 
 	// Environments

--- a/app/src/queries/specs.ts
+++ b/app/src/queries/specs.ts
@@ -28,21 +28,77 @@ import type {
 } from "@/types";
 
 /**
- * The document a collection is bound to, or nothing while it is bound to none.
+ * The one description of a full-document read, shared by the query and the two
+ * readers below.
  *
- * The engine has no metadata-only read, so this pulls `content` too - the whole
- * document, capped engine-side at `maxSpecDocumentBytes`. That is the cost of
- * showing where a binding came from, and it is paid once per spec: the response
- * is immutable (a changed document is a *new* document with a new id), so it is
- * cached indefinitely rather than refetched on every visit to the tab.
+ * A document is **immutable** - a changed one is a new document with a new id -
+ * so every reader of it wants the same thing: cached indefinitely, fetched once.
+ * Written once here because three copies of `staleTime: Infinity` beside three
+ * copies of the same `queryFn` is how one of them comes to refetch a 12 MB
+ * document on a window focus.
+ */
+function specDocumentQuery(specId: string) {
+	return {
+		queryKey: queryKeys.specs.detail(specId),
+		queryFn: () => apiService.getSpec(specId),
+		staleTime: Infinity,
+	};
+}
+
+/**
+ * The whole document a collection is bound to - `content` included.
+ *
+ * For the readers that need the text: export (`useOpenApiExportSource`) and the
+ * bound-spec matching the import dialog does. Both run on a user action, which
+ * is the rule this read follows - the Spec tab's card describes the document
+ * with `useSpecMetaQuery` below rather than transferring it (issue #712).
  */
 export function useSpecQuery(specId: string | null | undefined) {
 	return useQuery({
-		queryKey: queryKeys.specs.detail(specId ?? ""),
-		queryFn: () => apiService.getSpec(specId as string),
+		// `""` for a collection that binds nothing, so the disabled query has one
+		// key rather than one per falsy spelling.
+		...specDocumentQuery(specId ?? ""),
+		enabled: !!specId,
+	});
+}
+
+/**
+ * What the bound document *is* - where it came from, when, its hash and size -
+ * without the document (issue #712).
+ *
+ * Opening the Spec tab used to transfer the whole stored document to paint a
+ * source line and a date: 12 MB for Stripe's spec, 9.7 MB for GitHub's, on
+ * every first open, because those two fields live on the document rather than
+ * on the collection's binding. `GET /specs/:id/meta` answers them directly.
+ *
+ * Cached on the same terms as the document itself, and for the same reason: the
+ * row it describes cannot change under a given id.
+ */
+export function useSpecMetaQuery(specId: string | null | undefined) {
+	return useQuery({
+		queryKey: queryKeys.specs.meta(specId ?? ""),
+		queryFn: () => apiService.getSpecMeta(specId as string),
 		enabled: !!specId,
 		staleTime: Infinity,
 	});
+}
+
+/**
+ * Read a stored document's text on demand (issue #712).
+ *
+ * A reader rather than a query, for `useBoundSpecReader`'s reason: the caller is
+ * an event handler. The Sync section needs the bound bytes to compare a
+ * re-fetched document against, and needs them *when Check is pressed* - holding
+ * the button hostage to a background transfer is what this replaced. Going
+ * through `fetchQuery` on the document's own key means a document the tab, the
+ * export dialog or the import dialog has already read is answered from cache.
+ */
+export function useSpecContentReader(): (specId: string) => Promise<SpecDocument> {
+	const queryClient = useQueryClient();
+	return useCallback(
+		(specId) => queryClient.fetchQuery(specDocumentQuery(specId)),
+		[queryClient]
+	);
 }
 
 /**
@@ -74,13 +130,7 @@ export function useBoundSpecReader(): (collections: readonly Collection[]) => Pr
 				if (documents.has(specId)) continue;
 				documents.set(
 					specId,
-					queryClient
-						.fetchQuery({
-							queryKey: queryKeys.specs.detail(specId),
-							queryFn: () => apiService.getSpec(specId),
-							staleTime: Infinity,
-						})
-						.catch(() => null)
+					queryClient.fetchQuery(specDocumentQuery(specId)).catch(() => null)
 				);
 			}
 			const read = new Map(

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -67,6 +67,7 @@ import type {
 	SpecSyncRequest,
 	SpecSyncResponse,
 	SpecDocument,
+	SpecDocumentMeta,
 	OAuth2TokenRequest,
 	OAuth2TokenResponse,
 	OAuth2TokenStatusResponse,
@@ -245,12 +246,27 @@ export const apiService = {
 	},
 
 	/**
-	 * One stored document, `content` included - the engine has no metadata-only
-	 * read, and the Spec tab needs `sourceUrl` and `fetchedAt`, which live on the
-	 * document rather than on the collection's binding.
+	 * One stored document, `content` included - for the readers that need the
+	 * text: export, the sync comparison, and `$ref` resolution. Each of those
+	 * runs on a user action, so the transfer is paid when it buys something.
+	 *
+	 * Describing a document rather than reading it is `getSpecMeta` below.
 	 */
 	async getSpec(id: string): Promise<SpecDocument> {
 		return await httpClient.get<SpecDocument>(API_ENDPOINTS.SPEC_BY_ID(id));
+	},
+
+	/**
+	 * What a stored document *is*, without the document (issue #712).
+	 *
+	 * The Spec tab's card wants `sourceUrl` and `fetchedAt`, which live on the
+	 * document rather than on the collection's binding - and pulling the whole
+	 * document for them cost 12 MB on a first open of a Stripe-sized spec. The
+	 * fields here are the document's own values, so a card painted from this
+	 * read says exactly what one painted from `getSpec` would.
+	 */
+	async getSpecMeta(id: string): Promise<SpecDocumentMeta> {
+		return await httpClient.get<SpecDocumentMeta>(API_ENDPOINTS.SPEC_META(id));
 	},
 
 	/**

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -1189,6 +1189,27 @@ export interface SpecDocument {
 	responseSchemas: ResponseSchemaIndex | null;
 }
 
+/**
+ * A stored document described rather than transferred (issue #712).
+ *
+ * `GET /specs/:id/meta` - what the Spec tab's card needs to paint a source, a
+ * date and a size, without the up-to-`maxSpecDocumentBytes` document behind it
+ * (12 MB for Stripe's spec) riding along on a tab opening. The fields it does
+ * carry are the document's own, value for value; `content`, `operations` and
+ * `responseSchemas` are **absent**, not empty, so "not read here" cannot be
+ * mistaken for "this document has none".
+ */
+export interface SpecDocumentMeta {
+	id: string;
+	/** `null` - not `""` - when the document did not come from a URL. */
+	sourceUrl: string | null;
+	fetchedAt: number;
+	/** Hex sha256, computed engine-side on every write. */
+	hash: string;
+	/** The document's size in bytes - the unit `maxSpecDocumentBytes` caps. */
+	contentBytes: number;
+}
+
 export interface CreateSpecRequest {
 	/** Engine-assigned - see CreateCollectionRequest.id. */
 	id?: never;

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -333,6 +333,7 @@ and then unbound holds `{}`. On `updateCollection` the field is
 ```typescript
 apiService.createSpec(data): Promise<SpecDocument>       // POST /specs
 apiService.getSpec(id): Promise<SpecDocument>            // GET  /specs/:id
+apiService.getSpecMeta(id): Promise<SpecDocumentMeta>    // GET  /specs/:id/meta
 apiService.syncSpec(payload): Promise<SpecSyncResponse>  // POST /specs/sync
 ```
 
@@ -356,9 +357,25 @@ A document is immutable - a changed spec is a new
 document and a moved binding, which is what keeps a run's `specHash` stamp
 meaningful - and the **hash is computed engine-side** on the bytes it stored,
 never here. There is no delete call: unbinding is a `PUT /collections/:id`, and
-the document stays for whatever else binds it. `getSpec` returns `content` too
-(the engine has no metadata-only read), so `useSpecQuery` caches it with
-`staleTime: Infinity` rather than refetching a whole document to redraw a tab.
+the document stays for whatever else binds it. Both reads are cached with
+`staleTime: Infinity`, because the row behind a given id cannot change.
+
+**Describing a document and reading one are two calls** (issue #712).
+`getSpecMeta` answers `sourceUrl`, `fetchedAt`, `hash` and `contentBytes` and
+nothing else; `getSpec` sends `content` and both extracted indexes with it - up
+to `maxSpecDocumentBytes`, which is 12 MB for Stripe's published spec. The rule
+for choosing is what the caller does with the answer:
+
+| Caller | Read | Why |
+|--------|------|-----|
+| The Spec tab's card (`useSpecMetaQuery`) | meta | It paints a source, a date and a size; it never renders the document |
+| The Sync section's Check (`useSpecContentReader`) | full, on the click | It compares bytes, and the click is when a comparison was asked for |
+| Export (`useOpenApiExportSource`), the import dialog's bound-spec match | full, on the action | They rewrite or diff the document itself |
+
+Reading the full document *on tab open* is the thing this split removed: a first
+open of a bound tab transferred the whole spec to paint two fields, on a query
+that then sat in cache forever. A reader that needs the text still asks for it -
+on the action that needs it, where the wait is something the user started.
 
 #### Requests
 

--- a/docs/app/state-management.md
+++ b/docs/app/state-management.md
@@ -1280,6 +1280,15 @@ patched in place from the mutation's response, the same way a delete patches
 them, because the sidebar polls only its first page and a refetch would leave a
 pin invisible on any page the user had scrolled to.
 
+`specs.detail(id)` and `specs.meta(id)` are the same document under two keys
+(issue #712): the full read carries `content` and both extracted indexes, the
+meta read describes the row and nothing else. They are kept apart rather than
+merged so a cached description can never satisfy a reader that needs the text -
+and holding one row twice is safe here precisely because a document is immutable,
+which is also why both carry `staleTime: Infinity`. The Spec tab's card reads
+meta; export, the import dialog's bound-spec match and the Sync section's Check
+read the full document, each on the action that needs it.
+
 **Automatic Invalidation:**
 - Mutations automatically invalidate related queries (e.g., creating a request invalidates the collection's request list)
 - Some mutations use optimistic updates and cache updates for instant UI feedback

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1353,6 +1353,44 @@ names the count, the cap and the setting.
 validating it is what every reader wants it for. `404` (message `Spec not found`)
 when it does not exist.
 
+Read it for the *text*: an export, a re-fetch comparison, a `$ref` resolution.
+A client that only needs to describe the document should read the metadata route
+below instead - `content` here is up to `maxSpecDocumentBytes` (12 MB for
+Stripe's published spec), and it is sent in full on every read.
+
+### GET /specs/:id/meta
+
+Everything about a stored document except the document (issue #712).
+
+**Response:**
+```json
+{
+  "id": "spec_3f2b1c9a-...",
+  "sourceUrl": "https://api.example.com/openapi.json",
+  "fetchedAt": 1730000000000,
+  "hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "contentBytes": 12058329
+}
+```
+
+Every field carries the same value `GET /specs/:id` would give it - the two are
+one row seen two ways - and `404` is the same body, so a client that falls back
+from one to the other does not need two shapes of "not found".
+
+**`content`, `operations` and `responseSchemas` are absent, not empty.** All
+three are the fields that make a document big (both indexes are extracted from
+it and grow with it), and an empty one would be indistinguishable from a
+document that genuinely has none - the distinction `operations: null` exists to
+draw. A reader that needs any of them reads the full route.
+
+`contentBytes` is the document's size as the engine counts it - the same measure
+`maxSpecDocumentBytes` refuses a write by, so a size reported here and the limit
+it was stored under are in one unit.
+
+This route exists because binding metadata lives on the *document*: the app's
+Spec tab paints a source and a fetch date, and getting them used to cost a
+transfer of the whole spec on every first open of the tab.
+
 ### DELETE /specs/:id
 
 Delete a stored document.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -56,7 +56,7 @@ The daemon listens on `http://127.0.0.1:9876`. Key endpoints:
 | GET | `/health` | Health check |
 | POST | `/import/apply` | Persist a whole parsed import atomically; returns a temp-id -> real-id map |
 | GET | `/requests/:id/examples` | A request's saved example responses (issue #481), in stored order |
-| POST | `/specs` | Store an OpenAPI document (issue #637); `GET`/`DELETE /specs/:id` read and remove it |
+| POST | `/specs` | Store an OpenAPI document (issue #637); `GET`/`DELETE /specs/:id` read and remove it, `GET /specs/:id/meta` describes it without sending it (issue #712) |
 | POST | `/specs/sync` | Apply a re-fetched document to the collection bound to it (issue #655) - new document, moved binding and the created/updated/deleted requests in one transaction |
 | POST | `/collections`, `/requests`, `/environments`, `/requests/:id/examples` | **Create only** - 409 on an existing id |
 | PUT | `/collections/:id`, `/requests/:id`, `/environments/:id`, `/requests/:id/examples/:exampleId` | **Update only** (merge-patch) - 404 on a missing id |

--- a/engine/include/vayu/utils/json.hpp
+++ b/engine/include/vayu/utils/json.hpp
@@ -57,6 +57,17 @@ using Json = nlohmann::json;
 [[nodiscard]] Json serialize (const vayu::db::SpecDocument& spec);
 
 /**
+ * @brief The same document without the parts that make it big (issue #712).
+ *
+ * What `GET /specs/:id/meta` answers: the fields describing the document -
+ * where it came from, when, its hash and how many bytes it is - with `content`
+ * and both app-extracted indexes left out entirely rather than emptied, because
+ * an empty index is a document that declares nothing and this is a document
+ * whose index was not read.
+ */
+[[nodiscard]] Json serialize_meta (const vayu::db::SpecDocument& spec);
+
+/**
  * @brief Serialize an Environment to JSON
  */
 [[nodiscard]] Json serialize (const vayu::db::Environment& environment);

--- a/engine/src/http/routes/specs.cpp
+++ b/engine/src/http/routes/specs.cpp
@@ -365,6 +365,30 @@ get_spec_document_response (vayu::db::Database& db, const std::string& id) {
 }
 
 /**
+ * Testable core of GET /specs/:id/meta - what the document *is*, without the
+ * document (issue #712).
+ *
+ * Exists because the Spec tab's card needs `sourceUrl` and `fetchedAt` and
+ * nothing else, and those live on the row rather than on the collection's
+ * binding - so painting a URL and a date cost a transfer of the whole document
+ * (12 MB for Stripe's spec) on every first open. Readers that need the text -
+ * export, the sync comparison, `$ref` resolution - still read the full route,
+ * on an action rather than on a tab opening.
+ *
+ * A missing id answers the **same** 404 body as the full read: the two are one
+ * resource seen two ways, and a client that fell back from one to the other
+ * must not have to know two shapes of "not found".
+ */
+std::pair<int, nlohmann::json>
+get_spec_document_meta_response (vayu::db::Database& db, const std::string& id) {
+    auto spec = db.get_spec_document (id);
+    if (!spec) {
+        return { 404, error_body (404, "Spec not found") };
+    }
+    return { 200, vayu::json::serialize_meta (*spec) };
+}
+
+/**
  * Testable core of DELETE /specs/:id.
  *
  * A spec still bound by a collection is a **409 naming the collection**, never a
@@ -434,6 +458,31 @@ void register_spec_routes (RouteContext& ctx) {
         } catch (const std::exception& e) {
             vayu::utils::log_error ("POST /specs - Error: " + std::string (e.what ()));
             send_error (res, 400, e.what ());
+        }
+    });
+
+    /**
+     * GET /specs/:id/meta
+     * Returns everything about the document except the document: id, sourceUrl,
+     * fetchedAt, hash and contentBytes. `content` and the two app-extracted
+     * indexes are **absent**, not empty - see `serialize_meta`.
+     * Registered before the read below because both are `GET /specs/...`; the
+     * one-segment pattern cannot match this path, and the order says so anyway.
+     * Returns: the metadata, or 404 (the same body the full read answers with).
+     */
+    ctx.server.Get (R"(/specs/([^/]+)/meta)",
+    [&ctx] (const httplib::Request& req, httplib::Response& res) {
+        const std::string spec_id = req.matches[1];
+        try {
+            auto [status, body] = get_spec_document_meta_response (ctx.db, spec_id);
+            if (status != 200) {
+                vayu::utils::log_warning ("GET /specs/:id/meta - Spec not found: " + spec_id);
+            }
+            res.status = status;
+            res.set_content (body.dump (), "application/json");
+        } catch (const std::exception& e) {
+            vayu::utils::log_error ("GET /specs/:id/meta - Error: " + std::string (e.what ()));
+            send_error (res, 500, e.what ());
         }
     });
 

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -346,6 +346,28 @@ Json serialize (const vayu::db::SpecDocument& s) {
     return json;
 }
 
+Json serialize_meta (const vayu::db::SpecDocument& s) {
+    // Built from the full serialization and *narrowed*, never spelled a second
+    // time: two hand-written shapes of one row is how `sourceUrl` comes to be
+    // `null` on one read and `""` on the other. A field added above therefore
+    // reaches this read too unless it is named here - which is what the erase
+    // list is, and what `SpecMetaCarriesTheSameValuesAsTheFullDocument` pins.
+    Json json = serialize (s);
+    // The three heavy fields, and the only reason this route exists: the
+    // document is up to `maxSpecDocumentBytes` and both indexes are extracted
+    // from it, so a "metadata" read carrying any of them would transfer what
+    // the caller asked not to be sent.
+    json.erase ("content");
+    json.erase ("operations");
+    json.erase ("responseSchemas");
+    // Bytes as the engine counts them - `content.size()`, the same measure
+    // `spec_size_cap` refuses a write by, so a size shown beside a document and
+    // the limit it was stored under are the same unit. SQLite's `length()`
+    // would count characters and quietly disagree on any non-ASCII document.
+    json["contentBytes"] = s.content.size ();
+    return json;
+}
+
 Json serialize (const vayu::db::Collection& c) {
     Json json;
     json["id"] = c.id;

--- a/engine/tests/specs_route_test.cpp
+++ b/engine/tests/specs_route_test.cpp
@@ -50,6 +50,8 @@ create_spec_document_response (vayu::db::Database& db, const nlohmann::json& jso
 std::pair<int, nlohmann::json>
 get_spec_document_response (vayu::db::Database& db, const std::string& id);
 std::pair<int, nlohmann::json>
+get_spec_document_meta_response (vayu::db::Database& db, const std::string& id);
+std::pair<int, nlohmann::json>
 delete_spec_document_response (vayu::db::Database& db, const std::string& id);
 std::string spec_content_hash (const std::string& content);
 // Defined in collections.cpp / requests.cpp / import.cpp.
@@ -221,6 +223,69 @@ TEST_F (SpecsRouteTest, ReadsBackTheStoredDocumentAndAnswers404ForAMissingOne) {
 
     auto [missing, missing_body] = routes::get_spec_document_response (*db_, "spec_nope");
     EXPECT_EQ (missing, 404) << missing_body.dump ();
+}
+
+TEST_F (SpecsRouteTest, SpecMetaCarriesTheSameValuesAsTheFullDocumentWithoutTheHeavyFields) {
+    // A document with *both* app-extracted indexes, because they are the two
+    // fields that make a "metadata" read expensive if they ride along: they are
+    // extracted from the document and grow with it.
+    const json operations =
+    json::array ({ json{ { "operationId", "listPets" }, { "method", "GET" },
+    { "path", "/pets" }, { "responses", json::array ({ "200" }) } } });
+    const json response_schemas = { { "refRoots", json::object () },
+        { "operations",
+        json::array ({ json{ { "method", "GET" }, { "path", "/pets" },
+        { "responses",
+        json::array ({ json{ { "status", "200" }, { "contentType", "application/json" },
+        { "schema", json{ { "type", "array" } } } } }) } } }) } };
+    auto [create_status, created] = routes::create_spec_document_response (*db_,
+    json{ { "content", PETSTORE }, { "sourceUrl", "https://example.test/openapi.json" },
+    { "operations", operations }, { "responseSchemas", response_schemas } });
+    ASSERT_EQ (create_status, 200) << created.dump ();
+    const std::string id = created.value ("id", std::string{});
+
+    auto [status, meta] = routes::get_spec_document_meta_response (*db_, id);
+    ASSERT_EQ (status, 200) << meta.dump ();
+
+    // Absent, not empty. `"content": ""` would read as a document with no text
+    // and `"operations": []` as one that declares nothing - both of which are
+    // states a document can genuinely be in, so an unread field must not spell
+    // itself the same way (the repo's absent-not-empty rule).
+    EXPECT_FALSE (meta.contains ("content")) << meta.dump ();
+    EXPECT_FALSE (meta.contains ("operations")) << meta.dump ();
+    EXPECT_FALSE (meta.contains ("responseSchemas")) << meta.dump ();
+
+    // Bytes as the engine counts them - the same measure the write cap refuses
+    // by, so the number beside a document is in the unit of its limit.
+    EXPECT_EQ (meta["contentBytes"].get<size_t> (), std::string (PETSTORE).size ());
+
+    // Every other key is the full read's answer, value for value: the two are
+    // one row seen two ways, and a client that reads `sourceUrl` from the cheap
+    // route must get exactly what the expensive one would have said. This is
+    // what stops the meta shape drifting when a field is added above.
+    auto [full_status, full] = routes::get_spec_document_response (*db_, id);
+    ASSERT_EQ (full_status, 200) << full.dump ();
+    for (const auto& [key, value] : meta.items ()) {
+        if (key == "contentBytes") {
+            continue; // derived here; the full read carries no such field
+        }
+        ASSERT_TRUE (full.contains (key)) << key << " is not a field of the document";
+        EXPECT_EQ (value, full[key]) << key;
+    }
+    EXPECT_EQ (meta["sourceUrl"].get<std::string> (), "https://example.test/openapi.json");
+    EXPECT_EQ (meta["hash"].get<std::string> (), routes::spec_content_hash (PETSTORE));
+    EXPECT_GT (meta["fetchedAt"].get<int64_t> (), 0);
+}
+
+TEST_F (SpecsRouteTest, SpecMetaAnswersTheSame404AsTheFullReadForAMissingDocument) {
+    auto [meta_status, meta] = routes::get_spec_document_meta_response (*db_, "spec_nope");
+    auto [full_status, full] = routes::get_spec_document_response (*db_, "spec_nope");
+
+    EXPECT_EQ (meta_status, 404) << meta.dump ();
+    // One resource, two reads: a client falling back from one to the other must
+    // not have to know two shapes of "not found".
+    EXPECT_EQ (meta_status, full_status);
+    EXPECT_EQ (meta, full) << meta.dump () << " vs " << full.dump ();
 }
 
 TEST_F (SpecsRouteTest, DeletesAnUnboundDocument) {


### PR DESCRIPTION
## Description

**Root cause.** The Spec tab's card needs `sourceUrl` and `fetchedAt`, and both live on the *document* rather than on the collection's binding - so `useSpecQuery` -> `GET /specs/:id` pulled the whole stored document on first open (12 MB for Stripe's spec, 9.7 MB for GitHub's) to paint a URL and a date, with `staleTime: Infinity` making it precisely a first-open experience. While it was in flight the card was not merely blank: the source line rendered `sourceUrl ?? fileName ?? "a document stored with this collection"`, which for a URL-imported spec is a false statement until the read lands, and the mapped count flashed `0 of 0`.

**Approach.** Split describing a document from reading one.

- Engine: `GET /specs/:id/meta` returns `id`, `sourceUrl`, `fetchedAt`, `hash` and `contentBytes`, with `content`, `operations` and `responseSchemas` **absent, not empty**. `serialize_meta` builds the meta shape by narrowing the full serialization rather than spelling the fields a second time, and the test asserts every key it carries equals the full read's value for that key - so the two views of one row cannot drift when a field is added. `404` is the same body as the full read.
- App: the card reads meta (`useSpecMetaQuery`); the full read stays for the callers that need the text - export, the import dialog's bound-spec match, and the Sync section's comparison - each fetched on the action that needs it.
- Sync: `Check for changes` was disabled until the tab's background full-document query had answered ("The stored document has to load before it can be compared"). It now takes the binding's `specId` and reads the stored bytes **on the click**, through `fetchQuery` on the document's own key so an export or a second check reuses the read. The gate and its note are gone with the transfer they waited on; the existing `checking` spinner already covers the wait honestly.
- Pending state: cells whose input is unknown render the `Skeleton` primitive - the source line and `Fetched`/`Size` while the meta read is in flight, `Operations mapped` while the subtree's request lists are. `Hash` and `Bound` come off the collection's binding, which the tab has before it renders, so they are **not** skeletoned: hiding a value that is already known would be a second way of describing the document wrongly.

**Alternative rejected.** The issue offered `?meta=1` on the existing route as an option. A separate path gives the app its own cache key (`queryKeys.specs.meta(id)`), which is what stops a cached *description* from ever satisfying a reader that needs `content` - a query-string variant would have collided on the same route in the API surface and made that distinction a convention instead of a shape. I also considered a DB-level column select so the engine never materializes `content` at all; it is not in this diff because SQLite's `length()` counts characters rather than bytes and `contentBytes` has to be in the unit `maxSpecDocumentBytes` refuses a write by. The transfer was the cost this issue names, and an in-process row read is not it.

**Deviation from the issue spec, disclosed.** `SpecCoverageLine` is untouched. It is silent until it has both a run and a report and then appears - it never states a wrong number, so it has nothing to skeleton; the issue asked for the same treatment "if it currently pops".

`contentBytes` is part of the meta shape the issue asked for, and it has a reader: a new **Size** cell on the card, formatted through the existing settings `formatBytes` so a document's size and the limit it is stored under read in one unit.

## Type of Change
- [x] Bug fix (a pending card that made a false claim; a button gated on a transfer nobody asked for)
- [x] New feature (`GET /specs/:id/meta`)
- [ ] Breaking change
- [x] Documentation update

## Testing

All green on this branch, all commands from the issue:

- **Engine** - `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`: **2039 tests, 100% passed** (354s). Two new tests in `specs_route_test.cpp`: meta carries the full read's values with the three heavy fields absent (not empty), and a missing id answers the same 404 body as the full route.
- **Mutation check (engine)**: dropping `json.erase("content")` from `serialize_meta` reddens `SpecMetaCarriesTheSameValuesAsTheFullDocumentWithoutTheHeavyFields`; restoring it returns the suite to green.
- **App** - `pnpm test`: **518 files, 5649 tests, 100% passed**. `pnpm type-check`, `pnpm lint` and `prettier --check` on the touched files are clean (only files that were already clean were formatted).
- New app tests: the card renders skeletons for source/fetched/size while pending **and the fallback source string is unreachable there** (the mutation check the issue asked for), the mapped count cannot flash `0 of 0`, the size renders once known, Check is pressable before any document has been read and reads it on the click, and a stored document that cannot be read reports the failure without re-fetching anything.
- `mkdocs build --strict` passes for the docs edits.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `docs/engine/api-reference.md` (the new read), `docs/app/api-integration.md` (which caller reads which shape, and why), `docs/app/state-management.md` (the two spec keys and their cache policy), `engine/CLAUDE.md` (endpoint table)

## Related Issues
Closes #712

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXb4gtK8CckiTSFixmZ9ZH)_