### PR TITLE
feat(engine/app/tls): a client certificate can answer for every subdomain (#803)

### DIFF
--- a/app/src/modules/settings/main/panels/ClientCertificatesCard.test.tsx
+++ b/app/src/modules/settings/main/panels/ClientCertificatesCard.test.tsx
@@ -238,6 +238,55 @@ describe("ClientCertificatesCard", () => {
 		expect(screen.getByText("pkcs12")).toBeInTheDocument();
 	});
 
+	it("prints what each row will and will not match", () => {
+		// Issue #803: the pattern text alone is what a reader guesses wrong in
+		// both directions - a plain host looks like it covers its subdomains,
+		// and `*.example.com` looks like it covers `example.com`. Dropping
+		// either half of the sentence reddens this.
+		queryResult = {
+			data: [certificates[0], { ...certificates[1], id: "cert_3", host: "*.example.com" }],
+			isError: false,
+		};
+		renderCard();
+
+		expect(
+			screen.getByText("Matches api.example.com exactly - not its subdomains.")
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Matches any subdomain of example.com (api.example.com, a.b.example.com) - not example.com itself."
+			)
+		).toBeInTheDocument();
+	});
+
+	it("states the wildcard form where the host is typed", () => {
+		// A user who never learns the form registers one entry per service, and
+		// adds another every time a service appears - the case the wildcard
+		// shipped for.
+		renderCard();
+		fireEvent.click(screen.getByRole("button", { name: /add certificate/i }));
+
+		const hint = screen.getByText(/a host matches exactly/i);
+		expect(hint).toHaveTextContent("*.example.com");
+		expect(hint).toHaveTextContent("never");
+	});
+
+	it("sends a wildcard host through unchanged, for the engine to judge", () => {
+		// The card does not validate the pattern: the engine owns the one copy
+		// of that rule and its 400 names the shape that works, so a second
+		// (inevitably drifting) copy here would only refuse things the engine
+		// accepts.
+		renderCard();
+		fillDraft({ host: "*.example.com" });
+		fireEvent.click(screen.getByRole("button", { name: /^add certificate$/i }));
+
+		return waitFor(() =>
+			expect(createMutate).toHaveBeenCalledWith(
+				expect.objectContaining({ host: "*.example.com" })
+			)
+		);
+	});
+
 	it("says the engine did not answer rather than showing an empty registry", () => {
 		queryResult = { data: undefined, isError: true };
 		renderCard();

--- a/app/src/modules/settings/main/panels/ClientCertificatesCard.tsx
+++ b/app/src/modules/settings/main/panels/ClientCertificatesCard.tsx
@@ -27,6 +27,14 @@
  * repo's existing credential precedent) and, once stored, never sent back -
  * which is why an entry that has one shows a badge and not a value.
  *
+ * **Every row says what it reaches** (issue #803). A host matches exactly and
+ * `*.example.com` matches every subdomain but not `example.com` itself - a
+ * distinction the pattern text does not carry on its own, so each row prints
+ * the scope in words and the form states the wildcard form where the host is
+ * typed. The matching itself stays in the engine; nothing here re-implements
+ * it, because two copies of a rule about which certificate goes on a wire is
+ * one copy too many.
+ *
  * **The format is a field, not a guess** (issue #833). A PEM certificate keeps
  * its key in a second file; a PKCS#12 bundle carries both, and is the only
  * shape a Windows build can present at all. So the form asks which one, drops
@@ -65,6 +73,32 @@ import { fileBaseName } from "@/lib/file-path";
 /** What an entry is called: the same `host` / `host:port` the engine traces. */
 function targetLabel(certificate: ClientCertificate): string {
 	return certificate.port === null ? certificate.host : `${certificate.host}:${certificate.port}`;
+}
+
+/** The one wildcard form the engine stores - see `matchSummary` (issue #803). */
+function isWildcardHost(host: string): boolean {
+	return host.startsWith("*.");
+}
+
+/**
+ * What a row will and will not answer for, in one sentence (issue #803).
+ *
+ * Printed for every row rather than only the wildcard ones, and stating the
+ * negative half explicitly, because the pattern text alone is exactly what a
+ * reader guesses wrong: `*.example.com` looks like it covers `example.com` and
+ * does not, and a plain host looks like it covers its subdomains and does not.
+ * A certificate silently *not* presented is the failure this registry exists to
+ * end, so the scope is on screen rather than in the docs.
+ *
+ * The port is deliberately absent here - it is already the row's title and its
+ * badge, and this sentence is about which *hosts* the entry reaches.
+ */
+function matchSummary(host: string): string {
+	if (!isWildcardHost(host)) {
+		return `Matches ${host} exactly - not its subdomains.`;
+	}
+	const domain = host.slice(2);
+	return `Matches any subdomain of ${domain} (api.${domain}, a.b.${domain}) - not ${domain} itself.`;
 }
 
 /**
@@ -291,6 +325,11 @@ export function ClientCertificatesCard() {
 											</Badge>
 										)}
 									</div>
+									{/* What this row reaches, spelled out - the pattern
+									    text alone is what a reader guesses wrong. */}
+									<p className="text-xs text-muted-foreground">
+										{matchSummary(certificate.host)}
+									</p>
 									{/* The basename reads; the full path is the title,
 									    because two `client.pem` in different directories
 									    are different certificates. */}
@@ -351,6 +390,15 @@ export function ClientCertificatesCard() {
 								/>
 							</div>
 						</div>
+						{/* The wildcard form is stated where the host is typed, not only
+						    on the row it produces: a user who never learns it exists
+						    registers one entry per service and adds one per new service. */}
+						<p className="text-xs text-muted-foreground">
+							A host matches exactly. Write{" "}
+							<code className="font-mono">*.example.com</code> to answer for every
+							subdomain instead - <code className="font-mono">api.example.com</code>{" "}
+							and deeper, never <code className="font-mono">example.com</code> itself.
+						</p>
 
 						<div className="space-y-1.5">
 							<Label>Format</Label>

--- a/app/src/types/api.ts
+++ b/app/src/types/api.ts
@@ -783,7 +783,11 @@ export type ClientCertificateFormat = "pem" | "p12";
 
 export interface ClientCertificate {
 	id: string;
-	/** Lower-cased hostname, no scheme or port - the engine stores it this way. */
+	/**
+	 * Lower-cased hostname, no scheme or port - the engine stores it this way -
+	 * or the one wildcard form, `*.example.com`, which answers for every
+	 * subdomain and never for the domain itself (issue #803).
+	 */
 	host: string;
 	/** The port this entry is specific to, or null when it answers on every one. */
 	port: number | null;

--- a/docs/app/api-integration.md
+++ b/docs/app/api-integration.md
@@ -993,6 +993,9 @@ read "HTTP/2" there
 
 `clientCertificate` names the client-certificate registry entry the exchange
 presented, as `host` or `host:port`, and `""` when none matched (issue #707).
+It is the entry's own spelling, so a wildcard row reads as `*.example.com`
+rather than as the host that was dialled - which is the point: it says which
+row answered (issue #803).
 The renderer maps that empty string to `undefined` and `ResponseStatusBar` draws
 a chip only when there is one - the same show-it-only-when-it-happened rule the
 downgrade warning follows. Nothing on the request names a certificate (the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,8 +260,9 @@ client for a certificate, and a certificate belongs to the host being called
 rather than to one request - the transfer that needs it is as often a token
 fetch, a redirect or a script's `pm.sendRequest`. So the engine keeps a
 registry of host to certificate (Settings > Network & connectivity), matches an
-entry per transfer by exact host and optional port, and presents it on every one
-of the paths above without any request naming it. Only the file *paths* are
+entry per transfer by host and optional port - an exact name, or `*.example.com`
+for every subdomain of it but never the domain itself - and presents it on every
+one of the paths above without any request naming it. Only the file *paths* are
 stored, so the private key stays where the user's own tooling put it; a
 cert-authenticated exchange reports which entry it used, live and from History
 alike. See [Client

--- a/docs/engine/api-reference.md
+++ b/docs/engine/api-reference.md
@@ -2059,12 +2059,27 @@ proxy, a load run and a collection run read the registry **once at run start**
 and hold it, because libcurl reuses a pooled connection only when its TLS
 identity matches.
 
-**Matching is by exact host, and most specific wins.** An entry naming a port
-answers only that port; an entry with `port: null` answers the host on every
-port; an entry naming this exact port beats the catch-all beside it. There are
-no wildcards in v1 - `*.example.com` is not a pattern, it is a hostname that
-matches nothing. Host comparison is case-insensitive (rows are stored
-lower-cased), and an IPv6 host is registered without its brackets (`::1`).
+**Matching is by host, and most specific wins.** A `host` is either an exact
+name (`api.example.com`) or the one wildcard form, `*.example.com`, which is
+read as a label suffix: it answers for `api.example.com` and `a.b.example.com`,
+never for `example.com` itself and never for `notexample.com`. That is the whole
+syntax - a `*` anywhere else is a `400` naming the form, rather than a row
+stored as a hostname no transfer can ever equal - and a wildcard never answers
+for an address literal (`127.0.0.1`), which only an exact entry matches.
+
+Three tiers decide which entry answers, closest host first:
+
+| Tier | Beats | Example against `api.eu.example.com:8443` |
+|------|-------|-------------------------------------------|
+| 1 | An exact host beats every wildcard | `api.eu.example.com` wins over `*.eu.example.com`, even if only the wildcard names the port |
+| 2 | A longer wildcard beats a shorter one | `*.eu.example.com` wins over `*.example.com` |
+| 3 | Within one host, the port beats the catch-all | `*.example.com` + `port: 8443` wins over `*.example.com` + `port: null` |
+
+The order is total, so the answer never depends on the order rows were added:
+two entries can only rank equally by naming the same host *and* the same port,
+and the second such write is a `409`. Host comparison is case-insensitive (rows
+are stored lower-cased), and an IPv6 host is registered without its brackets
+(`::1`).
 
 **Paths, not contents.** The row holds the *paths* of the certificate and key
 files and the engine opens them at send time, so the private key never enters
@@ -2158,7 +2173,7 @@ id](#the-engine-owns-every-id)).
 
 | Field | Required | Meaning |
 |-------|----------|---------|
-| `host` | yes | Hostname, no scheme, port or path. Stored lower-cased. |
+| `host` | yes | Hostname, no scheme, port or path - or `*.example.com` for every subdomain of it. Stored lower-cased. |
 | `port` | no | The port this entry is specific to; `null` or absent means every port. |
 | `certPath` | yes | Path to the certificate file. Must be readable now. |
 | `certFormat` | no | `pem` or `p12`. Absent or `null` reads it off `certPath`, falling back to `pem`. |
@@ -2169,7 +2184,7 @@ id](#the-engine-owns-every-id)).
 
 | Status | When |
 |--------|------|
-| `400` | A host that could never match (carries a scheme, a path, a port, or brackets), a port outside `1..65535`, a non-integer `port`, a missing `host` / `certPath`, a `pem` entry with no `keyPath`, a `p12` entry that names one, a `certFormat` outside `pem` / `p12`, a `certFormat` the file's own bytes contradict, a file that is not readable, or a body `id`. |
+| `400` | A host that could never match (carries a scheme, a path, a port, or brackets, or a `*` outside the `*.example.com` form), a port outside `1..65535`, a non-integer `port`, a missing `host` / `certPath`, a `pem` entry with no `keyPath`, a `p12` entry that names one, a `certFormat` outside `pem` / `p12`, a `certFormat` the file's own bytes contradict, a file that is not readable, or a body `id`. |
 | `409` | Another entry already claims this `host` + `port`. Two rows for one target would make the certificate presented depend on row order, so the second is refused with the id of the first rather than silently shadowing it. |
 
 ### PUT /client-certificates/:id

--- a/docs/engine/db-schema.md
+++ b/docs/engine/db-schema.md
@@ -509,7 +509,7 @@ matching rule.
 | Column       | Type    | Notes                                                     |
 |--------------|---------|-----------------------------------------------------------|
 | `id`         | TEXT PK | `cert_` + UUID                                            |
-| `host`       | TEXT    | Hostname, lower-cased, no scheme/port/path. IPv6 without brackets |
+| `host`       | TEXT    | Hostname, lower-cased, no scheme/port/path, or `*.example.com` for every subdomain of it (issue #803). IPv6 without brackets |
 | `port`       | INTEGER | NULL = answers for the host on every port                 |
 | `cert_path`  | TEXT    | Path to the certificate file                              |
 | `key_path`   | TEXT    | Path to the private key file; `""` for a `p12` entry, which carries its own |
@@ -542,8 +542,11 @@ The wire is narrower than the file: reads never echo the passphrase, answering
 `port` is nullable rather than a sentinel because "every port" is the *absence*
 of a port, the same distinction `result_bodies.stream_events` draws. At most one
 row may claim a given `host` + `port` pair - the routes answer `409` on the
-second - so the per-transfer match is unique by construction and needs no
-tie-break.
+second, and a wildcard pattern is a `host` like any other, so the rule covers it
+unchanged. Several rows may still *match* one transfer once patterns overlap
+(#803), and they are ranked rather than tie-broken: closest host, then port. A
+tie would need the same host and port twice, which is the pair the `409`
+forbids.
 
 ---
 

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -315,8 +315,13 @@ Three things worth knowing before you design around them:
   `client_certificates`). The registry rides *inside* the `TransportPolicy`, so
   it reaches every outbound path with no per-site wiring and is read once per
   run on the load and collection paths - `match_client_certificate` then picks
-  the entry per transfer from that snapshot, exact host, port-specific beating
-  catch-all, no wildcards. Only file **paths** are stored (the key never enters
+  the entry per transfer from that snapshot, ranked in three tiers (#803):
+  closest host first - an exact name beats every wildcard, a longer wildcard
+  beats a shorter one - then port-specific beating catch-all. The only pattern
+  is `*.example.com`, a label suffix that answers for every subdomain and never
+  for the domain itself or an address literal; a `*` elsewhere is a write-time
+  400, and the ranking is total, so no match depends on row order.
+  Only file **paths** are stored (the key never enters
   the database); the passphrase is stored plaintext on the existing credential
   precedent and is **never echoed** - reads answer `hasPassphrase`. Both paths
   are checked at write time, because an unreadable file otherwise surfaces as an

--- a/engine/include/vayu/http/transport_policy.hpp
+++ b/engine/include/vayu/http/transport_policy.hpp
@@ -159,10 +159,12 @@ struct ClientCertRule {
      * string compare rather than a second URL parser. An IPv6 literal is stored
      * without its brackets, again because that is the form the parser yields.
      *
-     * Exact match only. Wildcards are deliberately absent in v1: a
-     * `*.example.com` that matched `a.b.example.com` but not `example.com`
-     * would be a rule the card cannot state in one line, and a certificate
-     * silently *not* used is the failure this feature exists to end.
+     * **Or one wildcard** (issue #803), written `*.example.com` and read as a
+     * label suffix: it answers for `api.example.com` and `a.b.example.com`,
+     * never for `example.com` itself and never for `notexample.com`. That is
+     * the whole syntax - a `*` anywhere else is refused at write time rather
+     * than stored as a hostname no transfer can equal. A wildcard never answers
+     * for an address literal, which only an exact entry matches.
      */
     std::string host;
 
@@ -208,7 +210,9 @@ std::string client_cert_label (const ClientCertRule& rule);
  * can never work - a host carrying a scheme, a port outside 1..65535, a
  * certificate or key file this process cannot open - because every one of those
  * surfaces at handshake time as a TLS error that names the endpoint rather than
- * the setting, which is the shape this epic exists to stop.
+ * the setting, which is the shape this epic exists to stop. A `*` that is not
+ * the `*.example.com` form is refused for the same reason (#803): it would
+ * store as a hostname no transfer can ever equal.
  *
  * @p format decides what a *complete* entry is (#833): a `Pem` row needs its
  * key file and a `Pkcs12` row must not name one, because the bundle carries the
@@ -283,11 +287,16 @@ struct TransportPolicy {
 /**
  * @brief The registry entry that answers for @p host on @p port, or null.
  *
- * Most specific wins: an entry naming this exact port beats one that answers
- * for the host on any port. Beyond that there is nothing to rank, because
- * `client_cert_rejection` refuses a second entry for a host+port pair that is
- * already registered - so a match is unique by construction rather than by a
- * tie-break nobody could predict from the card.
+ * Most specific wins, in three tiers (issue #803): the closest *host* first -
+ * an exact entry beats every wildcard, and a longer wildcard beats a shorter
+ * one - then the port, where an entry naming this exact port beats one that
+ * answers for the host on any port.
+ *
+ * That order is total, so the answer never depends on the order the rows come
+ * back in: two rules that rank equally would have to name the same host and the
+ * same port, and `reject_duplicate_target` answers the second such write with a
+ * 409. There is deliberately no tie-break beyond it - a rule nobody could
+ * predict from the card is the thing this ranking replaces, not adds.
  *
  * @param host Lower-cased hostname, as `parse_authority` yields it.
  * @param port The port the transfer dials, scheme default included - never 0,

--- a/engine/src/http/transport_policy.cpp
+++ b/engine/src/http/transport_policy.cpp
@@ -15,10 +15,12 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <compare>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <system_error>
 #include <utility>
@@ -42,6 +44,41 @@ constexpr std::array<std::string_view, 7> PROXY_SCHEMES = { "http", "https",
 bool is_blank (std::string_view value) {
     return std::all_of (value.begin (), value.end (),
     [] (unsigned char c) { return std::isspace (c) != 0; });
+}
+
+/// The one wildcard form the registry takes: a leading `*.` and nothing else
+/// (issue #803). Written once because the matcher and the write-time check must
+/// agree on what a pattern *is* - a shape one accepted and the other did not
+/// would store an entry that can never match.
+bool is_wildcard_host (std::string_view host) {
+    return host.rfind ("*.", 0) == 0;
+}
+
+/// The labels a wildcard answers for, dot included: `*.example.com` yields
+/// `.example.com`. That leading dot is the rule - it is what makes the apex a
+/// non-match without a second condition to forget.
+std::string_view wildcard_suffix (std::string_view pattern) {
+    return pattern.substr (1);
+}
+
+/**
+ * Whether @p host is an address rather than a name.
+ *
+ * A wildcard is a rule about DNS labels, so it must not answer for an address
+ * literal: without this, an entry for `*.0.1` presents the user's client
+ * identity to `127.0.0.1`, which is the failure this feature is most obliged
+ * not to introduce - a certificate offered to a host nobody registered. Shallow
+ * on purpose (digits and dots, or a colon): it decides what a *wildcard* may
+ * answer for, never whether an address is well formed, and an exact entry still
+ * matches an address literal the way it always did.
+ */
+bool is_address_literal (std::string_view host) {
+    if (host.find (':') != std::string_view::npos) {
+        return true; // an IPv6 literal, stored bracketless
+    }
+    return !host.empty () &&
+    std::all_of (host.begin (), host.end (),
+    [] (unsigned char c) { return std::isdigit (c) != 0 || c == '.'; });
 }
 
 /// The PEM markers a certificate is wrapped in. Only the certificate label is
@@ -361,6 +398,21 @@ std::string_view key_path) {
         [] (unsigned char c) { return std::isspace (c) != 0; })) {
         return std::string ("host contains whitespace");
     }
+    // The one wildcard form, and every near-miss refused by name (issue #803).
+    // A `*` anywhere else is a pattern this engine does not have - stored, it
+    // would be a hostname no transfer can ever equal, which is exactly the
+    // "registered and silently never used" state this registry exists to end.
+    if (const std::string_view labels = is_wildcard_host (host) ? host.substr (2) : host;
+        labels.find ('*') != std::string_view::npos) {
+        return std::string (
+        "a wildcard host is written '*.example.com' - one leading '*.' and "
+        "the domain it answers for, with no other '*'");
+    }
+    if (is_wildcard_host (host) && (host.size () == 2 || host[2] == '.')) {
+        return std::string ("'" + std::string (host) +
+        "' names no domain after the '*.' - register '*.example.com'");
+    }
+
     // The three shapes a user reaches for when they copy the address bar. Each
     // is refused by name rather than stored and quietly never matched, because
     // a registry entry that cannot match is indistinguishable from a feature
@@ -439,6 +491,68 @@ std::string_view key_path) {
     return std::nullopt;
 }
 
+namespace {
+
+/**
+ * How specific a matching rule is, most significant field first (issue #803).
+ *
+ * The three tiers the registry documents, as one comparable value: an exact
+ * host beats every wildcard, a longer wildcard beats a shorter one, and within
+ * one host pattern the entry naming this port beats the catch-all beside it.
+ *
+ * **Two matching rules can never tie**, which is what keeps the presented
+ * certificate independent of row order. Two exact rows that both match have the
+ * same host; two wildcards whose suffixes are the same length and both end at
+ * the end of the host *are* the same string. So a tie means one host+port pair
+ * twice, which the routes answer with a 409 and the resolver drops - there is
+ * no order-dependent case left for a tie-break to decide.
+ */
+struct ClientCertRank {
+    /// 1 for an exact host, 0 for a wildcard. Host specificity dominates: an
+    /// exact entry with no port still beats a wildcard that names one, because
+    /// "the closest host wins, then the port" is the rule a card can state.
+    int exact_host = 0;
+    /// Length of the wildcard suffix that matched, so the longest wins;
+    /// unused (and irrelevant) for an exact host, which already outranks these.
+    std::size_t suffix_length = 0;
+    /// 1 when the row names this port, 0 when it answers every port.
+    int exact_port = 0;
+
+    auto operator<=> (const ClientCertRank&) const = default;
+};
+
+/// How well @p rule answers for @p host on @p port, or nullopt when it does not.
+/// @p host is already lower-cased; rows are stored that way (`lowered` in the
+/// routes), so both sides of every comparison here are.
+std::optional<ClientCertRank>
+rank_client_cert_rule (const ClientCertRule& rule, std::string_view host, int port) {
+    if (rule.port && *rule.port != port) {
+        return std::nullopt;
+    }
+    const int exact_port = rule.port ? 1 : 0;
+
+    if (!is_wildcard_host (rule.host)) {
+        if (rule.host != host) {
+            return std::nullopt;
+        }
+        return ClientCertRank{ 1, 0, exact_port };
+    }
+
+    // `*.example.com` answers for `api.example.com` and `a.b.example.com`,
+    // never for `example.com` (which does not carry the leading dot) and never
+    // for `notexample.com` (same). One label of headroom is the whole rule:
+    // ending with `.example.com` *and* being longer than it means at least one
+    // character sits in front of that dot.
+    const std::string_view suffix = wildcard_suffix (rule.host);
+    if (host.size () <= suffix.size () || !host.ends_with (suffix) ||
+    is_address_literal (host)) {
+        return std::nullopt;
+    }
+    return ClientCertRank{ 0, suffix.size (), exact_port };
+}
+
+} // namespace
+
 const ClientCertRule*
 match_client_certificate (const TransportPolicy& policy, std::string_view host, int port) {
     if (policy.client_certificates.empty () || host.empty ()) {
@@ -449,28 +563,19 @@ match_client_certificate (const TransportPolicy& policy, std::string_view host, 
     std::transform (wanted.begin (), wanted.end (), wanted.begin (),
     [] (unsigned char c) { return static_cast<char> (std::tolower (c)); });
 
-    const ClientCertRule* any_port = nullptr;
+    const ClientCertRule* best = nullptr;
+    ClientCertRank best_rank;
     for (const auto& rule : policy.client_certificates) {
-        if (rule.host != wanted) {
+        const auto rank = rank_client_cert_rule (rule, wanted, port);
+        if (!rank) {
             continue;
         }
-        if (rule.port) {
-            // The specific entry, and there is at most one - the routes refuse
-            // a duplicate host+port pair - so this is the answer, not a
-            // candidate to keep ranking.
-            if (*rule.port == port) {
-                return &rule;
-            }
-            continue;
-        }
-        // Remembered rather than returned: a later entry may still name this
-        // exact port, and the specific one outranks the catch-all whatever
-        // order the rows come back in.
-        if (any_port == nullptr) {
-            any_port = &rule;
+        if (best == nullptr || best_rank < *rank) {
+            best      = &rule;
+            best_rank = *rank;
         }
     }
-    return any_port;
+    return best;
 }
 
 std::optional<std::string> ca_pem_rejection (std::string_view pem) {

--- a/engine/tests/client_certificates_test.cpp
+++ b/engine/tests/client_certificates_test.cpp
@@ -239,9 +239,9 @@ TEST (ClientCertMatching, AnotherHostMatchesNothing) {
     policy.client_certificates.push_back (rule ("cert_1", "api.example.com", std::nullopt));
 
     EXPECT_EQ (match_client_certificate (policy, "other.example.com", 443), nullptr);
-    // Not a suffix match: an entry for the apex must not answer for a
-    // subdomain, because v1 registers exact hosts and a certificate quietly
-    // presented to a host nobody registered is the opposite of the promise.
+    // Not a suffix match: a plain host is an exact rule, so an entry for the
+    // apex must not answer for a subdomain. Widening one is what the wildcard
+    // form below is for, and it has to be asked for.
     EXPECT_EQ (match_client_certificate (policy, "eu.api.example.com", 443), nullptr);
     EXPECT_EQ (match_client_certificate (policy, "", 443), nullptr);
 }
@@ -251,6 +251,143 @@ TEST (ClientCertMatching, TheHostComparisonIgnoresCase) {
     policy.client_certificates.push_back (rule ("cert_1", "api.example.com", std::nullopt));
 
     EXPECT_NE (match_client_certificate (policy, "API.Example.COM", 443), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Wildcards (issue #803)
+// ---------------------------------------------------------------------------
+
+TEST (ClientCertWildcardMatching, AWildcardAnswersForEverySubdomain) {
+    // The case the form exists for: one gateway fronting `api`, `auth` and
+    // `events`, where a new service otherwise means a row nobody remembers to
+    // add and an SSL error against the endpoint.
+    TransportPolicy policy;
+    policy.client_certificates.push_back (rule ("cert_star", "*.example.com", std::nullopt));
+
+    for (const char* host : { "api.example.com", "auth.example.com", "a.b.example.com" }) {
+        const ClientCertRule* matched = match_client_certificate (policy, host, 443);
+        ASSERT_NE (matched, nullptr) << host;
+        EXPECT_EQ (matched->id, "cert_star") << host;
+    }
+}
+
+TEST (ClientCertWildcardMatching, AWildcardAnswersForNeitherTheApexNorALookalike) {
+    // The two near-misses the rule is stated by. The apex is the one a user
+    // expects to be included and is not - `*.example.com` is "a subdomain of",
+    // which `example.com` is not one of - and the lookalike is the one that
+    // costs a client identity if the leading dot is ever dropped from the
+    // comparison.
+    TransportPolicy policy;
+    policy.client_certificates.push_back (rule ("cert_star", "*.example.com", std::nullopt));
+
+    EXPECT_EQ (match_client_certificate (policy, "example.com", 443), nullptr);
+    EXPECT_EQ (match_client_certificate (policy, "notexample.com", 443), nullptr);
+    EXPECT_EQ (match_client_certificate (policy, "example.com.evil.test", 443), nullptr);
+    EXPECT_EQ (match_client_certificate (policy, "api.example.org", 443), nullptr);
+}
+
+TEST (ClientCertWildcardMatching, AWildcardNeverAnswersForAnAddressLiteral) {
+    // A wildcard is a rule about DNS labels. Without this, `*.0.1` would
+    // present the user's identity to `127.0.0.1` - a certificate offered to a
+    // host nobody registered, which is worse than one not offered at all.
+    TransportPolicy policy;
+    policy.client_certificates.push_back (rule ("cert_star", "*.0.1", std::nullopt));
+
+    EXPECT_EQ (match_client_certificate (policy, "127.0.0.1", 443), nullptr);
+    // The IPv4-mapped form is the one that carries dots, so it is the one a
+    // textual suffix rule would otherwise answer for.
+    EXPECT_EQ (match_client_certificate (policy, "::ffff:127.0.0.1", 443), nullptr);
+    // …while an exact entry for an address still answers, as it always did.
+    policy.client_certificates.push_back (rule ("cert_exact", "127.0.0.1", std::nullopt));
+    const ClientCertRule* matched = match_client_certificate (policy, "127.0.0.1", 443);
+    ASSERT_NE (matched, nullptr);
+    EXPECT_EQ (matched->id, "cert_exact");
+}
+
+TEST (ClientCertWildcardMatching, TheWildcardComparisonIgnoresCase) {
+    TransportPolicy policy;
+    policy.client_certificates.push_back (rule ("cert_star", "*.example.com", std::nullopt));
+
+    EXPECT_NE (match_client_certificate (policy, "API.Example.COM", 443), nullptr);
+}
+
+TEST (ClientCertWildcardMatching, AnExactHostOutranksAWildcardThatAlsoMatches) {
+    // Tier one of three, asserted in both row orders because the implementation
+    // that returns the first match passes one order and fails the other - and
+    // the port is deliberately on the *wildcard* here: host specificity
+    // dominates, so an exact entry answering every port still wins. That is
+    // what makes the rule one a card can state.
+    const auto exact_row = rule ("cert_exact", "api.example.com", std::nullopt);
+    const auto wildcard_row = rule ("cert_star", "*.example.com", 8443);
+
+    TransportPolicy exact_first;
+    exact_first.client_certificates = { exact_row, wildcard_row };
+    TransportPolicy wildcard_first;
+    wildcard_first.client_certificates = { wildcard_row, exact_row };
+
+    for (const auto* policy : { &exact_first, &wildcard_first }) {
+        const ClientCertRule* matched =
+        match_client_certificate (*policy, "api.example.com", 8443);
+        ASSERT_NE (matched, nullptr);
+        EXPECT_EQ (matched->id, "cert_exact");
+    }
+
+    // …and a host the exact entry does not name still reaches the wildcard.
+    const ClientCertRule* other =
+    match_client_certificate (exact_first, "auth.example.com", 8443);
+    ASSERT_NE (other, nullptr);
+    EXPECT_EQ (other->id, "cert_star");
+}
+
+TEST (ClientCertWildcardMatching, TheLongestWildcardWins) {
+    // Tier two: two patterns can overlap - `*.example.com` and
+    // `*.eu.example.com` both answer for `api.eu.example.com` - so the registry
+    // needs a rule that is not "whichever row came back first". Longest suffix
+    // is the one a reader can apply by eye.
+    const auto broad  = rule ("cert_broad", "*.example.com", std::nullopt);
+    const auto narrow = rule ("cert_narrow", "*.eu.example.com", std::nullopt);
+
+    TransportPolicy broad_first;
+    broad_first.client_certificates = { broad, narrow };
+    TransportPolicy narrow_first;
+    narrow_first.client_certificates = { narrow, broad };
+
+    for (const auto* policy : { &broad_first, &narrow_first }) {
+        const ClientCertRule* matched =
+        match_client_certificate (*policy, "api.eu.example.com", 443);
+        ASSERT_NE (matched, nullptr);
+        EXPECT_EQ (matched->id, "cert_narrow");
+        // The broader one still owns everything outside the narrower's subtree.
+        const ClientCertRule* elsewhere =
+        match_client_certificate (*policy, "api.us.example.com", 443);
+        ASSERT_NE (elsewhere, nullptr);
+        EXPECT_EQ (elsewhere->id, "cert_broad");
+    }
+}
+
+TEST (ClientCertWildcardMatching, ThePortEntryOutranksTheWildcardCatchAll) {
+    // Tier three, inside one pattern: the port rule that already governed exact
+    // hosts governs wildcards the same way, so a second service on the same
+    // subtree can still have its own certificate.
+    const auto any_port  = rule ("cert_any", "*.example.com", std::nullopt);
+    const auto this_port = rule ("cert_8443", "*.example.com", 8443);
+
+    TransportPolicy any_first;
+    any_first.client_certificates = { any_port, this_port };
+    TransportPolicy port_first;
+    port_first.client_certificates = { this_port, any_port };
+
+    for (const auto* policy : { &any_first, &port_first }) {
+        const ClientCertRule* matched =
+        match_client_certificate (*policy, "api.example.com", 8443);
+        ASSERT_NE (matched, nullptr);
+        EXPECT_EQ (matched->id, "cert_8443");
+
+        const ClientCertRule* other =
+        match_client_certificate (*policy, "api.example.com", 443);
+        ASSERT_NE (other, nullptr);
+        EXPECT_EQ (other->id, "cert_any");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -289,6 +426,29 @@ TEST (ClientCertValidation, RejectsAHostThatCouldNeverMatch) {
     EXPECT_TRUE (reject ("api.example.com:8443").has_value ());
     EXPECT_TRUE (reject ("[::1]").has_value ());
     EXPECT_TRUE (reject ("api example com").has_value ());
+}
+
+TEST (ClientCertValidation, AcceptsTheWildcardFormAndRefusesEveryOtherStar) {
+    ScratchFile cert{ "validation_cert_wildcard.pem" };
+    ScratchFile key{ "validation_key_wildcard.pem" };
+    const auto reject = [&] (const std::string& host) {
+        return client_cert_rejection (
+        host, std::nullopt, ClientCertFormat::Pem, cert.path (), key.path ());
+    };
+
+    EXPECT_FALSE (reject ("*.example.com").has_value ());
+    // A single-label domain is the corporate-estate case this shipped for
+    // (`api.corp`, `auth.corp` behind one gateway), so it is not refused for
+    // looking too broad.
+    EXPECT_FALSE (reject ("*.corp").has_value ());
+
+    // Everything else carrying a `*` is refused *by name* rather than stored:
+    // each of these would otherwise be a hostname no transfer can ever equal,
+    // registered and silently never used.
+    for (const char* host : { "*", "*.", "*..example.com", "*example.com",
+         "api.*.com", "*.*.example.com", "**.example.com" }) {
+        EXPECT_TRUE (reject (host).has_value ()) << host;
+    }
 }
 
 TEST (ClientCertValidation, RejectsAPortOutsideTheRange) {
@@ -627,6 +787,42 @@ TEST_F (ClientCertificateDbTest, RefusesASecondEntryForTheSameTarget) {
     routes::create_client_certificate_response (*db_, body ("api.example.com")).first, 200);
 }
 
+TEST_F (ClientCertificateDbTest, AWildcardIsATargetLikeAnyOther) {
+    // The uniqueness rule extends to patterns because the pattern *is* the
+    // target string (#803) - without that, two rows for `*.example.com` would
+    // put the certificate presented back at the mercy of row order, which is
+    // the property the three-tier ranking exists to keep.
+    ASSERT_EQ (
+    routes::create_client_certificate_response (*db_, body ("*.example.com")).first, 200);
+
+    const auto [status, error] =
+    routes::create_client_certificate_response (*db_, body ("*.example.com"));
+    EXPECT_EQ (status, 409);
+    EXPECT_NE (error.dump ().find ("*.example.com"), std::string::npos);
+
+    // Overlapping-but-different patterns are allowed, and are exactly what the
+    // longest-suffix rule resolves: they can never tie, because two suffixes of
+    // the same length that both match a host are the same string.
+    EXPECT_EQ (
+    routes::create_client_certificate_response (*db_, body ("*.eu.example.com")).first, 200);
+    // As is the same pattern on one port, beside the catch-all.
+    EXPECT_EQ (routes::create_client_certificate_response (*db_, body ("*.example.com", 8443))
+               .first,
+    200);
+    EXPECT_EQ (db_->get_client_certificates ().size (), 3u);
+}
+
+TEST_F (ClientCertificateDbTest, RefusesAWildcardShapeThatCouldNeverMatch) {
+    // The route's half of the write-time check: a `*` outside the one form is a
+    // 400 naming the form, not a stored row that never answers.
+    const auto [status, error] =
+    routes::create_client_certificate_response (*db_, body ("*.*.com"));
+    EXPECT_EQ (status, 400);
+    EXPECT_NE (error.dump ().find ("*.example.com"), std::string::npos)
+    << "the rejection has to show the one shape that works: " << error.dump ();
+    EXPECT_TRUE (db_->get_client_certificates ().empty ());
+}
+
 TEST_F (ClientCertificateDbTest, UpdatesMergePatchStyle) {
     const auto [created_status, created] =
     routes::create_client_certificate_response (*db_, body ("api.example.com", 8443));
@@ -698,6 +894,28 @@ TEST_F (ClientCertificateDbTest, TheRegistryReachesTheResolvedPolicy) {
     ASSERT_NE (matched, nullptr);
     EXPECT_EQ (matched->cert_path, cert_.path ());
     EXPECT_EQ (matched->key_path, key_.path ());
+}
+
+TEST_F (ClientCertificateDbTest, AStoredWildcardSurvivesTheResolverAndAnswers) {
+    // The stored-to-matched path in one test, because the resolver re-runs
+    // `client_cert_rejection` on every row it reads (a row hand-edited around
+    // the routes is dropped there): a wildcard the route accepted but the
+    // resolver refused would be a registry entry that vanished between the card
+    // and the wire, which is worse than one refused up front.
+    ASSERT_EQ (
+    routes::create_client_certificate_response (*db_, body ("*.example.com")).first, 200);
+
+    const auto policy = resolve_transport_policy (*db_);
+    ASSERT_EQ (policy.client_certificates.size (), 1u);
+
+    const ClientCertRule* matched =
+    match_client_certificate (policy, "api.example.com", 443);
+    ASSERT_NE (matched, nullptr);
+    EXPECT_EQ (matched->cert_path, cert_.path ());
+    // The label a trace and the response pane carry is the pattern itself, so a
+    // user reading either learns which registry row answered.
+    EXPECT_EQ (client_cert_label (*matched), "*.example.com");
+    EXPECT_EQ (match_client_certificate (policy, "example.com", 443), nullptr);
 }
 
 TEST_F (ClientCertificateDbTest, ARowWhoseFileWentMissingIsDroppedAndNamed) {


### PR DESCRIPTION
## Description

Issue #803: the client-certificate registry matched an **exact** host, so a corporate estate behind one mTLS gateway (`api.corp`, `auth.corp`, `events.corp`) needed one row per service - and a new service failed as an `SslError` naming the endpoint, which is the misdiagnosis this epic exists to end.

**The plan, in one paragraph.** The root cause is that `host` was a name and nothing else, so widening an entry was impossible and the only failure mode available was "add another row, or don't and find out later". The approach is the one the issue specifies: exactly one pattern form - `*.example.com`, read as a label suffix - and a *total* ranking to go with it, because the moment two rows can match one transfer, "which certificate goes on the wire" stops being unique by construction. `match_client_certificate` now ranks every matching row by (closest host, longest wildcard, port-specific) and takes the maximum, and the ordering is total: two rows can only rank equally by naming the same host **and** the same port, which is exactly the pair `reject_duplicate_target` already answers with a `409`. So the uniqueness rule extends to patterns with no new code - the pattern *is* the target string - and no match depends on row order. **Alternatives rejected:** a general glob or regex matcher (a matcher with its own bug budget, and a rule no card can print); and keeping exact-host-only, which the issue lists as an equally valid resolution - that remains yours to take instead of merging this, but the fix pathway's own precondition ("if the rule can be stated in one line") is met, and the one line is on screen per row rather than in the docs.

### What ships

**Engine**

- `*.example.com` matches `api.example.com` and `a.b.example.com`, never `example.com`, never `notexample.com`. The leading dot in the stored suffix is the whole rule: ending with `.example.com` *and* being longer than it means at least one label sits in front.
- **A wildcard never answers for an address literal.** Without that guard `*.0.1` presents the user's client identity to `127.0.0.1` - a certificate offered to a host nobody registered, which is worse than one not offered. An exact entry still matches an address, as it always did.
- Three tiers, closest host first: an exact host beats every wildcard (even one naming the port), a longer wildcard beats a shorter one, and within one host pattern the port-specific row beats the catch-all.
- Write-time validation gained the near-misses: a `*` outside the one form is a `400` naming the form (`*`, `*.`, `*example.com`, `api.*.com`, `*.*.example.com`, `**.example.com`), rather than a row stored as a hostname no transfer can ever equal.

**App**

- Every row in the Settings card prints, in words, what it will and will not match - `Matches api.example.com exactly - not its subdomains.` / `Matches any subdomain of example.com (api.example.com, a.b.example.com) - not example.com itself.` Printed for exact rows too, because the guess goes wrong in both directions.
- The add form states the wildcard form where the host is typed. The card does **not** validate the pattern: the engine owns the one copy of that rule and its `400` names the shape that works, so a second copy here would only drift.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

All local, on this branch:

| Suite | Result |
|---|---|
| `python build.py -e -t` | clean |
| `cd engine && ctest --preset linux-dev --output-on-failure` | **2103 / 2103 passed**, 0 failed (11 of them new here) |
| `cd app && pnpm test` | **5781 / 5781 passed**, 522 files (3 new here; the same tree at the base commit `598227f` measures 5778 / 5778) |
| `cd app && pnpm type-check` | clean (all three configs) |
| `cd app && pnpm lint` (touched files) | clean |
| `cd app && pnpm format:check` (touched files) | clean; both were prettier-clean before |
| `mkdocs build --strict` | clean |

New engine tests (11): the seven `ClientCertWildcardMatching` cases (subdomain and deeper; the apex and the lookalike; the address literal; case folding; and the three tiers, each asserted in **both row orders** - the naive "first match wins" implementation passes one order and fails the other), one `ClientCertValidation` case covering the accepted form and every refused star, and three `ClientCertificateDbTest` cases: the `409` on a duplicate pattern with overlapping-but-distinct patterns allowed beside it, the `400` on a bad star shape, and a stored wildcard surviving the resolver (which re-runs `client_cert_rejection` on every row it reads) to answer on a subdomain and not on the apex.

New app tests (3): the per-row sentence in both directions, the form's hint, and a wildcard host sent through unchanged.

Mutation-checked, three of them run rather than reasoned about:

- Ranking a wildcard as though it were an exact host (`ClientCertRank{0, ...}` for the exact branch) reddens `AnExactHostOutranksAWildcardThatAlsoMatches` - and only in the wildcard-first row order, which is the point of asserting both.
- Dropping the leading dot from the stored suffix (`substr(2)`) reddens `AWildcardAnswersForNeitherTheApexNorALookalike`, since the apex and `notexample.com` both start matching.
- Dropping the `- not example.com itself.` half of the row sentence reddens `prints what each row will and will not match`.

**One honest note on the app suite.** Two earlier full-suite runs on this branch each reported `1 failed | 5780 passed`, always the same test - `run-view-navigability.test.tsx > counts the filtered list...`, an `Error: Test timed out in 5000ms`. Both of those runs shared the box with an engine build (565s and 495s wall, against 330s idle). Run on an idle machine the branch is green (5781/5781, 334s) and so is the base commit (5778/5778, 330s), so it is CPU contention against vitest's default 5s timeout on the most render-heavy test in the suite, not this diff. Diagnosed and filed as #846 rather than left in a PR comment; nothing here touches that module.

## Checklist
- [x] My code follows the style guidelines. Both C++ files are *not* clang-format-clean on master, so this ran `git-clang-format origin/master` - the changed lines only - rather than reformatting whole files; prettier likewise touched only `ClientCertificatesCard.tsx`, which was clean before
- [x] I have performed a self-review
- [x] I have added tests
- [x] I have updated documentation - `docs/engine/api-reference.md` (the matching rule, now a three-tier table, plus the `host` body field and the `400` list), `docs/architecture.md`, `docs/engine/db-schema.md` (the `host` column and the uniqueness paragraph, which now says why several *matching* rows still need no tie-break), `docs/app/api-integration.md` (a wildcard row reads as its own spelling in `clientCertificate`), `engine/CLAUDE.md`, and the `ClientCertRule::host` / `match_client_certificate` / `client_cert_rejection` header comments that stated "no wildcards"

## Related Issues
Closes #803

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFvbnPTG6op99S1P1xx4UU)_