### PR TITLE
perf(engine): precompile nlohmann/json.hpp and httplib.h

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -379,7 +379,24 @@ endif()
 # (C4651, fatal under /WX) rejects reuse from vayu-cli/vayu-engine outright.
 # httplib.h itself (24 files) is left out of the PCH for the same reason -
 # it is not something vayu_core's own compile settings actually cover.
-target_precompile_headers(vayu_core PRIVATE <nlohmann/json.hpp>)
+#
+# NOT MSVC, not NOT WIN32 - the exclusion is about the compiler's /Yu
+# interacting with sccache, not the platform (a clang-cl build would not
+# have this problem). Measured on two consecutive windows-latest CI runs
+# with the PCH on: only 48 of 222 build steps ever reached sccache as a
+# tracked request, unchanged between a cold run and a run immediately
+# after it (so warm on every other platform) - the second run reported
+# 100% hits on that same static 48 and was *slower* overall (19m21s)
+# than the first (18m06s), which was itself slower than the pre-PCH
+# baseline (8m07s at 79.6% hits). sccache is not caching the /Yu-bearing
+# compiles on MSVC; it appears to pass most of them straight to the real
+# compiler, uncached, every single run. ubuntu and macOS do not have
+# this problem - both went from a cold ~232-request run to a warm one
+# at 97-99% hits and roughly 6x-15x faster. Revisit if a future sccache
+# release fixes MSVC PCH support; do not re-enable without re-measuring.
+if(NOT MSVC)
+    target_precompile_headers(vayu_core PRIVATE <nlohmann/json.hpp>)
+endif()
 
 # ============================================================================
 # CLI Executable
@@ -402,7 +419,9 @@ if(VAYU_BUILD_CLI)
         vayu_warnings
         vayu_sanitizers
     )
-    target_precompile_headers(vayu-cli PRIVATE <nlohmann/json.hpp>)
+    if(NOT MSVC)
+        target_precompile_headers(vayu-cli PRIVATE <nlohmann/json.hpp>)
+    endif()
 
     # Not optional on Windows - see vayu_embed_windows_manifest above.
     vayu_embed_windows_manifest(vayu-cli)
@@ -452,7 +471,9 @@ if(VAYU_BUILD_ENGINE)
         vayu_warnings
         vayu_sanitizers
     )
-    target_precompile_headers(vayu-engine PRIVATE <nlohmann/json.hpp>)
+    if(NOT MSVC)
+        target_precompile_headers(vayu-engine PRIVATE <nlohmann/json.hpp>)
+    endif()
 
     # Not optional on Windows - see vayu_embed_windows_manifest above. This is
     # the binary the installer ships, so .github/check-windows-deps.py verifies
@@ -654,7 +675,9 @@ if(VAYU_BUILD_TESTS)
         vayu_warnings
         vayu_sanitizers
     )
-    target_precompile_headers(vayu_tests PRIVATE <nlohmann/json.hpp>)
+    if(NOT MSVC)
+        target_precompile_headers(vayu_tests PRIVATE <nlohmann/json.hpp>)
+    endif()
 
     # The test binary needs the manifest for two reasons: any test that opens a
     # TLS connection would otherwise run without ALPN, and `WindowsOsVersionShim`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -361,6 +361,22 @@ if(QUICKJS_FOUND)
 endif()
 
 # ============================================================================
+# Precompiled Header
+# ============================================================================
+
+# nlohmann/json.hpp is included in over half the engine's translation units
+# (93 of 174 .cpp files) and is expensive to parse on every one of them -
+# heavy template metaprogramming that gains nothing from being reparsed
+# identically each time. httplib.h (24 files) is the same shape of cost.
+# Precompiling both once on vayu_core and having every target that links it
+# reuse that PCH (REUSE_FROM) means the parse happens once per platform
+# instead of once per target.
+target_precompile_headers(vayu_core PRIVATE
+    <nlohmann/json.hpp>
+    <httplib.h>
+)
+
+# ============================================================================
 # CLI Executable
 # ============================================================================
 
@@ -372,7 +388,7 @@ if(VAYU_BUILD_CLI)
     target_include_directories(vayu-cli PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
-    
+
     target_link_libraries(vayu-cli PRIVATE
         vayu_core
         httplib::httplib
@@ -381,6 +397,7 @@ if(VAYU_BUILD_CLI)
         vayu_warnings
         vayu_sanitizers
     )
+    target_precompile_headers(vayu-cli REUSE_FROM vayu_core)
 
     # Not optional on Windows - see vayu_embed_windows_manifest above.
     vayu_embed_windows_manifest(vayu-cli)
@@ -430,6 +447,7 @@ if(VAYU_BUILD_ENGINE)
         vayu_warnings
         vayu_sanitizers
     )
