### PR TITLE
perf(engine/tests): run the Windows suite -j4 with the database tests locked apart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,9 @@ pass `ctest -j8`, cutting its wall time on Linux and macOS to roughly a fifth
 open a scratch database sharing a CTest `RESOURCE_LOCK`** - a plain `-j` there
 measured ~6x *slower* than serial, because concurrent SQLite commits cost more
 than the concurrency returns, so those tests never overlap while the rest of the
-suite does. They are 81% of the serial wall, so expect Windows near four fifths
-of its serial time rather than a fifth; see `docs/engine/building.md`. A
+suite does. They are 81% of the serial wall, so Windows lands near its old
+serial time rather than at a fifth of it - the lock makes `-j4` survivable
+there, it does not make it fast; see `docs/engine/building.md`. A
 rebuild ~2.5min; the app suite ~90s. Running
 both after retouching a doc comment reads as diligence and is just latency. Ask
 what a failure would even look like before running anything: **if no test could

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,11 +102,15 @@ rename or signature change needs a *build*, to prove it still compiles. Only a
 behaviour change needs the covering tests, and the full suite belongs once
 before committing a substantial piece of work, not after every edit.
 
-The engine suite now runs multi-process on Linux and macOS - those test presets
-pass `ctest -j8`, cutting its wall time to roughly a fifth (each ctest test
-runs in its own process under a private scratch directory, so `-j` is safe;
-`ctest -jN` overrides). **The Windows presets stay serial deliberately** -
-parallelism measured ~6x *slower* there; see `docs/engine/building.md`. A
+The engine suite now runs multi-process on every platform - the test presets
+pass `ctest -j8`, cutting its wall time on Linux and macOS to roughly a fifth
+(each ctest test runs in its own process under a private scratch directory, so
+`-j` is safe; `ctest -jN` overrides). **Windows runs `-j4` with the tests that
+open a scratch database sharing a CTest `RESOURCE_LOCK`** - a plain `-j` there
+measured ~6x *slower* than serial, because concurrent SQLite commits cost more
+than the concurrency returns, so those tests never overlap while the rest of the
+suite does. They are 81% of the serial wall, so expect Windows near four fifths
+of its serial time rather than a fifth; see `docs/engine/building.md`. A
 rebuild ~2.5min; the app suite ~90s. Running
 both after retouching a doc comment reads as diligence and is just latency. Ask
 what a failure would even look like before running anything: **if no test could

