### PR TITLE
fix(engine/app): deleting an imported example is a decision that lasts (#722)

### DIFF
--- a/app/src/modules/request-builder/components/RequestTabs/examples-tab.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/examples-tab.test.tsx
@@ -70,6 +70,7 @@ const example = (over: Partial<RequestExample> = {}): RequestExample => ({
 	headers: [{ key: "Content-Type", value: "application/json", enabled: true }],
 	body: '{"id":1}',
 	contentType: "application/json",
+	origin: "import",
 	...over,
 });
 
@@ -149,6 +150,36 @@ describe("Examples tab", () => {
 	});
 
 	/*
+	 * Where a row came from (issue #722). The engine has recorded `origin` since
+	 * #588 and a spec sync acts on the two kinds differently - it rewrites a
+	 * request's imported examples on any applied change and never touches a
+	 * saved one - so a list that shows neither leaves the user unable to predict
+	 * which rows the next sync owns.
+	 */
+	describe("the origin chip", () => {
+		it("marks an imported row and leaves a saved one unmarked", async () => {
+			listRequestExamples.mockResolvedValue([
+				example({ origin: "import" }),
+				example({ id: "exa_2", name: "Kept from a send", origin: "user" }),
+			]);
+			renderExamplesTab({ id: "req_1" });
+
+			// One chip, on the imported row rather than merely somewhere on the
+			// page - the whole point is which row it names.
+			const chips = await screen.findAllByText("Imported");
+			expect(chips).toHaveLength(1);
+			// By the expanders, in list order: a name query matches the delete
+			// button beside each row as well, which is why the tests above reach
+			// for `expanded` too.
+			const [imported, saved] = screen.getAllByRole("button", { expanded: false });
+			expect(imported.textContent).toContain("200 OK");
+			expect(imported.textContent).toContain("Imported");
+			expect(saved.textContent).toContain("Kept from a send");
+			expect(saved.textContent).not.toContain("Imported");
+		});
+	});
+
+	/*
 	 * Delete (issue #588). It landed with save-as-example because an example you
 	 * can create and never remove is the #553 zombie shape at a smaller scale -
 	 * and because a row a mock server answers with is not one to remove on a
@@ -170,6 +201,32 @@ describe("Examples tab", () => {
 			await waitFor(() =>
 				expect(deleteRequestExample).toHaveBeenCalledWith("req_1", "exa_1")
 			);
+		});
+
+		/*
+		 * The dialog used to promise "nothing here can bring it back" for every
+		 * row, which was false for an imported one: the next sync of any field
+		 * re-created it (issue #722). The engine keeps the delete now, so the
+		 * promise holds - and the copy says which way each kind of row can still
+		 * come back rather than asserting it cannot.
+		 */
+		it("tells an imported row what a sync and a re-import each do about it", async () => {
+			listRequestExamples.mockResolvedValue([example({ origin: "import" })]);
+			renderExamplesTab({ id: "req_1" });
+
+			fireEvent.click(await screen.findByRole("button", { name: /delete example 200 OK/i }));
+			expect(screen.getByText(/will not bring it back/i)).toBeTruthy();
+			expect(screen.getByText(/re-importing the document will/i)).toBeTruthy();
+			expect(screen.queryByText(/Nothing here can bring it back/i)).toBeNull();
+		});
+
+		it("tells a saved row that nothing brings it back", async () => {
+			listRequestExamples.mockResolvedValue([example({ origin: "user" })]);
+			renderExamplesTab({ id: "req_1" });
+
+			fireEvent.click(await screen.findByRole("button", { name: /delete example 200 OK/i }));
+			expect(screen.getByText(/Nothing here can bring it back/i)).toBeTruthy();
+			expect(screen.queryByText(/re-importing the document/i)).toBeNull();
 		});
 
 		it("keeps the row and names the refusal when the engine says no", async () => {

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ExamplesPanel.truncation.test.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ExamplesPanel.truncation.test.tsx
@@ -55,6 +55,8 @@ function example(overrides: Partial<RequestExample> = {}): RequestExample {
 		headers: [{ key: "Content-Type", value: "application/json", enabled: true }],
 		body: '{"id":1}',
 		contentType: "application/json",
+		// A truncated body can only come from a save: import copies whole ones.
+		origin: "user",
 		...overrides,
 	};
 }

--- a/app/src/modules/request-builder/components/RequestTabs/panels/ExamplesPanel.tsx
+++ b/app/src/modules/request-builder/components/RequestTabs/panels/ExamplesPanel.tsx
@@ -6,7 +6,8 @@
  */
 
 /**
- * ExamplesPanel - the request's saved example responses (issues #481, #588).
+ * ExamplesPanel - the request's saved example responses (issues #481, #588,
+ * #722).
  *
  * These are what an importer found next to the request and, until the engine
  * had a table for them, threw away: Postman's saved responses, an OpenAPI
@@ -20,6 +21,15 @@
  * because an example you can create and never remove is the #553 zombie shape
  * at a smaller scale; an editor for a stored example is a separate change, and
  * this is still a viewer until it exists.
+ *
+ * **A row says where it came from, because the two kinds behave differently**
+ * (#722). A spec sync rewrites a request's imported examples whenever it
+ * applies any change to it and never touches a saved one, so which rows the
+ * next sync owns is a fact about the list - and until the chip it was one the
+ * list did not show. Deleting either kind is durable now: the engine records a
+ * deleted imported example rather than only removing it, so this dialog's
+ * promise is true for both, and only the wording of what could still bring one
+ * back differs.
  */
 
 import { useState } from "react";
@@ -96,6 +106,30 @@ function ExampleRow({
 							title="Only the first part of the response was captured. A mock server serves this body as though it were the whole response."
 						>
 							Partial body
+						</Badge>
+					)}
+					{/*
+					 * Where the row came from (issue #722). The engine has
+					 * recorded it since #588 and the two kinds behave
+					 * differently - a sync rewrites the imported rows of a
+					 * request it applies any change to, and never the saved
+					 * ones - so leaving the asymmetry invisible made the list
+					 * unpredictable: nothing on screen said which rows the next
+					 * sync would replace.
+					 *
+					 * Neutral, unlike the amber beside it: this is where a row
+					 * came from, not something to watch out for. The muted
+					 * text-only chip the settings cards use for the same kind
+					 * of fact ("Every port", "Passphrase set") - `chip` paints
+					 * no background, so the colour is the caller's to state.
+					 */}
+					{example.origin === "import" && (
+						<Badge
+							variant="chip"
+							className="shrink-0 text-muted-foreground"
+							title="Written by an import or a spec sync. Applying a later sync to this request refreshes it from the document; an example you save from a response is never replaced."
+						>
+							Imported
 						</Badge>
 					)}
 				</button>
@@ -203,7 +237,14 @@ export default function ExamplesPanel() {
 			{/*
 			 * Confirmed rather than immediate: a mock server answers with the first
 			 * example of a matched route, so removing one can change what the next
-			 * restart serves - and nothing here can bring it back.
+			 * restart serves.
+			 *
+			 * The second sentence differs by origin because what happens next
+			 * does (issue #722). A saved example is simply gone. An imported one
+			 * is gone too - the engine keeps the delete as a tombstone, so no
+			 * later sync writes it back - but re-importing the document is a
+			 * fresh import and does bring it back, which is the one way it can
+			 * return and so the one thing worth saying here.
 			 */}
 			<DeleteConfirmDialog
 				open={!!pendingDelete}
@@ -213,7 +254,10 @@ export default function ExamplesPanel() {
 					<>
 						<span className="font-medium">{pendingDelete?.name}</span> is removed from
 						this request. A mock server for this collection stops answering with it once
-						it is restarted.
+						it is restarted.{" "}
+						{pendingDelete?.origin === "import"
+							? "Syncing this collection with its spec will not bring it back; re-importing the document will."
+							: "Nothing here can bring it back."}
 						{/* The engine's refusal, in the dialog that asked for the delete.
 						    Without it a failed delete looks like nothing happened: the row
 						    is still there and the dialog is still open. */}

--- a/app/src/services/exporters/openapi.test.ts
+++ b/app/src/services/exporters/openapi.test.ts
@@ -78,6 +78,7 @@ function example(overrides: Partial<RequestExample> = {}): RequestExample {
 		headers: [],
 		body: '{"id":"p1","name":"Rex"}',
 		contentType: "application/json",
+		origin: "import",
 		...overrides,
 	};
 }

--- a/app/src/types/domain.ts
+++ b/app/src/types/domain.ts
@@ -641,9 +641,8 @@ export interface Request {
  * A saved example response stored against a request (issue #481).
  *
  * What an importer found next to the request - Postman's saved responses, an
- * OpenAPI operation's documented ones - and, once the mock server lands, the
- * response it serves. Read-only in the app today: examples are created by
- * import, so the request builder lists them and nothing writes one.
+ * OpenAPI operation's documented ones - what the user kept from a live response
+ * (issue #588), and what a mock server for the collection answers with.
  *
  * The engine's row carries `order` and timestamps too. They are absent here on
  * purpose: the list arrives already in `order`, and no surface displays either,
@@ -659,6 +658,18 @@ export interface RequestExample {
 	body: string;
 	/** `""` when the source stated no media type - not a guess. */
 	contentType: string;
+	/**
+	 * Who wrote this row: `import` for what an importer or a spec sync produced,
+	 * `user` for what was saved from a live response (issues #588, #722).
+	 *
+	 * Typed here because the panel reads it, and it had to be: the two kinds
+	 * behave differently and the difference was invisible. A sync rewrites the
+	 * imported rows of every request it touches, so an imported example is the
+	 * document's to change and a saved one is not - and what deleting one means
+	 * differs with it. Always present: the engine has recorded an origin on
+	 * every row since #588 and defaults the column to `import`.
+	 */
+	origin: "import" | "user";
 	/**
 	 * True when `body` is only the first slice of the response this was saved
 	 * from (issue #659).

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -164,10 +164,13 @@ list key rather than splicing a row in, since the engine decides the id, the
 `order` an append lands on and the stored shape of the row.
 
 A saved example is written with **`origin: "user"`**, and an imported one keeps
-the engine's `"import"` default. That field is write-only from here - nothing in
-the app reads it back and `RequestExample` does not claim it - because its
-reader is the OpenAPI spec sync (#627), which may replace the examples a
-document produced and must never touch one a person saved. The rest of the
+the engine's `"import"` default. Its first reader is the OpenAPI spec sync
+(#627), which may replace the examples a document produced and must never touch
+one a person saved - and since #722 the panel reads it too: `RequestExample`
+claims the field, an imported row carries an **Imported** chip, and the delete
+dialog says what can still bring that kind of row back. The asymmetry the field
+encodes is a fact about the list, so leaving it invisible made which rows the
+next sync would replace unpredictable. The rest of the
 payload is the importers' own mapping, `contentType` included (the response's
 Content-Type header verbatim, `""` when it stated none), so an app-saved example
 and an imported one are served identically. No `order` is ever sent: the engine
@@ -176,9 +179,9 @@ example.
 
 No transformer, unlike a request row: an example carries no timestamp the app
 renders and no column that predates a schema change, so the wire shape *is* the
-domain shape - minus the `order`, `origin` and timestamps the `RequestExample`
-type deliberately does not claim, since the list arrives already ordered and no
-surface displays any of them. The stored order is the contract, not a suggestion: a mock
+domain shape - minus the `order` and timestamps the `RequestExample` type
+deliberately does not claim, since the list arrives already ordered and no
+surface displays either. The stored order is the contract, not a suggestion: a mock
 server answers with the first example of a matched request, so the panel renders
 the list as received rather than re-sorting it.
 

--- a/docs/app/openapi.md
+++ b/docs/app/openapi.md
@@ -348,7 +348,16 @@ by what the document now documents.
 
 - Examples you saved from a live response are **never** replaced. The engine
   records who wrote each one (`origin`), and only the imported ones are in
-  scope.
+  scope. The Examples panel marks the imported rows with an **Imported** chip,
+  so which rows a sync owns is visible where they are managed.
+- **An imported example you deleted stays deleted.** A sync refreshes examples
+  whenever it applies *any* change to a request - a rename is enough - so
+  before this the next sync silently brought a deleted one back. The engine now
+  records the deletion and the refresh skips that response status; re-importing
+  the document is the one thing that brings it back, and the delete dialog says
+  so. What is remembered is the **status**, not the example's name, because a
+  name carries the document's response description and changes when the
+  document rewords it.
 - The order is preserved where it can be: your saved examples never move, and a
   refreshed example never jumps ahead of one that was already in front of it.
   This matters because a mock server answers with the *first* example.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -1203,6 +1203,20 @@ is a `400`).
 
 ### DELETE /requests/:id/examples/:exampleId
 
+**Deleting an imported example is a decision that lasts** (issue #722). A spec
+sync rewrites the `origin: "import"` examples of every request it applies a
+change to, so a removed row used to come back on the next sync of any field -
+even a rename. The engine now keeps the row as a **tombstone** instead: the
+example is gone from every read (the list, a mock server, an export, and a `GET`
+or `PUT` on its id, all `404`), and a later sync leaves that response status
+alone rather than writing the document's example for it back. Re-importing the
+document is a fresh import and does bring it back, which is the only way it
+returns. An `origin: "user"` example is removed outright - nothing re-creates
+one, so there is no intent to keep.
+
+The response is the same either way, because from the caller's side so is the
+outcome:
+
 **Response:**
 ```json
 {
@@ -1482,6 +1496,11 @@ Four rules the payload cannot opt out of:
   first example" is what a mock server answers with. An **absent** `examples`
   leaves every example alone, `[]` removes the imported ones. An explicit
   `origin` on an item is a `400`: a sync writes imported examples by definition.
+  An example whose **status the user deleted** is not written back either
+  (issue #722) - the delete left a tombstone and the refresh skips that status,
+  so a sync of any field cannot undo it. The identity is the status, not the
+  name, because a name carries the document's response description and moves
+  when the document rewords it.
 - **A request cannot be moved here.** `collectionId` inside an `update` item is a
   `400`; use `PUT /requests/:id`.
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -269,6 +269,7 @@ found next to it (Postman's `item.response[]`, an OpenAPI operation's
 | `order`        | INTEGER | Sort order within the request; default 0          |
 | `origin`       | TEXT    | `import` \| `user`; NOT NULL, default `import`     |
 | `body_truncated` | INTEGER | `body` stops short of the captured response; NOT NULL, default `0` |
+| `suppressed`   | INTEGER | A tombstone: an imported example the user deleted; NOT NULL, default `0` |
 | `created_at`   | INTEGER | Unix ms                                           |
 | `updated_at`   | INTEGER | Unix ms                                           |
 
@@ -310,11 +311,29 @@ is answered as though it were complete. The Examples panel is the reader,
 painting a "Partial body" chip; before the column, the fact lived only in the
 example's *name*, which the save dialog invites the user to edit.
 
+**suppressed** (issue #722) marks a row as a tombstone: an `origin="import"`
+example the user deleted. Added the same ALTER-friendly way as the two columns
+above, and `false` is right for every pre-existing row - before it, a delete
+removed the row. It exists because deleting an imported example otherwise
+recorded nothing, while the sync refresh above rewrites every imported row of a
+request it applies *any* change to, so the next rename-only sync re-created what
+the user had removed. The row is kept so the refresh can skip that response
+**status** (the identity a document's example keeps across a reworded
+description, which its `name` does not), and `body`, `headers` and
+`content_type` are cleared when the flag goes on, since nothing serves a
+tombstone. `get_request_example`, `get_request_examples` and
+`count_request_examples` all filter suppressed rows out - so the list route, a
+mock server and an export behave exactly as though the delete had removed it -
+and `get_suppressed_request_examples` is the one read that sees them, for the
+one caller that must. A `user` row is still deleted outright: nothing re-creates
+a saved response, so there is no intent to keep.
+
 **Cascade.** Examples are owned by their request: `DELETE /requests/:id` removes
 them in the same transaction, and the `delete_collection` cascade removes each
 descendant request's examples before the requests themselves. Every read here is
 by `request_id` or by example id, so a row left behind would be unreachable
-rather than merely stale.
+rather than merely stale. A tombstone is a row like any other and goes with the
+same cascades.
 
 **Caps.** A body over `request_example::MAX_BODY_BYTES` (1 MiB) is a `400`, never
 a truncation - a half-body served as if whole is worse than a refused write - and

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -107,7 +107,15 @@ Three things worth knowing before you design around them:
   wrote, `user` for what the app saved from a live response - defaulting to
   `import`, and a `400` on anything else. It is stored so the OpenAPI spec sync
   (`POST /specs/sync`, #655) can replace the first kind without touching the
-  second; nothing else about a row says where it came from.
+  second; nothing else about a row says where it came from. **Deleting an
+  imported example keeps the row as a tombstone** (`suppressed`, #722), because
+  the refresh rewrites a request's imported rows on any applied change and so
+  a plain delete lasted only until the next sync of any field. Every read
+  filters tombstones out - `get_request_examples` and `get_request_example`, so
+  the list route, a mock server and an export all behave as though the row were
+  gone - and `get_suppressed_request_examples` is the single read that sees
+  them, for the refresh. It matches on the response **status**, which is what a
+  document's example keeps when its description is reworded.
 - **`GET /requests/:id` is a single-request lookup.** `useRequestQuery` uses it
   to load a restored request tab or a design-run copy on cold start - one round
   trip, not the old scan of every collection's list. A `404` means the request

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -148,12 +148,21 @@ class Database {
     // an example only means anything next to the request it answers.
 
     void save_request_example (const RequestExample& e);
+    /// A suppressed row reads as absent - see the definition (issue #722).
     std::optional<RequestExample> get_request_example (const std::string& id);
     /// Oldest first (created_at, then id) - the order a mock server resolves
     /// "the first example" in, so it is a contract rather than a detail.
+    /// Excludes tombstones, so a deleted imported example is gone to every
+    /// reader (issue #722).
     std::vector<RequestExample> get_request_examples (const std::string& request_id);
+    /// The tombstones only - deleted imported examples, which exist so a spec
+    /// sync does not write back what the user removed (issue #722).
+    std::vector<RequestExample> get_suppressed_request_examples (const std::string& request_id);
     int64_t count_request_examples (const std::string& request_id);
     void delete_request_example (const std::string& id);
+    /// Keeps an imported example's row as a tombstone instead of removing it
+    /// (issue #722). `now` is the caller's clock, as every other write here.
+    void suppress_request_example (const std::string& id, int64_t now);
 
     // OpenAPI documents (issue #637). Bound by collections rather than owned by
     // one, so nothing here cascades: `delete_spec_document` is only ever reached

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -1038,6 +1038,31 @@ struct RequestExample {
      * that ever had a partial one.
      */
     bool body_truncated = false;
+    /**
+     * A tombstone: the row is an imported example the user deleted (issue
+     * #722).
+     *
+     * Deleting an `origin="import"` example used to remove the row and record
+     * nothing, while a spec sync replaces every imported row of a request it
+     * applies *any* change to - so the next rename-only sync brought the
+     * deleted example back. The intent has to survive somewhere, and the row
+     * that held it is the one thing that already carries the identity: this
+     * flag keeps it as a marker of "the document's example for this status is
+     * not wanted here" and `refresh_examples` skips that status.
+     *
+     * A suppressed row is not an example any more. `get_request_example(s)`
+     * and `count_request_examples` filter it out, so every reader - the list
+     * route, the mock server, the export - behaves exactly as though the
+     * delete had removed it, and only the sync's own accessor
+     * (`get_suppressed_request_examples`) can see it. `body`, `headers` and
+     * `content_type` are cleared when the flag goes on: nothing serves a
+     * tombstone, so keeping a response body against a deleted row would retain
+     * bytes for a reader that does not exist.
+     *
+     * `false` for every row that predates the column, which is what they all
+     * are - a row a delete had reached was gone.
+     */
+    bool suppressed = false;
     int64_t created_at;
     int64_t updated_at;
 };

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -285,6 +285,11 @@ inline auto make_storage (const std::string& path) {
     // which is what they all are: import copies whole bodies, and the app's
     // save-as-example is the only writer that ever had a partial one.
     make_column ("body_truncated", &RequestExample::body_truncated, default_value (false)),
+    // A deleted imported example, kept as a tombstone so a later spec sync does
+    // not re-create it (issue #722). NOT NULL + default_value on the same
+    // precedent as the two columns above, and `false` is right for every
+    // pre-existing row: before this column a delete removed the row outright.
+    make_column ("suppressed", &RequestExample::suppressed, default_value (false)),
     make_column ("created_at", &RequestExample::created_at),
     make_column ("updated_at", &RequestExample::updated_at)),
 
@@ -941,9 +946,18 @@ void Database::save_request_example (const RequestExample& e) {
     impl_->storage.replace (e);
 }
 
+/**
+ * One example by id - a tombstoned row reads as gone (issue #722).
+ *
+ * The filter is here rather than in each caller because this is what the
+ * owner check of every `/requests/:id/examples/:exampleId` route reads: a
+ * suppressed row answering 200 would let a `PUT` bring a deleted example back
+ * by writing over its tombstone.
+ */
 std::optional<RequestExample> Database::get_request_example (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    auto rows = impl_->storage.get_all<RequestExample> (where (c (&RequestExample::id) == id));
+    auto rows = impl_->storage.get_all<RequestExample> (
+    where (c (&RequestExample::id) == id and c (&RequestExample::suppressed) == false));
     if (rows.empty ())
         return std::nullopt;
     return rows.front ();
@@ -957,21 +971,64 @@ std::vector<RequestExample> Database::get_request_examples (const std::string& r
     // has to lead, because a bulk import writes every example of one request in
     // the same millisecond - on `created_at` alone they all tie and the id
     // tiebreak returns the author's list shuffled.
+    // Tombstoned rows are excluded here and not by the callers, so a deleted
+    // imported example is invisible to the list route, the mock server and the
+    // export alike (issue #722).
     return impl_->storage.get_all<RequestExample> (
-    where (c (&RequestExample::request_id) == request_id),
+    where (c (&RequestExample::request_id) == request_id and c (&RequestExample::suppressed) == false),
     multi_order_by (order_by (&RequestExample::order),
     order_by (&RequestExample::created_at), order_by (&RequestExample::id)));
 }
 
+/**
+ * The request's tombstones - deleted imported examples (issue #722).
+ *
+ * The one read that sees suppressed rows, and it exists for one caller: the
+ * spec sync's `refresh_examples`, which has to know which statuses the user
+ * removed before writing the document's examples back.
+ */
+std::vector<RequestExample>
+Database::get_suppressed_request_examples (const std::string& request_id) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.get_all<RequestExample> (
+    where (c (&RequestExample::request_id) == request_id and c (&RequestExample::suppressed) == true));
+}
+
 int64_t Database::count_request_examples (const std::string& request_id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
-    return impl_->storage.count<RequestExample> (where (c (&RequestExample::request_id) == request_id));
+    // Tombstones do not count against `MAX_PER_REQUEST`: a user who deletes an
+    // imported example has fewer examples, not the same number with one hidden.
+    return impl_->storage.count<RequestExample> (
+    where (c (&RequestExample::request_id) == request_id and c (&RequestExample::suppressed) == false));
 }
 
 void Database::delete_request_example (const std::string& id) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
     vayu::utils::log_debug ("Deleting request example: id=" + id);
     impl_->storage.remove_all<RequestExample> (where (c (&RequestExample::id) == id));
+}
+
+/**
+ * Turns an imported example into a tombstone (issue #722).
+ *
+ * The row stays so a later sync knows the status was removed on purpose; what
+ * it held does not, because nothing reads a suppressed row's body.
+ */
+void Database::suppress_request_example (const std::string& id, int64_t now) {
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    vayu::utils::log_debug ("Suppressing imported request example: id=" + id);
+    auto rows = impl_->storage.get_all<RequestExample> (where (c (&RequestExample::id) == id));
+    if (rows.empty ()) {
+        return;
+    }
+    RequestExample row  = rows.front ();
+    row.suppressed      = true;
+    row.body            = "";
+    row.headers         = "";
+    row.content_type    = "";
+    row.body_truncated  = false;
+    row.updated_at      = now;
+    impl_->storage.replace (row);
 }
 
 // ============================================================================

--- a/engine/src/http/routes/examples.cpp
+++ b/engine/src/http/routes/examples.cpp
@@ -283,6 +283,18 @@ const nlohmann::json& json) {
 
 /**
  * Testable core of DELETE /requests/:id/examples/:exampleId.
+ *
+ * **An imported example is tombstoned rather than removed** (issue #722). A
+ * spec sync replaces every `origin="import"` row of a request it applies any
+ * change to, so a removed row came back on the next rename-only sync and the
+ * delete this route performs was not a decision that lasted. Keeping the row
+ * as a tombstone (`suppressed`) is what records the decision - the sync reads
+ * them and leaves that status alone.
+ *
+ * A user's own example is still removed outright: nothing re-creates one, so
+ * there is no intent to remember and a hidden row would be a leak with no
+ * reader. Either way the answer is the same, because from the caller's side it
+ * is: the example is gone from every read.
  */
 std::pair<int, nlohmann::json> delete_request_example_response (vayu::db::Database& db,
 const std::string& request_id,
@@ -295,7 +307,11 @@ const std::string& example_id) {
         return *err;
     }
 
-    db.delete_request_example (example_id);
+    if (x.origin == vayu::core::constants::request_example::ORIGIN_IMPORT) {
+        db.suppress_request_example (example_id, now_ms ());
+    } else {
+        db.delete_request_example (example_id);
+    }
     return { 200,
         nlohmann::json{ { "message", "Example deleted successfully" }, { "id", example_id } } };
 }

--- a/engine/src/http/routes/spec_sync.cpp
+++ b/engine/src/http/routes/spec_sync.cpp
@@ -43,6 +43,7 @@
 #include "vayu/utils/logger.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -195,6 +196,12 @@ std::string& temp_id_out) {
  * writes what the document says, and a payload that could claim `user` could
  * manufacture rows the *next* sync then refuses to replace - quietly turning
  * the protection this route exists to provide into a leak.
+ *
+ * @param suppressed_statuses the statuses this request holds a tombstone for
+ * (issue #722) - the document's example for one of them is validated like any
+ * other and then dropped, because the user deleted it and a sync that wrote it
+ * back would make that delete a suggestion. Empty on the create path: a
+ * request being created now has nothing behind it to have deleted.
  */
 std::optional<std::pair<int, nlohmann::json>> build_example_rows (const nlohmann::json& item,
 const std::string& request_id,
@@ -202,7 +209,8 @@ const std::string& owner,
 int base_order,
 int64_t now,
 std::vector<vayu::db::RequestExample>& out,
-size_t surviving) {
+size_t surviving,
+const std::unordered_set<int>& suppressed_statuses = {}) {
     if (!item.contains ("examples") || item["examples"].is_null ()) {
         return std::nullopt;
     }
@@ -210,13 +218,10 @@ size_t surviving) {
         return item_error (400, "Invalid 'examples': must be an array", owner);
     }
     const auto& examples = item["examples"];
-    if (examples.size () + surviving > vayu::core::constants::request_example::MAX_PER_REQUEST) {
-        return item_error (400,
-        "Too many examples: " + std::to_string (examples.size () + surviving) +
-        " exceeds the limit of " +
-        std::to_string (vayu::core::constants::request_example::MAX_PER_REQUEST) + " per request",
-        owner);
-    }
+    // Against what will be written rather than what was offered: a tombstoned
+    // example never lands, so counting it here would refuse a sync that fits.
+    std::vector<vayu::db::RequestExample> rows;
+    rows.reserve (examples.size ());
 
     for (size_t i = 0; i < examples.size (); ++i) {
         const auto& example = examples[i];
@@ -245,11 +250,27 @@ size_t surviving) {
             "example", owner)) {
             return err;
         }
+        // Validated first and dropped second, so a malformed example the user
+        // happens to have deleted is still a 400 rather than a silent skip.
+        if (suppressed_statuses.contains (x.status)) {
+            continue;
+        }
         // Document order from the block this refresh occupies - see
-        // `refresh_examples` for what decides where the block starts.
-        x.order = base_order + static_cast<int> (i);
-        out.push_back (std::move (x));
+        // `refresh_examples` for what decides where the block starts. Counted
+        // over what is kept, so a dropped example leaves no hole in the block.
+        x.order = base_order + static_cast<int> (rows.size ());
+        rows.push_back (std::move (x));
     }
+
+    if (rows.size () + surviving > vayu::core::constants::request_example::MAX_PER_REQUEST) {
+        return item_error (400,
+        "Too many examples: " + std::to_string (rows.size () + surviving) +
+        " exceeds the limit of " +
+        std::to_string (vayu::core::constants::request_example::MAX_PER_REQUEST) + " per request",
+        owner);
+    }
+    out.insert (out.end (), std::make_move_iterator (rows.begin ()),
+    std::make_move_iterator (rows.end ()));
     return std::nullopt;
 }
 
@@ -262,15 +283,34 @@ size_t surviving) {
  * was already ahead of it.** The imported rows are dropped and the new ones
  * take a consecutive block starting where the lowest of them sat; a request
  * whose examples were all user-saved gets the block after the last of them.
+ *
+ * **A deleted imported example is not written back** (issue #722). Deleting one
+ * leaves a tombstone rather than nothing, and the statuses those name are the
+ * one thing a refresh must not restore - otherwise any later sync of any field
+ * re-creates what the user removed, and the delete meant nothing.
  */
 struct ExampleRefresh {
     std::vector<std::string> replaced; ///< Imported row ids, to delete.
     int base_order = 0;                ///< Where the replacement block starts.
     size_t surviving = 0;              ///< User rows, which stay exactly as they are.
+    /**
+     * Statuses the user deleted, from this request's tombstones.
+     *
+     * The status is the identity, not the name: an imported example is the
+     * document's account of one response code, while its name carries the
+     * response *description* (`"404 - Not found"`) and moves whenever the
+     * document rewords it - so a name-keyed tombstone would resurrect the
+     * example on the first reworded description, which is the defect itself.
+     */
+    std::unordered_set<int> suppressed_statuses;
 };
 
-ExampleRefresh refresh_examples (const std::vector<vayu::db::RequestExample>& stored) {
+ExampleRefresh refresh_examples (const std::vector<vayu::db::RequestExample>& stored,
+const std::vector<vayu::db::RequestExample>& tombstones) {
     ExampleRefresh plan;
+    for (const auto& row : tombstones) {
+        plan.suppressed_statuses.insert (row.status);
+    }
     std::optional<int> lowest_import;
     int highest = -1;
     for (const auto& row : stored) {
@@ -609,11 +649,12 @@ spec_sync_response (vayu::db::Database& db, const nlohmann::json& body) {
             }
 
             if (item.contains ("examples") && !item["examples"].is_null ()) {
-                const auto plan = refresh_examples (db.get_request_examples (id));
+                const auto plan = refresh_examples (db.get_request_examples (id),
+                db.get_suppressed_request_examples (id));
                 batch.deleted_examples.insert (batch.deleted_examples.end (),
                 plan.replaced.begin (), plan.replaced.end ());
                 if (auto err = build_example_rows (item, id, id, plan.base_order, now,
-                    batch.examples, plan.surviving)) {
+                    batch.examples, plan.surviving, plan.suppressed_statuses)) {
                     result = *err;
                     return;
                 }
@@ -682,8 +723,8 @@ void register_spec_sync_routes (RouteContext& ctx) {
      * optional `parentId` inside the synced subtree), create (requests, each
      * with a `tempId` and either `collectionId` or `collectionTempId`, and
      * optional `examples`), update (requests by `id`, merge-patch, with
-     * optional `examples` which replace the imported ones and never the saved
-     * ones), delete (request ids).
+     * optional `examples` which replace the imported ones, never the saved
+     * ones, and never a status the user deleted), delete (request ids).
      * Returns: 200 `{idMap, specId, specHash, syncedAt, created, updated,
      * deleted}`; 400 (with `error.item`) for a payload this cannot apply, 404
      * for an unknown collection, 409 when a row the diff was computed against

--- a/engine/tests/examples_route_test.cpp
+++ b/engine/tests/examples_route_test.cpp
@@ -422,17 +422,56 @@ TEST_F (ExamplesRouteTest, UpdateRejectsMismatchedBodyId) {
 // Delete and the cascades
 // ---------------------------------------------------------------------------
 
-TEST_F (ExamplesRouteTest, DeleteRemovesTheRow) {
-    const std::string id = create_example ("req_1", json{ { "name", "x" } });
+TEST_F (ExamplesRouteTest, DeleteRemovesAUserSavedRowOutright) {
+    const std::string id =
+    create_example ("req_1", json{ { "name", "x" }, { "origin", "user" } });
 
     auto [status, body] = routes::delete_request_example_response (*db_, "req_1", id);
     ASSERT_EQ (status, 200);
     EXPECT_EQ (body["id"], id);
     EXPECT_FALSE (db_->get_request_example (id).has_value ());
+    // Nothing can re-create a saved response, so there is no intent to record
+    // and no tombstone to leave behind (issue #722).
+    EXPECT_TRUE (db_->get_suppressed_request_examples ("req_1").empty ());
 
     // A second delete is a 404 rather than a silent success.
     auto [again, _] = routes::delete_request_example_response (*db_, "req_1", id);
     EXPECT_EQ (again, 404);
+}
+
+// Issue #722. The row stays as a tombstone so a later spec sync knows not to
+// write the status back - and every read has to behave as though it were gone,
+// or a delete that "worked" would still be visible in the panel and served by a
+// mock. Mutation check: delete the origin branch in
+// `delete_request_example_response` and the tombstone assertion reddens; drop
+// the `suppressed` filter from either `Database` read and the first three do.
+TEST_F (ExamplesRouteTest, DeletingAnImportedExampleLeavesATombstoneNoReadCanSee) {
+    const std::string id = create_example ("req_1",
+    json{ { "name", "404 - Not found" }, { "status", 404 }, { "body", R"({"error":"gone"})" },
+    { "contentType", "application/json" } });
+
+    auto [status, body] = routes::delete_request_example_response (*db_, "req_1", id);
+    ASSERT_EQ (status, 200) << body.dump ();
+
+    auto [list_status, listed] = routes::list_request_examples_response (*db_, "req_1");
+    ASSERT_EQ (list_status, 200);
+    EXPECT_TRUE (listed.empty ());
+    EXPECT_FALSE (db_->get_request_example (id).has_value ());
+    EXPECT_EQ (db_->count_request_examples ("req_1"), 0);
+
+    // An update cannot bring it back by writing over the tombstone.
+    auto [update_status, _] =
+    routes::update_request_example_response (*db_, "req_1", id, json{ { "name", "back" } });
+    EXPECT_EQ (update_status, 404);
+
+    // What is kept is the status - the identity a sync matches on - and not the
+    // body, which no reader of a deleted example ever wants.
+    const auto tombstones = db_->get_suppressed_request_examples ("req_1");
+    ASSERT_EQ (tombstones.size (), 1u);
+    EXPECT_EQ (tombstones[0].id, id);
+    EXPECT_EQ (tombstones[0].status, 404);
+    EXPECT_TRUE (tombstones[0].body.empty ());
+    EXPECT_TRUE (tombstones[0].content_type.empty ());
 }
 
 // Without the cascade these rows survive their owner: every read is by request
@@ -442,9 +481,17 @@ TEST_F (ExamplesRouteTest, DeletingTheRequestDeletesItsExamples) {
     const std::string mine = create_example ("req_1", json{ { "name", "mine" } });
     const std::string theirs = create_example ("req_2", json{ { "name", "theirs" } });
 
+    // A tombstone is a row like any other, so the cascade has to take it too -
+    // otherwise a deleted imported example outlives the request it answered
+    // (issue #722).
+    const std::string tombstoned = create_example ("req_1", json{ { "name", "deleted" } });
+    routes::delete_request_example_response (*db_, "req_1", tombstoned);
+    ASSERT_EQ (db_->get_suppressed_request_examples ("req_1").size (), 1u);
+
     db_->delete_request ("req_1");
 
     EXPECT_FALSE (db_->get_request_example (mine).has_value ());
+    EXPECT_TRUE (db_->get_suppressed_request_examples ("req_1").empty ());
     // The sibling request's examples are untouched.
     EXPECT_TRUE (db_->get_request_example (theirs).has_value ());
 }

--- a/engine/tests/spec_sync_route_test.cpp
+++ b/engine/tests/spec_sync_route_test.cpp
@@ -15,6 +15,9 @@
  *    replaced and `origin="user"` rows are not, and the replacements never jump
  *    ahead of a user row that was already in front of them - "the first example"
  *    is what a mock server answers with, so the order is a contract.
+ *  - **So does deleting an imported one.** A refresh writes the document's
+ *    examples back for every status except one the user removed (issue #722) -
+ *    without that, any later sync of any field undid the delete.
  *  - **The binding moves with the rows.** After a sync the collection names the
  *    document that was just applied, or - if anything failed - the one it named
  *    before.
@@ -54,6 +57,11 @@ const std::string& id,
 const nlohmann::json& json);
 std::pair<int, nlohmann::json>
 create_request_response (vayu::db::Database& db, const nlohmann::json& json);
+// Defined in examples.cpp - the delete an imported example goes through, which
+// is what records the intent a refresh must respect (issue #722).
+std::pair<int, nlohmann::json> delete_request_example_response (vayu::db::Database& db,
+const std::string& request_id,
+const std::string& example_id);
 // Defined in runs.cpp - the reader that must not resolve coverage from the
 // collection's binding as it stands now.
 std::pair<int, nlohmann::json>
@@ -135,12 +143,15 @@ class SpecSyncRouteTest : public ::testing::Test {
     }
 
     /** One example row on @p request_id, written straight to the store. */
-    std::string seed_example (const std::string& request_id, const std::string& origin, int order) {
+    std::string seed_example (const std::string& request_id,
+    const std::string& origin,
+    int order,
+    int status = 200) {
         vayu::db::RequestExample x;
         x.id           = "exa_" + origin + "_" + std::to_string (order);
         x.request_id   = request_id;
         x.name         = origin + " " + std::to_string (order);
-        x.status       = 200;
+        x.status       = status;
         x.headers      = "[]";
         x.body         = "{}";
         x.content_type = "application/json";
@@ -423,6 +434,60 @@ TEST_F (SpecSyncRouteTest, AnAbsentExampleListLeavesEveryExampleAlone) {
     body (json{ { "update", json::array ({ json{ { "id", request }, { "name", "renamed" } } }) } }));
     ASSERT_EQ (status, 200) << response.dump ();
     EXPECT_EQ (db_->get_request_examples (request).size (), 1u);
+}
+
+// Issue #722. The refresh replaces every imported row of a request an apply
+// touches, so before this a rename-only sync re-created an example the user had
+// deleted - and the delete meant nothing. Deleting one leaves a tombstone and
+// the refresh skips that status. Mutation check: drop the
+// `suppressed_statuses` skip in `build_example_rows` and the deleted 404 comes
+// back, reddening both size assertions.
+TEST_F (SpecSyncRouteTest, ADeletedImportedExampleIsNotWrittenBackByALaterSync) {
+    const std::string request = create_request (root_);
+    seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 0, 200);
+    const std::string unwanted =
+    seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 1, 404);
+
+    auto [deleted, delete_body] =
+    routes::delete_request_example_response (*db_, request, unwanted);
+    ASSERT_EQ (deleted, 200) << delete_body.dump ();
+
+    // The payload a rename-only tick sends: every documented example, because
+    // the diff does not compare them (#654) and the app attaches the lot.
+    auto [status, response] = routes::spec_sync_response (*db_,
+    body (json{ { "update",
+        json::array ({ json{ { "id", request }, { "name", "renamed" },
+            { "examples",
+                json::array ({ json{ { "name", "200 - A user" }, { "status", 200 } },
+                    json{ { "name", "404 - Not found" }, { "status", 404 } } }) } } }) } }));
+    ASSERT_EQ (status, 200) << response.dump ();
+
+    auto rows = db_->get_request_examples (request);
+    ASSERT_EQ (rows.size (), 1u) << "the deleted 404 example came back";
+    EXPECT_EQ (rows[0].status, 200);
+    // The status the user kept still refreshes from the document - a tombstone
+    // suppresses its own status and nothing else.
+    EXPECT_EQ (rows[0].name, "200 - A user");
+    EXPECT_EQ (rows[0].order, 0);
+}
+
+// The identity a tombstone records is the *status*, not the name: an example's
+// name carries the document's response description, which a later revision may
+// reword - and a name-keyed tombstone would then miss, resurrecting exactly
+// what this fix makes durable (issue #722).
+TEST_F (SpecSyncRouteTest, ARewordedDescriptionDoesNotBringADeletedExampleBack) {
+    const std::string request = create_request (root_);
+    const std::string unwanted =
+    seed_example (request, vayu::core::constants::request_example::ORIGIN_IMPORT, 0, 404);
+    ASSERT_EQ (routes::delete_request_example_response (*db_, request, unwanted).first, 200);
+
+    auto [status, response] = routes::spec_sync_response (*db_,
+    body (json{ { "update",
+        json::array ({ json{ { "id", request },
+            { "examples", json::array ({ json{ { "name", "404 - No such user any more" },
+                { "status", 404 } } }) } } }) } }));
+    ASSERT_EQ (status, 200) << response.dump ();
+    EXPECT_TRUE (db_->get_request_examples (request).empty ());
 }
 
 TEST_F (SpecSyncRouteTest, RefusesAnExampleThatClaimsToBeTheUsers) {


### PR DESCRIPTION
## Description

**Root cause, approach, and the alternative rejected.** `POST /specs/sync` deletes every `origin="import"` example of a request it applies any change to and writes the document's in their place (`spec_sync.cpp`'s `refresh_examples`), while `spec-apply.ts` attaches `patch.examples` to *every* applied update - a rename-only tick included. A user-deleted imported example left no row and no record, so the next sync of any field re-created it; the delete was a suggestion. Verified against the current code before anything was touched: all three halves of the issue still hold exactly as written (the blanket replace, the unconditional `patch.examples`, and the panel's "nothing here can bring it back" comment beside a `RequestExample` type that omits `origin`).

The approach is the issue's second option, made durable at the row: deleting an imported example **tombstones** its row (`suppressed`) instead of removing it, and the refresh skips the response status a tombstone names. Every read filters tombstones out, so the list route, the mock server, an export and a `GET`/`PUT` on the id behave exactly as though the delete had removed it; one accessor (`get_suppressed_request_examples`) sees them, for the one caller that must. A `user` row is still removed outright - nothing re-creates a saved response, so there is no intent to record and a hidden row would be a leak with no reader.

**Rejected: the issue's first option, content-comparing the refresh.** It cannot make a delete durable - the re-fetched document still contains the deleted example, so the comparison finds a difference and replaces the block, restoring it. It only skips work when nothing changed at all.

**Rejected: a separate tombstone table.** Free of any risk of a suppressed row leaking into a reader, but it puts the cascade burden on four delete paths (request delete, collection delete, the sync's own delete, the bulk replace); the row-level flag inherits all four for free, and the reads it does touch are five call sites behind two `Database` accessors - the smaller surface. A test asserts the cascade takes tombstones with it.

**The identity a tombstone records is the status, not the name.** An imported example is the document's account of one response code (`buildExamples` walks `responses` by code), while its name is `"<code> - <description>"` and moves whenever the document rewords the description - so a name-keyed tombstone would resurrect the example on the first reworded description, which is the defect itself. Pinned by its own test.

**App changes** (the issue's surface half): `RequestExample` now claims `origin` and the panel reads it - an **Imported** chip on the rows a sync owns, and delete-confirm copy that differs by origin, since re-importing the document is the one thing that brings an imported row back. The chip is the muted text-only `variant="chip"` the settings cards use for the same kind of fact, not the amber of the "Partial body" chip beside it: where a row came from is not something to watch out for.

### Deliberate deviations from the issue spec

- **The chip reads "Imported", not "from spec".** `origin="import"` covers a Postman import as well as a spec sync, and "from spec" would be false on those rows. "Imported" is true for every row that carries it.
- **The delete-confirm copy is per-origin but does not claim less for an imported row.** With the tombstone the promise holds for both kinds, so the sentence that differs is what could still bring the row back ("Syncing this collection with its spec will not bring it back; re-importing the document will" vs "Nothing here can bring it back") rather than a weaker promise.
- **The per-request example cap now counts what will be written** rather than what the payload offered, so a sync whose only excess is a tombstoned example is no longer refused.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All green locally on this branch.

- `python build.py -e -t` - clean.
- `ctest --preset linux-dev --output-on-failure` - **2045 tests, 100% passed** (2041 before; +3 engine tests, one renamed).
- `pnpm test` - **5661 tests in 519 files, all passed** (+3 app tests).
- `pnpm type-check`, `pnpm lint`, `pnpm exec prettier --check` on the touched files - clean.

Mutation-checked, each reverted and re-run:

| Mutation | Reddens |
|---|---|
| drop the `suppressed_statuses` skip in `build_example_rows` | `ADeletedImportedExampleIsNotWrittenBackByALaterSync`, `ARewordedDescriptionDoesNotBringADeletedExampleBack` |
| delete the origin branch in `delete_request_example_response` | `DeletingAnImportedExampleLeavesATombstoneNoReadCanSee` |
| flip the panel's origin conditions to `"user"` | all three new app tests |

New tests: the sync one drives the delete through the real route (`delete_request_example_response`) rather than seeding a suppressed row, so what records the intent is exercised, not assumed; the route test asserts the tombstone is invisible to the list, to a lookup by id, to `count_request_examples` and to a `PUT`, and that its body was cleared.

Two notes, neither a change to this branch:

- `mkdocs build --strict` could not run here - mkdocs is not installed in this environment. The docs edits add no new links, headings or nav entries (prose inside existing sections plus one table row), so the failure modes that gate catches are not reachable from this diff; CI's docs job covers it.
- `vcpkg-fix-port` was needed for the cold-cache 403 the repo's `engine/CLAUDE.md` documents. It rewrites ports in the local vcpkg overlay, outside the repo - nothing in this diff.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit: `docs/app/openapi.md` (the examples/origin section - the durable delete and the chip), `docs/app/api-integration.md` (which said `origin` was write-only and that `RequestExample` does not claim it - now false), `docs/engine/api-reference.md` (the DELETE route's semantics and the sync's `examples` rule), `docs/engine/db-schema.md` (the `suppressed` column, and that the cascade takes tombstones), `engine/CLAUDE.md`, plus the `ExamplesPanel.tsx` comment the issue names.

## Related Issues
Closes #722

---
_Generated by [Claude Code](https://claude.ai/code/session_0138DbL4b8bS9md3sdvo8fux)_