### PR TITLE
test(app/history): the 5,000-step cases state their own timeout (#846)

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -34,6 +34,17 @@ does, without naming it), start the file with:
 
 Forgetting it fails loudly (`document is not defined`), never silently.
 
+**A render-heavy test asserts a wall clock it never wrote.** `vitest.config.ts`
+sets no `testTimeout`, so every case gets the default 5s - fine for the suite,
+a hidden performance budget for the handful that build thousands of rows and
+render them. The 5,000-step `ScenarioRunView` cases cost ~1.1s idle (~2.8s for
+the one that renders twice) and crossed 5s whenever the four cores were shared
+with an engine build, failing a run over machine load rather than over the code
+(#846). Give such a case an explicit `it(name, { timeout: N }, fn)` **with the
+measured cost and the multiplier in a comment**, so the next person under load
+does not raise it by reflex - and do not raise the global default, which would
+slow every genuinely hung test's failure to the new bound.
+
 **A source scan cannot see a class that arrives in a variable.** The badge-hover
 guard scanned for `<Badge className="bg-…">` and missed both real instances,
 because each got its background from a `statusColor` / `config.tint` binding;

--- a/app/src/modules/history/main/run-view-navigability.test.tsx
+++ b/app/src/modules/history/main/run-view-navigability.test.tsx
@@ -312,8 +312,27 @@ describe("the count chips as the filter", () => {
 	});
 });
 