+    target_precompile_headers(vayu-engine REUSE_FROM vayu_core)
 
     # Not optional on Windows - see vayu_embed_windows_manifest above. This is
     # the binary the installer ships, so .github/check-windows-deps.py verifies
@@ -631,6 +649,7 @@ if(VAYU_BUILD_TESTS)
         vayu_warnings
         vayu_sanitizers
     )
+    target_precompile_headers(vayu_tests REUSE_FROM vayu_core)
 
     # The test binary needs the manifest for two reasons: any test that opens a
     # TLS connection would otherwise run without ALPN, and `WindowsOsVersionShim`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -367,14 +367,19 @@ endif()
 # nlohmann/json.hpp is included in over half the engine's translation units
 # (93 of 174 .cpp files) and is expensive to parse on every one of them -
 # heavy template metaprogramming that gains nothing from being reparsed
-# identically each time. httplib.h (24 files) is the same shape of cost.
-# Precompiling both once on vayu_core and having every target that links it
-# reuse that PCH (REUSE_FROM) means the parse happens once per platform
-# instead of once per target.
-target_precompile_headers(vayu_core PRIVATE
-    <nlohmann/json.hpp>
-    <httplib.h>
-)
+# identically each time. Each target below precompiles it independently
+# (paying that parse cost once per target rather than once per TU) rather
+# than sharing one PCH via REUSE_FROM: REUSE_FROM requires every reusing
+# target's compiler invocation to match the PCH-owning target's exactly -
+# same macros, same linked libraries - and vayu_core is not: it does not
+# link httplib::httplib (only vayu-cli/vayu-engine/vayu_tests do, so a
+# shared PCH would compile httplib.h without vcpkg's CPPHTTPLIB_OPENSSL_SUPPORT
+# and silently drop httplib::SSLServer for every consumer), and its Windows
+# CRT/NOMINMAX defines are PRIVATE, so MSVC's own /Yu macro-parity check
+# (C4651, fatal under /WX) rejects reuse from vayu-cli/vayu-engine outright.
+# httplib.h itself (24 files) is left out of the PCH for the same reason -
+# it is not something vayu_core's own compile settings actually cover.
+target_precompile_headers(vayu_core PRIVATE <nlohmann/json.hpp>)
 
 # ============================================================================
 # CLI Executable
@@ -397,7 +402,7 @@ if(VAYU_BUILD_CLI)
         vayu_warnings
         vayu_sanitizers
     )
-    target_precompile_headers(vayu-cli REUSE_FROM vayu_core)
+    target_precompile_headers(vayu-cli PRIVATE <nlohmann/json.hpp>)
 
     # Not optional on Windows - see vayu_embed_windows_manifest above.
     vayu_embed_windows_manifest(vayu-cli)
@@ -447,7 +452,7 @@ if(VAYU_BUILD_ENGINE)
         vayu_warnings
         vayu_sanitizers
     )
-    target_precompile_headers(vayu-engine REUSE_FROM vayu_core)
+    target_precompile_headers(vayu-engine PRIVATE <nlohmann/json.hpp>)
 
     # Not optional on Windows - see vayu_embed_windows_manifest above. This is
     # the binary the installer ships, so .github/check-windows-deps.py verifies
@@ -649,7 +654,7 @@ if(VAYU_BUILD_TESTS)
         vayu_warnings
         vayu_sanitizers
     )
-    target_precompile_headers(vayu_tests REUSE_FROM vayu_core)
+    target_precompile_headers(vayu_tests PRIVATE <nlohmann/json.hpp>)
 
     # The test binary needs the manifest for two reasons: any test that opens a
     # TLS connection would otherwise run without ALPN, and `WindowsOsVersionShim`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -382,18 +382,19 @@ endif()
 #
 # NOT MSVC, not NOT WIN32 - the exclusion is about the compiler's /Yu
 # interacting with sccache, not the platform (a clang-cl build would not
