### PR TITLE
feat(app/descriptions): render the HTML subset, sanitized in the same pipeline (#711)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -65,6 +65,8 @@
 		"react-dom": "^19.2.7",
 		"react-markdown": "^10.1.0",
 		"react-resizable-panels": "^4.11.2",
+		"rehype-raw": "^7.0.0",
+		"rehype-sanitize": "^6.0.0",
 		"remark-gfm": "^4.0.1",
 		"tailwind-merge": "^3.6.0",
 		"tw-animate-css": "^1.4.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -110,6 +110,12 @@ importers:
       react-resizable-panels:
         specifier: ^4.11.2
         version: 4.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2408,6 +2414,10 @@ packages:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -2778,11 +2788,29 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2804,6 +2832,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -3447,6 +3478,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -3651,6 +3685,12 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -4116,6 +4156,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -4217,6 +4260,9 @@ packages:
     resolution: {integrity: sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
@@ -6586,6 +6632,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@6.0.1: {}
+
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
@@ -7038,6 +7086,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.3
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@ungap/structured-clone': 1.3.3
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -7058,9 +7143,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
 
   hermes-estree@0.25.1: {}
 
@@ -7081,6 +7184,8 @@ snapshots:
       - '@noble/hashes'
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -7872,6 +7977,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -8077,6 +8186,17 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:
@@ -8569,6 +8689,11 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -8636,6 +8761,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  web-namespaces@2.0.1: {}
 
   webcrypto-core@1.9.2:
     dependencies:

--- a/app/src/components/ui/markdown-view.test.tsx
+++ b/app/src/components/ui/markdown-view.test.tsx
@@ -114,25 +114,172 @@ describe("links cannot navigate this window", () => {
 	});
 });
 
