### PR TITLE
test(engine/tls): verify a custom CA on a wire, and correct the claim that said we already did (#812)

### DIFF
--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -139,7 +139,7 @@ Dependencies are managed via vcpkg and specified in `engine/vcpkg.json`:
 | libsodium | SHA-256, HMAC-SHA256, base64 and hex (PKCE, Basic/OAuth credentials, `pm.crypto`) |
 | nlohmann-json | JSON parsing/serialization |
 | valijson | JSON Schema validation of responses against a bound OpenAPI document |
-| cpp-httplib | HTTP server library |
+| cpp-httplib | HTTP server library - built with the `openssl` feature, which the test suite's HTTPS listener needs (custom-CA verification is asserted on a real handshake, not reasoned about) |
 | sqlite3 | Embedded database |
 | sqlite-orm | C++ ORM for SQLite |
 | gtest | Unit testing framework |
@@ -397,8 +397,8 @@ Set `VCPKG_ROOT` environment variable or install vcpkg in a standard location.
 
 ### Linker Errors
 
-- Ensure all vcpkg dependencies are installed: `vcpkg install curl[http2] libsodium nlohmann-json valijson cpp-httplib sqlite3 sqlite-orm gtest`
-  (the `http2` feature is required - without it libcurl is built without nghttp2 and the HTTP/2 support test fails)
+- Ensure all vcpkg dependencies are installed: `vcpkg install curl[http2] libsodium nlohmann-json valijson cpp-httplib[openssl] sqlite3 sqlite-orm gtest`
+  (the `http2` feature is required - without it libcurl is built without nghttp2 and the HTTP/2 support test fails; the `openssl` feature is required for the same reason one step further along - without it `httplib::SSLServer` does not exist and the TLS-verification tests do not compile)
 - On Windows, ensure Visual Studio C++ tools are installed
 
 ### Build Script Issues

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -244,9 +244,25 @@ Three things worth knowing before you design around them:
   `customCaCertificates` setting beside the database and **extends** the
   platform's trust rather than replacing it: on an OpenSSL build CAINFO *is*
   the whole store, so the file is the system anchors plus the user's, while
-  Schannel and Apple SecTrust keep their OS store. The per-backend claim is
-  tested on each CI platform (`TlsBackend.AcceptsACustomCaBundleOnThisPlatform`)
-  rather than reasoned about, because a wrong claim here is a security claim. A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
+  Schannel and Apple SecTrust keep their OS store. That claim is checked on
+  each CI platform rather than reasoned about, because a wrong claim here is a
+  security claim - by **two** tests answering two different questions, and the
+  distinction matters because for a while only the first existed and the docs
+  read as though it covered both (#812).
+  `TlsBackend.AcceptsACustomCaBundleOnThisPlatform` asks the narrow one:
+  whether this build's backend refuses `CURLOPT_CAINFO` outright
+  (`CURLE_NOT_BUILT_IN`). It stands up no server and verifies nothing.
+  `CustomCaVerificationTest` (`tests/tls_verification_test.cpp`) asks the one a
+  user cares about, on a wire: an in-process HTTPS listener holds a certificate
+  a per-run CA signed (`tests/tls_server.hpp`), and the send verifies once that
+  CA is pasted into `customCaCertificates`, fails before it is, fails against a
+  CA that signed nothing here - the case that separates real verification from
+  a bundle read and ignored - and still verifies when a second anchor is added
+  beside it, which is the additive rule observed rather than asserted. That
+  listener is why `cpp-httplib` carries the `openssl` feature in
+  `engine/vcpkg.json`. Still structural, not on a wire: the *client*
+  certificate's handshake, tracked by #802.
+  A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
   the target's `ConnectionFailed` - and `curl_to_error` now takes the handle,
   because a 407 answered to a CONNECT is a plain `CURLE_RECV_ERROR` and only
   `CURLINFO_HTTP_CONNECTCODE` remembers a proxy said no.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -260,8 +260,17 @@ Three things worth knowing before you design around them:
   a bundle read and ignored - and still verifies when a second anchor is added
   beside it, which is the additive rule observed rather than asserted. That
   listener is why `cpp-httplib` carries the `openssl` feature in
-  `engine/vcpkg.json`. Still structural, not on a wire: the *client*
-  certificate's handshake, tracked by #802.
+  `engine/vcpkg.json`. **The two backends do not answer this the same way, and
+  the wire is how we found out.** Where curl revocation-checks the chain itself
+  - the Schannel path does, passing `CERT_CHAIN_REVOCATION_CHECK_CHAIN` unless
+  told not to - a certificate authority minted for one test run is refused for
+  publishing no CRL, with the anchor loaded and the signature good. So the two
+  *positive* cases skip there, loudly and only on an error text naming
+  revocation, and #819 carries both halves of that: a fixture that serves a CRL,
+  and the user-facing question it exposes (someone pasting an internal CA with
+  no reachable distribution point gets the same refusal, and no doc says so).
+  The negative cases are asserted on every platform. Still structural, not on a
+  wire: the *client* certificate's handshake, tracked by #802.
   A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
   the target's `ConnectionFailed` - and `curl_to_error` now takes the handle,
   because a 407 answered to a CONNECT is a plain `CURLE_RECV_ERROR` and only

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -469,6 +469,7 @@ if(VAYU_BUILD_TESTS)
         tests/load_stream_events_test.cpp
         tests/sse_stream_test.cpp
         tests/transport_policy_test.cpp
+        tests/tls_verification_test.cpp
         tests/client_certificates_test.cpp
         tests/requests_route_test.cpp
         tests/examples_route_test.cpp

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -3,12 +3,15 @@
  * @brief The client-certificate registry (issue #707): what a row may say, how
  *        a target picks one, and that the pick reaches every driver.
  *
- * **What is not here, and why.** There is no live mTLS handshake. This suite
- * has no TLS server at all - `cpp-httplib` is built without OpenSSL support in
- * `engine/vcpkg.json`, deliberately - and the certificate *formats* the three
- * CI backends accept differ (Schannel wants a PKCS#12 or a store thumbprint
- * where OpenSSL wants a PEM pair), so a fixture built on checked-in PEMs would
- * fail on Windows while proving nothing about the code under test. What that
+ * **What is not here, and why.** There is no live mTLS handshake. A TLS server
+ * exists in the suite now - #812 added `tests/tls_server.hpp` and the
+ * `cpp-httplib[openssl]` feature it needs - so the first of the two reasons
+ * this was deferred is gone, and what remains is the second and harder one:
+ * the certificate *formats* the CI backends accept differ (Schannel wants a
+ * PKCS#12 or a store thumbprint where OpenSSL wants a PEM pair), so a fixture
+ * that presents one identity everywhere would fail on Windows while proving
+ * nothing about the code under test. #802 owns that matrix, and is expected to
+ * extend `TlsServer` rather than stand up a second listener. What that
  * leaves is covered three ways instead: the lookup is unit-tested at the
  * boundary, the *outcome* of the lookup is asserted end-to-end through the
  * design and stream drivers (both record the entry they matched on the

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -1,0 +1,346 @@
+#pragma once
+
+/**
+ * @file tls_server.hpp
+ * @brief An in-process HTTPS listener whose certificate a test-only CA signs,
+ *        so custom-CA verification can be asserted on a wire (issue #812).
+ *
+ * `TlsBackend.AcceptsACustomCaBundleOnThisPlatform` answers a narrower
+ * question than its name suggests - whether this build's backend refuses
+ * `CURLOPT_CAINFO` outright - and nothing in the suite ever proved that
+ * pointing curl at a user's anchors *makes verification succeed*, or that it
+ * fails without them. Neither can be answered without a real handshake, and a
+ * handshake needs a server, so here is one.
+ *
+ * **The material is generated per run, never checked in.** A committed
+ * certificate expires, and the suite would then fail on a date rather than on
+ * a change - the worst shape of red there is, since the failure names TLS and
+ * the cause is the calendar. Generating in-process also keeps a private key
+ * out of the repository, and lets a test ask for a *second*, unrelated CA
+ * cheaply, which is the only way to tell "verification works" apart from "any
+ * bundle is accepted".
+ *
+ * In-process rather than a script under `scripts/test/`, following the
+ * precedent of `mock_server.hpp`, `echo_server.hpp` and `proxy_server.hpp`.
+ *
+ * It is not a general-purpose TLS server. #802's mTLS fixture is expected to
+ * extend `TlsServer` with a client-certificate store rather than stand up a
+ * second listener - `TestCertificateAuthority::issue` already mints the client
+ * identity such a test would present.
+ */
+
+#include <httplib.h>
+
+#if !defined(CPPHTTPLIB_OPENSSL_SUPPORT)
+#error "tls_server.hpp needs cpp-httplib's openssl feature (engine/vcpkg.json)"
+#endif
+
+#include <openssl/bn.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace vayu::tests {
+
+namespace tls_detail {
+
+struct X509Deleter {
+    void operator() (X509* value) const noexcept {
+        X509_free (value);
+    }
+};
+struct KeyDeleter {
+    void operator() (EVP_PKEY* value) const noexcept {
+        EVP_PKEY_free (value);
+    }
+};
+struct BioDeleter {
+    void operator() (BIO* value) const noexcept {
+        BIO_free (value);
+    }
+};
+
+using X509Ptr = std::unique_ptr<X509, X509Deleter>;
+using KeyPtr  = std::unique_ptr<EVP_PKEY, KeyDeleter>;
+using BioPtr  = std::unique_ptr<BIO, BioDeleter>;
+
+/// Fail the way a fixture should: loudly, naming OpenSSL's own reason. A
+/// silently degraded fixture would leave the tests below asserting nothing.
+[[noreturn]] inline void fail (const std::string& what) {
+    const unsigned long reason = ERR_get_error ();
+    char detail[256]           = { 0 };
+    if (reason != 0) {
+        ERR_error_string_n (reason, detail, sizeof (detail));
+    }
+    throw std::runtime_error ("tls_server.hpp: " + what +
+    (reason != 0 ? std::string (": ") + detail : std::string ()));
+}
+
+inline std::string read_bio (const BioPtr& bio, const char* what) {
+    char* data        = nullptr;
+    const long length = BIO_get_mem_data (bio.get (), &data);
+    if (length <= 0 || data == nullptr) {
+        fail (std::string ("serialized ") + what + " to an empty PEM");
+    }
+    return { data, static_cast<std::string::size_type> (length) };
+}
+
+inline std::string to_pem (X509* certificate) {
+    BioPtr bio (BIO_new (BIO_s_mem ()));
+    if (!bio || PEM_write_bio_X509 (bio.get (), certificate) != 1) {
+        fail ("could not serialize a certificate to PEM");
+    }
+    return read_bio (bio, "a certificate");
+}
+
+inline std::string to_pem (EVP_PKEY* key) {
+    BioPtr bio (BIO_new (BIO_s_mem ()));
+    if (!bio ||
+    PEM_write_bio_PrivateKey (bio.get (), key, nullptr, nullptr, 0, nullptr, nullptr) != 1) {
+        fail ("could not serialize a private key to PEM");
+    }
+    return read_bio (bio, "a private key");
+}
+
+} // namespace tls_detail
+
+/// A certificate and the key that goes with it.
+struct CertificateAndKey {
+    tls_detail::X509Ptr certificate;
+    tls_detail::KeyPtr key;
+
+    /// The certificate as PEM - what a CA hands out and a test pastes into a
+    /// setting.
+    std::string pem () const {
+        return tls_detail::to_pem (certificate.get ());
+    }
+
+    /// The private key as unencrypted PEM. Only ever this process's own
+    /// short-lived key material: nothing here is written to disk, and the
+    /// listener below takes it from memory.
+    std::string key_pem () const {
+        return tls_detail::to_pem (key.get ());
+    }
+};
+
+/**
+ * @brief A self-signed CA that exists for the length of one test.
+ *
+ * Two of them in one test is the point as much as one is: a certificate this
+ * CA signed must verify against *this* CA's PEM and must not verify against
+ * another's, and only the second half tells real verification apart from a
+ * bundle being read and ignored.
+ */
+class TestCertificateAuthority {
+    public:
+    explicit TestCertificateAuthority (
+    const std::string& common_name = "Vayu Test CA")
+    : identity_ (self_signed (common_name)) {
+    }
+
+    /// The CA certificate as PEM - what a test pastes into
+    /// `customCaCertificates`.
+    std::string pem () const {
+        return identity_.pem ();
+    }
+
+    /**
+     * @brief A leaf certificate this CA signs, for @p subject_alt_names.
+     *
+     * @param common_name  The subject CN, for a human reading a failure.
+     * @param subject_alt_names OpenSSL's `subjectAltName` spelling, e.g.
+     *        `"IP:127.0.0.1,DNS:localhost"`. An IP literal must appear as an
+     *        `IP:` entry: a CN alone has not been enough for any backend this
+     *        engine builds against for years, and a hostname SAN does not
+     *        cover the address curl dials.
+     */
+    CertificateAndKey issue (const std::string& common_name,
+    const std::string& subject_alt_names) const {
+        return sign (common_name, subject_alt_names,
+        identity_.certificate.get (), identity_.key.get ());
+    }
+
+    private:
+    static tls_detail::KeyPtr generate_key () {
+        tls_detail::KeyPtr key (EVP_RSA_gen (2048));
+        if (!key) {
+            tls_detail::fail ("could not generate an RSA key");
+        }
+        return key;
+    }
+
+    /// Serial numbers must differ within a CA; the address of the certificate
+    /// under construction is unique for as long as this process runs, which is
+    /// the whole life of the material.
+    static void set_serial (X509* certificate) {
+        ASN1_INTEGER* serial = X509_get_serialNumber (certificate);
+        if (serial == nullptr ||
+        ASN1_INTEGER_set_uint64 (serial,
+        static_cast<uint64_t> (reinterpret_cast<uintptr_t> (certificate))) != 1) {
+            tls_detail::fail ("could not set a serial number");
+        }
+    }
+
+    static void set_name (X509_NAME* name, const std::string& common_name) {
+        if (X509_NAME_add_entry_by_txt (name, "CN", MBSTRING_ASC,
+            reinterpret_cast<const unsigned char*> (common_name.c_str ()), -1, -1, 0) != 1) {
+            tls_detail::fail ("could not set a subject name");
+        }
+    }
+
+    static void
+    add_extension (X509* certificate, X509* issuer, int nid, const std::string& value) {
+        X509V3_CTX ctx;
+        X509V3_set_ctx_nodb (&ctx);
+        X509V3_set_ctx (&ctx, issuer, certificate, nullptr, nullptr, 0);
+        X509_EXTENSION* extension =
+        X509V3_EXT_conf_nid (nullptr, &ctx, nid, value.c_str ());
+        if (extension == nullptr) {
+            tls_detail::fail ("could not build extension " + std::to_string (nid));
+        }
+        const int added = X509_add_ext (certificate, extension, -1);
+        X509_EXTENSION_free (extension);
+        if (added != 1) {
+            tls_detail::fail ("could not add extension " + std::to_string (nid));
+        }
+    }
+
+    /**
+     * A certificate valid from an hour ago to a day from now. Backdated
+     * because a runner whose clock sits a little behind the one that generated
+     * the material would otherwise reject a certificate that is merely young,
+     * and a day is long enough that no suite outlives it.
+     */
+    static void set_validity (X509* certificate) {
+        if (X509_gmtime_adj (X509_getm_notBefore (certificate), -3600) == nullptr ||
+        X509_gmtime_adj (X509_getm_notAfter (certificate), 86400) == nullptr) {
+            tls_detail::fail ("could not set a validity window");
+        }
+    }
+
+    static CertificateAndKey self_signed (const std::string& common_name) {
+        CertificateAndKey identity{ tls_detail::X509Ptr (X509_new ()), generate_key () };
+        X509* certificate = identity.certificate.get ();
+        if (certificate == nullptr) {
+            tls_detail::fail ("could not allocate a certificate");
+        }
+
+        X509_set_version (certificate, 2); // v3, the only version taking extensions
+        set_serial (certificate);
+        set_validity (certificate);
+        set_name (X509_get_subject_name (certificate), common_name);
+        if (X509_set_issuer_name (certificate, X509_get_subject_name (certificate)) != 1 ||
+        X509_set_pubkey (certificate, identity.key.get ()) != 1) {
+            tls_detail::fail ("could not seed the CA certificate");
+        }
+        add_extension (certificate, certificate, NID_basic_constraints, "critical,CA:TRUE");
+        add_extension (certificate, certificate, NID_key_usage, "critical,keyCertSign,cRLSign");
+        if (X509_sign (certificate, identity.key.get (), EVP_sha256 ()) == 0) {
+            tls_detail::fail ("could not self-sign the CA certificate");
+        }
+        return identity;
+    }
+
+    static CertificateAndKey sign (const std::string& common_name,
+    const std::string& subject_alt_names,
+    X509* issuer,
+    EVP_PKEY* issuer_key) {
+        CertificateAndKey leaf{ tls_detail::X509Ptr (X509_new ()), generate_key () };
+        X509* certificate = leaf.certificate.get ();
+        if (certificate == nullptr) {
+            tls_detail::fail ("could not allocate a certificate");
+        }
+
+        X509_set_version (certificate, 2);
+        set_serial (certificate);
+        set_validity (certificate);
+        set_name (X509_get_subject_name (certificate), common_name);
+        if (X509_set_issuer_name (certificate, X509_get_subject_name (issuer)) != 1 ||
+        X509_set_pubkey (certificate, leaf.key.get ()) != 1) {
+            tls_detail::fail ("could not seed a leaf certificate");
+        }
+        add_extension (certificate, issuer, NID_basic_constraints, "critical,CA:FALSE");
+        add_extension (certificate, issuer, NID_key_usage,
+        "critical,digitalSignature,keyEncipherment");
+        add_extension (certificate, issuer, NID_ext_key_usage, "serverAuth,clientAuth");
+        add_extension (certificate, issuer, NID_subject_alt_name, subject_alt_names);
+        if (X509_sign (certificate, issuer_key, EVP_sha256 ()) == 0) {
+            tls_detail::fail ("could not sign a leaf certificate");
+        }
+        return leaf;
+    }
+
+    CertificateAndKey identity_;
+};
+
+/**
+ * @brief An HTTPS listener on 127.0.0.1, holding a certificate the given CA
+ *        signed.
+ *
+ * Serves one route, `/hello`. What is under test is the handshake in front of
+ * it: a body only arrives at all if verification passed, so a 200 here is the
+ * assertion and the payload is only there to make a partial read visible.
+ */
+class TlsServer {
+    public:
+    explicit TlsServer (const TestCertificateAuthority& ca)
+    : identity_ (ca.issue ("127.0.0.1", "IP:127.0.0.1,DNS:localhost")),
+      cert_pem_ (identity_.pem ()), key_pem_ (identity_.key_pem ()),
+      svr_ (pem_memory ()) {
+        if (!svr_.is_valid ()) {
+            tls_detail::fail ("the TLS listener refused its own certificate");
+        }
+        svr_.Get ("/hello", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (R"({"over":"tls"})", "application/json");
+        });
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+        svr_.wait_until_ready ();
+    }
+
+    ~TlsServer () {
+        svr_.stop ();
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+
+    TlsServer (const TlsServer&)            = delete;
+    TlsServer& operator= (const TlsServer&) = delete;
+
+    std::string url (const std::string& path) const {
+        return "https://127.0.0.1:" + std::to_string (port_) + path;
+    }
+
+    private:
+    /**
+     * The listener takes its identity as PEM in memory rather than as a pair of
+     * file paths - the only two shapes `httplib::SSLServer` offers since 0.53 -
+     * so no private key is ever written to disk, not even to a scratch
+     * directory a failing run would leave behind.
+     *
+     * `client_ca_pem` is left null: this listener asks for no client
+     * certificate. That is the field #802's mTLS fixture fills in.
+     */
+    httplib::SSLServer::PemMemory pem_memory () const {
+        return { cert_pem_.c_str (), cert_pem_.size (), key_pem_.c_str (),
+            key_pem_.size (), nullptr, 0, nullptr };
+    }
+
+    CertificateAndKey identity_;
+    std::string cert_pem_;
+    std::string key_pem_;
+    httplib::SSLServer svr_;
+    std::thread thread_;
+    int port_ = 0;
+};
+
+} // namespace vayu::tests

--- a/engine/tests/tls_verification_test.cpp
+++ b/engine/tests/tls_verification_test.cpp
@@ -1,0 +1,197 @@
+/**
+ * @file tests/tls_verification_test.cpp
+ * @brief Custom-CA verification on a wire (issue #812).
+ *
+ * `TransportPolicyDbTest` in `transport_policy_test.cpp` proves the
+ * `customCaCertificates` setting is read, merged with the platform's anchors
+ * and materialized into a file, and
+ * `TlsBackend.AcceptsACustomCaBundleOnThisPlatform` proves this build's backend
+ * does not refuse `CURLOPT_CAINFO` outright. What neither of them touches is
+ * the claim a user actually cares about: that a host signed by a CA they pasted
+ * in **verifies**, and that it does not verify before they paste it.
+ *
+ * That is a handshake, so these tests hold one. Each stands up an HTTPS
+ * listener whose certificate a per-run CA signed (`tls_server.hpp`) and drives
+ * the ordinary design-send path at it, changing only the setting.
+ *
+ * **Why the wrong-CA case is not optional.** A bundle that curl reads and
+ * ignores would pass the happy path on any machine whose system store happens
+ * to be permissive, and the whole feature would look tested. Verifying against
+ * a CA that signed nothing here is what separates "the setting works" from
+ * "the request succeeded" - so the suite asserts a success, a failure without
+ * the setting, and a failure with the *wrong* setting.
+ *
+ * These run on all three CI platforms deliberately: the trust decision is made
+ * by a different backend on each (OpenSSL where curl is built against it,
+ * Schannel on Windows), and a claim about trust that holds on one is not a
+ * claim about the others.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+
+#include "temp_database.hpp"
+#include "tls_server.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/http/transport_policy.hpp"
+
+namespace vayu::http {
+namespace {
+
+using vayu::tests::TestCertificateAuthority;
+using vayu::tests::TlsServer;
+
+Request get_request (const std::string& url) {
+    Request request;
+    request.method = HttpMethod::GET;
+    request.url    = url;
+    return request;
+}
+
+/**
+ * A design send with exactly the transport the settings resolved to - the same
+ * path `POST /execute` takes, which is the point: the assertion is about the
+ * shipped applier, not about a handle assembled here.
+ *
+ * A refused handshake is a `Response` carrying `error_code`, not a
+ * `Result` error: `Client::send` reserves the error arm for a request it could
+ * not even attempt, so a transport failure arrives with a status of 0 and a
+ * code - the same shape the proxy tests read, and the same shape a stored
+ * trace holds.
+ */
+Response send_through (const TransportPolicy& transport, const std::string& url) {
+    ClientConfig config;
+    config.transport = transport;
+    Client client (config);
+    auto result = client.send (get_request (url));
+    EXPECT_TRUE (result.is_ok ())
+    << "the send was never attempted: " << result.error ().message;
+    return result.is_ok () ? result.value () : Response{};
+}
+
+class CustomCaVerificationTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        vayu::tests::remove_database_files (path_);
+        db_ = std::make_unique<vayu::db::Database> (path_);
+        db_->seed_default_config ();
+        // The default `proxyMode` is `environment`, and a machine that exports
+        // `https_proxy` - a corporate laptop, a sandboxed CI runner - would
+        // send this handshake to a proxy instead of to the fixture on
+        // loopback. The setting under test here is the trust store, so the
+        // proxy is pinned off rather than left to the runner: an assertion
+        // that passes or fails on an environment variable is not an assertion
+        // about this engine.
+        set_config ("proxyMode", "off");
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        vayu::tests::remove_database_files (path_);
+        // The materialized bundle is written beside the database and is not
+        // one of the database's own files, so it outlives the scratch set
+        // unless it is named here.
+        std::error_code ec;
+        std::filesystem::remove ("ca-bundle.pem", ec);
+    }
+
+    void set_config (const std::string& key, const std::string& value) {
+        auto entry = db_->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        entry->value = value;
+        db_->save_config_entry (*entry);
+    }
+
+    void set_custom_ca (const std::string& pem) {
+        set_config ("customCaCertificates", pem);
+    }
+
+    std::string path_ = "test_tls_verification.db";
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+
+TEST_F (CustomCaVerificationTest, AHostSignedByTheAddedCaVerifies) {
+    TestCertificateAuthority ca;
+    TlsServer server (ca);
+
+    set_custom_ca (ca.pem ());
+    const auto policy = resolve_transport_policy (*db_);
+    ASSERT_FALSE (policy.ca_bundle_path.empty ())
+    << "the paste was never materialized, so nothing about trust is being "
+       "tested";
+
+    const Response response = send_through (policy, server.url ("/hello"));
+    ASSERT_EQ (response.error_code, ErrorCode::None)
+    << "verification failed with the CA added: " << to_string (response.error_code)
+    << ": " << response.error_message;
+    EXPECT_EQ (response.status_code, 200);
+    EXPECT_NE (response.body.find ("over"), std::string::npos);
+}
+
+TEST_F (CustomCaVerificationTest, TheSameHostDoesNotVerifyWithoutIt) {
+    // The other half of the claim, and the one that makes the test above mean
+    // something: the endpoint is reachable either way, so a 200 there is the
+    // setting's doing rather than a permissive default.
+    TestCertificateAuthority ca;
+    TlsServer server (ca);
+
+    const auto policy = resolve_transport_policy (*db_);
+    ASSERT_TRUE (policy.ca_bundle_path.empty ()) << "no certificate was pasted";
+
+    const Response response = send_through (policy, server.url ("/hello"));
+    EXPECT_EQ (response.status_code, 0)
+    << "an untrusted certificate was accepted";
+    EXPECT_EQ (response.error_code, ErrorCode::SslError)
+    << "a verification refusal must read as a TLS error, not as an unreachable "
+       "endpoint: "
+    << to_string (response.error_code) << ": " << response.error_message;
+}
+
+TEST_F (CustomCaVerificationTest, ACaThatSignedNothingHereDoesNotVerify) {
+    // A bundle libcurl reads and ignores would pass the happy path. This is
+    // the case that fails if the anchors are not actually consulted.
+    TestCertificateAuthority ca;
+    TlsServer server (ca);
+    const TestCertificateAuthority unrelated ("Vayu Test CA (unrelated)");
+
+    set_custom_ca (unrelated.pem ());
+    const auto policy = resolve_transport_policy (*db_);
+    ASSERT_FALSE (policy.ca_bundle_path.empty ());
+
+    const Response response = send_through (policy, server.url ("/hello"));
+    EXPECT_EQ (response.status_code, 0)
+    << "a certificate from an unrelated CA was accepted";
+    EXPECT_EQ (response.error_code, ErrorCode::SslError)
+    << to_string (response.error_code) << ": " << response.error_message;
+}
+
+TEST_F (CustomCaVerificationTest, TheAddedCaExtendsTheStoreRatherThanReplacingIt) {
+    // The additive claim of #704 decision 4, asserted on a handshake rather
+    // than by reading the file: a *second* CA pasted alongside the first must
+    // not cost the first its trust. Verification succeeding after the paste
+    // grew is the only observation that distinguishes appending from
+    // overwriting at the point where it matters.
+    TestCertificateAuthority ca;
+    TlsServer server (ca);
+    const TestCertificateAuthority other ("Vayu Test CA (also trusted)");
+
+    set_custom_ca (other.pem () + ca.pem ());
+    const auto policy = resolve_transport_policy (*db_);
+    ASSERT_FALSE (policy.ca_bundle_path.empty ());
+
+    const Response response = send_through (policy, server.url ("/hello"));
+    ASSERT_EQ (response.error_code, ErrorCode::None)
+    << "a second anchor cost the first its trust: " << to_string (response.error_code)
+    << ": " << response.error_message;
+    EXPECT_EQ (response.status_code, 200);
+}
+
+} // namespace
+} // namespace vayu::http

--- a/engine/tests/tls_verification_test.cpp
+++ b/engine/tests/tls_verification_test.cpp
@@ -24,7 +24,14 @@
  * These run on all three CI platforms deliberately: the trust decision is made
  * by a different backend on each (OpenSSL where curl is built against it,
  * Schannel on Windows), and a claim about trust that holds on one is not a
- * claim about the others.
+ * claim about the others. That is not a formality - the backends answered
+ * differently the first time this ran. A backend that revocation-checks the
+ * chain refuses a CA minted for this run, because a CA minted for this run
+ * publishes no CRL, and the *positive* cases below therefore skip there rather
+ * than assert. The skip is narrow and loud: it fires only when the backend's
+ * own error text names revocation, prints that text, and is tracked by #819;
+ * every other refusal, on every platform, still fails. The negative cases have
+ * no such carve-out and are asserted everywhere.
  */
 
 #include <gtest/gtest.h>
@@ -72,6 +79,43 @@ Response send_through (const TransportPolicy& transport, const std::string& url)
     EXPECT_TRUE (result.is_ok ())
     << "the send was never attempted: " << result.error ().message;
     return result.is_ok () ? result.value () : Response{};
+}
+
+/**
+ * @brief Whether the backend refused for want of *revocation* information
+ *        rather than for want of trust.
+ *
+ * The two are different verdicts and only one of them is about this engine.
+ * A backend that asks the operating system to revocation-check the chain
+ * cannot be satisfied by a certificate authority minted seconds ago: it
+ * publishes no CRL, so the answer comes back "unknown" and the chain is
+ * refused even though the anchor was loaded and the signature is good. That is
+ * what curl's Schannel path does - `Curl_verify_certificate` passes
+ * `CERT_CHAIN_REVOCATION_CHECK_CHAIN` unless `CURLSSLOPT_NO_REVOKE` is set,
+ * and treats `CERT_TRUST_REVOCATION_STATUS_UNKNOWN` as a failure unless
+ * `CURLSSLOPT_REVOKE_BEST_EFFORT` is (`lib/vtls/schannel_verify.c`) - so the
+ * *positive* half of this suite cannot be hosted on such a backend until the
+ * fixture serves a CRL, which is #819.
+ *
+ * Matched on the backend's own words rather than on `_WIN32`, deliberately.
+ * The property that matters is "this backend demands revocation information",
+ * not "this is Windows", and a test that asserts the host platform is exactly
+ * what `CLAUDE.md` forbids - it would keep skipping on Windows if the reason
+ * changed, and keep failing elsewhere if the reason spread.
+ */
+bool refused_for_want_of_revocation (const Response& response) {
+    return response.error_code == ErrorCode::SslError &&
+    response.error_message.find ("revocation") != std::string::npos;
+}
+
+/// What such a skip says. Loudly, in the backend's own words: a guard that
+/// quietly does nothing on one platform is worse than no guard, so this has to
+/// read as "not answered here, and here is why" rather than as a pass.
+std::string revocation_skip_reason (const Response& response) {
+    return "this TLS backend revocation-checks the chain, which a CA minted for"
+           " this run cannot answer for - the anchor is not the thing it"
+           " refused. Tracked by #819. The backend said: " +
+    response.error_message;
 }
 
 class CustomCaVerificationTest : public ::testing::Test {
@@ -128,6 +172,9 @@ TEST_F (CustomCaVerificationTest, AHostSignedByTheAddedCaVerifies) {
        "tested";
 
     const Response response = send_through (policy, server.url ("/hello"));
+    if (refused_for_want_of_revocation (response)) {
+        GTEST_SKIP () << revocation_skip_reason (response);
+    }
     ASSERT_EQ (response.error_code, ErrorCode::None)
     << "verification failed with the CA added: " << to_string (response.error_code)
     << ": " << response.error_message;
@@ -187,6 +234,9 @@ TEST_F (CustomCaVerificationTest, TheAddedCaExtendsTheStoreRatherThanReplacingIt
     ASSERT_FALSE (policy.ca_bundle_path.empty ());
 
     const Response response = send_through (policy, server.url ("/hello"));
+    if (refused_for_want_of_revocation (response)) {
+        GTEST_SKIP () << revocation_skip_reason (response);
+    }
     ASSERT_EQ (response.error_code, ErrorCode::None)
     << "a second anchor cost the first its trust: " << to_string (response.error_code)
     << ": " << response.error_message;

--- a/engine/vcpkg.json
+++ b/engine/vcpkg.json
@@ -13,7 +13,12 @@
     "libsodium",
     "nlohmann-json",
     "valijson",
-    "cpp-httplib",
+    {
+      "name": "cpp-httplib",
+      "features": [
+        "openssl"
+      ]
+    },
     "gtest",
     {
       "name": "sqlite3",


### PR DESCRIPTION
## Description

**Plan.** The root cause is a doc claiming coverage that does not exist.
`engine/CLAUDE.md:246-248` said the custom-CA feature's per-backend claim was
"tested on each CI platform rather than reasoned about, because a wrong claim
here is a security claim", citing `TlsBackend.AcceptsACustomCaBundleOnThisPlatform`.
That test sets `CURLOPT_CAINFO` to `/nonexistent/ca-bundle.pem` and asserts
`CURLE_OK` - it proves the backend does not refuse the *option*, and nothing
more: no server, no signed certificate, no verification. Verified against the
current code before touching anything; the gap is exactly as the issue
describes. The approach is both halves of the issue's fix pathway - the claim
rewritten to say what each test checks, and the missing live test added,
built on a fixture written so #802 extends it rather than standing up a second
listener. **Alternative rejected:** correcting the doc alone and leaving the
test to #802's fixture work. The doc would then have to describe an open hole
in a security claim with no date on closing it, and #802 is the larger job -
it needs the per-backend PKCS#12/PEM matrix, which server-side verification
does not. The smaller question stands on its own.

**What is new.**

- `engine/tests/tls_server.hpp` - `TestCertificateAuthority` mints a self-signed
  CA and signs leaves for it; `TlsServer` serves one route from an
  `httplib::SSLServer` holding a leaf for `IP:127.0.0.1`. Material is generated
  **per run, in memory**: a checked-in certificate expires, and the suite would
  then go red on a date rather than on a change - naming TLS while the cause is
  the calendar. It also keeps a private key out of the repository and makes a
  *second*, unrelated CA cheap, which one of the cases below needs.
- `engine/tests/tls_verification_test.cpp` - `CustomCaVerificationTest` drives
  the ordinary design-send path (`Client::send` through the shipped
  `apply_transport_policy`) at that listener, changing only
  `customCaCertificates`.

**Four cases, because the happy path alone proves little.** A bundle libcurl
reads and ignores would pass it on any machine with a permissive store. So:
the host verifies once its CA is pasted in; it does **not** verify before that;
it does **not** verify against a CA that signed nothing here; and it *still*
verifies when a second anchor is added beside the first - #704 decision 4's
additive rule observed on a handshake instead of by reading the file back.

**One thing the fixture had to pin.** `proxyMode` is set to `off` in `SetUp`.
The default is `environment`, so a machine exporting `https_proxy` - a
corporate laptop, a sandboxed runner - would send the handshake to a proxy
instead of to loopback, and an assertion that passes or fails on an
environment variable is not an assertion about this engine.

**Dependency.** `cpp-httplib` gains the `openssl` feature; `httplib::SSLServer`
does not exist without it. OpenSSL was already in the tree on Linux and macOS
(vcpkg's `curl[ssl]` resolves to `curl[openssl]` on `!windows`); Windows gains
it. The first CI run on this branch missed the vcpkg cache **by construction** -
the key is the manifest hash - and cost ~13 min per leg cold; the second run hit
the new key and the engine legs came back in 2-4 min.

## The backends disagreed, which is the point

The first CI run (`ffe1c19`) passed all four cases on ubuntu and macOS and
failed **exactly the two positive ones** on Windows, with both negatives
passing. That split is the diagnosis: if the pasted anchor were not being
consulted, the *negative* cases would be the ones misbehaving.

curl's Schannel path validates a `CURLOPT_CAINFO` chain itself and asks Windows
to revocation-check it - `CERT_CHAIN_REVOCATION_CHECK_CHAIN` unless
`CURLSSLOPT_NO_REVOKE` is set, with an unknown status treated as failure unless
`CURLSSLOPT_REVOKE_BEST_EFFORT` is (`lib/vtls/schannel_verify.c`, pinned
baseline). A CA minted seconds ago publishes no CRL, so that answer can only be
"unknown". The OpenSSL-backed legs make no such check.

`e90a546` makes the positive cases skip where that happens, built so the skip
cannot rot into the quiet no-op #812 exists to end:

- it fires **only** when the backend's own error text names revocation - any
  other refusal, on any platform, still fails the suite;
- it **prints** that text, so the reason comes from the run;
- it matches on the words, **not** on `_WIN32`. "This backend demands revocation
  information" is the property that matters, and a test asserting the host
  platform is what `CLAUDE.md` forbids;
- the **negative cases keep no carve-out** and are asserted on every leg. They
  are what proves the anchor is consulted, and they were green on Windows from
  the first run.

**That gate also turned the diagnosis into evidence.** Windows now reports
`2047 tests run, 2045 passed, 2 skipped, 0 failed` - two skipped and zero failed
is only reachable if the refusal named revocation, since anything else fails.

**Deliberately not done:** setting `CURLSSLOPT_REVOKE_BEST_EFFORT` when a custom
bundle is in force. It is one line beside the existing `CURLSSLOPT_NATIVE_CA`
and it would turn every leg green - which is exactly why it does not belong in a
test-and-doc change. It weakens revocation enforcement as a side effect of a
user pasting a certificate, a security posture change wearing a one-line diff.

## Type of Change
- [x] Bug fix - a false claim in a doc future sessions are told to trust
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Test coverage

## Testing

Engine-only diff (C++ tests, CMake, vcpkg manifest and three docs). No app
file is touched, so per `CLAUDE.md`'s "scale the verification to what the
change could actually break" the app suite was not run - no vitest test could
change colour.

- `python build.py -e -t` then `ctest --preset linux-dev --output-on-failure` -
  **2046 tests, 100% passed** (2042 on the base commit; the four new ones are
  the delta).
- CI on `e90a546`: **all legs green, CI gate success.** ubuntu and macOS run all
  four cases; Windows runs two and skips two, loudly.
- `mkdocs build --strict` - clean.
- `clang-format` on the two new files (both new, so nothing pre-existing was
  reflowed).

Mutation-checked in both directions, since the positive and negative cases fail
to different mutations:

| Mutation | Result |
|---|---|
| `CURLOPT_CAINFO` always null (the bundle never applied) | `AHostSignedByTheAddedCaVerifies` and `TheAddedCaExtendsTheStoreRatherThanReplacingIt` fail; both negative cases still pass |
| `CURLOPT_SSL_VERIFYPEER` forced to `0` | `TheSameHostDoesNotVerifyWithoutIt` and `ACaThatSignedNothingHereDoesNotVerify` fail; both positive cases still pass |
| `refused_for_want_of_revocation` inverted to fire on success | the positive cases report `[  SKIPPED ]` with the full reason appended, rather than reading as a pass |
| baseline, unmutated | 4/4 pass |

All mutations reverted; `git diff` on `engine/src/` is empty in this branch.

The fixture itself was checked outside the engine, so a green suite could not be
the fixture being permissive: standing it up in a standalone binary and calling
it with the system `curl` gives `curl: (60) SSL certificate problem: unable to
get local issuer certificate` without `--cacert`, and `200` with it.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `engine/CLAUDE.md` (the corrected claim,
      naming what each test checks, what the backends disagreed about, and what
      is still structural), `docs/engine/building.md` (the dependency table row
      and the `vcpkg install` line in Linker Errors),
      `engine/tests/client_certificates_test.cpp`'s header (it said this suite
      has "no TLS server at all... deliberately", which is now half wrong -
      corrected to name what remains for #802 and to point at `TlsServer` as
      the thing to extend rather than duplicate)

## Related Issues
Closes #812

Two issues filed from what this turned up, rather than folded in:

- **#819** - the fixture CRL that would let the positive cases run on a
  revocation-checking backend too (and the skip be deleted), plus the
  user-facing half: someone on Windows pasting an internal CA with no reachable
  distribution point hits this same refusal today, worded so it names neither
  the setting they changed nor the reason. That second half needs your call, not
  a patch.
- **#818** - `engine/CLAUDE.md` and `transport_policy.hpp` both describe macOS as
  Apple SecTrust-backed, while the pinned vcpkg baseline maps curl's default
  `ssl` feature to `curl[openssl]` on `uwp | !windows`. This PR leaves that
  claim alone rather than trading one unverified statement for another - it is
  about a build I cannot run here.

**One note for review.** The error shape is worth a look: a refused handshake is
not a `Result` error - `Client::send` reserves that arm for a request it could
not attempt at all - so a verification failure arrives as an ok `Result` holding
a `Response` with `status_code == 0` and `error_code == SslError`. The tests
assert that shape, the same one the proxy tests in `transport_policy_test.cpp`
read and the same one a stored trace holds. My first draft asserted `is_error()`
and went red against entirely correct engine behaviour.