### PR TITLE
perf(engine/db): the first connection carries the engine's durability, and the config seed is one transaction (#838)

### DIFF
--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -355,10 +355,24 @@ suite) are only the visible tip of that group.
 
 So the group's serial time - the floor the whole hybrid model sits on - is a
 little under half what it was, and the seed is the larger of the two halves.
-Note what this does *not* change: the group is still locked on Windows, because
-the lock's justification is the `-j4` blow-up and only a Windows run can say
-whether a cheaper group survives overlapping. Do not shrink
-`vayu_scratch_database_suites` on the strength of the table above.
+
+**What that turned into on CI**, first run after the change (32275928094), all
+three legs green:
+
+| leg | ctest step | before |
+|---|---:|---:|
+| ubuntu | 30s | ~1m15s |
+| macOS | 53s | ~1m06s |
+| **windows** | **2m32s** (2105 tests, 10 skipped, 0 failed) | 5m27s / 4m50s |
+
+The Windows leg is the one this was aimed at, and it lands at roughly half of
+the 4m40s-6m38s band its *serial* runs spanned - so the hybrid model is finally
+faster than the serial one it replaced, rather than merely no slower.
+
+Note what this does *not* change: the group is still locked on Windows. The
+lock's justification is the `-j4` blow-up, and the number above says the group
+got cheaper, not that it now survives overlapping - that is its own experiment.
+Do not shrink `vayu_scratch_database_suites` without one.
 
 **What CI measured on the hybrid model: 5m27s and 4m50s** on two runs of the
 same tree (32249239500 and 32252015024), 2071 tests, 0 failures, 9 skipped. Both
@@ -368,9 +382,9 @@ way. What they do establish is that the mechanism works: the same `-j4` that too
 ~37 min without the lock now finishes in the time serial used to take, which is
 what the 81% number predicts and the reason to hold the expectation there rather
 than at the ~2.5 min this was first scoped for. Getting a real speedup meant
-making the database tests cheaper, which is issue #838 and the table above; what
-that buys the Windows leg specifically is whatever its first CI run after #838
-records on that issue.
+making the database tests cheaper, which is issue #838 and the table above -
+and which took the Windows leg to 2m32s, close to the ~2.5 min this whole line
+of work was first scoped for.
 
 Isolation is the **default** on every platform now, so a hand-run `ctest -j` is
 safe wherever it happens; the Windows presets used to set

--- a/docs/engine/building.md
+++ b/docs/engine/building.md
@@ -300,12 +300,27 @@ took ~37 min against a ~6 min serial run - the same `-j4` that cut ubuntu from
 3-5 min to 1m15s and macOS from ~4 min to 1m06s. The per-test durations said
 why: a fast band of pure-logic suites, and a slow band that is exactly the
 fixtures which open a scratch `Database`, where concurrent SQLite commits cost
