### PR TITLE
perf(ci/app): quality checks off the suite's critical path, Windows vitest sharded (#805)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -26,6 +26,20 @@ name: PR CI - run tests
 # paying for a full three-platform C++ build that could not be affected by the
 # diff. Split, an app-only pull request reports in roughly four minutes and an
 # engine-only one stops paying for three Node installs.
+#
+# The same argument, applied a second time to what was left (#805 phase 3). The
+# app job had grown back to 9m03s-9m12s on Windows against 6m03s-6m50s
+# elsewhere, and the shape was the same one: work that could not fail
+# differently sitting in front of, or beside, the work that could.
+#
+#   app windows  9m03s   one unsharded vitest run, 7m35s-7m58s of it
+#   app ubuntu   6m03s   lint 39s + format 13s + type-check 22s, then vitest
+#
+# So the platform-independent checks moved out to `quality`, which runs beside
+# the suites rather than ahead of one of them, and the Windows leg is two
+# vitest shards on two runners. Both are wall-clock changes only - the same
+# checks run on the same code, and `ci-gate` proves the shards between them ran
+# every file the suite contains.
 on:
   pull_request:
     branches:
@@ -143,8 +157,66 @@ jobs:
               - 'scripts/test/pre-commit_test.sh'
               - '.github/workflows/pr-tests.yml'
 
+  # Lint, formatting and type-check are platform-independent, so one runner
+  # answers for all three - they used to run inside the app job, where roughly
+  # 1.2 min of them stood in front of the suite that is the job's whole point,
+  # and the type-check ran a second and third time on runners that could not
+  # answer differently. Out here they run beside the tests instead of ahead of
+  # them (#805 phase 3).
+  #
+  # Nothing platform-specific is lost. `forceConsistentCasingInFileNames` makes
+  # the casing question a *Linux* question, and tsc has no other per-platform
+  # verdict; the matrix below exists for what the suite asserts at runtime, not
+  # for what the compiler says about the same files three times.
+  quality:
+    name: App quality checks
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true'
+    permissions:
+      contents: read
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint frontend
+        working-directory: app
+        run: pnpm lint
+
+      - name: Check frontend formatting
+        working-directory: app
+        run: pnpm format:check
+
+      # Three tsc projects, run concurrently by the script itself. A failing
+      # project still fails the script - `concurrently` defaults to
+      # `--success all` - and unlike the `&&` chain it replaced, all three now
+      # report their errors in one run instead of stopping at the first.
+      - name: Type-check frontend
+        working-directory: app
+        run: pnpm type-check
+
   app:
