### PR TITLE
docs(compare): the proxy and certificates row, with its two asterisks

### DIFF
--- a/docs/compare/vayu-vs-bruno.md
+++ b/docs/compare/vayu-vs-bruno.md
@@ -25,9 +25,22 @@ the request comes back green.
 | **SSE streaming** | Live Events view, scriptable, load-tested | Connects, no event UI |
 | **Mock servers** | Collection mock + OAuth issuer + webhook inbox | No |
 | **Data-driven runs** | CSV / TSV / JSON / JSONL | CSV / JSON |
+| **Proxy / custom CA / client certs** | In Settings - four proxy modes, additive CAs, per-host certs\* | In Preferences - proxy and CA file; certs per collection |
 | **Postman collection import** | Yes (v2.0 + v2.1) | Yes (via converter) |
 | **OpenAPI import** | Yes (3.1 / 3.0 / 2.0) | No |
 | **Open source** | Yes (dual-license) | Yes (MIT) |
+
+\* **Two asterisks that row has earned.** Client certificates are proven on a
+wire on Linux and macOS; **on Windows an mTLS handshake does not complete
+yet** - an upstream libcurl defect carried in curl's own `KNOWN_BUGS`, not a
+setting you can fix, with the backend change that resolves it approved and
+queued. And `system` proxy mode resolves a PAC script **once**, against a probe
+URL, applying that one answer engine-wide rather than per URL; a headless
+engine with nothing resolved falls back to environment-variable pickup rather
+than to no proxy. Detail:
+[proxy settings](../engine/api-reference.md#proxy-settings),
+[TLS trust](../engine/api-reference.md#tls-trust-settings) and
+[client certificates](../engine/api-reference.md#client-certificates).
 
 ## The native load engine is the difference
 

--- a/docs/compare/vayu-vs-jmeter.md
+++ b/docs/compare/vayu-vs-jmeter.md
@@ -27,9 +27,22 @@ the request in.
 | **Scripting** | QuickJS (`pm.*` syntax) | Groovy / BeanShell |
 | **Distributed execution** | No - single machine | Yes (controller + workers) |
 | **MCP / agent control** | Built in, local, drives the load engine | No |
+| **Proxy / custom CA / client certs** | In Settings - four proxy modes, additive CAs, per-host certs\* | JVM properties and the Java keystore |
 | **Postman collection import** | Yes (v2.0 + v2.1) | No |
 | **OpenAPI import** | Yes (3.1 / 3.0 / 2.0) | No |
 | **Open source** | Yes (dual-license) | Yes (Apache 2.0) |
+
+\* **Two asterisks that row has earned.** Client certificates are proven on a
+wire on Linux and macOS; **on Windows an mTLS handshake does not complete
+yet** - an upstream libcurl defect carried in curl's own `KNOWN_BUGS`, not a
+setting you can fix, with the backend change that resolves it approved and
+queued. And `system` proxy mode resolves a PAC script **once**, against a probe
+URL, applying that one answer engine-wide rather than per URL; a headless
+engine with nothing resolved falls back to environment-variable pickup rather
+than to no proxy. Detail:
+[proxy settings](../engine/api-reference.md#proxy-settings),
+[TLS trust](../engine/api-reference.md#tls-trust-settings) and
+[client certificates](../engine/api-reference.md#client-certificates).
 
 ## The engine, and what it does not cost you
 

--- a/docs/compare/vayu-vs-k6.md
+++ b/docs/compare/vayu-vs-k6.md
@@ -25,9 +25,22 @@ k6 was built for exactly that and Vayu is not trying to be it.
 | **Distributed / cloud execution** | No - single machine | Yes |
 | **MCP / agent control** | Built in, local, drives the load engine | Official server (experimental) |
 | **Data-driven runs** | CSV / TSV / JSON / JSONL | Yes (in script) |
+| **Proxy / custom CA / client certs** | In Settings - four proxy modes, additive CAs, per-host certs\* | Environment variables and script options (`tlsAuth`) |
 | **Postman collection import** | Yes (v2.0 + v2.1) | Limited |
 | **OpenAPI import** | Yes (3.1 / 3.0 / 2.0) | No |
 | **Open source** | Yes (dual-license) | Yes (AGPL v3) |
+
+\* **Two asterisks that row has earned.** Client certificates are proven on a
+wire on Linux and macOS; **on Windows an mTLS handshake does not complete
+yet** - an upstream libcurl defect carried in curl's own `KNOWN_BUGS`, not a
+setting you can fix, with the backend change that resolves it approved and
+queued. And `system` proxy mode resolves a PAC script **once**, against a probe
+URL, applying that one answer engine-wide rather than per URL; a headless
+engine with nothing resolved falls back to environment-variable pickup rather
+than to no proxy. Detail:
+[proxy settings](../engine/api-reference.md#proxy-settings),
+[TLS trust](../engine/api-reference.md#tls-trust-settings) and
+[client certificates](../engine/api-reference.md#client-certificates).
 
 ## The throughput is in the same class
 

--- a/docs/compare/vayu-vs-postman.md
+++ b/docs/compare/vayu-vs-postman.md
@@ -25,9 +25,22 @@ native C++ load engine in the same app.
 | **SSE streaming** | Live Events view, scriptable, load-tested | Client-side inspection |
 | **Mock servers** | Collection mock + OAuth issuer + webhook inbox | Yes (cloud tier) |
 | **Data-driven runs** | CSV / TSV / JSON / JSONL | CSV / JSON |
+| **Proxy / custom CA / client certs** | In Settings - four proxy modes, additive CAs, per-host certs\* | In Settings - proxy, CA file, per-domain certs |
 | **Postman collection import** | Yes (v2.0 + v2.1) | Native |
 | **OpenAPI import** | Yes (3.1 / 3.0 / 2.0) | Yes |
 | **Open source** | Yes (dual-license) | Partial |
+
+\* **Two asterisks that row has earned.** Client certificates are proven on a
+wire on Linux and macOS; **on Windows an mTLS handshake does not complete
+yet** - an upstream libcurl defect carried in curl's own `KNOWN_BUGS`, not a
+setting you can fix, with the backend change that resolves it approved and
+queued. And `system` proxy mode resolves a PAC script **once**, against a probe
+URL, applying that one answer engine-wide rather than per URL; a headless
+engine with nothing resolved falls back to environment-variable pickup rather
+than to no proxy. Detail:
+[proxy settings](../engine/api-reference.md#proxy-settings),
+[TLS trust](../engine/api-reference.md#tls-trust-settings) and
+[client certificates](../engine/api-reference.md#client-certificates).
 
 ## One app instead of two
 
@@ -49,8 +62,12 @@ component to sync with. Collections, environments, secrets, and run history live
 in a SQLite database in your home directory, and the app contacts no external
 service during normal use - no telemetry, no license check. That is what makes
 it usable behind a corporate firewall or on an air-gapped network, where a
-client that wants to reach a workspace API simply cannot work. The trade is
-real and stated plainly below: nothing syncs itself between machines either.
+client that wants to reach a workspace API simply cannot work. The firewall
+half of that is now true in both directions: the engine goes *through* the
+proxy your company runs, verifies against the CA it injects, and presents the
+client certificate its APIs ask for - configured once in Settings > Network &
+connectivity, applied to every outbound path. The trade is real and stated
+plainly below: nothing syncs itself between machines either.
 
 ## Your agent can drive it
 


### PR DESCRIPTION
## Description

#704's last actionable acceptance criterion. The transport epic shipped four phases - proxy modes, additive custom CAs, the per-host client-certificate registry, system-proxy resolution and diagnostics - and the four comparison pages made **no** proxy, mTLS, client-certificate or custom-CA claim at all. The audience that reads those pages to decide whether the tool survives their corporate network could not tell any of it had happened.

**Plan (root cause, approach, rejected alternative).** The root cause is not a missing feature but a missing claim: `docs/compare/` was written before the epic and never revisited, so a shipped capability was invisible exactly where it is shopped for. The approach is one table row per page plus a note carrying the two qualifications the issue makes mandatory, with every Vayu cell read off the code rather than off the issue's snapshot. The alternative I rejected was a dedicated "corporate networks" prose section per page: it would read as marketing on a page whose standing rule is that every claim is checkable, and it would put the Windows mTLS gap far from the claim it qualifies. A row plus an immediately adjacent asterisk keeps the caveat where the claim is.

**Both mandatory asterisks are carried, not elided:**

- **Windows client certificates do not complete a handshake yet** - upstream libcurl defect, curl's own `KNOWN_BUGS`; the approved backend change is what fixes it. A row claiming mTLS without qualifying the Windows leg would be a claim the repo cannot check.
- **`system` proxy mode resolves a PAC script once**, against a probe URL, applying that one answer engine-wide; a headless engine falls back to environment pickup rather than to no proxy. The row must not imply per-URL PAC.

**Verified against shipped behaviour, not the issue body** (files drift; these did not, but I checked rather than assumed): the four modes and the fallback semantics from `ProxyMode` in `engine/include/vayu/http/transport_policy.hpp`; the additive merge from `resolve_transport_policy` and `system_ca_bundle_pem`; the per-host registry, its wildcard/port tiers and the paths-never-contents rule from `match_client_certificate` and `ClientCertRule`; PAC-once from `app/electron/proxy-resolution.ts` and `docs/architecture.md`; and the Settings surfaces from `ClientCertificatesCard.tsx`, `ConnectionTestCard.tsx` and the "Custom CA Certificates" row.

The postman page's *"usable behind a corporate firewall or on an air-gapped network"* sentence was true only in the offline sense when written. It now says the firewall case holds in both directions, which is what phases 1, 2 and 4 shipped.

**Deliberate deviations from the issue spec:** none. Competitor cells are kept to what each tool documents (Postman's Settings certificates, Bruno's Preferences proxy plus per-collection certs, k6's env vars and `tlsAuth`, JMeter's JVM properties and keystore) rather than graded, so no cell asserts more than can be checked.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Docs-only, so verification is scaled to what could change colour - per CLAUDE.md, no suite here could go green-to-red.

- `mkdocs build --strict -f .github/mkdocs.yml` - **clean**, built in 3.26s. This is the gate for a docs-touching PR, and `validation.anchors` is `warn`, which `--strict` promotes to an error.
- All three link targets verified present in the built HTML rather than trusted from the build: `id="proxy-settings"`, `id="tls-trust-settings"`, `id="client-certificates"` in `engine/api-reference/index.html`.
- Rendering checked in the generated HTML: the note comes out as a single `<p>`. This was a real hazard worth naming - the ` - ` clause originally began a line, which Python-Markdown reads as a list item; the text is reflowed so no line starts with a dash.
- No test reads these pages (`rg` over `app/` for `docs/compare` is empty), unlike `design-system.md` and `state-management.md` which do have test readers.
- No em-dashes; prettier is scoped to `app/` so `docs/` is outside it, and no repo-wide formatting was run.

No engine or app code is touched, so no build or suite was run.

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable) - not applicable, docs-only
- [x] I have updated documentation

## Related Issues

Refs #704

Deliberately **not** `Closes`: epic criterion 3 (mTLS callable on all execution paths) is still open on the Windows leg and closes with the approved #843 backend switch. This PR retires criterion 5 only, which leaves #843 as the single thing holding the epic open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6o6n5uSNHeux7cL31PneG)_