-more than the concurrency returns (the flush barrier `synchronous=FULL` issues
-per commit, and the 25-250ms retry sleeps `os_win.c` answers a sharing violation
-with). Moving the scratch directories between volumes was tried and made no
-difference, and Windows Defender is not a factor - GitHub's hosted Windows
-images ship with real-time monitoring disabled - so do not re-litigate either
-without new measurements.
+more than the concurrency returns (the 25-250ms retry sleeps `os_win.c` answers
+a sharing violation with, and - until #838 - a genuine `synchronous=FULL` flush
+barrier, though not where this paragraph used to put it; see below). Moving the
+scratch directories between volumes was tried and made no difference, and
+Windows Defender is not a factor - GitHub's hosted Windows images ship with
+real-time monitoring disabled - so do not re-litigate either without new
+measurements.
+
+**Where the flush barrier actually was (#838).** This section used to name
+"the flush barrier `synchronous=FULL` issues per commit" as the cost, and that
+was wrong about the steady state: `dbSynchronous` defaults to **Off**
+(`constants::database::SYNCHRONOUS` is `0`), so a committed result has never
+carried an fsync. What did carry one was everything a `Database` does *before*
+`init` applies that setting - two `sync_schema` passes from the constructor and
+a config seed that wrote its sixty-odd rows as sixty-odd separate transactions -
+all of it on SQLite's own defaults, a rollback journal at `synchronous=FULL`.
+Per process, once; and the suite is one process per test. So the barrier was
+real, it was paid at open rather than per commit, and it was the engine paying
+for durability its own configuration says it does not want. #838 applies the
+engine's journal mode and `synchronous` to the first connection the constructor
+opens, and makes the seed one transaction.
 
 So the Windows presets run `-j4` with those tests holding a shared CTest
 `RESOURCE_LOCK`: no two of them run at once, while everything else runs 4-wide
@@ -321,13 +336,29 @@ contends rather than breaks.
 
 Measured locally on a 4-core box (Debug, 2070 tests, green in all four runs):
 299.6s serial, 84.8s at `-j4`, 58.6s at `-j8`, and 243.7s at `-j4` with the lock
-forced on - the last being the model Windows runs. That ratio is the honest
+forced on - the last being the model Windows runs. That ratio was the honest
 ceiling of this approach: the locked group is 817 of the 2070 tests but **81% of
 the serial wall**, because the route and load fixtures that dominate the suite's
 duration all open a database. The six fixtures the earlier analysis measured on
 Windows (197 tests, 57.2s, 19% of the wall here - within a point of the Windows
 figures, which is what makes this box a usable proxy for the *shape* of the
 suite) are only the visible tip of that group.
+
+**What #838 took off that group**, measured on the same class of box (Debug,
+`ctest -j1` over the locked filter only, all green):
+
+| build | locked-group serial wall |
+|---|---:|
+| before | 281.5s (820 tests) |
+| config seed in one transaction | 170.8s (822 tests) |
+| plus the pragmas on the first connection | **146.0s** (823 tests) |
+
+So the group's serial time - the floor the whole hybrid model sits on - is a
+little under half what it was, and the seed is the larger of the two halves.
+Note what this does *not* change: the group is still locked on Windows, because
+the lock's justification is the `-j4` blow-up and only a Windows run can say
+whether a cheaper group survives overlapping. Do not shrink
+`vayu_scratch_database_suites` on the strength of the table above.
 
 **What CI measured on the hybrid model: 5m27s and 4m50s** on two runs of the
 same tree (32249239500 and 32252015024), 2071 tests, 0 failures, 9 skipped. Both
@@ -336,9 +367,10 @@ speedup** - and with a baseline that noisy, two samples could not show one eithe
 way. What they do establish is that the mechanism works: the same `-j4` that took
 ~37 min without the lock now finishes in the time serial used to take, which is
 what the 81% number predicts and the reason to hold the expectation there rather
-than at the ~2.5 min this was first scoped for. Getting a real speedup means
-making the database tests cheaper to run concurrently, which is issue #838; treat
-that as the open work, not this paragraph as a win.
+than at the ~2.5 min this was first scoped for. Getting a real speedup meant
+making the database tests cheaper, which is issue #838 and the table above; what
+that buys the Windows leg specifically is whatever its first CI run after #838
+records on that issue.
 
 Isolation is the **default** on every platform now, so a hand-run `ctest -j` is
 safe wherever it happens; the Windows presets used to set