--- a/docs/building.md
+++ b/docs/building.md
@@ -236,8 +236,9 @@ cmake --build --preset macos-prod
 ctest --preset macos-prod
 ```
 
-The Linux and macOS test presets run the suite multi-process (`ctest -j8`); the
-Windows ones run serially on purpose, because parallelism measures far slower
+Every test preset runs the suite multi-process - `ctest -j8` on Linux and macOS,
+`-j4` on Windows, where the tests that open a scratch database are additionally
+held apart from each other because concurrent SQLite commits cost far more
 there. Pass `-jN` to override. See
 [Engine build guide](engine/building.md#running-tests) for the numbers.
 

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -327,10 +327,17 @@ the serial wall**, because the route and load fixtures that dominate the suite's
 duration all open a database. The six fixtures the earlier analysis measured on
 Windows (197 tests, 57.2s, 19% of the wall here - within a point of the Windows
 figures, which is what makes this box a usable proxy for the *shape* of the
-suite) are only the visible tip of that group. Expect Windows around four fifths
-of its serial time, not the halving a fast band would suggest; getting past that
-means making the database tests themselves cheaper to run concurrently, which is
-issue #838.
+suite) are only the visible tip of that group.
+
+**What the first CI run of the hybrid model measured: 5m27s, 2071 tests, 0
+failures** (run 32249239500). That is inside the 4m40s-6m38s band the serial legs
+spanned, so **it is not a speedup** - one sample cannot be, against a baseline
+that noisy. What it does establish is that the mechanism works: the same `-j4`
+that took ~37 min without the lock now finishes in the time serial used to take,
+which is what the 81% number predicts and the reason to hold the expectation
+there rather than at the ~2.5 min this was first scoped for. Getting a real
+speedup means making the database tests cheaper to run concurrently, which is
+issue #838; treat that as the open work, not this paragraph as a win.
 
 Isolation is the **default** on every platform now, so a hand-run `ctest -j` is
 safe wherever it happens; the Windows presets used to set

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -329,15 +329,16 @@ Windows (197 tests, 57.2s, 19% of the wall here - within a point of the Windows
 figures, which is what makes this box a usable proxy for the *shape* of the
 suite) are only the visible tip of that group.
 
-**What the first CI run of the hybrid model measured: 5m27s, 2071 tests, 0
-failures** (run 32249239500). That is inside the 4m40s-6m38s band the serial legs
-spanned, so **it is not a speedup** - one sample cannot be, against a baseline
-that noisy. What it does establish is that the mechanism works: the same `-j4`
-that took ~37 min without the lock now finishes in the time serial used to take,
-which is what the 81% number predicts and the reason to hold the expectation
-there rather than at the ~2.5 min this was first scoped for. Getting a real
-speedup means making the database tests cheaper to run concurrently, which is
-issue #838; treat that as the open work, not this paragraph as a win.
+**What CI measured on the hybrid model: 5m27s and 4m50s** on two runs of the
+same tree (32249239500 and 32252015024), 2071 tests, 0 failures, 9 skipped. Both
+sit inside the 4m40s-6m38s band the serial legs spanned, so **this is not a
+speedup** - and with a baseline that noisy, two samples could not show one either
+way. What they do establish is that the mechanism works: the same `-j4` that took
+~37 min without the lock now finishes in the time serial used to take, which is
+what the 81% number predicts and the reason to hold the expectation there rather
+than at the ~2.5 min this was first scoped for. Getting a real speedup means
+making the database tests cheaper to run concurrently, which is issue #838; treat
+that as the open work, not this paragraph as a win.
 
 Isolation is the **default** on every platform now, so a hand-run `ctest -j` is
 safe wherever it happens; the Windows presets used to set

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -274,9 +274,9 @@ ctest -V
 ./vayu_tests
 ```
 
