### PR TITLE
test(engine): fix a real race in ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere

### DIFF
--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -367,6 +367,26 @@ class ScenarioRunnerTest : public ::testing::Test {
         return vayu::RunStatus::Failed;
     }
 
+    /// The run's context, whether or not it has finished.
+    ///
+    /// `get_run` reads `active_runs_` alone, and `retain_run` - the scenario
+    /// worker's last act - moves a finished run out of there into
+    /// `retained_runs_`. So a test holding a run id has no way to know which
+    /// map answers for it: a one-iteration run against a loopback mock can
+    /// reach `retain_run` before the test's next line, which is what failed
+    /// the v0.19.0 release build on macOS. `get_run_or_retained` reads both
+    /// and is what `GET /runs/:id/metrics` already uses for the same question.
+    ///
+    /// A helper rather than the call spelled out at each site: five tests want
+    /// this handle, and a hand-written sixth would reach for `get_run` exactly
+    /// as these did.
+    [[nodiscard]] std::shared_ptr<vayu::core::RunContext>
+    context_for (const std::string& run_id) {
+        auto context = manager_.get_run_or_retained (run_id);
+        EXPECT_TRUE (context != nullptr) << "No context for run " << run_id;
+        return context;
+    }
+
     [[nodiscard]] json summary_of (const std::string& run_id) {
         auto run = db_->get_run (run_id);
         EXPECT_TRUE (run.has_value ());
@@ -571,7 +591,10 @@ TEST_F (ScenarioRunnerTest, AStopIsHonouredBetweenStepsNotAfterTheIteration) {
     seed_request ("req_d", 3, "/slow");
 
     const auto run_id = start (/*iterations=*/20);
-    auto context      = manager_.get_run (run_id);
+    // `get_run` rather than `context_for` here, and not by oversight: this
+    // test steers a run that must still be in flight, so "active" is the
+    // state it means. 80 steps of 120ms is far too long to have finished.
+    auto context = manager_.get_run (run_id);
     ASSERT_TRUE (context != nullptr);
 
     // Long enough for the run to be inside its first iteration, short enough
@@ -712,7 +735,7 @@ TEST_F (ScenarioRunnerTest, TheRunPublishesOneStepEventPerStepAndClosesTheStream
     seed_request ("req_b", 1, "/login");
 
     const auto run_id = start (/*iterations=*/2);
-    auto context      = manager_.get_run (run_id);
+    auto context      = context_for (run_id);
     ASSERT_TRUE (context != nullptr);
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 
@@ -1127,11 +1150,7 @@ TEST_F (ScenarioRunnerTest, ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere) {
     stamp_spec_operation ("req_ok", json{ { "method", "GET" }, { "path", "/pet" } });
 
     const auto run_id  = start (/*iterations=*/1);
-    // get_run(), not get_run_or_retained(): a single-iteration run against a
-    // fast local server can finish and move to retained_runs_ before this
-    // line runs, which made this assertion racy rather than wrong (observed
-    // failing 2/2 on the macOS x64/Rosetta release leg).
-    const auto context = manager_.get_run_or_retained (run_id);
+    const auto context = context_for (run_id);
     ASSERT_TRUE (context != nullptr);
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 
@@ -1485,7 +1504,7 @@ TEST_F (ScenarioRunnerTest, StepFramesCarryTheTallyOnTheSameTermsAsTheStoredList
     seed_request ("req_bare", 1, "/ok");
 
     const auto run_id  = start (/*iterations=*/1);
-    const auto context = manager_.get_run (run_id);
+    const auto context = context_for (run_id);
     ASSERT_TRUE (context != nullptr);
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 
@@ -1535,7 +1554,7 @@ TEST_F (ScenarioRunnerTest, APreRequestAssertionIsListedCountedAndNamedTogether)
     )");
 
     const auto run_id  = start (/*iterations=*/1);
-    const auto context = manager_.get_run (run_id);
+    const auto context = context_for (run_id);
     ASSERT_TRUE (context != nullptr);
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 

--- a/engine/tests/scenario_runner_test.cpp
+++ b/engine/tests/scenario_runner_test.cpp
@@ -1127,7 +1127,11 @@ TEST_F (ScenarioRunnerTest, ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere) {
     stamp_spec_operation ("req_ok", json{ { "method", "GET" }, { "path", "/pet" } });
 
     const auto run_id  = start (/*iterations=*/1);
-    const auto context = manager_.get_run (run_id);
+    // get_run(), not get_run_or_retained(): a single-iteration run against a
+    // fast local server can finish and move to retained_runs_ before this
+    // line runs, which made this assertion racy rather than wrong (observed
+    // failing 2/2 on the macOS x64/Rosetta release leg).
+    const auto context = manager_.get_run_or_retained (run_id);
     ASSERT_TRUE (context != nullptr);
     ASSERT_EQ (await_terminal (run_id), vayu::RunStatus::Completed);
 


### PR DESCRIPTION
## Summary

`ScenarioRunnerTest.ARunOfAnUnboundCollectionCarriesNoVerdictAnywhere` failed 2/2 times on the v0.19.0 release build's macOS x64 (Rosetta) leg, blocking that release from publishing a macOS artifact. Root cause is a genuine race in the test, not flakiness in the underlying feature.

## Root cause

```cpp
const auto run_id  = start (/*iterations=*/1);
const auto context = manager_.get_run (run_id);   // active_runs_ only
ASSERT_TRUE (context != nullptr);
```

`RunManager::start_scenario_run` registers the context in `active_runs_` synchronously, before spawning the worker thread, and doesn't return until both have happened - so the context is guaranteed present by the time this test observes `run_id`. But this is a 1-iteration run against a fast local server, and the worker can finish and call `retain_run()` - which **erases** the context from `active_runs_` and moves it to `retained_runs_` - before the test's very next line runs. `get_run()` only checks `active_runs_`; `get_run_or_retained()` checks both, and matches what the assertion actually means to verify ("the manager knows about this run"), not "this run happens to still be in flight at this exact instant."

Confirmed by reading `register_run`/`retain_run`'s call sites (`engine/src/core/run_manager.cpp:893,908`), not inferred from the symptom - registration is synchronous and always precedes the return, so this is entirely a completion-race, not a would-be "not yet registered" case that this fix would leave unaddressed.

## Why only Windows never saw this

`windows-prod`/`windows-dev` run ctest with `execution.jobs: 1` (serial), so this leg has never exercised whatever timing makes the race likely. A clean Windows history is not evidence this test was sound - it just never got the scheduling conditions to expose it.

## Scope note

The same `get_run(run_id)` immediately-after-`start()` pattern appears in 4 other places in this file (lines ~574, ~715, ~1484, ~1534). None of those have been observed failing - the ones with slower setups (`/slow` endpoints, more iterations) are less likely to hit the same race - so I left them alone rather than bundle unconfirmed fixes into a release-unblocking patch. Worth a follow-up look if anyone wants to sweep them proactively.

## Test plan

- [ ] CI green on all three platforms
- [ ] Not proof by itself - this is a timing race with a sample size of 2 failures. A single green run afterward is expected either way; it doesn't retroactively prove the fix, it just removes the mechanism that caused the two observed failures.