-describe("raw HTML in the source is not markup", () => {
-	it("does not execute an img onerror payload", () => {
-		// `rehype-raw` is deliberately not installed, so this is inert text.
+/**
+ * Raw HTML is rendered now, and these are the two halves of that trade.
+ *
+ * Stripe's official OpenAPI document writes every operation description as
+ * HTML, so the tags used to sit on screen as literal text. `rehype-raw` parses
+ * them and `rehype-sanitize` prunes the result immediately - and it is the
+ * hostile block below, not a comment, that holds the plugins in that order:
+ * sanitising before the raw HTML is parsed leaves every payload here intact.
+ */
+describe("the benign HTML subset renders", () => {
+	it("renders a paragraph, emphasis and code from raw HTML", () => {
+		const { container } = render(
+			<MarkdownView>
+				{"<p>Retrieves the <strong>account</strong>, <em>maybe</em> <code>id</code>.</p>"}
+			</MarkdownView>
+		);
+		expect(container.querySelector("p")).toBeTruthy();
+		expect(container.querySelector("strong")?.textContent).toBe("account");
+		expect(container.querySelector("em")?.textContent).toBe("maybe");
+		expect(container.querySelector("code")?.textContent).toBe("id");
+		// The defect itself: the markup used to be the text.
+		expect(container.textContent).not.toContain("<strong>");
+	});
+
+	it("renders b and i, which HTML descriptions use where markdown would not", () => {
+		const { container } = render(
+			<MarkdownView>{"<b>bold</b> and <i>italic</i>"}</MarkdownView>
+		);
+		expect(container.querySelector("b")?.textContent).toBe("bold");
+		expect(container.querySelector("i")?.textContent).toBe("italic");
+	});
+
+	it("renders an HTML list and an HTML table", () => {
+		const { container } = render(
+			<MarkdownView>
+				{
+					"<ul><li>one</li><li>two</li></ul><table><tbody><tr><td>a</td></tr></tbody></table>"
+				}
+			</MarkdownView>
+		);
+		expect(container.querySelectorAll("li")).toHaveLength(2);
+		expect(container.querySelector("table")).toBeTruthy();
+		expect(container.querySelector("td")?.textContent).toBe("a");
+	});
+
+	it("renders an HTML anchor as the same non-navigating button a markdown link gets", () => {
+		const { container } = render(
+			<MarkdownView>
+				{'<a href="https://example.test/x" target="_blank" rel="noreferrer">docs</a>'}
+			</MarkdownView>
+		);
+		expect(container.querySelector("a")).toBeNull();
+		expect(container.querySelector("[href]")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "docs" }));
+		expect(openExternalUrl).toHaveBeenCalledWith("https://example.test/x");
+	});
+
+	it("paints code inside a pre as a block rather than as an inline pill", () => {
+		// The `language-*` class this used to be decided from does not survive the
+		// sanitiser, so the rule moved into the container. Read the class, not the
+		// layout: jsdom has none.
+		const { container } = render(<MarkdownView>{"```\nx = 1\n```"}</MarkdownView>);
+		expect(container.querySelector("pre code")).toBeTruthy();
+		expect(container.firstElementChild?.className).toContain("[&_pre_code]:bg-transparent");
+	});
+});
+
+describe("hostile HTML stays inert", () => {
+	it("drops a script tag and its contents, rather than unwrapping the source onto the screen", () => {
+		const { container } = render(
+			<MarkdownView>{"<script>alert(1)</script>after"}</MarkdownView>
+		);
+		expect(container.querySelector("script")).toBeNull();
+		// Unwrapping instead of stripping would leave `alert(1)` as visible prose.
+		expect(container.textContent).not.toContain("alert(1)");
+		expect(container.textContent).toContain("after");
+	});
+
+	it("drops a style tag and its contents", () => {
+		const { container } = render(
+			<MarkdownView>{"<style>body{display:none}</style>text"}</MarkdownView>
+		);
+		expect(container.querySelector("style")).toBeNull();
+		expect(container.textContent).not.toContain("display:none");
+	});
+
+	it("does not render an img, so an onerror payload has nothing to fire on", () => {
 		const { container } = render(
 			<MarkdownView>{'<img src=x onerror="alert(1)">'}</MarkdownView>
 		);
 		expect(container.querySelector("img")).toBeNull();
 	});
 
-	it("does not turn a raw anchor into a link", () => {
+	it("does not render an iframe", () => {
 		const { container } = render(
-			<MarkdownView>{'<a href="https://evil.test">click</a>'}</MarkdownView>
+			<MarkdownView>{'<iframe src="https://evil.test"></iframe>'}</MarkdownView>
 		);
-		expect(container.querySelector("a")).toBeNull();
-		expect(container.querySelector("[href]")).toBeNull();
+		expect(container.querySelector("iframe")).toBeNull();
 	});
 
-	it("does not render a script tag", () => {
-		const { container } = render(<MarkdownView>{"<script>alert(1)</script>"}</MarkdownView>);
-		expect(container.querySelector("script")).toBeNull();
+	it("keeps a javascript: URL out of the DOM and out of openExternalUrl", () => {
+		const { container } = render(
+			<MarkdownView>{'<a href="javascript:alert(1)">click</a>'}</MarkdownView>
+		);
+		expect(container.querySelector("[href]")).toBeNull();
+		const link = screen.queryByRole("button", { name: "click" });
+		if (link) fireEvent.click(link);
+		expect(openExternalUrl).not.toHaveBeenCalled();
+	});
+
+	it("does not offer a link whose scheme this window could never act on", () => {
+		// `defaultSchema` passes `mailto`, `irc`, `ircs` and `xmpp` on an href; the
+		// schema here passes http(s) only, because the click goes to
+		// `openExternalUrl` and the main process refuses everything else. Keeping
+		// the href would put a destination in the tooltip and then do nothing with
+		// it - a button that lies about being clickable.
+		render(<MarkdownView>{'<a href="mailto:x@y.test">mail</a>'}</MarkdownView>);
+		const button = screen.getByRole("button", { name: "mail" });
+		expect(button).not.toHaveAttribute("title");
+		fireEvent.click(button);
+		expect(openExternalUrl).not.toHaveBeenCalled();
+	});
+
+	it("strips inline style and on* handlers from an element it does render", () => {
+		const { container } = render(
+			<MarkdownView>
+				{'<p style="position:fixed" onclick="alert(1)" onmouseover="alert(2)">hi</p>'}
+			</MarkdownView>
+		);
+		const p = container.querySelector("p");
+		expect(p?.textContent).toBe("hi");
+		expect(p?.getAttribute("style")).toBeNull();
+		expect(p?.getAttribute("onclick")).toBeNull();
+		expect(p?.getAttribute("onmouseover")).toBeNull();
+	});
+
+	it("strips class, so a description cannot paint a sheet over the window", () => {
+		// The cheapest attack on a renderer that keeps `class` is not a script:
+		// this app's own utilities are enough to cover the UI with an invisible
+		// overlay. Nothing a description carries may name them.
+		const { container } = render(
+			<MarkdownView>{'<p class="fixed inset-0 z-50 bg-black">hi</p>'}</MarkdownView>
+		);
+		const p = container.querySelector("p");
+		expect(p?.textContent).toBe("hi");
+		expect(p?.getAttribute("class")).toBeNull();
+	});
+
+	it("keeps no attribute the sanitiser's own default schema would have allowed", () => {
+		// The schema here is narrower than `defaultSchema`, whose `*` list passes
+		// `title`, `id`, `dir`, `align` and thirty more on every element. Nothing
+		// below reads any of them, so nothing keeps them - and deleting the
+		// narrowing, falling back to those defaults, is what this reddens on.
+		const { container } = render(
+			<MarkdownView>{'<p id="x" title="t" dir="rtl">hi</p>'}</MarkdownView>
+		);
+		const p = container.querySelector("p");
+		expect(p?.textContent).toBe("hi");
+		expect(p?.getAttributeNames()).toEqual([]);
+	});
+
+	it("renders malformed markup as text without crashing", () => {
+		const { container } = render(
+			<MarkdownView>{"<p><strong>unclosed <div><span>x</p>"}</MarkdownView>
+		);
+		expect(container.textContent).toContain("unclosed");
+		expect(container.textContent).toContain("x");
 	});
 });

--- a/app/src/components/ui/markdown-view.tsx
+++ b/app/src/components/ui/markdown-view.tsx
@@ -11,7 +11,7 @@
  * **The content here is not all hand-typed.** Descriptions arrive from imported
  * Postman, Insomnia and OpenAPI files - third-party documents off the internet -
  * and until now Vayu stored that markdown and displayed none of it, which is the
- * only reason it never mattered. Rendering it changes that, so three decisions
+ * only reason it never mattered. Rendering it changes that, so four decisions
  * are load-bearing rather than stylistic:
  *
  * **1. No navigating anchors, ever.** `electron/main.ts` sets
@@ -22,14 +22,34 @@
  * new origin, handing `window.electronAPI` to it. So the `a` renderer below
  * emits a `<button>`: no `href` reaches the DOM, and the click goes to the
  * scheme-validated `openExternalUrl` path, which refuses anything that is not
- * http(s).
+ * http(s). That is a single layer by design, and stays one until #822 puts a
+ * `will-navigate` refusal underneath it.
  *
  * **2. `react-markdown`, not `marked`.** It builds React elements from an AST
  * rather than an HTML string, so there is no `dangerouslySetInnerHTML` and no
- * sanitizer for anyone to forget. Raw HTML in the source is ignored - that needs
- * `rehype-raw`, which is deliberately not installed.
+ * sanitizer for anyone to forget.
  *
- * **3. The default `urlTransform` stays.** Overriding it disables
+ * **3. Raw HTML is rendered, and it is sanitized in the same pipeline.** This
+ * decision changed, and the reason is worth keeping. `rehype-raw` used to be
+ * deliberately absent, which made raw HTML inert - correct while nothing shipped
+ * HTML descriptions. Stripe's official OpenAPI document writes *every* operation
+ * description as HTML (`<p>Retrieves the details of an account.</p>`), which is
+ * spec-legal - OpenAPI `description` fields are CommonMark, and CommonMark
+ * admits inline HTML - so the tags were on screen as literal text. `rehype-raw`
+ * now parses them and **`rehype-sanitize` immediately prunes the result**
+ * against the allow-list below.
+ *
+ * That order is load-bearing, not stylistic: sanitizing before the raw HTML is
+ * parsed sanitizes a tree the payload is not in yet, and every hostile case
+ * below would render. The hostile tests in `markdown-view.test.tsx` are what
+ * hold the order - swap the two plugins and they go red.
+ *
+ * Sanitizing prunes hast *nodes*; react-markdown still emits React elements
+ * from the pruned tree, so decision 2's real property - no HTML string, no
+ * `dangerouslySetInnerHTML` - is unchanged. `allowedElements` below is a second
+ * gate over the same list, applied after the plugins.
+ *
+ * **4. The default `urlTransform` stays.** Overriding it disables
  * react-markdown's own URL sanitising, which has a published advisory against
  * exactly that mistake. `remark-gfm` is on for tables (imported Postman
  * descriptions use them), and it also turns bare URLs into autolinks - the `a`
@@ -39,20 +59,29 @@
 import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { type Options as SanitizeSchema } from "rehype-sanitize";
 import { cn } from "@/lib/utils";
 
 /**
- * Block-level elements a description has any business containing.
+ * Elements a description has any business containing.
  *
  * An allow-list rather than a deny-list: a deny-list has to be updated every
  * time the markdown spec or a plugin grows a node type, and the failure mode of
  * forgetting is that the new one renders.
+ *
+ * `b` and `i` earn their place now that raw HTML is parsed: they are what a
+ * hand-written or generator-emitted description uses where markdown would have
+ * produced the `strong` and `em` already here, and dropping them would unwrap
+ * emphasis a vendor did write.
  */
 const ALLOWED = [
 	"p",
 	"br",
 	"strong",
+	"b",
 	"em",
+	"i",
 	"del",
 	"code",
 	"pre",
@@ -75,6 +104,41 @@ const ALLOWED = [
 	"th",
 	"td",
 ];
+
+/**
+ * What survives sanitisation. Derived from `ALLOWED` rather than re-typed, so
+ * the two gates cannot drift into disagreeing about the same question.
+ *
+ * `href` on an anchor is the only attribute anything below reads, so it is the
+ * only one kept. **`class` in particular is never kept**: a description off the
+ * internet has no business naming this app's stylesheet, and the cheapest
+ * attack on a renderer that keeps it is not a script but
+ * `<p class="fixed inset-0 z-50">` - an invisible sheet over the whole window.
+ *
+ * `protocols` is narrower than the default (which also passes `irc`, `ircs`,
+ * `mailto` and `xmpp`) because a link here can do exactly one thing: go to
+ * `openExternalUrl`, which refuses any scheme but http(s). An `href` that
+ * survives sanitisation only to be refused at the other end is a button that
+ * lies about being clickable.
+ *
+ * Every key left unspecified falls back to `defaultSchema` - `hast-util-sanitize`
+ * merges shallowly (`{...defaultSchema, ...options}`) - so GitHub's clobber
+ * prefix and the required-ancestor map for table parts stay in force instead of
+ * being restated here and drifting.
+ */
+const SANITIZE_SCHEMA: SanitizeSchema = {
+	tagNames: ALLOWED,
+	attributes: { a: ["href"] },
+	protocols: { href: ["http", "https"] },
+	/*
+	 * An element outside `tagNames` is *unwrapped* by default: it goes, its
+	 * children stay. That is right for prose in a `<div>` or a `<span>` and
+	 * wrong where the content is not prose - an unwrapped `<style>` puts its CSS
+	 * on screen as words. The default schema strips `script` for that reason;
+	 * `style` needs saying.
+	 */
+	strip: ["script", "style"],
+};
 
 export interface MarkdownViewProps {
 	children: string;
@@ -124,22 +188,17 @@ export function MarkdownView({ children, className }: MarkdownViewProps) {
 			h4: Heading,
 			h5: Heading,
 			h6: Heading,
-			code: ({
-				children: c,
-				className: cls,
-			}: {
-				children?: React.ReactNode;
-				className?: string;
-			}) => {
-				// react-markdown gives fenced blocks a `language-*` class and inline
-				// code none, which is the only way to tell them apart here.
-				const isBlock = !!cls?.startsWith("language-");
-				return isBlock ? (
-					<code className="font-mono text-xs">{c}</code>
-				) : (
-					<code className="rounded-md bg-muted px-1 py-0.5 font-mono text-xs">{c}</code>
-				);
-			},
+			/*
+			 * Inline code, and only inline code. A fenced block used to be told apart
+			 * by the `language-*` class react-markdown puts on it - which no longer
+			 * survives sanitisation, and never existed on a raw `<pre><code>` a vendor
+			 * pasted in, so that one was already painted as a pill inside its own box.
+			 * Position answers it for both: this paints the pill, and the container
+			 * below flattens it back out for any `code` sitting inside a `pre`.
+			 */
+			code: ({ children: c }: { children?: React.ReactNode }) => (
+				<code className="rounded-md bg-muted px-1 py-0.5 font-mono text-xs">{c}</code>
+			),
 			pre: ({ children: c }: { children?: React.ReactNode }) => (
 				<pre className="overflow-x-auto rounded-md bg-muted p-2.5 text-xs">{c}</pre>
 			),
@@ -169,11 +228,19 @@ export function MarkdownView({ children, className }: MarkdownViewProps) {
 				"[&_ul]:list-disc [&_ol]:list-decimal [&_ul]:pl-5 [&_ol]:pl-5",
 				"[&_blockquote]:border-l-2 [&_blockquote]:border-primary/45 [&_blockquote]:pl-2.5 [&_blockquote]:text-muted-foreground",
 				"[&_hr]:my-3 [&_hr]:border-rule",
+				// Code inside a `pre` is a block, and the `pre` already paints the box
+				// - so the pill the `code` renderer applies is flattened here rather
+				// than decided from a class the sanitiser strips.
+				"[&_pre_code]:rounded-none [&_pre_code]:bg-transparent [&_pre_code]:p-0",
 				className
 			)}
 		>
 			<ReactMarkdown
 				remarkPlugins={[remarkGfm]}
+				// Raw first, sanitise immediately after. Reversing these two sanitises
+				// a tree the raw HTML has not been parsed into yet, which is the one
+				// way to have both plugins installed and no protection at all.
+				rehypePlugins={[rehypeRaw, [rehypeSanitize, SANITIZE_SCHEMA]]}
 				allowedElements={ALLOWED}
 				unwrapDisallowed
 				// `components` is what replaces anchors with non-navigating buttons.

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1448,7 +1448,7 @@ click-to-edit field used by the request **Info** tab and by
 before this existed - the collection one even advertised "Markdown supported"
 beside a plain textarea.
 
-**Two rules are load-bearing, not stylistic:**
+**Three rules are load-bearing, not stylistic:**
 
 1. **`MarkdownView` never emits a navigating anchor.** The main window has no
    `will-navigate` handler, no `setWindowOpenHandler` and no CSP, and the
@@ -1458,11 +1458,25 @@ beside a plain textarea.
    Links therefore render as `<button>`, with no `href` in the DOM, and open via
    the scheme-validated `openExternalUrl` IPC. `remark-gfm` autolinks bare URLs,
    so that override covers those too. Guarded by `markdown-view.test.tsx`.
+   This is a single layer by design; #822 tracks the `will-navigate` refusal
+   that would sit under it.
 2. **`react-markdown` with the default `urlTransform`.** It builds React
    elements from an AST, so there is no `dangerouslySetInnerHTML` and no
-   sanitiser to forget. Raw HTML is inert because `rehype-raw` is deliberately
-   not installed. Overriding `urlTransform` disables the built-in URL sanitising
-   (there is a published advisory for exactly that), so it stays on the default.
+   sanitiser to forget. Overriding `urlTransform` disables the built-in URL
+   sanitising (there is a published advisory for exactly that), so it stays on
+   the default.
+3. **Raw HTML renders, and `rehype-sanitize` runs immediately after
+   `rehype-raw`.** `rehype-raw` used to be deliberately absent, which made raw
+   HTML inert - fine until Stripe's official OpenAPI document turned out to
+   write every operation description as HTML (`<p>Retrieves…</p>`), which is
+   spec-legal and was on screen as literal text. The order is the rule: sanitise
+   before the raw HTML is parsed and it sanitises a tree the payload is not in
+   yet. The schema is derived from the component's own element allow-list, keeps
+   `href` on an anchor and **no other attribute** (`class` least of all - the
+   cheap attack is `<p class="fixed inset-0 z-50">`, not a script), passes
+   http(s) only, and strips `script` and `style` whole rather than unwrapping
+   their text onto the screen. Guarded by the benign and hostile blocks in
+   `markdown-view.test.tsx`, which are also what pin the plugin order.
 
 `MarkdownEditor`'s rule is **focus, not dirtiness**: rendered while unfocused,
 source the moment you click in. The caret goes to the end - mapping a rendered


### PR DESCRIPTION
## Description

**Plan.** The root cause is a stance that was correct until a fact changed:
`rehype-raw` was deliberately not installed, so raw HTML in a description was
inert - fine while nothing rendered descriptions at all, wrong once Stripe's
official OpenAPI document turned out to write **every** operation description as
HTML (`<p>Retrieves the details of an account.</p>`), which is spec-legal
(OpenAPI `description` is CommonMark; CommonMark admits inline HTML). Verified
against the current code before touching anything: `markdown-view.tsx:8-37` still
carried the "deliberately not installed" note, and the three tests asserting
inertness were still green.

The approach is the issue's: `rehype-raw` parses raw HTML and **`rehype-sanitize`
prunes the result immediately**, against a schema derived from the component's
own `ALLOWED` list rather than a second copy of it. The order is the security
property, not a style: sanitising before the raw HTML is parsed sanitises a tree
the payload is not in yet. **Alternative rejected:** converting HTML to markdown
at import time (turndown-style). It would not fix already-imported collections,
would need repeating in every importer, and rewrites third-party documents Vayu
otherwise stores verbatim.

### What the schema keeps, and why each line is there

- **`href` on an anchor, and nothing else, anywhere.** `class` least of all: the
  cheap attack on a renderer that keeps it is not a script but
  `<p class="fixed inset-0 z-50">` - this app's own utilities, an invisible sheet
  over the window.
- **http(s) only** (the default also passes `mailto`, `irc`, `ircs`, `xmpp`). A
  link here can do exactly one thing - go to `openExternalUrl`, which refuses
  every other scheme - so an `href` that survives only to be refused at the far
  end is a button that lies about being clickable.
- **`script` and `style` stripped whole.** An element outside `tagNames` is
  *unwrapped* by default: it goes, its children stay. Right for prose in a
  `<div>`, wrong where the content is not prose - an unwrapped `<style>` puts its
  CSS on screen as words. The default schema strips `script`; `style` needed
  saying.
- **Everything else falls back to `defaultSchema`**, which is how
  `hast-util-sanitize` merges (`{...defaultSchema, ...options}`), so GitHub's
  clobber prefix and the required-ancestor map for table parts stay in force
  instead of being restated here and drifting.

The three existing defenses are carried forward unchanged and still asserted:
anchors render as `<button>` with no `href` in the DOM and open through the
scheme-validated `openExternalUrl`; nothing emits an HTML string, so there is
still no `dangerouslySetInnerHTML` (sanitising prunes hast nodes, react-markdown
still builds React elements); the default `urlTransform` stays.

### Deliberate deviations from the issue spec

- **`b` and `i` join the allow-list.** The issue's own benign list names
  `<strong>`/`<b>`, and neither `b` nor `i` was in `ALLOWED` - they are what an
  HTML description writes where markdown produced the `strong` and `em` already
  there, so leaving them out would unwrap emphasis a vendor did write.
- **The block-vs-inline code rule moved from a class to a position.** This is
  forced by "`class` never": the `code` renderer told a fenced block apart by the
  `language-*` class react-markdown puts on it, and that class no longer
  survives. The container now flattens the inline pill for any `code` inside a
  `pre`. This also fixes a case that was already wrong - a raw `<pre><code>`
  never carried the class, so it was painted as a pill inside its own box.
- **The `will-navigate` rider is filed, not folded in.** The issue offers it as
  "in scope if small, its own issue if not". It is not small: `main.ts` registers
  everything at import time, so the repo's own precedent
  (`quit-signals.ts`, `oauth-window.ts`) means an extracted module, a fake-driven
  test and a source scan for the wiring - plus a deliberate answer about which
  navigations are the app's own, because a refusal that catches Vite's reload
  breaks the dev loop. Filed as **#822** with that reasoning; the component and
  `COMPONENTS.md` now point at it. Nothing in this PR depends on it: the anchor
  defense is unchanged and the sanitiser does not rely on the window.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only diff (TypeScript, one docs page, two dependencies); no engine file is
touched, so per `CLAUDE.md`'s "scale the verification to what the change could
actually break" the engine build and ctest were not run - no C++ test could
change colour. Everything the change can reach, on `2c0715d`:

- `pnpm test` - **5670 tests in 519 files, 100% passed** (5658 on the base
  commit; the twelve new ones are the delta)
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean (only the two
  markdown-view files were formatted; both were prettier-clean before)
- `mkdocs build --strict` could not run here - mkdocs is not installed in this
  environment. The docs edit adds no link, heading or nav entry (prose inside an
  existing section), so the failure modes that gate catches are not reachable
  from this diff; CI's docs job covers it.

New coverage replaces the three "raw HTML is not markup" tests, which inverted
into a benign block and a hostile one. Every knob in the schema is
mutation-checked - applied the mutation, confirmed red, restored:

| Mutation | Reddens |
|---|---|
| `rehype-sanitize` dropped from the chain | **4** hostile tests |
| plugins swapped (sanitise before raw) | **8** tests - this is what pins the order |
| `strip: ["script", "style"]` dropped | the style test (its CSS becomes prose) |
| `attributes: { a: ["href"] }` dropped (falls back to `defaultSchema`) | the attribute test |
| `protocols: { href: ["http", "https"] }` dropped | the `mailto:` test |
| `b` / `i` removed from `ALLOWED` | the b/i test |
| the `[&_pre_code]` flattening class removed | the block-code test |

Benign (5): a paragraph with `strong` / `em` / `code`; `b` and `i`; an HTML list
and table; an HTML anchor becoming the same non-navigating button a markdown link
gets, click included; block code inside a `pre`.

Hostile (7): `<script>` and `<style>` dropped **with their contents** (asserted
as text absent, not just the element); no `img` and so nothing for `onerror` to
fire on; no `iframe`; a `javascript:` href reaching neither the DOM nor
`openExternalUrl`; inline `style` and two `on*` handlers stripped from an element
that *does* render; `class` stripped, written as the overlay attack; malformed
markup rendering as text without crashing.

Two notes on how these are written. The attribute and protocol tests are
deliberately aimed at what **`defaultSchema` would have allowed** (`title`, `id`,
`dir` via its `*` list; `mailto` via its protocols) - an earlier draft asserted a
stripped `language-js` class and passed under the mutation too, because the
`code` renderer ignores incoming class names either way, so it proved nothing.
And the plugin order needs no source-scan guard: reversing the two plugins
reddens eight behavioural tests, which is a stronger statement than a grep.

No pre-existing failures observed on the base commit.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation - `docs/app/COMPONENTS.md` (the Markdown
      rules: rule 2 said raw HTML is inert because `rehype-raw` is deliberately
      not installed, which is now false; the new rule 3 states the order, the
      schema and what guards them), plus the component header, which is the
      reference future sessions are told to trust

## Related Issues

Closes #711

Filed from this work rather than folded in: **#822** - the main window still has
no `will-navigate` refusal or `setWindowOpenHandler`, which makes the anchor
defense single-layer.

---
_Generated by [Claude Code](https://claude.ai/code/session_014NsyKbHyMUa5BtjfrKavHK)_