-    name: App on ${{ matrix.os }}
+    name: App on ${{ matrix.os }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
     runs-on: ${{ matrix.os }}
     needs: changes
     if: needs.changes.outputs.code == 'true' && needs.changes.outputs.app == 'true'
@@ -153,11 +225,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # All three, even though nothing here compiles. The suite asserts
-        # platform behaviour (`platform.test.ts`, `updater.test.ts`) and the
-        # macOS runner is the only one that has ever caught a regression in the
-        # macOS branch - see the testing section of CLAUDE.md.
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # All three platforms, even though nothing here compiles. The suite
+        # asserts platform behaviour (`platform.test.ts`, `updater.test.ts`) and
+        # the macOS runner is the only one that has ever caught a regression in
+        # the macOS branch - see the testing section of CLAUDE.md.
+        #
+        # Windows is split in two because it is the wall of every app-only pull
+        # request: one unsharded run measured 7m35s-7m58s there against ~5 min
+        # on the other two, for a 9m03s-9m12s job. The suite is already parallel
+        # within a run (`pool: threads`, no worker cap) - the second runner buys
+        # what more threads on one runner cannot. ubuntu and macOS stay
+        # unsharded: they are not the wall, and a second runner each would cost
+        # more than it saves.
+        #
+        # `shard` is the literal vitest argument, so the index and the count
+        # cannot drift apart. Adding a third shard means adding `3/3` here *and*
+        # renumbering the others - the coverage check in `ci-gate` fails loudly
+        # if that is done by halves.
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+            shard: 1/2
+          - os: windows-latest
+            shard: 2/2
     # Roughly 4 minutes on the slowest runner; the ceiling is for a cold pnpm
     # store, not for the steady state.
     timeout-minutes: 20
@@ -184,25 +275,61 @@ jobs:
         working-directory: app
         run: pnpm install --frozen-lockfile
 
-      # Lint and formatting are platform-independent, so one runner answers for
-      # all three - the matrix exists for the suite's platform assertions.
-      - name: Lint frontend
-        if: matrix.os == 'ubuntu-latest'
-        working-directory: app
-        run: pnpm lint
-
-      - name: Check frontend formatting
-        if: matrix.os == 'ubuntu-latest'
-        working-directory: app
-        run: pnpm format:check
-
-      - name: Type-check frontend
-        working-directory: app
-        run: pnpm type-check
-
+      # One step rather than two `if`-guarded ones, so the unsharded and sharded
+      # invocations cannot drift. The json report is written only where it is
+      # read - by the manifest step below.
       - name: Run frontend tests
         working-directory: app
-        run: pnpm test
+        shell: bash
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          if [[ -z "$SHARD" ]]; then
+            pnpm test
+          else
+            pnpm test --shard="$SHARD" --reporter=default --reporter=json --outputFile.json=vitest-shard.json
+          fi
+
+      # A sharded suite is green when each shard is green, which is also true of
+      # a shard that ran nothing at all. These two files are what makes the
+      # difference visible: what this shard ran, and what the suite contains.
+      # `ci-gate` unions them across the shards and compares.
+      - name: Record what this shard ran
+        if: matrix.shard
+        id: manifest
+        working-directory: app
+        shell: bash
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          index="${SHARD%%/*}"
+          node scripts/shard-manifest.mjs vitest-shard.json > "shard-${index}.txt"
+          pnpm exec vitest list --filesOnly | node scripts/shard-manifest.mjs - > "full-suite-${index}.txt"
+          ran=$(wc -l < "shard-${index}.txt")
+          total=$(wc -l < "full-suite-${index}.txt")
+
+          # The manifest script already refuses an empty shard. This is the
+          # other half: a shard that ran *everything* means `--shard` was
+          # accepted and ignored, which reads as a pass while costing twice the
+          # runner time it was meant to save.
+          if [[ "$ran" -ge "$total" ]]; then
+            echo "::error::Shard $SHARD ran $ran of $total files - the shard argument did not take effect"
+            exit 1
+          fi
+
+          echo "artifact=vitest-shard-manifest-${index}" >> "$GITHUB_OUTPUT"
+          echo "- shard \`$SHARD\` ran **$ran** of **$total** test files" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload this shard's manifest
+        if: matrix.shard
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.manifest.outputs.artifact }}
+          path: |
+            app/shard-*.txt
+            app/full-suite-*.txt
+          if-no-files-found: error
+          retention-days: 1
 
   engine:
     name: Engine on ${{ matrix.os }}
@@ -475,9 +602,67 @@ jobs:
     # filter cannot be read as "nothing to test". Without it, a broken `changes`
     # job skips everything, and "skipped" would pass this gate on a change
     # nobody ran.
-    needs: [changes, app, engine, installer, build-script]
+    needs: [changes, quality, app, engine, installer, build-script]
     if: always()
+    # `actions: read` is what lets the download below reach this run's own
+    # artifacts; everything else here reads job results, which need nothing.
+    permissions:
+      contents: read
+      actions: read
     steps:
+      # The shard coverage proof lives here rather than in a job of its own
+      # because this is the only job that already runs after both Windows
+      # shards, and two file downloads add seconds to it instead of a runner
+      # start to the wall clock. It runs before the result check below so that a
+      # suite which was half-run is reported as such even on a run where every
+      # job is green - which is exactly the shape of the failure it guards.
+      - name: Collect the app shard manifests
+        if: needs.app.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          pattern: vitest-shard-manifest-*
+          merge-multiple: true
+          path: shard-manifests
+
+      - name: Prove the shards ran the whole suite between them
+        if: needs.app.result == 'success'
+        shell: bash
+        run: |
+          shopt -s nullglob
+          manifests=(shard-manifests/shard-*.txt)
+          suites=(shard-manifests/full-suite-*.txt)
+
+          # One manifest per sharded leg. A count that is not 2 means the matrix
+          # gained or lost a shard without this number following it - the case
+          # where `1/2` and `2/3` coexist and a third of the suite runs nowhere.
+          if [[ ${#manifests[@]} -ne 2 || ${#suites[@]} -ne 2 ]]; then
+            echo "::error::Expected 2 shard manifests, found ${#manifests[@]}"
+            exit 1
+          fi
+
+          # Both shards enumerate the suite from the same commit, so a
+          # disagreement means one of them was looking at a different tree and
+          # the comparison below would prove nothing.
+          if ! diff -u "${suites[0]}" "${suites[1]}"; then
+            echo "::error::The shards disagree about which test files exist"
+            exit 1
+          fi
+
+          duplicated=$(sort "${manifests[@]}" | uniq -d)
+          if [[ -n "$duplicated" ]]; then
+            echo "::error::Shards overlap - these files ran twice:"
+            echo "$duplicated"
+            exit 1
+          fi
+
+          sort -u "${manifests[@]}" > union.txt
+          if ! diff -u union.txt "${suites[0]}"; then
+            echo "::error::The shards did not run every test file (- ran, + expected)"
+            exit 1
+          fi
+
+          echo "- Windows shards covered all **$(wc -l < union.txt)** test files, none twice" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Pass if every job succeeded or was skipped
         run: |
           changes="${{ needs.changes.result }}"
@@ -499,6 +684,7 @@ jobs:
               status=1
             fi
           }
+          check quality   "${{ needs.quality.result }}"
           check app       "${{ needs.app.result }}"
           check engine    "${{ needs.engine.result }}"
           check installer "${{ needs.installer.result }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,10 +206,11 @@ pnpm format:check  # Prettier
 pnpm type-check
 ```
 
-The PR workflow runs `pnpm lint` and `pnpm format:check` on the app job, so a
-new `any`, a `react-hooks` violation or an unformatted file fails CI. Where a
-rule genuinely cannot be satisfied, suppress it on the single line with a
-comment saying why - an unexplained `eslint-disable` is treated as a defect.
+The PR workflow runs all three on its `App quality checks` job - one Linux
+runner, in parallel with the test jobs - so a new `any`, a `react-hooks`
+violation, an unformatted file or a type error fails CI. Where a rule genuinely
+cannot be satisfied, suppress it on the single line with a comment saying why -
+an unexplained `eslint-disable` is treated as a defect.
 
 ## Testing
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -52,6 +52,11 @@ lerna-debug.log*
 # Testing
 coverage/
 .nyc_output/
+# Written by a sharded run (`pnpm test --shard=1/2 --reporter=json ...`) and by
+# the manifest step that reads it; CI keeps them only as an artifact.
+vitest-shard.json
+shard-*.txt
+full-suite-*.txt
 
 # Temporary files
 *.tmp

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,scss,md,html,yml,yaml,cjs,mjs}\"",
 		"format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,scss,md,html,yml,yaml,cjs,mjs}\"",
-		"type-check": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.electron-test.json",
+		"type-check": "concurrently --group --names renderer,electron,electron-tests \"tsc --noEmit\" \"tsc -p tsconfig.node.json --noEmit\" \"tsc -p tsconfig.electron-test.json\"",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},

--- a/app/scripts/shard-manifest.mjs
+++ b/app/scripts/shard-manifest.mjs
@@ -1,0 +1,66 @@
+/**
+ * Normalises a list of test files to one path per line - relative to `app/`,
+ * POSIX-separated, sorted - so that two lists produced on different runners can
+ * be compared as text. CI unions the Windows shards' manifests and compares
+ * them against the full file list, so a shard that quietly ran half of what it
+ * should shows up there as a hole rather than as a green job.
+ *
+ * Two sources, because they answer different questions:
+ *
+ *   shard-manifest.mjs <report.json>   what a sharded run actually executed
+ *   vitest list --filesOnly | ... -    what the suite contains
+ *
+ * `vitest list --filesOnly --shard=1/2` would answer the first without running
+ * anything, and does not work: `list` accepts `--shard` and ignores it
+ * (measured on vitest 4.1.8 - each shard lists the whole suite). The only
+ * honest source for "which files did this shard run" is the report of a run
+ * that happened.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const [source] = process.argv.slice(2);
+if (!source) {
+	console.error("usage: shard-manifest.mjs <vitest-json-report>|-");
+	process.exit(2);
+}
+
+const appRoot = path.resolve(import.meta.dirname, "..");
+
+/*
+ * `vitest list` prints paths relative to its root (`app/`) on Linux and macOS
+ * and with backslashes on Windows, while the JSON report carries absolute
+ * paths. Resolving both against `app/` before relativising makes either spelling
+ * land on the same string, which is the only reason a manifest written on a
+ * Windows runner can be diffed against one written anywhere else.
+ */
+const relativeToApp = (file) =>
+	path
+		.relative(appRoot, path.resolve(appRoot, file.replace(/\\/g, "/")))
+		.split(path.sep)
+		.join("/");
+
+const readSource = () => {
+	if (source === "-") {
+		return readFileSync(0, "utf8")
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean);
+	}
+	const report = JSON.parse(readFileSync(source, "utf8"));
+	return (report.testResults ?? []).map((result) => result.name);
+};
+
+const files = readSource().map(relativeToApp).sort();
+
+/*
+ * An empty list is the failure this guard exists for - a shard whose `--shard`
+ * argument never reached vitest, or an enumeration that matched nothing. Fail
+ * here rather than write a file whose emptiness reads downstream as "covered".
+ */
+if (files.length === 0) {
+	console.error(`${source === "-" ? "stdin" : source} lists no test files.`);
+	process.exit(1);
+}
+
+process.stdout.write(`${files.join("\n")}\n`);

--- a/docs/app/building.md
+++ b/docs/app/building.md
@@ -83,7 +83,7 @@ app/
 | `pnpm electron:watch` | Watch Electron code for changes |
 | `pnpm electron:build` | Full production build (compile + build + package) |
 | `pnpm electron:pack` | Package Electron app (requires build first) |
-| `pnpm type-check` | TypeScript type checking (renderer, main process, and the Electron tests) |
+| `pnpm type-check` | TypeScript type checking (renderer, main process, and the Electron tests - the three projects run concurrently, and a failure in any of them fails the script) |
 | `pnpm lint` | Run ESLint |
 
 ## Development Workflow

--- a/docs/building.md
+++ b/docs/building.md
@@ -362,6 +362,10 @@ The project uses GitHub Actions for automated builds:
 - **PR Tests**: `.github/workflows/pr-tests.yml`
   - Runs on every pull request
   - Tests engine and frontend on Linux/Windows/macOS
+  - Lint, formatting and type-check run once, on their own Linux job, rather
+    than in front of a suite they cannot affect
+  - The Windows frontend suite runs as two vitest shards on two runners; the
+    `CI gate` job proves they covered every test file between them
 
 - **Release Build**: `.github/workflows/release.yml`
   - Triggers on version tags (`v*`)


### PR DESCRIPTION
## Description

Phase 3 of #805 - the app/CI structure half. Phases 1-2 landed in #808; phase 4
(`release.yml` splits) and the Windows ctest `-j` question stay open on the
issue, so this is `Refs`, not `Closes`.

**Plan.** The root cause is one shape appearing twice: work that cannot fail
differently sitting in front of, or beside, the work that can. Lint,
`format:check` and `type-check` ran *inside* the app job, so ~1.2 min of them
delayed the start of the suite that is the job's whole point on ubuntu - and the
type-check ran a second and third time on Windows and macOS, which cannot answer
differently (`forceConsistentCasingInFileNames` makes casing a Linux question;
tsc has no other per-platform verdict). The Windows leg was one unsharded vitest
run, 7m35s-7m58s of a 9m03s-9m12s job, and it is the wall of every app-only pull
request. So: a `quality` job beside the suites rather than ahead of one, and two
Windows shards on two runners. **Alternative rejected:** reordering the checks to
run *after* vitest inside the same job, which the issue offers as the cheaper
option. It shortens nothing - the job still ends when the slowest step ends - and
it delays the fastest failure signal a reviewer gets (a lint error would arrive
five minutes later than today). Also rejected: sharding all three platforms.
ubuntu and macOS are not the wall at ~6 min, and a second runner each would cost
more than it saves.

**The shard coverage proof.** A sharded suite is green when each shard is green,
which is also true of a shard that ran nothing at all - so the shards prove their
coverage rather than asserting it. Each writes what it ran (from its own run's
json report) and what the suite contains (`vitest list --filesOnly`), and
`ci-gate` unions them and diffs against the file list. It lives in `ci-gate`
because that is the only job already downstream of both shards: two file
downloads add seconds there, where a job of its own would add a runner start to
the wall clock.

**One trap worth naming**, and it is in the script so nobody pays for it twice:
`vitest list --filesOnly --shard=1/2` looks like the way to build this guard
without running anything, and it does not work. `list` accepts `--shard` and
ignores it - measured on 4.1.8, every shard lists all 519 files. The manifest has
to come from a run that happened.

**`type-check` concurrency.** The three tsc projects now run through
`concurrently` (already a devDependency) instead of an `&&` chain: 25.1s -> 18.5s
locally. Failure semantics are preserved and improved - `concurrently` defaults
to `--success all`, so any failing project still fails the script, and all three
report instead of stopping at the first.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] CI / tooling (no runtime code changed)

## Testing

No engine file is touched and no renderer source changes, so per `CLAUDE.md`'s
"scale the verification to what the change could actually break" the engine build
and ctest were not run - no C++ test could change colour. Everything the change
can reach, on `2c0715d`:

- `pnpm test` - **519 files, 5658 tests, 100% passed** (unsharded, the ubuntu and
  macOS legs' invocation)
- The sharded invocation, both halves, exactly as CI runs it:
  **shard 1/2 - 260 files / 2576 tests passed**, **shard 2/2 - 259 files / 3082
  tests passed**. 260 + 259 = 519, and the union of the two manifests is equal to
  the full file list.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean (the one new file
  was formatted; nothing else was touched by prettier)
- `mkdocs build --strict` - clean

Every guard mutation-checked by running the workflow's own shell verbatim against
the real manifests:

| Mutation | Result |
|---|---|
| a file removed from one shard's manifest (ran nowhere) | gate fails, naming the file |
| a file present in both manifests (ran twice) | gate fails, naming the file |
| one shard's manifest missing entirely | gate fails on the count |
| the shards enumerating different trees | gate fails on the diff |
| a report listing zero files | the shard's own job fails |
| a report listing all 519 files (`--shard` ignored) | the shard's own job fails |
| baseline, unmutated | passes, summary reads "covered all 519 test files, none twice" |

And for `type-check`, a type error introduced in each of the three projects in
turn (`src/lib/utils.ts`, `electron/main.ts`, `electron/app-paths.test.ts`): each
exits 1 naming its own project, with the other two still reported.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - the guards above are the tests; CI
      logic is only testable in CI, per the precedent in `cache-warm.yml`
- [x] I have updated documentation - `CONTRIBUTING.md` (the checks run on their
      own job now, not "on the app job"), `docs/building.md` (the CI section),
      `docs/app/building.md` (the `type-check` row)

## Related Issues
Refs #805 - phase 3 of four. Phase 4 and the Windows ctest `-j` gap keep the
issue open, the way #691 kept #690 open for its third item.

**One thing to confirm before merging.** The Windows app legs are renamed - `App
on windows-latest` becomes `App on windows-latest (shard 1/2)` and `(shard 2/2)`.
This is safe if `CI gate` is the only required check, which is what this
workflow's own header comment says it is; if branch protection also names the
per-OS app checks, the two old Windows names would sit "Expected" forever and
need updating in the ruleset.

---
_Generated by [Claude Code](https://claude.ai/code/session_012eeQp11w5PFoTNkyu5cuXy)_