### PR TITLE
fix(app/electron): refuse a navigation off the app, and deny window.open (#822)

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -7,7 +7,7 @@
 
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme, Menu, shell } from "electron";
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { EngineSidecar } from "./sidecar.js";
 import { resolveAppPaths } from "./app-paths.js";
 import { readDataFile } from "./data-file.js";
@@ -16,6 +16,7 @@ import { setupOAuthIpcHandlers } from "./oauth.js";
 import { loadWindowState, trackWindowState } from "./window-state.js";
 import { initAutoUpdater, checkForUpdatesNow, disposeAutoUpdater } from "./updater.js";
 import { installQuitOnSignal } from "./quit-signals.js";
+import { installWindowNavigationGuard } from "./window-navigation.js";
 import { createSaveFlusher } from "./save-flush.js";
 import { createRendererRecovery } from "./renderer-recovery.js";
 import { createQuitShutdown } from "./quit-shutdown.js";
@@ -263,11 +264,21 @@ function createWindow() {
 		mainWindow?.show();
 	});
 
+	// The preload re-runs on whatever this window navigates to, so a navigation
+	// off the app hands `window.electronAPI` to that origin. Installed before the
+	// load, so no navigation can land ahead of the guard. See
+	// window-navigation.ts.
+	const rendererEntry = path.join(__dirname, "../dist/index.html");
+	installWindowNavigationGuard(
+		mainWindow.webContents,
+		isDev ? DEV_SERVER_URL : pathToFileURL(rendererEntry).toString()
+	);
+
 	if (isDev) {
 		mainWindow.loadURL(DEV_SERVER_URL);
 		// mainWindow.webContents.openDevTools();
 	} else {
-		mainWindow.loadFile(path.join(__dirname, "../dist/index.html"));
+		mainWindow.loadFile(rendererEntry);
 	}
 
 	mainWindow.on("page-title-updated", (event) => {

--- a/app/electron/window-navigation.test.ts
+++ b/app/electron/window-navigation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * What is at stake here is the preload, not tidiness: it re-runs on whatever the
+ * main window navigates to, so a navigation off the app hands
+ * `window.electronAPI` - the engine, the filesystem readers, the OAuth surface -
+ * to a third-party origin. Before this guard the only thing in front of that was
+ * one component rendering links as buttons.
+ *
+ * So the assertions worth holding are the two directions of the predicate. A
+ * guard that refuses everything closes the hole and breaks the app; a guard that
+ * refuses nothing passes any test that only ever checks the happy path. Both
+ * builds are therefore asserted from both sides, and the dev server's own reload
+ * path is stated as a case rather than assumed.
+ *
+ * These drive a fake `webContents` rather than Electron, which is the whole
+ * reason the module lives outside main.ts.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+	installWindowNavigationGuard,
+	isAppOwnUrl,
+	type NavigableContents,
+} from "./window-navigation.js";
+
+// main.ts creates windows and starts the engine at import time, so the wiring
+// itself can only be read. Everything above this line would still pass with the
+// guard never installed, which is the whole of the bug being fixed.
+const mainSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "main.ts"), "utf8");
+
+const DEV_URL = "http://localhost:5173";
+const PROD_URL = "file:///opt/Vayu/resources/app.asar/dist/index.html";
+
+/** A WebContents that never existed: records the listener so a test can fire it. */
+function fakeContents() {
+	let navigate: ((event: { preventDefault(): void }, url: string) => void) | undefined;
+	const openHandler = vi.fn();
+
+	const contents: NavigableContents = {
+		on(_event, listener) {
+			navigate = listener;
+			return this;
+		},
+		setWindowOpenHandler(handler) {
+			openHandler.mockImplementation(handler);
+			return this;
+		},
+	};
+
+	return {
+		contents,
+		openHandler,
+		/** Attempt a navigation. Returns whether the window refused it. */
+		attempt(url: string): boolean {
+			const preventDefault = vi.fn();
+			navigate?.({ preventDefault }, url);
+			return preventDefault.mock.calls.length > 0;
+		},
+	};
+}
+
+/** Whether the installed guard lets `url` through. */
+function allows(appUrl: string, url: string): boolean {
+	const w = fakeContents();
+	installWindowNavigationGuard(w.contents, appUrl);
+	return !w.attempt(url);
+}
+
+describe("a production window goes nowhere but its own document", () => {
+	it("refuses an external https target", () => {
+		expect(allows(PROD_URL, "https://evil.example.com/")).toBe(false);
+	});
+
+	it("allows the entry document it was loaded with, so an in-page reload works", () => {
+		expect(allows(PROD_URL, PROD_URL)).toBe(true);
+	});
+
+	it("allows a hash route on that document", () => {
+		// Hash navigation is same-document; refusing it would break routing.
+		expect(allows(PROD_URL, `${PROD_URL}#/collections/1`)).toBe(true);
+	});
+
+	it("refuses another local file, which sharing a scheme is not permission for", () => {
+		// The reason the production branch cannot compare origins: every file:
+		// URL has the opaque origin "null", so an origin test passes this.
+		expect(new URL(PROD_URL).origin).toBe(new URL("file:///etc/passwd").origin);
+		expect(allows(PROD_URL, "file:///etc/passwd")).toBe(false);
+	});
+});
+
+describe("a development window keeps the dev server's reload path", () => {
+	it("allows the dev server root", () => {
+		expect(allows(DEV_URL, DEV_URL)).toBe(true);
+	});
+
+	it("allows any path under the dev server, which is where a full reload lands", () => {
+		// Vite reloads the page when an HMR update cannot be applied in place.
+		// That is page-initiated, so it arrives as a real navigation.
+		expect(allows(DEV_URL, `${DEV_URL}/index.html?t=1`)).toBe(true);
+	});
+
+	it("refuses a different port on the same host", () => {
+		expect(allows(DEV_URL, "http://localhost:5174/")).toBe(false);
+	});
+
+	it("refuses an external https target", () => {
+		expect(allows(DEV_URL, "https://evil.example.com/")).toBe(false);
+	});
+});
+
+describe("anything that is not a URL at all is refused rather than guessed at", () => {
+	it.each(["", "not a url", "javascript:alert(1)", "file:relative"])("refuses %j", (url) => {
+		expect(allows(PROD_URL, url)).toBe(false);
+	});
+});
+
+describe("the predicate itself", () => {
+	it("refuses when the app's own URL is unparseable, rather than allowing everything", () => {
+		expect(isAppOwnUrl("https://evil.example.com/", "")).toBe(false);
+	});
+});
+
+describe("window.open", () => {
+	it("is denied, whatever it asks for", () => {
+		const w = fakeContents();
+		installWindowNavigationGuard(w.contents, PROD_URL);
+		expect(w.openHandler({ url: "https://evil.example.com/" })).toEqual({ action: "deny" });
+		// Not even the app's own document: a child window carries the preload the
+		// same way a navigation does, and nothing in this app opens one.
+		expect(w.openHandler({ url: PROD_URL })).toEqual({ action: "deny" });
+	});
+});
+
+describe("main.ts wiring", () => {
+	it("read the real main.ts", () => {
+		// A guard that scanned an empty string would pass every assertion below.
+		expect(mainSource.length).toBeGreaterThan(1000);
+		expect(mainSource).toContain("createWindow");
+	});
+
+	it("installs the guard on the main window", () => {
+		expect(mainSource).toContain("installWindowNavigationGuard(\n\t\tmainWindow.webContents,");
+	});
+
+	it("installs it before the load, so no navigation lands ahead of it", () => {
+		const install = mainSource.indexOf("installWindowNavigationGuard(\n");
+		const load = mainSource.indexOf("mainWindow.loadURL(DEV_SERVER_URL)");
+		expect(install).toBeGreaterThan(-1);
+		expect(load).toBeGreaterThan(install);
+	});
+
+	it("passes the URL it actually loads, in both builds", () => {
+		// The predicate is only as good as the URL it is compared against, and a
+		// second spelling of the entry path here would drift from `loadFile`'s.
+		expect(mainSource).toContain(
+			"isDev ? DEV_SERVER_URL : pathToFileURL(rendererEntry).toString()"
+		);
+		expect(mainSource).toContain("mainWindow.loadFile(rendererEntry)");
+	});
+});

