### PR TITLE
test(engine/tls): a registered client certificate on a wire, and the refusals that read as internal errors (#802)

### DIFF
--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -691,6 +691,19 @@ own `SSL_ERROR` - the validation on the way in is about the *shape* of the
 paste, deliberately, so a chain curl would accept is never refused by a parser
 of ours.
 
+**A TLS connection that never answers is an `SSL_ERROR` too**, whatever code
+libcurl put on it. The mapping needs that rule because the interesting
+refusals do not arrive as TLS errors: under TLS 1.3 the server's verdict about
+the *client* - a certificate it will not accept, or one it demanded and did not
+get - reaches us after our own handshake has finished, so libcurl reports the
+generic receive error of a connection that went away, carrying the alert in its
+message. A key the stored passphrase does not open arrives as a generic
+argument error in the same way. All three used to surface as `INTERNAL_ERROR`,
+which says the failure was ours. The rule applies only where the mapping has no
+answer of its own, and only to an `https` transfer that produced no response
+line at all - so a `4xx`, a timeout, a refused connection and a proxy failure
+all keep the code they had (issue #802).
+
 Per-request, `verifySSL: false` turns verification off for one endpoint
 entirely (see [POST /execute](#post-execute)); trusting the authority here is
 the answer that keeps verification on everywhere else.
@@ -2068,12 +2081,19 @@ fails at handshake time as an SSL error against the endpoint, which reads as
 A cert-authenticated exchange says so. `POST /execute` returns
 `clientCertificate` on the response (`""` when none matched) and the stored
 trace carries the same value under the same name, so a restored response names
-the entry a live one named. The format the certificate files must be in is the
-TLS backend's business, and the two backends differ - OpenSSL (Linux and macOS)
-takes a PEM certificate and key pair; Schannel (Windows) expects a PKCS#12 file
-or a certificate store reference. The engine passes the paths through
-unchanged, and a format a backend rejects fails at handshake time with
-libcurl's own error.
+the entry a live one named.
+
+**A registered pair goes out as PEM.** The engine writes the two paths and no
+certificate *type*, so libcurl reads them in its default format - a PEM
+certificate and a PEM key, optionally encrypted under the stored passphrase.
+That is what every OpenSSL-backed build takes, which is Linux and macOS, and
+the handshake is asserted on a wire there (a design send, an SSE stream, a load
+run and a `pm.sendRequest` against a listener that demands a client
+certificate). **Windows cannot present one yet**: that build is Schannel-backed
+and wants a PKCS#12 file or a certificate-store reference, neither of which
+libcurl will read without being told the type. Issue #833 tracks giving a row
+its format; until it lands, an entry registered on Windows fails at handshake
+time with libcurl's own error.
 
 ### GET /client-certificates
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -295,14 +295,22 @@ Three things worth knowing before you design around them:
   so the skip and its helpers are gone and a refusal naming revocation is an
   ordinary failure again. What #819 keeps is the user-facing half, which is a
   decision rather than a fix: someone pasting an internal CA with no reachable
-  distribution point gets the same refusal, and no doc says so. Still
-  structural, not on a wire: the *client* certificate's
-  handshake, tracked by #802 - which should reuse this CRL rather than build a
-  second one.
+  distribution point gets the same refusal, and no doc says so. **The client
+  certificate's handshake is on a wire too now** (#802): the same `TlsServer`,
+  built with a second CA, demands a certificate that authority signed, so it
+  reuses this CRL rather than standing up a second listener.
   A proxy-hop failure is **`ErrorCode::ProxyError`**, distinct from
   the target's `ConnectionFailed` - and `curl_to_error` now takes the handle,
   because a 407 answered to a CONNECT is a plain `CURLE_RECV_ERROR` and only
-  `CURLINFO_HTTP_CONNECTCODE` remembers a proxy said no.
+  `CURLINFO_HTTP_CONNECTCODE` remembers a proxy said no. The handle answers a
+  second question for the same reason (#802): **an https transfer that failed
+  for a code with no mapping and produced no response line is an `SslError`**,
+  not the `InternalError` the default arm used to give it. Every
+  client-certificate refusal lands there - under TLS 1.3 the server's verdict
+  about the client arrives after the client's handshake finishes, so curl
+  reports `CURLE_RECV_ERROR` with the alert in its message. The rule is the
+  *shape*, never a list of codes, and it is consulted only after every mapping
+  with a meaning of its own has been tried.
 - **A client certificate belongs to a host, not to a request** (#707,
   `client_certificates`). The registry rides *inside* the `TransportPolicy`, so
   it reaches every outbound path with no per-site wiring and is read once per
@@ -316,7 +324,13 @@ Three things worth knowing before you design around them:
   entry is recorded on `Response::client_certificate` and travels both design
   funnels (live body and stored trace) under `clientCertificate`, deliberately
   *not* on the load path: it is a per-transfer string for a fact that is
-  constant for the run.
+  constant for the run. **What goes out is a PEM pair and nothing else**
+  (`tests/mutual_tls_test.cpp`, #802): the applier writes no
+  `CURLOPT_SSLCERTTYPE`, so libcurl reads both files in its default format -
+  right on every OpenSSL leg, and the reason the Schannel build, which wants
+  PKCS#12, can present nothing at all (#833). The live fixture skips that leg
+  with the reason printed and scans the applier so the skip cannot outlive its
+  cause.
 
 ## Request composition (engine-owned - POST /compose)
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -471,6 +471,7 @@ if(VAYU_BUILD_TESTS)
         tests/transport_policy_test.cpp
         tests/tls_verification_test.cpp
         tests/client_certificates_test.cpp
+        tests/mutual_tls_test.cpp
         tests/requests_route_test.cpp
         tests/examples_route_test.cpp
         tests/specs_route_test.cpp

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -475,6 +475,59 @@ bool proxy_refused_tunnel (CURL* curl) {
     return connect_code >= 400;
 }
 
+/**
+ * Whether a failure with no mapping of its own happened on a TLS connection
+ * that never answered - the shape every client-certificate refusal takes, and
+ * one no CURLcode names (issue #802).
+ *
+ * Three failures arrive this way and not one of them is internal to this
+ * engine: a key the stored passphrase does not open
+ * (`CURLE_BAD_FUNCTION_ARGUMENT` here, where the curl command line reports
+ * `CURLE_SSL_CERTPROBLEM` for the same event), a certificate the server will
+ * not accept, and a certificate the server demanded and did not get. The last
+ * two are `CURLE_RECV_ERROR`, because under TLS 1.3 the server's verdict about
+ * the *client* arrives after the client's own handshake has finished - so
+ * libcurl reports the ordinary code of a connection that went away
+ * mid-request, carrying the alert in its message ("tlsv13 alert certificate
+ * required", "tlsv1 alert unknown ca").
+ *
+ * The test is deliberately about that shape rather than about those three
+ * codes. An enumeration would be a list to extend every time a backend spread
+ * one event across another code - the trap `proxy_refused_tunnel` above exists
+ * to avoid - and it is consulted only where the mapping has already run out of
+ * meanings, so nothing with an answer of its own reaches it.
+ *
+ * What it costs: an https endpoint that accepts a connection and hangs up
+ * before answering for a reason of its own now reads as a TLS error. It read
+ * as an *internal* error before, which is worse - nothing inside this engine
+ * failed - and libcurl's own message travels with the code either way.
+ */
+bool tls_connection_never_answered (CURL* curl) {
+    if (!curl) {
+        return false;
+    }
+    char* scheme = nullptr;
+    if (curl_easy_getinfo (curl, CURLINFO_SCHEME, &scheme) != CURLE_OK || scheme == nullptr) {
+        return false;
+    }
+    // curl reports the scheme upper-cased; compared case-insensitively anyway,
+    // because that is a presentation detail of one version.
+    std::string lowered (scheme);
+    std::transform (lowered.begin (), lowered.end (), lowered.begin (),
+    [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
+    if (lowered != "https") {
+        return false;
+    }
+
+    // A response line, even a 4xx, means the TLS layer did its job and whatever
+    // failed after it is not a trust decision.
+    long response_code = 0;
+    if (curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &response_code) != CURLE_OK) {
+        return false;
+    }
+    return response_code == 0;
+}
+
 } // namespace
 
 Error curl_to_error (CURL* curl, CURLcode code, const char* error_buffer) {
@@ -511,7 +564,10 @@ Error curl_to_error (CURL* curl, CURLcode code, const char* error_buffer) {
         error.code = ErrorCode::SslError;
         break;
     case CURLE_URL_MALFORMAT: error.code = ErrorCode::InvalidUrl; break;
-    default: error.code = ErrorCode::InternalError; break;
+    default:
+        error.code = tls_connection_never_answered (curl) ? ErrorCode::SslError :
+                                                            ErrorCode::InternalError;
+        break;
     }
 
     return error;

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -3,21 +3,17 @@
  * @brief The client-certificate registry (issue #707): what a row may say, how
  *        a target picks one, and that the pick reaches every driver.
  *
- * **What is not here, and why.** There is no live mTLS handshake. A TLS server
- * exists in the suite now - #812 added `tests/tls_server.hpp` and the
- * `cpp-httplib[openssl]` feature it needs - so the first of the two reasons
- * this was deferred is gone, and what remains is the second and harder one:
- * the certificate *formats* the CI backends accept differ (Schannel wants a
- * PKCS#12 or a store thumbprint where OpenSSL wants a PEM pair), so a fixture
- * that presents one identity everywhere would fail on Windows while proving
- * nothing about the code under test. #802 owns that matrix, and is expected to
- * extend `TlsServer` rather than stand up a second listener. What that
- * leaves is covered three ways instead: the lookup is unit-tested at the
- * boundary, the *outcome* of the lookup is asserted end-to-end through the
- * design and stream drivers (both record the entry they matched on the
- * response), and the backend's willingness to take the three curl options at
- * all is probed on each platform the way `TlsBackend` probes `CURLOPT_CAINFO`.
- * The live handshake is tracked separately.
+ * **The live handshake is in `mutual_tls_test.cpp`** (#802), not here, and the
+ * split is deliberate: this file is about the *registry* - which row a target
+ * picks, and what a row may say - so its material is the bytes
+ * `not-a-real-certificate`, and nothing in it puts a certificate on a wire.
+ * That keeps the lookup asserted at the boundary, the lookup's *outcome*
+ * asserted end to end through the design and stream drivers (both record the
+ * entry they matched), and the backend's willingness to take the three curl
+ * options at all probed per platform the way `TlsBackend` probes
+ * `CURLOPT_CAINFO` - while the question of whether the bytes behind those paths
+ * are accepted by a server demanding a certificate is asked where a server
+ * exists to answer it.
  */
 
 #include <curl/curl.h>

--- a/engine/tests/mutual_tls_test.cpp
+++ b/engine/tests/mutual_tls_test.cpp
@@ -1,0 +1,525 @@
+/**
+ * @file tests/mutual_tls_test.cpp
+ * @brief A registered client certificate on a wire (issue #802).
+ *
+ * `client_certificates_test.cpp` proves the registry: what a row may say, which
+ * row a target picks, and that the pick reaches every driver. All of that is
+ * true of paths that hold no certificate at all - the files there are the bytes
+ * `not-a-real-certificate`, because nothing in that suite puts one on a wire.
+ * What it cannot answer is the claim #707 was opened for: that the bytes
+ * libcurl loads from those paths are **accepted by a server demanding a client
+ * certificate**.
+ *
+ * That is a handshake, so these tests hold one. `TlsServer` built with a second
+ * CA demands a certificate that authority signed (`tls_server.hpp`), and each
+ * case drives a shipped driver at it through a policy resolved from a real
+ * registry row - `POST /client-certificates` writes the row, the transport
+ * policy reads it back, and nothing here assembles a curl handle of its own.
+ *
+ * **Why the refusals are not optional.** A listener that asked for a
+ * certificate and accepted the handshake anyway would make every success below
+ * meaningless, so the suite asserts a failure with no entry registered, and a
+ * failure with an entry whose identity a *different* CA signed. The second is
+ * what separates "a certificate was presented" from "this certificate was
+ * accepted".
+ *
+ * ## The per-backend format matrix
+ *
+ * A client identity does not travel in one shape:
+ *
+ * | Backend | This build | A client identity arrives as |
+ * |---|---|---|
+ * | OpenSSL (Linux, macOS) | yes | a PEM certificate and a PEM key |
+ * | Schannel (Windows) | yes | PKCS#12, or a certificate-store reference |
+ *
+ * The engine writes `CURLOPT_SSLCERT` / `CURLOPT_SSLKEY` and **no**
+ * `CURLOPT_SSLCERTTYPE`, so what it can present is libcurl's default, a PEM
+ * pair - which is every backend in this repo except Schannel. The Windows leg
+ * therefore skips these cases, loudly and with that reason, rather than
+ * asserting a shape it cannot produce; `NoBackendIsSkippedForAReasonThatWentAway`
+ * is the guard that stops the skip from outliving its cause, and #833 tracks
+ * giving the registry a certificate format so the skip can go away entirely.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "temp_database.hpp"
+#include "tls_backend.hpp"
+#include "tls_server.hpp"
+#include "vayu/db/database.hpp"
+#include "vayu/http/client.hpp"
+#include "vayu/http/event_loop.hpp"
+#include "vayu/http/sse_stream.hpp"
+#include "vayu/http/transport_policy.hpp"
+#include "vayu/runtime/script_engine.hpp"
+
+namespace vayu::http::routes {
+// Defined in client_certificates.cpp; returns {http_status, json_body}.
+std::pair<int, nlohmann::json>
+create_client_certificate_response (vayu::db::Database& db, const nlohmann::json& json);
+} // namespace vayu::http::routes
+
+namespace vayu::http {
+namespace {
+
+using nlohmann::json;
+using vayu::tests::CertificateAndKey;
+using vayu::tests::ClientIdentityFormat;
+using vayu::tests::TestCertificateAuthority;
+using vayu::tests::TlsServer;
+namespace routes = vayu::http::routes;
+
+// ---------------------------------------------------------------------------
+// What this build can host
+// ---------------------------------------------------------------------------
+
+/// Why @p backend cannot present the identity this fixture mints, or empty if
+/// it can. Phrased as a sentence because it is printed by a skip: a leg that
+/// silently runs nothing is worse than one that runs nothing and says why.
+std::string cannot_present_a_pem_pair (std::string_view backend) {
+    switch (vayu::tests::client_identity_format (backend)) {
+    case ClientIdentityFormat::PemPair: return {};
+    case ClientIdentityFormat::Pkcs12:
+        return "TLS backend '" + std::string (backend) +
+        "' takes a client identity as PKCS#12 or as a certificate-store "
+        "reference, never as the PEM pair libcurl reads by default - and the "
+        "engine writes no CURLOPT_SSLCERTTYPE, so a PEM pair is the only shape "
+        "it can present. Registering a PKCS#12 file here would fail on the "
+        "format rather than on anything this suite is about. Tracked in #833.";
+    case ClientIdentityFormat::Unknown: break;
+    }
+    return "TLS backend '" + std::string (backend) +
+    "' is one no statement in this repo covers, so what a client identity must "
+    "look like for it is unknown - decide and record it rather than letting "
+    "this fixture guess.";
+}
+
+// ---------------------------------------------------------------------------
+// Fixture material
+// ---------------------------------------------------------------------------
+
+/**
+ * A PEM file on disk, removed when the test ends.
+ *
+ * The registry stores **paths** and libcurl opens them itself, so a client
+ * identity is the one piece of material here that cannot stay in memory the
+ * way the listener's does. It lands in the per-process scratch directory
+ * (`temp_database.hpp`), lives for one test, and is named after it.
+ */
+class PemFile {
+    public:
+    PemFile (std::string name, const std::string& contents)
+    : path_ (std::move (name)) {
+        std::ofstream out (path_, std::ios::binary | std::ios::trunc);
+        out << contents;
+        out.close ();
+        if (!out) {
+            throw std::runtime_error ("mutual_tls_test: could not write " + path_);
+        }
+    }
+    ~PemFile () {
+        std::error_code ec;
+        std::filesystem::remove (path_, ec);
+    }
+    PemFile (const PemFile&)            = delete;
+    PemFile& operator= (const PemFile&) = delete;
+
+    const std::string& path () const {
+        return path_;
+    }
+
+    private:
+    std::string path_;
+};
+
+/// A client identity as the registry wants it: two paths, and optionally a
+/// passphrase the key is actually encrypted under.
+struct ClientIdentity {
+    PemFile certificate;
+    PemFile key;
+};
+
+Request get_request (const std::string& url) {
+    Request request;
+    request.method = HttpMethod::GET;
+    request.url    = url;
+    return request;
+}
+
+/**
+ * A design send with exactly the transport the settings resolved to - the same
+ * path `POST /execute` takes.
+ *
+ * A refused handshake is a `Response` carrying `error_code`, not a `Result`
+ * error: `Client::send` reserves the error arm for a request it could not even
+ * attempt. Same shape `tls_verification_test.cpp` reads.
+ */
+Response send_through (const TransportPolicy& transport, const std::string& url) {
+    ClientConfig config;
+    config.transport = transport;
+    Client client (config);
+    auto result = client.send (get_request (url));
+    EXPECT_TRUE (result.is_ok ())
+    << "the send was never attempted: " << result.error ().message;
+    return result.is_ok () ? result.value () : Response{};
+}
+
+class MutualTlsTest : public ::testing::Test {
+    protected:
+    void SetUp () override {
+        if (const std::string why =
+            cannot_present_a_pem_pair (vayu::tests::tls_backend_name ());
+            !why.empty ()) {
+            GTEST_SKIP () << why;
+        }
+        vayu::tests::remove_database_files (path_);
+        db_ = std::make_unique<vayu::db::Database> (path_);
+        db_->seed_default_config ();
+        // The listener's own certificate is signed by a CA no store knows, so
+        // the client half of the exchange needs it pasted in - otherwise every
+        // case below would fail on *server* verification and say nothing about
+        // the client certificate it was written for.
+        set_config ("customCaCertificates", ca_.pem ());
+        // The default `proxyMode` is `environment`: a runner exporting
+        // `https_proxy` would send this handshake to a proxy instead of to the
+        // fixture on loopback, and an assertion that turns on an environment
+        // variable is not an assertion about this engine.
+        set_config ("proxyMode", "off");
+    }
+
+    void TearDown () override {
+        db_.reset ();
+        vayu::tests::remove_database_files (path_);
+        // The materialized bundle is written beside the database and is not one
+        // of the database's own files.
+        std::error_code ec;
+        std::filesystem::remove ("ca-bundle.pem", ec);
+    }
+
+    void set_config (const std::string& key, const std::string& value) {
+        auto entry = db_->get_config_entry (key);
+        ASSERT_TRUE (entry.has_value ()) << key << " is not seeded";
+        entry->value = value;
+        db_->save_config_entry (*entry);
+    }
+
+    /// An identity @p issuer signed, written where the registry can name it.
+    /// @p passphrase encrypts the key when it is not empty.
+    ClientIdentity identity (const std::string& name,
+    const TestCertificateAuthority& issuer,
+    const std::string& passphrase = {}) {
+        const CertificateAndKey minted =
+        issuer.issue ("vayu-test-client", "DNS:vayu-test-client");
+        return ClientIdentity{ PemFile{ name + "_cert.pem", minted.pem () },
+            PemFile{ name + "_key.pem",
+            passphrase.empty () ? minted.key_pem () : minted.encrypted_key_pem (passphrase) } };
+    }
+
+    /// Register an entry the way the app does, through the route - so the row
+    /// under test is one the shipped validation accepted.
+    void register_entry (const ClientIdentity& id,
+    std::optional<int> port       = std::nullopt,
+    const std::string& passphrase = {}) {
+        json payload = { { "host", "127.0.0.1" },
+            { "certPath", id.certificate.path () }, { "keyPath", id.key.path () } };
+        if (port) {
+            payload["port"] = *port;
+        }
+        if (!passphrase.empty ()) {
+            payload["passphrase"] = passphrase;
+        }
+        const auto [status, created] =
+        routes::create_client_certificate_response (*db_, payload);
+        ASSERT_EQ (status, 200) << created.dump ();
+    }
+
+    TransportPolicy policy () {
+        TransportPolicy resolved = resolve_transport_policy (*db_);
+        EXPECT_FALSE (resolved.ca_bundle_path.empty ())
+        << "the fixture CA was never materialized, so the listener's own "
+           "certificate would be refused before any client certificate is read";
+        return resolved;
+    }
+
+    /// Signs both the listener's certificate and the client identities it
+    /// accepts. One authority for both ends keeps the setup readable; the
+    /// identities that must be *refused* come from `stranger_`.
+    TestCertificateAuthority ca_{ "Vayu Test CA (mTLS)" };
+    TestCertificateAuthority stranger_{ "Vayu Test CA (unrelated)" };
+    std::string path_ = "test_mutual_tls.db";
+    std::unique_ptr<vayu::db::Database> db_;
+};
+
+// ---------------------------------------------------------------------------
+// The fixture's own guards
+// ---------------------------------------------------------------------------
+
+TEST (MutualTlsBackend, ClassifiesTheBackendsThisRepoCanBeBuiltAgainst) {
+    // Runs everywhere, including where the skip below is not taken: a
+    // classifier that answered "PEM pair" to everything would be green on
+    // Linux and macOS and would only be caught by the Windows leg - the rule
+    // that a per-platform branch must not be asserted only where it happens to
+    // be taken.
+    EXPECT_EQ (vayu::tests::client_identity_format ("OpenSSL/3.6.3"),
+    ClientIdentityFormat::PemPair);
+    EXPECT_EQ (vayu::tests::client_identity_format ("Schannel"), ClientIdentityFormat::Pkcs12);
+    EXPECT_EQ (vayu::tests::client_identity_format ("GnuTLS/3.8.4"),
+    ClientIdentityFormat::Unknown);
+    EXPECT_EQ (vayu::tests::client_identity_format (""), ClientIdentityFormat::Unknown);
+
+    EXPECT_TRUE (cannot_present_a_pem_pair ("OpenSSL/3.6.3").empty ());
+    EXPECT_FALSE (cannot_present_a_pem_pair ("Schannel").empty ());
+    EXPECT_FALSE (cannot_present_a_pem_pair ("GnuTLS/3.8.4").empty ());
+}
+
+TEST (MutualTlsBackend, NoBackendIsSkippedForAReasonThatWentAway) {
+    // The skip above rests on one fact about the shipped code: the applier
+    // writes no certificate *type*, so libcurl's default - a PEM pair - is the
+    // only shape the engine can present. The day that changes (#833), the
+    // Windows leg stops being unhostable, and a skip nobody revisits would
+    // quietly keep it dark. So the fact is read off the source rather than
+    // remembered.
+    const std::filesystem::path applier = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
+    "src" / "http" / "event_loop" / "curl_utils.cpp";
+    std::ifstream file (applier);
+    std::stringstream buffer;
+    buffer << file.rdbuf ();
+    const std::string source = buffer.str ();
+
+    // A guard reading an empty string passes forever.
+    ASSERT_GT (source.size (), 1000u) << "read nothing from " << applier;
+    ASSERT_NE (source.find ("CURLOPT_SSLCERT"), std::string::npos)
+    << "the client-certificate options are not in " << applier
+    << " any more, so this suite is asserting against the wrong file";
+
+    EXPECT_EQ (source.find ("CURLOPT_SSLCERTTYPE"), std::string::npos)
+    << "the applier now names a certificate type, so a backend that wants "
+       "PKCS#12 may be hostable after all - revisit the skip in this file "
+       "(#833) instead of leaving Windows dark";
+}
+
+TEST (MutualTlsErrorMapping, AnUnreachableHttpsEndpointIsStillAConnectionFailure) {
+    // The other half of the rule the refusals below rest on. `curl_to_error`
+    // reads an https transfer that produced no response line as a TLS failure
+    // *only* where the mapping has no answer of its own - so a port nothing
+    // listens on, which fails before any TLS happens and has an answer, must
+    // keep it. Widen the rule to "any https failure" and this test is what
+    // says so. It runs on every platform, including the ones the fixture below
+    // skips: the mapping is not backend-specific.
+    TransportPolicy transport;
+    transport.proxy_mode = ProxyMode::Off;
+
+    const Response response = send_through (transport, "https://127.0.0.1:1/hello");
+
+    EXPECT_EQ (response.status_code, 0);
+    EXPECT_EQ (response.error_code, ErrorCode::ConnectionFailed)
+    << "an endpoint that could not be reached now reads as a TLS failure: "
+    << to_string (response.error_code) << ": " << response.error_message;
+}
+
+TEST_F (MutualTlsTest, TheListenerRefusesAClientWithNoCertificate) {
+    // Without this, every success below would prove nothing: a listener that
+    // asked for a certificate and shrugged when none came would answer 200 to
+    // an engine that presented nothing at all.
+    TlsServer server (ca_, ca_);
+
+    const TransportPolicy resolved = policy ();
+    ASSERT_TRUE (resolved.client_certificates.empty ())
+    << "no entry was registered";
+    const Response response = send_through (resolved, server.url ("/hello"));
+
+    EXPECT_EQ (response.status_code, 0)
+    << "the listener answered a client that presented no certificate";
+    EXPECT_EQ (response.error_code, ErrorCode::SslError)
+    << "a handshake the server refused must read as a TLS error rather than as "
+       "an unreachable endpoint: "
+    << to_string (response.error_code) << ": " << response.error_message;
+}
+
+TEST_F (MutualTlsTest, AnIdentityFromAnotherAuthorityIsRefused) {
+    // The case that tells "a certificate was presented" apart from "this
+    // certificate was accepted". The identity is well-formed and loads
+    // cleanly; only its issuer is wrong.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity stranger = identity ("stranger", stranger_);
+    register_entry (stranger);
+
+    const Response response = send_through (policy (), server.url ("/hello"));
+
+    EXPECT_EQ (response.status_code, 0)
+    << "an identity signed by an authority the listener does not trust was "
+       "accepted";
+    EXPECT_EQ (response.error_code, ErrorCode::SslError)
+    << to_string (response.error_code) << ": " << response.error_message;
+}
+
+// ---------------------------------------------------------------------------
+// The drivers
+// ---------------------------------------------------------------------------
+
+TEST_F (MutualTlsTest, ADesignSendCompletesTheHandshakeAndNamesTheEntry) {
+    TlsServer server (ca_, ca_);
+    const ClientIdentity client = identity ("design", ca_);
+    register_entry (client);
+
+    const Response response = send_through (policy (), server.url ("/hello"));
+
+    ASSERT_EQ (response.error_code, ErrorCode::None)
+    << "the registered certificate did not complete the handshake: "
+    << to_string (response.error_code) << ": " << response.error_message;
+    EXPECT_EQ (response.status_code, 200);
+    EXPECT_NE (response.body.find ("over"), std::string::npos);
+    // The same field the design funnels print, now on an exchange that could
+    // not have happened without the entry it names.
+    EXPECT_EQ (response.client_certificate, "127.0.0.1");
+}
+
+TEST_F (MutualTlsTest, AnSseStreamPresentsTheCertificate) {
+    // The driver that had no proxy option at all before #705, and would have
+    // been the one to miss certificates too if each driver configured its own
+    // transport.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity client = identity ("sse", ca_);
+    register_entry (client);
+
+    SseStreamRequest spec;
+    spec.run_id    = "run-mtls-sse";
+    spec.request   = get_request (server.url ("/events"));
+    spec.transport = policy ();
+
+    SseStreamContext context (spec.run_id, spec.limits);
+    const Response response = consume_sse_stream (spec, context);
+
+    ASSERT_EQ (response.error_code, ErrorCode::None)
+    << to_string (response.error_code) << ": " << response.error_message;
+    EXPECT_EQ (response.status_code, 200);
+    EXPECT_EQ (response.client_certificate, "127.0.0.1");
+}
+
+TEST_F (MutualTlsTest, ALoadRunPresentsTheCertificate) {
+    // The load path resolves the policy once at run start and matches per
+    // transfer from that snapshot, and its handles are pooled - so this also
+    // says a reused handle keeps presenting the identity.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity client = identity ("load", ca_);
+    register_entry (client);
+
+    EventLoopConfig config;
+    config.transport = policy ();
+    EventLoop loop (config);
+    loop.start ();
+    std::vector<Request> requests;
+    for (int i = 0; i < 3; ++i) {
+        requests.push_back (get_request (server.url ("/hello")));
+    }
+    const auto batch = loop.execute_batch (requests);
+    loop.stop ();
+
+    EXPECT_EQ (batch.successful, 3u);
+    EXPECT_EQ (batch.failed, 0u);
+}
+
+TEST_F (MutualTlsTest, PmSendRequestPresentsTheCertificate) {
+    // `pm.sendRequest` builds its own ClientConfig inside the script engine, so
+    // the registry reaches it through the context or not at all - and a script
+    // that logs in against an mTLS endpoint is exactly the transfer #707's
+    // "a certificate belongs to a host, not to a request" was written for.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity client = identity ("script", ca_);
+    register_entry (client);
+
+    vayu::runtime::ScriptConfig script_config;
+    script_config.timeout_ms         = 10000;
+    script_config.allow_send_request = true;
+    vayu::runtime::ScriptEngine engine (script_config);
+
+    Request request;
+    Response response;
+    response.status_code = 200;
+    auto ctx = vayu::runtime::ScriptContext::for_test (request, response);
+    vayu::Environment env;
+    ctx.environment = &env;
+    ctx.transport   = policy ();
+
+    const auto result = engine.execute ("pm.sendRequest('" + server.url ("/hello") +
+    "', function (err, res) { pm.test('reached', function () { "
+    "pm.expect(res.code).to.eql(200); }); });",
+    ctx);
+
+    ASSERT_TRUE (result.success) << result.error_message;
+    ASSERT_EQ (result.tests.size (), 1u);
+    EXPECT_TRUE (result.tests.front ().passed)
+    << "the script's send did not complete the handshake: "
+    << result.tests.front ().error_message;
+}
+
+// ---------------------------------------------------------------------------
+// Precedence and the passphrase, on a wire
+// ---------------------------------------------------------------------------
+
+TEST_F (MutualTlsTest, ThePortEntryOutranksTheCatchAllOnAWire) {
+    // Precedence is unit-tested in `client_certificates_test.cpp` against a
+    // registry in memory. Here the two entries hold *different identities* and
+    // only one of them is one the listener accepts, so the handshake itself is
+    // the assertion: pick the catch-all and this connection never opens.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity accepted = identity ("port_entry", ca_);
+    const ClientIdentity refused  = identity ("catch_all", stranger_);
+    register_entry (refused);
+    register_entry (accepted, server.port ());
+
+    const Response response = send_through (policy (), server.url ("/hello"));
+
+    ASSERT_EQ (response.error_code, ErrorCode::None)
+    << "the catch-all's identity went out on a port another entry names: "
+    << to_string (response.error_code) << ": " << response.error_message;
+    EXPECT_EQ (response.status_code, 200);
+    EXPECT_EQ (
+    response.client_certificate, "127.0.0.1:" + std::to_string (server.port ()));
+}
+
+TEST_F (MutualTlsTest, AnEncryptedKeyOpensWithItsPassphraseAndNotWithout) {
+    // Both halves in one test on purpose: the failure alone would pass against
+    // an engine that never sends the passphrase at all, and the success alone
+    // would pass against a key that was never encrypted.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity client = identity ("passphrase", ca_, "hunter2");
+    register_entry (client, std::nullopt, "hunter2");
+
+    const Response opened = send_through (policy (), server.url ("/hello"));
+    ASSERT_EQ (opened.error_code, ErrorCode::None)
+    << "the stored passphrase did not open the key: " << to_string (opened.error_code)
+    << ": " << opened.error_message;
+    EXPECT_EQ (opened.status_code, 200);
+
+    // The same row, the same key, a passphrase that is not the one it was
+    // encrypted under.
+    auto row       = db_->get_client_certificates ().front ();
+    row.passphrase = "not-the-passphrase";
+    db_->save_client_certificate (row);
+
+    const Response refused = send_through (policy (), server.url ("/hello"));
+    EXPECT_EQ (refused.status_code, 0)
+    << "a key that could not be opened still connected";
+    EXPECT_EQ (refused.error_code, ErrorCode::SslError)
+    << "a client certificate that will not load must read as a TLS error, not "
+       "as an unreachable endpoint: "
+    << to_string (refused.error_code) << ": " << refused.error_message;
+    EXPECT_FALSE (refused.error_message.empty ())
+    << "the refusal names nothing, so a user is left to guess which of the two "
+       "settings is wrong";
+}
+
+} // namespace
+} // namespace vayu::http

--- a/engine/tests/tls_backend.hpp
+++ b/engine/tests/tls_backend.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+/**
+ * @file tls_backend.hpp
+ * @brief What TLS backend this build verifies with, and what a client identity
+ *        has to look like for it.
+ *
+ * Two suites need the same fact for different reasons - `transport_policy_test`
+ * asks whether `CURLOPT_CAINFO` replaces the trust store or adds to it,
+ * `mutual_tls_test` asks what format a *client* certificate may be in - and a
+ * second reader of `curl_version_info()` would be a second thing to correct
+ * when a build's backend changes. It lives here so there is one.
+ */
+
+#include <curl/curl.h>
+
+#include <string>
+#include <string_view>
+
+namespace vayu::tests {
+
+/// What `curl_version_info()` says this build verifies with, or empty when it
+/// will not say - which is itself a finding, not a default to paper over.
+inline std::string tls_backend_name () {
+    const curl_version_info_data* info = curl_version_info (CURLVERSION_NOW);
+    if (info == nullptr || info->ssl_version == nullptr) {
+        return {};
+    }
+    return info->ssl_version;
+}
+
+/// The shape a backend takes a client identity in.
+enum class ClientIdentityFormat {
+    /// A PEM certificate and a PEM key, the pair libcurl reads by default.
+    PemPair,
+    /// A PKCS#12 file, which libcurl reads only when told the type is `P12`,
+    /// or a reference into the platform's certificate store.
+    Pkcs12,
+    /// A backend no statement in this repo covers.
+    Unknown,
+};
+
+/// How @p backend expects a client identity to arrive. The families are the
+/// ones the pinned vcpkg baseline's `curl` port can be built against, the same
+/// set `verifies_through_a_bundle_file` in `transport_policy_test.cpp` covers.
+inline ClientIdentityFormat client_identity_format (std::string_view backend) {
+    for (const std::string_view family : { "OpenSSL", "LibreSSL", "BoringSSL", "quictls" }) {
+        if (backend.rfind (family, 0) == 0) {
+            return ClientIdentityFormat::PemPair;
+        }
+    }
+    if (backend.rfind ("Schannel", 0) == 0) {
+        return ClientIdentityFormat::Pkcs12;
+    }
+    return ClientIdentityFormat::Unknown;
+}
+
+} // namespace vayu::tests

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -23,11 +23,12 @@
  * In-process rather than a script under `scripts/test/`, following the
  * precedent of `mock_server.hpp`, `echo_server.hpp` and `proxy_server.hpp`.
  *
- * It is not a general-purpose TLS server. #802's mTLS fixture is expected to
- * extend `TlsServer` with a client-certificate store rather than stand up a
- * second listener - `TestCertificateAuthority::issue` already mints the client
- * identity such a test would present, and `CrlServer` below is the CRL that
- * fixture should reuse rather than build a second one (#819).
+ * It is not a general-purpose TLS server. **It demands a client certificate
+ * when it is built with a second CA** (#802): that listener is what proves a
+ * registered client certificate completes a real handshake, and it is the same
+ * listener rather than a second one, so the CRL below is reused rather than
+ * duplicated (#819) and `TestCertificateAuthority::issue` mints both ends of
+ * the exchange.
  *
  * **The CA publishes a CRL, and the leaf says where to find it** (#819). A
  * backend that revocation-checks the chain - curl's Schannel path passes
@@ -169,10 +170,33 @@ struct CertificateAndKey {
     }
 
     /// The private key as unencrypted PEM. Only ever this process's own
-    /// short-lived key material: nothing here is written to disk, and the
-    /// listener below takes it from memory.
+    /// short-lived key material, and the listener below takes it from memory -
+    /// a *client* identity is the one thing here that has to reach the disk,
+    /// because the registry stores paths and libcurl opens them itself.
     std::string key_pem () const {
         return tls_detail::to_pem (key.get ());
+    }
+
+    /**
+     * @brief The private key as PEM encrypted under @p passphrase.
+     *
+     * What the registry's `passphrase` field exists for. A key a backend
+     * cannot open without it is the only way to tell a passphrase that is
+     * *used* apart from one that is merely stored: drop `CURLOPT_KEYPASSWD`
+     * and a test presenting this key stops connecting.
+     */
+    std::string encrypted_key_pem (const std::string& passphrase) const {
+        tls_detail::BioPtr bio (BIO_new (BIO_s_mem ()));
+        // The passphrase travels as a length-counted buffer rather than
+        // through the callback: OpenSSL's default callback reads from a
+        // terminal, which a test process does not have.
+        if (!bio ||
+        PEM_write_bio_PrivateKey (bio.get (), key.get (), EVP_aes_256_cbc (),
+        reinterpret_cast<const unsigned char*> (passphrase.data ()),
+        static_cast<int> (passphrase.size ()), nullptr, nullptr) != 1) {
+            tls_detail::fail ("could not serialize an encrypted private key");
+        }
+        return tls_detail::read_bio (bio, "an encrypted private key");
     }
 
     /**
@@ -505,28 +529,33 @@ class CrlServer {
 
 /**
  * @brief An HTTPS listener on 127.0.0.1, holding a certificate the given CA
- *        signed.
+ *        signed - and, given a second CA, demanding a certificate *that* one
+ *        signed in return (#802).
  *
- * Serves one route, `/hello`. What is under test is the handshake in front of
- * it: a body only arrives at all if verification passed, so a 200 here is the
- * assertion and the payload is only there to make a partial read visible.
+ * Serves `/hello` and `/events`. What is under test is the handshake in front
+ * of them: a body only arrives at all if verification passed, so a 200 here is
+ * the assertion and the payload is only there to make a partial read visible.
+ * `/events` is the same assertion for the SSE driver, which reads a stream
+ * rather than a body and so cannot be pointed at `/hello`.
  */
 class TlsServer {
     public:
+    /// A listener that asks the client for nothing.
     explicit TlsServer (const TestCertificateAuthority& ca)
-    : crl_ (ca),
-      identity_ (ca.issue ("127.0.0.1", "IP:127.0.0.1,DNS:localhost", crl_.url ())),
-      cert_pem_ (identity_.pem ()), key_pem_ (identity_.key_pem ()),
-      svr_ (pem_memory ()) {
-        if (!svr_.is_valid ()) {
-            tls_detail::fail ("the TLS listener refused its own certificate");
-        }
-        svr_.Get ("/hello", [] (const httplib::Request&, httplib::Response& res) {
-            res.set_content (R"({"over":"tls"})", "application/json");
-        });
-        port_   = svr_.bind_to_any_port ("127.0.0.1");
-        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
-        svr_.wait_until_ready ();
+    : TlsServer (ca, nullptr) {
+    }
+
+    /**
+     * @brief A listener that completes a handshake only with a client
+     *        presenting a certificate @p client_ca signed.
+     *
+     * Passing the same CA twice is the ordinary case - one authority for both
+     * ends of a test - and passing a different one is what lets a test assert
+     * that an identity from *elsewhere* is refused, which is the difference
+     * between "mTLS is configured" and "any certificate is waved through".
+     */
+    TlsServer (const TestCertificateAuthority& ca, const TestCertificateAuthority& client_ca)
+    : TlsServer (ca, &client_ca) {
     }
 
     ~TlsServer () {
@@ -543,6 +572,12 @@ class TlsServer {
         return "https://127.0.0.1:" + std::to_string (port_) + path;
     }
 
+    /// The ephemeral port this listener took, for a test registering something
+    /// against this exact target rather than against the host.
+    int port () const {
+        return port_;
+    }
+
     /// Where this listener's CRL is served, which is also what its certificate
     /// names as a distribution point - the fixture guard asserts those agree.
     std::string crl_url () const {
@@ -557,17 +592,47 @@ class TlsServer {
 
     private:
     /**
+     * The one constructor body. @p client_ca is null for a listener that asks
+     * the client for nothing, and names the authority whose signature it will
+     * accept otherwise.
+     */
+    TlsServer (const TestCertificateAuthority& ca, const TestCertificateAuthority* client_ca)
+    : crl_ (ca),
+      identity_ (ca.issue ("127.0.0.1", "IP:127.0.0.1,DNS:localhost", crl_.url ())),
+      cert_pem_ (identity_.pem ()), key_pem_ (identity_.key_pem ()),
+      client_ca_pem_ (client_ca != nullptr ? client_ca->pem () : std::string ()),
+      svr_ (pem_memory ()) {
+        if (!svr_.is_valid ()) {
+            tls_detail::fail ("the TLS listener refused its own certificate");
+        }
+        svr_.Get ("/hello", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content (R"({"over":"tls"})", "application/json");
+        });
+        svr_.Get ("/events", [] (const httplib::Request&, httplib::Response& res) {
+            res.set_content ("data: one\n\ndata: two\n\n", "text/event-stream");
+        });
+        port_   = svr_.bind_to_any_port ("127.0.0.1");
+        thread_ = std::thread ([this] () { svr_.listen_after_bind (); });
+        svr_.wait_until_ready ();
+    }
+
+    /**
      * The listener takes its identity as PEM in memory rather than as a pair of
      * file paths - the only two shapes `httplib::SSLServer` offers since 0.53 -
      * so no private key is ever written to disk, not even to a scratch
      * directory a failing run would leave behind.
      *
-     * `client_ca_pem` is left null: this listener asks for no client
-     * certificate. That is the field #802's mTLS fixture fills in.
+     * A non-empty `client_ca_pem` is what turns this into an mTLS listener:
+     * `SSLServer` loads it as the verify store and switches the context to
+     * `SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT`, so a client with no
+     * certificate, or one this authority did not sign, never reaches a route.
+     * That refusal is the assertion, which is why it is left to the library
+     * rather than re-implemented per test.
      */
     httplib::SSLServer::PemMemory pem_memory () const {
         return { cert_pem_.c_str (), cert_pem_.size (), key_pem_.c_str (),
-            key_pem_.size (), nullptr, 0, nullptr };
+            key_pem_.size (), client_ca_pem_.empty () ? nullptr : client_ca_pem_.c_str (),
+            client_ca_pem_.size (), nullptr };
     }
 
     /// Declared first because the leaf below is minted naming its URL: the
@@ -577,6 +642,9 @@ class TlsServer {
     CertificateAndKey identity_;
     std::string cert_pem_;
     std::string key_pem_;
+    /// Empty for a listener that asks the client for nothing - the two states
+    /// this class has, held as one string rather than a flag beside it.
+    std::string client_ca_pem_;
     httplib::SSLServer svr_;
     std::thread thread_;
     int port_ = 0;

--- a/engine/tests/transport_policy_test.cpp
+++ b/engine/tests/transport_policy_test.cpp
@@ -35,6 +35,7 @@
 
 #include "proxy_server.hpp"
 #include "temp_database.hpp"
+#include "tls_backend.hpp"
 #include "vayu/db/database.hpp"
 #include "vayu/http/client.hpp"
 #include "vayu/http/debug_redact.hpp"
@@ -426,15 +427,7 @@ TEST_F (TransportPolicyDbTest, AnUnusablePasteIsNotMaterialized) {
     EXPECT_TRUE (policy.ca_bundle_path.empty ());
 }
 
-/// What `curl_version_info()` says this build verifies with, or empty when it
-/// will not say - which is itself a finding, not a default to paper over.
-std::string tls_backend_name () {
-    const curl_version_info_data* info = curl_version_info (CURLVERSION_NOW);
-    if (info == nullptr || info->ssl_version == nullptr) {
-        return {};
-    }
-    return info->ssl_version;
-}
+using vayu::tests::tls_backend_name;
 
 /// Whether @p backend verifies against the file `CURLOPT_CAINFO` names - which
 /// is the same question as whether that option *replaces* the trust store


### PR DESCRIPTION
## Description

**Plan.** The root cause is that nothing in the suite had ever put a client certificate on a wire: `client_certificates_test.cpp` registers paths whose contents are the bytes `not-a-real-certificate`, so every assertion about mTLS was about the *registry*, not about the handshake it exists to complete. Verified against the current tree before touching anything, and one half of the issue's premise had gone stale: #802 says "there is no TLS server in the suite at all", but #812/#819 added one (`tests/tls_server.hpp`, a per-run CA, a served CRL) and `cpp-httplib[openssl]` is already in `engine/vcpkg.json`. So the dependency phase of the fix pathway is not needed, and the approach is the one `engine/CLAUDE.md` names: extend `TlsServer` with a client-certificate store rather than stand up a second listener, reusing that CRL. **Alternative rejected:** a second, mTLS-only listener. It would need its own CA, its own CRL and its own distribution point, and the CRL apparatus is exactly the part #819 had to fix once already - two copies is two things to keep current.

`httplib::SSLServer::PemMemory` already carries a `client_ca_pem` field the old fixture left null, and filling it makes the library load that authority and switch the context to `SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT`. So the fixture change is one string, and the refusal - the thing every positive assertion here rests on - is the library's, not a re-implementation of one.

### What the wire said that memory could not

Six cases pass through drivers that were previously only asserted structurally: a design send, an SSE stream, a load run (three transfers over pooled handles) and `pm.sendRequest` all complete a real handshake with a registered certificate; a port-specific entry holding the accepted identity beats a catch-all holding one signed by a **different** CA, so precedence is proven by which connection opens rather than by which pointer a lookup returned; and an encrypted key opens with its stored passphrase and stops connecting with the wrong one, which is what tells a passphrase that is *used* from one that is merely stored.

Every row is registered through `POST /client-certificates` and read back through `resolve_transport_policy`, so what is under test is the shipped path end to end - no handle is assembled in the test.

### The finding: three refusals read as `INTERNAL_ERROR`

The first run of these tests turned up a real defect, which is why this PR is not test-only. `curl_to_error`'s `default:` arm mapped to `ErrorCode::InternalError`, and **every client-certificate refusal lands in that arm**:

| What happened | CURLcode | Message libcurl gave | Was | Now |
|---|---|---|---|---|
| server demanded a certificate, none registered | 56 `CURLE_RECV_ERROR` | `tlsv13 alert certificate required` | `INTERNAL_ERROR` | `SSL_ERROR` |
| identity signed by an authority the server does not trust | 56 `CURLE_RECV_ERROR` | `tlsv1 alert unknown ca` | `INTERNAL_ERROR` | `SSL_ERROR` |
| stored passphrase does not open the key | 43 `CURLE_BAD_FUNCTION_ARGUMENT` | `unable to set private key file` | `INTERNAL_ERROR` | `SSL_ERROR` |

The first two are receive errors because under TLS 1.3 the server's verdict about the *client* arrives after the client's own handshake has finished - so libcurl reports the ordinary code of a connection that went away mid-request, with the alert only in the message text. `INTERNAL_ERROR` tells a user that Vayu broke when the truth is that the endpoint refused their certificate.

The fix follows the precedent `proxy_refused_tunnel` set two lines above it: consult the handle, because one event is spread across several CURLcodes and a code list would be a list to extend forever. `tls_connection_never_answered` asks whether an `https` transfer produced **no response line at all**, and it is consulted **only in the `default:` arm** - after every code with a meaning of its own has been matched. So a timeout, a refused connection, a resolve failure, a malformed URL, a proxy refusal and any `4xx` all keep exactly the code they had. What it costs is stated in the code and the docs rather than hidden: an https endpoint that accepts a connection and hangs up before answering for a reason of its own now reads as a TLS error - which is still a better answer than "internal", since nothing inside the engine failed, and libcurl's own message travels either way.

### Windows: skipped, loudly, with a guard on the skip

The per-backend format matrix is the second half of the issue, and it is recorded as a tested classifier rather than a claim. OpenSSL (Linux **and** macOS since #818) takes a PEM certificate and key pair; Schannel takes PKCS#12 or a certificate-store reference. The engine writes `CURLOPT_SSLCERT` / `CURLOPT_SSLKEY` and **no `CURLOPT_SSLCERTTYPE`**, so a PEM pair is the only shape it can present at all - which means the Windows leg cannot host this fixture, and it skips with that sentence printed.

Two guards keep that honest. `ClassifiesTheBackendsThisRepoCanBeBuiltAgainst` exercises the classifier with **both** answers stubbed, so the Windows branch is asserted on every leg rather than only where it is taken. `NoBackendIsSkippedForAReasonThatWentAway` reads `curl_utils.cpp` and fails the moment `CURLOPT_SSLCERTTYPE` appears in it - a skip cannot outlive its cause. The gap itself is filed as **#833** (engine + app: a format on the row, no key path for a PKCS#12 entry, the card showing it), rather than widened into this PR.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Engine-only diff, and it changes shared error mapping, so the whole engine suite ran rather than the new file alone. No app file is touched.

- `python build.py -e -t` - clean
- `ctest --preset linux-dev --output-on-failure` - **2069 tests, 100% passed, 0 failed** in 79s (`-j8`; the baseline on `2eaeee7` is 2058, and the 11 are this file's)
- `mkdocs build --strict -f .github/mkdocs.yml` - clean (mkdocs installed here for the docs edits)

No pre-existing failures observed on the base commit.

Mutation checks (mutation applied, confirmed red, reverted; `git diff` against the pushed tree is empty):

| Mutation | Result |
|---|---|
| the `default:` arm maps to `InternalError` again (the state before this PR) | **3 fail** - every refusal: no certificate, wrong authority, wrong passphrase |
| the new rule is consulted *before* the switch instead of inside `default:` | **1 fail** - an unreachable https endpoint stops reading as `ConnectionFailed` |
| the listener stops asking for a client certificate (`client_ca_pem` back to null) | **2 fail** - both refusals, since anyone is now let in |
| the applier stops writing `CURLOPT_KEYPASSWD` | **1 fail** - the encrypted key no longer opens |
| `match_client_certificate` returns the first host match (no port precedence) | **1 fail** - the catch-all's refused identity goes out on a port another entry names |
| `CURLOPT_SSLCERTTYPE` appears in the applier | **1 fail** - the guard on the Windows skip, as designed |
| baseline, unmutated | 2069/2069 |

Formatting, per `CLAUDE.md`'s "format only files you touched that were clean before": `curl_utils.cpp` and `transport_policy_test.cpp` were **not** clang-format-clean at `HEAD`, so both are edited by hand and left otherwise untouched - running the formatter over `curl_utils.cpp` reflowed six unrelated hunks, which were reverted. The two new files are formatted, and `tls_server.hpp` and `client_certificates_test.cpp` were clean before and are clean after.

Local `clang-tidy` is 18.1.3 here and the repo's own pre-commit probe refuses anything below 19, so it did not lint - CI's toolchain does.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs in the same commit:

- `docs/engine/api-reference.md` - the client-certificates section said the engine "passes the paths through unchanged" and left the reader to conclude PKCS#12 works on Windows; it now says what actually goes out (a PEM pair), that the handshake is asserted on a wire on the OpenSSL legs, and that Windows cannot present one until #833. The TLS-trust section gains the new `SSL_ERROR` rule and what it deliberately does not cover.
- `engine/CLAUDE.md` - the client-certificate bullet ("still structural, not on a wire" is no longer true), the PEM-only constraint with its reader, and the `curl_to_error` rule beside the `ProxyError` one it follows.
- `engine/tests/client_certificates_test.cpp` - its header's "what is not here, and why" note pointed at a deferral that has now landed; it now states the split between the two files.

## Related Issues

Closes #802

Acceptance criteria:

- [x] A registered certificate is proven to complete a real mTLS handshake on at least one CI platform, on the design, SSE, load and `pm.sendRequest` paths. Proven on both OpenSSL legs (Linux and macOS), each driver asserted separately.
- [x] Per-backend certificate format is recorded as a tested matrix, not a claim - and any platform that cannot run the fixture skips with its reason printed. Both branches of the classifier asserted on every leg; the Schannel skip prints the reason and names #833.
- [x] A server-side rejection is asserted to surface as `SslError`. It did not before this PR - see the table above.
- [x] The deviation note in `client_certificates_test.cpp`'s header is updated.

Filed rather than folded in:

- **#833** - a certificate format on the registry row, so the Schannel build can present a PKCS#12 and the skip can go away. Engine plus app (the Settings card stops demanding a key path for a format that has none), which is a feature rather than the test this issue asked for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLxt1xHtRR24tXQqJuAc1B)_