+/**
+ * What a case that renders the 5,000-step fixture is allowed to take (#846).
+ *
+ * The three cases carrying this assert *windowing* - what is mounted, and what
+ * the "still to come" line counts. None of them asserts a duration, but
+ * vitest's default `testTimeout` of 5s quietly does: building 5,000 rows and
+ * rendering the window costs ~1.1s on an idle 4-core box, and ~2.8s for the
+ * case that pays the render twice by clicking a chip. Share those cores with
+ * anything else - an engine build, another job on the same CI runner - and the
+ * whole suite runs ~1.7x slower, which puts that case past 5s and fails the
+ * run over machine load rather than over the code.
+ *
+ * 20s is ~7x the measured worst case: far enough that contention cannot reach
+ * it, close enough that a genuinely hung render still fails in seconds. Raise
+ * the *fixture* if the storage cap changes; do not raise this number because a
+ * run went red - a case that needs more than 20s here has stopped windowing.
+ */
+const RENDERS_THE_CAP = { timeout: 20_000 };
+
 describe("a run at the storage cap", () => {
-	it("does not mount 5,000 cards to show the first screen of them", () => {
+	it("does not mount 5,000 cards to show the first screen of them", RENDERS_THE_CAP, () => {
 		reportQuery.data = report({
 			results: Array.from({ length: 5_000 }, (_, i) => storedStep(i, 0, "passed")),
 		});
@@ -329,18 +348,22 @@ describe("a run at the storage cap", () => {
 		expect(screen.getByText(/showing 200 of 5,000 steps/i)).toBeTruthy();
 	});
 
-	it("counts the filtered list, not the whole one, in what is still to come", () => {
-		reportQuery.data = report({
-			results: Array.from({ length: 5_000 }, (_, i) =>
-				storedStep(i, 0, i % 10 === 0 ? "failed" : "passed")
-			),
-		});
-		render(<ScenarioRunView run={RUN} />);
+	it(
+		"counts the filtered list, not the whole one, in what is still to come",
+		RENDERS_THE_CAP,
+		() => {
+			reportQuery.data = report({
+				results: Array.from({ length: 5_000 }, (_, i) =>
+					storedStep(i, 0, i % 10 === 0 ? "failed" : "passed")
+				),
+			});
+			render(<ScenarioRunView run={RUN} />);
 
-		fireEvent.click(chip("failed"));
+			fireEvent.click(chip("failed"));
 
-		expect(screen.getByText(/showing 200 of 500 steps/i)).toBeTruthy();
-	});
+			expect(screen.getByText(/showing 200 of 500 steps/i)).toBeTruthy();
+		}
+	);
 });
 
 describe("searching the step list by name", () => {
@@ -446,7 +469,9 @@ describe("searching the step list by name", () => {
 		expect(screen.getByText(/no steps recorded/i)).toBeTruthy();
 	});
 
-	it("restarts the growing window when a search narrows the list", () => {
+	// The third case rendering the 5,000-step fixture, so it carries the same
+	// timeout for the same reason.
+	it("restarts the growing window when a search narrows the list", RENDERS_THE_CAP, () => {
 		reportQuery.data = report({
 			results: Array.from({ length: 5_000 }, (_, i) =>
 				storedStep(i, 0, "passed", { name: i % 10 === 0 ? "POST /checkout" : "GET /cart" })


### PR DESCRIPTION
## Description

Issue #846: `run-view-navigability.test.tsx > a run at the storage cap > counts the filtered list, not the whole one, in what is still to come` fails a full-suite run with `Test timed out in 5000ms` whenever the machine is busy, and passes when it is idle.

**The plan, in one paragraph.** The root cause is that `app/vitest.config.ts` sets no `testTimeout`, so every case inherits vitest's default 5s - ample for the suite, and a *performance budget nobody wrote* for the handful of cases that build 5,000 stored steps and render `ScenarioRunView` over them. Measured on this 4-core box: ~1.1s for the plain storage-cap render, ~2.8s for the one that pays the render twice by clicking a filter chip, and ~0.9s for the search case. Contention stretches the whole run ~1.7x, which puts the 2.8s case past 5s - so a *windowing* assertion (what is mounted, what the "still to come" line counts) was failing over how loaded the machine was. The approach is the issue's option 1: the three cases that render the 5,000-step fixture carry an explicit `{ timeout: 20_000 }`, ~7x the measured worst case - past anything contention produces, still short enough that a genuinely hung render fails in seconds rather than minutes. The fixture stays at 5,000, so no coverage moves. **Alternatives rejected:** shrinking the fixture (option 2) - 5,000 *is* `maxScenarioStoredSteps`, and a smaller number would stop exercising the cap those cases exist for; and raising the global `testTimeout` (option 3) - it would slow every genuinely hung test's failure to the new bound, and the issue's condition for it ("unless a survey finds other tests in the same position") is not met, see below.

**The survey the issue asked for.** Every other big-fixture test measured, on the same box:

| case | cost | verdict |
|---|---|---|
| `run-view-navigability` - the three 5,000-step renders | 1138ms / **2815ms** / 886ms | in the danger zone, fixed here |
| `console-tests-density` - five 5,000-line console renders | 103-166ms | ~30x headroom, untouched |
| `mcp/tools.test.ts` - a 4,000-entry case | node env, no DOM | untouched |

So the population is three cases in one file, not a suite-wide condition - which is what keeps this out of `vitest.config.ts`.

**A third case, beyond the two the issue names.** `restarts the growing window when a search narrows the list` renders the same 5,000-step fixture from the `searching the step list by name` block and was never named because it has more headroom (886ms). It is the same latent failure, so it carries the same constant.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Reproduced first, exactly as the acceptance criteria ask - full app suite with all four cores contended, then the same run with the fix:

| run | tree | result | wall |
|---|---|---|---|
| baseline | `caeb6a4` (master), 4 cores contended | **1 failed** / 5808 passed - `Test timed out in 5000ms` at `run-view-navigability.test.tsx:332` | 608s |
| fixed | this branch, same contention | **5809 passed** (525 files), 0 failed | 607s |

The contention was generated with four busy-loop processes rather than `python build.py -e -t`: the engine build cannot run in this environment at all (vcpkg dies fetching openssl - `curl operation failed with response code 403`, and `vcpkg-fix-port openssl` then times out on `git ls-remote`). That is pre-existing and unrelated to this diff; the mechanism reproduced is the same one - four cores shared, suite wall ~1.8x its idle 330s.

Other checks on this branch:

| Check | Result |
|---|---|
| `pnpm exec vitest run` on the touched file | 18/18 passed |
| `pnpm type-check` | clean (all three configs) |
| `pnpm lint` (touched file) | clean |
| `pnpm format:check` (both touched files) | clean; both were prettier-clean before, so prettier touched only this file |

Engine suites were not run: this changes one app test file and a Markdown guide, so nothing in the engine could change colour (and the engine toolchain cannot configure here, above).

Mutation-checked, run rather than reasoned about: setting the constant to `{ timeout: 500 }` reddens all three cases with `Test timed out in 500ms` and leaves the file's other 15 green - which proves the option is actually read, rather than accepted and ignored by the runner.

## Checklist
- [x] My code follows the style guidelines - prettier expands the one `it(...)` whose name pushes the three-argument call past 100 columns; the other two keep their original shape
- [x] I have performed a self-review
- [x] I have added tests - none added; this repairs three existing ones without changing what they assert
- [x] I have updated documentation - `app/CLAUDE.md` gains the rule under the test-environment section, since the next render-heavy test is where this recurs

## Related Issues
Closes #846

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3eyg5LTkrJuogGJ8uGzhi)_