--- a/app/electron/window-navigation.ts
+++ b/app/electron/window-navigation.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Atharva Kusumbia
+ *
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the "app" directory of this source tree.
+ */
+
+/**
+ * The main window's refusal to go anywhere but the app.
+ *
+ * `contextIsolation: true` and `nodeIntegration: false` decide what a renderer
+ * may reach; neither decides *which document* the renderer is. The preload runs
+ * on whatever the window has navigated to, so a main window that follows a link
+ * to a third-party origin hands `window.electronAPI` - the engine, the
+ * filesystem readers, the OAuth surface - to that origin. Until this existed the
+ * only thing standing in front of that was an application-level convention:
+ * `MarkdownView` renders links as buttons, so no `href` reaches the DOM. One
+ * component, one override, and nothing underneath it. Descriptions arrive from
+ * imported Postman, Insomnia and OpenAPI documents, so the content reaching that
+ * convention is third-party.
+ *
+ * This is the layer underneath: whatever any surface renders, the window itself
+ * refuses to navigate off the app, and denies `window.open` outright.
+ *
+ * Kept out of main.ts so it can be tested - main.ts creates windows and starts
+ * the engine at import time, which no unit test can do.
+ */
+
+/** What a `will-navigate` listener is handed, without depending on Electron's types. */
+export interface NavigationAttempt {
+	preventDefault(): void;
+}
+
+/** The slice of `WebContents` this needs, so a test can pass a fake. */
+export interface NavigableContents {
+	on(event: "will-navigate", listener: (event: NavigationAttempt, url: string) => void): unknown;
+	setWindowOpenHandler(handler: (details: { url: string }) => { action: "deny" }): unknown;
+}
+
+function parseUrl(value: string): URL | null {
+	try {
+		return new URL(value);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Whether a navigation target is the app itself rather than somewhere else.
+ *
+ * The two builds are the app in two different forms, and the identity that
+ * distinguishes them is not the same one:
+ *
+ * - **Production is a `file:` load, where an origin cannot be the test.** Every
+ *   `file:` URL has the opaque origin `"null"`, so comparing origins would
+ *   accept `file:///etc/passwd` as the app's own. The document is the identity
+ *   there, which also costs nothing the app wants: it never navigates between
+ *   local files.
+ * - **Development is the Vite dev server, where the origin is exactly the
+ *   test.** A full reload (an HMR update the client cannot apply in place) is
+ *   page-initiated, so it arrives here as a real navigation, and it may land on
+ *   any path under that origin. A rule tighter than the origin would refuse it
+ *   and break the dev loop for everyone, which is a worse outcome than the hole
+ *   this closes.
+ *
+ * Anything unparseable is refused rather than guessed at.
+ */
+export function isAppOwnUrl(target: string, appUrl: string): boolean {
+	const to = parseUrl(target);
+	const app = parseUrl(appUrl);
+	if (!to || !app) return false;
+	if (app.protocol === "file:") {
+		return to.protocol === "file:" && to.pathname === app.pathname;
+	}
+	return to.origin === app.origin;
+}
+
+/**
+ * Refuse every navigation that is not the app itself, and deny `window.open`.
+ *
+ * `appUrl` is the URL the window is loading - the dev server in development, the
+ * bundled entry as a `file:` URL in production. It is passed in rather than
+ * derived here so the caller cannot drift from what it actually loads.
+ *
+ * The deny is unconditional because nothing in this app calls `window.open`: an
+ * outbound link goes through the scheme-validated `openExternalUrl` IPC to the
+ * user's browser, which is where a third-party page belongs. A child window
+ * would carry the preload the same way a navigation does.
+ */
+export function installWindowNavigationGuard(contents: NavigableContents, appUrl: string): void {
+	contents.on("will-navigate", (event, url) => {
+		if (isAppOwnUrl(url, appUrl)) return;
+		event.preventDefault();
+	});
+	contents.setWindowOpenHandler(() => ({ action: "deny" }));
+}

--- a/app/src/components/ui/markdown-view.test.tsx
+++ b/app/src/components/ui/markdown-view.test.tsx
@@ -16,11 +16,15 @@
  * Vayu stored that markdown and rendered none of it, which is the only reason
  * it had never mattered.
  *
- * The main window has no `will-navigate` handler, no `setWindowOpenHandler` and
- * no CSP (the only `setWindowOpenHandler` in the tree is in `oauth.ts`). A
- * clicked `<a href>` would navigate the whole renderer, and the preload re-runs
- * on the new origin, handing `window.electronAPI` to it. So the requirement is
- * not "sanitise the href" - it is that no `href` reaches the DOM at all.
+ * A clicked `<a href>` navigates the whole renderer, and the preload re-runs on
+ * the new origin, handing `window.electronAPI` to it. So the requirement is not
+ * "sanitise the href" - it is that no `href` reaches the DOM at all.
+ *
+ * The main window refuses an off-app navigation and denies `window.open` since
+ * #822 (`electron/window-navigation.ts`, guarded by its own test); there is
+ * still no CSP. That is the layer underneath these assertions, not a substitute
+ * for them - a refused navigation is a dead link, while a button reaches the
+ * user's browser.
  *
  * These assert that in the ways it could regress: a plain link, a bare URL that
  * `remark-gfm` autolinks behind your back, a `javascript:` URL, and raw HTML in

--- a/app/src/components/ui/markdown-view.tsx
+++ b/app/src/components/ui/markdown-view.tsx
@@ -14,15 +14,18 @@
  * only reason it never mattered. Rendering it changes that, so three decisions
  * are load-bearing rather than stylistic:
  *
- * **1. No navigating anchors, ever.** `electron/main.ts` sets
- * `contextIsolation: true` and `nodeIntegration: false`, but the main window has
- * no `will-navigate` handler, no `setWindowOpenHandler` and no CSP - the only
- * `setWindowOpenHandler` in the tree is in `oauth.ts`. A clicked `<a href>`
- * would therefore navigate the whole renderer, and the preload re-runs on the
- * new origin, handing `window.electronAPI` to it. So the `a` renderer below
- * emits a `<button>`: no `href` reaches the DOM, and the click goes to the
- * scheme-validated `openExternalUrl` path, which refuses anything that is not
- * http(s).
+ * **1. No navigating anchors, ever.** A clicked `<a href>` navigates the whole
+ * renderer, and the preload re-runs on the new origin, handing
+ * `window.electronAPI` to it. So the `a` renderer below emits a `<button>`: no
+ * `href` reaches the DOM, and the click goes to the scheme-validated
+ * `openExternalUrl` path, which refuses anything that is not http(s).
+ *
+ * This is the layer above, not the only one: since #822 the main window itself
+ * refuses a navigation that is not the app's own document and denies
+ * `window.open` (`electron/window-navigation.ts`), beside `contextIsolation:
+ * true` and `nodeIntegration: false`. There is still no CSP. Keep this override
+ * anyway - a refused navigation is a link that silently does nothing, where a
+ * button reaches the user's browser, which is what they meant.
  *
  * **2. `react-markdown`, not `marked`.** It builds React elements from an AST
  * rather than an HTML string, so there is no `dangerouslySetInnerHTML` and no

--- a/docs/app/COMPONENTS.md
+++ b/docs/app/COMPONENTS.md
@@ -1450,14 +1450,19 @@ beside a plain textarea.
 
 **Two rules are load-bearing, not stylistic:**
 
-1. **`MarkdownView` never emits a navigating anchor.** The main window has no
-   `will-navigate` handler, no `setWindowOpenHandler` and no CSP, and the
-   preload re-runs on the new origin - so a clicked `<a href>` would hand
-   `window.electronAPI` to whatever site it landed on. Descriptions arrive from
-   imported Postman / Insomnia / OpenAPI files, which are third-party documents.
-   Links therefore render as `<button>`, with no `href` in the DOM, and open via
-   the scheme-validated `openExternalUrl` IPC. `remark-gfm` autolinks bare URLs,
-   so that override covers those too. Guarded by `markdown-view.test.tsx`.
+1. **`MarkdownView` never emits a navigating anchor.** The preload re-runs on
+   the new origin, so a clicked `<a href>` would hand `window.electronAPI` to
+   whatever site it landed on. Descriptions arrive from imported Postman /
+   Insomnia / OpenAPI files, which are third-party documents. Links therefore
+   render as `<button>`, with no `href` in the DOM, and open via the
+   scheme-validated `openExternalUrl` IPC. `remark-gfm` autolinks bare URLs, so
+   that override covers those too. Guarded by `markdown-view.test.tsx`.
+
+   Underneath it, `electron/window-navigation.ts` makes the main window refuse a
+   navigation that is not the app's own document and deny `window.open`; there
+   is still no CSP. Keep both - the window guard turns an escaped link into a
+   dead one, and this override is what makes it reach the user's browser
+   instead.
 2. **`react-markdown` with the default `urlTransform`.** It builds React
    elements from an AST, so there is no `dangerouslySetInnerHTML` and no
    sanitiser to forget. Raw HTML is inert because `rehype-raw` is deliberately

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -306,6 +306,7 @@ The preload script (`electron/preload.ts`) exposes a minimal, context-isolated A
 - **Context Isolation**: Enabled in Electron (renderer cannot access Node.js APIs)
 - **No Node Integration**: Renderer runs in isolated context
 - **Preload Script**: Minimal IPC bridge through `contextBridge.exposeInMainWorld()`
+- **Window Navigation**: The main window refuses any navigation that is not the app's own document and denies `window.open` (`electron/window-navigation.ts`). The preload re-runs on whatever the window navigates to, so this is what keeps `window.electronAPI` off a third-party origin. The app's own document is the entry `file:` URL in production and the dev server's origin in development, where a Vite full reload is a real navigation. Outbound links go to the user's browser through the scheme-validated `openExternalUrl` IPC instead. There is no CSP
 - **Local Communication**: Engine runs on localhost only (127.0.0.1:9876)
 
 ## Performance Optimizations


### PR DESCRIPTION
## Description

**Plan.** The root cause is a defense that is one layer deep. `contextIsolation`
and `nodeIntegration` decide what a renderer may reach; neither decides *which
document the renderer is*, and the preload re-runs on whatever the main window
navigates to - so a navigation off the app hands `window.electronAPI` to that
origin. Verified against the current code before touching anything: `createWindow`
subscribed `page-title-updated`, `render-process-gone` and `did-finish-load` and
nothing else, and the only `setWindowOpenHandler` in the tree was `oauth.ts:56`,
for the auth window alone. The approach is the issue's: a new
`electron/window-navigation.ts` following the file's own precedent for anything
testable (`quit-signals.ts`, `oauth-window.ts`, `renderer-recovery.ts`) - an
installer taking the `webContents`-shaped surface it needs, driven through a
fake, with the wiring source-scanned. **Alternative rejected:** handlers written
inline in `createWindow`. It is fewer files and untestable - `main.ts` creates
windows and starts the engine at import time, so the predicate, which is the part
that can be wrong, would have no test at all.

### The predicate is the whole design question

The two builds are the app in two forms, and the identity that distinguishes each
is not the same one:

- **Production is a `file:` load, where an origin cannot be the test.** Every
  `file:` URL has the opaque origin `"null"`, so comparing origins would accept
  `file:///etc/passwd` as the app's own. The document is the identity there,
  which costs nothing the app wants - it never navigates between local files.
  Asserted directly, including the `new URL(...).origin` equality that is the
  reason for the branch.
- **Development is the Vite dev server, where the origin is exactly the test.** A
  full reload (an HMR update the client cannot apply in place) is page-initiated,
  so it arrives as a real navigation and may land on any path under that origin.
  A rule tighter than the origin would refuse it and break the dev loop for
  everyone, which is worse than the hole being closed.

Anything unparseable is refused rather than guessed at. `main.ts` passes the URL
it *actually* loads (`rendererEntry` is computed once and used by both the guard
and `loadFile`), because a second spelling of the entry path would drift from the
one the window is on - and a pinned test reads that.

**`window.open` is denied unconditionally.** Nothing in this app calls it -
checked, there is no `window.open` in `src/` or `electron/` outside tests - and
an outbound link goes through the scheme-validated `openExternalUrl` IPC to the
user's browser, which is where a third-party page belongs. A child window would
carry the preload the same way a navigation does.

**Deliberately not done: a CSP.** The issue scopes it out unless it turns out to
be free, and it is not - the renderer loads its own bundle, styles and fonts, so
it has a different blast radius and belongs in its own change. The statements
corrected below therefore still say a CSP is absent, because it is.

**The anchor-as-button behaviour does not change.** It stays as the layer above,
and the reason is now written next to it in all three places: a refused
navigation is a link that silently does nothing, where a button reaches the
user's browser, which is what the user meant.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

App-only diff (TypeScript plus two docs pages); no engine file is touched, so per
`CLAUDE.md`'s "scale the verification to what the change could actually break"
the engine build and ctest were not run - no C++ test could change colour.

**Re-run in full after merging `master` (`63e7815`) into this branch**, since
that merge brought in #823, which touches the same component:

- `pnpm test` - **5715 tests in 521 files, 100% passed**
- `pnpm type-check`, `pnpm lint`, `pnpm format:check` - clean

The new file is 18 of those tests (`vitest run
electron/window-navigation.test.ts` on its own reports 18). Before the merge, on
`2c0715d`, the same suite was 5677 in 520 files.

Every guard mutation-checked (mutation applied, confirmed red, reverted -
`git diff` against the pushed tree is empty):

| Mutation | Result |
|---|---|
| predicate always returns `true` (guard refuses nothing) | **9 of 18 fail** - every refusal case, in both builds |
| the `file:` branch dropped, so production compares origins | **3 fail**, including `file:///etc/passwd` being accepted as the app's own |
| `setWindowOpenHandler` not installed | the `window.open` case fails |
| the installer never called in `main.ts` | **3 wiring tests fail** |
| installed *after* the load instead of before | the ordering test fails |
| baseline, unmutated | 18/18 pass |

The wiring scan asserts it read a non-empty `main.ts` and that the file contains
`createWindow` before anything else, per the precedent in `oauth-window.test.ts`
- a scan of an empty string would otherwise pass every assertion under it.

One note on what the tests deliberately do **not** assert: nothing here reads
`process.platform`. The predicate's two branches are the two builds, not the
three operating systems, so there is no host-platform assertion for
`CLAUDE.md`'s rule to catch.

No pre-existing failures observed on the base commit.

**`mkdocs build --strict` could not run here** - mkdocs is not installed in this
environment. The docs edits are prose inside existing sections and add no new
links, headings or nav entries, so the failure modes that gate catches are not
reachable from this diff; CI's docs job covers it.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit - the three places the issue names, all of which stated
the absence as a current fact and would have become false together:
`app/src/components/ui/markdown-view.tsx` (decision 1),
`app/src/components/ui/markdown-view.test.tsx` (header), and
`docs/app/COMPONENTS.md` (Markdown rule 1). Plus a **Window Navigation** bullet
in `docs/app/architecture.md`'s Security Considerations list, which described the
Electron posture and would otherwise have been the one place still implying this
layer does not exist.

## Related Issues

Closes #822

### The #823 conflict, resolved

#823 merged first and rewrote the same decision-1 paragraphs this corrects, so
both sides changed the same sentence for different reasons. `master` is merged in
and resolved here (`131ed67`):

- **`markdown-view.tsx` and `docs/app/COMPONENTS.md`** keep #823's newer
  four-decision structure. The clause replaced is the one that had become false
  on merge - #823 wrote that the anchor override "is a single layer by design,
  and stays one until #822 puts a `will-navigate` refusal underneath it", and
  #822 is this branch. Both now say the layer exists and why the override stays
  anyway.
- **`markdown-view.test.tsx`** merged cleanly; nothing to resolve.
- The guard module and its tests never overlapped #823 at all.

Nothing else in the merge needed a decision, and no behaviour changed in the
resolution - both conflicts were comment and prose only.