-# have this problem). Measured on two consecutive windows-latest CI runs
-# with the PCH on: only 48 of 222 build steps ever reached sccache as a
-# tracked request, unchanged between a cold run and a run immediately
-# after it (so warm on every other platform) - the second run reported
-# 100% hits on that same static 48 and was *slower* overall (19m21s)
-# than the first (18m06s), which was itself slower than the pre-PCH
-# baseline (8m07s at 79.6% hits). sccache is not caching the /Yu-bearing
-# compiles on MSVC; it appears to pass most of them straight to the real
-# compiler, uncached, every single run. ubuntu and macOS do not have
-# this problem - both went from a cold ~232-request run to a warm one
-# at 97-99% hits and roughly 6x-15x faster. Revisit if a future sccache
-# release fixes MSVC PCH support; do not re-enable without re-measuring.
+# have this problem). sccache logged the large majority of Windows compile
+# requests (200 of 257 in the measured run) as non-cacheable because of the
+# /Fp flag, identical in a cold run and the run right after it - so the
+# "warm" run (19m21s) was slower than the cold one (18m06s), both far worse
+# than the no-PCH warm baseline (~2m). This is not a CI win on ubuntu/macOS
+# either, in the steady state #700's cache warming already produces: their
+# PCH-warm numbers are a wash against their own no-PCH warm baseline, and
+# macOS is a little slower (recurring PCH-creation cache misses each run).
+# Full measurements and the warm-vs-warm comparison that corrected the
+# original cold-vs-warm framing are on
+# https://github.com/athrvk/vayu/issues/805. Whatever value this PCH has is
+# in regimes CI's steady state does not exercise - a cold cache, or a local
+# build without sccache - not the PR pipeline itself.
 if(NOT MSVC)
     target_precompile_headers(vayu_core PRIVATE <nlohmann/json.hpp>)
 endif()


### PR DESCRIPTION
## Summary

`engine/CMakeLists.txt` had no precompiled header and no unity build anywhere. `nlohmann/json.hpp` is included in 93 of the engine's 174 `.cpp` files - a single-header library with real parse cost, reparsed identically in every one of those translation units.

**Current state: PCH is enabled for ubuntu and macOS only, guarded by `if(NOT MSVC)`.**

## What actually happened (measured, corrected after review)

1. First attempt shared one PCH across all four targets via `REUSE_FROM` and included `httplib.h`. Broke macOS (`vayu_core` doesn't link `httplib::httplib`, so the shared PCH compiled `httplib.h` without `CPPHTTPLIB_OPENSSL_SUPPORT` - `no member named SSLServer`) and Windows (`vayu_core`'s Windows CRT/NOMINMAX defines are `PRIVATE`, so `REUSE_FROM` consumers didn't match - MSVC's C4651 macro-parity check, fatal under `/WX`).
2. Scaled back: dropped `httplib.h`, dropped `REUSE_FROM`, each target precompiles `nlohmann/json.hpp` independently. Green on all three platforms.
3. **Windows: sccache does not cache `/Yu`-bearing (PCH) compiles under MSVC.** sccache logged 200 of 257 Windows compile requests as non-cacheable due to the `/Fp` flag, identical in a cold run and the run right after it - so "warm" (19m21s) was slower than cold (18m06s), both far worse than the no-PCH baseline (~2m). Now guarded behind `if(NOT MSVC)`; confirmed back to baseline afterward (2m03s, 99.52% hits, all requests tracked).
4. **ubuntu/macOS: also not a CI win, corrected after review caught the comparison error.** My original framing ("15m42s -> 1m00s") compared this branch's cold run (new compile flags = cache miss) against its own warm run - not against what CI already gets without the change. Checked against #829's actual no-PCH warm numbers (ubuntu 1m01s/99.56%, macOS 52s/99.56%), the PCH's warm numbers (1m00s, 1m09s) are a wash on ubuntu and a small regression on macOS (recurring PCH-creation cache misses every run).

Full measurements posted to [#805](https://github.com/athrvk/vayu/issues/805#issuecomment-5339260175).

## Net effect - the honest version

**This PR does not measurably speed up CI on any platform**, in the steady state #700's cache warming already produces. What it may still buy, unmeasured here: a cold cache (compile-flag changes, cache eviction) and local developer builds without sccache at all - both plausible beneficiaries of precompiling a 93-of-174-files header, neither exercised by this PR's CI runs. That's a real but different value case than "faster CI," and worth deciding on that basis rather than the number I originally reported.

## Test plan

- [x] CI green on all three platforms with the MSVC guard in place (confirmed, multiple runs)
- [x] ctest wall time unchanged across all runs, as expected for a compile-only change
- [x] No file collision with #805's remaining phases (this touches only `engine/CMakeLists.txt`)