### PR TITLE
fix(app/openapi): export what is stored, not part of it, and stop at the next document (#721)

### DIFF
--- a/app/src/modules/collections/ExportSpecDialog.test.tsx
+++ b/app/src/modules/collections/ExportSpecDialog.test.tsx
@@ -16,6 +16,11 @@
  * run, what the export could not carry, and that a document the engine would not
  * give up stops the export instead of silently downgrading it to a skeleton.
  * Those four are what this file locks.
+ *
+ * It also owns the two questions that live between the hook and the exporter
+ * (issue #721): which collections the subtree walk reaches, since a nested
+ * binding answers to a document of its own, and that assembly happens off the
+ * render pass, since neither the hook nor the exporter can see when it ran.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -32,13 +37,53 @@ const specQuery = {
 
 let requests: Request[] = [];
 let examples: RequestExample[] = [];
+/** Collections beyond the root, for the nested-binding cases. */
+let extraCollections: Array<Partial<Collection> & { id: string; parentId?: string }> = [];
+/** Requests filed under a collection other than the root. */
+let requestsByOtherCollection = new Map<string, Request[]>();
+let requestsMemo: {
+	key: string;
+	rows: Request[];
+	value: { requestsByCollection: Map<string, Request[]>; isLoading: boolean };
+} = { key: "", rows: [], value: { requestsByCollection: new Map(), isLoading: false } };
+
+/** How many times the exporter actually assembled a document. */
+const assembled = vi.hoisted(() => vi.fn<(format: string) => void>());
+/**
+ * Whether the pending line was on screen at the moment each assembly ran.
+ *
+ * Read inside the exporter rather than polled from the test, because the pending
+ * state is transient: a `findBy*` can miss it and report a freeze as a pass. An
+ * assembly that runs from render cannot see its own pending line, so a `false`
+ * here is exactly the defect.
+ */
+const pendingWhenAssembled = vi.hoisted(() => [] as boolean[]);
 
 vi.mock("@/queries/collections", () => ({
-	useCollectionsQuery: () => ({ data: [{ id: "col_1", name: "Petstore", parentId: undefined }] }),
-	useMultipleCollectionRequests: () => ({
-		requestsByCollection: new Map([["col_1", requests]]),
-		isLoading: false,
+	useCollectionsQuery: () => ({
+		data: [{ id: "col_1", name: "Petstore", parentId: undefined }, ...extraCollections],
 	}),
+	// Pinned to its contents, the way the real hook pins the map `combine`
+	// builds: it hands back the same object until the ids or the rows change,
+	// and a mock rebuilding it every render would model a hook this app does
+	// not have.
+	useMultipleCollectionRequests: (ids: string[]) => {
+		const key = ids.join(",");
+		if (requestsMemo.key !== key || requestsMemo.rows !== requests) {
+			requestsMemo = {
+				key,
+				rows: requests,
+				value: {
+					requestsByCollection: new Map([
+						["col_1", requests],
+						...[...requestsByOtherCollection].filter(([id]) => ids.includes(id)),
+					]),
+					isLoading: false,
+				},
+			};
+		}
+		return requestsMemo.value;
+	},
 }));
 
 vi.mock("@/queries/specs", () => ({ useSpecQuery: () => specQuery }));
@@ -46,6 +91,22 @@ vi.mock("@/queries/specs", () => ({ useSpecQuery: () => specQuery }));
 vi.mock("@/services/api", () => ({
 	apiService: { listRequestExamples: () => Promise.resolve(examples) },
 }));
+
+// The real exporter, counted. Assembly cost is the point of the deferral, and
+// only the number of times it ran says whether a format toggle re-paid it.
+vi.mock("@/services/exporters/openapi", async (importActual) => {
+	const actual = await importActual<typeof import("@/services/exporters/openapi")>();
+	return {
+		...actual,
+		exportOpenApi: (input: Parameters<typeof actual.exportOpenApi>[0]) => {
+			assembled(input.format);
+			pendingWhenAssembled.push(
+				document.body.textContent?.includes("Assembling the document") ?? false
+			);
+			return actual.exportOpenApi(input);
+		},
+	};
+});
 
 const { default: ExportSpecDialog } = await import("./ExportSpecDialog");
 
@@ -133,8 +194,17 @@ function captureDownload() {
 
 beforeEach(() => {
 	vi.restoreAllMocks();
+	assembled.mockClear();
+	pendingWhenAssembled.length = 0;
 	requests = [];
 	examples = [];
+	extraCollections = [];
+	requestsByOtherCollection = new Map();
+	requestsMemo = {
+		key: "",
+		rows: [],
+		value: { requestsByCollection: new Map(), isLoading: false },
+	};
 	specQuery.data = { content: SPEC };
 	specQuery.isLoading = false;
 	specQuery.isError = false;
@@ -188,6 +258,9 @@ describe("ExportSpecDialog", () => {
 		expect(Object.keys(parsed.paths)).toEqual(["/pets"]);
 
 		fireEvent.click(screen.getByRole("radio", { name: "YAML" }));
+		// The other format is assembled, not re-rendered: the click starts work
+		// that finishes after a paint, so the button it enables is the signal.
+		await waitFor(() => expect(assembled).toHaveBeenCalledTimes(2));
 		fireEvent.click(screen.getByRole("button", { name: "Download" }));
 		const asYaml = await download.read();
 		expect(asYaml.fileName).toBe("petstore.openapi.yaml");
@@ -225,6 +298,146 @@ describe("ExportSpecDialog", () => {
 				true
 			)
 		);
+	});
+
+	it("leaves a nested collection bound to another document out of this one", async () => {
+		// Collections re-parent freely, so spec B's collection can end up under
+		// spec A's. Its request names `listOwners` - a name this document happens
+		// to declare too, which is the whole hazard.
+		extraCollections = [
+			{
+				id: "col_2",
+				name: "Owners (another spec)",
+				parentId: "col_1",
+				openapi: { specId: "spec_2", specHash: "def456", syncedAt: 1 },
+			},
+		];
+		requests = [
+			request({ specOperation: { operationId: "listPets", method: "GET", path: "/pets" } }),
+		];
+		requestsByOtherCollection = new Map([
+			[
+				"col_2",
+				[
+					request({
+						id: "req_foreign",
+						collectionId: "col_2",
+						name: "List owners of the other spec",
+						specOperation: {
+							operationId: "listOwners",
+							method: "GET",
+							path: "/owners",
+						},
+					}),
+				],
+			],
+		]);
+		const download = captureDownload();
+		render(
+			withQueryClient(
+				<ExportSpecDialog collection={collection(true)} onOpenChange={vi.fn()} />
+			)
+		);
+
+		await screen.findByText(/own document, updated/);
+		const lines = screen.getAllByRole("listitem").map((li) => li.textContent);
+		expect(lines).toContain("1 request exported as an operation");
+		// `/owners` is removed because nothing in *this* collection claims it -
+		// the honest outcome. Without the boundary the foreign request claims it
+		// and rewrites it instead.
+		expect(lines).toContain("1 operation removed - nothing here claims it");
+		fireEvent.click(screen.getByRole("button", { name: "Download" }));
+		const json = JSON.parse((await download.read()).text);
+		expect(Object.keys(json.paths)).toEqual(["/pets"]);
+	});
+
+	it("keeps a nested collection bound to the same document, which describes it too", async () => {
+		extraCollections = [
+			{
+				id: "col_2",
+				name: "Owners",
+				parentId: "col_1",
+				openapi: { specId: "spec_1", specHash: "abc123", syncedAt: 1 },
+			},
+		];
+		requests = [
+			request({ specOperation: { operationId: "listPets", method: "GET", path: "/pets" } }),
+		];
+		requestsByOtherCollection = new Map([
+			[
+				"col_2",
+				[
+					request({
+						id: "req_owners",
+						collectionId: "col_2",
+						name: "List owners",
+						specOperation: {
+							operationId: "listOwners",
+							method: "GET",
+							path: "/owners",
+						},
+					}),
+				],
+			],
+		]);
+		const download = captureDownload();
+		render(
+			withQueryClient(
+				<ExportSpecDialog collection={collection(true)} onOpenChange={vi.fn()} />
+			)
+		);
+
+		await screen.findByText(/own document, updated/);
+		const lines = screen.getAllByRole("listitem").map((li) => li.textContent);
+		// A descendant bound to the *same* document describes the operations being
+		// patched. Stopping there would remove them as unclaimed - a deletion in
+		// place of a rewrite, which is not an improvement.
+		expect(lines).toContain("2 requests exported as an operation");
+		expect(lines).toContain("0 operations removed - nothing here claims it");
+		fireEvent.click(screen.getByRole("button", { name: "Download" }));
+		const json = JSON.parse((await download.read()).text);
+		expect(Object.keys(json.paths).sort()).toEqual(["/owners", "/pets"]);
+	});
+
+	it("assembles the document off the render pass, behind a line that says so", async () => {
+		requests = [
+			request({ specOperation: { operationId: "listPets", method: "GET", path: "/pets" } }),
+		];
+		render(
+			withQueryClient(
+				<ExportSpecDialog collection={collection(true)} onOpenChange={vi.fn()} />
+			)
+		);
+
+		await screen.findByText(/own document, updated/);
+		// Assembly happened while the pending line was on screen - which it cannot
+		// be if the work runs during render.
+		expect(pendingWhenAssembled).toEqual([true]);
+	});
+
+	it("assembles each format once, so toggling back is free", async () => {
+		requests = [
+			request({ specOperation: { operationId: "listPets", method: "GET", path: "/pets" } }),
+		];
+		render(
+			withQueryClient(
+				<ExportSpecDialog collection={collection(true)} onOpenChange={vi.fn()} />
+			)
+		);
+
+		await screen.findByText(/own document, updated/);
+		fireEvent.click(screen.getByRole("radio", { name: "YAML" }));
+		await waitFor(() => expect(assembled).toHaveBeenCalledTimes(2));
+		fireEvent.click(screen.getByRole("radio", { name: "JSON" }));
+
+		// The JSON document is still the one that was assembled first: a toggle
+		// back reads the cache rather than re-parsing the stored spec.
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Download" }).hasAttribute("disabled")).toBe(
+				false
+			)
+		);
+		expect(assembled.mock.calls.map((call) => call[0])).toEqual(["json", "yaml"]);
 	});
 
 	it("refuses to export a stored document it cannot parse", async () => {

--- a/app/src/modules/collections/ExportSpecDialog.tsx
+++ b/app/src/modules/collections/ExportSpecDialog.tsx
@@ -23,9 +23,16 @@
  * Mounted only while open, like `RunCollectionDialog`: the mount is the reset,
  * and the three reads the source hook makes cost nothing for a dialog nobody
  * opened.
+ *
+ * **Assembly is not a render** (issue #721). Parsing a stored document, walking
+ * it and serializing it is seconds of synchronous work on a 12MB spec, and it ran
+ * in a `useMemo` - during render, again on every format toggle, with the window
+ * frozen and nothing on screen to say why. It runs from an effect now, behind a
+ * pending line, and each format's result is kept until the source changes so the
+ * second toggle back is free.
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Copy, Download, FileJson, Loader2 } from "lucide-react";
 
 import {
@@ -47,9 +54,15 @@ import {
 	SpecDocumentError,
 	type ExportFormat,
 	type ExportNotes,
+	type ExportRequest,
+	type OpenApiExportInput,
+	type OpenApiExportResult,
 } from "@/services/exporters/openapi";
 import type { Collection } from "@/types";
 import { useOpenApiExportSource } from "./useOpenApiExportSource";
+
+/** An assembled document, or why it could not be assembled. Never both. */
+type Assembly = { value: OpenApiExportResult; error: null } | { value: null; error: string };
 
 export interface ExportSpecDialogProps {
 	/**
@@ -66,41 +79,44 @@ export default function ExportSpecDialog({ collection, onOpenChange }: ExportSpe
 	const source = useOpenApiExportSource(collection);
 	const copy = useCopy();
 
-	const result = useMemo(() => {
-		if (source.isLoading || source.specFailed) return null;
-		try {
-			return {
-				value: exportOpenApi({
-					collection,
-					requests: source.requests,
-					...(source.specContent === undefined
-						? {}
-						: { specContent: source.specContent }),
-					format,
-				}),
-				error: null as string | null,
-			};
-		} catch (error) {
-			// A stored document that cannot be read is refused rather than
-			// quietly downgraded to a skeleton: a skeleton in place of the
-			// document the user believes they are updating would drop every
-			// member of their spec Vayu does not model.
-			return {
-				value: null,
-				error:
-					error instanceof SpecDocumentError
-						? error.message
-						: `The document could not be assembled: ${(error as Error).message}`,
-			};
-		}
-	}, [
-		collection,
-		source.isLoading,
-		source.specFailed,
-		source.requests,
-		source.specContent,
-		format,
-	]);
+	// What has been assembled, and from which source. Held in state rather than
+	// beside a "pending" flag, so that stale is *derived*: a result belongs to
+	// one source key, and the moment the key moves it stops being the answer
+	// without anyone having to remember to clear it.
+	const [assembled, setAssembled] = useState<{
+		key: string;
+		byFormat: Partial<Record<ExportFormat, Assembly>>;
+	}>({ key: "", byFormat: {} });
+
+	const ready = !source.isLoading && !source.specFailed;
+	const { requests, specContent } = source;
+	const sourceKey = useMemo(() => describeSource(collection, requests), [collection, requests]);
+	const result = (assembled.key === sourceKey ? assembled.byFormat[format] : undefined) ?? null;
+
+	useEffect(() => {
+		// Both early exits are the derivation above having answered already:
+		// nothing to assemble yet, or this format assembled and kept - which is
+		// what makes a toggle back to JSON free rather than a second parse.
+		if (!ready || result) return;
+		// A task, not a microtask: a microtask runs before the browser paints, so
+		// the pending line below would never reach the screen and the window would
+		// freeze exactly as it did from render.
+		const scheduled = setTimeout(() => {
+			const assembly = assemble({
+				collection,
+				requests,
+				...(specContent === undefined ? {} : { specContent }),
+				format,
+			});
+			setAssembled((previous) =>
+				previous.key === sourceKey
+					? { key: sourceKey, byFormat: { ...previous.byFormat, [format]: assembly } }
+					: { key: sourceKey, byFormat: { [format]: assembly } }
+			);
+		}, 0);
+		return () => clearTimeout(scheduled);
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- `sourceKey` is the contents of `collection` and `requests`
+	}, [ready, result, sourceKey, specContent, format]);
 
 	const handleDownload = () => {
 		if (!result?.value) return;
@@ -147,6 +163,19 @@ export default function ExportSpecDialog({ collection, onOpenChange }: ExportSpe
 						<p className="flex items-center gap-2 text-xs text-muted-foreground">
 							<Loader2 className="h-3.5 w-3.5 animate-spin" />
 							Reading the collection…
+						</p>
+					)}
+
+					{/*
+					 * The reads are in and the document is being put together. A
+					 * large spec spends real time here, and a dialog that showed
+					 * nothing would read as one that had finished with nothing to
+					 * say.
+					 */}
+					{ready && !result && (
+						<p className="flex items-center gap-2 text-xs text-muted-foreground">
+							<Loader2 className="h-3.5 w-3.5 animate-spin" />
+							Assembling the document…
 						</p>
 					)}
 
@@ -263,6 +292,11 @@ function ExportSummary({ notes }: { notes: ExportNotes }) {
 					label="example"
 					suffix="with no recorded media type - the response is written, the body is not"
 				/>
+				<Line
+					count={notes.examplesTruncated}
+					label="example"
+					suffix="stored only in part - the response is written, the truncated body is not"
+				/>
 			</ul>
 			{notes.vocabularyNotWritten && (
 				<p className="text-[11px] text-muted-foreground">
@@ -273,6 +307,50 @@ function ExportSummary({ notes }: { notes: ExportNotes }) {
 			)}
 		</div>
 	);
+}
+
+/**
+ * The export, or the sentence that says why there is none.
+ *
+ * A stored document that cannot be read is refused rather than quietly
+ * downgraded to a skeleton: a skeleton in place of the document the user
+ * believes they are updating would drop every member of their spec Vayu does
+ * not model.
+ */
+function assemble(inputs: OpenApiExportInput): Assembly {
+	try {
+		return { value: exportOpenApi(inputs), error: null };
+	} catch (error) {
+		return {
+			value: null,
+			error:
+				error instanceof SpecDocumentError
+					? error.message
+					: `The document could not be assembled: ${(error as Error).message}`,
+		};
+	}
+}
+
+/**
+ * What the export would read, as a string that changes when it does.
+ *
+ * The rows themselves arrive as fresh arrays whenever a query re-runs, so
+ * keying the assembly on their identity would re-parse the document for a
+ * render that changed nothing. Timestamps carry the content: a request records
+ * `updatedAt` on every edit, and an example row is read-only in the app - it
+ * arrives with an import or a sync, both of which write new rows.
+ *
+ * `specContent` is not in here because it is a string, and a string is compared
+ * by value in the effect's dependency list already.
+ */
+function describeSource(collection: Collection, requests: readonly ExportRequest[]): string {
+	const rows = requests.map(
+		(entry) =>
+			`${entry.request.id}@${entry.request.updatedAt}+${entry.examples
+				.map((example) => example.id)
+				.join(".")}`
+	);
+	return `${collection.id}@${collection.updatedAt}|${rows.join(",")}`;
 }
 
 function Line({ count, label, suffix }: { count: number; label: string; suffix: string }) {

--- a/app/src/modules/collections/useOpenApiExportSource.ts
+++ b/app/src/modules/collections/useOpenApiExportSource.ts
@@ -24,6 +24,16 @@
  * `isLoading` covers them: exporting while they load would write a document
  * whose operations document no responses, and the user would have no way to
  * tell that from an API nobody saved a response for.
+ *
+ * **The subtree stops where another document begins** (issue #721). Collections
+ * re-parent freely, so a collection bound to spec B can sit under one bound to
+ * spec A. B's requests carry operation stamps of B, and `patchBoundDocument`
+ * matches a stamp by operationId, then by method+path - names generators hand
+ * out in every document (`listUsers`, `GET /users`) - so without a boundary B's
+ * rows claim A's operations and rewrite them with B's values. The walk therefore
+ * refuses to descend into a collection bound to a *different* document, the same
+ * predicate `collectionsUnderContract` uses to stop at a sub-collection that
+ * declares its own data contract.
  */
 
 import { useCallback, useMemo } from "react";
@@ -49,9 +59,15 @@ export interface OpenApiExportSource {
 
 export function useOpenApiExportSource(collection: Collection): OpenApiExportSource {
 	const { data: collections = [] } = useCollectionsQuery();
+	const exportedSpecId = collection.openapi?.specId;
 	const subtreeIds = useMemo(
-		() => collectSubtreeIds(collection.id, collections),
-		[collection.id, collections]
+		() =>
+			collectSubtreeIds(
+				collection.id,
+				collections,
+				(child) => !bindsAnotherDocument(child, exportedSpecId)
+			),
+		[collection.id, collections, exportedSpecId]
 	);
 	const { requestsByCollection, isLoading: requestsLoading } =
 		useMultipleCollectionRequests(subtreeIds);
@@ -107,4 +123,19 @@ export function useOpenApiExportSource(collection: Collection): OpenApiExportSou
 		isLoading: requestsLoading || exampleQueries.isLoading || (bound && spec.isLoading),
 		specFailed: bound && spec.isError,
 	};
+}
+
+/**
+ * Whether this collection answers to a document other than the one being
+ * exported.
+ *
+ * *Another* document, not *a* document: a descendant bound to the same spec as
+ * the root describes the very operations being patched, and excluding it would
+ * have the export remove them as operations "nothing here claims" - trading a
+ * cross-document rewrite for a silent deletion. A skeleton export (no
+ * `exportedSpecId`) has no document of its own, so every binding below it is
+ * another one.
+ */
+function bindsAnotherDocument(collection: Collection, exportedSpecId: string | undefined): boolean {
+	return hasSpecBinding(collection.openapi) && collection.openapi?.specId !== exportedSpecId;
 }

--- a/app/src/services/exporters/examples.ts
+++ b/app/src/services/exporters/examples.ts
@@ -44,7 +44,18 @@ export function writeResponseExamples(
 		const response = existing ?? { description: group[0].name || `${status} response` };
 		if (!existing) responses[status] = response;
 
-		const withMediaType = group.filter((example) => {
+		const writable = group.filter((example) => {
+			// A capped body is the first slice of a response, not the response
+			// (#659). Written as an `example` it would be indistinguishable from a
+			// complete one - and a body whose `JSON.parse` fails falls back to the
+			// raw string, so half a document would enter the contract as a quoted
+			// fragment. The response still lands, and the count says the body did
+			// not. Checked before the media type so a truncated body with no
+			// recorded type is counted once, as the loss that actually stopped it.
+			if (example.bodyTruncated) {
+				notes.examplesTruncated += 1;
+				return false;
+			}
 			if (example.contentType) return true;
 			// No honest `content` key exists for a body whose media type nobody
 			// stated. The response still lands - a 204 documents itself - and the
@@ -52,10 +63,10 @@ export function writeResponseExamples(
 			notes.examplesWithoutMediaType += 1;
 			return false;
 		});
-		if (withMediaType.length === 0) continue;
+		if (writable.length === 0) continue;
 
 		const content = childRecord(response, "content");
-		for (const [contentType, mediaGroup] of groupBy(withMediaType, (e) => e.contentType)) {
+		for (const [contentType, mediaGroup] of groupBy(writable, (e) => e.contentType)) {
 			const media = childRecord(content, contentType);
 			const values = mediaGroup.map((example) => exampleValue(example.body));
 			if (options.deriveSchema && media.schema === undefined) {

--- a/app/src/services/exporters/openapi.test.ts
+++ b/app/src/services/exporters/openapi.test.ts
@@ -244,6 +244,57 @@ describe("bound export - the document, updated", () => {
 		expect(notes.examplesWritten).toBe(0);
 	});
 
+	it("never writes a truncated body as an example, and counts the ones it left out", () => {
+		const requests = boundRequests();
+		requests[0].examples = [
+			example({ id: "ex_part", body: '{"id":"p1","na', bodyTruncated: true }),
+			example({ id: "ex_whole", name: "200 - whole" }),
+		];
+		const { document, notes } = exportJson({ requests, specContent: bound });
+
+		const media = (
+			operationOf(document, "/pets", "get") as {
+				responses: Record<string, { content: Record<string, Record<string, never>> }>;
+			}
+		).responses["200"].content["application/json"];
+		// The complete example is the one that lands, as `example` rather than a
+		// two-entry map: the truncated one never reaches the grouping that would
+		// have made it the second.
+		expect(media.example).toEqual({ id: "p1", name: "Rex" });
+		expect(media.examples).toBeUndefined();
+		expect(notes.examplesWritten).toBe(1);
+		expect(notes.examplesTruncated).toBe(1);
+	});
+
+	it("writes a truncated example's response without its body, and counts it once", () => {
+		const requests = boundRequests();
+		requests[0].examples = [
+			example({
+				id: "ex_404",
+				name: "404 - missing",
+				status: 404,
+				body: "not fou",
+				contentType: "",
+				bodyTruncated: true,
+			}),
+		];
+		const { document, notes } = exportJson({ requests, specContent: bound });
+
+		const response = (
+			operationOf(document, "/pets", "get") as {
+				responses: Record<string, { description: string; content?: unknown }>;
+			}
+		).responses["404"];
+		// The status is still documented - that much is known - and only the body
+		// is withheld. Counted as truncated and not also as media-type-less: one
+		// example, one line in the summary, naming the loss that stopped it.
+		expect(response.description).toBe("404 - missing");
+		expect(response.content).toBeUndefined();
+		expect(notes.examplesTruncated).toBe(1);
+		expect(notes.examplesWithoutMediaType).toBe(0);
+		expect(notes.examplesWritten).toBe(0);
+	});
+
 	it("writes a request's parameter value as the declared parameter's example, and leaves a $ref alone", () => {
 		const requests = boundRequests();
 		requests[0].request = request({
@@ -451,6 +502,28 @@ describe("skeleton export - a starting point, not a contract", () => {
 		// A body that is not JSON is the text it is, never dropped.
 		expect(responses["500"].content["text/plain"].example).toBe("boom");
 		expect(notes.examplesWritten).toBe(2);
+	});
+
+	it("derives no schema from a body it only has part of", () => {
+		const { document, notes } = exportJson({
+			requests: [
+				entry({ id: "r1" }, [
+					example({ id: "ex_part", body: '{"id":"p1","na', bodyTruncated: true }),
+				]),
+			],
+		});
+
+		const responses = operationOf(document, "/pets", "get").responses as Record<
+			string,
+			{ description: string; content?: unknown }
+		>;
+		// A skeleton is the one direction that reads a shape off an example body,
+		// which makes a partial body worse here than in the bound direction: the
+		// contract would state the fields the capture happened to reach as the
+		// whole of the response.
+		expect(responses["200"].content).toBeUndefined();
+		expect(notes.examplesTruncated).toBe(1);
+		expect(notes.examplesWritten).toBe(0);
 	});
 
 	it("counts a request it cannot place instead of guessing at one", () => {

--- a/app/src/services/exporters/openapi.ts
+++ b/app/src/services/exporters/openapi.ts
@@ -107,6 +107,14 @@ export interface ExportNotes {
 	 */
 	examplesWithoutMediaType: number;
 	/**
+	 * Examples whose stored body is only the first slice of the response it was
+	 * saved from (`bodyTruncated`, issue #659). The response is written, the body
+	 * is not: a partial body written as an `example` is indistinguishable from a
+	 * complete one, and a contract that documents half a payload as the payload
+	 * is worse than one that documents none.
+	 */
+	examplesTruncated: number;
+	/**
 	 * `$ref` parameters left exactly as they were. A shared parameter belongs to
 	 * every operation that names it, so writing one request's value into it
 	 * would edit the contract for operations this collection may not even have.
@@ -149,6 +157,7 @@ export function emptyNotes(direction: ExportNotes["direction"], dialect: string)
 		duplicateOperations: 0,
 		examplesWritten: 0,
 		examplesWithoutMediaType: 0,
+		examplesTruncated: 0,
 		sharedParametersLeft: 0,
 		vocabularyNotWritten: false,
 	};

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -393,11 +393,25 @@ Vayu has something to say, and otherwise left exactly as it was:
 - **Saved examples become response examples**, whether they came from the import
   or from a response you kept. One example for a status and media type is written
   as `example`, several as a named `examples` map. This is where work done in
-  Vayu flows back into the contract.
+  Vayu flows back into the contract. An example Vayu only kept **part** of - the
+  Examples panel marks those, and a big response is capped as it is saved - is
+  the one kind that does not: the status is documented, the body is not, and the
+  dialog counts it. Half a payload written as the payload would be
+  indistinguishable from a complete one to everyone downstream, including the
+  mock server.
 - **Everything else survives.** Vendor extensions, `info`, `tags`, `security`,
   components nothing references - all of it is carried through, because export
   patches the document rather than rebuilding it. The dialect is left alone too:
   a 3.0 document exports as 3.0, never quietly upgraded.
+
+**The export reaches every request under the collection - down to the next
+document.** A sub-collection bound to a *different* spec answers to that spec,
+so its requests are left to its own export: they carry operation names of the
+other document (`listUsers`, `GET /users` - names generators hand out in every
+document), and letting them through would have them claim operations here and
+overwrite them with values from somewhere else. A sub-collection bound to the
+**same** document is part of this export, because its requests describe these
+very operations - stopping there would remove them as operations nothing claims.
 
 A **Swagger 2.0** document is the one partial case, and it is stated as one:
 operations nothing claims are still removed, but nothing is written *into* an
@@ -441,7 +455,13 @@ Everything in it is something the collection actually holds:
 Both directions state what they could not carry, and the zeros are part of the
 statement: a request whose URL states no path, two requests that reduce to the
 same method and path (the first wins), an example whose media type was never
-recorded (the response is written, the body is not). Nothing is dropped quietly.
+recorded, an example stored only in part (the response is written, the body is
+not, in both of those last two). Nothing is dropped quietly.
+
+A large document takes a moment to put together, and the dialog says
+**Assembling the document…** while it does. Switching between JSON and YAML
+assembles the other format once; switching back is immediate, because the first
+one is still there.
 
 ## Contract coverage
 


### PR DESCRIPTION
## Description

All three of #721's findings, verified against the current code first - each is
still exactly as the issue describes.

**Plan.** The root cause the three share is the export reading more than it is
entitled to, or reading it at the wrong moment: a body it only has part of, a
subtree that belongs to another contract, and a document assembled during
render. The approach is one boundary per finding, each expressed through the
primitive that already owns the rule rather than a second copy of it - the
truncation flag the row already carries, the descend predicate
`collectSubtreeIds` already takes, and a state shape that makes staleness
derivable instead of cleared. **Alternative rejected:** writing a truncated body
under a marker (a `description` saying so, or an `x-` extension) instead of
withholding it. It reads as more honest and is not: everything downstream - a
re-import, the mock server, a code generator - would still consume the fragment
as the example, and the one reader who would see the marker is the person who
already knows, because they saved it.

### 1. A truncated body is no longer written as though it were the response

`bodyTruncated` has been on `RequestExample` since #659 and no file under
`services/exporters/` read it, so a capped body went out through
`exampleValue(example.body)` - and a capped body whose `JSON.parse` fails falls
back to the raw string (`payload.ts:46-49`), so half a JSON document entered the
contract as a quoted fragment. The filter that already drops a body with no
media type now drops a truncated one first, into a new `ExportNotes` field
(`examplesTruncated`) that the dialog prints beside its other losses. Truncation
is checked *before* the media type so one example produces one line rather than
two.

The status is still documented - that much is known - and only the body is
withheld, matching what the no-media-type case does one line below. The skeleton
direction gains the most: it is the one that derives a schema from an example
body, so a partial body there would have stated the fields the capture happened
to reach as the whole shape of the response.

### 2. The subtree walk stops where another document begins

`useOpenApiExportSource` called `collectSubtreeIds` with no descend predicate,
although the function takes one and `collectionsUnderContract` already uses it
to stop at a sub-collection declaring its own data contract. Collections
re-parent freely, so spec B's collection can sit under spec A's; B's requests
carry stamps of B, and `patchBoundDocument` matches by operationId then
method+path - names generators hand out in every document - so B's rows claimed
A's operations and rewrote them with B's values.

**Deliberate deviation from the issue spec**, and the one thing worth a
reviewer's eye: the issue says the walk stops at "a descendant carrying its own
spec binding". It stops at one bound to a **different** document. A descendant
bound to the *same* spec describes the very operations being patched, so
excluding it would have `patchBoundDocument` remove them as operations "nothing
here claims" - trading a cross-document rewrite for a silent deletion, which is
not an improvement. Both cases are tested, in both directions. For a skeleton
export (no document of its own) every binding below is another one, which is the
unconditional rule the issue describes.

Checked before relying on the predicate: an OpenAPI import binds the **root**
collection only (`openapi-v3.ts:176`); the per-tag folders it creates carry no
binding, so the boundary cannot swallow the collection it was meant to walk.

### 3. Assembly is off the render pass, and each format is assembled once

`ExportSpecDialog` parsed the stored document, ran the patch walk and serialized
inside a `useMemo` - during render, re-executed from scratch on every JSON/YAML
toggle, with `source.isLoading` covering only the network reads. It runs from an
effect now, behind an **Assembling the document…** line that reuses the existing
pending treatment, and the results are kept per format so a toggle back is free.

Two notes on the shape. Staleness is **derived, not cleared**: the state holds
`{ key, byFormat }` and a result is the answer only while its key matches the
current source, so nothing has to remember to invalidate it - and the effect
never calls `setState` synchronously, which `react-hooks/set-state-in-effect`
enforces. And the key is the source's *contents* (collection and request ids
with their `updatedAt`, plus example ids), not the arrays' identity: the rows
arrive as fresh arrays whenever a query re-runs, and keying on identity would
re-parse the document for a render that changed nothing - or, with the deferral,
restart the work it had just cancelled and leave a spinner that never resolves.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only diff (TypeScript and one docs page); no engine file is touched, so per
`CLAUDE.md`'s "scale the verification to what the change could actually break"
the engine build and ctest were not run - no C++ test could change colour.
Everything the change can reach, on `2c0715d`:

- `pnpm test` - **5665 tests in 519 files, 100% passed** (5658 on the base
  commit; the seven new ones are the delta)
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean (only
  `ExportSpecDialog.tsx` was formatted; `docs/app/openapi.md` was not
  prettier-clean before this branch and was left alone, per the repo rule)
- `mkdocs build --strict` - clean

New coverage, all mutation-checked (applied the mutation, confirmed red,
restored):

| Mutation | Result |
|---|---|
| drop the `bodyTruncated` filter | 3 exporter tests fail (bound `example` written, 404 body written, skeleton schema derived from half a body) |
| drop the descend predicate | `leaves a nested collection bound to another document out of this one` fails - the foreign request claims `/owners` |
| stop at *any* binding instead of a different one | `keeps a nested collection bound to the same document…` fails - its operation is removed as unclaimed |
| assemble during render | 3 dialog tests fail, including the pending-line guard |
| write only the current format into the cache | `assembles each format once, so toggling back is free` fails |

- `openapi.test.ts` (+3): a truncated example is absent from a bound document
  while the complete one beside it still lands as `example`; its response is
  written without `content` and counted once, as truncated rather than also as
  media-type-less; the skeleton derives no schema from it.
- `ExportSpecDialog.test.tsx` (+4): the foreign-binding fixture (B under A, B's
  request stamped with a name A also declares) and the same-spec one, each
  asserted through the downloaded document as well as the summary; assembly
  happens off the render pass; each format is assembled exactly once across a
  JSON → YAML → JSON toggle.

The pending-line guard is read **inside** the exporter (does the DOM already
show "Assembling the document" at the moment assembly runs?) rather than polled
from the test: the pending state is transient, and a `findBy*` that misses it
would report a frozen window as a pass.

One test-only change worth naming: the file's `useMultipleCollectionRequests`
mock now pins the map it returns to its contents, the way the real hook pins
what `combine` builds (`queries/collections.ts:105-137`). It was rebuilding the
map on every render, which is a hook this app does not have.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `docs/app/openapi.md` (the truncated-example
      rule, the subtree boundary and why it is "another document" rather than
      "a document", the pending line and the per-format caching, and the counts
      paragraph)

## Related Issues
Closes #721

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9CvKTUqABeAgyuZScNdxw)_