-The Linux and macOS **test presets** run the suite multi-process (`ctest -j8`,
-wired once into the hidden `test-base` test preset in
-`engine/CMakePresets.json`); a bare `ctest` or `./vayu_tests` runs serially.
+Every **test preset** runs the suite multi-process (`ctest -j8`, wired once into
+the hidden `test-base` test preset in `engine/CMakePresets.json`, which the
+Windows presets narrow to `-j4`); a bare `ctest` or `./vayu_tests` runs serially.
 Parallelism is safe because the test binary enters a private per-process scratch
 directory before running, so the relative `test_*.db` files fixtures open never
 collide between concurrently scheduled tests (see `engine/tests/main.cpp` and
@@ -295,19 +295,47 @@ runner is noisier than an idle machine, with the wall-clock-budget tests
 guess - and widening a timing budget to afford a bigger number is not on the
 table.
 
-**The Windows presets run serially, on purpose.** At `-j4` the Windows CI leg
-took ~37 min against a ~6 min serial run. The per-test durations say why: they
-split into a fast band (pure-logic suites) and a slow band that is exactly the
-fixtures which open a scratch `Database` - concurrent SQLite file I/O costs more
-there than the concurrency returns. The same `-j4` cut ubuntu from 3-5 min to
-1m15s and macOS from ~4 min to 1m06s, so the job count is per-OS rather than
-one number. Moving the scratch directories between volumes was tried and made no
-difference, so do not re-litigate that part without new measurements.
+**On Windows the database tests never overlap each other.** A plain `-j4` there
+took ~37 min against a ~6 min serial run - the same `-j4` that cut ubuntu from
+3-5 min to 1m15s and macOS from ~4 min to 1m06s. The per-test durations said
+why: a fast band of pure-logic suites, and a slow band that is exactly the
+fixtures which open a scratch `Database`, where concurrent SQLite commits cost
+more than the concurrency returns (the flush barrier `synchronous=FULL` issues
+per commit, and the 25-250ms retry sleeps `os_win.c` answers a sharing violation
+with). Moving the scratch directories between volumes was tried and made no
+difference, and Windows Defender is not a factor - GitHub's hosted Windows
+images ship with real-time monitoring disabled - so do not re-litigate either
+without new measurements.
 
-Because a serial run has nothing to isolate from, the Windows presets also set
-`VAYU_TEST_NO_SCRATCH_ISOLATION`, which skips the scratch directory entirely.
-Isolation is the **default** everywhere else - including a hand-run
-`ctest -j` on Windows, which is still safe.
+So the Windows presets run `-j4` with those tests holding a shared CTest
+`RESOURCE_LOCK`: no two of them run at once, while everything else runs 4-wide
+beside them. The locked suites are listed in `engine/CMakeLists.txt`
+(`vayu_scratch_database_suites`), which discovers the binary twice - once with a
+gtest filter matching them, once with its negation - so the two halves partition
+the suite exactly. Two configure-time guards keep the list honest: a name that
+matches no test fails the configure, and so does a `tests/*_test.cpp` that
+includes `temp_database.hpp` but contributes no locked suite. **The list is a
+performance statement, not a correctness one** - `ctest -j` is safe on any
+platform through the scratch directories alone, so a suite missing from it
+contends rather than breaks.
+
+Measured locally on a 4-core box (Debug, 2070 tests, green in all four runs):
+299.6s serial, 84.8s at `-j4`, 58.6s at `-j8`, and 243.7s at `-j4` with the lock
+forced on - the last being the model Windows runs. That ratio is the honest
+ceiling of this approach: the locked group is 817 of the 2070 tests but **81% of
+the serial wall**, because the route and load fixtures that dominate the suite's
+duration all open a database. The six fixtures the earlier analysis measured on
+Windows (197 tests, 57.2s, 19% of the wall here - within a point of the Windows
+figures, which is what makes this box a usable proxy for the *shape* of the
+suite) are only the visible tip of that group. Expect Windows around four fifths
+of its serial time, not the halving a fast band would suggest; getting past that
+means making the database tests themselves cheaper to run concurrently, which is
+issue #838.
+
+Isolation is the **default** on every platform now, so a hand-run `ctest -j` is
+safe wherever it happens; the Windows presets used to set
+`VAYU_TEST_NO_SCRATCH_ISOLATION` (which skips the scratch directory entirely)
+because a serial run has nothing to isolate from, and no preset sets it today.
 
 **Do not "improve" the job count to `"jobs": 0`.** Only CMake 3.29+ reads 0 as
 "one job per processor"; this project's floor is 3.25, where `ctest -j 0`

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -688,15 +688,156 @@ if(VAYU_BUILD_TESTS)
     # way vayu-engine is.
     vayu_embed_windows_manifest(vayu_tests)
 
+    # The suite is discovered in two halves so the tests that open a scratch
+    # `Database` can carry a CTest RESOURCE_LOCK the rest does not (#805
+    # phase 5). CTest never runs two tests holding the same lock at once, so no
+    # two database tests overlap while everything else runs `-j` beside them.
+    #
+    # Only Windows takes the lock. `ctest -j` is *correct* on every platform
+    # already - each test process owns a private scratch directory, see
+    # `tests/temp_database.hpp` - and what differs is the price of concurrent
+    # SQLite commits. On Windows a plain `-j4` measured ~37 min against a ~6 min
+    # serial run (#808), which is the cost this lock removes; the same `-j4`
+    # cuts ubuntu from 3-5 min to 1m15s, so locking the group there would only
+    # slow down a platform that has no such problem.
+    #
+    # The list is a performance statement, not a correctness one. A database
+    # suite missing from it still passes - it just contends - and a suite listed
+    # here that opens no database only gives up its own concurrency. So the
+    # guards below check the two things that can be checked exactly and cheaply
+    # (a name matching no test at all, and a database-using file no name here
+    # represents) rather than parsing C++ for what constructs a `Database`.
+    #
+    # The list was derived by tracing: every suite run alone under `strace` that
+    # opened a `*.db` file, which agreed with a source read everywhere but one
+    # false positive. Re-derive it the same way rather than by eye.
+    set(vayu_scratch_database_suites
+        AuthRefreshTuningTest
+        ClientCertificateDbTest
+        CollectMetrics
+        CollectionsRouteTest
+        ConfigRouteTest
+        CustomCaVerificationTest
+        DatabaseConcurrencyTest
+        DatabaseTest
+        DeleteRunTest
+        ErrorShapeRouteTest
+        ExamplesRouteTest
+        GlobalsRouteTest
+        ImportApplyRouteTest
+        InboxListenerTest
+        InboxStorageTest
+        LoadReplayEventsTest
+        LoadScriptScopesTest
+        LoadStrategyTest
+        MidRunRefreshTest
+        MockIssuerTest
+        MockServerTest
+        MonitorLimitsTest
+        MonitorRunTest
+        MutualTlsTest
+        OAuthAuthorizeTest
+        OAuthClientTest
+        OAuthRouteTest
+        PersistScriptVariablesTest
+        PlanAuthRefreshTest
+        RecordDesignResultTest
+        RelayTest
+        ReorderRouteTest
+        RequestComposerTest
+        RequestsRouteTest
+        ResourceWriteRouteTest
+        ResponseCaptureTest
+        RunShutdownTest
+        RunStopAccountingTest
+        RunsRouteTest
+        ScenarioLoadTest
+        ScenarioPlanTest
+        ScenarioRunnerTest
+        ScratchDatabaseCleanup
+        ScriptRequestNameTest
+        ScriptVariableScopesTest
+        SpecSyncRouteTest
+        SpecsRouteTest
+        SseLimitsTest
+        SseServerShutdownTest
+        StatsRouteTest
+        StreamExecuteTest
+        StreamedSampleRouteTest
+        TransportPolicyDbTest
+        TreeOrderTest
+    )
+
+    # Both guards read the same scan: every test macro in this suite sits at the
+    # start of a line, so which suites exist, and which file declares them, can
+    # be read off without compiling anything.
+    set(vayu_declared_test_suites "")
+    set(vayu_unrepresented_database_files "")
+    foreach(test_file IN LISTS vayu_test_files_on_disk)
+        file(STRINGS "${test_file}" vayu_test_macro_lines REGEX "^TEST(_F|_P)?[ \t]*\\(")
+        set(vayu_file_test_suites "")
+        foreach(macro_line IN LISTS vayu_test_macro_lines)
+            string(REGEX REPLACE "^TEST(_F|_P)?[ \t]*\\([ \t]*([A-Za-z0-9_]+).*$" "\\2"
+                vayu_file_test_suite "${macro_line}")
+            list(APPEND vayu_file_test_suites "${vayu_file_test_suite}")
+        endforeach()
+        list(APPEND vayu_declared_test_suites ${vayu_file_test_suites})
+
+        # Guard two: a test file that opens scratch databases and contributes no
+        # locked suite is a whole file's worth of contention nobody decided on -
+        # the shape a new `*_route_test.cpp` arrives in.
+        file(STRINGS "${test_file}" vayu_temp_database_include REGEX "temp_database\\.hpp")
+        if(vayu_temp_database_include)
+            set(vayu_file_is_represented FALSE)
+            foreach(suite IN LISTS vayu_file_test_suites)
+                if(suite IN_LIST vayu_scratch_database_suites)
+                    set(vayu_file_is_represented TRUE)
+                    break()
+                endif()
+            endforeach()
+            if(NOT vayu_file_is_represented)
+                file(RELATIVE_PATH vayu_relative_test_file
+                    "${CMAKE_CURRENT_SOURCE_DIR}" "${test_file}")
+                list(APPEND vayu_unrepresented_database_files "${vayu_relative_test_file}")
+            endif()
+        endif()
+    endforeach()
+    if(NOT vayu_declared_test_suites)
+        message(FATAL_ERROR
+            "Found no TEST/TEST_F declarations under ${CMAKE_CURRENT_SOURCE_DIR}/tests - "
+            "the scratch-database guards are scanning the wrong place and would "
+            "pass no matter which suite was missing.")
+    endif()
+    # Guard one: a name above that matches no test locks nothing and says so
+    # nowhere - a rename would quietly return that suite to contending.
+    foreach(suite IN LISTS vayu_scratch_database_suites)
+        if(NOT suite IN_LIST vayu_declared_test_suites)
+            message(FATAL_ERROR
+                "vayu_scratch_database_suites names '${suite}', which no test declares. "
+                "It locks nothing: on Windows that suite would run concurrently with "
+                "the other database tests again. Fix the name or drop it.")
+        endif()
+    endforeach()
+    if(vayu_unrepresented_database_files)
+        string(REPLACE ";" "\n  " vayu_unrepresented_database_files
+            "${vayu_unrepresented_database_files}")
+        message(FATAL_ERROR
+            "These test files include temp_database.hpp but contribute no suite to "
+            "vayu_scratch_database_suites, so their database tests would run "
+            "concurrently with every other one on Windows:\n  "
+            "${vayu_unrepresented_database_files}\n"
+            "Add the suites that open a Database to the list in engine/CMakeLists.txt.")
+    endif()
+
     # Discover tests for CTest. A per-test TIMEOUT acts as a safety net so a
     # deadlock (e.g. a thread-pool teardown hang) is reported as a failure
     # instead of blocking the suite indefinitely; healthy tests finish in <10s.
     #
     # DISCOVERY_TIMEOUT bounds something else entirely, and the two are easy to
     # confuse: `PROPERTIES TIMEOUT` is handed to CTest for each discovered test,
-    # while DISCOVERY_TIMEOUT caps the single `--gtest_list_tests` run that
-    # *finds* them at build time. It is not covered by the property above and
-    # defaults to **5 seconds**.
+    # while DISCOVERY_TIMEOUT caps each `--gtest_list_tests` run that *finds*
+    # them at build time (one per call below). It is not covered by the property
+    # above and defaults to **5 seconds**.
     #
     # Five seconds is not enough for the macOS x64 half of the release build.
     # That binary is cross-compiled for x86_64 and runs under Rosetta on the
@@ -721,8 +862,29 @@ if(VAYU_BUILD_TESTS)
     # what we just paid. Set globally rather than per-preset: one number is
     # easier to trust than a platform conditional, and no healthy configuration
     # comes close to it.
+
+    # One filter, used positive and negated, so the two halves partition the
+    # suite exactly however the list changes - no test is discovered twice and
+    # none is lost. Both halves are discovered on every platform (only the
+    # property differs) so a broken partition shows up as a changed test count
+    # everywhere rather than on Windows alone.
+    set(vayu_scratch_database_patterns ${vayu_scratch_database_suites})
+    list(TRANSFORM vayu_scratch_database_patterns APPEND ".*")
+    list(JOIN vayu_scratch_database_patterns ":" vayu_scratch_database_filter)
+
+    set(vayu_scratch_database_properties TIMEOUT 60)
+    if(WIN32)
+        list(APPEND vayu_scratch_database_properties RESOURCE_LOCK vayu_scratch_database)
+    endif()
+
     include(GoogleTest)
     gtest_discover_tests(vayu_tests
+        TEST_FILTER "${vayu_scratch_database_filter}"
+        DISCOVERY_TIMEOUT 150
+        PROPERTIES ${vayu_scratch_database_properties}
+    )
+    gtest_discover_tests(vayu_tests
+        TEST_FILTER "-${vayu_scratch_database_filter}"
         DISCOVERY_TIMEOUT 150
         PROPERTIES TIMEOUT 60
     )

--- a/engine/CMakePresets.json
+++ b/engine/CMakePresets.json
@@ -271,10 +271,7 @@
       "configurePreset": "windows-dev",
       "inherits": ["test-base"],
       "execution": {
-        "jobs": 1
-      },
-      "environment": {
-        "VAYU_TEST_NO_SCRATCH_ISOLATION": "1"
+        "jobs": 4
       }
     },
     {
@@ -283,10 +280,7 @@
       "configurePreset": "windows-prod",
       "inherits": ["test-base"],
       "execution": {
-        "jobs": 1
-      },
-      "environment": {
-        "VAYU_TEST_NO_SCRATCH_ISOLATION": "1"
+        "jobs": 4
       }
     },
     {

--- a/engine/tests/main.cpp
+++ b/engine/tests/main.cpp
@@ -23,12 +23,13 @@ int main (int argc, char** argv) {
     // per-test here.
     //
     // Isolating is the default, so a hand-run `ctest -j` is safe wherever it
-    // happens; `VAYU_TEST_NO_SCRATCH_ISOLATION` opts out, and the Windows test
-    // presets set it because they run serially. Measured on CI, the Windows
-    // ctest leg goes from ~6 min serial to over 30 min at `-j4` - the tests
-    // that open a database each pay seconds, the ones that do not are
-    // untouched - while the same `-j4` cuts ubuntu from 3-5 min to 1m12s and
-    // macOS from ~4 min to 1m50s.
+    // happens; `VAYU_TEST_NO_SCRATCH_ISOLATION` opts out and no preset sets it.
+    // Windows presets used to, because they ran serially: a plain `-j4` there
+    // measured over 30 min against a ~6 min serial run, where the same `-j4`
+    // cut ubuntu from 3-5 min to 1m12s. What costs on Windows is concurrent
+    // SQLite commits, not the directories, so the database tests now share a
+    // CTest RESOURCE_LOCK there and the rest of the suite runs `-j4` beside
+    // them (#805 phase 5, `engine/CMakeLists.txt`).
     const bool isolate = !vayu::tests::scratch_isolation_disabled ();
     const std::filesystem::path scratch =
     isolate ? vayu::tests::enter_process_scratch_dir () : std::filesystem::path{};

--- a/engine/tests/temp_database.hpp
+++ b/engine/tests/temp_database.hpp
@@ -28,11 +28,14 @@ namespace vayu::tests {
 /**
  * @brief Whether the per-process scratch directory below has been switched off.
  *
- * Set `VAYU_TEST_NO_SCRATCH_ISOLATION` (to anything) to skip it. The Windows
- * test presets do, because they run the suite serially: with one process there
- * is nothing to isolate from, so the directories would be pure cost - and on
- * Windows that cost is large (see `docs/engine/building.md`). Isolating is the
- * default everywhere else, so a hand-run `ctest -j` is safe on any platform.
+ * Set `VAYU_TEST_NO_SCRATCH_ISOLATION` (to anything) to skip it. **No test
+ * preset sets it any more**: the Windows presets did while they ran the suite
+ * serially - one process has nothing to isolate from - and they run `-j4` since
+ * #805 phase 5, with the database tests held apart by a CTest `RESOURCE_LOCK`
+ * rather than by running the whole suite one test at a time. The opt-out
+ * remains for a deliberately serial run (`ctest -j1`), where the directories
+ * are pure cost, and as the one-line way back to the old behaviour if the
+ * Windows measurement ever turns around again.
  *
  * Presence, not value, so this cannot be got wrong by writing `=0` and meaning
  * "off". MSVC deprecates `std::getenv` in favour of `_dupenv_s` (C4996) and


### PR DESCRIPTION
## Description

#805 phase 5, option A. The Windows test presets ran the suite one test at a time because a plain `-j4` there measured ~37 min against a ~6 min serial run, while the same `-j4` cut ubuntu from 3-5 min to 1m15s.

**Plan.** Root cause (from #808 and the 2026-08-19 research pass on the issue): what costs on Windows is *concurrent SQLite commits* - the flush barrier `synchronous=FULL` issues per commit, plus the 25-250ms retry sleeps `os_win.c` answers a sharing violation with - not the scratch directories, not Defender, not volume placement. Serializing the whole suite is therefore a bigger answer than the problem needs. The approach here is the issue's preferred option A: give every test that opens a scratch `Database` a shared CTest `RESOURCE_LOCK` on Windows, so no two of them overlap while everything else runs 4-wide beside them. The rejected alternative is option B (LLVM-style whole-binary gtest sharding): it would also collapse the ~2000-process model, but it is a much larger change and it loses per-test CTest granularity - a failure would name a shard, not a test - for a win option A already captures. Also rejected: applying the lock on all platforms, which would only slow down Linux and macOS, where the same concurrency is already free.

Mechanically, the binary is discovered twice - once through a gtest filter matching the locked suites, once through its negation - so the two halves partition the suite exactly, whatever the list says, and only the property differs between them. Both halves are discovered on every platform, so a broken partition shows up as a changed test count everywhere rather than on Windows alone. Scratch-directory isolation goes back on for Windows: it is what makes `-j` safe in general, and keeping it means the lock list stays a performance decision rather than becoming load-bearing for correctness.

**The result is smaller than the issue projected, and that is the main finding here.** The locked group is **817 of 2070 tests but 81% of the serial wall**. The six fixtures the 08:00 research comment measured on Windows (196 tests, 58s, 19%) reproduce almost exactly on this box (197 tests, 57.2s, 19%) - which is a good check that the box is a fair proxy for the shape of the suite - but they are a sample of the database group, not the group. Tracing every suite under `strace` and keeping the ones that open a `*.db` file gives 54 suites, and the fixtures that dominate the suite's duration (`MonitorRunTest`, `MidRunRefreshTest`, `LoadStrategyTest`, `DatabaseConcurrencyTest`, the route fixtures) are all in it. So Windows should land near four fifths of its serial time - roughly 4.5 min against today's 4m40s-6m38s - not the ~2.5 min the acceptance criterion names. That criterion needs the database tests to become cheap to run *concurrently*, which is filed as **#838** with the measurements.

**Deliberate deviations from the issue text**, both recorded above and in the docs:
- The locked list is derived by tracing rather than from the six fixture names, as the issue asked ("derive the definitive fixture list by grepping `temp_database.hpp` users"). It is larger than the issue assumed, which is what caps the win.
- The 10x Windows stability loop the criteria ask for is not runnable from this environment. The evidence is this PR's own `windows-latest` legs plus the local hybrid-vs-serial comparison below; the first CI run is also the first real measurement of the model.
- Phase 4 (`release.yml` splits) is untouched and stays open on #805.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Performance / test infrastructure

## Testing

Measured on a 4-core box (Debug, `linux-dev`), **2070 tests, 0 failures in every run**:

| run | wall | note |
|---|---|---|
| serial (`ctest -j1`) | 299.6s | baseline |
| `-j4`, no lock | 84.8s | what Linux does today |
| `-j8`, no lock (`linux-dev` preset) | 58.6s | no regression from this change |
| `-j4`, lock forced on | 243.7s | the model Windows now runs |

The partition itself: 817 + 1253 = 2070 discovered tests, the same total as before the split, and `RESOURCE_LOCK` present on exactly the 817 when forced on and on none of them on Linux.

Mutation checks, all three run and restored:

1. Rename a locked suite (`TreeOrderTest` -> `TreeOrderTests`) - configure fails: *"vayu_scratch_database_suites names 'TreeOrderTests', which no test declares."*
2. Delete the only suite representing a database file - configure fails naming `tests/tree_order_test.cpp`.
3. Point the source scan at a pattern that matches nothing - configure fails: *"Found no TEST/TEST_F declarations ... would pass no matter which suite was missing."* (the non-empty-scan rule, since a guard reading an empty scan passes forever).

No app-side change: #805's "App changes (required)" shipped with phase 3 in #816. No pre-existing failures were seen on this base.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable) - test infrastructure, verified by the mutation checks and the timing table above
- [x] I have updated documentation

`docs/engine/building.md` rewrites the "Windows presets run serially, on purpose" section into the hybrid model with the measured table and the ceiling it implies; `docs/building.md` and `CLAUDE.md` carry the one-line version; `engine/tests/main.cpp` and `temp_database.hpp` no longer say a preset disables scratch isolation, because none does. No page was added, moved or renamed and no link changed, so the docs build is unaffected.

## Related Issues
Closes #805 - **no**, deliberately: phase 4 and the acceptance criteria that only a release run or a Windows measurement can confirm are still open there. Delivers #805 phase 5, and files #838 for the ceiling it leaves behind.

---
_Generated by [Claude Code](https://claude.ai/code/session_019SksdwtqoSewwcZPhE3wAw)_