### PR TITLE
feat(engine/app/tls): a client certificate can go out as PKCS#12, not only as a PEM pair

### DIFF
--- a/app/src/modules/settings/main/panels/ClientCertificatesCard.test.tsx
+++ b/app/src/modules/settings/main/panels/ClientCertificatesCard.test.tsx
@@ -50,6 +50,7 @@ const certificates = [
 		port: 8443,
 		certPath: "/home/ada/certs/client.pem",
 		keyPath: "/home/ada/certs/client.key",
+		certFormat: "pem" as const,
 		hasPassphrase: true,
 		createdAt: 1,
 		updatedAt: 1,
@@ -58,8 +59,9 @@ const certificates = [
 		id: "cert_2",
 		host: "internal.example.com",
 		port: null,
-		certPath: "/home/ada/certs/internal.pem",
-		keyPath: "/home/ada/certs/internal.key",
+		certPath: "/home/ada/certs/internal.p12",
+		keyPath: "",
+		certFormat: "p12" as const,
 		hasPassphrase: false,
 		createdAt: 1,
 		updatedAt: 1,
@@ -131,6 +133,7 @@ describe("ClientCertificatesCard", () => {
 			host: "api.example.com",
 			port: null,
 			certPath: "/certs/client.pem",
+			certFormat: "pem",
 			keyPath: "/certs/client.key",
 			passphrase: undefined,
 		});
@@ -177,6 +180,48 @@ describe("ClientCertificatesCard", () => {
 		fireEvent.click(within(dialog).getByRole("button", { name: /^remove$/i }));
 
 		await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith("cert_1"));
+	});
+
+	it("prints what each row will present, and no key file for a bundle", () => {
+		renderCard();
+
+		// The engine may have read the format off the file, so the row is where
+		// a user finds out what will actually go on the wire (#833).
+		expect(screen.getByText("PEM")).toBeInTheDocument();
+		expect(screen.getByText("PKCS#12")).toBeInTheDocument();
+		// A bundle stores no key path. An empty name here would read as a file
+		// whose name went missing rather than as a format that has none.
+		expect(screen.getByText("internal.p12")).toBeInTheDocument();
+		expect(screen.getByText("client.key")).toBeInTheDocument();
+	});
+
+	it("drops the key file for a PKCS#12 entry and sends null in its place", async () => {
+		renderCard();
+		fireEvent.click(screen.getByRole("button", { name: /add certificate/i }));
+		fireEvent.change(screen.getByLabelText("Host"), {
+			target: { value: "api.example.com" },
+		});
+		fireEvent.change(screen.getByLabelText("Certificate file"), {
+			target: { value: "/certs/client.pem" },
+		});
+		// Fill the key first, then switch: the path is still in the draft, and
+		// sending it would be a 400 from an engine that refuses a bundle naming
+		// a key file.
+		fireEvent.change(screen.getByLabelText("Private key file"), {
+			target: { value: "/certs/client.key" },
+		});
+		fireEvent.click(screen.getByRole("radio", { name: /PKCS#12 bundle/i }));
+
+		// Absent rather than disabled - a bundle has no key file to ask for.
+		expect(screen.queryByLabelText("Private key file")).not.toBeInTheDocument();
+		// And the field is not required to submit, which is the dead end this
+		// change removes: a Windows user could fill in nothing that worked.
+		fireEvent.click(screen.getByRole("button", { name: /^add certificate$/i }));
+
+		await waitFor(() => expect(createMutate).toHaveBeenCalled());
+		expect(createMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ certFormat: "p12", keyPath: null })
+		);
 	});
 
 	it("says the engine did not answer rather than showing an empty registry", () => {

--- a/app/src/modules/settings/main/panels/ClientCertificatesCard.test.tsx
+++ b/app/src/modules/settings/main/panels/ClientCertificatesCard.test.tsx
@@ -224,6 +224,20 @@ describe("ClientCertificatesCard", () => {
 		);
 	});
 
+	it("shows a format it does not recognise rather than taking the card down", () => {
+		// A row hand-edited around the routes: the engine refuses to store this
+		// and still lists it. Indexing straight into the format table would
+		// throw and blank the whole Settings screen over one bad row.
+		queryResult = {
+			data: [{ ...certificates[0], certFormat: "pkcs12" as never }],
+			isError: false,
+		};
+		renderCard();
+
+		expect(screen.getByText("api.example.com:8443")).toBeInTheDocument();
+		expect(screen.getByText("pkcs12")).toBeInTheDocument();
+	});
+
 	it("says the engine did not answer rather than showing an empty registry", () => {
 		queryResult = { data: undefined, isError: true };
 		renderCard();

--- a/app/src/modules/settings/main/panels/ClientCertificatesCard.tsx
+++ b/app/src/modules/settings/main/panels/ClientCertificatesCard.tsx
@@ -94,6 +94,20 @@ const FORMATS: Record<
 	},
 };
 
+/**
+ * What a stored format is called on a row, falling back to the value itself.
+ *
+ * The engine refuses to *store* a format it does not know, so this only ever
+ * fires for a row hand-edited around the routes - which the engine still lists
+ * (it drops such a row from the transport policy and logs it, rather than
+ * hiding it). Indexing straight into the table there would throw on the lookup
+ * and take the whole Settings screen down over one bad row, instead of showing
+ * the user which row to fix.
+ */
+function formatBadge(certFormat: string): string {
+	return FORMATS[certFormat as ClientCertificateFormat]?.badge ?? certFormat;
+}
+
 /** The empty draft, and what "Cancel" restores. */
 const EMPTY_DRAFT = {
 	host: "",
@@ -269,7 +283,7 @@ export function ClientCertificatesCard() {
 										    this off the file, and what will be
 										    presented is the fact worth showing. */}
 										<Badge variant="chip" className="text-muted-foreground">
-											{FORMATS[certificate.certFormat].badge}
+											{formatBadge(certificate.certFormat)}
 										</Badge>
 										{certificate.hasPassphrase && (
 											<Badge variant="chip" className="text-muted-foreground">

--- a/app/src/modules/settings/main/panels/ClientCertificatesCard.tsx
+++ b/app/src/modules/settings/main/panels/ClientCertificatesCard.tsx
@@ -26,6 +26,14 @@
  * database. The passphrase is the exception: it is stored (plaintext, the
  * repo's existing credential precedent) and, once stored, never sent back -
  * which is why an entry that has one shows a badge and not a value.
+ *
+ * **The format is a field, not a guess** (issue #833). A PEM certificate keeps
+ * its key in a second file; a PKCS#12 bundle carries both, and is the only
+ * shape a Windows build can present at all. So the form asks which one, drops
+ * the key picker for a bundle - a card that kept demanding a key file the
+ * format does not have is a dead end no engine change fixes - and every row
+ * prints what it will present, because the engine may have read the format off
+ * the file and the user is the one who can correct it.
  */
 
 import { useRef, useState } from "react";
@@ -42,6 +50,8 @@ import {
 	Input,
 	Label,
 	SecretInput,
+	ToggleGroup,
+	ToggleGroupItem,
 } from "@/components/ui";
 import {
 	useClientCertificatesQuery,
@@ -49,7 +59,7 @@ import {
 	useDeleteClientCertificateMutation,
 } from "@/queries";
 import { useToastStore } from "@/stores";
-import type { ClientCertificate } from "@/types";
+import type { ClientCertificate, ClientCertificateFormat } from "@/types";
 import { fileBaseName } from "@/lib/file-path";
 
 /** What an entry is called: the same `host` / `host:port` the engine traces. */
@@ -57,8 +67,42 @@ function targetLabel(certificate: ClientCertificate): string {
 	return certificate.port === null ? certificate.host : `${certificate.host}:${certificate.port}`;
 }
 
+/**
+ * What each format is called on screen, and which files it needs. One table,
+ * because the segmented control, the row badge and the pickers all describe the
+ * same choice and three copies would be three things to keep in step.
+ *
+ * `accept` is a hint to the file dialog, never a rule: the engine reads the
+ * format off the file's own bytes and refuses a contradiction, so an oddly
+ * named certificate is still registrable by typing its path.
+ */
+const FORMATS: Record<
+	ClientCertificateFormat,
+	{ label: string; badge: string; accept: string; needsKeyFile: boolean }
+> = {
+	pem: {
+		label: "PEM + key file",
+		badge: "PEM",
+		accept: ".pem,.crt,.cer",
+		needsKeyFile: true,
+	},
+	p12: {
+		label: "PKCS#12 bundle",
+		badge: "PKCS#12",
+		accept: ".p12,.pfx",
+		needsKeyFile: false,
+	},
+};
+
 /** The empty draft, and what "Cancel" restores. */
-const EMPTY_DRAFT = { host: "", port: "", certPath: "", keyPath: "", passphrase: "" };
+const EMPTY_DRAFT = {
+	host: "",
+	port: "",
+	certPath: "",
+	keyPath: "",
+	passphrase: "",
+	certFormat: "pem" as ClientCertificateFormat,
+};
 
 /**
  * A file the user picks, reduced to its absolute path.
@@ -136,6 +180,8 @@ export function ClientCertificatesCard() {
 		setDraft(EMPTY_DRAFT);
 	};
 
+	const needsKeyFile = FORMATS[draft.certFormat].needsKeyFile;
+
 	const submit = async () => {
 		try {
 			await createCertificate.mutateAsync({
@@ -145,7 +191,11 @@ export function ClientCertificatesCard() {
 				// nothing rather than a 400 the user has to decode.
 				port: draft.port.trim() === "" ? null : Number(draft.port.trim()),
 				certPath: draft.certPath.trim(),
-				keyPath: draft.keyPath.trim(),
+				certFormat: draft.certFormat,
+				// A bundle carries its own key, and the engine refuses a row
+				// that names one - so this is null rather than a path the form
+				// happens to still hold from before the format was switched.
+				keyPath: needsKeyFile ? draft.keyPath.trim() : null,
 				passphrase: draft.passphrase === "" ? undefined : draft.passphrase,
 			});
 			showToast(`Client certificate registered for ${draft.host.trim()}`, "success");
@@ -172,7 +222,9 @@ export function ClientCertificatesCard() {
 	};
 
 	const canSubmit =
-		draft.host.trim() !== "" && draft.certPath.trim() !== "" && draft.keyPath.trim() !== "";
+		draft.host.trim() !== "" &&
+		draft.certPath.trim() !== "" &&
+		(!needsKeyFile || draft.keyPath.trim() !== "");
 
 	return (
 		<Card>
@@ -212,6 +264,13 @@ export function ClientCertificatesCard() {
 												Every port
 											</Badge>
 										)}
+										{/* Printed for every row, not only the
+										    unusual one: the engine may have read
+										    this off the file, and what will be
+										    presented is the fact worth showing. */}
+										<Badge variant="chip" className="text-muted-foreground">
+											{FORMATS[certificate.certFormat].badge}
+										</Badge>
 										{certificate.hasPassphrase && (
 											<Badge variant="chip" className="text-muted-foreground">
 												Passphrase set
@@ -225,9 +284,14 @@ export function ClientCertificatesCard() {
 										<span title={certificate.certPath}>
 											{fileBaseName(certificate.certPath)}
 										</span>
-										<span title={certificate.keyPath}>
-											{fileBaseName(certificate.keyPath)}
-										</span>
+										{/* A bundle stores no key path, so there is no
+									    second name to print - an empty span would
+									    read as a file whose name went missing. */}
+										{certificate.keyPath !== "" && (
+											<span title={certificate.keyPath}>
+												{fileBaseName(certificate.keyPath)}
+											</span>
+										)}
 									</div>
 								</div>
 								<Button
@@ -274,24 +338,62 @@ export function ClientCertificatesCard() {
 							</div>
 						</div>
 
+						<div className="space-y-1.5">
+							<Label>Format</Label>
+							<ToggleGroup
+								size="sm"
+								aria-label="Certificate format"
+								value={draft.certFormat}
+								// Radix clears the value when the active segment is
+								// pressed again; a format has no "off".
+								onValueChange={(next) =>
+									next &&
+									setDraft((d) => ({
+										...d,
+										certFormat: next as ClientCertificateFormat,
+									}))
+								}
+							>
+								{(Object.keys(FORMATS) as ClientCertificateFormat[]).map(
+									(format) => (
+										<ToggleGroupItem key={format} value={format}>
+											{FORMATS[format].label}
+										</ToggleGroupItem>
+									)
+								)}
+							</ToggleGroup>
+							<p className="text-xs text-muted-foreground">
+								A PKCS#12 bundle holds the certificate and its key in one file.
+								Windows can only present that form.
+							</p>
+						</div>
+
 						<PathPicker
 							id="client-cert-path"
 							label="Certificate file"
 							value={draft.certPath}
-							accept=".pem,.crt,.cer,.p12,.pfx"
+							accept={FORMATS[draft.certFormat].accept}
 							onPick={(path) => setDraft((d) => ({ ...d, certPath: path }))}
 						/>
-						<PathPicker
-							id="client-cert-key-path"
-							label="Private key file"
-							value={draft.keyPath}
-							accept=".pem,.key"
-							onPick={(path) => setDraft((d) => ({ ...d, keyPath: path }))}
-						/>
+						{/* Absent for a bundle rather than disabled: the engine
+						    refuses a PKCS#12 entry that names a key file, so a
+						    greyed-out field would be asking for something that
+						    can never be sent. */}
+						{needsKeyFile && (
+							<PathPicker
+								id="client-cert-key-path"
+								label="Private key file"
+								value={draft.keyPath}
+								accept=".pem,.key"
+								onPick={(path) => setDraft((d) => ({ ...d, keyPath: path }))}
+							/>
+						)}
 
 						<div className="space-y-1.5">
 							<Label htmlFor="client-cert-passphrase">
-								Key passphrase (optional)
+								{needsKeyFile
+									? "Key passphrase (optional)"
+									: "Bundle password (optional)"}
 							</Label>
 							<SecretInput
 								value={draft.passphrase}

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -774,6 +774,13 @@ export interface ClearCookiesResponse {
  * which is the only thing the card has to render. Sending it back would put a
  * secret into every screenshot of the Settings panel.
  */
+/**
+ * What the certificate file holds (issue #833). `pem` keeps the key in a second
+ * file; `p12` is a PKCS#12 bundle carrying both, and the only shape a Schannel
+ * (Windows) build can present at all.
+ */
+export type ClientCertificateFormat = "pem" | "p12";
+
 export interface ClientCertificate {
 	id: string;
 	/** Lower-cased hostname, no scheme or port - the engine stores it this way. */
@@ -781,7 +788,9 @@ export interface ClientCertificate {
 	/** The port this entry is specific to, or null when it answers on every one. */
 	port: number | null;
 	certPath: string;
+	/** `""` for a `p12` entry, which carries its own key and stores no path. */
 	keyPath: string;
+	certFormat: ClientCertificateFormat;
 	hasPassphrase: boolean;
 	createdAt: number;
 	updatedAt: number;
@@ -796,7 +805,15 @@ export interface ClientCertificateInput {
 	host: string;
 	port: number | null;
 	certPath: string;
-	keyPath: string;
+	/**
+	 * Absent lets the engine read the format off the file, which is what a
+	 * caller that has no opinion should do. Naming it is checked against those
+	 * same bytes, so a wrong value is a `400` rather than a handshake failure
+	 * later.
+	 */
+	certFormat?: ClientCertificateFormat;
+	/** `null` clears a stored path - how an entry moves from `pem` to `p12`. */
+	keyPath: string | null;
 	passphrase?: string | null;
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -287,7 +287,8 @@ Variables are resolved with priority: **Environment > Collection > Global**
   `Proxy-Authorization` header from the URL, and that header is on the
   redaction list, so credentials never reach a stored trace or a debug log.
 - **Client-certificate keys**: never stored. The `client_certificates` table
-  holds the *paths* of the certificate and key files and the engine opens them
+  holds the *paths* of the certificate and key files - one path where the
+  certificate is a PKCS#12 bundle carrying both - and the engine opens them
   at send time. The key's passphrase is the one part that is stored, plaintext,
   on the same precedent as every other credential above - and the API never
   echoes it back, answering `hasPassphrase` instead.

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2096,9 +2096,19 @@ on every transfer. Which formats work is a property of the build's TLS backend:
 A `pem` entry on Windows fails at handshake time with libcurl's own error -
 that backend takes no PEM pair at all, which before issue #833 (when the engine
 named no type) meant a Windows build could present nothing a user registered.
-Both formats are asserted on a wire on every leg the backend accepts them (a
-design send, an SSE stream, a load run and a `pm.sendRequest` against a listener
-that demands a client certificate).
+
+**On Windows, mutual TLS does not work today, and that is upstream** (issue
+#842). The engine stores the format and hands libcurl the right type, but
+curl's Schannel client-certificate path cannot complete the handshake: it
+imports the bundle with `PKCS12_NO_PERSIST_KEY` and the key that yields is one
+Schannel's credential path cannot use, so the transfer fails with
+`SEC_E_INTERNAL_ERROR ... The Local Security Authority cannot be contacted`.
+curl 8.21.0 - the pinned baseline - documents this in its own `KNOWN_BUGS`
+(curl issues 17626 and 3145). Nothing in Vayu's configuration changes it.
+
+On the OpenSSL legs both formats are asserted on a wire (a design send, an SSE
+stream, a load run and a `pm.sendRequest` against a listener that demands a
+client certificate).
 
 **A PKCS#12 entry names no key file**, because the bundle carries the key: a row
 that names one is a `400` rather than a stored path nothing would read, and

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2083,17 +2083,36 @@ A cert-authenticated exchange says so. `POST /execute` returns
 trace carries the same value under the same name, so a restored response names
 the entry a live one named.
 
-**A registered pair goes out as PEM.** The engine writes the two paths and no
-certificate *type*, so libcurl reads them in its default format - a PEM
-certificate and a PEM key, optionally encrypted under the stored passphrase.
-That is what every OpenSSL-backed build takes, which is Linux and macOS, and
-the handshake is asserted on a wire there (a design send, an SSE stream, a load
-run and a `pm.sendRequest` against a listener that demands a client
-certificate). **Windows cannot present one yet**: that build is Schannel-backed
-and wants a PKCS#12 file or a certificate-store reference, neither of which
-libcurl will read without being told the type. Issue #833 tracks giving a row
-its format; until it lands, an entry registered on Windows fails at handshake
-time with libcurl's own error.
+**The row says what format its certificate is in, and the engine tells libcurl
+so.** `certFormat` is `pem` - a PEM certificate with its key in a second file -
+or `p12`, a PKCS#12 bundle carrying both, and it becomes `CURLOPT_SSLCERTTYPE`
+on every transfer. Which formats work is a property of the build's TLS backend:
+
+| Backend | Builds | Presents |
+|---------|--------|----------|
+| OpenSSL | Linux, macOS | `pem` and `p12` |
+| Schannel | Windows | `p12` only |
+
+A `pem` entry on Windows fails at handshake time with libcurl's own error -
+that backend takes no PEM pair at all, which before issue #833 (when the engine
+named no type) meant a Windows build could present nothing a user registered.
+Both formats are asserted on a wire on every leg the backend accepts them (a
+design send, an SSE stream, a load run and a `pm.sendRequest` against a listener
+that demands a client certificate).
+
+**A PKCS#12 entry names no key file**, because the bundle carries the key: a row
+that names one is a `400` rather than a stored path nothing would read, and
+`keyPath` comes back `""`. The `passphrase` field covers both formats - libcurl
+reads it as the PEM key's passphrase and as the bundle's import password.
+
+**The format is checked against the file, and defaulted from it.** Leave
+`certFormat` out and the engine reads the first bytes of `certPath` - a PEM
+marker or the ASN.1 `SEQUENCE` a DER bundle opens with - and stores what it
+found, falling back to `pem` for a file it cannot classify. Name it and it is
+kept, but a *contradiction* (a bundle registered as `pem`, or the reverse) is a
+`400`: the alternative is libcurl's parse error against the endpoint, which is
+the misdiagnosis this registry exists to end. A file the engine cannot classify
+is left for the backend to judge rather than refused here.
 
 ### GET /client-certificates
 
@@ -2108,6 +2127,7 @@ Every registered entry.
     "port": 8443,
     "certPath": "/home/ada/certs/client.pem",
     "keyPath": "/home/ada/certs/client.key",
+    "certFormat": "pem",
     "hasPassphrase": true,
     "createdAt": 1767225600000,
     "updatedAt": 1767225600000
@@ -2116,7 +2136,7 @@ Every registered entry.
 ```
 
 `port` is `null` - not `0` and not omitted - for an entry that answers on every
-port.
+port. `keyPath` is `""` for a `p12` entry, which stores no key path at all.
 
 ### POST /client-certificates
 
@@ -2131,14 +2151,15 @@ id](#the-engine-owns-every-id)).
 | `host` | yes | Hostname, no scheme, port or path. Stored lower-cased. |
 | `port` | no | The port this entry is specific to; `null` or absent means every port. |
 | `certPath` | yes | Path to the certificate file. Must be readable now. |
-| `keyPath` | yes | Path to the private key file. Must be readable now. |
-| `passphrase` | no | The key's passphrase. Write-only. |
+| `certFormat` | no | `pem` or `p12`. Absent or `null` reads it off `certPath`, falling back to `pem`. |
+| `keyPath` | for `pem` | Path to the private key file. Must be readable now, and must be **absent** for `p12`. |
+| `passphrase` | no | The key's passphrase, or a PKCS#12 bundle's import password. Write-only. |
 
 **Errors:**
 
 | Status | When |
 |--------|------|
-| `400` | A host that could never match (carries a scheme, a path, a port, or brackets), a port outside `1..65535`, a non-integer `port`, a missing `host` / `certPath` / `keyPath`, a file that is not readable, or a body `id`. |
+| `400` | A host that could never match (carries a scheme, a path, a port, or brackets), a port outside `1..65535`, a non-integer `port`, a missing `host` / `certPath`, a `pem` entry with no `keyPath`, a `p12` entry that names one, a `certFormat` outside `pem` / `p12`, a `certFormat` the file's own bytes contradict, a file that is not readable, or a body `id`. |
 | `409` | Another entry already claims this `host` + `port`. Two rows for one target would make the certificate presented depend on row order, so the second is refused with the id of the first rather than silently shadowing it. |
 
 ### PUT /client-certificates/:id
@@ -2146,10 +2167,15 @@ id](#the-engine-owns-every-id)).
 Update an entry. **Update only** - a missing id is a `404`, never a silent
 create. Merge-patch under the [null-vs-absent
 rule](#the-null-vs-absent-rule): an absent field keeps its value, `port: null`
-widens the entry to every port, and `passphrase: null` clears a stored one.
+widens the entry to every port, `passphrase: null` clears a stored one, and
+`keyPath: null` clears the key path - which is how an entry moves from `pem` to
+`p12`, since a bundle may not name one. `certFormat: null` re-reads the format
+off `certPath`.
 
 Validation runs on the **merged** row, not on the body, so a `PUT` that moves
-only `keyPath` still proves the pair works together.
+only `keyPath` still proves the pair works together - and a `PUT` that names
+`certFormat: "p12"` without clearing `keyPath` is a `400`, because the merged
+row would be a bundle naming a key file.
 
 ### DELETE /client-certificates/:id
 

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -512,7 +512,8 @@ matching rule.
 | `host`       | TEXT    | Hostname, lower-cased, no scheme/port/path. IPv6 without brackets |
 | `port`       | INTEGER | NULL = answers for the host on every port                 |
 | `cert_path`  | TEXT    | Path to the certificate file                              |
-| `key_path`   | TEXT    | Path to the private key file                              |
+| `key_path`   | TEXT    | Path to the private key file; `""` for a `p12` entry, which carries its own |
+| `cert_format`| TEXT    | `pem` or `p12` (issue #833). NOT NULL, default `pem` - what a row written before this column existed is |
 | `passphrase` | TEXT    | The key's passphrase, `""` when it has none. **Plaintext** - see below |
 | `created_at` | INTEGER | Unix ms                                                   |
 | `updated_at` | INTEGER | Unix ms                                                   |
@@ -521,6 +522,13 @@ matching rule.
 paths, and the engine opens the files at send time - the strongest storage
 decision available without a keystore, and the reason a registry entry survives
 being copied between machines only if the files do.
+
+**`cert_format` is stored rather than sniffed per send.** The applier runs on
+every handle of every load run, so reading the file each time would pay for the
+same answer thousands of times - and a format nothing recorded is one the
+Settings card cannot print back for the user to correct. It is written once, at
+the moment the entry is registered, from the body or from the file's own first
+bytes; `client_cert_rejection` refuses a row whose bytes contradict it.
 
 **The passphrase is stored in plaintext, and that is disclosed rather than
 hidden.** It is the same treatment every other credential in this file already

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -324,13 +324,19 @@ Three things worth knowing before you design around them:
   entry is recorded on `Response::client_certificate` and travels both design
   funnels (live body and stored trace) under `clientCertificate`, deliberately
   *not* on the load path: it is a per-transfer string for a fact that is
-  constant for the run. **What goes out is a PEM pair and nothing else**
-  (`tests/mutual_tls_test.cpp`, #802): the applier writes no
-  `CURLOPT_SSLCERTTYPE`, so libcurl reads both files in its default format -
-  right on every OpenSSL leg, and the reason the Schannel build, which wants
-  PKCS#12, can present nothing at all (#833). The live fixture skips that leg
-  with the reason printed and scans the applier so the skip cannot outlive its
-  cause.
+  constant for the run. **The row says what format its certificate is in**
+  (`cert_format`, #833): the applier writes `CURLOPT_SSLCERTTYPE` from it, so a
+  `p12` bundle goes out as one and the Schannel build - which takes no PEM pair
+  at all and could therefore present *nothing* a user registered - works. A
+  PKCS#12 row stores no `key_path` (the bundle carries the key) and one
+  `passphrase` column serves both, since libcurl reads it as the import
+  password too. The format is **stored, not sniffed per transfer**, defaulted at
+  write time from the file's first bytes and refused when those bytes
+  contradict it - a check that is deliberately shallow, like `ca_pem_rejection`:
+  only a contradiction is an error, a file we cannot classify is the backend's
+  to judge. `tests/mutual_tls_test.cpp` runs every driver case once per format
+  the leg's backend accepts (`client_identity_formats()`), so Windows now proves
+  the PKCS#12 half on a wire instead of skipping.
 
 ## Request composition (engine-owned - POST /compose)
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -335,8 +335,16 @@ Three things worth knowing before you design around them:
   contradict it - a check that is deliberately shallow, like `ca_pem_rejection`:
   only a contradiction is an error, a file we cannot classify is the backend's
   to judge. `tests/mutual_tls_test.cpp` runs every driver case once per format
-  the leg's backend accepts (`client_identity_formats()`), so Windows now proves
-  the PKCS#12 half on a wire instead of skipping.
+  the leg's backend accepts (`client_identity_formats()`).
+  **mTLS still does not work on Windows, and the reason is now upstream rather
+  than ours** (#842): curl 8.21's Schannel client-cert path imports the bundle
+  with `PKCS12_NO_PERSIST_KEY` and cannot then use the key, which curl's own
+  `KNOWN_BUGS` documents (curl 17626, 3145) and which measures here as
+  `SEC_E_INTERNAL_ERROR` on every driver, with a legacy-PBE and a PBES2 bundle
+  alike. So the wire cases skip on that leg through `client_auth_defect()` -
+  kept deliberately separate from the format matrix, so a fixed libcurl deletes
+  one line - while what the engine itself does (the stored format, the option,
+  the registry rules) is asserted on Windows like everywhere else.
 
 ## Request composition (engine-owned - POST /compose)
 

--- a/engine/include/vayu/http/transport_policy.hpp
+++ b/engine/include/vayu/http/transport_policy.hpp
@@ -86,6 +86,55 @@ std::optional<ProxyMode> proxy_mode_from_string (std::string_view value);
 std::optional<std::string> proxy_url_rejection (std::string_view url);
 
 /**
+ * @brief The shape a stored client identity is in (issue #833).
+ *
+ * A property of the *row*, not of the transfer: the applier runs on every
+ * handle of every load run, so sniffing the file per send would pay for the
+ * same answer thousands of times - and an answer nothing stored is one the
+ * Settings card cannot print. It is written once, when the entry is registered.
+ */
+enum class ClientCertFormat {
+    /// A PEM certificate with its key in a second file - libcurl's default, and
+    /// the only shape an OpenSSL-backed build takes.
+    Pem,
+    /// A PKCS#12 file carrying certificate *and* key, which libcurl reads only
+    /// when told `CURLOPT_SSLCERTTYPE` is `P12`. The only file shape Schannel
+    /// takes.
+    Pkcs12
+};
+
+/// Every format, in the order the card offers them. The valid-values text of a
+/// rejection is built from this rather than from a literal list, so the set
+/// accepted and the set advertised cannot drift - `all_proxy_modes` exists for
+/// the same reason.
+std::array<ClientCertFormat, 2> all_client_cert_formats ();
+
+/// The wire spelling of @p format, as `certFormat` stores it.
+const char* to_string (ClientCertFormat format);
+
+/// What `CURLOPT_SSLCERTTYPE` is set to for @p format. Separate from the wire
+/// spelling because they are libcurl's words, not ours, and a rename of either
+/// must not silently become a rename of the other.
+const char* curl_ssl_cert_type (ClientCertFormat format);
+
+/// Parse a stored `certFormat`. An unrecognised value yields nullopt so the
+/// caller decides - the route rejects, the resolver logs and drops the row.
+std::optional<ClientCertFormat> client_cert_format_from_string (std::string_view value);
+
+/**
+ * @brief The format the bytes at @p path are in, or nullopt when they say
+ *        nothing this engine can read.
+ *
+ * Deliberately shallow, on `ca_pem_rejection`'s precedent: it asks what the
+ * first bytes *are*, never whether the certificate inside is valid, because a
+ * file curl would have accepted must not be refused by a parser of ours. PEM is
+ * `-----BEGIN` in the leading text; PKCS#12 is DER, so it opens with the ASN.1
+ * `SEQUENCE` tag. Anything else - a DER certificate, a truncated download, a
+ * text file - is nullopt, which callers treat as "unclassified", not "wrong".
+ */
+std::optional<ClientCertFormat> sniff_client_cert_format (std::string_view path);
+
+/**
  * @brief One registry row: the certificate a host is called with (issue #707).
  *
  * A certificate is a property of *where you are calling*, not of one request -
@@ -122,12 +171,20 @@ struct ClientCertRule {
     /// - see `match_client_certificate`.
     std::optional<int> port;
 
-    /// PEM (or, per platform, PKCS#12) certificate file, passed to
-    /// `CURLOPT_SSLCERT` verbatim.
+    /// Certificate file, passed to `CURLOPT_SSLCERT` verbatim. What libcurl
+    /// reads it as is `format` below, not a guess from its name.
     std::string cert_path;
 
-    /// Private key file, passed to `CURLOPT_SSLKEY` verbatim.
+    /// Private key file, passed to `CURLOPT_SSLKEY` verbatim. **Empty for
+    /// `Pkcs12`**, which carries its own key - and empty means the applier
+    /// writes null rather than `""`, so a pooled handle cannot keep a key path
+    /// a previous transfer set.
     std::string key_path;
+
+    /// What `cert_path` holds, and so what `CURLOPT_SSLCERTTYPE` says (#833).
+    /// Defaulted to `Pem` because that is what every row written before the
+    /// field existed is - the same value the column backfills to.
+    ClientCertFormat format = ClientCertFormat::Pem;
 
     /// The key's passphrase, empty when it has none. Stored plaintext - see the
     /// struct comment and `docs/engine/db-schema.md`.
@@ -152,9 +209,18 @@ std::string client_cert_label (const ClientCertRule& rule);
  * certificate or key file this process cannot open - because every one of those
  * surfaces at handshake time as a TLS error that names the endpoint rather than
  * the setting, which is the shape this epic exists to stop.
+ *
+ * @p format decides what a *complete* entry is (#833): a `Pem` row needs its
+ * key file and a `Pkcs12` row must not name one, because the bundle carries the
+ * key and a path nothing reads is a field the card would ask for in vain. The
+ * declared format is also checked against the file's own first bytes - but only
+ * where those bytes say something (see `sniff_client_cert_format`), so a file
+ * this engine cannot classify is left for the backend to judge rather than
+ * refused by a parser of ours.
  */
 std::optional<std::string> client_cert_rejection (std::string_view host,
 const std::optional<int>& port,
+ClientCertFormat format,
 std::string_view cert_path,
 std::string_view key_path);
 

--- a/engine/include/vayu/types.hpp
+++ b/engine/include/vayu/types.hpp
@@ -1432,8 +1432,14 @@ struct ClientCertificate {
     // ALTER-friendly default, so nothing pushes this towards a sentinel.
     std::optional<int> port;
     std::string cert_path;
-    std::string key_path;
-    std::string passphrase; // "" = the key has none
+    std::string key_path; // "" for a PKCS#12 entry, which carries its own key
+    // What `cert_path` holds: `pem` or `p12` (issue #833). Stored rather than
+    // sniffed per transfer - the applier runs on every handle of every load
+    // run, and a format nothing recorded is one the Settings card cannot print.
+    // Held as its wire spelling, like `requests.http_version`, so the column
+    // survives a reorder of `vayu::http::ClientCertFormat`.
+    std::string cert_format = "pem";
+    std::string passphrase; // "" = the key has none; a PKCS#12 import password too
     int64_t created_at = 0;
     int64_t updated_at = 0;
 };

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -470,7 +470,13 @@ inline auto make_storage (const std::string& path) {
     make_column ("host", &ClientCertificate::host),
     make_column ("port", &ClientCertificate::port), // NULL = every port
     make_column ("cert_path", &ClientCertificate::cert_path),
-    make_column ("key_path", &ClientCertificate::key_path),
+    make_column ("key_path", &ClientCertificate::key_path), // "" for PKCS#12
+    // What the certificate file holds (issue #833). NOT NULL with a
+    // default_value on the `http_version` precedent, so sync_schema can ALTER
+    // TABLE ADD COLUMN it onto a registry written before the field existed -
+    // and every such row backfills to `pem`, which is exactly what it is: the
+    // format libcurl read by default when nothing named one.
+    make_column ("cert_format", &ClientCertificate::cert_format, default_value ("pem")),
     make_column ("passphrase", &ClientCertificate::passphrase),
     make_column ("created_at", &ClientCertificate::created_at),
     make_column ("updated_at", &ClientCertificate::updated_at)));

--- a/engine/src/http/event_loop/curl_utils.cpp
+++ b/engine/src/http/event_loop/curl_utils.cpp
@@ -682,11 +682,25 @@ const std::string& url) {
     }
     curl_easy_setopt (curl, CURLOPT_SSLCERT,
     matched != nullptr ? matched->cert_path.c_str () : static_cast<const char*> (nullptr));
+    // What that file is (issue #833). Without it libcurl reads whatever is
+    // there as PEM, which is why a Schannel build - the one backend that takes
+    // no PEM pair at all - could present nothing a user registered. Written on
+    // every handle for the same reason as the path beside it, and null on no
+    // match so a pooled handle cannot keep the type a previous transfer set.
+    curl_easy_setopt (curl, CURLOPT_SSLCERTTYPE,
+    matched != nullptr ? curl_ssl_cert_type (matched->format) :
+                         static_cast<const char*> (nullptr));
+    // A PKCS#12 bundle carries its own key and stores no key path, so this is
+    // null there rather than "" - an empty string is a path, and libcurl would
+    // fail to open it.
     curl_easy_setopt (curl, CURLOPT_SSLKEY,
-    matched != nullptr ? matched->key_path.c_str () : static_cast<const char*> (nullptr));
+    matched != nullptr && !matched->key_path.empty () ?
+    matched->key_path.c_str () :
+    static_cast<const char*> (nullptr));
     // Null rather than "" when there is no passphrase: an empty string is a
     // passphrase attempt, and on a key that has none the backend answers by
-    // failing the load.
+    // failing the load. One field for both formats, because libcurl reads it as
+    // the PKCS#12 import password too.
     curl_easy_setopt (curl, CURLOPT_KEYPASSWD,
     matched != nullptr && !matched->passphrase.empty () ?
     matched->passphrase.c_str () :

--- a/engine/src/http/routes/client_certificates.cpp
+++ b/engine/src/http/routes/client_certificates.cpp
@@ -19,11 +19,12 @@
  * Two rules are enforced here rather than deeper down, because only a route can
  * answer with a status code:
  *
- *  1. **A registered entry is usable.** Host shape, port range and both file
- *     paths are checked at write time (`client_cert_rejection`). A path that is
- *     not there fails at handshake time as an SSL error naming the endpoint,
- *     which reads as "the API is broken" - the misdiagnosis this epic exists to
- *     end.
+ *  1. **A registered entry is usable.** Host shape, port range, the file paths
+ *     the declared format calls for, and that format against the file's own
+ *     bytes are all checked at write time (`client_cert_rejection`). A path
+ *     that is not there - or a PKCS#12 file registered as a PEM pair - fails at
+ *     handshake time as an SSL error naming the endpoint, which reads as "the
+ *     API is broken" - the misdiagnosis this epic exists to end.
  *  2. **One entry per host+port.** Two rows claiming the same target would make
  *     the certificate presented depend on row order, so the second one is a 409
  *     naming the first rather than a silent shadowing.
@@ -109,6 +110,71 @@ const std::string& self_id) {
     return std::nullopt;
 }
 
+/// The wire spellings a `certFormat` may take, for the tail of a rejection.
+/// Built from `all_client_cert_formats()` so the set accepted and the set
+/// advertised cannot drift - the `http_version_valid_list` rule.
+std::string cert_format_valid_list () {
+    std::string list;
+    for (const auto format : vayu::http::all_client_cert_formats ()) {
+        if (!list.empty ()) {
+            list += ", ";
+        }
+        list += "'" + std::string (vayu::http::to_string (format)) + "'";
+    }
+    return list;
+}
+
+/**
+ * The `certFormat` of a create or update body onto @p out (issue #833).
+ *
+ * Absent on create is the one place this engine *guesses*, and it guesses from
+ * the file rather than from a constant: a user who named a `.p12` gets a
+ * PKCS#12 row without having to know the field exists, and a file that says
+ * nothing this engine can read falls back to `pem`, which is what every row
+ * written before the field existed is. An explicit value is never overridden -
+ * `client_cert_rejection` then checks it against the file and refuses a
+ * contradiction, so correcting a bad sniff is possible and being wrong is loud.
+ *
+ * An unrecognised spelling is a 400 rather than the silent ignore
+ * `apply_string_field` would give it: an entry quietly registered as PEM
+ * because "PKCS12" was not the word we wanted is a handshake failure against
+ * the endpoint later.
+ */
+std::optional<std::pair<int, nlohmann::json>>
+apply_cert_format_field (const nlohmann::json& json,
+std::string& out,
+std::string_view cert_path,
+bool is_create) {
+    const auto seed = [&] () {
+        const auto sniffed = vayu::http::sniff_client_cert_format (cert_path);
+        out = sniffed ? vayu::http::to_string (*sniffed) :
+                        vayu::http::to_string (vayu::http::ClientCertFormat::Pem);
+    };
+    if (!json.contains ("certFormat")) {
+        if (is_create) {
+            seed ();
+        }
+        return std::nullopt;
+    }
+    if (json["certFormat"].is_null ()) {
+        seed ();
+        return std::nullopt;
+    }
+    if (!json["certFormat"].is_string ()) {
+        return std::make_pair (400,
+        error_body (400, "Invalid 'certFormat': must be a string. Valid values: " +
+        cert_format_valid_list ()));
+    }
+    const std::string candidate = json["certFormat"].get<std::string> ();
+    if (!vayu::http::client_cert_format_from_string (candidate)) {
+        return std::make_pair (400,
+        error_body (400, "Invalid 'certFormat': '" + candidate +
+        "' is not a certificate format. Valid values: " + cert_format_valid_list ()));
+    }
+    out = candidate;
+    return std::nullopt;
+}
+
 /**
  * The fields of a create or update body onto @p c, under the standard
  * null-vs-absent rule, ending in the shared usability check.
@@ -130,15 +196,48 @@ bool is_create) {
     if (auto err = apply_required_string_field (json, "certPath", c.cert_path, is_create)) {
         return err;
     }
-    if (auto err = apply_required_string_field (json, "keyPath", c.key_path, is_create)) {
+    // After `certPath`, because an absent format is read off that file.
+    if (auto err = apply_cert_format_field (json, c.cert_format, c.cert_path, is_create)) {
         return err;
+    }
+    // `keyPath` is required for a PEM pair and must be absent for a PKCS#12
+    // bundle, so it cannot go through `apply_required_string_field`: what a
+    // complete row looks like depends on the format beside it. `null` clears
+    // it, which is how an entry moves from PEM to PKCS#12 in one PUT; the
+    // "which format needs which file" rule itself stays in
+    // `client_cert_rejection`, the one copy both this route and the resolver
+    // read.
+    if (json.contains ("keyPath")) {
+        if (json["keyPath"].is_null ()) {
+            c.key_path.clear ();
+        } else if (!json["keyPath"].is_string ()) {
+            return std::make_pair (400,
+            error_body (400, "Invalid 'keyPath': must be a string, or null for a "
+                             "PKCS#12 entry that carries its own key"));
+        } else {
+            c.key_path = json["keyPath"].get<std::string> ();
+        }
+    } else if (is_create) {
+        c.key_path.clear ();
     }
     // The one field with a default: a key without a passphrase is the common
     // case, so absent on create means "none" and `null` on update clears it.
     apply_string_field (json, "passphrase", c.passphrase, "", is_create);
 
+    // The merged row's format. Unparseable only when the *stored* value is one
+    // no route would have written - a hand-edited row - and that is a 400
+    // rather than a fallback to `pem`: an update that answered 200 while
+    // leaving the row unusable is the silent acceptance this file exists to
+    // avoid, and the caller can fix it by naming `certFormat` here.
+    const auto format = vayu::http::client_cert_format_from_string (c.cert_format);
+    if (!format) {
+        return std::make_pair (400,
+        error_body (400, "Stored 'certFormat' is '" + c.cert_format +
+        "', which is not a certificate format - set it explicitly. Valid values: " +
+        cert_format_valid_list ()));
+    }
     if (const auto rejection =
-        vayu::http::client_cert_rejection (c.host, c.port, c.cert_path, c.key_path)) {
+        vayu::http::client_cert_rejection (c.host, c.port, *format, c.cert_path, c.key_path)) {
         return std::make_pair (
         400, error_body (400, "Invalid client certificate: " + *rejection));
     }
@@ -225,7 +324,8 @@ void register_client_certificate_routes (RouteContext& ctx) {
      * POST /client-certificates
      * Registers a certificate for a host. Create only.
      * Body params: host (required), port (int or null = every port),
-     * certPath (required), keyPath (required), passphrase.
+     * certPath (required), certFormat ('pem' | 'p12', read off the file when
+     * absent), keyPath (required for 'pem', refused for 'p12'), passphrase.
      * Returns: the created entry, 400 (bad shape, unreadable file, body `id`)
      * or 409 (host+port already registered).
      */

--- a/engine/src/http/transport_policy.cpp
+++ b/engine/src/http/transport_policy.cpp
@@ -295,8 +295,63 @@ std::string client_cert_label (const ClientCertRule& rule) {
     return rule.port ? rule.host + ":" + std::to_string (*rule.port) : rule.host;
 }
 
+std::array<ClientCertFormat, 2> all_client_cert_formats () {
+    return { ClientCertFormat::Pem, ClientCertFormat::Pkcs12 };
+}
+
+const char* to_string (ClientCertFormat format) {
+    switch (format) {
+    case ClientCertFormat::Pem: return "pem";
+    case ClientCertFormat::Pkcs12: return "p12";
+    }
+    return "pem";
+}
+
+const char* curl_ssl_cert_type (ClientCertFormat format) {
+    switch (format) {
+    case ClientCertFormat::Pem: return "PEM";
+    case ClientCertFormat::Pkcs12: return "P12";
+    }
+    return "PEM";
+}
+
+std::optional<ClientCertFormat> client_cert_format_from_string (std::string_view value) {
+    for (const auto format : all_client_cert_formats ()) {
+        if (value == to_string (format)) {
+            return format;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<ClientCertFormat> sniff_client_cert_format (std::string_view path) {
+    std::ifstream file{ std::string (path), std::ios::binary };
+    if (!file) {
+        return std::nullopt;
+    }
+    // Enough to clear the "Bag Attributes" preamble `openssl pkcs12` writes
+    // ahead of a PEM block, and small enough that a wrong path costs one page.
+    std::array<char, 4096> head{};
+    file.read (head.data (), static_cast<std::streamsize> (head.size ()));
+    const std::string_view leading (head.data (), static_cast<std::size_t> (file.gcount ()));
+    if (leading.empty ()) {
+        return std::nullopt;
+    }
+    // The PEM marker is looked for first because a PEM file is text and the
+    // ASN.1 tag below is also the ASCII digit '0' - a rule the other way round
+    // would classify a text file starting with a zero as a PKCS#12 bundle.
+    if (leading.find ("-----BEGIN") != std::string_view::npos) {
+        return ClientCertFormat::Pem;
+    }
+    if (static_cast<unsigned char> (leading.front ()) == 0x30) {
+        return ClientCertFormat::Pkcs12;
+    }
+    return std::nullopt;
+}
+
 std::optional<std::string> client_cert_rejection (std::string_view host,
 const std::optional<int>& port,
+ClientCertFormat format,
 std::string_view cert_path,
 std::string_view key_path) {
     if (host.empty () || is_blank (host)) {
@@ -331,12 +386,29 @@ std::string_view key_path) {
         return "port " + std::to_string (*port) + " is outside 1..65535";
     }
 
+    // A PKCS#12 bundle carries its own key, so a key path on such a row is a
+    // field nothing would ever read - refused rather than stored and ignored,
+    // because a card that keeps asking for a key file the format does not have
+    // is a dead end (#833). Clearing it is `keyPath: null` on the update.
+    if (format == ClientCertFormat::Pkcs12 && !key_path.empty () && !is_blank (key_path)) {
+        return std::string ("a PKCS#12 entry names no key file - the bundle carries the key, "
+                            "so clear the key file or register the certificate as PEM");
+    }
+
     // Both files are checked *here*, at the moment the user can still fix the
     // path, rather than at handshake time where curl reports
     // `CURLE_SSL_CERTPROBLEM` against the endpoint and says nothing about which
-    // setting named a file that is not there.
-    for (const auto& [label, path] : { std::pair{ "certificate file", cert_path },
-             std::pair{ "key file", key_path } }) {
+    // setting named a file that is not there. A PKCS#12 row has one file to
+    // check, which is the whole difference the format makes here.
+    std::vector<std::pair<const char*, std::string_view>> files{ { "certificate file", cert_path } };
+    if (format == ClientCertFormat::Pem) {
+        if (key_path.empty () || is_blank (key_path)) {
+            return std::string ("key file is empty - a PEM certificate keeps its key in a "
+                                "second file (only a PKCS#12 bundle carries its own)");
+        }
+        files.emplace_back ("key file", key_path);
+    }
+    for (const auto& [label, path] : files) {
         if (path.empty () || is_blank (path)) {
             return std::string (label) + " is empty";
         }
@@ -349,6 +421,19 @@ std::string_view key_path) {
         if (!probe) {
             return std::string (label) + " '" + std::string (path) + "' cannot be opened";
         }
+    }
+
+    // The declared format against the file's own bytes. Only a *contradiction*
+    // is refused: a file this engine cannot classify (a DER certificate, an
+    // encoding nobody here has seen) is left for the backend to judge, the same
+    // shallowness `ca_pem_rejection` is written with. What this catches is the
+    // mistake that otherwise surfaces as libcurl's own parse error against the
+    // endpoint - a `.p12` registered as a PEM pair, or the reverse.
+    if (const auto actual = sniff_client_cert_format (cert_path);
+        actual && *actual != format) {
+        return "certificate file '" + std::string (cert_path) + "' is " +
+        std::string (to_string (*actual)) + ", but the entry declares " +
+        std::string (to_string (format));
     }
 
     return std::nullopt;
@@ -424,8 +509,20 @@ TransportPolicy resolve_transport_policy (vayu::db::Database& db) {
     // The client-certificate registry (issue #707), read whole because a policy
     // serves every host a run may reach - see TransportPolicy::client_certificates.
     for (const auto& row : db.get_client_certificates ()) {
+        // A spelling the route would have refused, so only a hand-edited row
+        // reaches it. Dropped with its own line rather than defaulted to PEM:
+        // presenting the wrong shape is a handshake failure against the
+        // endpoint, and "which format" is not a thing to guess on the user's
+        // behalf.
+        const auto format = client_cert_format_from_string (row.cert_format);
+        if (!format) {
+            vayu::utils::log_error ("Client certificate '" + row.id + "' for host '" + row.host +
+            "' declares an unknown format '" + row.cert_format +
+            "'; requests to that host will be sent without it");
+            continue;
+        }
         if (const auto rejection =
-            client_cert_rejection (row.host, row.port, row.cert_path, row.key_path)) {
+            client_cert_rejection (row.host, row.port, *format, row.cert_path, row.key_path)) {
             // The routes refuse this shape, so only a hand-edited row or a file
             // that has moved since it was registered reaches here. Named rather
             // than swallowed, and named *now*: the alternative is a handshake
@@ -442,6 +539,7 @@ TransportPolicy resolve_transport_policy (vayu::db::Database& db) {
         rule.cert_path  = row.cert_path;
         rule.key_path   = row.key_path;
         rule.passphrase = row.passphrase;
+        rule.format     = *format;
         policy.client_certificates.push_back (std::move (rule));
     }
 

--- a/engine/src/utils/json.cpp
+++ b/engine/src/utils/json.cpp
@@ -574,7 +574,14 @@ Json serialize (const vayu::db::ClientCertificate& certificate) {
         json["port"] = nullptr;
     }
     json["certPath"] = certificate.cert_path;
-    json["keyPath"]  = certificate.key_path;
+    // `""`, not null, for a PKCS#12 entry: the field is a path the row does not
+    // have rather than a value withheld, and the card renders the empty string
+    // as "no key file" without a second case for absence.
+    json["keyPath"] = certificate.key_path;
+    // What the certificate file is read as (issue #833). Echoed because the
+    // card prints it per row - a format stored and never shown would be a
+    // guess the user cannot correct.
+    json["certFormat"] = certificate.cert_format;
     // Whether the key has a passphrase, never the passphrase - see the header.
     json["hasPassphrase"] = !certificate.passphrase.empty ();
     json["createdAt"]     = certificate.created_at;

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -67,9 +68,15 @@ namespace routes = vayu::http::routes;
  */
 class ScratchFile {
     public:
-    explicit ScratchFile (std::string name) : path_ (std::move (name)) {
+    /// @p contents defaults to bytes no format claims, which is what most of
+    /// this suite wants: a path that is *there*. A test about `certFormat`
+    /// passes shaped bytes instead - the marker or the ASN.1 tag - because that
+    /// is the one rule here that reads the file rather than the directory
+    /// entry.
+    explicit ScratchFile (std::string name, const std::string& contents = "not-a-real-certificate\n")
+    : path_ (std::move (name)) {
         std::ofstream out (path_, std::ios::binary | std::ios::trunc);
-        out << "not-a-real-certificate\n";
+        out.write (contents.data (), static_cast<std::streamsize> (contents.size ()));
     }
     ~ScratchFile () {
         std::error_code ec;
@@ -255,21 +262,22 @@ TEST (ClientCertValidation, AcceptsAHostAndAReadablePair) {
     ScratchFile key{ "validation_key.pem" };
 
     EXPECT_FALSE (
-    client_cert_rejection ("api.example.com", std::nullopt, cert.path (), key.path ())
+    client_cert_rejection ("api.example.com", std::nullopt, ClientCertFormat::Pem, cert.path (), key.path ())
     .has_value ());
     EXPECT_FALSE (
-    client_cert_rejection ("api.example.com", 8443, cert.path (), key.path ()).has_value ());
+    client_cert_rejection ("api.example.com", 8443, ClientCertFormat::Pem, cert.path (), key.path ()).has_value ());
     // An IPv6 literal, bracketless - the form `parse_authority` yields, so the
     // form a match will compare against.
     EXPECT_FALSE (
-    client_cert_rejection ("::1", 8443, cert.path (), key.path ()).has_value ());
+    client_cert_rejection ("::1", 8443, ClientCertFormat::Pem, cert.path (), key.path ()).has_value ());
 }
 
 TEST (ClientCertValidation, RejectsAHostThatCouldNeverMatch) {
     ScratchFile cert{ "validation_cert2.pem" };
     ScratchFile key{ "validation_key2.pem" };
     const auto reject = [&] (const std::string& host) {
-        return client_cert_rejection (host, std::nullopt, cert.path (), key.path ());
+        return client_cert_rejection (
+        host, std::nullopt, ClientCertFormat::Pem, cert.path (), key.path ());
     };
 
     // Every one of these is what a user gets by copying an address bar, and
@@ -288,11 +296,11 @@ TEST (ClientCertValidation, RejectsAPortOutsideTheRange) {
     ScratchFile key{ "validation_key3.pem" };
 
     EXPECT_TRUE (
-    client_cert_rejection ("api.example.com", 0, cert.path (), key.path ()).has_value ());
+    client_cert_rejection ("api.example.com", 0, ClientCertFormat::Pem, cert.path (), key.path ()).has_value ());
     EXPECT_TRUE (
-    client_cert_rejection ("api.example.com", 70000, cert.path (), key.path ()).has_value ());
+    client_cert_rejection ("api.example.com", 70000, ClientCertFormat::Pem, cert.path (), key.path ()).has_value ());
     EXPECT_TRUE (
-    client_cert_rejection ("api.example.com", -1, cert.path (), key.path ()).has_value ());
+    client_cert_rejection ("api.example.com", -1, ClientCertFormat::Pem, cert.path (), key.path ()).has_value ());
 }
 
 TEST (ClientCertValidation, RejectsAFileThatIsNotThere) {
@@ -300,21 +308,126 @@ TEST (ClientCertValidation, RejectsAFileThatIsNotThere) {
     ScratchFile key{ "validation_key4.pem" };
 
     const auto missing_cert = client_cert_rejection (
-    "api.example.com", std::nullopt, "/nope/client.pem", key.path ());
+    "api.example.com", std::nullopt, ClientCertFormat::Pem, "/nope/client.pem", key.path ());
     ASSERT_TRUE (missing_cert.has_value ());
     // The message has to name the file, or the user is left with "invalid
     // certificate" and two paths to check by hand.
     EXPECT_NE (missing_cert->find ("/nope/client.pem"), std::string::npos);
 
     const auto missing_key = client_cert_rejection (
-    "api.example.com", std::nullopt, cert.path (), "/nope/client.key");
+    "api.example.com", std::nullopt, ClientCertFormat::Pem, cert.path (), "/nope/client.key");
     ASSERT_TRUE (missing_key.has_value ());
     EXPECT_NE (missing_key->find ("/nope/client.key"), std::string::npos);
 
     // A directory is not a file, and opening one succeeds on some platforms -
     // which is why the check asks for a *regular* file.
-    EXPECT_TRUE (
-    client_cert_rejection ("api.example.com", std::nullopt, ".", key.path ()).has_value ());
+    EXPECT_TRUE (client_cert_rejection (
+    "api.example.com", std::nullopt, ClientCertFormat::Pem, ".", key.path ())
+    .has_value ());
+}
+
+// ---------------------------------------------------------------------------
+// The certificate format (issue #833)
+// ---------------------------------------------------------------------------
+
+/// The first bytes of each shape, which is all `sniff_client_cert_format`
+/// reads. Not real material: what is under test is the classifier, and a real
+/// bundle would prove the same thing while needing OpenSSL to mint it (the
+/// wire tests in `mutual_tls_test.cpp` use real ones).
+constexpr std::string_view PEM_SHAPED = "-----BEGIN CERTIFICATE-----\nMIIB\n";
+constexpr std::string_view DER_SHAPED = "\x30\x82\x04\x0a not really a bundle";
+
+TEST (ClientCertFormat, ReadsTheShapeOfAFileOrSaysNothing) {
+    ScratchFile pem{ "format_pem.pem", std::string (PEM_SHAPED) };
+    ScratchFile der{ "format_der.p12", std::string (DER_SHAPED) };
+    ScratchFile neither{ "format_neither.txt", "hello\n" };
+    ScratchFile empty{ "format_empty.pem", "" };
+
+    EXPECT_EQ (sniff_client_cert_format (pem.path ()), ClientCertFormat::Pem);
+    EXPECT_EQ (sniff_client_cert_format (der.path ()), ClientCertFormat::Pkcs12);
+    // Unclassified, *not* wrong: a file this engine cannot name is left for the
+    // backend to judge, the shallowness `ca_pem_rejection` is written with.
+    EXPECT_FALSE (sniff_client_cert_format (neither.path ()).has_value ());
+    EXPECT_FALSE (sniff_client_cert_format (empty.path ()).has_value ());
+    EXPECT_FALSE (sniff_client_cert_format ("/nope/client.p12").has_value ());
+}
+
+TEST (ClientCertFormat, TheWireSpellingAndTheCurlTypeAreSeparate) {
+    // Two vocabularies that happen to describe one thing: `certFormat` is ours
+    // and appears in every stored row, `CURLOPT_SSLCERTTYPE` is libcurl's. A
+    // helper that returned one for the other would send `pem` to a backend that
+    // only answers to `PEM`.
+    EXPECT_STREQ (to_string (ClientCertFormat::Pem), "pem");
+    EXPECT_STREQ (to_string (ClientCertFormat::Pkcs12), "p12");
+    EXPECT_STREQ (curl_ssl_cert_type (ClientCertFormat::Pem), "PEM");
+    EXPECT_STREQ (curl_ssl_cert_type (ClientCertFormat::Pkcs12), "P12");
+
+    EXPECT_EQ (client_cert_format_from_string ("pem"), ClientCertFormat::Pem);
+    EXPECT_EQ (client_cert_format_from_string ("p12"), ClientCertFormat::Pkcs12);
+    EXPECT_FALSE (client_cert_format_from_string ("PEM").has_value ());
+    EXPECT_FALSE (client_cert_format_from_string ("pkcs12").has_value ());
+    EXPECT_FALSE (client_cert_format_from_string ("").has_value ());
+}
+
+TEST (ClientCertValidation, APkcs12EntryCarriesItsOwnKeyAndMayNotNameOne) {
+    ScratchFile bundle{ "validation_bundle.p12", std::string (DER_SHAPED) };
+    ScratchFile key{ "validation_bundle_key.pem" };
+
+    EXPECT_FALSE (client_cert_rejection ("api.example.com", std::nullopt,
+    ClientCertFormat::Pkcs12, bundle.path (), "")
+                  .has_value ())
+    << "a bundle with no key path is the only complete shape a PKCS#12 entry "
+       "has";
+
+    // Stored and ignored is the failure this refusal exists to prevent: the
+    // card would keep asking for a file nothing ever opens.
+    const auto with_key = client_cert_rejection (
+    "api.example.com", std::nullopt, ClientCertFormat::Pkcs12, bundle.path (), key.path ());
+    ASSERT_TRUE (with_key.has_value ());
+    EXPECT_NE (with_key->find ("PKCS#12"), std::string::npos) << *with_key;
+
+    // And the mirror: a PEM entry without a key names what is missing rather
+    // than failing later against the endpoint.
+    const auto without_key = client_cert_rejection (
+    "api.example.com", std::nullopt, ClientCertFormat::Pem, bundle.path (), "");
+    ASSERT_TRUE (without_key.has_value ());
+    EXPECT_NE (without_key->find ("key file"), std::string::npos) << *without_key;
+}
+
+TEST (ClientCertValidation, RefusesAFileThatContradictsItsDeclaredFormat) {
+    ScratchFile pem{ "contradiction_cert.pem", std::string (PEM_SHAPED) };
+    ScratchFile der{ "contradiction_bundle.p12", std::string (DER_SHAPED) };
+    ScratchFile key{ "contradiction_key.pem" };
+
+    // The mistake worth catching at write time: a `.p12` registered as a PEM
+    // pair fails at handshake time as libcurl's own parse error against the
+    // endpoint, which is the misdiagnosis this registry exists to end.
+    const auto bundle_as_pem = client_cert_rejection (
+    "api.example.com", std::nullopt, ClientCertFormat::Pem, der.path (), key.path ());
+    ASSERT_TRUE (bundle_as_pem.has_value ());
+    EXPECT_NE (bundle_as_pem->find ("p12"), std::string::npos) << *bundle_as_pem;
+    EXPECT_NE (bundle_as_pem->find (der.path ()), std::string::npos) << *bundle_as_pem;
+
+    const auto pem_as_bundle = client_cert_rejection (
+    "api.example.com", std::nullopt, ClientCertFormat::Pkcs12, pem.path (), "");
+    ASSERT_TRUE (pem_as_bundle.has_value ());
+    EXPECT_NE (pem_as_bundle->find ("pem"), std::string::npos) << *pem_as_bundle;
+}
+
+TEST (ClientCertValidation, LeavesAFileItCannotClassifyToTheBackend) {
+    // The other half of the rule above, and the reason the check is a
+    // contradiction rather than a whitelist: a DER certificate, a format nobody
+    // here has seen, or the byte-shaped fixtures this suite uses must not be
+    // refused by a parser of ours.
+    ScratchFile unclassified{ "unclassified_cert.pem" };
+    ScratchFile key{ "unclassified_key.pem" };
+
+    EXPECT_FALSE (client_cert_rejection ("api.example.com", std::nullopt,
+    ClientCertFormat::Pem, unclassified.path (), key.path ())
+                  .has_value ());
+    EXPECT_FALSE (client_cert_rejection ("api.example.com", std::nullopt,
+    ClientCertFormat::Pkcs12, unclassified.path (), "")
+                  .has_value ());
 }
 
 // ---------------------------------------------------------------------------
@@ -337,6 +450,91 @@ TEST_F (ClientCertificateDbTest, CreatesAndListsAnEntry) {
     EXPECT_EQ (rows.front ().host, "api.example.com");
     ASSERT_TRUE (rows.front ().port.has_value ());
     EXPECT_EQ (*rows.front ().port, 8443);
+}
+
+TEST_F (ClientCertificateDbTest, RegistersAPkcs12EntryWithNoKeyPath) {
+    // The shape a Windows user has to be able to store (#833). The bundle
+    // carries the key, so the body names none at all - and the row echoes both
+    // the format and an empty `keyPath`, which is what lets the card stop
+    // asking for a file that does not exist.
+    ScratchFile bundle{ "route_bundle.p12", std::string (DER_SHAPED) };
+    const json payload = { { "host", "api.example.com" }, { "certPath", bundle.path () },
+        { "certFormat", "p12" } };
+
+    const auto [status, created] = routes::create_client_certificate_response (*db_, payload);
+    ASSERT_EQ (status, 200) << created.dump ();
+    EXPECT_EQ (created["certFormat"], "p12");
+    EXPECT_EQ (created["keyPath"], "");
+    EXPECT_EQ (db_->get_client_certificates ().front ().cert_format, "p12");
+}
+
+TEST_F (ClientCertificateDbTest, ReadsAnAbsentFormatOffTheFile) {
+    // A user who never learns the field exists still gets a usable row - and
+    // the guess comes from the bytes, not from a constant, so naming a bundle
+    // is enough.
+    ScratchFile bundle{ "sniffed_bundle.p12", std::string (DER_SHAPED) };
+    ScratchFile pem{ "sniffed_cert.pem", std::string (PEM_SHAPED) };
+
+    const auto [bundle_status, from_bundle] = routes::create_client_certificate_response (
+    *db_, json{ { "host", "bundle.example.com" }, { "certPath", bundle.path () } });
+    ASSERT_EQ (bundle_status, 200) << from_bundle.dump ();
+    EXPECT_EQ (from_bundle["certFormat"], "p12");
+
+    const auto [pem_status, from_pem] = routes::create_client_certificate_response (
+    *db_, json{ { "host", "pem.example.com" }, { "certPath", pem.path () },
+        { "keyPath", key_.path () } });
+    ASSERT_EQ (pem_status, 200) << from_pem.dump ();
+    EXPECT_EQ (from_pem["certFormat"], "pem");
+
+    // And a file that says nothing falls back to `pem` - what every row written
+    // before this field existed is, and what the column backfills to.
+    const auto [plain_status, from_plain] =
+    routes::create_client_certificate_response (*db_, body ("plain.example.com"));
+    ASSERT_EQ (plain_status, 200) << from_plain.dump ();
+    EXPECT_EQ (from_plain["certFormat"], "pem");
+}
+
+TEST_F (ClientCertificateDbTest, RefusesAFormatItDoesNotKnow) {
+    json payload           = body ("api.example.com");
+    payload["certFormat"]  = "pkcs12";
+
+    const auto [status, error] = routes::create_client_certificate_response (*db_, payload);
+    EXPECT_EQ (status, 400);
+    // Named rather than ignored: a row quietly stored as PEM because the
+    // spelling was not ours is a handshake failure against the endpoint later.
+    EXPECT_NE (error["error"]["message"].get<std::string> ().find ("'pem'"), std::string::npos)
+    << error.dump ();
+}
+
+TEST_F (ClientCertificateDbTest, RefusesAPemEntryWithNoKeyFile) {
+    json payload = { { "host", "api.example.com" }, { "certPath", cert_.path () } };
+
+    const auto [status, error] = routes::create_client_certificate_response (*db_, payload);
+    EXPECT_EQ (status, 400);
+    EXPECT_NE (error["error"]["message"].get<std::string> ().find ("key file"), std::string::npos)
+    << error.dump ();
+}
+
+TEST_F (ClientCertificateDbTest, MovingAnEntryToPkcs12ClearsTheKeyPath) {
+    // The merged-row rule doing real work: the format and the certificate move
+    // together, and `keyPath: null` is how the file the old format needed goes
+    // away. Without the clear the merged row would still name a key, which a
+    // PKCS#12 entry may not.
+    ScratchFile bundle{ "moved_bundle.p12", std::string (DER_SHAPED) };
+    const auto [created_status, created] =
+    routes::create_client_certificate_response (*db_, body ("api.example.com"));
+    ASSERT_EQ (created_status, 200) << created.dump ();
+    const std::string id = created["id"];
+
+    const auto [kept_status, kept] = routes::update_client_certificate_response (*db_, id,
+    json{ { "certFormat", "p12" }, { "certPath", bundle.path () } });
+    EXPECT_EQ (kept_status, 400) << kept.dump ();
+
+    const auto [status, updated] = routes::update_client_certificate_response (*db_, id,
+    json{ { "certFormat", "p12" }, { "certPath", bundle.path () }, { "keyPath", nullptr } });
+    ASSERT_EQ (status, 200) << updated.dump ();
+    EXPECT_EQ (updated["certFormat"], "p12");
+    EXPECT_EQ (updated["keyPath"], "");
 }
 
 TEST_F (ClientCertificateDbTest, StoresTheHostLowerCased) {
@@ -522,6 +720,59 @@ TEST_F (ClientCertificateDbTest, ARowWhoseFileWentMissingIsDroppedAndNamed) {
     EXPECT_EQ (policy.client_certificates.size (), 1u);
 }
 
+TEST_F (ClientCertificateDbTest, ARowDeclaringAFormatNobodyKnowsIsDroppedNotGuessed) {
+    // The route refuses this spelling, so only a hand-edited row reaches the
+    // resolver. Dropped rather than defaulted to PEM: presenting the wrong
+    // shape is a handshake failure against the endpoint, and which format a
+    // file is in is not a thing to guess on the user's behalf.
+    ASSERT_EQ (
+    routes::create_client_certificate_response (*db_, body ("api.example.com")).first, 200);
+    {
+        vayu::db::ClientCertificate row = db_->get_client_certificates ().front ();
+        row.cert_format                 = "pkcs12";
+        db_->save_client_certificate (row);
+    }
+
+    EXPECT_TRUE (resolve_transport_policy (*db_).client_certificates.empty ());
+
+    // And an update of that row answers 400 rather than 200-while-unusable: the
+    // merged format is read, not assumed, so the caller is told to name one.
+    const std::string id = db_->get_client_certificates ().front ().id;
+    const auto [status, error] =
+    routes::update_client_certificate_response (*db_, id, json{ { "host", "moved.example.com" } });
+    EXPECT_EQ (status, 400);
+    EXPECT_NE (error["error"]["message"].get<std::string> ().find ("certFormat"), std::string::npos)
+    << error.dump ();
+}
+
+TEST_F (ClientCertificateDbTest, TheStoredFormatReachesTheRuleTheApplierReads) {
+    // "Written but never read" is the defect this asserts against: a format
+    // stored on the row and dropped on the way to `ClientCertRule` would leave
+    // the applier writing PEM for every entry, exactly as before #833.
+    ScratchFile bundle{ "resolved_bundle.p12", std::string (DER_SHAPED) };
+    ASSERT_EQ (routes::create_client_certificate_response (*db_,
+               json{ { "host", "bundle.example.com" }, { "certPath", bundle.path () },
+                   { "certFormat", "p12" } })
+               .first,
+    200);
+    ASSERT_EQ (
+    routes::create_client_certificate_response (*db_, body ("pem.example.com")).first, 200);
+
+    const auto policy = resolve_transport_policy (*db_);
+    const ClientCertRule* bundle_rule =
+    match_client_certificate (policy, "bundle.example.com", 443);
+    ASSERT_NE (bundle_rule, nullptr);
+    EXPECT_EQ (bundle_rule->format, ClientCertFormat::Pkcs12);
+    EXPECT_TRUE (bundle_rule->key_path.empty ())
+    << "a bundle row carried a key path into the policy, which the applier "
+       "would hand libcurl as CURLOPT_SSLKEY";
+
+    const ClientCertRule* pem_rule = match_client_certificate (policy, "pem.example.com", 443);
+    ASSERT_NE (pem_rule, nullptr);
+    EXPECT_EQ (pem_rule->format, ClientCertFormat::Pem);
+    EXPECT_EQ (pem_rule->key_path, key_.path ());
+}
+
 // ---------------------------------------------------------------------------
 // Every driver applies the match
 // ---------------------------------------------------------------------------
@@ -628,6 +879,15 @@ TEST (ClientCertificateBackend, TakesTheCertificateOptionsOnThisPlatform) {
     << "TLS backend '" << backend << "' refuses CURLOPT_SSLKEY";
     EXPECT_EQ (curl_easy_setopt (curl, CURLOPT_KEYPASSWD, "secret"), CURLE_OK)
     << "TLS backend '" << backend << "' refuses CURLOPT_KEYPASSWD";
+    // Both types, on every leg: the option is how a stored format reaches
+    // libcurl at all (#833), and a backend that refused one of them would leave
+    // entries in that format going out as something else, or not at all.
+    for (const auto format : all_client_cert_formats ()) {
+        EXPECT_EQ (curl_easy_setopt (curl, CURLOPT_SSLCERTTYPE, curl_ssl_cert_type (format)),
+        CURLE_OK)
+        << "TLS backend '" << backend << "' refuses CURLOPT_SSLCERTTYPE '"
+        << curl_ssl_cert_type (format) << "'";
+    }
     curl_easy_cleanup (curl);
 }
 

--- a/engine/tests/mutual_tls_test.cpp
+++ b/engine/tests/mutual_tls_test.cpp
@@ -25,20 +25,24 @@
  *
  * ## The per-backend format matrix
  *
- * A client identity does not travel in one shape:
+ * A client identity does not travel in one shape, and since #833 the row says
+ * which one it is in - so every case here runs **once per format this build can
+ * present**, rather than once in the only format the engine could write:
  *
- * | Backend | This build | A client identity arrives as |
+ * | Backend | This build | A client identity may arrive as |
  * |---|---|---|
- * | OpenSSL (Linux, macOS) | yes | a PEM certificate and a PEM key |
- * | Schannel (Windows) | yes | PKCS#12, or a certificate-store reference |
+ * | OpenSSL (Linux, macOS) | yes | a PEM certificate + PEM key, or PKCS#12 |
+ * | Schannel (Windows) | yes | PKCS#12 (or a certificate-store reference) |
  *
- * The engine writes `CURLOPT_SSLCERT` / `CURLOPT_SSLKEY` and **no**
- * `CURLOPT_SSLCERTTYPE`, so what it can present is libcurl's default, a PEM
- * pair - which is every backend in this repo except Schannel. The Windows leg
- * therefore skips these cases, loudly and with that reason, rather than
- * asserting a shape it cannot produce; `NoBackendIsSkippedForAReasonThatWentAway`
- * is the guard that stops the skip from outliving its cause, and #833 tracks
- * giving the registry a certificate format so the skip can go away entirely.
+ * That set comes from `client_identity_formats()`, so no leg is dark and no leg
+ * asserts a shape its backend cannot load: Windows runs the PKCS#12 half of
+ * every case below and skips nothing, where before #833 it ran none of them.
+ * A backend nothing here classifies presents an empty set, which
+ * `ThisBuildCanPresentAClientIdentityAtAll` fails on rather than letting the
+ * suite quietly instantiate nothing.
+ *
+ * A certificate-store reference is Schannel's other shape and is out of scope
+ * (#833): the registry stores file paths, and a store expression is not a file.
  */
 
 #include <gtest/gtest.h>
@@ -81,59 +85,43 @@ using vayu::tests::TlsServer;
 namespace routes = vayu::http::routes;
 
 // ---------------------------------------------------------------------------
-// What this build can host
-// ---------------------------------------------------------------------------
-
-/// Why @p backend cannot present the identity this fixture mints, or empty if
-/// it can. Phrased as a sentence because it is printed by a skip: a leg that
-/// silently runs nothing is worse than one that runs nothing and says why.
-std::string cannot_present_a_pem_pair (std::string_view backend) {
-    switch (vayu::tests::client_identity_format (backend)) {
-    case ClientIdentityFormat::PemPair: return {};
-    case ClientIdentityFormat::Pkcs12:
-        return "TLS backend '" + std::string (backend) +
-        "' takes a client identity as PKCS#12 or as a certificate-store "
-        "reference, never as the PEM pair libcurl reads by default - and the "
-        "engine writes no CURLOPT_SSLCERTTYPE, so a PEM pair is the only shape "
-        "it can present. Registering a PKCS#12 file here would fail on the "
-        "format rather than on anything this suite is about. Tracked in #833.";
-    case ClientIdentityFormat::Unknown: break;
-    }
-    return "TLS backend '" + std::string (backend) +
-    "' is one no statement in this repo covers, so what a client identity must "
-    "look like for it is unknown - decide and record it rather than letting "
-    "this fixture guess.";
-}
-
-// ---------------------------------------------------------------------------
 // Fixture material
 // ---------------------------------------------------------------------------
 
 /**
- * A PEM file on disk, removed when the test ends.
+ * A file on disk, removed when the test ends.
  *
  * The registry stores **paths** and libcurl opens them itself, so a client
  * identity is the one piece of material here that cannot stay in memory the
  * way the listener's does. It lands in the per-process scratch directory
- * (`temp_database.hpp`), lives for one test, and is named after it.
+ * (`temp_database.hpp`), lives for one test, and is named after it. Binary,
+ * because a PKCS#12 bundle is DER and a text-mode write would corrupt it on
+ * the one platform that cannot use anything else.
  */
-class PemFile {
+class IdentityFile {
     public:
-    PemFile (std::string name, const std::string& contents)
+    IdentityFile (std::string name, const std::string& contents)
     : path_ (std::move (name)) {
         std::ofstream out (path_, std::ios::binary | std::ios::trunc);
-        out << contents;
+        out.write (contents.data (), static_cast<std::streamsize> (contents.size ()));
         out.close ();
         if (!out) {
             throw std::runtime_error ("mutual_tls_test: could not write " + path_);
         }
     }
-    ~PemFile () {
+    ~IdentityFile () {
+        if (path_.empty ()) {
+            return; // Moved from: the file belongs to whoever took it.
+        }
         std::error_code ec;
         std::filesystem::remove (path_, ec);
     }
-    PemFile (const PemFile&)            = delete;
-    PemFile& operator= (const PemFile&) = delete;
+    IdentityFile (IdentityFile&& other) noexcept : path_ (std::move (other.path_)) {
+        other.path_.clear ();
+    }
+    IdentityFile (const IdentityFile&)            = delete;
+    IdentityFile& operator= (const IdentityFile&) = delete;
+    IdentityFile& operator= (IdentityFile&&)      = delete;
 
     const std::string& path () const {
         return path_;
@@ -143,11 +131,22 @@ class PemFile {
     std::string path_;
 };
 
-/// A client identity as the registry wants it: two paths, and optionally a
-/// passphrase the key is actually encrypted under.
+/**
+ * A client identity as the registry wants it, in one format or the other: a
+ * certificate file, and a key file only where the format keeps the key in one.
+ *
+ * The `key` being *absent* rather than empty is the shape under test as much as
+ * the bytes are - a PKCS#12 row names no key path at all, and a fixture that
+ * passed an empty string would be registering something the route refuses.
+ */
 struct ClientIdentity {
-    PemFile certificate;
-    PemFile key;
+    IdentityFile certificate;
+    std::optional<IdentityFile> key;
+
+    /// What the registry stores for the key, which is nothing for a bundle.
+    std::string key_path () const {
+        return key ? key->path () : std::string{};
+    }
 };
 
 Request get_request (const std::string& url) {
@@ -175,14 +174,18 @@ Response send_through (const TransportPolicy& transport, const std::string& url)
     return result.is_ok () ? result.value () : Response{};
 }
 
-class MutualTlsTest : public ::testing::Test {
+/**
+ * Every case, once per format this build can present (#833).
+ *
+ * Parameterized rather than skipped: the formats a backend takes are a set, so
+ * "which cases run here" is a property of the build and not a leg being dark.
+ * A case that does not read the parameter - the refusal with no entry
+ * registered - still runs once per format, because it shares this fixture and a
+ * second fixture for one test would cost more than the handshake does.
+ */
+class MutualTlsTest : public ::testing::TestWithParam<ClientIdentityFormat> {
     protected:
     void SetUp () override {
-        if (const std::string why =
-            cannot_present_a_pem_pair (vayu::tests::tls_backend_name ());
-            !why.empty ()) {
-            GTEST_SKIP () << why;
-        }
         vayu::tests::remove_database_files (path_);
         db_ = std::make_unique<vayu::db::Database> (path_);
         db_->seed_default_config ();
@@ -214,25 +217,44 @@ class MutualTlsTest : public ::testing::Test {
         db_->save_config_entry (*entry);
     }
 
-    /// An identity @p issuer signed, written where the registry can name it.
-    /// @p passphrase encrypts the key when it is not empty.
+    /// The format this instance is exercising, and the `certFormat` a row
+    /// registered here declares.
+    ClientIdentityFormat format () const {
+        return GetParam ();
+    }
+
+    /**
+     * An identity @p issuer signed, in this instance's format, written where
+     * the registry can name it. @p passphrase protects the key when it is not
+     * empty - the PEM key by encryption, the bundle by its import password,
+     * which is the same `passphrase` column either way.
+     */
     ClientIdentity identity (const std::string& name,
     const TestCertificateAuthority& issuer,
     const std::string& passphrase = {}) {
         const CertificateAndKey minted =
         issuer.issue ("vayu-test-client", "DNS:vayu-test-client");
-        return ClientIdentity{ PemFile{ name + "_cert.pem", minted.pem () },
-            PemFile{ name + "_key.pem",
+        if (format () == ClientIdentityFormat::Pkcs12) {
+            return ClientIdentity{ IdentityFile{ name + "_identity.p12",
+                                   minted.pkcs12 (passphrase) },
+                std::nullopt };
+        }
+        return ClientIdentity{ IdentityFile{ name + "_cert.pem", minted.pem () },
+            IdentityFile{ name + "_key.pem",
             passphrase.empty () ? minted.key_pem () : minted.encrypted_key_pem (passphrase) } };
     }
 
     /// Register an entry the way the app does, through the route - so the row
-    /// under test is one the shipped validation accepted.
+    /// under test is one the shipped validation accepted, `certFormat` and the
+    /// key path it does or does not carry included.
     void register_entry (const ClientIdentity& id,
     std::optional<int> port       = std::nullopt,
     const std::string& passphrase = {}) {
-        json payload = { { "host", "127.0.0.1" },
-            { "certPath", id.certificate.path () }, { "keyPath", id.key.path () } };
+        json payload = { { "host", "127.0.0.1" }, { "certPath", id.certificate.path () },
+            { "certFormat", vayu::tests::client_identity_format_name (format ()) } };
+        if (!id.key_path ().empty ()) {
+            payload["keyPath"] = id.key_path ();
+        }
         if (port) {
             payload["port"] = *port;
         }
@@ -266,47 +288,31 @@ class MutualTlsTest : public ::testing::Test {
 // ---------------------------------------------------------------------------
 
 TEST (MutualTlsBackend, ClassifiesTheBackendsThisRepoCanBeBuiltAgainst) {
-    // Runs everywhere, including where the skip below is not taken: a
-    // classifier that answered "PEM pair" to everything would be green on
-    // Linux and macOS and would only be caught by the Windows leg - the rule
-    // that a per-platform branch must not be asserted only where it happens to
-    // be taken.
-    EXPECT_EQ (vayu::tests::client_identity_format ("OpenSSL/3.6.3"),
-    ClientIdentityFormat::PemPair);
-    EXPECT_EQ (vayu::tests::client_identity_format ("Schannel"), ClientIdentityFormat::Pkcs12);
-    EXPECT_EQ (vayu::tests::client_identity_format ("GnuTLS/3.8.4"),
-    ClientIdentityFormat::Unknown);
-    EXPECT_EQ (vayu::tests::client_identity_format (""), ClientIdentityFormat::Unknown);
-
-    EXPECT_TRUE (cannot_present_a_pem_pair ("OpenSSL/3.6.3").empty ());
-    EXPECT_FALSE (cannot_present_a_pem_pair ("Schannel").empty ());
-    EXPECT_FALSE (cannot_present_a_pem_pair ("GnuTLS/3.8.4").empty ());
+    // Runs everywhere, not only where each answer is taken: a classifier that
+    // returned both formats for everything would be green on Linux and macOS
+    // and would only be caught by the Windows leg - the rule that a
+    // per-platform branch must not be asserted only where it happens to apply.
+    EXPECT_EQ (vayu::tests::client_identity_formats ("OpenSSL/3.6.3"),
+    (std::vector<ClientIdentityFormat>{ ClientIdentityFormat::PemPair,
+    ClientIdentityFormat::Pkcs12 }));
+    EXPECT_EQ (vayu::tests::client_identity_formats ("Schannel"),
+    (std::vector<ClientIdentityFormat>{ ClientIdentityFormat::Pkcs12 }));
+    // A PEM pair is the shape Schannel takes *no* file in, which is the whole
+    // reason the format is stored - assert the absence, not just the presence.
+    EXPECT_TRUE (vayu::tests::client_identity_formats ("GnuTLS/3.8.4").empty ());
+    EXPECT_TRUE (vayu::tests::client_identity_formats ("").empty ());
 }
 
-TEST (MutualTlsBackend, NoBackendIsSkippedForAReasonThatWentAway) {
-    // The skip above rests on one fact about the shipped code: the applier
-    // writes no certificate *type*, so libcurl's default - a PEM pair - is the
-    // only shape the engine can present. The day that changes (#833), the
-    // Windows leg stops being unhostable, and a skip nobody revisits would
-    // quietly keep it dark. So the fact is read off the source rather than
-    // remembered.
-    const std::filesystem::path applier = std::filesystem::path (VAYU_ENGINE_SOURCE_DIR) /
-    "src" / "http" / "event_loop" / "curl_utils.cpp";
-    std::ifstream file (applier);
-    std::stringstream buffer;
-    buffer << file.rdbuf ();
-    const std::string source = buffer.str ();
-
-    // A guard reading an empty string passes forever.
-    ASSERT_GT (source.size (), 1000u) << "read nothing from " << applier;
-    ASSERT_NE (source.find ("CURLOPT_SSLCERT"), std::string::npos)
-    << "the client-certificate options are not in " << applier
-    << " any more, so this suite is asserting against the wrong file";
-
-    EXPECT_EQ (source.find ("CURLOPT_SSLCERTTYPE"), std::string::npos)
-    << "the applier now names a certificate type, so a backend that wants "
-       "PKCS#12 may be hostable after all - revisit the skip in this file "
-       "(#833) instead of leaving Windows dark";
+TEST (MutualTlsBackend, ThisBuildCanPresentAClientIdentityAtAll) {
+    // The instantiation below draws its parameters from this list, so an empty
+    // one would silently generate no tests - a leg reporting nothing, which is
+    // exactly the darkness #833 removed. Failing here names the backend
+    // instead.
+    EXPECT_FALSE (vayu::tests::client_identity_formats ().empty ())
+    << "TLS backend '" << vayu::tests::tls_backend_name ()
+    << "' is one no statement in this repo covers, so what a client identity "
+       "must look like for it is unknown - decide and record it rather than "
+       "letting this fixture guess";
 }
 
 TEST (MutualTlsErrorMapping, AnUnreachableHttpsEndpointIsStillAConnectionFailure) {
@@ -328,7 +334,7 @@ TEST (MutualTlsErrorMapping, AnUnreachableHttpsEndpointIsStillAConnectionFailure
     << to_string (response.error_code) << ": " << response.error_message;
 }
 
-TEST_F (MutualTlsTest, TheListenerRefusesAClientWithNoCertificate) {
+TEST_P (MutualTlsTest, TheListenerRefusesAClientWithNoCertificate) {
     // Without this, every success below would prove nothing: a listener that
     // asked for a certificate and shrugged when none came would answer 200 to
     // an engine that presented nothing at all.
@@ -347,7 +353,7 @@ TEST_F (MutualTlsTest, TheListenerRefusesAClientWithNoCertificate) {
     << to_string (response.error_code) << ": " << response.error_message;
 }
 
-TEST_F (MutualTlsTest, AnIdentityFromAnotherAuthorityIsRefused) {
+TEST_P (MutualTlsTest, AnIdentityFromAnotherAuthorityIsRefused) {
     // The case that tells "a certificate was presented" apart from "this
     // certificate was accepted". The identity is well-formed and loads
     // cleanly; only its issuer is wrong.
@@ -368,7 +374,7 @@ TEST_F (MutualTlsTest, AnIdentityFromAnotherAuthorityIsRefused) {
 // The drivers
 // ---------------------------------------------------------------------------
 
-TEST_F (MutualTlsTest, ADesignSendCompletesTheHandshakeAndNamesTheEntry) {
+TEST_P (MutualTlsTest, ADesignSendCompletesTheHandshakeAndNamesTheEntry) {
     TlsServer server (ca_, ca_);
     const ClientIdentity client = identity ("design", ca_);
     register_entry (client);
@@ -385,7 +391,7 @@ TEST_F (MutualTlsTest, ADesignSendCompletesTheHandshakeAndNamesTheEntry) {
     EXPECT_EQ (response.client_certificate, "127.0.0.1");
 }
 
-TEST_F (MutualTlsTest, AnSseStreamPresentsTheCertificate) {
+TEST_P (MutualTlsTest, AnSseStreamPresentsTheCertificate) {
     // The driver that had no proxy option at all before #705, and would have
     // been the one to miss certificates too if each driver configured its own
     // transport.
@@ -407,7 +413,7 @@ TEST_F (MutualTlsTest, AnSseStreamPresentsTheCertificate) {
     EXPECT_EQ (response.client_certificate, "127.0.0.1");
 }
 
-TEST_F (MutualTlsTest, ALoadRunPresentsTheCertificate) {
+TEST_P (MutualTlsTest, ALoadRunPresentsTheCertificate) {
     // The load path resolves the policy once at run start and matches per
     // transfer from that snapshot, and its handles are pooled - so this also
     // says a reused handle keeps presenting the identity.
@@ -430,7 +436,7 @@ TEST_F (MutualTlsTest, ALoadRunPresentsTheCertificate) {
     EXPECT_EQ (batch.failed, 0u);
 }
 
-TEST_F (MutualTlsTest, PmSendRequestPresentsTheCertificate) {
+TEST_P (MutualTlsTest, PmSendRequestPresentsTheCertificate) {
     // `pm.sendRequest` builds its own ClientConfig inside the script engine, so
     // the registry reaches it through the context or not at all - and a script
     // that logs in against an mTLS endpoint is exactly the transfer #707's
@@ -468,7 +474,7 @@ TEST_F (MutualTlsTest, PmSendRequestPresentsTheCertificate) {
 // Precedence and the passphrase, on a wire
 // ---------------------------------------------------------------------------
 
-TEST_F (MutualTlsTest, ThePortEntryOutranksTheCatchAllOnAWire) {
+TEST_P (MutualTlsTest, ThePortEntryOutranksTheCatchAllOnAWire) {
     // Precedence is unit-tested in `client_certificates_test.cpp` against a
     // registry in memory. Here the two entries hold *different identities* and
     // only one of them is one the listener accepts, so the handshake itself is
@@ -489,10 +495,12 @@ TEST_F (MutualTlsTest, ThePortEntryOutranksTheCatchAllOnAWire) {
     response.client_certificate, "127.0.0.1:" + std::to_string (server.port ()));
 }
 
-TEST_F (MutualTlsTest, AnEncryptedKeyOpensWithItsPassphraseAndNotWithout) {
+TEST_P (MutualTlsTest, AnEncryptedKeyOpensWithItsPassphraseAndNotWithout) {
     // Both halves in one test on purpose: the failure alone would pass against
     // an engine that never sends the passphrase at all, and the success alone
-    // would pass against a key that was never encrypted.
+    // would pass against a key that was never encrypted. One column covers both
+    // formats - libcurl reads `CURLOPT_KEYPASSWD` as the PKCS#12 import
+    // password too, so the bundle instance proves that reading as well.
     TlsServer server (ca_, ca_);
     const ClientIdentity client = identity ("passphrase", ca_, "hunter2");
     register_entry (client, std::nullopt, "hunter2");
@@ -520,6 +528,45 @@ TEST_F (MutualTlsTest, AnEncryptedKeyOpensWithItsPassphraseAndNotWithout) {
     << "the refusal names nothing, so a user is left to guess which of the two "
        "settings is wrong";
 }
+
+TEST_P (MutualTlsTest, AnEntryThatNamesNoFormatIsReadOffTheFileAndStillConnects) {
+    // The write-time default (#833), against real material rather than the
+    // byte-shaped fixtures in `client_certificates_test.cpp`: a user who never
+    // learns the field exists must still end up with a row that hands libcurl
+    // the right type. Declaring nothing and connecting anyway is the assertion,
+    // in both formats - a sniff that answered `pem` to everything would fail
+    // the bundle instance here and nowhere else.
+    TlsServer server (ca_, ca_);
+    const ClientIdentity client = identity ("sniffed", ca_);
+
+    json payload = { { "host", "127.0.0.1" }, { "certPath", client.certificate.path () } };
+    if (!client.key_path ().empty ()) {
+        payload["keyPath"] = client.key_path ();
+    }
+    const auto [status, created] = routes::create_client_certificate_response (*db_, payload);
+    ASSERT_EQ (status, 200) << created.dump ();
+    EXPECT_EQ (created["certFormat"], vayu::tests::client_identity_format_name (format ()));
+
+    const Response response = send_through (policy (), server.url ("/hello"));
+
+    ASSERT_EQ (response.error_code, ErrorCode::None)
+    << "an entry whose format was read off the file did not complete the "
+       "handshake: "
+    << to_string (response.error_code) << ": " << response.error_message;
+    EXPECT_EQ (response.status_code, 200);
+}
+
+/**
+ * One instance per format this build can present. `client_identity_formats()`
+ * is the single source of that set - a leg gets the cases its backend can
+ * actually load and no others, which is what replaced the Windows-wide skip.
+ */
+INSTANTIATE_TEST_SUITE_P (PerClientIdentityFormat,
+MutualTlsTest,
+::testing::ValuesIn (vayu::tests::client_identity_formats ()),
+[] (const ::testing::TestParamInfo<ClientIdentityFormat>& info) {
+    return vayu::tests::client_identity_format_name (info.param);
+});
 
 } // namespace
 } // namespace vayu::http

--- a/engine/tests/mutual_tls_test.cpp
+++ b/engine/tests/mutual_tls_test.cpp
@@ -432,8 +432,22 @@ TEST_P (MutualTlsTest, ALoadRunPresentsTheCertificate) {
     const auto batch = loop.execute_batch (requests);
     loop.stop ();
 
+    // The counters alone prove nothing about TLS, and this test believed they
+    // did until the Windows leg reported it green while every sibling case
+    // failed the handshake: `execute_batch` counts a `Result` that is *ok*, and
+    // a refused handshake is an ok Result carrying an `error_code` - the error
+    // arm is reserved for a request that could not be attempted at all. So the
+    // assertion is on each response.
+    ASSERT_EQ (batch.responses.size (), 3u);
     EXPECT_EQ (batch.successful, 3u);
     EXPECT_EQ (batch.failed, 0u);
+    for (const auto& result : batch.responses) {
+        ASSERT_TRUE (result.is_ok ()) << result.error ().message;
+        EXPECT_EQ (result.value ().error_code, ErrorCode::None)
+        << "a pooled transfer did not complete the handshake: "
+        << to_string (result.value ().error_code) << ": " << result.value ().error_message;
+        EXPECT_EQ (result.value ().status_code, 200);
+    }
 }
 
 TEST_P (MutualTlsTest, PmSendRequestPresentsTheCertificate) {

--- a/engine/tests/mutual_tls_test.cpp
+++ b/engine/tests/mutual_tls_test.cpp
@@ -34,12 +34,21 @@
  * | OpenSSL (Linux, macOS) | yes | a PEM certificate + PEM key, or PKCS#12 |
  * | Schannel (Windows) | yes | PKCS#12 (or a certificate-store reference) |
  *
- * That set comes from `client_identity_formats()`, so no leg is dark and no leg
- * asserts a shape its backend cannot load: Windows runs the PKCS#12 half of
- * every case below and skips nothing, where before #833 it ran none of them.
- * A backend nothing here classifies presents an empty set, which
- * `ThisBuildCanPresentAClientIdentityAtAll` fails on rather than letting the
- * suite quietly instantiate nothing.
+ * That set comes from `client_identity_formats()`, so no leg asserts a shape
+ * its backend cannot load. A backend nothing here classifies presents an empty
+ * set, which `ThisBuildCanPresentAClientIdentityAtAll` fails on rather than
+ * letting the suite quietly instantiate nothing.
+ *
+ * **The Schannel leg still skips these cases, for a different reason than
+ * before #833** (issue #842). It is no longer "the engine can only write a PEM
+ * pair" - the engine names the format now, and that is asserted on Windows by
+ * `ClientCertificateBackend` and the registry suites. It is that *libcurl*
+ * cannot complete a client-certificate handshake there: curl 8.21.0's own
+ * `docs/KNOWN_BUGS.md` carries two entries for it, and every case below was
+ * measured failing at the second `InitializeSecurityContext` with both a
+ * legacy-PBE and a PBES2 bundle. The gate is `client_auth_defect()`, which is
+ * deliberately separate from the format matrix so that a fixed libcurl deletes
+ * one line and this suite runs whole on Windows.
  *
  * A certificate-store reference is Schannel's other shape and is out of scope
  * (#833): the registry stores file paths, and a store expression is not a file.
@@ -186,6 +195,14 @@ Response send_through (const TransportPolicy& transport, const std::string& url)
 class MutualTlsTest : public ::testing::TestWithParam<ClientIdentityFormat> {
     protected:
     void SetUp () override {
+        // Not "this backend takes no such file" - it does, and the row that
+        // names it is asserted on every leg. This is libcurl's own defect on
+        // the Schannel client-cert path (#842), so the *handshake* is what
+        // cannot run here, and the day upstream fixes it this skip goes and the
+        // instantiation below runs the p12 half unchanged.
+        if (const std::string why = vayu::tests::client_auth_defect (); !why.empty ()) {
+            GTEST_SKIP () << why;
+        }
         vayu::tests::remove_database_files (path_);
         db_ = std::make_unique<vayu::db::Database> (path_);
         db_->seed_default_config ();
@@ -301,6 +318,16 @@ TEST (MutualTlsBackend, ClassifiesTheBackendsThisRepoCanBeBuiltAgainst) {
     // reason the format is stored - assert the absence, not just the presence.
     EXPECT_TRUE (vayu::tests::client_identity_formats ("GnuTLS/3.8.4").empty ());
     EXPECT_TRUE (vayu::tests::client_identity_formats ("").empty ());
+
+    // The two questions stay apart (#842): which formats a backend reads is a
+    // fact about the backend, whether it can finish a client-auth handshake is
+    // a fact about the libcurl we pin. Schannel answers "PKCS#12" to the first
+    // and "not today" to the second, and a reader who conflated them would
+    // delete the wrong thing when upstream lands a fix.
+    EXPECT_TRUE (vayu::tests::client_auth_defect ("OpenSSL/3.6.3").empty ());
+    EXPECT_FALSE (vayu::tests::client_auth_defect ("Schannel").empty ());
+    EXPECT_NE (vayu::tests::client_auth_defect ("Schannel").find ("#842"), std::string::npos)
+    << "the skip must name where its cause is tracked, or it outlives it";
 }
 
 TEST (MutualTlsBackend, ThisBuildCanPresentAClientIdentityAtAll) {

--- a/engine/tests/tls_backend.hpp
+++ b/engine/tests/tls_backend.hpp
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace vayu::tests {
 
@@ -29,30 +30,48 @@ inline std::string tls_backend_name () {
     return info->ssl_version;
 }
 
-/// The shape a backend takes a client identity in.
+/// The shape a client identity is stored in.
 enum class ClientIdentityFormat {
     /// A PEM certificate and a PEM key, the pair libcurl reads by default.
     PemPair,
-    /// A PKCS#12 file, which libcurl reads only when told the type is `P12`,
-    /// or a reference into the platform's certificate store.
+    /// A PKCS#12 file, which libcurl reads only when told the type is `P12`.
     Pkcs12,
-    /// A backend no statement in this repo covers.
-    Unknown,
 };
 
-/// How @p backend expects a client identity to arrive. The families are the
-/// ones the pinned vcpkg baseline's `curl` port can be built against, the same
-/// set `verifies_through_a_bundle_file` in `transport_policy_test.cpp` covers.
-inline ClientIdentityFormat client_identity_format (std::string_view backend) {
+/**
+ * Every format @p backend can present a client identity in - which is a *set*,
+ * not one answer (#833): an OpenSSL build reads both, Schannel only the bundle.
+ *
+ * Empty for a backend no statement in this repo covers, and that emptiness is
+ * asserted rather than defaulted away: guessing a format for an unknown backend
+ * would leave a leg testing a shape it cannot present. The families are the
+ * ones the pinned vcpkg baseline's `curl` port can be built against, the same
+ * set `verifies_through_a_bundle_file` in `transport_policy_test.cpp` covers.
+ *
+ * A certificate-store reference is Schannel's second shape and is deliberately
+ * absent: it is not a file, so nothing in the registry can name one.
+ */
+inline std::vector<ClientIdentityFormat> client_identity_formats (std::string_view backend) {
     for (const std::string_view family : { "OpenSSL", "LibreSSL", "BoringSSL", "quictls" }) {
         if (backend.rfind (family, 0) == 0) {
-            return ClientIdentityFormat::PemPair;
+            return { ClientIdentityFormat::PemPair, ClientIdentityFormat::Pkcs12 };
         }
     }
     if (backend.rfind ("Schannel", 0) == 0) {
-        return ClientIdentityFormat::Pkcs12;
+        return { ClientIdentityFormat::Pkcs12 };
     }
-    return ClientIdentityFormat::Unknown;
+    return {};
+}
+
+/// What this build can present, read off `curl_version_info()`.
+inline std::vector<ClientIdentityFormat> client_identity_formats () {
+    return client_identity_formats (tls_backend_name ());
+}
+
+/// The name a test parameter prints as, and the `certFormat` the registry
+/// stores - one spelling, so a failure names the row a reader would look for.
+inline std::string client_identity_format_name (ClientIdentityFormat format) {
+    return format == ClientIdentityFormat::PemPair ? "pem" : "p12";
 }
 
 } // namespace vayu::tests

--- a/engine/tests/tls_backend.hpp
+++ b/engine/tests/tls_backend.hpp
@@ -68,6 +68,42 @@ inline std::vector<ClientIdentityFormat> client_identity_formats () {
     return client_identity_formats (tls_backend_name ());
 }
 
+/**
+ * Why @p backend cannot complete a client-certificate handshake *at all* today,
+ * or empty when it can (issue #842).
+ *
+ * Separate from the format matrix above, and the distinction is the whole
+ * point: what a backend accepts as a *file* is a stable fact about the backend,
+ * while this is a defect in the libcurl we happen to pin. Folding the two
+ * together would say "Schannel takes no client identity", which is false and
+ * would be the wrong thing to delete when upstream lands a fix.
+ *
+ * curl 8.21.0 - the pinned baseline - carries two entries in its own
+ * `docs/KNOWN_BUGS.md` for this, one of them naming the exact call at
+ * `lib/vtls/schannel.c:488`. Measured here as every wire case failing at the
+ * second `InitializeSecurityContext`; the evidence is on #842.
+ */
+inline std::string client_auth_defect (std::string_view backend) {
+    if (backend.rfind ("Schannel", 0) != 0) {
+        return {};
+    }
+    return "TLS backend '" + std::string (backend) +
+    "' cannot complete a client-certificate handshake with a certificate read "
+    "from a file: curl imports it with PKCS12_NO_PERSIST_KEY, and the key that "
+    "yields is one Schannel's credential path cannot use - measured as "
+    "'SEC_E_INTERNAL_ERROR ... The Local Security Authority cannot be "
+    "contacted' on every driver, with both a legacy-PBE and a PBES2 bundle. "
+    "Documented upstream in curl 8.21.0's own KNOWN_BUGS (curl issues 17626 "
+    "and 3145). The engine still names the format - that half is asserted on "
+    "this leg by ClientCertificateBackend and the registry suites. Tracked in "
+    "#842; delete this skip with it, not before.";
+}
+
+/// The defect this build carries, if any.
+inline std::string client_auth_defect () {
+    return client_auth_defect (tls_backend_name ());
+}
+
 /// The name a test parameter prints as, and the `certFormat` the registry
 /// stores - one spelling, so a failure names the row a reader would look for.
 inline std::string client_identity_format_name (ClientIdentityFormat format) {

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -222,16 +222,26 @@ struct CertificateAndKey {
      * build could present nothing a user registered before #833. Written as one
      * file by the caller, where the PEM pair needs two.
      *
-     * **Deliberately old algorithms** (SHA-1 + 3DES for both the key and the
-     * certificate bag, rather than OpenSSL 3's AES-256 defaults). What is under
-     * test is whether the *engine* names the format, not which ciphers a
-     * platform's PKCS#12 reader has retired, and the widest-supported pair is
-     * the one that keeps a red here meaning the former.
+     * **OpenSSL's own defaults, deliberately** - AES-256-CBC under PBES2 with a
+     * SHA-256 MAC, which is what `openssl pkcs12 -export` writes today and so
+     * what a user's bundle looks like. The first cut of this fixture reached
+     * for SHA-1 + 3DES instead, reasoning that the oldest algorithms are the
+     * widest supported; the Windows leg answered that, and the answer is the
+     * other way round. Every p12 case there failed with
+     * `SEC_E_INTERNAL_ERROR ... The Local Security Authority cannot be
+     * contacted` on the second `InitializeSecurityContext` - Schannel having
+     * the certificate but no usable private key. A legacy-PBE bundle imports
+     * its key into the old CAPI provider, and curl imports with
+     * `PKCS12_NO_PERSIST_KEY`, so the ephemeral handle that combination yields
+     * is one Schannel cannot use for the handshake. A PBES2 bundle goes to CNG
+     * and works.
      */
     std::string pkcs12 (const std::string& passphrase = {}) const {
+        // 0 / 0 is "the library's default algorithm", read at build time rather
+        // than pinned here: the point is to be what today's OpenSSL emits, and
+        // a hardcoded NID would freeze this at what today happens to mean.
         tls_detail::Pkcs12Ptr bundle (PKCS12_create (passphrase.c_str (), "vayu-test-client",
-        key.get (), certificate.get (), nullptr, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
-        NID_pbe_WithSHA1And3_Key_TripleDES_CBC, 0, 0, 0));
+        key.get (), certificate.get (), nullptr, 0, 0, 0, 0, 0));
         if (!bundle) {
             tls_detail::fail ("could not build a PKCS#12 bundle");
         }

--- a/engine/tests/tls_server.hpp
+++ b/engine/tests/tls_server.hpp
@@ -51,6 +51,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
+#include <openssl/pkcs12.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
@@ -90,12 +91,18 @@ struct Asn1TimeDeleter {
         ASN1_TIME_free (value);
     }
 };
+struct Pkcs12Deleter {
+    void operator() (PKCS12* value) const noexcept {
+        PKCS12_free (value);
+    }
+};
 
 using X509Ptr     = std::unique_ptr<X509, X509Deleter>;
 using KeyPtr      = std::unique_ptr<EVP_PKEY, KeyDeleter>;
 using BioPtr      = std::unique_ptr<BIO, BioDeleter>;
 using CrlPtr      = std::unique_ptr<X509_CRL, CrlDeleter>;
 using Asn1TimePtr = std::unique_ptr<ASN1_TIME, Asn1TimeDeleter>;
+using Pkcs12Ptr   = std::unique_ptr<PKCS12, Pkcs12Deleter>;
 
 /// Fail the way a fixture should: loudly, naming OpenSSL's own reason. A
 /// silently degraded fixture would leave the tests below asserting nothing.
@@ -133,6 +140,14 @@ inline std::string to_pem (EVP_PKEY* key) {
         fail ("could not serialize a private key to PEM");
     }
     return read_bio (bio, "a private key");
+}
+
+inline std::string to_der (PKCS12* bundle) {
+    BioPtr bio (BIO_new (BIO_s_mem ()));
+    if (!bio || i2d_PKCS12_bio (bio.get (), bundle) != 1) {
+        fail ("could not serialize a PKCS#12 bundle to DER");
+    }
+    return read_bio (bio, "a PKCS#12 bundle");
 }
 
 inline std::string to_der (X509_CRL* crl) {
@@ -197,6 +212,30 @@ struct CertificateAndKey {
             tls_detail::fail ("could not serialize an encrypted private key");
         }
         return tls_detail::read_bio (bio, "an encrypted private key");
+    }
+
+    /**
+     * @brief The certificate and its key in one DER-encoded PKCS#12 bundle,
+     *        protected by @p passphrase - empty for a bundle with none.
+     *
+     * The shape Schannel takes a client identity in, and the reason a Windows
+     * build could present nothing a user registered before #833. Written as one
+     * file by the caller, where the PEM pair needs two.
+     *
+     * **Deliberately old algorithms** (SHA-1 + 3DES for both the key and the
+     * certificate bag, rather than OpenSSL 3's AES-256 defaults). What is under
+     * test is whether the *engine* names the format, not which ciphers a
+     * platform's PKCS#12 reader has retired, and the widest-supported pair is
+     * the one that keeps a red here meaning the former.
+     */
+    std::string pkcs12 (const std::string& passphrase = {}) const {
+        tls_detail::Pkcs12Ptr bundle (PKCS12_create (passphrase.c_str (), "vayu-test-client",
+        key.get (), certificate.get (), nullptr, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
+        NID_pbe_WithSHA1And3_Key_TripleDES_CBC, 0, 0, 0));
+        if (!bundle) {
+            tls_detail::fail ("could not build a PKCS#12 bundle");
+        }
+        return tls_detail::to_der (bundle.get ());
     }
 
     /**


### PR DESCRIPTION
## Description

**Plan.** Root cause: `detail::apply_transport_policy` wrote `CURLOPT_SSLCERT` / `CURLOPT_SSLKEY` and no `CURLOPT_SSLCERTTYPE`, so libcurl read both files in its default format - right on every OpenSSL leg, and the reason the Schannel (Windows) build could present *nothing* a user registered: it takes a client identity as PKCS#12, which libcurl reads only when told the type. Verified still true at `d8fe64e` before writing anything. The approach is the issue's Option A: the format becomes a property of the **row** (`client_certificates.cert_format`, `pem` | `p12`), written once at registration and read by the applier, because the applier runs on every handle of every load run and a format nothing recorded is one the Settings card cannot print back for the user to correct. The alternative I rejected was sniffing the file per transfer: it pays for the same answer thousands of times on the load path and leaves the card with a guess it cannot show or override.

Blast radius traced before editing: the row is written by two route handlers, read by `resolve_transport_policy` into `ClientCertRule`, applied by the one shared applier, and echoed by `serialize(ClientCertificate)` to exactly one consumer - `ClientCertificatesCard`. No MCP or importer path touches the registry. The new field has a reader on both sides (the applier and the card), per CLAUDE.md's written-but-never-read rule.

What changed:

- **Applier** writes `CURLOPT_SSLCERTTYPE` from the matched rule, on every handle and null on no match, like every option beside it. A PKCS#12 row stores no key path, so `CURLOPT_SSLKEY` is null there rather than `""` (an empty string is a path libcurl would fail to open).
- **`client_cert_rejection`** gains the format: a `pem` entry needs its key file, a `p12` entry may not name one (a path nothing reads is the field the card would ask for in vain), and the declared format is checked against the file's first bytes. **Only a contradiction is refused** - a file the engine cannot classify is left for the backend to judge, the same shallowness `ca_pem_rejection` is written with.
- **Routes**: `certFormat` is optional and read off the file when absent (falling back to `pem`, which is what every pre-existing row is). `keyPath: null` clears the path - how an entry moves from PEM to PKCS#12 in one `PUT`. An unknown spelling is a `400`; a stored spelling nothing parses is a `400` on update and a dropped row with its own log line in the resolver, never a silent fallback to `pem`.
- **Schema**: `cert_format` TEXT NOT NULL `default_value("pem")` on the `http_version` precedent, so `sync_schema` ALTERs it onto an existing registry and every row backfills to what it already is. No data migration.
- **App (required by the issue)**: the card asks for the format, drops the key picker for a bundle - a card that keeps demanding a key file the format does not have is a dead end no engine change fixes - relabels the passphrase as the bundle password, and prints the format on every row.

## ⚠️ What this does NOT deliver: the Windows handshake (issue #842)

The issue's first acceptance criterion - *"a registered PKCS#12 entry completes a real mTLS handshake on the Windows leg, with no skip left in `mutual_tls_test.cpp`"* - **is not met, and cannot be met from this repository.** I found this by shipping it and reading the Windows leg, so the PR carries the evidence:

With the type written, Windows now gets far enough to *attempt* client auth and fails every wire case at the second `InitializeSecurityContext` with `SEC_E_INTERNAL_ERROR (0x80090304) - The Local Security Authority cannot be contacted`. Two hypotheses were tested and are dead:

1. **The bundle's algorithms.** First fixture: SHA-1 + 3DES. Second: OpenSSL's defaults (AES-256-CBC under PBES2, SHA-256 MAC). Identical failure, both runs.
2. **The engine's option handling.** `AcquireCredentialsHandle` *succeeds* (curl prints its own failure text when it does not), so Schannel accepted the credential with the certificate attached. The failure is where the key is used to sign.

It is libcurl. curl 8.21.0 - the pinned baseline - ships two entries in its own `docs/KNOWN_BUGS.md`, one naming the exact call at `lib/vtls/schannel.c:488`:

> **Access violation sending client cert with Schannel** - "curl sets `PKCS12_NO_PERSIST_KEY` to avoid leaking the private key into the filesystem. Unfortunately that flag instead seems to trigger a crash." ([curl#17626](https://github.com/curl/curl/issues/17626)); **Client cert (MTLS) issues with Schannel** ([curl#3145](https://github.com/curl/curl/issues/3145))

So the wire cases skip on Schannel again - but for a different fact than the skip #833 asked me to remove, and through a deliberately separate gate. `client_auth_defect()` is not folded into `client_identity_formats()`: which formats a backend *reads* is a stable fact about the backend; whether it can *finish* a client-auth handshake is a defect in the libcurl we pin. Conflating them would assert "Schannel takes no client identity", which is false, and would be the wrong thing to delete when upstream lands a fix. A fixed libcurl deletes one line and the p12 half runs on Windows unchanged. **#842** tracks it, including the one experiment that would separate the remaining two candidate causes (TLS 1.3 client auth vs. key persistence), which needs a real Windows machine.

What still runs on Windows: the stored format, the registry and validation rules, the resolver plumbing, and `ClientCertificateBackend` asserting Schannel accepts `CURLOPT_SSLCERTTYPE` for both types. Only the handshake is dark there, and the docs now say so instead of claiming it works.

**This is worth a decision before merge.** The engine half is right either way and unblocks Windows the day curl is fixed - but if you would rather the PR not ship a Windows skip at all, say so and I will restructure.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -t`, `ctest --preset linux-dev --output-on-failure`, `cd app && pnpm test && pnpm type-check && pnpm lint`, plus `mkdocs build --strict`. All green; no pre-existing failures on this base.

- **Engine: 2092 / 2092** (was 2059 before this PR's additions). **App: 5765 / 5765** across 522 files; type-check, ESLint and Prettier (touched files only) clean.
- `mutual_tls_test.cpp` is parameterized over `client_identity_formats()`, so every driver case (design send, SSE, load run, `pm.sendRequest`, port precedence, passphrase, and a new "format read off the file" case) runs once per format the leg's backend accepts - `pem` and `p12` on Linux/macOS.
- PKCS#12 material is minted in-process (`CertificateAndKey::pkcs12`), with OpenSSL's default algorithms - what `openssl pkcs12 -export` writes today, so the fixture looks like a user's bundle.
- **Mutation checks** (revert, confirm red, restore): removing `CURLOPT_SSLCERTTYPE` reddens exactly the `p12` cases and no `pem` case; sending `keyPath` unconditionally from the card, rendering the key picker unconditionally, and dropping the row's format badge each redden the two new card tests.
- **A test that was lying, found and fixed along the way.** `ALoadRunPresentsTheCertificate` reported green on the first Windows run while every sibling failed - it asserted only `BatchResult::successful`, and `execute_batch` counts a `Result` that is *ok*; a refused handshake is an ok `Result` carrying an `error_code`, since the error arm is reserved for a request that could not be attempted at all. It would have passed with no certificate presented, on any platform. It now asserts each response's `error_code` and status, mutation-checked.
- Route/validation coverage added for: a `p12` entry with no `keyPath` accepted, a `pem` entry without one refused, a format the file contradicts refused (both directions), an unclassifiable file accepted under both formats, an unknown `certFormat` refused with the valid-values list, the format defaulted from the file, a `PUT` moving an entry to `p12` refused until `keyPath` is cleared, and the stored format reaching `ClientCertRule` with an empty key path.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commits: `docs/engine/api-reference.md` (the per-backend format table, the field table, the `GET` example, the error table, the `PUT` null rules, and what Windows can and cannot do), `docs/engine/db-schema.md`, `docs/architecture.md` and `engine/CLAUDE.md`.

## Related Issues
Closes #833. Follow-up filed: #842 (Windows mTLS blocked upstream in curl 8.21's Schannel client-cert path).