--- a/engine/include/vayu/db/database.hpp
+++ b/engine/include/vayu/db/database.hpp
@@ -543,6 +543,20 @@ class Database {
      */
     int applied_cache_size_bytes () const;
 
+    /**
+     * @brief SQLite's `synchronous` level on this database's connection, read
+     * back from SQLite rather than echoed (0 = OFF, 1 = NORMAL, 2 = FULL).
+     *
+     * The sibling of `applied_cache_size_bytes` above, and for the same reason:
+     * the level is applied twice over the life of a `Database` - the engine's
+     * compile-time default before the constructor's schema sync, then whatever
+     * `dbSynchronous` holds once `init` can read it - and asking SQLite is the
+     * only way to say which one is in force. Issue #838, where the startup log
+     * line reported the level the engine had *asked* for while the schema sync
+     * and the config seed had already run at SQLite's own default.
+     */
+    int applied_synchronous () const;
+
     // Type-safe config getters (replaces ConfigManager)
     int get_config_int (const std::string& key, int default_value = 0);
     std::string get_config_string (const std::string& key,

--- a/engine/src/db/database.cpp
+++ b/engine/src/db/database.cpp
@@ -584,6 +584,34 @@ struct Database::Impl {
                 sqlite3_free (err_msg);
             }
         };
+
+        // Durability, applied here rather than in `Database::init` - which is
+        // where it used to be applied *only* (issue #838).
+        //
+        // Everything before `init` runs on whatever SQLite defaults to, and
+        // SQLite defaults to a rollback journal at `synchronous=FULL`. That
+        // covered the two `sync_schema` passes the constructor makes and the
+        // ~66 separate commits `seed_default_config` used to write, so every
+        // database this engine has ever opened paid a full fsync barrier per
+        // statement for the whole of its startup, at settings its own
+        // `dbSynchronous` entry says should be `OFF`. Nothing chose that; it
+        // was the gap between opening the file and reading the row that says
+        // how to open it.
+        //
+        // The compile-time constant is used because the configured value lives
+        // in a table this connection has not created yet. `init` re-applies
+        // whatever `dbSynchronous` holds once it can read it, so a user who
+        // raised the setting still gets it for the process's whole working
+        // life - only the schema sync and the seed run at the default, and
+        // the constructor takes a `.bak` copy of the previous file before
+        // either of them touches it.
+        //
+        // Set through `storage.pragma` rather than the callback above because
+        // sqlite_orm remembers these two and re-applies them to every
+        // connection it opens - which is exactly why `cache_size`, which it
+        // does not remember, is in the callback instead.
+        storage.pragma.journal_mode (journal_mode::WAL);
+        storage.pragma.synchronous (vayu::core::constants::database::SYNCHRONOUS);
     }
 };
 
@@ -721,8 +749,10 @@ void Database::init () {
     // Idempotent, so this stays rather than needing a one-shot migration flag.
     impl_->storage.drop_table_if_exists ("metrics");
 
-    // WAL mode for better concurrent read/write performance
-    impl_->storage.pragma.journal_mode (journal_mode::WAL);
+    // WAL mode and the default `synchronous` are set by `Impl`'s constructor,
+    // before the first `sync_schema` - see the note there. They are deliberately
+    // not repeated here: two statements of one fact drift, and this one used to
+    // read as though the connection had been on a rollback journal until now.
 
     // Seed default configuration values if empty (must be before reading config)
     seed_default_config ();
@@ -748,10 +778,13 @@ void Database::init () {
     get_config_int ("dbBusyTimeout", vayu::core::constants::database::BUSY_TIMEOUT_MS);
     impl_->storage.pragma.busy_timeout (busy_timeout);
 
+    // Both values are read back from the connection rather than echoed from the
+    // config row: what the engine asked for and what SQLite holds are two
+    // different statements, and only the second one is worth logging.
     vayu::utils::log_debug ("Database initialized with WAL mode (cache=" +
     std::to_string (applied_cache_size_bytes () / 1024) + "KB, " +
     "busy_timeout=" + std::to_string (busy_timeout) + "ms, " +
-    "synchronous=" + std::to_string (synchronous) + ")");
+    "synchronous=" + std::to_string (applied_synchronous ()) + ")");
 
     // Close out runs abandoned by a previous process before pruning, so an
     // orphan becomes a terminal (and therefore prunable) row in the same
@@ -2156,6 +2189,13 @@ int Database::applied_cache_size_bytes () const {
     return impl_->applied_cache_size_bytes.load ();
 }
 
+int Database::applied_synchronous () const {
+    // Unlike the cache size above this is a query, not a cached atomic, so it
+    // takes the mutex the rest of the storage access does.
+    std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+    return impl_->storage.pragma.synchronous ();
+}
+
 // Type-safe config getters (replaces ConfigManager)
 int Database::get_config_int (const std::string& key, int default_value) {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
@@ -2247,6 +2287,23 @@ std::string db_synchronous_options_json () {
 
 void Database::seed_default_config () {
     std::lock_guard<std::recursive_mutex> lock (impl_->mutex);
+
+    // One transaction for the whole seed, for two reasons that happen to agree
+    // (issue #838).
+    //
+    // Correctness: this writes upwards of sixty rows - thirteen deletions of
+    // retired keys and one upsert per live entry - and each was its own
+    // implicit transaction, so a throw partway through left the config table
+    // half-seeded. The next start repaired it (a missing key is re-seeded, an
+    // existing one keeps the user's value), but "repaired on the next start"
+    // is not the same promise as "never observed half-written", and the
+    // config route can read this table while startup is still writing it.
+    //
+    // Cost: sixty-odd commits became one. On a scratch database that is the
+    // difference between sixty WAL commits per test process and a single one,
+    // which is what makes this show up in a test-suite wall time at all. The
+    // guard rolls back if anything below throws; `commit` is at the end.
+    auto seed_transaction = impl_->storage.transaction_guard ();
 
     // Retired settings: keys nothing reads any more. Delete any row left behind
     // by an older version so the Settings UI (which renders engine entries
@@ -3105,6 +3162,9 @@ void Database::seed_default_config () {
     "65536",   // 64KB
     "1048576", // 1MB
     std::nullopt, now }))));
