### PR TITLE
test(engine/tls): serve a CA-signed CRL so the positive custom-CA cases can run (#819)

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -280,13 +280,13 @@ Three things worth knowing before you design around them:
   never asks would report nothing about any of that, so
   `TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint` asserts on every
   leg that the extension is on the certificate served and that the document
-  behind it parses, is this CA's, and is current. The skip stays until a CI run
-  on a revocation-checking backend shows it unreachable; it fires only on an
-  error text naming revocation, and every other refusal still fails. What #819
-  keeps after that is the user-facing half, which is a decision rather than a
-  fix: someone pasting an internal CA with no reachable distribution point gets
-  the same refusal, and no doc says so. The negative cases are asserted on every
-  platform. Still structural, not on a wire: the *client* certificate's
+  behind it parses, is this CA's, and is current. **All four cases now run
+  everywhere** - the leg that skipped went to 2056 run, 2056 passed, 0 skipped -
+  so the skip and its helpers are gone and a refusal naming revocation is an
+  ordinary failure again. What #819 keeps is the user-facing half, which is a
+  decision rather than a fix: someone pasting an internal CA with no reachable
+  distribution point gets the same refusal, and no doc says so. Still
+  structural, not on a wire: the *client* certificate's
   handshake, tracked by #802 - which should reuse this CRL rather than build a
   second one.
   A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -271,14 +271,24 @@ Three things worth knowing before you design around them:
   `engine/vcpkg.json`. **The two backends do not answer this the same way, and
   the wire is how we found out.** Where curl revocation-checks the chain itself
   - the Schannel path does, passing `CERT_CHAIN_REVOCATION_CHECK_CHAIN` unless
-  told not to - a certificate authority minted for one test run is refused for
-  publishing no CRL, with the anchor loaded and the signature good. So the two
-  *positive* cases skip there, loudly and only on an error text naming
-  revocation, and #819 carries both halves of that: a fixture that serves a CRL,
-  and the user-facing question it exposes (someone pasting an internal CA with
-  no reachable distribution point gets the same refusal, and no doc says so).
-  The negative cases are asserted on every platform. Still structural, not on a
-  wire: the *client* certificate's handshake, tracked by #802.
+  told not to - a certificate authority minted for one test run was refused for
+  publishing no CRL, with the anchor loaded and the signature good, and the two
+  *positive* cases skipped there. **The fixture publishes one now** (#819): the
+  CA signs an empty CRL, a plain-HTTP `CrlServer` serves it, and the leaf names
+  that listener as its distribution point - on the leaf, because
+  `CERT_CHAIN_REVOCATION_CHECK_CHAIN` checks below the root. A backend that
+  never asks would report nothing about any of that, so
+  `TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint` asserts on every
+  leg that the extension is on the certificate served and that the document
+  behind it parses, is this CA's, and is current. The skip stays until a CI run
+  on a revocation-checking backend shows it unreachable; it fires only on an
+  error text naming revocation, and every other refusal still fails. What #819
+  keeps after that is the user-facing half, which is a decision rather than a
+  fix: someone pasting an internal CA with no reachable distribution point gets
+  the same refusal, and no doc says so. The negative cases are asserted on every
+  platform. Still structural, not on a wire: the *client* certificate's
+  handshake, tracked by #802 - which should reuse this CRL rather than build a
+  second one.
   A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
   the target's `ConnectionFailed` - and `curl_to_error` now takes the handle,
   because a 407 answered to a CONNECT is a plain `CURLE_RECV_ERROR` and only

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -26,7 +26,18 @@
  * It is not a general-purpose TLS server. #802's mTLS fixture is expected to
  * extend `TlsServer` with a client-certificate store rather than stand up a
  * second listener - `TestCertificateAuthority::issue` already mints the client
- * identity such a test would present.
+ * identity such a test would present, and `CrlServer` below is the CRL that
+ * fixture should reuse rather than build a second one (#819).
+ *
+ * **The CA publishes a CRL, and the leaf says where to find it** (#819). A
+ * backend that revocation-checks the chain - curl's Schannel path passes
+ * `CERT_CHAIN_REVOCATION_CHECK_CHAIN` - refuses a leaf whose revocation status
+ * it cannot determine, with the anchor loaded and the signature good. That is
+ * not a verdict about trust, and it made the *positive* half of
+ * `tls_verification_test.cpp` unhostable on that backend. So the CA signs an
+ * empty CRL, a plain-HTTP listener serves it, and the leaf carries a
+ * distribution point naming that listener. The other backends never ask, so
+ * nothing about them changes.
  */
 
 #include <httplib.h>
@@ -44,6 +55,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -67,10 +79,22 @@ struct BioDeleter {
         BIO_free (value);
     }
 };
+struct CrlDeleter {
+    void operator() (X509_CRL* value) const noexcept {
+        X509_CRL_free (value);
+    }
+};
+struct Asn1TimeDeleter {
+    void operator() (ASN1_TIME* value) const noexcept {
+        ASN1_TIME_free (value);
+    }
+};
 
-using X509Ptr = std::unique_ptr<X509, X509Deleter>;
-using KeyPtr  = std::unique_ptr<EVP_PKEY, KeyDeleter>;
-using BioPtr  = std::unique_ptr<BIO, BioDeleter>;
+using X509Ptr     = std::unique_ptr<X509, X509Deleter>;
+using KeyPtr      = std::unique_ptr<EVP_PKEY, KeyDeleter>;
+using BioPtr      = std::unique_ptr<BIO, BioDeleter>;
+using CrlPtr      = std::unique_ptr<X509_CRL, CrlDeleter>;
+using Asn1TimePtr = std::unique_ptr<ASN1_TIME, Asn1TimeDeleter>;
 
 /// Fail the way a fixture should: loudly, naming OpenSSL's own reason. A
 /// silently degraded fixture would leave the tests below asserting nothing.
@@ -110,6 +134,27 @@ inline std::string to_pem (EVP_PKEY* key) {
     return read_bio (bio, "a private key");
 }
 
+inline std::string to_der (X509_CRL* crl) {
+    BioPtr bio (BIO_new (BIO_s_mem ()));
+    if (!bio || i2d_X509_CRL_bio (bio.get (), crl) != 1) {
+        fail ("could not serialize a CRL to DER");
+    }
+    return read_bio (bio, "a CRL");
+}
+
+/// Whatever the BIO holds, empty included - unlike `read_bio`, which treats
+/// empty as a fixture defect. A certificate that carries no extension at all
+/// prints nothing, and that is an answer a guard wants to read rather than a
+/// reason to abort the run.
+inline std::string read_bio_text (const BioPtr& bio) {
+    char* data        = nullptr;
+    const long length = BIO_get_mem_data (bio.get (), &data);
+    if (length <= 0 || data == nullptr) {
+        return {};
+    }
+    return { data, static_cast<std::string::size_type> (length) };
+}
+
 } // namespace tls_detail
 
 /// A certificate and the key that goes with it.
@@ -128,6 +173,30 @@ struct CertificateAndKey {
     /// listener below takes it from memory.
     std::string key_pem () const {
         return tls_detail::to_pem (key.get ());
+    }
+
+    /**
+     * @brief The `crlDistributionPoints` extension as OpenSSL prints it, or
+     *        empty if the certificate carries none.
+     *
+     * Read off the certificate object the listener actually serves rather than
+     * off the string that was passed in when it was minted - the two agreeing
+     * is the thing worth asserting, since a distribution point the leaf does
+     * not carry is one no backend will ever fetch.
+     */
+    std::string crl_distribution_point_text () const {
+        const int index =
+        X509_get_ext_by_NID (certificate.get (), NID_crl_distribution_points, -1);
+        if (index < 0) {
+            return {};
+        }
+        X509_EXTENSION* extension = X509_get_ext (certificate.get (), index);
+        tls_detail::BioPtr bio (BIO_new (BIO_s_mem ()));
+        if (!bio || extension == nullptr ||
+        X509V3_EXT_print (bio.get (), extension, 0, 0) != 1) {
+            return {};
+        }
+        return tls_detail::read_bio_text (bio);
     }
 };
 
@@ -161,11 +230,81 @@ class TestCertificateAuthority {
      *        `IP:` entry: a CN alone has not been enough for any backend this
      *        engine builds against for years, and a hostname SAN does not
      *        cover the address curl dials.
+     * @param crl_distribution_point Where a backend that revocation-checks the
+     *        chain can fetch @ref crl_der, or empty for a leaf that names none.
+     *        `CERT_CHAIN_REVOCATION_CHECK_CHAIN` checks the chain below the
+     *        root, so this belongs on the *leaf* - the self-signed root is its
+     *        own trust anchor and answers to nobody.
      */
     CertificateAndKey issue (const std::string& common_name,
-    const std::string& subject_alt_names) const {
-        return sign (common_name, subject_alt_names,
+    const std::string& subject_alt_names,
+    const std::string& crl_distribution_point = {}) const {
+        return sign (common_name, subject_alt_names, crl_distribution_point,
         identity_.certificate.get (), identity_.key.get ());
+    }
+
+    /**
+     * @brief An empty CRL this CA signed, DER-encoded - the answer "nothing
+     *        issued here is revoked", which is the answer a fresh CA owes and
+     *        the one it could not give before #819.
+     *
+     * Empty is the whole point: a backend refusing the chain over an *unknown*
+     * revocation status is refusing for want of a document, not for want of
+     * trust, and this is that document.
+     */
+    std::string crl_der () const {
+        tls_detail::CrlPtr crl (X509_CRL_new ());
+        if (!crl) {
+            tls_detail::fail ("could not allocate a CRL");
+        }
+        // v2. A v1 CRL takes no extensions, and `crlNumber` below is one.
+        if (X509_CRL_set_version (crl.get (), 1) != 1 ||
+        X509_CRL_set_issuer_name (
+        crl.get (), X509_get_subject_name (identity_.certificate.get ())) != 1) {
+            tls_detail::fail ("could not seed a CRL");
+        }
+        set_crl_validity (crl.get ());
+        set_crl_number (crl.get ());
+        if (X509_CRL_sort (crl.get ()) != 1 ||
+        X509_CRL_sign (crl.get (), identity_.key.get (), EVP_sha256 ()) == 0) {
+            tls_detail::fail ("could not sign a CRL");
+        }
+        return tls_detail::to_der (crl.get ());
+    }
+
+    /**
+     * @brief Why @p der is not a CRL this CA would vouch for, or empty if it
+     *        is one.
+     *
+     * The fixture's own guard reads this. A CRL that is served but unparseable,
+     * or signed by nothing, or already expired, leaves the revocation question
+     * exactly where it was while looking fixed - and on the backends that never
+     * ask, nothing would notice.
+     */
+    std::string crl_defect (const std::string& der) const {
+        if (der.empty ()) {
+            return "nothing was served";
+        }
+        const auto* data = reinterpret_cast<const unsigned char*> (der.data ());
+        tls_detail::CrlPtr crl (
+        d2i_X509_CRL (nullptr, &data, static_cast<long> (der.size ())));
+        if (!crl) {
+            return "the " + std::to_string (der.size ()) + " bytes served are not a DER-encoded CRL";
+        }
+        if (X509_NAME_cmp (X509_CRL_get_issuer (crl.get ()),
+            X509_get_subject_name (identity_.certificate.get ())) != 0) {
+            return "the CRL names an issuer other than this CA";
+        }
+        tls_detail::KeyPtr public_key (X509_get_pubkey (identity_.certificate.get ()));
+        if (!public_key || X509_CRL_verify (crl.get (), public_key.get ()) != 1) {
+            return "the CRL is not signed by this CA's key";
+        }
+        const ASN1_TIME* next = X509_CRL_get0_nextUpdate (crl.get ());
+        if (next == nullptr || X509_cmp_current_time (next) <= 0) {
+            return "the CRL names no nextUpdate in the future, so a validator "
+                   "may treat it as stale";
+        }
+        return {};
     }
 
     private:
@@ -226,6 +365,29 @@ class TestCertificateAuthority {
         }
     }
 
+    /// The same window as a certificate's, and backdated for the same reason.
+    static void set_crl_validity (X509_CRL* crl) {
+        tls_detail::Asn1TimePtr last (ASN1_TIME_new ());
+        tls_detail::Asn1TimePtr next (ASN1_TIME_new ());
+        if (!last || !next || X509_gmtime_adj (last.get (), -3600) == nullptr ||
+        X509_gmtime_adj (next.get (), 86400) == nullptr ||
+        X509_CRL_set1_lastUpdate (crl, last.get ()) != 1 ||
+        X509_CRL_set1_nextUpdate (crl, next.get ()) != 1) {
+            tls_detail::fail ("could not set a CRL validity window");
+        }
+    }
+
+    /// One CRL per run, so its number never has to advance.
+    static void set_crl_number (X509_CRL* crl) {
+        ASN1_INTEGER* number = ASN1_INTEGER_new ();
+        if (number == nullptr || ASN1_INTEGER_set (number, 1) != 1 ||
+        X509_CRL_add1_ext_i2d (crl, NID_crl_number, number, 0, 0) != 1) {
+            ASN1_INTEGER_free (number);
+            tls_detail::fail ("could not set a CRL number");
+        }
+        ASN1_INTEGER_free (number);
+    }
+
     static CertificateAndKey self_signed (const std::string& common_name) {
         CertificateAndKey identity{ tls_detail::X509Ptr (X509_new ()), generate_key () };
         X509* certificate = identity.certificate.get ();
@@ -251,6 +413,7 @@ class TestCertificateAuthority {
 
     static CertificateAndKey sign (const std::string& common_name,
     const std::string& subject_alt_names,
+    const std::string& crl_distribution_point,
     X509* issuer,
     EVP_PKEY* issuer_key) {
         CertificateAndKey leaf{ tls_detail::X509Ptr (X509_new ()), generate_key () };
@@ -272,6 +435,10 @@ class TestCertificateAuthority {
         "critical,digitalSignature,keyEncipherment");
         add_extension (certificate, issuer, NID_ext_key_usage, "serverAuth,clientAuth");
         add_extension (certificate, issuer, NID_subject_alt_name, subject_alt_names);
+        if (!crl_distribution_point.empty ()) {
+            add_extension (certificate, issuer, NID_crl_distribution_points,
+            "URI:" + crl_distribution_point);
+        }
         if (X509_sign (certificate, issuer_key, EVP_sha256 ()) == 0) {
             tls_detail::fail ("could not sign a leaf certificate");
         }
@@ -279,6 +446,61 @@ class TestCertificateAuthority {
     }
 
     CertificateAndKey identity_;
+};
+
+/**
+ * @brief A plain-HTTP listener on 127.0.0.1 serving one CA's CRL (#819).
+ *
+ * Plain HTTP on purpose: a revocation fetch that needed TLS would need its own
+ * trust decision, and the chain being validated is the one asking. RFC 5280
+ * distribution points are `http:` for the same reason.
+ *
+ * The path carries a per-instance token because Windows caches a fetched CRL
+ * **by URL**. Two runs on one machine can land on the same ephemeral port, and
+ * the second would then be served the first run's CRL out of the cache - signed
+ * by a CA that no longer exists, which reads as a revocation failure and would
+ * make this fixture flake for a reason nothing in it names.
+ */
+class CrlServer {
+    public:
+    explicit CrlServer (const TestCertificateAuthority& ca)
+    : der_ (ca.crl_der ()) {
+        svr_.Get (path (), [this] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (der_, "application/pkix-crl");
+        });
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+        svr_.wait_until_ready ();
+    }
+
+    ~CrlServer () {
+        svr_.stop ();
+        if (thread_.joinable ()) {
+            thread_.join ();
+        }
+    }
+
+    CrlServer (const CrlServer&)            = delete;
+    CrlServer& operator= (const CrlServer&) = delete;
+
+    /// What a leaf's distribution point names, and where the guard fetches.
+    std::string url () const {
+        return "http://127.0.0.1:" + std::to_string (port_) + path ();
+    }
+
+    private:
+    /// No `.` in the path on purpose: httplib compiles a route pattern as a
+    /// regular expression, and a literal here reads as one.
+    std::string path () const {
+        std::ostringstream token;
+        token << "/crl-" << std::hex << reinterpret_cast<uintptr_t> (this);
+        return token.str ();
+    }
+
+    std::string der_;
+    httplib::Server svr_;
+    std::thread thread_;
+    int port_ = 0;
 };
 
 /**
@@ -292,7 +514,8 @@ class TestCertificateAuthority {
 class TlsServer {
     public:
     explicit TlsServer (const TestCertificateAuthority& ca)
-    : identity_ (ca.issue ("127.0.0.1", "IP:127.0.0.1,DNS:localhost")),
+    : crl_ (ca),
+      identity_ (ca.issue ("127.0.0.1", "IP:127.0.0.1,DNS:localhost", crl_.url ())),
       cert_pem_ (identity_.pem ()), key_pem_ (identity_.key_pem ()),
       svr_ (pem_memory ()) {
         if (!svr_.is_valid ()) {
@@ -320,6 +543,18 @@ class TlsServer {
         return "https://127.0.0.1:" + std::to_string (port_) + path;
     }
 
+    /// Where this listener's CRL is served, which is also what its certificate
+    /// names as a distribution point - the fixture guard asserts those agree.
+    std::string crl_url () const {
+        return crl_.url ();
+    }
+
+    /// The `crlDistributionPoints` extension as it stands on the certificate
+    /// this listener presents, or empty if it carries none.
+    std::string crl_distribution_point_text () const {
+        return identity_.crl_distribution_point_text ();
+    }
+
     private:
     /**
      * The listener takes its identity as PEM in memory rather than as a pair of
@@ -335,6 +570,10 @@ class TlsServer {
             key_pem_.size (), nullptr, 0, nullptr };
     }
 
+    /// Declared first because the leaf below is minted naming its URL: the
+    /// distribution point has to exist before the certificate that points at
+    /// it, and member order is what enforces that here.
+    CrlServer crl_;
     CertificateAndKey identity_;
     std::string cert_pem_;
     std::string key_pem_;

--- a/engine/tests/tls_verification_test.cpp
+++ b/engine/tests/tls_verification_test.cpp
@@ -21,31 +21,29 @@
  * "the request succeeded" - so the suite asserts a success, a failure without
  * the setting, and a failure with the *wrong* setting.
  *
- * These run on all three CI platforms deliberately: the trust decision is made
- * by a different backend on each (OpenSSL where curl is built against it,
- * Schannel on Windows), and a claim about trust that holds on one is not a
- * claim about the others. That is not a formality - the backends answered
- * differently the first time this ran. A backend that revocation-checks the
- * chain refused a CA minted for this run, because a CA minted for this run
- * published no CRL, and the *positive* cases below skipped there rather than
- * assert.
+ * All four run on all three CI platforms, and getting there took two rounds.
+ * The trust decision is made by a different backend on each (OpenSSL where curl
+ * is built against it, Schannel on Windows), and a claim about trust that holds
+ * on one is not a claim about the others - which is not a formality, because
+ * the backends answered differently the first time this ran. A backend that
+ * revocation-checks the chain refused a CA minted for this run, since a CA
+ * minted for this run published no CRL, and the two *positive* cases skipped
+ * there rather than assert.
  *
- * **The fixture now publishes one** (#819): the CA signs an empty CRL, a
+ * **The fixture publishes one now** (#819): the CA signs an empty CRL, a
  * plain-HTTP listener serves it, and the leaf names that listener as its
- * distribution point, so the revocation question has an answer on the backends
- * that ask it. The skip is kept until a CI run on such a backend shows it
- * unreachable - deleting it on the strength of a local run that never asks
- * would be replacing one unread claim with another, which is the defect #812
- * was filed about. It is narrow and loud either way: it fires only when the
- * backend's own error text names revocation, prints that text, and every other
- * refusal, on every platform, still fails. The negative cases have no such
- * carve-out and are asserted everywhere.
+ * distribution point. The skip that stood here, and the two helpers behind it,
+ * are gone - on the observation rather than on the theory, since the leg that
+ * skipped went to 2056 run, 2056 passed, 0 skipped (job 95970419762). A refusal
+ * naming revocation is now an ordinary failure on every platform, which is what
+ * it should be: the fixture answers that question, so a backend still asking it
+ * is telling us something.
  *
- * `TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint` is what keeps that
+ * `TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint` is what keeps this
  * honest on the backends that never ask. Without it the whole CRL apparatus
- * could be broken - unparseable bytes, a wrong signer, a stale window - and
- * every leg would stay green while Windows went on skipping for a reason
- * nobody would think to re-examine.
+ * could rot - unparseable bytes, a wrong signer, a stale window - and every
+ * OpenSSL leg would stay green while the Schannel one went red for a reason
+ * pointing at trust rather than at the fixture.
  */
 
 #include <gtest/gtest.h>
@@ -93,43 +91,6 @@ Response send_through (const TransportPolicy& transport, const std::string& url)
     EXPECT_TRUE (result.is_ok ())
     << "the send was never attempted: " << result.error ().message;
     return result.is_ok () ? result.value () : Response{};
-}
-
-/**
- * @brief Whether the backend refused for want of *revocation* information
- *        rather than for want of trust.
- *
- * The two are different verdicts and only one of them is about this engine.
- * A backend that asks the operating system to revocation-check the chain
- * cannot be satisfied by a certificate authority minted seconds ago: it
- * publishes no CRL, so the answer comes back "unknown" and the chain is
- * refused even though the anchor was loaded and the signature is good. That is
- * what curl's Schannel path does - `Curl_verify_certificate` passes
- * `CERT_CHAIN_REVOCATION_CHECK_CHAIN` unless `CURLSSLOPT_NO_REVOKE` is set,
- * and treats `CERT_TRUST_REVOCATION_STATUS_UNKNOWN` as a failure unless
- * `CURLSSLOPT_REVOKE_BEST_EFFORT` is (`lib/vtls/schannel_verify.c`) - so the
- * *positive* half of this suite cannot be hosted on such a backend until the
- * fixture serves a CRL, which is #819.
- *
- * Matched on the backend's own words rather than on `_WIN32`, deliberately.
- * The property that matters is "this backend demands revocation information",
- * not "this is Windows", and a test that asserts the host platform is exactly
- * what `CLAUDE.md` forbids - it would keep skipping on Windows if the reason
- * changed, and keep failing elsewhere if the reason spread.
- */
-bool refused_for_want_of_revocation (const Response& response) {
-    return response.error_code == ErrorCode::SslError &&
-    response.error_message.find ("revocation") != std::string::npos;
-}
-
-/// What such a skip says. Loudly, in the backend's own words: a guard that
-/// quietly does nothing on one platform is worse than no guard, so this has to
-/// read as "not answered here, and here is why" rather than as a pass.
-std::string revocation_skip_reason (const Response& response) {
-    return "this TLS backend revocation-checks the chain, which a CA minted for"
-           " this run cannot answer for - the anchor is not the thing it"
-           " refused. Tracked by #819. The backend said: " +
-    response.error_message;
 }
 
 class CustomCaVerificationTest : public ::testing::Test {
@@ -214,9 +175,6 @@ TEST_F (CustomCaVerificationTest, AHostSignedByTheAddedCaVerifies) {
        "tested";
 
     const Response response = send_through (policy, server.url ("/hello"));
-    if (refused_for_want_of_revocation (response)) {
-        GTEST_SKIP () << revocation_skip_reason (response);
-    }
     ASSERT_EQ (response.error_code, ErrorCode::None)
     << "verification failed with the CA added: " << to_string (response.error_code)
     << ": " << response.error_message;
@@ -276,9 +234,6 @@ TEST_F (CustomCaVerificationTest, TheAddedCaExtendsTheStoreRatherThanReplacingIt
     ASSERT_FALSE (policy.ca_bundle_path.empty ());
 
     const Response response = send_through (policy, server.url ("/hello"));
-    if (refused_for_want_of_revocation (response)) {
-        GTEST_SKIP () << revocation_skip_reason (response);
-    }
     ASSERT_EQ (response.error_code, ErrorCode::None)
     << "a second anchor cost the first its trust: " << to_string (response.error_code)
     << ": " << response.error_message;

--- a/engine/tests/tls_verification_test.cpp
+++ b/engine/tests/tls_verification_test.cpp
@@ -26,12 +26,26 @@
  * Schannel on Windows), and a claim about trust that holds on one is not a
  * claim about the others. That is not a formality - the backends answered
  * differently the first time this ran. A backend that revocation-checks the
- * chain refuses a CA minted for this run, because a CA minted for this run
- * publishes no CRL, and the *positive* cases below therefore skip there rather
- * than assert. The skip is narrow and loud: it fires only when the backend's
- * own error text names revocation, prints that text, and is tracked by #819;
- * every other refusal, on every platform, still fails. The negative cases have
- * no such carve-out and are asserted everywhere.
+ * chain refused a CA minted for this run, because a CA minted for this run
+ * published no CRL, and the *positive* cases below skipped there rather than
+ * assert.
+ *
+ * **The fixture now publishes one** (#819): the CA signs an empty CRL, a
+ * plain-HTTP listener serves it, and the leaf names that listener as its
+ * distribution point, so the revocation question has an answer on the backends
+ * that ask it. The skip is kept until a CI run on such a backend shows it
+ * unreachable - deleting it on the strength of a local run that never asks
+ * would be replacing one unread claim with another, which is the defect #812
+ * was filed about. It is narrow and loud either way: it fires only when the
+ * backend's own error text names revocation, prints that text, and every other
+ * refusal, on every platform, still fails. The negative cases have no such
+ * carve-out and are asserted everywhere.
+ *
+ * `TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint` is what keeps that
+ * honest on the backends that never ask. Without it the whole CRL apparatus
+ * could be broken - unparseable bytes, a wrong signer, a stale window - and
+ * every leg would stay green while Windows went on skipping for a reason
+ * nobody would think to re-examine.
  */
 
 #include <gtest/gtest.h>
@@ -160,6 +174,34 @@ class CustomCaVerificationTest : public ::testing::Test {
 };
 
 // ---------------------------------------------------------------------------
+
+TEST_F (CustomCaVerificationTest, TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint) {
+    // The guard for everything the revocation half of this fixture rests on,
+    // asserted where every backend can see it. A backend that revocation-checks
+    // the chain fetches this document and refuses the handshake if it is not
+    // there, not this CA's, or not current - and the backends that do not ask
+    // would report none of that.
+    TestCertificateAuthority ca;
+    TlsServer server (ca);
+
+    const std::string distribution_point = server.crl_distribution_point_text ();
+    ASSERT_FALSE (distribution_point.empty ())
+    << "the certificate the listener presents carries no crlDistributionPoints "
+       "extension, so no backend will ever fetch the CRL below";
+    EXPECT_NE (distribution_point.find (server.crl_url ()), std::string::npos)
+    << "the leaf points somewhere other than where the CRL is served: " << distribution_point
+    << " vs " << server.crl_url ();
+
+    const auto policy       = resolve_transport_policy (*db_);
+    const Response response = send_through (policy, server.crl_url ());
+    ASSERT_EQ (response.status_code, 200)
+    << "the distribution point answered " << response.status_code << ": "
+    << to_string (response.error_code) << ": " << response.error_message;
+
+    EXPECT_EQ (ca.crl_defect (response.body), "")
+    << "what the distribution point served is not a CRL this CA vouches for, "
+       "so a revocation-checking backend is no better off than before #819";
+}
 
 TEST_F (CustomCaVerificationTest, AHostSignedByTheAddedCaVerifies) {
     TestCertificateAuthority ca;


### PR DESCRIPTION
## Description

**Plan.** The root cause is a document that did not exist. curl's Schannel path
validates a `CURLOPT_CAINFO` chain itself and asks Windows to revocation-check
it (`CERT_CHAIN_REVOCATION_CHECK_CHAIN`), then treats an unknown status as a
refusal - so a certificate authority minted seconds ago, publishing no CRL and
naming no distribution point, was refused with the anchor loaded and the
signature good. #817 recorded that as a loud skip on the two *positive* cases;
this PR gives the backend the document it is asking for. Verified against the
current tree before touching anything: the skip and its two helpers were at
`tls_verification_test.cpp:106-119`, `TestCertificateAuthority` minted no CRL,
and `TlsServer` stood up one listener. **Alternative rejected:**
`CURLSSLOPT_REVOKE_BEST_EFFORT` on the engine handle. It is a one-line diff that
makes every leg green, and it is a security-posture change - it weakens
revocation enforcement for real users as a side effect of a test problem. That
is part 2 of #819 and needs an owner decision, not a patch smuggled in behind a
fixture fix.

The fix is three pieces, all under `engine/tests/`:

- **`TestCertificateAuthority::crl_der`** signs an empty CRL (v2, `crlNumber`,
  `lastUpdate`/`nextUpdate` bracketing the run). Empty is the point: the backend
  is refusing for want of a document, not for want of trust, and this is that
  document.
- **`CrlServer`** serves it over plain HTTP. Plain on purpose - a revocation
  fetch that needed TLS would need the trust decision that is still being made,
  which is why RFC 5280 distribution points are `http:`.
- **The leaf carries `crlDistributionPoints`** naming that listener. On the
  *leaf*, per the refinement in this issue's 00:58 comment: the revocation check
  covers the chain below the root, and the self-signed root answers to nobody.

### It worked, and the skip is gone

Two commits on purpose, and the split is the argument.

`ab6d909` landed the fixture with the skip **retained**, because whether the
skip was still reachable is an observation about a revocation-checking backend
and no local run makes it - Linux never asks. Deleting it on the strength of a
leg that never asks would have replaced one unread claim with another, which is
precisely the defect #812 was filed about.

That commit's Windows leg then answered:
**2056 tests run, 2056 passed, 0 skipped, 0 failed** (job
[95970419762](https://github.com/athrvk/vayu/actions/runs/32220669108/job/95970419762)),
against 2 skipped on #817's run. Since the skip fires *only* on an error text
naming revocation, zero skips is the fetched CRL and a validated chain, observed
rather than inferred. `4cc2b0d` therefore deletes the skip and both helpers, and
a refusal naming revocation is an ordinary failure on every platform again -
which is what it should be once the fixture answers the question.

### The guard is the part that matters on the legs that never ask

`TheFixtureServesACaSignedCrlAtTheLeafsDistributionPoint` runs everywhere and
asserts, in order: the certificate the listener *presents* carries the
extension (read off the X509 object, not off the string passed in when it was
minted); the extension names where the CRL is actually served; the distribution
point answers 200; and what it serves parses as DER, is issued by this CA, is
signed by this CA's key, and has a `nextUpdate` in the future.

Without it the whole apparatus could rot - unparseable bytes, a wrong signer, a
stale window - and every OpenSSL leg would stay green while the Schannel one
went red for a reason pointing at trust rather than at the fixture. That is
`CLAUDE.md`'s non-empty-scan discipline applied to a fixture whose real consumer
is a backend this machine cannot run.

Also worth having in the diff rather than only here: the CRL path carries a
per-instance token, because Windows caches a fetched CRL **by URL**. Two runs on
one machine can land on the same ephemeral port, and the second would be served
the first run's CRL out of the cache - signed by a CA that no longer exists,
which reads as a revocation failure and would make this fixture flake for a
reason nothing in it names.

**Not in scope: part 2 of #819** - what a real user pasting a CRL-less internal
CA should get. It stays open on the issue, and this PR does not narrow it: the
change is test-only, so a user pasting an internal CA with no reachable
distribution point still gets `schannel: the revocation status is unknown` with
nothing naming the cause.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t` then `ctest --preset linux-dev --output-on-failure`:
**2055 tests, 100% passed, 0 failed** (65.14s at `4cc2b0d`; 61.86s at
`ab6d909`). Baseline on `f9a4cee` was 2054; the new guard is the difference. No
pre-existing failures.

CI on `ab6d909`, all three engine legs green - and the Windows one is the
evidence the second commit rests on: **2056 run, 2056 passed, 0 skipped, 0
failed**.

Engine-tests-only diff (one header, one test file, one Markdown file), so per
`CLAUDE.md`'s "scale the verification to what the change could actually break"
the app suite was not run - no TypeScript file is touched and no vitest test
could change colour.

Mutation-checked (mutation applied, rebuilt, confirmed red, reverted;
`git diff` against the pushed tree is empty):

| Mutation | Result |
|---|---|
| the `crlDistributionPoints` extension dropped from the leaf | guard fails: *"the certificate the listener presents carries no crlDistributionPoints extension, so no backend will ever fetch the CRL below"* - the other 4 stay green |
| the CRL signed by an unrelated key | guard fails: *"the CRL is not signed by this CA's key"* |
| `nextUpdate` set 60s in the past | guard fails: *"the CRL names no nextUpdate in the future, so a validator may treat it as stale"* |
| the listener serves an empty body | guard fails: *"nothing was served"* |
| baseline, unmutated | 5/5 `CustomCaVerificationTest`, 2055/2055 suite |

Every mutation leaves the four original cases passing on this leg, which is the
point being made: on a backend that never asks about revocation, only the guard
notices.

`clang-format` was run on both touched C++ files - unlike the three files in
#826, these two were clean at `HEAD` (0 violations each, checked before
editing), so `CLAUDE.md`'s "format only files you touched that were clean
before" says to keep them that way. Both are clean after.

`mkdocs build --strict` was not run and does not apply: no file under `docs/` is
touched.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commits: `engine/CLAUDE.md`'s `TransportPolicy` bullet, which
carried #817's note that the positive cases skip for want of a CRL. It now says
the fixture publishes one, why the distribution point is on the leaf, what the
new guard asserts, that all four cases run everywhere with the numbers behind
that, and that what #819 keeps is the owner decision. The `tls_server.hpp` and
`tls_verification_test.cpp` file headers are updated for the same reason.

Overlaps #826 (open, for #818) in `engine/CLAUDE.md` only, as #819 predicted -
different sentences of the same bullet, so the two merge cleanly in either order
(verified with `git merge-tree`, 0 conflicts).

## Related Issues

Closes #819 for part 1. Left **open** on the issue: part 2, the owner decision
on what a real user pasting a CRL-less internal CA should get, which is not an
implementation task - so this does not auto-close.

Acceptance criteria:

- [x] Criterion 1 - the cause confirmed from a run rather than inferred.
      Answered on the issue at 00:58 from #817's `e90a546`; this PR acts on it.
- [x] Criterion 2 - the positive cases run on every CI leg now, proven by the
      Windows leg going 2 skipped to 0.
- [x] Criterion 3 - the skip and its two helpers deleted, on that observation.
- [ ] Criterion 4 - owner decision on part 2. Stays with you.