### PR TITLE
feat(app/mcp): an agent can read a collection's bound OpenAPI document

### DIFF
--- a/app/electron/mcp/data-changed.test.ts
+++ b/app/electron/mcp/data-changed.test.ts
@@ -125,6 +125,13 @@ describe("the registry declares its effects", () => {
 			create_collection: ["collection"],
 			update_collection: ["collection"],
 			delete_collection: ["collection"],
+			// Detaching an OpenAPI document (#761 phase A) rewrites one field of
+			// the collection row - `openapi` - and the Spec tab reads the binding
+			// off that row, so the family that refetches collections is the one
+			// that refreshes it. No `spec` family: the stored document is
+			// immutable under its id and this write neither changes nor deletes
+			// one, so the caches keyed by spec id cannot go stale here.
+			unbind_spec: ["collection"],
 			create_request: ["request"],
 			update_request: ["request"],
 			delete_request: ["request"],

--- a/app/electron/mcp/engine-client.ts
+++ b/app/electron/mcp/engine-client.ts
@@ -322,6 +322,31 @@ export class EngineClient {
 	}
 
 	/**
+	 * What a stored OpenAPI document *is* - id, sourceUrl, fetchedAt, hash and
+	 * contentBytes - without the document (`GET /specs/:id/meta`, issue #712).
+	 *
+	 * The default read for a spec, on the renderer's reasoning: the fields that
+	 * describe a binding live on the document, and fetching a 12 MB spec to print
+	 * a source line and a date is what this route was added to stop. A 404 arrives
+	 * as an {@link EngineRequestError}.
+	 */
+	getSpecMeta(id: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", `/specs/${encodeURIComponent(id)}/meta`, undefined, signal);
+	}
+
+	/**
+	 * The whole stored document, `content` included (`GET /specs/:id`).
+	 *
+	 * Only for a caller that asked for the text: the two extracted indexes
+	 * (`operations`, `responseSchemas`) ride along on this route and are as heavy
+	 * as the document, so a reader that only wants metadata takes
+	 * {@link getSpecMeta} instead.
+	 */
+	getSpec(id: string, signal?: AbortSignal): Promise<unknown> {
+		return this.request("GET", `/specs/${encodeURIComponent(id)}`, undefined, signal);
+	}
+
+	/**
 	 * A page of run history (newest first), bounded so a caller never pulls
 	 * unbounded history. Returns the `{data, pagination}` envelope; `data` rows
 	 * carry the compact `summary`, not the full config_snapshot.

--- a/app/electron/mcp/tools.test.ts
+++ b/app/electron/mcp/tools.test.ts
@@ -150,6 +150,22 @@ function fakeClient(overrides: Partial<Record<keyof EngineClient, unknown>> = {}
 			preRequestScript: "",
 			postRequestScript: "",
 		}),
+		getSpecMeta: vi.fn().mockResolvedValue({
+			id: "spec_1",
+			sourceUrl: "https://api.example.com/openapi.json",
+			fetchedAt: 1_755_000_000_000,
+			hash: "abc123",
+			contentBytes: 4,
+		}),
+		getSpec: vi.fn().mockResolvedValue({
+			id: "spec_1",
+			content: "{ }\n",
+			sourceUrl: "https://api.example.com/openapi.json",
+			fetchedAt: 1_755_000_000_000,
+			hash: "abc123",
+			operations: null,
+			responseSchemas: null,
+		}),
 		listRequestExamples: vi.fn().mockResolvedValue([]),
 		createRequestExample: vi
 			.fn()
@@ -6943,5 +6959,215 @@ describe("OAuth 2.0 token tools", () => {
 		expect(tools.get("fetch_oauth2_token")?.invalidates).toEqual(["oauth"]);
 		expect(tools.get("clear_oauth2_token")?.invalidates).toEqual(["oauth"]);
 		expect(tools.get("get_oauth2_token_status")?.invalidates).toEqual([]);
+	});
+});
+
+/**
+ * OpenAPI spec binding, phase A (issue #761).
+ *
+ * Two things are worth locking here, and neither is the passthrough.
+ *
+ * The first is that describing a binding must not transfer the document. That
+ * is the whole reason `GET /specs/:id/meta` exists (#712) - a real spec is
+ * megabytes, and one in a tool result exceeds the result token limit outright -
+ * so the tests assert *which route was called*, not just what came back. A
+ * version that read the full document and dropped `content` would answer
+ * identically and cost the same megabytes.
+ *
+ * The second is that `unbind_spec` writes `openapi: null` and never `{}`. The
+ * engine reads an absent field as "keep" and null as "reset to the default";
+ * `{}` is a value that happens to serialize as unbound today, and the two would
+ * drift the first time the default changed. The Spec tab's Unbind sends null for
+ * the same reason.
+ */
+describe("OpenAPI spec binding tools", () => {
+	const WRITES = { allowWrites: true };
+	const allText = (r: { content: Array<{ text: string }> }) =>
+		r.content.map((c) => c.text).join("\n");
+
+	/** A collection row bound to `spec_1`, as the engine serializes one. */
+	const boundCollection = {
+		id: "col_1",
+		name: "API",
+		openapi: { specId: "spec_1", specHash: "abc123", syncedAt: 1_755_000_000_000 },
+	};
+
+	/** The unbound state as the engine stores it: an empty object, not absent. */
+	const unboundCollection = { id: "col_1", name: "API", openapi: {} };
+
+	test("get_spec resolves a collection's binding and reads metadata, not the document", async () => {
+		const client = fakeClient({
+			getCollection: vi.fn().mockResolvedValue(boundCollection),
+		});
+		const res = await dispatchTool("get_spec", { collectionId: "col_1" }, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		expect(client.getSpecMeta).toHaveBeenCalledWith("spec_1", undefined);
+		// The document itself is never fetched for a metadata read - the point.
+		expect(client.getSpec).not.toHaveBeenCalled();
+		const value = JSON.parse(firstText(res));
+		expect(value).toMatchObject({
+			specId: "spec_1",
+			bound: true,
+			collectionId: "col_1",
+			sourceUrl: "https://api.example.com/openapi.json",
+			hash: "abc123",
+			contentBytes: 4,
+			binding: { specId: "spec_1", specHash: "abc123" },
+		});
+		expect(value).not.toHaveProperty("content");
+	});
+
+	test("get_spec reads a spec by id without touching collections", async () => {
+		const client = fakeClient();
+		const res = await dispatchTool("get_spec", { specId: "spec_9" }, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		expect(client.getCollection).not.toHaveBeenCalled();
+		expect(client.getSpecMeta).toHaveBeenCalledWith("spec_9", undefined);
+		// No collection was named, so there is no binding to report - the field is
+		// absent rather than null, which would read as "bound to nothing".
+		expect(JSON.parse(firstText(res))).not.toHaveProperty("binding");
+	});
+
+	test("an unbound collection is an answer, not an error, and reads no spec", async () => {
+		const client = fakeClient({
+			getCollection: vi.fn().mockResolvedValue(unboundCollection),
+		});
+		const res = await dispatchTool("get_spec", { collectionId: "col_1" }, ctxWith(client));
+		expect(res.isError).toBeFalsy();
+		expect(JSON.parse(firstText(res))).toEqual({ collectionId: "col_1", bound: false });
+		expect(client.getSpecMeta).not.toHaveBeenCalled();
+		expect(allText(res)).toMatch(/not bound/i);
+	});
+
+	test("get_spec refuses no selector and both selectors", async () => {
+		const client = fakeClient();
+		const neither = await dispatchTool("get_spec", {}, ctxWith(client));
+		expect(neither.isError).toBe(true);
+		const both = await dispatchTool(
+			"get_spec",
+			{ collectionId: "col_1", specId: "spec_1" },
+			ctxWith(client)
+		);
+		expect(both.isError).toBe(true);
+		expect(firstText(both)).toMatch(/not both/i);
+		expect(client.getSpecMeta).not.toHaveBeenCalled();
+	});
+
+	test("get_spec names a collection id nothing matches", async () => {
+		const client = fakeClient({ getCollection: vi.fn().mockResolvedValue(null) });
+		const res = await dispatchTool("get_spec", { collectionId: "nope" }, ctxWith(client));
+		expect(res.isError).toBe(true);
+		expect(firstText(res)).toContain("nope");
+		expect(client.getSpecMeta).not.toHaveBeenCalled();
+	});
+
+	test("includeContent reads the document and caps it, reporting the true size", async () => {
+		const document = "x".repeat(MAX_INLINE_BODY_BYTES * 2);
+		const client = fakeClient({
+			getSpec: vi.fn().mockResolvedValue({
+				id: "spec_1",
+				content: document,
+				sourceUrl: null,
+				fetchedAt: 1,
+				hash: "h",
+			}),
+		});
+		const res = await dispatchTool(
+			"get_spec",
+			{ specId: "spec_1", includeContent: true },
+			ctxWith(client)
+		);
+		expect(res.isError).toBeFalsy();
+		expect(client.getSpec).toHaveBeenCalledWith("spec_1", undefined);
+		expect(client.getSpecMeta).not.toHaveBeenCalled();
+		const value = JSON.parse(firstText(res));
+		expect(Buffer.byteLength(value.content as string, "utf8")).toBeLessThanOrEqual(
+			MAX_INLINE_BODY_BYTES
+		);
+		expect(value.contentTruncated).toBe(true);
+		// The full read carries no `contentBytes`, so the true size has to be
+		// measured here - a cut that reported its own length would tell an agent
+		// the spec is 32 KB.
+		expect(value.contentBytes).toBe(document.length);
+		expect(value.sourceUrl).toBeNull();
+	});
+
+	test("unbind_spec is refused while writes are off, and reads nothing", async () => {
+		const client = fakeClient({
+			getCollection: vi.fn().mockResolvedValue(boundCollection),
+		});
+		const res = await dispatchTool(
+			"unbind_spec",
+			{ collectionId: "col_1" },
+			ctxWith(client, { allowWrites: false })
+		);
+		expect(res.isError).toBe(true);
+		expect(client.updateCollection).not.toHaveBeenCalled();
+		expect(client.getCollection).not.toHaveBeenCalled();
+	});
+
+	test("unbind_spec sends openapi: null and names the document it detached", async () => {
+		const client = fakeClient({
+			getCollection: vi.fn().mockResolvedValue(boundCollection),
+		});
+		const res = await dispatchTool(
+			"unbind_spec",
+			{ collectionId: "col_1" },
+			ctxWith(client, WRITES)
+		);
+		expect(res.isError).toBeFalsy();
+		const [id, payload] = (client.updateCollection as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(id).toBe("col_1");
+		// Null, not `{}` - see this block's header.
+		expect(payload).toEqual({ openapi: null });
+		expect(Object.prototype.hasOwnProperty.call(payload, "openapi")).toBe(true);
+		expect((payload as { openapi: unknown }).openapi).toBeNull();
+		expect(allText(res)).toContain("spec_1");
+	});
+
+	test("unbind_spec writes nothing for a collection that binds nothing", async () => {
+		const client = fakeClient({
+			getCollection: vi.fn().mockResolvedValue(unboundCollection),
+		});
+		const res = await dispatchTool(
+			"unbind_spec",
+			{ collectionId: "col_1" },
+			ctxWith(client, WRITES)
+		);
+		expect(res.isError).toBeFalsy();
+		expect(client.updateCollection).not.toHaveBeenCalled();
+		expect(allText(res)).toMatch(/Nothing to do/i);
+	});
+
+	test("unbind_spec names a collection id nothing matches", async () => {
+		const client = fakeClient({ getCollection: vi.fn().mockResolvedValue(null) });
+		const res = await dispatchTool(
+			"unbind_spec",
+			{ collectionId: "nope" },
+			ctxWith(client, WRITES)
+		);
+		expect(res.isError).toBe(true);
+		expect(client.updateCollection).not.toHaveBeenCalled();
+	});
+
+	test("the categories and cache families are declared", () => {
+		const tools = new Map(TOOLS.map((t) => [t.name, t]));
+		expect(tools.get("get_spec")?.category).toBe("read");
+		expect(tools.get("get_spec")?.invalidates).toEqual([]);
+		expect(tools.get("unbind_spec")?.category).toBe("write");
+		// The Spec tab reads the binding off the collection row, so the family that
+		// refetches collections is the one that refreshes it - no `spec` entity.
+		expect(tools.get("unbind_spec")?.invalidates).toEqual(["collection"]);
+		// Nothing it names is destroyed: the document stays and so do the stamps.
+		expect(tools.get("unbind_spec")?.annotations.destructiveHint).toBe(false);
+	});
+
+	test("phase A ships no bind tool", () => {
+		// Deliberate, and recorded on #761: binding without operation matching
+		// would store a document with no operations/responseSchemas index and
+		// leave stale stamps uncleared, which makes coverage claim the wrong
+		// operation rather than none. If a bind lands later, this expectation is
+		// the thing that should be updated in the same commit.
+		expect(TOOLS.map((t) => t.name)).not.toContain("bind_spec");
 	});
 });

--- a/app/electron/mcp/tools.ts
+++ b/app/electron/mcp/tools.ts
@@ -3166,6 +3166,59 @@ function readOrderedSiblings(value: unknown): OrderedSibling[] {
 	);
 }
 
+// --- OpenAPI spec bindings ---------------------------------------------------
+
+/**
+ * A collection's binding to a stored OpenAPI document, as the collection row
+ * carries it (`openapi`, issue #637).
+ *
+ * The engine stores `{}` for the unbound state and refuses a non-empty binding
+ * that names no `specId`, so a row with a string `specId` is the only shape that
+ * means "bound" - and the only one this reads. `specHash` is stamped engine-side
+ * from the stored document at bind time; `syncedAt` is set by a spec sync.
+ */
+interface SpecBinding {
+	specId: string;
+	specHash?: string;
+	syncedAt?: number;
+}
+
+function readSpecBinding(collection: unknown): SpecBinding | null {
+	if (!isRecord(collection)) return null;
+	const binding = collection.openapi;
+	if (!isRecord(binding) || typeof binding.specId !== "string" || binding.specId === "") {
+		return null;
+	}
+	return {
+		specId: binding.specId,
+		...(typeof binding.specHash === "string" ? { specHash: binding.specHash } : {}),
+		...(typeof binding.syncedAt === "number" ? { syncedAt: binding.syncedAt } : {}),
+	};
+}
+
+/**
+ * The document's text as `get_spec` hands it back, bounded (issue #767's rule
+ * applied to a surface whose ceiling is far higher than a response body's).
+ *
+ * A stored spec may be up to `maxSpecDocumentBytes` - megabytes for a real one:
+ * Stripe's is 12 MB, GitHub's 9.7 MB - so the whole of it in a tool result
+ * exceeds the result token limit outright. The cut is `MAX_INLINE_BODY_BYTES`,
+ * this codebase's existing answer to "how much text does an automated reader
+ * get", and `contentBytes` beside it is the engine's own count of the whole
+ * document, so a truncated read always says what it is a prefix of.
+ *
+ * A document with no text answers `content: null` rather than dropping the
+ * field: a caller that asked for the content and got a result without it cannot
+ * tell "empty" from "this tool decided not to send it".
+ */
+function boundSpecContent(document: unknown): Record<string, unknown> {
+	if (!isRecord(document) || typeof document.content !== "string") {
+		return { content: null, contentTruncated: false };
+	}
+	const { text, truncated } = boundText(document.content);
+	return { content: text, contentTruncated: truncated };
+}
+
 // --- Tool definitions --------------------------------------------------------
 
 export const TOOLS: McpTool[] = [
@@ -3846,6 +3899,169 @@ export const TOOLS: McpTool[] = [
 				: withCaveat(
 						result,
 						`\n\nDeleted "${scope.name}" with ${scope.descendants} sub-collection(s) and ${scope.requests} saved request(s).`
+					);
+		},
+	},
+	{
+		name: "get_spec",
+		category: "read",
+		invalidates: [],
+		description:
+			"Read the OpenAPI document a collection is bound to - where it came from, when it was fetched, its content hash and its size - by `collectionId` (resolving the collection's binding) or by `specId` directly. The document text is NOT included by default: a real spec runs to megabytes, so pass includeContent: true to get it, capped at 32 KB with `contentBytes` reporting the true size. A collection that binds nothing answers `bound: false` rather than failing.",
+		annotations: {
+			title: "Get bound OpenAPI spec",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			collectionId: z
+				.string()
+				.optional()
+				.describe("Collection whose binding to resolve. Pass this or specId, not both."),
+			specId: z
+				.string()
+				.optional()
+				.describe(
+					"Stored document to read directly. Spec IDs come from a collection's binding - there is no list route for them."
+				),
+			includeContent: z
+				.boolean()
+				.optional()
+				.describe(
+					"Include the document text (capped at 32 KB). Off by default - the metadata is what describes a binding, and the text can be megabytes."
+				),
+		},
+		handler: async (args, ctx, signal) => {
+			const collectionId = str(args, "collectionId");
+			const specIdArg = str(args, "specId");
+			if (!collectionId && !specIdArg) {
+				return errorResult('Pass either "collectionId" or "specId".');
+			}
+			if (collectionId && specIdArg) {
+				return errorResult(
+					'Pass either "collectionId" or "specId", not both - they would have to agree, and this tool cannot say which one you meant if they do not.'
+				);
+			}
+			const includeContent = args.includeContent === true;
+
+			// Assigned on both arms below - by the argument, or by the binding the
+			// collection resolves to - so it is a string by the time it is read.
+			let specId: string;
+			let binding: SpecBinding | null = null;
+			if (collectionId) {
+				let collection: unknown;
+				try {
+					collection = await ctx.client.getCollection(collectionId, signal);
+				} catch (err) {
+					return engineErrorResult(err);
+				}
+				if (collection === null) {
+					return errorResult(`No collection with id "${collectionId}".`);
+				}
+				binding = readSpecBinding(collection);
+				// Unbound is an answer, not a failure: "which spec does this
+				// collection use" has "none" as a legitimate reply, and an error
+				// here would read as an engine or id problem.
+				if (!binding) {
+					return withCaveat(
+						jsonResult({ collectionId, bound: false }),
+						"\n\nThis collection is not bound to an OpenAPI document. Binding one is done in the Vayu app (Collection → Spec) - see https://github.com/athrvk/vayu/issues/761."
+					);
+				}
+				specId = binding.specId;
+			} else {
+				specId = specIdArg;
+			}
+
+			try {
+				// The metadata route unless the text was asked for: it is the whole
+				// point of `GET /specs/:id/meta` that describing a document does not
+				// transfer it, and the full read carries the two extracted indexes
+				// as well, which are as heavy as the document itself.
+				const document = includeContent
+					? await ctx.client.getSpec(specId, signal)
+					: await ctx.client.getSpecMeta(specId, signal);
+				const meta = isRecord(document) ? document : {};
+				const value: Record<string, unknown> = {
+					specId,
+					sourceUrl: meta.sourceUrl ?? null,
+					fetchedAt: meta.fetchedAt ?? null,
+					hash: meta.hash ?? null,
+					// `contentBytes` is only on the meta read; the full read carries
+					// the bytes themselves, so measure them the same way the engine
+					// does (`content.size()`) rather than reporting nothing.
+					contentBytes:
+						typeof meta.contentBytes === "number"
+							? meta.contentBytes
+							: typeof meta.content === "string"
+								? Buffer.byteLength(meta.content, "utf8")
+								: null,
+					...(binding ? { collectionId, bound: true, binding } : {}),
+					...(includeContent ? boundSpecContent(meta) : {}),
+				};
+				return jsonResult(value);
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+		},
+	},
+	{
+		name: "unbind_spec",
+		category: "write",
+		invalidates: ["collection"],
+		description:
+			"Detach a collection from the OpenAPI document it is bound to. GUARDED: requires write access to be enabled in Vayu Settings. The document itself is kept - other collections may bind it - and the requests keep the operation identities they were stamped with, exactly as the app's Unbind button leaves them, so re-binding the same document later costs nothing. After this the collection's runs report no contract coverage and its responses are no longer schema-checked. There is no bind over MCP yet: binding has to match every request to an operation, which is app-side logic (see issue #761), so re-binding is done in Vayu (Collection → Spec).",
+		annotations: {
+			title: "Unbind OpenAPI spec",
+			readOnlyHint: false,
+			// The binding goes, nothing it named does: the document stays stored and
+			// the stamps stay on the requests, and a re-bind in the app restores the
+			// state this leaves. That is not the irreversible loss the hint marks.
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+		inputSchema: {
+			collectionId: z.string().describe("Collection to unbind from its OpenAPI document."),
+		},
+		handler: async (args, ctx, signal) => {
+			const refused = writesDisabled(ctx);
+			if (refused) return refused;
+			const collectionId = requireStr(args, "collectionId");
+			let collection: unknown;
+			try {
+				collection = await ctx.client.getCollection(collectionId, signal);
+			} catch (err) {
+				return engineErrorResult(err);
+			}
+			if (collection === null) {
+				return errorResult(`No collection with id "${collectionId}".`);
+			}
+			const binding = readSpecBinding(collection);
+			// Read first so an unbound collection is reported as already unbound
+			// rather than written to. The PUT would succeed either way - the engine
+			// reads `null` as "reset to the default", and the default is unbound -
+			// and an agent told "unbound" about a collection that was never bound
+			// would believe it had changed something.
+			if (!binding) {
+				return withCaveat(
+					jsonResult({ collectionId, bound: false }),
+					"\n\nNothing to do: this collection was not bound to an OpenAPI document."
+				);
+			}
+			// `null`, not `{}`: the engine reads an absent field as "keep" and null
+			// as "reset to the default", which is unbound. The same value the Spec
+			// tab's Unbind sends, so the two paths cannot come to mean different
+			// things.
+			const result = await callEngine(() =>
+				ctx.client.updateCollection(collectionId, { openapi: null }, signal)
+			);
+			return result.isError
+				? result
+				: withCaveat(
+						result,
+						`\n\nUnbound from spec ${binding.specId}. The document is still stored (another collection may bind it), and the requests keep their recorded operation identities.`
 					);
 		},
 	},

--- a/docs/engine/mcp.md
+++ b/docs/engine/mcp.md
@@ -165,6 +165,8 @@ toggle), **load** (starts/stops load tests - allowlist + caps + confirmation).
 | `create_collection`    | write    | `POST /collections`                          | write toggle; takes `variables`, `auth` and both collection scripts |
 | `update_collection`    | write    | `GET /collections` (scan, only when variables change) + `PUT /collections/:id` (merge-patch) | write toggle; `variables` merges like `update_environment`'s, `removeVariables` deletes names |
 | `delete_collection`    | write    | `GET /collections` + `GET /requests?…` (×N) + `DELETE /collections/:id` | write toggle + confirm |
+| `get_spec`             | read     | `GET /collections` (scan, only for `collectionId`) + `GET /specs/:id/meta`, or `GET /specs/:id` with `includeContent` | - (document text off by default and capped at 32 KB; a collection binding nothing answers `bound: false`) |
+| `unbind_spec`          | write    | `GET /collections` (scan) + `PUT /collections/:id` (`openapi: null`) | write toggle; the document and the requests' recorded operations are kept |
 | `create_request`       | write    | `POST /requests`                             | write toggle; takes the builder's whole surface - auth, `followRedirects` / `maxRedirects` / `httpVersion` / `stream` / `verifySSL`, both scripts - minus file body parts |
 | `update_request`       | write    | `PUT /requests/:id` (merge-patch)            | write toggle; same fields, and only the ones named are written |
 | `delete_request`       | write    | `GET /requests/:id` + `DELETE /requests/:id` | write toggle + confirm     |
@@ -241,6 +243,23 @@ Notes:
   no such field - every transfer is bounded by the `defaultTimeout` setting
   (`resolve_request_timeout_ms`), which `update_engine_config` changes. Recorded
   here so it is not re-derived as a gap each time the schema is read.
+- **OpenAPI is readable over MCP, not writable** (issue
+  [#761](https://github.com/athrvk/vayu/issues/761), phase A). `get_spec` says
+  what a collection is bound to and `unbind_spec` detaches it; **binding, spec
+  sync, import and export stay app-only.** That is a boundary, not a gap in the
+  tool list: binding is not one write but a match of every saved request against
+  the document's operations, and the matcher, the sync diff and the export
+  assembly are renderer modules the main process cannot import (see
+  `app/tsconfig.node.json`). A bind that skipped the matching would store a
+  document with no operations or response-schema index - so the collection's runs
+  would report no coverage and its responses would go unchecked - and would leave
+  any stamp from a previous document in place, where coverage resolves it by
+  `operationId` and it claims the wrong operation rather than none. Phase B of
+  #761 is the decision about where that logic should live; until it lands, bind a
+  spec in Vayu (Collection → Spec). `unbind_spec` needs none of it, which is why
+  it ships: it writes exactly what the app's Unbind button writes, and leaves the
+  stamps alone for the same reason - re-binding the same document later costs
+  nothing.
 - **`get_run_report` carries contract coverage** for a run of a collection bound
   to an OpenAPI document (issue #629): which of the contract's operations the run
   exercised, which of their declared responses it saw, and any statuses the
@@ -1402,6 +1421,10 @@ builds on the mechanism the spec is deprecating and the payoff is client-depende
   provenance.
 - **`vayu mcp` bin** - package the stdio CLI as a first-class command
   ([#693](https://github.com/athrvk/vayu/issues/693)).
+- **OpenAPI bind / sync / import / export** - phase B of
+  [#761](https://github.com/athrvk/vayu/issues/761), gated on deciding where
+  operation matching, the sync diff and export assembly should live (see the
+  note under [Tools](#tools)).
 - **Live push over HTTP** - stateful sessions (see Design notes).
 - **Hosted MCP for Vayu Cloud** - OAuth-gated, remote.
 


### PR DESCRIPTION
## Description

#761 **phase A only**. Phase B stays gated on the engine-ownership decision the issue asks you to record there.

**Plan.** Root cause, verified at `d8fe64e` before writing anything: the whole OpenAPI stack is UI-only over MCP - `GET /specs/:id`, `/specs/:id/meta` and the collection's `openapi` binding have no tool, so an agent can read a schema verdict embedded in a run report but cannot ask what a collection is bound to. The approach is the issue's phase A: `get_spec` resolves a binding and describes the document, `unbind_spec` detaches one, and **no bind tool ships** (below). The alternative I rejected for `get_spec` was reading `GET /specs/:id` always and dropping `content` from the result - it answers identically and costs the same megabytes over loopback, which is exactly what `/meta` was added in #712 to stop.

**Blast radius traced before editing.** The binding is written by `PUT /collections/:id` (`validate_openapi_binding`, `collections.cpp:188`), read by the Spec tab off the collection row, and by `bound-spec-match.ts` / coverage. The two new engine-client methods have one caller each; the two new tools have readers on both sides - the agent, and (for `unbind_spec`'s `invalidates`) `mcp-invalidation.ts`'s `collection` family, which is exhaustive over `McpDataEntity` and is guarded by `data-changed.test.ts`.

### What ships

- **`get_spec`** (read) - by `collectionId` (resolving the binding off the collection row; there is no `GET /specs` list route, so ids come from bindings) or by `specId`. Reads `GET /specs/:id/meta` by default; `includeContent: true` reads the full document and caps the text at `MAX_INLINE_BODY_BYTES` (32 KB), with `contentBytes` carrying the true size so a prefix always says what it is a prefix of. A collection binding nothing answers `bound: false` with a pointer, not an error - "which spec does this collection use" has "none" as a legitimate reply.
- **`unbind_spec`** (write, write-toggle guarded) - sends `openapi: null`, exactly what the Spec tab's Unbind sends. `null`, never `{}`: the engine reads an absent field as "keep" and null as "reset to the default", and `{}` is a value that only happens to serialize as unbound today. It reads the binding first, so an unbound collection is reported rather than written to, and it leaves the requests' recorded operation identities alone for the reason the tab does - unbind-then-bind-the-same-document then costs nothing.

### Deliberate deviation from the issue spec: no `bind_spec`

The issue anticipated this ("If that caveat makes bind_spec worse than useless, drop it in the PR and record why - the read tool alone is still phase A"). It does, and the reason is stronger than the unstamped caveat the issue names. Binding is not one write. `useBindSpecMutation` stores the document **with the `operations` (#629) and `responseSchemas` (#628) indexes the renderer's parser extracts**, binds the collection, and then stamps *and clears* per-request identities. An MCP bind without the matcher would:

1. store a document carrying neither index, so the collection's runs report no contract coverage and its responses are silently never schema-checked - `run_collection_smoke` would report every row `unchecked` while claiming the collection is bound; and
2. leave stamps from a previously bound document in place. That is the #718 bug the renderer's `clearStamps` is required for: coverage resolves a stamp by `operationId` first, so a stale one whose id happens to exist in the new document **claims the wrong operation rather than none**.

A tool that can silently make coverage wrong is worse than an absent tool. `tools.test.ts` pins the absence with the reason, so a later bind updates it knowingly rather than by accident.

### App changes (required by the issue): none needed, verified

The issue asked for a new `spec` invalidation entity "or reuse `collection` - state which in the PR". **`collection` suffices, and no renderer change ships.** The Spec tab reads the binding off the collection row (`SpecTab.tsx:82-86`), and the `collection` family already invalidates `collections.all` + `requests.all`. A new `spec` family would have nothing to invalidate: `queryKeys.specs.detail/meta` are keyed by spec id and held at `staleTime: Infinity` because a stored document is immutable under its id, and an unbind neither changes nor deletes one. The renderer-local `spec-file-store` entry also needs no clearing: it is only rendered under `bound`, so a stale path after an MCP unbind is invisible, and a re-bind through the tab sets or clears it.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`cd app && pnpm test && pnpm type-check && pnpm lint`, plus `pnpm format:check` on the touched files and `mkdocs build --strict` (docs changed). All green; no pre-existing failures on this base.

- **App: 5775 / 5775 passed across 522 files** (was 5762 before this PR's additions), type-check clean on all three configs, ESLint clean at `--max-warnings 0`, Prettier clean on the four files touched.
- **13 new tests** in `tools.test.ts` (`describe("OpenAPI spec binding tools")`), plus the `unbind_spec` row in `data-changed.test.ts`'s exhaustive mutating-tool map - which failed the first full run exactly as designed, since a new mutating tool must name its renderer reader before the suite goes green.
- **Mutation checks** (applied, confirmed red, restored):
  - Reading the full document unconditionally instead of `/meta` reddens 2 tests - the ones asserting *which route* was called. This is the check that matters: a version that read the document and dropped `content` would answer identically.
  - Dropping `boundText` from the content path reddens the cap test.
  - Sending `openapi: {}` instead of `null` reddens the payload test.
- Coverage added for: binding resolution from a collection row, an unbound collection answering rather than failing, an unknown collection id, refusing neither/both selectors, reading by `specId` without touching collections, the 32 KB cap with the true `contentBytes`, the write toggle refusing before any read, the no-op on an already-unbound collection, and the declared categories/`invalidates`/`destructiveHint`.

No engine code changed, so no engine build or ctest run - per `CLAUDE.md`, no C++ test could change colour here, and the issue's own Tests section names only the app commands.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

Docs updated in the same commit: `docs/engine/mcp.md` gains both tool rows, a note under **Tools** stating the boundary (why bind / sync / import / export stay app-only, and why `unbind_spec` needs none of that machinery), and a **Deferred** entry pointing at phase B.

## Related Issues

Refs #761 - **not** `Closes`, deliberately: phase A is what this delivers, and the issue's second and third acceptance criteria are the phase B decision and the rule about TS duplication, both of which are yours to record.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbehjH9L47PJhnwuwokop)_