+
+    seed_transaction.commit ();
+
     if (existing.empty ()) {
         vayu::utils::log_info ("Seeded default configuration values");
     } else {

--- a/engine/tests/db_test.cpp
+++ b/engine/tests/db_test.cpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <set>
 #include <string>
 #include <utility>
@@ -390,6 +391,86 @@ TEST_F (DatabaseTest, CacheSizeConfigReachesTheConnection) {
     Database reopened (TEST_DB_PATH);
     reopened.init ();
     EXPECT_EQ (reopened.applied_cache_size_bytes (), kConfigured);
+}
+
+// Issue #838. Everything the constructor does - two `sync_schema` passes and,
+// through `init`, a sixty-row config seed - used to run on SQLite's own
+// defaults, because the engine applied WAL and `synchronous` only after all of
+// it. The assertions are deliberately made *before* `init` is called: that is
+// the window that was unguarded, and after `init` both settings would be in
+// force either way, so a test written there would pass against the bug.
+TEST_F (DatabaseTest, TheFirstConnectionCarriesTheEnginesDurabilitySettings) {
+    Database db (TEST_DB_PATH);
+
+    EXPECT_EQ (db.applied_synchronous (), vayu::core::constants::database::SYNCHRONOUS)
+    << "the schema sync ran at SQLite's default instead of the engine's";
+
+    // Journal mode is read off the database header rather than from a `-wal`
+    // sidecar: SQLite removes the sidecars when the last connection closes, and
+    // sqlite_orm holds none open between statements, so by the time the
+    // constructor returns there is nothing beside the file to look at. Byte 18
+    // of every SQLite file is the write format version - 1 for a rollback
+    // journal, 2 for WAL - and it persists, which is the point of the check.
+    std::ifstream header (TEST_DB_PATH, std::ios::binary);
+    ASSERT_TRUE (header.is_open ());
+    char format[20] = {};
+    ASSERT_TRUE (header.read (format, sizeof (format)))
+    << "a database this engine created is longer than its own header";
+    EXPECT_EQ (static_cast<int> (format[18]), 2)
+    << "the schema was written under a rollback journal, before init() set WAL";
+}
+
+// The other half of the same change: `init` must still hand the *configured*
+// level to the connection, so raising `dbSynchronous` is not quietly undone by
+// the default the constructor now applies. Reopened, because the entry is
+// restart-required - the same shape as CacheSizeConfigReachesTheConnection.
+TEST_F (DatabaseTest, SynchronousConfigStillWinsOverTheConstructorDefault) {
+    constexpr int kConfigured = 2; // FULL
+    static_assert (kConfigured != vayu::core::constants::database::SYNCHRONOUS,
+    "the test value must differ from the default the constructor applies");
+
+    {
+        Database db (TEST_DB_PATH);
+        db.init ();
+        auto entry = db.get_config_entry ("dbSynchronous");
+        ASSERT_TRUE (entry.has_value ());
+        entry->value = std::to_string (kConfigured);
+        db.save_config_entry (*entry);
+    }
+
+    Database reopened (TEST_DB_PATH);
+    reopened.init ();
+    EXPECT_EQ (reopened.applied_synchronous (), kConfigured);
+}
+
+// The seed is one transaction now (issue #838) rather than sixty-odd implicit
+// ones. What that must not change is what a re-seed *means*, which is the
+// regression a transaction wrapper can plausibly introduce: same rows, user
+// values kept, metadata refreshed. Proving the rollback half would need a
+// mid-seed failure, and this suite deliberately builds no fault injection for
+// SQLite (see the note in `db_concurrency_test.cpp`), so that half is left to
+// the shape of the code rather than claimed here.
+TEST_F (DatabaseTest, ASeedInsideOneTransactionStillPreservesUserValues) {
+    Database db (TEST_DB_PATH);
+    db.init ();
+
+    const size_t seeded = db.get_all_config_entries ().size ();
+    ASSERT_GT (seeded, 40u)
+    << "the seed is the many-row write this test is about";
+
+    auto entry = db.get_config_entry ("dbBusyTimeout");
+    ASSERT_TRUE (entry.has_value ());
+    entry->value = "12345";
+    db.save_config_entry (*entry);
+
+    db.seed_default_config ();
+
+    EXPECT_EQ (db.get_all_config_entries ().size (), seeded)
+    << "a re-seed neither adds nor drops rows";
+    auto preserved = db.get_config_entry ("dbBusyTimeout");
+    ASSERT_TRUE (preserved.has_value ());
+    EXPECT_EQ (preserved->value, "12345")
+    << "the seed keeps a user's value and only refreshes metadata";
 }
 
 // The "options" column is new (Task 4); an existing on-disk database predates


### PR DESCRIPTION
## Description

**The plan, and the root cause it rests on.** #838 asked how a fixture could opt into cheaper scratch-database durability without putting a test-only knob on the production `Database` API. Reading the code before writing any: `constants::database::SYNCHRONOUS` is **`0` (OFF)** and has been, so lever 1's premise - that a per-commit `synchronous=FULL` flush barrier is what makes concurrent scratch-database work expensive - is false for the steady state. There is nothing for a fixture to opt into.

The barrier is real, though, and it is paid somewhere else. `Database::init()` is where WAL and `synchronous` were applied, and it runs *after* the constructor's two `sync_schema` passes - so every database this engine has ever opened wrote its schema on SQLite's own defaults, a rollback journal at `synchronous=FULL`. Inside that same window `seed_default_config()` wrote its sixty-odd rows (thirteen deletions plus one upsert per live entry) as sixty-odd separate implicit transactions. Per process, once. The suite is one process per test.

So the fix belongs in the product, not in the fixtures: apply the engine's own journal mode and `synchronous` to the first connection the constructor opens, and make the seed one transaction. **The alternative I rejected** is the one the issue sketched - a per-fixture opt-in helper in `temp_database.hpp` writing `dbSynchronous` before `init()`. It works, but it would have bought a test-suite speedup by routing around a production defect instead of fixing it, and left the engine still paying full-durability fsyncs at every start for a setting it does not want.

### What changed

- `Database::Impl`'s constructor sets `journal_mode=WAL` and `synchronous=<compile-time default>` before the first `sync_schema`. Through `storage.pragma` rather than the `on_open` callback, because sqlite_orm re-applies exactly those two to every connection it opens (`on_open_internal`) - which is why `cache_size`, which it does not remember, stays in the callback. `init()` still overrides with whatever `dbSynchronous` holds once the row is readable, so a user who raises the setting keeps it for the process's working life.
- `seed_default_config()` takes a transaction guard. Sixty-odd commits become one, and the seed becomes atomic rather than merely self-repairing on the next start.
- `applied_synchronous()` joins `applied_cache_size_bytes()` as a read-back accessor, on that accessor's recorded justification. The startup log line now reports the level **in force** instead of the one requested, which is both more honest and the thing that gives the accessor a non-test reader.

### Blast radius

`Database` is the only writer of these pragmas; nothing else reads `synchronous`. The one behaviour delta outside tests: the constructor's schema sync (including a migration on an existing file) now runs at the engine's default rather than `FULL`. That is the same exposure every other write in the engine already has, the config description states it (*"the database stays uncorrupted through a crash, but the last few results may be lost to a power cut"*), and the constructor takes a `.bak` copy of the previous file before touching it. Flagging it explicitly rather than burying it: it is the only thing here anyone should push back on.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

`python build.py -e -t`, then `ctest --preset linux-dev` - **2113 tests, 0 failures, 40.6s**.

Measurements, 4-core box, Debug, `ctest -j1` over the locked scratch-database filter only, every run green:

| build | locked-group serial wall |
|---|---:|
| master | 281.5s (820 tests) |
| seed transaction alone | 170.8s (822 tests) |
| plus the pragmas on the first connection | **146.0s** (823 tests) |

The seed is the larger half; the arithmetic agrees with the mechanism (~66 fsyncing commits per open x ~2ms x ~820 test processes lands within noise of the 135s removed). The three new tests account for the 820/823 difference.

New tests in `db_test.cpp`, all mutation-checked by deleting the two pragma lines and rebuilding:

- `TheFirstConnectionCarriesTheEnginesDurabilitySettings` - asserts **before** `init()` is called, which is the window that was unguarded; after `init()` both settings hold either way, so a test written there would pass against the bug. Journal mode is read off byte 18 of the database header (1 = rollback journal, 2 = WAL) rather than from a `-wal` sidecar, because SQLite removes the sidecars when the last connection closes and sqlite_orm holds none open between statements. Reverted: `synchronous` reads 2 instead of 0 and the header byte reads 1 instead of 2 - both assertions redden.
- `SynchronousConfigStillWinsOverTheConstructorDefault` - the configured level survives the new default, on a reopened database as the restart-required flag demands.
- `ASeedInsideOneTransactionStillPreservesUserValues` - guards the regression a transaction wrapper can plausibly introduce (same rows, user values kept, metadata refreshed). Its rollback half is deliberately **not** claimed: proving it needs a mid-seed failure, and this suite builds no SQLite fault injection, for the reason recorded in `db_concurrency_test.cpp`.

`mkdocs build --strict` clean. `clang-format` introduces no new violations in any touched file (counts identical to `HEAD` on all three). clang-tidy could not run in this container - it ships 18.1.3 and `engine/.clang-tidy` needs >= 19 - so that gate is CI's.

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have added tests (if applicable)
- [x] I have updated documentation

## Related Issues

Refs #838.

Deliberately `Refs`, not `Closes`. Acceptance criterion 1 (the recorded decision, with its reason) is answered here; criterion 4 (docs) is done - `docs/engine/building.md` named *"the flush barrier `synchronous=FULL` issues per commit"* as the Windows cost, which was wrong, and now says where the barrier actually was, with the table above. Criterion 2 is **not** something this PR can close: it asks for the Windows leg below 80% of its serial wall, and only this PR's own `windows-latest` CI run can say. I will record that number on #838 when the run lands.

The locked group in `engine/CMakeLists.txt` is **unchanged on purpose**, and the docs now say not to shrink it on the strength of the Linux table: the lock's justification is the Windows `-j4` blow-up, and whether a cheaper group survives overlapping there is a Windows measurement, not an inference. Criterion 3 holds - no test is skipped, quarantined or loosened, and no fixture stops exercising the real write path (the opt-in that would have caused that is the design this PR rejected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw3VUukYZTLjgHZ1FumvLh)_